### PR TITLE
Render RPG2k windowskin for the title menu window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ All notable changes to this project will be documented in this file.
   - Implemented menu navigation with keyboard input (up/down arrows)
   - Added selection highlighting with cursor
   - Implemented basic menu item selection functionality
+- RPG Maker 2000 style windows
+  - `RGSS::Window` now renders a real windowskin: a stretched 32x32 background
+    tile plus the 8px frame border (corners and edges) taken from the System
+    graphic, with the selection cursor and contents composited on top
+  - Falls back to a plain dark panel with a light border when no windowskin can
+    be loaded
+  - Parsed the System graphic name (`system_graphic`, LDB chunk 19) from the
+    database and used it as the title menu windowskin
+  - Sized and centred the title menu window to fit its labels, matching the
+    reference title layout
+  - Added `RGSS::Bitmap#stretch_blt` (nearest-neighbour scaled blit with
+    opacity alpha-blending) plus a test
 - Input module implementation
   - Added key constants (UP, DOWN, LEFT, RIGHT, A, B, C, etc.)
   - Implemented input state tracking (press, trigger, repeat)

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -177,7 +177,10 @@ module LCF
           # https://wikiwiki.jp/viprpg-dev/200X%E5%85%B1%E9%80%9A/%E8%A7%A3%E6%9E%90%E3%81%BE%E3%81%A8%E3%82%81/%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9/%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0
           name: :system, type: :Array1D,
           elements: {
-            17 => { name: :title, type: :string }
+            17 => { name: :title, type: :string },
+            # System/ graphic that supplies the window skin (background, frame
+            # border and selection cursor).
+            19 => { name: :system_graphic, type: :string }
           }
         },
         23 => {

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -607,6 +607,57 @@ mrb_value bmp_blt(mrb_state* M, V self) {
   return self;
 }
 
+// Copy src_rect from `src` into dest_rect of self, scaling with nearest
+// neighbour sampling. Mirrors RGSS's Bitmap#stretch_blt and is used to stretch
+// the small windowskin pieces (32x32 background, 16x8/8x16 border edges) over
+// an arbitrarily sized window.
+mrb_value bmp_stretch_blt(mrb_state* M, V self) {
+  V drect_v, srect_v;
+  Bitmap* src;
+  mrb_int opacity = 255;
+  mrb_get_args(M, "odo|i", &drect_v, &src, &DataType<Bitmap>::data_type,
+               &srect_v, &opacity);
+  Bitmap& dst = bmp_self(M, self);
+  Rect& dr = DataType<Rect>::get(M, drect_v);
+  Rect& sr = DataType<Rect>::get(M, srect_v);
+  if (opacity < 0)
+    opacity = 0;
+  if (opacity > 255)
+    opacity = 255;
+  if (dr.width <= 0 || dr.height <= 0 || sr.width <= 0 || sr.height <= 0)
+    return self;
+  for (mrb_int j = 0; j < dr.height; ++j) {
+    const mrb_int dy = dr.y + j;
+    if (dy < 0 || dy >= dst.height)
+      continue;
+    const mrb_int sy = sr.y + j * sr.height / dr.height;
+    for (mrb_int i = 0; i < dr.width; ++i) {
+      const mrb_int dx = dr.x + i;
+      if (dx < 0 || dx >= dst.width)
+        continue;
+      const mrb_int sx = sr.x + i * sr.width / dr.width;
+      if (sx < 0 || sy < 0 || sx >= src->width || sy >= src->height)
+        continue;
+      int r, g, bl, a;
+      bmp_read(*src, sx, sy, r, g, bl, a);
+      const int alpha = a * opacity / 255;
+      if (alpha <= 0)
+        continue;
+      if (alpha >= 255) {
+        bmp_put(dst, dx, dy, r, g, bl, 255);
+        continue;
+      }
+      int dr2, dg, db, da;
+      bmp_read(dst, dx, dy, dr2, dg, db, da);
+      const int inv = 255 - alpha;
+      bmp_put(dst, dx, dy, (r * alpha + dr2 * inv) / 255,
+              (g * alpha + dg * inv) / 255, (bl * alpha + db * inv) / 255,
+              std::max(da, alpha));
+    }
+  }
+  return self;
+}
+
 auto find_char = [](char32_t c, const auto* g, unsigned g_len) -> const auto* {
   auto i = std::lower_bound(g, g + g_len, c, [](const auto& e, char32_t v) {
     return e.codepoint < v;
@@ -1107,6 +1158,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "stretch_blt", bmp_stretch_blt,
+                    MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
   mrb_define_method(M, bmp, "draw_text", bmp_draw_text,
                     MRB_ARGS_REQ(5) | MRB_ARGS_OPT(1));
   mrb_define_method(M, bmp, "text_size", bmp_text_size, MRB_ARGS_REQ(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -133,6 +133,18 @@ assert "RGSS::Bitmap blt" do
   assert_equal 0.0, dst.get_pixel(0, 0).alpha # untouched
 end
 
+assert "RGSS::Bitmap stretch_blt" do
+  src = RGSS::Bitmap.new(2, 2)
+  src.fill_rect(0, 0, 2, 2, RGSS::Color.new(0, 0, 255, 255))
+  dst = RGSS::Bitmap.new(8, 8)
+  # Stretch the 2x2 source across a 4x4 destination region.
+  dst.stretch_blt(RGSS::Rect.new(2, 2, 4, 4), src, RGSS::Rect.new(0, 0, 2, 2))
+  assert_equal 255.0, dst.get_pixel(2, 2).blue
+  assert_equal 255.0, dst.get_pixel(5, 5).blue
+  assert_equal 0.0, dst.get_pixel(0, 0).alpha # outside the destination rect
+  assert_equal 0.0, dst.get_pixel(6, 6).alpha
+end
+
 assert "RGSS::Font defaults" do
   f = RGSS::Font.new
   assert_equal RGSS::Font.default_name, f.name

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3,10 +3,21 @@ class Object
 end
 
 module RGSS
+  # RPG Maker 2000 style window. The visual is assembled from a "windowskin"
+  # System graphic laid out in the classic 160x80 arrangement:
+  #
+  #   (0, 0, 32, 32)   background fill (stretched over the interior)
+  #   (32, 0, 32, 32)  8px-thick frame border, split into 4 corners and 4 edges
+  #
+  # Background, frame, the selection cursor and the window contents are all
+  # composited into a single Bitmap that backs one Sprite.
   class Window
     # Windows are drawn above ordinary background sprites (which default to
     # z == 0), so give the backing sprite a high z by default.
     DEFAULT_Z = 100
+
+    # Thickness of the RPG2k frame border, in pixels.
+    BORDER = 8
 
     def initialize(x = 0, y = 0, width = 0, height = 0)
       @x = x
@@ -14,15 +25,20 @@ module RGSS
       @width = width
       @height = height
       @contents = nil
+      @windowskin = nil
+      @cursor_rect = Rect.new(0, 0, 0, 0)
+      @active = true
+      @visible = true
       # Back the window with a Sprite so its contents are actually drawn.
       @sprite = Sprite.new
       @sprite.x = x
       @sprite.y = y
       @sprite.z = DEFAULT_Z
+      allocate_skin
     end
 
-    attr_reader :x, :y, :contents
-    attr_accessor :width, :height
+    attr_reader :x, :y, :width, :height, :contents, :windowskin, :cursor_rect
+    attr_reader :active, :visible
 
     def x=(v)
       @x = v
@@ -34,14 +50,142 @@ module RGSS
       @sprite.y = v
     end
 
-    def contents=(bmp)
-      @contents = bmp
-      @sprite.bitmap = bmp if bmp
+    def z=(v)
+      @sprite.z = v
+    end
+
+    def width=(v)
+      @width = v
+      allocate_skin
+    end
+
+    def height=(v)
+      @height = v
+      allocate_skin
+    end
+
+    def windowskin=(bmp)
+      @windowskin = bmp
+      redraw
       bmp
     end
 
+    def contents=(bmp)
+      @contents = bmp
+      redraw
+      bmp
+    end
+
+    def cursor_rect=(rect)
+      @cursor_rect = rect
+      redraw
+      rect
+    end
+
+    def active=(v)
+      @active = v
+      redraw
+    end
+
+    def visible=(v)
+      @visible = v
+      redraw
+    end
+
+    # Present so the game loop can drive per-frame behaviour (cursor blinking,
+    # etc.). The cursor is drawn steadily for now, so this is a no-op.
+    def update; end
+
     def dispose
       @sprite.dispose
+    end
+
+    private
+
+    # (Re)create the backing bitmap whenever the window is resized, then redraw.
+    def allocate_skin
+      @skin = Bitmap.new([@width, 1].max, [@height, 1].max)
+      @sprite.bitmap = @skin
+      redraw
+    end
+
+    def redraw
+      @skin.clear
+      return unless @visible
+
+      if @windowskin
+        draw_background
+        draw_frame
+      else
+        draw_fallback
+      end
+
+      draw_cursor
+      draw_contents
+    end
+
+    # Stretch the 32x32 background tile over the whole window; the frame border
+    # is drawn on top of its outer edge afterwards.
+    def draw_background
+      @skin.stretch_blt Rect.new(0, 0, @width, @height), @windowskin,
+                        Rect.new(0, 0, 32, 32)
+    end
+
+    def draw_frame
+      w = @width
+      h = @height
+      b = BORDER
+      sk = @windowskin
+
+      # Corners (8x8, drawn 1:1).
+      @skin.blt 0, 0, sk, Rect.new(32, 0, b, b)
+      @skin.blt w - b, 0, sk, Rect.new(56, 0, b, b)
+      @skin.blt 0, h - b, sk, Rect.new(32, 24, b, b)
+      @skin.blt w - b, h - b, sk, Rect.new(56, 24, b, b)
+
+      # Edges (stretched along the free axis).
+      @skin.stretch_blt Rect.new(b, 0, w - 2 * b, b), sk, Rect.new(40, 0, 16, b)
+      @skin.stretch_blt Rect.new(b, h - b, w - 2 * b, b), sk,
+                        Rect.new(40, 24, 16, b)
+      @skin.stretch_blt Rect.new(0, b, b, h - 2 * b), sk, Rect.new(32, 8, b, 16)
+      @skin.stretch_blt Rect.new(w - b, b, b, h - 2 * b), sk,
+                        Rect.new(56, 8, b, 16)
+    end
+
+    # Used when no windowskin could be loaded: a plain dark panel with a light
+    # border so the window is still visible.
+    def draw_fallback
+      @skin.fill_rect 0, 0, @width, @height, Color.new(8, 8, 40, 224)
+      edge = Color.new(200, 200, 216, 255)
+      @skin.fill_rect 0, 0, @width, 1, edge
+      @skin.fill_rect 0, @height - 1, @width, 1, edge
+      @skin.fill_rect 0, 0, 1, @height, edge
+      @skin.fill_rect @width - 1, 0, 1, @height, edge
+    end
+
+    # Highlight box behind the selected item. cursor_rect is expressed in
+    # contents coordinates, so it is offset by the border thickness.
+    def draw_cursor
+      return unless @active
+      r = @cursor_rect
+      return if r.width <= 0 || r.height <= 0
+
+      # fill_rect overwrites (it does not alpha-blend onto the window
+      # background), so use an opaque highlight: a solid blue bar with a
+      # brighter border, matching the reference title screen's selection box.
+      x = BORDER + r.x
+      y = BORDER + r.y
+      @skin.fill_rect x, y, r.width, r.height, Color.new(24, 40, 176, 255)
+      border = Color.new(180, 200, 255, 255)
+      @skin.fill_rect x, y, r.width, 1, border
+      @skin.fill_rect x, y + r.height - 1, r.width, 1, border
+      @skin.fill_rect x, y, 1, r.height, border
+      @skin.fill_rect x + r.width - 1, y, 1, r.height, border
+    end
+
+    def draw_contents
+      return unless @contents
+      @skin.blt BORDER, BORDER, @contents, @contents.rect
     end
   end
 end
@@ -62,55 +206,63 @@ class RPG2k
     end
 
     class Title < Base
+      # Height of one selectable line. The shinonome font is 12px tall; the
+      # extra space gives a little breathing room between entries.
+      LINE_HEIGHT = 16
+      # draw_text is top-aligned, so nudge the 12px glyphs down to sit centred
+      # within the line (and the selection cursor).
+      TEXT_PAD_Y = (LINE_HEIGHT - 12) / 2
+
       def initialize parent
         super parent
 
         @title = Sprite.new
         @title.bitmap = Bitmap.new "Title/#{db.system.title}"
 
-        @menu_items = [db.term.new_game, db.term.continue, db.term.shutdown]
-
-        # Calculate window size based on menu items
-        item_height = 24  # Height for each menu item
-        window_width = 160  # Fixed width for the window
-        window_height = @menu_items.length * item_height + 32  # Add padding
-
-        # Position the window at the bottom right of the title screen
-        window_x = WIDTH - window_width - 16
-        window_y = HEIGHT - window_height - 16
-
-        @window = Window.new window_x, window_y, window_width, window_height
-
-        # Create contents bitmap for the window
-        win_cont = Bitmap.new window_width - 16, window_height - 32  # Subtract border size
-
-        # Draw each menu item
-        @menu_items.each_with_index do |item, index|
-          y_pos = index * item_height
-          win_cont.draw_text 8, y_pos, window_width - 32, item_height, item
-        end
-
-        @window.contents = win_cont
-
-        # Initialize selected item index
+        @menu_items =
+          [db.term.new_game, db.term.continue, db.term.shutdown].map(&:to_s)
         @selected_index = 0
 
-        # Draw the initial menu with selection
-        update_menu_display
+        # Size the contents to the widest menu label (plus a small right pad).
+        measure = Bitmap.new 1, 1
+        text_w = @menu_items.map { |t| measure.text_size(t).width }.max
+        content_w = text_w + 8
+        content_h = @menu_items.length * LINE_HEIGHT
+
+        window_width = content_w + Window::BORDER * 2
+        window_height = content_h + Window::BORDER * 2
+
+        # Centre the window horizontally, sitting in the lower third of the
+        # screen like the reference title layout.
+        window_x = (WIDTH - window_width) / 2
+        window_y = 160
+
+        @window = Window.new window_x, window_y, window_width, window_height
+        @window.windowskin = load_windowskin
+
+        # Render the (unchanging) menu labels once. White text reads clearly on
+        # the dark window background.
+        contents = Bitmap.new content_w, content_h
+        contents.font.color = Color.new(255, 255, 255, 255)
+        @menu_items.each_with_index do |item, index|
+          contents.draw_text 0, index * LINE_HEIGHT + TEXT_PAD_Y, content_w,
+                             LINE_HEIGHT, item
+        end
+        @window.contents = contents
+
+        refresh_cursor
       end
 
       def update
-        # Handle menu navigation
         if Input.trigger?(Input::DOWN) && @selected_index < @menu_items.length - 1
           @selected_index += 1
-          update_menu_display
+          refresh_cursor
         elsif Input.trigger?(Input::UP) && @selected_index > 0
           @selected_index -= 1
-          update_menu_display
+          refresh_cursor
         end
 
-        # Handle menu selection
-        if Input.trigger?(Input::C)  # C is usually the confirm button (like Enter/Z)
+        if Input.trigger?(Input::C)  # C is usually the confirm button (Enter/Z)
           case @selected_index
           when 0  # New Game
             # TODO: Implement new game logic
@@ -120,32 +272,27 @@ class RPG2k
             exit
           end
         end
+
+        @window.update
       end
 
       private
 
-      def update_menu_display
-        # Redraw the menu with the currently selected item highlighted
-        window_width = @window.width
-        window_height = @window.height
-        item_height = 24
+      # Load the System/ windowskin declared in the database. Returns nil when
+      # it is missing so the Window falls back to a plain panel instead of
+      # crashing.
+      def load_windowskin
+        name = db.system.system_graphic
+        return nil if name.nil? || name.empty?
+        Bitmap.new "System/#{name}"
+      rescue StandardError
+        nil
+      end
 
-        # Create a new bitmap for the window contents
-        win_cont = Bitmap.new window_width - 16, window_height - 32
-
-        # Draw each menu item, highlighting the selected one
-        @menu_items.each_with_index do |item, index|
-          y_pos = index * item_height
-
-          # Draw selection cursor or highlight for the selected item
-          if index == @selected_index
-            win_cont.draw_text 0, y_pos, 8, item_height, ">"  # Simple cursor
-          end
-
-          win_cont.draw_text 8, y_pos, window_width - 32, item_height, item
-        end
-
-        @window.contents = win_cont
+      def refresh_cursor
+        @window.cursor_rect =
+          Rect.new(0, @selected_index * LINE_HEIGHT, @window.contents.width,
+                   LINE_HEIGHT)
       end
     end
   end


### PR DESCRIPTION
Draw the title menu window from the game's System graphic instead of a
bare, frame-less sprite so it matches the reference RPG Maker 2000 look:
a stretched 32x32 background tile plus the 8px frame border (corners and
edges), with the selection cursor and contents composited on top. When
no windowskin can be loaded the window falls back to a plain dark panel
with a light border.

- Add RGSS::Bitmap#stretch_blt (nearest-neighbour scaled blit with
  opacity alpha-blending) and a test; used to stretch the small
  windowskin pieces over an arbitrarily sized window
- Parse the System graphic name (LDB chunk 19) into the database schema
  as system_graphic and use it as the title menu windowskin
- Rework RGSS::Window into a compositing RPG2k window (background, frame,
  cursor, contents) backed by a single sprite
- Size and centre the title menu window to fit its labels

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bx6y69V4jx9vdWZYLNNSpS