### PR TITLE
Add Emscripten/WASM build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,45 @@ jobs:
         run: |
           nix develop -c cmake --build build -t test
 
+  wasm:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: git config --global submodule.fetchJobs 4
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: nixbuild/nix-quick-install-action@v29
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.ccache
+            ~/.emscripten_cache
+          key: ${{ runner.os }}-emcc-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-emcc-
+
+      - name: cmake
+        run: |
+          nix develop -c emcmake cmake -S . -B wasm-build -GNinja
+
+      - name: build
+        run: |
+          nix develop -c cmake --build wasm-build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wasm
+          path: |
+            wasm-build/index.html
+            wasm-build/index.js
+            wasm-build/index.wasm
+
   screenshots:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
+/wasm-build
+/emsdk
 /data
 /ss

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v6.0.0
   hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
@@ -26,7 +26,7 @@ repos:
     #   entry: "ls"
     #   pass_filename: true
 - repo: https://github.com/NixOS/nixfmt
-  rev: master
+  rev: v1.4.0
   hooks:
     - id: nixfmt
 exclude: "3rd/.*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,11 @@ if(EMSCRIPTEN)
   # The native "host" build only produces mrbc; the app links the cross build.
   set(MRUBY_TARGET_NAME "emscripten")
   # mruby-onig-regexp normally extracts onigmo's objects into libmruby.a, but
-  # under emscripten that fails: the bundled onigmo builds its libonigmo.a with a
-  # host ranlib whose symbol table llvm-ar/wasm-ld cannot read (bulk extraction
-  # fails on the "/" member and produces corrupt objects). The pristine per-file
-  # wasm objects are still emitted next to the archive, so re-archive those with
-  # emar and link the result. Version tracks the pin in
+  # under emscripten that fails: the bundled onigmo builds its libonigmo.a with
+  # a host ranlib whose symbol table llvm-ar/wasm-ld cannot read (bulk
+  # extraction fails on the "/" member and produces corrupt objects). The
+  # pristine per-file wasm objects are still emitted next to the archive, so
+  # re-archive those with emar and link the result. Version tracks the pin in
   # 3rd/mruby-onig-regexp/mrbgem.rake.
   set(ONIGMO_DIR
       "${MRUBY_BUILD_DIR}/emscripten/mrbgems/mruby-onig-regexp/onigmo-6.2.0")
@@ -121,12 +121,11 @@ target_include_directories(${PROJECT_NAME}
 if(EMSCRIPTEN)
   # Emit a runnable page (index.html + .js + .wasm) with a growable heap so the
   # interpreter and game assets fit.
-  set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html"
-                                                   OUTPUT_NAME "index")
+  set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html" OUTPUT_NAME
+                                                                  "index")
   add_dependencies(${PROJECT_NAME} onigmo_clean)
-  target_link_options(
-    ${PROJECT_NAME} PRIVATE "-sALLOW_MEMORY_GROWTH=1" "-sEXIT_RUNTIME=0"
-    "-sFORCE_FILESYSTEM=1" "${ONIGMO_A}")
+  target_link_options(${PROJECT_NAME} PRIVATE "-sALLOW_MEMORY_GROWTH=1"
+                      "-sEXIT_RUNTIME=0" "-sFORCE_FILESYSTEM=1" "${ONIGMO_A}")
   # Optionally bake a game directory into the virtual filesystem at /game so the
   # page runs a real game. Pass -DWASM_GAME_DIR=/abs/path/to/game at configure
   # time; then the page auto-loads it via --game_dir=/game.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,16 @@ endif()
 
 project(rpg_maker_clone CXX)
 
