### PR TITLE
Implement Canvas2D putImageData to write pixels back to canvas

### DIFF
--- a/changelog.d/mv-putimagedata.added.md
+++ b/changelog.d/mv-putimagedata.added.md
@@ -1,0 +1,9 @@
+- MV canvas `putImageData`: the Canvas2D bridge now writes pixels back to a
+  canvas instead of ignoring the call. MV's `Bitmap.adjustTone` and
+  `Bitmap.rotateHue` read pixels with `getImageData`, recolour them and commit
+  them via `putImageData`; that write-back was a no-op, so hue-shifted graphics
+  (recoloured enemies/animations) and tone adjustments silently kept their
+  original colours. The new native (`__mv_canvasPutData` in
+  `mruby-mvjs/src/mvcanvas.cxx`) copies the pixels straight in — no source-over
+  blend, no transform, clamped to 0-255 to match a real `ImageData`'s
+  `Uint8ClampedArray`. Unit-tested in `mruby-mvjs/test/canvas_test.rb`.

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -656,6 +656,49 @@ JSValue js_get_pixel(JSContext* ctx,
   return arr;
 }
 
+// __mv_canvasPutData(handle, dx, dy, w, h, data)
+// Write a w*h block of RGBA bytes (a flat [r,g,b,a,...] array as produced by
+// getImageData) into the canvas at (dx, dy). Per the canvas spec putImageData
+// *replaces* pixels (no source-over blend) and ignores the current transform,
+// so this is a straight copy, clipped to the canvas bounds. Values are clamped
+// to 0-255 to mimic the Uint8ClampedArray a real ImageData exposes (our
+// getImageData hands back a plain array, so MV's `pixels[i] += tone` can run
+// out of range). MV drives this from Bitmap.adjustTone / rotateHue, which read
+// the pixels back, recolour them and write them out.
+JSValue js_put_data(JSContext* ctx,
+                    JSValueConst,
+                    int argc,
+                    JSValueConst* argv) {
+  Canvas* c = canvas_get(ai(ctx, argc, argv, 0));
+  if (!c || argc < 6)
+    return JS_UNDEFINED;
+  const int dx = ai(ctx, argc, argv, 1), dy = ai(ctx, argc, argv, 2);
+  const int w = ai(ctx, argc, argv, 3), h = ai(ctx, argc, argv, 4);
+  if (w <= 0 || h <= 0)
+    return JS_UNDEFINED;
+  const std::vector<double> data = js_num_array(ctx, argv[5]);
+  if (data.size() < static_cast<size_t>(w) * h * 4)
+    return JS_UNDEFINED;
+  for (int j = 0; j < h; ++j) {
+    const int ty = dy + j;
+    if (ty < 0 || ty >= c->h)
+      continue;
+    for (int i = 0; i < w; ++i) {
+      const int tx = dx + i;
+      if (tx < 0 || tx >= c->w)
+        continue;
+      const size_t si = (static_cast<size_t>(j) * w + i) * 4;
+      uint8_t* d = &c->px[(static_cast<size_t>(ty) * c->w + tx) * 4];
+      for (int k = 0; k < 4; ++k) {
+        double v = data[si + k];
+        v = v < 0 ? 0 : (v > 255 ? 255 : v);
+        d[k] = static_cast<uint8_t>(v);
+      }
+    }
+  }
+  return JS_UNDEFINED;
+}
+
 // __mv_imageLoad(path) -> a canvas handle holding the decoded image (0 on
 // failure). MV's Bitmap loads PNGs through `new Image()`; we decode them with
 // stb_image (RGBA8) straight into a canvas so the result can be used as a
@@ -844,6 +887,16 @@ const char* kCanvasPreamble = R"MVJS(
     }
     return { width: w, height: h, data: data };
   };
