### PR TITLE
Decode camera scroll and fix character graphics rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,8 +145,14 @@ present:
   - **111** — `SAVE_MAP_EVENT`: field 11 is each map event's live position
     (`SAVE_MOVABLE`) — confirmed because all 21 saved entries match map 12's 21
     defined events by id and sit in-bounds (`lcf_save_check.rb` re-checks this
-    when the map's `.lmu` is beside the save). Two leading int fields (1, 2, the
-    map scroll/pan) stay undecoded pending differential saves.
+    when the map's `.lmu` is beside the save). The two leading int fields (1, 2)
+    are the **camera scroll in 1/16 pixel** — the view's top-left corner, which
+    RPG_RT restores from here rather than deriving it from the hero. Measured
+    against the genuine runtime under wine (ADR 0021): with them absent it draws
+    the map's top-left corner whatever tile the hero is on, and 5120/3840 puts
+    its view at exactly (320, 240). `scripts/gen-rpg2k-save.rb` writes them
+    whenever it moves the party, without which the two runtimes render different
+    parts of the map.
   - **108** — `SAVE_PARTY_ACTOR`, one entry per actor the party has held. Beyond
     the state block, the decoded fields are level (31), exp (32), skills (51/52),
     equipment (61, five item ids `[weapon,shield,armour,helmet,accessory]`) and

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
   the message panel now land on RPG_RT's pixels; the residual difference is the
   font (RPG_RT uses Windows' MS Gothic, we use Shinonome, with matching
   metrics). See `docs/adr/0021-nepheshel-render-parity-under-wine.md`
+- An **in-game map** is diffed the same way, by resuming both runtimes from one
+  save (`scripts/compare-nepheshel-save-wine.bash`, with
+  `scripts/gen-rpg2k-save.rb --clear-scene --map <id>` placing the party and the
+  camera). Nepheshel's town, an interior and an open-water map now render
+  **pixel-identical** to RPG_RT — tile layers, autotiles, upper/lower layering
+  and event sprites all on its exact pixels
 
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,

--- a/changelog.d/rpg2k-charset-colour-key.fixed.md
+++ b/changelog.d/rpg2k-charset-colour-key.fixed.md
@@ -1,0 +1,9 @@
+- **Character, face and menu graphics are now colour-keyed**, so their palette
+  entry 0 is transparent instead of being blitted as an opaque block. CharSet
+  graphics (the party leader's and every map event's), FaceSet portraits and the
+  windowskin loaded by `Scene::Base` all loaded without the flag that the
+  chipset, the title screen and the map's own windowskin already used. Found by
+  the wine comparison: on Nepheshel's town map our renderer drew a solid pink
+  rectangle over a wall where the genuine `RPG_RT.exe` drew nothing, because
+  `CharSet/door.png`'s palette entry 0 is `#FF678B`. With the key applied the
+  town frame is **pixel-identical** to RPG_RT (0 of 307200 pixels differ).

--- a/changelog.d/rpg2k-save-camera-scroll.added.md
+++ b/changelog.d/rpg2k-save-camera-scroll.added.md
@@ -1,0 +1,10 @@
+- **The saved camera scroll (`.lsd` chunk 111 fields 1/2) is decoded**: it is
+  the view's top-left corner in **1/16 pixel**, measured against the genuine
+  `RPG_RT.exe` under wine (see `LCF::Schema::SAVE_MAP_EVENT` and ADR 0021).
+  `scripts/gen-rpg2k-save.rb` now writes it whenever it moves the party, and
+  grew `--clear-scene` to drop the running-event continuation (113) and the
+  shown pictures (103). Without both, resuming the same save put RPG_RT and this
+  engine on different parts of the map — and back in a timed cutscene — so the
+  map comparison reported a whole-screen difference that was never a rendering
+  fault. `LCF::Array1D#delete` removes a chunk outright (an absent chunk and an
+  empty one are not the same file to the real runtime).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -83,6 +83,22 @@ The work below is roughly ordered by the critical path to a walkable game
   harness did through Nepheshel's timed opening.
   `scripts/gen-rpg2k-save.rb` moves the party in that save to any map. See the
   addendum in ADR 0021. Two gaps it uncovered, both still open:
+  - ✅ **An ordinary map now diffs to zero.** Resuming the debug save landed
+    back in the demo's timed cutscene (its choice lives in chunk 113, its
+    backdrop in 103), and moving the party left RPG_RT drawing a different part
+    of the map entirely — it **restores the camera from the save** rather than
+    deriving it from the hero. Chunk 111's two leading ints, previously listed
+    here as undecoded, are that camera in **1/16 pixel** (measured against
+    RPG_RT: 5120/3840 puts its view at exactly (320, 240)).
+    `gen-rpg2k-save.rb` now writes them and grew `--clear-scene` to drop chunks
+    113/103. With both runtimes on the same tile the comparison found two real
+    rendering bugs — CharSet/FaceSet/menu-windowskin graphics loaded without the
+    colour key (a solid pink block over a wall) and lower-layer tile id 0 treated
+    as empty when it is water set 0 (black holes in the sea) — after which the
+    town, interior and open-water frames are **pixel-identical** to RPG_RT.
+    The comparison is only meaningful on a map where nothing moves on its own:
+    roaming events and parallel processes (needle traps, monsters) drift between
+    the runtimes, and no Nepheshel map with events is fully static.
   - ✅ **Shown pictures are restored on load.** Resuming mid-cutscene, RPG_RT
     drew the saved background picture and we drew black. `Game::State` treated
     `@pictures` as transient — true for a HUD re-shown by parallel events, false

--- a/docs/adr/0021-nepheshel-render-parity-under-wine.md
+++ b/docs/adr/0021-nepheshel-render-parity-under-wine.md
@@ -203,3 +203,87 @@ their defaults, so they are left to `Picture`'s defaults rather than guessed at.
 
 Making `to_lsd`'s own output loadable by RPG_RT remains open, and is tracked in
 `docs/TODO.md`.
+
+## Addendum: comparing an ordinary map, and the two bugs it found
+
+The save-based harness above still could not diff a *map*. It resumed the save
+`gen-lcf-save-wine.bash` writes, and that save is taken from Nepheshel's demo
+mode — mid-opening, with the demo's choice held in chunk 113 and its backdrop
+picture in chunk 103 — so resuming it put both runtimes back into a **timed**
+cutscene and they drifted apart exactly as the key-driven harness does.
+`scripts/gen-rpg2k-save.rb --clear-scene` drops those two chunks (removing them
+outright, not blanking them: `LCF::Array1D#delete`, since an absent chunk and an
+empty one are different files to RPG_RT). Both runtimes then stand on a plain
+map, which does not move until a key is pressed.
+
+That alone was not enough, and the reason is a decoded field.
+
+**RPG_RT restores the camera from the save; it does not derive it from the
+hero.** Moving the party to another map/tile and resuming drew the map's
+*top-left corner* whatever tile the hero was put on. `AGENTS.md` listed chunk
+111's two leading int fields as "the map scroll/pan … undecoded"; they are the
+view's top-left corner in **1/16 pixel**:
+
+| chunk 111 fields 1/2 | RPG_RT's view |
+| --- | --- |
+| absent | (0, 0) — the map's top-left corner |
+| 320 / 240 | scrolled ~20px, *not* to (320, 240) |
+| 5120 / 3840 | (320, 240) exactly — 16× the pixels |
+
+At 5120/3840 RPG_RT's frame matched ours (which centres the view on the hero,
+and puts it at (320,240) for that tile) over all but 260 of 307200 pixels, the
+residual being one animated coastline autotile. `gen-rpg2k-save.rb` now writes
+this whenever it moves the party, and `LCF::Schema::SAVE_MAP_EVENT` documents
+the unit. Without it the harness compared two different parts of the map and
+reported a whole-screen difference that was never a rendering fault.
+
+With both runtimes finally drawing the same place, two real defects showed up
+immediately — neither of which any unit check could have found, because both are
+about what the *data* means rather than what our geometry computes:
+
+| Fixed | Symptom against RPG_RT | Cause |
+| --- | --- | --- |
+| CharSet / FaceSet / `Scene::Base` windowskin | a solid **pink rectangle** over a wall on the town map, where RPG_RT drew nothing | loaded without the colour key, so the indexed PNG's palette entry 0 was blitted opaque (`CharSet/door.png`'s entry 0 is `#FF678B`). The chipset, the title screen and the map's own windowskin already passed the flag; these four call sites did not |
+| Lower-layer tile id **0** | large **black holes** in the sea — 90 of the 320 on-screen tiles on map 204 | `Game::ChipsetLayout.block` treated 0 as the empty tile. It is not: 0 is water set 0's plain chip, and RPG_RT draws deep water for it. Only the *upper* layer uses 0 to mean "no tile" (its own ids start at 10000), so that layer's caller now skips 0 before asking |
+
+After both fixes the frames are **pixel-identical** to the genuine RPG_RT: 0 of
+307200 differing pixels on Nepheshel's town map (12), on an interior (315) and
+on the open-water map (473) — chipset layers, autotiles, upper/lower layering
+and event sprites all landing on RPG_RT's exact pixels.
+
+### What this comparison can and cannot diff
+
+The harness is only meaningful on a map where **nothing moves on its own**, and
+Nepheshel has fewer of those than one would hope — a scan of all 543 maps finds
+no map with events whose pages are all stationary fixed graphics with no
+auto-start or parallel page. Two classes of map produce large diffs that are not
+defects, and both were mistaken for one before being run down:
+
+- **Roaming events.** Map 531's monsters and map 204's sea creatures walk under
+  their own move types; the two runtimes step them at different moments, so the
+  terrain diffs to zero and every sprite appears twice in the difference image.
+- **Parallel processes.** Map 114 is a needle-trap room whose driver event
+  cycles switches 281–290, raising and lowering needles and erasing a hidden
+  door. Both runtimes run it; they are simply not in the same phase.
+
+Two harness hazards are worth recording as well. `xwd` can catch RPG_RT
+mid-flip, giving a horizontally torn reference frame (a re-capture fixes it),
+and a longer settle on an encounter map lets the reference walk into a random
+battle. Prefer a short settle and a static map.
+
+The hero sprite stays outside the comparison. The debug save has Set Transparent
+Flag on (chunk 101 field 55) and its hero graphic override empty, so neither
+runtime draws him. Clearing the flag *and* filling the override from the party
+leader's database CharSet makes our engine draw him correctly — which is how the
+colour-key fix was confirmed on the hero as well as on the door — but the
+genuine RPG_RT resumed from the same edited file still does not, so shipping
+that as a harness option would only manufacture a difference. Character-sprite
+rendering is compared through the map's events instead, which both runtimes do
+draw, and that is what caught the colour-key bug.
+
+The font remains the floor for the *title* screen, as recorded above, with one
+correction to how that reads in practice: under this wine prefix RPG_RT's own
+kanji do not render — it substitutes a font without them and draws blobs where
+we draw 最初から / 続きから / 終了する. The residual title difference is
+therefore the reference's font handling as much as ours, and is not evidence
+about our text rendering either way.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -457,6 +457,18 @@ module LCF
       d && d.unpack('s<*')
     end
 
+    # Drop a chunk entirely, so #to_lcf omits it rather than writing an empty
+    # one. An absent chunk and a present-but-empty chunk are different files to
+    # the genuine runtime, and only the former means "nothing here": clearing
+    # the running-event continuation (113) by writing empty bytes leaves a
+    # zero-command interpreter state behind, where removing the chunk resumes
+    # with no event running at all. Returns the removed raw bytes, or nil.
+    def delete idx
+      was = @data[idx]
+      @data[idx] = nil
+      was
+    end
+
     # Set the raw bytes of a chunk from a Ruby value, encoding it through the
     # schema type of that field (LCF.encode) so an authored/edited section can
     # be written back out. With no schema attached a raw String is stored as-is.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1034,14 +1034,36 @@ module LCF
     # event's live position (a SAVE_MOVABLE) -- confirmed against a real save:
     # all 21 saved entries matched map 12's 21 defined events, id for id and at
     # in-bounds tiles (scripts/lcf_save_check.rb re-checks this). Fields 21/22 are
-    # the chipset replacement tables. A real save also carries two leading int
-    # fields (1, 2) -- the map scroll/pan position -- left undecoded until
-    # differential saves pin the units down.
+    # the chipset replacement tables.
+    #
+    # Fields 1/2 are the **camera scroll**, in 1/16 pixel: the top-left corner of
+    # the view, not a tile and not a plain pixel count. They were identified by
+    # experiment against the genuine RPG_RT under wine (ADR 0021): resuming a
+    # save whose hero was moved to map 1 tile (30,22) drew the map's *top-left*
+    # corner whichever tile the hero was put on -- because the runtime restores
+    # the view from here rather than deriving it from the hero -- and writing
+    # these two fields moved it:
+    #
+    #   | chunk 111 fields 1/2 | RPG_RT's view                     |
+    #   | -------------------- | --------------------------------- |
+    #   | absent               | (0, 0), the map's top-left corner  |
+    #   | 320 / 240            | scrolled ~20px, not to (320, 240)  |
+    #   | 5120 / 3840          | (320, 240) exactly -- 16x the pixels |
+    #
+    # At 5120/3840 the frame matched our own renderer (which centres the view on
+    # the hero, and puts it at (320,240) for that tile) over all but 260 of
+    # 307200 pixels, the residual being one animated coastline autotile. That is
+    # what pins the unit: 5120/16 = 320.
     SAVE_MAP_EVENT = {
+      1 => { name: :scroll_x, type: :int, default: 0 }, # 1/16 px
+      2 => { name: :scroll_y, type: :int, default: 0 }, # 1/16 px
       11 => { name: :events, type: :Array2D, elements: SAVE_MOVABLE },
       21 => { name: :chip_replacement_lower, type: :int8_array }, # uint8[144]
       22 => { name: :chip_replacement_upper, type: :int8_array }, # uint8[144]
     }
+
+    # Camera scroll fields of SAVE_MAP_EVENT are stored in 1/16 pixel.
+    SCROLL_UNITS_PER_PIXEL = 16
 
     # Party inventory (chunk 109 of the save file). Confirmed against a real
     # save: gold (21) matched the on-screen 100G, and the parallel item id/count

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -456,9 +456,16 @@ module Game
     end
 
     # The coarse block a tile id belongs to: :water, :animated, :terrain, :lower,
-    # :upper, or nil for the empty tile (0) and ids outside every block.
+    # :upper, or nil for an absent tile and ids outside every block.
+    #
+    # Id **0 is not empty**: it is water set 0's plain chip (set 0, no border and
+    # no corner), and the genuine RPG_RT draws it as deep water. Only the *upper*
+    # layer uses 0 to mean "no tile" -- its own ids start at BLOCK_F -- so that
+    # layer's callers skip 0 before asking (see Scene::Map#draw_layers). Treating
+    # 0 as empty here left holes: on Nepheshel's map 204 the sea rendered as
+    # black where RPG_RT drew water, 90 of the 320 on-screen tiles.
     def self.block(id)
-      return nil if id.nil? || id <= 0
+      return nil if id.nil? || id < 0
       if id >= BLOCK_F
         id < BLOCK_F + BLOCK_F_TILES ? :upper : nil
       elsif id >= BLOCK_E
@@ -476,8 +483,9 @@ module Game
     # [dx, dy, sx, sy, w, h]: dx/dy are pixel offsets within the destination
     # 16x16 tile, and sx/sy/w/h the source rect in the chipset image. Non-
     # autotile blocks return a single 16x16 rect; autotiles return four 8x8
-    # quarters. The empty tile (0) and out-of-range ids return []. `abf` / `cf`
-    # are the current animation columns/frames from #anim_ab / #anim_c.
+    # quarters. An absent tile and out-of-range ids return []; id 0 is water, not
+    # empty (see .block). `abf` / `cf` are the current animation columns/frames
+    # from #anim_ab / #anim_c.
     def self.quads(id, abf = 0, cf = 0)
       case block(id)
       when :water    then water_quads(id, abf)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -307,11 +307,14 @@ class RPG2k
       attr_reader :parent, :db, :map_tree
 
       # Load the System/ windowskin declared in the database (nil when missing,
-      # so Window falls back to a plain panel).
+      # so Window falls back to a plain panel). Colour-keyed, matching the map
+      # and title scenes' own loads of the same file: the skin's palette entry 0
+      # is transparent, and every menu built on this would otherwise draw the
+      # cursor and frame corners on opaque blocks.
       def make_windowskin
         name = @db.system.system_graphic
         return nil if name.nil? || name.empty?
-        Bitmap.new "System/#{name}"
+        Bitmap.new "System/#{name}", true
       rescue StandardError => e
         $stderr.puts "[RGSS] windowskin load failed, using plain panel: #{e.message}"
         nil
@@ -674,12 +677,19 @@ class RPG2k
       # The CharSet bitmap for an event graphic `name`, cached (including a
       # cached nil for a missing file so the event simply draws nothing rather
       # than a placeholder). Empty names have no graphic.
+      #
+      # Loaded colour-keyed, like the chipset: a CharSet is an indexed PNG whose
+      # palette entry 0 is the background, and without the key that background is
+      # blitted opaque -- a solid rectangle over the map instead of a sprite.
+      # Caught by the wine comparison, where Nepheshel's `door` event drew as a
+      # solid pink block (door.png's palette entry 0 is #FF678B) on a wall the
+      # genuine RPG_RT left alone.
       def event_charset(name)
         return nil if name.nil? || name.empty?
         return @event_charsets[name] if @event_charsets.key?(name)
         @event_charsets[name] =
           begin
-            Bitmap.new "CharSet/#{name}"
+            Bitmap.new "CharSet/#{name}", true
           rescue StandardError => e
             $stderr.puts "[RPG2k] event charset '#{name}' load failed, " \
                          "event drawn empty: #{e.message}"
@@ -719,14 +729,15 @@ class RPG2k
       end
 
       # Load the leader's CharSet graphic. Returns nil (falling back to a marker)
-      # when there is no party or the file is missing.
+      # when there is no party or the file is missing. Colour-keyed for the same
+      # reason event graphics are (see event_charset).
       def load_charset
         leader = @state.party.leader
         return nil if leader.nil?
         name = leader.charset_name
         @charset_index = leader.charset_index || 0
         return nil if name.nil? || name.empty?
-        Bitmap.new "CharSet/#{name}"
+        Bitmap.new "CharSet/#{name}", true
       rescue StandardError => e
         $stderr.puts "[RPG2k] party charset load failed, using marker: #{e.message}"
         nil
@@ -2634,9 +2645,11 @@ class RPG2k
 
       # Load the FaceSet graphic named by the message config, or nil when no face
       # is selected or the file is missing (the message then shows text only).
+      # Colour-keyed like the other character art: a FaceSet's palette entry 0 is
+      # its background, and drawing it opaque boxes the portrait in.
       def load_face(cfg)
         return nil unless cfg.face?
-        Bitmap.new "FaceSet/#{cfg.face_name}"
+        Bitmap.new "FaceSet/#{cfg.face_name}", true
       rescue StandardError => e
         $stderr.puts "[RPG2k] face graphic '#{cfg.face_name}' load failed: #{e.message}"
         nil
@@ -3022,7 +3035,10 @@ class RPG2k
 
             if @chipset_bmp
               draw_tile @lower_bmp, lower, dx, dy, abf, cf
-              draw_tile @upper_bmp, upper, dx, dy, abf, cf
+              # 0 means "no upper tile" (the upper layer's own ids start at
+              # BLOCK_F); on the lower layer the same value is water set 0, so
+              # only this call may skip it. See Game::ChipsetLayout.block.
+              draw_tile @upper_bmp, upper, dx, dy, abf, cf if upper && upper != 0
             else
               # Fallback: solid colour blocks keyed by tile id (no chipset image).
               @lower_bmp.fill_rect dx, dy, TILE, TILE, tile_color(lower)

--- a/scripts/gen-rpg2k-save.rb
+++ b/scripts/gen-rpg2k-save.rb
@@ -39,9 +39,31 @@
 #     --at X,Y         tile to stand on (default: the map's centre when --map
 #                      moves to another map, else unchanged)
 #     --facing DIR     down|left|right|up (default: unchanged)
+#     --clear-scene    drop the running-event continuation (chunk 113) and the
+#                      shown pictures (chunk 103), so the save resumes standing
+#                      on a plain map with nothing running over it
 #     --slot N         save slot to edit -> Save0<N>.lsd (default: 1)
 #     --out PATH       write here instead of over the input
 # GAME_DIR defaults to the RPG2000 test-bed (Nepheshel).
+#
+# WHY --clear-scene EXISTS: gen-lcf-save-wine.bash saves through EasyRPG's F9
+# debug menu from wherever the game happens to be, and for Nepheshel that is
+# mid-opening -- the save carries the opening demo's choice in chunk 113 and its
+# backdrop picture in chunk 103. Resuming it puts both runtimes back into that
+# cutscene, where the frames drift again for the same reason the key-driven
+# harness does: the cutscene is timed. Dropping those two chunks resumes on the
+# map itself, which is static until a key is pressed and so can be diffed
+# pixel-for-pixel -- and walked, a step at a time, with both runtimes staying in
+# lock-step. Everything else in the save (map event positions, the party,
+# switches and variables) is preserved byte-for-byte.
+#
+# One thing --clear-scene cannot restore is the hero *sprite*: the debug save is
+# taken in Nepheshel's demo mode, where Set Transparent Flag is on (chunk 101
+# field 55). Clearing that flag and giving the hero the party leader's CharSet
+# makes our engine draw him, but the genuine RPG_RT resumed from the same file
+# still does not, so it only manufactures a difference. Character-sprite
+# rendering is therefore compared through the map's *events*, which both
+# runtimes do draw -- and that is what caught the CharSet colour-key bug.
 
 require 'stringio'
 require 'optparse'
@@ -70,6 +92,33 @@ HERO_X = 12
 HERO_Y = 13
 HERO_DIRECTION = 22
 
+# Top-level save chunks --clear-scene removes, per LCF::Schema::SAVE_DATA.
+PICTURES = 103
+FOREGROUND_EVENT = 113
+
+# The saved map state (chunk 111) and its camera scroll fields, per
+# LCF::Schema::SAVE_MAP_EVENT.
+MAP_EVENTS = 111
+SCROLL_X = 1
+SCROLL_Y = 2
+
+# RPG2000 screen geometry, mirroring Game::TILE / RPG2k::WIDTH / RPG2k::HEIGHT
+# in the engine (which is mruby-only, so it cannot be loaded here).
+TILE = 16
+SCREEN_W = 320
+SCREEN_H = 240
+
+# The engine's Game.camera_offset: the view's top-left pixel so the hero is
+# centred, clamped to the map. Kept in step with mruby-rpg2k/mrblib/game.rb.
+def camera_offset(player_px, screen_px, map_px)
+  max = map_px - screen_px
+  max = 0 if max < 0
+  v = player_px - screen_px / 2
+  return 0 if v < 0
+  return max if v > max
+  v
+end
+
 DIRECTIONS = { 'up' => 8, 'right' => 6, 'left' => 4, 'down' => 2 }.freeze
 
 options = { slot: 1 }
@@ -78,6 +127,9 @@ parser = OptionParser.new do |o|
   o.on('--map ID', Integer, 'map id to place the party on') { |v| options[:map] = v }
   o.on('--at X,Y', 'tile to stand on') { |v| options[:at] = v }
   o.on('--facing DIR', DIRECTIONS.keys, 'down|left|right|up') { |v| options[:facing] = v }
+  o.on('--clear-scene', 'drop the running event (113) and pictures (103)') do
+    options[:clear_scene] = true
+  end
   o.on('--slot N', Integer, 'save slot to edit (default 1)') { |v| options[:slot] = v }
   o.on('--out PATH', 'write here instead of over the input') { |v| options[:out] = v }
 end
@@ -101,6 +153,13 @@ end
 from = [hero[HERO_MAP], hero[HERO_X], hero[HERO_Y]]
 map_id = options[:map] || from[0]
 
+map_path = File.join(game_dir, format('Map%04d.lmu', map_id))
+unless File.exist?(map_path)
+  warn "map #{map_id} has no #{File.basename(map_path)} in #{game_dir}"
+  exit 1
+end
+map = LCF::MapUnit.new(File.open(map_path, 'rb'))
+
 if options[:at]
   x, y = options[:at].split(',').map { |n| Integer(n) }
 elsif map_id == from[0]
@@ -110,12 +169,6 @@ else
   # Landing on another map with no tile given: stand in the middle. It is always
   # in bounds, though possibly unwalkable -- which is fine, since the comparison
   # only needs both runtimes on the same tile, and both will draw the hero there.
-  map_path = File.join(game_dir, format('Map%04d.lmu', map_id))
-  unless File.exist?(map_path)
-    warn "map #{map_id} has no #{File.basename(map_path)} in #{game_dir}"
-    exit 1
-  end
-  map = LCF::MapUnit.new(File.open(map_path, 'rb'))
   x = map.width / 2
   y = map.height / 2
 end
@@ -124,11 +177,37 @@ hero[HERO_MAP] = map_id
 hero[HERO_X] = x
 hero[HERO_Y] = y
 hero[HERO_DIRECTION] = DIRECTIONS.fetch(options[:facing]) if options[:facing]
+
 # Reading a chunk decodes a detached copy, so the edited chunk has to go back in
 # before serialising (same as scripts/lcf_save_roundtrip.rb).
 save[104] = hero
 
 moved_maps = map_id != from[0]
+
+# Re-centre the saved camera on the new tile. RPG_RT does NOT derive the view
+# from the hero when it resumes -- it restores the scroll recorded in chunk 111
+# (fields 1/2, in 1/16 pixel; see LCF::Schema::SAVE_MAP_EVENT for how the unit
+# was measured). Moving the party without this leaves the old scroll behind, and
+# the genuine runtime then draws a completely different part of the map from the
+# one our engine draws, which reads as a total rendering mismatch when it is
+# only a stale camera.
+map_ev = save[MAP_EVENTS] || LCF::Array1D.new('', LCF::Schema::SAVE_DATA[:elements][MAP_EVENTS])
+scroll_px = [camera_offset(x * TILE + TILE / 2, SCREEN_W, map.width * TILE),
+             camera_offset(y * TILE + TILE / 2, SCREEN_H, map.height * TILE)]
+map_ev[SCROLL_X] = scroll_px[0] * LCF::Schema::SCROLL_UNITS_PER_PIXEL
+map_ev[SCROLL_Y] = scroll_px[1] * LCF::Schema::SCROLL_UNITS_PER_PIXEL
+save[MAP_EVENTS] = map_ev
+
+# Drop the chunks that would replay the scene the save was taken in, leaving the
+# party standing on the map with nothing running (see the --clear-scene note in
+# the header). Both are optional sections a real save omits when there is no
+# event running and no picture shown, so removing them is a state RPG_RT itself
+# writes -- unlike an emptied chunk, which is a zero-length event/picture table.
+cleared = []
+if options[:clear_scene]
+  cleared << 'running event (113)' if save.delete(FOREGROUND_EVENT)
+  cleared << 'pictures (103)' if save.delete(PICTURES)
+end
 
 out = options[:out] || src
 save.save_to(out)
@@ -142,7 +221,19 @@ unless got == [map_id, x, y]
        "map=#{got[0]} (#{got[1]},#{got[2]})"
   exit 1
 end
+if options[:clear_scene] && (back.key?(FOREGROUND_EVENT) || back.key?(PICTURES))
+  warn 'FAILED: --clear-scene left chunk 113/103 in the written save'
+  exit 1
+end
+got_scroll = [back[MAP_EVENTS][SCROLL_X], back[MAP_EVENTS][SCROLL_Y]]
+want_scroll = scroll_px.map { |v| v * LCF::Schema::SCROLL_UNITS_PER_PIXEL }
+unless got_scroll == want_scroll
+  warn "FAILED: wrote scroll #{want_scroll.inspect} but read back #{got_scroll.inspect}"
+  exit 1
+end
 
 puts "#{out}: map #{from[0]} (#{from[1]},#{from[2]}) -> #{map_id} (#{x},#{y})" \
      "#{options[:facing] ? " facing #{options[:facing]}" : ''}" \
-     "#{moved_maps ? ' [map changed: the save keeps the old map event states]' : ''}"
+     "#{moved_maps ? ' [map changed: the save keeps the old map event states]' : ''}" \
+     " [camera #{scroll_px[0]},#{scroll_px[1]}px]" \
+     "#{cleared.empty? ? '' : " [cleared: #{cleared.join(', ')}]"}"

--- a/scripts/rpg2k_render_check.rb
+++ b/scripts/rpg2k_render_check.rb
@@ -51,8 +51,7 @@ end
 
 # -- block classification -----------------------------------------------------
 
-check 'empty and out-of-range ids classify as nil' do
-  eq nil, L.block(0)
+check 'absent and out-of-range ids classify as nil' do
   eq nil, L.block(nil)
   eq nil, L.block(-5)
   eq nil, L.block(5000 + 144)   # one past block E
@@ -61,6 +60,11 @@ check 'empty and out-of-range ids classify as nil' do
 end
 
 check 'ids classify into the six blocks' do
+  # Id 0 is water set 0's plain chip, NOT an empty tile: the genuine RPG_RT
+  # draws deep water for it, and treating it as empty punched black holes in
+  # Nepheshel's sea. Only the upper layer uses 0 to mean "no tile", and that
+  # layer's caller skips it before asking.
+  eq :water,    L.block(0)
   eq :water,    L.block(1)
   eq :water,    L.block(2500)
   eq :animated, L.block(3000)
@@ -73,13 +77,21 @@ check 'ids classify into the six blocks' do
   eq :upper,    L.block(10143)
 end
 
-# -- empty tile draws nothing -------------------------------------------------
+# -- absent tile draws nothing ------------------------------------------------
 
-check 'empty / invalid tiles produce no quads' do
-  eq [], L.quads(0)
+check 'absent / invalid tiles produce no quads' do
   eq [], L.quads(nil)
   eq [], L.quads(5000 + 144)
   eq [], L.quads(10000 + 144)
+end
+
+# Tile 0 is the plain chip of water set 0: four quarters out of block B's first
+# row pair, exactly like every other borderless, cornerless water tile.
+check 'tile 0 draws water set 0' do
+  quads = L.quads(0)
+  eq 4, quads.size
+  assert_quads_valid quads
+  eq L.quads(0), L.water_quads(0, 0)
 end
 
 # -- single-chip blocks (C, E, F) ---------------------------------------------


### PR DESCRIPTION
This PR brings map rendering to pixel-parity with RPG_RT by decoding the saved camera scroll position and fixing character graphic colour-keying.

## Summary

Two rendering issues prevented accurate map comparison against RPG_RT:
1. The camera scroll fields in save chunk 111 were undecoded, causing RPG_RT to draw from the map's top-left corner regardless of hero position
2. Character, face, and menu graphics were loaded without colour-keying, rendering palette entry 0 as opaque blocks instead of transparent backgrounds

With these fixes, Nepheshel's town, interior, and open-water maps now render pixel-identical to RPG_RT.

## Key Changes

**Camera Scroll Decoding:**
- Decoded chunk 111 fields 1/2 as camera scroll in **1/16 pixel units** (measured experimentally against RPG_RT under wine)
- `LCF::Schema::SAVE_MAP_EVENT` now documents these fields with the unit conversion constant `SCROLL_UNITS_PER_PIXEL`
- `scripts/gen-rpg2k-save.rb` now writes camera scroll whenever moving the party, using a `camera_offset()` function that mirrors the engine's view centering logic
- Added `--clear-scene` flag to drop chunks 113 (running event) and 103 (shown pictures), allowing comparison of static maps instead of timed cutscenes
- Added `LCF::Array1D#delete()` to remove chunks entirely (absent vs. empty chunks are different files to RPG_RT)

**Character Graphics Colour-Keying:**
- CharSet graphics (party leader and map events) now load with colour-key flag
- FaceSet portraits now load with colour-key flag  
- Menu windowskin now loads with colour-key flag
- All three were already colour-keyed in chipset and title screen loads; this brings consistency

**Tile ID 0 Fix:**
- Tile ID 0 is water set 0's plain chip, not an empty tile (only the upper layer uses 0 to mean "no tile")
- `Game::ChipsetLayout.block()` now treats 0 as water instead of nil
- `Scene::Map#draw_layers()` skips ID 0 only for the upper layer before querying quads
- This fixes black holes in the sea (90 tiles on Nepheshel's map 204)

**Testing & Documentation:**
- Updated `scripts/rpg2k_render_check.rb` tests to reflect tile 0 as water
- Expanded ADR 0021 with detailed addendum on map comparison methodology, the two bugs found, and harness limitations
- Updated `AGENTS.md` and `README.md` with camera scroll documentation
- Added changelog entries for both fixes

https://claude.ai/code/session_014GvggEqvLwM2dxVc2igX8t