### PR TITLE
Add cross-runtime testing for RPG Maker XP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -557,7 +557,13 @@ jobs:
       - name: Wait for the RPG XP test bed
         wait: [xp-testbed]
 
+      # Non-blocking on its first outings, the way the MV/MZ smokes were staged:
+      # this is the first check in the repo that drives a real browser, and a
+      # flake here would block the page deployment. The same runtime logic is
+      # covered blockingly by the native boot smoke in the `build` job; what is
+      # only covered here is the browser itself.
       - name: RPG XP browser smoke test
+        continue-on-error: true
         run: nix develop -c python3 scripts/rpgxp_browser_check.py
 
       - name: Upload RPG XP browser frames

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,8 @@ jobs:
       # can grab the same display, killing one Xvfb out from under its client
       # ("XIO: fatal IO error"). Reserved numbers: exe_open=99 (see the ctest
       # `exe_open` test in CMakeLists.txt); MV runs=100..108, the RPG2k
-      # real-game boot smoke=109..110, and the MZ boot smoke=111 below. Every
+      # real-game boot smoke=109..110, the MZ boot smoke=111, and the RPG XP
+      # real-game boot smoke=112 below. Every
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
       # check.
@@ -212,6 +213,15 @@ jobs:
           # per game. See ADR 0021.
           - name: RPG2k real-game boot smoke test
             run: nix develop -c ./scripts/rpg2k_boot_check.bash 109
+
+          # The same guard for the RPG Maker XP runtime: the XP checks above run
+          # mruby-rpgxp's sources under CRuby, so only booting the real binary
+          # catches mruby/CRuby divergence. `--rpgxp_new_game` drives the test
+          # bed past its title into the start map and logs `[RPGXP-MAP]`, which
+          # the script asserts on. Display 112 (see the reserved server-num map
+          # above). See docs/adr/0024-rpgxp-cross-runtime-testing.md.
+          - name: RPG XP real-game boot smoke test
+            run: nix develop -c ./scripts/rpgxp_boot_check.bash 112
 
           - name: MV boot smoke test
             continue-on-error: true
@@ -468,6 +478,14 @@ jobs:
         background: true
         run: nix develop -c ./scripts/download-mv-corescript.bash
 
+      # The project the browser smoke test below plays. Network-bound and
+      # unrelated to the compile, so it overlaps the build like the MV fetch
+      # above; the script is idempotent and writes only under data/.
+      - name: Download the RPG XP test bed
+        id: xp-testbed
+        background: true
+        run: nix develop -c ./scripts/download-opengame-xp.bash
+
       - uses: actions/cache@v6
         with:
           path: ~/.emscripten_cache
@@ -525,6 +543,33 @@ jobs:
             nix develop -c ccache --show-stats
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Play an RPG Maker XP project in the page that was just built: the check
+      # serves it, feeds the shell's loader a zip of the test bed, presses the
+      # decision key and asserts the runtime reaches the map ([RPGXP-MAP]), that
+      # keys move the party and that the canvas is not blank — the browser build
+      # is a runtime of its own (its own loader, input path and frame loop), and
+      # a green compile says nothing about it. It drives headless Chromium over
+      # the DevTools protocol with the Python standard library alone, so the
+      # `chromium` in the dev shell is the whole dependency. Screenshots of every
+      # step are uploaded below. See
+      # docs/adr/0024-rpgxp-cross-runtime-testing.md.
+      - name: Wait for the RPG XP test bed
+        wait: [xp-testbed]
+
+      - name: RPG XP browser smoke test
+        run: nix develop -c python3 scripts/rpgxp_browser_check.py
+
+      - name: Upload RPG XP browser frames
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpgxp-browser-frames
+          path: |
+            ss/rpgxp-browser-*.png
+            ss/rpgxp-browser.log
+          if-no-files-found: warn
 
       - uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@
   `scripts/rtp_xp_install.bash` and both runtimes read the same assets). The
   browser pass immediately found two page-only bugs — an XP project rendering on
   a 320x240 screen with its title window off-canvas, and the loader panel staying
-  on top of the running game — both fixed; see
+  on top of the running game — and the wine pass found four more that had kept an
+  XP project from drawing its RTP art at all: the XP RTP registry key was never
+  read, `.jpg` was missing from the asset search, truecolour images came out with
+  red and blue exchanged, and an RGBA image loaded opaque drew garbage. With those
+  fixed (RPG2000 rendering byte-identical) the title screen went from 74% of its
+  pixels differing from the genuine runtime to 15%; see
   [`docs/adr/0024-rpgxp-cross-runtime-testing.md`](docs/adr/0024-rpgxp-cross-runtime-testing.md)
 
 ### Terminal gaming

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@
   while the RGSS class library is completed; see
   [`docs/adr/0017-rpgxp-rgss-script-host.md`](docs/adr/0017-rpgxp-rgss-script-host.md)
   (data layer: [`docs/adr/0010-rpgxp-rgss-data-layer.md`](docs/adr/0010-rpgxp-rgss-data-layer.md))
+- An XP project is exercised in **every runtime it can run in**, all reaching the
+  same `[RPGXP-MAP]` marker (`--rpgxp_new_game` picks New Game without input):
+  `scripts/rpgxp_boot_check.bash` boots the native binary headlessly (in CI),
+  `scripts/rpgxp_browser_check.py` plays the project **in the browser build** —
+  it serves the emscripten page, hands the shell's own loader a zip of the
+  project, presses keys through the DevTools protocol and checks the runtime log
+  and the rendered canvas (headless Chromium, Python standard library only, no
+  npm dependency) — and `scripts/compare-rpgxp-wine.bash` diffs our frames
+  against the **genuine RGSS runtime**, booting the project's own
+  `Game.exe`/`RGSS104E.dll` under wine on the same key script (the XP twin of the
+  RPG2000 comparison; install the RTP into that wine prefix with
+  `scripts/rtp_xp_install.bash` and both runtimes read the same assets). The
+  browser pass immediately found two page-only bugs — an XP project rendering on
+  a 320x240 screen with its title window off-canvas, and the loader panel staying
+  on top of the running game — both fixed; see
+  [`docs/adr/0024-rpgxp-cross-runtime-testing.md`](docs/adr/0024-rpgxp-cross-runtime-testing.md)
 
 ### Terminal gaming
 - Render the game to a terminal instead of an SDL window, using either the DEC

--- a/changelog.d/rpgxp-browser-screen-size.fixed.md
+++ b/changelog.d/rpgxp-browser-screen-size.fixed.md
@@ -1,0 +1,8 @@
+- An RPG Maker XP project loaded in the **browser** build now renders at XP's
+  native 640x480 instead of the 320x240 default, so its title window and centred
+  text no longer fall off the canvas: the native path sizes the display from
+  `--game_dir` before creating it, but in the browser the project is mounted
+  later by the page's loader, so `rpg_start_game()` resizes the display when it
+  detects one. The page's loader panel also disappears once a game starts —
+  `hidden` was being overridden by the panel's own `display: flex` rule. Both
+  found by `scripts/rpgxp_browser_check.py`.

--- a/changelog.d/rpgxp-cross-runtime-testing.added.md
+++ b/changelog.d/rpgxp-cross-runtime-testing.added.md
@@ -1,0 +1,12 @@
+- RPG Maker XP projects are now tested in every runtime they can run in.
+  `--rpgxp_new_game` selects New Game without input and `RPGXP#start_new_game`
+  logs `[RPGXP-MAP] map=.. x=.. y=..`, the marker all three checks assert on:
+  `scripts/rpgxp_boot_check.bash` boots the native binary headlessly (wired into
+  CI), `scripts/rpgxp_browser_check.py` plays the project in the **browser
+  build** by feeding the emscripten page's own loader a zip of it and driving
+  headless Chromium over the DevTools protocol (Python standard library only —
+  no npm dependency; also wired into CI, with the frames uploaded as an
+  artifact), and `scripts/compare-rpgxp-wine.bash` diffs our frames against the
+  **genuine RGSS runtime** (`Game.exe` + `RGSS104E.dll` under wine) on the same
+  key script, the RPG Maker XP counterpart of the RPG2000 wine comparison. See
+  `docs/adr/0024-rpgxp-cross-runtime-testing.md`.

--- a/changelog.d/rpgxp-rtp-and-truecolour-assets.fixed.md
+++ b/changelog.d/rpgxp-rtp-and-truecolour-assets.fixed.md
@@ -1,0 +1,17 @@
+- RPG Maker XP projects now draw their real RTP graphics instead of
+  placeholders, and truecolour art draws in the right colours. Four fixes, all
+  found by diffing our frames against the genuine RGSS runtime under wine
+  (`scripts/compare-rpgxp-wine.bash`): the XP RTP registry key
+  (`Software\Enterbrain\RGSS\RTP\Standard`) is now what an XP project's
+  `RTP_DIR` resolves to (only the RPG2000 key was ever consulted, so no XP asset
+  could be found); `.jpg` joined the Bitmap search extensions (the XP RTP stores
+  title backgrounds as JPEG and windowskins as PNG); stb's decoded pixels are
+  swapped into LVGL's B, G, R order explicitly, since the vendored BGR hack only
+  covered indexed PNGs and left every truecolour PNG and JPEG with red and blue
+  exchanged; and a bitmap's pixel format now follows the channel count actually
+  requested from the decoder, so an RGBA image loaded opaque no longer fills a
+  4-byte-per-pixel bitmap from 3-channel data. RPG2000 rendering is unchanged
+  (its title screen is byte-identical before and after).
+- The RPG Maker XP title screen's command window is 192 wide, matching RMXP's
+  `Window_Command.new(192, ...)`; at 240 it sat too wide and too far left of the
+  genuine runtime's window.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -677,6 +677,25 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   Also reconcile the scripts' blocking main loop with the emscripten frame loop
   (Asyncify or a per-frame driver), and read graphics/audio out of the encrypted
   archive.
+- ✅ **Cross-runtime testing** — an XP project is booted in every runtime it can
+  run in, all asserting the same `[RPGXP-MAP]` marker (`--rpgxp_new_game` picks
+  New Game without input): `scripts/rpgxp_boot_check.bash` (the native binary,
+  the guard against mruby/CRuby divergence the CRuby-hosted checks cannot see),
+  `scripts/rpgxp_browser_check.py` (the emscripten page, driven in headless
+  Chromium over the DevTools protocol with no npm dependency) — both in CI — and
+  `scripts/compare-rpgxp-wine.bash`, which diffs our frames against the genuine
+  `Game.exe` + `RGSS104E.dll` under wine, the XP twin of
+  `compare-nepheshel-wine.bash`. That comparison is the harness the remaining
+  render work below is meant to be driven by: the tile layers are still
+  placeholder colour blocks, so its map steps differ wholesale until real
+  tileset/autotile blitting lands. See
+  [`docs/adr/0024-rpgxp-cross-runtime-testing.md`](adr/0024-rpgxp-cross-runtime-testing.md);
+  the browser pass already found (and this fixed) an XP project rendering on a
+  320x240 screen in the page and the loader panel covering the running game.
+  Still open there: running the **script host** in the browser (the ADR 0023
+  frame driver has never been verified in a real browser), and a way to pass
+  engine flags to the page so the browser check can use `--rpgxp_new_game`
+  instead of pressing keys.
 - Reference for the RGSS game library:
   https://www.rpgmaker.fixato.org/Manual/RPGVXAce/rgss/
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -691,7 +691,12 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   tileset/autotile blitting lands. See
   [`docs/adr/0024-rpgxp-cross-runtime-testing.md`](adr/0024-rpgxp-cross-runtime-testing.md);
   the browser pass already found (and this fixed) an XP project rendering on a
-  320x240 screen in the page and the loader panel covering the running game.
+  320x240 screen in the page and the loader panel covering the running game, and
+  the wine pass found four more (the XP RTP key was never read, `.jpg` was
+  missing from the asset search, truecolour images were red/blue-swapped, and an
+  RGBA image loaded opaque drew garbage) — the XP title screen now differs from
+  the genuine runtime in 15% of its pixels, down from 74%, the rest being the
+  windowskin's opacity and the reference's font-less text.
   Still open there: running the **script host** in the browser (the ADR 0023
   frame driver has never been verified in a real browser), and a way to pass
   engine flags to the page so the browser check can use `--rpgxp_new_game`

--- a/docs/adr/0024-rpgxp-cross-runtime-testing.md
+++ b/docs/adr/0024-rpgxp-cross-runtime-testing.md
@@ -51,13 +51,17 @@ marker so the three checks assert the same thing.
   build's gem set).
 - **Native: `scripts/rpgxp_boot_check.bash`.** Boots the built binary on the XP
   test bed under Xvfb and fails unless `[RPGXP-MAP]` shows up. This is the guard
-  against mruby/CRuby divergence in the XP runtime, and it runs in CI.
+  against mruby/CRuby divergence in the XP runtime, and it runs in CI as a
+  blocking check.
 - **Browser: `scripts/rpgxp_browser_check.py`.** Serves the built page, hands it
   a zip of the XP project through the shell's own loader, presses the decision
   key, and asserts: the runtime initialises, the project mounts, the game starts
   and the loader panel goes away, the display is XP-sized, `[RPGXP-MAP]` appears,
   arrow keys change the frame, the canvas is not blank, and nothing in the page
   log looks like an mruby exception. Screenshots of every step are written out.
+  It runs in the `wasm` CI job, uploading those frames — non-blocking at first,
+  the way the MV/MZ smokes were staged, since it is the repo's first check to
+  drive a real browser and a flake would block the page deployment.
 - **Reference: `scripts/compare-rpgxp-wine.bash`.** Boots the project's own
   `Game.exe`/`RGSS104E.dll` under wine and our engine on two Xvfb displays at
   640x480, feeds both the same key script, and writes per-step ref/ours/diff/cmp
@@ -111,6 +115,11 @@ browser build has, both now fixed here:
   (`RGSS_SCRIPT_HOST`, ADR 0017/0023) in the page is the natural next step for it
   — the frame driver added in ADR 0023 was written for the browser but has never
   been verified there.
+- The browser check loads an *unpacked* project. A packed release (`Game.ini` +
+  `Game.rgssad`, no loose `Data/`) is the shape most XP games ship in and takes a
+  different path through both the shell's loader and `RGSSData`; packing the test
+  bed into one (as `rpgxp_testbed_check.rb` already does) and loading that too is
+  the obvious next case.
 - The page has no way to pass engine flags, so the browser check reaches the map
   by pressing keys rather than with `--rpgxp_new_game`. That is the more faithful
   test (it exercises DOM input), but it means a title-screen regression and an

--- a/docs/adr/0024-rpgxp-cross-runtime-testing.md
+++ b/docs/adr/0024-rpgxp-cross-runtime-testing.md
@@ -105,6 +105,41 @@ browser build has, both now fixed here:
   by setting `hidden`, which the page's own `.panel { display: flex }` rule
   overrode. The check now asserts the *computed* style, not the property.
 
+**Found by the wine comparison, on its first real run** — four bugs that kept an
+XP project from drawing what the genuine runtime draws, all fixed here:
+
+- **The XP RTP was never looked up.** `xp_rtp_path()` (the
+  `Software\Enterbrain\RGSS\RTP\Standard` key) existed but nothing called it:
+  `RTP_DIR` was always the RPG2000 `Software\ASCII\RPG2000` path, so an XP
+  project could not find a single RTP asset and every graphic fell back to a
+  placeholder. The RTP is now picked by project type.
+- **`.jpg` was not in the asset search.** The XP RTP genuinely mixes formats —
+  windowskins and charsets are PNG, title backgrounds are JPEG — and the Bitmap
+  loader only tried `.png`/`.xyz`/`.bmp`, so every XP title screen stayed on the
+  fallback background. stb already decodes JPEG.
+- **Truecolour images were drawn with red and blue exchanged.** Every loader in
+  `mruby-rgss` hands back LVGL's B, G, R(, A) order, but stb decodes to
+  R, G, B(, A); the vendored stb carries a BGR hack that covers *indexed* PNGs
+  only — which is all an RPG2000 project has. XP's truecolour PNGs and JPEGs
+  came out channel-swapped. stb's output is now swapped explicitly, and the
+  RPG2000 title screen renders byte-identically before and after.
+- **An RGBA image loaded opaque drew garbage.** The bitmap's pixel format was
+  chosen from the *file's* channel count while the data was decoded with the
+  *requested* one, so an RGBA source loaded without the transparent flag filled
+  a 4-byte-per-pixel bitmap from 3-channel data — reading past the buffer. XP's
+  truecolour windowskin hit exactly that. The format now follows the request.
+
+- **The title's command window was the wrong size.** RMXP's `Scene_Title` builds
+  `Window_Command.new(192, ...)`; ours was 240 wide, so it sat 48 too wide and 24
+  too far left. Its height and y were already right.
+
+Measured on the title screen, that took the frame from **227,389 differing
+pixels (74%)** to **47,377 (15%)**, and the window frames now land on the
+reference's pixels. What is left inside the window is the reference drawing *no*
+text at all — RGSS finds no font in the wine prefix — our solid selection bar
+against its translucent one, and a level or two per channel from a different
+JPEG decoder.
+
 **Follow-ups this opens:**
 
 - The XP tile layers still render as placeholder colour blocks, so the wine

--- a/docs/adr/0024-rpgxp-cross-runtime-testing.md
+++ b/docs/adr/0024-rpgxp-cross-runtime-testing.md
@@ -1,0 +1,117 @@
+# 24. Testing RPG Maker XP against the browser build and the genuine RGSS runtime
+
+Date: 2026-08-04
+
+## Status
+
+Accepted — the native and browser checks run green on the OpenGame.exe XP test
+bed; the wine comparison is a manual/dev script, like its RPG2000 counterpart.
+
+## Context
+
+The RPG Maker XP runtime (`mruby-rpgxp`) had two kinds of coverage:
+
+- **Data-layer checks under CRuby** — `scripts/rpgxp_testbed_check.rb` and
+  `scripts/rpgxp_script_host_check.rb` load the very same `mrblib/*.rb` sources
+  under CRuby and drive them over a real project's `Data/*.rxdata`.
+- **Unit tests** — `mruby-rpgxp/test`, run by the per-gem `rake test`.
+
+Neither one runs the *engine*. The RPG2000 side learned twice over that this is
+not enough (ADR 0021): a bare `module_function` and `Enumerable#none?` both pass
+under CRuby and both break the real mruby build, so `rpg2k_boot_check.bash` boots
+the actual binary, and `compare-nepheshel-wine.bash` diffs its frames against the
+genuine `RPG_RT.exe` under wine. The XP side had neither.
+
+Two XP-specific gaps made that worse:
+
+1. **The browser is a third runtime, and nothing tested it.** The page
+   (`src/shell.html` + the emscripten build) has failure modes the native binary
+   cannot have: its loader mounts a project into the virtual filesystem at
+   *runtime*, `rpg_start_game()` picks the runtime from what landed there,
+   keyboard input arrives as DOM events, and the frame loop is the browser's, not
+   ours. The build being green says nothing about any of it. The XP path is also
+   the *newest* consumer of that loader (`Game.ini` detection was added to it),
+   and the page is what GitHub Pages and the `/preview` deployments serve.
+2. **There is a genuine XP runtime we can run.** The `OpenGame.exe` test bed the
+   repo already downloads ships Enterbrain's `Game.exe` + `RGSS104E.dll` beside
+   its `Data/*.rxdata` — both PE32, both runnable under wine. So the XP renderer
+   can be held against its reference the same way the RPG2000 renderer is,
+   instead of being judged by eye.
+
+## Decision
+
+Test an XP project in **all three** runtimes it can run in, with one shared
+marker so the three checks assert the same thing.
+
+- **A machine-readable "reached the map" marker and a way to get there without
+  input.** `--rpgxp_new_game` selects New Game once on the title screen, and
+  `RPGXP#start_new_game` logs `[RPGXP-MAP] map=<id> x=<x> y=<y>` — deliberately
+  mirroring `--rpg2k_new_game` / `[RPG2k-MAP]`, down to reading the flag's
+  constant through its own `rescue` (`Module#const_get` is not in this mruby
+  build's gem set).
+- **Native: `scripts/rpgxp_boot_check.bash`.** Boots the built binary on the XP
+  test bed under Xvfb and fails unless `[RPGXP-MAP]` shows up. This is the guard
+  against mruby/CRuby divergence in the XP runtime, and it runs in CI.
+- **Browser: `scripts/rpgxp_browser_check.py`.** Serves the built page, hands it
+  a zip of the XP project through the shell's own loader, presses the decision
+  key, and asserts: the runtime initialises, the project mounts, the game starts
+  and the loader panel goes away, the display is XP-sized, `[RPGXP-MAP]` appears,
+  arrow keys change the frame, the canvas is not blank, and nothing in the page
+  log looks like an mruby exception. Screenshots of every step are written out.
+- **Reference: `scripts/compare-rpgxp-wine.bash`.** Boots the project's own
+  `Game.exe`/`RGSS104E.dll` under wine and our engine on two Xvfb displays at
+  640x480, feeds both the same key script, and writes per-step ref/ours/diff/cmp
+  frames plus a differing-pixel count — the XP counterpart of
+  `compare-nepheshel-wine.bash`. One detail makes this share more than its shape
+  with the RPG2000 script: an editor-made XP project keeps its graphics in the
+  **RTP**, and our engine resolves the RTP through the *wine prefix's* registry
+  (`xp_rtp_path()` reads `Software\Enterbrain\RGSS\RTP\Standard`), so
+  `scripts/rtp_xp_install.bash` into that prefix feeds the reference and the
+  clone the same assets.
+
+### Driving a browser without adding a dependency
+
+The repo has no `package.json` and no npm/pip dependencies — deliberately;
+`src/shell.html` even unpacks zips with `DecompressionStream` rather than bundle
+a zip library. A Playwright/Puppeteer dependency for one smoke test would be the
+largest new dependency in the tree.
+
+So `rpgxp_browser_check.py` talks to headless Chromium over the **DevTools
+protocol using the Python standard library alone**: a ~90-line RFC 6455
+WebSocket client, `Runtime.evaluate` / `Input.dispatchKeyEvent` /
+`Page.captureScreenshot`, and a small non-interlaced PNG reader (zlib plus the
+five filter types) for the blank-frame assertion. The only new dependency is the
+`chromium` binary, added to the dev shell in `flake.nix`.
+
+## Consequences
+
+**Found immediately, in the browser, on the first run** — two bugs that only the
+browser build has, both now fixed here:
+
+- **An XP project loaded in the page rendered on a 320x240 screen.** Native
+  `main()` sizes the display to 640x480 from `--game_dir` *before* creating it,
+  but in the browser no project exists at that point — the page's loader mounts
+  one later — so the display stayed at the 320x240 default (doubled to a 640x480
+  window, which is why the canvas *looked* right). The XP scenes then drew off
+  the edge: the title's command window landed past the bottom and its centred
+  text past the right. `rpg_start_game()` now resizes the display when it
+  detects an XP project, and logs `[RPGXP] display sized to 640x480`, which the
+  check asserts on — the canvas size alone cannot tell the two cases apart.
+- **The loader panel stayed on screen above the running game.** It is dismissed
+  by setting `hidden`, which the page's own `.panel { display: flex }` rule
+  overrode. The check now asserts the *computed* style, not the property.
+
+**Follow-ups this opens:**
+
+- The XP tile layers still render as placeholder colour blocks, so the wine
+  comparison's map steps will differ wholesale until real tileset/autotile
+  blitting lands; the comparison exists to drive exactly that work, as it did for
+  RPG2000 (ADR 0021 / 0016).
+- The browser check drives the reimplemented flow. Running the **script host**
+  (`RGSS_SCRIPT_HOST`, ADR 0017/0023) in the page is the natural next step for it
+  — the frame driver added in ADR 0023 was written for the browser but has never
+  been verified there.
+- The page has no way to pass engine flags, so the browser check reaches the map
+  by pressing keys rather than with `--rpgxp_new_game`. That is the more faithful
+  test (it exercises DOM input), but it means a title-screen regression and an
+  input regression fail the same assertion.

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,11 @@
                 ninja
                 nixfmt
                 pre-commit
+                # Python is used by the repo's tooling scripts (the MV
+                # corescript build, scripts/serve.py and the browser check).
+                # It has been reaching them transitively through other inputs;
+                # name it so a required CI step cannot lose it.
+                python3
                 ruby
                 sccache
                 unar

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,12 @@
                 automake
                 cabal-install
                 ccache
+                # Headless browser for scripts/rpgxp_browser_check.py, which
+                # drives the emscripten page over the DevTools protocol (see
+                # docs/adr/0024-rpgxp-cross-runtime-testing.md). The script
+                # talks CDP with the Python standard library alone, so this
+                # binary is the whole dependency.
+                chromium
                 clang-tools
                 cmake
                 cmake-format

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -20,7 +20,13 @@ module RGSS
         [GAME_DIR, RTP_DIR].each do |d|
           next if d.nil? || d.empty?
           i = self._init_file("#{d}/#{f}", s) unless i
-          [:png, :xyz, :bmp].each do |ext|
+          # RGSS resolves a bare asset name against several image formats, and
+          # the RPG Maker XP RTP genuinely mixes them: its windowskins and
+          # charsets are .png while its title backgrounds are .jpg, so a
+          # png-only search left every XP title screen on the fallback
+          # background (found by scripts/compare-rpgxp-wine.bash). stb decodes
+          # JPEG, so both spellings of the extension are just more candidates.
+          [:png, :jpg, :jpeg, :xyz, :bmp].each do |ext|
             i = self._init_file("#{d}/#{f}.#{ext}", s) unless i
           end
         end

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -201,12 +201,12 @@ mrb_data_type DataType<T>::data_type{
 };
 
 // Generic floating point component getter/setter usable by Color and Tone.
-template <class T, double T::*Field>
+template <class T, double T::* Field>
 mrb_value component_get(mrb_state* M, V self) {
   return mrb_float_value(M, DataType<T>::get(M, self).*Field);
 }
 
-template <class T, double T::*Field, int Lo, int Hi>
+template <class T, double T::* Field, int Lo, int Hi>
 mrb_value component_set(mrb_state* M, V self) {
   mrb_float v;
   mrb_get_args(M, "f", &v);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -201,12 +201,12 @@ mrb_data_type DataType<T>::data_type{
 };
 
 // Generic floating point component getter/setter usable by Color and Tone.
-template <class T, double T::* Field>
+template <class T, double T::*Field>
 mrb_value component_get(mrb_state* M, V self) {
   return mrb_float_value(M, DataType<T>::get(M, self).*Field);
 }
 
-template <class T, double T::* Field, int Lo, int Hi>
+template <class T, double T::*Field, int Lo, int Hi>
 mrb_value component_set(mrb_state* M, V self) {
   mrb_float v;
   mrb_get_args(M, "f", &v);
@@ -1052,12 +1052,33 @@ mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
   mrb_get_args(M, "z|b", &f, &trans);
   int w, h, c;
   stbi__png_transparent_palette = trans;
-  stbi__png_to_bgr_palette = true;
-  std::shared_ptr<uint8_t> img(
-      stbi_load(f, &w, &h, &c, stbi__png_transparent_palette ? 4 : 3),
-      stbi_image_free);
-  if (!img)
+  // Every loader here hands back LVGL's B, G, R(, A) byte order (see load_xyz
+  // and load_png_tolerant, which build it themselves). stb decodes to
+  // R, G, B(, A), so its output is swapped below instead of relying on the
+  // vendored palette-only BGR hack: that covered indexed PNGs (all an RPG2000
+  // project has) and left every truecolour PNG and every JPEG with red and
+  // blue exchanged -- which is what an RPG Maker XP RTP is full of. Caught by
+  // diffing against the genuine RGSS runtime, see
+  // docs/adr/0024-rpgxp-cross-runtime-testing.md.
+  stbi__png_to_bgr_palette = false;
+  // The channel count has to be decided before decoding, because the bitmap's
+  // pixel format must follow what we *ask* stb for. It used to follow the
+  // file's own channel count instead, so an RGBA image loaded without `trans`
+  // allocated a 4-byte-per-pixel bitmap and filled it from 3-channel data --
+  // reading past the decoded buffer and drawing garbage. An XP windowskin
+  // (truecolour + alpha, loaded opaque) hit exactly that.
+  int probe_w = 0, probe_h = 0, probe_c = 0;
+  const bool has_alpha =
+      stbi_info(f, &probe_w, &probe_h, &probe_c) && probe_c == 4;
+  const int req = (trans || has_alpha) ? 4 : 3;
+  // Whether the pixels came from stb (R, G, B order, so they need the swap) or
+  // from one of the fallbacks above, which already emit LVGL's order.
+  bool from_stb = true;
+  std::shared_ptr<uint8_t> img(stbi_load(f, &w, &h, &c, req), stbi_image_free);
+  if (!img) {
+    from_stb = false;
     img.reset(load_xyz(f, &w, &h, &c, trans), stbi_image_free);
+  }
   // stb_image rejects some valid-enough PNGs (e.g. RPG Maker windowskins whose
   // deflate stream references a zero pre-history, giving "bad dist"); retry
   // with the tolerant PNG decoder before giving up.
@@ -1068,21 +1089,30 @@ mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
     // them in NFC (or vice versa); retry with the decomposed form before giving
     // up so accented paths still resolve.
     const std::string nfd_f = una::norm::to_nfd_utf8(f);
-    img.reset(stbi_load(nfd_f.c_str(), &w, &h, &c,
-                        stbi__png_transparent_palette ? 4 : 3),
-              stbi_image_free);
-    if (!img)
+    from_stb = true;
+    img.reset(stbi_load(nfd_f.c_str(), &w, &h, &c, req), stbi_image_free);
+    if (!img) {
+      from_stb = false;
       img.reset(load_xyz(nfd_f.c_str(), &w, &h, &c, trans), stbi_image_free);
+    }
     if (!img)
       img.reset(load_png_tolerant(nfd_f.c_str(), &w, &h, &c, trans),
                 stbi_image_free);
     if (!img)
       return mrb_nil_value();
   }
+  // The fallbacks always produce 4 channels; stb produced exactly what was
+  // requested.
+  const int channels = from_stb ? req : 4;
   Bitmap& bmp = DataType<Bitmap>::alloc_obj(
       M, self, w, h,
-      c == 4 ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_RGB888);
+      channels == 4 ? LV_COLOR_FORMAT_ARGB8888 : LV_COLOR_FORMAT_RGB888);
   std::memcpy(bmp.buffer.data(), img.get(), bmp.buffer.size());
+  if (from_stb) {
+    uint8_t* p = bmp.buffer.data();
+    for (size_t i = 0; i + 3 <= bmp.buffer.size(); i += (size_t)channels)
+      std::swap(p[i], p[i + 2]);
+  }
   return self;
 }
 

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -80,6 +80,11 @@ class RPGXP
     scene = Scene::Map.new(self, state)
     @scenes.last.dispose
     @scenes = [scene]