+  // putImageData(imageData, dx, dy): write pixels straight back (no blend, no
+  // transform), the inverse of getImageData. MV uses it in Bitmap.adjustTone and
+  // rotateHue to commit recoloured pixels; the optional dirty-rect args of the
+  // full spec are unused by MV, so only the 3-arg form is handled.
+  Ctx.prototype.putImageData = function (imageData, dx, dy) {
+    if (!imageData || !imageData.data) return;
+    g.__mv_canvasPutData(this.__h, dx | 0, dy | 0,
+                         imageData.width | 0, imageData.height | 0,
+                         imageData.data);
+  };
   // Pixel (em) size from a CSS font shorthand, e.g. '28px GameFont' -> 28.
   function fontPx(s) {
     var m = /([\d.]+)px/.exec(s || '');
@@ -918,7 +971,7 @@ const char* kCanvasPreamble = R"MVJS(
   // — are implemented above and deliberately excluded here.)
   var noops = ['beginPath', 'closePath', 'moveTo', 'lineTo',
     'arc', 'arcTo', 'rect', 'fill', 'stroke', 'clip',
-    'setLineDash', 'putImageData',
+    'setLineDash',
     'drawFocusIfNeeded', 'scrollPathIntoView'];
   noops.forEach(function (m) {
     if (!Ctx.prototype[m]) Ctx.prototype[m] = function () {};
@@ -1118,6 +1171,7 @@ void mv_install_canvas(JSContext* ctx) {
   install(ctx, global, "__mv_canvasClearRect", js_clear_rect, 5);
   install(ctx, global, "__mv_canvasDrawImage", js_draw_image, 18);
   install(ctx, global, "__mv_canvasGetPixel", js_get_pixel, 3);
+  install(ctx, global, "__mv_canvasPutData", js_put_data, 6);
   install(ctx, global, "__mv_canvasDrawText", js_draw_text, 17);
   install(ctx, global, "__mv_canvasFillGradient", js_fill_gradient, 15);
   install(ctx, global, "__mv_fontMeasure", js_measure_text, 2);

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -49,6 +49,34 @@ assert 'MV canvas getImageData reads back a region' do
   assert_equal "1,2,3,255", MV::JS.eval("ID.data.slice(0,4).join(',')")
 end
 
+assert 'MV canvas putImageData writes pixels straight back (getImageData inverse)' do
+  MV::JS.eval("globalThis.PD=document.createElement('canvas'); PD.width=2; PD.height=2; " \
+              "var x=PD.getContext('2d'); x.fillStyle='#00ff00'; x.fillRect(0,0,2,2); " \
+              "var d=x.getImageData(0,0,2,2); " \
+              "for (var i=0;i<d.data.length;i+=4){d.data[i]=10;d.data[i+1]=20;d.data[i+2]=30;d.data[i+3]=255;} " \
+              "x.putImageData(d,0,0);")
+  assert_equal "10,20,30,255", MV::JS.eval("__mv_canvasGetPixel(PD.__h,0,0).join(',')")
+  assert_equal "10,20,30,255", MV::JS.eval("__mv_canvasGetPixel(PD.__h,1,1).join(',')")
+end
+
+assert 'MV canvas putImageData clamps out-of-range channels (adjustTone add)' do
+  # Bitmap.adjustTone does pixels[i] += tone against a plain array, so channels
+  # can exceed 255 / go below 0; putImageData must clamp like a real ImageData's
+  # Uint8ClampedArray. 0x80(128)+200 -> 255, 128-200 -> 0, blue left at 128.
+  MV::JS.eval("var x=PD.getContext('2d'); x.fillStyle='#808080'; x.fillRect(0,0,2,2); " \
+              "var d=x.getImageData(0,0,2,2); " \
+              "for (var i=0;i<d.data.length;i+=4){d.data[i]+=200; d.data[i+1]-=200;} " \
+              "x.putImageData(d,0,0);")
+  assert_equal "255,0,128,255", MV::JS.eval("__mv_canvasGetPixel(PD.__h,0,0).join(',')")
+end
+
+assert 'MV canvas putImageData ignores the current transform (device coords)' do
+  MV::JS.eval("globalThis.PT=document.createElement('canvas'); PT.width=2; PT.height=2; " \
+              "var x=PT.getContext('2d'); x.translate(5,5); " \
+              "x.putImageData({width:1,height:1,data:[7,8,9,255]},0,0);")
+  assert_equal "7,8,9,255", MV::JS.eval("__mv_canvasGetPixel(PT.__h,0,0).join(',')")
+end
+
 # A 2x2 RGBA PNG: pixel (0,0) is opaque red, the other three opaque green.
 MV_IMAGE_PNG =
   "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52" \


### PR DESCRIPTION
## Summary
Implements the Canvas2D `putImageData` method for the MV canvas bridge, enabling pixel write-back functionality that was previously a no-op. This fixes color adjustments in `Bitmap.adjustTone` and `Bitmap.rotateHue` which read pixels, recolor them, and write them back.

## Key Changes
- **Native implementation** (`js_put_data`): Added C++ function that writes RGBA pixel data directly to canvas memory
  - Performs straight pixel copy without source-over blending or transform application
  - Clamps channel values to 0-255 to match `Uint8ClampedArray` behavior
  - Clips writes to canvas bounds
  - Handles out-of-range values from MV's `pixels[i] += tone` operations

- **JavaScript bridge**: Added `putImageData` method to canvas context prototype
  - Accepts `imageData` object with `width`, `height`, and `data` properties
  - Takes destination coordinates `(dx, dy)` in device space
  - Delegates to native `__mv_canvasPutData` function

- **Removed no-op stub**: Deleted `putImageData` from the no-ops list since it now has a real implementation

- **Comprehensive tests**: Added three test cases covering:
  - Basic pixel write-back functionality
  - Channel clamping for out-of-range values (adjustTone scenario)
  - Transform independence (device coordinates)

## Implementation Details
- Pixel data is stored as a flat RGBA array matching `getImageData` output format
- Clipping is performed per-pixel to handle partial writes at canvas edges
- Channel clamping uses saturating arithmetic: `v < 0 ? 0 : (v > 255 ? 255 : v)`
- No-op for invalid inputs (missing canvas, invalid dimensions, insufficient data)

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8