### PR TITLE
Load RPG Maker VX / VX Ace projects (RGSS2 / RGSS3 data layer)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,16 @@ jobs:
           - name: RPG XP script-host smoke check
             run: nix develop -c ruby scripts/rpgxp_script_host_check.rb
 
+          # RPG Maker VX / VX Ace data layer. Neither edition has a fetchable
+          # open-source test bed (the editors and their RTPs are commercial), so
+          # this check builds a full project per edition and drives the loader
+          # over it — loose on disk and repacked into the edition's encrypted
+          # archive — plus an audit that every field in the data has an accessor
+          # in the schema. It also picks up any real VX/VX Ace project that a
+          # future download step unpacks under data/.
+          - name: RPG VX / VX Ace data check
+            run: nix develop -c ruby scripts/rpgvx_testbed_check.rb
+
           # Validate the committed MV test-bed database (data/mv-sample) before
           # the non-blocking native MV smokes below. Pure CRuby, no JS engine —
           # a blocking guard against a sample-data regression that would

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ target_include_directories(mruby INTERFACE "${MRUBY_PREFIX}/include"
 # the next `make`, with no manual `cmake` re-run. Header changes under src/ are
 # caught too so an edit to a private header still forces the archive to be
 # rebuilt.
-foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-mvjs)
+foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx mruby-mvjs)
   file(
     GLOB_RECURSE
     src

--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@
   movement uses the tileset's passage flags with a follow camera
 - Both an **unpacked** project (a loose `Data/` folder) and an **encrypted
   archive** load: a packed release that ships only a `Game.rgssad` (RPG Maker XP;
-  RPG Maker VX's same-format `Game.rgss2a` too) is decrypted transparently, so
-  the database loads with no loose files present. Loose files, when present,
-  shadow the archive (as in RGSS). VX Ace's `Game.rgss3a` is detected but not yet
-  decoded
+  RPG Maker VX's same-format `Game.rgss2a` too) or a VX Ace `Game.rgss3a` is
+  decrypted transparently, so the database loads with no loose files present.
+  Loose files, when present, shadow the archive (as in RGSS)
 - The window is sized to XP's native 640×480 automatically.
 - An experimental **RGSS script host** can run the game's own bundled scripts
   (`Data/Scripts.rxdata`) unmodified — the way `RGSS104E.dll` does — instead of
@@ -83,6 +82,30 @@
   while the RGSS class library is completed; see
   [`docs/adr/0017-rpgxp-rgss-script-host.md`](docs/adr/0017-rpgxp-rgss-script-host.md)
   (data layer: [`docs/adr/0010-rpgxp-rgss-data-layer.md`](docs/adr/0010-rpgxp-rgss-data-layer.md))
+
+### RPG Maker VX / VX Ace
+
+- An **RPG Maker VX** (RGSS2) or **VX Ace** (RGSS3) project is recognised as
+  itself instead of being mistaken for XP, and its whole **database loads**: the
+  `Data/*.rvdata` / `*.rvdata2` files are Ruby `Marshal` dumps like XP's, read
+  through a typed RGSS2/RGSS3 `RPG::*` schema (`mruby-rpgvx`) — VX Ace's feature
+  system, `damage`/`effects` usables, per-map tilesets and region layer; VX's
+  per-actor `parameters` tables, areas and game-wide `System#passages`
+- Which edition a folder holds is detected from `Data/System.rvdata[2]` or, for
+  a **packed release** (which ships no loose `Data/` at all), from its encrypted
+  archive: VX's `Game.rgss2a` and VX Ace's `Game.rgss3a` both decrypt through the
+  same reader the XP side uses, so a single-archive release loads too
+- The window is sized to VX's native 544×416 automatically
+- A VX/VX Ace game's engine *is* its script bundle, so a project that ships
+  `Data/Scripts.rvdata[2]` can be driven by the same experimental **RGSS script
+  host** as XP (`RGSS_SCRIPT_HOST`); the built-in title/map flow is not written
+  yet, and a boot without the host says so rather than opening a blank window.
+  See
+  [`docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md`](docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md)
+- Have a VX / VX Ace project? `ruby scripts/rpgvx_testbed_check.rb path/to/Game`
+  loads its whole database and reports any field the schema is missing — the
+  editors are commercial and no open-source test bed exists, so that check is
+  how the schema gets validated against genuine editor output
 
 ### Terminal gaming
 - Render the game to a terminal instead of an SDL window, using either the DEC

--- a/build_config.rb
+++ b/build_config.rb
@@ -32,6 +32,7 @@ def rpg_maker_gems(conf)
   conf.gem "#{MRUBY_ROOT}/../../mruby-rgss"
   conf.gem "#{MRUBY_ROOT}/../../mruby-rpg2k"
   conf.gem "#{MRUBY_ROOT}/../../mruby-rpgxp"
+  conf.gem "#{MRUBY_ROOT}/../../mruby-rpgvx"
   conf.gem "#{MRUBY_ROOT}/../../mruby-mvjs"
 end
 

--- a/changelog.d/rpgvx-data-layer.added.md
+++ b/changelog.d/rpgvx-data-layer.added.md
@@ -1,0 +1,21 @@
+- **RPG Maker VX / VX Ace** projects are now recognised and their databases
+  load. The new `mruby-rpgvx` gem declares the RGSS2 (VX) and RGSS3 (VX Ace)
+  `RPG::*` schema — the feature system, `damage`/`effects` usables, per-map
+  tilesets and region layer of Ace, and VX's `parameters` tables, areas and
+  game-wide `System#passages` — so every `Data/*.rvdata` / `*.rvdata2` file
+  loads straight through `Marshal.load`, and `RPGVX::RGSSData` exposes them as a
+  database (edition-aware extension and table set, maps on demand, script bundle
+  decoding). A packed release loads too: VX's `Game.rgss2a` and VX Ace's
+  `Game.rgss3a` are read through the existing `RPGXP::RGSSAD`. `src/main.cxx`
+  detects the edition **before** the XP branch (a VX project has a `Game.ini`
+  too, so it used to be mis-detected as XP) and sizes the window to VX's native
+  544×416. A project that ships its scripts can be driven by the RGSS script
+  host (`RGSS_SCRIPT_HOST`), which now shares one per-frame Fiber driver with the
+  XP runtime; without it the boot reports the pending built-in flow instead of
+  opening a blank window. Covered by `mruby-rpgvx/test` and by the new
+  `scripts/rpgvx_testbed_check.rb`, which — no open-source VX/VX Ace test bed
+  being fetchable — builds a full project per edition, drives the loader over it
+  loose and repacked into its real encrypted archive, and audits that every
+  field in the data has an accessor in the schema (the check that matters when
+  it is pointed at a real game). See
+  [`docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md`](docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -654,6 +654,55 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
 - Reference for the RGSS game library:
   https://www.rpgmaker.fixato.org/Manual/RPGVXAce/rgss/
 
+### VX (RGSS2) and VX Ace (RGSS3)
+
+The two makers between XP and MV keep XP's shape — `Game.ini`, a `Data/` folder
+of Ruby `Marshal` dumps, a bundled script bundle that *is* the engine — and
+change the data extension (`.rvdata` / `.rvdata2`), the record schema and the
+screen (544×416). Full rationale:
+[`docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md`](adr/0024-rpgvx-rgss2-rgss3-data-layer.md).
+
+- ✅ **Data layer** — `mruby-rpgvx/mrblib/rgss2_data.rb` declares the RGSS2 and
+  RGSS3 `RPG::*` schema (VX Ace's `BaseItem#features`, `damage`/`effects`
+  usables, `Class#params`, per-map `Tilesets` and the fourth region layer; VX's
+  `Actor#parameters`, `Areas` and game-wide `System#passages`) so every
+  `Data/*.rvdata(2)` loads through `Marshal.load`, and `RPGVX::RGSSData` exposes
+  them as an edition-aware database (extension, table set, maps on demand,
+  script-bundle decoding). Both editions share the one `RPG::` namespace with
+  the XP schema, which is why the RGSS3 superclass chain is carried by
+  `*Fields` modules rather than real superclasses — see the ADR.
+- ✅ **Detection & dispatch** — VX Ace is `Data/System.rvdata2` or
+  `Game.rgss3a`, VX is `Data/System.rvdata` or `Game.rgss2a` (a packed release
+  ships no loose `Data/`, so the archive is the only marker). `src/main.cxx`
+  checks this **before** the XP branch — a VX project has a `Game.ini` too, so
+  it used to be handed to the XP runtime and fail on the missing
+  `Data/System.rxdata` — and sizes the window to 544×416.
+- ✅ **Encrypted archives** — `Game.rgss2a` (v1) and `Game.rgss3a` (v3) load
+  through the XP reader (`RPGXP::RGSSAD`) unchanged, so a single-archive release
+  boots with no loose files. Same remaining gap as XP: graphics/audio are still
+  read from loose files only.
+- 🚧 **Run the bundled scripts** — a VX/VX Ace game's engine is its script
+  bundle, so this is *the* path rather than a later refinement. The host already
+  runs (`RPGXP::ScriptHost`, ADR 0017) with the per-frame Fiber driver now
+  shared by both shells (`ScriptHost.build_driver`, ADR 0023); what is missing is
+  the RGSS2/RGSS3 halves of the `mruby-rgss` class library the stock scripts call
+  (the RGSS1 gap is tracked in
+  [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md); RGSS2 added
+  `Graphics.wait/fadeout`, `Window#openness`, `Cache`, and RGSS3 the `rgss_main`
+  wrapper and `Bitmap#draw_text` sizing the VX windows rely on).
+- **Built-in title/map flow** — the reimplemented scene stack the RPG2000 and XP
+  runtimes have (title → New Game → walkable map). Not written yet; a boot
+  without the script host reports that instead of showing a blank window.
+- **A real test bed.** Neither editor nor its RTP is redistributable and no
+  open-source VX/VX Ace project ships a genuine `Data/*.rvdata(2)` tree, so
+  `scripts/rpgvx_testbed_check.rb` builds a full project per edition instead and
+  drives the loader over it (loose, then repacked into the real archive
+  formats). A generated bed cannot prove a *field name* — the names are
+  transcribed from the RGSS2/RGSS3 references — so the check also audits that
+  every field in the data has an accessor, which is what makes running it
+  against a user's real game (`ruby scripts/rpgvx_testbed_check.rb path/to/Game`)
+  worthwhile. Finding a redistributable bed for CI remains open.
+
 ## RPG Maker with JavaScript
 
 Support the JavaScript makers (RPG Maker **MV**, then **MZ**) by embedding a real

--- a/docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md
+++ b/docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md
@@ -1,0 +1,117 @@
+# 24. RPG Maker VX / VX Ace data layer (RGSS2 / RGSS3)
+
+Date: 2026-08-04
+
+## Status
+
+Accepted
+
+## Context
+
+The engine covers RPG Maker 2000/2003 (LCF), XP (RGSS1) and the JavaScript
+makers (MV/MZ). The two makers in between — **VX** (RGSS2) and **VX Ace**
+(RGSS3) — were only reachable by accident: `RPGXP::RGSSAD` already decrypts
+their release archives (`Game.rgss2a` is XP's version-1 format; `Game.rgss3a` is
+the version-3 one, ADR "rgss3a"), but nothing could read what is inside them,
+and `src/main.cxx` dispatched **any** directory holding a `Game.ini` to the XP
+runtime — so a VX project was mis-detected as XP and failed on the first
+`Data/System.rxdata` that does not exist.
+
+Structurally VX and VX Ace are XP: `Game.ini`, a `Data/` folder of Ruby
+`Marshal` dumps, a bundled script bundle that *is* the game engine. Three things
+differ:
+
+- the data extension — `.rvdata` (VX) and `.rvdata2` (VX Ace);
+- the record schema — RGSS2 reworked XP's records (icon *indices*, faces,
+  vehicles, `terms`, the item/actor page conditions), and RGSS3 reworked them
+  again around a **feature** system: most records derive from `RPG::BaseItem`
+  and carry `features`, skills/items carry a `damage` formula plus an `effects`
+  list instead of fixed recovery fields, and per-level stats moved from
+  `RPG::Actor#parameters` onto `RPG::Class#params`. VX ships `Areas` and one
+  game-wide tileset (`RPG::System#passages`); VX Ace dropped areas, added
+  per-map `Tilesets` with a `flags` table, and gave maps a fourth data layer of
+  region ids;
+- the screen — 544x416 instead of XP's 640x480.
+
+There is no fetchable test bed for either edition. Both editors and their RTPs
+are commercial, and unlike XP (OpenGame) and MV (the MIT `rpgtkoolmv`
+corescript) no open-source project ships a genuine `Data/*.rvdata(2)` tree, so
+the schema cannot be validated against real editor output in CI the way
+`lcf_testbed_check.rb` and `rpgxp_testbed_check.rb` validate theirs.
+
+## Decision
+
+Add a `mruby-rpgvx` gem that layers the VX/VX Ace data layer on the XP runtime,
+mirroring how the XP layer was staged (ADR 0010).
+
+- **Schema** (`mrblib/rgss2_data.rb`). Declare the RGSS2 and RGSS3 records as
+  behaviour-free attribute holders, so every `Data/*.rvdata(2)` file loads
+  straight through `Marshal.load`. Field names are transcribed from the VX and
+  VX Ace "RPG module" references, cross-checked between two independent
+  transcriptions of the same chapters (the `rpg-maker-rgss3` reference gem and
+  the `rgss_db` tool, which agree field-for-field on RGSS3 and gave the RGSS2
+  set), the way ADR 0002 sources the LCF schema from the analysis wiki rather
+  than from guesses.
+- **One `RPG::` namespace.** `Marshal` resolves a class by its absolute path
+  from `Object`, so `RPG::Actor` in an `.rvdata2` stream and `RPG::Actor` in an
+  `.rxdata` stream are necessarily the same class in a build that links both
+  runtimes. The VX schema therefore *reopens* mruby-rpgxp's classes and adds its
+  fields; a record only carries the ivars its own stream wrote, so the unused
+  accessors read back nil. RGSS3's superclass chain (BaseItem → UsableItem /
+  EquipItem → Skill / Item / Weapon / Armor) cannot be expressed with real
+  superclasses for the same reason — a class's superclass cannot change when it
+  is reopened — so the inherited fields live in `BaseItemFields` /
+  `UsableItemFields` / `EquipItemFields` modules that both the concrete classes
+  and the (documentation-only) abstract classes include.
+- **Loader** (`mrblib/rgss_data.rb`). `RPGVX::RGSSData` is the XP loader's
+  counterpart, parameterised by edition: the extension, the edition-specific
+  tables (`Areas` vs `Tilesets`) and the archive name. Encrypted releases reuse
+  `RPGXP::RGSSAD` unchanged.
+- **Detection** (`mrblib/lib.rb`, `src/main.cxx`). A project is VX Ace when it
+  has `Data/System.rvdata2` or `Game.rgss3a`, VX when it has
+  `Data/System.rvdata` or `Game.rgss2a` — the archive counts on its own because
+  a packed release ships no loose `Data/` at all, and it is the only way to tell
+  a packed VX release from a packed VX Ace one. `main.cxx` checks this **before**
+  the XP branch (which keys on `Game.ini`, which VX projects also have) and sizes
+  the window to 544x416.
+- **Booting.** A VX/VX Ace game's engine *is* its script bundle, so rather than
+  reimplementing a title/map flow first (the RPG2000/XP staging), the boot shell
+  runs the project's own scripts through the existing RGSS script host when it is
+  enabled (`RGSS_SCRIPT_HOST`, ADR 0017), driven by the same per-frame Fiber as
+  XP (ADR 0023 — its construction moved into `RPGXP::ScriptHost.build_driver` so
+  both shells share one driver). Without the host the shell reports the pending
+  runtime instead of opening a blank window, as the MZ shell does.
+- **Validation** (`scripts/rpgvx_testbed_check.rb`). Since no real bed can be
+  downloaded, the check *builds* a complete project per edition — every `Data/`
+  table, a map with an event, a common event, a script bundle — and drives the
+  loader over it loose on disk and then repacked into the edition's real
+  encrypted archive (`Game.rgss2a` v1 / `Game.rgss3a` v3), asserting the
+  cross-references and the structural differences between the editions (three
+  vs four map layers, `System#passages` vs `Tileset#flags`, `Areas` vs
+  `Tilesets`). It also runs a **schema audit**: every instance variable in the
+  loaded data must have an accessor. That audit is trivially true for the
+  generated bed and is the whole point when the script is pointed at a real
+  game, which is how a user with a VX/VX Ace project validates the schema:
+  `ruby scripts/rpgvx_testbed_check.rb path/to/Game`.
+
+## Consequences
+
+- A VX or VX Ace project — unpacked or shipped as a single encrypted archive —
+  now loads: its whole database is readable through a typed schema, and it is
+  routed to its own runtime at the right resolution instead of crashing the XP
+  one.
+- A packed VX Ace release can be run end to end by the script host (whatever the
+  RGSS class library covers), because `read_object` resolves through the
+  archive.
+- The generated test bed proves the *path*, not the *names*. A field the
+  transcription got wrong or missed would only surface against real editor
+  output; the schema audit makes that failure loud the moment someone runs the
+  check on a real game, and a downloadable bed remains the wanted follow-up.
+- The three editions sharing one `RPG::` namespace means a class carries the
+  union of XP/VX/VX Ace fields. That is harmless for data (streams only set what
+  they wrote) but means the schema files, not the class definitions, are the
+  place to look up which fields an edition actually has.
+- Still to come, in order: reading graphics/audio out of the archive (shared
+  with the XP gap), the built-in title/map flow for a project whose scripts are
+  not run, and the RGSS2/RGSS3 halves of the `mruby-rgss` class library the
+  bundled scripts call (`docs/rpgxp-rgss-api-gap.md` tracks the RGSS1 set).

--- a/mruby-rpgvx/mrbgem.rake
+++ b/mruby-rpgvx/mrbgem.rake
@@ -1,0 +1,26 @@
+MRuby::Gem::Specification.new('mruby-rpgvx') do |spec|
+  spec.license = 'MIT'
+  spec.author = 'take-cheeze'
+  spec.summary = 'RPG Maker VX / VX Ace (RGSS2 / RGSS3) runtime'
+
+  # The VX side is layered on the XP runtime rather than duplicating it: the
+  # encrypted-archive reader (RPGXP::RGSSAD, which already decodes VX's
+  # `Game.rgss2a` and VX Ace's `Game.rgss3a`), the RGSS script host and the
+  # top-level Table/Color/Tone/Rect bindings Marshal resolves through are all
+  # shared. Declaring the dependency also fixes the load order: mruby-rpgxp's
+  # `RPG::*` schema is evaluated first, and rgss2_data.rb then reopens those
+  # classes with the RGSS2/RGSS3 fields (see the header of that file).
+  add_dependency 'mruby-rpgxp'
+  # Data/*.rvdata(2) are Ruby Marshal dumps, like XP's .rxdata.
+  add_dependency 'mruby-marshal'
+  add_dependency 'mruby-io'
+  # Array#compact, used to count the 1-based (nil at index 0) database tables.
+  add_dependency 'mruby-array-ext'
+
+  # Load order matters: lib.rb defines the RPGVX class and its WIDTH/HEIGHT/TILE
+  # constants, which the data sources read at class-body evaluation time. Set the
+  # order explicitly rather than relying on the default alphabetical glob.
+  spec.rbfiles = %w[lib rgss2_data rgss_data].map do |name|
+    "#{dir}/mrblib/#{name}.rb"
+  end
+end

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -1,0 +1,212 @@
+# RPG Maker VX / VX Ace runtime.
+#
+# VX (RGSS2) and VX Ace (RGSS3) are the two RGSS makers between XP and MV. They
+# keep XP's shape — a `Game.ini`, a `Data/` folder of Ruby `Marshal` dumps and a
+# bundled script bundle that *is* the engine — and change three things that
+# matter to a player:
+#
+#   * the data extension (`.rvdata` / `.rvdata2`) and the record schema
+#     (mrblib/rgss2_data.rb),
+#   * the encrypted-archive name (`Game.rgss2a`, the same version-1 format as
+#     XP's `.rgssad`; `Game.rgss3a`, the version-3 format) — both already
+#     decoded by `RPGXP::RGSSAD`,
+#   * the screen: 544x416 instead of XP's 640x480.
+#
+# This file is the boot shell: it detects which of the two editions a directory
+# holds, loads the database through `RPGVX::RGSSData`, and — because a VX/VX Ace
+# game ships its whole engine as Ruby — runs the project's own scripts through
+# the shared RGSS script host when that is enabled. A reimplemented built-in
+# title/map flow (what mruby-rpg2k and mruby-rpgxp do) is not built yet; until it
+# is, a boot without the script host reports the pending runtime rather than
+# showing a blank window. See docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md.
+#
+# Deliberately free of load-time RGSS references so the pure logic here (edition
+# detection, path mapping) can be loaded and exercised under CRuby by
+# scripts/rpgvx_testbed_check.rb.
+class RPGVX
+  # RPG Maker VX and VX Ace both render at 544x416 with 32px tiles. src/main.cxx
+  # sizes the window to match when a VX project is detected and the size was not
+  # overridden on the command line.
+  WIDTH = 544
+  HEIGHT = 416
+  TILE = 32
+
+  # The two editions, most recent first — detection order matters for a project
+  # that carries both (an upgraded VX project keeps its old `.rvdata` files
+  # beside the converted ones, and the editor treats it as VX Ace).
+  #
+  #   ext     - the Data/ file extension
+  #   archive - the encrypted release archive that stands in for a loose Data/
+  #   system  - the marker file identifying an unpacked project
+  #   rgss    - the RGSS version the edition's scripts are written against
+  EDITIONS = {
+    vxace: {
+      name: "RPG Maker VX Ace", ext: ".rvdata2", archive: "Game.rgss3a",
+      system: "Data/System.rvdata2", rgss: 3
+    },
+    vx: {
+      name: "RPG Maker VX", ext: ".rvdata", archive: "Game.rgss2a",
+      system: "Data/System.rvdata", rgss: 2
+    }
+  }.freeze
+
+  class << self
+    # Pure predicate: given the set of project-relative files that exist, which
+    # edition (if any) is this? Split out from `detect` so it can be exercised
+    # without touching the filesystem (see mruby-rpgvx/test).
+    def edition_for(present)
+      EDITIONS.each do |edition, info|
+        return edition if present.include?(info[:system]) ||
+                          present.include?(info[:archive])
+      end
+      nil
+    end
+
+    # The edition of the project in `dir`, or nil when it is not a VX/VX Ace
+    # project. A packed release ships no loose `Data/`, so the archive counts as
+    # a marker in its own right — which is also the only way to tell a packed VX
+    # release from a packed VX Ace one.
+    def detect(dir = GAME_DIR)
+      EDITIONS.each do |edition, info|
+        return edition if File.exist?("#{dir}/#{info[:system]}") ||
+                          File.exist?("#{dir}/#{info[:archive]}")
+      end
+      nil
+    end
+
+    def project?(dir = GAME_DIR)
+      !detect(dir).nil?
+    end
+
+    def info(edition)
+      EDITIONS[edition] || raise("unknown RPG Maker VX edition: #{edition.inspect}")
+    end
+
+    # The Data/ file extension of an edition (".rvdata" / ".rvdata2").
+    def data_ext(edition)
+      info(edition)[:ext]
+    end
+
+    def edition_name(edition)
+      info(edition)[:name]
+    end
+
+    # False until the built-in title/map flow exists. The database layer and the
+    # script host below are real; a game still cannot boot without one of them.
+    def runtime_available?
+      false
+    end
+  end
+
+  def initialize(_args)
+    @edition = self.class.detect(GAME_DIR)
+    @db = RGSSData.new(GAME_DIR, @edition) if @edition
+    @title = read_title
+    # A VX/VX Ace project's engine *is* its script bundle, so the script host is
+    # the only path that can currently run one. Off by default, like XP's.
+    @use_script_host = @db && RPGXP::ScriptHost.enabled? && @db.scripts?
+    setup_script_host_driver if @use_script_host
+  rescue StandardError => e
+    # A data problem must not crash the binary to a blank window; report it and
+    # let #start fall through to the pending notice.
+    $stderr.puts "[RGSS2] failed to load the #{maker_name} database: #{e.message}"
+    @db = nil
+  end
+
+  attr_reader :db, :edition, :title
+
+  # The edition's display name, for logs ("RPG Maker VX Ace").
+  def maker_name
+    @edition ? self.class.edition_name(@edition) : "RPG Maker VX"
+  end
+
+  # Native entry point. Report what was detected and loaded, then either drive
+  # the project's own scripts (when the host is enabled) or report the pending
+  # built-in runtime — mirroring how the MZ side reports its staged state.
+  def start
+    report_database
+    if @host_fiber
+      loop do
+        main_loop
+        break if @host_done
+      end
+    else
+      warn_runtime_pending
+    end
+  rescue RGSS::Timeout
+  end
+
+  # One frame. Both the desktop loop above and the web per-frame callback
+  # (src/main.cxx) call this.
+  def main_loop
+    return drive_script_host if @host_fiber
+    warn_runtime_pending
+  end
+
+  private
+
+  # Log the detected edition and a one-line summary of the loaded database. The
+  # `[RGSS2-DB]` marker is what scripts/rpgvx_testbed_check.rb looks for when it
+  # is pointed at a real project through the built binary.
+  def report_database
+    unless @db
+      $stderr.puts "[RGSS2] no RPG Maker VX / VX Ace project found under #{GAME_DIR}"
+      return
+    end
+    $stderr.puts "[RGSS2-DB] #{maker_name} #{@title.inspect}: " \
+                 "#{@db.summary}#{@db.archived? ? " (packed archive)" : ""}"
+  end
+
+  # The window/log title: VX and VX Ace both keep it in the database
+  # (`System#game_title`, which the editor also mirrors into Game.ini), so read
+  # it there and fall back to the folder name.
+  def read_title
+    title = @db && @db.system && @db.system.game_title
+    return title if title.is_a?(String) && !title.empty?
+    File.basename(GAME_DIR)
+  rescue StandardError => e
+    $stderr.puts "[RGSS2] could not read the game title: #{e.message}"
+    "RPG Maker VX"
+  end
+
+  # Build the driver Fiber for the bundled scripts, so their blocking main loop
+  # advances one frame per `main_loop` call (the web build's per-frame callback
+  # must get control back every frame). Shared with the XP runtime; see
+  # docs/adr/0023-rpgxp-script-host-frame-driver.md.
+  def setup_script_host_driver
+    @host_fiber = RPGXP::ScriptHost.build_driver(@db)
+  end
+
+  # Advance the script host by one frame. When its Main returns the Fiber is
+  # dead and the game is over; a failure logs and falls back to the pending
+  # notice rather than crashing to a blank screen.
+  def drive_script_host
+    if @host_fiber.alive?
+      @host_fiber.resume
+    else
+      @host_fiber = nil
+      @host_done = true
+    end
+  rescue RGSS::Timeout
+    @host_fiber = nil
+    @host_done = true
+  rescue StandardError => e
+    $stderr.puts "[RGSS2] script host failed (#{e.class}: #{e.message})"
+    @host_fiber = nil
+    @host_done = true
+  end
+
+  # Report the pending runtime once. Emscripten drives main_loop every frame, so
+  # without the guard this would print on each one.
+  def warn_runtime_pending
+    return if @warned_runtime_pending
+    @warned_runtime_pending = true
+    $stderr.puts "[RGSS2] #{maker_name} support is under construction: the " \
+                 "database (Data/*#{@edition ? self.class.data_ext(@edition) : ".rvdata"}, " \
+                 "loose or inside an encrypted archive) loads, but the built-in " \
+                 "title/map flow is not written yet. A project that ships its " \
+                 "scripts can be driven by the RGSS script host instead " \
+                 "(RGSS_SCRIPT_HOST=1). See " \
+                 "docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md."
+  end
+end

--- a/mruby-rpgvx/mrblib/rgss2_data.rb
+++ b/mruby-rpgvx/mrblib/rgss2_data.rb
@@ -1,0 +1,404 @@
+# RPG Maker VX (RGSS2) and VX Ace (RGSS3) data schema.
+#
+# Both editions store their database exactly the way RPG Maker XP does — one
+# Ruby `Marshal` dump per `Data/` file — so, as for XP (see
+# mruby-rpgxp/mrblib/rgss_data.rb), the "parser" is just the class table below:
+# `Marshal.load` allocates each object by name and sets its instance variables
+# directly, calling no `initialize`. Only the file extension changes:
+# `.rvdata` for VX, `.rvdata2` for VX Ace. The RGSS value types
+# (`Table`/`Color`/`Tone`/`Rect`) are the native mruby-rgss classes bound at the
+# top level by mruby-rpgxp's lib.rb, so the bare names in the stream resolve.
+#
+# What *does* change is the schema. RGSS2 reworked the RPG2000-era record layout
+# XP used (icon indices instead of icon file names, `parameters` tables, faces,
+# vehicles, terms), and RGSS3 reworked it again around a feature system: most
+# records gain `features` and derive from `RPG::BaseItem`, skills/items carry a
+# `damage` formula plus an `effects` list instead of fixed recovery fields, and
+# actors/classes moved their stats into `RPG::Class#params`.
+#
+# ## One RPG:: namespace, three editions
+#
+# A single build links the XP and VX runtimes, and `Marshal` resolves a class by
+# its absolute path from `Object` — so `RPG::Actor` in an `.rvdata2` stream and
+# `RPG::Actor` in an `.rxdata` stream are necessarily the *same* class. This file
+# therefore reopens the shared classes and adds the RGSS2/RGSS3 fields rather
+# than declaring a competing schema; a record only ever carries the ivars its own
+# stream wrote, so the unused accessors simply read back nil.
+#
+# For the same reason the RGSS3 superclass chain (BaseItem → UsableItem /
+# EquipItem → Skill / Item / Weapon / Armor / …) cannot be expressed with real
+# superclasses: mruby-rpgxp already declares those concrete classes flat, and a
+# class's superclass cannot change when it is reopened. The inherited fields are
+# carried by the `*Fields` modules below instead, which the (otherwise unused)
+# abstract classes include as well — so `RPG::BaseItem` still documents the RGSS3
+# shape while `RPG::Skill` answers `#features`. Everything here is deliberately
+# behaviour-free: these are attribute holders that mirror the editor's data model
+# 1:1, so the runtime and the host-side check (scripts/rpgvx_testbed_check.rb,
+# which loads this exact file under CRuby) read the same fields.
+#
+# Field names and their nesting follow the RGSS2 / RGSS3 references (the VX and
+# VX Ace help files' "RPG module" chapters); see
+# docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md for the sourcing. Fields present
+# in only one edition are marked `(VX)` or `(Ace)`.
+
+module RPG
+  # ---- RGSS3 record bases ---------------------------------------------------
+
+  # Fields every database record carries. VX has `id`/`name`/`icon_index`/
+  # `description`/`note`; VX Ace adds `features`, the list of
+  # `RPG::BaseItem::Feature` entries that replaced RGSS2's fixed trait fields.
+  module BaseItemFields
+    attr_accessor :id, :name, :icon_index, :description, :features, :note
+  end
+
+  # Fields of a usable (skill / item). RGSS2 spells its effect out in fixed
+  # fields (`base_damage`, `atk_f`, the recovery rates on Item); RGSS3 replaced
+  # them with a `damage` formula object plus a list of `effects`.
+  module UsableItemFields
+    include BaseItemFields
+
+    attr_accessor :scope, :occasion, :speed, :animation_id
+    # RGSS2 (VX).
+    attr_accessor :common_event_id, :base_damage, :variance, :atk_f, :spi_f,
+                  :physical_attack, :damage_to_mp, :absorb_damage,
+                  :ignore_defense, :element_set, :plus_state_set,
+                  :minus_state_set
+    # RGSS3 (Ace).
+    attr_accessor :success_rate, :repeats, :tp_gain, :hit_type, :damage,
+                  :effects
+  end
+
+  # Fields of an equippable (weapon / armour). RGSS3 only; VX's Weapon/Armor
+  # spell their price and stat bonuses out individually (see below).
+  module EquipItemFields
+    include BaseItemFields
+
+    attr_accessor :price, :etype_id, :params
+  end
+
+  # The abstract RGSS3 record classes. Nothing is ever serialised *as* one, but
+  # `Feature`, `Damage` and `Effect` are nested inside them, so the namespaces
+  # have to exist — and having them carry their fields keeps the documented
+  # hierarchy honest.
+  class BaseItem
+    include BaseItemFields
+
+    # An RGSS3 trait: a `code` (element rate, parameter, skill add, ...), the
+    # `data_id` it applies to and its `value`.
+    class Feature
+      attr_accessor :code, :data_id, :value
+    end
+  end
+
+  class UsableItem < BaseItem
+    include UsableItemFields
+
+    # An RGSS3 damage formula: `type` (none/HP damage/MP recover/...), the
+    # element, the Ruby `formula` string the engine evals, its `variance`
+    # percentage and whether it can crit.
+    class Damage
+      attr_accessor :type, :element_id, :formula, :variance, :critical
+    end
+
+    # One RGSS3 use effect (recover HP, add state, learn skill, ...).
+    class Effect
+      attr_accessor :code, :data_id, :value1, :value2
+    end
+  end
+
+  class EquipItem < BaseItem
+    include EquipItemFields
+  end
+
+  # ---- Audio ----------------------------------------------------------------
+
+  # RGSS2 introduced one class per audio slot. They are plain AudioFile
+  # subclasses in the data (RGSS gives them `play`/`stop` helpers); a stream
+  # names them, so they must exist. AudioFile itself is declared by
+  # mruby-rpgxp's schema and shared.
+  class AudioFile
+    attr_accessor :name, :volume, :pitch
+  end
+
+  class BGM < AudioFile
+    attr_accessor :pos # (Ace) resume position, saved with the game
+  end
+
+  class BGS < AudioFile
+    attr_accessor :pos # (Ace)
+  end
+
+  class ME < AudioFile
+  end
+
+  class SE < AudioFile
+  end
+
+  # ---- Database records -----------------------------------------------------
+
+  class Actor
+    include BaseItemFields
+
+    attr_accessor :class_id, :initial_level, :character_name, :character_index,
+                  :face_name, :face_index
+    # (VX) stats live on the actor, as in XP, and equipment is five id fields.
+    attr_accessor :exp_basis, :exp_inflation, :parameters, :weapon_id,
+                  :armor1_id, :armor2_id, :armor3_id, :armor4_id,
+                  :two_swords_style, :fix_equipment, :auto_battle,
+                  :super_guard, :pharmacology, :critical_bonus
+    # (Ace) stats moved to the class; equipment is one `equips` array and the
+    # traits above became `features`.
+    attr_accessor :nickname, :max_level, :equips
+  end
+
+  class Class
+    include BaseItemFields
+
+    attr_accessor :learnings
+    # (VX)
+    attr_accessor :position, :weapon_set, :armor_set, :element_ranks,
+                  :state_ranks, :skill_name_valid, :skill_name
+    # (Ace) the level-curve parameters and the 8 x max-level stat table.
+    attr_accessor :exp_params, :params
+
+    class Learning
+      attr_accessor :level, :skill_id, :note
+    end
+  end
+
+  class Skill
+    include UsableItemFields
+
+    attr_accessor :mp_cost, :message1, :message2
+    attr_accessor :hit # (VX)
+    # (Ace)
+    attr_accessor :stype_id, :tp_cost, :required_wtype_id1, :required_wtype_id2
+  end
+
+  class Item
+    include UsableItemFields
+
+    attr_accessor :price, :consumable
+    # (VX)
+    attr_accessor :hp_recovery_rate, :hp_recovery, :mp_recovery_rate,
+                  :mp_recovery, :parameter_type, :parameter_points
+    attr_accessor :itype_id # (Ace) normal item / key item
+  end
+
+  class Weapon
+    include EquipItemFields
+
+    attr_accessor :animation_id
+    # (VX)
+    attr_accessor :hit, :atk, :def, :spi, :agi, :two_handed, :fast_attack,
+                  :dual_attack, :critical_bonus, :element_set, :state_set
+    attr_accessor :wtype_id # (Ace)
+  end
+
+  class Armor
+    include EquipItemFields
+
+    # (VX) — `kind` is the slot (shield/helmet/body/accessory) VX Ace renamed to
+    # `etype_id`, with `atype_id` becoming the armour *type*.
+    attr_accessor :kind, :eva, :atk, :def, :spi, :agi, :prevent_critical,
+                  :half_mp_cost, :double_exp_gain, :auto_hp_recover,
+                  :element_set, :state_set
+    attr_accessor :atype_id # (Ace)
+  end
+
+  class Enemy
+    include BaseItemFields
+
+    attr_accessor :battler_name, :battler_hue, :exp, :gold, :actions
+    # (VX)
+    attr_accessor :maxhp, :maxmp, :atk, :def, :spi, :agi, :hit, :eva,
+                  :drop_item1, :drop_item2, :levitate, :has_critical,
+                  :element_ranks, :state_ranks
+    # (Ace) the eight-stat array and the three-slot drop table.
+    attr_accessor :params, :drop_items
+
+    class Action
+      attr_accessor :skill_id, :condition_type, :condition_param1,
+                    :condition_param2, :rating
+      attr_accessor :kind, :basic # (VX) attack / defend / escape / skill
+    end
+
+    class DropItem
+      attr_accessor :kind, :denominator
+      attr_accessor :item_id, :weapon_id, :armor_id # (VX)
+      attr_accessor :data_id                        # (Ace)
+    end
+  end
+
+  class State
+    include BaseItemFields
+
+    attr_accessor :restriction, :priority, :message1, :message2, :message3,
+                  :message4
+    # (VX)
+    attr_accessor :atk_rate, :def_rate, :spi_rate, :agi_rate, :nonresistance,
+                  :offset_by_opposite, :slip_damage, :reduce_hit_ratio,
+                  :battle_only, :release_by_damage, :hold_turn,
+                  :auto_release_prob, :element_set, :state_set
+    # (Ace) removal is described declaratively instead.
+    attr_accessor :remove_at_battle_end, :remove_by_restriction,
+                  :auto_removal_timing, :min_turns, :max_turns,
+                  :remove_by_damage, :chance_by_damage, :remove_by_walking,
+                  :steps_to_remove
+  end
+
+  # RGSS2 split the single XP animation sheet into two (`animation1_*` behind
+  # the battler, `animation2_*` in front).
+  class Animation
+    attr_accessor :id, :name, :animation1_name, :animation1_hue,
+                  :animation2_name, :animation2_hue, :position, :frame_max,
+                  :frames, :timings
+
+    class Frame
+      attr_accessor :cell_max, :cell_data
+    end
+
+    class Timing
+      attr_accessor :frame, :se, :flash_scope, :flash_color, :flash_duration
+    end
+  end
+
+  # (Ace) VX Ace restored per-map tilesets: nine sheet names (A1..A5, B..E) and
+  # one flags table of 8192 passage/priority/terrain words. VX has a single
+  # game-wide tileset whose flags live in `RPG::System#passages`, and no
+  # `Tilesets` file at all.
+  class Tileset
+    attr_accessor :id, :mode, :name, :tileset_names, :flags, :note
+  end
+
+  # (VX) A named rectangle on a map with its own encounter list — VX Ace dropped
+  # areas in favour of the region ids painted into the map's fourth data layer.
+  class Area
+    attr_accessor :id, :name, :map_id, :rect, :encounter_list, :order
+  end
+
+  class CommonEvent
+    attr_accessor :id, :name, :trigger, :switch_id, :list
+  end
+
+  class MapInfo
+    attr_accessor :name, :parent_id, :order, :expanded, :scroll_x, :scroll_y
+  end
+
+  class Map
+    attr_accessor :width, :height, :scroll_type, :autoplay_bgm, :bgm,
+                  :autoplay_bgs, :bgs, :disable_dashing, :encounter_list,
+                  :encounter_step, :parallax_name, :parallax_loop_x,
+                  :parallax_loop_y, :parallax_sx, :parallax_sy, :parallax_show,
+                  :data, :events
+    # (Ace) — VX has neither a per-map tileset nor a per-map battleback, and its
+    # `encounter_list` is a plain troop-id array where Ace's holds Encounters.
+    attr_accessor :display_name, :tileset_id, :specify_battleback,
+                  :battleback1_name, :battleback2_name, :note
+
+    # (Ace) one weighted encounter entry, optionally restricted to regions.
+    class Encounter
+      attr_accessor :troop_id, :weight, :region_set
+    end
+  end
+
+  class Event
+    attr_accessor :id, :name, :x, :y, :pages
+
+    class Page
+      attr_accessor :condition, :graphic, :move_type, :move_speed,
+                    :move_frequency, :move_route, :walk_anime, :step_anime,
+                    :direction_fix, :through, :priority_type, :trigger, :list
+
+      # RGSS2 added the item / actor page conditions and replaced XP's
+      # `always_on_top` with the three-way `priority_type` on the page.
+      class Condition
+        attr_accessor :switch1_valid, :switch2_valid, :variable_valid,
+                      :self_switch_valid, :item_valid, :actor_valid,
+                      :switch1_id, :switch2_id, :variable_id, :variable_value,
+                      :self_switch_ch, :item_id, :actor_id
+      end
+
+      # A character sheet holds eight characters from VX on, so the graphic
+      # picks one with `character_index` instead of XP's per-file hue.
+      class Graphic
+        attr_accessor :tile_id, :character_name, :character_index, :direction,
+                      :pattern
+      end
+    end
+  end
+
+  class EventCommand
+    attr_accessor :code, :indent, :parameters
+  end
+
+  class MoveRoute
+    attr_accessor :repeat, :skippable, :wait, :list
+  end
+
+  class MoveCommand
+    attr_accessor :code, :parameters
+  end
+
+  class Troop
+    attr_accessor :id, :name, :members, :pages
+
+    class Member
+      attr_accessor :enemy_id, :x, :y, :hidden
+      attr_accessor :immortal # (VX)
+    end
+
+    class Page
+      attr_accessor :condition, :span, :list
+
+      class Condition
+        attr_accessor :turn_ending, :turn_valid, :enemy_valid, :actor_valid,
+                      :switch_valid, :turn_a, :turn_b, :enemy_index, :enemy_hp,
+                      :actor_id, :actor_hp, :switch_id
+      end
+    end
+  end
+
+  class System
+    attr_accessor :game_title, :version_id, :party_members, :elements,
+                  :switches, :variables, :boat, :ship, :airship, :title_bgm,
+                  :battle_bgm, :battle_end_me, :gameover_me, :sounds,
+                  :test_battlers, :test_troop_id, :start_map_id, :start_x,
+                  :start_y, :terms, :battler_name, :battler_hue, :edit_map_id
+    # (VX) the game-wide tileset's 8192-entry passage table.
+    attr_accessor :passages
+    # (Ace)
+    attr_accessor :japanese, :currency_unit, :skill_types, :weapon_types,
+                  :armor_types, :title1_name, :title2_name, :opt_draw_title,
+                  :opt_use_midi, :opt_transparent, :opt_followers,
+                  :opt_slip_death, :opt_floor_death, :opt_display_tp,
+                  :opt_extra_exp, :window_tone, :battleback1_name,
+                  :battleback2_name
+
+    # The in-game vocabulary (XP's `RPG::System::Words`). VX names every term
+    # individually; VX Ace collapsed them into four indexed arrays.
+    class Terms
+      # (VX)
+      attr_accessor :level, :level_a, :hp, :hp_a, :mp, :mp_a, :atk, :def, :spi,
+                    :agi, :weapon, :armor1, :armor2, :armor3, :armor4,
+                    :weapon1, :weapon2, :attack, :skill, :guard, :item, :equip,
+                    :status, :save, :game_end, :fight, :escape, :new_game,
+                    :continue, :shutdown, :to_title, :cancel, :gold
+      # (Ace) basic[8] (level/HP/MP/TP...), params[8], etypes[5], commands[23].
+      attr_accessor :basic, :params, :etypes, :commands
+    end
+
+    # A boat / ship / airship: its sheet, start position and BGM.
+    class Vehicle
+      attr_accessor :character_name, :character_index, :bgm, :start_map_id,
+                    :start_x, :start_y
+    end
+
+    class TestBattler
+      attr_accessor :actor_id, :level
+      attr_accessor :weapon_id, :armor1_id, :armor2_id, :armor3_id,
+                    :armor4_id # (VX)
+      attr_accessor :equips    # (Ace)
+    end
+  end
+end

--- a/mruby-rpgvx/mrblib/rgss_data.rb
+++ b/mruby-rpgvx/mrblib/rgss_data.rb
@@ -1,0 +1,165 @@
+# RPG Maker VX / VX Ace database loader.
+#
+# The VX counterpart of RPGXP::RGSSData: each accessor is simply the
+# `Marshal.load` of the matching `Data/<name>.rvdata(2)` file, with the record
+# classes declared in rgss2_data.rb. Two things differ from the XP loader:
+#
+#   * the file extension depends on the edition (`.rvdata` for VX, `.rvdata2`
+#     for VX Ace), so the database is built for a detected edition;
+#   * the table set differs — VX ships `Areas` (named map rectangles with their
+#     own encounters) and no tilesets (it has one game-wide tileset, whose
+#     passage flags live in `System#passages`), while VX Ace dropped areas and
+#     added per-map `Tilesets`.
+#
+# The array-typed tables (Actors, Items, ...) are 1-based with a nil at index 0,
+# exactly as the editor writes them; MapInfos is a Hash keyed by map id. Maps are
+# large and loaded on demand.
+#
+# Encrypted releases are handled by the XP archive reader (`RPGXP::RGSSAD`),
+# which already decodes VX's version-1 `Game.rgss2a` and VX Ace's version-3
+# `Game.rgss3a`; a loose file on disk shadows the archive, matching RGSS.
+class RPGVX
+  class RGSSData
+    # The Data/ files both editions ship as an index-addressed array of records.
+    # Each becomes a reader of the same (lower-cased, plural) name.
+    ARRAY_FILES = {
+      actors: "Actors", classes: "Classes", skills: "Skills",
+      items: "Items", weapons: "Weapons", armors: "Armors",
+      enemies: "Enemies", troops: "Troops", states: "States",
+      animations: "Animations", common_events: "CommonEvents"
+    }.freeze
+
+    # Tables only one edition has. Missing on the other edition, where the
+    # reader answers nil.
+    EDITION_FILES = {
+      vx: { areas: "Areas" },
+      vxace: { tilesets: "Tilesets" }
+    }.freeze
+
+    # Every reader this class defines, so a caller can enumerate the database.
+    ALL_FILES = ARRAY_FILES.keys +
+                EDITION_FILES.values.map { |files| files.keys }.flatten
+
+    def initialize(game_dir, edition = nil)
+      @game_dir = game_dir
+      @edition = edition || RPGVX.detect(game_dir)
+      raise "#{game_dir} is not an RPG Maker VX / VX Ace project" unless @edition
+      @ext = RPGVX.data_ext(@edition)
+      @archive = open_archive
+      @system = load_data("System")
+      @map_infos = load_data("MapInfos")
+      @cache = {}
+      ARRAY_FILES.each { |name, file| @cache[name] = load_data(file) }
+      EDITION_FILES[@edition].each { |name, file| @cache[name] = load_data(file) }
+    end
+
+    attr_reader :system, :map_infos, :game_dir, :edition, :ext
+
+    ALL_FILES.each do |name|
+      define_method(name) { @cache[name] }
+    end
+
+    # Load one map (Data/MapNNN.rvdata(2)) by id. Maps are big, so they are not
+    # cached with the rest of the database — the caller loads the one it needs.
+    # Ids are zero-padded to three digits (Map001) without sprintf/format, which
+    # the XP loader avoids for the same reason (this mruby build's gem set is
+    # trimmed).
+    def load_map(id)
+      num = id.to_s
+      num = "0#{num}" while num.size < 3
+      load_data("Map#{num}")
+    end
+
+    # Absolute path of a Data/ entry.
+    def data_path(base)
+      "#{@game_dir}/Data/#{base}#{@ext}"
+    end
+
+    # Whether this project's data lives in an encrypted archive
+    # (Game.rgss2a / Game.rgss3a).
+    def archived?
+      !@archive.nil?
+    end
+
+    def vxace?
+      @edition == :vxace
+    end
+
+    # A one-line census of what loaded, for the boot log.
+    def summary
+      counts = ALL_FILES.map do |name|
+        table = @cache[name]
+        next nil unless table
+        "#{name}=#{table.compact.size}"
+      end
+      counts = counts.compact
+      counts.unshift "maps=#{(@map_infos || {}).size}"
+      counts.join(" ")
+    end
+
+    # Read + Marshal-parse an arbitrary project-relative file, exactly like
+    # RGSS's Kernel#load_data ("Data/System.rvdata2", "Save1.rvdata2", ...). A
+    # loose file on disk shadows the archive, matching RGSS; when there is none
+    # the entry is pulled from the encrypted archive. The RGSS script host uses
+    # this to feed Kernel#load_data.
+    def read_object(relative_path)
+      full = "#{@game_dir}/#{relative_path}"
+      return File.open(full, "rb") { |f| Marshal.load(f.read) } if File.exist?(full)
+      if @archive
+        bytes = @archive.read(relative_path)
+        return Marshal.load(bytes) if bytes
+      end
+      raise "cannot load #{relative_path}: no loose file and no archive entry"
+    end
+
+    # Marshal-dump `obj` to a project-relative file (RGSS's Kernel#save_data).
+    # Always writes a loose file under the game directory — RGSS never writes
+    # back into the encrypted archive — so in-game saving works on a packed
+    # project too.
+    def save_object(obj, relative_path)
+      File.open("#{@game_dir}/#{relative_path}", "wb") { |f| f.write(Marshal.dump(obj)) }
+    end
+
+    # Whether the project ships a script bundle (loose Data/Scripts.rvdata(2) or
+    # the archive entry). Cheap presence check — does not decode the scripts.
+    def scripts?
+      File.exist?(data_path("Scripts")) ||
+        (!@archive.nil? && @archive.include?("Data/Scripts#{@ext}"))
+    end
+
+    # The bundled RGSS scripts as an ordered array of [name, source]. The bundle
+    # has the same shape as XP's: a Marshal array of [id, name, zlib-deflated
+    # source] sections, evaluated top to bottom (the final "Main" section drives
+    # the game). Empty when the project ships no scripts.
+    def scripts
+      return [] unless scripts?
+      read_object("Data/Scripts#{@ext}").map do |section|
+        _id, name, deflated = section
+        [name.to_s, RGSS.zlib_inflate(deflated.to_s)]
+      end
+    end
+
+    private
+
+    # Open the game's encrypted archive if it exists, so a packed project with no
+    # loose Data/ folder still loads. Only this edition's archive counts:
+    # `RGSSAD.find` would also answer an XP `.rgssad`, which cannot hold
+    # `.rvdata` entries. Best effort — an unreadable archive is logged and
+    # treated as absent.
+    def open_archive
+      path = "#{@game_dir}/#{RPGVX.info(@edition)[:archive]}"
+      return nil unless File.exist?(path)
+      RPGXP::RGSSAD.open(path)
+    rescue StandardError => e
+      $stderr.puts "[RGSS2] failed to open archive #{path}: #{e.message}"
+      nil
+    end
+
+    # Load and Marshal-parse a Data/ entry by base name (System, MapInfos,
+    # Map001, ...). Delegates to the public read_object, which reads a loose file
+    # before the archive, matching RGSS.
+    def load_data(base)
+      read_object("Data/#{base}#{@ext}")
+    end
+  end
+end

--- a/mruby-rpgvx/test/rpgvx_test.rb
+++ b/mruby-rpgvx/test/rpgvx_test.rb
@@ -1,0 +1,468 @@
+# Unit tests for the RPG Maker VX / VX Ace layer that need no display and no
+# game on disk: edition detection, the per-edition file mapping and the
+# RGSS2/RGSS3 schema's Marshal round-trip (the real games load the same classes
+# through mruby-marshal). The on-disk and encrypted-archive paths — which need a
+# project tree — are driven by scripts/rpgvx_testbed_check.rb.
+
+# The boot shell reads GAME_DIR when a game is constructed; nothing tested here
+# does, but define a stand-in so the constant is never missing.
+GAME_DIR = "" unless Object.const_defined?(:GAME_DIR)
+
+# ---- Edition detection ----------------------------------------------------
+
+assert "RPGVX.edition_for identifies unpacked projects" do
+  assert_equal :vxace, RPGVX.edition_for(["Game.ini", "Data/System.rvdata2"])
+  assert_equal :vx, RPGVX.edition_for(["Game.ini", "Data/System.rvdata"])
+  # An XP project (or anything else) is not ours.
+  assert_nil RPGVX.edition_for(["Game.ini", "Data/System.rxdata"])
+  assert_nil RPGVX.edition_for([])
+end
+
+assert "RPGVX.edition_for identifies packed releases by their archive" do
+  # A packed release ships no loose Data/ at all, so the archive name is the
+  # only edition marker.
+  assert_equal :vxace, RPGVX.edition_for(["Game.ini", "Game.rgss3a"])
+  assert_equal :vx, RPGVX.edition_for(["Game.ini", "Game.rgss2a"])
+  # XP's own archive is not a VX marker.
+  assert_nil RPGVX.edition_for(["Game.ini", "Game.rgssad"])
+end
+
+assert "RPGVX.edition_for prefers VX Ace when a project carries both" do
+  present = ["Data/System.rvdata", "Data/System.rvdata2"]
+  assert_equal :vxace, RPGVX.edition_for(present)
+end
+
+assert "RPGVX edition metadata" do
+  assert_equal ".rvdata2", RPGVX.data_ext(:vxace)
+  assert_equal ".rvdata", RPGVX.data_ext(:vx)
+  assert_equal "RPG Maker VX Ace", RPGVX.edition_name(:vxace)
+  assert_equal "Game.rgss2a", RPGVX.info(:vx)[:archive]
+  assert_equal 3, RPGVX.info(:vxace)[:rgss]
+  assert_raise(RuntimeError) { RPGVX.info(:mv) }
+end
+
+assert "RPGVX screen geometry is VX's 544x416" do
+  assert_equal 544, RPGVX::WIDTH
+  assert_equal 416, RPGVX::HEIGHT
+  assert_equal 32, RPGVX::TILE
+end
+
+assert "RGSSData maps the edition-specific database tables" do
+  # VX has areas and no tilesets (one game-wide tileset, flags in System);
+  # VX Ace dropped areas and added per-map tilesets.
+  assert_equal({ areas: "Areas" }, RPGVX::RGSSData::EDITION_FILES[:vx])
+  assert_equal({ tilesets: "Tilesets" }, RPGVX::RGSSData::EDITION_FILES[:vxace])
+  assert_true RPGVX::RGSSData::ALL_FILES.include?(:actors)
+  assert_true RPGVX::RGSSData::ALL_FILES.include?(:areas)
+  assert_true RPGVX::RGSSData::ALL_FILES.include?(:tilesets)
+  # Every table is readable on the instance, whichever edition is loaded.
+  RPGVX::RGSSData::ALL_FILES.each do |name|
+    assert_true RPGVX::RGSSData.method_defined?(name), "no reader for #{name}"
+  end
+end
+
+# ---- RGSS2 (VX) schema ----------------------------------------------------
+
+assert "VX RPG::System Marshal round-trip" do
+  sys = RPG::System.new
+  sys.game_title = "VX Test"
+  sys.start_map_id = 1
+  sys.start_x = 8
+  sys.start_y = 6
+  sys.party_members = [1, 2]
+  sys.passages = Table.new(8192)
+  sys.passages[16] = 0x0f
+
+  bgm = RPG::BGM.new
+  bgm.name = "Theme1"
+  bgm.volume = 100
+  bgm.pitch = 100
+  sys.title_bgm = bgm
+
+  boat = RPG::System::Vehicle.new
+  boat.character_name = "Vehicle"
+  boat.character_index = 0
+  boat.start_map_id = 1
+  sys.boat = boat
+
+  terms = RPG::System::Terms.new
+  terms.hp = "HP"
+  terms.new_game = "New Game"
+  terms.gold = "G"
+  sys.terms = terms
+
+  loaded = Marshal.load(Marshal.dump(sys))
+  assert_true loaded.is_a?(RPG::System)
+  assert_equal "VX Test", loaded.game_title
+  assert_equal [1, 2], loaded.party_members
+  assert_true loaded.title_bgm.is_a?(RPG::BGM)
+  assert_true loaded.title_bgm.is_a?(RPG::AudioFile)
+  assert_equal "Theme1", loaded.title_bgm.name
+  assert_true loaded.passages.is_a?(Table)
+  assert_equal 0x0f, loaded.passages[16]
+  assert_equal 0, loaded.passages[17]
+  assert_equal "Vehicle", loaded.boat.character_name
+  assert_equal "New Game", loaded.terms.new_game
+end
+
+assert "VX RPG::Actor keeps its stats table and equipment ids" do
+  actor = RPG::Actor.new
+  actor.id = 1
+  actor.name = "Ralph"
+  actor.class_id = 1
+  actor.initial_level = 1
+  actor.character_name = "Actor1"
+  actor.character_index = 0
+  actor.face_name = "Actor1"
+  actor.face_index = 0
+  actor.weapon_id = 1
+  actor.armor1_id = 2
+  actor.parameters = Table.new(6, 100)
+  actor.parameters[0, 1] = 450
+  actor.parameters[1, 1] = 80
+
+  loaded = Marshal.load(Marshal.dump(actor))
+  assert_equal "Ralph", loaded.name
+  assert_equal 0, loaded.character_index
+  assert_equal 1, loaded.weapon_id
+  assert_true loaded.parameters.is_a?(Table)
+  assert_equal 450, loaded.parameters[0, 1]
+  assert_equal 80, loaded.parameters[1, 1]
+end
+
+assert "VX RPG::Skill carries the fixed damage fields" do
+  skill = RPG::Skill.new
+  skill.id = 1
+  skill.name = "Heal"
+  skill.icon_index = 128
+  skill.scope = 3
+  skill.mp_cost = 5
+  skill.base_damage = -100
+  skill.spi_f = 100
+  skill.variance = 20
+  skill.plus_state_set = []
+  skill.minus_state_set = [3]
+
+  loaded = Marshal.load(Marshal.dump(skill))
+  assert_equal "Heal", loaded.name
+  assert_equal 128, loaded.icon_index
+  assert_equal 5, loaded.mp_cost
+  assert_equal(-100, loaded.base_damage)
+  assert_equal [3], loaded.minus_state_set
+  # RGSS3-only fields simply read back nil on a VX record.
+  assert_nil loaded.damage
+  assert_nil loaded.features
+end
+
+assert "VX RPG::Map is a three-layer table with plain troop encounters" do
+  map = RPG::Map.new
+  map.width = 3
+  map.height = 2
+  map.encounter_list = [1, 1, 2]
+  map.encounter_step = 30
+  map.parallax_name = "BlueSky"
+  map.parallax_loop_x = true
+  map.data = Table.new(3, 2, 3)
+  map.data[0, 0, 0] = 1536
+  map.data[2, 1, 2] = 20
+  map.events = {}
+
+  loaded = Marshal.load(Marshal.dump(map))
+  assert_equal 3, loaded.width
+  assert_equal [1, 1, 2], loaded.encounter_list
+  assert_true loaded.parallax_loop_x
+  assert_equal 1536, loaded.data[0, 0, 0]
+  assert_equal 20, loaded.data[2, 1, 2]
+  assert_nil loaded.tileset_id   # VX has one game-wide tileset
+end
+
+assert "VX RPG::Area round-trips its rectangle" do
+  area = RPG::Area.new
+  area.id = 1
+  area.name = "Forest"
+  area.map_id = 2
+  area.order = 1
+  area.rect = Rect.new(0, 0, 5, 4)
+  area.encounter_list = [3]
+
+  loaded = Marshal.load(Marshal.dump(area))
+  assert_equal "Forest", loaded.name
+  assert_equal 2, loaded.map_id
+  assert_true loaded.rect.is_a?(Rect)
+  assert_equal 5, loaded.rect.width
+  assert_equal [3], loaded.encounter_list
+end
+
+# ---- RGSS3 (VX Ace) schema ------------------------------------------------
+
+assert "VX Ace RPG::System Marshal round-trip" do
+  sys = RPG::System.new
+  sys.game_title = "Ace Test"
+  sys.start_map_id = 1
+  sys.start_x = 10
+  sys.start_y = 8
+  sys.party_members = [1]
+  sys.currency_unit = "G"
+  sys.title1_name = "Book"
+  sys.title2_name = ""
+  sys.opt_draw_title = true
+  sys.window_tone = Tone.new(0, 0, 0)
+  sys.skill_types = [nil, "Special", "Magic"]
+  se = RPG::SE.new
+  se.name = "Cursor1"
+  se.volume = 80
+  sys.sounds = [se]
+
+  terms = RPG::System::Terms.new
+  terms.basic = ["Level", "LV", "HP", "HP", "MP", "MP", "TP", "TP"]
+  terms.params = ["Max HP", "Max MP", "Attack", "Defense",
+                  "M.Attack", "M.Defense", "Agility", "Luck"]
+  terms.etypes = ["Weapon", "Shield", "Head", "Body", "Accessory"]
+  terms.commands = ["Fight", "Escape"]
+  sys.terms = terms
+
+  loaded = Marshal.load(Marshal.dump(sys))
+  assert_equal "Ace Test", loaded.game_title
+  assert_equal "Book", loaded.title1_name
+  assert_true loaded.opt_draw_title
+  assert_true loaded.window_tone.is_a?(Tone)
+  assert_equal "Magic", loaded.skill_types[2]
+  assert_true loaded.sounds[0].is_a?(RPG::SE)
+  assert_equal "Cursor1", loaded.sounds[0].name
+  assert_equal "HP", loaded.terms.basic[2]
+  assert_equal "Accessory", loaded.terms.etypes[4]
+end
+
+assert "VX Ace records carry BaseItem features" do
+  actor = RPG::Actor.new
+  actor.id = 1
+  actor.name = "Eric"
+  actor.nickname = "Hero"
+  actor.class_id = 1
+  actor.initial_level = 1
+  actor.max_level = 99
+  actor.equips = [1, 0, 2, 0, 0]
+  actor.note = "note"
+  f = RPG::BaseItem::Feature.new
+  f.code = 22
+  f.data_id = 0
+  f.value = 0.95
+  actor.features = [f]
+
+  loaded = Marshal.load(Marshal.dump(actor))
+  assert_equal "Hero", loaded.nickname
+  assert_equal 99, loaded.max_level
+  assert_equal [1, 0, 2, 0, 0], loaded.equips
+  assert_true loaded.features[0].is_a?(RPG::BaseItem::Feature)
+  assert_equal 22, loaded.features[0].code
+  assert_equal 0.95, loaded.features[0].value
+end
+
+assert "VX Ace RPG::Class holds the exp curve and the stat table" do
+  klass = RPG::Class.new
+  klass.id = 1
+  klass.name = "Hero"
+  klass.exp_params = [30, 20, 30, 30]
+  klass.params = Table.new(8, 100)
+  klass.params[0, 1] = 450
+  klass.params[2, 1] = 22
+  learning = RPG::Class::Learning.new
+  learning.level = 3
+  learning.skill_id = 5
+  learning.note = ""
+  klass.learnings = [learning]
+
+  loaded = Marshal.load(Marshal.dump(klass))
+  assert_equal [30, 20, 30, 30], loaded.exp_params
+  assert_equal 450, loaded.params[0, 1]
+  assert_equal 22, loaded.params[2, 1]
+  assert_equal 3, loaded.learnings[0].level
+  assert_equal 5, loaded.learnings[0].skill_id
+end
+
+assert "VX Ace usable items carry a damage formula and effects" do
+  skill = RPG::Skill.new
+  skill.id = 1
+  skill.name = "Fire"
+  skill.stype_id = 1
+  skill.mp_cost = 5
+  skill.tp_cost = 0
+  skill.scope = 1
+  skill.hit_type = 2
+  damage = RPG::UsableItem::Damage.new
+  damage.type = 1
+  damage.element_id = 3
+  damage.formula = "100 + a.mat * 2 - b.mdf * 2"
+  damage.variance = 20
+  damage.critical = false
+  skill.damage = damage
+  effect = RPG::UsableItem::Effect.new
+  effect.code = 21   # add state
+  effect.data_id = 4
+  effect.value1 = 1.0
+  effect.value2 = 0
+  skill.effects = [effect]
+
+  loaded = Marshal.load(Marshal.dump(skill))
+  assert_true loaded.damage.is_a?(RPG::UsableItem::Damage)
+  assert_equal "100 + a.mat * 2 - b.mdf * 2", loaded.damage.formula
+  assert_equal 3, loaded.damage.element_id
+  assert_false loaded.damage.critical
+  assert_true loaded.effects[0].is_a?(RPG::UsableItem::Effect)
+  assert_equal 21, loaded.effects[0].code
+  assert_equal 4, loaded.effects[0].data_id
+end
+
+assert "VX Ace RPG::Tileset round-trips its sheet names and flags" do
+  ts = RPG::Tileset.new
+  ts.id = 1
+  ts.mode = 1
+  ts.name = "Field"
+  ts.tileset_names = ["TileA1", "TileA2", "TileA3", "TileA4", "TileA5",
+                      "TileB", "TileC", "TileD", "TileE"]
+  ts.flags = Table.new(8192)
+  ts.flags[2048] = 0x000f
+  ts.note = ""
+
+  loaded = Marshal.load(Marshal.dump(ts))
+  assert_equal "Field", loaded.name
+  assert_equal 9, loaded.tileset_names.size
+  assert_equal "TileB", loaded.tileset_names[5]
+  assert_true loaded.flags.is_a?(Table)
+  assert_equal 0x000f, loaded.flags[2048]
+end
+
+assert "VX Ace RPG::Map keeps four layers and weighted encounters" do
+  map = RPG::Map.new
+  map.display_name = "Town"
+  map.tileset_id = 1
+  map.width = 2
+  map.height = 2
+  map.note = ""
+  enc = RPG::Map::Encounter.new
+  enc.troop_id = 1
+  enc.weight = 10
+  enc.region_set = [1, 2]
+  map.encounter_list = [enc]
+  map.data = Table.new(2, 2, 4)
+  map.data[0, 0, 0] = 2048
+  map.data[1, 1, 3] = 5     # region id, the fourth layer
+  map.events = {}
+
+  loaded = Marshal.load(Marshal.dump(map))
+  assert_equal "Town", loaded.display_name
+  assert_equal 1, loaded.tileset_id
+  assert_true loaded.encounter_list[0].is_a?(RPG::Map::Encounter)
+  assert_equal 10, loaded.encounter_list[0].weight
+  assert_equal [1, 2], loaded.encounter_list[0].region_set
+  assert_equal 2048, loaded.data[0, 0, 0]
+  assert_equal 5, loaded.data[1, 1, 3]
+end
+
+assert "VX / VX Ace events select a character by index and priority type" do
+  ev = RPG::Event.new
+  ev.id = 1
+  ev.name = "EV001"
+  ev.x = 4
+  ev.y = 5
+
+  page = RPG::Event::Page.new
+  cond = RPG::Event::Page::Condition.new
+  cond.switch1_valid = true
+  cond.switch1_id = 3
+  cond.item_valid = false
+  cond.actor_valid = false
+  page.condition = cond
+
+  gfx = RPG::Event::Page::Graphic.new
+  gfx.character_name = "People1"
+  gfx.character_index = 5
+  gfx.direction = 2
+  gfx.pattern = 0
+  gfx.tile_id = 0
+  page.graphic = gfx
+
+  page.priority_type = 1
+  page.trigger = 0
+  cmd = RPG::EventCommand.new
+  cmd.code = 101
+  cmd.indent = 0
+  cmd.parameters = ["Actor1", 0, 0, 2]
+  page.list = [cmd]
+  route = RPG::MoveRoute.new
+  route.repeat = true
+  route.skippable = false
+  route.wait = false
+  mc = RPG::MoveCommand.new
+  mc.code = 1
+  mc.parameters = []
+  route.list = [mc]
+  page.move_route = route
+  ev.pages = [page]
+
+  loaded = Marshal.load(Marshal.dump(ev))
+  assert_equal "EV001", loaded.name
+  assert_equal 5, loaded.pages[0].graphic.character_index
+  assert_equal 1, loaded.pages[0].priority_type
+  assert_true loaded.pages[0].condition.switch1_valid
+  assert_equal 3, loaded.pages[0].condition.switch1_id
+  assert_equal 101, loaded.pages[0].list[0].code
+  assert_equal ["Actor1", 0, 0, 2], loaded.pages[0].list[0].parameters
+  assert_equal 1, loaded.pages[0].move_route.list[0].code
+end
+
+assert "VX Ace enemies carry the params array and drop table" do
+  enemy = RPG::Enemy.new
+  enemy.id = 1
+  enemy.name = "Slime"
+  enemy.battler_name = "Slime"
+  enemy.params = [100, 0, 10, 10, 10, 10, 10, 10]
+  enemy.exp = 10
+  enemy.gold = 5
+  drop = RPG::Enemy::DropItem.new
+  drop.kind = 1
+  drop.data_id = 3
+  drop.denominator = 4
+  enemy.drop_items = [drop]
+  action = RPG::Enemy::Action.new
+  action.skill_id = 1
+  action.condition_type = 0
+  action.rating = 5
+  enemy.actions = [action]
+
+  loaded = Marshal.load(Marshal.dump(enemy))
+  assert_equal [100, 0, 10, 10, 10, 10, 10, 10], loaded.params
+  assert_equal 3, loaded.drop_items[0].data_id
+  assert_equal 4, loaded.drop_items[0].denominator
+  assert_equal 5, loaded.actions[0].rating
+end
+
+# ---- Encrypted archives ---------------------------------------------------
+
+assert "a VX database survives its .rgss2a (v1) archive" do
+  sys = RPG::System.new
+  sys.game_title = "Packed VX"
+  sys.start_map_id = 4
+  blob = Marshal.dump(sys)
+
+  a = RPGXP::RGSSAD.new(RPGXP::RGSSAD.pack_v1([["Data\\System.rvdata", blob]]))
+  assert_equal 1, a.version
+  loaded = Marshal.load(a.read("Data/System.rvdata"))
+  assert_true loaded.is_a?(RPG::System)
+  assert_equal "Packed VX", loaded.game_title
+  assert_equal 4, loaded.start_map_id
+end
+
+assert "a VX Ace database survives its .rgss3a (v3) archive" do
+  sys = RPG::System.new
+  sys.game_title = "Packed Ace"
+  sys.start_map_id = 7
+  blob = Marshal.dump(sys)
+
+  a = RPGXP::RGSSAD.new(RPGXP::RGSSAD.pack_v3([["Data\\System.rvdata2", blob]]))
+  assert_equal 3, a.version
+  loaded = Marshal.load(a.read("Data/System.rvdata2"))
+  assert_true loaded.is_a?(RPG::System)
+  assert_equal "Packed Ace", loaded.game_title
+  assert_equal 7, loaded.start_map_id
+end

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -150,20 +150,13 @@ class RPGXP
 
   private
 
-  # Build the driver Fiber for the bundled scripts and install the per-frame
-  # yield. Only reached when the host is enabled, so the built-in flow never
-  # creates a Fiber nor wraps Graphics.update.
+  # Build the driver Fiber for the bundled scripts (which installs the per-frame
+  # Graphics.update yield). Only reached when the host is enabled, so the
+  # built-in flow never creates a Fiber nor wraps Graphics.update. The driver
+  # itself lives in ScriptHost so the VX / VX Ace shell (mruby-rpgvx) drives the
+  # bundled scripts through the same code.
   def setup_script_host_driver
-    install_graphics_yield
-    db = @db
-    @host_fiber = Fiber.new do
-      ScriptHost.driving = true
-      begin
-        ScriptHost.run(db)
-      ensure
-        ScriptHost.driving = false
-      end
-    end
+    @host_fiber = ScriptHost.build_driver(@db)
   end
 
   # Advance the script host by one frame. When its Main returns the Fiber is
@@ -185,20 +178,6 @@ class RPGXP
     @host_fiber = nil
     @use_script_host = false
     push Scene::Title.new(self) if @scenes.empty?
-  end
-
-  # Wrap the native Graphics.update so a scene's `loop { Graphics.update; ... }`
-  # yields the driver Fiber once per frame. Idempotent, and installed only on
-  # the script-host path — the built-in flow keeps the pristine native method.
-  def install_graphics_yield
-    return if RGSS::Graphics.respond_to?(:_update_native)
-    RGSS::Graphics.singleton_class.class_eval do
-      alias_method :_update_native, :update
-      def update
-        _update_native
-        Fiber.yield if ::RPGXP::ScriptHost.driving?
-      end
-    end
   end
 
   # The window title from Game.ini's [Game] Title=, falling back to the folder

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -98,6 +98,38 @@ class RPGXP
     def self.install_kernel(db)
       @db = db
     end
+
+    # Build the per-frame driver Fiber for a project's bundled scripts. The
+    # scripts own their whole blocking main loop, so it runs inside a Fiber that
+    # the wrapped Graphics.update below yields once per frame — the caller then
+    # resumes it once per frame (see RPGXP#drive_script_host / RPGVX). Shared by
+    # every RGSS maker's boot shell; see
+    # docs/adr/0023-rpgxp-script-host-frame-driver.md.
+    def self.build_driver(db)
+      install_graphics_yield
+      Fiber.new do
+        self.driving = true
+        begin
+          run(db)
+        ensure
+          self.driving = false
+        end
+      end
+    end
+
+    # Wrap the native Graphics.update so a scene's `loop { Graphics.update; ... }`
+    # yields the driver Fiber once per frame. Idempotent, and installed only on
+    # the script-host path — a built-in flow keeps the pristine native method.
+    def self.install_graphics_yield
+      return if RGSS::Graphics.respond_to?(:_update_native)
+      RGSS::Graphics.singleton_class.class_eval do
+        alias_method :_update_native, :update
+        def update
+          _update_native
+          Fiber.yield if ::RPGXP::ScriptHost.driving?
+        end
+      end
+    end
   end
 end
 

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -1,0 +1,1287 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Smoke-test the RPG Maker VX / VX Ace data layer.
+#
+# The schema (mruby-rpgvx/mrblib/rgss2_data.rb) and the database loader
+# (mruby-rpgvx/mrblib/rgss_data.rb) are written in the mruby/CRuby common subset,
+# so this harness loads those exact files under CRuby and drives
+# RPGVX::RGSSData over real project trees — the same trick
+# scripts/rpgxp_testbed_check.rb plays for XP. In the real build the
+# `.rvdata`/`.rvdata2` streams are read by mruby-marshal and the RGSS value types
+# (Table/Color/Tone/Rect) are the native C classes; here CRuby's own Marshal does
+# the reading and the value types are the shims below.
+#
+# Neither VX nor VX Ace has a fetchable open-source test bed the way XP
+# (OpenGame) and MV (Lunatic-Core) do — the editors and their RTPs are
+# commercial, and no equivalent project is redistributable — so this check
+# *builds* a project of its own for each edition, covering every Data/ table, and
+# drives the loader over it: loose on disk, then repacked into the edition's
+# encrypted archive (Game.rgss2a / Game.rgss3a). A generated bed cannot prove a
+# field *name* (only real editor output can), which is why every name is
+# transcribed from the RGSS2/RGSS3 references — see
+# docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md. What it does prove is that the
+# whole path works end to end and stays working.
+#
+# Point it at a real game and it checks that too, including an audit that every
+# instance variable in the real data has an accessor in our schema — the check
+# that would catch a field the schema misses:
+#
+#   ruby scripts/rpgvx_testbed_check.rb [GAME_DIR ...]
+#
+# With no arguments it also scans ./data for VX/VX Ace projects. Use
+# `--write DIR` to materialise the two generated sample projects on disk (handy
+# for pointing the built engine at one). Exits non-zero on any failure.
+
+require "tmpdir"
+require "fileutils"
+require "zlib"
+
+# --- RGSS value-type shims (native classes in the real build) --------------
+
+# RGSS Table: an N-dimensional grid of int16s. Marshal payload is five int32
+# little-endian header words (dim, xsize, ysize, zsize, item count) followed by
+# that many int16s. Matches mruby-rgss's src/lib.cxx table_load/table_dump.
+class Table
+  attr_reader :dim, :xsize, :ysize, :zsize, :data
+
+  def initialize(xsize, ysize = nil, zsize = nil)
+    @dim = ysize.nil? ? 1 : (zsize.nil? ? 2 : 3)
+    @xsize = xsize
+    @ysize = ysize || 1
+    @zsize = zsize || 1
+    @data = Array.new(@xsize * @ysize * @zsize, 0)
+  end
+
+  def self._load(s)
+    dim, x, y, z, count = s[0, 20].unpack("l<5")
+    t = allocate
+    t.instance_variable_set(:@dim, dim)
+    t.instance_variable_set(:@xsize, x)
+    t.instance_variable_set(:@ysize, y)
+    t.instance_variable_set(:@zsize, z)
+    t.instance_variable_set(:@data, s[20, count * 2].unpack("s<#{count}"))
+    t
+  end
+
+  def _dump(_limit = -1)
+    [@dim, @xsize, @ysize, @zsize, @data.size].pack("l<5") + @data.pack("s<*")
+  end
+
+  def [](x, y = 0, z = 0)
+    @data[x + @xsize * (y + @ysize * z)]
+  end
+
+  def []=(*args)
+    value = args.pop
+    x, y, z = args[0], args[1] || 0, args[2] || 0
+    @data[x + @xsize * (y + @ysize * z)] = value
+  end
+end
+
+# Color / Tone: four doubles. Rect: four int32s.
+class Color
+  def initialize(r = 0, g = 0, b = 0, a = 255)
+    @v = [r.to_f, g.to_f, b.to_f, a.to_f]
+  end
+  attr_reader :v
+  def _dump(_limit = -1) = @v.pack("E4")
+  def self._load(s)
+    c = allocate
+    c.instance_variable_set(:@v, s.unpack("E4"))
+    c
+  end
+end
+
+class Tone < Color; end
+
+class Rect
+  def initialize(x = 0, y = 0, width = 0, height = 0)
+    @v = [x, y, width, height]
+  end
+  def x = @v[0]
+  def y = @v[1]
+  def width = @v[2]
+  def height = @v[3]
+  def _dump(_limit = -1) = @v.pack("l<4")
+  def self._load(s)
+    r = allocate
+    r.instance_variable_set(:@v, s.unpack("l<4"))
+    r
+  end
+end
+
+# The script bundle is zlib-deflated per section; the real build inflates it
+# through the native RGSS.zlib_inflate (mruby-rgss). Graphics and the frame
+# timeout are native too — the boot check below needs them because the script
+# host's per-frame driver yields inside Graphics.update.
+module RGSS
+  def self.zlib_inflate(bytes) = Zlib::Inflate.inflate(bytes)
+
+  class Timeout < StandardError; end
+
+  module Graphics
+    @frames = 0
+    class << self
+      attr_reader :frames
+      def update = @frames += 1
+      def reset_frames = @frames = 0
+    end
+  end
+end
+
+# The real build pulls RGSS into the top level (mruby-rpgxp's lib.rb) so the
+# bundled scripts can say `Graphics.update`; mirror that here.
+class Object
+  include RGSS
+end
+
+# --- Load the real sources -------------------------------------------------
+
+ROOT = File.expand_path("..", __dir__)
+# The XP archive reader is shared: VX's Game.rgss2a is the same version-1 format
+# as XP's Game.rgssad, and VX Ace's Game.rgss3a is the version-3 one.
+load File.join(ROOT, "mruby-rpgxp", "mrblib", "rgssad.rb")
+# The VX shell runs a project's own scripts through the shared RGSS script host.
+load File.join(ROOT, "mruby-rpgxp", "mrblib", "script_host.rb")
+load File.join(ROOT, "mruby-rpgvx", "mrblib", "lib.rb")
+load File.join(ROOT, "mruby-rpgvx", "mrblib", "rgss2_data.rb")
+load File.join(ROOT, "mruby-rpgvx", "mrblib", "rgss_data.rb")
+
+# --- A generated project, one per edition ----------------------------------
+
+# Builds a small but complete project: every Data/ table an editor writes, a map
+# with an event, a common event and a script bundle. The values are chosen to be
+# recognisable (and edition-correct) rather than realistic.
+module Sample
+  module_function
+
+  def build(dir, edition)
+    ext = RPGVX.data_ext(edition)
+    ace = edition == :vxace
+    FileUtils.mkdir_p(File.join(dir, "Data"))
+    File.write(File.join(dir, "Game.ini"),
+               "[Game]\nRTP=\nLibrary=System\\RGSS#{ace ? 300 : 200}.dll\n" \
+               "Scripts=Data/Scripts#{ext}\nTitle=Sample\n")
+
+    write(dir, "System", ext, system(ace))
+    write(dir, "MapInfos", ext, { 1 => map_info })
+    write(dir, "Map001", ext, map(ace))
+    write(dir, "Actors", ext, [nil, actor(ace)])
+    write(dir, "Classes", ext, [nil, klass(ace)])
+    write(dir, "Skills", ext, [nil, skill(ace)])
+    write(dir, "Items", ext, [nil, item(ace)])
+    write(dir, "Weapons", ext, [nil, weapon(ace)])
+    write(dir, "Armors", ext, [nil, armor(ace)])
+    write(dir, "Enemies", ext, [nil, enemy(ace)])
+    write(dir, "Troops", ext, [nil, troop])
+    write(dir, "States", ext, [nil, state(ace)])
+    write(dir, "Animations", ext, [nil, animation])
+    write(dir, "CommonEvents", ext, [nil, common_event])
+    if ace
+      write(dir, "Tilesets", ext, [nil, tileset])
+    else
+      write(dir, "Areas", ext, [nil, area])
+    end
+    write(dir, "Scripts", ext, scripts(ext))
+    dir
+  end
+
+  def write(dir, base, ext, obj)
+    File.binwrite(File.join(dir, "Data", "#{base}#{ext}"), Marshal.dump(obj))
+  end
+
+  def audio(cls, name)
+    a = cls.new
+    a.name = name
+    a.volume = 100
+    a.pitch = 100
+    a
+  end
+
+  def system(ace)
+    s = RPG::System.new
+    s.game_title = ace ? "Ace Sample" : "VX Sample"
+    s.version_id = 12_345
+    s.party_members = [1]
+    s.elements = [nil, "Physical", "Fire"]
+    s.switches = [nil, "opened"]
+    s.variables = [nil, "counter"]
+    s.start_map_id = 1
+    s.start_x = 5
+    s.start_y = 5
+    s.title_bgm = audio(RPG::BGM, "Theme1")
+    s.battle_bgm = audio(RPG::BGM, "Battle1")
+    s.battle_end_me = audio(RPG::ME, "Victory1")
+    s.gameover_me = audio(RPG::ME, "Gameover1")
+    s.sounds = [audio(RPG::SE, "Cursor1"), audio(RPG::SE, "Decision1")]
+    s.boat = vehicle("Vehicle", 0)
+    s.ship = vehicle("Vehicle", 1)
+    s.airship = vehicle("Vehicle", 2)
+    s.test_battlers = [test_battler(ace)]
+    s.test_troop_id = 1
+    s.battler_name = ""
+    s.battler_hue = 0
+    s.edit_map_id = 1
+    s.terms = terms(ace)
+    if ace
+      s.japanese = false
+      s.currency_unit = "G"
+      s.skill_types = [nil, "Special", "Magic"]
+      s.weapon_types = [nil, "Dagger", "Sword"]
+      s.armor_types = [nil, "General Armor", "Magic Armor"]
+      s.title1_name = "Book"
+      s.title2_name = ""
+      s.opt_draw_title = true
+      s.opt_use_midi = false
+      s.opt_transparent = false
+      s.opt_followers = true
+      s.opt_slip_death = false
+      s.opt_floor_death = false
+      s.opt_display_tp = true
+      s.opt_extra_exp = false
+      s.window_tone = Tone.new(0, 0, 0)
+      s.battleback1_name = "Grassland"
+      s.battleback2_name = "Grassland"
+    else
+      # VX's single game-wide tileset: 8192 passage/priority words.
+      passages = Table.new(8192)
+      passages[16] = 0x0f
+      s.passages = passages
+    end
+    s
+  end
+
+  def vehicle(name, index)
+    v = RPG::System::Vehicle.new
+    v.character_name = name
+    v.character_index = index
+    v.bgm = audio(RPG::BGM, "Ship1")
+    v.start_map_id = 0
+    v.start_x = 0
+    v.start_y = 0
+    v
+  end
+
+  def test_battler(ace)
+    b = RPG::System::TestBattler.new
+    b.actor_id = 1
+    b.level = 1
+    if ace
+      b.equips = [1, 0, 2, 0, 0]
+    else
+      b.weapon_id = 1
+      b.armor1_id = 0
+      b.armor2_id = 2
+      b.armor3_id = 0
+      b.armor4_id = 0
+    end
+    b
+  end
+
+  def terms(ace)
+    t = RPG::System::Terms.new
+    if ace
+      t.basic = ["Level", "LV", "HP", "HP", "MP", "MP", "TP", "TP"]
+      t.params = ["Max HP", "Max MP", "Attack", "Defense",
+                  "M.Attack", "M.Defense", "Agility", "Luck"]
+      t.etypes = ["Weapon", "Shield", "Head", "Body", "Accessory"]
+      t.commands = ["Fight", "Escape", "Attack", "Guard", "Item",
+                    "Skill", "Equip", "Status", "Sort", "Save",
+                    "Game End", "Weapon", "Armor", "Key Item", "Equip",
+                    "Optimize", "Clear", "New Game", "Continue", "Shutdown",
+                    "To Title", "Cancel", ""]
+    else
+      t.level = "Level"
+      t.level_a = "LV"
+      t.hp = "HP"
+      t.hp_a = "HP"
+      t.mp = "MP"
+      t.mp_a = "MP"
+      t.attack = "Attack"
+      t.guard = "Guard"
+      t.item = "Item"
+      t.skill = "Skill"
+      t.equip = "Equip"
+      t.status = "Status"
+      t.save = "Save"
+      t.game_end = "End Game"
+      t.new_game = "New Game"
+      t.continue = "Continue"
+      t.shutdown = "Shutdown"
+      t.to_title = "To Title"
+      t.cancel = "Cancel"
+      t.gold = "G"
+    end
+    t
+  end
+
+  def map_info
+    i = RPG::MapInfo.new
+    i.name = "Field"
+    i.parent_id = 0
+    i.order = 1
+    i.expanded = false
+    i.scroll_x = 0
+    i.scroll_y = 0
+    i
+  end
+
+  def map(ace)
+    m = RPG::Map.new
+    m.width = 17
+    m.height = 13
+    m.scroll_type = 0
+    m.autoplay_bgm = false
+    m.bgm = audio(RPG::BGM, "")
+    m.autoplay_bgs = false
+    m.bgs = audio(RPG::BGS, "")
+    m.disable_dashing = false
+    m.encounter_step = 30
+    m.parallax_name = ""
+    m.parallax_loop_x = false
+    m.parallax_loop_y = false
+    m.parallax_sx = 0
+    m.parallax_sy = 0
+    m.parallax_show = false
+    # VX Ace maps carry a fourth layer of region ids; VX maps have three.
+    layers = ace ? 4 : 3
+    data = Table.new(m.width, m.height, layers)
+    m.height.times { |y| m.width.times { |x| data[x, y, 0] = 2048 } }
+    data[3, 3, 1] = 4352
+    data[4, 4, layers - 1] = 1
+    m.data = data
+    m.events = { 1 => event }
+    if ace
+      m.display_name = "Field"
+      m.tileset_id = 1
+      m.specify_battleback = false
+      m.battleback1_name = ""
+      m.battleback2_name = ""
+      m.note = ""
+      enc = RPG::Map::Encounter.new
+      enc.troop_id = 1
+      enc.weight = 10
+      enc.region_set = []
+      m.encounter_list = [enc]
+    else
+      m.encounter_list = [1]
+    end
+    m
+  end
+
+  def event
+    e = RPG::Event.new
+    e.id = 1
+    e.name = "EV001"
+    e.x = 8
+    e.y = 6
+    e.pages = [event_page]
+    e
+  end
+
+  def event_page
+    p = RPG::Event::Page.new
+    c = RPG::Event::Page::Condition.new
+    c.switch1_valid = false
+    c.switch2_valid = false
+    c.variable_valid = false
+    c.self_switch_valid = false
+    c.item_valid = false
+    c.actor_valid = false
+    c.switch1_id = 1
+    c.switch2_id = 1
+    c.variable_id = 1
+    c.variable_value = 0
+    c.self_switch_ch = "A"
+    c.item_id = 1
+    c.actor_id = 1
+    p.condition = c
+
+    g = RPG::Event::Page::Graphic.new
+    g.tile_id = 0
+    g.character_name = "People1"
+    g.character_index = 2
+    g.direction = 2
+    g.pattern = 0
+    p.graphic = g
+
+    p.move_type = 0
+    p.move_speed = 3
+    p.move_frequency = 3
+    p.move_route = move_route
+    p.walk_anime = true
+    p.step_anime = false
+    p.direction_fix = false
+    p.through = false
+    p.priority_type = 1
+    p.trigger = 0
+    p.list = [command(101, ["People1", 2, 0, 2]), command(401, ["Hello."]),
+              command(0, [])]
+    p
+  end
+
+  def move_route
+    r = RPG::MoveRoute.new
+    r.repeat = true
+    r.skippable = false
+    r.wait = false
+    c = RPG::MoveCommand.new
+    c.code = 0
+    c.parameters = []
+    r.list = [c]
+    r
+  end
+
+  def command(code, parameters, indent = 0)
+    c = RPG::EventCommand.new
+    c.code = code
+    c.indent = indent
+    c.parameters = parameters
+    c
+  end
+
+  def actor(ace)
+    a = RPG::Actor.new
+    a.id = 1
+    a.name = "Ralph"
+    a.class_id = 1
+    a.initial_level = 1
+    a.character_name = "Actor1"
+    a.character_index = 0
+    a.face_name = "Actor1"
+    a.face_index = 0
+    a.note = ""
+    if ace
+      a.icon_index = 0
+      a.description = ""
+      a.nickname = "Rookie"
+      a.max_level = 99
+      a.equips = [1, 0, 2, 0, 0]
+      a.features = [feature(22, 0, 0.95)]
+    else
+      a.exp_basis = 25
+      a.exp_inflation = 35
+      a.two_swords_style = false
+      a.fix_equipment = false
+      a.auto_battle = false
+      a.super_guard = false
+      a.pharmacology = false
+      a.critical_bonus = false
+      a.weapon_id = 1
+      a.armor1_id = 0
+      a.armor2_id = 2
+      a.armor3_id = 0
+      a.armor4_id = 0
+      params = Table.new(6, 100)
+      (0...100).each do |lv|
+        params[0, lv] = 400 + lv * 50
+        params[1, lv] = 80 + lv * 10
+        (2...6).each { |i| params[i, lv] = 10 + lv }
+      end
+      a.parameters = params
+    end
+    a
+  end
+
+  def feature(code, data_id, value)
+    f = RPG::BaseItem::Feature.new
+    f.code = code
+    f.data_id = data_id
+    f.value = value
+    f
+  end
+
+  def klass(ace)
+    k = RPG::Class.new
+    k.id = 1
+    k.name = "Hero"
+    k.note = ""
+    learning = RPG::Class::Learning.new
+    learning.level = 3
+    learning.skill_id = 1
+    learning.note = "" if ace
+    k.learnings = [learning]
+    if ace
+      k.icon_index = 0
+      k.description = ""
+      k.exp_params = [30, 20, 30, 30]
+      params = Table.new(8, 100)
+      (0...100).each do |lv|
+        params[0, lv] = 400 + lv * 50
+        params[1, lv] = 80 + lv * 10
+        (2...8).each { |i| params[i, lv] = 10 + lv }
+      end
+      k.params = params
+      k.features = [feature(23, 0, 1), feature(51, 1, 0)]
+    else
+      k.position = 0
+      k.weapon_set = [1]
+      k.armor_set = [1, 2, 3, 4]
+      k.element_ranks = Table.new(3)
+      k.state_ranks = Table.new(3)
+      k.skill_name_valid = false
+      k.skill_name = ""
+    end
+    k
+  end
+
+  def skill(ace)
+    s = RPG::Skill.new
+    s.id = 1
+    s.name = "Heal"
+    s.icon_index = 128
+    s.description = "Restores HP."
+    s.note = ""
+    s.scope = 3
+    s.occasion = 0
+    s.speed = 0
+    s.animation_id = 1
+    s.mp_cost = 5
+    s.message1 = " casts"
+    s.message2 = ""
+    if ace
+      s.features = []
+      s.stype_id = 1
+      s.tp_cost = 0
+      s.required_wtype_id1 = 0
+      s.required_wtype_id2 = 0
+      s.success_rate = 100
+      s.repeats = 1
+      s.tp_gain = 0
+      s.hit_type = 0
+      s.damage = damage(3, "100 + a.mat * 2")
+      s.effects = [effect(11, 0, 0.0, 100)]
+    else
+      s.hit = 100
+      s.common_event_id = 0
+      s.base_damage = -100
+      s.variance = 20
+      s.atk_f = 0
+      s.spi_f = 100
+      s.physical_attack = false
+      s.damage_to_mp = false
+      s.absorb_damage = false
+      s.ignore_defense = false
+      s.element_set = []
+      s.plus_state_set = []
+      s.minus_state_set = [1]
+    end
+    s
+  end
+
+  def damage(type, formula)
+    d = RPG::UsableItem::Damage.new
+    d.type = type
+    d.element_id = 0
+    d.formula = formula
+    d.variance = 20
+    d.critical = false
+    d
+  end
+
+  def effect(code, data_id, value1, value2)
+    e = RPG::UsableItem::Effect.new
+    e.code = code
+    e.data_id = data_id
+    e.value1 = value1
+    e.value2 = value2
+    e
+  end
+
+  def item(ace)
+    i = RPG::Item.new
+    i.id = 1
+    i.name = "Potion"
+    i.icon_index = 176
+    i.description = "Restores HP."
+    i.note = ""
+    i.scope = 7
+    i.occasion = 0
+    i.speed = 0
+    i.animation_id = 1
+    i.price = 50
+    i.consumable = true
+    if ace
+      i.features = []
+      i.itype_id = 1
+      i.success_rate = 100
+      i.repeats = 1
+      i.tp_gain = 0
+      i.hit_type = 0
+      i.damage = damage(3, "0")
+      i.effects = [effect(11, 0, 0.0, 500)]
+    else
+      i.common_event_id = 0
+      i.base_damage = 0
+      i.variance = 0
+      i.atk_f = 0
+      i.spi_f = 0
+      i.physical_attack = false
+      i.damage_to_mp = false
+      i.absorb_damage = false
+      i.ignore_defense = false
+      i.element_set = []
+      i.plus_state_set = []
+      i.minus_state_set = []
+      i.hp_recovery_rate = 0
+      i.hp_recovery = 500
+      i.mp_recovery_rate = 0
+      i.mp_recovery = 0
+      i.parameter_type = 0
+      i.parameter_points = 0
+    end
+    i
+  end
+
+  def weapon(ace)
+    w = RPG::Weapon.new
+    w.id = 1
+    w.name = "Bronze Sword"
+    w.icon_index = 96
+    w.description = ""
+    w.note = ""
+    w.price = 300
+    w.animation_id = 1
+    if ace
+      w.etype_id = 0
+      w.wtype_id = 2
+      w.params = [0, 0, 12, 0, 0, 0, 0, 0]
+      w.features = [feature(31, 1, 0)]
+    else
+      w.hit = 95
+      w.atk = 12
+      w.def = 0
+      w.spi = 0
+      w.agi = 0
+      w.two_handed = false
+      w.fast_attack = false
+      w.dual_attack = false
+      w.critical_bonus = false
+      w.element_set = []
+      w.state_set = []
+    end
+    w
+  end
+
+  def armor(ace)
+    a = RPG::Armor.new
+    a.id = 2
+    a.name = "Leather Shield"
+    a.icon_index = 128
+    a.description = ""
+    a.note = ""
+    a.price = 300
+    if ace
+      a.etype_id = 1
+      a.atype_id = 1
+      a.params = [0, 0, 0, 6, 0, 0, 0, 0]
+      a.features = []
+    else
+      a.kind = 0
+      a.eva = 0
+      a.atk = 0
+      a.def = 6
+      a.spi = 0
+      a.agi = 0
+      a.prevent_critical = false
+      a.half_mp_cost = false
+      a.double_exp_gain = false
+      a.auto_hp_recover = false
+      a.element_set = []
+      a.state_set = []
+    end
+    a
+  end
+
+  def enemy(ace)
+    e = RPG::Enemy.new
+    e.id = 1
+    e.name = "Slime"
+    e.battler_name = "Slime"
+    e.battler_hue = 0
+    e.exp = 10
+    e.gold = 5
+    e.note = ""
+    action = RPG::Enemy::Action.new
+    action.skill_id = 1
+    action.condition_type = 0
+    action.condition_param1 = 0
+    action.condition_param2 = 0
+    action.rating = 5
+    if ace
+      e.icon_index = 0
+      e.description = ""
+      e.params = [100, 0, 10, 10, 10, 10, 10, 10]
+      drop = RPG::Enemy::DropItem.new
+      drop.kind = 1
+      drop.data_id = 1
+      drop.denominator = 4
+      e.drop_items = [drop, RPG::Enemy::DropItem.new, RPG::Enemy::DropItem.new]
+      e.features = [feature(22, 0, 0.95)]
+    else
+      e.maxhp = 100
+      e.maxmp = 0
+      e.atk = 10
+      e.def = 10
+      e.spi = 10
+      e.agi = 10
+      e.hit = 95
+      e.eva = 5
+      e.levitate = false
+      e.has_critical = false
+      e.element_ranks = Table.new(3)
+      e.state_ranks = Table.new(3)
+      drop = RPG::Enemy::DropItem.new
+      drop.kind = 1
+      drop.item_id = 1
+      drop.weapon_id = 1
+      drop.armor_id = 1
+      drop.denominator = 4
+      e.drop_item1 = drop
+      e.drop_item2 = RPG::Enemy::DropItem.new
+      action.kind = 0
+      action.basic = 0
+    end
+    e.actions = [action]
+    e
+  end
+
+  def troop
+    t = RPG::Troop.new
+    t.id = 1
+    t.name = "Slime*1"
+    member = RPG::Troop::Member.new
+    member.enemy_id = 1
+    member.x = 250
+    member.y = 200
+    member.hidden = false
+    t.members = [member]
+    page = RPG::Troop::Page.new
+    cond = RPG::Troop::Page::Condition.new
+    cond.turn_ending = false
+    cond.turn_valid = false
+    cond.enemy_valid = false
+    cond.actor_valid = false
+    cond.switch_valid = false
+    cond.turn_a = 0
+    cond.turn_b = 0
+    cond.enemy_index = 0
+    cond.enemy_hp = 50
+    cond.actor_id = 1
+    cond.actor_hp = 50
+    cond.switch_id = 1
+    page.condition = cond
+    page.span = 0
+    page.list = [command(0, [])]
+    t.pages = [page]
+    t
+  end
+
+  def state(ace)
+    s = RPG::State.new
+    s.id = 1
+    s.name = "Knockout"
+    s.icon_index = 1
+    s.restriction = 4
+    s.priority = ace ? 100 : 5
+    s.note = ""
+    s.message1 = " has fallen."
+    s.message2 = ""
+    s.message3 = ""
+    s.message4 = ""
+    if ace
+      s.description = ""
+      s.features = []
+      s.remove_at_battle_end = false
+      s.remove_by_restriction = false
+      s.auto_removal_timing = 0
+      s.min_turns = 1
+      s.max_turns = 1
+      s.remove_by_damage = false
+      s.chance_by_damage = 100
+      s.remove_by_walking = false
+      s.steps_to_remove = 100
+    else
+      s.atk_rate = 100
+      s.def_rate = 100
+      s.spi_rate = 100
+      s.agi_rate = 100
+      s.nonresistance = false
+      s.offset_by_opposite = false
+      s.slip_damage = false
+      s.reduce_hit_ratio = false
+      s.battle_only = false
+      s.release_by_damage = false
+      s.hold_turn = 0
+      s.auto_release_prob = 0
+      s.element_set = []
+      s.state_set = []
+    end
+    s
+  end
+
+  def animation
+    a = RPG::Animation.new
+    a.id = 1
+    a.name = "Hit"
+    a.animation1_name = "Special1"
+    a.animation1_hue = 0
+    a.animation2_name = ""
+    a.animation2_hue = 0
+    a.position = 1
+    a.frame_max = 1
+    frame = RPG::Animation::Frame.new
+    frame.cell_max = 1
+    frame.cell_data = Table.new(1, 8)
+    a.frames = [frame]
+    timing = RPG::Animation::Timing.new
+    timing.frame = 0
+    timing.se = audio(RPG::SE, "Blow1")
+    timing.flash_scope = 0
+    timing.flash_color = Color.new(255, 255, 255, 255)
+    timing.flash_duration = 5
+    a.timings = [timing]
+    a
+  end
+
+  def common_event
+    c = RPG::CommonEvent.new
+    c.id = 1
+    c.name = "Autorun"
+    c.trigger = 0
+    c.switch_id = 1
+    c.list = [command(0, [])]
+    c
+  end
+
+  def tileset
+    t = RPG::Tileset.new
+    t.id = 1
+    t.mode = 1
+    t.name = "Field"
+    t.tileset_names = ["TileA1", "TileA2", "TileA3", "TileA4", "TileA5",
+                       "TileB", "TileC", "TileD", "TileE"]
+    flags = Table.new(8192)
+    flags[2048] = 0x000f
+    t.flags = flags
+    t.note = ""
+    t
+  end
+
+  def area
+    a = RPG::Area.new
+    a.id = 1
+    a.name = "Plains"
+    a.map_id = 1
+    a.rect = Rect.new(0, 0, 8, 8)
+    a.encounter_list = [1]
+    a.order = 1
+    a
+  end
+
+  # The script bundle: [id, name, zlib-deflated source] sections, exactly as XP
+  # stores them. A real game's Main boots its engine (`rgss_main { SceneManager
+  # .run }` in VX Ace); this one stands in for that — it reads the database back
+  # through the Kernel#load_data built-in the host installs and drives a few
+  # frames, so running it exercises the whole boot path (see Checker#check_boot).
+  def scripts(ext)
+    main = "$rgss_sample_title = load_data(\"Data/System#{ext}\").game_title\n" \
+           "3.times { Graphics.update }\n" \
+           "$rgss_sample_booted = true\n"
+    [[1, "Main", Zlib::Deflate.deflate(main)],
+     [2, "", Zlib::Deflate.deflate("# empty section\n")]]
+  end
+end
+
+# --- Checks ----------------------------------------------------------------
+
+class Checker
+  def initialize
+    @errors = 0
+    @projects = 0
+    @events = 0
+    @commands = 0
+  end
+
+  attr_reader :errors
+
+  def fail(msg)
+    @errors += 1
+    warn "  FAIL #{msg}"
+  end
+
+  def expect(cond, msg)
+    fail(msg) unless cond
+  end
+
+  # Every check a project must pass, whether generated or real.
+  def check_project(dir, expected_edition = nil)
+    puts "== #{dir} =="
+    edition = RPGVX.detect(dir)
+    expect(!edition.nil?, "#{dir}: not detected as a VX / VX Ace project")
+    return unless edition
+    expect(expected_edition.nil? || edition == expected_edition,
+           "#{dir}: detected #{edition}, expected #{expected_edition}")
+
+    db = RPGVX::RGSSData.new(dir)
+    expect(db.edition == edition, "#{dir}: database edition mismatch")
+    expect(db.ext == RPGVX.data_ext(edition), "#{dir}: wrong data extension")
+    check_system(db)
+    check_tables(db)
+    check_maps(db)
+    check_scripts(db)
+    audit(db)
+    puts "  #{RPGVX.edition_name(edition)}: #{db.summary}"
+    @projects += 1
+    db
+  rescue StandardError => ex
+    fail "#{dir}: #{ex.class}: #{ex.message}"
+    nil
+  end
+
+  def check_system(db)
+    sys = db.system
+    expect(sys.is_a?(RPG::System), "System is #{sys.class}, not RPG::System")
+    expect(sys.start_map_id.to_i > 0, "System.start_map_id must be positive")
+    expect(sys.party_members.is_a?(Array) && !sys.party_members.empty?,
+           "System.party_members must be a non-empty Array")
+    expect(sys.terms.is_a?(RPG::System::Terms), "System.terms missing")
+    expect(sys.title_bgm.is_a?(RPG::AudioFile),
+           "System.title_bgm must be an AudioFile")
+    [sys.boat, sys.ship, sys.airship].each_with_index do |v, i|
+      expect(v.is_a?(RPG::System::Vehicle), "System vehicle #{i} missing")
+    end
+    if db.vxace?
+      expect(sys.terms.basic.is_a?(Array) && sys.terms.basic.size >= 8,
+             "VX Ace Terms#basic must hold at least 8 entries")
+      expect(sys.terms.etypes.is_a?(Array),
+             "VX Ace Terms#etypes must be an Array")
+    else
+      # VX's one game-wide tileset keeps its flags here (VX Ace moved them onto
+      # RPG::Tileset#flags), which is the clearest structural difference.
+      expect(sys.passages.is_a?(Table), "VX System#passages must be a Table")
+      expect(sys.terms.hp.is_a?(String), "VX Terms#hp must be a String")
+    end
+  end
+
+  def check_tables(db)
+    expect(db.actors.is_a?(Array), "Actors must be an Array")
+    expect(db.actors[0].nil?, "Actors[0] should be nil (1-based table)")
+    db.actors.compact.each do |a|
+      expect(a.is_a?(RPG::Actor), "actor #{a.inspect} is not an RPG::Actor")
+      expect(a.name.is_a?(String), "actor #{a.id} has no name")
+      expect(db.classes[a.class_id.to_i].is_a?(RPG::Class),
+             "actor #{a.id}: class_id #{a.class_id} does not resolve")
+      if db.vxace?
+        expect(a.equips.is_a?(Array), "VX Ace actor #{a.id} needs an equips array")
+      else
+        expect(a.parameters.is_a?(Table),
+               "VX actor #{a.id} parameters must be a Table")
+      end
+    end
+
+    db.classes.compact.each do |k|
+      expect(k.learnings.is_a?(Array), "class #{k.id} learnings must be an Array")
+      expect(k.params.is_a?(Table),
+             "VX Ace class #{k.id} params must be a Table") if db.vxace?
+    end
+
+    db.skills.compact.each do |s|
+      if db.vxace?
+        expect(s.damage.is_a?(RPG::UsableItem::Damage),
+               "VX Ace skill #{s.id} needs a damage formula")
+        expect(s.effects.is_a?(Array), "VX Ace skill #{s.id} effects must be an Array")
+      end
+    end
+
+    # Edition-specific tables: exactly one of them is present.
+    if db.vxace?
+      expect(db.tilesets.is_a?(Array), "VX Ace needs a Tilesets table")
+      expect(db.areas.nil?, "VX Ace has no Areas table")
+      db.tilesets.compact.each do |t|
+        expect(t.flags.is_a?(Table), "tileset #{t.id} flags must be a Table")
+        expect(t.tileset_names.is_a?(Array) && t.tileset_names.size == 9,
+               "tileset #{t.id} must name 9 sheets (A1-A5, B-E)")
+      end
+    else
+      expect(db.areas.is_a?(Array), "VX needs an Areas table")
+      expect(db.tilesets.nil?, "VX has no Tilesets table")
+      db.areas.compact.each do |a|
+        expect(a.rect.is_a?(Rect), "area #{a.id} rect must be a Rect")
+        expect(db.map_infos.key?(a.map_id) || a.map_id.to_i.zero?,
+               "area #{a.id}: map_id #{a.map_id} does not resolve")
+      end
+    end
+  end
+
+  def check_maps(db)
+    db.map_infos.each do |id, info|
+      expect(info.is_a?(RPG::MapInfo), "MapInfos[#{id}] is not an RPG::MapInfo")
+      map = db.load_map(id)
+      expect(map.is_a?(RPG::Map), "Map#{id} is not an RPG::Map")
+      w = map.width.to_i
+      h = map.height.to_i
+      expect(w > 0 && h > 0, "Map#{id}: non-positive dimensions #{w}x#{h}")
+
+      tbl = map.data
+      expect(tbl.is_a?(Table), "Map#{id}: data is not a Table")
+      if tbl.is_a?(Table)
+        expect(tbl.xsize == w && tbl.ysize == h,
+               "Map#{id}: data #{tbl.xsize}x#{tbl.ysize} != map #{w}x#{h}")
+        expect(tbl.data.size == tbl.xsize * tbl.ysize * tbl.zsize,
+               "Map#{id}: data payload #{tbl.data.size} != " \
+               "#{tbl.xsize}x#{tbl.ysize}x#{tbl.zsize}")
+        # VX maps have three layers; VX Ace added a fourth for region ids.
+        expect(tbl.zsize == (db.vxace? ? 4 : 3),
+               "Map#{id}: #{tbl.zsize} layers, expected #{db.vxace? ? 4 : 3}")
+      end
+
+      if db.vxace?
+        expect(db.tilesets[map.tileset_id.to_i].is_a?(RPG::Tileset),
+               "Map#{id}: tileset_id #{map.tileset_id} does not resolve")
+        (map.encounter_list || []).each do |enc|
+          expect(enc.is_a?(RPG::Map::Encounter),
+                 "Map#{id}: encounter #{enc.inspect} is not an RPG::Map::Encounter")
+          expect(db.troops[enc.troop_id.to_i].is_a?(RPG::Troop),
+                 "Map#{id}: encounter troop #{enc.troop_id} does not resolve")
+        end
+      else
+        (map.encounter_list || []).each do |troop_id|
+          expect(db.troops[troop_id.to_i].is_a?(RPG::Troop),
+                 "Map#{id}: encounter troop #{troop_id} does not resolve")
+        end
+      end
+
+      check_events(id, map)
+    end
+  end
+
+  def check_events(map_id, map)
+    (map.events || {}).each do |eid, ev|
+      expect(ev.is_a?(RPG::Event), "Map#{map_id} event #{eid} is not an RPG::Event")
+      expect(ev.pages.is_a?(Array) && !ev.pages.empty?,
+             "Map#{map_id} event #{eid} has no pages")
+      (ev.pages || []).each do |page|
+        @events += 1
+        expect(page.condition.is_a?(RPG::Event::Page::Condition),
+               "Map#{map_id} event #{eid}: page condition missing")
+        expect(page.graphic.is_a?(RPG::Event::Page::Graphic),
+               "Map#{map_id} event #{eid}: page graphic missing")
+        expect(page.move_route.is_a?(RPG::MoveRoute),
+               "Map#{map_id} event #{eid}: page move route missing")
+        (page.list || []).each do |cmd|
+          expect(cmd.is_a?(RPG::EventCommand),
+                 "Map#{map_id} event #{eid}: command #{cmd.inspect} is not an " \
+                 "RPG::EventCommand")
+          @commands += 1
+        end
+      end
+    end
+  end
+
+  # The bundle decodes into named sections of Ruby source (the script host runs
+  # exactly this).
+  def check_scripts(db)
+    expect(db.scripts?, "project reports no script bundle")
+    sections = db.scripts
+    expect(!sections.empty?, "script bundle decoded to nothing")
+    sections.each do |name, source|
+      expect(name.is_a?(String), "script section name #{name.inspect} is not a String")
+      expect(source.is_a?(String), "script section #{name.inspect} did not inflate")
+    end
+  end
+
+  # Boot the project the way src/main.cxx does: construct the shell (which
+  # detects the edition and loads the database) with the RGSS script host on, and
+  # let it drive the game's own scripts to completion. The sample's Main section
+  # reads the database back through the host's Kernel#load_data and drives three
+  # frames, so this covers detection -> database -> host -> per-frame Fiber
+  # driver end to end.
+  def check_boot(dir, edition, title)
+    $rgss_sample_booted = nil
+    $rgss_sample_title = nil
+    RGSS::Graphics.reset_frames
+    previous = ENV["RGSS_SCRIPT_HOST"]
+
+    # Host off (the default): the shell must load the database, report the
+    # pending built-in flow and return — not run anything, and not hang.
+    ENV.delete("RGSS_SCRIPT_HOST")
+    with_game_dir(dir) do
+      game = RPGVX.new([])
+      expect(game.db.is_a?(RPGVX::RGSSData), "boot: no database without the script host")
+      game.start
+    end
+    expect($rgss_sample_booted.nil?,
+           "boot: the bundled scripts ran even though the host is disabled")
+
+    ENV["RGSS_SCRIPT_HOST"] = "1"
+    with_game_dir(dir) do
+      game = RPGVX.new([])
+      expect(game.edition == edition,
+             "boot: shell detected #{game.edition.inspect}, expected #{edition.inspect}")
+      expect(game.title == title,
+             "boot: shell title #{game.title.inspect}, expected #{title.inspect}")
+      game.start
+    end
+    expect($rgss_sample_booted == true, "boot: the bundled Main section did not run")
+    expect($rgss_sample_title == title,
+           "boot: Kernel#load_data returned #{$rgss_sample_title.inspect} " \
+           "from inside the scripts")
+    expect(RGSS::Graphics.frames == 3,
+           "boot: #{RGSS::Graphics.frames} frames driven, expected 3")
+    puts "  boot: script host ran the bundled scripts over #{RGSS::Graphics.frames} frames"
+  rescue StandardError => ex
+    fail "#{dir}: boot raised: #{ex.class}: #{ex.message}"
+  ensure
+    previous.nil? ? ENV.delete("RGSS_SCRIPT_HOST") : ENV["RGSS_SCRIPT_HOST"] = previous
+  end
+
+  # GAME_DIR is a load-time constant in the real build (src/main.cxx defines it
+  # per run); rebind it around a boot so several projects can be checked in one
+  # process.
+  def with_game_dir(dir)
+    Object.send(:remove_const, :GAME_DIR) if Object.const_defined?(:GAME_DIR)
+    Object.const_set(:GAME_DIR, dir)
+    yield
+  end
+
+  # Walk the loaded database and check that every instance variable the data
+  # carries has a reader in our schema. This is the check that catches a field
+  # the RGSS2/RGSS3 transcription missed — trivially true for the generated beds,
+  # and the whole point when this is pointed at a real game.
+  def audit(db)
+    seen = {}
+    missing = {}
+    roots = [db.system, db.map_infos] +
+            RPGVX::RGSSData::ALL_FILES.map { |name| db.send(name) }
+    db.map_infos.each_key { |id| roots << db.load_map(id) }
+    roots.each { |root| audit_value(root, seen, missing) }
+    missing.each do |klass, fields|
+      fail "#{klass} has no accessor for #{fields.keys.sort.join(", ")}"
+    end
+  end
+
+  def audit_value(value, seen, missing)
+    case value
+    when Array then value.each { |v| audit_value(v, seen, missing) }
+    when Hash then value.each_value { |v| audit_value(v, seen, missing) }
+    else
+      return unless value.class.name.to_s.start_with?("RPG::")
+      return if seen.key?(value.object_id)
+      seen[value.object_id] = true
+      value.instance_variables.each do |ivar|
+        reader = ivar.to_s[1..-1]
+        unless value.respond_to?(reader)
+          (missing[value.class.name] ||= {})[reader] = true
+        end
+        audit_value(value.instance_variable_get(ivar), seen, missing)
+      end
+    end
+  end
+
+  # Pack a loose project into its edition's encrypted archive and load the whole
+  # database back through it: a packed release ships no loose Data/ at all, so
+  # this is the only path such a game has.
+  def check_archive(dir, disk)
+    return unless disk
+    edition = disk.edition
+    ext = disk.ext
+    files = Dir[File.join(dir, "Data", "*#{ext}")].sort.map do |f|
+      ["Data\\#{File.basename(f)}", File.binread(f)]
+    end
+    archive_name = RPGVX.info(edition)[:archive]
+    archive = edition == :vxace ? RPGXP::RGSSAD.pack_v3(files)
+                                : RPGXP::RGSSAD.pack_v1(files)
+
+    reader = RPGXP::RGSSAD.new(archive)
+    expect(reader.version == (edition == :vxace ? 3 : 1),
+           "#{archive_name}: unexpected archive version #{reader.version}")
+    files.each do |name, bytes|
+      expect(reader.read(name) == bytes,
+             "#{archive_name} entry #{name} did not round-trip byte-for-byte")
+    end
+
+    Dir.mktmpdir do |tmp|
+      File.binwrite(File.join(tmp, archive_name), archive)
+      File.write(File.join(tmp, "Game.ini"), "[Game]\nTitle=Packed\n")
+      packed = RPGVX::RGSSData.new(tmp) # no loose Data/ -> uses the archive
+      expect(packed.archived?, "#{archive_name}: packed project should report archived?")
+      expect(packed.edition == edition,
+             "#{archive_name}: packed project detected as #{packed.edition}")
+      expect(packed.system.game_title == disk.system.game_title,
+             "#{archive_name}: System.game_title differs from on-disk")
+      expect(packed.actors.compact.size == disk.actors.compact.size,
+             "#{archive_name}: Actors count differs from on-disk")
+      expect(packed.scripts.size == disk.scripts.size,
+             "#{archive_name}: script section count differs from on-disk")
+      disk.map_infos.each_key do |id|
+        pm = packed.load_map(id)
+        dm = disk.load_map(id)
+        expect(pm.width == dm.width && pm.height == dm.height,
+               "#{archive_name}: Map#{id} dimensions differ from on-disk")
+      end
+      # RGSS never writes into the archive: save_data always lands on disk.
+      packed.save_object({ "slot" => 1 }, "Save1#{ext}")
+      expect(packed.read_object("Save1#{ext}") == { "slot" => 1 },
+             "#{archive_name}: save_object/read_object round-trip failed")
+    end
+    puts "  archive: packed #{files.size} entries; DB loads identically " \
+         "through #{archive_name}"
+  rescue StandardError => ex
+    fail "#{dir}: archive check raised: #{ex.class}: #{ex.message}"
+  end
+
+  def report
+    puts "checked #{@projects} project(s), #{@events} event pages, " \
+         "#{@commands} event commands"
+    if @errors.zero?
+      puts "OK: all VX / VX Ace data parsed cleanly"
+    else
+      warn "#{@errors} error(s)"
+    end
+  end
+end
+
+# --- Entry point -----------------------------------------------------------
+
+def discover_games(root)
+  return [] unless Dir.exist?(root)
+  %w[rvdata rvdata2].flat_map do |ext|
+    Dir.glob(File.join(root, "**", "Data", "System.#{ext}"))
+  end.map { |f| File.dirname(File.dirname(f)) }.sort.uniq
+end
+
+if ARGV[0] == "--write"
+  out = ARGV[1] || File.join(ROOT, "data")
+  [[:vx, "vx-sample"], [:vxace, "vxace-sample"]].each do |edition, name|
+    dir = File.join(out, name)
+    Sample.build(dir, edition)
+    puts "wrote #{RPGVX.edition_name(edition)} sample to #{dir}"
+  end
+  exit 0
+end
+
+checker = Checker.new
+
+# The generated beds: one per edition, loose then packed.
+Dir.mktmpdir("rpgvx-check") do |tmp|
+  { vx: "VX Sample", vxace: "Ace Sample" }.each do |edition, title|
+    dir = Sample.build(File.join(tmp, edition.to_s), edition)
+    db = checker.check_project(dir, edition)
+    checker.check_archive(dir, db)
+    checker.check_boot(dir, edition, title)
+  end
+end
+
+# Any real project handed to us, plus whatever is unpacked under ./data.
+games = ARGV.dup
+games = discover_games(File.join(ROOT, "data")) if games.empty?
+games.each do |dir|
+  db = checker.check_project(dir)
+  checker.check_archive(dir, db)
+end
+puts "no real VX / VX Ace test bed found (pass a GAME_DIR to check one)" if games.empty?
+
+checker.report
+exit(checker.errors.zero? ? 0 : 1)

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -260,6 +260,19 @@ extern "C" void rgss_sdl_input_init(void);
 extern "C" void rgss_audio_init(void);
 extern "C" void rgss_audio_shutdown(void);
 
+// Is this an RPG Maker VX (RGSS2) or VX Ace (RGSS3) project? Those look like XP
+// ones from the outside — a Game.ini beside a Data/ folder — so they have to be
+// recognised before the XP branch, which keys on Game.ini alone. Mirrors
+// RPGVX::EDITIONS (mruby-rpgvx/mrblib/lib.rb): an unpacked project is
+// identified by Data/System.rvdata(2), a packed release by its encrypted
+// archive (Game.rgss2a / Game.rgss3a), since such a release ships no loose
+// Data/ at all. The Ruby side re-detects which of the two editions it is.
+static bool is_rpgvx_game(const fs::path& gd) {
+  return fs::exists(gd / "Data" / "System.rvdata2") ||
+         fs::exists(gd / "Data" / "System.rvdata") ||
+         fs::exists(gd / "Game.rgss3a") || fs::exists(gd / "Game.rgss2a");
+}
+
 // Report an mruby exception (class, message, and Ruby backtrace) and bail out
 // of main(). Preferred over ng-log's CHECK: it prints the actual mruby error
 // detail, and under Emscripten ng-log's fatal path traps anyway (it formats
@@ -299,6 +312,10 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
   mrb_value game_obj;
   if (fs::exists(game_dir_path / "RPG_RT.ldb")) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &em_args);
+  } else if (is_rpgvx_game(game_dir_path)) {
+    // RPG Maker VX / VX Ace: checked before the XP branch below, which only
+    // looks for Game.ini — a VX project has one too. See mruby-rpgvx.
+    game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGVX"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "Game.ini")) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
@@ -317,7 +334,8 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "MV"), 1, &em_args);
   } else {
     std::fprintf(stderr,
-                 "No RPG2k (RPG_RT.ldb), RPG XP (Game.ini), RPG Maker MV "
+                 "No RPG2k (RPG_RT.ldb), RPG XP (Game.ini), RPG Maker VX / VX "
+                 "Ace (Data/System.rvdata[2]), RPG Maker MV "
                  "(js/rpg_core.js + data/System.json) or RPG Maker MZ "
                  "(js/rmmz_core.js + data/System.json) project found under "
                  "/game\n");
@@ -358,25 +376,30 @@ int main(int argc, char** argv) {
   }
   nglog::InitializeLogging(argv[0]);
 
-  // RPG Maker XP projects render at 640x480 (RPG2000/MV use 320x240). When the
-  // window size was not overridden on the command line, size the canvas to the
-  // XP resolution so an XP game's title and maps fill the screen. Detection
-  // mirrors the game-class dispatch below: Game.ini plus either a loose
-  // Data/System.rxdata or an encrypted archive (Game.rgssad / .rgss2a /
-  // .rgss3a), since a packed release ships no loose Data/ folder.
+  // RPG Maker XP projects render at 640x480 and VX / VX Ace ones at 544x416
+  // (RPG2000/MV use 320x240). When the window size was not overridden on the
+  // command line, size the canvas to the detected maker's resolution so its
+  // title and maps fill the screen. Detection mirrors the game-class dispatch
+  // below: VX first (its archives, .rgss2a / .rgss3a, are *not* XP markers),
+  // then Game.ini plus either a loose Data/System.rxdata or an XP archive,
+  // since a packed release ships no loose Data/ folder.
   {
     const fs::path gd = FLAGS_game_dir;
+    const bool vx_game = is_rpgvx_game(gd);
     const bool xp_data = fs::exists(gd / "Data" / "System.rxdata") ||
-                         fs::exists(gd / "Game.rgssad") ||
-                         fs::exists(gd / "Game.rgss2a") ||
-                         fs::exists(gd / "Game.rgss3a");
-    const bool xp_game = fs::exists(gd / "Game.ini") && xp_data;
+                         fs::exists(gd / "Game.rgssad");
+    const bool xp_game = !vx_game && fs::exists(gd / "Game.ini") && xp_data;
     gflags::CommandLineFlagInfo w_info, h_info;
     gflags::GetCommandLineFlagInfo("width", &w_info);
     gflags::GetCommandLineFlagInfo("height", &h_info);
-    if (xp_game && w_info.is_default && h_info.is_default) {
-      FLAGS_width = 640;
-      FLAGS_height = 480;
+    if (w_info.is_default && h_info.is_default) {
+      if (xp_game) {
+        FLAGS_width = 640;
+        FLAGS_height = 480;
+      } else if (vx_game) {
+        FLAGS_width = 544;
+        FLAGS_height = 416;
+      }
     }
   }
 
@@ -535,7 +558,7 @@ int main(int argc, char** argv) {
   em_args = args;
   mrb_gc_register(M, em_args);
   if (fs::exists(game_dir_path / "RPG_RT.ldb") ||
-      fs::exists(game_dir_path / "Game.ini") ||
+      fs::exists(game_dir_path / "Game.ini") || is_rpgvx_game(game_dir_path) ||
       (fs::exists(game_dir_path / "js" / "rpg_core.js") &&
        fs::exists(game_dir_path / "data" / "System.json")) ||
       (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
@@ -562,6 +585,14 @@ int main(int argc, char** argv) {
     // RPG Maker MV: a JavaScript game (js/rpg_core.js) with a JSON database.
     // See docs/adr/0004-javascript-maker-mv-quickjs.md.
     game_obj = mrb_obj_new(M, mrb_class_get(M, "MV"), 1, &args);
+  } else if (is_rpgvx_game(game_dir_path)) {
+    // RPG Maker VX / VX Ace: a Marshal database like XP's under a different
+    // extension (Data/*.rvdata[2]) and schema. Checked before the XP branch,
+    // which only looks for Game.ini — a VX project has one too. The database
+    // loads; the built-in title/map flow is still to come, so an unpacked
+    // project reports that unless the RGSS script host is enabled. See
+    // mruby-rpgvx and docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md.
+    game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGVX"), 1, &args);
   } else if (fs::exists(game_dir_path / "Game.ini")) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &args);
   } else {


### PR DESCRIPTION
VX and VX Ace were the gap between the XP and JavaScript runtimes. Their release archives already decrypted (`Game.rgss2a` is XP's v1 format, `Game.rgss3a` the v3 one), but nothing could read what was inside — and `src/main.cxx` handed *any* directory with a `Game.ini` to the XP runtime, so a VX project was mis-detected as XP and died on the `Data/System.rxdata` it does not have.

## What lands

**New `mruby-rpgvx` gem, layered on the XP runtime**

- **`mrblib/rgss2_data.rb`** — the RGSS2 (VX) and RGSS3 (VX Ace) `RPG::*` schema, so every `Data/*.rvdata(2)` file loads straight through `Marshal.load`: VX Ace's feature system, `damage`/`effects` usables, `Class#params`, per-map `Tilesets` and the fourth region layer; VX's `Actor#parameters`, `Areas` and game-wide `System#passages`.
- **`mrblib/rgss_data.rb`** — `RPGVX::RGSSData`, the XP loader's edition-aware counterpart (extension, `Areas` vs `Tilesets`, maps on demand, script-bundle decoding), reusing `RPGXP::RGSSAD` for packed releases.
- **`mrblib/lib.rb`** — edition detection and the boot shell. A VX/VX Ace game's engine *is* its script bundle, so rather than reimplementing a title/map flow first, the shell runs the project's own scripts through the existing RGSS script host when it is enabled (`RGSS_SCRIPT_HOST`); without it, it reports the pending built-in flow instead of opening a blank window (as the MZ shell does).
- **`src/main.cxx`** — checks VX **before** the XP branch and sizes the window to VX's native 544×416.
- **`RPGXP::ScriptHost.build_driver`** — the per-frame Fiber driver (ADR 0023) moved out of `RPGXP` so both shells share one implementation; the XP boot path is otherwise unchanged.

Detection: VX Ace is `Data/System.rvdata2` or `Game.rgss3a`, VX is `Data/System.rvdata` or `Game.rgss2a`. The archive counts on its own because a packed release ships no loose `Data/` at all — and it is the only way to tell a packed VX release from a packed VX Ace one.

## One `RPG::` namespace

`Marshal` resolves a class by its absolute path from `Object`, so `RPG::Actor` in an `.rvdata2` stream and in an `.rxdata` stream are necessarily the same class in a build that links both runtimes. The VX schema therefore *reopens* the XP classes and adds its fields (a record only carries the ivars its own stream wrote, so unused accessors read back nil). RGSS3's superclass chain (`BaseItem → UsableItem`/`EquipItem → Skill`/`Item`/`Weapon`/`Armor`) cannot be real superclasses for the same reason — a reopened class cannot change its superclass — so those fields live in `BaseItemFields` / `UsableItemFields` / `EquipItemFields` modules that the concrete classes and the documentation-only abstract classes both include. Full reasoning in `docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md`.

## Testing

- `mruby-rpgvx/test/rpgvx_test.rb` — edition detection, the per-edition file mapping and Marshal round-trips across the RGSS2/RGSS3 schema, plus both archive formats carrying a real database.
- `scripts/rpgvx_testbed_check.rb` (new blocking CI step) — builds a **complete project per edition** and drives the loader over it: loose on disk, repacked into its real encrypted archive (`Game.rgss2a` v1 / `Game.rgss3a` v3), and through a **boot** that runs the bundled scripts (the sample's `Main` reads the database back through the host's `Kernel#load_data` over three driven frames). It asserts the structural differences between the editions (three vs four map layers, `System#passages` vs `Tileset#flags`, `Areas` vs `Tilesets`) and the database cross-references, and runs a **schema audit**: every instance variable in the loaded data must have an accessor.

**Limitation, stated plainly:** neither editor nor its RTP is redistributable, and no open-source VX/VX Ace project ships a genuine `Data/*.rvdata(2)` tree — so there is no fetchable test bed the way XP (OpenGame) and MV (Lunatic-Core) have one. A generated bed proves the *path*, not the field *names*; those are transcribed from the VX/VX Ace RPG-module references, cross-checked between two independent transcriptions that agree field-for-field. That is what the schema audit is for: trivially true on the generated bed, and the whole point when someone points the check at a real game (`ruby scripts/rpgvx_testbed_check.rb path/to/Game`). Finding a redistributable bed for CI stays open in `docs/TODO.md`.

Verified locally: the check script is green for both editions (data, archives and boot), the audit was probed with a planted unknown field and fails as intended, every new/changed `.rb` parses under mruby 4.0's own `mrbc`, the detection/table logic runs under a real mruby interpreter, the shared Fiber driver was exercised under CRuby, and `clang-format` is clean. The native SDL/mruby binary cannot be built in the dev environment used here, so CI is the first full build.

## Follow-ups (tracked in `docs/TODO.md`)

Reading graphics/audio out of the archive (shared with the XP gap), the built-in title/map flow for a project whose scripts are not run, and the RGSS2/RGSS3 halves of the `mruby-rgss` class library the stock scripts call.