### PR TITLE
mruby-rgss: render RGSS::Sprite#zoom_x / #zoom_y natively

### DIFF
--- a/changelog.d/rpgxp-rgss-sprite-zoom-native.added.md
+++ b/changelog.d/rpgxp-rgss-sprite-zoom-native.added.md
@@ -1,0 +1,7 @@
+- **`RGSS::Sprite#zoom_x` / `#zoom_y` are now rendered.** `Sprite#zoom_x=`/`zoom_y=`
+  are native: a Sprite's canvas is an LVGL image, so they set its scale via
+  `lv_image_set_scale_x/y` (where 256 = 1.0), converting the RGSS float multiplier
+  to that fixed point — so `sprite.zoom_x = 2.0` actually doubles the sprite
+  instead of being stored-but-ignored. Follows the native `opacity` pass; angle,
+  mirror, and tone/color/src_rect are the remaining Sprite-compositing slices. See
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -37,7 +37,7 @@ These are complete enough for the stock scripts:
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
-### 1. `Sprite` extended properties ⚠️ (opacity rendered; rest stored)
+### 1. `Sprite` extended properties ⚠️ (opacity + zoom rendered; rest stored)
 
 `mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,
 `visible`/`visible=`, `dispose`, `update`, and stores the extra properties the
@@ -45,14 +45,15 @@ stock scripts set — `opacity` (~18), `ox`/`oy`, `zoom_x`/`zoom_y` (~3 each),
 `angle`, `mirror`, `tone`, `color`, `blend_type`, `bush_depth` (~2), `src_rect`
 and `flash` — with RGSS defaults (`mruby-rgss/mrblib/lib.rb`).
 
-**`opacity` is now rendered natively:** `Sprite#opacity=` sets the sprite
-canvas's LVGL object opacity (`src/lib.cxx`), so the compositor multiplies the
-bitmap's alpha by it — fades (`sprite.opacity = n`) now actually fade. Since a
-Sprite's native handle is an `lv_canvas` (an LVGL image subclass), the remaining
-transforms map to LVGL image styles too: **zoom_x/zoom_y** →
-`transform_scale_x/y`, **angle** → `transform_rotation`, **mirror** → negative
-scale; **tone/color/src_rect/bush_depth** need a software pre-composite through
-the existing `bmp_blt`/`bmp_stretch_blt` blend loops. Those are the next slices.
+**`opacity` and `zoom_x`/`zoom_y` are now rendered natively.** A Sprite's native
+handle is an `lv_canvas` (an LVGL image subclass), so: `Sprite#opacity=` sets the
+canvas's LVGL object opacity (the compositor multiplies the bitmap's alpha by it,
+so fades actually fade); `Sprite#zoom_x=`/`zoom_y=` set the image's scale
+(`lv_image_set_scale_x/y`, where 256 = 1.0), so the sprite scales. **Remaining:**
+**angle** → `lv_image_set_rotation` (needs the CCW→CW/0.1° convention and a
+pivot), **mirror** (LVGL image scale is unsigned, so it needs a flip pass), and
+**tone/color/src_rect/bush_depth** → a software pre-composite through the existing
+`bmp_blt`/`bmp_stretch_blt` blend loops. Those are the next slices.
 `Sprite_Character`, `Sprite_Battler`, `Arrow_Base`, weather and the animation
 player depend on these.
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -129,15 +129,16 @@ module RGSS
 
     # RGSS Sprite properties the stock scripts set — opacity fades, zoom, angle,
     # tone/colour, scroll origin, mirror, bush depth, blend mode, source rect.
-    # `opacity=` is now honoured natively (src/lib.cxx sets the sprite canvas's
-    # LVGL object opacity); it still stores @opacity here so the reader below
-    # returns the set value. The rest are stored so `sprite.zoom_x = n` no longer
-    # raises, but the native renderer does not yet honour them visually (tracked
-    # in docs/rpgxp-rgss-api-gap.md). Readers fall back to RGSS's defaults because
-    # the native #initialize does not set these ivars (and cannot be wrapped from
-    # here without replacing it). `nil?` checks — not `||` — where 0/false is a
-    # meaningful value (opacity 0 = transparent).
-    attr_writer :ox, :oy, :zoom_x, :zoom_y, :angle, :mirror,
+    # `opacity=`, `zoom_x=` and `zoom_y=` are now honoured natively (src/lib.cxx
+    # sets the sprite canvas's LVGL object opacity / image scale); they still
+    # store their ivars here so the readers below return the set values. The rest
+    # are stored so `sprite.angle = n` no longer raises, but the native renderer
+    # does not yet honour them visually (tracked in docs/rpgxp-rgss-api-gap.md).
+    # Readers fall back to RGSS's defaults because the native #initialize does not
+    # set these ivars (and cannot be wrapped from here without replacing it).
+    # `nil?` checks — not `||` — where 0/false is a meaningful value (opacity 0 =
+    # transparent).
+    attr_writer :ox, :oy, :angle, :mirror,
                 :bush_depth, :blend_type, :tone, :color, :src_rect
 
     def opacity

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2222,6 +2222,37 @@ mrb_value spr_set_opacity(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// RGSS Sprite#zoom_x= / #zoom_y= (a float multiplier, 1.0 = normal size). A
+// Sprite's native handle is an lv_canvas, an LVGL image that scales its content
+// by an integer factor where LV_SCALE_NONE (256) == 1.0. Convert the RGSS float
+// to that fixed point and apply it to the canvas; the float is mirrored into
+// @zoom_x/@zoom_y so the Ruby reader (defaulting to 1.0) returns it. A fresh
+// sprite is already LV_SCALE_NONE, matching RGSS's 1.0 default. mruby's "f"
+// coerces an Integer argument (e.g. `zoom_x = 1`) to Float.
+mrb_value spr_set_zoom_x(mrb_state* M, mrb_value self) {
+  mrb_float z;
+  mrb_get_args(M, "f", &z);
+  if (z < 0.0)
+    z = 0.0;
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  lv_image_set_scale_x(obj, static_cast<uint32_t>(z * LV_SCALE_NONE + 0.5));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@zoom_x"), mrb_float_value(M, z));
+  return self;
+}
+
+mrb_value spr_set_zoom_y(mrb_state* M, mrb_value self) {
+  mrb_float z;
+  mrb_get_args(M, "f", &z);
+  if (z < 0.0)
+    z = 0.0;
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  lv_image_set_scale_y(obj, static_cast<uint32_t>(z * LV_SCALE_NONE + 0.5));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@zoom_y"), mrb_float_value(M, z));
+  return self;
+}
+
 mrb_value obj_set_x(mrb_state* M, mrb_value self) {
   mrb_int x;
   mrb_get_args(M, "i", &x);
@@ -2627,6 +2658,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, spr, "visible=", obj_set_visible, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "opacity=", spr_set_opacity, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "zoom_x=", spr_set_zoom_x, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "zoom_y=", spr_set_zoom_y, MRB_ARGS_REQ(1));
 
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -161,10 +161,11 @@ assert "RGSS::Viewport API surface" do
 end
 
 assert "RGSS::Sprite API surface" do
-  # opacity= is native (honoured by the LVGL compositor, src/lib.cxx); the rest
-  # are native too. Sprite.new needs a live display, so this only asserts the
-  # method surface — the compositing itself is exercised by the game runs.
-  %i[bitmap= x= y= z= visible visible= opacity= dispose disposed?].each do |m|
+  # opacity=/zoom_x=/zoom_y= are native (honoured by the LVGL compositor,
+  # src/lib.cxx); the rest are native too. Sprite.new needs a live display, so
+  # this only asserts the method surface — the compositing itself is exercised by
+  # the game runs.
+  %i[bitmap= x= y= z= visible visible= opacity= zoom_x= zoom_y= dispose disposed?].each do |m|
     assert_true RGSS::Sprite.method_defined?(m), "Sprite##{m} missing"
   end
 end


### PR DESCRIPTION
## Summary

Second of the native Sprite-compositing render passes (follows the `opacity` pass, #208). Makes another stored-but-ignored property actually render.

`Sprite` zoom was held in a Ruby ivar; the renderer ignored it, so `sprite.zoom_x = 2.0` did nothing visually.

## Change

- **`mruby-rgss/src/lib.cxx`** — make `Sprite#zoom_x=`/`zoom_y=` native. A Sprite's native handle is an `lv_canvas` (an LVGL image), which scales its content by an integer factor where `LV_SCALE_NONE` (256) == 1.0. The setters convert the RGSS float multiplier to that fixed point and apply it via `lv_image_set_scale_x/y`, mirroring the float into `@zoom_x`/`@zoom_y` so the Ruby readers still return it. A fresh sprite is already `LV_SCALE_NONE`, matching RGSS's `1.0` default.
- **`mruby-rgss/mrblib/lib.rb`** — drop `:zoom_x`/`:zoom_y` from the `attr_writer` list (native setters replace them; the `def zoom_x`/`zoom_y` readers stay).

### Why the image API, not the generic transform style

I used `lv_image_set_scale_x/y` (image-specific) rather than the generic `lv_obj_set_style_transform_scale_*`. The generic obj transform has a landmine for this use: `lv_obj_pos.c` turns an **unset** scale into `1` (i.e. 1/256 size, not identity), and whether it actually redraws depends on the `LV_DRAW_TRANSFORM_USE_MATRIX` build config. The image scale is honored directly by the image draw, defaults to identity in the image constructor, and has none of those caveats — so it can't make a fresh sprite collapse.

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0** (`lv_image_set_scale_x/y(obj, uint32_t)` is the confirmed v9 image API; `lv_canvas` has `.base_class = &lv_image_class`).
- **`mruby-rgss/test`** — `Sprite.new` needs a live display, so the Sprite surface test now also asserts `zoom_x=`/`zoom_y=` are defined (a canary that the native methods are registered).
- **Same honest limitation as opacity:** no current game sets sprite zoom, so this is compile-verified but render-verified only once the RGSS script host boots an XP game.

## Remaining Sprite slices

`angle` → `lv_image_set_rotation` (needs the CCW→CW / 0.1° convention + pivot), `mirror` (LVGL image scale is unsigned, so a flip pass is needed), and `tone`/`color`/`src_rect`/`bush_depth` → a software pre-composite through the existing `bmp_blt`/`bmp_stretch_blt` blend loops.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #1 (`Sprite`) → ⚠️ (opacity + zoom rendered; rest stored).
- Changelog fragment `changelog.d/rpgxp-rgss-sprite-zoom-native.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_