### PR TITLE
Implement Player Visibility, Return to Title, Change/Trade Event Location, and Change Map Tileset commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
   branches, teleport, waits, numeric input (Input Number), BGM/SE playback,
   Call Event (run a common event / another event's page), Move Event (force a
   move route onto an event or the player), Halt All Movement (cancel every forced
-  route) and Erase Event (remove an event from
+  route), Set Transparent Flag (hide/show the hero), Return to Title and Erase
+  Event (remove an event from
   the map). Events start on the action button, on
   player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
   branches, teleport, waits, numeric input (Input Number), BGM/SE playback,
   Call Event (run a common event / another event's page), Move Event (force a
   move route onto an event or the player), Halt All Movement (cancel every forced
-  route), Set Transparent Flag (hide/show the hero), Return to Title and Erase
+  route), Change / Trade Event Location (snap or swap event/player tiles), Set
+  Transparent Flag (hide/show the hero), Return to Title and Erase
   Event (remove an event from
   the map). Events start on the action button, on
   player touch (walking into them),

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
   branches, teleport, waits, numeric input (Input Number), BGM/SE playback,
   Call Event (run a common event / another event's page), Move Event (force a
   move route onto an event or the player), Halt All Movement (cancel every forced
-  route), Change / Trade Event Location (snap or swap event/player tiles), Set
+  route), Change / Trade Event Location (snap or swap event/player tiles), Change
+  Map Tileset (swap the map's chipset), Set
   Transparent Flag (hide/show the hero), Return to Title and Erase
   Event (remove an event from
   the map). Events start on the action button, on

--- a/changelog.d/rpg2k-change-map-tileset.added.md
+++ b/changelog.d/rpg2k-change-map-tileset.added.md
@@ -1,0 +1,8 @@
+- The **Change Map Tileset** (11710) event command is now handled: it swaps the
+  current map's chipset to the id in param0. The interpreter records the request
+  and `Scene::Map` rebuilds the chipset model and its tile graphic (disposing the
+  old bitmap), so passability, terrain and rendering all pick up the new tileset
+  at once. The override lasts until the next map load — a teleport rebuilds from
+  the destination map's own chipset. Non-blocking, like the other map-mutating
+  commands. Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/changelog.d/rpg2k-event-location-commands.added.md
+++ b/changelog.d/rpg2k-event-location-commands.added.md
@@ -1,0 +1,11 @@
+- Two more RPG2000 event commands are now handled. **Change Event Location**
+  (10860) instantly places a character on the current map at a tile — the target
+  is the player (10001), "this event" (0 / 10005) or a map event by id, and the
+  x / y come either from the command's constants or (appointment mode 1) from two
+  variables. **Trade Event Locations** (10870) swaps the tiles of two such
+  characters. Both are non-blocking: the interpreter queues the request and
+  `Scene::Map` applies it after `#update`, snapping the target (cancelling a
+  half-finished player step and keeping a forced route's mirror in sync) and
+  refreshing the occupied-tile cache so collision and the event marker follow.
+  Vehicle targets stay unmodelled. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/changelog.d/rpg2k-player-visibility-return-title.added.md
+++ b/changelog.d/rpg2k-player-visibility-return-title.added.md
@@ -1,0 +1,13 @@
+- Two more RPG2000 event commands are now handled. **Set Transparent Flag /
+  Change Player Visibility** (11310) toggles a `player_transparent` flag on
+  `Game::State`; `Scene::Map` hides or shows the party leader's map sprite each
+  frame accordingly (combined with the leader graphic's own semi-transparent
+  flag), and the flag is persisted through Save / Continue. The polarity
+  (param0 non-zero = transparent) follows EasyRPG's
+  `SetSpriteHidden(parameters[0] != 0)`. **Return to Title Screen** (12510)
+  suspends on a `:return_title` request the scene answers by stopping the event
+  and calling the app's `return_to_title`, tearing the play scenes down and
+  showing a fresh title. Player Visibility was one of the two event-command gaps
+  `docs/rpg2000-sample-analysis.md` flagged in the real sample games, leaving
+  Pan Screen (11060) as the last presentation gap there. Covered by new checks
+  in `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -113,8 +113,9 @@ The work below is roughly ordered by the critical path to a walkable game
   Message Options, Change Face Graphic, Input Number, Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
   Tint Screen, Flash Screen, Shake Screen, Call Event, Move Event, Change / Trade
-  Event Location, Proceed With Movement, Halt All Movement, Erase Event, Return
-  to Title, End Event) with a per-frame step cap so a bad loop can't hang. **Memorize Location** stores the player's current map id, x and y
+  Event Location, Change Map Tileset, Proceed With Movement, Halt All Movement,
+  Erase Event, Return to Title, End Event) with a per-frame step cap so a bad
+  loop can't hang. **Memorize Location** stores the player's current map id, x and y
   into three variables, and **Recall to Location** teleports back to a location
   held in three variables (routed through the same teleport the Teleport command
   uses). **Call Event**
@@ -135,7 +136,9 @@ The work below is roughly ordered by the critical path to a walkable game
   the party leader's map sprite (persisted in the save), and **Return to Title
   Screen** stops the event and returns the app to a fresh title. **Change Event
   Location** snaps a character (player / this event / a map event) to a tile and
-  **Trade Event Locations** swaps two of them, refreshing collision. **Erase
+  **Trade Event Locations** swaps two of them, refreshing collision. **Change Map
+  Tileset** swaps the current map's chipset and rebuilds its tile graphic (until
+  the next map load). **Erase
   Event** removes the running event from the map for the rest of the visit (its
   marker, movement, collision and any parallel process). **Change
   HP/MP**, **Full Heal**, **Change Parameters**, **Change Level** and **Change

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -111,10 +111,10 @@ The work below is roughly ordered by the critical path to a walkable game
   Loop/Break/End, Label/Jump, Timer, Teleport, Memorize/Recall Location,
   Store Terrain/Event ID, Wait, Play BGM/SE, Memorize / Play Memorized BGM,
   Message Options, Change Face Graphic, Input Number, Change Actor
-  Name / Title / Sprite, Change Main Menu / Save Access, Tint
-  Screen, Flash Screen, Shake Screen, Call Event, Move Event, Proceed With
-  Movement, Halt All Movement, Erase Event, End Event) with a per-frame step cap
-  so a bad loop can't hang. **Memorize Location** stores the player's current map id, x and y
+  Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
+  Tint Screen, Flash Screen, Shake Screen, Call Event, Move Event, Proceed With
+  Movement, Halt All Movement, Erase Event, Return to Title, End Event) with a
+  per-frame step cap so a bad loop can't hang. **Memorize Location** stores the player's current map id, x and y
   into three variables, and **Recall to Location** teleports back to a location
   held in three variables (routed through the same teleport the Teleport command
   uses). **Call Event**
@@ -131,7 +131,9 @@ The work below is roughly ordered by the critical path to a walkable game
   digit-entry widget and writes the entered value to a variable. **Change Actor
   Name / Title / Sprite** rename a party actor, set its status-screen title or
   swap its CharSet graphic (the scene reloads the leader's on-screen sprite);
-  these edits survive Save / Continue. **Erase
+  these edits survive Save / Continue. **Set Transparent Flag** hides or shows
+  the party leader's map sprite (persisted in the save), and **Return to Title
+  Screen** stops the event and returns the app to a fresh title. **Erase
   Event** removes the running event from the map for the rest of the visit (its
   marker, movement, collision and any parallel process). **Change
   HP/MP**, **Full Heal**, **Change Parameters**, **Change Level** and **Change

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -112,9 +112,9 @@ The work below is roughly ordered by the critical path to a walkable game
   Store Terrain/Event ID, Wait, Play BGM/SE, Memorize / Play Memorized BGM,
   Message Options, Change Face Graphic, Input Number, Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
-  Tint Screen, Flash Screen, Shake Screen, Call Event, Move Event, Proceed With
-  Movement, Halt All Movement, Erase Event, Return to Title, End Event) with a
-  per-frame step cap so a bad loop can't hang. **Memorize Location** stores the player's current map id, x and y
+  Tint Screen, Flash Screen, Shake Screen, Call Event, Move Event, Change / Trade
+  Event Location, Proceed With Movement, Halt All Movement, Erase Event, Return
+  to Title, End Event) with a per-frame step cap so a bad loop can't hang. **Memorize Location** stores the player's current map id, x and y
   into three variables, and **Recall to Location** teleports back to a location
   held in three variables (routed through the same teleport the Teleport command
   uses). **Call Event**
@@ -133,7 +133,9 @@ The work below is roughly ordered by the critical path to a walkable game
   swap its CharSet graphic (the scene reloads the leader's on-screen sprite);
   these edits survive Save / Continue. **Set Transparent Flag** hides or shows
   the party leader's map sprite (persisted in the save), and **Return to Title
-  Screen** stops the event and returns the app to a fresh title. **Erase
+  Screen** stops the event and returns the app to a fresh title. **Change Event
+  Location** snaps a character (player / this event / a map event) to a tile and
+  **Trade Event Locations** swaps two of them, refreshing collision. **Erase
   Event** removes the running event from the map for the rest of the visit (its
   marker, movement, collision and any parallel process). **Change
   HP/MP**, **Full Heal**, **Change Parameters**, **Change Level** and **Change

--- a/docs/rpg2000-sample-analysis.md
+++ b/docs/rpg2000-sample-analysis.md
@@ -185,7 +185,7 @@ runtime can execute virtually all of it.
    | **Battle** | EnemyEncounter (10710) | Sample2 |
    | **BGM stack** ✅ | MemorizeBGM (11530), PlayMemorizedBGM (11540) — now implemented | Sample2 |
    | **Movement sync** ✅ | ProceedWithMovement (11340) — now implemented | Sample3 |
-   | **Menu/telep. access, misc** ✅ | ChangeMainMenuAccess (11960) and MemorizeLocation (10820) now implemented; PlayerVisibility (11310) remains | Sample3 |
+   | **Menu/telep. access, misc** ✅ | ChangeMainMenuAccess (11960), MemorizeLocation (10820) and PlayerVisibility (11310) — now implemented | Sample3 |
    | **Unidentified** | code 10660, 10690 (106xx range) | Sample2, Sample3 |
 
 ## Recommended priorities for the interpreter

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1670,6 +1670,10 @@ module Game
     # each nil or a `{ name:, volume:, tempo: }` hash. Play Memorized BGM (11540)
     # restores the stash. Persisted in the save so the memory survives a reload.
     attr_accessor :current_bgm, :memorized_bgm
+    # Whether the party leader's map sprite is hidden, toggled by the Set
+    # Transparent Flag / Change Player Visibility (11310) event command. Defaults
+    # off (the hero is shown) and is persisted in the save.
+    attr_accessor :player_transparent
 
     def initialize(party, map_id, x, y)
       @party = party
@@ -1687,6 +1691,7 @@ module Game
       @save_access = true
       @current_bgm = nil
       @memorized_bgm = nil
+      @player_transparent = false
       # Transient screen-effect state (tint transition); not serialised, so a
       # reloaded game starts with a neutral screen.
       @screen = Screen.new
@@ -1712,7 +1717,8 @@ module Game
         party: @party.to_h, timer_frames: @timer_frames,
         timer_running: @timer_running, message_config: @message_config.to_h,
         menu_access: @menu_access, save_access: @save_access,
-        current_bgm: @current_bgm, memorized_bgm: @memorized_bgm }
+        current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
+        player_transparent: @player_transparent }
     end
 
     # Rebuild a State from a parsed LCF::SaveData -- a real Save<N>.lsd written
@@ -1782,6 +1788,7 @@ module Game
       state.save_access = h[:save_access] unless h[:save_access].nil?
       state.current_bgm = h[:current_bgm]
       state.memorized_bgm = h[:memorized_bgm]
+      state.player_transparent = h[:player_transparent] ? true : false
       state
     end
   end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -55,6 +55,7 @@ module Game
       TINT_SCREEN      = 11030
       FLASH_SCREEN     = 11040
       SHAKE_SCREEN     = 11050
+      PLAYER_VISIBILITY = 11310
       MOVE_EVENT       = 11330
       PROCEED_WITH_MOVEMENT = 11340
       HALT_ALL_MOVEMENT = 11350
@@ -65,6 +66,7 @@ module Game
       PLAY_SE          = 11550
       CHANGE_SAVE_ACCESS = 11930
       CHANGE_MENU_ACCESS = 11960
+      RETURN_TO_TITLE  = 12510
     end
 
     # Move-command ids inside a Move Event that carry extra parameters (every
@@ -287,6 +289,7 @@ module Game
       when Cmd::TINT_SCREEN      then do_tint_screen cmd
       when Cmd::FLASH_SCREEN     then do_flash_screen cmd
       when Cmd::SHAKE_SCREEN     then do_shake_screen cmd
+      when Cmd::PLAYER_VISIBILITY then do_player_visibility cmd
       when Cmd::MOVE_EVENT       then do_move_event cmd
       when Cmd::PROCEED_WITH_MOVEMENT then do_proceed_with_movement cmd
       when Cmd::HALT_ALL_MOVEMENT then @halt_movement_requested = true
@@ -297,6 +300,7 @@ module Game
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
       when Cmd::CHANGE_SAVE_ACCESS then @state.save_access = cmd.param(0) != 0
       when Cmd::CHANGE_MENU_ACCESS then @state.menu_access = cmd.param(0) != 0
+      when Cmd::RETURN_TO_TITLE  then do_return_to_title cmd
       when Cmd::CALL_EVENT       then do_call_event cmd
       when Cmd::ERASE_EVENT      then @erase_requested = true
       when Cmd::END_EVENT        then @index = @list.size
@@ -885,6 +889,25 @@ module Game
     # route never finishes, so pairing it with this command waits indefinitely.
     def do_proceed_with_movement(_cmd)
       @wait_kind = :movement
+      @waiting = true
+    end
+
+    # Set Transparent Flag (Change Player Visibility): toggle whether the party
+    # leader's map sprite is hidden. Non-blocking — it only records the flag on
+    # the shared game state; the owning scene reads it each frame. The polarity
+    # (param0 non-zero = transparent / hidden) follows EasyRPG's
+    # `SetSpriteHidden(parameters[0] != 0)`; the flag persists through Save /
+    # Continue.
+    def do_player_visibility(cmd)
+      @state.player_transparent = cmd.param(0) != 0
+    end
+
+    # Return to Title Screen: abandon the running game and go back to the title.
+    # Raised as a :return_title request the owning scene answers by tearing the
+    # play scenes down and showing a fresh title (there is nothing to resume, so
+    # the request behaves like a one-way teleport out of the map).
+    def do_return_to_title(_cmd)
+      @wait_kind = :return_title
       @waiting = true
     end
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -36,6 +36,8 @@ module Game
       CHANGE_ACTOR_SPRITE = 10630
       MEMORIZE_LOCATION = 10820
       RECALL_LOCATION   = 10830
+      CHANGE_EVENT_LOCATION = 10860
+      TRADE_EVENT_LOCATIONS = 10870
       STORE_TERRAIN_ID  = 10910
       STORE_EVENT_ID    = 10920
       CONDITIONAL      = 12010
@@ -90,6 +92,7 @@ module Game
       @call_stack = []
       @resolver = nil
       @move_route_requests = []
+      @location_requests = []
       @erase_requested = false
       @halt_movement_requested = false
       @actor_graphic_changed = false
@@ -119,6 +122,7 @@ module Game
       @running = true
       @call_stack = []
       @move_route_requests = []
+      @location_requests = []
       @erase_requested = false
       @halt_movement_requested = false
       @actor_graphic_changed = false
@@ -134,6 +138,17 @@ module Game
     def take_move_route_requests
       reqs = @move_route_requests
       @move_route_requests = []
+      reqs
+    end
+
+    # Drain the instant event-repositioning requests (Change Event Location /
+    # Trade Event Locations) queued since the last call, returning them and
+    # clearing the queue. Each is a hash — `{ op: :set, target:, x:, y: }` or
+    # `{ op: :swap, a:, b: }`. Like Move Event these do not pause the interpreter;
+    # the owning scene polls this after #update and moves the characters.
+    def take_location_requests
+      reqs = @location_requests
+      @location_requests = []
       reqs
     end
 
@@ -284,6 +299,8 @@ module Game
       when Cmd::TELEPORT         then do_teleport cmd
       when Cmd::MEMORIZE_LOCATION then do_memorize_location cmd
       when Cmd::RECALL_LOCATION   then do_recall_location cmd
+      when Cmd::CHANGE_EVENT_LOCATION then do_change_event_location cmd
+      when Cmd::TRADE_EVENT_LOCATIONS then do_trade_event_locations cmd
       when Cmd::STORE_TERRAIN_ID  then do_store_terrain_id cmd
       when Cmd::STORE_EVENT_ID    then do_store_event_id cmd
       when Cmd::TINT_SCREEN      then do_tint_screen cmd
@@ -794,6 +811,29 @@ module Game
                    variables[cmd.param(2)], 0]
       @wait_kind = :teleport
       @waiting = true
+    end
+
+    # Change Event Location (Set Event Location): instantly place a character on
+    # the current map at a tile. param0 selects the target (10001 player, 0 /
+    # 10005 this event, else a map event id); param1 the appointment mode (0 the
+    # constants param2/param3, 1 the values of those two variables); param2/param3
+    # the x and y. Queued as a `:set` request the scene applies — non-blocking,
+    # so the rest of the command list runs on.
+    def do_change_event_location(cmd)
+      x = cmd.param(2)
+      y = cmd.param(3)
+      if cmd.param(1) == 1
+        x = variables[x]
+        y = variables[y]
+      end
+      @location_requests.push(op: :set, target: cmd.param(0), x: x, y: y)
+    end
+
+    # Trade Event Locations (Swap Event Locations): exchange the tiles of the two
+    # characters named by param0 and param1 (same target ids as Change Event
+    # Location). Queued as a `:swap` request the scene applies; non-blocking.
+    def do_trade_event_locations(cmd)
+      @location_requests.push(op: :swap, a: cmd.param(0), b: cmd.param(1))
     end
 
     # Store Terrain ID: write the terrain id of the tile at (x, y) into the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -66,6 +66,7 @@ module Game
       MEMORIZE_BGM     = 11530
       PLAY_MEMORIZED_BGM = 11540
       PLAY_SE          = 11550
+      CHANGE_MAP_TILESET = 11710
       CHANGE_SAVE_ACCESS = 11930
       CHANGE_MENU_ACCESS = 11960
       RETURN_TO_TITLE  = 12510
@@ -96,6 +97,7 @@ module Game
       @erase_requested = false
       @halt_movement_requested = false
       @actor_graphic_changed = false
+      @tileset_request = nil
       @input_variable = nil
       @input_digits = 1
       # Deterministic RNG for the Control Variables "random" operand (mruby has
@@ -126,6 +128,7 @@ module Game
       @erase_requested = false
       @halt_movement_requested = false
       @actor_graphic_changed = false
+      @tileset_request = nil
       reset_waits
     end
 
@@ -160,6 +163,16 @@ module Game
       v = @erase_requested
       @erase_requested = false
       v
+    end
+
+    # The new tileset (chipset) id requested by a Change Map Tileset command since
+    # the last call, or nil if none. Reading it clears the request. The owning
+    # scene polls this after #update and rebuilds the map's chipset; non-blocking,
+    # so the rest of the command list runs on.
+    def take_tileset_request
+      id = @tileset_request
+      @tileset_request = nil
+      id
     end
 
     # True (once) if a Halt All Movement command ran since the last call, clearing
@@ -315,6 +328,7 @@ module Game
       when Cmd::MEMORIZE_BGM     then do_memorize_bgm cmd
       when Cmd::PLAY_MEMORIZED_BGM then do_play_memorized_bgm cmd
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
+      when Cmd::CHANGE_MAP_TILESET then @tileset_request = cmd.param(0)
       when Cmd::CHANGE_SAVE_ACCESS then @state.save_access = cmd.param(0) != 0
       when Cmd::CHANGE_MENU_ACCESS then @state.menu_access = cmd.param(0) != 0
       when Cmd::RETURN_TO_TITLE  then do_return_to_title cmd

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -714,6 +714,7 @@ class RPG2k
           it.update
         end
         apply_move_requests(it, p[:event])
+        apply_location_requests(it, p[:event])
         apply_erase_request(it, p[:event])
       rescue StandardError
         nil
@@ -944,6 +945,91 @@ class RPG2k
         end
       end
 
+      # -- Change / Trade Event Location --------------------------------------
+
+      # Apply the instant-reposition requests an interpreter queued this step
+      # (Change Event Location / Trade Event Locations). `this_event` is the map
+      # event running the process (or nil), so a request targeting "this event"
+      # reaches the right character.
+      def apply_location_requests(interp, this_event)
+        reqs = interp.take_location_requests
+        return if reqs.nil? || reqs.empty?
+        reqs.each { |r| apply_location_request(r, this_event) }
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Event location change failed: #{e.message}"
+        nil
+      end
+
+      def apply_location_request(r, this_event)
+        if r[:op] == :swap
+          a = char_location(r[:a], this_event)
+          b = char_location(r[:b], this_event)
+          return unless a && b
+          set_char_location(r[:a], this_event, b[0], b[1])
+          set_char_location(r[:b], this_event, a[0], a[1])
+        else
+          set_char_location(r[:target], this_event, r[:x], r[:y])
+        end
+      end
+
+      # The current tile of a target character (the same target ids as Move
+      # Event), or nil for the player-less vehicle slots / a missing event.
+      def char_location(target, this_event)
+        case target
+        when MOVE_TARGET_PLAYER
+          [@state.x, @state.y]
+        when 0, MOVE_TARGET_THIS
+          this_event ? [this_event[:char].x, this_event[:char].y] : nil
+        when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          nil # vehicles are not modelled yet
+        else
+          ev = @events.find { |e| e[:id] == target }
+          ev ? [ev[:char].x, ev[:char].y] : nil
+        end
+      end
+
+      # Instantly move a target character to a tile.
+      def set_char_location(target, this_event, x, y)
+        case target
+        when MOVE_TARGET_PLAYER
+          move_player_to(x, y)
+        when 0, MOVE_TARGET_THIS
+          move_event_to(this_event, x, y) if this_event
+        when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          nil # vehicles are not modelled yet
+        else
+          ev = @events.find { |e| e[:id] == target }
+          move_event_to(ev, x, y) if ev
+        end
+      end
+
+      # Snap the player to a tile: cancel any in-progress step and keep a forced
+      # route's mirror character (if one is running) in sync so it steps on from
+      # the new tile.
+      def move_player_to(x, y)
+        @state.x = x
+        @state.y = y
+        @dest_x = x
+        @dest_y = y
+        @moving = false
+        @move_count = 0
+        if @player_char
+          @player_char.x = x
+          @player_char.y = y
+        end
+      end
+
+      # Snap an event to a tile and refresh the occupied-tile cache so collision
+      # and the marker follow it.
+      def move_event_to(ev, x, y)
+        return unless ev
+        ox = ev[:char].x
+        oy = ev[:char].y
+        ev[:char].x = x
+        ev[:char].y = y
+        reoccupy(ev, ox, oy)
+      end
+
       # Give a map event a forced route, overriding its page movement until the
       # route finishes (a repeating route runs until replaced). It steps on the
       # next frame, paced by the requested frequency when one was given.
@@ -1089,6 +1175,7 @@ class RPG2k
         else
           @interpreter.update
           apply_move_requests(@interpreter, @active_event)
+          apply_location_requests(@interpreter, @active_event)
           apply_erase_request(@interpreter, @active_event)
           apply_halt_request(@interpreter)
           apply_graphic_change(@interpreter)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -490,10 +490,20 @@ class RPG2k
       end
 
       def build_chipset
-        Game::ChipSet.new(@db, @map.chipset_id)
+        Game::ChipSet.new(@db, @tileset_id || @map.chipset_id)
       rescue StandardError => e
         $stderr.puts "[RPG2k] chipset load failed, tiles treated as passable: #{e.message}"
         nil
+      end
+
+      # Rebuild the chipset model and its tile graphic (after a Change Map Tileset
+      # swaps the tileset id), disposing the old graphic bitmap. Passability,
+      # terrain and rendering all read the refreshed chipset from here on.
+      def rebuild_chipset
+        @chipset = build_chipset
+        old = @chipset_bmp
+        @chipset_bmp = load_chipset_graphic
+        old.dispose if old && !old.equal?(@chipset_bmp)
       end
 
       # Load the chipset tile graphic (ChipSet/<name>). Chipsets are indexed
@@ -716,6 +726,7 @@ class RPG2k
         apply_move_requests(it, p[:event])
         apply_location_requests(it, p[:event])
         apply_erase_request(it, p[:event])
+        apply_tileset_request(it)
       rescue StandardError
         nil
       end
@@ -912,6 +923,21 @@ class RPG2k
       def player_hidden?
         leader = @state.party.leader
         @state.player_transparent || (leader && leader.transparent) ? true : false
+      end
+
+      # -- Change Map Tileset -------------------------------------------------
+
+      # If the interpreter ran a Change Map Tileset this step, swap the map's
+      # chipset to the requested id and rebuild its tile graphic. The override
+      # lasts until the next map load (see perform_teleport).
+      def apply_tileset_request(interp)
+        id = interp.take_tileset_request
+        return if id.nil?
+        @tileset_id = id
+        rebuild_chipset
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Change Map Tileset failed: #{e.message}"
+        nil
       end
 
       # -- Move Event (Set Move Route) ----------------------------------------
@@ -1179,6 +1205,7 @@ class RPG2k
           apply_erase_request(@interpreter, @active_event)
           apply_halt_request(@interpreter)
           apply_graphic_change(@interpreter)
+          apply_tileset_request(@interpreter)
         end
       end
 
@@ -1208,6 +1235,7 @@ class RPG2k
         @state.x = x
         @state.y = y
         @state.direction = dir if dir && dir > 0
+        @tileset_id = nil # a Change Map Tileset override does not survive a teleport
         @chipset = build_chipset
         @started_auto = {}
         @started_common = {}

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -901,9 +901,16 @@ class RPG2k
       def refresh_player_graphic
         @charset = load_charset
         @last_frame = nil
-        leader = @state.party.leader
-        @player_sprite.visible = !(leader && leader.transparent)
+        @player_sprite.visible = !player_hidden?
         @player_bmp.clear unless @charset
+      end
+
+      # Whether the party leader's map sprite should be hidden this frame: either
+      # the Set Transparent Flag command hid the player, or the leader's own
+      # actor graphic carries the (rarely used) semi-transparent flag.
+      def player_hidden?
+        leader = @state.party.leader
+        @state.player_transparent || (leader && leader.transparent) ? true : false
       end
 
       # -- Move Event (Set Move Route) ----------------------------------------
@@ -1077,6 +1084,7 @@ class RPG2k
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
           when :screen then @interpreter.resume unless @state.screen.busy?
+          when :return_title then perform_return_to_title
           end
         else
           @interpreter.update
@@ -1128,6 +1136,17 @@ class RPG2k
         @interpreter.stop
       rescue StandardError => e
         $stderr.puts "[RPG2k] Teleport failed: #{e.message}"
+        @interpreter.stop
+      end
+
+      # Return to Title Screen: stop the running event and hand control back to
+      # the app, which tears the play scenes down and shows a fresh title. There
+      # is nothing to resume afterwards — this scene is being disposed.
+      def perform_return_to_title
+        @interpreter.stop
+        @parent.return_to_title
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Return to Title failed: #{e.message}"
         @interpreter.stop
       end
 
@@ -1457,6 +1476,9 @@ class RPG2k
 
         @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
         @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE)
+        # Reflect the Set Transparent Flag command (and any leader graphic flag)
+        # every frame so the hero hides/shows as events toggle it.
+        @player_sprite.visible = !player_hidden?
         draw_player_frame
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1647,6 +1647,49 @@ check 'Halt All Movement raises a one-shot request without pausing' do
   eq false, it.take_halt_movement_request, 'and it clears after the first read'
 end
 
+# -- Player Visibility / Return to Title --------------------------------------
+
+check 'Set Transparent Flag toggles the player-transparent state, non-blocking' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::PLAYER_VISIBILITY, [1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq true, st.player_transparent, 'param0 != 0 hides the player'
+  ok !it.waiting?, 'Set Transparent Flag must not pause the interpreter'
+  eq true, st.switches[1], 'the command after it still ran'
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::PLAYER_VISIBILITY, [0])])
+  it2.update
+  eq false, st.player_transparent, 'param0 == 0 shows the player again'
+end
+
+check 'player_transparent round-trips through the save' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.player_transparent = true
+  eq true, Game::State.load(db, st.to_h).player_transparent
+  # A save written before the flag existed defaults to visible (off).
+  legacy = st.to_h
+  legacy.delete(:player_transparent)
+  eq false, Game::State.load(db, legacy).player_transparent
+end
+
+check 'Return to Title Screen raises a :return_title request' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::RETURN_TO_TITLE, []),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok it.waiting?, 'Return to Title pauses the interpreter'
+  eq :return_title, it.wait_kind
+  eq false, st.switches[1], 'the command after it does not run (the game is ending)'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1721,6 +1721,18 @@ check 'Trade Event Locations queues a :swap request' do
   eq [{ op: :swap, a: 3, b: 7 }], it.take_location_requests
 end
 
+check 'Change Map Tileset queues a one-shot tileset request, non-blocking' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_MAP_TILESET, [7]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Change Map Tileset must not pause the interpreter'
+  eq true, st.switches[1], 'the command after it still ran'
+  eq 7, it.take_tileset_request, 'the requested tileset id is reported once'
+  eq nil, it.take_tileset_request, 'and clears after the first read'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1690,6 +1690,37 @@ check 'Return to Title Screen raises a :return_title request' do
   eq false, st.switches[1], 'the command after it does not run (the game is ending)'
 end
 
+# -- Change / Trade Event Location --------------------------------------------
+
+check 'Change Event Location queues a :set request (constant and variable modes)' do
+  st = party_state
+  st.variables[7] = 4
+  st.variables[8] = 9
+  it = Game::Interpreter.new(st)
+  # event 3, mode 0 (constants), to (5, 6); then event 3, mode 1 (variables 7/8),
+  # then a switch to prove it did not pause.
+  it.start([FakeCmd.new(IC::CHANGE_EVENT_LOCATION, [3, 0, 5, 6]),
+            FakeCmd.new(IC::CHANGE_EVENT_LOCATION, [3, 1, 7, 8]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Change Event Location must not pause the interpreter'
+  eq true, st.switches[1]
+  reqs = it.take_location_requests
+  eq 2, reqs.size
+  eq({ op: :set, target: 3, x: 5, y: 6 }, reqs[0])
+  eq({ op: :set, target: 3, x: 4, y: 9 }, reqs[1], 'variable mode resolves x/y')
+  eq [], it.take_location_requests, 'the queue clears after draining'
+end
+
+check 'Trade Event Locations queues a :swap request' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::TRADE_EVENT_LOCATIONS, [3, 7])])
+  it.update
+  ok !it.waiting?, 'Trade Event Locations must not pause the interpreter'
+  eq [{ op: :swap, a: 3, b: 7 }], it.take_location_requests
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -122,19 +122,20 @@ R = Game::MoveRoute
 
 # A chipset with no passability table -> every tile is walkable, so movement is
 # bounded only by the map edges, the player and other events.
-def fake_chipset
+def fake_chipset(name = 'cs')
   # All tiles passable (no lower table); terrain tag 42 on chip index 0 (the id
   # every tile of the synthetic all-zero map maps to).
   td = Array.new(162, 0)
   td[0] = 42
-  OpenStruct.new(name: 'cs', chipset_name: 'cs', passable_data_lower: nil,
+  OpenStruct.new(name: name, chipset_name: name, passable_data_lower: nil,
                  terrain_data: td)
 end
 
 def fake_db(common = nil)
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: ''),
-    chipset: { 1 => fake_chipset },
+    # A second chipset (id 2) so Change Map Tileset has somewhere to swap to.
+    chipset: { 1 => fake_chipset, 2 => fake_chipset('cs2') },
     common_event: common,
     player: {}
   )
@@ -539,6 +540,18 @@ check 'Trade Event Locations swaps two events' do
   b = chars(scene)[2]
   eq [4, 1], [a.x, a.y], 'event 1 took event 2 old tile'
   eq [2, 2], [b.x, b.y], 'event 2 took event 1 old tile'
+end
+
+check 'Change Map Tileset rebuilds the map chipset from the new id' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::CHANGE_MAP_TILESET, [2])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  eq 'cs', scene.instance_variable_get(:@chipset).name, 'starts on chipset 1'
+  5.times { scene.update }
+  eq 'cs2', scene.instance_variable_get(:@chipset).name,
+     'the chipset was rebuilt from the requested tileset id'
+  eq 2, scene.instance_variable_get(:@tileset_id), 'the override id is recorded'
 end
 
 check 'Input Number opens a widget; confirming stores the entered value' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -208,6 +208,9 @@ class FakeParent
   def load_map(id); @map_maker.call(id); end
   # Scene::Map#try_open_menu pushes a Scene::Menu; record it instead.
   def push(scene); @pushed << scene; end
+  # Return to Title Screen (12510) hands control back here; record that it fired.
+  attr_reader :returned_to_title
+  def return_to_title; @returned_to_title = true; end
 end
 
 def fake_parent(db)
@@ -464,6 +467,31 @@ check 'Halt All Movement cancels a forced player route in the scene' do
   ok scene.instance_variable_get(:@player_route).nil?,
      'the forced player route was cancelled'
   eq [0, 0], [st.x, st.y], 'the player never moved (movement was halted)'
+end
+
+check 'Set Transparent Flag hides and shows the player sprite' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::PLAYER_VISIBILITY, [1])] # transparent ON
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  5.times { scene.update }
+  spr = scene.instance_variable_get(:@player_sprite)
+  eq false, spr.visible, 'the player sprite is hidden while transparent'
+  # A second event turns it back off.
+  st = scene.instance_variable_get(:@state)
+  st.player_transparent = false
+  scene.update
+  eq true, spr.visible, 'the player sprite shows again once transparency clears'
+end
+
+check 'Return to Title Screen hands control back to the app' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::RETURN_TO_TITLE, [])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  parent = scene.instance_variable_get(:@parent)
+  5.times { scene.update }
+  ok parent.returned_to_title, 'the app was told to return to the title screen'
 end
 
 check 'Input Number opens a widget; confirming stores the entered value' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -494,6 +494,53 @@ check 'Return to Title Screen hands control back to the app' do
   ok parent.returned_to_title, 'the app was told to return to the title screen'
 end
 
+check 'Change Event Location snaps another event to a tile' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3) # auto-start: place event 2 at (5, 3)
+  auto.event_commands = [ECmd.new(ic::CHANGE_EVENT_LOCATION, [2, 0, 5, 3])]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(1, 1, page) },
+                    player: [5, 5])
+  5.times { scene.update }
+  c = chars(scene)[2]
+  eq [5, 3], [c.x, c.y], 'the event was moved to the target tile'
+  tiles = scene.instance_variable_get(:@event_tiles)
+  ok tiles[[5, 3]] && tiles[[5, 3]][:id] == 2, 'the occupied-tile cache followed'
+  ok !tiles[[1, 1]], 'its old tile was released'
+end
+
+check 'Change Event Location with "this event" moves the runner itself' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::CHANGE_EVENT_LOCATION, [10005, 0, 4, 4])]
+  scene = new_scene({ 1 => event(2, 0, auto) }, player: [5, 5])
+  5.times { scene.update }
+  c = chars(scene)[1]
+  eq [4, 4], [c.x, c.y], 'the running event moved itself'
+end
+
+check 'Change Event Location targeting the player snaps the hero' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::CHANGE_EVENT_LOCATION, [10001, 0, 3, 2])]
+  scene = new_scene({ 1 => event(0, 0, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  5.times { scene.update }
+  eq [3, 2], [st.x, st.y], 'the player was moved to the target tile'
+end
+
+check 'Trade Event Locations swaps two events' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3) # auto-start: swap this event (1) with event 2
+  auto.event_commands = [ECmd.new(ic::TRADE_EVENT_LOCATIONS, [10005, 2])]
+  scene = new_scene({ 1 => event(2, 2, auto), 2 => event(4, 1, page) },
+                    player: [5, 5])
+  5.times { scene.update }
+  a = chars(scene)[1]
+  b = chars(scene)[2]
+  eq [4, 1], [a.x, a.y], 'event 1 took event 2 old tile'
+  eq [2, 2], [b.x, b.y], 'event 2 took event 1 old tile'
+end
+
 check 'Input Number opens a widget; confirming stores the entered value' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
Adds five more RPG2000 event commands to `Game::Interpreter`, continuing the event-command coverage after #171.

## Summary

Implements **Set Transparent Flag / Change Player Visibility (11310)**, **Return to Title Screen (12510)**, **Change Event Location (10860)**, **Trade Event Locations (10870)**, and **Change Map Tileset (11710)**. Together these close the Player Visibility gap the sample-game analysis flagged and add instant event/player repositioning plus live tileset swapping.

## Key Changes

**Set Transparent Flag / Change Player Visibility (11310)**
- Toggles a new `player_transparent` flag on `Game::State`
- `Scene::Map` hides/shows the party leader's map sprite each frame (combined with the leader graphic's own semi-transparent flag)
- Persisted through Save / Continue; backward compatible (absent = visible)
- Polarity (`param0 != 0` = transparent) follows EasyRPG's `SetSpriteHidden(parameters[0] != 0)`

**Return to Title Screen (12510)**
- Suspends on a `:return_title` request the scene answers by stopping the event and calling the app's existing `return_to_title`, tearing the play scenes down and showing a fresh title

**Change Event Location (10860)**
- Instantly snaps a character to a tile — target is the player (10001), "this event" (0 / 10005) or a map event by id
- x / y come from the command's constants or, in appointment mode 1, from two variables
- Non-blocking: queued and applied by `Scene::Map` after `#update`, cancelling a half-finished player step, keeping a forced route's mirror in sync, and refreshing the occupied-tile cache so collision and the marker follow

**Trade Event Locations (10870)**
- Swaps the tiles of two such characters (same target ids)

**Change Map Tileset (11710)**
- Records the requested chipset id; `Scene::Map` rebuilds the chipset model and its tile graphic (disposing the old bitmap) so passability, terrain and rendering all switch at once
- The override lasts until the next map load — a teleport rebuilds from the destination map's own chipset

Vehicle targets stay unmodelled, consistent with the existing Move Event handling.

## Testing
- `scripts/rpg2k_logic_check.rb` (120 checks): flag toggle + save round-trip, return-title request, location-request queueing (constant and variable modes), swap request, tileset request
- `scripts/rpg2k_scene_check.rb` (44 checks): sprite hides/shows, app return-to-title, event/this-event/player snapping with occupied-tile refresh, two-event swap, chipset rebuild
- README, `docs/TODO.md`, `docs/rpg2000-sample-analysis.md`, and per-change changelog fragments updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW