### PR TITLE
Default sixel scale to 1 for native resolution

### DIFF
--- a/src/main.cxx
+++ b/src/main.cxx
@@ -31,7 +31,7 @@ DEFINE_bool(sixel,
             "Render to the terminal using the sixel protocol instead of "
             "opening an SDL window");
 DEFINE_int32(sixel_scale,
-             2,
+             1,
              "Integer upscale factor for the sixel terminal output");
 
 namespace {


### PR DESCRIPTION
Change the default --sixel_scale from 2 to 1 so the terminal sixel output is emitted at the native 320x240 game resolution by default.