### PR TITLE
Implement z ordering for sprites and render the title menu window

### DIFF
--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -5,9 +5,13 @@ module RGSS
     def initialize f, s = nil
       if f.kind_of? String
         i = self._init_file(f, s)
-        i = self._init_file("#{GAME_DIR}/#{f}") unless i
-        i = self._init_file("#{GAME_DIR}/#{f}.png") unless i
-        i = self._init_file("#{GAME_DIR}/#{f}.xyz") unless i
+        [GAME_DIR, RTP_DIR].each do |d|
+          next if d.nil? || d.empty?
+          i = self._init_file("#{d}/#{f}") unless i
+          [:png, :xyz, :bmp].each do |ext|
+            i = self._init_file("#{d}/#{f}.#{ext}") unless i
+          end
+        end
         raise "Failed to init bitmap: #{f}" unless i
       else
         self._init_size(f, s)
@@ -19,6 +23,14 @@ module RGSS
   end
 
   class Font
+    attr_accessor :name, :size, :bold, :italic, :outline, :shadow,
+                  :color, :out_color
+
+    class << self
+      attr_accessor :default_name, :default_size, :default_bold,
+                    :default_italic, :default_shadow, :default_outline,
+                    :default_color, :default_out_color
+    end
   end
 
   class Plane
@@ -29,6 +41,7 @@ module RGSS
 
   class Sprite
     attr_reader :bitmap
+    attr_reader :x, :y, :z
   end
 
   class Table

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1,4 +1,5 @@
 #include <mruby.h>
+#include <mruby/array.h>
 #include <mruby/class.h>
 #include <mruby/data.h>
 #include <mruby/value.h>
@@ -14,6 +15,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -99,8 +101,17 @@ mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
   std::shared_ptr<uint8_t> img(
       stbi_load(f, &w, &h, &c, stbi__png_transparent_palette ? 4 : 3),
       stbi_image_free);
-  if (!img)
-    return mrb_nil_value();
+  if (!img) {
+    // Some archives store filenames in NFD form while the game data refers to
+    // them in NFC (or vice versa); retry with the decomposed form before giving
+    // up so accented paths still resolve.
+    const std::string nfd_f = una::norm::to_nfd_utf8(f);
+    img.reset(stbi_load(nfd_f.c_str(), &w, &h, &c,
+                        stbi__png_transparent_palette ? 4 : 3),
+              stbi_image_free);
+    if (!img)
+      return mrb_nil_value();
+  }
   Bitmap& bmp = DataType<Bitmap>::alloc_obj(
       M, self, w, h,
       c == 4 ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_RGB888);
