### PR TITLE
Add move-route command decoding and LCF test-bed smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,10 @@ jobs:
           nix develop -c ./scripts/download-mtf-meido-action.bash
           nix develop -c ./scripts/download-opengame-xp.bash
 
+      - name: LCF test-bed smoke check
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: nix develop -c ruby scripts/lcf_testbed_check.rb
+
       - name: test
         run: |
           nix develop -c cmake --build build -t test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
   into the event-page and common-event `move_route.commands` chunk. Previously
   that chunk was mis-declared as an event-command blob and failed to parse on
   real maps
+- Event-page condition schema now covers its trailing RPG2003 chunks
+  (`timer2_sec`, `compare_operator`), so a real map's condition data parses with
+  no unknown chunks. The RPG2000 runtime still compares variables with `>=`
 - `scripts/lcf_testbed_check.rb`: a host smoke-test that runs the pure-Ruby LCF
   parser (`mruby-lcf/mrblib/{lcf,schema}.rb`) over real downloaded test-bed
   projects — walking every schema field of a game's `RPG_RT.ldb`, `RPG_RT.lmt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Move-route command decoding for the LCF loaders: `LCF.parse_move_commands`
+  and `LCF::MoveCommand` decode the compact move-command layout (bare commands
+  plus the string/integer parameters that Switch On/Off, Change Graphic and Play
+  Sound Effect carry), exposed through a new `:move_commands` schema type wired
+  into the event-page and common-event `move_route.commands` chunk. Previously
+  that chunk was mis-declared as an event-command blob and failed to parse on
+  real maps
+- `scripts/lcf_testbed_check.rb`: a host smoke-test that runs the pure-Ruby LCF
+  parser (`mruby-lcf/mrblib/{lcf,schema}.rb`) over real downloaded test-bed
+  projects — walking every schema field of a game's `RPG_RT.ldb`, `RPG_RT.lmt`
+  and `Map*.lmu` and asserting structural invariants (layer sizes match the map
+  dimensions, move-command ids are in range, events iterate). It auto-discovers
+  games under `data/` and now runs in CI after the test-bed download step,
+  exercising the loaders against genuine editor output rather than only the
+  synthetic blobs the unit tests use
 - Built-in CPU/memory profiler for finding performance bottlenecks, enabled with
   `--profile` (report cadence tunable via `--profile_interval_ms`, default
   1000ms). Once a second it prints a summary line to stderr with the measured
@@ -41,6 +56,11 @@ All notable changes to this project will be documented in this file.
   viewport stacks on the screen. LVGL delete events invalidate the mruby
   wrappers so a viewport can safely own (and free) its child sprites
 - `RGSS::Sprite` / `RGSS::Viewport` gained a `visible` / `visible=` accessor
+
+### Fixed
+- LCF map-tree `scrollbar_x` / `scrollbar_y` (chunks 5/6) are now read as signed
+  ints instead of booleans; real games store multi-byte scrollbar positions
+  there, which raised `invalid bool size` when parsing an actual `RPG_RT.lmt`
 
 ### Changed
 - `RGSS::Window` is now assembled from three layered sprites inside a viewport

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,14 @@
 # TODOs of this project
 
 ## RPG Maker 2k
-- Support all data schema of LCF
+- 🚧 Support all data schema of LCF — the core database, map tree and map-unit
+  chunks needed for boot and gameplay are covered and validated against a real
+  test-bed by `scripts/lcf_testbed_check.rb`. Remaining chunks that appear in
+  real data but are not yet in `schema.rb` (surfaced by walking the test-bed):
+  database items (usage/effect flags 25–28 and `animation_data` sub-chunks),
+  `battle_anime2` frame/timing chunks, skill chunk 16, and a few map-unit
+  chunks (42, 50, 60–62, 90 — save/encounter/parallax metadata). These are
+  editor/battle/2003 details not on the walkable-game critical path
 - ✅ Show window component for title scene
 - ✅ Implement New Game functionality — builds the party, loads the start map
   and enters a walkable `Scene::Map` with events

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18,7 +18,11 @@ teleport), open a menu, save, and continue. The remaining work is mostly **the
 parts that need the native build + real game assets to develop and verify**:
 authentic chipset/charset rendering, audio, and the battle system. Everything
 landed so far is exercised by unit tests (`mruby-lcf/test` and a host harness),
