### PR TITLE
mruby-rgss: native tiling render for RGSS::Plane

### DIFF
--- a/changelog.d/rpgxp-rgss-plane-native.added.md
+++ b/changelog.d/rpgxp-rgss-plane-native.added.md
@@ -1,0 +1,9 @@
+- **`RGSS::Plane` now tiles and scrolls natively.** `Plane` was a pure-Ruby
+  property holder; it is now native (`mruby-rgss/src/lib.cxx`): `Plane.new` builds
+  an `lv_canvas` the size of the viewport (or screen) and fills it by tiling the
+  assigned `bitmap` with the `ox`/`oy` scroll wrapped around it, so map parallax
+  and fog planes actually render and scroll instead of being stored-but-ignored.
+  `bitmap=`, `ox=`/`oy=`, `opacity=`, `z=`, `visible`, `dispose` are native;
+  `zoom`/`blend`/`tone`/`color` are still stored-only (the tile is a straight
+  copy). First of the `Window`/`Tilemap`/`Plane` native renderers. See
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -85,12 +85,18 @@ data/priorities, scroll it, and dispose it — without raising. **Remaining:** t
 native render — autotile assembly + priority layering (the RPG2000 side already
 implements a portable reference in `Game::ChipsetLayout`).
 
-### 4. `Plane` ⚠️ (stored; render pending)
+### 4. `Plane` ⚠️ (tiling + scroll rendered; zoom/blend/tone/colour stored)
 
-`Plane` is now a pure-Ruby property holder (`bitmap`, `ox`/`oy`, `opacity`,
-`visible`, `z`, `zoom_x`/`zoom_y`, `blend_type`, `tone`, `color`, `dispose`) with
-RGSS defaults, so scripts that create and drive a `Plane` run. **Remaining:** the
-native tiling, scrolling full-viewport blit (map parallax and fog).
+`Plane` is now **native** (`mruby-rgss/src/lib.cxx`): `Plane.new` creates an
+`lv_canvas` the size of the viewport (or screen) whose buffer is filled by tiling
+the `bitmap` with the `ox`/`oy` scroll wrapped around it (`plane_retile`), so map
+parallax and fog now actually tile and scroll. `bitmap=`, `ox=`/`oy=`,
+`opacity=`, `z=`, `visible`/`visible=`, `dispose`/`disposed?` are native; the
+canvas is invalidated directly on each re-tile. **Remaining:** `zoom_x`/`zoom_y`,
+`blend_type`, `tone` and `color` are stored but not yet applied to the tiled blit
+(the tile is a straight copy — no scale/blend/tint yet). The per-scroll re-tile is
+a full-canvas `bmp_read`/`bmp_put` pass; a dirty-rect or offset-based scroll is a
+possible optimization.
 
 ### 5. `Kernel#sprintf` / `String#%` ✅ (mruby-sprintf gem)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -90,36 +90,47 @@ module RGSS
   end
 
   # RGSS Plane: a tiling, scrolling full-viewport bitmap (map parallax / fog).
-  # Pure-Ruby property holder for now so the stock RGSS scripts that create and
-  # drive a Plane run; the native tiling render is future work (tracked in
-  # docs/rpgxp-rgss-api-gap.md).
+  # The tiling render is native (src/lib.cxx creates an lv_canvas the size of the
+  # viewport and fills it by tiling the bitmap with the ox/oy scroll — see
+  # plane_init/plane_retile); `initialize`, `bitmap=`, `ox=`, `oy=`, `opacity=`,
+  # `z=`, `visible`/`visible=`, `dispose`/`disposed?` are all native. This
+  # reopening adds the plain readers plus the properties the native renderer does
+  # not yet honour visually (zoom, blend mode, tone, colour) — stored so scripts
+  # that set them run (tracked in docs/rpgxp-rgss-api-gap.md).
   class Plane
