### PR TITLE
RPG2000 battle status conditions: carry-through, item cure, and per-turn effects

### DIFF
--- a/changelog.d/rpg2k-battle-state-carry.added.md
+++ b/changelog.d/rpg2k-battle-state-carry.added.md
@@ -1,0 +1,15 @@
+- RPG Maker 2000: **status conditions now carry through a battle**, and a battle
+  medicine cures them. A `Game::Battle::Combatant` seeds its status set from its
+  source actor (`from_actor`), so a member who walked into the fight afflicted
+  (e.g. a map Change Condition) is still afflicted in battle; enemies carry none.
+  `battle_item_command` now reports the medicine's cured `state_set` alongside its
+  HP/SP recovery, and `apply_command` **removes those states from the target**
+  (an antidote / herb used mid-fight — unconditional, matching the field item
+  cure). `Battle#apply_to_party` writes each ally's surviving status set back to
+  its actor (before the HP write-back, so `set_hp` still has the last word on the
+  death state), so the cure — or an unremoved ailment — persists out of the
+  fight. Covered by new `scripts/rpg2k_logic_check.rb` checks (a battle antidote
+  cures only its listed state and the cure carries out; an uncured status
+  survives the battle). Afflicted-battler behaviour (poison ticking, sleep
+  skipping a turn) and in-battle *infliction* (attack skills rolling
+  `state_chance`) — which need the State database — remain follow-ups.

--- a/changelog.d/rpg2k-battle-state-effects.added.md
+++ b/changelog.d/rpg2k-battle-state-effects.added.md
@@ -1,0 +1,14 @@
+- RPG Maker 2000: **afflicted battlers now act on their status conditions each
+  turn** in battle. `Game::Battle` accepts the database `situation` (state) table,
+  and at the start of a battler's turn `apply_turn_states` applies each afflicting
+  state's per-turn effect: **slip damage** — HP (and SP) loss of `hp_change_val +
+  max * hp_change_max / 100`, grounded on EasyRPG's `ApplyConditions` — which can
+  knock the battler out, and a **"do nothing" restriction** (`restriction == 1`,
+  asleep / paralysed) that **skips its turn**. `Scene::Map` passes `db.situation`,
+  so real poison / sleep states take effect; a battle built without a state table
+  (the 3-argument form) stays inert, so existing call sites are unchanged.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks (fixed + percent slip, a
+  poison KO, an SP slip, a restriction skipping a commanded attack, and the inert
+  no-lookup case). State **auto-recovery** (`hold_turn` / `auto_release_prob`),
+  forced-attack restrictions, and in-battle state **infliction** (rolling
+  `state_chance`) remain follow-ups.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -320,11 +320,16 @@ The work below is roughly ordered by the critical path to a walkable game
   conditions carry through a battle**: a `Combatant` seeds its state set from its
   actor, a **battle medicine cures** its `state_set` (an antidote used mid-fight),
   and `apply_to_party` writes the surviving states back — so an ailment walks into
-  the fight, can be cured there, and the result persists out. Still to come:
-  criticals / attributes / damage variance, in-battle status **infliction**
-  (attack skills rolling `state_chance`) and afflicted-battler behaviour (poison
-  tick / sleep skip, which need the State DB), all-target skill/item scopes, the
-  per-terrain backdrop and the RPG2000 Game Over graphic.
+  the fight, can be cured there, and the result persists out. **Afflicted
+  battlers now act on their conditions each turn**: `Battle` takes the database
+  `situation` (state) table, and at the start of a battler's turn `apply_turn_
+  states` slips HP/SP (fixed val + a percentage of the max, per EasyRPG's
+  `ApplyConditions`) and **skips the turn** for a "do nothing" restriction (asleep
+  / paralysed). Still to come: state **auto-recovery** (`hold_turn` /
+  `auto_release_prob`) and forced-attack restrictions, in-battle status
+  **infliction** (attack skills rolling `state_chance`), criticals / attributes /
+  damage variance, all-target skill/item scopes, the per-terrain backdrop and the
+  RPG2000 Game Over graphic.
   The remaining event commands (Inflict Damage, Name Input, Show Battle
   Animation, vehicle boarding, tile substitution, ...) are TODO. **Change System
   Graphics** (10680) overrides the windowskin / font (save chunks 15 / 17; the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -316,10 +316,15 @@ The work below is roughly ordered by the critical path to a walkable game
   `Game::Actor#set_hp`, so damage sticks and a member reduced to 0 comes out
   戦闘不能 — and a **defeat ends the game** (return to title via
   `perform_game_over`) when the encounter's defeat mode is "game over" (no
-  `[Defeat]` handler) and the party is wiped (`Game::Party#all_dead?`). Still to
-  come: criticals / attributes / damage variance and in-battle status infliction
-  (rolling `state_chance`), all-target skill/item scopes, the per-terrain
-  backdrop and the RPG2000 Game Over graphic.
+  `[Defeat]` handler) and the party is wiped (`Game::Party#all_dead?`). **Status
+  conditions carry through a battle**: a `Combatant` seeds its state set from its
+  actor, a **battle medicine cures** its `state_set` (an antidote used mid-fight),
+  and `apply_to_party` writes the surviving states back — so an ailment walks into
+  the fight, can be cured there, and the result persists out. Still to come:
+  criticals / attributes / damage variance, in-battle status **infliction**
+  (attack skills rolling `state_chance`) and afflicted-battler behaviour (poison
+  tick / sleep skip, which need the State DB), all-target skill/item scopes, the
+  per-terrain backdrop and the RPG2000 Game Over graphic.
   The remaining event commands (Inflict Damage, Name Input, Show Battle
   Animation, vehicle boarding, tile substitution, ...) are TODO. **Change System
   Graphics** (10680) overrides the windowskin / font (save chunks 15 / 17; the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1772,11 +1772,12 @@ module Game
             .map { |id| [id, item_count(id)] }
     end
 
-    # The HP / SP a medicine restores to a battle `target` (Combatant snapshot),
-    # as `{ hp:, mp: }` — the same recovery the field menu applies.
+    # The HP / SP a medicine restores to a battle `target` (Combatant snapshot)
+    # plus the status conditions it cures, as `{ hp:, mp:, cured: [ids] }` — the
+    # same recovery and (antidote / herb) cure the field menu applies.
     def battle_item_command(it, target)
       hp, mp = item_recovery(it, target)
-      { hp: hp, mp: mp }
+      { hp: hp, mp: mp, cured: item_cured_states(it) }
     end
   end
 
@@ -2749,23 +2750,31 @@ module Game
     # stat the skill formulas read as `int`.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
-                           :actor) do
+                           :actor, :states) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
       def int; spi; end
+      # Whether `id` is currently afflicting this battler.
+      def state?(id); (states || []).include?(id); end
     end
+
+    # Seed the combatant's status set from the actor, so a member who walked into
+    # the fight afflicted (a map Change Condition) is still afflicted in battle,
+    # and a cure applied here can be written back. A bare fixture without #states
+    # starts clean.
+    def self.actor_states(a); a.respond_to?(:states) ? (a.states || []).dup : []; end
 
     def self.from_actor(a)
       Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
-                    nil, false, a.mp, a.max_mp, a.int, nil, a)
+                    nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a))
     end
 
-    # Enemies have no source actor (the last field stays nil), so the post-battle
-    # HP write-back skips them.
+    # Enemies have no source actor (that field stays nil), so the post-battle
+    # write-back skips them; they carry no status set into this simple sim.
     def self.from_enemy(e)
       Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
-                    nil, false, e.sp, e.max_sp, e.spi, nil)
+                    nil, false, e.sp, e.max_sp, e.spi, nil, nil, [])
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -2793,14 +2802,15 @@ module Game
     def finished?; !alive?(@allies) || !alive?(@enemies); end
 
     # Persist the fight's outcome onto the real party: write each ally combatant's
-    # final HP (and SP, which battle skills spend) back to its source actor, so
-    # damage taken in battle sticks and a combatant reduced to 0 comes out knocked
-    # out (戦闘不能). Combatants without a source actor -- enemies, or bare test
-    # snapshots -- are skipped. RPG2000 keeps the party's post-battle HP/SP; a
-    # downed member stays down until revived.
+    # final status set, HP and SP back to its source actor, so damage taken in
+    # battle sticks, a status cured (or inflicted) in battle carries out, and a
+    # combatant reduced to 0 comes out knocked out (戦闘不能). Combatants without a
+    # source actor -- enemies, or bare test snapshots -- are skipped. States are
+    # written before HP so `set_hp` gets the last word on the death state.
     def apply_to_party
       @allies.each do |c|
         next unless c.actor
+        c.actor.states = c.states if c.states && c.actor.respond_to?(:states=)
         c.actor.set_hp(c.hp)
         c.actor.mp = Game.clamp(c.mp, 0, c.actor.max_mp) if c.mp
       end
@@ -2851,12 +2861,13 @@ module Game
       ally.action = nil; ally.defending = false
     end
 
-    # Queue a single-target Item for `ally` on `target`: restore the HP / SP from
-    # Game::Party#battle_item_command. `item_id` rides along on the log entry so
-    # the scene consumes one from the bag when the action lands.
-    def command_item(ally, target, item_id:, name:, hp: 0, mp: 0)
+    # Queue a single-target Item for `ally` on `target`: restore the HP / SP and
+    # cure the status conditions from Game::Party#battle_item_command. `item_id`
+    # rides along on the log entry so the scene consumes one from the bag when the
+    # action lands.
+    def command_item(ally, target, item_id:, name:, hp: 0, mp: 0, cured: nil)
       ally.command = { kind: :item, target: target, item_id: item_id,
-                       name: name, hp: hp, mp: mp }
+                       name: name, hp: hp, mp: mp, cured: cured || [] }
       ally.action = nil; ally.defending = false
     end
 
@@ -2973,10 +2984,14 @@ module Game
         before_mp = target.mp || 0
         target.hp = [target.hp + hp, target.max_hp].min if hp > 0
         target.mp = [before_mp + mp, target.max_mp].min if mp > 0 && target.max_mp
+        # Cure the item's status conditions from the target (an antidote / herb),
+        # unconditionally, matching the field item cure.
+        cured = (cmd[:cured] || []).select { |s| target.state?(s) }
+        target.states = (target.states || []) - cured unless cured.empty?
         { recover: true, actor: b.name, source: cmd[:name],
           item_id: cmd[:item_id], target: target.name,
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
-          target_hp: target.hp, target_mp: target.mp }
+          cured: cured, target_hp: target.hp, target_mp: target.mp }
       end
     end
   end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2788,15 +2788,24 @@ module Game
 
     attr_reader :allies, :enemies, :rounds, :result, :log
 
-    def initialize(allies, enemies, rng = nil)
+    # `states` is an optional state-definition lookup (`[id]` -> a row exposing
+    # `restriction` / `hp_change_val` / `hp_change_max` / `sp_change_val` /
+    # `sp_change_max`, e.g. the database's `situation` table). When given, a
+    # battler's afflicted states take effect each turn (slip damage, skip if it
+    # cannot act); omitted, states are inert as before.
+    def initialize(allies, enemies, rng = nil, states = nil)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
+      @states = states
       @rounds = 0
       @result = nil
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
     end
+
+    # State `restriction` value meaning "cannot act" (asleep / paralysed).
+    RESTRICTION_DO_NOTHING = 1
 
     # True once one side has been wiped out (the battle is decided).
     def finished?; !alive?(@allies) || !alive?(@enemies); end
@@ -2826,6 +2835,8 @@ module Game
         return nil if @queue.empty? # hit MAX_ROUNDS
         b = @queue.shift
         next if b.dead?
+        can_act = apply_turn_states(b)
+        next if b.dead? || !can_act
         entry = strike(b)
         next unless entry # attacker had no living target; try the next
         @log << entry
@@ -2903,6 +2914,11 @@ module Game
         return nil if finished? || @queue.empty?
         b = @queue.shift
         next if b.dead?
+        # Afflicted states act at the start of the battler's turn: slip damage
+        # (which may knock it out) and, if it cannot act (asleep / paralysed), its
+        # turn is skipped.
+        can_act = apply_turn_states(b)
+        next if b.dead? || !can_act
         entry = strike(b)
         next unless entry
         @log << entry
@@ -2918,6 +2934,32 @@ module Game
     end
 
     private
+
+    # The state definition for `id` from the lookup, or nil (no lookup / unknown).
+    def state_def(id); @states ? @states[id] : nil; end
+
+    # A field off a state row, tolerating a fixture that omits it.
+    def state_field(d, name); d.respond_to?(name) ? (d.send(name) || 0) : 0; end
+
+    # Apply `b`'s afflicted states at the start of its turn: slip HP/SP damage
+    # (fixed val + a percentage of the max, per EasyRPG's ApplyConditions) from
+    # each state, and report whether the battler may act (a "do nothing"
+    # restriction skips its turn). Returns true if `b` may act.
+    def apply_turn_states(b)
+      can_act = true
+      (b.states || []).each do |id|
+        d = state_def(id)
+        next unless d
+        hp = state_field(d, :hp_change_val) + b.max_hp * state_field(d, :hp_change_max) / 100
+        b.hp -= hp if hp > 0
+        if b.max_mp && b.mp
+          sp = state_field(d, :sp_change_val) + b.max_mp * state_field(d, :sp_change_max) / 100
+          b.mp = [b.mp - sp, 0].max if sp > 0
+        end
+        can_act = false if state_field(d, :restriction) == RESTRICTION_DO_NOTHING
+      end
+      can_act
+    end
 
     def alive?(side); side.any? { |b| !b.dead? }; end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1816,8 +1816,12 @@ class RPG2k
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
         foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
+        # The database's state table drives per-turn afflictions (poison slip,
+        # sleep skip) in battle.
+        situations = db.respond_to?(:situation) ? db.situation : nil
         @battle_ui = { phase: :command, req: req, troop: troop,
-                       battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000)),
+                       battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
+                                                situations),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2121,7 +2121,7 @@ class RPG2k
         @battle_ui[:battle].command_item(current_actor, target,
                                          item_id: pending[:item_id],
                                          name: pending[:it].name,
-                                         hp: c[:hp], mp: c[:mp])
+                                         hp: c[:hp], mp: c[:mp], cured: c[:cured])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3658,7 +3658,41 @@ check 'battle_items lists battle medicines; battle_item_command recovers' do
   ok !st.party.battle_usable?(6), 'a field-only medicine is not battle-usable'
   target = combatant('T', 0, 0, 5, 100)
   target.max_mp = 30
-  eq({ hp: 40, mp: 0 }, st.party.battle_item_command(st.party.db_item(5), target))
+  eq({ hp: 40, mp: 0, cured: [] },
+     st.party.battle_item_command(st.party.db_item(5), target))
+end
+
+check 'a battle item cures the target status; states carry out via apply_to_party' do
+  # An antidote (reverse item curing state 3) used in battle on a poisoned ally.
+  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true) }
+  st = item_party(items)
+  st.party.gain_item(5, 1)
+  ally = st.party.actor_by_id(1)
+  ally.add_state(3); ally.add_state(9)         # afflicted entering the fight
+  c = Game::Battle.from_actor(ally)
+  eq true, c.state?(3)                          # the status walked into battle
+  bat = Game::Battle.new([c], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.command_item(c, c, item_id: 5, name: 'Antidote',
+                   **st.party.battle_item_command(st.party.db_item(5), c))
+  bat.run_round
+  eq false, c.state?(3)                         # cured in battle
+  eq true, c.state?(9)                          # an unlisted state stays
+  bat.apply_to_party
+  eq false, ally.state?(3)                      # ...and the cure persisted out
+  eq true, ally.state?(9)
+end
+
+check 'battle carries an actor status through unchanged when nothing cures it' do
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hero.add_state(5)                             # afflicted before the fight
+  hc = Game::Battle.from_actor(hero)
+  eq true, hc.state?(5)
+  hc.hp = 40                                    # took some damage on the way
+  bat = Game::Battle.new([hc], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  bat.apply_to_party
+  eq 40, hero.hp
+  eq true, hero.state?(5)                       # the status survived the battle
 end
 
 check 'Battle end_round clears a queued Skill / Item command' do

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3695,6 +3695,66 @@ check 'battle carries an actor status through unchanged when nothing cures it' d
   eq true, hero.state?(5)                       # the status survived the battle
 end
 
+# A state-definition lookup for the battle: id -> a row the sim reads for its
+# per-turn slip damage (hp/sp change) and action restriction.
+FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
+                          :sp_change_val, :sp_change_max)
+
+check 'battle poison slips HP each turn (fixed val + percent of max)' do
+  states = { 2 => FakeStateDef.new(0, 5, 10, 0, 0) } # 5 + 10% of max HP / turn
+  hero = combatant('Hero', 40, 0, 20, 100)           # max HP 100, acts first
+  hero.states = [2]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.begin_round
+  bat.step_action                                    # hero's turn: slip then strike
+  eq 85, hero.hp                                     # 100 - (5 + 10) poison
+end
+
+check 'battle poison (percent of max) can knock the battler out' do
+  states = { 2 => FakeStateDef.new(0, 0, 100, 0, 0) } # 100% of max HP / turn
+  hero = combatant('Hero', 0, 0, 1, 50)               # slow so the slip lands
+  hero.states = [2]
+  foe = combatant('Foe', 0, 0, 99, 100)               # fast but nearly harmless
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), states)
+  bat.run
+  ok hero.dead?, 'the poison finished the hero off'
+  eq :defeat, bat.result
+end
+
+check 'battle: a "do nothing" state (restriction 1) skips the turn' do
+  states = { 3 => FakeStateDef.new(1, 0, 0, 0, 0) }  # asleep / paralysed
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [3]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.command_attack(hero, slime)                    # even commanded, it cannot act
+  bat.run_round
+  eq 100, slime.hp                                   # the asleep hero never struck
+end
+
+check 'battle poison slips SP too when the battler has max SP' do
+  states = { 4 => FakeStateDef.new(0, 3, 0, 2, 0) }  # 3 HP + 2 SP / turn
+  mage = combatant_mp('Mage', 40, 0, 20, 100, 10)
+  mage.states = [4]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([mage], [slime], Game::Rng.new(1), states)
+  bat.begin_round
+  bat.step_action
+  eq 97, mage.hp
+  eq 8, mage.mp
+end
+
+check 'battle states stay inert without a state-definition lookup' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [2]                                  # afflicted, but no lookup
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1)) # 3-arg: no state defs
+  bat.begin_round
+  bat.step_action
+  eq 100, hero.hp                                    # nothing slipped
+end
+
 check 'Battle end_round clears a queued Skill / Item command' do
   mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
   foe  = combatant('Foe', 0, 0, 5, 100)


### PR DESCRIPTION
Extends the state system (after item cure #245, death-state coupling #250, and the field-skill / battle-HP work #253) **into battle**, in two related commits: statuses now carry through a fight, can be cured there, and — the second commit — **act each turn** (poison slips, sleep skips).

## 1. Status conditions carry through a battle

- **`Combatant` gains a `states` set**, seeded from its actor by `from_actor` — a member who walked in afflicted (a map Change Condition) is still afflicted in battle. Enemies carry none.
- **A battle medicine cures states.** `battle_item_command` reports the medicine's cured `state_set`; `apply_command` removes them from the target (an antidote mid-fight, unconditional, matching the field cure #245). `command_item` / `Scene::Map` thread it through.
- **The result persists out.** `Battle#apply_to_party` writes each ally's surviving status set back to its actor **before** the HP write-back, so `set_hp` keeps the last word on the death state.

## 2. Afflicted battlers act on their conditions each turn

- `Battle` takes the database **`situation` (state) table**; at the start of a battler's turn, **`apply_turn_states`** applies each afflicting state's effect:
  - **Slip damage** — HP (and SP) loss of `hp_change_val + max * hp_change_max / 100`, grounded on EasyRPG's `ApplyConditions`; can knock the battler out.
  - **Skip the turn** for a `restriction == 1` ("do nothing" — asleep / paralysed) state.
- Hooked into both `step_action` (scene battle) and `step` (headless run). `Scene::Map#open_battle` passes `db.situation`, so real poison / sleep states take effect. A battle built **without** a state table (the 3-arg form) stays inert, so existing call sites and tests are unchanged.

Together the loop is complete: an event poisons an actor → the poison ticks each battle turn (or sleep skips its turn) → an antidote cures it → the result persists out.

## Grounding

Item cure semantics from EasyRPG's item algorithm (#245); the per-turn slip formula and the `do_nothing` restriction from EasyRPG's `ApplyConditions` / `Restriction` enum.

## Tests

New `scripts/rpg2k_logic_check.rb` checks: the battle antidote cure + carry-out and an uncured status surviving; fixed + percent slip, a poison KO, an SP slip, a restriction skipping a commanded attack, and the inert no-lookup case. **254 logic + 78 scene + 35 render checks pass; save-load OK.**

## Follow-up

State **auto-recovery** (`hold_turn` / `auto_release_prob`), forced-attack restrictions, and in-battle status **infliction** (attack skills rolling `state_chance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj