### PR TITLE
rpg2k: render parallax map backgrounds

### DIFF
--- a/changelog.d/rpg2k-parallax-background.added.md
+++ b/changelog.d/rpg2k-parallax-background.added.md
@@ -1,0 +1,11 @@
+- **Parallax backgrounds** — RPG2000 maps now draw their `Panorama/<name>`
+  backdrop behind the tile layers instead of leaving the void. `Scene::Map`
+  composites the image into a screen-sized sprite at `z = -1`, and the new
+  `Game::Parallax` module computes the per-axis draw offset (a port of EasyRPG
+  Player's parallax model): a looping axis tiles the image and scrolls it at
+  half the camera rate with optional autoscroll (`parallax_sx`/`parallax_sy`),
+  while a non-looping axis anchors it — fixed to the screen for a full-screen
+  backdrop, panned across its excess for a larger image. Validated against the
+  real Nepheshel game (all 45 parallax maps' images resolve and every offset
+  stays in range across a camera sweep) and pinned by
+  `scripts/rpg2k_render_check.rb` / `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -67,6 +67,16 @@ The work below is roughly ordered by the critical path to a walkable game
   Passability still drives collision. Geometry is pinned by
   `scripts/rpg2k_render_check.rb`. Remaining: tile-replacement (Replace Chipset
   Tiles) substitution and screen-tone tinting of tiles.
+- ✅ Parallax background — `Scene::Map` draws the map's `Panorama/<name>`
+  backdrop behind the tile layers (a sprite at z = -1). `Game::Parallax` ports
+  EasyRPG's parallax model: a looping axis tiles the image and scrolls it at
+  half the camera rate with optional time-based autoscroll (`parallax_sx/sy`),
+  while a non-looping axis anchors it — fixed to the screen for the common
+  full-screen backdrop, panned across its excess for a larger image. Grounded
+  in the real Nepheshel data (all 45 parallax maps' images resolve and every
+  offset stays in range across a camera sweep) and pinned by
+  `scripts/rpg2k_render_check.rb`. The scroll *rate* mirrors EasyRPG's formulae
+  but still wants a native/wine visual diff to confirm.
 - ✅ Character sprites — the party leader and every map event render from their
   CharSet graphic (`Game::CharSet`, 4-direction, 3 walk frames). Events also
   draw a chipset tile when their graphic is a tile substitution (empty CharSet

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -637,6 +637,62 @@ module Game
     end
   end
 
+  # Geometry of the map's parallax background (the `Panorama/<name>` image drawn
+  # behind the tile layers, `MAP_UNIT` fields 31–38). Given the camera position,
+  # the screen / map / image sizes and the per-axis loop + autoscroll settings,
+  # #axis_offset returns the top-left offset (<= 0) at which to start tiling the
+  # image for that axis. The behaviour follows EasyRPG Player's parallax model:
+  #
+  #   * A **looping** axis tiles the image and scrolls it at half the map's rate
+  #     (the classic parallax factor), plus an optional autoscroll that drifts it
+  #     over time at the speed field's rate.
+  #   * A **non-looping** axis anchors the image: it stays fixed to the screen
+  #     when it is no larger than the screen (the common RPG2000 full-screen
+  #     backdrop), and pans across its excess width/height in step with the map
+  #     when it is larger.
+  #
+  # Pure integer geometry with no rendering dependency, so it is exercised
+  # directly by scripts/rpg2k_render_check.rb. The exact scroll *rate* mirrors
+  # EasyRPG's formulae but has not been visually diffed against RPG_RT under
+  # wine — that native comparison is the remaining validation.
+  module Parallax
+    module_function
+
+    # Per-frame autoscroll offset in pixels for an RPG2000 speed field, ported
+    # from EasyRPG's `scroll_amt` with its pan->pixel (/32) scaling so small
+    # speeds move a fraction of a pixel per frame: the fine delta is
+    # -(1<<speed) for speed>0 and +(1<<-speed) for speed<0, accumulated over
+    # `frame` frames and divided by 32.
+    def autoscroll_px(speed, frame)
+      return 0 if speed.nil? || speed == 0
+      amt = speed > 0 ? -(1 << speed) : (1 << -speed)
+      (frame * amt) / 32
+    end
+
+    # Top-left draw offset (in (-img_px, 0]) for one panorama axis.
+    def axis_offset(loop, autoscroll, speed, frame, cam_px, screen_px, map_px, img_px)
+      return 0 if img_px.nil? || img_px <= 0
+      if loop
+        base = cam_px / 2
+        base += autoscroll_px(speed, frame) if autoscroll
+        -(base % img_px)
+      else
+        anchored_offset(cam_px, screen_px, map_px, img_px)
+      end
+    end
+
+    # A non-looping axis: fixed to the screen while the image is no larger than
+    # it, otherwise panned across the image's excess as the camera sweeps the
+    # map (0 at the west/north edge, -excess at the east/south edge).
+    def anchored_offset(cam_px, screen_px, map_px, img_px)
+      return 0 if img_px <= screen_px
+      cam_max = map_px - screen_px
+      return 0 if cam_max <= 0
+      cam = Game.clamp(cam_px, 0, cam_max)
+      -((img_px - screen_px) * cam / cam_max)
+    end
+  end
+
   # Game switches: a 1-indexed set of booleans, defaulting to false.
   class Switches
     def initialize; @data = {}; end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -417,10 +417,11 @@ class RPG2k
 
       def dispose
         close_message
-        [@lower_sprite, @upper_sprite, @player_sprite].each do |s|
+        [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite].each do |s|
           s.dispose if s
         end
         @chipset_bmp.dispose if @chipset_bmp
+        @parallax_img.dispose if @parallax_img
       end
 
       def update
@@ -471,6 +472,34 @@ class RPG2k
         # CharSet graphics for events, loaded on demand and cached by name (a
         # cached nil marks a name that failed to load, so we log it once).
         @event_charsets = {}
+
+        setup_parallax
+      end
+
+      # Load the map's parallax background (Panorama/<name>) and its scroll
+      # settings, and create the sprite that carries it behind the tile layers
+      # (z = -1, below the lower tiles at z = 0). Skipped — leaving the map's
+      # backdrop the plain void — when the map has no parallax or the image is
+      # missing.
+      def setup_parallax
+        u = @map.unit
+        return unless (u.parallax_flag rescue false)
+        name = (u.parallax_name rescue '').to_s
+        return if name.empty?
+        @parallax_img = Bitmap.new "Panorama/#{name}"
+        @par_loop_x = (u.parallax_loop_x rescue false) ? true : false
+        @par_loop_y = (u.parallax_loop_y rescue false) ? true : false
+        @par_auto_x = (u.parallax_autoloop_x rescue false) ? true : false
+        @par_auto_y = (u.parallax_autoloop_y rescue false) ? true : false
+        @par_sx = (u.parallax_sx rescue 0) || 0
+        @par_sy = (u.parallax_sy rescue 0) || 0
+        @parallax_sprite = Sprite.new
+        @parallax_sprite.z = -1
+        @parallax_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        @parallax_sprite.bitmap = @parallax_bmp
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] parallax load failed, no backdrop drawn: #{e.message}"
+        @parallax_img = nil
       end
 
       # The CharSet bitmap for an event graphic `name`, cached (including a
@@ -1488,11 +1517,52 @@ class RPG2k
         # of void during the shake, which is fine.
         cam_x -= @state.screen.shake_offset
 
+        draw_parallax cam_x, cam_y
         draw_layers cam_x, cam_y
 
         @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
         @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE)
         draw_player_frame
+      end
+
+      # Composite the parallax background into its screen-sized buffer, tiling
+      # the image along any looping axis so it fills the view. The per-axis
+      # start offset (and, for a looping axis, the scroll/autoscroll) comes from
+      # Game::Parallax; @anim_frame drives the autoscroll. A non-looping axis
+      # draws a single copy at its anchored offset.
+      def draw_parallax cam_x, cam_y
+        return unless @parallax_img
+        iw = @parallax_img.width
+        ih = @parallax_img.height
+        ox = Game::Parallax.axis_offset(@par_loop_x, @par_auto_x, @par_sx,
+                                        @anim_frame, cam_x, SCREEN_W,
+                                        @map.width * TILE, iw)
+        oy = Game::Parallax.axis_offset(@par_loop_y, @par_auto_y, @par_sy,
+                                        @anim_frame, cam_y, SCREEN_H,
+                                        @map.height * TILE, ih)
+        @parallax_bmp.clear
+        src = Rect.new(0, 0, iw, ih)
+        parallax_tiles(oy, ih, SCREEN_H, @par_loop_y).each do |dy|
+          parallax_tiles(ox, iw, SCREEN_W, @par_loop_x).each do |dx|
+            @parallax_bmp.blt dx, dy, @parallax_img, src
+          end
+        end
+      end
+
+      # Draw positions along one axis so the image (size `size`, starting at
+      # `off` <= 0) covers `screen`: repeated every `size` when the axis loops,
+      # a single copy at `off` otherwise.
+      def parallax_tiles(off, size, screen, loop)
+        return [off] unless loop && size > 0
+        d = off
+        d -= size while d > 0        # begin at or left of the origin
+        d += size while d + size <= 0 # but not entirely off-screen
+        out = []
+        while d < screen
+          out << d
+          d += size
+        end
+        out
       end
 
       def draw_layers cam_x, cam_y

--- a/scripts/rpg2k_render_check.rb
+++ b/scripts/rpg2k_render_check.rb
@@ -285,6 +285,54 @@ check 'animation-type predicates classify the six types' do
   ok !EG.animated?(EG::FIXED_GRAPHIC)
 end
 
+# -- parallax background geometry (Game::Parallax) ----------------------------
+
+PX = Game::Parallax
+
+check 'a non-looping panorama no larger than the screen stays fixed' do
+  # The common Nepheshel full-screen backdrop: 640x480 image, any camera -> 0.
+  eq 0, PX.axis_offset(false, false, 0, 0, 0,   640, 1280, 640)
+  eq 0, PX.axis_offset(false, false, 0, 0, 320, 640,  1280, 640)
+  eq 0, PX.axis_offset(false, false, 0, 0, 999, 480,  2000, 480) # y axis
+end
+
+check 'a non-looping panorama wider than the screen pans across its excess' do
+  # img 1280, screen 640, map 1280 -> camera 0..640 reveals the 640px excess.
+  eq 0,    PX.axis_offset(false, false, 0, 0, 0,   640, 1280, 1280)
+  eq(-320, PX.axis_offset(false, false, 0, 0, 320, 640, 1280, 1280))
+  eq(-640, PX.axis_offset(false, false, 0, 0, 640, 640, 1280, 1280))
+  # Camera clamps, so past the edge it holds at the far offset.
+  eq(-640, PX.axis_offset(false, false, 0, 0, 9999, 640, 1280, 1280))
+end
+
+check 'a looping panorama scrolls at half the camera rate and wraps' do
+  eq 0,   PX.axis_offset(true, false, 0, 0, 0,   640, 4096, 256)
+  eq(-50, PX.axis_offset(true, false, 0, 0, 100, 640, 4096, 256)) # half of 100
+  eq 0,   PX.axis_offset(true, false, 0, 0, 512, 640, 4096, 256)  # 256 -> wraps to 0
+  eq(-44, PX.axis_offset(true, false, 0, 0, 600, 640, 4096, 256)) # 300 % 256 = 44
+end
+
+check 'autoscroll pixel delta follows the speed field (EasyRPG scroll_amt/32)' do
+  eq 0, PX.autoscroll_px(0, 1000)
+  eq 0, PX.autoscroll_px(nil, 1000)
+  eq(-16,  PX.autoscroll_px(4, 32))   # -(1<<4)=-16 per 32 frames
+  eq(-256, PX.autoscroll_px(8, 32))   # -(1<<8)=-256
+  eq 4,    PX.autoscroll_px(-2, 32)   # +(1<<2)=4
+end
+
+check 'a looping panorama with autoscroll drifts over time and stays in range' do
+  img = 256
+  (0..600).step(30).each do |frame|
+    off = PX.axis_offset(true, true, 4, frame, 0, 640, 4096, img)
+    ok off <= 0 && off > -img, "offset #{off} out of (-#{img}, 0]"
+  end
+end
+
+check 'a zero-size or absent panorama axis offsets to 0' do
+  eq 0, PX.axis_offset(true, false, 0, 0, 100, 640, 4096, 0)
+  eq 0, PX.axis_offset(false, false, 0, 0, 100, 640, 4096, nil)
+end
+
 if $failures.zero?
   puts "rpg2k render check: #{$checks} checks passed"
   exit 0

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -183,14 +183,15 @@ def move_route(cmd_ids, repeat: true, skippable: true)
   OpenStruct.new(commands: cmds, repeat: repeat, skippable: skippable)
 end
 
-# A 6x5 map, all tiles walkable, holding the given events (id => ev).
-def fake_map(id, events)
+# A 6x5 map, all tiles walkable, holding the given events (id => ev). `parallax`
+# is an optional hash of MAP_UNIT parallax fields merged onto the unit.
+def fake_map(id, events, parallax: nil)
   w = 6; h = 5
-  unit = OpenStruct.new(width: w, height: h, chipset_id: 1,
-                        lower_layer: Array.new(w * h, 0),
-                        upper_layer: Array.new(w * h, 0),
-                        events: events)
-  Game::Map.new(id, unit)
+  fields = { width: w, height: h, chipset_id: 1,
+             lower_layer: Array.new(w * h, 0),
+             upper_layer: Array.new(w * h, 0), events: events }
+  fields.merge!(parallax) if parallax
+  Game::Map.new(id, OpenStruct.new(fields))
 end
 
 # A minimal parent (stands in for the RPG2k app) and party leader. load_map is
@@ -218,10 +219,10 @@ def fake_party
   OpenStruct.new(leader: nil, actors: [])
 end
 
-def new_scene(events, player: [0, 0], common: nil)
+def new_scene(events, player: [0, 0], common: nil, parallax: nil)
   db = fake_db(common)
   state = Game::State.new(fake_party, 1, player[0], player[1])
-  state.map = fake_map(1, events)
+  state.map = fake_map(1, events, parallax: parallax)
   RPG2k::Scene::Map.new(fake_parent(db), state)
 end
 
@@ -819,6 +820,26 @@ check 'a continuous-animation event advances even while standing still' do
   e = event_hashes(scene)[1]
   eq [2, 2], [e[:char].x, e[:char].y], 'it did not move'
   ok e[:anim_phase] != 0, 'but its walk animation kept cycling'
+end
+
+check 'a map with a looping, autoscrolling parallax renders without raising' do
+  scene = new_scene({}, parallax: {
+    parallax_flag: true, parallax_name: 'BG',
+    parallax_loop_x: true, parallax_loop_y: true,
+    parallax_autoloop_x: true, parallax_sx: 4,
+    parallax_autoloop_y: false, parallax_sy: 0
+  })
+  ok scene.instance_variable_get(:@parallax_sprite), 'a parallax sprite is built'
+  ok scene.instance_variable_get(:@parallax_sprite).z < 0, 'drawn behind the tiles'
+  20.times { scene.update } # exercises the tiling + autoscroll draw path
+  ok true
+end
+
+check 'a map with no parallax builds no backdrop sprite' do
+  scene = new_scene({})
+  ok scene.instance_variable_get(:@parallax_sprite).nil?, 'no parallax sprite'
+  5.times { scene.update }
+  ok true
 end
 
 check 'rendering a map with charset + tile-substitution events does not raise' do


### PR DESCRIPTION
## Summary

Continues the Nepheshel rendering work (after #172 event sprites, #175 event interpolation). RPG2000 maps with a parallax flag drew **nothing behind the tiles** — the `Panorama/<name>` backdrop was missing, so transparent tiles and map edges showed the plain void. This draws it.

- **`Game::Parallax`** (new, pure geometry) ports EasyRPG Player's parallax model. `axis_offset` returns the per-axis top-left offset to start tiling the image:
  - a **looping** axis tiles the image and scrolls it at **half the camera rate** with optional time-based **autoscroll** (`parallax_sx`/`parallax_sy`);
  - a **non-looping** axis **anchors** it — fixed to the screen for the common full-screen (640×480) backdrop, panned across its excess for a larger image.
- **`Scene::Map`** loads `Panorama/<name>` into a screen-sized sprite at `z = -1` (behind the lower tile layer), computes the offset each frame (`@anim_frame` drives autoscroll) and tiles the image into the backdrop buffer. Maps with no parallax build no backdrop sprite (unchanged void).

## Grounding in real data

Across all 543 Nepheshel maps: **45 use a parallax**, and **all 45 images resolve** to real `Panorama/*.png` files. Sweeping the camera over each map for both axes and several frames, **every computed offset stays in the valid tiling range `(-img, 0]`** — 0 out-of-range samples.

## Testing

Pure-Ruby; exercised under CRuby by the host harnesses (the native SDL/mruby binary can't be built here):

- `ruby scripts/rpg2k_render_check.rb` — 29 checks ✓ (fixed-backdrop, wider-than-screen pan, half-rate loop + wrap, autoscroll delta, in-range drift, zero/absent image)
- `ruby scripts/rpg2k_logic_check.rb` — 114 ✓
- `ruby scripts/rpg2k_scene_check.rb` — 41 ✓ (a looping+autoscrolling parallax map renders; a no-parallax map builds no backdrop)

## Note / follow-up

The scroll **rate** mirrors EasyRPG's formulae, but — as with the earlier tilemap/sprite work — it hasn't been visually diffed against `RPG_RT.exe` under wine (not runnable in this environment). That native comparison is the remaining validation; the offsets are pinned and data-validated in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS)_