-find_package(Ruby REQUIRED)
-find_package(SDL2 REQUIRED)
+if(EMSCRIPTEN)
+  # Emscripten ships SDL2 as a "port": -sUSE_SDL=2 provides both the headers
+  # (needed while compiling lvgl's SDL driver) and the library at link time.
+  add_compile_options("-sUSE_SDL=2")
+  add_link_options("-sUSE_SDL=2")
+  # Provide a stand-in for the SDL2::SDL2 target the executable links against.
+  add_library(SDL2::SDL2 INTERFACE IMPORTED)
+else()
+  find_package(SDL2 REQUIRED)
+endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 add_subdirectory(3rd/lvgl EXCLUDE_FROM_ALL)
@@ -30,7 +38,23 @@ add_subdirectory(3rd/uni-algo EXCLUDE_FROM_ALL)
 set(MRUBY_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/3rd/mruby")
 add_library(mruby STATIC IMPORTED)
 set(MRUBY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/mruby")
-set(LIBMRUBY_A "${MRUBY_BUILD_DIR}/host/lib/libmruby.a")
+if(EMSCRIPTEN)
+  # The native "host" build only produces mrbc; the app links the cross build.
+  set(MRUBY_TARGET_NAME "emscripten")
+  # mruby-onig-regexp normally extracts onigmo's objects into libmruby.a, but
+  # under emscripten that fails: the bundled onigmo builds its libonigmo.a with a
+  # host ranlib whose symbol table llvm-ar/wasm-ld cannot read (bulk extraction
+  # fails on the "/" member and produces corrupt objects). The pristine per-file
+  # wasm objects are still emitted next to the archive, so re-archive those with
+  # emar and link the result. Version tracks the pin in
+  # 3rd/mruby-onig-regexp/mrbgem.rake.
+  set(ONIGMO_DIR
+      "${MRUBY_BUILD_DIR}/emscripten/mrbgems/mruby-onig-regexp/onigmo-6.2.0")
+  set(ONIGMO_A "${CMAKE_CURRENT_BINARY_DIR}/libonigmo_clean.a")
+else()
+  set(MRUBY_TARGET_NAME "host")
+endif()
+set(LIBMRUBY_A "${MRUBY_BUILD_DIR}/${MRUBY_TARGET_NAME}/lib/libmruby.a")
 set_target_properties(mruby PROPERTIES IMPORTED_LOCATION "${LIBMRUBY_A}")
 list(APPEND ADDITIONAL_CLEAN_FILES "${MRUBY_BUILD_DIR}")
 target_include_directories(mruby INTERFACE "${MRUBY_PREFIX}/include")
@@ -50,17 +74,37 @@ set(MRB_OPTS
     "CXXFLAGS=${CMAKE_CXX_FLAGS}"
     "CFLAGS=${CMAKE_C_FLAGS}"
     "LDFLAGS=${CMAKE_CXX_FLAGS}")
+if(EMSCRIPTEN)
+  # Tell build_config.rb to emit the emscripten cross build, and give it native
+  # compilers to build mrbc with (CC/CXX above point at emcc/em++).
+  list(APPEND MRB_OPTS MRUBY_TARGET=emscripten "HOST_CC=cc" "HOST_CXX=c++")
+endif()
 add_custom_command(
   OUTPUT "${LIBMRUBY_A}"
   COMMAND
-    mkdir -p ${MRUBY_BUILD_DIR}/repos/host && rm -f
+    mkdir -p ${MRUBY_BUILD_DIR}/repos/host
+    ${MRUBY_BUILD_DIR}/repos/${MRUBY_TARGET_NAME} && ln -sf
+    ${CMAKE_CURRENT_SOURCE_DIR}/3rd/mgem-list
     ${MRUBY_BUILD_DIR}/repos/host/mgem-list && ln -sf
     ${CMAKE_CURRENT_SOURCE_DIR}/3rd/mgem-list
-    ${MRUBY_BUILD_DIR}/repos/host/mgem-list && ${MRB_OPTS} rake -v
+    ${MRUBY_BUILD_DIR}/repos/${MRUBY_TARGET_NAME}/mgem-list && ${MRB_OPTS} rake
+    -v
   WORKING_DIRECTORY "${MRUBY_PREFIX}"
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/build_config.rb" ${MRB_FILES})
 add_custom_target(mruby_build DEPENDS "${LIBMRUBY_A}")
 add_dependencies(mruby mruby_build)
+
+if(EMSCRIPTEN)
+  # Re-archive onigmo's pristine per-file wasm objects (see ONIGMO_A above).
+  add_custom_command(
+    OUTPUT "${ONIGMO_A}"
+    COMMAND
+      sh -c
+      "${CMAKE_AR} crs '${ONIGMO_A}' $(find '${ONIGMO_DIR}' -name '*.o' -not -path '*/.libs/*')"
+    DEPENDS "${LIBMRUBY_A}"
+    VERBATIM)
+  add_custom_target(onigmo_clean DEPENDS "${ONIGMO_A}")
+endif()
 
 add_executable(${PROJECT_NAME} src/main.cxx)
 target_link_libraries(
@@ -74,17 +118,37 @@ target_link_libraries(
 target_include_directories(${PROJECT_NAME}
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rd/inicpp)
 
+if(EMSCRIPTEN)
+  # Emit a runnable page (index.html + .js + .wasm) with a growable heap so the
+  # interpreter and game assets fit.
+  set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html"
+                                                   OUTPUT_NAME "index")
+  add_dependencies(${PROJECT_NAME} onigmo_clean)
+  target_link_options(
+    ${PROJECT_NAME} PRIVATE "-sALLOW_MEMORY_GROWTH=1" "-sEXIT_RUNTIME=0"
+    "-sFORCE_FILESYSTEM=1" "${ONIGMO_A}")
+  # Optionally bake a game directory into the virtual filesystem at /game so the
+  # page runs a real game. Pass -DWASM_GAME_DIR=/abs/path/to/game at configure
+  # time; then the page auto-loads it via --game_dir=/game.
+  if(WASM_GAME_DIR)
+    target_link_options(${PROJECT_NAME} PRIVATE
+                        "--preload-file=${WASM_GAME_DIR}@/game")
+  endif()
+endif()
+
 install(TARGETS ${PROJECT_NAME} RUNTIME)
 
 enable_testing()
 
-add_test(
-  NAME mruby_test
-  COMMAND env ${MRB_OPTS} rake test
-  WORKING_DIRECTORY "${MRUBY_PREFIX}")
+if(NOT EMSCRIPTEN)
+  add_test(
+    NAME mruby_test
+    COMMAND env ${MRB_OPTS} rake test
+    WORKING_DIRECTORY "${MRUBY_PREFIX}")
 
-add_test(
-  NAME exe_open
-  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone --timeout_ms=100
-          --game_dir ./data/Nepheshel206beta/Nepheshel206Rbeta
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_test(
+    NAME exe_open
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone --timeout_ms=100
+            --game_dir ./data/Nepheshel206beta/Nepheshel206Rbeta
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,25 +1,74 @@
-MRuby::Build.new do |_conf|
-  toolchain :gcc
+# Gems shared by every build variant (the actual game libraries).
+def rpg_maker_gems(conf)
+  conf.gem core: 'mruby-array-ext'
+  conf.gem core: 'mruby-hash-ext'
+  conf.gem core: 'mruby-io'
 
-  enable_test
-  enable_debug
-
-  [cc, cxx].each do |t|
-    t.flags = t.flags.flatten.delete_if {|v| v == "-O0" }
-  end
-
-  gem core: 'mruby-array-ext'
-  gem core: 'mruby-hash-ext'
-  gem core: 'mruby-io'
-
-  gem "#{MRUBY_ROOT}/../mruby-stringio"
-  gem "#{MRUBY_ROOT}/../mruby-marshal"
-  gem "#{MRUBY_ROOT}/../mruby-onig-regexp" do
+  conf.gem "#{MRUBY_ROOT}/../mruby-stringio"
+  conf.gem "#{MRUBY_ROOT}/../mruby-marshal"
+  conf.gem "#{MRUBY_ROOT}/../mruby-onig-regexp" do
     bundle_onigmo
   end
 
-  gem "#{MRUBY_ROOT}/../../mruby-lcf"
-  gem "#{MRUBY_ROOT}/../../mruby-rgss"
-  gem "#{MRUBY_ROOT}/../../mruby-rpg2k"
-  gem "#{MRUBY_ROOT}/../../mruby-rpgxp"
+  conf.gem "#{MRUBY_ROOT}/../../mruby-lcf"
+  conf.gem "#{MRUBY_ROOT}/../../mruby-rgss"
+  conf.gem "#{MRUBY_ROOT}/../../mruby-rpg2k"
+  conf.gem "#{MRUBY_ROOT}/../../mruby-rpgxp"
+end
+
+# When targeting Emscripten the host build only exists to produce the `mrbc`
+# bytecode compiler (which must run natively during the cross build), while the
+# actual libmruby.a is produced by the `emscripten` cross build below.
+emscripten = ENV['MRUBY_TARGET'] == 'emscripten'
+
+MRuby::Build.new do |conf|
+  toolchain :gcc
+
+  enable_debug
+
+  if emscripten
+    # Force native host compilers so `mrbc` runs on the build machine even when
+    # CMake hands us emcc/em++ via CC/CXX.
+    conf.cc.command = ENV['HOST_CC'] || 'cc'
+    conf.cxx.command = ENV['HOST_CXX'] || 'c++'
+    conf.linker.command = ENV['HOST_CXX'] || 'c++'
+
+    # Only the compiler toolchain is needed on the host.
+    conf.gem core: 'mruby-compiler'
+    conf.gem core: 'mruby-bin-mrbc'
+  else
+    enable_test
+
+    [cc, cxx].each do |t|
+      t.flags = t.flags.flatten.delete_if { |v| v == "-O0" }
+    end
+
+    rpg_maker_gems(conf)
+  end
+end
+
+if emscripten
+  MRuby::CrossBuild.new('emscripten') do |conf|
+    toolchain :clang
+
+    conf.cc.command = 'emcc'
+    conf.cxx.command = 'em++'
+    conf.linker.command = 'emcc'
+    conf.archiver.command = 'emar'
+
+    # autotools inside mruby-onig-regexp needs a `--host` triplet that its
+    # (old) config.sub recognizes to enter cross-compilation mode. onigmo's
+    # config.sub does not know the real `*-emscripten` system, so use the
+    # closest triplet it accepts; it keeps the 32-bit wasm word size and only
+    # forces cross-compile mode (the actual compiler is still emcc).
+    conf.host_target = 'wasm32-unknown-linux'
+
+    enable_debug
+
+    [conf.cc, conf.cxx].each do |t|
+      t.flags = t.flags.flatten.delete_if { |v| v == "-O0" }
+    end
+
+    rpg_maker_gems(conf)
+  end
 end

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
                 autoconf
                 automake
                 xorg.libXi
+                emscripten
               ]
               ++ (
                 if system == "x86_64-linux" then

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -135,11 +135,15 @@ class RPG2k
     @scenes.push scene
   end
 
+  def main_loop
+    @scenes.last.update
+    Input.update
+    Graphics.update
+  end
+
   def start
     loop do
-      @scenes.last.update
-      Input.update
-      Graphics.update
+      main_loop
     end
   rescue RGSS::Timeout
   end

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -72,7 +72,8 @@ fs::path xp_rtp_path() {
 }
 
 #ifdef __EMSCRIPTEN__
-// Trampoline for emscripten_set_main_loop, which takes a plain function pointer.
+// Trampoline for emscripten_set_main_loop, which takes a plain function
+// pointer.
 std::function<void()> main_loop_;
 void main_loop() {
   main_loop_();
@@ -144,9 +145,10 @@ int main(int argc, char** argv) {
   // Instead we register a per-frame callback that runs a single iteration.
   //
   // emscripten_set_main_loop(..., simulate_infinite_loop=1) unwinds the C stack
-  // without running destructors, so `mrb`, `display` and `game_obj` intentionally
-  // outlive main(). Keep `game_obj` reachable from the GC and capture handles by
-  // value so the callback stays valid after main() returns to the browser.
+  // without running destructors, so `mrb`, `display` and `game_obj`
+  // intentionally outlive main(). Keep `game_obj` reachable from the GC and
+  // capture handles by value so the callback stays valid after main() returns
+  // to the browser.
   mrb_gc_register(M, game_obj);
   main_loop_ = [M, game_obj]() {
     mrb_funcall(M, game_obj, "main_loop", 0);

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -1,6 +1,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <regex>
 
@@ -12,6 +13,10 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <inicpp.hpp>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 DEFINE_int64(timeout_ms, -1, "timeout to exit");
 DEFINE_int64(width, 320, "width of the window");
@@ -66,6 +71,14 @@ fs::path xp_rtp_path() {
   return reg2path(ini["Software\\\\Enterbrain\\\\RGSS\\\\RTP"]["\"Standard\""]);
 }
 
+#ifdef __EMSCRIPTEN__
+// Trampoline for emscripten_set_main_loop, which takes a plain function pointer.
+std::function<void()> main_loop_;
+void main_loop() {
+  main_loop_();
+}
+#endif
+
 }  // namespace
 
 extern "C" void rgss_set_display(mrb_state* M, lv_display_t* d);
@@ -95,8 +108,16 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "GAME_DIR"),
                 mrb_str_new_cstr(M, FLAGS_game_dir.c_str()));
+#ifdef __EMSCRIPTEN__
+  // The wine registry (used to locate the RTP) does not exist in the browser
+  // filesystem, so leave RTP_DIR empty; games are expected to be self-contained
+  // in the preloaded game directory.
+  mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "RTP_DIR"),
+                mrb_str_new_cstr(M, ""));
+#else
   mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "RTP_DIR"),
                 mrb_str_new_cstr(M, rtp_path().c_str()));
+#endif
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "TIMEOUT_MS"),
                 mrb_fixnum_value(FLAGS_timeout_ms));
@@ -108,19 +129,43 @@ int main(int argc, char** argv) {
 
   const fs::path game_dir_path = FLAGS_game_dir;
 
+  mrb_value game_obj;
   if (fs::exists(game_dir_path / "RPG_RT.ldb")) {
-    mrb_value obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &args);
-    mrb_funcall(M, obj, "start", 0);
+    game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &args);
   } else if (fs::exists(game_dir_path / "Game.ini")) {
-    mrb_value obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &args);
-    mrb_funcall(M, obj, "start", 0);
+    game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &args);
   } else {
     CHECK(false) << "Unknown game directory: " << game_dir_path;
   }
-  mrb_print_backtrace(M);
+  CHECK(!M->exc);
+
+#ifdef __EMSCRIPTEN__
+  // The browser owns the event loop, so we cannot block in a Ruby `loop`.
+  // Instead we register a per-frame callback that runs a single iteration.
+  //
+  // emscripten_set_main_loop(..., simulate_infinite_loop=1) unwinds the C stack
+  // without running destructors, so `mrb`, `display` and `game_obj` intentionally
+  // outlive main(). Keep `game_obj` reachable from the GC and capture handles by
+  // value so the callback stays valid after main() returns to the browser.
+  mrb_gc_register(M, game_obj);
+  main_loop_ = [M, game_obj]() {
+    mrb_funcall(M, game_obj, "main_loop", 0);
+    if (M->exc) {
+      mrb_print_backtrace(M);
+      emscripten_cancel_main_loop();
+    }
+  };
+  emscripten_set_main_loop(main_loop, 0, 1);
+  return EXIT_SUCCESS;  // not reached; the call above unwinds the stack
+#else
+  mrb_funcall(M, game_obj, "start", 0);
+  if (M->exc) {
+    mrb_print_backtrace(M);
+  }
   CHECK(!M->exc);
 
   gflags::ShutDownCommandLineFlags();
 
   return EXIT_SUCCESS;
+#endif
 }


### PR DESCRIPTION
Build the app to WebAssembly with the same CMake/mruby tree:

- main.cxx: drive one frame per browser tick via emscripten_set_main_loop instead of the blocking Ruby `loop`; keep the interpreter/game object alive across the stack-unwinding main loop and skip the wine-registry RTP lookup.
- mruby-rpg2k: add RPG2k#main_loop for a single non-blocking iteration.
- build_config.rb: native host build for mrbc plus a MRuby::CrossBuild targeting Emscripten (emcc/em++/emar).
- CMakeLists: SDL2 via the -sUSE_SDL=2 port, emscripten libmruby path, index.html output with growable heap, optional -DWASM_GAME_DIR preload, and a workaround re-archiving onigmo's wasm objects (llvm-ar/wasm-ld can't read the host-ranlib symbol table of the bundled libonigmo.a).
- flake.nix: add emscripten to the dev shell.


Claude-Session: https://claude.ai/code/session_013LCf3TmF9xBweNTqcozFQd