### PR TITLE
Add SDL keyboard input support for the window backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Keyboard input now works in the SDL window backend: an SDL event watch (added
+  in `src/sdl_input.cxx`) observes key events without stealing them from LVGL's
+  own event pump, translates them to `RGSS::Input` key ids (arrows;
+  Z/Enter/Space = C, X/Esc = B, C = A; A/S/D = X/Y/Z; Q/PgUp = L, W/PgDn = R;
+  Shift/Ctrl/Alt and F5–F9), and feeds them into `RGSS::Input` from
+  `Graphics.update`, mirroring the existing terminal backend. Previously
+  `RGSS::Input.update` was a stub and games were only controllable under the
+  `--sixel`/`--iterm` terminal backends
 - `RGSS::Viewport` is now a functional display object rather than a stub: it
   wraps an LVGL container that positions and **clips** its sprites to a `rect`,
   scrolls their content by `ox`/`oy`, hides via `visible`, and takes part in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(EMSCRIPTEN)
   add_custom_target(onigmo_clean DEPENDS "${ONIGMO_A}")
 endif()
 
-add_executable(${PROJECT_NAME} src/main.cxx)
+add_executable(${PROJECT_NAME} src/main.cxx src/sdl_input.cxx)
 target_link_libraries(
   ${PROJECT_NAME}
   mruby

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -213,8 +213,11 @@ module RGSS
     @count = Array.new(20, 0)
 
     def self.update
-      # This would normally be implemented in C++ to read actual input
-      # For now, we'll just have a stub implementation
+      # Key transitions are pushed in from C++ via .press / .release: the SDL
+      # window backend (src/sdl_input.cxx -> rgss_sdl_poll) and the terminal
+      # backends (rgss_terminal_poll) both drain their events during
+      # Graphics.update. This method only advances the per-frame trigger/repeat
+      # bookkeeping over that state.
 
       # Reset triggered state after each frame
       @triggered.each_index do |i|

--- a/mruby-rgss/src/input_bridge.cxx
+++ b/mruby-rgss/src/input_bridge.cxx
@@ -1,0 +1,68 @@
+// SDL keyboard -> RGSS::Input bridge (mruby side).
+//
+// The SDL window backend lives in the executable, which is the only place with
+// SDL headers on its include path (the mruby-rgss gem is also built for the
+// terminal-only and emscripten variants and must not depend on SDL directly).
+// That executable installs an SDL event watch which translates SDL keysyms into
+// the integer RGSS::Input key ids (see mruby-rgss/mrblib/lib.rb) and hands them
+// here via rgss_sdl_input_push, without touching the mruby VM.
+//
+// rgss_sdl_poll then drains the buffered transitions into RGSS::Input once per
+// frame from Graphics.update, on the same thread that runs the interpreter.
+// This mirrors rgss_terminal_poll: SDL delivers real key-up events, so presses
+// and releases map straight onto RGSS::Input.press / RGSS::Input.release with
+// no hold-timer emulation.
+
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/value.h>
+
+#include <vector>
+
+namespace {
+
+struct PendingKey {
+  int key;
+  bool press;
+};
+
+// Filled by rgss_sdl_input_push (SDL event-watch context), drained by
+// rgss_sdl_poll (interpreter frame). Both run on the main thread, so no locking
+// is needed. Empty unless the SDL backend is active, which keeps this a cheap
+// no-op under the terminal backends.
+std::vector<PendingKey> g_pending;
+
+}  // namespace
+
+// Called from the executable's SDL event watch with an already-translated RGSS
+// key id (>= 0) and whether it was pressed or released.
+extern "C" void rgss_sdl_input_push(int key, bool press) {
+  g_pending.push_back({key, press});
+}
+
+// Drains buffered SDL key transitions into RGSS::Input. Called every frame from
+// Graphics.update, next to rgss_terminal_poll.
+extern "C" void rgss_sdl_poll(mrb_state* M) {
+  if (g_pending.empty())
+    return;
+
+  RClass* rgss = mrb_module_get(M, "RGSS");
+  if (!rgss) {
+    g_pending.clear();
+    return;
+  }
+  RClass* input = mrb_module_get_under(M, rgss, "Input");
+  if (!input) {
+    g_pending.clear();
+    return;
+  }
+
+  // Swap out the queue first so a re-entrant push (there is none today, but the
+  // mruby calls below run arbitrary Ruby) cannot invalidate the iterator or be
+  // dropped.
+  std::vector<PendingKey> pending;
+  pending.swap(g_pending);
+  for (const PendingKey& e : pending)
+    mrb_funcall(M, mrb_obj_value(input), e.press ? "press" : "release", 1,
+                mrb_fixnum_value(e.key));
+}

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -34,6 +34,10 @@
 // RGSS::Input.
 extern "C" void rgss_terminal_poll(mrb_state* M);
 
+// Defined in input_bridge.cxx (same gem).  A no-op unless the SDL window backend
+// is active and has captured key events; drains them into RGSS::Input.
+extern "C" void rgss_sdl_poll(mrb_state* M);
+
 namespace {
 mrb_value to_nfd(mrb_state* M, mrb_value self) {
   const char* ptr;
@@ -1386,6 +1390,7 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
   const mrb_value rgss_mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
 
   rgss_terminal_poll(M);
+  rgss_sdl_poll(M);
 
   if (mrb_const_defined(M, mrb_obj_value(M->object_class),
                         mrb_intern_lit(M, "TIMEOUT_MS"))) {

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -34,8 +34,8 @@
 // RGSS::Input.
 extern "C" void rgss_terminal_poll(mrb_state* M);
 
-// Defined in input_bridge.cxx (same gem).  A no-op unless the SDL window backend
-// is active and has captured key events; drains them into RGSS::Input.
+// Defined in input_bridge.cxx (same gem).  A no-op unless the SDL window
+// backend is active and has captured key events; drains them into RGSS::Input.
 extern "C" void rgss_sdl_poll(mrb_state* M);
 
 namespace {

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -122,6 +122,10 @@ void main_loop() {
 
 extern "C" void rgss_set_display(mrb_state* M, lv_display_t* d);
 
+// Installs the SDL keyboard watch that feeds RGSS::Input (src/sdl_input.cxx).
+// Only meaningful for the SDL window backend.
+extern "C" void rgss_sdl_input_init(void);
+
 // Report an mruby exception (class, message, and Ruby backtrace) and bail out
 // of main(). Preferred over ng-log's CHECK: it prints the actual mruby error
 // detail, and under Emscripten ng-log's fatal path traps anyway (it formats
@@ -184,6 +188,9 @@ int main(int argc, char** argv) {
     CHECK(display);
     lv_sdl_window_set_resizeable(display.get(), false);
     lv_sdl_window_set_zoom(display.get(), 2.f);
+    // SDL is initialised by lv_sdl_window_create above; install the keyboard
+    // watch now so key events reach RGSS::Input.
+    rgss_sdl_input_init();
   }
 
 #ifdef __EMSCRIPTEN__

--- a/src/sdl_input.cxx
+++ b/src/sdl_input.cxx
@@ -1,0 +1,137 @@
+// SDL keyboard capture for the desktop / browser (SDL) window backend.
+//
+// LVGL's SDL driver drains the whole SDL event queue itself inside
+// lv_timer_handler (see 3rd/lvgl/src/drivers/sdl/lv_sdl_window.c), so a second
+// SDL_PollEvent loop here would race it and steal events. Instead we register
+// an SDL event *watch*, which observes every event as it is pumped without
+// removing it from the queue, leaving LVGL's own handling untouched.
+//
+// The watch only translates keysyms to RGSS::Input key ids and buffers them via
+// rgss_sdl_input_push (defined in the mruby-rgss gem); the buffered transitions
+// are applied to RGSS::Input from rgss_sdl_poll during Graphics.update. Keeping
+// the SDL specifics here means the gem never needs SDL on its include path.
+
+#include <SDL2/SDL.h>
+
+// Buffer sink implemented in mruby-rgss/src/input_bridge.cxx.
+extern "C" void rgss_sdl_input_push(int key, bool press);
+
+namespace {
+
+// RGSS::Input key ids. Mirrors the constants in mruby-rgss/mrblib/lib.rb.
+enum RgssKey {
+  KEY_UP = 0,
+  KEY_DOWN = 1,
+  KEY_LEFT = 2,
+  KEY_RIGHT = 3,
+  KEY_A = 4,
+  KEY_B = 5,
+  KEY_C = 6,
+  KEY_X = 7,
+  KEY_Y = 8,
+  KEY_Z = 9,
+  KEY_L = 10,
+  KEY_R = 11,
+  KEY_SHIFT = 12,
+  KEY_CTRL = 13,
+  KEY_ALT = 14,
+  KEY_F5 = 15,
+  KEY_F6 = 16,
+  KEY_F7 = 17,
+  KEY_F8 = 18,
+  KEY_F9 = 19,
+};
+
+// Map an SDL keysym to an RGSS::Input key id, or -1 when the key is unbound.
+//
+// Confirm (C), cancel (B) and A follow the terminal backend's choices so both
+// window and terminal play the same: Z/Enter/Space confirm, X/Esc cancel, C is
+// the A button. The remaining letters, page keys, modifiers and function keys
+// follow RPG Maker XP's default keyboard layout.
+int map_key(SDL_Keycode k) {
+  switch (k) {
+    case SDLK_UP:
+      return KEY_UP;
+    case SDLK_DOWN:
+      return KEY_DOWN;
+    case SDLK_LEFT:
+      return KEY_LEFT;
+    case SDLK_RIGHT:
+      return KEY_RIGHT;
+    case SDLK_z:
+    case SDLK_RETURN:
+    case SDLK_KP_ENTER:
+    case SDLK_SPACE:
+      return KEY_C;
+    case SDLK_x:
+    case SDLK_ESCAPE:
+      return KEY_B;
+    case SDLK_c:
+      return KEY_A;
+    case SDLK_a:
+      return KEY_X;
+    case SDLK_s:
+      return KEY_Y;
+    case SDLK_d:
+      return KEY_Z;
+    case SDLK_q:
+    case SDLK_PAGEUP:
+      return KEY_L;
+    case SDLK_w:
+    case SDLK_PAGEDOWN:
+      return KEY_R;
+    case SDLK_LSHIFT:
+    case SDLK_RSHIFT:
+      return KEY_SHIFT;
+    case SDLK_LCTRL:
+    case SDLK_RCTRL:
+      return KEY_CTRL;
+    case SDLK_LALT:
+    case SDLK_RALT:
+      return KEY_ALT;
+    case SDLK_F5:
+      return KEY_F5;
+    case SDLK_F6:
+      return KEY_F6;
+    case SDLK_F7:
+      return KEY_F7;
+    case SDLK_F8:
+      return KEY_F8;
+    case SDLK_F9:
+      return KEY_F9;
+    default:
+      return -1;
+  }
+}
+
+int SDLCALL event_watch(void* /*user*/, SDL_Event* event) {
+  int key = -1;
+  bool press = false;
+  switch (event->type) {
+    case SDL_KEYDOWN:
+      // Ignore auto-repeat: RGSS::Input derives its own repeat timing from the
+      // held state, so only the initial press should re-trigger.
+      if (event->key.repeat)
+        return 0;
+      key = map_key(event->key.keysym.sym);
+      press = true;
+      break;
+    case SDL_KEYUP:
+      key = map_key(event->key.keysym.sym);
+      press = false;
+      break;
+    default:
+      return 0;
+  }
+  if (key >= 0)
+    rgss_sdl_input_push(key, press);
+  return 0;  // ignored for watchers
+}
+
+}  // namespace
+
+// Install the SDL keyboard watch. Call once, after the SDL window (and thus
+// SDL) has been initialised.
+extern "C" void rgss_sdl_input_init(void) {
+  SDL_AddEventWatch(event_watch, nullptr);
+}


### PR DESCRIPTION
## Summary
Implements keyboard input handling for the SDL window backend by adding an SDL event watch that translates key events into RGSS::Input key ids and feeds them into the input system during Graphics.update, mirroring the existing terminal backend functionality.

## Key Changes
- **New SDL input module** (`src/sdl_input.cxx`): Installs an SDL event watch that observes keyboard events without interfering with LVGL's own event pump. Translates SDL keysyms to RGSS::Input key ids following RPG Maker XP's default layout (arrows, Z/Enter/Space = C, X/Esc = B, C = A, etc.) and buffers them for processing.

- **Input bridge** (`mruby-rgss/src/input_bridge.cxx`): Implements the mruby-side buffer and polling mechanism. The `rgss_sdl_input_push` function receives translated key events from the SDL event watch, and `rgss_sdl_poll` drains them into RGSS::Input during Graphics.update on the interpreter thread.

- **Integration points**:
  - `src/main.cxx`: Calls `rgss_sdl_input_init()` after SDL window initialization to install the event watch
  - `mruby-rgss/src/lib.cxx`: Calls `rgss_sdl_poll()` during Graphics.update alongside the existing terminal poll
  - `CMakeLists.txt`: Adds `src/sdl_input.cxx` to the executable build

- **Documentation**: Updated CHANGELOG.md and code comments explaining the keyboard layout and architecture.

## Notable Implementation Details
- Uses SDL event watches rather than polling to avoid racing LVGL's own event queue consumption
- Ignores SDL auto-repeat events since RGSS::Input derives its own repeat timing from held state
- No locking needed since both the event watch and polling run on the main thread
- Keeps SDL dependencies isolated in the executable; the mruby gem remains SDL-agnostic
- Mirrors the terminal backend's approach: real key-up events map directly to press/release without hold-timer emulation

https://claude.ai/code/session_01FGU4bQo9doL2Nsx3sgyMj2