### PR TITLE
Handle unmappable bytes in CP932 to UTF-8 conversion gracefully

### DIFF
--- a/mruby-lcf/src/lcf.cxx
+++ b/mruby-lcf/src/lcf.cxx
@@ -40,8 +40,20 @@ mrb_value cp932_to_utf8(mrb_state* M, mrb_value self) {
       continue;
     }
     u = find_utf8(b[0]);
-    mrb_assert(u);
-    str.push_back(*u);
+    if (u) {
+      str.push_back(*u);
+      continue;
+    }
+    // Unmappable byte: the best-fit table (used here in reverse as a decoder)
+    // does not cover every valid CP932 code, and the input may contain
+    // truncated multi-byte sequences or invalid bytes. Emit U+FFFD instead of
+    // aborting the whole process. When the byte is a double-byte lead byte and
+    // a trailing byte follows, consume both so the stream stays in sync.
+    str.push_back(0xFFFD);
+    const bool is_dbcs_lead =
+        (b[0] >= 0x81 and b[0] <= 0x9F) or (b[0] >= 0xE0 and b[0] <= 0xFC);
+    if (is_dbcs_lead and (p + l - i) >= 2)
+      i += 1;
   }
   std::string ret = una::utf32to8(str);
 

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -17,6 +17,16 @@ assert "cp932 to unicode" do
   assert_equal "LcfDataBase", LCF.cp932_to_utf8("LcfDataBase")
 end
 
+assert "cp932 to unicode degrades on unmappable bytes instead of crashing" do
+  # A truncated double-byte sequence (lead byte 0x82 with no trailing byte)
+  # must not abort the process; it decodes to the replacement character.
+  assert_equal "�", LCF.cp932_to_utf8("\x82")
+  assert_equal "A�", LCF.cp932_to_utf8("A\x82")
+  # A lead byte followed by more text consumes its (invalid) trailing byte so
+  # the rest of the string is still decoded correctly.
+  assert_equal "�あ", LCF.cp932_to_utf8("\x82\x00\x82\xa0")
+end
+
 # ---- LCF binary format encoders (mirror the on-disk layout) ----------------
 # These let the parser be exercised against synthetic, self-consistent data.
 def lcf_ber(n)


### PR DESCRIPTION
## Summary
Replace assertion-based failure with graceful degradation when encountering unmappable bytes during CP932 to UTF-8 conversion. Invalid or truncated sequences now emit the Unicode replacement character (U+FFFD) instead of aborting the process.

## Key Changes
- Removed `mrb_assert(u)` that would crash on unmappable single bytes
- Added fallback logic to emit U+FFFD for bytes not found in the UTF-8 mapping table
- Implemented DBCS (double-byte character set) lead byte detection to consume both lead and trailing bytes when a truncated sequence is encountered, keeping the byte stream in sync
- Added comprehensive test cases covering:
  - Truncated double-byte sequences (lead byte with no trailing byte)
  - Invalid trailing bytes following a lead byte
  - Mixed valid and invalid sequences in the same string

## Implementation Details
The fix detects CP932 double-byte lead bytes (0x81-0x9F and 0xE0-0xFC ranges) and when one is encountered without a valid mapping, it checks if a trailing byte is available. If so, both bytes are consumed to prevent the next byte from being misinterpreted as a lead byte. This maintains stream synchronization while gracefully handling malformed input.

https://claude.ai/code/session_01Jg6m76o3bLnFqhUHioy5xY