### PR TITLE
rpg2k: Open Shop (buy / sell subsystem)

### DIFF
--- a/changelog.d/rpg2k-open-shop.added.md
+++ b/changelog.d/rpg2k-open-shop.added.md
@@ -1,0 +1,13 @@
+- The **Open Shop** (10720) event command is now a playable subsystem. It opens
+  a shop over the goods listed in the command (a buy+sell, buy-only or sell-only
+  screen per its mode): buying deducts the database price and adds the item,
+  selling returns half the price and removes it, with the party's 99-item and
+  gold caps enforced. A new `Game::Shop` owns the transaction rules
+  (affordability, stock, sellability) and tracks whether anything was traded,
+  which — exactly like the inn — selects the command's optional `[Transaction]` /
+  `[No Transaction]` handler branches (markers 20720 / 20721, closed by 20722).
+  `Game::Interpreter` records the request and suspends on a `:shop` wait;
+  `Scene::Map` drives the buy / sell menus and resumes it on leave. Buying and
+  selling are one unit per confirm for now (the quantity selector is a later
+  refinement). Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -127,7 +127,7 @@ The work below is roughly ordered by the critical path to a walkable game
   Change Actor
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
   Change Teleport / Escape Access, Set Teleport / Escape Target,
-  Change Encounter Rate, Change System BGM / SFX, Show Inn,
+  Change Encounter Rate, Change System BGM / SFX, Show Inn, Open Shop,
   Erase / Show Screen, Tint Screen, Flash Screen, Shake Screen, Pan Screen,
   Weather Effects, Call
   Event, Move Event, Change / Trade Event Location, Change Map Tileset, Proceed
@@ -206,7 +206,14 @@ The work below is roughly ordered by the critical path to a walkable game
   `[No Stay]` handler branches (structured and skipped like Show Choices).
   `Game::Interpreter` owns the gameplay and suspends on an `:inn` wait that
   `Scene::Map` drives; the inn fade and jingle are presentation still to come.
