### PR TITLE
Add vehicle BGM playback on boarding and disembarking

### DIFF
--- a/changelog.d/rpg2k-vehicle-bgm.added.md
+++ b/changelog.d/rpg2k-vehicle-bgm.added.md
@@ -1,0 +1,6 @@
+- **Vehicles now play their own BGM.** Boarding a boat / ship / airship switches
+  to the vehicle's database System music (`boat_music` / `ship_music` /
+  `airship_music`), remembering the BGM that was playing; stepping off restores
+  it, so the map's music resumes. A vehicle with no configured BGM leaves the
+  current music playing. Covered by a new check in `scripts/rpg2k_scene_check.rb`
+  (boarding a boat plays the boat BGM and disembarking brings the map BGM back).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -350,7 +350,8 @@ The work below is roughly ordered by the critical path to a walkable game
   the map (`Game::State#boarded`; airship flies over any tile, boat / ship follow
   their terrain). Placed vehicles are **drawn on the map** from their CharSet, the
   ridden one following the party under the hero, and the **airship floats above a
-  ground shadow** (the vehicle's own BGM is still to come). **Enter Hero Name**
+  ground shadow**. Boarding **plays the vehicle's own BGM** (the database System
+  boat / ship / airship music) and disembarking restores the map BGM. **Enter Hero Name**
   (10740) opens a character-entry widget that renames a
   party actor; **Change Level** (10420) / **Change EXP** (10410) honour their
   "show message" flag — a level-up queues one message per level gained, shown

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -474,6 +474,7 @@ class RPG2k
         @wait_timer = nil
         @anim_wait = nil
         @map_animation = nil
+        @pre_vehicle_bgm = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
         # a Move Event targeting "this event" can be resolved. nil for common
@@ -1035,16 +1036,22 @@ class RPG2k
           v = @state.vehicle(type)
           next unless v.placed? && v.map_id == @state.map_id
           if v.x == @state.x && v.y == @state.y
-            @state.boarded = type
+            board_as(type)
             return true
           elsif v.x == fx && v.y == fy
             @state.x = fx
             @state.y = fy
-            @state.boarded = type
+            board_as(type)
             return true
           end
         end
         false
+      end
+
+      # Mark the party aboard `type` and switch to the vehicle's BGM.
+      def board_as(type)
+        @state.boarded = type
+        play_vehicle_bgm(type)
       end
 
       # Step off the ridden vehicle onto the tile ahead when it is walkable on
@@ -1057,7 +1064,51 @@ class RPG2k
         @state.x = fx
         @state.y = fy
         @state.boarded = nil
+        restore_pre_vehicle_bgm # the map BGM resumes
       end
+
+      # Play the vehicle's own BGM (the database System boat / ship / airship
+      # music), remembering the BGM that was playing so #restore_pre_vehicle_bgm
+      # can bring it back on disembark. A vehicle with no configured BGM leaves
+      # the current music playing.
+      def play_vehicle_bgm(type)
+        music = vehicle_bgm(type)
+        name = music && music_name(music)
+        return if name.nil? || name.empty?
+        @pre_vehicle_bgm = @state.current_bgm
+        vol = music_volume(music)
+        tempo = music_tempo(music)
+        RGSS::Audio.bgm_play(name, vol, tempo)
+        @state.current_bgm = { name: name, volume: vol, tempo: tempo }
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] vehicle BGM failed: #{e.message}"
+      end
+
+      # Restore the BGM that was playing before the party boarded (the map BGM).
+      # A no-op when boarding did not switch the music.
+      def restore_pre_vehicle_bgm
+        bgm = @pre_vehicle_bgm
+        @pre_vehicle_bgm = nil
+        return unless bgm && bgm[:name] && !bgm[:name].empty?
+        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
+        @state.current_bgm = bgm
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] restoring BGM failed: #{e.message}"
+      end
+
+      # The database System BGM configured for vehicle `type` (boat / ship /
+      # airship), or nil when the database has none.
+      def vehicle_bgm(type)
+        field = "#{type}_music"
+        return nil unless @db.system.respond_to?(field)
+        @db.system.send(field)
+      end
+
+      # A parsed BGM chunk exposes file / volume / pitch; read them defensively so
+      # a bare fixture that omits a field still works.
+      def music_name(m); m.file rescue nil; end
+      def music_volume(m); (m.volume rescue nil) || 100; end
+      def music_tempo(m); (m.pitch rescue nil) || 100; end
 
       # Keep the ridden vehicle on the party's tile / facing.
       def follow_vehicle

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -149,7 +149,10 @@ end
 
 def fake_db(common = nil)
   OpenStruct.new(
-    system: OpenStruct.new(system_graphic: ''),
+    system: OpenStruct.new(system_graphic: '',
+                           boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
+                           ship_music: OpenStruct.new(file: 'ShipBGM', volume: 80, pitch: 100),
+                           airship_music: OpenStruct.new(file: 'AirBGM', volume: 80, pitch: 100)),
     # A second chipset (id 2) so Change Map Tileset has somewhere to swap to.
     chipset: { 1 => fake_chipset, 2 => fake_chipset('cs2') },
     # Terms the Show Inn window reads; blank greeting fields exercise the
@@ -1728,6 +1731,31 @@ check 'the airship floats above a ground shadow; a boat casts none' do
   boat.charset_name = 'Boat'
   scene.update
   ok !shadow.visible, 'a boat casts no airship shadow'
+end
+
+check 'boarding plays the vehicle BGM; disembarking restores the map BGM' do
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 } # the map's BGM
+  st.direction = 2
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded
+  eq 'BoatBGM', st.current_bgm[:name], 'the boat BGM plays while aboard'
+  eq 80, st.current_bgm[:volume]
+  # face the shore and disembark
+  st.direction = 8
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'disembarked'
+  eq 'Field', st.current_bgm[:name], 'the map BGM resumes on disembark'
 end
 
 check 'Enemy Encounter scene: the round animates action by action, not at once' do


### PR DESCRIPTION
## Summary
Vehicles (boats, ships, airships) now play their own BGM when boarded and restore the previous map BGM when disembarked, matching RPG Maker 2000 behavior.

## Changes
- **New instance variable** `@pre_vehicle_bgm` tracks the BGM playing before boarding so it can be restored on disembark
- **New method `board_as(type)`** extracted from `board_vehicle` to centralize boarding logic and trigger vehicle BGM playback
- **New method `play_vehicle_bgm(type)`** retrieves the vehicle's configured BGM from the database System settings and plays it, storing the previous BGM for restoration
- **New method `restore_pre_vehicle_bgm`** restores the map's BGM when disembarking
- **New helper methods** `vehicle_bgm(type)`, `music_name(m)`, `music_volume(m)`, and `music_tempo(m)` defensively extract BGM data from the database
- **Updated `disembark_vehicle`** to call `restore_pre_vehicle_bgm` when stepping off a vehicle
- **Test coverage** added to verify boarding plays the vehicle BGM and disembarking restores the map BGM
- **Test fixtures** updated with boat/ship/airship BGM configurations
- **Documentation** updated to reflect vehicle BGM as completed

## Implementation Details
- BGM restoration is defensive: if no BGM was stored or the vehicle has no configured BGM, the current music continues uninterrupted
- Error handling wraps BGM operations to prevent audio failures from crashing the interpreter
- The `@state.current_bgm` hash is updated to reflect the active music at all times

https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW