### PR TITLE
Export a real Save<N>.lsd from live game state (Game::State#to_lsd)

### DIFF
--- a/changelog.d/lcf-save-to-lsd.added.md
+++ b/changelog.d/lcf-save-to-lsd.added.md
@@ -1,0 +1,16 @@
+- The in-game **Save** now also exports a genuine RPG2000/2003 `Save<slot>.lsd`,
+  not just our portable `Marshal` dump. New `Game::State#to_lsd` builds the
+  `SAVE_DATA` chunks from live state -- system (101: switches, variables,
+  save_count), hero position/facing (104), the per-actor level/exp/equipment/
+  skills/HP/MP table (108) and the party roster / gold / item bag (109) -- the
+  exact inverse of `Game::State.from_lsd`. `save_game` writes it beside the
+  Marshal save (best-effort; a failed export never fails the save), so a slot is
+  now readable by real RPG_RT / EasyRPG tooling. To build a save from scratch the
+  `mruby-lcf` writer gained `LCF.pack_int16` + an `:int16_array` `encode` branch
+  (equipment / skills / item ids), `Array2D#[]=` with an empty-table constructor,
+  and an empty `File` constructor (`SaveData.new` with no stream). Continue now
+  prefers our full-fidelity Marshal save and falls back to a `.lsd` only when
+  there is no Marshal save (a foreign editor save dropped in), so the lower
+  -fidelity export never shadows a richer save. `scripts/rpg2k_save_load_check.rb`
+  proves `state -> to_lsd -> from_lsd` preserves every modelled field against the
+  real Nepheshel (2000) and mtf-meido-action (2003) saves. See ADR 0019.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -222,15 +222,20 @@ The work below is roughly ordered by the critical path to a walkable game
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default
   on and persist in the save)
-- 🚧 Save & Continue — implemented with a portable `Marshal` save of the game
-  state (`Game::State#to_h` / `State.load`) written via the menu's Save command;
-  "Continue" reloads it. **Reading** the real `LCF::SaveData` (`.lsd`) is done
-  (`Game::State.from_lsd`). **Writing** it now has its LCF foundation: `mruby-lcf`
-  can serialize a save back to bytes (`Array1D`/`Array2D`/`File#to_lcf`,
-  `LCF.write_ber`/`encode`, `Array1D#[]=`), proven byte-exact against the real
-  2000/2003 saves by `scripts/lcf_save_roundtrip.rb` (ADR 0018). The remaining
-  step is a `Game::State#to_lsd` that builds the `SAVE_DATA` chunks from live game
-  state and calls `SaveData#save_to`, replacing the `Marshal` save
+- 🚧 Save & Continue — the portable `Marshal` save of the game state
+  (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
+  menu's Save command; "Continue" reloads it. **Reading** the real
+  `LCF::SaveData` (`.lsd`) is done (`Game::State.from_lsd`), and **writing** it is
+  now done too: `Game::State#to_lsd` builds the `SAVE_DATA` chunks (system 101,
+  hero 104, party actors 108, inventory 109) from live game state and
+  `SaveData#save_to` writes a genuine `Save<slot>.lsd`, exported alongside the
+  Marshal save on every save (ADR 0019, on the `mruby-lcf` serializer of ADR
+  0018). It round-trips through `from_lsd` field-for-field
+  (`scripts/rpg2k_save_load_check.rb`). Remaining refinements to make the `.lsd`
+  the *primary* save (so Continue prefers it): model the fields the Marshal save
+  still holds but `.lsd` drops here — timer, message config, current/memorized
+  BGM, actor name/title/sprite overrides, access flags — plus the title chunk
+  (100, needs `:double` timestamp encoding) so the save-slot menu shows the party
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations, game-over scene (large; Nepheshel uses the default RPG2000
   battle). Needs real assets + the native build to develop against

--- a/docs/adr/0019-game-state-to-lsd.md
+++ b/docs/adr/0019-game-state-to-lsd.md
@@ -1,0 +1,91 @@
+# 19. Game::State#to_lsd: export the running game as a real Save<N>.lsd
+
+Date: 2026-08-04
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0018 gave `mruby-lcf` a **write** path proven byte-exact against real saves,
+and closed by noting the remaining step: a `Game::State#to_lsd` that builds a
+`SAVE_DATA` structure from live game state and calls `SaveData#save_to`. This ADR
+is that step.
+
+The read path already exists: `Game::State.from_lsd(db, save)` loads a parsed
+`.lsd` into the runtime, so **Continue** can resume a genuine editor save. It
+restores exactly four chunks -- system (101: switches, variables, save_count),
+hero position/facing (104), the per-actor level/exp/equipment/skills/HP/MP table
+(108) and the party roster / gold / item bag (109). `to_lsd` must be its inverse:
+write precisely those chunks, so a save we write is one our own reader restores
+identically.
+
+Two obstacles stood between the ADR 0018 serializer and `to_lsd`:
+
+- **The writer could only *edit* a save parsed from bytes.** `Array1D#[]=` and the
+  `to_lcf` family assume an object already built from a file. Building a save
+  *from scratch* -- an empty root, empty chunks, an empty actor table -- had no
+  constructor. `Array2D` had no `#[]=` at all.
+- **Two field types a save needs were not encodable.** The actor table's
+  `equipment` and `skills` (and the inventory's `item_ids`) are `:int16_array`,
+  which `LCF.encode` did not handle; ADR 0018 only added the scalar and
+  32-bit/8-bit/bool array encoders.
+
+A third question was *policy*, not mechanism: should the in-game Save switch from
+the portable `Marshal` dump to `.lsd`? It cannot, cleanly. The `Marshal` save
+carries state the `SAVE_DATA` chunks we model here do not -- the timer, message
+config, current/memorized BGM, actor name/title/sprite overrides, and the
+menu/save/teleport/escape access flags. Making Continue load the `.lsd` would
+silently drop all of that.
+
+## Decision
+
+- **`Game::State#to_lsd(save_count = 1)`** (`mruby-rpg2k/mrblib/game.rb`) builds an
+  `LCF::SaveData` and populates chunks 101/104/108/109 as the exact inverse of
+  `from_lsd`: switch/variable ids shift from 1-indexed in-game to 0-indexed in the
+  save (unset entries default to `false`/`0`); each roster `Actor`'s level, exp,
+  skills (+ skill count), equipment, HP and MP become a `SAVE_PARTY_ACTOR` entry
+  keyed by actor id; the inventory chunk stores the roster, the sorted item ids
+  with their counts, and gold. It returns the `SaveData`; the caller writes it
+  with `#save_to`.
+- **Make the `mruby-lcf` writer build from scratch.** `Array1D.new('', schema)`
+  already yields an empty, writable object (the read loop breaks on EOF);
+  `Array2D.new('', schema)` now does too (an empty string skips the entry-count
+  read) and gains `Array2D#[]=` to store entries; `File.new` (hence
+  `SaveData.new`) now accepts **no stream**, building an empty root of the
+  schema's type. So a save is assembled purely through `#[]=` and serialized with
+  the ADR 0018 `#to_lcf` / `#save_to`.
+- **Add the `:int16_array` encoder.** `LCF.pack_int16` is the inverse of the
+  reader's `unpack('s<*')`, built byte-wise (like `pack_int32`) so it does not
+  depend on mruby-pack's endian-suffix *pack* support; `LCF.encode` gains an
+  `:int16_array` branch.
+- **Export alongside, do not replace.** `save_game` writes the authoritative
+  `Marshal` save and then best-effort-exports `Save<slot>.lsd` via `to_lsd`
+  (`export_lsd`); a failed export is logged, never fatal. `continue_game` now
+  prefers our `Marshal` save and falls back to a `.lsd` only when there is none,
+  so the full-fidelity save always wins for our own slots while a foreign editor
+  save dropped into the game dir still resumes.
+
+## Consequences
+
+- **The save loop is closed at the runtime layer.** `Game::State` reads *and*
+  writes genuine `.lsd`. `scripts/rpg2k_save_load_check.rb` now also asserts
+  `state -> to_lsd -> from_lsd` preserves every modelled field (position, gold,
+  items, roster, per-actor level/exp/HP/MP/equipment/skills, switches, variables)
+  against the real Nepheshel (2000) and mtf-meido-action (2003) saves.
+- **CI guard is the mruby unit tests.** Like ADR 0018, the real `.lsd` fixtures
+  are not vendored, so the game-level round-trip runs on demand. The CI gate is
+  `mruby-lcf/test/lcf_test.rb`, extended with the from-scratch path: `pack_int16`
+  / `:int16_array` encoding, an `Array2D` built and populated via `#[]=`, and an
+  empty `SaveData` built chunk by chunk and read straight back.
+- **A deliberately lower-fidelity export.** The exported `.lsd` drops the fields
+  listed in Context, so it is an interoperability artifact, not the primary save.
+  Promoting `.lsd` to the primary save (and letting Continue prefer it) requires
+  modelling those fields plus the title chunk (100, which needs `:double`
+  timestamp encoding for the save-slot menu) -- tracked in `docs/TODO.md`.
+- **mruby-core discipline carries forward.** The new code uses only methods the
+  embedded mruby build provides (`+`/`== 0` for byte assembly and index tests,
+  no `String#<<` or `Integer#zero?`), the constraint that ADR 0018's follow-up
+  fix established; the unit tests run under the native `test` target that surfaces
+  such gaps.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -286,6 +286,21 @@ module LCF
     out.pack('C*')
   end
 
+  # Encode an array of 16bit integers as packed little-endian bytes -- the
+  # inverse of `unpack('s<*')` (the :int16_array reader). Each value is masked to
+  # its low 16 bits, so the signed reinterpretation the reader applies
+  # round-trips exactly. Built byte-wise rather than via `pack('s<*')` so it does
+  # not depend on mruby-pack's endian-suffix pack support (the readers only rely
+  # on unpack). Used for the save's item-id, equipment and skill tables.
+  def pack_int16 a
+    out = []
+    a.each do |v|
+      v &= 0xffff
+      out.push(v & 0xff, (v >> 8) & 0xff)
+    end
+    out.pack('C*')
+  end
+
   # Encode a Ruby value back to the raw chunk bytes for a schema field -- the
   # inverse of to_rb. Only the scalar and simple-array types a save actually
   # needs to be re-authored are handled; the packed command/double/tree types
@@ -301,6 +316,7 @@ module LCF
     when :uint8 ; [value & 0xff].pack('C')
     when :int8_array ; value.pack('C*')
     when :bool_array ; value.map { |b| b ? 1 : 0 }.pack('C*')
+    when :int16_array ; pack_int16 value
     when :int32_array ; pack_int32 value
     when :string ; utf8_to_cp932 value
     when :Array1D, :Array2D
@@ -313,7 +329,8 @@ module LCF
 
   module_function :read_ber, :write_ber, :to_rb, :read_section,
                   :parse_event_commands, :parse_move_commands,
-                  :unpack_int32, :unpack_double, :pack_int32, :encode, :binstr
+                  :unpack_int32, :unpack_double, :pack_int32, :pack_int16,
+                  :encode, :binstr
 
   MODE = 2000 # 2003
 
@@ -435,12 +452,23 @@ module LCF
       @data = []
       @scheme = schema
 
+      # An empty string builds an empty, writable table from scratch (populate
+      # via #[]= then #to_lcf); a real chunk starts with a BER entry count.
+      return if s.eof?
+
       (0...LCF.read_ber(s)).each do
         @data[LCF.read_ber s] = Array1D.new(s, schema)
       end
     end
 
     def [] idx ; @data[idx] end
+
+    # Store an entry (an Array1D, or its already-serialised bytes) at id +idx+,
+    # so an authored table can be assembled and written back out via #to_lcf.
+    def []= idx, entry
+      @data[idx] = entry
+      entry
+    end
 
     # Iterate over defined (id, Array1D) entries; useful for walking event or
     # actor tables that are sparsely populated.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1170,7 +1170,15 @@ module LCF
   end
 
   class File
-    def initialize io
+    def initialize io = nil
+      # No stream builds an empty, writable file from scratch: an empty root of
+      # the schema's type, ready to populate via #[]= and serialise with #to_lcf
+      # / #save_to. Multi-section (Array-schema) files are not yet buildable.
+      if io.nil?
+        raise 'section-based file construction not implemented' if schema.is_a? Array
+        @root = LCF.const_get(schema[:type]).new('', schema)
+        return
+      end
       @io = io
       h_len = LCF.read_ber io
       h = io.read h_len

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -522,3 +522,55 @@ assert 'SaveData edit survives a write/reload round-trip' do
   assert_equal 7, reread.hero.y          # untouched field preserved
   assert_equal 2, reread[101].save_count
 end
+
+# ---- Build a save FROM SCRATCH (ADR 0019, Game::State#to_lsd) --------------
+# The writer above edits a save parsed from bytes; these exercise assembling a
+# save with no source file: int16 field encoding, an Array2D populated via #[]=,
+# and an empty SaveData built up chunk by chunk and read straight back.
+
+assert 'LCF.pack_int16 / encode :int16_array inverts the reader' do
+  vals = [0, 1, 255, 256, 32767, 40000, 65535]
+  bytes = LCF.pack_int16(vals)
+  assert_equal LCF.encode(vals, :int16_array), bytes
+  # unpack('s<*') reads these back as signed 16; masking to 16 bits recovers the
+  # value written, so the low half round-trips exactly.
+  assert_equal vals, bytes.unpack('s<*').map { |v| v & 0xffff }
+  # Non-negative ids (equipment/skills/item ids) match the unsigned LE reference
+  # the test helper uses to author int16 fields.
+  assert_equal [10, 20, 0, 0, 5].pack('v*'), LCF.pack_int16([10, 20, 0, 0, 5])
+end
+
+assert 'Array2D built from scratch serialises and reads back' do
+  schema = { elements: LCF::Schema::SAVE_PARTY_ACTOR }
+  a = LCF::Array2D.new('', schema)         # empty, writable table
+  e = LCF::Array1D.new('', schema)
+  e[31] = 5                                # level (:int)
+  e[52] = [101, 102]                       # skills (:int16_array)
+  e[61] = [1, 2, 0, 0, 0]                  # equipment (:int16_array)
+  a[1] = e
+  reread = LCF::Array2D.new(a.to_lcf, schema)
+  assert_equal 5, reread[1].level
+  assert_equal [101, 102], reread[1].skills
+  assert_equal [1, 2, 0, 0, 0], reread[1].equipment
+end
+
+assert 'SaveData built from scratch round-trips through the reader' do
+  save = LCF::SaveData.new                 # no io => empty, writable save
+  hero = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+  hero[11] = 3; hero[12] = 8; hero[13] = 4; hero[22] = 1
+  save[104] = hero
+  sys = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SYSTEM })
+  sys[32] = [false, true, false]           # switches (:bool_array)
+  sys[34] = [0, 7, 0]                       # variables (:int32_array)
+  sys[131] = 2                              # save_count
+  save[101] = sys
+
+  reread = LCF::SaveData.new(StringIO.new(save.to_lcf))
+  assert_equal 3, reread.hero.map_id
+  assert_equal 8, reread.hero.x
+  assert_equal 4, reread.hero.y
+  assert_equal 1, reread.hero.direction
+  assert_equal [false, true, false], reread[101].switches
+  assert_equal [0, 7, 0], reread[101].variables
+  assert_equal 2, reread[101].save_count
+end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1818,6 +1818,71 @@ module Game
         teleport_access: @teleport_access, escape_access: @escape_access }
     end
 
+    # Serialise to a genuine RPG2000/2003 Save<N>.lsd (an LCF::SaveData) -- the
+    # inverse of .from_lsd. It writes exactly the chunks that path reads back:
+    # the system chunk (101: switches, variables, save_count), the hero
+    # position/facing (104), the per-actor level/exp/equipment/skills/HP/MP table
+    # (108) and the party roster / gold / item bag (109). Fields our Marshal save
+    # also carries but this format does not model here (timer, message config,
+    # BGM, actor name/sprite overrides, access flags) are intentionally dropped,
+    # so this is a lower-fidelity, interoperable *export* rather than a
+    # replacement for #to_h. Switch and variable ids are 1-indexed in-game but
+    # 0-indexed in the save, so they shift down by one; unset entries default to
+    # false / 0. +save_count+ goes in the system chunk (RPG_RT increments it on
+    # every save).
+    def to_lsd(save_count = 1)
+      save = LCF::SaveData.new
+
+      hero = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+      hero[11] = @map_id
+      hero[12] = @x
+      hero[13] = @y
+      hero[22] = @direction || 2
+      save[104] = hero
+
+      sys = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SYSTEM })
+      sw = @switches.to_h
+      sw_max = sw.empty? ? 0 : sw.keys.max
+      switches = Array.new(sw_max, false)
+      sw.each { |id, v| switches[id - 1] = v ? true : false }
+      sys[31] = sw_max
+      sys[32] = switches
+      vr = @variables.to_h
+      vr_max = vr.empty? ? 0 : vr.keys.max
+      variables = Array.new(vr_max, 0)
+      vr.each { |id, v| variables[id - 1] = v }
+      sys[33] = vr_max
+      sys[34] = variables
+      sys[131] = save_count
+      sys[132] = 1
+      save[101] = sys
+
+      actors = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
+      @party.actors.each do |a|
+        e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
+        e[31] = a.level
+        e[32] = a.exp
+        e[51] = a.skills.size
+        e[52] = a.skills
+        e[61] = a.equipment
+        e[71] = a.hp
+        e[72] = a.mp
+        actors[a.id] = e
+      end
+      save[108] = actors
+
+      inv = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_INVENTORY })
+      inv[1] = @party.actors.map { |a| a.id }
+      item_ids = @party.items.keys.sort
+      inv[11] = item_ids.size
+      inv[12] = item_ids
+      inv[13] = item_ids.map { |i| @party.items[i] }
+      inv[21] = @party.gold
+      save[109] = inv
+
+      save
+    end
+
     # Rebuild a State from a parsed LCF::SaveData -- a real Save<N>.lsd written
     # by an actual editor, rather than our own Marshal hash. Only the fields we
     # model are restored: the hero's map, tile position and facing (chunk 104),

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2154,27 +2154,43 @@ class RPG2k
     false
   end
 
-  # Persist the running game state to a slot.
+  # Persist the running game state to a slot. Our own portable Marshal dump is
+  # the authoritative save (it carries the full state -- timer, message config,
+  # BGM, actor overrides, access flags -- that the .lsd format does not model
+  # here). Alongside it we also export a genuine editor Save<slot>.lsd via
+  # State#to_lsd, so the slot is readable by real RPG_RT/EasyRPG tooling. The
+  # export is best-effort: a failure there is logged but never fails the save.
   def save_game state, slot = 1
     data = Marshal.dump state.to_h
     File.open(save_path(slot), "wb") { |f| f.write data }
+    export_lsd(state, slot)
     true
   rescue StandardError => e
     $stderr.puts "[RPG2k] Failed to save: #{e.message}"
     false
   end
 
-  # Continue: resume a saved game and switch to its map. A genuine editor
-  # Save<N>.lsd is loaded through the LCF save schema when present (so a real
-  # save dropped into the game dir resumes correctly); otherwise our own Marshal
-  # save is used. Warns and stays on the title when there is nothing to load.
+  # Write a real Save<slot>.lsd next to the Marshal save. Best-effort: any error
+  # is logged and swallowed so it cannot break the primary save.
+  def export_lsd state, slot = 1
+    state.to_lsd.save_to(lsd_path(slot))
+  rescue StandardError => e
+    $stderr.puts "[RPG2k] .lsd export failed for slot #{slot}: #{e.message}"
+  end
+
+  # Continue: resume a saved game and switch to its map. Our own Marshal save is
+  # preferred when present -- it is the full-fidelity record we wrote (save_game
+  # also exports a lower-fidelity Save<slot>.lsd beside it, which would drop the
+  # timer, message config, BGM and actor overrides if loaded instead). A genuine
+  # editor Save<N>.lsd is the fallback, so a real save dropped into the game dir
+  # (with no Marshal save) still resumes through the LCF save schema. Warns and
+  # stays on the title when there is nothing to load.
   def continue_game
