### PR TITLE
Play system SFX in the map choice window

### DIFF
--- a/changelog.d/rpg2k-choice-system-sfx.added.md
+++ b/changelog.d/rpg2k-choice-system-sfx.added.md
@@ -1,0 +1,5 @@
+The map choice window now plays the RPG2000 system sounds: the cursor sound
+as the selection moves between options and the decision sound when a choice is
+confirmed. Each resolves a Change System SFX (10670) override held on the game
+state before falling back to the database's own sound, so events that swap the
+system sounds are honoured.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -284,12 +284,16 @@ The work below is roughly ordered by the critical path to a walkable game
   snow (drifting 2×2 flecks), the particle count scaling with strength and the
   positions advancing with the scene's animation frame so the field animates.
   **Set Teleport / Escape Target** (11810 / 11830), **Change Encounter Rate**
-  (11740) and **Change System BGM / SFX** (10660 / 10670) record their payloads
+  (11740) and **Change System BGM** (10660) record their payloads
   on `Game::State` — a per-map teleport-target registry, a single escape target,
-  the encounter step rate and per-slot system music / sound overrides — and
+  the encounter step rate and per-slot system music overrides — and
   round-trip through the save, but nothing consumes them yet (the Teleport /
-  Escape skills, encounter system and battle / menu scenes are not built), so
-  they are modelled for save fidelity like the access flags.
+  Escape skills, encounter system and battle scene are not built), so
+  they are modelled for save fidelity like the access flags. **Change System
+  SFX** (10670) is now consumed on the map: the choice window plays the cursor
+  sound as the selection moves and the decision sound on confirm, resolving a
+  Change System SFX override on `Game::State` before the database default
+  (`Scene::Map#system_se` / `play_system_se`).
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3271,10 +3271,13 @@ class RPG2k
           if Input.trigger?(Input::DOWN) && @choice_index < @message[:count] - 1
             @choice_index += 1
             set_choice_cursor
+            play_system_se(SFX_CURSOR)
           elsif Input.trigger?(Input::UP) && @choice_index > 0
             @choice_index -= 1
             set_choice_cursor
+            play_system_se(SFX_CURSOR)
           elsif Input.trigger?(Input::C)
+            play_system_se(SFX_DECISION)
             index = @choice_index
             close_message
             @interpreter.choose(index)
@@ -3282,6 +3285,45 @@ class RPG2k
         else
           drive_text_message
         end
+      end
+
+      # RPG2000 system-sound slots (Change System SFX / 10670 stores overrides by
+      # these indices; the same order backs the database defaults).
+      SFX_CURSOR = 0
+      SFX_DECISION = 1
+      SFX_CANCEL = 2
+      SFX_BUZZER = 3
+      DB_SE_FIELD = { SFX_CURSOR => :cursor_se, SFX_DECISION => :decision_se,
+                      SFX_CANCEL => :cancel_se, SFX_BUZZER => :buzzer_se }.freeze
+
+      # Play a system sound effect by slot, preferring a Change System SFX
+      # override held on the game state and falling back to the database's own
+      # sound. A no-op when neither names a file (or no audio backend is present).
+      def play_system_se(slot)
+        se = system_se(slot)
+        return unless se
+        Audio.se_play se[:name], se[:volume] || 100, se[:tempo] || 100
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] system SE '#{slot}' playback failed: #{e.message}"
+      end
+
+      # The audio for a system slot as { name:, volume:, tempo: } — the state
+      # override (set by Change System SFX) first, then the database default for
+      # that slot, or nil when neither names a file.
+      def system_se(slot)
+        ov = @state.system_sfx[slot]
+        return ov if ov && ov[:name] && !ov[:name].empty?
+        db_system_se(slot)
+      end
+
+      def db_system_se(slot)
+        field = DB_SE_FIELD[slot]
+        return nil unless field && db.system.respond_to?(field)
+        se = db.system.send(field)
+        name = se && se.respond_to?(:file) ? se.file : nil
+        return nil if name.nil? || name.empty?
+        { name: name, volume: (se.respond_to?(:volume) ? se.volume : 100),
+          tempo: (se.respond_to?(:pitch) ? se.pitch : 100) }
       end
 
       # A plain (non-choice) message: type the text out, and let a button press

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -99,7 +99,10 @@ module RGSS
 
   module Audio
     def self.bgm_play(*); end
