### PR TITLE
RPG Maker XP: autonomous event movement + event-touch trigger

### DIFF
--- a/changelog.d/rpgxp-event-movement.added.md
+++ b/changelog.d/rpgxp-event-movement.added.md
@@ -1,0 +1,15 @@
+- RPG Maker **XP** autonomous event movement — map events now roam. New
+  `RPGXP::Game::Character` (a movable grid entity), `RPGXP::Game::MoveType`
+  (the page's autonomous type: fixed / random / approach) and
+  `RPGXP::Game::MoveRoute` (a cursor over an `RPG::MoveRoute` that executes the
+  XP move-command set — the cardinal and diagonal moves, move toward/away/forward/
+  backward/random, the turns, jump/wait, and the switch / speed / frequency /
+  walk-anime / step-anime / direction-fix / through / always-on-top / graphic /
+  opacity / blend / play-SE side effects) drive the events. `Scene::Map` gives
+  each event a persistent character (kept across page re-selection so a roamed
+  event doesn't snap back to its spawn tile), steps it per its page's move type
+  or custom route paced by move frequency, and keeps events off each other, the
+  player and impassable tiles via a `MapWorld` adapter. The **event-touch**
+  trigger (an event walking into the player) now fires too. Covered by new
+  `mruby-rpgxp/test` cases (character moves/turns/facing, move-route
+  movement/blocking/side-effects, move-type direction selection).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -191,11 +191,16 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   Gold, Transfer Player and Play BGM/BGS/ME/SE, indent- and terminator-driven
   with a per-frame step cap. `Scene::Map` starts events on the action button, on
   player touch, on autorun or as a background parallel process, drives a
-  message/choice window, and re-selects pages when an event finishes. Covered by
-  `mruby-rpgxp/test` and driven over the real test bed by
-  `scripts/rpgxp_testbed_check.rb`. Still to come: autonomous event move
-  types / move routes (events don't roam yet), Input Number, and the many
-  screen-effect / picture / battle commands (skipped for now).
+  message/choice window, and re-selects pages when an event finishes. Events
+  also **roam autonomously**: `Game::Character` / `Game::MoveType` /
+  `Game::MoveRoute` drive an event's page move type (fixed / random / approach)
+  or custom move route (the full XP move-command set), paced by move frequency
+  and blocked by terrain / the player / other events, and the **event-touch**
+  trigger fires when an event walks into the player. Covered by `mruby-rpgxp/test`
+  and driven over the real test bed by `scripts/rpgxp_testbed_check.rb`. Still to
+  come: the interpreter's *Set Move Route* (209) command (apply a forced route
+  from an event command), Input Number, and the many screen-effect / picture /
+  battle commands (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
   (RPG Maker XP; VX's same-format `Game.rgss2a`) loads: `RPGXP::RGSSAD`
   (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts the version-1 format and

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -135,6 +135,284 @@ class RPGXP
       end
     end
 
+    # A movable grid entity (a map event, or the player). Directions are the
+    # numpad convention shared with RPG2000: 2 down, 4 left, 6 right, 8 up.
+    class Character
+      DIR_DELTA = { 2 => [0, 1], 4 => [-1, 0], 6 => [1, 0], 8 => [0, -1] }.freeze
+      # 90-degree clockwise / counter-clockwise turns and the 180-degree flip.
+      TURN_RIGHT = { 8 => 6, 6 => 2, 2 => 4, 4 => 8 }.freeze
+      TURN_LEFT  = { 8 => 4, 4 => 2, 2 => 6, 6 => 8 }.freeze
+      TURN_180   = { 8 => 2, 2 => 8, 4 => 6, 6 => 4 }.freeze
+      CARDINALS = [2, 4, 6, 8].freeze
+
+      attr_accessor :x, :y, :direction, :move_speed, :move_frequency,
+                    :through, :direction_fix, :walk_anime, :step_anime,
+                    :always_on_top, :opacity, :blend_type
+      attr_reader :graphic_name, :graphic_hue, :pattern
+
+      def initialize(x = 0, y = 0, direction = 2)
+        @x = x
+        @y = y
+        @direction = direction
+        @move_speed = 3
+        @move_frequency = 3
+        @through = false
+        @direction_fix = false
+        @walk_anime = true
+        @step_anime = false
+        @always_on_top = false
+        @opacity = 255
+        @blend_type = 0
+        @graphic_name = nil
+        @graphic_hue = 0
+        @pattern = 0
+      end
+
+      def set_graphic(name, hue = 0, direction = nil, pattern = nil)
+        @graphic_name = name
+        @graphic_hue = hue || 0
+        face(direction) if direction && direction > 0
+        @pattern = pattern if pattern
+      end
+
+      def self.step_tile(px, py, dir)
+        dx, dy = DIR_DELTA[dir] || [0, 0]
+        [px + dx, py + dy]
+      end
+
+      def front_tile(dir = @direction)
+        Character.step_tile(@x, @y, dir)
+      end
+
+      # Turn to face `dir` (a no-op while facing is locked / direction-fixed).
+      def face(dir)
+        @direction = dir unless @direction_fix || dir.nil?
+      end
+
+      def move(dir)
+        face(dir)
+        dx, dy = DIR_DELTA[dir] || [0, 0]
+        @x += dx
+        @y += dy
+      end
+
+      # Move one tile diagonally; RMXP keeps a cardinal facing, favouring the
+      # vertical part unless already facing one of the two component directions.
+      def move_diagonal(horizontal, vertical)
+        face(vertical) unless @direction == horizontal || @direction == vertical
+        hx, = DIR_DELTA[horizontal] || [0, 0]
+        _, vy = DIR_DELTA[vertical] || [0, 0]
+        @x += hx
+        @y += vy
+      end
+
+      def turn_right;  @direction = TURN_RIGHT[@direction] || @direction; end
+      def turn_left;   @direction = TURN_LEFT[@direction]  || @direction; end
+      def turn_around; @direction = TURN_180[@direction]   || @direction; end
+
+      # Direction pointing from this character toward (tx, ty); ties resolve to
+      # the horizontal axis. Returns the current facing when already on the tile.
+      def direction_toward(tx, ty)
+        dx = tx - @x
+        dy = ty - @y
+        if dx.abs >= dy.abs && dx != 0
+          dx > 0 ? 6 : 4
+        elsif dy != 0
+          dy > 0 ? 2 : 8
+        else
+          @direction
+        end
+      end
+
+      def direction_away(tx, ty)
+        TURN_180[direction_toward(tx, ty)] || @direction
+      end
+    end
+
+    # Runtime execution of an RMXP move route (an RPG::MoveRoute: a list of
+    # RPG::MoveCommand with the XP move-command codes, plus repeat / skippable
+    # flags). A MoveRoute is a cursor over that list; `step` runs the command
+    # under the cursor against a Character and advances. Movement commands ask
+    # the `world` whether the destination is passable; a non-repeating route
+    # reports `done?` once every command has run.
+    #
+    # `world` responds to: passable?(character, dir), hero_position -> [x, y],
+    # set_switch(id, on), play_sound(audio), random(n) -> 0...n.
+    class MoveRoute
+      # XP move-command codes (RPG::MoveCommand#code).
+      DOWN = 1; LEFT = 2; RIGHT = 3; UP = 4
+      LOWER_LEFT = 5; LOWER_RIGHT = 6; UPPER_LEFT = 7; UPPER_RIGHT = 8
+      RANDOM = 9; TOWARD = 10; AWAY = 11; FORWARD = 12; BACKWARD = 13
+      JUMP = 14; WAIT = 15
+      TURN_DOWN = 16; TURN_LEFT = 17; TURN_RIGHT = 18; TURN_UP = 19
+      TURN_90R = 20; TURN_90L = 21; TURN_180 = 22; TURN_90RL = 23
+      TURN_RANDOM = 24; TURN_TOWARD = 25; TURN_AWAY = 26
+      SWITCH_ON = 27; SWITCH_OFF = 28; CHANGE_SPEED = 29; CHANGE_FREQ = 30
+      WALK_ON = 31; WALK_OFF = 32; STEP_ON = 33; STEP_OFF = 34
+      DIRFIX_ON = 35; DIRFIX_OFF = 36; THROUGH_ON = 37; THROUGH_OFF = 38
+      TOP_ON = 39; TOP_OFF = 40
+      CHANGE_GRAPHIC = 41; CHANGE_OPACITY = 42; CHANGE_BLEND = 43
+      PLAY_SE = 44; SCRIPT = 45
+
+      MOVE_DIR = { DOWN => 2, LEFT => 4, RIGHT => 6, UP => 8 }.freeze
+      DIAGONAL = { LOWER_LEFT => [4, 2], LOWER_RIGHT => [6, 2],
+                   UPPER_LEFT => [4, 8], UPPER_RIGHT => [6, 8] }.freeze
+      TURN_DIR = { TURN_DOWN => 2, TURN_LEFT => 4, TURN_RIGHT => 6, TURN_UP => 8 }.freeze
+
+      def self.from_page(route)
+        route && new(route.list || [], route.repeat, route.skippable)
+      end
+
+      def initialize(list, repeat, skippable)
+        @list = list || []
+        @repeat = repeat
+        @skippable = skippable
+        @index = 0
+        @done = @list.empty?
+      end
+
+      def done?; @done; end
+
+      # Run the command under the cursor. Returns a status symbol; a blocked,
+      # non-skippable move keeps the cursor so it retries next step.
+      def step(character, world)
+        return :done if @done
+        cmd = @list[@index]
+        return advance_done(true) if cmd.nil? || cmd.code == 0
+        status, advance = execute(cmd, character, world)
+        advance_cursor if advance
+        status
+      end
+
+      private
+
+      def advance_done(advance)
+        advance_cursor if advance
+        :done
+      end
+
+      def advance_cursor
+        @index += 1
+        return if @index < @list.size
+        if @repeat
+          @index = 0
+        else
+          @done = true
+        end
+      end
+
+      def params(cmd)
+        cmd.parameters || []
+      end
+
+      def execute(cmd, character, world)
+        code = cmd.code
+        case code
+        when DOWN, LEFT, RIGHT, UP
+          do_move(character, world, MOVE_DIR[code])
+        when LOWER_LEFT, LOWER_RIGHT, UPPER_LEFT, UPPER_RIGHT
+          do_diagonal(character, world, code)
+        when RANDOM   then do_move(character, world, Character::CARDINALS[world.random(4)])
+        when TOWARD   then do_move(character, world, toward(character, world))
+        when AWAY     then do_move(character, world, away(character, world))
+        when FORWARD  then do_move(character, world, character.direction)
+        when BACKWARD then do_move(character, world, Character::TURN_180[character.direction])
+        when JUMP     then [:jumped, true] # pixel jump is cosmetic; treat as a beat
+        when WAIT     then [:waited, true]
+        when TURN_DOWN, TURN_LEFT, TURN_RIGHT, TURN_UP
+          character.face(TURN_DIR[code]); [:turned, true]
+        when TURN_90R  then character.turn_right;  [:turned, true]
+        when TURN_90L  then character.turn_left;   [:turned, true]
+        when TURN_180  then character.turn_around; [:turned, true]
+        when TURN_90RL
+          world.random(2) == 0 ? character.turn_right : character.turn_left
+          [:turned, true]
+        when TURN_RANDOM then character.face(Character::CARDINALS[world.random(4)]); [:turned, true]
+        when TURN_TOWARD then character.face(toward(character, world)); [:turned, true]
+        when TURN_AWAY   then character.face(away(character, world));   [:turned, true]
+        when SWITCH_ON  then world.set_switch(params(cmd)[0], true);  [:effect, true]
+        when SWITCH_OFF then world.set_switch(params(cmd)[0], false); [:effect, true]
+        when CHANGE_SPEED then character.move_speed = params(cmd)[0] || character.move_speed; [:effect, true]
+        when CHANGE_FREQ  then character.move_frequency = params(cmd)[0] || character.move_frequency; [:effect, true]
+        when WALK_ON    then character.walk_anime = true;  [:effect, true]
+        when WALK_OFF   then character.walk_anime = false; [:effect, true]
+        when STEP_ON    then character.step_anime = true;  [:effect, true]
+        when STEP_OFF   then character.step_anime = false; [:effect, true]
+        when DIRFIX_ON  then character.direction_fix = true;  [:effect, true]
+        when DIRFIX_OFF then character.direction_fix = false; [:effect, true]
+        when THROUGH_ON  then character.through = true;  [:effect, true]
+        when THROUGH_OFF then character.through = false; [:effect, true]
+        when TOP_ON     then character.always_on_top = true;  [:effect, true]
+        when TOP_OFF    then character.always_on_top = false; [:effect, true]
+        when CHANGE_GRAPHIC
+          p = params(cmd)
+          character.set_graphic(p[0], p[1], p[2], p[3]); [:effect, true]
+        when CHANGE_OPACITY then character.opacity = params(cmd)[0] || character.opacity; [:effect, true]
+        when CHANGE_BLEND   then character.blend_type = params(cmd)[0] || character.blend_type; [:effect, true]
+        when PLAY_SE then world.play_sound(params(cmd)[0]); [:effect, true]
+        else [:effect, true] # SCRIPT and any unsupported code: no-op, advance
+        end
+      end
+
+      # One-tile move in `dir`. A blocked move on a non-skippable route keeps the
+      # cursor (advance == false) so it retries; it still turns to face the wall.
+      def do_move(character, world, dir)
+        return [:turned, true] if dir.nil?
+        if character.through || world.passable?(character, dir)
+          character.move(dir)
+          [:moved, true]
+        else
+          character.face(dir)
+          @skippable ? [:blocked, true] : [:blocked, false]
+        end
+      end
+
+      def do_diagonal(character, world, code)
+        horizontal, vertical = DIAGONAL[code]
+        passable = character.through ||
+                   (world.passable?(character, horizontal) &&
+                    world.passable?(character, vertical))
+        if passable
+          character.move_diagonal(horizontal, vertical)
+          [:moved, true]
+        else
+          character.face(vertical)
+          @skippable ? [:blocked, true] : [:blocked, false]
+        end
+      end
+
+      def toward(character, world)
+        hx, hy = world.hero_position
+        character.direction_toward(hx, hy)
+      end
+
+      def away(character, world)
+        hx, hy = world.hero_position
+        character.direction_away(hx, hy)
+      end
+    end
+
+    # Autonomous (non-custom) event movement: given a page's move_type, pick the
+    # direction the character should try next. Returns a numpad direction, or nil
+    # for "no autonomous movement" (fixed) and for the custom-route type (driven
+    # by a MoveRoute instead). RMXP has four types.
+    module MoveType
+      FIXED    = 0
+      RANDOM   = 1
+      APPROACH = 2
+      CUSTOM   = 3
+
+      def self.next_direction(type, character, world)
+        case type
+        when RANDOM   then Character::CARDINALS[world.random(4)]
+        when APPROACH
+          hx, hy = world.hero_position
+          character.direction_toward(hx, hy)
+        else nil # FIXED / CUSTOM: no autonomous step
+        end
+      end
+    end
+
     # Edge-clamped follow camera: centre `focus` in a `screen`-wide view over a
     # `world`-wide map, never scrolling past either edge (matches the RPG2000
     # camera helper).

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -287,6 +287,39 @@ class RPGXP
       end
     end
 
+    # Adapter exposing the running map to the movement engine (Game::MoveRoute /
+    # Game::MoveType): it bridges their `world` protocol — passability, hero
+    # position, switch and sound side effects, randomness — onto the Scene::Map.
+    class MapWorld
+      def initialize(scene, rng)
+        @scene = scene
+        @rng = rng
+      end
+
+      def passable?(character, dir)
+        @scene.char_passable?(character, dir)
+      end
+
+      def hero_position
+        [@scene.state.x, @scene.state.y]
+      end
+
+      def set_switch(id, on)
+        @scene.state.switches[id] = on
+      end
+
+      def play_sound(audio)
+        return if audio.nil? || !audio.respond_to?(:name) || audio.name.nil?
+        Audio.se_play(audio.name, audio.volume || 100, audio.pitch || 100)
+      rescue StandardError => e
+        $stderr.puts "[RGSS] event move SE failed: #{e.message}"
+      end
+
+      def random(n)
+        @rng.random(n)
+      end
+    end
+
     class Map < Base
       TILE = RPGXP::TILE
       SCREEN_W = RPGXP::WIDTH
@@ -295,6 +328,10 @@ class RPGXP
       ROWS = SCREEN_H / TILE + 1
       SPEED = 4 # pixels/frame while stepping (must divide TILE)
       MSG_LINE_H = 32
+
+      # Frames between autonomous event steps, keyed by RMXP move frequency
+      # (1 slowest .. 6 fastest). Placeholder pacing while events draw as markers.
+      EVENT_MOVE_DELAY = { 1 => 120, 2 => 60, 3 => 30, 4 => 15, 5 => 8, 6 => 4 }.freeze
 
       # Event-page start triggers (RPG::Event::Page#trigger).
       TRIGGER_ACTION       = 0 # player presses the action button facing it
@@ -325,6 +362,12 @@ class RPGXP
         @choice_index = 0
         @running_event_id = nil
 
+        # Deterministic RNG for autonomous movement, and the adapter the movement
+        # engine queries. Characters persist across page re-selection (keyed by
+        # event id) so a roamed event does not snap back to its spawn tile.
+        @rng = Game::Rng.new(0x52584250)
+        @world = MapWorld.new(self, @rng)
+        @characters = {}
         build_events
         build_parallels
         setup_sprites
@@ -344,9 +387,20 @@ class RPGXP
         elsif @interpreter.running? || @interpreter.waiting?
           drive_interpreter
         else
-          start_autorun || (step_parallels; step_movement; try_action)
+          unless start_autorun
+            step_parallels
+            step_events
+            unless event_busy? # an event-touch may have started a process
+              step_movement
+              try_action
+            end
+          end
         end
         render
+      end
+
+      def event_busy?
+        @message || @interpreter.running? || @interpreter.waiting?
       end
 
       private
@@ -370,17 +424,50 @@ class RPGXP
         @events = {}
         @event_tiles = {}
         (@map.events || {}).each do |id, ev|
-          page = Game::EventPage.select(ev.pages, @state.switches, @state.variables,
-                                        ->(ch) { @state.self_switch(@state.map_id, id, ch) })
-          entry = { id: id, ev: ev, page: page, x: ev.x, y: ev.y,
-                    trigger: page && page.trigger }
+          entry = build_event(id, ev)
           @events[id] = entry
-          @event_tiles[[ev.x, ev.y]] = entry if page
+          @event_tiles[[entry[:char].x, entry[:char].y]] = entry if entry[:page]
         end
       rescue StandardError => e
         $stderr.puts "[RGSS] event setup failed, map runs with no events: #{e.message}"
         @events = {}
         @event_tiles = {}
+      end
+
+      # Build one event's runtime entry: its active page, a persistent
+      # Game::Character (reused across rebuilds so a roamed event keeps its
+      # position) refreshed with the page's movement properties, and the page's
+      # autonomous move type or custom move route.
+      def build_event(id, ev)
+        page = Game::EventPage.select(ev.pages, @state.switches, @state.variables,
+                                      ->(ch) { @state.self_switch(@state.map_id, id, ch) })
+        ch = (@characters[id] ||= Game::Character.new(ev.x, ev.y, ev_direction(page)))
+        move_type = 0
+        route = nil
+        if page
+          ch.move_speed = page.move_speed || 3
+          ch.move_frequency = page.move_frequency || 3
+          ch.through = page.through ? true : false
+          ch.direction_fix = page.direction_fix ? true : false
+          ch.always_on_top = page.always_on_top ? true : false
+          g = page.graphic
+          ch.set_graphic(g.character_name, g.character_hue, g.direction, g.pattern) if g
+          move_type = page.move_type || 0
+          route = Game::MoveRoute.from_page(page.move_route) if move_type == Game::MoveType::CUSTOM
+        end
+        { id: id, ev: ev, page: page, char: ch, trigger: page && page.trigger,
+          move_type: move_type, route: route,
+          move_timer: EVENT_MOVE_DELAY[ch.move_frequency] || 30 }
+      rescue StandardError => e
+        $stderr.puts "[RGSS] event ##{id} setup failed: #{e.message}"
+        { id: id, ev: ev, page: nil, char: (@characters[id] ||= Game::Character.new(ev.x, ev.y)),
+          trigger: nil, move_type: 0, route: nil, move_timer: 30 }
+      end
+
+      def ev_direction(page)
+        return 2 unless page && page.graphic
+        d = page.graphic.direction
+        d && d > 0 ? d : 2
       end
 
       # Background (parallel-process) interpreters: one per event whose active
@@ -424,10 +511,79 @@ class RPGXP
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
         e = @event_tiles[[fx, fy]]
         return unless e && e[:trigger] == TRIGGER_ACTION && list_nonempty?(page_list(e))
+        e[:char].face(e[:char].direction_toward(@state.x, @state.y))
+        start_event(e)
+      end
+
+      # Run an event's command list (faced toward the player by the caller).
+      def start_event(e)
         @running_event_id = e[:id]
         @interpreter.start(page_list(e), @state.map_id, e[:id])
         drive_interpreter
       end
+
+      # Advance each event's autonomous / custom-route movement one frame, paced
+      # by move frequency. Skipped once any event process is running this frame,
+      # so the map holds still during messages.
+      def step_events
+        @events.each { |_id, e| step_event(e) }
+      end
+
+      def step_event(e)
+        return if event_busy?
+        ch = e[:char]
+        return unless ch && e[:page]
+        e[:move_timer] -= 1
+        return if e[:move_timer] > 0
+        e[:move_timer] = EVENT_MOVE_DELAY[ch.move_frequency] || 30
+        ox = ch.x
+        oy = ch.y
+        if e[:route]
+          e[:route].step(ch, @world) unless e[:route].done?
+        else
+          dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
+          move_autonomous(e, dir) if dir
+        end
+        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
+      rescue StandardError => ex
+        $stderr.puts "[RGSS] event ##{e[:id]} movement failed: #{ex.message}"
+      end
+
+      # Move an autonomous event one step in `dir`. Walking into the player fires
+      # an event-touch (trigger 2) event instead of moving; any other obstacle
+      # just turns the event to face it.
+      def move_autonomous(e, dir)
+        ch = e[:char]
+        nx, ny = Game::Character.step_tile(ch.x, ch.y, dir)
+        if nx == @state.x && ny == @state.y
+          ch.face(dir)
+          start_event(e) if e[:trigger] == TRIGGER_EVENT_TOUCH && list_nonempty?(page_list(e))
+        elsif @world.passable?(ch, dir)
+          ch.move(dir)
+        else
+          ch.face(dir)
+        end
+      end
+
+      # Update the occupied-tile cache after event `e` moved off (ox, oy). Done
+      # eagerly so an event that already moved this frame blocks the next one.
+      def reoccupy(e, ox, oy)
+        @event_tiles.delete([ox, oy]) if @event_tiles[[ox, oy]].equal?(e)
+        @event_tiles[[e[:char].x, e[:char].y]] = e
+      end
+
+      # Collision test for an event stepping one tile in `dir`: in bounds, not
+      # onto the player or another event, and passable per the tileset. A
+      # "through" character ignores all of it. Public: called by MapWorld.
+      def char_passable?(character, dir)
+        return true if character.through
+        nx, ny = Game::Character.step_tile(character.x, character.y, dir)
+        return false unless in_bounds?(nx, ny)
+        return false if nx == @state.x && ny == @state.y
+        return false if @event_tiles[[nx, ny]]
+        @tileset.passable?(@map, nx, ny, dir)
+      end
+      public :char_passable?
 
       def drive_interpreter
         if @interpreter.waiting?
@@ -507,6 +663,7 @@ class RPGXP
         @dest_x = x
         @dest_y = y
         @last_frame = nil
+        @characters = {} # new map: events start at their spawn tiles
         build_events
         build_parallels
       rescue StandardError => e

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -417,3 +417,91 @@ assert "RGSSAD rejects a bad header and an unsupported version" do
   v3 = "RGSSAD\x00\x03rest"
   assert_raise(RuntimeError) { RPGXP::RGSSAD.new(v3) }
 end
+
+# ---- Autonomous event movement: Character / MoveRoute / MoveType -----------
+
+# Build an RPG::MoveCommand (code / parameters).
+def mv(code, params = [])
+  c = RPG::MoveCommand.new
+  c.code = code
+  c.parameters = params
+  c
+end
+
+# World stand-in for the movement engine.
+class FakeWorld
+  def initialize(passable: true, hero: [0, 0], rng: 0)
+    @passable = passable
+    @hero = hero
+    @rng = rng
+    @switches = {}
+    @sounds = 0
+  end
+  attr_reader :switches, :sounds
+  def passable?(_ch, _dir); @passable; end
+  def hero_position; @hero; end
+  def set_switch(id, on); @switches[id] = on; end
+  def play_sound(_audio); @sounds += 1; end
+  def random(n); @rng % n; end
+end
+
+assert "Game::Character move / face / turns / toward" do
+  c = RPGXP::Game::Character.new(3, 4, 2)
+  c.move(6)
+  assert_equal 4, c.x
+  assert_equal 4, c.y
+  assert_equal 6, c.direction
+  c.turn_right # clockwise: 6 -> 2
+  assert_equal 2, c.direction
+  # Direction-fix locks facing.
+  c.direction_fix = true
+  c.face(8)
+  assert_equal 2, c.direction
+  c.direction_fix = false
+  assert_equal [3, 5], RPGXP::Game::Character.step_tile(3, 4, 2)
+  # Toward a tile to the right.
+  d = RPGXP::Game::Character.new(4, 4).direction_toward(10, 4)
+  assert_equal 6, d
+  assert_equal 4, RPGXP::Game::Character.new(4, 4).direction_away(10, 4)
+end
+
+assert "Game::MoveRoute moves forward and repeats" do
+  route = RPGXP::Game::MoveRoute.new([mv(12)], true, false) # Move Forward, repeat
+  c = RPGXP::Game::Character.new(0, 0, 6) # facing right
+  assert_equal :moved, route.step(c, FakeWorld.new(passable: true))
+  assert_equal 1, c.x
+  assert_false route.done? # repeats
+end
+
+assert "Game::MoveRoute blocked non-skippable retries and faces the wall" do
+  route = RPGXP::Game::MoveRoute.new([mv(1), mv(4)], false, false) # Down, then Up
+  c = RPGXP::Game::Character.new(0, 0, 8)
+  assert_equal :blocked, route.step(c, FakeWorld.new(passable: false))
+  assert_equal 2, c.direction # turned to face the blocked Down move
+  assert_equal 0, c.y         # did not move
+  assert_false route.done?    # cursor held on the blocked command
+end
+
+assert "Game::MoveRoute side effects: switch, speed, play SE, done" do
+  world = FakeWorld.new
+  route = RPGXP::Game::MoveRoute.new([mv(27, [5]), mv(29, [6]), mv(44, [nil])], false, false)
+  c = RPGXP::Game::Character.new(0, 0)
+  route.step(c, world) # Switch 5 ON
+  route.step(c, world) # Change Speed -> 6
+  route.step(c, world) # Play SE
+  assert_true world.switches[5]
+  assert_equal 6, c.move_speed
+  assert_equal 1, world.sounds
+  assert_true route.done? # non-repeating route exhausted
+end
+
+assert "Game::MoveType picks a direction per move type" do
+  c = RPGXP::Game::Character.new(0, 0)
+  # RANDOM: rng 2 -> CARDINALS[2 % 4] = 6.
+  assert_equal 6, RPGXP::Game::MoveType.next_direction(1, c, FakeWorld.new(rng: 2))
+  # APPROACH: toward a hero to the right -> 6.
+  assert_equal 6, RPGXP::Game::MoveType.next_direction(2, c, FakeWorld.new(hero: [5, 0]))
+  # FIXED / CUSTOM: no autonomous step.
+  assert_true RPGXP::Game::MoveType.next_direction(0, c, FakeWorld.new).nil?
+  assert_true RPGXP::Game::MoveType.next_direction(3, c, FakeWorld.new).nil?
+end


### PR DESCRIPTION
Map events now roam. This adds the XP movement model and wires it into the map scene, continuing the XP support from #119 / #130 (events were static markers before).

## Changes

- **`RPGXP::Game::Character`** (`mruby-rpgxp/mrblib/game.rb`) — a movable grid entity: the numpad directions, `move` / `face` / diagonal move, 90°/180° turns, and toward/away direction helpers, with a direction-fix facing lock.
- **`RPGXP::Game::MoveType`** — a page's autonomous type: fixed / random / approach.
- **`RPGXP::Game::MoveRoute`** — a cursor over an `RPG::MoveRoute` executing the XP move-command set: the cardinal and diagonal moves, move toward/away/forward/backward/random, the turns, jump/wait, and the switch / speed / frequency / walk-anime / step-anime / direction-fix / through / always-on-top / graphic / opacity / blend / play-SE side effects. A blocked, non-skippable move keeps the cursor so it retries next step, and still turns to face the wall.
- **`Scene::Map`** — a `MapWorld` adapter exposes passability / hero position / switch / sound / RNG to the movement engine. Each event gets a **persistent** `Character` (kept across page re-selection, so a roamed event does not snap back to its spawn tile), stepped per its page move type or custom route, paced by move frequency, and kept off other events, the player and impassable tiles. The **event-touch** trigger (an event walking into the player) now fires.

## Testing

- **Unit tests** (`mruby-rpgxp/test/rpgxp_test.rb`): character moves / turns / facing / direction-fix; move-route movement, blocked-and-retry, side effects (switch / speed / play-SE) and repeat-vs-done; move-type direction selection. All 25 XP cases pass under the CRuby harness.
- The existing `scripts/rpgxp_testbed_check.rb` and the rest of the suite still pass on this base.

The movement classes are the mruby/CRuby common subset and reuse the deterministic RNG, so they run on the trimmed mruby.

Docs updated via a `changelog.d/` fragment and TODO. Real tileset/autotile rendering and event **sprites** (events still draw as markers) are the next step, tracked in the TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195uJEZ1MyFGesTrHWTXBpo

---
_Generated by [Claude Code](https://claude.ai/code/session_0195uJEZ1MyFGesTrHWTXBpo)_