### PR TITLE
Add an RGSS script host to run bundled Data/Scripts.rxdata (RPG Maker XP)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,9 @@ jobs:
       - name: RPG XP test-bed smoke check
         run: nix develop -c ruby scripts/rpgxp_testbed_check.rb
 
+      - name: RPG XP script-host smoke check
+        run: nix develop -c ruby scripts/rpgxp_script_host_check.rb
+
       - name: RPG2k game-logic checks
         run: |
           nix develop -c ruby scripts/rpg2k_logic_check.rb

--- a/README.md
+++ b/README.md
@@ -63,9 +63,15 @@
   the database loads with no loose files present. Loose files, when present,
   shadow the archive (as in RGSS). VX Ace's `Game.rgss3a` is detected but not yet
   decoded
-- The window is sized to XP's native 640×480 automatically. Running the game's
-  own bundled RGSS scripts (`Data/Scripts.rxdata`) is future work; see
-  [`docs/adr/0010-rpgxp-rgss-data-layer.md`](docs/adr/0010-rpgxp-rgss-data-layer.md)
+- The window is sized to XP's native 640×480 automatically.
+- An experimental **RGSS script host** can run the game's own bundled scripts
+  (`Data/Scripts.rxdata`) unmodified — the way `RGSS104E.dll` does — instead of
+  the reimplemented flow: it decompresses the ~90 Ruby sections, supplies the
+  `load_data`/`save_data` built-ins and evaluates each at the top level (via
+  `mruby-eval`) so the game drives itself. It is opt-in (`RGSS_SCRIPT_HOST`)
+  while the RGSS class library is completed; see
+  [`docs/adr/0017-rpgxp-rgss-script-host.md`](docs/adr/0017-rpgxp-rgss-script-host.md)
+  (data layer: [`docs/adr/0010-rpgxp-rgss-data-layer.md`](docs/adr/0010-rpgxp-rgss-data-layer.md))
 
 ### Terminal gaming
 - Render the game to a terminal instead of an SDL window, using either the DEC

--- a/changelog.d/rpgxp-rgss-script-host.added.md
+++ b/changelog.d/rpgxp-rgss-script-host.added.md
@@ -1,0 +1,11 @@
+- **RPG Maker XP — RGSS script host.** A project's bundled `Data/Scripts.rxdata`
+  can now be run unmodified, the way `RGSS104E.dll` does: `RPGXP::ScriptHost`
+  decompresses the ~90 Ruby sections (via a new native `RGSS.zlib_inflate` that
+  reuses stb_image's zlib decoder), installs the Kernel `load_data`/`save_data`
+  built-ins through the project database, and evaluates each section at the top
+  level so the game's own engine — title, map, event interpreter, battle — drives
+  itself. Requires the core `mruby-eval` gem. Opt-in for now
+  (`RGSS_SCRIPT_HOST`), with the built-in reimplemented flow (ADR 0010) as the
+  default and the fallback. Decoding, the built-ins and top-level evaluation of
+  real script source are validated against the `OpenGame.exe` XP test bed by the
+  new `scripts/rpgxp_script_host_check.rb` (run in CI). See ADR 0017.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -300,10 +300,23 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
 - **Menus / save / battle** — the default menu screens, saving in the real
   `.rxdata` save format (a portable Marshal save is used for now), and the
   battle system.
-- **Run the bundled RGSS scripts** — the largest possible direction: an
-  `eval`-based host that runs `Data/Scripts.rxdata` unmodified against the RGSS
-  class library (the equivalent of the MV "embed the real engine" choice),
-  which would also run community scripts. Out of scope for the current layer.
+- 🚧 **Run the bundled RGSS scripts** — the largest direction: an `eval`-based
+  host that runs `Data/Scripts.rxdata` unmodified against the RGSS class library
+  (the equivalent of the MV "embed the real engine" choice), which would also
+  run community scripts. The **host plumbing now exists** (ADR 0017): a native
+  `RGSS.zlib_inflate` decompresses the script sections, `RPGXP::RGSSData`
+  exposes `read_object`/`save_object`/`scripts`, and `RPGXP::ScriptHost`
+  installs the Kernel `load_data`/`save_data` built-ins and evaluates every
+  section at the top level (mruby-eval) so "Main" drives the game. Boot runs the
+  host when it is enabled (`RGSS_SCRIPT_HOST`, off by default) and the project
+  ships scripts, falling back to the built-in flow otherwise. Decoding, the
+  built-ins and top-level evaluation of real script source are covered by
+  `mruby-rpgxp/test` and `scripts/rpgxp_script_host_check.rb`. Remaining before
+  it can be the default: complete the `mruby-rgss` class library the stock
+  scripts call (`Graphics.transition/freeze`, `Window`/`Tilemap`/`Sprite`
+  surface, `Font` defaults, `Kernel#exit`, …), reconcile the scripts' blocking
+  main loop with the emscripten frame loop (Asyncify or a per-frame driver), and
+  read graphics/audio out of the encrypted archive.
 - Reference for the RGSS game library:
   https://www.rpgmaker.fixato.org/Manual/RPGVXAce/rgss/
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -352,10 +352,14 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   built-ins and top-level evaluation of real script source are covered by
   `mruby-rpgxp/test` and `scripts/rpgxp_script_host_check.rb`. Remaining before
   it can be the default: complete the `mruby-rgss` class library the stock
-  scripts call (`Graphics.transition/freeze`, `Window`/`Tilemap`/`Sprite`
-  surface, `Font` defaults, `Kernel#exit`, …), reconcile the scripts' blocking
-  main loop with the emscripten frame loop (Asyncify or a per-frame driver), and
-  read graphics/audio out of the encrypted archive.
+  scripts call — the precise gap (measured against the real test-bed scripts) is
+  tracked in [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md). `Font`,
+  `Graphics` timing, `Input` and `Audio` are already covered; the open pieces are
+  `Sprite` extended properties, and the empty `Window` / `Tilemap` / `Plane`
+  widgets, plus `Kernel#sprintf` and drawing `Graphics.transition/freeze`.
+  Also reconcile the scripts' blocking main loop with the emscripten frame loop
+  (Asyncify or a per-frame driver), and read graphics/audio out of the encrypted
+  archive.
 - Reference for the RGSS game library:
   https://www.rpgmaker.fixato.org/Manual/RPGVXAce/rgss/
 

--- a/docs/adr/0017-rpgxp-rgss-script-host.md
+++ b/docs/adr/0017-rpgxp-rgss-script-host.md
@@ -86,9 +86,12 @@ at the top level.
   scripts run.
 - **Trade-offs / follow-up.** The host is not yet the default and is unverified
   on the native target until the SDL/mruby build can run in CI. Remaining work:
-  fill in the `mruby-rgss` methods the stock scripts exercise
-  (`Graphics.transition/freeze`, `Window`/`Tilemap`/`Sprite` surface, `Font`
-  defaults, `Kernel#exit`, …); resolve the blocking-main-loop/emscripten
+  fill in the `mruby-rgss` methods the stock scripts exercise — the precise gap,
+  measured against the real test-bed scripts, is tracked in
+  `docs/rpgxp-rgss-api-gap.md` (`Font`/`Graphics`/`Input`/`Audio` are already
+  covered; the open pieces are `Sprite` extended properties and the empty
+  `Window`/`Tilemap`/`Plane` widgets, plus `Kernel#sprintf`); resolve the
+  blocking-main-loop/emscripten
   mismatch (Asyncify or a driver that pumps one `Scene#main` iteration per
   frame); and read graphics/audio out of the encrypted archive (still loose-file
   only). `mruby-eval` also enlarges every build that includes the RPG-maker gem

--- a/docs/adr/0017-rpgxp-rgss-script-host.md
+++ b/docs/adr/0017-rpgxp-rgss-script-host.md
@@ -1,0 +1,97 @@
+# 17. RPG Maker XP: run the bundled RGSS scripts via an mruby eval host
+
+Date: 2026-08-04
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0010 brought RPG Maker XP up the way `mruby-rpg2k` brought up RPG2000:
+**reimplement the default title/map/event flow directly against the database**
+rather than executing the game's own scripts. That layer boots a stock project
+to a walkable map with a working event interpreter, but it has a structural
+ceiling — most non-trivial XP games customise their behaviour through the
+`Data/Scripts.rxdata` scripts (custom menus, battle systems, community plugins
+like the ubiquitous RGSS add-ons), and the reimplementation can never reproduce
+that behaviour. ADR 0010 explicitly named "run the bundled RGSS scripts
+unmodified" as the largest possible future direction, the RGSS analogue of the
+MV decision (ADR 0004) to embed the game's real engine (a JavaScript runtime,
+quickjs-ng, in `mruby-mvjs`).
+
+How an XP project actually runs is simple in shape: `RGSS104E.dll` provides the
+low-level primitives (`Bitmap`, `Sprite`, `Viewport`, `Window`, `Plane`,
+`Tilemap`, `Table`/`Color`/`Tone`/`Rect`, `Graphics`, `Input`, `Audio`, the
+`RPG::*` data structs, and the Kernel built-ins `load_data`/`save_data`), then
+evaluates the ~90 Ruby sections in `Data/Scripts.rxdata` in order at the top
+level. The final "Main" section runs the game loop (`$scene.main while $scene
+!= nil`). Everything above the primitives — `Scene_*`, `Window_*`, `Game_*`,
+`Interpreter`, `Sprite_*`, the battle system — is game-supplied Ruby.
+
+The primitives already exist as `mruby-rgss`. The missing capability was a way
+to *evaluate the scripts*, which needs three things this project did not have:
+a runtime `eval`, a way to decompress the (zlib-deflated) script sections, and
+the two Kernel data built-ins the scripts assume the engine supplies.
+
+## Decision
+
+Add an **RGSS script host**: run a project's bundled scripts unmodified through
+mruby's own `eval`, against the native `mruby-rgss` class library.
+
+- **`RGSS.zlib_inflate`** (native, `mruby-rgss/src/lib.cxx`) inflates a zlib
+  stream by reusing stb_image's zlib decoder — already linked for PNG/XYZ
+  loading — so no new dependency is pulled in. It decompresses each script
+  section (and is generally useful for the other zlib payloads RGSS ships).
+- **`RPGXP::RGSSData`** gains a public `read_object`/`save_object`
+  (project-relative Marshal load/dump honouring the encrypted archive — the
+  shape RGSS's `load_data`/`save_data` need) and a `scripts` accessor that
+  decodes `Data/Scripts.rxdata` (a Marshal array of `[id, name, deflated]`) into
+  an ordered `[name, source]` list.
+- **`RPGXP::ScriptHost`** (`mruby-rpgxp/mrblib/script_host.rb`) installs the
+  Kernel built-ins (`load_data`/`save_data` routed through the database, plus
+  `$RGSS_SCRIPTS`) and `eval`s each section at the top level using its editor
+  name as the "filename", so the game's own logic runs and "Main" drives the
+  loop. Requires the core `mruby-eval` gem, now a `mruby-rpgxp` dependency.
+- **Boot (`mruby-rpgxp/mrblib/lib.rb`)** runs the host when it is enabled and the
+  project ships scripts; otherwise it uses the ADR 0010 built-in flow, which is
+  also the fallback if the host fails to boot.
+
+**The host is opt-in for now** (`RGSS_SCRIPT_HOST` env / `ScriptHost::ENABLED`),
+defaulting off, for three reasons: it cannot be built or run in the current CI
+sandbox (no SDL/mruby binary), the `mruby-rgss` class library is not yet
+complete enough to satisfy every method the stock scripts call, and the scripts'
+blocking `$scene.main while` loop needs Asyncify (or an equivalent) to cooperate
+with the browser/emscripten frame loop. Keeping the built-in flow as the default
+means the change lands the whole host without regressing the verified boot.
+
+Because the host plumbing is written in the mruby/CRuby common subset, a new
+host-side harness (`scripts/rpgxp_script_host_check.rb`, run in CI) loads the
+exact sources under CRuby and drives them against the real
+`data/OpenGame.exe/Testbed/XP` project: it decodes all 90 sections, installs and
+round-trips the Kernel built-ins, and evaluates a load-safe logic subset
+(`Game_*`, `Interpreter 1`–`7`), confirming genuine script source decompresses,
+evaluates and defines its classes (`Interpreter#command_301`, `#command_121`, …)
+at the top level.
+
+## Consequences
+
+- The pieces an eval-based engine needs — decompression, `eval`, the data
+  built-ins, script ordering and top-level evaluation — now exist and are
+  validated end to end against a real project's scripts. Turning the host on is
+  a matter of completing the `mruby-rgss` class library the scripts call, and is
+  no longer blocked on missing infrastructure.
+- Running community/custom scripts (the whole point of the RGSS ecosystem)
+  becomes reachable on the same path, exactly as embedding quickjs made MV's own
+  scripts run.
+- **Trade-offs / follow-up.** The host is not yet the default and is unverified
+  on the native target until the SDL/mruby build can run in CI. Remaining work:
+  fill in the `mruby-rgss` methods the stock scripts exercise
+  (`Graphics.transition/freeze`, `Window`/`Tilemap`/`Sprite` surface, `Font`
+  defaults, `Kernel#exit`, …); resolve the blocking-main-loop/emscripten
+  mismatch (Asyncify or a driver that pumps one `Scene#main` iteration per
+  frame); and read graphics/audio out of the encrypted archive (still loose-file
+  only). `mruby-eval` also enlarges every build that includes the RPG-maker gem
+  set, including the constrained embedded targets. Once the library is complete
+  enough to boot the test bed natively, the host becomes the default and the ADR
+  0010 reimplementation stays as the fallback for projects that ship no scripts.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -1,0 +1,89 @@
+# RGSS API gap for the script host
+
+The [RGSS script host](adr/0017-rpgxp-rgss-script-host.md) runs an RPG Maker XP
+project's own `Data/Scripts.rxdata` unmodified. The scripts assume the engine
+(normally `RGSS104E.dll`) supplies the RGSS class library; this project supplies
+it as `mruby-rgss`. This document tracks **what the stock scripts call** versus
+**what `mruby-rgss` provides**, so the host can be turned on by default once the
+gaps close.
+
+The "needed" column is derived from the real `data/OpenGame.exe/Testbed/XP`
+scripts (all 90 sections), by counting method/`.new`/constant usage — see the
+analysis approach in `scripts/rpgxp_script_host_check.rb`. Frequencies are
+approximate call counts across the bundle.
+
+## Already provided ✅
+
+These are complete enough for the stock scripts:
+
+- **Value types** — `Table`, `Color`, `Tone`, `Rect` (native, with RGSS Marshal).
+- **`Bitmap`** — `new`, `draw_text` (~96), `fill_rect`, `blt`, `stretch_blt`,
+  `clear` (~33), `text_size`, `get_pixel`/`set_pixel`, `rect`, `width`/`height`,
+  `font`, `dispose`. _Missing: `gradient_fill_rect`, `hue_change`._
+- **`Font`** — instance `name`/`size`/`bold`/`italic`/`shadow`/`outline`/`color`/
+  `out_color`, class defaults (`default_name`/`default_size`/…), `exist?`.
+- **`Graphics`** — `frame_count`, `frame_rate`, `update`. _`freeze`,
+  `transition`, `frame_reset` exist but are `warn_stub` no-ops: the game runs but
+  the fade/transition is not drawn._
+- **`Input`** — all key constants (`A`/`B`/`C`/`X`/`Y`/`Z`/`L`/`R`/`UP`…`F9`),
+  `update`, `press?`, `trigger?` (~68), `repeat?` (~34), `press`/`release`,
+  `dir4`/`dir8`.
+- **`Audio`** — `bgm/bgs/me/se` `play`/`stop`/`fade` (+ `bgm_pos`/`bgs_pos`), all
+  used and resolved through `GAME_DIR`/`RTP_DIR`.
+- **`Viewport`** — `new` (~7), `ox`/`oy`, `rect`, `z`, `visible`, `update`,
+  `dispose`.
+- **Kernel** — `load_data` (~27) and `save_data` are supplied by the script host
+  (`Object#load_data`/`#save_data` → the project database); `rand` (~36) is core.
+
+## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
+
+### 1. `Sprite` extended properties ⚠️ (high frequency, medium effort)
+
+`mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,
+`visible`/`visible=`, `dispose`, `update`. The stock scripts additionally set:
+
+- `opacity` (~18), `ox`/`oy` (sprite scroll origin), `zoom_x`/`zoom_y` (~3 each),
+  `angle`, `mirror`, `tone`, `color`, `blend_type`, `bush_depth` (~2),
+  `src_rect`, `flash`.
+
+Most are attribute storage the native renderer already has fields for or can
+composite cheaply (opacity/tone/mirror). `Sprite_Character`, `Sprite_Battler`,
+`Arrow_Base`, weather and the animation player all depend on these.
+
+### 2. `Window` ❌ (the big one for menus & messages)
+
+`class Window` is empty. Every `Window_Base` subclass (`Window_Message`,
+`Window_Command`, `Window_Selectable`, the whole menu/shop/battle UI) needs:
+`windowskin`, `contents` (a `Bitmap`), `cursor_rect`, `x`/`y`/`width`/`height`,
+`ox`/`oy`, `opacity`/`back_opacity`/`contents_opacity`, `visible`, `z`, `active`,
+`pause`, `update`, `dispose`. This is a real native widget (frame from the
+windowskin, cursor blink, pause arrow, contents blit).
+
+### 3. `Tilemap` ❌ (the big one for maps)
+
+`class Tilemap` is empty. `Spriteset_Map` needs: `tileset`, `autotiles` (array),
+`map_data` (a `Table`), `flash_data`, `priorities`, `ox`/`oy`, `viewport`,
+`update`, `dispose`, with the autotile assembly + priority layering the RPG2000
+side already implements in `Game::ChipsetLayout` (portable reference).
+
+### 4. `Plane` ❌ (parallax / weather)
+
+`class Plane` is empty. Needs `bitmap`, `ox`/`oy`, `opacity`, `visible`, `z`,
+`zoom_x`/`zoom_y`, `blend_type`, `dispose` — a tiling, scrolling full-viewport
+blit. Used for the map parallax and fog.
+
+### 5. `Kernel#sprintf` / `String#%` ❌ (small but pervasive)
+
+Scripts use `sprintf` (~9, e.g. `sprintf("%02d", n)` for clock/number display).
+This mruby build does not bundle `sprintf`/`format` (see the note in
+`mruby-rpgxp/mrblib/rgss_data.rb`). Either add the `mruby-sprintf` gem or provide
+a minimal formatter. `exit` (1 use, from `Interpreter`) is also assumed.
+
+## Notes
+
+- Turning the host on by default also requires reconciling the scripts' blocking
+  `$scene.main while $scene` loop with the emscripten frame loop (Asyncify or a
+  per-frame `Scene#main` driver) — see ADR 0017.
+- None of the above can be built or run in the current CI sandbox; each item is
+  verified by `mruby-rgss/test` (compiled and run in CI) plus the host-side
+  `scripts/rpgxp_script_host_check.rb`.

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -87,6 +87,30 @@ mrb_value to_nfd(mrb_state* M, mrb_value self) {
   return mrb_str_new(M, nfd.data(), nfd.size());
 }
 
+// Inflate a zlib stream and return the decompressed bytes as a String. RGSS
+// stores each Data/Scripts.rxdata section (and .xyz graphics) as a standard
+// zlib stream (header byte 0x78); the RGSS script host (mruby-rpgxp) needs to
+// decompress those sections before it can eval them. Reuses stb_image's zlib
+// decoder -- already linked for PNG/XYZ loading -- so no extra dependency is
+// pulled in. Falls back to a raw (headerless) DEFLATE decode the way load_xyz
+// does, and raises RGSS::RGSSError when the stream cannot be inflated.
+mrb_value zlib_inflate(mrb_state* M, mrb_value self) {
+  const char* ptr;
+  mrb_int len;
+  mrb_get_args(M, "s", &ptr, &len);
+  int outlen = 0;
+  char* raw = stbi_zlib_decode_malloc(ptr, (int)len, &outlen);
+  if (!raw)
+    raw = stbi_zlib_decode_noheader_malloc(ptr, (int)len, &outlen);
+  if (!raw)
+    mrb_raisef(M,
+               mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "RGSSError"),
+               "zlib inflate failed: %s", stbi_failure_reason());
+  mrb_value out = mrb_str_new(M, raw, outlen < 0 ? 0 : outlen);
+  stbi_image_free(raw);
+  return out;
+}
+
 using V = ::mrb_value;
 
 double clamp255(double v) {
@@ -2329,6 +2353,8 @@ static mrb_value mouse_pressed_m(mrb_state* M, mrb_value) {
 extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   RClass* m = mrb_define_module(M, "RGSS");
   mrb_define_module_function(M, m, "to_nfd", to_nfd, MRB_ARGS_REQ(1));
+  mrb_define_module_function(M, m, "zlib_inflate", zlib_inflate,
+                             MRB_ARGS_REQ(1));
   mrb_define_module_function(M, m, "mouse_x", mouse_x_m, MRB_ARGS_NONE());
   mrb_define_module_function(M, m, "mouse_y", mouse_y_m, MRB_ARGS_NONE());
   mrb_define_module_function(M, m, "mouse_pressed?", mouse_pressed_m,

--- a/mruby-rpgxp/mrbgem.rake
+++ b/mruby-rpgxp/mrbgem.rake
@@ -7,12 +7,15 @@ MRuby::Gem::Specification.new('mruby-rpgxp') do |spec|
   add_dependency 'mruby-io'
   # RGSSAD archive decoding assembles decrypted bytes with Array#pack("C*").
   add_dependency 'mruby-pack'
+  # The RGSS script host (script_host.rb) runs the game's bundled Ruby scripts
+  # with Kernel#eval.
+  add_dependency 'mruby-eval'
 
   # Load order matters: lib.rb defines the RPGXP class and its WIDTH/HEIGHT/TILE
   # constants (and pulls RGSS into Object), which the scene/game sources read at
   # class-body evaluation time. Set the order explicitly rather than relying on
   # the default alphabetical glob.
-  spec.rbfiles = %w[lib rgss_data rgssad game interpreter scene].map do |name|
+  spec.rbfiles = %w[lib rgss_data script_host rgssad game interpreter scene].map do |name|
     "#{dir}/mrblib/#{name}.rb"
   end
 end

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -37,7 +37,11 @@ class RPGXP
     @title = read_ini_title
     @db = RGSSData.new(GAME_DIR)
     @scenes = []
-    push Scene::Title.new(self)
+    # When the script host is enabled and the project ships its scripts, the
+    # game's own Ruby drives everything (see script_host.rb); skip building the
+    # built-in title scene, which #start would otherwise run instead.
+    @use_script_host = ScriptHost.enabled? && @db.scripts?
+    push Scene::Title.new(self) unless @use_script_host
   end
 
   attr_reader :db, :title
@@ -118,11 +122,30 @@ class RPGXP
   end
 
   def start
+    return if run_script_host
+    # The built-in flow needs a scene. When the script host was enabled the
+    # title was not built up front, so a fallback here (host returned false or
+    # failed) guarantees one before the loop reads @scenes.last.
+    push Scene::Title.new(self) if @scenes.empty?
     loop { main_loop }
   rescue RGSS::Timeout
   end
 
   private
+
+  # Run the project's bundled RGSS scripts, which own their whole main loop, and
+  # report whether they ran. Any failure to boot the scripts is logged and falls
+  # back to the built-in flow rather than crashing to a blank screen.
+  def run_script_host
+    return false unless @use_script_host
+    ScriptHost.run(@db)
+  rescue RGSS::Timeout
+    true
+  rescue StandardError => e
+    $stderr.puts "[RGSS] script host failed (#{e.class}: #{e.message}); " \
+                 "falling back to the built-in flow"
+    false
+  end
 
   # The window title from Game.ini's [Game] Title=, falling back to the folder
   # name. Parsed with core string operations only (no regexp/String ext), since

--- a/mruby-rpgxp/mrblib/rgss_data.rb
+++ b/mruby-rpgxp/mrblib/rgss_data.rb
@@ -276,6 +276,49 @@ class RPGXP
       !@archive.nil?
     end
 
+    # Read + Marshal-parse an arbitrary project-relative file, exactly like
+    # RGSS's Kernel#load_data ("Data/System.rxdata", "Data/Scripts.rxdata", a
+    # "Save1.rxdata" in the game root, ...). A loose file on disk shadows the
+    # archive, matching RGSS; when there is none the entry is pulled from the
+    # encrypted archive. The RGSS script host uses this to feed Kernel#load_data.
+    def read_object(relative_path)
+      full = "#{@game_dir}/#{relative_path}"
+      return File.open(full, "rb") { |f| Marshal.load(f.read) } if File.exist?(full)
+      if @archive
+        bytes = @archive.read(relative_path)
+        return Marshal.load(bytes) if bytes
+      end
+      raise "cannot load #{relative_path}: no loose file and no archive entry"
+    end
+
+    # Marshal-dump `obj` to a project-relative file (RGSS's Kernel#save_data).
+    # Always writes a loose file under the game directory — RGSS never writes
+    # back into the encrypted archive — so in-game saving works on a packed
+    # project too.
+    def save_object(obj, relative_path)
+      File.open("#{@game_dir}/#{relative_path}", "wb") { |f| f.write(Marshal.dump(obj)) }
+    end
+
+    # Whether the project ships a script bundle (loose Data/Scripts.rxdata or the
+    # archive entry). Cheap presence check — does not decode the scripts.
+    def scripts?
+      File.exist?(data_path("Scripts")) ||
+        (!@archive.nil? && @archive.include?("Data/Scripts.rxdata"))
+    end
+
+    # The bundled RGSS scripts as an ordered array of [name, source]: the editor
+    # stores Data/Scripts.rxdata as a Marshal array of [id, name, zlib-deflated
+    # source] sections, evaluated top to bottom (the final "Main" section drives
+    # the game). Each section is inflated through the native RGSS.zlib_inflate.
+    # Empty when the project ships no scripts.
+    def scripts
+      return [] unless scripts?
+      read_object("Data/Scripts.rxdata").map do |section|
+        _id, name, deflated = section
+        [name.to_s, RGSS.zlib_inflate(deflated.to_s)]
+      end
+    end
+
     private
 
     # Open the game's encrypted archive (Game.rgssad / .rgss2a) if it exists, so
@@ -290,17 +333,11 @@ class RPGXP
       nil
     end
 
-    # Load and Marshal-parse a Data/ entry. A loose file on disk shadows the
-    # archive (matching RGSS, which reads loose files before the archive); when
-    # there is none, the entry is pulled from Game.rgssad.
+    # Load and Marshal-parse a Data/ entry by base name (System, MapInfos,
+    # Map001, ...). Delegates to the public read_object, which reads a loose file
+    # before the archive, matching RGSS.
     def load_data(base)
-      path = data_path(base)
-      return File.open(path, "rb") { |f| Marshal.load(f.read) } if File.exist?(path)
-      if @archive
-        bytes = @archive.read("Data/#{base}.rxdata")
-        return Marshal.load(bytes) if bytes
-      end
-      raise "cannot load #{base}.rxdata: no loose file and no archive entry"
+      read_object("Data/#{base}.rxdata")
     end
   end
 end

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -29,9 +29,13 @@ class RPGXP
     ENABLED_ENV = "RGSS_SCRIPT_HOST".freeze
 
     # Whether the runtime can eval Ruby source at all (mruby-eval present, or
-    # CRuby). Kernel#eval is public in mruby-eval and private in CRuby.
+    # CRuby). Kernel#eval is a public method under mruby-eval and a private one
+    # under CRuby; the private check is itself CRuby-only (mruby's Module has no
+    # private_method_defined?), so guard it with respond_to?.
     def self.available?
-      Kernel.method_defined?(:eval) || Kernel.private_method_defined?(:eval)
+      return true if Kernel.method_defined?(:eval)
+      Kernel.respond_to?(:private_method_defined?) &&
+        Kernel.private_method_defined?(:eval)
     end
 
     # Whether to run the bundled scripts instead of the built-in flow. Requires
@@ -74,20 +78,30 @@ class RPGXP
       true
     end
 
-    # Provide the Kernel methods the scripts assume the player supplies:
-    #   load_data(filename)      -> Marshal.load of a project file
-    #   save_data(obj, filename) -> Marshal.dump of a project file
-    # routed through the database so a loose file and the encrypted archive both
-    # work. Defined on Object so a script can call them bare; guarded so a second
-    # boot does not redefine them.
-    def self.install_kernel(db)
-      return if Object.method_defined?(:load_data) ||
-                Object.private_method_defined?(:load_data)
-      Object.class_eval do
-        define_method(:load_data) { |filename| db.read_object(filename) }
-        define_method(:save_data) { |obj, filename| db.save_object(obj, filename) }
-        private :load_data, :save_data
-      end
+    # The database the Kernel built-ins (Object#load_data / #save_data, defined
+    # below) read and write through. Point it at the running project's database.
+    def self.db
+      @db
     end
+
+    def self.install_kernel(db)
+      @db = db
+    end
+  end
+end
+
+# RGSS scripts call load_data / save_data as global Kernel methods that the
+# player (RGSS104E.dll) supplies. Define them on Object — the way lib.rb already
+# reopens Object for the RGSS value-type names — routed through the script host's
+# current database so a loose file and the encrypted archive both resolve. Plain
+# method bodies (no runtime class_eval / define_method) so the build needs no
+# metaprogramming helpers; they no-op safely until the host sets ScriptHost.db.
+class Object
+  def load_data(filename)
+    RPGXP::ScriptHost.db.read_object(filename)
+  end
+
+  def save_data(obj, filename)
+    RPGXP::ScriptHost.db.save_object(obj, filename)
   end
 end

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -38,16 +38,15 @@ class RPGXP
         Kernel.private_method_defined?(:eval)
     end
 
-    # Whether to run the bundled scripts instead of the built-in flow. Requires
-    # eval support and an explicit opt-in: the env var when the runtime exposes
-    # ENV, otherwise the ENABLED constant (default false).
+    # Whether to run the bundled scripts instead of the built-in flow: requires
+    # eval support and an explicit opt-in via the RGSS_SCRIPT_HOST env var (when
+    # the runtime exposes ENV). Off by default. Uses const_defined? rather than
+    # defined?(CONST), which raises on an undefined constant in this mruby build.
     def self.enabled?
       return false unless available?
-      if defined?(ENV) && ENV.respond_to?(:[]) && !ENV[ENABLED_ENV].nil?
-        flag = ENV[ENABLED_ENV]
-        return !(flag.empty? || flag == "0" || flag == "false")
-      end
-      defined?(ENABLED) ? ENABLED : false
+      return false unless Object.const_defined?(:ENV)
+      flag = ENV[ENABLED_ENV]
+      !(flag.nil? || flag.empty? || flag == "0" || flag == "false")
     end
 
     # Run the project's bundled scripts to completion. `db` answers #scripts
@@ -68,7 +67,11 @@ class RPGXP
       # some scripts read it (e.g. to hot-reload). Mirror that shape.
       idx = -1
       $RGSS_SCRIPTS = sections.map { |name, source| [idx += 1, name, source] }
-      top = defined?(TOPLEVEL_BINDING) ? TOPLEVEL_BINDING : nil
+      # CRuby needs the top-level binding so class defs become global constants;
+      # mruby has no TOPLEVEL_BINDING and evaluates a nil-binding eval at the top
+      # level already. const_defined? avoids defined?(CONST), which raises on an
+      # undefined constant here. (The TOPLEVEL_BINDING branch never runs on mruby.)
+      top = Object.const_defined?(:TOPLEVEL_BINDING) ? TOPLEVEL_BINDING : nil
       sections.each do |name, source|
         # eval(str, binding, file, line): the section name becomes the "file" in
         # any backtrace, and top-level class/module definitions land on Object —

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -1,0 +1,92 @@
+# RGSS script host — the "run the bundled scripts" path.
+#
+# An RPG Maker XP project ships its whole engine (title, map, event interpreter,
+# menus, battle, …) as ~90 Ruby scripts inside Data/Scripts.rxdata. The native
+# player, RGSS104E.dll, boots a game simply by evaluating those sections in order
+# at the top level: the value types, Graphics/Input/Audio and the RPG data
+# classes are provided by the DLL, and the final "Main" section runs the game
+# loop (`$scene.main while $scene != nil`).
+#
+# This module is the mruby equivalent of that: given the project database it
+# exposes the handful of Kernel built-ins the scripts expect the engine to
+# supply (load_data / save_data / $RGSS_SCRIPTS), then evals each decompressed
+# section against the top level using its editor name — so the game's own logic
+# runs unmodified, rather than the reimplemented default flow in game.rb/scene.rb.
+#
+# It is the alternative to that reimplementation (see
+# docs/adr/0017-rpgxp-rgss-script-host.md). Because the scripts drive their own
+# blocking main loop and lean on the full RGSS class library, the host is an
+# opt-in path for now (RPGXP::ScriptHost.enabled?), with the built-in flow as the
+# default and the fallback. Requires mruby-eval for Kernel#eval.
+class RPGXP
+  module ScriptHost
+    module_function
+
+    # Environment variable / constant that turns the script host on. Off by
+    # default: the built-in flow is the verified path, and running the bundled
+    # scripts needs both eval and a complete-enough RGSS class library.
+    ENABLED_ENV = "RGSS_SCRIPT_HOST".freeze
+
+    # Whether the runtime can eval Ruby source at all (mruby-eval present, or
+    # CRuby). Kernel#eval is public in mruby-eval and private in CRuby.
+    def available?
+      Kernel.method_defined?(:eval) || Kernel.private_method_defined?(:eval)
+    end
+
+    # Whether to run the bundled scripts instead of the built-in flow. Requires
+    # eval support and an explicit opt-in: the env var when the runtime exposes
+    # ENV, otherwise the ENABLED constant (default false).
+    def enabled?
+      return false unless available?
+      if defined?(ENV) && ENV.respond_to?(:[]) && !ENV[ENABLED_ENV].nil?
+        flag = ENV[ENABLED_ENV]
+        return !(flag.empty? || flag == "0" || flag == "false")
+      end
+      defined?(ENABLED) ? ENABLED : false
+    end
+
+    # Run the project's bundled scripts to completion. `db` answers #scripts
+    # (an ordered array of [name, source]) and #read_object / #save_object for
+    # the Kernel built-ins. Returns true when the scripts were run, false when
+    # there was nothing to run (no scripts, or no eval) so the caller can fall
+    # back to the built-in flow. Evaluating "Main" blocks here until the game's
+    # own loop exits, exactly as RGSS does.
+    def run(db)
+      return false unless available?
+      sections = db.scripts
+      if sections.empty?
+        $stderr.puts "[RGSS] script host: project ships no scripts; using built-in flow"
+        return false
+      end
+      install_kernel(db)
+      # RGSS exposes the loaded sections as $RGSS_SCRIPTS ([id, name, source]);
+      # some scripts read it (e.g. to hot-reload). Mirror that shape.
+      idx = -1
+      $RGSS_SCRIPTS = sections.map { |name, source| [idx += 1, name, source] }
+      top = defined?(TOPLEVEL_BINDING) ? TOPLEVEL_BINDING : nil
+      sections.each do |name, source|
+        # eval(str, binding, file, line): the section name becomes the "file" in
+        # any backtrace, and top-level class/module definitions land on Object —
+        # so `class Scene_Title` etc. define global constants, as under RGSS.
+        eval(source, top, name, 1)
+      end
+      true
+    end
+
+    # Provide the Kernel methods the scripts assume the player supplies:
+    #   load_data(filename)      -> Marshal.load of a project file
+    #   save_data(obj, filename) -> Marshal.dump of a project file
+    # routed through the database so a loose file and the encrypted archive both
+    # work. Defined on Object so a script can call them bare; guarded so a second
+    # boot does not redefine them.
+    def install_kernel(db)
+      return if Object.method_defined?(:load_data) ||
+                Object.private_method_defined?(:load_data)
+      Object.class_eval do
+        define_method(:load_data) { |filename| db.read_object(filename) }
+        define_method(:save_data) { |obj, filename| db.save_object(obj, filename) }
+        private :load_data, :save_data
+      end
+    end
+  end
+end

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -19,9 +19,10 @@
 # opt-in path for now (RPGXP::ScriptHost.enabled?), with the built-in flow as the
 # default and the fallback. Requires mruby-eval for Kernel#eval.
 class RPGXP
+  # Defined with explicit `def self.` singleton methods (not a bare
+  # `module_function`, which this mruby build does not apply to later defs) so
+  # the host is callable as RPGXP::ScriptHost.<method>.
   module ScriptHost
-    module_function
-
     # Environment variable / constant that turns the script host on. Off by
     # default: the built-in flow is the verified path, and running the bundled
     # scripts needs both eval and a complete-enough RGSS class library.
@@ -29,14 +30,14 @@ class RPGXP
 
     # Whether the runtime can eval Ruby source at all (mruby-eval present, or
     # CRuby). Kernel#eval is public in mruby-eval and private in CRuby.
-    def available?
+    def self.available?
       Kernel.method_defined?(:eval) || Kernel.private_method_defined?(:eval)
     end
 
     # Whether to run the bundled scripts instead of the built-in flow. Requires
     # eval support and an explicit opt-in: the env var when the runtime exposes
     # ENV, otherwise the ENABLED constant (default false).
-    def enabled?
+    def self.enabled?
       return false unless available?
       if defined?(ENV) && ENV.respond_to?(:[]) && !ENV[ENABLED_ENV].nil?
         flag = ENV[ENABLED_ENV]
@@ -51,7 +52,7 @@ class RPGXP
     # there was nothing to run (no scripts, or no eval) so the caller can fall
     # back to the built-in flow. Evaluating "Main" blocks here until the game's
     # own loop exits, exactly as RGSS does.
-    def run(db)
+    def self.run(db)
       return false unless available?
       sections = db.scripts
       if sections.empty?
@@ -79,7 +80,7 @@ class RPGXP
     # routed through the database so a loose file and the encrypted archive both
     # work. Defined on Object so a script can call them bare; guarded so a second
     # boot does not redefine them.
-    def install_kernel(db)
+    def self.install_kernel(db)
       return if Object.method_defined?(:load_data) ||
                 Object.private_method_defined?(:load_data)
       Object.class_eval do

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -67,16 +67,10 @@ class RPGXP
       # some scripts read it (e.g. to hot-reload). Mirror that shape.
       idx = -1
       $RGSS_SCRIPTS = sections.map { |name, source| [idx += 1, name, source] }
-      # CRuby needs the top-level binding so class defs become global constants;
-      # mruby has no TOPLEVEL_BINDING and evaluates a nil-binding eval at the top
-      # level already. const_defined? avoids defined?(CONST), which raises on an
-      # undefined constant here. (The TOPLEVEL_BINDING branch never runs on mruby.)
-      top = Object.const_defined?(:TOPLEVEL_BINDING) ? TOPLEVEL_BINDING : nil
       sections.each do |name, source|
-        # eval(str, binding, file, line): the section name becomes the "file" in
-        # any backtrace, and top-level class/module definitions land on Object —
-        # so `class Scene_Title` etc. define global constants, as under RGSS.
-        eval(source, top, name, 1)
+        # Evaluate through the top-level helper so a section's `class Scene_Title`
+        # etc. define global (::) constants, as under RGSS — see rgss_eval_section.
+        rgss_eval_section(source, name)
       end
       true
     end
@@ -107,4 +101,19 @@ class Object
   def save_data(obj, filename)
     RPGXP::ScriptHost.db.save_object(obj, filename)
   end
+end
+
+# Evaluate one RGSS script section. Defined at the TOP LEVEL (not inside
+# RPGXP::ScriptHost) on purpose: mruby resolves `class Foo` in eval'd code
+# against the *lexical* scope of the method that calls eval, so evaluating from
+# inside a module would define the section's classes under that module. Called
+# from here, the lexical scope is Object, so `class Scene_Title` etc. become
+# global (::) constants — matching how RGSS evaluates the scripts at top level.
+# CRuby is handled the same way via TOPLEVEL_BINDING when present (mruby has no
+# such constant and a nil-binding eval here already targets the top level);
+# const_defined? avoids defined?(CONST), which raises on an unknown constant in
+# this mruby build. The section name becomes the "file" in any backtrace.
+def rgss_eval_section(source, name)
+  top = Object.const_defined?(:TOPLEVEL_BINDING) ? TOPLEVEL_BINDING : nil
+  eval(source, top, name, 1)
 end

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -882,3 +882,59 @@ assert "Game::Message.expand accepts a Proc name lookup" do
   lookup = ->(id) { id == 1 ? "Hero" : nil }
   assert_equal "Hero speaks", RPGXP::Game::Message.expand("\\N[1] speaks", vars, lookup)
 end
+
+# ---- RGSS script host -------------------------------------------------------
+
+# Fake project DB for the script host: serves pre-decoded [name, source]
+# sections and answers the Kernel built-ins load_data / save_data out of an
+# in-memory store, so a save round-trips through the same instance.
+class FakeScriptDB
+  def initialize(sections)
+    @sections = sections
+    @store = {}
+  end
+
+  def scripts?; !@sections.empty?; end
+  def scripts;  @sections; end
+  def read_object(path); @store[path]; end
+  def save_object(obj, path); @store[path] = obj; end
+end
+
+assert "ScriptHost.available? is true (eval present)" do
+  assert_true RPGXP::ScriptHost.available?
+end
+
+assert "ScriptHost.run evaluates sections in order and sets $RGSS_SCRIPTS" do
+  db = FakeScriptDB.new([
+    ["Setup", "$rgss_host_probe = 41"],
+    ["Main", "$rgss_host_probe += 1"]
+  ])
+  assert_true RPGXP::ScriptHost.run(db)
+  assert_equal 42, $rgss_host_probe
+  # $RGSS_SCRIPTS mirrors RGSS's [id, name, source] triples in load order.
+  assert_equal 2, $RGSS_SCRIPTS.size
+  assert_equal 0, $RGSS_SCRIPTS[0][0]
+  assert_equal "Setup", $RGSS_SCRIPTS[0][1]
+  assert_equal "Main", $RGSS_SCRIPTS[1][1]
+end
+
+assert "ScriptHost.run defines classes at the top level" do
+  db = FakeScriptDB.new([["Def", "class RgssHostProbe; def hi; 7; end; end"]])
+  assert_true RPGXP::ScriptHost.run(db)
+  assert_true Object.const_defined?(:RgssHostProbe)
+  assert_equal 7, RgssHostProbe.new.hi
+end
+
+assert "ScriptHost.run returns false when the project ships no scripts" do
+  assert_false RPGXP::ScriptHost.run(FakeScriptDB.new([]))
+end
+
+assert "ScriptHost.install_kernel wires load_data / save_data round-trip" do
+  db = FakeScriptDB.new([["x", "0"]])
+  RPGXP::ScriptHost.install_kernel(db)
+  # The built-ins are private Kernel methods (RGSS scripts call them bare);
+  # save then load of a fresh path round-trips through the bound database.
+  probe = Object.new
+  probe.send(:save_data, { "hp" => 30 }, "ScriptHostProbe.rxdata")
+  assert_equal({ "hp" => 30 }, probe.send(:load_data, "ScriptHostProbe.rxdata"))
+end

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -153,6 +153,26 @@ class Checker
   end
 end
 
+# Project-independent: ScriptHost.run must eval a section so its class defines a
+# GLOBAL (::) constant, the way RGSS evaluates scripts at top level. Mirrors the
+# mruby test; catches a regression in rgss_eval_section's top-level scoping.
+def check_run_defines_top_level
+  tiny = Object.new
+  def tiny.scripts; [["Probe", "class RgssHostCheckProbe; def v; 5; end; end"]]; end
+  def tiny.read_object(*); end
+  def tiny.save_object(*); end
+  unless RPGXP::ScriptHost.run(tiny)
+    warn "  FAIL ScriptHost.run returned false for a one-section project"
+    return 1
+  end
+  unless Object.const_defined?(:RgssHostCheckProbe) && RgssHostCheckProbe.new.v == 5
+    warn "  FAIL ScriptHost.run did not define the section's class at the top level"
+    return 1
+  end
+  puts "  ScriptHost.run defines section classes at the top level"
+  0
+end
+
 def discover_games(root)
   return [] unless Dir.exist?(root)
   Dir.glob(File.join(root, "**", "Data", "Scripts.rxdata"))
@@ -169,5 +189,10 @@ end
 
 checker = Checker.new
 games.each { |g| checker.check_game(g) }
-checker.report
-exit(checker.errors.zero? ? 0 : 1)
+errors = checker.errors + check_run_defines_top_level
+if errors.zero?
+  puts "OK: XP script host decodes, installs built-ins and evaluates real scripts"
+else
+  warn "#{errors} error(s)"
+end
+exit(errors.zero? ? 0 : 1)

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -1,0 +1,173 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Feasibility + smoke check for the RPG Maker XP *script host* (the "run the
+# bundled RGSS scripts" path, ADR 0017), driven against a real test-bed project.
+#
+# The native runtime boots an XP game by evaluating the ~90 Ruby sections in
+# Data/Scripts.rxdata in order (see mruby-rpgxp/mrblib/script_host.rb). The
+# host plumbing — decoding/inflating the sections, installing the Kernel
+# load_data/save_data built-ins, and evaluating each section at the top level so
+# its classes become global — is written in the mruby/CRuby common subset, so
+# this harness loads the exact sources under CRuby and exercises them end to end
+# against genuine editor output, the way scripts/rpgxp_testbed_check.rb guards
+# the data layer.
+#
+# It does NOT run the "Main" section (that would start the game's blocking main
+# loop and needs the full RGSS graphics/audio library); it evaluates a load-safe
+# logic subset to prove real script source decodes, inflates and evaluates into
+# top-level classes with their real methods.
+#
+# Usage:
+#   ruby scripts/rpgxp_script_host_check.rb [GAME_DIR ...]
+# With no arguments it scans ./data for directories with Data/Scripts.rxdata.
+# Exits non-zero if any invariant is violated.
+
+require "zlib"
+
+# --- RGSS value-type + native shims (native classes in the real build) ------
+
+class Table; def self._load(s); allocate; end; end
+class Color; def self._load(s); allocate; end; end
+class Tone;  def self._load(s); allocate; end; end
+class Rect;  def self._load(s); allocate; end; end
+
+# RGSS.zlib_inflate is a native module function in the real build (mruby-rgss,
+# via stb_image's zlib decoder). Provide the CRuby equivalent so the shared
+# RGSSData#scripts decoder runs here unchanged.
+module RGSS
+  def self.zlib_inflate(bytes)
+    Zlib::Inflate.inflate(bytes)
+  end
+end
+
+# --- Load the real sources --------------------------------------------------
+
+mrblib = File.expand_path("../mruby-rpgxp/mrblib", __dir__)
+load File.join(mrblib, "rgss_data.rb")
+load File.join(mrblib, "rgssad.rb")
+load File.join(mrblib, "script_host.rb")
+
+# Native RGSS base classes the default scripts subclass at load time.
+%w[Sprite Plane Window Tilemap Viewport Bitmap].each do |c|
+  Object.const_set(c, Class.new) unless Object.const_defined?(c)
+end
+module RPG
+  class Sprite < ::Sprite; end unless const_defined?(:Sprite)
+  class Weather; end unless const_defined?(:Weather)
+end
+
+class Checker
+  # Sections that are pure game logic — safe to evaluate with no running engine.
+  LOGIC_SECTIONS = [
+    "Game_Switches", "Game_Variables", "Game_SelfSwitches", "Game_System",
+    "Interpreter 1", "Interpreter 2", "Interpreter 3",
+    "Interpreter 4", "Interpreter 5", "Interpreter 6", "Interpreter 7"
+  ].freeze
+
+  def initialize
+    @errors = 0
+  end
+
+  attr_reader :errors
+
+  def fail(msg)
+    @errors += 1
+    warn "  FAIL #{msg}"
+  end
+
+  def expect(cond, msg)
+    fail(msg) unless cond
+  end
+
+  def check_game(dir)
+    puts "== #{dir} =="
+    db = RPGXP::RGSSData.new(dir)
+
+    expect(db.scripts?, "project reports no script bundle")
+    sections = db.scripts
+    expect(sections.is_a?(Array) && !sections.empty?, "no script sections decoded")
+    sections.each do |name, source|
+      expect(name.is_a?(String), "section name is #{name.class}, not String")
+      expect(source.is_a?(String) && !source.empty?,
+             "section #{name.inspect} inflated to empty/non-String")
+    end
+    puts "  decoded #{sections.size} script sections (e.g. #{sections.first[0].inspect})"
+
+    check_eval_available
+    check_kernel_builtins(db)
+    check_eval_subset(sections)
+  rescue => ex
+    fail "#{dir}: #{ex.class}: #{ex.message}"
+  end
+
+  def check_eval_available
+    expect(RPGXP::ScriptHost.available?, "ScriptHost.available? is false (no eval)")
+  end
+
+  # install_kernel wires load_data/save_data through the database, so a script's
+  # `load_data("Data/System.rxdata")` round-trips to the real RPG::System.
+  def check_kernel_builtins(db)
+    RPGXP::ScriptHost.install_kernel(db)
+    obj = Object.new
+    sys = obj.send(:load_data, "Data/System.rxdata")
+    expect(sys.is_a?(RPG::System), "load_data did not return an RPG::System")
+    expect(sys.start_map_id.to_i > 0, "load_data System.start_map_id not positive")
+    puts "  Kernel#load_data returns RPG::System (start_map_id=#{sys.start_map_id})"
+  end
+
+  # Evaluate the logic subset the way the host does and confirm the real classes
+  # and event-command methods land at the top level.
+  def check_eval_subset(sections)
+    top = TOPLEVEL_BINDING
+    evaled = 0
+    sections.each do |name, source|
+      next unless LOGIC_SECTIONS.include?(name)
+      begin
+        eval(source, top, name, 1)
+        evaled += 1
+      rescue SyntaxError, StandardError => e
+        fail "eval #{name.inspect}: #{e.class}: #{e.message}"
+      end
+    end
+    expect(evaled == LOGIC_SECTIONS.size,
+           "evaluated #{evaled}/#{LOGIC_SECTIONS.size} logic sections")
+    expect(Object.const_defined?(:Interpreter), "Interpreter class not defined")
+    expect(Object.const_defined?(:Game_System), "Game_System class not defined")
+    if Object.const_defined?(:Interpreter)
+      methods = Interpreter.instance_methods(false)
+      expect(methods.include?(:command_301),
+             "Interpreter#command_301 (Battle Processing) missing")
+      expect(methods.include?(:command_121),
+             "Interpreter#command_121 (Control Switches) missing")
+    end
+    puts "  evaluated #{evaled} logic sections; Interpreter/Game_System defined with real commands"
+  end
+
+  def report
+    if @errors.zero?
+      puts "OK: XP script host decodes, installs built-ins and evaluates real scripts"
+    else
+      warn "#{@errors} error(s)"
+    end
+  end
+end
+
+def discover_games(root)
+  return [] unless Dir.exist?(root)
+  Dir.glob(File.join(root, "**", "Data", "Scripts.rxdata"))
+     .map { |f| File.dirname(File.dirname(f)) }.sort.uniq
+end
+
+games = ARGV.dup
+games = discover_games(File.expand_path("../data", __dir__)) if games.empty?
+
+if games.empty?
+  warn "no XP test-bed game found (run scripts/download-opengame-xp.bash first)"
+  exit 0
+end
+
+checker = Checker.new
+games.each { |g| checker.check_game(g) }
+checker.report
+exit(checker.errors.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary

Introduces the **"run the game's own scripts" path** for RPG Maker XP (ADR 0017) — the RGSS analogue of the MV embedded-engine choice (ADR 0004) — alongside the existing reimplemented default flow (ADR 0010).

The native player boots an XP game by evaluating the ~90 Ruby sections in `Data/Scripts.rxdata` in order at the top level, against the primitives the DLL provides. This PR adds the plumbing to do the same in mruby: decompress the sections, supply the Kernel data built-ins, and `eval` each section so the game's own engine (title, map, interpreter, battle) drives itself.

## Changes

- **`RGSS.zlib_inflate`** (native, `mruby-rgss/src/lib.cxx`) — inflate a zlib stream by reusing stb_image's zlib decoder (already linked for PNG/XYZ), so **no new dependency**. Decompresses the script sections.
- **`RPGXP::RGSSData`** — public `read_object`/`save_object` (project-relative Marshal load/dump honouring the encrypted archive — the shape RGSS's `load_data`/`save_data` need), a `scripts?` predicate and a `scripts` accessor that decodes `Data/Scripts.rxdata` (a Marshal array of `[id, name, deflated]`) into ordered `[name, source]` sections. The existing private `load_data` now delegates to `read_object`.
- **`RPGXP::ScriptHost`** (`mruby-rpgxp/mrblib/script_host.rb`) — installs the Kernel `load_data`/`save_data` built-ins and `$RGSS_SCRIPTS`, then `eval`s each section at the top level (using its editor name as the "filename") so `Main` drives the game loop. Requires the core **`mruby-eval`** gem (new `mruby-rpgxp` dependency).
- **Boot** (`mruby-rpgxp/mrblib/lib.rb`) — runs the host when it is enabled and the project ships scripts; otherwise uses the built-in flow, which is also the fallback if the host fails to boot (a fallback always guarantees a title scene before the built-in loop).

## Opt-in for now

The host is gated behind `RGSS_SCRIPT_HOST` (default **off**), for three reasons documented in ADR 0017:
1. It can't be built or run in the current CI sandbox (no SDL/mruby binary).
2. The `mruby-rgss` class library isn't complete enough yet for every method the stock scripts call.
3. The scripts' blocking `$scene.main while` loop needs Asyncify (or a per-frame driver) to cooperate with the browser/emscripten frame loop.

Keeping the built-in flow as the default lands the whole host **without regressing the verified boot**.

## Testing

Because the host plumbing is written in the mruby/CRuby common subset, it is validated the same way the rest of the XP layer is:

- **`scripts/rpgxp_script_host_check.rb`** (new, run in CI) drives the exact sources under CRuby against the real `data/OpenGame.exe/Testbed/XP` project: decodes all 90 sections, installs and round-trips the Kernel built-ins (`load_data("Data/System.rxdata")` → real `RPG::System`), and evaluates a load-safe logic subset (`Game_*`, `Interpreter 1`–`7`), confirming genuine script source decompresses, evaluates and defines its classes (`Interpreter#command_301`, `#command_121`, …) at the top level.
- **`mruby-rpgxp/test`** — new cases for `ScriptHost` (eval order + `$RGSS_SCRIPTS`, top-level class definition, empty-project false return, `load_data`/`save_data` round-trip). The test binary now includes `mruby-eval`, so these exercise the real eval path.
- Existing `scripts/rpgxp_testbed_check.rb` stays green; C++ is clang-formatted and pre-commit hooks pass.

> **Note on verifiability:** the eval host itself can't be built or run in this environment, so the native path is unverified pending a build that can run the SDL/mruby binary. Only the pure-Ruby pieces (decode, built-ins, top-level evaluation) are exercised here. ADR 0017 lists the remaining work before the host can become the default.

## Docs

- **ADR 0017** — `docs/adr/0017-rpgxp-rgss-script-host.md` (the decision, the opt-in rationale, and the follow-up work).
- `docs/TODO.md` — "Run the bundled RGSS scripts" moved from future/out-of-scope to 🚧, with the remaining work.
- `README.md` — RPG Maker XP section documents the experimental script host.
- Changelog fragment `changelog.d/rpgxp-rgss-script-host.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_