### PR TITLE
CI: Skip tc39/test262 clone by default in flake build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           submodules: recursive
 
+      # Keep the tc39/test262 clone out of CI — `nix develop` fetches this flake
+      # with submodules and would otherwise trip over quickjs-ng's unused nested
+      # entry. See the script for the full story.
+      - name: Skip the quickjs test262 submodule
+        run: ./scripts/skip-quickjs-test262.bash
+        env:
+          CLONE_TEST262: ${{ vars.CLONE_TEST262 }}
+
       - uses: nixbuild/nix-quick-install-action@v35
       - name: Restore and cache Nix store
         uses: nix-community/cache-nix-action@v7
@@ -342,6 +350,13 @@ jobs:
         with:
           submodules: recursive
 
+      # Same as the `build` job: keep the tc39/test262 clone out of the nix
+      # submodule walk that `nix develop` triggers.
+      - name: Skip the quickjs test262 submodule
+        run: ./scripts/skip-quickjs-test262.bash
+        env:
+          CLONE_TEST262: ${{ vars.CLONE_TEST262 }}
+
       - uses: nixbuild/nix-quick-install-action@v35
       - name: Restore and cache Nix store
         uses: nix-community/cache-nix-action@v7
@@ -594,23 +609,16 @@ jobs:
         with:
           submodules: recursive
 
-      # quickjs-ng pins a nested `test262` submodule with `update = none`, so the
-      # recursive checkout above skips it — it is the tc39 conformance suite
-      # (tens of thousands of files) and nothing in this build uses it.
-      # `nix build '.?submodules=1'` still walks every entry of every nested
-      # `.gitmodules` and fails on test262 because the directory is absent, so
-      # drop the entry from the working tree instead of cloning tc39/test262.
-      # The gitlink goes with it (`update-index --force-remove`): an entry left
-      # in the index with no `.gitmodules` mapping is an orphan that `git
-      # submodule status` itself errors on. Both edits only dirty the quickjs
-      # checkout, which nix copies as-is; nothing in the build reads either.
-      # Set the `CLONE_TEST262` repository variable to `1` to fetch it instead.
-      - name: Drop the quickjs test262 submodule entry (skips the tc39 clone)
-        if: ${{ vars.CLONE_TEST262 != '1' }}
-        run: |
-          git -C 3rd/quickjs config --file .gitmodules --remove-section submodule.test262
-          git -C 3rd/quickjs update-index --force-remove test262
+      # Same as the `build` job — `nix build '.?submodules=1'` walks every entry
+      # of every nested `.gitmodules`, so drop quickjs-ng's unused test262 entry
+      # rather than cloning tc39/test262 to satisfy the walk.
+      - name: Skip the quickjs test262 submodule
+        run: ./scripts/skip-quickjs-test262.bash
+        env:
+          CLONE_TEST262: ${{ vars.CLONE_TEST262 }}
 
+      # The opt-out (`CLONE_TEST262=1`) leaves the submodule registered, so it
+      # has to be materialised for the walk to find it.
       - name: Materialize quickjs test262 submodule for the flake build
         if: ${{ vars.CLONE_TEST262 == '1' }}
         run: git -C 3rd/quickjs -c submodule.test262.update=checkout submodule update --init --depth 1 test262

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -595,11 +595,24 @@ jobs:
           submodules: recursive
 
       # quickjs-ng pins a nested `test262` submodule with `update = none`, so the
-      # recursive checkout above skips it. `nix build '.?submodules=1'` still
-      # recurses into every nested submodule and fails to fetch test262 when it
-      # is absent, so materialise it here (shallow). It is only needed to satisfy
-      # nix's recursive fetch; nothing in the build uses it.
+      # recursive checkout above skips it — it is the tc39 conformance suite
+      # (tens of thousands of files) and nothing in this build uses it.
+      # `nix build '.?submodules=1'` still walks every entry of every nested
+      # `.gitmodules` and fails on test262 because the directory is absent, so
+      # drop the entry from the working tree instead of cloning tc39/test262.
+      # The gitlink goes with it (`update-index --force-remove`): an entry left
+      # in the index with no `.gitmodules` mapping is an orphan that `git
+      # submodule status` itself errors on. Both edits only dirty the quickjs
+      # checkout, which nix copies as-is; nothing in the build reads either.
+      # Set the `CLONE_TEST262` repository variable to `1` to fetch it instead.
+      - name: Drop the quickjs test262 submodule entry (skips the tc39 clone)
+        if: ${{ vars.CLONE_TEST262 != '1' }}
+        run: |
+          git -C 3rd/quickjs config --file .gitmodules --remove-section submodule.test262
+          git -C 3rd/quickjs update-index --force-remove test262
+
       - name: Materialize quickjs test262 submodule for the flake build
+        if: ${{ vars.CLONE_TEST262 == '1' }}
         run: git -C 3rd/quickjs -c submodule.test262.update=checkout submodule update --init --depth 1 test262
 
       - uses: nixbuild/nix-quick-install-action@v35

--- a/changelog.d/ci-skip-test262-clone.changed.md
+++ b/changelog.d/ci-skip-test262-clone.changed.md
@@ -1,0 +1,6 @@
+- CI no longer clones `tc39/test262`. The flake job used to materialize
+  quickjs-ng's nested `test262` submodule (which git itself skips, `update =
+  none`) just so `nix build` with `self.submodules = true` would not trip over
+  the missing directory; it now drops the entry from the quickjs working tree
+  instead. Set the `CLONE_TEST262` repository variable to `1` to fetch the
+  conformance suite anyway.

--- a/changelog.d/ci-skip-test262-clone.changed.md
+++ b/changelog.d/ci-skip-test262-clone.changed.md
@@ -1,6 +1,7 @@
-- CI no longer clones `tc39/test262`. The flake job used to materialize
-  quickjs-ng's nested `test262` submodule (which git itself skips, `update =
-  none`) just so `nix build` with `self.submodules = true` would not trip over
-  the missing directory; it now drops the entry from the quickjs working tree
-  instead. Set the `CLONE_TEST262` repository variable to `1` to fetch the
-  conformance suite anyway.
+- CI no longer clones `tc39/test262`. Every nix job (`build`, `wasm`, `flake`)
+  fetches this flake with `self.submodules = true`, which walks quickjs-ng's
+  nested `test262` entry; the `flake` job used to materialize that submodule
+  (the whole conformance suite, which git itself skips via `update = none`)
+  just to keep the walk happy. `scripts/skip-quickjs-test262.bash` now
+  deregisters the entry from the quickjs checkout instead, and each nix job
+  runs it after checkout. Set `CLONE_TEST262=1` to opt out.

--- a/scripts/skip-quickjs-test262.bash
+++ b/scripts/skip-quickjs-test262.bash
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Deregister quickjs-ng's nested `test262` submodule from the local checkout so
+# nothing ever clones https://github.com/tc39/test262 — the tc39 conformance
+# suite, tens of thousands of files that nothing in this build uses.
+#
+# git already skips it: quickjs-ng pins the entry with `update = none`, so a
+# recursive checkout leaves the directory absent. Nix does not — every job that
+# runs `nix develop` or `nix build` fetches this flake with
+# `self.submodules = true` (flake.nix), and that walks every entry of every
+# nested `.gitmodules`, including this one, which fails on the missing
+# directory. The previous fix cloned test262 (shallow) purely to satisfy that
+# walk; dropping the entry instead keeps the walk happy for free.
+#
+# Both the `.gitmodules` section and the gitlink go: an index entry with no
+# `.gitmodules` mapping is an orphan that `git submodule status` itself errors
+# on. This only dirties the quickjs checkout — nix copies the working tree as
+# is, no file on disk is removed, and nothing in the build reads either.
+#
+# Idempotent, so jobs can run it after any checkout. Set CLONE_TEST262=1 to opt
+# out and keep the submodule registered (then materialise it with
+# `git -C 3rd/quickjs -c submodule.test262.update=checkout \
+#      submodule update --init --depth 1 test262`).
+
+if [ "${CLONE_TEST262:-}" = "1" ]; then
+  echo "CLONE_TEST262=1: leaving quickjs's test262 submodule registered"
+  exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+quickjs="${repo_root}/3rd/quickjs"
+
+if [ ! -e "${quickjs}/.git" ]; then
+  echo "3rd/quickjs is not checked out; nothing to do"
+  exit 0
+fi
+
+if git -C "${quickjs}" config --file .gitmodules --get-regexp '^submodule\.test262\.' \
+  >/dev/null 2>&1; then
+  git -C "${quickjs}" config --file .gitmodules --remove-section submodule.test262
+  echo "dropped submodule.test262 from 3rd/quickjs/.gitmodules"
+fi
+
+if git -C "${quickjs}" ls-files --error-unmatch test262 >/dev/null 2>&1; then
+  git -C "${quickjs}" update-index --force-remove test262
+  echo "dropped the test262 gitlink from 3rd/quickjs's index"
+fi


### PR DESCRIPTION
## Summary
Optimizes the CI flake build job by skipping the clone of the large tc39/test262 conformance suite by default, since it's not used in the build process.

## Key Changes
- **Modified build workflow**: Changed the approach for handling quickjs-ng's nested `test262` submodule from materializing it (shallow clone) to removing it from the working tree
  - Removes the `submodule.test262` entry from `.gitmodules` in the quickjs checkout
  - Removes the test262 gitlink from the git index using `update-index --force-remove`
  - These changes only affect the local quickjs checkout that nix copies as-is
  
- **Added conditional logic**: 
  - New step to drop the test262 submodule entry (runs by default)
  - Updated existing materialization step to only run when `CLONE_TEST262` repository variable is set to `1`
  
- **Added changelog entry**: Documents the CI optimization and the opt-in mechanism for users who need the conformance suite

## Implementation Details
The solution avoids the issue where `nix build '.?submodules=1'` would fail when encountering the test262 directory entry in `.gitmodules` without the actual directory present. By removing both the `.gitmodules` entry and the gitlink from the index, the build can proceed without cloning tens of thousands of test262 files. Users can still opt-in to cloning test262 by setting the `CLONE_TEST262` repository variable.

https://claude.ai/code/session_012cX36eDiFcUnDmZsYBQgUK