### PR TITLE
Generate real RPG2003 saves headlessly via wine and debug menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,19 @@ Create ADRs in /docs/adr for:
 - The `LcfSaveData` schema lives in `mruby-lcf/mrblib/schema.rb` (`SAVE_DATA`).
   Analyse a real save with `ruby scripts/lcf_save_check.rb <path/to/Save01.lsd>`;
   it lists documented vs. undocumented top-level chunks and reads every
-  documented field. Generate a real save by running an RPG Maker 2000 game under
-  wine (headless via Xvfb) and saving in-game — synthetic blobs cannot catch a
-  mistyped field, so validate against genuine output.
+  documented field. Synthetic blobs cannot catch a mistyped field, so validate
+  against genuine output.
+- Generate a real save headlessly with `./scripts/gen-lcf-save-wine.bash`: it
+  boots a game's EasyRPG Player under wine (Xvfb + `matchbox-window-manager` so
+  the SDL window gets input focus) with `--test-play` and uses the **debug menu**
+  (F9 → Save → slot) to write a genuine `Save<N>.lsd` from anywhere — no
+  playthrough needed, which is how a real **RPG2003** save is obtained despite
+  those games' menu-disabled intros (and Nepheshel's Gate-only saving). It then
+  runs `lcf_save_check.rb`. Defaults to the mtf-meido-action RPG2003 test-bed;
+  pass a game dir + slot for others. Input notes for driving EasyRPG under Xvfb:
+  a window manager is required (no WM → wine never focuses the window → keys are
+  dropped), decision keys must be *held* (keydown/pause/keyup, not a tap), and
+  menu-cursor moves want short taps. See ADR 0017.
 - Top-level chunk map, from a real save (Nepheshel, saved at the town Gate).
   Documented in `SAVE_DATA`: 100 title, 101 system, 103 pictures, 104–107
   hero/boat/ship/airship, 108 party actors, 110 teleport targets, 111 map
@@ -130,9 +140,11 @@ Create ADRs in /docs/adr for:
   asserts the Classes table decodes and every actor's `class_id` resolves. The
   2003-specific content lives almost entirely in the database (`RPG_RT.ldb`),
   which is validated against real 2003 games (Song-of-the-Sea, mtf-meido-action);
-  the `.lsd` layout is largely shared with 2000, and generating a real 2003 save
-  is gated behind those games' menu-disabled intros (save-level 2003 validation
-  is follow-up — see ADR 0013).
+  the `.lsd` layout is largely shared with 2000. A real 2003 save is now
+  validated too: `gen-lcf-save-wine.bash` writes one from mtf-meido-action via
+  the debug menu (bypassing its menu-disabled intro), and it parses through
+  `SAVE_DATA` and round-trips into the runtime cleanly — see ADR 0017 (this was
+  the follow-up deferred by ADR 0013).
 
 ## Testing Standards
 

--- a/changelog.d/gen-lcf-save-wine-2003.added.md
+++ b/changelog.d/gen-lcf-save-wine-2003.added.md
@@ -1,0 +1,12 @@
+- Real `Save<N>.lsd` fixtures can now be generated **headlessly** and for the
+  **RPG Maker 2003** edition. `scripts/gen-lcf-save-wine.bash` boots an RPG
+  2000/2003 game's EasyRPG Player under wine + Xvfb + a window manager and uses
+  the **test-play debug menu** (F9 -> Save) to write a genuine `LcfSaveData` from
+  anywhere -- bypassing both Nepheshel's Gate-only saving and the 2003 test
+  games' menu-disabled intro, then runs `scripts/lcf_save_check.rb` over the
+  result. This closes the save-level 2003 validation deferred by ADR 0013: a real
+  mtf-meido-action (RPG2003) save parses through the `SAVE_DATA` schema and
+  round-trips into the runtime cleanly, the `SAVE_TITLE` hero HP matches party
+  actor 1's saved HP, and every `SAVE_MAP_EVENT` position matches a defined,
+  in-bounds event on the current map. The undocumented top-level chunks 102, 112
+  and 200 are confirmed to appear in both editions' saves. See ADR 0017.

--- a/docs/adr/0017-generate-real-lcf-saves-under-wine.md
+++ b/docs/adr/0017-generate-real-lcf-saves-under-wine.md
@@ -1,0 +1,77 @@
+# 17. Generate real LCF saves under wine and validate a real RPG2003 save
+
+Date: 2026-08-04
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0009-0014 built and validated the `LcfSaveData` schema
+(`mruby-lcf/mrblib/schema.rb` `SAVE_DATA`) against a genuine RPG Maker **2000**
+save -- one produced by playing Nepheshel to an in-game save point (a "Gate")
+under EasyRPG Player and running `scripts/lcf_save_check.rb` over the result.
+Synthetic blobs cannot catch a mistyped field, so validation has always insisted
+on real editor/runtime output.
+
+The gap was the **2003** edition. ADR 0013 validated real 2003 *database and map*
+data (mtf-meido-action, Song-of-the-Sea decode as 2003, every `class_id`
+resolves), but explicitly **deferred save-level 2003 validation**: the available
+2003 games open with a *menu-disabled intro*, so the normal in-game Save cannot
+be reached without playing through the scripted opening. Reaching Nepheshel's own
+save point already needed a fragile playthrough; a save-disabled 2003 intro made
+it impossible by the same route.
+
+Two further frictions made even the 2000 case hard to reproduce in CI:
+
+- Under a headless X server (Xvfb) with **no window manager**, wine never marks
+  the SDL window as the foreground window, so EasyRPG receives no keystrokes --
+  the game boots and renders but cannot be driven.
+- EasyRPG's decision key is dropped when sent as a zero-length tap; it must be
+  *held* (keydown, pause, keyup). Menu-cursor moves, conversely, want short taps
+  so each advances exactly one cell.
+
+## Decision
+
+- **Use EasyRPG Player's test-play debug menu to save.** Launched with
+  `--test-play`, EasyRPG binds **F9** to a debug menu whose first entry is
+  **"Save"**. It invokes the normal save scene from anywhere, regardless of
+  whether the game currently permits saving -- so it bypasses Nepheshel's Gate
+  gating *and* the 2003 games' menu-disabled intro. Boot the game, start a New
+  Game, then F9 -> Save -> a file slot writes a byte-real `Save<N>.lsd` with no
+  playthrough, for either edition.
+- **`scripts/gen-lcf-save-wine.bash`** encodes this headlessly: Xvfb +
+  `matchbox-window-manager` (so the SDL window gets X input focus) + wine running
+  `Player.exe --test-play`, driven with held decision keys / tapped cursor moves,
+  then F9 -> Save -> slot, then `scripts/lcf_save_check.rb` over the output. It
+  defaults to the **mtf-meido-action** RPG2003 test-bed (already in the download
+  set, ships EasyRPG Player.exe) and takes any game dir + slot as arguments.
+
+## Consequences
+
+- **Save-level RPG2003 validation is now real, closing the ADR 0013 follow-up.**
+  A genuine mtf-meido-action `Save01.lsd` parses cleanly through `SAVE_DATA` and
+  round-trips into the runtime via `Game::State.from_lsd`
+  (`scripts/rpg2k_save_load_check.rb`). The 2003 save exercises the same id-driven
+  chunk layout as 2000 -- title, system, hero/vehicles, party actors (108),
+  inventory (109), map events (111), foreground/common-event exec state
+  (113/114) -- and the cross-checks hold: the `SAVE_TITLE` hero HP equals party
+  actor 1's saved HP, and every `SAVE_MAP_EVENT` position matches a defined,
+  in-bounds event on the current map. The pictures chunk (103) is heavily
+  populated by the 2003 intro's CG, giving that section real bytes to read.
+- **The undocumented top-level chunks 102, 112 and 200 appear in both editions'
+  saves**, confirming they are written by the runtime independent of edition
+  rather than being a 2000-only or 2003-only artifact. They remain undocumented
+  (102 and 112 are one byte each, 200 is five) pending differential saves, as
+  before.
+- **Real-save fixtures are now reproducible without a manual playthrough**, for
+  any RPG2000/2003 project EasyRPG can boot. That makes it cheap to regenerate a
+  save after a schema change and to add new games as fixtures. The generated
+  `.lsd` is not vendored (games are downloaded, not redistributed; `data/` is
+  git-ignored) -- the script reproduces it on demand.
+- The method depends on EasyRPG's `--test-play` debug menu and on a window
+  manager being present under Xvfb; the script documents both. Games with a
+  name-entry step before control (Nepheshel) need that one game-specific
+  sub-sequence added before the F9 save; the 2003 test-bed reaches a saveable
+  state with no game-specific steps.

--- a/scripts/gen-lcf-save-wine.bash
+++ b/scripts/gen-lcf-save-wine.bash
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+# Generate a genuine RPG Maker 2000/2003 Save<N>.lsd headlessly under wine and
+# analyse it with scripts/lcf_save_check.rb.
+#
+# The database/map schemas are validated against real games by
+# lcf_testbed_check.rb, and the save-data schema against a real 2000 save
+# (Nepheshel) by lcf_save_check.rb. Getting a *2003* save was the gap: the 2003
+# test games (mtf-meido-action, Song-of-the-Sea) open with a menu-disabled intro,
+# so the in-game Save cannot be reached without playing the scripted opening --
+# ADR 0013 deferred save-level 2003 validation for exactly this reason.
+#
+# The way past it is EasyRPG Player's **test-play debug menu** (F9): its first
+# entry is "Save", which invokes the normal save scene from anywhere, ignoring
+# whether the game currently permits saving. So booting the game under
+# `--test-play`, starting a New Game, and picking F9 -> Save -> a file slot
+# writes a byte-real LcfSaveData without any playthrough -- for either edition.
+#
+# Two things make the input actually reach the game under a headless X server:
+#   * a window manager (matchbox) so the SDL window gets X input focus -- with no
+#     WM, wine never marks the window foreground and keystrokes are dropped;
+#   * the decision key must be *held* (keydown, pause, keyup), not tapped -- a
+#     zero-length press is swallowed by the title/menu handlers. Menu cursor
+#     moves, by contrast, want short taps so they advance exactly one cell.
+#
+# Requires: wine (win64 -- EasyRPG's Player.exe is a 64-bit PE), Xvfb,
+#           matchbox-window-manager, x11-apps (xwd), ImageMagick (convert),
+#           xdotool, and a Japanese locale for the CP932 text. On Debian/Ubuntu:
+#     apt-get install --no-install-recommends wine wine64 xvfb \
+#         matchbox-window-manager x11-apps imagemagick xdotool \
+#         fonts-ipafont unar locales
+#     locale-gen ja_JP.UTF-8
+#
+# Usage: ./scripts/gen-lcf-save-wine.bash [game_dir] [slot]
+#   game_dir defaults to data/mtf-meido-action/Debug (a real RPG2003 project,
+#            already part of the testbed download set; ships EasyRPG Player.exe).
+#            Pass data/Nepheshel206beta/Nepheshel206Rbeta for the RPG2000 case
+#            (needs a name-entry step -- see NEPHESHEL notes below).
+#   slot     save file number (default 1) -> Save0<slot>.lsd.
+
+set -eux -o pipefail
+
+cd "$(dirname "$0")/.."
+
+GAME_DIR="${1:-data/mtf-meido-action/Debug}"
+SLOT="${2:-1}"
+LSD="$(printf 'Save%02d.lsd' "${SLOT}")"
+
+# Fetch the default test-bed if absent (ships EasyRPG Player.exe alongside data).
+if [ ! -e "${GAME_DIR}/RPG_RT.ldb" ] ; then
+    if [ "${GAME_DIR}" = "data/mtf-meido-action/Debug" ] ; then
+        ./scripts/download-mtf-meido-action.bash
+    else
+        echo "No RPG_RT.ldb in ${GAME_DIR}" >&2 ; exit 1
+    fi
+fi
+
+# EasyRPG Player.exe: use the one in the game dir, else borrow the test-bed's.
+if [ ! -f "${GAME_DIR}/Player.exe" ] ; then
+    if [ ! -f data/mtf-meido-action/Debug/Player.exe ] ; then
+        ./scripts/download-mtf-meido-action.bash
+    fi
+    cp data/mtf-meido-action/Debug/Player.exe "${GAME_DIR}/"
+fi
+
+export WINEARCH=win64
+export WINEPREFIX="${WINEPREFIX:-$HOME/.wine-rpg2k-save}"
+export WINEDLLOVERRIDES="mscoree,mshtml="
+export WINEDEBUG="${WINEDEBUG:--all}"
+# Japanese locale so the ANSI code page is 932 and CP932 text decodes.
+export LANG=ja_JP.UTF-8
+export LC_ALL=ja_JP.UTF-8
+# No GPU under Xvfb: ask SDL for its software renderer. Do NOT set
+# SDL_VIDEODRIVER -- under wine SDL must use its "windows" driver.
+export SDL_RENDER_DRIVER=software
+
+export DISPLAY="${DISPLAY:-:1024}"
+Xvfb "${DISPLAY}" -screen 0 640x480x24 >/tmp/gen-lcf-xvfb.log 2>&1 &
+XVFB_PID=$!
+# A window manager so the SDL window receives X input focus (see header).
+matchbox-window-manager -use_titlebar no >/tmp/gen-lcf-wm.log 2>&1 &
+WM_PID=$!
+cleanup() {
+    kill "${PLAYER_PID:-}" 2>/dev/null || true
+    kill "${WM_PID}" 2>/dev/null || true
+    kill "${XVFB_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+sleep 2
+
+# One-time prefix bootstrap.
+if [ ! -d "${WINEPREFIX}" ] ; then
+    wine wineboot --init
+fi
+
+mkdir -p ss
+
+# --- input helpers ---------------------------------------------------------
+# The game window is named "EasyRPG Player"; find it, focus it, and drive it.
+win() { xdotool search --name 'EasyRPG' 2>/dev/null | head -1 ; }
+
+# hold_key SECONDS KEY...  -- press each key held for SECONDS (decision keys).
+hold_key() {
+    local secs="$1" ; shift
+    local wid ; wid="$(win)"
+    xdotool windowfocus "${wid}" 2>/dev/null || true
+    xdotool windowraise "${wid}" 2>/dev/null || true
+    sleep 0.3
+    local k
+    for k in "$@" ; do
+        xdotool keydown --window "${wid}" --clearmodifiers "${k}" 2>/dev/null || true
+        sleep "${secs}"
+        xdotool keyup --window "${wid}" --clearmodifiers "${k}" 2>/dev/null || true
+        sleep 0.35
+    done
+}
+
+shot() { xwd -root -display "${DISPLAY}" -silent | convert xwd:- "png:ss/$1" ; }
+
+# --- boot and save ---------------------------------------------------------
+( cd "${GAME_DIR}" && wine Player.exe --test-play ) >/tmp/gen-lcf-player.log 2>&1 &
+PLAYER_PID=$!
+
+# Wait for the title screen, then snapshot it.
+for _ in $(seq 1 30) ; do win >/dev/null && break ; sleep 1 ; done
+sleep 12
+shot title.png
+
+# Start a New Game (the top menu entry). Decision keys are HELD, not tapped.
+hold_key 0.25 Return
+sleep 6
+
+# NEPHESHEL note: the RPG2000 game inserts a "skip opening demo?" choice and a
+# name-entry grid here; drive those first (Down + Return to skip, then navigate
+# the kana grid to <決定> and Return to accept the default name) before the F9
+# save. The RPG2003 test-bed drops straight into a controllable cutscene, so the
+# generic path below (advance a few messages, then F9 -> Save) reaches a saveable
+# state without any game-specific steps.
+hold_key 0.2 Return Return Return
+sleep 2
+
+# Open the test-play debug menu (F9); its first entry, "Save", is preselected.
+hold_key 0.1 F9
+sleep 1.5
+shot debug-menu.png
+hold_key 0.25 Return          # choose "Save" -> opens the save-file scene
+sleep 1
+# File 1 is preselected; step down (slot-1) times to reach the requested slot.
+for _ in $(seq 2 "${SLOT}") ; do hold_key 0.03 Down ; done
+hold_key 0.25 Return          # confirm the file slot -> writes Save0<N>.lsd
+sleep 2
+shot saved.png
+
+if [ ! -f "${GAME_DIR}/${LSD}" ] ; then
+    echo "FAILED: ${GAME_DIR}/${LSD} was not written" >&2
+    exit 1
+fi
+echo "Wrote ${GAME_DIR}/${LSD}"
+
+# Analyse the genuine save with the same parser the runtime uses.
+ruby scripts/lcf_save_check.rb "${GAME_DIR}/${LSD}"


### PR DESCRIPTION
## Summary

This PR adds the ability to generate genuine RPG Maker 2003 save files (`Save<N>.lsd`) headlessly under wine, closing a gap in save-level validation that was deferred in ADR 0013. Previously, only RPG2000 saves could be validated against real output; RPG2003 games' menu-disabled intros made it impossible to reach the in-game save functionality through normal gameplay.

## Key Changes

- **New script: `scripts/gen-lcf-save-wine.bash`** — Generates real `LcfSaveData` files by:
  - Booting an RPG2000/2003 game's EasyRPG Player under wine with `--test-play`
  - Running headlessly via Xvfb + matchbox-window-manager (required for X input focus)
  - Using the test-play debug menu (F9 → Save) to write a genuine save from anywhere, bypassing both Nepheshel's Gate-only saving and 2003 games' menu-disabled intros
  - Running `lcf_save_check.rb` to validate the output
  - Defaults to mtf-meido-action (RPG2003 test-bed); accepts any game dir + slot as arguments

- **ADR 0017** — Documents the decision to use EasyRPG's debug menu for headless save generation, the technical challenges (window manager requirement, held vs. tapped keys), and consequences (real 2003 save validation now complete, undocumented chunks 102/112/200 confirmed in both editions)

- **Updated AGENTS.md** — Clarifies the save generation workflow and input requirements for driving EasyRPG under Xvfb

- **Changelog entry** — Records the new capability and validates that real 2003 saves parse cleanly through `SAVE_DATA` and round-trip into the runtime

## Notable Implementation Details

- The script requires a window manager (matchbox) under Xvfb; without it, wine never marks the SDL window as foreground and keystrokes are dropped
- Decision keys must be *held* (keydown/pause/keyup), not tapped; menu-cursor moves require short taps to advance exactly one cell
- Japanese locale (ja_JP.UTF-8) is required for CP932 text decoding
- A real mtf-meido-action save now validates: `SAVE_TITLE` hero HP matches party actor 1's saved HP, and every `SAVE_MAP_EVENT` position matches a defined, in-bounds event on the current map

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj