### PR TITLE
Cure status states from the RPG2000 item menu

### DIFF
--- a/changelog.d/rpg2k-item-cure-states.added.md
+++ b/changelog.d/rpg2k-item-cure-states.added.md
@@ -1,0 +1,13 @@
+- RPG Maker 2000 item menu: a medicine now **cures status conditions**. When an
+  item has `reverse_state_effect` set, using it removes the states listed in its
+  `state_set` (a byte per state, index i → state id i+1) from the target — the
+  antidote / herb case — unconditionally, matching EasyRPG's item algorithm.
+  `Game::Party#use_medicine` cures alongside the HP/SP recovery and consumes the
+  item when *either* healed or cured; `item_effective?` reports such an item as
+  usable when the target is afflicted even at full HP, so it is no longer greyed
+  out. `Game::Party#item_cured_states` exposes the cured set (empty for a
+  non-reverse item, whose states would be *inflicted* — left to battle). Covered
+  by new `scripts/rpg2k_logic_check.rb` checks (curing only the listed states, the
+  no-op-when-unafflicted case, a combined heal+cure item, and the non-reverse
+  case). Builds on the actor-state model added just before; inflicting states
+  (`state_chance`) remains a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -225,8 +225,12 @@ The work below is roughly ordered by the critical path to a walkable game
   `add_state` / `remove_state` / `state?`; **Full Recovery clears it**), which
   persists in both the Marshal save and the `.lsd` (chunk 108 fields 81/82,
   previously parsed-but-unused) and is restored by `from_lsd`, so a real save's
-  status ailments survive. Applying states from battle / items / skills (the
-  item `state_set` + `reverse_state_effect` fields) is the remaining piece.
+  status ailments survive. The **item menu cures states**: a medicine with
+  `reverse_state_effect` set removes its `state_set` conditions from the target
+  (an antidote / herb — unconditional, matching EasyRPG's item algorithm), and
+  such an item now counts as usable when the target is afflicted even at full HP.
+  Still remaining: *inflicting* states (the non-reverse item case rolled against
+  `state_chance`, and skill / battle infliction).
   **Show / Move / Erase
   Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
   (centre position, zoom, opacity, tone and the scroll-with-map flag) held on

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1333,6 +1333,21 @@ module Game
       [hp, mp]
     end
 
+    # The status-condition ids a medicine cures. RPG2000 items list affected
+    # states in `state_set` (a 0/1 byte per state, index i -> state id i+1); when
+    # `reverse_state_effect` is set the item *removes* them (an antidote / herb),
+    # which is the only item-state effect the field menu applies -- an item that
+    # would *inflict* states (the non-reverse case, rolled against state_chance) is
+    # left to battle. Curing is unconditional, matching EasyRPG's item algorithm.
+    def item_cured_states(it)
+      return [] unless it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+      set = it.state_set
+      return [] unless set
+      out = []
+      set.each_index { |i| out.push(i + 1) if set[i] && set[i] != 0 }
+      out
+    end
+
     # Whether using item `id` on `actor` would change anything, so the menu can
     # grey out a no-op. A medicine is effective when the target is below full
     # HP/SP and it restores some (RPG_RT forbids using a pure-recovery item on a
@@ -1344,7 +1359,8 @@ module Game
       case it.type
       when ITEM_MEDICINE
         hp, mp = item_recovery(it, actor)
-        (hp > 0 && actor.hp < actor.max_hp) || (mp > 0 && actor.mp < actor.max_mp)
+        (hp > 0 && actor.hp < actor.max_hp) || (mp > 0 && actor.mp < actor.max_mp) ||
+          item_cured_states(it).any? { |s| actor.state?(s) }
       when ITEM_SKILL_BOOK
         s = it.skill_id
         !s.nil? && s != 0 && !actor.knows_skill?(s)
@@ -1372,10 +1388,12 @@ module Game
 
     # A single-target medicine (scope 0) heals `actor`; an all-ally medicine
     # (scope 1) heals the whole party regardless of `actor`. Applies the recovery
-    # (clamped to each target's maxima) and consumes one from the bag only when it
-    # actually healed someone (so using it on a full party wastes nothing).
+    # (clamped to each target's maxima) and cures the item's status conditions,
+    # and consumes one from the bag only when it actually did something to someone
+    # (so using it on a full, unafflicted party wastes nothing).
     def use_medicine(it, id, actor)
       targets = it.scope == 1 ? @actors : [actor].compact
+      cured = item_cured_states(it)
       affected = []
       targets.each do |t|
         hp, mp = item_recovery(it, t)
@@ -1383,7 +1401,14 @@ module Game
         before_mp = t.mp
         t.change_hp(hp) if hp > 0
         t.change_mp(mp) if mp > 0
-        affected.push(t) if t.hp != before_hp || t.mp != before_mp
+        changed = t.hp != before_hp || t.mp != before_mp
+        cured.each do |s|
+          if t.state?(s)
+            t.remove_state(s)
+            changed = true
+          end
+        end
+        affected.push(t) if changed
       end
       lose_item(id, 1) unless affected.empty?
       affected

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1251,13 +1251,15 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :max_hp_points, :max_sp_points, :type, :name, :scope,
                       :recover_hp, :recover_hp_rate, :recover_sp, :recover_sp_rate,
                       :price, :skill_id,
-                      :atk_points2, :def_points2, :spi_points2, :agi_points2)
+                      :atk_points2, :def_points2, :spi_points2, :agi_points2,
+                      :state_set, :reverse_state_effect)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
-              skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0)
+              skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0,
+              state_set: nil, reverse_state: false)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
-               atk2, dfn2, spi2, agi2)
+               atk2, dfn2, spi2, agi2, state_set, reverse_state)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -1656,6 +1658,52 @@ check 'use_item restores MP and item_effective? tracks the SP deficit' do
   st.party.use_item(6, hero)
   eq 25, hero.mp                               # 10 + 15
   eq 0, st.party.item_count(6)
