### PR TITLE
mruby-rgss: render RGSS::Plane#tone, #color and #blend_type

### DIFF
--- a/changelog.d/rpgxp-rgss-plane-tint-blend.added.md
+++ b/changelog.d/rpgxp-rgss-plane-tint-blend.added.md
@@ -1,0 +1,7 @@
+- **`RGSS::Plane#tone`, `#color` and `#blend_type` are now rendered.** `tone=` and
+  `color=` bake an RGSS tone (grey desaturation + RGB offset) and a colour overlay
+  into the tiled buffer per pixel (the same maths Sprite uses), and `blend_type=`
+  maps 0/1/2 onto the plane canvas's LVGL blend mode. Combined with the already-native
+  `opacity=`, a fog/parallax Plane now renders its tint and composites additively
+  instead of the effects being stored-but-ignored. `zoom_x`/`zoom_y` (scaled tiling)
+  remain the outstanding Plane properties. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -119,18 +119,22 @@ flat layer (a correct fix needs the above-priority tiles to become their own
 z-ordered objects that interleave with character sprites per row); and
 `flash_data` is ignored.
 
-### 4. `Plane` ⚠️ (tiling + scroll rendered; zoom/blend/tone/colour stored)
+### 4. `Plane` ⚠️ (tiling + scroll + tint/blend rendered; zoom stored)
 
 `Plane` is now **native** (`mruby-rgss/src/lib.cxx`): `Plane.new` creates an
 `lv_canvas` the size of the viewport (or screen) whose buffer is filled by tiling
 the `bitmap` with the `ox`/`oy` scroll wrapped around it (`plane_retile`), so map
 parallax and fog now actually tile and scroll. `bitmap=`, `ox=`/`oy=`,
-`opacity=`, `z=`, `visible`/`visible=`, `dispose`/`disposed?` are native; the
-canvas is invalidated directly on each re-tile. **Remaining:** `zoom_x`/`zoom_y`,
-`blend_type`, `tone` and `color` are stored but not yet applied to the tiled blit
-(the tile is a straight copy — no scale/blend/tint yet). The per-scroll re-tile is
-a full-canvas `bmp_read`/`bmp_put` pass; a dirty-rect or offset-based scroll is a
-possible optimization.
+`opacity=`, `tone=`, `color=`, `blend_type=`, `z=`, `visible`/`visible=`,
+`dispose`/`disposed?` are native. `opacity=` and `blend_type=` map onto the plane
+canvas's LVGL object (so a fog Plane can fade and composite additively), and
+`tone=`/`color=` bake an RGSS tone (grey desaturation + RGB offset) and a colour
+overlay into the tiled buffer per pixel (the same maths Sprite uses) — so a tinted
+fog renders its tint. The canvas is invalidated directly on each re-tile.
+**Remaining:** `zoom_x`/`zoom_y` are stored but not applied (scaled tiling is a
+different mechanism from the current 1:1 wrap and is future work). The per-scroll
+re-tile is a full-canvas `bmp_read`/`bmp_put` pass; a dirty-rect or offset-based
+scroll is a possible optimization.
 
 ### 5. `Kernel#sprintf` / `String#%` ✅ (mruby-sprintf gem)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -99,7 +99,13 @@ module RGSS
   # that set them run (tracked in docs/rpgxp-rgss-api-gap.md).
   class Plane
     attr_reader :bitmap, :ox, :oy, :z, :viewport
-    attr_writer :zoom_x, :zoom_y, :blend_type
+    # `opacity=`, `tone=`, `color=` and `blend_type=` are native (src/lib.cxx):
+    # opacity/blend map onto the plane canvas's LVGL object, and tone/colour are
+    # baked into the tiled buffer by plane_retile. `zoom_x`/`zoom_y` are still
+    # stored-only (scaled tiling is future work). The readers below return the set
+    # values; native #initialize does not set these ivars, so they fall back to
+    # RGSS defaults here.
+    attr_writer :zoom_x, :zoom_y
 
     def opacity
       @opacity.nil? ? 255 : @opacity
@@ -121,16 +127,8 @@ module RGSS
       @tone ||= Tone.new(0, 0, 0, 0)
     end
 
-    def tone=(t)
-      @tone = t
-    end
-
     def color
       @color ||= Color.new(0, 0, 0, 0)
-    end
-
-    def color=(c)
-      @color = c
     end
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2662,6 +2662,23 @@ void plane_retile(mrb_state* M, mrb_value self) {
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@ox")));
   const mrb_int oy =
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@oy")));
+
+  // Tone (grey desaturation + RGB offset) and colour overlay are baked into the
+  // tiled buffer per pixel, the same way Sprite does — so a tinted fog/parallax
+  // Plane renders its tint. (Same maths as spr_bind_display.)
+  const mrb_value tone_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@tone"));
+  const mrb_value color_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@color"));
+  Tone tn{};
+  Color cl{0, 0, 0, 0};
+  if (mrb_test(tone_v) && DATA_PTR(tone_v))
+    tn = DataType<Tone>::get(M, tone_v);
+  if (mrb_test(color_v) && DATA_PTR(color_v))
+    cl = DataType<Color>::get(M, color_v);
+  const bool has_tone =
+      tn.red != 0 || tn.green != 0 || tn.blue != 0 || tn.gray != 0;
+  const bool has_color = cl.alpha != 0;
+  const int ca = static_cast<int>(cl.alpha);
+
   for (int y = 0; y < dst.height; ++y) {
     const int sy =
         static_cast<int>(((y + oy) % src.height + src.height) % src.height);
@@ -2670,6 +2687,23 @@ void plane_retile(mrb_state* M, mrb_value self) {
           static_cast<int>(((x + ox) % src.width + src.width) % src.width);
       int r, g, b, a;
       bmp_read(src, sx, sy, r, g, b, a);
+      if (has_tone) {
+        const int gy = static_cast<int>(tn.gray);
+        if (gy != 0) {
+          const int lum = (r * 77 + g * 150 + b * 29) / 256;
+          r += (lum - r) * gy / 255;
+          g += (lum - g) * gy / 255;
+          b += (lum - b) * gy / 255;
+        }
+        r = clamp_byte(r + static_cast<int>(tn.red));
+        g = clamp_byte(g + static_cast<int>(tn.green));
+        b = clamp_byte(b + static_cast<int>(tn.blue));
+      }
+      if (has_color) {
+        r = clamp_byte(r + (static_cast<int>(cl.red) - r) * ca / 255);
+        g = clamp_byte(g + (static_cast<int>(cl.green) - g) * ca / 255);
+        b = clamp_byte(b + (static_cast<int>(cl.blue) - b) * ca / 255);
+      }
       bmp_put(dst, x, y, r, g, b, a);
     }
   }
@@ -2742,6 +2776,24 @@ mrb_value plane_set_oy(mrb_state* M, mrb_value self) {
   mrb_iv_set(M, self, mrb_intern_lit(M, "@oy"), mrb_fixnum_value(oy));
   plane_retile(M, self);
   return self;
+}
+
+// Plane#tone= / #color= tint the tiled buffer (baked in by plane_retile), so a
+// fog/parallax Plane re-tiles with its new tint on assign.
+mrb_value plane_set_tone(mrb_state* M, mrb_value self) {
+  mrb_value v;
+  mrb_get_args(M, "o", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@tone"), v);
+  plane_retile(M, self);
+  return v;
+}
+
+mrb_value plane_set_color(mrb_state* M, mrb_value self) {
+  mrb_value v;
+  mrb_get_args(M, "o", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@color"), v);
+  plane_retile(M, self);
+  return v;
 }
 
 // ---- Tilemap --------------------------------------------------------------
@@ -3741,6 +3793,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, plane, "ox=", plane_set_ox, MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "oy=", plane_set_oy, MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "opacity=", spr_set_opacity, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "tone=", plane_set_tone, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "color=", plane_set_color, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "blend_type=", spr_set_blend_type,
+                    MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "z=", obj_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, plane, "visible=", obj_set_visible, MRB_ARGS_REQ(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -480,7 +480,8 @@ assert "RGSS::Plane API surface" do
   # and tiles the bitmap into it, so construction needs a live display the
   # headless test binary lacks. Assert only the method surface here (the tiling
   # itself is exercised by the game runs), matching the Viewport/Sprite tests.
-  %i[bitmap= ox= oy= opacity= z= visible visible= dispose disposed?].each do |m|
+  %i[bitmap= ox= oy= opacity= tone= color= blend_type= z= visible visible=
+     dispose disposed?].each do |m|
     assert_true RGSS::Plane.method_defined?(m), "Plane##{m} missing"
   end
 end


### PR DESCRIPTION
## What

`RGSS::Plane#tone`, `#color` and `#blend_type` are now rendered. Plane backs map
parallax and **fog**, and fog relies on exactly these effects, so a tinted/additive
fog now renders correctly instead of the effects being stored-but-ignored.

## How

- **`tone=` / `color=`** bake an RGSS tone (grey desaturation + RGB offset) and a
  colour overlay into the tiled buffer per pixel in `plane_retile`, using the same
  maths `Sprite#tone=`/`color=` use. Assigning either re-tiles.
- **`blend_type=`** reuses the generic native blend setter, mapping 0/1/2 onto the
  plane canvas's LVGL blend mode (normal / additive / subtractive) — the same
  mechanism as `Sprite#blend_type=`.
- Combined with the already-native `opacity=`, the full set of Plane compositing
  effects now renders. Removed the Ruby `tone=`/`color=`/`blend_type` writers that
  were storing-but-ignoring; the readers stay.
- Test surface, gap doc (item #4) and a changelog fragment updated.

## Notes

`zoom_x`/`zoom_y` remain the only outstanding Plane properties. Scaled tiling is a
different mechanism from the current 1:1 wrap (the source would need to be sampled
at a fractional step), so it's left as a documented follow-up rather than folded in
here.

## Testing

Compile-verified via the `mruby-rgss/test` surface check (`tone=`/`color=`/`blend_type=`
are in the asserted Plane surface). The native classes need a live display, so the
tinting itself is exercised by game runs, not unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_