### PR TITLE
Implement RPG2000 Weather Effects and Change Teleport/Escape Access commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
   Call Event (run a common event / another event's page), Move Event (force a
   move route onto an event or the player), Halt All Movement (cancel every forced
   route), Change / Trade Event Location (snap or swap event/player tiles), Change
-  Map Tileset (swap the map's chipset), Set
+  Map Tileset (swap the map's chipset), Weather Effects (set rain/snow type and
+  strength), Set
   Transparent Flag (hide/show the hero), Return to Title and Erase
   Event (remove an event from
   the map). Events start on the action button, on

--- a/changelog.d/rpg2k-teleport-escape-access.added.md
+++ b/changelog.d/rpg2k-teleport-escape-access.added.md
@@ -1,0 +1,8 @@
+- The **Change Teleport Access** (11820) and **Change Escape Access** (11840)
+  event commands are now handled, completing the access-flag family alongside
+  Change Main Menu / Save Access. Each toggles a `Game::State` flag
+  (`teleport_access` / `escape_access`) from `param0`; both default off (RPG2000
+  games enable the skills once their targets are set) and round-trip through
+  Save / Continue. The Teleport and Escape skills are not executed yet, so these
+  gate nothing at runtime — they are modelled for save fidelity. Covered by new
+  checks in `scripts/rpg2k_logic_check.rb`.

--- a/changelog.d/rpg2k-weather-effects.added.md
+++ b/changelog.d/rpg2k-weather-effects.added.md
@@ -1,0 +1,9 @@
+- The **Weather Effects** (11070) event command is now handled: it records the
+  map weather type (param0 — 0 none, 1 rain, 2 snow, higher values for the
+  RPG2003 additions) and strength (param1 — 0 weak .. 2 strong) on a new
+  `Game::Weather` model held by `Game::State`. Non-blocking, and the setting
+  round-trips through Save / Continue (defaulting to none on a save written
+  before it existed). Like the picture and screen-tint overlays this is the
+  Ruby-half model only — compositing the rain/snow particles is native (C++)
+  renderer work still to come. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -124,8 +124,9 @@ The work below is roughly ordered by the critical path to a walkable game
   Store Terrain/Event ID, Wait, Play BGM/SE, Memorize / Play Memorized BGM,
   Message Options, Change Face Graphic, Input Number, Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
-  Tint Screen, Flash Screen, Shake Screen, Call Event, Move Event, Change / Trade
-  Event Location, Change Map Tileset, Proceed With Movement, Halt All Movement,
+  Tint Screen, Flash Screen, Shake Screen, Weather Effects, Call Event, Move
+  Event, Change / Trade Event Location, Change Map Tileset, Proceed With
+  Movement, Halt All Movement,
   Erase Event, Return to Title, End Event) with a per-frame step cap so a bad
   loop can't hang. **Memorize Location** stores the player's current map id, x and y
   into three variables, and **Recall to Location** teleports back to a location
@@ -164,9 +165,12 @@ The work below is roughly ordered by the critical path to a walkable game
   spirit / agility) and **game quantities** (party gold, timer seconds).
   Conditional Branch covers switch / variable / **timer** / gold / item
   conditions and the **actor** sub-conditions (in party, name, level ≥, HP ≥,
-  item equipped, skill known; state is not modelled). The remaining commands
-  (pictures, weather, battles, shop / inn, EXP gain / level-up messages, ...) are
-  TODO
+  item equipped, skill known; state is not modelled). **Weather Effects** (11070)
+  records the map weather type (none / rain / snow) and strength on `Game::State`
+  — the Ruby-half model only, like the tint overlay, so it round-trips through the
+  save but drawing the rain/snow particles is native renderer work still to come.
+  The remaining commands (pictures, battles, shop / inn, EXP gain / level-up
+  messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   speed/wait codes are consumed). Text now **reveals gradually** (a

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -124,6 +124,7 @@ The work below is roughly ordered by the critical path to a walkable game
   Store Terrain/Event ID, Wait, Play BGM/SE, Memorize / Play Memorized BGM,
   Message Options, Change Face Graphic, Input Number, Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
+  Change Teleport / Escape Access,
   Tint Screen, Flash Screen, Shake Screen, Weather Effects, Call Event, Move
   Event, Change / Trade Event Location, Change Map Tileset, Proceed With
   Movement, Halt All Movement,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1715,8 +1715,39 @@ module Game
 
   # The overall running-game state: who is in the party and where they are,
   # plus the global switches and variables.
+  # Map weather set by the Weather Effects (11070) event command: a type (0 none,
+  # 1 rain, 2 snow; the RPG2003 additions store as higher values) and a strength
+  # (0 weak .. 2 strong). Like the picture / tint overlays this is the Ruby-half
+  # model only — drawing the rain/snow particles is native renderer work still to
+  # come — but it round-trips through the save so a reloaded game keeps its
+  # weather.
+  class Weather
+    attr_reader :type, :strength
+
+    def initialize(type = 0, strength = 0)
+      @type = type
+      @strength = strength
+    end
+
+    def set(type, strength)
+      @type = type
+      @strength = strength
+    end
+
+    # Whether no weather is active (type 0).
+    def none?; @type == 0; end
+
+    def to_h; { type: @type, strength: @strength }; end
+
+    def load_h(h)
+      return unless h
+      @type = h[:type] || 0
+      @strength = h[:strength] || 0
+    end
+  end
+
   class State
-    attr_reader :party, :switches, :variables, :message_config, :screen
+    attr_reader :party, :switches, :variables, :message_config, :screen, :weather
     attr_accessor :map, :map_id, :x, :y, :direction, :timer_frames, :timer_running
     # Whether the player may open the main menu / save, toggled by the Change
     # Main Menu Access (11960) and Change Save Access (11930) event commands;
@@ -1748,6 +1779,7 @@ module Game
       @current_bgm = nil
       @memorized_bgm = nil
       @player_transparent = false
+      @weather = Weather.new
       # Transient screen-effect state (tint transition); not serialised, so a
       # reloaded game starts with a neutral screen.
       @screen = Screen.new
@@ -1774,7 +1806,7 @@ module Game
         timer_running: @timer_running, message_config: @message_config.to_h,
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
-        player_transparent: @player_transparent }
+        player_transparent: @player_transparent, weather: @weather.to_h }
     end
 
     # Rebuild a State from a parsed LCF::SaveData -- a real Save<N>.lsd written
@@ -1845,6 +1877,7 @@ module Game
       state.current_bgm = h[:current_bgm]
       state.memorized_bgm = h[:memorized_bgm]
       state.player_transparent = h[:player_transparent] ? true : false
+      state.weather.load_h(h[:weather])
       state
     end
   end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1753,6 +1753,12 @@ module Game
     # Main Menu Access (11960) and Change Save Access (11930) event commands;
     # both default on and are persisted in the save.
     attr_accessor :menu_access, :save_access
+    # Whether the Teleport and Escape skills are usable, toggled by the Change
+    # Teleport Access (11820) and Change Escape Access (11840) event commands.
+    # Default off — RPG2000 games enable these once the skill's targets are set —
+    # and persisted in the save. (The skills themselves are not executed yet, so
+    # these gate nothing at runtime; they are modelled for save fidelity.)
+    attr_accessor :teleport_access, :escape_access
     # The BGM currently playing and the one stashed by Memorize BGM (11530),
     # each nil or a `{ name:, volume:, tempo: }` hash. Play Memorized BGM (11540)
     # restores the stash. Persisted in the save so the memory survives a reload.
@@ -1776,6 +1782,8 @@ module Game
       @message_config = MessageConfig.new
       @menu_access = true
       @save_access = true
+      @teleport_access = false
+      @escape_access = false
       @current_bgm = nil
       @memorized_bgm = nil
       @player_transparent = false
@@ -1806,7 +1814,8 @@ module Game
         timer_running: @timer_running, message_config: @message_config.to_h,
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
-        player_transparent: @player_transparent, weather: @weather.to_h }
+        player_transparent: @player_transparent, weather: @weather.to_h,
+        teleport_access: @teleport_access, escape_access: @escape_access }
     end
 
     # Rebuild a State from a parsed LCF::SaveData -- a real Save<N>.lsd written
@@ -1878,6 +1887,8 @@ module Game
       state.memorized_bgm = h[:memorized_bgm]
       state.player_transparent = h[:player_transparent] ? true : false
       state.weather.load_h(h[:weather])
+      state.teleport_access = h[:teleport_access] ? true : false
+      state.escape_access = h[:escape_access] ? true : false
       state
     end
   end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -68,6 +68,8 @@ module Game
       PLAY_MEMORIZED_BGM = 11540
       PLAY_SE          = 11550
       CHANGE_MAP_TILESET = 11710
+      CHANGE_TELEPORT_ACCESS = 11820
+      CHANGE_ESCAPE_ACCESS   = 11840
       CHANGE_SAVE_ACCESS = 11930
       CHANGE_MENU_ACCESS = 11960
       RETURN_TO_TITLE  = 12510
@@ -331,6 +333,8 @@ module Game
       when Cmd::PLAY_MEMORIZED_BGM then do_play_memorized_bgm cmd
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
       when Cmd::CHANGE_MAP_TILESET then @tileset_request = cmd.param(0)
+      when Cmd::CHANGE_TELEPORT_ACCESS then @state.teleport_access = cmd.param(0) != 0
+      when Cmd::CHANGE_ESCAPE_ACCESS then @state.escape_access = cmd.param(0) != 0
       when Cmd::CHANGE_SAVE_ACCESS then @state.save_access = cmd.param(0) != 0
       when Cmd::CHANGE_MENU_ACCESS then @state.menu_access = cmd.param(0) != 0
       when Cmd::RETURN_TO_TITLE  then do_return_to_title cmd

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -57,6 +57,7 @@ module Game
       TINT_SCREEN      = 11030
       FLASH_SCREEN     = 11040
       SHAKE_SCREEN     = 11050
+      WEATHER_EFFECTS  = 11070
       PLAYER_VISIBILITY = 11310
       MOVE_EVENT       = 11330
       PROCEED_WITH_MOVEMENT = 11340
@@ -319,6 +320,7 @@ module Game
       when Cmd::TINT_SCREEN      then do_tint_screen cmd
       when Cmd::FLASH_SCREEN     then do_flash_screen cmd
       when Cmd::SHAKE_SCREEN     then do_shake_screen cmd
+      when Cmd::WEATHER_EFFECTS  then do_weather cmd
       when Cmd::PLAYER_VISIBILITY then do_player_visibility cmd
       when Cmd::MOVE_EVENT       then do_move_event cmd
       when Cmd::PROCEED_WITH_MOVEMENT then do_proceed_with_movement cmd
@@ -1006,6 +1008,16 @@ module Game
       return unless cmd.param(3) != 0 && @state.screen.shaking?
       @wait_kind = :screen
       @waiting = true
+    end
+
+    # Weather Effects: set the map weather type (param0 — 0 none, 1 rain, 2 snow;
+    # the RPG2003 additions come through as higher values) and strength (param1 —
+    # 0 weak .. 2 strong) on the shared game state. Non-blocking; like the picture
+    # / tint overlays this records the Ruby-half model only — compositing the
+    # rain/snow particles is native renderer work still to come — but the setting
+    # is applied and persists through Save / Continue.
+    def do_weather(cmd)
+      @state.weather.set(cmd.param(0), cmd.param(1))
     end
 
     # Memorize BGM: stash a copy of the currently-playing BGM so a later Play

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1766,6 +1766,49 @@ check 'Weather round-trips through the save' do
   ok Game::State.load(db, legacy).weather.none?
 end
 