@@ -129,7 +140,7 @@ mrb_value bmp_draw_text(mrb_state* M, mrb_value self) {
   mrb_get_args(M, "iiiis", &x, &y, &w, &h, &s, &len);
 
   auto draw = [&x, y, &bmp](const auto& c) {
-    static const uint8_t col[] = {0, 0, 0, 0};
+    static const uint8_t col[] = {0, 0, 0, 255};
     const unsigned col_len = lv_color_format_get_size(bmp.format);
     for (unsigned i = 0; i < c.HEIGHT; ++i) {
       for (unsigned j = 0; j < c.WIDTH; ++j) {
@@ -217,6 +228,23 @@ mrb_value obj_dispose(mrb_state* M, mrb_value self) {
   return mrb_nil_value();
 }
 
+// Array of top-level display objects (Sprites) whose stacking order is driven
+// by their `z` attribute. Populated lazily by rgss_set_display / add_root_obj.
+mrb_value root_objs(mrb_state* M) {
+  const mrb_value mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
+  const mrb_value ret = mrb_const_get(M, mod, mrb_intern_lit(M, "_roots"));
+  mrb_assert(mrb_array_p(ret));
+  return ret;
+}
+
+// Flag the module so the next Graphics.update reshuffles LVGL sibling order to
+// match the objects' `z` values. Reordering every frame would be wasteful, so
+// callers only mark it dirty when a `z` (or the root set) actually changes.
+void update_z(mrb_state* M) {
+  const mrb_value mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
+  mrb_iv_set(M, mod, mrb_intern_lit(M, "_z_updated"), mrb_true_value());
+}
+
 mrb_value gfx_update(mrb_state* M, mrb_value self) {
   const uint32_t frame_start = lv_tick_get();
   const mrb_value rgss_mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
@@ -236,6 +264,30 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
                  mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Timeout"),
                  "Timeout");
     }
+  }
+
+  // Reapply z ordering when something changed since the last frame. LVGL draws
+  // siblings in child order, so we sort the live roots by their `z` and move
+  // them to the foreground from lowest to highest, leaving the greatest `z` on
+  // top. Disposed sprites (null DATA_PTR) are dropped from the root set here so
+  // it does not grow unbounded.
+  if (mrb_bool(mrb_iv_get(M, rgss_mod, mrb_intern_lit(M, "_z_updated")))) {
+    const mrb_value roots = root_objs(M);
+    const mrb_value live = mrb_ary_new(M);
+    std::multimap<mrb_int, lv_obj_t*> orders;
+    for (mrb_int i = 0; i < RARRAY_LEN(roots); ++i) {
+      const mrb_value v = RARRAY_PTR(roots)[i];
+      if (!DATA_PTR(v))
+        continue;
+      mrb_ary_push(M, live, v);
+      const mrb_value z = mrb_iv_get(M, v, mrb_intern_lit(M, "@z"));
+      mrb_assert(mrb_fixnum_p(z));
+      orders.insert({mrb_fixnum(z), reinterpret_cast<lv_obj_t*>(DATA_PTR(v))});
+    }
+    mrb_const_set(M, rgss_mod, mrb_intern_lit(M, "_roots"), live);
+    for (const auto& order : orders)
+      lv_obj_move_foreground(order.second);
+    mrb_iv_set(M, rgss_mod, mrb_intern_lit(M, "_z_updated"), mrb_false_value());
   }
 
   lv_timer_handler();
@@ -273,12 +325,22 @@ lv_obj_t* parent_object(mrb_state* M, mrb_value vp) {
   return reinterpret_cast<lv_obj_t*>(DATA_PTR(vp));
 }
 
+// Register a display object as a z-ordered root and give it a default z of 0.
+void add_root_obj(mrb_state* M, mrb_value v) {
+  mrb_ary_push(M, root_objs(M), v);
+  mrb_iv_set(M, v, mrb_intern_lit(M, "@x"), mrb_fixnum_value(0));
+  mrb_iv_set(M, v, mrb_intern_lit(M, "@y"), mrb_fixnum_value(0));
+  mrb_iv_set(M, v, mrb_intern_lit(M, "@z"), mrb_fixnum_value(0));
+  update_z(M);
+}
+
 mrb_value spr_init(mrb_state* M, mrb_value self) {
   mrb_value vp = mrb_nil_value();
   mrb_get_args(M, "|o", &vp);
 
   lv_obj_t* p = lv_canvas_create(parent_object(M, vp));
   mrb_data_init(self, p, &obj_type);
+  add_root_obj(M, self);
   return self;
 }
 
@@ -292,6 +354,34 @@ mrb_value spr_set_bmp(mrb_state* M, mrb_value self) {
   mrb_assert(obj);
   lv_canvas_set_buffer(obj, p->buffer.data(), p->width, p->height, p->format);
   return bmp;
+}
+
+mrb_value obj_set_x(mrb_state* M, mrb_value self) {
+  mrb_int x;
+  mrb_get_args(M, "i", &x);
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  lv_obj_set_x(obj, x);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@x"), mrb_fixnum_value(x));
+  return self;
+}
+
+mrb_value obj_set_y(mrb_state* M, mrb_value self) {
+  mrb_int y;
+  mrb_get_args(M, "i", &y);
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  lv_obj_set_y(obj, y);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@y"), mrb_fixnum_value(y));
+  return self;
+}
+
+mrb_value obj_set_z(mrb_state* M, mrb_value self) {
+  mrb_int z;
+  mrb_get_args(M, "i", &z);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@z"), mrb_fixnum_value(z));
+  update_z(M);
+  return self;
 }
 
 mrb_value vp_init(mrb_state* M, mrb_value self) {
@@ -315,6 +405,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
 
   mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_game_start"),
                 mrb_fixnum_value(lv_tick_get()));
+  mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_roots"),
+                mrb_ary_new(M));
 
   RClass* vp = mrb_define_class_under(M, m, "Viewport", M->object_class);
   MRB_SET_INSTANCE_TT(vp, MRB_TT_DATA);
@@ -328,6 +420,9 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "bitmap=", spr_set_bmp, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "dispose", obj_dispose, MRB_ARGS_NONE());
   mrb_define_method(M, spr, "disposed?", obj_disposed, MRB_ARGS_NONE());
+  mrb_define_method(M, spr, "x=", obj_set_x, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "y=", obj_set_y, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "z=", obj_set_z, MRB_ARGS_REQ(1));
 
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -4,7 +4,9 @@ end
 
 module RGSS
   class Window
-    attr_accessor :contents
+    # Windows are drawn above ordinary background sprites (which default to
+    # z == 0), so give the backing sprite a high z by default.
+    DEFAULT_Z = 100
 
     def initialize(x = 0, y = 0, width = 0, height = 0)
       @x = x
@@ -12,9 +14,35 @@ module RGSS
       @width = width
       @height = height
       @contents = nil
+      # Back the window with a Sprite so its contents are actually drawn.
+      @sprite = Sprite.new
+      @sprite.x = x
+      @sprite.y = y
+      @sprite.z = DEFAULT_Z
     end
 
-    attr_accessor :x, :y, :width, :height
+    attr_reader :x, :y, :contents
+    attr_accessor :width, :height
+
+    def x=(v)
+      @x = v
+      @sprite.x = v
+    end
+
+    def y=(v)
+      @y = v
+      @sprite.y = v
+    end
+
+    def contents=(bmp)
+      @contents = bmp
+      @sprite.bitmap = bmp if bmp
+      bmp
+    end
+
+    def dispose
+      @sprite.dispose
+    end
   end
 end
 


### PR DESCRIPTION
Continues the work started on the `z` branch ("Implement z ordering for sprite"). That branch was based on an older `master` and predated the `DataType<T>` refactor of `mruby-rgss/src/lib.cxx` and the rewritten Title scene, so it could not be merged cleanly. This ports the feature onto the current code and finishes wiring it into the app.

## RGSS (`mruby-rgss`)
- **Sprite z ordering.** Top-level `Sprite`s are tracked in an `RGSS::_roots` array. `Sprite#z=` records a per-object `@z` and marks the module dirty; `Graphics.update` reshuffles LVGL sibling order (`lv_obj_move_foreground`, lowest → highest `z`) **only when something changed**, and prunes disposed sprites from the root set so it cannot grow unbounded.
- **Sprite geometry.** Added `Sprite#x= / #y= / #z=` with matching `x/y/z` readers.
- **Bitmap loading.** File search now also covers `RTP_DIR` and the `.bmp` extension, and retries with an NFD-normalized path so accented filenames resolve.
- **draw_text fix.** Glyphs were drawn with alpha `0` (fully transparent → invisible); now opaque black (alpha `255`).
- **Font.** Added instance and class-level (`default_*`) attribute accessors.

## RPG2k (`mruby-rpg2k`)
- **Render the title menu.** `RGSS::Window` was pure-Ruby and its `contents` bitmap was computed but **never actually drawn**. It is now backed by a `Sprite`, positioned via `x/y` and layered above background sprites with a high `z` — which exercises the new z-ordering in the real app.

The `z` branch's throwaway demo in `main.rb` was dropped, since this branch's Title scene is considerably more complete.

## Verification
- `g++ -fsyntax-only` of `lib.cxx` against the real mruby / lvgl / uni-algo / stb headers — clean.
- `clang-format` — no changes.
- `ruby -c` on both `mrblib` files — OK.
- No trailing-whitespace / final-newline issues (matches the pre-commit hooks).

A full build was not run in the authoring environment (no nix toolchain / SDL2 dev packages); CI is the final gate.

## Follow-up
The menu currently renders as opaque black glyphs over the title image with no window skin/background, so legibility depends on the title art. A proper RGSS window skin would be a natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01176i5sACugpHLSG9n4b1Xx

---
_Generated by [Claude Code](https://claude.ai/code/session_01176i5sACugpHLSG9n4b1Xx)_