### PR TITLE
Implement actor sub-conditions in Conditional Branch evaluation

### DIFF
--- a/changelog.d/cond-actor-subconditions.added.md
+++ b/changelog.d/cond-actor-subconditions.added.md
@@ -1,0 +1,6 @@
+- **Conditional Branch** now evaluates the RPG2000 **actor (hero)**
+  sub-conditions instead of only "is in party": whether the actor's name equals
+  the command's string, whether its level is at least a value, and whether its
+  HP is at least a value. Skill / equipment / state sub-conditions remain
+  unmodelled and evaluate to false, as does a stat check on an actor not in the
+  party. Covered by new checks in `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -113,9 +113,10 @@ The work below is roughly ordered by the critical path to a walkable game
   constants and other variables but also a **random** range, an **actor stat**
   (level / HP / MP / max HP-MP / attack / defence / spirit / agility) and **game
   quantities** (party gold, timer seconds). Conditional Branch covers switch /
-  variable / **timer** / gold / item / actor-in-party conditions. The remaining
-  commands (pictures, screen effects, battles, EXP/level changes — which need
-  the per-level stat growth curves, not yet parsed — ...) are TODO
+  variable / **timer** / gold / item conditions and the **actor** sub-conditions
+  (in party, name, level ≥, HP ≥; skill / equipment / state are not modelled).
+  The remaining commands (pictures, screen effects, battles, EXP/level changes —
+  which need the per-level stat growth curves, not yet parsed — ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   colour/speed/wait codes are consumed). Face graphics, per-code colour changes

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -543,9 +543,28 @@ module Game
       when 4 # item: param1 id, param2 (0 has / 1 not)
         has = party.has_item?(cmd.param(1))
         cmd.param(2) == 0 ? has : !has
-      when 5 # actor in party: param1 id
-        party.include_actor?(cmd.param(1))
+      when 5 # actor: param1 id, param2 sub-condition (see actor_condition)
+        actor_condition(cmd)
       else true
+      end
+    end
+
+    # Conditional type 5 (actor/hero): param1 is the actor id, param2 selects the
+    # sub-condition — 0 in party, 1 name equals the command string, 2 level >=
+    # param3, 3 HP >= param3. The skill / equipment / state sub-conditions
+    # (4/5/6) are not modelled and read as false. The stat checks need the actor
+    # to be in the party (the only actors this build instantiates); a missing
+    # actor is false.
+    def actor_condition(cmd)
+      id = cmd.param(1)
+      return party.include_actor?(id) if cmd.param(2) == 0
+      actor = party.actor_by_id(id)
+      return false unless actor
+      case cmd.param(2)
+      when 1 then actor.name == cmd.string
+      when 2 then actor.level >= cmd.param(3)
+      when 3 then actor.hp >= cmd.param(3)
+      else false
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -774,6 +774,51 @@ check 'Control Variables actor operand reads 0 for an absent actor' do
   eq 0, st.variables[1]
 end
 
+# -- Conditional branch: actor (hero) sub-conditions -------------------------
+
+# Build a conditional (type 5) with an if-body switch 1 and an else-body switch
+# 2, run it against a fresh party_state, and return that state.
+def run_actor_cond(params, string: '')
+  st = party_state
+  yield st if block_given?
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONDITIONAL, params, indent: 0, string: string),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+            FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+            FakeCmd.new(IC::END_BRANCH, [], indent: 0)])
+  it.update
+  st
+end
+
+check 'Conditional actor: in-party sub-condition (type 5, sub 0)' do
+  st = run_actor_cond([5, 1, 0])     # actor 1 is in the party
+  eq true, st.switches[1]
+  st = run_actor_cond([5, 9, 0])     # actor 9 is not
+  eq true, st.switches[2]
+end
+
+check 'Conditional actor: level >= (type 5, sub 2)' do
+  eq true,  run_actor_cond([5, 1, 2, 5]).switches[1] # actor 1 level 5 >= 5
+  eq true,  run_actor_cond([5, 1, 2, 6]).switches[2] # 5 >= 6 is false -> else
+end
+
+check 'Conditional actor: HP >= (type 5, sub 3)' do
+  st = run_actor_cond([5, 1, 3, 50]) { |s| s.party.actor_by_id(1).hp = 30 }
+  eq true, st.switches[2] # hp 30 < 50 -> else
+  st = run_actor_cond([5, 1, 3, 50]) { |s| s.party.actor_by_id(1).hp = 80 }
+  eq true, st.switches[1] # hp 80 >= 50
+end
+
+check 'Conditional actor: name equals the command string (type 5, sub 1)' do
+  eq true, run_actor_cond([5, 1, 1], string: 'Hero').switches[1]
+  eq true, run_actor_cond([5, 1, 1], string: 'Nope').switches[2]
+end
+
+check 'Conditional actor: unmodelled sub-condition reads false (type 5, sub 6)' do
+  eq true, run_actor_cond([5, 1, 6, 3]).switches[2] # has-state -> false -> else
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
Expanded the Conditional Branch (type 5) evaluation to handle actor/hero sub-conditions beyond just "is in party". The interpreter now evaluates whether an actor's name matches the command string, whether its level meets a threshold, and whether its HP meets a threshold.

## Key Changes
- **interpreter.rb**: Refactored actor condition evaluation into a dedicated `actor_condition` method that handles:
  - Sub-condition 0: Actor is in party (existing behavior)
  - Sub-condition 1: Actor's name equals the command string
  - Sub-condition 2: Actor's level >= param3
  - Sub-condition 3: Actor's HP >= param3
  - Sub-conditions 4-6: Skill/equipment/state checks (unmodelled, return false)
  - Missing actors: Return false for stat checks on actors not in party

- **rpg2k_logic_check.rb**: Added comprehensive test coverage with four new checks:
  - In-party sub-condition validation
  - Level comparison logic
  - HP comparison logic with state mutation
  - Name equality check with command string parameter
  - Unmodelled sub-condition fallback behavior

- **Documentation**: Updated CHANGELOG and TODO to reflect the new actor sub-condition support and clarify which conditions remain unimplemented

## Implementation Details
The `actor_condition` method follows a defensive pattern: it returns early for the simple "in party" check, then retrieves the actor and returns false if not found before evaluating stat-based conditions. This ensures stat checks only run on instantiated actors that are in the party, matching the game's expected behavior.

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y