-    lsd = existing_lsd
-    if lsd
-      state = Game::State.from_lsd(@db, LCF::SaveData.new(File.open(lsd, "rb")))
-    elsif File.exist?(save_path)
+    if File.exist?(save_path)
       data = File.open(save_path, "rb") { |f| f.read }
       state = Game::State.load(@db, Marshal.load(data))
+    elsif (lsd = existing_lsd)
+      state = Game::State.from_lsd(@db, LCF::SaveData.new(File.open(lsd, "rb")))
     else
       RGSS.warn_stub "Continue (no save data found)"
       return

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -115,6 +115,33 @@ def check_game(dir)
                                  .map { |i| i + 1 }
   eq nonzero, state.variables.to_h.reject { |_k, v| v == 0 }.keys.sort, 'variable ids set'
 
+  # Writer round-trip (ADR 0019): serialise the runtime state back to a genuine
+  # .lsd with State#to_lsd, re-read it with State.from_lsd, and confirm every
+  # modelled field survives -- i.e. to_lsd is a faithful inverse of from_lsd.
+  round = Game::State.from_lsd(db, LCF::SaveData.new(StringIO.new(state.to_lsd.to_lcf)))
+  eq state.map_id, round.map_id, 'to_lsd: map id'
+  eq state.x, round.x, 'to_lsd: hero x'
+  eq state.y, round.y, 'to_lsd: hero y'
+  eq state.direction, round.direction, 'to_lsd: hero direction'
+  eq state.party.gold, round.party.gold, 'to_lsd: gold'
+  eq state.party.items, round.party.items, 'to_lsd: items'
+  eq state.party.actors.map { |a| a.id }, round.party.actors.map { |a| a.id },
+     'to_lsd: roster'
+  state.party.actors.each do |a|
+    b = round.party.actor_by_id(a.id)
+    next unless b
+    eq a.level, b.level, "to_lsd: actor #{a.id} level"
+    eq a.exp, b.exp, "to_lsd: actor #{a.id} exp"
+    eq a.hp, b.hp, "to_lsd: actor #{a.id} hp"
+    eq a.mp, b.mp, "to_lsd: actor #{a.id} mp"
+    eq a.equipment, b.equipment, "to_lsd: actor #{a.id} equipment"
+    eq a.skills.sort, b.skills.sort, "to_lsd: actor #{a.id} skills"
+  end
+  eq state.switches.to_h.select { |_k, v| v }.keys.sort,
+     round.switches.to_h.select { |_k, v| v }.keys.sort, 'to_lsd: switches on'
+  eq state.variables.to_h.reject { |_k, v| v == 0 },
+     round.variables.to_h.reject { |_k, v| v == 0 }, 'to_lsd: variables set'
+
   puts "  leader=#{state.party.leader.name.inspect} hp=#{state.party.leader.hp} " \
        "mp=#{state.party.leader.mp} map=#{state.map_id} " \
        "pos=(#{state.x},#{state.y}) gold=#{state.party.gold} " \


### PR DESCRIPTION
## What & why

Closes the LCF save loop at the runtime layer. The read path already exists — `Game::State.from_lsd` loads a genuine editor `.lsd` so **Continue** can resume one — and #180 gave `mruby-lcf` a byte-exact **write** path (ADR 0018). This PR adds the missing runtime piece: turning live game state back into a genuine RPG2000/2003 `Save<N>.lsd`.

`Game::State#to_lsd` builds an `LCF::SaveData` as the exact inverse of `from_lsd`, writing the four chunks that path reads back:

- **101** system — switches, variables (1-indexed in-game → 0-indexed in the save), save_count
- **104** hero — map / x / y / facing
- **108** party actors — per-actor level, exp, equipment, skills, HP, MP
- **109** inventory — roster, gold, sorted item ids + counts

## Supporting `mruby-lcf` infra (build a save from scratch)

The ADR 0018 writer could only *edit* a save parsed from bytes. To assemble one from nothing:

- `LCF.pack_int16` + an `:int16_array` `encode` branch (equipment / skills / item ids) — the one field type `from_lsd` reads that wasn't yet encodable. Built byte-wise, so it needs no mruby-pack endian-suffix *pack* support.
- `Array2D#[]=` plus an empty-table constructor (`Array2D.new('', schema)`).
- An empty `File`/`SaveData` constructor (`SaveData.new` with no stream).

## Integration (no Continue regression)

`save_game` writes the authoritative full-fidelity `Marshal` save **and** best-effort-exports `Save<slot>.lsd` beside it (a failed export is logged, never fatal), so a slot is readable by real RPG_RT / EasyRPG tooling. `continue_game` now **prefers our Marshal save** and falls back to a `.lsd` only when there is none — so the lower-fidelity export (it drops timer, message config, BGM, actor overrides and access flags) never shadows a richer save, while a foreign editor save dropped into the game dir still resumes.

## Verification

- **Game-level round-trip** — `scripts/rpg2k_save_load_check.rb` now asserts `state → to_lsd → from_lsd` preserves every modelled field (position, gold, items, roster, per-actor level/exp/HP/MP/equipment/skills, switches, variables) against the real Nepheshel (2000) and mtf-meido-action (2003) saves.
- **mruby unit tests** (`mruby-lcf/test/lcf_test.rb`, the native `test` gate) — extended with the from-scratch path: `pack_int16` / `:int16_array` encoding, an `Array2D` populated via `#[]=`, and an empty `SaveData` built chunk by chunk and read straight back.
- New code uses only mruby-core methods (the constraint #180's follow-up fix established — no `String#<<` / `Integer#zero?`).

Docs: **ADR 0019**, changelog fragment, `docs/TODO.md` update (Save & Continue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_