### PR TITLE
mruby-rgss: honour RGSS::Window#stretch (tiled background)

### DIFF
--- a/changelog.d/rpgxp-rgss-window-stretch.added.md
+++ b/changelog.d/rpgxp-rgss-window-stretch.added.md
@@ -1,0 +1,5 @@
+- **`RGSS::Window#stretch` is now honoured.** With the default (`true`) the 128×128
+  windowskin background tile is stretched over the whole window as before; setting
+  it `false` tiles that background at 1:1, repeating it across the window (edge
+  tiles clip against the canvas), matching RMXP. `stretch=` is native and re-renders
+  on assignment. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -96,8 +96,9 @@ one axis and the centre fills the rest, so the selection box keeps a sharp borde
 at any size. So the whole menu/message/shop/battle UI renders — framed windows,
 text, selection cursor and message pause. The content blit already clips to the
 content area (its source rect is the content-area size, so taller `contents` are
-cropped and scrolled, not overflowed). **Remaining:** `stretch` (tiled vs stretched
-background) is ignored, and the RMXP windowskin source-rect constants are
+cropped and scrolled, not overflowed). `stretch=` picks between the stretched
+(default) windowskin background and a tiled one (the 128×128 tile repeated at 1:1
+across the window). **Remaining:** the RMXP windowskin source-rect constants are
 best-effort until a game exercises them.
 
 ### 3. `Tilemap` ⚠️ (tiles + animated autotiles rendered; priority layering pending)

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -236,14 +236,13 @@ module RGSS
   # `pause`). `update` advances the blink/pause animation and redraws. Almost the
   # whole surface is native — `initialize`, `contents=`, `windowskin=`, `x=`,
   # `y=`, `width=`, `height=`, `ox=`, `oy=`, `opacity=`, `back_opacity=`,
-  # `contents_opacity=`, `cursor_rect=`, `active=`, `pause=`, `update`, `z=`,
-  # `visible`/`visible=`, `dispose`/`disposed?`. This reopening only adds the
-  # plain readers (and their RGSS defaults) plus `stretch`, which the tiling-vs-
-  # stretch background choice does not yet distinguish.
+  # `contents_opacity=`, `cursor_rect=`, `active=`, `pause=`, `stretch=`,
+  # `update`, `z=`, `visible`/`visible=`, `dispose`/`disposed?`. `stretch=` picks
+  # between the stretched (default) and tiled windowskin background. This reopening
+  # only adds the plain readers and their RGSS defaults.
   class Window
     attr_reader :contents, :windowskin, :x, :y, :width, :height, :ox, :oy, :z,
                 :viewport, :contents_opacity
-    attr_writer :stretch
 
     def opacity
       @opacity.nil? ? 255 : @opacity

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -3375,11 +3375,26 @@ void window_refresh(mrb_state* M, mrb_value self) {
   if (mrb_test(skin) && DATA_PTR(skin)) {
     const mrb_int op = clamp_opacity(M, self, "@opacity");
     const mrb_int back = op * clamp_opacity(M, self, "@back_opacity") / 255;
-    // Background: stretch the 128x128 tile at (0,0) over the whole window.
-    const mrb_value bg[] = {make_rect(M, 0, 0, w, h), skin,
-                            make_rect(M, 0, 0, 128, 128),
-                            mrb_fixnum_value(back)};
-    mrb_funcall_argv(M, canvas, sblt, 4, bg);
+    // Background from the 128x128 tile at (0,0). RMXP's `stretch` (default
+    // true) scales that tile over the whole window; when false it is tiled at
+    // 1:1, repeating across the window (edge tiles clip against the canvas).
+    const mrb_value st = mrb_iv_get(M, self, mrb_intern_lit(M, "@stretch"));
+    const bool stretch = mrb_nil_p(st) ? true : mrb_test(st);
+    if (stretch) {
+      const mrb_value bg[] = {make_rect(M, 0, 0, w, h), skin,
+                              make_rect(M, 0, 0, 128, 128),
+                              mrb_fixnum_value(back)};
+      mrb_funcall_argv(M, canvas, sblt, 4, bg);
+    } else {
+      for (mrb_int ty = 0; ty < h; ty += 128) {
+        for (mrb_int tx = 0; tx < w; tx += 128) {
+          const mrb_value bg[] = {mrb_fixnum_value(tx), mrb_fixnum_value(ty),
+                                  skin, make_rect(M, 0, 0, 128, 128),
+                                  mrb_fixnum_value(back)};
+          mrb_funcall_argv(M, canvas, blt, 5, bg);
+        }
+      }
+    }
     // Frame: the 64x64 border at (128,0), a 9-slice with 16px corners/margins.
     const mrb_value tl[] = {mrb_fixnum_value(0), mrb_fixnum_value(0), skin,
                             make_rect(M, 128, 0, b, b), mrb_fixnum_value(op)};
@@ -3616,6 +3631,14 @@ mrb_value window_set_pause(mrb_state* M, mrb_value self) {
   mrb_bool v;
   mrb_get_args(M, "b", &v);
   mrb_iv_set(M, self, mrb_intern_lit(M, "@pause"), mrb_bool_value(v));
+  window_refresh(M, self);
+  return self;
+}
+
+mrb_value window_set_stretch(mrb_state* M, mrb_value self) {
+  mrb_bool v;
+  mrb_get_args(M, "b", &v);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@stretch"), mrb_bool_value(v));
   window_refresh(M, self);
   return self;
 }
@@ -4077,6 +4100,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
                     MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "active=", window_set_active, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "pause=", window_set_pause, MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "stretch=", window_set_stretch, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "update", window_update, MRB_ARGS_NONE());
   mrb_define_method(M, window, "z=", obj_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "visible", obj_visible, MRB_ARGS_NONE());

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -580,7 +580,7 @@ assert "RGSS::Window API surface" do
   %i[contents= x= y= width= height= ox= oy= contents_opacity= z= visible
      visible= dispose disposed? windowskin windowskin= cursor_rect cursor_rect=
      opacity opacity= back_opacity back_opacity= cursor_rect= active active=
-     pause pause= stretch update].each do |m|
+     pause pause= stretch stretch= update].each do |m|
     assert_true RGSS::Window.method_defined?(m), "Window##{m} missing"
   end
 end


### PR DESCRIPTION
## What

`RGSS::Window#stretch` is now honoured. With the default (`true`) the 128×128
windowskin background tile is stretched over the whole window as before; setting it
`false` tiles that background at 1:1, matching RMXP.

## How

- In `window_refresh`, when `stretch` is false the background is drawn by blitting
  the `(0,0,128,128)` tile at 128px steps across the window; edge tiles clip against
  the canvas. `stretch` (default `true`) keeps the single `stretch_blt`.
- `stretch=` is now a **native** setter (was a Ruby `attr_writer` that didn't
  re-render); it stores the flag and re-refreshes, mirroring `active=`/`pause=`.
- The reader (defaulting to `true`) stays in `mrblib`. Test surface, gap doc (item
  #2) and a changelog fragment updated.

## Testing

Compile-verified via the `mruby-rgss/test` surface check (`stretch=` is in the
asserted Window surface). The windowskin compositing needs a live display, so the
tiling itself is exercised by game runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_