-    attr_accessor :bitmap, :visible, :z, :ox, :oy, :opacity, :zoom_x, :zoom_y,
-                  :blend_type, :tone, :color
-    attr_reader :viewport
+    attr_reader :bitmap, :ox, :oy, :z, :viewport
+    attr_writer :zoom_x, :zoom_y, :blend_type
 
-    def initialize(viewport = nil)
-      @viewport = viewport
-      @bitmap = nil
-      @visible = true
-      @z = 0
-      @ox = 0
-      @oy = 0
-      @opacity = 255
-      @zoom_x = 1.0
-      @zoom_y = 1.0
-      @blend_type = 0
-      @tone = Tone.new(0, 0, 0, 0)
-      @color = Color.new(0, 0, 0, 0)
-      @disposed = false
+    def opacity
+      @opacity.nil? ? 255 : @opacity
     end
 
-    def dispose
-      @disposed = true
+    def zoom_x
+      @zoom_x.nil? ? 1.0 : @zoom_x
     end
 
-    def disposed?
-      @disposed
+    def zoom_y
+      @zoom_y.nil? ? 1.0 : @zoom_y
+    end
+
+    def blend_type
+      @blend_type || 0
+    end
+
+    def tone
+      @tone ||= Tone.new(0, 0, 0, 0)
+    end
+
+    def tone=(t)
+      @tone = t
+    end
+
+    def color
+      @color ||= Color.new(0, 0, 0, 0)
+    end
+
+    def color=(c)
+      @color = c
     end
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2376,6 +2376,120 @@ mrb_value obj_visible(mrb_state* M, mrb_value self) {
   return mrb_nil_p(v) ? mrb_true_value() : v;
 }
 
+// ---- Plane ----------------------------------------------------------------
+
+// Redraw the plane's canvas: fill it by tiling the source bitmap, wrapping the
+// ox/oy scroll around the bitmap's size. The canvas buffer is a scratch Bitmap
+// (@_plane_canvas) sized to the viewport; bmp_read/bmp_put bridge any source /
+// canvas format difference. The canvas is invalidated directly (its backing
+// buffer is not the sprite @bitmap that Graphics.update's dirty sweep watches).
+void plane_retile(mrb_state* M, mrb_value self) {
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  if (!obj)
+    return;
+  const mrb_value canvas_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@_plane_canvas"));
+  if (mrb_nil_p(canvas_v))
+    return;
+  Bitmap& dst = DataType<Bitmap>::get(M, canvas_v);
+  const mrb_value bmp_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@bitmap"));
+  if (mrb_nil_p(bmp_v)) {
+    std::fill(dst.buffer.begin(), dst.buffer.end(), static_cast<uint8_t>(0));
+    lv_obj_invalidate(obj);
+    return;
+  }
+  Bitmap& src = DataType<Bitmap>::get(M, bmp_v);
+  if (src.width <= 0 || src.height <= 0) {
+    std::fill(dst.buffer.begin(), dst.buffer.end(), static_cast<uint8_t>(0));
+    lv_obj_invalidate(obj);
+    return;
+  }
+  const mrb_int ox =
+      mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@ox")));
+  const mrb_int oy =
+      mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@oy")));
+  for (int y = 0; y < dst.height; ++y) {
+    const int sy =
+        static_cast<int>(((y + oy) % src.height + src.height) % src.height);
+    for (int x = 0; x < dst.width; ++x) {
+      const int sx =
+          static_cast<int>(((x + ox) % src.width + src.width) % src.width);
+      int r, g, b, a;
+      bmp_read(src, sx, sy, r, g, b, a);
+      bmp_put(dst, x, y, r, g, b, a);
+    }
+  }
+  lv_obj_invalidate(obj);
+}
+
+mrb_value plane_init(mrb_state* M, mrb_value self) {
+  mrb_value vp = mrb_nil_value();
+  mrb_get_args(M, "|o", &vp);
+
+  mrb_int w = 0, h = 0;
+  if (mrb_nil_p(vp)) {
+    lv_display_t* d = get_display(M);
+    w = lv_display_get_horizontal_resolution(d);
+    h = lv_display_get_vertical_resolution(d);
+  } else {
+    Rect& r =
+        DataType<Rect>::get(M, mrb_iv_get(M, vp, mrb_intern_lit(M, "@rect")));
+    w = r.width;
+    h = r.height;
+  }
+  if (w <= 0)
+    w = 1;
+  if (h <= 0)
+    h = 1;
+
+  lv_obj_t* c = lv_canvas_create(parent_object(M, vp));
+  wrap_lv_obj(M, self, c);
+  register_zobj(M, self);
+  lv_obj_set_pos(c, 0, 0);
+
+  RClass* bmp_class =
+      mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Bitmap");
+  const mrb_value canvas_v =
+      DataType<Bitmap>::make(M, bmp_class, w, h, LV_COLOR_FORMAT_ARGB8888);
+  Bitmap& canvas = DataType<Bitmap>::get(M, canvas_v);
+  std::fill(canvas.buffer.begin(), canvas.buffer.end(),
+            static_cast<uint8_t>(0));
+  lv_canvas_set_buffer(c, canvas.buffer.data(), w, h, LV_COLOR_FORMAT_ARGB8888);
+
+  // Hold the canvas buffer (a Bitmap) and the viewport on the plane so the GC
+  // keeps them alive for its lifetime.
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_plane_canvas"), canvas_v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@viewport"), vp);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@bitmap"), mrb_nil_value());
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(0));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(0));
+  return self;
+}
+
+mrb_value plane_set_bmp(mrb_state* M, mrb_value self) {
+  mrb_value bmp;
+  mrb_get_args(M, "o", &bmp);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@bitmap"), bmp);
+  plane_retile(M, self);
+  return bmp;
+}
+
+mrb_value plane_set_ox(mrb_state* M, mrb_value self) {
+  mrb_int ox;
+  mrb_get_args(M, "i", &ox);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(ox));
+  plane_retile(M, self);
+  return self;
+}
+
+mrb_value plane_set_oy(mrb_state* M, mrb_value self) {
+  mrb_int oy;
+  mrb_get_args(M, "i", &oy);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(oy));
+  plane_retile(M, self);
+  return self;
+}
+
 // ---- Viewport -------------------------------------------------------------
 
 // Build an RGSS::Rect value.
