### PR TITLE
ci: give the MV real-game play smoke a reserved xvfb display (fix flaky exe_open)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,10 @@ jobs:
       # avoided: its server-number probe is not atomic, so concurrent -a runs
       # can grab the same display, killing one Xvfb out from under its client
       # ("XIO: fatal IO error"). Reserved numbers: exe_open=99 (see the ctest
-      # `exe_open` test in CMakeLists.txt); MV runs=100..104 below.
+      # `exe_open` test in CMakeLists.txt); MV runs=100..105 below. Every MV
+      # smoke here must use a distinct --server-num (never `-a`), or its
+      # non-atomic probe can steal exe_open's display and fail that required
+      # check.
       - parallel:
           - name: LCF test-bed smoke check
             run: nix develop -c ruby scripts/lcf_testbed_check.rb
@@ -192,7 +195,7 @@ jobs:
           - name: MV real-game play smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+              nix develop -c xvfb-run --server-num=105 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/Lunatic-Core \
                 --mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png
 

--- a/changelog.d/ci-exe-open-xvfb-display.fixed.md
+++ b/changelog.d/ci-exe-open-xvfb-display.fixed.md
@@ -1,0 +1,7 @@
+- **CI: fix the intermittent `exe_open` failure.** The "MV real-game play smoke
+  test" in `.github/workflows/build.yml` was still launching `xvfb-run -a` while
+  its siblings use reserved fixed display numbers. In the shared `parallel`
+  group its non-atomic display probe could grab `exe_open`'s reserved `:99`,
+  killing that Xvfb out from under the client ("XIO: fatal IO error") and
+  failing the required `build` check at random. Give it its own reserved
+  `--server-num=105` so no MV smoke can collide with `exe_open`.


### PR DESCRIPTION
## Problem

The required `build` check has been failing intermittently on the `exe_open` ctest — currently on **~2/3 of runs**, including unrelated merges that never touch the RPG2000 boot (e.g. #189, an RPG-Maker-XP change, fails `exe_open` identically on `master`). The boot exits non-zero with no Ruby exception, `[RPG2k]`/`[RGSS]` error, crash, or backtrace — just the headless `ALSA … cannot find card '0'` noise and an `xvfb-run` `kill: … No such process`, i.e. an Xvfb that died.

## Root cause

Commit `4b9dea5` ("ci: give each concurrent xvfb-run a fixed display number") replaced the `xvfb-run -a` invocations with reserved fixed `--server-num`s (exe_open=99, MV runs=100..104) *specifically* because `-a`'s non-atomic display probe races and collides under the shared `parallel` group, killing one Xvfb with an "XIO: fatal IO error".

**It missed one:** the **"MV real-game play smoke test"** step still ran `xvfb-run -a`. In the parallel group its probe can select `exe_open`'s reserved `:99`, taking that Xvfb out from under the client and failing the required check at random. That exactly matches the failure signature and the intermittency.

## Fix

Give that step its own reserved `--server-num=105` (99–105 are now all distinct), and note in the group comment that every MV smoke must use a distinct number, never `-a`.

```diff
-              nix develop -c xvfb-run -a timeout 120 ./build/rpg_maker_clone \
+              nix develop -c xvfb-run --server-num=105 timeout 120 ./build/rpg_maker_clone \
```

## Verification

- No live `xvfb-run -a` invocation remains in `build.yml` (the only remaining `-a` is prose in the explanatory comment).
- All seven reserved displays are distinct: `99` (exe_open, CMakeLists) + `100–105` (MV smokes).
- `build.yml` parses as valid YAML.

This unblocks the whole merge queue, not just one PR. (It's the same flake currently blocking #191.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwiLbHYL9gRsdwo2SThNaS)_