### PR TITLE
Implement Erase Event command to remove events from the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- The event interpreter now supports **Erase Event**. Running it removes the
+  event that is executing (foreground or a parallel process) from the map for
+  the rest of the visit — its marker, movement, collision tile and, for a
+  parallel event, its background process — while the rest of the command list
+  still runs (Erase Event does not pause the interpreter). A common event, which
+  has no map event, is unaffected. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.
 - **Control Variables** now supports more operand sources than constants and
   other variables: a **random** integer in a range, an **actor stat** (level,
   current/max HP and MP, attack, defence, spirit or agility of an actor by id)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@
   switches/variables (set from constants, other variables, random rolls, actor
   stats or gold/timer), party/gold/item changes, actor HP/MP and base-stat
   changes and full heal, conditional branches, teleport, waits, BGM/SE playback,
-  Call Event (run a common event / another event's page) and Move Event (force a
-  move route onto an event or the player). Events start on the action button, on
+  Call Event (run a common event / another event's page), Move Event (force a
+  move route onto an event or the player) and Erase Event (remove an event from
+  the map). Events start on the action button, on
   player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -96,13 +96,16 @@ The work below is roughly ordered by the critical path to a walkable game
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Change HP/MP, Full Heal, Change Parameters, Conditional Branch/Else/End,
   Loop/Break/End, Label/Jump, Timer, Teleport, Wait, Play BGM/SE, Call Event,
-  Move Event, End Event) with a per-frame step cap so a bad loop can't hang. **Call Event**
+  Move Event, Erase Event, End Event) with a per-frame step cap so a bad loop
+  can't hang. **Call Event**
   suspends the current list, runs the referenced common event (or map-event
   page) to completion via a resolver + call stack — so call-only common events,
   which auto-start/parallel never reach, now run — and returns to the caller;
   recursion is bounded. **Move Event** decodes the forced move route packed into
   the command's parameters and hands it to the scene, which drives the target (a
-  map event, "this event" or the player) along it in the background. **Change
+  map event, "this event" or the player) along it in the background. **Erase
+  Event** removes the running event from the map for the rest of the visit (its
+  marker, movement, collision and any parallel process). **Change
   HP/MP**, **Full Heal** and **Change Parameters** apply to a fixed actor, a
   variable-selected actor or the whole party, clamped to each actor's maxima
   (Change HP honours the allow-death floor; Change Parameters re-clamps current

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -37,6 +37,7 @@ module Game
       COMMENT          = 12410
       COMMENT_2        = 22410
       END_EVENT        = 12310
+      ERASE_EVENT      = 12320
       CALL_EVENT       = 12330
       TELEPORT         = 10810
       MOVE_EVENT       = 11330
@@ -66,6 +67,7 @@ module Game
       @call_stack = []
       @resolver = nil
       @move_route_requests = []
+      @erase_requested = false
       # Deterministic RNG for the Control Variables "random" operand (mruby has
       # no Kernel#rand here); seeded like the map scene's own RNG.
       @rng = Game::Rng.new(0x2000)
@@ -86,6 +88,7 @@ module Game
       @running = true
       @call_stack = []
       @move_route_requests = []
+      @erase_requested = false
       reset_waits
     end
 
@@ -99,6 +102,16 @@ module Game
       reqs = @move_route_requests
       @move_route_requests = []
       reqs
+    end
+
+    # True (once) if an Erase Event command ran since the last call, clearing the
+    # flag. The owning scene polls this after #update and removes the event that
+    # was running this interpreter from the map. Like Move Event, Erase Event does
+    # not pause the interpreter — the rest of the command list still runs.
+    def take_erase_request
+      v = @erase_requested
+      @erase_requested = false
+      v
     end
 
     # Upper bound on commands run in a single update, so a malformed loop cannot
@@ -204,6 +217,7 @@ module Game
       when Cmd::PLAY_BGM         then play_audio(:bgm, cmd)
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
       when Cmd::CALL_EVENT       then do_call_event cmd
+      when Cmd::ERASE_EVENT      then @erase_requested = true
       when Cmd::END_EVENT        then @index = @list.size
       else nil # unimplemented / no-op (labels, comments, ...)
       end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -627,7 +627,9 @@ class RPG2k
       # process keeps running). Called only while the foreground is idle, so
       # parallels pause during messages and foreground events.
       def step_parallels
-        @parallels.each { |p| step_parallel(p) }
+        # Iterate a copy: an Erase Event in a parallel process removes it from
+        # @parallels mid-loop (see erase_event).
+        @parallels.dup.each { |p| step_parallel(p) }
       end
 
       def step_parallel(p)
@@ -642,6 +644,7 @@ class RPG2k
           it.update
         end
         apply_move_requests(it, p[:event])
+        apply_erase_request(it, p[:event])
       rescue StandardError
         nil
       end
@@ -737,6 +740,29 @@ class RPG2k
       def reoccupy(e, ox, oy)
         @event_tiles.delete([ox, oy]) if @event_tiles[[ox, oy]].equal?(e)
         @event_tiles[[e[:char].x, e[:char].y]] = e
+      end
+
+      # -- Erase Event --------------------------------------------------------
+
+      # If the interpreter ran an Erase Event this step, remove the event that
+      # was running it (`this_event`) from the map. A common event has no such
+      # map event, so nothing happens.
+      def apply_erase_request(interp, this_event)
+        erase_event(this_event) if interp.take_erase_request && this_event
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Erase Event failed: #{e.message}"
+        nil
+      end
+
+      # Remove an event from the map for the rest of the visit: drop it from the
+      # runtime list, the occupied-tile cache (so it no longer draws, moves or
+      # blocks) and any background process it was driving. It reappears only on
+      # the next map (re)load, matching RPG2000's Erase Event.
+      def erase_event(ev)
+        @events.delete(ev)
+        tile = [ev[:char].x, ev[:char].y]
+        @event_tiles.delete(tile) if @event_tiles[tile].equal?(ev)
+        @parallels.reject! { |p| p[:event].equal?(ev) } if @parallels
       end
 
       # -- Move Event (Set Move Route) ----------------------------------------
@@ -853,6 +879,7 @@ class RPG2k
         else
           @interpreter.update
           apply_move_requests(@interpreter, @active_event)
+          apply_erase_request(@interpreter, @active_event)
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -477,6 +477,18 @@ check 'Call Event with no resolver set is a safe no-op' do
   eq true, st.switches[1]
 end
 
+check 'Erase Event sets a one-shot request without pausing the interpreter' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ERASE_EVENT, []),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Erase Event must not pause the interpreter'
+  eq true, st.switches[1], 'the command after Erase Event still ran'
+  eq true, it.take_erase_request, 'the erase was requested'
+  eq false, it.take_erase_request, 'the request is one-shot (cleared on read)'
+end
+
 check 'a message inside a called event pauses and resumes across the boundary' do
   st = new_state
   called = [FakeCmd.new(IC::SHOW_MESSAGE, [], string: 'hi'),

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -381,6 +381,33 @@ check 'a non-repeating player route finishes and returns control to input' do
   ok st.y > 0, "input resumed after the route finished, at y=#{st.y}"
 end
 
+check 'Erase Event removes the running event from the map' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3) # auto-start: erase myself
+  auto.event_commands = [ECmd.new(ic::ERASE_EVENT, [])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  ok chars(scene)[1], 'event present before it runs'
+  5.times { scene.update }
+  evs = scene.instance_variable_get(:@events)
+  ok evs.none? { |e| e[:id] == 1 }, 'the event is gone from the runtime list'
+  tiles = scene.instance_variable_get(:@event_tiles)
+  ok !tiles[[2, 2]], 'its occupied tile is cleared (no marker, no collision)'
+end
+
+check 'Erase Event stops a parallel process that erases itself' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4) # parallel: bump var 1, then erase myself
+  par.event_commands = [add_var_cmd(1), ECmd.new(ic::ERASE_EVENT, [])]
+  scene = new_scene({ 1 => event(2, 2, par) }, player: [5, 5])
+  10.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  eq 1, st.variables[1], 'the process ran once, then erased itself (no re-loop)'
+  ok scene.instance_variable_get(:@events).none? { |e| e[:id] == 1 },
+     'erased from the event list'
+  ok scene.instance_variable_get(:@parallels).empty?,
+     'its background process was removed'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
This PR adds support for the **Erase Event** command in the event interpreter. When executed, it removes the running event (whether foreground or parallel process) from the map for the remainder of the visit, including its visual marker, movement capability, collision tile, and any associated background process.

## Key Changes

- **Interpreter support**: Added `ERASE_EVENT` command (opcode 12320) that sets a one-shot `@erase_requested` flag without pausing execution, allowing subsequent commands in the list to run.

- **Scene integration**: 
  - Added `apply_erase_request()` method to process erase requests after interpreter updates in both foreground and parallel event contexts
  - Added `erase_event()` method that removes an event from the runtime list (`@events`), clears its occupied tile cache (`@event_tiles`), and removes any associated parallel process from `@parallels`

- **Parallel process safety**: Modified `step_parallels()` to iterate over a copy of `@parallels` to safely handle mid-loop removal when a parallel process erases itself

- **Documentation**: Updated CHANGELOG, README, and TODO with Erase Event details and behavior

## Notable Implementation Details

- Erase Event does not pause the interpreter—commands after it in the same list continue executing
- Common events (which have no associated map event) are unaffected by erase requests
- The implementation properly handles the edge case where a parallel process erases itself mid-execution by iterating over a duplicate of the parallels list
- Comprehensive test coverage added for both foreground and parallel event erasure scenarios

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y