### PR TITLE
Remove git submodule dependency updates from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,17 +14,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-
-  # The project's third-party dependencies are vendored as git submodules under
-  # 3rd/. Watch them for new upstream commits. They are grouped into a single
-  # PR to keep the noise down; review carefully since some (e.g. the mruby
-  # gems) are version-coupled.
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      submodules:
-        patterns:
-          - "*"


### PR DESCRIPTION
This change removes the Dependabot configuration for automatically checking and updating git submodules.

## Summary
The git submodule update automation has been disabled by removing the `gitsubmodule` package ecosystem configuration from `.github/dependabot.yml`.

## Changes
- Removed the `gitsubmodule` package ecosystem configuration that was monitoring the `3rd/` directory for upstream commits
- Removed the weekly schedule and grouping settings that were bundling submodule updates into a single PR

## Rationale
The vendored third-party dependencies (particularly version-coupled dependencies like mruby gems) will no longer be automatically updated via Dependabot. This likely reflects a decision to manage submodule updates manually to better control version coupling and ensure careful review of interdependent changes.

https://claude.ai/code/session_01MzhoVM9aZgEezRcxKGX97X