### PR TITLE
Fix lazy schema defaults to evaluate callables instead of returning Proc

### DIFF
--- a/changelog.d/lazy-schema-default-eval.fixed.md
+++ b/changelog.d/lazy-schema-default-eval.fixed.md
@@ -1,0 +1,4 @@
+- Absent LCF fields with a lazy (`-> { ... }`) schema default now resolve to the
+  default's **value** instead of the `Proc` itself, so edition-dependent defaults
+  like an actor's `max_level` and the `exp_basic`/`exp_increase`/`exp_correction`
+  curve read as numbers (e.g. `50`/`30`) rather than an un-called lambda.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -169,7 +169,13 @@ module LCF
   end
 
   def to_rb d, s
-    return s[:default] unless d
+    # An absent field yields its schema default. A callable (`-> { ... }`)
+    # default is lazy -- evaluate it -- so edition-dependent defaults such as
+    # max level and the exp curve resolve to their value, not the Proc itself.
+    unless d
+      dv = s[:default]
+      return dv.respond_to?(:call) ? dv.call : dv
+    end
 
     case s[:type]
     when :Array1D ; return Array1D.new d, s

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -259,6 +259,12 @@ module LCF
 
   def exp_default; MODE == 2003 ? 300 : 30 end
 
+  # Edition-dependent helpers are referenced as `LCF.<name>` from lazy schema
+  # defaults (`-> { LCF.level_max }` etc.), so they must be module functions --
+  # otherwise calling the default raises NoMethodError for module LCF.
+  module_function :var_max, :var_min, :level_max, :pc_hp_max, :npc_hp_max,
+                  :exp_default
+
   class Array1D
     def initialize s, schema
       s = StringIO.new s if s.is_a? String

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -86,7 +86,7 @@ module LCF
             4 => { name: :charset_index, type: :int, default: 0 },
             5 => { name: :semi_transparent, type: :bool, default: false },
             7 => { name: :initial_level, type: :int, default: 1 },
-            8 => { name: :max_level, type: :int, default: -> { LCF.max_level } },
+            8 => { name: :max_level, type: :int, default: -> { LCF.level_max } },
             9 => { name: :has_critical_rate, type: :bool, default: true },
             10 => { name: :critical_rate, type: :int, default: 30 },
 

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -142,6 +142,17 @@ assert "LCF::Array1D#int16_values reads a raw short array past a named accessor"
   assert_false row.respond_to?(:no_such_field)
 end
 
+assert "LCF absent-field defaults: a lambda default is evaluated, not returned raw" do
+  row = LCF::Array1D.new(
+    lcf_array1d([lcf_int_field(1, 7)]),
+    { elements: { 1 => { name: :present, type: :int, default: 0 },
+                  2 => { name: :lazy,    type: :int, default: -> { 42 } },
+                  3 => { name: :static,  type: :int, default: 5 } } })
+  assert_equal 7, row.present   # a present chunk decodes normally
+  assert_equal 42, row.lazy     # absent + callable default -> its called value
+  assert_equal 5, row.static    # absent + plain default -> the value itself
+end
+
 assert "LCF::Database#maker detects RPG2003 by the Classes section (chunk 30)" do
   actor = lcf_array1d([lcf_str_field(1, "Hero"), lcf_int_field(57, 3)])
   klass = lcf_array1d([lcf_str_field(1, "Soldier")])

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -153,6 +153,18 @@ assert "LCF absent-field defaults: a lambda default is evaluated, not returned r
   assert_equal 5, row.static    # absent + plain default -> the value itself
 end
 
+assert "LCF edition-dependent helpers are callable as module methods (used by lazy defaults)" do
+  # The real schema uses `-> { LCF.level_max }` / `-> { LCF.exp_default }` etc.
+  # as lazy defaults, so these must be reachable as `LCF.<name>` -- otherwise
+  # evaluating an absent field's default raises NoMethodError for module LCF.
+  assert_equal LCF::MODE == 2003 ? 99 : 50, LCF.level_max
+  assert_equal LCF::MODE == 2003 ? 300 : 30, LCF.exp_default
+  assert_equal LCF::MODE == 2003 ? 9_999_999 : 999_999, LCF.var_max
+  assert_equal LCF::MODE == 2003 ? -9_999_999 : -999_999, LCF.var_min
+  assert_equal LCF::MODE == 2003 ? 9999 : 999, LCF.pc_hp_max
+  assert_equal LCF::MODE == 2003 ? 99_999 : 9999, LCF.npc_hp_max
+end
+
 assert "LCF::Database#maker detects RPG2003 by the Classes section (chunk 30)" do
   actor = lcf_array1d([lcf_str_field(1, "Hero"), lcf_int_field(57, 3)])
   klass = lcf_array1d([lcf_str_field(1, "Soldier")])


### PR DESCRIPTION
## Summary
This PR fixes a bug where absent LCF fields with lazy (callable) schema defaults were returning the `Proc` object itself instead of evaluating it to get the actual default value. This was particularly problematic for edition-dependent defaults like `max_level` and experience curve values.

## Key Changes

- **Modified `LCF#to_rb` method** to detect and evaluate callable defaults:
  - When a field is absent and has a schema default, check if the default is callable
  - If callable, invoke it to get the actual value; otherwise return the value as-is
  - This allows edition-dependent defaults (e.g., `-> { LCF.level_max }`) to resolve to their numeric values

- **Exposed edition-dependent helper methods as module functions**:
  - Made `var_max`, `var_min`, `level_max`, `pc_hp_max`, `npc_hp_max`, and `exp_default` callable as `LCF.<method>` 
  - This enables lazy defaults to properly reference these helpers without raising `NoMethodError`

- **Fixed schema reference bug**:
  - Corrected `max_level` default from `-> { LCF.max_level }` to `-> { LCF.level_max }` to match the actual method name

- **Added comprehensive test coverage**:
  - Test verifying that callable defaults are evaluated while plain defaults are returned as-is
  - Test confirming all edition-dependent helpers are accessible as module methods with correct values for both RPG2003 and RPG2000 modes

## Implementation Details
The fix leverages Ruby's `respond_to?(:call)` to distinguish between callable and non-callable defaults, allowing the same default field to support both static values and lazy-evaluated expressions. This maintains backward compatibility while enabling dynamic, edition-aware defaults.

https://claude.ai/code/session_01SZ7BfqHrD1VhJAtHJ3vHPr