### PR TITLE
rpg2k: slide events smoothly between tiles

### DIFF
--- a/changelog.d/rpg2k-event-movement-interpolation.added.md
+++ b/changelog.d/rpg2k-event-movement-interpolation.added.md
@@ -1,0 +1,8 @@
+- **Smooth event movement** — map events now slide between tiles instead of
+  hopping. `Scene::Map` gives each event the same pixel-interpolation model as
+  the player: a single-tile cardinal step eases from the old tile to the new one
+  over `TILE/SPEED` frames (`event_pixel`, driven by a per-event
+  `disp`/`move_count` slide started in `reoccupy`), and the walk animation only
+  cycles while the sprite is actually sliding — a resting event shows its page
+  pose. A longer hop (jump or multi-tile move) snaps rather than streaking
+  across the map. Covered by new checks in `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -73,10 +73,12 @@ The work below is roughly ordered by the critical path to a walkable game
   name), composite into the correct layer relative to the hero (below / above /
   same-layer y-sorted), honour the translucent flag, and pick their walk frame
   from the page's animation type (`Game::EventGraphic`: walk-while-moving,
-  continuous, fixed-direction, fixed-graphic, spin). Grounded in the real
-  Nepheshel data and pinned by `scripts/rpg2k_render_check.rb` /
-  `scripts/rpg2k_scene_check.rb`. Remaining polish: per-step pixel interpolation
-  of event movement (events currently hop tile-to-tile) and vehicle sprites
+  continuous, fixed-direction, fixed-graphic, spin). Events also **slide
+  smoothly between tiles** (per-step pixel interpolation, mirroring the player):
+  a single-tile step eases across over `TILE/SPEED` frames while the walk
+  animation cycles, and a longer hop snaps. Grounded in the real Nepheshel data
+  and pinned by `scripts/rpg2k_render_check.rb` /
+  `scripts/rpg2k_scene_check.rb`. Remaining polish: vehicle sprites
 - ✅ Movement & collision — grid movement with pixel interpolation, walk
   animation and edge/tile/event collision. Move-route *data* decodes
   (`LCF.parse_move_commands` / `LCF::MoveCommand`, wired into the event-page and

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -570,12 +570,14 @@ class RPG2k
         { id: id, char: ch, trigger: page_trigger(page),
           commands: page_commands(page), move_type: move_type, route: route,
           move_timer: EVENT_MOVE_DELAY[ch.move_frequency] || 40,
-          # Rendering state: the page's static graphic fields plus a live walk
-          # animation phase / counter and a "stepping" flag (see step_event).
+          # Rendering state: the page's static graphic fields, a live walk
+          # animation phase / counter, a mid-step "moving" flag, and the pixel
+          # slide (display origin disp_x/disp_y + move_count 0..TILE) that eases
+          # the sprite between tiles. move_count == TILE means "at rest".
           layer: page_layer(page), translucent: page_translucent(page),
           anim_type: page_anim_type(page), base_dir: dir,
           base_pattern: page_pattern(page), anim_phase: 0, anim_count: 0,
-          moving: false }
+          moving: false, disp_x: ev.x, disp_y: ev.y, move_count: TILE }
       end
 
       # Build the Call Event resolver for the current map: common events keyed by
@@ -788,36 +790,36 @@ class RPG2k
         nil
       end
 
-      # Advance each event's walk-animation phase once per frame. An event
-      # "moves" for animation purposes when it has autonomous movement (a
-      # non-stationary move type) or a forced route in progress; such events —
-      # and any continuous/spin animation type — cycle their walk frames on the
-      # ANIM_FRAME_PERIOD cadence, while a stationary, non-continuous event rests
-      # on its page pose. Game::EventGraphic.frame reads @moving / @anim_phase to
-      # pick the drawn column.
+      # Advance each event's pixel slide and walk-animation phase once per frame.
+      # An event "moves" for animation purposes while it is sliding between two
+      # tiles (see reoccupy / event_sliding?); such events — and any
+      # continuous/spin animation type — cycle their walk frames on the
+      # ANIM_FRAME_PERIOD cadence, while an event resting on a tile shows its
+      # page pose. Game::EventGraphic.frame reads @moving / @anim_phase to pick
+      # the drawn column, and event_pixel reads the slide for the draw position.
       def animate_events
         @events.each { |e| animate_event(e) }
       end
 
       def animate_event(e)
+        # Advance the slide first so a fixed-graphic event still glides smoothly.
+        e[:move_count] += SPEED if e[:move_count] < TILE
+        sliding = event_sliding?(e)
+        e[:moving] = sliding
         type = e[:anim_type]
-        walking = event_walking?(e)
-        e[:moving] = walking
         return unless Game::EventGraphic.animated?(type)
-        return unless walking || Game::EventGraphic.continuous?(type)
+        return unless sliding || Game::EventGraphic.continuous?(type)
         e[:anim_count] += 1
         return if e[:anim_count] < ANIM_FRAME_PERIOD
         e[:anim_count] = 0
         e[:anim_phase] = (e[:anim_phase] + 1) % Game::EventGraphic::WALK_COLUMNS.size
       end
 
-      # Whether an event is currently in motion (so it shows its walk cycle
-      # rather than a standing pose): it has a forced route, or its page gives it
-      # an autonomous, non-stationary move type.
-      def event_walking?(e)
-        return true if e[:forced_route]
-        mt = e[:move_type]
-        !mt.nil? && mt != Game::MoveType::STATIONARY
+      # Whether an event is mid-step: its display origin has not yet caught up to
+      # its logical tile (the slide started by reoccupy is still in progress).
+      def event_sliding?(e)
+        e[:move_count] < TILE &&
+          (e[:disp_x] != e[:char].x || e[:disp_y] != e[:char].y)
       end
 
       # Move an autonomous event one step in `dir`. Walking into the player fires
@@ -839,9 +841,42 @@ class RPG2k
       # Update the occupied-tile cache after event `e` moved off (ox, oy). Done
       # eagerly (rather than a single end-of-frame rebuild) so an event that has
       # already moved this frame blocks the next event from stepping onto it.
+      # Also begins the pixel slide from the old tile toward the new one so the
+      # sprite glides instead of teleporting (see event_pixel).
       def reoccupy(e, ox, oy)
         @event_tiles.delete([ox, oy]) if @event_tiles[[ox, oy]].equal?(e)
         @event_tiles[[e[:char].x, e[:char].y]] = e
+        start_event_slide(e, ox, oy)
+      end
+
+      # Begin a render slide for event `e` that just stepped off (ox, oy): the
+      # sprite eases from that tile to its new one over TILE/SPEED frames. Only
+      # single-tile cardinal steps slide; a longer hop (a jump, or a diagonal of
+      # more than one tile) snaps so the sprite never streaks across the map.
+      def start_event_slide(e, ox, oy)
+        if (e[:char].x - ox).abs + (e[:char].y - oy).abs == 1
+          e[:disp_x] = ox
+          e[:disp_y] = oy
+          e[:move_count] = 0
+        else
+          e[:disp_x] = e[:char].x
+          e[:disp_y] = e[:char].y
+          e[:move_count] = TILE
+        end
+      end
+
+      # Current position of event `e` in map pixels, interpolated from its
+      # display origin toward its logical tile while a slide is in progress.
+      def event_pixel(e)
+        cx = e[:char].x
+        cy = e[:char].y
+        if event_sliding?(e)
+          t = e[:move_count]
+          [e[:disp_x] * TILE + (cx - e[:disp_x]) * t,
+           e[:disp_y] * TILE + (cy - e[:disp_y]) * t]
+        else
+          [cx * TILE, cy * TILE]
+        end
       end
 
       # -- Erase Event --------------------------------------------------------
@@ -1549,8 +1584,9 @@ class RPG2k
                                             e[:char].direction, e[:anim_phase],
                                             e[:moving])
         sx, sy, sw, sh = Game::CharSet.frame_rect(e[:char].graphic_index, dir, col)
-        dx = e[:char].x * TILE - cam_x - (Game::CharSet::WIDTH - TILE) / 2
-        dy = e[:char].y * TILE - cam_y - (Game::CharSet::HEIGHT - TILE)
+        epx, epy = event_pixel(e)
+        dx = epx - cam_x - (Game::CharSet::WIDTH - TILE) / 2
+        dy = epy - cam_y - (Game::CharSet::HEIGHT - TILE)
         bmp.blt dx, dy, charset, Rect.new(sx, sy, sw, sh), opacity
       end
 
@@ -1560,8 +1596,9 @@ class RPG2k
       def draw_event_tile(e, bmp, cam_x, cam_y, opacity)
         return unless @chipset_bmp
         sx, sy, sw, sh = Game::ChipsetLayout.event_tile_rect(e[:char].graphic_index)
-        dx = e[:char].x * TILE - cam_x
-        dy = e[:char].y * TILE - cam_y
+        epx, epy = event_pixel(e)
+        dx = epx - cam_x
+        dy = epy - cam_y
         bmp.blt dx, dy, @chipset_bmp, Rect.new(sx, sy, sw, sh), opacity
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -770,13 +770,45 @@ check 'a wandering event cycles its walk phase; a stationary one rests' do
   mover = event(3, 2, page(charset_name: 'c', x_move_type: Game::MoveType::RANDOM))
   still = event(1, 1, page(charset_name: 'c')) # stationary, non-continuous
   scene = new_scene({ 1 => mover, 2 => still }, player: [5, 4])
-  40.times { scene.update }
   eh = event_hashes(scene)
-  ok eh[1][:moving], 'a random mover is flagged moving'
-  ok eh[1][:anim_phase] != 0 || eh[1][:anim_count] != 0,
-     'the mover advanced its walk animation'
-  ok !eh[2][:moving], 'a stationary event is not flagged moving'
+  slid = false
+  200.times { scene.update; slid ||= eh[1][:moving] }
+  ok slid, 'a random mover slides between tiles at some point'
+  ok [eh[1][:char].x, eh[1][:char].y] != [3, 2], 'the mover changed tiles'
+  ok eh[1][:anim_phase] != 0, 'the mover advanced its walk animation while sliding'
+  ok !eh[2][:moving], 'a stationary event never slides'
+  eq [1, 1], [eh[2][:char].x, eh[2][:char].y], 'the stationary event held its tile'
   eq 0, eh[2][:anim_phase], 'a stationary non-continuous event holds its pose'
+end
+
+check 'an event slides smoothly between tiles instead of teleporting' do
+  # A forced route walks the event one tile east; sample its pixel position
+  # through the step and confirm it eases across rather than jumping a full tile.
+  ev = event(0, 2, page(charset_name: 'c', frequency: 6))
+  scene = new_scene({ 1 => ev }, player: [5, 4])
+  e = event_hashes(scene)[1]
+  scene.send(:force_event_route, e,
+             Game::MoveRoute.new(move_route([R::MOVE_RIGHT]).commands,
+                                 repeat: false, skippable: true), nil)
+  xs = []
+  20.times { scene.update; xs << scene.send(:event_pixel, e)[0] }
+  ok xs.include?(16), 'the slide completes on the destination tile (x px 16)'
+  mids = xs.select { |px| px.positive? && px < 16 }
+  ok !mids.empty?, "expected intermediate pixel offsets during the slide, got #{xs.inspect}"
+  ok xs.each_cons(2).all? { |a, b| b >= a }, 'the slide advances monotonically east'
+end
+
+check 'a multi-tile hop snaps rather than streaking across the map' do
+  # Reoccupy with a >1-tile jump should not start a slide (move_count stays at
+  # TILE, so event_pixel is the destination tile immediately).
+  ev = event(1, 1, page(charset_name: 'c'))
+  scene = new_scene({ 1 => ev })
+  e = event_hashes(scene)[1]
+  e[:char].x = 4 # simulate a jump landing (2 tiles east)
+  scene.send(:reoccupy, e, 1, 1)
+  eq RPG2k::Scene::Map::TILE, e[:move_count], 'a long hop does not slide'
+  eq [4 * RPG2k::Scene::Map::TILE, 1 * RPG2k::Scene::Map::TILE],
+     scene.send(:event_pixel, e), 'it snaps to the destination tile'
 end
 
 check 'a continuous-animation event advances even while standing still' do


### PR DESCRIPTION
## Summary

Follow-up to #172 (event sprite rendering). Map events used to **hop tile-to-tile** while the player glided; they now slide with the same pixel-interpolation model as the player, matching how the original game renders movement.

- `reoccupy` starts a slide from the old tile toward the new one; `event_pixel` eases the sprite across a single cardinal step over `TILE/SPEED` frames.
- A longer hop (a jump, or a diagonal of more than one tile) **snaps** so the sprite never streaks across the map.
- The walk animation now cycles **only while an event is actually sliding**, so a resting event shows its page pose and a mover walks as it slides — this makes the animation-type frame selection added in #172 render correctly in motion.

Collision and event triggers are unchanged: they still key off the logical tile (`char.x/char.y`); only the draw position interpolates.

## Testing

Pure-Ruby change in `mruby-rpg2k/mrblib/main.rb`, exercised by the host harnesses under CRuby (the native SDL/mruby binary can't be built here):

- `ruby scripts/rpg2k_render_check.rb` — 23 checks ✓
- `ruby scripts/rpg2k_logic_check.rb` — 114 checks ✓
- `ruby scripts/rpg2k_scene_check.rb` — 39 checks ✓, including new checks for the smooth slide (intermediate pixel offsets + monotonic advance), the multi-tile snap, and the reworked slide-based walk-animation behaviour.

Docs (`docs/TODO.md`) and a `changelog.d/` fragment are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS)_