### PR TITLE
RPG2000 battle: forced-action restrictions (berserk/confused) + damage variance

### DIFF
--- a/changelog.d/rpg2k-battle-damage-variance.added.md
+++ b/changelog.d/rpg2k-battle-damage-variance.added.md
@@ -1,0 +1,12 @@
+- RPG Maker 2000: **basic attacks now vary their damage**. `Game::Battle` gains
+  an opt-in `variance` flag; when set, each basic attack spreads its base damage
+  by RPG2000's normal-attack variance (a `var` of 4 — an adjustment of
+  `var*base/10`, min 1, centred on the base with a random offset and floored at
+  1), a port of EasyRPG's `Algo::VarianceAdjustEffect`. `Scene::Map` turns it on
+  for the live game, so two hits from the same attacker differ; it stays **off by
+  default** so seeded / headless fights remain exactly reproducible and the
+  existing battle checks are unaffected. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks (a hit lands within its computed spread,
+  the spread is seed-deterministic and varies across many hits, and a
+  variance-off fight still deals exactly the base damage). Skill / item damage
+  variance and criticals remain follow-ups.

--- a/changelog.d/rpg2k-battle-forced-restrictions.added.md
+++ b/changelog.d/rpg2k-battle-forced-restrictions.added.md
@@ -1,0 +1,12 @@
+- RPG Maker 2000: **"forced action" status restrictions now steer a battler's
+  attack**, completing the battle `restriction` handling (alongside the existing
+  "do nothing" skip). A state with `restriction` 2 (berserk / provoke) forces the
+  battler into a basic attack on a random living **enemy** even when it was told
+  to defend or cast, and `restriction` 3 (confused) sends that attack at a random
+  member of its **own side** (itself included) instead of the enemy — so a
+  confusion spell turns a foe against its allies, and a berserk state denies the
+  target its chosen command. The restriction overrides the queued command / defend
+  for that turn; the values follow `lcf::rpg::State::Restriction`. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks (a confused battler spares the enemy and
+  hits its own side; a berserk battler attacks despite a defend command). Enemy-
+  cast infliction remains the main state-system follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -331,9 +331,12 @@ The work below is roughly ordered by the critical path to a walkable game
   afflicts the foe, which then slips or skips via the per-turn processing above.
   A state also **auto-recovers**: a per-battler turn counter lets `apply_turn_
   states` roll `auto_release_prob` once the state has held past its `hold_turn`,
-  so a temporary ailment wears off. Still to come: forced-attack restrictions,
-  enemy-cast infliction, criticals / attributes / damage variance, all-target
-  skill/item scopes, the per-terrain backdrop and the RPG2000 Game Over graphic.
+  so a temporary ailment wears off. **Forced-action restrictions** work too: a
+  `restriction` of 2 (berserk) forces a basic attack on a random enemy even when
+  the battler was told to defend, and 3 (confused) sends the attack at a random
+  member of its own side. Still to come: enemy-cast infliction, criticals /
+  attributes / damage variance, all-target skill/item scopes, the per-terrain
+  backdrop and the RPG2000 Game Over graphic.
   The remaining event commands (Inflict Damage, Name Input, Show Battle
   Animation, vehicle boarding, tile substitution, ...) are TODO. **Change System
   Graphics** (10680) overrides the windowskin / font (save chunks 15 / 17; the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -334,9 +334,11 @@ The work below is roughly ordered by the critical path to a walkable game
   so a temporary ailment wears off. **Forced-action restrictions** work too: a
   `restriction` of 2 (berserk) forces a basic attack on a random enemy even when
   the battler was told to defend, and 3 (confused) sends the attack at a random
-  member of its own side. Still to come: enemy-cast infliction, criticals /
-  attributes / damage variance, all-target skill/item scopes, the per-terrain
-  backdrop and the RPG2000 Game Over graphic.
+  member of its own side. Basic attacks apply RPG2000's **damage variance** (a
+  `var` of 4 spread via `Algo::VarianceAdjustEffect`), enabled for the live game
+  and off for seeded / headless fights. Still to come: enemy-cast infliction,
+  criticals / attributes / skill damage variance, all-target skill/item scopes,
+  the per-terrain backdrop and the RPG2000 Game Over graphic.
   The remaining event commands (Inflict Damage, Name Input, Show Battle
   Animation, vehicle boarding, tile substitution, ...) are TODO. **Change System
   Graphics** (10680) overrides the windowskin / font (save chunks 15 / 17; the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2801,16 +2801,23 @@ module Game
     # `sp_change_max`, e.g. the database's `situation` table). When given, a
     # battler's afflicted states take effect each turn (slip damage, skip if it
     # cannot act); omitted, states are inert as before.
-    def initialize(allies, enemies, rng = nil, states = nil)
+    # `variance`, when true, applies RPG2000's +/- spread to each basic attack's
+    # damage (a `var` of 4, per EasyRPG's Algo::VarianceAdjustEffect). Off by
+    # default so a seeded fight is exactly reproducible; the live game turns it on.
+    def initialize(allies, enemies, rng = nil, states = nil, variance = false)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
       @states = states
+      @variance = variance
       @rounds = 0
       @result = nil
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
     end
+
+    # RPG2000 normal-attack damage variance on the 0-10 `var` scale.
+    NORMAL_ATTACK_VARIANCE = 4
 
     # State `restriction` values (lcf::rpg::State::Restriction): the battler
     # cannot act (asleep / paralysed), is forced to attack a random enemy
@@ -3024,13 +3031,26 @@ module Game
       deal_attack(b, target)
     end
 
-    # `b` lands a basic attack on `target`, halved (min 1) if the target defends.
+    # `b` lands a basic attack on `target`: the base damage (optionally spread by
+    # variance), halved (min 1) if the target defends.
     def deal_attack(b, target)
       dmg = Battle.attack_damage(b.atk, target.def)
+      dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance
       dmg = [dmg / 2, 1].max if target.defending
       target.hp -= dmg
       { attacker: b.name, target: target.name, damage: dmg,
         target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead? }
+    end
+
+    # Spread `base` by a `var` (0-10) amount: an adjustment of `var*base/10` (min
+    # 1) is centred on the base with a random offset, floored at 1. Port of
+    # EasyRPG's Algo::VarianceAdjustEffect.
+    def varied(base, var)
+      return base unless var > 0 && base > 0
+      adj = var * base / 10
+      adj = 1 if adj < 1
+      d = base + @rng.random(adj + 1) - adj / 2
+      d < 1 ? 1 : d
     end
 
     # The most disruptive "forced action" restriction among `b`'s states (0 = act

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2812,8 +2812,12 @@ module Game
       @queue = []    # battlers still to act this round, in agility order
     end
 
-    # State `restriction` value meaning "cannot act" (asleep / paralysed).
-    RESTRICTION_DO_NOTHING = 1
+    # State `restriction` values (lcf::rpg::State::Restriction): the battler
+    # cannot act (asleep / paralysed), is forced to attack a random enemy
+    # (berserk / provoke), or attacks a random member of its own side (confused).
+    RESTRICTION_DO_NOTHING   = 1
+    RESTRICTION_ATTACK_ENEMY = 2
+    RESTRICTION_ATTACK_ALLY  = 3
 
     # True once one side has been wiped out (the battle is decided).
     def finished?; !alive?(@allies) || !alive?(@enemies); end
@@ -3006,15 +3010,49 @@ module Game
     # has no living target). A defending target takes half damage (min 1). An
     # ally with a queued Skill / Item command resolves that instead.
     def strike(b)
+      # A "forced action" restriction (berserk / confused) overrides the chosen
+      # command / defend with a basic attack on a forced target.
+      r = battler_restriction(b)
+      if r == RESTRICTION_ATTACK_ENEMY || r == RESTRICTION_ATTACK_ALLY
+        target = restricted_target(b, r)
+        return target ? deal_attack(b, target) : nil
+      end
       return apply_command(b) if b.command
       return nil if side_of(b) == :ally && b.defending # defending = no attack
       target = attack_target(b)
       return nil unless target
+      deal_attack(b, target)
+    end
+
+    # `b` lands a basic attack on `target`, halved (min 1) if the target defends.
+    def deal_attack(b, target)
       dmg = Battle.attack_damage(b.atk, target.def)
       dmg = [dmg / 2, 1].max if target.defending
       target.hp -= dmg
       { attacker: b.name, target: target.name, damage: dmg,
         target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead? }
+    end
+
+    # The most disruptive "forced action" restriction among `b`'s states (0 = act
+    # normally). A "do nothing" state has already skipped the turn upstream, so
+    # only the attack-enemy / attack-ally restrictions matter here; the higher
+    # value (attack-ally) wins when several are present.
+    def battler_restriction(b)
+      r = 0
+      (b.states || []).each do |id|
+        v = state_field(state_def(id), :restriction)
+        r = v if v > r && (v == RESTRICTION_ATTACK_ENEMY || v == RESTRICTION_ATTACK_ALLY)
+      end
+      r
+    end
+
+    # A random living target for a forced attack: an enemy (attack-enemy) or a
+    # member of the battler's own side including itself (attack-ally / confusion).
+    def restricted_target(b, r)
+      own = side_of(b) == :ally ? @allies : @enemies
+      pool = r == RESTRICTION_ATTACK_ALLY ? own : (side_of(b) == :ally ? @enemies : @allies)
+      living = pool.reject(&:dead?)
+      living.empty? ? nil : living[@rng.random(living.size)]
     end
 
     # The living target `b` attacks: an ally uses its chosen target while it

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1821,7 +1821,7 @@ class RPG2k
         situations = db.respond_to?(:situation) ? db.situation : nil
         @battle_ui = { phase: :command, req: req, troop: troop,
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
-                                                situations),
+                                                situations, true),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3379,6 +3379,42 @@ check 'Battle.attack_damage is half attack less a quarter defence, min 1' do
   eq 1,  Game::Battle.attack_damage(0, 0)
 end
 
+# base 20 (atk 40 vs def 0); variance 4 -> adj = 8, spread 20-4 .. 20+8-4 = 16..24.
+def variance_hit(seed)
+  hero = combatant('Hero', 40, 0, 20, 100)
+  slime = combatant('Slime', 0, 0, 5, 1000)          # tanky, survives the hit
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(seed), nil, true)
+  bat.begin_round
+  bat.step_action[:damage]
+end
+
+check 'battle damage variance spreads a basic attack within its range' do
+  d = variance_hit(1)
+  ok d >= 16 && d <= 24, "in 16..24 (got #{d})"
+end
+
+check 'battle damage variance is seed-deterministic' do
+  eq variance_hit(1), variance_hit(1), 'same seed -> same damage'
+end
+
+check 'battle damage variance produces a spread of values across hits' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  slime = combatant('Slime', 0, 0, 5, 100_000)       # huge HP: many hits land
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, true)
+  20.times { bat.run_round }
+  hits = bat.log.select { |e| e[:attacker] == 'Hero' }.map { |e| e[:damage] }
+  ok hits.uniq.length > 1, "variance spreads damage (#{hits.uniq.sort.inspect})"
+  ok hits.all? { |d| d >= 16 && d <= 24 }, 'every hit within 16..24'
+end
+
+check 'without variance a seeded fight deals exactly the base damage' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  slime = combatant('Slime', 0, 0, 5, 1000)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))  # 3-arg: variance off
+  bat.begin_round
+  eq 20, bat.step_action[:damage]                    # exact base, unaffected
+end
+
 check 'Battle: a stronger party wins, a weaker one is defeated' do
   hero = combatant('Hero', 40, 20, 20, 200)
   slime = combatant('Slime', 8, 4, 5, 30)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3829,6 +3829,29 @@ check 'battle state at 0% auto_release_prob never wears off on its own' do
   eq true, hero.state?(5)                            # 0% -> stays for the whole fight
 end
 
+check 'battle: a confused battler (restriction 3) attacks its own side' do
+  states = { 6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0) } # attack-ally (confusion)
+  hero = combatant('Hero', 40, 0, 1, 100)                 # slow: the foe acts first
+  hero.states = [6]
+  slime = combatant('Slime', 0, 0, 5, 100)                # harmless enemy (atk 0)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.command_attack(hero, slime)                         # commanded at the enemy...
+  bat.run_round
+  eq 100, slime.hp                                        # ...confusion spared the enemy
+  eq 79, hero.hp                                          # slime's 1 + the hero's own 20
+end
+
+check 'battle: a berserk battler (restriction 2) attacks despite defending' do
+  states = { 7 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0) } # attack-enemy (berserk)
+  hero = combatant('Hero', 40, 0, 20, 100)                # fast: acts first
+  hero.states = [7]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  bat.command_defend(hero)                                # tries to defend...
+  bat.run_round
+  eq 80, slime.hp                                         # ...but berserk forced a 20 hit
+end
+
 check 'Battle end_round clears a queued Skill / Item command' do
   mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
   foe  = combatant('Foe', 0, 0, 5, 100)


### PR DESCRIPTION
Two battle-combat refinements.

## 1. Forced-action restrictions (completes the `restriction` handling)

Alongside the existing "do nothing" skip (#262), a battler can now be **forced to attack**:
- **`restriction` 2 (berserk / provoke)** — a basic attack on a random living **enemy**, even when told to defend or cast.
- **`restriction` 3 (confused)** — the attack is redirected at a random member of the battler's **own side** (itself included).

The restriction overrides the queued command / defend for the turn; `strike` consults `battler_restriction(b)` and hits `restricted_target(b, r)`. Symmetric, so a party confusion skill turns an enemy on its own troop. Values from `lcf::rpg::State::Restriction`.

## 2. Basic-attack damage variance

`Game::Battle` gains an opt-in `variance` flag; when set, each basic attack spreads its base damage by RPG2000's normal-attack variance (a `var` of 4 → an adjustment of `var*base/10`, min 1, centred with a random offset, floored at 1) — a port of EasyRPG's `Algo::VarianceAdjustEffect`. `Scene::Map` turns it on for the live game; it defaults **off** so seeded / headless fights stay exactly reproducible and existing exact-damage checks are unaffected.

The attack body was refactored into a shared `deal_attack(b, target)` used by the normal, forced, and variance paths.

## Tests

New `scripts/rpg2k_logic_check.rb` checks: a confused battler spares the enemy and damages its own side; a berserk battler attacks despite a defend command; a variance hit lands within its computed spread, the spread is seed-deterministic and varies across many hits, and a variance-off fight deals exactly the base. **265 logic + 78 scene + 35 render checks pass; save-load OK.**

## Follow-up

Enemy-cast infliction (enemy attacks applying states to the party — needs enemy action patterns), skill/item damage variance, and criticals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj