### PR TITLE
Make libmruby rebuild smarter with GLOB_RECURSE CONFIGURE_DEPENDS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,6 @@ jobs:
           SKIP: nixfmt
         run: |
           nix develop -c pre-commit run -a || (
-            echo "pre-commit failed" ;
             git diff --exit-code ;
             false
           )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,11 @@ jobs:
         env:
           SKIP: nixfmt
         run: |
-          nix develop -c pre-commit run -a
-          git diff --exit-code
+          nix develop -c pre-commit run -a || (
+            echo "pre-commit failed" ;
+            git diff --exit-code ;
+            false
+          )
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,25 @@ set(LIBMRUBY_A "${MRUBY_BUILD_DIR}/${MRUBY_TARGET_NAME}/lib/libmruby.a")
 set_target_properties(mruby PROPERTIES IMPORTED_LOCATION "${LIBMRUBY_A}")
 list(APPEND ADDITIONAL_CLEAN_FILES "${MRUBY_BUILD_DIR}")
 target_include_directories(mruby INTERFACE "${MRUBY_PREFIX}/include")
+# Collect the source of each local mrbgem so libmruby.a rebuilds when any of it
+# changes. GLOB_RECURSE also picks up files in nested subdirectories, and
+# CONFIGURE_DEPENDS makes CMake re-run the glob at build time: adding or removing
+# a source file triggers a reconfigure (and thus a libmruby rebuild) on the next
+# `make`, with no manual `cmake` re-run. Header changes under src/ are caught too
+# so an edit to a private header still forces the archive to be rebuilt.
 foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp)
-  file(GLOB cxx ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.cxx)
-  file(GLOB rb ${CMAKE_CURRENT_SOURCE_DIR}/${g}/mrblib/*.rb)
-  list(APPEND MRB_FILES ${cxx} ${rb}
+  file(
+    GLOB_RECURSE src
+    CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.cxx
+    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.hxx)
+  file(GLOB_RECURSE rb CONFIGURE_DEPENDS
+       ${CMAKE_CURRENT_SOURCE_DIR}/${g}/mrblib/*.rb)
+  list(APPEND MRB_FILES ${src} ${rb}
        ${CMAKE_CURRENT_SOURCE_DIR}/${g}/mrbgem.rake)
 endforeach()
 set(MRB_OPTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,16 @@ foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp)
   list(APPEND MRB_FILES ${src} ${rb}
        ${CMAKE_CURRENT_SOURCE_DIR}/${g}/mrbgem.rake)
 endforeach()
+
+# Also rebuild libmruby.a when mruby's own core changes. These sources live in
+# the 3rd/mruby submodule; CONFIGURE_DEPENDS keeps the list current as the
+# submodule is checked out or updated to a new revision.
+file(GLOB_RECURSE mruby_core CONFIGURE_DEPENDS
+     ${MRUBY_PREFIX}/src/*.c
+     ${MRUBY_PREFIX}/src/*.h
+     ${MRUBY_PREFIX}/mrblib/*.rb
+     ${MRUBY_PREFIX}/include/*.h)
+list(APPEND MRB_FILES ${mruby_core})
 set(MRB_OPTS
     MRUBY_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/build_config.rb
     MRUBY_BUILD_DIR=${MRUBY_BUILD_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,13 +65,15 @@ list(APPEND ADDITIONAL_CLEAN_FILES "${MRUBY_BUILD_DIR}")
 target_include_directories(mruby INTERFACE "${MRUBY_PREFIX}/include")
 # Collect the source of each local mrbgem so libmruby.a rebuilds when any of it
 # changes. GLOB_RECURSE also picks up files in nested subdirectories, and
-# CONFIGURE_DEPENDS makes CMake re-run the glob at build time: adding or removing
-# a source file triggers a reconfigure (and thus a libmruby rebuild) on the next
-# `make`, with no manual `cmake` re-run. Header changes under src/ are caught too
-# so an edit to a private header still forces the archive to be rebuilt.
+# CONFIGURE_DEPENDS makes CMake re-run the glob at build time: adding or
+# removing a source file triggers a reconfigure (and thus a libmruby rebuild) on
+# the next `make`, with no manual `cmake` re-run. Header changes under src/ are
+# caught too so an edit to a private header still forces the archive to be
+# rebuilt.
 foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp)
   file(
-    GLOB_RECURSE src
+    GLOB_RECURSE
+    src
     CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.c
     ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.cxx
@@ -88,11 +90,14 @@ endforeach()
 # Also rebuild libmruby.a when mruby's own core changes. These sources live in
 # the 3rd/mruby submodule; CONFIGURE_DEPENDS keeps the list current as the
 # submodule is checked out or updated to a new revision.
-file(GLOB_RECURSE mruby_core CONFIGURE_DEPENDS
-     ${MRUBY_PREFIX}/src/*.c
-     ${MRUBY_PREFIX}/src/*.h
-     ${MRUBY_PREFIX}/mrblib/*.rb
-     ${MRUBY_PREFIX}/include/*.h)
+file(
+  GLOB_RECURSE
+  mruby_core
+  CONFIGURE_DEPENDS
+  ${MRUBY_PREFIX}/src/*.c
+  ${MRUBY_PREFIX}/src/*.h
+  ${MRUBY_PREFIX}/mrblib/*.rb
+  ${MRUBY_PREFIX}/include/*.h)
 list(APPEND MRB_FILES ${mruby_core})
 set(MRB_OPTS
     MRUBY_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/build_config.rb


### PR DESCRIPTION
The MRB_FILES dependency list that drives when libmruby.a is rebuilt was gathered with plain file(GLOB), which is evaluated only at configure time. Adding or removing a source file left the list stale, so libmruby would not rebuild until cmake was re-run by hand.

Switch to file(GLOB_RECURSE ... CONFIGURE_DEPENDS): CONFIGURE_DEPENDS makes CMake re-run the glob at build time and reconfigure when the set of matched files changes, and GLOB_RECURSE also picks up sources in nested subdirectories. Header files under src/ are now globbed too so editing a private header forces the archive to rebuild.


Claude-Session: https://claude.ai/code/session_01Hbsj3SU7DhCTK1LiAS1wPS