### PR TITLE
RPG2000: Control Variables item/party operands + attack-skill damage variance

### DIFF
--- a/changelog.d/rpg2k-battle-skill-variance.added.md
+++ b/changelog.d/rpg2k-battle-skill-variance.added.md
@@ -1,0 +1,9 @@
+- RPG Maker 2000: **attack-skill damage now varies too**, extending the basic-
+  attack variance. A battle skill carries its own `variance` field (0-10, default
+  4) on its command, and `apply_command` spreads the skill's damage by it — via
+  the same `Algo::VarianceAdjustEffect` port — when the fight has variance enabled
+  (the live game; still off for seeded / headless fights, so exact-damage checks
+  hold). Covered by a new `scripts/rpg2k_logic_check.rb` check (a Fire skill's
+  damage stays within its computed spread and varies across casts) and the
+  `battle_skill_command` shape assertion updated for the `variance` key. `FakeSkill`
+  gained `variance`.

--- a/changelog.d/rpg2k-control-var-item-operand.added.md
+++ b/changelog.d/rpg2k-control-var-item-operand.added.md
@@ -1,0 +1,11 @@
+- RPG Maker 2000: the **Control Variables** command now reads **item counts** and
+  the **party size**. Operand type 4 (item) was previously unhandled and silently
+  returned the item id; it now returns the number of that item held in the bag
+  (mode 0) or the number equipped across the whole party (mode 1, each equipping
+  slot counted), matching EasyRPG's `ControlVariables::Item`. Operand type 7
+  (other game quantities) gained selector 2, the number of party members, next to
+  the existing gold and timer selectors. So an event can branch on "how many
+  Potions do I have", "is the sword equipped", or "how big is the party". Covered
+  by new `scripts/rpg2k_logic_check.rb` checks (held vs equipped item counts, and
+  the party-size selector). The event-reference operand (type 6 — an event's or
+  the hero's map id / position / facing) remains a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -217,7 +217,10 @@ The work below is roughly ordered by the critical path to a walkable game
   equipped item's bonuses into the effective stats). **Control
   Variables** reads not just constants and other variables but also a **random**
   range, an **actor stat** (level / EXP / HP / MP / max HP-MP / attack / defence /
-  spirit / agility) and **game quantities** (party gold, timer seconds).
+  spirit / agility), an **item** count (number held, or number equipped across the
+  party) and **game quantities** (party gold, timer seconds, party size). The
+  event-reference operand (map id / position / facing of an event or the hero)
+  is still TODO.
   Conditional Branch covers switch / variable / **timer** / gold / item
   conditions and **all** the **actor** sub-conditions (in party, name, level ≥,
   HP ≥, item equipped, skill known, and **afflicted by a state**). Actors now

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -337,11 +337,12 @@ The work below is roughly ordered by the critical path to a walkable game
   so a temporary ailment wears off. **Forced-action restrictions** work too: a
   `restriction` of 2 (berserk) forces a basic attack on a random enemy even when
   the battler was told to defend, and 3 (confused) sends the attack at a random
-  member of its own side. Basic attacks apply RPG2000's **damage variance** (a
-  `var` of 4 spread via `Algo::VarianceAdjustEffect`), enabled for the live game
-  and off for seeded / headless fights. Still to come: enemy-cast infliction,
-  criticals / attributes / skill damage variance, all-target skill/item scopes,
-  the per-terrain backdrop and the RPG2000 Game Over graphic.
+  member of its own side. Basic attacks **and attack skills** apply RPG2000's
+  **damage variance** (a `var` of 4 for attacks, each skill's own `variance` for
+  skills, spread via `Algo::VarianceAdjustEffect`), enabled for the live game and
+  off for seeded / headless fights. Still to come: enemy-cast infliction,
+  criticals / attributes, all-target skill/item scopes, the per-terrain backdrop
+  and the RPG2000 Game Over graphic.
   The remaining event commands (Inflict Damage, Name Input, Show Battle
   Animation, vehicle boarding, tile substitution, ...) are TODO. **Change System
   Graphics** (10680) overrides the windowskin / font (save chunks 15 / 17; the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1742,6 +1742,12 @@ module Game
       sk.respond_to?(:hit) ? (sk.hit || 100) : 100
     end
 
+    # A skill's damage variance (its `variance` field on the 0-10 scale, default
+    # 4), the spread applied to its battle damage when the fight rolls variance.
+    def skill_variance(sk)
+      sk.respond_to?(:variance) ? (sk.variance || 4) : 4
+    end
+
     # The command numbers for casting `sk` from `caster` on `target` (both
     # Combatant snapshots): the caster's SP `cost`, and the signed HP / SP deltas
     # to the target — negative HP for an attack skill (base effect less a quarter
@@ -1754,7 +1760,8 @@ module Game
         dmg = base - (target ? target.def / 4 : 0)
         dmg = 1 if dmg < 1
         { cost: cost, hp: -dmg, mp: 0,
-          inflict: skill_state_ids(sk), chance: skill_hit(sk) }
+          inflict: skill_state_ids(sk), chance: skill_hit(sk),
+          variance: skill_variance(sk) }
       else
         { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0 }
       end
