### PR TITLE
Couple the RPG2000 death state (戦闘不能) to HP, add Change Condition

### DIFF
--- a/changelog.d/rpg2k-death-state.added.md
+++ b/changelog.d/rpg2k-death-state.added.md
@@ -1,0 +1,19 @@
+- RPG Maker 2000: the **death state (戦闘不能, state id 1)** is now coupled to HP,
+  and events can change conditions. `Game::Actor` gains `dead?` / `alive?`, and
+  the coupling mirrors EasyRPG's `lcf::rpg::State::kDeathID`: lethal `change_hp`
+  (death allowed) knocks the actor out — HP hits 0 and state 1 is inflicted —
+  while inflicting state 1 directly zeroes HP. A downed actor is unaffected by HP
+  changes (healing can't revive it); curing the death state, or **Full Recovery**,
+  revives at 1 HP. Because a downed actor is HP 0 **and** state 1, and both fields
+  already round-trip (chunk 108's HP field 71 and the state fields 81/82), a
+  knocked-out party member stays down across **Continue** — the `.lsd` round-trip
+  test now KOs the leader and asserts it. The **Change Condition** event command
+  (10480) is wired: it inflicts (op 0) or cures (op 1) a state on the targeted
+  actors (same scope layout as Change HP), so an event can poison, cure, KO, or
+  revive — reviving via removing state 1 stands the actor back up. Grounded
+  against EasyRPG's `Game_Battler::ChangeHp` / `AddState` / `RemoveState` and
+  `Game_Interpreter::CommandChangeCondition`, and covered by new
+  `scripts/rpg2k_logic_check.rb` checks (the HP↔death coupling, the command) and
+  the downed-leader `.lsd` round-trip in `scripts/rpg2k_save_load_check.rb`.
+  Inflicting states from battle / skills (rolling `state_chance`) and party-wipe
+  game over remain follow-ups.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -229,8 +229,15 @@ The work below is roughly ordered by the critical path to a walkable game
   `reverse_state_effect` set removes its `state_set` conditions from the target
   (an antidote / herb — unconditional, matching EasyRPG's item algorithm), and
   such an item now counts as usable when the target is afflicted even at full HP.
-  Still remaining: *inflicting* states (the non-reverse item case rolled against
-  `state_chance`, and skill / battle infliction).
+  The **death state (戦闘不能, id 1)** is **coupled to HP** (EasyRPG's
+  `kDeathID`): lethal `change_hp` knocks the actor out and inflicts state 1
+  (zeroing HP), a downed actor can't be healed by HP changes, and curing the
+  death state (or Full Recovery) revives at 1 HP — `Game::Actor#dead?`/`alive?`
+  report it, and the KO'd HP-0 + state-1 pair round-trips through the `.lsd`. The
+  **Change Condition** event command (10480) inflicts / cures a state on the
+  target actors, so events can poison, cure, KO, or revive. Still remaining:
+  *inflicting* states from combat (the non-reverse item case rolled against
+  `state_chance`, and skill / battle infliction), and party-wipe game over.
   **Show / Move / Erase
   Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
   (centre position, zoom, opacity, tone and the scroll-with-map flag) held on

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -928,24 +928,51 @@ module Game
 
     # -- status conditions (状態) -------------------------------------------
 
+    # The incapacitation state (戦闘不能). RPG2000 hardcodes it as state id 1, and
+    # it is coupled to HP: a downed actor (HP 0) carries it, and it is cleared the
+    # moment HP is restored (matching EasyRPG's `lcf::rpg::State::kDeathID`).
+    DEATH_STATE = 1
+
+    # Whether the actor is knocked out. HP is authoritative and kept in sync with
+    # the death state, so either signal reports it.
+    def dead?; @hp <= 0 || @states.include?(DEATH_STATE); end
+
+    # Whether the actor is still standing (a live party member).
+    def alive?; !dead?; end
+
     # Whether `state_id` is currently afflicting the actor.
     def state?(state_id)
       return false if state_id.nil? || state_id == 0
       @states.include?(state_id)
     end
 
-    # Inflict / cure a status condition (no-ops for an absent/duplicate id).
+    # Inflict a status condition (no-ops for an absent/duplicate id). Inflicting
+    # the death state (戦闘不能) knocks the actor out, zeroing HP.
     def add_state(state_id)
       return if state_id.nil? || state_id == 0 || @states.include?(state_id)
       @states.push(state_id)
+      @hp = 0 if state_id == DEATH_STATE
     end
 
-    def remove_state(state_id); @states.delete(state_id); end
+    # Cure a status condition. Removing the death state revives a downed actor
+    # with 1 HP (RPG2000's revive floor); returns the removed id or nil.
+    def remove_state(state_id)
+      removed = @states.delete(state_id)
+      @hp = 1 if removed == DEATH_STATE && @hp <= 0
+      removed
+    end
 
-    # Cure every status condition (RPG2000 Full Recovery clears them).
-    def clear_states; @states = []; end
+    # Cure every status condition (RPG2000 Full Recovery clears them). If the
+    # actor was down, curing the death state revives it with 1 HP.
+    def clear_states
+      revive = @hp <= 0 && @states.include?(DEATH_STATE)
+      @states = []
+      @hp = 1 if revive && @hp <= 0
+    end
 
-    # Replace the state set (Continue restoring the saved conditions).
+    # Replace the state set (Continue restoring the saved conditions). The saved
+    # HP is authoritative and restored separately, so this assigns without the
+    # HP-coupling side effects.
     def states=(ids)
       @states = (ids || []).reject { |s| s.nil? || s == 0 }.uniq
     end
@@ -1131,10 +1158,16 @@ module Game
     # Apply a HP change (positive heals, negative damages), clamped to
     # [floor, max_hp]. The floor is 0 when death is allowed (the actor may be
     # knocked out) or 1 otherwise, matching RPG2000's Change HP "allow death"
-    # flag. Returns the new HP.
+    # flag. Reaching 0 with death allowed inflicts the death state (戦闘不能).
+    # A downed actor is unaffected -- HP changes cannot revive it (that needs the
+    # death state cured / Full Recovery), matching EasyRPG's ChangeHp. Returns the
+    # new HP.
     def change_hp(delta, allow_death = true)
+      return @hp if dead?
       floor = allow_death ? 0 : 1
       @hp = Game.clamp(@hp + delta, floor, @max_hp)
+      add_state(DEATH_STATE) if @hp <= 0
+      @hp
     end
 
     # Apply a MP (SP) change, clamped to [0, max_mp]. Returns the new MP.
@@ -1396,18 +1429,21 @@ module Game
       cured = item_cured_states(it)
       affected = []
       targets.each do |t|
-        hp, mp = item_recovery(it, t)
-        before_hp = t.hp
-        before_mp = t.mp
-        t.change_hp(hp) if hp > 0
-        t.change_mp(mp) if mp > 0
-        changed = t.hp != before_hp || t.mp != before_mp
+        changed = false
+        # Cure first: a revive item (curing 戦闘不能) stands the actor back up so
+        # the HP recovery below lands instead of being blocked as a no-op.
         cured.each do |s|
           if t.state?(s)
             t.remove_state(s)
             changed = true
           end
         end
+        hp, mp = item_recovery(it, t)
+        before_hp = t.hp
+        before_mp = t.mp
+        t.change_hp(hp) if hp > 0
+        t.change_mp(mp) if mp > 0
+        changed ||= t.hp != before_hp || t.mp != before_mp
         affected.push(t) if changed
       end
       lose_item(id, 1) unless affected.empty?

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -32,6 +32,7 @@ module Game
       CHANGE_EQUIP     = 10440
       CHANGE_HP        = 10460
       CHANGE_MP        = 10470
+      CHANGE_CONDITION = 10480
       FULL_HEAL        = 10490
       CHANGE_ACTOR_NAME   = 10610
       CHANGE_ACTOR_TITLE  = 10620
@@ -481,6 +482,7 @@ module Game
       when Cmd::CHANGE_EQUIP     then do_change_equipment cmd
       when Cmd::CHANGE_HP        then do_change_hp cmd
       when Cmd::CHANGE_MP        then do_change_mp cmd
+      when Cmd::CHANGE_CONDITION then do_change_condition cmd
       when Cmd::FULL_HEAL        then do_full_heal cmd
       when Cmd::CHANGE_ACTOR_NAME   then do_change_actor_name cmd
       when Cmd::CHANGE_ACTOR_TITLE  then do_change_actor_title cmd
@@ -996,6 +998,19 @@ module Game
     # Full recovery: restore HP and MP to their maxima for the target actors.
     def do_full_heal(cmd)
       stat_targets(cmd).each { |a| a.full_heal }
+    end
+
+    # Change Condition: inflict or cure a status condition on the target actors.
+    # param0/param1 pick the targets (same scope layout as Change HP); param2 is
+    # the operation (0 add / inflict, non-zero remove / cure) and param3 the state
+    # id. Removing the death state (戦闘不能) revives a downed actor; inflicting it
+    # knocks the actor out — the HP coupling lives in Game::Actor.
+    def do_change_condition(cmd)
+      state_id = cmd.param(3)
+      remove = cmd.param(2) != 0
+      stat_targets(cmd).each do |a|
+        remove ? a.remove_state(state_id) : a.add_state(state_id)
+      end
     end
 
     # -- actor identity / graphic ---------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1346,8 +1346,8 @@ end
 check 'Actor change_hp/change_mp/full_heal clamp within their bounds' do
   hero = party_state.party.actor_by_id(1)
   hero.change_hp(-30);          eq 70, hero.hp
-  hero.change_hp(-1000, true);  eq 0, hero.hp   # death allowed -> floor 0
-  hero.change_hp(-5, false);    eq 1, hero.hp   # death disallowed -> floor 1
+  hero.change_hp(-1000, false);  eq 1, hero.hp  # death disallowed -> floor 1 (alive)
+  eq false, hero.dead?
   hero.change_hp(9999);         eq 100, hero.hp # capped at max_hp
   hero.change_mp(-1000);        eq 0, hero.mp
   hero.change_mp(9999);         eq 30, hero.mp  # capped at max_mp
@@ -2043,6 +2043,49 @@ check 'Conditional actor: afflicted by state (type 5, sub 6)' do
   eq true, st.switches[2]
 end
 
+# -- Change Condition (event command 10480) ---------------------------------
+
+check 'Change Condition inflicts a state on the targeted actor (op 0)' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # scope 1 (fixed actor), actor 1, op 0 (add), state 4.
+  it.start([FakeCmd.new(IC::CHANGE_CONDITION, [1, 1, 0, 4])])
+  it.update
+  eq true, st.party.actor_by_id(1).state?(4)
+end
+
+check 'Change Condition removes a state on the targeted actor (op 1)' do
+  st = party_state
+  st.party.actor_by_id(1).add_state(4)
+  it = Game::Interpreter.new(st)
+  # op 1 (remove) clears state 4.
+  it.start([FakeCmd.new(IC::CHANGE_CONDITION, [1, 1, 1, 4])])
+  it.update
+  eq false, st.party.actor_by_id(1).state?(4)
+end
+
+check 'Change Condition can KO the whole party (scope 0) via the death state' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # scope 0 (whole party), op 0 (add), state 1 (戦闘不能) -> everyone down.
+  it.start([FakeCmd.new(IC::CHANGE_CONDITION, [0, 0, 0, Game::Actor::DEATH_STATE])])
+  it.update
+  eq true, st.party.actors.all?(&:dead?)
+  eq [0, 0], st.party.actors.map(&:hp)
+end
+
+check 'Change Condition reviving the death state stands an actor back up' do
+  st = party_state
+  st.party.actor_by_id(1).add_state(Game::Actor::DEATH_STATE)  # down first
+  it = Game::Interpreter.new(st)
+  # op 1 (remove) state 1 -> revived with 1 HP.
+  it.start([FakeCmd.new(IC::CHANGE_CONDITION, [1, 1, 1, Game::Actor::DEATH_STATE])])
+  it.update
+  a = st.party.actor_by_id(1)
+  eq false, a.dead?
+  eq 1, a.hp
+end
+
 check 'Actor status states: add / remove / query, cleared by Full Recovery' do
   a = party_state.party.actor_by_id(1)
   eq [], a.states
@@ -2056,6 +2099,41 @@ check 'Actor status states: add / remove / query, cleared by Full Recovery' do
   eq [1, 2], a.states
   a.full_heal
   eq [], a.states                                     # Full Recovery clears states
+end
+
+check 'Actor death state: lethal HP inflicts 戦闘不能 (state 1), block on revive' do
+  a = party_state.party.actor_by_id(1)
+  eq false, a.dead?
+  a.change_hp(-1000, true)                            # lethal damage -> knocked out
+  eq 0, a.hp
+  eq true, a.dead?
+  eq true, a.state?(Game::Actor::DEATH_STATE)         # HP 0 couples to state 1
+  a.change_hp(500)                                    # a downed actor cannot be healed
+  eq 0, a.hp
+  eq true, a.dead?
+  a.remove_state(Game::Actor::DEATH_STATE)            # curing 戦闘不能 revives with 1 HP
+  eq 1, a.hp
+  eq false, a.dead?
+  a.change_hp(49); eq 50, a.hp                        # healing lands again once alive
+end
+
+check 'Actor death state: inflicting state 1 zeroes HP; Full Recovery revives' do
+  a = party_state.party.actor_by_id(1)
+  a.add_state(Game::Actor::DEATH_STATE)               # inflict KO directly
+  eq 0, a.hp
+  eq true, a.dead?
+  a.full_heal                                         # Full Recovery clears states + revives
+  eq 100, a.hp
+  eq false, a.dead?
+  eq false, a.state?(Game::Actor::DEATH_STATE)
+end
+
+check 'Actor death state: non-lethal damage floors HP at 1, no KO' do
+  a = party_state.party.actor_by_id(1)
+  a.change_hp(-1000, false)                           # death disallowed -> floor 1
+  eq 1, a.hp
+  eq false, a.dead?
+  eq false, a.state?(Game::Actor::DEATH_STATE)
 end
 
 check 'State save round-trips per-actor status states' do

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -206,6 +206,7 @@ def check_game(dir)
     state.party.leader.name = 'Renamed'
     state.party.leader.add_state(3)   # afflict the leader with a couple of states
     state.party.leader.add_state(7)
+    state.party.leader.change_hp(-99_999)  # ...and knock them out (HP 0 + 戦闘不能)
   end
 
   round = Game::State.from_lsd(db, LCF::SaveData.new(StringIO.new(state.to_lsd.to_lcf)))
@@ -227,6 +228,15 @@ def check_game(dir)
     eq a.equipment, b.equipment, "to_lsd: actor #{a.id} equipment"
     eq a.skills.sort, b.skills.sort, "to_lsd: actor #{a.id} skills"
     eq a.states.sort, b.states.sort, "to_lsd: actor #{a.id} states"
+    eq a.dead?, b.dead?, "to_lsd: actor #{a.id} dead? survives"
+  end
+  # The knocked-out leader specifically: HP 0 and the death state (戦闘不能) must
+  # both come back so a downed party member stays down across Continue.
+  if state.party.leader
+    rl = round.party.actor_by_id(state.party.leader.id)
+    eq 0, rl.hp, 'to_lsd: downed leader restores at HP 0'
+    eq true, rl.dead?, 'to_lsd: downed leader stays knocked out'
+    eq true, rl.state?(Game::Actor::DEATH_STATE), 'to_lsd: leader death state survives'
   end
   eq state.switches.to_h.select { |_k, v| v }.keys.sort,
      round.switches.to_h.select { |_k, v| v }.keys.sort, 'to_lsd: switches on'


### PR DESCRIPTION
Builds on the actor status-state model (#240) and item cure (#245): the **death state** (戦闘不能, id 1) is now tied to HP, and events can change conditions.

## Behavior

`Game::Actor` gains `DEATH_STATE = 1`, `dead?` and `alive?`. HP and the incapacitation state are kept in sync, mirroring EasyRPG's `lcf::rpg::State::kDeathID`:

- **Lethal `change_hp`** (death allowed) knocks the actor out — HP reaches 0 **and** state 1 is inflicted. Inflicting state 1 directly (`add_state`) zeroes HP.
- A **downed actor is unaffected by HP changes** — healing can't revive it (matching EasyRPG's `ChangeHp`, which returns 0 when dead).
- **Curing the death state** (`remove_state 1`), or **Full Recovery**, revives at 1 HP.
- `use_medicine` now **cures states before healing HP**, so a revive item stands the actor up first and its HP recovery lands instead of being a no-op.

## Change Condition event command (10480)

Wired the **Change Condition** command: it inflicts (op 0) or cures (op 1) a state on the target actors (same scope layout as Change HP). So an event can poison, cure, KO, or revive — removing state 1 stands a downed actor back up. Grounded on EasyRPG's `Game_Interpreter::CommandChangeCondition`.

## Save persistence

A KO'd actor is HP 0 **and** state 1, and both fields already round-trip (`.lsd` chunk 108 field 71 HP, fields 81/82 states). So a downed party member **survives Continue** — the save-load round-trip now knocks out the leader and asserts HP 0 + the death state come back (verified against the real Nepheshel / mtf-meido saves, where `hp=0` round-trips faithfully rather than being dropped as a zero field).

## Grounding

Confirmed against EasyRPG's `Game_Battler::ChangeHp` / `AddState` / `RemoveState` (death id = `kDeathID` = 1; HP↔state coupling; revive floor 1 HP; `IsDead` is HP-based) and `Game_Interpreter::CommandChangeCondition` (param2 op, param3 state id).

## Tests

New `scripts/rpg2k_logic_check.rb` checks: the HP↔death coupling (lethal KO, heal-blocked-while-down, revive-via-cure), inflict-state-1-zeroes-HP + Full-Recovery-revives, the non-lethal floor, and the Change Condition command (inflict, cure, party KO via death state, revive). Updated the existing clamp test for the new no-heal-while-down rule. Downed-leader `.lsd` round-trip in `scripts/rpg2k_save_load_check.rb`. **222 logic + 70 scene + 35 render checks pass; save-load OK.**

## Follow-up

*Inflicting* states from combat (rolling `state_chance` for the non-reverse item case, plus skill / battle infliction) and party-wipe game over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_