### PR TITLE
Extend the .lsd export to near-parity with the Marshal save

### DIFF
--- a/changelog.d/lcf-save-lsd-extended-fields.added.md
+++ b/changelog.d/lcf-save-lsd-extended-fields.added.md
@@ -1,0 +1,17 @@
+- The `Save<slot>.lsd` export is now near-parity with the portable `Marshal`
+  save. `Game::State#to_lsd` / `from_lsd` gained the fields ADR 0019 had dropped:
+  the **message-window configuration** (position / transparency / face,
+  SaveSystem 41-54), the **current & memorised BGM** (75 / 78), the
+  **player-transparent flag** (55) and the **menu / save / teleport / escape
+  access flags** (121-124), plus the leader's on-map **CharSet override** in the
+  hero chunk (104). It also now writes the **title chunk (100)** — the OLE
+  timestamp, the leader's name / level / current HP and each party member's
+  FaceSet — so a real RPG_RT / EasyRPG file-select screen shows the party. The
+  timestamp is a `:double`, so the `mruby-lcf` writer gained `LCF.pack_double`
+  (a byte-wise IEEE-754 encoder, the inverse of `unpack_double`) and a `:double`
+  `encode` branch. The only live-state fields still not in the `.lsd` are the
+  game timer (liblcf's SaveSystem has no field for it) and per-actor name/title
+  overrides for non-leader members, so the Marshal save stays primary.
+  `scripts/rpg2k_save_load_check.rb` now mutates every new field before the
+  `state -> to_lsd -> from_lsd` round-trip and asserts each survives, against the
+  real Nepheshel (2000) and mtf-meido-action (2003) saves. See ADR 0019.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -241,11 +241,18 @@ The work below is roughly ordered by the critical path to a walkable game
   `SaveData#save_to` writes a genuine `Save<slot>.lsd`, exported alongside the
   Marshal save on every save (ADR 0019, on the `mruby-lcf` serializer of ADR
   0018). It round-trips through `from_lsd` field-for-field
-  (`scripts/rpg2k_save_load_check.rb`). Remaining refinements to make the `.lsd`
-  the *primary* save (so Continue prefers it): model the fields the Marshal save
-  still holds but `.lsd` drops here — timer, message config, current/memorized
-  BGM, actor name/title/sprite overrides, access flags — plus the title chunk
-  (100, needs `:double` timestamp encoding) so the save-slot menu shows the party
+  (`scripts/rpg2k_save_load_check.rb`). The export is now **near-parity** with the
+  Marshal save: on top of the four original chunks it also writes the message
+  config, current/memorized BGM, the player-transparent flag, the
+  menu/save/teleport/escape access flags (all SaveSystem chunk 101), the leader's
+  on-map CharSet override (hero chunk 104) and the **title chunk (100)** — the
+  `:double` timestamp (via the new `LCF.pack_double`), the leader's
+  name/level/HP and the party FaceSets — so a real RPG_RT/EasyRPG file-select
+  screen shows the party. Still keeping the Marshal save *primary* (so Continue
+  prefers it) are two fields the `.lsd` cannot yet carry: the **game timer**
+  (liblcf's SaveSystem has no field for it — needs a documented chunk id) and
+  **per-actor name/title overrides for non-leader** members (only the leader's
+  name is in the title chunk)
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations, game-over scene (large; Nepheshel uses the default RPG2000
   battle). Needs real assets + the native build to develop against

--- a/docs/adr/0020-lsd-export-extended-fields.md
+++ b/docs/adr/0020-lsd-export-extended-fields.md
@@ -1,0 +1,85 @@
+# 20. Bring the .lsd export to near-parity with the Marshal save
+
+Date: 2026-08-04
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0019 gave `Game::State#to_lsd` a writer that exports four save chunks
+(system 101, hero 104, actors 108, inventory 109) as the exact inverse of
+`from_lsd`, and closed by naming what promoting `.lsd` to the *primary* save
+would take: modelling the fields the `Marshal` dump carries but the export drops
+— the timer, message config, current/memorized BGM, actor name/title/sprite
+overrides and the menu/save/teleport/escape access flags — plus the title chunk
+(100), which needs `:double` timestamp encoding for the save-slot menu. This ADR
+narrows that gap to almost nothing.
+
+Two facts shaped the scope:
+
+- **Most of those fields already exist in the `SAVE_SYSTEM` / `SAVE_TITLE` /
+  `SAVE_MOVABLE` schema**, they were simply never written or read by the runtime.
+  The message config maps to SaveSystem 41–54, the BGM to 75 / 78, the
+  player-transparent flag to 55, the access flags to 121–124; the leader's on-map
+  sprite is the hero chunk's CharSet (104 / 73 / 75); the title chunk (100) holds
+  the leader's name / level / HP and the party FaceSets. These mappings were
+  confirmed field-for-field against liblcf's `RPG::SaveSystem`.
+- **The game timer has no home in the save's system chunk.** liblcf's
+  `SaveSystem` carries a `frame_count` but no timer field, so there is no
+  documented chunk id to write the countdown into. Inventing one would violate
+  the codebase's rule that every schema field cites a source (a wiki page or a
+  real-save decode), so the timer is deliberately left out rather than guessed.
+
+The one encoder still missing was `:double`: `LCF.encode` handled every scalar
+and array type a save needs except the title timestamp.
+
+## Decision
+
+- **`Game::State#to_lsd` / `from_lsd` round-trip the extended fields.** The
+  export now also writes, and the reader restores: the message-window
+  configuration (SaveSystem 41–54, with the documented sign conventions — 41
+  transparency is 0/1, 43 prevent-overlap is the inverse of our "pinned" flag, 53
+  face side is 0 left / 1 right), the current and memorized BGM (75 / 78, via a
+  nested BGM chunk built from our `{ name:, volume:, tempo: }` hash), the
+  player-transparent flag (55), the access flags (121–124, only overriding the
+  constructor default when physically present so a foreign save keeps our
+  defaults), the leader's CharSet override in the hero chunk (104), and the title
+  chunk (100): the timestamp, the leader's name / level / current HP and up to
+  four party FaceSets. The leader's display name is restored from the title
+  chunk, so a Change Actor Name on the leader survives.
+- **Add the `:double` encoder.** `LCF.pack_double` builds the 8 little-endian
+  IEEE-754 bytes byte-wise from the sign / biased exponent / 52-bit mantissa —
+  the inverse of `unpack_double` — so it needs neither the `'E'` pack directive
+  nor a full 64-bit integer (mruby's `Integer` is 63-bit; the assembly never
+  forms a value above 2**52). `LCF.encode` gains a `:double` branch. It is exact
+  over the non-negative finite domain a timestamp occupies, which is also the
+  domain `unpack_double`'s 63-bit assembly reproduces.
+- **Keep the Marshal save primary.** With the timer and non-leader name/title
+  overrides still outside the `.lsd`, `save_game` continues to write the Marshal
+  dump as authoritative and export the (now near-parity) `.lsd` beside it;
+  Continue still prefers the Marshal save and falls back to a `.lsd` only when
+  there is none.
+
+## Consequences
+
+- **The `.lsd` we write is now readable as a real save with the party on the
+  file screen.** A genuine RPG_RT / EasyRPG file-select shows the leader's name,
+  level, HP and the party portraits from the title chunk we emit.
+- **The round-trip guard grew.** `scripts/rpg2k_save_load_check.rb` mutates every
+  new field (message config, BGM, transparency, access flags, leader sprite /
+  name) to a non-default value before `state -> to_lsd -> from_lsd` and asserts
+  each survives, against the real Nepheshel (2000) and mtf-meido-action (2003)
+  saves; it also gained a `utf8_to_cp932` shim, since the writer now emits string
+  fields the earlier all-numeric export never did. The CI gate,
+  `mruby-lcf/test/lcf_test.rb`, adds a `pack_double` / `:double` round-trip
+  (checked against the 1.5 reference bytes and `unpack_double`) and a
+  from-scratch save that writes the title chunk plus the extended system fields
+  and reads them straight back.
+- **The remaining gap to a `.lsd`-primary save is two fields.** The game timer
+  (blocked on a documented SaveSystem chunk id) and per-actor name/title
+  overrides for non-leader members. Both are tracked in `docs/TODO.md`.
+- **mruby-core discipline carries forward.** `pack_double` uses only core
+  arithmetic and `Array#pack('C*')`, forming no value wider than mruby's 63-bit
+  integer, consistent with the ADR 0018/0019 constraint.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -301,19 +301,79 @@ module LCF
     out.pack('C*')
   end
 
+  # Encode a Ruby Float as a little-endian IEEE-754 64bit double -- the inverse
+  # of unpack_double (the save file's timestamp field). Assembled byte-wise from
+  # the sign / biased exponent / 52bit mantissa so it needs neither the 'E' pack
+  # directive nor a full 64bit integer (mruby's Integer is 63bit): the sign and
+  # exponent land in the top two bytes and the mantissa fills the low seven, so
+  # no intermediate value ever exceeds 2**52. Finite values (including 0.0) and
+  # NaN are handled; a timestamp is always finite and non-negative, which is also
+  # the domain unpack_double reproduces exactly (its 63bit assembly cannot hold a
+  # bit pattern with the sign or a very large exponent set).
+  def pack_double v
+    v = v.to_f
+    sign = 0
+    if v != v                       # NaN
+      exp = 0x7ff
+      frac = 1 << 51
+    elsif v == 0.0
+      exp = 0
+      frac = 0
+    else
+      if v < 0.0
+        sign = 1
+        v = -v
+      end
+      e = 0
+      while v >= 2.0 && e < 1024
+        v = v / 2.0
+        e = e + 1
+      end
+      while v < 1.0 && e > -1074
+        v = v * 2.0
+        e = e - 1
+      end
+      exp = e + 1023
+      # 52bit mantissa of the normalised significand (1.xxxx -> xxxx), rounded.
+      frac = ((v - 1.0) * 4503599627370496.0 + 0.5).to_i
+      if frac >= 4503599627370496   # rounding carried into the next binade
+        frac = 0
+        exp = exp + 1
+      end
+      if exp >= 0x7ff               # overflow -> infinity
+        exp = 0x7ff
+        frac = 0
+      elsif exp <= 0                # underflow -> flush to zero
+        exp = 0
+        frac = 0
+      end
+    end
+    b = []
+    b[0] = frac & 0xff
+    b[1] = (frac >> 8) & 0xff
+    b[2] = (frac >> 16) & 0xff
+    b[3] = (frac >> 24) & 0xff
+    b[4] = (frac >> 32) & 0xff
+    b[5] = (frac >> 40) & 0xff
+    b[6] = ((exp & 0xf) << 4) | ((frac >> 48) & 0xf)
+    b[7] = (sign << 7) | ((exp >> 4) & 0x7f)
+    b.pack('C*')
+  end
+
   # Encode a Ruby value back to the raw chunk bytes for a schema field -- the
   # inverse of to_rb. Only the scalar and simple-array types a save actually
-  # needs to be re-authored are handled; the packed command/double/tree types
-  # are still round-tripped as their original raw bytes (never re-encoded from
-  # decoded values), so they are intentionally left out. A nested :Array1D /
-  # :Array2D value is serialised through its own #to_lcf. Strings go back out
-  # as cp932 via LCF.utf8_to_cp932 (the build's uni-algo encoder; the CRuby
-  # harnesses provide a Windows-31J stand-in), mirroring cp932_to_utf8 on read.
+  # needs to be re-authored are handled; the packed command/tree types are still
+  # round-tripped as their original raw bytes (never re-encoded from decoded
+  # values), so they are intentionally left out. A nested :Array1D / :Array2D
+  # value is serialised through its own #to_lcf. Strings go back out as cp932 via
+  # LCF.utf8_to_cp932 (the build's uni-algo encoder; the CRuby harnesses provide
+  # a Windows-31J stand-in), mirroring cp932_to_utf8 on read.
   def encode value, type
     case type
     when :int ; write_ber value
     when :bool ; [value ? 1 : 0].pack('C')
     when :uint8 ; [value & 0xff].pack('C')
+    when :double ; pack_double value
     when :int8_array ; value.pack('C*')
     when :bool_array ; value.map { |b| b ? 1 : 0 }.pack('C*')
     when :int16_array ; pack_int16 value
@@ -330,7 +390,7 @@ module LCF
   module_function :read_ber, :write_ber, :to_rb, :read_section,
                   :parse_event_commands, :parse_move_commands,
                   :unpack_int32, :unpack_double, :pack_int32, :pack_int16,
-                  :encode, :binstr
+                  :pack_double, :encode, :binstr
 
   MODE = 2000 # 2003
 

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -540,6 +540,65 @@ assert 'LCF.pack_int16 / encode :int16_array inverts the reader' do
   assert_equal [10, 20, 0, 0, 5].pack('v*'), LCF.pack_int16([10, 20, 0, 0, 5])
 end
 
+assert 'LCF.pack_double / encode :double inverts unpack_double' do
+  # The little-endian IEEE-754 bytes of 1.5 -- the same reference the reader test
+  # above decodes -- must be exactly what pack_double emits.
+  assert_equal "\x00\x00\x00\x00\x00\x00\xf8\x3f", LCF.pack_double(1.5)
+  assert_equal LCF.pack_double(2.5), LCF.encode(2.5, :double)
+  # The non-negative finite values a save timestamp actually takes round-trip
+  # through unpack_double exactly (the reader's 63bit assembly holds this domain).
+  [0.0, 1.0, 2.5, 0.5, 1234.0, 45000.5, 100.25].each do |v|
+    assert_equal v, LCF.unpack_double(LCF.pack_double(v)), "double #{v}"
+  end
+end
+
+assert 'SaveData title chunk + system message/bgm/access fields round-trip from scratch' do
+  save = LCF::SaveData.new
+  # Title (chunk 100): the :double timestamp exercises the pack_double encoder,
+  # plus the leader name/level/HP and a face slot shown on the file screen.
+  title = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_TITLE })
+  title[1] = 45000.5
+  title[11] = "Iris"; title[12] = 9; title[13] = 123
+  title[21] = "FaceA"; title[22] = 2
+  save[100] = title
+  # System (chunk 101): message-window config, the player-transparent flag, a
+  # nested current-BGM chunk and the access flags.
+  sys = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SYSTEM })
+  sys[41] = 1; sys[42] = 0; sys[43] = false
+  sys[51] = "MsgFace"; sys[52] = 4; sys[53] = 1; sys[54] = true
+  sys[55] = true
+  cur = LCF::Array1D.new('', { elements: LCF::Schema::BGM })
+  cur[1] = "Field"; cur[3] = 80; cur[4] = 120
+  sys[75] = cur
+  sys[121] = true; sys[122] = false; sys[123] = false; sys[124] = true
+  save[101] = sys
+
+  reread = LCF::SaveData.new(StringIO.new(save.to_lcf))
+  t = reread[100]
+  assert_equal 45000.5, t.timestamp
+  assert_equal "Iris", t.hero_name
+  assert_equal 9, t.hero_level
+  assert_equal 123, t.hero_hp
+  assert_equal "FaceA", t.face1_name
+  assert_equal 2, t.face1_index
+  s = reread[101]
+  assert_equal 1, s.message_transparent
+  assert_equal 0, s.message_position
+  assert_false s.message_prevent_overlap
+  assert_equal "MsgFace", s.face_name
+  assert_equal 4, s.face_index
+  assert_equal 1, s.face_right_position
+  assert_true s.face_flip
+  assert_true s.transparent
+  assert_equal "Field", s.current_bgm.file
+  assert_equal 80, s.current_bgm.volume
+  assert_equal 120, s.current_bgm.pitch
+  assert_true s.teleport_allowed
+  assert_false s.escape_allowed
+  assert_false s.save_allowed
+  assert_true s.menu_allowed
+end
+
 assert 'Array2D built from scratch serialises and reads back' do
   schema = { elements: LCF::Schema::SAVE_PARTY_ACTOR }
   a = LCF::Array2D.new('', schema)         # empty, writable table

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -833,6 +833,18 @@ module Game
       @charset_index = index
     end
 
+    # The actor's database FaceSet graphic (顔グラフィック), shown on the
+    # save-select screen (the SAVE_TITLE face slots) -- distinct from the message
+    # face configured per Show Message. Defaults to none when the database row
+    # (or edition) does not carry one.
+    def faceset_name
+      @db_row.respond_to?(:faceset_name) ? (@db_row.faceset_name || '') : ''
+    end
+
+    def faceset_index
+      @db_row.respond_to?(:faceset_index) ? (@db_row.faceset_index || 0) : 0
+    end
+
     # Whether the actor knows `skill_id`.
     def knows_skill?(skill_id)
       return false if skill_id.nil? || skill_id == 0
@@ -1910,25 +1922,61 @@ module Game
     end
 
     # Serialise to a genuine RPG2000/2003 Save<N>.lsd (an LCF::SaveData) -- the
-    # inverse of .from_lsd. It writes exactly the chunks that path reads back:
-    # the system chunk (101: switches, variables, save_count), the hero
-    # position/facing (104), the per-actor level/exp/equipment/skills/HP/MP table
-    # (108) and the party roster / gold / item bag (109). Fields our Marshal save
-    # also carries but this format does not model here (timer, message config,
-    # BGM, actor name/sprite overrides, access flags) are intentionally dropped,
-    # so this is a lower-fidelity, interoperable *export* rather than a
-    # replacement for #to_h. Switch and variable ids are 1-indexed in-game but
-    # 0-indexed in the save, so they shift down by one; unset entries default to
-    # false / 0. +save_count+ goes in the system chunk (RPG_RT increments it on
-    # every save).
-    def to_lsd(save_count = 1)
+    # inverse of .from_lsd. It writes the chunks that path reads back:
+    #
+    #   * title (100): the save-select metadata -- a timestamp (a :double, hence
+    #     the pack_double encoder) and the leader's name / level / current HP plus
+    #     each party member's FaceSet, so real RPG_RT/EasyRPG tooling shows the
+    #     party on the file screen;
+    #   * system (101): switches, variables, save_count, the message-window
+    #     configuration (position / transparency / face), the current and
+    #     memorised BGM, the player-transparent flag and the
+    #     menu/save/teleport/escape access flags;
+    #   * hero (104): map position, facing and the leader's on-map CharSet (so a
+    #     Change Sprite override survives);
+    #   * actors (108): the per-actor level/exp/equipment/skills/HP/MP table;
+    #   * inventory (109): the party roster / gold / item bag.
+    #
+    # Switch and variable ids are 1-indexed in-game but 0-indexed in the save, so
+    # they shift down by one; unset entries default to false / 0. +save_count+
+    # goes in the system chunk (RPG_RT increments it on every save); +timestamp+
+    # is the OLE-automation date shown on the file screen (a placeholder default,
+    # since this environment has no clock and the save-select scene is not drawn
+    # yet). The only live-state fields still dropped versus #to_h are the game
+    # timer (which liblcf's SaveSystem has no field for) and per-actor name/title
+    # overrides for non-leader members, so this is now a near-parity export.
+    def to_lsd(save_count = 1, timestamp = 0.0)
       save = LCF::SaveData.new
+
+      leader = @party.leader
+      members = @party.actors
+      if leader
+        title = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_TITLE })
+        title[1] = timestamp.to_f
+        title[11] = leader.name
+        title[12] = leader.level
+        title[13] = leader.hp
+        # Up to four party faces fill the file-screen portrait slots (21/22 ..
+        # 27/28), one FaceSet name+index pair per member.
+        face_fields = [[21, 22], [23, 24], [25, 26], [27, 28]]
+        members.each_index do |i|
+          break if i >= face_fields.size
+          nf, xf = face_fields[i]
+          title[nf] = members[i].faceset_name
+          title[xf] = members[i].faceset_index
+        end
+        save[100] = title
+      end
 
       hero = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
       hero[11] = @map_id
       hero[12] = @x
       hero[13] = @y
       hero[22] = @direction || 2
+      if leader
+        hero[73] = leader.charset_name || ''
+        hero[75] = leader.charset_index || 0
+      end
       save[104] = hero
 
       sys = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SYSTEM })
@@ -1944,6 +1992,25 @@ module Game
       vr.each { |id, v| variables[id - 1] = v }
       sys[33] = vr_max
       sys[34] = variables
+      # Message-window configuration (field 41 transparency is 0/1, 43 is the
+      # inverse of our "pinned" flag: prevent-overlap true == not position_fixed,
+      # 53 face side is 0 left / 1 right).
+      mc = @message_config
+      sys[41] = mc.transparent ? 1 : 0
+      sys[42] = mc.position
+      sys[43] = mc.position_fixed ? false : true
+      sys[44] = mc.continue_events ? true : false
+      sys[51] = mc.face_name || ''
+      sys[52] = mc.face_index || 0
+      sys[53] = mc.face_right ? 1 : 0
+      sys[54] = mc.face_flipped ? true : false
+      sys[55] = @player_transparent ? true : false
+      sys[75] = bgm_chunk(@current_bgm) if @current_bgm
+      sys[78] = bgm_chunk(@memorized_bgm) if @memorized_bgm
+      sys[121] = @teleport_access ? true : false
+      sys[122] = @escape_access ? true : false
+      sys[123] = @save_access ? true : false
+      sys[124] = @menu_access ? true : false
       sys[131] = save_count
       sys[132] = 1
       save[101] = sys
@@ -1974,14 +2041,30 @@ module Game
       save
     end
 
+    # Build a BGM chunk (an LCF::Array1D over the BGM schema) from our stored
+    # `{ name:, volume:, tempo: }` hash: file (1), volume (3) and pitch (4). Used
+    # for the system chunk's current-BGM (75) and stored-BGM (78) slots.
+    def bgm_chunk(bgm)
+      b = LCF::Array1D.new('', { elements: LCF::Schema::BGM })
+      b[1] = bgm[:name] || ''
+      b[3] = bgm[:volume] || 100
+      b[4] = bgm[:tempo] || 100
+      b
+    end
+
     # Rebuild a State from a parsed LCF::SaveData -- a real Save<N>.lsd written
-    # by an actual editor, rather than our own Marshal hash. Only the fields we
-    # model are restored: the hero's map, tile position and facing (chunk 104),
-    # the party roster / gold / items (inventory, chunk 109) and the switches and
-    # variables (system, chunk 101). Switches and variables are 0-indexed arrays
-    # in the save but 1-indexed in-game, so they shift by one. `save[101]` is
-    # used instead of `save.system` because the latter collides with Kernel#system
-    # under CRuby (where the loaders are unit-tested).
+    # by an actual editor, rather than our own Marshal hash. The modelled fields
+    # are restored: the hero's map / tile position / facing and the leader's
+    # on-map CharSet (chunk 104), the party roster / gold / items (inventory,
+    # chunk 109), the per-actor level/exp/HP/MP/equipment/skills table (chunk
+    # 108), the switches and variables plus the message-window configuration, the
+    # current / memorised BGM, the player-transparent flag and the access flags
+    # (system, chunk 101), and the leader's display name (title, chunk 100).
+    # Switches and variables are 0-indexed arrays in the save but 1-indexed
+    # in-game, so they shift by one. `save[101]` / `save[100]` are used instead of
+    # `save.system` / `save.title` because the former collides with Kernel#system
+    # under CRuby (where the loaders are unit-tested) and the latter is kept
+    # parallel to it.
     def self.from_lsd(db, save)
       hero = save.hero
       inv = save.inventory
@@ -2012,6 +2095,11 @@ module Game
       party.load_state(items: items, gold: inv.gold, hp: hp, mp: mp)
       state = new(party, hero.map_id, hero.x, hero.y)
       state.direction = hero.direction || 2
+      # The leader's on-map sprite override (a Change Sprite Association), stored
+      # in the hero chunk's CharSet fields.
+      if party.leader && hero.charset_name && !hero.charset_name.empty?
+        party.leader.set_charset(hero.charset_name, hero.charset_index || 0)
+      end
       sys = save[101]
       switches = {}
       (sys.switches || []).each_with_index { |v, i| switches[i + 1] = v if v }
@@ -2019,7 +2107,44 @@ module Game
       variables = {}
       (sys.variables || []).each_with_index { |v, i| variables[i + 1] = v unless v == 0 }
       state.variables.replace(variables)
+      # Message-window configuration (inverse of the mapping #to_lsd writes).
+      mc = state.message_config
+      mc.transparent = (sys.message_transparent || 0) != 0
+      mc.position = sys.message_position || MessageConfig::POS_BOTTOM
+      mc.position_fixed = sys.message_prevent_overlap ? false : true
+      mc.continue_events = sys.message_continue_events ? true : false
+      mc.face_name = sys.face_name || ''
+      mc.face_index = sys.face_index || 0
+      mc.face_right = (sys.face_right_position || 0) != 0
+      mc.face_flipped = sys.face_flip ? true : false
+      state.player_transparent = sys.transparent ? true : false
+      # Overridden BGM playback state; an empty file name means "none".
+      state.current_bgm = bgm_from_chunk(sys.current_bgm)
+      state.memorized_bgm = bgm_from_chunk(sys.stored_bgm)
+      # Access flags: only an explicitly-stored value overrides the constructor
+      # default (so a foreign save that omits them keeps our defaults).
+      state.teleport_access = sys.teleport_allowed unless sys.teleport_allowed.nil?
+      state.escape_access = sys.escape_allowed unless sys.escape_allowed.nil?
+      state.save_access = sys.save_allowed unless sys.save_allowed.nil?
+      state.menu_access = sys.menu_allowed unless sys.menu_allowed.nil?
+      # The leader's display name from the file-screen title chunk (a Change
+      # Actor Name override survives for the leader).
+      title = save[100]
+      if title && party.leader
+        nm = title.hero_name
+        party.leader.name = nm if nm && !nm.empty?
+      end
       state
