### PR TITLE
Add pointer/touch input bridge to MV's TouchInput for menu clicking

### DIFF
--- a/changelog.d/mv-touchinput.added.md
+++ b/changelog.d/mv-touchinput.added.md
@@ -1,0 +1,11 @@
+- MV mouse / touch input: the pointer now drives MV's `TouchInput`, so title
+  and menu items are clickable. The SDL window backend's event watch captures
+  mouse motion and the left button (`src/sdl_input.cxx`), buffers them in
+  `mruby-rgss` (`input_bridge.cxx`) and exposes them as
+  `RGSS::Input.mouse_x` / `mouse_y` / `mouse_pressed?`; each frame `MV#sync_touch`
+  pushes a sample into `TouchInput` — setting `_x`/`_y` and feeding `_newState`
+  the triggered/moved/released edges MV's DOM handlers would — so its windows'
+  `isTriggered`/`isPressed` hit-testing works. Coordinates are 1:1 canvas pixels
+  (MV renders un-zoomed). The bridge mapping is unit-tested
+  (`mruby-mvjs/test/touch_test.rb`); non-SDL backends report the pointer at the
+  origin, unpressed.

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -132,6 +132,27 @@ class MV
       input_map.select { |key, _| RGSS::Input.press?(key) }.values
     end
 
+    # JS that pushes a pointer sample (canvas x/y, left-button pressed) into MV's
+    # TouchInput: it sets `_x`/`_y` and feeds `_newState` the triggered/released/
+    # moved edges MV's DOM handlers would, tracking the previous state on the
+    # object so press/release are detected across frames. MV's `TouchInput.update`
+    # (run during the scene update) turns `_newState` into the isTriggered/
+    # isPressed/isReleased its windows query, so menu clicks work. Split out so
+    # the mapping is unit-testable without a live engine or a pointer device.
+    def touch_bridge_js(x, y, pressed)
+      "(function(x,y,p){ if (typeof TouchInput === 'undefined' || " \
+      "!TouchInput._newState) return; TouchInput._x = x; TouchInput._y = y; " \
+      "var prev = !!TouchInput.__mvPrev; " \
+      "if (p && !prev) { TouchInput._screenPressed = true; " \
+      "TouchInput._mousePressed = true; TouchInput._pressedTime = 0; " \
+      "TouchInput._newState.triggered = true; } " \
+      "else if (!p && prev) { TouchInput._screenPressed = false; " \
+      "TouchInput._mousePressed = false; TouchInput._newState.released = true; } " \
+      "else if (p && prev) { TouchInput._newState.moved = true; } " \
+      "TouchInput.__mvPrev = p; })(#{x.to_i}, #{y.to_i}, " \
+      "#{pressed ? "true" : "false"});"
+    end
+
     # Parse one drained audio op (see AUDIO_BRIDGE_JS) into a call spec:
     # [method, *args]. `*_play` ops become [:kind_play, "audio/<kind>/<name>",
     # volume, pitch] with the maker's folder prepended so RGSS resolves it under
@@ -216,6 +237,7 @@ class MV
     boot unless @booted
 
     sync_input # M5: push RGSS input into MV's Input before the scene updates
+    sync_touch # M5: push RGSS mouse into MV's TouchInput before the scene update
     pump_frame # M3: run the rAF/timer queue for one frame
     pump_audio # M5: drain MV's queued audio ops into RGSS::Audio
     log_scene_transition # trace boot progress (Scene_Boot -> Scene_Title -> ...)
@@ -246,6 +268,22 @@ class MV
     )
   rescue StandardError => e
     $stderr.puts "[MV] input sync error: #{e.message}"
+  end
+
+  # Bridge the pointer to MV's TouchInput (menu/title clicking). RGSS::Input,
+  # fed by the SDL backend, exposes the current pointer position and button;
+  # push a sample into TouchInput each frame before the scene updates (see
+  # MV.touch_bridge_js). No-op until the engine (and thus TouchInput) has loaded,
+  # and inert under backends with no mouse (the state stays at the origin,
+  # unpressed).
+  def sync_touch
+    MV::JS.eval(
+      self.class.touch_bridge_js(
+        RGSS::Input.mouse_x, RGSS::Input.mouse_y, RGSS::Input.mouse_pressed?
+      )
+    )
+  rescue StandardError => e
+    $stderr.puts "[MV] touch sync error: #{e.message}"
   end
 
   # Drain the audio ops MV queued this frame (see AUDIO_BRIDGE_JS) and play them

