### PR TITLE
mruby-rgss: render RGSS::Tilemap autotiles

### DIFF
--- a/changelog.d/rpgxp-rgss-tilemap-autotiles.added.md
+++ b/changelog.d/rpgxp-rgss-tilemap-autotiles.added.md
@@ -1,0 +1,8 @@
+- **`RGSS::Tilemap` now renders autotiles.** Building on the regular-tile render,
+  `tilemap_refresh` now also assembles the seven autotiles (tile ids 48–383): each
+  32×32 autotile tile is built from its four 16×16 quads using the RMXP 48-shape
+  quad table (`AUTOTILE_QUADS`, derived from mkxp's `autotileRects`), read from the
+  `autotiles[0..6]` bitmaps — so water/terrain ground fills in instead of leaving
+  holes. Per-tile priority layering and autotile animation are still pending (one
+  flat layer, first animation frame); `flash_data` is ignored. See
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -83,19 +83,20 @@ clip contents taller than the window; `stretch` (tiled vs stretched background) 
 ignored; and the RMXP windowskin source-rect constants are best-effort until a
 game exercises them.
 
-### 3. `Tilemap` ⚠️ (regular tiles rendered; autotiles + priority pending)
+### 3. `Tilemap` ⚠️ (tiles + autotiles rendered; priority layering pending)
 
 `Tilemap` is now **native** (`mruby-rgss/src/lib.cxx`): `Tilemap.new` creates an
 `lv_canvas` the size of the viewport (or screen) and `tilemap_refresh` draws the
 visible part of the map — for each of the three `map_data` layers it blits the
-tiles overlapping the viewport (given `ox`/`oy`) from the `tileset`. `tileset=`,
+tiles overlapping the viewport (given `ox`/`oy`). **Regular tiles** (id ≥ 384)
+come straight from the `tileset`; **autotiles** (id 48–383) are assembled from
+their four 16×16 quads using the RMXP 48-shape quad table (`AUTOTILE_QUADS`,
+derived from mkxp), so water/terrain ground now fills in. `tileset=`,
 `map_data=`, `ox=`/`oy=`, `z=`, `visible`/`visible=`, `dispose`/`disposed?` are
-native, and re-render on change. **Remaining:** only **regular tiles** (id ≥ 384)
-are drawn — the seven **autotiles** (id 48–383, the 48-shape 2×2 quad assembly)
-and the per-tile **priority layering** are still stored-only (`autotiles`,
-`priorities`, `flash_data`), so autotile-heavy ground (water, terrain) is missing
-and everything renders on one flat layer. The RPG2000 side has a portable
-autotile reference in `Game::ChipsetLayout`.
+native and re-render on change. **Remaining:** the per-tile **priority layering**
+(`priorities`) — tiles that should draw above characters — is stored-only, so
+everything renders on one flat layer; **autotile animation** uses only the first
+frame; and `flash_data` is ignored.
 
 ### 4. `Plane` ⚠️ (tiling + scroll rendered; zoom/blend/tone/colour stored)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -211,14 +211,14 @@ module RGSS
   # RGSS Tilemap: the layered, autotiled map ground Spriteset_Map builds from the
   # tileset, the seven autotiles, and the map's data/priority Tables. Now native
   # (src/lib.cxx): Tilemap.new builds an lv_canvas the size of the viewport and
-  # tilemap_refresh draws the visible regular tiles of the three map_data layers
-  # from the tileset, scrolled by ox/oy. `initialize`, `tileset=`, `map_data=`,
-  # `ox=`/`oy=`, `z=`, `visible`/`visible=`, `dispose`/`disposed?` are native.
-  # This reopening keeps the plain readers plus the properties the native renderer
-  # does not yet honour — the seven `autotiles` (so id 48..383 autotile ground is
-  # missing for now), `priorities` (priority layering) and `flash_data` — stored
-  # so scripts run (tracked in docs/rpgxp-rgss-api-gap.md; the RPG2000 side has a
-  # portable autotile reference in Game::ChipsetLayout).
+  # tilemap_refresh draws the visible tiles of the three map_data layers scrolled
+  # by ox/oy — regular tiles from the tileset and autotiles assembled from their
+  # four quads (the seven `autotiles` bitmaps are read by the native renderer).
+  # `initialize`, `tileset=`, `map_data=`, `ox=`/`oy=`, `z=`, `visible`/`visible=`,
+  # `dispose`/`disposed?` are native. This reopening keeps the plain readers, the
+  # `autotiles` slot array (which the native renderer reads), and the properties
+  # not yet honoured — `priorities` (priority layering) and `flash_data` — stored
+  # so scripts run (tracked in docs/rpgxp-rgss-api-gap.md).
   class Tilemap
     attr_reader :tileset, :map_data, :ox, :oy, :viewport
     attr_accessor :flash_data, :priorities

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2558,13 +2558,73 @@ static void blit_blend(Bitmap& dst,
   }
 }
 
