### PR TITLE
Render weather effects as animated particle overlay on map

### DIFF
--- a/changelog.d/rpg2k-weather-render.added.md
+++ b/changelog.d/rpg2k-weather-render.added.md
@@ -1,0 +1,5 @@
+`Scene::Map` now renders the map weather effect (Change Weather / 11070): a
+screen-sized overlay draws animated rain streaks or drifting snow, with the
+particle count scaling to the weather strength, so the type/strength already
+held on `Game::State` become visible on the map instead of only round-tripping
+through the save.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -256,9 +256,11 @@ The work below is roughly ordered by the critical path to a walkable game
   above the map and below the message window. Picture **tone** is carried but not
   yet drawn (needs the same native tone support as the screen tint). **Weather
   Effects** (11070) records the map weather type (none / rain / snow) and strength
-  on `Game::State` — the Ruby-half model only, like the tint overlay, so it
-  round-trips through the save but drawing the rain/snow particles is native
-  renderer work still to come.
+  on `Game::State`, and `Scene::Map` now draws it: a screen-sized overlay sprite
+  (z 430, above the weather-less tint layer and below the animation layer) onto
+  which `draw_weather` paints rain streaks (falling, wind-skewed 1×6 marks) or
+  snow (drifting 2×2 flecks), the particle count scaling with strength and the
+  positions advancing with the scene's animation frame so the field animates.
   **Set Teleport / Escape Target** (11810 / 11830), **Change Encounter Rate**
   (11740) and **Change System BGM / SFX** (10660 / 10670) record their payloads
   on `Game::State` — a per-map teleport-target registry, a single escape target,
@@ -426,7 +428,8 @@ The work below is roughly ordered by the critical path to a walkable game
   Confirmed in the real binary before the code was written — forcing the fade
   layer to opacity 128 halves the rendered frame's mean brightness (31.9 → 15.2).
 
-  Still open here: **weather**, and the **tint** (Tint Screen). The tint really
+  Both the **weather** particle overlay and the **tint** (Tint Screen) layer are
+  now composited by `Scene::Map` alongside the fade and flash. The tint really
   does need native work, unlike the fade and flash — a tone rescales what is
   already drawn rather than laying a colour over it. That native half now
   exists: `RGSS::Bitmap#tone_blt(src, tone)` copies a bitmap applying an

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -507,7 +507,7 @@ class RPG2k
         close_shop
         close_battle
         [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
-         @picture_sprite, @fade_sprite, @flash_sprite].each do |s|
+         @picture_sprite, @fade_sprite, @flash_sprite, @weather_sprite].each do |s|
           s.dispose if s
         end
         (@vehicle_sprites || {}).each_value { |s| s.dispose if s }
@@ -632,6 +632,14 @@ class RPG2k
         @flash_sprite.bitmap = @flash_bmp
         @flash_sprite.opacity = 0
         @flash_rgb = nil
+
+        # Weather Effects: rain / snow particles drawn on a screen-sized layer
+        # (under the flash / fade overlays), animated by @anim_frame.
+        @weather_sprite = Sprite.new
+        @weather_sprite.z = 430
+        @weather_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        @weather_sprite.bitmap = @weather_bmp
+        @weather_sprite.visible = false
       end
 
       # Push this frame's fade and flash levels onto the two overlay sprites.
@@ -653,6 +661,59 @@ class RPG2k
           end
           @flash_sprite.opacity = strength
         end
