### PR TITLE
Update GitHub Actions and add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependabot configuration.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Keep the GitHub Actions used by the CI workflows up to date. This also
+  # prevents the "Node.js 20 is deprecated" runner warnings from creeping back
+  # in as actions move their runtime forward.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # The project's third-party dependencies are vendored as git submodules under
+  # 3rd/. Watch them for new upstream commits. They are grouped into a single
+  # PR to keep the noise down; review carefully since some (e.g. the mruby
+  # gems) are version-coupled.
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      submodules:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - run: git config --global submodule.fetchJobs 4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - uses: nixbuild/nix-quick-install-action@v29
       - name: Restore and cache Nix store
-        uses: nix-community/cache-nix-action@v5
+        uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -51,7 +51,7 @@ jobs:
       #   if: ${{ !startsWith(matrix.os, 'macos') }}
 
       - name: cache rtp
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: rtp-cache
         with:
           path: scripts/*.zip
@@ -75,7 +75,7 @@ jobs:
           )
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: cmake
         run: |
@@ -86,7 +86,7 @@ jobs:
           nix develop -c cmake --build build
 
       - name: cache test game
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: data
@@ -104,18 +104,18 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - run: git config --global submodule.fetchJobs 4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - uses: nixbuild/nix-quick-install-action@v29
       - name: Restore and cache Nix store
-        uses: nix-community/cache-nix-action@v5
+        uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.ccache
@@ -131,7 +131,7 @@ jobs:
         run: |
           nix develop -c cmake --build wasm-build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wasm
           path: |
@@ -143,12 +143,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: git config --global submodule.fetchJobs 4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: cache test game
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: data
@@ -156,7 +156,7 @@ jobs:
 
       - uses: nixbuild/nix-quick-install-action@v29
       - name: Restore and cache Nix store
-        uses: nix-community/cache-nix-action@v5
+        uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -173,7 +173,7 @@ jobs:
           mv ./docker-wine $HOME/.local/bin
           export PATH=$HOME/.local/bin:$PATH
           ./scripts/take_title_screenshot.bash
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: screenshots
           path: ss/
@@ -186,13 +186,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - run: git config --global submodule.fetchJobs 4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: nixbuild/nix-quick-install-action@v27
+      - uses: nixbuild/nix-quick-install-action@v29
       - name: Restore and cache Nix store
-        uses: nix-community/cache-nix-action@v5
+        uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
 


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions to their latest versions and introduces automated dependency management through Dependabot configuration.

## Key Changes
- **GitHub Actions Updates:**
  - `actions/checkout`: v4 → v5
  - `actions/cache`: v4 → v5
  - `actions/upload-artifact`: v4 → v6
  - `nix-community/cache-nix-action`: v5 → v7
  - `mozilla-actions/sccache-action`: v0.0.9 → v0.0.10
  - `nixbuild/nix-quick-install-action`: v27 → v29 (in one job)

- **New Dependabot Configuration:**
  - Added `.github/dependabot.yml` to automate dependency updates
  - Configured weekly checks for GitHub Actions with a limit of 10 open PRs
  - Configured weekly checks for git submodules (vendored under `3rd/`) with grouped PRs to reduce noise
  - Both configurations use weekly scheduling intervals

## Implementation Details
The Dependabot configuration groups all GitHub Actions updates into a single PR and all git submodule updates into a single PR, helping to keep the notification volume manageable while ensuring dependencies stay current. The submodule grouping is particularly important given the note that some submodules (e.g., mruby gems) are version-coupled and should be reviewed together.

https://claude.ai/code/session_01CYv8oZZzSBFvHaSNmpXD33