### PR TITLE
Use alternate screen buffer to preserve shell history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
     and a monotonic-clock tick/delay source (`mruby-rgss/src/sixel.cxx`)
   - Wired terminal keyboard input (arrows/WASD, confirm, cancel, quit) into the
     RGSS::Input module via `Graphics.update`
+  - Switched to the terminal's alternate screen buffer while a game is running
+    so it no longer scribbles sixels over the shell history; on exit (including
+    fatal signals) the pre-game screen contents and cursor are restored
   - Documented the decision in `docs/adr/0001-terminal-gaming-sixel.md`
 - Expanded the `mruby-rgss` RGSS built-in class library:
   - `RGSS::Color` — floating point RGBA color with clamping, `set`, `==`,

--- a/include/sixel.hxx
+++ b/include/sixel.hxx
@@ -17,8 +17,10 @@ typedef struct _lv_display_t lv_display_t;
 // in a terminal.  The created display is registered as LVGL's default display.
 //
 // As a side effect the controlling terminal is switched into raw mode so that
-// keyboard input can be read without line buffering; it is restored
-// automatically on process exit.
+// keyboard input can be read without line buffering, and into the alternate
+// screen buffer so the game does not overwrite the user's shell history.  Both
+// are restored automatically on process exit (and on fatal signals), returning
+// the terminal to its pre-game contents.
 lv_display_t* sixel_display_create(int32_t hor_res, int32_t ver_res, int scale);
 
 // Poll the terminal for keyboard input and forward it to the RGSS::Input

--- a/mruby-rgss/src/sixel.cxx
+++ b/mruby-rgss/src/sixel.cxx
@@ -95,12 +95,26 @@ void show_cursor() {
   write_all(seq, sizeof(seq) - 1);
 }
 
+// True once the alternate screen buffer has been entered, so teardown only
+// leaves it if init actually switched to it.
+bool g_alt_screen = false;
+
 void restore_terminal() {
+  // Undo the visual state first (while still in raw mode), then hand the
+  // terminal back to the shell.  Leaving the alternate screen buffer restores
+  // the exact pre-game screen contents and cursor position; the explicit
+  // erase covers the few terminals that keep sixel output in a layer that
+  // survives the screen switch.
+  show_cursor();
+  if (g_alt_screen) {
+    static const char leave_alt[] = "\x1b[2J\x1b[?1049l";
+    write_all(leave_alt, sizeof(leave_alt) - 1);
+    g_alt_screen = false;
+  }
   if (g_termios_saved) {
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &g_orig_termios);
     g_termios_saved = false;
   }
-  show_cursor();
 }
 
 void signal_handler(int sig) {
@@ -127,6 +141,14 @@ void init_terminal() {
   std::atexit(restore_terminal);
   for (int sig : {SIGINT, SIGTERM, SIGHUP, SIGQUIT})
     signal(sig, signal_handler);
+
+  // Switch to the alternate screen buffer so the game does not scribble sixels
+  // over the user's shell history; leaving it on exit restores what was there
+  // before.  Sixels painted here belong to the alt buffer and are discarded on
+  // switch-back in the common terminals (xterm, foot, WezTerm, mlterm, ...).
+  static const char enter_alt[] = "\x1b[?1049h";
+  write_all(enter_alt, sizeof(enter_alt) - 1);
+  g_alt_screen = true;
 
   static const char hide_cursor[] = "\x1b[?25l";
   write_all(hide_cursor, sizeof(hide_cursor) - 1);


### PR DESCRIPTION
## Summary
Modified the terminal initialization and cleanup code to use the alternate screen buffer while a game is running. This prevents sixel graphics output from overwriting the user's shell history and command line, restoring the exact pre-game screen state on exit.

## Key Changes
- Added `g_alt_screen` global flag to track whether the alternate screen buffer is active
- Modified `init_terminal()` to enter the alternate screen buffer (`\x1b[?1049h`) before hiding the cursor
- Refactored `restore_terminal()` to:
  - Show the cursor and leave the alternate screen buffer before restoring terminal attributes
  - Clear the screen (`\x1b[2J`) before switching back to ensure sixel artifacts don't persist
  - Only attempt to leave the alternate buffer if `init_terminal()` successfully entered it
- Updated documentation in `sixel.hxx` to reflect that both raw mode and alternate screen buffer are restored on exit and fatal signals

## Implementation Details
- The alternate screen buffer switch happens early in initialization, after signal handlers are registered but before cursor hiding
- Screen clearing and buffer exit are performed while still in raw mode, ensuring proper terminal state during cleanup
- The implementation accounts for terminal variations: some terminals keep sixel output in a layer that survives the screen switch, so an explicit erase is included
- The flag-based approach ensures cleanup is idempotent and only undoes what was actually initialized

https://claude.ai/code/session_01VV3JUZxiww8QfGYzPkepdg