+    # A machine-readable marker so a headless run (see --rpgxp_new_game,
+    # scripts/rpgxp_boot_check.bash, scripts/rpgxp_browser_check.mjs and
+    # scripts/compare-rpgxp-wine.bash) can assert the map scene was really
+    # reached, not just the title.
+    $stderr.puts "[RPGXP-MAP] map=#{state.map_id} x=#{state.x} y=#{state.y}"
   rescue StandardError => e
     $stderr.puts "[RGSS] Failed to start new game: #{e.message}"
   end

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -257,7 +257,13 @@ class RPGXP
       end
 
       def build_command_window
-        w = 240
+        # RMXP's Scene_Title builds `Window_Command.new(192, commands)` and
+        # places it centred at y = 288; the height falls out of the same
+        # 32-pixel rows plus the skin's 16-pixel border. Matching its width is
+        # what puts our window on the genuine runtime's pixels -- 240 left it
+        # 48 too wide and 24 too far left (measured with
+        # scripts/compare-rpgxp-wine.bash).
+        w = 192
         h = COMMANDS.size * LINE_H + Panel::BORDER * 2
         @command = Panel.new((WIDTH - w) / 2, HEIGHT - h - 64, w, h, @skin)
         @command.z = 200

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -202,13 +202,36 @@ class RPGXP
           @index -= 1
           play_se(@db.system.cursor_se)
           refresh_cursor
-        elsif Input.trigger?(Input::C)
+        elsif Input.trigger?(Input::C) || auto_select?
           play_se(@db.system.decision_se)
           select_command
         end
       end
 
       private
+
+      # `--rpgxp_new_game`: pick New Game once, without input, so a headless run
+      # reaches the map scene instead of sitting on the title screen. One-shot;
+      # a no-op during normal play.
+      #
+      # The constant is read through its own `begin`/`rescue` rather than a
+      # helper taking its name: `Module#const_get` is not something this
+      # runtime's mruby build is known to carry, and the whole point of the flag
+      # is catching mruby/CRuby divergence, not adding more (ADR 0021).
+      def auto_select?
+        return false if @auto_started
+        return false unless auto_new_game?
+        @auto_started = true
+        @index = 0
+        $stderr.puts "[RGSS] --rpgxp_new_game: selecting New Game"
+        true
+      end
+
+      def auto_new_game?
+        RPGXP_NEW_GAME
+      rescue StandardError
+        false
+      end
 
       def build_background
         @bg = Sprite.new

--- a/scripts/compare-rpgxp-wine.bash
+++ b/scripts/compare-rpgxp-wine.bash
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+# Side-by-side graphic comparison between the *genuine* RPG Maker XP runtime
+# (the project's Game.exe driving Enterbrain's RGSS104E.dll, run under wine) and
+# this project's engine, both playing the same XP project -- by default the
+# OpenGame.exe "Testbed/XP" project this repo already downloads, which ships a
+# real Game.exe + RGSS104E.dll beside its Data/*.rxdata.
+#
+# This is the RPG Maker XP counterpart of scripts/compare-nepheshel-wine.bash,
+# and exists for the same reason: the XP renderer is a re-implementation of an
+# engine whose behaviour is only documented by its output. The unit checks and
+# scripts/rpgxp_testbed_check.rb pin the *data* we decode, but they cannot tell
+# us that the title's command window sits in the wrong place or that a map layer
+# is drawn in the wrong order. Booting both runtimes on the same project and
+# diffing the frames can.
+#
+# Both runtimes are driven headlessly, each on its own Xvfb display at XP's
+# native 640x480, fed the same key script, and captured with xwd. For every step
+# the script writes
+#   <out>/rpgxp-ref-<step>.png    the genuine RGSS frame
+#   <out>/rpgxp-ours-<step>.png   our engine's frame
+#   <out>/rpgxp-diff-<step>.png   their (amplified) difference
+#   <out>/rpgxp-cmp-<step>.png    all three side by side
+# and prints the fraction of differing pixels so a regression is visible in a
+# log without opening the images.
+#
+# Requires: wine (with 32-bit support -- Game.exe and RGSS104E.dll are both
+#           PE32), Xvfb, x11-apps (xwd), xdotool, ImageMagick, a window manager
+#           (matchbox), and a built ./build/rpg_maker_clone. On Debian/Ubuntu:
+#     dpkg --add-architecture i386 && apt-get update
+#     apt-get install --no-install-recommends wine wine32:i386 wine64 xvfb \
+#         x11-apps xdotool imagemagick unar matchbox-window-manager \
+#         libgl1:i386 libgl1-mesa-dri:i386
+#
+# NOTES on running the genuine RGSS runtime headlessly (each one cost a
+# debugging round; do not drop them):
+#   * The RTP. An editor-made project stores only its database: its graphics and
+#     audio ("001-Title01", "001-Grassland01", ...) live in the RPG Maker XP RTP.
+#     Install it into this same wine prefix with scripts/rtp_xp_install.bash --
+#     that registers Software\Enterbrain\RGSS\RTP\Standard in the prefix, which
+#     is exactly where *our* engine looks it up too (see xp_rtp_path() in
+#     src/main.cxx), so one install feeds both runtimes. Without it the genuine
+#     runtime pops a "file not found" message box and the comparison is against
+#     an error dialog.
+#   * RGSS draws through DirectDraw/Direct3D, which wine implements over
+#     wined3d -> OpenGL. Under Xvfb there is no GPU, so Mesa's software
+#     rasteriser has to serve (LIBGL_ALWAYS_SOFTWARE=1) and the 32-bit libGL
+#     must be installed, or every frame stays black.
+#   * A window manager must be running or wine never focuses the window and all
+#     synthesised keys are dropped.
+#   * Keys must be *held* (keydown, pause, keyup): a tap is often missed between
+#     two of the runtime's polls.
+#
+# Usage: ./scripts/compare-rpgxp-wine.bash [game_dir] [out_dir]
+
+set -eu -o pipefail
+
+cd "$(dirname "$0")/.."
+
+GAME_DIR="${1:-data/OpenGame.exe/Testbed/XP}"
+OUT_DIR="${2:-ss}"
+ENGINE="${ENGINE:-./build/rpg_maker_clone}"
+
+REF_DISPLAY="${REF_DISPLAY:-:1092}"
+OUR_DISPLAY="${OUR_DISPLAY:-:1093}"
+
+# Fetch the test bed if it is not present yet.
+if [ ! -f "${GAME_DIR}/Game.ini" ] ; then
+    ./scripts/download-opengame-xp.bash
+fi
+
+if [ ! -x "${ENGINE}" ] ; then
+    echo "error: ${ENGINE} not built; run cmake --build build first" >&2
+    exit 1
+fi
+
+if [ ! -f "${GAME_DIR}/Game.exe" ] ; then
+    echo "error: ${GAME_DIR} has no Game.exe to compare against" >&2
+    exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+# 32-bit prefix: both Game.exe and RGSS104E.dll are PE32. Keep it separate from
+# the RPG2000 prefixes so the XP RTP registration cannot be confused with the
+# RPG2000 one.
+export WINEARCH="${WINEARCH:-win32}"
+export WINEPREFIX="${WINEPREFIX:-$HOME/.wine-rpgxp}"
+export WINEDLLOVERRIDES="mscoree,mshtml="
+export WINEDEBUG="${WINEDEBUG:-err+all}"
+# No GPU under Xvfb: wined3d needs a working GL, so use Mesa's rasteriser.
+export LIBGL_ALWAYS_SOFTWARE=1
+
+if [ ! -d "${WINEPREFIX}" ] ; then
+    echo "== bootstrapping ${WINEPREFIX}"
+    wineboot --init >/tmp/rpgxp-wineboot.log 2>&1 || true
+fi
+
+# Our engine resolves the RTP through the same prefix, so report the state once
+# rather than letting both runtimes quietly fall back to placeholders.
+if grep -q 'Enterbrain\\\\RGSS\\\\RTP' "${WINEPREFIX}/system.reg" 2>/dev/null ; then
+    echo "== RTP registered in ${WINEPREFIX}"
+else
+    echo "warning: no RPG Maker XP RTP registered in ${WINEPREFIX};" \
+         "run WINEPREFIX=${WINEPREFIX} ./scripts/rtp_xp_install.bash first," \
+         "or the genuine runtime will only show an error dialog" >&2
+fi
+
+PIDS=()
+cleanup() {
+    for p in "${PIDS[@]:-}" ; do
+        [ -n "${p}" ] && kill "${p}" 2>/dev/null || true
+    done
+}
+trap cleanup EXIT
+
+# The steps to capture: <label> <keys to send before capturing>. Keys are
+# xdotool key names, space separated; "<key>*<n>" repeats one; "-" means "send
+# nothing, just wait". An editor-fresh XP project opens on its title screen with
+# New Game selected, so one decision key reaches the start map and the rest is
+# walking around on it.
+STEPS=(
+    "title -"
+    "title-cursor Down"
+    "newgame Up Return"
+    "walk-down Down*3"
+    "walk-right Right*3"
+    "walk-up Up*3"
+)
+
+start_ref() {
+    Xvfb "${REF_DISPLAY}" -screen 0 640x480x24 >/tmp/rpgxp-ref-xvfb.log 2>&1 &
+    PIDS+=($!)
+    sleep 2
+    DISPLAY="${REF_DISPLAY}" matchbox-window-manager -use_titlebar no \
+        >/tmp/rpgxp-ref-wm.log 2>&1 &
+    PIDS+=($!)
+    sleep 1
+    ( cd "${GAME_DIR}" && DISPLAY="${REF_DISPLAY}" wine Game.exe ) \
+        >/tmp/rpgxp-ref-player.log 2>&1 &
+    PIDS+=($!)
+    # wine's first run in a fresh prefix bootstraps the whole prefix, so give
+    # the reference a generous head start before the first capture.
+    sleep "${REF_BOOT_WAIT:-25}"
+}
+
+start_ours() {
+    Xvfb "${OUR_DISPLAY}" -screen 0 640x480x24 >/tmp/rpgxp-our-xvfb.log 2>&1 &
+    PIDS+=($!)
+    sleep 2
+    DISPLAY="${OUR_DISPLAY}" matchbox-window-manager -use_titlebar no \
+        >/tmp/rpgxp-our-wm.log 2>&1 &
+    PIDS+=($!)
+    sleep 1
+    DISPLAY="${OUR_DISPLAY}" "${ENGINE}" --game_dir "${GAME_DIR}" \
+        --timeout_ms="${OUR_TIMEOUT_MS:-900000}" >/tmp/rpgxp-our-player.log 2>&1 &
+    PIDS+=($!)
+    sleep "${OUR_BOOT_WAIT:-8}"
+}
+
+# Hold each key for ~120ms: both runtimes poll the keyboard once a frame and
+# drop a key that goes down and up between two polls.
+send_keys() {
+    local disp="$1" ; shift
+    for spec in "$@" ; do
+        [ "${spec}" = "-" ] && continue
+        local k="${spec%%\**}" n=1
+        [ "${spec}" != "${k}" ] && n="${spec##*\*}"
+        for _ in $(seq 1 "${n}") ; do
+            DISPLAY="${disp}" xdotool keydown "${k}"
+            sleep 0.12
+            DISPLAY="${disp}" xdotool keyup "${k}"
+            sleep 0.4
+        done
+    done
+}
+
+capture() {
+    local disp="$1" out="$2"
+    DISPLAY="${disp}" xwd -root -silent | convert xwd:- png:"${out}"
+}
+
+start_ref
+start_ours
+
+for step in "${STEPS[@]}" ; do
+    label="${step%% *}"
+    keys="${step#* }"
+    # shellcheck disable=SC2086
+    send_keys "${REF_DISPLAY}" ${keys}
+    # shellcheck disable=SC2086
+    send_keys "${OUR_DISPLAY}" ${keys}
+    sleep "${STEP_SETTLE:-2}"
+
+    ref="${OUT_DIR}/rpgxp-ref-${label}.png"
+    our="${OUT_DIR}/rpgxp-ours-${label}.png"
+    capture "${REF_DISPLAY}" "${ref}"
+    capture "${OUR_DISPLAY}" "${our}"
+
+    # A difference image (amplified so a few-pixel offset is visible) beside the
+    # two frames, and the fraction of pixels that differ at all.
+    convert "${ref}" "${our}" -compose difference -composite -auto-level \
+        "${OUT_DIR}/rpgxp-diff-${label}.png"
+    convert "${ref}" "${our}" "${OUT_DIR}/rpgxp-diff-${label}.png" \
+        +append "${OUT_DIR}/rpgxp-cmp-${label}.png"
+    total=$(identify -format '%[fx:w*h]' "${ref}")
+    differing=$(compare -metric AE -fuzz "${DIFF_FUZZ:-3%}" "${ref}" "${our}" \
+        null: 2>&1 || true)
+    printf '%-16s differing pixels: %s / %s\n' "${label}" "${differing}" "${total}"
+done
+
+echo "frames written to ${OUT_DIR}/rpgxp-{ref,ours,diff,cmp}-*.png"

--- a/scripts/compare-rpgxp-wine.bash
+++ b/scripts/compare-rpgxp-wine.bash
@@ -203,6 +203,17 @@ for step in "${STEPS[@]}" ; do
         "${OUT_DIR}/rpgxp-diff-${label}.png"
     convert "${ref}" "${our}" "${OUT_DIR}/rpgxp-diff-${label}.png" \
         +append "${OUT_DIR}/rpgxp-cmp-${label}.png"
+    # A reference frame with almost no colours means the genuine runtime did not
+    # render at all (no GL, a missing RTP asset behind an error dialog, a window
+    # that never got focus). Say so, or the pixel counts below read as a huge
+    # regression in *our* renderer.
+    ref_colours=$(convert "${ref}" -format %k info:)
+    if [ "${ref_colours}" -le 2 ] ; then
+        echo "warning: the reference frame for '${label}' has ${ref_colours}" \
+             "colour(s) -- the genuine runtime probably rendered nothing;" \
+             "check /tmp/rpgxp-ref-player.log" >&2
+    fi
+
     total=$(identify -format '%[fx:w*h]' "${ref}")
     differing=$(compare -metric AE -fuzz "${DIFF_FUZZ:-3%}" "${ref}" "${our}" \
         null: 2>&1 || true)

--- a/scripts/compare-rpgxp-wine.bash
+++ b/scripts/compare-rpgxp-wine.bash
@@ -46,6 +46,14 @@
 #     wined3d -> OpenGL. Under Xvfb there is no GPU, so Mesa's software
 #     rasteriser has to serve (LIBGL_ALWAYS_SOFTWARE=1) and the 32-bit libGL
 #     must be installed, or every frame stays black.
+#   * Audio must initialise, even though nobody is listening. RGSS opens
+#     DirectSound at boot and, when that fails, stops on a modal "Failed to
+#     initialize DirectX Audio." message box -- which is all the reference draws,
+#     forever. A container with no sound card needs ALSA pointed at a null
+#     device, e.g.
+#         printf 'pcm.!default { type null }\nctl.!default { type null }\n' \
+#             > /etc/asound.conf
+#     (the MIDI warning wine then logs is harmless).
 #   * A window manager must be running or wine never focuses the window and all
 #     synthesised keys are dropped.
 #   * Keys must be *held* (keydown, pause, keyup): a tap is often missed between

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Boot the built engine on a real RPG Maker XP project and confirm it reaches
+# the map, headlessly.
+#
+# Why this exists: the RPG Maker XP runtime is written in Ruby under
+# mruby-rpgxp, and the checks that cover it (scripts/rpgxp_testbed_check.rb,
+# scripts/rpgxp_script_host_check.rb) load those same sources under *CRuby*.
+# That cannot see mruby/CRuby divergence -- exactly the gap that had shipped two
+# RPG2000 bugs (a bare `module_function`, `Enumerable#none?`) with every check
+# green, which is why the LCF side grew scripts/rpg2k_boot_check.bash. This is
+# the same guard for the XP side, and it is the native counterpart of
+# scripts/rpgxp_browser_check.py (the same project, the same marker, in the
+# browser build).
+#
+# The engine aborts on an uncaught mruby exception, so simply running it is most
+# of the test; `--rpgxp_new_game` selects New Game without input and logs the
+# `[RPGXP-MAP]` marker this asserts on, which is what pushes the run past the
+# title screen into the map scene and its renderer.
+#
+# Game directories that are not present are skipped with a message rather than
+# silently passed over -- but if *none* of them is present the check fails,
+# because then it proved nothing.
+#
+# Usage: ./scripts/rpgxp_boot_check.bash [server_num] [game_dir...]
+#   server_num  xvfb-run --server-num to use (default 112; see the reserved
+#               display numbers in .github/workflows/build.yml)
+#   game_dir    defaults to the repo's RPG Maker XP test bed
+
+set -eu -o pipefail
+
+cd "$(dirname "$0")/.."
+
+SERVER_NUM="${1:-112}"
+shift || true
+
+ENGINE="${ENGINE:-./build/rpg_maker_clone}"
+TIMEOUT_MS="${RPGXP_TIMEOUT_MS:-20000}"
+
+GAMES=("$@")
+if [ "${#GAMES[@]}" -eq 0 ] ; then
+    GAMES=(data/OpenGame.exe/Testbed/XP)
+fi
+
+if [ ! -x "${ENGINE}" ] ; then
+    echo "error: ${ENGINE} not built; run cmake --build build first" >&2
+    exit 1
+fi
+
+checked=0
+failed=0
+num="${SERVER_NUM}"
+
+for game in "${GAMES[@]}" ; do
+    if [ ! -f "${game}/Game.ini" ] ; then
+        echo "skip ${game}: no Game.ini (run scripts/download-opengame-xp.bash first)"
+        continue
+    fi
+    checked=$((checked + 1))
+    log="$(mktemp)"
+    echo "== ${game}"
+    # Each game gets its own display number: xvfb-run -a's probe is not atomic
+    # and can steal a display from a concurrent run (see build.yml).
+    if ! xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
+            --game_dir "${game}" --rpgxp_new_game \
+            --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
+        echo "FAILED: ${game}: the engine exited non-zero" >&2
+        failed=$((failed + 1))
+    elif ! grep -q '\[RPGXP-MAP\]' "${log}" ; then
+        echo "FAILED: ${game}: never reached the map scene ([RPGXP-MAP] missing)" >&2
+        failed=$((failed + 1))
+    else
+        grep '\[RPGXP-MAP\]' "${log}"
+    fi
+    # ALSA has no device under CI and floods stderr; keep the rest.
+    grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -40 || true
+    rm -f "${log}"
+    num=$((num + 1))
+done
+
+if [ "${checked}" -eq 0 ] ; then
+    echo "FAILED: none of the requested game directories is present, so nothing" \
+         "was checked: ${GAMES[*]}" >&2
+    exit 1
+fi
+
+if [ "${failed}" -ne 0 ] ; then
+    echo "rpgxp boot check: ${failed} of ${checked} game(s) FAILED" >&2
+    exit 1
+fi
+
+echo "rpgxp boot check: ${checked} game(s) booted into the map"

--- a/scripts/rpgxp_browser_check.py
+++ b/scripts/rpgxp_browser_check.py
@@ -412,6 +412,9 @@ def main():
                     help="report every failed assertion instead of stopping at "
                          "the first one")
     args = ap.parse_args()
+    # Each step is minutes apart; block buffering would hold the whole log back
+    # to the end of the run, which is exactly when a CI log is least useful.
+    sys.stdout.reconfigure(line_buffering=True)
 
     index = os.path.join(args.page, "index.html")
     if not os.path.exists(index):

--- a/scripts/rpgxp_browser_check.py
+++ b/scripts/rpgxp_browser_check.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Boot an RPG Maker XP project in the *browser* build and assert it plays.
+
+Why this exists: the emscripten page (`src/shell.html` + the wasm runtime) is a
+third execution environment beside the native binary and the terminal backends,
+and nothing tested it. Its failures are its own -- the shell's zip loader can
+mount a project the native path never sees, `rpg_start_game()` picks the runtime
+from what landed in the virtual filesystem, keyboard input arrives as DOM events
+instead of SDL ones, and a wasm-only mruby divergence (or a missing exported
+runtime method) shows up as a blank canvas, not a failed build. So this drives
+the real page in a real browser: it serves the built page, hands it a zip of an
+XP project exactly as a user would, presses the same keys a player would, and
+checks what the runtime logged and what the canvas actually shows.
+
+It talks to headless Chromium over the DevTools protocol using nothing but the
+Python standard library (a ~90-line WebSocket client below, and a small PNG
+reader for the frame check), so it adds no npm/pip dependency to a repo that
+deliberately has neither -- the same reason `src/shell.html` unpacks zips with
+`DecompressionStream` instead of a bundled zip library.
+
+What it asserts, in order:
+
+  1. the runtime reaches `onRuntimeInitialized` (the Load button enables),
+  2. the shell's loader unpacks the project zip and mounts it under /game,
+  3. `rpg_start_game()` starts the RPG Maker XP runtime (the loader panel
+     disappears and the canvas is sized to XP's native 640x480),
+  4. pressing the decision key on the title screen starts New Game and the
+     runtime logs `[RPGXP-MAP] map=.. x=.. y=..` (the marker added for exactly
+     this, see --rpgxp_new_game),
+  5. arrow keys move the party leader -- the frame changes between captures,
+  6. the canvas is not a blank/uniform image, and
+  7. nothing in the page log looks like an mruby exception or an abort.
+
+Screenshots of every step are written to the output directory so a human (or a
+CI artifact) can see what the browser drew.
+
+Usage:
+    python3 scripts/rpgxp_browser_check.py [--page wasm-build]
+        [--game data/OpenGame.exe/Testbed/XP] [--out ss] [--chromium PATH]
+
+The browser is found via --chromium, then $CHROMIUM, then the usual names on
+PATH (chromium, chromium-browser, google-chrome). Build the page first:
+    emcmake cmake -S . -B wasm-build -GNinja && cmake --build wasm-build
+"""
+
+import argparse
+import base64
+import http.server
+import json
+import os
+import shutil
+import socket
+import socketserver
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
+import zipfile
+import zlib
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The page's own log element and the markers the runtime writes into it.
+MAP_MARKER = "[RPGXP-MAP]"
+SCREEN_MARKER = "[RPGXP] display sized to 640x480"
+# Anything here in the page log means the run is a failure even if the markers
+# showed up: an mruby exception, an emscripten abort or a failed assertion.
+ERROR_PATTERNS = (
+    "mruby error:",
+    "abort(",
+    "RuntimeError: Aborted",
+    "Uncaught",
+)
+
+
+# --- Minimal WebSocket client (RFC 6455) -----------------------------------
+# Chrome's DevTools endpoint speaks WebSocket and nothing else; the standard
+# library has a server-side handshake helper but no client, so here is the
+# smallest client that can carry CDP: text frames, client-side masking,
+# continuation frames and ping/pong. No permessage-deflate (Chrome only uses it
+# when offered).
+
+
+class WebSocket:
+    def __init__(self, url, timeout=30.0):
+        u = urllib.parse.urlparse(url)
+        self.sock = socket.create_connection((u.hostname, u.port), timeout)
+        self.sock.settimeout(timeout)
+        path = u.path or "/"
+        if u.query:
+            path += "?" + u.query
+        key = base64.b64encode(os.urandom(16)).decode()
+        req = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {u.hostname}:{u.port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n\r\n"
+        )
+        self.sock.sendall(req.encode())
+        self.buf = b""
+        while b"\r\n\r\n" not in self.buf:
+            self._fill()
+        head, self.buf = self.buf.split(b"\r\n\r\n", 1)
+        status = head.split(b"\r\n", 1)[0]
+        if b" 101" not in status:
+            raise RuntimeError(f"WebSocket handshake failed: {status!r}")
+
+    def _fill(self):
+        chunk = self.sock.recv(65536)
+        if not chunk:
+            raise ConnectionError("WebSocket closed by peer")
+        self.buf += chunk
+
+    def _take(self, n):
+        while len(self.buf) < n:
+            self._fill()
+        out, self.buf = self.buf[:n], self.buf[n:]
+        return out
+
+    def send(self, text):
+        payload = text.encode()
+        mask = os.urandom(4)
+        header = bytearray([0x81])  # FIN + text opcode
+        n = len(payload)
+        if n < 126:
+            header.append(0x80 | n)
+        elif n < 65536:
+            header.append(0x80 | 126)
+            header += struct.pack(">H", n)
+        else:
+            header.append(0x80 | 127)
+            header += struct.pack(">Q", n)
+        header += mask
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        self.sock.sendall(bytes(header) + masked)
+
+    def recv(self):
+        """Return the next complete text message (reassembling fragments)."""
+        data = b""
+        while True:
+            b0, b1 = self._take(2)
+            fin, opcode = b0 & 0x80, b0 & 0x0F
+            n = b1 & 0x7F
+            if n == 126:
+                (n,) = struct.unpack(">H", self._take(2))
+            elif n == 127:
+                (n,) = struct.unpack(">Q", self._take(8))
+            payload = self._take(n)
+            if opcode == 0x9:  # ping -> pong, keeping the same payload
+                self.sock.sendall(b"\x8a" + bytes([0x80 | len(payload)]) +
+                                  b"\x00\x00\x00\x00" + payload)
+                continue
+            if opcode == 0x8:
+                raise ConnectionError("WebSocket closed by peer")
+            if opcode == 0xA:  # pong
+                continue
+            data += payload
+            if fin:
+                return data.decode("utf-8", "replace")
+
+    def close(self):
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+class Devtools:
+    """A CDP session on one page target."""
+
+    def __init__(self, ws_url, timeout=60.0):
+        self.ws = WebSocket(ws_url, timeout)
+        self.next_id = 0
+        self.events = []
+
+    def call(self, method, **params):
+        self.next_id += 1
+        msg_id = self.next_id
+        self.ws.send(json.dumps({"id": msg_id, "method": method,
+                                 "params": params}))
+        while True:
+            msg = json.loads(self.ws.recv())
+            if msg.get("id") != msg_id:
+                self.events.append(msg)
+                continue
+            if "error" in msg:
+                raise RuntimeError(f"{method} failed: {msg['error']}")
+            return msg.get("result", {})
+
+    def evaluate(self, expression):
+        res = self.call("Runtime.evaluate", expression=expression,
+                        returnByValue=True, awaitPromise=True)
+        if res.get("exceptionDetails"):
+            raise RuntimeError("page JS raised: " +
+                               json.dumps(res["exceptionDetails"]))
+        return res.get("result", {}).get("value")
+
+    def key(self, code, vkey, text=None, hold=0.12):
+        """Press and release one key, holding it long enough to be polled.
+
+        The runtime samples input once a frame, so a key that goes down and up
+        between two polls is missed -- the same reason the wine comparison
+        scripts hold their keys (see scripts/compare-rpgxp-wine.bash).
+        """
+        down = {"type": "keyDown" if text else "rawKeyDown", "code": code,
+                "key": code if len(code) > 1 else code.lower(),
+                "windowsVirtualKeyCode": vkey, "nativeVirtualKeyCode": vkey}
+        if text:
+            down["text"] = text
+            down["unmodifiedText"] = text
+        self.call("Input.dispatchKeyEvent", **down)
+        time.sleep(hold)
+        self.call("Input.dispatchKeyEvent", type="keyUp", code=code,
+                  key=down["key"], windowsVirtualKeyCode=vkey,
+                  nativeVirtualKeyCode=vkey)
+
+    def screenshot(self, path):
+        res = self.call("Page.captureScreenshot", format="png")
+        png = base64.b64decode(res["data"])
+        with open(path, "wb") as f:
+            f.write(png)
+        return png
+
+    def close(self):
+        self.ws.close()
+
+
+# --- Just enough PNG to tell a rendered frame from a blank one --------------
+
+
+def png_pixels(png):
+    """Decode a non-interlaced 8-bit RGB/RGBA PNG into (width, height, rows).
+
+    Chrome's screenshots are exactly that, and a real decoder would mean a new
+    dependency for one blank-frame assertion.
+    """
+    if png[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("not a PNG")
+    pos, idat, width, height, channels = 8, b"", 0, 0, 4
+    while pos < len(png):
+        (length,) = struct.unpack(">I", png[pos:pos + 4])
+        ctype = png[pos + 4:pos + 8]
+        body = png[pos + 8:pos + 8 + length]
+        pos += 12 + length
+        if ctype == b"IHDR":
+            width, height, depth, colour = struct.unpack(">IIBB", body[:10])
+            if depth != 8 or colour not in (2, 6) or body[12] != 0:
+                raise ValueError(f"unsupported PNG (depth={depth} "
+                                 f"colour={colour} interlace={body[12]})")
+            channels = 3 if colour == 2 else 4
+        elif ctype == b"IDAT":
+            idat += body
+        elif ctype == b"IEND":
+            break
+
+    raw = zlib.decompress(idat)
+    stride = width * channels
+    rows, prev = [], bytearray(stride)
+    for y in range(height):
+        start = y * (stride + 1)
+        filt = raw[start]
+        line = bytearray(raw[start + 1:start + 1 + stride])
+        for x in range(stride):
+            a = line[x - channels] if x >= channels else 0
+            b = prev[x]
+            c = prev[x - channels] if x >= channels else 0
+            if filt == 1:
+                line[x] = (line[x] + a) & 0xFF
+            elif filt == 2:
+                line[x] = (line[x] + b) & 0xFF
+            elif filt == 3:
+                line[x] = (line[x] + (a + b) // 2) & 0xFF
+            elif filt == 4:
+                p = a + b - c
+                pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
+                pred = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[x] = (line[x] + pred) & 0xFF
+        rows.append(bytes(line))
+        prev = line
+    return width, height, rows, channels
+
+
+def frame_stats(png):
+    """(distinct colours, fraction of non-black pixels) for a screenshot."""
+    width, height, rows, channels = png_pixels(png)
+    colours, lit, total = set(), 0, 0
+    # Sampling every 4th pixel is plenty to tell "black screen" from "a game",
+    # and keeps the pure-Python decode cheap on a 640x480+ frame.
+    for y in range(0, height, 4):
+        row = rows[y]
+        for x in range(0, width, 4):
+            off = x * channels
+            px = row[off:off + 3]
+            colours.add(px)
+            total += 1
+            if max(px) > 16:
+                lit += 1
+    return len(colours), (lit / total if total else 0.0)
+
+
+# --- Serving the page and the project zip ----------------------------------
+
+
+def build_zip(game_dir, zip_path):
+    """Pack a project the way a user's download would be: one top-level folder."""
+    root = os.path.basename(os.path.normpath(game_dir))
+    count = 0
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
+        for dirpath, _dirnames, filenames in os.walk(game_dir):
+            for name in filenames:
+                full = os.path.join(dirpath, name)
+                rel = os.path.relpath(full, game_dir)
+                z.write(full, os.path.join(root, rel))
+                count += 1
+    return count
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+
+def serve(directory):
+    handler = lambda *a, **kw: QuietHandler(*a, directory=directory, **kw)
+    socketserver.TCPServer.allow_reuse_address = True
+    httpd = socketserver.ThreadingTCPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, httpd.server_address[1]
+
+
+def find_chromium(explicit):
+    candidates = [explicit, os.environ.get("CHROMIUM"), "chromium",
+                  "chromium-browser", "google-chrome", "google-chrome-stable"]
+    for c in candidates:
+        if not c:
+            continue
+        path = shutil.which(c) or (c if os.path.isfile(c) else None)
+        if path:
+            return path
+    raise SystemExit(
+        "error: no chromium found; pass --chromium PATH or set $CHROMIUM")
+
+
+def launch_browser(chromium, profile_dir):
+    proc = subprocess.Popen(
+        [chromium, "--headless=new", "--remote-debugging-port=0",
+         f"--user-data-dir={profile_dir}", "--no-sandbox",
+         "--disable-dev-shm-usage", "--hide-scrollbars", "--mute-audio",
+         # Headless has no GPU: let ANGLE fall back to SwiftShader so the
+         # canvas still gets a WebGL context (the SDL2 port needs one).
+         "--enable-unsafe-swiftshader", "--use-gl=angle",
+         "--use-angle=swiftshader", "--window-size=800,1000",
+         "--disable-background-timer-throttling", "about:blank"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    port_file = os.path.join(profile_dir, "DevToolsActivePort")
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            err = proc.stderr.read().decode("utf-8", "replace")[-2000:]
+            raise SystemExit(f"error: chromium exited early:\n{err}")
+        if os.path.exists(port_file):
+            content = open(port_file).read().split("\n")
+            if len(content) >= 2 and content[0].strip():
+                return proc, int(content[0].strip())
+        time.sleep(0.2)
+    raise SystemExit("error: chromium never reported a DevTools port")
+
+
+def page_target(port):
+    """The websocket URL of the browser's first page target."""
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/list") as r:
+            for target in json.load(r):
+                if target.get("type") == "page":
+                    return target["webSocketDebuggerUrl"]
+        time.sleep(0.2)
+    raise SystemExit("error: chromium exposed no page target")
+
+
+# --- The check itself -------------------------------------------------------
+
+
+def wait_for(fn, what, timeout, poll=0.5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        value = fn()
+        if value:
+            return value
+        time.sleep(poll)
+    raise AssertionError(f"timed out after {timeout:.0f}s waiting for {what}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--page", default=os.path.join(REPO, "wasm-build"),
+                    help="directory holding the built index.html (default: wasm-build)")
+    ap.add_argument("--game",
+                    default=os.path.join(REPO, "data/OpenGame.exe/Testbed/XP"),
+                    help="RPG Maker XP project directory to load")
+    ap.add_argument("--out", default=os.path.join(REPO, "ss"),
+                    help="directory for the captured frames (default: ss)")
+    ap.add_argument("--chromium", default=None, help="browser binary to drive")
+    ap.add_argument("--keep-going", action="store_true",
+                    help="report every failed assertion instead of stopping at "
+                         "the first one")
+    args = ap.parse_args()
+
+    index = os.path.join(args.page, "index.html")
+    if not os.path.exists(index):
+        raise SystemExit(f"error: {index} not built; run "
+                         "`emcmake cmake -S . -B wasm-build -GNinja && "
+                         "cmake --build wasm-build` first")
+    if not os.path.exists(os.path.join(args.game, "Game.ini")):
+        raise SystemExit(f"error: {args.game} is not an RPG Maker XP project "
+                         "(no Game.ini); run scripts/download-opengame-xp.bash")
+    os.makedirs(args.out, exist_ok=True)
+
+    chromium = find_chromium(args.chromium)
+    failures = []
+
+    def check(ok, message):
+        if ok:
+            print(f"  ok: {message}")
+        else:
+            print(f"  FAILED: {message}", file=sys.stderr)
+            failures.append(message)
+            if not args.keep_going:
+                raise AssertionError(message)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # The page and the project zip are served from one directory so the
+        # loader's fetch is same-origin (no CORS proxy needed), without copying
+        # the build output.
+        docroot = os.path.join(tmp, "www")
+        os.makedirs(docroot)
+        for name in os.listdir(args.page):
+            if name.startswith("index."):
+                os.symlink(os.path.join(os.path.abspath(args.page), name),
+                           os.path.join(docroot, name))
+        zip_path = os.path.join(docroot, "game.zip")
+        files = build_zip(args.game, zip_path)
+        print(f"packed {files} file(s) of {args.game} "
+              f"({os.path.getsize(zip_path) // 1024} KiB)")
+
+        httpd, port = serve(docroot)
+        profile = os.path.join(tmp, "profile")
+        os.makedirs(profile)
+        proc, cdp_port = launch_browser(chromium, profile)
+        dt = None
+        try:
+            dt = Devtools(page_target(cdp_port))
+            dt.call("Page.enable")
+            dt.call("Runtime.enable")
+            dt.call("Page.navigate", url=f"http://127.0.0.1:{port}/index.html")
+
+            print("== runtime")
+            wait_for(lambda: dt.evaluate(
+                "!!document.getElementById('load') && "
+                "!document.getElementById('load').disabled"),
+                "the wasm runtime to initialise", 120)
+            check(True, "runtime initialised (Load enabled)")
+            dt.screenshot(os.path.join(args.out, "rpgxp-browser-1-loader.png"))
+
+            print("== load the project")
+            dt.evaluate(
+                "document.getElementById('url').value = "
+                f"'http://127.0.0.1:{port}/game.zip';"
+                "document.getElementById('nocache').checked = true;"
+                "document.getElementById('load').click(); true")
+            log = wait_for(lambda: page_log(dt) if "Mounted" in page_log(dt)
+                           else None, "the loader to mount the project", 180)
+            mounted = [ln for ln in log.splitlines() if "Mounted" in ln]
+            check(bool(mounted), f"project mounted under /game ({mounted[-1]})")
+            # Computed style, not the `hidden` property: the loader is dismissed
+            # by setting `hidden`, which a `display: flex` rule in the page's own
+            # CSS used to override -- leaving the panel on screen above the
+            # running game while every property-level check passed.
+            check(wait_for(lambda: dt.evaluate(
+                "getComputedStyle(document.getElementById('loader')).display"
+                " === 'none'"),
+                "the loader panel to go away", 60),
+                "rpg_start_game() started the game and dismissed the loader")
+            size = dt.evaluate("(c => c.width + 'x' + c.height)"
+                               "(document.getElementById('canvas'))")
+            check(size == "640x480", f"canvas is XP's native 640x480 (got {size})")
+            # The canvas size alone cannot catch the real hazard here: a 320x240
+            # display doubled to a 640x480 window is the same canvas, but the XP
+            # scenes then draw off its edge. The runtime logs the resolution it
+            # actually took, so assert on that.
+            check(SCREEN_MARKER in page_log(dt),
+                  f"runtime sized its display for XP ({SCREEN_MARKER})")
+            title = dt.screenshot(os.path.join(args.out,
+                                               "rpgxp-browser-2-title.png"))
+            colours, lit = frame_stats(title)
+            check(colours > 4 and lit > 0.01,
+                  f"title screen drew something ({colours} colours, "
+                  f"{lit * 100:.1f}% lit)")
+
+            print("== new game")
+            # Enter is the decision key (src/sdl_input.cxx maps Return/z/space
+            # to RGSS Input::C); the title's first entry is New Game.
+            dt.key("Enter", 13, text="\r")
+            log = wait_for(lambda: page_log(dt) if MAP_MARKER in page_log(dt)
+                           else None, f"the {MAP_MARKER} marker", 60)
+            marker = [ln for ln in log.splitlines() if MAP_MARKER in ln][-1]
+            check(True, f"reached the map scene ({marker.strip()})")
+            before = dt.screenshot(os.path.join(args.out,
+                                                "rpgxp-browser-3-map.png"))
+
+            print("== input")
+            for _ in range(3):
+                dt.key("ArrowDown", 40)
+            time.sleep(1.0)
+            after = dt.screenshot(os.path.join(args.out,
+                                               "rpgxp-browser-4-walk.png"))
+            check(before != after, "arrow keys changed the rendered frame")
+            colours, lit = frame_stats(after)
+            check(colours > 4 and lit > 0.01,
+                  f"map frame is not blank ({colours} colours, "
+                  f"{lit * 100:.1f}% lit)")
+
+            print("== runtime log")
+            log = page_log(dt)
+            bad = [ln for ln in log.splitlines()
+                   if any(p in ln for p in ERROR_PATTERNS)]
+            check(not bad, "no mruby exception or abort in the page log" +
+                  (f" (saw: {bad[0]})" if bad else ""))
+            with open(os.path.join(args.out, "rpgxp-browser.log"), "w") as f:
+                f.write(log)
+            for line in log.splitlines():
+                if "[RGSS]" in line or MAP_MARKER in line:
+                    print(f"  runtime: {line.strip()}")
+        except AssertionError as e:
+            print(f"error: {e}", file=sys.stderr)
+            if dt is not None:
+                try:
+                    dt.screenshot(os.path.join(args.out,
+                                               "rpgxp-browser-failure.png"))
+                    with open(os.path.join(args.out, "rpgxp-browser.log"),
+                              "w") as f:
+                        f.write(page_log(dt))
+                except Exception:  # the page may be gone; the failure stands
+                    pass
+            failures.append(str(e))
+        finally:
+            if dt is not None:
+                dt.close()
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            httpd.shutdown()
+
+    print(f"frames written to {args.out}/rpgxp-browser-*.png")
+    if failures:
+        print(f"rpgxp browser check: {len(failures)} assertion(s) FAILED",
+              file=sys.stderr)
+        return 1
+    print("rpgxp browser check: the XP test bed boots and plays in the browser")
+    return 0
+
+
+def page_log(dt):
+    """The shell page's runtime log (stdout+stderr of the wasm module)."""
+    return dt.evaluate("document.getElementById('log').textContent") or ""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rpgxp_browser_check.py
+++ b/scripts/rpgxp_browser_check.py
@@ -562,6 +562,7 @@ def main():
             except subprocess.TimeoutExpired:
                 proc.kill()
             httpd.shutdown()
+            httpd.server_close()
 
     print(f"frames written to {args.out}/rpgxp-browser-*.png")
     if failures:

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -52,6 +52,14 @@ DEFINE_bool(
     "Save<N>.lsd (see scripts/compare-nepheshel-save-wine.bash) instead of "
     "being driven there by counting key presses");
 DEFINE_bool(
+    rpgxp_new_game,
+    false,
+    "For RPG Maker XP: once the title screen appears, auto-select New Game so "
+    "the game advances into its start map without input, and log the map it "
+    "reaches as [RPGXP-MAP]. Used to smoke-test the RGSS path headlessly (in "
+    "CI, in the browser build and beside the genuine RGSS runtime under wine; "
+    "see scripts/rpgxp_boot_check.bash and scripts/compare-rpgxp-wine.bash)");
+DEFINE_bool(
     mv_new_game,
     false,
     "For RPG Maker MV: once the title screen appears, auto-select New Game so "
@@ -144,6 +152,12 @@ DEFINE_string(profile_trace,
 namespace {
 
 namespace fs = std::filesystem;
+
+// RPG Maker XP's native screen size (RPG2000/MV render at 320x240). Mirrors
+// RPGXP::WIDTH / RPGXP::HEIGHT in mruby-rpgxp/mrblib/lib.rb; the display is
+// sized to it whenever an XP project is the one being booted.
+constexpr int RPGXP_WIDTH = 640;
+constexpr int RPGXP_HEIGHT = 480;
 
 #ifndef __EMSCRIPTEN__
 // mruby's heap is routed through lvgl's memory pool so both are accounted under
@@ -300,6 +314,20 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
   if (fs::exists(game_dir_path / "RPG_RT.ldb")) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "Game.ini")) {
+    // RPG Maker XP renders at 640x480. Native main() sizes the display from
+    // --game_dir before creating it, but in the browser no project exists yet
+    // at that point (the page's loader mounts one here, later), so the display
+    // was created at the 320x240 default and doubled. Resize it now, before the
+    // runtime builds any screen-sized object: with a 320x240 canvas the XP
+    // scenes draw off the edge -- the title's command window lands past the
+    // bottom and its centred text past the right (found by
+    // scripts/rpgxp_browser_check.py; see docs/adr/0024).
+    if (em_display) {
+      lv_display_set_resolution(em_display.get(), RPGXP_WIDTH, RPGXP_HEIGHT);
+      lv_sdl_window_set_zoom(em_display.get(), 1.f);
+      std::fprintf(stderr, "[RPGXP] display sized to %dx%d\n", RPGXP_WIDTH,
+                   RPGXP_HEIGHT);
+    }
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
              fs::exists(game_dir_path / "data" / "System.json")) {
@@ -375,8 +403,8 @@ int main(int argc, char** argv) {
     gflags::GetCommandLineFlagInfo("width", &w_info);
     gflags::GetCommandLineFlagInfo("height", &h_info);
     if (xp_game && w_info.is_default && h_info.is_default) {
-      FLAGS_width = 640;
-      FLAGS_height = 480;
+      FLAGS_width = RPGXP_WIDTH;
+      FLAGS_height = RPGXP_HEIGHT;
     }
   }
 
@@ -489,6 +517,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RPG2K_CONTINUE"),
                 mrb_bool_value(FLAGS_rpg2k_continue));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RPGXP_NEW_GAME"),
+                mrb_bool_value(FLAGS_rpgxp_new_game));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -216,6 +216,18 @@ fs::path xp_rtp_path() {
   return reg2path(ini["Software\\\\Enterbrain\\\\RGSS\\\\RTP"]["\"Standard\""]);
 }
 
+// An RPG Maker XP project: Game.ini plus either a loose Data/System.rxdata or
+// an encrypted archive (a packed release ships no loose Data/ folder). Mirrors
+// the game-class dispatch in main(), and decides both the screen size and which
+// RTP registry key the assets are looked up under.
+bool is_xp_game(const fs::path& game_dir) {
+  const bool xp_data = fs::exists(game_dir / "Data" / "System.rxdata") ||
+                       fs::exists(game_dir / "Game.rgssad") ||
+                       fs::exists(game_dir / "Game.rgss2a") ||
+                       fs::exists(game_dir / "Game.rgss3a");
+  return fs::exists(game_dir / "Game.ini") && xp_data;
+}
+
 // Read the [RPG_RT] FullPackageFlag from RPG_RT.ini in the game directory. When
 // set to 1 the game bundles every asset it needs ("full package") and must not
 // fall back to the RTP, so the runtime disables RTP lookups entirely.
@@ -393,12 +405,7 @@ int main(int argc, char** argv) {
   // Data/System.rxdata or an encrypted archive (Game.rgssad / .rgss2a /
   // .rgss3a), since a packed release ships no loose Data/ folder.
   {
-    const fs::path gd = FLAGS_game_dir;
-    const bool xp_data = fs::exists(gd / "Data" / "System.rxdata") ||
-                         fs::exists(gd / "Game.rgssad") ||
-                         fs::exists(gd / "Game.rgss2a") ||
-                         fs::exists(gd / "Game.rgss3a");
-    const bool xp_game = fs::exists(gd / "Game.ini") && xp_data;
+    const bool xp_game = is_xp_game(FLAGS_game_dir);
     gflags::CommandLineFlagInfo w_info, h_info;
     gflags::GetCommandLineFlagInfo("width", &w_info);
     gflags::GetCommandLineFlagInfo("height", &h_info);
@@ -503,8 +510,20 @@ int main(int argc, char** argv) {
 #else
   // RPG_RT.ini's FullPackageFlag=1 marks a self-contained game; honour it by
   // clearing RTP_DIR so bitmap lookups never reach into the installed RTP.
+  //
+  // The two makers register their RTP under different keys and lay it out
+  // differently, so pick by project type: RPG Maker XP resolves
+  // Software\Enterbrain\RGSS\RTP\Standard (whose tree is rooted at Graphics/
+  // and Audio/, matching the "Graphics/Titles/..." paths XP data stores),
+  // RPG2000 resolves Software\ASCII\RPG2000\RuntimePackagePath. Only the
+  // RPG2000 key was wired up before, so an XP project could never find its RTP
+  // art and every asset fell back to a placeholder (found while bringing up
+  // scripts/compare-rpgxp-wine.bash, which needs both runtimes to draw the same
+  // pictures to be worth anything).
   const std::string rtp_dir =
-      full_package_flag(FLAGS_game_dir) ? std::string() : rtp_path().string();
+      full_package_flag(FLAGS_game_dir)
+          ? std::string()
+          : (is_xp_game(FLAGS_game_dir) ? xp_rtp_path() : rtp_path()).string();
   mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "RTP_DIR"),
                 mrb_str_new_cstr(M, rtp_dir.c_str()));
 #endif

--- a/src/shell.html
+++ b/src/shell.html
@@ -41,6 +41,11 @@
         --error: #ff6b6b;
       }
       * { box-sizing: border-box; }
+      /* The loader panel is dismissed by setting `hidden` on it, but the UA's
+         `[hidden] { display: none }` loses to the `display: flex` rules below,
+         so it stayed on screen above the running game. Author-level and
+         !important so any element hidden here really disappears. */
+      [hidden] { display: none !important; }
       html, body { margin: 0; }
       body {
         min-height: 100vh;


### PR DESCRIPTION
## Summary

Implements comprehensive testing of RPG Maker XP projects across all three execution environments: the native binary, the browser build, and the genuine RGSS runtime under wine. This catches runtime-specific bugs that data-layer checks under CRuby cannot detect.

## Key Changes

- **New `--rpgxp_new_game` flag** (`src/main.cxx`): Auto-selects New Game on the title screen without input, allowing headless testing. Logs `[RPGXP-MAP] map=.. x=.. y=..` when reaching the start map, providing a machine-readable marker for all three test scripts.

- **Native boot smoke test** (`scripts/rpgxp_boot_check.bash`): Boots the built engine on XP projects under Xvfb and asserts the `[RPGXP-MAP]` marker appears, catching mruby/CRuby divergence the CRuby-hosted checks cannot see. Integrated into CI.

- **Browser smoke test** (`scripts/rpgxp_browser_check.py`): Drives the emscripten page in headless Chromium over the DevTools protocol (using only Python stdlib—a ~90-line WebSocket client + PNG decoder). Serves the built page, hands it a project zip through the shell's loader, presses keys, and asserts: runtime initialization, project mounting, game start, XP-native 640x480 display, `[RPGXP-MAP]` appearance, frame changes on input, non-blank canvas, and no exceptions in logs. Screenshots of each step are captured.

- **Wine comparison script** (`scripts/compare-rpgxp-wine.bash`): Boots the project's own `Game.exe`/`RGSS104E.dll` under wine alongside our engine on separate Xvfb displays, feeds both the same key script, and generates per-step ref/ours/diff/cmp frames plus differing-pixel counts—the XP counterpart of the RPG2000 wine comparison.

- **RTP and asset fixes** (`mruby-rgss/src/lib.cxx`, `mruby-rgss/mrblib/lib.rb`): Fixed truecolour PNG/JPEG rendering (stb was outputting RGB but code expected BGR), added `.jpg` to Bitmap search extensions, and corrected XP RTP registry key lookup (`Software\Enterbrain\RGSS\RTP\Standard` instead of RPG2000's key).

- **Browser display sizing** (`src/main.cxx`, `src/shell.html`): XP projects now render at native 640x480 in the browser instead of 320x240 default. Added `is_xp_game()` helper to detect XP projects and size the display accordingly. Fixed CSS to ensure the loader panel properly hides when dismissed.

- **Title screen auto-selection** (`mruby-rpgxp/mrblib/scene.rb`): Implemented `auto_select?` method that triggers New Game selection once when `--rpgxp_new_game` is active, enabling headless progression past the title screen.

- **Documentation and CI integration**: Added ADR 0024 explaining the cross-runtime testing strategy, updated build.yml to run the native boot test (display 112), and added changelog entries.

## Notable Implementation Details

- The browser test adds **no npm/pip dependencies**: it implements RFC 6455 WebSocket handshake and framing in ~90 lines of Python, uses `Runtime.evaluate` / `Input.dispatchKeyEvent` / `Page.captureScreenshot` from the DevTools protocol, and decodes non-interlaced 8-bit PNGs with zlib + the five filter types to check for blank frames.

- The wine comparison shares the same wine prefix's registry with our engine for RTP resolution, so both runtimes access identical assets (`xp_rtp_path()` reads `Software\Enterbrain\RGSS\RTP\Standard`).

- The `[RPGXP-MAP]` marker mirrors the RPG2000 `[RPG2k-MAP]` pattern, deliberately using `begin`/`rescue` to read the flag constant rather than `Module

https://claude.ai/code/session_017Gfz65XQy51ZNZ2Vo1TwVn