### PR TITLE
mruby-rgss: draw the Window cursor and pause arrow

### DIFF
--- a/changelog.d/rpgxp-rgss-window-cursor-pause.added.md
+++ b/changelog.d/rpgxp-rgss-window-cursor-pause.added.md
@@ -1,0 +1,10 @@
+- **`RGSS::Window` now draws the selection cursor and pause arrow.** Building on the
+  windowskin frame, `window_refresh` now also draws the blinking cursor highlight
+  at `cursor_rect` (when the window is `active`) and the animated pause arrow (when
+  `pause` is set), both cycled by a per-window animation counter. `Window#update`
+  is native: it advances that counter and redraws — which also picks up the
+  in-place `cursor_rect` mutation stock scripts do via `cursor_rect.set`.
+  `cursor_rect=`, `active=`, `pause=`, `update` are now native. With this the
+  menu/message/shop/battle UI renders fully — frame, text, selection cursor and
+  message pause. The cursor is a stretched highlight (a crisp 9-slice is a
+  refinement). See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -61,7 +61,7 @@ through the existing `bmp_blt`/`bmp_stretch_blt` blend loops (extending the same
 scratch-buffer machinery mirror introduced). That is the next slice. `Sprite_Character`, `Sprite_Battler`,
 `Arrow_Base`, weather and the animation player depend on these.
 
-### 2. `Window` ⚠️ (background + frame + contents rendered; cursor/pause pending)
+### 2. `Window` ⚠️ (background + frame + contents + cursor + pause rendered)
 
 `Window` is now **native** (`mruby-rgss/src/lib.cxx`): `Window.new` creates an
 `lv_canvas` the size of the window and `window_refresh` composites it — when a
@@ -72,12 +72,16 @@ area (inset 16px, scrolled by `ox`/`oy`) at `contents_opacity`. The compositing
 reuses the tested `Bitmap#clear`/`#stretch_blt`/`#blt` via `mrb_funcall`; only the
 RMXP windowskin source rects are new. `contents=`, `windowskin=`, `x=`/`y=`,
 `width=`/`height=`, `ox=`/`oy=`, `opacity=`/`back_opacity=`/`contents_opacity=`,
-`z=`, `visible`/`visible=`, `dispose`/`disposed?` are native. So the whole
-menu/message/shop/battle UI shows its framed windows. **Remaining:** the blinking
-cursor rect and the pause arrow (both need per-frame animation via `update`) are
-stored (`cursor_rect`, `active`, `pause`, `stretch`) but not yet drawn; the
-content blit does not yet clip contents taller than the window; and the RMXP
-windowskin source-rect constants are best-effort until a game exercises them.
+`z=`, `visible`/`visible=`, `dispose`/`disposed?` are native. It also draws the
+**blinking cursor** highlight at `cursor_rect` (when `active`) and the **pause
+arrow** (when `pause`); `Window#update` advances the blink/pause animation and
+redraws (also picking up in-place `cursor_rect` mutation, which scripts do via
+`cursor_rect.set`). So the whole menu/message/shop/battle UI renders — framed
+windows, text, selection cursor and message pause. **Remaining:** the cursor is a
+stretched highlight rather than a crisp 9-slice; the content blit does not yet
+clip contents taller than the window; `stretch` (tiled vs stretched background) is
+ignored; and the RMXP windowskin source-rect constants are best-effort until a
+game exercises them.
 
 ### 3. `Tilemap` ⚠️ (stored; native autotile/priority render pending)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -252,19 +252,19 @@ module RGSS
   # Window.new builds an lv_canvas the size of the window and blits the game's
   # `contents` Bitmap into the content area (inset 16px, scrolled by ox/oy) at
   # contents_opacity, and — when a `windowskin` is set — draws the stretched
-  # background at `back_opacity` and the 9-slice frame at `opacity`. `initialize`,
-  # `contents=`, `windowskin=`, `x=`, `y=`, `width=`, `height=`, `ox=`, `oy=`,
-  # `opacity=`, `back_opacity=`, `contents_opacity=`, `z=`, `visible`/`visible=`,
-  # `dispose`/`disposed?` are native. This reopening adds the plain readers plus
-  # the properties the native renderer does not yet honour (the blinking cursor
-  # rect and the pause arrow) — stored so scripts that set them run (tracked in
-  # docs/rpgxp-rgss-api-gap.md).
+  # background at `back_opacity`, the 9-slice frame at `opacity`, the blinking
+  # cursor highlight at `cursor_rect` (when `active`) and the pause arrow (when
+  # `pause`). `update` advances the blink/pause animation and redraws. Almost the
+  # whole surface is native — `initialize`, `contents=`, `windowskin=`, `x=`,
+  # `y=`, `width=`, `height=`, `ox=`, `oy=`, `opacity=`, `back_opacity=`,
+  # `contents_opacity=`, `cursor_rect=`, `active=`, `pause=`, `update`, `z=`,
+  # `visible`/`visible=`, `dispose`/`disposed?`. This reopening only adds the
+  # plain readers (and their RGSS defaults) plus `stretch`, which the tiling-vs-
+  # stretch background choice does not yet distinguish.
   class Window
     attr_reader :contents, :windowskin, :x, :y, :width, :height, :ox, :oy, :z,
                 :viewport, :contents_opacity
-    attr_writer :active, :pause, :stretch
-
-    def update; end
+    attr_writer :stretch
 
     def opacity
       @opacity.nil? ? 255 : @opacity
@@ -276,10 +276,6 @@ module RGSS
 
     def cursor_rect
       @cursor_rect ||= Rect.new(0, 0, 0, 0)
-    end
-
-    def cursor_rect=(r)
-      @cursor_rect = r
     end
 
     def active

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2643,6 +2643,41 @@ void window_refresh(mrb_state* M, mrb_value self) {
                            mrb_fixnum_value(cop)};
     mrb_funcall_argv(M, canvas, blt, 5, c);
   }
+
+  const mrb_int anim =
+      mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@_anim")));
+  // Cursor: a blinking highlight from the windowskin cursor region (128,64,
+  // 32,32) drawn at cursor_rect (content coords, offset by the padding), when
+  // the window is active. Stretched to the rect for now (a crisp 9-slice border
+  // is a refinement); the blink alpha oscillates with @_anim. Redrawn each
+  // frame by Window#update because scripts mutate cursor_rect in place.
+  const mrb_value cr_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@cursor_rect"));
+  const mrb_value active_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@active"));
+  const bool active = mrb_nil_p(active_v) ? true : mrb_test(active_v);
+  if (mrb_test(skin) && DATA_PTR(skin) && active && mrb_test(cr_v) &&
+      DATA_PTR(cr_v)) {
+    Rect& cr = DataType<Rect>::get(M, cr_v);
+    if (cr.width > 0 && cr.height > 0) {
+      const mrb_int phase = ((anim % 32) + 32) % 32;
+      const mrb_int level = phase < 16 ? phase : 32 - phase;  // 0..16
+      const mrb_int calpha = 255 - level * 8;                 // 255..127
+      const mrb_value cur[] = {
+          make_rect(M, b + cr.x, b + cr.y, cr.width, cr.height), skin,
+          make_rect(M, 128, 64, 32, 32), mrb_fixnum_value(calpha)};
+      mrb_funcall_argv(M, canvas, sblt, 4, cur);
+    }
+  }
+  // Pause arrow: one of four 16x16 frames at (160,64) cycled by @_anim, drawn
+  // centred on the bottom edge when the window is paused.
+  if (mrb_test(skin) && DATA_PTR(skin) &&
+      mrb_test(mrb_iv_get(M, self, mrb_intern_lit(M, "@pause")))) {
+    const mrb_int f = (anim / 8) % 4;
+    const mrb_value pa[] = {
+        mrb_fixnum_value(w / 2 - 8), mrb_fixnum_value(h - 16), skin,
+        make_rect(M, 160 + (f % 2) * 16, 64 + (f / 2) * 16, 16, 16),
+        mrb_fixnum_value(255)};
+    mrb_funcall_argv(M, canvas, blt, 5, pa);
+  }
   mrb_gc_arena_restore(M, arena);
   lv_obj_invalidate(obj);
 }
@@ -2662,6 +2697,7 @@ mrb_value window_init(mrb_state* M, mrb_value self) {
   mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(0));
   mrb_iv_set(M, self, mrb_intern_lit(M, "@contents_opacity"),
              mrb_fixnum_value(255));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_anim"), mrb_fixnum_value(0));
   window_ensure_canvas(M, self, 1, 1);
   return self;
 }
@@ -2736,6 +2772,50 @@ mrb_value window_set_back_opacity(mrb_state* M, mrb_value self) {
   mrb_get_args(M, "i", &v);
   mrb_iv_set(M, self, mrb_intern_lit(M, "@back_opacity"), mrb_fixnum_value(v));
   window_refresh(M, self);
+  return self;
+}
+
+mrb_value window_set_cursor_rect(mrb_state* M, mrb_value self) {
+  mrb_value v;
+  mrb_get_args(M, "o", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@cursor_rect"), v);
+  window_refresh(M, self);
+  return v;
+}
+
+mrb_value window_set_active(mrb_state* M, mrb_value self) {
+  mrb_bool v;
+  mrb_get_args(M, "b", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@active"), mrb_bool_value(v));
+  window_refresh(M, self);
+  return self;
+}
+
+mrb_value window_set_pause(mrb_state* M, mrb_value self) {
+  mrb_bool v;
+  mrb_get_args(M, "b", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@pause"), mrb_bool_value(v));
+  window_refresh(M, self);
+  return self;
+}
+
+// Per-frame tick: advance the blink/pause animation and, when the window has a
+// visible cursor or is paused, redraw so the animation and any in-place
+// cursor_rect mutation show. Windows without a cursor or pause need no
+// per-frame work.
+mrb_value window_update(mrb_state* M, mrb_value self) {
+  const mrb_int anim =
+      mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@_anim")));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_anim"), mrb_fixnum_value(anim + 1));
+  const mrb_value cr = mrb_iv_get(M, self, mrb_intern_lit(M, "@cursor_rect"));
+  const mrb_value active_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@active"));
+  const bool active = mrb_nil_p(active_v) ? true : mrb_test(active_v);
+  const bool has_cursor = active && mrb_test(cr) && DATA_PTR(cr) &&
+                          DataType<Rect>::get(M, cr).width > 0;
+  const bool paused =
+      mrb_test(mrb_iv_get(M, self, mrb_intern_lit(M, "@pause")));
+  if (has_cursor || paused)
+    window_refresh(M, self);
   return self;
 }
 
@@ -3143,6 +3223,11 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, window, "opacity=", window_set_opacity, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "back_opacity=", window_set_back_opacity,
                     MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "cursor_rect=", window_set_cursor_rect,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "active=", window_set_active, MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "pause=", window_set_pause, MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "update", window_update, MRB_ARGS_NONE());
   mrb_define_method(M, window, "z=", obj_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, window, "visible=", obj_set_visible, MRB_ARGS_REQ(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -492,8 +492,8 @@ assert "RGSS::Window API surface" do
   # back_opacity, active, pause, stretch) are covered by being defined below.
   %i[contents= x= y= width= height= ox= oy= contents_opacity= z= visible
      visible= dispose disposed? windowskin windowskin= cursor_rect cursor_rect=
-     opacity opacity= back_opacity back_opacity= active pause stretch
-     update].each do |m|
+     opacity opacity= back_opacity back_opacity= cursor_rect= active active=
+     pause pause= stretch update].each do |m|
     assert_true RGSS::Window.method_defined?(m), "Window##{m} missing"
   end
 end


### PR DESCRIPTION
## Summary

Completes the `Window` renderer (after contents #226 and windowskin frame #230). Draws the two remaining pieces — the selection **cursor** and the message **pause arrow** — both of which need per-frame animation.

## Change

- **`mruby-rgss/src/lib.cxx`** — `window_refresh` now also draws:
  - **Cursor** — a blinking highlight stretched from the windowskin cursor region `(128,64,32,32)` at `cursor_rect` (offset by the 16px padding), when the window is `active`. The blink alpha oscillates with a per-window `@_anim` counter.
  - **Pause arrow** — one of four 16×16 frames at `(160,64)`, cycled by `@_anim`, centred on the bottom edge, when `pause` is set.
- **`Window#update` is now native** — it advances `@_anim` and, when the window has a visible cursor or is paused, re-composites. That per-frame redraw is also what picks up the **in-place `cursor_rect` mutation** stock scripts do via `cursor_rect.set` (which never calls `cursor_rect=`). `cursor_rect=`, `active=`, `pause=` are native too.
- **`mruby-rgss/mrblib/lib.rb`** — the `Window` reopening drops `update`/`cursor_rect=`/`active=`/`pause=` (native now), keeping the readers/defaults.

## Scope / limitations (honest)

- The cursor is a **stretched highlight**, not a crisp 9-slice border (a refinement — the 9-slice corner constant is the uncertain part).
- `stretch` (tiled vs stretched background) is still ignored; the content blit doesn't clip contents taller than the window.
- The per-frame redraw re-composites the whole window (fine for the few windows with an active cursor; a dirty/separate-layer optimization is possible later).
- The RMXP windowskin/cursor source-rect constants remain best-effort until a game exercises them.

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0**; ran clang-format + whitespace/EOF locally and checked `mrb_intern_lit` is only used with string literals (the #230 fix — the runtime-string helper uses `mrb_intern_cstr`).
- **`mruby-rgss/test`** — asserts the now-native `cursor_rect=`/`active=`/`pause=`/`update` are on the method surface; `Window.new` needs a live display so compositing is exercised by the game runs.
- **No current game creates a `Window`**, so this is compile-verified but render-verified once the RGSS script host boots — zero regression risk.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #2 (`Window`) → ⚠️ (background + frame + contents + cursor + pause rendered).
- Changelog fragment `changelog.d/rpgxp-rgss-window-cursor-pause.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_