### PR TITLE
mvjs: depend on mruby-array-ext for Array#- (replace the reject workaround)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,27 @@ Create ADRs in /docs/adr for:
 - Codes are formatted by precommit. Please run it after code edit finishes
 - Most dependencies are managed by nix flake. See flake.nix for detail
 
+### mruby stdlib methods live in core `*-ext` mrbgems — depend on them
+
+mruby's base classes are deliberately minimal; many methods you expect from
+CRuby live in separate **core mrbgems** (`mruby-array-ext` for `Array#-` /
+`#difference` / `#compact` / …, `mruby-numeric-ext` for `Integer#zero?`,
+`mruby-hash-ext`, `mruby-string-ext`, `mruby-enum-ext`, …). If your Ruby uses
+such a method, **do not hand-roll a workaround** (e.g. `reject`/`==` instead of
+`-`/`zero?`) — use the real method and make sure the providing core gem is
+present:
+
+- **Declare it in the gem that uses it.** Add `add_dependency '<gem>'` to that
+  gem's `mrbgem.rake` (see `mruby-mvjs/mrbgem.rake` depending on
+  `mruby-array-ext`). This is what makes the method available in the gem's own
+  **test** build — the per-gem `rake test` binary only pulls the gem plus its
+  declared dependencies, so a method that works in the full game build can still
+  be "undefined method" in CI's `mruby_test` if the dependency is not declared.
+  This exact gap produced `undefined method '-' for Array` for MZ.
+- If the whole game needs it too, it also belongs in the shared list in
+  `build_config.rb` (`rpg_maker_gems`) — but the gem-level `add_dependency` is
+  the part that keeps the tests honest, so prefer to always add it there.
+
 ## Error Handling
 
 - Do not silence errors. Never swallow an exception (or ignore a failing

--- a/changelog.d/mz-array-ext-dependency.changed.md
+++ b/changelog.d/mz-array-ext-dependency.changed.md
@@ -1,0 +1,7 @@
+- MZ (M6.2): `MZ.runnable_scripts` now uses `Array#-` from the core
+  `mruby-array-ext` gem — declared as a proper `add_dependency` in
+  `mruby-mvjs/mrbgem.rake` — instead of the `reject`/`include?` workaround. The
+  earlier `undefined method '-' for Array` in CI came from the gem's own test
+  build not pulling in `mruby-array-ext`; declaring the dependency fixes that at
+  the source. AGENTS.md now documents the rule: depend on the core `*-ext`
+  mrbgem that provides a stdlib method rather than hand-rolling around it.

--- a/mruby-mvjs/mrbgem.rake
+++ b/mruby-mvjs/mrbgem.rake
@@ -7,6 +7,13 @@ MRuby::Gem::Specification.new('mruby-mvjs') do |spec|
   # layer, and reads its data/asset files through mruby-io.
   add_dependency 'mruby-rgss'
   add_dependency 'mruby-io'
+  # Ruby-side maker logic uses Array#- (MZ.runnable_scripts filters the engine
+  # script list); it lives in the core mruby-array-ext gem, not mruby's base
+  # Array. Declare the dependency so the gem — and its own test build — always
+  # pull it in, rather than relying on the top-level build_config or hand-rolling
+  # the difference. (mruby core omits several stdlib methods into *-ext gems; the
+  # rule is to depend on the providing core gem, see AGENTS.md.)
+  add_dependency 'mruby-array-ext'
 
   # The embedded JavaScript engine (quickjs-ng, vendored at 3rd/quickjs). The
   # header is needed to compile src/mvjs.cxx in every build (native and wasm);

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -101,8 +101,7 @@ class MZ
     #     rides the shared RGSS::Audio bridge instead, so skipping it does not
     #     block reaching a scene.
     def runnable_scripts
-      skip = ["js/main.js", "js/libs/vorbisdecoder.js"]
-      CORE_SCRIPTS.reject { |s| skip.include?(s) }
+      CORE_SCRIPTS - ["js/main.js", "js/libs/vorbisdecoder.js"]
     end
 
     # The JS that installs MZ's extra host globals (see HOST_GLOBALS_JS).

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -75,8 +75,7 @@ assert 'MZ.runnable_scripts drops the loader and the WASM-gated decoder' do
   # and is audio-only, so it is skipped rather than throwing at load.
   assert_false scripts.include?("js/libs/vorbisdecoder.js")
   # Everything else is kept, in the same order as CORE_SCRIPTS.
-  skip = ["js/main.js", "js/libs/vorbisdecoder.js"]
-  expected = MZ.core_scripts.reject { |s| skip.include?(s) }
+  expected = MZ.core_scripts - ["js/main.js", "js/libs/vorbisdecoder.js"]
   assert_equal expected, scripts
   # The engine core and PIXI must survive the filtering.
   assert_true scripts.include?("js/rmmz_core.js")


### PR DESCRIPTION
## What

Follow-up to #224. That PR worked around `undefined method '-' for Array` by rewriting `MZ.runnable_scripts` with `reject`/`include?`. This replaces the workaround with the real method (`Array#-`) and fixes the actual cause: the gem didn't declare its dependency on the core `mruby-array-ext` gem.

## Root cause

`Array#-` isn't in mruby's base `Array` — it lives in the core **`mruby-array-ext`** mrbgem (registered there as `ary_sub` → `MRB_OPSYM(sub)`). `mruby-array-ext` *is* in the top-level `build_config.rb`, so the full game build has it — which is why it wasn't obvious. But CI's `mruby_test` runs `rake test`, and a gem's own test build pulls only **that gem plus its declared `add_dependency` gems** (mvjs declared `mruby-rgss` + `mruby-io`, not array-ext). So `Array#-` was undefined in the mvjs test binary specifically, while working everywhere else.

## Fix

- `mruby-mvjs/mrbgem.rake`: `add_dependency 'mruby-array-ext'` — the same way `mruby-rpgxp` declares core gems like `mruby-pack`/`mruby-eval`.
- `mruby-mvjs/mrblib/mz.rb` + `test/mz_test.rb`: use `CORE_SCRIPTS - [...]` again (clearer than the `reject` filter).
- `AGENTS.md`: document the rule — mruby stdlib methods live in core `*-ext` mrbgems (`mruby-array-ext`, `mruby-numeric-ext`, …); depend on the providing gem rather than hand-rolling around the missing method, and note that the gem-level `add_dependency` (not just `build_config`) is what keeps the per-gem test build honest.

## Verification

Built natively and ran `rake test` — the exact mechanism behind the `mruby_test` CI check:

```
Total: 1605   OK: 1602   KO: 0   Skip: 3 (unrelated: IO#isatty, onig, marshal)
```

The two MZ specs (`runnable_scripts`, `host_globals_js`) run and pass with `Array#-` live. Before this change (array-ext undeclared) the `runnable_scripts` spec is the one that raised the `undefined method '-'` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_