### PR TITLE
rpg2k: per-actor battle commands — Attack/Defend + targeting (battle path, step 6)

### DIFF
--- a/changelog.d/rpg2k-battle-per-actor-commands.added.md
+++ b/changelog.d/rpg2k-battle-per-actor-commands.added.md
@@ -1,0 +1,13 @@
+- The battle screen now takes **per-actor commands each round** instead of a
+  single party-level Fight. For every living party member the player picks
+  **Attack** (then chooses which enemy to target) or **Defend**, and the round
+  then executes — party actions and enemy attacks resolve in agility order —
+  repeating until one side falls. Defending halves the damage that member takes
+  that round and forgoes its attack; cancelling on the first actor flees when the
+  encounter allows escape. `Game::Battle` gained the round-based API this needs
+  (`command_attack` / `command_defend` / `run_round`, with a chosen target and
+  the defend halving) alongside the existing headless `run`. The per-turn
+  animation, and Skill / Item commands, are still to come. Covered by new checks
+  in `scripts/rpg2k_logic_check.rb` (commanded-target attack, defend halves
+  damage) and updated ones in `scripts/rpg2k_scene_check.rb` (Attack to a win /
+  a loss over multiple rounds, and Flee).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -243,13 +243,16 @@ The work below is roughly ordered by the critical path to a walkable game
   for now, and `Scene::Map` traces the fight to the console from the log.
   Encounters now open a **battle screen** (driven by `Scene::Map` during the
   `:battle` wait, like the shop / inn): a status panel of the troop and each
-  party member's HP over a **Fight / Flee** command menu. Fight resolves the
-  battle and shows the result (`Victory!` with EXP / gold, or defeat); Flee
-  escapes when allowed; dismissing the result resumes the event and routes the
-  `[Victory]` / `[Escape]` / `[Defeat]` branch. Still to come: skills / items /
-  criticals / attributes / variance in the sim, the per-actor command menu
-  (Attack / Skill / Item / Defend + targeting) and per-turn animation from the
-  log, enemy / battler sprites, and game over on defeat.
+  party member's HP, and **per-actor commands each round** — for every living
+  member the player picks **Attack** (choosing a target) or **Defend** (half
+  damage, no attack that round), then the round executes in agility order,
+  repeating until a side falls. Cancelling on the first actor flees when escape
+  is allowed. `Game::Battle` has the round-based API (`command_attack` /
+  `command_defend` / `run_round`) alongside the headless `run`. Dismissing the
+  result resumes the event and routes the `[Victory]` / `[Escape]` / `[Defeat]`
+  branch. Still to come: Skill / Item commands, criticals / attributes / variance
+  in the sim, per-turn animation from the log, enemy / battler sprites, and game
+  over on defeat.
   The remaining commands (EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2495,7 +2495,11 @@ module Game
   class Battle
     # A battler reduced to what the fight needs. Snapshotting Game::Actor /
     # Game::Enemy keeps the real party untouched by a resolved battle.
-    Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp) do
+    # `action` is the ally's chosen attack target for the round (nil = none /
+    # auto), `defending` halves damage taken that round; both are cleared each
+    # round. Enemies leave them nil and attack a random party member.
+    Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
+                           :action, :defending) do
       def dead?; hp <= 0; end
     end
 
@@ -2549,6 +2553,32 @@ module Game
       @result = alive?(@allies) ? :victory : :defeat
     end
 
+    # Assign an ally's action for the coming round: attack `target`, or defend
+    # (take half damage and not attack). Player-driven battles command each ally
+    # before running the round; enemies choose their own action.
+    def command_attack(ally, target); ally.action = target; ally.defending = false; end
+    def command_defend(ally); ally.action = nil; ally.defending = true; end
+
+    # Execute one full round — living battlers act in agility order, allies using
+    # their assigned action, enemies attacking a random party member — and return
+    # the round's log entries. Ally commands are cleared afterwards for the next
+    # round. `finished?` / `result` report the outcome once a side is wiped.
+    def run_round
+      entries = []
+      refill_queue
+      until @queue.empty? || finished?
+        b = @queue.shift
+        next if b.dead?
+        entry = strike(b)
+        next unless entry
+        @log << entry
+        entries << entry
+      end
+      @allies.each { |a| a.action = nil; a.defending = false }
+      @result = alive?(@allies) ? :victory : :defeat if finished?
+      entries
+    end
+
     private
 
     def alive?(side); side.any? { |b| !b.dead? }; end
@@ -2564,16 +2594,28 @@ module Game
                           .sort_by { |b, i| [-b.agi, i] }.map { |b, _| b }
     end
 
-    # `b` attacks a random living member of the opposing side, returning a log
-    # entry (or nil when its side has no living target left).
+    # `b` attacks its target, returning a log entry (or nil when it defends or
+    # has no living target). A defending target takes half damage (min 1).
     def strike(b)
-      foes = (side_of(b) == :ally ? @enemies : @allies).reject(&:dead?)
-      return nil if foes.empty?
-      target = foes[@rng.random(foes.size)]
+      return nil if side_of(b) == :ally && b.defending # defending = no attack
+      target = attack_target(b)
+      return nil unless target
       dmg = Battle.attack_damage(b.atk, target.def)
+      dmg = [dmg / 2, 1].max if target.defending
       target.hp -= dmg
       { attacker: b.name, target: target.name, damage: dmg,
         target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead? }
+    end
+
+    # The living target `b` attacks: an ally uses its chosen target while it
+    # lives, otherwise a random living foe; enemies always pick a random party
+    # member.
+    def attack_target(b)
+      if side_of(b) == :ally && b.action && !b.action.dead?
+        return b.action
+      end
+      foes = (side_of(b) == :ally ? @enemies : @allies).reject(&:dead?)
+      foes.empty? ? nil : foes[@rng.random(foes.size)]
     end
 
     def side_of(b); @allies.any? { |a| a.equal?(b) } ? :ally : :enemy; end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1723,6 +1723,13 @@ class RPG2k
       # when allowed. Dismissing the result resumes the interpreter with the
       # outcome. The per-turn animation (stepping Game::Battle#log on screen) is a
       # later stage; for now Fight resolves the fight at once.
+      # Drive the turn-based battle screen the map shows during a :battle wait.
+      # Each round the player commands every living party member (Attack a chosen
+      # enemy, or Defend), then the round executes (party actions + enemy attacks,
+      # in agility order); this repeats until a side falls. B on the first actor
+      # flees when the encounter allows it. The per-turn animation of the round is
+      # still to come — for now the round applies at once and the status HP
+      # updates. Dismissing the result resumes the event with the outcome.
       def drive_battle
         req = @interpreter.battle_request
         return @interpreter.resume_battle(:victory) unless req
@@ -1730,7 +1737,11 @@ class RPG2k
           open_battle(req) # opened this frame; take input from the next one
           return
         end
-        @battle_ui[:phase] == :command ? drive_battle_command : drive_battle_result
+        case @battle_ui[:phase]
+        when :command then drive_battle_command
+        when :target  then drive_battle_target
+        when :result  then drive_battle_result
+        end
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle failed: #{e.message}"
         close_battle
@@ -1741,37 +1752,99 @@ class RPG2k
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
         foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
-        commands = ['Fight']
-        commands << 'Flee' if req[:allow_escape]
         @battle_ui = { phase: :command, req: req, troop: troop,
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000)),
-                       allies: allies, foes: foes, commands: commands, cmd: 0,
-                       status_win: build_battle_status(allies, foes),
-                       cmd_win: nil, result_win: nil, result: nil }
+                       allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
+                       status_win: nil, cmd_win: nil, target_win: nil,
+                       result_win: nil, result: nil }
+        refresh_battle_status
         draw_battle_command
       end
 
+      def living_allies; @battle_ui[:allies].reject(&:dead?); end
+      def living_foes;   @battle_ui[:foes].reject(&:dead?);   end
+      def current_actor; living_allies[@battle_ui[:actor_i]]; end
+
+      # Per-actor command menu: Attack (pick a target) or Defend.
       def drive_battle_command
-        cmds = @battle_ui[:commands]
-        if Input.trigger?(Input::DOWN) && @battle_ui[:cmd] < cmds.length - 1
+        if Input.trigger?(Input::DOWN) && @battle_ui[:cmd] < 1
           @battle_ui[:cmd] += 1
           draw_battle_command
         elsif Input.trigger?(Input::UP) && @battle_ui[:cmd] > 0
           @battle_ui[:cmd] -= 1
           draw_battle_command
         elsif Input.trigger?(Input::C)
-          cmds[@battle_ui[:cmd]] == 'Flee' ? finish_battle(:escape) : battle_fight
+          if @battle_ui[:cmd].zero?
+            @battle_ui[:target_i] = 0
+            @battle_ui[:phase] = :target
+            draw_battle_target
+          else
+            @battle_ui[:battle].command_defend(current_actor)
+            advance_actor
+          end
+        elsif Input.trigger?(Input::B)
+          if @battle_ui[:actor_i].zero?
+            finish_battle(:escape) if @battle_ui[:req][:allow_escape]
+          else
+            @battle_ui[:actor_i] -= 1 # re-command the previous member
+            @battle_ui[:cmd] = 0
+            draw_battle_command
+          end
         end
       end
 
-      # Resolve the fight, grant rewards on a win, and switch to the result
-      # window (the status / command windows come down).
-      def battle_fight
+      # Target-selection menu: pick which living enemy the current actor attacks.
+      def drive_battle_target
+        foes = living_foes
+        if Input.trigger?(Input::DOWN) && @battle_ui[:target_i] < foes.length - 1
+          @battle_ui[:target_i] += 1
+          draw_battle_target
+        elsif Input.trigger?(Input::UP) && @battle_ui[:target_i] > 0
+          @battle_ui[:target_i] -= 1
+          draw_battle_target
+        elsif Input.trigger?(Input::C)
+          @battle_ui[:battle].command_attack(current_actor, foes[@battle_ui[:target_i]])
+          close_battle_target
+          @battle_ui[:phase] = :command
+          advance_actor
+        elsif Input.trigger?(Input::B)
+          close_battle_target
+          @battle_ui[:phase] = :command
+          draw_battle_command
+        end
+      end
+
+      # Move to the next living party member, or execute the round once every
+      # member has a command.
+      def advance_actor
+        @battle_ui[:actor_i] += 1
+        @battle_ui[:cmd] = 0
+        if @battle_ui[:actor_i] >= living_allies.length
+          execute_round
+        else
+          draw_battle_command
+        end
+      end
+
+      # Run one round, refresh the HP display, and either show the result or open
+      # the next command phase.
+      def execute_round
         battle = @battle_ui[:battle]
-        result = battle.run
-        log_battle(battle, result)
-        lines = battle_result_lines(result, @battle_ui[:troop])
+        log_round(battle.run_round)
+        refresh_battle_status
+        if battle.finished?
+          enter_battle_result(battle.result)
+        else
+          @battle_ui[:actor_i] = 0
+          @battle_ui[:cmd] = 0
+          @battle_ui[:phase] = :command
+          draw_battle_command
+        end
+      end
+
+      def enter_battle_result(result)
         @battle_ui[:result] = result
+        lines = battle_result_lines(result, @battle_ui[:troop])
         [@battle_ui[:status_win], @battle_ui[:cmd_win]].each { |w| w.dispose if w }
         @battle_ui[:status_win] = nil
         @battle_ui[:cmd_win] = nil
@@ -1787,6 +1860,14 @@ class RPG2k
       def finish_battle(result)
         close_battle
         @interpreter.resume_battle(result)
+      end
+
+      def log_round(entries)
+        entries.each do |e|
+          line = "#{e[:attacker]} hits #{e[:target]} for #{e[:damage]}"
+          line += " — defeated!" if e[:defeated]
+          $stderr.puts "[RPG2k battle] #{line}"
+        end
       end
 
       # The result window's text: the outcome, and on a win the EXP / gold gained
@@ -1806,33 +1887,69 @@ class RPG2k
 
       BATTLE_LINE_H = 14
 
-      # A full-width panel near the top listing the enemy troop, then each party
-      # member with their HP — the battle's status display.
-      def build_battle_status(allies, foes)
-        lines = foes.map(&:name)
-        lines += allies.map { |a| "#{a.name}  HP #{a.hp}/#{a.max_hp}" }
-        battle_text_window(lines, 6, 300)
+      # Rebuild the status panel near the top: the enemy troop (marked down when
+      # defeated), then each party member with their HP.
+      def refresh_battle_status
+        @battle_ui[:status_win].dispose if @battle_ui[:status_win]
+        lines = @battle_ui[:foes].map { |e| e.dead? ? "#{e.name} (down)" : e.name }
+        lines += @battle_ui[:allies].map do |a|
+          "#{a.name}  HP #{a.hp < 0 ? 0 : a.hp}/#{a.max_hp}"
+        end
+        @battle_ui[:status_win] = battle_text_window(lines, 6, 300)
       end
 
-      # The Fight / Flee command menu, a small panel at the bottom with a cursor.
+      # The current actor's command menu — their name as a header, then Attack /
+      # Defend with a cursor.
       def draw_battle_command
-        cmds = @battle_ui[:commands]
+        actor = current_actor
+        return unless actor
         @battle_ui[:cmd_win].dispose if @battle_ui[:cmd_win]
-        w = 88
-        inner_h = cmds.length * BATTLE_LINE_H
+        labels = [actor.name, 'Attack', 'Defend']
+        w = 96
+        inner_h = labels.length * BATTLE_LINE_H
         win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
                          w, inner_h + Window::BORDER * 2)
         win.z = 320
         win.windowskin = @windowskin
         c = Bitmap.new(w - Window::BORDER * 2, inner_h)
         c.font.color = Color.new(255, 255, 255, 255)
-        cmds.each_with_index do |label, i|
+        labels.each_with_index do |label, i|
           c.draw_text 0, i * BATTLE_LINE_H, c.width, BATTLE_LINE_H, label
         end
         win.contents = c
+        # The cursor sits over Attack / Defend (rows 1 and 2, below the name).
         win.cursor_rect =
-          Rect.new(0, @battle_ui[:cmd] * BATTLE_LINE_H, c.width, BATTLE_LINE_H)
+          Rect.new(0, (1 + @battle_ui[:cmd]) * BATTLE_LINE_H, c.width, BATTLE_LINE_H)
         @battle_ui[:cmd_win] = win
+      end
+
+      # The target-selection menu — the living enemies, with a cursor.
+      def draw_battle_target
+        foes = living_foes
+        @battle_ui[:target_win].dispose if @battle_ui[:target_win]
+        w = 120
+        inner_h = [foes.length, 1].max * BATTLE_LINE_H
+        win = Window.new(SCREEN_W - w - 10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
+                         w, inner_h + Window::BORDER * 2)
+        win.z = 330
+        win.windowskin = @windowskin
+        c = Bitmap.new(w - Window::BORDER * 2, inner_h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        foes.each_with_index do |e, i|
+          c.draw_text 0, i * BATTLE_LINE_H, c.width, BATTLE_LINE_H, e.name
+        end
+        win.contents = c
+        unless foes.empty?
+          win.cursor_rect =
+            Rect.new(0, @battle_ui[:target_i] * BATTLE_LINE_H, c.width, BATTLE_LINE_H)
+        end
+        @battle_ui[:target_win] = win
+      end
+
+      def close_battle_target
+        return unless @battle_ui[:target_win]
+        @battle_ui[:target_win].dispose
+        @battle_ui[:target_win] = nil
       end
 
       def open_battle_result(lines)
@@ -1860,19 +1977,8 @@ class RPG2k
       def close_battle
         return unless @battle_ui
         [@battle_ui[:status_win], @battle_ui[:cmd_win],
-         @battle_ui[:result_win]].each { |w| w.dispose if w }
+         @battle_ui[:target_win], @battle_ui[:result_win]].each { |w| w.dispose if w }
         @battle_ui = nil
