### PR TITLE
Implement Canvas2D difference blend and pattern tiling for MV

### DIFF
--- a/changelog.d/mv-screen-tone.added.md
+++ b/changelog.d/mv-screen-tone.added.md
@@ -1,0 +1,11 @@
+- MV negative screen tones (map darkening): the Canvas2D bridge now implements
+  `globalCompositeOperation = 'difference'`. MV's `ToneSprite` (the Canvas-path
+  screen-tone changer, used because we run PIXI's canvas renderer) darkens the
+  frame with a difference/lighter/difference fill sequence, gated on the boot
+  probe `Graphics.canUseDifferenceBlend()`. That probe reads a white-on-white
+  `difference` pixel and only enabled the path if it came back black — which it
+  never did while the op fell through to source-over, so negative tones (night,
+  caves, dungeons, "Tint Screen" event commands) had no effect. With the real
+  op, the probe passes and negative tones darken the map. Positive tones already
+  worked via `'lighter'`; `'saturation'` (grey/desaturation) stays disabled.
+  Unit-tested in `mruby-mvjs/test/canvas_test.rb`.

--- a/changelog.d/mv-tiling-pattern.added.md
+++ b/changelog.d/mv-tiling-pattern.added.md
@@ -1,0 +1,11 @@
+- MV tiling patterns (parallax backgrounds and battlebacks): the Canvas2D
+  bridge now implements `createPattern` and a repeating pattern `fillStyle`.
+  MV's `TilingSprite` — the map parallax layer and the battle background
+  sprites — renders by cutting the texture into a pattern with
+  `createPattern(canvas, 'repeat')` and filling a rect with it. `createPattern`
+  previously returned an empty object, so those layers filled with nothing and
+  rendered blank. It now returns a pattern that `fillRect` tiles: the new native
+  (`__mv_canvasFillPattern` in `mruby-mvjs/src/mvcanvas.cxx`) wraps the source
+  over the rect under the current transform, anchored at the user-space origin
+  to match canvas `'repeat'` semantics. Unit-tested in
+  `mruby-mvjs/test/canvas_test.rb` (tiling and transform anchoring).

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -207,11 +207,32 @@ void blend_add(uint8_t* d, int r, int g, int b, int a) {
   d[3] = static_cast<uint8_t>(std::min(255, d[3] + a));
 }
 
-// Dispatch to the source-over or additive blend based on a composite-op mode
-// (0 = source-over, 1 = lighter/additive) threaded through from the Ctx.
+// "difference" blend: |dest - source| per channel, mixed in by the source
+// coverage `a`. MV uses it (with opaque white / colour fills) to invert the
+// frame so a following additive fill subtracts instead of adds -- that is how
+// negative screen tones (night, caves, "tint screen" events) darken the map.
+// Reachable once the boot feature-probe reports canUseDifferenceBlend, which it
+// now does because this makes the probe's white-on-white difference read black.
+void blend_difference(uint8_t* d, int r, int g, int b, int a) {
+  if (a <= 0)
+    return;
+  const int ia = 255 - a;
+  const int dr = d[0] > r ? d[0] - r : r - d[0];
+  const int dg = d[1] > g ? d[1] - g : g - d[1];
+  const int db = d[2] > b ? d[2] - b : b - d[2];
+  d[0] = static_cast<uint8_t>((dr * a + d[0] * ia) / 255);
+  d[1] = static_cast<uint8_t>((dg * a + d[1] * ia) / 255);
+  d[2] = static_cast<uint8_t>((db * a + d[2] * ia) / 255);
+  d[3] = static_cast<uint8_t>((a * 255 + d[3] * ia) / 255);
+}
+
+// Dispatch by composite-op mode (0 = source-over, 1 = lighter/additive,
+// 2 = difference) threaded through from the Ctx.
 inline void blend_mode(uint8_t* d, int r, int g, int b, int a, int mode) {
   if (mode == 1)
     blend_add(d, r, g, b, a);
+  else if (mode == 2)
+    blend_difference(d, r, g, b, a);
   else
     blend(d, r, g, b, a);
 }
@@ -804,6 +825,16 @@ const char* kCanvasPreamble = R"MVJS(
   Ctx.prototype.transform = function (a, b, c, d, e, f) { this._m = matMul(this._m, [a, b, c, d, e, f]); };
   Ctx.prototype.setTransform = function (a, b, c, d, e, f) { this._m = [a, b, c, d, e, f]; };
   Ctx.prototype.resetTransform = function () { this._m = [1, 0, 0, 1, 0, 0]; };
+  // Map globalCompositeOperation to the native blend mode: 1 = lighter/additive
+  // (flashes, weather, positive tones), 2 = difference (negative screen tones).
+  // Everything else (including the default source-over) is 0; unsupported ops
+  // stay source-over, which is also why the boot blend-mode probe leaves
+  // saturation disabled.
+  function compositeMode(op) {
+    if (op === 'lighter') return 1;
+    if (op === 'difference') return 2;
+    return 0;
+  }
   // Map the axis-aligned rect (x,y,w,h) through the current matrix to a device
   // rect. Exact for translate/scale (the common case); for rotation/skew this
   // is the rect's bounding box, which is enough for the solid fills MV uses.
@@ -820,7 +851,7 @@ const char* kCanvasPreamble = R"MVJS(
     var c = parseColor(fs);
     var a = Math.round(c[3] * this.globalAlpha);
     var r = mapRect(this._m, x, y, w, h);
-    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
+    var mode = compositeMode(this.globalCompositeOperation);
     g.__mv_canvasFillRect(this.__h, r[0], r[1], r[2], r[3], c[0], c[1], c[2], a,
                           mode);
   };
@@ -872,7 +903,7 @@ const char* kCanvasPreamble = R"MVJS(
     }
     var a = Math.round(this.globalAlpha * 255);
     var m = this._m;
-    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
+    var mode = compositeMode(this.globalCompositeOperation);
     g.__mv_canvasDrawImage(this.__h, h, sx, sy, sw, sh, dx, dy, dw, dh, a,
                            m[0], m[1], m[2], m[3], m[4], m[5], mode);
   };

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -604,6 +604,71 @@ void gradient_sample(const std::vector<double>& off,
   }
 }
 
+// __mv_canvasFillPattern(dstH, srcH, rx, ry, rw, rh, a, b, c, d, e, f, alpha)
+// Fill the user-space rect (rx,ry,rw,rh) with the source canvas tiled
+// ('repeat') under the current matrix [a b c d e f]. Like drawImage, but the
+// source wraps (mod its size) over the rect and the tiling is anchored at the
+// user-space origin, matching createPattern(canvas, 'repeat') + fillRect. MV's
+// TilingSprite (map parallax and battlebacks) renders through this.
+JSValue js_fill_pattern(JSContext* ctx,
+                        JSValueConst,
+                        int argc,
+                        JSValueConst* argv) {
+  Canvas* dst = canvas_get(ai(ctx, argc, argv, 0));
+  Canvas* src = canvas_get(ai(ctx, argc, argv, 1));
+  if (!dst || !src || src->w <= 0 || src->h <= 0)
+    return JS_UNDEFINED;
+  const double rx = ad(ctx, argc, argv, 2, 0), ry = ad(ctx, argc, argv, 3, 0);
+  const double rw = ad(ctx, argc, argv, 4, 0), rh = ad(ctx, argc, argv, 5, 0);
+  const double ma = ad(ctx, argc, argv, 6, 1), mb = ad(ctx, argc, argv, 7, 0);
+  const double mc = ad(ctx, argc, argv, 8, 0), md = ad(ctx, argc, argv, 9, 1);
+  const double me = ad(ctx, argc, argv, 10, 0), mf = ad(ctx, argc, argv, 11, 0);
+  const int ga = argc > 12 ? ai(ctx, argc, argv, 12) : 255;
+  if (rw <= 0 || rh <= 0)
+    return JS_UNDEFINED;
+  const double det = ma * md - mb * mc;
+  if (det == 0)
+    return JS_UNDEFINED;
+  const double invdet = 1.0 / det;
+
+  // Device-space bounding box of the four transformed rect corners.
+  const double cxs[4] = {rx, rx + rw, rx + rw, rx};
+  const double cys[4] = {ry, ry, ry + rh, ry + rh};
+  double minx = 1e18, miny = 1e18, maxx = -1e18, maxy = -1e18;
+  for (int i = 0; i < 4; ++i) {
+    const double X = ma * cxs[i] + mc * cys[i] + me;
+    const double Y = mb * cxs[i] + md * cys[i] + mf;
+    minx = std::min(minx, X);
+    maxx = std::max(maxx, X);
+    miny = std::min(miny, Y);
+    maxy = std::max(maxy, Y);
+  }
+  int x0 = std::max(static_cast<int>(std::floor(minx)), 0);
+  int y0 = std::max(static_cast<int>(std::floor(miny)), 0);
+  int x1 = std::min(static_cast<int>(std::ceil(maxx)), dst->w);
+  int y1 = std::min(static_cast<int>(std::ceil(maxy)), dst->h);
+
+  for (int py = y0; py < y1; ++py) {
+    for (int px = x0; px < x1; ++px) {
+      const double rxp = px - me, ryp = py - mf;
+      const double u = (md * rxp - mc * ryp) * invdet;
+      const double v = (-mb * rxp + ma * ryp) * invdet;
+      if (u < rx || u >= rx + rw || v < ry || v >= ry + rh)
+        continue;
+      const long iu = static_cast<long>(std::floor(u));
+      const long iv = static_cast<long>(std::floor(v));
+      const int sxx = static_cast<int>(((iu % src->w) + src->w) % src->w);
+      const int syy = static_cast<int>(((iv % src->h) + src->h) % src->h);
+      const uint8_t* sp =
+          &src->px[(static_cast<size_t>(syy) * src->w + sxx) * 4];
+      const int a = sp[3] * ga / 255;
+      blend(&dst->px[(static_cast<size_t>(py) * dst->w + px) * 4], sp[0], sp[1],
+            sp[2], a);
+    }
+  }
+  return JS_UNDEFINED;
+}
+
 // __mv_canvasFillGradient(handle, rx, ry, rw, rh, x0, y0, x1, y1,
 //                         offsets, r, g, b, a, globalAlpha)
 // Fill the device rect (rx,ry,rw,rh) with a linear gradient whose axis runs
@@ -848,6 +913,7 @@ const char* kCanvasPreamble = R"MVJS(
   Ctx.prototype.fillRect = function (x, y, w, h) {
     var fs = this.fillStyle;
     if (fs && fs.__mvGrad) { this._fillGradientRect(fs, x, y, w, h); return; }
+    if (fs && fs.__mvPattern) { this._fillPatternRect(fs, x, y, w, h); return; }
     var c = parseColor(fs);
     var a = Math.round(c[3] * this.globalAlpha);
     var r = mapRect(this._m, x, y, w, h);
@@ -877,6 +943,16 @@ const char* kCanvasPreamble = R"MVJS(
     }
     g.__mv_canvasFillGradient(this.__h, r[0], r[1], r[2], r[3],
       p0[0], p0[1], p1[0], p1[1], offs, rr, gg, bb, aa, this.globalAlpha);
+  };
+  // Fill a rect with a repeating pattern fillStyle (createPattern). The rect and
+  // current matrix are handed to the native tiler, which wraps the source over
+  // the rect anchored at the user-space origin (canvas 'repeat' semantics).
+  Ctx.prototype._fillPatternRect = function (pat, x, y, w, h) {
+    if (!pat.__srcH) return;
+    var m = this._m;
+    var a = Math.round(this.globalAlpha * 255);
+    g.__mv_canvasFillPattern(this.__h, pat.__srcH, x, y, w, h,
+                             m[0], m[1], m[2], m[3], m[4], m[5], a);
   };
   Ctx.prototype.clearRect = function (x, y, w, h) {
     var r = mapRect(this._m, x, y, w, h);
@@ -995,7 +1071,16 @@ const char* kCanvasPreamble = R"MVJS(
   Ctx.prototype.createRadialGradient = function (x0, y0, r0, x1, y1, r1) {
     return makeGradient('radial', x1, y1, x1 + (r1 || 0), y1);
   };
-  Ctx.prototype.createPattern = function () { return {}; };
+  // createPattern(image, repetition): a pattern usable as a fillStyle, tiling
+  // the image's canvas. Only 'repeat' is modelled (what MV's TilingSprite uses);
+  // _fillPatternRect reads __srcH to tile it.
+  Ctx.prototype.createPattern = function (image, repetition) {
+    return {
+      __mvPattern: true,
+      __srcH: srcHandle(image),
+      repeat: repetition || 'repeat',
+    };
+  };
   // Path and text operations MV/PIXI call but that the buffer path does not need
   // yet: accept and ignore. Real implementations land as needed. (Transform ops
   // — save/restore/translate/scale/rotate/transform/setTransform/resetTransform
@@ -1205,6 +1290,7 @@ void mv_install_canvas(JSContext* ctx) {
   install(ctx, global, "__mv_canvasPutData", js_put_data, 6);
   install(ctx, global, "__mv_canvasDrawText", js_draw_text, 17);
   install(ctx, global, "__mv_canvasFillGradient", js_fill_gradient, 15);
+  install(ctx, global, "__mv_canvasFillPattern", js_fill_pattern, 13);
   install(ctx, global, "__mv_fontMeasure", js_measure_text, 2);
   install(ctx, global, "__mv_imageLoad", js_image_load, 1);
   JS_FreeValue(ctx, global);

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -182,6 +182,33 @@ assert 'MV::JS.present returns false for a bad handle or non-Bitmap' do
   assert_equal false, MV::JS.present("not a bitmap", 1)
 end
 
+assert 'MV canvas createPattern tiles a source across fillRect (repeat)' do
+  # 2x2 source: red, green / blue, white. MV's TilingSprite (parallax,
+  # battlebacks) fills with such a pattern; the tile must repeat as (x%2, y%2).
+  MV::JS.eval("globalThis.PS=document.createElement('canvas'); PS.width=2; PS.height=2; " \
+              "var s=PS.getContext('2d'); " \
+              "s.fillStyle='#ff0000'; s.fillRect(0,0,1,1); s.fillStyle='#00ff00'; s.fillRect(1,0,1,1); " \
+              "s.fillStyle='#0000ff'; s.fillRect(0,1,1,1); s.fillStyle='#ffffff'; s.fillRect(1,1,1,1); " \
+              "globalThis.PDST=document.createElement('canvas'); PDST.width=4; PDST.height=4; " \
+              "var x=PDST.getContext('2d'); x.fillStyle=x.createPattern(PS,'repeat'); x.fillRect(0,0,4,4);")
+  assert_equal "255,0,0,255", MV::JS.eval("__mv_canvasGetPixel(PDST.__h,0,0).join(',')")     # src(0,0)
+  assert_equal "0,255,0,255", MV::JS.eval("__mv_canvasGetPixel(PDST.__h,1,0).join(',')")     # src(1,0)
+  assert_equal "255,0,0,255", MV::JS.eval("__mv_canvasGetPixel(PDST.__h,2,0).join(',')")     # wrap -> src(0,0)
+  assert_equal "0,0,255,255", MV::JS.eval("__mv_canvasGetPixel(PDST.__h,0,1).join(',')")     # src(0,1)
+  assert_equal "255,255,255,255", MV::JS.eval("__mv_canvasGetPixel(PDST.__h,3,3).join(',')") # src(1,1)
+end
+
+assert 'MV canvas pattern fill honors the transform (translate anchors tiling)' do
+  # createPattern tiles anchored at the user-space origin, so a translate shifts
+  # which tile lands where; device(1,0) <- user(0,0)=red, device(0,0) <-
+  # user(-1,0) which wraps to src(1,0)=green.
+  MV::JS.eval("globalThis.PT2=document.createElement('canvas'); PT2.width=4; PT2.height=2; " \
+              "var x=PT2.getContext('2d'); x.translate(1,0); " \
+              "x.fillStyle=x.createPattern(PS,'repeat'); x.fillRect(-1,0,5,2);")
+  assert_equal "0,255,0,255", MV::JS.eval("__mv_canvasGetPixel(PT2.__h,0,0).join(',')")   # wrapped green
+  assert_equal "255,0,0,255", MV::JS.eval("__mv_canvasGetPixel(PT2.__h,1,0).join(',')")   # red
+end
+
 assert 'MV canvas translate offsets a drawImage blit' do
   MV::JS.eval("globalThis.TS=document.createElement('canvas'); TS.width=1; TS.height=1; " \
               "var s=TS.getContext('2d'); s.fillStyle='#ff0000'; s.fillRect(0,0,1,1);")

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -77,6 +77,35 @@ assert 'MV canvas putImageData ignores the current transform (device coords)' do
   assert_equal "7,8,9,255", MV::JS.eval("__mv_canvasGetPixel(PT.__h,0,0).join(',')")
 end
 
+assert "MV canvas globalCompositeOperation 'difference' yields |dest - source|" do
+  # White base, then 'difference' with #404040 -> |255-64| = 191 per channel.
+  MV::JS.eval("globalThis.DF=document.createElement('canvas'); DF.width=2; DF.height=2; " \
+              "var x=DF.getContext('2d'); x.fillStyle='#ffffff'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#404040'; x.fillRect(0,0,2,2);")
+  assert_equal "191,191,191,255", MV::JS.eval("__mv_canvasGetPixel(DF.__h,0,0).join(',')")
+end
+
+assert "MV canvas 'difference' white-on-white reads black (blend-mode probe)" do
+  # Graphics._testCanvasBlendModes fills white, then 'difference' white and reads
+  # the pixel: 0 means canUseDifferenceBlend, which negative screen tones need.
+  MV::JS.eval("globalThis.DP=document.createElement('canvas'); DP.width=1; DP.height=1; " \
+              "var x=DP.getContext('2d'); x.globalCompositeOperation='source-over'; " \
+              "x.fillStyle='white'; x.fillRect(0,0,1,1); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='white'; x.fillRect(0,0,1,1);")
+  assert_equal "0,0,0,255", MV::JS.eval("__mv_canvasGetPixel(DP.__h,0,0).join(',')")
+end
+
+assert 'MV canvas negative-tone sequence darkens (difference/lighter/difference)' do
+  # ToneSprite's negative-tone path: a -64 tone on a mid-grey frame -> invert,
+  # add 64, invert -> frame darkened by 64 (128 -> 64).
+  MV::JS.eval("globalThis.TN=document.createElement('canvas'); TN.width=2; TN.height=2; " \
+              "var x=TN.getContext('2d'); x.fillStyle='#808080'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='lighter'; x.fillStyle='#404040'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2);")
+  assert_equal "64,64,64,255", MV::JS.eval("__mv_canvasGetPixel(TN.__h,0,0).join(',')")
+end
+
 # A 2x2 RGBA PNG: pixel (0,0) is opaque red, the other three opaque green.
 MV_IMAGE_PNG =
   "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52" \


### PR DESCRIPTION
This PR adds two critical Canvas2D features needed for RPG Maker MV rendering:

## Summary
Implements `globalCompositeOperation = 'difference'` blend mode and `createPattern` with repeating tile fills in the Canvas2D bridge. These enable MV's negative screen tones (map darkening) and tiling sprites (parallax backgrounds, battlebacks) to render correctly.

## Key Changes

**Difference Blend Mode (`globalCompositeOperation = 'difference'`)**
- Added `blend_difference()` function implementing per-channel absolute difference blending: `|dest - source|`
- Extended `blend_mode()` dispatcher to handle mode 2 (difference) alongside existing source-over (0) and lighter/additive (1)
- Updated `compositeMode()` helper to map 'difference' string to mode 2
- MV's `ToneSprite` uses a difference/lighter/difference sequence to darken the frame for negative screen tones (night, caves, dungeons)
- The boot probe `Graphics.canUseDifferenceBlend()` now correctly detects support by reading white-on-white difference as black

**Pattern Tiling (`createPattern` and repeating fills)**
- Implemented `js_fill_pattern()` native function to tile a source canvas across a destination rect
- Tiling wraps source coordinates modulo source dimensions and anchors at the user-space origin (matching canvas 'repeat' semantics)
- Applies the current transformation matrix to map device pixels back to user space for correct tile positioning
- Updated `createPattern()` to return a pattern object with `__mvPattern` flag and source handle
- Added `_fillPatternRect()` method to dispatch pattern fills through the native tiler
- MV's `TilingSprite` (parallax layers, battle backgrounds) now renders by tiling textures correctly

**Supporting Changes**
- Refactored composite operation handling to use `compositeMode()` function in both `fillRect` and `drawImage` paths
- Added comprehensive unit tests covering difference blend behavior, white-on-white probe, negative tone darkening sequence, and pattern tiling with transforms

## Implementation Details
- Difference blend mixes the result with source alpha: `(|dest - source| * a + dest * (255-a)) / 255`
- Pattern tiling uses inverse matrix transformation to map each device pixel to user space, then wraps to source coordinates
- Modulo operation handles negative coordinates correctly: `((coord % size) + size) % size`
- All operations respect global alpha and maintain RGBA channel integrity

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8