### PR TITLE
rpg2k: battle screen skeleton — status + Fight/Flee (battle path, step 5)

### DIFF
--- a/changelog.d/rpg2k-battle-screen-skeleton.added.md
+++ b/changelog.d/rpg2k-battle-screen-skeleton.added.md
@@ -1,0 +1,12 @@
+- Enemy Encounters now open a **battle screen** on the map (the skeleton of the
+  turn-based battle). It shows a status panel — the enemy troop and each party
+  member's HP — over a **Fight / Flee** command menu. Choosing *Fight* resolves
+  the battle (via `Game::Battle`) and shows the result (Victory with EXP / gold,
+  or defeat); *Flee* escapes when the encounter allows it. Dismissing the result
+  resumes the event with the outcome, routing the `[Victory]` / `[Escape]` /
+  `[Defeat]` handler branch as before. `Scene::Map` drives it during the
+  `:battle` wait, the same way it drives the shop and inn. Still to come: the
+  per-actor command menu (Attack / Skill / Item / Defend + targeting), per-turn
+  animation from the combat log, enemy / battler sprites, and game over on
+  defeat. Covered by updated / new checks in `scripts/rpg2k_scene_check.rb`
+  (Fight → win / lose, and Flee → escape).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -240,13 +240,16 @@ The work below is roughly ordered by the critical path to a walkable game
   entry (attacker / target / damage / defeated), so an on-screen battle can
   animate it action-by-action; `#run` steps to completion for the headless
   resolution. It runs on Combatant snapshots, so the party's real HP is untouched
-  for now, and `Scene::Map` traces the fight to the console from the log. After
-  the fight it shows an on-map **battle result window** (`Victory!` with EXP /
-  gold gained, or `The party was defeated...`), waiting for a confirm before
-  resuming and routing the `[Victory]` / `[Defeat]` branch. Still to come: skills
-  / items / criticals / attributes / variance / escape in the sim, and the full
-  on-screen turn-based battle (party / enemy display, HP, the command menu and
-  per-turn animation from the log) plus game over on defeat.
+  for now, and `Scene::Map` traces the fight to the console from the log.
+  Encounters now open a **battle screen** (driven by `Scene::Map` during the
+  `:battle` wait, like the shop / inn): a status panel of the troop and each
+  party member's HP over a **Fight / Flee** command menu. Fight resolves the
+  battle and shows the result (`Victory!` with EXP / gold, or defeat); Flee
+  escapes when allowed; dismissing the result resumes the event and routes the
+  `[Victory]` / `[Escape]` / `[Defeat]` branch. Still to come: skills / items /
+  criticals / attributes / variance in the sim, the per-actor command menu
+  (Attack / Skill / Item / Defend + targeting) and per-turn animation from the
+  log, enemy / battler sprites, and game over on defeat.
   The remaining commands (EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -469,7 +469,7 @@ class RPG2k
         @message = nil
         @inn_window = nil
         @shop = nil
-        @battle_seq = nil
+        @battle_ui = nil
         @wait_timer = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
@@ -1717,40 +1717,76 @@ class RPG2k
       # so the party's real HP is left untouched for now — the on-screen
       # turn-based battle (that would show and persist HP) and game over on defeat
       # are still to come.
+      # Drive the battle screen the map shows during a :battle wait. It opens on
+      # a Fight / Flee command menu over a party / enemy status display; choosing
+      # Fight resolves the (headless) battle and shows the result, Flee escapes
+      # when allowed. Dismissing the result resumes the interpreter with the
+      # outcome. The per-turn animation (stepping Game::Battle#log on screen) is a
+      # later stage; for now Fight resolves the fight at once.
       def drive_battle
         req = @interpreter.battle_request
         return @interpreter.resume_battle(:victory) unless req
-        @battle_seq = resolve_battle(req) if @battle_seq.nil?
-        if @battle_seq[:window].nil?
-          if @battle_seq[:shown]
-            result = @battle_seq[:result]
-            @battle_seq = nil
-            @interpreter.resume_battle(result)
-          else
-            open_battle_window(@battle_seq[:lines])
-            @battle_seq[:shown] = true
-          end
+        if @battle_ui.nil?
+          open_battle(req) # opened this frame; take input from the next one
           return
         end
-        # The result window is up; any confirm / cancel dismisses it.
-        close_battle_window if Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        @battle_ui[:phase] == :command ? drive_battle_command : drive_battle_result
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle failed: #{e.message}"
+        close_battle
+        @interpreter.resume_battle(:victory)
       end
 
-      # Run the headless battle, grant rewards on a win and build the result
-      # window's lines. Rewards are applied now (so the amounts can be shown); the
-      # interpreter is resumed later, once the player dismisses the window.
-      def resolve_battle(req)
+      def open_battle(req)
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
         foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
-        battle = Game::Battle.new(allies, foes, Game::Rng.new(0x2000))
+        commands = ['Fight']
+        commands << 'Flee' if req[:allow_escape]
+        @battle_ui = { phase: :command, req: req, troop: troop,
+                       battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000)),
+                       allies: allies, foes: foes, commands: commands, cmd: 0,
+                       status_win: build_battle_status(allies, foes),
+                       cmd_win: nil, result_win: nil, result: nil }
+        draw_battle_command
+      end
+
+      def drive_battle_command
+        cmds = @battle_ui[:commands]
+        if Input.trigger?(Input::DOWN) && @battle_ui[:cmd] < cmds.length - 1
+          @battle_ui[:cmd] += 1
+          draw_battle_command
+        elsif Input.trigger?(Input::UP) && @battle_ui[:cmd] > 0
+          @battle_ui[:cmd] -= 1
+          draw_battle_command
+        elsif Input.trigger?(Input::C)
+          cmds[@battle_ui[:cmd]] == 'Flee' ? finish_battle(:escape) : battle_fight
+        end
+      end
+
+      # Resolve the fight, grant rewards on a win, and switch to the result
+      # window (the status / command windows come down).
+      def battle_fight
+        battle = @battle_ui[:battle]
         result = battle.run
-        log_battle(battle, result) # blow-by-blow trace to the console
-        lines = battle_result_lines(result, troop)
-        { lines: lines, result: result, window: nil, shown: false }
-      rescue StandardError => e
-        $stderr.puts "[RPG2k] battle resolution failed: #{e.message}"
-        { lines: ['Victory!'], result: :victory, window: nil, shown: false }
+        log_battle(battle, result)
+        lines = battle_result_lines(result, @battle_ui[:troop])
+        @battle_ui[:result] = result
+        [@battle_ui[:status_win], @battle_ui[:cmd_win]].each { |w| w.dispose if w }
+        @battle_ui[:status_win] = nil
+        @battle_ui[:cmd_win] = nil
+        open_battle_result(lines)
+        @battle_ui[:phase] = :result
+      end
+
+      def drive_battle_result
+        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        finish_battle(@battle_ui[:result])
+      end
+
+      def finish_battle(result)
+        close_battle
+        @interpreter.resume_battle(result)
       end
 
       # The result window's text: the outcome, and on a win the EXP / gold gained
@@ -1770,12 +1806,47 @@ class RPG2k
 
       BATTLE_LINE_H = 14
 
-      def open_battle_window(lines)
-        inner_w = SCREEN_W - 20 - Window::BORDER * 2
-        inner_h = lines.length * BATTLE_LINE_H
+      # A full-width panel near the top listing the enemy troop, then each party
+      # member with their HP — the battle's status display.
+      def build_battle_status(allies, foes)
+        lines = foes.map(&:name)
+        lines += allies.map { |a| "#{a.name}  HP #{a.hp}/#{a.max_hp}" }
+        battle_text_window(lines, 6, 300)
+      end
+
+      # The Fight / Flee command menu, a small panel at the bottom with a cursor.
+      def draw_battle_command
+        cmds = @battle_ui[:commands]
+        @battle_ui[:cmd_win].dispose if @battle_ui[:cmd_win]
+        w = 88
+        inner_h = cmds.length * BATTLE_LINE_H
         win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
-                         SCREEN_W - 20, inner_h + Window::BORDER * 2)
-        win.z = 300
+                         w, inner_h + Window::BORDER * 2)
+        win.z = 320
+        win.windowskin = @windowskin
+        c = Bitmap.new(w - Window::BORDER * 2, inner_h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        cmds.each_with_index do |label, i|
+          c.draw_text 0, i * BATTLE_LINE_H, c.width, BATTLE_LINE_H, label
+        end
+        win.contents = c
+        win.cursor_rect =
+          Rect.new(0, @battle_ui[:cmd] * BATTLE_LINE_H, c.width, BATTLE_LINE_H)
+        @battle_ui[:cmd_win] = win
+      end
+
+      def open_battle_result(lines)
+        @battle_ui[:result_win] =
+          battle_text_window(lines, SCREEN_H - lines.length * BATTLE_LINE_H -
+                                    Window::BORDER * 2 - 6, 320)
+      end
+
+      # A full-width text panel of `lines` at vertical position `y` and depth `z`.
+      def battle_text_window(lines, y, z)
+        inner_w = SCREEN_W - 20 - Window::BORDER * 2
+        inner_h = [lines.length, 1].max * BATTLE_LINE_H
+        win = Window.new(10, y, SCREEN_W - 20, inner_h + Window::BORDER * 2)
+        win.z = z
         win.windowskin = @windowskin
         c = Bitmap.new(inner_w, inner_h)
         c.font.color = Color.new(255, 255, 255, 255)
@@ -1783,18 +1854,14 @@ class RPG2k
           c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, line
         end
         win.contents = c
-        @battle_seq[:window] = win
-      end
-
-      def close_battle_window
-        return unless @battle_seq && @battle_seq[:window]
-        @battle_seq[:window].dispose
-        @battle_seq[:window] = nil
+        win
       end
 
       def close_battle
-        close_battle_window
-        @battle_seq = nil
+        return unless @battle_ui
+        [@battle_ui[:status_win], @battle_ui[:cmd_win],
+         @battle_ui[:result_win]].each { |w| w.dispose if w }
+        @battle_ui = nil
       end
 
       # Trace a resolved battle blow-by-blow to the console — a stand-in for the

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1306,11 +1306,16 @@ check 'Enemy Encounter scene: winning the battle grants rewards, runs Victory' d
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  5.times { scene.update } # battle runs (strong party wins); result window opens
+  3.times { scene.update } # the battle UI opens on the Fight command menu
+  eq 0, st.party.gold, 'no rewards until the fight is resolved'
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Fight
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update # battle resolves (strong party wins); rewards + result window
   eq 20, st.party.gold, 'gained the troop gold (2 Slimes x 10)'
   eq 10, st.party.actors.first.exp, 'gained the troop EXP (2 Slimes x 5)'
-  ok !st.switches[1], 'still showing the Victory result window'
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the result window
+  ok !st.switches[1], 'showing the Victory result'
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the result
   scene.update
   RGSS::Input.triggered = []
   3.times { scene.update } # interpreter resumes -> runs the Victory handler
@@ -1334,9 +1339,13 @@ check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   # A frail hero the two Slimes overwhelm.
   st.instance_variable_set(:@party,
                            BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
-  5.times { scene.update } # battle runs; the party loses; result window opens
+  3.times { scene.update } # command menu opens
+  RGSS::Input.triggered = [RGSS::Input::C] # Fight
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update # the party loses; defeat result window opens
   ok !st.switches[1] && !st.switches[3], 'result window is up'
-  RGSS::Input.triggered = [RGSS::Input::C]
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss
   scene.update
   RGSS::Input.triggered = []
   3.times { scene.update }
@@ -1344,6 +1353,34 @@ check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   eq 0, st.party.actors.first.exp, 'no EXP on a loss'
   ok !st.switches[1], 'the Victory handler was skipped'
   ok st.switches[3], 'the Defeat handler ran'
+end
+
+check 'Enemy Encounter scene: Flee escapes when allowed, runs Escape' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 2, 1, 0], indent: 0), # escape mode 2 (custom)
+    ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::ESCAPE_HANDLER, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::END_BATTLE, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  3.times { scene.update } # command menu offers Fight / Flee
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # cursor to Flee
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # Flee -> escape
+  scene.update
+  RGSS::Input.triggered = []
+  3.times { scene.update } # interpreter resumes -> Escape handler
+  eq 0, st.party.gold, 'fleeing grants nothing'
+  ok !st.switches[1], 'the Victory handler was skipped'
+  ok st.switches[2], 'the Escape handler ran'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
Step 5 of the battle path (option 1, staged): the **battle screen skeleton**. Encounters now open a battle UI instead of only a result window.

## What changed
`Scene::Map` drives a battle screen during the `:battle` wait — the same pattern as the shop and inn (no scene-stack push, so it stays testable in the host harness):

- A **status panel** shows the enemy troop and each party member's HP.
- A **Fight / Flee** command menu (Flee only appears when the encounter allows escape).
- **Fight** resolves the battle via `Game::Battle`, then shows the result (Victory with EXP/gold, or a defeat message).
- **Flee** escapes when allowed.
- Dismissing the result resumes the interpreter with the outcome, routing the `[Victory]` / `[Escape]` / `[Defeat]` handler branch as before.

## Staged — what's next
This is the skeleton. Still ahead: the per-actor command menu (Attack / Skill / Item / Defend + targeting), per-turn animation from the combat log (`Game::Battle#step`/`#log` is ready for it), enemy/battler sprites, and game over on defeat.

## Testing
- `scripts/rpg2k_scene_check.rb` — **65 pass** (Fight → win grants rewards + runs Victory; Fight → loss shows defeat, grants nothing, runs Defeat; Flee → runs the Escape handler)
- `scripts/rpg2k_logic_check.rb` — **206 pass** (battle logic unchanged)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_