### PR TITLE
Add RGSS::Bitmap#tone_blt, the native half of Tint Screen

### DIFF
--- a/changelog.d/rgss-bitmap-tone-blt.added.md
+++ b/changelog.d/rgss-bitmap-tone-blt.added.md
@@ -1,0 +1,10 @@
+- `RGSS::Bitmap#tone_blt(src, tone)` — copy a bitmap applying an `RGSS::Tone`:
+  desaturate toward luminance by `gray` (0..255), then add the per-channel
+  offsets (-255..255), leaving alpha untouched. This is the native half that
+  Tint Screen needs and the screen fade/flash did not: a tone rescales what is
+  already drawn, so unlike those it cannot be had by compositing a solid colour
+  on top. It writes to a separate destination rather than transforming in place,
+  so repeating it is idempotent — a caller that redraws a layer only when it
+  changes would otherwise re-tint an already-tinted layer every frame.
+  Nothing consumes it yet; see `docs/TODO.md` for what is left to wire it into
+  `Scene::Map`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -365,10 +365,27 @@ The work below is roughly ordered by the critical path to a walkable game
   Confirmed in the real binary before the code was written — forcing the fade
   layer to opacity 128 halves the rendered frame's mean brightness (31.9 → 15.2).
 
-  Still open here: **weather**, and the **tint** (Tint Screen), which really does
-  need native work — a tone is a per-channel multiply against what is already
-  drawn, and no amount of compositing a solid colour on top reproduces that.
-  Tint remains the Ruby half only
+  Still open here: **weather**, and the **tint** (Tint Screen). The tint really
+  does need native work, unlike the fade and flash — a tone rescales what is
+  already drawn rather than laying a colour over it. That native half now
+  exists: `RGSS::Bitmap#tone_blt(src, tone)` copies a bitmap applying an
+  RGSS `Tone` (desaturate toward luminance by `gray`, then add the per-channel
+  offsets), covered by `mruby-rgss/test/test.rb`. It writes to a separate
+  destination on purpose — the map layers are redrawn only when they change, so
+  an in-place tone would re-tint an already-tinted layer every frame and walk it
+  to black.
+
+  **Nothing calls it yet.** A first attempt at wiring it through `Scene::Map`
+  (tone each scene-owned layer into a shadow bitmap, point the sprite at the
+  shadow) was written and then dropped rather than shipped: instrumentation
+  confirms the code runs and finds its four layers, but the rendered frame is
+  unchanged — a forced full-strength green tint moved the frame's mean green by
+  0.09/255. So the remaining work is not the tone maths but finding why a
+  per-frame `Sprite#bitmap=` swap does not reach the display; suspects are the
+  sprite's cached canvas source and the dirty-flag sweep in
+  `mruby-rgss/src/lib.cxx`. Note the obvious probe is misleading: the Nepheshel
+  opening is nearly black (frame mean ~32/255), where a *subtractive* tint
+  changes almost nothing even when it is working — use an additive one
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -201,12 +201,12 @@ mrb_data_type DataType<T>::data_type{
 };
 
 // Generic floating point component getter/setter usable by Color and Tone.
-template <class T, double T::*Field>
+template <class T, double T::* Field>
 mrb_value component_get(mrb_state* M, V self) {
   return mrb_float_value(M, DataType<T>::get(M, self).*Field);
 }
 
-template <class T, double T::*Field, int Lo, int Hi>
+template <class T, double T::* Field, int Lo, int Hi>
 mrb_value component_set(mrb_state* M, V self) {
   mrb_float v;
   mrb_get_args(M, "f", &v);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1197,13 +1197,16 @@ mrb_value bmp_tone_blt(mrb_state* M, V self) {
   Bitmap& src = DataType<Bitmap>::get(M, src_v);
   Tone& t = DataType<Tone>::get(M, tone_v);
 
-  if (src.width != dst.width || src.height != dst.height)
-    mrb_raisef(M,
-               mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "RGSSError"),
-               "tone_blt: size mismatch (self %dx%d, src %dx%d)", dst.width,
-               dst.height, src.width, src.height);
+  if (src.width != dst.width || src.height != dst.height) {
+    RClass* mod = mrb_module_get(M, "RGSS");
+    RClass* err = mrb_class_get_under(M, mod, "RGSSError");
+    mrb_raisef(M, err, "tone_blt: size mismatch (self %dx%d, src %dx%d)",
+               dst.width, dst.height, src.width, src.height);
+  }
 
-  const int tr = (int)t.red, tg = (int)t.green, tb = (int)t.blue;
+  const int tr = (int)t.red;
+  const int tg = (int)t.green;
+  const int tb = (int)t.blue;
   const int gray = (int)t.gray;
   for (int32_t y = 0; y < src.height; ++y) {
     for (int32_t x = 0; x < src.width; ++x) {

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -201,12 +201,12 @@ mrb_data_type DataType<T>::data_type{
 };
 
 // Generic floating point component getter/setter usable by Color and Tone.
-template <class T, double T::* Field>
+template <class T, double T::*Field>
 mrb_value component_get(mrb_state* M, V self) {
   return mrb_float_value(M, DataType<T>::get(M, self).*Field);
 }
 
-template <class T, double T::* Field, int Lo, int Hi>
+template <class T, double T::*Field, int Lo, int Hi>
 mrb_value component_set(mrb_state* M, V self) {
   mrb_float v;
   mrb_get_args(M, "f", &v);
@@ -1168,6 +1168,60 @@ mrb_value bmp_fill_rect(mrb_state* M, V self) {
     for (mrb_int i = x; i < x + w; ++i)
       bmp_put(b, i, j, c.red, c.green, c.blue, c.alpha);
   b.dirty = true;
+  return self;
+}
+
+int clamp_channel(int v) {
+  return v < 0 ? 0 : (v > 255 ? 255 : v);
+}
+
+// RGSS Bitmap#tone_blt(src, tone): copy `src` into this bitmap, same size,
+// applying an RGSS Tone.
+//
+// A tone is *not* a colour drawn on top -- it rescales what is already there,
+// which is why it cannot be done the way the screen fade and flash are (a solid
+// sprite composited at some opacity). Hence a real pixel pass.
+//
+// RGSS order, which RPG2000's Tint Screen reduces to: desaturate toward
+// luminance by `gray` (0..255), then add the per-channel offsets (-255..255).
+// Luminance uses the usual 299/587/114 weights. Alpha is copied untouched: a
+// tone tints what is visible, it does not make anything more or less so.
+//
+// It writes into a separate destination rather than transforming in place
+// because the caller redraws its layers only when they change; toning in place
+// would re-tone an already-toned layer every frame and march it to black.
+mrb_value bmp_tone_blt(mrb_state* M, V self) {
+  Bitmap& dst = bmp_self(M, self);
+  V src_v, tone_v;
+  mrb_get_args(M, "oo", &src_v, &tone_v);
+  Bitmap& src = DataType<Bitmap>::get(M, src_v);
+  Tone& t = DataType<Tone>::get(M, tone_v);
+
+  if (src.width != dst.width || src.height != dst.height)
+    mrb_raisef(M,
+               mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "RGSSError"),
+               "tone_blt: size mismatch (self %dx%d, src %dx%d)", dst.width,
+               dst.height, src.width, src.height);
+
+  const int tr = (int)t.red, tg = (int)t.green, tb = (int)t.blue;
+  const int gray = (int)t.gray;
+  for (int32_t y = 0; y < src.height; ++y) {
+    for (int32_t x = 0; x < src.width; ++x) {
+      int r, g, b, a;
+      bmp_read(src, x, y, r, g, b, a);
+      if (gray > 0) {
+        const int lum = (r * 299 + g * 587 + b * 114) / 1000;
+        r += (lum - r) * gray / 255;
+        g += (lum - g) * gray / 255;
+        b += (lum - b) * gray / 255;
+      }
+      r = clamp_channel(r + tr);
+      g = clamp_channel(g + tg);
+      b = clamp_channel(b + tb);
+      bmp_put(dst, x, y, r, g, b, a);
+    }
+  }
+  dst.dirty = true;
   return self;
 }
 
@@ -3698,6 +3752,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "tone_blt", bmp_tone_blt, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "stretch_blt", bmp_stretch_blt,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
   mrb_define_method(M, bmp, "draw_text", bmp_draw_text,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -140,6 +140,48 @@ assert "RGSS::Bitmap blt" do
   assert_equal 0.0, dst.get_pixel(0, 0).alpha # untouched
 end
 
+assert "RGSS::Bitmap tone_blt" do
+  src = RGSS::Bitmap.new(2, 2)
+  src.fill_rect(0, 0, 2, 2, RGSS::Color.new(100, 150, 200, 255))
+
+  # A neutral tone copies the source through untouched.
+  dst = RGSS::Bitmap.new(2, 2)
+  dst.tone_blt(src, RGSS::Tone.new(0, 0, 0, 0))
+  assert_equal 100.0, dst.get_pixel(0, 0).red
+  assert_equal 150.0, dst.get_pixel(0, 0).green
+  assert_equal 200.0, dst.get_pixel(0, 0).blue
+  assert_equal 255.0, dst.get_pixel(0, 0).alpha
+
+  # Offsets are added per channel and clamped at both ends.
+  dst.tone_blt(src, RGSS::Tone.new(50, -200, 100, 0))
+  assert_equal 150.0, dst.get_pixel(1, 1).red
+  assert_equal 0.0, dst.get_pixel(1, 1).green   # 150 - 200 clamps to 0
+  assert_equal 255.0, dst.get_pixel(1, 1).blue  # 200 + 100 clamps to 255
+
+  # Full gray pulls every channel to the luminance of the source pixel:
+  # (100*299 + 150*587 + 200*114) / 1000 = 140.75, truncated to 140 by the
+  # integer pixel path (no rounding, as elsewhere in the blitters).
+  dst.tone_blt(src, RGSS::Tone.new(0, 0, 0, 255))
+  assert_equal 140.0, dst.get_pixel(0, 1).red
+  assert_equal 140.0, dst.get_pixel(0, 1).green
+  assert_equal 140.0, dst.get_pixel(0, 1).blue
+
+  # Toning reads the source every time rather than accumulating: repeating the
+  # same call is idempotent, which is what stops a per-frame tone marching a
+  # cached layer to black.
+  before = dst.get_pixel(0, 1).red
+  dst.tone_blt(src, RGSS::Tone.new(0, 0, 0, 255))
+  assert_equal before, dst.get_pixel(0, 1).red
+
+  # Alpha is carried through untouched -- a tone tints what shows, it does not
+  # change what is visible.
+  faded = RGSS::Bitmap.new(2, 2)
+  faded.fill_rect(0, 0, 2, 2, RGSS::Color.new(10, 10, 10, 77))
+  dst.tone_blt(faded, RGSS::Tone.new(90, 0, 0, 0))
+  assert_equal 77.0, dst.get_pixel(0, 0).alpha
+  assert_equal 100.0, dst.get_pixel(0, 0).red
+end
+
 assert "RGSS::Bitmap stretch_blt" do
   src = RGSS::Bitmap.new(2, 2)
   src.fill_rect(0, 0, 2, 2, RGSS::Color.new(0, 0, 255, 255))


### PR DESCRIPTION
Follows #238. Tint Screen is the one screen effect that genuinely needs native support — the fade and flash turned out not to, since they are solid sprites composited at an opacity, but a **tone rescales what is already drawn**, so it needs a real pixel pass.

## What this adds

`RGSS::Bitmap#tone_blt(src, tone)` — copy a bitmap applying an `RGSS::Tone`, in RGSS order: desaturate toward luminance by `gray` (0..255), then add the per-channel offsets (-255..255). Alpha is carried through untouched; a tone tints what is visible, it does not change what is visible.

It writes into a **separate destination** rather than transforming in place. The map layers are redrawn only when they change, so an in-place tone would re-tint an already-tinted layer every frame and walk it to black. Copying from an untouched source makes repeating the call idempotent, which the tests pin directly.

## Nothing calls it yet — deliberately

I wrote the `Scene::Map` wiring too (tone each scene-owned layer into a shadow bitmap, point the sprite at the shadow — events composite into the tile layers, so five layers covers the whole scene) and then **dropped it rather than ship it**.

Instrumentation confirms that code runs and finds its four layers on the test map, but the rendered frame does not change: a forced full-strength green tint moved the frame's mean green by **0.09/255**. Shipping a per-frame rendering path that demonstrably does not do its job seemed worse than shipping the primitive alone.

`docs/TODO.md` records where the trail stops, so the next person does not restart from zero:

* the tone maths is not the problem — it is unit-tested in isolation;
* what is unexplained is why a per-frame `Sprite#bitmap=` swap does not reach the display. Suspects are the sprite's cached canvas source and the dirty-flag sweep in `mruby-rgss/src/lib.cxx`;
* **the obvious probe misleads.** Nepheshel's opening is nearly black (frame mean ~32/255), where a *subtractive* tint changes almost nothing even when it is working correctly. My first probe used one and read as a false negative. Use an additive tint.

## Verification

* The mruby suite (1614 assertions, run under ctest), with new `tone_blt` cases for: neutral copy, per-channel offsets clamping at both ends, full-gray landing on the source pixel's luminance, idempotence under repetition, and alpha passthrough.
* One test expectation I got wrong on the first pass and corrected rather than papered over: luminance of (100,150,200) is 140.75, and the integer pixel path truncates to 140, not 141. The test now says so.
* `cmake --build build -t test`, `rpg2k_scene_check` (70), `rpg2k_render_check` (35), and `scripts/rpg2k_boot_check.bash` on both test-beds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GaJTmgx1TB7ZCUGFjSh3j

---
_Generated by [Claude Code](https://claude.ai/code/session_018GaJTmgx1TB7ZCUGFjSh3j)_