### PR TITLE
Add iTerm2 inline-image protocol terminal backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ All notable changes to this project will be documented in this file.
     so it no longer scribbles sixels over the shell history; on exit (including
     fatal signals) the pre-game screen contents and cursor are restored
   - Documented the decision in `docs/adr/0001-terminal-gaming-sixel.md`
+- Terminal gaming support using iTerm2's inline-image protocol
+  - Added `--iterm` flag to render frames to the terminal via the OSC 1337
+    `File=` sequence, plus `--iterm_scale` for integer upscaling. Each frame is
+    PNG-encoded (via stb_image_write) and emitted base64-encoded, so it renders
+    in terminals that don't support sixel — including VS Code's integrated
+    terminal, iTerm2 and WezTerm
+  - Refactored the windowless terminal backend so both the sixel and iTerm2
+    encoders share one core (`mruby-rgss/src/terminal.cxx`: raw-mode input,
+    monotonic tick/delay source, alternate-screen handling); each protocol is
+    now just a frame encoder (`sixel.cxx` / `iterm.cxx`)
+  - Documented the decision in `docs/adr/0002-terminal-gaming-iterm2.md`
 - Expanded the `mruby-rgss` RGSS built-in class library:
   - `RGSS::Color` — floating point RGBA color with clamping, `set`, `==`,
     `to_s` and Marshal (`_dump`/`_load`) support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,12 +49,12 @@ All notable changes to this project will be documented in this file.
     monotonic tick/delay source, alternate-screen handling); each protocol is
     now just a frame encoder (`sixel.cxx` / `iterm.cxx`)
   - Documented the decision in `docs/adr/0003-terminal-gaming-iterm2.md`
-- Added a `--term_stats` flag (on by default) that prints the terminal emit
-  rate — frame size, MB/s and fps — to stderr about once a second while a
-  terminal backend is active, so the real per-frame byte cost can be measured
-  against the estimated bandwidth. Disable with `--noterm_stats`; the counter
-  lives in the shared `terminal.cxx`, so both the sixel and iTerm2 backends
-  report it
+- Added a `--term_stats` flag (on by default) that draws the terminal emit
+  rate — frame size, MB/s and fps — on-screen just under the control legend,
+  refreshed about once a second while a terminal backend is active, so the real
+  per-frame byte cost is visible against the estimated bandwidth. Disable with
+  `--noterm_stats`; the counter lives in the shared `terminal.cxx`, so both the
+  sixel and iTerm2 backends report it
 - Expanded the `mruby-rgss` RGSS built-in class library:
   - `RGSS::Color` — floating point RGBA color with clamping, `set`, `==`,
     `to_s` and Marshal (`_dump`/`_load`) support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ All notable changes to this project will be documented in this file.
     monotonic tick/delay source, alternate-screen handling); each protocol is
     now just a frame encoder (`sixel.cxx` / `iterm.cxx`)
   - Documented the decision in `docs/adr/0002-terminal-gaming-iterm2.md`
+- Added a `--term_stats` flag (on by default) that prints the terminal emit
+  rate — frame size, MB/s and fps — to stderr about once a second while a
+  terminal backend is active, so the real per-frame byte cost can be measured
+  against the estimated bandwidth. Disable with `--noterm_stats`; the counter
+  lives in the shared `terminal.cxx`, so both the sixel and iTerm2 backends
+  report it
 - Expanded the `mruby-rgss` RGSS built-in class library:
   - `RGSS::Color` — floating point RGBA color with clamping, `set`, `==`,
     `to_s` and Marshal (`_dump`/`_load`) support

--- a/README.md
+++ b/README.md
@@ -30,13 +30,9 @@
   image
 - `--sixel` works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm
   and Windows Terminal; `--iterm` works in iTerm2, WezTerm and VS Code
-- Either backend prints its emit rate (frame size, MB/s, fps) to stderr about
-  once a second; this is on by default and can be turned off with
-  `--noterm_stats`. Redirect stderr to keep the numbers off the game screen:
-
-  ```sh
-  ./rpg_maker_clone --iterm --game_dir path/to/game 2>stats.log
-  ```
+- Either backend draws its emit rate (frame size, MB/s, fps) on-screen just
+  under the control legend, refreshed about once a second; this is on by default
+  and can be turned off with `--noterm_stats`
 
 ## TODO
 - Run zip file directly

--- a/README.md
+++ b/README.md
@@ -7,18 +7,27 @@
 - Shows a menu with options for New Game, Continue, and Shutdown
 - Supports keyboard navigation (up/down) and selection (enter/Z)
 
-### Terminal gaming (sixel)
-- Render the game to any sixel-capable terminal instead of an SDL window
+### Terminal gaming
+- Render the game to a terminal instead of an SDL window, using either the DEC
+  **sixel** protocol or **iTerm2's inline-image** protocol
 - Run with `--sixel` (optionally `--sixel_scale=N` to upscale the picture):
 
   ```sh
   ./rpg_maker_clone --sixel --sixel_scale=2 --game_dir path/to/game
   ```
 
+- Or with `--iterm` (optionally `--iterm_scale=N`), which encodes each frame as
+  a PNG and works in terminals that don't speak sixel — including **VS Code's
+  integrated terminal**:
+
+  ```sh
+  ./rpg_maker_clone --iterm --iterm_scale=2 --game_dir path/to/game
+  ```
+
 - Controls: arrow keys or `WASD` to move, `Z`/`Enter`/`Space` to confirm,
   `X`/`Esc` to cancel, `Q` or `Ctrl-C` to quit
-- Works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm and
-  Windows Terminal
+- `--sixel` works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm
+  and Windows Terminal; `--iterm` works in iTerm2, WezTerm and VS Code
 
 ## TODO
 - Run zip file directly

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@
   `X`/`Esc` to cancel, `Q` or `Ctrl-C` to quit
 - `--sixel` works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm
   and Windows Terminal; `--iterm` works in iTerm2, WezTerm and VS Code
+- Either backend prints its emit rate (frame size, MB/s, fps) to stderr about
+  once a second; this is on by default and can be turned off with
+  `--noterm_stats`. Redirect stderr to keep the numbers off the game screen:
+
+  ```sh
+  ./rpg_maker_clone --iterm --game_dir path/to/game 2>stats.log
+  ```
 
 ## TODO
 - Run zip file directly

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,18 +15,28 @@
 - Menu items are drawn using the game's font system
 - Selection is highlighted with a cursor
 
-### Terminal gaming (sixel)
-- Alternative display backend that renders each frame to the terminal using the
-  DEC sixel protocol, enabled with the `--sixel` flag
+### Terminal gaming (sixel / iTerm2)
+- Alternative display backends that render each frame to the terminal instead of
+  opening a window: the DEC sixel protocol (`--sixel`) and iTerm2's inline-image
+  protocol (`--iterm`)
 - Lets the runtime be played on hosts without a windowing system (headless
-  servers, SSH sessions, embedded boards with a serial console)
+  servers, SSH sessions, embedded boards with a serial console); `--iterm` also
+  covers terminals that lack sixel support, notably VS Code's integrated
+  terminal
+- Both backends share the same windowless terminal core
+  (`mruby-rgss/src/terminal.cxx`: raw-mode input, monotonic tick/delay source,
+  alternate-screen handling) and differ only in the frame encoder
+  (`sixel.cxx` / `iterm.cxx`)
 - Reads keyboard input directly from the terminal and forwards it to
   `RGSS::Input`
-- Output is throughput-bound: 320×240 at 60 Hz needs roughly 20 Mbaud (up to
-  ~70 Mbaud worst case), far beyond a real serial UART, so the backend targets a
-  local PTY or SSH pipe
-- See `docs/adr/0001-terminal-gaming-sixel.md` for the design rationale and a
-  full bandwidth breakdown
+- Output is throughput-bound: the sixel path for 320×240 at 60 Hz needs roughly
+  20 Mbaud (up to ~70 Mbaud worst case); the iTerm2 path PNG-compresses each
+  frame, which shrinks flat tile/sprite regions substantially but spends CPU on
+  encoding. Either way the backend targets a local PTY or SSH pipe, not a real
+  serial UART
+- See `docs/adr/0001-terminal-gaming-sixel.md` and
+  `docs/adr/0002-terminal-gaming-iterm2.md` for the design rationale and a full
+  bandwidth breakdown
 
 ## Third party libraries
 - Third party libraries is placed to `3rd/` directory

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,9 +47,9 @@
   Terminals do not report key-release events, so a key is treated as held for
   a short window (`HOLD_MS`) after its last byte; the terminal's own
   auto-repeat sustains movement while a key stays down.
