### PR TITLE
Implement Set Move Route (209) and Input Number (103) commands

### DIFF
--- a/changelog.d/rpgxp-rgss3a-archive.added.md
+++ b/changelog.d/rpgxp-rgss3a-archive.added.md
@@ -1,0 +1,12 @@
+- RPG Maker **VX Ace** encrypted-archive (`Game.rgss3a`, RGSSAD version 3)
+  support. `RPGXP::RGSSAD` now decrypts the v3 layout in addition to v1: a
+  plaintext 32-bit seed in the header derives a base key (`seed * 9 + 3`), a
+  fixed-key table of entry records (absolute offset, size, per-file data key and
+  name) is walked to a zero-offset terminator, and each file's data is decrypted
+  with its own per-file key using the same routine as v1. `RPGXP::RGSSData`
+  transparently falls back to a `.rgss3a` archive (already tried by `RGSSAD.find`)
+  when a `.rxdata` is not loose on disk. New `RGSSAD.pack_v3` builds v3 archives
+  (the inverse of the reader, used as the test fixture builder). Covered by new
+  `mruby-rpgxp/test` round-trips and by `scripts/rpgxp_testbed_check.rb`, which
+  now packs the real test bed as both `.rgssad` and `.rgss3a` and reloads the
+  whole database through each.

--- a/changelog.d/rpgxp-set-move-route-input-number.added.md
+++ b/changelog.d/rpgxp-set-move-route-input-number.added.md
@@ -1,0 +1,17 @@
+- RPG Maker **XP** *Set Move Route* (209) and *Input Number* (103) event
+  commands. `RPGXP::Game::Interpreter` now queues the `RPG::MoveRoute` packed
+  into a Set Move Route command for its target (the player `-1`, "this event"
+  `0`, or a map event id), resolving "this event" to the running event and
+  dropping requests with no context or no route; unlike a message / wait /
+  teleport, a move route does not suspend the interpreter, so `Scene::Map`
+  drains the queue after each step (`take_move_route_requests`) and drives the
+  target along the route in the background. A forced route overrides an event's
+  page movement until it finishes (paced by the event's move frequency) and does
+  not survive a map change; a forced *player* route mirrors a `Game::Character`,
+  snaps tile-to-tile and suppresses input while active. *Input Number* suspends
+  the interpreter with a `:number` request; `Scene::Map` opens a digit-entry
+  widget backed by a pure, testable `RPGXP::Game::NumberInput` (fixed digit
+  count with a movable cursor, up/down wrapping each digit 0–9) and
+  `resume_number` stores the entered value into the target variable. Covered by
+  new `mruby-rpgxp/test` cases (move-route queueing / target resolution, the
+  input-number request + result, and the number-input digit model).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -215,14 +215,16 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route targets and
   the many screen-effect / picture / battle commands (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
-  (RPG Maker XP; VX's same-format `Game.rgss2a`) loads: `RPGXP::RGSSAD`
-  (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts the version-1 format and
-  `RPGXP::RGSSData` falls back to it when a `.rxdata` is not loose on disk.
-  Covered by `mruby-rpgxp/test` and by `scripts/rpgxp_testbed_check.rb` (packs
-  the real test bed and reloads through the archive). Remaining: VX Ace's
-  version-3 `Game.rgss3a`, and reading **graphics/audio** out of the archive
-  (only the Ruby `Data/` path is wired; the native `Bitmap`/`Audio` loaders still
-  read loose files).
+  (RPG Maker XP; VX's same-format `Game.rgss2a`) or a VX Ace `Game.rgss3a` loads:
+  `RPGXP::RGSSAD` (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts **both** the version-1
+  format (rolling 0xDEADCAFE key) and the version-3 format (a plaintext header
+  seed → base key, a fixed-key entry table with per-file data keys) and
+  `RPGXP::RGSSData` falls back to whichever archive is present when a `.rxdata` is
+  not loose on disk. Covered by `mruby-rpgxp/test` (v1 and v3 round-trips) and by
+  `scripts/rpgxp_testbed_check.rb` (packs the real test bed as both `.rgssad` and
+  `.rgss3a` and reloads the whole DB through each). Remaining: reading
+  **graphics/audio** out of the archive (only the Ruby `Data/` path is wired; the
+  native `Bitmap`/`Audio` loaders still read loose files).
 - **Menus / save / battle** — the default menu screens, saving in the real
   `.rxdata` save format (a portable Marshal save is used for now), and the
   battle system.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -202,11 +202,18 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   `Game::MoveRoute` drive an event's page move type (fixed / random / approach)
   or custom move route (the full XP move-command set), paced by move frequency
   and blocked by terrain / the player / other events, and the **event-touch**
-  trigger fires when an event walks into the player. Covered by `mruby-rpgxp/test`
-  and driven over the real test bed by `scripts/rpgxp_testbed_check.rb`. Still to
-  come: the interpreter's *Set Move Route* (209) command (apply a forced route
-  from an event command), Input Number, and the many screen-effect / picture /
-  battle commands (skipped for now).
+  trigger fires when an event walks into the player. The interpreter's *Set Move
+  Route* (209) command is now wired up: it queues the `RPG::MoveRoute` packed
+  into the command for its target — the player, "this event" or a map event id —
+  and `Scene::Map` drains the queue and drives the target along the route in the
+  background (a forced route overrides page movement until it finishes and does
+  not survive a map change; a forced player route snaps tile-to-tile and
+  suppresses input while active). *Input Number* (103) is implemented too: the
+  interpreter suspends with a `:number` request and `Scene::Map` drives a
+  digit-entry widget (`Game::NumberInput`) whose value is stored into the target
+  variable. Covered by `mruby-rpgxp/test` and driven over the real test bed by
+  `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route targets and
+  the many screen-effect / picture / battle commands (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
   (RPG Maker XP; VX's same-format `Game.rgss2a`) loads: `RPGXP::RGSSAD`
   (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts the version-1 format and

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -117,6 +117,53 @@ class RPGXP
       end
     end
 
+    # Digit-entry model for the Input Number (103) command: a fixed number of
+    # decimal digits with a cursor. Up/down change the digit under the cursor
+    # (wrapping 0..9), left/right move the cursor (clamped). `value` reads the
+    # whole number back. Pure logic so the scene's number widget is unit-testable
+    # without a display.
+    class NumberInput
+      MAX_DIGITS = 8
+
+      attr_reader :digits, :cursor
+
+      def initialize(digits)
+        d = digits.to_i
+        d = 1 if d < 1
+        d = MAX_DIGITS if d > MAX_DIGITS
+        @digits = d
+        @values = Array.new(d, 0)
+        @cursor = 0
+      end
+
+      # The digit shown at position i (0 = most significant, leftmost).
+      def digit(i)
+        @values[i] || 0
+      end
+
+      def inc
+        @values[@cursor] = (@values[@cursor] + 1) % 10
+      end
+
+      def dec
+        @values[@cursor] = (@values[@cursor] + 9) % 10
+      end
+
+      def left
+        @cursor -= 1 if @cursor > 0
+      end
+
+      def right
+        @cursor += 1 if @cursor < @digits - 1
+      end
+
+      def value
+        v = 0
+        @values.each { |d| v = v * 10 + d }
+        v
+      end
+    end
+
     # RPG Maker XP character sheets are a 4x4 grid: four columns (walk patterns)
     # by four rows (facing down/left/right/up, top to bottom). One frame is a
     # quarter of the sheet in each axis.

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -65,6 +65,7 @@ class RPGXP
       WHEN            = 402
       WHEN_CANCEL     = 403
       CHOICES_END     = 404
+      INPUT_NUMBER    = 103
       WAIT            = 106
       COMMENT         = 108
       COMMENT_LINE    = 408
@@ -83,6 +84,7 @@ class RPGXP
       CONTROL_SELF_SW = 123
       CHANGE_GOLD     = 125
       TRANSFER_PLAYER = 201
+      MOVE_ROUTE      = 209
       PLAY_BGM        = 241
       PLAY_BGS        = 245
       PLAY_ME         = 249
@@ -90,6 +92,11 @@ class RPGXP
 
       MAX_STEPS_PER_FRAME = 10_000
       MAX_CALL_DEPTH = 100
+
+      # Set Move Route (209) target codes: RMXP stores -1 for the player and 0 for
+      # "this event"; a positive value is a map event id.
+      MOVE_TARGET_PLAYER = -1
+      MOVE_TARGET_THIS   = 0
 
       def initialize(state)
         @state = state
@@ -101,7 +108,7 @@ class RPGXP
       # resolver#common_event_list(id) -> the command list of a common event.
       attr_accessor :resolver
       attr_reader :wait_kind, :message_lines, :choice_labels, :choice_cancel,
-                  :wait_frames, :teleport
+                  :wait_frames, :teleport, :input_variable, :input_digits
 
       def running?; @running; end
       def waiting?; @waiting; end
@@ -114,6 +121,7 @@ class RPGXP
         @map_id = map_id
         @event_id = event_id
         @call_stack = []
+        @move_route_requests = []
         @running = true
         reset_waits
         self
@@ -123,8 +131,21 @@ class RPGXP
         @list = []
         @index = 0
         @call_stack = []
+        @move_route_requests = []
         @running = false
         reset_waits
+      end
+
+      # Drain the Set Move Route (209) requests queued since the last call,
+      # returning them (each a hash: target -> :player or an event id, route ->
+      # the RPG::MoveRoute) and clearing the queue. Unlike a message / wait /
+      # teleport, a Move Route does not suspend the interpreter — the route runs
+      # in the background — so the owning Scene::Map polls this after each #update
+      # and applies the routes to the target characters.
+      def take_move_route_requests
+        reqs = @move_route_requests || []
+        @move_route_requests = []
+        reqs
       end
 
       # Advance until the list finishes or a UI request suspends us. Runs at most
@@ -155,6 +176,14 @@ class RPGXP
         update
       end
 
+      # Resume an Input Number request: store the entered `value` into the target
+      # variable and continue running the list.
+      def resume_number(value)
+        variables[@input_variable] = value.to_i if @input_variable
+        reset_waits
+        update
+      end
+
       # Resume a choice: `index` is the chosen option (or the cancel index).
       def choose(index)
         list = @list
@@ -172,6 +201,7 @@ class RPGXP
         @index = 0
         @running = false
         @call_stack = []
+        @move_route_requests = []
         reset_waits
       end
 
@@ -183,6 +213,8 @@ class RPGXP
         @choice_cancel = nil
         @wait_frames = 0
         @teleport = nil
+        @input_variable = nil
+        @input_digits = nil
       end
 
       def switches;  @state.switches;  end
@@ -192,6 +224,7 @@ class RPGXP
         case cmd.code
         when SHOW_TEXT       then do_show_text(cmd)
         when SHOW_CHOICES    then do_show_choices(cmd)
+        when INPUT_NUMBER    then do_input_number(cmd)
         when WHEN, WHEN_CANCEL then skip_past_choices(cmd) # fell through a branch
         when CHOICES_END, BRANCH_END, LABEL, COMMENT, COMMENT_LINE,
              TEXT_LINE, 0
@@ -210,6 +243,7 @@ class RPGXP
         when CONTROL_SELF_SW then do_control_self_switch(cmd)
         when CHANGE_GOLD     then do_change_gold(cmd)
         when TRANSFER_PLAYER then do_transfer(cmd)
+        when MOVE_ROUTE      then do_move_route(cmd)
         when PLAY_BGM        then do_play(cmd, :bgm)
         when PLAY_BGS        then do_play(cmd, :bgs)
         when PLAY_ME         then do_play(cmd, :me)
@@ -309,6 +343,18 @@ class RPGXP
       # just past the choice block's 404.
       def skip_past_choices(cmd)
         skip_to_after([CHOICES_END], cmd.indent)
+      end
+
+      # Input Number (103): [variable_id, digits]. Suspends with a :number request
+      # the scene answers by driving a digit-entry widget and calling
+      # `resume_number` with the value, which stores it into the variable.
+      def do_input_number(cmd)
+        @input_variable = param(cmd, 0)
+        digits = param(cmd, 1, 1).to_i
+        @input_digits = digits < 1 ? 1 : digits
+        @wait_kind = :number
+        @waiting = true
+        @index += 1
       end
 
       def do_wait(cmd)
@@ -493,6 +539,26 @@ class RPGXP
         @wait_kind = :teleport
         @waiting = true
         @index += 1
+      end
+
+      # Set Move Route (209): [target, RPG::MoveRoute]. Queues a forced route for
+      # the target (the player, this event, or a map event id) without pausing —
+      # the scene drains the queue and drives the route in the background. A route
+      # aimed at "this event" from a common event with no event context, or with
+      # no route object, is dropped.
+      def do_move_route(cmd)
+        target = param(cmd, 0)
+        route = param(cmd, 1)
+        @index += 1
+        return unless route
+        resolved =
+          case target
+          when MOVE_TARGET_PLAYER then :player
+          when MOVE_TARGET_THIS   then @event_id
+          else target
+          end
+        return if resolved.nil?
+        @move_route_requests << { target: resolved, route: route }
       end
 
       def do_play(cmd, kind)

--- a/mruby-rpgxp/mrblib/rgssad.rb
+++ b/mruby-rpgxp/mrblib/rgssad.rb
@@ -3,8 +3,8 @@
 # A released RPG Maker XP game usually ships its whole Data/ (and Graphics/,
 # Audio/, ...) tree packed into a single encrypted `Game.rgssad`, with no loose
 # files on disk. RPG Maker VX packs the same "version 1" format under the name
-# `Game.rgss2a`. (VX Ace's `Game.rgss3a` is a different, version-3 layout and is
-# not handled yet.)
+# `Game.rgss2a`. VX Ace ships a different, version-3 layout as `Game.rgss3a`;
+# both are handled here.
 #
 # The v1 format is a header — "RGSSAD\0" plus a version byte — followed by a flat
 # list of entries, each one: a 32-bit name length, the name (with '\' path
@@ -18,6 +18,16 @@
 #   * the file data XORs the four little-endian key bytes, advancing the key
 #     every four bytes, seeded from the key value in force right after the
 #     entry's size field.
+#
+# The v3 (`.rgss3a`) format instead stores a single base key in the header (a
+# plaintext 32-bit seed at offset 8, from which `key = seed * 9 + 3`), then a
+# table of fixed-shape entry records — offset, size, per-file data key, name
+# length, name — terminated by a record whose offset decrypts to 0. Every record
+# integer XORs the *same* base key's four little-endian bytes (the key does not
+# advance while walking the table), and each name byte XORs the key byte at its
+# position mod 4. The file data at `offset` is decrypted exactly as in v1 but
+# seeded with the record's own per-file key, so the same `decrypt_data` serves
+# both versions.
 #
 # Implemented with byte-wise arithmetic only — no bignum bitwise operators, no
 # `Integer#chr` / String-ext helpers — so it runs on this trimmed mruby the same
@@ -85,6 +95,68 @@ class RPGXP
       out.pack("C*")
     end
 
+    # Build a version-3 (`.rgss3a`) archive from `files` ([name, bytes] pairs).
+    # The inverse of parse_v3 — used to repack a project and as the v3 test
+    # fixture builder. `seed` is the plaintext base seed stored in the header.
+    def self.pack_v3(files, seed = 0xCAFECAFE)
+      key = (seed * 9 + 3) % MASK
+      # Precompute name bytes and give each file a distinct per-file data key.
+      entries = []
+      files.each_with_index do |(name, bytes), i|
+        entries << { name: arch_name_bytes(name), bytes: bytes,
+                     magic: (0x11111111 * (i + 1)) % MASK }
+      end
+      # The data region begins after the whole entry table (records + a 4-byte
+      # zero-offset terminator); assign each file a slot there in order.
+      table_size = 4
+      entries.each { |e| table_size += 16 + e[:name].size }
+      pos = 12 + table_size
+      entries.each { |e| e[:offset] = pos; pos += e[:bytes].bytesize }
+
+      out = [0x52, 0x47, 0x53, 0x53, 0x41, 0x44, 0x00, 0x03] # "RGSSAD\0" + v3
+      b = 0
+      while b < 4 # plaintext seed, little-endian
+        out << ((seed / POW[b]) % 256)
+        b += 1
+      end
+      put_int = lambda do |v|
+        c = 0
+        while c < 4
+          out << (((v / POW[c]) % 256) ^ ((key / POW[c]) % 256))
+          c += 1
+        end
+      end
+      entries.each do |e|
+        put_int.call(e[:offset])
+        put_int.call(e[:bytes].bytesize)
+        put_int.call(e[:magic])
+        put_int.call(e[:name].size)
+        j = 0
+        while j < e[:name].size
+          out << (e[:name][j] ^ ((key / POW[j % 4]) % 256))
+          j += 1
+        end
+      end
+      put_int.call(0) # terminator: an offset that decrypts to 0
+      entries.each do |e|
+        bytes = e[:bytes]
+        dkey = e[:magic]
+        j = 0
+        idx = 0
+        n = bytes.bytesize
+        while idx < n
+          if j == 4
+            dkey = (dkey * 7 + 3) % MASK
+            j = 0
+          end
+          out << (bytes.getbyte(idx) ^ ((dkey / POW[j]) % 256))
+          j += 1
+          idx += 1
+        end
+      end
+      out.pack("C*")
+    end
+
     # A name's bytes with '/' rewritten to '\' (works without String#tr).
     def self.arch_name_bytes(name)
       bytes = []
@@ -107,9 +179,12 @@ class RPGXP
       case @version
       when 1
         parse_v1
+      when 3
+        parse_v3
       else
         raise "unsupported RGSSAD version #{@version} " \
-              "(only version 1 — .rgssad / .rgss2a — is supported)"
+              "(only versions 1 — .rgssad / .rgss2a — and 3 — .rgss3a — " \
+              "are supported)"
       end
     end
 
@@ -165,6 +240,17 @@ class RPGXP
       v
     end
 
+    # Read a plain (un-obfuscated) 32-bit little-endian integer at `i`.
+    def read_plain_int(i)
+      v = 0
+      b = 0
+      while b < 4
+        v += @data.getbyte(i + b) * POW[b]
+        b += 1
+      end
+      v
+    end
+
     def parse_v1
       key = START_KEY
       i = 8
@@ -191,6 +277,37 @@ class RPGXP
 
         @entries[name_bytes.pack("C*")] = { offset: i, size: size, key: key }
         i += size
+      end
+    end
+
+    # Parse the v3 (`.rgss3a`) entry table. The base key comes from the plaintext
+    # header seed and stays fixed while walking the records; each record carries
+    # its data's absolute offset, size and per-file key, so unlike v1 the records
+    # live together up front and the data blocks follow. Terminated by a record
+    # whose offset field decrypts to 0.
+    def parse_v3
+      key = (read_plain_int(8) * 9 + 3) % MASK
+      i = 12
+      len = @data.bytesize
+      while i + 16 <= len
+        offset = read_int(i, key)
+        break if offset == 0 # terminator record
+        size = read_int(i + 4, key)
+        file_key = read_int(i + 8, key)
+        nlen = read_int(i + 12, key)
+        i += 16
+        break if nlen <= 0 || i + nlen > len
+
+        name_bytes = []
+        j = 0
+        while j < nlen
+          name_bytes << (@data.getbyte(i + j) ^ key_byte(key, j % 4))
+          j += 1
+        end
+        i += nlen
+        next if offset < 0 || offset + size > len
+
+        @entries[name_bytes.pack("C*")] = { offset: offset, size: size, key: file_key }
       end
     end
 

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -368,6 +368,13 @@ class RPGXP
         @rng = Game::Rng.new(0x52584250)
         @world = MapWorld.new(self, @rng)
         @characters = {}
+        # Forced routes from a Set Move Route (209) command, keyed by event id
+        # (kept out of the per-rebuild event entry so they survive page
+        # re-selection); plus the player's forced route mirror.
+        @forced_routes = {}
+        @player_route = nil
+        @player_char = nil
+        @player_route_timer = 0
         build_events
         build_parallels
         setup_sprites
@@ -378,17 +385,21 @@ class RPGXP
 
       def dispose
         close_message
+        close_number_input
         [@lower_sprite, @upper_sprite, @player_sprite].each { |s| s.dispose if s }
       end
 
       def update
         if @message
           drive_message
+        elsif @number_input
+          drive_number_input
         elsif @interpreter.running? || @interpreter.waiting?
           drive_interpreter
         else
           unless start_autorun
             step_parallels
+            step_player_route
             step_events
             unless event_busy? # an event-touch may have started a process
               step_movement
@@ -400,7 +411,7 @@ class RPGXP
       end
 
       def event_busy?
-        @message || @interpreter.running? || @interpreter.waiting?
+        @message || @number_input || @interpreter.running? || @interpreter.waiting?
       end
 
       private
@@ -532,7 +543,11 @@ class RPGXP
       def step_event(e)
         return if event_busy?
         ch = e[:char]
-        return unless ch && e[:page]
+        return unless ch
+        # A forced route (Set Move Route) overrides page movement until it is done.
+        forced = @forced_routes[e[:id]]
+        return step_forced_event(e, ch, forced) if forced
+        return unless e[:page]
         e[:move_timer] -= 1
         return if e[:move_timer] > 0
         e[:move_timer] = EVENT_MOVE_DELAY[ch.move_frequency] || 30
@@ -547,6 +562,79 @@ class RPGXP
         reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
       rescue StandardError => ex
         $stderr.puts "[RGSS] event ##{e[:id]} movement failed: #{ex.message}"
+      end
+
+      # Advance an event's forced route one paced step, updating its occupied
+      # tile, and drop the route once a non-repeating one is exhausted.
+      def step_forced_event(e, ch, forced)
+        forced[:timer] -= 1
+        return if forced[:timer] > 0
+        forced[:timer] = EVENT_MOVE_DELAY[ch.move_frequency] || 30
+        ox = ch.x
+        oy = ch.y
+        forced[:route].step(ch, @world) unless forced[:route].done?
+        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
+        @forced_routes.delete(e[:id]) if forced[:route].done?
+      rescue StandardError => ex
+        $stderr.puts "[RGSS] event ##{e[:id]} forced move failed: #{ex.message}"
+        @forced_routes.delete(e[:id])
+      end
+
+      # Apply the Set Move Route requests an interpreter queued this frame. The
+      # interpreter has already resolved each target to :player or an event id.
+      def apply_move_requests(interp)
+        reqs = interp.take_move_route_requests
+        return if reqs.nil? || reqs.empty?
+        reqs.each { |r| apply_move_request(r) }
+      rescue StandardError => e
+        $stderr.puts "[RGSS] Set Move Route apply failed: #{e.message}"
+      end
+
+      def apply_move_request(r)
+        route = Game::MoveRoute.from_page(r[:route])
+        return unless route
+        if r[:target] == :player
+          start_player_route(route)
+        else
+          force_event_route(r[:target], route)
+        end
+      end
+
+      # Give a map event a forced route, overriding its page movement until the
+      # route finishes (a repeating route runs until replaced). It steps on the
+      # next frame, paced by the event's own move frequency.
+      def force_event_route(id, route)
+        return unless @characters[id]
+        @forced_routes[id] = { route: route, timer: 0 }
+      end
+
+      # Drive the player along a forced route: the player has no Game::Character,
+      # so mirror one, step it against the map world and write the tile back to
+      # the state. Forced player steps snap tile-to-tile (no pixel interpolation)
+      # and suppress input movement while active.
+      def start_player_route(route)
+        @player_char = Game::Character.new(@state.x, @state.y, @state.direction)
+        @player_route = route
+        @player_route_timer = 0
+      end
+
+      def step_player_route
+        return unless @player_route
+        @player_route_timer -= 1
+        return if @player_route_timer > 0
+        @player_route_timer = EVENT_MOVE_DELAY[@player_char.move_frequency] || 30
+        @player_route.step(@player_char, @world) unless @player_route.done?
+        @state.x = @player_char.x
+        @state.y = @player_char.y
+        @state.direction = @player_char.direction
+        @dest_x = @state.x
+        @dest_y = @state.y
+        @moving = false
+        @move_count = 0
+        @player_route = nil if @player_route.done?
+      rescue StandardError => e
+        $stderr.puts "[RGSS] player forced move failed: #{e.message}"
+        @player_route = nil
       end
 
       # Move an autonomous event one step in `dir`. Walking into the player fires
@@ -590,11 +678,13 @@ class RPGXP
           case @interpreter.wait_kind
           when :message  then open_message(@interpreter.message_lines, false)
           when :choice   then open_message(@interpreter.choice_labels, true)
+          when :number   then open_number_input(@interpreter.input_digits)
           when :wait     then drive_wait
           when :teleport then perform_teleport(@interpreter.teleport)
           end
         else
           @interpreter.update
+          apply_move_requests(@interpreter)
           finish_event unless @interpreter.running? || @interpreter.waiting?
         end
       end
@@ -640,9 +730,11 @@ class RPGXP
           end
         elsif it.running?
           it.update
+          apply_move_requests(it)
         else
           it.start(p[:list], @state.map_id, p[:id]) # loop the process
           it.update
+          apply_move_requests(it)
         end
       rescue StandardError
         nil
@@ -664,6 +756,9 @@ class RPGXP
         @dest_y = y
         @last_frame = nil
         @characters = {} # new map: events start at their spawn tiles
+        @forced_routes = {} # forced routes do not survive a map change
+        @player_route = nil
+        @player_char = nil
         build_events
         build_parallels
       rescue StandardError => e
@@ -748,6 +843,70 @@ class RPGXP
         @message = nil
       end
 
+      # -- number input (Input Number command) --------------------------------
+
+      # Open a digit-entry window for the Input Number (103) command. A compact
+      # centred panel shows `digits` boxes with a cursor the player edits.
+      def open_number_input(digits)
+        return if @number_input
+        model = Game::NumberInput.new(digits || 1)
+        cell = 28
+        w = model.digits * cell + Panel::BORDER * 2 + 8
+        h = MSG_LINE_H + Panel::BORDER * 2
+        win = Panel.new((SCREEN_W - w) / 2, SCREEN_H - h - 80, w, h, load_windowskin)
+        win.z = 320
+        contents = Bitmap.new(win.inner_width, win.inner_height)
+        @number_input = { window: win, contents: contents, model: model, cell: cell }
+        draw_number_input
+      end
+
+      def draw_number_input
+        ni = @number_input
+        return unless ni
+        model = ni[:model]
+        c = ni[:contents]
+        c.clear
+        c.font.color = Color.new(255, 255, 255, 255)
+        cell = ni[:cell]
+        (0...model.digits).each do |i|
+          x = 4 + i * cell
+          if i == model.cursor
+            c.fill_rect x, 2, cell - 4, MSG_LINE_H - 2, Color.new(40, 72, 200, 160)
+          end
+          c.draw_text x, 2, cell - 4, MSG_LINE_H - 4, model.digit(i).to_s, 1
+        end
+        ni[:window].contents = c
+      end
+
+      def drive_number_input
+        ni = @number_input
+        model = ni[:model]
+        if Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+          model.inc
+          draw_number_input
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+          model.dec
+          draw_number_input
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
+          model.left
+          draw_number_input
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
+          model.right
+          draw_number_input
+        elsif Input.trigger?(Input::C)
+          value = model.value
+          close_number_input
+          @interpreter.resume_number(value)
+          drive_after_message
+        end
+      end
+
+      def close_number_input
+        return unless @number_input
+        @number_input[:window].dispose
+        @number_input = nil
+      end
+
       def list_nonempty?(list)
         list && list.any? { |c| c.code != 0 }
       end
@@ -786,6 +945,7 @@ class RPGXP
           return
         end
 
+        return if @player_route # a forced route controls the player
         dir = Input.dir4
         return if dir == 0
 

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -128,6 +128,34 @@ assert "Game::CharSet frame geometry (4x4 sheet)" do
   assert_equal 0, r0.y
 end
 
+assert "Game::NumberInput edits digits and reads the value back" do
+  ni = RPGXP::Game::NumberInput.new(3)
+  assert_equal 3, ni.digits
+  assert_equal 0, ni.cursor
+  assert_equal 0, ni.value
+
+  ni.inc                     # leftmost digit -> 1
+  ni.right                   # move to middle
+  ni.inc; ni.inc            # middle -> 2
+  ni.right                   # rightmost
+  ni.inc; ni.inc; ni.inc; ni.inc; ni.inc # -> 5
+  assert_equal 125, ni.value
+
+  # Down wraps 0 -> 9; cursor clamps at both ends.
+  z = RPGXP::Game::NumberInput.new(2)
+  z.dec                      # 0 -> 9
+  assert_equal 90, z.value
+  z.left                     # already at 0: no move
+  assert_equal 0, z.cursor
+  z.right; z.right           # clamps at the last digit
+  assert_equal 1, z.cursor
+
+  # Digit count is clamped to a sane range.
+  assert_equal 1, RPGXP::Game::NumberInput.new(0).digits
+  assert_equal RPGXP::Game::NumberInput::MAX_DIGITS,
+               RPGXP::Game::NumberInput.new(99).digits
+end
+
 assert "Game::State save/load round-trip" do
   db = FakeDB.new(actors: [nil, "a1", "a2"])
   state = RPGXP::Game::State.new(db, [1, 2], 5, 9, 7, 4)
@@ -371,6 +399,81 @@ assert "Interpreter: transfer player surfaces a teleport request" do
   assert_true it.waiting?
   assert_equal :teleport, it.wait_kind
   assert_equal [3, 8, 9, 2], it.teleport
+end
+
+# Build an RPG::MoveRoute (list of MoveCommands + repeat/skippable flags).
+def move_route(list, repeat = false, skippable = false)
+  r = RPG::MoveRoute.new
+  r.list = list
+  r.repeat = repeat
+  r.skippable = skippable
+  r
+end
+
+assert "Interpreter: set move route queues a request without pausing" do
+  s = new_state
+  route = move_route([mv(1)]) # Move Down
+  it = RPGXP::Game::Interpreter.new(s)
+  it.start([
+    cmd(209, [-1, route], 0),      # Set Move Route -> player
+    cmd(121, [5, 5, 0], 0)         # then switch 5 ON (proves it did not pause)
+  ], 1, 7)
+  it.update
+  assert_false it.waiting?          # a move route does not suspend the interpreter
+  assert_true s.switches[5]         # ran the command after it
+  reqs = it.take_move_route_requests
+  assert_equal 1, reqs.size
+  assert_equal :player, reqs[0][:target]
+  assert_equal route, reqs[0][:route]
+  # Draining empties the queue.
+  assert_true it.take_move_route_requests.empty?
+end
+
+assert "Interpreter: set move route resolves the target" do
+  s = new_state
+  # Target 0 ("this event") resolves to the running event id (7).
+  it = RPGXP::Game::Interpreter.new(s)
+  it.start([cmd(209, [0, move_route([mv(4)])], 0)], 1, 7)
+  it.update
+  reqs = it.take_move_route_requests
+  assert_equal 1, reqs.size
+  assert_equal 7, reqs[0][:target]
+
+  # A positive id passes straight through.
+  it2 = RPGXP::Game::Interpreter.new(s)
+  it2.start([cmd(209, [3, move_route([mv(4)])], 0)], 1, 7)
+  it2.update
+  assert_equal 3, it2.take_move_route_requests[0][:target]
+
+  # "This event" from a common event with no event context is dropped.
+  it3 = RPGXP::Game::Interpreter.new(s)
+  it3.start([cmd(209, [0, move_route([mv(4)])], 0)], 1, nil)
+  it3.update
+  assert_true it3.take_move_route_requests.empty?
+
+  # A request with no route object is dropped.
+  it4 = RPGXP::Game::Interpreter.new(s)
+  it4.start([cmd(209, [-1, nil], 0)], 1, 7)
+  it4.update
+  assert_true it4.take_move_route_requests.empty?
+end
+
+assert "Interpreter: input number surfaces a request and stores the result" do
+  s = new_state
+  it = RPGXP::Game::Interpreter.new(s)
+  it.start([
+    cmd(103, [4, 3], 0),           # input into variable 4, 3 digits
+    cmd(121, [1, 1, 0], 0)         # then switch 1 ON
+  ], 1, 7)
+  it.update
+  assert_true it.waiting?
+  assert_equal :number, it.wait_kind
+  assert_equal 4, it.input_variable
+  assert_equal 3, it.input_digits
+  it.resume_number(275)
+  assert_equal 275, s.variables[4]  # stored into the variable
+  assert_true s.switches[1]         # resumed past the input command
+  assert_false it.running?
 end
 
 # ---- RGSSAD encrypted archive reader --------------------------------------

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -516,9 +516,43 @@ end
 
 assert "RGSSAD rejects a bad header and an unsupported version" do
   assert_raise(RuntimeError) { RPGXP::RGSSAD.new("NOTRGSS\x01") }
-  # A version-3 (.rgss3a) header is recognised but not yet supported.
-  v3 = "RGSSAD\x00\x03rest"
-  assert_raise(RuntimeError) { RPGXP::RGSSAD.new(v3) }
+  # An unknown version (only 1 and 3 are supported) is rejected.
+  v4 = "RGSSAD\x00\x04rest"
+  assert_raise(RuntimeError) { RPGXP::RGSSAD.new(v4) }
+end
+
+assert "RGSSAD v3 (.rgss3a) round-trips entries" do
+  files = [
+    ["Data\\System.rxdata", "sys\x00\x01\xfe\xff data"],
+    ["Data\\Map001.rxdata", (("A".."Z").to_a.join) * 100], # spans 4-byte key steps
+    ["Graphics\\Titles\\001-Title01.png", "\x89PNG\r\n\x1a\n"]
+  ]
+  archive = RPGXP::RGSSAD.pack_v3(files)
+  a = RPGXP::RGSSAD.new(archive)
+
+  assert_equal 3, a.version
+  assert_equal 3, a.names.size
+  files.each do |name, data|
+    assert_equal data.bytes, a.read(name).bytes
+  end
+  # '/'-style lookups normalise to the archive's '\' names.
+  assert_equal files[0][1].bytes, a.read("Data/System.rxdata").bytes
+  assert_true a.include?("Data/Map001.rxdata")
+  assert_false a.include?("Data/Missing.rxdata")
+  assert_true a.read("Data/Missing.rxdata").nil?
+end
+
+assert "RGSSAD v3 carries real Marshal data through the archive" do
+  sys = RPG::System.new
+  sys.title_name = "001-Title01"
+  sys.start_map_id = 7
+  blob = Marshal.dump(sys)
+
+  a = RPGXP::RGSSAD.new(RPGXP::RGSSAD.pack_v3([["Data\\System.rxdata", blob]]))
+  loaded = Marshal.load(a.read("Data\\System.rxdata"))
+  assert_true loaded.is_a?(RPG::System)
+  assert_equal "001-Title01", loaded.title_name
+  assert_equal 7, loaded.start_map_id
 end
 
 # ---- Autonomous event movement: Character / MoveRoute / MoveType -----------

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -401,6 +401,14 @@ assert "Interpreter: transfer player surfaces a teleport request" do
   assert_equal [3, 8, 9, 2], it.teleport
 end
 
+# Build an RPG::MoveCommand (code / parameters).
+def mv(code, params = [])
+  c = RPG::MoveCommand.new
+  c.code = code
+  c.parameters = params
+  c
+end
+
 # Build an RPG::MoveRoute (list of MoveCommands + repeat/skippable flags).
 def move_route(list, repeat = false, skippable = false)
   r = RPG::MoveRoute.new
@@ -556,14 +564,6 @@ assert "RGSSAD v3 carries real Marshal data through the archive" do
 end
 
 # ---- Autonomous event movement: Character / MoveRoute / MoveType -----------
-
-# Build an RPG::MoveCommand (code / parameters).
-def mv(code, params = [])
-  c = RPG::MoveCommand.new
-  c.code = code
-  c.parameters = params
-  c
-end
 
 # World stand-in for the movement engine.
 class FakeWorld

--- a/scripts/rpgxp_testbed_check.rb
+++ b/scripts/rpgxp_testbed_check.rb
@@ -196,6 +196,7 @@ class Checker
       if it.waiting?
         case it.wait_kind
         when :choice then it.choose(0)
+        when :number then it.resume_number(0)
         when :teleport then break
         else it.resume
         end

--- a/scripts/rpgxp_testbed_check.rb
+++ b/scripts/rpgxp_testbed_check.rb
@@ -227,44 +227,51 @@ class Checker
     end
   end
 
-  # Pack the real Data/*.rxdata into an encrypted v1 archive, then load the whole
-  # database back through Game.rgssad and confirm it is identical to the on-disk
-  # load — exercising the RGSSAD reader against real file sizes/contents and the
-  # RGSSData archive fallback end to end.
+  # Pack the real Data/*.rxdata into an encrypted archive, then load the whole
+  # database back through it and confirm it is identical to the on-disk load —
+  # exercising the RGSSAD reader against real file sizes/contents and the
+  # RGSSData archive fallback end to end. Both the v1 (`.rgssad`, XP/VX) and v3
+  # (`.rgss3a`, VX Ace) formats are checked against the same real data.
   def check_archive(dir, disk)
     files = Dir[File.join(dir, "Data", "*.rxdata")].sort.map do |f|
       ["Data\\#{File.basename(f)}", File.binread(f)]
     end
-    archive = RPGXP::RGSSAD.pack_v1(files)
+    check_archive_format(disk, files, 1, "Game.rgssad",
+                         RPGXP::RGSSAD.pack_v1(files))
+    check_archive_format(disk, files, 3, "Game.rgss3a",
+                         RPGXP::RGSSAD.pack_v3(files))
+  rescue => ex
+    fail "#{dir}: archive check raised: #{ex.class}: #{ex.message}"
+  end
 
+  def check_archive_format(disk, files, version, filename, archive)
     # Reading one entry back must reproduce the original bytes exactly.
     reader = RPGXP::RGSSAD.new(archive)
+    expect(reader.version == version, "#{filename}: version is #{reader.version}, not #{version}")
     files.each do |name, bytes|
       got = reader.read(name)
-      expect(got == bytes, "archive entry #{name} did not round-trip byte-for-byte")
+      expect(got == bytes, "#{filename} entry #{name} did not round-trip byte-for-byte")
     end
 
     Dir.mktmpdir do |tmp|
-      File.binwrite(File.join(tmp, "Game.rgssad"), archive)
+      File.binwrite(File.join(tmp, filename), archive)
       File.write(File.join(tmp, "Game.ini"), "[Game]\nTitle=Packed\n")
       packed = RPGXP::RGSSData.new(tmp) # no loose Data/ -> uses the archive
-      expect(packed.archived?, "packed project should report archived?")
+      expect(packed.archived?, "#{filename}: packed project should report archived?")
       expect(packed.system.start_map_id == disk.system.start_map_id,
-             "archived System.start_map_id differs from on-disk")
+             "#{filename}: System.start_map_id differs from on-disk")
       expect(packed.system.title_name == disk.system.title_name,
-             "archived System.title_name differs from on-disk")
+             "#{filename}: System.title_name differs from on-disk")
       expect(packed.actors.compact.size == disk.actors.compact.size,
-             "archived Actors count differs from on-disk")
+             "#{filename}: Actors count differs from on-disk")
       disk.map_infos.each_key do |id|
         pm = packed.load_map(id)
         dm = disk.load_map(id)
         expect(pm.width == dm.width && pm.height == dm.height,
-               "archived Map#{id} dimensions differ from on-disk")
+               "#{filename}: Map#{id} dimensions differ from on-disk")
       end
     end
-    puts "  archive: packed #{files.size} entries; DB loads identically through Game.rgssad"
-  rescue => ex
-    fail "#{dir}: archive check raised: #{ex.class}: #{ex.message}"
+    puts "  archive: packed #{files.size} entries; DB loads identically through #{filename}"
   end
 
   def report


### PR DESCRIPTION
This PR adds support for two RPG Maker XP event commands to the interpreter and scene:

## Summary
Implements the *Set Move Route* (209) command for applying forced movement routes to the player or map events, and the *Input Number* (103) command for digit-entry UI. Both commands are now fully integrated with the interpreter, scene, and event system.

## Key Changes

**Set Move Route (209) Command:**
- `Interpreter#do_move_route` queues move route requests without suspending execution
- Resolves target codes: `-1` for player, `0` for "this event" (with event context), or explicit event IDs
- `Interpreter#take_move_route_requests` drains the queue for the scene to process
- `Scene::Map#apply_move_requests` applies queued routes to their targets
- `Scene::Map#force_event_route` applies a route to a map event, overriding page movement
- `Scene::Map#start_player_route` / `step_player_route` drive the player along a forced route by mirroring a `Game::Character`, snapping tile-to-tile and suppressing input
- Forced routes are paced by the target's move frequency and do not survive map changes
- `Scene::Map#step_forced_event` advances event routes one paced step

**Input Number (103) Command:**
- `Interpreter#do_input_number` suspends with a `:number` wait kind
- `Game::NumberInput` model provides pure digit-entry logic: fixed digit count, movable cursor, up/down wrapping 0–9, left/right cursor movement
- `Scene::Map#open_number_input` / `draw_number_input` / `drive_number_input` / `close_number_input` implement the UI widget
- `Interpreter#resume_number` stores the entered value into the target variable and resumes execution

**Scene Integration:**
- Updated `Scene::Map#update` to drive number input and step player routes
- `event_busy?` now includes number input state
- Move route requests are applied after interpreter and parallel process updates
- Forced routes and player route state are cleared on map transfer

## Notable Implementation Details
- Move routes do not suspend the interpreter (unlike messages/waits/teleports), allowing commands after a Set Move Route to execute immediately
- The player's forced route uses a mirrored `Game::Character` to leverage existing movement logic against the map world
- `Game::NumberInput` is a pure model class, making it unit-testable without display dependencies
- Comprehensive test coverage added for move-route queueing, target resolution, and number-input digit manipulation

https://claude.ai/code/session_01Dm3JmLxiKEerTubStiXX1N