### PR TITLE
Render message text colour codes with typewriter effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too
 - Message text reveals gradually (a typewriter effect; a button press completes
-  it, then dismisses) and expands the common control codes (`\v[n]` variable,
-  `\n[n]` actor name, `\\`)
+  it, then dismisses), expands the common control codes (`\v[n]` variable,
+  `\n[n]` actor name, `\\`) and draws `\c[n]` colour changes
 - A countdown timer can be set/started/stopped from events
 - Press the cancel button to open a menu (party status, Save, End Game); "New
   Game" state can be saved and reloaded from the title's "Continue"

--- a/changelog.d/message-colour-render.added.md
+++ b/changelog.d/message-colour-render.added.md
@@ -1,0 +1,8 @@
+- Message text now draws `\c[n]` **colour changes** in colour. `Scene::Map`
+  parses each line into `Game::Message.parse` colour runs and draws each run in
+  its palette colour, laid out left to right; `Game::Message.visible_segments`
+  truncates the runs to the gradual-reveal cursor so colour and the typewriter
+  effect work together. The palette is a small built-in approximation for now
+  (reading the real 20-colour row from the System windowskin is a follow-up).
+  Covered by a new `Message.visible_segments` check in
+  `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -121,9 +121,12 @@ The work below is roughly ordered by the critical path to a walkable game
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   speed/wait codes are consumed). Text now **reveals gradually** (a
   `Game::TextReveal` typewriter driven by `Scene::Map`, with a button press
-  completing the reveal before dismissing), and `Game::Message.parse` splits a
-  line into `\c[n]` **colour runs** (`{text:, color:}` segments) — drawing those
-  runs in colour is the remaining render step. Face graphics are still TODO
+  completing the reveal before dismissing), and `\c[n]` **colour codes** are
+  drawn in colour: `Game::Message.parse` splits a line into `{text:, color:}`
+  runs and `Scene::Map` draws each run in its palette colour, revealing across
+  runs (`Game::Message.visible_segments`). The palette is a built-in
+  approximation for now (the real 20-colour row from the System windowskin, and
+  face graphics, are still TODO)
 - ✅ Common events — auto-start common events run once on the map, and parallel
   common events now run **continuously** in the background alongside the player
   via their own looping interpreter (`Scene::Map#step_parallels`), each gated by

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -81,6 +81,31 @@ module Game
       segs
     end
 
+    # Truncate per-line colour segments to the first `revealed` characters
+    # across all lines (for the typewriter effect over coloured text). `seg_lines`
+    # is an array of lines, each an array of `{ text:, color: }` segments (as
+    # #parse returns). Returns the same shape with later text dropped: full
+    # segments while the budget lasts, then a partial segment, then nothing.
+    def self.visible_segments(seg_lines, revealed)
+      remaining = revealed
+      seg_lines.map do |segs|
+        out = []
+        segs.each do |seg|
+          t = seg[:text]
+          if remaining <= 0
+            next
+          elsif remaining >= t.length
+            remaining -= t.length
+            out << seg
+          else
+            out << { text: t[0, remaining], color: seg[:color] }
+            remaining = 0
+          end
+        end
+        out
+      end
+    end
+
     # Read an optional "[digits]" argument at position i; returns [value, new_i].
     def self.read_bracket(text, i)
       return [nil, i] unless i < text.length && text[i] == '['

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -944,39 +944,67 @@ class RPG2k
       def open_message(lines, choice)
         return if @message
         names = ->(id) { actor_name(id) }
-        lines = (lines || []).map do |l|
-          Game::Message.expand(l.to_s, @state.variables, names)
+        raw = (lines || [])
+        raw = [''] if raw.empty?
+        # Parse each line into colour runs; the plain text (segments joined)
+        # drives the reveal counter so it counts visible characters only.
+        seg_lines = raw.map do |l|
+          Game::Message.parse(l.to_s, @state.variables, names)
         end
-        lines = [''] if lines.empty?
+        plain = seg_lines.map { |segs| segs.map { |s| s[:text] }.join }
         inner_w = SCREEN_W - 20 - Window::BORDER * 2
-        inner_h = lines.length * MSG_LINE_H
+        inner_h = plain.length * MSG_LINE_H
         win = Window.new(10, SCREEN_H - (inner_h + Window::BORDER * 2) - 6,
                          SCREEN_W - 20, inner_h + Window::BORDER * 2)
         win.z = 300
         win.windowskin = @windowskin
 
         contents = Bitmap.new(inner_w, inner_h)
-        contents.font.color = Color.new(255, 255, 255, 255)
 
         # Plain messages type out gradually; choice lists appear at once.
-        reveal = Game::TextReveal.new(lines)
+        reveal = Game::TextReveal.new(plain)
         reveal.reveal_all if choice
-        @message = { window: win, choice: choice, count: lines.length,
-                     reveal: reveal, contents: contents, inner_w: inner_w }
+        @message = { window: win, choice: choice, count: plain.length,
+                     reveal: reveal, contents: contents, inner_w: inner_w,
+                     seg_lines: seg_lines }
         draw_message_contents
         win.contents = contents
         @choice_index = 0
         set_choice_cursor if choice
       end
 
-      # (Re)draw the message body showing the currently revealed characters.
+      # (Re)draw the message body showing the currently revealed characters,
+      # each colour run in its own colour, laid out left to right per line.
       def draw_message_contents
         return unless @message
         c = @message[:contents]
         c.clear
-        @message[:reveal].visible_lines.each_with_index do |line, i|
-          c.draw_text 0, i * MSG_LINE_H, @message[:inner_w], MSG_LINE_H, line
+        vis = Game::Message.visible_segments(@message[:seg_lines],
+                                             @message[:reveal].revealed)
+        vis.each_with_index do |segs, i|
+          x = 0
+          y = i * MSG_LINE_H
+          segs.each do |seg|
+            c.font.color = message_color(seg[:color])
+            c.draw_text x, y, @message[:inner_w] - x, MSG_LINE_H, seg[:text]
+            x += c.text_size(seg[:text]).width
+          end
         end
+      end
+
+      # RPG2000 message text palette (`\c[n]`). A small built-in approximation
+      # until the real 20-colour row is read from the System windowskin; unknown
+      # indices fall back to the default (white).
+      MSG_COLORS = {
+        0 => [255, 255, 255], 1 => [128, 176, 255], 2 => [255, 128, 128],
+        3 => [128, 255, 128], 4 => [255, 255, 128], 5 => [128, 240, 240],
+        6 => [255, 160, 255], 7 => [200, 200, 200], 8 => [255, 192, 128],
+        9 => [160, 160, 255]
+      }.freeze
+
+      def message_color(idx)
+        rgb = MSG_COLORS[idx] || MSG_COLORS[0]
+        Color.new(rgb[0], rgb[1], rgb[2], 255)
       end
 
       def set_choice_cursor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -410,6 +410,22 @@ check 'Message.parse omits empty runs and matches expand when joined' do
   eq Game::Message.expand(src, vars, names), joined
 end
 
+check 'Message.visible_segments truncates colour runs to the revealed count' do
+  sl = [[{ text: 'ab', color: 0 }, { text: 'cd', color: 2 }],
+        [{ text: 'ef', color: 1 }]]
+  eq [[], []], Game::Message.visible_segments(sl, 0)
+  # 3 chars: first run whole, one char of the second run; nothing on line 2.
+  eq [[{ text: 'ab', color: 0 }, { text: 'c', color: 2 }], []],
+     Game::Message.visible_segments(sl, 3)
+  eq [[{ text: 'ab', color: 0 }, { text: 'cd', color: 2 }], []],
+     Game::Message.visible_segments(sl, 4)
+  # Line 1 full (4), then one char of line 2.
+  eq [[{ text: 'ab', color: 0 }, { text: 'cd', color: 2 }],
+      [{ text: 'e', color: 1 }]],
+     Game::Message.visible_segments(sl, 5)
+  eq sl, Game::Message.visible_segments(sl, 99) # capped: everything shows
+end
+
 # -- Interpreter (a few existing-behaviour regressions) -----------------------
 
 # Build a minimal State without the LCF database: stub Party just enough for the


### PR DESCRIPTION
## Summary
Implement rendering of RPG2000 message colour codes (`\c[n]`) in colour while preserving the gradual typewriter reveal effect. Message text now displays in the appropriate palette colour for each segment, with the reveal cursor working correctly across colour boundaries.

## Key Changes
- **Message parsing**: Refactored `open_message` to use `Game::Message.parse` which splits text into `{text:, color:}` segments instead of just expanding to plain text
- **Colour-aware reveal**: Added `Game::Message.visible_segments` to truncate colour segments based on the reveal count, ensuring the typewriter effect works across colour boundaries
- **Rendering**: Updated `draw_message_contents` to iterate through visible segments and draw each in its corresponding colour using a new `message_color` helper
- **Colour palette**: Added `MSG_COLORS` constant with a built-in 10-colour approximation of the RPG2000 palette (indices 0-9); unknown indices fall back to white
- **Tests**: Added comprehensive test coverage for `visible_segments` in `rpg2k_logic_check.rb`
- **Documentation**: Updated TODO and README to reflect colour code support; added changelog entry

## Implementation Details
- The reveal counter now counts visible characters across all lines (plain text), while rendering uses the parsed colour segments
- Segments are drawn left-to-right with `x` position tracking to handle variable-width text
- The palette is a temporary approximation; reading the real 20-colour row from the System windowskin is deferred as a follow-up
- Choice lists still reveal all text at once (no typewriter effect for choices)

https://claude.ai/code/session_01A4aDnWrZrFeSCwb3E6hJ7y