### PR TITLE
mruby-rgss: render RGSS::Plane#zoom_x/#zoom_y (scaled tiling)

### DIFF
--- a/changelog.d/rpgxp-rgss-plane-zoom.added.md
+++ b/changelog.d/rpgxp-rgss-plane-zoom.added.md
@@ -1,0 +1,6 @@
+- **`RGSS::Plane#zoom_x`/`#zoom_y` are now rendered.** The tiled pattern scales by
+  sampling the source at the reciprocal rate (nearest-neighbour), so a zoomed
+  parallax/fog Plane appears larger or smaller instead of the zoom being
+  stored-but-ignored; a zoom of 1.0 keeps the fast integer tiling path. This was the
+  last outstanding Plane property, so `Plane` is now fully rendered. See
+  `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -119,22 +119,23 @@ flat layer (a correct fix needs the above-priority tiles to become their own
 z-ordered objects that interleave with character sprites per row); and
 `flash_data` is ignored.
 
-### 4. `Plane` ⚠️ (tiling + scroll + tint/blend rendered; zoom stored)
+### 4. `Plane` ✅ (tiling + scroll + tint/blend + zoom all rendered)
 
 `Plane` is now **native** (`mruby-rgss/src/lib.cxx`): `Plane.new` creates an
 `lv_canvas` the size of the viewport (or screen) whose buffer is filled by tiling
 the `bitmap` with the `ox`/`oy` scroll wrapped around it (`plane_retile`), so map
 parallax and fog now actually tile and scroll. `bitmap=`, `ox=`/`oy=`,
-`opacity=`, `tone=`, `color=`, `blend_type=`, `z=`, `visible`/`visible=`,
-`dispose`/`disposed?` are native. `opacity=` and `blend_type=` map onto the plane
-canvas's LVGL object (so a fog Plane can fade and composite additively), and
-`tone=`/`color=` bake an RGSS tone (grey desaturation + RGB offset) and a colour
-overlay into the tiled buffer per pixel (the same maths Sprite uses) — so a tinted
-fog renders its tint. The canvas is invalidated directly on each re-tile.
-**Remaining:** `zoom_x`/`zoom_y` are stored but not applied (scaled tiling is a
-different mechanism from the current 1:1 wrap and is future work). The per-scroll
-re-tile is a full-canvas `bmp_read`/`bmp_put` pass; a dirty-rect or offset-based
-scroll is a possible optimization.
+`opacity=`, `tone=`, `color=`, `blend_type=`, `zoom_x=`/`zoom_y=`, `z=`,
+`visible`/`visible=`, `dispose`/`disposed?` are native. `opacity=` and
+`blend_type=` map onto the plane canvas's LVGL object (so a fog Plane can fade and
+composite additively); `tone=`/`color=` bake an RGSS tone (grey desaturation + RGB
+offset) and a colour overlay into the tiled buffer per pixel (the same maths
+Sprite uses) — so a tinted fog renders its tint; and `zoom_x=`/`zoom_y=` scale the
+tiled pattern (nearest-neighbour: the source is sampled at the reciprocal rate,
+with a zoom of 1.0 staying on the fast integer path). The canvas is invalidated
+directly on each re-tile. **Remaining:** none for correctness — the per-scroll
+re-tile is a full-canvas `bmp_read`/`bmp_put` pass, so a dirty-rect or
+offset-based scroll is a possible optimization.
 
 ### 5. `Kernel#sprintf` / `String#%` ✅ (mruby-sprintf gem)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -99,13 +99,12 @@ module RGSS
   # that set them run (tracked in docs/rpgxp-rgss-api-gap.md).
   class Plane
     attr_reader :bitmap, :ox, :oy, :z, :viewport
-    # `opacity=`, `tone=`, `color=` and `blend_type=` are native (src/lib.cxx):
-    # opacity/blend map onto the plane canvas's LVGL object, and tone/colour are
-    # baked into the tiled buffer by plane_retile. `zoom_x`/`zoom_y` are still
-    # stored-only (scaled tiling is future work). The readers below return the set
+    # `opacity=`, `tone=`, `color=`, `blend_type=` and `zoom_x=`/`zoom_y=` are all
+    # native (src/lib.cxx): opacity/blend map onto the plane canvas's LVGL object,
+    # and tone/colour/zoom are baked into the tiled buffer by plane_retile (zoom
+    # samples the source at the reciprocal rate). The readers below return the set
     # values; native #initialize does not set these ivars, so they fall back to
     # RGSS defaults here.
-    attr_writer :zoom_x, :zoom_y
 
     def opacity
       @opacity.nil? ? 255 : @opacity

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2663,6 +2663,19 @@ void plane_retile(mrb_state* M, mrb_value self) {
   const mrb_int oy =
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@oy")));
 
+  // zoom_x/zoom_y scale the tiled pattern (nearest-neighbour): a zoom of 2.0
+  // samples the source at half the rate, so the bitmap appears twice as large.
+  // A non-positive or absent zoom is treated as 1.0 (the fast integer path).
+  const mrb_value zx_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@zoom_x"));
+  const mrb_value zy_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@zoom_y"));
+  double zx = mrb_test(zx_v) ? mrb_as_float(M, zx_v) : 1.0;
+  double zy = mrb_test(zy_v) ? mrb_as_float(M, zy_v) : 1.0;
+  if (zx <= 0.0)
+    zx = 1.0;
+  if (zy <= 0.0)
+    zy = 1.0;
+  const bool scaled = zx != 1.0 || zy != 1.0;
+
   // Tone (grey desaturation + RGB offset) and colour overlay are baked into the
   // tiled buffer per pixel, the same way Sprite does — so a tinted fog/parallax
   // Plane renders its tint. (Same maths as spr_bind_display.)
@@ -2680,11 +2693,13 @@ void plane_retile(mrb_state* M, mrb_value self) {
   const int ca = static_cast<int>(cl.alpha);
 
   for (int y = 0; y < dst.height; ++y) {
-    const int sy =
-        static_cast<int>(((y + oy) % src.height + src.height) % src.height);
+    const int syb = scaled ? static_cast<int>(std::floor((y + oy) / zy))
+                           : static_cast<int>(y + oy);
+    const int sy = (syb % src.height + src.height) % src.height;
     for (int x = 0; x < dst.width; ++x) {
-      const int sx =
-          static_cast<int>(((x + ox) % src.width + src.width) % src.width);
+      const int sxb = scaled ? static_cast<int>(std::floor((x + ox) / zx))
+                             : static_cast<int>(x + ox);
+      const int sx = (sxb % src.width + src.width) % src.width;
       int r, g, b, a;
       bmp_read(src, sx, sy, r, g, b, a);
       if (has_tone) {
@@ -2794,6 +2809,24 @@ mrb_value plane_set_color(mrb_state* M, mrb_value self) {
   mrb_iv_set(M, self, mrb_intern_lit(M, "@color"), v);
   plane_retile(M, self);
   return v;
+}
+
+// Plane#zoom_x= / #zoom_y= scale the tiled pattern; plane_retile samples the
+// source at the reciprocal rate, so assigning a zoom re-tiles.
+mrb_value plane_set_zoom_x(mrb_state* M, mrb_value self) {
+  mrb_float z;
+  mrb_get_args(M, "f", &z);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@zoom_x"), mrb_float_value(M, z));
+  plane_retile(M, self);
+  return self;
+}
+
+mrb_value plane_set_zoom_y(mrb_state* M, mrb_value self) {
+  mrb_float z;
+  mrb_get_args(M, "f", &z);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@zoom_y"), mrb_float_value(M, z));
+  plane_retile(M, self);
+  return self;
 }
 
 // ---- Tilemap --------------------------------------------------------------
@@ -3795,6 +3828,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, plane, "opacity=", spr_set_opacity, MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "tone=", plane_set_tone, MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "color=", plane_set_color, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "zoom_x=", plane_set_zoom_x, MRB_ARGS_REQ(1));
+  mrb_define_method(M, plane, "zoom_y=", plane_set_zoom_y, MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "blend_type=", spr_set_blend_type,
                     MRB_ARGS_REQ(1));
   mrb_define_method(M, plane, "z=", obj_set_z, MRB_ARGS_REQ(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -480,8 +480,8 @@ assert "RGSS::Plane API surface" do
   # and tiles the bitmap into it, so construction needs a live display the
   # headless test binary lacks. Assert only the method surface here (the tiling
   # itself is exercised by the game runs), matching the Viewport/Sprite tests.
-  %i[bitmap= ox= oy= opacity= tone= color= blend_type= z= visible visible=
-     dispose disposed?].each do |m|
+  %i[bitmap= ox= oy= opacity= tone= color= blend_type= zoom_x= zoom_y= z=
+     visible visible= dispose disposed?].each do |m|
     assert_true RGSS::Plane.method_defined?(m), "Plane##{m} missing"
   end
 end


### PR DESCRIPTION
## What

`RGSS::Plane#zoom_x`/`#zoom_y` are now rendered — the last outstanding Plane
property, so **`Plane` is now fully rendered (item #4 in the gap doc → ✅)**.

## How

- `plane_retile` samples the source at the reciprocal of the zoom
  (nearest-neighbour): a zoom of 2.0 samples the bitmap at half rate, so it appears
  twice as large. Wrapping still tiles the (scaled) pattern across the whole canvas.
- A zoom of 1.0 (or absent / non-positive) stays on the existing fast integer path,
  so the common unscaled case pays no float cost.
- New native `plane_set_zoom_x`/`plane_set_zoom_y` (`"f"` args) store the zoom and
  re-tile; registered as `zoom_x=`/`zoom_y=`. Removed the Ruby `attr_writer :zoom_x,
  :zoom_y`; the readers (defaulting to 1.0) stay.
- Test surface, gap doc (item #4) and a changelog fragment updated.

## Testing

Compile-verified via the `mruby-rgss/test` surface check (`zoom_x=`/`zoom_y=` are in
the asserted Plane surface). The native classes need a live display, so the scaling
itself is exercised by game runs, not unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_