### PR TITLE
mruby-rgss: RGSS::Tilemap property holder

### DIFF
--- a/changelog.d/rpgxp-rgss-tilemap-holder.added.md
+++ b/changelog.d/rpgxp-rgss-tilemap-holder.added.md
@@ -1,0 +1,7 @@
+- **`RGSS::Tilemap` property holder.** `RGSS::Tilemap` is no longer an empty stub:
+  it now stores the properties `Spriteset_Map` drives — `tileset`, the seven
+  `autotiles[0..6]` slots, `map_data`/`flash_data`/`priorities` (`Table`s),
+  `ox`/`oy`, `visible`, `viewport` — with RGSS defaults, so the stock map scene can
+  build, scroll and dispose its ground layer without raising. The native autotile
+  assembly + priority-layering render is still future work; see
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -62,12 +62,16 @@ without raising. **Remaining:** the native widget compositing — the frame buil
 from the windowskin, the blinking cursor rect, the pause arrow, and blitting the
 scrolled `contents` at `contents_opacity` — is future work.
 
-### 3. `Tilemap` ❌ (the big one for maps)
+### 3. `Tilemap` ⚠️ (stored; native autotile/priority render pending)
 
-`class Tilemap` is empty. `Spriteset_Map` needs: `tileset`, `autotiles` (array),
-`map_data` (a `Table`), `flash_data`, `priorities`, `ox`/`oy`, `viewport`,
-`update`, `dispose`, with the autotile assembly + priority layering the RPG2000
-side already implements in `Game::ChipsetLayout` (portable reference).
+`Tilemap` is now a pure-Ruby property holder (`mruby-rgss/mrblib/lib.rb`) with
+RGSS defaults: `tileset` (a `Bitmap`), `autotiles` (the seven `[0..6]` slots,
+indexable/assignable), `map_data`/`flash_data`/`priorities` (`Table`s), `ox`/`oy`,
+`visible`, `viewport`, `update`, `dispose`/`disposed?`. So `Spriteset_Map` can
+build its ground layer — assign the tileset, fill the autotiles, set the map
+data/priorities, scroll it, and dispose it — without raising. **Remaining:** the
+native render — autotile assembly + priority layering (the RPG2000 side already
+implements a portable reference in `Game::ChipsetLayout`).
 
 ### 4. `Plane` ⚠️ (stored; render pending)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -194,7 +194,43 @@ module RGSS
     end
   end
 
+  # RGSS Tilemap: the layered, autotiled map ground that Spriteset_Map builds from
+  # the tileset, the seven autotiles, and the map's data/priority Tables. Pure-Ruby
+  # property holder for now so the stock scripts that create and drive a Tilemap
+  # run — Spriteset_Map assigns `tileset`, fills `autotiles[0..6]`, sets `map_data`
+  # /`priorities`/`flash_data`, scrolls it via `ox`/`oy`, and disposes it — while
+  # the native autotile assembly + priority layering render is future work (tracked
+  # in docs/rpgxp-rgss-api-gap.md; the RPG2000 side already implements a portable
+  # reference in Game::ChipsetLayout).
   class Tilemap
+    attr_accessor :tileset, :map_data, :flash_data, :priorities, :visible, :ox, :oy
+    attr_reader :viewport, :autotiles
+
+    def initialize(viewport = nil)
+      @viewport = viewport
+      @tileset = nil
+      # RGSS exposes exactly seven autotile slots (0..6); the game assigns each
+      # with `tilemap.autotiles[i] = bitmap` and reads them back to dispose. A
+      # fixed-size Array holds the references (there is no `autotiles=` in RGSS).
+      @autotiles = Array.new(7)
+      @map_data = nil
+      @flash_data = nil
+      @priorities = nil
+      @visible = true
+      @ox = 0
+      @oy = 0
+      @disposed = false
+    end
+
+    def update; end
+
+    def dispose
+      @disposed = true
+    end
+
+    def disposed?
+      @disposed
+    end
   end
 
   # RGSS Window: the framed, scrollable box every Window_Base subclass (message,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -557,6 +557,52 @@ assert("RGSS::Window property defaults and accessors") do
   assert_true w.disposed?
 end
 
+assert("RGSS::Tilemap property defaults and accessors") do
+  t = RGSS::Tilemap.new
+  # RGSS defaults.
+  assert_true t.tileset.nil?
+  assert_true t.map_data.nil?
+  assert_true t.flash_data.nil?
+  assert_true t.priorities.nil?
+  assert_true t.visible
+  assert_equal 0, t.ox
+  assert_equal 0, t.oy
+  assert_true t.viewport.nil?
+  assert_false t.disposed?
+  # Seven autotile slots, all empty, indexable and assignable.
+  assert_equal 7, t.autotiles.size
+  assert_true t.autotiles[0].nil?
+  auto = RGSS::Bitmap.new(96, 128)
+  t.autotiles[3] = auto
+  assert_equal auto, t.autotiles[3]
+
+  # Writable — Spriteset_Map sets these from $game_map.
+  ts = RGSS::Bitmap.new(256, 256)
+  data = RGSS::Table.new(20, 15, 3)
+  prio = RGSS::Table.new(384)
+  t.tileset = ts
+  t.map_data = data
+  t.priorities = prio
+  t.ox = 32
+  t.oy = 16
+  t.visible = false
+  assert_equal ts, t.tileset
+  assert_equal data, t.map_data
+  assert_equal prio, t.priorities
+  assert_equal 32, t.ox
+  assert_equal 16, t.oy
+  assert_false t.visible
+
+  # A viewport-bound tilemap remembers whatever viewport it was constructed with
+  # (a real RGSS::Viewport needs a live display the headless test binary lacks).
+  marker = Object.new
+  assert_equal marker, RGSS::Tilemap.new(marker).viewport
+
+  t.update
+  t.dispose
+  assert_true t.disposed?
+end
+
 # RGSS::Sprite.new needs an initialized display (it references RGSS::_display),
 # which the headless mrbtest build does not set up, so the Sprite extended
 # properties cannot be exercised here — they are load-verified with the rest of


### PR DESCRIPTION
## Summary

Closes the `Tilemap` gap (item #3) from the [RGSS API gap doc](../blob/master/docs/rpgxp-rgss-api-gap.md) — the big blocker for the map scene (follow-up to the script host #176, `Sprite` #189, `Plane`, `sprintf` #190, and the `Window` holder #199).

`RGSS::Tilemap` was an empty stub, so `Spriteset_Map` raised as soon as it assigned the tileset.

## Change

- **`mruby-rgss/mrblib/lib.rb`** — give `RGSS::Tilemap` a pure-Ruby **property holder**, the same approach already used for `Window`, `Plane` and `Sprite`'s extended props. It stores, with RGSS defaults, everything `Spriteset_Map` drives:
  - `tileset` (a `Bitmap`)
  - `autotiles` — the seven `[0..6]` slots, indexable and assignable (`tilemap.autotiles[i] = bitmap`); there is no `autotiles=` in RGSS, so it's a read-only fixed-size container
  - `map_data` / `flash_data` / `priorities` (`Table`s)
  - `ox` / `oy`, `visible`
  - `viewport` (read-only, from the constructor), `update`, `dispose` / `disposed?`

  So the map scene can build its ground layer — assign the tileset, fill the autotiles, set the map data/priorities, scroll it, and dispose it — without raising.

**Not in scope (still future work):** the native render — autotile assembly + priority layering. The RPG2000 side already implements a portable reference in `Game::ChipsetLayout`. The gap-doc entry is downgraded from ❌ to ⚠️ (stored; render pending), matching how `Window`/`Plane`/`Sprite` are tracked.

## Testing

- **`mruby-rgss/test`** — a new `RGSS::Tilemap` check mirroring the `Window`/`Plane` tests: RGSS defaults, the seven indexable/assignable autotile slots, writable accessors (`tileset`, `map_data`, `priorities`, `ox`/`oy`, `visible`), the viewport binding, `update`, and `dispose`/`disposed?`. It uses a marker object for the viewport because a real `RGSS::Viewport` needs a live display the headless `mrbtest` binary lacks (same reason the `Viewport`/`Sprite` tests only assert their surface).
- Verified the holder's semantics standalone (defaults, the autotile slots, read/write, dispose) before pushing.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #3 (`Tilemap`) → ⚠️ (stored; native autotile/priority render pending).
- Changelog fragment `changelog.d/rpgxp-rgss-tilemap-holder.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_