### PR TITLE
RPG Maker MZ project detection (M6.1 foundation)

### DIFF
--- a/changelog.d/mz-detection-foundation.added.md
+++ b/changelog.d/mz-detection-foundation.added.md
@@ -1,0 +1,8 @@
+- RPG Maker MZ project detection (milestone M6.1). A new `MZ` class
+  (`mruby-mvjs/mrblib/mz.rb`) recognises an MZ project (`js/rmmz_core.js` +
+  `data/System.json`) and knows the canonical `rmmz_*` script load order, wired
+  into `src/main.cxx`'s maker sniff. MZ shares MV's embedded quickjs host, but
+  ships PIXI v5 (WebGL-only) and so needs a WebGL-subset backend that is not
+  built yet; pointing the binary at an MZ game now reports that pending state
+  cleanly instead of failing with "no project found". Covered by host specs
+  (`mruby-mvjs/test/mz_test.rb`); see ADR 0004 (M6) for the sub-milestone plan.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -538,3 +538,14 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     still wants a device / a native listen; CI only checks dispatch + resolve.
 - 🚧 **M6 — MZ.** A WebGL-subset backend on LVGL so PIXI v5 / RPG Maker MZ runs
   on the same foundation (`js/rmmz_*.js`).
+  - ✅ M6.1 foundation: an `MZ` class (`mruby-mvjs/mrblib/mz.rb`) detects an MZ
+    project (`js/rmmz_core.js` + `data/System.json`), knows the canonical
+    `rmmz_*` load order, and is wired into `src/main.cxx`'s maker sniff so an MZ
+    game reports the pending WebGL backend cleanly instead of "no project
+    found". Covered by `mruby-mvjs/test/mz_test.rb`.
+  - 🚧 M6.2 host reuse: run the `rmmz_*` scripts on the shared quickjs host to
+    reach `Scene_Boot` in logic; a committed MZ sample is authorable (MZ's
+    corescript has an MIT community reimplementation, `stak/rmmz-corescript`,
+    fetchable like the MV corescript).
+  - 🚧 M6.3 WebGL rendering: the WebGL-subset backend behind PIXI v5 (the bulk
+    of the work — MZ dropped the Canvas2D renderer the MV bridge targets).

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -120,7 +120,23 @@ JavaScript loads and interprets the JSON.
 - **M5 — Play.** Input + save/load (`require('fs')` shim) + audio wiring; a
   walkable MV game in the SDL window and the sixel/iTerm2 terminals.
 - **M6 — MZ.** A WebGL-subset backend on LVGL so PIXI v5 / RPG Maker MZ runs on
-  the same foundation.
+  the same foundation. Broken into sub-milestones:
+  - **M6.1 — Foundation (landed).** An `MZ` class (`mruby-mvjs/mrblib/mz.rb`)
+    that detects an MZ project (`js/rmmz_core.js` + `data/System.json`) and
+    knows the canonical `rmmz_*` load order, wired into `src/main.cxx`'s maker
+    sniff. When the binary is pointed at an MZ game it reports the pending
+    WebGL backend cleanly instead of the "no project found" error. Covered by
+    host specs (`mruby-mvjs/test/mz_test.rb`).
+  - **M6.2 — Host reuse.** Drive the shared quickjs host / host-globals / IO /
+    input / audio bridges (all maker-agnostic) with the `rmmz_*` scripts, so an
+    MZ game reaches `Scene_Boot` in logic (no pixels). A committed MZ sample is
+    authorable the same way `data/mv-sample` is: MZ's corescript has an MIT
+    community reimplementation ([stak/rmmz-corescript]), fetched (never
+    vendored) like the MV corescript, so no proprietary engine is redistributed.
+  - **M6.3 — WebGL rendering.** The WebGL-subset backend behind PIXI v5, the
+    bulk of the work — MZ dropped the Canvas2D renderer the MV bridge targets.
+
+[stak/rmmz-corescript]: https://github.com/stak/rmmz-corescript
 
 ## Consequences
 

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -1,0 +1,114 @@
+# RPG Maker MZ support (foundation — milestone M6.1).
+#
+# MZ is the JavaScript maker family's newer member: like MV it is a *JavaScript*
+# application with a `data/*.json` database, and it runs on the same embedded
+# quickjs-ng host, host-global shims and IO/input/audio bridges that MV already
+# uses (see mruby-mvjs and docs/adr/0004-javascript-maker-mv-quickjs.md). Two
+# things set it apart:
+#
+#   1. Its engine scripts are `js/rmmz_*.js` (not MV's `js/rpg_*.js`), loaded in
+#      a slightly different order (pako/localforage/effekseer instead of MV's
+#      lz-string), and a community MIT reimplementation exists
+#      (github.com/stak/rmmz-corescript), so an MZ test bed is authorable the
+#      same way `data/mv-sample` is for MV.
+#   2. It ships **PIXI v5, which is WebGL-only** — there is no Canvas2D renderer
+#      to map onto the `Canvas2D -> Bitmap` bridge MV drives. Rendering therefore
+#      needs a WebGL-subset backend on LVGL, which is the bulk of milestone M6
+#      and is **not built yet**.
+#
+# So this class is the M6.1 foundation, mirroring MV's original M1: it recognises
+# an MZ project and knows the canonical script load order, and reports the
+# pending WebGL backend cleanly instead of misbehaving when the binary is pointed
+# at an MZ game. The host reuse (M6.2) and the WebGL renderer (M6.3) land later.
+class MZ
+  # RPG Maker MZ renders at 816x624 by default, same nominal canvas as MV.
+  WIDTH = 816
+  HEIGHT = 624
+
+  # The files that unambiguously mark a directory as an RPG Maker MZ project:
+  # the core engine script and the system database. MV uses `js/rpg_core.js`
+  # instead, so the two never collide.
+  REQUIRED_MARKERS = ["js/rmmz_core.js", "data/System.json"].freeze
+
+  # The MZ engine scripts, in the order the stock `index.html` loads them: the
+  # vendored libraries first (PIXI v5, then pako for save compression,
+  # localforage for storage, and Effekseer for animations), then the engine
+  # modules, then the game's plugin list and entry point. As on the MV side the
+  # runtime prefers the game's own `index.html` when present and only falls back
+  # to this list, so it need only be the canonical default.
+  CORE_SCRIPTS = [
+    "js/libs/pixi.js",
+    "js/libs/pako.min.js",
+    "js/libs/localforage.min.js",
+    "js/libs/effekseer.min.js",
+    "js/libs/vorbis.js",
+    "js/rmmz_core.js",
+    "js/rmmz_managers.js",
+    "js/rmmz_objects.js",
+    "js/rmmz_scenes.js",
+    "js/rmmz_sprites.js",
+    "js/rmmz_windows.js",
+    "js/plugins.js",
+    "js/main.js",
+  ].freeze
+
+  class << self
+    # The canonical MZ script load order (see CORE_SCRIPTS).
+    def core_scripts
+      CORE_SCRIPTS
+    end
+
+    # Pure predicate: given the set of project-relative files that exist, is this
+    # an MZ project? Split out from `project?` so it can be exercised without
+    # touching the filesystem (see mruby-mvjs/test/mz_test.rb).
+    def satisfied?(present)
+      REQUIRED_MARKERS.all? { |m| present.include?(m) }
+    end
+
+    # Does the directory look like an RPG Maker MZ project?
+    def project?(dir = GAME_DIR)
+      REQUIRED_MARKERS.all? { |m| File.exist?("#{dir}/#{m}") }
+    end
+
+    # False until the WebGL-subset backend PIXI v5 needs (milestone M6) is built.
+    # The quickjs host itself is already present (it is shared with MV), but MZ
+    # cannot render a frame without WebGL, so a whole game cannot yet boot.
+    def runtime_available?
+      false
+    end
+  end
+
+  def initialize(args)
+    @args = args
+    @game_dir = GAME_DIR
+  end
+
+  attr_reader :game_dir
+
+  # Native entry point. Until the WebGL backend lands (M6), this reports the
+  # pending state instead of failing hard, so the rest of the binary — and the
+  # other makers — are unaffected.
+  def start
+    warn_runtime_pending
+  end
+
+  # Per-frame entry point (Emscripten drives this directly, as for the other
+  # makers). A no-op beyond the pending notice until M6 lands.
+  def main_loop
+    warn_runtime_pending
+  end
+
+  private
+
+  # Report the pending runtime once. Emscripten drives main_loop every frame, so
+  # without the guard this would print on each one.
+  def warn_runtime_pending
+    return if @warned_runtime_pending
+    @warned_runtime_pending = true
+    $stderr.puts "[MZ] RPG Maker MZ support is under construction: MZ ships " \
+                 "PIXI v5 (WebGL-only), and the WebGL-subset backend it needs " \
+                 "is not built into this binary yet. The engine/host/IO/input/" \
+                 "audio layers are shared with MV; only the renderer is " \
+                 "missing. See docs/adr/0004-javascript-maker-mv-quickjs.md (M6)."
+  end
+end

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -1,0 +1,57 @@
+# Tests for the pure Ruby logic of the RPG Maker MZ foundation (milestone M6.1):
+# project detection and the script load order. Like the MV specs, these exercise
+# the logic without the WebGL renderer (not built yet), so they run in the host
+# test harness.
+
+assert 'MZ.satisfied? recognises an MZ project layout' do
+  present = [
+    "js/rmmz_core.js",
+    "js/rmmz_managers.js",
+    "data/System.json",
+    "data/Actors.json",
+    "img/system/Window.png",
+  ]
+  assert_true MZ.satisfied?(present)
+end
+
+assert 'MZ.satisfied? rejects layouts missing a required marker' do
+  # Has the engine script but no database.
+  assert_false MZ.satisfied?(["js/rmmz_core.js", "js/main.js"])
+  # Has the database but no engine script.
+  assert_false MZ.satisfied?(["data/System.json", "data/Map001.json"])
+  assert_false MZ.satisfied?([])
+end
+
+assert 'MZ.satisfied? does not mistake an MV project for MZ' do
+  # MV ships js/rpg_core.js, not js/rmmz_core.js — the two never collide.
+  assert_false MZ.satisfied?(["js/rpg_core.js", "data/System.json"])
+  # And MV must not be recognised as MZ.
+  assert_true MV.satisfied?(["js/rpg_core.js", "data/System.json"])
+end
+
+assert 'MZ.core_scripts loads the vendored libraries before the engine' do
+  scripts = MZ.core_scripts
+  pixi = scripts.index("js/libs/pixi.js")
+  core = scripts.index("js/rmmz_core.js")
+  assert_true !pixi.nil? && !core.nil?
+  assert_true pixi < core
+end
+
+assert 'MZ.core_scripts evaluates main.js last' do
+  assert_equal "js/main.js", MZ.core_scripts.last
+end
+
+assert 'MZ.core_scripts keeps the MZ engine module order' do
+  scripts = MZ.core_scripts
+  order = %w[
+    js/rmmz_core.js js/rmmz_managers.js js/rmmz_objects.js
+    js/rmmz_scenes.js js/rmmz_sprites.js js/rmmz_windows.js
+  ]
+  indices = order.map { |s| scripts.index(s) }
+  assert_false indices.include?(nil)
+  assert_equal indices, indices.sort
+end
+
+assert 'MZ.runtime_available? is false until the WebGL backend lands' do
+  assert_false MZ.runtime_available?
+end

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -285,6 +285,14 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "Game.ini")) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &em_args);
+  } else if (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
+             fs::exists(game_dir_path / "data" / "System.json")) {
+    // RPG Maker MZ: a JavaScript project (js/rmmz_core.js + data/System.json).
+    // Mirrors MZ::REQUIRED_MARKERS. MZ shares MV's embedded JS host but ships
+    // PIXI v5 (WebGL-only); the WebGL backend it needs is not built yet, so
+    // this reports the pending state instead of the "no project found" error
+    // below (see mruby-mvjs/mrblib/mz.rb, docs/adr/0004 M6).
+    game_obj = mrb_obj_new(M, mrb_class_get(M, "MZ"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "js" / "rpg_core.js") &&
              fs::exists(game_dir_path / "data" / "System.json")) {
     // RPG Maker MV: a JavaScript project (js/rpg_core.js + data/System.json).
@@ -293,8 +301,9 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "MV"), 1, &em_args);
   } else {
     std::fprintf(stderr,
-                 "No RPG2k (RPG_RT.ldb), RPG XP (Game.ini) or RPG Maker MV "
-                 "(js/rpg_core.js + data/System.json) project found under "
+                 "No RPG2k (RPG_RT.ldb), RPG XP (Game.ini), RPG Maker MV "
+                 "(js/rpg_core.js + data/System.json) or RPG Maker MZ "
+                 "(js/rmmz_core.js + data/System.json) project found under "
                  "/game\n");
     return 1;
   }
@@ -506,6 +515,8 @@ int main(int argc, char** argv) {
   if (fs::exists(game_dir_path / "RPG_RT.ldb") ||
       fs::exists(game_dir_path / "Game.ini") ||
       (fs::exists(game_dir_path / "js" / "rpg_core.js") &&
+       fs::exists(game_dir_path / "data" / "System.json")) ||
+      (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
        fs::exists(game_dir_path / "data" / "System.json"))) {
     rpg_start_game();
   } else {
@@ -518,6 +529,12 @@ int main(int argc, char** argv) {
   mrb_value game_obj;
   if (fs::exists(game_dir_path / "RPG_RT.ldb")) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &args);
+  } else if (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
+             fs::exists(game_dir_path / "data" / "System.json")) {
+    // RPG Maker MZ: a JavaScript game (js/rmmz_core.js) with a JSON database.
+    // Shares MV's JS host but needs a WebGL backend (not built yet), so it
+    // reports the pending state. See mruby-mvjs/mrblib/mz.rb, docs/adr/0004 M6.
+    game_obj = mrb_obj_new(M, mrb_class_get(M, "MZ"), 1, &args);
   } else if (fs::exists(game_dir_path / "js" / "rpg_core.js") &&
              fs::exists(game_dir_path / "data" / "System.json")) {
     // RPG Maker MV: a JavaScript game (js/rpg_core.js) with a JSON database.


### PR DESCRIPTION
## Summary

Starts milestone **M6 (RPG Maker MZ)** with the foundation slice, mirroring MV's original M1: recognise an MZ project and report the pending renderer cleanly, rather than misbehaving when the binary is pointed at one.

MZ is the JavaScript maker family's newer member — `data/*.json` + `js/rmmz_*.js` on the **same embedded quickjs host** MV already uses. Two things set it apart: its engine scripts are `rmmz_*` (not `rpg_*`), and it ships **PIXI v5, which is WebGL-only** — there's no Canvas2D renderer to map onto the `Canvas2D → Bitmap` bridge MV drives. Rendering therefore needs a WebGL-subset backend (the bulk of M6), which isn't built yet.

## Changes

- **`mruby-mvjs/mrblib/mz.rb`** (new): an `MZ` class with the MZ markers (`js/rmmz_core.js` + `data/System.json`), the canonical `rmmz_*` load order, and `start`/`main_loop` that report the pending WebGL backend once (`runtime_available?` is `false`).
- **`src/main.cxx`**: MZ added to **both** maker-sniff sites (native dispatch + the emscripten baked/loader guard), ahead of the MV branch (distinct markers). Pointing the binary at an MZ project now reports the pending state and exits cleanly instead of aborting with "Unknown game directory".
- **`mruby-mvjs/test/mz_test.rb`** (new): host specs for detection, MV/MZ non-collision, and the load order.
- **`docs/adr/0004-…md`**, **`docs/TODO.md`**, **changelog fragment**: the M6 sub-milestone plan — **M6.1** detection (this) / **M6.2** host reuse / **M6.3** WebGL — noting that MZ's corescript has an MIT community reimplementation ([stak/rmmz-corescript]), so an MZ test bed is authorable like `data/mv-sample`.

## Verification

Native build:
- `mruby_test` (including the new MZ specs) passes.
- Pointing the binary at a stub MZ project prints `[MZ] RPG Maker MZ support is under construction… (M6).` and exits `0`.
- The MV sample still boots to `Scene_Map` — no dispatch regression.

This is deliberately the foundation only; the WebGL renderer (M6.3) is the large follow-up and can't be verified in this headless environment.

[stak/rmmz-corescript]: https://github.com/stak/rmmz-corescript

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_