### PR TITLE
Add RPG Maker 2003 item, skill, and battle animation schema

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3,11 +3,14 @@
 ## RPG Maker 2k
 - 🚧 Support all data schema of LCF — the core database, map tree and map-unit
   chunks needed for boot and gameplay are covered and validated against a real
-  test-bed by `scripts/lcf_testbed_check.rb`. Remaining chunks that appear in
-  real data but are not yet in `schema.rb` (surfaced by walking the test-bed):
-  database items (usage/effect flags 25–28 and `animation_data` sub-chunks),
-  `battle_anime2` frame/timing chunks, skill chunk 16, and a few map-unit
-  chunks (42, 50, 60–62, 90 — save/encounter/parallax metadata). These are
+  test-bed by `scripts/lcf_testbed_check.rb`. Transcribed from the 200X共通
+  解析まとめ wiki: item armour-option flags (25–28) and the item/skill
+  `使用時アニメ` weapon fields (the shared `BATTLER_ANIMATION` union),
+  skill switch/occasion chunks (13, 16, 18, 19), and the `battle_anime2`
+  attack-motion + `基本と拡張`/`武器` pose object lists (chunks 2, 10, 11).
+  The remaining map-unit chunks that appear in real data (42, 50, 60–62, 90 —
+  save/encounter/parallax metadata) are **not documented on the wiki's マップ
+  page**, so they still need to be derived from the test-bed walk. These are
   editor/battle/2003 details not on the walkable-game critical path
 - ✅ Show window component for title scene
 - ✅ Implement New Game functionality — builds the party, loads the start map

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -56,11 +56,21 @@ module LCF
       2 => { name: :skill_id, type: :int, default: 1 },
     }
 
-    # Battler-animation attachment (使用者アニメ) shared by skills and items.
+    # Battler-animation attachment (使用時アニメ) shared by skills and items.
+    # The アイテム and 特殊技能 pages document different fields of the same
+    # object; this is their union. The weapon/movement fields (3, 4, 7-9, 12,
+    # 13) are from the item page, the basic-CBA field (14) from the skill page.
     BATTLER_ANIMATION = {
-      5 => { name: :movement, type: :int, default: 0 },
-      6 => { name: :after_image, type: :bool, default: false },
-      14 => { name: :battle_animation_id, type: :int, default: 3 },
+      3 => { name: :weapon_cba, type: :int, default: 0 },        # 武器CBAの選択 (2003)
+      4 => { name: :weapon, type: :int, default: 0 },            # 武器 (2003)
+      5 => { name: :movement, type: :int, default: 0 },          # 移動の選択
+      6 => { name: :after_image, type: :bool, default: false },  # 残像の選択
+      7 => { name: :attack_times, type: :int, default: 0 },      # 攻撃の回数 (2003)
+      8 => { name: :ranged_weapon, type: :bool, default: false },# 遠距離武器/使う (2003)
+      9 => { name: :flying_animation, type: :int, default: 0 },  # 飛行中のアニメの選択 (2003)
+      12 => { name: :speed, type: :int, default: 0 },            # 速度 (2003)
+      13 => { name: :extension, type: :int, default: 1 },        # 拡張 (2003)
+      14 => { name: :battle_animation_id, type: :int, default: 3 }, # 基本CBAの選択
     }
 
     DATABASE = {
@@ -127,7 +137,11 @@ module LCF
             10 => { name: :sp_percent, type: :int, default: 1 },
             11 => { name: :sp_cost, type: :int, default: 0 },
             12 => { name: :scope, type: :int, default: 0 },
+            13 => { name: :switch_id, type: :int, default: 1 },              # ONにするスイッチ (種別: スイッチ)
             14 => { name: :animation_id, type: :int, default: 1 },
+            16 => { name: :sound_effect, type: :Array1D, elements: SE },     # 効果音 (種別: テレポート/エスケープ/スイッチ)
+            18 => { name: :occasion_field, type: :bool, default: true },     # 使用可能な場面/フィールド
+            19 => { name: :occasion_battle, type: :bool, default: false },   # 使用可能な場面/バトル
             20 => { name: :reverse_state_effect, type: :bool, default: false },
             21 => { name: :physical_rate, type: :int, default: 0 },
             22 => { name: :magical_rate, type: :int, default: 3 },
@@ -173,6 +187,10 @@ module LCF
             22 => { name: :dual_attack, type: :bool, default: false },
             23 => { name: :attack_all, type: :bool, default: false },
             24 => { name: :ignore_evasion, type: :bool, default: false },
+            25 => { name: :prevent_critical, type: :bool, default: false },  # 必殺(痛恨の一撃)防止 (盾/鎧/兜/装飾品)
+            26 => { name: :raise_evasion, type: :bool, default: false },     # 物理攻撃の回避率アップ
+            27 => { name: :half_sp_cost, type: :bool, default: false },      # MP消費量半分
+            28 => { name: :no_terrain_damage, type: :bool, default: false }, # 地形ダメージ無効
             29 => { name: :cursed, type: :bool, default: false },
             31 => { name: :scope, type: :int, default: 0 },
             32 => { name: :recover_hp_rate, type: :int, default: 0 },
@@ -755,8 +773,29 @@ module LCF
           name: :battle_anime2, type: :Array2D,
           elements: {
             1 => { name: :name, type: :string, default: '' },
-            2 => { name: :battler_name, type: :string, default: '' },
-            3 => { name: :speed, type: :int, default: 0 },
+            2 => { name: :attack_motion, type: :int, default: 0 },     # 攻撃モーション (2003)
+            10 => {
+              # 基本と拡張 — object list, 33 elements by default (2003).
+              name: :base_data, type: :Array2D,
+              elements: {
+                1 => { name: :name, type: :string, default: '' },
+                2 => { name: :battler_name, type: :string, default: '' },   # 戦闘(武器)グラフィック
+                3 => { name: :battler_position, type: :int, default: 0 },   # グラフィック/位置
+                # 戦闘アニメ. The wiki table's type/default cells are garbled
+                # (形式 "0" / 省略時 "空文字列"); it holds the battle-animation id.
+                4 => { name: :animation_id, type: :int, default: 0 },
+                5 => { name: :extension, type: :int, default: 1 },          # 拡張
+              }
+            },
+            11 => {
+              # 武器 — object list, 33 elements by default (2003).
+              name: :weapon_data, type: :Array2D,
+              elements: {
+                1 => { name: :name, type: :string, default: '' },
+                2 => { name: :battler_name, type: :string, default: '' },   # 戦闘(武器)グラフィック
+                3 => { name: :battler_position, type: :int, default: 0 },   # グラフィック/位置
+              }
+            },
           }
         },
       },

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -93,6 +93,60 @@ assert "LCF::MapTree multi-part parse exposes start position" do
   assert_equal "MAP1", lmt.map_properties[1].name
 end
 
+assert "LCF::Database item armour option flags (chunks 25-28) and equip animation" do
+  # 使用時アニメ (chunk 70) is an object list; its weapon fields (3/4/12) come
+  # from the item page, so the shared BATTLER_ANIMATION union must decode them.
+  equip_anim = lcf_array1d([lcf_int_field(3, 2), lcf_int_field(4, 5),
+                            lcf_int_field(12, 4)])
+  item = lcf_array1d([lcf_str_field(1, "Shield"),
+                      lcf_field(25, "\x01"), lcf_field(26, "\x00"),
+                      lcf_field(27, "\x01"), lcf_field(28, "\x01"),
+                      lcf_field(70, lcf_array2d([[1, equip_anim]]))])
+  db = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(13, lcf_array2d([[1, item]]))]))) # item = chunk 13
+  assert_equal "Shield", db.item[1].name
+  assert_true db.item[1].prevent_critical
+  assert_false db.item[1].raise_evasion
+  assert_true db.item[1].half_sp_cost
+  assert_true db.item[1].no_terrain_damage
+  a = db.item[1].animation_data[1]
+  assert_equal 2, a.weapon_cba
+  assert_equal 5, a.weapon
+  assert_equal 4, a.speed
+end
+
+assert "LCF::Database skill switch/occasion chunks (13, 16, 18, 19)" do
+  se = lcf_array1d([lcf_str_field(1, "Teleport"), lcf_int_field(3, 80)])
+  skill = lcf_array1d([lcf_str_field(1, "Warp"), lcf_int_field(13, 7),
+                       lcf_field(16, se), lcf_field(18, "\x01"),
+                       lcf_field(19, "\x00")])
+  db = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(12, lcf_array2d([[1, skill]]))]))) # skill = chunk 12
+  assert_equal 7, db.skill[1].switch_id
+  assert_equal "Teleport", db.skill[1].sound_effect.file
+  assert_equal 80, db.skill[1].sound_effect.volume
+  assert_true db.skill[1].occasion_field
+  assert_false db.skill[1].occasion_battle
+end
+
+assert "LCF::Database battle_anime2 attack motion and pose object lists (chunks 2, 10, 11)" do
+  base = lcf_array1d([lcf_str_field(1, "Swing"), lcf_str_field(2, "Sword"),
+                      lcf_int_field(3, 1), lcf_int_field(4, 6)])
+  weapon = lcf_array1d([lcf_str_field(1, "Blade"), lcf_str_field(2, "WpnGfx"),
+                        lcf_int_field(3, 2)])
+  anim = lcf_array1d([lcf_str_field(1, "Fighter"), lcf_int_field(2, 3),
+                      lcf_field(10, lcf_array2d([[1, base]])),
+                      lcf_field(11, lcf_array2d([[1, weapon]]))])
+  db = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(32, lcf_array2d([[1, anim]]))]))) # battle_anime2 = chunk 32
+  assert_equal "Fighter", db.battle_anime2[1].name
+  assert_equal 3, db.battle_anime2[1].attack_motion
+  b = db.battle_anime2[1].base_data[1]
+  assert_equal "Sword", b.battler_name
+  assert_equal 6, b.animation_id
+  assert_equal "WpnGfx", db.battle_anime2[1].weapon_data[1].battler_name
+end
+
 assert "LCF decodes boolean chunks (1 byte 0/1)" do
   ce = lcf_array1d([lcf_int_field(11, 3), lcf_field(12, "\x01"),
                     lcf_int_field(13, 7)])


### PR DESCRIPTION
This PR adds support for additional RPG Maker 2003 data fields in the LCF database schema, bringing the implementation closer to full coverage of the 200X共通解析まとめ wiki documentation.

## Summary
Expanded the LCF schema to support item armour options, skill configuration, and battle animation pose data that were previously missing. These additions enable proper decoding of equipment effects, skill behavior flags, and combat animation definitions.

## Key Changes

- **Item armour option flags (chunks 25-28)**: Added support for `prevent_critical`, `raise_evasion`, `half_sp_cost`, and `no_terrain_damage` boolean flags on equipment items
- **Battler animation union expansion**: Extended `BATTLER_ANIMATION` schema to include weapon-related fields (3, 4, 7-9, 12-13) from the item page alongside existing skill-page fields, documenting the shared object structure used by both skills and items
- **Skill configuration chunks**: Added support for:
  - Chunk 13: `switch_id` (switch to toggle when skill is used)
  - Chunk 16: `sound_effect` (SE object with file and volume)
  - Chunks 18-19: `occasion_field` and `occasion_battle` (usage context flags)
- **Battle animation 2 pose data (chunks 2, 10, 11)**: Added support for:
  - Chunk 2: `attack_motion` (attack motion type)
  - Chunk 10: `base_data` (object list for base and extended poses with battler graphics and animation)
  - Chunk 11: `weapon_data` (object list for weapon poses with battler graphics)

## Implementation Details

The `BATTLER_ANIMATION` schema now documents that it represents a union of fields from both the item page (weapon/movement fields) and skill page (basic CBA field), with detailed comments explaining the source of each field. This clarifies the shared structure used across different database objects.

All new fields include Japanese wiki field names as comments for reference and maintainability.

https://claude.ai/code/session_019mEyaCwUAwSRBKS9NUF2Mc