### PR TITLE
Decode percent-encoded asset filenames in mv_resolve_path

### DIFF
--- a/changelog.d/mv-url-decode.fixed.md
+++ b/changelog.d/mv-url-decode.fixed.md
@@ -1,0 +1,9 @@
+- MV now finds assets whose filenames are percent-encoded. MV builds every
+  image/asset URL with `encodeURIComponent(filename)`, so a `$`-prefixed
+  character sheet (`$Hero` → `%24Hero.png`), a `!`-prefixed object character
+  (`%21…`), or any filename with a space (`%20`) reached our file loader still
+  encoded and failed to open — silently falling back to a 1×1 empty bitmap, so
+  those sprites rendered invisible. `mv_resolve_path` now url-decodes `%XX`
+  escapes before touching the filesystem, so `$`/`!` character sheets and
+  spaced filenames load. This is common in real MV games (big-character sheets
+  use the `$` prefix). Unit-tested in `mruby-mvjs/test/canvas_test.rb`.

--- a/mruby-mvjs/src/mvjs.cxx
+++ b/mruby-mvjs/src/mvjs.cxx
@@ -812,12 +812,46 @@ mrb_value js_screenshot(mrb_state* mrb, mrb_value self) {
   return mrb_true_value();
 }
 
+// Decode %XX percent-escapes. MV builds asset URLs with
+// encodeURIComponent(filename) (see ImageManager.loadBitmap / AudioManager), so
+// a "$Hero" character sheet is requested as "%24Hero.png", "!Door" as
+// "%21Door.png", and a space as "%20" — none of which match the file on disk
+// until decoded. Only well-formed %HH triples are decoded; a lone '%' or bad
+// hex is passed through unchanged, so already-decoded paths are untouched.
+std::string url_decode(const std::string& s) {
+  auto hex = [](char c) -> int {
+    if (c >= '0' && c <= '9')
+      return c - '0';
+    if (c >= 'a' && c <= 'f')
+      return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+      return c - 'A' + 10;
+    return -1;
+  };
+  std::string out;
+  out.reserve(s.size());
+  for (size_t i = 0; i < s.size(); ++i) {
+    if (s[i] == '%' && i + 2 < s.size()) {
+      const int h = hex(s[i + 1]), l = hex(s[i + 2]);
+      if (h >= 0 && l >= 0) {
+        out.push_back(static_cast<char>((h << 4) | l));
+        i += 2;
+        continue;
+      }
+    }
+    out.push_back(s[i]);
+  }
+  return out;
+}
+
 }  // namespace
 
 // Root a game-relative path at the configured base dir. Declared in mvhost.hxx
 // and shared with the Canvas2D image loader (mvcanvas.cxx). Kept at file scope
 // (external linkage) so it can reach the anonymous-namespace `g_base_dir`.
-std::string mv_resolve_path(const std::string& p) {
+std::string mv_resolve_path(const std::string& raw) {
+  // MV percent-encodes asset filenames; decode before touching the filesystem.
+  const std::string p = url_decode(raw);
   if (p.empty() || p[0] == '/' || g_base_dir.empty())
     return p;
   // Already rooted at the base dir (e.g. a path the Ruby side pre-joined)?

--- a/mruby-mvjs/test/canvas_test.rb
+++ b/mruby-mvjs/test/canvas_test.rb
@@ -165,6 +165,25 @@ assert 'MV Image decodes a PNG and serves as a drawImage source' do
   end
 end
 
+assert 'MV Image loads a percent-encoded filename (encodeURIComponent path)' do
+  # MV builds asset URLs with encodeURIComponent(filename), so a "$Hero"
+  # character sheet is requested as "%24Hero.png". The loader must url-decode to
+  # find the on-disk file; without it the load falls back to a 1x1 empty bitmap.
+  # The file on disk carries the literal "$"; we request it percent-encoded.
+  disk = "mvjs_$enc_fixture.png"
+  File.open(disk, "wb") { |f| f.write(MV_IMAGE_PNG) }
+  begin
+    MV::JS.base_dir = ""
+    MV::JS.eval("globalThis.ENC=new Image(); ENC.src='mvjs_%24enc_fixture.png';")
+    MV::JS.pump(0.0)
+    # width == 2 proves the real 2x2 file was found (a decode miss would be 1x1).
+    assert_equal 2, MV::JS.eval("ENC.width")
+    assert_equal 2, MV::JS.eval("ENC.height")
+  ensure
+    File.delete(disk) rescue nil
+  end
+end
+
 assert 'MV Image resolves a missing file as a 1x1 empty bitmap (boot does not stall)' do
   # A missing image loads (onload) as a 1x1 transparent bitmap rather than
   # erroring, so MV's ImageManager.isReady() does not block the boot forever on


### PR DESCRIPTION
## Summary
MV.js builds asset URLs using `encodeURIComponent(filename)`, which percent-encodes special characters like `$`, `!`, and spaces. The file loader was receiving these encoded paths but attempting to open them directly from disk, causing asset loads to fail silently and fall back to 1×1 empty bitmaps. This change adds URL decoding to `mv_resolve_path` so encoded filenames are properly resolved to their on-disk counterparts.

## Changes
- **Added `url_decode()` function** in `mvjs.cxx`: Decodes `%XX` percent-escape sequences in asset paths. Only well-formed hex triples are decoded; malformed escapes are passed through unchanged to avoid corrupting already-decoded paths.
- **Updated `mv_resolve_path()`**: Now decodes the input path before filesystem operations, ensuring `%24Hero.png` resolves to `$Hero.png` on disk.
- **Added test case** in `canvas_test.rb`: Verifies that a percent-encoded filename (`%24enc_fixture.png`) correctly loads the on-disk file (`$enc_fixture.png`), confirming the 2×2 fixture image is found rather than falling back to a 1×1 empty bitmap.

## Implementation Details
- The `hex()` lambda safely converts hex digits (0-9, a-f, A-F) to their numeric values, returning -1 for invalid characters
- The decoder validates that `%` is followed by exactly 2 valid hex digits before decoding; lone `%` characters or invalid sequences are preserved
- String is pre-reserved to the input size for efficiency
- This is particularly important for MV games using `$`-prefixed big character sheets and `!`-prefixed object characters, which are common conventions in the RPG Maker community

https://claude.ai/code/session_01VWbwGqK7VdmieL3YhRFEy8