### PR TITLE
Write LcfSaveData back out: an LCF serializer verified against real saves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,12 @@ Create ADRs in /docs/adr for:
   it lists documented vs. undocumented top-level chunks and reads every
   documented field. Synthetic blobs cannot catch a mistyped field, so validate
   against genuine output.
+- The save layer can also **write** `.lsd` (`mruby-lcf` `to_lcf` / `write_ber` /
+  `encode` / `Array1D#[]=`, ADR 0018). Verify the writer with
+  `ruby scripts/lcf_save_roundtrip.rb <path/to/Save01.lsd>`: it re-serializes a
+  real save byte-for-byte and edits+reloads scalar fields through the schema.
+  Because unedited chunks (including the undocumented 102/112/200) are copied
+  raw, the round-trip is exact without those chunks being documented.
 - Generate a real save headlessly with `./scripts/gen-lcf-save-wine.bash`: it
   boots a game's EasyRPG Player under wine (Xvfb + `matchbox-window-manager` so
   the SDL window gets input focus) with `--test-play` and uses the **debug menu**

--- a/changelog.d/lcf-save-writer.added.md
+++ b/changelog.d/lcf-save-writer.added.md
@@ -1,0 +1,13 @@
+- The LCF layer can now **write** `LcfSaveData`, not just read it. New inverse
+  primitives in `mruby-lcf` -- `LCF.write_ber` (the exact inverse of `read_ber`),
+  `LCF.encode` for scalar/simple-array field types, `Array1D#to_lcf` /
+  `Array2D#to_lcf` / `File#to_lcf` / `File#save_to`, and `Array1D#[]=` to edit a
+  parsed save through its schema -- serialize a save back to bytes. Because the
+  reader keeps every chunk's raw payload (including the undocumented chunks 102,
+  112, 200), a save read and re-serialized reproduces the original **byte for
+  byte**: `scripts/lcf_save_roundtrip.rb` proves this against the real RPG2000
+  (Nepheshel, 17797 B) and RPG2003 (mtf-meido-action, 11132 B) fixtures, and also
+  edits the hero position / save counter through the schema and confirms the
+  change survives a write/reload. `scripts/gen-lcf-save-wine.bash` runs the
+  round-trip harness after generating a save. This is the serializer a future
+  real-format in-game Save (`Game::State#to_lsd`) will build on. See ADR 0018.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -200,8 +200,13 @@ The work below is roughly ordered by the critical path to a walkable game
   on and persist in the save)
 - 🚧 Save & Continue — implemented with a portable `Marshal` save of the game
   state (`Game::State#to_h` / `State.load`) written via the menu's Save command;
-  "Continue" reloads it. Reading/writing the real `LCF::SaveData` (`.lsd`) format
-  is still TODO
+  "Continue" reloads it. **Reading** the real `LCF::SaveData` (`.lsd`) is done
+  (`Game::State.from_lsd`). **Writing** it now has its LCF foundation: `mruby-lcf`
+  can serialize a save back to bytes (`Array1D`/`Array2D`/`File#to_lcf`,
+  `LCF.write_ber`/`encode`, `Array1D#[]=`), proven byte-exact against the real
+  2000/2003 saves by `scripts/lcf_save_roundtrip.rb` (ADR 0018). The remaining
+  step is a `Game::State#to_lsd` that builds the `SAVE_DATA` chunks from live game
+  state and calls `SaveData#save_to`, replacing the `Marshal` save
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations, game-over scene (large; Nepheshel uses the default RPG2000
   battle). Needs real assets + the native build to develop against

--- a/docs/adr/0018-lcf-save-data-writer.md
+++ b/docs/adr/0018-lcf-save-data-writer.md
@@ -1,0 +1,100 @@
+# 18. Write LcfSaveData back out: an LCF serializer verified against real saves
+
+Date: 2026-08-04
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0009-0017 built the `LcfSaveData` **read** path: the `SAVE_DATA` schema
+(`mruby-lcf/mrblib/schema.rb`), the chunk/BER decoders (`mruby-lcf/mrblib/lcf.rb`),
+and validation against genuine RPG Maker 2000 (Nepheshel) and 2003
+(mtf-meido-action) saves via `scripts/lcf_save_check.rb`. `Game::State.from_lsd`
+loads a parsed save into the running game, so **Continue** can already resume a
+real `.lsd`.
+
+The write path did not exist. `mruby-lcf` was parse-only, and the in-game **Save**
+command still persists a portable `Marshal` dump of `Game::State`, not the real
+`.lsd` format (see `docs/TODO.md`, "Save & Continue"). Before the runtime can
+save in the genuine format, the LCF layer needs to be able to turn a parsed
+(or edited) save structure back into byte-faithful `LcfSaveData` -- and that
+serializer has to be *proven* against real files, exactly as the reader was, or
+a subtly wrong writer would produce saves the real editor/EasyRPG rejects.
+
+The key enabler is already in the reader: `Array1D`/`Array2D` retain every
+chunk's **raw payload bytes** (`@data[idx] = s.read len`) for *every* chunk,
+documented or not -- decoding is lazy, per field, on access. The still
+-undocumented top-level chunks (102, 112, 200) are therefore held verbatim, not
+discarded. So a faithful copy needs no understanding of those chunks and no
+field-level re-encoding: re-emit the retained raw bytes with correct framing.
+
+Two framing details had to be pinned down against the real fixtures:
+
+- **Chunk order.** Both real saves store their top-level chunks in strictly
+  ascending id order, so emitting `@data` by ascending index reproduces it.
+- **Top-level terminator.** An `Array1D` embedded in an `Array2D` is closed by a
+  `write_ber(0)` terminator (entries carry no length prefix, so the reader scans
+  until id 0). The **top level of a save file has no such terminator** -- the
+  chunk list runs to EOF, and the reader stops on `eof?`. Emitting a terminator
+  there adds one spurious trailing byte; both real fixtures confirm its absence.
+
+## Decision
+
+- **Add the inverse primitives to `mruby-lcf/mrblib/lcf.rb`:** `LCF.write_ber`
+  (the exact inverse of `read_ber`, including the 32-bit two's-complement form
+  so negatives round-trip -- `-1` -> `8f ff ff ff 7f`, as RPG_RT writes), plus
+  `LCF.encode` / `LCF.pack_int32` for the scalar and simple-array field types a
+  save actually re-authors (`:int`, `:bool`, `:uint8`, `:int8_array`,
+  `:bool_array`, `:int32_array`, `:string`). Packed command / `:double` / `:Tree`
+  fields are intentionally not re-encoded from decoded values; they are preserved
+  as their original raw bytes.
+- **Serialize structurally:** `Array1D#to_lcf(terminate = true)` re-emits present
+  chunks ascending as `write_ber(id) + write_ber(len) + bytes` (raw bytes for
+  unedited chunks; a nested object's own `#to_lcf` otherwise), with the
+  terminator suppressible; `Array2D#to_lcf` writes the count-prefixed entry list;
+  `File#to_lcf` prefixes the BER-length header and serializes the root
+  Array1D **without** a top-level terminator. `File#save_to(path)` writes it.
+- **Edit in place:** `Array1D#[]=` encodes a Ruby value through the field's schema
+  type and stores it as that chunk's raw bytes, so a parsed save can be modified
+  (e.g. hero position, save counter) and written back.
+- **String encoding mirrors the reader.** As `cp932_to_utf8` (uni-algo) decodes
+  on read, `LCF.utf8_to_cp932` encodes `:string` fields on write; the CRuby
+  harnesses provide a Windows-31J stand-in, symmetric with the existing read stub.
+- **Portability.** Byte buffers use `String.new` (ASCII-8BIT under CRuby, a plain
+  buffer under mruby) and an `LCF.binstr` coercion that is a no-op under mruby
+  (no `Encoding`); iteration uses `each_with_index` (blockless enumerators and
+  `each_index` are avoided, matching the reader's existing idiom).
+
+## Consequences
+
+- **Byte-exact round-trip on real saves.** `scripts/lcf_save_roundtrip.rb` parses
+  a genuine `.lsd`, re-serializes it, and asserts the bytes equal the original --
+  verified against both the RPG2000 (Nepheshel, 17797 B) and RPG2003
+  (mtf-meido-action, 11132 B) fixtures. Because the undocumented chunks are
+  copied verbatim, this proves the *framing* (BER lengths, ascending order, no
+  top-level terminator) is reproduced bit for bit without needing those chunks
+  documented.
+- **Edits survive a write/reload.** The same harness bumps the hero position and
+  the system save counter through the schema, writes, and re-parses -- the new
+  values load back and an untouched chunk (the title block) is byte-identical,
+  proving `LCF.encode` / `#[]=` produce a genuinely re-loadable save.
+- **CI coverage is synthetic-but-real.** The real `.lsd` fixtures are generated
+  under wine and not vendored (`data/` is git-ignored), so -- like
+  `lcf_save_check.rb` -- the round-trip harness runs on demand
+  (`scripts/gen-lcf-save-wine.bash` now runs it after generating a save), not in
+  CI. The writer's CI guard is `mruby-lcf/test/lcf_test.rb`, which exercises
+  `write_ber` against the reference encoder, `Array1D`/`Array2D#to_lcf`,
+  `Array1D#[]=`, and a whole-file `SaveData#to_lcf` round-trip on self-consistent
+  synthetic data run by the native `test` target.
+- **Save & Continue can now target the real format.** The remaining work is a
+  `Game::State#to_lsd` that builds a `SAVE_DATA` structure from live game state
+  and calls `SaveData#save_to`, replacing the portable `Marshal` save -- a
+  runtime-side change that this LCF serializer makes possible. Until then the
+  writer is exercised by the round-trip harness and unit tests.
+- **The writer stays honest about what it can re-encode.** Packed event/move
+  command lists, doubles (the save timestamp) and tree chunks are round-tripped
+  as raw bytes but not yet re-encodable from decoded values; a future change that
+  needs to author those from scratch must add their encoders (and prove them the
+  same way).

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -298,7 +298,7 @@ module LCF
     when :int32_array ; pack_int32 value
     when :string ; utf8_to_cp932 value
     when :Array1D, :Array2D
-      return value.dup.force_encoding('BINARY') if value.is_a? String
+      return binstr(value) if value.is_a? String
       value.to_lcf
     else
       raise "cannot encode type: #{type}"
@@ -376,7 +376,7 @@ module LCF
       if elem
         @data[idx] = LCF.encode(value, elem[:type])
       elsif value.is_a? String
-        @data[idx] = value.dup.force_encoding('BINARY')
+        @data[idx] = LCF.binstr(value)
       else
         raise "cannot encode chunk #{idx} without a schema"
       end
@@ -398,11 +398,11 @@ module LCF
     def to_lcf terminate = true
       out = String.new
       @data.each_with_index do |v, idx|
-        next if idx.zero? || v.nil?
+        next if idx == 0 || v.nil?
         bytes = LCF.binstr(v.is_a?(String) ? v : v.to_lcf)
-        out << LCF.write_ber(idx) << LCF.write_ber(bytes.bytesize) << bytes
+        out = out + LCF.write_ber(idx) + LCF.write_ber(bytes.bytesize) + bytes
       end
-      out << LCF.write_ber(0) if terminate
+      out = out + LCF.write_ber(0) if terminate
       out
     end
 
@@ -446,11 +446,11 @@ module LCF
     def to_lcf
       ids = []
       @data.each_with_index { |v, i| ids.push(i) unless v.nil? }
-      out = String.new << LCF.write_ber(ids.size)
+      out = LCF.write_ber(ids.size)
       ids.each do |i|
         entry = @data[i]
         bytes = LCF.binstr(entry.is_a?(String) ? entry : entry.to_lcf)
-        out << LCF.write_ber(i) << bytes
+        out = out + LCF.write_ber(i) + bytes
       end
       out
     end

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -27,6 +27,26 @@ module LCF
     [ret].pack('L').unpack1('l')
   end
 
+  # Inverse of read_ber: encode an integer as a base-128 (BER) big-endian byte
+  # string, every byte but the last carrying the 0x80 continuation bit. The
+  # value is first reduced to its 32-bit two's-complement form so that negative
+  # numbers round-trip through read_ber (which reinterprets the low 32 bits as
+  # signed) -- e.g. -1 becomes the five bytes 8f ff ff ff 7f, exactly as RPG_RT
+  # writes it. Non-negative numbers use the shortest encoding (RPG_RT's own),
+  # so a value read from a real file re-encodes to the identical bytes.
+  def write_ber(n)
+    n &= 0xffff_ffff
+    groups = [n & 0x7f]
+    while n > 0x7f
+      n >>= 7
+      groups.unshift(n & 0x7f)
+    end
+    last = groups.size - 1
+    bytes = []
+    groups.each_with_index { |g, i| bytes << (i < last ? (g | 0x80) : g) }
+    bytes.pack('C*')
+  end
+
   class Tree
     def initialize(selected_id, maps)
       @selected_id = selected_id
@@ -239,8 +259,55 @@ module LCF
     sign == 1 ? -val : val
   end
 
-  module_function :read_ber, :to_rb, :read_section, :parse_event_commands,
-                  :parse_move_commands, :unpack_int32, :unpack_double
+  # Coerce a value to a raw byte string safe to concatenate with other byte
+  # strings. Under CRuby (the analysis harnesses) this re-tags it ASCII-8BIT so
+  # appending cp932 bytes to a binary buffer does not raise on encoding
+  # mismatch; under mruby (no Encoding class) strings are already raw bytes and
+  # #force_encoding is absent, so it is a no-op.
+  def binstr s
+    s = s.to_s
+    s.respond_to?(:force_encoding) ? s.dup.force_encoding('BINARY') : s
+  end
+
+  # Encode an array of signed 32bit integers as packed little-endian bytes --
+  # the inverse of unpack_int32 (used for the save file's variable table).
+  def pack_int32 a
+    out = []
+    a.each do |v|
+      v &= 0xffff_ffff
+      out.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff)
+    end
+    out.pack('C*')
+  end
+
+  # Encode a Ruby value back to the raw chunk bytes for a schema field -- the
+  # inverse of to_rb. Only the scalar and simple-array types a save actually
+  # needs to be re-authored are handled; the packed command/double/tree types
+  # are still round-tripped as their original raw bytes (never re-encoded from
+  # decoded values), so they are intentionally left out. A nested :Array1D /
+  # :Array2D value is serialised through its own #to_lcf. Strings go back out
+  # as cp932 via LCF.utf8_to_cp932 (the build's uni-algo encoder; the CRuby
+  # harnesses provide a Windows-31J stand-in), mirroring cp932_to_utf8 on read.
+  def encode value, type
+    case type
+    when :int ; write_ber value
+    when :bool ; [value ? 1 : 0].pack('C')
+    when :uint8 ; [value & 0xff].pack('C')
+    when :int8_array ; value.pack('C*')
+    when :bool_array ; value.map { |b| b ? 1 : 0 }.pack('C*')
+    when :int32_array ; pack_int32 value
+    when :string ; utf8_to_cp932 value
+    when :Array1D, :Array2D
+      return value.dup.force_encoding('BINARY') if value.is_a? String
+      value.to_lcf
+    else
+      raise "cannot encode type: #{type}"
+    end
+  end
+
+  module_function :read_ber, :write_ber, :to_rb, :read_section,
+                  :parse_event_commands, :parse_move_commands,
+                  :unpack_int32, :unpack_double, :pack_int32, :encode, :binstr
 
   MODE = 2000 # 2003
 
@@ -301,6 +368,44 @@ module LCF
       d && d.unpack('s<*')
     end
 
+    # Set the raw bytes of a chunk from a Ruby value, encoding it through the
+    # schema type of that field (LCF.encode) so an authored/edited section can
+    # be written back out. With no schema attached a raw String is stored as-is.
+    def []= idx, value
+      elem = @schema && @schema[:elements] && @schema[:elements][idx]
+      if elem
+        @data[idx] = LCF.encode(value, elem[:type])
+      elsif value.is_a? String
+        @data[idx] = value.dup.force_encoding('BINARY')
+      else
+        raise "cannot encode chunk #{idx} without a schema"
+      end
+      value
+    end
+
+    # Serialise back to the on-disk chunk stream: every present chunk in
+    # ascending id order as write_ber(id) + write_ber(len) + bytes. Chunks are
+    # stored as their original raw bytes, so a file read and re-serialised
+    # without edits reproduces byte-for-byte; an edited chunk (see #[]=) carries
+    # only its own re-encoded bytes. A chunk whose value is a nested
+    # Array1D/Array2D is serialised through that object's own #to_lcf.
+    #
+    # When +terminate+ a write_ber(0) terminator is appended. That terminator is
+    # required for an Array1D embedded in an Array2D, where entries carry no
+    # length prefix and the reader scans until id 0; it is omitted at the top
+    # level of a save file, whose chunk list runs to EOF with no terminator (a
+    # real RPG2000/2003 .lsd ends on the last chunk's bytes).
+    def to_lcf terminate = true
+      out = String.new
+      @data.each_with_index do |v, idx|
+        next if idx.zero? || v.nil?
+        bytes = LCF.binstr(v.is_a?(String) ? v : v.to_lcf)
+        out << LCF.write_ber(idx) << LCF.write_ber(bytes.bytesize) << bytes
+      end
+      out << LCF.write_ber(0) if terminate
+      out
+    end
+
     def method_missing sym, *args
       raise args unless args.empty?
       self[@sym2idx[sym]]
@@ -333,5 +438,21 @@ module LCF
       end
     end
     include Enumerable
+
+    # Serialise back to the on-disk layout: write_ber(entry count) followed by,
+    # for each defined entry in ascending id order, write_ber(id) and the
+    # entry's own Array1D#to_lcf (which supplies its trailing terminator). The
+    # inverse of the reader; an unedited table reproduces its original bytes.
+    def to_lcf
+      ids = []
+      @data.each_with_index { |v, i| ids.push(i) unless v.nil? }
+      out = String.new << LCF.write_ber(ids.size)
+      ids.each do |i|
+        entry = @data[i]
+        bytes = LCF.binstr(entry.is_a?(String) ? entry : entry.to_lcf)
+        out << LCF.write_ber(i) << bytes
+      end
+      out
+    end
   end
 end

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1196,8 +1196,7 @@ module LCF
     def to_lcf
       raise 'section-based file serialization not implemented' if schema.is_a? Array
       root = @root.is_a?(LCF::Array1D) ? @root.to_lcf(false) : @root.to_lcf
-      out = String.new << LCF.write_ber(header.bytesize)
-      out << LCF.binstr(header) << LCF.binstr(root)
+      LCF.write_ber(header.bytesize) + LCF.binstr(header) + LCF.binstr(root)
     end
 
     # Write #to_lcf to a path (binary). Uses ::File since LCF::File shadows it.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1187,6 +1187,24 @@ module LCF
     def header; raise end
     def schema; raise end
 
+    # Serialise the whole file back to bytes: the BER-length-prefixed header
+    # string followed by the root object's own serialisation. The inverse of
+    # #initialize; a file read and written back without edits reproduces it
+    # byte-for-byte. The top-level chunk list runs to EOF with no terminator
+    # (matching a real .lsd), so the root Array1D is serialised with
+    # terminate=false. Multi-section (Array-schema) files are not yet writable.
+    def to_lcf
+      raise 'section-based file serialization not implemented' if schema.is_a? Array
+      root = @root.is_a?(LCF::Array1D) ? @root.to_lcf(false) : @root.to_lcf
+      out = String.new << LCF.write_ber(header.bytesize)
+      out << LCF.binstr(header) << LCF.binstr(root)
+    end
+
+    # Write #to_lcf to a path (binary). Uses ::File since LCF::File shadows it.
+    def save_to path
+      ::File.open(path, 'wb') { |f| f.write to_lcf }
+    end
+
     def method_missing sym, *args
       # Use __send__ rather than send: some mruby builds do not expose Kernel#send
       # on objects that define their own method_missing (Array1D / Sections),

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -420,3 +420,82 @@ assert "LCF::SaveData decodes per-actor level/exp/skills/HP/MP (chunk 108)" do
   # Absent optional vitals read as nil, so the runtime restore leaves them alone.
   assert_nil save.actors[1].skills
 end
+
+# ---- LCF binary format WRITER (inverse of the readers, ADR 0018) -----------
+# uni-algo stand-in for the reverse transcoder, mirroring the cp932_to_utf8 the
+# harness relies on for reads; the writer only needs it for :string fields.
+module LCF
+  def utf8_to_cp932(s); s.dup; end
+  module_function :utf8_to_cp932
+end
+
+assert 'LCF.write_ber matches the reference encoder and round-trips read_ber' do
+  # write_ber is the exact inverse of read_ber; cross-check it against lcf_ber
+  # (the test's own reference encoder) and prove read(write(n)) == n.
+  [0, 1, 0x7f, 0x80, 0x3fff, 0x4000, 100, 200, 123_456, -1, -2, -1000].each do |n|
+    assert_equal lcf_ber(n), LCF.write_ber(n)
+    assert_equal n, LCF.read_ber(StringIO.new(LCF.write_ber(n)))
+  end
+  # The documented edge vectors, byte for byte (see the "Read BER number" test).
+  assert_equal "\x7f", LCF.write_ber(0x7f)
+  assert_equal "\x81\x00", LCF.write_ber(0x80)
+  assert_equal "\x8f\xff\xff\xff\x7f", LCF.write_ber(-1)
+end
+
+assert 'Array1D#to_lcf reproduces its source bytes (terminated and not)' do
+  body = lcf_array1d([lcf_int_field(12, 5), lcf_int_field(13, 7),
+                      lcf_str_field(73, "chr")])
+  a = LCF::Array1D.new(body, nil)
+  # As embedded in an Array2D: keep the trailing 0 terminator.
+  assert_equal body, a.to_lcf
+  # As at the top level of a save file: no terminator.
+  assert_equal body[0...-1], a.to_lcf(false)
+end
+
+assert 'Array1D#[]= re-encodes int and string fields through the schema' do
+  schema = { elements: LCF::Schema::SAVE_MOVABLE }
+  a = LCF::Array1D.new(lcf_array1d([lcf_int_field(12, 5), lcf_int_field(13, 7),
+                                    lcf_str_field(73, "old")]), schema)
+  assert_equal 5, a.x
+  a[12] = 9                 # :int field
+  a[73] = "newchr"          # :string field (exercises LCF.encode + utf8_to_cp932)
+  assert_equal 9, a.x
+  reread = LCF::Array1D.new(a.to_lcf, schema)
+  assert_equal 9, reread.x
+  assert_equal 7, reread.y             # untouched field preserved
+  assert_equal "newchr", reread.charset_name
+end
+
+assert 'Array2D#to_lcf reproduces its source bytes' do
+  e1 = lcf_array1d([lcf_int_field(31, 1)])
+  e3 = lcf_array1d([lcf_int_field(31, 5), lcf_int_field(32, 307)])
+  body = lcf_array2d([[1, e1], [3, e3]])
+  a = LCF::Array2D.new(body, { elements: LCF::Schema::SAVE_PARTY_ACTOR })
+  assert_equal body, a.to_lcf
+end
+
+assert 'SaveData#to_lcf round-trips a whole file byte-for-byte' do
+  # A real .lsd has no top-level terminator: the chunk list runs to EOF.
+  title = lcf_array1d([lcf_str_field(11, "Hero"), lcf_int_field(12, 3)])
+  sys   = lcf_array1d([lcf_int_field(131, 1)])
+  hero  = lcf_array1d([lcf_int_field(12, 11), lcf_int_field(13, 7)])
+  body  = lcf_field(100, title) + lcf_field(101, sys) + lcf_field(104, hero)
+  file  = lcf_ber("LcfSaveData".bytesize) + "LcfSaveData" + body
+  save  = LCF::SaveData.new(StringIO.new(file))
+  assert_equal file, save.to_lcf
+end
+
+assert 'SaveData edit survives a write/reload round-trip' do
+  sys   = lcf_array1d([lcf_int_field(131, 1)])
+  hero  = lcf_array1d([lcf_int_field(12, 11), lcf_int_field(13, 7)])
+  body  = lcf_field(101, sys) + lcf_field(104, hero)
+  save  = LCF::SaveData.new(lcf_file("LcfSaveData", body))
+
+  h = save[104]; h[12] = 42;               save[104] = h
+  s = save[101]; s[131] = s.save_count + 1; save[101] = s
+
+  reread = LCF::SaveData.new(StringIO.new(save.to_lcf))
+  assert_equal 42, reread.hero.x
+  assert_equal 7, reread.hero.y          # untouched field preserved
+  assert_equal 2, reread[101].save_count
+end

--- a/scripts/gen-lcf-save-wine.bash
+++ b/scripts/gen-lcf-save-wine.bash
@@ -159,3 +159,6 @@ echo "Wrote ${GAME_DIR}/${LSD}"
 
 # Analyse the genuine save with the same parser the runtime uses.
 ruby scripts/lcf_save_check.rb "${GAME_DIR}/${LSD}"
+
+# Prove the writer against it too: re-serialise byte-for-byte and edit/reload.
+ruby scripts/lcf_save_roundtrip.rb "${GAME_DIR}/${LSD}"

--- a/scripts/lcf_save_roundtrip.rb
+++ b/scripts/lcf_save_roundtrip.rb
@@ -1,0 +1,166 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Prove the LCF save-data *writer* against real Save<N>.lsd files.
+#
+# scripts/lcf_save_check.rb established that the read path (ADR 0009, the
+# `SAVE_DATA` schema) decodes a genuine RPG Maker 2000/2003 save. This harness
+# exercises the inverse -- LCF.write_ber / Array1D#to_lcf / Array2D#to_lcf /
+# File#to_lcf (ADR 0018) -- in two ways:
+#
+#   1. Byte-exact round-trip: parse a real .lsd and re-serialise it; the bytes
+#      must equal the original file exactly. Because the reader keeps every
+#      chunk's raw payload (documented or not -- e.g. the still-undocumented
+#      chunks 102, 112, 200), a faithful copy needs no field-level re-encoding,
+#      so this proves the framing (BER lengths, ascending chunk order, the
+#      trailing terminator) is reproduced bit for bit.
+#
+#   2. Semantic edit: change scalar fields through the schema (hero position and
+#      the system save counter), write the save, read it back, and confirm the
+#      new values survive while an untouched chunk is unchanged. This proves the
+#      value encoders (LCF.encode) and #[]= produce a genuinely re-loadable save.
+#
+# The only native dependency is cp932 transcoding (uni-algo in the real build);
+# here Ruby's Windows-31J codec stands in, in both directions.
+#
+# Usage:
+#   ruby scripts/lcf_save_roundtrip.rb [SAVE.lsd ...]
+# With no arguments it scans ./data for Save*.lsd files. Exits non-zero on any
+# byte mismatch, failed edit, or parse error.
+
+require 'stringio'
+
+module LCF
+  # uni-algo stand-ins: transcode between Shift_JIS (Windows-31J) and UTF-8,
+  # degrading unmappable input rather than aborting, mirroring the native codec.
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+
+  def utf8_to_cp932(s)
+    s.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+mrblib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(mrblib, 'lcf.rb')
+load File.join(mrblib, 'schema.rb')
+
+class RoundTripper
+  attr_reader :errors
+
+  # Save-file chunk / field ids used by the semantic-edit test.
+  SYSTEM       = 101   # SAVE_DATA -> system (SAVE_SYSTEM)
+  HERO         = 104   # SAVE_DATA -> hero (SAVE_MOVABLE)
+  SAVE_COUNT   = 131   # SAVE_SYSTEM -> save_count (:int)
+  HERO_X       = 12    # SAVE_MOVABLE -> x (:int)
+
+  def initialize
+    @errors = 0
+    @files = 0
+  end
+
+  def fail(msg)
+    @errors += 1
+    warn "  FAIL #{msg}"
+  end
+
+  def first_diff(a, b)
+    len = [a.bytesize, b.bytesize].min
+    i = 0
+    i += 1 while i < len && a.getbyte(i) == b.getbyte(i)
+    i
+  end
+
+  def check(path)
+    puts "== #{path} =="
+    original = File.binread(path)
+
+    # 1. Byte-exact round-trip.
+    save = LCF::SaveData.new(StringIO.new(original))
+    rebuilt = save.to_lcf
+    if rebuilt == original
+      puts "  round-trip: byte-exact (#{original.bytesize} bytes)"
+    else
+      off = first_diff(original, rebuilt)
+      fail "round-trip differs at byte #{off}: " \
+           "orig=#{original.bytesize}B (#{fmt_byte(original, off)}) " \
+           "rebuilt=#{rebuilt.bytesize}B (#{fmt_byte(rebuilt, off)})"
+    end
+
+    # 2. Semantic edit: bump hero X and the save counter, then reload.
+    edit = LCF::SaveData.new(StringIO.new(original))
+    hero = edit[HERO]
+    sys  = edit[SYSTEM]
+    old_x     = hero.x.to_i
+    old_count = sys.save_count.to_i
+
+    hero[HERO_X]      = old_x + 1
+    sys[SAVE_COUNT]   = old_count + 1
+    edit[HERO]        = hero
+    edit[SYSTEM]      = sys
+
+    reread = LCF::SaveData.new(StringIO.new(edit.to_lcf))
+    new_x     = reread.hero.x.to_i
+    new_count = reread[SYSTEM].save_count.to_i
+    if new_x == old_x + 1 && new_count == old_count + 1
+      puts "  edit: hero.x #{old_x} -> #{new_x}, save_count #{old_count} -> #{new_count} (reloaded OK)"
+    else
+      fail "edit did not survive reload: hero.x #{old_x}->#{new_x} " \
+           "(want #{old_x + 1}), save_count #{old_count}->#{new_count} (want #{old_count + 1})"
+    end
+
+    # An untouched chunk (the title block) must be byte-identical after the edit.
+    orig_title = LCF::SaveData.new(StringIO.new(original))
+                             .instance_variable_get(:@root)
+                             .instance_variable_get(:@data)[100]
+    edit_title = reread.instance_variable_get(:@root)
+                       .instance_variable_get(:@data)[100]
+    if orig_title == edit_title
+      puts "  edit: untouched title chunk unchanged"
+    else
+      fail 'editing hero/system perturbed the untouched title chunk'
+    end
+
+    @files += 1
+  rescue => ex
+    fail "#{path}: #{ex.class}: #{ex.message}\n    #{ex.backtrace.first}"
+  end
+
+  def fmt_byte(s, off)
+    off < s.bytesize ? format('0x%02x', s.getbyte(off)) : 'EOF'
+  end
+
+  def report
+    puts "round-tripped #{@files} save file(s)"
+    if @errors.zero?
+      puts 'OK: LCF save writer reproduces and edits real .lsd files'
+    else
+      warn "#{@errors} error(s)"
+    end
+  end
+end
+
+def discover_saves(root)
+  return [] unless Dir.exist?(root)
+  Dir.glob(File.join(root, '**', 'Save*.lsd')).sort.uniq
+end
+
+saves = ARGV.dup
+saves = discover_saves(File.expand_path('../data', __dir__)) if saves.empty?
+
+if saves.empty?
+  warn 'no Save*.lsd found (pass a path, or generate one with ' \
+       'scripts/gen-lcf-save-wine.bash -- see AGENTS.md)'
+  exit 0
+end
+
+rt = RoundTripper.new
+saves.each { |s| rt.check(s) }
+rt.report
+exit(rt.errors.zero? ? 0 : 1)


### PR DESCRIPTION
## What & why

`mruby-lcf` was parse-only, and the in-game **Save** still persists a portable `Marshal` dump rather than the real `.lsd` format (the roadmap's stated Save & Continue blocker). This adds the inverse of the reader so a parsed — or edited — save can be serialized back to **byte-faithful** `LcfSaveData`. It's the foundation a future real-format `Game::State#to_lsd` will build on; the reader (`Game::State.from_lsd`) already exists.

Follows on from the just-merged #173, which generated the real 2000/2003 `.lsd` fixtures this writer is validated against.

## Changes

- **`mruby-lcf/mrblib/lcf.rb`** — `LCF.write_ber` (exact inverse of `read_ber`, using the 32-bit two's-complement form so negatives round-trip, e.g. `-1` → `8f ff ff ff 7f` as RPG_RT writes); `LCF.encode` / `LCF.pack_int32` for the scalar/simple-array field types a save re-authors (`:int`, `:bool`, `:uint8`, `:int8_array`, `:bool_array`, `:int32_array`, `:string`); a portable `LCF.binstr` byte-coercion (no-op under mruby, which has no `Encoding`).
- **Serialization** — `Array1D#to_lcf(terminate)`, `Array2D#to_lcf`, `File#to_lcf`, `File#save_to`. Two framing facts pinned against the real fixtures: chunks are emitted in **ascending id order**, and the **top level of a save has no terminator** (the chunk list runs to EOF), while an `Array1D` nested in an `Array2D` keeps its `write_ber(0)` terminator.
- **`Array1D#[]=`** — encode a Ruby value through the field's schema type and store it as that chunk's raw bytes, so a parsed save can be edited and written back.

Because unedited chunks are copied **raw**, the still-undocumented top-level chunks (102/112/200) are preserved verbatim — the round-trip is byte-exact without those chunks being understood.

## Verification

- **`scripts/lcf_save_roundtrip.rb`** (new) proves the writer against the real saves: re-serialization is **byte-exact** — RPG2000 (Nepheshel, 17797 B) and RPG2003 (mtf-meido-action, 11132 B) — and a hero-position / save-counter edit through the schema survives a write/reload while an untouched chunk stays byte-identical. `scripts/gen-lcf-save-wine.bash` runs it after generating a save.
- **`mruby-lcf/test/lcf_test.rb`** is the CI guard (real `.lsd` fixtures are wine-generated, not vendored, so like `lcf_save_check.rb` the round-trip harness isn't in CI): `write_ber` vs the reference encoder, `Array1D`/`Array2D#to_lcf`, `Array1D#[]=` for **int and string** fields, and a whole-file `SaveData#to_lcf` round-trip on synthetic self-consistent data (run by the native `test` target).
- No read-path regression — `scripts/lcf_save_check.rb` still parses both real saves cleanly.

## Docs

ADR 0018, a changelog fragment, and AGENTS.md / `docs/TODO.md` updates. The remaining Save & Continue step — a runtime-side `Game::State#to_lsd` that builds the `SAVE_DATA` chunks from live game state and calls `SaveData#save_to` — is noted there; this serializer makes it possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_