### PR TITLE
rpg2k: Enemy Encounter + runtime troop model (battle path, step 1)

### DIFF
--- a/changelog.d/rpg2k-enemy-encounter.added.md
+++ b/changelog.d/rpg2k-enemy-encounter.added.md
@@ -1,0 +1,15 @@
+- The **Enemy Encounter** (10710) event command is now handled, and the runtime
+  battle model it needs has landed: `Game::Enemy` instantiates a database enemy
+  (combat stats, EXP / gold, battle position, full starting HP / SP) and
+  `Game::Troop` instantiates an enemy group (敵グループ) into its live members and
+  totals the EXP / gold it is worth. The command decodes its parameters
+  (constant or variable troop id, escape mode — disallow / end-event / custom
+  handler — defeat mode, first-strike) and, like the inn and shop, routes the
+  optional `[Victory]` / `[Escape]` / `[Defeat]` handler branches (markers 20710 /
+  20711 / 20712, closed by 20713) on the outcome; the "end event processing"
+  escape mode abandons the rest of the event. `Game::Interpreter` suspends on a
+  `:battle` wait. The turn-based battle screen is not built yet, so `Scene::Map`
+  resolves an encounter as an **immediate victory** that grants the troop's EXP
+  (to every party member) and gold, then runs the Victory handler — a
+  placeholder until the real battle system lands. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -128,6 +128,7 @@ The work below is roughly ordered by the critical path to a walkable game
   Name / Title / Sprite, Set Transparent Flag, Change Main Menu / Save Access,
   Change Teleport / Escape Access, Set Teleport / Escape Target,
   Change Encounter Rate, Change System BGM / SFX, Show Inn, Open Shop,
+  Enemy Encounter,
   Erase / Show Screen, Tint Screen, Flash Screen, Shake Screen, Pan Screen,
   Show/Move/Erase Picture,
   Weather Effects, Call
@@ -214,7 +215,15 @@ The work below is roughly ordered by the critical path to a walkable game
   branches. The interpreter suspends on a `:shop` wait; `Scene::Map` drives the
   buy / sell menus (one unit per confirm — the quantity selector is a later
   refinement).
-  The remaining commands (battles, EXP gain / level-up
+  **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
+  instantiate a database enemy group into live members and total its EXP / gold,
+  and the command decodes its troop id, escape / defeat modes and first-strike
+  and routes the `[Victory]` / `[Escape]` / `[Defeat]` handler branches on the
+  outcome (the "end event processing" escape mode abandons the event). The
+  interpreter suspends on a `:battle` wait; the turn-based battle screen is not
+  built, so `Scene::Map` resolves an encounter as an immediate victory granting
+  the troop's EXP and gold — a placeholder until the battle system lands.
+  The remaining commands (the battle system proper, EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2227,6 +2227,63 @@ module Game
     end
   end
 
+  # A single enemy instantiated from the database (chunk 14) for a battle: its
+  # combat stats plus the EXP / gold it is worth and its battle-screen position.
+  # Current HP / SP start full. The turn-based battle that would reduce them is
+  # not built yet, so for now this backs the Enemy Encounter reward model.
+  class Enemy
+    attr_reader :id, :name, :max_hp, :max_sp, :atk, :def, :spi, :agi,
+                :exp, :gold, :x, :y, :hidden
+    attr_accessor :hp, :sp
+
+    def initialize(db, id, x = 0, y = 0, hidden = false)
+      row = db.enemy[id]
+      @id = id
+      @name    = row ? row.name.to_s : ''
+      @max_hp  = row ? row.max_hp : 1
+      @max_sp  = row ? row.max_sp : 0
+      @atk     = row ? row.attack : 0
+      @def     = row ? row.defense : 0
+      @spi     = row ? row.spirit : 0
+      @agi     = row ? row.agility : 0
+      @exp     = row ? row.exp : 0
+      @gold    = row ? row.gold : 0
+      @x = x
+      @y = y
+      @hidden = hidden ? true : false
+      @hp = @max_hp
+      @sp = @max_sp
+    end
+
+    def dead?; @hp <= 0; end
+  end
+
+  # An enemy troop (敵グループ, chunk 15) instantiated for a battle: the live
+  # Enemy members at their positions. Also totals the EXP / gold the troop is
+  # worth, which the Enemy Encounter command grants on victory. The battle
+  # simulation itself is still to come.
+  class Troop
+    attr_reader :id, :name, :members
+
+    def initialize(db, id)
+      row = db.enemy_group[id]
+      @id = id
+      @name = row ? row.name.to_s : ''
+      @members = []
+      # Array2D#each yields (id, entry); a plain Hash test double does the same.
+      row.members.each { |_, m| @members << member(db, m) } if row && row.members
+    end
+
+    def total_exp;  @members.reduce(0) { |s, e| s + e.exp } end
+    def total_gold; @members.reduce(0) { |s, e| s + e.gold } end
+
+    private
+
+    def member(db, m)
+      Enemy.new(db, m.enemy_id, m.x, m.y, m.invisible)
+    end
+  end
+
   # Map weather set by the Weather Effects (11070) event command: a type (0 none,
   # 1 rain, 2 snow; the RPG2003 additions store as higher values) and a strength
   # (0 weak .. 2 strong). Like the picture / tint overlays this is the Ruby-half

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -38,6 +38,11 @@ module Game
       CHANGE_ACTOR_SPRITE = 10630
       CHANGE_SYSTEM_BGM   = 10660
       CHANGE_SYSTEM_SFX   = 10670
+      ENEMY_ENCOUNTER  = 10710
+      VICTORY_HANDLER  = 20710
+      ESCAPE_HANDLER   = 20711
+      DEFEAT_HANDLER   = 20712
+      END_BATTLE       = 20713
       OPEN_SHOP           = 10720
       SHOP_TRANSACTION    = 20720
       SHOP_NO_TRANSACTION = 20721
@@ -134,7 +139,7 @@ module Game
     def waiting?; @waiting; end
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
                 :teleport, :input_digits, :key_input_request, :inn_request,
-                :shop_request
+                :shop_request, :battle_request
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
@@ -362,6 +367,45 @@ module Game
       nil
     end
 
+    # Resume an Enemy Encounter with the battle's outcome (:victory, :escape or
+    # :defeat). Rewards (EXP / gold on victory) are granted by the scene, which
+    # owns the battle; this only steers event flow. Escape with the "end event
+    # processing" mode abandons the rest of the event; otherwise, when the
+    # command carries [Victory] / [Escape] / [Defeat] handler branches, jump into
+    # the matching one. A game-over on defeat is the scene's concern.
+    def resume_battle(result)
+      if result == :escape && @battle_escape_aborts
+        @index = @list.size
+        @call_stack = []
+        reset_waits
+        return
+      end
+      if @battle_has_handlers
+        target = find_battle_option(result)
+        @index = target if target
+      end
+      reset_waits
+    end
+
+    BATTLE_HANDLERS = { victory: Cmd::VICTORY_HANDLER, escape: Cmd::ESCAPE_HANDLER,
+                        defeat: Cmd::DEFEAT_HANDLER }.freeze
+
+    # Locate the handler branch for a battle outcome, like the inn / shop
+    # branches: the index just after its marker, falling back to END_BATTLE and
+    # to nil once the encounter's indent level is left.
+    def find_battle_option(result)
+      want = BATTLE_HANDLERS[result]
+      i = @index
+      while i < @list.size
+        c = @list[i]
+        return i + 1 if c.indent == @battle_indent && c.code == want
+        return i if c.indent == @battle_indent && c.code == Cmd::END_BATTLE
+        return nil if c.indent < @battle_indent
+        i += 1
+      end
+      nil
+    end
+
     # RPG2000 key-input result codes in priority order (highest first). When more
     # than one accepted button is active RPG_RT returns the largest code:
     # Shift > Cancel > Decision > Up > Right > Left > Down.
@@ -395,6 +439,7 @@ module Game
       @key_input_request = nil
       @inn_request = nil
       @shop_request = nil
+      @battle_request = nil
     end
 
     def switches;  @state.switches;  end
@@ -411,6 +456,11 @@ module Game
       when Cmd::CHOICE_END       then nil
       when Cmd::INPUT_NUMBER     then do_input_number cmd
       when Cmd::KEY_INPUT_PROC   then do_key_input cmd
+      when Cmd::ENEMY_ENCOUNTER  then do_enemy_encounter cmd
+      when Cmd::VICTORY_HANDLER  then skip_to([Cmd::END_BATTLE], cmd.indent); consume
+      when Cmd::ESCAPE_HANDLER   then skip_to([Cmd::END_BATTLE], cmd.indent); consume
+      when Cmd::DEFEAT_HANDLER   then skip_to([Cmd::END_BATTLE], cmd.indent); consume
+      when Cmd::END_BATTLE       then nil
       when Cmd::OPEN_SHOP        then do_open_shop cmd
       when Cmd::SHOP_TRANSACTION    then skip_to([Cmd::SHOP_END], cmd.indent); consume
       when Cmd::SHOP_NO_TRANSACTION then skip_to([Cmd::SHOP_END], cmd.indent); consume
@@ -735,6 +785,32 @@ module Game
         goods: cmd.parameters[4..-1] || []
       }
       @wait_kind = :shop
+      @waiting = true
+    end
+
+    # Enemy Encounter (10710): start a battle against a troop. param0 is the
+    # troop-id source (0 constant, 1 variable) and param1 the id / variable;
+    # param3 the escape mode (0 disallow, 1 end event processing on escape,
+    # 2 custom [Escape] handler), param4 the defeat mode (0 game over, 1 custom
+    # [Defeat] handler), param5 the first-strike flag. The command may be
+    # followed by [Victory] / [Escape] / [Defeat] handler branches (markers
+    # VICTORY/ESCAPE/DEFEAT_HANDLER, closed by END_BATTLE), like a Show Choices
+    # block. The interpreter records the request and suspends on a :battle wait;
+    # the scene runs the battle (rewards, game over) and resumes via
+    # resume_battle. The turn-based battle itself is not built yet.
+    def do_enemy_encounter(cmd)
+      escape_mode = cmd.param(3)
+      @battle_indent = cmd.indent
+      @battle_escape_aborts = escape_mode == 1
+      nxt = @list[@index]
+      @battle_has_handlers =
+        !nxt.nil? && nxt.code == Cmd::VICTORY_HANDLER && nxt.indent == cmd.indent
+      @battle_request = {
+        troop_id: cmd.param(0) == 0 ? cmd.param(1) : variables[cmd.param(1)],
+        allow_escape: escape_mode != 0, first_strike: cmd.param(5) != 0,
+        defeat_game_over: cmd.param(4) == 0
+      }
+      @wait_kind = :battle
       @waiting = true
     end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1297,6 +1297,7 @@ class RPG2k
           when :key_input then drive_key_input
           when :inn then drive_inn
           when :shop then drive_shop
+          when :battle then drive_battle
           when :wait then drive_wait
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
@@ -1620,6 +1621,26 @@ class RPG2k
         @shop[:window].dispose if @shop[:window]
         @shop[:gold].dispose if @shop[:gold]
         @shop = nil
+      end
+
+      # -- Enemy Encounter (placeholder battle) -------------------------------
+
+      # Resolve an Enemy Encounter. The turn-based battle screen is not built
+      # yet, so an encounter is treated as an immediate victory: the troop is
+      # instantiated from the database, its EXP is granted to every party member
+      # and its gold to the party, then the [Victory] handler runs. Escape /
+      # defeat outcomes, rewards drops and the battle UI are still to come.
+      def drive_battle
+        req = @interpreter.battle_request
+        return @interpreter.resume_battle(:victory) unless req
+        troop = Game::Troop.new(db, req[:troop_id])
+        exp = troop.total_exp
+        @state.party.actors.each { |a| a.gain_exp(exp) }
+        @state.party.gain_gold(troop.total_gold)
+        @interpreter.resume_battle(:victory)
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle placeholder failed: #{e.message}"
+        @interpreter.resume_battle(:victory)
       end
 
       def drive_wait

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2725,6 +2725,127 @@ check 'Open Shop routes Transaction / No Transaction handler branches' do
   eq true, st2.switches[3]
 end
 
+# -- Enemy Encounter (troop model + command) ----------------------------------
+
+EnemyRow = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                      :agility, :exp, :gold)
+GroupMember = Struct.new(:enemy_id, :x, :y, :invisible)
+GroupRow = Struct.new(:name, :members)
+BattleDB = Struct.new(:enemy, :enemy_group)
+
+# A database with two enemies and one troop of three (two Slimes + a hidden Bat).
+def battle_db
+  enemies = {
+    2 => EnemyRow.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10),
+    3 => EnemyRow.new('Bat',   12, 0, 6, 2, 2, 9, 3, 4)
+  }
+  groups = {
+    1 => GroupRow.new('Slimes', { 1 => GroupMember.new(2, 10, 20, false),
+                                  2 => GroupMember.new(2, 40, 20, false),
+                                  3 => GroupMember.new(3, 70, 20, true) })
+  }
+  BattleDB.new(enemies, groups)
+end
+
+check 'Game::Troop instantiates its members and totals EXP / gold' do
+  troop = Game::Troop.new(battle_db, 1)
+  eq 'Slimes', troop.name
+  eq [2, 2, 3], troop.members.map(&:id)
+  eq 13, troop.total_exp, '5 + 5 + 3'
+  eq 24, troop.total_gold, '10 + 10 + 4'
+  first = troop.members.first
+  eq 30, first.max_hp
+  eq 30, first.hp, 'starts at full HP'
+  eq [10, 20], [first.x, first.y]
+  ok !first.hidden
+  ok troop.members.last.hidden, 'the Bat is invisible'
+end
+
+check 'Game::Enemy reads its combat stats from the database' do
+  e = Game::Enemy.new(battle_db, 3)
+  eq 'Bat', e.name
+  eq 12, e.max_hp
+  eq 9, e.agi
+  eq 3, e.exp
+  ok !e.dead?
+  e.hp = 0
+  ok e.dead?
+end
+
+check 'a missing troop / enemy degrades to an empty, harmless model' do
+  troop = Game::Troop.new(battle_db, 99)
+  eq [], troop.members
+  eq 0, troop.total_exp
+  eq 1, Game::Enemy.new(battle_db, 99).max_hp, 'defaults for a missing enemy'
+end
+
+check 'Enemy Encounter parses the troop and modes and suspends on :battle' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # const troop 4, setup 0, escape mode 2 (custom), defeat mode 1 (custom),
+  # first-strike on.
+  it.start([FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 4, 0, 2, 1, 1])])
+  it.update
+  ok it.waiting?
+  eq :battle, it.wait_kind
+  req = it.battle_request
+  eq 4, req[:troop_id]
+  eq true, req[:allow_escape]
+  eq true, req[:first_strike]
+  eq false, req[:defeat_game_over], 'defeat mode 1 uses a handler'
+end
+
+check 'Enemy Encounter reads a variable troop id and escape-disallow' do
+  st = party_state
+  st.variables[7] = 12
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ENEMY_ENCOUNTER, [1, 7, 0, 0, 0, 0])])
+  it.update
+  eq 12, it.battle_request[:troop_id]
+  eq false, it.battle_request[:allow_escape], 'escape mode 0 disallows escape'
+  eq true, it.battle_request[:defeat_game_over], 'defeat mode 0 is game over'
+end
+
+check 'Enemy Encounter routes Victory / Escape / Defeat handler branches' do
+  list = [
+    FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 1, 0, 2, 1, 0], indent: 0),
+    FakeCmd.new(IC::VICTORY_HANDLER, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    FakeCmd.new(IC::ESCAPE_HANDLER, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    FakeCmd.new(IC::DEFEAT_HANDLER, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0], indent: 1),
+    FakeCmd.new(IC::END_BATTLE, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 4, 4, 0], indent: 0)
+  ]
+  { victory: 1, escape: 2, defeat: 3 }.each do |result, branch_switch|
+    st = party_state
+    it = Game::Interpreter.new(st)
+    it.start(list)
+    it.update
+    it.resume_battle(result)
+    it.update
+    [1, 2, 3].each do |s|
+      eq(s == branch_switch, st.switches[s] || false, "#{result} -> switch #{s}")
+    end
+    eq true, st.switches[4], 'execution continues past the encounter'
+  end
+end
+
+check 'Enemy Encounter escape-abort mode ends the event' do
+  list = [
+    FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 1, 0, 1, 0, 0], indent: 0), # escape=abort
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start(list)
+  it.update
+  it.resume_battle(:escape)
+  it.update
+  ok !st.switches[5], 'the rest of the event is abandoned on an aborting escape'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -152,6 +152,13 @@ def fake_db(common = nil)
     # A tiny item table the Open Shop window prices its goods from.
     item: { 3 => OpenStruct.new(name: 'Potion', price: 100),
             5 => OpenStruct.new(name: 'Herb', price: 40) },
+    # An enemy and a troop of two, for the placeholder Enemy Encounter victory.
+    enemy: { 2 => OpenStruct.new(name: 'Slime', max_hp: 30, max_sp: 0, attack: 8,
+                                 defense: 4, spirit: 3, agility: 5, exp: 5,
+                                 gold: 10) },
+    enemy_group: { 1 => OpenStruct.new(name: 'Slimes', members: {
+      1 => OpenStruct.new(enemy_id: 2, x: 0, y: 0, invisible: false),
+      2 => OpenStruct.new(enemy_id: 2, x: 0, y: 0, invisible: false) }) },
     common_event: common,
     player: {}
   )
@@ -393,6 +400,22 @@ class InnStubParty
   attr_reader :actors, :gold
   attr_accessor :leader
   def initialize(gold); @gold = gold; @actors = [InnStubActor.new('Hero')]; @leader = nil; end
+  def gain_gold(n); @gold += n; end
+end
+
+# A party the placeholder battle grants rewards to: gold plus actors that bank
+# EXP, with the leader Scene::Map reads while rendering.
+class BattleStubActor
+  attr_accessor :exp
+  attr_reader :id
+  def initialize; @exp = 0; @id = 1; end
+  def gain_exp(n); @exp += n; end
+end
+
+class BattleStubParty
+  attr_reader :actors, :gold
+  attr_accessor :leader
+  def initialize; @actors = [BattleStubActor.new]; @gold = 0; @leader = nil; end
   def gain_gold(n); @gold += n; end
 end
 
@@ -1236,6 +1259,27 @@ check 'Open Shop scene: leaving without buying runs the No Transaction branch' d
   eq 500, st.party.gold, 'no gold spent'
   ok !st.switches[1], 'the Transaction branch was skipped'
   ok st.switches[2], 'the No Transaction branch ran'
+end
+
+check 'Enemy Encounter scene: a placeholder victory grants rewards, runs Victory' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 1, 0], indent: 0), # troop 1
+    ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::ESCAPE_HANDLER, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::END_BATTLE, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  5.times { scene.update } # the encounter auto-resolves to victory
+  eq 20, st.party.gold, 'gained the troop gold (2 Slimes x 10)'
+  eq 10, st.party.actors.first.exp, 'gained the troop EXP (2 Slimes x 5)'
+  ok st.switches[1], 'the Victory handler ran'
+  ok !st.switches[2], 'the Escape handler was skipped'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
The first step toward the battle system: the Enemy Encounter command, the runtime troop/enemy model it needs, and battle-result branch routing. Verified against liblcf / EasyRPG. The turn-based battle screen is a later PR; encounters resolve as a placeholder victory for now so events stay playable.

## Runtime battle model
- **`Game::Enemy`** — instantiates a database enemy (chunk 14): combat stats, EXP / gold, battle-screen position, full starting HP / SP.
- **`Game::Troop`** — instantiates an enemy group (敵グループ, chunk 15) into its live members and totals the EXP / gold it is worth.

(The LCF schema for both already existed; this is the Game-level runtime layer.)

## Enemy Encounter (10710)
Decodes its parameters — constant or variable troop id, escape mode (disallow / end-event-processing / custom handler), defeat mode (game over / custom handler), first-strike — and, like the inn and shop, routes the optional `[Victory]` / `[Escape]` / `[Defeat]` handler branches (markers 20710 / 20711 / 20712, closed by 20713) on the outcome. The "end event processing" escape mode abandons the rest of the event.

`Game::Interpreter` suspends on a `:battle` wait. **`Scene::Map` resolves an encounter as an immediate victory** that instantiates the troop, grants its EXP to every party member and its gold to the party, then runs the Victory handler — a documented placeholder until the real battle screen lands (escape/defeat outcomes and game-over come with it).

## Testing
- `scripts/rpg2k_logic_check.rb` — **191 pass** (new: troop instantiation + EXP/gold totals, enemy stats, missing-row degradation, encounter param parsing (const + variable id, escape/defeat modes), Victory/Escape/Defeat branch routing, escape-abort ends the event)
- `scripts/rpg2k_scene_check.rb` — **62 pass** (new: an encounter grants the troop's rewards and runs the Victory handler)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_