### PR TITLE
mruby-rgss: render RGSS::Sprite#flash (timed colour pulse)

### DIFF
--- a/changelog.d/rpgxp-rgss-sprite-flash.added.md
+++ b/changelog.d/rpgxp-rgss-sprite-flash.added.md
@@ -1,0 +1,8 @@
+- **`RGSS::Sprite#flash` is now rendered.** `Sprite#flash(color, duration)` runs a
+  timed pulse: a colour flash overlays that colour into the sprite's pre-composite
+  at an alpha that fades over the duration, while a nil-colour "empty" flash blinks
+  the sprite out and back in. `Sprite#update` decays the flash one frame at a time
+  and clears it when the duration runs out. This was the last stored-but-ignored
+  Sprite property, so the battle hit-flash, dying-blink and animation flashes now
+  actually show. Also finishes wiring `Sprite#bush_depth=` natively (it was being
+  shadowed by a stray Ruby `attr_writer`). See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -37,7 +37,7 @@ These are complete enough for the stock scripts:
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
-### 1. `Sprite` extended properties ⚠️ (opacity/zoom/angle/mirror/tone/color/src_rect/blend_type/bush_depth rendered; flash stored)
+### 1. `Sprite` extended properties ✅ (opacity/zoom/angle/mirror/tone/color/src_rect/blend_type/bush_depth/flash all rendered)
 
 `mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,
 `visible`/`visible=`, `dispose`, `update`, and stores the extra properties the
@@ -60,16 +60,19 @@ pixel; and `Sprite#src_rect=` crops the display to a sub-rectangle (the scratch
 is that region, reused across frames to avoid GC churn). `Sprite#update` is native
 and re-composites when a `src_rect` is set, so the per-frame `src_rect.set` that
 character sprites do actually changes the shown cell. Crop/mirror/tone/colour
-share one pre-composite (`spr_bind_display`). **Snapshot caveat:** a sprite that
-redraws its bitmap, or mutates tone/colour in place, still needs a re-assign
-(`bitmap=`/`tone=`/`color=`) unless it also has a `src_rect` (which re-composites
-via `update`). `Sprite#blend_type=` maps 0/1/2 to the canvas object's LVGL blend
-mode (normal / additive / subtractive), so additive effects composite;
+share one pre-composite (`spr_bind_display`). `Sprite#blend_type=` maps 0/1/2 to
+the canvas object's LVGL blend mode (normal / additive / subtractive), so
+additive effects composite;
 `Sprite#bush_depth=` fades the bottom N rows to half opacity in the same
-pre-composite, so a character wading through bushes dims below the waist.
-**Remaining:** **flash** (a timed colour pulse — needs `update`-driven timing).
-`Sprite_Character`, `Sprite_Battler`, `Arrow_Base`, weather and the animation
-player depend on it.
+pre-composite, so a character wading through bushes dims below the waist; and
+`Sprite#flash(color, duration)` runs a timed colour pulse — a colour flash
+overlays that colour at a fading alpha, a nil-colour "empty" flash blinks the
+sprite out, and `update` decays it one frame at a time until it clears. So all of
+`Sprite_Character`, `Sprite_Battler`, `Arrow_Base`, the weather sprites and the
+battle animation player now get their full visual treatment. **Snapshot caveat:**
+a sprite that redraws its bitmap, or mutates tone/colour in place, still needs a
+re-assign (`bitmap=`/`tone=`/`color=`) to re-composite unless it also has a
+`src_rect` or an active flash (which re-composite via `update`).
 
 ### 2. `Window` ⚠️ (background + frame + contents + cursor + pause rendered)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -139,20 +139,21 @@ module RGSS
     attr_reader :x, :y, :z
 
     # RGSS Sprite properties the stock scripts set — opacity fades, zoom, angle,
-    # tone/colour, scroll origin, mirror, bush depth, blend mode, source rect.
-    # `opacity=`, `zoom_x=`, `zoom_y=`, `angle=`, `mirror=`, `tone=`, `color=`,
-    # `src_rect=`, `blend_type=` and `bush_depth=` are now honoured natively
-    # (src/lib.cxx sets the sprite canvas's LVGL object opacity / image scale /
-    # image rotation / blend mode; mirror, tone, colour, the src_rect crop and the
-    # bush-depth bottom fade are baked into a scratch copy the canvas points at, and
-    # `update` re-composites so per-frame `src_rect.set` shows). They still store
-    # their ivars here so the readers below return the set values. `flash` is stored
-    # only so `sprite.flash(...)` no longer raises, but the native renderer does not
-    # yet honour it visually (tracked in docs/rpgxp-rgss-api-gap.md). Readers fall
-    # back to RGSS's defaults because the native #initialize does not set these
-    # ivars (and cannot be wrapped from here without replacing it). `nil?` checks —
-    # not `||` — where 0/false is a meaningful value (opacity 0 = transparent).
-    attr_writer :ox, :oy, :bush_depth
+    # tone/colour, scroll origin, mirror, bush depth, blend mode, source rect,
+    # flash. `opacity=`, `zoom_x=`, `zoom_y=`, `angle=`, `mirror=`, `tone=`,
+    # `color=`, `src_rect=`, `blend_type=`, `bush_depth=` and `flash` are all now
+    # honoured natively (src/lib.cxx sets the sprite canvas's LVGL object opacity /
+    # image scale / image rotation / blend mode; mirror, tone, colour, the src_rect
+    # crop, the bush-depth bottom fade and the timed flash pulse are baked into a
+    # scratch copy the canvas points at, and `update` re-composites so per-frame
+    # `src_rect.set` shows and an active flash decays). `bush_depth=` and `flash`
+    # are native methods, so they must NOT be redefined by an `attr_writer` here —
+    # that would shadow them. Only `ox`/`oy` (read by the native tone/flash pass
+    # but not otherwise wired) stay Ruby-side. The readers below fall back to
+    # RGSS's defaults because the native #initialize does not set these ivars (and
+    # cannot be wrapped from here without replacing it). `nil?` checks — not `||` —
+    # where 0/false is a meaningful value (opacity 0 = transparent).
+    attr_writer :ox, :oy
 
     def opacity
       @opacity.nil? ? 255 : @opacity
