### PR TITLE
Enable MV movement smoke test on all platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,6 @@ jobs:
       # start/end tile with `[MV-MOVE] ... moved=<bool>`. Non-blocking, like the
       # other MV smoke tests; the lines show up in the job log for inspection.
       - name: MV movement smoke test
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         continue-on-error: true
         run: |
           nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \


### PR DESCRIPTION
## Summary
Removed the Ubuntu-only platform restriction from the MV movement smoke test in the CI/CD pipeline, allowing it to run on all supported operating systems.

## Changes
- Removed the `if: ${{ startsWith(matrix.os, 'ubuntu') }}` condition from the MV movement smoke test job, enabling it to execute across all CI matrix configurations rather than being limited to Ubuntu runners

## Details
The test will now run on all platforms defined in the build matrix while maintaining its non-blocking behavior (`continue-on-error: true`), allowing for broader platform coverage and earlier detection of platform-specific issues with MV movement functionality.

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8