### PR TITLE
Persist emscripten system-library cache in the wasm CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,22 +105,6 @@ jobs:
 
   wasm:
     runs-on: ubuntu-24.04
-    env:
-      # Cache emcc/em++ compilations with ccache (sccache, the dev-shell default,
-      # does not support emcc and silently compiles uncached). CCACHE_DIR matches
-      # the cached path below so the cache actually survives between runs.
-      CCACHE_DIR: /home/runner/.ccache
-      CCACHE_MAXSIZE: "2G"
-      # Make cache entries reproducible across runs so the warm cache actually
-      # hits. Without this the RelWithDebInfo (-g) objects embed the absolute
-      # build path and the hash keys on the compiler mtime, both of which cost
-      # hits; BASEDIR+NOHASHDIR strip the paths, COMPILERCHECK=content ignores
-      # the (nix-store) compiler timestamp, and the sloppiness flags stop
-      # freshly-checked-out header mtimes and __DATE__/__TIME__ from missing.
-      CCACHE_BASEDIR: ${{ github.workspace }}
-      CCACHE_NOHASHDIR: "true"
-      CCACHE_COMPILERCHECK: content
-      CCACHE_SLOPPINESS: "time_macros,include_file_ctime,include_file_mtime,system_headers,locale,pch_defines"
     steps:
       - run: git config --global submodule.fetchJobs 4
       - uses: actions/checkout@v7
@@ -136,9 +120,7 @@ jobs:
 
       - uses: actions/cache@v6
         with:
-          path: |
-            ~/.ccache
-            ~/.emscripten_cache
+          path: ~/.emscripten_cache
           key: ${{ runner.os }}-emcc-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-emcc-
 
@@ -153,18 +135,12 @@ jobs:
       - name: cmake
         run: |
           nix develop -c env EM_CACHE="$HOME/.emscripten_cache" \
-            emcmake cmake -S . -B wasm-build -GNinja \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            emcmake cmake -S . -B wasm-build -GNinja
 
       - name: build
         run: |
           nix develop -c env EM_CACHE="$HOME/.emscripten_cache" \
             cmake --build wasm-build
-
-      - name: ccache stats
-        if: always()
-        run: nix develop -c ccache -s
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,15 +132,25 @@ jobs:
           key: ${{ runner.os }}-emcc-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-emcc-
 
+      # Emscripten builds its system libraries (libc/libc++, and the -fexceptions
+      # variant this project forces) on the first emcc call, which costs ~50s of
+      # the configure step. The nixpkgs emscripten setup hook points EM_CACHE at
+      # an ephemeral temp dir, so that work is thrown away every run and the
+      # cached ~/.emscripten_cache is never written. Override EM_CACHE on the
+      # command itself (after the hook runs) so the libraries are built once and
+      # restored on later runs. It must be set for both configure and build,
+      # since emcc runs in both.
       - name: cmake
         run: |
-          nix develop -c emcmake cmake -S . -B wasm-build -GNinja \
+          nix develop -c env EM_CACHE="$HOME/.emscripten_cache" \
+            emcmake cmake -S . -B wasm-build -GNinja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: build
         run: |
-          nix develop -c cmake --build wasm-build
+          nix develop -c env EM_CACHE="$HOME/.emscripten_cache" \
+            cmake --build wasm-build
 
       - name: ccache stats
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,16 @@ jobs:
       # the cached path below so the cache actually survives between runs.
       CCACHE_DIR: /home/runner/.ccache
       CCACHE_MAXSIZE: "2G"
+      # Make cache entries reproducible across runs so the warm cache actually
+      # hits. Without this the RelWithDebInfo (-g) objects embed the absolute
+      # build path and the hash keys on the compiler mtime, both of which cost
+      # hits; BASEDIR+NOHASHDIR strip the paths, COMPILERCHECK=content ignores
+      # the (nix-store) compiler timestamp, and the sloppiness flags stop
+      # freshly-checked-out header mtimes and __DATE__/__TIME__ from missing.
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "true"
+      CCACHE_COMPILERCHECK: content
+      CCACHE_SLOPPINESS: "time_macros,include_file_ctime,include_file_mtime,system_headers,locale,pch_defines"
     steps:
       - run: git config --global submodule.fetchJobs 4
       - uses: actions/checkout@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,12 @@ jobs:
 
   wasm:
     runs-on: ubuntu-24.04
