### PR TITLE
Surface errors in recovery paths instead of silently swallowing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,19 @@ Create ADRs in /docs/adr for:
 - Codes are formatted by precommit. Please run it after code edit finishes
 - Most dependencies are managed by nix flake. See flake.nix for detail
 
+## Error Handling
+
+- Do not silence errors. Never swallow an exception (or ignore a failing
+  return value) so that a failure disappears without a trace.
+- When you catch an error to keep the game running (e.g. a missing asset or
+  optional data field falling back to a default), still surface it — log it to
+  `$stderr` with a `[RPG2k]`/`[RGSS]` tag and the underlying `e.message`, the
+  way the rest of the runtime code already does. A recovered error should be
+  visible in the log, not invisible.
+- Prefer catching the narrowest exception you can. Avoid bare `rescue` /
+  broad `rescue StandardError` when a specific class expresses the real
+  failure you are recovering from.
+
 ## Testing Standards
 
 - Unit tests are written using Google Test and executed by CTest. Use `cmake --build build -t test` to run it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,17 @@ All notable changes to this project will be documented in this file.
   there, which raised `invalid bool size` when parsing an actual `RPG_RT.lmt`
 
 ### Changed
+- The RPG2000 runtime no longer silences errors it recovers from. The `rescue`
+  guards added for event movement — asset loads (chipset/charset), optional
+  event-page field reads, common-event and move-route parsing, event-SE/BGM
+  playback, per-event stepping, actor-name lookup and the save-slot check —
+  previously swallowed their exception and returned a fallback with no trace.
+  They now log the failure to `$stderr` (tagged `[RPG2k]`/`[RGSS]`, with the
+  underlying message) before falling back, matching the logging the rest of the
+  runtime already does, so a missing asset or malformed field is visible instead
+  of silently degrading. The optional page-field reads share a single
+  `page_field` guard. `AGENTS.md` gains an "Error Handling" note recording the
+  don't-silence-errors expectation.
 - Bumped the vendored mruby submodule to the 4.0.0 release (from a 3.3.0-era
   snapshot). `build_config.rb` drops the `mruby-print` gem (removed in 4.0;
   `Kernel#p`/`#print` are now in the core and `mruby-io` supplies

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -450,7 +450,8 @@ module Game
       cmds = route.commands
       return nil if cmds.nil? || cmds.empty?
       new(cmds, repeat: route.repeat, skippable: route.skippable)
-    rescue StandardError
+    rescue StandardError => e
+      $stderr.puts "[RPG2k] move route parse failed, event uses no custom route: #{e.message}"
       nil
     end
 
@@ -663,7 +664,8 @@ module Game
                   switch_id: c.switch_id, commands: c.event)
       end
       list
-    rescue StandardError
+    rescue StandardError => e
+      $stderr.puts "[RPG2k] common event load failed, none available: #{e.message}"
       []
     end
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -383,7 +383,8 @@ module Game
         pitch = cmd.parameters.size > 1 ? cmd.param(1) : 100
         RGSS::Audio.se_play(name, volume, pitch)
       end
-    rescue StandardError
+    rescue StandardError => e
+      $stderr.puts "[RPG2k] #{kind} playback failed for '#{name}': #{e.message}"
       nil
     end
   end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -275,7 +275,8 @@ class RPG2k
       def play_sound(name, volume, tempo, _balance)
         return if name.nil? || name.empty?
         RGSS::Audio.se_play(name, volume, tempo)
-      rescue StandardError
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] event SE '#{name}' playback failed: #{e.message}"
         nil
       end
 
@@ -393,7 +394,8 @@ class RPG2k
 
       def build_chipset
         Game::ChipSet.new(@db, @map.chipset_id)
-      rescue StandardError
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] chipset load failed, tiles treated as passable: #{e.message}"
         nil
       end
 
@@ -406,7 +408,8 @@ class RPG2k
         @charset_index = leader.charset_index || 0
         return nil if name.nil? || name.empty?
         Bitmap.new "CharSet/#{name}"
-      rescue StandardError
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] party charset load failed, using marker: #{e.message}"
         nil
       end
 
@@ -438,7 +441,8 @@ class RPG2k
           @events.push(build_event(id, ev, page))
         end
         rebuild_event_tiles
-      rescue StandardError
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] event setup failed, map runs with no events: #{e.message}"
         @events = []
         @event_tiles = {}
       end
@@ -462,15 +466,27 @@ class RPG2k
         @events.each { |e| @event_tiles[[e[:char].x, e[:char].y]] = e }
       end
 
-      def page_trigger(page); page.trigger; rescue StandardError; 0; end
-      def page_commands(page); page.event_commands; rescue StandardError; nil; end
-      def page_direction(page); d = page.direction; d && d > 0 ? d : 2; rescue StandardError; 2; end
-      def page_move_type(page); page.move_type || 0; rescue StandardError; 0; end
-      def page_move_speed(page); page.move_speed || 3; rescue StandardError; 3; end
-      def page_move_frequency(page); page.move_frequency || 3; rescue StandardError; 3; end
-      def page_move_route(page); page.move_route; rescue StandardError; nil; end
-      def page_charset_name(page); page.charset_name; rescue StandardError; nil; end
-      def page_charset_index(page); page.charset_index || 0; rescue StandardError; 0; end
+      # Read an optional event-page field through a guard that logs (rather than
+      # silently swallowing) any access error before falling back to `default`.
+      # A malformed page then degrades a single field instead of taking out the
+      # whole event list, and the failure still surfaces in the log.
+      def page_field(name, default)
+        yield
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] event page field '#{name}' unavailable " \
+                     "(#{e.message}), using #{default.inspect}"
+        default
+      end
+
+      def page_trigger(page); page_field(:trigger, 0) { page.trigger }; end
+      def page_commands(page); page_field(:commands, nil) { page.event_commands }; end
+      def page_direction(page); page_field(:direction, 2) { d = page.direction; d && d > 0 ? d : 2 }; end
+      def page_move_type(page); page_field(:move_type, 0) { page.move_type || 0 }; end
+      def page_move_speed(page); page_field(:move_speed, 3) { page.move_speed || 3 }; end
+      def page_move_frequency(page); page_field(:move_frequency, 3) { page.move_frequency || 3 }; end
+      def page_move_route(page); page_field(:move_route, nil) { page.move_route }; end
+      def page_charset_name(page); page_field(:charset_name, nil) { page.charset_name }; end
+      def page_charset_index(page); page_field(:charset_index, 0) { page.charset_index || 0 }; end
 
       # -- event execution ----------------------------------------------------
 
@@ -533,7 +549,8 @@ class RPG2k
           @world.passable?(ch, dir) ? ch.move(dir) : ch.face(dir) if dir
         end
         reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
-      rescue StandardError
+      rescue StandardError => ex
+        $stderr.puts "[RPG2k] event ##{e[:id]} movement failed: #{ex.message}"
         nil
       end
 
@@ -629,7 +646,8 @@ class RPG2k
       def actor_name(id)
         a = @db.player[id]
         a ? a.name.to_s : ''
-      rescue StandardError
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] actor name ##{id} lookup failed: #{e.message}"
         ''
       end
 
@@ -1093,7 +1111,8 @@ class RPG2k
 
   def save_exists? slot = 1
     File.exist? save_path(slot)
-  rescue StandardError
+  rescue StandardError => e
+    $stderr.puts "[RPG2k] save-slot check failed for slot #{slot}: #{e.message}"
     false
   end
 


### PR DESCRIPTION
## Summary

This change eliminates silent error suppression throughout the RPG2000 runtime by adding logging to all `rescue` guards that catch exceptions to keep the game running. Previously, errors during asset loads, optional field reads, and event processing would disappear without a trace. Now they are logged to `$stderr` with context before falling back to defaults.

## Key Changes

- **Error logging in recovery paths**: All `rescue StandardError` blocks now capture the exception and log it to `$stderr` with a `[RPG2k]`/`[RGSS]` tag and the underlying error message before returning fallback values
  - Asset loads: chipset, charset, sound effects, BGM
  - Optional event-page field reads: trigger, commands, direction, move properties, charset info
  - Event processing: movement stepping, common-event parsing, move-route parsing
  - Game state: actor name lookup, save-slot existence check

- **Refactored page-field access**: Introduced a `page_field` helper method that centralizes the error-handling pattern for optional event-page field reads, reducing duplication and ensuring consistent logging across all nine field accessors

- **Documentation**: Added an "Error Handling" section to `AGENTS.md` establishing the principle that errors should never be silently swallowed—recovered errors must be logged so failures are visible in the runtime log

## Implementation Details

- The `page_field` helper accepts a field name, default value, and a block, executing the block and catching `StandardError` to log and return the default
- All exception variables are now explicitly named (e.g., `=> e`, `=> ex`) to enable logging the error message
- Log messages include context about what failed and what fallback is being used (e.g., "chipset load failed, tiles treated as passable")
- The change maintains backward compatibility—all fallback behavior is identical, only visibility is improved

https://claude.ai/code/session_01XadWG1i1VUaQYdXCP6mrhi