### PR TITLE
Draw the game timer on the map (Timer Operation show flag)

### DIFF
--- a/changelog.d/rpg2k-timer-display.added.md
+++ b/changelog.d/rpg2k-timer-display.added.md
@@ -1,0 +1,5 @@
+The game timer is now drawn on the map. The Timer Operation command's start
+carries RPG2000's "show timer" flag, and while set `Scene::Map` shows a small
+top-centre window counting down as `M:SS` (independent of whether the timer is
+still running, so a stopped timer stays on screen frozen). The visibility flag
+round-trips through the save.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -415,7 +415,11 @@ The work below is roughly ordered by the critical path to a walkable game
   the message/choice UI (those requests are skipped) — full parallel UI is a
   later refinement
 - 🚧 Screen effects — the game **timer** works (Timer Operation command +
-  `Game::State` countdown). The **Tint Screen** (11030) command now drives a
+  `Game::State` countdown) and is now **drawn**: the start operation's
+  "show timer" flag sets a `timer_visible` state (persisted in the save), and
+  while set `Scene::Map` shows a small top-centre window counting down as
+  `M:SS`, independent of whether the timer is still running. The **Tint Screen**
+  (11030) command now drives a
   `Game::Screen` tint state machine on `Game::State`: it interpolates the four
   RPG2000 channels (red/green/blue/saturation, 0..200) toward their target over
   the command's duration (advanced each frame by `Scene::Map`), and the wait

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3246,6 +3246,10 @@ module Game
   class State
     attr_reader :party, :switches, :variables, :message_config, :screen, :weather
     attr_accessor :map, :map_id, :x, :y, :direction, :timer_frames, :timer_running
+    # Whether the timer is shown on the map, set by the Timer Operation's start
+    # (the RPG2000 "show timer" flag). Counting (timer_running) and being drawn
+    # (timer_visible) are independent: a stopped timer stays on screen, frozen.
+    attr_accessor :timer_visible
     # Whether the player may open the main menu / save, toggled by the Change
     # Main Menu Access (11960) and Change Save Access (11930) event commands;
     # both default on and are persisted in the save.
@@ -3305,6 +3309,7 @@ module Game
       @variables = Variables.new
       @timer_frames = 0
       @timer_running = false
+      @timer_visible = false
       @message_config = MessageConfig.new
       @menu_access = true
       @save_access = true
@@ -3383,6 +3388,15 @@ module Game
     # Remaining timer seconds (assuming 60 fps).
     def timer_seconds; @timer_frames / 60; end
 
+    # The timer as RPG2000 draws it: whole minutes, a colon, then zero-padded
+    # seconds (e.g. 90 s -> "1:30"). Minutes are not capped at two digits. The
+    # seconds are padded by hand: this mruby build bundles no sprintf.
+    def timer_display_text
+      s = timer_seconds
+      secs = s % 60
+      "#{s / 60}:#{secs < 10 ? "0#{secs}" : secs}"
+    end
+
     # The six Change Screen Transitions (10690) slots (see #screen_transitions).
     SCREEN_TRANSITION_SLOTS = 6
 
@@ -3407,7 +3421,8 @@ module Game
       { map_id: @map_id, x: @x, y: @y, direction: @direction,
         switches: @switches.to_h, variables: @variables.to_h,
         party: @party.to_h, timer_frames: @timer_frames,
-        timer_running: @timer_running, message_config: @message_config.to_h,
+        timer_running: @timer_running, timer_visible: @timer_visible,
+        message_config: @message_config.to_h,
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
         player_transparent: @player_transparent, weather: @weather.to_h,
@@ -3756,6 +3771,7 @@ module Game
       state.variables.replace(h[:variables] || {})
       state.timer_frames = h[:timer_frames] || 0
       state.timer_running = h[:timer_running] || false
+      state.timer_visible = h[:timer_visible] || false
       state.message_config.load_h(h[:message_config])
       # Access flags default on; only an explicit stored value overrides them
       # (so a save written before these existed keeps the menu/save enabled).

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -989,13 +989,17 @@ module Game
       end
     end
 
-    # Timer: op 0 set (seconds), 1 start, 2 stop.
+    # Timer: op 0 set (seconds), 1 start, 2 stop. Start carries the RPG2000
+    # "show timer" flag in param 3 (param 4 is the run-in-battle flag, unused
+    # here); stopping freezes the display but leaves it shown.
     def do_timer(cmd)
       case cmd.param(0)
       when 0
         sec = cmd.param(1) == 0 ? cmd.param(2) : variables[cmd.param(2)]
         @state.timer_frames = sec * 60
-      when 1 then @state.timer_running = true
+      when 1
+        @state.timer_running = true
+        @state.timer_visible = cmd.param(3) != 0
       when 2 then @state.timer_running = false
       end
     end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -477,6 +477,8 @@ class RPG2k
         @wait_timer = nil
         @anim_wait = nil
         @map_animation = nil
+        @timer_window = nil
+        @timer_text = nil
         @pre_vehicle_bgm = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
@@ -515,6 +517,7 @@ class RPG2k
           s.dispose if s
         end
         (@vehicle_sprites || {}).each_value { |s| s.dispose if s }
+        @timer_window.dispose if @timer_window
         @airship_shadow.dispose if @airship_shadow
         @animation_sprite.dispose if @animation_sprite
         @chipset_bmp.dispose if @chipset_bmp
@@ -3445,6 +3448,44 @@ class RPG2k
 
         draw_pictures cam_x, cam_y
         update_screen_overlay
+        draw_timer
+      end
+
+      # RPG2000 timer: a small window in the top centre showing the remaining
+      # time as M:SS while the timer is visible. Visibility (the Start command's
+      # "show timer" flag) is independent of whether it is still counting, so a
+      # stopped timer stays on screen frozen; it hides only when never shown.
+      # The window and its contents are built once, and the text is redrawn only
+      # when the displayed second changes (not every frame).
+      TIMER_INNER_W = 40
+      TIMER_INNER_H = 16
+
+      def draw_timer
+        unless @state.timer_visible
+          @timer_window.visible = false if @timer_window
+          return
+        end
+        build_timer_window unless @timer_window
+        @timer_window.visible = true
+        text = @state.timer_display_text
+        return if text == @timer_text
+
+        @timer_text = text
+        c = @timer_window.contents
+        c.clear
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, c.width, c.height, text, 1 # centre-aligned
+      end
+
+      def build_timer_window
+        ow = TIMER_INNER_W + Window::BORDER * 2
+        oh = TIMER_INNER_H + Window::BORDER * 2
+        win = Window.new((SCREEN_W - ow) / 2, 4, ow, oh)
+        win.z = 250 # above the map, below the message / menu windows (z 300+)
+        win.windowskin = @windowskin
+        win.contents = Bitmap.new(TIMER_INNER_W, TIMER_INNER_H)
+        @timer_window = win
+        @timer_text = nil
       end
 
       # Position and draw each vehicle placed on the current map. A parked vehicle

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1078,6 +1078,35 @@ check 'conditional branch on the timer' do
   eq false, st.switches[5]
 end
 
+check 'Timer Operation start carries the show-timer flag; text is M:SS' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # Set 90 s (constant operand), then start with the show-timer flag on.
+  it.start([
+    FakeCmd.new(IC::TIMER_OPERATION, [0, 0, 90]),        # set = 90 s
+    FakeCmd.new(IC::TIMER_OPERATION, [1, 0, 0, 1, 0]),   # start, visible
+  ])
+  it.update
+  eq 90 * 60, st.timer_frames
+  eq true, st.timer_running
+  eq true, st.timer_visible, 'the show-timer flag turns the display on'
+  eq '1:30', st.timer_display_text, '90 s reads as 1:30'
+  # Stopping freezes the count but leaves the display shown.
+  it.start([FakeCmd.new(IC::TIMER_OPERATION, [2])])
+  it.update
+  eq false, st.timer_running
+  eq true, st.timer_visible, 'a stopped timer stays on screen'
+  # A start with the flag clear hides it again.
+  it.start([FakeCmd.new(IC::TIMER_OPERATION, [1, 0, 0, 0, 0])])
+  it.update
+  eq false, st.timer_visible, 'starting without the flag hides the timer'
+  # Padding: seconds below ten keep a leading zero, minutes are uncapped.
+  st.timer_frames = 5 * 60
+  eq '0:05', st.timer_display_text
+  st.timer_frames = 605 * 60 # 10 min 5 s
+  eq '10:05', st.timer_display_text
+end
+
 # -- Memorize / Recall Location ----------------------------------------------
 
 check 'Memorize Location stores map/x/y into three variables' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1755,6 +1755,25 @@ check 'Weather draws a particle overlay when active and hides it when clear' do
   ok !wsp.visible, 'clearing weather hides the overlay'
 end
 
+check 'the timer window shows M:SS while visible and hides when never shown' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  ok scene.instance_variable_get(:@timer_window).nil?, 'no window until shown'
+  # Show a 75 s timer (Start with the show flag on).
+  st.timer_frames = 75 * 60
+  st.timer_visible = true
+  scene.update
+  win = scene.instance_variable_get(:@timer_window)
+  ok win, 'the window is built on first display'
+  ok win.visible, 'and shown'
+  eq '1:15', win.contents.draw_calls.last[4], 'it draws the M:SS text'
+  # Hiding the timer hides the window.
+  st.timer_visible = false
+  scene.update
+  ok !win.visible, 'clearing visibility hides the timer window'
+end
+
 check 'boarding plays the vehicle BGM; disembarking restores the map BGM' do
   scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary
The game timer already counted down and fed conditionals, but it was never drawn. It is now shown on the map.

## Changes
- **Model (`game.rb`)** — a new `timer_visible` state, independent of `timer_running` (a stopped timer stays on screen, frozen), plus a `timer_display_text` helper that formats the remaining time as `M:SS` (seconds hand-padded, since this mruby build bundles no sprintf). Both `timer_visible` and the visibility flag round-trip through `to_h`/`from_h`.
- **Interpreter (`interpreter.rb`)** — Timer Operation's *start* now reads RPG2000's "show timer" flag (param 3) into `timer_visible`; *stop* leaves the display shown but frozen.
- **Scene (`main.rb`)** — `draw_timer` shows a small top-centre `Window` counting down as `M:SS` while visible, built lazily, redrawing text only when the displayed second changes, and disposed with the scene.

## Testing
- `scripts/rpg2k_logic_check.rb` — **282 checks pass** (adds the show-flag semantics and `M:SS` padding, incl. `0:05` and uncapped `10:05`).
- `scripts/rpg2k_scene_check.rb` — **90 checks pass** (adds a check that the window appears with the right text and hides when visibility clears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_