+// RMXP autotile quad table: 48 shapes x 4 quads (TL, TR, BL, BR), each the
+// source (x,y) of a 16x16 piece in the 96x128 autotile bitmap. Derived from
+// mkxp (Ancurio/mkxp, src/autotiles.cpp); the .5 texel-centre offsets there are
+// floored for CPU sampling.
+static const int AUTOTILE_QUADS[48][4][2] = {
+    {{32, 64}, {48, 64}, {32, 80}, {48, 80}},
+    {{64, 0}, {48, 64}, {32, 80}, {48, 80}},
+    {{32, 64}, {80, 0}, {32, 80}, {48, 80}},
+    {{64, 0}, {80, 0}, {32, 80}, {48, 80}},
+    {{32, 64}, {48, 64}, {32, 80}, {80, 16}},
+    {{64, 0}, {48, 64}, {32, 80}, {80, 16}},
+    {{32, 64}, {80, 0}, {32, 80}, {80, 16}},
+    {{64, 0}, {80, 0}, {32, 80}, {80, 16}},
+    {{32, 64}, {48, 64}, {64, 16}, {48, 80}},
+    {{64, 0}, {48, 64}, {64, 16}, {48, 80}},
+    {{32, 64}, {80, 0}, {64, 16}, {48, 80}},
+    {{64, 0}, {80, 0}, {64, 16}, {48, 80}},
+    {{32, 64}, {48, 64}, {64, 16}, {80, 16}},
+    {{64, 0}, {48, 64}, {64, 16}, {80, 16}},
+    {{32, 64}, {80, 0}, {64, 16}, {80, 16}},
+    {{64, 0}, {80, 0}, {64, 16}, {80, 16}},
+    {{0, 64}, {16, 64}, {0, 80}, {16, 80}},
+    {{0, 64}, {80, 0}, {0, 80}, {16, 80}},
+    {{0, 64}, {16, 64}, {0, 80}, {80, 16}},
+    {{0, 64}, {80, 0}, {0, 80}, {80, 16}},
+    {{32, 32}, {48, 32}, {32, 48}, {48, 48}},
+    {{32, 32}, {48, 32}, {32, 48}, {80, 16}},
+    {{32, 32}, {48, 32}, {64, 16}, {48, 48}},
+    {{32, 32}, {48, 32}, {64, 16}, {80, 16}},
+    {{64, 64}, {80, 64}, {64, 80}, {80, 80}},
+    {{64, 64}, {80, 64}, {64, 16}, {80, 80}},
+    {{64, 0}, {80, 64}, {64, 80}, {80, 80}},
+    {{64, 0}, {80, 64}, {64, 16}, {80, 80}},
+    {{32, 96}, {48, 96}, {32, 112}, {48, 112}},
+    {{64, 0}, {48, 96}, {32, 112}, {48, 112}},
+    {{32, 96}, {80, 0}, {32, 112}, {48, 112}},
+    {{64, 0}, {80, 0}, {32, 112}, {48, 112}},
+    {{0, 64}, {80, 64}, {0, 80}, {80, 80}},
+    {{32, 32}, {48, 32}, {32, 112}, {48, 112}},
+    {{0, 32}, {16, 32}, {0, 48}, {16, 48}},
+    {{0, 32}, {16, 32}, {0, 48}, {80, 16}},
+    {{64, 32}, {80, 32}, {64, 48}, {80, 48}},
+    {{64, 32}, {80, 32}, {64, 16}, {80, 48}},
+    {{64, 96}, {80, 96}, {64, 112}, {80, 112}},
+    {{64, 0}, {80, 96}, {64, 112}, {80, 112}},
+    {{0, 96}, {16, 96}, {0, 112}, {16, 112}},
+    {{0, 96}, {80, 0}, {0, 112}, {16, 112}},
+    {{0, 32}, {80, 32}, {0, 48}, {80, 48}},
+    {{0, 32}, {16, 32}, {0, 112}, {16, 112}},
+    {{0, 96}, {80, 96}, {0, 112}, {80, 112}},
+    {{64, 32}, {80, 32}, {64, 112}, {80, 112}},
+    {{0, 32}, {80, 32}, {0, 112}, {80, 112}},
+    {{0, 0}, {16, 0}, {0, 16}, {16, 16}},
+};
+
+// Destination offsets of the four autotile quads within a 32x32 tile, in the
+// table's TL, TR, BL, BR order.
+static const int AUTOTILE_QUAD_OFF[4][2] = {{0, 0}, {16, 0}, {0, 16}, {16, 16}};
+
 // Redraw the visible part of the map into the tilemap's canvas. For each of the
 // three map-data layers, the tiles overlapping the viewport (given ox/oy) are
-// blitted from the tileset. Only regular tiles (id >= 384) are drawn; the seven
-// autotiles (id 48..383) and the per-tile priority layering are future work
-// (tracked in docs/rpgxp-rgss-api-gap.md), so autotile-heavy ground is missing
-// for now. The canvas is invalidated directly (its buffer is not a sprite
-// @bitmap that Graphics.update's dirty sweep watches).
+// blitted from the tileset (regular tiles, id >= 384) or assembled from the
+// four autotile quads (id 48..383). Per-tile priority layering and autotile
+// animation are future work (tracked in docs/rpgxp-rgss-api-gap.md), so
+// everything renders on one flat layer using the first animation frame. The
+// canvas is invalidated directly (its buffer is not a sprite @bitmap that
+// Graphics.update's dirty sweep watches).
 void tilemap_refresh(mrb_state* M, mrb_value self) {
   lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
   if (!obj)
@@ -2592,6 +2652,9 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@ox")));
   const mrb_int oy =
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@oy")));
+  const mrb_value autotiles_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@autotiles"));
+  const bool have_autotiles = mrb_array_p(autotiles_v);
 
   int tx0 = static_cast<int>(ox) / TILE_SIZE;
   int ty0 = static_cast<int>(oy) / TILE_SIZE;
@@ -2613,14 +2676,31 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
         if (idx < 0 || idx >= static_cast<int>(md.data.size()))
           continue;
         const int id = md.data[idx];
-        if (id < 384)  // empty / autotile — deferred
+        if (id < 48)  // 0 = empty; 1..47 are the unused blank autotile
           continue;
-        const int ti = id - 384;
-        const int sx = (ti % cols) * TILE_SIZE;
-        const int sy = (ti / cols) * TILE_SIZE;
-        blit_blend(dst, tx * TILE_SIZE - static_cast<int>(ox),
-                   ty * TILE_SIZE - static_cast<int>(oy), ts, sx, sy, TILE_SIZE,
-                   TILE_SIZE);
+        const int dx0 = tx * TILE_SIZE - static_cast<int>(ox);
+        const int dy0 = ty * TILE_SIZE - static_cast<int>(oy);
+        if (id < 384) {
+          // Autotile: id/48 selects autotiles[0..6], id%48 the 48-shape quad
+          // assembly. Uses the first animation frame (x offset 0).
+          if (!have_autotiles)
+            continue;
+          const mrb_value at = mrb_ary_ref(M, autotiles_v, id / 48 - 1);
+          if (!mrb_test(at) || !DATA_PTR(at))
+            continue;
+          Bitmap& ab = DataType<Bitmap>::get(M, at);
+          const int shape = id % 48;
+          for (int q = 0; q < 4; ++q)
+            blit_blend(dst, dx0 + AUTOTILE_QUAD_OFF[q][0],
+                       dy0 + AUTOTILE_QUAD_OFF[q][1], ab,
+                       AUTOTILE_QUADS[shape][q][0], AUTOTILE_QUADS[shape][q][1],
+                       16, 16);
+        } else {
+          // Regular tile from the tileset.
+          const int ti = id - 384;
+          blit_blend(dst, dx0, dy0, ts, (ti % cols) * TILE_SIZE,
+                     (ti / cols) * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to the regular-tile Tilemap render (#236): assembles the **autotiles** (map tile ids 48–383) — the seven water/terrain/edge tiles that make up most of a real map's ground. Without them the map had holes; with them it fills in.

## Change

- **`mruby-rgss/src/lib.cxx`** — `tilemap_refresh` now handles autotile ids:
  - `id / 48` selects one of the `autotiles[0..6]` bitmaps; `id % 48` is the shape.
  - Each 32×32 autotile tile is built from its **four 16×16 quads** (TL/TR/BL/BR) using the RMXP 48-shape quad table `AUTOTILE_QUADS`, blitting each quad from the autotile bitmap's `96×128` grid.

### On the quad table (the risky part, done right)

The 48-shape × 4-quad table is a large exact constant — a wrong entry garbles tiles, and nothing in this sandbox would catch it. So rather than reconstruct it from memory, I **derived it from mkxp** ([Ancurio/mkxp `src/autotiles.cpp`](https://github.com/Ancurio/mkxp/blob/master/src/autotiles.cpp) `autotileRects`), the reference RGSS reimplementation — flooring its `.5` texel-centre offsets for CPU sampling. The table is checked in verbatim with that provenance in a comment.

## Scope (still pending)

- **Priority layering** (`priorities`) — tiles that should draw above characters — is stored-only, so everything renders on one flat layer.
- **Autotile animation** uses only the first frame (water won't animate yet).
- `flash_data` is ignored.

## Testing

- The **`build`** job compiles this against **LVGL v9.5.0**; ran clang-format + whitespace/EOF locally and checked `mrb_intern_lit` is only used with string literals.
- `mruby-rgss/test` — the Tilemap surface test already covers the (unchanged) method surface; `Tilemap.new` needs a live display, so the assembly is exercised by the game runs.
- **No current game creates a `Tilemap`**, so this is compile-verified but render-verified once the RGSS script host boots — zero regression risk.

## Docs

- `docs/rpgxp-rgss-api-gap.md` — item #3 (`Tilemap`) → ⚠️ (tiles + autotiles rendered; priority layering pending).
- Changelog fragment `changelog.d/rpgxp-rgss-tilemap-autotiles.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_