### PR TITLE
Scale actor base stats with level; restore level/exp on Continue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,11 @@ Create ADRs in /docs/adr for:
   the data (or the rpg2kpsp analysis wiki) spells out, per ADR 0002.
 - The runtime can resume from a real save: `Game::State.from_lsd(db, save)`
   rebuilds a `State` from a parsed `LcfSaveData` (leader position, party roster,
-  gold, items, switches, variables, and the roster's saved current HP/MP from
-  chunk 108), and `continue_game` loads an editor `Save<N>.lsd` when present.
+  gold, items, switches, variables, and each roster actor's saved level/exp and
+  current HP/MP from chunk 108), and `continue_game` loads an editor
+  `Save<N>.lsd` when present. Actor base stats scale with level from the database
+  growth curve (chunk 31, six shorts per level, via `LCF::Array1D#int16_values`),
+  so a restored level rescales the maxima — see ADR 0015.
   `ruby scripts/rpg2k_save_load_check.rb` round-trips a real save through it. Use
   `save[101]`, not `save.system`, in CRuby-tested code — `system` resolves to
   `Kernel#system` there.

--- a/changelog.d/level-scaled-stats-restore-level.added.md
+++ b/changelog.d/level-scaled-stats-restore-level.added.md
@@ -1,0 +1,8 @@
+- The RPG2000 runtime now **scales actor base stats with level** from the
+  database growth curve (chunk 31, six shorts per level, read via the new
+  `LCF::Array1D#int16_values`), and **Continue restores each roster member's
+  saved level and exp** before its current HP/MP -- so a resumed party comes back
+  levelled and wounded with HP/MP inside correctly-scaled maxima, instead of
+  keeping level-1 stats. New Game also honours a non-1 initial level.
+  `rpg2k_save_load_check.rb` asserts the restored level/exp and the HP/MP bounds.
+  See ADR 0015.

--- a/docs/adr/0015-level-scaled-base-stats-and-restore-level-on-continue.md
+++ b/docs/adr/0015-level-scaled-base-stats-and-restore-level-on-continue.md
@@ -1,0 +1,47 @@
+# 15. Level-scaled base stats and restoring level/exp on Continue
+
+Date: 2026-08-03
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0014 decoded the per-actor save chunk (level, exp, equipment, current HP/MP)
+and restored current HP/MP on Continue, but flagged a gap: the runtime derived an
+actor's max HP/SP (and the four battle stats) from the database at the actor's
+*initial* level and never scaled them, so a resumed level-8 hero kept level-1
+maxima and `from_lsd` restored current HP/MP against the wrong ceiling. The
+database actually stores a full growth curve -- chunk 31 of each actor is six
+shorts (maxHP, maxSP, atk, def, int, agi) *per level* -- but the schema's `status`
+accessor, via its `order:` mapping, only ever surfaced the first (level-1) row.
+
+## Decision
+
+- **`LCF::Array1D#int16_values(idx)`** returns a chunk's raw little-endian short
+  array, bypassing the `order:` mapping, so a caller can read the whole parameter
+  curve rather than just its first row. `status` (the named level-1 view) is
+  unchanged, keeping its schema and unit test intact.
+- **`Game::Actor` scales its base stats with level.** `base_stats(level)` indexes
+  the growth curve (via `int16_values(31)`) at the actor's level, clamped to the
+  curve's length; `set_level(level)` recomputes the six stats and re-clamps
+  current HP/MP to the new maxima. A row that only offers a `status` hash (the
+  test fixtures, or a database without a curve) is treated as level-independent,
+  so `Actor` works with both. New Game now also honours a non-1 initial level.
+- **`Game::State.from_lsd`** restores each roster member's saved level (rescaling
+  its stats) and exp before applying the saved current HP/MP, so Continue resumes
+  a levelled, wounded party whose HP/MP sit within correctly-scaled maxima.
+
+## Consequences
+
+- Continue rebuilds actors at their real level: `rpg2k_save_load_check.rb` now
+  asserts the restored level and exp and that each actor's current HP/MP stays
+  within its rescaled maxima; the real Nepheshel save still round-trips (its
+  level-1 leader is unchanged). The existing logic (81) and scene checks pass,
+  and the New Game path is unaffected for level-1 actors because the curve's
+  first row equals the old level-1 status.
+- Only base stats scale; equipment bonuses, per-state modifiers and exp-driven
+  level-up are still not modelled, and `exp` is stored but no gain-exp path
+  consumes it yet -- follow-up. The growth curve is read straight from the
+  database, so no save fixture is bundled.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -292,6 +292,15 @@ module LCF
       !@data[idx].nil?
     end
 
+    # Raw little-endian int16 values of a chunk, bypassing any schema `order`
+    # mapping. Lets a caller read a variable-length short array (e.g. the actor
+    # parameter growth curve, six shorts per level) whose named accessor only
+    # surfaces the first row. Returns nil when the chunk is absent.
+    def int16_values idx
+      d = @data[idx]
+      d && d.unpack('s<*')
+    end
+
     def method_missing sym, *args
       raise args unless args.empty?
       self[@sym2idx[sym]]

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -125,6 +125,19 @@ assert "LCF::Array1D#key? distinguishes an absent chunk from a present one" do
   assert_false row.key?(2)
 end
 
+assert "LCF::Array1D#int16_values reads a raw short array past a named accessor" do
+  # Chunk 31 with a two-level parameter curve (six shorts per level); the named
+  # `status` accessor only surfaces the first row, int16_values sees all of it.
+  status = [10, 5, 3, 2, 1, 4, 20, 10, 6, 4, 2, 8]
+  row = LCF::Array1D.new(
+    lcf_array1d([lcf_shorts_field(31, status)]),
+    { elements: { 31 => { name: :status, type: :int16_array,
+                          order: [:max_hp, :max_mp, :atk, :def, :int, :agi] } } })
+  assert_equal 10, row.status[:max_hp]        # named accessor: level 1 only
+  assert_equal status, row.int16_values(31)   # raw: the whole curve
+  assert_nil row.int16_values(99)             # absent chunk
+end
+
 assert "LCF::Database#maker detects RPG2003 by the Classes section (chunk 30)" do
   actor = lcf_array1d([lcf_str_field(1, "Hero"), lcf_int_field(57, 3)])
   klass = lcf_array1d([lcf_str_field(1, "Soldier")])

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -307,9 +307,13 @@ module Game
 
   # One party member, snapshotted from the database's actor (player) table.
   class Actor
-    attr_reader :id, :name, :level, :charset_name, :charset_index
+    attr_reader :id, :name, :level, :exp, :charset_name, :charset_index
     attr_accessor :hp, :mp
     attr_reader :max_hp, :max_mp, :atk, :def, :int, :agi
+
+    # The six base stats in database parameter-curve order (chunk 31 stores six
+    # shorts -- maxHP, maxSP, atk, def, int, agi -- per level).
+    STAT_NAMES = [:max_hp, :max_mp, :atk, :def, :int, :agi].freeze
 
     def initialize(db, id)
       @id = id
@@ -319,17 +323,49 @@ module Game
       @name = a.name
       @charset_name = a.charset_name
       @charset_index = a.charset_index
-      @level = a.initial_level
-      st = a.status || {}
-      @max_hp = st[:max_hp] || 0
-      @max_mp = st[:max_mp] || 0
-      @atk = st[:atk] || 0
-      @def = st[:def] || 0
-      @int = st[:int] || 0
-      @agi = st[:agi] || 0
-      # A fresh actor starts at full health.
+      @db_row = a
+      @exp = 0
+      # Base stats scale with level from the growth curve, so seed them at the
+      # actor's initial level, then start at full health.
+      set_level(a.initial_level || 1)
       @hp = @max_hp
       @mp = @max_mp
+    end
+
+    attr_writer :exp
+
+    # Set the actor's level and recompute the six base stats from the database
+    # growth curve at that level (see #base_stats). Current HP/MP are re-clamped
+    # to the new maxima so lowering the level never leaves a stat over its cap.
+    def set_level(level)
+      @level = level && level >= 1 ? level : 1
+      s = base_stats(@level)
+      @max_hp = s[0]
+      @max_mp = s[1]
+      @atk = s[2]
+      @def = s[3]
+      @int = s[4]
+      @agi = s[5]
+      @hp = @max_hp if @hp && @hp > @max_hp
+      @mp = @max_mp if @mp && @mp > @max_mp
+    end
+
+    # The six base stats at `level`. Real database rows expose the full growth
+    # curve (six shorts per level) via LCF::Array1D#int16_values; index it by
+    # level, clamped to the curve's length. A row that only offers a single
+    # `status` hash (the test fixtures, or a database without a curve) is treated
+    # as level-independent.
+    def base_stats(level)
+      a = @db_row
+      curve = a.respond_to?(:int16_values) ? a.int16_values(31) : nil
+      if curve && curve.size >= STAT_NAMES.size
+        levels = curve.size / STAT_NAMES.size
+        lv = level > levels ? levels : level
+        base = (lv - 1) * STAT_NAMES.size
+        return STAT_NAMES.each_index.map { |i| curve[base + i] || 0 }
+      end
+      st = (a.respond_to?(:status) ? a.status : nil) || {}
+      STAT_NAMES.map { |k| st[k] || 0 }
     end
 
     # Apply a HP change (positive heals, negative damages), clamped to
@@ -983,13 +1019,19 @@ module Game
       ids = inv.item_ids || []
       counts = inv.item_counts || []
       ids.each_index { |i| items[ids[i]] = counts[i] || 0 }
-      # Per-actor vitals come from the SAVE_PARTY_ACTOR table (chunk 108), keyed
-      # by actor id. Restore the saved current HP/SP for the roster so Continue
-      # resumes a wounded party rather than silently healing it to full.
+      # Per-actor state comes from the SAVE_PARTY_ACTOR table (chunk 108), keyed
+      # by actor id. Restore each roster member's saved level (which rescales its
+      # base stats) and exp first, then its current HP/SP, so Continue resumes a
+      # levelled, wounded party rather than a fresh full-health one.
       hp = {}
       mp = {}
       (save[108] || []).each do |aid, sa|
         next unless roster.include?(aid)
+        actor = party.actor_by_id(aid)
+        if actor
+          actor.set_level(sa.level) if sa.level
+          actor.exp = sa.exp if sa.exp
+        end
         hp[aid] = sa.hp if sa.hp
         mp[aid] = sa.mp if sa.mp
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -882,6 +882,19 @@ end
 # Game::Actor read (player table + the initial party list).
 FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
                            :initial_level, :status)
+# Like FakePlayerRow but exposing the full growth curve the way a real LCF row
+# does (six shorts per level via #int16_values(31)), so Actor scales its base
+# stats by level instead of using a single level-independent status hash.
+class CurveRow < FakePlayerRow
+  def initialize(name, cs, ci, level, curve)
+    super(name, cs, ci, level, nil)
+    @curve = curve
+  end
+
+  def int16_values(idx)
+    idx == 31 ? @curve : nil
+  end
+end
 FakeActorSystem = Struct.new(:party)
 class FakeActorDB
   attr_reader :player, :system
@@ -945,6 +958,36 @@ check 'Actor change_hp/change_mp/full_heal clamp within their bounds' do
   hero.hp = 10; hero.mp = 5
   hero.full_heal
   eq [100, 30], [hero.hp, hero.mp]
+end
+
+check 'Actor base stats scale with level from the growth curve' do
+  # Two levels, six stats each: L1 = maxhp10/maxmp5/atk3/def2/int1/agi4,
+  # L2 = double each (except as listed).
+  curve = [10, 5, 3, 2, 1, 4,  20, 10, 6, 4, 2, 8]
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, curve) }, [1])
+  a = Game::Party.new(db).leader
+  eq 1, a.level
+  eq [10, 5, 3, 2, 1, 4], [a.max_hp, a.max_mp, a.atk, a.def, a.int, a.agi]
+  eq 10, a.hp                       # a fresh actor starts full
+  a.set_level(2)
+  eq [20, 10, 6, 4, 2, 8], [a.max_hp, a.max_mp, a.atk, a.def, a.int, a.agi]
+  # A level past the curve clamps to its last entry rather than reading past it.
+  a.set_level(99)
+  eq 20, a.max_hp
+  # Lowering the level re-clamps current HP/MP to the smaller maxima.
+  a.hp = 20; a.mp = 10
+  a.set_level(1)
+  eq [10, 5], [a.hp, a.mp]
+end
+
+check 'Actor without a growth curve falls back to a level-independent status' do
+  # party_state uses FakePlayerRow (a status hash, no int16_values): stats stay
+  # put regardless of level, and the initial level is honoured.
+  hero = party_state.party.actor_by_id(1)
+  eq 5, hero.level
+  eq [100, 30], [hero.max_hp, hero.max_mp]
+  hero.set_level(2)
+  eq [100, 30], [hero.max_hp, hero.max_mp]
 end
 
 check 'Change HP command damages a fixed actor' do

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -94,8 +94,14 @@ def check_game(dir)
   state.party.actors.each do |a|
     sa = saved[a.id]
     next unless sa
+    # Level (which rescales base stats) and exp are restored too, and the
+    # rescaled max HP/MP must still bound the restored current HP/MP.
+    eq sa.level, a.level, "actor #{a.id} level" if sa.level
+    eq sa.exp, a.exp, "actor #{a.id} exp" if sa.exp
     eq sa.hp, a.hp, "actor #{a.id} hp" if sa.hp
     eq sa.mp, a.mp, "actor #{a.id} mp" if sa.mp
+    eq true, a.hp <= a.max_hp, "actor #{a.id} hp within max (#{a.hp}/#{a.max_hp})"
+    eq true, a.mp <= a.max_mp, "actor #{a.id} mp within max (#{a.mp}/#{a.max_mp})"
   end
 
   # Switches/variables shift from the save's 0-indexed arrays to 1-indexed ids.


### PR DESCRIPTION
## Summary

Follow-up to #142. That PR decoded per-actor save state and restored current HP/MP, but flagged a gap: the runtime derived max HP/SP and the battle stats from the database at an actor's **initial** level and never scaled them, so a resumed high-level hero kept level-1 maxima and HP/MP were restored against the wrong ceiling. The database actually stores a full growth curve (chunk 31: six shorts — maxHP, maxSP, atk, def, int, agi — **per level**), but the `status` accessor only surfaced the level-1 row. This reads the curve and scales.

## What changed

- **`LCF::Array1D#int16_values(idx)`** returns a chunk's raw little-endian short array, bypassing the schema `order:` mapping — so the full parameter curve can be read, not just its first row. `status` is unchanged.
- **`Game::Actor` scales base stats with level.** `base_stats(level)` indexes the growth curve (`int16_values(31)`) at the actor's level, clamped to the curve length; `set_level(level)` recomputes the six stats and re-clamps current HP/MP to the new maxima. A row that only offers a `status` hash (test fixtures / a DB without a curve) stays level-independent, so both shapes work. New Game now also honours a non-1 initial level.
- **`Game::State.from_lsd`** restores each roster member's saved **level** (rescaling its stats) and **exp** before its current HP/MP — Continue resumes a levelled, wounded party whose HP/MP sit within correctly-scaled maxima.

## Validation

Verified on real data — Nepheshel actor 1 scales exactly to its curve: **L1 → 50, L2 → 82, L8 → 456** max HP (473 max MP, 491 atk at L8).

| Check | Result |
|-------|--------|
| `rpg2k_logic_check.rb` | 81 checks passed (incl. new curve-scaling + fallback tests) |
| `rpg2k_scene_check.rb` | 26 checks passed |
| `rpg2k_save_load_check.rb` | real save round-trips; asserts restored level/exp and HP/MP within rescaled maxima |
| `lcf_testbed_check.rb` | 1151 maps parse cleanly |

New mruby unit test for `int16_values`; logic-check fixtures (`CurveRow`) exercise level scaling and the hash fallback. New Game is unaffected for level-1 actors because the curve's first row equals the old level-1 `status`.

## Scope / follow-up

Only base stats scale; equipment bonuses, per-state modifiers and exp-driven level-up aren't modelled yet, and `exp` is stored but no gain-exp path consumes it — follow-up. The growth curve is read straight from the database (no save fixture bundled). See ADR 0015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG)_