-since the full SDL/mruby binary can't be built or run in this environment.
+since the full SDL/mruby binary can't be built or run in this environment. The
+LCF loaders are additionally smoke-tested against real downloaded test-bed
+projects (`scripts/lcf_testbed_check.rb`, run in CI after the download step),
+which parses a genuine game's `RPG_RT.ldb`/`.lmt`/`Map*.lmu` end to end and
+catches format surprises the synthetic unit tests can't.
 
 The work below is roughly ordered by the critical path to a walkable game
 (1 → 2 → 3 → 4/5/6 → 7/8/9); battle and full menus can follow.
@@ -47,7 +51,10 @@ The work below is roughly ordered by the critical path to a walkable game
   (`Game::CharSet`, 4-direction, 3 walk frames); NPC/event sprites are drawn as
   markers for now
 - ✅ Movement & collision — grid movement with pixel interpolation, walk
-  animation and edge/tile/event collision. Move-route processing still to come
+  animation and edge/tile/event collision. Move-route *data* now decodes
+  (`LCF.parse_move_commands` / `LCF::MoveCommand`, wired into the event-page and
+  common-event `move_route` schema); driving events from those routes at runtime
+  is still to come
 
 #### Event system
 - 🚧 Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -69,6 +69,59 @@ module LCF
     cmds
   end
 
+  # One decoded RPG2000 move-route command: a command id plus the optional
+  # string / integer parameters a handful of commands carry. Move commands use a
+  # different, more compact on-disk layout than event commands.
+  class MoveCommand
+    attr_reader :command_id, :parameter_string,
+                :parameter_a, :parameter_b, :parameter_c
+
+    def initialize(command_id, string, a, b, c)
+      @command_id = command_id
+      @parameter_string = string
+      @parameter_a = a
+      @parameter_b = b
+      @parameter_c = c
+    end
+  end
+
+  # Move-command ids that carry parameters (every other id is a bare command).
+  MOVE_SWITCH_ON = 32       # + switch id
+  MOVE_SWITCH_OFF = 33      # + switch id
+  MOVE_CHANGE_GRAPHIC = 34  # + charset name (string) + charset index
+  MOVE_PLAY_SOUND = 35      # + file name (string) + volume, tempo, balance
+
+  # Decode a packed move-command list (the `:move_commands` schema type used by
+  # event-page and common-event move routes). Unlike event commands, each entry
+  # is a bare command id optionally followed by a length-prefixed cp932 string
+  # and/or a few BER integer parameters, selected by the id. The list runs to
+  # the end of the blob (its length is also stored separately as `command_size`).
+  def parse_move_commands d
+    s = StringIO.new d
+    cmds = []
+    until s.eof?
+      id = read_ber s
+      str = ''
+      a = b = c = 0
+      case id
+      when MOVE_SWITCH_ON, MOVE_SWITCH_OFF
+        a = read_ber s
+      when MOVE_CHANGE_GRAPHIC
+        slen = read_ber s
+        str = slen > 0 ? cp932_to_utf8(s.read(slen)) : ''
+        a = read_ber s
+      when MOVE_PLAY_SOUND
+        slen = read_ber s
+        str = slen > 0 ? cp932_to_utf8(s.read(slen)) : ''
+        a = read_ber s
+        b = read_ber s
+        c = read_ber s
+      end
+      cmds.push MoveCommand.new(id, str, a, b, c)
+    end
+    cmds
+  end
+
   # Holds the sequential sections of a multi-section file (e.g. the map tree,
   # which is a map-properties table followed by the tree order and the initial
   # party/vehicle positions). Sections are reachable by their schema name;
@@ -129,6 +182,7 @@ module LCF
     when :int8_array ; return d.bytes
     when :int32_array ; return unpack_int32(d)
     when :event ; return parse_event_commands(d)
+    when :move_commands ; return parse_move_commands(d)
     when :string ; return LCF.cp932_to_utf8 d
     when :Tree
       s = StringIO.new(d)
@@ -156,7 +210,7 @@ module LCF
   end
 
   module_function :read_ber, :to_rb, :read_section, :parse_event_commands,
-                  :unpack_int32
+                  :parse_move_commands, :unpack_int32
 
   MODE = 2000 # 2003
 

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -772,8 +772,10 @@ module LCF
           3 => { name: :indentation, type: :int },
           # 0 = root, 1 = normal map, 2 = area.
           4 => { name: :type, type: :int, default: 1 },
