### PR TITLE
Fix concurrent xvfb-run display collision in CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,13 @@ jobs:
       # group (implicit wait at the end). The MV smoke tests stay non-blocking
       # (continue-on-error) while the MV runtime is brought up; the required
       # checks (LCF / RPG XP / RPG2k / ctest) fail the group — and the job — if
-      # they fail. Each MV run uses `xvfb-run -a` (auto-picked display) and a
-      # distinct screenshot path, so the concurrent runs never collide.
+      # they fail. Each xvfb-run instance gets a fixed, distinct display number
+      # (--server-num) and a distinct screenshot path, so the concurrent runs
+      # never collide. `xvfb-run -a` (auto-picked display) is deliberately
+      # avoided: its server-number probe is not atomic, so concurrent -a runs
+      # can grab the same display, killing one Xvfb out from under its client
+      # ("XIO: fatal IO error"). Reserved numbers: exe_open=99 (see the ctest
+      # `exe_open` test in CMakeLists.txt); MV runs=100..104 below.
       - parallel:
           - name: LCF test-bed smoke check
             run: nix develop -c ruby scripts/lcf_testbed_check.rb
@@ -161,35 +166,35 @@ jobs:
           - name: MV boot smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+              nix develop -c xvfb-run --server-num=100 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=5000 --game_dir data/Lunatic-Core \
                 --mv_screenshot=ss/mv_title.png
 
           - name: MV sample smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+              nix develop -c xvfb-run --server-num=101 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=5000 --game_dir data/mv-sample \
                 --mv_new_game --mv_screenshot=ss/mv_sample.png
 
           - name: MV battle smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+              nix develop -c xvfb-run --server-num=102 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_battle_test=1 --mv_screenshot=ss/mv_battle.png
 
           - name: MV movement smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+              nix develop -c xvfb-run --server-num=103 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_move_test
 
           - name: MV message smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+              nix develop -c xvfb-run --server-num=104 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_message_test --mv_screenshot=ss/mv_message.png
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,8 +314,8 @@ if(NOT EMSCRIPTEN)
   # (exe_open=99, MV runs=100..104 in .github/workflows/build.yml) so they can
   # never collide.
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(exe_open_cmd xvfb-run --server-num=99 "--server-args=-screen 0 640x480x24"
-                     ${exe_open_cmd})
+    set(exe_open_cmd xvfb-run --server-num=99
+                     "--server-args=-screen 0 640x480x24" ${exe_open_cmd})
   endif()
   add_test(
     NAME exe_open

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,8 +305,16 @@ if(NOT EMSCRIPTEN)
   # so run under a virtual X server (xvfb-run is provided by the dev shell).
   # Older LVGL silently tolerated a failed SDL_CreateWindow; v9.5.0 correctly
   # errors out when no window can be created, which would abort this smoke test.
+  #
+  # Use a fixed display number rather than `xvfb-run -a`: CI runs this test
+  # concurrently with the MV smoke tests, which are also xvfb-run instances, and
+  # `-a`'s auto server-number probe is not atomic — concurrent probes can pick
+  # the same display, so one Xvfb loses its server and the client dies with an
+  # "XIO: fatal IO error". Each concurrent run gets its own reserved number
+  # (exe_open=99, MV runs=100..104 in .github/workflows/build.yml) so they can
+  # never collide.
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(exe_open_cmd xvfb-run -a "--server-args=-screen 0 640x480x24"
+    set(exe_open_cmd xvfb-run --server-num=99 "--server-args=-screen 0 640x480x24"
                      ${exe_open_cmd})
   endif()
   add_test(


### PR DESCRIPTION
## Summary
Replace `xvfb-run -a` (auto-picked display) with fixed, distinct display numbers in concurrent test runs to prevent display server collisions that cause "XIO: fatal IO error" failures.

## Problem
The CI workflow runs multiple xvfb-run instances concurrently (MV smoke tests + exe_open test). The `-a` flag uses a non-atomic server-number probe, allowing concurrent runs to grab the same display number. This causes one Xvfb instance to lose its server while a client is still connected, resulting in fatal IO errors.

## Changes
- **CMakeLists.txt**: Changed `exe_open` test from `xvfb-run -a` to `xvfb-run --server-num=99`
- **.github/workflows/build.yml**: 
  - Changed all 5 MV smoke tests from `xvfb-run -a` to fixed display numbers (100-104)
  - Updated comments to document the reserved display number ranges and explain why `-a` is avoided

## Implementation Details
- Reserved display numbers: `exe_open=99`, MV smoke tests=`100..104`
- Each concurrent xvfb-run instance now has a guaranteed unique display, preventing collisions
- Updated documentation in both files to explain the atomic safety issue and the reservation scheme

https://claude.ai/code/session_011182QSytoCbhxdrzs9g6a4