### PR TITLE
RPG2000 battle status: attack-skill infliction + auto-recovery

### DIFF
--- a/changelog.d/rpg2k-battle-skill-inflict.added.md
+++ b/changelog.d/rpg2k-battle-skill-inflict.added.md
@@ -1,0 +1,14 @@
+- RPG Maker 2000: **battle attack skills now inflict status conditions**. An
+  enemy-scope skill's `state_effects` (index `i` → state id `i+1`) ride along on
+  its battle command (`battle_skill_command`), and `apply_command` rolls each
+  against the skill's **`hit` accuracy** (default 100) on a target that survives
+  the hit — adding the state to the target combatant. So a Poison Sting or Sleep
+  spell afflicts the foe, which then slips HP or skips its turn through the
+  per-turn state processing added alongside. `command_skill` threads the inflict
+  set and chance through, and `Scene::Map` passes them from the skill menu. The
+  chance is grounded on EasyRPG's to-hit for skill states; a defeated target is
+  not afflicted, and a state the target already carries is not re-rolled. Covered
+  by new `scripts/rpg2k_logic_check.rb` checks (a 100%-accuracy skill inflicts its
+  state on a surviving enemy, a 0%-accuracy skill never does, and an inflicted
+  "do nothing" state then skips the enemy's next turn). Enemy-cast infliction,
+  state auto-recovery, and forced-attack restrictions remain follow-ups.

--- a/changelog.d/rpg2k-battle-state-recovery.added.md
+++ b/changelog.d/rpg2k-battle-state-recovery.added.md
@@ -1,0 +1,11 @@
+- RPG Maker 2000: **battle status conditions now wear off on their own**. Each
+  `Game::Battle::Combatant` keeps a per-state turn counter; at the start of a
+  battler's turn `apply_turn_states` first rolls each afflicting state for
+  auto-recovery — once the counter has passed the state's `hold_turn`, an
+  `auto_release_prob`% roll (0 = never) cures it — before applying that turn's
+  slip damage / restriction to whatever remains. So a temporary poison or sleep
+  fades after a few turns instead of lasting the whole fight, while a permanent
+  ailment (0% release) stays. Grounded on EasyRPG's `BattleStateHeal`. Covered by
+  new `scripts/rpg2k_logic_check.rb` checks (a state cures only after it has held
+  past `hold_turn`, and a 0%-release state never wears off on its own). Enemy-cast
+  infliction and forced-attack restrictions remain follow-ups.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -329,10 +329,11 @@ The work below is roughly ordered by the critical path to a walkable game
   scope-enemy skill's `state_effects`, and `apply_command` rolls each against the
   skill's `hit` accuracy on a surviving target — so a Poison Sting / Sleep spell
   afflicts the foe, which then slips or skips via the per-turn processing above.
-  Still to come: state **auto-recovery** (`hold_turn` / `auto_release_prob`) and
-  forced-attack restrictions, enemy-cast infliction, criticals / attributes /
-  damage variance, all-target skill/item scopes, the per-terrain backdrop and the
-  RPG2000 Game Over graphic.
+  A state also **auto-recovers**: a per-battler turn counter lets `apply_turn_
+  states` roll `auto_release_prob` once the state has held past its `hold_turn`,
+  so a temporary ailment wears off. Still to come: forced-attack restrictions,
+  enemy-cast infliction, criticals / attributes / damage variance, all-target
+  skill/item scopes, the per-terrain backdrop and the RPG2000 Game Over graphic.
   The remaining event commands (Inflict Damage, Name Input, Show Battle
   Animation, vehicle boarding, tile substitution, ...) are TODO. **Change System
   Graphics** (10680) overrides the windowskin / font (save chunks 15 / 17; the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -325,9 +325,12 @@ The work below is roughly ordered by the critical path to a walkable game
   `situation` (state) table, and at the start of a battler's turn `apply_turn_
   states` slips HP/SP (fixed val + a percentage of the max, per EasyRPG's
   `ApplyConditions`) and **skips the turn** for a "do nothing" restriction (asleep
-  / paralysed). Still to come: state **auto-recovery** (`hold_turn` /
-  `auto_release_prob`) and forced-attack restrictions, in-battle status
-  **infliction** (attack skills rolling `state_chance`), criticals / attributes /
+  / paralysed). **Attack skills inflict states**: `battle_skill_command` carries a
+  scope-enemy skill's `state_effects`, and `apply_command` rolls each against the
+  skill's `hit` accuracy on a surviving target — so a Poison Sting / Sleep spell
+  afflicts the foe, which then slips or skips via the per-turn processing above.
+  Still to come: state **auto-recovery** (`hold_turn` / `auto_release_prob`) and
+  forced-attack restrictions, enemy-cast infliction, criticals / attributes /
   damage variance, all-target skill/item scopes, the per-terrain backdrop and the
   RPG2000 Game Over graphic.
   The remaining event commands (Inflict Damage, Name Input, Show Battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1736,17 +1736,25 @@ module Game
       end
     end
 
+    # A skill's state-infliction accuracy (its `hit` field, default 100), used as
+    # the per-state roll when an attack skill inflicts its `state_effects`.
+    def skill_hit(sk)
+      sk.respond_to?(:hit) ? (sk.hit || 100) : 100
+    end
+
     # The command numbers for casting `sk` from `caster` on `target` (both
     # Combatant snapshots): the caster's SP `cost`, and the signed HP / SP deltas
     # to the target — negative HP for an attack skill (base effect less a quarter
-    # of the target's defence, min 1), positive HP / SP for a recovery skill.
+    # of the target's defence, min 1), positive HP / SP for a recovery skill. An
+    # attack skill also carries the states it may inflict and the roll chance.
     def battle_skill_command(sk, caster, target)
       cost = skill_cost(sk, caster)
       base = skill_effect(sk, caster)
       if sk.scope == 0
         dmg = base - (target ? target.def / 4 : 0)
         dmg = 1 if dmg < 1
-        { cost: cost, hp: -dmg, mp: 0 }
+        { cost: cost, hp: -dmg, mp: 0,
+          inflict: skill_state_ids(sk), chance: skill_hit(sk) }
       else
         { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0 }
       end
@@ -2866,9 +2874,10 @@ module Game
     # SP and applying the signed HP / SP deltas (negative HP = damage, positive =
     # recovery) computed by Game::Party#battle_skill_command. Resolved in agility
     # order by #apply_command when the round runs.
-    def command_skill(ally, target, name:, cost:, hp: 0, mp: 0)
+    def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil, chance: 100)
       ally.command = { kind: :skill, target: target, name: name,
-                       cost: cost, hp: hp, mp: mp }
+                       cost: cost, hp: hp, mp: mp,
+                       inflict: inflict || [], chance: chance }
       ally.action = nil; ally.defending = false
     end
 
@@ -3018,9 +3027,12 @@ module Game
       if hp < 0
         dmg = -hp
         target.hp -= dmg
+        # An attack skill may inflict its states on a surviving target, each
+        # rolled against the skill's accuracy.
+        inflicted = target.dead? ? [] : roll_inflict(target, cmd)
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
-          skill: cmd[:name] }
+          inflicted: inflicted, skill: cmd[:name] }
       else
         before_hp = target.hp
         before_mp = target.mp || 0
@@ -3035,6 +3047,21 @@ module Game
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
           cured: cured, target_hp: target.hp, target_mp: target.mp }
       end
+    end
+
+    # Inflict a skill command's `inflict` states on `target`, each landing only if
+    # a 0..99 roll comes in under the skill's `chance` (its accuracy). Skips a
+    # state the target already carries. Returns the states actually inflicted.
+    def roll_inflict(target, cmd)
+      chance = cmd[:chance] || 100
+      inflicted = []
+      (cmd[:inflict] || []).each do |sid|
+        next if target.state?(sid)
+        next unless @rng.random(100) < chance
+        target.states = (target.states || []) + [sid]
+        inflicted << sid
+      end
+      inflicted
     end
   end
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2758,7 +2758,7 @@ module Game
     # stat the skill formulas read as `int`.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
-                           :actor, :states) do
+                           :actor, :states, :state_turns) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
@@ -2950,15 +2950,24 @@ module Game
     # A field off a state row, tolerating a fixture that omits it.
     def state_field(d, name); d.respond_to?(name) ? (d.send(name) || 0) : 0; end
 
-    # Apply `b`'s afflicted states at the start of its turn: slip HP/SP damage
-    # (fixed val + a percentage of the max, per EasyRPG's ApplyConditions) from
-    # each state, and report whether the battler may act (a "do nothing"
+    # Apply `b`'s afflicted states at the start of its turn: first roll each state
+    # for auto-recovery (once it has held longer than its `hold_turn`, an
+    # `auto_release_prob`% roll cures it), then, for the states that remain, slip
+    # HP/SP damage (fixed val + a percentage of the max, per EasyRPG's
+    # ApplyConditions) and report whether the battler may act (a "do nothing"
     # restriction skips its turn). Returns true if `b` may act.
     def apply_turn_states(b)
       can_act = true
-      (b.states || []).each do |id|
+      b.state_turns ||= {}
+      (b.states || []).dup.each do |id|
         d = state_def(id)
         next unless d
+        b.state_turns[id] = (b.state_turns[id] || 0) + 1
+        if recovers_from_state?(b, id, d)
+          b.states = b.states - [id]
+          b.state_turns.delete(id)
+          next
+        end
         hp = state_field(d, :hp_change_val) + b.max_hp * state_field(d, :hp_change_max) / 100
         b.hp -= hp if hp > 0
         if b.max_mp && b.mp
@@ -2968,6 +2977,16 @@ module Game
         can_act = false if state_field(d, :restriction) == RESTRICTION_DO_NOTHING
       end
       can_act
+    end
+
+    # Whether `b` shakes off state `id` this turn: only once it has held for more
+    # than the state's `hold_turn`, then an `auto_release_prob`% roll (0 = never
+    # auto-releases). Grounded on EasyRPG's BattleStateHeal.
+    def recovers_from_state?(b, id, d)
+      prob = state_field(d, :auto_release_prob)
+      return false if prob <= 0
+      return false unless b.state_turns[id] > state_field(d, :hold_turn)
+      @rng.random(100) < prob
     end
 
     def alive?(side); side.any? { |b| !b.dead? }; end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2046,7 +2046,8 @@ class RPG2k
         c = @state.party.battle_skill_command(sk, current_actor, target)
         @battle_ui[:battle].command_skill(current_actor, target,
                                           name: sk.name, cost: c[:cost],
-                                          hp: c[:hp], mp: c[:mp])
+                                          hp: c[:hp], mp: c[:mp],
+                                          inflict: c[:inflict], chance: c[:chance])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1265,13 +1265,17 @@ end
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
                        :affect_hp, :affect_sp, :occasion_battle,
-                       :state_effects, :reverse_state_effect)
+                       :state_effects, :reverse_state_effect, :hit)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
-               occ_battle: true, state_effects: nil, reverse_state: false)
+               occ_battle: true, state_effects: nil, reverse_state: false, hit: 100)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
-                prate, mrate, hp, sp, occ_battle, state_effects, reverse_state)
+                prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit)
 end
+# A state-definition lookup for the battle: id -> a row the sim reads for its
+# per-turn slip damage (hp/sp change) and action restriction.
+FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
+                          :sp_change_val, :sp_change_max)
 class FakeActorDB
   attr_reader :player, :system, :item, :skill
   def initialize(players, party_ids, items = {}, skills = {})
@@ -3575,13 +3579,63 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # atk 10, spi 12, maxSP 30
   foe = combatant('Foe', 0, 8, 5, 100)                      # def 8
   # skill_effect = 20 + 40*12/40 = 32; attack dmg = 32 - 8/4 = 30
-  eq({ cost: 6, hp: -30, mp: 0 },
+  eq({ cost: 6, hp: -30, mp: 0, inflict: [], chance: 100 },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
   eq({ cost: 5, hp: 32, mp: 0 },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))
   # Cure affects HP and SP: effect = 10 + 40*12/40 = 22
   eq({ cost: 4, hp: 22, mp: 22 },
      st.party.battle_skill_command(st.party.db_skill(9), caster, nil))
+end
+
+check 'a battle attack skill inflicts its state_effects on a surviving enemy' do
+  skills = { 7 => fake_skill(name: 'Poison Sting', scope: 0, sp_cost: 3, power: 20,
+                             mrate: 40, state_effects: [0, 0, 1], hit: 100) }
+  st = skill_party(skills)
+  mage = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+  c = st.party.battle_skill_command(st.party.db_skill(7), mage, foe)
+  eq [3], c[:inflict], 'state_effects -> state id 3'
+  eq 100, c[:chance]
+  bat = Game::Battle.new([mage], [foe], Game::Rng.new(1))
+  bat.command_skill(mage, foe, name: 'Poison Sting', cost: c[:cost],
+                    hp: c[:hp], mp: c[:mp], inflict: c[:inflict], chance: c[:chance])
+  bat.run_round
+  eq true, foe.state?(3)                        # inflicted on the surviving enemy
+end
+
+check 'a battle attack skill at 0% accuracy never inflicts its state' do
+  skills = { 7 => fake_skill(name: 'Dud', scope: 0, sp_cost: 3, power: 20,
+                             mrate: 40, state_effects: [0, 0, 1], hit: 0) }
+  st = skill_party(skills)
+  mage = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+  c = st.party.battle_skill_command(st.party.db_skill(7), mage, foe)
+  eq 0, c[:chance]
+  bat = Game::Battle.new([mage], [foe], Game::Rng.new(1))
+  bat.command_skill(mage, foe, name: 'Dud', cost: c[:cost], hp: c[:hp], mp: c[:mp],
+                    inflict: c[:inflict], chance: c[:chance])
+  bat.run_round
+  eq false, foe.state?(3)                        # 0% -> never lands
+end
+
+check 'a skill-inflicted "do nothing" state then skips the enemy turn' do
+  # Sleep inflicts state 4; the state table marks 4 as restriction 1 (do nothing).
+  skills = { 7 => fake_skill(name: 'Sleep', scope: 0, sp_cost: 3, power: 1,
+                             state_effects: [0, 0, 0, 1], hit: 100) }
+  states = { 4 => FakeStateDef.new(1, 0, 0, 0, 0) }
+  st = skill_party(skills)
+  hero = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 40, 0, 1, 100)          # slow (acts after the hero)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), states)
+  c = st.party.battle_skill_command(st.party.db_skill(7), hero, foe)
+  bat.command_skill(hero, foe, name: 'Sleep', cost: c[:cost], hp: c[:hp], mp: c[:mp],
+                    inflict: c[:inflict], chance: c[:chance])
+  bat.run_round
+  eq true, foe.state?(4), 'the foe was put to sleep'
+  hp_before = hero.hp
+  bat.run_round                                  # next round: the asleep foe skips
+  eq hp_before, hero.hp, 'the sleeping foe did not attack'
 end
 
 check 'Battle command_skill resolves an attack skill: damage lands, SP is spent' do
@@ -3695,10 +3749,6 @@ check 'battle carries an actor status through unchanged when nothing cures it' d
   eq true, hero.state?(5)                       # the status survived the battle
 end
 
-# A state-definition lookup for the battle: id -> a row the sim reads for its
-# per-turn slip damage (hp/sp change) and action restriction.
-FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
-                          :sp_change_val, :sp_change_max)
 
 check 'battle poison slips HP each turn (fixed val + percent of max)' do
   states = { 2 => FakeStateDef.new(0, 5, 10, 0, 0) } # 5 + 10% of max HP / turn

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1273,9 +1273,10 @@ def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                 prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
-# per-turn slip damage (hp/sp change) and action restriction.
+# per-turn slip damage (hp/sp change), action restriction and auto-recovery.
 FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
-                          :sp_change_val, :sp_change_max)
+                          :sp_change_val, :sp_change_max,
+                          :hold_turn, :auto_release_prob)
 class FakeActorDB
   attr_reader :player, :system, :item, :skill
   def initialize(players, party_ids, items = {}, skills = {})
@@ -3803,6 +3804,29 @@ check 'battle states stay inert without a state-definition lookup' do
   bat.begin_round
   bat.step_action
   eq 100, hero.hp                                    # nothing slipped
+end
+
+check 'battle state auto-recovers once it has held past hold_turn' do
+  # hold_turn 1, 100% release: eligible only once the counter exceeds 1.
+  states = { 5 => FakeStateDef.new(0, 0, 0, 0, 0, 1, 100) }
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [5]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.run_round
+  eq true, hero.state?(5)                            # turn 1: counter 1, not > 1
+  bat.run_round
+  eq false, hero.state?(5)                           # turn 2: counter 2 > 1 -> cured
+end
+
+check 'battle state at 0% auto_release_prob never wears off on its own' do
+  states = { 5 => FakeStateDef.new(0, 0, 0, 0, 0, 0, 0) } # hold 0, prob 0
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [5]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  3.times { bat.run_round }
+  eq true, hero.state?(5)                            # 0% -> stays for the whole fight
 end
 
 check 'Battle end_round clears a queued Skill / Item command' do


### PR DESCRIPTION
Two related battle-status increments (after the carry-through / item-cure and per-turn slip/skip effects in #262), completing most of the afflicted-battler lifecycle.

## 1. Attack skills inflict states

- **`battle_skill_command`** — an enemy-scope (0) attack skill carries its `state_effects` (index `i` → state id `i+1`) and its **`hit` accuracy** as the roll chance.
- **`apply_command`** rolls each candidate against the chance on a **surviving** target (`roll_inflict`) and adds it to the target combatant's `states`. A defeated target isn't afflicted; a state already present isn't re-rolled.
- `command_skill` threads the inflict set + chance; `Scene::Map#apply_pending_skill` passes them from the menu.

So a Poison Sting inflicts poison (slips HP each turn) or a Sleep spell inflicts a "do nothing" state (skips the foe's turn) — grounded on EasyRPG's skill to-hit.

## 2. States auto-recover

- Each `Combatant` keeps a **per-state turn counter** (`state_turns`). At the start of a battler's turn, `apply_turn_states` first rolls each afflicting state for auto-recovery — once the counter passes the state's **`hold_turn`**, an **`auto_release_prob`%** roll (0 = never) cures it — before applying that turn's slip / restriction to the states that remain.
- So a temporary poison/sleep fades after a few turns, while a permanent ailment (0% release) stays. Grounded on EasyRPG's `BattleStateHeal`.

Together with #262 the battle status lifecycle is now: **inflict** (skill) → **behave** (slip / skip) → **recover** (auto or via a battle item cure) → **persist** out.

## Tests

New `scripts/rpg2k_logic_check.rb` checks: 100%/0% skill infliction, an inflicted "do nothing" state skipping the enemy's next turn; a state auto-recovering only after holding past `hold_turn`, and a 0%-release state never wearing off. `FakeSkill` gained `hit`; `FakeStateDef` gained `hold_turn`/`auto_release_prob`; the `battle_skill_command` shape assertion updated. **259 logic + 78 scene + 35 render checks pass; save-load OK.**

## Follow-up

Enemy-cast infliction (enemy attacks/skills applying states to the party) and forced-attack restrictions (confusion / provoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj