### PR TITLE
Use ubuntu-slim runner for preview-gate CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,7 +361,12 @@ jobs:
           && startsWith(github.event.comment.body, '/preview')
           && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
                       github.event.comment.author_association) }}
-    runs-on: ubuntu-latest
+    # Two `gh api` calls and nothing else — no checkout, no compiler, no build
+    # tools — so this runs on the small `ubuntu-slim` image (1 CPU, 5 GB RAM,
+    # 15-minute job cap) rather than a full-fat runner. `gh` and `jq` ship with
+    # the image. This is exactly the "issue operations / short-running job"
+    # shape that label is meant for, and it bills at a lower rate.
+    runs-on: ubuntu-slim
     permissions:
       # Read the PR to find its head commit; write reactions on the comment
       # (a PR conversation comment is an issue comment, hence `issues`).

--- a/changelog.d/ci-preview-gate-ubuntu-slim.changed.md
+++ b/changelog.d/ci-preview-gate-ubuntu-slim.changed.md
@@ -1,0 +1,5 @@
+- CI's `preview-gate` job now runs on the `ubuntu-slim` runner instead of
+  `ubuntu-latest`. The job only makes two `gh api` calls — resolve the pull
+  request's head SHA and add the 👀 reaction — with no checkout and no build
+  tooling, so the small image (1 CPU, 5 GB RAM, 15-minute cap) covers it and
+  bills at a lower rate. `gh` and `jq` are preinstalled there.


### PR DESCRIPTION
## Summary
Optimized the `preview-gate` CI job to run on the `ubuntu-slim` runner instead of `ubuntu-latest`, reducing resource consumption and costs for this lightweight operation.

## Key Changes
- Changed the `preview-gate` job runner from `ubuntu-latest` to `ubuntu-slim`
- Added detailed comments explaining the rationale: the job only performs two `gh api` calls (resolving the PR's head SHA and adding a reaction) with no checkout or build tooling required
- The smaller image (1 CPU, 5 GB RAM, 15-minute cap) is sufficient for this use case and bills at a lower rate
- Both `gh` and `jq` are preinstalled on the `ubuntu-slim` image, meeting all job dependencies

## Implementation Details
This change leverages GitHub Actions' `ubuntu-slim` runner, which is specifically designed for lightweight, short-running jobs that don't require compilation or build tools. The `preview-gate` job is an ideal candidate since it only:
1. Resolves the pull request's head commit SHA
2. Adds a reaction to the triggering comment

No source code checkout or compilation is needed, making the full `ubuntu-latest` runner unnecessary and wasteful for this particular workflow step.

https://claude.ai/code/session_01TpMhoLWxGLLarWDsSWH9QX