### PR TITLE
Remove flake-utils dependency and use tarball nixpkgs source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,58 +1,21 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784526640,
-        "narHash": "sha256-fg38+m9GRsJjGzuKVBQH5fksSijZSbZR/1gTmNUECBo=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "036c2421db75172aeef4bb83921988891d4773c9",
-        "type": "github"
+        "lastModified": 1785002762,
+        "narHash": "sha256-djHx+I7Yp2yyngFbDgZtvcLyWsGZ85WlVSTl1XW3Ta8=",
+        "rev": "f7a2e428f5d71c47a5a938a3c5ad7138bb291093",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.6144.f7a2e428f5d7/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "release-26.05",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,41 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=release-26.05";
-    flake-utils.url = "github:numtide/flake-utils";
+    # Fetched from the NixOS channel mirror (*.nixos.org) rather than
+    # `github:nixos/nixpkgs` so the flake resolves in sandboxes whose GitHub
+    # access is scoped to the session's own repositories (e.g. Claude Code on
+    # the web), where GitHub archive tarballs for other repos are rejected.
+    # Channel revisions are what cache.nixos.org has prebuilt, so binary-cache
+    # hit rates are as good as or better than tracking the release branch head.
+    nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
     self.submodules = true;
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      flake-utils,
-    }:
-    flake-utils.lib.eachDefaultSystem (
+    { self, nixpkgs }:
+    let
+      # Minimal inline of flake-utils' `eachDefaultSystem`, dropped as an input
+      # for the same GitHub-scoping reason as nixpkgs above. For each system it
+      # evaluates `f system` and lifts every returned attribute to
+      # `<attr>.<system>`, merging across systems.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      eachDefaultSystem =
+        f:
+        builtins.foldl' (
+          acc: system:
+          let
+            ret = f system;
+          in
+          builtins.foldl' (
+            acc': key: acc' // { ${key} = (acc'.${key} or { }) // { ${system} = ret.${key}; }; }
+          ) acc (builtins.attrNames ret)
+        ) { } systems;
+    in
+    eachDefaultSystem (
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
## Summary
This PR removes the `flake-utils` dependency and replaces the GitHub-based nixpkgs source with a tarball-based channel URL. It includes an inline implementation of the minimal `eachDefaultSystem` functionality needed to support multi-system outputs.

## Key Changes
- **Removed flake-utils dependency**: Eliminated the external `flake-utils` input to reduce dependencies and improve compatibility in sandboxed environments with restricted GitHub access
- **Switched nixpkgs source**: Changed from `github:nixos/nixpkgs?ref=release-26.05` to `https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz` to enable flake resolution in environments where GitHub archive access is scoped to the session's own repositories
- **Inlined eachDefaultSystem**: Implemented a minimal inline version of `flake-utils.lib.eachDefaultSystem` that:
  - Defines the standard system list (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin)
  - Uses `builtins.foldl'` to iterate over systems and merge outputs
  - Maintains the same output structure as the original flake-utils implementation

## Implementation Details
The inline `eachDefaultSystem` function uses nested `foldl'` operations to:
1. Iterate through each system
2. Evaluate the output function for that system
3. Restructure the returned attributes from `{ attr = value }` to `{ attr.system = value }`
4. Merge results across all systems into a single attribute set

This approach maintains full compatibility with the existing flake outputs while eliminating the external dependency.

https://claude.ai/code/session_01WXF6bBfRiqoaJEx6bW5vBF