### PR TITLE
Model actor skill sets: seed on New Game, restore on Continue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,8 +109,8 @@ Create ADRs in /docs/adr for:
   the data (or the rpg2kpsp analysis wiki) spells out, per ADR 0002.
 - The runtime can resume from a real save: `Game::State.from_lsd(db, save)`
   rebuilds a `State` from a parsed `LcfSaveData` (leader position, party roster,
-  gold, items, switches, variables, and each roster actor's saved level/exp and
-  current HP/MP from chunk 108), and `continue_game` loads an editor
+  gold, items, switches, variables, and each roster actor's saved level/exp,
+  current HP/MP, equipment and skills from chunk 108), and `continue_game` loads an editor
   `Save<N>.lsd` when present. Actor base stats scale with level from the database
   growth curve (chunk 31, six shorts per level, via `LCF::Array1D#int16_values`),
   so a restored level rescales the maxima — see ADR 0015. `Game::Actor` also

--- a/changelog.d/actor-skill-set.added.md
+++ b/changelog.d/actor-skill-set.added.md
@@ -1,0 +1,8 @@
+- `Game::Actor` now tracks the **skills it knows**. New Game seeds them from the
+  database growth table (every skill whose learn-level is at or below the actor's
+  level; levelling learns more and never un-learns), Continue restores the saved
+  skill set (chunk 108 field 52), and the **actor "knows skill" conditional
+  branch** (type 5, sub 4) is modelled via `Actor#knows_skill?`. Validated
+  against a real save: the skills learnt up to each actor's level match its saved
+  skill list exactly (e.g. actor 3 at L5 → {25, 27, 32}). Covered by the logic
+  and save-load checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -132,7 +132,7 @@ The work below is roughly ordered by the critical path to a walkable game
   spirit / agility) and **game quantities** (party gold, timer seconds).
   Conditional Branch covers switch / variable / **timer** / gold / item
   conditions and the **actor** sub-conditions (in party, name, level ≥, HP ≥,
-  item equipped; skill / state are not modelled). The remaining commands
+  item equipped, skill known; state is not modelled). The remaining commands
   (pictures, screen effects, battles, EXP gain / level-up messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -570,8 +570,9 @@ module Game
     # accessory.
     EQUIP_ORDER = [:weapon, :shield, :armor, :helmet, :accessory].freeze
 
-    # The equipped item ids, one per EQUIP_ORDER slot (0 = an empty slot).
-    attr_reader :equipment
+    # The equipped item ids, one per EQUIP_ORDER slot (0 = an empty slot), and
+    # the ids of the skills the actor knows.
+    attr_reader :equipment, :skills
 
     def initialize(db, id)
       @db = db
@@ -585,8 +586,10 @@ module Game
       @db_row = a
       @exp = 0
       @equipment = normalize_equipment(a.respond_to?(:initial_equipment) ? a.initial_equipment : nil)
+      @skills = []
       # Base stats scale with level from the growth curve and equipment adds on
-      # top, so seed them at the actor's initial level, then start at full health.
+      # top, and levelling learns skills, so seed them all at the actor's initial
+      # level, then start at full health.
       set_level(a.initial_level || 1)
       @hp = @max_hp
       @mp = @max_mp
@@ -601,7 +604,47 @@ module Game
     def set_level(level)
       @level = level && level >= 1 ? level : 1
       @base = base_stats(@level)
+      learn_level_skills
       recompute_stats
+    end
+
+    # Learn every skill the database growth table grants at or below the current
+    # level (RPG2000 never un-learns on the way down), on top of whatever the
+    # actor already knows. Confirmed against a real save: the skills learnt up to
+    # an actor's level match the saved skill list exactly.
+    def learn_level_skills
+      learn_table.each { |skill_id, at| learn_skill(skill_id) if at <= @level }
+    end
+
+    # The database learn table as [skill_id, level] pairs (empty for a row that
+    # exposes no learn table, e.g. the test fixtures).
+    def learn_table
+      a = @db_row
+      return [] unless a.respond_to?(:skills) && a.skills
+      out = []
+      a.skills.each { |_i, l| out.push([l.skill_id, l.level]) }
+      out
+    end
+
+    # Whether the actor knows `skill_id`.
+    def knows_skill?(skill_id)
+      return false if skill_id.nil? || skill_id == 0
+      @skills.include?(skill_id)
+    end
+
+    # Learn / forget a skill (the Change Skill operations and levelling).
+    def learn_skill(skill_id)
+      return if skill_id.nil? || skill_id == 0 || @skills.include?(skill_id)
+      @skills.push(skill_id)
+    end
+
+    def forget_skill(skill_id)
+      @skills.delete(skill_id)
+    end
+
+    # Replace the known-skill set (Continue restoring the saved skills).
+    def skills=(ids)
+      @skills = (ids || []).reject { |s| s.nil? || s == 0 }.uniq
     end
 
     # Replace the equipped items (an array of up to five item ids in EQUIP_ORDER,
@@ -1525,6 +1568,7 @@ module Game
           actor.set_level(sa.level) if sa.level
           actor.exp = sa.exp if sa.exp
           actor.equip(sa.equipment) if sa.equipment
+          actor.skills = sa.skills if sa.skills
         end
         hp[aid] = sa.hp if sa.hp
         mp[aid] = sa.mp if sa.mp

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -640,9 +640,9 @@ module Game
 
     # Conditional type 5 (actor/hero): param1 is the actor id, param2 selects the
     # sub-condition — 0 in party, 1 name equals the command string, 2 level >=
-    # param3, 3 HP >= param3, 5 has item param3 equipped. The skill / state
-    # sub-conditions (4/6) are not modelled and read as false. The stat checks
-    # need the actor to be in the party (the only actors this build
+    # param3, 3 HP >= param3, 4 knows skill param3, 5 has item param3 equipped.
+    # The state sub-condition (6) is not modelled and reads as false. The stat
+    # checks need the actor to be in the party (the only actors this build
     # instantiates); a missing actor is false.
     def actor_condition(cmd)
       id = cmd.param(1)
@@ -653,6 +653,7 @@ module Game
       when 1 then actor.name == cmd.string
       when 2 then actor.level >= cmd.param(3)
       when 3 then actor.hp >= cmd.param(3)
+      when 4 then actor.knows_skill?(cmd.param(3))
       when 5 then actor.equipped?(cmd.param(3))
       else false
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1106,6 +1106,23 @@ class CurveRow < FakePlayerRow
     idx == 31 ? @curve : nil
   end
 end
+
+# A database learn-table row (skill_id learnt at level), plus an Array2D-alike
+# table exposing them the way the real player row's #skills does (each yields
+# id, entry). Lets Game::Actor seed its skills by level without the LCF parser.
+FakeLearn = Struct.new(:skill_id, :level)
+class FakeLearnTable
+  def initialize(pairs); @pairs = pairs; end # [[skill_id, level], ...]
+  def each; @pairs.each_index { |i| yield i, FakeLearn.new(*@pairs[i]) }; end
+end
+class SkillRow < CurveRow
+  def initialize(name, cs, ci, level, curve, learns)
+    super(name, cs, ci, level, curve)
+    @learns = learns
+  end
+
+  def skills; FakeLearnTable.new(@learns); end
+end
 FakeActorSystem = Struct.new(:party)
 # A database item row exposing just the equipment-bonus fields Game::Actor reads.
 FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
@@ -1226,6 +1243,27 @@ check 'Actor without a growth curve falls back to a level-independent status' do
   eq [100, 30], [hero.max_hp, hero.max_mp]
   hero.set_level(2)
   eq [100, 30], [hero.max_hp, hero.max_mp]
+end
+
+check 'Actor learns skills from the growth table up to its level' do
+  # 25@L1, 32@L1, 27@L5 -- mirrors a real actor whose L5 skill set is 25/27/32.
+  learns = [[25, 1], [32, 1], [27, 5]]
+  db = FakeActorDB.new(
+    { 1 => SkillRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4], learns) }, [1])
+  a = Game::Party.new(db).leader
+  eq [25, 32], a.skills.sort            # only the L1 skills at level 1
+  a.set_level(5)
+  eq [25, 27, 32], a.skills.sort        # 27 joins at level 5
+  a.set_level(1)
+  eq [25, 27, 32], a.skills.sort        # levelling down keeps learnt skills
+  ok a.knows_skill?(27)
+  ok !a.knows_skill?(99)
+  # learn / forget mutate the set.
+  a.learn_skill(99); ok a.knows_skill?(99)
+  a.forget_skill(27); ok !a.knows_skill?(27)
+  # restoring a saved set replaces it.
+  a.skills = [1, 2, 2, 0]
+  eq [1, 2], a.skills.sort
 end
 
 check 'Change HP command damages a fixed actor' do
@@ -1468,6 +1506,13 @@ end
 check 'Conditional actor: name equals the command string (type 5, sub 1)' do
   eq true, run_actor_cond([5, 1, 1], string: 'Hero').switches[1]
   eq true, run_actor_cond([5, 1, 1], string: 'Nope').switches[2]
+end
+
+check 'Conditional actor: knows skill (type 5, sub 4)' do
+  st = run_actor_cond([5, 1, 4, 12]) { |s| s.party.actor_by_id(1).learn_skill(12) }
+  eq true, st.switches[1]            # skill 12 known -> if-branch
+  st = run_actor_cond([5, 1, 4, 12]) # skill not known -> else
+  eq true, st.switches[2]
 end
 
 check 'Conditional actor: equipped item (type 5, sub 5)' do

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -104,6 +104,8 @@ def check_game(dir)
     eq true, a.mp <= a.max_mp, "actor #{a.id} mp within max (#{a.mp}/#{a.max_mp})"
     # The saved equipment (chunk 108 field 61) is re-equipped onto the actor.
     eq (sa.equipment || []), a.equipment, "actor #{a.id} equipment" if sa.equipment
+    # The saved skills (chunk 108 field 52) are restored as the known-skill set.
+    eq (sa.skills || []).sort, a.skills.sort, "actor #{a.id} skills" if sa.skills
   end
 
   # Switches/variables shift from the save's 0-indexed arrays to 1-indexed ids.


### PR DESCRIPTION
## Summary

Follow-up to the actor/save-restore work (#142/#151/#153/#161). Skills were decoded in the save (chunk 108 field 52) but never modelled in the runtime — the last saved per-actor field not restored. This adds the skill set, parallel to the equipment model.

## What changed

- **`Game::Actor` tracks the skills it knows.** New Game seeds them from the database growth table — every skill whose learn-level is at or below the actor's level; levelling learns more and never un-learns.
- **`Game::State.from_lsd` restores the saved skill set** (chunk 108 field 52) on Continue.
- **The actor "knows skill" conditional branch** (type 5, sub-condition 4) is now modelled via `Actor#knows_skill?`; `learn_skill` / `forget_skill` mutate the set.

## Validation

**Cross-validated against the real save**: the skills learnt up to each actor's level (from the DB learn table) match its saved skill list exactly —

| actor | level | seeded from learn table | saved (chunk 108 f52) |
|-------|-------|-------------------------|-----------------------|
| 2 | 1 | {1} | {1} |
| 3 | 5 | {25, 27, 32} | {25, 27, 32} |
| 4 | 8 | {49, 56, 62} | {49, 56, 62} |

| Check | Result |
|-------|--------|
| `rpg2k_logic_check.rb` | 105 checks passed (seeding by level, learn/forget, restore, skill condition) |
| `rpg2k_scene_check.rb` | 29 checks passed |
| `rpg2k_save_load_check.rb` | real save round-trips; asserts restored skills |
| `lcf_testbed_check.rb` | parses cleanly |

## Scope / follow-up

The Change Skill event command (10450) is **not** included: its parameter layout couldn't be cleanly resolved from Nepheshel's events (`[1,1,1,4,0]`, actor 1's learn table is empty), and per the repo's decode-don't-guess rule I left it out rather than guess. Skills are known/checked but not yet *used* (no skill-cast / battle system). This completes the per-actor save-restore surface (level, exp, HP/MP, equipment, skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG)_