### PR TITLE
Decode per-actor save state (chunk 108) and restore HP/MP on Continue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,11 @@ Create ADRs in /docs/adr for:
     common-event id (505 entries for Nepheshel), each a per-event exec state.
   - **200** — a non-standard high-id chunk written by some runtimes; not part of
     the canonical RPG2000 layout, so it is intentionally left undocumented.
+  - **111** — `SAVE_MAP_EVENT`: field 11 is each map event's live position
+    (`SAVE_MOVABLE`) — confirmed because all 21 saved entries match map 12's 21
+    defined events by id and sit in-bounds (`lcf_save_check.rb` re-checks this
+    when the map's `.lmu` is beside the save). Two leading int fields (1, 2, the
+    map scroll/pan) stay undecoded pending differential saves.
   - **108** — `SAVE_PARTY_ACTOR`, one entry per actor the party has held. Beyond
     the state block, the decoded fields are level (31), exp (32), skills (51/52),
     equipment (61, five item ids `[weapon,shield,armour,helmet,accessory]`) and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,21 @@ Create ADRs in /docs/adr for:
     common-event id (505 entries for Nepheshel), each a per-event exec state.
   - **200** — a non-standard high-id chunk written by some runtimes; not part of
     the canonical RPG2000 layout, so it is intentionally left undocumented.
+  - **108** — `SAVE_PARTY_ACTOR`, one entry per actor the party has held. Beyond
+    the state block, the decoded fields are level (31), exp (32), skills (51/52)
+    and current HP/MP (71/72) — validated because level tracks exp across the
+    roster and actor 1's HP (71) matches the SAVE_TITLE `hero_hp`. Equipment and
+    the base-stat block are still undecoded (see ADR 0014).
 - When decoding a chunk, prove field meanings against real bytes (change one
   known thing in-game, re-save, diff) rather than guessing; document only what
   the data (or the rpg2kpsp analysis wiki) spells out, per ADR 0002.
 - The runtime can resume from a real save: `Game::State.from_lsd(db, save)`
-  rebuilds a `State` from a parsed `LcfSaveData`, and `continue_game` loads an
-  editor `Save<N>.lsd` when present. `ruby scripts/rpg2k_save_load_check.rb`
-  round-trips a real save through it. Use `save[101]`, not `save.system`, in
-  CRuby-tested code — `system` resolves to `Kernel#system` there.
+  rebuilds a `State` from a parsed `LcfSaveData` (leader position, party roster,
+  gold, items, switches, variables, and the roster's saved current HP/MP from
+  chunk 108), and `continue_game` loads an editor `Save<N>.lsd` when present.
+  `ruby scripts/rpg2k_save_load_check.rb` round-trips a real save through it. Use
+  `save[101]`, not `save.system`, in CRuby-tested code — `system` resolves to
+  `Kernel#system` there.
 - **RPG2000 vs RPG2003:** `LCF::MODE` is a compile-time constant (2000) that only
   supplies edition-dependent *defaults* (max level, variable range); chunk
   decoding is id-driven, so a 2003 file parses either way. To branch on a file's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,12 @@ Create ADRs in /docs/adr for:
   - **200** — a non-standard high-id chunk written by some runtimes; not part of
     the canonical RPG2000 layout, so it is intentionally left undocumented.
   - **108** — `SAVE_PARTY_ACTOR`, one entry per actor the party has held. Beyond
-    the state block, the decoded fields are level (31), exp (32), skills (51/52)
-    and current HP/MP (71/72) — validated because level tracks exp across the
-    roster and actor 1's HP (71) matches the SAVE_TITLE `hero_hp`. Equipment and
-    the base-stat block are still undecoded (see ADR 0014).
+    the state block, the decoded fields are level (31), exp (32), skills (51/52),
+    equipment (61, five item ids `[weapon,shield,armour,helmet,accessory]`) and
+    current HP/MP (71/72) — validated because level tracks exp across the roster,
+    actor 1's HP (71) matches the SAVE_TITLE `hero_hp`, and every equipment id
+    resolves to a database item of the matching type. The base-stat block is
+    still undecoded (see ADR 0014).
 - When decoding a chunk, prove field meanings against real bytes (change one
   known thing in-game, re-save, diff) rather than guessing; document only what
   the data (or the rpg2kpsp analysis wiki) spells out, per ADR 0002.

--- a/changelog.d/restore-per-actor-save-state.added.md
+++ b/changelog.d/restore-per-actor-save-state.added.md
@@ -2,7 +2,10 @@
   learned skills, equipment and current HP/MP**, decoded from a real save and
   cross-checked (level rises with exp across the roster; the level-1 hero's HP
   matches the independent SAVE_TITLE summary; every equipment slot's item id
-  resolves to an item of the matching type in the database). `Game::State.from_lsd` restores the roster's
+  resolves to an item of the matching type in the database). `lcf_save_check.rb`
+  also cross-checks the `SAVE_MAP_EVENT` (chunk 111) saved event positions
+  against the current map when its `.lmu` is present — every saved event must be
+  a real, in-bounds event on that map (confirmed: 21/21 on Nepheshel's map 12). `Game::State.from_lsd` restores the roster's
   saved HP/MP so **Continue resumes a wounded party instead of healing it to
   full**, `lcf_save_check.rb` reports each actor's level/exp/HP/MP, and
   `rpg2k_save_load_check.rb` asserts the restored vitals. See ADR 0014.

--- a/changelog.d/restore-per-actor-save-state.added.md
+++ b/changelog.d/restore-per-actor-save-state.added.md
@@ -1,0 +1,7 @@
+- The `SAVE_PARTY_ACTOR` save chunk (108) now decodes per-actor **level, exp,
+  learned skills and current HP/MP**, decoded from a real save and cross-checked
+  (level rises with exp across the roster; the level-1 hero's HP matches the
+  independent SAVE_TITLE summary). `Game::State.from_lsd` restores the roster's
+  saved HP/MP so **Continue resumes a wounded party instead of healing it to
+  full**, `lcf_save_check.rb` reports each actor's level/exp/HP/MP, and
+  `rpg2k_save_load_check.rb` asserts the restored vitals. See ADR 0014.

--- a/changelog.d/restore-per-actor-save-state.added.md
+++ b/changelog.d/restore-per-actor-save-state.added.md
@@ -1,7 +1,8 @@
 - The `SAVE_PARTY_ACTOR` save chunk (108) now decodes per-actor **level, exp,
-  learned skills and current HP/MP**, decoded from a real save and cross-checked
-  (level rises with exp across the roster; the level-1 hero's HP matches the
-  independent SAVE_TITLE summary). `Game::State.from_lsd` restores the roster's
+  learned skills, equipment and current HP/MP**, decoded from a real save and
+  cross-checked (level rises with exp across the roster; the level-1 hero's HP
+  matches the independent SAVE_TITLE summary; every equipment slot's item id
+  resolves to an item of the matching type in the database). `Game::State.from_lsd` restores the roster's
   saved HP/MP so **Continue resumes a wounded party instead of healing it to
   full**, `lcf_save_check.rb` reports each actor's level/exp/HP/MP, and
   `rpg2k_save_load_check.rb` asserts the restored vitals. See ADR 0014.

--- a/docs/adr/0014-decode-and-restore-per-actor-save-state.md
+++ b/docs/adr/0014-decode-and-restore-per-actor-save-state.md
@@ -30,9 +30,13 @@ gap was purely in decoding chunk 108 and feeding it through.
   the level-1 hero) equals actor 1's decoded HP. Equipment is confirmed against
   the database: every slot's id resolves to an item of the matching type (slot 0
   weapons, slot 2 armour, slot 3 helmets, slot 4 accessories; a dual-wield hero
-  carries a second weapon in the shield slot). The base-stat block is present but
-  left undecoded until proven. `hp`/`mp` carry no schema default, so an absent
-  field reads as `nil` and never overwrites a live value.
+  carries a second weapon in the shield slot). Field 1, the actor name, is
+  identified (the hero's stored name matches the SAVE_TITLE `hero_name` exactly)
+  but left unmodelled -- the runtime resolves names from the database and reserve
+  actors store only a placeholder; the remaining single-byte fields (2/33/34) are
+  constant in the sampled save, so their meaning is not yet provable. `hp`/`mp`
+  carry no schema default, so an absent field reads as `nil` and never overwrites
+  a live value.
 - **`Game::State.from_lsd`** reads chunk 108, keys it by actor id, and passes the
   roster's saved current HP/SP into `Party#load_state`, so Continue resumes a
   wounded party instead of a fully-healed one.

--- a/docs/adr/0014-decode-and-restore-per-actor-save-state.md
+++ b/docs/adr/0014-decode-and-restore-per-actor-save-state.md
@@ -20,13 +20,17 @@ gap was purely in decoding chunk 108 and feeding it through.
 
 ## Decision
 
-- **`SAVE_PARTY_ACTOR`** now decodes the growth and vitals fields, decoded from a
-  real save (Nepheshel Save01) and cross-checked against genuine data: `level`
-  (31) and `exp` (32) -- level rises with exp across the roster (actor 3 is
-  L5/307exp, actor 4 L8/1177exp); `skill_size`/`skills` (51/52, a `uint16[]` of
-  the learned skills); and current `hp`/`mp` (71/72). Field 71 is confirmed by an
-  independent chunk: the SAVE_TITLE summary's `hero_hp` (50 for the level-1 hero)
-  equals actor 1's decoded HP. The equipment and base-stat blocks are present but
+- **`SAVE_PARTY_ACTOR`** now decodes the growth, vitals and equipment fields,
+  decoded from a real save (Nepheshel Save01) and cross-checked against genuine
+  data: `level` (31) and `exp` (32) -- level rises with exp across the roster
+  (actor 3 is L5/307exp, actor 4 L8/1177exp); `skill_size`/`skills` (51/52, a
+  `uint16[]` of the learned skills); current `hp`/`mp` (71/72); and `equipment`
+  (61), five item ids `[weapon, shield, armour, helmet, accessory]`. Field 71 is
+  confirmed by an independent chunk: the SAVE_TITLE summary's `hero_hp` (50 for
+  the level-1 hero) equals actor 1's decoded HP. Equipment is confirmed against
+  the database: every slot's id resolves to an item of the matching type (slot 0
+  weapons, slot 2 armour, slot 3 helmets, slot 4 accessories; a dual-wield hero
+  carries a second weapon in the shield slot). The base-stat block is present but
   left undecoded until proven. `hp`/`mp` carry no schema default, so an absent
   field reads as `nil` and never overwrites a live value.
 - **`Game::State.from_lsd`** reads chunk 108, keys it by actor id, and passes the
@@ -45,7 +49,8 @@ gap was purely in decoding chunk 108 and feeding it through.
 - Only current HP/MP are applied to the runtime; the runtime derives max HP/SP
   from the database at the actor's *initial* level and does not yet scale stats
   with level, so a high-level saved actor's HP can exceed the runtime's computed
-  maximum. Level-scaled stats (and restoring level, exp, skills and states into
-  the runtime) remain follow-up -- the decoding added here is the prerequisite.
+  maximum. Level-scaled stats (and restoring level, exp, skills, equipment and
+  states into the runtime, which has no equipment model yet) remain follow-up --
+  the decoding added here is the prerequisite.
   No save fixture is bundled (games are downloaded, not redistributed), so the
   checks run against a locally generated save.

