### PR TITLE
mruby-rgss: render RGSS::Sprite#opacity natively

### DIFF
--- a/changelog.d/rpgxp-rgss-sprite-opacity-native.added.md
+++ b/changelog.d/rpgxp-rgss-sprite-opacity-native.added.md
@@ -1,0 +1,7 @@
+- **`RGSS::Sprite#opacity` is now rendered.** `Sprite#opacity=` is native: it sets
+  the sprite canvas's LVGL object opacity (`mruby-rgss/src/lib.cxx`), so the
+  compositor multiplies the bitmap's alpha by it and `sprite.opacity = n` fades
+  actually fade instead of being stored-but-ignored. First of the native
+  Sprite-compositing render passes; zoom/angle/mirror (LVGL image transforms) and
+  tone/color/src_rect (software pre-composite) follow. See
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -37,17 +37,24 @@ These are complete enough for the stock scripts:
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
-### 1. `Sprite` extended properties ⚠️ (stored; render pending)
+### 1. `Sprite` extended properties ⚠️ (opacity rendered; rest stored)
 
 `mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,
-`visible`/`visible=`, `dispose`, `update`, and now **stores** the extra
-properties the stock scripts set — `opacity` (~18), `ox`/`oy`, `zoom_x`/`zoom_y`
-(~3 each), `angle`, `mirror`, `tone`, `color`, `blend_type`, `bush_depth` (~2),
-`src_rect` and `flash` — with RGSS defaults (`mruby-rgss/mrblib/lib.rb`), so a
-script's `sprite.opacity = n` no longer raises. **Remaining:** the native
-renderer does not yet honour them visually (opacity/zoom/tone/mirror compositing
-in the draw path). `Sprite_Character`, `Sprite_Battler`, `Arrow_Base`, weather
-and the animation player depend on these.
+`visible`/`visible=`, `dispose`, `update`, and stores the extra properties the
+stock scripts set — `opacity` (~18), `ox`/`oy`, `zoom_x`/`zoom_y` (~3 each),
+`angle`, `mirror`, `tone`, `color`, `blend_type`, `bush_depth` (~2), `src_rect`
+and `flash` — with RGSS defaults (`mruby-rgss/mrblib/lib.rb`).
+
+**`opacity` is now rendered natively:** `Sprite#opacity=` sets the sprite
+canvas's LVGL object opacity (`src/lib.cxx`), so the compositor multiplies the
+bitmap's alpha by it — fades (`sprite.opacity = n`) now actually fade. Since a
+Sprite's native handle is an `lv_canvas` (an LVGL image subclass), the remaining
+transforms map to LVGL image styles too: **zoom_x/zoom_y** →
+`transform_scale_x/y`, **angle** → `transform_rotation`, **mirror** → negative
+scale; **tone/color/src_rect/bush_depth** need a software pre-composite through
+the existing `bmp_blt`/`bmp_stretch_blt` blend loops. Those are the next slices.
+`Sprite_Character`, `Sprite_Battler`, `Arrow_Base`, weather and the animation
+player depend on these.
 
 ### 2. `Window` ⚠️ (stored; native frame/cursor render pending)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -129,13 +129,15 @@ module RGSS
 
     # RGSS Sprite properties the stock scripts set — opacity fades, zoom, angle,
     # tone/colour, scroll origin, mirror, bush depth, blend mode, source rect.
-    # mruby-rgss stores them so `sprite.opacity = n` / `sprite.zoom_x` no longer
-    # raise; the native renderer does not yet honour them visually (tracked in
-    # docs/rpgxp-rgss-api-gap.md). Readers fall back to RGSS's defaults because
+    # `opacity=` is now honoured natively (src/lib.cxx sets the sprite canvas's
+    # LVGL object opacity); it still stores @opacity here so the reader below
+    # returns the set value. The rest are stored so `sprite.zoom_x = n` no longer
+    # raises, but the native renderer does not yet honour them visually (tracked
+    # in docs/rpgxp-rgss-api-gap.md). Readers fall back to RGSS's defaults because
     # the native #initialize does not set these ivars (and cannot be wrapped from
     # here without replacing it). `nil?` checks — not `||` — where 0/false is a
     # meaningful value (opacity 0 = transparent).
-    attr_writer :opacity, :ox, :oy, :zoom_x, :zoom_y, :angle, :mirror,
+    attr_writer :ox, :oy, :zoom_x, :zoom_y, :angle, :mirror,
                 :bush_depth, :blend_type, :tone, :color, :src_rect
 
     def opacity

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2202,6 +2202,26 @@ mrb_value spr_set_bmp(mrb_state* M, mrb_value self) {
   return bmp;
 }
 
