### PR TITLE
Fix Integer#zero? calls in mruby code without numeric-ext

### DIFF
--- a/changelog.d/mv-move-zero-fix.fixed.md
+++ b/changelog.d/mv-move-zero-fix.fixed.md
@@ -1,0 +1,8 @@
+- MV movement smoke test (`--mv_move_test`) now actually walks the player.
+  The probe called `Integer#zero?`, but this mruby build omits
+  `mruby-numeric-ext` (kept lean for the embedded targets), so `#zero?` is not
+  defined and the call raised `undefined method 'zero?' for Integer` every
+  frame — aborting the probe before it ever pressed a direction, so the player
+  never moved. Rewritten as `== 0`. The same latent `Integer#zero?` call in
+  RPG2000's `Tone#update_tint` (which would have raised mid-tint on the native
+  binary) is fixed the same way.

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -469,7 +469,11 @@ class MV
     return unless current_scene == "Scene_Map"
 
     @move_frame ||= 0
-    if @move_frame.zero?
+    # NB: use `== 0`, not Integer#zero? — this mruby build omits
+    # mruby-numeric-ext (kept lean for the embedded targets), so #zero? is not
+    # defined and calling it raised "undefined method 'zero?' for Integer" every
+    # frame, aborting the probe before it pressed a direction.
+    if @move_frame == 0
       @move_start = player_tile
       $stderr.puts "[MV-MOVE] start #{@move_start}"
     end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1440,7 +1440,9 @@ module Game
       @b += (@tb - @b) / @frames
       @sat += (@tsat - @sat) / @frames
       @frames -= 1
-      return unless @frames.zero?
+      # `== 0`, not Integer#zero?: this mruby build omits mruby-numeric-ext, so
+      # #zero? is undefined and would raise here mid-tint (see mv.rb's probe).
+      return unless @frames == 0
       @r = @tr; @g = @tg; @b = @tb; @sat = @tsat # land exactly on the target
     end
 


### PR DESCRIPTION
This PR fixes runtime errors caused by calling `Integer#zero?` in a mruby build that omits the `mruby-numeric-ext` extension.

## Summary
The mruby build used for embedded targets is kept lean by excluding `mruby-numeric-ext`, which means `Integer#zero?` is not available. Two locations in the codebase were calling this undefined method, causing runtime errors.

## Changes
- **MV movement smoke test** (`mruby-mvjs/mrblib/mv.rb`): Changed `@move_frame.zero?` to `@move_frame == 0` in the `maybe_move_test` probe. The undefined method error was being raised every frame, aborting the probe before it could press any direction, so the player never moved.
- **RPG2000 tint update** (`mruby-rpg2k/mrblib/game.rb`): Changed `@frames.zero?` to `@frames == 0` in `Tone#update_tint`. This would have raised a runtime error mid-tint on the native binary.

Both changes use the equivalent `== 0` comparison instead, which is always available and produces the same behavior.

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt