### PR TITLE
Implement RPG2000 chipset tile rendering from EasyRPG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
         run: |
           nix develop -c ruby scripts/rpg2k_logic_check.rb
           nix develop -c ruby scripts/rpg2k_scene_check.rb
+          nix develop -c ruby scripts/rpg2k_render_check.rb
 
       - name: test
         run: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
   (random, vertical/horizontal pacing, approaching or fleeing the hero) or runs a
   custom move route, paced by its move frequency and blocked by terrain, the
   player and other events
-- Tiles are currently drawn as colour blocks (real chipset rendering is planned)
+- Tiles are blitted from the map's real ChipSet graphic — lower/upper chips,
+  water and terrain autotiles assembled from quarter-tiles, and animated tiles —
+  falling back to colour blocks only when the chipset image is missing
 
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,
@@ -208,7 +210,8 @@
 
 ## TODO
 - Editor with [imgui](https://github.com/ocornut/imgui)
-- Real chipset tile rendering (lower/upper chip graphics, autotiles, tile
-  animation); the map scene currently draws placeholder colour-block tiles
+- Chipset tile-replacement (Replace Chipset Tiles) and screen-tone tinting of
+  tiles; the map scene already blits real chipset graphics with autotiles and
+  tile animation
 - Battle system and the item/skill/equip/status menu screens
 - Audio pitch/tempo control and a guaranteed MIDI synth in the build

--- a/changelog.d/rpg2k-chipset-rendering.added.md
+++ b/changelog.d/rpg2k-chipset-rendering.added.md
@@ -1,0 +1,9 @@
+- **RPG2000 chipset rendering** — `Scene::Map` now blits the lower/upper tile
+  layers from the map's real `ChipSet/<name>` graphic instead of solid colour
+  blocks. `Game::ChipsetLayout` ports EasyRPG Player's `TilemapLayer` geometry:
+  single-chip lower (block E) / upper (block F) tiles, water (blocks A/B) and
+  terrain (block D) autotiles assembled from four 8×8 quarter-tiles per the
+  combination encoded in the tile id, the animated block-C tiles, and
+  water/animation frame cycling driven by the chipset's animation type/speed.
+  Missing chipset images fall back to the previous colour blocks. Geometry is
+  pinned by the new `scripts/rpg2k_render_check.rb`. See ADR 0016.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -57,10 +57,16 @@ The work below is roughly ordered by the critical path to a walkable game
   edge/tile/event collision and an edge-clamped follow camera
 
 #### Map & characters
-- 🚧 Tilemap rendering — `Scene::Map` currently draws each tile as a solid
-  colour block derived from its tile id (a navigable placeholder) and reads
-  chipset passability for collision; real chipset blitting (lower/upper chip
-  graphics, autotile assembly, tile animation) is the remaining work
+- ✅ Tilemap rendering — `Scene::Map` blits the lower/upper layers from the
+  map's real ChipSet graphic via `Game::ChipsetLayout` (a port of EasyRPG
+  Player's `TilemapLayer` geometry): single-chip lower (block E) / upper
+  (block F) tiles, water (blocks A/B) and terrain (block D) autotiles assembled
+  from four 8×8 quarter-tiles per the combination encoded in the tile id, the
+  two animated block-C tiles, and water/animation frame cycling. Falls back to
+  the previous solid-colour blocks when the chipset image is missing.
+  Passability still drives collision. Geometry is pinned by
+  `scripts/rpg2k_render_check.rb`. Remaining: tile-replacement (Replace Chipset
+  Tiles) substitution and screen-tone tinting of tiles.
 - 🚧 Character sprites — the party leader renders from its CharSet graphic
   (`Game::CharSet`, 4-direction, 3 walk frames); NPC/event sprites are drawn as
   markers for now

--- a/docs/adr/0016-rpg2k-chipset-tile-rendering.md
+++ b/docs/adr/0016-rpg2k-chipset-tile-rendering.md
@@ -1,0 +1,83 @@
+# 0016. RPG2000 chipset tile rendering ported from EasyRPG
+
+Date: 2026-08-03
+
+## Status
+
+Accepted
+
+## Context
+
+`Scene::Map` renders the walkable map, but until now each tile was drawn as a
+solid colour block keyed by its tile id — a navigable placeholder. The map data
+already decodes correctly (`LCF::MapUnit` lower/upper layers, `chipset_id`) and
+the chipset database chunk parses (`RPG_RT.ldb` chunk 20: `chipset_name`,
+passability, terrain, animation type/speed), so the missing piece was purely the
+*geometry*: turning a tile id into the pixel rectangle(s) it occupies in the
+`ChipSet/<name>.png` graphic.
+
+RPG Maker 2000 does not store whole 16×16 tiles for every map cell. Tile ids are
+partitioned into blocks, and two of those blocks — water (A/B) and terrain (D) —
+are **autotiles**: the id encodes a border/corner *combination* the editor chose
+from the cell's neighbours, and the drawn tile is assembled at runtime from four
+8×8 quarter-tiles, each copied from a different chip of the chipset. Reproducing
+this from a prose description is error-prone; the exact quarter-selection tables
+and block offsets matter.
+
+Two additional constraints shaped the approach:
+
+- This environment cannot build or run the native SDL/mruby binary, so the
+  logic has to be verifiable as pure Ruby under CRuby, the way the existing
+  loader/logic/scene harnesses are.
+- The renderer already exposes an alpha-blending `Bitmap#blt(x, y, src, rect)`
+  (C) and loads indexed PNGs with palette-index-0 transparency (the flag already
+  used for the windowskin), which is exactly what chipset blitting needs.
+
+## Decision
+
+Add `Game::ChipsetLayout` (pure Ruby in `mruby-rpg2k/mrblib/game.rb`), a direct
+port of EasyRPG Player's `src/tilemap_layer.cpp` geometry, and drive
+`Scene::Map` from it.
+
+- The chipset image is the fixed RPG2000 480×256 grid of 16×16 chips. A tile id
+  maps to a block: water A/B (`0..2999`), animated C (`3000..3149`), terrain D
+  (`4000..4599`), lower E (`5000..5143`), upper F (`10000..10143`).
+- `ChipsetLayout.quads(id, abf, cf)` returns the blit rectangles for a tile:
+  one 16×16 chip for blocks C/E/F, or four 8×8 quarters for the A/B and D
+  autotiles. The quarter-selection tables (`BLOCK_A_SUBTILES`,
+  `BLOCK_D_SUBTILES`) and the block offsets are transcribed verbatim from
+  EasyRPG, including the water A+B combining step and the set-1/set-2 column and
+  row remaps. Because the map already stores the fully-resolved combination id,
+  no neighbour recomputation is needed at render time.
+- Water tiles cycle through three animation columns and the block-C tiles
+  through four frames; `anim_ab`/`anim_c` reproduce EasyRPG's timing (fast/slow
+  = every 12/24 frames; type 0 walks `0,1,2,1`, type 1 cycles `0,1,2`).
+  `Game::ChipSet` now also reads the chipset `animation_type`/`animation_speed`.
+- `Scene::Map` loads `ChipSet/<name>` (with the palette-0 transparency flag),
+  keeps a per-scene frame counter, and blits every visible lower/upper tile each
+  frame via `ChipsetLayout`. When the chipset image is missing it falls back to
+  the previous solid-colour blocks, so a game with an unresolved graphic stays
+  navigable and the failure is logged (`[RPG2k] chipset graphic load failed …`).
+
+Passability and terrain lookup are unchanged — they keep using the existing
+`ChipSet` tables — so this change is rendering-only.
+
+## Consequences
+
+- Maps now look like the real game: proper ground/wall/water graphics, correct
+  autotile borders and cliffs, and animated water/tiles, instead of a mosaic of
+  coloured squares. Upper-layer chips blend with transparency over the lower
+  layer as intended.
+- The geometry is exercised without any native build or real image by
+  `scripts/rpg2k_render_check.rb` (run in CI next to the logic/scene checks),
+  which sweeps every water and terrain combination and asserts every quad lands
+  inside the 480×256 grid; `scripts/rpg2k_scene_check.rb` now exercises the blit
+  wiring through its RGSS stubs.
+- The scene redraws every visible tile every frame (as the placeholder did),
+  now at up to four blits per autotile. This is acceptable at RPG2000's small
+  resolution; if it becomes a bottleneck the obvious follow-up is to redraw only
+  when the camera or animation frame changes, or to pre-compose an autotile
+  cache the way EasyRPG does.
+- Not yet covered: the *Replace Chipset Tiles* event command (the runtime uses
+  an identity chip substitution — correct for a fresh game) and screen-tone
+  tinting of tiles. Both are noted as follow-ups in `docs/TODO.md`.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -245,7 +245,7 @@ module Game
     # numpad direction -> passability bit.
     DIR_BIT = { 2 => 0x01, 4 => 0x02, 6 => 0x04, 8 => 0x08 }.freeze
 
-    attr_reader :name, :graphic
+    attr_reader :name, :graphic, :animation_type, :animation_speed
 
     def initialize(db, id)
       c = db.chipset[id]
@@ -253,6 +253,12 @@ module Game
       @graphic = c ? c.chipset_name : ''
       @passable_lower = c ? c.passable_data_lower : nil
       @terrain = c ? c.terrain_data : nil
+      # Water-animation parameters (chipset chunks 11/12): the animation "type"
+      # (0 = 3-frame back-and-forth, 1 = 3-frame cycle) and speed flag (0 slow,
+      # non-zero fast). Consumed by ChipsetLayout when picking the animation
+      # column for the water autotiles.
+      @animation_type = c ? (c.animation_type || 0) : 0
+      @animation_speed = c ? (c.animation_speed || 0) : 0
     end
 
     # Chip index into the lower passability table for a lower-layer tile id.
@@ -283,6 +289,247 @@ module Game
       idx = ChipSet.lower_index(tile_id)
       return 0 if idx.nil? || idx < 0 || idx >= @terrain.size
       @terrain[idx] || 0
+    end
+  end
+
+  # Maps an RPG2000/2003 map tile id to the source rectangle(s) it occupies in a
+  # chipset image (`ChipSet/<name>.png`, a fixed 480x256 grid of 16x16 tiles).
+  #
+  # This is a direct port of EasyRPG Player's `TilemapLayer` geometry. A tile id
+  # names one of six blocks:
+  #
+  #   * A/B (0..2999)      water autotiles, animated (3 columns)
+  #   * C   (3000..3149)   the two animated ground tiles (4 frames)
+  #   * D   (4000..4599)   terrain autotiles (grass edges, cliffs, ...)
+  #   * E   (5000..5143)   plain lower-layer tiles (one 16x16 chip each)
+  #   * F   (10000..10143) upper-layer tiles (one 16x16 chip each)
+  #
+  # Autotiles (blocks A/B and D) are not stored as whole 16x16 chips: the id
+  # encodes a *combination* the map editor picked from the tile's neighbours, and
+  # the drawn tile is assembled from four 8x8 quarter-tiles, each copied from a
+  # different chip of the chipset. #quads returns those four quarters (or the one
+  # whole chip, for the non-autotile blocks) as blit rectangles.
+  #
+  # Pure geometry with no rendering dependency, so it is exercised directly by
+  # scripts/rpg2k_render_check.rb under CRuby.
+  module ChipsetLayout
+    TS = 16      # tile size in pixels
+    HTS = 8      # quarter (8x8) size
+    CHIPSET_W = 480
+    CHIPSET_H = 256
+
+    BLOCK_C = 3000
+    BLOCK_D = 4000
+    BLOCK_E = 5000
+    BLOCK_F = 10000
+    BLOCK_E_TILES = 144
+    BLOCK_F_TILES = 144
+
+    # [a_subtile][row][col] -> block-A chipset row (0..3) for that quarter, or -1
+    # to take the quarter from block B instead. (EasyRPG BlockA_Subtiles_IDS.)
+    N = -1
+    BLOCK_A_SUBTILES = [
+      [[N, N], [N, N]], [[3, N], [N, N]], [[N, 3], [N, N]], [[3, 3], [N, N]],
+      [[N, N], [N, 3]], [[3, N], [N, 3]], [[N, 3], [N, 3]], [[3, 3], [N, 3]],
+      [[N, N], [3, N]], [[3, N], [3, N]], [[N, 3], [3, N]], [[3, 3], [3, N]],
+      [[N, N], [3, 3]], [[3, N], [3, 3]], [[N, 3], [3, 3]], [[3, 3], [3, 3]],
+      [[1, N], [1, N]], [[1, 3], [1, N]], [[1, N], [1, 3]], [[1, 3], [1, 3]],
+      [[2, 2], [N, N]], [[2, 2], [N, 3]], [[2, 2], [3, N]], [[2, 2], [3, 3]],
+      [[N, 1], [N, 1]], [[N, 1], [3, 1]], [[3, 1], [N, 1]], [[3, 1], [3, 1]],
+      [[N, N], [2, 2]], [[3, N], [2, 2]], [[N, 3], [2, 2]], [[3, 3], [2, 2]],
+      [[1, 1], [1, 1]], [[2, 2], [2, 2]], [[0, 2], [1, N]], [[0, 2], [1, 3]],
+      [[2, 0], [N, 1]], [[2, 0], [3, 1]], [[N, 1], [2, 0]], [[3, 1], [2, 0]],
+      [[1, N], [0, 2]], [[1, 3], [0, 2]], [[0, 0], [1, 1]], [[0, 2], [0, 2]],
+      [[1, 1], [0, 0]], [[2, 0], [2, 0]], [[0, 0], [0, 0]]
+    ].freeze
+
+    # [subtile][row][col] -> [dx, dy] chipset-chip offset within the block-D cell.
+    # (EasyRPG BlockD_Subtiles_IDS.)
+    BLOCK_D_SUBTILES = [
+      [[[1, 2], [1, 2]], [[1, 2], [1, 2]]], [[[2, 0], [1, 2]], [[1, 2], [1, 2]]],
+      [[[1, 2], [2, 0]], [[1, 2], [1, 2]]], [[[2, 0], [2, 0]], [[1, 2], [1, 2]]],
+      [[[1, 2], [1, 2]], [[1, 2], [2, 0]]], [[[2, 0], [1, 2]], [[1, 2], [2, 0]]],
+      [[[1, 2], [2, 0]], [[1, 2], [2, 0]]], [[[2, 0], [2, 0]], [[1, 2], [2, 0]]],
+      [[[1, 2], [1, 2]], [[2, 0], [1, 2]]], [[[2, 0], [1, 2]], [[2, 0], [1, 2]]],
+      [[[1, 2], [2, 0]], [[2, 0], [1, 2]]], [[[2, 0], [2, 0]], [[2, 0], [1, 2]]],
+      [[[1, 2], [1, 2]], [[2, 0], [2, 0]]], [[[2, 0], [1, 2]], [[2, 0], [2, 0]]],
+      [[[1, 2], [2, 0]], [[2, 0], [2, 0]]], [[[2, 0], [2, 0]], [[2, 0], [2, 0]]],
+      [[[0, 2], [0, 2]], [[0, 2], [0, 2]]], [[[0, 2], [2, 0]], [[0, 2], [0, 2]]],
+      [[[0, 2], [0, 2]], [[0, 2], [2, 0]]], [[[0, 2], [2, 0]], [[0, 2], [2, 0]]],
+      [[[1, 1], [1, 1]], [[1, 1], [1, 1]]], [[[1, 1], [1, 1]], [[1, 1], [2, 0]]],
+      [[[1, 1], [1, 1]], [[2, 0], [1, 1]]], [[[1, 1], [1, 1]], [[2, 0], [2, 0]]],
+      [[[2, 2], [2, 2]], [[2, 2], [2, 2]]], [[[2, 2], [2, 2]], [[2, 0], [2, 2]]],
+      [[[2, 0], [2, 2]], [[2, 2], [2, 2]]], [[[2, 0], [2, 2]], [[2, 0], [2, 2]]],
+      [[[1, 3], [1, 3]], [[1, 3], [1, 3]]], [[[2, 0], [1, 3]], [[1, 3], [1, 3]]],
+      [[[1, 3], [2, 0]], [[1, 3], [1, 3]]], [[[2, 0], [2, 0]], [[1, 3], [1, 3]]],
+      [[[0, 2], [2, 2]], [[0, 2], [2, 2]]], [[[1, 1], [1, 1]], [[1, 3], [1, 3]]],
+      [[[0, 1], [0, 1]], [[0, 1], [0, 1]]], [[[0, 1], [0, 1]], [[0, 1], [2, 0]]],
+      [[[2, 1], [2, 1]], [[2, 1], [2, 1]]], [[[2, 1], [2, 1]], [[2, 0], [2, 1]]],
+      [[[2, 3], [2, 3]], [[2, 3], [2, 3]]], [[[2, 0], [2, 3]], [[2, 3], [2, 3]]],
+      [[[0, 3], [0, 3]], [[0, 3], [0, 3]]], [[[0, 3], [2, 0]], [[0, 3], [0, 3]]],
+      [[[0, 1], [2, 1]], [[0, 1], [2, 1]]], [[[0, 1], [0, 1]], [[0, 3], [0, 3]]],
+      [[[0, 3], [2, 3]], [[0, 3], [2, 3]]], [[[2, 1], [2, 1]], [[2, 3], [2, 3]]],
+      [[[0, 1], [2, 1]], [[0, 3], [2, 3]]], [[[1, 2], [1, 2]], [[1, 2], [1, 2]]],
+      [[[1, 2], [1, 2]], [[1, 2], [1, 2]]], [[[0, 0], [0, 0]], [[0, 0], [0, 0]]]
+    ].freeze
+
+    module_function
+
+    # Animation column (0..2) for the water autotiles (blocks A/B), from a frame
+    # counter and the chipset's animation_type / animation_speed. Fast chipsets
+    # advance every 12 frames, slow ones every 24. Type 0 walks 0,1,2,1 (a
+    # back-and-forth); type 1 cycles 0,1,2.
+    def anim_ab(frame, animation_type, animation_speed)
+      step = frame / (animation_speed != 0 ? 12 : 24)
+      if animation_type != 0
+        step % 3
+      else
+        step %= 4
+        step == 3 ? 1 : step
+      end
+    end
+
+    # Animation frame (0..3) for the block-C animated tiles (advances every 6
+    # frames).
+    def anim_c(frame)
+      (frame / 6) % 4
+    end
+
+    # The coarse block a tile id belongs to: :water, :animated, :terrain, :lower,
+    # :upper, or nil for the empty tile (0) and ids outside every block.
+    def block(id)
+      return nil if id.nil? || id <= 0
+      if id >= BLOCK_F
+        id < BLOCK_F + BLOCK_F_TILES ? :upper : nil
+      elsif id >= BLOCK_E
+        id < BLOCK_E + BLOCK_E_TILES ? :lower : nil
+      elsif id >= BLOCK_D
+        :terrain
+      elsif id >= BLOCK_C
+        :animated
+      else
+        :water
+      end
+    end
+
+    # Source rectangles to draw for a tile id, as an array of
+    # [dx, dy, sx, sy, w, h]: dx/dy are pixel offsets within the destination
+    # 16x16 tile, and sx/sy/w/h the source rect in the chipset image. Non-
+    # autotile blocks return a single 16x16 rect; autotiles return four 8x8
+    # quarters. The empty tile (0) and out-of-range ids return []. `abf` / `cf`
+    # are the current animation columns/frames from #anim_ab / #anim_c.
+    def quads(id, abf = 0, cf = 0)
+      case block(id)
+      when :water    then water_quads(id, abf)
+      when :animated then [full(3 + (id - BLOCK_C) / 50, 4 + cf)]
+      when :terrain  then terrain_quads(id)
+      when :lower    then [lower_quad(id - BLOCK_E)]
+      when :upper    then [upper_quad(id - BLOCK_F)]
+      else []
+      end
+    end
+
+    # -- internals ----------------------------------------------------------
+
+    # A whole 16x16 chip at chipset grid (col, row).
+    def full(col, row)
+      [0, 0, col * TS, row * TS, TS, TS]
+    end
+
+    # Four 8x8 quarters assembled from `quarters[j][i] = [chip_col, chip_row]`:
+    # quarter (j, i) is copied from the matching 8x8 sub-quadrant of that chip.
+    def quads_from_quarters(quarters)
+      out = []
+      2.times do |j|
+        2.times do |i|
+          qc, qr = quarters[j][i]
+          out << [i * HTS, j * HTS, qc * TS + i * HTS, qr * TS + j * HTS, HTS, HTS]
+        end
+      end
+      out
+    end
+
+    # Water autotile (blocks A/B). `set` (id/1000) selects the water set, then the
+    # id's low digits select a block-B border combination and a block-A corner
+    # combination; each quarter comes from block A or block B accordingly.
+    def water_quads(id, anim)
+      set = id / 1000
+      b_subtile = (id % 1000) / 50
+      a_subtile = id % 50
+      return [] if a_subtile >= BLOCK_A_SUBTILES.size || b_subtile >= TS
+      quarters = [[nil, nil], [nil, nil]]
+
+      # Quarters the A table leaves open (-1) come from block B (rows 4..7).
+      2.times do |j|
+        2.times do |i|
+          next unless BLOCK_A_SUBTILES[a_subtile][j][i] == N
+          t = (b_subtile >> (j * 2 + i)) & 1
+          t ^= 3 if set == 2
+          quarters[j][i] = [anim, 4 + t]
+        end
+      end
+      # The remaining quarters come from block A (rows given by the table; set 1
+      # uses the second column trio, +3).
+      2.times do |j|
+        2.times do |i|
+          row = BLOCK_A_SUBTILES[a_subtile][j][i]
+          next if row == N
+          quarters[j][i] = [anim + (set == 1 ? 3 : 0), row]
+        end
+      end
+      # When both a border and a corner are set, the border quarters win.
+      if b_subtile != 0 && a_subtile != 0
+        2.times do |j|
+          2.times do |i|
+            t = (b_subtile >> (j * 2 + i)) & 1
+            t *= 2 if set == 2
+            next if t == 0
+            quarters[j][i] = [anim, 4 + t]
+          end
+        end
+      end
+      quads_from_quarters(quarters)
+    end
+
+    # Terrain autotile (block D). Each block is a 3x4 chip cell; the id's low
+    # digits pick one of 50 corner combinations within it.
+    def terrain_quads(id)
+      blk = (id - BLOCK_D) / 50
+      subtile = (id - BLOCK_D) % 50
+      return [] if blk < 0 || blk >= 12 || subtile >= BLOCK_D_SUBTILES.size
+      if blk < 4
+        base_col = (blk % 2) * 3
+        base_row = 8 + (blk / 2) * 4
+      else
+        base_col = 6 + (blk % 2) * 3
+        base_row = ((blk - 4) / 2) * 4
+      end
+      quarters = [[nil, nil], [nil, nil]]
+      2.times do |j|
+        2.times do |i|
+          off = BLOCK_D_SUBTILES[subtile][j][i]
+          quarters[j][i] = [base_col + off[0], base_row + off[1]]
+        end
+      end
+      quads_from_quarters(quarters)
+    end
+
+    # Plain lower-layer chip (block E), laid out in two 6-wide columns.
+    def lower_quad(idx)
+      if idx < 96
+        full(12 + idx % 6, idx / 6)
+      else
+        full(18 + (idx - 96) % 6, (idx - 96) / 6)
+      end
+    end
+
+    # Upper-layer chip (block F), in two 6-wide columns of the right half.
+    def upper_quad(idx)
+      if idx < 48
+        full(18 + idx % 6, 8 + idx / 6)
+      else
+        full(24 + (idx - 48) % 6, (idx - 48) / 6)
+      end
     end
   end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -320,9 +320,11 @@ class RPG2k
     end
 
     # Play scene: renders the loaded map and lets the party leader walk around
-    # it. Tiles are drawn as solid colour blocks derived from their tile id (a
-    # placeholder until real chipset blitting lands — see docs/TODO.md); the
-    # player is drawn from its real CharSet graphic. Movement is grid based with
+    # it. Tiles are blitted from the map's real ChipSet graphic via
+    # Game::ChipsetLayout (lower/upper chips, water/terrain autotile assembly and
+    # tile animation); if the chipset image is missing they fall back to solid
+    # colour blocks derived from the tile id. The player is drawn from its real
+    # CharSet graphic. Movement is grid based with
     # smooth pixel interpolation, walk animation, tile/edge/event collision and
     # a camera that follows the player and clamps to the map edges. Events roam
     # the map per their page's movement type (random / vertical / horizontal /
@@ -365,6 +367,7 @@ class RPG2k
         @state = state
         @map = state.map
         @chipset = build_chipset
+        @chipset_bmp = load_chipset_graphic
         @charset = load_charset
         @windowskin = load_windowskin
         @interpreter = Game::Interpreter.new(@state)
@@ -399,6 +402,8 @@ class RPG2k
         @dest_y = @state.y
         @tile_colors = {}
         @last_frame = nil
+        # Frame counter driving the chipset's water/animated-tile animation.
+        @anim_frame = 0
 
         setup_sprites
         render
@@ -411,11 +416,13 @@ class RPG2k
         [@lower_sprite, @upper_sprite, @player_sprite].each do |s|
           s.dispose if s
         end
+        @chipset_bmp.dispose if @chipset_bmp
       end
 
       def update
         @state.tick_timer # the timer keeps counting during events too
         @state.screen.update # screen tint progresses every frame, even in events
+        @anim_frame += 1 # water / animated tiles cycle even during events
         if event_busy?
           drive_event
         else
@@ -462,6 +469,20 @@ class RPG2k
         Game::ChipSet.new(@db, @map.chipset_id)
       rescue StandardError => e
         $stderr.puts "[RPG2k] chipset load failed, tiles treated as passable: #{e.message}"
+        nil
+      end
+
+      # Load the chipset tile graphic (ChipSet/<name>). Chipsets are indexed
+      # PNGs whose palette index 0 is the transparent colour, so load with the
+      # colour-key flag (like the windowskin). Returns nil — falling back to the
+      # solid-colour tile blocks — when there is no chipset or the file is
+      # missing.
+      def load_chipset_graphic
+        name = @chipset && @chipset.graphic
+        return nil if name.nil? || name.empty?
+        Bitmap.new "ChipSet/#{name}", true
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] chipset graphic load failed, using colour blocks: #{e.message}"
         nil
       end
 
@@ -1263,6 +1284,14 @@ class RPG2k
         ox = cam_x % TILE
         oy = cam_y % TILE
 
+        # Animation columns/frames for this render, shared by every tile so the
+        # whole map animates in lock-step. Only needed on the real-chipset path.
+        if @chipset_bmp
+          abf = Game::ChipsetLayout.anim_ab(@anim_frame, @chipset.animation_type,
+                                            @chipset.animation_speed)
+          cf = Game::ChipsetLayout.anim_c(@anim_frame)
+        end
+
         (0...ROWS).each do |ry|
           (0...COLS).each do |rx|
             tx = first_tx + rx
@@ -1271,16 +1300,31 @@ class RPG2k
             dy = ry * TILE - oy
 
             lower = @map.lower(tx, ty)
-            @lower_bmp.fill_rect dx, dy, TILE, TILE, tile_color(lower)
-
             upper = @map.upper(tx, ty)
-            @upper_bmp.fill_rect dx, dy, TILE, TILE, tile_color(upper) if upper && upper != 0
+
+            if @chipset_bmp
+              draw_tile @lower_bmp, lower, dx, dy, abf, cf
+              draw_tile @upper_bmp, upper, dx, dy, abf, cf
+            else
+              # Fallback: solid colour blocks keyed by tile id (no chipset image).
+              @lower_bmp.fill_rect dx, dy, TILE, TILE, tile_color(lower)
+              @upper_bmp.fill_rect dx, dy, TILE, TILE, tile_color(upper) if upper && upper != 0
+            end
 
             if @event_tiles[[tx, ty]]
               @lower_bmp.fill_rect dx + 3, dy + 3, TILE - 6, TILE - 6,
                                    Color.new(230, 90, 90, 255)
             end
           end
+        end
+      end
+
+      # Blit one map tile from the chipset image into `bmp` at (dx, dy). A plain
+      # chip is a single 16x16 copy; an autotile is assembled from four 8x8
+      # quarters. Empty/out-of-range ids draw nothing (id 0 is transparent).
+      def draw_tile bmp, id, dx, dy, abf, cf
+        Game::ChipsetLayout.quads(id, abf, cf).each do |qdx, qdy, sx, sy, w, h|
+          bmp.blt dx + qdx, dy + qdy, @chipset_bmp, Rect.new(sx, sy, w, h)
         end
       end
 

--- a/scripts/rpg2k_render_check.rb
+++ b/scripts/rpg2k_render_check.rb
@@ -1,0 +1,209 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Unit check for the RPG2000 chipset rendering geometry (Game::ChipsetLayout in
+# mruby-rpg2k/mrblib/game.rb). Like scripts/rpg2k_logic_check.rb this loads the
+# pure-Ruby source under CRuby — the geometry has no RGSS/SDL dependency, so it
+# can be verified without the native binary or any real chipset image.
+#
+# It pins the tile-id -> chipset source-rect mapping ported from EasyRPG Player's
+# TilemapLayer: block classification, the single-chip blocks C/E/F, and the four
+# 8x8 quarter assembly of the water (A/B) and terrain (D) autotiles. Every quad
+# it produces must land inside the fixed 480x256 chipset grid.
+#
+# Usage: ruby scripts/rpg2k_render_check.rb   (exits non-zero on any failure)
+
+lib = File.expand_path('../mruby-rpg2k/mrblib', __dir__)
+load File.join(lib, 'game.rb')
+
+L = Game::ChipsetLayout
+
+$failures = 0
+$checks = 0
+
+def check(name)
+  $checks += 1
+  yield
+rescue StandardError => e
+  $failures += 1
+  warn "  FAIL #{name}: #{e.class}: #{e.message}"
+  warn "    #{e.backtrace.first(3).join("\n    ")}"
+end
+
+def ok(cond, msg = 'expected truthy'); raise msg unless cond; end
+def eq(exp, act, msg = nil)
+  return if exp == act
+  raise "expected #{exp.inspect}, got #{act.inspect}#{msg ? " (#{msg})" : ''}"
+end
+
+# Every quad must be a valid, in-bounds source rect and a valid destination
+# offset within the 16x16 tile.
+def assert_quads_valid(quads)
+  quads.each do |dx, dy, sx, sy, w, h|
+    ok [0, 8].include?(dx), "dest x offset #{dx}"
+    ok [0, 8].include?(dy), "dest y offset #{dy}"
+    ok [8, 16].include?(w), "width #{w}"
+    ok [8, 16].include?(h), "height #{h}"
+    ok sx >= 0 && sx + w <= L::CHIPSET_W, "src x #{sx}+#{w} out of 480"
+    ok sy >= 0 && sy + h <= L::CHIPSET_H, "src y #{sy}+#{h} out of 256"
+  end
+end
+
+# -- block classification -----------------------------------------------------
+
+check 'empty and out-of-range ids classify as nil' do
+  eq nil, L.block(0)
+  eq nil, L.block(nil)
+  eq nil, L.block(-5)
+  eq nil, L.block(5000 + 144)   # one past block E
+  eq nil, L.block(10000 + 144)  # one past block F
+  eq nil, L.block(20000)
+end
+
+check 'ids classify into the six blocks' do
+  eq :water,    L.block(1)
+  eq :water,    L.block(2500)
+  eq :animated, L.block(3000)
+  eq :animated, L.block(3050)
+  eq :terrain,  L.block(4000)
+  eq :terrain,  L.block(4599)
+  eq :lower,    L.block(5000)
+  eq :lower,    L.block(5143)
+  eq :upper,    L.block(10000)
+  eq :upper,    L.block(10143)
+end
+
+# -- empty tile draws nothing -------------------------------------------------
+
+check 'empty / invalid tiles produce no quads' do
+  eq [], L.quads(0)
+  eq [], L.quads(nil)
+  eq [], L.quads(5000 + 144)
+  eq [], L.quads(10000 + 144)
+end
+
+# -- single-chip blocks (C, E, F) ---------------------------------------------
+
+check 'block E lower tiles map to a single 16x16 chip' do
+  q = L.quads(5000)
+  eq 1, q.size
+  eq [0, 0, 12 * 16, 0, 16, 16], q.first  # id 0 -> col 12, row 0
+  assert_quads_valid q
+
+  # id 6 -> second row of the first 6-wide column
+  eq [0, 0, 12 * 16, 1 * 16, 16, 16], L.quads(5006).first
+  # id 96 -> start of the second column (col 18, row 0)
+  eq [0, 0, 18 * 16, 0, 16, 16], L.quads(5000 + 96).first
+  assert_quads_valid L.quads(5143)
+end
+
+check 'block F upper tiles map to a single 16x16 chip in the right half' do
+  # id 0 -> col 18, row 8
+  eq [0, 0, 18 * 16, 8 * 16, 16, 16], L.quads(10000).first
+  # id 48 -> second column group (col 24, row 0)
+  eq [0, 0, 24 * 16, 0, 16, 16], L.quads(10000 + 48).first
+  assert_quads_valid L.quads(10000)
+  assert_quads_valid L.quads(10143)
+end
+
+check 'block C animated tiles pick their row from the animation frame' do
+  # id 3000 -> col 3, row 4 + frame
+  eq [0, 0, 3 * 16, 4 * 16, 16, 16], L.quads(3000, 0, 0).first
+  eq [0, 0, 3 * 16, 7 * 16, 16, 16], L.quads(3000, 0, 3).first
+  # id 3050 -> col 4
+  eq [0, 0, 4 * 16, 4 * 16, 16, 16], L.quads(3050, 0, 0).first
+  assert_quads_valid L.quads(3000, 0, 2)
+end
+
+# -- autotiles (A/B water, D terrain) -----------------------------------------
+
+check 'water autotiles assemble four in-bounds 8x8 quarters' do
+  # Sweep every water set / border / corner combination.
+  (0..2).each do |set|
+    (0...16).each do |b|
+      (0...L::BLOCK_A_SUBTILES.size).each do |a|
+        id = set * 1000 + b * 50 + a
+        next if id.zero?
+        (0..2).each do |anim|
+          q = L.quads(id, anim, 0)
+          eq 4, q.size, "id #{id} anim #{anim}"
+          # The four quarters tile the destination (TL, TR, BL, BR).
+          eq [[0, 0], [8, 0], [0, 8], [8, 8]], q.map { |dx, dy, *| [dx, dy] }
+          assert_quads_valid q
+        end
+      end
+    end
+  end
+end
+
+check 'water quarters come from the correct A/B chipset rows' do
+  # a_subtile 46 is "all four corners" -> every quarter is block-A row 0.
+  q = L.quads(46, 0, 0) # set 0, b_subtile 0, a_subtile 46
+  q.each { |_, _, _, sy, _, _| eq 0, sy / 16, 'block-A row 0 expected' }
+  # b_subtile 15 (all borders), a_subtile 0 -> every quarter is block-B (rows 4..7).
+  L.quads(15 * 50, 0, 0).each do |_, _, _, sy, _, _|
+    ok (4..7).include?(sy / 16), "block-B row, got #{sy / 16}"
+  end
+end
+
+check 'water set 1 uses the second block-A column trio (anim + 3)' do
+  # set 1, a_subtile 46 (all block A). Column = anim + 3.
+  L.quads(1000 + 46, 1, 0).each do |_, _, sx, _, _, _|
+    ok [4, 5].include?(sx / 16), "expected col 4/5 for set1 anim1, got #{sx / 16}"
+  end
+end
+
+check 'terrain autotiles assemble four in-bounds 8x8 quarters' do
+  (0...12).each do |blk|
+    (0...50).each do |sub|
+      id = 4000 + blk * 50 + sub
+      q = L.quads(id)
+      eq 4, q.size, "id #{id}"
+      eq [[0, 0], [8, 0], [0, 8], [8, 8]], q.map { |dx, dy, *| [dx, dy] }
+      assert_quads_valid q
+    end
+  end
+end
+
+check 'terrain block placement follows the two-column D layout' do
+  # block 0 -> first column, lower region (base col 0, base row 8).
+  # subtile 46 (all-solid-ish) uses offset [1,2] for every quarter in the port.
+  q0 = L.quads(4000 + 0 * 50 + 47) # subtile 47 -> [1,2] all quarters
+  q0.each do |_, _, sx, sy, _, _|
+    eq (0 + 1), sx / 16, 'block0 col'
+    eq (8 + 2), sy / 16, 'block0 row'
+  end
+  # block 4 -> second column, top region (base col 6, base row 0).
+  q4 = L.quads(4000 + 4 * 50 + 47)
+  q4.each do |_, _, sx, sy, _, _|
+    eq (6 + 1), sx / 16, 'block4 col'
+    eq (0 + 2), sy / 16, 'block4 row'
+  end
+end
+
+# -- animation helpers --------------------------------------------------------
+
+check 'anim_ab: slow chipset advances every 24 frames, type 0 walks 0,1,2,1' do
+  seq = (0...4).map { |k| L.anim_ab(k * 24, 0, 0) }
+  eq [0, 1, 2, 1], seq
+  # Fast chipset (speed != 0) advances every 12 frames.
+  eq 1, L.anim_ab(12, 0, 1)
+end
+
+check 'anim_ab: type 1 cycles 0,1,2' do
+  seq = (0...3).map { |k| L.anim_ab(k * 24, 1, 0) }
+  eq [0, 1, 2], seq
+  eq 0, L.anim_ab(3 * 24, 1, 0)
+end
+
+check 'anim_c cycles 0..3 every 6 frames' do
+  eq [0, 1, 2, 3, 0], (0..4).map { |k| L.anim_c(k * 6) }
+end
+
+if $failures.zero?
+  puts "rpg2k render check: #{$checks} checks passed"
+  exit 0
+else
+  warn "rpg2k render check: #{$failures} of #{$checks} checks FAILED"
+  exit 1
+end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -25,10 +25,19 @@ module RGSS
     def initialize(*); end
   end
 
-  # A no-op drawing surface. Records nothing; every draw call is ignored.
+  # A no-op drawing surface. Records nothing; every draw call is ignored. A
+  # String first arg means "load this file": we pretend a standard 480x256
+  # chipset (or other graphic) loaded, so Scene::Map exercises the real
+  # ChipsetLayout blit path instead of the colour-block fallback.
   class Bitmap
     attr_reader :width, :height
-    def initialize(w = 1, h = 1); @width = w.to_i; @height = h.to_i; end
+    def initialize(w = 1, h = 1)
+      if w.is_a?(String)
+        @width = 480; @height = 256
+      else
+        @width = w.to_i; @height = h.to_i
+      end
+    end
     def clear; end
     def fill_rect(*); end
     def blt(*); end


### PR DESCRIPTION
Adds real chipset tile rendering to `Scene::Map`, replacing the placeholder solid-colour tile blocks with proper graphics blitted from the map's `ChipSet/<name>` image.

## Summary

This implements the complete RPG2000 chipset rendering geometry by porting EasyRPG Player's `TilemapLayer` logic. Maps now display with proper ground/wall/water graphics, correct autotile borders and cliffs, and animated water/tiles instead of a mosaic of coloured squares.

## Key Changes

- **`Game::ChipsetLayout` module** — Pure Ruby geometry engine that maps tile IDs to chipset source rectangles:
  - Classifies tile IDs into six blocks: water A/B (0–2999), animated C (3000–3149), terrain D (4000–4599), lower E (5000–5143), upper F (10000–10143)
  - Returns single 16×16 chip rectangles for blocks C/E/F
  - Assembles four 8×8 quarter-tiles for water (A/B) and terrain (D) autotiles using transcribed lookup tables (`BLOCK_A_SUBTILES`, `BLOCK_D_SUBTILES`)
  - Handles water set remapping and animation column selection
  - Provides animation helpers (`anim_ab`, `anim_c`) for water/tile frame cycling

- **`Game::ChipSet` enhancements** — Now reads and exposes `animation_type` and `animation_speed` from the chipset database, driving the animation timing

- **`Scene::Map` rendering** — Loads the chipset graphic with palette-0 transparency and blits tiles via `ChipsetLayout`:
  - Maintains a per-scene frame counter (`@anim_frame`) that advances every frame
  - Computes animation columns/frames once per render and applies to all visible tiles
  - Falls back to solid-colour blocks when the chipset image is missing or unresolved
  - Logs failures to stderr for debugging

- **Test coverage** — New `scripts/rpg2k_render_check.rb` exercises the pure-Ruby geometry under CRuby:
  - Validates block classification for all tile ID ranges
  - Sweeps every water and terrain autotile combination
  - Asserts all generated quads land within the 480×256 chipset grid
  - Tests animation timing helpers
  - Runs in CI alongside existing logic/scene checks

## Implementation Details

- The chipset image is the fixed RPG2000 480×256 grid of 16×16 chips; no runtime recomputation of autotile combinations is needed since the map already stores the fully-resolved combination ID
- Water animation cycles through three columns; block-C tiles cycle through four frames
- Fast chipsets advance every 12 frames, slow ones every 24; type 0 walks `0,1,2,1` (back-and-forth), type 1 cycles `0,1,2`
- Upper-layer chips blend with transparency over the lower layer as intended
- Passability and terrain lookup remain unchanged — this is rendering-only

## Fallback Behavior

When the chipset image is missing or fails to load, the scene gracefully falls back to the previous solid-colour tile blocks, keeping the game navigable while logging the failure. This allows games with unresolved graphics to remain playable.

https://claude.ai/code/session_01MC7j6tGdociTuefMoJHEL2