### PR TITLE
ci: add GitHub-hosted rpg2k/xp test-bed download scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,14 @@ jobs:
         id: cache
         with:
           path: data
-          key: game-${{ hashFiles('./scripts/download-nepheshel.bash') }}
+          key: game-${{ hashFiles('./scripts/download-*.bash') }}
 
       - name: Download game
         if: steps.cache.outputs.cache-hit != 'true'
-        run: nix develop -c ./scripts/download-nepheshel.bash
+        run: |
+          nix develop -c ./scripts/download-nepheshel.bash
+          nix develop -c ./scripts/download-mtf-meido-action.bash
+          nix develop -c ./scripts/download-opengame-xp.bash
 
       - name: test
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,15 @@ All notable changes to this project will be documented in this file.
   - Added key constants (UP, DOWN, LEFT, RIGHT, A, B, C, etc.)
   - Implemented input state tracking (press, trigger, repeat)
   - Added directional input helpers (dir4, dir8)
+- GitHub-hosted test-bed download scripts reachable from sandboxed/proxied
+  environments where the tkool CDN is blocked (unlike the existing
+  Nepheshel/Pray-for-You scripts):
+  - `scripts/download-mtf-meido-action.bash` — RPG Maker 2000 game
+    (`data/mtf-meido-action/Debug`: `RPG_RT.ldb`/`.lmt` and 13 `Map*.lmu`)
+  - `scripts/download-opengame-xp.bash` — RPG Maker XP project
+    (`data/OpenGame.exe/Testbed/XP`: full `Data/*.rxdata` set)
+  - Both use a sparse, blob-filtered `git clone`; the CI `build` job now fetches
+    them alongside Nepheshel and keys the game cache off all download scripts
 
 ### Fixed
 - LCF `File#method_missing` delegates field access with `__send__` instead of

--- a/scripts/download-mtf-meido-action.bash
+++ b/scripts/download-mtf-meido-action.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# RPG Maker 2000 test-bed game (non-EasyRPG), hosted on GitHub so it is
+# reachable from sandboxed/proxied environments where the tkool CDN is blocked.
+# After running, the game directory is:
+#   data/mtf-meido-action/Debug
+# which contains RPG_RT.ldb / RPG_RT.lmt / RPG_RT.ini and Map0001..0013.lmu.
+
+set -eux -o pipefail
+
+mkdir -p $(dirname $0)/../data
+
+cd $(dirname $0)/../data
+
+if [ ! -d mtf-meido-action ] ; then
+    git clone --depth 1 --filter=blob:none --sparse \
+        https://github.com/lychees/mtf-meido-action.git
+    git -C mtf-meido-action sparse-checkout set Debug
+fi

--- a/scripts/download-opengame-xp.bash
+++ b/scripts/download-opengame-xp.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# RPG Maker XP test-bed project (non-EasyRPG), hosted on GitHub so it is
+# reachable from sandboxed/proxied environments where the tkool CDN is blocked.
+# After running, the game directory is:
+#   data/OpenGame.exe/Testbed/XP
+# which contains a full Data/*.rxdata set (Scripts, System, Actors, Map001, ...).
+
+set -eux -o pipefail
+
+mkdir -p $(dirname $0)/../data
+
+cd $(dirname $0)/../data
+
+if [ ! -d OpenGame.exe ] ; then
+    git clone --depth 1 --filter=blob:none --sparse \
+        https://github.com/aphadeon/OpenGame.exe.git
+    git -C OpenGame.exe sparse-checkout set Testbed/XP
+fi


### PR DESCRIPTION
The existing test-bed downloads (Nepheshel, Pray for You) fetch from the tkool CDN and fgamearchives, which are unreachable from sandboxed/proxied environments. Add two GitHub-hosted alternatives that are reachable there:

- download-mtf-meido-action.bash: RPG Maker 2000 game (non-EasyRPG) with RPG_RT.ldb/.lmt and 13 Map*.lmu under data/mtf-meido-action/Debug
- download-opengame-xp.bash: RPG Maker XP project with a full Data/*.rxdata set under data/OpenGame.exe/Testbed/XP

Both use a sparse, blob-filtered git clone to fetch only the game dir. The CI build job now downloads them alongside Nepheshel and keys the game cache off all download scripts.


Claude-Session: https://claude.ai/code/session_01CwPn6LD17mQpsA3ghNL45Z