### PR TITLE
Support seed items in the RPG2000 item menu

### DIFF
--- a/changelog.d/rpg2k-item-seeds.added.md
+++ b/changelog.d/rpg2k-item-seeds.added.md
@@ -1,0 +1,11 @@
+- RPG Maker 2000 item menu: **seeds** (database item type 8) are now usable
+  alongside medicines and skill books. Choosing a seed prompts for an ally and
+  permanently raises that ally's base stats, then consumes one seed. The boosts
+  come from the item's `max_hp_points` / `max_sp_points` and the **`*_points2`**
+  stat set (attack/defence/spirit/agility) — the set RPG2000 seeds use, distinct
+  from the `*_points1` equipment bonuses (confirmed against EasyRPG's
+  `Game_Actor`) — and are applied through `Game::Actor#change_param`, so the
+  RPG2000 stat caps hold. `Game::Party#use_item` gains a `use_seed` branch, and
+  `field_usable?` / `item_effective?` account for seeds (a seed with no boost is
+  ineffective and not consumed), with two new checks in
+  `scripts/rpg2k_logic_check.rb`. Switch (type 9) item use remains a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -289,12 +289,15 @@ The work below is roughly ordered by the critical path to a walkable game
   **Skill** remains a placeholder (it shares the battle effect formula, so it is
   best built with / after the battle system). The **Item** command opens
   `Scene::ItemMenu`: it lists the party's usable **medicines** (database item type
-  6) and **skill books** (type 7) with their held counts. A medicine heals its
-  target — a single-target item a chosen ally, an all-ally item (scope 1) the
-  whole party — restoring HP/SP (flat + percentage of max, clamped); a skill book
-  teaches its skill (item field 53) to a chosen ally who does not already know it.
-  Either consumes one on a use that had any effect, and greys out / reports a use
-  with no effect (a full target, or an actor who already knows the skill). The
+  6), **skill books** (type 7) and **seeds** (type 8) with their held counts. A
+  medicine heals its target — a single-target item a chosen ally, an all-ally item
+  (scope 1) the whole party — restoring HP/SP (flat + percentage of max, clamped);
+  a skill book teaches its skill (item field 53) to a chosen ally who does not
+  already know it; a seed permanently raises a chosen ally's base stats (the
+  item's `max_hp_points` / `max_sp_points` and the `*_points2` stat set, applied
+  through `Actor#change_param` so the stat caps hold). Each consumes one on a use
+  that had any effect, and greys out / reports a use with no effect (a full
+  target, an actor who already knows the skill, or a seed with no boost). The
   **Equip** command
   opens `Scene::EquipMenu`: it shows a party member's five equipment slots and
   stats (LEFT/RIGHT cycle members), and for a chosen slot lists the bag's fitting
@@ -306,8 +309,8 @@ The work below is roughly ordered by the critical path to a walkable game
   `use_item` for items; `equip_candidates` / `equip_from_bag` / `unequip_to_bag`
   for equip) and `Game::Actor` (`next_level_exp` / `exp_to_next` for status),
   covered by `scripts/rpg2k_logic_check.rb`; the RGSS windows are the
-  untestable-here UI. Seed (8) / switch (9) item use, the item usable-occasion
-  gate, and two-handed / dual-wield equipping are later refinements.
+  untestable-here UI. Switch (type 9) item use, the item usable-occasion gate,
+  and two-handed / dual-wield equipping are later refinements.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1238,9 +1238,11 @@ module Game
 
     # RPG2000 database item types. Types 1..5 are the equipment slots (see
     # Actor::EQUIP_ORDER); 6 is a healing medicine (薬); 7 is a skill book (本)
-    # that teaches a skill. Seed (8) / switch (9) menu use is a later refinement.
+    # that teaches a skill; 8 is a seed (種) that permanently raises a stat.
+    # Switch (9) menu use is a later refinement.
     ITEM_MEDICINE = 6
     ITEM_SKILL_BOOK = 7
+    ITEM_SEED = 8
 
     # The database row for a held item id, or nil when the database has no item
     # table (a bare test fixture) or no such row.
@@ -1250,11 +1252,11 @@ module Game
     end
 
     # Whether item `id` can be used from the field (main-menu) item screen: a
-    # medicine or a skill book the party actually holds.
+    # medicine, a skill book or a seed the party actually holds.
     def field_usable?(id)
       it = db_item(id)
       return false unless it && item_count(id) > 0
-      it.type == ITEM_MEDICINE || it.type == ITEM_SKILL_BOOK
+      it.type == ITEM_MEDICINE || it.type == ITEM_SKILL_BOOK || it.type == ITEM_SEED
     end
 
     # The bag's field-usable items as `[id, count]` pairs in ascending id order,
@@ -1287,6 +1289,8 @@ module Game
       when ITEM_SKILL_BOOK
         s = it.skill_id
         !s.nil? && s != 0 && !actor.knows_skill?(s)
+      when ITEM_SEED
+        seed_boosts(it).any? { |b| b != 0 }
       else
         false
       end
@@ -1294,13 +1298,15 @@ module Game
 
     # Use item `id` from the field menu, dispatching on its database type, and
     # return the actors it affected (empty when it did nothing -- then nothing is
-    # consumed). A medicine heals; a skill book teaches its skill.
+    # consumed). A medicine heals; a skill book teaches its skill; a seed raises a
+    # stat.
     def use_item(id, actor = nil)
       it = db_item(id)
       return [] unless it && item_count(id) > 0
       case it.type
       when ITEM_MEDICINE then use_medicine(it, id, actor)
       when ITEM_SKILL_BOOK then use_skill_book(it, id, actor)
+      when ITEM_SEED then use_seed(it, id, actor)
       else []
       end
     end
@@ -1331,6 +1337,29 @@ module Game
       skill = it.skill_id
       return [] unless actor && skill && skill != 0 && !actor.knows_skill?(skill)
       actor.learn_skill(skill)
+      lose_item(id, 1)
+      [actor]
+    end
+
+    # The six permanent stat boosts a seed grants, in Actor::STAT_NAMES order
+    # (max HP, max SP, attack, defence, spirit, agility). RPG2000 seeds use the
+    # item's max_hp_points / max_sp_points and the *_points2 stat set -- distinct
+    # from the *_points1 fields that carry equipment bonuses -- confirmed against
+    # EasyRPG's Game_Actor seed handling.
+    def seed_boosts(it)
+      [it.max_hp_points || 0, it.max_sp_points || 0,
+       it.atk_points2 || 0, it.def_points2 || 0,
+       it.spi_points2 || 0, it.agi_points2 || 0]
+    end
+
+    # A seed permanently raises `actor`'s base stats by seed_boosts (each applied
+    # through Actor#change_param, so RPG2000's stat caps hold). Consumes one when
+    # it carries any boost; a seed with no boost does nothing and is not consumed.
+    def use_seed(it, id, actor)
+      return [] unless actor
+      boosts = seed_boosts(it)
+      return [] unless boosts.any? { |b| b != 0 }
+      boosts.each_index { |i| actor.change_param(i, boosts[i]) if boosts[i] != 0 }
       lose_item(id, 1)
       [actor]
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1250,12 +1250,14 @@ FakeActorSystem = Struct.new(:party)
 FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :max_hp_points, :max_sp_points, :type, :name, :scope,
                       :recover_hp, :recover_hp_rate, :recover_sp, :recover_sp_rate,
-                      :price, :skill_id)
+                      :price, :skill_id,
+                      :atk_points2, :def_points2, :spi_points2, :agi_points2)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
-              skill_id: 0)
+              skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
-               rhp, rhp_rate, rsp, rsp_rate, price, skill_id)
+               rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
+               atk2, dfn2, spi2, agi2)
 end
 class FakeActorDB
   attr_reader :player, :system, :item
@@ -1674,6 +1676,30 @@ check 'a skill book on an actor who already knows the skill does nothing' do
   eq false, st.party.item_effective?(8, hero)
   eq [], st.party.use_item(8, hero)
   eq 1, st.party.item_count(8)                 # not consumed
+end
+
+check 'a seed permanently raises the target stats (points2 set) and is consumed' do
+  st = item_party({ 9 => fake_item(type: 8, mhp: 50, atk2: 5) })
+  st.party.gain_item(9, 2)
+  hero = st.party.leader                        # max_hp 100, atk 10
+  eq true, st.party.item_effective?(9, hero)
+  eq [hero], st.party.use_item(9, hero)
+  eq 150, hero.max_hp                           # +50 base max HP
+  eq 15, hero.atk                               # +5 base attack (atk_points2)
+  eq 1, st.party.item_count(9)                  # one seed consumed
+end
+
+check 'field_items includes seeds; a seed with no boost is ineffective' do
+  items = { 9 => fake_item(type: 8, mhp: 20),   # seed with a boost
+            4 => fake_item(type: 8) }           # seed with no boost
+  st = item_party(items)
+  st.party.gain_item(9, 1)
+  st.party.gain_item(4, 1)
+  eq [[4, 1], [9, 1]], st.party.field_items     # both held seeds are listed
+  hero = st.party.leader
+  eq false, st.party.item_effective?(4, hero)   # no boost -> ineffective
+  eq [], st.party.use_item(4, hero)             # nothing happens
+  eq 1, st.party.item_count(4)                  # not consumed
 end
 
 # -- Field equip menu (Game::Party bag-aware equip) --------------------------


### PR DESCRIPTION
The field item menu now uses **seeds** (database item type 8) in addition to medicines and skill books. (Continues #198 / #209.)

## Behavior

- Seeds appear in the item list alongside medicines and skill books.
- Choosing a seed prompts for an ally and **permanently raises that ally's base stats**, then consumes one seed.
- A seed with no boost is reported as ineffective and consumes nothing.

## Grounding

The boosts come from the item's `max_hp_points` / `max_sp_points` and the **`*_points2`** stat set (attack / defence / spirit / agility) — the set RPG2000 seeds use, **distinct from the `*_points1` equipment bonuses**. Confirmed against EasyRPG's `Game_Actor` seed handling (`SetBaseAtk(GetBaseAtk() + item->atk_points2)`, etc.) rather than guessed — a plausible guess of `points1` would have been wrong. Boosts are applied through the existing `Game::Actor#change_param`, so RPG2000's stat caps hold.

## Structure

`Game::Party#use_item` gains a `use_seed` branch (with `seed_boosts`), and `field_usable?` / `item_effective?` account for seeds. `Scene::ItemMenu` already routes non-all-ally-medicine items through the single-target picker, so no scene change was needed.

## Tests

Two new checks in `scripts/rpg2k_logic_check.rb` (the host harness CI runs): a seed raises max HP (`max_hp_points`) and attack (`atk_points2`) then consumes one, and a no-boost seed is listed but ineffective and not consumed. All 196 logic checks pass; the scene / render / save-load / testbed harnesses stay green.

## Follow-ups

Switch (type 9) item use (needs `Game::State` threaded into item use to flip the switch); the Skill menu screen (shares the battle effect formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_