### PR TITLE
rpg2k: Key Input Processing, Show Inn, and inert-scaffolding event commands

### DIFF
--- a/changelog.d/rpg2k-key-input-proc.added.md
+++ b/changelog.d/rpg2k-key-input-proc.added.md
@@ -1,0 +1,13 @@
+- The **Key Input Processing** (11610) event command is now handled. It waits
+  for — or, in no-wait mode, samples — one of a chosen set of buttons and writes
+  its RPG2000 key code to a variable (Down 1, Left 2, Right 3, Up 4, Decision 5,
+  Cancel 6, Shift 7; highest wins when several are held). The RPG_RT parameter
+  layout is followed faithfully, including the pre-1.50 form that packs all four
+  arrows into a single flag versus the 1.50+ form with an individual flag per
+  direction plus Shift. `Game::Interpreter` records the request and suspends on a
+  `:key_input` wait; `Scene::Map` samples real input (triggered edges when
+  waiting, held state otherwise) — for foreground events and, so the common
+  "parallel process polls a key each frame" idiom works, for parallel processes
+  too. RPG2003 number / operator keys and Maniac mouse input are not modelled.
+  Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/changelog.d/rpg2k-show-inn.added.md
+++ b/changelog.d/rpg2k-show-inn.added.md
@@ -1,0 +1,13 @@
+- The **Show Inn / Stay at Inn** (10730) event command is now a playable
+  subsystem. A priced inn opens a greeting window with Accept / Cancel choices
+  (Accept selectable only when the party can afford the price) and a gold
+  window; a free inn (price 0) skips the prompt. Staying deducts the price and
+  fully heals the party (HP and MP), and either outcome routes into the
+  command's optional `[Stay]` / `[No Stay]` handler branches (markers 20730 /
+  20731, closed by 20732), laid out and skipped exactly like a Show Choices
+  block. `Game::Interpreter` owns the gameplay — affordability, gold, healing
+  and branch routing — and suspends on an `:inn` wait; `Scene::Map` renders the
+  prompt and resumes it. The inn fade-out/in and the inn jingle are presentation
+  still to come (like the screen-fade commands), so staying heals without them
+  for now. Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/changelog.d/rpg2k-target-encounter-system-audio.added.md
+++ b/changelog.d/rpg2k-target-encounter-system-audio.added.md
@@ -1,0 +1,10 @@
+- The **Set Teleport Target** (11810), **Set Escape Target** (11830), **Change
+  Encounter Rate** (11740), **Change System BGM** (10660) and **Change System
+  SFX** (10670) event commands are now handled. Each records its payload in
+  `Game::State` — a per-map teleport-target registry, a single escape target,
+  the encounter step rate, and per-slot system music / sound overrides — and
+  round-trips through Save / Continue. The Teleport / Escape skills, encounter
+  system and battle / menu scenes that would consume these are not built yet, so
+  they gate and play nothing at runtime; they are modelled for save fidelity,
+  like the teleport / escape access flags. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -125,7 +125,8 @@ The work below is roughly ordered by the critical path to a walkable game
   Store Terrain/Event ID, Wait, Play BGM/SE, Memorize / Play Memorized BGM,
   Message Options, Change Face Graphic, Input Number, Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
-  Change Teleport / Escape Access,
+  Change Teleport / Escape Access, Set Teleport / Escape Target,
+  Change Encounter Rate, Change System BGM / SFX,
   Tint Screen, Flash Screen, Shake Screen, Pan Screen, Weather Effects, Call
   Event, Move Event, Change / Trade Event Location, Change Map Tileset, Proceed
   With Movement, Halt All Movement,
@@ -184,8 +185,16 @@ The work below is roughly ordered by the critical path to a walkable game
   Effects** (11070) records the map weather type (none / rain / snow) and strength
   on `Game::State` — the Ruby-half model only, like the tint overlay, so it
   round-trips through the save but drawing the rain/snow particles is native
-  renderer work still to come. The remaining commands (battles, shop / inn, EXP
-  gain / level-up
+  renderer work still to come.
+  **Set Teleport / Escape Target** (11810 / 11830), **Change Encounter Rate**
+  (11740) and **Change System BGM / SFX** (10660 / 10670) record their payloads
+  on `Game::State` — a per-map teleport-target registry, a single escape target,
+  the encounter step rate and per-slot system music / sound overrides — and
+  round-trip through the save, but nothing consumes them yet (the Teleport /
+  Escape skills, encounter system and battle / menu scenes are not built), so
+  they are modelled for save fidelity like the access flags.
+  The remaining commands (battles, shop / inn, EXP gain / level-up
+  messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;
   speed/wait codes are consumed). Text now **reveals gradually** (a

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -127,7 +127,7 @@ The work below is roughly ordered by the critical path to a walkable game
   Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
   Change Teleport / Escape Access, Set Teleport / Escape Target,
-  Change Encounter Rate, Change System BGM / SFX,
+  Change Encounter Rate, Change System BGM / SFX, Show Inn,
   Tint Screen, Flash Screen, Shake Screen, Pan Screen, Weather Effects, Call
   Event, Move Event, Change / Trade Event Location, Change Map Tileset, Proceed
   With Movement, Halt All Movement,
@@ -198,7 +198,14 @@ The work below is roughly ordered by the critical path to a walkable game
   round-trip through the save, but nothing consumes them yet (the Teleport /
   Escape skills, encounter system and battle / menu scenes are not built), so
   they are modelled for save fidelity like the access flags.
-  The remaining commands (battles, shop / inn, EXP gain / level-up
+  **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
+  window with Accept / Cancel choices (Accept gated on whether the party can
+  afford it) plus a gold window, staying deducts the price and fully heals the
+  party, and either outcome routes into the command's optional `[Stay]` /
+  `[No Stay]` handler branches (structured and skipped like Show Choices).
+  `Game::Interpreter` owns the gameplay and suspends on an `:inn` wait that
+  `Scene::Map` drives; the inn fade and jingle are presentation still to come.
+  The remaining commands (battles, shop, EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -123,7 +123,8 @@ The work below is roughly ordered by the critical path to a walkable game
   Branch/Else/End,
   Loop/Break/End, Label/Jump, Timer, Teleport, Memorize/Recall Location,
   Store Terrain/Event ID, Wait, Play BGM/SE, Memorize / Play Memorized BGM,
-  Message Options, Change Face Graphic, Input Number, Change Actor
+  Message Options, Change Face Graphic, Input Number, Key Input Processing,
+  Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
   Change Teleport / Escape Access, Set Teleport / Escape Target,
   Change Encounter Rate, Change System BGM / SFX,
@@ -145,7 +146,11 @@ The work below is roughly ordered by the critical path to a walkable game
   progress has finished — the scene advances those routes while it waits and
   resumes it once none remain. **Halt All Movement** cancels every forced route
   at once (the player's and each event's). **Input Number** suspends on a
-  digit-entry widget and writes the entered value to a variable. **Change Actor
+  digit-entry widget and writes the entered value to a variable. **Key Input
+  Processing** waits for (or, in no-wait mode, samples) a chosen set of buttons
+  and writes the pressed key's RPG2000 code to a variable — the scene drives it
+  for foreground and parallel events alike, following RPG_RT's pre-1.50 /
+  1.50+ parameter layouts (number / operator keys and mouse are not modelled). **Change Actor
   Name / Title / Sprite** rename a party actor, set its status-screen title or
   swap its CharSet graphic (the scene reloads the leader's on-screen sprite);
   these edits survive Save / Continue. **Set Transparent Flag** hides or shows

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1998,6 +1998,21 @@ module Game
     # Transparent Flag / Change Player Visibility (11310) event command. Defaults
     # off (the hero is shown) and is persisted in the save.
     attr_accessor :player_transparent
+    # Random-encounter step rate set by Change Encounter Rate (11740); nil until
+    # a command overrides it (the map's own rate then applies). No encounter
+    # subsystem consumes it yet — kept for save fidelity.
+    attr_accessor :encounter_rate
+    # Teleport / Escape skill destinations registered by Set Teleport Target
+    # (11810) and Set Escape Target (11830). `teleport_targets` is a hash keyed
+    # by map id → `{ x:, y:, switch_id: }`; `escape_target` is nil or one such
+    # hash (with `map_id:`). The skills are not executed yet, so these are
+    # modelled for save fidelity only, like the teleport / escape access flags.
+    attr_accessor :teleport_targets, :escape_target
+    # System music / sound overrides from Change System BGM (10660) and Change
+    # System SFX (10670), each a hash keyed by context slot → an audio hash. The
+    # battle / menu scenes that would play them are not built yet; stored for
+    # save fidelity.
+    attr_accessor :system_bgm, :system_sfx
 
     def initialize(party, map_id, x, y)
       @party = party
@@ -2018,6 +2033,11 @@ module Game
       @current_bgm = nil
       @memorized_bgm = nil
       @player_transparent = false
+      @encounter_rate = nil
+      @teleport_targets = {}
+      @escape_target = nil
+      @system_bgm = {}
+      @system_sfx = {}
       @weather = Weather.new
       # Transient screen-effect state (tint transition); not serialised, so a
       # reloaded game starts with a neutral screen.
@@ -2072,7 +2092,10 @@ module Game
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
         player_transparent: @player_transparent, weather: @weather.to_h,
-        teleport_access: @teleport_access, escape_access: @escape_access }
+        teleport_access: @teleport_access, escape_access: @escape_access,
+        encounter_rate: @encounter_rate, teleport_targets: @teleport_targets,
+        escape_target: @escape_target, system_bgm: @system_bgm,
+        system_sfx: @system_sfx }
     end
 
     # Serialise to a genuine RPG2000/2003 Save<N>.lsd (an LCF::SaveData) -- the
@@ -2324,6 +2347,13 @@ module Game
       state.weather.load_h(h[:weather])
       state.teleport_access = h[:teleport_access] ? true : false
       state.escape_access = h[:escape_access] ? true : false
+      # Registries default empty / unset; a save written before these existed
+      # simply restores nothing.
+      state.encounter_rate = h[:encounter_rate]
+      state.teleport_targets = h[:teleport_targets] || {}
+      state.escape_target = h[:escape_target]
+      state.system_bgm = h[:system_bgm] || {}
+      state.system_sfx = h[:system_sfx] || {}
       state
     end
   end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -38,6 +38,10 @@ module Game
       CHANGE_ACTOR_SPRITE = 10630
       CHANGE_SYSTEM_BGM   = 10660
       CHANGE_SYSTEM_SFX   = 10670
+      SHOW_INN         = 10730
+      INN_STAY         = 20730
+      INN_NO_STAY      = 20731
+      INN_END          = 20732
       MEMORIZE_LOCATION = 10820
       RECALL_LOCATION   = 10830
       CHANGE_EVENT_LOCATION = 10860
@@ -123,7 +127,7 @@ module Game
     def running?; @running; end
     def waiting?; @waiting; end
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
-                :teleport, :input_digits, :key_input_request
+                :teleport, :input_digits, :key_input_request, :inn_request
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
@@ -286,6 +290,41 @@ module Game
       reset_waits
     end
 
+    # Resume a Show Inn request with the player's decision. On a stay: charge the
+    # inn price and fully heal the party (HP and MP). Either way, if the event
+    # carries [Stay] / [No Stay] handler sub-branches, jump into the matching one;
+    # otherwise execution simply continues past the command. The owning scene
+    # shows the greeting / choice prompt while the interpreter is paused on the
+    # :inn wait, then calls this.
+    def resume_inn(stayed)
+      if stayed
+        party.gain_gold(-@inn_price) if @inn_price && @inn_price > 0
+        party.actors.each(&:full_heal)
+      end
+      if @inn_has_handlers
+        target = find_inn_option(stayed)
+        @index = target if target
+      end
+      reset_waits
+    end
+
+    # Locate the [Stay] (INN_STAY) or [No Stay] (INN_NO_STAY) handler branch for
+    # the pending inn, returning the index just after its marker. Falls back to
+    # the INN_END marker (so an absent branch runs nothing) and to nil once the
+    # inn's own indent level is left without a match.
+    def find_inn_option(stay)
+      want = stay ? Cmd::INN_STAY : Cmd::INN_NO_STAY
+      i = @index
+      while i < @list.size
+        c = @list[i]
+        return i + 1 if c.indent == @inn_indent && c.code == want
+        return i if c.indent == @inn_indent && c.code == Cmd::INN_END
+        return nil if c.indent < @inn_indent
+        i += 1
+      end
+      nil
+    end
+
     # RPG2000 key-input result codes in priority order (highest first). When more
     # than one accepted button is active RPG_RT returns the largest code:
     # Shift > Cancel > Decision > Up > Right > Left > Down.
@@ -317,6 +356,7 @@ module Game
       @wait_frames = 0
       @teleport = nil
       @key_input_request = nil
+      @inn_request = nil
     end
 
     def switches;  @state.switches;  end
@@ -333,6 +373,10 @@ module Game
       when Cmd::CHOICE_END       then nil
       when Cmd::INPUT_NUMBER     then do_input_number cmd
       when Cmd::KEY_INPUT_PROC   then do_key_input cmd
+      when Cmd::SHOW_INN         then do_show_inn cmd
+      when Cmd::INN_STAY         then skip_to([Cmd::INN_END], cmd.indent); consume
+      when Cmd::INN_NO_STAY      then skip_to([Cmd::INN_END], cmd.indent); consume
+      when Cmd::INN_END          then nil
       when Cmd::CONTROL_SWITCHES then do_control_switches cmd
       when Cmd::CONTROL_VARS     then do_control_vars cmd
       when Cmd::TIMER_OPERATION  then do_timer cmd
@@ -600,6 +644,30 @@ module Game
       # overwrites it below via the scene's immediate resume.
       variables[var_id] = 0 if wait && var_id && var_id > 0
       @wait_kind = :key_input
+      @waiting = true
+    end
+
+    # Show Inn / Stay at Inn (10730): offer to rest for a price. param0 selects
+    # which term set greets the player (0 inn A, 1 inn B); param1 is the price.
+    # A price of 0 skips the prompt and stays for free. The command may be
+    # followed by [Stay] / [No Stay] handler branches (markers INN_STAY /
+    # INN_NO_STAY, closed by INN_END) that run on the matching outcome, laid out
+    # exactly like a Show Choices block. The interpreter records the request and
+    # suspends on an :inn wait; the scene shows the greeting, the accept / cancel
+    # choices (accept selectable only when affordable) and the gold window, then
+    # resumes via resume_inn. Charging gold and healing the party happen there.
+    def do_show_inn(cmd)
+      price = cmd.param(1)
+      @inn_price = price
+      @inn_indent = cmd.indent
+      # Handler branches, when present, open with an INN_STAY marker immediately
+      # after the command (as a Show Choices block opens with CHOICE_OPTION).
+      nxt = @list[@index]
+      @inn_has_handlers =
+        !nxt.nil? && nxt.code == Cmd::INN_STAY && nxt.indent == cmd.indent
+      @inn_request = { type: cmd.param(0), price: price,
+                       can_afford: party.gold >= price, prompt: price > 0 }
+      @wait_kind = :inn
       @waiting = true
     end
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -19,6 +19,7 @@ module Game
       CHOICE_OPTION    = 20140
       CHOICE_END       = 20141
       INPUT_NUMBER     = 10150
+      KEY_INPUT_PROC   = 11610
       CONTROL_SWITCHES = 10210
       CONTROL_VARS     = 10220
       TIMER_OPERATION  = 10230
@@ -122,7 +123,7 @@ module Game
     def running?; @running; end
     def waiting?; @waiting; end
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
-                :teleport, :input_digits
+                :teleport, :input_digits, :key_input_request
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
@@ -276,6 +277,36 @@ module Game
       reset_waits
     end
 
+    # Resume a Key Input Processing request: store the pressed key's RPG2000
+    # `code` (0 when nothing matched, only reached in no-wait mode) into the
+    # target variable and continue. The owning scene samples input while the
+    # interpreter is paused on the :key_input wait, then calls this.
+    def resume_key_input(code)
+      variables[@input_variable] = code.to_i if @input_variable && @input_variable > 0
+      reset_waits
+    end
+
+    # RPG2000 key-input result codes in priority order (highest first). When more
+    # than one accepted button is active RPG_RT returns the largest code:
+    # Shift > Cancel > Decision > Up > Right > Left > Down.
+    KEY_INPUT_CODES = [
+      [:shift, 7], [:cancel, 6], [:decision, 5],
+      [:up, 4], [:right, 3], [:left, 2], [:down, 1]
+    ].freeze
+
+    # Given the set of currently-active key symbols (an array like [:decision]),
+    # return the RPG2000 code of the highest-priority key the pending request
+    # accepts, or 0 when none of the accepted keys are active. Called by the
+    # owning scene once it has sampled real input.
+    def key_input_result(active)
+      acc = @key_input_request && @key_input_request[:accepted]
+      return 0 unless acc
+      KEY_INPUT_CODES.each do |sym, code|
+        return code if acc[sym] && active.include?(sym)
+      end
+      0
+    end
+
     private
 
     def reset_waits
@@ -285,6 +316,7 @@ module Game
       @choice_labels = nil
       @wait_frames = 0
       @teleport = nil
+      @key_input_request = nil
     end
 
     def switches;  @state.switches;  end
@@ -300,6 +332,7 @@ module Game
       when Cmd::CHOICE_OPTION    then skip_to([Cmd::CHOICE_END], cmd.indent); consume
       when Cmd::CHOICE_END       then nil
       when Cmd::INPUT_NUMBER     then do_input_number cmd
+      when Cmd::KEY_INPUT_PROC   then do_key_input cmd
       when Cmd::CONTROL_SWITCHES then do_control_switches cmd
       when Cmd::CONTROL_VARS     then do_control_vars cmd
       when Cmd::TIMER_OPERATION  then do_timer cmd
@@ -527,6 +560,46 @@ module Game
       @input_digits = digits < 1 ? 1 : digits
       @input_variable = cmd.param(1)
       @wait_kind = :number
+      @waiting = true
+    end
+
+    # Key Input Processing (11610): wait for — or, in no-wait mode, sample — one
+    # of a chosen set of buttons and store its RPG2000 code in a variable. The
+    # parameter layout matches RPG_RT and depends on the command's length:
+    #   param0            target variable id
+    #   param1            wait flag (0 = read this frame and continue)
+    #   param2            (pre-1.50 only) accept all four arrows when non-zero
+    #   param3 / param4   accept Decision (OK) / Cancel — always present
+    #   param5..param9    (1.50+) accept Shift / Down / Left / Right / Up
+    # The interpreter only records the request and suspends on a :key_input wait;
+    # the owning scene samples real input (triggered edges when waiting, held
+    # state otherwise) and calls resume_key_input with the resulting code. Number
+    # and operator keys (RPG2003) and the mouse (Maniac) are not modelled.
+    def do_key_input(cmd)
+      var_id = cmd.param(0)
+      wait = cmd.param(1) != 0
+      accepted = { decision: cmd.param(3) != 0, cancel: cmd.param(4) != 0,
+                   shift: false, down: false, left: false, right: false,
+                   up: false }
+      if cmd.parameters.size < 6
+        # Pre-1.50: a single flag enables the whole D-pad, no Shift.
+        if cmd.param(2) != 0
+          accepted[:down] = accepted[:left] = true
+          accepted[:right] = accepted[:up] = true
+        end
+      else
+        accepted[:shift] = cmd.param(5) != 0
+        accepted[:down]  = cmd.param(6) != 0
+        accepted[:left]  = cmd.param(7) != 0
+        accepted[:right] = cmd.param(8) != 0
+        accepted[:up]    = cmd.param(9) != 0
+      end
+      @input_variable = var_id
+      @key_input_request = { wait: wait, accepted: accepted }
+      # RPG_RT clears the variable while a waiting proc is pending; a no-wait proc
+      # overwrites it below via the scene's immediate resume.
+      variables[var_id] = 0 if wait && var_id && var_id > 0
+      @wait_kind = :key_input
       @waiting = true
     end
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -35,6 +35,8 @@ module Game
       CHANGE_ACTOR_NAME   = 10610
       CHANGE_ACTOR_TITLE  = 10620
       CHANGE_ACTOR_SPRITE = 10630
+      CHANGE_SYSTEM_BGM   = 10660
+      CHANGE_SYSTEM_SFX   = 10670
       MEMORIZE_LOCATION = 10820
       RECALL_LOCATION   = 10830
       CHANGE_EVENT_LOCATION = 10860
@@ -73,7 +75,10 @@ module Game
       PLAY_MEMORIZED_BGM = 11540
       PLAY_SE          = 11550
       CHANGE_MAP_TILESET = 11710
+      CHANGE_ENCOUNTER_RATE = 11740
+      SET_TELEPORT_TARGET = 11810
       CHANGE_TELEPORT_ACCESS = 11820
+      SET_ESCAPE_TARGET   = 11830
       CHANGE_ESCAPE_ACCESS   = 11840
       CHANGE_SAVE_ACCESS = 11930
       CHANGE_MENU_ACCESS = 11960
@@ -343,6 +348,11 @@ module Game
       when Cmd::PLAY_MEMORIZED_BGM then do_play_memorized_bgm cmd
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
       when Cmd::CHANGE_MAP_TILESET then @tileset_request = cmd.param(0)
+      when Cmd::CHANGE_ENCOUNTER_RATE then @state.encounter_rate = cmd.param(0)
+      when Cmd::SET_TELEPORT_TARGET then do_set_teleport_target cmd
+      when Cmd::SET_ESCAPE_TARGET   then do_set_escape_target cmd
+      when Cmd::CHANGE_SYSTEM_BGM    then do_change_system_bgm cmd
+      when Cmd::CHANGE_SYSTEM_SFX    then do_change_system_sfx cmd
       when Cmd::CHANGE_TELEPORT_ACCESS then @state.teleport_access = cmd.param(0) != 0
       when Cmd::CHANGE_ESCAPE_ACCESS then @state.escape_access = cmd.param(0) != 0
       when Cmd::CHANGE_SAVE_ACCESS then @state.save_access = cmd.param(0) != 0
@@ -1131,6 +1141,60 @@ module Game
     def do_memorize_bgm(_cmd)
       cur = @state.current_bgm
       @state.memorized_bgm = cur ? cur.dup : nil
+    end
+
+    # Set Teleport Target: register (or clear) a destination the party can jump
+    # to with the Teleport skill. param0 is the operation (0 add, 1 remove),
+    # param1 the map id; on add, param2/param3 are the tile x/y and an optional
+    # switch (param4 flags its presence, param5 is the switch id) gates the
+    # target's availability. Stored in a Game::State registry keyed by map id.
+    # Nothing consumes it yet — the Teleport skill is not executed — so this is
+    # modelled purely for save fidelity, mirroring the access flags.
+    def do_set_teleport_target(cmd)
+      map_id = cmd.param(1)
+      if cmd.param(0) != 0
+        @state.teleport_targets.delete(map_id)
+        return
+      end
+      switch_id = cmd.param(4) != 0 ? cmd.param(5) : nil
+      @state.teleport_targets[map_id] =
+        { x: cmd.param(2), y: cmd.param(3), switch_id: switch_id }
+    end
+
+    # Set Escape Target: register the single destination the Escape skill jumps
+    # to. param0 map id, param1/param2 the tile x/y, and an optional switch
+    # (param3 flags its presence, param4 the switch id). Like the teleport
+    # registry this is stored for save fidelity only; the Escape skill is not
+    # executed yet.
+    def do_set_escape_target(cmd)
+      switch_id = cmd.param(3) != 0 ? cmd.param(4) : nil
+      @state.escape_target =
+        { map_id: cmd.param(0), x: cmd.param(1), y: cmd.param(2),
+          switch_id: switch_id }
+    end
+
+    # Change System BGM: override one of the system music slots (battle,
+    # victory, inn, ...) selected by param0. The remaining fields carry a Music
+    # struct: string = file name, param1 fade-in, param2 volume, param3 tempo,
+    # param4 balance. Stashed in a Game::State slot table; the battle / inn / …
+    # scenes that would play these are not built yet, so this only preserves the
+    # configured music across Save / Continue.
+    def do_change_system_bgm(cmd)
+      @state.system_bgm[cmd.param(0)] = {
+        name: cmd.string, fadein: cmd.param(1), volume: cmd.param(2),
+        tempo: cmd.param(3), balance: cmd.param(4)
+      }
+    end
+
+    # Change System SFX: override one of the system sound slots (cursor,
+    # decision, cancel, ...) selected by param0. string = file name, param1
+    # volume, param2 tempo, param3 balance. Stored for save fidelity like the
+    # system BGM; nothing plays these yet.
+    def do_change_system_sfx(cmd)
+      @state.system_sfx[cmd.param(0)] = {
+        name: cmd.string, volume: cmd.param(1),
+        tempo: cmd.param(2), balance: cmd.param(3)
+      }
     end
 
     # Play Memorized BGM: resume the BGM stashed by Memorize BGM, making it the

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -802,6 +802,9 @@ class RPG2k
           else
             p[:wait_timer] -= 1
           end
+        elsif it.wait_kind == :key_input
+          # Parallel processes commonly poll a key each frame into a variable.
+          resolve_key_input(it)
         else
           it.resume # background: ignore message/choice/teleport requests
         end
@@ -1287,6 +1290,7 @@ class RPG2k
           when :message then open_message(@interpreter.message_lines, false)
           when :choice then open_message(@interpreter.choice_labels, true)
           when :number then open_number_input(@interpreter.input_digits)
+          when :key_input then drive_key_input
           when :wait then drive_wait
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
@@ -1302,6 +1306,42 @@ class RPG2k
           apply_halt_request(@interpreter)
           apply_graphic_change(@interpreter)
           apply_tileset_request(@interpreter)
+        end
+      end
+
+      # Maps the interpreter's accepted-key symbols onto RGSS input buttons.
+      # Decision (OK) is the confirm button C, Cancel is B — the same mapping the
+      # message and menu widgets use.
+      KEY_INPUT_BUTTONS = {
+        down: Input::DOWN, left: Input::LEFT, right: Input::RIGHT,
+        up: Input::UP, decision: Input::C, cancel: Input::B, shift: Input::SHIFT
+      }.freeze
+
+      def drive_key_input
+        resolve_key_input(@interpreter)
+      end
+
+      # Drive a Key Input Processing wait for interpreter `it` (the foreground
+      # event or a parallel process): sample the accepted buttons and hand back
+      # the resulting RPG2000 key code. A waiting proc uses triggered edges and
+      # only resumes once a key is actually pressed; a no-wait proc reads the
+      # held state and resumes immediately (storing 0 when nothing is down),
+      # matching RPG_RT.
+      def resolve_key_input(it)
+        req = it.key_input_request
+        return it.resume_key_input(0) unless req
+        accepted = req[:accepted]
+        active = []
+        KEY_INPUT_BUTTONS.each do |sym, btn|
+          next unless accepted[sym]
+          hit = req[:wait] ? Input.trigger?(btn) : Input.press?(btn)
+          active << sym if hit
+        end
+        code = it.key_input_result(active)
+        if req[:wait]
+          it.resume_key_input(code) if code != 0
+        else
+          it.resume_key_input(code)
         end
       end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -387,6 +387,7 @@ class RPG2k
         @interpreter.map_info = self
         build_parallels
         @message = nil
+        @inn_window = nil
         @wait_timer = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
@@ -417,6 +418,7 @@ class RPG2k
 
       def dispose
         close_message
+        close_inn_window
         [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
          @picture_sprite].each do |s|
           s.dispose if s
@@ -1291,6 +1293,7 @@ class RPG2k
           when :choice then open_message(@interpreter.choice_labels, true)
           when :number then open_number_input(@interpreter.input_digits)
           when :key_input then drive_key_input
+          when :inn then drive_inn
           when :wait then drive_wait
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
@@ -1343,6 +1346,122 @@ class RPG2k
         else
           it.resume_key_input(code)
         end
+      end
+
+      # -- Show Inn (Stay at Inn) ---------------------------------------------
+
+      INN_LINE_H = 14
+
+      # Drive a Show Inn wait: a free stay (price 0) resumes at once; otherwise a
+      # greeting window with Accept / Cancel choices and a gold window is shown,
+      # Accept selectable only when the party can afford the price. The
+      # interpreter charges gold and heals the party in resume_inn.
+      def drive_inn
+        req = @interpreter.inn_request
+        return @interpreter.resume_inn(false) unless req
+        return @interpreter.resume_inn(true) unless req[:prompt]
+
+        if @inn_window.nil?
+          open_inn_window(req) # opened this frame; take input from the next one
+          return
+        end
+        if Input.trigger?(Input::DOWN) && @inn_choice < 1
+          @inn_choice += 1
+          set_inn_cursor
+        elsif Input.trigger?(Input::UP) && @inn_choice > 0
+          @inn_choice -= 1
+          set_inn_cursor
+        elsif Input.trigger?(Input::C)
+          if @inn_choice.zero?
+            # Accept: only honoured when the party can pay; otherwise ignored.
+            if req[:can_afford]
+              close_inn_window
+              @interpreter.resume_inn(true)
+            end
+          else
+            close_inn_window
+            @interpreter.resume_inn(false)
+          end
+        elsif Input.trigger?(Input::B)
+          close_inn_window
+          @interpreter.resume_inn(false)
+        end
+      end
+
+      # RPG2000 inn term set (A or B) selected by the command's type parameter.
+      # Blank database terms (e.g. a bare test project) fall back to plain
+      # English so the window is never empty.
+      def inn_terms(type)
+        t = db.term
+        a = type.zero?
+        {
+          greet1: nonblank(a ? t.inn_a_greeting_1 : t.inn_b_greeting_1, 'Stay the night for'),
+          greet2: nonblank(a ? t.inn_a_greeting_2 : t.inn_b_greeting_2, '?'),
+          greet3: nonblank(a ? t.inn_a_greeting_3 : t.inn_b_greeting_3, 'Will you stay?'),
+          accept: nonblank(a ? t.inn_a_accept : t.inn_b_accept, 'Yes'),
+          cancel: nonblank(a ? t.inn_a_cancel : t.inn_b_cancel, 'No')
+        }
+      end
+
+      def nonblank(s, fallback)
+        s = s.to_s
+        s.empty? ? fallback : s
+      end
+
+      def open_inn_window(req)
+        terms = inn_terms(req[:type])
+        gold_term = nonblank(db.term.gold, 'G')
+        lines = ["#{terms[:greet1]} #{req[:price]}#{gold_term} #{terms[:greet2]}".strip,
+                 terms[:greet3], terms[:accept], terms[:cancel]]
+        inner_w = SCREEN_W - 20 - Window::BORDER * 2
+        inner_h = lines.length * INN_LINE_H
+        win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
+                         SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        win.z = 300
+        win.windowskin = @windowskin
+        contents = Bitmap.new(inner_w, inner_h)
+        contents.font.color = Color.new(255, 255, 255, 255)
+        lines.each_with_index do |line, i|
+          contents.draw_text 0, i * INN_LINE_H, inner_w, INN_LINE_H, line
+        end
+        win.contents = contents
+
+        gwin = build_inn_gold_window(gold_term)
+        @inn_window = { window: win, gold: gwin }
+        # Start on Accept when affordable, else on Cancel.
+        @inn_choice = req[:can_afford] ? 0 : 1
+        set_inn_cursor
+      end
+
+      # A small window showing the party's current gold, mirroring the RPG2000
+      # inn's gold display.
+      def build_inn_gold_window(gold_term)
+        gw = 88
+        gh = INN_LINE_H + Window::BORDER * 2
+        win = Window.new(SCREEN_W - gw - 6, 6, gw, gh)
+        win.z = 300
+        win.windowskin = @windowskin
+        c = Bitmap.new(gw - Window::BORDER * 2, INN_LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, c.width, INN_LINE_H, "#{@state.party.gold}#{gold_term}"
+        win.contents = c
+        win
+      end
+
+      # The Accept / Cancel lines sit below the two greeting lines, so the cursor
+      # row is offset by 2.
+      def set_inn_cursor
+        return unless @inn_window
+        win = @inn_window[:window]
+        row = 2 + @inn_choice
+        win.cursor_rect = Rect.new(0, row * INN_LINE_H, win.contents.width, INN_LINE_H)
+      end
+
+      def close_inn_window
+        return unless @inn_window
+        @inn_window[:window].dispose
+        @inn_window[:gold].dispose if @inn_window[:gold]
+        @inn_window = nil
       end
 
       def drive_wait

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2289,6 +2289,96 @@ check 'Key Input Proc accepts only the chosen keys' do
   eq 0, it.key_input_result([:cancel, :up, :down]), 'unlisted keys ignored'
 end
 
+# -- Show Inn (Stay at Inn) ---------------------------------------------------
+
+check 'Show Inn: staying charges the price and full-heals the party' do
+  st = party_state
+  st.party.gain_gold(1000)
+  st.party.actors.each { |a| a.hp = 1; a.mp = 0 }
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_INN, [0, 100, 0])])
+  it.update
+  ok it.waiting?, 'Show Inn suspends the interpreter'
+  eq :inn, it.wait_kind
+  req = it.inn_request
+  eq true, req[:prompt], 'a priced inn prompts'
+  eq true, req[:can_afford]
+  eq 100, req[:price]
+  it.resume_inn(true)
+  ok !it.waiting?, 'the inn resolved'
+  eq 900, st.party.gold, 'the price was deducted'
+  st.party.actors.each do |a|
+    eq a.max_hp, a.hp, "#{a.name} HP restored"
+    eq a.max_mp, a.mp, "#{a.name} MP restored"
+  end
+end
+
+check 'Show Inn: cancelling leaves gold and HP untouched' do
+  st = party_state
+  st.party.gain_gold(1000)
+  st.party.actors.each { |a| a.hp = 1; a.mp = 0 }
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_INN, [0, 100, 0])])
+  it.update
+  it.resume_inn(false)
+  eq 1000, st.party.gold, 'no gold spent on cancel'
+  eq 1, st.party.actors.first.hp, 'no healing on cancel'
+end
+
+check 'Show Inn: a free stay (price 0) skips the prompt' do
+  st = party_state
+  st.party.actors.each { |a| a.hp = 1 }
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_INN, [0, 0, 0])])
+  it.update
+  eq false, it.inn_request[:prompt], 'a free inn needs no prompt'
+  it.resume_inn(true)
+  eq st.party.actors.first.max_hp, st.party.actors.first.hp, 'still heals'
+end
+
+check 'Show Inn: the affordability flag reflects the party gold' do
+  st = party_state
+  st.party.gain_gold(50)
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_INN, [0, 100, 0])])
+  it.update
+  eq false, it.inn_request[:can_afford], 'cannot afford a 100g inn with 50g'
+end
+
+check 'Show Inn: Stay / No Stay handler branches route on the outcome' do
+  # Layout mirrors a Show Choices block: the command is followed by the two
+  # marked branches, closed by INN_END, then a command that always runs.
+  list = [
+    FakeCmd.new(IC::SHOW_INN, [0, 100, 0], indent: 0),
+    FakeCmd.new(IC::INN_STAY, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    FakeCmd.new(IC::INN_NO_STAY, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    FakeCmd.new(IC::INN_END, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0], indent: 0)
+  ]
+  st = party_state
+  st.party.gain_gold(1000)
+  it = Game::Interpreter.new(st)
+  it.start(list)
+  it.update
+  it.resume_inn(true)
+  it.update
+  eq true, st.switches[1], 'the Stay branch ran'
+  ok !st.switches[2], 'the No Stay branch was skipped'
+  eq true, st.switches[3], 'execution continued past the inn'
+  # And the No Stay path on a fresh run.
+  st2 = party_state
+  it2 = Game::Interpreter.new(st2)
+  it2.start(list)
+  it2.update
+  it2.resume_inn(false)
+  it2.update
+  ok !st2.switches[1], 'the Stay branch was skipped'
+  eq true, st2.switches[2], 'the No Stay branch ran'
+  eq true, st2.switches[3], 'execution continued past the inn'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2228,6 +2228,67 @@ check 'Targets / rate / system audio round-trip through the save' do
   eq({}, legacy_loaded.system_sfx)
 end
 
+# -- Key Input Processing -----------------------------------------------------
+
+check 'Key Input Proc (1.50 layout) waits, clears the var, resolves by priority' do
+  st = party_state
+  st.variables[1] = 99 # a stale value the waiting proc must clear
+  it = Game::Interpreter.new(st)
+  # var 1, wait, (legacy dir slot 0), decision, cancel, shift, down, left,
+  # right, up — every key accepted.
+  it.start([FakeCmd.new(IC::KEY_INPUT_PROC, [1, 1, 0, 1, 1, 1, 1, 1, 1, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0])])
+  it.update
+  ok it.waiting?, 'a waiting proc suspends the interpreter'
+  eq :key_input, it.wait_kind
+  eq 0, st.variables[1], 'the target variable is cleared while waiting'
+  eq true, it.key_input_request[:wait]
+  # Highest-valued matching key wins: Shift(7) > Cancel(6) > Decision(5) >
+  # Up(4) > Right(3) > Left(2) > Down(1); nothing pressed yields 0.
+  eq 7, it.key_input_result([:down, :decision, :shift])
+  eq 6, it.key_input_result([:cancel, :decision, :down])
+  eq 5, it.key_input_result([:decision, :down])
+  eq 1, it.key_input_result([:down])
+  eq 0, it.key_input_result([])
+  # A key press resumes, stores the code, and the next command runs.
+  it.resume_key_input(it.key_input_result([:decision, :down]))
+  ok !it.waiting?, 'the proc resumed'
+  it.update
+  eq 5, st.variables[1]
+  eq true, st.switches[3], 'the command after the proc ran'
+end
+
+check 'Key Input Proc pre-1.50 layout enables the whole D-pad, no Shift' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # Five params (<6): var 2, no-wait, all-directions flag on, decision on,
+  # cancel off.
+  it.start([FakeCmd.new(IC::KEY_INPUT_PROC, [2, 0, 1, 1, 0])])
+  it.update
+  ok it.waiting?, 'even a no-wait proc routes through the scene once'
+  req = it.key_input_request
+  eq false, req[:wait], 'no-wait requests read held state, not edges'
+  acc = req[:accepted]
+  [:down, :left, :right, :up, :decision].each { |k| eq true, acc[k], "#{k} on" }
+  eq false, acc[:cancel], 'cancel not accepted'
+  eq false, acc[:shift], 'pre-1.50 has no Shift'
+  eq 4, it.key_input_result([:up])
+  eq 0, it.key_input_result([:cancel]), 'an unaccepted key yields 0'
+  # No-wait mode does not pre-clear the variable; the resume writes the read.
+  it.resume_key_input(it.key_input_result([]))
+  eq 0, st.variables[2]
+end
+
+check 'Key Input Proc accepts only the chosen keys' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # Accept Decision only (all direction / shift / cancel flags off).
+  it.start([FakeCmd.new(IC::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 0, 0, 0, 0])])
+  it.update
+  eq 5, it.key_input_result([:decision])
+  eq 0, it.key_input_result([:cancel, :up, :down]), 'unlisted keys ignored'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2130,6 +2130,104 @@ check 'party save round-trips actor EXP and re-derives the level' do
   eq 3, la.level, 'level re-derived from the restored EXP'
 end
 
+# -- Set Teleport / Escape Target, Change Encounter Rate ----------------------
+
+check 'Set Teleport Target registers, updates and removes a destination' do
+  st = party_state
+  eq({}, st.teleport_targets, 'no targets registered by default')
+  it = Game::Interpreter.new(st)
+  # Add map 4 @ (7, 9) with switch 12 gating it, then a plain command after.
+  it.start([FakeCmd.new(IC::SET_TELEPORT_TARGET, [0, 4, 7, 9, 1, 12]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'setting a target must not pause the interpreter'
+  eq({ x: 7, y: 9, switch_id: 12 }, st.teleport_targets[4])
+  eq true, st.switches[1], 'the command after it still ran'
+  # Re-adding the same map overwrites; an absent switch flag stores nil.
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::SET_TELEPORT_TARGET, [0, 4, 2, 3, 0, 0])])
+  it2.update
+  eq({ x: 2, y: 3, switch_id: nil }, st.teleport_targets[4])
+  # Operation 1 removes it.
+  it3 = Game::Interpreter.new(st)
+  it3.start([FakeCmd.new(IC::SET_TELEPORT_TARGET, [1, 4])])
+  it3.update
+  ok !st.teleport_targets.key?(4), 'the target was removed'
+end
+
+check 'Set Escape Target stores the single escape destination' do
+  st = party_state
+  eq nil, st.escape_target, 'no escape target by default'
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SET_ESCAPE_TARGET, [8, 3, 5, 1, 20])])
+  it.update
+  eq({ map_id: 8, x: 3, y: 5, switch_id: 20 }, st.escape_target)
+  # A second command replaces it; no switch flag stores nil.
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::SET_ESCAPE_TARGET, [2, 1, 1, 0, 0])])
+  it2.update
+  eq({ map_id: 2, x: 1, y: 1, switch_id: nil }, st.escape_target)
+end
+
+check 'Change Encounter Rate stores the step rate, non-blocking' do
+  st = party_state
+  eq nil, st.encounter_rate, 'encounter rate unset by default'
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_ENCOUNTER_RATE, [25]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'changing the rate must not pause the interpreter'
+  eq 25, st.encounter_rate
+  eq true, st.switches[1], 'the command after it still ran'
+end
+
+check 'Change System BGM / SFX stash per-slot audio overrides' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # System BGM slot 0 (battle): [fadein, volume, tempo, balance].
+  it.start([FakeCmd.new(IC::CHANGE_SYSTEM_BGM, [0, 2, 80, 110, 50],
+                        string: 'Battle1'),
+            FakeCmd.new(IC::CHANGE_SYSTEM_SFX, [1, 90, 100, 50],
+                        string: 'Decision2')])
+  it.update
+  eq({ name: 'Battle1', fadein: 2, volume: 80, tempo: 110, balance: 50 },
+     st.system_bgm[0])
+  eq({ name: 'Decision2', volume: 90, tempo: 100, balance: 50 },
+     st.system_sfx[1])
+end
+
+check 'Targets / rate / system audio round-trip through the save' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.encounter_rate = 30
+  st.teleport_targets[4] = { x: 7, y: 9, switch_id: 12 }
+  st.escape_target = { map_id: 8, x: 3, y: 5, switch_id: nil }
+  st.system_bgm[0] = { name: 'Battle1', fadein: 0, volume: 100,
+                       tempo: 100, balance: 50 }
+  st.system_sfx[1] = { name: 'Decision2', volume: 100, tempo: 100,
+                       balance: 50 }
+  loaded = Game::State.load(db, st.to_h)
+  eq 30, loaded.encounter_rate
+  eq({ x: 7, y: 9, switch_id: 12 }, loaded.teleport_targets[4])
+  eq({ map_id: 8, x: 3, y: 5, switch_id: nil }, loaded.escape_target)
+  eq 'Battle1', loaded.system_bgm[0][:name]
+  eq 'Decision2', loaded.system_sfx[1][:name]
+  # A save written before these existed restores empty / unset registries.
+  legacy = st.to_h
+  [:encounter_rate, :teleport_targets, :escape_target,
+   :system_bgm, :system_sfx].each { |k| legacy.delete(k) }
+  legacy_loaded = Game::State.load(db, legacy)
+  eq nil, legacy_loaded.encounter_rate
+  eq({}, legacy_loaded.teleport_targets)
+  eq nil, legacy_loaded.escape_target
+  eq({}, legacy_loaded.system_bgm)
+  eq({}, legacy_loaded.system_sfx)
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -137,6 +137,9 @@ def fake_db(common = nil)
     system: OpenStruct.new(system_graphic: ''),
     # A second chipset (id 2) so Change Map Tileset has somewhere to swap to.
     chipset: { 1 => fake_chipset, 2 => fake_chipset('cs2') },
