### PR TITLE
RPG Maker XP: more event interpreter commands (inventory, party, erase)

### DIFF
--- a/changelog.d/rpgxp-erase-event.added.md
+++ b/changelog.d/rpgxp-erase-event.added.md
@@ -1,0 +1,8 @@
+- RPG Maker **XP** *Erase Event* (116) command. The interpreter flags the
+  running event for erasure (a one-shot request drained via `take_erase_request`)
+  and keeps executing the rest of the list, and `Scene::Map` removes the event —
+  its marker, movement, collision, forced route and any parallel process — for
+  the rest of the map visit. The removal is keyed by event id so it survives the
+  `build_events` rebuild that a finishing event triggers, and erased events
+  reappear only when the map is (re)loaded. Covered by a new interpreter test and
+  exercised end to end by the host scene harness.

--- a/changelog.d/rpgxp-party-inventory.added.md
+++ b/changelog.d/rpgxp-party-inventory.added.md
@@ -1,0 +1,10 @@
+- RPG Maker **XP** party inventory and item event commands. `RPGXP::Game::State`
+  now carries `$game_party`-style item / weapon / armor stores (id → count, each
+  clamped to 0..99 and persisted in the portable save), and the interpreter runs
+  *Change Items* (126), *Change Weapons* (127) and *Change Armor* (128) — adding
+  or removing a constant or variable amount. The Conditional Branch **item /
+  weapon / armor** possession tests (types 8 / 9 / 10) are evaluated, and Control
+  Variables can read an **item count** (operand type 3) as its source. Covered by
+  new `mruby-rpgxp/test` cases (inventory clamping + save round-trip, the three
+  change commands with constant and variable operands, the possession
+  conditionals, and the item-count variable operand).

--- a/changelog.d/rpgxp-party-member.added.md
+++ b/changelog.d/rpgxp-party-member.added.md
@@ -1,0 +1,8 @@
+- RPG Maker **XP** *Change Party Member* (129) event command plus the party-
+  related conditional and variable sources. The interpreter adds or removes an
+  actor from `Game::State#party` (no duplicates, removals delete the id), the
+  Conditional Branch **actor "is in the party"** test (type 4, sub-type 0) is
+  evaluated, and Control Variables can read the **"other" game quantities**
+  (operand type 7) — map id, party member count and gold. Covered by new
+  `mruby-rpgxp/test` cases (add/remove/duplicate party changes, the in-party
+  conditional, and the game-quantity operands).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -221,9 +221,15 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   suppresses input while active). *Input Number* (103) is implemented too: the
   interpreter suspends with a `:number` request and `Scene::Map` drives a
   digit-entry widget (`Game::NumberInput`) whose value is stored into the target
-  variable. Covered by `mruby-rpgxp/test` and driven over the real test bed by
-  `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route targets and
-  the many screen-effect / picture / battle commands (skipped for now).
+  variable. The party also carries an **inventory** now (`Game::State` item /
+  weapon / armor stores, each id → count capped at 99, persisted in the save):
+  *Change Items / Weapons / Armor* (126/127/128) add or remove by a constant or
+  a variable amount, the Conditional Branch **item / weapon / armor** possession
+  tests (types 8/9/10) run, and Control Variables can read an **item count** as
+  its operand. Covered by `mruby-rpgxp/test` and driven over the real test bed by
+  `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route targets, the
+  actor / enemy / character conditional sub-conditions, and the many
+  screen-effect / picture / battle commands (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
   (RPG Maker XP; VX's same-format `Game.rgss2a`) or a VX Ace `Game.rgss3a` loads:
   `RPGXP::RGSSAD` (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts **both** the version-1

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -226,10 +226,13 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   *Change Items / Weapons / Armor* (126/127/128) add or remove by a constant or
   a variable amount, the Conditional Branch **item / weapon / armor** possession
   tests (types 8/9/10) run, and Control Variables can read an **item count** as
-  its operand. Covered by `mruby-rpgxp/test` and driven over the real test bed by
-  `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route targets, the
-  actor / enemy / character conditional sub-conditions, and the many
-  screen-effect / picture / battle commands (skipped for now).
+  its operand. *Change Party Member* (129) adds/removes actors from the party,
+  the **actor "is in the party"** conditional (type 4) is evaluated, and Control
+  Variables also reads the **"other" game quantities** — map id, party size and
+  gold (operand type 7). Covered by `mruby-rpgxp/test` and driven over the real
+  test bed by `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route
+  targets, the remaining actor / enemy / character conditional sub-conditions,
+  and the many screen-effect / picture / battle commands (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
   (RPG Maker XP; VX's same-format `Game.rgss2a`) or a VX Ace `Game.rgss3a` loads:
   `RPGXP::RGSSAD` (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts **both** the version-1

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -203,9 +203,12 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   (`Game::EventPage`: switch / variable / self-switch, highest match wins) and a
   `Game::Interpreter` runs the XP command list with a suspend/resume model: Show
   Text / Choices, Conditional Branch / Else / End, Loop / Break / Repeat, Label /
-  Jump, Call Common Event, Control Switches / Variables / Self Switch, Change
-  Gold, Transfer Player and Play BGM/BGS/ME/SE, indent- and terminator-driven
-  with a per-frame step cap. `Scene::Map` starts events on the action button, on
+  Jump, Call Common Event, Erase Event, Control Switches / Variables / Self
+  Switch, Change Gold, Transfer Player and Play BGM/BGS/ME/SE, indent- and
+  terminator-driven with a per-frame step cap. **Erase Event** (116) flags the
+  running event and `Scene::Map` drops it (its sprite, movement, collision and
+  any parallel process) for the rest of the map visit, keyed so it stays gone
+  across page re-selection and reappears on a fresh map load. `Scene::Map` starts events on the action button, on
   player touch, on autorun or as a background parallel process, drives a
   message/choice window, and re-selects pages when an event finishes. Events
   also **roam autonomously**: `Game::Character` / `Game::MoveType` /

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -67,11 +67,29 @@ class RPGXP
         # game (they persist when you leave and re-enter a map), keyed the way
         # RMXP's $game_self_switches is.
         @self_switches = Hash.new(false)
+        # Party possessions, mirroring $game_party's separate item / weapon /
+        # armor stores (id => count, each capped at 99 like RMXP).
+        @items = Hash.new(0)
+        @weapons = Hash.new(0)
+        @armors = Hash.new(0)
       end
+
+      MAX_ITEMS = 99
 
       attr_reader :db
       attr_accessor :map_id, :x, :y, :direction, :map, :party, :gold,
-                    :switches, :variables, :self_switches
+                    :switches, :variables, :self_switches,
+                    :items, :weapons, :armors
+
+      # Possession counts, clamped to 0..MAX_ITEMS. `store` is one of :items /
+      # :weapons / :armors.
+      def item_count(id);   @items[id];   end
+      def weapon_count(id); @weapons[id]; end
+      def armor_count(id);  @armors[id];  end
+
+      def gain_item(id, n = 1);   change_possession(@items, id, n);   end
+      def gain_weapon(id, n = 1); change_possession(@weapons, id, n); end
+      def gain_armor(id, n = 1);  change_possession(@armors, id, n);  end
 
       # Read/write a self switch for a specific event on a specific map.
       def self_switch(map_id, event_id, ch)
@@ -94,7 +112,9 @@ class RPGXP
         { map_id: @map_id, x: @x, y: @y, direction: @direction,
           party: @party, gold: @gold, switches: hash_to_plain(@switches),
           variables: hash_to_plain(@variables),
-          self_switches: hash_to_plain(@self_switches) }
+          self_switches: hash_to_plain(@self_switches),
+          items: hash_to_plain(@items), weapons: hash_to_plain(@weapons),
+          armors: hash_to_plain(@armors) }
       end
 
       def self.load(db, h)
@@ -103,10 +123,21 @@ class RPGXP
         (h[:switches] || {}).each { |k, v| s.switches[k] = v }
         (h[:variables] || {}).each { |k, v| s.variables[k] = v }
         (h[:self_switches] || {}).each { |k, v| s.self_switches[k] = v }
+        (h[:items] || {}).each { |k, v| s.items[k] = v }
+        (h[:weapons] || {}).each { |k, v| s.weapons[k] = v }
+        (h[:armors] || {}).each { |k, v| s.armors[k] = v }
         s
       end
 
       private
+
+      # Adjust a possession store by `n`, clamped to 0..MAX_ITEMS.
+      def change_possession(store, id, n)
+        c = store[id] + n
+        c = 0 if c < 0
+        c = MAX_ITEMS if c > MAX_ITEMS
+        store[id] = c
+      end
 
       # Default-valued Hashes do not round-trip their default through Marshal in a
       # useful way, so persist a plain copy of the set entries only.

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -86,6 +86,7 @@ class RPGXP
       CHANGE_ITEMS    = 126
       CHANGE_WEAPONS  = 127
       CHANGE_ARMOR    = 128
+      CHANGE_PARTY    = 129
       TRANSFER_PLAYER = 201
       MOVE_ROUTE      = 209
       PLAY_BGM        = 241
@@ -248,6 +249,7 @@ class RPGXP
         when CHANGE_ITEMS    then do_change_items(cmd)
         when CHANGE_WEAPONS  then do_change_weapons(cmd)
         when CHANGE_ARMOR    then do_change_armor(cmd)
+        when CHANGE_PARTY    then do_change_party(cmd)
         when TRANSFER_PLAYER then do_transfer(cmd)
         when MOVE_ROUTE      then do_move_route(cmd)
         when PLAY_BGM        then do_play(cmd, :bgm)
@@ -393,6 +395,12 @@ class RPGXP
           compare(lhs, rhs, param(cmd, 4, 0))
         when 2 # self switch: [2, ch, value(0 on / 1 off)]
           self_switch_on?(param(cmd, 1)) == (param(cmd, 2) == 0)
+        when 4 # actor: [4, actor_id, sub_type, ...]; sub 0 = "is in the party"
+          if param(cmd, 2) == 0
+            @state.party.include?(param(cmd, 1))
+          else
+            true # name / skill / equipment / state sub-conditions not modelled
+          end
         when 7 # gold: [7, amount, cmp(0 >= / 1 <=)]
           param(cmd, 2) == 0 ? @state.gold >= param(cmd, 1) : @state.gold <= param(cmd, 1)
         when 8 # item: [8, item_id] — party holds at least one
@@ -508,7 +516,19 @@ class RPGXP
           hi = param(cmd, 5, lo)
           lo + @rng.random(hi - lo + 1)
         when 3 then @state.item_count(param(cmd, 4)) # item count held
+        when 7 then game_quantity(param(cmd, 4))     # "other" game data
         else 0                                          # unsupported operand
+        end
+      end
+
+      # Control Variables "other" operand (type 7): a handful of game quantities.
+      # Only the display-independent ones are modelled; the rest read as 0.
+      def game_quantity(kind)
+        case kind
+        when 0 then @state.map_id      # map id
+        when 1 then @state.party.size  # party member count
+        when 2 then @state.gold        # gold
+        else 0                         # steps / play time / timer / saves / battles
         end
       end
 
@@ -550,6 +570,20 @@ class RPGXP
         amount = param(cmd, 2) == 0 ? param(cmd, 3, 0) : variables[param(cmd, 3)]
         amount = -amount if param(cmd, 1) != 0 # decrease
         yield(id, amount)
+        @index += 1
+      end
+
+      # Change Party Member (129): [actor_id, operation(0 add / 1 remove),
+      # initialize?]. Adds an actor to the party (no duplicates, appended in the
+      # order added) or removes it. The `initialize` flag (reset stats on add) is
+      # ignored until actor battle stats are modelled.
+      def do_change_party(cmd)
+        actor_id = param(cmd, 0)
+        if param(cmd, 1) == 0
+          @state.party << actor_id unless @state.party.include?(actor_id)
+        else
+          @state.party.delete(actor_id)
+        end
         @index += 1
       end
 

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -83,6 +83,9 @@ class RPGXP
       CONTROL_VARS    = 122
       CONTROL_SELF_SW = 123
       CHANGE_GOLD     = 125
+      CHANGE_ITEMS    = 126
+      CHANGE_WEAPONS  = 127
+      CHANGE_ARMOR    = 128
       TRANSFER_PLAYER = 201
       MOVE_ROUTE      = 209
       PLAY_BGM        = 241
@@ -242,6 +245,9 @@ class RPGXP
         when CONTROL_VARS    then do_control_vars(cmd)
         when CONTROL_SELF_SW then do_control_self_switch(cmd)
         when CHANGE_GOLD     then do_change_gold(cmd)
+        when CHANGE_ITEMS    then do_change_items(cmd)
+        when CHANGE_WEAPONS  then do_change_weapons(cmd)
+        when CHANGE_ARMOR    then do_change_armor(cmd)
         when TRANSFER_PLAYER then do_transfer(cmd)
         when MOVE_ROUTE      then do_move_route(cmd)
         when PLAY_BGM        then do_play(cmd, :bgm)
@@ -389,6 +395,12 @@ class RPGXP
           self_switch_on?(param(cmd, 1)) == (param(cmd, 2) == 0)
         when 7 # gold: [7, amount, cmp(0 >= / 1 <=)]
           param(cmd, 2) == 0 ? @state.gold >= param(cmd, 1) : @state.gold <= param(cmd, 1)
+        when 8 # item: [8, item_id] — party holds at least one
+          @state.item_count(param(cmd, 1)) > 0
+        when 9 # weapon: [9, weapon_id, include_equipped?] — party holds it
+          @state.weapon_count(param(cmd, 1)) > 0
+        when 10 # armor: [10, armor_id, include_equipped?] — party holds it
+          @state.armor_count(param(cmd, 1)) > 0
         else
           true # unsupported condition types default to the true branch
         end
@@ -495,6 +507,7 @@ class RPGXP
           lo = param(cmd, 4, 0)
           hi = param(cmd, 5, lo)
           lo + @rng.random(hi - lo + 1)
+        when 3 then @state.item_count(param(cmd, 4)) # item count held
         else 0                                          # unsupported operand
         end
       end
@@ -522,6 +535,21 @@ class RPGXP
         amount = param(cmd, 1) == 0 ? param(cmd, 2, 0) : variables[param(cmd, 2)]
         @state.gold += (param(cmd, 0) == 0 ? amount : -amount)
         @state.gold = 0 if @state.gold < 0
+        @index += 1
+      end
+
+      # Change Items / Weapons / Armor (126/127/128):
+      # [id, operation(0 increase / 1 decrease), operand(0 const / 1 variable),
+      #  amount]. A variable operand reads the count from that variable.
+      def do_change_items(cmd);   change_possession(cmd) { |id, n| @state.gain_item(id, n) };   end
+      def do_change_weapons(cmd); change_possession(cmd) { |id, n| @state.gain_weapon(id, n) }; end
+      def do_change_armor(cmd);   change_possession(cmd) { |id, n| @state.gain_armor(id, n) };  end
+
+      def change_possession(cmd)
+        id = param(cmd, 0)
+        amount = param(cmd, 2) == 0 ? param(cmd, 3, 0) : variables[param(cmd, 3)]
+        amount = -amount if param(cmd, 1) != 0 # decrease
+        yield(id, amount)
         @index += 1
       end
 

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -76,6 +76,7 @@ class RPGXP
       BREAK_LOOP      = 113
       REPEAT_ABOVE    = 413
       EXIT_EVENT      = 115
+      ERASE_EVENT     = 116
       CALL_COMMON     = 117
       LABEL           = 118
       JUMP_LABEL      = 119
@@ -126,6 +127,7 @@ class RPGXP
         @event_id = event_id
         @call_stack = []
         @move_route_requests = []
+        @erase_requested = false
         @running = true
         reset_waits
         self
@@ -138,6 +140,16 @@ class RPGXP
         @move_route_requests = []
         @running = false
         reset_waits
+      end
+
+      # True (once) if an Erase Event command ran since the last call, clearing
+      # the flag. The scene polls this after #update and removes the running
+      # event from the map (Erase Event does not pause the interpreter — the rest
+      # of the list still runs).
+      def take_erase_request
+        v = @erase_requested
+        @erase_requested = false
+        v
       end
 
       # Drain the Set Move Route (209) requests queued since the last call,
@@ -206,6 +218,7 @@ class RPGXP
         @running = false
         @call_stack = []
         @move_route_requests = []
+        @erase_requested = false
         reset_waits
       end
 
@@ -240,6 +253,7 @@ class RPGXP
         when REPEAT_ABOVE    then do_repeat(cmd)
         when BREAK_LOOP      then do_break(cmd)
         when EXIT_EVENT      then stop
+        when ERASE_EVENT     then do_erase_event(cmd)
         when CALL_COMMON     then do_call_common(cmd)
         when JUMP_LABEL      then do_jump_label(cmd)
         when CONTROL_SWITCHES then do_control_switches(cmd)
@@ -484,6 +498,14 @@ class RPGXP
         return false if @call_stack.empty?
         @list, @index, @event_id = @call_stack.pop
         true
+      end
+
+      # Erase Event (116): flag the running event for removal and keep going —
+      # RMXP erases the event (hides it, drops its triggers) but the current
+      # command list runs to the end.
+      def do_erase_event(cmd)
+        @erase_requested = true if @event_id
+        @index += 1
       end
 
       # -- state changes ------------------------------------------------------

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -375,6 +375,9 @@ class RPGXP
         @player_route = nil
         @player_char = nil
         @player_route_timer = 0
+        # Event ids erased by an Erase Event (116) command: skipped when the event
+        # list is rebuilt so they stay gone until the map is (re)loaded.
+        @erased = {}
         build_events
         build_parallels
         setup_sprites
@@ -435,6 +438,7 @@ class RPGXP
         @events = {}
         @event_tiles = {}
         (@map.events || {}).each do |id, ev|
+          next if @erased[id] # erased for the rest of this map visit
           entry = build_event(id, ev)
           @events[id] = entry
           @event_tiles[[entry[:char].x, entry[:char].y]] = entry if entry[:page]
@@ -685,8 +689,33 @@ class RPGXP
         else
           @interpreter.update
           apply_move_requests(@interpreter)
+          apply_erase_request(@interpreter, @running_event_id)
           finish_event unless @interpreter.running? || @interpreter.waiting?
         end
+      end
+
+      # Remove the running event from the map when its interpreter raised an Erase
+      # Event this step. Keyed by id so the removal survives the build_events
+      # rebuild that finish_event triggers.
+      def apply_erase_request(interp, event_id)
+        erase_event(event_id) if interp.take_erase_request && event_id
+      rescue StandardError => e
+        $stderr.puts "[RGSS] Erase Event failed: #{e.message}"
+      end
+
+      # Drop an event from the runtime list, the occupied-tile cache (so it no
+      # longer draws / moves / blocks), any forced route and any parallel process
+      # it was driving, and mark it erased so a rebuild keeps it gone.
+      def erase_event(id)
+        @erased[id] = true
+        e = @events[id]
+        if e && e[:char]
+          tile = [e[:char].x, e[:char].y]
+          @event_tiles.delete(tile) if @event_tiles[tile].equal?(e)
+        end
+        @events.delete(id)
+        @forced_routes.delete(id)
+        @parallels.reject! { |p| p[:id] == id } if @parallels
       end
 
       # An event finished: re-select pages (a self switch / switch it set may
@@ -731,10 +760,12 @@ class RPGXP
         elsif it.running?
           it.update
           apply_move_requests(it)
+          apply_erase_request(it, p[:id])
         else
           it.start(p[:list], @state.map_id, p[:id]) # loop the process
           it.update
           apply_move_requests(it)
+          apply_erase_request(it, p[:id])
         end
       rescue StandardError
         nil
@@ -757,6 +788,7 @@ class RPGXP
         @last_frame = nil
         @characters = {} # new map: events start at their spawn tiles
         @forced_routes = {} # forced routes do not survive a map change
+        @erased = {} # erased events reappear on a fresh map
         @player_route = nil
         @player_char = nil
         build_events

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -371,6 +371,25 @@ assert "Interpreter: control variables from game quantities" do
   assert_equal 250, s.variables[3]
 end
 
+assert "Interpreter: erase event surfaces a one-shot request without pausing" do
+  s = new_state
+  it = RPGXP::Game::Interpreter.new(s)
+  it.start([
+    cmd(116, [], 0),          # erase this event
+    cmd(121, [4, 4, 0], 0)    # then switch 4 ON (proves it kept running)
+  ], 1, 7)
+  it.update
+  assert_true s.switches[4]           # ran the command after the erase
+  assert_true it.take_erase_request   # the erase was requested
+  assert_false it.take_erase_request  # ... and the flag cleared on read
+
+  # A common event with no event context requests no erase.
+  it2 = RPGXP::Game::Interpreter.new(s)
+  it2.start([cmd(116, [], 0)], 1, nil)
+  it2.update
+  assert_false it2.take_erase_request
+end
+
 assert "Interpreter: conditional branch true and else" do
   # Switch 5 ON -> true branch sets switch 1; else sets switch 2.
   list = [

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -334,6 +334,43 @@ assert "Interpreter: control variable from item count" do
   assert_equal 12, s.variables[1]
 end
 
+assert "Interpreter: change party member and actor-in-party condition" do
+  s = new_state # party starts as [1]
+  run_to_end(s, [
+    cmd(129, [2, 0, 0], 0),   # add actor 2
+    cmd(129, [3, 0, 0], 0),   # add actor 3
+    cmd(129, [1, 1, 0], 0)    # remove actor 1
+  ])
+  assert_equal [2, 3], s.party
+  run_to_end(s, [cmd(129, [2, 0, 0], 0)]) # adding a duplicate is a no-op
+  assert_equal [2, 3], s.party
+
+  s2 = new_state # party [1]
+  run_to_end(s2, [
+    cmd(111, [4, 1, 0], 0),   # if actor 1 in party
+    cmd(121, [1, 1, 0], 1),   #   switch 1 ON
+    cmd(412, [], 0),
+    cmd(111, [4, 9, 0], 0),   # if actor 9 in party
+    cmd(121, [2, 2, 0], 1),   #   switch 2 ON
+    cmd(412, [], 0)
+  ])
+  assert_true s2.switches[1]   # actor 1 is in party
+  assert_false s2.switches[2]  # actor 9 is not
+end
+
+assert "Interpreter: control variables from game quantities" do
+  s = new_state # map_id 1, party [1]
+  s.gold = 250
+  run_to_end(s, [
+    cmd(122, [1, 1, 0, 7, 0], 0),   # var1 = map id (1)
+    cmd(122, [2, 2, 0, 7, 1], 0),   # var2 = party size (1)
+    cmd(122, [3, 3, 0, 7, 2], 0)    # var3 = gold (250)
+  ])
+  assert_equal 1, s.variables[1]
+  assert_equal 1, s.variables[2]
+  assert_equal 250, s.variables[3]
+end
+
 assert "Interpreter: conditional branch true and else" do
   # Switch 5 ON -> true branch sets switch 1; else sets switch 2.
   list = [

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -161,6 +161,9 @@ assert "Game::State save/load round-trip" do
   state = RPGXP::Game::State.new(db, [1, 2], 5, 9, 7, 4)
   state.switches[3] = true
   state.variables[10] = 42
+  state.gain_item(1, 3)
+  state.gain_weapon(2, 1)
+  state.gain_armor(4, 5)
 
   h = state.to_h
   loaded = RPGXP::Game::State.load(db, Marshal.load(Marshal.dump(h)))
@@ -171,9 +174,13 @@ assert "Game::State save/load round-trip" do
   assert_equal [1, 2], loaded.party
   assert_true loaded.switches[3]
   assert_equal 42, loaded.variables[10]
+  assert_equal 3, loaded.item_count(1)
+  assert_equal 1, loaded.weapon_count(2)
+  assert_equal 5, loaded.armor_count(4)
   # Default-valued stores still behave after load.
   assert_false loaded.switches[999]
   assert_equal 0, loaded.variables[999]
+  assert_equal 0, loaded.item_count(999)
 end
 
 # ---- Event system: page selection + interpreter ---------------------------
@@ -276,6 +283,55 @@ assert "Interpreter: control switches / variables / gold" do
   assert_true s.switches[7]
   assert_equal 50, s.variables[1]
   assert_equal 100, s.gold
+end
+
+assert "Interpreter: change items / weapons / armor (const + variable)" do
+  s = new_state
+  s.variables[4] = 7
+  run_to_end(s, [
+    cmd(126, [3, 0, 0, 5], 0),   # item 3 += 5
+    cmd(126, [3, 1, 0, 2], 0),   # item 3 -= 2  -> 3
+    cmd(126, [9, 0, 1, 4], 0),   # item 9 += var4 (7)
+    cmd(127, [1, 0, 0, 1], 0),   # weapon 1 += 1
+    cmd(128, [2, 0, 0, 4], 0)    # armor 2 += 4
+  ])
+  assert_equal 3, s.item_count(3)
+  assert_equal 7, s.item_count(9)
+  assert_equal 1, s.weapon_count(1)
+  assert_equal 4, s.armor_count(2)
+  # Possession clamps to 0..99.
+  s.gain_item(3, -100)
+  assert_equal 0, s.item_count(3)
+  s.gain_item(5, 250)
+  assert_equal 99, s.item_count(5)
+end
+
+assert "Interpreter: item / weapon / armor conditional branches" do
+  list = [
+    cmd(111, [8, 3], 0),        # if has item 3
+    cmd(121, [1, 1, 0], 1),     #   switch 1 ON
+    cmd(412, [], 0),
+    cmd(111, [9, 1], 0),        # if has weapon 1
+    cmd(121, [2, 2, 0], 1),     #   switch 2 ON
+    cmd(412, [], 0),
+    cmd(111, [10, 2], 0),       # if has armor 2
+    cmd(121, [3, 3, 0], 1),     #   switch 3 ON
+    cmd(412, [], 0)
+  ]
+  s = new_state
+  s.gain_item(3, 1)
+  s.gain_weapon(1, 1)
+  run_to_end(s, list)
+  assert_true s.switches[1]     # holds item 3
+  assert_true s.switches[2]     # holds weapon 1
+  assert_false s.switches[3]    # lacks armor 2
+end
+
+assert "Interpreter: control variable from item count" do
+  s = new_state
+  s.gain_item(5, 12)
+  run_to_end(s, [cmd(122, [1, 1, 0, 3, 5], 0)]) # var1 = count of item 5
+  assert_equal 12, s.variables[1]
 end
 
 assert "Interpreter: conditional branch true and else" do


### PR DESCRIPTION
## Summary

Extends the RPG Maker XP event interpreter with several new commands and the state they need, continuing the XP `docs/TODO.md` event-system work (follow-up to the Set Move Route / Input Number / `.rgss3a` changes merged in #138). Three self-contained commits:

**1. Party inventory + item commands**
- `RPGXP::Game::State` gains `$game_party`-style **item / weapon / armor** stores (id → count, clamped `0..99`), round-tripped through the portable save.
- **Change Items / Weapons / Armor (126 / 127 / 128)** — add/remove a constant or variable amount.
- Conditional Branch **item / weapon / armor** possession tests (types 8 / 9 / 10).
- Control Variables **item-count** operand (type 3).

**2. Change Party Member + party data sources**
- **Change Party Member (129)** — add/remove an actor from the party (no duplicates).
- Conditional Branch **actor "is in the party"** test (type 4, sub-type 0).
- Control Variables **"other" quantities** (type 7): map id, party member count, gold.

**3. Erase Event (116)**
- The interpreter flags the running event (one-shot `take_erase_request`) and keeps running the list; `Scene::Map` removes the event — marker, movement, collision, forced route, parallel process — for the rest of the map visit, keyed so it survives page re-selection and reappears on a fresh map load.

## Testing

Pure logic, exercised the way the rest of the XP runtime is:

- New `mruby-rpgxp/test` cases for every command / condition / operand above.
- The real test file runs under CRuby with mruby's immediate-`assert` semantics and RGSS value-type stubs: **39/39 assertions pass** in file order.
- A host scene harness (RGSS stubs) drives forced routes and the erase path end to end: **11/11**.
- `docs/TODO.md` updated and one changelog fragment added per commit under `changelog.d/`.

Still to come (unchanged): vehicle move-route targets, the remaining actor / enemy / character conditional sub-conditions, and the screen-effect / picture / battle commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)