### PR TITLE
Add an RPG2000 field equip menu (change equipment from the menu)

### DIFF
--- a/changelog.d/rpg2k-equip-menu.added.md
+++ b/changelog.d/rpg2k-equip-menu.added.md
@@ -1,0 +1,13 @@
+- RPG Maker 2000 main menu: the **Equip** command now opens a working equipment
+  screen (`Scene::EquipMenu`) instead of reporting "not implemented". It shows one
+  party member's five equipment slots (weapon / shield / armour / helmet /
+  accessory) with the item worn in each, plus that member's stats; LEFT/RIGHT
+  cycle through the party. Choosing a slot lists the bag's items that fit it (by
+  database item type) with a leading Remove entry; choosing one equips it —
+  taking it from the bag and returning the previously-worn item to the bag — or
+  empties the slot, recomputing the member's stats either way. The bag-aware
+  logic is `Game::Party#equip_candidates` / `equip_from_bag` / `unequip_to_bag`
+  (distinct from the Change Equipment event command, which does not touch the
+  bag), covered by four new checks in `scripts/rpg2k_logic_check.rb` (the CI-run
+  host harness); `Scene::EquipMenu` is the RGSS UI over it. Two-handed weapons and
+  dual-wield equipping are later refinements.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -256,17 +256,23 @@ The work below is roughly ordered by the critical path to a walkable game
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a
-  command list. Save, End Game and **Item** work; skill / equip / status are
+  command list. Save, End Game, **Item** and **Equip** work; skill / status are
   placeholders still to be built from the parsed `term`/skill/actor data. The
   **Item** command opens `Scene::ItemMenu`: it lists the party's usable medicines
   (database item type 6) with their held counts, applies a single-target item to
   a chosen ally or an all-ally item (scope 1) to the whole party, restores HP/SP
   (flat + percentage of max, clamped), consumes one on a use that had any effect,
   and greys out / reports a use with no effect (a target already full). The
-  decision logic is `Game::Party#field_items` / `item_recovery` / `item_effective?`
-  / `use_item`, covered by `scripts/rpg2k_logic_check.rb`; the RGSS windows are
-  the untestable-here UI. Book (7) / seed (8) / switch (9) item use and the
-  usable-occasion gate are later refinements.
+  **Equip** command opens `Scene::EquipMenu`: it shows a party member's five
+  equipment slots and stats (LEFT/RIGHT cycle members), and for a chosen slot
+  lists the bag's fitting items (plus Remove); equipping swaps the previously-worn
+  item back into the bag and recomputes stats. The decision logic is on
+  `Game::Party` (`field_items` / `item_recovery` / `item_effective?` / `use_item`
+  for items; `equip_candidates` / `equip_from_bag` / `unequip_to_bag` for equip),
+  covered by `scripts/rpg2k_logic_check.rb`; the RGSS windows are the
+  untestable-here UI. Book (7) / seed (8) / switch (9) item use, the item
+  usable-occasion gate, and two-handed / dual-wield equipping are later
+  refinements.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default
@@ -295,8 +301,8 @@ The work below is roughly ordered by the critical path to a walkable game
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations, game-over scene (large; Nepheshel uses the default RPG2000
   battle). Needs real assets + the native build to develop against
-- Skill / Equip / Status menu screens — the menu framework and party data are in
-  place, and the Item screen now exists (see Menu scene above); Skill / Equip /
+- Skill / Status menu screens — the menu framework and party data are in place,
+  and the Item and Equip screens now exist (see Menu scene above); Skill and
   Status still need building
 
 #### Assets & infrastructure

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1261,6 +1261,51 @@ module Game
       lose_item(id, 1) unless affected.empty?
       affected
     end
