### PR TITLE
ci: drop the macOS build, the WASM build covers our needs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    strategy:
-      # Don't let a flaky failure on one OS (e.g. a corrupt nix-archive
-      # download in nix-quick-install-action) cancel the other OS's build.
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-24.04
-          - macos-latest
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
 
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -49,10 +41,6 @@ jobs:
 
       - run: nix develop -c echo test
 
-      # TODO: Restore macos wine if needed
-      # - run: brew install --cask wine@staging
-      #   if: ${{ !startsWith(matrix.os, 'macos') }}
-
       - name: cache rtp
         uses: actions/cache@v6
         id: rtp-cache
@@ -60,13 +48,11 @@ jobs:
           path: scripts/*.zip
           key: rtp-${{ hashFiles('./scripts/rtp*_install.bash') }}
           restore-keys: rtp-
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Download RTP
         run: |
           nix develop -c ./scripts/rtp_install.bash
           nix develop -c ./scripts/rtp_xp_install.bash
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: pre-commit
         env:
@@ -92,7 +78,7 @@ jobs:
         if: always()
         run: |
           {
-            echo "## sccache stats — ${{ matrix.os }}"
+            echo "## sccache stats"
             echo ""
             echo '```'
             nix develop -c sccache --show-stats
@@ -114,15 +100,12 @@ jobs:
           nix develop -c ./scripts/download-opengame-xp.bash
 
       - name: LCF test-bed smoke check
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: nix develop -c ruby scripts/lcf_testbed_check.rb
 
       - name: RPG XP test-bed smoke check
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: nix develop -c ruby scripts/rpgxp_testbed_check.rb
 
       - name: RPG2k game-logic checks
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           nix develop -c ruby scripts/rpg2k_logic_check.rb
           nix develop -c ruby scripts/rpg2k_scene_check.rb
@@ -136,11 +119,9 @@ jobs:
       # brought up: the step logs the engine's output/errors for iteration but
       # does not fail the build.
       - name: Download MV test game
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: nix develop -c ./scripts/download-lunatic-core.bash
 
       - name: MV boot smoke test
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         continue-on-error: true
         run: |
           mkdir -p ss
@@ -152,7 +133,6 @@ jobs:
       # while the maker is brought up. Best-effort: the boot is non-blocking, so
       # the screenshot may be missing on some runs.
       - name: Upload MV screenshot
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -164,11 +144,9 @@ jobs:
       # is in git; the MIT engine is fetched here. A controlled bed that boots to
       # a walkable map with a parallel test event. Non-blocking, like above.
       - name: Build MV sample engine
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: nix develop -c ./scripts/download-mv-corescript.bash
 
       - name: MV sample smoke test
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         continue-on-error: true
         run: |
           mkdir -p ss
@@ -177,7 +155,6 @@ jobs:
             --mv_new_game --mv_screenshot=ss/mv_sample.png
 
       - name: Upload MV sample screenshot
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -189,7 +166,6 @@ jobs:
       # against troop 1) so the battle scene — its windows and HP/MP gauges — is
       # exercised and captured. Non-blocking, like the other MV smoke tests.
       - name: MV battle smoke test
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         continue-on-error: true
         run: |
           mkdir -p ss
@@ -198,7 +174,6 @@ jobs:
             --mv_battle_test=1 --mv_screenshot=ss/mv_battle.png
 
       - name: Upload MV battle screenshot
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
The build job ran a two-OS matrix (ubuntu-24.04 + macos-latest) where the
macOS leg only ever exercised the native compile — every test, smoke check
and download step was gated behind startsWith(matrix.os, 'ubuntu'). With the
WASM job providing the portable artifact, the macOS runner adds cost without
coverage.

Collapse the build job to ubuntu-24.04, remove the now-redundant per-step
ubuntu guards and the macOS wine TODO, and drop matrix.os from the sccache
stats heading.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ACMFQeiuioyJSaoSwopJf