+    end
+
+    # Rebuild our `{ name:, volume:, tempo: }` BGM hash from a parsed BGM chunk
+    # (an LCF::Array1D over the BGM schema). Returns nil for an absent chunk or an
+    # empty file name (the "use the database value" sentinel).
+    def self.bgm_from_chunk(chunk)
+      return nil unless chunk
+      name = chunk.file
+      return nil if name.nil? || name.empty?
+      { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100 }
     end
 
     # Rebuild a State from a saved hash. Actors are re-created from the database

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2222,9 +2222,9 @@ class RPG2k
   end
 
   # Persist the running game state to a slot. Our own portable Marshal dump is
-  # the authoritative save (it carries the full state -- timer, message config,
-  # BGM, actor overrides, access flags -- that the .lsd format does not model
-  # here). Alongside it we also export a genuine editor Save<slot>.lsd via
+  # the authoritative save (it still carries the two fields the .lsd export does
+  # not model -- the game timer and per-actor name/title overrides for non-leader
+  # members). Alongside it we also export a near-parity editor Save<slot>.lsd via
   # State#to_lsd, so the slot is readable by real RPG_RT/EasyRPG tooling. The
   # export is best-effort: a failure there is logged but never fails the save.
   def save_game state, slot = 1
@@ -2247,11 +2247,11 @@ class RPG2k
 
   # Continue: resume a saved game and switch to its map. Our own Marshal save is
   # preferred when present -- it is the full-fidelity record we wrote (save_game
-  # also exports a lower-fidelity Save<slot>.lsd beside it, which would drop the
-  # timer, message config, BGM and actor overrides if loaded instead). A genuine
-  # editor Save<N>.lsd is the fallback, so a real save dropped into the game dir
-  # (with no Marshal save) still resumes through the LCF save schema. Warns and
-  # stays on the title when there is nothing to load.
+  # also exports a near-parity Save<slot>.lsd beside it, which would still drop
+  # the timer and non-leader actor name/title overrides if loaded instead). A
+  # genuine editor Save<N>.lsd is the fallback, so a real save dropped into the
+  # game dir (with no Marshal save) still resumes through the LCF save schema.
+  # Warns and stays on the title when there is nothing to load.
   def continue_game
     if File.exist?(save_path)
       data = File.open(save_path, "rb") { |f| f.read }

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -26,7 +26,14 @@ module LCF
     s.dup.force_encoding('Windows-31J')
      .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
   end
-  module_function :cp932_to_utf8
+  # Inverse of cp932_to_utf8, for the writer path (State#to_lsd now emits string
+  # fields -- charset, face and BGM names, the hero name). Mirrors the build's
+  # native uni-algo encoder with Ruby's Windows-31J transcoder.
+  def utf8_to_cp932(s)
+    s.dup.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
   def self.max_level; MODE == 2003 ? 99 : 50; end
 end
 
@@ -118,6 +125,32 @@ def check_game(dir)
   # Writer round-trip (ADR 0019): serialise the runtime state back to a genuine
   # .lsd with State#to_lsd, re-read it with State.from_lsd, and confirm every
   # modelled field survives -- i.e. to_lsd is a faithful inverse of from_lsd.
+  #
+  # Exercise the extended fields the export gained after ADR 0019 (message-window
+  # config, current/memorised BGM, the player-transparent flag, the access flags
+  # and the leader's sprite/name overrides) by mutating the state to non-default
+  # values first, so the round-trip proves they are written and read back.
+  mc = state.message_config
+  mc.transparent = true
+  mc.position = Game::MessageConfig::POS_TOP
+  mc.position_fixed = true
+  mc.continue_events = true
+  mc.face_name = 'FaceSet1'
+  mc.face_index = 3
+  mc.face_right = true
+  mc.face_flipped = true
+  state.player_transparent = true
+  state.current_bgm = { name: 'Theme', volume: 80, tempo: 120 }
+  state.memorized_bgm = { name: 'Boss', volume: 90, tempo: 100 }
+  state.menu_access = false
+  state.save_access = false
+  state.teleport_access = true
+  state.escape_access = true
+  if state.party.leader
+    state.party.leader.set_charset('HeroAlt', 5)
+    state.party.leader.name = 'Renamed'
+  end
+
   round = Game::State.from_lsd(db, LCF::SaveData.new(StringIO.new(state.to_lsd.to_lcf)))
   eq state.map_id, round.map_id, 'to_lsd: map id'
   eq state.x, round.x, 'to_lsd: hero x'
@@ -141,6 +174,29 @@ def check_game(dir)
      round.switches.to_h.select { |_k, v| v }.keys.sort, 'to_lsd: switches on'
   eq state.variables.to_h.reject { |_k, v| v == 0 },
      round.variables.to_h.reject { |_k, v| v == 0 }, 'to_lsd: variables set'
+
+  # Extended fields: message config, BGM, transparency, access flags, overrides.
+  rmc = round.message_config
+  eq true, rmc.transparent, 'to_lsd: message transparent'
+  eq Game::MessageConfig::POS_TOP, rmc.position, 'to_lsd: message position'
+  eq true, rmc.position_fixed, 'to_lsd: message position_fixed'
+  eq true, rmc.continue_events, 'to_lsd: message continue_events'
+  eq 'FaceSet1', rmc.face_name, 'to_lsd: message face_name'
+  eq 3, rmc.face_index, 'to_lsd: message face_index'
+  eq true, rmc.face_right, 'to_lsd: message face_right'
+  eq true, rmc.face_flipped, 'to_lsd: message face_flipped'
+  eq true, round.player_transparent, 'to_lsd: player_transparent'
+  eq({ name: 'Theme', volume: 80, tempo: 120 }, round.current_bgm, 'to_lsd: current_bgm')
+  eq({ name: 'Boss', volume: 90, tempo: 100 }, round.memorized_bgm, 'to_lsd: memorized_bgm')
+  eq false, round.menu_access, 'to_lsd: menu_access'
+  eq false, round.save_access, 'to_lsd: save_access'
+  eq true, round.teleport_access, 'to_lsd: teleport_access'
+  eq true, round.escape_access, 'to_lsd: escape_access'
+  if round.party.leader
+    eq 'HeroAlt', round.party.leader.charset_name, 'to_lsd: leader sprite override'
+    eq 5, round.party.leader.charset_index, 'to_lsd: leader sprite index'
+    eq 'Renamed', round.party.leader.name, 'to_lsd: leader name override'
+  end
 
   puts "  leader=#{state.party.leader.name.inspect} hp=#{state.party.leader.hp} " \
        "mp=#{state.party.leader.mp} map=#{state.map_id} " \


### PR DESCRIPTION
Follow-up to ADR 0019, closing most of the gap toward making `.lsd` the primary RPG2000/2003 save.

## What

`Game::State#to_lsd` / `from_lsd` now round-trip the live-state fields the export previously dropped:

- **Message-window config** → SaveSystem chunks 41–54 (position, transparency, face — with the documented sign conventions: 41 transparency is 0/1, 43 prevent-overlap is the inverse of our "pinned" flag, 53 face side is 0 left / 1 right)
- **Current / memorized BGM** → 75 / 78 (a nested BGM chunk built from our `{ name:, volume:, tempo: }` hash)
- **Player-transparent flag** → 55
- **Menu / save / teleport / escape access flags** → 121–124 (only overriding the constructor default when physically present, so a foreign save keeps our defaults)
- **Leader's on-map CharSet override** → hero chunk 104
- **Title chunk (100)** → the timestamp, the leader's name / level / current HP and the party FaceSets, so a real RPG_RT / EasyRPG file-select screen shows the party

## New encoder

The title timestamp is a `:double`, so `mruby-lcf` gains `LCF.pack_double` — a byte-wise IEEE-754 encoder (the inverse of `unpack_double`) that forms no value wider than mruby's 63-bit integer — plus a `:double` branch in `LCF.encode`.

## Still deferred (why the Marshal save stays primary)

- **Game timer** — confirmed against liblcf that `RPG::SaveSystem` has no timer field (only `frame_count`), so there is no documented chunk id to write it into, and this codebase requires every schema field to cite a source. Left out rather than guessed.
- **Per-actor name/title overrides for non-leader members** — only the leader's name is in the title chunk.

Both are now the only items tracked in `docs/TODO.md` for a `.lsd`-primary save.

## Verification

- `scripts/rpg2k_save_load_check.rb` mutates every new field to a non-default value before the `state → to_lsd → from_lsd` round-trip and asserts each survives, against the real Nepheshel (2000) and mtf-meido-action (2003) saves. It also gained a `utf8_to_cp932` shim, since the writer now emits string fields the earlier all-numeric export never did.
- CI gate `mruby-lcf/test/lcf_test.rb` adds a `pack_double` / `:double` round-trip (checked against the 1.5 reference bytes and `unpack_double`) and a from-scratch save that writes the title chunk plus the extended system fields and reads them straight back.
- `pack_double` verified against native `pack('E')` across a range of values; all RPG2000 CRuby harnesses (logic / scene / render / save-load / testbed) stay green.

## Docs

ADR 0020, a changelog fragment, and narrowed `docs/TODO.md` / `main.rb` comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_