+end
+
+check 'a cure medicine (reverse_state_effect) removes only its listed states' do
+  # state_set: byte per state, index i -> state id i+1; states 3 and 7 marked.
+  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1, 0, 0, 0, 1], reverse_state: true) }
+  st = item_party(items)
+  st.party.gain_item(5, 2)
+  hero = st.party.leader
+  hero.add_state(3); hero.add_state(9)         # 3 is curable by the item, 9 is not
+  eq [3, 7], st.party.item_cured_states(st.party.db_item(5))
+  eq true, st.party.item_effective?(5, hero)
+  eq [hero], st.party.use_item(5, hero)
+  eq false, hero.state?(3)                      # cured
+  eq true, hero.state?(9)                       # a state the item does not list stays
+  eq 1, st.party.item_count(5)                  # consumed
+end
+
+check 'a cure medicine on an unafflicted, full target does nothing / not consumed' do
+  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true) }
+  st = item_party(items)
+  st.party.gain_item(5, 1)
+  hero = st.party.leader                        # full HP, no states
+  eq false, st.party.item_effective?(5, hero)
+  eq [], st.party.use_item(5, hero)
+  eq 1, st.party.item_count(5)
+end
+
+check 'a heal+cure item counts either the heal or the cure as a use' do
+  items = { 5 => fake_item(type: 6, rhp: 40, state_set: [0, 0, 1], reverse_state: true) }
+  st = item_party(items)
+  st.party.gain_item(5, 3)
+  hero = st.party.leader
+  hero.add_state(3)                             # full HP but afflicted -> cures, consumes
+  eq [hero], st.party.use_item(5, hero)
+  eq false, hero.state?(3)
+  eq 2, st.party.item_count(5)
+  hero.change_hp(-50)                           # 100 -> 50, unafflicted -> heals, consumes
+  eq [hero], st.party.use_item(5, hero)
+  eq 90, hero.hp                                # 50 + 40
+  eq 1, st.party.item_count(5)
+end
+
+check 'a non-reverse item lists no cured states (infliction is battle-only)' do
+  st = item_party({})
+  it = fake_item(type: 6, state_set: [0, 0, 1], reverse_state: false)
+  eq [], st.party.item_cured_states(it)
 end
 
 check 'field_items includes skill books alongside medicines' do


### PR DESCRIPTION
Builds on the actor status-state model (#240): a medicine can now **cure** states, connecting states to the item menu.

## Behavior

When an item has `reverse_state_effect` set, using it **removes** the states listed in its `state_set` (a byte per state, index `i` → state id `i+1`) from the target — the antidote / herb case — **unconditionally**, matching EasyRPG's item algorithm (items don't roll `state_chance` for curing).

- `Game::Party#use_medicine` cures alongside HP/SP recovery and consumes the item when it **either** healed or cured someone.
- `item_effective?` now reports such an item as usable when the target is afflicted **even at full HP**, so it isn't greyed out.
- `Game::Party#item_cured_states` exposes the cured set (empty for a non-reverse item, whose states would be *inflicted* — left to battle).

## Grounding

`reverse_state_effect` semantics confirmed against EasyRPG's `Game_BattleAlgorithm::Item` — reverse ⇒ remove those states, and curing is unconditional (unlike skills, which roll `state_chance`).

## Tests

New `scripts/rpg2k_logic_check.rb` checks: curing only the listed states (leaving others), the no-op when the target is unafflicted and full (not consumed), a combined heal+cure item (either effect counts as a use), and the non-reverse case listing no cured states. The item fixture gained `state_set`/`reverse_state_effect`. All 215 logic checks pass; the scene / render / save-load / testbed harnesses stay green.

## Follow-up

*Inflicting* states — the non-reverse item case rolled against `state_chance`, plus skill / battle infliction — the other half of the state system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_