@@ -2737,6 +2851,19 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "zoom_y=", spr_set_zoom_y, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "angle=", spr_set_angle, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "mirror=", spr_set_mirror, MRB_ARGS_REQ(1));
+
+  RClass* plane = mrb_define_class_under(M, m, "Plane", M->object_class);
+  MRB_SET_INSTANCE_TT(plane, MRB_TT_DATA);
+  mrb_define_method(M, plane, "initialize", plane_init, MRB_ARGS_OPT(1));
+  mrb_define_method(M, plane, "bitmap=", plane_set_bmp, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "ox=", plane_set_ox, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "oy=", plane_set_oy, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "opacity=", spr_set_opacity, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "z=", obj_set_z, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "visible", obj_visible, MRB_ARGS_NONE());
+  mrb_define_method(M, plane, "visible=", obj_set_visible, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "dispose", obj_dispose, MRB_ARGS_NONE());
+  mrb_define_method(M, plane, "disposed?", obj_disposed, MRB_ARGS_NONE());
 
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -473,36 +473,14 @@ assert "RGSS::Bitmap loads a PNG whose deflate stream trips \"bad dist\"" do
   end
 end
 
-assert("RGSS::Plane property defaults and accessors") do
-  p = RGSS::Plane.new
-  # RGSS defaults.
-  assert_true p.visible
-  assert_equal 0, p.z
-  assert_equal 0, p.ox
-  assert_equal 0, p.oy
-  assert_equal 255, p.opacity
-  assert_equal 1.0, p.zoom_x
-  assert_equal 1.0, p.zoom_y
-  assert_equal 0, p.blend_type
-  assert_true p.bitmap.nil?
-  assert_true p.tone.is_a?(RGSS::Tone)
-  assert_true p.color.is_a?(RGSS::Color)
-  assert_false p.disposed?
-
-  # Writable.
-  p.ox = 12
-  p.oy = -4
-  p.opacity = 128
-  p.z = 5
-  p.visible = false
-  assert_equal 12, p.ox
-  assert_equal(-4, p.oy)
-  assert_equal 128, p.opacity
-  assert_equal 5, p.z
-  assert_false p.visible
-
-  p.dispose
-  assert_true p.disposed?
+assert "RGSS::Plane API surface" do
+  # Plane is now native: Plane.new builds an lv_canvas the size of the viewport
+  # and tiles the bitmap into it, so construction needs a live display the
+  # headless test binary lacks. Assert only the method surface here (the tiling
+  # itself is exercised by the game runs), matching the Viewport/Sprite tests.
+  %i[bitmap= ox= oy= opacity= z= visible visible= dispose disposed?].each do |m|
+    assert_true RGSS::Plane.method_defined?(m), "Plane##{m} missing"
+  end
 end
 
 assert("RGSS::Window property defaults and accessors") do


### PR DESCRIPTION
## Summary

First of the **`Window`/`Tilemap`/`Plane` native renderers** — the biggest remaining RGSS class-library work. Starts with `Plane` because it's the simplest (a single tiling canvas) and establishes the "pure-Ruby holder → native LVGL object" pattern the other two will follow.

`Plane` was a pure-Ruby property holder, so map parallax and fog were stored but never drawn.

## Change

- **`mruby-rgss/src/lib.cxx`** — make `Plane` a native LVGL-backed class:
  - `plane_init` creates an `lv_canvas` the size of the viewport (or the screen when there's no viewport), parented like a sprite (`parent_object`), and registered for z-ordering (`register_zobj`). Its buffer is a scratch `Bitmap` held on the plane so the GC keeps it alive.
  - `plane_retile` fills that buffer by **tiling** the assigned `bitmap`, wrapping the `ox`/`oy` scroll around the bitmap's size (`bmp_read`/`bmp_put` bridge any source↔canvas format difference), then invalidates the canvas **directly** — its backing buffer isn't the sprite `@bitmap` that `Graphics.update`'s dirty-sweep watches.
  - `bitmap=`, `ox=`/`oy=` re-tile; `opacity=`, `z=`, `visible`/`visible=`, `dispose`/`disposed?` reuse the shared obj helpers.
- **`mruby-rgss/mrblib/lib.rb`** — the `Plane` reopening keeps only the readers plus the still-unrendered properties (`zoom_x`/`zoom_y`, `blend_type`, `tone`, `color`) as stored-only, so scripts that set them still run.

## Scope / limitations (honest)

- The tile is a **straight copy** — `zoom`/`blend_type`/`tone`/`color` are stored but not yet applied. A follow-up slice.
- The per-scroll re-tile is a full-canvas `bmp_read`/`bmp_put` pass (correct, not yet optimized — a dirty-rect/offset scroll is possible later).

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0** (`lv_canvas_create`/`lv_canvas_set_buffer`/`lv_obj_set_pos`/`lv_obj_invalidate` are all confirmed v9 APIs, used the same way as the existing Sprite/Viewport code). I ran the repo's clang-format + whitespace/EOF hooks locally.
- **`mruby-rgss/test`** — `Plane.new` now needs a live display (it builds a canvas), so the Plane test becomes **surface-only**, matching the Viewport/Sprite tests (the previous test instantiated a Plane, which the headless `mrbtest` binary can no longer do).
- **No current game creates a `Plane`**, so this is compile-verified but render-verified only once the RGSS script host boots an XP game — zero regression risk to the existing RPG2000/MV runs.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #4 (`Plane`) → ⚠️ (tiling + scroll rendered; zoom/blend/tone/colour stored).
- Changelog fragment `changelog.d/rpgxp-rgss-plane-native.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_