### PR TITLE
Move the message window away from the hero when not pinned

### DIFF
--- a/changelog.d/rpg2k-message-auto-position.added.md
+++ b/changelog.d/rpg2k-message-auto-position.added.md
@@ -1,0 +1,5 @@
+The message window now moves away from the hero when it is not position-fixed
+(RPG2000's default): if the hero stands in the lower half of the screen the
+window jumps to the top, otherwise it sits at the bottom, so talking to
+something near a map's bottom edge no longer covers it. A position-fixed
+message still honours its configured top/middle/bottom slot.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -407,9 +407,13 @@ The work below is roughly ordered by the critical path to a walkable game
   the swatch's shading reads as a top-to-bottom gradient on the text the way
   RPG2000 draws it (`Game::MessagePalette` locates each swatch — a 10×2 grid of
   16×16 cells from y = 48, per EasyRPG's layout), falling back to a flat colour
-  only when no windowskin loaded or for an out-of-range index. Auto-positioning
-  the window away from the hero (when not pinned) and the mirrored-face flag are
-  later refinements
+  only when no windowskin loaded or for an out-of-range index. When the message
+  is **not pinned** (`position_fixed` off, the RPG2000 default) the window now
+  relocates to keep clear of the hero — top when the hero sits in the lower half
+  of the screen, bottom otherwise — so talking to something at a map's bottom
+  edge shows the text up top; the exact zone boundary is approximate pending a
+  wine diff, but the direction matches RPG_RT. The mirrored-face flag is a
+  later refinement
 - ✅ Common events — auto-start common events run once on the map, and parallel
   common events now run **continuously** in the background alongside the player
   via their own looping interpreter (`Scene::Map#step_parallels`), each gated by

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3171,15 +3171,39 @@ class RPG2k
       end
 
       # Vertical position of a `win_h`-tall message window for the configured
-      # display position (top / middle / bottom). Auto-positioning away from the
-      # hero (when `position_fixed` is off) is a later refinement; the window is
-      # placed at the requested position for now.
+      # display position (top / middle / bottom). When the message is not pinned
+      # (`position_fixed` off, RPG2000's default), the window relocates so it does
+      # not cover the hero: if the hero is standing in the lower half of the
+      # screen the window jumps to the top, and vice-versa (so talking to
+      # something at the bottom edge of a map shows the text up top). The exact
+      # zone boundary is approximate pending a wine diff; the direction matches
+      # RPG_RT.
       def message_window_y(win_h, cfg)
-        case cfg.position
+        pos = cfg.position
+        pos = auto_message_position(win_h) unless cfg.position_fixed
+        case pos
         when Game::MessageConfig::POS_TOP    then 0
         when Game::MessageConfig::POS_MIDDLE then (SCREEN_H - win_h) / 2
         else SCREEN_H - win_h
         end
+      end
+
+      # Pick the message position that keeps clear of the hero: top when the hero
+      # is in the lower half of the screen, bottom otherwise.
+      def auto_message_position(_win_h)
+        if hero_screen_y >= SCREEN_H / 2
+          Game::MessageConfig::POS_TOP
+        else
+          Game::MessageConfig::POS_BOTTOM
+        end
+      end
+
+      # The hero tile's centre in screen pixels, from the edge-clamped follow
+      # camera (ignoring transient pan / shake offsets).
+      def hero_screen_y
+        _px, py = player_pixel
+        cam_y = Game.camera_offset(py + TILE / 2, SCREEN_H, @map.height * TILE)
+        (py + TILE / 2) - cam_y
       end
 
       # Load the FaceSet graphic named by the message config, or nil when no face

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1753,6 +1753,33 @@ check 'Tint Screen darkens the view through a black overlay; neutral clears it' 
   eq 0, tint.opacity, 'a neutral tint clears the overlay'
 end
 
+check 'the message window moves away from the hero when not position-fixed' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  cfg = st.message_config
+  # A tall map so the follow camera clamps and the hero can sit low on screen.
+  w = 6; h = 30
+  tall = Game::Map.new(1, OpenStruct.new(
+    width: w, height: h, chipset_id: 1,
+    lower_layer: Array.new(w * h, 0), upper_layer: Array.new(w * h, 0),
+    events: {}))
+  scene.instance_variable_set(:@map, tall)
+  st.map = tall
+  win_h = 80
+  mwy = ->(c) { scene.send(:message_window_y, win_h, c) }
+  # Default (not fixed): hero near the bottom -> the window jumps to the top.
+  st.y = 28
+  eq 0, mwy.call(cfg), 'hero low on screen -> window at the top'
+  # Hero at the top of the map -> the window sits at the bottom.
+  st.y = 0
+  eq 240 - win_h, mwy.call(cfg), 'hero high on screen -> window at the bottom'
+  # Pinned: the configured position wins regardless of where the hero stands.
+  cfg.position_fixed = true
+  cfg.position = Game::MessageConfig::POS_MIDDLE
+  st.y = 28
+  eq (240 - win_h) / 2, mwy.call(cfg), 'position-fixed keeps the configured slot'
+end
+
 check 'Weather draws a particle overlay when active and hides it when clear' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary
RPG2000 relocates an unpinned message window (`position_fixed` off, the default) so it does not cover the hero. `message_window_y` previously always used the configured top/middle/bottom slot; it now avoids the hero.

## Changes
- **Scene (`main.rb`)** — when the message is not position-fixed, `message_window_y` computes the hero's edge-clamped screen position (new `hero_screen_y` helper) and puts the window at the **top** when the hero is in the lower half of the screen, **bottom** otherwise. A position-fixed message still honours its exact configured slot.

## Notes
The exact zone boundary is approximate pending a wine diff (matching how the project treats other native-parity features), but the direction matches RPG_RT — talking to something at a map's bottom edge now shows the text up top.

## Testing
- `scripts/rpg2k_scene_check.rb` — **91 checks pass** (adds a check on a tall map, so the follow camera actually clamps: hero low → window top, hero high → window bottom, `position_fixed` → configured MIDDLE slot).
- `scripts/rpg2k_logic_check.rb` — **284 checks pass** (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_