### PR TITLE
Add MV movement smoke test to verify input walks the player

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,18 @@ jobs:
           path: ss/mv_battle.png
           if-no-files-found: warn
 
+      # Confirm input actually walks the player (not just that the map renders):
+      # New Game -> map, then hold a direction for a spell and log the player's
+      # start/end tile with `[MV-MOVE] ... moved=<bool>`. Non-blocking, like the
+      # other MV smoke tests; the lines show up in the job log for inspection.
+      - name: MV movement smoke test
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        continue-on-error: true
+        run: |
+          nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+            --timeout_ms=6000 --game_dir data/mv-sample \
+            --mv_new_game --mv_move_test
+
   wasm:
     runs-on: ubuntu-24.04
     env:

--- a/changelog.d/mv-move-smoke.added.md
+++ b/changelog.d/mv-move-smoke.added.md
@@ -1,0 +1,10 @@
+- MV movement smoke check: a new `--mv_move_test` flag drives the committed MV
+  sample past New Game onto the map, then holds a direction (cycling
+  down/right/up/left so an open direction is found on any map) and logs the
+  player's start/end tile as `[MV-MOVE] ... moved=<bool>`. It exercises the full
+  gameplay path — `RGSS::Input` → `MV#sync_input` → MV's `Input` → `Scene_Map` →
+  `Game_Player` → `Game_Map` passability → position — so CI confirms input
+  actually walks the player, not just that the map renders. Wired as a
+  non-blocking `build` job step alongside the existing MV boot/battle smokes. The
+  direction cycling (`MV.move_probe_dir`) is unit-tested in
+  `mruby-mvjs/test/input_test.rb`.

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -19,6 +19,13 @@ class MV
   WIDTH = 816
   HEIGHT = 624
 
+  # Movement probe (see #maybe_move_test): frames each direction is held, and the
+  # total run length. It cycles down/right/up/left so at least one open direction
+  # is exercised on any map. Class-level so both the probe and its unit test see
+  # them.
+  MOVE_PROBE_DWELL = 20
+  MOVE_PROBE_FRAMES = 80
+
   # The files that unambiguously mark a directory as an RPG Maker MV project:
   # the core engine script and the system database. (MZ uses `js/rmmz_core.js`
   # instead and is a separate, later target — see ADR 0004, milestone M6.)
@@ -132,6 +139,14 @@ class MV
       input_map.select { |key, _| RGSS::Input.press?(key) }.values
     end
 
+    # The RGSS::Input direction key the movement probe holds on a given frame.
+    # Split out so the cycling is unit-testable without a booted game.
+    def move_probe_dir(frame)
+      dirs = [RGSS::Input::DOWN, RGSS::Input::RIGHT,
+              RGSS::Input::UP, RGSS::Input::LEFT]
+      dirs[(frame / MOVE_PROBE_DWELL) % dirs.length]
+    end
+
     # JS that pushes a pointer sample (canvas x/y, left-button pressed) into MV's
     # TouchInput: it sets `_x`/`_y` and feeds `_newState` the triggered/released/
     # moved edges MV's DOM handlers would, tracking the previous state on the
@@ -243,6 +258,7 @@ class MV
     log_scene_transition # trace boot progress (Scene_Boot -> Scene_Title -> ...)
     maybe_new_game # CI: auto-advance past the title to the first map
     maybe_battle_test # CI: start a test battle once on the map, if requested
+    maybe_move_test # CI: hold a direction on the map and log that the player moved
     present # M4: copy the MV canvas onto the on-screen sprite's bitmap
     maybe_screenshot # capture the rendered frame once, if requested (CI)
     RGSS::Input.update
@@ -376,7 +392,7 @@ class MV
     rescue StandardError
       false
     end
-    return unless new_game || battle_test_troop > 0
+    return unless new_game || battle_test_troop > 0 || move_test_requested?
     return unless current_scene == "Scene_Title"
 
     @new_game_done = true
@@ -419,6 +435,58 @@ class MV
       0
     end
     v.is_a?(Integer) ? v : 0
+  end
+
+  # Whether --mv_move_test was requested (a launcher constant set by main.cxx).
+  def move_test_requested?
+    (begin
+      MV_MOVE_TEST
+    rescue StandardError
+      false
+    end) == true
+  end
+
+  # The player's current map tile as "x,y", or "" if the game isn't up yet.
+  def player_tile
+    MV::JS.eval("($gamePlayer ? ($gamePlayer.x + ',' + $gamePlayer.y) : '')")
+  rescue StandardError
+    ""
+  end
+
+  # When --mv_move_test is set (CI), once on the map hold a direction — cycling
+  # so some open direction is found — via RGSS::Input for MOVE_PROBE_FRAMES
+  # frames, then log the player's start/end tile and whether it ever moved. This
+  # drives the full path (RGSS::Input -> sync_input -> MV Input -> Scene_Map ->
+  # Game_Player -> Game_Map passability -> position), so a headless run confirms
+  # input actually walks the player, not just that the map renders. The input is
+  # pushed into MV by next frame's #sync_input. One-shot; a no-op during normal
+  # play (flag unset).
+  def maybe_move_test
+    return if @move_test_done
+    return unless move_test_requested?
+    return unless current_scene == "Scene_Map"
+
+    @move_frame ||= 0
+    if @move_frame.zero?
+      @move_start = player_tile
+      $stderr.puts "[MV-MOVE] start #{@move_start}"
+    end
+    cur = player_tile
+    @move_seen = true if !cur.empty? && cur != @move_start
+
+    dirs = [RGSS::Input::UP, RGSS::Input::DOWN, RGSS::Input::LEFT,
+            RGSS::Input::RIGHT]
+    dirs.each { |k| RGSS::Input.release(k) }
+    @move_frame += 1
+    if @move_frame < MOVE_PROBE_FRAMES
+      RGSS::Input.press(self.class.move_probe_dir(@move_frame))
+      return
+    end
+
+    @move_test_done = true
+    $stderr.puts "[MV-MOVE] end #{player_tile} moved=#{@move_seen ? true : false}"
+  rescue StandardError => e
+    $stderr.puts "[MV] move test error: #{e.message}"
   end
 
   # Log the running scene's class name whenever it changes, so the boot's

--- a/mruby-mvjs/test/input_test.rb
+++ b/mruby-mvjs/test/input_test.rb
@@ -54,3 +54,16 @@ assert 'MV pushes held buttons into Input._currentState (and clears released)' d
     MV::JS.eval("delete globalThis.Input;")
   end
 end
+
+assert 'MV movement probe cycles direction every dwell window' do
+  # The --mv_move_test probe holds down, then right, then up, then left (each for
+  # MOVE_PROBE_DWELL frames) so some open direction moves the player on any map.
+  d = MV::MOVE_PROBE_DWELL
+  assert_equal RGSS::Input::DOWN, MV.move_probe_dir(0)
+  assert_equal RGSS::Input::DOWN, MV.move_probe_dir(d - 1)
+  assert_equal RGSS::Input::RIGHT, MV.move_probe_dir(d)
+  assert_equal RGSS::Input::UP, MV.move_probe_dir(2 * d)
+  assert_equal RGSS::Input::LEFT, MV.move_probe_dir(3 * d)
+  # Wraps back to down after all four.
+  assert_equal RGSS::Input::DOWN, MV.move_probe_dir(4 * d)
+end

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -47,6 +47,12 @@ DEFINE_int32(
     "For RPG Maker MV: once on the map, start a test battle against this troop "
     "id (implies --mv_new_game to reach the map). 0 disables. Used to capture "
     "the battle scene in CI");
+DEFINE_bool(
+    mv_move_test,
+    false,
+    "For RPG Maker MV: once on the map, hold a direction for a spell (implies "
+    "--mv_new_game to reach the map) and log the player's start/end tile, so a "
+    "headless run confirms input actually moves the player. Used in CI");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -434,6 +440,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_BATTLE_TEST"),
                 mrb_fixnum_value(FLAGS_mv_battle_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MV_MOVE_TEST"),
+                mrb_bool_value(FLAGS_mv_move_test));
   CHECK_NO_EXC(M);
 
   const mrb_value args = mrb_ary_new_capa(M, argc - 1);


### PR DESCRIPTION
## Summary
Adds a new `--mv_move_test` flag and corresponding CI smoke test to verify that player input actually moves the character on the map in RPG Maker MV, not just that the map renders.

## Key Changes
- **New `--mv_move_test` flag** in `src/main.cxx`: A boolean launcher constant that enables the movement test in CI
- **Movement probe implementation** in `mruby-mvjs/mrblib/mv.rb`:
  - Added `MOVE_PROBE_DWELL` and `MOVE_PROBE_FRAMES` constants to control probe timing
  - Implemented `move_probe_dir(frame)` method that cycles through directions (down → right → up → left) to ensure at least one open direction is exercised on any map
  - Implemented `maybe_move_test()` method that runs once on the map, holds a direction for 80 frames, and logs the player's start/end tile with a `moved=<bool>` indicator
  - Added helper methods: `move_test_requested?()` and `player_tile()`
- **Unit test** in `mruby-mvjs/test/input_test.rb`: Tests the direction cycling logic of `move_probe_dir()`
- **CI integration** in `.github/workflows/build.yml`: New non-blocking smoke test step that runs the movement test with a 6-second timeout
- **Changelog entry**: Documents the new feature for release notes

## Implementation Details
- The movement probe cycles through directions every 20 frames (MOVE_PROBE_DWELL) for a total of 80 frames (MOVE_PROBE_FRAMES), ensuring that on any map layout, at least one direction will be passable
- The test exercises the full input pipeline: `RGSS::Input` → `MV#sync_input` → MV's `Input` → `Scene_Map` → `Game_Player` → `Game_Map` passability → position
- Logging via stderr with `[MV-MOVE]` prefix allows inspection in CI job logs without blocking the build
- The `move_probe_dir()` method is extracted as a class method to make the cycling logic unit-testable without requiring a booted game

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8