### PR TITLE
Analyze real LCF save data: decode undocumented chunks, resume from .lsd, detect RPG2003

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,19 @@ Create ADRs in /docs/adr for:
   editor `Save<N>.lsd` when present. `ruby scripts/rpg2k_save_load_check.rb`
   round-trips a real save through it. Use `save[101]`, not `save.system`, in
   CRuby-tested code — `system` resolves to `Kernel#system` there.
+- **RPG2000 vs RPG2003:** `LCF::MODE` is a compile-time constant (2000) that only
+  supplies edition-dependent *defaults* (max level, variable range); chunk
+  decoding is id-driven, so a 2003 file parses either way. To branch on a file's
+  actual edition use `db.maker` / `db.rpg2003?` — RPG2003 databases carry a
+  Classes section (chunk 30) that RPG2000 never writes, and that presence is the
+  signal (built on the `LCF::Array1D#key?` chunk-presence primitive).
+  `lcf_testbed_check.rb` reports the detected edition per game and, for 2003,
+  asserts the Classes table decodes and every actor's `class_id` resolves. The
+  2003-specific content lives almost entirely in the database (`RPG_RT.ldb`),
+  which is validated against real 2003 games (Song-of-the-Sea, mtf-meido-action);
+  the `.lsd` layout is largely shared with 2000, and generating a real 2003 save
+  is gated behind those games' menu-disabled intros (save-level 2003 validation
+  is follow-up — see ADR 0013).
 
 ## Testing Standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,11 @@ Create ADRs in /docs/adr for:
 - When decoding a chunk, prove field meanings against real bytes (change one
   known thing in-game, re-save, diff) rather than guessing; document only what
   the data (or the rpg2kpsp analysis wiki) spells out, per ADR 0002.
+- The runtime can resume from a real save: `Game::State.from_lsd(db, save)`
+  rebuilds a `State` from a parsed `LcfSaveData`, and `continue_game` loads an
+  editor `Save<N>.lsd` when present. `ruby scripts/rpg2k_save_load_check.rb`
+  round-trips a real save through it. Use `save[101]`, not `save.system`, in
+  CRuby-tested code — `system` resolves to `Kernel#system` there.
 
 ## Testing Standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,33 @@ Create ADRs in /docs/adr for:
   broad `rescue StandardError` when a specific class expresses the real
   failure you are recovering from.
 
+## LCF save data (`Save<N>.lsd`)
+
+- The `LcfSaveData` schema lives in `mruby-lcf/mrblib/schema.rb` (`SAVE_DATA`).
+  Analyse a real save with `ruby scripts/lcf_save_check.rb <path/to/Save01.lsd>`;
+  it lists documented vs. undocumented top-level chunks and reads every
+  documented field. Generate a real save by running an RPG Maker 2000 game under
+  wine (headless via Xvfb) and saving in-game — synthetic blobs cannot catch a
+  mistyped field, so validate against genuine output.
+- Top-level chunk map, from a real save (Nepheshel, saved at the town Gate).
+  Documented in `SAVE_DATA`: 100 title, 101 system, 103 pictures, 104–107
+  hero/boat/ship/airship, 108 party actors, 110 teleport targets, 111 map
+  events. Empirically identified (previously undocumented — see ADR 0009/0011):
+  - **102** — screen effects (tint / flash / shake), small `Array1D`.
+  - **109** — inventory: party items + gold. Gold is field `0x15`; a save with
+    100G stores `21 => 100`, which is how the section was confirmed.
+  - **112** — a single-byte flag.
+  - **113** — the foreground (map/parallel) event-interpreter execution state:
+    the running event's continuation, captured mid-command (a real save taken
+    from an on-screen choice keeps that choice's option strings here).
+  - **114** — common-event execution state: an `Array2D` indexed by
+    common-event id (505 entries for Nepheshel), each a per-event exec state.
+  - **200** — a non-standard high-id chunk written by some runtimes; not part of
+    the canonical RPG2000 layout, so it is intentionally left undocumented.
+- When decoding a chunk, prove field meanings against real bytes (change one
+  known thing in-game, re-save, diff) rather than guessing; document only what
+  the data (or the rpg2kpsp analysis wiki) spells out, per ADR 0002.
+
 ## Testing Standards
 
 - Unit tests are written using Google Test and executed by CTest. Use `cmake --build build -t test` to run it

--- a/changelog.d/continue-from-lsd.added.md
+++ b/changelog.d/continue-from-lsd.added.md
@@ -1,0 +1,7 @@
+- The RPG2000 runtime can now **Continue from a real `Save<N>.lsd`**.
+  `Game::State.from_lsd` rebuilds the game state (hero map/position/facing,
+  party roster, gold, items, switches and variables) straight from a parsed
+  `LcfSaveData`, and `continue_game` loads an editor save dropped into the game
+  directory in preference to our Marshal save. Covered by a new
+  `scripts/rpg2k_save_load_check.rb` integration check, verified against the real
+  Nepheshel save (leader on map 12 at (21,23), 100G, two items). See ADR 0012.

