### PR TITLE
RPG Maker XP: expand message control codes in Show Text / Choices

### DIFF
--- a/changelog.d/rpgxp-message-codes.added.md
+++ b/changelog.d/rpgxp-message-codes.added.md
@@ -1,0 +1,7 @@
+- RPG Maker **XP** message control codes — Show Text and Show Choices now expand
+  the common RMXP codes instead of printing them raw. `RPGXP::Game::Message.expand`
+  substitutes `\V[n]` (variable value) and `\N[n]` (actor name), turns `\\` into a
+  literal backslash, and consumes the display-only `\C[n]` (colour) and `\G`
+  (gold window) codes; `Scene::Map` expands each message and choice line against
+  the game variables and the actor database before drawing it. Covered by new
+  `mruby-rpgxp/test` cases.

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -5,6 +5,49 @@
 
 class RPGXP
   module Game
+    # Expansion of RMXP message control codes. `\V[n]` (or `\v[n]`) inserts the
+    # value of variable n, `\N[n]` the name of actor n, `\\` a literal backslash;
+    # the display-only codes `\C[n]` (colour) and `\G` (gold window) produce no
+    # characters and are consumed. `names` is any object responding to `[]`
+    # (an id -> name lookup). Written in the mruby/CRuby common subset.
+    module Message
+      def self.expand(text, variables, names)
+        return "" if text.nil?
+        out = ""
+        i = 0
+        n = text.length
+        while i < n
+          ch = text[i]
+          if ch == "\\" && i + 1 < n
+            code = text[i + 1]
+            i += 2
+            arg, i = read_bracket(text, i)
+            case code
+            when "v", "V" then out << variables[arg.to_i].to_s if arg
+            when "n", "N" then out << (names[arg.to_i] || "").to_s if arg
+            when "\\"     then out << "\\"
+            # \C[n] colour and \G gold window have no visible text: dropped
+            # (the bracketed arg after \C is already consumed above).
+            end
+          else
+            out << ch
+            i += 1
+          end
+        end
+        out
+      end
+
+      # Read an optional "[digits]" argument at position i; returns [value, new_i].
+      def self.read_bracket(text, i)
+        return [nil, i] unless i < text.length && text[i] == "["
+        j = i + 1
+        j += 1 while j < text.length && text[j] != "]"
+        val = text[(i + 1)...j]
+        j += 1 if j < text.length # consume ']'
+        [val, j]
+      end
+    end
+
     # The mutable game state: which map/tile the player stands on and the global
     # switch/variable stores. `party` is the list of actor ids; the database is
     # kept for name/graphic lookups. `map` is the currently loaded RPG::Map.

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -673,9 +673,21 @@ class RPGXP
 
       # -- message / choice window --------------------------------------------
 
+      # Look up an actor name by id for the \N[] message control code.
+      def actor_name(id)
+        a = @db.actors[id]
+        a ? a.name.to_s : ""
+      rescue StandardError
+        ""
+      end
+
       def open_message(lines, choice)
         return if @message
-        lines = (lines || []).map(&:to_s)
+        names = ->(id) { actor_name(id) }
+        lines = (lines || []).map do |l|
+          # Choice labels are expanded too, so \V[n]/\N[n] work in menu options.
+          Game::Message.expand(l.to_s, @state.variables, names)
+        end
         lines = [""] if lines.empty?
         h = lines.length * MSG_LINE_H + Panel::BORDER * 2
         win = Panel.new(0, SCREEN_H - h - 8, SCREEN_W, h, load_windowskin)

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -505,3 +505,32 @@ assert "Game::MoveType picks a direction per move type" do
   assert_true RPGXP::Game::MoveType.next_direction(0, c, FakeWorld.new).nil?
   assert_true RPGXP::Game::MoveType.next_direction(3, c, FakeWorld.new).nil?
 end
+
+# ---- Message control-code expansion ---------------------------------------
+
+assert "Game::Message.expand handles variable / name / literal / dropped codes" do
+  vars = Hash.new(0)
+  vars[3] = 42
+  names = { 1 => "Aluxes", 2 => "Basil" }
+
+  m = RPGXP::Game::Message
+  assert_equal "You have 42 gold.", m.expand("You have \\V[3] gold.", vars, names)
+  assert_equal "Hi, Aluxes!", m.expand("Hi, \\N[1]!", vars, names)
+  # Lower-case codes work too.
+  assert_equal "Basil / 42", m.expand("\\n[2] / \\v[3]", vars, names)
+  # A literal backslash, and a missing name -> empty.
+  assert_equal "path\\to", m.expand("path\\\\to", vars, names)
+  assert_equal "", m.expand("\\N[9]", vars, names)
+  # Colour (\C[n]) and gold (\G) are display-only: consumed, no visible text.
+  assert_equal "red text", m.expand("\\C[2]red text", vars, names)
+  assert_equal "gold", m.expand("\\Ggold", vars, names)
+  # Plain text and nil.
+  assert_equal "plain", m.expand("plain", vars, names)
+  assert_equal "", m.expand(nil, vars, names)
+end
+
+assert "Game::Message.expand accepts a Proc name lookup" do
+  vars = Hash.new(0)
+  lookup = ->(id) { id == 1 ? "Hero" : nil }
+  assert_equal "Hero speaks", RPGXP::Game::Message.expand("\\N[1] speaks", vars, lookup)
+end


### PR DESCRIPTION
Message and choice text now expands the common RMXP control codes instead of printing them raw, continuing the XP event system (#119 / #133).

## Changes

- **`RPGXP::Game::Message.expand`** (`mruby-rpgxp/mrblib/game.rb`) — substitutes `\V[n]` / `\v[n]` (variable value) and `\N[n]` / `\n[n]` (actor name), turns `\\` into a literal backslash, and consumes the display-only `\C[n]` (colour) and `\G` (gold window) codes (no visible characters). Mirrors the RPG2000 side's `Game::Message.expand`, in the mruby/CRuby common subset.
- **`Scene::Map`** — expands every message and choice line against the game variables and an actor-name lookup over the database before drawing, so a Show Text like `You have \V[3] gold, \N[1]!` renders with the real values. Choice options are expanded too.

## Testing

- **Unit tests** (`mruby-rpgxp/test/rpgxp_test.rb`): variable / name substitution, lower- and upper-case codes, literal backslash, missing-name → empty, `\C[n]` / `\G` dropped, plain-text and nil passthrough, and a `Proc`-based name lookup. All 27 XP cases pass under the CRuby harness, and the existing test-bed check still passes.

Docs updated via a `changelog.d/` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195uJEZ1MyFGesTrHWTXBpo

---
_Generated by [Claude Code](https://claude.ai/code/session_0195uJEZ1MyFGesTrHWTXBpo)_