### PR TITLE
Add additive blend mode support for Canvas2D 'lighter' composite

### DIFF
--- a/changelog.d/mv-additive-blend.added.md
+++ b/changelog.d/mv-additive-blend.added.md
@@ -1,0 +1,8 @@
+- MV additive blend mode: the Canvas2D bridge now honours
+  `ctx.globalCompositeOperation = 'lighter'` (PIXI's ADD blend) on `fillRect`
+  and `drawImage`, adding the source into the destination and clamping instead
+  of always compositing source-over. MV drives this for battle-animation
+  flashes, weather and glow sprites, which previously rendered too dark. The
+  native blend (`mruby-mvjs/src/mvcanvas.cxx`) gained an additive path selected
+  by a composite-op mode threaded through from the context; the mapping is
+  unit-tested (`mruby-mvjs/test/canvas_test.rb`).

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -193,6 +193,29 @@ void blend(uint8_t* d, int r, int g, int b, int a) {
   d[3] = static_cast<uint8_t>((a * 255 + d[3] * ia) / 255);
 }
 
+// Additive ("lighter") blend: the source, scaled by its coverage `a`, is added
+// to the destination and clamped. This is canvas globalCompositeOperation =
+// 'lighter' (PIXI blendMode ADD), which MV uses for battle-animation flashes,
+// weather and glow sprites; under plain source-over those effects come out too
+// dark.
+void blend_add(uint8_t* d, int r, int g, int b, int a) {
+  if (a <= 0)
+    return;
+  d[0] = static_cast<uint8_t>(std::min(255, d[0] + r * a / 255));
+  d[1] = static_cast<uint8_t>(std::min(255, d[1] + g * a / 255));
+  d[2] = static_cast<uint8_t>(std::min(255, d[2] + b * a / 255));
+  d[3] = static_cast<uint8_t>(std::min(255, d[3] + a));
+}
+
+// Dispatch to the source-over or additive blend based on a composite-op mode
+// (0 = source-over, 1 = lighter/additive) threaded through from the Ctx.
+inline void blend_mode(uint8_t* d, int r, int g, int b, int a, int mode) {
+  if (mode == 1)
+    blend_add(d, r, g, b, a);
+  else
+    blend(d, r, g, b, a);
+}
+
 int ai(JSContext* ctx, int argc, JSValueConst* argv, int i) {
   int32_t v = 0;
   if (i < argc)
@@ -233,7 +256,9 @@ JSValue js_height(JSContext* ctx, JSValueConst, int argc, JSValueConst* argv) {
   return JS_NewInt32(ctx, c ? c->h : 0);
 }
 
-// __mv_canvasFillRect(handle, x, y, w, h, r, g, b, a)
+// __mv_canvasFillRect(handle, x, y, w, h, r, g, b, a, mode)
+// `mode` (optional, default 0) selects the composite op: 0 = source-over,
+// 1 = lighter/additive.
 JSValue js_fill_rect(JSContext* ctx,
                      JSValueConst,
                      int argc,
@@ -245,6 +270,7 @@ JSValue js_fill_rect(JSContext* ctx,
   int rw = ai(ctx, argc, argv, 3), rh = ai(ctx, argc, argv, 4);
   const int r = ai(ctx, argc, argv, 5), g = ai(ctx, argc, argv, 6);
   const int b = ai(ctx, argc, argv, 7), a = ai(ctx, argc, argv, 8);
+  const int mode = argc > 9 ? ai(ctx, argc, argv, 9) : 0;
   for (int j = 0; j < rh; ++j) {
     const int ty = y + j;
     if (ty < 0 || ty >= c->h)
@@ -253,7 +279,8 @@ JSValue js_fill_rect(JSContext* ctx,
       const int tx = x + i;
       if (tx < 0 || tx >= c->w)
         continue;
-      blend(&c->px[(static_cast<size_t>(ty) * c->w + tx) * 4], r, g, b, a);
+      blend_mode(&c->px[(static_cast<size_t>(ty) * c->w + tx) * 4], r, g, b, a,
+                 mode);
     }
   }
   return JS_UNDEFINED;
@@ -285,7 +312,7 @@ JSValue js_clear_rect(JSContext* ctx,
 }
 
 // __mv_canvasDrawImage(dstH, srcH, sx, sy, sw, sh, dx, dy, dw, dh, alpha,
-//                      a, b, c, d, e, f)
+//                      a, b, c, d, e, f, mode)
 // Nearest-neighbour blit of a source rect into a dest rect, modulated by a
 // global alpha (0-255) and transformed by the current 2D matrix
 // [a b c d e f] (device = (a*u+c*v+e, b*u+d*v+f)). This is the workhorse PIXI's
@@ -311,6 +338,7 @@ JSValue js_draw_image(JSContext* ctx,
   const double ma = ad(ctx, argc, argv, 11, 1), mb = ad(ctx, argc, argv, 12, 0);
   const double mc = ad(ctx, argc, argv, 13, 0), md = ad(ctx, argc, argv, 14, 1);
   const double me = ad(ctx, argc, argv, 15, 0), mf = ad(ctx, argc, argv, 16, 0);
+  const int mode = argc > 17 ? ai(ctx, argc, argv, 17) : 0;
   if (dw <= 0 || dh <= 0 || sw <= 0 || sh <= 0)
     return JS_UNDEFINED;
   const double det = ma * md - mb * mc;
@@ -354,8 +382,8 @@ JSValue js_draw_image(JSContext* ctx,
       const uint8_t* sp =
           &src->px[(static_cast<size_t>(syy) * src->w + sxx) * 4];
       const int a = sp[3] * ga / 255;
-      blend(&dst->px[(static_cast<size_t>(py) * dst->w + px) * 4], sp[0], sp[1],
-            sp[2], a);
+      blend_mode(&dst->px[(static_cast<size_t>(py) * dst->w + px) * 4], sp[0],
+                 sp[1], sp[2], a, mode);
     }
   }
   return JS_UNDEFINED;
@@ -749,7 +777,9 @@ const char* kCanvasPreamble = R"MVJS(
     var c = parseColor(fs);
     var a = Math.round(c[3] * this.globalAlpha);
     var r = mapRect(this._m, x, y, w, h);
-    g.__mv_canvasFillRect(this.__h, r[0], r[1], r[2], r[3], c[0], c[1], c[2], a);
+    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
+    g.__mv_canvasFillRect(this.__h, r[0], r[1], r[2], r[3], c[0], c[1], c[2], a,
+                          mode);
   };
   // Fill a rect with a gradient fillStyle. The rect and the gradient axis are
   // both mapped through the current transform to device space, then the native
@@ -799,8 +829,9 @@ const char* kCanvasPreamble = R"MVJS(
     }
     var a = Math.round(this.globalAlpha * 255);
     var m = this._m;
+    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
     g.__mv_canvasDrawImage(this.__h, h, sx, sy, sw, sh, dx, dy, dw, dh, a,
-                           m[0], m[1], m[2], m[3], m[4], m[5]);
+                           m[0], m[1], m[2], m[3], m[4], m[5], mode);
   };
   Ctx.prototype.getImageData = function (x, y, w, h) {
     w = w | 0; h = h | 0;
@@ -1083,9 +1114,9 @@ void mv_install_canvas(JSContext* ctx) {
   install(ctx, global, "__mv_canvasResize", js_resize, 3);
   install(ctx, global, "__mv_canvasWidth", js_width, 1);
   install(ctx, global, "__mv_canvasHeight", js_height, 1);
-  install(ctx, global, "__mv_canvasFillRect", js_fill_rect, 9);
+  install(ctx, global, "__mv_canvasFillRect", js_fill_rect, 10);
   install(ctx, global, "__mv_canvasClearRect", js_clear_rect, 5);
-  install(ctx, global, "__mv_canvasDrawImage", js_draw_image, 17);
+  install(ctx, global, "__mv_canvasDrawImage", js_draw_image, 18);
   install(ctx, global, "__mv_canvasGetPixel", js_get_pixel, 3);
   install(ctx, global, "__mv_canvasDrawText", js_draw_text, 17);
   install(ctx, global, "__mv_canvasFillGradient", js_fill_gradient, 15);

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -145,6 +145,51 @@ assert 'MV canvas scale enlarges a drawImage blit' do
   assert_equal "0,0,0,0", MV::JS.eval("__mv_canvasGetPixel(SD.__h,2,2).join(',')")
 end
 
+assert "MV canvas globalCompositeOperation 'lighter' adds fills (additive blend)" do
+  # MV sets ctx.globalCompositeOperation='lighter' for battle-animation flashes,
+  # weather and glow sprites. The second fill must add to the first, not replace
+  # it: 0x30+0x10 red, 0x00+0x10 green/blue; alpha stays opaque.
+  MV::JS.eval("globalThis.L=document.createElement('canvas'); L.width=2; L.height=2; " \
+              "var x=L.getContext('2d'); x.globalAlpha=1; " \
+              "x.globalCompositeOperation='source-over'; x.fillStyle='#300000'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='lighter'; x.fillStyle='#101010'; x.fillRect(0,0,2,2);")
+  assert_equal "64,16,16,255", MV::JS.eval("__mv_canvasGetPixel(L.__h,0,0).join(',')")
+end
+
+assert "MV canvas 'lighter' clamps additive fills at 255" do
+  MV::JS.eval("var x=L.getContext('2d'); x.globalCompositeOperation='source-over'; " \
+              "x.fillStyle='#f0f0f0'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='lighter'; x.fillStyle='#303030'; x.fillRect(0,0,2,2);")
+  assert_equal "255,255,255,255", MV::JS.eval("__mv_canvasGetPixel(L.__h,0,0).join(',')")
+end
+
+assert "MV canvas 'lighter' drawImage adds the source over the dest" do
+  # An opaque green source additively drawn over an opaque red dest -> yellow.
+  MV::JS.eval("globalThis.LS=document.createElement('canvas'); LS.width=2; LS.height=2; " \
+              "var s=LS.getContext('2d'); s.fillStyle='#00ff00'; s.fillRect(0,0,2,2); " \
+              "globalThis.LD=document.createElement('canvas'); LD.width=2; LD.height=2; " \
+              "var d=LD.getContext('2d'); d.fillStyle='#ff0000'; d.fillRect(0,0,2,2); " \
+              "d.globalCompositeOperation='lighter'; d.drawImage(LS,0,0);")
+  assert_equal "255,255,0,255", MV::JS.eval("__mv_canvasGetPixel(LD.__h,0,0).join(',')")
+end
+
+assert 'MV canvas default composite still overwrites on drawImage (source-over)' do
+  # Regression: with no 'lighter' the blit replaces rather than adds.
+  MV::JS.eval("var d=LD.getContext('2d'); d.globalCompositeOperation='source-over'; " \
+              "d.fillStyle='#ff0000'; d.fillRect(0,0,2,2); " \
+              "globalThis.LS2=document.createElement('canvas'); LS2.width=2; LS2.height=2; " \
+              "var s=LS2.getContext('2d'); s.fillStyle='#00ff00'; s.fillRect(0,0,2,2); " \
+              "d.drawImage(LS2,0,0);")
+  assert_equal "0,255,0,255", MV::JS.eval("__mv_canvasGetPixel(LD.__h,0,0).join(',')")
+end
+
+assert 'MV canvas save/restore round-trips globalCompositeOperation' do
+  v = MV::JS.eval("var x=document.createElement('canvas').getContext('2d'); " \
+                  "x.save(); x.globalCompositeOperation='lighter'; x.restore(); " \
+                  "x.globalCompositeOperation")
+  assert_equal "source-over", v
+end
+
 assert 'MV canvas translate offsets a fillRect' do
   MV::JS.eval("globalThis.FR=document.createElement('canvas'); FR.width=4; FR.height=4; " \
               "var x=FR.getContext('2d'); x.translate(1,1); x.fillStyle='#0000ff'; x.fillRect(0,0,2,2);")


### PR DESCRIPTION
## Summary
Implements support for the Canvas2D `globalCompositeOperation = 'lighter'` mode in the MV canvas bridge, enabling additive blending for battle-animation flashes, weather effects, and glow sprites that were previously rendering too dark under the default source-over compositing.

## Key Changes
- **New blend function**: Added `blend_add()` that performs additive blending by scaling the source by its alpha and adding to the destination with clamping at 255
- **Blend mode dispatcher**: Introduced `blend_mode()` inline function that routes to either standard source-over or additive blending based on a mode parameter
- **Extended native APIs**: Updated `__mv_canvasFillRect` and `__mv_canvasDrawImage` native functions to accept an optional `mode` parameter (0 = source-over, 1 = lighter/additive)
- **JavaScript integration**: Modified Canvas2D context wrapper to detect `globalCompositeOperation === 'lighter'` and pass the corresponding mode flag to native fill and draw operations
- **Comprehensive tests**: Added 5 new test cases covering additive fills, clamping behavior, additive image drawing, source-over regression, and save/restore round-tripping

## Implementation Details
- The mode parameter is threaded through from the JavaScript context layer down to the pixel-level blending operations
- Additive blending scales source RGB by `(alpha / 255)` before adding to destination, with alpha channel also additively blended and clamped
- The implementation maintains backward compatibility by defaulting to source-over (mode 0) when the parameter is omitted
- All changes are localized to the canvas bridge with no modifications to the broader rendering pipeline

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8