### PR TITLE
Evaluate lazy schema defaults instead of returning the Proc

### DIFF
--- a/changelog.d/lazy-schema-default-eval.fixed.md
+++ b/changelog.d/lazy-schema-default-eval.fixed.md
@@ -1,0 +1,4 @@
+- Absent LCF fields with a lazy (`-> { ... }`) schema default now resolve to the
+  default's **value** instead of the `Proc` itself, so edition-dependent defaults
+  like an actor's `max_level` and the `exp_basic`/`exp_increase`/`exp_correction`
+  curve read as numbers (e.g. `50`/`30`) rather than an un-called lambda.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -169,7 +169,13 @@ module LCF
   end
 
   def to_rb d, s
-    return s[:default] unless d
+    # An absent field yields its schema default. A callable (`-> { ... }`)
+    # default is lazy -- evaluate it -- so edition-dependent defaults such as
+    # max level and the exp curve resolve to their value, not the Proc itself.
+    unless d
+      dv = s[:default]
+      return dv.respond_to?(:call) ? dv.call : dv
+    end
 
     case s[:type]
     when :Array1D ; return Array1D.new d, s

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -142,6 +142,17 @@ assert "LCF::Array1D#int16_values reads a raw short array past a named accessor"
   assert_false row.respond_to?(:no_such_field)
 end
 
+assert "LCF absent-field defaults: a lambda default is evaluated, not returned raw" do
+  row = LCF::Array1D.new(
+    lcf_array1d([lcf_int_field(1, 7)]),
+    { elements: { 1 => { name: :present, type: :int, default: 0 },
+                  2 => { name: :lazy,    type: :int, default: -> { 42 } },
+                  3 => { name: :static,  type: :int, default: 5 } } })
+  assert_equal 7, row.present   # a present chunk decodes normally
+  assert_equal 42, row.lazy     # absent + callable default -> its called value
+  assert_equal 5, row.static    # absent + plain default -> the value itself
+end
+
 assert "LCF::Database#maker detects RPG2003 by the Classes section (chunk 30)" do
   actor = lcf_array1d([lcf_str_field(1, "Hero"), lcf_int_field(57, 3)])
   klass = lcf_array1d([lcf_str_field(1, "Soldier")])


### PR DESCRIPTION
## Summary

Bug fix surfaced while reading actor exp parameters. `LCF.to_rb` returned `s[:default]` verbatim for an absent field, so a **lazy `-> { ... }` default** (used for edition-dependent values) surfaced as the `Proc` object instead of its value:

```ruby
db.player[3].max_level   # => #<Proc:0x... (lambda)>   (should be 50)
db.player[3].exp_basic   # => #<Proc:0x... (lambda)>   (should be 30)
```

Six schema fields use lazy defaults (`max_level`, `exp_basic`/`exp_increase`/`exp_correction`, and the var range), all affected.

## Fix

`to_rb` now calls a callable default before returning it (a plain value is returned as-is). After the fix, `max_level` reads `50` and the exp curve `30/30/30` — numbers, not lambdas.

## Validation

| Check | Result |
|-------|--------|
| new `mruby-lcf/test` case | present chunk decodes; absent + lambda default → its called value; absent + plain default → the value |
| `lcf_testbed_check.rb` | 1151 maps parse cleanly |
| `rpg2k_logic_check.rb` | 105 checks passed |
| `rpg2k_scene_check.rb` | 29 checks passed |
| `rpg2k_save_load_check.rb` | real save round-trips |

Unblocks reading the exp curve correctly (a prerequisite for a future Change EXP / level-from-exp command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfAkG1zmDhg3idGtRM3wKG)_