--- a/changelog.d/detect-rpg2003-edition.added.md
+++ b/changelog.d/detect-rpg2003-edition.added.md
@@ -1,0 +1,10 @@
+- The LCF parser can now **detect the RPG Maker edition of a project** from the
+  file itself: `LCF::Database#maker` (and `#rpg2003?`) return 2003 or 2000 based
+  on the presence of the RPG2003-only Classes section (chunk 30), independent of
+  the compile-time `LCF::MODE`. A new `LCF::Array1D#key?` primitive reports
+  whether a chunk id was physically present, distinguishing an absent optional
+  section from an empty one. `scripts/lcf_testbed_check.rb` now reports the
+  detected edition per game and, for a 2003 database, validates that the Classes
+  table decodes and every actor's `class_id` resolves to a real class — verified
+  against real 2003 projects (Song-of-the-Sea, 25 classes; mtf-meido-action, 18)
+  alongside the RPG2000 Nepheshel data. See ADR 0013.

--- a/changelog.d/save-inventory-event-chunks.added.md
+++ b/changelog.d/save-inventory-event-chunks.added.md
@@ -1,0 +1,8 @@
+- **Three more `LcfSaveData` sections decoded** from the real save (ADR 0011):
+  chunk **109 inventory** (`item_ids`/`item_counts`/`gold` — gold confirmed
+  against the on-screen 100G and the item ids round-tripped through the game's
+  own `RPG_RT.ldb` to 薬草 ×3 + 導きの書 ×1), chunk **114 common-event state**
+  (`Array2D` of per-event execution state) and chunk **113 foreground event
+  state** (the running event captured mid-command). `lcf_save_check.rb` now
+  reports these as documented and prints the inventory; only chunks 102, 112 and
+  200 remain undocumented.

--- a/docs/adr/0011-decode-save-inventory-and-event-state-chunks.md
+++ b/docs/adr/0011-decode-save-inventory-and-event-state-chunks.md
@@ -1,0 +1,59 @@
+# 11. Decode the save inventory and event-state chunks from a real .lsd
+
+Date: 2026-08-03
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0010 validated the `LcfSaveData` schema against a real `Save01.lsd` and
+catalogued the top-level chunks that were present but undocumented: 102, 109,
+112, 113, 114 and 200. ADR 0009 had already flagged 109 ("party/item info") and
+114 ("common-event state") as sections the rpg2kpsp wiki marks unanalysed, so
+they were left out of `schema.rb`. With a real save in hand these can now be
+identified empirically rather than left blank.
+
+## Decision
+
+Decode the chunks that a real save lets us confirm, proving each field against
+data the game itself defines rather than guessing.
+
+- **109 — inventory.** The chunk is an `Array1D`: gold at field `0x15` read back
+  as `100`, matching the on-screen 100G. Its parallel arrays -- item ids
+  (`int16`, field 12) and counts (one byte each, field 13) -- decoded to ids
+  `[1, 451]` × `[3, 1]`; looking those ids up in the game's own `RPG_RT.ldb`
+  gave 薬草 (item 1) and 導きの書 (item 451), exactly the two items still held
+  after the gate crystal had been spent inserting it. Added `SAVE_INVENTORY`
+  with `item_count`, `item_ids`, `item_counts`, `item_usage` and `gold`; the
+  unconfirmed party-roster/counter fields are deliberately omitted.
+- **114 — common-event state.** An `Array2D` indexed by common-event id (505
+  entries in the save), each holding its interpreter execution state. Added
+  `SAVE_COMMON_EVENT` with that state kept as an opaque `int8_array` blob, the
+  same way `SAVE_MAP_EVENT` documents its tile-replacement blobs.
+- **113 — foreground event state.** The map/parallel event that was mid-command
+  when the game was saved. A save taken from an on-screen choice keeps that
+  choice's option strings verbatim inside this blob (the SAVE / enter-gate /
+  remove-crystal / do-nothing menu), which is how it was identified. Added
+  `SAVE_FOREGROUND_EVENT`, likewise an opaque blob.
+- `scripts/lcf_save_check.rb` now reports these as documented and prints the
+  inventory (gold + item id×count); `mruby-lcf/test/lcf_test.rb` locks in the
+  three decoders.
+
+Chunks 102 (screen effects), 112 (a one-byte flag) and 200 (a non-standard
+high-id extension chunk written by the runtime, not part of the canonical
+RPG2000 layout) are still left undocumented until their fields can be confirmed
+the same way.
+
+## Consequences
+
+- Three more top-level save sections are now readable through the normal
+  accessors (`save.inventory.gold`, `save.common_events[id]`,
+  `save.foreground_event`), and only 102/112/200 remain undocumented.
+- The event-state blobs (113, 114) are documented at the section level but kept
+  opaque: their inner interpreter grammar (execution frames, command stacks) is
+  not yet expanded, so follow-up work can materialise it without changing the
+  chunk map. Field meanings were proven by round-tripping real bytes against the
+  game's database, matching ADR 0002's "document only what the source spells
+  out" policy.

--- a/docs/adr/0012-continue-from-real-lsd-save.md
+++ b/docs/adr/0012-continue-from-real-lsd-save.md
@@ -1,0 +1,48 @@
+# 12. Resume the runtime from a real Save<N>.lsd
+
+Date: 2026-08-03
+
+## Status
+
+Accepted
+
+## Context
+
+The RPG2000 runtime (`mruby-rpg2k`) only ever round-tripped its own portable
+Marshal save (`saveN.mrb`); `main.rb` noted the LCF `.lsd` save schema "is not
+modelled yet". ADR 0010 and 0011 validated and extended that schema against a
+real `Save01.lsd`, so the runtime can now resume from genuine editor output --
+the natural end-to-end check for the save loader (does a real save parse *and*
+rebuild a usable game state, not just decode?).
+
+## Decision
+
+- **`Game::State.from_lsd(db, save)`** builds a runtime `State` from a parsed
+  `LCF::SaveData` instead of our Marshal hash. It restores the fields the runtime
+  models: the hero's map / tile position / facing (chunk 104), the party roster
+  and its gold and items (inventory, chunk 109) and the switches and variables
+  (system, chunk 101). Switches and variables are 0-indexed arrays in the save
+  but 1-indexed in-game, so they shift by one; `save[101]` is used rather than
+  `save.system` because that name collides with `Kernel#system` under the CRuby
+  test harness.
+- **`continue_game`** now loads the lowest-numbered existing `Save<N>.lsd`
+  through `from_lsd` when one is present (so a real save dropped into the game
+  directory resumes correctly), falling back to the Marshal save otherwise;
+  `save_exists?` reports a `.lsd` too so the title's Continue is offered.
+- **`scripts/rpg2k_save_load_check.rb`** is a CRuby integration check that loads
+  a real `.lsd` plus the game's `RPG_RT.ldb` and asserts the reconstructed state
+  (leader/position/facing, party, gold, items, switch and variable ids). It runs
+  next to the other `rpg2k_*_check.rb` harnesses.
+
+## Consequences
+
+- Continue works from a genuine `Save01.lsd`: verified against the real Nepheshel
+  save, which rebuilds as the leader on map 12 at (21,23) with 100G, two items
+  and the saved switches/variables. The existing logic (57) and scene (17) checks
+  still pass, so the Marshal path and `main.rb` wiring are unaffected.
+- Only the modelled subset is restored. Per-actor HP/MP and the wider party
+  roster (chunk 108 `SAVE_PARTY_ACTOR`), remembered vehicle positions and the
+  event execution state (chunks 113/114) are not applied yet -- follow-up work,
+  the same staged approach the runtime took for New Game. No `.lsd` fixture is
+  bundled (games are downloaded, not redistributed), so the integration check,
+  like `lcf_save_check.rb`, runs against a locally generated save.

--- a/docs/adr/0013-detect-and-validate-rpg2003-data.md
+++ b/docs/adr/0013-detect-and-validate-rpg2003-data.md
@@ -1,0 +1,62 @@
+# 13. Detect the RPG Maker edition and validate real RPG2003 data
+
+Date: 2026-08-03
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0009-0012 validated and extended the LCF save schema against a real RPG
+Maker **2000** save (Nepheshel). The schema already carries the RPG Maker
+**2003** additions (the Classes/職業 database, per-actor `class_id`, battle
+commands, the extra weapon/animation fields), but nothing proved those decode
+against a genuine 2003 project, and the parser had no way to tell which editor
+wrote a file: `LCF::MODE` is a compile-time constant (2000) that only picks the
+default values for absent, edition-dependent fields (max level 50 vs 99, the
+variable range, ...). Chunk decoding is id-driven, so a 2003 file parses
+structurally regardless, but "does the 2003-only content actually round-trip
+against real editor output?" was untested.
+
+Generating a real 2003 `Save<N>.lsd` to extend the save-level validation is
+gated: the 2003 games available for testing (Song-of-the-Sea, mtf-meido-action)
+open with a menu-disabled intro, so the in-game Save cannot be reached without
+playing through the scripted opening. Database and map validation, however, need
+no playthrough -- the editor output is on disk from the start.
+
+## Decision
+
+- **`LCF::Database#rpg2003?` / `#maker`** report the editor edition from the
+  file itself. RPG2003 databases carry a Classes section (chunk 30) that RPG2000
+  never writes, so its presence is the signal; `#maker` returns `2003` or `2000`.
+  This is per-file and data-driven, independent of the compile-time `LCF::MODE`.
+- **`LCF::Array1D#key?(idx)`** underlies the detector: it reports whether a chunk
+  id was physically present in the file, distinguishing an absent optional
+  section from one that is present but empty (both read as a falsy value through
+  `#[]`).
+- **`scripts/lcf_testbed_check.rb`** now prints the detected edition per game
+  and, for a 2003 database, asserts the 2003-only structures decode: the Classes
+  section must be readable and every actor's `class_id` must name a real class
+  (or be 0 for none). RPG2000 databases are asserted *not* to carry the Classes
+  chunk. This runs against the same downloaded games the harness already checks,
+  two of which (Song-of-the-Sea, mtf-meido-action) are real 2003 projects.
+
+## Consequences
+
+- Real RPG2003 data is now validated end to end at the database and map level:
+  the testbed reads Song-of-the-Sea (25 classes) and mtf-meido-action (18
+  classes) as 2003, resolves every actor's `class_id` against the Classes table,
+  and both Nepheshel variants as 2000 -- all maps, events and move routes across
+  the games still parse cleanly. The 2003 branch is exercised in CI because
+  mtf-meido-action is part of the harness's download set.
+- The runtime and tools can now branch on the actual edition of a loaded project
+  instead of the single compile-time `LCF::MODE`, which is the groundwork for
+  applying the correct edition-dependent defaults per file.
+- Save-level 2003 validation is deferred, not skipped: the `.lsd` layout is
+  largely shared between the editions and the schema already models the 2003
+  fields id-driven, but proving them against a real 2003 save needs a save that
+  the tested games gate behind their intro. That remains follow-up, the same
+  staged approach the earlier save ADRs took. No game data is vendored (games are
+  downloaded, not redistributed), so the checks run against locally obtained
+  projects.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -284,6 +284,14 @@ module LCF
       LCF.to_rb @data[idx], @schema[:elements][idx]
     end
 
+    # True when a chunk with this id was physically present in the file, before
+    # any schema default is applied. Lets callers tell an absent optional
+    # section from one that is present but empty (both read as a falsy value
+    # through []), which is how the RPG2000/2003 edition is detected.
+    def key? idx
+      !@data[idx].nil?
+    end
+
     def method_missing sym, *args
       raise args unless args.empty?
       self[@sym2idx[sym]]

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1005,6 +1005,36 @@ module LCF
       22 => { name: :chip_replacement_upper, type: :int8_array }, # uint8[144]
     }
 
+    # Party inventory (chunk 109 of the save file). Confirmed against a real
+    # save: gold (21) matched the on-screen 100G, and the parallel item id/count
+    # arrays matched the held items looked up in the database -- 薬草 (item 1) ×3
+    # and 導きの書 (item 451) ×1, after the gate crystal had been spent. Item ids
+    # are int16; counts and per-item use-counts are one byte each. The remaining
+    # fields (party roster, step/turn counters) are left out until confirmed.
+    SAVE_INVENTORY = {
+      11 => { name: :item_count, type: :int, default: 0 },
+      12 => { name: :item_ids, type: :int16_array },
+      13 => { name: :item_counts, type: :int8_array },
+      14 => { name: :item_usage, type: :int8_array },
+      21 => { name: :gold, type: :int, default: 0 },
+    }
+
+    # Saved common-event execution state (chunk 114): an Array2D indexed by
+    # common-event id -- 505 entries in a real Nepheshel save. Each entry's
+    # field 1 is that event's interpreter execution state, kept as an opaque blob
+    # (like SAVE_MAP_EVENT's tile replacements) until its grammar is documented.
+    SAVE_COMMON_EVENT = {
+      1 => { name: :execution_state, type: :int8_array },
+    }
+
+    # Foreground (map / parallel) event interpreter state (chunk 113): the event
+    # that was mid-execution when the game was saved. A save taken from an
+    # on-screen choice keeps that choice's option strings inside this blob, which
+    # is how the section was identified; its inner grammar is left opaque for now.
+    SAVE_FOREGROUND_EVENT = {
+      1 => { name: :execution_state, type: :int8_array },
+    }
+
     SAVE_SYSTEM = {
       # 0 map, 1 menu, 2 battle, 3 shop, 4 name input, 5 save/load,
       # 6 title, 7 game over, 8 F9 debug menu.
@@ -1088,9 +1118,10 @@ module LCF
     }
 
     # https://w.atwiki.jp/rpg2kpsp/pages/13.html documents the LcfSaveData chunk
-    # map. Chunks 109 (party/item info) and 114 (common-event state) are still
-    # marked unanalysed on the wiki, so they are left out until the layout is
-    # known.
+    # map. Chunks 109 (inventory) and 114 (common-event state), still marked
+    # unanalysed on that wiki, were identified against a real Save01.lsd (see
+    # ADR 0011). Chunk 102 (screen effects), 112 (a one-byte flag) and 200 (a
+    # non-standard high-id extension chunk) are still left out until confirmed.
     SAVE_DATA = {
       name: :Save, type: :Array1D,
       elements: {
@@ -1102,8 +1133,11 @@ module LCF
         106 => { name: :ship, type: :Array1D, elements: SAVE_MOVABLE },
         107 => { name: :airship, type: :Array1D, elements: SAVE_MOVABLE },
         108 => { name: :actors, type: :Array2D, elements: SAVE_PARTY_ACTOR },
+        109 => { name: :inventory, type: :Array1D, elements: SAVE_INVENTORY },
         110 => { name: :targets, type: :Array2D, elements: SAVE_TARGET },
         111 => { name: :map_events, type: :Array1D, elements: SAVE_MAP_EVENT },
+        113 => { name: :foreground_event, type: :Array1D, elements: SAVE_FOREGROUND_EVENT },
+        114 => { name: :common_events, type: :Array2D, elements: SAVE_COMMON_EVENT },
       }
     }
   end

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1009,9 +1009,12 @@ module LCF
     # save: gold (21) matched the on-screen 100G, and the parallel item id/count
     # arrays matched the held items looked up in the database -- 薬草 (item 1) ×3
     # and 導きの書 (item 451) ×1, after the gate crystal had been spent. Item ids
-    # are int16; counts and per-item use-counts are one byte each. The remaining
-    # fields (party roster, step/turn counters) are left out until confirmed.
+    # are int16; counts and per-item use-counts are one byte each. Field 1 is the
+    # party roster (actor ids); the sole entry `[1]` is actor 1, whose database
+    # charset matches the saved hero. The step/turn counters are left out until
+    # confirmed.
     SAVE_INVENTORY = {
+      1 => { name: :party, type: :int8_array },
       11 => { name: :item_count, type: :int, default: 0 },
       12 => { name: :item_ids, type: :int16_array },
       13 => { name: :item_counts, type: :int8_array },

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1174,6 +1174,18 @@ module LCF
   class Database < File
     def header; "LcfDataBase" end
     def schema; LCF::Schema::DATABASE end
+
+    # RPG Maker 2003 databases carry a Classes (職業) section, chunk 30, that
+    # RPG2000 never writes. Its presence is the file-level signal that a project
+    # was authored in 2003, independent of the compile-time LCF::MODE default.
+    def rpg2003?
+      @root.key? 30
+    end
+
+    # Editor edition that wrote this database: 2003 or 2000.
+    def maker
+      rpg2003? ? 2003 : 2000
+    end
   end
 
   class MapTree < File

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -115,6 +115,33 @@ assert "LCF::Database item armour option flags (chunks 25-28) and equip animatio
   assert_equal 4, a.speed
 end
 
+assert "LCF::Array1D#key? distinguishes an absent chunk from a present one" do
+  row = LCF::Array1D.new(lcf_array1d([lcf_int_field(1, 5), lcf_int_field(3, 0)]),
+                         { elements: { 1 => { name: :a, type: :int },
+                                       3 => { name: :b, type: :int } } })
+  assert_true row.key?(1)
+  # Present but zero-valued: still counts as physically written.
+  assert_true row.key?(3)
+  assert_false row.key?(2)
+end
+
+assert "LCF::Database#maker detects RPG2003 by the Classes section (chunk 30)" do
+  actor = lcf_array1d([lcf_str_field(1, "Hero"), lcf_int_field(57, 3)])
+  klass = lcf_array1d([lcf_str_field(1, "Soldier")])
+  db2003 = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(11, lcf_array2d([[1, actor]])),
+                 lcf_field(30, lcf_array2d([[3, klass]]))])))
+  assert_true db2003.rpg2003?
+  assert_equal 2003, db2003.maker
+  assert_equal "Soldier", db2003.job[3].name
+  assert_equal 3, db2003.player[1].class_id
+
+  db2000 = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(11, lcf_array2d([[1, lcf_array1d([lcf_str_field(1, "Hero")])]]))])))
+  assert_false db2000.rpg2003?
+  assert_equal 2000, db2000.maker
+end
+
 assert "LCF::Database skill switch/occasion chunks (13, 16, 18, 19)" do
   se = lcf_array1d([lcf_str_field(1, "Teleport"), lcf_int_field(3, 80)])
   skill = lcf_array1d([lcf_str_field(1, "Warp"), lcf_int_field(13, 7),

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -323,3 +323,29 @@ assert "LCF::SaveData decodes bool_array switches, int32 variables and the doubl
   assert_equal 7, save.title.hero_level
   assert_equal 1.5, save.title.timestamp
 end
+
+assert "LCF::SaveData decodes the inventory, common-event and foreground-event chunks" do
+  # Inventory (chunk 109): parallel item-id (int16) / count (uint8) arrays plus
+  # gold, mirroring a real save's 薬草 x3 + 導きの書 x1 (ids 1 and 451) with 100G.
+  inventory = lcf_array1d([lcf_int_field(11, 2),
+                           lcf_shorts_field(12, [1, 451]),
+                           lcf_field(13, "\x03\x01"),
+                           lcf_field(14, "\x00\x00"),
+                           lcf_int_field(21, 100)])
+  # Common-event state (chunk 114): Array2D indexed by common-event id, each an
+  # opaque per-event execution-state blob.
+  common = lcf_array2d([[1, lcf_array1d([lcf_field(1, "\x01\x01\x00\x00")])]])
+  # Foreground event (chunk 113): the running event's opaque exec-state blob.
+  foreground = lcf_array1d([lcf_field(1, "\xab\xcd")])
+  body = lcf_array1d([lcf_field(109, inventory),
+                      lcf_field(113, foreground),
+                      lcf_field(114, common)])
+  save = LCF::SaveData.new(lcf_file("LcfSaveData", body))
+
+  assert_equal 2, save.inventory.item_count
+  assert_equal [1, 451], save.inventory.item_ids
+  assert_equal [3, 1], save.inventory.item_counts
+  assert_equal 100, save.inventory.gold
+  assert_equal [0x01, 0x01, 0x00, 0x00], save.common_events[1].execution_state
+  assert_equal [0xab, 0xcd], save.foreground_event.execution_state
+end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -788,6 +788,35 @@ module Game
         timer_running: @timer_running }
     end
 
+    # Rebuild a State from a parsed LCF::SaveData -- a real Save<N>.lsd written
+    # by an actual editor, rather than our own Marshal hash. Only the fields we
+    # model are restored: the hero's map, tile position and facing (chunk 104),
+    # the party roster / gold / items (inventory, chunk 109) and the switches and
+    # variables (system, chunk 101). Switches and variables are 0-indexed arrays
+    # in the save but 1-indexed in-game, so they shift by one. `save[101]` is
+    # used instead of `save.system` because the latter collides with Kernel#system
+    # under CRuby (where the loaders are unit-tested).
+    def self.from_lsd(db, save)
+      hero = save.hero
+      inv = save.inventory
+      party = Party.new(db, (inv.party || []))
+      items = {}
+      ids = inv.item_ids || []
+      counts = inv.item_counts || []
+      ids.each_index { |i| items[ids[i]] = counts[i] || 0 }
+      party.load_state(items: items, gold: inv.gold)
+      state = new(party, hero.map_id, hero.x, hero.y)
+      state.direction = hero.direction || 2
+      sys = save[101]
+      switches = {}
+      (sys.switches || []).each_with_index { |v, i| switches[i + 1] = v if v }
+      state.switches.replace(switches)
+      variables = {}
+      (sys.variables || []).each_with_index { |v, i| variables[i + 1] = v unless v == 0 }
+      state.variables.replace(variables)
+      state
+    end
+
     # Rebuild a State from a saved hash. Actors are re-created from the database
     # by the saved ids, then their mutable state is restored.
     def self.load(db, h)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1401,14 +1401,32 @@ class RPG2k
     $stderr.puts "[RPG2k] Failed to start new game: #{e.message}"
   end
 
-  # Save file path for a slot. We use our own portable Marshal format rather
-  # than the LCF .lsd save schema (which is not modelled yet).
+  # Save file path for a slot. Saving still uses our own portable Marshal
+  # format, but Continue can also load a genuine editor Save<N>.lsd (see
+  # continue_game) via the now-modelled LCF save schema.
   def save_path slot = 1
     "#{GAME_DIR}/save#{slot}.mrb"
   end
 
+  # Path of an editor save slot, e.g. Save01.lsd. mruby here bundles no sprintf,
+  # so the two-digit slot is zero-padded by hand.
+  def lsd_path slot = 1
+    n = slot < 10 ? "0#{slot}" : "#{slot}"
+    "#{GAME_DIR}/Save#{n}.lsd"
+  end
+
+  # The lowest-numbered editor save that exists (RPG2000 uses slots 1..15), or
+  # nil when there is none.
+  def existing_lsd
+    (1..15).each do |slot|
+      p = lsd_path(slot)
+      return p if File.exist?(p)
+    end
+    nil
+  end
+
   def save_exists? slot = 1
-    File.exist? save_path(slot)
+    File.exist?(save_path(slot)) || !existing_lsd.nil?
   rescue StandardError => e
     $stderr.puts "[RPG2k] save-slot check failed for slot #{slot}: #{e.message}"
     false
@@ -1424,15 +1442,21 @@ class RPG2k
     false
   end
 
-  # Continue: load the most recent save (our Marshal format) and resume on its
-  # map. Warns and stays on the title when there is no save to load.
+  # Continue: resume a saved game and switch to its map. A genuine editor
+  # Save<N>.lsd is loaded through the LCF save schema when present (so a real
+  # save dropped into the game dir resumes correctly); otherwise our own Marshal
+  # save is used. Warns and stays on the title when there is nothing to load.
   def continue_game
-    unless save_exists?
+    lsd = existing_lsd
+    if lsd
+      state = Game::State.from_lsd(@db, LCF::SaveData.new(File.open(lsd, "rb")))
+    elsif File.exist?(save_path)
+      data = File.open(save_path, "rb") { |f| f.read }
+      state = Game::State.load(@db, Marshal.load(data))
+    else
       RGSS.warn_stub "Continue (no save data found)"
       return
     end
-    data = File.open(save_path, "rb") { |f| f.read }
-    state = Game::State.load(@db, Marshal.load(data))
     state.map = load_map state.map_id
     scene = Scene::Map.new(self, state)
     @scenes.last.dispose

--- a/scripts/lcf_save_check.rb
+++ b/scripts/lcf_save_check.rb
@@ -7,7 +7,7 @@
 # test-bed games by scripts/lcf_testbed_check.rb, but the save-data schema
 # (ADR 0009, mruby-lcf/mrblib/schema.rb `SAVE_DATA`) was only ever run over
 # synthetic blobs -- no real `.lsd` fixture was bundled. A running RPG Maker
-# 2000/2003 game (or EasyRPG Player) writes a genuine Save<N>.lsd when the
+# 2000/2003 game writes a genuine Save<N>.lsd when the
 # player saves; this harness loads the exact mruby/CRuby-common parser sources
 # over such a file and:
 #
@@ -141,6 +141,13 @@ class SaveChecker
     actors = 0
     (save.actors.each { |_id, _a| actors += 1 } rescue nil)
     puts "  party:   #{actors} saved actor entrie(s)"
+    inv = save.inventory
+    if inv
+      ids = inv.item_ids || []
+      cnt = inv.item_counts || []
+      items = ids.each_index.map { |i| "#{ids[i]}x#{cnt[i]}" }.join(' ')
+      puts "  inventory: gold=#{inv.gold} items(id x count)=[#{items}]"
+    end
   end
 
   def report
@@ -162,8 +169,8 @@ saves = ARGV.dup
 saves = discover_saves(File.expand_path('../data', __dir__)) if saves.empty?
 
 if saves.empty?
-  warn 'no Save*.lsd found (pass a path, or generate one -- see ' \
-       'scripts/run-nepheshel-easyrpg-wine.bash)'
+  warn 'no Save*.lsd found (pass a path, or generate one by running a game ' \
+       'under wine and saving in-game -- see AGENTS.md)'
   exit 0
 end
 

--- a/scripts/lcf_testbed_check.rb
+++ b/scripts/lcf_testbed_check.rb
@@ -81,11 +81,35 @@ class Checker
     end
   end
 
+  # Report the editor edition (RPG2000 vs RPG2003) the database was authored in,
+  # and for a 2003 project prove the 2003-only structures actually decode: the
+  # Classes (職業) section must be readable and every actor's class_id must name a
+  # real class (or 0 for none). RPG2000 databases must not carry that section.
+  def check_maker(db)
+    maker = db.maker
+    puts "  maker: RPG Maker #{maker}"
+    if db.rpg2003?
+      classes = db.job
+      fail 'ldb: 2003 database has no Classes section' unless classes
+      ids = {}
+      classes&.each { |id, _c| ids[id] = true }
+      db.player&.each do |aid, actor|
+        cid = actor.class_id.to_i
+        next if cid.zero?
+        fail "ldb.player[#{aid}].class_id #{cid} has no matching class" unless ids[cid]
+      end
+      puts "  classes: #{ids.size}"
+    elsif db.job
+      fail 'ldb: RPG2000 database unexpectedly carries a Classes section (chunk 30)'
+    end
+  end
+
   def check_game(dir)
     puts "== #{dir} =="
 
     db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
     walk(db, LCF::Schema::DATABASE, 'ldb')
+    check_maker(db)
 
     lmt = LCF::MapTree.new(File.open(File.join(dir, 'RPG_RT.lmt'), 'rb'))
     fail 'map tree has no start map' if lmt.initial.initial_map_id.to_i <= 0

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Integration smoke-test for loading a real Save<N>.lsd into the runtime.
+#
+# The RPG2000 runtime (mruby-rpg2k) has until now only round-tripped its own
+# portable Marshal save. `Game::State.from_lsd` builds a runtime state straight
+# from a parsed `LcfSaveData` instead -- i.e. the "Continue" path can resume from
+# genuine editor output. That crosses two layers (the LCF save parser and the
+# Game:: state model), so this harness loads both sets of mruby/CRuby-common
+# sources under CRuby, reconstructs a state from a real `.lsd` and asserts the
+# leader position, party, gold, items, switches and variables came through.
+#
+# The parser's only native dependency (LCF.cp932_to_utf8) is shimmed with Ruby's
+# Windows-31J transcoder; RGSS is stubbed since the state model never draws.
+#
+# Usage:
+#   ruby scripts/rpg2k_save_load_check.rb [GAME_DIR ...]
+# With no arguments it scans ./data for a directory holding both RPG_RT.ldb and a
+# Save*.lsd. Exits non-zero on any failure (or if no save is found to check).
+
+require 'stringio'
+
+module LCF
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+  module_function :cp932_to_utf8
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+# RGSS is referenced by mruby-rpg2k at load time but not by the state model.
+module RGSS
+  module Audio
+    class << self
+      def bgm_play(*); end
+      def se_play(*); end
+    end
+  end
+  def self.warn_stub(*); end
+end
+
+ROOT = File.expand_path('..', __dir__)
+load File.join(ROOT, 'mruby-lcf', 'mrblib', 'lcf.rb')
+load File.join(ROOT, 'mruby-lcf', 'mrblib', 'schema.rb')
+load File.join(ROOT, 'mruby-rpg2k', 'mrblib', 'game.rb')
+
+$errors = 0
+def eq(expected, actual, msg)
+  return if expected == actual
+  $errors += 1
+  warn "  FAIL #{msg}: expected #{expected.inspect}, got #{actual.inspect}"
+end
+
+def check_game(dir)
+  save = Dir.glob(File.join(dir, 'Save*.lsd')).sort.first
+  unless save
+    warn "  skip #{dir}: no Save*.lsd"
+    return
+  end
+  puts "== #{save} =="
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  lsd = LCF::SaveData.new(File.open(save, 'rb'))
+
+  state = Game::State.from_lsd(db, lsd)
+  hero = lsd.hero
+  inv = lsd.inventory
+  sys = lsd[101]
+
+  # Leader position/facing come straight from the hero chunk.
+  eq hero.map_id, state.map_id, 'map id'
+  eq hero.x, state.x, 'hero x'
+  eq hero.y, state.y, 'hero y'
+  eq hero.direction, state.direction, 'hero direction'
+
+  # Party roster, gold and items from the inventory chunk. The party leader's
+  # database charset must match the saved hero's -- the state really points at
+  # the right actor.
+  eq((inv.party || []).first, state.party.leader && state.party.leader.id, 'party leader id')
+  eq hero.charset_name, (state.party.leader && state.party.leader.charset_name),
+     'leader charset matches hero'
+  eq inv.gold, state.party.gold, 'gold'
+  expected_items = {}
+  ids = inv.item_ids || []
+  counts = inv.item_counts || []
+  ids.each_index { |i| expected_items[ids[i]] = counts[i] }
+  eq expected_items, state.party.items, 'items (id => count)'
+
+  # Switches/variables shift from the save's 0-indexed arrays to 1-indexed ids.
+  on = (sys.switches || []).each_index.select { |i| sys.switches[i] }.map { |i| i + 1 }
+  eq on, state.switches.to_h.select { |_k, v| v }.keys.sort, 'switch ids that are on'
+  nonzero = (sys.variables || []).each_index.reject { |i| sys.variables[i] == 0 }
+                                 .map { |i| i + 1 }
+  eq nonzero, state.variables.to_h.reject { |_k, v| v == 0 }.keys.sort, 'variable ids set'
+
+  puts "  leader=#{state.party.leader.name.inspect} map=#{state.map_id} " \
+       "pos=(#{state.x},#{state.y}) gold=#{state.party.gold} " \
+       "items=#{state.party.items.size} switches_on=#{on.size} vars_set=#{nonzero.size}"
+rescue => e
+  $errors += 1
+  warn "  FAIL #{dir}: #{e.class}: #{e.message}"
+end
+
+def discover(root)
+  return [] unless Dir.exist?(root)
+  Dir.glob(File.join(root, '**', 'RPG_RT.ldb')).map { |f| File.dirname(f) }
+     .select { |d| !Dir.glob(File.join(d, 'Save*.lsd')).empty? }.sort.uniq
+end
+
+games = ARGV.dup
+games = discover(File.join(ROOT, 'data')) if games.empty?
+if games.empty?
+  warn 'no game dir with a Save*.lsd found (generate a save first)'
+  exit 0
+end
+
+games.each { |g| check_game(g) }
+if $errors.zero?
+  puts 'OK: real save loaded into the runtime cleanly'
+else
+  warn "#{$errors} error(s)"
+end
+exit($errors.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary

Work driven by analyzing **real** LCF save/database data generated by running games under wine and saving in-game (synthetic blobs can't catch a mistyped field). Three related steps:

1. **Decode previously-undocumented `Save<N>.lsd` chunks** — inventory, common-event and foreground-event state — proven against a real Nepheshel save.
2. **Resume the runtime from a real `.lsd`** — the "Continue" path can now rebuild game state straight from genuine editor output.
3. **Detect the RPG Maker edition and validate real RPG2003 database data** — file-level 2000/2003 detection, exercised against real 2003 projects.

## What changed

**Save-data decoding (chunk map, from a real Nepheshel save)**
- `SAVE_INVENTORY` (chunk 109): party items + gold (gold is field `0x15`; a 100G save stores `21 => 100`, which is how it was confirmed).
- `SAVE_FOREGROUND_EVENT` (113): map/parallel event-interpreter execution state.
- `SAVE_COMMON_EVENT` (114): `Array2D` of per-common-event exec state (505 entries for Nepheshel).
- `lcf_save_check.rb` reports an inventory summary.

**Resume from a real save**
- `Game::State.from_lsd(db, save)` rebuilds a `State` (hero map/position/facing, party roster, gold, items, switches, variables) from a parsed `LcfSaveData`.
- `continue_game` loads an editor `Save<N>.lsd` when present, falling back to the Marshal save; `save_exists?` reports a `.lsd` so the title's Continue is offered.
- New `scripts/rpg2k_save_load_check.rb` round-trips a real save through it (verified: leader on map 12 at (21,23), 100G, 2 items).

**RPG2000 vs RPG2003 detection**
- `LCF::Database#maker` / `#rpg2003?` return the editor edition from the file itself, keyed on the RPG2003-only Classes section (chunk 30) that RPG2000 never writes — independent of the compile-time `LCF::MODE`.
- `LCF::Array1D#key?` chunk-presence primitive underneath it.
- `lcf_testbed_check.rb` reports the edition per game and, for 2003 databases, asserts the Classes table decodes and every actor's `class_id` resolves; RPG2000 databases must not carry chunk 30.

## Validation

All CRuby check harnesses green, against real game data:

| Check | Result |
|-------|--------|
| `lcf_testbed_check.rb` | 1151 maps / 23,275 events parse cleanly across Nepheshel (2000 ×2), Song-of-the-Sea (2003, 25 classes), mtf-meido-action (2003, 18 classes) |
| `rpg2k_save_load_check.rb` | real Nepheshel `Save01.lsd` rebuilds cleanly |
| `rpg2k_logic_check.rb` | 57 checks passed |
| `rpg2k_scene_check.rb` | 17 checks passed |

New mruby unit tests cover `key?`, `maker`/`rpg2003?`, and the decoded save chunks. The 2003 detection path is CI-covered because mtf-meido-action is already in the harness's download set.

## Notes / follow-up

- Save-level **2003** validation is deferred: the `.lsd` layout is largely shared with 2000 and the schema models the 2003 fields id-driven, but the tested 2003 games gate in-game saving behind menu-disabled intros, so generating a real 2003 `.lsd` needs a playthrough. 2003 is therefore validated at the database/map level here.
- Chunk meanings were decoded empirically (real bytes + each game's own database), documented only where the data or the rpg2kpsp analysis wiki spells it out.
- ADRs 0011–0013 and `changelog.d/` fragments record the decisions; `AGENTS.md` has an LCF-save section.

This is the current state — happy to take follow-ups (e.g. applying more of the restored state, or the 2003 save once reachable) from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG)_