### PR TITLE
rpg2k: implement Show / Move / Erase Picture

### DIFF
--- a/changelog.d/rpg2k-show-picture.added.md
+++ b/changelog.d/rpg2k-show-picture.added.md
@@ -1,0 +1,16 @@
+- **Show Picture** — the RPG2000 Show / Move / Erase Picture commands
+  (11110/11120/11130) now display `Picture/<name>` images over the map. A
+  `Game::Picture` per shown id (held on `Game::State`) carries its centre
+  position, zoom, opacity, tone and scroll-with-map flag, decoded with EasyRPG
+  Player's parameter layout (literal or variable-sourced coordinates,
+  transparency → opacity). **Move Picture** eases every parameter to its target
+  over the command's duration, and its wait flag suspends the interpreter (a
+  new `:picture` wait) until the move settles; **Erase Picture** removes it.
+  `Scene::Map` composites the pictures id-ordered — scaled by `stretch_blt`, at
+  their opacity — into a layer above the map and below the message window.
+  Grounded in the real Nepheshel game (all 104 Show Picture commands' images
+  resolve, ids and zoom in range) and covered by `scripts/rpg2k_logic_check.rb`
+  (Picture interpolation + the three commands) and `scripts/rpg2k_scene_check.rb`
+  (a picture renders and its move advances under the scene loop). Picture tone
+  is carried but not yet drawn (it needs the same native tone support as the
+  screen tint).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -157,9 +157,18 @@ The work below is roughly ordered by the critical path to a walkable game
   spirit / agility) and **game quantities** (party gold, timer seconds).
   Conditional Branch covers switch / variable / **timer** / gold / item
   conditions and the **actor** sub-conditions (in party, name, level ≥, HP ≥,
-  item equipped, skill known; state is not modelled). The remaining commands
-  (pictures, weather, battles, shop / inn, EXP gain / level-up messages, ...) are
-  TODO
+  item equipped, skill known; state is not modelled). **Show / Move / Erase
+  Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
+  (centre position, zoom, opacity, tone and the scroll-with-map flag) held on
+  `Game::State`, decoded with EasyRPG's parameter layout (literal or
+  variable-sourced coordinates, transparency → opacity); Move eases every
+  parameter to its target over the duration and its wait flag suspends the
+  interpreter (`:picture`) until the move settles; `Scene::Map` composites the
+  pictures (id-ordered, zoomed via `stretch_blt`, at their opacity) into a layer
+  above the map and below the message window. Picture **tone** is carried but not
+  yet drawn (needs the same native tone support as the screen tint). The
+  remaining commands (weather, battles, shop / inn, EXP gain / level-up
+  messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   speed/wait codes are consumed). Text now **reveals gradually** (a
@@ -199,8 +208,9 @@ The work below is roughly ordered by the critical path to a walkable game
   a colour + strength that fades to zero over the duration; like the tint it is
   the Ruby half (drawing the full-screen colour overlay at its strength needs
   the same alpha-blend / viewport support in C++). All three share the `:screen`
-  wait. Pan, transitions/fade, Show Picture and weather remain, and the
-  tint/flash still need `RGSS::Viewport` tone/alpha support in C++ to show
+  wait. **Show Picture** now renders (see the interpreter bullet above). Pan,
+  transitions/fade and weather remain, and the tint/flash still need
+  `RGSS::Viewport` tone/alpha support in C++ to show
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1713,6 +1713,71 @@ module Game
     end
   end
 
+  # One on-screen picture shown by the Show Picture (11110) event command. Holds
+  # its file name, the current visual parameters (centre position, zoom percent,
+  # 0..255 opacity and the four RPG2000 tone channels) and, while a Move Picture
+  # (11120) is in flight, linearly interpolates every parameter toward its target
+  # over the move's duration. Pure data — the owning Scene::Map reads the current
+  # values each frame to blit the picture; #update advances the interpolation.
+  #
+  # Positions are RPG2000 screen coordinates of the picture's *centre*; a picture
+  # flagged `fixed_to_map` scrolls with the map (the scene subtracts the camera)
+  # rather than staying put on screen. Tone channels are 0..200 (100 neutral);
+  # applying them is deferred (needs native tone support), so they are carried
+  # but not yet drawn.
+  class Picture
+    attr_reader :id, :name, :fixed_to_map, :use_transparent_color
+    attr_reader :x, :y, :zoom, :opacity, :red, :green, :blue, :saturation
+
+    def initialize(id, opts = {})
+      @id = id
+      @name = opts[:name] || ''
+      @x = opts[:x] || 0
+      @y = opts[:y] || 0
+      @zoom = opts[:zoom] || 100
+      @opacity = opts[:opacity] || 255
+      @red = opts[:red] || 100
+      @green = opts[:green] || 100
+      @blue = opts[:blue] || 100
+      @saturation = opts[:saturation] || 100
+      @fixed_to_map = opts[:fixed_to_map] ? true : false
+      @use_transparent_color = opts[:use_transparent_color] ? true : false
+      @frames = 0
+    end
+
+    # Begin a move toward new visual parameters over `frames` frames; with
+    # frames <= 0 the change applies immediately.
+    def move_to(x, y, zoom, opacity, red, green, blue, saturation, frames)
+      @tx = x; @ty = y; @tzoom = zoom; @topacity = opacity
+      @tred = red; @tgreen = green; @tblue = blue; @tsat = saturation
+      @frames = frames > 0 ? frames : 0
+      finish_move if @frames == 0
+    end
+
+    def moving?; @frames > 0; end
+
+    # Advance one frame of the in-flight move (a no-op when at rest). Every
+    # parameter eases a `1/remaining` fraction toward its target, so integer
+    # division still lands exactly on the target on the final frame.
+    def update
+      return unless moving?
+      @x = step(@x, @tx); @y = step(@y, @ty)
+      @zoom = step(@zoom, @tzoom); @opacity = step(@opacity, @topacity)
+      @red = step(@red, @tred); @green = step(@green, @tgreen)
+      @blue = step(@blue, @tblue); @saturation = step(@saturation, @tsat)
+      @frames -= 1
+    end
+
+    private
+
+    def step(cur, target); cur + (target - cur) / @frames; end
+
+    def finish_move
+      @x = @tx; @y = @ty; @zoom = @tzoom; @opacity = @topacity
+      @red = @tred; @green = @tgreen; @blue = @tblue; @saturation = @tsat
+    end
+  end
+
   # The overall running-game state: who is in the party and where they are,
   # plus the global switches and variables.
   class State
@@ -1746,7 +1811,33 @@ module Game
       # Transient screen-effect state (tint transition); not serialised, so a
       # reloaded game starts with a neutral screen.
       @screen = Screen.new
+      # Shown pictures, id => Game::Picture. Transient like @screen (RPG2000's
+      # HUD pictures are re-shown by parallel events on load), so not serialised.
+      @pictures = {}
     end
+
+    attr_reader :pictures
+
+    # Show (or replace) picture `id` with the given Picture options hash.
+    def show_picture(id, opts)
+      @pictures[id] = Picture.new(id, opts) if id && id > 0
+    end
+
+    # Start a move on picture `id` (a no-op if it is not shown). `args` are the
+    # Picture#move_to arguments (x, y, zoom, opacity, r, g, b, s, frames).
+    def move_picture(id, *args)
+      pic = @pictures[id]
+      pic.move_to(*args) if pic
+    end
+
+    def erase_picture(id); @pictures.delete(id); end
+
+    # Advance every shown picture's in-flight move one frame.
+    def update_pictures; @pictures.each_value(&:update); end
+
+    # Whether any picture is still interpolating a move (for the Move Picture
+    # "wait until done" flag).
+    def pictures_moving?; @pictures.values.any?(&:moving?); end
 
     # Advance the countdown timer one frame (call once per frame). Returns true
     # on the frame the timer reaches zero.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -55,6 +55,9 @@ module Game
       TINT_SCREEN      = 11030
       FLASH_SCREEN     = 11040
       SHAKE_SCREEN     = 11050
+      SHOW_PICTURE     = 11110
+      MOVE_PICTURE     = 11120
+      ERASE_PICTURE    = 11130
       MOVE_EVENT       = 11330
       PROCEED_WITH_MOVEMENT = 11340
       HALT_ALL_MOVEMENT = 11350
@@ -287,6 +290,9 @@ module Game
       when Cmd::TINT_SCREEN      then do_tint_screen cmd
       when Cmd::FLASH_SCREEN     then do_flash_screen cmd
       when Cmd::SHAKE_SCREEN     then do_shake_screen cmd
+      when Cmd::SHOW_PICTURE     then do_show_picture cmd
+      when Cmd::MOVE_PICTURE     then do_move_picture cmd
+      when Cmd::ERASE_PICTURE    then do_erase_picture cmd
       when Cmd::MOVE_EVENT       then do_move_event cmd
       when Cmd::PROCEED_WITH_MOVEMENT then do_proceed_with_movement cmd
       when Cmd::HALT_ALL_MOVEMENT then @halt_movement_requested = true
@@ -929,6 +935,66 @@ module Game
       return unless cmd.param(3) != 0 && @state.screen.shaking?
       @wait_kind = :screen
       @waiting = true
+    end
+
+    # Show Picture (11110): display picture param0 from the string file name at
+    # the centre position param2/param3 (literal, or read from those variables
+    # when the position-mode param1 is non-zero), at zoom param5 (%), transparency
+    # param6 (0 opaque .. 100 clear), tone param8..11 (r/g/b/saturation) and the
+    # "make colour 0 transparent" flag param7; param4 pins it to the map (it then
+    # scrolls with the camera). The parameter layout is a direct port of EasyRPG
+    # Player's CommandShowPicture (RPG2000 branch).
+    def do_show_picture(cmd)
+      id = cmd.param(0)
+      return if id <= 0
+      @state.show_picture(id,
+                          name: picture_name(cmd),
+                          x: picture_coord(cmd, 2), y: picture_coord(cmd, 3),
+                          zoom: cmd.param(5),
+                          opacity: trans_to_opacity(cmd.param(6)),
+                          use_transparent_color: cmd.param(7) != 0,
+                          fixed_to_map: cmd.param(4) > 0,
+                          red: cmd.param(8), green: cmd.param(9),
+                          blue: cmd.param(10), saturation: cmd.param(11))
+    end
+
+    # Move Picture (11120): ease picture param0 to a new position/zoom/opacity/
+    # tone over param14 tenths of a second. When the wait flag (param15) is set,
+    # pause until the move finishes — the scene advances the pictures each frame
+    # and resumes us once none is moving. Same parameter layout as Show Picture,
+    # plus the trailing duration/wait pair (EasyRPG's CommandMovePicture).
+    def do_move_picture(cmd)
+      id = cmd.param(0)
+      frames = cmd.param(14) * FRAMES_PER_TENTH
+      @state.move_picture(id, picture_coord(cmd, 2), picture_coord(cmd, 3),
+                          cmd.param(5), trans_to_opacity(cmd.param(6)),
+                          cmd.param(8), cmd.param(9), cmd.param(10),
+                          cmd.param(11), frames)
+      return unless cmd.param(15) != 0 && @state.pictures[id] &&
+                    @state.pictures[id].moving?
+      @wait_kind = :picture
+      @waiting = true
+    end
+
+    # Erase Picture (11130): remove picture param0 from the screen.
+    def do_erase_picture(cmd)
+      @state.erase_picture(cmd.param(0))
+    end
+
+    # A picture coordinate: the literal param at `idx`, or the value of the
+    # variable it names when the position-mode param (index 1) is non-zero.
+    def picture_coord(cmd, idx)
+      cmd.param(1) != 0 ? variables[cmd.param(idx)] : cmd.param(idx)
+    end
+
+    # RPG2000 transparency (0 opaque .. 100 fully clear) -> a 0..255 opacity.
+    def trans_to_opacity(top_trans)
+      (100 - Game.clamp(top_trans, 0, 100)) * 255 / 100
+    end
+
+    # The picture's file name (the command's string parameter), or ''.
+    def picture_name(cmd)
+      (cmd.string || '').to_s
     end
 
     # Memorize BGM: stash a copy of the currently-playing BGM so a later Play

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -417,7 +417,8 @@ class RPG2k
 
       def dispose
         close_message
-        [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite].each do |s|
+        [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
+         @picture_sprite].each do |s|
           s.dispose if s
         end
         @chipset_bmp.dispose if @chipset_bmp
@@ -427,6 +428,7 @@ class RPG2k
       def update
         @state.tick_timer # the timer keeps counting during events too
         @state.screen.update # screen tint progresses every frame, even in events
+        @state.update_pictures # picture moves progress every frame too
         @anim_frame += 1 # water / animated tiles cycle even during events
         if event_busy?
           drive_event
@@ -474,6 +476,35 @@ class RPG2k
         @event_charsets = {}
 
         setup_parallax
+        setup_pictures
+      end
+
+      # Create the buffer that carries the Show Picture layer. Pictures composite
+      # into one screen-sized sprite above the map and characters (z = 250) but
+      # below the message window (z = 300); source images are cached by
+      # [name, transparent-colour] as they are shown.
+      def setup_pictures
+        @picture_sprite = Sprite.new
+        @picture_sprite.z = 250
+        @picture_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        @picture_sprite.bitmap = @picture_bmp
+        @picture_srcs = {}
+      end
+
+      # Load (and cache) a picture's source image (Picture/<name>). `transparent`
+      # loads it with the colour-key so palette index 0 shows through. A cached
+      # nil marks a missing file so a broken picture simply draws nothing.
+      def picture_src(name, transparent)
+        return nil if name.nil? || name.empty?
+        key = [name, transparent]
+        return @picture_srcs[key] if @picture_srcs.key?(key)
+        @picture_srcs[key] =
+          begin
+            Bitmap.new "Picture/#{name}", transparent
+          rescue StandardError => e
+            $stderr.puts "[RPG2k] picture '#{name}' load failed, not drawn: #{e.message}"
+            nil
+          end
       end
 
       # Load the map's parallax background (Panorama/<name>) and its scroll
@@ -1141,6 +1172,7 @@ class RPG2k
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
           when :screen then @interpreter.resume unless @state.screen.busy?
+          when :picture then @interpreter.resume unless @state.pictures_moving?
           end
         else
           @interpreter.update
@@ -1523,6 +1555,41 @@ class RPG2k
         @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
         @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE)
         draw_player_frame
+
+        draw_pictures cam_x, cam_y
+      end
+
+      # Composite the Show Picture layer into its buffer, drawing lowest-id first
+      # so higher-numbered pictures sit on top. Each picture is scaled by its zoom
+      # about its centre and blitted at its opacity; a picture pinned to the map
+      # scrolls with the camera, otherwise it holds its screen position. (Tone is
+      # carried on the picture but not yet applied — that needs native tone
+      # support, like the screen tint.)
+      def draw_pictures(cam_x, cam_y)
+        @picture_bmp.clear
+        pics = @state.pictures
+        return if pics.empty?
+        pics.keys.sort.each { |id| draw_picture pics[id], cam_x, cam_y }
+      end
+
+      def draw_picture(pic, cam_x, cam_y)
+        src = picture_src(pic.name, pic.use_transparent_color)
+        return unless src
+        zw = src.width * pic.zoom / 100
+        zh = src.height * pic.zoom / 100
+        return if zw <= 0 || zh <= 0
+        # RPG2000 positions a picture by its centre.
+        dx = pic.x - zw / 2
+        dy = pic.y - zh / 2
+        if pic.fixed_to_map
+          dx -= cam_x
+          dy -= cam_y
+        end
+        @picture_bmp.stretch_blt Rect.new(dx, dy, zw, zh), src,
+                                 Rect.new(0, 0, src.width, src.height),
+                                 pic.opacity
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] picture ##{pic.id} draw failed: #{e.message}"
       end
 
       # Composite the parallax background into its screen-sized buffer, tiling

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1647,6 +1647,116 @@ check 'Halt All Movement raises a one-shot request without pausing' do
   eq false, it.take_halt_movement_request, 'and it clears after the first read'
 end
 
+# -- Pictures (Game::Picture + Show/Move/Erase Picture) -----------------------
+
+check 'Game::Picture holds its shown parameters' do
+  p = Game::Picture.new(3, name: 'pic', x: 160, y: 120, zoom: 100,
+                        opacity: 255, fixed_to_map: true,
+                        use_transparent_color: true,
+                        red: 100, green: 100, blue: 100, saturation: 100)
+  eq [3, 'pic', 160, 120, 100, 255], [p.id, p.name, p.x, p.y, p.zoom, p.opacity]
+  ok p.fixed_to_map && p.use_transparent_color
+  ok !p.moving?
+end
+
+check 'Game::Picture eases a move and lands exactly on the last frame' do
+  p = Game::Picture.new(1, x: 0, y: 0, zoom: 100, opacity: 0)
+  p.move_to(40, 20, 200, 255, 100, 100, 100, 100, 4) # over 4 frames
+  ok p.moving?
+  p.update; eq [10, 5], [p.x, p.y]
+  p.update; eq [20, 10], [p.x, p.y]
+  p.update; eq [30, 15], [p.x, p.y]
+  p.update; eq [40, 20, 200, 255], [p.x, p.y, p.zoom, p.opacity]
+  ok !p.moving?, 'settled once the move completes'
+end
+
+check 'Game::Picture with non-divisible steps still lands exactly' do
+  p = Game::Picture.new(1, x: 0, y: 0)
+  p.move_to(10, 0, 100, 255, 100, 100, 100, 100, 3)
+  3.times { p.update }
+  eq 10, p.x
+  ok !p.moving?
+end
+
+check 'Game::Picture with zero duration applies immediately' do
+  p = Game::Picture.new(1, x: 5, y: 5, opacity: 0)
+  p.move_to(99, 88, 150, 128, 100, 100, 100, 100, 0)
+  eq [99, 88, 150, 128], [p.x, p.y, p.zoom, p.opacity]
+  ok !p.moving?
+end
+
+check 'Show Picture creates a picture from its parameters' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # id 1, pos-mode 0 (literal), x 160, y -32, fixed 0, zoom 100, trans 0,
+  # use-transp 1, tone 100/100/100/100, effect 0/60.
+  it.start([FakeCmd.new(IC::SHOW_PICTURE,
+                        [1, 0, 160, -32, 0, 100, 0, 1, 100, 100, 100, 100, 0, 60],
+                        string: 'pic01')])
+  it.update
+  p = st.pictures[1]
+  ok p, 'picture 1 exists'
+  eq ['pic01', 160, -32, 100, 255], [p.name, p.x, p.y, p.zoom, p.opacity]
+  ok p.use_transparent_color, 'transparent-colour flag decoded'
+  ok !p.fixed_to_map
+end
+
+check 'Show Picture transparency maps to opacity and reads position variables' do
+  st = new_state
+  st.variables[7] = 200
+  st.variables[8] = 40
+  it = Game::Interpreter.new(st)
+  # pos-mode 1 -> x/y come from variables 7/8; transparency 100 -> opacity 0.
+  it.start([FakeCmd.new(IC::SHOW_PICTURE,
+                        [2, 1, 7, 8, 1, 100, 100, 0, 100, 100, 100, 100, 0, 0],
+                        string: 'p')])
+  it.update
+  p = st.pictures[2]
+  eq [200, 40, 0], [p.x, p.y, p.opacity], 'x/y from vars, transparency 100 -> opacity 0'
+  ok p.fixed_to_map, 'fixed-to-map flag decoded'
+end
+
+check 'Move Picture eases the picture and its wait flag pauses the interpreter' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::SHOW_PICTURE,
+               [1, 0, 0, 0, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0], string: 'p'),
+    # Move to (60,0) over 1 tenth (=6 frames) with the wait flag set, then a
+    # switch we can watch to prove the interpreter paused.
+    FakeCmd.new(IC::MOVE_PICTURE,
+               [1, 0, 60, 0, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0, 1, 1]),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])
+  ])
+  it.update # Show
+  it.update # Move -> starts the move and waits
+  ok it.waiting?, 'the wait flag paused the interpreter'
+  ok st.pictures[1].moving?, 'the picture is interpolating'
+  # Drive the picture the way the scene does, then let the interpreter resume.
+  6.times { st.update_pictures }
+  ok !st.pictures_moving?, 'the move finished'
+  eq 60, st.pictures[1].x
+  it.resume
+  it.update
+  eq true, st.switches[1], 'the command after the waited move ran'
+end
+
+check 'Erase Picture removes the picture' do
+  st = new_state
+  # Show alone first, to confirm it is present before erasing.
+  its = Game::Interpreter.new(st)
+  its.start([FakeCmd.new(IC::SHOW_PICTURE,
+                         [5, 0, 0, 0, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0],
+                         string: 'p')])
+  its.update
+  ok st.pictures[5], 'shown'
+  # Then Erase (both commands are non-blocking, so they run in one update).
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ERASE_PICTURE, [5])])
+  it.update
+  ok st.pictures[5].nil?, 'erased'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -842,6 +842,21 @@ check 'a map with no parallax builds no backdrop sprite' do
   ok true
 end
 
+check 'a shown picture renders through the scene and its move advances' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  ok scene.instance_variable_get(:@picture_sprite), 'a picture layer sprite exists'
+  ok scene.instance_variable_get(:@picture_sprite).z < 300, 'below the message window'
+  # Show a picture on the state, start a move, then let the scene loop drive it:
+  # each update advances the pictures and re-renders (which must not raise).
+  st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
+  st.move_picture(1, 160, 60, 200, 128, 100, 100, 100, 100, 6)
+  ok st.pictures_moving?, 'the picture is moving'
+  6.times { scene.update }
+  ok !st.pictures_moving?, 'the move completed under the scene loop'
+  eq 60, st.pictures[1].y, 'the picture reached its target'
+end
+
 check 'rendering a map with charset + tile-substitution events does not raise' do
   charset_ev = event(2, 2, page(charset_name: 'npc', charset_index: 1, layer: 1))
   tile_ev    = event(3, 3, page(charset_name: '', charset_index: 97, layer: 0))


### PR DESCRIPTION
## Summary

Continues the Nepheshel rendering work (after #172 event sprites, #175 event interpolation, #179 parallax). The Show Picture family of event commands (11110/11120/11130) was a no-op, so pictures never appeared. This implements them end to end.

- **`Game::Picture`** (held on `Game::State` by id) carries a picture's centre position, zoom, opacity, tone and scroll-with-map flag, and linearly eases every parameter toward a target over a move's duration (landing exactly on the final frame).
- **Interpreter** decodes the RPG2000 parameter layout — a port of EasyRPG Player's `CommandShowPicture` / `CommandMovePicture`: literal or variable-sourced coordinates, transparency → opacity, zoom, tone, and the fixed-to-map flag. **Move Picture** eases to the new parameters over its duration and, when its wait flag is set, suspends the interpreter (a new `:picture` wait) until the move settles; **Erase Picture** removes it.
- **`Scene::Map`** composites the pictures id-ordered into a layer above the map and below the message window (z = 250), scaled by `stretch_blt` and drawn at their opacity, advancing the moves every frame.

## Grounding in real data

Across all 543 Nepheshel maps + common events: **104 Show Picture commands**, and **all 104 images resolve** to real `Picture/*` files. Decoded picture ids are all in 1..50, zoom in 50..1000%, and 14 commands use variable-sourced coordinates — all handled.

## Testing

Pure-Ruby; exercised under CRuby by the host harnesses (the native SDL/mruby binary can't be built here):

- `ruby scripts/rpg2k_render_check.rb` — 29 ✓
- `ruby scripts/rpg2k_logic_check.rb` — 132 ✓ (added `Game::Picture` interpolation + the three commands, incl. the waited-move resume)
- `ruby scripts/rpg2k_scene_check.rb` — 49 ✓ (a picture renders and its move advances under the scene loop)

## Notes

- Rebased/merged onto the latest `master`; resolved conflicts with the concurrently-landed Weather Effects / Player Visibility / Return-to-Title work (both feature sets coexist and all checks pass).
- Picture **tone** is carried on the model but not yet drawn — it needs the same native tone support as the screen tint. As with the earlier rendering work, the pixel appearance hasn't been visually diffed against `RPG_RT.exe` under wine (not runnable here); the parameter decoding and move interpolation are pinned and data-validated in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS)_