@@ -200,13 +201,6 @@ module RGSS
 
     def src_rect
       @src_rect ||= Rect.new(0, 0, 0, 0)
-    end
-
-    # Flash the sprite (colour + duration in frames). Stored; the visual flash is
-    # future native work.
-    def flash(color, duration)
-      @flash_color = color
-      @flash_duration = duration
     end
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2258,6 +2258,29 @@ void spr_bind_display(mrb_state* M, mrb_value self, lv_obj_t* obj) {
       mrb_iv_get(M, self, mrb_intern_lit(M, "@bush_depth"));
   const int bush = mrb_test(bush_v) ? mrb_as_int(M, bush_v) : 0;
 
+  // flash: a timed colour pulse (Sprite#flash) that decays over its duration,
+  // advanced one frame per Sprite#update. A colour flash overlays that colour
+  // at a fading alpha; a nil-colour ("empty") flash instead blinks the sprite
+  // out and back in.
+  const mrb_value fcnt_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_count"));
+  const mrb_value fdur_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_duration"));
+  const mrb_value fcol_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_color"));
+  const int flash_count = mrb_test(fcnt_v) ? mrb_as_int(M, fcnt_v) : 0;
+  const int flash_dur = mrb_test(fdur_v) ? mrb_as_int(M, fdur_v) : 0;
+  const bool flash_on = flash_count > 0 && flash_dur > 0;
+  const bool flash_color_on = flash_on && mrb_test(fcol_v) && DATA_PTR(fcol_v);
+  const bool flash_empty = flash_on && !flash_color_on;
+  Color fcl{0, 0, 0, 0};
+  if (flash_color_on)
+    fcl = DataType<Color>::get(M, fcol_v);
+  // Colour flash intensity fades from full (count == duration) to nothing.
+  const int fa = flash_color_on
+                     ? static_cast<int>(fcl.alpha) * flash_count / flash_dur
+                     : 0;
+
   // src_rect: display only a sub-region of the bitmap (character-animation
   // cells set this every frame). A non-default rect crops to (cx, cy, cw, ch).
   int cx = 0, cy = 0, cw = src.width, ch = src.height;
@@ -2276,7 +2299,7 @@ void spr_bind_display(mrb_state* M, mrb_value self, lv_obj_t* obj) {
     }
   }
 
-  if (cropped || mirror || has_tone || has_color || bush > 0) {
+  if (cropped || mirror || has_tone || has_color || bush > 0 || flash_on) {
     // Reuse the scratch bitmap when its size still matches (src_rect changes
     // every frame, so re-allocating here would churn the GC).
     mrb_value fx_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@_fx_bitmap"));
@@ -2319,6 +2342,13 @@ void spr_bind_display(mrb_state* M, mrb_value self, lv_obj_t* obj) {
           g = clamp_byte(g + (static_cast<int>(cl.green) - g) * ca / 255);
           b = clamp_byte(b + (static_cast<int>(cl.blue) - b) * ca / 255);
         }
+        if (flash_color_on) {
+          r = clamp_byte(r + (static_cast<int>(fcl.red) - r) * fa / 255);
+          g = clamp_byte(g + (static_cast<int>(fcl.green) - g) * fa / 255);
+          b = clamp_byte(b + (static_cast<int>(fcl.blue) - b) * fa / 255);
+        }
+        if (flash_empty)
+          a = a * (flash_dur - flash_count) / flash_dur;
         if (bush > 0 && y >= ch - bush)
           a /= 2;
         bmp_put(fx, x, y, r, g, b, a);
@@ -2471,16 +2501,35 @@ mrb_value spr_set_src_rect(mrb_state* M, mrb_value self) {
 // Per-frame tick: stock scripts (Sprite_Character etc.) mutate src_rect in
 // place via `src_rect.set(...)` each frame, which does not call src_rect=, so a
 // sprite that uses src_rect re-composites here to pick that up (and any
-// tone/color change). Sprites without a src_rect need no per-frame work.
+// tone/color change). An active flash also decays one frame here. Sprites with
+// neither need no per-frame work.
 mrb_value spr_update(mrb_state* M, mrb_value self) {
+  bool recomposite = false;
+
+  // Advance an active flash: it fades one frame per update and clears (dropping
+  // its colour) once the duration runs out.
+  const mrb_value fcnt = mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_count"));
+  int fc = mrb_test(fcnt) ? mrb_as_int(M, fcnt) : 0;
+  if (fc > 0) {
+    --fc;
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_count"),
+               mrb_fixnum_value(fc));
+    if (fc == 0)
+      mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_color"), mrb_nil_value());
+    recomposite = true;
+  }
+
   const mrb_value sr = mrb_iv_get(M, self, mrb_intern_lit(M, "@src_rect"));
   if (mrb_test(sr) && DATA_PTR(sr)) {
     Rect& r = DataType<Rect>::get(M, sr);
-    if (r.width > 0 && r.height > 0) {
-      lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
-      if (obj)
-        spr_bind_display(M, self, obj);
-    }
+    if (r.width > 0 && r.height > 0)
+      recomposite = true;
+  }
+
+  if (recomposite) {
+    lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+    if (obj)
+      spr_bind_display(M, self, obj);
   }
   return self;
 }
@@ -2513,6 +2562,24 @@ mrb_value spr_set_bush_depth(mrb_state* M, mrb_value self) {
   mrb_assert(obj);
   spr_bind_display(M, self, obj);
   return self;
+}
+
+// RGSS Sprite#flash(color, duration) starts a timed colour pulse; a nil colour
+// is an "empty" flash that blinks the sprite out. The state is baked into the
+// composite by spr_bind_display and decayed each frame by spr_update.
+mrb_value spr_flash(mrb_state* M, mrb_value self) {
+  mrb_value color;
+  mrb_int duration;
+  mrb_get_args(M, "oi", &color, &duration);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_color"), color);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_duration"),
+             mrb_fixnum_value(duration));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_count"),
+             mrb_fixnum_value(duration));
+  lv_obj_t* obj = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  mrb_assert(obj);
+  spr_bind_display(M, self, obj);
+  return mrb_nil_value();
 }
 
 mrb_value obj_set_x(mrb_state* M, mrb_value self) {
@@ -3623,6 +3690,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, spr, "update", spr_update, MRB_ARGS_NONE());
   mrb_define_method(M, spr, "blend_type=", spr_set_blend_type, MRB_ARGS_REQ(1));
   mrb_define_method(M, spr, "bush_depth=", spr_set_bush_depth, MRB_ARGS_REQ(1));
+  mrb_define_method(M, spr, "flash", spr_flash, MRB_ARGS_REQ(2));
 
   RClass* plane = mrb_define_class_under(M, m, "Plane", M->object_class);
   MRB_SET_INSTANCE_TT(plane, MRB_TT_DATA);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -166,7 +166,7 @@ assert "RGSS::Sprite API surface" do
   # display, so this only asserts the method surface — the compositing itself is
   # exercised by the game runs.
   %i[bitmap= x= y= z= visible visible= opacity= zoom_x= zoom_y= angle= mirror=
-     tone= color= src_rect= update blend_type= bush_depth= dispose
+     tone= color= src_rect= update blend_type= bush_depth= flash dispose
      disposed?].each do |m|
     assert_true RGSS::Sprite.method_defined?(m), "Sprite##{m} missing"
   end


### PR DESCRIPTION
## What

`RGSS::Sprite#flash(color, duration)` is now rendered — the last stored-but-ignored
Sprite property. So `Sprite_Battler` hit-flashes, dying-blinks and battle-animation
flashes now actually show, which makes **item #1 (Sprite) in the gap doc fully
rendered**.

## How

- **Colour flash** — `flash(color, duration)` overlays `color` into the sprite's
  pre-composite (`spr_bind_display`) at an alpha that fades from full (at the start)
  to nothing over `duration`, sharing the same per-pixel pass as tone/colour.
- **Empty flash** — `flash(nil, duration)` blinks the sprite out and back in by
  scaling the per-pixel alpha from 0 up to full over the duration.
- **Timing** — `Sprite#update` decays the flash one frame per tick and clears it
  (dropping the flash colour) when the duration runs out; a sprite with an active
  flash re-composites each frame.
- New native `spr_flash` (`"oi"` args, so `flash(nil, n)` is accepted); registered
  as `Sprite#flash`. Removed the Ruby `flash` stub.
- **Also fixes** a latent bug from #247: a stray `attr_writer :bush_depth` in the
  Ruby reopening was shadowing the native `Sprite#bush_depth=` (the mrblib runs
  after the C gem init), so bush-depth assignment did not re-composite. Removed it;
  the `bush_depth` reader stays.
- Test surface, gap doc (item #1 → ✅) and a changelog fragment updated.

## Testing

Compile-verified via the `mruby-rgss/test` surface check (the native classes need a
live display, so the rendering itself is exercised by game runs, not unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_