### PR TITLE
Add RGSS built-in classes to mruby-rgss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Expanded the `mruby-rgss` RGSS built-in class library:
+  - `RGSS::Color` — floating point RGBA color with clamping, `set`, `==`,
+    `to_s` and Marshal (`_dump`/`_load`) support
+  - `RGSS::Tone` — red/green/blue/gray tone with clamping, `set`, `==`,
+    `to_s` and Marshal support
+  - `RGSS::Table` — 1/2/3 dimensional 16bit integer array (`[]`, `[]=`,
+    `xsize`/`ysize`/`zsize`/`dim`, `resize`) with the RGSS Marshal format,
+    used for map/tile data
+  - `RGSS::Bitmap` — added `width`, `height`, `rect`, `clear`, `fill_rect`,
+    `get_pixel`, `set_pixel`, `blt` (with opacity alpha-blending) and
+    font-aware, alignment-aware `draw_text`
+  - `RGSS::Rect` — added `==`, `to_s`, Marshal support and fixed the instance
+    type so `Rect.new` no longer trips the DATA assertion
+  - `RGSS::Font` — name/size/bold/italic/color plus class-level defaults and
+    `Font.exist?`; `Bitmap#font`/`Bitmap#font=` accessors
+  - `RGSS::Audio` — inert stubs for the standard bgm/bgs/me/se API
+  - `RGSS::Graphics` — `frame_count` (advanced by `update`), `frame_rate`,
+    `freeze`, `transition`, `frame_reset`
+  - Tests covering the new value classes, bitmap pixel operations and Marshal
+    round-trips
 - Title screen menu implementation
   - Added window component to display menu items (New Game, Continue, Shutdown)
   - Implemented menu navigation with keyboard input (up/down arrows)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ All notable changes to this project will be documented in this file.
     type so `Rect.new` no longer trips the DATA assertion
   - `RGSS::Font` — name/size/bold/italic/color plus class-level defaults and
     `Font.exist?`; `Bitmap#font`/`Bitmap#font=` accessors
-  - `RGSS::Audio` — inert stubs for the standard bgm/bgs/me/se API
+  - `RGSS::Audio` — inert stubs for the standard bgm/bgs/me/se API that warn
+    (once per method) to stderr when called
   - `RGSS::Graphics` — `frame_count` (advanced by `update`), `frame_rate`,
-    `freeze`, `transition`, `frame_reset`
+    and `freeze`/`transition`/`frame_reset` stubs that warn (once per method)
+    to stderr when called
   - Tests covering the new value classes, bitmap pixel operations and Marshal
     round-trips
 - Title screen menu implementation

--- a/mruby-rgss/mrbgem.rake
+++ b/mruby-rgss/mrbgem.rake
@@ -3,6 +3,9 @@ MRuby::Gem::Specification.new('mruby-rgss') do |spec|
   spec.author = 'take-cheeze'
   spec.summary = 'RGSS implementation in mruby'
 
+  # Color, Tone and Table provide RGSS-compatible Marshal (_dump/_load) support.
+  add_dependency 'mruby-marshal'
+
   cxx.include_paths <<
     "#{dir}/../3rd/uni-algo/include" <<
     "#{dir}/../3rd/lvgl" <<

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1,6 +1,16 @@
 module RGSS
   class Timeout < StandardError; end
 
+  # Emit a warning the first time an unimplemented stub method is called.
+  # Warning on every call would flood the log from within the game loop, so
+  # each method name is reported only once.
+  @warned_stubs = {}
+  def self.warn_stub(name)
+    return if @warned_stubs[name]
+    @warned_stubs[name] = true
+    $stderr.puts "[RGSS] #{name} is not implemented yet (stub, does nothing)"
+  end
+
   # Color, Rect, Table and Tone are implemented in C (see src/lib.cxx).
 
   class Bitmap
@@ -90,22 +100,59 @@ module RGSS
   # inert stubs that keep scripts calling the standard API from crashing.
   module Audio
     class << self
-      def bgm_play(filename, volume = 100, pitch = 100); end
-      def bgm_stop; end
-      def bgm_fade(time); end
-      def bgm_pos; 0; end
+      def bgm_play(filename, volume = 100, pitch = 100)
+        RGSS.warn_stub("Audio.bgm_play")
+      end
 
-      def bgs_play(filename, volume = 100, pitch = 100); end
-      def bgs_stop; end
-      def bgs_fade(time); end
-      def bgs_pos; 0; end
+      def bgm_stop
+        RGSS.warn_stub("Audio.bgm_stop")
+      end
 
-      def me_play(filename, volume = 100, pitch = 100); end
-      def me_stop; end
-      def me_fade(time); end
+      def bgm_fade(time)
+        RGSS.warn_stub("Audio.bgm_fade")
+      end
 
-      def se_play(filename, volume = 100, pitch = 100); end
-      def se_stop; end
+      def bgm_pos
+        RGSS.warn_stub("Audio.bgm_pos")
+        0
+      end
+
+      def bgs_play(filename, volume = 100, pitch = 100)
+        RGSS.warn_stub("Audio.bgs_play")
+      end
+
+      def bgs_stop
+        RGSS.warn_stub("Audio.bgs_stop")
+      end
+
+      def bgs_fade(time)
+        RGSS.warn_stub("Audio.bgs_fade")
+      end
+
+      def bgs_pos
+        RGSS.warn_stub("Audio.bgs_pos")
+        0
+      end
+
+      def me_play(filename, volume = 100, pitch = 100)
+        RGSS.warn_stub("Audio.me_play")
+      end
+
+      def me_stop
+        RGSS.warn_stub("Audio.me_stop")
+      end
+
+      def me_fade(time)
+        RGSS.warn_stub("Audio.me_fade")
+      end
+
+      def se_play(filename, volume = 100, pitch = 100)
+        RGSS.warn_stub("Audio.se_play")
+      end
+
+      def se_stop
+        RGSS.warn_stub("Audio.se_stop")
+      end
     end
   end
 
@@ -116,11 +163,17 @@ module RGSS
     class << self
       attr_accessor :frame_count, :frame_rate
 
-      def freeze; end
+      def freeze
+        RGSS.warn_stub("Graphics.freeze")
+      end
 
-      def transition(duration = 8, filename = nil, vague = 40); end
+      def transition(duration = 8, filename = nil, vague = 40)
+        RGSS.warn_stub("Graphics.transition")
+      end
 
-      def frame_reset; end
+      def frame_reset
+        RGSS.warn_stub("Graphics.frame_reset")
+      end
     end
   end
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1,6 +1,8 @@
 module RGSS
   class Timeout < StandardError; end
 
+  # Color, Rect, Table and Tone are implemented in C (see src/lib.cxx).
+
   class Bitmap
     def initialize f, s = nil
       if f.kind_of? String
@@ -13,34 +15,55 @@ module RGSS
         self._init_size(f, s)
       end
     end
+
+    # Font used by #draw_text. Created lazily from the current defaults.
+    def font
+      @font ||= Font.new
+    end
+
+    def font=(f)
+      @font = f
+    end
   end
 
-  class Color
-  end
-
+  # RGSS Font. Rendering currently uses the built-in shinonome bitmap font, so
+  # only the attributes that scripts read/write are modelled here.
   class Font
+    @default_name = "Arial"
+    @default_size = 22
+    @default_bold = false
+    @default_italic = false
+    @default_color = Color.new(255, 255, 255, 255)
+
+    class << self
+      attr_accessor :default_name, :default_size, :default_bold,
+                    :default_italic, :default_color
+
+      def exist?(name)
+        true
+      end
+    end
+
+    attr_accessor :name, :size, :bold, :italic, :color
+
+    def initialize(name = Font.default_name, size = Font.default_size)
+      @name = name
+      @size = size
+      @bold = Font.default_bold
+      @italic = Font.default_italic
+      @color = Color.new(Font.default_color.red, Font.default_color.green,
+                         Font.default_color.blue, Font.default_color.alpha)
+    end
   end
 
   class Plane
-  end
-
-  class Rect
   end
 
   class Sprite
     attr_reader :bitmap
   end
 
-  class Table
-  end
-
   class Tilemap
-  end
-
-  class Tone
-  end
-
-  class Viewport
   end
 
   class Window
@@ -49,10 +72,42 @@ module RGSS
   class RGSSError < StandardError
   end
 
+  # RGSS Audio module. Playback back-ends are not wired up yet, so these are
+  # inert stubs that keep scripts calling the standard API from crashing.
   module Audio
+    class << self
+      def bgm_play(filename, volume = 100, pitch = 100); end
+      def bgm_stop; end
+      def bgm_fade(time); end
+      def bgm_pos; 0; end
+
+      def bgs_play(filename, volume = 100, pitch = 100); end
+      def bgs_stop; end
+      def bgs_fade(time); end
+      def bgs_pos; 0; end
+
+      def me_play(filename, volume = 100, pitch = 100); end
+      def me_stop; end
+      def me_fade(time); end
+
+      def se_play(filename, volume = 100, pitch = 100); end
+      def se_stop; end
+    end
   end
 
   module Graphics
+    @frame_count = 0
+    @frame_rate = 40
+
+    class << self
+      attr_accessor :frame_count, :frame_rate
+
+      def freeze; end
+
+      def transition(duration = 8, filename = nil, vague = 40); end
+
+      def frame_reset; end
+    end
   end
 
   module Input

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -121,12 +121,12 @@ mrb_data_type DataType<T>::data_type{
 };
 
 // Generic floating point component getter/setter usable by Color and Tone.
-template <class T, double T::*Field>
+template <class T, double T::* Field>
 mrb_value component_get(mrb_state* M, V self) {
   return mrb_float_value(M, DataType<T>::get(M, self).*Field);
 }
 
-template <class T, double T::*Field, int Lo, int Hi>
+template <class T, double T::* Field, int Lo, int Hi>
 mrb_value component_set(mrb_state* M, V self) {
   mrb_float v;
   mrb_get_args(M, "f", &v);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1,6 +1,7 @@
 #include <mruby.h>
 #include <mruby/class.h>
 #include <mruby/data.h>
+#include <mruby/string.h>
 #include <mruby/value.h>
 #include <mruby/variable.h>
 
@@ -13,6 +14,7 @@
 #include "shinonome.hxx"
 
 #include <algorithm>
+#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <vector>
@@ -33,8 +35,33 @@ mrb_value to_nfd(mrb_state* M, mrb_value self) {
 
 using V = ::mrb_value;
 
+double clamp255(double v) {
+  return v < 0 ? 0 : (v > 255 ? 255 : v);
+}
+
+double clamp_signed255(double v) {
+  return v < -255 ? -255 : (v > 255 ? 255 : v);
+}
+
 struct Rect {
   mrb_int x{0}, y{0}, width{0}, height{0};
+};
+
+// RGSS Color: floating point RGBA components in the range 0..255.
+struct Color {
+  double red{0}, green{0}, blue{0}, alpha{255};
+};
+
+// RGSS Tone: red/green/blue in -255..255 and gray in 0..255.
+struct Tone {
+  double red{0}, green{0}, blue{0}, gray{0};
+};
+
+// RGSS Table: 1..3 dimensional array of 16bit integers used for map data.
+struct Table {
+  int32_t dim{1};
+  int32_t xsize{0}, ysize{1}, zsize{1};
+  std::vector<int16_t> data;
 };
 
 struct Bitmap {
@@ -70,6 +97,16 @@ struct DataType {
     return *ptr;
   }
 
+  // Allocate a brand new instance of class `c` wrapping a freshly constructed
+  // T. Used by the Marshal `_load` class methods which receive the class and
+  // must return a populated object.
+  template <class... Args>
+  static V make(mrb_state* M, RClass* c, Args... args) {
+    void* mem_ptr = mrb_malloc(M, sizeof(T));
+    T* ptr = new (mem_ptr) T{args...};
+    return mrb_obj_value(mrb_data_object_alloc(M, c, ptr, &data_type));
+  }
+
   static T& get(mrb_state* M, V self) {
     return *reinterpret_cast<T*>(mrb_data_get_ptr(M, self, &data_type));
   }
@@ -80,6 +117,306 @@ mrb_data_type DataType<T>::data_type{
     typeid(T).name(),
     &DataType<T>::free_obj,
 };
+
+// Generic floating point component getter/setter usable by Color and Tone.
+template <class T, double T::*Field>
+mrb_value component_get(mrb_state* M, V self) {
+  return mrb_float_value(M, DataType<T>::get(M, self).*Field);
+}
+
+template <class T, double T::*Field, int Lo, int Hi>
+mrb_value component_set(mrb_state* M, V self) {
+  mrb_float v;
+  mrb_get_args(M, "f", &v);
+  if (v < Lo)
+    v = Lo;
+  if (v > Hi)
+    v = Hi;
+  DataType<T>::get(M, self).*Field = v;
+  return mrb_float_value(M, v);
+}
+
+std::string pack_doubles(std::initializer_list<double> vals) {
+  std::string s;
+  s.reserve(vals.size() * sizeof(double));
+  for (double v : vals) {
+    char buf[sizeof(double)];
+    std::memcpy(buf, &v, sizeof(double));
+    s.append(buf, sizeof(double));
+  }
+  return s;
+}
+
+void unpack_doubles(const char* p, mrb_int len, double* out, int n) {
+  for (int i = 0; i < n; ++i) {
+    if ((mrb_int)((i + 1) * sizeof(double)) <= len)
+      std::memcpy(&out[i], p + i * sizeof(double), sizeof(double));
+  }
+}
+
+// ---- Color ----------------------------------------------------------------
+
+mrb_value color_init(mrb_state* M, V self) {
+  mrb_float r = 0, g = 0, b = 0, a = 255;
+  mrb_get_args(M, "fff|f", &r, &g, &b, &a);
+  Color& c = DataType<Color>::alloc_obj(M, self);
+  c.red = clamp255(r);
+  c.green = clamp255(g);
+  c.blue = clamp255(b);
+  c.alpha = clamp255(a);
+  return self;
+}
+
+mrb_value color_set(mrb_state* M, V self) {
+  Color& c = DataType<Color>::get(M, self);
+  if (mrb_get_argc(M) == 1) {
+    V o;
+    mrb_get_args(M, "o", &o);
+    c = DataType<Color>::get(M, o);
+  } else {
+    mrb_float r, g, b, a = 255;
+    mrb_get_args(M, "fff|f", &r, &g, &b, &a);
+    c.red = clamp255(r);
+    c.green = clamp255(g);
+    c.blue = clamp255(b);
+    c.alpha = clamp255(a);
+  }
+  return self;
+}
+
+mrb_value color_eq(mrb_state* M, V self) {
+  V o;
+  mrb_get_args(M, "o", &o);
+  if (!mrb_obj_is_kind_of(M, o, mrb_class(M, self)))
+    return mrb_false_value();
+  Color& a = DataType<Color>::get(M, self);
+  Color& b = DataType<Color>::get(M, o);
+  return mrb_bool_value(a.red == b.red && a.green == b.green &&
+                        a.blue == b.blue && a.alpha == b.alpha);
+}
+
+mrb_value color_to_s(mrb_state* M, V self) {
+  Color& c = DataType<Color>::get(M, self);
+  char buf[128];
+  std::snprintf(buf, sizeof(buf), "(%g, %g, %g, %g)", c.red, c.green, c.blue,
+                c.alpha);
+  return mrb_str_new_cstr(M, buf);
+}
+
+mrb_value color_dump(mrb_state* M, V self) {
+  Color& c = DataType<Color>::get(M, self);
+  std::string s = pack_doubles({c.red, c.green, c.blue, c.alpha});
+  return mrb_str_new(M, s.data(), s.size());
+}
+
+mrb_value color_load(mrb_state* M, V self) {
+  const char* p;
+  mrb_int len;
+  mrb_get_args(M, "s", &p, &len);
+  double d[4] = {0, 0, 0, 255};
+  unpack_doubles(p, len, d, 4);
+  V obj = DataType<Color>::make(M, mrb_class_ptr(self));
+  Color& c = DataType<Color>::get(M, obj);
+  c.red = d[0];
+  c.green = d[1];
+  c.blue = d[2];
+  c.alpha = d[3];
+  return obj;
+}
+
+// ---- Tone -----------------------------------------------------------------
+
+mrb_value tone_init(mrb_state* M, V self) {
+  mrb_float r = 0, g = 0, b = 0, gray = 0;
+  mrb_get_args(M, "fff|f", &r, &g, &b, &gray);
+  Tone& t = DataType<Tone>::alloc_obj(M, self);
+  t.red = clamp_signed255(r);
+  t.green = clamp_signed255(g);
+  t.blue = clamp_signed255(b);
+  t.gray = clamp255(gray);
+  return self;
+}
+
+mrb_value tone_set(mrb_state* M, V self) {
+  Tone& t = DataType<Tone>::get(M, self);
+  if (mrb_get_argc(M) == 1) {
+    V o;
+    mrb_get_args(M, "o", &o);
+    t = DataType<Tone>::get(M, o);
+  } else {
+    mrb_float r, g, b, gray = 0;
+    mrb_get_args(M, "fff|f", &r, &g, &b, &gray);
+    t.red = clamp_signed255(r);
+    t.green = clamp_signed255(g);
+    t.blue = clamp_signed255(b);
+    t.gray = clamp255(gray);
+  }
+  return self;
+}
+
+mrb_value tone_eq(mrb_state* M, V self) {
+  V o;
+  mrb_get_args(M, "o", &o);
+  if (!mrb_obj_is_kind_of(M, o, mrb_class(M, self)))
+    return mrb_false_value();
+  Tone& a = DataType<Tone>::get(M, self);
+  Tone& b = DataType<Tone>::get(M, o);
+  return mrb_bool_value(a.red == b.red && a.green == b.green &&
+                        a.blue == b.blue && a.gray == b.gray);
+}
+
+mrb_value tone_to_s(mrb_state* M, V self) {
+  Tone& t = DataType<Tone>::get(M, self);
+  char buf[128];
+  std::snprintf(buf, sizeof(buf), "(%g, %g, %g, %g)", t.red, t.green, t.blue,
+                t.gray);
+  return mrb_str_new_cstr(M, buf);
+}
+
+mrb_value tone_dump(mrb_state* M, V self) {
+  Tone& t = DataType<Tone>::get(M, self);
+  std::string s = pack_doubles({t.red, t.green, t.blue, t.gray});
+  return mrb_str_new(M, s.data(), s.size());
+}
+
+mrb_value tone_load(mrb_state* M, V self) {
+  const char* p;
+  mrb_int len;
+  mrb_get_args(M, "s", &p, &len);
+  double d[4] = {0, 0, 0, 0};
+  unpack_doubles(p, len, d, 4);
+  V obj = DataType<Tone>::make(M, mrb_class_ptr(self));
+  Tone& t = DataType<Tone>::get(M, obj);
+  t.red = d[0];
+  t.green = d[1];
+  t.blue = d[2];
+  t.gray = d[3];
+  return obj;
+}
+
+// ---- Table ----------------------------------------------------------------
+
+long table_index(const Table& t, mrb_int x, mrb_int y, mrb_int z) {
+  if (x < 0 || x >= t.xsize || y < 0 || y >= t.ysize || z < 0 || z >= t.zsize)
+    return -1;
+  return x + y * (long)t.xsize + z * (long)t.xsize * t.ysize;
+}
+
+mrb_value table_init(mrb_state* M, V self) {
+  mrb_int a, b = 1, c = 1;
+  mrb_get_args(M, "i|ii", &a, &b, &c);
+  mrb_int argc = mrb_get_argc(M);
+  Table& t = DataType<Table>::alloc_obj(M, self);
+  t.dim = argc;
+  t.xsize = a;
+  t.ysize = argc >= 2 ? b : 1;
+  t.zsize = argc >= 3 ? c : 1;
+  t.data.assign((size_t)t.xsize * t.ysize * t.zsize, 0);
+  return self;
+}
+
+mrb_value table_get(mrb_state* M, V self) {
+  mrb_int x, y = 0, z = 0;
+  mrb_get_args(M, "i|ii", &x, &y, &z);
+  Table& t = DataType<Table>::get(M, self);
+  long i = table_index(t, x, y, z);
+  if (i < 0)
+    return mrb_nil_value();
+  return mrb_fixnum_value(t.data[i]);
+}
+
+mrb_value table_set(mrb_state* M, V self) {
+  mrb_int p0, p1, p2 = 0, p3 = 0;
+  mrb_get_args(M, "ii|ii", &p0, &p1, &p2, &p3);
+  mrb_int argc = mrb_get_argc(M);
+  mrb_int x = p0, y = 0, z = 0, v;
+  if (argc == 2) {
+    v = p1;
+  } else if (argc == 3) {
+    y = p1;
+    v = p2;
+  } else {
+    y = p1;
+    z = p2;
+    v = p3;
+  }
+  Table& t = DataType<Table>::get(M, self);
+  long i = table_index(t, x, y, z);
+  if (i >= 0)
+    t.data[i] = (int16_t)v;
+  return mrb_fixnum_value(v);
+}
+
+mrb_value table_resize(mrb_state* M, V self) {
+  mrb_int a, b = 1, c = 1;
+  mrb_get_args(M, "i|ii", &a, &b, &c);
+  mrb_int argc = mrb_get_argc(M);
+  Table& t = DataType<Table>::get(M, self);
+  int32_t nx = a, ny = argc >= 2 ? b : 1, nz = argc >= 3 ? c : 1;
+  std::vector<int16_t> nd((size_t)nx * ny * nz, 0);
+  for (int32_t z = 0; z < std::min(nz, t.zsize); ++z)
+    for (int32_t y = 0; y < std::min(ny, t.ysize); ++y)
+      for (int32_t x = 0; x < std::min(nx, t.xsize); ++x)
+        nd[x + y * (long)nx + z * (long)nx * ny] =
+            t.data[x + y * (long)t.xsize + z * (long)t.xsize * t.ysize];
+  t.dim = argc;
+  t.xsize = nx;
+  t.ysize = ny;
+  t.zsize = nz;
+  t.data = std::move(nd);
+  return self;
+}
+
+mrb_value table_dump(mrb_state* M, V self) {
+  Table& t = DataType<Table>::get(M, self);
+  std::string s;
+  auto put32 = [&s](uint32_t v) {
+    char b[4];
+    std::memcpy(b, &v, 4);
+    s.append(b, 4);
+  };
+  put32(t.dim);
+  put32(t.xsize);
+  put32(t.ysize);
+  put32(t.zsize);
+  put32((uint32_t)t.data.size());
+  for (int16_t v : t.data) {
+    char b[2];
+    std::memcpy(b, &v, 2);
+    s.append(b, 2);
+  }
+  return mrb_str_new(M, s.data(), s.size());
+}
+
+mrb_value table_load(mrb_state* M, V self) {
+  const char* p;
+  mrb_int len;
+  mrb_get_args(M, "s", &p, &len);
+  auto get32 = [p, len](mrb_int off) -> uint32_t {
+    uint32_t v = 0;
+    if (off + 4 <= len)
+      std::memcpy(&v, p + off, 4);
+    return v;
+  };
+  V obj = DataType<Table>::make(M, mrb_class_ptr(self));
+  Table& t = DataType<Table>::get(M, obj);
+  t.dim = get32(0);
+  t.xsize = get32(4);
+  t.ysize = get32(8);
+  t.zsize = get32(12);
+  uint32_t count = get32(16);
+  t.data.assign(count, 0);
+  for (uint32_t i = 0; i < count; ++i) {
+    int16_t v = 0;
+    mrb_int off = 20 + (mrb_int)i * 2;
+    if (off + 2 <= len)
+      std::memcpy(&v, p + off, 2);
+    t.data[i] = v;
+  }
+  return obj;
+}
+
+// ---- Bitmap ---------------------------------------------------------------
 
 mrb_value bmp_init_size(mrb_state* M, mrb_value self) {
   mrb_int w, h;
@@ -108,6 +445,153 @@ mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
   return self;
 }
 
+Bitmap& bmp_self(mrb_state* M, V self) {
+  return DataType<Bitmap>::get(M, self);
+}
+
+// Write an RGBA color into the bitmap at (x, y). LVGL stores ARGB8888 as
+// B, G, R, A bytes (and RGB888 as B, G, R), matching how images are loaded.
+void bmp_put(Bitmap& b,
+             mrb_int x,
+             mrb_int y,
+             double r,
+             double g,
+             double bl,
+             double a) {
+  if (x < 0 || y < 0 || x >= b.width || y >= b.height)
+    return;
+  const unsigned bpp = lv_color_format_get_size(b.format);
+  uint8_t* p = b.buffer.data() + ((size_t)y * b.width + x) * bpp;
+  p[0] = (uint8_t)bl;
+  p[1] = (uint8_t)g;
+  p[2] = (uint8_t)r;
+  if (bpp >= 4)
+    p[3] = (uint8_t)a;
+}
+
+void bmp_read(const Bitmap& b,
+              mrb_int x,
+              mrb_int y,
+              int& r,
+              int& g,
+              int& bl,
+              int& a) {
+  const unsigned bpp = lv_color_format_get_size(b.format);
+  const uint8_t* p = b.buffer.data() + ((size_t)y * b.width + x) * bpp;
+  bl = p[0];
+  g = p[1];
+  r = p[2];
+  a = bpp >= 4 ? p[3] : 255;
+}
+
+mrb_value bmp_width(mrb_state* M, V self) {
+  return mrb_fixnum_value(bmp_self(M, self).width);
+}
+
+mrb_value bmp_height(mrb_state* M, V self) {
+  return mrb_fixnum_value(bmp_self(M, self).height);
+}
+
+mrb_value bmp_rect(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  const V args[] = {mrb_fixnum_value(0), mrb_fixnum_value(0),
+                    mrb_fixnum_value(b.width), mrb_fixnum_value(b.height)};
+  return mrb_obj_new(
+      M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Rect"), 4, args);
+}
+
+mrb_value bmp_clear(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  std::fill(b.buffer.begin(), b.buffer.end(), 0);
+  return self;
+}
+
+mrb_value bmp_fill_rect(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  mrb_int x, y, w, h;
+  V col;
+  if (mrb_get_argc(M) <= 2) {
+    V r;
+    mrb_get_args(M, "oo", &r, &col);
+    Rect& rc = DataType<Rect>::get(M, r);
+    x = rc.x;
+    y = rc.y;
+    w = rc.width;
+    h = rc.height;
+  } else {
+    mrb_get_args(M, "iiiio", &x, &y, &w, &h, &col);
+  }
+  Color& c = DataType<Color>::get(M, col);
+  for (mrb_int j = y; j < y + h; ++j)
+    for (mrb_int i = x; i < x + w; ++i)
+      bmp_put(b, i, j, c.red, c.green, c.blue, c.alpha);
+  return self;
+}
+
+mrb_value bmp_get_pixel(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  mrb_int x, y;
+  mrb_get_args(M, "ii", &x, &y);
+  int r = 0, g = 0, bl = 0, a = 0;
+  if (x >= 0 && y >= 0 && x < b.width && y < b.height)
+    bmp_read(b, x, y, r, g, bl, a);
+  const V args[] = {mrb_float_value(M, r), mrb_float_value(M, g),
+                    mrb_float_value(M, bl), mrb_float_value(M, a)};
+  return mrb_obj_new(
+      M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Color"), 4, args);
+}
+
+mrb_value bmp_set_pixel(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  mrb_int x, y;
+  V col;
+  mrb_get_args(M, "iio", &x, &y, &col);
+  Color& c = DataType<Color>::get(M, col);
+  bmp_put(b, x, y, c.red, c.green, c.blue, c.alpha);
+  return self;
+}
+
+mrb_value bmp_blt(mrb_state* M, V self) {
+  mrb_int x, y;
+  Bitmap* src;
+  V srect;
+  mrb_int opacity = 255;
+  mrb_get_args(M, "iido|i", &x, &y, &src, &DataType<Bitmap>::data_type, &srect,
+               &opacity);
+  Bitmap& dst = bmp_self(M, self);
+  Rect& rc = DataType<Rect>::get(M, srect);
+  if (opacity < 0)
+    opacity = 0;
+  if (opacity > 255)
+    opacity = 255;
+  for (mrb_int sy = rc.y; sy < rc.y + rc.height; ++sy) {
+    for (mrb_int sx = rc.x; sx < rc.x + rc.width; ++sx) {
+      if (sx < 0 || sy < 0 || sx >= src->width || sy >= src->height)
+        continue;
+      int r, g, bl, a;
+      bmp_read(*src, sx, sy, r, g, bl, a);
+      const int alpha = a * opacity / 255;
+      const mrb_int dx = x + (sx - rc.x);
+      const mrb_int dy = y + (sy - rc.y);
+      if (dx < 0 || dy < 0 || dx >= dst.width || dy >= dst.height)
+        continue;
+      if (alpha <= 0)
+        continue;
+      if (alpha >= 255) {
+        bmp_put(dst, dx, dy, r, g, bl, 255);
+        continue;
+      }
+      int dr, dg, db, da;
+      bmp_read(dst, dx, dy, dr, dg, db, da);
+      const int inv = 255 - alpha;
+      bmp_put(dst, dx, dy, (r * alpha + dr * inv) / 255,
+              (g * alpha + dg * inv) / 255, (bl * alpha + db * inv) / 255,
+              std::max(da, alpha));
+    }
+  }
+  return self;
+}
+
 auto find_char = [](char32_t c, const auto* g, unsigned g_len) -> const auto* {
   auto i = std::lower_bound(g, g + g_len, c, [](const auto& e, char32_t v) {
     return e.codepoint < v;
@@ -119,25 +603,76 @@ auto find_char = [](char32_t c, const auto* g, unsigned g_len) -> const auto* {
   return i;
 };
 
-mrb_value bmp_draw_text(mrb_state* M, mrb_value self) {
-  mrb_assert(DATA_PTR(self));
+// Measure the pixel width and height of `s` using the shinonome font tables.
+void measure_text(std::string_view s, int& width, unsigned& height) {
+  width = 0;
+  height = 0;
+  for (const char32_t c : s | una::views::utf8) {
+    auto f = find_char(c, shinonome::GOTHIC, shinonome::GOTHIC_LEN);
+    if (f) {
+      width += f->WIDTH;
+      height = std::max<unsigned>(height, f->HEIGHT);
+      continue;
+    }
+    auto h = find_char(c, shinonome::LATIN1, shinonome::LATIN1_LEN);
+    if (h) {
+      width += h->WIDTH;
+      height = std::max<unsigned>(height, h->HEIGHT);
+      continue;
+    }
+    h = find_char(c, shinonome::HANKAKU, shinonome::HANKAKU_LEN);
+    if (h) {
+      width += h->WIDTH;
+      height = std::max<unsigned>(height, h->HEIGHT);
+      continue;
+    }
+  }
+}
 
-  auto& bmp = *reinterpret_cast<Bitmap*>(DATA_PTR(self));
+mrb_value bmp_draw_text(mrb_state* M, mrb_value self) {
+  auto& bmp = bmp_self(M, self);
 
   mrb_int x, y, w, h, len;
+  mrb_int align = 0;
   const char* s;
-  mrb_get_args(M, "iiiis", &x, &y, &w, &h, &s, &len);
+  mrb_get_args(M, "iiiis|i", &x, &y, &w, &h, &s, &len, &align);
 
-  auto draw = [&x, y, &bmp](const auto& c) {
-    static const uint8_t col[] = {0, 0, 0, 0};
-    const unsigned col_len = lv_color_format_get_size(bmp.format);
+  // Text color comes from the bitmap's font when one has been assigned,
+  // otherwise default to opaque black.
+  uint8_t col[4] = {0, 0, 0, 255};
+  V fv = mrb_iv_get(M, self, mrb_intern_lit(M, "@font"));
+  if (!mrb_nil_p(fv)) {
+    V cv = mrb_funcall(M, fv, "color", 0);
+    if (!mrb_nil_p(cv)) {
+      Color& c = DataType<Color>::get(M, cv);
+      col[0] = (uint8_t)c.blue;
+      col[1] = (uint8_t)c.green;
+      col[2] = (uint8_t)c.red;
+      col[3] = (uint8_t)c.alpha;
+    }
+  }
+
+  // Horizontal alignment: 0 left, 1 center, 2 right.
+  int tw = 0;
+  unsigned th = 0;
+  measure_text(std::string_view(s, len), tw, th);
+  if (align == 1)
+    x += (w - tw) / 2;
+  else if (align == 2)
+    x += w - tw;
+
+  const unsigned col_len = lv_color_format_get_size(bmp.format);
+  auto draw = [&x, y, &bmp, &col, col_len](const auto& c) {
     for (unsigned i = 0; i < c.HEIGHT; ++i) {
       for (unsigned j = 0; j < c.WIDTH; ++j) {
         const unsigned idx = i * c.WIDTH + j;
+        const mrb_int px = x + j;
+        const mrb_int py = y + i;
+        if (px < 0 || py < 0 || px >= bmp.width || py >= bmp.height)
+          continue;
         if (c.data[idx / 32] & (1 << (idx % 32)))
-          std::memcpy(
-              bmp.buffer.data() + ((y + i) * bmp.width + j + x) * col_len, col,
-              col_len);
+          std::memcpy(bmp.buffer.data() + (py * bmp.width + px) * col_len, col,
+                      col_len);
       }
     }
     x += c.WIDTH;
@@ -149,14 +684,14 @@ mrb_value bmp_draw_text(mrb_state* M, mrb_value self) {
       draw(*f);
       continue;
     }
-    auto h = find_char(c, shinonome::LATIN1, shinonome::LATIN1_LEN);
-    if (h) {
-      draw(*h);
+    auto hh = find_char(c, shinonome::LATIN1, shinonome::LATIN1_LEN);
+    if (hh) {
+      draw(*hh);
       continue;
     }
-    h = find_char(c, shinonome::HANKAKU, shinonome::HANKAKU_LEN);
-    if (h) {
-      draw(*h);
+    hh = find_char(c, shinonome::HANKAKU, shinonome::HANKAKU_LEN);
+    if (hh) {
+      draw(*hh);
       continue;
     }
   }
@@ -171,27 +706,7 @@ mrb_value bmp_text_size(mrb_state* M, mrb_value self) {
 
   int w = 0;
   unsigned height = 0;
-
-  for (const char32_t c : std::string_view(s, len) | una::views::utf8) {
-    auto f = find_char(c, shinonome::GOTHIC, shinonome::GOTHIC_LEN);
-    if (f) {
-      w += f->WIDTH;
-      height = std::max(height, f->HEIGHT);
-      continue;
-    }
-    auto h = find_char(c, shinonome::LATIN1, shinonome::LATIN1_LEN);
-    if (h) {
-      w += h->WIDTH;
-      height = std::max(height, h->HEIGHT);
-      continue;
-    }
-    h = find_char(c, shinonome::HANKAKU, shinonome::HANKAKU_LEN);
-    if (h) {
-      w += h->WIDTH;
-      height = std::max(height, h->HEIGHT);
-      continue;
-    }
-  }
+  measure_text(std::string_view(s, len), w, height);
 
   const mrb_value args[] = {
       mrb_fixnum_value(0),
@@ -240,6 +755,13 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
 
   lv_timer_handler();
   lv_task_handler();
+
+  // Advance Graphics.frame_count, matching RGSS semantics.
+  V gfx = mrb_obj_value(
+      mrb_module_get_under(M, mrb_module_get(M, "RGSS"), "Graphics"));
+  V fc = mrb_iv_get(M, gfx, mrb_intern_lit(M, "@frame_count"));
+  mrb_iv_set(M, gfx, mrb_intern_lit(M, "@frame_count"),
+             mrb_fixnum_value((mrb_fixnum_p(fc) ? mrb_fixnum(fc) : 0) + 1));
 
   const int32_t sleep = 1000 / 60 - lv_tick_elaps(frame_start);
   if (sleep > 0) {
@@ -300,50 +822,10 @@ mrb_value vp_init(mrb_state* M, mrb_value self) {
   return self;
 }
 
-}  // namespace
-
-extern "C" void rgss_set_display(mrb_state* M, lv_display_t* display) {
-  mrb_assert(!mrb_const_defined(M, mrb_obj_value(mrb_module_get(M, "RGSS")),
-                                mrb_intern_lit(M, "_display")));
-  mrb_const_set(M, mrb_obj_value(mrb_module_get(M, "RGSS")),
-                mrb_intern_lit(M, "_display"), mrb_cptr_value(M, display));
-}
-
-extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
-  RClass* m = mrb_define_module(M, "RGSS");
-  mrb_define_module_function(M, m, "to_nfd", to_nfd, MRB_ARGS_REQ(1));
-
-  mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_game_start"),
-                mrb_fixnum_value(lv_tick_get()));
-
-  RClass* vp = mrb_define_class_under(M, m, "Viewport", M->object_class);
-  MRB_SET_INSTANCE_TT(vp, MRB_TT_DATA);
-  mrb_define_method(M, vp, "initialize", vp_init, MRB_ARGS_NONE());
-  mrb_define_method(M, vp, "dispose", obj_dispose, MRB_ARGS_NONE());
-  mrb_define_method(M, vp, "disposed?", obj_disposed, MRB_ARGS_NONE());
-
-  RClass* spr = mrb_define_class_under(M, m, "Sprite", M->object_class);
-  MRB_SET_INSTANCE_TT(spr, MRB_TT_DATA);
-  mrb_define_method(M, spr, "initialize", spr_init, MRB_ARGS_OPT(1));
-  mrb_define_method(M, spr, "bitmap=", spr_set_bmp, MRB_ARGS_REQ(1));
-  mrb_define_method(M, spr, "dispose", obj_dispose, MRB_ARGS_NONE());
-  mrb_define_method(M, spr, "disposed?", obj_disposed, MRB_ARGS_NONE());
-
-  RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
-  MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);
-  mrb_define_method(M, bmp, "_init_size", bmp_init_size, MRB_ARGS_REQ(2));
-  mrb_define_method(M, bmp, "_init_file", bmp_init_file,
-                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
-  mrb_define_method(M, bmp, "draw_text", bmp_draw_text,
-                    MRB_ARGS_REQ(5) | MRB_ARGS_OPT(1));
-  mrb_define_method(M, bmp, "text_size", bmp_text_size, MRB_ARGS_REQ(1));
-  mrb_define_method(M, bmp, "dispose", obj_dispose, MRB_ARGS_NONE());
-  mrb_define_method(M, bmp, "disposed?", obj_disposed, MRB_ARGS_NONE());
-
-  RClass* gfx = mrb_define_module_under(M, m, "Graphics");
-  mrb_define_module_function(M, gfx, "update", gfx_update, MRB_ARGS_NONE());
-
+// Register x/y/width/height accessors for the Rect class.
+void define_rect(mrb_state* M, RClass* m) {
   RClass* rect = mrb_define_class_under(M, m, "Rect", M->object_class);
+  MRB_SET_INSTANCE_TT(rect, MRB_TT_DATA);
   mrb_define_method(
       M, rect, "initialize",
       [](mrb_state* M, V self) -> V {
@@ -435,6 +917,201 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
         return mrb_fixnum_value(DataType<Rect>::get(M, self).height = x);
       },
       MRB_ARGS_REQ(1));
+  mrb_define_method(
+      M, rect, "==",
+      [](mrb_state* M, V self) {
+        V o;
+        mrb_get_args(M, "o", &o);
+        if (!mrb_obj_is_kind_of(M, o, mrb_class(M, self)))
+          return mrb_false_value();
+        Rect& a = DataType<Rect>::get(M, self);
+        Rect& b = DataType<Rect>::get(M, o);
+        return mrb_bool_value(a.x == b.x && a.y == b.y && a.width == b.width &&
+                              a.height == b.height);
+      },
+      MRB_ARGS_REQ(1));
+  mrb_define_method(
+      M, rect, "to_s",
+      [](mrb_state* M, V self) {
+        Rect& r = DataType<Rect>::get(M, self);
+        char buf[128];
+        std::snprintf(buf, sizeof(buf), "(%d, %d, %d, %d)", (int)r.x, (int)r.y,
+                      (int)r.width, (int)r.height);
+        return mrb_str_new_cstr(M, buf);
+      },
+      MRB_ARGS_NONE());
+  mrb_define_method(
+      M, rect, "_dump",
+      [](mrb_state* M, V self) {
+        Rect& r = DataType<Rect>::get(M, self);
+        int32_t v[4] = {(int32_t)r.x, (int32_t)r.y, (int32_t)r.width,
+                        (int32_t)r.height};
+        return mrb_str_new(M, reinterpret_cast<const char*>(v), sizeof(v));
+      },
+      MRB_ARGS_REQ(1));
+  mrb_define_class_method(
+      M, rect, "_load",
+      [](mrb_state* M, V self) {
+        const char* p;
+        mrb_int len;
+        mrb_get_args(M, "s", &p, &len);
+        int32_t v[4] = {0, 0, 0, 0};
+        std::memcpy(v, p, std::min<mrb_int>(len, sizeof(v)));
+        return DataType<Rect>::make(M, mrb_class_ptr(self), v[0], v[1], v[2],
+                                    v[3]);
+      },
+      MRB_ARGS_REQ(1));
+}
+
+}  // namespace
+
+extern "C" void rgss_set_display(mrb_state* M, lv_display_t* display) {
+  mrb_assert(!mrb_const_defined(M, mrb_obj_value(mrb_module_get(M, "RGSS")),
+                                mrb_intern_lit(M, "_display")));
+  mrb_const_set(M, mrb_obj_value(mrb_module_get(M, "RGSS")),
+                mrb_intern_lit(M, "_display"), mrb_cptr_value(M, display));
+}
+
+extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
+  RClass* m = mrb_define_module(M, "RGSS");
+  mrb_define_module_function(M, m, "to_nfd", to_nfd, MRB_ARGS_REQ(1));
+
+  mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_game_start"),
+                mrb_fixnum_value(lv_tick_get()));
+
+  RClass* vp = mrb_define_class_under(M, m, "Viewport", M->object_class);
+  MRB_SET_INSTANCE_TT(vp, MRB_TT_DATA);
+  mrb_define_method(M, vp, "initialize", vp_init, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "dispose", obj_dispose, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "disposed?", obj_disposed, MRB_ARGS_NONE());
+
+  RClass* spr = mrb_define_class_under(M, m, "Sprite", M->object_class);
+  MRB_SET_INSTANCE_TT(spr, MRB_TT_DATA);
+  mrb_define_method(M, spr, "initialize", spr_init, MRB_ARGS_OPT(1));
+  mrb_define_method(M, spr, "bitmap=", spr_set_bmp, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "dispose", obj_dispose, MRB_ARGS_NONE());
+  mrb_define_method(M, spr, "disposed?", obj_disposed, MRB_ARGS_NONE());
+
+  RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
+  MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);
+  mrb_define_method(M, bmp, "_init_size", bmp_init_size, MRB_ARGS_REQ(2));
+  mrb_define_method(M, bmp, "_init_file", bmp_init_file,
+                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "width", bmp_width, MRB_ARGS_NONE());
+  mrb_define_method(M, bmp, "height", bmp_height, MRB_ARGS_NONE());
+  mrb_define_method(M, bmp, "rect", bmp_rect, MRB_ARGS_NONE());
+  mrb_define_method(M, bmp, "clear", bmp_clear, MRB_ARGS_NONE());
+  mrb_define_method(M, bmp, "fill_rect", bmp_fill_rect,
+                    MRB_ARGS_REQ(2) | MRB_ARGS_OPT(3));
+  mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
+  mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
+  mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "draw_text", bmp_draw_text,
+                    MRB_ARGS_REQ(5) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "text_size", bmp_text_size, MRB_ARGS_REQ(1));
+  mrb_define_method(M, bmp, "dispose", obj_dispose, MRB_ARGS_NONE());
+  mrb_define_method(M, bmp, "disposed?", obj_disposed, MRB_ARGS_NONE());
+
+  RClass* color = mrb_define_class_under(M, m, "Color", M->object_class);
+  MRB_SET_INSTANCE_TT(color, MRB_TT_DATA);
+  mrb_define_method(M, color, "initialize", color_init,
+                    MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, color, "set", color_set,
+                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(3));
+  mrb_define_method(M, color, "red", component_get<Color, &Color::red>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, color, "green", component_get<Color, &Color::green>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, color, "blue", component_get<Color, &Color::blue>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, color, "alpha", component_get<Color, &Color::alpha>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, color, "red=", component_set<Color, &Color::red, 0, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, color,
+                    "green=", component_set<Color, &Color::green, 0, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, color,
+                    "blue=", component_set<Color, &Color::blue, 0, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, color,
+                    "alpha=", component_set<Color, &Color::alpha, 0, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, color, "==", color_eq, MRB_ARGS_REQ(1));
+  mrb_define_method(M, color, "to_s", color_to_s, MRB_ARGS_NONE());
+  mrb_define_method(M, color, "_dump", color_dump, MRB_ARGS_REQ(1));
+  mrb_define_class_method(M, color, "_load", color_load, MRB_ARGS_REQ(1));
+
+  RClass* tone = mrb_define_class_under(M, m, "Tone", M->object_class);
+  MRB_SET_INSTANCE_TT(tone, MRB_TT_DATA);
+  mrb_define_method(M, tone, "initialize", tone_init,
+                    MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, tone, "set", tone_set,
+                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(3));
+  mrb_define_method(M, tone, "red", component_get<Tone, &Tone::red>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, tone, "green", component_get<Tone, &Tone::green>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, tone, "blue", component_get<Tone, &Tone::blue>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, tone, "gray", component_get<Tone, &Tone::gray>,
+                    MRB_ARGS_NONE());
+  mrb_define_method(M, tone, "red=", component_set<Tone, &Tone::red, -255, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, tone,
+                    "green=", component_set<Tone, &Tone::green, -255, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, tone,
+                    "blue=", component_set<Tone, &Tone::blue, -255, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, tone, "gray=", component_set<Tone, &Tone::gray, 0, 255>,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, tone, "==", tone_eq, MRB_ARGS_REQ(1));
+  mrb_define_method(M, tone, "to_s", tone_to_s, MRB_ARGS_NONE());
+  mrb_define_method(M, tone, "_dump", tone_dump, MRB_ARGS_REQ(1));
+  mrb_define_class_method(M, tone, "_load", tone_load, MRB_ARGS_REQ(1));
+
+  RClass* table = mrb_define_class_under(M, m, "Table", M->object_class);
+  MRB_SET_INSTANCE_TT(table, MRB_TT_DATA);
+  mrb_define_method(M, table, "initialize", table_init,
+                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
+  mrb_define_method(M, table, "[]", table_get,
+                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
+  mrb_define_method(M, table, "[]=", table_set,
+                    MRB_ARGS_REQ(2) | MRB_ARGS_OPT(2));
+  mrb_define_method(M, table, "resize", table_resize,
+                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
+  mrb_define_method(
+      M, table, "xsize",
+      [](mrb_state* M, V self) {
+        return mrb_fixnum_value(DataType<Table>::get(M, self).xsize);
+      },
+      MRB_ARGS_NONE());
+  mrb_define_method(
+      M, table, "ysize",
+      [](mrb_state* M, V self) {
+        return mrb_fixnum_value(DataType<Table>::get(M, self).ysize);
+      },
+      MRB_ARGS_NONE());
+  mrb_define_method(
+      M, table, "zsize",
+      [](mrb_state* M, V self) {
+        return mrb_fixnum_value(DataType<Table>::get(M, self).zsize);
+      },
+      MRB_ARGS_NONE());
+  mrb_define_method(
+      M, table, "dim",
+      [](mrb_state* M, V self) {
+        return mrb_fixnum_value(DataType<Table>::get(M, self).dim);
+      },
+      MRB_ARGS_NONE());
+  mrb_define_method(M, table, "_dump", table_dump, MRB_ARGS_REQ(1));
+  mrb_define_class_method(M, table, "_load", table_load, MRB_ARGS_REQ(1));
+
+  RClass* gfx = mrb_define_module_under(M, m, "Graphics");
+  mrb_define_module_function(M, gfx, "update", gfx_update, MRB_ARGS_NONE());
+
+  define_rect(M, m);
 }
 
 extern "C" void mrb_mruby_rgss_gem_final(mrb_state* mrb) {}

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1,4 +1,142 @@
 # From: https://github.com/uni-algo/uni-algo?tab=readme-ov-file#normalization-functions
-assert "" do
+assert "RGSS.to_nfd" do
   assert_equal RGSS.to_nfd("Ŵ"), "W\u0302"
+end
+
+assert "RGSS::Color basics" do
+  c = RGSS::Color.new(10, 20, 30)
+  assert_equal 10.0, c.red
+  assert_equal 20.0, c.green
+  assert_equal 30.0, c.blue
+  assert_equal 255.0, c.alpha
+
+  c.set(1, 2, 3, 4)
+  assert_equal 1.0, c.red
+  assert_equal 4.0, c.alpha
+
+  c.red = 500
+  assert_equal 255.0, c.red # clamped to 0..255
+  c.blue = -10
+  assert_equal 0.0, c.blue
+end
+
+assert "RGSS::Color equality and marshal" do
+  a = RGSS::Color.new(1, 2, 3, 4)
+  b = RGSS::Color.new(1, 2, 3, 4)
+  assert_true a == b
+  assert_false a == RGSS::Color.new(1, 2, 3, 5)
+
+  loaded = Marshal.load(Marshal.dump(a))
+  assert_true loaded.is_a?(RGSS::Color)
+  assert_true a == loaded
+end
+
+assert "RGSS::Tone basics and clamping" do
+  t = RGSS::Tone.new(-300, 20, 30, 400)
+  assert_equal(-255.0, t.red) # clamped to -255..255
+  assert_equal 20.0, t.green
+  assert_equal 255.0, t.gray  # clamped to 0..255
+
+  loaded = Marshal.load(Marshal.dump(t))
+  assert_true loaded == t
+end
+
+assert "RGSS::Rect basics" do
+  r = RGSS::Rect.new(1, 2, 3, 4)
+  assert_equal 1, r.x
+  assert_equal 4, r.height
+  r.set(5, 6, 7, 8)
+  assert_equal 5, r.x
+  assert_equal 8, r.height
+
+  assert_true r == RGSS::Rect.new(5, 6, 7, 8)
+
+  loaded = Marshal.load(Marshal.dump(r))
+  assert_true loaded == r
+
+  r.empty
+  assert_equal 0, r.x
+  assert_equal 0, r.width
+end
+
+assert "RGSS::Table 1D" do
+  t = RGSS::Table.new(3)
+  assert_equal 3, t.xsize
+  assert_equal 1, t.ysize
+  assert_equal 1, t.zsize
+  assert_equal 1, t.dim
+  assert_equal 0, t[0]
+  t[0] = 42
+  t[2] = -7
+  assert_equal 42, t[0]
+  assert_equal(-7, t[2])
+  assert_nil t[3]  # out of range
+  assert_nil t[-1]
+end
+
+assert "RGSS::Table 3D and resize" do
+  t = RGSS::Table.new(2, 3, 4)
+  assert_equal 3, t.dim
+  assert_equal 4, t.zsize
+  t[1, 2, 3] = 99
+  assert_equal 99, t[1, 2, 3]
+  assert_equal 0, t[0, 0, 0]
+
+  t.resize(4, 3, 4)
+  assert_equal 4, t.xsize
+  assert_equal 99, t[1, 2, 3] # preserved through resize
+end
+
+assert "RGSS::Table marshal round-trip" do
+  t = RGSS::Table.new(2, 2)
+  t[0, 0] = 1
+  t[1, 0] = 2
+  t[0, 1] = 3
+  t[1, 1] = 4
+  loaded = Marshal.load(Marshal.dump(t))
+  assert_true loaded.is_a?(RGSS::Table)
+  assert_equal 2, loaded.xsize
+  assert_equal 2, loaded.ysize
+  assert_equal 1, loaded[0, 0]
+  assert_equal 4, loaded[1, 1]
+end
+
+assert "RGSS::Bitmap pixel operations" do
+  b = RGSS::Bitmap.new(4, 4)
+  assert_equal 4, b.width
+  assert_equal 4, b.height
+  assert_equal 0, b.rect.x
+  assert_equal 4, b.rect.width
+
+  b.set_pixel(1, 1, RGSS::Color.new(10, 20, 30, 40))
+  px = b.get_pixel(1, 1)
+  assert_equal 10.0, px.red
+  assert_equal 20.0, px.green
+  assert_equal 30.0, px.blue
+  assert_equal 40.0, px.alpha
+
+  b.fill_rect(0, 0, 4, 4, RGSS::Color.new(255, 0, 0, 255))
+  assert_equal 255.0, b.get_pixel(3, 3).red
+
+  b.clear
+  assert_equal 0.0, b.get_pixel(3, 3).red
+  assert_equal 0.0, b.get_pixel(3, 3).alpha
+end
+
+assert "RGSS::Bitmap blt" do
+  src = RGSS::Bitmap.new(2, 2)
+  src.fill_rect(0, 0, 2, 2, RGSS::Color.new(0, 128, 0, 255))
+  dst = RGSS::Bitmap.new(4, 4)
+  dst.blt(1, 1, src, RGSS::Rect.new(0, 0, 2, 2))
+  assert_equal 128.0, dst.get_pixel(1, 1).green
+  assert_equal 128.0, dst.get_pixel(2, 2).green
+  assert_equal 0.0, dst.get_pixel(0, 0).alpha # untouched
+end
+
+assert "RGSS::Font defaults" do
+  f = RGSS::Font.new
+  assert_equal RGSS::Font.default_name, f.name
+  assert_equal RGSS::Font.default_size, f.size
+  assert_true f.color.is_a?(RGSS::Color)
+  assert_true RGSS::Font.exist?("Arial")
 end


### PR DESCRIPTION
## Summary

Expands the `mruby-rgss` mrbgem with a substantial slice of the **RGSS (RPG Maker XP) built-in class library**, building on the existing `Bitmap`/`Sprite`/`Viewport`/`Rect` foundation.

### New classes (C++, `mruby-rgss/src/lib.cxx`)
- **`Color`** — floating-point RGBA (clamped 0–255) with `set`, `==`, `to_s`, and RGSS-compatible Marshal (`_dump`/`_load`).
- **`Tone`** — red/green/blue (−255–255) + gray (0–255) with the same feature set.
- **`Table`** — 1/2/3-dimensional 16-bit integer array (`[]`, `[]=`, `xsize`/`ysize`/`zsize`/`dim`, `resize` with overlap preservation) using the exact RGSS Marshal binary format used for map/tile data.

### Enhanced
- **`Bitmap`** — added `width`, `height`, `rect`, `clear`, `fill_rect`, `get_pixel`, `set_pixel`, `blt` (opacity alpha-blending), and made `draw_text` honor the font color and horizontal `align`.
- **`Rect`** — added `==`, `to_s`, Marshal support, and set `MRB_TT_DATA` as the instance type so `Rect.new` no longer trips the `mrb_data_p` assertion (latent bug — the class was a DATA type but never called `MRB_SET_INSTANCE_TT`).
- **`Graphics.update`** now advances `frame_count`; `draw_text`'s default color is now opaque (previously wrote alpha 0, which is invisible on ARGB bitmaps).

### Ruby side (`mruby-rgss/mrblib/lib.rb`)
- **`Font`** — name/size/bold/italic/color with class-level defaults and `Font.exist?`; `Bitmap#font` / `Bitmap#font=` accessors.
- **`Audio`** — inert stubs for the standard bgm/bgs/me/se API.
- **`Graphics`** — `frame_count`, `frame_rate`, `freeze`, `transition`, `frame_reset`.

## Tests
Added coverage in `mruby-rgss/test/test.rb` for the value classes, bitmap pixel operations, and Marshal round-trips.

## Verification
A full test run wasn't possible in the dev environment (the CMake build needs SDL2, plus LVGL config). To compensate:
- Compiled `lib.cxx` with `-fsyntax-only` against the real LVGL, mruby, uni-algo, and stb headers — clean.
- Ran `clang-format` per the repo config and re-verified the compile.
- Syntax-checked the Ruby files.

## Notes
Marshal round-trips **within** this runtime (classes are namespaced `RGSS::Color`, etc.). Loading raw RPG Maker XP `.rxdata` files — which use top-level `Color`/`Table`/`Tone` — would need a class-name mapping, consistent with how the project already namespaces everything under `RGSS`. That's a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTWa2FEzhS9Mk75dXfTT4n)_