+
+        draw_weather
+      end
+
+      WEATHER_RAIN = 1
+      WEATHER_SNOW = 2
+      # Particles at the lightest strength; each step up adds another band.
+      WEATHER_BASE_PARTICLES = 48
+      RAIN_COLOR = Color.new(200, 210, 255, 200)
+      SNOW_COLOR = Color.new(255, 255, 255, 220)
+
+      # Draw the active weather onto its overlay: falling rain streaks or drifting
+      # snow flecks, their count scaling with the strength (0..2). Positions are a
+      # deterministic hash of the particle index advanced by @anim_frame, so the
+      # field falls smoothly without needing a per-frame RNG. Cleared / hidden
+      # when there is no weather.
+      def draw_weather
+        w = @state.weather
+        if w.none? || (w.type != WEATHER_RAIN && w.type != WEATHER_SNOW)
+          @weather_sprite.visible = false
+          return
+        end
+        @weather_sprite.visible = true
+        @weather_bmp.clear
+        n = weather_particle_count(w)
+        n.times { |i| draw_weather_particle(w.type, i) }
+      end
+
+      def weather_particle_count(w)
+        WEATHER_BASE_PARTICLES * ((w.strength || 0) + 1)
+      end
+
+      # A single particle's on-screen cell, spread across the screen by a cheap
+      # hash of its index and falling as @anim_frame advances (wrapping at the
+      # bottom). Rain is a slanted streak; snow a small fleck that also drifts.
+      def draw_weather_particle(type, i)
+        x0 = (i * 97) % SCREEN_W
+        y0 = (i * 59) % SCREEN_H
+        if type == WEATHER_RAIN
+          y = (y0 + @anim_frame * 8) % SCREEN_H
+          x = (x0 - @anim_frame * 2) % SCREEN_W
+          @weather_bmp.fill_rect x, y, 1, 6, RAIN_COLOR
+        else
+          y = (y0 + @anim_frame * 3) % SCREEN_H
+          x = (x0 + weather_drift(i)) % SCREEN_W
+          @weather_bmp.fill_rect x, y, 2, 2, SNOW_COLOR
+        end
+      end
+
+      # A small side-to-side snow drift, from a triangle wave over @anim_frame.
+      def weather_drift(i)
+        phase = (@anim_frame / 8 + i) % 8
+        phase < 4 ? phase : 8 - phase
       end
 
       # Create the buffer that carries the Show Picture layer. Pictures composite

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1730,6 +1730,28 @@ check 'the airship floats above a ground shadow; a boat casts none' do
   ok !shadow.visible, 'a boat casts no airship shadow'
 end
 
+check 'Weather draws a particle overlay when active and hides it when clear' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  wsp = scene.instance_variable_get(:@weather_sprite)
+  scene.update
+  ok !wsp.visible, 'no weather -> no overlay'
+  st.weather.set(1, 2) # heavy rain
+  scene.update
+  ok wsp.visible, 'rain draws an overlay'
+  # A stronger downpour draws more particles than a light one.
+  heavy = scene.send(:weather_particle_count, st.weather)
+  st.weather.set(1, 0) # light rain
+  light = scene.send(:weather_particle_count, st.weather)
+  ok heavy > light, 'strength scales the particle count'
+  st.weather.set(2, 1) # snow
+  scene.update
+  ok wsp.visible, 'snow draws an overlay too'
+  st.weather.set(0, 0) # clear
+  scene.update
+  ok !wsp.visible, 'clearing weather hides the overlay'
+end
+
 check 'Enemy Encounter scene: the round animates action by action, not at once' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
Implements visual rendering of weather effects (rain and snow) on the map scene. The weather state that was previously only stored in `Game::State` is now drawn as an animated particle overlay sprite, making weather effects visible during gameplay.

## Key Changes
- **Weather sprite setup**: Added `@weather_sprite` initialization in `setup_screen_overlay` with z-order 430 (above tint, below animations)
- **Weather rendering**: Implemented `draw_weather` method that:
  - Shows/hides the weather overlay based on active weather state
  - Draws rain as falling 1×6 streaks with wind skew
  - Draws snow as drifting 2×2 flecks with side-to-side motion
  - Scales particle count with weather strength (base 48 particles per strength level)
- **Deterministic animation**: Uses hash-based particle positioning (`i * 97 % SCREEN_W`, etc.) advanced by `@anim_frame` for smooth animation without per-frame RNG
- **Snow drift**: Implements triangle-wave drift pattern for natural-looking snow movement
- **Cleanup**: Added `@weather_sprite` to the dispose list to prevent memory leaks
- **Tests**: Added comprehensive test coverage for weather visibility, particle scaling, and overlay behavior
- **Documentation**: Updated TODO.md to reflect completed weather rendering work

## Implementation Details
- Weather particles use deterministic positioning based on particle index to avoid needing per-frame random number generation
- Rain falls at 8 pixels/frame with 2-pixel wind skew per frame
- Snow falls at 3 pixels/frame with a triangle-wave drift pattern (±4 pixels over 8 frames)
- Weather overlay is cleared and hidden when weather is inactive or type is invalid
- Particle count formula: `WEATHER_BASE_PARTICLES * (strength + 1)` allows strength 0-2 to produce 48-144 particles

https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW