### PR TITLE
Add terminal gaming support using sixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Terminal gaming support using the DEC sixel graphics protocol
+  - Added `--sixel` flag to render frames to a sixel-capable terminal instead
+    of opening an SDL window, plus `--sixel_scale` for integer upscaling
+  - Implemented a windowless LVGL display backend with a sixel flush callback
+    and a monotonic-clock tick/delay source (`mruby-rgss/src/sixel.cxx`)
+  - Wired terminal keyboard input (arrows/WASD, confirm, cancel, quit) into the
+    RGSS::Input module via `Graphics.update`
+  - Documented the decision in `docs/adr/0001-terminal-gaming-sixel.md`
 - Expanded the `mruby-rgss` RGSS built-in class library:
   - `RGSS::Color` — floating point RGBA color with clamping, `set`, `==`,
     `to_s` and Marshal (`_dump`/`_load`) support

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@
 - Shows a menu with options for New Game, Continue, and Shutdown
 - Supports keyboard navigation (up/down) and selection (enter/Z)
 
+### Terminal gaming (sixel)
+- Render the game to any sixel-capable terminal instead of an SDL window
+- Run with `--sixel` (optionally `--sixel_scale=N` to upscale the picture):
+
+  ```sh
+  ./rpg_maker_clone --sixel --sixel_scale=2 --game_dir path/to/game
+  ```
+
+- Controls: arrow keys or `WASD` to move, `Z`/`Enter`/`Space` to confirm,
+  `X`/`Esc` to cancel, `Q` or `Ctrl-C` to quit
+- Works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm and
+  Windows Terminal
+
 ## TODO
 - Run zip file directly
 - Editor with [imgui](https://github.com/ocornut/imgui)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,15 @@
 - Menu items are drawn using the game's font system
 - Selection is highlighted with a cursor
 
+### Terminal gaming (sixel)
+- Alternative display backend that renders each frame to the terminal using the
+  DEC sixel protocol, enabled with the `--sixel` flag
+- Lets the runtime be played on hosts without a windowing system (headless
+  servers, SSH sessions, embedded boards with a serial console)
+- Reads keyboard input directly from the terminal and forwards it to
+  `RGSS::Input`
+- See `docs/adr/0001-terminal-gaming-sixel.md` for the design rationale
+
 ## Third party libraries
 - Third party libraries is placed to `3rd/` directory
 

--- a/docs/adr/0001-terminal-gaming-sixel.md
+++ b/docs/adr/0001-terminal-gaming-sixel.md
@@ -1,0 +1,62 @@
+# 1. Terminal gaming with the sixel graphics protocol
+
+Date: 2026-07-20
+
+## Status
+
+Accepted
+
+## Context
+
+The runtime only had a single display backend: an SDL window created with
+`lv_sdl_window_create`. That requires a desktop windowing system, which
+conflicts with a core project goal — running RPG Maker games "on any
+environment such like embedded boards". It also makes the runtime awkward to
+use over SSH or on headless CI hosts.
+
+LVGL (already the rendering layer) is display-agnostic: a display is just a
+framebuffer plus a flush callback. Many terminals (xterm in vt340 mode, mlterm,
+foot, WezTerm, Windows Terminal, ...) can display bitmap images inline via the
+DEC **sixel** protocol. That makes a terminal a viable render target with no
+new windowing dependency.
+
+Two integration concerns had to be solved:
+
+- **Timing.** Without SDL there is no tick source, and LVGL needs one for
+  `lv_tick_get`/`lv_delay_ms` (used by the frame limiter and the timeout).
+- **Input.** `RGSS::Input` was a stub with no C++ wiring, and terminals do not
+  report key-release events.
+
+## Decision
+
+Add a second, windowless display backend (`mruby-rgss/src/sixel.cxx`), selected
+at runtime with the `--sixel` flag (`--sixel_scale` controls integer upscaling):
+
+- Create the display with `lv_display_create` in `LV_DISPLAY_RENDER_MODE_FULL`
+  backed by an RGB565 full-screen buffer, so each flush holds the whole frame.
+- The flush callback encodes the frame to sixel and writes it to the terminal.
+  Colours are quantised to a fixed 6×6×6 (216-entry) cube so encoding stays
+  `O(pixels)` with no palette search; bands are run-length encoded.
+- Provide a monotonic-clock tick source and a `nanosleep`-based delay via
+  `lv_tick_set_cb` / `lv_delay_set_cb`.
+- Put the terminal into raw mode (restored on exit and on fatal signals) and
+  read keys directly. Because there are no key-up events, a key is held for a
+  short window (`HOLD_MS`) after its last byte; the terminal's own auto-repeat
+  sustains held movement keys. Input is forwarded to `RGSS::Input` from
+  `Graphics.update` through the exported `rgss_terminal_poll` hook.
+
+## Consequences
+
+- The runtime can now be played on hosts without a GUI, advancing the
+  "run anywhere" goal.
+- SDL remains the default; the sixel path is fully opt-in, so existing behaviour
+  is unchanged.
+- Trade-offs / follow-up work:
+  - The fixed 216-colour palette limits fidelity; an adaptive palette (or
+    libsixel) could improve quality later.
+  - Terminal input has no key-release, so `HOLD_MS` is a heuristic; held-key
+    feel depends on the terminal's auto-repeat settings.
+  - The backend lives inside the `mruby-rgss` gem (so it is part of
+    `libmruby.a` and links into both the game executable and mruby's own
+    `mrbtest` binary). `main.cxx` calls the exported `sixel_display_create`,
+    mirroring the existing `rgss_set_display` seam.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,21 @@
+# <ADR number>. <short title of the decision>
+
+Date: YYYY-MM-DD
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by <link>
+
+## Context
+
+What is the issue that we are seeing that motivates this decision or change?
+Describe the forces at play (technical, project, product constraints).
+
+## Decision
+
+What is the change that we are actually proposing or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change? Include
+trade-offs and any follow-up work.

--- a/include/sixel.hxx
+++ b/include/sixel.hxx
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+// Forward declarations to avoid pulling heavy headers into every includer.
+struct mrb_state;
+struct _lv_display_t;
+typedef struct _lv_display_t lv_display_t;
+
+// Create an LVGL display that renders each frame to the terminal using the
+// DEC sixel graphics protocol instead of opening a desktop window.  This lets
+// the games be played inside any sixel-capable terminal (xterm -ti vt340,
+// mlterm, foot, wezterm, Windows Terminal, ...).
+//
+// `hor_res`/`ver_res` are the logical game resolution.  `scale` upscales the
+// emitted image by an integer nearest-neighbour factor so pixel-art is legible
+// in a terminal.  The created display is registered as LVGL's default display.
+//
+// As a side effect the controlling terminal is switched into raw mode so that
+// keyboard input can be read without line buffering; it is restored
+// automatically on process exit.
+lv_display_t* sixel_display_create(int32_t hor_res, int32_t ver_res, int scale);
+
+// Poll the terminal for keyboard input and forward it to the RGSS::Input
+// module.  Safe to call unconditionally: it is a no-op until a sixel display
+// has been created.  Meant to be invoked once per frame from Graphics.update.
+void sixel_terminal_poll(mrb_state* M);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -26,6 +26,10 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
+// Defined in sixel.cxx (same gem).  A no-op unless the game was started with
+// --sixel; forwards terminal keyboard input to RGSS::Input.
+extern "C" void rgss_terminal_poll(mrb_state* M);
+
 namespace {
 mrb_value to_nfd(mrb_state* M, mrb_value self) {
   const char* ptr;
@@ -763,6 +767,8 @@ void update_z(mrb_state* M) {
 mrb_value gfx_update(mrb_state* M, mrb_value self) {
   const uint32_t frame_start = lv_tick_get();
   const mrb_value rgss_mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
+
+  rgss_terminal_poll(M);
 
   if (mrb_const_defined(M, mrb_obj_value(M->object_class),
                         mrb_intern_lit(M, "TIMEOUT_MS"))) {

--- a/mruby-rgss/src/sixel.cxx
+++ b/mruby-rgss/src/sixel.cxx
@@ -1,0 +1,426 @@
+#include "sixel.hxx"
+
+#include <cerrno>
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <string>
+#include <vector>
+
+#include <termios.h>
+#include <unistd.h>
+
+#include <lvgl.h>
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/value.h>
+
+namespace {
+
+// RGSS::Input key ids (mirrors mruby-rgss/mrblib/lib.rb).
+enum Key {
+  KEY_UP = 0,
+  KEY_DOWN = 1,
+  KEY_LEFT = 2,
+  KEY_RIGHT = 3,
+  KEY_A = 4,
+  KEY_B = 5,
+  KEY_C = 6,
+};
+
+// Terminals do not report key-release events, so a key is considered held for
+// this long after the last byte that produced it was received.  Keeping this
+// short makes menus responsive; the terminal's own auto-repeat sustains held
+// movement keys.
+constexpr uint32_t HOLD_MS = 150;
+
+// ---------------------------------------------------------------------------
+// Global backend state
+// ---------------------------------------------------------------------------
+bool g_active = false;
+bool g_have_tty = false;
+int g_scale = 1;
+termios g_orig_termios;
+bool g_termios_saved = false;
+
+// Full-screen render buffer handed to LVGL (RENDER_MODE_FULL, RGB565).
+std::vector<uint8_t> g_fb;
+
+// Reused across frames to avoid per-frame allocation churn.
+std::string g_out;
+std::vector<uint8_t> g_oidx;
+std::string g_line;
+
+struct KeyState {
+  bool pressed = false;
+  uint32_t expiry = 0;
+};
+KeyState g_keys[16];
+
+// ---------------------------------------------------------------------------
+// Time sources (LVGL needs a tick/delay source without SDL)
+// ---------------------------------------------------------------------------
+uint32_t now_ms() {
+  timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint32_t>(ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL);
+}
+
+void delay_ms(uint32_t ms) {
+  timespec ts;
+  ts.tv_sec = ms / 1000;
+  ts.tv_nsec = static_cast<long>(ms % 1000) * 1000000L;
+  nanosleep(&ts, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Terminal handling
+// ---------------------------------------------------------------------------
+void write_all(const char* p, size_t n) {
+  while (n > 0) {
+    const ssize_t w = ::write(STDOUT_FILENO, p, n);
+    if (w <= 0) {
+      if (w < 0 && errno == EINTR)
+        continue;
+      break;
+    }
+    p += w;
+    n -= static_cast<size_t>(w);
+  }
+}
+
+void show_cursor() {
+  static const char seq[] = "\x1b[?25h";
+  write_all(seq, sizeof(seq) - 1);
+}
+
+void restore_terminal() {
+  if (g_termios_saved) {
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &g_orig_termios);
+    g_termios_saved = false;
+  }
+  show_cursor();
+}
+
+void signal_handler(int sig) {
+  restore_terminal();
+  // Re-raise with the default handler so the exit status reflects the signal.
+  signal(sig, SIG_DFL);
+  raise(sig);
+}
+
+void init_terminal() {
+  g_have_tty = isatty(STDIN_FILENO);
+  if (g_have_tty && tcgetattr(STDIN_FILENO, &g_orig_termios) == 0) {
+    g_termios_saved = true;
+    termios raw = g_orig_termios;
+    // Raw-ish mode: no line buffering, no echo, no signal generation (so we
+    // can read Ctrl-C ourselves), non-blocking reads.
+    raw.c_lflag &= ~(ICANON | ECHO | ISIG);
+    raw.c_iflag &= ~(IXON | ICRNL);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 0;
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+  }
+
+  std::atexit(restore_terminal);
+  for (int sig : {SIGINT, SIGTERM, SIGHUP, SIGQUIT})
+    signal(sig, signal_handler);
+
+  static const char hide_cursor[] = "\x1b[?25l";
+  write_all(hide_cursor, sizeof(hide_cursor) - 1);
+}
+
+// ---------------------------------------------------------------------------
+// Sixel encoding
+// ---------------------------------------------------------------------------
+// Fixed 6x6x6 colour cube (216 registers).  Direct quantisation keeps encoding
+// O(pixels) with no palette search, which is important for interactive frame
+// rates.
+inline int quant6(int v) {
+  const int q = (v * 6) / 256;
+  return q > 5 ? 5 : q;
+}
+
+const std::string& palette_definition() {
+  static const std::string def = [] {
+    std::string s;
+    for (int i = 0; i < 216; ++i) {
+      const int r = ((i / 36) % 6) * 255 / 5;
+      const int g = ((i / 6) % 6) * 255 / 5;
+      const int b = (i % 6) * 255 / 5;
+      s += '#';
+      s += std::to_string(i);
+      s += ";2;";
+      s += std::to_string(r * 100 / 255);
+      s += ';';
+      s += std::to_string(g * 100 / 255);
+      s += ';';
+      s += std::to_string(b * 100 / 255);
+    }
+    return s;
+  }();
+  return def;
+}
+
+// Run-length-encode a line of sixel bytes onto `s`, trimming trailing empties.
+void emit_rle(std::string& s, const std::string& line) {
+  size_t n = line.size();
+  while (n > 0 && line[n - 1] == '?')  // trailing background needs no output
+    --n;
+  size_t i = 0;
+  while (i < n) {
+    const char c = line[i];
+    size_t j = i + 1;
+    while (j < n && line[j] == c)
+      ++j;
+    const size_t run = j - i;
+    if (run >= 4) {
+      s += '!';
+      s += std::to_string(run);
+      s += c;
+    } else {
+      s.append(run, c);
+    }
+    i = j;
+  }
+}
+
+void encode_frame(int w, int h, const uint16_t* pix) {
+  const int scale = g_scale;
+  const int out_w = w * scale;
+  const int out_h = h * scale;
+
+  // Quantise (and upscale) the whole frame once into a palette-index buffer.
+  g_oidx.resize(static_cast<size_t>(out_w) * out_h);
+  for (int oy = 0; oy < out_h; ++oy) {
+    const uint16_t* row = pix + (oy / scale) * w;
+    uint8_t* dst = g_oidx.data() + static_cast<size_t>(oy) * out_w;
+    for (int ox = 0; ox < out_w; ++ox) {
+      const uint16_t p = row[ox / scale];
+      // RGB565 -> 8 bit per channel.
+      const int r = ((p >> 11) & 0x1f) << 3;
+      const int g = ((p >> 5) & 0x3f) << 2;
+      const int b = (p & 0x1f) << 3;
+      dst[ox] =
+          static_cast<uint8_t>(quant6(r) * 36 + quant6(g) * 6 + quant6(b));
+    }
+  }
+
+  std::string& s = g_out;
+  s.clear();
+  s += "\x1b[H";  // cursor home: overdraw the previous frame in place
+  s += "\x1bPq";  // enter sixel mode
+  s += "\"1;1;";  // raster attributes: 1:1 aspect ratio
+  s += std::to_string(out_w);
+  s += ';';
+  s += std::to_string(out_h);
+  s += palette_definition();
+
+  bool used[216];
+  int used_list[216];
+  for (int by = 0; by < out_h; by += 6) {
+    const int bh = (out_h - by < 6) ? (out_h - by) : 6;
+
+    // Collect the colours present in this 6-row band.
+    std::memset(used, 0, sizeof(used));
+    int used_count = 0;
+    for (int r = 0; r < bh; ++r) {
+      const uint8_t* rowp = g_oidx.data() + static_cast<size_t>(by + r) * out_w;
+      for (int ox = 0; ox < out_w; ++ox) {
+        const uint8_t c = rowp[ox];
+        if (!used[c]) {
+          used[c] = true;
+          used_list[used_count++] = c;
+        }
+      }
+    }
+
+    for (int u = 0; u < used_count; ++u) {
+      const int c = used_list[u];
+      s += '#';
+      s += std::to_string(c);
+      g_line.assign(out_w, 0);  // raw 6-bit accumulators (one bit per row)
+      for (int r = 0; r < bh; ++r) {
+        const uint8_t* rowp =
+            g_oidx.data() + static_cast<size_t>(by + r) * out_w;
+        const char bit = static_cast<char>(1 << r);
+        for (int ox = 0; ox < out_w; ++ox)
+          if (rowp[ox] == c)
+            g_line[ox] = static_cast<char>(g_line[ox] | bit);
+      }
+      // A sixel data byte is 0x3F ('?') plus the 6-bit column value.
+      for (char& ch : g_line)
+        ch = static_cast<char>('?' + ch);
+      emit_rle(s, g_line);
+      s += (u + 1 < used_count) ? '$' : '-';  // overlay next colour / new band
+    }
+    if (used_count == 0)
+      s += '-';
+  }
+
+  s += "\x1b\\";  // exit sixel mode
+  write_all(s.data(), s.size());
+}
+
+void flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+  if (lv_display_flush_is_last(disp)) {
+    const int w = lv_area_get_width(area);
+    const int h = lv_area_get_height(area);
+    encode_frame(w, h, reinterpret_cast<const uint16_t*>(px_map));
+  }
+  lv_display_flush_ready(disp);
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard input
+// ---------------------------------------------------------------------------
+void send_key(mrb_state* M, int key, bool press) {
+  RClass* rgss = mrb_module_get(M, "RGSS");
+  if (!rgss)
+    return;
+  RClass* input = mrb_module_get_under(M, rgss, "Input");
+  if (!input)
+    return;
+  mrb_funcall(M, mrb_obj_value(input), press ? "press" : "release", 1,
+              mrb_fixnum_value(key));
+}
+
+void hold_key(mrb_state* M, int key, uint32_t now) {
+  if (key < 0)
+    return;
+  if (!g_keys[key].pressed) {
+    g_keys[key].pressed = true;
+    send_key(M, key, true);
+  }
+  g_keys[key].expiry = now + HOLD_MS;
+}
+
+}  // namespace
+
+// Exported so the mruby-rgss gem (Graphics.update) can drive input polling
+// without a compile-time dependency on this translation unit.
+extern "C" void rgss_terminal_poll(mrb_state* M) {
+  sixel_terminal_poll(M);
+}
+
+void sixel_terminal_poll(mrb_state* M) {
+  if (!g_active || !g_have_tty)
+    return;
+
+  const uint32_t now = now_ms();
+
+  std::vector<char> buf;
+  char chunk[64];
+  for (;;) {
+    const ssize_t n = ::read(STDIN_FILENO, chunk, sizeof(chunk));
+    if (n <= 0)
+      break;
+    buf.insert(buf.end(), chunk, chunk + n);
+    if (static_cast<size_t>(n) < sizeof(chunk))
+      break;
+  }
+
+  for (size_t i = 0; i < buf.size();) {
+    const unsigned char c = static_cast<unsigned char>(buf[i]);
+    if (c == 0x1b && i + 2 < buf.size() && buf[i + 1] == '[') {
+      switch (buf[i + 2]) {
+        case 'A':
+          hold_key(M, KEY_UP, now);
+          break;
+        case 'B':
+          hold_key(M, KEY_DOWN, now);
+          break;
+        case 'C':
+          hold_key(M, KEY_RIGHT, now);
+          break;
+        case 'D':
+          hold_key(M, KEY_LEFT, now);
+          break;
+        default:
+          break;
+      }
+      i += 3;
+      continue;
+    }
+
+    switch (c) {
+      case 'w':
+      case 'W':
+        hold_key(M, KEY_UP, now);
+        break;
+      case 's':
+      case 'S':
+        hold_key(M, KEY_DOWN, now);
+        break;
+      case 'a':
+      case 'A':
+        hold_key(M, KEY_LEFT, now);
+        break;
+      case 'd':
+      case 'D':
+        hold_key(M, KEY_RIGHT, now);
+        break;
+      case 'z':
+      case 'Z':
+      case '\r':
+      case '\n':
+      case ' ':
+        hold_key(M, KEY_C, now);
+        break;
+      case 'x':
+      case 'X':
+      case 0x1b:  // 'x' or bare ESC = cancel
+        hold_key(M, KEY_B, now);
+        break;
+      case 'c':
+      case 'C':
+        hold_key(M, KEY_A, now);
+        break;
+      case 'q':
+      case 0x03:  // 'q' or Ctrl-C = quit
+        restore_terminal();
+        std::exit(0);
+        break;
+      default:
+        break;
+    }
+    ++i;
+  }
+
+  // Auto-release keys whose hold window has elapsed.
+  for (int k = 0; k < static_cast<int>(sizeof(g_keys) / sizeof(g_keys[0]));
+       ++k) {
+    if (g_keys[k].pressed &&
+        static_cast<int32_t>(now - g_keys[k].expiry) >= 0) {
+      g_keys[k].pressed = false;
+      send_key(M, k, false);
+    }
+  }
+}
+
+lv_display_t* sixel_display_create(int32_t hor_res,
+                                   int32_t ver_res,
+                                   int scale) {
+  g_scale = scale < 1 ? 1 : scale;
+
+  lv_tick_set_cb(now_ms);
+  lv_delay_set_cb(delay_ms);
+
+  lv_display_t* disp = lv_display_create(hor_res, ver_res);
+  if (!disp)
+    return nullptr;
+
+  lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
+  const uint32_t buf_size =
+      static_cast<uint32_t>(hor_res) * ver_res * sizeof(uint16_t);
+  g_fb.assign(buf_size, 0);
+  lv_display_set_buffers(disp, g_fb.data(), nullptr, buf_size,
+                         LV_DISPLAY_RENDER_MODE_FULL);
+  lv_display_set_flush_cb(disp, flush_cb);
+
+  init_terminal();
+  g_active = true;
+  return disp;
+}

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -16,6 +16,8 @@
 #include <ng-log/logging.h>
 #include <inicpp.hpp>
 
+#include "sixel.hxx"
+
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
@@ -24,6 +26,13 @@ DEFINE_int64(timeout_ms, -1, "timeout to exit");
 DEFINE_int64(width, 320, "width of the window");
 DEFINE_int64(height, 240, "height of the window");
 DEFINE_string(game_dir, "", "Game directory");
+DEFINE_bool(sixel,
+            false,
+            "Render to the terminal using the sixel protocol instead of "
+            "opening an SDL window");
+DEFINE_int32(sixel_scale,
+             2,
+             "Integer upscale factor for the sixel terminal output");
 
 namespace {
 
@@ -124,12 +133,20 @@ int main(int argc, char** argv) {
 
   lv_init();
 
-  std::shared_ptr<lv_display_t> display(
-      lv_sdl_window_create(FLAGS_width, FLAGS_height),
-      [](lv_display_t*) { lv_sdl_quit(); });
-  CHECK(display);
-  lv_sdl_window_set_resizeable(display.get(), false);
-  lv_sdl_window_set_zoom(display.get(), 2.f);
+  std::shared_ptr<lv_display_t> display;
+  if (FLAGS_sixel) {
+    display = std::shared_ptr<lv_display_t>(
+        sixel_display_create(FLAGS_width, FLAGS_height, FLAGS_sixel_scale),
+        [](lv_display_t*) {});
+    CHECK(display);
+  } else {
+    display = std::shared_ptr<lv_display_t>(
+        lv_sdl_window_create(FLAGS_width, FLAGS_height),
+        [](lv_display_t*) { lv_sdl_quit(); });
+    CHECK(display);
+    lv_sdl_window_set_resizeable(display.get(), false);
+    lv_sdl_window_set_zoom(display.get(), 2.f);
+  }
 
 #ifdef __EMSCRIPTEN__
   // mruby uses word boxing, which stores the type tag in the low 3 bits of each


### PR DESCRIPTION
## Summary

Adds a second, windowless LVGL display backend that renders each frame to a **sixel-capable terminal**, so the runtime can be played over SSH or on headless / embedded hosts without a windowing system. SDL remains the default; the sixel path is fully opt-in via `--sixel`.

This advances the project's "run on any environment such like embedded boards" goal, and along the way wires up the previously-stubbed `RGSS::Input` for terminal keyboard input.

## What's included

**New backend (`src/sixel.cxx` / `src/sixel.hxx`)** — self-contained, no new dependencies:
- **Rendering**: LVGL display in `LV_DISPLAY_RENDER_MODE_FULL` backed by a full-screen RGB565 buffer; the flush callback quantises to a fixed 6×6×6 (216-colour) cube — direct mapping, no palette search, so encoding stays `O(pixels)` — and run-length-encodes each sixel band, writing it inline with cursor-home so frames overdraw in place.
- **Timing**: registers a `CLOCK_MONOTONIC` tick source and a `nanosleep` delay via `lv_tick_set_cb` / `lv_delay_set_cb`, since without SDL LVGL has no tick source (the frame limiter and timeout rely on it).
- **Input**: puts the terminal into raw mode (restored on normal exit and on `SIGINT/TERM/HUP/QUIT`), reads keys directly, and forwards them to `RGSS::Input`. Terminals send no key-up events, so a key is held for a short `HOLD_MS` window and the terminal's own auto-repeat sustains held movement keys.

**Wiring**:
- `--sixel` and `--sixel_scale=N` flags in `src/main.cxx` branch the display creation.
- `Graphics.update` (`mruby-rgss`) calls the exported `rgss_terminal_poll` hook, resolved at final link — mirroring the existing `rgss_set_display` seam.

**Controls**: arrow keys / `WASD` move, `Z`/`Enter`/`Space` confirm, `X`/`Esc` cancel, `Q` or `Ctrl-C` quit.

## Usage

```sh
./rpg_maker_clone --sixel --sixel_scale=2 --game_dir path/to/game
```

Works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm and Windows Terminal.

## Docs

Per the repo guidelines, updated `README.md`, `CHANGELOG.md`, `docs/README.md`, and added an ADR (`docs/adr/0001-terminal-gaming-sixel.md`, plus the referenced `docs/adr/template.md` that was missing).

## Testing notes

A full build isn't possible in the authoring environment (SDL2 + the full mruby/nix toolchain and most submodules aren't available), but:
- `src/sixel.cxx` was `-fsyntax-only -Wall` compiled clean against the **real** LVGL and mruby headers (submodules fetched for verification), and every LVGL/mruby API signature used was verified against source.
- Ran the repo's formatting/whitespace checks (`clang-format`, trailing-whitespace, EOF-newline).

CI will provide the end-to-end build/test confirmation.

## Known trade-offs

- Fixed 216-colour palette caps fidelity; an adaptive palette or libsixel could improve quality later.
- Terminal input has no key-release, so `HOLD_MS` is a heuristic — held-key feel depends on the terminal's auto-repeat settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5ZBb6QPm9BaJgHeMD5P9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ZBb6QPm9BaJgHeMD5P9y)_