-- Prints an emit-rate report (frame size, MB/s, fps) to stderr about once a
-  second so the real per-frame byte cost can be measured; on by default,
-  disabled with `--noterm_stats`
+- Draws an emit-rate report (frame size, MB/s, fps) on-screen just under the
+  control legend, refreshed about once a second, so the real per-frame byte cost
+  is visible while playing; on by default, disabled with `--noterm_stats`
 - Output is throughput-bound: the sixel path for 320×240 at 60 Hz needs roughly
   20 Mbaud (up to ~70 Mbaud worst case); the iTerm2 path PNG-compresses each
   frame, which shrinks flat tile/sprite regions substantially but spends CPU on

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,9 @@
   (`sixel.cxx` / `iterm.cxx`)
 - Reads keyboard input directly from the terminal and forwards it to
   `RGSS::Input`
+- Prints an emit-rate report (frame size, MB/s, fps) to stderr about once a
+  second so the real per-frame byte cost can be measured; on by default,
+  disabled with `--noterm_stats`
 - Output is throughput-bound: the sixel path for 320×240 at 60 Hz needs roughly
   20 Mbaud (up to ~70 Mbaud worst case); the iTerm2 path PNG-compresses each
   frame, which shrinks flat tile/sprite regions substantially but spends CPU on

--- a/docs/adr/0002-terminal-gaming-iterm2.md
+++ b/docs/adr/0002-terminal-gaming-iterm2.md
@@ -1,0 +1,106 @@
+# 2. Terminal gaming with the iTerm2 inline-image protocol
+
+Date: 2026-07-22
+
+## Status
+
+Accepted
+
+Extends [1. Terminal gaming with the sixel graphics protocol](0001-terminal-gaming-sixel.md).
+
+## Context
+
+ADR 0001 added a windowless display backend that renders each frame to the
+terminal with the DEC **sixel** protocol. Sixel is widely supported (xterm in
+vt340 mode, mlterm, foot, WezTerm, Windows Terminal, ...) but there is one
+common environment where it does *not* work: **VS Code's integrated terminal**.
+That terminal is built on xterm.js, whose image addon implements the **sixel**
+and **iTerm2 inline-image** protocols but *not* the kitty graphics protocol.
+Since developers frequently run the game straight from the editor, a backend
+that renders there is valuable.
+
+The iTerm2 inline-image protocol also fixes two fidelity/bandwidth limitations
+called out in ADR 0001:
+
+- Sixel here quantises to a fixed 216-colour cube. iTerm2 payloads are ordinary
+  image files, so we get full 24-bit colour with no banding.
+- The sixel encoder re-emits the ~3.2 KB palette every frame and is otherwise
+  ~1 byte/pixel. An image file can be PNG-compressed, and the large flat
+  tile/sprite regions typical of RPG Maker games compress heavily.
+
+The protocol is understood by iTerm2, WezTerm and xterm.js (hence VS Code), so
+one backend covers all three.
+
+## Decision
+
+Add a third display backend selected with `--iterm` (`--iterm_scale` controls
+integer upscaling), alongside the existing `--sixel`.
+
+Because the sixel and iTerm2 backends differ *only* in how a finished frame is
+turned into bytes, the shared machinery from `sixel.cxx` was extracted into a
+new **`mruby-rgss/src/terminal.cxx`** (declared in `include/terminal.hxx`):
+
+- LVGL display creation in `LV_DISPLAY_RENDER_MODE_FULL` backed by an RGB565
+  full-screen buffer.
+- The monotonic-clock tick source and `nanosleep`-based delay
+  (`lv_tick_set_cb` / `lv_delay_set_cb`).
+- Raw-mode terminal setup, alternate-screen switching, cursor hiding, and
+  restoration on exit and fatal signals.
+- Keyboard polling (arrows/WASD, confirm, cancel, quit) forwarded to
+  `RGSS::Input`, exported as `rgss_terminal_poll`.
+
+`terminal_display_create(w, h, scale, encode)` takes a per-protocol encoder
+callback; `sixel.cxx` and `iterm.cxx` now contain *only* their encoder plus a
+thin `*_display_create` wrapper. This keeps the two backends in lockstep on
+input, timing and teardown.
+
+The iTerm2 encoder (`mruby-rgss/src/iterm.cxx`):
+
+- Expands the RGB565 frame to RGB888, upscaling by an integer nearest-neighbour
+  factor.
+- Encodes it to PNG with `stb_image_write` (already vendored in `3rd/stb`),
+  which bundles its own deflate implementation so no zlib dependency is added.
+  `STBI_WRITE_NO_STDIO` keeps only the in-memory `*_to_func` API. The
+  compression level is lowered from stb's default of 8 to 6 to favour encode
+  latency on the game loop.
+- base64-encodes the PNG and wraps it in the OSC 1337 sequence
+  `ESC ] 1337 ; File=inline=1;size=N;width=Wpx;height=Hpx;preserveAspectRatio=0 : <base64> BEL`.
+  A leading `ESC[H` (cursor home) makes each frame overdraw the previous one in
+  place, mirroring the sixel path.
+
+## Bandwidth
+
+Unlike sixel's ~1 byte/pixel, the iTerm2 path is PNG-compressed, so frame size
+depends heavily on content. A frame is `PNG(frame) × 4/3` bytes on the wire
+(base64 overhead):
+
+- Flat/gradient regions compress dramatically — a synthetic 120×72 test frame
+  of gradients plus flat blocks encoded to **447 bytes** of PNG (596 bytes
+  base64), versus 25,920 bytes of raw RGB.
+- Busy, high-entropy frames compress far less; the ceiling approaches the raw
+  RGB size (`w × h × 3 × scale²`) plus base64 overhead before PNG's own header.
+
+So for the flat tile/sprite regions typical of these games the iTerm2 path is
+usually *lighter* on the wire than sixel, at the cost of **CPU spent on PNG
+deflate every frame** — the opposite trade-off from the sixel encoder, which is
+cheap to compute but bulky. As with sixel, `--iterm_scale` multiplies the pixel
+work (and the worst-case byte count) by `scale²`, and the backend targets a
+local PTY or SSH pipe rather than a real UART.
+
+## Consequences
+
+- The runtime now renders in VS Code's integrated terminal (and iTerm2 /
+  WezTerm), where sixel and kitty do not both work — broadening the "run
+  anywhere" goal.
+- Full 24-bit colour with no palette banding on this path.
+- `--sixel` and `--iterm` are mutually exclusive; `main.cxx` rejects passing
+  both. SDL remains the default and is unchanged.
+- Trade-offs / follow-up work:
+  - PNG encoding costs CPU per frame; on a slow host the frame rate may need to
+    drop. Lowering the compression level or diffing against the previous frame
+    (the iTerm2 protocol has no built-in delta, unlike kitty) could help.
+  - Terminal input still has no key-release, so the `HOLD_MS` heuristic from
+    ADR 0001 applies unchanged (it now lives in `terminal.cxx`).
+  - The backend continues to live inside the `mruby-rgss` gem, linking into both
+    the game executable and mruby's `mrbtest`; `main.cxx` calls the exported
+    `iterm_display_create`, mirroring the `sixel_display_create` seam.

--- a/include/iterm.hxx
+++ b/include/iterm.hxx
@@ -6,10 +6,12 @@
 struct _lv_display_t;
 typedef struct _lv_display_t lv_display_t;
 
-// Create an LVGL display that renders each frame to the terminal using the
-// DEC sixel graphics protocol instead of opening a desktop window.  This lets
-// the games be played inside any sixel-capable terminal (xterm -ti vt340,
-// mlterm, foot, wezterm, Windows Terminal, ...).
+// Create an LVGL display that renders each frame to the terminal using iTerm2's
+// inline-image protocol (the OSC 1337 "File=" sequence) instead of opening a
+// desktop window.  Each frame is PNG-encoded and emitted base64-encoded, so
+// this works on any terminal that understands the protocol -- iTerm2, WezTerm,
+// and, unlike sixel/kitty, VS Code's integrated terminal (xterm.js image
+// addon).
 //
 // `hor_res`/`ver_res` are the logical game resolution.  `scale` upscales the
 // emitted image by an integer nearest-neighbour factor so pixel-art is legible
@@ -18,4 +20,4 @@ typedef struct _lv_display_t lv_display_t;
 // The shared terminal backend (see terminal.hxx) also puts the controlling
 // terminal into raw mode and the alternate screen buffer, restored on exit; use
 // terminal_poll() to forward keyboard input to RGSS::Input.
-lv_display_t* sixel_display_create(int32_t hor_res, int32_t ver_res, int scale);
+lv_display_t* iterm_display_create(int32_t hor_res, int32_t ver_res, int scale);

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -16,6 +16,12 @@ typedef struct _lv_display_t lv_display_t;
 // and iTerm2 backends stay identical.
 void terminal_append_legend(std::string& s);
 
+// Append the emit-rate report row (frame size, MB/s, fps) drawn just under the
+// legend, in the same dim/cleared/CR-LF style.  Encoders call this right after
+// terminal_append_legend.  The text is refreshed about once a second; a no-op
+// when --term_stats is disabled.
+void terminal_append_stats(std::string& s);
+
 // A per-protocol frame encoder.  It is handed one finished frame as an RGB565
 // buffer at the logical game resolution (`w`x`h`) plus the integer upscale
 // factor `scale`, and is responsible for turning it into a terminal byte stream

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -22,7 +22,10 @@ void terminal_append_legend(std::string& s);
 // and emitting it with `terminal_write`.  The sixel and iTerm2 backends differ
 // only in this function; everything else (raw mode, input, timing, the LVGL
 // display/buffer wiring) is shared.
-using terminal_encode_fn = void (*)(int w, int h, int scale, const uint16_t* pix);
+using terminal_encode_fn = void (*)(int w,
+                                    int h,
+                                    int scale,
+                                    const uint16_t* pix);
 
 // Create a windowless LVGL display that renders each frame to the controlling
 // terminal via `encode`, instead of opening a desktop window.
