### PR TITLE
AGENTS.md: document auto-merge approval and conflict-resolution rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,17 @@ directly. Before opening one:
   includes code that needs review. Each PR gets a **Cloudflare Pages** preview
   and must keep CI green before it is merged; pushes to `master` deploy the page
   to **GitHub Pages**.
+- **Auto-merge counts as approval — keep moving.** When a PR has auto-merge
+  enabled, treat it as already review-approved: do not block waiting for the
+  merge to land. Move straight on to the next task if there is work left to do;
+  the PR merges itself once CI passes.
+- **Resolve conflicts when you find them.** When a branch or PR has merge
+  conflicts against `master` (a push to `master` made the PR un-mergeable, or a
+  merge/rebase stops on a conflict), resolve them yourself rather than leaving
+  them: merge the latest `master` into the branch (or rebase onto it, per the
+  branch's convention), fix the conflicted files, re-run the checks you can, and
+  push. Only ask when a conflict is genuinely ambiguous — both sides changed the
+  same logic and picking one silently drops behavior.
 
 ## Architecture Decision Records
 

--- a/changelog.d/agents-auto-merge-approval.added.md
+++ b/changelog.d/agents-auto-merge-approval.added.md
@@ -1,0 +1,4 @@
+- **AGENTS.md** now documents an auto-merge rule for agents: when a pull
+  request has auto-merge enabled, treat it as already review-approved and move
+  on to the next task if work remains, rather than blocking until the merge
+  lands.

--- a/changelog.d/agents-resolve-conflicts.added.md
+++ b/changelog.d/agents-resolve-conflicts.added.md
@@ -1,0 +1,4 @@
+- **AGENTS.md** now documents a conflict-resolution rule for agents: when a
+  branch or PR has merge conflicts against `master`, resolve them (merge or
+  rebase the latest `master`, fix the files, re-run checks, and push) instead of
+  leaving them, asking only when a conflict is genuinely ambiguous.


### PR DESCRIPTION
## What & why

Turns behaviors that previously lived only in the Claude Code session harness into project-owned rules documented in `AGENTS.md`, so they're visible to contributors and future agent sessions and editable from within the project.

Two rules, both added to the *Pull Requests* section:

1. **Auto-merge counts as approval.** When a PR has auto-merge enabled, treat it as already review-approved and move on to the next task if there is work left — don't block waiting for the merge to land.
2. **Resolve conflicts when you find them.** When a branch or PR has merge conflicts against `master`, resolve them (merge or rebase the latest `master`, fix the files, re-run checks, push) instead of leaving them, asking only when a conflict is genuinely ambiguous.

## Changes

- **`AGENTS.md`** — two new bullets in the *Pull Requests* guidelines (above).
- **`changelog.d/agents-auto-merge-approval.added.md`** and **`changelog.d/agents-resolve-conflicts.added.md`** — matching changelog fragments (per the repo's fragment convention).

## Notes

Docs-only change. `pre-commit` isn't installed in this environment (nor `nix`), so I verified the relevant Markdown hooks manually — no trailing whitespace and all files end with a newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)