### PR TITLE
Populate LCF map, map tree and save data schemas from spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project will be documented in this file.
 - Honour `RPG_RT.ini`'s `[RPG_RT] FullPackageFlag`: when set to `1` the game is
   treated as a self-contained ("full") package and RTP lookups are disabled by
   clearing `RTP_DIR`, so bitmaps are resolved only from the game directory
+- Populated the LCF map, map tree and save data schemas from the VIPRPG 200X
+  analysis notes (`mruby-lcf/mrblib/schema.rb`):
+  - `MAP_UNIT` (`LcfMapUnit`) — chipset/size, scroll and parallax settings, the
+    lower/upper tile layers and the full map event tree (events → pages →
+    appearance condition and move route)
+  - `SAVE_DATA` (`LcfSaveData`) — save title (file-select screen fields), the
+    system block (scene, switches/variables, message/face settings, BGM/SE
+    overrides, transitions, permissions) and hero/vehicle positions
+  - Map tree: fixed the area-rect field (was a typo `type: :Araa`), renamed the
+    editor-only chunk 3 to `indentation` and gave encounters an enemy-group
+    default; the reader now loads all three map-tree sections (properties, tree
+    order and initial positions) instead of only the first
+- Verified by parsing the bundled Nepheshel `RPG_RT.lmt` and all 543 `Map*.lmu`
+  files across both game variants (tile layers match `width * height`).
 - Terminal gaming support using the DEC sixel graphics protocol
   - Added `--sixel` flag to render frames to a sixel-capable terminal instead
     of opening an SDL window, plus `--sixel_scale` for integer upscaling
@@ -62,6 +76,13 @@ All notable changes to this project will be documented in this file.
   - Added key constants (UP, DOWN, LEFT, RIGHT, A, B, C, etc.)
   - Implemented input state tracking (press, trigger, repeat)
   - Added directional input helpers (dir4, dir8)
+
+### Fixed
+- LCF reader (`mruby-lcf/mrblib/lcf.rb`): booleans are read as their real
+  1-byte encoding (previously required a 0-byte chunk and always returned
+  `true`); nested `Array2D`/`Array1D` sections wrap a `String` in `StringIO`
+  correctly (the old `kind_of? IO` check failed for `StringIO`); added the
+  `:int16_array` element type used by the tile layers and the area rect.
 
 ### Changed
 - Updated documentation to reflect new title screen functionality

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -31,6 +31,47 @@ module LCF
     attr_reader :selected_id, :maps
   end
 
+  # Holds the sequential sections of a multi-section file (e.g. the map tree,
+  # which is a map-properties table followed by the tree order and the initial
+  # party/vehicle positions). Sections are reachable by their schema name;
+  # #[] indexes into the first section for convenience.
+  class Sections
+    def initialize
+      @by_name = {}
+      @list = []
+    end
+
+    def add name, value
+      @by_name[name] = value
+      @list.push value
+    end
+
+    def [] idx ; @list.first[idx] end
+
+    def method_missing sym, *args
+      return @by_name[sym] if @by_name.key? sym
+      super
+    end
+
+    def respond_to_missing? sym, include_private = false
+      @by_name.key?(sym) || super
+    end
+  end
+
+  # Read one section of a file sequentially from the stream +io+.
+  def read_section io, s
+    case s[:type]
+    when :Array2D ; Array2D.new io, s
+    when :Array1D ; Array1D.new io, s
+    when :Tree
+      map_count = read_ber io
+      maps = Array.new(map_count) { read_ber io }
+      Tree.new read_ber(io), maps
+    else
+      raise "Unsupported section type: #{s[:type]}"
+    end
+  end
+
   def to_rb d, s
     return s[:default] unless d
 
@@ -39,8 +80,14 @@ module LCF
     when :Array2D ; return Array2D.new d, s
     when :int ; return read_ber StringIO.new(d)
     when :bool
-      raise "invalid bool size: #{d.size}" if d.size != 0
+      raise "invalid bool size: #{d.size}" if d.size != 1
       return d.bytes[0] != 0
+    when :int16_array
+      vals = d.unpack('s<*')
+      return vals unless s[:order]
+      h = {}
+      s[:order].each_with_index { |name, i| h[name] = vals[i] }
+      return h
     when :string ; return LCF.cp932_to_utf8 d
     when :Tree
       s = StringIO.new(d)
@@ -54,7 +101,7 @@ module LCF
     raise "Unsupported type: #{s[:type]}"
   end
 
-  module_function :read_ber, :to_rb
+  module_function :read_ber, :to_rb, :read_section
 
   MODE = 2000 # 2003
 
@@ -69,7 +116,7 @@ module LCF
 
   class Array1D
     def initialize s, schema
-      s = StringIO.new s unless s.kind_of? IO
+      s = StringIO.new s if s.is_a? String
 
       @data = []
       @schema = schema
@@ -106,6 +153,8 @@ module LCF
 
   class Array2D
     def initialize s, schema
+      s = StringIO.new s if s.is_a? String
+
       @data = []
       @scheme = schema
 

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -244,7 +244,9 @@ module LCF
         elements: {
           1 => { name: :name, type: :string },
           2 => { name: :parent_map_id, type: :int },
-          3 => { name: :_reserved, type: :int },
+          # Editor-only node depth / management data.
+          3 => { name: :indentation, type: :int },
+          # 0 = root, 1 = normal map, 2 = area.
           4 => { name: :type, type: :int, default: 1 },
           5 => { name: :x_scroll, type: :bool, default: false },
           6 => { name: :y_scroll, type: :bool, default: false },
@@ -256,9 +258,10 @@ module LCF
           31 => { name: :teleport, type: :int, default: 1 },
           32 => { name: :escape, type: :int, default: 1 },
           33 => { name: :save, type: :int, default: 1 },
-          41 => { name: :enemy_groups, type: :Array2D, elements: {1 => { name: :enemy_group_id, type: :int }}},
+          41 => { name: :enemy_groups, type: :Array2D, elements: {1 => { name: :enemy_group_id, type: :int, default: 1 }}},
           44 => { name: :encount_steps, type: :int, default: 25 },
-          51 => { name: :area, type: :Araa },
+          # Area bounds, only used by area nodes (type == 2): [X1, Y1, X2 + 1, Y2 + 1].
+          51 => { name: :area, type: :int16_array, order: [:left, :top, :right, :bottom] },
         }
       },
       {
@@ -287,6 +290,188 @@ module LCF
         },
       },
     ]
