### PR TITLE
Add --mv_save_test smoke: confirm MV save/load round-trips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
       # avoided: its server-number probe is not atomic, so concurrent -a runs
       # can grab the same display, killing one Xvfb out from under its client
       # ("XIO: fatal IO error"). Reserved numbers: exe_open=99 (see the ctest
-      # `exe_open` test in CMakeLists.txt); MV runs=100..106 below. Every MV
+      # `exe_open` test in CMakeLists.txt); MV runs=100..107 below. Every MV
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
       # check.
@@ -243,6 +243,16 @@ jobs:
               nix develop -c xvfb-run --server-num=106 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_menu_test --mv_screenshot=ss/mv_menu.png
+
+          # Confirm the save path works: New Game -> map, then a save+load
+          # round-trip through DataManager, logging `[MV-SAVE] saved=.. exists=..
+          # loaded=..`. Non-visual, so no screenshot.
+          - name: MV save smoke test
+            continue-on-error: true
+            run: |
+              nix develop -c xvfb-run --server-num=107 timeout 120 ./build/rpg_maker_clone \
+                --timeout_ms=6000 --game_dir data/mv-sample \
+                --mv_new_game --mv_save_test
 
       - name: Upload MV screenshot
         continue-on-error: true

--- a/changelog.d/mv-save-smoke.added.md
+++ b/changelog.d/mv-save-smoke.added.md
@@ -1,0 +1,9 @@
+- MV save smoke test: a new `--mv_save_test` flag drives the MV sample past New
+  Game onto the map, then runs a save+load round-trip through the real
+  `DataManager` — `saveGame` serializes the `$game*` objects into a slot via
+  `StorageManager` (the host keeps `Utils.isNwjs()` false, so this goes through
+  the localStorage shim that persists to disk), `StorageManager.exists` confirms
+  the slot, and `loadGame` reads it back and rebuilds the game objects — logging
+  `[MV-SAVE] saved=<bool> exists=<bool> loaded=<bool>`. It exercises the save
+  path every game relies on, so CI confirms saves actually write and reload.
+  Wired as a non-blocking `build` job step alongside the other MV smokes.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -483,5 +483,12 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     map interpreter instead of a bare out-of-loop `SceneManager.push`, which
     deadlocked on the frozen encounter-effect intro. Runs on Lunatic-Core (real
     battlers/battleback) and logs `[MV-BTL] reached_battle=<bool>`.
+  - ✅ Menu smoke: `--mv_menu_test` opens `Scene_Menu` via the engine's real
+    `callMenu` path (re-asserting `Scene_Map.menuCalling`) and logs
+    `[MV-MENU] reached_menu=<bool>`.
+  - ✅ Save smoke: `--mv_save_test` runs a save+load round-trip through
+    `DataManager` (save → `StorageManager.exists` → load) and logs
+    `[MV-SAVE] saved=.. exists=.. loaded=..`, confirming the localStorage-backed
+    save path writes and reloads.
 - 🚧 **M6 — MZ.** A WebGL-subset backend on LVGL so PIXI v5 / RPG Maker MZ runs
   on the same foundation (`js/rmmz_*.js`).

--- a/mruby-mvjs/mrblib/mv.rb
+++ b/mruby-mvjs/mrblib/mv.rb
@@ -261,6 +261,7 @@ class MV
     maybe_move_test # CI: hold a direction on the map and log that the player moved
     maybe_message_test # CI: show a text message on the map and log the window opened
     maybe_menu_test # CI: open the menu on the map and log that Scene_Menu opened
+    maybe_save_test # CI: save+load round-trip on the map and log the result
     present # M4: copy the MV canvas onto the on-screen sprite's bitmap
     maybe_screenshot # capture the rendered frame once, if requested (CI)
     RGSS::Input.update
@@ -395,7 +396,8 @@ class MV
       false
     end
     return unless new_game || battle_test_troop > 0 || move_test_requested? ||
-                  message_test_requested? || menu_test_requested?
+                  message_test_requested? || menu_test_requested? ||
+                  save_test_requested?
     return unless current_scene == "Scene_Title"
 
     @new_game_done = true
@@ -628,6 +630,44 @@ class MV
     $stderr.puts "[MV-MENU] reached_menu=false scene=#{current_scene}"
   rescue StandardError => e
     $stderr.puts "[MV] menu test error: #{e.message}"
