### PR TITLE
Implement player-touch and event-touch event triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Map events now fire on **touch**. In addition to the action button (trigger 0)
+  and auto-start (3), `Scene::Map` runs **player-touch** events (trigger 1: the
+  player walks into the event) and **event-touch** events (trigger 2: the event
+  walks into the player). A touched event turns to face the player before its
+  commands run, the player does not step onto the event, and once any event's
+  process starts, player movement / the action button / the menu are held until
+  it finishes. True parallel-process events (trigger 4) are still to come.
+  Covered by new checks in `scripts/rpg2k_scene_check.rb` (the input stub is now
+  scriptable).
 - The event interpreter now supports **Call Event**. A Call Event command
   suspends the current command list and runs a referenced list to completion,
   then resumes where it left off, via a call stack on `Game::Interpreter` and a

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,
   switches/variables, party/gold/item changes, conditional branches, teleport,
-  waits and BGM/SE playback; action-button and auto-start/parallel (common)
-  events trigger, gated by their page/switch conditions
+  waits, BGM/SE playback and Call Event (run a common event / another event's
+  page). Events start on the action button, on player touch (walking into them),
+  on event touch (they walk into the player) or auto-start, gated by their
+  page/switch conditions; auto-start/parallel common events also run
 - Message text expands the common control codes (`\v[n]` variable, `\n[n]`
   actor name, `\\`)
 - A countdown timer can be set/started/stopped from events

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -81,12 +81,15 @@ The work below is roughly ordered by the critical path to a walkable game
 
 #### Event system
 - 🚧 Event pages — page conditions (switch/variable/item/actor) are implemented
-  (`Game::EventPage`), action-button + auto-start triggers run, and a page's
-  autonomous move type / custom move route now drives the event at runtime (see
-  Movement & collision). Touch, event-touch and parallel triggers are still to
-  come, as is the interpreter's *Set Move Route* (Move Event) command — the
-  runtime engine exists, but decoding a route embedded in an event command's
-  parameters is not wired up yet
+  (`Game::EventPage`), and the start triggers now run: **action button**
+  (trigger 0), **player touch** (1, walking into the event), **event touch**
+  (2, the event walking into the player) and **auto-start** (3). A page's
+  autonomous move type / custom move route also drives the event at runtime (see
+  Movement & collision). Still to come: true **parallel** process events
+  (trigger 4 — needs a background interpreter per event, currently not run), and
+  the interpreter's *Set Move Route* (Move Event) command — the runtime engine
+  exists, but decoding a route embedded in an event command's parameters is not
+  wired up yet
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Conditional Branch/Else/End, Loop/Break/End, Label/Jump, Timer, Teleport,

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -333,6 +333,14 @@ class RPG2k
       EVENT_MOVE_DELAY = { 1 => 96, 2 => 64, 3 => 40, 4 => 24,
                            5 => 12, 6 => 6, 7 => 3, 8 => 1 }.freeze
 
+      # Event-page start conditions (the page `trigger` field): how the event's
+      # command list is set off.
+      TRIGGER_ACTION       = 0 # player presses the action button facing it
+      TRIGGER_PLAYER_TOUCH = 1 # player walks into it
+      TRIGGER_EVENT_TOUCH  = 2 # it walks into the player
+      TRIGGER_AUTO_START   = 3 # runs automatically once on the map
+      TRIGGER_PARALLEL     = 4 # runs continuously in the background
+
       def initialize parent, state
         super parent
         @state = state
@@ -520,7 +528,7 @@ class RPG2k
       # started at most once per visit so an ungated process cannot hard-loop.
       def start_autostart
         ev = @events.find do |e|
-          e[:trigger] == 3 && e[:commands] && !@started_auto[e[:id]]
+          e[:trigger] == TRIGGER_AUTO_START && e[:commands] && !@started_auto[e[:id]]
         end
         if ev
           @started_auto[ev[:id]] = true
@@ -536,17 +544,25 @@ class RPG2k
         @interpreter.start(ce[:commands])
       end
 
-      # On the action button, run the event the player is facing (trigger 0).
-      # The faced event turns toward the player before its commands run.
+      # The event currently standing on tile (x, y), or nil.
+      def event_at(x, y)
+        @event_tiles[[x, y]]
+      end
+
+      # Turn `ev` to face the player and run its command list.
+      def start_event(ev)
+        ev[:char].face(ev[:char].direction_toward(@state.x, @state.y))
+        @interpreter.start(ev[:commands])
+      end
+
+      # On the action button, run the trigger-0 event the player is facing. The
+      # faced event turns toward the player before its commands run.
       def try_action_trigger
+        return if event_busy?
         return unless Input.trigger?(Input::C)
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
-        ev = @events.find do |e|
-          e[:char].x == fx && e[:char].y == fy && e[:trigger] == 0 && e[:commands]
-        end
-        return unless ev
-        ev[:char].face(Game::Character::TURN_180[@state.direction] || 2)
-        @interpreter.start(ev[:commands])
+        ev = event_at(fx, fy)
+        start_event(ev) if ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands]
       end
 
       # Advance autonomous / custom-route event movement one frame. Skipped
@@ -556,6 +572,7 @@ class RPG2k
       end
 
       def step_event(e)
+        return if event_busy? # an event fired earlier this frame; hold the rest
         ch = e[:char]
         e[:move_timer] -= 1
         return if e[:move_timer] > 0
@@ -566,12 +583,27 @@ class RPG2k
           e[:route].step(ch, @world) unless e[:route].done?
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
-          # Bumping into an obstacle still turns the event to face it.
-          @world.passable?(ch, dir) ? ch.move(dir) : ch.face(dir) if dir
+          move_autonomous(e, dir) if dir
         end
         reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
       rescue StandardError
         nil
+      end
+
+      # Move an autonomous event one step in `dir`. Walking into the player fires
+      # an event-touch (trigger 2) event instead of moving; any other obstacle
+      # just turns the event to face it.
+      def move_autonomous(e, dir)
+        ch = e[:char]
+        nx, ny = Game::Character.step_tile(ch.x, ch.y, dir)
+        if nx == @state.x && ny == @state.y
+          ch.face(dir)
+          start_event(e) if e[:trigger] == TRIGGER_EVENT_TOUCH && e[:commands]
+        elsif @world.passable?(ch, dir)
+          ch.move(dir)
+        else
+          ch.face(dir)
+        end
       end
 
       # Update the occupied-tile cache after event `e` moved off (ox, oy). Done
@@ -601,6 +633,7 @@ class RPG2k
 
       # The cancel button opens the main menu over the map.
       def try_open_menu
+        return if event_busy?
         return unless Input.trigger?(Input::B)
         @parent.push Scene::Menu.new(@parent, @state)
       end
@@ -741,11 +774,20 @@ class RPG2k
           return
         end
 
+        return if event_busy? # don't start a new move while an event runs
         dir = Input.dir4
         return if dir == 0
 
         @state.direction = dir
         nx, ny = target_tile(@state.x, @state.y, dir)
+
+        # Walking into a player-touch (trigger 1) event runs it instead of moving.
+        touched = event_at(nx, ny)
+        if touched && touched[:trigger] == TRIGGER_PLAYER_TOUCH && touched[:commands]
+          start_event(touched)
+          return
+        end
+
         return unless passable?(nx, ny, dir)
 
         @dest_x = nx

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -51,11 +51,16 @@ module RGSS
     def dispose; end
   end
 
-  # No input: the player never moves, no buttons are pressed.
+  # Scriptable input: tests set `dir_value` (a numpad direction held down) and
+  # `triggered` (buttons pressed this frame). Defaults to no input.
   module Input
     C = 1; B = 2; UP = 3; DOWN = 4; LEFT = 5; RIGHT = 6
-    def self.trigger?(_); false; end
-    def self.dir4; 0; end
+    class << self
+      attr_accessor :dir_value, :triggered
+    end
+    def self.reset; @dir_value = 0; @triggered = []; end
+    def self.trigger?(k); Array(@triggered).include?(k); end
+    def self.dir4; @dir_value || 0; end
     def self.update; end
   end
 
@@ -85,6 +90,7 @@ $checks = 0
 
 def check(name)
   $checks += 1
+  RGSS::Input.reset # each check starts from a clean input state
   yield
 rescue StandardError => e
   $failures += 1
@@ -246,6 +252,41 @@ check 'an autostart event Calls a call-only common event through the scene' do
   10.times { scene.update }
   st = scene.instance_variable_get(:@state)
   ok st.switches[7], 'call-only common event ran via Call Event'
+end
+
+check 'player-touch (trigger 1): walking into an event runs it, no move' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 1) # player touch
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # hold right, into the event at (1,0)
+  6.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[6], 'player-touch event ran'
+  eq [0, 0], [st.x, st.y], 'player did not step onto the event'
+end
+
+check 'event-touch (trigger 2): an event walking into the player runs it' do
+  ic = Game::Interpreter::Cmd
+  pg = page(x_move_type: Game::MoveType::TOWARD, trigger: 2, frequency: 8)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])]
+  scene = new_scene({ 1 => event(3, 0, pg) }, player: [0, 0])
+  ch = chars(scene)[1]
+  20.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[5], 'event-touch event ran'
+  eq [1, 0], [ch.x, ch.y], 'event stopped adjacent, did not enter the player'
+end
+
+check 'action (trigger 0) does not fire on mere contact' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 0) # needs the action button
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # walk into it, but do not press the action button
+  6.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok !st.switches[4], 'a trigger-0 event must not run just from being bumped'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR implements two additional event trigger types for map events: **player-touch** (trigger 1) and **event-touch** (trigger 2), completing the core event triggering system alongside the existing action-button (trigger 0) and auto-start (trigger 3) triggers.

## Key Changes

- **Added trigger constants** to `Map` class for better code readability:
  - `TRIGGER_ACTION` (0): player presses action button facing the event
  - `TRIGGER_PLAYER_TOUCH` (1): player walks into the event
  - `TRIGGER_EVENT_TOUCH` (2): event walks into the player
  - `TRIGGER_AUTO_START` (3): runs automatically once per map visit
  - `TRIGGER_PARALLEL` (4): runs continuously in background (not yet implemented)

- **Refactored event interaction logic**:
  - Extracted `event_at(x, y)` helper to find events at a tile
  - Extracted `start_event(ev)` helper to turn event toward player and run its commands
  - Updated `try_action_trigger` to use new helpers and check `TRIGGER_ACTION` constant

- **Implemented player-touch detection**: When the player moves into a tile with an event that has `trigger == TRIGGER_PLAYER_TOUCH`, the event runs instead of the player moving onto that tile

- **Implemented event-touch detection**: When an autonomous event moves into the player's tile, if it has `trigger == TRIGGER_EVENT_TOUCH`, the event runs instead of moving onto the player

- **Added event-busy gating**: Player movement, action button, and menu are now blocked while any event is running, preventing multiple simultaneous event executions

- **Updated `step_event` logic**: Extracted autonomous movement into `move_autonomous()` method to handle event-touch collisions and obstacle interactions

- **Enhanced test infrastructure**: Made `Input` module scriptable with `dir_value` and `triggered` attributes, allowing tests to simulate player input; added three new checks for player-touch, event-touch, and action-trigger behavior

## Notable Implementation Details

- Events that are touched turn to face the player before their commands execute
- The player does not step onto a tile when triggering a player-touch event
- Events stop adjacent to the player when triggering event-touch (do not enter the player's tile)
- Once any event starts processing, all player input is blocked until completion
- Trigger constants replace magic numbers for improved maintainability

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y