### PR TITLE
Add Change Parameters event command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,12 @@ All notable changes to this project will be documented in this file.
     script load order
   - Documented the decision, layered architecture and milestone roadmap in
     `docs/adr/0004-javascript-maker-mv-quickjs.md` and `docs/TODO.md`
+- The event interpreter now supports **Change Parameters**: it adjusts an
+  actor's base stat — max HP, max MP, attack, defence, spirit or agility — for a
+  fixed actor, a variable-selected actor or the whole party, by a constant or
+  variable amount. `Game::Actor#change_param` clamps to RPG2000's limits (max
+  HP/MP 1–9999, the battle stats 1–999) and re-clamps current HP/MP when a
+  maximum is lowered. Covered by new checks in `scripts/rpg2k_logic_check.rb`.
 - The event interpreter now supports **Change HP**, **Change MP** and **Full
   Heal**. Each targets a fixed actor, an actor whose id is held in a variable,
   or the whole party, and takes a constant or variable amount. `Game::Actor`

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,
-  switches/variables, party/gold/item changes, actor HP/MP changes and full
-  heal, conditional branches, teleport, waits, BGM/SE playback, Call Event (run
-  a common event / another event's page) and Move Event (force a move route onto
-  an event or the player). Events start on the action button, on player touch
-  (walking into them),
+  switches/variables, party/gold/item changes, actor HP/MP and base-stat changes
+  and full heal, conditional branches, teleport, waits, BGM/SE playback, Call
+  Event (run a common event / another event's page) and Move Event (force a move
+  route onto an event or the player). Events start on the action button, on
+  player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -94,20 +94,22 @@ The work below is roughly ordered by the critical path to a walkable game
   modelled yet
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
-  Change HP/MP, Full Heal, Conditional Branch/Else/End, Loop/Break/End,
-  Label/Jump, Timer, Teleport, Wait, Play BGM/SE, Call Event, Move Event, End
-  Event) with a per-frame step cap so a bad loop can't hang. **Call Event**
+  Change HP/MP, Full Heal, Change Parameters, Conditional Branch/Else/End,
+  Loop/Break/End, Label/Jump, Timer, Teleport, Wait, Play BGM/SE, Call Event,
+  Move Event, End Event) with a per-frame step cap so a bad loop can't hang. **Call Event**
   suspends the current list, runs the referenced common event (or map-event
   page) to completion via a resolver + call stack — so call-only common events,
   which auto-start/parallel never reach, now run — and returns to the caller;
   recursion is bounded. **Move Event** decodes the forced move route packed into
   the command's parameters and hands it to the scene, which drives the target (a
   map event, "this event" or the player) along it in the background. **Change
-  HP/MP** and **Full Heal** apply to a fixed actor, a variable-selected actor or
-  the whole party, clamped to each actor's maxima (Change HP honours the
-  allow-death floor). Conditional Branch covers switch / variable / **timer** /
-  gold / item / actor-in-party conditions. The remaining commands (pictures,
-  screen effects, battles, EXP/level/parameter changes, ...) are TODO
+  HP/MP**, **Full Heal** and **Change Parameters** apply to a fixed actor, a
+  variable-selected actor or the whole party, clamped to each actor's maxima
+  (Change HP honours the allow-death floor; Change Parameters re-clamps current
+  HP/MP when a maximum is lowered). Conditional Branch covers switch / variable /
+  **timer** / gold / item / actor-in-party conditions. The remaining commands
+  (pictures, screen effects, battles, EXP/level changes — which need the
+  per-level stat growth curves, not yet parsed — ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   colour/speed/wait codes are consumed). Face graphics, per-code colour changes

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -189,6 +189,33 @@ module Game
       @hp = @max_hp
       @mp = @max_mp
     end
+
+    # Change Parameters base-stat types (the RPG2000 command's parameter field).
+    PARAM_MAX_HP = 0
+    PARAM_MAX_MP = 1
+    PARAM_ATK    = 2
+    PARAM_DEF    = 3
+    PARAM_INT    = 4
+    PARAM_AGI    = 5
+
+    # Apply a base-parameter change (the Change Parameters command). `type` is
+    # one of the PARAM_* constants; `delta` is signed. Stats clamp to RPG2000's
+    # limits (max HP/MP 1..9999, the four battle stats 1..999), and lowering a
+    # maximum re-clamps the current HP/MP so it never exceeds its new cap.
+    def change_param(type, delta)
+      case type
+      when PARAM_MAX_HP
+        @max_hp = Game.clamp(@max_hp + delta, 1, 9999)
+        @hp = @max_hp if @hp > @max_hp
+      when PARAM_MAX_MP
+        @max_mp = Game.clamp(@max_mp + delta, 1, 9999)
+        @mp = @max_mp if @mp > @max_mp
+      when PARAM_ATK then @atk = Game.clamp(@atk + delta, 1, 999)
+      when PARAM_DEF then @def = Game.clamp(@def + delta, 1, 999)
+      when PARAM_INT then @int = Game.clamp(@int + delta, 1, 999)
+      when PARAM_AGI then @agi = Game.clamp(@agi + delta, 1, 999)
+      end
+    end
   end
 
   # The active party. On a new game it is seeded from the database's initial

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -22,6 +22,7 @@ module Game
       CHANGE_GOLD      = 10310
       CHANGE_ITEMS     = 10320
       CHANGE_PARTY     = 10330
+      CHANGE_PARAM     = 10430
       CHANGE_HP        = 10460
       CHANGE_MP        = 10470
       FULL_HEAL        = 10490
@@ -183,6 +184,7 @@ module Game
       when Cmd::CHANGE_GOLD      then do_change_gold cmd
       when Cmd::CHANGE_ITEMS     then do_change_items cmd
       when Cmd::CHANGE_PARTY     then do_change_party cmd
+      when Cmd::CHANGE_PARAM     then do_change_params cmd
       when Cmd::CHANGE_HP        then do_change_hp cmd
       when Cmd::CHANGE_MP        then do_change_mp cmd
       when Cmd::FULL_HEAL        then do_full_heal cmd
@@ -443,6 +445,17 @@ module Game
     # Full recovery: restore HP and MP to their maxima for the target actors.
     def do_full_heal(cmd)
       stat_targets(cmd).each { |a| a.full_heal }
+    end
+
+    # Change Parameters: adjust a base stat. param3 selects the stat (0 max HP,
+    # 1 max MP, 2 attack, 3 defence, 4 spirit/int, 5 agility), param2 is the
+    # operation (0 add, 1 remove) and param4/param5 the operand (0 constant /
+    # 1 variable, value).
+    def do_change_params(cmd)
+      type = cmd.param(3)
+      amount = cmd.param(4) == 0 ? cmd.param(5) : variables[cmd.param(5)]
+      amount = -amount if cmd.param(2) != 0
+      stat_targets(cmd).each { |a| a.change_param(type, amount) }
     end
 
     # -- conditional branch ---------------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -669,6 +669,48 @@ check 'Full Heal restores the whole party to max HP/MP' do
   eq [50, 20],  [st.party.actor_by_id(2).hp, st.party.actor_by_id(2).mp]
 end
 
+check 'Change Parameters adds to a base battle stat' do
+  st = party_state
+  a = st.party.actor_by_id(1) # atk 10
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 1, op 0 (add), param 2 (atk), operand const 5
+  it.start([FakeCmd.new(IC::CHANGE_PARAM, [1, 1, 0, 2, 0, 5])])
+  it.update
+  eq 15, a.atk
+end
+
+check 'Change Parameters lowering max HP re-clamps current HP' do
+  st = party_state
+  a = st.party.actor_by_id(1) # max_hp 100, hp 100
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 1, op 1 (remove), param 0 (max_hp), const 60 -> max_hp 40
+  it.start([FakeCmd.new(IC::CHANGE_PARAM, [1, 1, 1, 0, 0, 60])])
+  it.update
+  eq 40, a.max_hp
+  eq 40, a.hp # current HP clamped down to the new maximum
+end
+
+check 'Change Parameters clamps a stat at its floor across the whole party' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # scope 0 (party), op 1 (remove), param 2 (atk), const 9999 -> floor 1
+  it.start([FakeCmd.new(IC::CHANGE_PARAM, [0, 0, 1, 2, 0, 9999])])
+  it.update
+  eq 1, st.party.actor_by_id(1).atk
+  eq 1, st.party.actor_by_id(2).atk
+end
+
+check 'Change Parameters raises max MP with a variable operand' do
+  st = party_state
+  st.variables[4] = 20
+  a = st.party.actor_by_id(2) # max_mp 20
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 2, op 0 (add), param 1 (max_mp), operand type 1 (var), var 4
+  it.start([FakeCmd.new(IC::CHANGE_PARAM, [1, 2, 0, 1, 1, 4])])
+  it.update
+  eq 40, a.max_mp
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
Implements support for the RPG2000 "Change Parameters" event command, allowing scripts to modify actor base stats (max HP, max MP, attack, defence, spirit, and agility) for individual actors or the entire party.

## Key Changes
- **Game::Actor#change_param**: New method that applies signed deltas to base stats with proper clamping to RPG2000 limits (max HP/MP: 1–9999, battle stats: 1–999). When a maximum stat is lowered, the corresponding current stat is re-clamped to ensure it never exceeds the new cap.
- **Game::Interpreter#do_change_params**: Implements the Change Parameters command handler, supporting both constant and variable operands, and targeting fixed actors, variable-selected actors, or the whole party.
- **Command constant**: Added `CHANGE_PARAM = 10430` to the command registry.
- **Comprehensive test coverage**: Four new checks in `scripts/rpg2k_logic_check.rb` validating:
  - Adding to a base battle stat
  - Re-clamping current HP when max HP is lowered
  - Clamping stats to their floor across the whole party
  - Using variable operands for stat changes

## Implementation Details
- The `change_param` method uses a case statement to handle each of the six parameter types with appropriate clamping ranges
- HP/MP re-clamping logic ensures `current <= maximum` after a maximum is reduced
- The interpreter handler correctly interprets the command's parameter fields: param3 for stat type, param2 for operation (add/remove), and param4/param5 for the operand (constant or variable reference)
- Documentation updated in README.md, docs/TODO.md, and CHANGELOG.md to reflect the new capability

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y