+  end
+
+  # Whether --mv_save_test was requested (a launcher constant set by main.cxx).
+  def save_test_requested?
+    (begin
+      MV_SAVE_TEST
+    rescue StandardError
+      false
+    end) == true
+  end
+
+  # When --mv_save_test is set (CI), once on the map run a save+load round-trip
+  # through the real DataManager and log the result. This drives the save path
+  # every game relies on: DataManager.saveGame serializes $game* into a save
+  # slot via StorageManager (our host keeps Utils.isNwjs() false, so this goes
+  # through the localStorage shim that persists to disk), StorageManager.exists
+  # confirms the slot, and DataManager.loadGame reads it back and rebuilds the
+  # game objects. A headless run thus confirms saves actually write and reload.
+  # One-shot; a no-op during normal play (flag unset).
+  def maybe_save_test
+    return if @save_test_done
+    return unless save_test_requested?
+    return unless current_scene == "Scene_Map"
+
+    @save_test_done = true
+    res = MV::JS.eval(
+      "(function(){ try { " \
+      "if (typeof DataManager === 'undefined') return 'no DataManager'; " \
+      "var saved = DataManager.saveGame(1); " \
+      "var exists = StorageManager.exists(1); " \
+      "var loaded = DataManager.loadGame(1); " \
+      "return 'saved=' + (!!saved) + ' exists=' + (!!exists) + " \
+      "' loaded=' + (!!loaded); " \
+      "} catch (e) { return 'error: ' + String(e && e.message || e); } })()"
+    )
+    $stderr.puts "[MV-SAVE] #{res}"
+  rescue StandardError => e
+    $stderr.puts "[MV] save test error: #{e.message}"
   end
 
   # Log the running scene's class name whenever it changes, so the boot's

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -66,6 +66,13 @@ DEFINE_bool(
     "For RPG Maker MV: once on the map, press the cancel/menu button (implies "
     "--mv_new_game to reach the map) and log whether Scene_Menu opened, so a "
     "headless run confirms the menu path works. Used in CI");
+DEFINE_bool(
+    mv_save_test,
+    false,
+    "For RPG Maker MV: once on the map, save to a slot and load it back "
+    "(implies --mv_new_game to reach the map) and log whether the save/load "
+    "round-trip succeeded, so a headless run confirms the save path works. "
+    "Used in CI");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -462,6 +469,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_MENU_TEST"),
                 mrb_bool_value(FLAGS_mv_menu_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MV_SAVE_TEST"),
+                mrb_bool_value(FLAGS_mv_save_test));
   CHECK_NO_EXC(M);
 
   const mrb_value args = mrb_ary_new_capa(M, argc - 1);


### PR DESCRIPTION
## Summary

Save/load was the last M5 path without a smoke, and every game relies on it. This adds a `--mv_save_test` flag that runs a full save→load round-trip through the real `DataManager`.

## Changes

- **`src/main.cxx`**: a new `--mv_save_test` flag (+ `MV_SAVE_TEST` constant), mirroring the other MV smoke flags.
- **`mruby-mvjs/mrblib/mv.rb`**: `maybe_save_test` — once on the map, `DataManager.saveGame(1)` serializes the `$game*` objects into a slot via `StorageManager` (the host keeps `Utils.isNwjs()` false, so this goes through the localStorage shim that persists to disk), `StorageManager.exists(1)` confirms the slot, and `DataManager.loadGame(1)` reads it back and rebuilds the game objects. Logs `[MV-SAVE] saved=<bool> exists=<bool> loaded=<bool>`.
- **`.github/workflows/build.yml`**: a non-blocking `MV save smoke test` step (`data/mv-sample`, `--server-num=107`). Non-visual, so no screenshot.
- **`changelog.d/mv-save-smoke.added.md`**, **`docs/TODO.md`**: changelog fragment + M5 checklist entries (save, and the menu smoke that just landed).

## Verification

Built the native binary locally and ran the exact CI command:

```
[MV] scene: Scene_Map
[MV-SAVE] saved=true exists=true loaded=true
```

Both `data/mv-sample` and `data/Lunatic-Core` report `saved=true exists=true loaded=true`. `mruby_test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_