--- a/mruby-mvjs/test/touch_test.rb
+++ b/mruby-mvjs/test/touch_test.rb
@@ -1,0 +1,37 @@
+# Tests for the pointer bridge (milestone M5): RGSS::Input mouse state (fed by
+# the SDL backend) pushed into MV's TouchInput for menu/title clicking.
+
+assert 'MV touch bridge feeds TouchInput press/move/release edges' do
+  # Minimal TouchInput stand-in with the fields the bridge drives; _newState is
+  # what MV's TouchInput.update consumes.
+  MV::JS.eval("globalThis.TouchInput = { _newState: {} };")
+  begin
+    # First pressed sample: sets position, marks triggered + pressed.
+    MV::JS.eval(MV.touch_bridge_js(120, 84, true))
+    assert_equal 120, MV::JS.eval("TouchInput._x")
+    assert_equal 84, MV::JS.eval("TouchInput._y")
+    assert_equal true, MV::JS.eval("!!TouchInput._newState.triggered")
+    assert_equal true, MV::JS.eval("!!TouchInput._screenPressed")
+
+    # Held + same/again pressed: a move edge, not another trigger.
+    MV::JS.eval("TouchInput._newState = {};")
+    MV::JS.eval(MV.touch_bridge_js(122, 84, true))
+    assert_equal false, MV::JS.eval("!!TouchInput._newState.triggered")
+    assert_equal true, MV::JS.eval("!!TouchInput._newState.moved")
+
+    # Release: a released edge, pressed flags cleared.
+    MV::JS.eval("TouchInput._newState = {};")
+    MV::JS.eval(MV.touch_bridge_js(122, 84, false))
+    assert_equal true, MV::JS.eval("!!TouchInput._newState.released")
+    assert_equal false, MV::JS.eval("!!TouchInput._screenPressed")
+  ensure
+    MV::JS.eval("delete globalThis.TouchInput;")
+  end
+end
+
+assert 'RGSS::Input exposes pointer state (defaults with no SDL mouse)' do
+  # With no SDL backend driving it, the pointer sits at the origin, unpressed.
+  assert_equal true, RGSS::Input.mouse_x.is_a?(Integer)
+  assert_equal true, RGSS::Input.mouse_y.is_a?(Integer)
+  assert_equal false, RGSS::Input.mouse_pressed?
+end

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -327,5 +327,20 @@ module RGSS
       return 9 if press?(UP) && press?(RIGHT)
       return dir4
     end
+
+    # Pointer state, captured by the SDL window backend (see input_bridge.cxx).
+    # In game/canvas pixels; (0, 0) and unpressed under backends with no mouse.
+    # MV's TouchInput bridge reads these for menu/title clicking.
+    def self.mouse_x
+      RGSS.mouse_x
+    end
+
+    def self.mouse_y
+      RGSS.mouse_y
+    end
+
+    def self.mouse_pressed?
+      RGSS.mouse_pressed?
+    end
   end
 end

--- a/mruby-rgss/src/input_bridge.cxx
+++ b/mruby-rgss/src/input_bridge.cxx
@@ -40,6 +40,35 @@ extern "C" void rgss_sdl_input_push(int key, bool press) {
   g_pending.push_back({key, press});
 }
 
+// --- mouse ------------------------------------------------------------------
+// The latest pointer position (in game/window pixels — the SDL window backend
+// renders the game 1:1 at MV's resolution, which is the only maker that reads
+// the mouse) and left-button state. Written by the SDL event watch, read on the
+// interpreter thread. Only current state is kept — consumers (e.g. MV's
+// TouchInput) derive their own trigger/press timing — so no queue is needed.
+namespace {
+int g_mouse_x = 0;
+int g_mouse_y = 0;
+bool g_mouse_pressed = false;
+}  // namespace
+
+// Called from the executable's SDL event watch for mouse motion/button events.
+extern "C" void rgss_sdl_mouse_push(int x, int y, bool pressed) {
+  g_mouse_x = x;
+  g_mouse_y = y;
+  g_mouse_pressed = pressed;
+}
+
+extern "C" int rgss_mouse_x(void) {
+  return g_mouse_x;
+}
+extern "C" int rgss_mouse_y(void) {
+  return g_mouse_y;
+}
+extern "C" int rgss_mouse_pressed(void) {
+  return g_mouse_pressed ? 1 : 0;
+}
+
 // Drains buffered SDL key transitions into RGSS::Input. Called every frame from
 // Graphics.update, next to rgss_terminal_poll.
 extern "C" void rgss_sdl_poll(mrb_state* M) {

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -39,6 +39,14 @@ extern "C" void rgss_terminal_poll(mrb_state* M);
 // backend is active and has captured key events; drains them into RGSS::Input.
 extern "C" void rgss_sdl_poll(mrb_state* M);
 
+// Defined in input_bridge.cxx (same gem).  The latest pointer state captured by
+// the SDL backend (0 / not-pressed under the other backends); exposed to Ruby
+// as RGSS.mouse_x / mouse_y / mouse_pressed? so MV's TouchInput bridge can read
+// it.
+extern "C" int rgss_mouse_x(void);
+extern "C" int rgss_mouse_y(void);
+extern "C" int rgss_mouse_pressed(void);
+
 // Defined in audio.cxx (same gem).  Registers the native RGSS::Audio methods
 // and drives the audio backend's per-frame work (a no-op when no backend is
 // installed).
@@ -1959,9 +1967,28 @@ extern "C" void rgss_set_display(mrb_state* M, lv_display_t* display) {
                 mrb_intern_lit(M, "_display"), mrb_cptr_value(M, display));
 }
 
+// RGSS.mouse_x / mouse_y / mouse_pressed? — the pointer state captured by the
+// SDL backend (see input_bridge.cxx). Read by MV's TouchInput bridge.
+static mrb_value mouse_x_m(mrb_state* M, mrb_value) {
+  (void)M;
+  return mrb_fixnum_value(rgss_mouse_x());
+}
+static mrb_value mouse_y_m(mrb_state* M, mrb_value) {
+  (void)M;
+  return mrb_fixnum_value(rgss_mouse_y());
+}
+static mrb_value mouse_pressed_m(mrb_state* M, mrb_value) {
+  (void)M;
+  return mrb_bool_value(rgss_mouse_pressed() != 0);
+}
+
 extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   RClass* m = mrb_define_module(M, "RGSS");
   mrb_define_module_function(M, m, "to_nfd", to_nfd, MRB_ARGS_REQ(1));
+  mrb_define_module_function(M, m, "mouse_x", mouse_x_m, MRB_ARGS_NONE());
+  mrb_define_module_function(M, m, "mouse_y", mouse_y_m, MRB_ARGS_NONE());
+  mrb_define_module_function(M, m, "mouse_pressed?", mouse_pressed_m,
+                             MRB_ARGS_NONE());
 
   mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_game_start"),
                 mrb_fixnum_value(lv_tick_get()));

--- a/src/sdl_input.cxx
+++ b/src/sdl_input.cxx
@@ -13,8 +13,9 @@
 
 #include <SDL2/SDL.h>
 
-// Buffer sink implemented in mruby-rgss/src/input_bridge.cxx.
+// Buffer sinks implemented in mruby-rgss/src/input_bridge.cxx.
 extern "C" void rgss_sdl_input_push(int key, bool press);
+extern "C" void rgss_sdl_mouse_push(int x, int y, bool pressed);
 
 namespace {
 
@@ -120,6 +121,18 @@ int SDLCALL event_watch(void* /*user*/, SDL_Event* event) {
       key = map_key(event->key.keysym.sym);
       press = false;
       break;
+    // Pointer -> RGSS mouse state (MV's TouchInput reads it). Coordinates are
+    // window pixels; the SDL backend renders MV 1:1, so they are canvas pixels.
+    case SDL_MOUSEMOTION:
+      rgss_sdl_mouse_push(event->motion.x, event->motion.y,
+                          (event->motion.state & SDL_BUTTON_LMASK) != 0);
+      return 0;
+    case SDL_MOUSEBUTTONDOWN:
+    case SDL_MOUSEBUTTONUP:
+      if (event->button.button == SDL_BUTTON_LEFT)
+        rgss_sdl_mouse_push(event->button.x, event->button.y,
+                            event->type == SDL_MOUSEBUTTONDOWN);
+      return 0;
     default:
       return 0;
   }


### PR DESCRIPTION
## Summary
Implements pointer input bridging from the SDL backend through RGSS to MV's TouchInput system, enabling clickable menus and title screens. The pointer state is captured by the SDL event watch, exposed via RGSS::Input methods, and synchronized into MV's TouchInput each frame before scene updates.

## Key Changes

- **SDL event capture** (`src/sdl_input.cxx`): Added mouse motion and button event handlers that push pointer state (x, y, left-button pressed) to the RGSS layer via `rgss_sdl_mouse_push()`.

- **Input bridge** (`mruby-rgss/src/input_bridge.cxx`): Implemented mouse state storage and accessor functions (`rgss_mouse_x()`, `rgss_mouse_y()`, `rgss_mouse_pressed()`) that maintain the latest pointer position and button state from SDL events.

- **RGSS API** (`mruby-rgss/src/lib.cxx` and `mrblib/lib.rb`): Exposed pointer state as `RGSS::Input.mouse_x`, `mouse_y`, and `mouse_pressed?` methods for Ruby code to query.

- **MV TouchInput bridge** (`mruby-mvjs/mrblib/mv.rb`): 
  - Added `touch_bridge_js()` method that generates JavaScript to push pointer samples into MV's TouchInput, tracking state transitions to emit triggered/moved/released edges that MV's window hit-testing expects.
  - Added `sync_touch()` method called each frame in `main_loop()` to synchronize the current pointer state into TouchInput before scene updates.

- **Tests** (`mruby-mvjs/test/touch_test.rb`): Unit tests verify the JavaScript bridge correctly handles press/move/release state transitions and that RGSS::Input exposes pointer state (defaulting to origin/unpressed on non-SDL backends).

## Implementation Details

- Coordinates are in game/canvas pixels (1:1 with window pixels since SDL renders MV unzoomed).
- The bridge is a no-op until MV's engine loads and TouchInput is available.
- Non-SDL backends report the pointer at (0, 0) unpressed, making the feature gracefully degrade.
- State tracking occurs in JavaScript (`TouchInput.__mvPrev`) to detect edges across frames, allowing MV's `TouchInput.update()` to properly set `isTriggered`/`isPressed`/`isReleased` flags for window click handling.

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8