### PR TITLE
Document Nepheshel roadmap and critical path to gameplay

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,6 +6,64 @@
 - Implement New Game functionality
 - Implement Continue functionality
 
+### Issue items needed to run Nepheshel
+
+Today the runtime boots only to the title screen: `RPG2k` loads the database
+(`RPG_RT.ldb`) and map tree (`RPG_RT.lmt`), shows the title image plus the
+New Game / Continue / Shutdown menu, and stops there. "New Game" and
+"Continue" are TODO stubs (`mruby-rpg2k/mrblib/main.rb`). The RGSS primitives
+(`Bitmap`, `Window`, `Sprite`, `Font`, `Input`) exist, but `Tilemap` is an
+empty stub, `Audio`/`Graphics` are warn-once stubs, and there is no LMU (map)
+schema, event interpreter, or battle code.
+
+The work below is roughly ordered by the critical path to a walkable game
+(1 → 2 → 3 → 4/5/6 → 7/8/9); battle and full menus can follow.
+
+#### Boot into gameplay (unblocks everything)
+- LMU map parsing — add a `MAP_UNIT` schema (`LCF::MapUnit` has a header but no
+  schema; `schema.rb` only defines `DATABASE` and `MAP_TREE`): dimensions,
+  lower/upper tile layers, events, encounter data
+- New Game logic — build the party from the database, read the start position
+  from the map tree, and transfer to the starting map (replaces the TODO in
+  `Scene::Title#update`)
+- Map scene (`Scene::Map`) — the play loop hosting the tilemap, player and
+  events
+
+#### Map & characters
+- Tilemap rendering — real `RGSS::Tilemap`: chipset lower/upper layers, tile
+  animation, and passability/terrain lookup
+- Character sprites — charset graphics (8-direction, walk frames) for the
+  player and NPCs
+- Movement & collision — player walking, tile collision, move-route processing
+
+#### Event system
+- Event pages — page conditions (switch/variable/item) and trigger types
+  (action / touch / auto-start / parallel)
+- Event command interpreter — the ~100+ RPG2000 commands (Show Message,
+  Choices, switches/variables, conditional branches, Teleport, Move Event,
+  Change Items/Party, ...)
+- Message window — text with control codes (`\v`, `\n`, `\c`, `\.`), face
+  graphics, choice cursor
+- Common events — parallel and auto-start common events
+- Screen effects — transitions/fade, tint, flash, shake, Show Picture,
+  weather, timer
+
+#### Menus, save, battle
+- Menu scene — item / skill / equip / status / save, driven by the already
+  parsed `term` and item/skill/actor data
+- Save & Continue — `LCF::SaveData` has a header but no schema/logic; needed
+  for the Continue path
+- Battle system — enemy groups, battle scene, actions/damage/states,
+  animations, game-over scene (large; Nepheshel uses the default RPG2000
+  battle)
+
+#### Assets & infrastructure
+- Audio playback — replace the inert `RGSS::Audio` stubs with real
+  BGM/BGS/ME/SE (WAV/MIDI)
+- RTP resolution / `FullPackageFlag` (issue #40) — `RPG_RT.ini`'s
+  `FullPackageFlag=1` disables RTP; resource lookup must fall back between the
+  game directory and the RTP
+
 ## RPG Maker with RGSS
 - Support game library features of RGSS which could be found in https://www.rpgmaker.fixato.org/Manual/RPGVXAce/rgss/
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation of the work needed to bring Nepheshel from a title screen to a playable game. It outlines the critical path and dependencies for implementing core RPG2000 functionality.

## Changes
- Added detailed "Issue items needed to run Nepheshel" section to TODO.md
- Documented the current state: title screen boots successfully, but New Game/Continue are stubs and core systems (Tilemap, Audio, Graphics, event interpreter, battle) are missing or incomplete
- Organized remaining work into logical phases:
  - **Boot into gameplay**: LMU map parsing, New Game logic, Map scene
  - **Map & characters**: Tilemap rendering, character sprites, movement/collision
  - **Event system**: Event pages, command interpreter, message window, common events, screen effects
  - **Menus, save, battle**: Menu scene, save/continue, battle system
  - **Assets & infrastructure**: Audio playback, RTP resolution
- Provided ordering guidance showing the critical path (phases 1→2→3→4/5/6→7/8/9) to reach a walkable game state

## Details
The roadmap clarifies that battle and full menus are secondary to the core gameplay loop. Each phase includes specific technical requirements (e.g., MAP_UNIT schema definition, charset graphics handling, ~100+ RPG2000 command implementation) to guide implementation priorities.

https://claude.ai/code/session_01Cz2x3PV3hoTpSciG3JBwuZ