### PR TITLE
Correct the MZ (M6) plan: no open-source MZ engine to fetch

### DIFF
--- a/changelog.d/mz-corescript-license-correction.changed.md
+++ b/changelog.d/mz-corescript-license-correction.changed.md
@@ -1,0 +1,8 @@
+- Corrected the RPG Maker MZ (M6) plan: MZ's engine is **not** open-source. MV's
+  corescript is an official MIT project (`rpgtkoolmv`, redistributed by KADOKAWA)
+  that `data/mv-sample` fetches, but MZ's engine ships only with the paid editor
+  and has no equivalent open-source release — the GitHub mirrors of it carry no
+  license. So, unlike MV, there is no committable/fetchable MZ test bed; MZ is
+  developed against a user-supplied project. Updates ADR 0004, `docs/TODO.md`
+  and `mruby-mvjs/mrblib/mz.rb`, which had incorrectly described
+  `stak/rmmz-corescript` as an MIT reimplementation.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -555,8 +555,9 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     game reports the pending WebGL backend cleanly instead of "no project
     found". Covered by `mruby-mvjs/test/mz_test.rb`.
   - 🚧 M6.2 host reuse: run the `rmmz_*` scripts on the shared quickjs host to
-    reach `Scene_Boot` in logic; a committed MZ sample is authorable (MZ's
-    corescript has an MIT community reimplementation, `stak/rmmz-corescript`,
-    fetchable like the MV corescript).
+    reach `Scene_Boot` in logic. Note there is **no fetchable MZ test bed** —
+    MZ's engine ships only with the paid editor (no open-source release like
+    MV's MIT `rpgtkoolmv`), so MZ is verified against a user-supplied project,
+    not a committed/downloaded sample.
   - 🚧 M6.3 WebGL rendering: the WebGL-subset backend behind PIXI v5 (the bulk
     of the work — MZ dropped the Canvas2D renderer the MV bridge targets).

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -129,14 +129,19 @@ JavaScript loads and interprets the JSON.
     host specs (`mruby-mvjs/test/mz_test.rb`).
   - **M6.2 — Host reuse.** Drive the shared quickjs host / host-globals / IO /
     input / audio bridges (all maker-agnostic) with the `rmmz_*` scripts, so an
-    MZ game reaches `Scene_Boot` in logic (no pixels). A committed MZ sample is
-    authorable the same way `data/mv-sample` is: MZ's corescript has an MIT
-    community reimplementation ([stak/rmmz-corescript]), fetched (never
-    vendored) like the MV corescript, so no proprietary engine is redistributed.
+    MZ game reaches `Scene_Boot` in logic (no pixels). Unlike MV, there is **no
+    committable/fetchable MZ test bed**: MV's corescript is an official
+    open-source project ([rpgtkoolmv], MIT, redistributed by KADOKAWA) that
+    `data/mv-sample` fetches, but MZ's engine ships only with the paid editor
+    (© Gotcha Gotcha Games / KADOKAWA) and has no equivalent open-source
+    release — the GitHub mirrors of it (e.g. `stak/rmmz-corescript`) carry no
+    license. So MZ is developed and verified against a **user-supplied** MZ
+    project, not a downloaded engine, the same constraint the RPG2000/XP beds
+    hit for their (also non-redistributable) game assets.
   - **M6.3 — WebGL rendering.** The WebGL-subset backend behind PIXI v5, the
     bulk of the work — MZ dropped the Canvas2D renderer the MV bridge targets.
 
-[stak/rmmz-corescript]: https://github.com/stak/rmmz-corescript
+[rpgtkoolmv]: https://github.com/rpgtkoolmv/corescript
 
 ## Consequences
 

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -8,9 +8,11 @@
 #
 #   1. Its engine scripts are `js/rmmz_*.js` (not MV's `js/rpg_*.js`), loaded in
 #      a slightly different order (pako/localforage/effekseer instead of MV's
-#      lz-string), and a community MIT reimplementation exists
-#      (github.com/stak/rmmz-corescript), so an MZ test bed is authorable the
-#      same way `data/mv-sample` is for MV.
+#      lz-string). Unlike MV — whose corescript is an official MIT project
+#      (rpgtkoolmv, redistributed by KADOKAWA) that `data/mv-sample` fetches —
+#      MZ's engine ships only with the paid editor and has no equivalent
+#      open-source release, so running MZ needs a user-supplied MZ project
+#      rather than a committed or fetched engine.
 #   2. It ships **PIXI v5, which is WebGL-only** — there is no Canvas2D renderer
 #      to map onto the `Canvas2D -> Bitmap` bridge MV drives. Rendering therefore
 #      needs a WebGL-subset backend on LVGL, which is the bulk of milestone M6


### PR DESCRIPTION
## Summary

The M6.1 change (#212) stated that MZ's corescript has an MIT community reimplementation (`stak/rmmz-corescript`) fetchable like MV's, so a committed MZ test bed would be authorable the way `data/mv-sample` is. **That is inaccurate, and a licensing hazard.**

Verified against the actual repo and sources:
- **MV** — `rpgtkoolmv/corescript` is a genuine official open-source project (MIT, redistributed by KADOKAWA). That's why `download-mv-corescript.bash` can legitimately fetch it for `data/mv-sample`.
- **MZ** — the engine ships only with the paid editor (© Gotcha Gotcha Games / KADOKAWA) and has **no** equivalent open-source release. `stak/rmmz-corescript` has **no LICENSE, no README, and no MIT header** — it's an unlicensed mirror of proprietary code. (The only "MIT" string in it refers to a bundled third-party FPSMeter component.)

## Changes (docs/comments only — no behaviour change)

- **`docs/adr/0004-…md`**, **`docs/TODO.md`**, **`mruby-mvjs/mrblib/mz.rb`** header: remove the "MZ corescript is MIT / fetchable" claim. State that MZ has no committable/fetchable test bed and is developed/verified against a **user-supplied** MZ project — the same constraint the RPG2000/XP beds hit for their non-redistributable assets.
- **`changelog.d/mz-corescript-license-correction.changed.md`**.

## Verification

`mz.rb` is a comment-only edit; it still compiles (native build OK) and the MZ detection specs (`mruby-mvjs/test/mz_test.rb`) are unaffected. No `stak/rmmz` "MIT" claim remains except the corrected line noting the mirror carries no license.

## Note on forward M6 work

This changes the M6 plan: there's no fetchable MZ engine, so **M6.2 (host reuse) and M6.3 (WebGL backend) can only be verified against a user-supplied MZ project**, not a committed sample. Getting M6 further therefore needs either a WebGL-subset backend effort or an MZ project supplied out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_