### PR TITLE
Render Tint Screen darkening via black overlay sprite

### DIFF
--- a/changelog.d/rpg2k-tint-screen-render.added.md
+++ b/changelog.d/rpg2k-tint-screen-render.added.md
@@ -1,0 +1,10 @@
+- **Tint Screen now darkens the view.** The Tint Screen (11030) command already
+  drove a `Game::Screen` tone state machine; the darkening half of it now draws.
+  `Scene::Map` overlays a black screen sprite (below the flash / fade overlays)
+  whose opacity approximates how far the tone's channels average below neutral
+  (100), so a night / cave tint visibly dims the map the way RPG_RT does, and a
+  neutral tone clears it. A full tone — the colour cast, brightening above
+  neutral, and saturation — needs native per-pixel tone and is still to come.
+  Covered by a new check in `scripts/rpg2k_scene_check.rb` (a black tint drives a
+  near-opaque overlay, a partial tint a partial one, and a neutral tint clears
+  it).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -397,9 +397,12 @@ The work below is roughly ordered by the critical path to a walkable game
   RPG2000 channels (red/green/blue/saturation, 0..200) toward their target over
   the command's duration (advanced each frame by `Scene::Map`), and the wait
   flag pauses the interpreter until the effect settles (a `:screen` wait,
-  resumed by the scene once `Game::Screen#busy?` clears). The tint is the Ruby
-  half only — **applying** it as an `RGSS::Viewport` tone is native (C++) work
-  still to come, so it does not yet change what is drawn. **Shake Screen**
+  resumed by the scene once `Game::Screen#busy?` clears). The **darkening** half
+  of the tint now draws: `Scene::Map` overlays a black screen sprite (below the
+  flash / fade overlays) whose opacity approximates how far the tone averages
+  below neutral, so a night / cave tint dims the map. A full tone — the colour
+  cast, brightening above neutral and saturation — still needs an
+  `RGSS::Viewport` tone in C++. **Shake Screen**
   (11050) also drives `Game::Screen`: a timed, float-free triangle-wave
   horizontal offset (amplitude from power, rate from speed) that `Scene::Map`
   subtracts from the camera, so — unlike the tint — the shake **is** visible

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -507,7 +507,7 @@ class RPG2k
         close_shop
         close_battle
         [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
-         @picture_sprite, @fade_sprite, @flash_sprite].each do |s|
+         @picture_sprite, @fade_sprite, @flash_sprite, @tint_sprite].each do |s|
           s.dispose if s
         end
         (@vehicle_sprites || {}).each_value { |s| s.dispose if s }
@@ -632,6 +632,16 @@ class RPG2k
         @flash_sprite.bitmap = @flash_bmp
         @flash_sprite.opacity = 0
         @flash_rgb = nil
+
+        # Tint Screen: a black overlay whose opacity approximates the tint's
+        # darkening (below flash / fade, over the map and UI). A full tone
+        # (colour cast, brightening, saturation) is native work still to come.
+        @tint_sprite = Sprite.new
+        @tint_sprite.z = 440
+        @tint_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        @tint_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(0, 0, 0, 255)
+        @tint_sprite.bitmap = @tint_bmp
+        @tint_sprite.opacity = 0
       end
 
       # Push this frame's fade and flash levels onto the two overlay sprites.
@@ -641,6 +651,7 @@ class RPG2k
       def update_screen_overlay
         screen = @state.screen
         @fade_sprite.opacity = screen.fade_level
+        @tint_sprite.opacity = tint_overlay_opacity(screen.tint)
 
         r, g, b, strength = screen.flash_color
         if strength <= 0
@@ -653,6 +664,17 @@ class RPG2k
           end
           @flash_sprite.opacity = strength
         end
+      end
+
+      # Approximate the darkening of a Tint Screen tone (`[r, g, b, sat]`, each
+      # 0..200 with 100 neutral) as the opacity of a black overlay: the further
+      # the channels average below neutral, the darker. Brightening (above 100),
+      # the colour cast and saturation need a real tone and are not applied.
+      def tint_overlay_opacity(tint)
+        r, g, b, = tint
+        avg = (r + g + b) / 3
+        return 0 if avg >= 100
+        (100 - avg) * 255 / 100
       end
 
       # Create the buffer that carries the Show Picture layer. Pictures composite

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1730,6 +1730,26 @@ check 'the airship floats above a ground shadow; a boat casts none' do
   ok !shadow.visible, 'a boat casts no airship shadow'
 end
 
+check 'Tint Screen darkens the view through a black overlay; neutral clears it' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Tint to (0,0,0) sat 100 instantly (0 tenths), no wait — a full darken.
+  auto.event_commands = [ECmd.new(ic::TINT_SCREEN, [0, 0, 0, 100, 0, 0], indent: 0)]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  5.times { scene.update }
+  tint = scene.instance_variable_get(:@tint_sprite)
+  ok tint.opacity > 200, 'a black tint darkens the screen'
+  # A half-darken (50,50,50) reads as roughly half opacity.
+  st.screen.tint_to(50, 50, 50, 100, 0)
+  scene.update
+  ok tint.opacity > 100 && tint.opacity < 160, 'a partial tint is partly opaque'
+  # Neutral (100,100,100) clears the overlay.
+  st.screen.tint_to(100, 100, 100, 100, 0)
+  scene.update
+  eq 0, tint.opacity, 'a neutral tint clears the overlay'
+end
+
 check 'Enemy Encounter scene: the round animates action by action, not at once' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
Implements visual rendering of the Tint Screen command's darkening effect. Previously, the tint state was tracked but not drawn. Now a black overlay sprite approximates the darkening by mapping the tone's RGB channels to overlay opacity.

## Changes
- **Added `@tint_sprite` overlay**: A black screen-sized sprite (z=440, between map/UI and flash/fade overlays) that renders the darkening portion of tint effects
- **Implemented `tint_overlay_opacity()` method**: Calculates overlay opacity by averaging the tone's RGB channels (0..200 range, 100=neutral); channels below 100 darken proportionally, channels at/above 100 produce no darkening
- **Updated `setup_screen_overlay()`**: Initializes the tint sprite with a black bitmap and zero opacity
- **Updated `update_screen_overlay()`**: Drives the tint sprite's opacity each frame based on current screen tint state
- **Updated `dispose()`**: Includes `@tint_sprite` in sprite cleanup
- **Added comprehensive test**: Validates that full black tint (0,0,0) produces near-opaque overlay, partial tint (50,50,50) produces partial opacity, and neutral tint (100,100,100) clears the overlay

## Implementation Details
- The tint darkening is approximated as a black overlay rather than a full per-pixel tone, which would require native C++ `RGSS::Viewport` tone support
- Colour cast, brightening (channels above 100), and saturation adjustments remain unimplemented and noted as future work
- The overlay sits at z=440, positioned below flash/fade effects (z=500+) but above the map and UI layers

https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW