### PR TITLE
mruby-rgss: implement Bitmap#gradient_fill_rect

### DIFF
--- a/changelog.d/rpgxp-rgss-bitmap-gradient-fill.added.md
+++ b/changelog.d/rpgxp-rgss-bitmap-gradient-fill.added.md
@@ -1,0 +1,7 @@
+- **`RGSS::Bitmap#gradient_fill_rect` is now implemented.** It fills a rect with a
+  linear gradient from `color1` to `color2` — left-to-right, or top-to-bottom with
+  the `vertical` flag — and supports both the `(rect, c1, c2, vertical=false)` and
+  `(x, y, width, height, c1, c2, vertical=false)` signatures, matching RGSS. Scripts
+  that draw HP/gauge bars and gradient backgrounds now render them. Covered by a
+  `mruby-rgss/test` unit test (Bitmap ops run headless). `hue_change` is the last
+  missing Bitmap method. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -17,9 +17,9 @@ approximate call counts across the bundle.
 These are complete enough for the stock scripts:
 
 - **Value types** — `Table`, `Color`, `Tone`, `Rect` (native, with RGSS Marshal).
-- **`Bitmap`** — `new`, `draw_text` (~96), `fill_rect`, `blt`, `stretch_blt`,
-  `clear` (~33), `text_size`, `get_pixel`/`set_pixel`, `rect`, `width`/`height`,
-  `font`, `dispose`. _Missing: `gradient_fill_rect`, `hue_change`._
+- **`Bitmap`** — `new`, `draw_text` (~96), `fill_rect`, `gradient_fill_rect`,
+  `blt`, `stretch_blt`, `clear` (~33), `text_size`, `get_pixel`/`set_pixel`,
+  `rect`, `width`/`height`, `font`, `dispose`. _Missing: `hue_change`._
 - **`Font`** — instance `name`/`size`/`bold`/`italic`/`shadow`/`outline`/`color`/
   `out_color`, class defaults (`default_name`/`default_size`/…), `exist?`.
 - **`Graphics`** — `frame_count`, `frame_rate`, `update`. _`freeze`,

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1228,6 +1228,43 @@ mrb_value bmp_tone_blt(mrb_state* M, V self) {
   return self;
 }
 
+// RGSS Bitmap#gradient_fill_rect(rect, color1, color2, vertical=false) or
+// (x, y, width, height, color1, color2, vertical=false): fill the rect with a
+// linear gradient from color1 to color2, left-to-right (or top-to-bottom when
+// vertical). Like fill_rect, it overwrites the pixels (colour + alpha).
+mrb_value bmp_gradient_fill_rect(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  mrb_int x, y, w, h;
+  V col1, col2;
+  mrb_bool vertical = false;
+  if (mrb_get_argc(M) <= 4) {
+    V r;
+    mrb_get_args(M, "ooo|b", &r, &col1, &col2, &vertical);
+    Rect& rc = DataType<Rect>::get(M, r);
+    x = rc.x;
+    y = rc.y;
+    w = rc.width;
+    h = rc.height;
+  } else {
+    mrb_get_args(M, "iiiioo|b", &x, &y, &w, &h, &col1, &col2, &vertical);
+  }
+  Color& c1 = DataType<Color>::get(M, col1);
+  Color& c2 = DataType<Color>::get(M, col2);
+  const mrb_int span = vertical ? h : w;
+  for (mrb_int j = y; j < y + h; ++j) {
+    for (mrb_int i = x; i < x + w; ++i) {
+      const mrb_int pos = vertical ? (j - y) : (i - x);
+      const double t = span > 1 ? static_cast<double>(pos) / (span - 1) : 0.0;
+      bmp_put(b, i, j, c1.red + (c2.red - c1.red) * t,
+              c1.green + (c2.green - c1.green) * t,
+              c1.blue + (c2.blue - c1.blue) * t,
+              c1.alpha + (c2.alpha - c1.alpha) * t);
+    }
+  }
+  b.dirty = true;
+  return self;
+}
+
 mrb_value bmp_get_pixel(mrb_state* M, V self) {
   Bitmap& b = bmp_self(M, self);
   mrb_int x, y;
@@ -3954,6 +3991,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "clear", bmp_clear, MRB_ARGS_NONE());
   mrb_define_method(M, bmp, "fill_rect", bmp_fill_rect,
                     MRB_ARGS_REQ(2) | MRB_ARGS_OPT(3));
+  mrb_define_method(M, bmp, "gradient_fill_rect", bmp_gradient_fill_rect,
+                    MRB_ARGS_REQ(3) | MRB_ARGS_OPT(4));
   mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -194,6 +194,28 @@ assert "RGSS::Bitmap stretch_blt" do
   assert_equal 0.0, dst.get_pixel(6, 6).alpha
 end
 
+assert "RGSS::Bitmap gradient_fill_rect" do
+  red = RGSS::Color.new(255, 0, 0, 255)
+  blue = RGSS::Color.new(0, 0, 255, 255)
+
+  # Horizontal gradient across the full width (span 9 => denominator 8).
+  b = RGSS::Bitmap.new(9, 2)
+  b.gradient_fill_rect(0, 0, 9, 2, red, blue)
+  assert_equal 255.0, b.get_pixel(0, 0).red  # left end is color1
+  assert_equal 0.0, b.get_pixel(0, 0).blue
+  assert_equal 0.0, b.get_pixel(8, 1).red    # right end is color2
+  assert_equal 255.0, b.get_pixel(8, 1).blue
+  mid = b.get_pixel(4, 0)                     # halfway: t = 4/8 = 0.5
+  assert_equal 127.0, mid.red                 # 255 - 255*0.5 = 127.5 -> 127
+  assert_equal 127.0, mid.blue
+
+  # Vertical gradient via the Rect overload + the vertical flag.
+  v = RGSS::Bitmap.new(2, 9)
+  v.gradient_fill_rect(RGSS::Rect.new(0, 0, 2, 9), red, blue, true)
+  assert_equal 255.0, v.get_pixel(1, 0).red   # top row is color1
+  assert_equal 255.0, v.get_pixel(1, 8).blue  # bottom row is color2
+end
+
 assert "RGSS::Viewport API surface" do
   # Viewport creation needs a live display, which the test binary does not set
   # up, so only assert the method surface here (exercised for real by the game).


### PR DESCRIPTION
## What

Implements `RGSS::Bitmap#gradient_fill_rect`, one of the two Bitmap methods the gap
doc listed as missing. Scripts that draw HP/gauge bars and gradient backgrounds now
render them instead of raising `NoMethodError`.

## How

- Fills a rect with a linear gradient from `color1` to `color2` — left-to-right, or
  top-to-bottom when the `vertical` flag is set. Interpolates all four channels
  (including alpha) with an endpoint-inclusive `pos / (span - 1)` factor, so the
  first and last row/column land exactly on `color1`/`color2`.
- Supports both RGSS signatures: `(rect, color1, color2, vertical=false)` and
  `(x, y, width, height, color1, color2, vertical=false)` — argument-count branch,
  mirroring `fill_rect`.
- Like `fill_rect`, it overwrites the pixels (colour + alpha) rather than blending.

## Testing

Unlike the display classes, `Bitmap` runs headless, so this ships with **real unit
assertions** (`mruby-rgss/test`): horizontal and vertical gradients, checking both
endpoints and the interpolated midpoint. CI actually executes them.

## Notes

`hue_change` is now the last missing Bitmap method noted in the gap doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_