### PR TITLE
mvjs: MZ host reuse (M6.2) — drive the engine to the WebGL wall

### DIFF
--- a/changelog.d/mz-host-reuse-boot-probe.added.md
+++ b/changelog.d/mz-host-reuse-boot-probe.added.md
@@ -1,0 +1,13 @@
+- MZ (M6.2): the RPG Maker MZ path now reuses the shared quickjs host to drive
+  the real `rmmz_*` engine up to the renderer boundary. `MZ#boot_probe` loads the
+  engine scripts (skipping MZ's `main.js` dynamic loader and the WASM-gated,
+  audio-only `vorbisdecoder.js`), installs the `HTMLVideoElement`/
+  `HTMLImageElement` host globals `rmmz_managers.js` requires, and runs
+  `SceneManager.run(Scene_Boot)`, which reaches exactly `Utils.canUseWebGL()`
+  in `rmmz_managers.js` and stops — proving everything up to WebGL works. The
+  pure logic (`MZ.runnable_scripts`, `MZ.host_globals_js`) is covered by host
+  specs; the full boot is verified against a user-supplied MZ project since MZ's
+  engine has no open-source release to commit. ADR 0004 and `docs/TODO.md` now
+  carry the measured boot map, correcting the earlier source-read guess that the
+  Effekseer WASM init blocked the boot (it does not — it lives in the bypassed
+  `main.js`).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -586,17 +586,23 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
     `rmmz_*` load order, and is wired into `src/main.cxx`'s maker sniff so an MZ
     game reports the pending WebGL backend cleanly instead of "no project
     found". Covered by `mruby-mvjs/test/mz_test.rb`.
-  - 🚧 M6.2 host reuse: run the `rmmz_*` scripts on the shared quickjs host to
-    reach `Scene_Boot` in logic. Note there is **no fetchable MZ test bed** —
-    MZ's engine ships only with the paid editor (no open-source release like
-    MV's MIT `rpgtkoolmv`), so MZ is verified against a user-supplied project,
-    not a committed/downloaded sample. Reading the real engine, the ordered
-    boot-path gaps before pixels are: (1) MZ's `main.js` is a dynamic
-    `<script>`-injection loader (not MV's `window.onload`), so the host must
-    drive the load sequence itself; (2) it inits the **Effekseer WASM**
-    runtime before `Scene_Boot` (needs a WASM shim or a no-op `effekseer`
-    stub); then M6.3.
+  - ✅ M6.2 host reuse (to the WebGL wall): `MZ#boot_probe`
+    (`mruby-mvjs/mrblib/mz.rb`) runs the `rmmz_*` scripts on the shared quickjs
+    host and calls `SceneManager.run(Scene_Boot)`, which reaches the renderer
+    boundary and stops — everything up to pixels works. There is **no fetchable
+    MZ test bed** (MZ's engine ships only with the paid editor, no open-source
+    release like MV's MIT `rpgtkoolmv`), so this path is verified against a
+    user-supplied project, not CI; the pure logic it leans on
+    (`MZ.runnable_scripts`, `MZ.host_globals_js`) is covered by
+    `mruby-mvjs/test/mz_test.rb`. The measured boot map (correcting the earlier
+    source-read guesses): PIXI v5.2.4 loads under quickjs; `rmmz_managers.js`
+    needs `HTMLVideoElement`/`HTMLImageElement` host globals (empty-constructor
+    stubs suffice); the Effekseer WASM init is **not** on the boot path (it
+    lives in the bypassed `main.js`, and `effekseer.min.js` loads without WASM),
+    so the only WASM-gated script is the audio-only `vorbisdecoder.js`, which is
+    skipped; the sole remaining blocker is WebGL (M6.3).
   - 🚧 M6.3 WebGL rendering: the WebGL-subset backend behind PIXI v5 (the bulk
     of the work — MZ dropped the Canvas2D renderer the MV bridge targets). The
-    exact gate is `SceneManager.run` → `Utils.canUseWebGL()` throwing unless
-    `canvas.getContext("webgl")` returns a real (LVGL-backed) context.
+    exact gate is `SceneManager.run` → `Utils.canUseWebGL()` throwing at
+    `rmmz_managers.js:1890` unless `canvas.getContext("webgl")` returns a real
+    (LVGL-backed) context.

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -127,40 +127,58 @@ JavaScript loads and interprets the JSON.
     sniff. When the binary is pointed at an MZ game it reports the pending
     WebGL backend cleanly instead of the "no project found" error. Covered by
     host specs (`mruby-mvjs/test/mz_test.rb`).
-  - **M6.2 — Host reuse.** Drive the shared quickjs host / host-globals / IO /
-    input / audio bridges (all maker-agnostic) with the `rmmz_*` scripts, so an
-    MZ game reaches `Scene_Boot` in logic (no pixels). Unlike MV, there is **no
-    committable/fetchable MZ test bed**: MV's corescript is an official
-    open-source project ([rpgtkoolmv], MIT, redistributed by KADOKAWA) that
-    `data/mv-sample` fetches, but MZ's engine ships only with the paid editor
-    (© Gotcha Gotcha Games / KADOKAWA) and has no equivalent open-source
-    release — the GitHub mirrors of it (e.g. `stak/rmmz-corescript`) carry no
-    license. So MZ is developed and verified against a **user-supplied** MZ
-    project, not a downloaded engine, the same constraint the RPG2000/XP beds
-    hit for their (also non-redistributable) game assets.
+  - **M6.2 — Host reuse (landed, to the WebGL wall).** Drive the shared quickjs
+    host / host-globals / IO / input / audio bridges (all maker-agnostic) with
+    the `rmmz_*` scripts. `MZ#boot_probe` (`mruby-mvjs/mrblib/mz.rb`) now loads
+    every engine script and calls `SceneManager.run(Scene_Boot)`, which reaches
+    exactly the WebGL guard below and stops there — everything up to the
+    renderer works. Unlike MV, there is **no committable/fetchable MZ test
+    bed**: MV's corescript is an official open-source project ([rpgtkoolmv],
+    MIT, redistributed by KADOKAWA) that `data/mv-sample` fetches, but MZ's
+    engine ships only with the paid editor (© Gotcha Gotcha Games / KADOKAWA)
+    and has no equivalent open-source release — the GitHub mirrors of it (e.g.
+    `stak/rmmz-corescript`) carry no license. So this path is developed and
+    verified against a **user-supplied** MZ project, not a downloaded engine
+    (the same constraint the RPG2000/XP beds hit for their non-redistributable
+    assets), and cannot run in CI; the pure logic it leans on
+    (`MZ.runnable_scripts`, `MZ.host_globals_js`) is covered by host specs
+    instead.
   - **M6.3 — WebGL rendering.** The WebGL-subset backend behind PIXI v5, the
     bulk of the work — MZ dropped the Canvas2D renderer the MV bridge targets.
 
-  **Concrete boot-path gaps (read off the real MZ engine).** MZ's boot differs
-  from MV's in more than the renderer; the host-integration work, in the order
-  the engine hits it, is:
-  1. **Script loading.** MV registers `window.onload` and the host evals
-     `CORE_SCRIPTS` then fires it. MZ's `main.js` is itself the loader: it
-     appends the other scripts as `<script>` elements and waits for their
-     `onload`. The host reuse (M6.2) must drive that sequence directly rather
-     than eval `main.js`, since our shim does not fetch+execute injected
-     `<script>` tags.
-  2. **Effekseer WASM runtime.** Before `Scene_Boot`, `main.js` calls
-     `effekseer.initRuntime("js/libs/effekseer.wasm", …)` and only proceeds on
-     its callback. The quickjs host has no WebAssembly, so this needs either a
-     WASM shim or a stubbed `effekseer` runtime whose `initRuntime` invokes the
-     success callback (Effekseer only drives battle animations, so a no-op
-     stub is enough to boot).
-  3. **The WebGL wall.** `SceneManager.run` starts with
-     `if (!Utils.canUseWebGL()) throw new Error("… does not support WebGL")`
-     (`rmmz_managers.js`), and PIXI v5 has no Canvas2D fallback. This is M6.3:
-     `canvas.getContext("webgl")` must return a real (LVGL-backed) context —
-     the host deliberately keeps it `null` today so MV's PIXI v4 uses Canvas.
+  **Concrete boot map (verified by running the engine on the host).** MZ's boot
+  differs from MV's in more than the renderer. Driving the shared host through a
+  real MZ project (`MZ#boot_probe`) turned the earlier source-read guesses into
+  a measured map — in the order the engine hits it:
+  1. **Script loading — solved by driving the order directly.** MV registers
+     `window.onload` and the host evals `CORE_SCRIPTS` then fires it. MZ's
+     `main.js` is itself the loader: it appends the other scripts as `<script>`
+     elements and waits for their `onload`. The host reuse evaluates
+     `MZ.runnable_scripts` (CORE_SCRIPTS minus `main.js`) in order instead of
+     eval'ing the loader, since our shim does not fetch+execute injected
+     `<script>` tags. PIXI v5.2.4 loads and runs fine under quickjs.
+  2. **Extra host globals.** `rmmz_managers.js` references `HTMLVideoElement`
+     and `HTMLImageElement` at module-load time and fails to define the module
+     if they are absent (MV's `rpg_*` never touch them). Empty-constructor
+     stubs (`MZ.host_globals_js`) get past module load — the host draws through
+     RGSS::Bitmap, not the DOM.
+  3. **Effekseer WASM — not on the boot path.** The earlier guess was that
+     `main.js` calls `effekseer.initRuntime(…)` and blocks `Scene_Boot` on it,
+     needing a WASM shim. Measured: because M6.2 bypasses `main.js`, that
+     `initRuntime` call is skipped entirely, and `effekseer.min.js` itself
+     loads without WebAssembly (the WASM is fetched lazily, only when an
+     animation plays). The one script that *does* need `WebAssembly` at load is
+     `js/libs/vorbisdecoder.js`; it is audio-only, so `MZ.runnable_scripts`
+     skips it and audio rides the shared RGSS::Audio bridge. No Effekseer stub
+     is required to reach a scene.
+  4. **The WebGL wall — the sole remaining blocker (M6.3).** With 1–3 handled,
+     `SceneManager.run(Scene_Boot)` reaches exactly
+     `if (!Utils.canUseWebGL()) throw …` at `rmmz_managers.js:1890` and throws
+     (caught by `SceneManager.catchException`); PIXI v5 has no Canvas2D
+     fallback. This is M6.3: `canvas.getContext("webgl")` must return a real
+     (LVGL-backed) context — the host deliberately keeps it `null` today so
+     MV's PIXI v4 uses Canvas. Nothing else stands between the host and a
+     rendered MZ frame.
 
 [rpgtkoolmv]: https://github.com/rpgtkoolmv/corescript
 

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -101,7 +101,8 @@ class MZ
     #     rides the shared RGSS::Audio bridge instead, so skipping it does not
     #     block reaching a scene.
     def runnable_scripts
-      CORE_SCRIPTS - ["js/main.js", "js/libs/vorbisdecoder.js"]
+      skip = ["js/main.js", "js/libs/vorbisdecoder.js"]
+      CORE_SCRIPTS.reject { |s| skip.include?(s) }
     end
 
     # The JS that installs MZ's extra host globals (see HOST_GLOBALS_JS).

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -18,10 +18,13 @@
 #      needs a WebGL-subset backend on LVGL, which is the bulk of milestone M6
 #      and is **not built yet**.
 #
-# So this class is the M6.1 foundation, mirroring MV's original M1: it recognises
-# an MZ project and knows the canonical script load order, and reports the
-# pending WebGL backend cleanly instead of misbehaving when the binary is pointed
-# at an MZ game. The host reuse (M6.2) and the WebGL renderer (M6.3) land later.
+# This class carries the M6.1 foundation (project detection + canonical script
+# load order) and the M6.2 host reuse: when pointed at an MZ game it now drives
+# the shared quickjs host through the real `rmmz_*` engine as far as it goes
+# without a renderer — loading every script, installing the extra host globals
+# MZ needs, and running `SceneManager.run(Scene_Boot)` up to the point PIXI v5
+# demands WebGL — then reports that precise boundary and the pending backend
+# cleanly. Only the WebGL-subset renderer (M6.3) is still missing.
 class MZ
   # RPG Maker MZ renders at 816x624 by default, same nominal canvas as MV.
   WIDTH = 816
@@ -44,7 +47,10 @@ class MZ
   # `main.js` is itself the loader — it injects the other scripts as `<script>`
   # elements and, once they load, initialises the Effekseer WASM runtime and
   # calls `SceneManager.run(Scene_Boot)`. So the host reuse (M6.2) cannot simply
-  # eval `main.js`; it must drive that sequence itself (see ADR 0004 M6).
+  # eval `main.js`; it drives the load sequence itself (see #boot_probe and
+  # `runnable_scripts`) and bypasses the Effekseer WASM init, which `main.js`
+  # would otherwise gate the boot on — Effekseer only draws battle animations,
+  # so skipping it does not block reaching a scene (see ADR 0004 M6.2).
   CORE_SCRIPTS = [
     "js/libs/pixi.js",
     "js/libs/pako.min.js",
@@ -61,10 +67,46 @@ class MZ
     "js/main.js",
   ].freeze
 
+  # The extra host globals MZ needs on top of MV's shims. `rmmz_managers.js`
+  # references `HTMLVideoElement` and `HTMLImageElement` at module-load time
+  # (its Graphics/Video setup) and the whole module fails to define if they are
+  # undefined; MV's `rpg_*` never touch them, so the shared host does not
+  # provide them. Empty constructors are enough to get past module load — the
+  # host draws through RGSS::Bitmap, not the DOM. Idempotent, so re-evaluating
+  # is harmless.
+  HOST_GLOBALS_JS =
+    "(function(g){ " \
+    "if (typeof g.HTMLVideoElement === 'undefined') " \
+    "g.HTMLVideoElement = function(){}; " \
+    "if (typeof g.HTMLImageElement === 'undefined') " \
+    "g.HTMLImageElement = function(){}; })(globalThis);".freeze
+
   class << self
     # The canonical MZ script load order (see CORE_SCRIPTS).
     def core_scripts
       CORE_SCRIPTS
+    end
+
+    # The subset of CORE_SCRIPTS the host reuse (M6.2) actually evaluates to
+    # drive the engine to a scene, in load order. Two entries are dropped from
+    # the browser's full list:
+    #
+    #   * `js/main.js` — MZ's entry point is itself a dynamic
+    #     `<script>`-injection loader; the host drives the load order directly
+    #     (see #boot_probe) rather than eval the loader, just as the MV side
+    #     bypasses the `<script>` tags `window.onload` would inject.
+    #   * `js/libs/vorbisdecoder.js` — gated on `WebAssembly`, which the quickjs
+    #     host does not provide, and used only to decode Ogg audio; evaluating
+    #     it throws `ReferenceError: WebAssembly is not defined`, and audio
+    #     rides the shared RGSS::Audio bridge instead, so skipping it does not
+    #     block reaching a scene.
+    def runnable_scripts
+      CORE_SCRIPTS - ["js/main.js", "js/libs/vorbisdecoder.js"]
+    end
+
+    # The JS that installs MZ's extra host globals (see HOST_GLOBALS_JS).
+    def host_globals_js
+      HOST_GLOBALS_JS
     end
 
     # Pure predicate: given the set of project-relative files that exist, is this
@@ -94,30 +136,99 @@ class MZ
 
   attr_reader :game_dir
 
-  # Native entry point. Until the WebGL backend lands (M6), this reports the
-  # pending state instead of failing hard, so the rest of the binary — and the
-  # other makers — are unaffected.
+  # Native entry point. The WebGL renderer (M6.3) is not built, so a full game
+  # cannot boot; but the M6.2 host reuse can still drive the shared host through
+  # the engine to the exact renderer boundary. Do that once to verify the host
+  # reuse and surface where it stops, then report the pending backend cleanly.
+  # The rest of the binary — and the other makers — are unaffected either way.
   def start
+    boundary = boot_probe
+    if boundary && !boundary.empty?
+      $stderr.puts "[MZ] host reuse reached the renderer boundary: " \
+                   "#{boundary.split("\n").first}"
+    end
+    warn_runtime_pending
+  rescue StandardError => e
+    $stderr.puts "[MZ] boot probe error: #{e.message}"
     warn_runtime_pending
   end
 
   # Per-frame entry point (Emscripten drives this directly, as for the other
-  # makers). A no-op beyond the pending notice until M6 lands.
+  # makers). A no-op beyond the pending notice until the renderer lands: without
+  # WebGL nothing can be presented, so there is no per-frame work to do.
   def main_loop
     warn_runtime_pending
   end
 
   private
 
+  # M6.2 host reuse: drive the shared quickjs host through the real MZ engine as
+  # far as it goes without a renderer, and return the exact boundary it stops
+  # at. This is *not* a playable boot — MZ's PIXI v5 is WebGL-only and the
+  # WebGL-subset backend (M6.3) is not built, so `SceneManager.run` reaches the
+  # `Utils.canUseWebGL()` guard in `rmmz_managers.js` and throws. Running to
+  # that precise wall — rather than guessing at it — is the M6.2 deliverable: it
+  # proves the engine scripts, the extra host globals, the IO bridge and the
+  # load order are all correct right up to the renderer.
+  #
+  # Returns the caught renderer-boundary error (a `Utils.canUseWebGL` throw when
+  # the engine is present), or an empty string when the engine scripts are
+  # absent (nothing to run) or it stops somewhere unexpected.
+  #
+  # There is no committable/fetchable MZ engine (© Gotcha Gotcha Games /
+  # KADOKAWA — see ADR 0004 M6.2), so this path is verified locally against a
+  # user-supplied MZ project rather than in CI; the pure logic it leans on
+  # (`runnable_scripts`, `host_globals_js`) is covered by host specs.
+  def boot_probe
+    return "" unless self.class.project?(@game_dir)
+
+    # MZ's own scripts request data/assets with game-relative paths; root them
+    # at the game dir since the process is not chdir'd into it (as MV does).
+    MV::JS.base_dir = @game_dir
+    MV::JS.eval(self.class.host_globals_js)
+
+    self.class.runnable_scripts.each do |script|
+      path = "#{@game_dir}/#{script}"
+      next unless File.exist?(path)
+      begin
+        MV::JS.eval_file(path)
+      rescue StandardError => e
+        # As in a browser, a script that throws while executing is logged and
+        # the next one still runs — one bad script never aborts the page.
+        $stderr.puts "[MZ] error loading #{script}: #{e.message}"
+      end
+    end
+
+    # SceneManager.run swallows a boot exception through catchException; replace
+    # it so the WebGL wall it hits is captured instead of vanishing, then run.
+    MV::JS.eval(
+      "if (typeof SceneManager !== 'undefined') { SceneManager.__mzErr = null; " \
+      "SceneManager.catchException = function(e){ SceneManager.__mzErr = " \
+      "(e && (e.stack || e.message)) || String(e); }; }"
+    )
+    MV::JS.eval(
+      "(function(){ if (typeof SceneManager === 'undefined' || " \
+      "typeof Scene_Boot === 'undefined') return; try { " \
+      "SceneManager.run(Scene_Boot); } catch(e){ SceneManager.__mzErr = " \
+      "(e && (e.stack || e.message)) || String(e); } })();"
+    )
+    MV::JS.eval(
+      "(function(){ return (typeof SceneManager !== 'undefined' && " \
+      "SceneManager.__mzErr) ? SceneManager.__mzErr : ''; })();"
+    )
+  end
+
   # Report the pending runtime once. Emscripten drives main_loop every frame, so
   # without the guard this would print on each one.
   def warn_runtime_pending
     return if @warned_runtime_pending
     @warned_runtime_pending = true
-    $stderr.puts "[MZ] RPG Maker MZ support is under construction: MZ ships " \
-                 "PIXI v5 (WebGL-only), and the WebGL-subset backend it needs " \
-                 "is not built into this binary yet. The engine/host/IO/input/" \
-                 "audio layers are shared with MV; only the renderer is " \
-                 "missing. See docs/adr/0004-javascript-maker-mv-quickjs.md (M6)."
+    $stderr.puts "[MZ] RPG Maker MZ support is under construction: the engine " \
+                 "now loads on the shared host (M6.2), but MZ ships PIXI v5 " \
+                 "(WebGL-only) and the WebGL-subset backend it needs (M6.3) is " \
+                 "not built into this binary yet, so no frame can render. The " \
+                 "engine/host/IO/input/audio layers are shared with MV; only " \
+                 "the renderer is missing. See " \
+                 "docs/adr/0004-javascript-maker-mv-quickjs.md (M6)."
   end
 end

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -66,6 +66,31 @@ assert 'MZ.core_scripts keeps the MZ engine module order' do
   assert_equal indices, indices.sort
 end
 
+assert 'MZ.runnable_scripts drops the loader and the WASM-gated decoder' do
+  scripts = MZ.runnable_scripts
+  # The host drives the load order itself, so MZ's dynamic <script>-injection
+  # loader is never evaluated...
+  assert_false scripts.include?("js/main.js")
+  # ...and the Vorbis decoder needs WebAssembly (absent from the quickjs host)
+  # and is audio-only, so it is skipped rather than throwing at load.
+  assert_false scripts.include?("js/libs/vorbisdecoder.js")
+  # Everything else is kept, in the same order as CORE_SCRIPTS.
+  expected = MZ.core_scripts - ["js/main.js", "js/libs/vorbisdecoder.js"]
+  assert_equal expected, scripts
+  # The engine core and PIXI must survive the filtering.
+  assert_true scripts.include?("js/rmmz_core.js")
+  assert_true scripts.include?("js/libs/pixi.js")
+end
+
+assert 'MZ.host_globals_js defines the DOM globals rmmz_managers needs' do
+  js = MZ.host_globals_js
+  # rmmz_managers.js aborts its module if these are undefined; the shim must
+  # define both, and guard so re-evaluating does not clobber a real one.
+  assert_true js.include?("HTMLVideoElement")
+  assert_true js.include?("HTMLImageElement")
+  assert_true js.include?("=== 'undefined'")
+end
+
 assert 'MZ.runtime_available? is false until the WebGL backend lands' do
   assert_false MZ.runtime_available?
 end

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -75,7 +75,8 @@ assert 'MZ.runnable_scripts drops the loader and the WASM-gated decoder' do
   # and is audio-only, so it is skipped rather than throwing at load.
   assert_false scripts.include?("js/libs/vorbisdecoder.js")
   # Everything else is kept, in the same order as CORE_SCRIPTS.
-  expected = MZ.core_scripts - ["js/main.js", "js/libs/vorbisdecoder.js"]
+  skip = ["js/main.js", "js/libs/vorbisdecoder.js"]
+  expected = MZ.core_scripts.reject { |s| skip.include?(s) }
   assert_equal expected, scripts
   # The engine core and PIXI must survive the filtering.
   assert_true scripts.include?("js/rmmz_core.js")


### PR DESCRIPTION
## What

Advances RPG Maker **MZ** support from the M6.1 foundation to **M6.2 host reuse**: when the binary is pointed at an MZ project it now drives the shared quickjs host through the *real* `rmmz_*` engine as far as it goes without a renderer, and reports the exact point it stops.

`MZ#boot_probe` (`mruby-mvjs/mrblib/mz.rb`):
1. Roots asset IO at the game dir and installs the extra host globals MZ needs — `HTMLVideoElement`/`HTMLImageElement`, which `rmmz_managers.js` references at module-load time (MV's `rpg_*` never touch them). Empty constructors suffice; the host draws through `RGSS::Bitmap`, not the DOM.
2. Evals `MZ.runnable_scripts` in load order — `CORE_SCRIPTS` minus `js/main.js` (MZ's dynamic `<script>`-injection loader, which the host replaces by driving the order itself) and `js/libs/vorbisdecoder.js` (gated on `WebAssembly`, which the quickjs host lacks, and audio-only, so it is skipped — audio rides the shared `RGSS::Audio` bridge).
3. Runs `SceneManager.run(Scene_Boot)`, capturing the exception `SceneManager.catchException` swallows.

The engine reaches **exactly** `if (!Utils.canUseWebGL()) throw …` at `rmmz_managers.js:1890` and stops — proving the engine scripts, host globals, IO and load order are all correct right up to the renderer. WebGL (M6.3) is the sole remaining blocker to a scene.

`MZ#start` runs the probe once, logs the boundary, then reports the pending backend cleanly (`runtime_available?` stays `false` — nothing can render yet).

## Correcting the earlier boot-path guess

The previous ADR/TODO notes were read off the engine source and guessed that `main.js`'s **Effekseer WASM `initRuntime`** would block `Scene_Boot` and need a WASM shim or `effekseer` stub. Running the engine on the host showed that is **wrong**: because M6.2 bypasses `main.js`, that `initRuntime` call is skipped entirely, and `effekseer.min.js` itself loads fine without WebAssembly (the WASM is fetched lazily, only when an animation plays). No Effekseer stub is needed to reach a scene. ADR 0004 and `docs/TODO.md` now carry the **measured** boot map instead of the guess.

## Verification

- **Host specs** (`mruby-mvjs/test/mz_test.rb`, run in CI via `mruby_test`): new specs cover `MZ.runnable_scripts` (drops the loader + WASM decoder, keeps order/engine/PIXI) and `MZ.host_globals_js` (defines both DOM globals, guarded so re-eval is safe).
- **Full boot**: verified locally against a user-supplied MZ project. There is **no committable/fetchable MZ test bed** — MZ's engine ships only with the paid editor (© Gotcha Gotcha Games / KADOKAWA) with no open-source release like MV's MIT `rpgtkoolmv`, and its GitHub mirrors carry no license. So the native boot path is intentionally **not exercised in CI**; only the pure logic it leans on is. This is the same non-redistributable-assets constraint the RPG2000/XP beds already hit.

## Files

- `mruby-mvjs/mrblib/mz.rb` — `runnable_scripts` / `host_globals_js` helpers + `boot_probe`, wired into `start`.
- `mruby-mvjs/test/mz_test.rb` — host specs for the new helpers.
- `docs/adr/0004-javascript-maker-mv-quickjs.md`, `docs/TODO.md` — M6.2 marked landed-to-the-WebGL-wall; measured boot map replaces the source-read guess.
- `changelog.d/mz-host-reuse-boot-probe.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_