+
+    # The equipment slot index (0..4) a held item occupies by its database type
+    # -- weapon(1)->0, shield(2)->1, armour(3)->2, helmet(4)->3, accessory(5)->4
+    # -- or nil when the item is not equipment (or unknown). Mirrors
+    # Actor#equip_item's `type - 1` mapping.
+    def equip_slot_for(id)
+      it = db_item(id)
+      return nil unless it
+      t = it.type
+      (t >= 1 && t <= Actor::EQUIP_ORDER.size) ? t - 1 : nil
+    end
+
+    # Held items equippable in equipment `slot` (0..4), as [id, count] pairs in
+    # ascending id order -- the candidate list for the equip menu's chosen slot.
+    def equip_candidates(slot)
+      @items.keys.sort.select { |id| item_count(id) > 0 && equip_slot_for(id) == slot }
+            .map { |id| [id, item_count(id)] }
+    end
+
+    # Equip bag item `item_id` on `actor`, moving it through the inventory the way
+    # the equip menu does: take one from the bag, equip it into the slot its type
+    # dictates, and return the previously-equipped item (if any) to the bag. A
+    # no-op returning false unless the party holds the item and it is equipment;
+    # true on success. (Unlike the Change Equipment event command, which does not
+    # touch the bag, the menu swaps through it.)
+    def equip_from_bag(actor, item_id)
+      return false unless actor && item_count(item_id) > 0
+      slot = equip_slot_for(item_id)
+      return false if slot.nil?
+      previous = actor.equipment[slot]
+      actor.equip_item(item_id)
+      lose_item(item_id, 1)
+      gain_item(previous, 1) if previous && previous != 0
+      true
+    end
+
+    # Unequip `actor`'s `slot`, returning the removed item to the bag. Returns the
+    # removed item id (0 when the slot was already empty or the slot is invalid).
+    def unequip_to_bag(actor, slot)
+      return 0 unless actor && slot >= 0 && slot < Actor::EQUIP_ORDER.size
+      removed = actor.equipment[slot]
+      actor.unequip(slot)
+      gain_item(removed, 1) if removed && removed != 0
+      removed || 0
+    end
   end
 
   # A loaded map (.lmu) plus convenience accessors for the two tile layers.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2158,6 +2158,8 @@ class RPG2k
         case COMMANDS[@index]
         when "Item"
           @parent.push Scene::ItemMenu.new(@parent, @state)
+        when "Equip"
+          @parent.push Scene::EquipMenu.new(@parent, @state)
         when "Save"
           if @state.save_access
             show_message(@parent.save_game(@state) ? "Game saved." : "Save failed.")
@@ -2404,6 +2406,196 @@ class RPG2k
         return unless @message
         @message[:window].dispose
         @message = nil
+      end
+    end
+
+    # The field equip screen (main menu -> Equip). Shows one party member's five
+    # equipment slots and current stats; LEFT/RIGHT cycle the member. Choosing a
+    # slot lists the bag's items that fit it (plus Remove); choosing one equips it
+    # -- swapping the previously-worn item back into the bag -- or empties the
+    # slot. The bag-aware equip logic is Game::Party#equip_candidates /
+    # equip_from_bag / unequip_to_bag (host-tested); this is the RGSS UI over it,
+    # mirroring Scene::ItemMenu's helpers. Actor-cycling covers the party; two-
+    # handed weapons and dual-wield are later refinements.
+    class EquipMenu < Base
+      SCREEN_W = RPG2k::WIDTH
+      SCREEN_H = RPG2k::HEIGHT
+      LINE_H = 16
+      SLOTS = ["Weapon", "Shield", "Armor", "Helmet", "Accessory"].freeze
+
+      def initialize parent, state
+        super parent
+        @state = state
+        @skin = make_windowskin
+        @actor_index = 0
+        @slot_index = 0
+        @cand_index = 0
+        @mode = :slots          # :slots list, or :items candidate pick
+        build_stats_window
+        build_slot_window
+      end
+
+      def dispose
+        @stats_window.dispose if @stats_window
+        @slot_window.dispose if @slot_window
+        @cand_window.dispose if @cand_window
+      end
+
+      def update
+        @mode == :items ? update_items : update_slots
+      end
+
+      private
+
+      def actor
+        @state.party.actors[@actor_index]
+      end
+
+      def item_name(id)
+        return "-" if id.nil? || id == 0
+        it = @state.party.db_item(id)
+        n = it && it.name.to_s
+        n.nil? || n.empty? ? "Item #{id}" : n
+      end
+
+      def update_slots
+        party = @state.party.actors
+        if Input.trigger?(Input::B)
+          @parent.pop
+        elsif Input.trigger?(Input::DOWN) && @slot_index < SLOTS.size - 1
+          @slot_index += 1
+          refresh_slot_cursor
+        elsif Input.trigger?(Input::UP) && @slot_index > 0
+          @slot_index -= 1
+          refresh_slot_cursor
+        elsif Input.trigger?(Input::RIGHT) && @actor_index < party.size - 1
+          @actor_index += 1
+          rebuild_for_actor
+        elsif Input.trigger?(Input::LEFT) && @actor_index > 0
+          @actor_index -= 1
+          rebuild_for_actor
+        elsif Input.trigger?(Input::C)
+          @cand_index = 0
+          @mode = :items
+          build_cand_window
+        end
+      end
+
+      def candidates
+        # The slot's fitting bag items, with a leading Remove entry (id 0).
+        @candidates ||= [[0, 0]] + @state.party.equip_candidates(@slot_index)
+      end
+
+      def update_items
+        if Input.trigger?(Input::B)
+          leave_items
+        elsif Input.trigger?(Input::DOWN) && @cand_index < candidates.size - 1
+          @cand_index += 1
+          refresh_cand_cursor
+        elsif Input.trigger?(Input::UP) && @cand_index > 0
+          @cand_index -= 1
+          refresh_cand_cursor
+        elsif Input.trigger?(Input::C)
+          apply_choice
+        end
+      end
+
+      def apply_choice
+        id, = candidates[@cand_index]
+        if id == 0
+          @state.party.unequip_to_bag(actor, @slot_index)
+        else
+          @state.party.equip_from_bag(actor, id)
+        end
+        leave_items
+        rebuild_for_actor
+      end
+
+      def leave_items
+        @candidates = nil
+        @mode = :slots
+        if @cand_window
+          @cand_window.dispose
+          @cand_window = nil
+        end
+      end
+
+      def rebuild_for_actor
+        @slot_index = SLOTS.size - 1 if @slot_index >= SLOTS.size
+        build_stats_window
+        build_slot_window
+      end
+
+      def build_stats_window
+        @stats_window.dispose if @stats_window
+        inner_w = SCREEN_W - Window::BORDER * 2
+        h = LINE_H * 3
+        @stats_window = Window.new(0, 0, SCREEN_W, h + Window::BORDER * 2)
+        @stats_window.z = 400
+        @stats_window.windowskin = @skin
+        c = Bitmap.new(inner_w, h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        a = actor
+        c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}  Lv #{a.level}"
+        c.draw_text 0, LINE_H, inner_w, LINE_H,
+                    "HP #{a.hp}/#{a.max_hp}  MP #{a.mp}/#{a.max_mp}"
+        c.draw_text 0, LINE_H * 2, inner_w, LINE_H,
+                    "Atk #{a.atk}  Def #{a.def}  Int #{a.int}  Agi #{a.agi}"
+        @stats_window.contents = c
+      end
+
+      def build_slot_window
+        @slot_window.dispose if @slot_window
+        inner_w = SCREEN_W - Window::BORDER * 2
+        h = SLOTS.size * LINE_H
+        y = LINE_H * 3 + Window::BORDER * 2
+        @slot_window = Window.new(0, y, SCREEN_W, h + Window::BORDER * 2)
+        @slot_window.z = 400
+        @slot_window.windowskin = @skin
+        c = Bitmap.new(inner_w, h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        eq = actor.equipment
+        SLOTS.each_with_index do |label, i|
+          c.draw_text 0, i * LINE_H, 80, LINE_H, label
+          c.draw_text 80, i * LINE_H, inner_w - 80, LINE_H, item_name(eq[i])
+        end
+        @slot_window.contents = c
+        refresh_slot_cursor
+      end
+
+      def refresh_slot_cursor
+        return unless @slot_window
+        @slot_window.cursor_rect =
+          Rect.new(0, @slot_index * LINE_H, @slot_window.contents.width, LINE_H)
+      end
+
+      def build_cand_window
+        @cand_window.dispose if @cand_window
+        rows = candidates
+        inner_w = SCREEN_W - Window::BORDER * 2
+        h = rows.size * LINE_H
+        @cand_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
+                                  SCREEN_W, h + Window::BORDER * 2)
+        @cand_window.z = 450
+        @cand_window.windowskin = @skin
+        c = Bitmap.new(inner_w, h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        rows.each_with_index do |(id, count), i|
+          if id == 0
+            c.draw_text 0, i * LINE_H, inner_w, LINE_H, "(Remove)"
+          else
+            c.draw_text 0, i * LINE_H, inner_w - 40, LINE_H, item_name(id)
+            c.draw_text inner_w - 40, i * LINE_H, 40, LINE_H, ":#{count}"
+          end
+        end
+        @cand_window.contents = c
+        refresh_cand_cursor
+      end
+
+      def refresh_cand_cursor
+        return unless @cand_window
+        @cand_window.cursor_rect =
+          Rect.new(0, @cand_index * LINE_H, @cand_window.contents.width, LINE_H)
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1589,6 +1589,71 @@ check 'use_item restores MP and item_effective? tracks the SP deficit' do
   eq 0, st.party.item_count(6)
 end
 
+# -- Field equip menu (Game::Party bag-aware equip) --------------------------
+
+# A single-hero party (base stats maxHP10/maxSP5/atk3/def2/int1/agi4) plus the
+# given item table, for the equip-menu checks.
+def equip_party(items)
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) },
+                       [1], items)
+  Game::State.new(Game::Party.new(db), 1, 0, 0)
+end
+
+check 'equip_candidates lists held items for a slot, in id order' do
+  items = { 7 => fake_item(atk: 15, type: 1),   # weapon  -> slot 0
+            9 => fake_item(atk: 5,  type: 1),   # weapon  -> slot 0
+            8 => fake_item(dfn: 9,  type: 3),   # armour  -> slot 2
+            5 => fake_item(type: 6, rhp: 10) }  # medicine (not equipment)
+  st = equip_party(items)
+  [7, 9, 8, 5].each { |id| st.party.gain_item(id, 1) }
+  eq [[7, 1], [9, 1]], st.party.equip_candidates(0)   # weapons
+  eq [[8, 1]], st.party.equip_candidates(2)           # armour
+  eq [], st.party.equip_candidates(1)                 # shield: none held
+end
+
+check 'equip_from_bag equips, consumes the item and returns the old one' do
+  items = { 7 => fake_item(atk: 15, type: 1), 9 => fake_item(atk: 5, type: 1) }
+  st = equip_party(items)
+  a = st.party.leader
+  st.party.gain_item(7, 1)
+  st.party.gain_item(9, 1)
+  eq 3, a.atk                        # base atk
+  ok st.party.equip_from_bag(a, 7)
+  eq 18, a.atk                       # +15
+  eq 7, a.equipment[0]
+  eq 0, st.party.item_count(7)       # consumed from the bag
+  # Swapping to weapon 9 returns weapon 7 to the bag.
+  ok st.party.equip_from_bag(a, 9)
+  eq 8, a.atk                        # base 3 + 5
+  eq 9, a.equipment[0]
+  eq 0, st.party.item_count(9)
+  eq 1, st.party.item_count(7)       # the replaced weapon came back
+end
+
+check 'unequip_to_bag clears the slot and returns the item to the bag' do
+  st = equip_party({ 8 => fake_item(dfn: 9, type: 3) })
+  a = st.party.leader
+  st.party.gain_item(8, 1)
+  st.party.equip_from_bag(a, 8)
+  eq 11, a.def                       # base 2 + 9
+  eq 8, st.party.unequip_to_bag(a, 2)
+  eq 2, a.def
+  eq 0, a.equipment[2]
+  eq 1, st.party.item_count(8)       # back in the bag
+  eq 0, st.party.unequip_to_bag(a, 2) # already empty -> 0
+end
+
+check 'equip_from_bag rejects a non-equippable or unheld item' do
+  items = { 5 => fake_item(type: 6, rhp: 10), 7 => fake_item(atk: 15, type: 1) }
+  st = equip_party(items)
+  a = st.party.leader
+  st.party.gain_item(5, 1)
+  eq false, st.party.equip_from_bag(a, 5)   # medicine: not equipment
+  eq false, st.party.equip_from_bag(a, 7)   # not held
+  eq 1, st.party.item_count(5)              # untouched
+  eq 0, a.equipment[0]
+end
+
 # -- Control Variables operands ----------------------------------------------
 
 check 'Control Variables random operand stays within its range' do


### PR DESCRIPTION
The main menu's **Equip** command now opens a working `Scene::EquipMenu` instead of reporting "not implemented". (Follows the field item menu from #198.)

## Behavior

- Shows one party member's five equipment slots (weapon / shield / armour / helmet / accessory) with the item worn in each, plus that member's stats. **LEFT/RIGHT** cycle through the party.
- Choosing a slot lists the bag's items that fit it (by database item type) with a leading **Remove** entry.
- Choosing one **equips** it — taking it from the bag and returning the previously-worn item to the bag — or empties the slot, recomputing the member's stats either way.

## Structure

The bag-aware equip logic lives in pure-Ruby `Game::Party` methods — `equip_slot_for`, `equip_candidates`, `equip_from_bag`, `unequip_to_bag` — **distinct from the Change Equipment event command**, which does not touch the bag. `Scene::EquipMenu` is the RGSS UI over that logic, mirroring `Scene::ItemMenu` / `Scene::Menu` helpers (not runnable headless, like the other scenes).

## Tests

Four new checks in `scripts/rpg2k_logic_check.rb` (the host harness CI runs — `mruby-rpg2k/test/` has no native rpg2k tests, so this is the gate): candidate listing/ordering per slot, equip-with-swap that consumes the new item and returns the old one, unequip-returns-to-bag, and rejection of a non-equippable or unheld item. All 171 logic checks pass; the scene / render / save-load / testbed harnesses stay green.

## Follow-ups

Two-handed weapons and dual-wield equipping; the Skill and Status menu screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_