### PR TITLE
Make our exported .lsd loadable by RPG_RT, and correct why it was not

### DIFF
--- a/changelog.d/rpg2k-lsd-export-loadable.fixed.md
+++ b/changelog.d/rpg2k-lsd-export-loadable.fixed.md
@@ -1,0 +1,10 @@
+- **Saves exported as `Save<N>.lsd` can now be loaded by the genuine
+  `RPG_RT.exe`.** `Game::State#to_lsd` defaulted the file-screen date to `0.0`,
+  and zero on the OLE-automation scale is 1899-12-30 — which RPG_RT reads as an
+  *empty file slot*, so it silently ignored the save and left "Continue" dead,
+  with no error anywhere. The date now defaults to the current time.
+  The cause previously recorded for this — that our five chunks against a real
+  save's sixteen were simply too few — was wrong: a real save stripped to
+  exactly those five chunks still loads. Swapping in one of our chunks at a time
+  isolated the title chunk, then the single field. Pinned by
+  `scripts/rpg2k_save_load_check.rb`, and the ADR 0021 write-up is corrected.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -94,14 +94,19 @@ The work below is roughly ordered by the critical path to a walkable game
     region of the resumed frame is now pixel-identical to RPG_RT. Zoom, opacity
     and tone have save fields but no sample where they are off their defaults,
     so they are still left at `Picture`'s defaults rather than guessed at.
-  - **`Game::State#to_lsd` output is not loadable by RPG_RT.** It round-trips
-    through our own parser (`scripts/lcf_save_roundtrip.rb`), but the genuine
-    runtime just leaves "Continue" dead: a real save is sixteen chunks and
-    11–18 KB, ours is five chunks and ~180 bytes, missing the vehicles,
-    pictures, map events and common events plus chunks 102/112/200, which are
-    not in our schema at all. Until then anything that must be read by RPG_RT
-    has to start from a save `scripts/gen-lcf-save-wine.bash` produced and be
-    *edited*, which preserves untouched chunks byte-for-byte.
+  - ✅ **`Game::State#to_lsd` output is loadable by RPG_RT.** It round-tripped
+    through our own parser (`scripts/lcf_save_roundtrip.rb`) but the genuine
+    runtime left "Continue" dead, with no error anywhere. The assumed cause —
+    that our five chunks against a real save's sixteen were too few — was
+    **wrong**: a real save stripped to exactly those five chunks still loads.
+    Swapping in one of our chunks at a time isolated the title chunk (100), and
+    then the field: `to_lsd` wrote the file-screen date as `0.0`, and zero on
+    the OLE-automation scale is 1899-12-30, which RPG_RT reads as an *empty
+    slot*. It now defaults to the current time, and a from-scratch `to_lsd` save
+    loads in the real runtime. A `to_lsd` save still carries no picture,
+    map-event or vehicle state, so it resumes into a bare scene — enough to
+    prove the file loads, not enough to compare rendering, which is why the
+    comparison harness still edits a genuine save.
 - ✅ Parallax background — `Scene::Map` draws the map's `Panorama/<name>`
   backdrop behind the tile layers (a sprite at z = -1). `Game::Parallax` ports
   EasyRPG's parallax model: a looping axis tiles the image and scrolls it at

--- a/docs/adr/0021-nepheshel-render-parity-under-wine.md
+++ b/docs/adr/0021-nepheshel-render-parity-under-wine.md
@@ -126,16 +126,46 @@ whichever map the comparison wants.
 
 Two things had to be learned the hard way, and both are worth keeping:
 
-**The save must be a genuine one.** `Game::State#to_lsd` can write a
+**The save had to be a genuine one.** `Game::State#to_lsd` can write a
 `Save<N>.lsd` from nothing and it round-trips through our own parser, so it
-looked usable — but RPG_RT silently refuses to load it and "Continue" just
-does nothing on the title screen. A real save carries sixteen chunks and
-11–18 KB; `to_lsd` emits five and ~180 bytes, with no vehicles, pictures, map
-events or common events, and none of the three chunks (102, 112, 200) that are
-not in our schema at all. `scripts/lcf_save_roundtrip.rb` could never have
-caught this: it only proves we can re-read our own output. So the harness starts
-from a save `gen-lcf-save-wine.bash` produced with EasyRPG and *edits* it, which
-preserves every untouched chunk byte-for-byte.
+looked usable — but RPG_RT silently refused to load it and "Continue" just did
+nothing on the title screen, with no error anywhere.
+`scripts/lcf_save_roundtrip.rb` could never have caught that: it only proves we
+can re-read our *own* output. So the harness was built to start from a save
+`gen-lcf-save-wine.bash` produced with EasyRPG and *edit* it, which preserves
+every untouched chunk byte-for-byte.
+
+The obvious explanation was that too much was missing — a real save carries
+sixteen chunks and 11–18 KB where `to_lsd` emits five and ~180 bytes, with no
+vehicles, pictures, map events or common events, and none of chunks 102, 112 or
+200, which our schema does not model at all. **That explanation was wrong**, and
+this ADR asserted it before it was tested. Stripping a real save down to exactly
+the five chunks `to_lsd` writes produces a 9.6 KB file that RPG_RT still loads
+happily, so nothing was missing at all.
+
+Swapping our version of one chunk at a time into that stripped save found the
+real cause in the title chunk (100), and then one field at a time within it:
+
+| Variant of the stripped-but-loadable save | Result |
+| --- | --- |
+| our chunk 101 / 104 / 108 / 109 | loads |
+| our chunk 100 | **refused** |
+| our chunk 100, with a real date in field 1 | loads |
+| our chunk 100, with the face fields dropped instead | refused |
+
+`to_lsd` defaulted the file-screen date to `0.0`. Zero on the OLE-automation
+scale is 1899-12-30, which RPG_RT reads as an **empty file slot** — so it never
+offered the save, and never reported a problem either. The date now defaults to
+the current time (`State.ole_now`), and a `to_lsd` save written from scratch
+loads in the genuine RPG_RT: it leaves the title, the process stays alive and
+keeps responding to input. Pinned by a check in
+`scripts/rpg2k_save_load_check.rb`, since nothing else about the file-screen
+metadata has this effect.
+
+The harness still edits a genuine save rather than writing one, and should: a
+`to_lsd` save carries no picture, map-event or vehicle state, so resuming it
+lands in a valid but bare scene — fine for proving the file loads, useless for
+comparing rendering.
 
 **The first thing the comparison found: shown pictures were not restored on
 load.** Resuming Nepheshel's opening, RPG_RT drew the cutscene's background

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2754,12 +2754,21 @@ module Game
     # Switch and variable ids are 1-indexed in-game but 0-indexed in the save, so
     # they shift down by one; unset entries default to false / 0. +save_count+
     # goes in the system chunk (RPG_RT increments it on every save); +timestamp+
-    # is the OLE-automation date shown on the file screen (a placeholder default,
-    # since this environment has no clock and the save-select scene is not drawn
-    # yet). The only live-state fields still dropped versus #to_h are the game
-    # timer (which liblcf's SaveSystem has no field for) and per-actor name/title
+    # is the OLE-automation date shown on the file screen, defaulting to now.
+    #
+    # That default used to be 0.0, and it is why the genuine RPG_RT refused to
+    # load anything this wrote: a zero date is 1899-12-30, which RPG_RT reads as
+    # an empty slot, so "Continue" stayed dead with no error at all. It was
+    # found by stripping a real save down to exactly the chunks written here
+    # (it still loaded, so nothing was missing), then swapping in one of ours at
+    # a time until only the title chunk failed, then one field at a time within
+    # it. See ADR 0021.
+    #
+    # The only live-state fields still dropped versus #to_h are the game timer
+    # (which liblcf's SaveSystem has no field for) and per-actor name/title
     # overrides for non-leader members, so this is now a near-parity export.
-    def to_lsd(save_count = 1, timestamp = 0.0)
+    def to_lsd(save_count = 1, timestamp = nil)
+      timestamp = State.ole_now if timestamp.nil?
       save = LCF::SaveData.new
 
       leader = @party.leader
@@ -2976,6 +2985,26 @@ module Game
                                x: (pic.current_x || 0).to_i,
                                y: (pic.current_y || 0).to_i)
       end
+    end
+
+    # Days from the OLE-automation epoch (1899-12-30) to the Unix epoch. RPG_RT
+    # stores a save's date as days-since-1899-12-30 in a double, the fraction
+    # being the time of day.
+    OLE_EPOCH_OFFSET = 25569
+
+    # A save date RPG_RT will accept, as of now. It must be non-zero: RPG_RT
+    # treats a zero date as an empty file slot and will not offer the save (see
+    # #to_lsd). Falls back to a fixed, plainly-synthetic date if this build has
+    # no clock, since any valid date beats the one value that breaks loading.
+    #
+    # 2000-01-01, the sentinel: recognisable in a file screen as "not a real
+    # play session" without being a value RPG_RT rejects.
+    NO_CLOCK_TIMESTAMP = 36526.0
+
+    def self.ole_now
+      Time.now.to_i / 86400.0 + OLE_EPOCH_OFFSET
+    rescue StandardError
+      NO_CLOCK_TIMESTAMP
     end
 
     # Rebuild our `{ name:, volume:, tempo: }` BGM hash from a parsed BGM chunk

--- a/scripts/compare-nepheshel-save-wine.bash
+++ b/scripts/compare-nepheshel-save-wine.bash
@@ -17,10 +17,10 @@
 # map this comparison wants.
 #
 # It has to be a *genuine* save. Game::State#to_lsd can emit one from nothing,
-# and it round-trips through our own parser, but RPG_RT will not load it --
-# "Continue" simply stays dead on the title screen (a real save has sixteen
-# chunks and ~11-18 KB; to_lsd emits five and ~180 bytes). See gen-rpg2k-save.rb
-# and docs/TODO.md.
+# and RPG_RT does load those now, but such a save holds only the five chunks
+# that model our runtime state -- no pictures, no map events, no vehicles -- so
+# it resumes into a valid but bare scene, which cannot be compared against the
+# real thing. See gen-rpg2k-save.rb and ADR 0021.
 #
 # Each runtime is then brought to the map without input:
 #   * ours with --rpg2k_continue (auto-selects Continue on the title screen);

--- a/scripts/gen-rpg2k-save.rb
+++ b/scripts/gen-rpg2k-save.rb
@@ -14,15 +14,17 @@
 # timed, so it cannot drift; this puts that save wherever the comparison needs
 # it.
 #
-# WHY IT EDITS A SAVE INSTEAD OF WRITING ONE: `Game::State#to_lsd` can already
-# emit a Save<N>.lsd from nothing, and it round-trips through our own parser --
-# but the genuine RPG_RT *refuses to load it*, leaving "Continue" dead on the
-# title screen. A real save carries sixteen chunks (~11-18 KB); to_lsd emits
-# five (~180 bytes), missing the vehicles, pictures, map events, common events
-# and three chunks not in our schema at all (102, 112, 200). Editing a genuine
-# save sidesteps that entirely: every chunk we do not touch is preserved
-# byte-for-byte, which scripts/lcf_save_roundtrip.rb already proves our writer
-# does. Making to_lsd's own output loadable is tracked separately in docs/TODO.md.
+# WHY IT EDITS A SAVE INSTEAD OF WRITING ONE: `Game::State#to_lsd` can emit a
+# Save<N>.lsd from nothing, and the genuine RPG_RT does load one now (it used to
+# refuse them -- the file-screen date defaulted to 0.0, which is 1899-12-30 on
+# the OLE scale and reads as an empty slot; see ADR 0021). But a to_lsd save
+# carries only the five chunks that model our runtime state: no pictures, no map
+# events, no vehicles. It resumes into a valid but *bare* scene, which is no use
+# for comparing rendering against the real thing.
+#
+# Editing a genuine save keeps all of that: every chunk not touched here is
+# preserved byte-for-byte, which scripts/lcf_save_roundtrip.rb already proves
+# our writer does.
 #
 # Get the base save with scripts/gen-lcf-save-wine.bash, which drives EasyRPG
 # Player's F9 debug menu under wine to write one without a playthrough.

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -165,6 +165,18 @@ def check_game(dir)
   end.new(empty), blank)
   eq({}, empty, 'an unnamed picture slot is not re-shown')
 
+  # The save's date must not be zero. RPG_RT reads a zero OLE date (1899-12-30)
+  # as an empty file slot and silently refuses the save -- "Continue" simply does
+  # nothing, with no error anywhere -- which is exactly what to_lsd used to write
+  # and why nothing it produced could be loaded by the genuine runtime (ADR
+  # 0021). Nothing else in the file screen's metadata has that effect, so this is
+  # the one field worth pinning.
+  stamp = state.to_lsd[100][1]
+  eq true, !stamp.nil? && stamp > 0,
+     "to_lsd writes a non-zero save date (got #{stamp.inspect})"
+  # A caller-supplied date still wins, so a deterministic export stays possible.
+  eq 40000.0, state.to_lsd(1, 40000.0)[100][1], 'an explicit timestamp is kept'
+
   # Writer round-trip (ADR 0019): serialise the runtime state back to a genuine
   # .lsd with State#to_lsd, re-read it with State.from_lsd, and confirm every
   # modelled field survives -- i.e. to_lsd is a faithful inverse of from_lsd.


### PR DESCRIPTION
Closes the last item left open by #228 — and corrects the reason that PR gave for it, which was wrong.

## The bug

`Game::State#to_lsd` defaulted the file-screen date to `0.0`. Zero on the OLE-automation scale is **1899-12-30**, which the genuine `RPG_RT.exe` reads as an **empty file slot**: it never offered the save and never reported a problem, so "Continue" just did nothing on the title screen.

The date now defaults to the current time (`State.ole_now`), and a `to_lsd` save written from scratch — all 179 bytes of it — loads in the real runtime: it leaves the title screen, and the process stays alive and keeps responding to input. An explicit `timestamp` argument still wins, so a deterministic export remains possible.

## The correction

#228 recorded a different cause in ADR 0021, `docs/TODO.md` and two script headers: that RPG_RT refused our saves because five chunks against a real save's sixteen was simply too little. That was plausible, and I asserted it without testing it. **It is wrong.**

Stripping a real save down to exactly the five chunks `to_lsd` writes gives a 9.6 KB file that RPG_RT still loads happily — so nothing was missing. Swapping our version of one chunk at a time into that stripped save isolated the fault, and then a field-at-a-time pass isolated it further:

| Variant of the stripped-but-loadable save | Result |
| --- | --- |
| our chunk 101 / 104 / 108 / 109 | loads |
| our chunk 100 (title) | **refused** |
| our chunk 100, with a real date in field 1 | loads |
| our chunk 100, with the face fields dropped instead | refused |

Every "refused" above is the title screen still showing after Down → Return → Return; every "loads" is it gone. A control run of the unmodified save through the same harness distinguishes the two, since the reference's opening is animated and frames are never identical between runs.

## Why the harness still edits a genuine save

Unchanged, but the headers now say why. A `to_lsd` save holds only the five chunks that model our runtime state — no pictures, no map events, no vehicles — so it resumes into a valid but **bare** scene. That is enough to prove the file loads and useless for comparing rendering, which is what `scripts/compare-nepheshel-save-wine.bash` exists to do.

## Verification

* Two new checks in `scripts/rpg2k_save_load_check.rb`: the written date is non-zero, and an explicit timestamp is kept. Both verified to fail when the old `0.0` default is put back.
* `rpg2k_logic_check` (206), `rpg2k_scene_check` (68), `rpg2k_render_check` (35), `rpg2k_save_load_check`, `lcf_save_roundtrip`, `lcf_save_check`, `lcf_testbed_check`, `cmake --build build -t test` — all pass.
* `scripts/rpg2k_boot_check.bash` on both test-beds.
* The load itself, against the genuine `RPG_RT.exe` under wine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GaJTmgx1TB7ZCUGFjSh3j

---
_Generated by [Claude Code](https://claude.ai/code/session_018GaJTmgx1TB7ZCUGFjSh3j)_