### PR TITLE
Add MV message window smoke test for dialogue rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,26 @@ jobs:
             --timeout_ms=6000 --game_dir data/mv-sample \
             --mv_new_game --mv_move_test
 
+      # Confirm the message/dialogue path renders: New Game -> map, then show a
+      # text message and log with `[MV-MSG] ... window_open=<bool>` whether the
+      # message window opened. Captures a frame so the rendered box can be
+      # inspected. Non-blocking, like the other MV smoke tests.
+      - name: MV message smoke test
+        continue-on-error: true
+        run: |
+          mkdir -p ss
+          nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+            --timeout_ms=6000 --game_dir data/mv-sample \
+            --mv_new_game --mv_message_test --mv_screenshot=ss/mv_message.png
+
+      - name: Upload MV message screenshot
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: mv-message-screenshot
+          path: ss/mv_message.png
+          if-no-files-found: warn
+
   wasm:
     runs-on: ubuntu-24.04
     env:

--- a/changelog.d/mv-message-smoke.added.md
+++ b/changelog.d/mv-message-smoke.added.md
@@ -1,0 +1,8 @@
+- MV message-window smoke check: a new `--mv_message_test` flag drives the
+  committed MV sample past New Game onto the map, queues a "Show Text" message
+  through `$gameMessage`, lets `Scene_Map`'s `Window_Message` open and draw it,
+  then logs `[MV-MSG] busy=<bool> window_open=<bool>` and captures a frame. It
+  exercises the dialogue path every RPG uses (event → `$gameMessage` →
+  `Window_Message` → text render), so CI confirms message boxes actually
+  display. Wired as a non-blocking `build` job step alongside the existing MV
+  boot/battle/movement smokes.

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -259,6 +259,7 @@ class MV
     maybe_new_game # CI: auto-advance past the title to the first map
     maybe_battle_test # CI: start a test battle once on the map, if requested
     maybe_move_test # CI: hold a direction on the map and log that the player moved
+    maybe_message_test # CI: show a text message on the map and log the window opened
     present # M4: copy the MV canvas onto the on-screen sprite's bitmap
     maybe_screenshot # capture the rendered frame once, if requested (CI)
     RGSS::Input.update
@@ -392,7 +393,8 @@ class MV
     rescue StandardError
       false
     end
-    return unless new_game || battle_test_troop > 0 || move_test_requested?
+    return unless new_game || battle_test_troop > 0 || move_test_requested? ||
+                  message_test_requested?
     return unless current_scene == "Scene_Title"
 
     @new_game_done = true
@@ -487,6 +489,50 @@ class MV
     $stderr.puts "[MV-MOVE] end #{player_tile} moved=#{@move_seen ? true : false}"
   rescue StandardError => e
     $stderr.puts "[MV] move test error: #{e.message}"
+  end
+
+  # Whether --mv_message_test was requested (a launcher constant set by main.cxx).
+  def message_test_requested?
+    (begin
+      MV_MESSAGE_TEST
+    rescue StandardError
+      false
+    end) == true
+  end
+
+  # When --mv_message_test is set (CI), once on the map queue a "Show Text"
+  # message through $gameMessage, let Scene_Map's Window_Message open and draw
+  # it over a few frames, then log whether the window opened and is showing the
+  # text. This drives the message/dialogue path every RPG uses (event ->
+  # $gameMessage -> Window_Message -> text render), so a headless run confirms
+  # message boxes actually display. One-shot; a no-op during normal play.
+  MSG_PROBE_FRAMES = 45
+  def maybe_message_test
+    return if @msg_test_done
+    return unless message_test_requested?
+    return unless current_scene == "Scene_Map"
+
+    @msg_frame ||= 0
+    if @msg_frame == 0
+      MV::JS.eval(
+        "if (typeof $gameMessage !== 'undefined' && !$gameMessage.isBusy()) " \
+        "{ $gameMessage.add('MV message smoke test'); }"
+      )
+      $stderr.puts "[MV-MSG] queued a message"
+    end
+    @msg_frame += 1
+    return if @msg_frame < MSG_PROBE_FRAMES
+
+    @msg_test_done = true
+    busy = MV::JS.eval("(typeof $gameMessage !== 'undefined' && " \
+                       "$gameMessage.isBusy()) ? true : false")
+    open = MV::JS.eval(
+      "(SceneManager._scene && SceneManager._scene._messageWindow && " \
+      "SceneManager._scene._messageWindow.openness > 0) ? true : false"
+    )
+    $stderr.puts "[MV-MSG] busy=#{busy} window_open=#{open}"
+  rescue StandardError => e
+    $stderr.puts "[MV] message test error: #{e.message}"
   end
 
   # Log the running scene's class name whenever it changes, so the boot's

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -53,6 +53,13 @@ DEFINE_bool(
     "For RPG Maker MV: once on the map, hold a direction for a spell (implies "
     "--mv_new_game to reach the map) and log the player's start/end tile, so a "
     "headless run confirms input actually moves the player. Used in CI");
+DEFINE_bool(
+    mv_message_test,
+    false,
+    "For RPG Maker MV: once on the map, show a text message (implies "
+    "--mv_new_game to reach the map) and log whether the message window "
+    "opened, so a headless run confirms the message/window path renders. "
+    "Used in CI");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -443,6 +450,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_MOVE_TEST"),
                 mrb_bool_value(FLAGS_mv_move_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MV_MESSAGE_TEST"),
+                mrb_bool_value(FLAGS_mv_message_test));
   CHECK_NO_EXC(M);
 
   const mrb_value args = mrb_ary_new_capa(M, argc - 1);


### PR DESCRIPTION
## Summary
This PR adds a new `--mv_message_test` flag and corresponding CI test to verify that RPG Maker MV's message/dialogue rendering path works correctly in headless environments. The test queues a text message, allows the message window to render, and logs whether the window opened successfully.

## Key Changes
- **New command-line flag**: `--mv_message_test` in `src/main.cxx` that enables the message window smoke test
- **MV constant**: `MV_MESSAGE_TEST` passed from C++ to mruby to control test execution
- **Message test implementation** in `mrblib/mv.rb`:
  - `message_test_requested?()` checks if the test flag is set
  - `maybe_message_test()` queues a "Show Text" message via `$gameMessage`, waits 45 frames for rendering, then logs the message busy state and window openness
  - Integrated into `main_loop()` and `maybe_new_game()` flow
- **CI workflow**: New non-blocking test job in `.github/workflows/build.yml` that runs the message test and captures a screenshot for inspection
- **Changelog entry**: Documents the new feature for release notes

## Implementation Details
- The test exercises the core dialogue path: event → `$gameMessage` → `Window_Message` → text render
- Uses JavaScript evaluation to queue the message and check window state without direct Ruby access to MV internals
- Runs as a one-shot after reaching the map (similar to existing `mv_move_test`)
- Captures a frame via `--mv_screenshot` for visual verification
- Marked as `continue-on-error: true` in CI to avoid blocking the build on rendering issues

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8