### PR TITLE
Implement Viewport as a functional display object with z-ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `RGSS::Viewport` is now a functional display object rather than a stub: it
+  wraps an LVGL container that positions and **clips** its sprites to a `rect`,
+  scrolls their content by `ox`/`oy`, hides via `visible`, and takes part in
+  `z` ordering against top-level sprites. Sprites created with
+  `Sprite.new(viewport)` are parented to it, and z ordering is now resolved
+  per LVGL parent so sprites inside a viewport stack among themselves while the
+  viewport stacks on the screen. LVGL delete events invalidate the mruby
+  wrappers so a viewport can safely own (and free) its child sprites
+- `RGSS::Sprite` / `RGSS::Viewport` gained a `visible` / `visible=` accessor
+
+### Changed
+- `RGSS::Window` is now assembled from three layered sprites inside a viewport
+  (windowskin background+frame, selection cursor, and contents/text) instead of
+  compositing everything into one sprite's bitmap. The viewport clips the layers
+  to the window rectangle, and updating the cursor or text no longer re-blits
+  the windowskin
 - Playable gameplay after "New Game": `RPG2k#start_new_game` builds the party
   (`Game::Party`/`Game::Actor`) from the database, reads the start position from
   the map tree, loads the starting map and enters a walkable `Scene::Map`. The

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -69,8 +69,9 @@ The work below is roughly ordered by the critical path to a walkable game
   still simplified to a once-per-visit start
 - 🚧 Screen effects — the game **timer** works (Timer Operation command +
   `Game::State` countdown); transitions/fade, tint, flash, shake, Show Picture
-  and weather remain. Most of these need new `RGSS::Sprite`/`Viewport` support
-  in C++ (opacity, tone, flash) before they can be driven from Ruby
+  and weather remain. `RGSS::Viewport` now exists (position/clip/scroll/z), but
+  most of these still need more `RGSS::Sprite`/`Viewport` support in C++
+  (opacity, tone, flash) before they can be driven from Ruby
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1082,8 +1082,8 @@ void vp_apply(mrb_state* M, mrb_value self) {
   lv_obj_t* outer = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
   if (!outer)
     return;
-  Rect& r = DataType<Rect>::get(
-      M, mrb_iv_get(M, self, mrb_intern_lit(M, "@rect")));
+  Rect& r =
+      DataType<Rect>::get(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@rect")));
   const mrb_int w = std::max<mrb_int>(r.width, 0);
   const mrb_int h = std::max<mrb_int>(r.height, 0);
   lv_obj_set_pos(outer, r.x, r.y);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -809,11 +809,13 @@ mrb_value obj_dispose(mrb_state* M, mrb_value self) {
   return mrb_nil_value();
 }
 
-// Array of top-level display objects (Sprites) whose stacking order is driven
-// by their `z` attribute. Populated lazily by rgss_set_display / add_root_obj.
-mrb_value root_objs(mrb_state* M) {
+// Array of z-ordered display objects (Sprites and Viewports). Stacking is
+// resolved per LVGL parent: sprites sharing a parent (the screen, or a
+// Viewport's content layer) are ordered among themselves by their `z`.
+// Populated by register_zobj.
+mrb_value zorder_objs(mrb_state* M) {
   const mrb_value mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
-  const mrb_value ret = mrb_const_get(M, mod, mrb_intern_lit(M, "_roots"));
+  const mrb_value ret = mrb_const_get(M, mod, mrb_intern_lit(M, "_zobjs"));
   mrb_assert(mrb_array_p(ret));
   return ret;
 }
@@ -850,26 +852,31 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
   }
 
   // Reapply z ordering when something changed since the last frame. LVGL draws
-  // siblings in child order, so we sort the live roots by their `z` and move
-  // them to the foreground from lowest to highest, leaving the greatest `z` on
-  // top. Disposed sprites (null DATA_PTR) are dropped from the root set here so
+  // siblings in child order, so within each LVGL parent we sort that parent's
+  // z-managed objects by `z` and move them to the foreground from lowest to
+  // highest, leaving the greatest `z` on top. Grouping by parent means sprites
+  // that live inside a Viewport are ordered among themselves, while the
+  // Viewport (and top-level sprites) are ordered against each other on the
+  // screen. Disposed objects (null DATA_PTR) are dropped from the set here so
   // it does not grow unbounded.
   if (mrb_bool(mrb_iv_get(M, rgss_mod, mrb_intern_lit(M, "_z_updated")))) {
-    const mrb_value roots = root_objs(M);
+    const mrb_value objs = zorder_objs(M);
     const mrb_value live = mrb_ary_new(M);
-    std::multimap<mrb_int, lv_obj_t*> orders;
-    for (mrb_int i = 0; i < RARRAY_LEN(roots); ++i) {
-      const mrb_value v = RARRAY_PTR(roots)[i];
+    std::map<lv_obj_t*, std::multimap<mrb_int, lv_obj_t*>> by_parent;
+    for (mrb_int i = 0; i < RARRAY_LEN(objs); ++i) {
+      const mrb_value v = RARRAY_PTR(objs)[i];
       if (!DATA_PTR(v))
         continue;
       mrb_ary_push(M, live, v);
+      lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(v));
       const mrb_value z = mrb_iv_get(M, v, mrb_intern_lit(M, "@z"));
       mrb_assert(mrb_fixnum_p(z));
-      orders.insert({mrb_fixnum(z), reinterpret_cast<lv_obj_t*>(DATA_PTR(v))});
+      by_parent[lv_obj_get_parent(obj)].insert({mrb_fixnum(z), obj});
     }
-    mrb_const_set(M, rgss_mod, mrb_intern_lit(M, "_roots"), live);
-    for (const auto& order : orders)
-      lv_obj_move_foreground(order.second);
+    mrb_const_set(M, rgss_mod, mrb_intern_lit(M, "_zobjs"), live);
+    for (const auto& group : by_parent)
+      for (const auto& order : group.second)
+        lv_obj_move_foreground(order.second);
     mrb_iv_set(M, rgss_mod, mrb_intern_lit(M, "_z_updated"), mrb_false_value());
   }
 
@@ -939,17 +946,44 @@ lv_display_t* get_display(mrb_state* M) {
 
 const mrb_data_type obj_type = {"lv_obj_t", free_obj};
 
+// LVGL fires LV_EVENT_DELETE when an object is destroyed, including when its
+// parent is deleted and takes the whole subtree with it. Each wrapped object
+// stores its mruby RData in user_data; null the data pointer here so the mruby
+// wrapper (and its later dispose/GC) never calls lv_obj_delete on a freed
+// object. This is what makes it safe to nest Sprites inside a Viewport that
+// owns them: whichever wrapper the GC frees first, the others are invalidated.
+void on_lv_delete(lv_event_t* e) {
+  lv_obj_t* obj = static_cast<lv_obj_t*>(lv_event_get_target(e));
+  if (void* ud = lv_obj_get_user_data(obj))
+    static_cast<struct RData*>(ud)->data = nullptr;
+}
+
+// Bind an lv_obj to its mruby wrapper: record the wrapper in user_data and hook
+// the delete event so the wrapper is invalidated if LVGL frees the object.
+void wrap_lv_obj(mrb_state* M, mrb_value self, lv_obj_t* obj) {
+  mrb_data_init(self, obj, &obj_type);
+  lv_obj_set_user_data(obj, mrb_ptr(self));
+  lv_obj_add_event_cb(obj, on_lv_delete, LV_EVENT_DELETE, nullptr);
+}
+
+// A Viewport wraps an outer clipping frame whose sole child is an inner content
+// layer that actually holds the sprites; new sprites parent to that layer so
+// they are clipped to the viewport and scrolled by its ox/oy.
+lv_obj_t* viewport_content(lv_obj_t* outer) {
+  return lv_obj_get_child(outer, 0);
+}
+
 lv_obj_t* parent_object(mrb_state* M, mrb_value vp) {
   if (mrb_nil_p(vp))
     return lv_display_get_screen_active(get_display(M));
 
   mrb_assert(mrb_type(vp) == MRB_TT_DATA && DATA_TYPE(vp) == &obj_type);
-  return reinterpret_cast<lv_obj_t*>(DATA_PTR(vp));
+  return viewport_content(reinterpret_cast<lv_obj_t*>(DATA_PTR(vp)));
 }
 
-// Register a display object as a z-ordered root and give it a default z of 0.
-void add_root_obj(mrb_state* M, mrb_value v) {
-  mrb_ary_push(M, root_objs(M), v);
+// Register a display object for z-ordering and give it a default z of 0.
+void register_zobj(mrb_state* M, mrb_value v) {
+  mrb_ary_push(M, zorder_objs(M), v);
   mrb_iv_set(M, v, mrb_intern_lit(M, "@x"), mrb_fixnum_value(0));
   mrb_iv_set(M, v, mrb_intern_lit(M, "@y"), mrb_fixnum_value(0));
   mrb_iv_set(M, v, mrb_intern_lit(M, "@z"), mrb_fixnum_value(0));
@@ -961,8 +995,10 @@ mrb_value spr_init(mrb_state* M, mrb_value self) {
   mrb_get_args(M, "|o", &vp);
 
   lv_obj_t* p = lv_canvas_create(parent_object(M, vp));
-  mrb_data_init(self, p, &obj_type);
-  add_root_obj(M, self);
+  wrap_lv_obj(M, self, p);
+  register_zobj(M, self);
+  // Keep the viewport alive as long as the sprite refers to it.
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@viewport"), vp);
   return self;
 }
 
@@ -1009,10 +1045,144 @@ mrb_value obj_set_z(mrb_state* M, mrb_value self) {
   return self;
 }
 
-mrb_value vp_init(mrb_state* M, mrb_value self) {
-  lv_obj_t* p = lv_canvas_create(lv_display_get_screen_active(get_display(M)));
-  mrb_data_init(self, p, &obj_type);
+// Shared visible= for Sprite and Viewport: LVGL's HIDDEN flag also hides the
+// whole child subtree, so hiding a Viewport hides everything drawn in it.
+mrb_value obj_set_visible(mrb_state* M, mrb_value self) {
+  mrb_bool v;
+  mrb_get_args(M, "b", &v);
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  if (v)
+    lv_obj_remove_flag(obj, LV_OBJ_FLAG_HIDDEN);
+  else
+    lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@visible"), mrb_bool_value(v));
   return self;
+}
+
+mrb_value obj_visible(mrb_state* M, mrb_value self) {
+  mrb_value v = mrb_iv_get(M, self, mrb_intern_lit(M, "@visible"));
+  return mrb_nil_p(v) ? mrb_true_value() : v;
+}
+
+// ---- Viewport -------------------------------------------------------------
+
+// Build an RGSS::Rect value.
+mrb_value make_rect(mrb_state* M, mrb_int x, mrb_int y, mrb_int w, mrb_int h) {
+  const mrb_value args[] = {mrb_fixnum_value(x), mrb_fixnum_value(y),
+                            mrb_fixnum_value(w), mrb_fixnum_value(h)};
+  return mrb_obj_new(
+      M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Rect"), 4, args);
+}
+
+// Push the stored @rect / @ox / @oy onto the underlying LVGL objects: the outer
+// frame takes the rect's position and size (and clips to it), while the inner
+// content layer is shifted by (-ox, -oy) to scroll its sprites.
+void vp_apply(mrb_state* M, mrb_value self) {
+  lv_obj_t* outer = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  if (!outer)
+    return;
+  Rect& r = DataType<Rect>::get(
+      M, mrb_iv_get(M, self, mrb_intern_lit(M, "@rect")));
+  const mrb_int w = std::max<mrb_int>(r.width, 0);
+  const mrb_int h = std::max<mrb_int>(r.height, 0);
+  lv_obj_set_pos(outer, r.x, r.y);
+  lv_obj_set_size(outer, w, h);
+
+  lv_obj_t* inner = viewport_content(outer);
+  const mrb_value ox = mrb_iv_get(M, self, mrb_intern_lit(M, "@ox"));
+  const mrb_value oy = mrb_iv_get(M, self, mrb_intern_lit(M, "@oy"));
+  lv_obj_set_pos(inner, -(mrb_fixnum_p(ox) ? mrb_fixnum(ox) : 0),
+                 -(mrb_fixnum_p(oy) ? mrb_fixnum(oy) : 0));
+  lv_obj_set_size(inner, w, h);
+}
+
+mrb_value vp_init(mrb_state* M, mrb_value self) {
+  // Viewport.new(x, y, width, height) | Viewport.new(rect) | Viewport.new
+  // (the last covering the whole screen, matching RGSS).
+  mrb_int x = 0, y = 0, w = 0, h = 0;
+  const mrb_int argc = mrb_get_argc(M);
+  if (argc == 1) {
+    mrb_value rv;
+    mrb_get_args(M, "o", &rv);
+    Rect& r = DataType<Rect>::get(M, rv);
+    x = r.x;
+    y = r.y;
+    w = r.width;
+    h = r.height;
+  } else if (argc >= 4) {
+    mrb_get_args(M, "iiii", &x, &y, &w, &h);
+  } else {
+    lv_display_t* d = get_display(M);
+    w = lv_display_get_horizontal_resolution(d);
+    h = lv_display_get_vertical_resolution(d);
+  }
+
+  lv_obj_t* screen = lv_display_get_screen_active(get_display(M));
+  lv_obj_t* outer = lv_obj_create(screen);
+  lv_obj_remove_style_all(outer);
+  lv_obj_remove_flag(outer, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(outer, LV_SCROLLBAR_MODE_OFF);
+
+  // Inner content layer: children beyond the viewport bounds must survive here
+  // (only the outer frame clips), so let it overflow.
+  lv_obj_t* inner = lv_obj_create(outer);
+  lv_obj_remove_style_all(inner);
+  lv_obj_remove_flag(inner, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_add_flag(inner, LV_OBJ_FLAG_OVERFLOW_VISIBLE);
+
+  wrap_lv_obj(M, self, outer);
+  register_zobj(M, self);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@rect"), make_rect(M, x, y, w, h));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(0));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(0));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@visible"), mrb_true_value());
+  vp_apply(M, self);
+  return self;
+}
+
+mrb_value vp_rect(mrb_state* M, mrb_value self) {
+  return mrb_iv_get(M, self, mrb_intern_lit(M, "@rect"));
+}
+
+mrb_value vp_set_rect(mrb_state* M, mrb_value self) {
+  mrb_value rv;
+  mrb_get_args(M, "o", &rv);
+  Rect& r = DataType<Rect>::get(M, rv);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@rect"),
+             make_rect(M, r.x, r.y, r.width, r.height));
+  vp_apply(M, self);
+  return rv;
+}
+
+mrb_value vp_ox(mrb_state* M, mrb_value self) {
+  return mrb_iv_get(M, self, mrb_intern_lit(M, "@ox"));
+}
+
+mrb_value vp_oy(mrb_state* M, mrb_value self) {
+  return mrb_iv_get(M, self, mrb_intern_lit(M, "@oy"));
+}
+
+mrb_value vp_set_ox(mrb_state* M, mrb_value self) {
+  mrb_int v;
+  mrb_get_args(M, "i", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(v));
+  vp_apply(M, self);
+  return mrb_fixnum_value(v);
+}
+
+mrb_value vp_set_oy(mrb_state* M, mrb_value self) {
+  mrb_int v;
+  mrb_get_args(M, "i", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(v));
+  vp_apply(M, self);
+  return mrb_fixnum_value(v);
+}
+
+// Present so the game loop can drive per-frame behaviour (flash, etc.); no
+// animated viewport effects are modelled yet, so this is a no-op.
+mrb_value vp_update(mrb_state* M, mrb_value self) {
+  return mrb_nil_value();
 }
 
 // Register x/y/width/height accessors for the Rect class.
@@ -1171,12 +1341,22 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
 
   mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_game_start"),
                 mrb_fixnum_value(lv_tick_get()));
-  mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_roots"),
+  mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_zobjs"),
                 mrb_ary_new(M));
 
   RClass* vp = mrb_define_class_under(M, m, "Viewport", M->object_class);
   MRB_SET_INSTANCE_TT(vp, MRB_TT_DATA);
-  mrb_define_method(M, vp, "initialize", vp_init, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "initialize", vp_init, MRB_ARGS_OPT(4));
+  mrb_define_method(M, vp, "rect", vp_rect, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "rect=", vp_set_rect, MRB_ARGS_REQ(1));
+  mrb_define_method(M, vp, "ox", vp_ox, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "oy", vp_oy, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "ox=", vp_set_ox, MRB_ARGS_REQ(1));
+  mrb_define_method(M, vp, "oy=", vp_set_oy, MRB_ARGS_REQ(1));
+  mrb_define_method(M, vp, "z=", obj_set_z, MRB_ARGS_REQ(1));
+  mrb_define_method(M, vp, "visible", obj_visible, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "visible=", obj_set_visible, MRB_ARGS_REQ(1));
+  mrb_define_method(M, vp, "update", vp_update, MRB_ARGS_NONE());
   mrb_define_method(M, vp, "dispose", obj_dispose, MRB_ARGS_NONE());
   mrb_define_method(M, vp, "disposed?", obj_disposed, MRB_ARGS_NONE());
 
@@ -1189,6 +1369,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "x=", obj_set_x, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "y=", obj_set_y, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "z=", obj_set_z, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "visible", obj_visible, MRB_ARGS_NONE());
+  mrb_define_method(M, spr, "visible=", obj_set_visible, MRB_ARGS_REQ(1));
 
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -886,7 +886,7 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
   // cleared only after the whole sweep so a bitmap shared by several sprites
   // invalidates all of them.
   {
-    const mrb_value roots = root_objs(M);
+    const mrb_value roots = zorder_objs(M);
     const mrb_sym bitmap_sym = mrb_intern_lit(M, "@bitmap");
     for (mrb_int i = 0; i < RARRAY_LEN(roots); ++i) {
       const mrb_value v = RARRAY_PTR(roots)[i];

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -145,6 +145,20 @@ assert "RGSS::Bitmap stretch_blt" do
   assert_equal 0.0, dst.get_pixel(6, 6).alpha
 end
 
+assert "RGSS::Viewport API surface" do
+  # Viewport creation needs a live display, which the test binary does not set
+  # up, so only assert the method surface here (exercised for real by the game).
+  %i[rect rect= ox oy ox= oy= z= visible visible= update dispose disposed?].each do |m|
+    assert_true RGSS::Viewport.method_defined?(m), "Viewport##{m} missing"
+  end
+end
+
+assert "RGSS::Sprite API surface" do
+  %i[bitmap= x= y= z= visible visible= dispose disposed?].each do |m|
+    assert_true RGSS::Sprite.method_defined?(m), "Sprite##{m} missing"
+  end
+end
+
 assert "RGSS::Font defaults" do
   f = RGSS::Font.new
   assert_equal RGSS::Font.default_name, f.name

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -9,15 +9,25 @@ module RGSS
   #   (0, 0, 32, 32)   background fill (stretched over the interior)
   #   (32, 0, 32, 32)  8px-thick frame border, split into 4 corners and 4 edges
   #
-  # Background, frame, the selection cursor and the window contents are all
-  # composited into a single Bitmap that backs one Sprite.
+  # The window is a Viewport that clips its contents to the window rectangle.
+  # Rather than compositing everything into one Bitmap, three separate Sprites
+  # are layered inside the viewport by their `z`: the windowskin (background +
+  # frame), the selection cursor, and the contents (text and other graphics
+  # drawn by callers). Keeping them apart means updating the cursor or the text
+  # no longer forces the skin to be re-blitted.
   class Window
     # Windows are drawn above ordinary background sprites (which default to
-    # z == 0), so give the backing sprite a high z by default.
+    # z == 0), so give the backing viewport a high z by default.
     DEFAULT_Z = 100
 
     # Thickness of the RPG2k frame border, in pixels.
     BORDER = 8
+
+    # z of each layer within the window's viewport (skin at the back, text on
+    # top, cursor highlight sandwiched between them).
+    SKIN_Z = 0
+    CURSOR_Z = 1
+    CONTENTS_Z = 2
 
     def initialize(x = 0, y = 0, width = 0, height = 0)
       @x = x
@@ -29,11 +39,22 @@ module RGSS
       @cursor_rect = Rect.new(0, 0, 0, 0)
       @active = true
       @visible = true
-      # Back the window with a Sprite so its contents are actually drawn.
-      @sprite = Sprite.new
-      @sprite.x = x
-      @sprite.y = y
-      @sprite.z = DEFAULT_Z
+
+      # The viewport groups and clips the three layers to the window rect.
+      @viewport = Viewport.new(x, y, [width, 1].max, [height, 1].max)
+      @viewport.z = DEFAULT_Z
+
+      @skin_sprite = Sprite.new(@viewport)
+      @skin_sprite.z = SKIN_Z
+      @cursor_sprite = Sprite.new(@viewport)
+      @cursor_sprite.z = CURSOR_Z
+      # Contents are drawn inside the frame, so offset the sprite by the border.
+      @contents_sprite = Sprite.new(@viewport)
+      @contents_sprite.z = CONTENTS_Z
+      @contents_sprite.x = BORDER
+      @contents_sprite.y = BORDER
+      @contents_sprite.visible = false
+
       allocate_skin
     end
 
@@ -42,54 +63,57 @@ module RGSS
 
     def x=(v)
       @x = v
-      @sprite.x = v
+      update_rect
     end
 
     def y=(v)
       @y = v
-      @sprite.y = v
+      update_rect
     end
 
     def z=(v)
-      @sprite.z = v
+      @viewport.z = v
     end
 
     def width=(v)
       @width = v
       allocate_skin
+      update_rect
     end
 
     def height=(v)
       @height = v
       allocate_skin
+      update_rect
     end
 
     def windowskin=(bmp)
       @windowskin = bmp
-      redraw
+      draw_skin
       bmp
     end
 
     def contents=(bmp)
       @contents = bmp
-      redraw
+      @contents_sprite.visible = !bmp.nil?
+      @contents_sprite.bitmap = bmp if bmp
       bmp
     end
 
     def cursor_rect=(rect)
       @cursor_rect = rect
-      redraw
+      draw_cursor
       rect
     end
 
     def active=(v)
       @active = v
-      redraw
+      draw_cursor
     end
 
     def visible=(v)
       @visible = v
-      redraw
+      @viewport.visible = v
     end
 
     # Present so the game loop can drive per-frame behaviour (cursor blinking,
@@ -97,38 +121,46 @@ module RGSS
     def update; end
 
     def dispose
-      @sprite.dispose
+      # Dispose the layers before the viewport so each Sprite tears its own
+      # LVGL object down; disposing the viewport then only frees the frame.
+      [@skin_sprite, @cursor_sprite, @contents_sprite].each(&:dispose)
+      @viewport.dispose
     end
 
     private
 
-    # (Re)create the backing bitmap whenever the window is resized, then redraw.
-    def allocate_skin
-      @skin = Bitmap.new([@width, 1].max, [@height, 1].max)
-      @sprite.bitmap = @skin
-      redraw
+    # Move/resize the viewport to track the window rectangle.
+    def update_rect
+      @viewport.rect = Rect.new(@x, @y, [@width, 1].max, [@height, 1].max)
     end
 
-    def redraw
-      @skin.clear
-      return unless @visible
+    # (Re)create the skin and cursor bitmaps whenever the window is resized,
+    # then redraw both layers.
+    def allocate_skin
+      @skin_bmp = Bitmap.new([@width, 1].max, [@height, 1].max)
+      @skin_sprite.bitmap = @skin_bmp
+      @cursor_bmp = Bitmap.new([@width, 1].max, [@height, 1].max)
+      @cursor_sprite.bitmap = @cursor_bmp
+      draw_skin
+      draw_cursor
+    end
 
+    # Redraw the windowskin layer (background + frame, or the fallback panel).
+    def draw_skin
+      @skin_bmp.clear
       if @windowskin
         draw_background
         draw_frame
       else
         draw_fallback
       end
-
-      draw_cursor
-      draw_contents
     end
 
     # Stretch the 32x32 background tile over the whole window; the frame border
     # is drawn on top of its outer edge afterwards.
     def draw_background
-      @skin.stretch_blt Rect.new(0, 0, @width, @height), @windowskin,
-                        Rect.new(0, 0, 32, 32)
+      @skin_bmp.stretch_blt Rect.new(0, 0, @width, @height), @windowskin,
+                            Rect.new(0, 0, 32, 32)
     end
 
     def draw_frame
@@ -138,34 +170,38 @@ module RGSS
       sk = @windowskin
 
       # Corners (8x8, drawn 1:1).
-      @skin.blt 0, 0, sk, Rect.new(32, 0, b, b)
-      @skin.blt w - b, 0, sk, Rect.new(56, 0, b, b)
-      @skin.blt 0, h - b, sk, Rect.new(32, 24, b, b)
-      @skin.blt w - b, h - b, sk, Rect.new(56, 24, b, b)
+      @skin_bmp.blt 0, 0, sk, Rect.new(32, 0, b, b)
+      @skin_bmp.blt w - b, 0, sk, Rect.new(56, 0, b, b)
+      @skin_bmp.blt 0, h - b, sk, Rect.new(32, 24, b, b)
+      @skin_bmp.blt w - b, h - b, sk, Rect.new(56, 24, b, b)
 
       # Edges (stretched along the free axis).
-      @skin.stretch_blt Rect.new(b, 0, w - 2 * b, b), sk, Rect.new(40, 0, 16, b)
-      @skin.stretch_blt Rect.new(b, h - b, w - 2 * b, b), sk,
-                        Rect.new(40, 24, 16, b)
-      @skin.stretch_blt Rect.new(0, b, b, h - 2 * b), sk, Rect.new(32, 8, b, 16)
-      @skin.stretch_blt Rect.new(w - b, b, b, h - 2 * b), sk,
-                        Rect.new(56, 8, b, 16)
+      @skin_bmp.stretch_blt Rect.new(b, 0, w - 2 * b, b), sk,
+                            Rect.new(40, 0, 16, b)
+      @skin_bmp.stretch_blt Rect.new(b, h - b, w - 2 * b, b), sk,
+                            Rect.new(40, 24, 16, b)
+      @skin_bmp.stretch_blt Rect.new(0, b, b, h - 2 * b), sk,
+                            Rect.new(32, 8, b, 16)
+      @skin_bmp.stretch_blt Rect.new(w - b, b, b, h - 2 * b), sk,
+                            Rect.new(56, 8, b, 16)
     end
 
     # Used when no windowskin could be loaded: a plain dark panel with a light
     # border so the window is still visible.
     def draw_fallback
-      @skin.fill_rect 0, 0, @width, @height, Color.new(8, 8, 40, 224)
+      @skin_bmp.fill_rect 0, 0, @width, @height, Color.new(8, 8, 40, 224)
       edge = Color.new(200, 200, 216, 255)
-      @skin.fill_rect 0, 0, @width, 1, edge
-      @skin.fill_rect 0, @height - 1, @width, 1, edge
-      @skin.fill_rect 0, 0, 1, @height, edge
-      @skin.fill_rect @width - 1, 0, 1, @height, edge
+      @skin_bmp.fill_rect 0, 0, @width, 1, edge
+      @skin_bmp.fill_rect 0, @height - 1, @width, 1, edge
+      @skin_bmp.fill_rect 0, 0, 1, @height, edge
+      @skin_bmp.fill_rect @width - 1, 0, 1, @height, edge
     end
 
-    # Highlight box behind the selected item. cursor_rect is expressed in
-    # contents coordinates, so it is offset by the border thickness.
+    # Highlight box behind the selected item, on its own layer. cursor_rect is
+    # expressed in contents coordinates, so it is offset by the border
+    # thickness (the contents layer carries the same offset).
     def draw_cursor
+      @cursor_bmp.clear
       return unless @active
       r = @cursor_rect
       return if r.width <= 0 || r.height <= 0
@@ -175,17 +211,12 @@ module RGSS
       # brighter border, matching the reference title screen's selection box.
       x = BORDER + r.x
       y = BORDER + r.y
-      @skin.fill_rect x, y, r.width, r.height, Color.new(24, 40, 176, 255)
+      @cursor_bmp.fill_rect x, y, r.width, r.height, Color.new(24, 40, 176, 255)
       border = Color.new(180, 200, 255, 255)
-      @skin.fill_rect x, y, r.width, 1, border
-      @skin.fill_rect x, y + r.height - 1, r.width, 1, border
-      @skin.fill_rect x, y, 1, r.height, border
-      @skin.fill_rect x + r.width - 1, y, 1, r.height, border
-    end
-
-    def draw_contents
-      return unless @contents
-      @skin.blt BORDER, BORDER, @contents, @contents.rect
+      @cursor_bmp.fill_rect x, y, r.width, 1, border
+      @cursor_bmp.fill_rect x, y + r.height - 1, r.width, 1, border
+      @cursor_bmp.fill_rect x, y, 1, r.height, border
+      @cursor_bmp.fill_rect x + r.width - 1, y, 1, r.height, border
     end
   end
 end


### PR DESCRIPTION
## Summary
This PR implements `RGSS::Viewport` as a fully functional display object that can position, clip, and scroll its child sprites. It also refactors the z-ordering system to work per-parent (screen or viewport), enabling proper layering of sprites within viewports while maintaining correct stacking on the screen.

## Key Changes

### Viewport Implementation
- `Viewport` now creates an LVGL container with an outer clipping frame and inner content layer
- Supports initialization with `Rect`, individual coordinates, or defaults to screen size
- Implements `rect`, `ox`, `oy`, `z`, and `visible` accessors with proper LVGL synchronization
- Sprites created with `Sprite.new(viewport)` are parented to the viewport's content layer and clipped to its bounds
- Viewport scrolling via `ox`/`oy` offsets the inner content layer

### Z-Ordering Refactor
- Renamed `root_objs` to `zorder_objs` and `_roots` constant to `_zobjs` for clarity
- Changed z-ordering from a flat list to per-parent grouping: sprites are now sorted within their LVGL parent (screen or viewport)
- This allows sprites inside a viewport to stack among themselves while the viewport itself stacks on the screen
- Disposed objects are filtered out during z-ordering to prevent unbounded array growth

### Object Lifecycle Management
- Added `on_lv_delete` event handler to invalidate mruby wrappers when LVGL deletes objects
- Added `wrap_lv_obj` helper to bind mruby wrappers to LVGL objects with proper event hookup
- Sprites now store a reference to their viewport to keep it alive as long as the sprite exists
- Safe nesting: whichever wrapper the GC frees first, others are invalidated

### Sprite and Viewport Visibility
- Added `visible` / `visible=` accessors to both `Sprite` and `Viewport`
- Uses LVGL's `LV_OBJ_FLAG_HIDDEN` flag which also hides child subtrees
- Hiding a viewport hides all sprites drawn within it

### Window Refactoring
- `Window` now uses a `Viewport` to clip and position its contents
- Decomposed the monolithic backing bitmap into three layered sprites:
  - Windowskin (background + frame) at `z=0`
  - Selection cursor at `z=1`
  - Contents/text at `z=2`
- Each layer is now independently updatable without re-blitting the entire window
- Viewport handles clipping to the window rectangle and scrolling via `ox`/`oy`

## Implementation Details
- `viewport_content()` helper extracts the inner content layer from a viewport's outer frame
- `vp_apply()` synchronizes viewport properties (rect, ox, oy) to LVGL objects
- Z-ordering uses `std::map<lv_obj_t*, std::multimap<mrb_int, lv_obj_t*>>` to group objects by parent before reordering
- Event callbacks ensure LVGL-initiated deletions don't leave dangling mruby pointers

https://claude.ai/code/session_01YB4fpHLtQhCx85j6hRogLi