### PR TITLE
Support skill-book items in the RPG2000 item menu

### DIFF
--- a/changelog.d/rpg2k-item-skill-books.added.md
+++ b/changelog.d/rpg2k-item-skill-books.added.md
@@ -1,0 +1,10 @@
+- RPG Maker 2000 item menu: **skill books** (database item type 7) are now usable
+  alongside medicines. Choosing a book prompts for an ally, and — if that ally
+  does not already know it — teaches the skill in the book's `skill_id` field
+  (53) and consumes one book; a book used on someone who already knows the skill
+  is reported and consumed nothing. `Game::Party#use_item` now dispatches on the
+  item type (`use_medicine` / `use_skill_book`), and `field_usable?` /
+  `item_effective?` account for books, with three new checks in
+  `scripts/rpg2k_logic_check.rb`. `Scene::ItemMenu` routes books through the
+  existing single-target picker (only an all-ally medicine still skips it). Seed
+  (type 8, permanent stat boost) and switch (type 9) item use remain follow-ups.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -279,11 +279,14 @@ The work below is roughly ordered by the critical path to a walkable game
   command list. Save, End Game, **Item**, **Equip** and **Status** work; only
   **Skill** remains a placeholder (it shares the battle effect formula, so it is
   best built with / after the battle system). The **Item** command opens
-  `Scene::ItemMenu`: it lists the party's usable medicines (database item type 6)
-  with their held counts, applies a single-target item to a chosen ally or an
-  all-ally item (scope 1) to the whole party, restores HP/SP (flat + percentage
-  of max, clamped), consumes one on a use that had any effect, and greys out /
-  reports a use with no effect (a target already full). The **Equip** command
+  `Scene::ItemMenu`: it lists the party's usable **medicines** (database item type
+  6) and **skill books** (type 7) with their held counts. A medicine heals its
+  target — a single-target item a chosen ally, an all-ally item (scope 1) the
+  whole party — restoring HP/SP (flat + percentage of max, clamped); a skill book
+  teaches its skill (item field 53) to a chosen ally who does not already know it.
+  Either consumes one on a use that had any effect, and greys out / reports a use
+  with no effect (a full target, or an actor who already knows the skill). The
+  **Equip** command
   opens `Scene::EquipMenu`: it shows a party member's five equipment slots and
   stats (LEFT/RIGHT cycle members), and for a chosen slot lists the bag's fitting
   items (plus Remove); equipping swaps the previously-worn item back into the bag
@@ -294,9 +297,8 @@ The work below is roughly ordered by the critical path to a walkable game
   `use_item` for items; `equip_candidates` / `equip_from_bag` / `unequip_to_bag`
   for equip) and `Game::Actor` (`next_level_exp` / `exp_to_next` for status),
   covered by `scripts/rpg2k_logic_check.rb`; the RGSS windows are the
-  untestable-here UI. Book (7) / seed (8) / switch (9) item use, the item
-  usable-occasion gate, and two-handed / dual-wield equipping are later
-  refinements.
+  untestable-here UI. Seed (8) / switch (9) item use, the item usable-occasion
+  gate, and two-handed / dual-wield equipping are later refinements.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1236,11 +1236,11 @@ module Game
       @gold = 999_999 if @gold > 999_999
     end
 
-    # RPG2000 database item type for a consumable medicine (薬). Types 1..5 are
-    # the equipment slots (see Actor::EQUIP_ORDER); 6 is the healing item the
-    # field menu can use. Book (7) / seed (8) / switch (9) menu use is a later
-    # refinement.
+    # RPG2000 database item types. Types 1..5 are the equipment slots (see
+    # Actor::EQUIP_ORDER); 6 is a healing medicine (薬); 7 is a skill book (本)
+    # that teaches a skill. Seed (8) / switch (9) menu use is a later refinement.
     ITEM_MEDICINE = 6
+    ITEM_SKILL_BOOK = 7
 
     # The database row for a held item id, or nil when the database has no item
     # table (a bare test fixture) or no such row.
@@ -1249,11 +1249,12 @@ module Game
       @db.item[id]
     end
 
-    # Whether item `id` can be used from the field (main-menu) item screen.
-    # Currently: a medicine the party actually holds.
+    # Whether item `id` can be used from the field (main-menu) item screen: a
+    # medicine or a skill book the party actually holds.
     def field_usable?(id)
       it = db_item(id)
-      !it.nil? && it.type == ITEM_MEDICINE && item_count(id) > 0
+      return false unless it && item_count(id) > 0
+      it.type == ITEM_MEDICINE || it.type == ITEM_SKILL_BOOK
     end
 
     # The bag's field-usable items as `[id, count]` pairs in ascending id order,
@@ -1271,26 +1272,44 @@ module Game
       [hp, mp]
     end
 
-    # Whether using medicine `id` on `actor` would change anything -- RPG_RT
-    # forbids using a pure-recovery item on a target already at full HP/SP, so the
-    # menu greys those out. A restore of 0 (an item with no recovery) is never
-    # effective.
+    # Whether using item `id` on `actor` would change anything, so the menu can
+    # grey out a no-op. A medicine is effective when the target is below full
+    # HP/SP and it restores some (RPG_RT forbids using a pure-recovery item on a
+    # full target); a skill book is effective when the target does not already
+    # know its skill.
     def item_effective?(id, actor)
       it = db_item(id)
-      return false unless it && it.type == ITEM_MEDICINE && actor
-      hp, mp = item_recovery(it, actor)
-      (hp > 0 && actor.hp < actor.max_hp) || (mp > 0 && actor.mp < actor.max_mp)
+      return false unless it && actor
+      case it.type
+      when ITEM_MEDICINE
+        hp, mp = item_recovery(it, actor)
+        (hp > 0 && actor.hp < actor.max_hp) || (mp > 0 && actor.mp < actor.max_mp)
+      when ITEM_SKILL_BOOK
+        s = it.skill_id
+        !s.nil? && s != 0 && !actor.knows_skill?(s)
+      else
+        false
+      end
     end
 
-    # Use medicine `id`. A single-target item (scope 0) heals `actor`; an all-ally
-    # item (scope 1) heals the whole party regardless of `actor`. Applies the
-    # recovery (clamped to each target's maxima), consumes one from the bag only
-    # when it actually healed someone, and returns the actors it affected (empty
-    # when nothing changed, e.g. everyone was already full -- then nothing is
-    # consumed).
+    # Use item `id` from the field menu, dispatching on its database type, and
+    # return the actors it affected (empty when it did nothing -- then nothing is
+    # consumed). A medicine heals; a skill book teaches its skill.
     def use_item(id, actor = nil)
       it = db_item(id)
-      return [] unless it && it.type == ITEM_MEDICINE && item_count(id) > 0
+      return [] unless it && item_count(id) > 0
+      case it.type
+      when ITEM_MEDICINE then use_medicine(it, id, actor)
+      when ITEM_SKILL_BOOK then use_skill_book(it, id, actor)
+      else []
+      end
+    end
+
+    # A single-target medicine (scope 0) heals `actor`; an all-ally medicine
+    # (scope 1) heals the whole party regardless of `actor`. Applies the recovery
+    # (clamped to each target's maxima) and consumes one from the bag only when it
+    # actually healed someone (so using it on a full party wastes nothing).
+    def use_medicine(it, id, actor)
       targets = it.scope == 1 ? @actors : [actor].compact
       affected = []
       targets.each do |t|
@@ -1303,6 +1322,17 @@ module Game
       end
       lose_item(id, 1) unless affected.empty?
       affected
+    end
+
+    # A skill book teaches its skill (item field 53) to `actor` if the actor does
+    # not already know it, consuming one book. A book with no skill, or used on an
+    # actor who already knows the skill, does nothing and is not consumed.
+    def use_skill_book(it, id, actor)
+      skill = it.skill_id
+      return [] unless actor && skill && skill != 0 && !actor.knows_skill?(skill)
+      actor.learn_skill(skill)
+      lose_item(id, 1)
+      [actor]
     end
 
     # The equipment slot index (0..4) a held item occupies by its database type

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2445,8 +2445,10 @@ class RPG2k
         return if items.empty?
         id, = items[@item_index]
         it = @state.party.db_item(id)
-        if it && it.scope == 1
-          apply_item(id, nil)          # all-ally: no target prompt
+        # Only an all-ally medicine skips the target prompt; single-target
+        # medicines and skill books (always one actor) ask who to use it on.
+        if it && it.scope == 1 && it.type == Game::Party::ITEM_MEDICINE
+          apply_item(id, nil)
         else
           @pending_item = id
           @mode = :target

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1250,11 +1250,12 @@ FakeActorSystem = Struct.new(:party)
 FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :max_hp_points, :max_sp_points, :type, :name, :scope,
                       :recover_hp, :recover_hp_rate, :recover_sp, :recover_sp_rate,
-                      :price)
+                      :price, :skill_id)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
-              scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0)
+              scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
+              skill_id: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
-               rhp, rhp_rate, rsp, rsp_rate, price)
+               rhp, rhp_rate, rsp, rsp_rate, price, skill_id)
 end
 class FakeActorDB
   attr_reader :player, :system, :item
@@ -1643,6 +1644,36 @@ check 'use_item restores MP and item_effective? tracks the SP deficit' do
   st.party.use_item(6, hero)
   eq 25, hero.mp                               # 10 + 15
   eq 0, st.party.item_count(6)
+end
+
+check 'field_items includes skill books alongside medicines' do
+  items = { 5 => fake_item(type: 6, rhp: 10),       # medicine
+            8 => fake_item(type: 7, skill_id: 42),  # skill book
+            3 => fake_item(type: 1, atk: 5) }       # weapon (not usable)
+  st = item_party(items)
+  [5, 8, 3].each { |id| st.party.gain_item(id, 1) }
+  eq [[5, 1], [8, 1]], st.party.field_items
+end
+
+check 'a skill book teaches its skill to the target and is consumed' do
+  st = item_party({ 8 => fake_item(type: 7, skill_id: 42) })
+  st.party.gain_item(8, 2)
+  hero = st.party.leader
+  eq false, hero.knows_skill?(42)
+  eq true, st.party.item_effective?(8, hero)
+  eq [hero], st.party.use_item(8, hero)
+  eq true, hero.knows_skill?(42)
+  eq 1, st.party.item_count(8)                 # one book consumed
+end
+
+check 'a skill book on an actor who already knows the skill does nothing' do
+  st = item_party({ 8 => fake_item(type: 7, skill_id: 42) })
+  st.party.gain_item(8, 1)
+  hero = st.party.leader
+  hero.learn_skill(42)
+  eq false, st.party.item_effective?(8, hero)
+  eq [], st.party.use_item(8, hero)
+  eq 1, st.party.item_count(8)                 # not consumed
 end
 
 # -- Field equip menu (Game::Party bag-aware equip) --------------------------


### PR DESCRIPTION
The field item menu now uses **skill books** (database item type 7) in addition to medicines. (Extends the item menu from #198.)

## Behavior

- Skill books appear in the item list alongside medicines.
- Choosing a book prompts for an ally; if that ally does **not** already know the skill, it teaches the skill in the book's `skill_id` field (53) and consumes one book.
- A book used on someone who already knows the skill is reported and consumes nothing (greyed-out via `item_effective?`).

## Structure

`Game::Party#use_item` now dispatches on the item type (`use_medicine` / `use_skill_book`) instead of assuming medicine, and `field_usable?` / `item_effective?` account for books. `Scene::ItemMenu` routes books through the existing single-target picker — only an all-ally medicine still skips it. The skill teach/knows checks reuse the existing `Game::Actor#learn_skill` / `knows_skill?`.

## Tests

Three new checks in `scripts/rpg2k_logic_check.rb` (the host harness CI runs): a book listed alongside medicines (and a weapon excluded), teach-and-consume on an actor who doesn't know it, and the already-known no-op (not consumed). All 187 logic checks pass; the scene / render / save-load / testbed harnesses stay green.

## Follow-ups

Seed (type 8, permanent stat boost) and switch (type 9) item use; the Skill menu screen (shares the battle effect formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_