### PR TITLE
Implement Move Event and actor stat-change commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,13 @@ All notable changes to this project will be documented in this file.
     script load order
   - Documented the decision, layered architecture and milestone roadmap in
     `docs/adr/0004-javascript-maker-mv-quickjs.md` and `docs/TODO.md`
+- The event interpreter now supports **Change HP**, **Change MP** and **Full
+  Heal**. Each targets a fixed actor, an actor whose id is held in a variable,
+  or the whole party, and takes a constant or variable amount. `Game::Actor`
+  gained `change_hp` / `change_mp` / `full_heal` helpers that clamp to the
+  actor's maxima; Change HP honours RPG2000's "allow death" flag (the HP floor
+  is 0 when knockout is allowed, 1 otherwise). Covered by new checks in
+  `scripts/rpg2k_logic_check.rb`.
 - The event interpreter now supports **Move Event** (Set Move Route). The
   command's parameters pack a target id followed by a forced move route; the
   interpreter decodes that route (including the switch / change-graphic /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,20 @@ All notable changes to this project will be documented in this file.
     script load order
   - Documented the decision, layered architecture and milestone roadmap in
     `docs/adr/0004-javascript-maker-mv-quickjs.md` and `docs/TODO.md`
+- The event interpreter now supports **Move Event** (Set Move Route). The
+  command's parameters pack a target id followed by a forced move route; the
+  interpreter decodes that route (including the switch / change-graphic /
+  play-sound sub-commands, whose strings live in the command's string field) into
+  `Game::MoveCommand`s and queues a non-blocking request — a Move Event runs in
+  the background rather than pausing the interpreter. `Scene::Map` drains those
+  requests and applies the route as a *forced route* to the target: a specific
+  map event, "this event" (the event running the command, tracked for foreground
+  and parallel processes) or the player (mirrored by a `Game::Character`, with
+  input movement suppressed while it runs). A forced route overrides page
+  movement until it finishes (a repeating route runs until replaced) and is
+  paced by the requested move frequency. Vehicle targets (boat/ship/airship) are
+  recognised but not yet modelled. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.
 - **Parallel-process events** (page trigger 4) and parallel common events now
   run continuously in the background. Each gets its own looping
   `Game::Interpreter` driven by `Scene::Map#step_parallels`: it runs its command

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,
   switches/variables, party/gold/item changes, conditional branches, teleport,
-  waits, BGM/SE playback and Call Event (run a common event / another event's
-  page). Events start on the action button, on player touch (walking into them),
+  waits, BGM/SE playback, Call Event (run a common event / another event's page)
+  and Move Event (force a move route onto an event or the player). Events start
+  on the action button, on player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@
 
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,
-  switches/variables, party/gold/item changes, conditional branches, teleport,
-  waits, BGM/SE playback, Call Event (run a common event / another event's page)
-  and Move Event (force a move route onto an event or the player). Events start
-  on the action button, on player touch (walking into them),
+  switches/variables, party/gold/item changes, actor HP/MP changes and full
+  heal, conditional branches, teleport, waits, BGM/SE playback, Call Event (run
+  a common event / another event's page) and Move Event (force a move route onto
+  an event or the player). Events start on the action button, on player touch
+  (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -94,17 +94,20 @@ The work below is roughly ordered by the critical path to a walkable game
   modelled yet
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
-  Conditional Branch/Else/End, Loop/Break/End, Label/Jump, Timer, Teleport,
-  Wait, Play BGM/SE, Call Event, Move Event, End Event) with a per-frame step
-  cap so a bad loop can't hang. **Call Event** suspends the current list, runs
-  the referenced common event (or map-event page) to completion via a resolver +
-  call stack — so call-only common events, which auto-start/parallel never
-  reach, now run — and returns to the caller; recursion is bounded. **Move
-  Event** decodes the forced move route packed into the command's parameters and
-  hands it to the scene, which drives the target (a map event, "this event" or
-  the player) along it in the background. Conditional Branch covers switch /
-  variable / **timer** / gold / item / actor-in-party conditions. The remaining
-  commands (pictures, screen effects, battles, actor stat changes, ...) are TODO
+  Change HP/MP, Full Heal, Conditional Branch/Else/End, Loop/Break/End,
+  Label/Jump, Timer, Teleport, Wait, Play BGM/SE, Call Event, Move Event, End
+  Event) with a per-frame step cap so a bad loop can't hang. **Call Event**
+  suspends the current list, runs the referenced common event (or map-event
+  page) to completion via a resolver + call stack — so call-only common events,
+  which auto-start/parallel never reach, now run — and returns to the caller;
+  recursion is bounded. **Move Event** decodes the forced move route packed into
+  the command's parameters and hands it to the scene, which drives the target (a
+  map event, "this event" or the player) along it in the background. **Change
+  HP/MP** and **Full Heal** apply to a fixed actor, a variable-selected actor or
+  the whole party, clamped to each actor's maxima (Change HP honours the
+  allow-death floor). Conditional Branch covers switch / variable / **timer** /
+  gold / item / actor-in-party conditions. The remaining commands (pictures,
+  screen effects, battles, EXP/level/parameter changes, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   colour/speed/wait codes are consumed). Face graphics, per-code colour changes

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -86,20 +86,25 @@ The work below is roughly ordered by the critical path to a walkable game
   event walking into the player), **auto-start** (3) and **parallel** (4, a
   background interpreter per event, driven by `Scene::Map#step_parallels`). A
   page's autonomous move type / custom move route also drives the event at
-  runtime (see Movement & collision). Still to come: the interpreter's *Set Move
-  Route* (Move Event) command — the runtime engine exists, but decoding a route
-  embedded in an event command's parameters is not wired up yet
+  runtime (see Movement & collision). The interpreter's *Set Move Route* (Move
+  Event) command is now wired up too: it decodes the route packed into the
+  command's parameters and applies it as a forced route to the target — a map
+  event (including "this event") or the player, overriding page movement until
+  it finishes. Still to come: vehicle targets (boat/ship/airship), which are not
+  modelled yet
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Conditional Branch/Else/End, Loop/Break/End, Label/Jump, Timer, Teleport,
-  Wait, Play BGM/SE, Call Event, End Event) with a per-frame step cap so a bad
-  loop can't hang. **Call Event** suspends the current list, runs the referenced
-  common event (or map-event page) to completion via a resolver + call stack —
-  so call-only common events, which auto-start/parallel never reach, now run —
-  and returns to the caller; recursion is bounded. Conditional Branch covers
-  switch / variable / **timer** / gold / item / actor-in-party conditions. The
-  remaining commands (Move Event, pictures, screen effects, battles, actor stat
-  changes, ...) are TODO
+  Wait, Play BGM/SE, Call Event, Move Event, End Event) with a per-frame step
+  cap so a bad loop can't hang. **Call Event** suspends the current list, runs
+  the referenced common event (or map-event page) to completion via a resolver +
+  call stack — so call-only common events, which auto-start/parallel never
+  reach, now run — and returns to the caller; recursion is bounded. **Move
+  Event** decodes the forced move route packed into the command's parameters and
+  hands it to the scene, which drives the target (a map event, "this event" or
+  the player) along it in the background. Conditional Branch covers switch /
+  variable / **timer** / gold / item / actor-in-party conditions. The remaining
+  commands (pictures, screen effects, battles, actor stat changes, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   colour/speed/wait codes are consumed). Face graphics, per-code colour changes

--- a/docs/adr/0008-event-movement-runtime.md
+++ b/docs/adr/0008-event-movement-runtime.md
@@ -70,7 +70,14 @@ run in CI.
 - Event sprites are still drawn as markers, so movement currently snaps tile to
   tile with no per-step pixel interpolation (unlike the player). Smooth event
   interpolation and real charset rendering are follow-up work.
-- The interpreter's *Set Move Route* (Move Event) event command is still not
-  wired up: the runtime engine exists, but decoding a route embedded inline in
-  an event command's parameters (a different layout from the page/common-event
-  `move_route` chunk) remains to be done.
+- The interpreter's *Set Move Route* (Move Event) event command is now wired up.
+  Its route is packed inline in the command's parameters (a different layout from
+  the page/common-event `move_route` chunk — the ids are the same, but the
+  strings for change-graphic / play-sound live in the command's string field,
+  prefixed by their length in the parameter list). `Game::Interpreter` decodes it
+  into `Game::MoveCommand`s and queues a non-blocking request; `Scene::Map`
+  applies it as a *forced route* to the target (a map event, "this event" or the
+  player) that overrides page movement until it finishes, reusing the same
+  `MoveRoute` executor and `world` protocol. The player, which has no
+  `Game::Character`, is mirrored by one for the duration and input movement is
+  suppressed while the route runs. Vehicle targets remain unmodelled.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -389,6 +389,25 @@ module Game
     end
   end
 
+  # One decoded move-route command: a command id plus the optional string /
+  # integer parameters a handful of commands carry. This mirrors
+  # LCF::MoveCommand (produced by the native parser for event-page routes) so a
+  # MoveRoute can execute it, but is defined here in the pure-Ruby game layer so
+  # the interpreter — which decodes the move route embedded in a Move Event
+  # command's parameters, with no LCF parser loaded — can build them too.
+  class MoveCommand
+    attr_reader :command_id, :parameter_string,
+                :parameter_a, :parameter_b, :parameter_c
+
+    def initialize(command_id, string = '', a = 0, b = 0, c = 0)
+      @command_id = command_id
+      @parameter_string = string
+      @parameter_a = a
+      @parameter_b = b
+      @parameter_c = c
+    end
+  end
+
   # Runtime execution of a decoded LCF move route (an array of LCF::MoveCommand,
   # as produced by LCF.parse_move_commands and stored on an event page's
   # `move_route`). A MoveRoute is a cursor over that list: `step` runs the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -168,6 +168,27 @@ module Game
       @hp = @max_hp
       @mp = @max_mp
     end
+
+    # Apply a HP change (positive heals, negative damages), clamped to
+    # [floor, max_hp]. The floor is 0 when death is allowed (the actor may be
+    # knocked out) or 1 otherwise, matching RPG2000's Change HP "allow death"
+    # flag. Returns the new HP.
+    def change_hp(delta, allow_death = true)
+      floor = allow_death ? 0 : 1
+      @hp = Game.clamp(@hp + delta, floor, @max_hp)
+    end
+
+    # Apply a MP (SP) change, clamped to [0, max_mp]. Returns the new MP.
+    def change_mp(delta)
+      @mp = Game.clamp(@mp + delta, 0, @max_mp)
+    end
+
+    # Restore HP and MP to their maxima (RPG2000 Full Recovery; state recovery
+    # is not modelled yet).
+    def full_heal
+      @hp = @max_hp
+      @mp = @max_mp
+    end
   end
 
   # The active party. On a new game it is seeded from the database's initial
@@ -211,6 +232,7 @@ module Game
     def leader; @actors.first; end
 
     def include_actor?(id); @actors.any? { |a| a.id == id }; end
+    def actor_by_id(id); @actors.find { |a| a.id == id }; end
 
     def add_actor(id)
       return if include_actor?(id)

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -35,9 +35,19 @@ module Game
       END_EVENT        = 12310
       CALL_EVENT       = 12330
       TELEPORT         = 10810
+      MOVE_EVENT       = 11330
       WAIT             = 11410
       PLAY_BGM         = 11510
       PLAY_SE          = 11550
+    end
+
+    # Move-command ids inside a Move Event that carry extra parameters (every
+    # other id is a bare command). Mirrors LCF's move-route parameter layout.
+    module MoveCmd
+      SWITCH_ON      = 32 # + switch id
+      SWITCH_OFF     = 33 # + switch id
+      CHANGE_GRAPHIC = 34 # + charset name (string) + charset index
+      PLAY_SOUND     = 35 # + file name (string) + volume, tempo, balance
     end
 
     # Upper bound on nested Call Event depth, so a common event that (directly or
@@ -51,6 +61,7 @@ module Game
       @running = false
       @call_stack = []
       @resolver = nil
+      @move_route_requests = []
       reset_waits
     end
 
@@ -67,7 +78,20 @@ module Game
       @index = 0
       @running = true
       @call_stack = []
+      @move_route_requests = []
       reset_waits
+    end
+
+    # Drain the Move Event (Set Move Route) requests queued since the last call,
+    # returning them (each a hash: target, frequency, repeat, skippable,
+    # commands) and clearing the queue. Unlike message/wait/teleport, a Move
+    # Event does not pause the interpreter — the route runs in the background —
+    # so the owning scene polls this after each #update to apply the routes to
+    # the target characters.
+    def take_move_route_requests
+      reqs = @move_route_requests
+      @move_route_requests = []
+      reqs
     end
 
     # Upper bound on commands run in a single update, so a malformed loop cannot
@@ -164,6 +188,7 @@ module Game
       when Cmd::BREAK_LOOP       then do_break_loop cmd
       when Cmd::END_LOOP         then do_end_loop cmd
       when Cmd::TELEPORT         then do_teleport cmd
+      when Cmd::MOVE_EVENT       then do_move_event cmd
       when Cmd::WAIT             then do_wait cmd
       when Cmd::PLAY_BGM         then play_audio(:bgm, cmd)
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
@@ -424,6 +449,57 @@ module Game
       @teleport = [cmd.param(0), cmd.param(1), cmd.param(2), cmd.param(3)]
       @wait_kind = :teleport
       @waiting = true
+    end
+
+    # Move Event (Set Move Route): queue a forced move route for a target
+    # character. The command parameters are [target, frequency, repeat,
+    # skippable, then the move-route commands]; the target id selects the player
+    # (10001), a vehicle (10002-4), this event (10005 or 0) or a map event (its
+    # id). The route runs in the background, so this only records the request —
+    # the scene resolves the target and steps the route (see decode_move_route).
+    def do_move_event(cmd)
+      params = cmd.parameters || []
+      return if params.empty?
+      @move_route_requests.push(
+        target: cmd.param(0),
+        frequency: cmd.param(1),
+        repeat: cmd.param(2) != 0,
+        skippable: cmd.param(3) != 0,
+        commands: decode_move_route(params, cmd.string || '')
+      )
+    end
+
+    # Decode the move-route commands packed into a Move Event's parameter list
+    # (from index 4 on). Most ids are bare; a few carry integer parameters, and
+    # change-graphic / play-sound carry a string whose bytes live in the event
+    # command's string field, prefixed in the parameter list by their length
+    # (matching LCF's layout). Returns Game::MoveCommand objects a MoveRoute can
+    # run. String slicing assumes ASCII file names (as charset/SE names are).
+    def decode_move_route(params, string)
+      cmds = []
+      i = 4
+      soff = 0
+      while i < params.size
+        id = params[i]; i += 1
+        a = b = c = 0
+        str = ''
+        case id
+        when MoveCmd::SWITCH_ON, MoveCmd::SWITCH_OFF
+          a = params[i] || 0; i += 1
+        when MoveCmd::CHANGE_GRAPHIC
+          len = params[i] || 0; i += 1
+          str = string[soff, len] || ''; soff += len
+          a = params[i] || 0; i += 1
+        when MoveCmd::PLAY_SOUND
+          len = params[i] || 0; i += 1
+          str = string[soff, len] || ''; soff += len
+          a = params[i] || 0; i += 1
+          b = params[i] || 0; i += 1
+          c = params[i] || 0; i += 1
+        end
+        cmds.push Game::MoveCommand.new(id, str, a, b, c)
+      end
+      cmds
     end
 
     def do_wait(cmd)

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -22,6 +22,9 @@ module Game
       CHANGE_GOLD      = 10310
       CHANGE_ITEMS     = 10320
       CHANGE_PARTY     = 10330
+      CHANGE_HP        = 10460
+      CHANGE_MP        = 10470
+      FULL_HEAL        = 10490
       CONDITIONAL      = 12010
       ELSE_BRANCH      = 22010
       END_BRANCH       = 22011
@@ -180,6 +183,9 @@ module Game
       when Cmd::CHANGE_GOLD      then do_change_gold cmd
       when Cmd::CHANGE_ITEMS     then do_change_items cmd
       when Cmd::CHANGE_PARTY     then do_change_party cmd
+      when Cmd::CHANGE_HP        then do_change_hp cmd
+      when Cmd::CHANGE_MP        then do_change_mp cmd
+      when Cmd::FULL_HEAL        then do_full_heal cmd
       when Cmd::CONDITIONAL      then do_conditional cmd
       when Cmd::ELSE_BRANCH      then skip_to([Cmd::END_BRANCH], cmd.indent); consume
       when Cmd::END_BRANCH       then nil
@@ -399,6 +405,44 @@ module Game
       else
         party.remove_actor(actor)
       end
+    end
+
+    # -- actor HP / MP --------------------------------------------------------
+
+    # The actors a stat-change command targets. param0 selects the scope: 0 the
+    # whole party, 1 a fixed actor id (param1), 2 the actor whose id is held in
+    # variable param1. Actors not in the party resolve to nothing.
+    def stat_targets(cmd)
+      case cmd.param(0)
+      when 0 then party.actors
+      when 1 then [party.actor_by_id(cmd.param(1))].compact
+      when 2 then [party.actor_by_id(variables[cmd.param(1)])].compact
+      else []
+      end
+    end
+
+    # The signed amount a HP/MP change applies: param2 is the operation (0 add,
+    # 1 remove) and param3/param4 the operand (0 constant / 1 variable, value).
+    def stat_amount(cmd)
+      amount = cmd.param(3) == 0 ? cmd.param(4) : variables[cmd.param(4)]
+      cmd.param(2) == 0 ? amount : -amount
+    end
+
+    # Change HP: param5 is the "allow death" flag (0 floors HP at 1, 1 permits 0).
+    def do_change_hp(cmd)
+      amount = stat_amount(cmd)
+      allow_death = cmd.param(5) != 0
+      stat_targets(cmd).each { |a| a.change_hp(amount, allow_death) }
+    end
+
+    def do_change_mp(cmd)
+      amount = stat_amount(cmd)
+      stat_targets(cmd).each { |a| a.change_mp(amount) }
+    end
+
+    # Full recovery: restore HP and MP to their maxima for the target actors.
+    def do_full_heal(cmd)
+      stat_targets(cmd).each { |a| a.full_heal }
     end
 
     # -- conditional branch ---------------------------------------------------

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -342,6 +342,15 @@ class RPG2k
       TRIGGER_AUTO_START   = 3 # runs automatically once on the map
       TRIGGER_PARALLEL     = 4 # runs continuously in the background
 
+      # Move Event (Set Move Route) target ids: the player, the three vehicles
+      # and "this event" (the event running the command). Any other id is a map
+      # event id. Vehicles are not modelled yet, so those targets are ignored.
+      MOVE_TARGET_PLAYER  = 10001
+      MOVE_TARGET_BOAT    = 10002
+      MOVE_TARGET_SHIP    = 10003
+      MOVE_TARGET_AIRSHIP = 10004
+      MOVE_TARGET_THIS    = 10005
+
       def initialize parent, state
         super parent
         @state = state
@@ -363,6 +372,15 @@ class RPG2k
         @message = nil
         @wait_timer = nil
         @choice_index = 0
+        # The map event whose commands the foreground interpreter is running, so
+        # a Move Event targeting "this event" can be resolved. nil for common
+        # events (which have no map character).
+        @active_event = nil
+        # A forced move route applied to the player by a Move Event, with its own
+        # character mirror and step timer; nil when the player moves by input.
+        @player_route = nil
+        @player_char = nil
+        @player_route_timer = 0
 
         # Player pixel position and step state.
         @moving = false
@@ -395,6 +413,7 @@ class RPG2k
             drive_event
           else
             step_parallels
+            step_player_route
             step_events
             step_movement
             try_action_trigger
@@ -552,6 +571,7 @@ class RPG2k
         end
         if ev
           @started_auto[ev[:id]] = true
+          @active_event = ev
           @interpreter.start(ev[:commands])
           return
         end
@@ -562,6 +582,7 @@ class RPG2k
         end
         return unless ce
         @started_common[ce[:id]] = true
+        @active_event = nil # a common event has no "this event" map character
         @interpreter.start(ce[:commands])
       end
 
@@ -579,21 +600,25 @@ class RPG2k
         @parallels = []
         @events.each do |e|
           next unless e[:trigger] == TRIGGER_PARALLEL && e[:commands]
-          @parallels.push new_parallel(e[:commands], nil)
+          @parallels.push new_parallel(e[:commands], nil, e)
         end
         @common.each do |c|
           next unless c[:trigger] == Game::CommonEvent::PARALLEL && c[:commands]
-          @parallels.push new_parallel(c[:commands], c[:need_flag] ? c[:switch_id] : nil)
+          @parallels.push new_parallel(c[:commands],
+                                       c[:need_flag] ? c[:switch_id] : nil, nil)
         end
       rescue StandardError
         @parallels = []
       end
 
-      def new_parallel(commands, gate_switch)
+      # Build one background process. `event` is the owning map event (so a Move
+      # Event targeting "this event" resolves) or nil for a common event.
+      def new_parallel(commands, gate_switch, event)
         it = Game::Interpreter.new(@state)
         it.resolver = @interpreter.resolver
         it.start(commands)
-        { interp: it, commands: commands, gate_switch: gate_switch, wait_timer: nil }
+        { interp: it, commands: commands, gate_switch: gate_switch,
+          wait_timer: nil, event: event }
       end
 
       # Advance every background parallel process one frame. They loop their
@@ -616,6 +641,7 @@ class RPG2k
           it.start(p[:commands]) # loop the process
           it.update
         end
+        apply_move_requests(it, p[:event])
       rescue StandardError
         nil
       end
@@ -642,6 +668,7 @@ class RPG2k
       # Turn `ev` to face the player and run its command list.
       def start_event(ev)
         ev[:char].face(ev[:char].direction_toward(@state.x, @state.y))
+        @active_event = ev
         @interpreter.start(ev[:commands])
       end
 
@@ -666,10 +693,17 @@ class RPG2k
         ch = e[:char]
         e[:move_timer] -= 1
         return if e[:move_timer] > 0
-        e[:move_timer] = EVENT_MOVE_DELAY[ch.move_frequency] || 40
+        forced = e[:forced_route]
+        # A forced route (from a Move Event) is paced by its own frequency when
+        # one was given, otherwise by the page's; it overrides page movement.
+        freq = forced && e[:forced_freq] ? e[:forced_freq] : ch.move_frequency
+        e[:move_timer] = EVENT_MOVE_DELAY[freq] || 40
         ox = ch.x
         oy = ch.y
-        if e[:route]
+        if forced
+          forced.step(ch, @world) unless forced.done?
+          e[:forced_route] = nil if forced.done? # revert to page movement
+        elsif e[:route]
           e[:route].step(ch, @world) unless e[:route].done?
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
@@ -703,6 +737,80 @@ class RPG2k
       def reoccupy(e, ox, oy)
         @event_tiles.delete([ox, oy]) if @event_tiles[[ox, oy]].equal?(e)
         @event_tiles[[e[:char].x, e[:char].y]] = e
+      end
+
+      # -- Move Event (Set Move Route) ----------------------------------------
+
+      # Apply the Move Event requests an interpreter queued this step. `this_event`
+      # is the map event running that process (or nil for a common event), so a
+      # route targeting "this event" reaches the right character.
+      def apply_move_requests(interp, this_event)
+        reqs = interp.take_move_route_requests
+        return if reqs.nil? || reqs.empty?
+        reqs.each { |r| apply_move_request(r, this_event) }
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Move Event apply failed: #{e.message}"
+        nil
+      end
+
+      def apply_move_request(r, this_event)
+        route = Game::MoveRoute.new(r[:commands], repeat: r[:repeat],
+                                    skippable: r[:skippable])
+        return if route.empty?
+        case r[:target]
+        when MOVE_TARGET_PLAYER
+          start_player_route(route, r[:frequency])
+        when 0, MOVE_TARGET_THIS
+          force_event_route(this_event, route, r[:frequency]) if this_event
+        when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          nil # vehicles are not modelled yet
+        else
+          ev = @events.find { |e| e[:id] == r[:target] }
+          force_event_route(ev, route, r[:frequency]) if ev
+        end
+      end
+
+      # Give a map event a forced route, overriding its page movement until the
+      # route finishes (a repeating route runs until replaced). It steps on the
+      # next frame, paced by the requested frequency when one was given.
+      def force_event_route(ev, route, freq)
+        ev[:forced_route] = route
+        ev[:forced_freq] = valid_move_freq(freq)
+        ev[:move_timer] = 0
+      end
+
+      # Drive the player along a forced route: the player has no Game::Character,
+      # so mirror one, step it against the map world and write the tile back to
+      # the state. Forced player steps snap tile-to-tile (no pixel interpolation)
+      # and suppress input movement while active.
+      def start_player_route(route, freq)
+        @player_char = Game::Character.new(@state.x, @state.y, @state.direction)
+        @player_char.move_frequency = valid_move_freq(freq) ||
+                                      @player_char.move_frequency
+        @player_route = route
+        @player_route_timer = 0
+      end
+
+      def step_player_route
+        return unless @player_route
+        @player_route_timer -= 1
+        return if @player_route_timer > 0
+        @player_route_timer = EVENT_MOVE_DELAY[@player_char.move_frequency] || 40
+        @player_route.step(@player_char, @world) unless @player_route.done?
+        @state.x = @player_char.x
+        @state.y = @player_char.y
+        @state.direction = @player_char.direction
+        @dest_x = @state.x
+        @dest_y = @state.y
+        @moving = false
+        @move_count = 0
+        @player_route = nil if @player_route.done?
+      end
+
+      # A move frequency the request may override the target's pace with (1..8),
+      # or nil to keep the target's own frequency.
+      def valid_move_freq(f)
+        (f && f >= 1 && f <= 8) ? f : nil
       end
 
       # Collision test for an event stepping one tile in `dir`: in bounds, not
@@ -744,6 +852,7 @@ class RPG2k
           end
         else
           @interpreter.update
+          apply_move_requests(@interpreter, @active_event)
         end
       end
 
@@ -776,6 +885,8 @@ class RPG2k
         @chipset = build_chipset
         @started_auto = {}
         @started_common = {}
+        @active_event = nil
+        @player_route = nil # a forced player route does not survive a teleport
         build_events
         @interpreter.resolver = build_resolver
         build_parallels
@@ -872,6 +983,7 @@ class RPG2k
         end
 
         return if event_busy? # don't start a new move while an event runs
+        return if @player_route # a forced route controls the player
         dir = Input.dir4
         return if dir == 0
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -565,6 +565,110 @@ check 'conditional branch on the timer' do
   eq false, st.switches[5]
 end
 
+# -- actor HP / MP commands ---------------------------------------------------
+
+# A database row for an actor, and a fake DB exposing just what Game::Party /
+# Game::Actor read (player table + the initial party list).
+FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
+                           :initial_level, :status)
+FakeActorSystem = Struct.new(:party)
+class FakeActorDB
+  attr_reader :player, :system
+  def initialize(players, party_ids)
+    @player = players
+    @system = FakeActorSystem.new(party_ids)
+  end
+end
+
+def party_state
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+    2 => FakePlayerRow.new('Ally', '', 0, 3,
+                           max_hp: 50, max_mp: 20, atk: 6, def: 5),
+  }
+  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2])), 1, 0, 0)
+end
+
+check 'Actor change_hp/change_mp/full_heal clamp within their bounds' do
+  hero = party_state.party.actor_by_id(1)
+  hero.change_hp(-30);          eq 70, hero.hp
+  hero.change_hp(-1000, true);  eq 0, hero.hp   # death allowed -> floor 0
+  hero.change_hp(-5, false);    eq 1, hero.hp   # death disallowed -> floor 1
+  hero.change_hp(9999);         eq 100, hero.hp # capped at max_hp
+  hero.change_mp(-1000);        eq 0, hero.mp
+  hero.change_mp(9999);         eq 30, hero.mp  # capped at max_mp
+  hero.hp = 10; hero.mp = 5
+  hero.full_heal
+  eq [100, 30], [hero.hp, hero.mp]
+end
+
+check 'Change HP command damages a fixed actor' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # scope 1 (fixed id), actor 1, op 1 (remove), operand const 40, allow-death 0
+  it.start([FakeCmd.new(IC::CHANGE_HP, [1, 1, 1, 0, 40, 0])])
+  it.update
+  eq 60, st.party.actor_by_id(1).hp
+end
+
+check 'Change HP allow-death flag chooses the floor (0 vs 1)' do
+  st = party_state
+  a = st.party.actor_by_id(1)
+  a.hp = 20
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_HP, [1, 1, 1, 0, 999, 0])]) # not lethal
+  it.update
+  eq 1, a.hp
+  a.hp = 20
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CHANGE_HP, [1, 1, 1, 0, 999, 1])]) # lethal
+  it2.update
+  eq 0, a.hp
+end
+
+check 'Change HP heals with a variable operand' do
+  st = party_state
+  st.variables[3] = 25
+  a = st.party.actor_by_id(1)
+  a.hp = 50
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 1, op 0 (add), operand type 1 (variable), var id 3 (=25)
+  it.start([FakeCmd.new(IC::CHANGE_HP, [1, 1, 0, 1, 3, 0])])
+  it.update
+  eq 75, a.hp
+end
+
+check 'Change HP targets an actor id held in a variable' do
+  st = party_state
+  st.variables[7] = 2
+  it = Game::Interpreter.new(st)
+  # scope 2 (actor id from variable 7 -> actor 2), op 1 remove, const 15
+  it.start([FakeCmd.new(IC::CHANGE_HP, [2, 7, 1, 0, 15, 0])])
+  it.update
+  eq 35, st.party.actor_by_id(2).hp # 50 - 15
+end
+
+check 'Change MP applies to the whole party' do
+  st = party_state
+  st.party.actors.each { |a| a.mp = 5 }
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_MP, [0, 0, 0, 0, 10])]) # scope 0, add const 10
+  it.update
+  eq 15, st.party.actor_by_id(1).mp
+  eq 15, st.party.actor_by_id(2).mp
+end
+
+check 'Full Heal restores the whole party to max HP/MP' do
+  st = party_state
+  st.party.actors.each { |a| a.hp = 1; a.mp = 0 }
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::FULL_HEAL, [0, 0])]) # scope 0 (whole party)
+  it.update
+  eq [100, 30], [st.party.actor_by_id(1).hp, st.party.actor_by_id(1).mp]
+  eq [50, 20],  [st.party.actor_by_id(2).hp, st.party.actor_by_id(2).mp]
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -494,6 +494,60 @@ check 'a message inside a called event pauses and resumes across the boundary' d
   eq true, st.switches[1], 'returned to and finished the caller'
 end
 
+check 'Move Event queues a decoded, non-blocking route request' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # target 25 (a map event), freq 4, repeat on, skippable off, then MOVE_UP(0),
+  # MOVE_RIGHT(1); a Control Switches command follows to prove no pause.
+  it.start([FakeCmd.new(IC::MOVE_EVENT, [25, 4, 1, 0, R::MOVE_UP, R::MOVE_RIGHT]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Move Event must not pause the interpreter'
+  eq true, st.switches[1], 'the command after Move Event still ran'
+  reqs = it.take_move_route_requests
+  eq 1, reqs.size
+  r = reqs[0]
+  eq 25, r[:target]
+  eq 4, r[:frequency]
+  eq true, r[:repeat]
+  eq false, r[:skippable]
+  eq [R::MOVE_UP, R::MOVE_RIGHT], r[:commands].map(&:command_id)
+  eq 0, it.take_move_route_requests.size, 'draining clears the queue'
+end
+
+check 'Move Event decodes switch / change-graphic / play-sound sub-commands' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # header: this-event target, freq 0, repeat 0, skippable 0. Then:
+  #   SWITCH_ON(32) + switch 7
+  #   CHANGE_GRAPHIC(34) + len 4 + index 2   (string "Hero")
+  #   PLAY_SOUND(35)    + len 3 + 90,100,50  (string "bel")
+  params = [10005, 0, 0, 0, 32, 7, 34, 4, 2, 35, 3, 90, 100, 50]
+  it.start([FakeCmd.new(IC::MOVE_EVENT, params, string: 'Herobel')])
+  it.update
+  cmds = it.take_move_route_requests[0][:commands]
+  eq [32, 34, 35], cmds.map(&:command_id)
+  eq 7, cmds[0].parameter_a
+  eq 'Hero', cmds[1].parameter_string
+  eq 2, cmds[1].parameter_a
+  eq 'bel', cmds[2].parameter_string
+  eq [90, 100, 50],
+     [cmds[2].parameter_a, cmds[2].parameter_b, cmds[2].parameter_c]
+end
+
+check 'a decoded Move Event route drives a Character through a MoveRoute' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::MOVE_EVENT, [7, 0, 0, 0, R::MOVE_RIGHT, R::MOVE_DOWN])])
+  it.update
+  route = R.new(it.take_move_route_requests[0][:commands], repeat: false)
+  c = Game::Character.new(0, 0)
+  w = FakeWorld.new
+  route.step(c, w); route.step(c, w)
+  eq [1, 1], [c.x, c.y], 'the decoded commands moved the character'
+  ok route.done?, 'non-repeating decoded route finishes'
+end
+
 check 'conditional branch on the timer' do
   st = new_state
   st.timer_frames = 30 * 60 # 30 seconds remaining

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -329,6 +329,58 @@ check 'parallel processes pause while a foreground event is running' do
   eq 0, scene.instance_variable_get(:@state).variables[1]
 end
 
+check 'Move Event forces a target map event onto a route' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3) # auto-start: on load, tell event 2 to walk east
+  # target event 2, freq 8, repeat on, skippable on, MOVE_RIGHT.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [2, 8, 1, 1, R::MOVE_RIGHT])]
+  mover = event(1, 1, page) # stationary by default; the route drives it
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => mover }, player: [5, 0])
+  40.times { scene.update }
+  c = chars(scene)[2]
+  ok c.x > 1, "forced event should have walked east, at x=#{c.x}"
+  eq 1, c.y, 'it stayed on its row'
+end
+
+check 'Move Event with "this event" moves the running event itself' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10005 (this event), freq 8, repeat on, skippable on, MOVE_DOWN.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10005, 8, 1, 1, R::MOVE_DOWN])]
+  scene = new_scene({ 1 => event(2, 0, auto) }, player: [5, 4])
+  c = chars(scene)[1]
+  30.times { scene.update }
+  ok c.y > 0, "the event moved itself downward, at y=#{c.y}"
+  eq 2, c.x, 'it stayed on its column'
+end
+
+check 'a forced player route suppresses input while it runs' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10001 (player), freq 8, repeat on, skippable on, MOVE_DOWN.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10001, 8, 1, 1, R::MOVE_DOWN])]
+  scene = new_scene({ 1 => event(3, 0, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.dir_value = 8 # hold up: must be ignored while the route drives down
+  30.times { scene.update }
+  ok st.y > 0, "player was driven downward by the route, at y=#{st.y}"
+  eq 0, st.x, 'input (up) was suppressed; player stayed on its column'
+end
+
+check 'a non-repeating player route finishes and returns control to input' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10001 (player), freq 8, repeat off, skippable on, MOVE_RIGHT.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10001, 8, 0, 1, R::MOVE_RIGHT])]
+  scene = new_scene({ 1 => event(3, 3, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  10.times { scene.update } # the route steps the player east once, then ends
+  eq [1, 0], [st.x, st.y], 'the one-command route moved the player east'
+  RGSS::Input.dir_value = 2 # input works again now the route is done
+  20.times { scene.update } # enough frames for the interpolated step to commit
+  ok st.y > 0, "input resumed after the route finished, at y=#{st.y}"
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
This PR adds support for three event interpreter commands: **Move Event** (Set Move Route), **Change HP**, **Change MP**, and **Full Heal**.

## Summary

The event interpreter now handles forced move routes and actor stat modifications, enabling events to drive characters along scripted paths and modify party member health/mana.

## Key Changes

**Move Event (Set Move Route)**
- `Game::Interpreter` decodes move routes packed into event command parameters, including sub-commands (switch on/off, change graphic, play sound) whose strings live in the command's string field
- Routes are queued as non-blocking requests via `take_move_route_requests()`, allowing the interpreter to continue without pausing
- `Scene::Map` applies these requests as *forced routes* that override page movement:
  - Map events receive forced routes that step on the next frame, paced by requested frequency
  - "This event" (target id 10005 or 0) resolves to the event running the command, tracked separately for foreground and parallel processes
  - Player routes are mirrored via a temporary `Game::Character`, suppress input movement while active, and snap tile-to-tile
  - Vehicle targets (boat/ship/airship) are recognized but not yet modeled
- Forced routes finish when complete; repeating routes run until replaced

**Actor Stat Changes**
- `Game::Actor` gained `change_hp(delta, allow_death)`, `change_mp(delta)`, and `full_heal()` methods that clamp to actor maxima
- Change HP honors RPG2000's "allow death" flag (HP floor is 0 when knockout allowed, 1 otherwise)
- Commands target a fixed actor, a variable-selected actor, or the whole party
- Amounts can be constant or variable-sourced

## Implementation Details

- Move route decoding handles the LCF parameter layout where strings are prefixed by length in the parameter list
- `Game::MoveCommand` class mirrors LCF's structure so decoded routes work with the existing `MoveRoute` executor
- Parallel processes now track their owning event so "this event" routes resolve correctly
- Player forced routes use `EVENT_MOVE_DELAY` pacing and update state position/direction directly
- All changes covered by new test checks in `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y