### PR TITLE
rpg2k: headless auto-battle (Game::Battle) — battle path, step 2

### DIFF
--- a/changelog.d/rpg2k-headless-battle.added.md
+++ b/changelog.d/rpg2k-headless-battle.added.md
@@ -1,0 +1,13 @@
+- Enemy Encounters now **resolve an actual battle** instead of an automatic
+  win. A new `Game::Battle` runs a headless turn-based fight of the party
+  against the troop: battlers act in agility order (highest first), each striking
+  a random living opponent for `max(1, attack / 2 − defence / 4)` damage, until
+  one side is wiped — `:victory` when every enemy is down, `:defeat` when the
+  whole party is. `Scene::Map` runs it on Combatant snapshots, so a resolved
+  battle leaves the party's real HP untouched for now, and grants the troop's
+  EXP / gold only on a win. This is a deliberately simple first cut: no skills,
+  items, criticals, attributes, damage variance or escape, and the on-screen
+  turn-based battle (which would show and persist HP) plus game over on defeat
+  are still to come. Covered by new checks in `scripts/rpg2k_logic_check.rb`
+  (damage formula, stronger party wins / weaker loses, agility turn order) and
+  `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -220,10 +220,15 @@ The work below is roughly ordered by the critical path to a walkable game
   and the command decodes its troop id, escape / defeat modes and first-strike
   and routes the `[Victory]` / `[Escape]` / `[Defeat]` handler branches on the
   outcome (the "end event processing" escape mode abandons the event). The
-  interpreter suspends on a `:battle` wait; the turn-based battle screen is not
-  built, so `Scene::Map` resolves an encounter as an immediate victory granting
-  the troop's EXP and gold — a placeholder until the battle system lands.
-  The remaining commands (the battle system proper, EXP gain / level-up
+  interpreter suspends on a `:battle` wait, and `Scene::Map` resolves it by
+  running a **headless auto-battle** (`Game::Battle`): battlers act in agility
+  order, each striking a random living opponent for `max(1, atk/2 − def/4)`
+  damage until one side is wiped (`:victory` / `:defeat`), granting the troop's
+  EXP / gold on a win. It runs on Combatant snapshots, so the party's real HP is
+  untouched for now. Still to come: skills / items / criticals / attributes /
+  variance / escape in the sim, and the on-screen turn-based battle (showing and
+  persisting HP) with game over on defeat.
+  The remaining commands (EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`;

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2314,6 +2314,78 @@ module Game
     end
   end
 
+  # A headless auto-battle that decides an Enemy Encounter by the combatants'
+  # stats. Battlers act in agility order (highest first); each attacks a random
+  # living opponent for `attack_damage` and the fight runs to a result: :victory
+  # when every enemy is down, :defeat when the whole party is. It works on
+  # Combatant snapshots, so the caller can resolve a battle without mutating the
+  # real party. This is a deliberately simple first cut — no skills, items,
+  # criticals, attributes, damage variance or escape yet — the turn-based battle
+  # screen and those refinements are still to come.
+  class Battle
+    # A battler reduced to what the fight needs. Snapshotting Game::Actor /
+    # Game::Enemy keeps the real party untouched by a resolved battle.
+    Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp) do
+      def dead?; hp <= 0; end
+    end
+
+    def self.from_actor(a); Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp); end
+    def self.from_enemy(e); Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp); end
+
+    # RPG2000-style physical damage: half the attacker's attack less a quarter of
+    # the defender's defence, floored at 1 so a fight always terminates.
+    def self.attack_damage(atk, dfn)
+      d = atk / 2 - dfn / 4
+      d < 1 ? 1 : d
+    end
+
+    MAX_ROUNDS = 1000 # safety net against a stalemate (should never be reached)
+
+    attr_reader :allies, :enemies, :rounds, :result
+
+    def initialize(allies, enemies, rng = nil)
+      @allies = allies
+      @enemies = enemies
+      @rng = rng || Rng.new(0x2000)
+      @rounds = 0
+      @result = nil
+    end
+
+    # Run the fight to completion and return :victory or :defeat.
+    def run
+      while alive?(@allies) && alive?(@enemies)
+        @rounds += 1
+        break if @rounds > MAX_ROUNDS
+        turn_order.each do |b|
+          next if b.dead?
+          strike(b)
+          break unless alive?(@allies) && alive?(@enemies)
+        end
+      end
+      @result = alive?(@allies) ? :victory : :defeat
+    end
+
+    private
+
+    def alive?(side); side.any? { |b| !b.dead? }; end
+
+    # Battlers ordered by agility (highest first); ties keep their listed order.
+    def turn_order
+      (@allies + @enemies).each_with_index
+                          .sort_by { |b, i| [-b.agi, i] }.map { |b, _| b }
+    end
+
+    # `b` attacks a random living member of the opposing side.
+    def strike(b)
+      foes = (side_of(b) == :ally ? @enemies : @allies).reject(&:dead?)
+      return if foes.empty?
+      target = foes[@rng.random(foes.size)]
+      target.hp -= Battle.attack_damage(b.atk, target.def)
+    end
+
+    def side_of(b); @allies.any? { |a| a.equal?(b) } ? :ally : :enemy; end
+  end
+
   # Map weather set by the Weather Effects (11070) event command: a type (0 none,
   # 1 rain, 2 snow; the RPG2003 additions store as higher values) and a strength
   # (0 weak .. 2 strong). Like the picture / tint overlays this is the Ruby-half

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1623,23 +1623,30 @@ class RPG2k
         @shop = nil
       end
 
-      # -- Enemy Encounter (placeholder battle) -------------------------------
+      # -- Enemy Encounter (headless battle) ----------------------------------
 
-      # Resolve an Enemy Encounter. The turn-based battle screen is not built
-      # yet, so an encounter is treated as an immediate victory: the troop is
-      # instantiated from the database, its EXP is granted to every party member
-      # and its gold to the party, then the [Victory] handler runs. Escape /
-      # defeat outcomes, rewards drops and the battle UI are still to come.
+      # Resolve an Enemy Encounter by running a headless auto-battle (Game::Battle)
+      # of the party against the troop. On victory the troop's EXP is granted to
+      # every party member and its gold to the party, then the [Victory] handler
+      # runs; a defeat routes the [Defeat] handler. The battle works on snapshots,
+      # so the party's real HP is left untouched for now — the on-screen
+      # turn-based battle (that would show and persist HP) and game over on defeat
+      # are still to come.
       def drive_battle
         req = @interpreter.battle_request
         return @interpreter.resume_battle(:victory) unless req
         troop = Game::Troop.new(db, req[:troop_id])
-        exp = troop.total_exp
-        @state.party.actors.each { |a| a.gain_exp(exp) }
-        @state.party.gain_gold(troop.total_gold)
-        @interpreter.resume_battle(:victory)
+        allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
+        foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
+        result = Game::Battle.new(allies, foes, Game::Rng.new(0x2000)).run
+        if result == :victory
+          exp = troop.total_exp
+          @state.party.actors.each { |a| a.gain_exp(exp) }
+          @state.party.gain_gold(troop.total_gold)
+        end
+        @interpreter.resume_battle(result)
       rescue StandardError => e
-        $stderr.puts "[RPG2k] battle placeholder failed: #{e.message}"
+        $stderr.puts "[RPG2k] battle resolution failed: #{e.message}"
         @interpreter.resume_battle(:victory)
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2877,6 +2877,44 @@ check 'Enemy Encounter escape-abort mode ends the event' do
   ok !st.switches[5], 'the rest of the event is abandoned on an aborting escape'
 end
 
+# -- Battle (headless auto-battle) --------------------------------------------
+
+def combatant(name, atk, dfn, agi, hp)
+  Game::Battle::Combatant.new(name, atk, dfn, agi, hp, hp)
+end
+
+check 'Battle.attack_damage is half attack less a quarter defence, min 1' do
+  eq 18, Game::Battle.attack_damage(40, 8),  '20 - 2'
+  eq 1,  Game::Battle.attack_damage(2, 40),  'floored at 1'
+  eq 1,  Game::Battle.attack_damage(0, 0)
+end
+
+check 'Battle: a stronger party wins, a weaker one is defeated' do
+  hero = combatant('Hero', 40, 20, 20, 200)
+  slime = combatant('Slime', 8, 4, 5, 30)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  eq :victory, b.run
+  ok slime.dead?, 'the enemy was defeated'
+  ok !hero.dead?
+  ok hero.hp < 200, 'the hero took some damage on the way'
+
+  weak = combatant('Weak', 6, 2, 3, 10)
+  boss = combatant('Boss', 60, 30, 40, 500)
+  b2 = Game::Battle.new([weak], [boss], Game::Rng.new(1))
+  eq :defeat, b2.run
+  ok weak.dead?
+  ok !boss.dead?
+end
+
+check 'Battle: the fastest battler strikes first' do
+  # A fast glass cannon one-shots a slow foe before it ever acts.
+  fast = combatant('Fast', 100, 0, 99, 20)
+  slow = combatant('Slow', 100, 0, 1, 40) # 50 damage kills it in one hit
+  b = Game::Battle.new([fast], [slow], Game::Rng.new(1))
+  eq :victory, b.run
+  eq 20, fast.hp, 'the slow enemy never landed a hit'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -406,9 +406,13 @@ end
 # A party the placeholder battle grants rewards to: gold plus actors that bank
 # EXP, with the leader Scene::Map reads while rendering.
 class BattleStubActor
-  attr_accessor :exp
-  attr_reader :id
-  def initialize; @exp = 0; @id = 1; end
+  attr_accessor :exp, :hp
+  attr_reader :id, :name, :atk, :def, :agi, :max_hp
+  def initialize
+    @exp = 0; @id = 1; @name = 'Hero'
+    # Strong enough to beat the two-Slime troop the scene db defines.
+    @atk = 40; @def = 20; @agi = 20; @hp = 200; @max_hp = 200
+  end
   def gain_exp(n); @exp += n; end
 end
 
@@ -1261,7 +1265,7 @@ check 'Open Shop scene: leaving without buying runs the No Transaction branch' d
   ok st.switches[2], 'the No Transaction branch ran'
 end
 
-check 'Enemy Encounter scene: a placeholder victory grants rewards, runs Victory' do
+check 'Enemy Encounter scene: winning the battle grants rewards, runs Victory' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = [
@@ -1275,7 +1279,7 @@ check 'Enemy Encounter scene: a placeholder victory grants rewards, runs Victory
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  5.times { scene.update } # the encounter auto-resolves to victory
+  5.times { scene.update } # the headless battle runs; the strong party wins
   eq 20, st.party.gold, 'gained the troop gold (2 Slimes x 10)'
   eq 10, st.party.actors.first.exp, 'gained the troop EXP (2 Slimes x 5)'
   ok st.switches[1], 'the Victory handler ran'


### PR DESCRIPTION
Step 2 of the battle path (after #210's Enemy Encounter + troop model): resolve an encounter by running an **actual fight** instead of an automatic win.

## Game::Battle
A headless turn-based auto-battle of the party against the troop:
- Battlers act in **agility order** (highest first).
- Each strikes a random living opponent for **`max(1, atk/2 − def/4)`** damage.
- Runs until one side is wiped → **`:victory`** (all enemies down) or **`:defeat`** (whole party down).
- Operates on `Combatant` **snapshots** (`Battle.from_actor` / `from_enemy`), so a resolved battle leaves the party's real HP untouched.

`Scene::Map`'s Enemy Encounter handler now runs `Game::Battle` and grants the troop's EXP / gold only on a win; the outcome routes the `[Victory]` / `[Defeat]` handler branches as before. So encounters now depend on the combatants' stats — a strong party wins, a weak one loses.

## Deliberately a first cut
No skills / items / criticals / attributes / damage variance / escape in the sim yet, and the **on-screen turn-based battle** (showing and persisting HP) plus **game over on defeat** are still to come. The formula and turn model are the foundation those build on.

## Testing
- `scripts/rpg2k_logic_check.rb` — **197 pass** (new: damage formula incl. the min-1 floor, stronger party wins / weaker is defeated, agility turn order lets a fast attacker strike first)
- `scripts/rpg2k_scene_check.rb` — **62 pass** (winning the battle grants rewards and runs the Victory handler)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_