### PR TITLE
Draw the screen fade and flash overlays

### DIFF
--- a/changelog.d/rpg2k-screen-fade-flash-drawn.added.md
+++ b/changelog.d/rpg2k-screen-fade-flash-drawn.added.md
@@ -1,0 +1,13 @@
+- **Erase / Show Screen and Flash Screen now actually draw.** Both were modelled
+  in `Game::Screen` but nothing rendered them, so a game that faded to black
+  simply kept playing in full view. `Scene::Map` now carries two screen-sized
+  colour sprites above everything — the message window included, which is what
+  RPG2000 does — shown at the effect's own 0..255 strength.
+
+  These were recorded as blocked on native `RGSS::Viewport` tone/alpha support.
+  They were not: `RGSS::Sprite#opacity` is already LVGL's per-object alpha at
+  blit time, so no C++ change was needed. Verified in the real binary first —
+  forcing the fade layer to opacity 128 halves the rendered frame's mean
+  brightness. The **tint** does still need native work, since a tone multiplies
+  against what is already drawn and cannot be reproduced by compositing a solid
+  colour over it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -325,9 +325,9 @@ The work below is roughly ordered by the critical path to a walkable game
   horizontal offset (amplitude from power, rate from speed) that `Scene::Map`
   subtracts from the camera, so — unlike the tint — the shake **is** visible
   with the current renderer. **Flash Screen** (11040) drives `Game::Screen` too:
-  a colour + strength that fades to zero over the duration; like the tint it is
-  the Ruby half (drawing the full-screen colour overlay at its strength needs
-  the same alpha-blend / viewport support in C++). **Pan Screen** (11060) drives
+  a colour + strength that fades to zero over the duration, and it **is** drawn:
+  a screen-sized colour sprite above everything, shown at the flash's strength
+  through `Sprite#opacity`. **Pan Screen** (11060) drives
   `Game::Screen` as well: lock / unlock freeze or resume the camera's hero
   follow, and pan / reset scroll a pixel offset toward a target that `Scene::Map`
   adds to the camera (so — like the shake — the pan **is** visible; while locked
@@ -335,11 +335,22 @@ The work below is roughly ordered by the critical path to a walkable game
   (11020) drive `Game::Screen` too: a fade level (0 visible .. 255 black) that
   eases like the tint over a fixed transition and is held erased until a Show,
   recording the requested transition style (fade / block / stripe / scroll) for
-  fidelity while modelling only the fade. All share the `:screen` wait, so event
-  timing around them is correct. **Show Picture** now renders (see the
-  interpreter bullet above). Weather remains, and the tint / flash / screen-fade
-  overlays still need `RGSS::Viewport` tone/alpha support in C++ to actually
-  darken or colour what is drawn
+  fidelity while modelling only the fade — and the fade **is** drawn, by the
+  same screen-sized sprite mechanism as the flash. All share the `:screen` wait,
+  so event timing around them is correct. **Show Picture** now renders (see the
+  interpreter bullet above).
+
+  The fade and flash overlays were listed here as blocked on `RGSS::Viewport`
+  tone/alpha support in C++. **They were not**: `RGSS::Sprite#opacity` already
+  maps onto LVGL's per-object alpha at blit time, so a screen-sized sprite of
+  solid colour shown at the effect's strength is the entire mechanism, in Ruby.
+  Confirmed in the real binary before the code was written — forcing the fade
+  layer to opacity 128 halves the rendered frame's mean brightness (31.9 → 15.2).
+
+  Still open here: **weather**, and the **tint** (Tint Screen), which really does
+  need native work — a tone is a per-channel multiply against what is already
+  drawn, and no amount of compositing a solid colour on top reproduces that.
+  Tint remains the Ruby half only
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -504,7 +504,7 @@ class RPG2k
         close_shop
         close_battle
         [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
-         @picture_sprite].each do |s|
+         @picture_sprite, @fade_sprite, @flash_sprite].each do |s|
           s.dispose if s
         end
         @chipset_bmp.dispose if @chipset_bmp
@@ -563,6 +563,58 @@ class RPG2k
 
         setup_parallax
         setup_pictures
+        setup_screen_overlay
+      end
+
+      # The full-screen colour layers Erase/Show Screen (fade) and Flash Screen
+      # draw. Both sit above everything, message window included -- RPG2000 fades
+      # and flashes the whole screen, not just the map.
+      #
+      # No native work was needed for this, despite the note in docs/TODO.md that
+      # it wanted "alpha-blend / viewport support in C++": RGSS::Sprite#opacity
+      # already maps onto LVGL's per-object alpha at blit time, which is exactly
+      # the per-sprite opacity RGSS specifies. So a screen-sized sprite of solid
+      # colour, shown at the effect's strength, is the whole mechanism.
+      #
+      # The bitmaps are filled once and only re-filled when the colour changes
+      # (never, for the always-black fade): a per-frame fill of the screen would
+      # be 76800 pixel writes to produce the same image, where changing the
+      # opacity is one property set.
+      def setup_screen_overlay
+        @fade_sprite = Sprite.new
+        @fade_sprite.z = 500
+        @fade_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        @fade_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(0, 0, 0, 255)
+        @fade_sprite.bitmap = @fade_bmp
+        @fade_sprite.opacity = 0
+
+        @flash_sprite = Sprite.new
+        @flash_sprite.z = 450
+        @flash_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        @flash_sprite.bitmap = @flash_bmp
+        @flash_sprite.opacity = 0
+        @flash_rgb = nil
+      end
+
+      # Push this frame's fade and flash levels onto the two overlay sprites.
+      # Both are 0..255 already: Game::Screen models the fade as 0 visible ..
+      # 255 black, and the flash as a colour plus a 0..255 strength that decays
+      # over the command's duration.
+      def update_screen_overlay
+        screen = @state.screen
+        @fade_sprite.opacity = screen.fade_level
+
+        r, g, b, strength = screen.flash_color
+        if strength <= 0
+          @flash_sprite.opacity = 0
+        else
+          rgb = [r, g, b]
+          if @flash_rgb != rgb
+            @flash_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(r, g, b, 255)
+            @flash_rgb = rgb
+          end
+          @flash_sprite.opacity = strength
+        end
       end
 
       # Create the buffer that carries the Show Picture layer. Pictures composite
@@ -2424,6 +2476,7 @@ class RPG2k
         draw_player_frame
 
         draw_pictures cam_x, cam_y
+        update_screen_overlay
       end
 
       # Composite the Show Picture layer into its buffer, drawing lowest-id first

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -21,8 +21,13 @@ require 'ostruct'
 module RGSS
   Rect = Struct.new(:x, :y, :width, :height)
 
+  # Records its components so the screen-overlay checks can assert the colour a
+  # layer was filled with, not just that a fill happened.
   class Color
-    def initialize(*); end
+    attr_reader :red, :green, :blue, :alpha
+    def initialize(r = 0, g = 0, b = 0, a = 255)
+      @red = r; @green = g; @blue = b; @alpha = a
+    end
   end
 
   # A no-op drawing surface. Records nothing; every draw call is ignored. A
@@ -39,7 +44,8 @@ module RGSS
       end
     end
     def clear; end
-    def fill_rect(*); end
+    def fill_rect(*a); (@fill_calls ||= []) << a; end
+    attr_reader :fill_calls
     def blt(*); end
     def stretch_blt(*); end
     # Record draw_text / blend_text calls so message-rendering checks can assert
@@ -58,7 +64,7 @@ module RGSS
   Color2 = Struct.new(:red, :green, :blue, :alpha)
 
   class Sprite
-    attr_accessor :bitmap, :x, :y, :z, :visible
+    attr_accessor :bitmap, :x, :y, :z, :visible, :opacity
     def initialize(*); end
     def dispose; end
   end
@@ -1430,6 +1436,62 @@ check 'neither flag set leaves the title screen waiting for input' do
   scene.instance_variable_set(:@auto_started, false)
   scene.instance_variable_set(:@selected_index, 0)
   ok !scene.send(:auto_select?), 'no auto-select without a flag'
+end
+
+# -- screen fade / flash overlays ---------------------------------------------
+#
+# Erase/Show Screen and Flash Screen are drawn as two full-screen colour sprites
+# above everything (RPG2000 fades and flashes the message window too), shown at
+# the effect's own 0..255 strength through Sprite#opacity. docs/TODO.md had these
+# down as needing native alpha support first; they do not -- Sprite#opacity is
+# already LVGL's per-object alpha -- and a forced mid-fade halves the rendered
+# frame's brightness in the real binary, which is what motivated writing them.
+#
+# What is worth pinning here is the wiring: the levels reach the sprites, and the
+# flash layer is not re-filled on frames where its colour has not changed (it is
+# a screen-sized fill per frame otherwise, to produce an identical image).
+def overlay(scene)
+  [scene.instance_variable_get(:@fade_sprite),
+   scene.instance_variable_get(:@flash_sprite)]
+end
+
+check 'Erase/Show Screen drives the fade layer opacity' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  eq 0, fade.opacity, 'nothing erased yet, so the fade layer is invisible'
+
+  st = scene.instance_variable_get(:@state)
+  st.screen.erase(0, 1) # fade fully out over one frame
+  4.times { scene.update }
+  eq 255, fade.opacity, 'a completed Erase Screen leaves the screen black'
+
+  st.screen.show(0, 1)
+  4.times { scene.update }
+  eq 0, fade.opacity, 'Show Screen brings it back'
+end
+
+check 'Flash Screen drives the flash layer, and refills only on a colour change' do
+  scene = new_scene({}, player: [5, 5])
+  _, flash = overlay(scene)
+  scene.update
+  eq 0, flash.opacity, 'no flash, no overlay'
+
+  st = scene.instance_variable_get(:@state)
+  st.screen.flash(31, 0, 0, 200, 20) # red
+  scene.update
+  fills = flash.bitmap.fill_calls || []
+  eq 1, fills.length, 'the flash layer is filled once when the colour is set'
+  eq [31, 0, 0], fills.last[4].then { |c| [c.red, c.green, c.blue] },
+     'filled with the flash colour'
+  eq true, flash.opacity > 0, 'the flash layer is visible while flashing'
+
+  # Same colour on the next frame: the strength changes, the fill does not.
+  before = flash.opacity
+  scene.update
+  eq 1, (flash.bitmap.fill_calls || []).length,
+     'an unchanged colour does not re-fill the screen-sized layer'
+  eq true, flash.opacity <= before, 'the flash decays'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
Erase / Show Screen and Flash Screen were modelled in `Game::Screen` but nothing rendered them, so a game that faded to black simply kept playing in full view.

`Scene::Map` now carries two screen-sized colour sprites above everything — the message window included, which is what RPG2000 fades and flashes — shown at each effect's own 0..255 strength through `Sprite#opacity`.

## No native work was needed

`docs/TODO.md` listed both as blocked on `RGSS::Viewport` tone/alpha support in C++. **They were not.** `RGSS::Sprite#opacity` already maps onto LVGL's per-object alpha at blit time, which is exactly the per-sprite opacity RGSS specifies — so a solid-colour sprite shown at the effect's strength is the entire mechanism, in Ruby.

I checked that in the real binary *before* writing the feature, rather than trusting either the TODO or my own reading of the blit path: forcing the fade layer to opacity 128 and capturing a rendered frame gives

| | mean brightness |
| --- | --- |
| baseline | 31.9 |
| fade layer at opacity 128 | 15.2 |

— very near the half an overlay at that opacity should produce. The TODO entry is corrected in this PR.

## Cost

The layer bitmaps are filled once and re-filled only when the colour changes — so never, for the always-black fade. Filling per frame would be 76,800 pixel writes to produce an image identical to the previous frame's, where the level itself is a single property set.

## What is deliberately still open

**Tint** (Tint Screen) stays exactly where it was, as the Ruby half only. A tone is a per-channel *multiply* against what is already drawn; unlike the fade and flash it cannot be had by compositing a solid colour on top, so it does genuinely still want native support. **Weather** likewise remains.

## Verification

* Two new checks in `scripts/rpg2k_scene_check.rb`: the fade and flash levels reach the sprites across an Erase → Show cycle, and the flash layer is *not* re-filled on a frame where its colour has not changed. Both verified to fail when the wiring is broken.
* `rpg2k_logic_check` (208), `rpg2k_scene_check` (70), `rpg2k_render_check` (35), `rpg2k_save_load_check`, `lcf_save_roundtrip`, `lcf_testbed_check`, `cmake --build build -t test` — all pass.
* `scripts/rpg2k_boot_check.bash` on both test-beds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GaJTmgx1TB7ZCUGFjSh3j

---
_Generated by [Claude Code](https://claude.ai/code/session_018GaJTmgx1TB7ZCUGFjSh3j)_