### PR TITLE
mruby-rpgxp: drive the script host's blocking loop via a Fiber (ADR 0023)

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -4,6 +4,11 @@ def rpg_maker_gems(conf)
   conf.gem core: 'mruby-hash-ext'
   conf.gem core: 'mruby-io'
   conf.gem core: 'mruby-numeric-ext'
+  # Fiber: the RGSS script host drives the game's bundled blocking main loop
+  # (`$scene.main while $scene`) one frame at a time through a Fiber so the web
+  # build's per-frame emscripten callback keeps control each frame. Not in the
+  # default gem set (docs/adr/0023-rpgxp-script-host-frame-driver.md).
+  conf.gem core: 'mruby-fiber'
   # Kernel#sprintf / #format and String#%: the RGSS script host runs the game's
   # bundled scripts, which format numbers with sprintf ("%02d" clocks, "%04d"
   # ids, "%+d", "%0*d", …). Not in the default gem set, so pull it in explicitly.

--- a/changelog.d/rpgxp-script-host-fiber-driver.added.md
+++ b/changelog.d/rpgxp-script-host-fiber-driver.added.md
@@ -1,0 +1,10 @@
+- **The RGSS script host now drives the game's blocking main loop one frame at a
+  time via a Fiber.** When `RGSS_SCRIPT_HOST` is on, `RPGXP` runs the bundled
+  scripts' `Main` (`$scene.main while $scene`) inside an mruby `Fiber` and wraps
+  `Graphics.update` to `Fiber.yield` once per frame, so `RPGXP#main_loop` advances
+  exactly one game frame per call — which lets the web build's per-frame
+  `emscripten_set_main_loop` callback keep control each frame instead of hanging on
+  the scripts' blocking loop. The scripts run unmodified and no Asyncify is needed.
+  Gated behind the (off-by-default) `RGSS_SCRIPT_HOST` flag, so the built-in flow is
+  unchanged; `mruby-fiber` is added to the build. See
+  `docs/adr/0023-rpgxp-script-host-frame-driver.md`.

--- a/docs/adr/0023-rpgxp-script-host-frame-driver.md
+++ b/docs/adr/0023-rpgxp-script-host-frame-driver.md
@@ -4,7 +4,8 @@ Date: 2026-08-04
 
 ## Status
 
-Proposed
+Accepted — driver implemented (gated behind `RGSS_SCRIPT_HOST`); needs a real
+project booted under the web build to verify end to end.
 
 ## Context
 

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -166,10 +166,14 @@ still assumed and not yet provided.
   host on by default is reconciling the scripts' blocking `$scene.main while
   $scene` loop with the web build's per-frame `emscripten_set_main_loop` callback
   (the desktop build blocks fine; the web build calls `RPGXP#main_loop` once per
-  browser frame, so an unmodified blocking script loop would hang the tab). The
-  design for this — run `Main` inside an mruby `Fiber` that yields at
-  `Graphics.update`, resumed once per frame — is
-  [ADR 0023](adr/0023-rpgxp-script-host-frame-driver.md).
+  browser frame, so an unmodified blocking script loop would hang the tab). This
+  is now **implemented** ([ADR 0023](adr/0023-rpgxp-script-host-frame-driver.md)):
+  when the host is enabled, `RPGXP` runs `Main` inside an mruby `Fiber` and the
+  wrapped `Graphics.update` yields it once per frame, so `main_loop` drives one
+  game frame per browser callback. It is gated behind `RGSS_SCRIPT_HOST` (off by
+  default), so the built-in flow is unchanged; the remaining step is to boot a real
+  project under the web build with the flag on and confirm it end to end (plus
+  wiring `exit`, the one Kernel built-in the `Interpreter` still assumes).
 - None of the above can be built or run in the current CI sandbox; each item is
   verified by `mruby-rgss/test` (compiled and run in CI) plus the host-side
   `scripts/rpgxp_script_host_check.rb`.

--- a/mruby-rpgxp/mrbgem.rake
+++ b/mruby-rpgxp/mrbgem.rake
@@ -10,6 +10,9 @@ MRuby::Gem::Specification.new('mruby-rpgxp') do |spec|
   # The RGSS script host (script_host.rb) runs the game's bundled Ruby scripts
   # with Kernel#eval.
   add_dependency 'mruby-eval'
+  # The script-host driver runs the scripts' blocking main loop inside a Fiber
+  # (docs/adr/0023-rpgxp-script-host-frame-driver.md).
+  add_dependency 'mruby-fiber'
   # Kernel#sprintf / #format and String#% (used by the stock RGSS scripts, and by
   # the sprintf availability test). It is also enabled in build_config.rb, but
   # declaring the dependency here forces mruby-sprintf to initialize before this

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -41,7 +41,14 @@ class RPGXP
     # game's own Ruby drives everything (see script_host.rb); skip building the
     # built-in title scene, which #start would otherwise run instead.
     @use_script_host = ScriptHost.enabled? && @db.scripts?
-    push Scene::Title.new(self) unless @use_script_host
+    if @use_script_host
+      # The scripts own their whole blocking main loop; drive it one frame at a
+      # time through a Fiber so the web build's per-frame callback still gets
+      # control back each frame (docs/adr/0023-rpgxp-script-host-frame-driver.md).
+      setup_script_host_driver
+    else
+      push Scene::Title.new(self)
+    end
   end
 
   attr_reader :db, :title
@@ -113,7 +120,15 @@ class RPGXP
     false
   end
 
+  # One frame of the game. Both the desktop `loop { main_loop }` and the web
+  # per-frame `emscripten_set_main_loop` callback (src/main.cxx) call this. When
+  # the script host is driving, a frame is one resume of its Fiber (which runs
+  # the scripts' loop up to their next Graphics.update); otherwise it is the
+  # built-in scene/input/graphics tick. The `@host_fiber` guard is nil in the
+  # default flow, so that path is unchanged.
   def main_loop
+    return drive_script_host if @host_fiber
+
     RGSS::Profiler.frame do
       RGSS::Profiler.section("scene.update") { @scenes.last.update }
       RGSS::Profiler.section("input.update") { Input.update }
@@ -122,29 +137,68 @@ class RPGXP
   end
 
   def start
-    return if run_script_host
-    # The built-in flow needs a scene. When the script host was enabled the
-    # title was not built up front, so a fallback here (host returned false or
-    # failed) guarantees one before the loop reads @scenes.last.
-    push Scene::Title.new(self) if @scenes.empty?
-    loop { main_loop }
+    # The built-in flow needs a scene; a script-host boot builds its Fiber in
+    # #initialize instead. `@host_done` only becomes true once the host's Main
+    # returns, so the built-in flow loops forever exactly as before.
+    push Scene::Title.new(self) if @scenes.empty? && !@host_fiber
+    loop do
+      main_loop
+      break if @host_done
+    end
   rescue RGSS::Timeout
   end
 
   private
 
-  # Run the project's bundled RGSS scripts, which own their whole main loop, and
-  # report whether they ran. Any failure to boot the scripts is logged and falls
-  # back to the built-in flow rather than crashing to a blank screen.
-  def run_script_host
-    return false unless @use_script_host
-    ScriptHost.run(@db)
+  # Build the driver Fiber for the bundled scripts and install the per-frame
+  # yield. Only reached when the host is enabled, so the built-in flow never
+  # creates a Fiber nor wraps Graphics.update.
+  def setup_script_host_driver
+    install_graphics_yield
+    db = @db
+    @host_fiber = Fiber.new do
+      ScriptHost.driving = true
+      begin
+        ScriptHost.run(db)
+      ensure
+        ScriptHost.driving = false
+      end
+    end
+  end
+
+  # Advance the script host by one frame. When its Main returns the Fiber is
+  # dead and the game is over; a boot failure logs and falls back to the
+  # built-in flow rather than crashing to a blank screen.
+  def drive_script_host
+    if @host_fiber.alive?
+      @host_fiber.resume
+    else
+      @host_fiber = nil
+      @host_done = true
+    end
   rescue RGSS::Timeout
-    true
+    @host_fiber = nil
+    @host_done = true
   rescue StandardError => e
     $stderr.puts "[RGSS] script host failed (#{e.class}: #{e.message}); " \
                  "falling back to the built-in flow"
-    false
+    @host_fiber = nil
+    @use_script_host = false
+    push Scene::Title.new(self) if @scenes.empty?
+  end
+
+  # Wrap the native Graphics.update so a scene's `loop { Graphics.update; ... }`
+  # yields the driver Fiber once per frame. Idempotent, and installed only on
+  # the script-host path — the built-in flow keeps the pristine native method.
+  def install_graphics_yield
+    return if RGSS::Graphics.respond_to?(:_update_native)
+    RGSS::Graphics.singleton_class.class_eval do
+      alias_method :_update_native, :update
+      def update
+        _update_native
+        Fiber.yield if ::RPGXP::ScriptHost.driving?
+      end
+    end
   end
 
   # The window title from Game.ini's [Game] Title=, falling back to the folder

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -28,6 +28,20 @@ class RPGXP
     # scripts needs both eval and a complete-enough RGSS class library.
     ENABLED_ENV = "RGSS_SCRIPT_HOST".freeze
 
+    # True while the host's blocking `Main` runs inside the driver Fiber (see
+    # RPGXP#setup_script_host_driver). The wrapped Graphics.update reads this to
+    # decide whether to yield the fiber once per frame — so the flag is only ever
+    # set on the script-host path and the built-in flow never yields. See
+    # docs/adr/0023-rpgxp-script-host-frame-driver.md.
+    @driving = false
+    def self.driving?
+      @driving
+    end
+
+    def self.driving=(v)
+      @driving = v
+    end
+
     # Whether the runtime can eval Ruby source at all (mruby-eval present, or
     # CRuby). Kernel#eval is a public method under mruby-eval and a private one
     # under CRuby; the private check is itself CRuby-only (mruby's Module has no

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -95,6 +95,7 @@ class Checker
     puts "  decoded #{sections.size} script sections (e.g. #{sections.first[0].inspect})"
 
     check_eval_available
+    check_driving_flag
     check_kernel_builtins(db)
     check_eval_subset(sections)
   rescue => ex
@@ -103,6 +104,20 @@ class Checker
 
   def check_eval_available
     expect(RPGXP::ScriptHost.available?, "ScriptHost.available? is false (no eval)")
+  end
+
+  # The per-frame Fiber driver reads ScriptHost.driving? from the wrapped
+  # Graphics.update to decide whether to yield (ADR 0023). The wrapping needs the
+  # native runtime, but the flag itself is plain Ruby, so guard its default and
+  # round-trip here.
+  def check_driving_flag
+    expect(RPGXP::ScriptHost.driving? == false,
+           "ScriptHost.driving? should default to false")
+    RPGXP::ScriptHost.driving = true
+    expect(RPGXP::ScriptHost.driving? == true, "ScriptHost.driving= did not set")
+    RPGXP::ScriptHost.driving = false
+    expect(RPGXP::ScriptHost.driving? == false, "ScriptHost.driving= did not clear")
+    puts "  ScriptHost.driving? defaults false and round-trips"
   end
 
   # install_kernel wires load_data/save_data through the database, so a script's


### PR DESCRIPTION
## What

Implements [ADR 0023](https://github.com/take-cheeze/rpg-maker-clone/blob/master/docs/adr/0023-rpgxp-script-host-frame-driver.md):
drives the RGSS script host's blocking main loop one frame at a time so the web
build's per-frame callback keeps control. This is the last structural blocker to
turning the host on by default — now that the display classes render.

## How

- When `RGSS_SCRIPT_HOST` is on, `RPGXP#initialize` builds
  `@host_fiber = Fiber.new { ScriptHost.run(@db) }` instead of pushing the built-in
  title.
- `Graphics.update` is wrapped (idempotent, singleton-method alias) to
  `Fiber.yield` when `ScriptHost.driving?` — so a scene's `loop { Graphics.update; … }`
  advances one iteration per resume.
- `RPGXP#main_loop` resumes the fiber when set; the existing desktop
  `loop { main_loop }` and web `emscripten_set_main_loop(main_loop)` both drive it
  unchanged. `main_loop` returning after one resume = one game frame per browser
  callback.
- Fiber death (Main returns) ends the game cleanly; a boot failure logs and falls
  back to the built-in flow. Adds `mruby-fiber` to the build (`build_config.rb` +
  `mruby-rpgxp` dep).

## Safety: the built-in flow is unchanged

Everything is gated behind `@use_script_host` (off by default):

- The fiber and the `Graphics.update` wrapper are **only** created/installed on the
  host path — the default flow keeps the pristine native `Graphics.update`.
- `main_loop`'s `@host_fiber` guard is nil by default → it takes the original
  scene/input/graphics tick. `start`'s `@host_done` is never set → it loops exactly
  as before.

So the verified default boot path is behaviourally identical.

## Testing

- The `ScriptHost.driving?` flag (default false + round-trip) is covered by a new
  assertion in `scripts/rpgxp_script_host_check.rb` (runs green under CRuby).
- The fiber/`Graphics.update` wrapping needs the native runtime + a live display,
  so it can't be unit-tested. **The real test is booting a project under the web
  build with `RGSS_SCRIPT_HOST=1`** — this is the first point the host path becomes
  exercisable end-to-end. Follow-up: wiring `exit` to end the fiber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_