### PR TITLE
Implement difference and saturation blend modes for screen tones

### DIFF
--- a/changelog.d/mv-saturation-tone.added.md
+++ b/changelog.d/mv-saturation-tone.added.md
@@ -1,0 +1,12 @@
+- MV grey / desaturation tones: the Canvas2D bridge now implements
+  `globalCompositeOperation = 'saturation'`, completing screen-tone support
+  alongside `'lighter'` (positive) and `'difference'` (negative). MV's
+  `ToneSprite` and per-sprite tinting desaturate by filling white in
+  `'saturation'` mode, gated on the boot probe `Graphics.canUseSaturationBlend()`
+  — which stayed false while the op fell through to source-over, so the grey
+  component of a screen tone (flashbacks, sepia/monochrome scenes) had no
+  effect. MV only ever fills white here, so the blend collapses each pixel to
+  its own luminosity (a brightness-preserving greyscale) by the fill's coverage;
+  the probe now passes. Implemented as blend mode 3 in
+  `mruby-mvjs/src/mvcanvas.cxx` and unit-tested in
+  `mruby-mvjs/test/canvas_test.rb`.

--- a/changelog.d/mv-screen-tone.added.md
+++ b/changelog.d/mv-screen-tone.added.md
@@ -1,0 +1,11 @@
+- MV negative screen tones (map darkening): the Canvas2D bridge now implements
+  `globalCompositeOperation = 'difference'`. MV's `ToneSprite` (the Canvas-path
+  screen-tone changer, used because we run PIXI's canvas renderer) darkens the
+  frame with a difference/lighter/difference fill sequence, gated on the boot
+  probe `Graphics.canUseDifferenceBlend()`. That probe reads a white-on-white
+  `difference` pixel and only enabled the path if it came back black — which it
+  never did while the op fell through to source-over, so negative tones (night,
+  caves, dungeons, "Tint Screen" event commands) had no effect. With the real
+  op, the probe passes and negative tones darken the map. Positive tones already
+  worked via `'lighter'`; `'saturation'` (grey/desaturation) stays disabled.
+  Unit-tested in `mruby-mvjs/test/canvas_test.rb`.

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -226,13 +226,34 @@ void blend_difference(uint8_t* d, int r, int g, int b, int a) {
   d[3] = static_cast<uint8_t>((a * 255 + d[3] * ia) / 255);
 }
 
+// "saturation" blend, as MV uses it: a white fill desaturates the backdrop.
+// The non-separable saturation mode takes the source's saturation (0 for white)
+// with the backdrop's hue and luminosity, so a white source collapses every
+// pixel to its own luminosity -- a greyscale that preserves brightness. MV only
+// ever fills white here (ToneSprite's grey tone, Sprite grey colour-tone), so
+// the source colour is ignored and each channel lerps toward the luminosity by
+// the coverage `a`. Reachable once the boot probe reports
+// canUseSaturationBlend, which it now does (white-on-black saturation reads
+// back black).
+void blend_saturation(uint8_t* d, int /*r*/, int /*g*/, int /*b*/, int a) {
+  if (a <= 0)
+    return;
+  // Rec. 601-ish luminosity with 0.30/0.59/0.11 weights scaled to /256.
+  const int lum = (77 * d[0] + 151 * d[1] + 28 * d[2]) >> 8;
+  d[0] = static_cast<uint8_t>(d[0] + (lum - d[0]) * a / 255);
+  d[1] = static_cast<uint8_t>(d[1] + (lum - d[1]) * a / 255);
+  d[2] = static_cast<uint8_t>(d[2] + (lum - d[2]) * a / 255);
+}
+
 // Dispatch by composite-op mode (0 = source-over, 1 = lighter/additive,
-// 2 = difference) threaded through from the Ctx.
+// 2 = difference, 3 = saturation) threaded through from the Ctx.
 inline void blend_mode(uint8_t* d, int r, int g, int b, int a, int mode) {
   if (mode == 1)
     blend_add(d, r, g, b, a);
   else if (mode == 2)
     blend_difference(d, r, g, b, a);
+  else if (mode == 3)
+    blend_saturation(d, r, g, b, a);
   else
     blend(d, r, g, b, a);
 }
@@ -826,13 +847,13 @@ const char* kCanvasPreamble = R"MVJS(
   Ctx.prototype.setTransform = function (a, b, c, d, e, f) { this._m = [a, b, c, d, e, f]; };
   Ctx.prototype.resetTransform = function () { this._m = [1, 0, 0, 1, 0, 0]; };
   // Map globalCompositeOperation to the native blend mode: 1 = lighter/additive
-  // (flashes, weather, positive tones), 2 = difference (negative screen tones).
-  // Everything else (including the default source-over) is 0; unsupported ops
-  // stay source-over, which is also why the boot blend-mode probe leaves
-  // saturation disabled.
+  // (flashes, weather, positive tones), 2 = difference (negative screen tones),
+  // 3 = saturation (grey/desaturation tones). Everything else (including the
+  // default source-over) is 0; unsupported ops stay source-over.
   function compositeMode(op) {
     if (op === 'lighter') return 1;
     if (op === 'difference') return 2;
+    if (op === 'saturation') return 3;
     return 0;
   }
   // Map the axis-aligned rect (x,y,w,h) through the current matrix to a device

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -207,11 +207,32 @@ void blend_add(uint8_t* d, int r, int g, int b, int a) {
   d[3] = static_cast<uint8_t>(std::min(255, d[3] + a));
 }
 
-// Dispatch to the source-over or additive blend based on a composite-op mode
-// (0 = source-over, 1 = lighter/additive) threaded through from the Ctx.
+// "difference" blend: |dest - source| per channel, mixed in by the source
+// coverage `a`. MV uses it (with opaque white / colour fills) to invert the
+// frame so a following additive fill subtracts instead of adds -- that is how
+// negative screen tones (night, caves, "tint screen" events) darken the map.
+// Reachable once the boot feature-probe reports canUseDifferenceBlend, which it
+// now does because this makes the probe's white-on-white difference read black.
+void blend_difference(uint8_t* d, int r, int g, int b, int a) {
+  if (a <= 0)
+    return;
+  const int ia = 255 - a;
+  const int dr = d[0] > r ? d[0] - r : r - d[0];
+  const int dg = d[1] > g ? d[1] - g : g - d[1];
+  const int db = d[2] > b ? d[2] - b : b - d[2];
+  d[0] = static_cast<uint8_t>((dr * a + d[0] * ia) / 255);
+  d[1] = static_cast<uint8_t>((dg * a + d[1] * ia) / 255);
+  d[2] = static_cast<uint8_t>((db * a + d[2] * ia) / 255);
+  d[3] = static_cast<uint8_t>((a * 255 + d[3] * ia) / 255);
+}
+
+// Dispatch by composite-op mode (0 = source-over, 1 = lighter/additive,
+// 2 = difference) threaded through from the Ctx.
 inline void blend_mode(uint8_t* d, int r, int g, int b, int a, int mode) {
   if (mode == 1)
     blend_add(d, r, g, b, a);
+  else if (mode == 2)
+    blend_difference(d, r, g, b, a);
   else
     blend(d, r, g, b, a);
 }
@@ -804,6 +825,16 @@ const char* kCanvasPreamble = R"MVJS(
   Ctx.prototype.transform = function (a, b, c, d, e, f) { this._m = matMul(this._m, [a, b, c, d, e, f]); };
   Ctx.prototype.setTransform = function (a, b, c, d, e, f) { this._m = [a, b, c, d, e, f]; };
   Ctx.prototype.resetTransform = function () { this._m = [1, 0, 0, 1, 0, 0]; };
+  // Map globalCompositeOperation to the native blend mode: 1 = lighter/additive
+  // (flashes, weather, positive tones), 2 = difference (negative screen tones).
+  // Everything else (including the default source-over) is 0; unsupported ops
+  // stay source-over, which is also why the boot blend-mode probe leaves
+  // saturation disabled.
+  function compositeMode(op) {
+    if (op === 'lighter') return 1;
+    if (op === 'difference') return 2;
+    return 0;
+  }
   // Map the axis-aligned rect (x,y,w,h) through the current matrix to a device
   // rect. Exact for translate/scale (the common case); for rotation/skew this
   // is the rect's bounding box, which is enough for the solid fills MV uses.
@@ -820,7 +851,7 @@ const char* kCanvasPreamble = R"MVJS(
     var c = parseColor(fs);
     var a = Math.round(c[3] * this.globalAlpha);
     var r = mapRect(this._m, x, y, w, h);
-    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
+    var mode = compositeMode(this.globalCompositeOperation);
     g.__mv_canvasFillRect(this.__h, r[0], r[1], r[2], r[3], c[0], c[1], c[2], a,
                           mode);
   };
@@ -872,7 +903,7 @@ const char* kCanvasPreamble = R"MVJS(
     }
     var a = Math.round(this.globalAlpha * 255);
     var m = this._m;
-    var mode = this.globalCompositeOperation === 'lighter' ? 1 : 0;
+    var mode = compositeMode(this.globalCompositeOperation);
     g.__mv_canvasDrawImage(this.__h, h, sx, sy, sw, sh, dx, dy, dw, dh, a,
                            m[0], m[1], m[2], m[3], m[4], m[5], mode);
   };

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -106,6 +106,31 @@ assert 'MV canvas negative-tone sequence darkens (difference/lighter/difference)
   assert_equal "64,64,64,255", MV::JS.eval("__mv_canvasGetPixel(TN.__h,0,0).join(',')")
 end
 
+assert "MV canvas 'saturation' white fill desaturates to luminosity (grey tone)" do
+  # A red frame fully desaturated -> grey at red's luminosity (0.30*255 ~= 76).
+  MV::JS.eval("globalThis.ST=document.createElement('canvas'); ST.width=2; ST.height=2; " \
+              "var x=ST.getContext('2d'); x.globalAlpha=1; x.fillStyle='#ff0000'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='saturation'; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2);")
+  assert_equal "76,76,76,255", MV::JS.eval("__mv_canvasGetPixel(ST.__h,0,0).join(',')")
+end
+
+assert "MV canvas 'saturation' white-on-black reads black (blend-mode probe)" do
+  # Graphics._testCanvasBlendModes: black, then 'saturation' white; pixel 0 sets
+  # canUseSaturationBlend, which the grey-tone path needs.
+  MV::JS.eval("globalThis.SP=document.createElement('canvas'); SP.width=1; SP.height=1; " \
+              "var x=SP.getContext('2d'); x.fillStyle='#000000'; x.fillRect(0,0,1,1); " \
+              "x.globalCompositeOperation='saturation'; x.fillStyle='#ffffff'; x.fillRect(0,0,1,1);")
+  assert_equal "0,0,0,255", MV::JS.eval("__mv_canvasGetPixel(SP.__h,0,0).join(',')")
+end
+
+assert "MV canvas 'saturation' respects globalAlpha (partial desaturation)" do
+  # Halfway from red (255,0,0) toward luminosity 76 -> (166,38,38).
+  MV::JS.eval("globalThis.SG=document.createElement('canvas'); SG.width=2; SG.height=2; " \
+              "var x=SG.getContext('2d'); x.globalAlpha=1; x.fillStyle='#ff0000'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='saturation'; x.globalAlpha=0.5; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2);")
+  assert_equal "166,38,38,255", MV::JS.eval("__mv_canvasGetPixel(SG.__h,0,0).join(',')")
+end
+
 # A 2x2 RGBA PNG: pixel (0,0) is opaque red, the other three opaque green.
 MV_IMAGE_PNG =
   "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52" \

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -77,6 +77,35 @@ assert 'MV canvas putImageData ignores the current transform (device coords)' do
   assert_equal "7,8,9,255", MV::JS.eval("__mv_canvasGetPixel(PT.__h,0,0).join(',')")
 end
 
+assert "MV canvas globalCompositeOperation 'difference' yields |dest - source|" do
+  # White base, then 'difference' with #404040 -> |255-64| = 191 per channel.
+  MV::JS.eval("globalThis.DF=document.createElement('canvas'); DF.width=2; DF.height=2; " \
+              "var x=DF.getContext('2d'); x.fillStyle='#ffffff'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#404040'; x.fillRect(0,0,2,2);")
+  assert_equal "191,191,191,255", MV::JS.eval("__mv_canvasGetPixel(DF.__h,0,0).join(',')")
+end
+
+assert "MV canvas 'difference' white-on-white reads black (blend-mode probe)" do
+  # Graphics._testCanvasBlendModes fills white, then 'difference' white and reads
+  # the pixel: 0 means canUseDifferenceBlend, which negative screen tones need.
+  MV::JS.eval("globalThis.DP=document.createElement('canvas'); DP.width=1; DP.height=1; " \
+              "var x=DP.getContext('2d'); x.globalCompositeOperation='source-over'; " \
+              "x.fillStyle='white'; x.fillRect(0,0,1,1); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='white'; x.fillRect(0,0,1,1);")
+  assert_equal "0,0,0,255", MV::JS.eval("__mv_canvasGetPixel(DP.__h,0,0).join(',')")
+end
+
+assert 'MV canvas negative-tone sequence darkens (difference/lighter/difference)' do
+  # ToneSprite's negative-tone path: a -64 tone on a mid-grey frame -> invert,
+  # add 64, invert -> frame darkened by 64 (128 -> 64).
+  MV::JS.eval("globalThis.TN=document.createElement('canvas'); TN.width=2; TN.height=2; " \
+              "var x=TN.getContext('2d'); x.fillStyle='#808080'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='lighter'; x.fillStyle='#404040'; x.fillRect(0,0,2,2); " \
+              "x.globalCompositeOperation='difference'; x.fillStyle='#ffffff'; x.fillRect(0,0,2,2);")
+  assert_equal "64,64,64,255", MV::JS.eval("__mv_canvasGetPixel(TN.__h,0,0).join(',')")
+end
+
 # A 2x2 RGBA PNG: pixel (0,0) is opaque red, the other three opaque green.
 MV_IMAGE_PNG =
   "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52" \


### PR DESCRIPTION
## Summary
This PR adds support for `globalCompositeOperation = 'difference'` and `'saturation'` blend modes in the Canvas2D bridge, enabling MV's negative (darkening) and grey (desaturation) screen tones to work correctly.

## Key Changes

- **Added `blend_difference()` function**: Implements the absolute difference blend mode (`|dest - source|` per channel), mixed in by source coverage. This enables negative screen tones (night, caves, dungeons) which use a difference/lighter/difference fill sequence to darken the map.

- **Added `blend_saturation()` function**: Implements a white-fill desaturation mode that collapses each pixel toward its own luminosity (brightness-preserving greyscale). This enables grey/desaturation tones used by `ToneSprite` and per-sprite tinting.

- **Extended blend mode dispatch**: Updated `blend_mode()` to handle modes 2 (difference) and 3 (saturation) in addition to the existing 0 (source-over) and 1 (lighter/additive).

- **Added `compositeMode()` helper**: Refactored the composite operation mapping into a reusable function that translates `globalCompositeOperation` strings to native blend mode integers (0-3), replacing inline conditional checks.

- **Updated fill and draw operations**: Modified `fillRect()` and `drawImage()` implementations to use the new `compositeMode()` function instead of hardcoded checks for `'lighter'`.

- **Comprehensive test coverage**: Added 6 new unit tests validating:
  - Difference blend arithmetic correctness
  - White-on-white difference probe (reads black, enabling `canUseDifferenceBlend`)
  - Negative tone sequence (difference/lighter/difference darkens correctly)
  - Saturation desaturation to luminosity
  - White-on-black saturation probe (reads black, enabling `canUseSaturationBlend`)
  - Saturation respects `globalAlpha` for partial desaturation

## Implementation Details

- **Luminosity calculation**: Uses Rec. 601-ish weights (0.30/0.59/0.11) scaled to /256 for efficient integer arithmetic in the saturation blend.
- **Coverage blending**: Both new modes properly blend the result with the destination using the source alpha coverage, maintaining consistency with existing blend operations.
- **Probe compatibility**: The implementations ensure that the boot-time feature probes (`Graphics._testCanvasBlendModes`) correctly detect support by returning the expected black pixels for white-on-white difference and white-on-black saturation operations.

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8