### PR TITLE
Implement Move Event (Set Move Route) command for event interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,20 @@ All notable changes to this project will be documented in this file.
     script load order
   - Documented the decision, layered architecture and milestone roadmap in
     `docs/adr/0004-javascript-maker-mv-quickjs.md` and `docs/TODO.md`
+- The event interpreter now supports **Move Event** (Set Move Route). The
+  command's parameters pack a target id followed by a forced move route; the
+  interpreter decodes that route (including the switch / change-graphic /
+  play-sound sub-commands, whose strings live in the command's string field) into
+  `Game::MoveCommand`s and queues a non-blocking request — a Move Event runs in
+  the background rather than pausing the interpreter. `Scene::Map` drains those
+  requests and applies the route as a *forced route* to the target: a specific
+  map event, "this event" (the event running the command, tracked for foreground
+  and parallel processes) or the player (mirrored by a `Game::Character`, with
+  input movement suppressed while it runs). A forced route overrides page
+  movement until it finishes (a repeating route runs until replaced) and is
+  paced by the requested move frequency. Vehicle targets (boat/ship/airship) are
+  recognised but not yet modelled. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.
 - **Parallel-process events** (page trigger 4) and parallel common events now
   run continuously in the background. Each gets its own looping
   `Game::Interpreter` driven by `Scene::Map#step_parallels`: it runs its command

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,
   switches/variables, party/gold/item changes, conditional branches, teleport,
-  waits, BGM/SE playback and Call Event (run a common event / another event's
-  page). Events start on the action button, on player touch (walking into them),
+  waits, BGM/SE playback, Call Event (run a common event / another event's page)
+  and Move Event (force a move route onto an event or the player). Events start
+  on the action button, on player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -86,20 +86,25 @@ The work below is roughly ordered by the critical path to a walkable game
   event walking into the player), **auto-start** (3) and **parallel** (4, a
   background interpreter per event, driven by `Scene::Map#step_parallels`). A
   page's autonomous move type / custom move route also drives the event at
-  runtime (see Movement & collision). Still to come: the interpreter's *Set Move
-  Route* (Move Event) command — the runtime engine exists, but decoding a route
-  embedded in an event command's parameters is not wired up yet
+  runtime (see Movement & collision). The interpreter's *Set Move Route* (Move
+  Event) command is now wired up too: it decodes the route packed into the
+  command's parameters and applies it as a forced route to the target — a map
+  event (including "this event") or the player, overriding page movement until
+  it finishes. Still to come: vehicle targets (boat/ship/airship), which are not
+  modelled yet
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Conditional Branch/Else/End, Loop/Break/End, Label/Jump, Timer, Teleport,
-  Wait, Play BGM/SE, Call Event, End Event) with a per-frame step cap so a bad
-  loop can't hang. **Call Event** suspends the current list, runs the referenced
-  common event (or map-event page) to completion via a resolver + call stack —
-  so call-only common events, which auto-start/parallel never reach, now run —
-  and returns to the caller; recursion is bounded. Conditional Branch covers
-  switch / variable / **timer** / gold / item / actor-in-party conditions. The
-  remaining commands (Move Event, pictures, screen effects, battles, actor stat
-  changes, ...) are TODO
+  Wait, Play BGM/SE, Call Event, Move Event, End Event) with a per-frame step
+  cap so a bad loop can't hang. **Call Event** suspends the current list, runs
+  the referenced common event (or map-event page) to completion via a resolver +
+  call stack — so call-only common events, which auto-start/parallel never
+  reach, now run — and returns to the caller; recursion is bounded. **Move
+  Event** decodes the forced move route packed into the command's parameters and
+  hands it to the scene, which drives the target (a map event, "this event" or
+  the player) along it in the background. Conditional Branch covers switch /
+  variable / **timer** / gold / item / actor-in-party conditions. The remaining
+  commands (pictures, screen effects, battles, actor stat changes, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   colour/speed/wait codes are consumed). Face graphics, per-code colour changes

--- a/docs/adr/0008-event-movement-runtime.md
+++ b/docs/adr/0008-event-movement-runtime.md
@@ -70,7 +70,14 @@ run in CI.
 - Event sprites are still drawn as markers, so movement currently snaps tile to
   tile with no per-step pixel interpolation (unlike the player). Smooth event
   interpolation and real charset rendering are follow-up work.
-- The interpreter's *Set Move Route* (Move Event) event command is still not
-  wired up: the runtime engine exists, but decoding a route embedded inline in
-  an event command's parameters (a different layout from the page/common-event
-  `move_route` chunk) remains to be done.
+- The interpreter's *Set Move Route* (Move Event) event command is now wired up.
+  Its route is packed inline in the command's parameters (a different layout from
+  the page/common-event `move_route` chunk — the ids are the same, but the
+  strings for change-graphic / play-sound live in the command's string field,
+  prefixed by their length in the parameter list). `Game::Interpreter` decodes it
+  into `Game::MoveCommand`s and queues a non-blocking request; `Scene::Map`
+  applies it as a *forced route* to the target (a map event, "this event" or the
+  player) that overrides page movement until it finishes, reusing the same
+  `MoveRoute` executor and `world` protocol. The player, which has no
+  `Game::Character`, is mirrored by one for the duration and input movement is
+  suppressed while the route runs. Vehicle targets remain unmodelled.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -389,6 +389,25 @@ module Game
     end
   end
 
+  # One decoded move-route command: a command id plus the optional string /
+  # integer parameters a handful of commands carry. This mirrors
+  # LCF::MoveCommand (produced by the native parser for event-page routes) so a
+  # MoveRoute can execute it, but is defined here in the pure-Ruby game layer so
+  # the interpreter — which decodes the move route embedded in a Move Event
+  # command's parameters, with no LCF parser loaded — can build them too.
+  class MoveCommand
+    attr_reader :command_id, :parameter_string,
+                :parameter_a, :parameter_b, :parameter_c
+
+    def initialize(command_id, string = '', a = 0, b = 0, c = 0)
+      @command_id = command_id
+      @parameter_string = string
+      @parameter_a = a
+      @parameter_b = b
+      @parameter_c = c
+    end
+  end
+
   # Runtime execution of a decoded LCF move route (an array of LCF::MoveCommand,
   # as produced by LCF.parse_move_commands and stored on an event page's
   # `move_route`). A MoveRoute is a cursor over that list: `step` runs the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -35,9 +35,19 @@ module Game
       END_EVENT        = 12310
       CALL_EVENT       = 12330
       TELEPORT         = 10810
+      MOVE_EVENT       = 11330
       WAIT             = 11410
       PLAY_BGM         = 11510
       PLAY_SE          = 11550
+    end
+
+    # Move-command ids inside a Move Event that carry extra parameters (every
+    # other id is a bare command). Mirrors LCF's move-route parameter layout.
+    module MoveCmd
+      SWITCH_ON      = 32 # + switch id
+      SWITCH_OFF     = 33 # + switch id
+      CHANGE_GRAPHIC = 34 # + charset name (string) + charset index
+      PLAY_SOUND     = 35 # + file name (string) + volume, tempo, balance
     end
 
     # Upper bound on nested Call Event depth, so a common event that (directly or
@@ -51,6 +61,7 @@ module Game
       @running = false
       @call_stack = []
       @resolver = nil
+      @move_route_requests = []
       reset_waits
     end
 
@@ -67,7 +78,20 @@ module Game
       @index = 0
       @running = true
       @call_stack = []
+      @move_route_requests = []
       reset_waits
+    end
+
+    # Drain the Move Event (Set Move Route) requests queued since the last call,
+    # returning them (each a hash: target, frequency, repeat, skippable,
+    # commands) and clearing the queue. Unlike message/wait/teleport, a Move
+    # Event does not pause the interpreter — the route runs in the background —
+    # so the owning scene polls this after each #update to apply the routes to
+    # the target characters.
+    def take_move_route_requests
+      reqs = @move_route_requests
+      @move_route_requests = []
+      reqs
     end
 
     # Upper bound on commands run in a single update, so a malformed loop cannot
@@ -164,6 +188,7 @@ module Game
       when Cmd::BREAK_LOOP       then do_break_loop cmd
       when Cmd::END_LOOP         then do_end_loop cmd
       when Cmd::TELEPORT         then do_teleport cmd
+      when Cmd::MOVE_EVENT       then do_move_event cmd
       when Cmd::WAIT             then do_wait cmd
       when Cmd::PLAY_BGM         then play_audio(:bgm, cmd)
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
@@ -424,6 +449,57 @@ module Game
       @teleport = [cmd.param(0), cmd.param(1), cmd.param(2), cmd.param(3)]
       @wait_kind = :teleport
       @waiting = true
+    end
+
+    # Move Event (Set Move Route): queue a forced move route for a target
+    # character. The command parameters are [target, frequency, repeat,
+    # skippable, then the move-route commands]; the target id selects the player
+    # (10001), a vehicle (10002-4), this event (10005 or 0) or a map event (its
+    # id). The route runs in the background, so this only records the request —
+    # the scene resolves the target and steps the route (see decode_move_route).
+    def do_move_event(cmd)
+      params = cmd.parameters || []
+      return if params.empty?
+      @move_route_requests.push(
+        target: cmd.param(0),
+        frequency: cmd.param(1),
+        repeat: cmd.param(2) != 0,
+        skippable: cmd.param(3) != 0,
+        commands: decode_move_route(params, cmd.string || '')
+      )
+    end
+
+    # Decode the move-route commands packed into a Move Event's parameter list
+    # (from index 4 on). Most ids are bare; a few carry integer parameters, and
+    # change-graphic / play-sound carry a string whose bytes live in the event
+    # command's string field, prefixed in the parameter list by their length
+    # (matching LCF's layout). Returns Game::MoveCommand objects a MoveRoute can
+    # run. String slicing assumes ASCII file names (as charset/SE names are).
+    def decode_move_route(params, string)
+      cmds = []
+      i = 4
+      soff = 0
+      while i < params.size
+        id = params[i]; i += 1
+        a = b = c = 0
+        str = ''
+        case id
+        when MoveCmd::SWITCH_ON, MoveCmd::SWITCH_OFF
+          a = params[i] || 0; i += 1
+        when MoveCmd::CHANGE_GRAPHIC
+          len = params[i] || 0; i += 1
+          str = string[soff, len] || ''; soff += len
+          a = params[i] || 0; i += 1
+        when MoveCmd::PLAY_SOUND
+          len = params[i] || 0; i += 1
+          str = string[soff, len] || ''; soff += len
+          a = params[i] || 0; i += 1
+          b = params[i] || 0; i += 1
+          c = params[i] || 0; i += 1
+        end
+        cmds.push Game::MoveCommand.new(id, str, a, b, c)
+      end
+      cmds
     end
 
     def do_wait(cmd)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -342,6 +342,15 @@ class RPG2k
       TRIGGER_AUTO_START   = 3 # runs automatically once on the map
       TRIGGER_PARALLEL     = 4 # runs continuously in the background
 
+      # Move Event (Set Move Route) target ids: the player, the three vehicles
+      # and "this event" (the event running the command). Any other id is a map
+      # event id. Vehicles are not modelled yet, so those targets are ignored.
+      MOVE_TARGET_PLAYER  = 10001
+      MOVE_TARGET_BOAT    = 10002
+      MOVE_TARGET_SHIP    = 10003
+      MOVE_TARGET_AIRSHIP = 10004
+      MOVE_TARGET_THIS    = 10005
+
       def initialize parent, state
         super parent
         @state = state
@@ -363,6 +372,15 @@ class RPG2k
         @message = nil
         @wait_timer = nil
         @choice_index = 0
+        # The map event whose commands the foreground interpreter is running, so
+        # a Move Event targeting "this event" can be resolved. nil for common
+        # events (which have no map character).
+        @active_event = nil
+        # A forced move route applied to the player by a Move Event, with its own
+        # character mirror and step timer; nil when the player moves by input.
+        @player_route = nil
+        @player_char = nil
+        @player_route_timer = 0
 
         # Player pixel position and step state.
         @moving = false
@@ -395,6 +413,7 @@ class RPG2k
             drive_event
           else
             step_parallels
+            step_player_route
             step_events
             step_movement
             try_action_trigger
@@ -552,6 +571,7 @@ class RPG2k
         end
         if ev
           @started_auto[ev[:id]] = true
+          @active_event = ev
           @interpreter.start(ev[:commands])
           return
         end
@@ -562,6 +582,7 @@ class RPG2k
         end
         return unless ce
         @started_common[ce[:id]] = true
+        @active_event = nil # a common event has no "this event" map character
         @interpreter.start(ce[:commands])
       end
 
@@ -579,21 +600,25 @@ class RPG2k
         @parallels = []
         @events.each do |e|
           next unless e[:trigger] == TRIGGER_PARALLEL && e[:commands]
-          @parallels.push new_parallel(e[:commands], nil)
+          @parallels.push new_parallel(e[:commands], nil, e)
         end
         @common.each do |c|
           next unless c[:trigger] == Game::CommonEvent::PARALLEL && c[:commands]
-          @parallels.push new_parallel(c[:commands], c[:need_flag] ? c[:switch_id] : nil)
+          @parallels.push new_parallel(c[:commands],
+                                       c[:need_flag] ? c[:switch_id] : nil, nil)
         end
       rescue StandardError
         @parallels = []
       end
 
-      def new_parallel(commands, gate_switch)
+      # Build one background process. `event` is the owning map event (so a Move
+      # Event targeting "this event" resolves) or nil for a common event.
+      def new_parallel(commands, gate_switch, event)
         it = Game::Interpreter.new(@state)
         it.resolver = @interpreter.resolver
         it.start(commands)
-        { interp: it, commands: commands, gate_switch: gate_switch, wait_timer: nil }
+        { interp: it, commands: commands, gate_switch: gate_switch,
+          wait_timer: nil, event: event }
       end
 
       # Advance every background parallel process one frame. They loop their
@@ -616,6 +641,7 @@ class RPG2k
           it.start(p[:commands]) # loop the process
           it.update
         end
+        apply_move_requests(it, p[:event])
       rescue StandardError
         nil
       end
@@ -642,6 +668,7 @@ class RPG2k
       # Turn `ev` to face the player and run its command list.
       def start_event(ev)
         ev[:char].face(ev[:char].direction_toward(@state.x, @state.y))
+        @active_event = ev
         @interpreter.start(ev[:commands])
       end
 
@@ -666,10 +693,17 @@ class RPG2k
         ch = e[:char]
         e[:move_timer] -= 1
         return if e[:move_timer] > 0
-        e[:move_timer] = EVENT_MOVE_DELAY[ch.move_frequency] || 40
+        forced = e[:forced_route]
+        # A forced route (from a Move Event) is paced by its own frequency when
+        # one was given, otherwise by the page's; it overrides page movement.
+        freq = forced && e[:forced_freq] ? e[:forced_freq] : ch.move_frequency
+        e[:move_timer] = EVENT_MOVE_DELAY[freq] || 40
         ox = ch.x
         oy = ch.y
-        if e[:route]
+        if forced
+          forced.step(ch, @world) unless forced.done?
+          e[:forced_route] = nil if forced.done? # revert to page movement
+        elsif e[:route]
           e[:route].step(ch, @world) unless e[:route].done?
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
@@ -703,6 +737,80 @@ class RPG2k
       def reoccupy(e, ox, oy)
         @event_tiles.delete([ox, oy]) if @event_tiles[[ox, oy]].equal?(e)
         @event_tiles[[e[:char].x, e[:char].y]] = e
+      end
+
+      # -- Move Event (Set Move Route) ----------------------------------------
+
+      # Apply the Move Event requests an interpreter queued this step. `this_event`
+      # is the map event running that process (or nil for a common event), so a
+      # route targeting "this event" reaches the right character.
+      def apply_move_requests(interp, this_event)
+        reqs = interp.take_move_route_requests
+        return if reqs.nil? || reqs.empty?
+        reqs.each { |r| apply_move_request(r, this_event) }
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Move Event apply failed: #{e.message}"
+        nil
+      end
+
+      def apply_move_request(r, this_event)
+        route = Game::MoveRoute.new(r[:commands], repeat: r[:repeat],
+                                    skippable: r[:skippable])
+        return if route.empty?
+        case r[:target]
+        when MOVE_TARGET_PLAYER
+          start_player_route(route, r[:frequency])
+        when 0, MOVE_TARGET_THIS
+          force_event_route(this_event, route, r[:frequency]) if this_event
+        when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          nil # vehicles are not modelled yet
+        else
+          ev = @events.find { |e| e[:id] == r[:target] }
+          force_event_route(ev, route, r[:frequency]) if ev
+        end
+      end
+
+      # Give a map event a forced route, overriding its page movement until the
+      # route finishes (a repeating route runs until replaced). It steps on the
+      # next frame, paced by the requested frequency when one was given.
+      def force_event_route(ev, route, freq)
+        ev[:forced_route] = route
+        ev[:forced_freq] = valid_move_freq(freq)
+        ev[:move_timer] = 0
+      end
+
+      # Drive the player along a forced route: the player has no Game::Character,
+      # so mirror one, step it against the map world and write the tile back to
+      # the state. Forced player steps snap tile-to-tile (no pixel interpolation)
+      # and suppress input movement while active.
+      def start_player_route(route, freq)
+        @player_char = Game::Character.new(@state.x, @state.y, @state.direction)
+        @player_char.move_frequency = valid_move_freq(freq) ||
+                                      @player_char.move_frequency
+        @player_route = route
+        @player_route_timer = 0
+      end
+
+      def step_player_route
+        return unless @player_route
+        @player_route_timer -= 1
+        return if @player_route_timer > 0
+        @player_route_timer = EVENT_MOVE_DELAY[@player_char.move_frequency] || 40
+        @player_route.step(@player_char, @world) unless @player_route.done?
+        @state.x = @player_char.x
+        @state.y = @player_char.y
+        @state.direction = @player_char.direction
+        @dest_x = @state.x
+        @dest_y = @state.y
+        @moving = false
+        @move_count = 0
+        @player_route = nil if @player_route.done?
+      end
+
+      # A move frequency the request may override the target's pace with (1..8),
+      # or nil to keep the target's own frequency.
+      def valid_move_freq(f)
+        (f && f >= 1 && f <= 8) ? f : nil
       end
 
       # Collision test for an event stepping one tile in `dir`: in bounds, not
@@ -744,6 +852,7 @@ class RPG2k
           end
         else
           @interpreter.update
+          apply_move_requests(@interpreter, @active_event)
         end
       end
 
@@ -776,6 +885,8 @@ class RPG2k
         @chipset = build_chipset
         @started_auto = {}
         @started_common = {}
+        @active_event = nil
+        @player_route = nil # a forced player route does not survive a teleport
         build_events
         @interpreter.resolver = build_resolver
         build_parallels
@@ -872,6 +983,7 @@ class RPG2k
         end
 
         return if event_busy? # don't start a new move while an event runs
+        return if @player_route # a forced route controls the player
         dir = Input.dir4
         return if dir == 0
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -494,6 +494,60 @@ check 'a message inside a called event pauses and resumes across the boundary' d
   eq true, st.switches[1], 'returned to and finished the caller'
 end
 
+check 'Move Event queues a decoded, non-blocking route request' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # target 25 (a map event), freq 4, repeat on, skippable off, then MOVE_UP(0),
+  # MOVE_RIGHT(1); a Control Switches command follows to prove no pause.
+  it.start([FakeCmd.new(IC::MOVE_EVENT, [25, 4, 1, 0, R::MOVE_UP, R::MOVE_RIGHT]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Move Event must not pause the interpreter'
+  eq true, st.switches[1], 'the command after Move Event still ran'
+  reqs = it.take_move_route_requests
+  eq 1, reqs.size
+  r = reqs[0]
+  eq 25, r[:target]
+  eq 4, r[:frequency]
+  eq true, r[:repeat]
+  eq false, r[:skippable]
+  eq [R::MOVE_UP, R::MOVE_RIGHT], r[:commands].map(&:command_id)
+  eq 0, it.take_move_route_requests.size, 'draining clears the queue'
+end
+
+check 'Move Event decodes switch / change-graphic / play-sound sub-commands' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # header: this-event target, freq 0, repeat 0, skippable 0. Then:
+  #   SWITCH_ON(32) + switch 7
+  #   CHANGE_GRAPHIC(34) + len 4 + index 2   (string "Hero")
+  #   PLAY_SOUND(35)    + len 3 + 90,100,50  (string "bel")
+  params = [10005, 0, 0, 0, 32, 7, 34, 4, 2, 35, 3, 90, 100, 50]
+  it.start([FakeCmd.new(IC::MOVE_EVENT, params, string: 'Herobel')])
+  it.update
+  cmds = it.take_move_route_requests[0][:commands]
+  eq [32, 34, 35], cmds.map(&:command_id)
+  eq 7, cmds[0].parameter_a
+  eq 'Hero', cmds[1].parameter_string
+  eq 2, cmds[1].parameter_a
+  eq 'bel', cmds[2].parameter_string
+  eq [90, 100, 50],
+     [cmds[2].parameter_a, cmds[2].parameter_b, cmds[2].parameter_c]
+end
+
+check 'a decoded Move Event route drives a Character through a MoveRoute' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::MOVE_EVENT, [7, 0, 0, 0, R::MOVE_RIGHT, R::MOVE_DOWN])])
+  it.update
+  route = R.new(it.take_move_route_requests[0][:commands], repeat: false)
+  c = Game::Character.new(0, 0)
+  w = FakeWorld.new
+  route.step(c, w); route.step(c, w)
+  eq [1, 1], [c.x, c.y], 'the decoded commands moved the character'
+  ok route.done?, 'non-repeating decoded route finishes'
+end
+
 check 'conditional branch on the timer' do
   st = new_state
   st.timer_frames = 30 * 60 # 30 seconds remaining

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -329,6 +329,58 @@ check 'parallel processes pause while a foreground event is running' do
   eq 0, scene.instance_variable_get(:@state).variables[1]
 end
 
+check 'Move Event forces a target map event onto a route' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3) # auto-start: on load, tell event 2 to walk east
+  # target event 2, freq 8, repeat on, skippable on, MOVE_RIGHT.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [2, 8, 1, 1, R::MOVE_RIGHT])]
+  mover = event(1, 1, page) # stationary by default; the route drives it
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => mover }, player: [5, 0])
+  40.times { scene.update }
+  c = chars(scene)[2]
+  ok c.x > 1, "forced event should have walked east, at x=#{c.x}"
+  eq 1, c.y, 'it stayed on its row'
+end
+
+check 'Move Event with "this event" moves the running event itself' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10005 (this event), freq 8, repeat on, skippable on, MOVE_DOWN.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10005, 8, 1, 1, R::MOVE_DOWN])]
+  scene = new_scene({ 1 => event(2, 0, auto) }, player: [5, 4])
+  c = chars(scene)[1]
+  30.times { scene.update }
+  ok c.y > 0, "the event moved itself downward, at y=#{c.y}"
+  eq 2, c.x, 'it stayed on its column'
+end
+
+check 'a forced player route suppresses input while it runs' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10001 (player), freq 8, repeat on, skippable on, MOVE_DOWN.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10001, 8, 1, 1, R::MOVE_DOWN])]
+  scene = new_scene({ 1 => event(3, 0, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.dir_value = 8 # hold up: must be ignored while the route drives down
+  30.times { scene.update }
+  ok st.y > 0, "player was driven downward by the route, at y=#{st.y}"
+  eq 0, st.x, 'input (up) was suppressed; player stayed on its column'
+end
+
+check 'a non-repeating player route finishes and returns control to input' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10001 (player), freq 8, repeat off, skippable on, MOVE_RIGHT.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10001, 8, 0, 1, R::MOVE_RIGHT])]
+  scene = new_scene({ 1 => event(3, 3, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  10.times { scene.update } # the route steps the player east once, then ends
+  eq [1, 0], [st.x, st.y], 'the one-command route moved the player east'
+  RGSS::Input.dir_value = 2 # input works again now the route is done
+  20.times { scene.update } # enough frames for the interpolated step to commit
+  ok st.y > 0, "input resumed after the route finished, at y=#{st.y}"
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
This PR implements the Move Event (Set Move Route) event command, allowing events and the player to be driven along forced move routes that run in the background without pausing the interpreter.

## Key Changes

- **Interpreter support**: Added `do_move_event` command handler that decodes move routes packed into event command parameters, including sub-commands (switch on/off, change graphic, play sound) whose strings are stored in the command's string field. Routes are queued as non-blocking requests via `take_move_route_requests`.

- **Move route decoding**: Implemented `decode_move_route` to parse the parameter layout (which differs from stored page routes) and build `Game::MoveCommand` objects that can be executed by the existing `MoveRoute` engine.

- **Scene integration**: Extended `Scene::Map` to:
  - Track the currently-running event (`@active_event`) for foreground and parallel processes so "this event" targets can be resolved
  - Apply move requests to target characters: specific map events, "this event", or the player
  - Support forced routes on events that override page movement until completion
  - Mirror the player with a `Game::Character` for the duration of a forced route, stepping it each frame and syncing position back to the state
  - Suppress input movement while a player route is active

- **Move frequency support**: Forced routes can override the target's move frequency (1-8) or use the target's default if not specified.

- **Constants**: Added target id constants (`MOVE_TARGET_PLAYER`, `MOVE_TARGET_THIS`, etc.) and move command ids (`MoveCmd::SWITCH_ON`, etc.) for clarity.

## Implementation Details

- Move Event requests are polled after each interpreter update (both foreground and parallel) and applied immediately, allowing routes to start on the next frame
- Forced event routes are stepped alongside page movement, with the forced route taking precedence
- Player routes snap tile-to-tile (no pixel interpolation) and clear input-driven movement state
- Routes survive across frames via `@player_route` / `@player_char` / `@player_route_timer` state, but are cleared on teleport
- Vehicle targets (boat/ship/airship) are recognized but not yet modelled
- Comprehensive test coverage added for route decoding, event forcing, and player route suppression

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y