### PR TITLE
Make Cloudflare Pages previews on-request via `/preview` comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,13 @@ on:
   pull_request:
     branches: [ master ]
 
+  # Lets a maintainer publish a Cloudflare Pages preview on demand by
+  # commenting `/preview` on a pull request. Only the `preview-gate`,
+  # `wasm` and `preview-cloudflare` jobs take part in this flow; every other
+  # job opts out with `github.event_name != 'issue_comment'`.
+  issue_comment:
+    types: [ created ]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -17,6 +24,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # `/preview` comments only ever want the wasm page; skip the rest of CI.
+    if: ${{ github.event_name != 'issue_comment' }}
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
 
@@ -327,8 +336,63 @@ jobs:
           path: ss/mv_menu.png
           if-no-files-found: warn
 
+  # `/preview` command gate. Cloudflare previews are opt-in per pull request:
+  # they are published when someone with write access comments `/preview` on the
+  # PR, not automatically on every push to every PR. This job resolves that
+  # comment into the head commit the preview should build and acknowledges the
+  # command with a 👀 reaction, so it is visible that the run started.
+  #
+  # `issue_comment` runs on the base repo with access to the repository secrets
+  # even when the pull request comes from a fork, so the author check below is
+  # the security boundary: only OWNER / MEMBER / COLLABORATOR comments get past
+  # it. Anyone else's `/preview` is ignored — no build, no deploy.
+  preview-gate:
+    if: >-
+      ${{ github.event_name == 'issue_comment'
+          && github.event.issue.pull_request != null
+          && startsWith(github.event.comment.body, '/preview')
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                      github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Read the PR to find its head commit; write reactions on the comment
+      # (a PR conversation comment is an issue comment, hence `issues`).
+      pull-requests: read
+      issues: write
+    outputs:
+      head-sha: ${{ steps.pr.outputs.head-sha }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_ID: ${{ github.event.comment.id }}
+    steps:
+      - name: Resolve the pull request head
+        id: pr
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            --jq '"head-sha=\(.head.sha)"' >> "$GITHUB_OUTPUT"
+
+      - name: Acknowledge the command
+        run: |
+          gh api --silent -X POST \
+            "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes
+
   wasm:
+    # Builds the page for ordinary CI (push / pull request / manual run) and,
+    # on a `/preview` comment, for the commit that comment asked to preview.
+    # `preview-gate` is skipped outside the comment flow — which would skip this
+    # job along with it — so the condition spells both cases out.
+    needs: preview-gate
+    if: >-
+      ${{ !cancelled()
+          && (github.event_name != 'issue_comment'
+              || needs.preview-gate.result == 'success') }}
     runs-on: ubuntu-24.04
+    permissions:
+      # A `/preview` comment can ask for a fork's branch to be built, so keep
+      # the token read-only here; `preview-gate` limits who may ask.
+      contents: read
     env:
       # Cache emcc compilations across runs. sccache (used by the native build)
       # does not understand emcc, so the wasm build uses ccache instead, which
@@ -341,6 +405,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          # The PR head for a `/preview` comment; empty everywhere else, which
+          # is checkout's default of "the ref that triggered the workflow".
+          ref: ${{ needs.preview-gate.outputs.head-sha }}
 
       - uses: nixbuild/nix-quick-install-action@v35
       - name: Restore and cache Nix store
@@ -426,6 +493,7 @@ jobs:
     # or flash the board, so CI compiles it. Builds the display + input HAL and
     # the Arduino sketch; the mruby interpreter is layered on in a later slice
     # (see app/wio/README.md and docs/adr/0005-wio-terminal-port.md).
+    if: ${{ github.event_name != 'issue_comment' }}
     runs-on: ubuntu-24.04
     steps:
       - run: git config --global submodule.fetchJobs 4
@@ -460,6 +528,7 @@ jobs:
     # input HAL and the entry-point sketch into EBOOT.PBP; the mruby interpreter
     # is layered on in a later slice (see app/psp/README.md and
     # docs/adr/0010-psp-port.md).
+    if: ${{ github.event_name != 'issue_comment' }}
     runs-on: ubuntu-24.04
     steps:
       - run: git config --global submodule.fetchJobs 4
@@ -583,6 +652,7 @@ jobs:
           if-no-files-found: warn
 
   flake:
+    if: ${{ github.event_name != 'issue_comment' }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -645,25 +715,31 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
-  # Publish a Cloudflare Pages preview deployment for every pull request, so the
-  # branch's build gets a shareable URL before it merges. Requires two repo
-  # secrets — CLOUDFLARE_API_TOKEN (a token with the "Cloudflare Pages: Edit"
+  # Publish a Cloudflare Pages preview deployment on request, so a pull request's
+  # build gets a shareable URL before it merges. Comment `/preview` on the PR to
+  # trigger it (see `preview-gate` above for who may). Requires two repo secrets
+  # — CLOUDFLARE_API_TOKEN (a token with the "Cloudflare Pages: Edit"
   # permission) and CLOUDFLARE_ACCOUNT_ID — and a Cloudflare Pages project named
   # "rpg-maker-clone" (create it once in the dashboard as a "Direct Upload"
   # project). See docs/deploy.md for the one-time setup.
   preview-cloudflare:
-    needs: wasm
-    # Only PRs from branches in this repo — forks and Dependabot can't read the
-    # secrets, so skip them instead of failing the job.
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    # `preview-gate` only succeeds on a `/preview` comment, so depending on it
+    # is what keeps this job out of ordinary push / pull-request runs.
+    needs: [ preview-gate, wasm ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+    # Two `/preview` comments in a row would otherwise race to publish the same
+    # Pages project; queue them per PR instead. Not cancel-in-progress — a
+    # cancelled upload leaves a half-written deployment.
+    concurrency:
+      group: cloudflare-preview-${{ github.event.issue.number }}
+      cancel-in-progress: false
     # Job-level env can read secrets (job-level `if` cannot), so expose whether
     # Cloudflare is configured to a step that gates the deploy. This keeps the
-    # PR green when the optional Cloudflare setup hasn't been done yet, instead
-    # of failing the required check on a missing secret.
+    # job green when the optional Cloudflare setup hasn't been done yet, instead
+    # of failing on a missing secret.
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -677,6 +753,21 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Cloudflare secrets not set — skipping the preview deployment. See docs/deploy.md for the one-time setup."
           fi
+      # `/preview` is an explicit request, so say something when it cannot be
+      # honoured rather than leaving the comment answered by a 👀 and nothing
+      # else.
+      - name: Report the missing setup on the PR
+        if: steps.creds.outputs.configured != 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloudflare-preview
+          number: ${{ github.event.issue.number }}
+          message: |
+            ### ⚡ Cloudflare Pages preview
+
+            `/preview` cannot run: the `CLOUDFLARE_API_TOKEN` /
+            `CLOUDFLARE_ACCOUNT_ID` repository secrets are not set. See
+            `docs/deploy.md` for the one-time setup.
       - name: Download wasm page
         if: steps.creds.outputs.configured == 'true'
         uses: actions/download-artifact@v7
@@ -691,25 +782,29 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # Any --branch other than the project's production branch is published
-          # as a preview; the PR head branch is never master, so this is always
-          # a preview deployment.
+          # as a preview. `pr-<number>` is used rather than the PR's own branch
+          # name so a fork branch that happens to be called master cannot land
+          # on the production deployment, and so each PR keeps a stable
+          # preview URL across repeated `/preview` runs.
           command: >-
             pages deploy site
             --project-name=rpg-maker-clone
-            --branch=${{ github.head_ref }}
-            --commit-hash=${{ github.event.pull_request.head.sha }}
+            --branch=pr-${{ github.event.issue.number }}
+            --commit-hash=${{ needs.preview-gate.outputs.head-sha }}
             --commit-dirty=true
       - name: Comment preview URL on the PR
         if: ${{ steps.cf.outputs.deployment-url != '' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: cloudflare-preview
+          number: ${{ github.event.issue.number }}
           message: |
             ### ⚡ Cloudflare Pages preview
 
             | | |
             | --- | --- |
             | **Preview URL** | ${{ steps.cf.outputs.deployment-url }} |
-            | **Commit** | ${{ github.event.pull_request.head.sha }} |
+            | **Commit** | ${{ needs.preview-gate.outputs.head-sha }} |
 
             Open the link and load an RPG Maker project with the on-page loader.
+            Comment `/preview` again to publish a fresh build.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,11 @@ directly. Before opening one:
   validators before pushing.
 - **Open a PR when there is code to review.** Push with
   `git push -u origin <branch>`, then open a pull request whenever the change
-  includes code that needs review. Each PR gets a **Cloudflare Pages** preview
-  and must keep CI green before it is merged; pushes to `master` deploy the page
-  to **GitHub Pages**.
+  includes code that needs review. A PR must keep CI green before it is merged;
+  pushes to `master` deploy the page to **GitHub Pages**. A **Cloudflare Pages**
+  preview is published on request — comment `/preview` on the PR when a
+  reviewer should see the change running in the browser (see
+  `docs/deploy.md`).
 - **Auto-merge counts as approval — keep moving.** When a PR has auto-merge
   enabled, treat it as already review-approved: do not block waiting for the
   merge to land. Move straight on to the next task if there is work left to do;

--- a/README.md
+++ b/README.md
@@ -208,10 +208,11 @@
 - The page draws an **on-screen keypad** (D-pad plus OK/Cancel/Dash, the L/R
   shoulders and the A/X/Y/Z buttons) beneath the canvas, so the game is playable
   by touch or mouse without a physical keyboard; the keyboard keeps working too.
-- CI publishes this page automatically: pushes to `master` deploy it to
-  **GitHub Pages**, and every pull request gets a **Cloudflare Pages** preview
-  URL commented on the PR. See [`docs/deploy.md`](docs/deploy.md) for the
-  one-time repo setup (Pages source + Cloudflare secrets).
+- CI publishes this page: pushes to `master` deploy it to **GitHub Pages**, and
+  commenting `/preview` on a pull request builds that PR and posts a
+  **Cloudflare Pages** preview URL back on it. See
+  [`docs/deploy.md`](docs/deploy.md) for the one-time repo setup (Pages source +
+  Cloudflare secrets).
 
 ### Audio
 

--- a/changelog.d/preview-on-comment.changed.md
+++ b/changelog.d/preview-on-comment.changed.md
@@ -1,0 +1,6 @@
+- **Cloudflare Pages previews are now on request.** The `preview-cloudflare` CI
+  job no longer runs for every pull request; comment `/preview` on a PR and CI
+  builds that PR's head and posts the preview URL back on it. Only owner /
+  member / collaborator comments are honoured, which — because `issue_comment`
+  runs on the base repo — also makes previews work for pull requests from forks,
+  which the automatic `pull_request` runs could never do. See `docs/deploy.md`.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -8,7 +8,7 @@ map) as the `wasm` build artifact. Two downstream jobs publish that artifact:
 | Job | Trigger | Destination | URL |
 | --- | --- | --- | --- |
 | `deploy-pages` | push to `master` | GitHub Pages | `https://<owner>.github.io/<repo>/` |
-| `preview-cloudflare` | pull request | Cloudflare Pages preview | commented on the PR |
+| `preview-cloudflare` | `/preview` comment on a PR | Cloudflare Pages preview | commented on the PR |
 
 Neither job rebuilds anything — they reuse the exact bytes the `wasm` job
 produced, so what the preview shows is what ships.
@@ -44,14 +44,41 @@ and no `gh-pages` branch. The workflow already grants the job the required
    - `CLOUDFLARE_ACCOUNT_ID` — your account ID (shown in the dashboard URL and
      on any domain's overview page).
 
-Once the secrets exist, every pull request from a branch in this repo gets a
-fresh preview deployment and a sticky PR comment with its URL. Pull requests
-from forks are skipped because forked runs cannot read the secrets.
+## Publishing a preview: comment `/preview`
+
+Previews are **on request, not automatic**. Comment
+
+```
+/preview
+```
+
+on a pull request and CI builds that PR's head commit and publishes it to
+Cloudflare Pages, then edits a sticky comment on the PR with the URL. The
+command comment gets a 👀 reaction as soon as the run starts. Comment
+`/preview` again at any point to publish a fresh build of the latest head.
+
+Previews cost a full wasm build each, and most PRs never need one, so nothing
+is published until someone asks. Pushing new commits to a PR does **not**
+refresh an existing preview — the previous URL keeps serving the build it was
+made from until the next `/preview`.
+
+Who may run it, and against what:
+
+- Only comments from a repo **owner, org member or collaborator** are acted on;
+  anyone else's `/preview` is ignored silently. `issue_comment` runs on the base
+  repository with access to the secrets even for pull requests from forks, so
+  this check is the security boundary — a maintainer typing `/preview` is what
+  authorises a fork's code to be built and deployed.
+- Fork pull requests therefore work, unlike the old automatic previews (a forked
+  `pull_request` run cannot read the secrets; an `issue_comment` run can).
+- Each PR deploys to the Cloudflare branch `pr-<number>`, so its preview URL is
+  stable across repeated `/preview` runs and a fork branch that happens to be
+  named `master` can never reach the production deployment.
 
 Until the secrets are set, the `preview-cloudflare` job **skips the deploy and
-still passes** (it logs a notice pointing here), so a missing Cloudflare setup
-never blocks a PR — the preview is an optional add-on to the GitHub Pages
-deploy.
+still passes**, and comments on the PR to say the setup is missing — a missing
+Cloudflare setup never blocks a PR, since the preview is an optional add-on to
+the GitHub Pages deploy.
 
 > Renaming the Cloudflare project? Update `--project-name` in the
 > `preview-cloudflare` job to match.


### PR DESCRIPTION
## Summary

Changes the Cloudflare Pages preview deployment from automatic (on every pull request) to on-request (via `/preview` comment). This reduces unnecessary builds while enabling previews for fork pull requests, which couldn't access secrets in the previous automatic flow.

## Key Changes

- **New `issue_comment` trigger**: Added workflow trigger for `/preview` comments on pull requests
- **New `preview-gate` job**: Validates that the comment author is an owner/member/collaborator, resolves the PR's head commit, and acknowledges the command with a 👀 reaction
- **Updated `wasm` job**: Now depends on `preview-gate` and conditionally runs for both ordinary CI and `/preview` comment flows; accepts an optional `ref` parameter to build the requested commit
- **Updated `preview-cloudflare` job**: 
  - Now depends on `preview-gate` instead of running automatically on all PRs
  - Uses `pr-<number>` as the Cloudflare branch name for stable preview URLs across repeated runs
  - Adds concurrency control to prevent race conditions from multiple `/preview` comments
  - Reports missing Cloudflare setup via sticky PR comment instead of silently skipping
- **Opt-out guards**: Added `if: ${{ github.event_name != 'issue_comment' }}` to other jobs (`build`, `wio-terminal`, `psp`, `flake`) to skip them during `/preview` runs
- **Documentation updates**: Updated `docs/deploy.md`, `README.md`, and `AGENTS.md` to explain the new on-request preview flow and security model

## Implementation Details

- Security boundary: Only OWNER/MEMBER/COLLABORATOR comments trigger previews, enforced in `preview-gate` before any secrets are accessed
- Fork support: `issue_comment` runs on the base repository with secret access, enabling previews for fork PRs when a maintainer requests them
- Stable URLs: Each PR gets its own Cloudflare branch (`pr-<number>`), preventing fork branches named `master` from reaching production and keeping preview URLs consistent across multiple `/preview` runs
- User feedback: Command comments receive immediate 👀 reaction; missing setup is reported via sticky PR comment rather than silent failure

https://claude.ai/code/session_015rnbpyfUrZqBjAGYqhy5iW