--- a/docs/adr/0014-decode-and-restore-per-actor-save-state.md
+++ b/docs/adr/0014-decode-and-restore-per-actor-save-state.md
@@ -1,0 +1,51 @@
+# 14. Decode per-actor save state and restore HP/MP on Continue
+
+Date: 2026-08-03
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0011-0013 decoded the inventory and event-state save chunks and wired the
+runtime's "Continue" (`Game::State.from_lsd`) to rebuild a state from a real
+`Save<N>.lsd`. That restore covered the leader's position, the party roster,
+gold, items, switches and variables, but the per-actor status chunk
+(`SAVE_PARTY_ACTOR`, chunk 108) was modelled only as its opaque state block --
+so a resumed party silently healed to full, dropping the saved vitals. The
+runtime's `Actor` already models `hp`/`mp`/`level` and `Party#load_state`
+already restores per-actor HP/MP (the portable Marshal save uses it), so the
+gap was purely in decoding chunk 108 and feeding it through.
+
+## Decision
+
+- **`SAVE_PARTY_ACTOR`** now decodes the growth and vitals fields, decoded from a
+  real save (Nepheshel Save01) and cross-checked against genuine data: `level`
+  (31) and `exp` (32) -- level rises with exp across the roster (actor 3 is
+  L5/307exp, actor 4 L8/1177exp); `skill_size`/`skills` (51/52, a `uint16[]` of
+  the learned skills); and current `hp`/`mp` (71/72). Field 71 is confirmed by an
+  independent chunk: the SAVE_TITLE summary's `hero_hp` (50 for the level-1 hero)
+  equals actor 1's decoded HP. The equipment and base-stat blocks are present but
+  left undecoded until proven. `hp`/`mp` carry no schema default, so an absent
+  field reads as `nil` and never overwrites a live value.
+- **`Game::State.from_lsd`** reads chunk 108, keys it by actor id, and passes the
+  roster's saved current HP/SP into `Party#load_state`, so Continue resumes a
+  wounded party instead of a fully-healed one.
+- **`scripts/lcf_save_check.rb`** reports each saved actor's level/exp/HP/MP, and
+  **`scripts/rpg2k_save_load_check.rb`** asserts every restored roster member's
+  HP/MP matches its chunk-108 entry.
+
+## Consequences
+
+- Continue from a real save now preserves the party's vitals: the Nepheshel save
+  resumes the hero at 50/0 HP/MP (its saved values) rather than full health, and
+  the integration check enforces it. The save analyser surfaces the per-actor
+  growth data that was previously invisible.
+- Only current HP/MP are applied to the runtime; the runtime derives max HP/SP
+  from the database at the actor's *initial* level and does not yet scale stats
+  with level, so a high-level saved actor's HP can exceed the runtime's computed
+  maximum. Level-scaled stats (and restoring level, exp, skills and states into
+  the runtime) remain follow-up -- the decoding added here is the prerequisite.
+  No save fixture is bundled (games are downloaded, not redistributed), so the
+  checks run against a locally generated save.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1016,6 +1016,13 @@ module LCF
     # snapshot list (each entry reuses SAVE_MOVABLE, but without the map-id chunk
     # that only the hero/vehicle entries carry). Fields 21/22 hold the lower/upper
     # tile replacements applied by the "replace chipset tiles" event command.
+    # The running map's saved event state (chunk 111). Field 11 is each map
+    # event's live position (a SAVE_MOVABLE) -- confirmed against a real save:
+    # all 21 saved entries matched map 12's 21 defined events, id for id and at
+    # in-bounds tiles (scripts/lcf_save_check.rb re-checks this). Fields 21/22 are
+    # the chipset replacement tables. A real save also carries two leading int
+    # fields (1, 2) -- the map scroll/pan position -- left undecoded until
+    # differential saves pin the units down.
     SAVE_MAP_EVENT = {
       11 => { name: :events, type: :Array2D, elements: SAVE_MOVABLE },
       21 => { name: :chip_replacement_lower, type: :int8_array }, # uint8[144]

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -971,11 +971,20 @@ module LCF
 
     # https://w.atwiki.jp/rpg2kpsp/pages/40.html
     #
-    # Saved per-party-member status (chunk 108), one entry per hero. The
-    # rpg2kpsp page only documents the state block; the remaining fields (level,
-    # exp, current HP/SP, equipment, …) are catalogued in sue445's analysis and
-    # are not transcribed here.
+    # Saved per-actor status (chunk 108), one entry per hero the party has held.
+    # The rpg2kpsp page documents the state block; the growth/vitals fields below
+    # were decoded from a real save (Nepheshel Save01) and cross-checked: level
+    # (31) rises with exp (32) across the roster — actor 3 is L5/307exp, actor 4
+    # L8/1177exp — and current HP/SP (71/72) sit at a hero's live vitals (the
+    # level-1 hero at 50/0, higher members at several hundred). Equipment and the
+    # base-stat block are present too but left undecoded until proven.
     SAVE_PARTY_ACTOR = {
+      31 => { name: :level, type: :int, default: 1 },      # レベル
+      32 => { name: :exp, type: :int, default: 0 },        # 経験値
+      51 => { name: :skill_size, type: :int, default: 0 }, # 『特技』情報のデータ数
+      52 => { name: :skills, type: :int16_array },         # 習得特技 (uint16[])
+      71 => { name: :hp, type: :int },                     # 現在ＨＰ
+      72 => { name: :mp, type: :int },                     # 現在ＭＰ
       81 => { name: :state_size, type: :int, default: 0 }, # 『状態』情報のデータ数
       82 => { name: :states, type: :int16_array },         # 『状態』情報 (uint16[])
     }

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -972,17 +972,21 @@ module LCF
     # https://w.atwiki.jp/rpg2kpsp/pages/40.html
     #
     # Saved per-actor status (chunk 108), one entry per hero the party has held.
-    # The rpg2kpsp page documents the state block; the growth/vitals fields below
-    # were decoded from a real save (Nepheshel Save01) and cross-checked: level
-    # (31) rises with exp (32) across the roster — actor 3 is L5/307exp, actor 4
-    # L8/1177exp — and current HP/SP (71/72) sit at a hero's live vitals (the
-    # level-1 hero at 50/0, higher members at several hundred). Equipment and the
-    # base-stat block are present too but left undecoded until proven.
+    # The rpg2kpsp page documents the state block; the fields below were decoded
+    # from a real save (Nepheshel Save01) and cross-checked against the database:
+    # level (31) rises with exp (32) across the roster — actor 3 is L5/307exp,
+    # actor 4 L8/1177exp; current HP/SP (71/72) sit at a hero's live vitals (the
+    # level-1 hero at 50/0); and equipment (61) is five item ids [weapon, shield,
+    # armour, helmet, accessory] — every slot's id resolves to an item of the
+    # matching type in the database (slot 0 weapons, slot 2 armour, slot 3
+    # helmets, slot 4 accessories; a dual-wield hero carries a second weapon in
+    # the shield slot). The base-stat block is present too but left undecoded.
     SAVE_PARTY_ACTOR = {
       31 => { name: :level, type: :int, default: 1 },      # レベル
       32 => { name: :exp, type: :int, default: 0 },        # 経験値
       51 => { name: :skill_size, type: :int, default: 0 }, # 『特技』情報のデータ数
       52 => { name: :skills, type: :int16_array },         # 習得特技 (uint16[])
+      61 => { name: :equipment, type: :int16_array },      # 装備 [武器,盾,鎧,兜,装飾]
       71 => { name: :hp, type: :int },                     # 現在ＨＰ
       72 => { name: :mp, type: :int },                     # 現在ＭＰ
       81 => { name: :state_size, type: :int, default: 0 }, # 『状態』情報のデータ数

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -980,7 +980,11 @@ module LCF
     # armour, helmet, accessory] — every slot's id resolves to an item of the
     # matching type in the database (slot 0 weapons, slot 2 armour, slot 3
     # helmets, slot 4 accessories; a dual-wield hero carries a second weapon in
-    # the shield slot). The base-stat block is present too but left undecoded.
+    # the shield slot). Field 1 is the (renamable) name — the hero's stored name
+    # matches the SAVE_TITLE hero_name exactly — but it is left unmodelled here
+    # because the runtime resolves names from the database and reserve actors
+    # store only a placeholder. Fields 2/33/34 are single bytes that are constant
+    # in the sampled save, so their meaning is not yet provable.
     SAVE_PARTY_ACTOR = {
       31 => { name: :level, type: :int, default: 1 },      # レベル
       32 => { name: :exp, type: :int, default: 0 },        # 経験値

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -382,6 +382,7 @@ assert "LCF::SaveData decodes per-actor level/exp/skills/HP/MP (chunk 108)" do
   # actor 1 (level-1 hero, HP 50/MP 0, no skills or states).
   a3 = lcf_array1d([lcf_int_field(31, 5), lcf_int_field(32, 307),
                     lcf_int_field(51, 3), lcf_shorts_field(52, [11, 12, 13]),
+                    lcf_shorts_field(61, [82, 0, 128, 220, 0]),
                     lcf_int_field(71, 56), lcf_int_field(72, 53),
                     lcf_int_field(81, 25), lcf_shorts_field(82, [0] * 25)])
   a1 = lcf_array1d([lcf_int_field(31, 1), lcf_int_field(32, 0),
@@ -393,6 +394,7 @@ assert "LCF::SaveData decodes per-actor level/exp/skills/HP/MP (chunk 108)" do
   assert_equal 307, save.actors[3].exp
   assert_equal 3, save.actors[3].skill_size
   assert_equal [11, 12, 13], save.actors[3].skills
+  assert_equal [82, 0, 128, 220, 0], save.actors[3].equipment
   assert_equal 56, save.actors[3].hp
   assert_equal 53, save.actors[3].mp
   assert_equal 1, save.actors[1].level

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -376,3 +376,28 @@ assert "LCF::SaveData decodes the inventory, common-event and foreground-event c
   assert_equal [0x01, 0x01, 0x00, 0x00], save.common_events[1].execution_state
   assert_equal [0xab, 0xcd], save.foreground_event.execution_state
 end
+
+assert "LCF::SaveData decodes per-actor level/exp/skills/HP/MP (chunk 108)" do
+  # Mirrors a real save's actor 3 (L5, 307 exp, HP 56/MP 53, three skills) and
+  # actor 1 (level-1 hero, HP 50/MP 0, no skills or states).
+  a3 = lcf_array1d([lcf_int_field(31, 5), lcf_int_field(32, 307),
+                    lcf_int_field(51, 3), lcf_shorts_field(52, [11, 12, 13]),
+                    lcf_int_field(71, 56), lcf_int_field(72, 53),
+                    lcf_int_field(81, 25), lcf_shorts_field(82, [0] * 25)])
+  a1 = lcf_array1d([lcf_int_field(31, 1), lcf_int_field(32, 0),
+                    lcf_int_field(71, 50), lcf_int_field(72, 0)])
+  body = lcf_array1d([lcf_field(108, lcf_array2d([[1, a1], [3, a3]]))])
+  save = LCF::SaveData.new(lcf_file("LcfSaveData", body))
+
+  assert_equal 5, save.actors[3].level
+  assert_equal 307, save.actors[3].exp
+  assert_equal 3, save.actors[3].skill_size
+  assert_equal [11, 12, 13], save.actors[3].skills
+  assert_equal 56, save.actors[3].hp
+  assert_equal 53, save.actors[3].mp
+  assert_equal 1, save.actors[1].level
+  assert_equal 50, save.actors[1].hp
+  assert_equal 0, save.actors[1].mp
+  # Absent optional vitals read as nil, so the runtime restore leaves them alone.
+  assert_nil save.actors[1].skills
+end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -887,12 +887,23 @@ module Game
     def self.from_lsd(db, save)
       hero = save.hero
       inv = save.inventory
-      party = Party.new(db, (inv.party || []))
+      roster = inv.party || []
+      party = Party.new(db, roster)
       items = {}
       ids = inv.item_ids || []
       counts = inv.item_counts || []
       ids.each_index { |i| items[ids[i]] = counts[i] || 0 }
-      party.load_state(items: items, gold: inv.gold)
+      # Per-actor vitals come from the SAVE_PARTY_ACTOR table (chunk 108), keyed
+      # by actor id. Restore the saved current HP/SP for the roster so Continue
+      # resumes a wounded party rather than silently healing it to full.
+      hp = {}
+      mp = {}
+      (save[108] || []).each do |aid, sa|
+        next unless roster.include?(aid)
+        hp[aid] = sa.hp if sa.hp
+        mp[aid] = sa.mp if sa.mp
+      end
+      party.load_state(items: items, gold: inv.gold, hp: hp, mp: mp)
       state = new(party, hero.map_id, hero.x, hero.y)
       state.direction = hero.direction || 2
       sys = save[101]

--- a/scripts/lcf_save_check.rb
+++ b/scripts/lcf_save_check.rb
@@ -142,7 +142,10 @@ class SaveChecker
     detail = []
     (save.actors.each do |id, a|
       actors += 1
-      detail << "##{id} L#{a.level}/#{a.exp}xp hp=#{a.hp} mp=#{a.mp}" if detail.size < 4
+      if detail.size < 4
+        eq = (a.equipment || []).reject { |i| i == 0 }.size
+        detail << "##{id} L#{a.level}/#{a.exp}xp hp=#{a.hp} mp=#{a.mp} eq=#{eq}"
+      end
     end rescue nil)
     puts "  party:   #{actors} saved actor entrie(s)#{detail.empty? ? '' : " #{detail.join('  ')}"}"
     inv = save.inventory

--- a/scripts/lcf_save_check.rb
+++ b/scripts/lcf_save_check.rb
@@ -139,8 +139,12 @@ class SaveChecker
       fail 'hero has non-positive map id' if h.map_id.to_i <= 0
     end
     actors = 0
-    (save.actors.each { |_id, _a| actors += 1 } rescue nil)
-    puts "  party:   #{actors} saved actor entrie(s)"
+    detail = []
+    (save.actors.each do |id, a|
+      actors += 1
+      detail << "##{id} L#{a.level}/#{a.exp}xp hp=#{a.hp} mp=#{a.mp}" if detail.size < 4
+    end rescue nil)
+    puts "  party:   #{actors} saved actor entrie(s)#{detail.empty? ? '' : " #{detail.join('  ')}"}"
     inv = save.inventory
     if inv
       ids = inv.item_ids || []

--- a/scripts/lcf_save_check.rb
+++ b/scripts/lcf_save_check.rb
@@ -111,9 +111,38 @@ class SaveChecker
     puts "  schema chunks absent from this save: #{missing.join(', ')}" unless missing.empty?
 
     summarise(save, raw, schema)
+    check_map_events(save, File.dirname(path))
     @files += 1
   rescue => ex
     fail "#{path}: #{ex.class}: #{ex.message}"
+  end
+
+  # SAVE_MAP_EVENT (chunk 111) field 11 stores each map event's current position
+  # as a SAVE_MOVABLE. When the current map's .lmu sits next to the save, prove
+  # that decode: every saved event id must be a real event on that map and its
+  # position must lie inside the map. (Chunk 111 also carries two leading int
+  # fields whose meaning needs differential saves to pin down.)
+  def check_map_events(save, dir)
+    me = save.map_events
+    return unless me && me.events
+    map_id = save.hero.map_id.to_i
+    f = File.join(dir, "Map#{map_id.to_s.rjust(4, '0')}.lmu")
+    return unless File.exist?(f)
+    mu = LCF::MapUnit.new(File.open(f, 'rb'))
+    defined = {}
+    mu.events.each { |id, _e| defined[id] = true }
+    w = mu.width.to_i
+    h = mu.height.to_i
+    saved = 0
+    me.events.each do |id, m|
+      next unless m
+      saved += 1
+      fail "map-event #{id} not defined on map #{map_id}" unless defined[id]
+      unless (0...w).cover?(m.x.to_i) && (0...h).cover?(m.y.to_i)
+        fail "map-event #{id} position (#{m.x},#{m.y}) outside map #{map_id} #{w}x#{h}"
+      end
+    end
+    puts "  map-events: #{saved} saved on map #{map_id} (all match defined events, in-bounds)"
   end
 
   # Cross-check the decoded values a save always carries -- these confirm the

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -87,6 +87,17 @@ def check_game(dir)
   ids.each_index { |i| expected_items[ids[i]] = counts[i] }
   eq expected_items, state.party.items, 'items (id => count)'
 
+  # Per-actor current HP/SP come from the SAVE_PARTY_ACTOR table (chunk 108).
+  # Each restored roster member must carry the vitals its save entry stored.
+  saved = {}
+  lsd[108]&.each { |id, sa| saved[id] = sa }
+  state.party.actors.each do |a|
+    sa = saved[a.id]
+    next unless sa
+    eq sa.hp, a.hp, "actor #{a.id} hp" if sa.hp
+    eq sa.mp, a.mp, "actor #{a.id} mp" if sa.mp
+  end
+
   # Switches/variables shift from the save's 0-indexed arrays to 1-indexed ids.
   on = (sys.switches || []).each_index.select { |i| sys.switches[i] }.map { |i| i + 1 }
   eq on, state.switches.to_h.select { |_k, v| v }.keys.sort, 'switch ids that are on'
@@ -94,7 +105,8 @@ def check_game(dir)
                                  .map { |i| i + 1 }
   eq nonzero, state.variables.to_h.reject { |_k, v| v == 0 }.keys.sort, 'variable ids set'
 
-  puts "  leader=#{state.party.leader.name.inspect} map=#{state.map_id} " \
+  puts "  leader=#{state.party.leader.name.inspect} hp=#{state.party.leader.hp} " \
+       "mp=#{state.party.leader.mp} map=#{state.map_id} " \
        "pos=(#{state.x},#{state.y}) gold=#{state.party.gold} " \
        "items=#{state.party.items.size} switches_on=#{on.size} vars_set=#{nonzero.size}"
 rescue => e


### PR DESCRIPTION
## Summary

Follow-up to #137. Continues analyzing real LCF save data: the per-actor status chunk `SAVE_PARTY_ACTOR` (108) was modelled only as its opaque state block, so `Game::State.from_lsd` (Continue) silently healed a resumed party to full. This decodes the growth/vitals/equipment fields and restores current HP/MP.

## What changed

- **`SAVE_PARTY_ACTOR` (chunk 108)** now decodes `level` (31), `exp` (32), `skill_size`/`skills` (51/52, `uint16[]`), `equipment` (61) and current `hp`/`mp` (71/72). Decoded from a real save (Nepheshel `Save01`) and cross-checked against the database:
  - level rises with exp across the roster — actor 3 is L5/307exp, actor 4 L8/1177exp;
  - actor 1's decoded HP (field 71 = 50) matches the **independent** `SAVE_TITLE` `hero_hp`, confirming 71 = current HP;
  - **equipment** (61) is five item ids `[weapon, shield, armour, helmet, accessory]` — every slot's id resolves to an item of the matching type (slot 0 weapons, slot 2 armour, slot 3 helmets, slot 4 accessories), and a dual-wield hero carries a second weapon in the shield slot;
  - `hp`/`mp` carry no schema default, so an absent field reads as `nil` and never overwrites a live value.
  - Field 1, the actor name, is *identified* (the hero's stored name matches `SAVE_TITLE` `hero_name` exactly) but left unmodelled — names resolve from the database and reserve actors store a placeholder. Fields 2/33/34 are single bytes constant in the sampled save, so not yet provable.
- **`Game::State.from_lsd`** reads chunk 108, keys it by actor id, and restores the roster's current HP/SP via `Party#load_state` — Continue now resumes a wounded party instead of full-healing it.
- **`scripts/lcf_save_check.rb`** reports each saved actor's `L#/exp hp/mp eq`; **`scripts/rpg2k_save_load_check.rb`** asserts every restored roster member's HP/MP matches its chunk-108 entry.
- New mruby unit tests for chunk-108 decoding; ADR 0014, changelog fragment, `AGENTS.md` updated.

## Validation

All CRuby harnesses green against real game data:

| Check | Result |
|-------|--------|
| `lcf_testbed_check.rb` | 1151 maps / 23,275 events parse cleanly |
| `rpg2k_save_load_check.rb` | real Nepheshel save resumes leader at `hp=50 mp=0` |
| `rpg2k_logic_check.rb` | 64 checks passed |
| `rpg2k_scene_check.rb` | 18 checks passed |

Unit-test logic additionally verified under CRuby (the mruby `assert` blocks mirror the on-disk layout).

## Scope / follow-up

Only current HP/MP are *applied* to the runtime: it derives max HP/SP from the database at an actor's *initial* level and does not yet scale stats with level, so a high-level saved actor's HP can exceed the runtime's computed max. Restoring level/exp/skills/equipment/states into the runtime (which has no equipment model yet), plus level-scaled stats, remain follow-up — the decoding here is the prerequisite. No save fixture is bundled (games are downloaded, not redistributed). See ADR 0014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG