### PR TITLE
Add the RPG Maker XP Change Actor event commands

### DIFF
--- a/changelog.d/rpgxp-change-actor-commands.added.md
+++ b/changelog.d/rpgxp-change-actor-commands.added.md
@@ -1,0 +1,15 @@
+- RPG Maker **XP**: the **Change Actor** event commands now mutate the per-actor
+  model (`RPGXP::Game::Actor`). Implemented: **Change HP** (311, honouring the
+  "allow knockout" floor of 0 vs 1), **Change SP** (312), **Recover All** (314),
+  **Change Level** (316 — which learns any newly-reached class skills and regrows
+  the level-derived stats), **Change Skills** (318, learn / forget) and **Change
+  Equipment** (319, the weapon and four armor slots, an id of 0 emptying a slot).
+  Each resolves its target through RMXP's `iterate_actor` (a fixed actor id, or
+  one held in a variable) and the value commands through `operate_value`
+  (increase / decrease, constant or variable operand), matching RGSS's
+  Interpreter. The mutated per-actor state (level, HP/SP, skills, equipment) now
+  round-trips through the Marshal save. Covered by new `mruby-rpgxp/test` cases
+  for each command plus the save round-trip; the `rpgxp_testbed_check` /
+  `rpgxp_script_host_check` harnesses stay green. Change EXP (315), the exp-curve
+  alignment of Change Level, and Change Parameters (317) — which need the RMXP EXP
+  curve and per-actor stat deltas — are the remaining follow-ups.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -453,17 +453,24 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   memoises one live actor per id (like RMXP's `$game_actors`). It powers the full
   **actor Conditional Branch** (type 4): *is in the party* (0), *name is* (1),
   *skill learned* (2), *weapon equipped* (3) and *armor equipped* (4), matched to
-  RMXP's `command_111`. **Battle Processing** (301) navigates its result
+  RMXP's `command_111`. The model's **Change Actor** commands mutate it: **Change
+  HP** (311, with the allow-knockout floor), **Change SP** (312), **Recover All**
+  (314), **Change Level** (316, which learns newly-reached class skills and
+  regrows the level-derived stats), **Change Skills** (318 learn / forget) and
+  **Change Equipment** (319, weapon + four armor slots), each targeting a fixed or
+  variable-held actor id; the mutated per-actor state now persists through the
+  Marshal save. **Battle Processing** (301) navigates its result
   branches — If Win (601), If Escape (602), If Lose (603), branch end (604) —
   running only the branch that matches the resolved outcome (a win by default,
   configurable via the interpreter's `battle_outcome`, since there is no battle
   system yet); the real `OpenGame.exe` XP test bed uses this structure. Covered
   by `mruby-rpgxp/test` and driven over the real test bed by
   `scripts/rpgxp_testbed_check.rb` (which now builds a `Game::Actor` for every
-  database actor). Still to come: the **Change Actor** commands (Change HP/SP,
-  EXP, Level, Parameters, Skills, Equipment) that mutate the new model, the actor
-  *state* (5) and enemy / character conditional sub-conditions, vehicle
-  move-route targets, and the many screen-effect / picture commands, plus the
+  database actor). Still to come: the remaining **Change Actor** commands that need
+  the RMXP EXP curve — **Change EXP** (315) and **Change Level**'s exp alignment —
+  and **Change Parameters** (317, permanent stat deltas on top of the table); the
+  actor *state* (5) and enemy / character conditional sub-conditions; vehicle
+  move-route targets; and the many screen-effect / picture commands, plus the
   battle system itself that Battle Processing would drive (skipped for now).
 - ✅ **Encrypted archives** — a packed release that ships only a `Game.rgssad`
   (RPG Maker XP; VX's same-format `Game.rgss2a`) or a VX Ace `Game.rgss3a` loads:

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -119,13 +119,15 @@ class RPGXP
       end
 
       # Portable save payload (our own Marshal format, not the RMXP .rxdata save).
+      # `actors` holds only the actors whose live state has been touched (built via
+      # #actor); untouched actors re-derive from the database identically on load.
       def to_h
         { map_id: @map_id, x: @x, y: @y, direction: @direction,
           party: @party, gold: @gold, switches: hash_to_plain(@switches),
           variables: hash_to_plain(@variables),
           self_switches: hash_to_plain(@self_switches),
           items: hash_to_plain(@items), weapons: hash_to_plain(@weapons),
-          armors: hash_to_plain(@armors) }
+          armors: hash_to_plain(@armors), actors: actor_states }
       end
 
       def self.load(db, h)
@@ -137,7 +139,15 @@ class RPGXP
         (h[:items] || {}).each { |k, v| s.items[k] = v }
         (h[:weapons] || {}).each { |k, v| s.weapons[k] = v }
         (h[:armors] || {}).each { |k, v| s.armors[k] = v }
+        (h[:actors] || {}).each { |id, ah| a = s.actor(id); a && a.load_h(ah) }
         s
+      end
+
+      # The saved live state of every actor built so far (id => Game::Actor#to_h).
+      def actor_states
+        out = {}
+        (@actors || {}).each { |id, a| out[id] = a.to_h }
+        out
       end
 
       private
@@ -224,7 +234,85 @@ class RPGXP
           armor_id == @armor3_id || armor_id == @armor4_id
       end
 
+      # -- mutators (the Change Actor event commands) -------------------------
+
+      # Add `delta` to current HP, clamped to [floor, max HP]. `allow_death` (the
+      # command's "allow knockout" flag) lets HP reach 0; otherwise the floor is 1.
+      def change_hp(delta, allow_death = false)
+        @hp = clamp(@hp + delta, allow_death ? 0 : 1, max_hp)
+      end
+
+      # Add `delta` to current SP, clamped to [0, max SP].
+      def change_sp(delta); @sp = clamp(@sp + delta, 0, max_sp); end
+
+      # Fully restore HP and SP (RMXP Recover All also clears states, which are
+      # not modelled yet).
+      def recover_all
+        @hp = max_hp
+        @sp = max_sp
+      end
+
+      # Move the level by `delta` (Change Level); see #set_level.
+      def change_level(delta); set_level(@level + delta); end
+
+      # Set the level, clamped to 1..final_level. Newly-reached class learnings are
+      # learned (RMXP keeps skills on a level drop, so none are removed), and
+      # current HP/SP are re-clamped to the new maxima.
+      def set_level(level)
+        @level = clamp(level, 1, @record.final_level || 99)
+        learnable_skills(@level).each { |s| @skills.push(s) unless @skills.include?(s) }
+        @hp = max_hp if @hp > max_hp
+        @sp = max_sp if @sp > max_sp
+      end
+
+      def learn_skill(skill_id)
+        return if skill_id.nil? || skill_id == 0 || @skills.include?(skill_id)
+        @skills.push(skill_id)
+      end
+
+      def forget_skill(skill_id); @skills.delete(skill_id); end
+
+      # Equip an item into a slot: 0 weapon, 1..4 the four armor slots. An id of 0
+      # empties the slot. Other slot numbers are ignored.
+      def equip(slot, item_id)
+        case slot
+        when 0 then @weapon_id = item_id
+        when 1 then @armor1_id = item_id
+        when 2 then @armor2_id = item_id
+        when 3 then @armor3_id = item_id
+        when 4 then @armor4_id = item_id
+        end
+      end
+
+      # -- save round-trip ----------------------------------------------------
+
+      # The mutable state to persist (the fields the Change Actor commands touch);
+      # everything else is re-derived from the database on load.
+      def to_h
+        { level: @level, hp: @hp, sp: @sp, skills: @skills.dup,
+          weapon_id: @weapon_id, armor1_id: @armor1_id, armor2_id: @armor2_id,
+          armor3_id: @armor3_id, armor4_id: @armor4_id }
+      end
+
+      # Restore mutable state from #to_h (missing keys keep the database defaults);
+      # level is applied first so the saved HP/SP land against the right maxima.
+      def load_h(h)
+        return self unless h
+        @level = h[:level] if h[:level]
+        @skills = h[:skills].dup if h[:skills]
+        @weapon_id = h[:weapon_id] if h.key?(:weapon_id)
+        @armor1_id = h[:armor1_id] if h.key?(:armor1_id)
+        @armor2_id = h[:armor2_id] if h.key?(:armor2_id)
+        @armor3_id = h[:armor3_id] if h.key?(:armor3_id)
+        @armor4_id = h[:armor4_id] if h.key?(:armor4_id)
+        @hp = h[:hp] if h[:hp]
+        @sp = h[:sp] if h[:sp]
+        self
+      end
+
       private
+
+      def clamp(v, lo, hi); v < lo ? lo : (v > hi ? hi : v); end
 
       # The skill ids the class has taught by `level` (every learning at or below
       # it). RMXP seeds an actor's known skills this way at its starting level.

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -88,6 +88,12 @@ class RPGXP
       CHANGE_WEAPONS  = 127
       CHANGE_ARMOR    = 128
       CHANGE_PARTY    = 129
+      CHANGE_HP       = 311
+      CHANGE_SP       = 312
+      RECOVER_ALL     = 314
+      CHANGE_LEVEL    = 316
+      CHANGE_SKILLS   = 318
+      CHANGE_EQUIP    = 319
       TRANSFER_PLAYER = 201
       MOVE_ROUTE      = 209
       PLAY_BGM        = 241
@@ -278,6 +284,12 @@ class RPGXP
         when CHANGE_WEAPONS  then do_change_weapons(cmd)
         when CHANGE_ARMOR    then do_change_armor(cmd)
         when CHANGE_PARTY    then do_change_party(cmd)
+        when CHANGE_HP       then do_change_hp(cmd)
+        when CHANGE_SP       then do_change_sp(cmd)
+        when RECOVER_ALL     then do_recover_all(cmd)
+        when CHANGE_LEVEL    then do_change_level(cmd)
+        when CHANGE_SKILLS   then do_change_skills(cmd)
+        when CHANGE_EQUIP    then do_change_equipment(cmd)
         when TRANSFER_PLAYER then do_transfer(cmd)
         when MOVE_ROUTE      then do_move_route(cmd)
         when BATTLE_PROCESS  then do_battle_process(cmd)
@@ -681,6 +693,68 @@ class RPGXP
         else
           @state.party.delete(actor_id)
         end
+        @index += 1
+      end
+
+      # -- Change Actor commands ----------------------------------------------
+      # Each targets one actor via iterate_actor(param0 type, param1 id): a fixed
+      # id (type 0) or one read from a variable (type 1). The value commands take
+      # the operate_value triple (operation, operand type, operand) at 2/3/4.
+
+      # The live Game::Actor a Change Actor command targets, or nil for an unknown
+      # id. param0 selects fixed (0) vs variable-held (1) actor id in param1.
+      def change_actor_target(cmd)
+        id = param(cmd, 0) == 0 ? param(cmd, 1) : variables[param(cmd, 1)]
+        @state.actor(id)
+      end
+
+      # The signed operand of an operate command at parameter indices op/type/val:
+      # +value on increase (operation 0), -value on decrease (1); the value is a
+      # constant (type 0) or read from a variable (type 1).
+      def operate_value(cmd, op_i, type_i, val_i)
+        v = param(cmd, type_i) == 0 ? param(cmd, val_i, 0) : variables[param(cmd, val_i)]
+        param(cmd, op_i) == 0 ? v : -v
+      end
+
+      def do_change_hp(cmd)
+        a = change_actor_target(cmd)
+        a.change_hp(operate_value(cmd, 2, 3, 4), param(cmd, 5)) if a
+        @index += 1
+      end
+
+      def do_change_sp(cmd)
+        a = change_actor_target(cmd)
+        a.change_sp(operate_value(cmd, 2, 3, 4)) if a
+        @index += 1
+      end
+
+      def do_recover_all(cmd)
+        a = change_actor_target(cmd)
+        a.recover_all if a
+        @index += 1
+      end
+
+      def do_change_level(cmd)
+        a = change_actor_target(cmd)
+        a.change_level(operate_value(cmd, 2, 3, 4)) if a
+        @index += 1
+      end
+
+      # Change Skills (318): [actor_type, actor_id, operation(0 learn / 1 forget),
+      # skill_id].
+      def do_change_skills(cmd)
+        a = change_actor_target(cmd)
+        if a
+          param(cmd, 2) == 0 ? a.learn_skill(param(cmd, 3)) : a.forget_skill(param(cmd, 3))
+        end
+        @index += 1
+      end
+
+      # Change Equipment (319): [actor_type, actor_id, slot(0 weapon, 1..4 armor),
+      # item_id (0 removes)].
+      def do_change_equipment(cmd)
+        a = change_actor_target(cmd)
+        a.equip(param(cmd, 2), param(cmd, 3)) if a
         @index += 1
       end
 

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -418,6 +418,90 @@ assert "Interpreter: actor skill / weapon / armor / name conditionals" do
   assert_false s.switches[6]   # armor 99 not equipped
 end
 
+# Like xp_actor_db but with a full parameters table (levels 0..7, max HP =
+# 50 + 20/level) and a class that teaches skill 50 at level 2 and 60 at level 5,
+# for exercising the Change Actor commands (level-ups, stat regrowth).
+def xp_change_db
+  a = RPG::Actor.new
+  a.id = 1; a.name = "Aluxes"; a.class_id = 1
+  a.initial_level = 3; a.final_level = 6
+  a.weapon_id = 7; a.armor1_id = 11
+  a.armor2_id = 0; a.armor3_id = 0; a.armor4_id = 0
+  prm = Table.new(6, 8)
+  lv = 0
+  while lv < 8
+    prm[0, lv] = 50 + lv * 20; prm[1, lv] = 10 + lv * 5; prm[2, lv] = 5 + lv
+    prm[3, lv] = 4; prm[4, lv] = 3; prm[5, lv] = 2
+    lv += 1
+  end
+  a.parameters = prm
+  cls = RPG::Class.new; cls.id = 1
+  l1 = RPG::Class::Learning.new; l1.level = 2; l1.skill_id = 50
+  l2 = RPG::Class::Learning.new; l2.level = 5; l2.skill_id = 60
+  cls.learnings = [l1, l2]
+  FakeDB.new(actors: [nil, a], classes: [nil, cls])
+end
+
+assert "Interpreter: Change HP / SP / Recover All" do
+  s = RPGXP::Game::State.new(xp_change_db, [1], 1, 0, 0)
+  a = s.actor(1)                                   # level 3: max HP 110, max SP 25
+  run_to_end(s, [cmd(311, [0, 1, 1, 0, 40, false], 0)])  # HP -40
+  assert_equal 70, a.hp
+  run_to_end(s, [cmd(311, [0, 1, 1, 0, 999, false], 0)]) # can't knock out -> floor 1
+  assert_equal 1, a.hp
+  run_to_end(s, [cmd(311, [0, 1, 1, 0, 999, true], 0)])  # knockout allowed -> 0
+  assert_equal 0, a.hp
+  run_to_end(s, [cmd(312, [0, 1, 1, 0, 20], 0)])         # SP -20 (25 -> 5)
+  assert_equal 5, a.sp
+  run_to_end(s, [cmd(314, [0, 1], 0)])                   # Recover All
+  assert_equal 110, a.hp
+  assert_equal 25, a.sp
+end
+
+assert "Interpreter: Change Level learns skills and regrows stats" do
+  s = RPGXP::Game::State.new(xp_change_db, [1], 1, 0, 0)
+  a = s.actor(1)
+  assert_false a.knows_skill?(60)
+  run_to_end(s, [cmd(316, [0, 1, 0, 0, 2], 0)])          # level +2 -> 5
+  assert_equal 5, a.level
+  assert_true a.knows_skill?(50)                          # kept
+  assert_true a.knows_skill?(60)                          # learned at level 5
+  assert_equal 150, a.max_hp                              # 50 + 5*20
+end
+
+assert "Interpreter: Change Skills / Change Equipment (via a variable-held id)" do
+  s = RPGXP::Game::State.new(xp_change_db, [1], 1, 0, 0)
+  a = s.actor(1)
+  s.variables[9] = 1                                      # actor id in variable 9
+  run_to_end(s, [cmd(318, [1, 9, 0, 99], 0)])            # learn skill 99 (variable target)
+  assert_true a.knows_skill?(99)
+  run_to_end(s, [cmd(318, [0, 1, 1, 50], 0)])            # forget skill 50
+  assert_false a.knows_skill?(50)
+  run_to_end(s, [cmd(319, [0, 1, 0, 8], 0)])             # weapon slot 0 -> 8
+  assert_equal 8, a.weapon_id
+  run_to_end(s, [cmd(319, [0, 1, 3, 33], 0)])            # armor slot 3 -> 33
+  assert_equal 33, a.armor3_id
+  run_to_end(s, [cmd(319, [0, 1, 0, 0], 0)])             # remove the weapon
+  assert_equal 0, a.weapon_id
+end
+
+assert "Game::State save round-trip preserves mutated actor state" do
+  s = RPGXP::Game::State.new(xp_change_db, [1], 1, 0, 0)
+  a = s.actor(1)
+  run_to_end(s, [cmd(316, [0, 1, 0, 0, 2], 0)])          # level 5
+  run_to_end(s, [cmd(311, [0, 1, 1, 0, 30, true], 0)])   # HP -30
+  run_to_end(s, [cmd(318, [0, 1, 0, 77], 0)])            # learn skill 77
+  run_to_end(s, [cmd(319, [0, 1, 1, 44], 0)])            # armor1 -> 44
+  loaded = RPGXP::Game::State.load(xp_change_db, Marshal.load(Marshal.dump(s.to_h)))
+  b = loaded.actor(1)
+  assert_equal a.level, b.level
+  assert_equal a.hp, b.hp
+  assert_equal a.sp, b.sp
+  assert_equal a.skills.sort, b.skills.sort
+  assert_equal a.weapon_id, b.weapon_id
+  assert_equal a.armor1_id, b.armor1_id
+end
+
 assert "Interpreter: control variables from game quantities" do
   s = new_state # map_id 1, party [1]
   s.gold = 250


### PR DESCRIPTION
Builds on the per-actor model (#227): the **Change Actor** event commands now mutate it, and the mutations persist through the save.

## Commands

- **Change HP** (311) — honours the "allow knockout" flag (floor 0 vs 1)
- **Change SP** (312)
- **Recover All** (314)
- **Change Level** (316) — learns any newly-reached class skills and regrows the level-derived stats
- **Change Skills** (318) — learn / forget
- **Change Equipment** (319) — the weapon and four armor slots (id 0 empties a slot)

Each resolves its target through RMXP's `iterate_actor` (a fixed actor id, or one held in a variable) and the value commands through `operate_value` (increase/decrease, constant or variable operand), matching RGSS's `Interpreter`.

## Model + save

`Game::Actor` gains the mutators (`change_hp`/`change_sp`/`recover_all`/`change_level`/`set_level`/`learn_skill`/`forget_skill`/`equip`) plus `to_h`/`load_h`, and `Game::State` now serializes the mutated per-actor state (level, HP/SP, skills, equipment) into the Marshal save (only actors that were touched; untouched ones re-derive from the database).

## Tests

New `mruby-rpgxp/test` cases: Change HP/SP/Recover All (including the knockout floor), Change Level (skill-learning + stat regrowth), Change Skills / Change Equipment (with a variable-held target), and a full save round-trip that mutates level/HP/skills/equipment and reloads. The `rpgxp_testbed_check` (real OpenGame.exe XP data — 8 actors still build cleanly) and `rpgxp_script_host_check` harnesses stay green.

## Follow-ups

Change EXP (315), the exp-curve alignment of Change Level, and Change Parameters (317) — all need the RMXP EXP curve / per-actor stat deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_