### PR TITLE
Implement changelog fragment system to reduce merge conflicts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,12 @@
 
 -   Update relevant documentation in /docs when modifying features
 -   Keep README.md in sync with new capabilities
--   Maintain changelog entries in CHANGELOG.md
+-   Record changelog entries as fragment files in `changelog.d/`, **not** by
+    editing the `## [Unreleased]` section of `CHANGELOG.md` directly. Add one
+    `changelog.d/<slug>.<category>.md` file per change so branches never
+    collide on the same lines. See `changelog.d/README.md` for the format;
+    `scripts/build_changelog.rb` folds the fragments into `CHANGELOG.md` at
+    release time.
 
 ## Architecture Decision Records
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+<!--
+  Do not hand-edit the [Unreleased] section below — it caused constant merge
+  conflicts because every branch touched the same lines. Add a fragment file
+  under changelog.d/ instead (see changelog.d/README.md). The fragments are
+  folded in here at release time by scripts/build_changelog.rb.
+-->
+
 ## [Unreleased]
 
 ### Added

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,45 @@
+# Changelog fragments
+
+To avoid merge conflicts, **do not edit the `## [Unreleased]` section of
+`CHANGELOG.md` by hand.** Every branch that edited that one section touched the
+same lines, so every pull request collided.
+
+Instead, each change gets its own file in this directory. Two branches never
+touch the same file, so the fragments merge cleanly. The fragments are folded
+into `CHANGELOG.md` at release time by `scripts/build_changelog.rb`.
+
+## Adding an entry
+
+Create one file per change, named `<slug>.<category>.md`:
+
+```
+changelog.d/control-variables-operands.added.md
+changelog.d/lmt-scrollbar-signed.fixed.md
+```
+
+- `<slug>` — a short, unique, kebab-case description. Anything unique works;
+  the issue/PR number (`118.added.md`) or a topic slug both avoid collisions.
+- `<category>` — one of: `added`, `changed`, `deprecated`, `removed`,
+  `fixed`, `security` (matching the "Keep a Changelog" sections).
+
+The file body is the Markdown bullet(s) exactly as they should appear in the
+changelog, starting with `- `. Wrapped continuation lines are indented two
+spaces, like the rest of `CHANGELOG.md`:
+
+```markdown
+- **Control Variables** now supports random integers, actor stats and game
+  quantities as operand sources. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb`.
+```
+
+## Handy commands
+
+```bash
+ruby scripts/build_changelog.rb list        # list pending fragments
+ruby scripts/build_changelog.rb preview     # preview the merged Unreleased section
+ruby scripts/build_changelog.rb release 1.2.0   # fold fragments into CHANGELOG.md
+```
+
+`release` renames `## [Unreleased]` to the given version (dated today unless a
+date is passed), merges the pending fragments into it, opens a fresh empty
+`## [Unreleased]`, and deletes the consumed fragment files.