+// RGSS Sprite#opacity= (0..255). The Sprite's native handle is an lv_canvas,
+// which LVGL composites; the object-level style opacity multiplies the bitmap's
+// own alpha at blit time, which is exactly RGSS's per-sprite opacity. The value
+// is clamped and mirrored into @opacity so the Ruby reader (defaulting to 255)
+// returns what was set. A fresh sprite needs no explicit call: LVGL's default
+// object opacity is fully opaque, matching RGSS's 255 default.
+mrb_value spr_set_opacity(mrb_state* M, mrb_value self) {
+  mrb_int opa;
+  mrb_get_args(M, "i", &opa);
+  if (opa < 0)
+    opa = 0;
+  else if (opa > 255)
+    opa = 255;
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  lv_obj_set_style_opa(obj, static_cast<lv_opa_t>(opa), 0);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@opacity"), mrb_fixnum_value(opa));
+  return self;
+}
+
 mrb_value obj_set_x(mrb_state* M, mrb_value self) {
   mrb_int x;
   mrb_get_args(M, "i", &x);
@@ -2606,6 +2626,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "z=", obj_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, spr, "visible=", obj_set_visible, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "opacity=", spr_set_opacity, MRB_ARGS_REQ(1));
 
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -161,7 +161,10 @@ assert "RGSS::Viewport API surface" do
 end
 
 assert "RGSS::Sprite API surface" do
-  %i[bitmap= x= y= z= visible visible= dispose disposed?].each do |m|
+  # opacity= is native (honoured by the LVGL compositor, src/lib.cxx); the rest
+  # are native too. Sprite.new needs a live display, so this only asserts the
+  # method surface — the compositing itself is exercised by the game runs.
+  %i[bitmap= x= y= z= visible visible= opacity= dispose disposed?].each do |m|
     assert_true RGSS::Sprite.method_defined?(m), "Sprite##{m} missing"
   end
 end


### PR DESCRIPTION
## Summary

First of the **native render passes** for the RGSS class library (follow-up to the property holders — Sprite props #189, Window #199, Tilemap #203). Those slices made the stock scripts *run* without raising; this one makes a stored property actually *render*.

`Sprite#opacity` was held in a Ruby ivar but ignored by the renderer, so `sprite.opacity = n` fades did nothing visually.

## Change

- **`mruby-rgss/src/lib.cxx`** — make `Sprite#opacity=` native. A Sprite's native handle is an `lv_canvas`, which LVGL composites, so the setter clamps to `0..255` and calls `lv_obj_set_style_opa` on the canvas object — LVGL then multiplies the bitmap's alpha by it at blit time, which is exactly RGSS's per-sprite opacity. The value is mirrored into `@opacity` so the existing Ruby reader still returns it.
- **`mruby-rgss/mrblib/lib.rb`** — drop `:opacity` from the `attr_writer` list (the native setter replaces it; the `def opacity` reader stays). A fresh sprite needs no call: LVGL's default object opacity is fully opaque, matching RGSS's `255` default.

## Why this slice first

The map of the backend (it's **LVGL**, a retained-mode scene graph — each Sprite *is* a canvas, LVGL does the compositing) showed Sprite compositing reuses the most existing infrastructure: the canvas, the z-order list, and the dirty-invalidate loop already exist. `opacity` is the highest-value single property (~18 uses — every fade) and maps to one clean LVGL call with no transform-buffer concerns.

Because a Sprite's canvas is an **LVGL image subclass**, the remaining transforms map to LVGL image styles too and are the natural next slices: `zoom_x/zoom_y` → `transform_scale_x/y`, `angle` → `transform_rotation`, `mirror` → negative scale; `tone`/`color`/`src_rect`/`bush_depth` need a software pre-composite through the existing `bmp_blt`/`bmp_stretch_blt` blend loops.

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0** — `lv_obj_set_style_opa(obj, lv_opa_t, selector)` is the confirmed v9 style API, and `lv_canvas` has `.base_class = &lv_image_class` so object opacity applies.
- **`mruby-rgss/test`** — `Sprite.new` needs a live display the headless `mrbtest` binary lacks, so the Sprite surface test now also asserts `opacity=` is defined (a canary that the native method is registered).
- **Honest limitation:** no current game (RPG2000/MV) calls `sprite.opacity=` — RPG2000's picture opacity is still a Ruby overlay ("a later native refinement", `mruby-rpg2k/mrblib/game.rb`) — so this primitive is compile-verified but not yet exercised by the headless game runs. The visible payoff arrives when the RGSS script host boots an XP game (fades everywhere), or when RPG2000's picture opacity is wired to this native primitive (a natural follow-up).

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #1 (`Sprite`) now notes opacity is rendered natively and lays out the remaining transform/composite slices.
- Changelog fragment `changelog.d/rpgxp-rgss-sprite-opacity-native.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_