+    # Terms the Show Inn window reads; blank greeting fields exercise the
+    # scene's English fallbacks.
+    term: OpenStruct.new(gold: 'G'),
     common_event: common,
     player: {}
   )
@@ -363,6 +366,87 @@ check 'parallel common event runs only while its switch gate is on' do
   st.switches[2] = true
   5.times { scene.update }
   ok st.variables[3] > 0, 'it should run once the gate switch is on'
+end
+
+# A lightweight party for the inn tests: resume_inn only needs gold + a party
+# roster whose members respond to full_heal, and Scene::Map reads party.leader.
+class InnStubActor
+  attr_accessor :hp, :mp
+  attr_reader :max_hp, :max_mp, :name
+  def initialize(name); @name = name; @hp = 1; @mp = 0; @max_hp = 100; @max_mp = 30; end
+  def full_heal; @hp = @max_hp; @mp = @max_mp; end
+end
+
+class InnStubParty
+  attr_reader :actors, :gold
+  attr_accessor :leader
+  def initialize(gold); @gold = gold; @actors = [InnStubActor.new('Hero')]; @leader = nil; end
+  def gain_gold(n); @gold += n; end
+end
+
+# Build an auto-start event running `commands`, with a stub party holding `gold`.
+def inn_scene(gold, commands)
+  auto = page(trigger: 3)
+  auto.event_commands = commands
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, InnStubParty.new(gold))
+  [scene, st]
+end
+
+# Show Inn followed by [Stay] / [No Stay] handler branches (switch 1 / switch 2),
+# closed by INN_END — the standard structured layout.
+def inn_commands(ic, price)
+  [
+    ECmd.new(ic::SHOW_INN, [0, price, 0], indent: 0),
+    ECmd.new(ic::INN_STAY, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::INN_NO_STAY, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::INN_END, [], indent: 0)
+  ]
+end
+
+check 'Show Inn scene: accepting heals the party, spends gold, runs Stay branch' do
+  scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  5.times { scene.update } # inn command runs; the greeting prompt opens
+  ok !st.switches[1] && !st.switches[2], 'still waiting on the prompt'
+  RGSS::Input.triggered = [RGSS::Input::C] # cursor starts on Accept (affordable)
+  scene.update # resumes with a stay
+  scene.update # runs the Stay branch
+  eq 900, st.party.gold, 'the price was deducted'
+  eq st.party.actors.first.max_hp, st.party.actors.first.hp, 'party healed'
+  ok st.switches[1], 'the Stay branch ran'
+  ok !st.switches[2], 'the No Stay branch was skipped'
+end
+
+check 'Show Inn scene: cancelling with B spends nothing and runs No Stay' do
+  scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  5.times { scene.update }
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update # resumes with no stay
+  scene.update # runs the No Stay branch
+  eq 1000, st.party.gold, 'no gold spent on cancel'
+  eq 1, st.party.actors.first.hp, 'no healing on cancel'
+  ok !st.switches[1], 'the Stay branch was skipped'
+  ok st.switches[2], 'the No Stay branch ran'
+end
+
+check 'Show Inn scene: an unaffordable Accept is ignored' do
+  scene, st = inn_scene(50, inn_commands(Game::Interpreter::Cmd, 100)) # 50g < 100g
+  5.times { scene.update }
+  # Cursor starts on Cancel when broke; move up to Accept and press it.
+  RGSS::Input.triggered = [RGSS::Input::UP]
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C]
+  3.times { scene.update }
+  ok !st.switches[1] && !st.switches[2], 'Accept is inert while unaffordable'
+  eq 50, st.party.gold, 'no gold spent'
+  # Cancel still works.
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  scene.update
+  ok st.switches[2], 'the No Stay branch ran on cancel'
 end
 
 check 'Key Input Proc waits for a key, stores its code, then continues' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -63,7 +63,7 @@ module RGSS
   # Scriptable input: tests set `dir_value` (a numpad direction held down) and
   # `triggered` (buttons pressed this frame). Defaults to no input.
   module Input
-    C = 1; B = 2; UP = 3; DOWN = 4; LEFT = 5; RIGHT = 6
+    C = 1; B = 2; UP = 3; DOWN = 4; LEFT = 5; RIGHT = 6; SHIFT = 7
     class << self
       attr_accessor :dir_value, :triggered
     end
@@ -72,6 +72,7 @@ module RGSS
     # The scene treats a held key like a triggered one for widget navigation; the
     # stub answers both from the same `triggered` set.
     def self.repeat?(k); Array(@triggered).include?(k); end
+    def self.press?(k); Array(@triggered).include?(k); end
     def self.dir4; @dir_value || 0; end
     def self.update; end
   end
@@ -362,6 +363,49 @@ check 'parallel common event runs only while its switch gate is on' do
   st.switches[2] = true
   5.times { scene.update }
   ok st.variables[3] > 0, 'it should run once the gate switch is on'
+end
+
+check 'Key Input Proc waits for a key, stores its code, then continues' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Wait-mode proc into var 1 accepting Decision + all directions (1.50
+  # layout: [var, wait, _, decision, cancel, shift, down, left, right, up]),
+  # then flip switch 5 to prove it resumed.
+  auto.event_commands = [
+    ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 1, 1, 1, 1]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  5.times { scene.update } # no key pressed: the proc keeps waiting
+  eq 0, st.variables[1], 'no key yet -> variable stays 0'
+  ok !st.switches[5], 'the proc has not resumed'
+  RGSS::Input.triggered = [RGSS::Input::C] # press Decision (OK)
+  scene.update # this frame resumes the proc and stores the code
+  eq 5, st.variables[1], 'Decision stored code 5'
+  scene.update # the following command runs once the proc has resumed
+  ok st.switches[5], 'the event continued after the key press'
+end
+
+check 'Key Input Proc ignores keys it was not told to accept' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Accept Decision only; a Cancel press must not resume it.
+  auto.event_commands = [
+    ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 0, 0, 0, 0]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.triggered = [RGSS::Input::B] # Cancel: not accepted
+  3.times { scene.update }
+  ok !st.switches[5], 'an unaccepted key must not resume the proc'
+  eq 0, st.variables[1]
+  RGSS::Input.triggered = [RGSS::Input::C] # Decision: accepted
+  scene.update # resumes and stores the code
+  eq 5, st.variables[1]
+  scene.update # the following command runs
+  ok st.switches[5]
 end
 
 check 'parallel processes pause while a foreground event is running' do


### PR DESCRIPTION
Continues filling out the RPG2000 event-command interpreter, from quick state-only commands up to the first interactive game-mode subsystem. Each command's parameter layout and behaviour is verified against liblcf / EasyRPG, not memory.

## What's included

### 1. State-only ("scaffolding") commands — `655a34c`
Five commands that decode their payload onto `Game::State` and round-trip through Save / Continue, but whose consuming subsystems don't exist yet (so they're modelled for save fidelity, like the existing access flags):

- **Set Teleport Target** (11810) / **Set Escape Target** (11830) — a per-map teleport-target registry (add / overwrite / remove) and a single escape target, each with an optional gating switch.
- **Change Encounter Rate** (11740) — the random-encounter step rate.
- **Change System BGM** (10660) / **Change System SFX** (10670) — per-slot system music / sound overrides (battle, victory, inn / cursor, decision, …).

### 2. Key Input Processing (11610) — `762653f`
Waits for — or, in no-wait mode, samples — a chosen set of buttons and writes the pressed key's RPG2000 code to a variable (Down 1, Left 2, Right 3, Up 4, Decision 5, Cancel 6, Shift 7; highest wins). Follows RPG_RT's pre-1.50 (all arrows in one flag) and 1.50+ (individual per-direction flags plus Shift) parameter layouts. The interpreter records the request and suspends on a `:key_input` wait; `Scene::Map` samples real input (triggered edges when waiting, held state otherwise) — for foreground **and** parallel events, so the common "parallel process polls a key each frame" idiom works. RPG2003 number/operator keys and Maniac mouse input are not modelled.

### 3. Show Inn / Stay at Inn (10730) — `69c7b4f`
The first interactive game-mode subsystem. A priced inn opens a greeting window with Accept / Cancel choices (Accept selectable only when the party can afford the price) and a gold window; a free inn (price 0) skips the prompt. Staying deducts the price and fully heals the party (HP and MP), and either outcome routes into the command's optional `[Stay]` / `[No Stay]` handler branches (markers 20730 / 20731, closed by 20732), laid out and skipped exactly like a Show Choices block. `Game::Interpreter` owns the gameplay (affordability, gold, healing, branch routing) so it is unit-tested in isolation; `Scene::Map` owns presentation. The inn fade-out/in and jingle are presentation still to come (like the screen-fade commands), so a stay heals without them for now.

## Testing

Both host harnesses (pure-Ruby sources under CRuby) stay green with new coverage for every command above:

- `scripts/rpg2k_logic_check.rb` — **145 checks pass** (interpreter logic: param layouts, key priority, inn affordability / gold / heal / branch routing, save round-trips)
- `scripts/rpg2k_scene_check.rb` — **54 checks pass** (scene wiring: key-input capture, inn accept/cancel/unaffordable paths)

Docs (`docs/TODO.md`) and `changelog.d/` fragments updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_