### PR TITLE
Implement Canvas2D 'difference' blend mode for MV negative screen tones

### DIFF
--- a/changelog.d/mv-screen-tone.added.md
+++ b/changelog.d/mv-screen-tone.added.md
@@ -1,0 +1,11 @@
+- MV negative screen tones (map darkening): the Canvas2D bridge now implements
+  `globalCompositeOperation = 'difference'`. MV's `ToneSprite` (the Canvas-path
+  screen-tone changer, used because we run PIXI's canvas renderer) darkens the
+  frame with a difference/lighter/difference fill sequence, gated on the boot
+  probe `Graphics.canUseDifferenceBlend()`. That probe reads a white-on-white
+  `difference` pixel and only enabled the path if it came back black — which it
+  never did while the op fell through to source-over, so negative tones (night,
+  caves, dungeons, "Tint Screen" event commands) had no effect. With the real
+  op, the probe passes and negative tones darken the map. Positive tones already
+  worked via `'lighter'`; `'saturation'` (grey/desaturation) stays disabled.
+  Unit-tested in `mruby-mvjs/test/canvas_test.rb`.

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -207,11 +207,32 @@ void blend_add(uint8_t* d, int r, int g, int b, int a) {
   d[3] = static_cast<uint8_t>(std::min(255, d[3] + a));
 }
 
-// Dispatch to the source-over or additive blend based on a composite-op mode
-// (0 = source-over, 1 = lighter/additive) threaded through from the Ctx.
+// "difference" blend: |dest - source| per channel, mixed in by the source
+// coverage `a`. MV uses it (with opaque white / colour fills) to invert the
+// frame so a following additive fill subtracts instead of adds -- that is how
+// negative screen tones (night, caves, "tint screen" events) darken the map.
+// Reachable once the boot feature-probe reports canUseDifferenceBlend, which it
+// now does because this makes the probe's white-on-white difference read black.
+void blend_difference(uint8_t* d, int r, int g, int b, int a) {
+  if (a <= 0)
+    return;
+  const int ia = 255 - a;
+  const int dr = d[0] > r ? d[0] - r : r - d[0];
+  const int dg = d[1] > g ? d[1] - g : g - d[1];
+  const int db = d[2] > b ? d[2] - b : b - d[2];
+  d[0] = static_cast<uint8_t>((dr * a + d[0] * ia) / 255);
+  d[1] = static_cast<uint8_t>((dg * a + d[1] * ia) / 255);
+  d[2] = static_cast<uint8_t>((db * a + d[2] * ia) / 255);
+  d[3] = static_cast<uint8_t>((a * 255 + d[3] * ia) / 255);
+}
+
+// Dispatch by composite-op mode (0 = source-over, 1 = lighter/additive,
+// 2 = difference) threaded through from the Ctx.
 inline void blend_mode(uint8_t* d, int r, int g, int b, int a, int mode) {
   if (mode == 1)
     blend_add(d, r, g, b, a);
+  else if (mode == 2)
+    blend_difference(d, r, g, b, a);
   else
     blend(d, r, g, b, a);
 }
@@ -804,6 +825,16 @@ const char* kCanvasPreamble = R"MVJS(
   Ctx.prototype.transform = function (a, b, c, d, e, f) { this._m = matMul(this._m, [a, b, c, d, e, f]); };
   Ctx.prototype.setTransform = function (a, b, c, d, e, f) { this._m = [a, b, c, d, e, f]; };
   Ctx.prototype.resetTransform = function () { this._m = [1, 0, 0, 1, 0, 0]; };
+  // Map globalCompositeOperation to the native blend mode: 1 = lighter/additive
+  // (flashes, weather, positive tones), 2 = difference (negative screen tones).
+  // Everything else (including the default source-over) is 0; unsupported ops
+  // stay source-over, which is also why the boot blend-mode probe leaves
+  // saturation disabled.
+  function compositeMode(op) {
+    if (op === 'lighter') return 1;
+    if (op === 'difference') return 2;
+    return 0;
+  }
   // Map the axis-aligned rect (x,y,w,h) through the current matrix to a device
   // rect. Exact for translate/scale (the common case); for rotation/skew this
   // is the rect's bounding box, which is enough for the solid fills MV uses.
@@ -820,7 +851,7 @@ const char* kCanvasPreamble = R"MVJS(
     var c = parseColor(fs);
     var a = Math.round(c[3] * this.globalAlpha);
     var r = mapRect(this._m, x, y, w, h);
-    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
+    var mode = compositeMode(this.globalCompositeOperation);
     g.__mv_canvasFillRect(this.__h, r[0], r[1], r[2], r[3], c[0], c[1], c[2], a,
                           mode);
   };
@@ -872,7 +903,7 @@ const char* kCanvasPreamble = R"MVJS(
     }
     var a = Math.round(this.globalAlpha * 255);
     var m = this._m;
-    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
+    var mode = compositeMode(this.globalCompositeOperation);
     g.__mv_canvasDrawImage(this.__h, h, sx, sy, sw, sh, dx, dy, dw, dh, a,
                            m[0], m[1], m[2], m[3], m[4], m[5], mode);
   };

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -77,6 +77,35 @@ assert 'MV canvas putImageData ignores the current transform (device coords)' do
   assert_equal "7,8,9,255", MV::JS.eval("__mv_canvasGetPixel(PT.__h,0,0).join(',')")
 end
 
+assert "MV canvas globalCompositeOperation 'difference' yields |dest - source|" do
+  # White base, then 'difference' with #404040 -> |255-64| = 191 per channel.
+  MV::JS.eval("globalThis.DF=document.createElement('canvas'); DF.width=2; DF.height=2; " \
+              "var x=DF.getContext('2d'); x.fillStyle='#ffffff'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#404040'; x.fillRect(0,0,2,2);")
+  assert_equal "191,191,191,255", MV::JS.eval("__mv_canvasGetPixel(DF.__h,0,0).join(',')")
+end
+
+assert "MV canvas 'difference' white-on-white reads black (blend-mode probe)" do
+  # Graphics._testCanvasBlendModes fills white, then 'difference' white and reads
+  # the pixel: 0 means canUseDifferenceBlend, which negative screen tones need.
+  MV::JS.eval("globalThis.DP=document.createElement('canvas'); DP.width=1; DP.height=1; " \
+              "var x=DP.getContext('2d'); x.globalCompositeOperation='source-over'; " \
+              "x.fillStyle='white'; x.fillRect(0,0,1,1); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='white'; x.fillRect(0,0,1,1);")
+  assert_equal "0,0,0,255", MV::JS.eval("__mv_canvasGetPixel(DP.__h,0,0).join(',')")
+end
+
+assert 'MV canvas negative-tone sequence darkens (difference/lighter/difference)' do
+  # ToneSprite's negative-tone path: a -64 tone on a mid-grey frame -> invert,
+  # add 64, invert -> frame darkened by 64 (128 -> 64).
+  MV::JS.eval("globalThis.TN=document.createElement('canvas'); TN.width=2; TN.height=2; " \
+              "var x=TN.getContext('2d'); x.fillStyle='#808080'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='lighter'; x.fillStyle='#404040'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2);")
+  assert_equal "64,64,64,255", MV::JS.eval("__mv_canvasGetPixel(TN.__h,0,0).join(',')")
+end
+
 # A 2x2 RGBA PNG: pixel (0,0) is opaque red, the other three opaque green.
 MV_IMAGE_PNG =
   "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52" \


### PR DESCRIPTION
## Summary
This PR adds support for the `'difference'` composite operation in the Canvas2D bridge, enabling MV's negative screen tones (map darkening effects) to work correctly. The implementation includes a new blend mode dispatcher and comprehensive test coverage.

## Key Changes
- **New `blend_difference()` function**: Implements the difference blend operation (`|dest - source|` per channel) with proper alpha blending. This is used by MV's `ToneSprite` to invert the frame, allowing subsequent additive fills to subtract instead of add.
- **Updated `blend_mode()` dispatcher**: Extended to handle three modes: 0 (source-over, default), 1 (lighter/additive), and 2 (difference).
- **New `compositeMode()` helper**: JavaScript function that maps `globalCompositeOperation` strings to native blend mode integers, replacing inline conditional logic.
- **Updated fill and draw operations**: Both `fillRect()` and `drawImage()` now use the new `compositeMode()` function for consistent mode resolution.
- **Comprehensive test coverage**: Three new assertions verify:
  - Basic difference blend math (white + #404040 → #BFBFBF)
  - The boot probe behavior (white-on-white difference → black, enabling `canUseDifferenceBlend`)
  - The complete negative-tone sequence (difference/lighter/difference darkens mid-grey by 64)

## Implementation Details
The difference blend operation is mixed with the destination using source alpha coverage, maintaining proper alpha channel blending. The implementation enables MV's negative screen tone path which was previously non-functional because the operation fell through to source-over. The boot probe now correctly detects difference blend support, allowing negative tones (night, caves, dungeons, "Tint Screen" events) to darken the map as intended.

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8