### PR TITLE
Honor RPG_RT.ini FullPackageFlag to disable RTP lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Honour `RPG_RT.ini`'s `[RPG_RT] FullPackageFlag`: when set to `1` the game is
+  treated as a self-contained ("full") package and RTP lookups are disabled by
+  clearing `RTP_DIR`, so bitmaps are resolved only from the game directory
 - Terminal gaming support using the DEC sixel graphics protocol
   - Added `--sixel` flag to render frames to a sixel-capable terminal instead
     of opening an SDL window, plus `--sixel_scale` for integer upscaling

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -82,6 +82,17 @@ fs::path xp_rtp_path() {
   return reg2path(ini["Software\\\\Enterbrain\\\\RGSS\\\\RTP"]["\"Standard\""]);
 }
 
+// Read the [RPG_RT] FullPackageFlag from RPG_RT.ini in the game directory. When
+// set to 1 the game bundles every asset it needs ("full package") and must not
+// fall back to the RTP, so the runtime disables RTP lookups entirely.
+bool full_package_flag(const fs::path& game_dir) {
+  const fs::path ini_path = game_dir / "RPG_RT.ini";
+  if (!fs::exists(ini_path))
+    return false;
+  return inicpp::IniManager(ini_path.string())["RPG_RT"].toInt(
+             "FullPackageFlag") == 1;
+}
+
 #ifdef __EMSCRIPTEN__
 // Trampoline for emscripten_set_main_loop, which takes a plain function
 // pointer.
@@ -174,8 +185,12 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "RTP_DIR"),
                 mrb_str_new_cstr(M, ""));
 #else
+  // RPG_RT.ini's FullPackageFlag=1 marks a self-contained game; honour it by
+  // clearing RTP_DIR so bitmap lookups never reach into the installed RTP.
+  const std::string rtp_dir =
+      full_package_flag(FLAGS_game_dir) ? std::string() : rtp_path().string();
   mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "RTP_DIR"),
-                mrb_str_new_cstr(M, rtp_path().c_str()));
+                mrb_str_new_cstr(M, rtp_dir.c_str()));
 #endif
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "TIMEOUT_MS"),


### PR DESCRIPTION
## Summary
This change adds support for the `FullPackageFlag` setting in `RPG_RT.ini`, allowing games to declare themselves as self-contained packages that should not fall back to the installed RTP for asset resolution.

## Changes
- Added `full_package_flag()` function to read the `[RPG_RT] FullPackageFlag` setting from `RPG_RT.ini` in the game directory
- Modified the `RTP_DIR` constant initialization to check the `FullPackageFlag` setting:
  - When `FullPackageFlag=1`, `RTP_DIR` is set to an empty string, disabling RTP lookups entirely
  - When the flag is absent or set to 0, `RTP_DIR` is set to the normal RTP path as before
- Updated `CHANGELOG.md` to document this new feature

## Implementation Details
- The `full_package_flag()` function safely handles missing `RPG_RT.ini` files by returning `false`
- The RTP directory resolution is only applied on non-Emscripten builds (the existing `#else` branch)
- This ensures bitmap and asset lookups are restricted to the game directory when a game is marked as a full package, preventing unintended fallback to system-wide RTP installations

https://claude.ai/code/session_01Ag47eARLAiXqhNDsrCkV16

closes https://github.com/take-cheeze/rpg-maker-clone/issues/40