### PR TITLE
Handle Change Level and Change Equipment event commands

### DIFF
--- a/changelog.d/change-level-equipment-commands.added.md
+++ b/changelog.d/change-level-equipment-commands.added.md
@@ -1,0 +1,7 @@
+- The event interpreter now handles the **Change Level** (10420) and **Change
+  Equipment** (10440) commands. Change Level adds/subtracts a const or variable
+  amount to the target actors' level, rescaling their base stats through the
+  growth curve; Change Equipment equips an item (const, or an id read from a
+  variable) into the slot matching its type, or removes a slot's gear — folding
+  the bonus into the actor's effective stats. Confirmed against real Nepheshel
+  events (e.g. actor 3 equipping armour 127). Covered by the logic checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -115,17 +115,19 @@ The work below is roughly ordered by the critical path to a walkable game
   resumes it once none remain. **Erase
   Event** removes the running event from the map for the rest of the visit (its
   marker, movement, collision and any parallel process). **Change
-  HP/MP**, **Full Heal** and **Change Parameters** apply to a fixed actor, a
-  variable-selected actor or the whole party, clamped to each actor's maxima
-  (Change HP honours the allow-death floor; Change Parameters re-clamps current
-  HP/MP when a maximum is lowered). **Control Variables** reads not just
-  constants and other variables but also a **random** range, an **actor stat**
-  (level / HP / MP / max HP-MP / attack / defence / spirit / agility) and **game
-  quantities** (party gold, timer seconds). Conditional Branch covers switch /
-  variable / **timer** / gold / item conditions and the **actor** sub-conditions
-  (in party, name, level ≥, HP ≥; skill / equipment / state are not modelled).
-  The remaining commands (pictures, screen effects, battles, EXP/level changes —
-  which need the per-level stat growth curves, not yet parsed — ...) are TODO
+  HP/MP**, **Full Heal**, **Change Parameters**, **Change Level** and **Change
+  Equipment** apply to a fixed actor, a variable-selected actor or the whole
+  party, clamped to each actor's maxima (Change HP honours the allow-death floor;
+  Change Parameters re-clamps current HP/MP when a maximum is lowered; Change
+  Level rescales base stats through the per-level growth curve; Change Equipment
+  folds an equipped item's bonuses into the effective stats). **Control
+  Variables** reads not just constants and other variables but also a **random**
+  range, an **actor stat** (level / HP / MP / max HP-MP / attack / defence /
+  spirit / agility) and **game quantities** (party gold, timer seconds).
+  Conditional Branch covers switch / variable / **timer** / gold / item
+  conditions and the **actor** sub-conditions (in party, name, level ≥, HP ≥,
+  item equipped; skill / state are not modelled). The remaining commands
+  (pictures, screen effects, battles, EXP gain / level-up messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   speed/wait codes are consumed). Text now **reveals gradually** (a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -370,6 +370,35 @@ module Game
       @equipment.include?(item_id)
     end
 
+    # Equip a database item into the slot matching its type (weapon type 1 ->
+    # slot 0, shield 2 -> 1, armour 3 -> 2, helmet 4 -> 3, accessory 5 -> 4) and
+    # recompute the boosted stats. A non-equippable item, an unknown id, or a
+    # database without an item table is ignored. Drives the Change Equipment
+    # event command's equip operation.
+    def equip_item(item_id)
+      return if item_id.nil? || item_id == 0 || !@db.respond_to?(:item)
+      it = @db.item[item_id]
+      return unless it
+      slot = it.type - 1
+      return unless slot >= 0 && slot < EQUIP_ORDER.size
+      @equipment[slot] = item_id
+      recompute_stats
+    end
+
+    # Clear an equipment slot: 0..4 empties that one slot, EQUIP_ORDER.size (5)
+    # strips every slot, any other value is a no-op. Drives the Change Equipment
+    # command's remove operation.
+    def unequip(slot)
+      if slot == EQUIP_ORDER.size
+        @equipment = EQUIP_ORDER.map { 0 }
+      elsif slot >= 0 && slot < EQUIP_ORDER.size
+        @equipment[slot] = 0
+      else
+        return
+      end
+      recompute_stats
+    end
+
     # The six base stats at `level`. Real database rows expose the full growth
     # curve (six shorts per level) via LCF::Array1D#int16_values; index it by
     # level, clamped to the curve's length. A row that only offers a single

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -24,7 +24,9 @@ module Game
       CHANGE_GOLD      = 10310
       CHANGE_ITEMS     = 10320
       CHANGE_PARTY     = 10330
+      CHANGE_LEVEL     = 10420
       CHANGE_PARAM     = 10430
+      CHANGE_EQUIP     = 10440
       CHANGE_HP        = 10460
       CHANGE_MP        = 10470
       FULL_HEAL        = 10490
@@ -220,7 +222,9 @@ module Game
       when Cmd::CHANGE_GOLD      then do_change_gold cmd
       when Cmd::CHANGE_ITEMS     then do_change_items cmd
       when Cmd::CHANGE_PARTY     then do_change_party cmd
+      when Cmd::CHANGE_LEVEL     then do_change_level cmd
       when Cmd::CHANGE_PARAM     then do_change_params cmd
+      when Cmd::CHANGE_EQUIP     then do_change_equipment cmd
       when Cmd::CHANGE_HP        then do_change_hp cmd
       when Cmd::CHANGE_MP        then do_change_mp cmd
       when Cmd::FULL_HEAL        then do_full_heal cmd
@@ -580,6 +584,28 @@ module Game
       amount = cmd.param(4) == 0 ? cmd.param(5) : variables[cmd.param(5)]
       amount = -amount if cmd.param(2) != 0
       stat_targets(cmd).each { |a| a.change_param(type, amount) }
+    end
+
+    # Change Level: add (op 0) or subtract (op 1) a const/variable amount to the
+    # target actors' level, rescaling their base stats through the growth curve.
+    def do_change_level(cmd)
+      amount = stat_amount(cmd)
+      stat_targets(cmd).each { |a| a.set_level(a.level + amount) }
+    end
+
+    # Change Equipment. param2 selects the operation: 0 equips an item (param3 0
+    # = the item id in param4, 1 = the id held in variable param4) into the slot
+    # matching its type; 1 removes equipment, param4 selecting the slot (0..4, or
+    # 5 for every slot). Confirmed against real events, e.g. `[1, 3, 0, 0, 127]`
+    # equips armour 127 onto actor 3.
+    def do_change_equipment(cmd)
+      targets = stat_targets(cmd)
+      if cmd.param(2) == 0
+        item = cmd.param(3) == 0 ? cmd.param(4) : variables[cmd.param(4)]
+        targets.each { |a| a.equip_item(item) }
+      else
+        targets.each { |a| a.unequip(cmd.param(4)) }
+      end
     end
 
     # -- conditional branch ---------------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1109,9 +1109,9 @@ end
 FakeActorSystem = Struct.new(:party)
 # A database item row exposing just the equipment-bonus fields Game::Actor reads.
 FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
-                      :max_hp_points, :max_sp_points)
-def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0)
-  FakeItem.new(atk, dfn, spi, agi, mhp, msp)
+                      :max_hp_points, :max_sp_points, :type)
+def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0)
+  FakeItem.new(atk, dfn, spi, agi, mhp, msp, type)
 end
 class FakeActorDB
   attr_reader :player, :system, :item
@@ -1334,6 +1334,48 @@ check 'Change Parameters raises max MP with a variable operand' do
   it.start([FakeCmd.new(IC::CHANGE_PARAM, [1, 2, 0, 1, 1, 4])])
   it.update
   eq 40, a.max_mp
+end
+
+check 'Change Level command raises the level and rescales stats' do
+  # Two-level curve: L1 maxhp10/atk3, L2 maxhp20/atk6.
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4, 20, 10, 6, 4, 2, 8]) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  eq [1, 10, 3], [a.level, a.max_hp, a.atk]
+  it = Game::Interpreter.new(st)
+  # scope 1 fixed, actor 1, op 0 (add), operand-type 0 (const), amount 1, show 0
+  it.start([FakeCmd.new(IC::CHANGE_LEVEL, [1, 1, 0, 0, 1, 0])])
+  it.update
+  eq [2, 20, 6], [a.level, a.max_hp, a.atk]
+  # op 1 removes a level.
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CHANGE_LEVEL, [1, 1, 1, 0, 1, 0])])
+  it2.update
+  eq 1, a.level
+end
+
+check 'Change Equipment command equips into the type slot and removes' do
+  items = { 7 => fake_item(atk: 15, type: 1),   # weapon -> slot 0
+            8 => fake_item(dfn: 9, type: 3) }    # armour -> slot 2
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  # Equip weapon 7 (const item): scope1, actor1, op0 equip, operand0 const, item7.
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  eq 18, a.atk         # base 3 + 15
+  eq 7, a.equipment[0]
+  # Equip armour 8 from variable 5 (operand source 1).
+  st.variables[5] = 8
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 1, 5])]); it.update }
+  eq 11, a.def         # base 2 + 9
+  eq 8, a.equipment[2]
+  # Remove the weapon slot (op 1, slot 0).
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, 0])]); it.update }
+  eq 3, a.atk
+  eq 0, a.equipment[0]
+  eq 8, a.equipment[2] # armour still on
 end
 
 # -- Control Variables operands ----------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #153 (the actor equipment model). Wires the two remaining actor-mutating event commands to the actor model built over #151/#153, completing the actor-command surface alongside Change HP/MP/Parameters/Full Heal.

## What changed

- **Change Level (10420)** — adds (op 0) or subtracts (op 1) a constant or variable amount to the target actors' level via `Actor#set_level`, rescaling base stats through the per-level growth curve.
- **Change Equipment (10440)** — equips an item (a constant id, or one read from a variable) into the slot matching its database type, or removes a slot's gear; the bonus folds into the effective stats. Adds `Actor#equip_item` / `#unequip`.
- Both reuse the existing `stat_targets` / `stat_amount` targeting helpers (fixed actor / variable-selected actor / whole party), same as Change HP/Parameters.

## Validation

The Change Equipment param layout was **decoded from real Nepheshel events** (47 occurrences) rather than guessed — e.g. `[1, 3, 0, 0, 127]` equips armour 127 (麻の服) onto actor 3, `[1, 2, 0, 0, 128]` equips ローブ onto actor 2; every clean case equips a real item into the slot matching its type. Verified end-to-end that `equip_item(127)` on a real actor lands in the armour slot and adjusts `def`.

| Check | Result |
|-------|--------|
| `rpg2k_logic_check.rb` | 103 checks passed (level rescale + equip/remove-from-variable flow) |
| `rpg2k_scene_check.rb` | 29 checks passed |
| `rpg2k_save_load_check.rb` | real save round-trips |
| `lcf_testbed_check.rb` | parses cleanly |

`docs/TODO.md` refreshed — the growth curve is now parsed, and level/equipment changes plus the item-equipped condition are modelled (the paragraph had gone stale after #151/#153).

## Scope / follow-up

Change EXP (with exp-threshold level-up) and the level-up message are still TODO; the Change Equipment remove operation follows the documented slot layout (0–4, 5 = all) since Nepheshel's sample only exercises the equip path cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG)_