### PR TITLE
mruby-rgss: RGSS::Window property holder

### DIFF
--- a/changelog.d/rpgxp-rgss-window-holder.added.md
+++ b/changelog.d/rpgxp-rgss-window-holder.added.md
@@ -1,0 +1,8 @@
+- **`RGSS::Window` property holder.** `RGSS::Window` is no longer an empty stub:
+  it now stores the properties every `Window_Base` subclass drives — `windowskin`,
+  `contents`, `cursor_rect`, `x`/`y`/`width`/`height`, `ox`/`oy`,
+  `opacity`/`back_opacity`/`contents_opacity`, `visible`, `z`, `active`, `pause`,
+  `stretch`, `viewport` — with RGSS defaults, so the stock menu/message/shop/battle
+  windows construct, configure and draw into their `contents` without raising. The
+  native frame/cursor/pause compositing is still future work; see
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -49,14 +49,18 @@ renderer does not yet honour them visually (opacity/zoom/tone/mirror compositing
 in the draw path). `Sprite_Character`, `Sprite_Battler`, `Arrow_Base`, weather
 and the animation player depend on these.
 
-### 2. `Window` ❌ (the big one for menus & messages)
+### 2. `Window` ⚠️ (stored; native frame/cursor render pending)
 
-`class Window` is empty. Every `Window_Base` subclass (`Window_Message`,
-`Window_Command`, `Window_Selectable`, the whole menu/shop/battle UI) needs:
-`windowskin`, `contents` (a `Bitmap`), `cursor_rect`, `x`/`y`/`width`/`height`,
-`ox`/`oy`, `opacity`/`back_opacity`/`contents_opacity`, `visible`, `z`, `active`,
-`pause`, `update`, `dispose`. This is a real native widget (frame from the
-windowskin, cursor blink, pause arrow, contents blit).
+`Window` is now a pure-Ruby property holder (`mruby-rgss/mrblib/lib.rb`) with
+RGSS defaults: `windowskin`, `contents` (a `Bitmap` the game creates and draws
+into), `cursor_rect` (a `Rect`), `x`/`y`/`width`/`height`, `ox`/`oy`,
+`opacity`/`back_opacity`/`contents_opacity`, `visible`, `z`, `active`, `pause`,
+`stretch`, `viewport`, `update`, `dispose`/`disposed?`. So every `Window_Base`
+subclass (`Window_Message`, `Window_Command`, `Window_Selectable`, the whole
+menu/shop/battle UI) can construct, configure and draw into its `contents`
+without raising. **Remaining:** the native widget compositing — the frame built
+from the windowskin, the blinking cursor rect, the pause arrow, and blitting the
+scrolled `contents` at `contents_opacity` — is future work.
 
 ### 3. `Tilemap` ❌ (the big one for maps)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -197,7 +197,50 @@ module RGSS
   class Tilemap
   end
 
+  # RGSS Window: the framed, scrollable box every Window_Base subclass (message,
+  # command, menu, shop, battle status) builds on. Pure-Ruby property holder for
+  # now so the stock RGSS scripts that create and drive a Window run — they set a
+  # windowskin and draw into a real `contents` Bitmap, which works; the native
+  # frame/cursor/pause compositing is future work (tracked in
+  # docs/rpgxp-rgss-api-gap.md). `contents` defaults to nil (RGSS starts a Window
+  # with no contents until the game assigns one).
   class Window
+    attr_accessor :windowskin, :contents, :cursor_rect, :x, :y, :width, :height,
+                  :ox, :oy, :opacity, :back_opacity, :contents_opacity,
+                  :visible, :z, :active, :pause, :stretch
+    attr_reader :viewport
+
+    def initialize(viewport = nil)
+      @viewport = viewport
+      @windowskin = nil
+      @contents = nil
+      @cursor_rect = Rect.new(0, 0, 0, 0)
+      @x = 0
+      @y = 0
+      @width = 0
+      @height = 0
+      @ox = 0
+      @oy = 0
+      @opacity = 255
+      @back_opacity = 255
+      @contents_opacity = 255
+      @visible = true
+      @z = 0
+      @active = true
+      @pause = false
+      @stretch = true
+      @disposed = false
+    end
+
+    def update; end
+
+    def dispose
+      @disposed = true
+    end
+
+    def disposed?
+      @disposed
+    end
   end
 
   class RGSSError < StandardError

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -501,6 +501,62 @@ assert("RGSS::Plane property defaults and accessors") do
   assert_true p.disposed?
 end
 
+assert("RGSS::Window property defaults and accessors") do
+  w = RGSS::Window.new
+  # RGSS defaults.
+  assert_true w.windowskin.nil?
+  assert_true w.contents.nil?
+  assert_true w.cursor_rect.is_a?(RGSS::Rect)
+  assert_equal 0, w.x
+  assert_equal 0, w.y
+  assert_equal 0, w.width
+  assert_equal 0, w.height
+  assert_equal 0, w.ox
+  assert_equal 0, w.oy
+  assert_equal 255, w.opacity
+  assert_equal 255, w.back_opacity
+  assert_equal 255, w.contents_opacity
+  assert_true w.visible
+  assert_equal 0, w.z
+  assert_true w.active
+  assert_false w.pause
+  assert_true w.stretch
+  assert_true w.viewport.nil?
+  assert_false w.disposed?
+
+  # Writable — the stock Window_Base sets these on every window.
+  w.x = 80
+  w.y = 64
+  w.width = 160
+  w.height = 128
+  w.back_opacity = 200
+  w.contents_opacity = 128
+  w.active = false
+  w.pause = true
+  w.z = 100
+  w.cursor_rect = RGSS::Rect.new(0, 0, 32, 32)
+  assert_equal 80, w.x
+  assert_equal 64, w.y
+  assert_equal 160, w.width
+  assert_equal 128, w.height
+  assert_equal 200, w.back_opacity
+  assert_equal 128, w.contents_opacity
+  assert_false w.active
+  assert_true w.pause
+  assert_equal 100, w.z
+  assert_equal 32, w.cursor_rect.width
+
+  # A viewport-bound window remembers whatever viewport it was constructed with.
+  # (A real RGSS::Viewport needs a live display the headless test binary lacks,
+  # so a marker object stands in — Window only stores the reference.)
+  marker = Object.new
+  assert_equal marker, RGSS::Window.new(marker).viewport
+
+  w.update
+  w.dispose
+  assert_true w.disposed?
+end
+
 # RGSS::Sprite.new needs an initialized display (it references RGSS::_display),
 # which the headless mrbtest build does not set up, so the Sprite extended
 # properties cannot be exercised here — they are load-verified with the rest of


### PR DESCRIPTION
## Summary

Closes the `Window` gap (item #2) from the [RGSS API gap doc](../blob/master/docs/rpgxp-rgss-api-gap.md) — the biggest blocker for menus and messages (follow-up to the script host #176, `Sprite` extended props #189, `Plane` holder, and the `sprintf` gem #190).

`RGSS::Window` was an empty stub, so any stock script that creates a `Window_Base` subclass (`Window_Message`, `Window_Command`, `Window_Selectable`, the whole menu/shop/battle UI) raised as soon as it set a property.

## Change

- **`mruby-rgss/mrblib/lib.rb`** — give `RGSS::Window` a pure-Ruby **property holder**, the same approach already used for `Plane` and `Sprite`'s extended props. It stores, with RGSS defaults, everything `Window_Base` drives:
  - `windowskin`, `contents` (the game creates and draws into a real `Bitmap`), `cursor_rect` (a `Rect`)
  - `x`/`y`/`width`/`height`, `ox`/`oy`, `z`, `visible`
  - `opacity`/`back_opacity`/`contents_opacity` (default 255)
  - `active` (true), `pause` (false), `stretch` (true)
  - `viewport` (read-only, from the constructor), `update`, `dispose`/`disposed?`

  So a script can construct a window, assign its skin, and blit into `contents` without raising.

**Not in scope (still future work):** the native widget compositing — the frame built from the windowskin, the blinking cursor rect, the pause arrow, and blitting the scrolled `contents` at `contents_opacity`. The gap-doc entry is downgraded from ❌ to ⚠️ (stored; render pending), matching how `Plane`/`Sprite` are tracked.

## Testing

- **`mruby-rgss/test`** — a new `RGSS::Window` check mirroring the existing `Plane` test: RGSS defaults, writable accessors (`x`, `back_opacity`, `active`, `pause`, `z`, `cursor_rect`), the viewport binding, `update`, and `dispose`/`disposed?`. It uses a marker object for the viewport because a real `RGSS::Viewport` needs a live display the headless `mrbtest` binary lacks (the same reason the `Viewport`/`Sprite` tests only assert their surface).
- Verified the holder's semantics standalone (defaults, read/write, dispose) before pushing.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #2 (`Window`) → ⚠️ (stored; native frame/cursor render pending).
- Changelog fragment `changelog.d/rpgxp-rgss-window-holder.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_