### PR TITLE
RPG2000 state system: field-skill status, battle HP/SP persistence, game over, vehicle save

### DIFF
--- a/changelog.d/rpg2k-battle-hp-persist.added.md
+++ b/changelog.d/rpg2k-battle-hp-persist.added.md
@@ -1,0 +1,16 @@
+- RPG Maker 2000: **a battle's damage now sticks to the party**. The auto-battle
+  runs on `Game::Battle::Combatant` snapshots (so the real actors are untouched
+  mid-fight); when the fight ends, `Battle#apply_to_party` writes each ally
+  combatant's final HP back to its source actor via the new `Game::Actor#set_hp`
+  (an absolute setter that clamps to `[0, max]` and keeps the death state in
+  sync). So a member who took damage stays wounded, and one reduced to 0 comes
+  out **knocked out** (戦闘不能) — tying the battle into the death-state model —
+  while a survivor keeps exactly the HP it ended on. `Scene::Map#finish_battle`
+  applies this before resuming the event, and because a level-up on victory only
+  clamps HP down (never heals), reward EXP can't secretly refill a wounded party.
+  Combatants built from an enemy (or bare test snapshots) carry no source actor
+  and are skipped. Covered by new `scripts/rpg2k_logic_check.rb` checks
+  (`set_hp` HP↔death sync, write-back persisting damage and a KO, reviving a
+  previously-downed actor that survived, and the no-op for actorless combatants).
+  Reviving / healing a downed member is still done through Full Recovery, item
+  cure, or the death-state cure — battle just no longer discards its own results.

--- a/changelog.d/rpg2k-game-over-on-defeat.added.md
+++ b/changelog.d/rpg2k-game-over-on-defeat.added.md
@@ -1,0 +1,12 @@
+- RPG Maker 2000: **losing a battle can now end the game**. When an Enemy
+  Encounter set to the default *game over* defeat mode (no custom `[Defeat]`
+  handler) wipes the whole party, `Scene::Map#finish_battle` returns to the title
+  screen instead of resuming the event. It is gated on the party actually being
+  wiped: `Game::Party#all_dead?` / `#any_alive?` report the game-over condition
+  (every member 戦闘不能), evaluated after the battle's HP write-back so a downed
+  party is seen as downed. A defeat routed to a custom `[Defeat]` handler still
+  runs that branch as before — only the game-over defeat mode returns to the
+  title. Covered by a new `scripts/rpg2k_scene_check.rb` check (a frail party is
+  overwhelmed and the scene hands back to the title) and
+  `scripts/rpg2k_logic_check.rb` checks for the party predicates. A dedicated
+  Game Over graphic before the title remains a follow-up.

