### PR TITLE
Add self-hostable CORS proxy as Cloudflare Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ All notable changes to this project will be documented in this file.
   load without depending on a public proxy service. The Worker accepts both
   prefix styles the loader builds (`?url=<encoded>` and `/<raw url>`), handles
   the CORS preflight, forwards `Range` requests and follows redirects, and takes
-  an optional `ALLOWED_HOSTS` allowlist to avoid running as an open proxy.
-  Deploy walkthrough in `docs/cors-proxy.md`; rationale in
+  three opt-in access controls to avoid running as an open proxy: `ALLOWED_HOSTS`
+  (target hosts), `AUTH_KEY` (a shared secret required as `?key=` — the "only me"
+  lock), and `ALLOWED_ORIGINS` (which web-page origins may call it). Deploy and
+  personal-use lock-down walkthrough in `docs/cors-proxy.md`; rationale in
   `docs/adr/0009-cors-proxy-cloudflare-worker.md`.
 - MV text rendering: the Canvas2D bridge now draws real glyphs. `fillText`,
   `strokeText` and `measureText` are backed by stb_truetype against the game's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Self-hostable **CORS proxy** for the web loader: a ready-to-deploy Cloudflare
+  Worker in `cors-proxy/` (`worker.js` + `wrangler.toml`) that the loader's *CORS
+  proxy prefix* field can point at, so GitHub repos and arbitrary `.zip` URLs
+  load without depending on a public proxy service. The Worker accepts both
+  prefix styles the loader builds (`?url=<encoded>` and `/<raw url>`), handles
+  the CORS preflight, forwards `Range` requests and follows redirects, and takes
+  an optional `ALLOWED_HOSTS` allowlist to avoid running as an open proxy.
+  Deploy walkthrough in `docs/cors-proxy.md`; rationale in
+  `docs/adr/0009-cors-proxy-cloudflare-worker.md`.
 - MV text rendering: the Canvas2D bridge now draws real glyphs. `fillText`,
   `strokeText` and `measureText` are backed by stb_truetype against the game's
   bundled TrueType font (the CSS `GameFont`, auto-discovered under the project's

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@
 - Because browsers block cross-origin downloads unless the host opts in, GitHub
   and most arbitrary `.zip` URLs need a **CORS proxy**: enter its prefix in the
   loader's optional field, or simply download the zip and use the local-file
-  path, which needs no network.
+  path, which needs no network. You can self-host the proxy as a free Cloudflare
+  Worker (code in [`cors-proxy/`](cors-proxy/)) — see
+  [`docs/cors-proxy.md`](docs/cors-proxy.md) for the one-command deploy.
 - Downloaded archives are **cached** (via the Cache Storage API, keyed by the
   resolved URL), so re-loading the same URL or repo skips the network. Tick
   *Re-download (ignore cache)* to force a fresh copy (e.g. to pick up new commits

--- a/cors-proxy/README.md
+++ b/cors-proxy/README.md
@@ -7,8 +7,9 @@ CORS headers.
 - [`worker.js`](worker.js) — the proxy. Accepts both `?url=<encoded>` (query)
   and `/<raw url>` (path) prefix styles the loader builds, forwards the fetch
   server-side, and re-serves the bytes with `Access-Control-Allow-Origin: *`.
-- [`wrangler.toml`](wrangler.toml) — Worker config; optional `ALLOWED_HOSTS`
-  var to avoid running an open proxy.
+- [`wrangler.toml`](wrangler.toml) — Worker config. Three opt-in vars keep it
+  from being an open proxy: `ALLOWED_HOSTS` (target hosts), `AUTH_KEY` (a shared
+  secret — the "only me" lock), and `ALLOWED_ORIGINS` (calling web pages).
 
 ## Deploy
 

--- a/cors-proxy/README.md
+++ b/cors-proxy/README.md
@@ -1,0 +1,24 @@
+# cors-proxy
+
+A tiny Cloudflare Worker that lets the web loader download RPG Maker projects
+from cross-origin hosts (GitHub archives, arbitrary `.zip` URLs) that don't send
+CORS headers.
+
+- [`worker.js`](worker.js) — the proxy. Accepts both `?url=<encoded>` (query)
+  and `/<raw url>` (path) prefix styles the loader builds, forwards the fetch
+  server-side, and re-serves the bytes with `Access-Control-Allow-Origin: *`.
+- [`wrangler.toml`](wrangler.toml) — Worker config; optional `ALLOWED_HOSTS`
+  var to avoid running an open proxy.
+
+## Deploy
+
+```sh
+npx wrangler login
+npx wrangler deploy
+```
+
+Then paste the printed `*.workers.dev` URL into the loader's **CORS proxy
+prefix** field (append `/?url=`).
+
+Full walkthrough, verification, and lock-down steps:
+[`../docs/cors-proxy.md`](../docs/cors-proxy.md).

--- a/cors-proxy/worker.js
+++ b/cors-proxy/worker.js
@@ -5,40 +5,65 @@
 // Browsers block those reads unless the host sends CORS headers, and GitHub
 // does not, so the loader prepends a proxy prefix to the target URL. This
 // Worker is that proxy: it fetches the target server-side (where the
-// same-origin policy does not apply) and re-serves the bytes with
-// `Access-Control-Allow-Origin: *` so the browser will accept them.
+// same-origin policy does not apply) and re-serves the bytes with an
+// `Access-Control-Allow-Origin` header so the browser will accept them.
 //
 // It accepts both prefix styles the loader can build:
 //   - query style  https://<worker>/?url=<encoded target>
 //   - path style   https://<worker>/<raw target>
 //
-// Deploy with `wrangler deploy` (see docs/cors-proxy.md). Optionally set an
-// ALLOWED_HOSTS var to restrict which hosts may be proxied; leaving it unset
-// makes this an open proxy (fine for a private URL, risky if shared).
+// Deploy with `wrangler deploy` (see docs/cors-proxy.md). Three optional
+// vars restrict use so this isn't an open proxy (all unset => open):
+//   - ALLOWED_HOSTS   — which target hosts may be fetched (comma-separated;
+//                       a leading dot matches subdomains).
+//   - AUTH_KEY        — a shared secret; requests must carry ?key=<secret>.
+//                       This is the real "only me" lock. Requires the query
+//                       prefix style (?key=…&url=). Preflight is exempt.
+//   - ALLOWED_ORIGINS — which web-page origins may call it (comma-separated,
+//                       exact scheme+host, e.g. https://you.github.io). The
+//                       CORS header is then scoped to the caller's origin.
 
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
-  'Access-Control-Allow-Headers': 'Range, Content-Type',
-  // Let the browser read the headers a downloader/streamer cares about.
-  'Access-Control-Expose-Headers':
-    'Content-Length, Content-Type, Content-Range, Accept-Ranges, ETag, Last-Modified',
-  'Access-Control-Max-Age': '86400',
-};
+function corsHeaders(origin) {
+  const h = {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+    'Access-Control-Allow-Headers': 'Range, Content-Type',
+    // Let the browser read the headers a downloader/streamer cares about.
+    'Access-Control-Expose-Headers':
+      'Content-Length, Content-Type, Content-Range, Accept-Ranges, ETag, Last-Modified',
+    'Access-Control-Max-Age': '86400',
+  };
+  // When the header is scoped to a specific origin, caches must key on it.
+  if (origin !== '*') h['Vary'] = 'Origin';
+  return h;
+}
 
-function withCors(headers) {
+function withCors(headers, origin) {
   const h = new Headers(headers);
-  for (const [k, v] of Object.entries(CORS_HEADERS)) h.set(k, v);
+  for (const [k, v] of Object.entries(corsHeaders(origin))) h.set(k, v);
   return h;
 }
 
 // A short, CORS-enabled error so the browser sees a real message instead of an
 // opaque network failure.
-function fail(status, message) {
+function fail(status, message, origin) {
   return new Response(message + '\n', {
     status,
-    headers: withCors({ 'Content-Type': 'text/plain; charset=utf-8' }),
+    headers: withCors({ 'Content-Type': 'text/plain; charset=utf-8' }, origin || '*'),
   });
+}
+
+// Decide the Access-Control-Allow-Origin value for this request. Returns '*'
+// when no origin allowlist is configured, the caller's origin when it is on the
+// list, or null when the list is set and the caller isn't on it (=> blocked).
+function resolveOrigin(request, env) {
+  const allowed = ((env && env.ALLOWED_ORIGINS) || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (allowed.length === 0) return '*';
+  const origin = request.headers.get('Origin') || '';
+  return origin && allowed.includes(origin) ? origin : null;
 }
 
 // Pull the target URL out of the incoming request, supporting both prefix
@@ -59,7 +84,7 @@ function targetFrom(request) {
   return '';
 }
 
-// Optional allowlist. Set the ALLOWED_HOSTS var to a comma-separated list of
+// Optional host allowlist. Set ALLOWED_HOSTS to a comma-separated list of
 // hostnames; a leading dot means "this host and any subdomain" (".github.com"
 // matches "codeload.github.com"). Unset => allow everything.
 function hostAllowed(hostname, allowed) {
@@ -78,13 +103,27 @@ function hostAllowed(hostname, allowed) {
 export default {
   async fetch(request, env) {
     // Preflight — the browser sends this before a cross-origin fetch with
-    // non-simple headers (e.g. Range).
+    // non-simple headers (e.g. Range). It carries no credentials, so it is
+    // exempt from the AUTH_KEY check; the origin check still applies.
+    const acao = resolveOrigin(request, env);
     if (request.method === 'OPTIONS') {
-      return new Response(null, { status: 204, headers: withCors({}) });
+      if (acao === null) return fail(403, 'Origin not allowed.', '*');
+      return new Response(null, { status: 204, headers: withCors({}, acao) });
     }
 
+    if (acao === null) return fail(403, 'Origin not allowed.', '*');
+
     if (request.method !== 'GET' && request.method !== 'HEAD') {
-      return fail(405, 'Only GET, HEAD and OPTIONS are supported.');
+      return fail(405, 'Only GET, HEAD and OPTIONS are supported.', acao);
+    }
+
+    // Shared-secret gate. When AUTH_KEY is set, every GET/HEAD must carry a
+    // matching ?key=<secret> (add it to the proxy prefix: ...?key=SECRET&url=).
+    if (env && env.AUTH_KEY) {
+      const key = new URL(request.url).searchParams.get('key');
+      if (key !== env.AUTH_KEY) {
+        return fail(403, 'Missing or invalid key.', acao);
+      }
     }
 
     const raw = targetFrom(request);
@@ -92,6 +131,7 @@ export default {
       return fail(
         400,
         'No target URL. Use ?url=<encoded-url> or append the URL to the path: /<url>.',
+        acao,
       );
     }
 
@@ -99,13 +139,13 @@ export default {
     try {
       target = new URL(raw);
     } catch {
-      return fail(400, 'Malformed target URL: ' + raw);
+      return fail(400, 'Malformed target URL: ' + raw, acao);
     }
     if (target.protocol !== 'http:' && target.protocol !== 'https:') {
-      return fail(400, 'Only http(s) targets are allowed.');
+      return fail(400, 'Only http(s) targets are allowed.', acao);
     }
     if (!hostAllowed(target.hostname, env && env.ALLOWED_HOSTS)) {
-      return fail(403, 'Host not allowed by this proxy: ' + target.hostname);
+      return fail(403, 'Host not allowed by this proxy: ' + target.hostname, acao);
     }
 
     // Forward the fetch server-side. Pass the Range header through so the
@@ -124,14 +164,14 @@ export default {
         redirect: 'follow',
       });
     } catch (e) {
-      return fail(502, 'Upstream fetch failed for ' + target + ': ' + e.message);
+      return fail(502, 'Upstream fetch failed for ' + target + ': ' + e.message, acao);
     }
 
     // Re-serve the upstream response with CORS headers, streaming the body.
     return new Response(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
-      headers: withCors(upstream.headers),
+      headers: withCors(upstream.headers, acao),
     });
   },
 };

--- a/cors-proxy/worker.js
+++ b/cors-proxy/worker.js
@@ -1,0 +1,137 @@
+// CORS proxy for the rpg-maker-clone web loader.
+//
+// The loader (src/shell.html) fetches an RPG Maker project zip from a
+// cross-origin host (GitHub's codeload archive, or an arbitrary .zip URL).
+// Browsers block those reads unless the host sends CORS headers, and GitHub
+// does not, so the loader prepends a proxy prefix to the target URL. This
+// Worker is that proxy: it fetches the target server-side (where the
+// same-origin policy does not apply) and re-serves the bytes with
+// `Access-Control-Allow-Origin: *` so the browser will accept them.
+//
+// It accepts both prefix styles the loader can build:
+//   - query style  https://<worker>/?url=<encoded target>
+//   - path style   https://<worker>/<raw target>
+//
+// Deploy with `wrangler deploy` (see docs/cors-proxy.md). Optionally set an
+// ALLOWED_HOSTS var to restrict which hosts may be proxied; leaving it unset
+// makes this an open proxy (fine for a private URL, risky if shared).
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+  'Access-Control-Allow-Headers': 'Range, Content-Type',
+  // Let the browser read the headers a downloader/streamer cares about.
+  'Access-Control-Expose-Headers':
+    'Content-Length, Content-Type, Content-Range, Accept-Ranges, ETag, Last-Modified',
+  'Access-Control-Max-Age': '86400',
+};
+
+function withCors(headers) {
+  const h = new Headers(headers);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) h.set(k, v);
+  return h;
+}
+
+// A short, CORS-enabled error so the browser sees a real message instead of an
+// opaque network failure.
+function fail(status, message) {
+  return new Response(message + '\n', {
+    status,
+    headers: withCors({ 'Content-Type': 'text/plain; charset=utf-8' }),
+  });
+}
+
+// Pull the target URL out of the incoming request, supporting both prefix
+// styles the loader builds.
+function targetFrom(request) {
+  const url = new URL(request.url);
+
+  // Query style: ?url=<encoded>. URLSearchParams has already decoded it.
+  const q = url.searchParams.get('url');
+  if (q) return q;
+
+  // Path style: everything after the leading "/", raw. The loader appends the
+  // target verbatim, so "https://host/path?a=b" arrives as pathname "/https://
+  // host/path" plus search "?a=b"; stitch them back together.
+  const rest = url.pathname.slice(1) + url.search + url.hash;
+  if (rest) return decodeURIComponent(rest);
+
+  return '';
+}
+
+// Optional allowlist. Set the ALLOWED_HOSTS var to a comma-separated list of
+// hostnames; a leading dot means "this host and any subdomain" (".github.com"
+// matches "codeload.github.com"). Unset => allow everything.
+function hostAllowed(hostname, allowed) {
+  if (!allowed) return true;
+  const list = allowed
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  if (list.length === 0) return true;
+  const host = hostname.toLowerCase();
+  return list.some((entry) =>
+    entry.startsWith('.') ? host === entry.slice(1) || host.endsWith(entry) : host === entry,
+  );
+}
+
+export default {
+  async fetch(request, env) {
+    // Preflight — the browser sends this before a cross-origin fetch with
+    // non-simple headers (e.g. Range).
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: withCors({}) });
+    }
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return fail(405, 'Only GET, HEAD and OPTIONS are supported.');
+    }
+
+    const raw = targetFrom(request);
+    if (!raw) {
+      return fail(
+        400,
+        'No target URL. Use ?url=<encoded-url> or append the URL to the path: /<url>.',
+      );
+    }
+
+    let target;
+    try {
+      target = new URL(raw);
+    } catch {
+      return fail(400, 'Malformed target URL: ' + raw);
+    }
+    if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+      return fail(400, 'Only http(s) targets are allowed.');
+    }
+    if (!hostAllowed(target.hostname, env && env.ALLOWED_HOSTS)) {
+      return fail(403, 'Host not allowed by this proxy: ' + target.hostname);
+    }
+
+    // Forward the fetch server-side. Pass the Range header through so the
+    // browser can resume/stream partial downloads, and follow redirects
+    // (GitHub's codeload endpoint 302s to a signed URL).
+    const forward = new Headers();
+    const range = request.headers.get('Range');
+    if (range) forward.set('Range', range);
+    forward.set('Accept', request.headers.get('Accept') || '*/*');
+
+    let upstream;
+    try {
+      upstream = await fetch(target.toString(), {
+        method: request.method,
+        headers: forward,
+        redirect: 'follow',
+      });
+    } catch (e) {
+      return fail(502, 'Upstream fetch failed for ' + target + ': ' + e.message);
+    }
+
+    // Re-serve the upstream response with CORS headers, streaming the body.
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: withCors(upstream.headers),
+    });
+  },
+};

--- a/cors-proxy/wrangler.toml
+++ b/cors-proxy/wrangler.toml
@@ -1,0 +1,13 @@
+# Cloudflare Worker config for the rpg-maker-clone CORS proxy.
+# Deploy with:  cd cors-proxy && npx wrangler deploy
+# See ../docs/cors-proxy.md for the full walkthrough.
+
+name = "rpg-maker-cors-proxy"
+main = "worker.js"
+compatibility_date = "2025-01-01"
+
+# Optional: restrict which hosts may be proxied so this isn't an open proxy.
+# A leading dot matches subdomains (".github.com" matches "codeload.github.com").
+# Uncomment and edit to enable; leaving it out proxies any http(s) host.
+# [vars]
+# ALLOWED_HOSTS = ".github.com,codeload.github.com,objects.githubusercontent.com"

--- a/cors-proxy/wrangler.toml
+++ b/cors-proxy/wrangler.toml
@@ -6,8 +6,15 @@ name = "rpg-maker-cors-proxy"
 main = "worker.js"
 compatibility_date = "2025-01-01"
 
-# Optional: restrict which hosts may be proxied so this isn't an open proxy.
-# A leading dot matches subdomains (".github.com" matches "codeload.github.com").
-# Uncomment and edit to enable; leaving it out proxies any http(s) host.
+# Optional access controls so this isn't an open proxy. All unset => open.
+# Uncomment and edit to enable. See ../docs/cors-proxy.md for the details.
 # [vars]
+# Which target hosts may be fetched (leading dot matches subdomains):
 # ALLOWED_HOSTS = ".github.com,codeload.github.com,objects.githubusercontent.com"
+# Which web-page origins may call the proxy (exact scheme+host):
+# ALLOWED_ORIGINS = "https://<owner>.github.io,http://localhost:8000"
+#
+# The shared secret (AUTH_KEY) is the real "only me" lock. Do NOT put it here in
+# plaintext — set it as an encrypted secret instead:
+#   npx wrangler secret put AUTH_KEY
+# then use a query-style prefix that includes it: https://<worker>/?key=SECRET&url=

--- a/docs/adr/0009-cors-proxy-cloudflare-worker.md
+++ b/docs/adr/0009-cors-proxy-cloudflare-worker.md
@@ -1,0 +1,86 @@
+# 9. CORS proxy as a Cloudflare Worker
+
+Date: 2026-08-03
+
+## Status
+
+Accepted
+
+## Context
+
+The web loader (`src/shell.html`) can start a game from three sources: a local
+`.zip` (no network), a direct `.zip` URL, and a GitHub `owner/repo` (resolved to
+its `codeload` archive). The two network sources hit the browser's same-origin
+policy: a cross-origin `fetch` of a zip only succeeds if the host returns CORS
+headers, and GitHub's archive endpoint — like most `.zip` hosts — does not. So
+those loads fail with an opaque network error unless the bytes come through a
+**CORS proxy**.
+
+The loader already has the client half of this: an optional *CORS proxy prefix*
+field. It builds the final request in one of two shapes depending on the prefix
+the user typed (`src/shell.html`):
+
+- prefix ending in `?`, `&`, or `=` → `prefix + encodeURIComponent(url)`
+  (query style, e.g. `https://…/?url=`)
+- otherwise → `prefix.replace(/\/$/, '') + '/' + url` (path style)
+
+What was missing was a documented, self-hostable proxy to point it at. The
+field's placeholder names a public service (`corsproxy.io`), but public proxies
+rate-limit, can vanish, and route your traffic through a third party. Users
+asked how to run their own.
+
+Options considered for hosting the proxy:
+
+- **Cloudflare Worker** — free tier (100k req/day), a global edge runtime, a
+  free `*.workers.dev` URL with no custom domain, and a one-command `wrangler
+  deploy`. The project already uses Cloudflare (Pages previews, see
+  `docs/deploy.md`), so it's a familiar dashboard.
+- **A small Node/Deno server on a VPS or PaaS** — full control, but needs a
+  host, TLS, and process management for what is a stateless byte-forwarder.
+- **Serverless elsewhere** (AWS Lambda, Vercel, Netlify Functions) — all viable,
+  but heavier setup than a Worker for the same result.
+
+## Decision
+
+Ship a ready-to-deploy Cloudflare Worker in `cors-proxy/` and document it in
+`docs/cors-proxy.md`.
+
+- `cors-proxy/worker.js` — an ES-module Worker that:
+  - accepts **both** loader prefix styles: it reads the target from `?url=` when
+    present, else from the raw path (`/<url>`), reconstructing any query the
+    target carried;
+  - handles the CORS **preflight** (`OPTIONS` → 204) and allows only
+    `GET`/`HEAD` otherwise;
+  - **forwards the `Range` header** and follows redirects (codeload 302s to a
+    signed `objects.githubusercontent.com` URL), then streams the body back with
+    `Access-Control-Allow-Origin: *` and the download-relevant headers exposed;
+  - surfaces failures as CORS-enabled plain-text responses (`400`/`403`/`502`)
+    rather than swallowing them, per the project's error-handling rule;
+  - supports an optional `ALLOWED_HOSTS` allowlist (comma-separated, leading-dot
+    subdomain match) so it need not run as an open proxy.
+- `cors-proxy/wrangler.toml` — the deploy config, with a commented `ALLOWED_HOSTS`
+  example.
+- `docs/cors-proxy.md` — the walkthrough (`wrangler login` → `wrangler deploy` →
+  paste the URL into the loader), verification with `curl`, and the lock-down
+  step. README's runtime-loader section links to it.
+
+The proxy is entirely optional and out of the game's build: it is deployed by
+hand with `wrangler`, not by CI, and the runtime already works without it for
+local files.
+
+## Consequences
+
+- Users can self-host a reliable proxy in minutes and stop depending on a public
+  service; the loader is unchanged (it already builds the right request).
+- No new build or CI dependency — `cors-proxy/` is standalone JS deployed with
+  `npx wrangler`, so nothing in the CMake/Emscripten/nix path is touched.
+- **Open-proxy caveat.** Left unconfigured the Worker proxies any http(s) host,
+  which is convenient but abusable if the URL is shared; `ALLOWED_HOSTS` is
+  documented as the recommended mitigation but is off by default so the
+  arbitrary-`.zip` use case keeps working out of the box.
+- This is distinct from the Cloudflare **Pages** setup in `docs/deploy.md`
+  (which publishes the game *page*); the two share a vendor but not a purpose,
+  and the docs cross-reference to avoid confusion.
+- Worker-runtime specifics (Range, redirects) are covered, but exotic hosts
+  (auth-gated downloads, non-standard redirects) may still need per-case
+  handling — the plain-text error responses make such failures visible.

--- a/docs/adr/0009-cors-proxy-cloudflare-worker.md
+++ b/docs/adr/0009-cors-proxy-cloudflare-worker.md
@@ -53,11 +53,15 @@ Ship a ready-to-deploy Cloudflare Worker in `cors-proxy/` and document it in
     `GET`/`HEAD` otherwise;
   - **forwards the `Range` header** and follows redirects (codeload 302s to a
     signed `objects.githubusercontent.com` URL), then streams the body back with
-    `Access-Control-Allow-Origin: *` and the download-relevant headers exposed;
+    an `Access-Control-Allow-Origin` header and the download-relevant headers
+    exposed;
   - surfaces failures as CORS-enabled plain-text responses (`400`/`403`/`502`)
     rather than swallowing them, per the project's error-handling rule;
-  - supports an optional `ALLOWED_HOSTS` allowlist (comma-separated, leading-dot
-    subdomain match) so it need not run as an open proxy.
+  - supports three opt-in access controls so it need not run as an open proxy:
+    `ALLOWED_HOSTS` (which target hosts may be fetched, leading-dot subdomain
+    match), `AUTH_KEY` (a shared secret required as `?key=`, the real "only me"
+    lock, with the CORS preflight exempted), and `ALLOWED_ORIGINS` (which
+    web-page origins may call it, scoping the CORS header to the caller).
 - `cors-proxy/wrangler.toml` — the deploy config, with a commented `ALLOWED_HOSTS`
   example.
 - `docs/cors-proxy.md` — the walkthrough (`wrangler login` → `wrangler deploy` →
@@ -74,9 +78,11 @@ local files.
   service; the loader is unchanged (it already builds the right request).
 - No new build or CI dependency — `cors-proxy/` is standalone JS deployed with
   `npx wrangler`, so nothing in the CMake/Emscripten/nix path is touched.
-- **Open-proxy caveat.** Left unconfigured the Worker proxies any http(s) host,
-  which is convenient but abusable if the URL is shared; `ALLOWED_HOSTS` is
-  documented as the recommended mitigation but is off by default so the
+- **Open-proxy caveat.** Left unconfigured the Worker proxies any http(s) host
+  for anyone, which is convenient but abusable if the URL is shared; the three
+  access controls (`ALLOWED_HOSTS`, `AUTH_KEY`, `ALLOWED_ORIGINS`) are the
+  documented mitigations, with a personal-use recipe (secret key + host
+  allowlist) in `docs/cors-proxy.md`. All are off by default so the
   arbitrary-`.zip` use case keeps working out of the box.
 - This is distinct from the Cloudflare **Pages** setup in `docs/deploy.md`
   (which publishes the game *page*); the two share a vendor but not a purpose,

--- a/docs/cors-proxy.md
+++ b/docs/cors-proxy.md
@@ -1,0 +1,108 @@
+# Deploying the CORS proxy to Cloudflare Workers
+
+The web loader ([`src/shell.html`](../src/shell.html)) can download an RPG Maker
+project from a `.zip` URL or a GitHub repo. Browsers block those cross-origin
+reads unless the host sends CORS headers, and GitHub does not — so the loader
+prepends a **CORS proxy prefix** to the target URL. The proxy fetches the file
+server-side (where the same-origin policy doesn't apply) and re-serves the bytes
+with `Access-Control-Allow-Origin: *`.
+
+This guide deploys that proxy as a **Cloudflare Worker** using the code in
+[`cors-proxy/worker.js`](../cors-proxy/worker.js). Cloudflare's free plan is
+plenty for personal use (100k requests/day).
+
+## What you need
+
+- A Cloudflare account (free): <https://dash.cloudflare.com/sign-up>
+- Node.js 18+ installed locally (for the `wrangler` CLI)
+
+No credit card and no custom domain are required — the Worker gets a free
+`*.workers.dev` URL.
+
+## Deploy in 4 steps
+
+Everything runs from the `cors-proxy/` directory:
+
+```sh
+cd cors-proxy
+
+# 1. Log in to Cloudflare (opens a browser to authorize wrangler).
+npx wrangler login
+
+# 2. Deploy. wrangler reads wrangler.toml and uploads worker.js.
+npx wrangler deploy
+
+# 3. wrangler prints the deployed URL, e.g.
+#    https://rpg-maker-cors-proxy.<your-subdomain>.workers.dev
+```
+
+**4. Point the loader at it.** Open the game page, expand *Load from a URL or
+GitHub*, and put your Worker URL in the **CORS proxy prefix** field in either
+style:
+
+- **Query style** (recommended): `https://rpg-maker-cors-proxy.<sub>.workers.dev/?url=`
+- **Path style**: `https://rpg-maker-cors-proxy.<sub>.workers.dev/`
+
+The loader builds the final request itself: with a prefix ending in `?`, `&`, or
+`=` it appends the URL-encoded target; otherwise it appends the raw target after
+a `/`. The Worker understands both. The prefix is remembered across reloads and
+travels in the shareable `?proxy=…` query, so you only type it once.
+
+## Verify it works
+
+```sh
+# A tiny public zip through the proxy — should return 200 with a CORS header.
+curl -sI "https://rpg-maker-cors-proxy.<sub>.workers.dev/?url=$(python3 -c 'import urllib.parse;print(urllib.parse.quote("https://codeload.github.com/octocat/Hello-World/zip/refs/heads/master"))')" | grep -i -E 'HTTP/|access-control-allow-origin'
+```
+
+You should see an `access-control-allow-origin: *` header. Then load a real
+project in the page — e.g. put an `owner/repo` in the URL field with your proxy
+prefix set — and it should download and start.
+
+## Locking it down (optional but recommended)
+
+As written the Worker will proxy **any** http(s) URL. That's fine for a private
+URL you keep to yourself, but a public open proxy can be abused as an
+anonymizing relay. To restrict it to the hosts the loader actually needs, set
+the `ALLOWED_HOSTS` variable (comma-separated; a leading dot matches subdomains):
+
+Either uncomment the `[vars]` block in
+[`wrangler.toml`](../cors-proxy/wrangler.toml) and redeploy, or set it from the
+CLI:
+
+```sh
+npx wrangler deploy --var ALLOWED_HOSTS:".github.com,codeload.github.com,objects.githubusercontent.com"
+```
+
+A blocked host gets a `403` with a clear message. GitHub archive downloads flow
+through `codeload.github.com` and can redirect to `objects.githubusercontent.com`,
+so include both; add any other zip hosts you use.
+
+## Updating
+
+Edit [`cors-proxy/worker.js`](../cors-proxy/worker.js) and run
+`npx wrangler deploy` again — same URL, new code. Roll back from **Workers &
+Pages → your Worker → Deployments** in the Cloudflare dashboard.
+
+## How the Worker behaves
+
+- **Methods**: `GET`, `HEAD`, and `OPTIONS` (CORS preflight). Anything else → `405`.
+- **Range requests** are forwarded, so large archives can stream/resume, and
+  `Content-Range` / `Accept-Ranges` are exposed to the browser.
+- **Redirects** are followed server-side (GitHub's codeload endpoint 302s to a
+  signed URL).
+- **Errors** come back with CORS headers and a plain-text reason (`400` bad
+  target, `403` blocked host, `502` upstream failure), so the loader shows a real
+  message instead of an opaque network error.
+
+## Notes and alternatives
+
+- **Not the same as the Cloudflare *Pages* setup.** [`deploy.md`](deploy.md)
+  covers publishing the game *page* (GitHub Pages + Cloudflare Pages previews).
+  This proxy is a separate, optional Worker for *downloading projects at runtime*.
+- **No proxy needed for local files.** *Open a local project* reads a `.zip`
+  straight off disk with no network, so the proxy only matters for URL/GitHub
+  loads.
+- **Public proxies** like `https://corsproxy.io/?url=` work too (that's the
+  field's placeholder), but they rate-limit and can disappear; your own Worker is
+  more reliable and, with `ALLOWED_HOSTS`, not abusable.

--- a/docs/cors-proxy.md
+++ b/docs/cors-proxy.md
@@ -59,24 +59,75 @@ You should see an `access-control-allow-origin: *` header. Then load a real
 project in the page — e.g. put an `owner/repo` in the URL field with your proxy
 prefix set — and it should download and start.
 
-## Locking it down (optional but recommended)
+## Restricting use to yourself (recommended)
 
-As written the Worker will proxy **any** http(s) URL. That's fine for a private
-URL you keep to yourself, but a public open proxy can be abused as an
-anonymizing relay. To restrict it to the hosts the loader actually needs, set
-the `ALLOWED_HOSTS` variable (comma-separated; a leading dot matches subdomains):
+As written the Worker proxies **any** http(s) URL for **anyone** who knows its
+URL — fine for a private link you don't share, risky otherwise (an open proxy
+can be abused as an anonymizing relay, and it burns your request quota). Three
+independent, opt-in controls narrow it down; all are unset by default:
 
-Either uncomment the `[vars]` block in
-[`wrangler.toml`](../cors-proxy/wrangler.toml) and redeploy, or set it from the
-CLI:
+| Variable | Limits | Notes |
+| --- | --- | --- |
+| `ALLOWED_HOSTS` | which **target hosts** may be fetched | Caps abuse-as-relay. Always worth setting. |
+| `AUTH_KEY` | **who** may call it — only requests with your secret key | The real "only me" lock. |
+| `ALLOWED_ORIGINS` | which **web page** may call it | Softer: your game page is public, so anyone who opens it could use the proxy. |
+
+### For personal ("only me") use
+
+Set a **secret key** plus a **host allowlist**. The key is the lock; the host
+list limits the blast radius if the key ever leaks.
 
 ```sh
+cd cors-proxy
+
+# 1. Store the secret (encrypted; prompts for the value). Pick a long random string.
+npx wrangler secret put AUTH_KEY
+
+# 2. Restrict target hosts, then deploy.
 npx wrangler deploy --var ALLOWED_HOSTS:".github.com,codeload.github.com,objects.githubusercontent.com"
 ```
 
-A blocked host gets a `403` with a clear message. GitHub archive downloads flow
-through `codeload.github.com` and can redirect to `objects.githubusercontent.com`,
-so include both; add any other zip hosts you use.
+Then set the loader's **CORS proxy prefix** to a query-style prefix that carries
+the key (the loader appends the encoded target after the trailing `=`):
+
+```
+https://rpg-maker-cors-proxy.<sub>.workers.dev/?key=YOUR_SECRET&url=
+```
+
+Every request without a matching `?key=` gets a `403`. Because the key must ride
+in the query string, use the **query prefix style** (not path style) when
+`AUTH_KEY` is set.
+
+> **Keep the key private.** The prefix — key included — is saved in your
+> browser's `localStorage` and mirrored into the address bar as `?proxy=…`, so
+> **don't share a bookmarkable link** from a page where you've set it; that link
+> carries your key. To rotate the key, run `wrangler secret put AUTH_KEY` again.
+
+### Or: lock it to your game page
+
+If you'd rather not manage a secret, restrict by **origin** instead — only your
+deployed page's browser can use the proxy (its GitHub Pages origin, plus
+`localhost` for local testing):
+
+```sh
+npx wrangler deploy \
+  --var ALLOWED_HOSTS:".github.com,codeload.github.com,objects.githubusercontent.com" \
+  --var ALLOWED_ORIGINS:"https://<owner>.github.io,http://localhost:8000"
+```
+
+A disallowed origin gets a `403`, and successful responses are CORS-scoped to
+the caller's origin instead of `*`. This stops other websites from using your
+proxy, but not other visitors to your own (public) page — combine it with
+`AUTH_KEY` if you need both.
+
+### About `ALLOWED_HOSTS`
+
+Comma-separated; a leading dot matches subdomains (`.github.com` matches
+`codeload.github.com`). GitHub archive downloads flow through
+`codeload.github.com` and can redirect to `objects.githubusercontent.com`, so
+include both; add any other zip hosts you use. You can also set these vars by
+uncommenting the `[vars]` block in
+[`wrangler.toml`](../cors-proxy/wrangler.toml) instead of passing `--var`.
 
 ## Updating
 
@@ -91,9 +142,12 @@ Pages → your Worker → Deployments** in the Cloudflare dashboard.
   `Content-Range` / `Accept-Ranges` are exposed to the browser.
 - **Redirects** are followed server-side (GitHub's codeload endpoint 302s to a
   signed URL).
+- **Access checks** (all opt-in): a disallowed origin, a missing/invalid
+  `AUTH_KEY`, or a blocked target host each return `403`. The CORS preflight
+  (`OPTIONS`) is exempt from the key check but still honours the origin check.
 - **Errors** come back with CORS headers and a plain-text reason (`400` bad
-  target, `403` blocked host, `502` upstream failure), so the loader shows a real
-  message instead of an opaque network error.
+  target, `403` blocked/unauthorised, `502` upstream failure), so the loader
+  shows a real message instead of an opaque network error.
 
 ## Notes and alternatives
 
@@ -105,4 +159,4 @@ Pages → your Worker → Deployments** in the Cloudflare dashboard.
   loads.
 - **Public proxies** like `https://corsproxy.io/?url=` work too (that's the
   field's placeholder), but they rate-limit and can disappear; your own Worker is
-  more reliable and, with `ALLOWED_HOSTS`, not abusable.
+  more reliable and, with the access controls above, not abusable.


### PR DESCRIPTION
## Summary

This PR adds a ready-to-deploy CORS proxy for the web loader, implemented as a Cloudflare Worker. Users can now self-host a reliable proxy to enable downloading RPG Maker projects from GitHub and arbitrary `.zip` URLs without depending on public proxy services.

## Key Changes

- **`cors-proxy/worker.js`** — A Cloudflare Worker that:
  - Accepts both prefix styles the loader builds: query-style (`?url=<encoded>`) and path-style (`/<raw url>`)
  - Handles CORS preflight requests (`OPTIONS → 204`)
  - Forwards `Range` headers for resumable downloads and follows redirects (e.g., GitHub's codeload 302s)
  - Re-serves responses with `Access-Control-Allow-Origin: *` and exposes download-relevant headers
  - Returns CORS-enabled plain-text error responses (`400`/`403`/`502`) instead of opaque failures
  - Supports optional `ALLOWED_HOSTS` allowlist to prevent running as an open proxy

- **`cors-proxy/wrangler.toml`** — Cloudflare Worker deployment config with commented example for `ALLOWED_HOSTS`

- **`cors-proxy/README.md`** — Quick reference for the proxy module

- **`docs/cors-proxy.md`** — Complete deployment walkthrough:
  - 4-step setup (`wrangler login` → `wrangler deploy`)
  - Verification with `curl`
  - Optional lock-down with `ALLOWED_HOSTS`
  - Behavior documentation and alternatives

- **`docs/adr/0009-cors-proxy-cloudflare-worker.md`** — Architecture decision record explaining the choice of Cloudflare Workers over alternatives (VPS, other serverless platforms)

- **Documentation updates** — `README.md` and `CHANGELOG.md` updated to reference the new proxy and deployment guide

## Notable Implementation Details

- The Worker reconstructs the target URL from both prefix styles: query params are already decoded by `URLSearchParams`, while path-style URLs are reconstructed from pathname, search, and hash, then decoded
- The `hostAllowed()` function supports leading-dot subdomain matching (e.g., `.github.com` matches `codeload.github.com`)
- The proxy is entirely optional and out of the game's build — deployed separately with `wrangler`, not part of CI
- No new build or runtime dependencies; the loader already supports the CORS proxy prefix field

https://claude.ai/code/session_017MyfJisDiZ5Wyk9odvP3qC