### PR TITLE
mruby-rgss: implement Bitmap#hue_change

### DIFF
--- a/changelog.d/rpgxp-rgss-bitmap-hue-change.added.md
+++ b/changelog.d/rpgxp-rgss-bitmap-hue-change.added.md
@@ -1,0 +1,6 @@
+- **`RGSS::Bitmap#hue_change` is now implemented.** It rotates every pixel's hue by
+  the given number of degrees (an RGB → HSV → RGB pass that preserves saturation,
+  value and alpha, matching RMXP), so scripts that recolour battlers/tilesets by hue
+  work. A hue of 0 (mod 360) is a no-op. Covered by a `mruby-rgss/test` unit test
+  (Bitmap ops run headless). This was the last missing `Bitmap` method — `Bitmap` is
+  now complete for the stock scripts. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -19,7 +19,8 @@ These are complete enough for the stock scripts:
 - **Value types** — `Table`, `Color`, `Tone`, `Rect` (native, with RGSS Marshal).
 - **`Bitmap`** — `new`, `draw_text` (~96), `fill_rect`, `gradient_fill_rect`,
   `blt`, `stretch_blt`, `clear` (~33), `text_size`, `get_pixel`/`set_pixel`,
-  `rect`, `width`/`height`, `font`, `dispose`. _Missing: `hue_change`._
+  `rect`, `width`/`height`, `font`, `hue_change`, `dispose`. _Complete for the
+  stock scripts._
 - **`Font`** — instance `name`/`size`/`bold`/`italic`/`shadow`/`outline`/`color`/
   `out_color`, class defaults (`default_name`/`default_size`/…), `exist?`.
 - **`Graphics`** — `frame_count`, `frame_rate`, `update`. _`freeze`,

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1265,6 +1265,75 @@ mrb_value bmp_gradient_fill_rect(mrb_state* M, V self) {
   return self;
 }
 
+// RGSS Bitmap#hue_change(hue): rotate every pixel's hue by `hue` degrees,
+// preserving saturation, value and alpha (an RGB -> HSV -> RGB pass, matching
+// RMXP's hue rotation). A hue of 0 (mod 360) is a no-op.
+mrb_value bmp_hue_change(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  mrb_int hue;
+  mrb_get_args(M, "i", &hue);
+  hue = ((hue % 360) + 360) % 360;
+  if (hue == 0)
+    return self;
+  for (int32_t y = 0; y < b.height; ++y) {
+    for (int32_t x = 0; x < b.width; ++x) {
+      int r, g, bl, a;
+      bmp_read(b, x, y, r, g, bl, a);
+      const double rf = r / 255.0, gf = g / 255.0, bf = bl / 255.0;
+      const double mx = std::max(rf, std::max(gf, bf));
+      const double mn = std::min(rf, std::min(gf, bf));
+      const double delta = mx - mn;
+      double h = 0.0;
+      if (delta > 0.0) {
+        if (mx == rf)
+          h = 60.0 * std::fmod((gf - bf) / delta, 6.0);
+        else if (mx == gf)
+          h = 60.0 * ((bf - rf) / delta + 2.0);
+        else
+          h = 60.0 * ((rf - gf) / delta + 4.0);
+        if (h < 0.0)
+          h += 360.0;
+      }
+      const double s = mx == 0.0 ? 0.0 : delta / mx;
+      const double v = mx;
+      h = std::fmod(h + hue, 360.0);
+      // HSV -> RGB.
+      const double c = v * s;
+      const double xx = c * (1.0 - std::fabs(std::fmod(h / 60.0, 2.0) - 1.0));
+      const double m = v - c;
+      double nr, ng, nb;
+      if (h < 60.0) {
+        nr = c;
+        ng = xx;
+        nb = 0.0;
+      } else if (h < 120.0) {
+        nr = xx;
+        ng = c;
+        nb = 0.0;
+      } else if (h < 180.0) {
+        nr = 0.0;
+        ng = c;
+        nb = xx;
+      } else if (h < 240.0) {
+        nr = 0.0;
+        ng = xx;
+        nb = c;
+      } else if (h < 300.0) {
+        nr = xx;
+        ng = 0.0;
+        nb = c;
+      } else {
+        nr = c;
+        ng = 0.0;
+        nb = xx;
+      }
+      bmp_put(b, x, y, (nr + m) * 255.0, (ng + m) * 255.0, (nb + m) * 255.0, a);
+    }
+  }
+  b.dirty = true;
+  return self;
+}
+
 mrb_value bmp_get_pixel(mrb_state* M, V self) {
   Bitmap& b = bmp_self(M, self);
   mrb_int x, y;
@@ -3993,6 +4062,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
                     MRB_ARGS_REQ(2) | MRB_ARGS_OPT(3));
   mrb_define_method(M, bmp, "gradient_fill_rect", bmp_gradient_fill_rect,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(4));
+  mrb_define_method(M, bmp, "hue_change", bmp_hue_change, MRB_ARGS_REQ(1));
   mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -216,6 +216,26 @@ assert "RGSS::Bitmap gradient_fill_rect" do
   assert_equal 255.0, v.get_pixel(1, 8).blue  # bottom row is color2
 end
 
+assert "RGSS::Bitmap hue_change" do
+  # A 120-degree hue rotation maps the primaries exactly: R -> G -> B -> R,
+  # preserving saturation, value and alpha.
+  b = RGSS::Bitmap.new(2, 2)
+  b.fill_rect(0, 0, 2, 2, RGSS::Color.new(255, 0, 0, 200))
+  b.hue_change(120)  # red -> green
+  px = b.get_pixel(0, 0)
+  assert_equal 0.0, px.red
+  assert_equal 255.0, px.green
+  assert_equal 0.0, px.blue
+  assert_equal 200.0, px.alpha  # alpha untouched
+
+  b.hue_change(120)  # green -> blue
+  assert_equal 255.0, b.get_pixel(1, 1).blue
+  assert_equal 0.0, b.get_pixel(1, 1).green
+
+  b.hue_change(0)  # no-op
+  assert_equal 255.0, b.get_pixel(1, 1).blue
+end
+
 assert "RGSS::Viewport API surface" do
   # Viewport creation needs a live display, which the test binary does not set
   # up, so only assert the method surface here (exercised for real by the game).


### PR DESCRIPTION
## What

Implements `RGSS::Bitmap#hue_change` — the last `Bitmap` method the gap doc listed as
missing. Scripts that recolour battlers, tilesets or icons by hue now work instead of
raising `NoMethodError`. With this, **`Bitmap` is complete for the stock scripts**.

## How

- Rotates every pixel's hue by `hue` degrees via an RGB → HSV → RGB pass, preserving
  saturation, value and alpha — matching RMXP's hue rotation (it shifts hue only, not
  a colour-matrix approximation).
- `hue` is normalised mod 360; a hue of 0 short-circuits to a no-op (no pixel pass).

## Testing

`Bitmap` runs headless, so this ships with **real unit assertions** (`mruby-rgss/test`):
a 120° rotation maps the primaries exactly (R → G → B → R), which the test checks
alongside alpha preservation and the 0° no-op. CI executes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_