--- a/changelog.d/rpg2k-skill-state-effects.added.md
+++ b/changelog.d/rpg2k-skill-state-effects.added.md
@@ -1,0 +1,16 @@
+- RPG Maker 2000: **field skills now change status conditions**. `cast_skill`
+  applies a skill's `state_effects` (a 0/1 byte per state, index `i` → state id
+  `i+1`) to its targets — **curing** them by default and **inflicting** them when
+  `reverse_state_effect` is set (the opposite polarity to items, where the reverse
+  flag marks the cure). The field path is **deterministic** (no accuracy roll),
+  matching EasyRPG's `Game_Battler::UseSkill`, and states are applied **before**
+  HP/SP recovery: a revive skill that cures the death state (戦闘不能) stands the
+  ally back up so its recovery then lands, while a plain heal still can't touch a
+  downed ally. `skill_effective?` now reports a cure/inflict skill as usable even
+  when HP/SP are full (so a status skill isn't greyed out), and such a skill only
+  spends SP when it actually changed something. Grounded against EasyRPG's field
+  `Game_Battler::UseSkill` (scope self/ally/party, `reverse_state_effect` polarity,
+  no to-hit). Covered by new `scripts/rpg2k_logic_check.rb` checks (cure only the
+  listed states, revive-then-heal, a plain heal not reviving, inflict via the
+  reverse flag, and the no-op on an unafflicted target). Inflicting states in
+  **battle** (rolling `state_chance`) remains a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -241,9 +241,10 @@ The work below is roughly ordered by the critical path to a walkable game
   default and inflicting them when `reverse_state_effect` is set (the opposite
   polarity to items); states apply before HP so a revive skill (curing 戦闘不能)
   stands the ally up and its recovery then lands, and a cure skill is usable even
-  at full HP. Still remaining: inflicting states from **battle** (rolling
-  `state_chance` / to-hit, the non-reverse item case, enemy attacks) and
-  party-wipe game over.
+  at full HP. A **party wipe now ends the game** (a game-over-mode battle defeat
+  returns to the title — see the Enemy Encounter entry). Still remaining:
+  inflicting states from **battle** (rolling `state_chance` / to-hit, the
+  non-reverse item case, enemy attacks).
   **Show / Move / Erase
   Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
   (centre position, zoom, opacity, tone and the scroll-with-map flag) held on
@@ -306,10 +307,13 @@ The work below is roughly ordered by the critical path to a walkable game
   is allowed. `Game::Battle` has the round-based API (`command_attack` /
   `command_defend` / `run_round`) alongside the headless `run`. Dismissing the
   result resumes the event and routes the `[Victory]` / `[Escape]` / `[Defeat]`
-  branch. Post-battle HP now persists to the party (see above). Still to come:
+  branch. Post-battle HP now persists to the party (see above), and a **defeat in
+  "game over" mode with the whole party knocked out returns to the title screen**
+  (`Scene::Map#finish_battle`, gated by `Game::Party#all_dead?`); a defeat routed
+  to a custom `[Defeat]` handler still runs the branch instead. Still to come:
   Skill / Item commands, criticals / attributes / variance in the sim, in-battle
   state infliction (rolling `state_chance`), per-turn animation from the log,
-  enemy / battler sprites, and game over on defeat.
+  enemy / battler sprites, and a dedicated Game Over graphic before the title.
   The remaining commands (EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -291,8 +291,12 @@ The work below is roughly ordered by the critical path to a walkable game
   EXP / gold on a win. `#step` performs one action at a time and appends a `#log`
   entry (attacker / target / damage / defeated), so an on-screen battle can
   animate it action-by-action; `#run` steps to completion for the headless
-  resolution. It runs on Combatant snapshots, so the party's real HP is untouched
-  for now, and `Scene::Map` traces the fight to the console from the log.
+  resolution. It runs on Combatant snapshots, and `Battle#apply_to_party` then
+  **writes each survivor's final HP back to its actor** when the fight ends
+  (`Scene::Map#finish_battle`), so damage taken **persists** and a combatant
+  reduced to 0 comes out **knocked out** (戦闘不能, via `Actor#set_hp`) — a level-up
+  on victory does not heal. `Scene::Map` traces the fight to the console from the
+  log.
   Encounters now open a **battle screen** (driven by `Scene::Map` during the
   `:battle` wait, like the shop / inn): a status panel of the troop and each
   party member's HP, and **per-actor commands each round** — for every living
@@ -302,9 +306,10 @@ The work below is roughly ordered by the critical path to a walkable game
   is allowed. `Game::Battle` has the round-based API (`command_attack` /
   `command_defend` / `run_round`) alongside the headless `run`. Dismissing the
   result resumes the event and routes the `[Victory]` / `[Escape]` / `[Defeat]`
-  branch. Still to come: Skill / Item commands, criticals / attributes / variance
-  in the sim, per-turn animation from the log, enemy / battler sprites, and game
-  over on defeat.
+  branch. Post-battle HP now persists to the party (see above). Still to come:
+  Skill / Item commands, criticals / attributes / variance in the sim, in-battle
+  state infliction (rolling `state_chance`), per-turn animation from the log,
+  enemy / battler sprites, and game over on defeat.
   The remaining commands (EXP gain / level-up
   messages, ...) are TODO
 - 🚧 Message window — renders text lines and a choice cursor and expands the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -235,9 +235,15 @@ The work below is roughly ordered by the critical path to a walkable game
   death state (or Full Recovery) revives at 1 HP — `Game::Actor#dead?`/`alive?`
   report it, and the KO'd HP-0 + state-1 pair round-trips through the `.lsd`. The
   **Change Condition** event command (10480) inflicts / cures a state on the
-  target actors, so events can poison, cure, KO, or revive. Still remaining:
-  *inflicting* states from combat (the non-reverse item case rolled against
-  `state_chance`, and skill / battle infliction), and party-wipe game over.
+  target actors, so events can poison, cure, KO, or revive. **Field skills change
+  status too**: `cast_skill` applies a skill's `state_effects` deterministically
+  (EasyRPG's field `Game_Battler::UseSkill` — no accuracy roll), curing them by
+  default and inflicting them when `reverse_state_effect` is set (the opposite
+  polarity to items); states apply before HP so a revive skill (curing 戦闘不能)
+  stands the ally up and its recovery then lands, and a cure skill is usable even
+  at full HP. Still remaining: inflicting states from **battle** (rolling
+  `state_chance` / to-hit, the non-reverse item case, enemy attacks) and
+  party-wipe game over.
   **Show / Move / Erase
   Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
   (centre position, zoom, opacity, tone and the scroll-with-map flag) held on

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1170,6 +1170,21 @@ module Game
       @hp
     end
 
+    # Set HP to an absolute value, clamped to [0, max_hp], keeping the death
+    # state (戦闘不能) in sync: 0 knocks the actor out, a positive value revives a
+    # downed one. Unlike change_hp this is not blocked while dead -- it is the
+    # write-back used to persist a battle's outcome (a wounded or KO'd survivor)
+    # onto the party. Returns the new HP.
+    def set_hp(value)
+      @hp = Game.clamp(value, 0, @max_hp)
+      if @hp <= 0
+        add_state(DEATH_STATE)
+      else
+        remove_state(DEATH_STATE)
+      end
+      @hp
+    end
+
     # Apply a MP (SP) change, clamped to [0, max_mp]. Returns the new MP.
     def change_mp(delta)
       @mp = Game.clamp(@mp + delta, 0, @max_mp)
@@ -2638,11 +2653,13 @@ module Game
     # auto), `defending` halves damage taken that round; both are cleared each
     # round. Enemies leave them nil and attack a random party member.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
-                           :action, :defending) do
+                           :action, :defending, :actor) do
       def dead?; hp <= 0; end
     end
 
-    def self.from_actor(a); Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp); end
+    def self.from_actor(a)
+      Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp, nil, nil, a)
+    end
     def self.from_enemy(e); Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp); end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -2668,6 +2685,15 @@ module Game
 
     # True once one side has been wiped out (the battle is decided).
     def finished?; !alive?(@allies) || !alive?(@enemies); end
+
+    # Persist the fight's outcome onto the real party: write each ally combatant's
+    # final HP back to its source actor, so damage taken in battle sticks and a
+    # combatant reduced to 0 comes out knocked out (戦闘不能). Combatants without a
+    # source actor -- enemies, or bare test snapshots -- are skipped. RPG2000
+    # keeps the party's post-battle HP; a downed member stays down until revived.
+    def apply_to_party
+      @allies.each { |c| c.actor.set_hp(c.hp) if c.actor }
+    end
 
     # Perform the next single action and return its log entry, or nil when the
     # battle is already decided (or has hit the round cap). Living battlers act

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2823,6 +2823,58 @@ module Game
     end
   end
 
+  # A boat / ship / airship's saved location. RPG2000 stores one per vehicle in
+  # its own `.lsd` chunk (105 boat, 106 ship, 107 airship, each a SAVE_MOVABLE):
+  # the map it sits on, its tile position and facing, and its on-map graphic.
+  # Only that saved location is modelled here -- enough to round-trip a save so a
+  # parked vehicle stays where the player left it. Boarding / piloting a vehicle
+  # is not built yet (`map_id` 0 means it has never been placed).
+  class Vehicle
+    TYPES = [:boat, :ship, :airship].freeze
+
+    attr_accessor :map_id, :x, :y, :direction, :charset_name, :charset_index
+    attr_reader :type
+
+    def initialize(type, map_id = 0, x = 0, y = 0, direction = 2)
+      @type = type
+      @map_id = map_id || 0
+      @x = x || 0
+      @y = y || 0
+      @direction = direction || 2
+      @charset_name = ''
+      @charset_index = 0
+    end
+
+    # Whether the vehicle has been placed on a map (0 = never positioned).
+    def placed?; @map_id > 0; end
+
+    def to_h
+      { map_id: @map_id, x: @x, y: @y, direction: @direction,
+        charset_name: @charset_name, charset_index: @charset_index }
+    end
+
+    def load_h(h)
+      return unless h
+      @map_id = h[:map_id] || 0
+      @x = h[:x] || 0
+      @y = h[:y] || 0
+      @direction = h[:direction] || 2
+      @charset_name = h[:charset_name] || ''
+      @charset_index = h[:charset_index] || 0
+    end
+
+    # Populate from a parsed SAVE_MOVABLE chunk (a vehicle location in a `.lsd`).
+    def load_movable(m)
+      return unless m
+      @map_id = m.map_id || 0
+      @x = m.x || 0
+      @y = m.y || 0
+      @direction = m.direction || 2
+      @charset_name = m.charset_name || ''
+      @charset_index = m.charset_index || 0
+    end
+  end
+
   class State
     attr_reader :party, :switches, :variables, :message_config, :screen, :weather
     attr_accessor :map, :map_id, :x, :y, :direction, :timer_frames, :timer_running
@@ -2885,6 +2937,10 @@ module Game
       @system_bgm = {}
       @system_sfx = {}
       @weather = Weather.new
+      # The three vehicles' saved locations (boat / ship / airship), persisted in
+      # `.lsd` chunks 105-107. Unplaced until a save restores them.
+      @vehicles = { boat: Vehicle.new(:boat), ship: Vehicle.new(:ship),
+                    airship: Vehicle.new(:airship) }
       # Transient screen-effect state (tint transition); not serialised, so a
       # reloaded game starts with a neutral screen.
       @screen = Screen.new
@@ -2893,7 +2949,10 @@ module Game
       @pictures = {}
     end
 
-    attr_reader :pictures
+    attr_reader :pictures, :vehicles
+
+    # The saved location of vehicle `type` (:boat / :ship / :airship), or nil.
+    def vehicle(type); @vehicles[type]; end
 
     # Show (or replace) picture `id` with the given Picture options hash.
     def show_picture(id, opts)
@@ -2945,7 +3004,9 @@ module Game
         teleport_access: @teleport_access, escape_access: @escape_access,
         encounter_rate: @encounter_rate, teleport_targets: @teleport_targets,
         escape_target: @escape_target, system_bgm: @system_bgm,
-        system_sfx: @system_sfx }
+        system_sfx: @system_sfx,
+        vehicles: { boat: @vehicles[:boat].to_h, ship: @vehicles[:ship].to_h,
+                    airship: @vehicles[:airship].to_h } }
     end
 
     # Serialise to a genuine RPG2000/2003 Save<N>.lsd (an LCF::SaveData) -- the
@@ -3014,6 +3075,22 @@ module Game
         hero[75] = leader.charset_index || 0
       end
       save[104] = hero
+
+      # Vehicle locations (105 boat / 106 ship / 107 airship). Only a placed
+      # vehicle is written, so a game that never positioned one leaves the chunk
+      # absent, exactly as RPG_RT does.
+      { 105 => :boat, 106 => :ship, 107 => :airship }.each do |chunk, type|
+        v = @vehicles[type]
+        next unless v.placed?
+        mv = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+        mv[11] = v.map_id
+        mv[12] = v.x
+        mv[13] = v.y
+        mv[22] = v.direction
+        mv[73] = v.charset_name || ''
+        mv[75] = v.charset_index || 0
+        save[chunk] = mv
+      end
 
       sys = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_SYSTEM })
       sw = @switches.to_h
@@ -3136,6 +3213,11 @@ module Game
       party.load_state(items: items, gold: inv.gold, hp: hp, mp: mp)
       state = new(party, hero.map_id, hero.x, hero.y)
       state.direction = hero.direction || 2
+      # Vehicle locations (chunks 105 boat / 106 ship / 107 airship), each a
+      # SAVE_MOVABLE; an absent chunk leaves that vehicle unplaced.
+      state.vehicle(:boat).load_movable(save.boat)
+      state.vehicle(:ship).load_movable(save.ship)
+      state.vehicle(:airship).load_movable(save.airship)
       # The leader's on-map sprite override (a Change Sprite Association), stored
       # in the hero chunk's CharSet fields.
       if party.leader && hero.charset_name && !hero.charset_name.empty?
@@ -3265,6 +3347,11 @@ module Game
       state.escape_target = h[:escape_target]
       state.system_bgm = h[:system_bgm] || {}
       state.system_sfx = h[:system_sfx] || {}
+      if (v = h[:vehicles])
+        state.vehicle(:boat).load_h(v[:boat])
+        state.vehicle(:ship).load_h(v[:ship])
+        state.vehicle(:airship).load_h(v[:airship])
+      end
       state
     end
   end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1592,34 +1592,84 @@ module Game
       end
     end
 
+    # The states a field skill changes, from its `state_effects` (a 0/1 byte per
+    # state, index i -> state id i+1). Per EasyRPG's Game_Battler::UseSkill, the
+    # field path is deterministic (no accuracy roll): with `reverse_state_effect`
+    # cleared (the default) the skill *cures* those states, with it set it
+    # *inflicts* them -- the opposite polarity to items, where the reverse flag
+    # marks the cure.
+    def skill_state_ids(sk)
+      set = sk.respond_to?(:state_effects) ? sk.state_effects : nil
+      return [] unless set
+      out = []
+      set.each_index { |i| out.push(i + 1) if set[i] && set[i] != 0 }
+      out
+    end
+
+    # The states a field skill cures (the default, non-reverse case).
+    def skill_cured_states(sk)
+      return [] if sk.respond_to?(:reverse_state_effect) && sk.reverse_state_effect
+      skill_state_ids(sk)
+    end
+
+    # The states a field skill inflicts (the reverse case).
+    def skill_inflicted_states(sk)
+      return [] unless sk.respond_to?(:reverse_state_effect) && sk.reverse_state_effect
+      skill_state_ids(sk)
+    end
+
     # Whether casting skill `sid` on `target` would change anything -- used to grey
     # out a no-op (e.g. a heal on an already-full ally). Requires the caster to be
-    # able to cast it at all.
+    # able to cast it at all. A skill that cures a condition the target actually
+    # has (or inflicts one it lacks) is usable even when HP/SP are full.
     def skill_effective?(caster, sid, target)
       sk = db_skill(sid)
       return false unless sk && can_cast?(caster, sid)
       amount = skill_effect(sk, caster)
-      return false unless amount > 0
+      cured = skill_cured_states(sk)
+      inflicted = skill_inflicted_states(sk)
       skill_targets(sk, caster, target).any? do |t|
-        (sk.affect_hp && t.hp < t.max_hp) || (sk.affect_sp && t.mp < t.max_mp)
+        (amount > 0 && sk.affect_hp && t.hp < t.max_hp) ||
+          (amount > 0 && sk.affect_sp && t.mp < t.max_mp) ||
+          cured.any? { |s| t.state?(s) } ||
+          inflicted.any? { |s| !t.state?(s) }
       end
     end
 
-    # Cast field skill `sid` from `caster` on `target` (scope-dependent). Restores
-    # HP and/or SP by the skill effect to each target (clamped), then spends the
-    # caster's SP -- but only when it actually helped someone, so a wasted cast
-    # (everyone full) costs nothing. Returns the affected actors.
+    # Cast field skill `sid` from `caster` on `target` (scope-dependent). Applies
+    # the skill's status changes then restores HP and/or SP by the skill effect to
+    # each target (clamped), then spends the caster's SP -- but only when it
+    # actually helped someone, so a wasted cast (everyone full and unafflicted)
+    # costs nothing. States are applied before HP so a cure that clears the death
+    # state revives the target and the recovery then lands. Returns the affected
+    # actors.
     def cast_skill(caster, sid, target = nil)
       sk = db_skill(sid)
       return [] unless sk && can_cast?(caster, sid)
       amount = skill_effect(sk, caster)
+      cured = skill_cured_states(sk)
+      inflicted = skill_inflicted_states(sk)
       affected = []
       skill_targets(sk, caster, target).each do |t|
+        changed = false
+        cured.each do |s|
+          if t.state?(s)
+            t.remove_state(s)
+            changed = true
+          end
+        end
+        inflicted.each do |s|
+          unless t.state?(s)
+            t.add_state(s)
+            changed = true
+          end
+        end
         before_hp = t.hp
         before_mp = t.mp
         t.change_hp(amount) if sk.affect_hp && amount > 0
         t.change_mp(amount) if sk.affect_sp && amount > 0
-        affected.push(t) if t.hp != before_hp || t.mp != before_mp
+        changed ||= t.hp != before_hp || t.mp != before_mp
+        affected.push(t) if changed
       end
       caster.change_mp(-skill_cost(sk, caster)) unless affected.empty?
       affected

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1318,6 +1318,12 @@ module Game
     def include_actor?(id); @actors.any? { |a| a.id == id }; end
     def actor_by_id(id); @actors.find { |a| a.id == id }; end
 
+    # Whether any party member is still standing. An empty party counts as wiped.
+    def any_alive?; @actors.any? { |a| !a.dead? }; end
+
+    # Whether the whole party is knocked out (戦闘不能) -- the game-over condition.
+    def all_dead?; !any_alive?; end
+
     def add_actor(id)
       return if include_actor?(id)
       @actors.push Actor.new(@db, id)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1910,6 +1910,9 @@ class RPG2k
       end
 
       def finish_battle(result)
+        # Persist the party's post-battle HP (and any knock-outs) before leaving
+        # the fight, so damage taken sticks and a downed member stays down.
+        @battle_ui[:battle].apply_to_party
         close_battle
         @interpreter.resume_battle(result)
       end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1913,8 +1913,17 @@ class RPG2k
         # Persist the party's post-battle HP (and any knock-outs) before leaving
         # the fight, so damage taken sticks and a downed member stays down.
         @battle_ui[:battle].apply_to_party
+        # A defeat in "game over" mode (no custom [Defeat] handler) with the whole
+        # party knocked out ends the game -- back to the title screen. Otherwise
+        # the event resumes down its Victory / Escape / Defeat branch.
+        game_over = result == :defeat && @battle_ui[:req][:defeat_game_over] &&
+                    @state.party.all_dead?
         close_battle
-        @interpreter.resume_battle(result)
+        if game_over
+          @parent.return_to_title
+        else
+          @interpreter.resume_battle(result)
+        end
       end
 
       def log_round(entries)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2210,6 +2210,19 @@ check 'Actor death state: non-lethal damage floors HP at 1, no KO' do
   eq false, a.state?(Game::Actor::DEATH_STATE)
 end
 
+check 'Actor#set_hp sets an absolute HP and syncs the death state' do
+  a = party_state.party.actor_by_id(1)                # max 100
+  a.set_hp(9999); eq 100, a.hp                        # clamped to max
+  a.set_hp(0)
+  eq 0, a.hp
+  eq true, a.dead?                                    # 0 -> knocked out
+  eq true, a.state?(Game::Actor::DEATH_STATE)
+  a.set_hp(25)
+  eq 25, a.hp
+  eq false, a.dead?                                   # positive -> revived
+  eq false, a.state?(Game::Actor::DEATH_STATE)        # death state cleared
+end
+
 check 'State save round-trips per-actor status states' do
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
@@ -3317,6 +3330,45 @@ check 'Battle: a defending ally takes half damage and does not attack' do
   bat.run_round
   eq 100, foe.hp, 'the defending hero did not strike back'
   eq 90, hero.hp, 'took half of 20 = 10'
+end
+
+check 'Battle#apply_to_party writes post-battle HP back, KOing at 0' do
+  st = party_state
+  hero = st.party.actor_by_id(1)   # hp 100
+  ally = st.party.actor_by_id(2)   # hp 50
+  hc = Game::Battle.from_actor(hero)
+  ac = Game::Battle.from_actor(ally)
+  hc.hp = 30                       # hero ended the fight wounded
+  ac.hp = -5                       # ally was knocked out
+  bat = Game::Battle.new([hc, ac], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.apply_to_party
+  eq 30, hero.hp                   # damage persisted to the real actor
+  eq false, hero.dead?
+  eq 0, ally.hp                    # clamped to 0
+  eq true, ally.dead?
+  eq true, ally.state?(Game::Actor::DEATH_STATE)  # a KO inflicts 戦闘不能
+end
+
+check 'Battle#apply_to_party revives a previously-downed actor that survives' do
+  st = party_state
+  ally = st.party.actor_by_id(2)
+  ally.change_hp(-9999)            # currently KO'd from a prior fight
+  eq true, ally.dead?
+  c = Game::Battle.from_actor(ally)
+  c.hp = 20                        # ...took part in a fight and came out at 20 HP
+  bat = Game::Battle.new([c], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.apply_to_party
+  eq 20, ally.hp
+  eq false, ally.dead?
+  eq false, ally.state?(Game::Actor::DEATH_STATE)  # revived, death state cleared
+end
+
+check 'Battle#apply_to_party ignores combatants with no source actor' do
+  # A bare snapshot (from_enemy / test combatant) must not raise on write-back.
+  bat = Game::Battle.new([combatant('Ghost', 10, 0, 5, 0)],
+                         [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.apply_to_party                # no source actor -> silently skipped
+  ok true, 'write-back skipped bare combatants without error'
 end
 
 # -- summary ------------------------------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2223,6 +2223,21 @@ check 'Actor#set_hp sets an absolute HP and syncs the death state' do
   eq false, a.state?(Game::Actor::DEATH_STATE)        # death state cleared
 end
 
+check 'Party#all_dead? / any_alive? track the game-over condition' do
+  st = party_state
+  eq true, st.party.any_alive?
+  eq false, st.party.all_dead?
+  st.party.actor_by_id(1).change_hp(-9999)            # leader down
+  eq true, st.party.any_alive?                        # the ally still stands
+  eq false, st.party.all_dead?
+  st.party.actor_by_id(2).change_hp(-9999)            # ally down too
+  eq false, st.party.any_alive?
+  eq true, st.party.all_dead?                         # whole party wiped
+  st.party.actor_by_id(1).full_heal                   # revive one
+  eq true, st.party.any_alive?
+  eq false, st.party.all_dead?
+end
+
 check 'State save round-trips per-actor status states' do
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1264,11 +1264,12 @@ end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
-                       :affect_hp, :affect_sp)
+                       :affect_hp, :affect_sp, :state_effects, :reverse_state_effect)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
-               sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false)
+               sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
+               state_effects: nil, reverse_state: false)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
-                prate, mrate, hp, sp)
+                prate, mrate, hp, sp, state_effects, reverse_state)
 end
 class FakeActorDB
   attr_reader :player, :system, :item, :skill
@@ -1839,6 +1840,79 @@ check 'casting a heal with the target already full spends no SP' do
   eq false, st.party.skill_effective?(hero, 5, ally)
   eq [], st.party.cast_skill(hero, 5, ally)
   eq 30, hero.mp                               # unchanged
+end
+
+# -- Field skill status effects (cure / inflict, deterministic) --------------
+
+check 'a cure skill removes only its state_effects states (usable at full HP)' do
+  # state_effects index i -> state id i+1; [0,0,1,0,0,0,1] flags states 3 and 7.
+  skills = { 5 => fake_skill(name: 'Refresh', scope: 3, sp_cost: 4,
+                             state_effects: [0, 0, 1, 0, 0, 0, 1]) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)               # full HP
+  hero.learn_skill(5)
+  ally.add_state(3); ally.add_state(7); ally.add_state(9)
+  eq true, st.party.skill_effective?(hero, 5, ally)   # afflicted -> usable at full HP
+  eq [ally], st.party.cast_skill(hero, 5, ally)
+  eq false, ally.state?(3)                     # cured
+  eq false, ally.state?(7)                     # cured
+  eq true, ally.state?(9)                      # not listed -> stays
+  eq 26, hero.mp                               # 30 - 4, consumed
+end
+
+check 'a revive skill cures the death state, then its HP recovery lands' do
+  # Cures state 1 (戦闘不能) and heals. States apply first: the cure revives the
+  # ally to 1 HP, then the recovery lands. effect = power 20 + mrate 40*int12/40 = 32.
+  skills = { 6 => fake_skill(name: 'Life', scope: 3, sp_cost: 6,
+                             power: 20, mrate: 40, hp: true, state_effects: [1]) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.learn_skill(6)
+  ally.change_hp(-9999)                        # KO: HP 0 + state 1
+  eq true, ally.dead?
+  eq [ally], st.party.cast_skill(hero, 6, ally)
+  eq false, ally.dead?
+  eq 33, ally.hp                               # revived to 1, then +32
+end
+
+check 'a plain heal skill cannot revive a downed ally' do
+  skills = { 7 => fake_skill(name: 'Heal', scope: 3, sp_cost: 5,
+                             power: 20, mrate: 40, hp: true) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.learn_skill(7)
+  ally.change_hp(-9999)                        # KO
+  eq [], st.party.cast_skill(hero, 7, ally)    # a plain heal can't touch a KO'd actor
+  eq true, ally.dead?
+  eq 30, hero.mp                               # nothing spent
+end
+
+check 'a reverse skill inflicts its state_effects states' do
+  skills = { 8 => fake_skill(name: 'Curse', scope: 3, sp_cost: 3,
+                             state_effects: [0, 0, 1], reverse_state: true) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.learn_skill(8)
+  eq true, st.party.skill_effective?(hero, 8, ally)   # can inflict -> usable
+  eq [ally], st.party.cast_skill(hero, 8, ally)
+  eq true, ally.state?(3)                      # inflicted
+  eq 27, hero.mp                               # 30 - 3
+end
+
+check 'a pure cure skill on an unafflicted ally does nothing and spends no SP' do
+  skills = { 5 => fake_skill(name: 'Refresh', scope: 3, sp_cost: 4,
+                             state_effects: [0, 0, 1]) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.learn_skill(5)
+  eq false, st.party.skill_effective?(hero, 5, ally)
+  eq [], st.party.cast_skill(hero, 5, ally)
+  eq 30, hero.mp
 end
 
 # -- Field equip menu (Game::Party bag-aware equip) --------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1324,6 +1324,37 @@ check 'State save round-trips the message configuration' do
   eq true, legacy_loaded.save_access, 'absent save access defaults on'
 end
 
+check 'Vehicle: unplaced by default, placed once positioned' do
+  v = Game::Vehicle.new(:boat)
+  eq :boat, v.type
+  eq false, v.placed?                          # map_id 0 -> never positioned
+  v.map_id = 4; v.x = 8; v.y = 6; v.direction = 1
+  eq true, v.placed?
+  h = v.to_h
+  w = Game::Vehicle.new(:boat)
+  w.load_h(h)
+  eq [4, 8, 6, 1], [w.map_id, w.x, w.y, w.direction]
+end
+
+check 'State save round-trips vehicle locations (boat / ship / airship)' do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.vehicle(:boat).map_id = 4; st.vehicle(:boat).x = 8; st.vehicle(:boat).y = 6
+  st.vehicle(:airship).map_id = 2; st.vehicle(:airship).x = 3
+  st.vehicle(:airship).y = 5; st.vehicle(:airship).direction = 3
+  loaded = Game::State.load(db, st.to_h)
+  eq [4, 8, 6], [loaded.vehicle(:boat).map_id, loaded.vehicle(:boat).x,
+                 loaded.vehicle(:boat).y]
+  eq true, loaded.vehicle(:airship).placed?
+  eq 3, loaded.vehicle(:airship).direction
+  eq false, loaded.vehicle(:ship).placed?      # never positioned -> stays unplaced
+  # A save written before vehicles existed simply restores them unplaced.
+  legacy = st.to_h
+  legacy.delete(:vehicles)
+  eq false, Game::State.load(db, legacy).vehicle(:boat).placed?
+end
+
 check 'Party save round-trips actor name / title / sprite overrides' do
   players = {
     1 => FakePlayerRow.new('Hero', 'Base', 0, 5,

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -208,6 +208,14 @@ def check_game(dir)
     state.party.leader.add_state(7)
     state.party.leader.change_hp(-99_999)  # ...and knock them out (HP 0 + 戦闘不能)
   end
+  # Park the boat and airship so the vehicle chunks (105/107) are exercised.
+  state.vehicle(:boat).map_id = 12
+  state.vehicle(:boat).x = 9
+  state.vehicle(:boat).y = 4
+  state.vehicle(:boat).direction = 1
+  state.vehicle(:airship).map_id = 3
+  state.vehicle(:airship).x = 15
+  state.vehicle(:airship).y = 7
 
   round = Game::State.from_lsd(db, LCF::SaveData.new(StringIO.new(state.to_lsd.to_lcf)))
   eq state.map_id, round.map_id, 'to_lsd: map id'
@@ -238,6 +246,14 @@ def check_game(dir)
     eq true, rl.dead?, 'to_lsd: downed leader stays knocked out'
     eq true, rl.state?(Game::Actor::DEATH_STATE), 'to_lsd: leader death state survives'
   end
+  # Parked vehicles (chunks 105 boat / 107 airship) survive; the untouched ship
+  # (chunk 106) is absent and stays unplaced.
+  eq [12, 9, 4, 1], [round.vehicle(:boat).map_id, round.vehicle(:boat).x,
+                     round.vehicle(:boat).y, round.vehicle(:boat).direction],
+     'to_lsd: boat location'
+  eq [3, 15, 7], [round.vehicle(:airship).map_id, round.vehicle(:airship).x,
+                  round.vehicle(:airship).y], 'to_lsd: airship location'
+  eq false, round.vehicle(:ship).placed?, 'to_lsd: untouched ship stays unplaced'
   eq state.switches.to_h.select { |_k, v| v }.keys.sort,
      round.switches.to_h.select { |_k, v| v }.keys.sort, 'to_lsd: switches on'
   eq state.variables.to_h.reject { |_k, v| v == 0 },

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -424,6 +424,7 @@ class BattleStubActor
   # Battle write-back (Game::Battle#apply_to_party) sets the actor's post-battle
   # HP absolutely; the stub has no state model, so just clamp to [0, max].
   def set_hp(value); @hp = value < 0 ? 0 : (value > @max_hp ? @max_hp : value); end
+  def dead?; @hp <= 0; end
 end
 
 class BattleStubParty
@@ -431,6 +432,8 @@ class BattleStubParty
   attr_accessor :leader
   def initialize(actor = BattleStubActor.new); @actors = [actor]; @gold = 0; @leader = nil; end
   def gain_gold(n); @gold += n; end
+  def any_alive?; @actors.any? { |a| !a.dead? }; end
+  def all_dead?; !any_alive?; end
 end
 
 # A party the shop can charge and stock: gold plus an item-count bag, with the
@@ -1369,6 +1372,27 @@ check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   eq 0, st.party.actors.first.exp, 'no EXP on a loss'
   ok !st.switches[1], 'the Victory handler was skipped'
   ok st.switches[3], 'the Defeat handler ran'
+end
+
+check 'Enemy Encounter scene: a game-over defeat returns to the title' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # A bare encounter with defeat mode 0 (game over) and no handler block.
+  auto.event_commands = [ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 0, 0], indent: 0)]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  # A frail hero the two Slimes overwhelm.
+  st.instance_variable_set(:@party,
+                           BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
+  scene.update
+  battle_attack_to_end(scene)
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the defeat result window
+  scene.update
+  RGSS::Input.triggered = []
+  # finish_battle wrote the wipe back to the party, then went to the title.
+  ok st.party.all_dead?, 'the party was wiped out'
+  parent = scene.instance_variable_get(:@parent)
+  ok parent.returned_to_title, 'a game-over defeat returns to the title screen'
 end
 
 check 'Enemy Encounter scene: Flee (B on the first actor) runs Escape' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -421,6 +421,9 @@ class BattleStubActor
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
   end
   def gain_exp(n); @exp += n; end
+  # Battle write-back (Game::Battle#apply_to_party) sets the actor's post-battle
+  # HP absolutely; the stub has no state model, so just clamp to [0, max].
+  def set_hp(value); @hp = value < 0 ? 0 : (value > @max_hp ? @max_hp : value); end
 end
 
 class BattleStubParty


### PR DESCRIPTION
Four related RPG2000 increments on the save-data / state / battle path (after item cure #245, the death-state coupling #250, and Change Condition). All pure-Ruby, deterministic, covered by the CRuby harnesses. Merged with `master` to resolve a conflict with the parallel battle-Skill/Item + Change Screen Transitions / Game Over work (`perform_game_over` is now the shared game-over path; `Combatant` keeps both the new SP/command fields and the actor back-reference).

## 1. Field-skill status effects (cure / inflict)

`cast_skill` applies a skill's `state_effects` (index `i` → state id `i+1`): **cure** by default, **inflict** when `reverse_state_effect` is set (opposite polarity to items). Deterministic in the field (EasyRPG's `Game_Battler::UseSkill`), states before HP so a revive skill stands the ally up and its recovery lands; usable at full HP; SP spent only when it changed something.

## 2. Battle HP / SP persistence

The auto-battle ran on `Combatant` snapshots and discarded the result. Now **`Battle#apply_to_party`** writes each ally's final HP **and SP** back through **`Game::Actor#set_hp`** (absolute setter, keeps the death state in sync; 0 → KO 戦闘不能, positive → revive). Damage sticks, a member reduced to 0 comes out knocked out, SP spent on battle skills persists, and a level-up on victory only clamps HP down. Enemies / bare snapshots have no source actor and are skipped.

## 3. Game over on a party wipe

**`Game::Party#all_dead?` / `#any_alive?`** report the game-over condition (evaluated after write-back). **`Scene::Map#finish_battle`** routes a `:defeat` in the default *game over* mode (no `[Defeat]` handler) with the party wiped to `perform_game_over` (→ title). A custom `[Defeat]` handler still runs its branch.

## 4. Vehicle location save persistence

The `.lsd` already parsed the per-vehicle chunks (105 boat / 106 ship / 107 airship, each `SAVE_MOVABLE`) but the runtime dropped them. **`Game::Vehicle`** models a vehicle's saved location (map / x / y / facing / graphic); `Game::State` holds the three, exposed via `#vehicles` / `#vehicle(type)`. `to_lsd` writes 105–107 for each placed vehicle (unplaced ones omitted, as RPG_RT does); `from_lsd` and the Marshal `to_h`/`load` round-trip them. Boarding / piloting is still to come — this is the save-fidelity half, so a parked vehicle stays where the player left it.

## Tests

New `scripts/rpg2k_logic_check.rb` checks across all four parts, a new `scripts/rpg2k_scene_check.rb` game-over-defeat check, and the `.lsd` round-trip in `scripts/rpg2k_save_load_check.rb` now parks the boat + airship (and KOs the leader) and asserts they return. **247 logic + 78 scene + 35 render checks pass; save-load OK** (against the real Nepheshel / mtf-meido saves).

## Follow-up

In-battle state **infliction** (rolling `state_chance`), vehicle **boarding / piloting**, and a dedicated Game Over graphic before the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj