### PR TITLE
Fix RGSSAD decryption for entries larger than mruby array cap

### DIFF
--- a/changelog.d/rpgxp-rgssad-large-entry.fixed.md
+++ b/changelog.d/rpgxp-rgssad-large-entry.fixed.md
@@ -1,0 +1,12 @@
+- RPG Maker **XP** encrypted archives with large entries now load on the native
+  (mruby) runtime. `RPGXP::RGSSAD#decrypt_data` (`mruby-rpgxp/mrblib/rgssad.rb`)
+  had accumulated the whole decrypted entry into a single per-byte `Array`, which
+  overflowed mruby's array-length cap (`MRB_ARY_LENGTH_MAX`, 131072) on any
+  archived file bigger than 128 KB — real games pack maps, `Animations.rxdata`
+  and graphics well past that, so booting them raised
+  `ArgumentError: array size too big`. The decryptor now packs the plaintext in
+  bounded chunks and joins them, staying byte-for-byte identical to the previous
+  output while keeping every intermediate array small (CRuby, whose arrays are
+  unbounded, never hit this, so `scripts/rpgxp_testbed_check.rb` had not caught
+  it). Verified by booting the packed *Pray for You* project (222 archived
+  entries, no loose `Data/`).

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -42,7 +42,7 @@
 
 #if LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN
     /*Size of the memory available for `lv_malloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (16 * 1024U * 1024U)          /*[bytes]*/
+    #define LV_MEM_SIZE (64 * 1024U * 1024U)          /*[bytes]*/
 
     /*Size of the memory expand for `lv_malloc()` in bytes*/
     #define LV_MEM_POOL_EXPAND_SIZE 0

--- a/mruby-rpgxp/mrblib/rgssad.rb
+++ b/mruby-rpgxp/mrblib/rgssad.rb
@@ -32,7 +32,9 @@
 # Implemented with byte-wise arithmetic only — no bignum bitwise operators, no
 # `Integer#chr` / String-ext helpers — so it runs on this trimmed mruby the same
 # as under CRuby (where scripts/rpgxp_testbed_check.rb exercises it against real
-# data). Decrypted bytes are assembled with `Array#pack("C*")` (mruby-pack).
+# data). Decrypted bytes are assembled by packing bounded chunks with
+# `Array#pack("C*")` (mruby-pack) and joining them, so no single Array grows past
+# mruby's array-length cap on large entries.
 
 class RPGXP
   class RGSSAD
@@ -41,6 +43,9 @@ class RPGXP
     MASK = 0x100000000 # 2**32
     # Little-endian byte multipliers, so an int is rebuilt without bit-shifting.
     POW = [1, 256, 65536, 16777216].freeze
+    # Max per-byte integers held in one Array while decrypting, kept under mruby's
+    # MRB_ARY_LENGTH_MAX (131072) so a large entry does not overflow the Array.
+    DECRYPT_CHUNK = 65536
 
     # The archive path for a game directory (Game.rgssad / .rgss2a / .rgss3a), or
     # nil when the project is unpacked. Extensions are tried in release order.
@@ -61,7 +66,16 @@ class RPGXP
     # project and as the fixture builder for the archive tests.
     def self.pack_v1(files)
       key = START_KEY
+      # Accumulate into bounded chunks (see DECRYPT_CHUNK): a whole archive is far
+      # larger than mruby's array-length cap, so a single `out` array would
+      # overflow. `flush` empties `out` in place so the closures below keep
+      # writing to the same array.
+      parts = []
       out = [0x52, 0x47, 0x53, 0x53, 0x41, 0x44, 0x00, 0x01] # "RGSSAD\0" + v1
+      flush = lambda do
+        parts << out.pack("C*") unless out.empty?
+        out.clear
+      end
       put_int = lambda do |v|
         b = 0
         while b < 4
@@ -88,11 +102,13 @@ class RPGXP
             j = 0
           end
           out << (bytes.getbyte(idx) ^ ((dkey / POW[j]) % 256))
+          flush.call if out.size >= DECRYPT_CHUNK
           j += 1
           idx += 1
         end
       end
-      out.pack("C*")
+      flush.call
+      parts.join
     end
 
     # Build a version-3 (`.rgss3a`) archive from `files` ([name, bytes] pairs).
@@ -113,7 +129,14 @@ class RPGXP
       pos = 12 + table_size
       entries.each { |e| e[:offset] = pos; pos += e[:bytes].bytesize }
 
+      # Bounded-chunk accumulation, as in pack_v1 (a full archive overflows a
+      # single mruby array); `flush` empties `out` in place for the closures.
+      parts = []
       out = [0x52, 0x47, 0x53, 0x53, 0x41, 0x44, 0x00, 0x03] # "RGSSAD\0" + v3
+      flush = lambda do
+        parts << out.pack("C*") unless out.empty?
+        out.clear
+      end
       b = 0
       while b < 4 # plaintext seed, little-endian
         out << ((seed / POW[b]) % 256)
@@ -150,11 +173,13 @@ class RPGXP
             j = 0
           end
           out << (bytes.getbyte(idx) ^ ((dkey / POW[j]) % 256))
+          flush.call if out.size >= DECRYPT_CHUNK
           j += 1
           idx += 1
         end
       end
-      out.pack("C*")
+      flush.call
+      parts.join
     end
 
     # A name's bytes with '/' rewritten to '\' (works without String#tr).
@@ -313,9 +338,17 @@ class RPGXP
 
     # Decrypt `size` bytes of file data, seeded from `seed` (the key right after
     # the size field). The key advances every four bytes.
+    #
+    # The plaintext is assembled in bounded chunks rather than one big Array of
+    # per-byte integers: mruby caps Array length at MRB_ARY_LENGTH_MAX (131072),
+    # so a single accumulating array overflows on any archived entry larger than
+    # that (real XP games pack maps, Animations.rxdata and graphics well past it).
+    # Packing each chunk to a String and joining stays byte-for-byte identical to
+    # the old `out.pack("C*")` while keeping every intermediate array tiny.
     def decrypt_data(bytes, seed)
       key = seed
-      out = []
+      parts = []
+      chunk = []
       j = 0
       idx = 0
       n = bytes.bytesize
@@ -324,11 +357,16 @@ class RPGXP
           key = advance(key)
           j = 0
         end
-        out << (bytes.getbyte(idx) ^ key_byte(key, j))
+        chunk << (bytes.getbyte(idx) ^ key_byte(key, j))
+        if chunk.size >= DECRYPT_CHUNK
+          parts << chunk.pack("C*")
+          chunk = []
+        end
         j += 1
         idx += 1
       end
-      out.pack("C*")
+      parts << chunk.pack("C*") unless chunk.empty?
+      parts.join
     end
 
     # Canonical archive form of a lookup name: '/' separators rewritten to '\'.

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -563,6 +563,29 @@ assert "RGSSAD v3 carries real Marshal data through the archive" do
   assert_equal 7, loaded.start_map_id
 end
 
+# An entry larger than mruby's array-length cap (MRB_ARY_LENGTH_MAX, 131072) must
+# still pack and read back byte-for-byte: real games ship maps, Animations.rxdata
+# and graphics well past that, and accumulating one integer per byte used to
+# overflow the Array. Build the payload with String#* (not a big Array literal,
+# which would hit the same cap here) and compare with == / bytesize so the check
+# itself never materialises an over-cap Array.
+assert "RGSSAD round-trips an entry larger than the mruby array cap" do
+  pattern = (0..255).to_a.pack("C*")           # 256 bytes, every value
+  big = pattern * 900                            # 230400 bytes, over the cap
+  assert_true big.bytesize > 131072
+  [:pack_v1, :pack_v3].each do |packer|
+    files = [
+      ["Data\\Small.rxdata", "hi\x00\xff"],
+      ["Data\\Big.rxdata", big]
+    ]
+    a = RPGXP::RGSSAD.new(RPGXP::RGSSAD.send(packer, files))
+    got = a.read("Data\\Big.rxdata")
+    assert_equal big.bytesize, got.bytesize
+    assert_true big == got
+    assert_equal "hi\x00\xff".bytes, a.read("Data\\Small.rxdata").bytes
+  end
+end
+
 # ---- Autonomous event movement: Character / MoveRoute / MoveType -----------
 
 # World stand-in for the movement engine.


### PR DESCRIPTION
## Summary
Fixed a critical bug in RPG Maker XP encrypted archive handling where decrypting entries larger than mruby's array-length cap (131,072 bytes) would fail with an `ArgumentError`. Real game archives commonly contain maps, Animations.rxdata, and graphics well exceeding this limit.

## Changes
- **Modified `RPGXP::RGSSAD#decrypt_data`**: Changed from accumulating all decrypted bytes in a single array to packing bounded chunks (65,536 bytes each) into strings and joining them. This keeps intermediate arrays small while maintaining byte-for-byte identical output.

- **Updated `pack_v1` and `pack_v3` methods**: Applied the same bounded-chunk accumulation pattern when building archives, preventing overflow during the encryption process for large files.

- **Added `DECRYPT_CHUNK` constant**: Set to 65,536 to stay well under mruby's `MRB_ARY_LENGTH_MAX` (131,072), ensuring no single array grows too large during decryption or packing.

- **Added comprehensive test**: New test case verifies that entries larger than the array cap (230,400 bytes in the test) round-trip correctly through both `pack_v1` and `pack_v3` without overflow.

- **Updated documentation**: Enhanced comments explaining the bounded-chunk approach and why it's necessary for mruby compatibility.

- **Increased LVGL memory pool**: Bumped `LV_MEM_SIZE` from 16 MB to 64 MB in `include/lv_conf.h` to support larger asset handling.

## Implementation Details
The fix maintains complete compatibility with CRuby (which has unbounded arrays) by using the same `Array#pack("C*")` and `String#join` operations. The chunking is transparent to callers—the decrypted output is identical to the previous implementation, just assembled differently to avoid mruby's array-length limitations.

https://claude.ai/code/session_01VYQwWSTjWgrTp3itVB4tpd