+
+    # https://wikiwiki.jp/viprpg-dev/200X%E5%85%B1%E9%80%9A/%E8%A7%A3%E6%9E%90%E3%81%BE%E3%81%A8%E3%82%81/%E3%83%9E%E3%83%83%E3%83%97
+    #
+    # Conditions that must hold for an event page to be active.
+    MAP_EVENT_PAGE_CONDITION = {
+      # Bit flags selecting which of the conditions below are enabled.
+      1 => { name: :flags, type: :int, default: 0 },
+      2 => { name: :switch_a_id, type: :int, default: 1 },
+      3 => { name: :switch_b_id, type: :int, default: 1 },
+      4 => { name: :variable_id, type: :int, default: 1 },
+      5 => { name: :variable_value, type: :int, default: 0 },
+      6 => { name: :item_id, type: :int, default: 1 },
+      7 => { name: :actor_id, type: :int, default: 1 },
+      8 => { name: :timer_sec, type: :int, default: 0 },
+    }
+
+    MOVE_ROUTE = {
+      11 => { name: :command_size, type: :int, default: 0 },
+      12 => { name: :commands, type: :event },
+      21 => { name: :repeat, type: :bool, default: true },
+      22 => { name: :skippable, type: :bool, default: false },
+    }
+
+    MAP_EVENT_PAGE = {
+      2 => { name: :condition, type: :Array1D, elements: MAP_EVENT_PAGE_CONDITION },
+      21 => { name: :charset_name, type: :string, default: '' },
+      22 => { name: :charset_index, type: :int, default: 0 },
+      # 2 = down, 4 = left, 6 = right, 8 = up.
+      23 => { name: :direction, type: :int, default: 2 },
+      24 => { name: :pattern, type: :int, default: 1 },
+      25 => { name: :translucent, type: :bool, default: false },
+      31 => { name: :move_type, type: :int, default: 0 },
+      32 => { name: :move_frequency, type: :int, default: 3 },
+      # Start condition: 0 = action key, 1 = touch by player, ...
+      33 => { name: :trigger, type: :int, default: 0 },
+      # Layer / priority: 0 = below, 1 = same, 2 = above the player.
+      34 => { name: :layer, type: :int, default: 0 },
+      35 => { name: :overlap_forbidden, type: :bool, default: false },
+      36 => { name: :animation_type, type: :int, default: 0 },
+      37 => { name: :move_speed, type: :int, default: 3 },
+      41 => { name: :move_route, type: :Array1D, elements: MOVE_ROUTE },
+      51 => { name: :event_command_size, type: :int, default: 0 },
+      52 => { name: :event_commands, type: :event },
+    }
+
+    MAP_EVENT = {
+      1 => { name: :name, type: :string, default: '' },
+      2 => { name: :x, type: :int, default: 0 },
+      3 => { name: :y, type: :int, default: 0 },
+      5 => { name: :pages, type: :Array2D, elements: MAP_EVENT_PAGE },
+    }
+
+    MAP_UNIT = {
+      name: :Map, type: :Array1D,
+      elements: {
+        1 => { name: :chipset_id, type: :int, default: 1 },
+        2 => { name: :width, type: :int, default: 20 },
+        3 => { name: :height, type: :int, default: 15 },
+        # 0 = none, 1 = vertical, 2 = horizontal, 3 = both.
+        11 => { name: :scroll_type, type: :int, default: 0 },
+        31 => { name: :parallax_flag, type: :bool, default: false },
+        32 => { name: :parallax_name, type: :string, default: '' },
+        33 => { name: :parallax_loop_x, type: :bool, default: false },
+        34 => { name: :parallax_loop_y, type: :bool, default: false },
+        35 => { name: :parallax_autoloop_x, type: :bool, default: false },
+        36 => { name: :parallax_sx, type: :int, default: 0 },
+        37 => { name: :parallax_autoloop_y, type: :bool, default: false },
+        38 => { name: :parallax_sy, type: :int, default: 0 },
+        # width * height signed shorts, one tile id per cell.
+        71 => { name: :lower_layer, type: :int16_array },
+        72 => { name: :upper_layer, type: :int16_array },
+        81 => { name: :events, type: :Array2D, elements: MAP_EVENT },
+        91 => { name: :save_count, type: :int, default: 0 },
+      }
+    }
+
+    # https://wikiwiki.jp/viprpg-dev/200X%E5%85%B1%E9%80%9A/%E8%A7%A3%E6%9E%90%E3%81%BE%E3%81%A8%E3%82%81/%E3%82%BB%E3%83%BC%E3%83%96%E3%83%87%E3%83%BC%E3%82%BF
+    #
+    # Snapshot of a hero or vehicle on the map. Vehicles reuse the same layout.
+    SAVE_MOVABLE = {
+      11 => { name: :map_id, type: :int },
+      12 => { name: :x, type: :int },
+      13 => { name: :y, type: :int },
+      # 0 = down, 1 = right, 2 = up, 3 = left.
+      22 => { name: :direction, type: :int },
+      35 => { name: :animation_type, type: :int },
+      37 => { name: :move_speed, type: :int },
+      73 => { name: :charset_name, type: :string },
+      75 => { name: :charset_index, type: :int },
+    }
+
+    SAVE_SYSTEM = {
+      # 0 map, 1 menu, 2 battle, 3 shop, 4 name input, 5 save/load,
+      # 6 title, 7 game over, 8 F9 debug menu.
+      1 => { name: :scene, type: :int, default: 0 },
+      11 => { name: :frame_count, type: :int },
+      15 => { name: :system_graphic, type: :string },
+      16 => { name: :wallpaper_type, type: :int },
+      17 => { name: :font, type: :int },
+      31 => { name: :switch_size, type: :int, default: 0 },
+      32 => { name: :switches, type: :bool_array },
+      33 => { name: :variable_size, type: :int, default: 0 },
+      34 => { name: :variables, type: :int32_array },
+      # 0 = normal, 1 = transparent.
+      41 => { name: :message_transparent, type: :int, default: 0 },
+      # 0 = top, 1 = middle, 2 = bottom.
+      42 => { name: :message_position, type: :int, default: 2 },
+      43 => { name: :message_prevent_overlap, type: :bool, default: true },
+      44 => { name: :message_continue_events, type: :bool, default: false },
+      51 => { name: :face_name, type: :string, default: '' },
+      52 => { name: :face_index, type: :int, default: 0 },
+      53 => { name: :face_right_position, type: :int, default: 0 },
+      54 => { name: :face_flip, type: :bool, default: false },
+      55 => { name: :transparent, type: :bool, default: false },
+      # Overridden BGM/SE playback state. An empty file name means "use the
+      # database value".
+      71 => { name: :title_bgm, type: :Array1D, elements: BGM },
+      72 => { name: :battle_bgm, type: :Array1D, elements: BGM },
+      73 => { name: :battle_end_bgm, type: :Array1D, elements: BGM },
+      74 => { name: :inn_bgm, type: :Array1D, elements: BGM },
+      75 => { name: :current_bgm, type: :Array1D, elements: BGM },
+      78 => { name: :stored_bgm, type: :Array1D, elements: BGM },
+      79 => { name: :boat_bgm, type: :Array1D, elements: BGM },
+      80 => { name: :ship_bgm, type: :Array1D, elements: BGM },
+      81 => { name: :airship_bgm, type: :Array1D, elements: BGM },
+      82 => { name: :gameover_bgm, type: :Array1D, elements: BGM },
+      91 => { name: :cursor_se, type: :Array1D, elements: SE },
+      92 => { name: :decision_se, type: :Array1D, elements: SE },
+      93 => { name: :cancel_se, type: :Array1D, elements: SE },
+      94 => { name: :buzzer_se, type: :Array1D, elements: SE },
+      95 => { name: :battle_start_se, type: :Array1D, elements: SE },
+      96 => { name: :escape_se, type: :Array1D, elements: SE },
+      97 => { name: :enemy_attack_se, type: :Array1D, elements: SE },
+      98 => { name: :enemy_damaged_se, type: :Array1D, elements: SE },
+      99 => { name: :ally_damaged_se, type: :Array1D, elements: SE },
+      100 => { name: :evasion_se, type: :Array1D, elements: SE },
+      101 => { name: :enemy_death_se, type: :Array1D, elements: SE },
+      102 => { name: :item_se, type: :Array1D, elements: SE },
+      # Transition effects. A value of 0xff means "use the database value".
+      111 => { name: :teleport_erase_transition, type: :int },
+      112 => { name: :teleport_show_transition, type: :int },
+      113 => { name: :battle_start_erase_transition, type: :int },
+      114 => { name: :battle_start_show_transition, type: :int },
+      115 => { name: :battle_end_erase_transition, type: :int },
+      116 => { name: :battle_end_show_transition, type: :int },
+      121 => { name: :teleport_allowed, type: :bool },
+      122 => { name: :escape_allowed, type: :bool },
+      123 => { name: :save_allowed, type: :bool },
+      124 => { name: :menu_allowed, type: :bool },
+      125 => { name: :battle_background, type: :string },
+      131 => { name: :save_count, type: :int },
+      132 => { name: :save_slot, type: :int, default: 1 },
+    }
+
+    # Fields shown on the file-select screen (chunk 100 of the save file). The
+    # wiki lists them inline at the top of the save-data page.
+    SAVE_TITLE = {
+      1 => { name: :timestamp, type: :double },
+      11 => { name: :hero_name, type: :string },
+      12 => { name: :hero_level, type: :int },
+      13 => { name: :hero_hp, type: :int },
+      21 => { name: :face1_name, type: :string },
+      22 => { name: :face1_index, type: :int, default: 0 },
+      23 => { name: :face2_name, type: :string },
+      24 => { name: :face2_index, type: :int, default: 0 },
+      25 => { name: :face3_name, type: :string },
+      26 => { name: :face3_index, type: :int, default: 0 },
+      27 => { name: :face4_name, type: :string },
+      28 => { name: :face4_index, type: :int, default: 0 },
+    }
+
+    SAVE_DATA = {
+      name: :Save, type: :Array1D,
+      elements: {
+        100 => { name: :title, type: :Array1D, elements: SAVE_TITLE },
+        101 => { name: :system, type: :Array1D, elements: SAVE_SYSTEM },
+        104 => { name: :hero, type: :Array1D, elements: SAVE_MOVABLE },
+        105 => { name: :boat, type: :Array1D, elements: SAVE_MOVABLE },
+        106 => { name: :ship, type: :Array1D, elements: SAVE_MOVABLE },
+        107 => { name: :airship, type: :Array1D, elements: SAVE_MOVABLE },
+      }
+    }
   end
 
   class File
@@ -296,7 +481,9 @@ module LCF
       h = io.read h_len
       raise "Invalid header: #{h} (expected: #{header})" if h != header
       if schema.is_a? Array
-        @root = LCF.const_get(schema.first[:type]).new io, schema.first
+        sections = LCF::Sections.new
+        schema.each { |s| sections.add s[:name], LCF.read_section(io, s) }
+        @root = sections
       else
         @root = LCF.const_get(schema[:type]).new io, schema
       end
@@ -322,9 +509,11 @@ module LCF
 
   class MapUnit < File
     def header; "LcfMapUnit" end
-    end
+    def schema; LCF::Schema::MAP_UNIT end
+  end
 
   class SaveData < File
     def header; "LcfSaveData" end
-    end
+    def schema; LCF::Schema::SAVE_DATA end
+  end
 end


### PR DESCRIPTION
Fill in the previously-stubbed LcfMapUnit and LcfSaveData schemas and complete the map tree, deriving field names and chunk IDs from the VIPRPG 200X analysis notes (map / map tree / save data pages):

- MAP_UNIT: chipset/size, scroll and parallax settings, lower/upper tile layers, and the full map event tree (events -> pages -> appearance condition and move route).
- SAVE_DATA: save title (file-select fields), the system block (scene, switches/variables, message/face settings, BGM/SE overrides, transitions, permissions) and hero/vehicle positions.
- Map tree: fix the area-rect field (was a typo type: :Araa), rename the editor-only chunk 3 to indentation, and give encounters an enemy-group default. LCF::File now reads all three map-tree sections (properties, tree order, initial positions) instead of only the first.

Reader fixes needed for the above (mruby-lcf/mrblib/lcf.rb):
- Read booleans as their real 1-byte encoding (the old check required a 0-byte chunk and always returned true).
- Wrap a String in StringIO for nested Array2D/Array1D sections (the old kind_of? IO check failed for StringIO, crashing on map events).
- Add the :int16_array element type used by tile layers and the area rect.

Verified by parsing the bundled Nepheshel RPG_RT.lmt and all 543 Map*.lmu files across both game variants (tile layers match width * height), and confirming RPG_RT.ldb still parses.