### PR TITLE
Implement gradual message text reveal (typewriter effect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too
-- Message text expands the common control codes (`\v[n]` variable, `\n[n]`
-  actor name, `\\`)
+- Message text reveals gradually (a typewriter effect; a button press completes
+  it, then dismisses) and expands the common control codes (`\v[n]` variable,
+  `\n[n]` actor name, `\\`)
 - A countdown timer can be set/started/stopped from events
 - Press the cancel button to open a menu (party status, Save, End Game); "New
   Game" state can be saved and reloaded from the title's "Continue"

--- a/changelog.d/message-gradual-reveal.added.md
+++ b/changelog.d/message-gradual-reveal.added.md
@@ -1,0 +1,7 @@
+- Message text now **reveals gradually** (RPG2000's typewriter effect) instead
+  of appearing all at once. A pure `Game::TextReveal` cursor exposes the
+  already-expanded lines a couple of characters per frame; `Scene::Map` redraws
+  the window as it fills and, on a button press, first completes the reveal and
+  only dismisses the message once it is fully shown. Choice lists still appear at
+  once. Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -119,8 +119,10 @@ The work below is roughly ordered by the critical path to a walkable game
   which need the per-level stat growth curves, not yet parsed — ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
-  colour/speed/wait codes are consumed). Face graphics, per-code colour changes
-  and gradual text reveal are still TODO
+  colour/speed/wait codes are consumed). Text now **reveals gradually** (a
+  `Game::TextReveal` typewriter driven by `Scene::Map`, with a button press
+  completing the reveal before dismissing). Face graphics and per-code colour
+  changes are still TODO
 - ✅ Common events — auto-start common events run once on the map, and parallel
   common events now run **continuously** in the background alongside the player
   via their own looping interpreter (`Scene::Map#step_parallels`), each gated by

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -71,6 +71,48 @@ module Game
     end
   end
 
+  # Gradual message text reveal (RPG2000's typewriter effect): a cursor over a
+  # set of already-expanded message lines that exposes them a few characters per
+  # frame. Pure data — the owning scene reads #visible_lines to (re)draw the
+  # window, calls #advance each frame, and #reveal_all to finish instantly when
+  # the player presses a button.
+  class TextReveal
+    def initialize(lines, revealed = 0)
+      @lines = lines || []
+      @total = 0
+      @lines.each { |l| @total += l.length }
+      @revealed = Game.clamp(revealed, 0, @total)
+    end
+
+    attr_reader :revealed, :total
+
+    def done?; @revealed >= @total; end
+    def reveal_all; @revealed = @total; end
+
+    # Reveal `n` more characters (default 1), never past the total.
+    def advance(n = 1)
+      n = 0 if n < 0
+      @revealed = Game.clamp(@revealed + n, 0, @total)
+    end
+
+    # The lines truncated to however many characters are currently revealed:
+    # earlier lines fill up before later ones start, so the result is a run of
+    # full lines, then one partial line, then empty strings.
+    def visible_lines
+      remaining = @revealed
+      @lines.map do |line|
+        if remaining >= line.length
+          remaining -= line.length
+          line
+        else
+          shown = line[0, remaining] || ''
+          remaining = 0
+          shown
+        end
+      end
+    end
+  end
+
   def self.clamp(v, lo, hi)
     return lo if v < lo
     return hi if v > hi

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -929,6 +929,8 @@ class RPG2k
       # -- message / choice window --------------------------------------------
 
       MSG_LINE_H = 14
+      # Characters revealed per frame for the message typewriter effect.
+      MSG_REVEAL_SPEED = 2
 
       # Look up an actor name by id for the \n[] message control code.
       def actor_name(id)
@@ -955,14 +957,26 @@ class RPG2k
 
         contents = Bitmap.new(inner_w, inner_h)
         contents.font.color = Color.new(255, 255, 255, 255)
-        lines.each_with_index do |line, i|
-          contents.draw_text 0, i * MSG_LINE_H, inner_w, MSG_LINE_H, line
-        end
-        win.contents = contents
 
-        @message = { window: win, choice: choice, count: lines.length }
+        # Plain messages type out gradually; choice lists appear at once.
+        reveal = Game::TextReveal.new(lines)
+        reveal.reveal_all if choice
+        @message = { window: win, choice: choice, count: lines.length,
+                     reveal: reveal, contents: contents, inner_w: inner_w }
+        draw_message_contents
+        win.contents = contents
         @choice_index = 0
         set_choice_cursor if choice
+      end
+
+      # (Re)draw the message body showing the currently revealed characters.
+      def draw_message_contents
+        return unless @message
+        c = @message[:contents]
+        c.clear
+        @message[:reveal].visible_lines.each_with_index do |line, i|
+          c.draw_text 0, i * MSG_LINE_H, @message[:inner_w], MSG_LINE_H, line
+        end
       end
 
       def set_choice_cursor
@@ -985,7 +999,22 @@ class RPG2k
             close_message
             @interpreter.choose(index)
           end
-        elsif Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        else
+          drive_text_message
+        end
+      end
+
+      # A plain (non-choice) message: type the text out, and let a button press
+      # first complete the reveal, then (once fully shown) dismiss and resume.
+      def drive_text_message
+        reveal = @message[:reveal]
+        pressed = Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        unless reveal.done?
+          pressed ? reveal.reveal_all : reveal.advance(MSG_REVEAL_SPEED)
+          draw_message_contents
+          return
+        end
+        if pressed
           close_message
           @interpreter.resume
         end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -336,6 +336,43 @@ check 'Rng stays in range and is deterministic per seed' do
   eq 0, Game::Rng.new.random(0) # random(0) is defined as 0
 end
 
+# -- TextReveal (message typewriter effect) ----------------------------------
+
+check 'TextReveal exposes characters across lines in order' do
+  r = Game::TextReveal.new(['abc', 'de'])
+  eq 5, r.total
+  eq 0, r.revealed
+  eq ['', ''], r.visible_lines
+  r.advance(2)
+  eq ['ab', ''], r.visible_lines
+  r.advance(2)                      # 4 revealed: first line full, one of line 2
+  eq ['abc', 'd'], r.visible_lines
+  ok !r.done?, 'not done until every character shows'
+  r.advance(2)                      # capped at 5
+  eq 5, r.revealed
+  ok r.done?
+  eq ['abc', 'de'], r.visible_lines
+end
+
+check 'TextReveal#reveal_all finishes immediately' do
+  r = Game::TextReveal.new(['hello', 'world'])
+  r.reveal_all
+  ok r.done?
+  eq ['hello', 'world'], r.visible_lines
+end
+
+check 'TextReveal handles empty lines and an all-empty message' do
+  r = Game::TextReveal.new(['', 'x', ''])
+  eq 1, r.total
+  eq ['', '', ''], r.visible_lines
+  r.advance(1)
+  ok r.done?
+  eq ['', 'x', ''], r.visible_lines
+
+  empty = Game::TextReveal.new([''])
+  ok empty.done?, 'a message with no characters is already fully revealed'
+end
+
 # -- Interpreter (a few existing-behaviour regressions) -----------------------
 
 # Build a minimal State without the LCF database: stub Party just enough for the

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -408,6 +408,40 @@ check 'Erase Event stops a parallel process that erases itself' do
      'its background process was removed'
 end
 
+check 'a message types out gradually, then a button completes and dismisses it' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hello'),
+                         ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+
+  # Tick until the message window opens (autostart -> Show Message).
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  ok !reveal.done?, 'text is not fully revealed as soon as it opens'
+  before = reveal.revealed
+
+  scene.update # no input: more characters reveal
+  ok reveal.revealed > before, 'text keeps revealing over frames'
+
+  # A button press while revealing completes the text but does not dismiss it.
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  ok reveal.done?, 'the button press completed the reveal'
+  ok scene.instance_variable_get(:@message), 'message stays open once completed'
+  ok !st.switches[1], 'the command after the message has not run yet'
+
+  # A second press, now fully shown, dismisses and resumes the interpreter.
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  ok !scene.instance_variable_get(:@message), 'message dismissed'
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[1], 'the interpreter resumed and ran the next command'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
Implements RPG2000's typewriter effect for message text, where characters are revealed gradually over frames instead of appearing all at once. A button press completes the reveal before dismissing the message.

## Key Changes

- **New `Game::TextReveal` class** (`mrblib/game.rb`): A pure data structure that manages character-by-character text reveal across multiple lines. Tracks total characters, revealed count, and provides methods to:
  - `advance(n)`: Reveal `n` more characters per frame
  - `reveal_all()`: Instantly complete the reveal
  - `visible_lines()`: Return lines truncated to currently revealed characters
  - `done?()`: Check if all characters are revealed

- **Message window updates** (`mrblib/main.rb`):
  - Added `MSG_REVEAL_SPEED = 2` constant for characters revealed per frame
  - Modified `open_message()` to create a `TextReveal` instance (choice lists skip reveal and show instantly)
  - New `draw_message_contents()` method redraws the message window with currently visible text
  - New `drive_text_message()` method handles the typewriter logic:
    - Button press while revealing: completes the reveal but keeps window open
    - Button press when fully revealed: dismisses and resumes interpreter
    - No input: advances reveal by `MSG_REVEAL_SPEED` characters

- **Comprehensive test coverage**:
  - `scripts/rpg2k_logic_check.rb`: Unit tests for `TextReveal` class behavior (character progression across lines, edge cases with empty lines)
  - `scripts/rpg2k_scene_check.rb`: Integration test verifying the full message flow (gradual reveal, button interaction, interpreter resumption)

- **Documentation updates**: Updated README and TODO to reflect the completed typewriter effect feature

## Implementation Details

The `TextReveal` class uses a simple character-counting approach: it tracks total characters across all lines and the number revealed, then maps this to line-by-line visibility. This allows efficient per-frame updates without string manipulation overhead.

Choice lists bypass the reveal mechanism entirely by calling `reveal_all()` immediately, maintaining the original instant-display behavior for selections.

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y