### PR TITLE
mruby-rpgxp: provide Kernel#exit for the script host

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -9,6 +9,10 @@ def rpg_maker_gems(conf)
   # build's per-frame emscripten callback keeps control each frame. Not in the
   # default gem set (docs/adr/0023-rpgxp-script-host-frame-driver.md).
   conf.gem core: 'mruby-fiber'
+  # Kernel#exit / SystemExit: the stock RMXP Interpreter calls `exit` to abort on
+  # runaway common-event recursion; the script host provides it so that raises a
+  # catchable SystemExit the driver ends the game on, rather than a NoMethodError.
+  conf.gem core: 'mruby-exit'
   # Kernel#sprintf / #format and String#%: the RGSS script host runs the game's
   # bundled scripts, which format numbers with sprintf ("%02d" clocks, "%04d"
   # ids, "%+d", "%0*d", …). Not in the default gem set, so pull it in explicitly.

--- a/changelog.d/rpgxp-script-host-exit.added.md
+++ b/changelog.d/rpgxp-script-host-exit.added.md
@@ -1,0 +1,7 @@
+- **`Kernel#exit` is now provided for the RGSS script host.** The stock RMXP
+  `Interpreter` calls `exit` to abort on runaway common-event recursion; the
+  `mruby-exit` core gem is now in the build, so that raises a catchable
+  `SystemExit` which the script-host driver ends the game on (rather than a
+  `NoMethodError`). The per-frame driver also idles cleanly after the host game
+  ends, so the web build's callback no longer falls into the built-in tick with no
+  scenes. See `docs/rpgxp-rgss-api-gap.md`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -157,8 +157,10 @@ offset-based scroll is a possible optimization.
 Scripts use `sprintf` (~9, e.g. `%02d`/`%04d` clocks and ids, `%+d`, `%0*d`).
 The `mruby-sprintf` core gem is now in the build (`build_config.rb`), providing
 `Kernel#sprintf`/`#format` and `String#%`. Covered by the gem's own tests plus a
-`mruby-rpgxp/test` availability check. `exit` (1 use, from `Interpreter`) is
-still assumed and not yet provided.
+`mruby-rpgxp/test` availability check. `exit` (1 use, from `Interpreter`, which
+calls it to abort on runaway common-event recursion) is now provided by the
+`mruby-exit` core gem — it raises a catchable `SystemExit` that the script-host
+driver ends the game on (see item 3 above / ADR 0023).
 
 ## Notes
 
@@ -171,9 +173,10 @@ still assumed and not yet provided.
   when the host is enabled, `RPGXP` runs `Main` inside an mruby `Fiber` and the
   wrapped `Graphics.update` yields it once per frame, so `main_loop` drives one
   game frame per browser callback. It is gated behind `RGSS_SCRIPT_HOST` (off by
-  default), so the built-in flow is unchanged; the remaining step is to boot a real
-  project under the web build with the flag on and confirm it end to end (plus
-  wiring `exit`, the one Kernel built-in the `Interpreter` still assumes).
+  default), so the built-in flow is unchanged. `exit` (used by the `Interpreter`)
+  is now wired too — it raises a `SystemExit` the driver ends the game on. The
+  remaining step is to boot a real project under the web build with the flag on and
+  confirm it end to end.
 - None of the above can be built or run in the current CI sandbox; each item is
   verified by `mruby-rgss/test` (compiled and run in CI) plus the host-side
   `scripts/rpgxp_script_host_check.rb`.

--- a/mruby-rpgxp/mrbgem.rake
+++ b/mruby-rpgxp/mrbgem.rake
@@ -13,6 +13,9 @@ MRuby::Gem::Specification.new('mruby-rpgxp') do |spec|
   # The script-host driver runs the scripts' blocking main loop inside a Fiber
   # (docs/adr/0023-rpgxp-script-host-frame-driver.md).
   add_dependency 'mruby-fiber'
+  # Kernel#exit / SystemExit — the stock Interpreter calls `exit` to abort on
+  # runaway common-event recursion; the driver ends the game on it.
+  add_dependency 'mruby-exit'
   # Kernel#sprintf / #format and String#% (used by the stock RGSS scripts, and by
   # the sprintf availability test). It is also enabled in build_config.rb, but
   # declaring the dependency here forces mruby-sprintf to initialize before this

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -128,6 +128,10 @@ class RPGXP
   # default flow, so that path is unchanged.
   def main_loop
     return drive_script_host if @host_fiber
+    # The host game has ended (Main returned, or a script called `exit`); the web
+    # per-frame callback keeps calling this, so idle instead of falling into the
+    # built-in tick with no scenes.
+    return if @host_done
 
     RGSS::Profiler.frame do
       RGSS::Profiler.section("scene.update") { @scenes.last.update }
@@ -176,7 +180,10 @@ class RPGXP
       @host_fiber = nil
       @host_done = true
     end
-  rescue RGSS::Timeout
+  rescue RGSS::Timeout, SystemExit
+    # A clean end: the timeout guard fired, or a script called `exit` (RMXP's
+    # Interpreter does this to abort on runaway common-event recursion). End the
+    # game rather than treating it as a boot failure.
     @host_fiber = nil
     @host_done = true
   rescue StandardError => e

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -1110,3 +1110,19 @@ assert "Kernel#sprintf / #format / String#% are available for the script host" d
   assert_equal "S [0012-3456]", sprintf("S [%04d-%04d]", 12, 3456)
   assert_equal "  hi", ("%4s" % "hi")
 end
+
+# The script-host driver runs the game's blocking Main inside a Fiber (ADR 0023)
+# and ends the game when a script calls `exit` (raised as a catchable
+# SystemExit). Confirm both gems are linked into the build — without invoking
+# `exit`, which would terminate the test runner.
+assert "Fiber and Kernel#exit / SystemExit are available for the script host" do
+  assert_true Object.const_defined?(:Fiber), "Fiber missing (mruby-fiber)"
+  assert_true Object.const_defined?(:SystemExit), "SystemExit missing (mruby-exit)"
+  assert_true Kernel.private_method_defined?(:exit) ||
+              Kernel.method_defined?(:exit), "Kernel#exit missing (mruby-exit)"
+  # A Fiber round-trips a value through yield/resume, the mechanism the driver
+  # relies on to advance one frame per resume.
+  f = Fiber.new { Fiber.yield(:frame); :done }
+  assert_equal :frame, f.resume
+  assert_equal :done, f.resume
+end

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -1117,9 +1117,12 @@ end
 # `exit`, which would terminate the test runner.
 assert "Fiber and Kernel#exit / SystemExit are available for the script host" do
   assert_true Object.const_defined?(:Fiber), "Fiber missing (mruby-fiber)"
-  assert_true Object.const_defined?(:SystemExit), "SystemExit missing (mruby-exit)"
-  assert_true Kernel.private_method_defined?(:exit) ||
-              Kernel.method_defined?(:exit), "Kernel#exit missing (mruby-exit)"
+  # mruby-exit defines Kernel#exit (a private method) alongside SystemExit, so the
+  # constant's presence proves the gem is linked. mruby's Module has no
+  # #private_method_defined? (it is CRuby-only, as script_host.rb notes), so we do
+  # not reflect on the private method here.
+  assert_true Object.const_defined?(:SystemExit),
+              "SystemExit / Kernel#exit missing (mruby-exit)"
   # A Fiber round-trips a value through yield/resume, the mechanism the driver
   # relies on to advance one frame per resume.
   f = Fiber.new { Fiber.yield(:frame); :done }


### PR DESCRIPTION
## What

Wires `Kernel#exit` into the RGSS script host — the one Kernel built-in the stock
scripts still assumed. This was the follow-up flagged in ADR 0023.

## Why

Decoding the testbed scripts, the sole `exit` call is a safety abort in
`Interpreter#initialize`: on runaway common-event recursion (`depth > 100`) it
prints an error and calls `exit` to terminate the game. So Ruby-standard `exit`
semantics (raise `SystemExit`) are exactly right.

## How

- Add the **`mruby-exit`** core gem (`build_config.rb` + `mruby-rpgxp` dep) →
  `Kernel#exit` raises a catchable `SystemExit`.
- The driver (`drive_script_host`) catches `SystemExit` alongside the existing
  timeout guard and ends the game cleanly, rather than letting it hit the
  `StandardError` boot-failure fallback (`SystemExit < Exception`, not
  `StandardError`).
- Also fixes a latent gap: after the host game ends (`@host_done`), `main_loop`
  now idles instead of falling into the built-in scene/input/graphics tick with an
  empty scene stack — which the web build's per-frame callback would otherwise hit
  every frame after the game exits.

## Testing

- `mruby-rpgxp/test` gains a build-availability assertion: `Fiber` and
  `SystemExit`/`Kernel#exit` are linked in, plus a `Fiber` yield/resume round-trip
  (the mechanism the driver relies on) — **without invoking `exit`**, which would
  kill the test runner. Verified the assertion logic under CRuby.
- The existing CRuby `scripts/rpgxp_script_host_check.rb` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkba7rBdnx8JYFhu6NaHN)_