### PR TITLE
Add an RPG2000 field status menu (per-member detail screen)

### DIFF
--- a/changelog.d/rpg2k-status-menu.added.md
+++ b/changelog.d/rpg2k-status-menu.added.md
@@ -1,0 +1,11 @@
+- RPG Maker 2000 main menu: the **Status** command now opens a working status
+  screen (`Scene::StatusMenu`) instead of reporting "not implemented". It shows
+  one party member's full detail — name and title, level, current EXP and the EXP
+  still needed for the next level, HP/MP, the six stats (attack / defence /
+  spirit / agility plus max HP/MP) and the five equipped items; LEFT/RIGHT cycle
+  through the party. The read-only screen adds one piece of tested logic,
+  `Game::Actor#next_level_exp` / `exp_to_next` (derived from the existing RPG2000
+  EXP curve, nil at the maximum level), covered by two new checks in
+  `scripts/rpg2k_logic_check.rb`; the rest reads existing accessors. With Item,
+  Equip and Status done, only the Skill screen remains — it shares the battle
+  effect formula and is best built with the battle system.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -268,19 +268,23 @@ The work below is roughly ordered by the critical path to a walkable game
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a
-  command list. Save, End Game, **Item** and **Equip** work; skill / status are
-  placeholders still to be built from the parsed `term`/skill/actor data. The
-  **Item** command opens `Scene::ItemMenu`: it lists the party's usable medicines
-  (database item type 6) with their held counts, applies a single-target item to
-  a chosen ally or an all-ally item (scope 1) to the whole party, restores HP/SP
-  (flat + percentage of max, clamped), consumes one on a use that had any effect,
-  and greys out / reports a use with no effect (a target already full). The
-  **Equip** command opens `Scene::EquipMenu`: it shows a party member's five
-  equipment slots and stats (LEFT/RIGHT cycle members), and for a chosen slot
-  lists the bag's fitting items (plus Remove); equipping swaps the previously-worn
-  item back into the bag and recomputes stats. The decision logic is on
-  `Game::Party` (`field_items` / `item_recovery` / `item_effective?` / `use_item`
-  for items; `equip_candidates` / `equip_from_bag` / `unequip_to_bag` for equip),
+  command list. Save, End Game, **Item**, **Equip** and **Status** work; only
+  **Skill** remains a placeholder (it shares the battle effect formula, so it is
+  best built with / after the battle system). The **Item** command opens
+  `Scene::ItemMenu`: it lists the party's usable medicines (database item type 6)
+  with their held counts, applies a single-target item to a chosen ally or an
+  all-ally item (scope 1) to the whole party, restores HP/SP (flat + percentage
+  of max, clamped), consumes one on a use that had any effect, and greys out /
+  reports a use with no effect (a target already full). The **Equip** command
+  opens `Scene::EquipMenu`: it shows a party member's five equipment slots and
+  stats (LEFT/RIGHT cycle members), and for a chosen slot lists the bag's fitting
+  items (plus Remove); equipping swaps the previously-worn item back into the bag
+  and recomputes stats. The **Status** command opens `Scene::StatusMenu`: a
+  read-only per-member detail (name/title, level, EXP and EXP-to-next, HP/MP, the
+  six stats and the equipped items; LEFT/RIGHT cycle members). The decision logic
+  is on `Game::Party` (`field_items` / `item_recovery` / `item_effective?` /
+  `use_item` for items; `equip_candidates` / `equip_from_bag` / `unequip_to_bag`
+  for equip) and `Game::Actor` (`next_level_exp` / `exp_to_next` for status),
   covered by `scripts/rpg2k_logic_check.rb`; the RGSS windows are the
   untestable-here UI. Book (7) / seed (8) / switch (9) item use, the item
   usable-occasion gate, and two-handed / dual-wield equipping are later
@@ -313,9 +317,9 @@ The work below is roughly ordered by the critical path to a walkable game
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations, game-over scene (large; Nepheshel uses the default RPG2000
   battle). Needs real assets + the native build to develop against
-- Skill / Status menu screens — the menu framework and party data are in place,
-  and the Item and Equip screens now exist (see Menu scene above); Skill and
-  Status still need building
+- Skill menu screen — the Item, Equip and Status screens now exist (see Menu
+  scene above); only Skill remains, and it is best built with / after the battle
+  system since a skill's HP/SP effect shares that damage/heal formula
 
 #### Assets & infrastructure
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1035,6 +1035,23 @@ module Game
       set_exp(@exp + delta)
     end
 
+    # Total EXP needed to *be at* the next level, or nil at the maximum level
+    # (where there is no next level).
+    def next_level_exp
+      return nil if @level >= max_level
+      exp_for_level(@level + 1)
+    end
+
+    # EXP still required to reach the next level (0 once the threshold is met, so
+    # a just-levelled actor reads 0 briefly), or nil at the maximum level. Drives
+    # the status screen's "to next level" figure.
+    def exp_to_next
+      nxt = next_level_exp
+      return nil unless nxt
+      rem = nxt - @exp
+      rem < 0 ? 0 : rem
+    end
+
     # Change the level by `delta` (the Change Level command). Recomputes the base
     # stats via #set_level and re-aligns EXP to the new level, mirroring EasyRPG's
     # ChangeLevel: on a level up EXP rises to at least the new level's threshold;

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2180,6 +2180,8 @@ class RPG2k
           @parent.push Scene::ItemMenu.new(@parent, @state)
         when "Equip"
           @parent.push Scene::EquipMenu.new(@parent, @state)
+        when "Status"
+          @parent.push Scene::StatusMenu.new(@parent, @state)
         when "Save"
           if @state.save_access
             show_message(@parent.save_game(@state) ? "Game saved." : "Save failed.")
@@ -2616,6 +2618,79 @@ class RPG2k
         return unless @cand_window
         @cand_window.cursor_rect =
           Rect.new(0, @cand_index * LINE_H, @cand_window.contents.width, LINE_H)
+      end
+    end
+
+    # The field status screen (main menu -> Status). Shows one party member's full
+    # detail -- name/title, level, EXP and EXP-to-next, HP/MP, the six stats and
+    # the five equipment slots; LEFT/RIGHT cycle the member. Read-only, so there
+    # is no sub-mode. The EXP-to-next figure is Game::Actor#exp_to_next
+    # (host-tested); the rest reads existing accessors.
+    class StatusMenu < Base
+      SCREEN_W = RPG2k::WIDTH
+      SCREEN_H = RPG2k::HEIGHT
+      LINE_H = 16
+      SLOTS = ["Weapon", "Shield", "Armor", "Helmet", "Accessory"].freeze
+
+      def initialize parent, state
+        super parent
+        @state = state
+        @skin = make_windowskin
+        @actor_index = 0
+        build_window
+      end
+
+      def dispose
+        @window.dispose if @window
+      end
+
+      def update
+        party = @state.party.actors
+        if Input.trigger?(Input::B)
+          @parent.pop
+        elsif Input.trigger?(Input::RIGHT) && @actor_index < party.size - 1
+          @actor_index += 1
+          build_window
+        elsif Input.trigger?(Input::LEFT) && @actor_index > 0
+          @actor_index -= 1
+          build_window
+        end
+      end
+
+      private
+
+      def item_name(id)
+        return "-" if id.nil? || id == 0
+        it = @state.party.db_item(id)
+        n = it && it.name.to_s
+        n.nil? || n.empty? ? "Item #{id}" : n
+      end
+
+      def build_window
+        @window.dispose if @window
+        inner_w = SCREEN_W - Window::BORDER * 2
+        @window = Window.new(0, 0, SCREEN_W, SCREEN_H)
+        @window.z = 400
+        @window.windowskin = @skin
+        c = Bitmap.new(inner_w, SCREEN_H - Window::BORDER * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        a = @state.party.actors[@actor_index]
+        title = a.title.to_s
+        header = title.empty? ? a.name.to_s : "#{a.name}  #{title}"
+        nxt = a.exp_to_next
+        lines = [
+          header,
+          "Lv #{a.level}    EXP #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
+          "HP #{a.hp}/#{a.max_hp}    MP #{a.mp}/#{a.max_mp}",
+          "Atk #{a.atk}   Def #{a.def}   Int #{a.int}   Agi #{a.agi}",
+          "",
+        ]
+        eqp = a.equipment
+        SLOTS.each_with_index { |label, i| lines.push("#{label}: #{item_name(eqp[i])}") }
+        lines.each_with_index do |line, i|
+          c.draw_text 0, i * LINE_H, inner_w, LINE_H, line
+        end
+        @window.contents = c
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1709,6 +1709,30 @@ check 'equip_from_bag rejects a non-equippable or unheld item' do
   eq 0, a.equipment[0]
 end
 
+# -- Status screen (Game::Actor EXP-to-next) ---------------------------------
+
+check 'next_level_exp / exp_to_next track the curve across a level up' do
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 3, [10, 5, 3, 2, 1, 4]) },
+                       [1])
+  a = Game::Party.new(db).leader                 # starts at level 3
+  eq a.exp_for_level(4), a.next_level_exp
+  eq a.next_level_exp - a.exp, a.exp_to_next
+  need = a.exp_to_next
+  ok need > 0, "expected a positive EXP-to-next, got #{need}"
+  a.gain_exp(need)                               # exactly reaches level 4
+  eq 4, a.level
+  eq a.exp_for_level(5) - a.exp, a.exp_to_next   # now measured against level 5
+end
+
+check 'next_level_exp / exp_to_next are nil at the maximum level' do
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) },
+                       [1])
+  a = Game::Party.new(db).leader
+  a.set_level(a.max_level)
+  eq nil, a.next_level_exp
+  eq nil, a.exp_to_next
+end
+
 # -- Control Variables operands ----------------------------------------------
 
 check 'Control Variables random operand stays within its range' do


### PR DESCRIPTION
The main menu's **Status** command now opens a working `Scene::StatusMenu` instead of reporting "not implemented". (Completes the menu series after Item #198 and Equip #202.)

## Behavior

Shows one party member's full detail — name and title, level, current EXP and the **EXP still needed for the next level**, HP/MP, the six stats (attack / defence / spirit / agility plus max HP/MP) and the five equipped items. **LEFT/RIGHT** cycle through the party. The screen is read-only, so there is no sub-mode.

## Structure

The one piece of new logic is `Game::Actor#next_level_exp` / `exp_to_next`, derived from the existing RPG2000 EXP curve (`exp_for_level`) and returning nil at the maximum level. Everything else reads existing accessors. `Scene::StatusMenu` is the RGSS UI over it, mirroring the Item/Equip scene helpers (not runnable headless, like the other scenes).

## Tests

Two new checks in `scripts/rpg2k_logic_check.rb` (the host harness CI runs — `mruby-rpg2k/test/` has no native rpg2k tests, so this is the gate): `exp_to_next` tracks the curve across a level-up (measured against the following level afterward), and both `next_level_exp` / `exp_to_next` are nil at the maximum level. All 177 logic checks pass; the scene / render / save-load / testbed harnesses stay green.

## Menu series

With **Item**, **Equip** and **Status** done, only the **Skill** screen remains — it shares the battle HP/SP effect formula, so it is best built with / after the battle system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_