### PR TITLE
Add event movement runtime: move routes and autonomous walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- The event interpreter now supports **Call Event**. A Call Event command
+  suspends the current command list and runs a referenced list to completion,
+  then resumes where it left off, via a call stack on `Game::Interpreter` and a
+  resolver the scene supplies (common events by id; a map event's page from the
+  loaded map). This makes *call-only* common events (start condition 5) — which
+  auto-start and parallel processing never reach — actually run, and lets events
+  share logic. Nested calls unwind correctly and recursion is bounded
+  (`MAX_CALL_DEPTH`) so a self-calling event terminates instead of hanging.
+  Conditional Branch also gained the **timer** condition (compare the countdown
+  timer's seconds). `Scene::Map` wires a resolver over its common and map events
+  (refreshed on teleport). Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.
 - Events now move on the map. Decoded move routes (`LCF.parse_move_commands`)
   and event-page movement settings, which previously only parsed, now drive
   events at runtime. A new `Game::MoveRoute` executor runs a decoded route

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -90,9 +90,14 @@ The work below is roughly ordered by the critical path to a walkable game
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Conditional Branch/Else/End, Loop/Break/End, Label/Jump, Timer, Teleport,
-  Wait, Play BGM/SE, End Event) with a per-frame step cap so a bad loop can't
-  hang; the remaining ~90 commands (Move Event, pictures, screen effects,
-  battles, actor stat changes, Call Event, ...) are TODO
+  Wait, Play BGM/SE, Call Event, End Event) with a per-frame step cap so a bad
+  loop can't hang. **Call Event** suspends the current list, runs the referenced
+  common event (or map-event page) to completion via a resolver + call stack —
+  so call-only common events, which auto-start/parallel never reach, now run —
+  and returns to the caller; recursion is bounded. Conditional Branch covers
+  switch / variable / **timer** / gold / item / actor-in-party conditions. The
+  remaining commands (Move Event, pictures, screen effects, battles, actor stat
+  changes, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   colour/speed/wait codes are consumed). Face graphics, per-code colour changes

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -33,17 +33,24 @@ module Game
       COMMENT          = 12410
       COMMENT_2        = 22410
       END_EVENT        = 12310
+      CALL_EVENT       = 12330
       TELEPORT         = 10810
       WAIT             = 11410
       PLAY_BGM         = 11510
       PLAY_SE          = 11550
     end
 
+    # Upper bound on nested Call Event depth, so a common event that (directly or
+    # indirectly) calls itself unwinds instead of growing the stack without end.
+    MAX_CALL_DEPTH = 100
+
     def initialize(state)
       @state = state
       @list = []
       @index = 0
       @running = false
+      @call_stack = []
+      @resolver = nil
       reset_waits
     end
 
@@ -51,11 +58,15 @@ module Game
     def waiting?; @waiting; end
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
                 :teleport
+    # Resolves the command list a Call Event refers to (a common event, or a page
+    # of a map event). Set by the owning scene; nil disables Call Event.
+    attr_accessor :resolver
 
     def start(commands)
       @list = commands || []
       @index = 0
       @running = true
+      @call_stack = []
       reset_waits
     end
 
@@ -64,17 +75,37 @@ module Game
     MAX_STEPS = 1_000_000
 
     # Advance through commands until the list ends or a command asks to wait.
+    # When the current (possibly called) list runs out, control returns to the
+    # caller via the call stack; the process ends only once the outermost list is
+    # exhausted.
     def update
       return unless @running
       steps = 0
-      while @index < @list.size && !@waiting
+      until @waiting
+        # Unwind any exhausted called lists back to a caller with commands left.
+        return_from_call while @index >= @list.size && !@call_stack.empty?
+        break if @index >= @list.size # nothing left anywhere
         cmd = @list[@index]
         @index += 1
         execute cmd
         steps += 1
         break if steps >= MAX_STEPS
       end
-      @running = false if @index >= @list.size && !@waiting
+      @running = false if finished?
+    end
+
+    # True when nothing is left to run: the current list is exhausted, no caller
+    # is waiting on the stack, and we are not paused on a UI/map request.
+    def finished?
+      @index >= @list.size && @call_stack.empty? && !@waiting
+    end
+
+    # Resume the caller that a finished called-list returned to; returns false
+    # when there is no caller (the outermost list is done).
+    def return_from_call
+      return false if @call_stack.empty?
+      @list, @index = @call_stack.pop
+      true
     end
 
     # Resume after a message/wait/teleport request has been handled.
@@ -82,10 +113,12 @@ module Game
       reset_waits
     end
 
-    # Abandon the rest of the current command list (e.g. after a teleport).
+    # Abandon the rest of the current command list (e.g. after a teleport),
+    # including any pending callers.
     def stop
       @running = false
       @index = @list.size
+      @call_stack = []
       reset_waits
     end
 
@@ -134,9 +167,37 @@ module Game
       when Cmd::WAIT             then do_wait cmd
       when Cmd::PLAY_BGM         then play_audio(:bgm, cmd)
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
+      when Cmd::CALL_EVENT       then do_call_event cmd
       when Cmd::END_EVENT        then @index = @list.size
       else nil # unimplemented / no-op (labels, comments, ...)
       end
+    end
+
+    # Call Event: suspend the current list and run a referenced command list to
+    # completion, then resume where we left off. param0 selects what is called:
+    #   0 – common event: param1 = common event id
+    #   1 – map event:    param1 = event id, param2 = page number
+    #   2 – map event, ids taken indirectly from variables
+    # A missing/empty target is a no-op; recursion is bounded by MAX_CALL_DEPTH.
+    def do_call_event(cmd)
+      return unless @resolver
+      cmds = resolve_call(cmd)
+      return if cmds.nil? || cmds.empty?
+      return if @call_stack.size >= MAX_CALL_DEPTH
+      @call_stack.push [@list, @index]
+      @list = cmds
+      @index = 0
+    end
+
+    def resolve_call(cmd)
+      case cmd.param(0)
+      when 0 then @resolver.common_event_commands(cmd.param(1))
+      when 1 then @resolver.map_event_commands(cmd.param(1), cmd.param(2))
+      when 2 then @resolver.map_event_commands(variables[cmd.param(1)],
+                                               variables[cmd.param(2)])
+      end
+    rescue StandardError
+      nil
     end
 
     # -- flow helpers ---------------------------------------------------------
@@ -331,6 +392,9 @@ module Game
       when 1 # variable: param1 id, param2 operand type, param3 operand, param4 comparison
         rhs = cmd.param(2) == 0 ? cmd.param(3) : variables[cmd.param(3)]
         compare(variables[cmd.param(1)], rhs, cmd.param(4))
+      when 2 # timer: param1 seconds, param2 comparison (0 >=, 1 <=)
+        cmd.param(2) == 0 ? @state.timer_seconds >= cmd.param(1) \
+                          : @state.timer_seconds <= cmd.param(1)
       when 3 # gold: param1 amount, param2 comparison (0 >=, 1 <=)
         cmd.param(2) == 0 ? party.gold >= cmd.param(1) : party.gold <= cmd.param(1)
       when 4 # item: param1 id, param2 (0 has / 1 not)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -284,6 +284,31 @@ class RPG2k
       end
     end
 
+    # Resolves the command list a Call Event refers to. Common events are looked
+    # up by id; a map event's page is fetched from the loaded map unit (best
+    # effort — the page index follows the LCF page numbering).
+    class EventResolver
+      def initialize(common_by_id, map_events)
+        @common = common_by_id || {}
+        @map_events = map_events || {}
+      end
+
+      def common_event_commands(id)
+        @common[id]
+      end
+
+      def map_event_commands(id, page_index)
+        ev = @map_events[id]
+        return nil unless ev
+        pages = ev.pages
+        return nil unless pages
+        page = pages[page_index]
+        page && page.event_commands
+      rescue StandardError
+        nil
+      end
+    end
+
     # Play scene: renders the loaded map and lets the party leader walk around
     # it. Tiles are drawn as solid colour blocks derived from their tile id (a
     # placeholder until real chipset blitting lands — see docs/TODO.md); the
@@ -324,6 +349,7 @@ class RPG2k
         @rng = Game::Rng.new(0x2000)
         @world = MapWorld.new(self, @rng)
         build_events
+        @interpreter.resolver = build_resolver
         @message = nil
         @wait_timer = nil
         @choice_index = 0
@@ -454,6 +480,17 @@ class RPG2k
         { id: id, char: ch, trigger: page_trigger(page),
           commands: page_commands(page), move_type: move_type, route: route,
           move_timer: EVENT_MOVE_DELAY[ch.move_frequency] || 40 }
+      end
+
+      # Build the Call Event resolver for the current map: common events keyed by
+      # id (they are global) plus this map's raw events for map-event page calls.
+      def build_resolver
+        common = {}
+        @common.each { |c| common[c[:id]] = c[:commands] }
+        map_events = (@map.unit.events rescue nil)
+        EventResolver.new(common, map_events)
+      rescue StandardError
+        EventResolver.new({}, nil)
       end
 
       # Recompute the occupied-tile set from the events' current positions.
@@ -612,6 +649,7 @@ class RPG2k
         @started_auto = {}
         @started_common = {}
         build_events
+        @interpreter.resolver = build_resolver
         @moving = false
         @move_count = 0
         @last_frame = nil

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -406,6 +406,111 @@ check 'interpreter pauses on a message and resumes' do
   eq true, st.switches[2] # ran the command after the message
 end
 
+# A Call Event resolver stub: maps common-event id -> command list, and
+# (map event id, page) -> command list.
+class FakeResolver
+  def initialize(common: {}, maps: {})
+    @common = common
+    @maps = maps
+  end
+  def common_event_commands(id); @common[id]; end
+  def map_event_commands(id, page); (@maps[id] || {})[page]; end
+end
+
+check 'Call Event runs a common event then returns to the caller' do
+  st = new_state
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])] # switch 9 = ON
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: { 5 => called })
+  it.start([
+    FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),          # call common event 5
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0]), # then switch 1 = ON
+  ])
+  it.update
+  eq true, st.switches[9], 'the called common event ran'
+  eq true, st.switches[1], 'control returned to the caller'
+  ok !it.running?, 'the whole process finished'
+end
+
+check 'Call Event as the last command returns cleanly (nested unwinds)' do
+  st = new_state
+  inner = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0])]
+  # common event 5 is: set switch 2, then call common event 6 (its last command)
+  middle = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0]),
+            FakeCmd.new(IC::CALL_EVENT, [0, 6, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: { 5 => middle, 6 => inner })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0])]) # call 5 as the only command
+  it.update
+  eq true, st.switches[2]
+  eq true, st.switches[3]
+  ok !it.running?, 'both nested calls unwound and the process ended'
+end
+
+check 'a missing Call Event target is a no-op and the caller continues' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: {}) # id 5 not defined
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq true, st.switches[1]
+  ok !it.running?
+end
+
+check 'a self-calling common event terminates instead of hanging' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  self_call = [FakeCmd.new(IC::CALL_EVENT, [0, 1, 0])] # calls itself
+  it.resolver = FakeResolver.new(common: { 1 => self_call })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 1, 0])])
+  it.update # must return (bounded by MAX_CALL_DEPTH), not loop forever
+  ok !it.running?, 'recursion was bounded and the process ended'
+end
+
+check 'Call Event with no resolver set is a safe no-op' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq true, st.switches[1]
+end
+
+check 'a message inside a called event pauses and resumes across the boundary' do
+  st = new_state
+  called = [FakeCmd.new(IC::SHOW_MESSAGE, [], string: 'hi'),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 8, 8, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: { 7 => called })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 7, 0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok it.waiting?, 'paused on the message inside the called event'
+  eq ['hi'], it.message_lines
+  it.resume
+  it.update
+  eq true, st.switches[8], 'finished the called event after the message'
+  eq true, st.switches[1], 'returned to and finished the caller'
+end
+
+check 'conditional branch on the timer' do
+  st = new_state
+  st.timer_frames = 30 * 60 # 30 seconds remaining
+  it = Game::Interpreter.new(st)
+  cmds = [
+    FakeCmd.new(IC::CONDITIONAL, [2, 10, 0], indent: 0), # timer >= 10s ?
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 4, 4, 0], indent: 1),
+    FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 1),
+    FakeCmd.new(IC::END_BRANCH, [], indent: 0),
+  ]
+  it.start(cmds)
+  it.update
+  eq true, st.switches[4], 'timer >= 10s branch taken'
+  eq false, st.switches[5]
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -108,13 +108,25 @@ def fake_chipset
   OpenStruct.new(name: 'cs', chipset_name: 'cs', passable_data_lower: nil)
 end
 
-def fake_db
+def fake_db(common = nil)
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: ''),
     chipset: { 1 => fake_chipset },
-    common_event: nil,
+    common_event: common,
     player: {}
   )
+end
+
+# An event command (the interpreter reads code/param/string/indent/parameters).
+class ECmd
+  attr_reader :code, :indent, :string, :parameters
+  def initialize(code, params = [], indent: 0, string: '')
+    @code = code
+    @parameters = params
+    @indent = indent
+    @string = string
+  end
+  def param(i); @parameters[i] || 0; end
 end
 
 # One event page. Defaults: an action-trigger, stationary event with no route.
@@ -157,8 +169,8 @@ def fake_party
   OpenStruct.new(leader: nil, actors: [])
 end
 
-def new_scene(events, player: [0, 0])
-  db = fake_db
+def new_scene(events, player: [0, 0], common: nil)
+  db = fake_db(common)
   state = Game::State.new(fake_party, 1, player[0], player[1])
   state.map = fake_map(1, events)
   RPG2k::Scene::Map.new(fake_parent(db), state)
@@ -220,6 +232,20 @@ check 'two events do not stack on the same tile' do
   end
   # They walk toward each other and end up adjacent on row 2.
   ok (ca.x - cb.x).abs == 1, "expected adjacency, got a=#{ca.x} b=#{cb.x}"
+end
+
+check 'an autostart event Calls a call-only common event through the scene' do
+  ic = Game::Interpreter::Cmd
+  # A common event with start_term 5 (call-only): auto-start/parallel never runs
+  # it, so if switch 7 flips it can only be via Call Event.
+  ce = OpenStruct.new(start_term: 5, need_flag: false, switch_id: 1,
+                      event: [ECmd.new(ic::CONTROL_SWITCHES, [0, 7, 7, 0])])
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [ECmd.new(ic::CALL_EVENT, [0, 1, 0])] # call common event 1
+  scene = new_scene({ 1 => event(2, 2, pg) }, common: { 1 => ce })
+  10.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[7], 'call-only common event ran via Call Event'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the event movement system for RPG2000 games, enabling events to roam the map autonomously or follow custom move routes. This includes move-route execution, autonomous movement types (random/vertical/horizontal/toward-away hero), and the supporting infrastructure to make events feel alive in the game world.

## Key Changes

- **Game::Character** — A new movable entity class representing an event's runtime state: tile position, facing direction, and movement-related flags (speed, frequency, through, facing lock, animation, transparency, graphic). Provides geometry operations (`move`, `face`, turns, `direction_toward`/`direction_away`) without any drawing logic.

- **Game::MoveRoute** — Executes decoded LCF move commands against a Character. Implements all 42 RPG2000 move-route opcodes (cardinal/diagonal/random moves, turns, facing, switches, graphics, sound, flags). Respects `repeat` and `skippable` flags; blocked non-skippable moves turn to face obstacles and retry on the next step. Uses a `world` collaborator for passability checks, hero position, switch/sound side effects, and randomness.

- **Game::MoveType** — Autonomous movement types: stationary, custom (move-route driven), random walk, vertical/horizontal bounce, and approach/flee the hero. Returns the next direction to move each frame.

- **Game::Rng** — A deterministic LCG (multiplier 75, prime modulus 65537) for random movement. Stays within signed 32-bit arithmetic to avoid bigint promotion on mruby.

- **Scene::Map integration** — Builds a `Game::Character` per active event page with its movement type and route. Steps autonomous events each frame (with frequency-based delays). Provides `MapWorld` adapter bridging the movement engine's `world` protocol to the scene (passability, hero position, switches, sound, RNG). Supplies an `EventResolver` for Call Event to look up common events and map event pages.

- **Call Event support** — The interpreter now supports Call Event commands, suspending the current list and running a referenced list (common event or map event page) to completion before resuming. Implemented via a call stack with bounded depth (`MAX_CALL_DEPTH = 100`) to prevent infinite recursion. Scene supplies a resolver to look up command lists.

- **Test harnesses** — Two new host-side test scripts verify the pure gameplay logic under CRuby:
  - `scripts/rpg2k_logic_check.rb` — Unit tests for Character, MoveRoute, MoveType, Rng, and Interpreter (move routes, switches, conditionals, gold/items, messages, Call Event)
  - `scripts/rpg2k_scene_check.rb` — Integration smoke tests for Scene::Map driving event movement (custom routes, random walk, collision, common event calls)

## Notable Implementation Details

- Movement logic is pure `Game::` code touching neither RGSS (drawing/audio) nor the native LCF parser at load time, making it testable under host CRuby without the SDL/mruby binary.
- The `world` protocol is minimal (5 methods) to keep the movement engine decoupled from the scene.
- Blocked moves on non-skippable routes face the obstacle and retry, matching RPG2000 behavior.
- Diagonal moves combine horizontal and vertical directions, facing the vertical component.
- Event collision prevents stacking on the same tile; the player also blocks events.
- Autonomous movement frequency is mapped to frame delays (1 slowest = 96 frames, 8 fastest = 1 frame).

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y