+# -- Change Teleport / Escape Access ------------------------------------------
+
+check 'Change Teleport / Escape Access toggle their flags, non-blocking' do
+  st = party_state
+  eq false, st.teleport_access, 'teleport access defaults off'
+  eq false, st.escape_access, 'escape access defaults off'
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_TELEPORT_ACCESS, [1]),
+            FakeCmd.new(IC::CHANGE_ESCAPE_ACCESS, [1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'the access commands must not pause the interpreter'
+  eq true, st.teleport_access
+  eq true, st.escape_access
+  eq true, st.switches[1], 'the command after them still ran'
+  # And they can be turned back off.
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CHANGE_TELEPORT_ACCESS, [0])])
+  it2.update
+  eq false, st.teleport_access
+end
+
+check 'Teleport / Escape access round-trip through the save' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.teleport_access = true
+  st.escape_access = true
+  loaded = Game::State.load(db, st.to_h)
+  eq true, loaded.teleport_access
+  eq true, loaded.escape_access
+  # A save written before these existed defaults them off.
+  legacy = st.to_h
+  legacy.delete(:teleport_access)
+  legacy.delete(:escape_access)
+  legacy_loaded = Game::State.load(db, legacy)
+  eq false, legacy_loaded.teleport_access
+  eq false, legacy_loaded.escape_access
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1733,6 +1733,39 @@ check 'Change Map Tileset queues a one-shot tileset request, non-blocking' do
   eq nil, it.take_tileset_request, 'and clears after the first read'
 end
 
+# -- Weather Effects ----------------------------------------------------------
+
+check 'Weather Effects sets the weather type and strength, non-blocking' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  ok st.weather.none?, 'no weather to start'
+  it.start([FakeCmd.new(IC::WEATHER_EFFECTS, [1, 2]), # rain, strong
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Weather Effects must not pause the interpreter'
+  eq 1, st.weather.type
+  eq 2, st.weather.strength
+  ok !st.weather.none?, 'weather is now active'
+  eq true, st.switches[1], 'the command after it still ran'
+end
+
+check 'Weather round-trips through the save' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.weather.set(2, 1) # snow, medium
+  loaded = Game::State.load(db, st.to_h)
+  eq 2, loaded.weather.type
+  eq 1, loaded.weather.strength
+  # A save written before weather existed defaults to none.
+  legacy = st.to_h
+  legacy.delete(:weather)
+  ok Game::State.load(db, legacy).weather.none?
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
Adds three more RPG2000 event commands to `Game::Interpreter`, continuing the event-command coverage after #177. All are self-contained state changes with no scene/render wiring.

## Weather Effects (11070)

Records the map weather type and strength on a new `Game::Weather` model held by `Game::State`, following this repo's "model the state now, native render later" pattern (same shape as the screen-tint overlay).

- **`Game::Weather`** — `type` (0 none, 1 rain, 2 snow; higher values pass through for the RPG2003 additions) and `strength` (0 weak .. 2 strong), with `set`, `none?`, `to_h`/`load_h`.
- **`Game::State`** gains a `weather` member, round-tripped through `to_h` / `load` (older save → none).
- Interpreter dispatches to `do_weather` (type = param0, strength = param1). Non-blocking.

Like the picture and screen-tint overlays this is the **Ruby-half model only** — compositing the rain/snow particles is native (C++) renderer work still to come.

## Change Teleport Access (11820) / Change Escape Access (11840)

Completes the access-flag family alongside Change Main Menu / Save Access.

- Each toggles a `Game::State` flag (`teleport_access` / `escape_access`) from `param0`; both default **off** (RPG2000 games enable the skills once their targets are set) and round-trip through Save / Continue.
- The Teleport and Escape skills aren't executed yet, so these gate nothing at runtime — modelled for save fidelity.

## Testing
- `scripts/rpg2k_logic_check.rb` (124 checks): weather set + save round-trip; access toggles + save round-trip (including the pre-existing-save defaults)
- `scripts/rpg2k_scene_check.rb` (48) and `scripts/rpg2k_render_check.rb` (29) stay green
- README, `docs/TODO.md`, and per-change changelog fragments updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW