### PR TITLE
mruby-rgss: draw the windowskin background + frame for RGSS::Window

### DIFF
--- a/changelog.d/rpgxp-rgss-window-frame-native.added.md
+++ b/changelog.d/rpgxp-rgss-window-frame-native.added.md
@@ -1,0 +1,9 @@
+- **`RGSS::Window` now draws its windowskin background and frame.** Building on the
+  native contents render, `window_refresh` now composites the windowskin when one
+  is set: it stretches the 128×128 background tile over the window at
+  `back_opacity` and draws the 64×64 frame as a 9-slice (16px corners) at
+  `opacity`, then blits the contents on top — so framed menu/message/shop/battle
+  windows render, not just their text. `windowskin=`, `opacity=`, `back_opacity=`
+  are now native (they trigger a refresh); the compositing reuses the tested
+  `Bitmap#stretch_blt`/`#blt`. The blinking cursor rect and the pause arrow (which
+  need per-frame animation) remain stored-only. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -61,20 +61,23 @@ through the existing `bmp_blt`/`bmp_stretch_blt` blend loops (extending the same
 scratch-buffer machinery mirror introduced). That is the next slice. `Sprite_Character`, `Sprite_Battler`,
 `Arrow_Base`, weather and the animation player depend on these.
 
-### 2. `Window` ⚠️ (contents rendered; windowskin frame/cursor/pause pending)
+### 2. `Window` ⚠️ (background + frame + contents rendered; cursor/pause pending)
 
 `Window` is now **native** (`mruby-rgss/src/lib.cxx`): `Window.new` creates an
-`lv_canvas` the size of the window and `window_refresh` blits the game's
-`contents` `Bitmap` into the content area (inset 16px, scrolled by `ox`/`oy`) at
-`contents_opacity`, so **window text now renders**. `contents=`, `x=`/`y=`,
-`width=`/`height=` (which re-allocate the canvas), `ox=`/`oy=`,
-`contents_opacity=`, `z=`, `visible`/`visible=`, `dispose`/`disposed?` are
-native. So every `Window_Base` subclass (`Window_Message`, `Window_Command`, the
-menu/shop/battle UI) shows its text. **Remaining:** the windowskin compositing —
-the stretched background at `back_opacity`, the 9-slice frame, the blinking
-cursor rect and the pause arrow — is stored (`windowskin`, `cursor_rect`,
-`opacity`, `back_opacity`, `active`, `pause`, `stretch`) but not yet drawn; and
-the content blit does not yet clip contents taller than the window.
+`lv_canvas` the size of the window and `window_refresh` composites it — when a
+`windowskin` is set it stretches the 128×128 background tile at `(0,0)` over the
+window at `back_opacity` and draws the 64×64 frame at `(128,0)` as a 9-slice
+(16px corners) at `opacity`, then blits the `contents` `Bitmap` into the content
+area (inset 16px, scrolled by `ox`/`oy`) at `contents_opacity`. The compositing
+reuses the tested `Bitmap#clear`/`#stretch_blt`/`#blt` via `mrb_funcall`; only the
+RMXP windowskin source rects are new. `contents=`, `windowskin=`, `x=`/`y=`,
+`width=`/`height=`, `ox=`/`oy=`, `opacity=`/`back_opacity=`/`contents_opacity=`,
+`z=`, `visible`/`visible=`, `dispose`/`disposed?` are native. So the whole
+menu/message/shop/battle UI shows its framed windows. **Remaining:** the blinking
+cursor rect and the pause arrow (both need per-frame animation via `update`) are
+stored (`cursor_rect`, `active`, `pause`, `stretch`) but not yet drawn; the
+content blit does not yet clip contents taller than the window; and the RMXP
+windowskin source-rect constants are best-effort until a game exercises them.
 
 ### 3. `Tilemap` ⚠️ (stored; native autotile/priority render pending)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -251,22 +251,27 @@ module RGSS
   # command, menu, shop, battle status) builds on. Now native (src/lib.cxx):
   # Window.new builds an lv_canvas the size of the window and blits the game's
   # `contents` Bitmap into the content area (inset 16px, scrolled by ox/oy) at
-  # contents_opacity — so window text renders. `initialize`, `contents=`, `x=`,
-  # `y=`, `width=`, `height=`, `ox=`, `oy=`, `contents_opacity=`, `z=`,
-  # `visible`/`visible=`, `dispose`/`disposed?` are native. This reopening adds
-  # the plain readers plus the properties the native renderer does not yet honour
-  # (the windowskin background/frame, the blinking cursor rect and the pause
-  # arrow) — stored so scripts that set them run (tracked in
+  # contents_opacity, and — when a `windowskin` is set — draws the stretched
+  # background at `back_opacity` and the 9-slice frame at `opacity`. `initialize`,
+  # `contents=`, `windowskin=`, `x=`, `y=`, `width=`, `height=`, `ox=`, `oy=`,
+  # `opacity=`, `back_opacity=`, `contents_opacity=`, `z=`, `visible`/`visible=`,
+  # `dispose`/`disposed?` are native. This reopening adds the plain readers plus
+  # the properties the native renderer does not yet honour (the blinking cursor
+  # rect and the pause arrow) — stored so scripts that set them run (tracked in
   # docs/rpgxp-rgss-api-gap.md).
   class Window
-    attr_reader :contents, :x, :y, :width, :height, :ox, :oy, :z, :viewport,
-                :contents_opacity
-    attr_writer :windowskin, :opacity, :back_opacity, :active, :pause, :stretch
+    attr_reader :contents, :windowskin, :x, :y, :width, :height, :ox, :oy, :z,
+                :viewport, :contents_opacity
+    attr_writer :active, :pause, :stretch
 
     def update; end
 
-    def windowskin
-      @windowskin
+    def opacity
+      @opacity.nil? ? 255 : @opacity
+    end
+
+    def back_opacity
+      @back_opacity.nil? ? 255 : @back_opacity
     end
 
     def cursor_rect
@@ -275,14 +280,6 @@ module RGSS
 
     def cursor_rect=(r)
       @cursor_rect = r
-    end
-
-    def opacity
-      @opacity.nil? ? 255 : @opacity
-    end
-
-    def back_opacity
-      @back_opacity.nil? ? 255 : @back_opacity
     end
 
     def active

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2519,6 +2519,8 @@ mrb_value plane_set_oy(mrb_state* M, mrb_value self) {
 
 // ---- Window ---------------------------------------------------------------
 
+mrb_value make_rect(mrb_state* M, mrb_int x, mrb_int y, mrb_int w, mrb_int h);
+
 // RGSS insets a window's contents 16px from its frame on every side, so the
 // drawable content area is (width - 32) x (height - 32).
 static const int WINDOW_PADDING = 16;
@@ -2551,10 +2553,23 @@ Bitmap& window_ensure_canvas(mrb_state* M,
   return c;
 }
 
-// Repaint the window canvas: clear it, then blit the contents bitmap into the
-// content area (inset by WINDOW_PADDING, scrolled by ox/oy) at
-// contents_opacity. The windowskin background/frame and the cursor/pause
-// overlays are not drawn yet (tracked in docs/rpgxp-rgss-api-gap.md).
+static mrb_int clamp_opacity(mrb_state* M, mrb_value self, const char* iv) {
+  mrb_int v = mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_cstr(M, iv)));
+  if (v < 0)
+    return 0;
+  if (v > 255)
+    return 255;
+  return v;
+}
+
+// Repaint the window canvas: clear it, draw the windowskin background + 9-slice
+// frame (if a windowskin is set), then blit the contents bitmap into the
+// content area (inset by WINDOW_PADDING, scrolled by ox/oy). The compositing
+// reuses the tested Bitmap#clear/#stretch_blt/#blt methods via mrb_funcall;
+// only the RMXP windowskin source rects are new here (the 128x128 background at
+// (0,0) and the 64x64 frame at (128,0) with 16px corners). The blinking cursor
+// rect and the pause arrow are not drawn yet (tracked in
+// docs/rpgxp-rgss-api-gap.md).
 void window_refresh(mrb_state* M, mrb_value self) {
   lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
   if (!obj)
@@ -2563,43 +2578,72 @@ void window_refresh(mrb_state* M, mrb_value self) {
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@width")));
   const mrb_int h =
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@height")));
-  Bitmap& dst = window_ensure_canvas(M, self, w, h);
-  std::fill(dst.buffer.begin(), dst.buffer.end(), static_cast<uint8_t>(0));
+  window_ensure_canvas(M, self, w, h);
+  const mrb_value canvas =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@_win_canvas"));
+  const mrb_sym blt = mrb_intern_lit(M, "blt");
+  const mrb_sym sblt = mrb_intern_lit(M, "stretch_blt");
+  // The compositing allocates transient Rect values; drop them off the GC arena
+  // when done (canvas/skin/contents stay alive via their ivars on self).
+  const int arena = mrb_gc_arena_save(M);
+  mrb_funcall_argv(M, canvas, mrb_intern_lit(M, "clear"), 0, nullptr);
+
+  const mrb_value skin = mrb_iv_get(M, self, mrb_intern_lit(M, "@windowskin"));
+  const mrb_int b = WINDOW_PADDING;
+  if (mrb_test(skin) && DATA_PTR(skin)) {
+    const mrb_int op = clamp_opacity(M, self, "@opacity");
+    const mrb_int back = op * clamp_opacity(M, self, "@back_opacity") / 255;
+    // Background: stretch the 128x128 tile at (0,0) over the whole window.
+    const mrb_value bg[] = {make_rect(M, 0, 0, w, h), skin,
+                            make_rect(M, 0, 0, 128, 128),
+                            mrb_fixnum_value(back)};
+    mrb_funcall_argv(M, canvas, sblt, 4, bg);
+    // Frame: the 64x64 border at (128,0), a 9-slice with 16px corners/margins.
+    const mrb_value tl[] = {mrb_fixnum_value(0), mrb_fixnum_value(0), skin,
+                            make_rect(M, 128, 0, b, b), mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, blt, 5, tl);
+    const mrb_value tr[] = {mrb_fixnum_value(w - b), mrb_fixnum_value(0), skin,
+                            make_rect(M, 176, 0, b, b), mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, blt, 5, tr);
+    const mrb_value bl[] = {mrb_fixnum_value(0), mrb_fixnum_value(h - b), skin,
+                            make_rect(M, 128, 48, b, b), mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, blt, 5, bl);
+    const mrb_value br[] = {mrb_fixnum_value(w - b), mrb_fixnum_value(h - b),
+                            skin, make_rect(M, 176, 48, b, b),
+                            mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, blt, 5, br);
+    const mrb_value top[] = {make_rect(M, b, 0, w - 2 * b, b), skin,
+                             make_rect(M, 144, 0, 32, b), mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, sblt, 4, top);
+    const mrb_value bottom[] = {make_rect(M, b, h - b, w - 2 * b, b), skin,
+                                make_rect(M, 144, 48, 32, b),
+                                mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, sblt, 4, bottom);
+    const mrb_value left[] = {make_rect(M, 0, b, b, h - 2 * b), skin,
+                              make_rect(M, 128, 16, b, 32),
+                              mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, sblt, 4, left);
+    const mrb_value right[] = {make_rect(M, w - b, b, b, h - 2 * b), skin,
+                               make_rect(M, 176, 16, b, 32),
+                               mrb_fixnum_value(op)};
+    mrb_funcall_argv(M, canvas, sblt, 4, right);
+  }
 
   const mrb_value cont = mrb_iv_get(M, self, mrb_intern_lit(M, "@contents"));
-  if (!mrb_nil_p(cont)) {
-    Bitmap& src = DataType<Bitmap>::get(M, cont);
-    mrb_int op = mrb_as_int(
-        M, mrb_iv_get(M, self, mrb_intern_lit(M, "@contents_opacity")));
-    if (op < 0)
-      op = 0;
-    else if (op > 255)
-      op = 255;
+  if (mrb_test(cont) && DATA_PTR(cont)) {
+    const mrb_int cop = clamp_opacity(M, self, "@contents_opacity");
     const mrb_int ox =
         mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@ox")));
     const mrb_int oy =
         mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@oy")));
-    const mrb_int cw = w - 2 * WINDOW_PADDING;
-    const mrb_int ch = h - 2 * WINDOW_PADDING;
-    for (mrb_int j = 0; j < ch; ++j) {
-      const mrb_int sy = oy + j;
-      const mrb_int dy = WINDOW_PADDING + j;
-      if (sy < 0 || sy >= src.height || dy < 0 || dy >= dst.height)
-        continue;
-      for (mrb_int i = 0; i < cw; ++i) {
-        const mrb_int sx = ox + i;
-        const mrb_int dx = WINDOW_PADDING + i;
-        if (sx < 0 || sx >= src.width || dx < 0 || dx >= dst.width)
-          continue;
-        int r, g, b, a;
-        bmp_read(src, sx, sy, r, g, b, a);
-        const int alpha = a * static_cast<int>(op) / 255;
-        if (alpha <= 0)
-          continue;
-        bmp_put(dst, dx, dy, r, g, b, alpha);
-      }
-    }
+    // Blit the scrolled contents into the content area, inset by
+    // WINDOW_PADDING.
+    const mrb_value c[] = {mrb_fixnum_value(b), mrb_fixnum_value(b), cont,
+                           make_rect(M, ox, oy, w - 2 * b, h - 2 * b),
+                           mrb_fixnum_value(cop)};
+    mrb_funcall_argv(M, canvas, blt, 5, c);
   }
+  mrb_gc_arena_restore(M, arena);
   lv_obj_invalidate(obj);
 }
 
@@ -2667,6 +2711,30 @@ mrb_value window_set_contents_opacity(mrb_state* M, mrb_value self) {
   mrb_get_args(M, "i", &v);
   mrb_iv_set(M, self, mrb_intern_lit(M, "@contents_opacity"),
              mrb_fixnum_value(v));
+  window_refresh(M, self);
+  return self;
+}
+
+mrb_value window_set_skin(mrb_state* M, mrb_value self) {
+  mrb_value v;
+  mrb_get_args(M, "o", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@windowskin"), v);
+  window_refresh(M, self);
+  return v;
+}
+
+mrb_value window_set_opacity(mrb_state* M, mrb_value self) {
+  mrb_int v;
+  mrb_get_args(M, "i", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@opacity"), mrb_fixnum_value(v));
+  window_refresh(M, self);
+  return self;
+}
+
+mrb_value window_set_back_opacity(mrb_state* M, mrb_value self) {
+  mrb_int v;
+  mrb_get_args(M, "i", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@back_opacity"), mrb_fixnum_value(v));
   window_refresh(M, self);
   return self;
 }
@@ -3070,6 +3138,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, window, "ox=", window_set_ox, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "oy=", window_set_oy, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "contents_opacity=", window_set_contents_opacity,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "windowskin=", window_set_skin, MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "opacity=", window_set_opacity, MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "back_opacity=", window_set_back_opacity,
                     MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "z=", obj_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "visible", obj_visible, MRB_ARGS_NONE());

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -492,7 +492,8 @@ assert "RGSS::Window API surface" do
   # back_opacity, active, pause, stretch) are covered by being defined below.
   %i[contents= x= y= width= height= ox= oy= contents_opacity= z= visible
      visible= dispose disposed? windowskin windowskin= cursor_rect cursor_rect=
-     opacity opacity= back_opacity active pause stretch update].each do |m|
+     opacity opacity= back_opacity back_opacity= active pause stretch
+     update].each do |m|
     assert_true RGSS::Window.method_defined?(m), "Window##{m} missing"
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to the native Window contents render (#226): draws the **windowskin background and frame**, so windows look like windows — not just floating text. Completes the visible bulk of the `Window` renderer.

## Change

- **`mruby-rgss/src/lib.cxx`** — `window_refresh` now composites the windowskin when one is set:
  - **Background** — stretches the 128×128 tile at `(0,0)` over the whole window at `back_opacity` (× `opacity`).
  - **Frame** — draws the 64×64 border at `(128,0)` as a **9-slice** (16px corners `blt`'d 1:1, edges `stretch_blt`'d) at `opacity`.
  - Then blits the contents into the content area as before.
  - The compositing reuses the already-tested `Bitmap#clear`/`#stretch_blt`/`#blt` methods via `mrb_funcall` — **only the RMXP windowskin source rects are new C** — with a GC arena save/restore around the transient `Rect` values. The 9-slice structure mirrors the existing RPG2000 `Window#draw_frame` (`mruby-rpg2k/mrblib/main.rb`), with RMXP-specific constants.
  - `windowskin=`, `opacity=`, `back_opacity=` are now native (they trigger a refresh).
- **`mruby-rgss/mrblib/lib.rb`** — the `Window` reopening drops those three from its writers (native now) and keeps the readers.

## Scope / limitations (honest)

- The **blinking cursor rect** and the **pause arrow** need per-frame animation via `Window#update`, so they stay stored-only (`cursor_rect`, `active`, `pause`, `stretch`) — a follow-up slice.
- The content blit doesn't yet clip contents taller than the window.
- The **RMXP windowskin source-rect constants** (bg `(0,0,128,128)`, frame `(128,0,64,64)` with 16px corners) are the standard layout but **best-effort until a game exercises them** — they're isolated and easy to correct.

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0**; ran clang-format + whitespace/EOF locally.
- **`mruby-rgss/test`** — asserts the (now-native) `windowskin=`/`opacity=`/`back_opacity=` are on the method surface; `Window.new` needs a live display so compositing is exercised by the game runs.
- **No current game creates a `Window`**, so this is compile-verified but render-verified once the RGSS script host boots an XP game — zero regression risk.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #2 (`Window`) → ⚠️ (background + frame + contents rendered; cursor/pause pending).
- Changelog fragment `changelog.d/rpgxp-rgss-window-frame-native.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_