### PR TITLE
Add web deployment to GitHub Pages and Cloudflare Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,10 +192,16 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: wasm
+          # index.wasm.map lets the deployed page symbolicate wasm stack traces
+          # (the build links with -gsource-map); it is optional but harmless to
+          # ship. All paths sit under wasm-build/, so the artifact stores them at
+          # its root (index.html, index.js, index.wasm[.map]) — ready to publish
+          # as-is.
           path: |
             wasm-build/index.html
             wasm-build/index.js
             wasm-build/index.wasm
+            wasm-build/index.wasm.map
 
   screenshots:
     runs-on: ubuntu-latest
@@ -289,3 +295,88 @@ jobs:
 
       - name: Build flake
         run: nix build -L '.#build'
+
+  # Publish the WebAssembly page to GitHub Pages on every push to master. The
+  # build carries no pthreads/SharedArrayBuffer, so it needs no COOP/COEP
+  # headers and serves fine from Pages. Requires Settings → Pages → "Build and
+  # deployment" → Source = "GitHub Actions" to be enabled once for the repo.
+  deploy-pages:
+    needs: wasm
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    # Serialise deploys so an older run can't overwrite a newer one; let the
+    # in-progress publish finish rather than cancelling it half-written.
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download wasm page
+        uses: actions/download-artifact@v7
+        with:
+          name: wasm
+          path: site
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  # Publish a Cloudflare Pages preview deployment for every pull request, so the
+  # branch's build gets a shareable URL before it merges. Requires two repo
+  # secrets — CLOUDFLARE_API_TOKEN (a token with the "Cloudflare Pages: Edit"
+  # permission) and CLOUDFLARE_ACCOUNT_ID — and a Cloudflare Pages project named
+  # "rpg-maker-clone" (create it once in the dashboard as a "Direct Upload"
+  # project). See docs/deploy.md for the one-time setup.
+  preview-cloudflare:
+    needs: wasm
+    # Only PRs from branches in this repo — forks and Dependabot can't read the
+    # secrets, so skip them instead of failing the job.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download wasm page
+        uses: actions/download-artifact@v7
+        with:
+          name: wasm
+          path: site
+      - name: Deploy preview to Cloudflare Pages
+        id: cf
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Any --branch other than the project's production branch is published
+          # as a preview; the PR head branch is never master, so this is always
+          # a preview deployment.
+          command: >-
+            pages deploy site
+            --project-name=rpg-maker-clone
+            --branch=${{ github.head_ref }}
+            --commit-hash=${{ github.event.pull_request.head.sha }}
+            --commit-dirty=true
+      - name: Comment preview URL on the PR
+        if: ${{ steps.cf.outputs.deployment-url != '' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloudflare-preview
+          message: |
+            ### ⚡ Cloudflare Pages preview
+
+            | | |
+            | --- | --- |
+            | **Preview URL** | ${{ steps.cf.outputs.deployment-url }} |
+            | **Commit** | ${{ github.event.pull_request.head.sha }} |
+
+            Open the link and load an RPG Maker project with the on-page loader.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,14 +345,32 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    # Job-level env can read secrets (job-level `if` cannot), so expose whether
+    # Cloudflare is configured to a step that gates the deploy. This keeps the
+    # PR green when the optional Cloudflare setup hasn't been done yet, instead
+    # of failing the required check on a missing secret.
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
+      - name: Check for Cloudflare credentials
+        id: creds
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Cloudflare secrets not set — skipping the preview deployment. See docs/deploy.md for the one-time setup."
+          fi
       - name: Download wasm page
+        if: steps.creds.outputs.configured == 'true'
         uses: actions/download-artifact@v7
         with:
           name: wasm
           path: site
       - name: Deploy preview to Cloudflare Pages
         id: cf
+        if: steps.creds.outputs.configured == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@
 - The page draws an **on-screen keypad** (D-pad plus OK/Cancel/Dash, the L/R
   shoulders and the A/X/Y/Z buttons) beneath the canvas, so the game is playable
   by touch or mouse without a physical keyboard; the keyboard keeps working too.
+- CI publishes this page automatically: pushes to `master` deploy it to
+  **GitHub Pages**, and every pull request gets a **Cloudflare Pages** preview
+  URL commented on the PR. See [`docs/deploy.md`](docs/deploy.md) for the
+  one-time repo setup (Pages source + Cloudflare secrets).
 
 ### Audio
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,52 @@
+# Web deployment (GitHub Pages + Cloudflare Pages previews)
+
+The `wasm` job in [`.github/workflows/build.yml`](../.github/workflows/build.yml)
+cross-compiles the runtime to WebAssembly and uploads the page
+(`index.html` + `index.js` + `index.wasm`, plus the `index.wasm.map` source
+map) as the `wasm` build artifact. Two downstream jobs publish that artifact:
+
+| Job | Trigger | Destination | URL |
+| --- | --- | --- | --- |
+| `deploy-pages` | push to `master` | GitHub Pages | `https://<owner>.github.io/<repo>/` |
+| `preview-cloudflare` | pull request | Cloudflare Pages preview | commented on the PR |
+
+Neither job rebuilds anything — they reuse the exact bytes the `wasm` job
+produced, so what the preview shows is what ships.
+
+The build links without pthreads / SharedArrayBuffer, so the page needs no
+`Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` headers and runs
+on static hosts (like GitHub Pages) that cannot set them. Neither deployment
+bakes a game in, so the page opens on its runtime loader — drop in a local
+`.zip`, a `.zip` URL, or a `owner/repo` GitHub project to play.
+
+## One-time setup
+
+### GitHub Pages
+
+1. Repo **Settings → Pages → Build and deployment**.
+2. Set **Source** to **GitHub Actions**.
+
+That's all — `deploy-pages` uses `actions/deploy-pages`, which needs no branch
+and no `gh-pages` branch. The workflow already grants the job the required
+`pages: write` and `id-token: write` permissions.
+
+### Cloudflare Pages previews
+
+1. In the Cloudflare dashboard, **Workers & Pages → Create → Pages → Upload
+   assets**, and create a project named **`rpg-maker-clone`** (this must match
+   the `--project-name` in the `preview-cloudflare` job). Direct-Upload is the
+   right type — we push assets from CI rather than letting Cloudflare build.
+2. Create an API token (**My Profile → API Tokens**) with the
+   **Account → Cloudflare Pages → Edit** permission.
+3. Add two repository secrets under **Settings → Secrets and variables →
+   Actions**:
+   - `CLOUDFLARE_API_TOKEN` — the token from step 2.
+   - `CLOUDFLARE_ACCOUNT_ID` — your account ID (shown in the dashboard URL and
+     on any domain's overview page).
+
+Once the secrets exist, every pull request from a branch in this repo gets a
+fresh preview deployment and a sticky PR comment with its URL. Pull requests
+from forks are skipped because forked runs cannot read the secrets.
+
+> Renaming the Cloudflare project? Update `--project-name` in the
+> `preview-cloudflare` job to match.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -48,5 +48,10 @@ Once the secrets exist, every pull request from a branch in this repo gets a
 fresh preview deployment and a sticky PR comment with its URL. Pull requests
 from forks are skipped because forked runs cannot read the secrets.
 
+Until the secrets are set, the `preview-cloudflare` job **skips the deploy and
+still passes** (it logs a notice pointing here), so a missing Cloudflare setup
+never blocks a PR — the preview is an optional add-on to the GitHub Pages
+deploy.
+
 > Renaming the Cloudflare project? Update `--project-name` in the
 > `preview-cloudflare` job to match.


### PR DESCRIPTION
## Summary
This PR adds automated deployment of the WebAssembly build to GitHub Pages (on pushes to master) and Cloudflare Pages previews (on pull requests), along with documentation for the required one-time setup.

## Key Changes

- **Updated wasm artifact upload**: Added `index.wasm.map` source map to the artifact so deployed pages can symbolicate WebAssembly stack traces
- **Added `deploy-pages` job**: Automatically publishes the wasm build to GitHub Pages on every push to master, with proper concurrency controls to prevent race conditions
- **Added `preview-cloudflare` job**: Deploys pull request builds to Cloudflare Pages with preview URLs commented on PRs; includes safeguards to skip fork PRs that cannot access secrets
- **Added deployment documentation**: New `docs/deploy.md` file with:
  - Overview of the two deployment jobs and their triggers
  - One-time setup instructions for GitHub Pages (enable GitHub Actions as source)
  - One-time setup instructions for Cloudflare Pages (create project, API token, and repository secrets)
- **Updated README**: Added a note about automatic CI deployments and link to deployment documentation

## Implementation Details

- The build uses no pthreads/SharedArrayBuffer, so no special COOP/COEP headers are needed — the page runs fine on static hosts like GitHub Pages
- Both deployment jobs reuse the exact artifact bytes from the `wasm` build job, ensuring preview and production are identical
- The Cloudflare job uses sticky PR comments to provide a persistent preview URL for each PR
- Proper permissions and concurrency settings prevent deployment race conditions and unauthorized access

https://claude.ai/code/session_01RuRTHVcfSQnWDwcuoxMb17