### PR TITLE
Implement Input Number, actor mutations, and Halt All Movement commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@
 - Map events run through an event-command interpreter: messages and choices,
   switches/variables (set from constants, other variables, random rolls, actor
   stats or gold/timer), party/gold/item changes, actor HP/MP and base-stat
-  changes and full heal, conditional branches, teleport, waits, BGM/SE playback,
+  changes and full heal, actor name / title / sprite changes, conditional
+  branches, teleport, waits, numeric input (Input Number), BGM/SE playback,
   Call Event (run a common event / another event's page), Move Event (force a
-  move route onto an event or the player) and Erase Event (remove an event from
+  move route onto an event or the player), Halt All Movement (cancel every forced
+  route) and Erase Event (remove an event from
   the map). Events start on the action button, on
   player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as

--- a/changelog.d/rpg2k-actor-input-halt-commands.added.md
+++ b/changelog.d/rpg2k-actor-input-halt-commands.added.md
@@ -1,0 +1,13 @@
+- Six more RPG2000 event commands are now handled. **Input Number** (10150)
+  suspends the interpreter on a `:number` request the map scene answers with a
+  digit-entry widget (backed by a testable `Game::NumberInput` model), storing
+  the entered value into the target variable. **Change Actor Name** (10610),
+  **Change Actor Title** (10620) and **Change Sprite Association** (10630) mutate
+  a party actor's name, status-screen title, and CharSet graphic / transparency
+  — `Game::Actor` gains the writable `name` / `title` / `transparent` fields and
+  a `set_charset`, seeded from the database row (`title`, `semi_transparent`),
+  and the scene reloads the leader's on-screen sprite when it changes. **Halt All
+  Movement** (11350) cancels every forced move route in progress (the player's
+  and each event's). These edits also survive a Save / Continue: `Game::Party`
+  now round-trips each actor's name / title / sprite overrides. Covered by new
+  checks in `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -103,10 +103,11 @@ The work below is roughly ordered by the critical path to a walkable game
   Change HP/MP, Full Heal, Change Parameters, Conditional Branch/Else/End,
   Loop/Break/End, Label/Jump, Timer, Teleport, Memorize/Recall Location,
   Store Terrain/Event ID, Wait, Play BGM/SE, Memorize / Play Memorized BGM,
-  Message Options, Change Face Graphic, Change Main Menu / Save Access, Tint
+  Message Options, Change Face Graphic, Input Number, Change Actor
+  Name / Title / Sprite, Change Main Menu / Save Access, Tint
   Screen, Flash Screen, Shake Screen, Call Event, Move Event, Proceed With
-  Movement, Erase Event, End Event) with a per-frame step cap so a bad loop
-  can't hang. **Memorize Location** stores the player's current map id, x and y
+  Movement, Halt All Movement, Erase Event, End Event) with a per-frame step cap
+  so a bad loop can't hang. **Memorize Location** stores the player's current map id, x and y
   into three variables, and **Recall to Location** teleports back to a location
   held in three variables (routed through the same teleport the Teleport command
   uses). **Call Event**
@@ -118,7 +119,12 @@ The work below is roughly ordered by the critical path to a walkable game
   map event, "this event" or the player) along it in the background. **Proceed
   With Movement** then pauses the interpreter until every forced route in
   progress has finished — the scene advances those routes while it waits and
-  resumes it once none remain. **Erase
+  resumes it once none remain. **Halt All Movement** cancels every forced route
+  at once (the player's and each event's). **Input Number** suspends on a
+  digit-entry widget and writes the entered value to a variable. **Change Actor
+  Name / Title / Sprite** rename a party actor, set its status-screen title or
+  swap its CharSet graphic (the scene reloads the leader's on-screen sprite);
+  these edits survive Save / Continue. **Erase
   Event** removes the running event from the map for the rest of the visit (its
   marker, movement, collision and any parallel process). **Change
   HP/MP**, **Full Heal**, **Change Parameters**, **Change Level** and **Change
@@ -133,7 +139,8 @@ The work below is roughly ordered by the critical path to a walkable game
   Conditional Branch covers switch / variable / **timer** / gold / item
   conditions and the **actor** sub-conditions (in party, name, level ≥, HP ≥,
   item equipped, skill known; state is not modelled). The remaining commands
-  (pictures, screen effects, battles, EXP gain / level-up messages, ...) are TODO
+  (pictures, weather, battles, shop / inn, EXP gain / level-up messages, ...) are
+  TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   speed/wait codes are consumed). Text now **reveals gradually** (a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -552,10 +552,48 @@ module Game
     def replace(h); @data = h || {}; end
   end
 
+  # A digit-entry model backing the Input Number event command: `digits` cells,
+  # a movable cursor, and per-cell 0..9 increment/decrement, exposing the entered
+  # integer via #value. The scene draws it and feeds it input; the logic (cursor
+  # bounds, wrap-around, place value) lives here so it is unit-testable.
+  class NumberInput
+    MAX_DIGITS = 7 # RPG2000 caps Input Number at seven digits (0..9,999,999)
+
+    attr_reader :digits, :cursor
+
+    def initialize(digits)
+      d = digits.to_i
+      d = 1 if d < 1
+      d = MAX_DIGITS if d > MAX_DIGITS
+      @digits = d
+      @values = Array.new(d, 0)
+      @cursor = 0
+    end
+
+    # The digit shown at position i (0 = most significant, leftmost).
+    def digit(i); @values[i] || 0; end
+
+    def inc; @values[@cursor] = (@values[@cursor] + 1) % 10; end
+    def dec; @values[@cursor] = (@values[@cursor] + 9) % 10; end
+    def left;  @cursor -= 1 if @cursor > 0; end
+    def right; @cursor += 1 if @cursor < @digits - 1; end
+
+    # The entered value as a base-10 integer (leftmost cell is most significant).
+    def value
+      v = 0
+      @values.each { |d| v = v * 10 + d }
+      v
+    end
+  end
+
   # One party member, snapshotted from the database's actor (player) table.
   class Actor
-    attr_reader :id, :name, :level, :exp, :charset_name, :charset_index
+    attr_reader :id, :level, :exp, :charset_name, :charset_index
     attr_accessor :hp, :mp
+    # Name and title (the status-screen subtitle) are mutable via the Change
+    # Actor Name / Title event commands. `transparent` hides the actor's map
+    # sprite (the Change Sprite Association transparency flag).
+    attr_accessor :name, :title, :transparent
     attr_reader :max_hp, :max_mp, :atk, :def, :int, :agi
 
     # The six base stats in database parameter-curve order (chunk 31 stores six
@@ -581,8 +619,10 @@ module Game
       raise "No such actor: #{id}" if a.nil?
 
       @name = a.name
+      @title = a.respond_to?(:title) ? (a.title || '') : ''
       @charset_name = a.charset_name
       @charset_index = a.charset_index
+      @transparent = a.respond_to?(:semi_transparent) ? (a.semi_transparent ? true : false) : false
       @db_row = a
       @exp = 0
       @equipment = normalize_equipment(a.respond_to?(:initial_equipment) ? a.initial_equipment : nil)
@@ -624,6 +664,13 @@ module Game
       out = []
       a.skills.each { |_i, l| out.push([l.skill_id, l.level]) }
       out
+    end
+
+    # Replace the actor's CharSet graphic (the Change Sprite Association event
+    # command): `name` is the file and `index` the cell within it.
+    def set_charset(name, index)
+      @charset_name = name
+      @charset_index = index
     end
 
     # Whether the actor knows `skill_id`.
@@ -803,25 +850,51 @@ module Game
       @gold = 0
     end
 
-    # Serialise the mutable party state (see State#to_h).
+    # Serialise the mutable party state (see State#to_h). Beyond HP/MP this keeps
+    # the fields the Change Actor Name / Title / Sprite commands mutate, so those
+    # edits survive a Save / Continue instead of reverting to the database row.
     def to_h
       hp = {}
       mp = {}
-      @actors.each { |a| hp[a.id] = a.hp; mp[a.id] = a.mp }
+      meta = {}
+      @actors.each do |a|
+        hp[a.id] = a.hp
+        mp[a.id] = a.mp
+        meta[a.id] = { name: a.name, title: a.title,
+                       charset_name: a.charset_name,
+                       charset_index: a.charset_index,
+                       transparent: a.transparent }
+      end
       { actor_ids: @actors.map { |a| a.id }, items: @items, gold: @gold,
-        hp: hp, mp: mp }
+        hp: hp, mp: mp, actor_meta: meta }
     end
 
-    # Restore item/gold and per-actor hp/mp from a saved party hash.
+    # Restore item/gold, per-actor hp/mp and the name/title/sprite overrides from
+    # a saved party hash. A save written before actor_meta existed simply keeps
+    # the database defaults.
     def load_state(data)
       @items = data[:items] || {}
       @gold = data[:gold] || 0
       hp = data[:hp] || {}
       mp = data[:mp] || {}
+      meta = data[:actor_meta] || {}
       @actors.each do |a|
         a.hp = hp[a.id] if hp[a.id]
         a.mp = mp[a.id] if mp[a.id]
+        apply_actor_meta(a, meta[a.id])
       end
+    end
+
+    # Apply a saved name/title/sprite override hash to an actor (nil = no
+    # override, keeping the database defaults).
+    def apply_actor_meta(actor, m)
+      return unless m
+      actor.name = m[:name] if m[:name]
+      actor.title = m[:title] unless m[:title].nil?
+      if m[:charset_name]
+        actor.set_charset(m[:charset_name], m[:charset_index] || actor.charset_index)
+      end
+      actor.transparent = m[:transparent] unless m[:transparent].nil?
     end
 
     def each(&blk); @actors.each(&blk); end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -18,6 +18,7 @@ module Game
       SHOW_CHOICES     = 10140
       CHOICE_OPTION    = 20140
       CHOICE_END       = 20141
+      INPUT_NUMBER     = 10150
       CONTROL_SWITCHES = 10210
       CONTROL_VARS     = 10220
       TIMER_OPERATION  = 10230
@@ -30,6 +31,9 @@ module Game
       CHANGE_HP        = 10460
       CHANGE_MP        = 10470
       FULL_HEAL        = 10490
+      CHANGE_ACTOR_NAME   = 10610
+      CHANGE_ACTOR_TITLE  = 10620
+      CHANGE_ACTOR_SPRITE = 10630
       MEMORIZE_LOCATION = 10820
       RECALL_LOCATION   = 10830
       STORE_TERRAIN_ID  = 10910
@@ -53,6 +57,7 @@ module Game
       SHAKE_SCREEN     = 11050
       MOVE_EVENT       = 11330
       PROCEED_WITH_MOVEMENT = 11340
+      HALT_ALL_MOVEMENT = 11350
       WAIT             = 11410
       PLAY_BGM         = 11510
       MEMORIZE_BGM     = 11530
@@ -84,6 +89,10 @@ module Game
       @resolver = nil
       @move_route_requests = []
       @erase_requested = false
+      @halt_movement_requested = false
+      @actor_graphic_changed = false
+      @input_variable = nil
+      @input_digits = 1
       # Deterministic RNG for the Control Variables "random" operand (mruby has
       # no Kernel#rand here); seeded like the map scene's own RNG.
       @rng = Game::Rng.new(0x2000)
@@ -93,7 +102,7 @@ module Game
     def running?; @running; end
     def waiting?; @waiting; end
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
-                :teleport
+                :teleport, :input_digits
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
@@ -109,6 +118,8 @@ module Game
       @call_stack = []
       @move_route_requests = []
       @erase_requested = false
+      @halt_movement_requested = false
+      @actor_graphic_changed = false
       reset_waits
     end
 
@@ -131,6 +142,26 @@ module Game
     def take_erase_request
       v = @erase_requested
       @erase_requested = false
+      v
+    end
+
+    # True (once) if a Halt All Movement command ran since the last call, clearing
+    # the flag. The owning scene polls this after #update and cancels every forced
+    # move route in progress (the player's and each event's). Non-blocking, like
+    # Erase Event: the rest of the command list keeps running.
+    def take_halt_movement_request
+      v = @halt_movement_requested
+      @halt_movement_requested = false
+      v
+    end
+
+    # True (once) if a Change Sprite Association (Change Actor Graphic) command
+    # ran since the last call, clearing the flag. The owning scene polls this
+    # after #update and reloads the party leader's on-screen sprite so a mid-event
+    # graphic change is reflected. Non-blocking.
+    def take_actor_graphic_changed
+      v = @actor_graphic_changed
+      @actor_graphic_changed = false
       v
     end
 
@@ -193,6 +224,15 @@ module Game
       reset_waits
     end
 
+    # Resume an Input Number request: store the entered `value` into the target
+    # variable and continue. The owning scene drives a digit-entry widget while
+    # the interpreter is paused on the :number wait, then calls this with the
+    # number the player entered.
+    def resume_number(value)
+      variables[@input_variable] = value.to_i if @input_variable
+      reset_waits
+    end
+
     private
 
     def reset_waits
@@ -216,6 +256,7 @@ module Game
       when Cmd::SHOW_CHOICES     then do_show_choices cmd
       when Cmd::CHOICE_OPTION    then skip_to([Cmd::CHOICE_END], cmd.indent); consume
       when Cmd::CHOICE_END       then nil
+      when Cmd::INPUT_NUMBER     then do_input_number cmd
       when Cmd::CONTROL_SWITCHES then do_control_switches cmd
       when Cmd::CONTROL_VARS     then do_control_vars cmd
       when Cmd::TIMER_OPERATION  then do_timer cmd
@@ -228,6 +269,9 @@ module Game
       when Cmd::CHANGE_HP        then do_change_hp cmd
       when Cmd::CHANGE_MP        then do_change_mp cmd
       when Cmd::FULL_HEAL        then do_full_heal cmd
+      when Cmd::CHANGE_ACTOR_NAME   then do_change_actor_name cmd
+      when Cmd::CHANGE_ACTOR_TITLE  then do_change_actor_title cmd
+      when Cmd::CHANGE_ACTOR_SPRITE then do_change_actor_sprite cmd
       when Cmd::CONDITIONAL      then do_conditional cmd
       when Cmd::ELSE_BRANCH      then skip_to([Cmd::END_BRANCH], cmd.indent); consume
       when Cmd::END_BRANCH       then nil
@@ -245,6 +289,7 @@ module Game
       when Cmd::SHAKE_SCREEN     then do_shake_screen cmd
       when Cmd::MOVE_EVENT       then do_move_event cmd
       when Cmd::PROCEED_WITH_MOVEMENT then do_proceed_with_movement cmd
+      when Cmd::HALT_ALL_MOVEMENT then @halt_movement_requested = true
       when Cmd::WAIT             then do_wait cmd
       when Cmd::PLAY_BGM         then play_audio(:bgm, cmd)
       when Cmd::MEMORIZE_BGM     then do_memorize_bgm cmd
@@ -411,6 +456,19 @@ module Game
       nil
     end
 
+    # Input Number: RPG2000 lays the parameters out as [digits, variable_id]
+    # (note the order is the reverse of RPG Maker XP's). Suspends with a :number
+    # request the owning scene answers by driving a digit-entry widget and calling
+    # `resume_number` with the value, which stores it into the variable. A digit
+    # count below 1 is clamped so the widget always has at least one cell.
+    def do_input_number(cmd)
+      digits = cmd.param(0)
+      @input_digits = digits < 1 ? 1 : digits
+      @input_variable = cmd.param(1)
+      @wait_kind = :number
+      @waiting = true
+    end
+
     # -- state commands -------------------------------------------------------
 
     def range(cmd)
@@ -573,6 +631,40 @@ module Game
     # Full recovery: restore HP and MP to their maxima for the target actors.
     def do_full_heal(cmd)
       stat_targets(cmd).each { |a| a.full_heal }
+    end
+
+    # -- actor identity / graphic ---------------------------------------------
+
+    # Change Actor Name: rename the actor whose id is param0 to the command
+    # string. A blank name is ignored (RPG_RT keeps the previous name), and an
+    # actor not in the party is a no-op — this build only instantiates party
+    # actors.
+    def do_change_actor_name(cmd)
+      name = cmd.string
+      return if name.nil? || name.empty?
+      actor = party.actor_by_id(cmd.param(0))
+      actor.name = name if actor
+    end
+
+    # Change Actor Title: set the title (class/subtitle shown on the status
+    # screen) of the actor whose id is param0 to the command string. An empty
+    # string clears the title. A no-op for an actor not in the party.
+    def do_change_actor_title(cmd)
+      actor = party.actor_by_id(cmd.param(0))
+      actor.title = cmd.string || '' if actor
+    end
+
+    # Change Sprite Association (Change Actor Graphic): give the actor whose id is
+    # param0 a new CharSet graphic — the command string names the file, param1 is
+    # the cell index and param2 the transparency flag (non-zero hides the sprite).
+    # Records a one-shot request so the owning scene can reload the party leader's
+    # on-screen sprite; a no-op for an actor not in the party.
+    def do_change_actor_sprite(cmd)
+      actor = party.actor_by_id(cmd.param(0))
+      return unless actor
+      actor.set_charset(cmd.string || '', cmd.param(1))
+      actor.transparent = cmd.param(2) != 0
+      @actor_graphic_changed = true
     end
 
     # Change Parameters: adjust a base stat. param3 selects the stat (0 max HP,

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -589,7 +589,7 @@ class RPG2k
       # -- event execution ----------------------------------------------------
 
       def event_busy?
-        @message || @interpreter.running? || @interpreter.waiting?
+        @message || @number_input || @interpreter.running? || @interpreter.waiting?
       end
 
       # Start the first not-yet-run auto-start process in the foreground: map
@@ -798,6 +798,45 @@ class RPG2k
         @parallels.reject! { |p| p[:event].equal?(ev) } if @parallels
       end
 
+      # -- Halt All Movement --------------------------------------------------
+
+      # If the interpreter ran a Halt All Movement this step, cancel every forced
+      # move route in progress — the player's and each event's — so a route set by
+      # an earlier Move Event stops where it is. Events fall back to their page's
+      # autonomous movement; the player returns to input control.
+      def apply_halt_request(interp)
+        return unless interp.take_halt_movement_request
+        @player_route = nil
+        @player_char = nil
+        @events.each { |e| e[:forced_route] = nil } if @events
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Halt All Movement failed: #{e.message}"
+        nil
+      end
+
+      # -- Change Sprite Association (Change Actor Graphic) --------------------
+
+      # If the interpreter changed an actor's sprite this step, reload the party
+      # leader's on-screen graphic so the change shows immediately (a change to a
+      # non-leader actor is held in the model until that actor leads the party).
+      def apply_graphic_change(interp)
+        refresh_player_graphic if interp.take_actor_graphic_changed
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Change Actor Graphic failed: #{e.message}"
+        nil
+      end
+
+      # Reload the party leader's CharSet graphic and apply its transparency to
+      # the player sprite, forcing a redraw on the next frame. The transparency
+      # flag hides the sprite outright (the renderer has no partial-opacity path).
+      def refresh_player_graphic
+        @charset = load_charset
+        @last_frame = nil
+        leader = @state.party.leader
+        @player_sprite.visible = !(leader && leader.transparent)
+        @player_bmp.clear unless @charset
+      end
+
       # -- Move Event (Set Move Route) ----------------------------------------
 
       # Apply the Move Event requests an interpreter queued this step. `this_event`
@@ -955,10 +994,16 @@ class RPG2k
           return
         end
 
+        if @number_input
+          drive_number_input
+          return
+        end
+
         if @interpreter.waiting?
           case @interpreter.wait_kind
           when :message then open_message(@interpreter.message_lines, false)
           when :choice then open_message(@interpreter.choice_labels, true)
+          when :number then open_number_input(@interpreter.input_digits)
           when :wait then drive_wait
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
@@ -968,6 +1013,8 @@ class RPG2k
           @interpreter.update
           apply_move_requests(@interpreter, @active_event)
           apply_erase_request(@interpreter, @active_event)
+          apply_halt_request(@interpreter)
+          apply_graphic_change(@interpreter)
         end
       end
 
@@ -1196,6 +1243,74 @@ class RPG2k
         return unless @message
         @message[:window].dispose
         @message = nil
+      end
+
+      # -- number input (Input Number command) --------------------------------
+
+      # Pixels per digit cell in the Input Number widget.
+      NUM_CELL = 16
+
+      # Open a digit-entry window for the Input Number command. A compact panel
+      # near the bottom of the screen shows `digits` cells with an editable
+      # cursor; the interpreter is resumed with the entered value on confirm.
+      def open_number_input(digits)
+        return if @number_input
+        model = Game::NumberInput.new(digits || 1)
+        inner_w = model.digits * NUM_CELL
+        inner_h = MSG_LINE_H
+        win_w = inner_w + Window::BORDER * 2
+        win_h = inner_h + Window::BORDER * 2
+        win = Window.new((SCREEN_W - win_w) / 2, SCREEN_H - win_h - 6, win_w, win_h)
+        win.z = 320
+        win.windowskin = @windowskin
+        contents = Bitmap.new(inner_w, inner_h)
+        @number_input = { window: win, contents: contents, model: model }
+        draw_number_input
+        win.contents = contents
+      end
+
+      def draw_number_input
+        ni = @number_input
+        return unless ni
+        model = ni[:model]
+        c = ni[:contents]
+        c.clear
+        (0...model.digits).each do |i|
+          x = i * NUM_CELL
+          if i == model.cursor
+            c.fill_rect x, 1, NUM_CELL, MSG_LINE_H - 2, Color.new(40, 72, 200, 160)
+          end
+          c.font.color = Color.new(255, 255, 255, 255)
+          c.draw_text x, 0, NUM_CELL, MSG_LINE_H, model.digit(i).to_s, 1
+        end
+      end
+
+      def drive_number_input
+        ni = @number_input
+        model = ni[:model]
+        if Input.trigger?(Input::UP) || Input.repeat?(Input::UP)
+          model.inc
+          draw_number_input
+        elsif Input.trigger?(Input::DOWN) || Input.repeat?(Input::DOWN)
+          model.dec
+          draw_number_input
+        elsif Input.trigger?(Input::LEFT) || Input.repeat?(Input::LEFT)
+          model.left
+          draw_number_input
+        elsif Input.trigger?(Input::RIGHT) || Input.repeat?(Input::RIGHT)
+          model.right
+          draw_number_input
+        elsif Input.trigger?(Input::C)
+          value = model.value
+          close_number_input
+          @interpreter.resume_number(value)
+        end
+      end
+
+      def close_number_input
+        return unless @number_input
+        @number_input[:window].dispose
+        @number_input = nil
       end
 
       def step_movement

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1182,6 +1182,26 @@ check 'State save round-trips the message configuration' do
   eq true, legacy_loaded.save_access, 'absent save access defaults on'
 end
 
+check 'Party save round-trips actor name / title / sprite overrides' do
+  players = {
+    1 => FakePlayerRow.new('Hero', 'Base', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  hero.name = 'Renamed'
+  hero.title = 'Champion'
+  hero.set_charset('Monster', 3)
+  hero.transparent = true
+  loaded = Game::State.load(db, st.to_h).party.actor_by_id(1)
+  eq 'Renamed', loaded.name
+  eq 'Champion', loaded.title
+  eq 'Monster', loaded.charset_name
+  eq 3, loaded.charset_index
+  eq true, loaded.transparent
+end
+
 check 'Actor change_hp/change_mp/full_heal clamp within their bounds' do
   hero = party_state.party.actor_by_id(1)
   hero.change_hp(-30);          eq 70, hero.hp
@@ -1524,6 +1544,107 @@ end
 
 check 'Conditional actor: unmodelled sub-condition reads false (type 5, sub 6)' do
   eq true, run_actor_cond([5, 1, 6, 3]).switches[2] # has-state -> false -> else
+end
+
+# -- Input Number -------------------------------------------------------------
+
+check 'Input Number pauses with a :number request, resume stores the value' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # RPG2000 layout is [digits, variable_id]: 3 digits into variable 7.
+  it.start([FakeCmd.new(IC::INPUT_NUMBER, [3, 7]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok it.waiting?, 'Input Number must pause the interpreter'
+  eq :number, it.wait_kind
+  eq 3, it.input_digits
+  it.resume_number(123)
+  it.update
+  eq 123, st.variables[7], 'the entered value lands in the target variable'
+  eq true, st.switches[1], 'the command after Input Number still ran'
+end
+
+check 'Input Number clamps a zero digit count to at least one cell' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::INPUT_NUMBER, [0, 4])])
+  it.update
+  eq 1, it.input_digits
+end
+
+check 'NumberInput edits digits and reads out the entered value' do
+  m = Game::NumberInput.new(3)
+  eq 3, m.digits
+  eq 0, m.cursor
+  m.left # already leftmost: no move
+  eq 0, m.cursor
+  m.inc; m.inc          # leftmost digit -> 2
+  m.right; m.inc        # middle digit  -> 1
+  m.right; m.right      # clamp at the rightmost cell
+  eq 2, m.cursor
+  m.dec                 # rightmost 0 -> 9 (wraps)
+  eq 219, m.value
+end
+
+check 'NumberInput clamps its digit count to the 1..7 range' do
+  eq 1, Game::NumberInput.new(0).digits
+  eq 7, Game::NumberInput.new(99).digits
+end
+
+# -- Change Actor Name / Title / Sprite ---------------------------------------
+
+check 'Change Actor Name renames the actor; a blank name is ignored' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_ACTOR_NAME, [1], string: 'Zelda')])
+  it.update
+  eq 'Zelda', st.party.actor_by_id(1).name
+  ok !it.waiting?, 'Change Actor Name must not pause the interpreter'
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CHANGE_ACTOR_NAME, [1], string: '')])
+  it2.update
+  eq 'Zelda', st.party.actor_by_id(1).name # unchanged by the blank name
+end
+
+check 'Change Actor Title sets the title; an empty string clears it' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_ACTOR_TITLE, [2], string: 'Sage')])
+  it.update
+  eq 'Sage', st.party.actor_by_id(2).title
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CHANGE_ACTOR_TITLE, [2], string: '')])
+  it2.update
+  eq '', st.party.actor_by_id(2).title
+end
+
+check 'Change Sprite Association swaps the CharSet and flags a graphic change' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # actor 1, charset "Monster", cell 4, transparent = 1.
+  it.start([FakeCmd.new(IC::CHANGE_ACTOR_SPRITE, [1, 4, 1], string: 'Monster')])
+  it.update
+  a = st.party.actor_by_id(1)
+  eq 'Monster', a.charset_name
+  eq 4, a.charset_index
+  eq true, a.transparent
+  ok !it.waiting?, 'Change Actor Graphic must not pause the interpreter'
+  eq true, it.take_actor_graphic_changed, 'a one-shot graphic-change request is set'
+  eq false, it.take_actor_graphic_changed, 'and it clears after the first read'
+end
+
+# -- Halt All Movement --------------------------------------------------------
+
+check 'Halt All Movement raises a one-shot request without pausing' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::HALT_ALL_MOVEMENT, []),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0])])
+  it.update
+  ok !it.waiting?, 'Halt All Movement must not pause the interpreter'
+  eq true, st.switches[3], 'the command after Halt All Movement still ran'
+  eq true, it.take_halt_movement_request, 'a one-shot halt request is set'
+  eq false, it.take_halt_movement_request, 'and it clears after the first read'
 end
 
 # -- summary ------------------------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -69,6 +69,9 @@ module RGSS
     end
     def self.reset; @dir_value = 0; @triggered = []; end
     def self.trigger?(k); Array(@triggered).include?(k); end
+    # The scene treats a held key like a triggered one for widget navigation; the
+    # stub answers both from the same `triggered` set.
+    def self.repeat?(k); Array(@triggered).include?(k); end
     def self.dir4; @dir_value || 0; end
     def self.update; end
   end
@@ -436,6 +439,48 @@ check 'Erase Event stops a parallel process that erases itself' do
      'erased from the event list'
   ok scene.instance_variable_get(:@parallels).empty?,
      'its background process was removed'
+end
+
+check 'Halt All Movement cancels a forced player route in the scene' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Force the player onto a repeating downward route, then immediately halt all
+  # movement: the route must be cancelled before it can step the player.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10001, 8, 1, 1, R::MOVE_DOWN]),
+                         ECmd.new(ic::HALT_ALL_MOVEMENT, [])]
+  scene = new_scene({ 1 => event(3, 0, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  20.times { scene.update }
+  ok scene.instance_variable_get(:@player_route).nil?,
+     'the forced player route was cancelled'
+  eq [0, 0], [st.x, st.y], 'the player never moved (movement was halted)'
+end
+
+check 'Input Number opens a widget; confirming stores the entered value' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Two digits into variable 5, then flip switch 1 so we can see it resumed.
+  auto.event_commands = [ECmd.new(ic::INPUT_NUMBER, [2, 5]),
+                         ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+
+  ni = nil
+  12.times do
+    scene.update
+    ni = scene.instance_variable_get(:@number_input)
+    break if ni
+  end
+  ok ni, 'the number-entry widget opened'
+
+  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C]  # confirm
+  scene.update
+  ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
+  5.times { RGSS::Input.reset; scene.update }
+  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
 check 'a message types out gradually, then a button completes and dismisses it' do


### PR DESCRIPTION
This PR adds support for six more RPG2000 event commands, enabling numeric input, actor customization, and movement control during event execution.

## Summary
Implements the Input Number (10150), Change Actor Name/Title/Sprite (10610/10620/10630), and Halt All Movement (11350) event commands. These commands allow events to prompt players for numeric input, modify actor properties at runtime, and cancel forced movement routes. Actor mutations now persist across save/load cycles.

## Key Changes

**Input Number Command**
- New `Game::NumberInput` model handles digit entry logic (cursor movement, increment/decrement, value calculation)
- Map scene drives a digit-entry widget with visual feedback (highlighted cursor cell)
- Interpreter suspends on `:number` wait kind; scene resumes with entered value via `resume_number()`
- Digit count clamped to 1..7 range (RPG2000 limit)

**Actor Mutations**
- `Game::Actor` gains writable `name`, `title`, and `transparent` fields
- New `set_charset(name, index)` method for sprite changes
- Fields seeded from database row (`title`, `semi_transparent`)
- Scene reloads party leader's on-screen sprite when graphic changes mid-event

**Party State Persistence**
- `Game::Party#to_h` now serializes actor name/title/sprite overrides in `actor_meta` hash
- `Game::Party#load_state` restores these overrides on load, preserving runtime mutations
- Backward compatible: saves without `actor_meta` keep database defaults

**Halt All Movement Command**
- Cancels all forced move routes (player and events) immediately
- Non-blocking: rest of command list continues executing
- Scene polls `take_halt_movement_request()` after interpreter update

**Scene Integration**
- `event_busy?` now checks `@number_input` state
- New `apply_halt_request()` and `apply_graphic_change()` methods process interpreter requests
- `drive_number_input()` handles UP/DOWN/LEFT/RIGHT/C input for digit editing
- `refresh_player_graphic()` reloads charset and applies transparency flag

## Testing
- Unit tests in `scripts/rpg2k_logic_check.rb` cover command logic, state round-tripping, and NumberInput model
- Scene integration tests in `scripts/rpg2k_scene_check.rb` verify widget lifecycle and movement halting
- All existing tests remain passing

https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW