### PR TITLE
rpg2k: on-map battle result window (battle path, step 4)

### DIFF
--- a/changelog.d/rpg2k-battle-result-window.added.md
+++ b/changelog.d/rpg2k-battle-result-window.added.md
@@ -1,0 +1,10 @@
+- Winning or losing an Enemy Encounter now shows an on-map **battle result
+  window** before returning to the event. `Scene::Map` runs the battle, then
+  displays the outcome — `Victory!` with the EXP and gold gained, or `The party
+  was defeated...` — and waits for a confirm before resuming the interpreter (and
+  routing the `[Victory]` / `[Defeat]` handler branch). Rewards are still granted
+  only on a win. This is the first visible piece of the battle screen; the full
+  turn-based battle (party / enemy display, HP, the command menu and per-turn
+  animation from the combat log) is still to come. Covered by new checks in
+  `scripts/rpg2k_scene_check.rb` (a win shows the result then runs Victory; a
+  loss shows the defeat text, grants nothing and runs Defeat).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -228,10 +228,13 @@ The work below is roughly ordered by the critical path to a walkable game
   entry (attacker / target / damage / defeated), so an on-screen battle can
   animate it action-by-action; `#run` steps to completion for the headless
   resolution. It runs on Combatant snapshots, so the party's real HP is untouched
-  for now, and until the battle screen exists `Scene::Map` traces the fight to
-  the console from the log. Still to come: skills / items / criticals /
-  attributes / variance / escape in the sim, and the on-screen turn-based battle
-  (showing and persisting HP, with the command menu) plus game over on defeat.
+  for now, and `Scene::Map` traces the fight to the console from the log. After
+  the fight it shows an on-map **battle result window** (`Victory!` with EXP /
+  gold gained, or `The party was defeated...`), waiting for a confirm before
+  resuming and routing the `[Victory]` / `[Defeat]` branch. Still to come: skills
+  / items / criticals / attributes / variance / escape in the sim, and the full
+  on-screen turn-based battle (party / enemy display, HP, the command menu and
+  per-turn animation from the log) plus game over on defeat.
   The remaining commands (EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -389,6 +389,7 @@ class RPG2k
         @message = nil
         @inn_window = nil
         @shop = nil
+        @battle_seq = nil
         @wait_timer = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
@@ -421,6 +422,7 @@ class RPG2k
         close_message
         close_inn_window
         close_shop
+        close_battle
         [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
          @picture_sprite].each do |s|
           s.dispose if s
@@ -1635,21 +1637,81 @@ class RPG2k
       def drive_battle
         req = @interpreter.battle_request
         return @interpreter.resume_battle(:victory) unless req
+        @battle_seq = resolve_battle(req) if @battle_seq.nil?
+        if @battle_seq[:window].nil?
+          if @battle_seq[:shown]
+            result = @battle_seq[:result]
+            @battle_seq = nil
+            @interpreter.resume_battle(result)
+          else
+            open_battle_window(@battle_seq[:lines])
+            @battle_seq[:shown] = true
+          end
+          return
+        end
+        # The result window is up; any confirm / cancel dismisses it.
+        close_battle_window if Input.trigger?(Input::C) || Input.trigger?(Input::B)
+      end
+
+      # Run the headless battle, grant rewards on a win and build the result
+      # window's lines. Rewards are applied now (so the amounts can be shown); the
+      # interpreter is resumed later, once the player dismisses the window.
+      def resolve_battle(req)
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
         foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
         battle = Game::Battle.new(allies, foes, Game::Rng.new(0x2000))
         result = battle.run
-        log_battle(battle, result) # until the battle screen lands, trace it to the console
-        if result == :victory
-          exp = troop.total_exp
-          @state.party.actors.each { |a| a.gain_exp(exp) }
-          @state.party.gain_gold(troop.total_gold)
-        end
-        @interpreter.resume_battle(result)
+        log_battle(battle, result) # blow-by-blow trace to the console
+        lines = battle_result_lines(result, troop)
+        { lines: lines, result: result, window: nil, shown: false }
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle resolution failed: #{e.message}"
-        @interpreter.resume_battle(:victory)
+        { lines: ['Victory!'], result: :victory, window: nil, shown: false }
+      end
+
+      # The result window's text: the outcome, and on a win the EXP / gold gained
+      # (granted here). RPG2000 shows this after the fight before returning to the
+      # map.
+      def battle_result_lines(result, troop)
+        return ['The party was defeated...'] unless result == :victory
+        exp = troop.total_exp
+        gold = troop.total_gold
+        @state.party.actors.each { |a| a.gain_exp(exp) }
+        @state.party.gain_gold(gold)
+        lines = ['Victory!']
+        lines << "Gained #{exp} EXP." if exp > 0
+        lines << "Found #{gold} gold." if gold > 0
+        lines
+      end
+
+      BATTLE_LINE_H = 14
+
+      def open_battle_window(lines)
+        inner_w = SCREEN_W - 20 - Window::BORDER * 2
+        inner_h = lines.length * BATTLE_LINE_H
+        win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
+                         SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        win.z = 300
+        win.windowskin = @windowskin
+        c = Bitmap.new(inner_w, inner_h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        lines.each_with_index do |line, i|
+          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, line
+        end
+        win.contents = c
+        @battle_seq[:window] = win
+      end
+
+      def close_battle_window
+        return unless @battle_seq && @battle_seq[:window]
+        @battle_seq[:window].dispose
+        @battle_seq[:window] = nil
+      end
+
+      def close_battle
+        close_battle_window
+        @battle_seq = nil
       end
 
       # Trace a resolved battle blow-by-blow to the console — a stand-in for the

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -408,10 +408,11 @@ end
 class BattleStubActor
   attr_accessor :exp, :hp
   attr_reader :id, :name, :atk, :def, :agi, :max_hp
-  def initialize
+  # Defaults are strong enough to beat the two-Slime troop the scene db defines;
+  # a defeat test passes weaker stats.
+  def initialize(atk: 40, dfn: 20, agi: 20, hp: 200)
     @exp = 0; @id = 1; @name = 'Hero'
-    # Strong enough to beat the two-Slime troop the scene db defines.
-    @atk = 40; @def = 20; @agi = 20; @hp = 200; @max_hp = 200
+    @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
   end
   def gain_exp(n); @exp += n; end
 end
@@ -419,7 +420,7 @@ end
 class BattleStubParty
   attr_reader :actors, :gold
   attr_accessor :leader
-  def initialize; @actors = [BattleStubActor.new]; @gold = 0; @leader = nil; end
+  def initialize(actor = BattleStubActor.new); @actors = [actor]; @gold = 0; @leader = nil; end
   def gain_gold(n); @gold += n; end
 end
 
@@ -1279,11 +1280,44 @@ check 'Enemy Encounter scene: winning the battle grants rewards, runs Victory' d
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  5.times { scene.update } # the headless battle runs; the strong party wins
+  5.times { scene.update } # battle runs (strong party wins); result window opens
   eq 20, st.party.gold, 'gained the troop gold (2 Slimes x 10)'
   eq 10, st.party.actors.first.exp, 'gained the troop EXP (2 Slimes x 5)'
-  ok st.switches[1], 'the Victory handler ran'
+  ok !st.switches[1], 'still showing the Victory result window'
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the result window
+  scene.update
+  RGSS::Input.triggered = []
+  3.times { scene.update } # interpreter resumes -> runs the Victory handler
+  ok st.switches[1], 'the Victory handler ran after the result was dismissed'
   ok !st.switches[2], 'the Escape handler was skipped'
+end
+
+check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 1, 0], indent: 0),
+    ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::DEFEAT_HANDLER, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 3, 3, 0], indent: 1),
+    ECmd.new(ic::END_BATTLE, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  # A frail hero the two Slimes overwhelm.
+  st.instance_variable_set(:@party,
+                           BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
+  5.times { scene.update } # battle runs; the party loses; result window opens
+  ok !st.switches[1] && !st.switches[3], 'result window is up'
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  3.times { scene.update }
+  eq 0, st.party.gold, 'no gold on a loss'
+  eq 0, st.party.actors.first.exp, 'no EXP on a loss'
+  ok !st.switches[1], 'the Victory handler was skipped'
+  ok st.switches[3], 'the Defeat handler ran'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
Step 4 of the battle path (after #218's turn-stepped model): the first **visible** piece of the battle — a result window shown after an encounter resolves.

## What changed
After resolving an Enemy Encounter, `Scene::Map` now shows a battle result window before returning to the event:
- **Victory** — `Victory!`, plus the EXP and gold gained.
- **Defeat** — `The party was defeated...`

The interpreter stays suspended on the `:battle` wait until the player dismisses the window (confirm / cancel), then resumes and routes the `[Victory]` / `[Defeat]` handler branch as before. Rewards are granted only on a win. The blow-by-blow combat log still traces to the console.

This is the first on-screen piece of the battle. The full turn-based battle (party / enemy display, HP, the command menu and per-turn animation from the combat log) and game over on defeat are still ahead.

## Testing
- `scripts/rpg2k_logic_check.rb` — **206 pass** (unchanged battle logic)
- `scripts/rpg2k_scene_check.rb` — **63 pass** (new: a win shows the result then runs the Victory handler; a loss shows the defeat text, grants nothing and runs the Defeat handler)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_