-          5 => { name: :x_scroll, type: :bool, default: false },
-          6 => { name: :y_scroll, type: :bool, default: false },
+          # Editor-only scrollbar positions (RPG Maker's map-editor viewport),
+          # stored as signed ints — not booleans.
+          5 => { name: :scrollbar_x, type: :int, default: 0 },
+          6 => { name: :scrollbar_y, type: :int, default: 0 },
           7 => { name: :node_extracted, type: :bool, default: false },
           11 => { name: :bgm_type, type: :int, default: 0 },
           12 => { name: :bgm, type: :Array1D, elements: BGM },
@@ -832,7 +834,7 @@ module LCF
 
     MOVE_ROUTE = {
       11 => { name: :command_size, type: :int, default: 0 },
-      12 => { name: :commands, type: :event },
+      12 => { name: :commands, type: :move_commands, default: [] },
       21 => { name: :repeat, type: :bool, default: true },
       22 => { name: :skippable, type: :bool, default: false },
     }

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -830,6 +830,11 @@ module LCF
       6 => { name: :item_id, type: :int, default: 1 },
       7 => { name: :actor_id, type: :int, default: 1 },
       8 => { name: :timer_sec, type: :int, default: 0 },
+      # RPG2003-only: a second timer condition and the variable comparison
+      # operator (0 = >=). The RPG2000 runtime always compares with >=, so these
+      # are carried for schema completeness rather than consumed by EventPage.
+      9 => { name: :timer2_sec, type: :int, default: 0 },
+      10 => { name: :compare_operator, type: :int, default: 0 },
     }
 
     MOVE_ROUTE = {

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -117,6 +117,65 @@ assert "LCF.parse_event_commands decodes an event command list" do
   assert_equal 0, cmds[1].param(9) # missing parameters read as 0
 end
 
+assert "LCF.parse_move_commands decodes bare and parameterised commands" do
+  # face_down (bare), switch_on + id, change_graphic + name/index,
+  # play_sound + name/volume/tempo/balance, move_forward (bare).
+  blob = lcf_ber(14)
+  blob += lcf_ber(32) + lcf_ber(7)
+  blob += lcf_ber(34) + lcf_ber("Hero".bytesize) + "Hero" + lcf_ber(2)
+  blob += lcf_ber(35) + lcf_ber("bell".bytesize) + "bell" +
+          lcf_ber(100) + lcf_ber(80) + lcf_ber(50)
+  blob += lcf_ber(11)
+  cmds = LCF.parse_move_commands(blob)
+  assert_equal 5, cmds.size
+  assert_equal 14, cmds[0].command_id
+  assert_equal 0, cmds[0].parameter_a
+  assert_equal '', cmds[0].parameter_string
+  assert_equal 32, cmds[1].command_id
+  assert_equal 7, cmds[1].parameter_a
+  assert_equal "Hero", cmds[2].parameter_string
+  assert_equal 2, cmds[2].parameter_a
+  assert_equal "bell", cmds[3].parameter_string
+  assert_equal 100, cmds[3].parameter_a
+  assert_equal 80, cmds[3].parameter_b
+  assert_equal 50, cmds[3].parameter_c
+  assert_equal 11, cmds[4].command_id
+end
+
+assert "LCF map-tree scroll bars decode as ints, not booleans" do
+  # These chunks (5/6) hold the editor's signed scrollbar positions; a real game
+  # stores multi-byte BER ints here, which the old :bool schema could not read.
+  props = lcf_array2d([[1, lcf_array1d([lcf_str_field(1, "MAP1"),
+                                        lcf_int_field(5, 320),
+                                        lcf_int_field(6, -48)])]])
+  lmt = LCF::MapTree.new(lcf_file("LcfMapTree",
+    props + lcf_tree([1], 1) +
+    lcf_array1d([lcf_int_field(1, 1), lcf_int_field(2, 0), lcf_int_field(3, 0)])))
+  assert_equal 320, lmt.map_properties[1].scrollbar_x
+  assert_equal(-48, lmt.map_properties[1].scrollbar_y)
+end
+
+assert "LCF::MapUnit event page decodes a move route" do
+  route = lcf_array1d([lcf_int_field(11, 2),
+                       lcf_field(12, lcf_ber(14) + lcf_ber(11)),
+                       lcf_field(21, "\x00"), lcf_field(22, "\x01")])
+  page = lcf_array1d([lcf_str_field(21, "hero"), lcf_field(41, route)])
+  event = lcf_array1d([lcf_str_field(1, "NPC"), lcf_int_field(2, 0),
+                       lcf_int_field(3, 0),
+                       lcf_field(5, lcf_array2d([[1, page]]))])
+  body = lcf_array1d([lcf_int_field(1, 1), lcf_int_field(2, 1),
+                      lcf_int_field(3, 1),
+                      lcf_field(81, lcf_array2d([[1, event]]))])
+  lmu = LCF::MapUnit.new(lcf_file("LcfMapUnit", body))
+  mr = lmu.events[1].pages[1].move_route
+  assert_false mr.repeat
+  assert_true mr.skippable
+  cmds = mr.commands
+  assert_equal 2, cmds.size
+  assert_equal 14, cmds[0].command_id
+  assert_equal 11, cmds[1].command_id
+end
+
 assert "LCF::MapUnit parses layers, nested events and event commands" do
   cmds = lcf_ber(10110) + lcf_ber(0) + lcf_ber("Hi".bytesize) + "Hi" + lcf_ber(0)
   page = lcf_array1d([lcf_str_field(21, "hero"), lcf_int_field(23, 4),

--- a/scripts/lcf_testbed_check.rb
+++ b/scripts/lcf_testbed_check.rb
@@ -1,0 +1,138 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Smoke-test the LCF loaders against real RPG Maker 2000 test-bed projects.
+#
+# The parser (mruby-lcf/mrblib/{lcf,schema}.rb) is written in the mruby/CRuby
+# common subset, so this harness loads those exact sources under CRuby and runs
+# them over a downloaded game's RPG_RT.ldb / RPG_RT.lmt / Map*.lmu. The unit
+# tests in mruby-lcf/test exercise the schema against synthetic blobs; this
+# exercises it against genuine editor output, which is where format surprises
+# (unexpected chunk types, move-route encodings, ...) actually show up.
+#
+# The only native dependency of the parser is LCF.cp932_to_utf8 (uni-algo in the
+# real build); here it is provided by Ruby's Windows-31J transcoder. Only
+# structural, encoding-independent invariants are asserted, so the shim never
+# affects the result.
+#
+# Usage:
+#   ruby scripts/lcf_testbed_check.rb [GAME_DIR ...]
+# With no arguments it scans ./data for directories that contain an RPG_RT.ldb.
+# Exits non-zero if any file fails to parse or an invariant is violated.
+
+require 'stringio'
+
+module LCF
+  # uni-algo stand-in: transcode Shift_JIS (Windows-31J) to UTF-8, degrading
+  # unmappable bytes rather than aborting, mirroring the native decoder.
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "�")
+  end
+  module_function :cp932_to_utf8
+
+  # Referenced by a lazy default in the actor schema; RPG2000 caps at 50.
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+mrblib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(mrblib, 'lcf.rb')
+load File.join(mrblib, 'schema.rb')
+
+class Checker
+  def initialize
+    @errors = 0
+    @maps = 0
+    @events = 0
+    @move_commands = 0
+  end
+
+  attr_reader :errors
+
+  def fail(msg)
+    @errors += 1
+    warn "  FAIL #{msg}"
+  end
+
+  # Recursively read every declared field of an Array1D so any chunk whose bytes
+  # do not match its schema type raises here instead of at game runtime.
+  def walk(row, schema, path)
+    return unless schema && schema[:elements]
+    schema[:elements].each do |idx, e|
+      begin
+        v = row[idx]
+      rescue => ex
+        fail "#{path}.#{e[:name]} (chunk #{idx}, #{e[:type]}): #{ex.class}: #{ex.message}"
+        next
+      end
+      case e[:type]
+      when :Array2D
+        v&.each { |id, r| walk(r, e, "#{path}.#{e[:name]}[#{id}]") }
+      when :Array1D
+        walk(v, e, "#{path}.#{e[:name]}") if v
+      when :move_commands
+        v&.each do |mc|
+          @move_commands += 1
+          unless (0..41).cover?(mc.command_id)
+            fail "#{path}.#{e[:name]}: move command id out of range: #{mc.command_id}"
+          end
+        end
+      end
+    end
+  end
+
+  def check_game(dir)
+    puts "== #{dir} =="
+
+    db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+    walk(db, LCF::Schema::DATABASE, 'ldb')
+
+    lmt = LCF::MapTree.new(File.open(File.join(dir, 'RPG_RT.lmt'), 'rb'))
+    fail 'map tree has no start map' if lmt.initial.initial_map_id.to_i <= 0
+    lmt.map_properties.each { |id, m| walk(m, LCF::Schema::MAP_TREE[0], "lmt[#{id}]") }
+
+    Dir[File.join(dir, 'Map*.lmu')].sort.each do |f|
+      base = File.basename(f)
+      lmu = LCF::MapUnit.new(File.open(f, 'rb'))
+      walk(lmu, LCF::Schema::MAP_UNIT, base)
+      w = lmu.width.to_i
+      h = lmu.height.to_i
+      fail "#{base}: non-positive dimensions #{w}x#{h}" if w <= 0 || h <= 0
+      lower = lmu.lower_layer
+      upper = lmu.upper_layer
+      fail "#{base}: lower layer #{lower.size} != #{w}x#{h}" if lower && lower.size != w * h
+      fail "#{base}: upper layer #{upper.size} != #{w}x#{h}" if upper && upper.size != w * h
+      lmu.events.each { |_id, _ev| @events += 1 }
+      @maps += 1
+    end
+  rescue => ex
+    fail "#{dir}: #{ex.class}: #{ex.message}"
+  end
+
+  def report
+    puts "checked #{@maps} maps, #{@events} events, #{@move_commands} move commands"
+    if @errors.zero?
+      puts 'OK: all test-bed data parsed cleanly'
+    else
+      warn "#{@errors} error(s)"
+    end
+  end
+end
+
+def discover_games(root)
+  return [] unless Dir.exist?(root)
+  Dir.glob(File.join(root, '**', 'RPG_RT.ldb')).map { |f| File.dirname(f) }.sort.uniq
+end
+
+games = ARGV.dup
+games = discover_games(File.expand_path('../data', __dir__)) if games.empty?
+
+if games.empty?
+  warn 'no test-bed game found (pass a GAME_DIR or run scripts/download-*.bash first)'
+  exit 0
+end
+
+checker = Checker.new
+games.each { |g| checker.check_game(g) }
+checker.report
+exit(checker.errors.zero? ? 0 : 1)


### PR DESCRIPTION
This PR adds support for decoding RPG2000 move-route commands and introduces a host-side smoke-test harness for validating the LCF loaders against real game data.

## Summary

The LCF loaders previously failed to parse move routes in real games because they used an incorrect schema type for the move-command blob. This PR implements proper move-command decoding and adds a comprehensive test harness that exercises the parser against genuine downloaded test-bed projects.

## Key Changes

- **Move-command decoding**: Implemented `LCF.parse_move_commands` and `LCF::MoveCommand` class to decode the compact move-command layout used by RPG2000. Move commands use a different on-disk format than event commands: bare command IDs optionally followed by length-prefixed strings and/or BER integers depending on the command type (Switch On/Off, Change Graphic, Play Sound Effect).

- **Schema fixes**:
  - Changed `move_route.commands` from `:event` type to `:move_commands` type in the schema
  - Fixed map-tree `scrollbar_x`/`scrollbar_y` (chunks 5/6) from `:bool` to `:int` type — real games store signed multi-byte scrollbar positions there, which previously raised "invalid bool size" errors

- **Test-bed smoke-test harness** (`scripts/lcf_testbed_check.rb`):
  - Loads the pure-Ruby LCF parser sources and runs them over real downloaded games
  - Recursively walks every declared field of the database, map tree, and map units
  - Validates structural invariants: layer sizes match map dimensions, move-command IDs are in valid range (0-41), events iterate properly
  - Auto-discovers games under `data/` directory or accepts explicit game directories
  - Integrated into CI to run after test-bed download, catching format surprises that synthetic unit tests cannot

- **Documentation updates**: Updated CHANGELOG and TODO to reflect move-route data decoding and the new test-bed validation approach.

## Implementation Details

- The move-command parser handles the variable-length encoding where command IDs determine which parameters follow (string length + string + integers)
- The test harness uses Ruby's Windows-31J transcoder as a stand-in for the native uni-algo encoder, sufficient for structural validation
- The harness reports aggregate statistics (maps, events, move commands checked) and exits non-zero on any parsing failure or invariant violation

https://claude.ai/code/session_01UVLBBeLQ1ugGSoJydp7ZYc