### PR TITLE
mruby-rgss: draw RGSS::Window cursor as a crisp 9-slice

### DIFF
--- a/changelog.d/rpgxp-rgss-window-cursor-nineslice.changed.md
+++ b/changelog.d/rpgxp-rgss-window-cursor-nineslice.changed.md
@@ -1,0 +1,6 @@
+- **`RGSS::Window`'s selection cursor is now a crisp 9-slice.** Instead of stretching
+  the whole 32×32 windowskin cursor region over `cursor_rect` (which blurred the
+  border), it draws a 9-patch with 2px corners (matching RMXP/mkxp's `buildFrame`):
+  the four corners copy 1:1, the four edges stretch along one axis and the centre
+  fills the rest, so the selection box keeps a sharp border at any size. The blink
+  animation is unchanged. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -87,15 +87,18 @@ reuses the tested `Bitmap#clear`/`#stretch_blt`/`#blt` via `mrb_funcall`; only t
 RMXP windowskin source rects are new. `contents=`, `windowskin=`, `x=`/`y=`,
 `width=`/`height=`, `ox=`/`oy=`, `opacity=`/`back_opacity=`/`contents_opacity=`,
 `z=`, `visible`/`visible=`, `dispose`/`disposed?` are native. It also draws the
-**blinking cursor** highlight at `cursor_rect` (when `active`) and the **pause
+**blinking cursor** 9-slice at `cursor_rect` (when `active`) and the **pause
 arrow** (when `pause`); `Window#update` advances the blink/pause animation and
 redraws (also picking up in-place `cursor_rect` mutation, which scripts do via
-`cursor_rect.set`). So the whole menu/message/shop/battle UI renders — framed
-windows, text, selection cursor and message pause. **Remaining:** the cursor is a
-stretched highlight rather than a crisp 9-slice; the content blit does not yet
-clip contents taller than the window; `stretch` (tiled vs stretched background) is
-ignored; and the RMXP windowskin source-rect constants are best-effort until a
-game exercises them.
+`cursor_rect.set`). The cursor is a crisp **9-slice** with 2px corners (matching
+RMXP/mkxp's `buildFrame`): the four corners copy 1:1, the four edges stretch along
+one axis and the centre fills the rest, so the selection box keeps a sharp border
+at any size. So the whole menu/message/shop/battle UI renders — framed windows,
+text, selection cursor and message pause. The content blit already clips to the
+content area (its source rect is the content-area size, so taller `contents` are
+cropped and scrolled, not overflowed). **Remaining:** `stretch` (tiled vs stretched
+background) is ignored, and the RMXP windowskin source-rect constants are
+best-effort until a game exercises them.
 
 ### 3. `Tilemap` ⚠️ (tiles + animated autotiles rendered; priority layering pending)
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -3430,9 +3430,11 @@ void window_refresh(mrb_state* M, mrb_value self) {
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@_anim")));
   // Cursor: a blinking highlight from the windowskin cursor region (128,64,
   // 32,32) drawn at cursor_rect (content coords, offset by the padding), when
-  // the window is active. Stretched to the rect for now (a crisp 9-slice border
-  // is a refinement); the blink alpha oscillates with @_anim. Redrawn each
-  // frame by Window#update because scripts mutate cursor_rect in place.
+  // the window is active. It is a 9-slice with 2px corners (matching
+  // RMXP/mkxp's buildFrame): the four 2x2 corners are copied 1:1, the four
+  // edges are stretched along one axis and the centre fills the rest. The blink
+  // alpha oscillates with @_anim. Redrawn each frame by Window#update because
+  // scripts mutate cursor_rect in place.
   const mrb_value cr_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@cursor_rect"));
   const mrb_value active_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@active"));
   const bool active = mrb_nil_p(active_v) ? true : mrb_test(active_v);
@@ -3443,10 +3445,47 @@ void window_refresh(mrb_state* M, mrb_value self) {
       const mrb_int phase = ((anim % 32) + 32) % 32;
       const mrb_int level = phase < 16 ? phase : 32 - phase;  // 0..16
       const mrb_int calpha = 255 - level * 8;                 // 255..127
-      const mrb_value cur[] = {
-          make_rect(M, b + cr.x, b + cr.y, cr.width, cr.height), skin,
-          make_rect(M, 128, 64, 32, 32), mrb_fixnum_value(calpha)};
-      mrb_funcall_argv(M, canvas, sblt, 4, cur);
+      const mrb_value op = mrb_fixnum_value(calpha);
+      const mrb_int dx = b + cr.x, dy = b + cr.y, dw = cr.width, dh = cr.height;
+      // The cursor skin region and its 2px 9-slice corner size.
+      const int sx = 128, sy = 64, ss = 32, k = 2;
+      if (dw >= 2 * k && dh >= 2 * k) {
+        // Corners (blt, 1:1). {tl, tr, bl, br} as {dstx, dsty, srcx, srcy}.
+        const mrb_int corners[4][4] = {
+            {dx, dy, sx, sy},
+            {dx + dw - k, dy, sx + ss - k, sy},
+            {dx, dy + dh - k, sx, sy + ss - k},
+            {dx + dw - k, dy + dh - k, sx + ss - k, sy + ss - k}};
+        for (const auto& c : corners) {
+          const mrb_value a[] = {mrb_fixnum_value(c[0]), mrb_fixnum_value(c[1]),
+                                 skin, make_rect(M, c[2], c[3], k, k), op};
+          mrb_funcall_argv(M, canvas, blt, 5, a);
+        }
+        // Edges (stretch_blt) as {dstRect..., srcRect...}: top, bottom, left,
+        // right. Top/bottom stretch horizontally, left/right vertically.
+        const mrb_int edges[4][8] = {
+            {dx + k, dy, dw - 2 * k, k, sx + k, sy, ss - 2 * k, k},
+            {dx + k, dy + dh - k, dw - 2 * k, k, sx + k, sy + ss - k,
+             ss - 2 * k, k},
+            {dx, dy + k, k, dh - 2 * k, sx, sy + k, k, ss - 2 * k},
+            {dx + dw - k, dy + k, k, dh - 2 * k, sx + ss - k, sy + k, k,
+             ss - 2 * k}};
+        for (const auto& e : edges) {
+          const mrb_value a[] = {make_rect(M, e[0], e[1], e[2], e[3]), skin,
+                                 make_rect(M, e[4], e[5], e[6], e[7]), op};
+          mrb_funcall_argv(M, canvas, sblt, 4, a);
+        }
+        // Centre (stretch_blt).
+        const mrb_value ctr[] = {
+            make_rect(M, dx + k, dy + k, dw - 2 * k, dh - 2 * k), skin,
+            make_rect(M, sx + k, sy + k, ss - 2 * k, ss - 2 * k), op};
+        mrb_funcall_argv(M, canvas, sblt, 4, ctr);
+      } else {
+        // Rect too small for the 9-slice: fall back to a plain stretch.
+        const mrb_value cur[] = {make_rect(M, dx, dy, dw, dh), skin,
+                                 make_rect(M, sx, sy, ss, ss), op};
+        mrb_funcall_argv(M, canvas, sblt, 4, cur);
+      }
     }
   }
   // Pause arrow: one of four 16x16 frames at (160,64) cycled by @_anim, drawn


### PR DESCRIPTION
## What

The `RGSS::Window` selection cursor was a single stretch of the 32×32 windowskin
cursor region over `cursor_rect`, which blurred the border at non-32px sizes. Draw
it as a proper 9-slice instead, so the selection box keeps a sharp border at any
size.

## How

- 9-patch with **2px corners**, geometry taken from RMXP/mkxp's `buildFrame` (not
  guessed): the four 2×2 corners copy 1:1 (`blt`), the four edges stretch along one
  axis and the centre fills the rest (`stretch_blt`), all at the existing blink
  alpha.
- A `cursor_rect` too small for the slice (< 4px in either axis) falls back to the
  old plain stretch, so tiny rects can't produce negative edge sizes.
- The blink animation is unchanged.
- Also corrects the gap doc's pessimistic note: the content blit already clips to
  the content area (its source rect is the content-area size, so taller `contents`
  are cropped + scrolled, not overflowed).

## Testing

Compile-verified via the `mruby-rgss/test` surface check. The native windowskin
compositing needs a live display, so the cursor rendering is exercised by game
runs, not unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_