### PR TITLE
MV: Boot without complete art and auto-advance past title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           mkdir -p ss
           nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
             --timeout_ms=5000 --game_dir data/mv-sample \
-            --mv_screenshot=ss/mv_sample.png
+            --mv_new_game --mv_screenshot=ss/mv_sample.png
 
       - name: Upload MV sample screenshot
         if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/changelog.d/mv-sample-boots-to-map.added.md
+++ b/changelog.d/mv-sample-boots-to-map.added.md
@@ -1,0 +1,11 @@
+- MV boots without complete art, and the committed sample now reaches its map.
+  MV's `Scene_Boot` reserves system images (`img/system/Window.png`, …) and
+  blocks on `ImageManager.isReady()` until they load, so a project missing that
+  (optional) art — like the deliberately asset-free `data/mv-sample` — stalled
+  in `Scene_Boot` forever. A missing/undecodable image now resolves as a 1×1
+  transparent bitmap (via `onload`) instead of erroring, so the boot proceeds
+  and absent art simply draws nothing (`drawImage` clamps out-of-range reads).
+  A new `--mv_new_game` flag auto-selects **New Game** once the title appears,
+  so the CI smoke test drives the sample past the title into `Scene_Map`
+  (`[MV] scene: Scene_Boot → Scene_Title → Scene_Map`) and captures the
+  in-game frame. Covered by `mruby-mvjs/test/canvas_test.rb`.

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -219,6 +219,7 @@ class MV
     pump_frame # M3: run the rAF/timer queue for one frame
     pump_audio # M5: drain MV's queued audio ops into RGSS::Audio
     log_scene_transition # trace boot progress (Scene_Boot -> Scene_Title -> ...)
+    maybe_new_game # CI: auto-advance past the title to the first map
     present # M4: copy the MV canvas onto the on-screen sprite's bitmap
     maybe_screenshot # capture the rendered frame once, if requested (CI)
     RGSS::Input.update
@@ -312,6 +313,36 @@ class MV
     $stderr.puts "[MV] screenshot #{ok ? "saved" : "failed"}: #{path}"
   rescue StandardError => e
     $stderr.puts "[MV] screenshot error: #{e.message}"
+  end
+
+  # When --mv_new_game is set (CI), select "New Game" once the title screen is
+  # up so the game advances to its first map without any input — letting a
+  # headless capture show in-game rendering, not just the title. One-shot; a
+  # no-op during normal play (flag unset).
+  def maybe_new_game
+    return if @new_game_done
+
+    want = begin
+      MV_NEW_GAME
+    rescue StandardError
+      false
+    end
+    return unless want
+
+    scene = MV::JS.eval(
+      "(typeof SceneManager !== 'undefined' && SceneManager._scene) ? " \
+      "SceneManager._scene.constructor.name : ''"
+    )
+    return unless scene == "Scene_Title"
+
+    @new_game_done = true
+    MV::JS.eval(
+      "if (SceneManager._scene && SceneManager._scene.commandNewGame) " \
+      "SceneManager._scene.commandNewGame();"
+    )
+    $stderr.puts "[MV] auto New Game"
+  rescue StandardError => e
+    $stderr.puts "[MV] new game error: #{e.message}"
   end
 
   # Log the running scene's class name whenever it changes, so the boot's

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -882,15 +882,19 @@ const char* kCanvasPreamble = R"MVJS(
       this.complete = false;
       var h = g.__mv_imageLoad(v);
       g.requestAnimationFrame(function () {
-        if (h) {
-          self.__h = h;
-          self.width = g.__mv_canvasWidth(h);
-          self.height = g.__mv_canvasHeight(h);
-          self.complete = true;
-          if (typeof self.onload === 'function') self.onload();
-        } else if (typeof self.onerror === 'function') {
-          self.onerror(new Error('image load failed: ' + v));
-        }
+        // A missing or undecodable image resolves as a 1x1 transparent bitmap
+        // (via onload), not an error. MV reserves system art (Window, IconSet,
+        // …) and blocks on ImageManager.isReady() until it loads, so an absent
+        // file would otherwise stall the boot forever. A project running
+        // without its (optional) art still boots and reaches the map; the empty
+        // bitmap draws nothing (drawImage clamps out-of-range source reads), so
+        // e.g. a degenerate windowskin is invisible rather than fatal.
+        if (!h) h = g.__mv_canvasCreate(1, 1);
+        self.__h = h;
+        self.width = g.__mv_canvasWidth(h);
+        self.height = g.__mv_canvasHeight(h);
+        self.complete = true;
+        if (typeof self.onload === 'function') self.onload();
       });
     },
   });

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -83,12 +83,21 @@ assert 'MV Image decodes a PNG and serves as a drawImage source' do
   end
 end
 
-assert 'MV Image fires onerror for a missing file' do
+assert 'MV Image resolves a missing file as a 1x1 empty bitmap (boot does not stall)' do
+  # A missing image loads (onload) as a 1x1 transparent bitmap rather than
+  # erroring, so MV's ImageManager.isReady() does not block the boot forever on
+  # reserved-but-absent system art (a project running without its art still
+  # boots). onerror must NOT fire.
   MV::JS.base_dir = ""
-  MV::JS.eval("globalThis.IE=new Image(); globalThis.IE_err=false; " \
-              "IE.onerror=function(){IE_err=true;}; IE.src='definitely_missing_image.png';")
+  MV::JS.eval("globalThis.IE=new Image(); globalThis.IE_ok=false; globalThis.IE_err=false; " \
+              "IE.onload=function(){IE_ok=true;}; IE.onerror=function(){IE_err=true;}; " \
+              "IE.src='definitely_missing_image.png';")
   MV::JS.pump(0.0)
-  assert_equal true, MV::JS.eval("IE_err")
+  assert_equal true, MV::JS.eval("IE_ok")
+  assert_equal false, MV::JS.eval("IE_err")
+  assert_equal 1, MV::JS.eval("IE.width")
+  assert_equal 1, MV::JS.eval("IE.height")
+  assert_equal true, MV::JS.eval("IE.complete")
 end
 
 assert 'MV::JS.present blits a canvas onto an RGSS::Bitmap with correct channels' do

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -35,6 +35,12 @@ DEFINE_string(
     "",
     "For RPG Maker MV: write a PNG of the rendered frame to this path "
     "after boot, then keep running (used to capture output in CI)");
+DEFINE_bool(
+    mv_new_game,
+    false,
+    "For RPG Maker MV: once the title screen appears, auto-select New Game so "
+    "the game advances to its first map without input (used to capture "
+    "in-game output in CI)");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -411,6 +417,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MV_NEW_GAME"),
+                mrb_bool_value(FLAGS_mv_new_game));
   CHECK_NO_EXC(M);
 
   const mrb_value args = mrb_ary_new_capa(M, argc - 1);


### PR DESCRIPTION
## Summary
This change enables RPG Maker MV games to boot successfully even when system art files are missing, and adds an automated way to advance past the title screen for CI testing. The sample MV game now reaches its first map instead of stalling during boot.

## Key Changes

- **Graceful handling of missing images**: Modified the image loading pipeline to resolve missing or undecodable images as 1×1 transparent bitmaps (via `onload`) instead of firing `onerror`. This prevents `ImageManager.isReady()` from blocking indefinitely on absent system art files like `Window.png`.

- **Auto-advance past title screen**: Added `maybe_new_game()` method that automatically selects "New Game" once `Scene_Title` appears, allowing headless CI runs to reach the in-game map without user input.

- **New `--mv_new_game` flag**: Introduced a command-line flag to enable the auto-advance behavior, controlled via the `MV_NEW_GAME` constant passed to mruby.

- **Updated CI workflow**: Modified the build workflow to use `--mv_new_game` when capturing the MV sample screenshot, so it captures in-game rendering rather than just the title screen.

- **Test coverage**: Updated the canvas test to verify that missing images load successfully as 1×1 bitmaps with `onload` firing (not `onerror`), and that the image dimensions and completion state are correct.

## Implementation Details

- Missing images now create a 1×1 transparent canvas via `__mv_canvasCreate(1, 1)` in the `requestAnimationFrame` callback, ensuring the boot sequence continues.
- The `maybe_new_game()` method is a one-shot operation (tracked by `@new_game_done`) that only executes when the flag is set and `Scene_Title` is active.
- Error handling is defensive with try-catch blocks to prevent exceptions from disrupting the main loop.

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8