-    def self.se_play(*); end
+    # Record se_play calls so system-SFX checks can assert which sound fired.
+    class << self; attr_accessor :se_calls; end
+    def self.se_play(*a); (@se_calls ||= []) << a; end
+    def self.reset_se; @se_calls = []; end
   end
 
   def self.warn_stub(*); end
@@ -152,7 +155,9 @@ def fake_db(common = nil)
     system: OpenStruct.new(system_graphic: '',
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
                            ship_music: OpenStruct.new(file: 'ShipBGM', volume: 80, pitch: 100),
-                           airship_music: OpenStruct.new(file: 'AirBGM', volume: 80, pitch: 100)),
+                           airship_music: OpenStruct.new(file: 'AirBGM', volume: 80, pitch: 100),
+                           cursor_se: OpenStruct.new(file: 'Cursor1', volume: 100, pitch: 100),
+                           decision_se: OpenStruct.new(file: 'Decision1', volume: 100, pitch: 100)),
     # A second chipset (id 2) so Change Map Tileset has somewhere to swap to.
     chipset: { 1 => fake_chipset, 2 => fake_chipset('cs2') },
     # Terms the Show Inn window reads; blank greeting fields exercise the
@@ -1751,6 +1756,43 @@ check 'Tint Screen darkens the view through a black overlay; neutral clears it' 
   st.screen.tint_to(100, 100, 100, 100, 0)
   scene.update
   eq 0, tint.opacity, 'a neutral tint clears the overlay'
+end
+
+check 'the choice window plays the cursor and decision system sounds' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_CHOICES, [], indent: 0),
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'Yes'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'No'),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg && msg[:choice] }
+  ok(msg && msg[:choice], 'choice window opened')
+  RGSS::Audio.reset_se
+  # Moving the cursor plays the database cursor sound.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  eq 'Cursor1', RGSS::Audio.se_calls.last[0], 'cursor move plays the cursor SE'
+  # A Change System SFX override then wins over the database default.
+  st = scene.instance_variable_get(:@state)
+  st.system_sfx[0] = { name: 'MyCursor', volume: 90, tempo: 100 }
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::UP]
+  scene.update
+  RGSS::Input.reset
+  eq 'MyCursor', RGSS::Audio.se_calls.last[0], 'the override wins over the DB default'
+  # Confirming plays the decision sound and closes the window.
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq 'Decision1', RGSS::Audio.se_calls.last[0], 'confirm plays the decision SE'
+  ok !scene.instance_variable_get(:@message), 'the choice window closed on confirm'
 end
 
 check 'Weather draws a particle overlay when active and hides it when clear' do


### PR DESCRIPTION
## Summary
The `Scene::Map` choice window was silent. It now plays the RPG2000 system sounds, and Change System SFX (10670) — previously modelled but never consumed — takes effect for them.

## Changes
- **Scene (`main.rb`)** — the choice window plays the **cursor** sound as the selection moves between options and the **decision** sound on confirm. New `system_se(slot)` / `play_system_se(slot)` helpers resolve a Change System SFX override held on `Game::State` first, then the database's own sound for that slot (`cursor_se` / `decision_se` / …), and no-op when neither names a file.

## Notes
Only the map choice window is wired here (cursor + decision). Cancel/buzzer and the battle/menu SFX slots follow when those flows grow. `\s`-style scope is unchanged.

## Testing
- `scripts/rpg2k_scene_check.rb` — **91 checks pass** (adds a check driving a Show Choices block: cursor move plays the DB cursor SE, a `Game::State` override then wins, and confirm plays the decision SE and closes the window). The `Audio` stub now records `se_play` calls.
- `scripts/rpg2k_logic_check.rb` — **285 checks pass** (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_