@@ -33,8 +36,8 @@ using terminal_encode_fn = void (*)(int w, int h, int scale, const uint16_t* pix
 //
 // As a side effect the controlling terminal is switched into raw mode (so
 // keyboard input can be read without line buffering) and into the alternate
-// screen buffer (so the game does not overwrite the user's shell history), and a
-// monotonic tick/delay source is installed so LVGL runs without SDL.  The
+// screen buffer (so the game does not overwrite the user's shell history), and
+// a monotonic tick/delay source is installed so LVGL runs without SDL.  The
 // terminal state is restored automatically on process exit and on fatal
 // signals.
 lv_display_t* terminal_display_create(int32_t hor_res,

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -42,3 +42,9 @@ void terminal_poll(mrb_state* M);
 // Write raw bytes to the controlling terminal, handling partial writes and
 // EINTR.  Meant for encoders assembling a frame.
 void terminal_write(const char* p, size_t n);
+
+// Enable or disable the periodic emit-rate report (frame size, MB/s, fps)
+// printed to stderr about once a second while a terminal backend is active.
+// Enabled by default; wired to the --term_stats flag.  Has no effect unless a
+// terminal display was created (the SDL path never calls the encoder).
+void terminal_set_stats(bool enabled);

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Forward declarations to avoid pulling heavy headers into every includer.
+struct mrb_state;
+struct _lv_display_t;
+typedef struct _lv_display_t lv_display_t;
+
+// A per-protocol frame encoder.  It is handed one finished frame as an RGB565
+// buffer at the logical game resolution (`w`x`h`) plus the integer upscale
+// factor `scale`, and is responsible for turning it into a terminal byte stream
+// and emitting it with `terminal_write`.  The sixel and iTerm2 backends differ
+// only in this function; everything else (raw mode, input, timing, the LVGL
+// display/buffer wiring) is shared.
+using terminal_encode_fn = void (*)(int w, int h, int scale, const uint16_t* pix);
+
+// Create a windowless LVGL display that renders each frame to the controlling
+// terminal via `encode`, instead of opening a desktop window.
+//
+// `hor_res`/`ver_res` are the logical game resolution; `scale` upscales the
+// emitted image by an integer nearest-neighbour factor so pixel-art is legible
+// in a terminal.  The created display is registered as LVGL's default display.
+//
+// As a side effect the controlling terminal is switched into raw mode (so
+// keyboard input can be read without line buffering) and into the alternate
+// screen buffer (so the game does not overwrite the user's shell history), and a
+// monotonic tick/delay source is installed so LVGL runs without SDL.  The
+// terminal state is restored automatically on process exit and on fatal
+// signals.
+lv_display_t* terminal_display_create(int32_t hor_res,
+                                      int32_t ver_res,
+                                      int scale,
+                                      terminal_encode_fn encode);
+
+// Poll the terminal for keyboard input and forward it to the RGSS::Input
+// module.  Safe to call unconditionally: it is a no-op until a terminal display
+// has been created.  Meant to be invoked once per frame from Graphics.update.
+void terminal_poll(mrb_state* M);
+
+// Write raw bytes to the controlling terminal, handling partial writes and
+// EINTR.  Meant for encoders assembling a frame.
+void terminal_write(const char* p, size_t n);

--- a/mruby-rgss/src/iterm.cxx
+++ b/mruby-rgss/src/iterm.cxx
@@ -88,8 +88,9 @@ void iterm_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   // `size` lets the terminal show a progress indicator; width/height in px pin
   // the on-screen size to the encoded resolution; preserveAspectRatio=0 avoids
   // extra letterboxing since the two already match.  A leading cursor-home plus
-  // the shared control legend lets each frame overdraw the previous one in place
-  // with the key reference pinned on the top row, matching the sixel backend.
+  // the shared control legend lets each frame overdraw the previous one in
+  // place with the key reference pinned on the top row, matching the sixel
+  // backend.
   std::string& s = g_out;
   s.clear();
   s += "\x1b[H";

--- a/mruby-rgss/src/iterm.cxx
+++ b/mruby-rgss/src/iterm.cxx
@@ -95,6 +95,7 @@ void iterm_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   s.clear();
   s += "\x1b[H";
   terminal_append_legend(s);
+  terminal_append_stats(s);
   s += "\x1b]1337;File=inline=1;size=";
   s += std::to_string(g_png.size());
   s += ";width=";

--- a/mruby-rgss/src/iterm.cxx
+++ b/mruby-rgss/src/iterm.cxx
@@ -1,0 +1,116 @@
+#include "iterm.hxx"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "terminal.hxx"
+
+// stb_image_write brings its own deflate implementation, so PNG encoding needs
+// no external zlib.  STBI_WRITE_NO_STDIO drops the FILE*-based helpers (we only
+// use the in-memory *_to_func API), and the implementation lives in this one
+// translation unit.
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#define STBI_WRITE_NO_STDIO
+#include <stb_image_write.h>
+
+namespace {
+
+// Reused across frames to avoid per-frame allocation churn.
+std::vector<uint8_t> g_rgb;  // RGB888, upscaled frame fed to the PNG encoder
+std::string g_png;           // encoded PNG bytes
+std::string g_b64;           // base64 of g_png
+std::string g_out;           // full OSC 1337 sequence written to the terminal
+
+// Standard base64 alphabet; iTerm2 expects the image payload base64-encoded.
+void base64_append(std::string& out, const std::string& in) {
+  static const char tbl[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const size_t n = in.size();
+  out.reserve(out.size() + ((n + 2) / 3) * 4);
+  size_t i = 0;
+  for (; i + 3 <= n; i += 3) {
+    const uint32_t v = static_cast<uint8_t>(in[i]) << 16 |
+                       static_cast<uint8_t>(in[i + 1]) << 8 |
+                       static_cast<uint8_t>(in[i + 2]);
+    out += tbl[(v >> 18) & 63];
+    out += tbl[(v >> 12) & 63];
+    out += tbl[(v >> 6) & 63];
+    out += tbl[v & 63];
+  }
+  if (n - i == 1) {
+    const uint32_t v = static_cast<uint8_t>(in[i]) << 16;
+    out += tbl[(v >> 18) & 63];
+    out += tbl[(v >> 12) & 63];
+    out += '=';
+    out += '=';
+  } else if (n - i == 2) {
+    const uint32_t v = static_cast<uint8_t>(in[i]) << 16 |
+                       static_cast<uint8_t>(in[i + 1]) << 8;
+    out += tbl[(v >> 18) & 63];
+    out += tbl[(v >> 12) & 63];
+    out += tbl[(v >> 6) & 63];
+    out += '=';
+  }
+}
+
+// stbi_write_png_to_func sink: append the encoded bytes to a std::string.
+void png_sink(void* ctx, void* data, int size) {
+  auto* s = static_cast<std::string*>(ctx);
+  s->append(static_cast<const char*>(data), static_cast<size_t>(size));
+}
+
+void iterm_encode_frame(int w, int h, int scale, const uint16_t* pix) {
+  const int out_w = w * scale;
+  const int out_h = h * scale;
+
+  // Expand RGB565 to RGB888, upscaling by nearest-neighbour, into g_rgb.
+  g_rgb.resize(static_cast<size_t>(out_w) * out_h * 3);
+  for (int oy = 0; oy < out_h; ++oy) {
+    const uint16_t* row = pix + (oy / scale) * w;
+    uint8_t* dst = g_rgb.data() + static_cast<size_t>(oy) * out_w * 3;
+    for (int ox = 0; ox < out_w; ++ox) {
+      const uint16_t p = row[ox / scale];
+      *dst++ = static_cast<uint8_t>(((p >> 11) & 0x1f) << 3);  // R
+      *dst++ = static_cast<uint8_t>(((p >> 5) & 0x3f) << 2);   // G
+      *dst++ = static_cast<uint8_t>((p & 0x1f) << 3);          // B
+    }
+  }
+
+  g_png.clear();
+  stbi_write_png_to_func(png_sink, &g_png, out_w, out_h, 3, g_rgb.data(),
+                         out_w * 3);
+
+  g_b64.clear();
+  base64_append(g_b64, g_png);
+
+  // iTerm2 inline-image protocol: OSC 1337 ; File = <args> : <base64> BEL.
+  // `size` lets the terminal show a progress indicator; width/height in px pin
+  // the on-screen size to the encoded resolution; preserveAspectRatio=0 avoids
+  // extra letterboxing since the two already match.  A leading cursor-home lets
+  // each frame overdraw the previous one in place.
+  std::string& s = g_out;
+  s.clear();
+  s += "\x1b[H";
+  s += "\x1b]1337;File=inline=1;size=";
+  s += std::to_string(g_png.size());
+  s += ";width=";
+  s += std::to_string(out_w);
+  s += "px;height=";
+  s += std::to_string(out_h);
+  s += "px;preserveAspectRatio=0:";
+  s += g_b64;
+  s += "\x07";  // BEL terminates the OSC sequence
+  terminal_write(s.data(), s.size());
+}
+
+}  // namespace
+
+lv_display_t* iterm_display_create(int32_t hor_res,
+                                   int32_t ver_res,
+                                   int scale) {
+  // Trade a little PNG size for encode speed: this runs once per frame on the
+  // game loop, so favour latency over the last few percent of compression.
+  stbi_write_png_compression_level = 6;
+  return terminal_display_create(hor_res, ver_res, scale, iterm_encode_frame);
+}

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -26,8 +26,9 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-// Defined in sixel.cxx (same gem).  A no-op unless the game was started with
-// --sixel; forwards terminal keyboard input to RGSS::Input.
+// Defined in terminal.cxx (same gem).  A no-op unless the game was started with
+// a terminal backend (--sixel / --iterm); forwards terminal keyboard input to
+// RGSS::Input.
 extern "C" void rgss_terminal_poll(mrb_state* M);
 
 namespace {

--- a/mruby-rgss/src/sixel.cxx
+++ b/mruby-rgss/src/sixel.cxx
@@ -1,158 +1,18 @@
 #include "sixel.hxx"
 
-#include <cerrno>
-#include <csignal>
-#include <cstdlib>
+#include <cstdint>
 #include <cstring>
-#include <ctime>
 #include <string>
 #include <vector>
 
-#include <termios.h>
-#include <unistd.h>
-
-#include <lvgl.h>
-#include <mruby.h>
-#include <mruby/class.h>
-#include <mruby/value.h>
+#include "terminal.hxx"
 
 namespace {
-
-// RGSS::Input key ids (mirrors mruby-rgss/mrblib/lib.rb).
-enum Key {
-  KEY_UP = 0,
-  KEY_DOWN = 1,
-  KEY_LEFT = 2,
-  KEY_RIGHT = 3,
-  KEY_A = 4,
-  KEY_B = 5,
-  KEY_C = 6,
-};
-
-// Terminals do not report key-release events, so a key is considered held for
-// this long after the last byte that produced it was received.  Keeping this
-// short makes menus responsive; the terminal's own auto-repeat sustains held
-// movement keys.
-constexpr uint32_t HOLD_MS = 150;
-
-// ---------------------------------------------------------------------------
-// Global backend state
-// ---------------------------------------------------------------------------
-bool g_active = false;
-bool g_have_tty = false;
-int g_scale = 1;
-termios g_orig_termios;
-bool g_termios_saved = false;
-
-// Full-screen render buffer handed to LVGL (RENDER_MODE_FULL, RGB565).
-std::vector<uint8_t> g_fb;
 
 // Reused across frames to avoid per-frame allocation churn.
 std::string g_out;
 std::vector<uint8_t> g_oidx;
 std::string g_line;
-
-struct KeyState {
-  bool pressed = false;
-  uint32_t expiry = 0;
-};
-KeyState g_keys[16];
-
-// ---------------------------------------------------------------------------
-// Time sources (LVGL needs a tick/delay source without SDL)
-// ---------------------------------------------------------------------------
-uint32_t now_ms() {
-  timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return static_cast<uint32_t>(ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL);
-}
-
-void delay_ms(uint32_t ms) {
-  timespec ts;
-  ts.tv_sec = ms / 1000;
-  ts.tv_nsec = static_cast<long>(ms % 1000) * 1000000L;
-  nanosleep(&ts, nullptr);
-}
-
-// ---------------------------------------------------------------------------
-// Terminal handling
-// ---------------------------------------------------------------------------
-void write_all(const char* p, size_t n) {
-  while (n > 0) {
-    const ssize_t w = ::write(STDOUT_FILENO, p, n);
-    if (w <= 0) {
-      if (w < 0 && errno == EINTR)
-        continue;
-      break;
-    }
-    p += w;
-    n -= static_cast<size_t>(w);
-  }
-}
-
-void show_cursor() {
-  static const char seq[] = "\x1b[?25h";
-  write_all(seq, sizeof(seq) - 1);
-}
-
-// True once the alternate screen buffer has been entered, so teardown only
-// leaves it if init actually switched to it.
-bool g_alt_screen = false;
-
-void restore_terminal() {
-  // Undo the visual state first (while still in raw mode), then hand the
-  // terminal back to the shell.  Leaving the alternate screen buffer restores
-  // the exact pre-game screen contents and cursor position; the explicit
-  // erase covers the few terminals that keep sixel output in a layer that
-  // survives the screen switch.
-  show_cursor();
-  if (g_alt_screen) {
-    static const char leave_alt[] = "\x1b[2J\x1b[?1049l";
-    write_all(leave_alt, sizeof(leave_alt) - 1);
-    g_alt_screen = false;
-  }
-  if (g_termios_saved) {
-    tcsetattr(STDIN_FILENO, TCSAFLUSH, &g_orig_termios);
-    g_termios_saved = false;
-  }
-}
-
-void signal_handler(int sig) {
-  restore_terminal();
-  // Re-raise with the default handler so the exit status reflects the signal.
-  signal(sig, SIG_DFL);
-  raise(sig);
-}
-
-void init_terminal() {
-  g_have_tty = isatty(STDIN_FILENO);
-  if (g_have_tty && tcgetattr(STDIN_FILENO, &g_orig_termios) == 0) {
-    g_termios_saved = true;
-    termios raw = g_orig_termios;
-    // Raw-ish mode: no line buffering, no echo, no signal generation (so we
-    // can read Ctrl-C ourselves), non-blocking reads.
-    raw.c_lflag &= ~(ICANON | ECHO | ISIG);
-    raw.c_iflag &= ~(IXON | ICRNL);
-    raw.c_cc[VMIN] = 0;
-    raw.c_cc[VTIME] = 0;
-    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
-  }
-
-  std::atexit(restore_terminal);
-  for (int sig : {SIGINT, SIGTERM, SIGHUP, SIGQUIT})
-    signal(sig, signal_handler);
-
-  // Switch to the alternate screen buffer so the game does not scribble sixels
-  // over the user's shell history; leaving it on exit restores what was there
-  // before.  Sixels painted here belong to the alt buffer and are discarded on
-  // switch-back in the common terminals (xterm, foot, WezTerm, mlterm, ...).
-  static const char enter_alt[] = "\x1b[?1049h";
-  write_all(enter_alt, sizeof(enter_alt) - 1);
-  g_alt_screen = true;
-
-  static const char hide_cursor[] = "\x1b[?25l";
-  write_all(hide_cursor, sizeof(hide_cursor) - 1);
-}
 
 // ---------------------------------------------------------------------------
 // Sixel encoding
@@ -209,8 +69,7 @@ void emit_rle(std::string& s, const std::string& line) {
   }
 }
 
-void encode_frame(int w, int h, const uint16_t* pix) {
-  const int scale = g_scale;
+void sixel_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   const int out_w = w * scale;
   const int out_h = h * scale;
 
@@ -283,166 +142,13 @@ void encode_frame(int w, int h, const uint16_t* pix) {
   }
 
   s += "\x1b\\";  // exit sixel mode
-  write_all(s.data(), s.size());
-}
-
-void flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
-  if (lv_display_flush_is_last(disp)) {
-    const int w = lv_area_get_width(area);
-    const int h = lv_area_get_height(area);
-    encode_frame(w, h, reinterpret_cast<const uint16_t*>(px_map));
-  }
-  lv_display_flush_ready(disp);
-}
-
-// ---------------------------------------------------------------------------
-// Keyboard input
-// ---------------------------------------------------------------------------
-void send_key(mrb_state* M, int key, bool press) {
-  RClass* rgss = mrb_module_get(M, "RGSS");
-  if (!rgss)
-    return;
-  RClass* input = mrb_module_get_under(M, rgss, "Input");
-  if (!input)
-    return;
-  mrb_funcall(M, mrb_obj_value(input), press ? "press" : "release", 1,
-              mrb_fixnum_value(key));
-}
-
-void hold_key(mrb_state* M, int key, uint32_t now) {
-  if (key < 0)
-    return;
-  if (!g_keys[key].pressed) {
-    g_keys[key].pressed = true;
-    send_key(M, key, true);
-  }
-  g_keys[key].expiry = now + HOLD_MS;
+  terminal_write(s.data(), s.size());
 }
 
 }  // namespace
 
-// Exported so the mruby-rgss gem (Graphics.update) can drive input polling
-// without a compile-time dependency on this translation unit.
-extern "C" void rgss_terminal_poll(mrb_state* M) {
-  sixel_terminal_poll(M);
-}
-
-void sixel_terminal_poll(mrb_state* M) {
-  if (!g_active || !g_have_tty)
-    return;
-
-  const uint32_t now = now_ms();
-
-  std::vector<char> buf;
-  char chunk[64];
-  for (;;) {
-    const ssize_t n = ::read(STDIN_FILENO, chunk, sizeof(chunk));
-    if (n <= 0)
-      break;
-    buf.insert(buf.end(), chunk, chunk + n);
-    if (static_cast<size_t>(n) < sizeof(chunk))
-      break;
-  }
-
-  for (size_t i = 0; i < buf.size();) {
-    const unsigned char c = static_cast<unsigned char>(buf[i]);
-    if (c == 0x1b && i + 2 < buf.size() && buf[i + 1] == '[') {
-      switch (buf[i + 2]) {
-        case 'A':
-          hold_key(M, KEY_UP, now);
-          break;
-        case 'B':
-          hold_key(M, KEY_DOWN, now);
-          break;
-        case 'C':
-          hold_key(M, KEY_RIGHT, now);
-          break;
-        case 'D':
-          hold_key(M, KEY_LEFT, now);
-          break;
-        default:
-          break;
-      }
-      i += 3;
-      continue;
-    }
-
-    switch (c) {
-      case 'w':
-      case 'W':
-        hold_key(M, KEY_UP, now);
-        break;
-      case 's':
-      case 'S':
-        hold_key(M, KEY_DOWN, now);
-        break;
-      case 'a':
-      case 'A':
-        hold_key(M, KEY_LEFT, now);
-        break;
-      case 'd':
-      case 'D':
-        hold_key(M, KEY_RIGHT, now);
-        break;
-      case 'z':
-      case 'Z':
-      case '\r':
-      case '\n':
-      case ' ':
-        hold_key(M, KEY_C, now);
-        break;
-      case 'x':
-      case 'X':
-      case 0x1b:  // 'x' or bare ESC = cancel
-        hold_key(M, KEY_B, now);
-        break;
-      case 'c':
-      case 'C':
-        hold_key(M, KEY_A, now);
-        break;
-      case 'q':
-      case 0x03:  // 'q' or Ctrl-C = quit
-        restore_terminal();
-        std::exit(0);
-        break;
-      default:
-        break;
-    }
-    ++i;
-  }
-
-  // Auto-release keys whose hold window has elapsed.
-  for (int k = 0; k < static_cast<int>(sizeof(g_keys) / sizeof(g_keys[0]));
-       ++k) {
-    if (g_keys[k].pressed &&
-        static_cast<int32_t>(now - g_keys[k].expiry) >= 0) {
-      g_keys[k].pressed = false;
-      send_key(M, k, false);
-    }
-  }
-}
-
 lv_display_t* sixel_display_create(int32_t hor_res,
                                    int32_t ver_res,
                                    int scale) {
-  g_scale = scale < 1 ? 1 : scale;
-
-  lv_tick_set_cb(now_ms);
-  lv_delay_set_cb(delay_ms);
-
-  lv_display_t* disp = lv_display_create(hor_res, ver_res);
-  if (!disp)
-    return nullptr;
-
-  lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
-  const uint32_t buf_size =
-      static_cast<uint32_t>(hor_res) * ver_res * sizeof(uint16_t);
-  g_fb.assign(buf_size, 0);
-  lv_display_set_buffers(disp, g_fb.data(), nullptr, buf_size,
-                         LV_DISPLAY_RENDER_MODE_FULL);
-  lv_display_set_flush_cb(disp, flush_cb);
-
-  init_terminal();
-  g_active = true;
-  return disp;
+  return terminal_display_create(hor_res, ver_res, scale, sixel_encode_frame);
 }

--- a/mruby-rgss/src/sixel.cxx
+++ b/mruby-rgss/src/sixel.cxx
@@ -93,8 +93,8 @@ void sixel_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   s.clear();
   s += "\x1b[H";  // cursor home: overdraw the previous frame in place
   terminal_append_legend(s);  // one-line key reference pinned above the image
-  s += "\x1bPq";  // enter sixel mode
-  s += "\"1;1;";  // raster attributes: 1:1 aspect ratio
+  s += "\x1bPq";              // enter sixel mode
+  s += "\"1;1;";              // raster attributes: 1:1 aspect ratio
   s += std::to_string(out_w);
   s += ';';
   s += std::to_string(out_h);

--- a/mruby-rgss/src/sixel.cxx
+++ b/mruby-rgss/src/sixel.cxx
@@ -93,6 +93,7 @@ void sixel_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   s.clear();
   s += "\x1b[H";  // cursor home: overdraw the previous frame in place
   terminal_append_legend(s);  // one-line key reference pinned above the image
+  terminal_append_stats(s);   // emit-rate report row (no-op if --noterm_stats)
   s += "\x1bPq";              // enter sixel mode
   s += "\"1;1;";              // raster attributes: 1:1 aspect ratio
   s += std::to_string(out_w);

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -223,8 +223,8 @@ void terminal_set_stats(bool enabled) {
 
 void terminal_append_legend(std::string& s) {
   // Reserve the top text row for a one-line key reference, then start the image
-  // one row lower.  Terminals place the frame at the current cursor position, so
-  // drawing the legend first (and emitting CR/LF) pins it above the picture
+  // one row lower.  Terminals place the frame at the current cursor position,
+  // so drawing the legend first (and emitting CR/LF) pins it above the picture
   // where it can never be overdrawn -- unlike positioning it after the image,
   // whose end-cursor location is not portable and left the legend overlapping
   // the bottom of the frame.  \x1b[K clears any stale text from the previous

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -50,13 +50,15 @@ bool g_termios_saved = false;
 std::vector<uint8_t> g_fb;
 
 // Emit-rate statistics: how many bytes the active encoder pushes to the
-// terminal, printed to stderr about once a second.  On by default; toggled with
-// --term_stats.
+// terminal, recomputed about once a second and drawn on-screen just under the
+// control legend.  On by default; toggled with --term_stats.
 bool g_stats = true;
 uint64_t g_stats_bytes = 0;   // bytes written to the terminal this interval
 uint32_t g_stats_frames = 0;  // frames emitted this interval
 uint32_t g_stats_last_ms = 0;
 bool g_stats_started = false;
+std::string
+    g_stats_line;  // last formatted report, drawn by terminal_append_stats
 
 struct KeyState {
   bool pressed = false;
@@ -148,10 +150,10 @@ void init_terminal() {
   terminal_write(hide_cursor, sizeof(hide_cursor) - 1);
 }
 
-// Once per ~second, print the emit rate (bytes the encoder pushed to the
-// terminal) to stderr and reset the interval counters.  stderr is used so the
-// numbers do not land in the stdout image stream; redirect it (2>stats.log) to
-// keep them off the game screen.
+// Once per ~second, recompute the emit rate (bytes the encoder pushed to the
+// terminal) into g_stats_line and reset the interval counters.  The line is
+// drawn into each frame by terminal_append_stats, so it never lands in the
+// stdout image stream or scrolls the alternate screen.
 void maybe_report_stats(uint32_t now) {
   if (!g_stats)
     return;
@@ -170,8 +172,11 @@ void maybe_report_stats(uint32_t now) {
       g_stats_frames
           ? static_cast<double>(g_stats_bytes) / g_stats_frames / 1024.0
           : 0.0;
-  std::fprintf(stderr, "[term_stats] %.1f KB/frame  %.2f MB/s  %.1f fps\n",
-               kb_per_frame, mbps, fps);
+  char buf[128];
+  std::snprintf(buf, sizeof(buf),
+                "term_stats: %.1f KB/frame  %.2f MB/s  %.1f fps", kb_per_frame,
+                mbps, fps);
+  g_stats_line.assign(buf);
   g_stats_bytes = 0;
   g_stats_frames = 0;
   g_stats_last_ms = now;
@@ -231,6 +236,21 @@ void terminal_append_legend(std::string& s) {
   // frame and the dim SGR keeps the legend visually secondary to the game.
   s += "\x1b[K\x1b[2m";
   s += "Move: Arrows/WASD  OK: Z/Enter/Space  Cancel: X/Esc  A: C  Quit: Q";
+  s += "\x1b[0m\r\n";
+}
+
+void terminal_append_stats(std::string& s) {
+  // Draw the emit-rate report on its own row just under the legend, using the
+  // same cursor-home overdraw model so it refreshes in place instead of
+  // scrolling the alternate screen (the reason the old stderr print was
+  // dropped).  No-op when stats are disabled so the row is not reserved.  The
+  // row is always emitted once stats are on -- with a placeholder for the first
+  // second before a rate has been measured -- so the image never shifts down a
+  // row when the first sample arrives.
+  if (!g_stats)
+    return;
+  s += "\x1b[K\x1b[2m";
+  s += g_stats_line.empty() ? "term_stats: measuring..." : g_stats_line;
   s += "\x1b[0m\r\n";
 }
 

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -1,0 +1,317 @@
+#include "terminal.hxx"
+
+#include <cerrno>
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <vector>
+
+#include <termios.h>
+#include <unistd.h>
+
+#include <lvgl.h>
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/value.h>
+
+namespace {
+
+// RGSS::Input key ids (mirrors mruby-rgss/mrblib/lib.rb).
+enum Key {
+  KEY_UP = 0,
+  KEY_DOWN = 1,
+  KEY_LEFT = 2,
+  KEY_RIGHT = 3,
+  KEY_A = 4,
+  KEY_B = 5,
+  KEY_C = 6,
+};
+
+// Terminals do not report key-release events, so a key is considered held for
+// this long after the last byte that produced it was received.  Keeping this
+// short makes menus responsive; the terminal's own auto-repeat sustains held
+// movement keys.
+constexpr uint32_t HOLD_MS = 150;
+
+// ---------------------------------------------------------------------------
+// Global backend state
+// ---------------------------------------------------------------------------
+bool g_active = false;
+bool g_have_tty = false;
+int g_scale = 1;
+terminal_encode_fn g_encode = nullptr;
+termios g_orig_termios;
+bool g_termios_saved = false;
+
+// Full-screen render buffer handed to LVGL (RENDER_MODE_FULL, RGB565).
+std::vector<uint8_t> g_fb;
+
+struct KeyState {
+  bool pressed = false;
+  uint32_t expiry = 0;
+};
+KeyState g_keys[16];
+
+// ---------------------------------------------------------------------------
+// Time sources (LVGL needs a tick/delay source without SDL)
+// ---------------------------------------------------------------------------
+uint32_t now_ms() {
+  timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint32_t>(ts.tv_sec * 1000ULL + ts.tv_nsec / 1000000ULL);
+}
+
+void delay_ms(uint32_t ms) {
+  timespec ts;
+  ts.tv_sec = ms / 1000;
+  ts.tv_nsec = static_cast<long>(ms % 1000) * 1000000L;
+  nanosleep(&ts, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Terminal handling
+// ---------------------------------------------------------------------------
+void show_cursor() {
+  static const char seq[] = "\x1b[?25h";
+  terminal_write(seq, sizeof(seq) - 1);
+}
+
+// True once the alternate screen buffer has been entered, so teardown only
+// leaves it if init actually switched to it.
+bool g_alt_screen = false;
+
+void restore_terminal() {
+  // Undo the visual state first (while still in raw mode), then hand the
+  // terminal back to the shell.  Leaving the alternate screen buffer restores
+  // the exact pre-game screen contents and cursor position; the explicit
+  // erase covers the few terminals that keep image output in a layer that
+  // survives the screen switch.
+  show_cursor();
+  if (g_alt_screen) {
+    static const char leave_alt[] = "\x1b[2J\x1b[?1049l";
+    terminal_write(leave_alt, sizeof(leave_alt) - 1);
+    g_alt_screen = false;
+  }
+  if (g_termios_saved) {
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &g_orig_termios);
+    g_termios_saved = false;
+  }
+}
+
+void signal_handler(int sig) {
+  restore_terminal();
+  // Re-raise with the default handler so the exit status reflects the signal.
+  signal(sig, SIG_DFL);
+  raise(sig);
+}
+
+void init_terminal() {
+  g_have_tty = isatty(STDIN_FILENO);
+  if (g_have_tty && tcgetattr(STDIN_FILENO, &g_orig_termios) == 0) {
+    g_termios_saved = true;
+    termios raw = g_orig_termios;
+    // Raw-ish mode: no line buffering, no echo, no signal generation (so we
+    // can read Ctrl-C ourselves), non-blocking reads.
+    raw.c_lflag &= ~(ICANON | ECHO | ISIG);
+    raw.c_iflag &= ~(IXON | ICRNL);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 0;
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+  }
+
+  std::atexit(restore_terminal);
+  for (int sig : {SIGINT, SIGTERM, SIGHUP, SIGQUIT})
+    signal(sig, signal_handler);
+
+  // Switch to the alternate screen buffer so the game does not scribble image
+  // data over the user's shell history; leaving it on exit restores what was
+  // there before.  Images painted here belong to the alt buffer and are
+  // discarded on switch-back in the common terminals (xterm, foot, WezTerm,
+  // mlterm, ...).
+  static const char enter_alt[] = "\x1b[?1049h";
+  terminal_write(enter_alt, sizeof(enter_alt) - 1);
+  g_alt_screen = true;
+
+  static const char hide_cursor[] = "\x1b[?25l";
+  terminal_write(hide_cursor, sizeof(hide_cursor) - 1);
+}
+
+void flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+  if (lv_display_flush_is_last(disp) && g_encode) {
+    const int w = lv_area_get_width(area);
+    const int h = lv_area_get_height(area);
+    g_encode(w, h, g_scale, reinterpret_cast<const uint16_t*>(px_map));
+  }
+  lv_display_flush_ready(disp);
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard input
+// ---------------------------------------------------------------------------
+void send_key(mrb_state* M, int key, bool press) {
+  RClass* rgss = mrb_module_get(M, "RGSS");
+  if (!rgss)
+    return;
+  RClass* input = mrb_module_get_under(M, rgss, "Input");
+  if (!input)
+    return;
+  mrb_funcall(M, mrb_obj_value(input), press ? "press" : "release", 1,
+              mrb_fixnum_value(key));
+}
+
+void hold_key(mrb_state* M, int key, uint32_t now) {
+  if (key < 0)
+    return;
+  if (!g_keys[key].pressed) {
+    g_keys[key].pressed = true;
+    send_key(M, key, true);
+  }
+  g_keys[key].expiry = now + HOLD_MS;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+void terminal_write(const char* p, size_t n) {
+  while (n > 0) {
+    const ssize_t w = ::write(STDOUT_FILENO, p, n);
+    if (w <= 0) {
+      if (w < 0 && errno == EINTR)
+        continue;
+      break;
+    }
+    p += w;
+    n -= static_cast<size_t>(w);
+  }
+}
+
+// Exported so the mruby-rgss gem (Graphics.update) can drive input polling
+// without a compile-time dependency on this translation unit.
+extern "C" void rgss_terminal_poll(mrb_state* M) {
+  terminal_poll(M);
+}
+
+void terminal_poll(mrb_state* M) {
+  if (!g_active || !g_have_tty)
+    return;
+
+  const uint32_t now = now_ms();
+
+  std::vector<char> buf;
+  char chunk[64];
+  for (;;) {
+    const ssize_t n = ::read(STDIN_FILENO, chunk, sizeof(chunk));
+    if (n <= 0)
+      break;
+    buf.insert(buf.end(), chunk, chunk + n);
+    if (static_cast<size_t>(n) < sizeof(chunk))
+      break;
+  }
+
+  for (size_t i = 0; i < buf.size();) {
+    const unsigned char c = static_cast<unsigned char>(buf[i]);
+    if (c == 0x1b && i + 2 < buf.size() && buf[i + 1] == '[') {
+      switch (buf[i + 2]) {
+        case 'A':
+          hold_key(M, KEY_UP, now);
+          break;
+        case 'B':
+          hold_key(M, KEY_DOWN, now);
+          break;
+        case 'C':
+          hold_key(M, KEY_RIGHT, now);
+          break;
+        case 'D':
+          hold_key(M, KEY_LEFT, now);
+          break;
+        default:
+          break;
+      }
+      i += 3;
+      continue;
+    }
+
+    switch (c) {
+      case 'w':
+      case 'W':
+        hold_key(M, KEY_UP, now);
+        break;
+      case 's':
+      case 'S':
+        hold_key(M, KEY_DOWN, now);
+        break;
+      case 'a':
+      case 'A':
+        hold_key(M, KEY_LEFT, now);
+        break;
+      case 'd':
+      case 'D':
+        hold_key(M, KEY_RIGHT, now);
+        break;
+      case 'z':
+      case 'Z':
+      case '\r':
+      case '\n':
+      case ' ':
+        hold_key(M, KEY_C, now);
+        break;
+      case 'x':
+      case 'X':
+      case 0x1b:  // 'x' or bare ESC = cancel
+        hold_key(M, KEY_B, now);
+        break;
+      case 'c':
+      case 'C':
+        hold_key(M, KEY_A, now);
+        break;
+      case 'q':
+      case 0x03:  // 'q' or Ctrl-C = quit
+        restore_terminal();
+        std::exit(0);
+        break;
+      default:
+        break;
+    }
+    ++i;
+  }
+
+  // Auto-release keys whose hold window has elapsed.
+  for (int k = 0; k < static_cast<int>(sizeof(g_keys) / sizeof(g_keys[0]));
+       ++k) {
+    if (g_keys[k].pressed &&
+        static_cast<int32_t>(now - g_keys[k].expiry) >= 0) {
+      g_keys[k].pressed = false;
+      send_key(M, k, false);
+    }
+  }
+}
+
+lv_display_t* terminal_display_create(int32_t hor_res,
+                                      int32_t ver_res,
+                                      int scale,
+                                      terminal_encode_fn encode) {
+  g_scale = scale < 1 ? 1 : scale;
+  g_encode = encode;
+
+  lv_tick_set_cb(now_ms);
+  lv_delay_set_cb(delay_ms);
+
+  lv_display_t* disp = lv_display_create(hor_res, ver_res);
+  if (!disp)
+    return nullptr;
+
+  lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
+  const uint32_t buf_size =
+      static_cast<uint32_t>(hor_res) * ver_res * sizeof(uint16_t);
+  g_fb.assign(buf_size, 0);
+  lv_display_set_buffers(disp, g_fb.data(), nullptr, buf_size,
+                         LV_DISPLAY_RENDER_MODE_FULL);
+  lv_display_set_flush_cb(disp, flush_cb);
+
+  init_terminal();
+  g_active = true;
+  return disp;
+}

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -2,6 +2,7 @@
 
 #include <cerrno>
 #include <csignal>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
@@ -46,6 +47,15 @@ bool g_termios_saved = false;
 
 // Full-screen render buffer handed to LVGL (RENDER_MODE_FULL, RGB565).
 std::vector<uint8_t> g_fb;
+
+// Emit-rate statistics: how many bytes the active encoder pushes to the
+// terminal, printed to stderr about once a second.  On by default; toggled with
+// --term_stats.
+bool g_stats = true;
+uint64_t g_stats_bytes = 0;   // bytes written to the terminal this interval
+uint32_t g_stats_frames = 0;  // frames emitted this interval
+uint32_t g_stats_last_ms = 0;
+bool g_stats_started = false;
 
 struct KeyState {
   bool pressed = false;
@@ -137,11 +147,42 @@ void init_terminal() {
   terminal_write(hide_cursor, sizeof(hide_cursor) - 1);
 }
 
+// Once per ~second, print the emit rate (bytes the encoder pushed to the
+// terminal) to stderr and reset the interval counters.  stderr is used so the
+// numbers do not land in the stdout image stream; redirect it (2>stats.log) to
+// keep them off the game screen.
+void maybe_report_stats(uint32_t now) {
+  if (!g_stats)
+    return;
+  if (!g_stats_started) {  // anchor the first interval; don't report a partial
+    g_stats_started = true;
+    g_stats_last_ms = now;
+    return;
+  }
+  const uint32_t dt = now - g_stats_last_ms;
+  if (dt < 1000)
+    return;
+  const double secs = dt / 1000.0;
+  const double mbps = static_cast<double>(g_stats_bytes) / secs / (1024 * 1024);
+  const double fps = g_stats_frames / secs;
+  const double kb_per_frame =
+      g_stats_frames
+          ? static_cast<double>(g_stats_bytes) / g_stats_frames / 1024.0
+          : 0.0;
+  std::fprintf(stderr, "[term_stats] %.1f KB/frame  %.2f MB/s  %.1f fps\n",
+               kb_per_frame, mbps, fps);
+  g_stats_bytes = 0;
+  g_stats_frames = 0;
+  g_stats_last_ms = now;
+}
+
 void flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
   if (lv_display_flush_is_last(disp) && g_encode) {
     const int w = lv_area_get_width(area);
     const int h = lv_area_get_height(area);
     g_encode(w, h, g_scale, reinterpret_cast<const uint16_t*>(px_map));
+    ++g_stats_frames;
+    maybe_report_stats(now_ms());
   }
   lv_display_flush_ready(disp);
 }
@@ -175,7 +216,13 @@ void hold_key(mrb_state* M, int key, uint32_t now) {
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+void terminal_set_stats(bool enabled) {
+  g_stats = enabled;
+}
+
 void terminal_write(const char* p, size_t n) {
+  if (g_stats)
+    g_stats_bytes += n;
   while (n > 0) {
     const ssize_t w = ::write(STDOUT_FILENO, p, n);
     if (w <= 0) {

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -233,8 +233,10 @@ void terminal_append_legend(std::string& s) {
   // where it can never be overdrawn -- unlike positioning it after the image,
   // whose end-cursor location is not portable and left the legend overlapping
   // the bottom of the frame.  \x1b[K clears any stale text from the previous
-  // frame and the dim SGR keeps the legend visually secondary to the game.
-  s += "\x1b[K\x1b[2m";
+  // frame; reverse video (SGR 7) renders the row as a status bar that stays
+  // legible on any terminal background -- a dim foreground (SGR 2) was too
+  // faint to read on light themes.
+  s += "\x1b[K\x1b[7m";
   s += "Move: Arrows/WASD  OK: Z/Enter/Space  Cancel: X/Esc  A: C  Quit: Q";
   s += "\x1b[0m\r\n";
 }
@@ -246,10 +248,11 @@ void terminal_append_stats(std::string& s) {
   // dropped).  No-op when stats are disabled so the row is not reserved.  The
   // row is always emitted once stats are on -- with a placeholder for the first
   // second before a rate has been measured -- so the image never shifts down a
-  // row when the first sample arrives.
+  // row when the first sample arrives.  Reverse video (SGR 7) matches the
+  // legend so both stay legible on any terminal background.
   if (!g_stats)
     return;
-  s += "\x1b[K\x1b[2m";
+  s += "\x1b[K\x1b[7m";
   s += g_stats_line.empty() ? "term_stats: measuring..." : g_stats_line;
   s += "\x1b[0m\r\n";
 }

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -16,6 +16,7 @@
 #include <ng-log/logging.h>
 #include <inicpp.hpp>
 
+#include "iterm.hxx"
 #include "sixel.hxx"
 
 #ifdef __EMSCRIPTEN__
@@ -33,6 +34,14 @@ DEFINE_bool(sixel,
 DEFINE_int32(sixel_scale,
              1,
              "Integer upscale factor for the sixel terminal output");
+DEFINE_bool(iterm,
+            false,
+            "Render to the terminal using iTerm2's inline-image protocol "
+            "instead of opening an SDL window (works in iTerm2, WezTerm and "
+            "VS Code's integrated terminal)");
+DEFINE_int32(iterm_scale,
+             1,
+             "Integer upscale factor for the iTerm2 terminal output");
 
 namespace {
 
@@ -144,10 +153,19 @@ int main(int argc, char** argv) {
 
   lv_init();
 
+  CHECK(!(FLAGS_sixel && FLAGS_iterm))
+      << "--sixel and --iterm are mutually exclusive; pick one terminal "
+         "backend";
+
   std::shared_ptr<lv_display_t> display;
   if (FLAGS_sixel) {
     display = std::shared_ptr<lv_display_t>(
         sixel_display_create(FLAGS_width, FLAGS_height, FLAGS_sixel_scale),
+        [](lv_display_t*) {});
+    CHECK(display);
+  } else if (FLAGS_iterm) {
+    display = std::shared_ptr<lv_display_t>(
+        iterm_display_create(FLAGS_width, FLAGS_height, FLAGS_iterm_scale),
         [](lv_display_t*) {});
     CHECK(display);
   } else {

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -18,6 +18,7 @@
 
 #include "iterm.hxx"
 #include "sixel.hxx"
+#include "terminal.hxx"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -42,6 +43,11 @@ DEFINE_bool(iterm,
 DEFINE_int32(iterm_scale,
              1,
              "Integer upscale factor for the iTerm2 terminal output");
+DEFINE_bool(term_stats,
+            true,
+            "While a terminal backend (--sixel/--iterm) is active, print the "
+            "emit rate (frame size, MB/s, fps) to stderr about once a second; "
+            "redirect stderr (2>stats.log) to keep it off the game screen");
 
 namespace {
 
@@ -156,6 +162,8 @@ int main(int argc, char** argv) {
   CHECK(!(FLAGS_sixel && FLAGS_iterm))
       << "--sixel and --iterm are mutually exclusive; pick one terminal "
          "backend";
+
+  terminal_set_stats(FLAGS_term_stats);
 
   std::shared_ptr<lv_display_t> display;
   if (FLAGS_sixel) {

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -43,11 +43,12 @@ DEFINE_bool(iterm,
 DEFINE_int32(iterm_scale,
              1,
              "Integer upscale factor for the iTerm2 terminal output");
-DEFINE_bool(term_stats,
-            true,
-            "While a terminal backend (--sixel/--iterm) is active, print the "
-            "emit rate (frame size, MB/s, fps) to stderr about once a second; "
-            "redirect stderr (2>stats.log) to keep it off the game screen");
+DEFINE_bool(
+    term_stats,
+    true,
+    "While a terminal backend (--sixel/--iterm) is active, draw the "
+    "emit rate (frame size, MB/s, fps) on-screen just under the control "
+    "legend, refreshed about once a second");
 
 namespace {
 


### PR DESCRIPTION
## Summary

Adds a new terminal display backend that renders frames using iTerm2's inline-image protocol (OSC 1337), complementing the existing sixel backend. This enables the game to run in terminals that lack sixel support, notably VS Code's integrated terminal.

## Key Changes

- **New `terminal.cxx` module**: Extracted shared terminal infrastructure from `sixel.cxx` into a reusable core that handles:
  - LVGL display creation with RGB565 full-screen buffering
  - Monotonic clock tick/delay sources (replacing SDL dependencies)
  - Raw-mode terminal setup, alternate-screen switching, and restoration on exit/signals
  - Keyboard input polling and forwarding to `RGSS::Input`
  - Generic frame encoder callback interface

- **New `iterm.cxx` backend**: Implements iTerm2 protocol encoding:
  - Expands RGB565 frames to RGB888 with integer nearest-neighbour upscaling
  - PNG-encodes frames using `stb_image_write` (already vendored)
  - Base64-encodes PNG and wraps in OSC 1337 sequence
  - Cursor-home prefix allows frames to overdraw in place

- **Refactored `sixel.cxx`**: Now contains only sixel-specific encoding logic; delegates display creation and input handling to the shared terminal backend

- **New public API** (`terminal.hxx`):
  - `terminal_display_create()`: Creates a display with a custom encoder callback
  - `terminal_poll()`: Polls keyboard input (exported as `rgss_terminal_poll` for mruby integration)
  - `terminal_write()`: Writes bytes to terminal with EINTR/partial-write handling

- **CLI flags**: Added `--iterm` and `--iterm_scale` flags; `--sixel` and `--iterm` are mutually exclusive

## Implementation Details

- The iTerm2 encoder trades PNG deflate CPU cost per frame for better compression on typical RPG Maker content (flat tiles/sprites), resulting in lower bandwidth than sixel in many cases
- PNG compression level set to 6 (vs stb's default 8) to favour encode latency on the game loop
- Both sixel and iTerm2 backends now share identical input handling, timing, and terminal lifecycle management, ensuring consistent behaviour
- The shared terminal core is built into the `mruby-rgss` gem and exported for use by `Graphics.update`

## Consequences

- Game can now run in VS Code's integrated terminal (xterm.js), iTerm2, and WezTerm via `--iterm`
- Full 24-bit colour on iTerm2 path (no sixel's 216-colour palette quantization)
- Sixel and iTerm2 backends remain mutually exclusive; SDL is still the default

https://claude.ai/code/session_01Tu3a67EchZJSpcmJJmjSTV