### PR TITLE
Evaluate the orientation Conditional Branch (type 6) in RPG2000

### DIFF
--- a/changelog.d/rpg2k-conditional-orientation.added.md
+++ b/changelog.d/rpg2k-conditional-orientation.added.md
@@ -1,0 +1,12 @@
+- RPG Maker 2000: the **Conditional Branch** command now evaluates the
+  **orientation** condition (type 6) — true when the referenced character is
+  facing a given direction. `param1` is the character (`10001` the hero, a
+  positive id a map event) and `param2` the direction (0 up / 1 right / 2 down /
+  3 left, mapped to the runtime's 2/4/6/8 numpad facing). The hero's facing comes
+  from `Game::State`; an event's from `Scene::Map#event_position` via the
+  interpreter's `map_info`. An unresolvable reference (no map, unknown event, or
+  the still-unmodelled this-event / vehicle refs) reads false. Previously this
+  condition fell through to an unconditional "true". Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (the hero facing a direction takes the
+  branch or the else, a map event's facing, and an unknown event falls to the
+  else).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -239,10 +239,10 @@ The work below is roughly ordered by the critical path to a walkable game
   an event's map id reads 0, matching an RPG_RT 2000 quirk; screen coordinates
   are not modelled).
   Conditional Branch covers switch / variable / **timer** / gold / item /
-  **vehicle** (is the party aboard the boat / ship / airship) conditions and
-  **all** the **actor** sub-conditions (in party, name, level ≥, HP ≥, item
-  equipped, skill known, and **afflicted by a state**); the event-facing
-  condition (type 6) is still TODO. Actors now
+  **vehicle** (is the party aboard the boat / ship / airship) / **orientation**
+  (is the hero or a map event facing a given direction) conditions and **all**
+  the **actor** sub-conditions (in party, name, level ≥, HP ≥, item equipped,
+  skill known, and **afflicted by a state**). Actors now
   carry a **status-condition (状態) set** (`Game::Actor#states` with
   `add_state` / `remove_state` / `state?`; **Full Recovery clears it**), which
   persists in both the Marshal save and the `.lsd` (chunk 108 fields 81/82,

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1284,11 +1284,31 @@ module Game
         cmd.param(2) == 0 ? has : !has
       when 5 # actor: param1 id, param2 sub-condition (see actor_condition)
         actor_condition(cmd)
+      when 6 # orientation: is character param1 (10001 the hero, a positive id a
+             # map event) facing direction param2 (0 up / 1 right / 2 down / 3 left)?
+        facing = character_facing(cmd.param(1))
+        !facing.nil? && facing == FACING_NUMPAD[cmd.param(2)]
       when 7 # vehicle: true when the party is riding vehicle param1 (0 boat /
              # 1 ship / 2 airship)
         v = cmd.param(1)
         v >= 0 && v < Vehicle::TYPES.size && @state.boarded == Vehicle::TYPES[v]
       else true
+      end
+    end
+
+    # Orientation directions (0 up / 1 right / 2 down / 3 left) mapped to the
+    # runtime's 2/4/6/8 numpad facing, matching EasyRPG's facing enum.
+    FACING_NUMPAD = [8, 6, 2, 4].freeze
+
+    # The numpad facing (2/4/6/8) of the character referenced by `ref` (10001 the
+    # hero, a positive id a map event), or nil when it can't be resolved (no
+    # map_info, an unknown event, or a still-unmodelled this-event / vehicle ref).
+    def character_facing(ref)
+      if ref == 10001
+        @state.direction
+      elsif ref > 0 && ref < 10000 && @map_info.respond_to?(:event_position)
+        pos = @map_info.event_position(ref)
+        pos && pos[:direction]
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2219,6 +2219,21 @@ def run_actor_cond(params, string: '')
   st
 end
 
+# Like run_actor_cond but with a FakeMapInfo hook set (event 7 at (2,3) dir 6),
+# for conditions that read map events.
+def run_cond_with_mapinfo(params)
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new
+  it.start([FakeCmd.new(IC::CONDITIONAL, params, indent: 0),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+            FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+            FakeCmd.new(IC::END_BRANCH, [], indent: 0)])
+  it.update
+  st
+end
+
 check 'Conditional actor: in-party sub-condition (type 5, sub 0)' do
   st = run_actor_cond([5, 1, 0])     # actor 1 is in the party
   eq true, st.switches[1]
@@ -2412,6 +2427,18 @@ check 'Conditional Branch: party riding a vehicle (type 7)' do
   eq true, st.switches[2]                            # asked about the boat -> else
   st = run_actor_cond([7, 2])                        # on foot (boarded nil)
   eq true, st.switches[2]                            # not aboard -> else
+end
+
+check 'Conditional Branch: character orientation (type 6)' do
+  # direction param 0 up / 1 right / 2 down / 3 left -> numpad 8/6/2/4.
+  st = run_actor_cond([6, 10001, 3]) { |s| s.direction = 4 } # hero facing left
+  eq true, st.switches[1]                            # facing left -> if-branch
+  st = run_actor_cond([6, 10001, 1]) { |s| s.direction = 4 } # asked facing right
+  eq true, st.switches[2]                            # not facing right -> else
+  # FakeMapInfo's event 7 faces right (numpad 6 = param 1).
+  eq true, run_cond_with_mapinfo([6, 7, 1]).switches[1]  # event faces right
+  eq true, run_cond_with_mapinfo([6, 7, 0]).switches[2]  # not facing up -> else
+  eq true, run_cond_with_mapinfo([6, 9, 1]).switches[2]  # unknown event -> else
 end
 
 # -- Input Number -------------------------------------------------------------


### PR DESCRIPTION
Completes the Conditional Branch condition set (after the vehicle condition in #283). The **orientation** condition (type 6) previously fell through to an unconditional "true", so an "if event N is facing down" branch always ran.

## Behavior

Type 6 is now true when the referenced character is facing a given direction:
- **`param1`** = character: **`10001`** the hero, a **positive id** a map event.
- **`param2`** = direction: **0 up / 1 right / 2 down / 3 left**, mapped to the runtime's 2/4/6/8 numpad facing (`FACING_NUMPAD`).
- The hero's facing comes from `Game::State`; an event's from `Scene::Map#event_position` via the interpreter's `map_info` (the `character_facing` helper). An unresolvable reference (no map, unknown event, or the still-unmodelled this-event / vehicle refs) reads false.

## Grounding

The facing enum (0 up / 1 right / 2 down / 3 left → numpad) is the same one EasyRPG's `ControlVariables::Event` converts for the character-direction operand (grounded in #283); the character-reference scheme (10001 hero, positive event id) is the `GetCharacter` convention the codebase already uses for Move Event and the operand-6 read.

## Tests

New `scripts/rpg2k_logic_check.rb` check: the hero facing a direction takes the if- or else-branch; a map event's facing; an unknown event falls to the else. A `run_cond_with_mapinfo` helper sets a `FakeMapInfo` for the event case. **285 logic + 90 scene + 36 render checks pass; save-load OK.**

## Follow-up

The remaining unmodelled character references for orientation / position — the "this event" self-reference and vehicles — need the running-event and vehicle-character context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_