@@ -2885,10 +2892,11 @@ module Game
     # SP and applying the signed HP / SP deltas (negative HP = damage, positive =
     # recovery) computed by Game::Party#battle_skill_command. Resolved in agility
     # order by #apply_command when the round runs.
-    def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil, chance: 100)
+    def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
+                      chance: 100, variance: 0)
       ally.command = { kind: :skill, target: target, name: name,
                        cost: cost, hp: hp, mp: mp,
-                       inflict: inflict || [], chance: chance }
+                       inflict: inflict || [], chance: chance, variance: variance }
       ally.action = nil; ally.defending = false
     end
 
@@ -3103,6 +3111,8 @@ module Game
       mp = cmd[:mp] || 0
       if hp < 0
         dmg = -hp
+        # Spread the skill's damage by its own variance when the fight rolls it.
+        dmg = varied(dmg, cmd[:variance]) if @variance && cmd[:variance] && cmd[:variance] > 0
         target.hp -= dmg
         # An attack skill may inflict its states on a surviving target, each
         # rolled against the skill's accuracy.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -867,9 +867,22 @@ module Game
       when 1 then variables[cmd.param(5)]                  # variable
       when 2 then variables[variables[cmd.param(5)]]       # variable indirect
       when 3 then random_operand(cmd)                      # random in a range
+      when 4 then item_operand(cmd)                        # item count / equipped
       when 5 then actor_operand(cmd)                       # an actor's stat
       when 7 then other_operand(cmd)                       # gold / timer / ...
       else cmd.param(5)
+      end
+    end
+
+    # Operand type 4: a count for the item with id param5. param6 selects the
+    # mode: 0 the number held in the bag, 1 the number equipped across the party
+    # (each slot equipping it counts). Matches EasyRPG's ControlVariables::Item.
+    def item_operand(cmd)
+      id = cmd.param(5)
+      if cmd.param(6) == 1
+        party.actors.reduce(0) { |n, a| n + a.equipment.count(id) }
+      else
+        party.item_count(id)
       end
     end
 
@@ -904,12 +917,13 @@ module Game
     end
 
     # Operand type 7: a miscellaneous game quantity selected by param5 (0 party
-    # gold, 1 timer seconds). Other selectors (steps, play time, save / battle
-    # counts) are not modelled and read as 0.
+    # gold, 1 timer seconds, 2 the number of party members). Other selectors
+    # (steps, play time, save / battle counts) are not modelled and read as 0.
     def other_operand(cmd)
       case cmd.param(5)
       when 0 then party.gold
       when 1 then @state.timer_seconds
+      when 2 then party.actors.size
       else 0
       end
     end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2047,7 +2047,8 @@ class RPG2k
         @battle_ui[:battle].command_skill(current_actor, target,
                                           name: sk.name, cost: c[:cost],
                                           hp: c[:hp], mp: c[:mp],
-                                          inflict: c[:inflict], chance: c[:chance])
+                                          inflict: c[:inflict], chance: c[:chance],
+                                          variance: c[:variance] || 0)
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2067,6 +2067,27 @@ check 'Control Variables reads party gold and the timer (operand type 7)' do
   eq 90, st.variables[2]
 end
 
+check 'Control Variables reads the party size (operand type 7, selector 2)' do
+  st = party_state                                             # 2 members
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 7, 2])]) # var1 = party size
+  it.update
+  eq 2, st.variables[1]
+end
+
+check 'Control Variables reads item count and equipped count (operand type 4)' do
+  st = party_state
+  st.party.gain_item(7, 3)                                     # 3 of item 7 in the bag
+  st.party.actor_by_id(1).equip([7, 0, 0, 0, 0])              # hero equips item 7
+  st.party.actor_by_id(2).equip([0, 7, 0, 0, 0])              # ally equips item 7
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 4, 7, 0]),   # var1 = held
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 4, 7, 1])])  # var2 = equipped
+  it.update
+  eq 3, st.variables[1]                                        # 3 held in the bag
+  eq 2, st.variables[2]                                        # two members equip it
+end
+
 check 'Control Variables reads an actor stat (operand type 5)' do
   st = party_state
   a = st.party.actor_by_id(1) # atk 10, max_hp 100

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1265,12 +1265,14 @@ end
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
                        :affect_hp, :affect_sp, :occasion_battle,
