### PR TITLE
Implement event touch triggers and parallel background processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Parallel-process events** (page trigger 4) and parallel common events now
+  run continuously in the background. Each gets its own looping
+  `Game::Interpreter` driven by `Scene::Map#step_parallels`: it runs its command
+  list, honours `Wait`, and restarts when it finishes. A parallel common event
+  that needs a flag is gated by its switch, re-checked every frame so toggling
+  the switch starts or stops it. Background processes deliberately do not drive
+  the message/choice/teleport UI (those requests are skipped) and pause while a
+  foreground event or message is active, so they never fight the player for the
+  message window. Auto-start common events now run only in the foreground (no
+  longer double-counted as parallel). Covered by new checks in
+  `scripts/rpg2k_scene_check.rb`.
 - Map events now fire on **touch**. In addition to the action button (trigger 0)
   and auto-start (3), `Scene::Map` runs **player-touch** events (trigger 1: the
   player walks into the event) and **event-touch** events (trigger 2: the event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Map events now fire on **touch**. In addition to the action button (trigger 0)
+  and auto-start (3), `Scene::Map` runs **player-touch** events (trigger 1: the
+  player walks into the event) and **event-touch** events (trigger 2: the event
+  walks into the player). A touched event turns to face the player before its
+  commands run, the player does not step onto the event, and once any event's
+  process starts, player movement / the action button / the menu are held until
+  it finishes. True parallel-process events (trigger 4) are still to come.
+  Covered by new checks in `scripts/rpg2k_scene_check.rb` (the input stub is now
+  scriptable).
 - The event interpreter now supports **Call Event**. A Call Event command
   suspends the current command list and runs a referenced list to completion,
   then resumes where it left off, via a call stack on `Game::Interpreter` and a

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@
   switches/variables, party/gold/item changes, conditional branches, teleport,
   waits, BGM/SE playback and Call Event (run a common event / another event's
   page). Events start on the action button, on player touch (walking into them),
-  on event touch (they walk into the player) or auto-start, gated by their
-  page/switch conditions; auto-start/parallel common events also run
+  on event touch (they walk into the player), auto-start, or run continuously as
+  a parallel background process, gated by their page/switch conditions;
+  auto-start and parallel common events run too
 - Message text expands the common control codes (`\v[n]` variable, `\n[n]`
   actor name, `\\`)
 - A countdown timer can be set/started/stopped from events

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,
   switches/variables, party/gold/item changes, conditional branches, teleport,
-  waits and BGM/SE playback; action-button and auto-start/parallel (common)
-  events trigger, gated by their page/switch conditions
+  waits, BGM/SE playback and Call Event (run a common event / another event's
+  page). Events start on the action button, on player touch (walking into them),
+  on event touch (they walk into the player) or auto-start, gated by their
+  page/switch conditions; auto-start/parallel common events also run
 - Message text expands the common control codes (`\v[n]` variable, `\n[n]`
   actor name, `\\`)
 - A countdown timer can be set/started/stopped from events

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -81,12 +81,15 @@ The work below is roughly ordered by the critical path to a walkable game
 
 #### Event system
 - 🚧 Event pages — page conditions (switch/variable/item/actor) are implemented
-  (`Game::EventPage`), action-button + auto-start triggers run, and a page's
-  autonomous move type / custom move route now drives the event at runtime (see
-  Movement & collision). Touch, event-touch and parallel triggers are still to
-  come, as is the interpreter's *Set Move Route* (Move Event) command — the
-  runtime engine exists, but decoding a route embedded in an event command's
-  parameters is not wired up yet
+  (`Game::EventPage`), and the start triggers now run: **action button**
+  (trigger 0), **player touch** (1, walking into the event), **event touch**
+  (2, the event walking into the player) and **auto-start** (3). A page's
+  autonomous move type / custom move route also drives the event at runtime (see
+  Movement & collision). Still to come: true **parallel** process events
+  (trigger 4 — needs a background interpreter per event, currently not run), and
+  the interpreter's *Set Move Route* (Move Event) command — the runtime engine
+  exists, but decoding a route embedded in an event command's parameters is not
+  wired up yet
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Conditional Branch/Else/End, Loop/Break/End, Label/Jump, Timer, Teleport,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -80,16 +80,15 @@ The work below is roughly ordered by the critical path to a walkable game
   (scene integration under host Ruby)
 
 #### Event system
-- 🚧 Event pages — page conditions (switch/variable/item/actor) are implemented
-  (`Game::EventPage`), and the start triggers now run: **action button**
-  (trigger 0), **player touch** (1, walking into the event), **event touch**
-  (2, the event walking into the player) and **auto-start** (3). A page's
-  autonomous move type / custom move route also drives the event at runtime (see
-  Movement & collision). Still to come: true **parallel** process events
-  (trigger 4 — needs a background interpreter per event, currently not run), and
-  the interpreter's *Set Move Route* (Move Event) command — the runtime engine
-  exists, but decoding a route embedded in an event command's parameters is not
-  wired up yet
+- ✅ Event pages — page conditions (switch/variable/item/actor) are implemented
+  (`Game::EventPage`), and all five start triggers now run: **action button**
+  (0), **player touch** (1, walking into the event), **event touch** (2, the
+  event walking into the player), **auto-start** (3) and **parallel** (4, a
+  background interpreter per event, driven by `Scene::Map#step_parallels`). A
+  page's autonomous move type / custom move route also drives the event at
+  runtime (see Movement & collision). Still to come: the interpreter's *Set Move
+  Route* (Move Event) command — the runtime engine exists, but decoding a route
+  embedded in an event command's parameters is not wired up yet
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Conditional Branch/Else/End, Loop/Break/End, Label/Jump, Timer, Teleport,
@@ -105,10 +104,13 @@ The work below is roughly ordered by the critical path to a walkable game
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   colour/speed/wait codes are consumed). Face graphics, per-code colour changes
   and gradual text reveal are still TODO
-- 🚧 Common events — auto-start and parallel common events run on the map
-  (`Game::CommonEvent`), gated by their switch when `need_flag` is set; true
-  concurrent parallel execution (running every frame alongside the player) is
-  still simplified to a once-per-visit start
+- ✅ Common events — auto-start common events run once on the map, and parallel
+  common events now run **continuously** in the background alongside the player
+  via their own looping interpreter (`Scene::Map#step_parallels`), each gated by
+  its switch when `need_flag` is set (re-checked every frame, so toggling the
+  switch starts/stops it). Background processes honour `Wait` but do not drive
+  the message/choice UI (those requests are skipped) — full parallel UI is a
+  later refinement
 - 🚧 Screen effects — the game **timer** works (Timer Operation command +
   `Game::State` countdown); transitions/fade, tint, flash, shake, Show Picture
   and weather remain. `RGSS::Viewport` now exists (position/clip/scroll/z), but

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -358,6 +358,7 @@ class RPG2k
         @world = MapWorld.new(self, @rng)
         build_events
         @interpreter.resolver = build_resolver
+        build_parallels
         @message = nil
         @wait_timer = nil
         @choice_index = 0
@@ -392,6 +393,7 @@ class RPG2k
           if event_busy?
             drive_event
           else
+            step_parallels
             step_events
             step_movement
             try_action_trigger
@@ -523,9 +525,11 @@ class RPG2k
         @message || @interpreter.running? || @interpreter.waiting?
       end
 
-      # Start the first eligible not-yet-run auto-start/parallel process: map
-      # events with an auto-start trigger, then eligible common events. Each is
-      # started at most once per visit so an ungated process cannot hard-loop.
+      # Start the first not-yet-run auto-start process in the foreground: map
+      # events with an auto-start trigger, then auto-start common events (whose
+      # switch gate, if any, is on). Each runs at most once per visit so an
+      # ungated process cannot hard-loop. Parallel processes are driven
+      # separately by #step_parallels.
       def start_autostart
         ev = @events.find do |e|
           e[:trigger] == TRIGGER_AUTO_START && e[:commands] && !@started_auto[e[:id]]
@@ -536,12 +540,82 @@ class RPG2k
           return
         end
 
-        ce = Game::CommonEvent.eligible(@common, @state.switches).find do |c|
-          c[:commands] && !@started_common[c[:id]]
+        ce = @common.find do |c|
+          c[:trigger] == Game::CommonEvent::AUTO_START && c[:commands] &&
+            common_gate_open?(c) && !@started_common[c[:id]]
         end
         return unless ce
         @started_common[ce[:id]] = true
         @interpreter.start(ce[:commands])
+      end
+
+      # A common event's switch gate: open unless it needs a flag that is off.
+      def common_gate_open?(c)
+        return true unless c[:need_flag]
+        @state.switches[c[:switch_id]]
+      end
+
+      # Build the background (parallel-process) interpreters: map events with a
+      # parallel trigger plus parallel common events. Each gets its own
+      # Game::Interpreter, looped by #step_parallels; a common event that needs a
+      # flag carries its gate switch so it only runs while that switch is on.
+      def build_parallels
+        @parallels = []
+        @events.each do |e|
+          next unless e[:trigger] == TRIGGER_PARALLEL && e[:commands]
+          @parallels.push new_parallel(e[:commands], nil)
+        end
+        @common.each do |c|
+          next unless c[:trigger] == Game::CommonEvent::PARALLEL && c[:commands]
+          @parallels.push new_parallel(c[:commands], c[:need_flag] ? c[:switch_id] : nil)
+        end
+      rescue StandardError
+        @parallels = []
+      end
+
+      def new_parallel(commands, gate_switch)
+        it = Game::Interpreter.new(@state)
+        it.resolver = @interpreter.resolver
+        it.start(commands)
+        { interp: it, commands: commands, gate_switch: gate_switch, wait_timer: nil }
+      end
+
+      # Advance every background parallel process one frame. They loop their
+      # command list and honour Wait; as background processes they do not drive
+      # the message/choice/teleport UI (those requests are simply resumed so the
+      # process keeps running). Called only while the foreground is idle, so
+      # parallels pause during messages and foreground events.
+      def step_parallels
+        @parallels.each { |p| step_parallel(p) }
+      end
+
+      def step_parallel(p)
+        return if p[:gate_switch] && !@state.switches[p[:gate_switch]]
+        it = p[:interp]
+        if it.waiting?
+          drive_parallel_wait(p, it)
+        elsif it.running?
+          it.update
+        else
+          it.start(p[:commands]) # loop the process
+          it.update
+        end
+      rescue StandardError
+        nil
+      end
+
+      def drive_parallel_wait(p, it)
+        if it.wait_kind == :wait
+          p[:wait_timer] = frames_from_tenths(it.wait_frames) if p[:wait_timer].nil?
+          if p[:wait_timer] <= 0
+            p[:wait_timer] = nil
+            it.resume
+          else
+            p[:wait_timer] -= 1
+          end
+        else
+          it.resume # background: ignore message/choice/teleport requests
+        end
       end
 
       # The event currently standing on tile (x, y), or nil.
@@ -657,17 +731,21 @@ class RPG2k
       end
 
       def drive_wait
-        if @wait_timer.nil?
-          fr = Graphics.frame_rate
-          fr = 60 if fr.nil? || fr <= 0
-          @wait_timer = @interpreter.wait_frames * fr / 10
-        end
+        @wait_timer = frames_from_tenths(@interpreter.wait_frames) if @wait_timer.nil?
         if @wait_timer <= 0
           @wait_timer = nil
           @interpreter.resume
         else
           @wait_timer -= 1
         end
+      end
+
+      # Convert an RPG2000 wait duration (tenths of a second) to a frame count at
+      # the current frame rate (defaulting to 60 fps).
+      def frames_from_tenths(tenths)
+        fr = Graphics.frame_rate
+        fr = 60 if fr.nil? || fr <= 0
+        tenths * fr / 10
       end
 
       def perform_teleport(t)
@@ -683,6 +761,7 @@ class RPG2k
         @started_common = {}
         build_events
         @interpreter.resolver = build_resolver
+        build_parallels
         @moving = false
         @move_count = 0
         @last_frame = nil

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -333,6 +333,14 @@ class RPG2k
       EVENT_MOVE_DELAY = { 1 => 96, 2 => 64, 3 => 40, 4 => 24,
                            5 => 12, 6 => 6, 7 => 3, 8 => 1 }.freeze
 
+      # Event-page start conditions (the page `trigger` field): how the event's
+      # command list is set off.
+      TRIGGER_ACTION       = 0 # player presses the action button facing it
+      TRIGGER_PLAYER_TOUCH = 1 # player walks into it
+      TRIGGER_EVENT_TOUCH  = 2 # it walks into the player
+      TRIGGER_AUTO_START   = 3 # runs automatically once on the map
+      TRIGGER_PARALLEL     = 4 # runs continuously in the background
+
       def initialize parent, state
         super parent
         @state = state
@@ -520,7 +528,7 @@ class RPG2k
       # started at most once per visit so an ungated process cannot hard-loop.
       def start_autostart
         ev = @events.find do |e|
-          e[:trigger] == 3 && e[:commands] && !@started_auto[e[:id]]
+          e[:trigger] == TRIGGER_AUTO_START && e[:commands] && !@started_auto[e[:id]]
         end
         if ev
           @started_auto[ev[:id]] = true
@@ -536,17 +544,25 @@ class RPG2k
         @interpreter.start(ce[:commands])
       end
 
-      # On the action button, run the event the player is facing (trigger 0).
-      # The faced event turns toward the player before its commands run.
+      # The event currently standing on tile (x, y), or nil.
+      def event_at(x, y)
+        @event_tiles[[x, y]]
+      end
+
+      # Turn `ev` to face the player and run its command list.
+      def start_event(ev)
+        ev[:char].face(ev[:char].direction_toward(@state.x, @state.y))
+        @interpreter.start(ev[:commands])
+      end
+
+      # On the action button, run the trigger-0 event the player is facing. The
+      # faced event turns toward the player before its commands run.
       def try_action_trigger
+        return if event_busy?
         return unless Input.trigger?(Input::C)
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
-        ev = @events.find do |e|
-          e[:char].x == fx && e[:char].y == fy && e[:trigger] == 0 && e[:commands]
-        end
-        return unless ev
-        ev[:char].face(Game::Character::TURN_180[@state.direction] || 2)
-        @interpreter.start(ev[:commands])
+        ev = event_at(fx, fy)
+        start_event(ev) if ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands]
       end
 
       # Advance autonomous / custom-route event movement one frame. Skipped
@@ -556,6 +572,7 @@ class RPG2k
       end
 
       def step_event(e)
+        return if event_busy? # an event fired earlier this frame; hold the rest
         ch = e[:char]
         e[:move_timer] -= 1
         return if e[:move_timer] > 0
@@ -566,12 +583,27 @@ class RPG2k
           e[:route].step(ch, @world) unless e[:route].done?
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
-          # Bumping into an obstacle still turns the event to face it.
-          @world.passable?(ch, dir) ? ch.move(dir) : ch.face(dir) if dir
+          move_autonomous(e, dir) if dir
         end
         reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
       rescue StandardError
         nil
+      end
+
+      # Move an autonomous event one step in `dir`. Walking into the player fires
+      # an event-touch (trigger 2) event instead of moving; any other obstacle
+      # just turns the event to face it.
+      def move_autonomous(e, dir)
+        ch = e[:char]
+        nx, ny = Game::Character.step_tile(ch.x, ch.y, dir)
+        if nx == @state.x && ny == @state.y
+          ch.face(dir)
+          start_event(e) if e[:trigger] == TRIGGER_EVENT_TOUCH && e[:commands]
+        elsif @world.passable?(ch, dir)
+          ch.move(dir)
+        else
+          ch.face(dir)
+        end
       end
 
       # Update the occupied-tile cache after event `e` moved off (ox, oy). Done
@@ -601,6 +633,7 @@ class RPG2k
 
       # The cancel button opens the main menu over the map.
       def try_open_menu
+        return if event_busy?
         return unless Input.trigger?(Input::B)
         @parent.push Scene::Menu.new(@parent, @state)
       end
@@ -741,11 +774,20 @@ class RPG2k
           return
         end
 
+        return if event_busy? # don't start a new move while an event runs
         dir = Input.dir4
         return if dir == 0
 
         @state.direction = dir
         nx, ny = target_tile(@state.x, @state.y, dir)
+
+        # Walking into a player-touch (trigger 1) event runs it instead of moving.
+        touched = event_at(nx, ny)
+        if touched && touched[:trigger] == TRIGGER_PLAYER_TOUCH && touched[:commands]
+          start_event(touched)
+          return
+        end
+
         return unless passable?(nx, ny, dir)
 
         @dest_x = nx

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -51,11 +51,16 @@ module RGSS
     def dispose; end
   end
 
-  # No input: the player never moves, no buttons are pressed.
+  # Scriptable input: tests set `dir_value` (a numpad direction held down) and
+  # `triggered` (buttons pressed this frame). Defaults to no input.
   module Input
     C = 1; B = 2; UP = 3; DOWN = 4; LEFT = 5; RIGHT = 6
-    def self.trigger?(_); false; end
-    def self.dir4; 0; end
+    class << self
+      attr_accessor :dir_value, :triggered
+    end
+    def self.reset; @dir_value = 0; @triggered = []; end
+    def self.trigger?(k); Array(@triggered).include?(k); end
+    def self.dir4; @dir_value || 0; end
     def self.update; end
   end
 
@@ -85,6 +90,7 @@ $checks = 0
 
 def check(name)
   $checks += 1
+  RGSS::Input.reset # each check starts from a clean input state
   yield
 rescue StandardError => e
   $failures += 1
@@ -246,6 +252,41 @@ check 'an autostart event Calls a call-only common event through the scene' do
   10.times { scene.update }
   st = scene.instance_variable_get(:@state)
   ok st.switches[7], 'call-only common event ran via Call Event'
+end
+
+check 'player-touch (trigger 1): walking into an event runs it, no move' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 1) # player touch
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # hold right, into the event at (1,0)
+  6.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[6], 'player-touch event ran'
+  eq [0, 0], [st.x, st.y], 'player did not step onto the event'
+end
+
+check 'event-touch (trigger 2): an event walking into the player runs it' do
+  ic = Game::Interpreter::Cmd
+  pg = page(x_move_type: Game::MoveType::TOWARD, trigger: 2, frequency: 8)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])]
+  scene = new_scene({ 1 => event(3, 0, pg) }, player: [0, 0])
+  ch = chars(scene)[1]
+  20.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[5], 'event-touch event ran'
+  eq [1, 0], [ch.x, ch.y], 'event stopped adjacent, did not enter the player'
+end
+
+check 'action (trigger 0) does not fire on mere contact' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 0) # needs the action button
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # walk into it, but do not press the action button
+  6.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok !st.switches[4], 'a trigger-0 event must not run just from being bumped'
 end
 
 # -- summary ------------------------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -289,6 +289,46 @@ check 'action (trigger 0) does not fire on mere contact' do
   ok !st.switches[4], 'a trigger-0 event must not run just from being bumped'
 end
 
+# CONTROL_VARS params to add `by` to variable `id`:
+# [mode 0=single, id, id, op 1=add, operand 0=const, value].
+def add_var_cmd(id, by = 1)
+  ECmd.new(Game::Interpreter::Cmd::CONTROL_VARS, [0, id, id, 1, 0, by])
+end
+
+check 'parallel (trigger 4): a background event runs every frame' do
+  pg = page(trigger: 4)
+  pg.event_commands = [add_var_cmd(1)]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  10.times { scene.update }
+  v = scene.instance_variable_get(:@state).variables[1]
+  ok v >= 8, "parallel event should have looped ~10 times, got #{v}"
+end
+
+check 'parallel common event runs only while its switch gate is on' do
+  ce = OpenStruct.new(start_term: 4, need_flag: true, switch_id: 2,
+                      event: [add_var_cmd(3)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  5.times { scene.update }
+  eq 0, st.variables[3], 'gated-off parallel common event must not run'
+  st.switches[2] = true
+  5.times { scene.update }
+  ok st.variables[3] > 0, 'it should run once the gate switch is on'
+end
+
+check 'parallel processes pause while a foreground event is running' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi')]
+  par = page(trigger: 4)
+  par.event_commands = [add_var_cmd(1)]
+  scene = new_scene({ 1 => event(2, 2, auto), 2 => event(4, 4, par) })
+  10.times { scene.update }
+  # The autostart event opens a message and waits for input we never give, so
+  # the foreground stays busy and the parallel process never advances.
+  eq 0, scene.instance_variable_get(:@state).variables[1]
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
This PR completes the event trigger system by implementing player-touch (trigger 1), event-touch (trigger 2), and parallel (trigger 4) event pages. Parallel processes now run continuously in the background with their own looping interpreters, while touch-triggered events fire when the player or an event walks into them.

## Key Changes

- **Parallel-process events**: Map events and common events with trigger 4 now run continuously in the background via `Scene::Map#step_parallels`. Each gets its own `Game::Interpreter` that loops its command list, honours `Wait` commands, and restarts when finished. Parallel common events respect their switch gates (re-checked every frame). Background processes deliberately skip message/choice/teleport requests and pause while foreground events are active.

- **Player-touch events** (trigger 1): When the player walks into an event, it fires instead of the player moving onto that tile. The event turns to face the player before running.

- **Event-touch events** (trigger 2): When an autonomous event walks into the player, it fires instead of entering the player's tile. The event turns to face the player before running.

- **Touch event refactoring**: Extracted `event_at(x, y)` to look up events by tile position and `start_event(ev)` to turn an event toward the player and start its commands. This eliminates duplication across action, player-touch, and event-touch triggers.

- **Autonomous movement improvements**: `move_autonomous` now checks for event-touch collisions before moving, allowing events to trigger on contact with the player.

- **Input system enhancement**: The test input stub (`RGSS::Input`) is now scriptable with `dir_value` and `triggered` attributes, allowing tests to simulate directional input and button presses.

- **Constants**: Added `TRIGGER_*` constants to `Scene::Map` for the five event page triggers (0–4), improving code readability.

- **Utility extraction**: Extracted `frames_from_tenths` to convert RPG2000 wait durations (tenths of a second) to frame counts, used by both foreground and parallel wait handling.

## Notable Implementation Details

- Parallel processes are built once per map load in `build_parallels` and stepped every frame in `step_parallels` only while the foreground is idle (`!event_busy?`), ensuring they pause during messages and foreground events.

- Each parallel process tracks its own wait timer (`p[:wait_timer]`) separate from the foreground interpreter's wait state.

- Common events with `need_flag` carry their `gate_switch` ID so the gate can be re-checked every frame; toggling the switch starts or stops the process.

- The foreground event system now checks `event_busy?` before starting new player movement or menu actions, preventing input during active events.

- Tests cover all five triggers, parallel looping, switch gating, and foreground/background interaction.

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y