### PR TITLE
mvjs: expose WebGL enums as WebGLRenderingContext statics for PIXI (M6.3c)

### DIFF
--- a/changelog.d/mz-webgl-enum-statics.changed.md
+++ b/changelog.d/mz-webgl-enum-statics.changed.md
@@ -1,0 +1,8 @@
+- MZ (M6.3c, in progress): the WebGL wrapper now exposes the GL enum constants as
+  static properties on the global `WebGLRenderingContext` constructor
+  (`WebGLRenderingContext.RGBA`, `.SCISSOR_TEST`, ...), not only on the context
+  instance. PIXI v5's ScissorSystem/StencilSystem read the enums off the
+  constructor while building the renderer, so `new PIXI.Renderer` threw a
+  ReferenceError without them. Found by booting PIXI v5.2.4 (the version RPG
+  Maker MZ ships) against the wrapper's method surface under Node; with this,
+  PIXI constructs its renderer and renders a sprite through the wrapper.

--- a/mruby-mvjs/src/mvwebgl.cxx
+++ b/mruby-mvjs/src/mvwebgl.cxx
@@ -1171,7 +1171,16 @@ const char* kWebGLPreamble = R"MVJS(
     this._ext = {};
   }
   var P = WebGLRenderingContext.prototype;
-  for (var k in K) P[k] = K[k];
+  // The GL enums live both on the prototype (read as `gl.RGBA`) and as static
+  // properties on the constructor (`WebGLRenderingContext.RGBA`). PIXI v5's
+  // ScissorSystem/StencilSystem read the enum off the *constructor* at
+  // renderer-construction time (e.g. `WebGLRenderingContext.SCISSOR_TEST`), so
+  // without the statics `new PIXI.Renderer` throws a ReferenceError before it
+  // can create a context. Mirror the browser, which exposes both.
+  for (var k in K) {
+    P[k] = K[k];
+    WebGLRenderingContext[k] = K[k];
+  }
 
   // Whole-context state.
   P.viewport = function (x, y, w, h) { g.__mv_glViewport(this.__gl, x, y, w, h); };

--- a/mruby-mvjs/test/gl_test.rb
+++ b/mruby-mvjs/test/gl_test.rb
@@ -69,6 +69,24 @@ assert 'the Utils.canUseWebGL() gate shape passes through the wrapper' do
   JS
 end
 
+# --- M6.3c: gaps PIXI v5 exercises at renderer construction -------------------
+
+assert 'WebGLRenderingContext exposes the GL enums as constructor statics (PIXI reads them there)' do
+  skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
+
+  # PIXI v5's ScissorSystem/StencilSystem read the enum off the *constructor*
+  # (e.g. `WebGLRenderingContext.SCISSOR_TEST`) while building the renderer, not
+  # off the context instance — so `new PIXI.Renderer` throws a ReferenceError
+  # without these statics. (Found by booting PIXI v5.2.4 against the wrapper's
+  # method surface.) Values are the standard WebGL/GLES2 tokens.
+  assert_equal 0x0C11, MV::JS.eval("WebGLRenderingContext.SCISSOR_TEST")  # 3089
+  assert_equal 0x0B90, MV::JS.eval("WebGLRenderingContext.STENCIL_TEST")  # 2960
+  assert_equal 0x1908, MV::JS.eval("WebGLRenderingContext.RGBA")          # 6408
+  assert_equal 0x0DE1, MV::JS.eval("WebGLRenderingContext.TEXTURE_2D")    # 3553
+  # The same enums remain on the instance (read as `gl.RGBA`).
+  assert_equal 0x1908, MV::JS.eval("document.createElement('canvas').getContext('webgl').RGBA")
+end
+
 assert 'a green triangle renders end to end through the WebGL wrapper' do
   skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
 


### PR DESCRIPTION
## What

First concrete **M6.3c** gap. To find exactly what PIXI v5 exercises, I booted
**PIXI v5.2.4** (the version RPG Maker MZ ships, from the `stak/rmmz-corescript`
mirror) under Node against a mock GL whose surface mirrors the M6.3b wrapper
(`mvwebgl.cxx`), with a `Proxy` flagging every method/constant PIXI touches that
the wrapper lacks.

Result: PIXI constructs its renderer and renders a sprite + Graphics fill using
**only methods the wrapper already has** — with **one hard gap**. PIXI's
`ScissorSystem`/`StencilSystem` read GL enums off the **global
`WebGLRenderingContext` constructor** (`WebGLRenderingContext.SCISSOR_TEST`)
while building the renderer, not off the context instance. The wrapper put the
enums only on the prototype, so `new PIXI.Renderer` threw a `ReferenceError`
before it could create a context. (VAO/instancing are feature-detected and PIXI
falls back cleanly when absent, so they aren't required to boot.)

## Change

- **`mvwebgl.cxx`**: assign the enum table to the `WebGLRenderingContext`
  constructor as well as the prototype, mirroring the browser (which exposes
  both). One-line-of-intent fix in the JS preamble.
- **`gl_test.rb`**: pin the constructor statics (`WebGLRenderingContext.RGBA` /
  `.SCISSOR_TEST` / `.STENCIL_TEST` / `.TEXTURE_2D`) and that the instance enums
  still resolve.

## Verification

The Node harness (PIXI v5.2.4 + the wrapper's exact method/constant surface)
shows `new PIXI.Renderer(...)` throwing `WebGLRenderingContext.SCISSOR_TEST is
not defined` without this, and rendering a sprite successfully with it. CI runs
the native `gl_test.rb` assertions on the surfaceless-EGL backend; where the
backend is absent (Emscripten/darwin) they skip via `MV::GL.available?`.

This is the first M6.3c gap; the full rmmz `Scene_Boot` integration — CI-fetching
the corescript, a minimal MZ database, the remaining host shims, and presenting
the GL frame on-screen — follows in subsequent changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN7wuqM5uLwZkV4mhR5dzt)_