-                       :state_effects, :reverse_state_effect, :hit)
+                       :state_effects, :reverse_state_effect, :hit, :variance)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
-               occ_battle: true, state_effects: nil, reverse_state: false, hit: 100)
+               occ_battle: true, state_effects: nil, reverse_state: false, hit: 100,
+               variance: 4)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
-                prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit)
+                prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
+                variance)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
 # per-turn slip damage (hp/sp change), action restriction and auto-recovery.
@@ -3436,6 +3438,28 @@ check 'without variance a seeded fight deals exactly the base damage' do
   eq 20, bat.step_action[:damage]                    # exact base, unaffected
 end
 
+check 'battle skill damage varies by the skill variance when the fight rolls it' do
+  skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
+                             mrate: 40, variance: 4) }
+  st = skill_party(skills)
+  mage = Game::Battle.from_actor(st.party.actor_by_id(1))    # spi 12 -> effect 32
+  slime = combatant('Slime', 0, 0, 5, 100_000)               # def 0, tanky
+  bat = Game::Battle.new([mage], [slime], Game::Rng.new(1), nil, true) # variance on
+  c = st.party.battle_skill_command(st.party.db_skill(7), mage, slime) # base 32
+  dmgs = []
+  20.times do
+    bat.command_skill(mage, slime, name: 'Fire', cost: c[:cost], hp: c[:hp],
+                      mp: c[:mp], inflict: c[:inflict], chance: c[:chance],
+                      variance: c[:variance])
+    e = bat.run_round.find { |x| x[:skill] == 'Fire' }
+    dmgs << e[:damage] if e
+    break if bat.finished?
+  end
+  # base 32, var 4 -> adj = 12, spread 32-6 .. 32+12-6 = 26..38.
+  ok dmgs.uniq.length > 1, "skill damage varies (#{dmgs.uniq.sort.inspect})"
+  ok dmgs.all? { |d| d >= 26 && d <= 38 }, "within 26..38 (#{dmgs.inspect})"
+end
+
 check 'Battle: a stronger party wins, a weaker one is defeated' do
   hero = combatant('Hero', 40, 20, 20, 200)
   slime = combatant('Slime', 8, 4, 5, 30)
@@ -3637,7 +3661,7 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # atk 10, spi 12, maxSP 30
   foe = combatant('Foe', 0, 8, 5, 100)                      # def 8
   # skill_effect = 20 + 40*12/40 = 32; attack dmg = 32 - 8/4 = 30
-  eq({ cost: 6, hp: -30, mp: 0, inflict: [], chance: 100 },
+  eq({ cost: 6, hp: -30, mp: 0, inflict: [], chance: 100, variance: 4 },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
   eq({ cost: 5, hp: 32, mp: 0 },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))


### PR DESCRIPTION
Two small, independent RPG2000 logic increments (bundled because the working branch was occupied; each has its own changelog fragment).

## 1. Control Variables: item counts + party size

Fills two gaps in the Control Variables command's operand handling:
- **Operand type 4 (item)** was unhandled and silently returned the item id. It now returns the number **held in the bag** (mode 0) or the number **equipped across the party** (mode 1, each slot counted) — matching EasyRPG's `ControlVariables::Item`.
- **Operand type 7 (other)** gains **selector 2 — the party member count** — beside gold (0) and timer (1).

So an event can branch on "how many Potions do I have", "is the sword equipped", or "how big is the party" — all previously read a wrong value.

## 2. Attack-skill damage variance

Extends the basic-attack damage variance (#270) to skills:
- `battle_skill_command` carries each skill's own **`variance`** field (0–10, default 4) on its command; `apply_command` spreads the skill's damage by it (same `Algo::VarianceAdjustEffect` port) when the fight has variance enabled.
- `Scene::Map` passes it through; **off by default** for seeded / headless fights, so exact-damage checks hold.

## Tests

New `scripts/rpg2k_logic_check.rb` checks: held vs equipped item counts and the party-size selector; a Fire skill's damage stays within its computed spread and varies across casts. The `battle_skill_command` shape assertion gained `variance`; `FakeSkill` gained `variance`. **268 logic + 78 scene + 35 render checks pass; save-load OK.**

## Follow-up

Control Variables operand type 6 (event / hero position — needs the running-event context); criticals and enemy-cast state infliction in battle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj