### PR TITLE
rpg2k: turn-stepped battle model + combat log (battle path, step 3)

### DIFF
--- a/changelog.d/rpg2k-battle-stepped-log.added.md
+++ b/changelog.d/rpg2k-battle-stepped-log.added.md
@@ -1,0 +1,9 @@
+- `Game::Battle` is now **turn-stepped and logged**, the substrate the on-screen
+  battle will animate. `#step` performs one battler's action at a time — living
+  battlers act in agility order, a new round refills the queue — and appends a
+  `#log` entry (`attacker`, `target`, `damage`, `target_hp`, `defeated`); `#run`
+  steps to completion for the headless resolution as before, and `#finished?`
+  reports when a side is wiped. Until the battle screen exists, `Scene::Map`
+  traces a resolved encounter blow-by-blow to the console from the log. Covered
+  by new checks in `scripts/rpg2k_logic_check.rb` (step-by-step advance + log
+  entries, `run` records every hit).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -221,13 +221,17 @@ The work below is roughly ordered by the critical path to a walkable game
   and routes the `[Victory]` / `[Escape]` / `[Defeat]` handler branches on the
   outcome (the "end event processing" escape mode abandons the event). The
   interpreter suspends on a `:battle` wait, and `Scene::Map` resolves it by
-  running a **headless auto-battle** (`Game::Battle`): battlers act in agility
+  running a **turn-stepped auto-battle** (`Game::Battle`): battlers act in agility
   order, each striking a random living opponent for `max(1, atk/2 − def/4)`
   damage until one side is wiped (`:victory` / `:defeat`), granting the troop's
-  EXP / gold on a win. It runs on Combatant snapshots, so the party's real HP is
-  untouched for now. Still to come: skills / items / criticals / attributes /
-  variance / escape in the sim, and the on-screen turn-based battle (showing and
-  persisting HP) with game over on defeat.
+  EXP / gold on a win. `#step` performs one action at a time and appends a `#log`
+  entry (attacker / target / damage / defeated), so an on-screen battle can
+  animate it action-by-action; `#run` steps to completion for the headless
+  resolution. It runs on Combatant snapshots, so the party's real HP is untouched
+  for now, and until the battle screen exists `Scene::Map` traces the fight to
+  the console from the log. Still to come: skills / items / criticals /
+  attributes / variance / escape in the sim, and the on-screen turn-based battle
+  (showing and persisting HP, with the command menu) plus game over on defeat.
   The remaining commands (EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2343,14 +2343,16 @@ module Game
     end
   end
 
-  # A headless auto-battle that decides an Enemy Encounter by the combatants'
+  # A turn-stepped auto-battle that decides an Enemy Encounter by the combatants'
   # stats. Battlers act in agility order (highest first); each attacks a random
-  # living opponent for `attack_damage` and the fight runs to a result: :victory
-  # when every enemy is down, :defeat when the whole party is. It works on
-  # Combatant snapshots, so the caller can resolve a battle without mutating the
-  # real party. This is a deliberately simple first cut — no skills, items,
-  # criticals, attributes, damage variance or escape yet — the turn-based battle
-  # screen and those refinements are still to come.
+  # living opponent for `attack_damage`, and the fight resolves to :victory when
+  # every enemy is down or :defeat when the whole party is. `#step` performs one
+  # action at a time and appends a `#log` entry, so an on-screen battle can
+  # animate it action-by-action; `#run` steps to completion for a headless
+  # resolution. It works on Combatant snapshots, so the caller can resolve a
+  # battle without mutating the real party. This is a deliberately simple first
+  # cut — no skills, items, criticals, attributes, damage variance or escape yet
+  # — the turn-based battle *screen* and those refinements are still to come.
   class Battle
     # A battler reduced to what the fight needs. Snapshotting Game::Actor /
     # Game::Enemy keeps the real party untouched by a resolved battle.
@@ -2370,7 +2372,7 @@ module Game
 
     MAX_ROUNDS = 1000 # safety net against a stalemate (should never be reached)
 
-    attr_reader :allies, :enemies, :rounds, :result
+    attr_reader :allies, :enemies, :rounds, :result, :log
 
     def initialize(allies, enemies, rng = nil)
       @allies = allies
@@ -2378,19 +2380,33 @@ module Game
       @rng = rng || Rng.new(0x2000)
       @rounds = 0
       @result = nil
+      @log = []      # one entry per landed attack, in order (see #strike)
+      @queue = []    # battlers still to act this round, in agility order
     end
 
-    # Run the fight to completion and return :victory or :defeat.
-    def run
-      while alive?(@allies) && alive?(@enemies)
-        @rounds += 1
-        break if @rounds > MAX_ROUNDS
-        turn_order.each do |b|
-          next if b.dead?
-          strike(b)
-          break unless alive?(@allies) && alive?(@enemies)
-        end
+    # True once one side has been wiped out (the battle is decided).
+    def finished?; !alive?(@allies) || !alive?(@enemies); end
+
+    # Perform the next single action and return its log entry, or nil when the
+    # battle is already decided (or has hit the round cap). Living battlers act
+    # in agility order; a new round refills the queue.
+    def step
+      loop do
+        return nil if finished?
+        refill_queue if @queue.empty?
+        return nil if @queue.empty? # hit MAX_ROUNDS
+        b = @queue.shift
+        next if b.dead?
+        entry = strike(b)
+        next unless entry # attacker had no living target; try the next
+        @log << entry
+        return entry
       end
+    end
+
+    # Step the fight to completion and return :victory or :defeat.
+    def run
+      step until finished? || @rounds > MAX_ROUNDS
       @result = alive?(@allies) ? :victory : :defeat
     end
 
@@ -2398,18 +2414,27 @@ module Game
 
     def alive?(side); side.any? { |b| !b.dead? }; end
 
+    def refill_queue
+      @rounds += 1
+      @queue = turn_order unless @rounds > MAX_ROUNDS
+    end
+
     # Battlers ordered by agility (highest first); ties keep their listed order.
     def turn_order
       (@allies + @enemies).each_with_index
                           .sort_by { |b, i| [-b.agi, i] }.map { |b, _| b }
     end
 
-    # `b` attacks a random living member of the opposing side.
+    # `b` attacks a random living member of the opposing side, returning a log
+    # entry (or nil when its side has no living target left).
     def strike(b)
       foes = (side_of(b) == :ally ? @enemies : @allies).reject(&:dead?)
-      return if foes.empty?
+      return nil if foes.empty?
       target = foes[@rng.random(foes.size)]
-      target.hp -= Battle.attack_damage(b.atk, target.def)
+      dmg = Battle.attack_damage(b.atk, target.def)
+      target.hp -= dmg
+      { attacker: b.name, target: target.name, damage: dmg,
+        target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead? }
     end
 
     def side_of(b); @allies.any? { |a| a.equal?(b) } ? :ally : :enemy; end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1638,7 +1638,9 @@ class RPG2k
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
         foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
-        result = Game::Battle.new(allies, foes, Game::Rng.new(0x2000)).run
+        battle = Game::Battle.new(allies, foes, Game::Rng.new(0x2000))
+        result = battle.run
+        log_battle(battle, result) # until the battle screen lands, trace it to the console
         if result == :victory
           exp = troop.total_exp
           @state.party.actors.each { |a| a.gain_exp(exp) }
@@ -1648,6 +1650,17 @@ class RPG2k
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle resolution failed: #{e.message}"
         @interpreter.resume_battle(:victory)
+      end
+
+      # Trace a resolved battle blow-by-blow to the console — a stand-in for the
+      # on-screen battle log until the battle screen exists.
+      def log_battle(battle, result)
+        battle.log.each do |e|
+          line = "#{e[:attacker]} hits #{e[:target]} for #{e[:damage]}"
+          line += " — defeated!" if e[:defeated]
+          $stderr.puts "[RPG2k battle] #{line}"
+        end
+        $stderr.puts "[RPG2k battle] #{result}"
       end
 
       def drive_wait

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2941,6 +2941,34 @@ check 'Battle: the fastest battler strikes first' do
   eq 20, fast.hp, 'the slow enemy never landed a hit'
 end
 
+check 'Battle#step performs one action at a time and logs it' do
+  hero = combatant('Hero', 40, 20, 20, 200)
+  slime = combatant('Slime', 8, 4, 5, 30)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  ok !b.finished?
+  first = b.step
+  ok first, 'a step returns its log entry'
+  eq 1, b.log.length
+  # Hero (agility 20) acts before the Slime (5): 40/2 - 4/4 = 19 damage.
+  eq 'Hero', first[:attacker]
+  eq 'Slime', first[:target]
+  eq 19, first[:damage]
+  eq 11, first[:target_hp]
+  ok !first[:defeated]
+  b.step until b.finished?
+  ok slime.dead?
+  ok b.log.last[:defeated], 'the final logged hit downed the enemy'
+  eq nil, b.step, 'stepping a decided battle yields nothing'
+end
+
+check 'Battle#run records a combat log of every hit' do
+  b = Game::Battle.new([combatant('Hero', 40, 20, 20, 200)],
+                       [combatant('Slime', 8, 4, 5, 30)], Game::Rng.new(1))
+  eq :victory, b.run
+  ok b.log.length >= 2, 'the Slime took at least two hits'
+  ok b.log.all? { |e| e[:damage] >= 1 }, 'every hit did at least 1 damage'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
Step 3 of the battle path (after #216's headless auto-battle): make `Game::Battle` **turn-stepped and observable**, the substrate the on-screen battle will animate action-by-action.

## What changed
- **`#step`** — performs one battler's action at a time. Living battlers act in agility order; a new round refills the queue. Returns (and appends to `#log`) an entry: `attacker`, `target`, `damage`, `target_hp`, `defeated`.
- **`#finished?`** — true once a side is wiped.
- **`#run`** — steps to completion and returns `:victory` / `:defeat`, exactly as before (the merged headless resolution is unchanged; it just builds the log on the way).
- **`Scene::Map`** — until the battle *screen* exists, traces a resolved encounter blow-by-blow to the console from the log, so battles are observable (a stand-in battle log).

This is the observable-model foundation an on-screen battle needs (something to animate turn-by-turn); the actual battle UI + player command menu build on it next.

## Testing
- `scripts/rpg2k_logic_check.rb` — **201 pass** (new: `#step` advances one action and logs it with exact damage/target-HP, ordering, and stops when decided; `#run` records every hit)
- `scripts/rpg2k_scene_check.rb` — **62 pass** (unchanged — `run()` outcome preserved)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_