-  The remaining commands (battles, shop, EXP gain / level-up
+  **Open Shop** (10720) is a playable game-mode too: a `Game::Shop` holds the
+  goods and buy / sell rules and performs the transactions (buy at the database
+  price, sell at half, party 99-item / gold caps enforced), tracking whether
+  anything was traded to pick the command's `[Transaction]` / `[No Transaction]`
+  branches. The interpreter suspends on a `:shop` wait; `Scene::Map` drives the
+  buy / sell menus (one unit per confirm — the quantity selector is a later
+  refinement).
+  The remaining commands (battles, EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2141,6 +2141,75 @@ module Game
 
   # The overall running-game state: who is in the party and where they are,
   # plus the global switches and variables.
+  # An open shop (Open Shop, 10720). Holds the goods on offer and the buy / sell
+  # rules, and performs the transactions against the party's gold and inventory.
+  # RPG2000 buys at the item's database price and sells at half of it; the party
+  # caps items at 99 and gold at 999999 (Party enforces both). `did_transaction`
+  # records whether anything was actually bought or sold, which decides the
+  # event's [Transaction] / [No Transaction] branch. The scene drives the UI and
+  # calls #buy / #sell one unit at a time.
+  class Shop
+    attr_reader :goods, :did_transaction
+
+    def initialize(db, party, goods, allow_buy, allow_sell)
+      @db = db
+      @party = party
+      @goods = (goods || []).select { |id| id && id > 0 }
+      @allow_buy = allow_buy
+      @allow_sell = allow_sell
+      @did_transaction = false
+    end
+
+    def allow_buy?;  @allow_buy;  end
+    def allow_sell?; @allow_sell; end
+
+    # Database price of item `id` (0 when the item is missing or free).
+    def price(id)
+      it = @db.item[id]
+      it ? (it.price || 0) : 0
+    end
+
+    # Display name of item `id` ('' when missing).
+    def name(id)
+      it = @db.item[id]
+      it ? it.name.to_s : ''
+    end
+
+    # Half the database price — what a sale returns (RPG2000 rounds down).
+    def sell_price(id); price(id) / 2; end
+
+    # Whether item `id` can be sold: the party owns at least one and it has a
+    # non-zero price (RPG2000 marks price-0 / key items as unsellable).
+    def sellable?(id); price(id) > 0 && @party.item_count(id) > 0; end
+
+    # The party's sellable items, id-ordered, for the sell list.
+    def sellable_items
+      @party.items.keys.select { |id| sellable?(id) }.sort
+    end
+
+    # Buy one unit of `id`: must be stocked, buying allowed, affordable and not
+    # already capped at 99. Returns whether the purchase happened.
+    def buy(id)
+      return false unless @allow_buy && @goods.include?(id)
+      cost = price(id)
+      return false if @party.gold < cost || @party.item_count(id) >= 99
+      @party.gain_gold(-cost)
+      @party.gain_item(id, 1)
+      @did_transaction = true
+      true
+    end
+
+    # Sell one unit of `id` at half price: must be allowed and sellable. Returns
+    # whether the sale happened.
+    def sell(id)
+      return false unless @allow_sell && sellable?(id)
+      @party.gain_gold(sell_price(id))
+      @party.gain_item(id, -1)
+      @did_transaction = true
+      true
+    end
+  end
+
   # Map weather set by the Weather Effects (11070) event command: a type (0 none,
   # 1 rain, 2 snow; the RPG2003 additions store as higher values) and a strength
   # (0 weak .. 2 strong). Like the picture / tint overlays this is the Ruby-half

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -38,6 +38,10 @@ module Game
       CHANGE_ACTOR_SPRITE = 10630
       CHANGE_SYSTEM_BGM   = 10660
       CHANGE_SYSTEM_SFX   = 10670
+      OPEN_SHOP           = 10720
+      SHOP_TRANSACTION    = 20720
+      SHOP_NO_TRANSACTION = 20721
+      SHOP_END            = 20722
       SHOW_INN         = 10730
       INN_STAY         = 20730
       INN_NO_STAY      = 20731
@@ -129,7 +133,8 @@ module Game
     def running?; @running; end
     def waiting?; @waiting; end
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
-                :teleport, :input_digits, :key_input_request, :inn_request
+                :teleport, :input_digits, :key_input_request, :inn_request,
+                :shop_request
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
@@ -327,6 +332,36 @@ module Game
       nil
     end
 
+    # Resume an Open Shop request once the player leaves the shop. `transacted`
+    # is whether anything was actually bought or sold — the buying and selling
+    # (gold and inventory changes) happen in the shop scene, mirroring RPG_RT.
+    # When the event carries [Transaction] / [No Transaction] handler branches,
+    # jump into the matching one; otherwise execution simply continues.
+    def resume_shop(transacted)
+      if @shop_has_handlers
+        target = find_shop_option(transacted)
+        @index = target if target
+      end
+      reset_waits
+    end
+
+    # Locate the [Transaction] (SHOP_TRANSACTION) or [No Transaction]
+    # (SHOP_NO_TRANSACTION) handler branch for the pending shop, returning the
+    # index just after its marker. Falls back to SHOP_END and to nil once the
+    # shop's own indent level is left — the same structure as the inn branches.
+    def find_shop_option(transacted)
+      want = transacted ? Cmd::SHOP_TRANSACTION : Cmd::SHOP_NO_TRANSACTION
+      i = @index
+      while i < @list.size
+        c = @list[i]
+        return i + 1 if c.indent == @shop_indent && c.code == want
+        return i if c.indent == @shop_indent && c.code == Cmd::SHOP_END
+        return nil if c.indent < @shop_indent
+        i += 1
+      end
+      nil
+    end
+
     # RPG2000 key-input result codes in priority order (highest first). When more
     # than one accepted button is active RPG_RT returns the largest code:
     # Shift > Cancel > Decision > Up > Right > Left > Down.
@@ -359,6 +394,7 @@ module Game
       @teleport = nil
       @key_input_request = nil
       @inn_request = nil
+      @shop_request = nil
     end
 
     def switches;  @state.switches;  end
@@ -375,6 +411,10 @@ module Game
       when Cmd::CHOICE_END       then nil
       when Cmd::INPUT_NUMBER     then do_input_number cmd
       when Cmd::KEY_INPUT_PROC   then do_key_input cmd
+      when Cmd::OPEN_SHOP        then do_open_shop cmd
+      when Cmd::SHOP_TRANSACTION    then skip_to([Cmd::SHOP_END], cmd.indent); consume
+      when Cmd::SHOP_NO_TRANSACTION then skip_to([Cmd::SHOP_END], cmd.indent); consume
+      when Cmd::SHOP_END         then nil
       when Cmd::SHOW_INN         then do_show_inn cmd
       when Cmd::INN_STAY         then skip_to([Cmd::INN_END], cmd.indent); consume
       when Cmd::INN_NO_STAY      then skip_to([Cmd::INN_END], cmd.indent); consume
@@ -672,6 +712,29 @@ module Game
       @inn_request = { type: cmd.param(0), price: price,
                        can_afford: party.gold >= price, prompt: price > 0 }
       @wait_kind = :inn
+      @waiting = true
+    end
+
+    # Open Shop (10720): enter a shop selling the goods listed from param4 on.
+    # param0 is the mode (0 buy + sell, 1 buy only, 2 sell only); param1 the
+    # shop-screen style (recorded for fidelity). Like the inn, the command may be
+    # followed by [Transaction] / [No Transaction] handler branches (markers
+    # SHOP_TRANSACTION / SHOP_NO_TRANSACTION, closed by SHOP_END) that run on
+    # whether the player bought or sold anything. The interpreter records the
+    # request and suspends on a :shop wait; the scene runs the buy / sell UI
+    # (where the gold and inventory changes happen) and resumes via resume_shop.
+    def do_open_shop(cmd)
+      mode = cmd.param(0)
+      @shop_indent = cmd.indent
+      nxt = @list[@index]
+      @shop_has_handlers =
+        !nxt.nil? && nxt.code == Cmd::SHOP_TRANSACTION && nxt.indent == cmd.indent
+      @shop_request = {
+        mode: mode, allow_buy: mode == 0 || mode == 1,
+        allow_sell: mode == 0 || mode == 2, type: cmd.param(1),
+        goods: cmd.parameters[4..-1] || []
+      }
+      @wait_kind = :shop
       @waiting = true
     end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -388,6 +388,7 @@ class RPG2k
         build_parallels
         @message = nil
         @inn_window = nil
+        @shop = nil
         @wait_timer = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
@@ -419,6 +420,7 @@ class RPG2k
       def dispose
         close_message
         close_inn_window
+        close_shop
         [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
          @picture_sprite].each do |s|
           s.dispose if s
@@ -1294,6 +1296,7 @@ class RPG2k
           when :number then open_number_input(@interpreter.input_digits)
           when :key_input then drive_key_input
           when :inn then drive_inn
+          when :shop then drive_shop
           when :wait then drive_wait
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
@@ -1462,6 +1465,161 @@ class RPG2k
         @inn_window[:window].dispose
         @inn_window[:gold].dispose if @inn_window[:gold]
         @inn_window = nil
+      end
+
+      # -- Open Shop (buy / sell) ---------------------------------------------
+
+      SHOP_LINE_H = 14
+
+      # Drive an Open Shop wait. On the first frame the shop opens (a command
+      # menu for a buy+sell shop, or straight to the buy / sell list for a
+      # single-mode shop). Buying and selling happen one unit per confirm on
+      # Game::Shop; leaving resumes the interpreter with whether anything was
+      # traded (which picks the [Transaction] / [No Transaction] branch).
+      def drive_shop
+        req = @interpreter.shop_request
+        return @interpreter.resume_shop(false) unless req
+        if @shop.nil?
+          open_shop(req) # opened this frame; take input from the next one
+          return
+        end
+        @shop[:screen] == :command ? drive_shop_command : drive_shop_list
+      end
+
+      def open_shop(req)
+        model = Game::Shop.new(db, @state.party, req[:goods],
+                               req[:allow_buy], req[:allow_sell])
+        has_menu = req[:allow_buy] && req[:allow_sell]
+        screen = has_menu ? :command : (req[:allow_buy] ? :buy : :sell)
+        @shop = { model: model, has_menu: has_menu, screen: screen, index: 0,
+                  window: nil, gold: build_shop_gold_window }
+        draw_shop
+      end
+
+      def shop_gold_term; nonblank(db.term.gold, 'G'); end
+
+      def build_shop_gold_window
+        gw = 88
+        win = Window.new(SCREEN_W - gw - 6, 6, gw, SHOP_LINE_H + Window::BORDER * 2)
+        win.z = 300
+        win.windowskin = @windowskin
+        win
+      end
+
+      # The [label, target] rows for the current shop screen: the command menu's
+      # actions, the goods on the buy list, or the party's sellable items.
+      def shop_lines
+        m = @shop[:model]
+        case @shop[:screen]
+        when :command
+          rows = []
+          rows << ['Buy', :buy] if m.allow_buy?
+          rows << ['Sell', :sell] if m.allow_sell?
+          rows << ['Leave', :leave]
+          rows
+        when :buy
+          m.goods.map { |id| ["#{m.name(id)}  #{m.price(id)}#{shop_gold_term}", id] }
+        else # :sell
+          m.sellable_items.map do |id|
+            ["#{m.name(id)} x#{@state.party.item_count(id)}  " \
+             "#{m.sell_price(id)}#{shop_gold_term}", id]
+          end
+        end
+      end
+
+      def draw_shop
+        lines = shop_lines
+        @shop[:index] = Game.clamp(@shop[:index], 0, [lines.length - 1, 0].max)
+        inner_w = SCREEN_W - 20 - Window::BORDER * 2
+        inner_h = [lines.length, 1].max * SHOP_LINE_H
+        @shop[:window].dispose if @shop[:window]
+        win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
+                         SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        win.z = 300
+        win.windowskin = @windowskin
+        c = Bitmap.new(inner_w, inner_h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        lines.each_with_index do |(label, _), i|
+          c.draw_text 0, i * SHOP_LINE_H, inner_w, SHOP_LINE_H, label
+        end
+        win.contents = c
+        unless lines.empty?
+          win.cursor_rect =
+            Rect.new(0, @shop[:index] * SHOP_LINE_H, inner_w, SHOP_LINE_H)
+        end
+        @shop[:window] = win
+        draw_shop_gold
+      end
+
+      def draw_shop_gold
+        gw = 88
+        c = Bitmap.new(gw - Window::BORDER * 2, SHOP_LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, c.width, SHOP_LINE_H,
+                    "#{@state.party.gold}#{shop_gold_term}"
+        @shop[:gold].contents = c
+      end
+
+      def drive_shop_command
+        lines = shop_lines
+        if shop_move_cursor(lines)
+          # cursor moved
+        elsif Input.trigger?(Input::C)
+          case lines[@shop[:index]][1]
+          when :buy  then shop_switch(:buy)
+          when :sell then shop_switch(:sell)
+          when :leave then leave_shop
+          end
+        elsif Input.trigger?(Input::B)
+          leave_shop
+        end
+      end
+
+      def drive_shop_list
+        lines = shop_lines
+        if shop_move_cursor(lines)
+          # cursor moved
+        elsif Input.trigger?(Input::C) && !lines.empty?
+          id = lines[@shop[:index]][1]
+          @shop[:screen] == :buy ? @shop[:model].buy(id) : @shop[:model].sell(id)
+          draw_shop # refresh gold and, after a sale, the (shrunk) list
+        elsif Input.trigger?(Input::B)
+          @shop[:has_menu] ? shop_switch(:command) : leave_shop
+        end
+      end
+
+      # Move the shop cursor with Up / Down; returns true if it moved.
+      def shop_move_cursor(lines)
+        if Input.trigger?(Input::DOWN) && @shop[:index] < lines.length - 1
+          @shop[:index] += 1
+          draw_shop
+          true
+        elsif Input.trigger?(Input::UP) && @shop[:index] > 0
+          @shop[:index] -= 1
+          draw_shop
+          true
+        else
+          false
+        end
+      end
+
+      def shop_switch(screen)
+        @shop[:screen] = screen
+        @shop[:index] = 0
+        draw_shop
+      end
+
+      def leave_shop
+        transacted = @shop[:model].did_transaction
+        close_shop
+        @interpreter.resume_shop(transacted)
+      end
+
+      def close_shop
+        return unless @shop
+        @shop[:window].dispose if @shop[:window]
+        @shop[:gold].dispose if @shop[:gold]
+        @shop = nil
       end
 
       def drive_wait

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1249,11 +1249,12 @@ FakeActorSystem = Struct.new(:party)
 # the medicine recovery/scope fields Game::Party#use_item reads.
 FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :max_hp_points, :max_sp_points, :type, :name, :scope,
-                      :recover_hp, :recover_hp_rate, :recover_sp, :recover_sp_rate)
+                      :recover_hp, :recover_hp_rate, :recover_sp, :recover_sp_rate,
+                      :price)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
-              scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0)
+              scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
-               rhp, rhp_rate, rsp, rsp_rate)
+               rhp, rhp_rate, rsp, rsp_rate, price)
 end
 class FakeActorDB
   attr_reader :player, :system, :item
@@ -2584,6 +2585,120 @@ check 'Show Inn: Stay / No Stay handler branches route on the outcome' do
   ok !st2.switches[1], 'the Stay branch was skipped'
   eq true, st2.switches[2], 'the No Stay branch ran'
   eq true, st2.switches[3], 'execution continued past the inn'
+end
+
+# -- Open Shop ----------------------------------------------------------------
+
+# A shop over a party with `gold` gold and the given goods (id => price). Item
+# names are irrelevant to the logic, so they are left blank.
+def shop_setup(gold, goods, allow_buy: true, allow_sell: true)
+  items = {}
+  goods.each { |id, price| items[id] = fake_item(name: "i#{id}", price: price) }
+  db = FakeActorDB.new(
+    { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                             atk: 10, def: 8) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.gain_gold(gold)
+  shop = Game::Shop.new(db, st.party, goods.keys, allow_buy, allow_sell)
+  [st, shop]
+end
+
+check 'Shop buy deducts gold, adds the item, and records a transaction' do
+  st, shop = shop_setup(500, { 3 => 100 })
+  ok shop.buy(3), 'the purchase succeeds'
+  eq 400, st.party.gold, 'price deducted'
+  eq 1, st.party.item_count(3), 'item added'
+  ok shop.did_transaction
+end
+
+check 'Shop buy refuses when unaffordable, unstocked, capped, or sell-only' do
+  st, shop = shop_setup(50, { 3 => 100 })
+  ok !shop.buy(3), 'cannot afford 100 with 50'
+  eq 50, st.party.gold
+  ok !shop.buy(7), 'item 7 is not stocked'
+  ok !shop.did_transaction, 'no failed purchase counts as a transaction'
+  # capped at 99
+  st2, shop2 = shop_setup(999_999, { 3 => 1 })
+  st2.party.gain_item(3, 99)
+  ok !shop2.buy(3), 'cannot exceed 99 of an item'
+  # sell-only shop refuses buys
+  _st3, shop3 = shop_setup(500, { 3 => 100 }, allow_buy: false, allow_sell: true)
+  ok !shop3.buy(3)
+end
+
+check 'Shop sell adds half price, removes the item, records a transaction' do
+  st, shop = shop_setup(0, { 3 => 100 })
+  st.party.gain_item(3, 2)
+  ok shop.sell(3), 'the sale succeeds'
+  eq 50, st.party.gold, 'half of 100'
+  eq 1, st.party.item_count(3), 'one removed'
+  ok shop.did_transaction
+end
+
+check 'Shop sell refuses unowned, price-0 (key), or in a buy-only shop' do
+  st, shop = shop_setup(0, { 3 => 100 })
+  ok !shop.sell(3), 'nothing owned to sell'
+  # a price-0 item is unsellable even when held
+  st2, shop2 = shop_setup(0, { 4 => 0 })
+  st2.party.gain_item(4, 1)
+  ok !shop2.sell(4), 'key / price-0 items cannot be sold'
+  # buy-only shop refuses sells
+  st3, shop3 = shop_setup(0, { 3 => 100 }, allow_buy: true, allow_sell: false)
+  st3.party.gain_item(3, 1)
+  ok !shop3.sell(3)
+end
+
+check 'Shop sellable_items lists only held, priced goods in id order' do
+  st, shop = shop_setup(0, { 3 => 100, 5 => 40, 8 => 0 })
+  st.party.gain_item(8, 1) # price 0 -> not sellable
+  st.party.gain_item(5, 2)
+  st.party.gain_item(3, 1)
+  eq [3, 5], shop.sellable_items
+end
+
+check 'Open Shop parses the mode and goods and suspends on :shop' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # mode 1 (buy only), type 0, param2 handlers flag, param3 unused, goods 3/5/7.
+  it.start([FakeCmd.new(IC::OPEN_SHOP, [1, 0, 0, 0, 3, 5, 7])])
+  it.update
+  ok it.waiting?, 'Open Shop suspends the interpreter'
+  eq :shop, it.wait_kind
+  req = it.shop_request
+  eq true, req[:allow_buy]
+  eq false, req[:allow_sell], 'mode 1 is buy-only'
+  eq [3, 5, 7], req[:goods]
+end
+
+check 'Open Shop routes Transaction / No Transaction handler branches' do
+  list = [
+    FakeCmd.new(IC::OPEN_SHOP, [0, 0, 0, 0, 3], indent: 0),
+    FakeCmd.new(IC::SHOP_TRANSACTION, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    FakeCmd.new(IC::SHOP_NO_TRANSACTION, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    FakeCmd.new(IC::SHOP_END, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0], indent: 0)
+  ]
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start(list)
+  it.update
+  it.resume_shop(true) # bought something
+  it.update
+  eq true, st.switches[1], 'the Transaction branch ran'
+  ok !st.switches[2], 'the No Transaction branch was skipped'
+  eq true, st.switches[3], 'execution continued past the shop'
+  # And the no-transaction path on a fresh run.
+  st2 = party_state
+  it2 = Game::Interpreter.new(st2)
+  it2.start(list)
+  it2.update
+  it2.resume_shop(false)
+  it2.update
+  ok !st2.switches[1]
+  eq true, st2.switches[2], 'the No Transaction branch ran'
+  eq true, st2.switches[3]
 end
 
 # -- summary ------------------------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -149,6 +149,9 @@ def fake_db(common = nil)
     # Terms the Show Inn window reads; blank greeting fields exercise the
     # scene's English fallbacks.
     term: OpenStruct.new(gold: 'G'),
+    # A tiny item table the Open Shop window prices its goods from.
+    item: { 3 => OpenStruct.new(name: 'Potion', price: 100),
+            5 => OpenStruct.new(name: 'Herb', price: 40) },
     common_event: common,
     player: {}
   )
@@ -391,6 +394,22 @@ class InnStubParty
   attr_accessor :leader
   def initialize(gold); @gold = gold; @actors = [InnStubActor.new('Hero')]; @leader = nil; end
   def gain_gold(n); @gold += n; end
+end
+
+# A party the shop can charge and stock: gold plus an item-count bag, with the
+# leader Scene::Map reads while rendering.
+class ShopStubParty
+  attr_reader :actors, :gold, :items
+  attr_accessor :leader
+  def initialize(gold); @gold = gold; @items = {}; @actors = []; @leader = nil; end
+  def gain_gold(n); @gold += n; @gold = 0 if @gold < 0; end
+  def item_count(id); @items[id] || 0; end
+  def gain_item(id, n = 1)
+    c = item_count(id) + n
+    c = 0 if c < 0
+    c = 99 if c > 99
+    @items[id] = c
+  end
 end
 
 # Build an auto-start event running `commands`, with a stub party holding `gold`.
@@ -1165,6 +1184,58 @@ check 'Erase Screen pauses the event until the fade settles, then continues' do
   eq 255, st.screen.fade_level, 'the screen is fully erased'
   ok st.screen.erased?, 'held erased'
   ok st.switches[5], 'the event resumed after the fade settled'
+end
+
+check 'Open Shop scene: buying then leaving runs the Transaction branch' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3, 5], indent: 0), # buy-only, goods 3/5
+    ECmd.new(ic::SHOP_TRANSACTION, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::SHOP_NO_TRANSACTION, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::SHOP_END, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the shop opens straight to the buy list (buy-only)
+  ok !st.switches[1] && !st.switches[2], 'still shopping'
+  RGSS::Input.triggered = [RGSS::Input::C] # buy the first good (id 3 @ 100)
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  eq 400, st.party.gold, 'one Potion bought'
+  eq 1, st.party.item_count(3)
+  RGSS::Input.triggered = [RGSS::Input::B] # leave the shop
+  scene.update
+  scene.update # the Transaction branch runs
+  ok st.switches[1], 'the Transaction branch ran (a purchase happened)'
+  ok !st.switches[2], 'the No Transaction branch was skipped'
+end
+
+check 'Open Shop scene: leaving without buying runs the No Transaction branch' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3], indent: 0),
+    ECmd.new(ic::SHOP_TRANSACTION, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::SHOP_NO_TRANSACTION, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::SHOP_END, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update }
+  RGSS::Input.triggered = [RGSS::Input::B] # leave immediately
+  scene.update
+  scene.update
+  eq 500, st.party.gold, 'no gold spent'
+  ok !st.switches[1], 'the Transaction branch was skipped'
+  ok st.switches[2], 'the No Transaction branch ran'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
Adds the shop game-mode to the RPG2000 event-command interpreter, verified against liblcf / EasyRPG.

## Open Shop (10720)

Opens a shop over the goods the command lists, in a **buy+sell**, **buy-only** or **sell-only** screen per its mode (`param0`; `param1` is the shop style, goods are the item ids from `param4` on).

A new **`Game::Shop`** owns the transaction rules:
- **Buy** deducts the database price and adds the item; refused when unaffordable, unstocked, capped at 99, or in a sell-only shop.
- **Sell** returns half the price and removes the item; refused for unowned items, price-0 / key items, or in a buy-only shop.
- The party's 99-item and 999999-gold caps are enforced (via `Party`).
- It tracks whether anything was traded, which — exactly like the inn — selects the command's optional `[Transaction]` / `[No Transaction]` handler branches (markers 20720 / 20721, closed by 20722), laid out and skipped like a Show Choices block.

`Game::Interpreter` records the request and suspends on a `:shop` wait; `Scene::Map` drives the buy / sell menus (a command menu for a buy+sell shop, straight to the list for a single-mode one) and resumes the interpreter on leave with the traded flag. Buying and selling are one unit per confirm for now — the quantity selector is a later refinement.

## Testing

- `scripts/rpg2k_logic_check.rb` — **182 pass** (new: buy/sell success + every refusal case, `sellable_items` filtering, Open Shop param parsing, Transaction / No Transaction branch routing)
- `scripts/rpg2k_scene_check.rb` — **61 pass** (new: buy-then-leave runs the Transaction branch and moves gold/inventory; leave-without-buying runs No Transaction)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_