### PR TITLE
rpg2k: Erase Screen / Show Screen (screen fade transitions)

### DIFF
--- a/changelog.d/rpg2k-erase-show-screen.added.md
+++ b/changelog.d/rpg2k-erase-show-screen.added.md
@@ -1,0 +1,11 @@
+- The **Erase Screen** (11010) and **Show Screen** (11020) event commands are
+  now handled. They fade the whole screen out to black and back over a fixed
+  transition, modelled on `Game::Screen` as a fade level (0 visible .. 255
+  black) that eases like the tint transition and is held erased until a Show.
+  Both run their transition and pause the event on the existing `:screen` wait
+  until it settles, so event timing around fades is correct. The requested
+  transition style (param0: 0 fade, higher = block / stripe / scroll variants)
+  is recorded for fidelity but only the fade is modelled, and — like the tint
+  and flash overlays — drawing the actual black overlay is the native refinement
+  still to come. Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -128,7 +128,8 @@ The work below is roughly ordered by the critical path to a walkable game
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
   Change Teleport / Escape Access, Set Teleport / Escape Target,
   Change Encounter Rate, Change System BGM / SFX, Show Inn,
-  Tint Screen, Flash Screen, Shake Screen, Pan Screen, Weather Effects, Call
+  Erase / Show Screen, Tint Screen, Flash Screen, Shake Screen, Pan Screen,
+  Weather Effects, Call
   Event, Move Event, Change / Trade Event Location, Change Map Tileset, Proceed
   With Movement, Halt All Movement,
   Erase Event, Return to Title, End Event) with a per-frame step cap so a bad
@@ -249,10 +250,15 @@ The work below is roughly ordered by the critical path to a walkable game
   `Game::Screen` as well: lock / unlock freeze or resume the camera's hero
   follow, and pan / reset scroll a pixel offset toward a target that `Scene::Map`
   adds to the camera (so — like the shake — the pan **is** visible; while locked
-  the view holds where locking began). All four share the `:screen` wait. **Show
-  Picture** now renders (see the interpreter bullet above). Transitions/fade and
-  weather remain, and the tint/flash still need `RGSS::Viewport` tone/alpha
-  support in C++ to show
+  the view holds where locking began). **Erase Screen** (11010) / **Show Screen**
+  (11020) drive `Game::Screen` too: a fade level (0 visible .. 255 black) that
+  eases like the tint over a fixed transition and is held erased until a Show,
+  recording the requested transition style (fade / block / stripe / scroll) for
+  fidelity while modelling only the fade. All share the `:screen` wait, so event
+  timing around them is correct. **Show Picture** now renders (see the
+  interpreter bullet above). Weather remains, and the tint / flash / screen-fade
+  overlays still need `RGSS::Viewport` tone/alpha support in C++ to actually
+  darken or colour what is drawn
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1765,6 +1765,10 @@ module Game
       @pan_ty = 0
       @pan_step = 1     # pixels moved toward the target per frame
       @pan_locked = false # when true the scene stops the camera following the hero
+      @fade = 0            # screen erasure: 0 fully visible .. 255 fully black
+      @fade_target = 0     # the level the current transition eases toward
+      @fade_frames = 0     # frames left in the current fade (0 = settled)
+      @fade_transition = 0 # RPG2000 transition style (see Erase/Show Screen)
     end
 
     # Current tint as [red, green, blue, saturation] (each 0..200, 100 neutral).
@@ -1798,8 +1802,25 @@ module Game
     # True while a pan/reset scroll has not yet reached its target.
     def panning?; @pan_x != @pan_tx || @pan_y != @pan_ty; end
 
+    # Screen erasure level (0 fully visible .. 255 fully black). The scene draws
+    # a black overlay at this opacity — the native half still to come, like the
+    # tint and flash overlays — so the level is modelled but does not yet darken
+    # the screen.
+    def fade_level; @fade; end
+
+    # The RPG2000 transition style requested by the last Erase / Show Screen
+    # (0 = fade, higher = block / stripe / scroll variants). Recorded for
+    # fidelity; only the fade is modelled.
+    def fade_transition; @fade_transition; end
+
+    # True while an erase / show fade is still in progress.
+    def fading?; @fade_frames > 0; end
+
+    # True once the screen is fully erased (held black until a Show Screen).
+    def erased?; @fade >= 255; end
+
     # True while any screen effect is still animating (drives the wait flag).
-    def busy?; tinting? || shaking? || flashing? || panning?; end
+    def busy?; tinting? || shaking? || flashing? || panning? || fading?; end
 
     # Begin a tint transition to the target channels over `frames` frames
     # (frames <= 0 applies it immediately). Values are clamped to 0..200.
@@ -1847,6 +1868,19 @@ module Game
       end
     end
 
+    # Erase Screen: fade the screen out to black over `frames` frames using the
+    # given RPG2000 transition style. Held black afterwards until #show. A no-op
+    # (settles immediately) when the screen is already fully erased.
+    def erase(transition, frames)
+      fade_to(255, transition, frames)
+    end
+
+    # Show Screen: fade the screen back in from black over `frames` frames. A
+    # no-op when the screen is already fully visible.
+    def show(transition, frames)
+      fade_to(0, transition, frames)
+    end
+
     # Pan-operation direction (RPG2000: 0 up, 1 right, 2 down, 3 left) -> unit
     # camera delta. A positive x pans the view right, a positive y pans it down.
     PAN_DELTA = { 0 => [0, -1], 1 => [1, 0], 2 => [0, 1], 3 => [-1, 0] }.freeze
@@ -1878,9 +1912,30 @@ module Game
       update_shake
       update_flash
       update_pan
+      update_fade
     end
 
     private
+
+    # Start a fade toward `target` (0 visible / 255 black) over `frames` frames.
+    # Already at the target -> settle immediately so the command does not wait.
+    def fade_to(target, transition, frames)
+      @fade_transition = transition
+      @fade_target = target
+      if frames <= 0 || @fade == target
+        @fade = target
+        @fade_frames = 0
+      else
+        @fade_frames = frames
+      end
+    end
+
+    def update_fade
+      return if @fade_frames <= 0
+      @fade += (@fade_target - @fade) / @fade_frames
+      @fade_frames -= 1
+      @fade = @fade_target if @fade_frames.zero? # land exactly on the target
+    end
 
     def update_tint
       return if @frames <= 0

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -62,6 +62,8 @@ module Game
       ERASE_EVENT      = 12320
       CALL_EVENT       = 12330
       TELEPORT         = 10810
+      ERASE_SCREEN     = 11010
+      SHOW_SCREEN      = 11020
       TINT_SCREEN      = 11030
       FLASH_SCREEN     = 11040
       SHAKE_SCREEN     = 11050
@@ -407,6 +409,8 @@ module Game
       when Cmd::TRADE_EVENT_LOCATIONS then do_trade_event_locations cmd
       when Cmd::STORE_TERRAIN_ID  then do_store_terrain_id cmd
       when Cmd::STORE_EVENT_ID    then do_store_event_id cmd
+      when Cmd::ERASE_SCREEN     then do_erase_screen cmd
+      when Cmd::SHOW_SCREEN      then do_show_screen cmd
       when Cmd::TINT_SCREEN      then do_tint_screen cmd
       when Cmd::FLASH_SCREEN     then do_flash_screen cmd
       when Cmd::SHAKE_SCREEN     then do_shake_screen cmd
@@ -1148,6 +1152,33 @@ module Game
     # Frames per tenth of a second at RPG2000's fixed 60 fps, for turning a
     # screen effect's 0.1s-unit duration into a frame count.
     FRAMES_PER_TENTH = 6
+
+    # Fixed length of an Erase / Show Screen transition. RPG_RT runs these for a
+    # set per-style duration rather than an event-supplied one; this approximates
+    # the common fade at ~0.5s.
+    SCREEN_FADE_FRAMES = 32
+
+    # Erase Screen (11010) / Show Screen (11020): fade the whole screen out to
+    # black or back in over a fixed duration, using the transition style in
+    # param0 (0 = fade; higher = block / stripe / scroll variants, of which only
+    # the fade is modelled). Both always run their transition and pause the event
+    # until it settles — the owning scene advances Game::Screen each frame and
+    # resumes us on the :screen wait. Only the fade *level* is modelled; drawing
+    # the black overlay is the native refinement still pending for the tint and
+    # flash overlays too.
+    def do_erase_screen(cmd)
+      @state.screen.erase(cmd.param(0), SCREEN_FADE_FRAMES)
+      return unless @state.screen.fading?
+      @wait_kind = :screen
+      @waiting = true
+    end
+
+    def do_show_screen(cmd)
+      @state.screen.show(cmd.param(0), SCREEN_FADE_FRAMES)
+      return unless @state.screen.fading?
+      @wait_kind = :screen
+      @waiting = true
+    end
 
     # Tint Screen: transition the shared screen tint to the RPG2000 channels
     # param0..3 (red / green / blue / saturation, each 0..200) over param4 tenths

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1006,6 +1006,61 @@ check 'Pan Screen (op 2) with a wait pauses until the scroll finishes' do
   eq [16, 0], st.screen.pan_offset
 end
 
+# -- Erase / Show Screen ------------------------------------------------------
+
+check 'Erase Screen fades to black, pauses the event, then holds erased' do
+  st = new_state
+  eq 0, st.screen.fade_level, 'screen visible by default'
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ERASE_SCREEN, [0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok it.waiting?, 'Erase Screen suspends until the fade settles'
+  eq :screen, it.wait_kind
+  ok st.screen.fading?, 'the fade is in progress'
+  ok !st.switches[1], 'the next command has not run yet'
+  st.screen.update until !st.screen.busy? # the scene advances it each frame
+  eq 255, st.screen.fade_level, 'fully black'
+  ok st.screen.erased?, 'the screen is held erased'
+  it.resume
+  it.update
+  eq true, st.switches[1], 'the event continued once the fade settled'
+end
+
+check 'Show Screen fades back in from black' do
+  st = new_state
+  st.screen.erase(0, 32)
+  st.screen.update until !st.screen.fading? # start fully black
+  eq 255, st.screen.fade_level
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_SCREEN, [0])])
+  it.update
+  ok it.waiting?, 'Show Screen also waits for its fade'
+  st.screen.update until !st.screen.fading?
+  eq 0, st.screen.fade_level, 'fully visible again'
+  ok !st.screen.erased?
+end
+
+check 'Show Screen when already visible does not pause' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_SCREEN, [0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0])])
+  it.update
+  ok !it.waiting?, 'a no-op show settles immediately'
+  eq true, st.switches[2], 'the event ran straight through'
+end
+
+check 'Erase Screen records the transition style and ramps the level' do
+  st = new_state
+  st.screen.erase(3, 32) # transition style 3 (a block/stripe variant)
+  eq 3, st.screen.fade_transition, 'the style is recorded for fidelity'
+  before = st.screen.fade_level
+  st.screen.update
+  ok st.screen.fade_level > before, 'the level eases toward black'
+  ok st.screen.fade_level < 255, 'over time, not instantly'
+end
+
 check 'conditional branch on the timer' do
   st = new_state
   st.timer_frames = 30 * 60 # 30 seconds remaining

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1104,6 +1104,24 @@ check 'Pan Screen locks the camera and holds the interpreter while scrolling' do
   ok st.switches[1], 'the interpreter resumed after the pan'
 end
 
+check 'Erase Screen pauses the event until the fade settles, then continues' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::ERASE_SCREEN, [0]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  scene.update # runs Erase Screen -> suspends on :screen
+  ok !st.switches[5], 'the event pauses while the screen fades'
+  ok st.screen.fading?, 'the fade is in progress'
+  40.times { scene.update } # the scene advances Game::Screen each frame
+  eq 255, st.screen.fade_level, 'the screen is fully erased'
+  ok st.screen.erased?, 'held erased'
+  ok st.switches[5], 'the event resumed after the fade settled'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
Adds the screen-transition pair to the RPG2000 event-command interpreter, verified against liblcf / EasyRPG.

## Erase Screen (11010) / Show Screen (11020)

They fade the whole screen out to black and back over a fixed transition, modelled on `Game::Screen` as a **fade level** (0 visible … 255 black) that eases like the existing tint transition and is **held erased** until a Show.

- **Params** (verified against EasyRPG): `param0` selects the transition style — `0` = fade; higher = block / stripe / scroll variants. The style is recorded on `Game::Screen` for fidelity, but only the fade is modelled.
- **Event timing**: both run their transition and pause the event on the existing `:screen` wait until it settles — `Scene::Map` advances `Game::Screen` each frame and resumes once `busy?` clears. This is the same wait tint / flash / shake / pan already use, so event flow around fades is correct. It also lays the groundwork for the inn fade deferred in #195.
- **Consistent deferral**: like the tint and flash overlays, drawing the actual black overlay is the native `RGSS::Viewport` alpha refinement still to come, so the fade level is modelled but does not yet darken what's drawn. Documented in `docs/TODO.md`.

## Testing

- `scripts/rpg2k_logic_check.rb` — **171 pass** (new: fade-to-black + `:screen` wait + held-erased, fade-in, no-op show on an already-visible screen, transition-style recording + level ramp)
- `scripts/rpg2k_scene_check.rb` — **56 pass** (new: an event pauses through the fade and resumes once the screen settles)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_