### PR TITLE
Implement Battle Processing (301) result branch navigation

### DIFF
--- a/changelog.d/rpgxp-battle-processing.added.md
+++ b/changelog.d/rpgxp-battle-processing.added.md
@@ -1,0 +1,9 @@
+- **RPG Maker XP — Battle Processing (301).** The event interpreter now
+  navigates a Battle Processing command's result branches — If Win (601), If
+  Escape (602), If Lose (603) and the branch terminator (604) — instead of
+  falling through and running every branch. With no battle system yet the fight
+  resolves to a configurable `battle_outcome` (a win by default, so the victory
+  branch runs and the game progresses) and the stub is logged. This is the
+  structure the real `OpenGame.exe` XP test bed uses; covered by
+  `mruby-rpgxp/test` and driven over the test bed by
+  `scripts/rpgxp_testbed_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -262,10 +262,16 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   its operand. *Change Party Member* (129) adds/removes actors from the party,
   the **actor "is in the party"** conditional (type 4) is evaluated, and Control
   Variables also reads the **"other" game quantities** — map id, party size and
-  gold (operand type 7). Covered by `mruby-rpgxp/test` and driven over the real
-  test bed by `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route
-  targets, the remaining actor / enemy / character conditional sub-conditions,
-  and the many screen-effect / picture / battle commands (skipped for now).
+  gold (operand type 7). **Battle Processing** (301) navigates its result
+  branches — If Win (601), If Escape (602), If Lose (603), branch end (604) —
+  running only the branch that matches the resolved outcome (a win by default,
+  configurable via the interpreter's `battle_outcome`, since there is no battle
+  system yet); the real `OpenGame.exe` XP test bed uses this structure. Covered
+  by `mruby-rpgxp/test` and driven over the real test bed by
+  `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route targets,
+  the remaining actor / enemy / character conditional sub-conditions, and the
+  many screen-effect / picture commands, plus the battle system itself that
+  Battle Processing would drive (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
   (RPG Maker XP; VX's same-format `Game.rgss2a`) or a VX Ace `Game.rgss3a` loads:
   `RPGXP::RGSSAD` (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts **both** the version-1

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -94,6 +94,14 @@ class RPGXP
       PLAY_BGS        = 245
       PLAY_ME         = 249
       PLAY_SE         = 250
+      BATTLE_PROCESS  = 301
+
+      # Battle Processing (301) result branches, at the 301's own indent: If Win
+      # (601), If Escape (602), If Lose (603) and the branch terminator (604).
+      IF_WIN     = 601
+      IF_ESCAPE  = 602
+      IF_LOSE    = 603
+      BATTLE_END = 604
 
       MAX_STEPS_PER_FRAME = 10_000
       MAX_CALL_DEPTH = 100
@@ -107,11 +115,17 @@ class RPGXP
         @state = state
         @rng = Rng.new
         @resolver = nil
+        @battle_outcome = :win
         reset
       end
 
       # resolver#common_event_list(id) -> the command list of a common event.
       attr_accessor :resolver
+      # The result a Battle Processing (301) command resolves to while there is
+      # no battle system: :win (default, so the victory branch runs and the game
+      # progresses), :escape or :lose. A future battle scene sets this from the
+      # real outcome before the interpreter navigates the result branches.
+      attr_accessor :battle_outcome
       attr_reader :wait_kind, :message_lines, :choice_labels, :choice_cancel,
                   :wait_frames, :teleport, :input_variable, :input_digits
 
@@ -266,6 +280,9 @@ class RPGXP
         when CHANGE_PARTY    then do_change_party(cmd)
         when TRANSFER_PLAYER then do_transfer(cmd)
         when MOVE_ROUTE      then do_move_route(cmd)
+        when BATTLE_PROCESS  then do_battle_process(cmd)
+        when IF_WIN, IF_ESCAPE, IF_LOSE then skip_past_battle(cmd) # fell through a branch
+        when BATTLE_END      then consume
         when PLAY_BGM        then do_play(cmd, :bgm)
         when PLAY_BGS        then do_play(cmd, :bgs)
         when PLAY_ME         then do_play(cmd, :me)
@@ -365,6 +382,60 @@ class RPGXP
       # just past the choice block's 404.
       def skip_past_choices(cmd)
         skip_to_after([CHOICES_END], cmd.indent)
+      end
+
+      # -- battle processing --------------------------------------------------
+
+      # Battle Processing (301): [troop_id, can_escape, can_lose]. There is no
+      # battle system yet, so resolve the fight to @battle_outcome (a win by
+      # default, so the common victory branch runs and the game progresses) and
+      # jump into the matching result branch — If Win (601) / If Escape (602) /
+      # If Lose (603) — skipping the others. The 601/602/603 markers sit at the
+      # 301's own indent, like a choice's When markers, terminated by 604. The
+      # stub is logged so a skipped battle is visible rather than silent.
+      def do_battle_process(cmd)
+        troop_id = param(cmd, 0)
+        code = case @battle_outcome
+               when :escape then IF_ESCAPE
+               when :lose   then IF_LOSE
+               else IF_WIN
+               end
+        $stderr.puts "[RGSS] Battle Processing (troop #{troop_id.inspect}) " \
+                     "not implemented; resolving as #{@battle_outcome}"
+        target = seek_battle_branch([code], cmd.indent, @index + 1)
+        @index = target ? target + 1 : skip_to_battle_end(cmd.indent)
+      end
+
+      # A branch marker reached by falling through the previous branch's body:
+      # jump to just past the block's 604.
+      def skip_past_battle(cmd)
+        skip_to_after([BATTLE_END], cmd.indent)
+      end
+
+      # First command at `indent` whose code is in `codes`, searched from `from`
+      # and bounded by the block terminator (604); nil if none precedes it.
+      def seek_battle_branch(codes, indent, from)
+        i = from
+        while i < @list.size
+          c = @list[i]
+          if c.indent == indent
+            return i if codes.include?(c.code)
+            break if c.code == BATTLE_END
+          end
+          i += 1
+        end
+        nil
+      end
+
+      # Index just past the block's 604 at `indent` (or the list end).
+      def skip_to_battle_end(indent)
+        i = @index + 1
+        while i < @list.size
+          c = @list[i]
+          return i + 1 if c.indent == indent && c.code == BATTLE_END
+          i += 1
+        end
+        @list.size
       end
 
       # Input Number (103): [variable_id, digits]. Suspends with a :number request

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -444,6 +444,82 @@ assert "Interpreter: show choices runs the chosen branch" do
   assert_true s2.switches[3]
 end
 
+# Battle Processing (301) with all three result branches (601/602/603) at the
+# command's own indent, terminated by 604, then an always-run command after.
+def battle_list
+  [
+    cmd(301, [1, true, true], 0),   # Battle Processing troop 1, can escape/lose
+    cmd(601, [], 0),                # If Win
+    cmd(121, [1, 1, 0], 1),         #   switch 1 ON
+    cmd(602, [], 0),                # If Escape
+    cmd(121, [2, 2, 0], 1),         #   switch 2 ON
+    cmd(603, [], 0),                # If Lose
+    cmd(121, [3, 3, 0], 1),         #   switch 3 ON
+    cmd(604, [], 0),                # Branch End
+    cmd(121, [4, 4, 0], 0)          # after the block (always runs)
+  ]
+end
+
+def run_battle(outcome)
+  s = new_state
+  it = RPGXP::Game::Interpreter.new(s)
+  it.battle_outcome = outcome
+  it.start(battle_list, 1, 7)
+  it.update
+  s
+end
+
+assert "Interpreter: battle processing runs only the matching result branch" do
+  # Default outcome is a win: only the win branch runs, then the after command.
+  win = run_battle(:win)
+  assert_true  win.switches[1]
+  assert_false win.switches[2]
+  assert_false win.switches[3]
+  assert_true  win.switches[4]
+
+  esc = run_battle(:escape)
+  assert_false esc.switches[1]
+  assert_true  esc.switches[2]
+  assert_false esc.switches[3]
+  assert_true  esc.switches[4]
+
+  lose = run_battle(:lose)
+  assert_false lose.switches[1]
+  assert_false lose.switches[2]
+  assert_true  lose.switches[3]
+  assert_true  lose.switches[4]
+
+  # A fresh interpreter defaults to :win without setting battle_outcome.
+  s = new_state
+  run_to_end(s, battle_list)
+  assert_true  s.switches[1]
+  assert_false s.switches[2]
+  assert_true  s.switches[4]
+end
+
+assert "Interpreter: battle processing skips a block missing the branch" do
+  # can_lose off -> no 603 branch; resolving as :lose skips the whole block but
+  # still runs the command after 604.
+  list = [
+    cmd(301, [1, true, false], 0),  # can escape, cannot lose
+    cmd(601, [], 0),                # If Win
+    cmd(121, [1, 1, 0], 1),         #   switch 1 ON
+    cmd(602, [], 0),                # If Escape
+    cmd(121, [2, 2, 0], 1),         #   switch 2 ON
+    cmd(604, [], 0),                # Branch End (no If Lose)
+    cmd(121, [4, 4, 0], 0)          # after the block
+  ]
+  s = new_state
+  it = RPGXP::Game::Interpreter.new(s)
+  it.battle_outcome = :lose
+  it.start(list, 1, 7)
+  it.update
+  assert_false s.switches[1]
+  assert_false s.switches[2]
+  assert_true  s.switches[4]       # fell through to after the block
+  assert_false it.running?
+end
+
 assert "Interpreter: loop with break counts to a threshold" do
   s = new_state
   run_to_end(s, [


### PR DESCRIPTION
## Summary
Adds support for Battle Processing (301) command execution in the RPG Maker XP event interpreter, including proper navigation of result branches (If Win/Escape/Lose) based on a configurable battle outcome.

## Changes
- **Command constants**: Added `BATTLE_PROCESS` (301) and result branch markers (`IF_WIN` 601, `IF_ESCAPE` 602, `IF_LOSE` 603, `BATTLE_END` 604) to the command code registry
- **Battle outcome tracking**: Introduced `battle_outcome` attribute (defaults to `:win`) to control which result branch executes when there is no actual battle system
- **Branch navigation logic**: 
  - `do_battle_process()` resolves the battle to the configured outcome, logs a stub message, and jumps to the matching result branch
  - `seek_battle_branch()` locates the first matching branch marker at the correct indent level
  - `skip_to_battle_end()` finds the block terminator (604)
  - `skip_past_battle()` handles falling through from one branch to the next by skipping to after the block
- **Execution handling**: Added cases in `execute()` to handle battle processing and branch markers
- **Comprehensive tests**: Added test cases covering:
  - All three outcome paths (win/escape/lose) with correct branch execution
  - Default behavior (win outcome without explicit setting)
  - Missing branches (e.g., can't lose but outcome is lose) properly skip the block
  - Commands after the block always execute

## Implementation Details
The implementation mirrors the choice/branch structure already in the interpreter, treating battle result branches similarly to choice "When" branches. The stub logs to stderr so skipped battles are visible during testing. The default `:win` outcome ensures game progression when no battle system is present, while the configurable `battle_outcome` allows test scenarios and future battle system integration to control the flow.

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN