### PR TITLE
MZ: correct load order + map the concrete M6 boot-path gaps

### DIFF
--- a/changelog.d/mz-load-order-and-boot-gaps.fixed.md
+++ b/changelog.d/mz-load-order-and-boot-gaps.fixed.md
@@ -1,0 +1,10 @@
+- MZ (M6) foundation: corrected the `MZ::CORE_SCRIPTS` load order against the
+  real engine's `main.js` — the Vorbis decoder is `js/libs/vorbisdecoder.js`,
+  not `js/libs/vorbis.js` (guarded by a new spec in `mruby-mvjs/test/mz_test.rb`
+  that also asserts no MV-only libs leak in). Documented the concrete,
+  source-verified M6 boot-path gaps in ADR 0004 and `docs/TODO.md`: MZ's
+  `main.js` is a dynamic `<script>`-injection loader (not MV's `window.onload`),
+  it initialises an Effekseer WASM runtime before `Scene_Boot` (needs a WASM
+  shim or a no-op stub), and the WebGL wall is precisely
+  `SceneManager.run` → `Utils.canUseWebGL()` throwing without a real
+  `getContext("webgl")` — turning "M6 needs WebGL" into an ordered work list.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -566,6 +566,13 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     reach `Scene_Boot` in logic. Note there is **no fetchable MZ test bed** —
     MZ's engine ships only with the paid editor (no open-source release like
     MV's MIT `rpgtkoolmv`), so MZ is verified against a user-supplied project,
-    not a committed/downloaded sample.
+    not a committed/downloaded sample. Reading the real engine, the ordered
+    boot-path gaps before pixels are: (1) MZ's `main.js` is a dynamic
+    `<script>`-injection loader (not MV's `window.onload`), so the host must
+    drive the load sequence itself; (2) it inits the **Effekseer WASM**
+    runtime before `Scene_Boot` (needs a WASM shim or a no-op `effekseer`
+    stub); then M6.3.
   - 🚧 M6.3 WebGL rendering: the WebGL-subset backend behind PIXI v5 (the bulk
-    of the work — MZ dropped the Canvas2D renderer the MV bridge targets).
+    of the work — MZ dropped the Canvas2D renderer the MV bridge targets). The
+    exact gate is `SceneManager.run` → `Utils.canUseWebGL()` throwing unless
+    `canvas.getContext("webgl")` returns a real (LVGL-backed) context.

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -141,6 +141,27 @@ JavaScript loads and interprets the JSON.
   - **M6.3 — WebGL rendering.** The WebGL-subset backend behind PIXI v5, the
     bulk of the work — MZ dropped the Canvas2D renderer the MV bridge targets.
 
+  **Concrete boot-path gaps (read off the real MZ engine).** MZ's boot differs
+  from MV's in more than the renderer; the host-integration work, in the order
+  the engine hits it, is:
+  1. **Script loading.** MV registers `window.onload` and the host evals
+     `CORE_SCRIPTS` then fires it. MZ's `main.js` is itself the loader: it
+     appends the other scripts as `<script>` elements and waits for their
+     `onload`. The host reuse (M6.2) must drive that sequence directly rather
+     than eval `main.js`, since our shim does not fetch+execute injected
+     `<script>` tags.
+  2. **Effekseer WASM runtime.** Before `Scene_Boot`, `main.js` calls
+     `effekseer.initRuntime("js/libs/effekseer.wasm", …)` and only proceeds on
+     its callback. The quickjs host has no WebAssembly, so this needs either a
+     WASM shim or a stubbed `effekseer` runtime whose `initRuntime` invokes the
+     success callback (Effekseer only drives battle animations, so a no-op
+     stub is enough to boot).
+  3. **The WebGL wall.** `SceneManager.run` starts with
+     `if (!Utils.canUseWebGL()) throw new Error("… does not support WebGL")`
+     (`rmmz_managers.js`), and PIXI v5 has no Canvas2D fallback. This is M6.3:
+     `canvas.getContext("webgl")` must return a real (LVGL-backed) context —
+     the host deliberately keeps it `null` today so MV's PIXI v4 uses Canvas.
+
 [rpgtkoolmv]: https://github.com/rpgtkoolmv/corescript
 
 ## Consequences

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -32,18 +32,25 @@ class MZ
   # instead, so the two never collide.
   REQUIRED_MARKERS = ["js/rmmz_core.js", "data/System.json"].freeze
 
-  # The MZ engine scripts, in the order the stock `index.html` loads them: the
-  # vendored libraries first (PIXI v5, then pako for save compression,
-  # localforage for storage, and Effekseer for animations), then the engine
-  # modules, then the game's plugin list and entry point. As on the MV side the
-  # runtime prefers the game's own `index.html` when present and only falls back
-  # to this list, so it need only be the canonical default.
+  # The MZ engine scripts, in the order they load: the vendored libraries first
+  # (PIXI v5, then pako for save compression, localforage for storage, Effekseer
+  # for animations, and the Vorbis decoder), then the engine modules, then the
+  # game's plugin list and entry point. Verified against the real engine's
+  # `main.js` `scriptUrls` (the exact filenames — e.g. `vorbisdecoder.js`, not
+  # `vorbis.js`). As on the MV side the runtime prefers the game's own
+  # `index.html` when present and only falls back to this list.
+  #
+  # NB: MZ's boot entry differs from MV's. MV registers `window.onload`; MZ's
+  # `main.js` is itself the loader — it injects the other scripts as `<script>`
+  # elements and, once they load, initialises the Effekseer WASM runtime and
+  # calls `SceneManager.run(Scene_Boot)`. So the host reuse (M6.2) cannot simply
+  # eval `main.js`; it must drive that sequence itself (see ADR 0004 M6).
   CORE_SCRIPTS = [
     "js/libs/pixi.js",
     "js/libs/pako.min.js",
     "js/libs/localforage.min.js",
     "js/libs/effekseer.min.js",
-    "js/libs/vorbis.js",
+    "js/libs/vorbisdecoder.js",
     "js/rmmz_core.js",
     "js/rmmz_managers.js",
     "js/rmmz_objects.js",

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -41,6 +41,20 @@ assert 'MZ.core_scripts evaluates main.js last' do
   assert_equal "js/main.js", MZ.core_scripts.last
 end
 
+assert 'MZ.core_scripts uses the real MZ library filenames' do
+  scripts = MZ.core_scripts
+  # These are the exact names from the engine's main.js scriptUrls / libs dir —
+  # note vorbisdecoder.js (not vorbis.js), and MZ's pako/localforage/effekseer
+  # rather than MV's lz-string.
+  %w[
+    js/libs/pixi.js js/libs/pako.min.js js/libs/localforage.min.js
+    js/libs/effekseer.min.js js/libs/vorbisdecoder.js
+  ].each { |lib| assert_true scripts.include?(lib) }
+  # MV-only libraries must not leak into the MZ list.
+  assert_false scripts.include?("js/libs/lz-string.js")
+  assert_false scripts.include?("js/libs/vorbis.js")
+end
+
 assert 'MZ.core_scripts keeps the MZ engine module order' do
   scripts = MZ.core_scripts
   order = %w[


### PR DESCRIPTION
## Summary

Read the real RPG Maker MZ engine (`main.js` + `rmmz_managers.js`) and used it to sharpen the M6 foundation — a small code fix plus a precise, source-verified scope for the remaining work.

## Changes

- **Fix `MZ::CORE_SCRIPTS`** (`mruby-mvjs/mrblib/mz.rb`): the Vorbis library is `js/libs/vorbisdecoder.js`, **not** `js/libs/vorbis.js` — verified against `main.js`'s `scriptUrls` and the engine's `libs/` dir. A new spec in `mruby-mvjs/test/mz_test.rb` pins the real library filenames and asserts no MV-only libs (`lz-string`, the wrong vorbis name) leak in.
- **Map the concrete boot-path gaps** in ADR 0004 and `docs/TODO.md`, turning "M6 needs WebGL" into an ordered work list read off the engine:
  1. MZ's `main.js` is a **dynamic `<script>`-injection loader** (not MV's `window.onload`), so the host reuse (M6.2) must drive the load sequence itself rather than eval `main.js`.
  2. `main.js` initialises an **Effekseer WASM runtime** before `Scene_Boot` — the quickjs host has no WebAssembly, so this needs a WASM shim or a no-op `effekseer` stub whose `initRuntime` fires its success callback (Effekseer only drives battle animations).
  3. The **WebGL wall** is precisely `SceneManager.run` → `Utils.canUseWebGL()` throwing unless `canvas.getContext("webgl")` returns a real (LVGL-backed) context; PIXI v5 has no Canvas2D fallback.
- Note in `mz.rb` that MZ's boot entry differs from MV's.
- **`changelog.d/…`**.

## Verification

Native build OK; `mruby_test` (including the updated MZ specs) passes. This is a one-line constant fix + docs; the findings come from reading the actual (proprietary, not committed) MZ engine locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_