--- a/scripts/build_changelog.rb
+++ b/scripts/build_changelog.rb
@@ -1,0 +1,228 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Assemble changelog fragments (changelog.d/*.md) into CHANGELOG.md.
+#
+# Editing the single `## [Unreleased]` section by hand made every branch touch
+# the same lines, so pull requests constantly conflicted. Instead each change
+# lands as its own file under changelog.d/, and this script folds them in.
+#
+# Usage:
+#   ruby scripts/build_changelog.rb list             # list pending fragments
+#   ruby scripts/build_changelog.rb preview          # print the merged Unreleased section
+#   ruby scripts/build_changelog.rb release VERSION [DATE]
+#
+# See changelog.d/README.md for the fragment format.
+
+require "date"
+
+# CHANGELOG.md and fragments contain UTF-8 (→, —, …); read/write them as such
+# regardless of the ambient locale.
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
+ROOT = File.expand_path("..", __dir__)
+FRAGMENT_DIR = File.join(ROOT, "changelog.d")
+CHANGELOG = File.join(ROOT, "CHANGELOG.md")
+
+# Canonical "Keep a Changelog" categories, in display order.
+CATEGORIES = %w[added changed deprecated removed fixed security].freeze
+HEADINGS = {
+  "added" => "Added",
+  "changed" => "Changed",
+  "deprecated" => "Deprecated",
+  "removed" => "Removed",
+  "fixed" => "Fixed",
+  "security" => "Security",
+}.freeze
+
+# A fragment file is `<slug>.<category>.md`. Returns [category, path] pairs
+# grouped by category, in canonical order, each list sorted by filename so the
+# output is deterministic regardless of filesystem order.
+def load_fragments
+  grouped = Hash.new { |h, k| h[k] = [] }
+  Dir.glob(File.join(FRAGMENT_DIR, "*.md")).sort.each do |path|
+    name = File.basename(path, ".md")
+    category = name.split(".").last
+    unless CATEGORIES.include?(category)
+      abort "Fragment #{File.basename(path)} has an unknown category " \
+            "'#{category}'. Expected one of: #{CATEGORIES.join(', ')}."
+    end
+    grouped[category] << path
+  end
+  grouped
+end
+
+# Read a fragment body, ensuring it is a non-empty Markdown bullet.
+def fragment_body(path)
+  body = File.read(path).strip
+  abort "Fragment #{File.basename(path)} is empty." if body.empty?
+  unless body.start_with?("- ")
+    abort "Fragment #{File.basename(path)} must start with '- ' " \
+          "(a Markdown list item). See changelog.d/README.md."
+  end
+  body
+end
+
+# Render pending fragments as `### Category` blocks.
+def render_fragments(grouped)
+  out = []
+  CATEGORIES.each do |category|
+    paths = grouped[category]
+    next if paths.empty?
+
+    out << "### #{HEADINGS[category]}"
+    out << paths.map { |p| fragment_body(p) }.join("\n")
+    out << ""
+  end
+  out.join("\n").rstrip
+end
+
+def pending_paths(grouped)
+  CATEGORIES.flat_map { |c| grouped[c] }
+end
+
+def cmd_list
+  grouped = load_fragments
+  paths = pending_paths(grouped)
+  if paths.empty?
+    puts "No pending changelog fragments."
+    return
+  end
+  puts "Pending changelog fragments:"
+  paths.each { |p| puts "  #{File.basename(p)}" }
+end
+
+def cmd_preview
+  grouped = load_fragments
+  rendered = render_fragments(grouped)
+  if rendered.empty?
+    puts "No pending changelog fragments."
+    return
+  end
+  puts "## [Unreleased]  (with pending fragments merged in)"
+  puts
+  puts rendered
+end
+
+# Split CHANGELOG.md into [preamble, unreleased_body, rest]. `unreleased_body`
+# is everything between the `## [Unreleased]` heading and the next `## ` header
+# (or end of file).
+def split_changelog(text)
+  lines = text.lines
+  start = lines.index { |l| l.start_with?("## [Unreleased]") }
+  abort "Could not find a '## [Unreleased]' heading in CHANGELOG.md." if start.nil?
+
+  finish = ((start + 1)...lines.length).find { |i| lines[i].start_with?("## ") }
+  finish ||= lines.length
+
+  # preamble excludes the `## [Unreleased]` heading itself so the caller can
+  # re-emit a fresh heading without duplicating it.
+  preamble = lines[0...start].join
+  body = lines[(start + 1)...finish].join
+  rest = lines[finish..].join
+  [preamble, body, rest]
+end
+
+# Append fragment bullets into the matching `### Category` subsection of the
+# Unreleased body, creating subsections (in canonical order) when absent. Only
+# the first occurrence of a heading is appended to; pre-existing duplicates are
+# left untouched.
+def merge_into_body(body, grouped)
+  CATEGORIES.each do |category|
+    paths = grouped[category]
+    next if paths.empty?
+
+    bullets = paths.map { |p| fragment_body(p) }.join("\n")
+    heading = "### #{HEADINGS[category]}"
+    body = append_to_subsection(body, category, heading, bullets)
+  end
+  body
+end
+
+def append_to_subsection(body, category, heading, bullets)
+  lines = body.lines
+  head_idx = lines.index { |l| l.rstrip == heading }
+
+  if head_idx
+    # Find the end of this subsection (next `### ` or end of body).
+    nxt = ((head_idx + 1)...lines.length).find { |i| lines[i].start_with?("### ") }
+    nxt ||= lines.length
+    # Back up over trailing blank lines within the subsection.
+    insert = nxt
+    insert -= 1 while insert > head_idx + 1 && lines[insert - 1].strip.empty?
+    lines.insert(insert, "#{bullets}\n")
+    lines.join
+  else
+    insert_new_subsection(lines, category, heading, bullets).join
+  end
+end
+
+# Insert a brand-new subsection so that subsections stay in canonical order.
+def insert_new_subsection(lines, category, heading, bullets)
+  rank = CATEGORIES.index(category)
+  target = nil
+  lines.each_with_index do |line, i|
+    next unless line.start_with?("### ")
+
+    other = line.sub("### ", "").strip.downcase
+    other_rank = CATEGORIES.index(other)
+    if other_rank && other_rank > rank
+      target = i
+      break
+    end
+  end
+
+  block = ["#{heading}\n", "#{bullets}\n", "\n"]
+  if target
+    lines.insert(target, *block)
+  else
+    lines << "\n" unless lines.empty? || lines.last.end_with?("\n\n") || lines.last.strip.empty?
+    lines.concat(block)
+  end
+  lines
+end
+
+def cmd_release(version, date)
+  abort "VERSION is required, e.g. `release 1.2.0`." if version.nil? || version.empty?
+
+  grouped = load_fragments
+  text = File.read(CHANGELOG)
+  preamble, body, rest = split_changelog(text)
+
+  merged = merge_into_body(body, grouped).rstrip
+
+  new_unreleased = "## [Unreleased]\n\n"
+  released_header = "## [#{version}] - #{date}\n"
+  released = "#{released_header}\n#{merged}\n\n"
+
+  content = "#{preamble.rstrip}\n\n#{new_unreleased}#{released}#{rest.strip}\n"
+  File.write(CHANGELOG, content.gsub(/\n{3,}/, "\n\n"))
+
+  consumed = pending_paths(grouped)
+  consumed.each { |p| File.delete(p) }
+
+  puts "Released #{version} (#{date}); folded #{consumed.size} fragment(s) into CHANGELOG.md."
+end
+
+command = ARGV.shift
+case command
+when "list"
+  cmd_list
+when "preview"
+  cmd_preview
+when "release"
+  version = ARGV.shift
+  date = ARGV.shift || Date.today.iso8601
+  cmd_release(version, date)
+else
+  warn <<~USAGE
+    Usage:
+      ruby scripts/build_changelog.rb list
+      ruby scripts/build_changelog.rb preview
+      ruby scripts/build_changelog.rb release VERSION [DATE]
+
+    See changelog.d/README.md for the fragment format.
+  USAGE
+  exit(command.nil? ? 1 : 2)
+end


### PR DESCRIPTION
## Summary

Introduces a changelog fragment system to eliminate merge conflicts caused by multiple branches editing the same `## [Unreleased]` section in `CHANGELOG.md`. Each change now gets its own file in `changelog.d/`, which are automatically merged at release time.

## Key Changes

- **Added `scripts/build_changelog.rb`** — A Ruby script that manages changelog fragments with three commands:
  - `list` — Display pending fragment files
  - `preview` — Show how the Unreleased section will look with fragments merged
  - `release VERSION [DATE]` — Fold fragments into CHANGELOG.md, create a new release entry, and clean up consumed fragments

- **Added `changelog.d/README.md`** — Documentation explaining the fragment format and workflow:
  - Fragment naming convention: `<slug>.<category>.md`
  - Supported categories: added, changed, deprecated, removed, fixed, security
  - Fragment content must be Markdown bullet points starting with `- `

- **Updated `CHANGELOG.md`** — Added a comment block explaining the new fragment-based workflow and warning against hand-editing the Unreleased section

- **Updated `AGENTS.md`** — Revised contribution guidelines to direct changelog entries to the fragment system instead of direct CHANGELOG.md editing

- **Added `changelog.d/.gitkeep`** — Placeholder to ensure the fragments directory exists in version control

## Implementation Details

The build script handles:
- Deterministic ordering by sorting fragments by filename within each category
- Validation of fragment format (must start with `- ` and be non-empty)
- Intelligent merging that appends to existing category subsections or creates new ones in canonical order
- Proper whitespace handling to maintain consistent formatting
- Automatic cleanup of consumed fragments after release

https://claude.ai/code/session_01Vwnb8HHD1JkRZFTrmgHaJP