### PR TITLE
Parallelize MV sample engine build in WASM CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,6 +452,22 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
 
+      # Fetch + build the MIT MV engine into the committed sample so it can be
+      # bundled into the page as a one-click preset (WASM_SAMPLE_DIR below).
+      # Like the `build` job's downloads, this is network-bound work that feeds
+      # nothing in the configure step, so it runs as a `background: true` step
+      # and overlaps the cache restores and `emcmake cmake` below instead of
+      # holding them up. WASM_SAMPLE_DIR is only consumed at *link* time (it
+      # becomes an emcc `--preload-file`, see CMakeLists.txt), and configure
+      # merely resolves the path of the committed data/mv-sample directory, so
+      # the barrier before `build` is early enough. The script is idempotent and
+      # writes only inside data/ (git-ignored engine files plus its
+      # data/.mv-corescript clone), so nothing here races the concurrent steps.
+      - name: Build MV sample engine
+        id: mv-sample
+        background: true
+        run: nix develop -c ./scripts/download-mv-corescript.bash
+
       - uses: actions/cache@v6
         with:
           path: ~/.emscripten_cache
@@ -473,11 +489,6 @@ jobs:
       # command itself (after the hook runs) so the libraries are built once and
       # restored on later runs. It must be set for both configure and build,
       # since emcc runs in both.
-      # Fetch + build the MIT MV engine into the committed sample so it can be
-      # bundled into the page as a one-click preset (WASM_SAMPLE_DIR below).
-      - name: Build MV sample engine
-        run: nix develop -c ./scripts/download-mv-corescript.bash
-
       - name: cmake
         # CMAKE_<LANG>_COMPILER_LAUNCHER is initialised from the environment at
         # configure time and stored in CMakeCache.txt, so setting ccache here is
@@ -490,6 +501,13 @@ jobs:
             CMAKE_CXX_COMPILER_LAUNCHER=ccache \
             emcmake cmake -S . -B wasm-build -GNinja \
             -DWASM_SAMPLE_DIR=data/mv-sample
+
+      # Barrier: the link step packages data/mv-sample into index.data, so the
+      # engine files must be in place before the build starts. A failed
+      # background fetch surfaces here and fails the job, exactly as it did when
+      # this ran inline.
+      - name: Wait for the MV sample engine
+        wait: [mv-sample]
 
       - name: build
         run: |

--- a/changelog.d/ci-wasm-background-mv-sample.changed.md
+++ b/changelog.d/ci-wasm-background-mv-sample.changed.md
@@ -1,0 +1,7 @@
+- CI's `wasm` job now fetches/builds the MV sample engine as a `background: true`
+  step, so the corescript clone overlaps the emcc/ccache cache restores and the
+  `emcmake cmake` configure instead of running strictly before them. A
+  `wait: [mv-sample]` barrier before the build keeps the guarantee the inline
+  step gave: `WASM_SAMPLE_DIR` is consumed at link time (as an emcc
+  `--preload-file` that generates `index.data`), so the engine files are always
+  in place before linking, and a failed fetch still fails the job.


### PR DESCRIPTION
## Summary
Refactored the WASM CI job to build the MIT MV sample engine as a background step, allowing it to overlap with cache restoration and CMake configuration instead of blocking them sequentially.

## Key Changes
- Moved the "Build MV sample engine" step to run as a `background: true` step earlier in the job, positioned right after cache setup
- Added an explicit `wait: [mv-sample]` barrier before the build step to ensure the engine files are in place before linking
- Maintained the same correctness guarantees: the engine files are consumed at link time (as an emcc `--preload-file`), so the barrier before the build step is sufficient to prevent race conditions

## Implementation Details
- The MV sample engine build is network-bound work that doesn't feed into the configure step, making it ideal for parallelization
- The script is idempotent and only writes to the `data/` directory (which is git-ignored), so it doesn't race with concurrent steps
- The barrier is placed before the build step rather than before configure, since `WASM_SAMPLE_DIR` is only consumed at link time when generating `index.data`
- If the background fetch fails, the job still fails at the barrier, preserving the same error behavior as the original inline step

https://claude.ai/code/session_01793hrTrdm1GUQ2qjZ6rmmd