### PR TITLE
Add Message.parse to split message lines into colour runs

### DIFF
--- a/changelog.d/message-colour-parse.added.md
+++ b/changelog.d/message-colour-parse.added.md
@@ -1,0 +1,7 @@
+- `Game::Message.parse` splits a message line into `\c[n]` **colour runs** —
+  an array of `{text:, color:}` segments — expanding `\v`/`\n`/`\\` within each
+  run and dropping the display-only codes, so the concatenated segment text
+  still equals `Game::Message.expand`. This is the data layer for coloured
+  message text; the window renderer will draw the runs in colour as a follow-up.
+  `Message.expand` is now defined in terms of `parse`. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -119,10 +119,11 @@ The work below is roughly ordered by the critical path to a walkable game
   which need the per-level stat growth curves, not yet parsed — ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
-  colour/speed/wait codes are consumed). Text now **reveals gradually** (a
+  speed/wait codes are consumed). Text now **reveals gradually** (a
   `Game::TextReveal` typewriter driven by `Scene::Map`, with a button press
-  completing the reveal before dismissing). Face graphics and per-code colour
-  changes are still TODO
+  completing the reveal before dismissing), and `Game::Message.parse` splits a
+  line into `\c[n]` **colour runs** (`{text:, color:}` segments) — drawing those
+  runs in colour is the remaining render step. Face graphics are still TODO
 - ✅ Common events — auto-start common events run once on the map, and parallel
   common events now run **continuously** in the background alongside the player
   via their own looping interpreter (`Scene::Map#step_parallels`), each gated by

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -35,9 +35,25 @@ module Game
   # (`\c`/`\s` colour/speed, `\.`/`\|`/`\!` waits, `\>`/`\<`, `\^`, `\_`, `\$`)
   # are consumed. `names` may be a Hash or any object responding to `[]`.
   module Message
+    # Expand a line to its plain visible text (no colour information): the same
+    # string the segments from #parse concatenate to.
     def self.expand(text, variables, names)
-      return '' if text.nil?
-      out = ''
+      parse(text, variables, names).map { |s| s[:text] }.join
+    end
+
+    # Parse a message line into coloured runs. Returns an array of segments
+    # `{ text:, color: }`, where `color` is the `\c[n]` palette index in effect
+    # for that run (0 = the default colour). `\v[n]` (variable) and `\n[n]`
+    # (actor name) are expanded into the text and `\\` yields a literal
+    # backslash; the display-only codes (`\s` speed, `\.`/`\|`/`\!` waits,
+    # `\>`/`\<`, `\^`, `\_`, `\$`) produce no characters and are dropped. Runs
+    # with no text (e.g. a colour change before any character) are omitted, so a
+    # line that renders nothing yields an empty array.
+    def self.parse(text, variables, names)
+      return [] if text.nil?
+      segs = []
+      cur = ''
+      color = 0
       i = 0
       n = text.length
       while i < n
@@ -47,17 +63,22 @@ module Game
           i += 2
           arg, i = read_bracket(text, i)
           case code
-          when 'v', 'V' then out << variables[arg.to_i].to_s if arg
-          when 'n', 'N' then out << (names[arg.to_i] || '').to_s if arg
-          when "\\"     then out << "\\"
-          # colour/speed/wait/etc. produce no visible characters: dropped.
+          when 'v', 'V' then cur << variables[arg.to_i].to_s if arg
+          when 'n', 'N' then cur << (names[arg.to_i] || '').to_s if arg
+          when "\\"     then cur << "\\"
+          when 'c', 'C' # colour change: close the current run, switch colour
+            segs << { text: cur, color: color } unless cur.empty?
+            cur = ''
+            color = arg ? arg.to_i : 0
+          # other display codes produce no characters: dropped.
           end
         else
-          out << ch
+          cur << ch
           i += 1
         end
       end
-      out
+      segs << { text: cur, color: color } unless cur.empty?
+      segs
     end
 
     # Read an optional "[digits]" argument at position i; returns [value, new_i].

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -373,6 +373,43 @@ check 'TextReveal handles empty lines and an all-empty message' do
   ok empty.done?, 'a message with no characters is already fully revealed'
 end
 
+# -- Message parsing (control codes / colour) --------------------------------
+
+check 'Message.expand fills v/n codes and drops display codes' do
+  vars = Game::Variables.new
+  vars[3] = 7
+  names = { 5 => 'Aria' }
+  eq 'HP:7', Game::Message.expand('HP:\v[3]', vars, names)
+  eq 'Aria!', Game::Message.expand('\n[5]!', vars, names)
+  eq 'ab', Game::Message.expand('a\.\|b', vars, names)   # wait codes dropped
+  eq 'a\\b', Game::Message.expand('a\\\\b', vars, names) # \\ -> one backslash
+  eq '', Game::Message.expand(nil, vars, names)
+end
+
+check 'Message.parse splits colour runs and expands codes within them' do
+  vars = Game::Variables.new
+  vars[3] = 7
+  names = { 5 => 'Aria' }
+  segs = Game::Message.parse('Hi \c[2]\n[5]\c[0]!', vars, names)
+  eq [{ text: 'Hi ', color: 0 },
+      { text: 'Aria', color: 2 },
+      { text: '!', color: 0 }], segs
+  # A variable inside a coloured run keeps that run's colour.
+  eq [{ text: 'HP:', color: 0 }, { text: '7', color: 1 }],
+     Game::Message.parse('HP:\c[1]\v[3]', vars, names)
+end
+
+check 'Message.parse omits empty runs and matches expand when joined' do
+  vars = Game::Variables.new
+  names = {}
+  # A leading colour change produces no empty run.
+  eq [{ text: 'x', color: 4 }], Game::Message.parse('\c[4]x', vars, names)
+  eq [], Game::Message.parse('\c[3]', vars, names) # nothing visible
+  src = 'a\c[1]b\c[0]c'
+  joined = Game::Message.parse(src, vars, names).map { |s| s[:text] }.join
+  eq Game::Message.expand(src, vars, names), joined
+end
+
 # -- Interpreter (a few existing-behaviour regressions) -----------------------
 
 # Build a minimal State without the LCF database: stub Party just enough for the


### PR DESCRIPTION
## Summary
Refactored message parsing to support colour-coded text segments. Introduced `Game::Message.parse` which splits a message line into `{text:, color:}` segments based on `\c[n]` colour control codes, while expanding variable/actor name codes and dropping display-only codes. Redefined `Message.expand` in terms of `parse` to avoid code duplication.

## Key Changes
- **New `Message.parse` method**: Parses a message line into an array of colour run segments, each containing the visible text and the active colour index. Expands `\v[n]` (variables), `\n[n]` (actor names), and `\\` (literal backslash) within each run while dropping display-only codes (`\s`, `\.`, `\|`, `\!`, etc.)
- **Refactored `Message.expand`**: Now implemented as `parse(text, variables, names).map { |s| s[:text] }.join`, eliminating duplicate parsing logic
- **Colour tracking**: Maintains the current colour state as the parser processes control codes, creating new segments when colour changes occur
- **Empty run omission**: Segments with no visible text (e.g., colour changes before any character) are omitted from the result
- **Comprehensive test coverage**: Added three new checks in `rpg2k_logic_check.rb` covering variable/code expansion, colour run splitting, and consistency between `parse` and `expand`
- **Documentation**: Updated TODO.md to reflect that colour run parsing is now complete, with rendering as the remaining step

## Implementation Details
- The parser maintains `cur` (current text buffer) and `color` (current colour index) state
- When a `\c[n]` code is encountered, the current run is finalized and a new one begins with the new colour
- The implementation ensures that `parse().map { |s| s[:text] }.join` always equals `expand()` for the same input

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y