+    env:
+      # Cache emcc/em++ compilations with ccache (sccache, the dev-shell default,
+      # does not support emcc and silently compiles uncached). CCACHE_DIR matches
+      # the cached path below so the cache actually survives between runs.
+      CCACHE_DIR: /home/runner/.ccache
+      CCACHE_MAXSIZE: "2G"
     steps:
       - run: git config --global submodule.fetchJobs 4
       - uses: actions/checkout@v7
@@ -128,11 +134,17 @@ jobs:
 
       - name: cmake
         run: |
-          nix develop -c emcmake cmake -S . -B wasm-build -GNinja
+          nix develop -c emcmake cmake -S . -B wasm-build -GNinja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: build
         run: |
           nix develop -c cmake --build wasm-build
+
+      - name: ccache stats
+        if: always()
+        run: nix develop -c ccache -s
 
       - uses: actions/upload-artifact@v7
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
                 autoconf
                 automake
                 cabal-install
+                ccache
                 clang-tools
                 cmake
                 cmake-format

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
                 autoconf
                 automake
                 cabal-install
-                ccache
                 clang-tools
                 cmake
                 cmake-format


### PR DESCRIPTION
## Summary
Speeds up the `wasm` CI job by persisting emscripten's system-library cache across runs. On a cold run the first `emcc` call spends ~46s building emscripten's system libraries (libc/libc++, plus the `-fexceptions` variant this project forces). The nixpkgs emscripten setup hook points `EM_CACHE` at an ephemeral temp dir, so that work was thrown away every run and the workflow's `~/.emscripten_cache` cache was never actually written.

This overrides `EM_CACHE` to `~/.emscripten_cache` on the `cmake` and `build` commands (after the dev-shell hook runs), so the libraries are built once and restored on later runs.

## Changes
- `.github/workflows/build.yml` (`wasm` job): set `EM_CACHE=$HOME/.emscripten_cache` on the configure and build steps, and narrow the `actions/cache` path to `~/.emscripten_cache` (the previously-cached `~/.ccache` was never written to).

## Measured impact
- The eliminated system-library rebuild is **~46s** (measured on the `-- Looking for C++ include unistd.h` configure check: 15:48:02 → 15:48:48 cold).
- On the best like-for-like comparison the `cmake` configure step dropped from **4m00s (cold) → 2m31s (warm)** — the 46s plus faster feature-probe links against the pre-built libs.
- Caveat: GitHub's shared runners vary by more than the saving on any single run (the `build` step alone swung between ~4m and ~5.3m across near-identical configs), so the solid, deterministic floor is the ~46s syslib rebuild; the larger drop is real but sits partly inside runner noise.

## What was tried and dropped
An earlier iteration wired **ccache** into the wasm build (sccache, the dev-shell default, does not support `emcc`). Across several runs — including a warm cache with the standard reproducibility knobs (`CCACHE_BASEDIR`, `CCACHE_NOHASHDIR`, `CCACHE_COMPILERCHECK=content`, relaxed sloppiness) — the cross-run hit rate stayed at ~13–17%. emcc's objects don't reproduce between runs, so ccache only added hashing/store overhead and made the build step slower than the uncached baseline. It was reverted; only the `EM_CACHE` fix remains.

## Note on the ~5-minute goal
Caching alone doesn't get the `wasm` job to ~5 min — this lands it around ~7 min. The remaining floor is structural: the mruby `rake` build runs ~88s essentially serial, the ng-log/gflags CMake feature-probes cost ~90s (each `emcc`/node spawn ~1.7s), plus ~1m40 fixed overhead (checkout + nix restore). Getting to ~5 min would mean parallelizing the mruby build, trimming the configure probes, or a larger runner — separate, more invasive changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)