### PR TITLE
mruby-rgss: animate RGSS::Tilemap autotiles

### DIFF
--- a/changelog.d/rpgxp-rgss-tilemap-autotile-anim.added.md
+++ b/changelog.d/rpgxp-rgss-tilemap-autotile-anim.added.md
@@ -1,0 +1,8 @@
+- **`RGSS::Tilemap` autotiles now animate.** An autotile bitmap wider than one
+  96px frame holds several animation frames; `Tilemap#update` (now native) advances
+  a counter whose frame index is `counter / 16` mod 4 — matching RMXP/mkxp's
+  16-ticks-per-frame `atAnimation` timing — and the renderer shifts the autotile
+  source into the current frame's column, so water and waterfalls animate instead
+  of freezing on frame 0. The per-frame work is skipped except on a frame boundary,
+  and entirely when the map has no animated autotile. See
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -96,7 +96,7 @@ clip contents taller than the window; `stretch` (tiled vs stretched background) 
 ignored; and the RMXP windowskin source-rect constants are best-effort until a
 game exercises them.
 
-### 3. `Tilemap` ⚠️ (tiles + autotiles rendered; priority layering pending)
+### 3. `Tilemap` ⚠️ (tiles + animated autotiles rendered; priority layering pending)
 
 `Tilemap` is now **native** (`mruby-rgss/src/lib.cxx`): `Tilemap.new` creates an
 `lv_canvas` the size of the viewport (or screen) and `tilemap_refresh` draws the
@@ -104,12 +104,20 @@ visible part of the map — for each of the three `map_data` layers it blits the
 tiles overlapping the viewport (given `ox`/`oy`). **Regular tiles** (id ≥ 384)
 come straight from the `tileset`; **autotiles** (id 48–383) are assembled from
 their four 16×16 quads using the RMXP 48-shape quad table (`AUTOTILE_QUADS`,
-derived from mkxp), so water/terrain ground now fills in. `tileset=`,
-`map_data=`, `ox=`/`oy=`, `z=`, `visible`/`visible=`, `dispose`/`disposed?` are
-native and re-render on change. **Remaining:** the per-tile **priority layering**
-(`priorities`) — tiles that should draw above characters — is stored-only, so
-everything renders on one flat layer; **autotile animation** uses only the first
-frame; and `flash_data` is ignored.
+derived from mkxp), so water/terrain ground now fills in. **Animated autotiles**
+(a wider autotile bitmap holds several 96px frames side by side) now cycle:
+`Tilemap#update` advances a counter whose frame index is `counter / 16` (mod 4,
+matching RMXP/mkxp's 16-tick-per-frame `atAnimation` table), and the renderer
+shifts the autotile source into that frame's column — so water and waterfalls
+animate. `update` only re-tiles on a frame boundary, and only when the map
+actually has an animated autotile (recorded during the last refresh), so static
+maps do no per-frame work. `tileset=`, `map_data=`, `ox=`/`oy=`, `z=`, `update`,
+`visible`/`visible=`, `dispose`/`disposed?` are native and re-render on change.
+**Remaining:** the per-tile **priority layering** (`priorities`) — tiles that
+should draw above characters — is stored-only, so everything still renders on one
+flat layer (a correct fix needs the above-priority tiles to become their own
+z-ordered objects that interleave with character sprites per row); and
+`flash_data` is ignored.
 
 ### 4. `Plane` ⚠️ (tiling + scroll rendered; zoom/blend/tone/colour stored)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -210,16 +210,16 @@ module RGSS
   # tilemap_refresh draws the visible tiles of the three map_data layers scrolled
   # by ox/oy — regular tiles from the tileset and autotiles assembled from their
   # four quads (the seven `autotiles` bitmaps are read by the native renderer).
-  # `initialize`, `tileset=`, `map_data=`, `ox=`/`oy=`, `z=`, `visible`/`visible=`,
-  # `dispose`/`disposed?` are native. This reopening keeps the plain readers, the
-  # `autotiles` slot array (which the native renderer reads), and the properties
-  # not yet honoured — `priorities` (priority layering) and `flash_data` — stored
-  # so scripts run (tracked in docs/rpgxp-rgss-api-gap.md).
+  # `initialize`, `tileset=`, `map_data=`, `ox=`/`oy=`, `z=`, `update`,
+  # `visible`/`visible=`, `dispose`/`disposed?` are native. `update` advances the
+  # autotile animation (frames cycle through the wider autotile bitmaps). This
+  # reopening keeps the plain readers, the `autotiles` slot array (which the
+  # native renderer reads), and the properties not yet honoured — `priorities`
+  # (priority layering) and `flash_data` — stored so scripts run (tracked in
+  # docs/rpgxp-rgss-api-gap.md).
   class Tilemap
     attr_reader :tileset, :map_data, :ox, :oy, :viewport
     attr_accessor :flash_data, :priorities
-
-    def update; end
 
     # RGSS exposes exactly seven autotile slots (0..6); the game assigns each with
     # `tilemap.autotiles[i] = bitmap` and reads them back to dispose. A fixed-size

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2844,6 +2844,10 @@ static const int AUTOTILE_QUADS[48][4][2] = {
 // table's TL, TR, BL, BR order.
 static const int AUTOTILE_QUAD_OFF[4][2] = {{0, 0}, {16, 0}, {0, 16}, {16, 16}};
 
+// One autotile animation frame is 96px wide (3 tiles); animated autotiles pack
+// several such frames left to right.
+static const int AUTOTILE_FRAME_W = 96;
+
 // Redraw the visible part of the map into the tilemap's canvas. For each of the
 // three map-data layers, the tiles overlapping the viewport (given ox/oy) are
 // blitted from the tileset (regular tiles, id >= 384) or assembled from the
@@ -2883,6 +2887,17 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
       mrb_iv_get(M, self, mrb_intern_lit(M, "@autotiles"));
   const bool have_autotiles = mrb_array_p(autotiles_v);
 
+  // Autotile animation: an autotile bitmap wider than one 96px frame holds
+  // several animation frames side by side. RMXP shows each of the four frames
+  // for 16 ticks (mkxp's atAnimation table), so the current frame is the tick
+  // counter / 16, mod 4. `any_anim` records whether this map actually has an
+  // animated autotile, so tilemap_update can skip the periodic re-tile when the
+  // map is static.
+  const mrb_value anim_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_anim"));
+  const int anim = mrb_test(anim_v) ? mrb_as_int(M, anim_v) : 0;
+  const int frame_idx = (anim / 16) % 4;
+  bool any_anim = false;
+
   int tx0 = static_cast<int>(ox) / TILE_SIZE;
   int ty0 = static_cast<int>(oy) / TILE_SIZE;
   if (tx0 < 0)
@@ -2917,11 +2932,19 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
             continue;
           Bitmap& ab = DataType<Bitmap>::get(M, at);
           const int shape = id % 48;
+          // Animated autotile: shift the source into the current frame's 96px
+          // column. A single-frame (96px-wide) autotile stays at offset 0.
+          int sx_off = 0;
+          if (ab.width > AUTOTILE_FRAME_W) {
+            any_anim = true;
+            sx_off =
+                (frame_idx % (ab.width / AUTOTILE_FRAME_W)) * AUTOTILE_FRAME_W;
+          }
           for (int q = 0; q < 4; ++q)
             blit_blend(dst, dx0 + AUTOTILE_QUAD_OFF[q][0],
                        dy0 + AUTOTILE_QUAD_OFF[q][1], ab,
-                       AUTOTILE_QUADS[shape][q][0], AUTOTILE_QUADS[shape][q][1],
-                       16, 16);
+                       AUTOTILE_QUADS[shape][q][0] + sx_off,
+                       AUTOTILE_QUADS[shape][q][1], 16, 16);
         } else {
           // Regular tile from the tileset.
           const int ti = id - 384;
@@ -2931,6 +2954,8 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
       }
     }
   }
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_animated"),
+             mrb_bool_value(any_anim));
   lv_obj_invalidate(obj);
 }
 
@@ -2974,6 +2999,23 @@ mrb_value tilemap_init(mrb_state* M, mrb_value self) {
   mrb_iv_set(M, self, mrb_intern_lit(M, "@map_data"), mrb_nil_value());
   mrb_iv_set(M, self, mrb_intern_lit(M, "@ox"), mrb_fixnum_value(0));
   mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(0));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_anim"), mrb_fixnum_value(0));
+  return self;
+}
+
+// Per-frame tick: advance the autotile animation. The counter cycles 0..63 and
+// the frame it selects is counter / 16, so only every 16th update crosses a
+// frame boundary and needs a re-tile — and only when the map has an animated
+// autotile at all (recorded by tilemap_refresh). A static map does no work.
+mrb_value tilemap_update(mrb_state* M, mrb_value self) {
+  if (!mrb_test(mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_animated"))))
+    return self;
+  const mrb_value anim_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_anim"));
+  const int anim = mrb_test(anim_v) ? mrb_as_int(M, anim_v) : 0;
+  const int next = (anim + 1) % 64;
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_anim"), mrb_fixnum_value(next));
+  if (anim / 16 != next / 16)
+    tilemap_refresh(M, self);
   return self;
 }
 
@@ -3714,6 +3756,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
                     MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "ox=", tilemap_set_ox, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "oy=", tilemap_set_oy, MRB_ARGS_REQ(1));
+  mrb_define_method(M, tilemap, "update", tilemap_update, MRB_ARGS_NONE());
   mrb_define_method(M, tilemap, "z=", obj_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, tilemap, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, tilemap, "visible=", obj_set_visible, MRB_ARGS_REQ(1));


### PR DESCRIPTION
## What

`RGSS::Tilemap` animated autotiles (water, waterfalls, animated terrain) now cycle
through their frames instead of freezing on frame 0.

## How

- An autotile bitmap wider than one 96px frame packs several animation frames side
  by side. `Tilemap#update` is now **native** and advances a counter that cycles
  `0..63`; the frame it selects is `counter / 16` (mod 4), matching RMXP/mkxp's
  16-ticks-per-frame `atAnimation` table. `tilemap_refresh` shifts the autotile
  source rect into that frame's 96px column (`frame % (width / 96)` so any frame
  count is safe).
- **No wasted work:** `update` re-tiles only when it crosses a frame boundary
  (every 16th tick), and only when the last refresh actually drew an animated
  autotile (recorded in `@_tm_animated`). A static map does nothing per frame.
- Replaces the Ruby `def update; end` stub with the native method; gap doc (item
  #3) and a changelog fragment updated.

## Notes

The remaining Tilemap gap is **priority layering** (`priorities`) — tiles that draw
above characters. That one is architectural: a correct fix needs the above-priority
tiles to become their own z-ordered objects interleaving with character sprites per
row (the flat single-canvas model can't express it), so it's left as a deliberate
follow-up rather than folded in here.

## Testing

Compile-verified via the `mruby-rgss/test` surface check (`Tilemap#update` is in the
asserted surface). The native classes need a live display, so the animation itself
is exercised by game runs, not unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_