### PR TITLE
Add a per-actor model to the RPG Maker XP runtime

### DIFF
--- a/changelog.d/rpgxp-actor-model.added.md
+++ b/changelog.d/rpgxp-actor-model.added.md
@@ -1,0 +1,16 @@
+- RPG Maker **XP**: a per-actor runtime model. `RPGXP::Game::Actor` wraps each
+  `RPG::Actor` database record and its `RPG::Class`, deriving the actor's
+  level-based stats straight from its `parameters` table (max HP/SP, str, dex,
+  agi, int), its known skills from the class's learnings up to the current level,
+  and its equipment from the actor's default weapon and four armor slots.
+  `Game::State#actor(id)` memoises one live actor per id (the way RMXP's
+  `$game_actors[id]` does), so future Change-Actor commands have a place to mutate
+  state. The model immediately powers the full **actor Conditional Branch** (type
+  4): *is in the party*, *name is*, *skill learned*, *weapon equipped* and *armor
+  equipped* — previously only "is in the party" was evaluated and the rest
+  silently took the true branch, so conditions gated on a learned skill or worn
+  equipment now behave correctly. Matched to RMXP's `command_111`. Covered by new
+  `mruby-rpgxp/test` unit tests (the model plus the conditional branches) and by
+  `scripts/rpgxp_testbed_check.rb`, which now builds a `Game::Actor` for every
+  actor in the real OpenGame.exe XP test bed and checks the derived state
+  resolves. The Change-Actor commands that mutate this model are a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -441,18 +441,27 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   a variable amount, the Conditional Branch **item / weapon / armor** possession
   tests (types 8/9/10) run, and Control Variables can read an **item count** as
   its operand. *Change Party Member* (129) adds/removes actors from the party,
-  the **actor "is in the party"** conditional (type 4) is evaluated, and Control
-  Variables also reads the **"other" game quantities** — map id, party size and
-  gold (operand type 7). **Battle Processing** (301) navigates its result
+  and Control Variables also reads the **"other" game quantities** — map id,
+  party size and gold (operand type 7). A **per-actor model** (`Game::Actor`)
+  now wraps each `RPG::Actor` record and its class: level-derived stats read
+  straight from the actor's `parameters` table (max HP/SP, str/dex/agi/int), the
+  known skills from the class's learnings up to the current level, and the
+  equipment from the actor's weapon / four armor slots; `State#actor(id)`
+  memoises one live actor per id (like RMXP's `$game_actors`). It powers the full
+  **actor Conditional Branch** (type 4): *is in the party* (0), *name is* (1),
+  *skill learned* (2), *weapon equipped* (3) and *armor equipped* (4), matched to
+  RMXP's `command_111`. **Battle Processing** (301) navigates its result
   branches — If Win (601), If Escape (602), If Lose (603), branch end (604) —
   running only the branch that matches the resolved outcome (a win by default,
   configurable via the interpreter's `battle_outcome`, since there is no battle
   system yet); the real `OpenGame.exe` XP test bed uses this structure. Covered
   by `mruby-rpgxp/test` and driven over the real test bed by
-  `scripts/rpgxp_testbed_check.rb`. Still to come: vehicle move-route targets,
-  the remaining actor / enemy / character conditional sub-conditions, and the
-  many screen-effect / picture commands, plus the battle system itself that
-  Battle Processing would drive (skipped for now).
+  `scripts/rpgxp_testbed_check.rb` (which now builds a `Game::Actor` for every
+  database actor). Still to come: the **Change Actor** commands (Change HP/SP,
+  EXP, Level, Parameters, Skills, Equipment) that mutate the new model, the actor
+  *state* (5) and enemy / character conditional sub-conditions, vehicle
+  move-route targets, and the many screen-effect / picture commands, plus the
+  battle system itself that Battle Processing would drive (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
   (RPG Maker XP; VX's same-format `Game.rgss2a`) or a VX Ace `Game.rgss3a` loads:
   `RPGXP::RGSSAD` (`mruby-rpgxp/mrblib/rgssad.rb`) decrypts **both** the version-1

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -107,6 +107,17 @@ class RPGXP
         id && @db.actors[id]
       end
 
+      # The live Game::Actor for actor `id` (any database actor, not only party
+      # members), built from the database on first use and memoised so its
+      # mutable state -- once the Change Actor commands mutate it -- persists
+      # across the game, the way RMXP's `$game_actors[id]` does. Returns nil for
+      # an unknown id.
+      def actor(id)
+        return nil if id.nil? || id == 0 || @db.actors[id].nil?
+        @actors ||= {}
+        @actors[id] ||= Actor.new(@db, id)
+      end
+
       # Portable save payload (our own Marshal format, not the RMXP .rxdata save).
       def to_h
         { map_id: @map_id, x: @x, y: @y, direction: @direction,
@@ -144,6 +155,85 @@ class RPGXP
       def hash_to_plain(h)
         out = {}
         h.each { |k, v| out[k] = v }
+        out
+      end
+    end
+
+    # A party actor's live menu/battle state, wrapping its RPG::Actor database
+    # record (and RPG::Class). Level-derived stats come straight from the actor's
+    # `parameters` Table (kind 0 max HP, 1 max SP, 2 str, 3 dex, 4 agi, 5 int),
+    # the known skills from the class's learnings up to the current level, and the
+    # equipment from the actor's default weapon and four armor slots. The Change
+    # Actor event commands will mutate this object rather than the shared database
+    # record; for now it exposes what the actor Conditional Branch sub-conditions
+    # (skill learned / weapon / armor equipped) need to read.
+    class Actor
+      # Parameter kinds indexing the RPG::Actor#parameters Table.
+      PARAM_MAXHP = 0
+      PARAM_MAXSP = 1
+      PARAM_STR   = 2
+      PARAM_DEX   = 3
+      PARAM_AGI   = 4
+      PARAM_INT   = 5
+
+      attr_reader :id
+      attr_accessor :level, :hp, :sp, :skills,
+                    :weapon_id, :armor1_id, :armor2_id, :armor3_id, :armor4_id
+
+      def initialize(db, id)
+        @db = db
+        @id = id
+        @record = db.actors[id]
+        raise "No such actor: #{id}" if @record.nil?
+        @class = db.classes[@record.class_id]
+        @level = @record.initial_level
+        @weapon_id = @record.weapon_id
+        @armor1_id = @record.armor1_id
+        @armor2_id = @record.armor2_id
+        @armor3_id = @record.armor3_id
+        @armor4_id = @record.armor4_id
+        @skills = learnable_skills(@level)
+        @hp = max_hp
+        @sp = max_sp
+      end
+
+      # The actor's database display name.
+      def name; @record.name; end
+
+      # A level-derived stat read from the parameters table (`parameters[kind,
+      # level]`); level is 1-based, matching the table the editor writes.
+      def param(kind); @record.parameters[kind, @level]; end
+      def max_hp; param(PARAM_MAXHP); end
+      def max_sp; param(PARAM_MAXSP); end
+      def str;    param(PARAM_STR);   end
+      def dex;    param(PARAM_DEX);   end
+      def agi;    param(PARAM_AGI);   end
+      def int;    param(PARAM_INT);   end
+
+      # -- Conditional Branch actor predicates --------------------------------
+      # Matched to RMXP's command_111 actor tests (exact-match on the equipped
+      # weapon / any of the four armor slots), so they mirror the editor's
+      # behaviour including its quirks (an id of 0 tests the empty slot).
+
+      def knows_skill?(skill_id); @skills.include?(skill_id); end
+
+      def weapon_equipped?(weapon_id); @weapon_id == weapon_id; end
+
+      def armor_equipped?(armor_id)
+        armor_id == @armor1_id || armor_id == @armor2_id ||
+          armor_id == @armor3_id || armor_id == @armor4_id
+      end
+
+      private
+
+      # The skill ids the class has taught by `level` (every learning at or below
+      # it). RMXP seeds an actor's known skills this way at its starting level.
+      def learnable_skills(level)
+        out = []
+        learnings = @class && @class.learnings
+        (learnings || []).each do |l|
+          out.push(l.skill_id) if l.skill_id && l.level && l.level <= level
+        end
         out
       end
     end

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -480,11 +480,15 @@ class RPGXP
           compare(lhs, rhs, param(cmd, 4, 0))
         when 2 # self switch: [2, ch, value(0 on / 1 off)]
           self_switch_on?(param(cmd, 1)) == (param(cmd, 2) == 0)
-        when 4 # actor: [4, actor_id, sub_type, ...]; sub 0 = "is in the party"
-          if param(cmd, 2) == 0
-            @state.party.include?(param(cmd, 1))
-          else
-            true # name / skill / equipment / state sub-conditions not modelled
+        when 4 # actor: [4, actor_id, sub_type, value]
+          actor = @state.actor(param(cmd, 1))
+          case param(cmd, 2)
+          when 0 then @state.party.include?(param(cmd, 1))              # in the party
+          when 1 then !actor.nil? && actor.name == param(cmd, 3)        # name is
+          when 2 then !actor.nil? && actor.knows_skill?(param(cmd, 3))  # skill learned
+          when 3 then !actor.nil? && actor.weapon_equipped?(param(cmd, 3)) # weapon
+          when 4 then !actor.nil? && actor.armor_equipped?(param(cmd, 3))  # armor
+          else true # state (5) sub-condition not modelled
           end
         when 7 # gold: [7, amount, cmp(0 >= / 1 <=)]
           param(cmd, 2) == 0 ? @state.gold >= param(cmd, 1) : @state.gold <= param(cmd, 1)

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -11,11 +11,12 @@ RTP_DIR = "" unless Object.const_defined?(:RTP_DIR)
 
 # Minimal database stand-in exposing just the accessors the runtime reads.
 class FakeDB
-  def initialize(actors: [], tilesets: [])
+  def initialize(actors: [], tilesets: [], classes: [])
     @actors = actors
     @tilesets = tilesets
+    @classes = classes
   end
-  attr_reader :actors, :tilesets
+  attr_reader :actors, :tilesets, :classes
 end
 
 assert "RPG schema Marshal round-trip" do
@@ -356,6 +357,65 @@ assert "Interpreter: change party member and actor-in-party condition" do
   ])
   assert_true s2.switches[1]   # actor 1 is in party
   assert_false s2.switches[2]  # actor 9 is not
+end
+
+# A FakeDB whose actor 1 (Aluxes) is level 3 of class 1, wearing weapon 7 and
+# armor 11, with the class teaching skill 50 at level 2 and skill 60 at level 4.
+def xp_actor_db
+  a = RPG::Actor.new
+  a.id = 1; a.name = "Aluxes"; a.class_id = 1
+  a.initial_level = 3; a.final_level = 5
+  a.weapon_id = 7; a.armor1_id = 11
+  a.armor2_id = 0; a.armor3_id = 0; a.armor4_id = 0
+  prm = Table.new(6, 6)                 # 6 params x levels 0..5
+  prm[0, 3] = 100; prm[1, 3] = 30; prm[2, 3] = 12
+  prm[3, 3] = 10;  prm[4, 3] = 8;  prm[5, 3] = 6
+  a.parameters = prm
+  cls = RPG::Class.new; cls.id = 1
+  l1 = RPG::Class::Learning.new; l1.level = 2; l1.skill_id = 50
+  l2 = RPG::Class::Learning.new; l2.level = 4; l2.skill_id = 60
+  cls.learnings = [l1, l2]
+  FakeDB.new(actors: [nil, a], classes: [nil, cls])
+end
+
+assert "Game::Actor derives stats, skills and equipment from the database" do
+  a = RPGXP::Game::Actor.new(xp_actor_db, 1)
+  assert_equal 3, a.level
+  assert_equal 100, a.max_hp
+  assert_equal 30, a.max_sp
+  assert_equal 12, a.str
+  assert_equal 6, a.int
+  assert_equal "Aluxes", a.name
+  assert_equal 100, a.hp                 # HP/SP start full
+  assert_equal 30, a.sp
+  assert_equal [50], a.skills            # only the learning at level <= 3
+  assert_true  a.knows_skill?(50)
+  assert_false a.knows_skill?(60)
+  assert_true  a.weapon_equipped?(7)
+  assert_false a.weapon_equipped?(8)
+  assert_true  a.armor_equipped?(11)
+  assert_false a.armor_equipped?(12)
+end
+
+assert "Interpreter: actor skill / weapon / armor / name conditionals" do
+  s = RPGXP::Game::State.new(xp_actor_db, [1], 1, 0, 0)
+  # State#actor memoises one live actor per id.
+  assert_true s.actor(1).equal?(s.actor(1))
+  assert_nil s.actor(99)
+  run_to_end(s, [
+    cmd(111, [4, 1, 2, 50], 0), cmd(121, [1, 1, 0], 1), cmd(412, [], 0), # knows skill 50
+    cmd(111, [4, 1, 2, 60], 0), cmd(121, [2, 2, 0], 1), cmd(412, [], 0), # not skill 60
+    cmd(111, [4, 1, 3, 7], 0),  cmd(121, [3, 3, 0], 1), cmd(412, [], 0), # weapon 7
+    cmd(111, [4, 1, 4, 11], 0), cmd(121, [4, 4, 0], 1), cmd(412, [], 0), # armor 11
+    cmd(111, [4, 1, 1, "Aluxes"], 0), cmd(121, [5, 5, 0], 1), cmd(412, [], 0), # name is
+    cmd(111, [4, 1, 4, 99], 0), cmd(121, [6, 6, 0], 1), cmd(412, [], 0)  # not armor 99
+  ])
+  assert_true  s.switches[1]   # skill 50 learned
+  assert_false s.switches[2]   # skill 60 not learned (class teaches it at level 4)
+  assert_true  s.switches[3]   # weapon 7 equipped
+  assert_true  s.switches[4]   # armor 11 equipped
+  assert_true  s.switches[5]   # name matches
+  assert_false s.switches[6]   # armor 99 not equipped
 end
 
 assert "Interpreter: control variables from game quantities" do

--- a/scripts/rpgxp_testbed_check.rb
+++ b/scripts/rpgxp_testbed_check.rb
@@ -108,9 +108,10 @@ class Checker
 
     check_system(db.system)
     check_actors(db.actors)
+    @db = db
+    check_game_actors(db)
     check_tilesets(db.tilesets)
     @resolver = CommonResolver.new(db.common_events)
-    @db = db
     check_maps(db)
     check_archive(dir, db)
   rescue => ex
@@ -137,6 +138,29 @@ class Checker
       expect(a.parameters.is_a?(Table), "actor #{a.id} parameters must be a Table")
     end
     puts "  actors: #{actors.compact.size} (e.g. #{actors.compact.first&.name.inspect})"
+  end
+
+  # Build the live RPGXP::Game::Actor for every database actor and assert its
+  # derived state resolves: stats read from the parameters table at the actor's
+  # level (so a mis-sized table or bad level surfaces here), HP/SP start full, and
+  # the skills / equipment lists are well-formed. This exercises the actor model
+  # the Change-Actor commands and actor conditionals build on, over real data.
+  def check_game_actors(db)
+    built = 0
+    db.actors.compact.each do |a|
+      ga = RPGXP::Game::Actor.new(db, a.id)
+      expect(ga.max_hp.to_i > 0, "actor #{a.id} Game::Actor max_hp must be positive (got #{ga.max_hp.inspect})")
+      expect(ga.max_sp.to_i >= 0, "actor #{a.id} Game::Actor max_sp must be non-negative")
+      expect(ga.hp == ga.max_hp && ga.sp == ga.max_sp, "actor #{a.id} must start at full HP/SP")
+      expect(ga.skills.is_a?(Array), "actor #{a.id} skills must be an Array")
+      expect([true, false].include?(ga.weapon_equipped?(a.weapon_id.to_i)),
+             "actor #{a.id} weapon_equipped? must be boolean")
+      built += 1
+    end
+    first = db.actors.compact.first
+    sample = first && RPGXP::Game::Actor.new(db, first.id)
+    puts "  game-actors: #{built} built" +
+         (sample ? " (e.g. #{sample.name.inspect} Lv#{sample.level} HP#{sample.max_hp} skills=#{sample.skills.size})" : "")
   end
 
   def check_tilesets(tilesets)


### PR DESCRIPTION
Gives the RPG Maker XP side a per-actor runtime model and uses it to complete the actor Conditional Branch. (Foundation for the Change-Actor commands, which follow.)

## What

`RPGXP::Game::Actor` wraps each `RPG::Actor` record and its `RPG::Class`, deriving:
- **Stats** — level-based, read straight from the actor's `parameters` table (max HP/SP, str, dex, agi, int).
- **Skills** — from the class's `learnings` up to the current level.
- **Equipment** — the actor's default weapon and four armor slots.

`Game::State#actor(id)` memoises one live actor per id (like RMXP's `$game_actors[id]`), so the future Change-Actor commands have somewhere to mutate.

## Fixes a real gap

The model immediately powers the full **actor Conditional Branch** (type 4): *is-in-party* (0), *name-is* (1), *skill-learned* (2), *weapon-equipped* (3), *armor-equipped* (4) — matched to RMXP's `command_111`. Previously **only "is in the party" was evaluated and every other actor sub-condition silently took the true branch**, so a branch gated on a learned skill or worn equipment always passed. Now they behave correctly.

## Tests

- New `mruby-rpgxp/test` unit tests: `Game::Actor` derives stats/skills/equipment from a synthetic actor+class fixture (with a `parameters` `Table`), and the skill/weapon/armor/name conditionals drive the interpreter down the right branch.
- `scripts/rpgxp_testbed_check.rb` (CI, CRuby) now builds a `Game::Actor` for **every** actor in the real OpenGame.exe XP test bed and asserts the derived state resolves. Verified locally against the downloaded test bed: **8 actors built, stats/skills read from the parameters table** (e.g. Aluxes Lv1 HP741, 1 skill). The existing `rpgxp_script_host_check` stays green.

## Follow-ups

The **Change-Actor** commands (Change HP/SP, EXP, Level, Parameters, Skills, Equipment) that mutate this model; the actor *state* (5) and enemy/character conditional sub-conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_