### PR TITLE
mruby-rgss: render RGSS::Sprite#mirror natively

### DIFF
--- a/changelog.d/rpgxp-rgss-sprite-mirror-native.added.md
+++ b/changelog.d/rpgxp-rgss-sprite-mirror-native.added.md
@@ -1,0 +1,10 @@
+- **`RGSS::Sprite#mirror` is now rendered.** `Sprite#mirror=` is native: LVGL's
+  `lv_image` has no flip, so it re-binds the sprite's canvas to a
+  horizontally-flipped scratch copy of the bitmap (a per-sprite `Bitmap` held on
+  the sprite so the GC keeps it alive) — so `sprite.mirror = true` actually
+  flips the sprite instead of being stored-but-ignored. The flip is a snapshot,
+  so a sprite that redraws its bitmap contents while mirrored must re-assign
+  `bitmap=` to refresh. Completes the LVGL-mappable Sprite transforms (after
+  opacity, zoom and angle); the introduced scratch-buffer machinery is what the
+  remaining tone/color/src_rect pre-composite will extend. See
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -37,7 +37,7 @@ These are complete enough for the stock scripts:
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
-### 1. `Sprite` extended properties ⚠️ (opacity + zoom + angle rendered; rest stored)
+### 1. `Sprite` extended properties ⚠️ (opacity + zoom + angle + mirror rendered; rest stored)
 
 `mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,
 `visible`/`visible=`, `dispose`, `update`, and stores the extra properties the
@@ -52,11 +52,13 @@ alpha by it, so fades actually fade); `Sprite#zoom_x=`/`zoom_y=` set the image's
 scale (`lv_image_set_scale_x/y`, where 256 = 1.0), so the sprite scales;
 `Sprite#angle=` sets the image's rotation (`lv_image_set_rotation`, converting
 RGSS's counter-clockwise degrees to LVGL's clockwise 0.1° units, pivoting on the
-sprite's `ox`/`oy` origin). **Remaining:** **mirror** — LVGL's `lv_image` has no
-flip, so it needs a software horizontal-flip pass; and
-**tone/color/src_rect/bush_depth** → a software pre-composite through the existing
-`bmp_blt`/`bmp_stretch_blt` blend loops. Both share the same scratch-buffer
-machinery and are the next slices. `Sprite_Character`, `Sprite_Battler`,
+sprite's `ox`/`oy` origin); `Sprite#mirror=` re-binds the canvas to a
+horizontally-flipped scratch copy of the bitmap (LVGL's `lv_image` has no flip,
+so mirroring is a software pass — the flip is a snapshot, so a sprite that
+redraws its bitmap contents while mirrored must re-assign `bitmap=` to refresh).
+**Remaining:** **tone/color/src_rect/bush_depth** → a software pre-composite
+through the existing `bmp_blt`/`bmp_stretch_blt` blend loops (extending the same
+scratch-buffer machinery mirror introduced). That is the next slice. `Sprite_Character`, `Sprite_Battler`,
 `Arrow_Base`, weather and the animation player depend on these.
 
 ### 2. `Window` ⚠️ (stored; native frame/cursor render pending)

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -129,17 +129,17 @@ module RGSS
 
     # RGSS Sprite properties the stock scripts set — opacity fades, zoom, angle,
     # tone/colour, scroll origin, mirror, bush depth, blend mode, source rect.
-    # `opacity=`, `zoom_x=`, `zoom_y=` and `angle=` are now honoured natively
-    # (src/lib.cxx sets the sprite canvas's LVGL object opacity / image scale /
-    # image rotation); they still store their ivars here so the readers below
-    # return the set values. The rest are stored so `sprite.mirror = true` no
-    # longer raises, but the native renderer does not yet honour them visually
-    # (tracked in docs/rpgxp-rgss-api-gap.md). Readers fall back to RGSS's
-    # defaults because the native #initialize does not set these ivars (and cannot
-    # be wrapped from here without replacing it). `nil?` checks — not `||` — where
-    # 0/false is a meaningful value (opacity 0 = transparent).
-    attr_writer :ox, :oy, :mirror,
-                :bush_depth, :blend_type, :tone, :color, :src_rect
+    # `opacity=`, `zoom_x=`, `zoom_y=`, `angle=` and `mirror=` are now honoured
+    # natively (src/lib.cxx sets the sprite canvas's LVGL object opacity / image
+    # scale / image rotation, and mirror re-binds the canvas to a flipped copy);
+    # they still store their ivars here so the readers below return the set
+    # values. The rest are stored so `sprite.tone = t` no longer raises, but the
+    # native renderer does not yet honour them visually (tracked in
+    # docs/rpgxp-rgss-api-gap.md). Readers fall back to RGSS's defaults because
+    # the native #initialize does not set these ivars (and cannot be wrapped from
+    # here without replacing it). `nil?` checks — not `||` — where 0/false is a
+    # meaningful value (opacity 0 = transparent).
+    attr_writer :ox, :oy, :bush_depth, :blend_type, :tone, :color, :src_rect
 
     def opacity
       @opacity.nil? ? 255 : @opacity

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2187,18 +2187,55 @@ mrb_value spr_init(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// Point the sprite's canvas at the bitmap it should display: the assigned
+// bitmap directly, or — when the sprite is mirrored — a horizontally-flipped
+// scratch copy (LVGL's lv_image has no flip, so mirroring is a software pass).
+// The scratch Bitmap is kept in @_mirror_bitmap so it lives as long as the
+// sprite and is freed with it. The flip is a snapshot taken here; a sprite that
+// redraws its bitmap contents while mirrored must re-assign bitmap= (or set
+// mirror= again) to refresh it (tracked in docs/rpgxp-rgss-api-gap.md).
+void spr_bind_display(mrb_state* M, mrb_value self, lv_obj_t* obj) {
+  const mrb_value bmp_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@bitmap"));
+  if (mrb_nil_p(bmp_v))
+    return;
+  Bitmap& src = DataType<Bitmap>::get(M, bmp_v);
+  if (mrb_test(mrb_iv_get(M, self, mrb_intern_lit(M, "@mirror")))) {
+    RClass* bmp_class =
+        mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Bitmap");
+    const mrb_value flip_v =
+        DataType<Bitmap>::make(M, bmp_class, src.width, src.height, src.format);
+    Bitmap& flip = DataType<Bitmap>::get(M, flip_v);
+    const int px = lv_color_format_get_size(src.format);
+    const int w = src.width;
+    for (int y = 0; y < src.height; ++y) {
+      const uint8_t* srow = src.buffer.data() + static_cast<size_t>(y) * w * px;
+      uint8_t* drow = flip.buffer.data() + static_cast<size_t>(y) * w * px;
+      for (int x = 0; x < w; ++x)
+        std::memcpy(drow + static_cast<size_t>(x) * px,
+                    srow + static_cast<size_t>(w - 1 - x) * px, px);
+    }
+    flip.dirty = true;
+    // Hold the scratch bitmap on the sprite so the GC keeps it alive.
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@_mirror_bitmap"), flip_v);
+    lv_canvas_set_buffer(obj, flip.buffer.data(), src.width, src.height,
+                         src.format);
+  } else {
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@_mirror_bitmap"), mrb_nil_value());
+    lv_canvas_set_buffer(obj, src.buffer.data(), src.width, src.height,
+                         src.format);
+  }
+  // Repaint on the next Graphics.update, even if the contents were drawn before
+  // the bitmap was attached to this sprite.
+  src.dirty = true;
+}
+
 mrb_value spr_set_bmp(mrb_state* M, mrb_value self) {
-  Bitmap* p;
-  mrb_get_args(M, "d", &p, &DataType<Bitmap>::data_type);
-  V bmp;
+  mrb_value bmp;
   mrb_get_args(M, "o", &bmp);
   mrb_iv_set(M, self, mrb_intern_lit(M, "@bitmap"), bmp);
   lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
   mrb_assert(obj);
-  lv_canvas_set_buffer(obj, p->buffer.data(), p->width, p->height, p->format);
-  // Repaint the newly assigned bitmap on the next Graphics.update, even if its
-  // contents were drawn before it was attached to this sprite.
-  p->dirty = true;
+  spr_bind_display(M, self, obj);
   return bmp;
 }
 
@@ -2275,6 +2312,19 @@ mrb_value spr_set_angle(mrb_state* M, mrb_value self) {
       mrb_nil_p(oy) ? 0 : static_cast<int32_t>(mrb_as_int(M, oy)));
   lv_image_set_rotation(obj, static_cast<int32_t>(tenths));
   mrb_iv_set(M, self, mrb_intern_lit(M, "@angle"), mrb_float_value(M, deg));
+  return self;
+}
+
+// RGSS Sprite#mirror= (horizontal flip). LVGL's lv_image has no flip, so this
+// re-binds the canvas to a flipped scratch copy of the bitmap (or back to the
+// bitmap itself) via spr_bind_display.
+mrb_value spr_set_mirror(mrb_state* M, mrb_value self) {
+  mrb_bool m;
+  mrb_get_args(M, "b", &m);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@mirror"), mrb_bool_value(m));
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  spr_bind_display(M, self, obj);
   return self;
 }
 
@@ -2686,6 +2736,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "zoom_x=", spr_set_zoom_x, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "zoom_y=", spr_set_zoom_y, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "angle=", spr_set_angle, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "mirror=", spr_set_mirror, MRB_ARGS_REQ(1));
 
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -161,11 +161,11 @@ assert "RGSS::Viewport API surface" do
 end
 
 assert "RGSS::Sprite API surface" do
-  # opacity=/zoom_x=/zoom_y=/angle= are native (honoured by the LVGL compositor,
-  # src/lib.cxx); the rest are native too. Sprite.new needs a live display, so
-  # this only asserts the method surface — the compositing itself is exercised by
-  # the game runs.
-  %i[bitmap= x= y= z= visible visible= opacity= zoom_x= zoom_y= angle= dispose disposed?].each do |m|
+  # opacity=/zoom_x=/zoom_y=/angle=/mirror= are native (honoured by the LVGL
+  # compositor, src/lib.cxx); the rest are native too. Sprite.new needs a live
+  # display, so this only asserts the method surface — the compositing itself is
+  # exercised by the game runs.
+  %i[bitmap= x= y= z= visible visible= opacity= zoom_x= zoom_y= angle= mirror= dispose disposed?].each do |m|
     assert_true RGSS::Sprite.method_defined?(m), "Sprite##{m} missing"
   end
 end


### PR DESCRIPTION
## Summary

Fourth native Sprite-compositing pass (after `opacity` #208, `zoom` #211, `angle` #214). Completes the set of transforms LVGL can express for a sprite — but `mirror` needs a different mechanism than the others.

`Sprite#mirror` (horizontal flip) was held in a Ruby ivar; the renderer ignored it, so `sprite.mirror = true` did nothing.

## Change

LVGL v9's `lv_image` has **no flip API** and the generic negative-scale transform is off in this build (`LV_DRAW_TRANSFORM_USE_MATRIX` = 0), so mirroring is a **software pass**:

- **`mruby-rgss/src/lib.cxx`** — a shared `spr_bind_display` helper points the sprite's canvas at either the assigned bitmap, or — when mirrored — a **horizontally-flipped scratch copy** built with the existing `Bitmap` machinery (`DataType<Bitmap>::make` at the source's width/height/format, then a per-row reverse `memcpy`). The scratch is held in `@_mirror_bitmap` so the GC keeps it alive and frees it with the sprite. Both `bitmap=` and `mirror=` route through the helper, so assigning a bitmap to a mirrored sprite flips it too.
- **`mruby-rgss/mrblib/lib.rb`** — drop `:mirror` from the `attr_writer` list (native setter replaces it; the `def mirror` reader stays).

### Snapshot semantics (documented limitation)

The flip is a **snapshot** taken at `mirror=`/`bitmap=` time. A sprite that redraws its bitmap *contents* while mirrored must re-assign `bitmap=` to refresh the flip. This covers the dominant case (a static charset/battler bitmap toggled between facings); making it fully live would mean re-flipping in `Graphics.update` on the source's dirty flag — a follow-up. This scratch-buffer machinery is also the foundation the remaining `tone`/`color`/`src_rect` pre-composite will extend.

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0**. I ran the repo's clang-format locally against this file so the format hook passes (keeping to the nix-pinned style — my newer local clang-format only disagreed on two pre-existing template lines, which I left as master has them).
- **`mruby-rgss/test`** — `Sprite.new` needs a live display, so the Sprite surface test now also asserts `mirror=` is defined.
- **Same honest limitation:** no current game sets sprite mirror, so this is compile-verified but render-verified only once the RGSS script host boots an XP game.

## Remaining Sprite work

`tone`/`color`/`src_rect`/`bush_depth` → a software pre-composite through the existing `bmp_blt`/`bmp_stretch_blt` blend loops, extending the scratch-buffer machinery this PR introduces. After that, the `Window`/`Tilemap`/`Plane` native renderers.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #1 → ⚠️ (opacity + zoom + angle + mirror rendered; rest stored).
- Changelog fragment `changelog.d/rpgxp-rgss-sprite-mirror-native.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_