-      end
-
-      # Trace a resolved battle blow-by-blow to the console — a stand-in for the
-      # on-screen battle log until the battle screen exists.
-      def log_battle(battle, result)
-        battle.log.each do |e|
-          line = "#{e[:attacker]} hits #{e[:target]} for #{e[:damage]}"
-          line += " — defeated!" if e[:defeated]
-          $stderr.puts "[RPG2k battle] #{line}"
-        end
-        $stderr.puts "[RPG2k battle] #{result}"
       end
 
       def drive_wait

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3060,6 +3060,28 @@ check 'Battle#run records a combat log of every hit' do
   ok b.log.all? { |e| e[:damage] >= 1 }, 'every hit did at least 1 damage'
 end
 
+check 'Battle: a commanded attack hits the chosen enemy; run_round clears it' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  a = combatant('A', 0, 0, 5, 100) # harmless, slow enemies
+  b = combatant('B', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [a, b], Game::Rng.new(1))
+  bat.command_attack(hero, b) # target B specifically
+  bat.run_round
+  eq 100, a.hp, 'A was not the chosen target'
+  eq 80, b.hp, 'B took 20 damage (40/2 - 0/4)'
+  eq nil, hero.action, 'the command is cleared for the next round'
+end
+
+check 'Battle: a defending ally takes half damage and does not attack' do
+  hero = combatant('Hero', 40, 0, 1, 100) # slow, so the foe acts first
+  foe = combatant('Foe', 40, 0, 20, 100)  # 40/2 = 20 damage, halved to 10
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1))
+  bat.command_defend(hero)
+  bat.run_round
+  eq 100, foe.hp, 'the defending hero did not strike back'
+  eq 90, hero.hp, 'took half of 20 = 10'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1292,60 +1292,67 @@ check 'Open Shop scene: leaving without buying runs the No Transaction branch' d
   ok st.switches[2], 'the No Transaction branch ran'
 end
 
-check 'Enemy Encounter scene: winning the battle grants rewards, runs Victory' do
-  ic = Game::Interpreter::Cmd
-  auto = page(trigger: 3)
-  auto.event_commands = [
-    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 1, 0], indent: 0), # troop 1
+# Battle command / result command lists for the encounter tests below.
+def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil)
+  handler2 = second_switch_code || ic::ESCAPE_HANDLER
+  [
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, escape_mode, 1, 0], indent: 0),
     ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
     ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
-    ECmd.new(ic::ESCAPE_HANDLER, [], indent: 0),
-    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(handler2, [], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, (handler2 == ic::DEFEAT_HANDLER ? 3 : 2),
+                                    (handler2 == ic::DEFEAT_HANDLER ? 3 : 2), 0], indent: 1),
     ECmd.new(ic::END_BATTLE, [], indent: 0)
   ]
+end
+
+# Drive a battle by having each living actor Attack the first enemy every round
+# until the result window appears (command / target cursors start on Attack /
+# the first target).
+def battle_attack_to_end(scene, max = 100)
+  max.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :result
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && %i[command target].include?(ui[:phase])
+    scene.update # a nil ui just means the battle is still opening
+    RGSS::Input.triggered = []
+  end
+end
+
+check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Victory' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  3.times { scene.update } # the battle UI opens on the Fight command menu
-  eq 0, st.party.gold, 'no rewards until the fight is resolved'
-  RGSS::Input.triggered = [RGSS::Input::C] # choose Fight
-  scene.update
-  RGSS::Input.triggered = []
-  scene.update # battle resolves (strong party wins); rewards + result window
+  scene.update # opens the per-actor command menu (Attack / Defend)
+  eq 0, st.party.gold, 'no rewards mid-battle'
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
   eq 20, st.party.gold, 'gained the troop gold (2 Slimes x 10)'
   eq 10, st.party.actors.first.exp, 'gained the troop EXP (2 Slimes x 5)'
   ok !st.switches[1], 'showing the Victory result'
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the result
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss result
   scene.update
   RGSS::Input.triggered = []
-  3.times { scene.update } # interpreter resumes -> runs the Victory handler
-  ok st.switches[1], 'the Victory handler ran after the result was dismissed'
+  3.times { scene.update }
+  ok st.switches[1], 'the Victory handler ran'
   ok !st.switches[2], 'the Escape handler was skipped'
 end
 
 check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
-  auto.event_commands = [
-    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 1, 0], indent: 0),
-    ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
-    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
-    ECmd.new(ic::DEFEAT_HANDLER, [], indent: 0),
-    ECmd.new(ic::CONTROL_SWITCHES, [0, 3, 3, 0], indent: 1),
-    ECmd.new(ic::END_BATTLE, [], indent: 0)
-  ]
+  auto.event_commands = battle_event_commands(ic, second_switch_code: ic::DEFEAT_HANDLER)
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   # A frail hero the two Slimes overwhelm.
   st.instance_variable_set(:@party,
                            BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
-  3.times { scene.update } # command menu opens
-  RGSS::Input.triggered = [RGSS::Input::C] # Fight
   scene.update
-  RGSS::Input.triggered = []
-  scene.update # the party loses; defeat result window opens
-  ok !st.switches[1] && !st.switches[3], 'result window is up'
-  RGSS::Input.triggered = [RGSS::Input::C] # dismiss
+  battle_attack_to_end(scene)
+  ok !st.switches[1] && !st.switches[3], 'defeat result window is up'
+  RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.triggered = []
   3.times { scene.update }
@@ -1355,26 +1362,15 @@ check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   ok st.switches[3], 'the Defeat handler ran'
 end
 
-check 'Enemy Encounter scene: Flee escapes when allowed, runs Escape' do
+check 'Enemy Encounter scene: Flee (B on the first actor) runs Escape' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
-  auto.event_commands = [
-    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 2, 1, 0], indent: 0), # escape mode 2 (custom)
-    ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
-    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
-    ECmd.new(ic::ESCAPE_HANDLER, [], indent: 0),
-    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
-    ECmd.new(ic::END_BATTLE, [], indent: 0)
-  ]
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2) # custom escape handler
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  3.times { scene.update } # command menu offers Fight / Flee
-  RGSS::Input.triggered = [RGSS::Input::DOWN] # cursor to Flee
-  scene.update
-  RGSS::Input.triggered = []
-  scene.update
-  RGSS::Input.triggered = [RGSS::Input::C] # Flee -> escape
+  2.times { scene.update } # the encounter runs, then the command menu opens
+  RGSS::Input.triggered = [RGSS::Input::B] # Flee (cancel on the first actor)
   scene.update
   RGSS::Input.triggered = []
   3.times { scene.update } # interpreter resumes -> Escape handler


### PR DESCRIPTION
Step 6 of the battle path (option 1, next stage): replace the single party-level Fight with a real **per-actor command menu** each round.

## What changed
Each round, for every living party member the player picks:
- **Attack** — then chooses which enemy to target.
- **Defend** — takes half damage that round and forgoes its attack.

Then the round **executes** (party actions + enemy attacks, in agility order), and it repeats until one side falls. Cancelling (B) on the first actor **flees** when the encounter allows escape.

`Game::Battle` gained the round-based API this needs:
- `command_attack(ally, target)` / `command_defend(ally)` assign an ally's action for the coming round.
- `run_round` executes one round using those commands (enemies attack a random party member), clears them, and reports the outcome.
- A defending target takes half damage (min 1) and a defending ally doesn't attack.

The headless `run` / `step` path is unchanged — allies with no command auto-attack — so previous resolutions still hold. `Scene::Map` drives the command / target / result phases during the `:battle` wait.

## Still ahead
Per-turn animation (stepping `Game::Battle#log` on screen), the Skill / Item commands, criticals / attributes / variance, battler sprites, and game over on defeat.

## Testing
- `scripts/rpg2k_logic_check.rb` — **208 pass** (new: a commanded attack hits the chosen enemy and the command clears; a defending ally takes half damage and doesn't attack)
- `scripts/rpg2k_scene_check.rb` — **65 pass** (rewritten: Attack each round to a win over several rounds; to a loss with a frail party; Flee via cancel on the first actor)

Docs (`docs/TODO.md`) and a `changelog.d/` fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_