### PR TITLE
mruby-rgss: render RGSS::Sprite#angle natively

### DIFF
--- a/changelog.d/rpgxp-rgss-sprite-angle-native.added.md
+++ b/changelog.d/rpgxp-rgss-sprite-angle-native.added.md
@@ -1,0 +1,8 @@
+- **`RGSS::Sprite#angle` is now rendered.** `Sprite#angle=` is native: a Sprite's
+  canvas is an LVGL image, so it sets the image rotation via `lv_image_set_rotation`,
+  converting RGSS's counter-clockwise degrees to LVGL's clockwise 0.1° units and
+  pivoting on the sprite's `ox`/`oy` origin — so `sprite.angle = 90` actually
+  rotates the sprite instead of being stored-but-ignored. Follows the native
+  `opacity` and `zoom` passes; `mirror` (a software horizontal-flip pass) and
+  `tone`/`color`/`src_rect` (a software pre-composite) are the remaining
+  Sprite-compositing slices. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -37,7 +37,7 @@ These are complete enough for the stock scripts:
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
-### 1. `Sprite` extended properties ⚠️ (opacity + zoom rendered; rest stored)
+### 1. `Sprite` extended properties ⚠️ (opacity + zoom + angle rendered; rest stored)
 
 `mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,
 `visible`/`visible=`, `dispose`, `update`, and stores the extra properties the
@@ -45,17 +45,19 @@ stock scripts set — `opacity` (~18), `ox`/`oy`, `zoom_x`/`zoom_y` (~3 each),
 `angle`, `mirror`, `tone`, `color`, `blend_type`, `bush_depth` (~2), `src_rect`
 and `flash` — with RGSS defaults (`mruby-rgss/mrblib/lib.rb`).
 
-**`opacity` and `zoom_x`/`zoom_y` are now rendered natively.** A Sprite's native
-handle is an `lv_canvas` (an LVGL image subclass), so: `Sprite#opacity=` sets the
-canvas's LVGL object opacity (the compositor multiplies the bitmap's alpha by it,
-so fades actually fade); `Sprite#zoom_x=`/`zoom_y=` set the image's scale
-(`lv_image_set_scale_x/y`, where 256 = 1.0), so the sprite scales. **Remaining:**
-**angle** → `lv_image_set_rotation` (needs the CCW→CW/0.1° convention and a
-pivot), **mirror** (LVGL image scale is unsigned, so it needs a flip pass), and
+**`opacity`, `zoom_x`/`zoom_y` and `angle` are now rendered natively.** A Sprite's
+native handle is an `lv_canvas` (an LVGL image subclass), so: `Sprite#opacity=`
+sets the canvas's LVGL object opacity (the compositor multiplies the bitmap's
+alpha by it, so fades actually fade); `Sprite#zoom_x=`/`zoom_y=` set the image's
+scale (`lv_image_set_scale_x/y`, where 256 = 1.0), so the sprite scales;
+`Sprite#angle=` sets the image's rotation (`lv_image_set_rotation`, converting
+RGSS's counter-clockwise degrees to LVGL's clockwise 0.1° units, pivoting on the
+sprite's `ox`/`oy` origin). **Remaining:** **mirror** — LVGL's `lv_image` has no
+flip, so it needs a software horizontal-flip pass; and
 **tone/color/src_rect/bush_depth** → a software pre-composite through the existing
-`bmp_blt`/`bmp_stretch_blt` blend loops. Those are the next slices.
-`Sprite_Character`, `Sprite_Battler`, `Arrow_Base`, weather and the animation
-player depend on these.
+`bmp_blt`/`bmp_stretch_blt` blend loops. Both share the same scratch-buffer
+machinery and are the next slices. `Sprite_Character`, `Sprite_Battler`,
+`Arrow_Base`, weather and the animation player depend on these.
 
 ### 2. `Window` ⚠️ (stored; native frame/cursor render pending)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -129,16 +129,16 @@ module RGSS
 
     # RGSS Sprite properties the stock scripts set — opacity fades, zoom, angle,
     # tone/colour, scroll origin, mirror, bush depth, blend mode, source rect.
-    # `opacity=`, `zoom_x=` and `zoom_y=` are now honoured natively (src/lib.cxx
-    # sets the sprite canvas's LVGL object opacity / image scale); they still
-    # store their ivars here so the readers below return the set values. The rest
-    # are stored so `sprite.angle = n` no longer raises, but the native renderer
-    # does not yet honour them visually (tracked in docs/rpgxp-rgss-api-gap.md).
-    # Readers fall back to RGSS's defaults because the native #initialize does not
-    # set these ivars (and cannot be wrapped from here without replacing it).
-    # `nil?` checks — not `||` — where 0/false is a meaningful value (opacity 0 =
-    # transparent).
-    attr_writer :ox, :oy, :angle, :mirror,
+    # `opacity=`, `zoom_x=`, `zoom_y=` and `angle=` are now honoured natively
+    # (src/lib.cxx sets the sprite canvas's LVGL object opacity / image scale /
+    # image rotation); they still store their ivars here so the readers below
+    # return the set values. The rest are stored so `sprite.mirror = true` no
+    # longer raises, but the native renderer does not yet honour them visually
+    # (tracked in docs/rpgxp-rgss-api-gap.md). Readers fall back to RGSS's
+    # defaults because the native #initialize does not set these ivars (and cannot
+    # be wrapped from here without replacing it). `nil?` checks — not `||` — where
+    # 0/false is a meaningful value (opacity 0 = transparent).
+    attr_writer :ox, :oy, :mirror,
                 :bush_depth, :blend_type, :tone, :color, :src_rect
 
     def opacity

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2253,6 +2253,31 @@ mrb_value spr_set_zoom_y(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// RGSS Sprite#angle= (degrees, counter-clockwise, float). LVGL image rotation
+// is in 0.1-degree units, clockwise, normalised to [0, 3600), so negate and
+// scale. RGSS rotates about the sprite's (ox, oy) origin, which is the LVGL
+// image pivot (default 0,0). The @ox/@oy ivars are read here so a script that
+// sets the origin before rotating gets the right pivot; a later ox=/oy= that
+// must re-pivot simply re-assigns angle. The float is mirrored into @angle for
+// the Ruby reader.
+mrb_value spr_set_angle(mrb_state* M, mrb_value self) {
+  mrb_float deg;
+  mrb_get_args(M, "f", &deg);
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  long tenths = std::lround(-deg * 10.0) % 3600;
+  if (tenths < 0)
+    tenths += 3600;
+  const mrb_value ox = mrb_iv_get(M, self, mrb_intern_lit(M, "@ox"));
+  const mrb_value oy = mrb_iv_get(M, self, mrb_intern_lit(M, "@oy"));
+  lv_image_set_pivot(
+      obj, mrb_nil_p(ox) ? 0 : static_cast<int32_t>(mrb_as_int(M, ox)),
+      mrb_nil_p(oy) ? 0 : static_cast<int32_t>(mrb_as_int(M, oy)));
+  lv_image_set_rotation(obj, static_cast<int32_t>(tenths));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@angle"), mrb_float_value(M, deg));
+  return self;
+}
+
 mrb_value obj_set_x(mrb_state* M, mrb_value self) {
   mrb_int x;
   mrb_get_args(M, "i", &x);
@@ -2660,6 +2685,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "opacity=", spr_set_opacity, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "zoom_x=", spr_set_zoom_x, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "zoom_y=", spr_set_zoom_y, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "angle=", spr_set_angle, MRB_ARGS_REQ(1));
 
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -161,11 +161,11 @@ assert "RGSS::Viewport API surface" do
 end
 
 assert "RGSS::Sprite API surface" do
-  # opacity=/zoom_x=/zoom_y= are native (honoured by the LVGL compositor,
+  # opacity=/zoom_x=/zoom_y=/angle= are native (honoured by the LVGL compositor,
   # src/lib.cxx); the rest are native too. Sprite.new needs a live display, so
   # this only asserts the method surface — the compositing itself is exercised by
   # the game runs.
-  %i[bitmap= x= y= z= visible visible= opacity= zoom_x= zoom_y= dispose disposed?].each do |m|
+  %i[bitmap= x= y= z= visible visible= opacity= zoom_x= zoom_y= angle= dispose disposed?].each do |m|
     assert_true RGSS::Sprite.method_defined?(m), "Sprite##{m} missing"
   end
 end


### PR DESCRIPTION
## Summary

Third of the native Sprite-compositing render passes (follows `opacity` #208 and `zoom` #211).

`Sprite#angle` was held in a Ruby ivar; the renderer ignored it, so `sprite.angle = 90` didn't rotate anything.

## Change

- **`mruby-rgss/src/lib.cxx`** — make `Sprite#angle=` native. A Sprite's canvas is an LVGL image, which rotates its content. RGSS `angle` is **counter-clockwise degrees**; LVGL `lv_image_set_rotation` takes **clockwise 0.1° units** in `[0, 3600)` — so negate, scale by 10, and normalize. RGSS rotates about the sprite's `(ox, oy)` origin, which maps to the LVGL image pivot (`lv_image_set_pivot`, read from `@ox`/`@oy`, default `0,0`). The float is mirrored into `@angle` so the Ruby reader still returns it.
- **`mruby-rgss/mrblib/lib.rb`** — drop `:angle` from the `attr_writer` list (native setter replaces it; the `def angle` reader stays).

### Note on the pivot

The pivot is read from `@ox`/`@oy` at `angle=` time, so a script that sets the origin before rotating (the common order) gets the right pivot. A script that changes `ox`/`oy` *after* setting the angle would need to re-assign the angle to re-pivot — documented inline; a fuller fix comes when `ox`/`oy` get their own native position/pivot handling.

## Why mirror is not in this PR

You picked "angle + mirror," but they turn out to be **different mechanisms**, so per the one-change-per-PR convention they're split. `angle` maps to a clean LVGL image-rotation style (this PR). `mirror`, however, has **no LVGL `lv_image` flip API in v9** — it needs a software horizontal-flip pass (a scratch buffer + blit), the same machinery the `tone`/`color`/`src_rect` pre-composite will use. Mirror lands next as its own PR built on that machinery.

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0** (`lv_image_set_rotation`/`lv_image_set_pivot` are the confirmed v9 image API).
- **`mruby-rgss/test`** — `Sprite.new` needs a live display, so the Sprite surface test now also asserts `angle=` is defined.
- **Same honest limitation:** no current game sets sprite angle, so this is compile-verified but render-verified only once the RGSS script host boots an XP game. The CCW→CW conversion and pivot are best-effort until a game exercises them.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #1 → ⚠️ (opacity + zoom + angle rendered; rest stored).
- Changelog fragment `changelog.d/rpgxp-rgss-sprite-angle-native.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_