### PR TITLE
Add on-screen log console for terminal backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ All notable changes to this project will be documented in this file.
   viewport stacks on the screen. LVGL delete events invalidate the mruby
   wrappers so a viewport can safely own (and free) its child sprites
 - `RGSS::Sprite` / `RGSS::Viewport` gained a `visible` / `visible=` accessor
+- On-screen **log console** for the `--sixel`/`--iterm` terminal backends: a
+  fixed block of rows drawn above the game image (like the control legend and
+  emit-rate stats) that mirrors the engine's `ng-log` output. The last few
+  messages are tailed newest-at-the-bottom and coloured by severity (dim info,
+  yellow warnings, red errors); rows are truncated to the terminal width so a
+  long line cannot wrap and shift the image. On by default, disabled with
+  `--noterm_console`, and sized with `--term_console_lines=N` (default 5). While
+  a terminal backend is active, `ng-log`'s own `stderr` output is suppressed
+  (down to `FATAL`) so messages appear only in the console instead of scribbling
+  over the picture. The executable installs an `nglog::LogSink`
+  (`src/log_console.cxx`) that feeds the buffer through the shared
+  `terminal.cxx`, so the `mruby-rgss` gem keeps no compile-time dependency on
+  `ng-log`. Documented in `docs/adr/0005-terminal-log-console.md`
 
 ### Changed
 - `RGSS::Window` is now assembled from three layered sprites inside a viewport

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,8 @@ if(EMSCRIPTEN)
   add_custom_target(onigmo_clean DEPENDS "${ONIGMO_A}")
 endif()
 
-add_executable(${PROJECT_NAME} src/main.cxx src/sdl_input.cxx)
+add_executable(${PROJECT_NAME} src/main.cxx src/sdl_input.cxx
+                               src/log_console.cxx)
 target_link_libraries(
   ${PROJECT_NAME}
   mruby

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@
 - Either backend draws its emit rate (frame size, MB/s, fps) on-screen just
   under the control legend, refreshed about once a second; this is on by default
   and can be turned off with `--noterm_stats`
+- Both backends also show a **log console** above the game image that mirrors
+  the engine's `ng-log` output on-screen — otherwise those messages would land
+  on `stderr` and scribble over the terminal picture. The last few messages are
+  tailed (newest at the bottom, coloured by severity: dim info, yellow warnings,
+  red errors). On by default; turn it off with `--noterm_console` or change how
+  many rows it reserves with `--term_console_lines=N` (default 5):
+
+  ```sh
+  ./rpg_maker_clone --sixel --term_console_lines=8 --game_dir path/to/game
+  ```
 
 ### Profiling
 

--- a/docs/adr/0005-terminal-log-console.md
+++ b/docs/adr/0005-terminal-log-console.md
@@ -1,0 +1,100 @@
+# 5. On-screen log console for the terminal backends
+
+Date: 2026-07-24
+
+## Status
+
+Accepted
+
+Extends [1. Terminal gaming with the sixel graphics protocol](0001-terminal-gaming-sixel.md)
+and [3. Terminal gaming with the iTerm2 inline-image protocol](0003-terminal-gaming-iterm2.md).
+
+## Context
+
+The `--sixel` and `--iterm` backends (ADRs 0001 and 0003) paint every frame onto
+the terminal's **alternate screen** with cursor-home overdraw. The engine also
+logs through `ng-log`, which by default writes `ERROR` and above to **stderr**.
+On a normal SDL run those two never collide, but under a terminal backend
+stderr and the game image share the same screen: any `LOG(ERROR)` lands as stray
+text somewhere over the picture, corrupting the frame until the next overdraw
+(and, mid-frame, can split an image escape sequence).
+
+ADR 0001 already hit this with the emit-rate stats and solved it by drawing them
+*into the frame* as a reserved row rather than printing to stderr. Log messages
+have the same problem but are more valuable to see: when something goes wrong in
+a headless / SSH session there is no window and no visible stderr, so a failing
+game just misbehaves silently.
+
+We wanted the messages surfaced **in the terminal UI**, next to the game, in
+both backends, without:
+
+- coupling the `mruby-rgss` gem to `ng-log` (the gem links into mruby's own
+  `mrbtest`, which must not drag in the logging library), or
+- letting a long or multi-line message wrap and shove the image around.
+
+## Decision
+
+Add a **log console**: a fixed block of rows drawn above the game image,
+alongside the existing control legend and stats rows, that tails recent
+`ng-log` messages. Selected with `--term_console` (on by default,
+`--noterm_console` to disable) and sized with `--term_console_lines=N`
+(default 5).
+
+The work is split across the two existing seams so the gem stays `ng-log`-free:
+
+- **Executable side** (`src/log_console.cxx`): an `nglog::LogSink` subclass whose
+  `send()` forwards each message — severity, source file/line, text — into the
+  terminal backend through the exported `terminal_console_push`. `main.cxx`
+  installs it (`log_console_install`) only when a terminal backend is active and
+  the console is enabled.
+- **Gem side** (`mruby-rgss/src/terminal.cxx`): a mutex-guarded ring buffer of
+  the last messages, plus `terminal_append_console`, which the sixel and iTerm2
+  encoders call right after `terminal_append_stats`. It emits a reverse-video
+  header row and exactly `--term_console_lines` message rows, tailing the buffer
+  newest-at-the-bottom (nearest the image). The buffer stores only ints and
+  strings, so the gem never sees an `ng-log` type.
+
+Details that make it robust:
+
+- **Fixed height.** The block is always `header + N` rows regardless of how many
+  messages exist (empty slots are blank cleared rows), so the image never shifts
+  as logs arrive — the same reasoning that pins the legend above the frame in
+  ADR 0001.
+- **No wrap.** Each row is truncated to the terminal width (`TIOCGWINSZ`) so a
+  long line cannot wrap onto a second row and push the image down.
+- **Single line per message.** Control bytes (newlines, tabs) are replaced with
+  spaces on capture, so one log entry occupies exactly one row.
+- **Severity colour.** Rows are coloured by `ng-log` severity — dim `INFO`,
+  yellow `WARNING`, red `ERROR`, bold-red `FATAL` — so problems stand out.
+- **Thread-safe.** `ng-log` may call the sink from whichever thread ran the
+  `LOG()` line; the push path only locks the ring-buffer mutex and never logs,
+  matching `LogSink`'s contract.
+
+Because the console now carries the messages, `main.cxx` also calls
+`nglog::SetStderrLogging(NGLOG_FATAL)` when a terminal backend is active, so
+`ng-log` stops writing to stderr (and thus stops scribbling on the image).
+`FATAL` still prints, but it aborts and restores the terminal on the way out, so
+there is no surviving frame to corrupt. File logging is untouched.
+
+## Consequences
+
+- Engine log output is visible on-screen in both terminal backends, including on
+  headless / SSH hosts where there is no window — advancing the "run anywhere"
+  goal from ADR 0001.
+- stderr no longer corrupts the terminal image while a backend is active (a
+  pre-existing latent bug, not just a console feature).
+- The `mruby-rgss` gem keeps no compile-time dependency on `ng-log`; the sink
+  lives in the executable, mirroring the `rgss_terminal_poll` / `rgss_set_display`
+  seams. The console renderer and buffer live in the shared `terminal.cxx`, so
+  the sixel and iTerm2 paths stay identical (each just adds one
+  `terminal_append_console` call).
+- Trade-offs / follow-up work:
+  - The console occupies rows *above* the image because a terminal backend
+    cannot portably know the cursor position *after* an inline image (the same
+    limitation that put the legend on top in ADR 0001); a genuinely bottom-docked
+    panel would need per-terminal cell-size probing.
+  - Only the plain message text is shown (no timestamp column) to keep rows
+    short; the full record is still in the log file.
+  - There is no runtime show/hide key: a fixed-height block keeps the image
+    position stable and avoids the stale-row / screen-clear handling a toggle
+    would require. It can be sized or disabled from the command line instead.

--- a/include/log_console.hxx
+++ b/include/log_console.hxx
@@ -1,0 +1,8 @@
+#pragma once
+
+// Install an nglog::LogSink that forwards every log message into the terminal
+// log console (see terminal_console_push in terminal.hxx).  Call this once,
+// after nglog::InitializeLogging, when a terminal backend (--sixel/--iterm) is
+// active and the console is enabled.  Lives in the executable rather than the
+// mruby-rgss gem so the gem keeps no compile-time dependency on ng-log.
+void log_console_install();

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -72,8 +72,8 @@ void terminal_set_stats(bool enabled);
 // A TUI log panel that mirrors ng-log output on-screen, drawn above the game
 // image just like the legend and stats rows.  Because a terminal backend paints
 // each frame onto the alternate screen with cursor-home overdraw, anything
-// ng-log wrote to stderr would scribble over the picture; the console reserves a
-// fixed block of rows for the last few messages instead, tailing them like a
+// ng-log wrote to stderr would scribble over the picture; the console reserves
+// a fixed block of rows for the last few messages instead, tailing them like a
 // real console (newest at the bottom, nearest the image).
 //
 // The pieces are split across the executable and this gem so the gem keeps no

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -65,3 +65,44 @@ void terminal_write(const char* p, size_t n);
 // Enabled by default; wired to the --term_stats flag.  Has no effect unless a
 // terminal display was created (the SDL path never calls the encoder).
 void terminal_set_stats(bool enabled);
+
+// ---------------------------------------------------------------------------
+// Log console
+// ---------------------------------------------------------------------------
+// A TUI log panel that mirrors ng-log output on-screen, drawn above the game
+// image just like the legend and stats rows.  Because a terminal backend paints
+// each frame onto the alternate screen with cursor-home overdraw, anything
+// ng-log wrote to stderr would scribble over the picture; the console reserves a
+// fixed block of rows for the last few messages instead, tailing them like a
+// real console (newest at the bottom, nearest the image).
+//
+// The pieces are split across the executable and this gem so the gem keeps no
+// compile-time dependency on ng-log: the executable installs an nglog::LogSink
+// (see src/log_console.cxx) that forwards each message here through
+// terminal_console_push, and the encoders draw the buffered lines with
+// terminal_append_console.
+
+// Enable the log console and set how many message rows it reserves (a header
+// row is always drawn above them).  `lines` is clamped to at least 1.  Wired to
+// the --term_console / --term_console_lines flags; a no-op visually until an
+// encoder calls terminal_append_console.
+void terminal_set_console(bool enabled, int lines);
+
+// Append one log line to the console's ring buffer.  Thread-safe: ng-log may
+// call the installed sink from whichever thread ran the LOG() statement.
+// `severity` uses ng-log's LogSeverity ordering (0=INFO, 1=WARNING, 2=ERROR,
+// 3=FATAL) and selects the row colour; `file`/`line` are the message's source
+// location (may be null/0).  The message is stored sanitised to a single
+// printable line.  Safe to call before a terminal display exists.
+void terminal_console_push(int severity,
+                           const char* file,
+                           int line,
+                           const char* msg,
+                           size_t msg_len);
+
+// Append the log-console block (header row plus the reserved message rows) to
+// `s` in the same dim/cleared/CR-LF style as the legend and stats rows.
+// Encoders call this right after terminal_append_stats.  A no-op when the
+// console is disabled.  The block is a fixed height so the game image never
+// shifts as messages arrive; missing rows are drawn blank.
+void terminal_append_console(std::string& s);

--- a/mruby-rgss/src/iterm.cxx
+++ b/mruby-rgss/src/iterm.cxx
@@ -96,6 +96,7 @@ void iterm_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   s += "\x1b[H";
   terminal_append_legend(s);
   terminal_append_stats(s);
+  terminal_append_console(s);
   s += "\x1b]1337;File=inline=1;size=";
   s += std::to_string(g_png.size());
   s += ";width=";

--- a/mruby-rgss/src/sixel.cxx
+++ b/mruby-rgss/src/sixel.cxx
@@ -92,11 +92,11 @@ void sixel_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   std::string& s = g_out;
   s.clear();
   s += "\x1b[H";  // cursor home: overdraw the previous frame in place
-  terminal_append_legend(s);  // one-line key reference pinned above the image
-  terminal_append_stats(s);   // emit-rate report row (no-op if --noterm_stats)
-  terminal_append_console(s);  // ng-log console block (no-op if --noterm_console)
-  s += "\x1bPq";              // enter sixel mode
-  s += "\"1;1;";              // raster attributes: 1:1 aspect ratio
+  terminal_append_legend(s);   // one-line key reference pinned above the image
+  terminal_append_stats(s);    // emit-rate report row (no-op if --noterm_stats)
+  terminal_append_console(s);  // ng-log console block (no-op if disabled)
+  s += "\x1bPq";               // enter sixel mode
+  s += "\"1;1;";               // raster attributes: 1:1 aspect ratio
   s += std::to_string(out_w);
   s += ';';
   s += std::to_string(out_h);

--- a/mruby-rgss/src/sixel.cxx
+++ b/mruby-rgss/src/sixel.cxx
@@ -94,6 +94,7 @@ void sixel_encode_frame(int w, int h, int scale, const uint16_t* pix) {
   s += "\x1b[H";  // cursor home: overdraw the previous frame in place
   terminal_append_legend(s);  // one-line key reference pinned above the image
   terminal_append_stats(s);   // emit-rate report row (no-op if --noterm_stats)
+  terminal_append_console(s);  // ng-log console block (no-op if --noterm_console)
   s += "\x1bPq";              // enter sixel mode
   s += "\"1;1;";              // raster attributes: 1:1 aspect ratio
   s += std::to_string(out_w);

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -74,12 +74,13 @@ struct ConsoleLine {
   std::string text;
 };
 
-bool g_console = false;   // wired to --term_console
-int g_console_lines = 5;  // reserved message rows (wired to --term_console_lines)
+bool g_console = false;  // wired to --term_console
+// Reserved message rows, wired to --term_console_lines.
+int g_console_lines = 5;
 // A few more than g_console_lines are retained so raising the row count (or a
 // burst arriving between frames) still has scrollback to show.
 constexpr size_t CONSOLE_HISTORY = 256;
-std::mutex g_console_mutex;         // guards g_console_buf (sink vs. render thread)
+std::mutex g_console_mutex;  // guards g_console_buf (sink vs. render thread)
 std::deque<ConsoleLine> g_console_buf;
 
 struct KeyState {
@@ -205,8 +206,8 @@ void maybe_report_stats(uint32_t now) {
 }
 
 // Current terminal width in columns, so console rows can be truncated to avoid
-// line-wrap (which would push the game image down a row).  Falls back to 80 when
-// the size is unknown (e.g. output is not a tty).
+// line-wrap (which would push the game image down a row).  Falls back to 80
+// when the size is unknown (e.g. output is not a tty).
 int term_cols() {
   winsize ws{};
   if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0)
@@ -226,8 +227,8 @@ void append_sanitised(std::string& out, const char* msg, size_t n) {
   }
 }
 
-// SGR foreground colour for a log row, keyed by ng-log severity.  INFO is dim so
-// it recedes; warnings/errors escalate to yellow/red so they stand out.
+// SGR foreground colour for a log row, keyed by ng-log severity.  INFO is dim
+// so it recedes; warnings/errors escalate to yellow/red so they stand out.
 const char* severity_color(int severity) {
   switch (severity) {
     case 1:
@@ -345,10 +346,10 @@ void terminal_console_push(int severity,
 }
 
 void terminal_append_console(std::string& s) {
-  // Reserve a fixed block (header + g_console_lines rows) regardless of how many
-  // messages exist, so the image never shifts as logs arrive: empty slots are
-  // drawn as blank cleared rows.  The newest messages sit at the bottom of the
-  // block, right above the image, tailing like a real console.  Same
+  // Reserve a fixed block (header + g_console_lines rows) regardless of how
+  // many messages exist, so the image never shifts as logs arrive: empty slots
+  // are drawn as blank cleared rows.  The newest messages sit at the bottom of
+  // the block, right above the image, tailing like a real console.  Same
   // cursor-home overdraw + reverse-video header style as the legend/stats rows.
   if (!g_console)
     return;

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -6,9 +6,13 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <deque>
+#include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include <sys/ioctl.h>
 #include <termios.h>
 #include <unistd.h>
 
@@ -59,6 +63,24 @@ uint32_t g_stats_last_ms = 0;
 bool g_stats_started = false;
 std::string
     g_stats_line;  // last formatted report, drawn by terminal_append_stats
+
+// ---------------------------------------------------------------------------
+// Log console: a fixed block of rows above the image mirroring ng-log output.
+// ---------------------------------------------------------------------------
+// One captured log message: its ng-log severity (0=INFO..3=FATAL, selects the
+// row colour) and the sanitised single-line text.
+struct ConsoleLine {
+  int severity = 0;
+  std::string text;
+};
+
+bool g_console = false;   // wired to --term_console
+int g_console_lines = 5;  // reserved message rows (wired to --term_console_lines)
+// A few more than g_console_lines are retained so raising the row count (or a
+// burst arriving between frames) still has scrollback to show.
+constexpr size_t CONSOLE_HISTORY = 256;
+std::mutex g_console_mutex;         // guards g_console_buf (sink vs. render thread)
+std::deque<ConsoleLine> g_console_buf;
 
 struct KeyState {
   bool pressed = false;
@@ -182,6 +204,43 @@ void maybe_report_stats(uint32_t now) {
   g_stats_last_ms = now;
 }
 
+// Current terminal width in columns, so console rows can be truncated to avoid
+// line-wrap (which would push the game image down a row).  Falls back to 80 when
+// the size is unknown (e.g. output is not a tty).
+int term_cols() {
+  winsize ws{};
+  if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0)
+    return ws.ws_col;
+  return 80;
+}
+
+// Append `msg` (length `n`) to `out` as a single printable line: control bytes
+// (newlines, tabs, ...) become spaces so one log entry never spans rows.
+void append_sanitised(std::string& out, const char* msg, size_t n) {
+  if (!msg)
+    return;
+  out.reserve(out.size() + n);
+  for (size_t i = 0; i < n; ++i) {
+    const unsigned char c = static_cast<unsigned char>(msg[i]);
+    out += (c < 0x20 || c == 0x7f) ? ' ' : static_cast<char>(c);
+  }
+}
+
+// SGR foreground colour for a log row, keyed by ng-log severity.  INFO is dim so
+// it recedes; warnings/errors escalate to yellow/red so they stand out.
+const char* severity_color(int severity) {
+  switch (severity) {
+    case 1:
+      return "\x1b[33m";  // WARNING -> yellow
+    case 2:
+      return "\x1b[31m";  // ERROR -> red
+    case 3:
+      return "\x1b[1;31m";  // FATAL -> bold red
+    default:
+      return "\x1b[2m";  // INFO -> dim
+  }
+}
+
 void flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
   if (lv_display_flush_is_last(disp) && g_encode) {
     const int w = lv_area_get_width(area);
@@ -255,6 +314,74 @@ void terminal_append_stats(std::string& s) {
   s += "\x1b[K\x1b[7m";
   s += g_stats_line.empty() ? "term_stats: measuring..." : g_stats_line;
   s += "\x1b[0m\r\n";
+}
+
+void terminal_set_console(bool enabled, int lines) {
+  g_console = enabled;
+  g_console_lines = lines < 1 ? 1 : lines;
+}
+
+void terminal_console_push(int severity,
+                           const char* file,
+                           int line,
+                           const char* msg,
+                           size_t msg_len) {
+  ConsoleLine entry;
+  entry.severity = severity;
+  // Prefix with the source location (as ng-log's own format does) so the
+  // console is useful for tracing where a message came from.
+  if (file && *file) {
+    entry.text += file;
+    entry.text += ':';
+    entry.text += std::to_string(line);
+    entry.text += "] ";
+  }
+  append_sanitised(entry.text, msg, msg_len);
+
+  std::lock_guard<std::mutex> lock(g_console_mutex);
+  g_console_buf.push_back(std::move(entry));
+  while (g_console_buf.size() > CONSOLE_HISTORY)
+    g_console_buf.pop_front();
+}
+
+void terminal_append_console(std::string& s) {
+  // Reserve a fixed block (header + g_console_lines rows) regardless of how many
+  // messages exist, so the image never shifts as logs arrive: empty slots are
+  // drawn as blank cleared rows.  The newest messages sit at the bottom of the
+  // block, right above the image, tailing like a real console.  Same
+  // cursor-home overdraw + reverse-video header style as the legend/stats rows.
+  if (!g_console)
+    return;
+
+  const int cols = term_cols();
+
+  s += "\x1b[K\x1b[7m";
+  s += "ng-log console";
+  s += "\x1b[0m\r\n";
+
+  std::lock_guard<std::mutex> lock(g_console_mutex);
+  const int have = static_cast<int>(g_console_buf.size());
+  const int shown = have < g_console_lines ? have : g_console_lines;
+  const int blank = g_console_lines - shown;
+  const int first = have - shown;  // index of the oldest shown message
+
+  for (int row = 0; row < g_console_lines; ++row) {
+    s += "\x1b[K";  // clear the whole row first (cursor is at column 0)
+    if (row < blank) {
+      s += "\r\n";  // no message yet for this slot
+      continue;
+    }
+    const ConsoleLine& entry = g_console_buf[first + (row - blank)];
+    s += severity_color(entry.severity);
+    // Truncate to the terminal width so a long line cannot wrap and push the
+    // image down.  Colour escapes have zero display width, so only the visible
+    // text is measured.
+    if (cols > 0 && static_cast<int>(entry.text.size()) > cols)
+      s.append(entry.text, 0, static_cast<size_t>(cols));
+    else
+      s += entry.text;
+    s += "\x1b[0m\r\n";
+  }
 }
 
 void terminal_write(const char* p, size_t n) {

--- a/src/log_console.cxx
+++ b/src/log_console.cxx
@@ -1,0 +1,37 @@
+#include "log_console.hxx"
+
+#include <cstddef>
+
+#include <ng-log/logging.h>
+
+#include "terminal.hxx"
+
+namespace {
+
+// Forwards each ng-log message into the terminal log console.  send() must be
+// thread-safe (ng-log calls it from whichever thread ran the LOG() line) and
+// must not itself log; terminal_console_push only touches a mutex-guarded ring
+// buffer, so both hold.
+class TerminalLogSink : public nglog::LogSink {
+ public:
+  void send(nglog::LogSeverity severity,
+            const char* /*full_filename*/,
+            const char* base_filename,
+            int line,
+            const nglog::LogMessageTime& /*time*/,
+            const char* message,
+            size_t message_len) override {
+    terminal_console_push(static_cast<int>(severity), base_filename, line,
+                          message, message_len);
+  }
+};
+
+// The sink is registered with ng-log for the process lifetime, so give it
+// static storage rather than leaking a heap allocation.
+TerminalLogSink g_sink;
+
+}  // namespace
+
+void log_console_install() {
+  nglog::AddLogSink(&g_sink);
+}

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -17,6 +17,7 @@
 #include <inicpp.hpp>
 
 #include "iterm.hxx"
+#include "log_console.hxx"
 #include "profiler.hxx"
 #include "sixel.hxx"
 #include "terminal.hxx"
@@ -50,6 +51,16 @@ DEFINE_bool(
     "While a terminal backend (--sixel/--iterm) is active, draw the "
     "emit rate (frame size, MB/s, fps) on-screen just under the control "
     "legend, refreshed about once a second");
+DEFINE_bool(
+    term_console,
+    true,
+    "While a terminal backend (--sixel/--iterm) is active, draw a log "
+    "console above the game image that mirrors ng-log messages on-screen "
+    "(so they are not scribbled over the picture via stderr); the last "
+    "--term_console_lines messages are tailed, newest at the bottom");
+DEFINE_int32(term_console_lines,
+             5,
+             "Number of ng-log message rows the --term_console panel reserves");
 DEFINE_bool(profile,
             false,
             "Enable the CPU/memory profiler: measure per-frame work time and "
@@ -191,6 +202,21 @@ int main(int argc, char** argv) {
          "backend";
 
   terminal_set_stats(FLAGS_term_stats);
+
+  // The log console mirrors ng-log output on the alternate screen while a
+  // terminal backend paints the game there; without it, ng-log's stderr writes
+  // would scribble over the image.  Configure it always (harmless for the SDL
+  // path, whose encoder never runs), but only install the sink and stop routing
+  // messages to stderr when such a backend is actually active and the console
+  // is enabled.
+  const bool terminal_backend = FLAGS_sixel || FLAGS_iterm;
+  terminal_set_console(FLAGS_term_console, FLAGS_term_console_lines);
+  if (terminal_backend && FLAGS_term_console) {
+    log_console_install();
+    // Keep stderr clean so messages land only in the on-screen console; FATAL
+    // still prints (it aborts and restores the terminal anyway).
+    nglog::SetStderrLogging(nglog::NGLOG_FATAL);
+  }
 
   std::shared_ptr<lv_display_t> display;
   if (FLAGS_sixel) {


### PR DESCRIPTION
## Summary

Adds an on-screen log console to the `--sixel` and `--iterm` terminal backends that mirrors `ng-log` output directly above the game image. This prevents log messages from being written to stderr and corrupting the terminal picture during gameplay.

## Key Changes

- **New log console infrastructure**: Added `terminal_set_console()`, `terminal_console_push()`, and `terminal_append_console()` functions to manage a thread-safe, fixed-height message buffer in `mruby-rgss/src/terminal.cxx`
  - Ring buffer stores up to 256 messages with severity level and sanitized single-line text
  - Mutex-guarded to safely receive messages from any thread
  - Fixed block height (header + configurable rows) ensures the game image never shifts as messages arrive

- **Log sink integration**: Created `src/log_console.cxx` with an `nglog::LogSink` subclass that forwards messages into the terminal console
  - Keeps the `mruby-rgss` gem free of `ng-log` compile-time dependencies
  - Installed only when a terminal backend is active and console is enabled

- **Command-line flags**: Added `--term_console` (enabled by default) and `--term_console_lines=N` (default 5) to control the console
  - `--noterm_console` disables the feature
  - `--term_console_lines=N` sets the number of message rows reserved

- **Encoder integration**: Updated `sixel_encode_frame()` and `iterm_encode_frame()` to call `terminal_append_console()` after stats, rendering the console block with the legend and stats

- **Stderr suppression**: When a terminal backend is active with the console enabled, `ng-log`'s stderr output is suppressed to `FATAL` level only, preventing message corruption of the image

## Implementation Details

- **Single-line messages**: Control characters (newlines, tabs) are replaced with spaces during capture so each log entry occupies exactly one row
- **Severity coloring**: Messages are colored by `ng-log` severity — dim INFO, yellow WARNING, red ERROR, bold-red FATAL — for visual hierarchy
- **Width truncation**: Console rows are truncated to terminal width (via `TIOCGWINSZ`) to prevent line wrapping that would shift the image down
- **Newest-at-bottom layout**: Messages tail with the newest at the bottom, nearest the game image, like a real console
- **Fixed height guarantee**: Empty message slots are drawn as blank cleared rows, so the image position remains stable regardless of message count

## Documentation

Added comprehensive ADR 0005 documenting the design rationale, thread-safety guarantees, and architectural split between the executable and gem.

https://claude.ai/code/session_01XAvJrtuBiE2Rzq6c86k2Nz