### PR TITLE
docs: ADR 0022 for Tilemap priority layering design

### DIFF
--- a/docs/adr/0022-rpgxp-tilemap-priority-layering.md
+++ b/docs/adr/0022-rpgxp-tilemap-priority-layering.md
@@ -1,0 +1,126 @@
+# 22. RPG Maker XP: Tilemap priority layering
+
+Date: 2026-08-04
+
+## Status
+
+Proposed
+
+## Context
+
+The native `RGSS::Tilemap` (`mruby-rgss/src/lib.cxx`) now renders the map:
+regular tiles, autotiles (with the 48-shape quad table) and autotile animation
+all draw into a single `lv_canvas` sized to the viewport, at the tilemap's own
+`z`. What it does **not** do is honour per-tile **priority**.
+
+In RMXP a tileset carries a `priorities` `Table` indexed by tile id (0..5 per
+id). Priority 0 is flat ground drawn below the characters. Priority ≥ 1 means the
+tile stands "up" out of the map — a wall top, a roof, a tree crown — and must
+draw **above** a character who is standing lower on the screen than the tile, but
+**below** a character standing higher. That per-row interleaving is what lets you
+walk behind the crown of a tree while still standing in front of its trunk. Stock
+`Spriteset_Map` relies on the engine's `Tilemap` to do this internally: it gives
+character sprites a `z` of roughly their on-screen feet position (`screen_y`,
+~0..map-pixel-height) and leaves fog/weather/pictures at fixed high `z`
+(fog ≈ 3000, weather ≈ 1000 in stock scripts). The `Tilemap` is expected to place
+its priority tiles into that same `z` continuum.
+
+Today all tiles land on one flat canvas at one `z`, so every priority tile draws
+on the same plane as the ground — characters always walk in front of roofs and
+tree crowns. This is the last substantial gap for `Tilemap` (autotile animation
+and `flash_data` aside).
+
+Two constraints make this more than a one-line change:
+
+1. **It cannot be verified headlessly.** The `mruby-rgss` test binary has no live
+   display, so `Tilemap` rendering is only ever exercised by a running game. Every
+   other render slice this cycle shipped "compile-verified, render-verified in a
+   game run"; priority layering additionally introduces new *z-ordered objects*
+   and a custom dispose path, so a mistake risks a crash on map load, not just a
+   cosmetic glitch. That raises the bar for landing it blind.
+2. **The `z` scheme is shared with conventions set elsewhere.** Above-priority
+   tiles must interleave with per-row character `z` values yet stay below
+   fog/weather. A single flat "above" layer at one fixed `z` cannot satisfy both:
+   pick a `z` above all characters and roofs cover characters who should occlude
+   them; pick one below fog and it still can't interleave per row. Correct
+   behaviour needs a *per-row* set of `z` values, matching how RMXP spreads
+   priority tiles through the character `z` range.
+
+For reference, the non-script reimplementation (`mruby-rpgxp/mrblib/scene.rb`,
+`Scene_Map`) already fakes a coarse version of this with three sprites —
+`@lower_sprite` (`z = 0`), `@player_sprite` (`z = 100`), `@upper_sprite`
+(`z = 200`) — but it splits by *map layer index*, not the `priorities` table, and
+draws flat colour rects, so it is only a placeholder and does not inform the
+correct `z` maths. The proper implementation belongs in the native `Tilemap` that
+serves the script-host path.
+
+## Decision
+
+Render the map in **two passes split by priority**, with the above-priority tiles
+spread across **per-row `z` strips** so they interleave with character sprites:
+
+- **Ground pass — the existing canvas.** Priority-0 tiles (and any tile when no
+  `priorities` table is set) keep drawing into `@_tm_canvas` at the tilemap's `z`,
+  exactly as now. No behaviour change when a map has no priority tiles.
+
+- **Above pass — one canvas strip per map row.** For each visible map row `ty`
+  that contains at least one priority ≥ 1 tile, allocate (lazily, reused across
+  frames) a full-width `lv_canvas` strip and draw that row's priority tiles into
+  it. Give the strip a `z` derived from the RMXP rule — the tile's on-screen foot
+  row plus its priority — so it sorts into the character `z` continuum:
+
+  ```
+  z = (ty + prio) * TILE_SIZE + TILE_SIZE - oy
+  ```
+
+  (the exact constant to be confirmed against the testbed `Spriteset_Map`
+  character-`z` formula during in-game verification). Because each strip is at the
+  `z` of its own row, a character one row lower sorts in front of it and a
+  character one row higher sorts behind it — the per-row occlusion RMXP gives.
+
+- **Strips are z-ordered companion objects.** Each strip is wrapped as an internal
+  mruby data object (`mrb_data_object_alloc(... , &obj_type)`, then the same
+  `lv_obj_set_user_data` + `LV_EVENT_DELETE` hook `wrap_lv_obj` installs) and
+  registered via `register_zobj`, so `gfx_update`'s existing per-parent `z` sort
+  interleaves them with the character sprites that share the viewport. The strips
+  are held in an ivar array on the tilemap (`@_tm_above`) so the GC keeps them
+  alive, and their `z` is refreshed on scroll (`oy` change).
+
+- **`priorities=` becomes native.** It currently is a Ruby `attr_accessor`, so
+  assigning it does not re-render. Make it a native setter that stores the table
+  and calls `tilemap_refresh`, matching `tileset=`/`map_data=` — otherwise the
+  common `tilemap.priorities = tileset.priorities` after `map_data=` would not
+  take effect.
+
+- **Custom dispose.** `Tilemap#dispose` must delete every strip's `lv_obj` (via
+  the wrapper's `dfree`, which routes through `on_lv_delete` and nulls the
+  wrapper — no double free) before disposing the main canvas, so no strip lingers
+  in the `z` set or on screen after the map is torn down.
+
+Priority is looked up as `priorities[id]` for every tile id (autotile ids 48..383
+and regular ids ≥ 384 alike); an out-of-range id or a nil table is treated as
+priority 0.
+
+## Consequences
+
+- **Correct occlusion.** Characters walk behind roofs/tree crowns above them and
+  in front of the same tiles below them, the defining RMXP map look, for the
+  script-host path.
+- **New moving parts.** The tilemap goes from one `lv_obj` to 1 + N (N = visible
+  rows carrying priority tiles, bounded by the viewport height — ~15 on a 480px
+  screen). That means more `z`-set churn on scroll and a custom dispose; both are
+  bounded and follow the existing `wrap_lv_obj`/`on_lv_delete`/`register_zobj`
+  patterns, but they are the first place `mruby-rgss` mints z-ordered objects that
+  a script never sees.
+- **Must be verified in a game.** The `z` constant and the strip lifecycle can
+  only be confirmed against a running map (ideally the testbed `Spriteset_Map`);
+  this ADR exists so that scheme is agreed before the ~100–150 line, crash-capable
+  change lands, rather than shipped blind like the cosmetic slices.
+- **Cheaper fallback rejected.** A single flat "above" canvas at a fixed high `z`
+  was considered and rejected: it is far simpler (one companion object, no per-row
+  maths) but cannot both interleave with per-row characters and stay under fog, so
+  it would trade one wrong look (roofs always behind) for another (roofs always in
+  front). If an interim step is wanted, it should be labelled explicitly as a
+  known-approximate stopgap.
+- **Out of scope.** `flash_data` (the map flash overlay) and multi-frame
+  correctness of animated *priority* autotiles are unchanged and remain follow-ups.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -116,9 +116,13 @@ maps do no per-frame work. `tileset=`, `map_data=`, `ox=`/`oy=`, `z=`, `update`,
 `visible`/`visible=`, `dispose`/`disposed?` are native and re-render on change.
 **Remaining:** the per-tile **priority layering** (`priorities`) — tiles that
 should draw above characters — is stored-only, so everything still renders on one
-flat layer (a correct fix needs the above-priority tiles to become their own
-z-ordered objects that interleave with character sprites per row); and
-`flash_data` is ignored.
+flat layer. A correct fix needs the above-priority tiles to become their own
+z-ordered objects that interleave with character sprites per row; the design is
+worked out in
+[ADR 0022](adr/0022-rpgxp-tilemap-priority-layering.md) (per-row `z` strips as
+companion z-objects) and is held for review before it lands, because it mints new
+z-ordered objects and a custom dispose path that can only be verified in a running
+game. `flash_data` is also still ignored.
 
 ### 4. `Plane` ✅ (tiling + scroll + tint/blend + zoom all rendered)
 


### PR DESCRIPTION
## What

Design ADR (status **Proposed**) for native `RGSS::Tilemap` **priority layering** —
the last substantial `Tilemap` gap. Docs only; no code change.

## Why an ADR instead of a patch

Every render slice this cycle was compile-verified and render-checked in a game
run. Priority layering is different: a correct fix has to make above-priority tiles
their own **z-ordered objects** that interleave with character sprites per row, plus
a custom dispose path — the first place `mruby-rgss` mints z-objects a script never
sees. Its crash-safety and (especially) its `z` scheme can only be verified in a
running game, and the `z` values must reconcile with conventions set elsewhere
(character `z ≈ screen_y`, fog/weather at fixed high `z`). That's a design decision
worth agreeing before ~100–150 lines of crash-capable code land.

## What the ADR proposes

- **Ground pass** unchanged (priority-0 tiles on the existing canvas).
- **Above pass**: one reused `lv_canvas` strip per visible map row that has a
  priority ≥ 1 tile, each at a per-row `z` (`(ty + prio) * TILE_SIZE + TILE_SIZE -
  oy`, exact constant TBD against the testbed `Spriteset_Map`), wrapped as internal
  companion z-objects via the existing `wrap_lv_obj`/`on_lv_delete`/`register_zobj`
  patterns so `gfx_update`'s sort interleaves them with characters.
- Make `priorities=` native (so it re-renders), and a custom `Tilemap#dispose` that
  tears the strips down.
- Records the rejected cheaper fallback (a single flat "above" layer — can't sit
  correctly both between per-row characters and below fog) and the out-of-scope bits
  (`flash_data`, animated priority autotiles).

Gap doc item #3 now links the ADR.

## Note

No changelog fragment: this is a *Proposed* design, not a shipped user-facing
change, so a changelog entry would misrepresent it as implemented. Implementation is
the natural follow-up once the `z` scheme here is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_