### PR TITLE
CI: drive the real MV test bed (Lunatic-Core) past the title into play

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,20 @@ jobs:
                 --timeout_ms=5000 --game_dir data/Lunatic-Core \
                 --mv_screenshot=ss/mv_title.png
 
+          # Drive the real downloaded MV test bed (Lunatic-Core) past the title
+          # into actual play: New Game -> map, then hold a direction and log the
+          # player's start/end tile (`[MV-MOVE] ... moved=<bool>`) and capture a
+          # frame. The boot smoke above only reaches the title; this exercises
+          # the fuller real game's map / movement / render path (a real database,
+          # autotiles and character sheet the minimal sample can't cover).
+          # Non-blocking, like the other MV smokes.
+          - name: MV real-game play smoke test
+            continue-on-error: true
+            run: |
+              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+                --timeout_ms=6000 --game_dir data/Lunatic-Core \
+                --mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png
+
           - name: MV sample smoke test
             continue-on-error: true
             run: |
@@ -208,6 +222,14 @@ jobs:
         with:
           name: mv-screenshot
           path: ss/mv_title.png
+          if-no-files-found: warn
+
+      - name: Upload MV play screenshot
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: mv-play-screenshot
+          path: ss/mv_play.png
           if-no-files-found: warn
 
       - name: Upload MV sample screenshot

--- a/changelog.d/mv-real-game-play-smoke.added.md
+++ b/changelog.d/mv-real-game-play-smoke.added.md
@@ -1,0 +1,7 @@
+- MV real-game play smoke test: a new CI step drives the downloaded RPG Maker
+  MV test bed (KinoAR/Lunatic-Core) past the title into actual play — New Game →
+  map, then holds a direction and logs the player's start/end tile
+  (`[MV-MOVE] ... moved=<bool>`) and captures a frame. The existing boot smoke
+  only reached the title; this exercises the fuller real game's
+  map/movement/render path (a real database, autotiles and character sheet the
+  minimal `data/mv-sample` can't cover). Non-blocking, like the other MV smokes.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -415,5 +415,9 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     (`width*height*6`), tileset/actor/class cross-references, party members —
     and runs as a **blocking** CI step ahead of the non-blocking native MV
     smokes, so a regression in the committed `data/mv-sample` fails the build.
+  - ✅ Real-game play smoke: CI drives the downloaded Lunatic-Core bed past the
+    title into New Game → map and a movement probe (`--mv_new_game
+    --mv_move_test`), not just the title boot — so the fuller real game's
+    map/movement/render path is exercised, not only the minimal sample's.
 - 🚧 **M6 — MZ.** A WebGL-subset backend on LVGL so PIXI v5 / RPG Maker MZ runs
   on the same foundation (`js/rmmz_*.js`).


### PR DESCRIPTION
## Summary

CI only booted the downloaded RPG Maker MV test bed (KinoAR/Lunatic-Core) to its **title screen** (`--mv_screenshot`). The fuller real game's **New Game → map → movement → render** path went untested — only the minimal committed `data/mv-sample` exercised New Game / move / message.

This adds a non-blocking smoke that drives the real game into actual play, so CI covers a real database, real autotiles and a real character sheet that the minimal sample can't.

## Changes

- **`.github/workflows/build.yml`**:
  - New `MV real-game play smoke test` step: runs Lunatic-Core with `--mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png` (non-blocking, `continue-on-error`, like the other MV smokes).
  - New `Upload MV play screenshot` artifact step.
- **`changelog.d/mv-real-game-play-smoke.added.md`**, **`docs/TODO.md`**: changelog fragment and an M5 note.

## Verification

Built the native binary locally (SDL2 + quickjs + mruby) and ran the exact CI command against the downloaded Lunatic-Core:

```
[MV] scene: Scene_Boot
[MV] scene: Scene_Title
[MV] scene: Scene_Map
[MV-MOVE] start 8,6
[MV-MOVE] end 8,7 moved=true
[MV] screenshot saved: ss/mv_play.png
```

The captured frame renders correctly — grass autotiles with the hero (Harold) sprite — confirming the real game boots to a walkable map and input moves the player, end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_