### PR TITLE
Model and persist RPG2000 actor status states

### DIFF
--- a/changelog.d/rpg2k-actor-states.added.md
+++ b/changelog.d/rpg2k-actor-states.added.md
@@ -1,0 +1,14 @@
+- RPG Maker 2000: actor **status conditions (状態)** are now modelled and saved.
+  `Game::Actor` carries a state-id set (`states`, with `add_state` / `remove_state`
+  / `state?`), and **Full Recovery** clears it. The set persists both ways: the
+  portable Marshal save round-trips it, and `Game::State#to_lsd` now writes chunk
+  108's per-actor state fields (81 `state_size` / 82 `states`) — previously parsed
+  but never populated — with `from_lsd` restoring them, so an actor's ailments in
+  a real `Save<N>.lsd` survive Continue instead of being dropped. The Conditional
+  Branch **actor "afflicted by state"** sub-condition (type 5, sub 6) is wired up,
+  where it used to always read false. Covered by new `scripts/rpg2k_logic_check.rb`
+  checks (the state model, the conditional, and a Marshal round-trip) and by
+  `scripts/rpg2k_save_load_check.rb` (the `.lsd` `to_lsd -> from_lsd` round-trip
+  now asserts states survive, against the real Nepheshel / mtf-meido saves).
+  Inflicting states from battle / items / skills (the item `state_set` /
+  `reverse_state_effect` fields) remains a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -219,8 +219,15 @@ The work below is roughly ordered by the critical path to a walkable game
   range, an **actor stat** (level / EXP / HP / MP / max HP-MP / attack / defence /
   spirit / agility) and **game quantities** (party gold, timer seconds).
   Conditional Branch covers switch / variable / **timer** / gold / item
-  conditions and the **actor** sub-conditions (in party, name, level ≥, HP ≥,
-  item equipped, skill known; state is not modelled). **Show / Move / Erase
+  conditions and **all** the **actor** sub-conditions (in party, name, level ≥,
+  HP ≥, item equipped, skill known, and **afflicted by a state**). Actors now
+  carry a **status-condition (状態) set** (`Game::Actor#states` with
+  `add_state` / `remove_state` / `state?`; **Full Recovery clears it**), which
+  persists in both the Marshal save and the `.lsd` (chunk 108 fields 81/82,
+  previously parsed-but-unused) and is restored by `from_lsd`, so a real save's
+  status ailments survive. Applying states from battle / items / skills (the
+  item `state_set` + `reverse_state_effect` fields) is the remaining piece.
+  **Show / Move / Erase
   Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
   (centre position, zoom, opacity, tone and the scroll-with-map flag) held on
   `Game::State`, decoded with EasyRPG's parameter layout (literal or

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -825,9 +825,10 @@ module Game
     # accessory.
     EQUIP_ORDER = [:weapon, :shield, :armor, :helmet, :accessory].freeze
 
-    # The equipped item ids, one per EQUIP_ORDER slot (0 = an empty slot), and
-    # the ids of the skills the actor knows.
-    attr_reader :equipment, :skills
+    # The equipped item ids, one per EQUIP_ORDER slot (0 = an empty slot), the
+    # ids of the skills the actor knows, and the ids of the status conditions
+    # (状態) currently afflicting the actor.
+    attr_reader :equipment, :skills, :states
 
     def initialize(db, id)
       @db = db
@@ -844,6 +845,7 @@ module Game
       @exp = 0
       @equipment = normalize_equipment(a.respond_to?(:initial_equipment) ? a.initial_equipment : nil)
       @skills = []
+      @states = []
       # Base stats scale with level from the growth curve and equipment adds on
       # top, and levelling learns skills, so seed them all at the actor's initial
       # level, then start at full health.
@@ -922,6 +924,30 @@ module Game
     # Replace the known-skill set (Continue restoring the saved skills).
     def skills=(ids)
       @skills = (ids || []).reject { |s| s.nil? || s == 0 }.uniq
+    end
+
+    # -- status conditions (状態) -------------------------------------------
+
+    # Whether `state_id` is currently afflicting the actor.
+    def state?(state_id)
+      return false if state_id.nil? || state_id == 0
+      @states.include?(state_id)
+    end
+
+    # Inflict / cure a status condition (no-ops for an absent/duplicate id).
+    def add_state(state_id)
+      return if state_id.nil? || state_id == 0 || @states.include?(state_id)
+      @states.push(state_id)
+    end
+
+    def remove_state(state_id); @states.delete(state_id); end
+
+    # Cure every status condition (RPG2000 Full Recovery clears them).
+    def clear_states; @states = []; end
+
+    # Replace the state set (Continue restoring the saved conditions).
+    def states=(ids)
+      @states = (ids || []).reject { |s| s.nil? || s == 0 }.uniq
     end
 
     # Replace the equipped items (an array of up to five item ids in EQUIP_ORDER,
@@ -1116,11 +1142,12 @@ module Game
       @mp = Game.clamp(@mp + delta, 0, @max_mp)
     end
 
-    # Restore HP and MP to their maxima (RPG2000 Full Recovery; state recovery
-    # is not modelled yet).
+    # Restore HP and MP to their maxima and cure every status condition
+    # (RPG2000 Full Recovery).
     def full_heal
       @hp = @max_hp
       @mp = @max_mp
+      clear_states
     end
 
     # Change Parameters base-stat types (the RPG2000 command's parameter field).
@@ -1198,7 +1225,7 @@ module Game
         meta[a.id] = { name: a.name, title: a.title,
                        charset_name: a.charset_name,
                        charset_index: a.charset_index,
-                       transparent: a.transparent }
+                       transparent: a.transparent, states: a.states.dup }
       end
       { actor_ids: @actors.map { |a| a.id }, items: @items, gold: @gold,
         hp: hp, mp: mp, exp: exp, actor_meta: meta }
@@ -1233,6 +1260,7 @@ module Game
         actor.set_charset(m[:charset_name], m[:charset_index] || actor.charset_index)
       end
       actor.transparent = m[:transparent] unless m[:transparent].nil?
+      actor.states = m[:states] if m[:states]
     end
 
     def each(&blk); @actors.each(&blk); end
@@ -2890,6 +2918,10 @@ module Game
         e[61] = a.equipment
         e[71] = a.hp
         e[72] = a.mp
+        unless a.states.empty?
+          e[81] = a.states.size
+          e[82] = a.states
+        end
         actors[a.id] = e
       end
       save[108] = actors
@@ -2953,6 +2985,7 @@ module Game
           actor.exp = sa.exp if sa.exp
           actor.equip(sa.equipment) if sa.equipment
           actor.skills = sa.skills if sa.skills
+          actor.states = sa.states if sa.states
         end
         hp[aid] = sa.hp if sa.hp
         mp[aid] = sa.mp if sa.mp

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1090,10 +1090,9 @@ module Game
 
     # Conditional type 5 (actor/hero): param1 is the actor id, param2 selects the
     # sub-condition — 0 in party, 1 name equals the command string, 2 level >=
-    # param3, 3 HP >= param3, 4 knows skill param3, 5 has item param3 equipped.
-    # The state sub-condition (6) is not modelled and reads as false. The stat
-    # checks need the actor to be in the party (the only actors this build
-    # instantiates); a missing actor is false.
+    # param3, 3 HP >= param3, 4 knows skill param3, 5 has item param3 equipped,
+    # 6 afflicted by state param3. The stat checks need the actor to be in the
+    # party (the only actors this build instantiates); a missing actor is false.
     def actor_condition(cmd)
       id = cmd.param(1)
       return party.include_actor?(id) if cmd.param(2) == 0
@@ -1105,6 +1104,7 @@ module Game
       when 3 then actor.hp >= cmd.param(3)
       when 4 then actor.knows_skill?(cmd.param(3))
       when 5 then actor.equipped?(cmd.param(3))
+      when 6 then actor.state?(cmd.param(3))
       else false
       end
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1988,6 +1988,43 @@ check 'Conditional actor: equipped item (type 5, sub 5)' do
   eq true, st.switches[2]
 end
 
+check 'Conditional actor: afflicted by state (type 5, sub 6)' do
+  st = run_actor_cond([5, 1, 6, 4]) { |s| s.party.actor_by_id(1).add_state(4) }
+  eq true, st.switches[1]            # state 4 present -> if-branch
+  st = run_actor_cond([5, 1, 6, 4]) # no states -> else
+  eq true, st.switches[2]
+end
+
+check 'Actor status states: add / remove / query, cleared by Full Recovery' do
+  a = party_state.party.actor_by_id(1)
+  eq [], a.states
+  eq false, a.state?(3)
+  a.add_state(3); a.add_state(3); a.add_state(7)     # duplicate is ignored
+  eq [3, 7], a.states
+  eq true, a.state?(3)
+  a.remove_state(3)
+  eq [7], a.states
+  a.states = [1, 0, nil, 2, 2]                        # setter drops 0/nil, dedups
+  eq [1, 2], a.states
+  a.full_heal
+  eq [], a.states                                     # Full Recovery clears states
+end
+
+check 'State save round-trips per-actor status states' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
+    2 => FakePlayerRow.new('Ally', '', 0, 3, max_hp: 50, max_mp: 20, atk: 6, def: 5),
+  }
+  db = FakeActorDB.new(players, [1, 2])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.actor_by_id(1).add_state(3)
+  st.party.actor_by_id(1).add_state(9)
+  st.party.actor_by_id(2).add_state(5)
+  loaded = Game::State.load(db, Marshal.load(Marshal.dump(st.to_h)))
+  eq [3, 9], loaded.party.actor_by_id(1).states.sort
+  eq [5], loaded.party.actor_by_id(2).states.sort
+end
+
 check 'Conditional actor: unmodelled sub-condition reads false (type 5, sub 6)' do
   eq true, run_actor_cond([5, 1, 6, 3]).switches[2] # has-state -> false -> else
 end

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -204,6 +204,8 @@ def check_game(dir)
   if state.party.leader
     state.party.leader.set_charset('HeroAlt', 5)
     state.party.leader.name = 'Renamed'
+    state.party.leader.add_state(3)   # afflict the leader with a couple of states
+    state.party.leader.add_state(7)
   end
 
   round = Game::State.from_lsd(db, LCF::SaveData.new(StringIO.new(state.to_lsd.to_lcf)))
@@ -224,6 +226,7 @@ def check_game(dir)
     eq a.mp, b.mp, "to_lsd: actor #{a.id} mp"
     eq a.equipment, b.equipment, "to_lsd: actor #{a.id} equipment"
     eq a.skills.sort, b.skills.sort, "to_lsd: actor #{a.id} skills"
+    eq a.states.sort, b.states.sort, "to_lsd: actor #{a.id} states"
   end
   eq state.switches.to_h.select { |_k, v| v }.keys.sort,
      round.switches.to_h.select { |_k, v| v }.keys.sort, 'to_lsd: switches on'


### PR DESCRIPTION
Closes the RPG2000 save-data gap identified in the save-state review: the per-actor **status conditions (状態)** — `SAVE_PARTY_ACTOR` chunk 108 fields 81 (`state_size`) / 82 (`states`) — were parsed but never used, so states were dropped on load and the "actor afflicted by state" conditional always read false.

## What

- `Game::Actor` carries a state-id set: `states`, with `add_state` / `remove_state` / `state?` and a `states=` setter (drops 0/nil, dedups). **Full Recovery** (`full_heal`) now clears it.
- **Persistence both ways:**
  - Marshal save round-trips it (via `Party` `actor_meta` / `apply_actor_meta`).
  - `Game::State#to_lsd` writes chunk 108 fields 81/82, and `from_lsd` restores them — so an actor's ailments in a real `Save<N>.lsd` now survive Continue.
- The Conditional Branch **actor sub-condition 6** (afflicted by state) is wired to `Actor#state?`, where it used to hard-code `false`.

## Tests

- `scripts/rpg2k_logic_check.rb`: the state model (add/remove/query, dedup, Full-Recovery-clears), the state conditional (type 5 sub 6), and a Marshal save round-trip. (211 checks pass.)
- `scripts/rpg2k_save_load_check.rb`: the `to_lsd → from_lsd` round-trip now afflicts the leader with states and asserts they survive — against the real Nepheshel (2000) and mtf-meido-action (2003) saves.

All RPG2000 harnesses (logic / scene / render / save-load / testbed) stay green.

## Follow-up

Inflicting states from battle / items / skills (the item `state_set` / `reverse_state_effect` fields, and the state-chance/rank data) — the other half of the state system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_