### PR TITLE
Add critical hits to RPG2000 basic battle attacks

### DIFF
--- a/changelog.d/rpg2k-battle-criticals.added.md
+++ b/changelog.d/rpg2k-battle-criticals.added.md
@@ -1,0 +1,13 @@
+- RPG Maker 2000: **basic attacks can now land critical hits** (3x damage). Each
+  battler carries a 1-in-N critical chance read from the database — an actor's
+  `has_critical_rate` / `critical_rate` (default 1/30), an enemy's `critical_hit`
+  / `critical_hit_chance` — surfaced as `Game::Actor#crit_denominator` /
+  `Game::Enemy#crit_denominator` and snapshotted onto the `Combatant`. When the
+  fight has criticals enabled (an opt-in `Game::Battle` flag the live game turns
+  on; off by default so seeded / headless fights stay reproducible), `deal_attack`
+  rolls the attacker's chance and triples the damage on a hit, tagging the log
+  entry `critical: true`. No critical lands on a same-side hit (a confused ally
+  striking an ally), matching EasyRPG. Covered by new `scripts/rpg2k_logic_check.rb`
+  checks (a 1-in-1 attacker always crits for 3x with criticals on; no crit when
+  the flag is off or the attacker's denominator is 0). Elemental attributes and
+  `prevent_critical` gear remain follow-ups.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -361,9 +361,11 @@ The work below is roughly ordered by the critical path to a walkable game
   member of its own side. Basic attacks **and attack skills** apply RPG2000's
   **damage variance** (a `var` of 4 for attacks, each skill's own `variance` for
   skills, spread via `Algo::VarianceAdjustEffect`), enabled for the live game and
-  off for seeded / headless fights. Still to come: enemy-cast infliction,
-  criticals / attributes, all-target skill/item scopes, the per-terrain backdrop
-  and the RPG2000 Game Over graphic.
+  off for seeded / headless fights. A basic attack can land a **3x critical hit**
+  at the attacker's database 1-in-N chance (actor `critical_rate`, enemy
+  `critical_hit_chance`); no crit on a same-side hit. Still to come: enemy-cast
+  infliction, elemental attributes, `prevent_critical` gear, all-target skill/item
+  scopes, the per-terrain backdrop and the RPG2000 Game Over graphic.
   The remaining event commands (tile substitution and other native-render
   effects) are TODO. **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1178,6 +1178,15 @@ module Game
       @hp
     end
 
+    # The actor's 1-in-N critical-hit chance from the database (0 = never), gated
+    # by `has_critical_rate` with `critical_rate` as the denominator (default 30,
+    # i.e. 1/30). A bare fixture without the fields never crits.
+    def crit_denominator
+      return 0 unless @db_row.respond_to?(:has_critical_rate) && @db_row.has_critical_rate
+      n = @db_row.respond_to?(:critical_rate) ? @db_row.critical_rate : 0
+      n && n > 0 ? n : 0
+    end
+
     # Set HP to an absolute value, clamped to [0, max_hp], keeping the death
     # state (戦闘不能) in sync: 0 knocks the actor out, a positive value revives a
     # downed one. Unlike change_hp this is not blocked while dead -- it is the
@@ -2721,7 +2730,18 @@ module Game
       @hidden = hidden ? true : false
       @hp = @max_hp
       @sp = @max_sp
+      # 1-in-N critical-hit chance (0 = never), from the enemy's critical_hit
+      # flag + critical_hit_chance denominator.
+      @crit_denom = if row && row.respond_to?(:critical_hit) && row.critical_hit
+                      n = row.respond_to?(:critical_hit_chance) ? row.critical_hit_chance : 0
+                      n && n > 0 ? n : 0
+                    else
+                      0
+                    end
     end
+
+    attr_reader :crit_denom
+    def crit_denominator; @crit_denom; end
 
     def dead?; @hp <= 0; end
   end
@@ -2773,7 +2793,7 @@ module Game
     # stat the skill formulas read as `int`.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
-                           :actor, :states, :state_turns) do
+                           :actor, :states, :state_turns, :crit_denom) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
@@ -2788,16 +2808,22 @@ module Game
     # starts clean.
     def self.actor_states(a); a.respond_to?(:states) ? (a.states || []).dup : []; end
 
+    # A battler's critical-hit denominator (0 when it never crits, or the source
+    # lacks the field).
+    def self.crit_denom_of(b); b.respond_to?(:crit_denominator) ? b.crit_denominator : 0; end
+
     def self.from_actor(a)
       Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
-                    nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a))
+                    nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
+                    nil, crit_denom_of(a))
     end
 
     # Enemies have no source actor (that field stays nil), so the post-battle
     # write-back skips them; they carry no status set into this simple sim.
     def self.from_enemy(e)
       Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
-                    nil, false, e.sp, e.max_sp, e.spi, nil, nil, [])
+                    nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
+                    crit_denom_of(e))
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -2817,14 +2843,18 @@ module Game
     # battler's afflicted states take effect each turn (slip damage, skip if it
     # cannot act); omitted, states are inert as before.
     # `variance`, when true, applies RPG2000's +/- spread to each basic attack's
-    # damage (a `var` of 4, per EasyRPG's Algo::VarianceAdjustEffect). Off by
-    # default so a seeded fight is exactly reproducible; the live game turns it on.
-    def initialize(allies, enemies, rng = nil, states = nil, variance = false)
+    # damage (a `var` of 4, per EasyRPG's Algo::VarianceAdjustEffect). `criticals`,
+    # when true, lets a basic attack land a 3x critical at the attacker's 1-in-N
+    # `crit_denom` chance. Both off by default so a seeded fight is exactly
+    # reproducible; the live game turns them on.
+    def initialize(allies, enemies, rng = nil, states = nil, variance = false,
+                   criticals = false)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
       @states = states
       @variance = variance
+      @criticals = criticals
       @rounds = 0
       @result = nil
       @log = []      # one entry per landed attack, in order (see #strike)
@@ -3048,14 +3078,27 @@ module Game
     end
 
     # `b` lands a basic attack on `target`: the base damage (optionally spread by
-    # variance), halved (min 1) if the target defends.
+    # variance), tripled on a critical hit, then halved (min 1) if the target
+    # defends. The crit note rides on the log entry.
     def deal_attack(b, target)
       dmg = Battle.attack_damage(b.atk, target.def)
       dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance
+      # No critical on a same-side hit (e.g. a confused ally striking an ally),
+      # matching EasyRPG.
+      crit = critical?(b) && side_of(b) != side_of(target)
+      dmg *= 3 if crit
       dmg = [dmg / 2, 1].max if target.defending
       target.hp -= dmg
-      { attacker: b.name, target: target.name, damage: dmg,
+      { attacker: b.name, target: target.name, damage: dmg, critical: crit,
         target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead? }
+    end
+
+    # Whether `b`'s attack criticals: enabled for the fight, the attacker has a
+    # non-zero 1-in-N `crit_denom`, and a 0..N-1 roll lands on 0.
+    def critical?(b)
+      return false unless @criticals
+      denom = b.crit_denom
+      denom && denom > 0 && @rng.random(denom) == 0
     end
 
     # Spread `base` by a `var` (0-10) amount: an adjustment of `var*base/10` (min

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2099,7 +2099,7 @@ class RPG2k
         situations = db.respond_to?(:situation) ? db.situation : nil
         @battle_ui = { phase: :command, req: req, troop: troop,
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
-                                                situations, true),
+                                                situations, true, true),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3706,6 +3706,39 @@ check 'without variance a seeded fight deals exactly the base damage' do
   eq 20, bat.step_action[:damage]                    # exact base, unaffected
 end
 
+check 'battle: a critical hit triples the damage when the fight rolls one' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_denom = 1                                # 1-in-1 -> always crits
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  # 6-arg: variance off, criticals on.
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
+  bat.begin_round
+  e = bat.step_action
+  eq 60, e[:damage]                                  # base 20 * 3
+  eq true, e[:critical]
+end
+
+check 'battle: no critical when the fight has criticals off' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_denom = 1                                # would always crit, but...
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))  # 3-arg: crit off
+  bat.begin_round
+  e = bat.step_action
+  eq 20, e[:damage]
+  ok !e[:critical]
+end
+
+check 'battle: a zero crit_denom never criticals even with criticals on' do
+  hero = combatant('Hero', 40, 0, 20, 100)           # crit_denom nil -> never
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
+  bat.begin_round
+  e = bat.step_action
+  eq 20, e[:damage]
+  ok !e[:critical]
+end
+
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
                              mrate: 40, variance: 4) }


### PR DESCRIPTION
Basic attacks can now land a **3x critical hit** at the attacker's database chance (after damage variance in #270).

## Behavior

- **Per-battler chance from the DB.** `Game::Actor#crit_denominator` reads `has_critical_rate` + `critical_rate` (default 1/30); `Game::Enemy#crit_denominator` reads `critical_hit` + `critical_hit_chance`. The 1-in-N denominator is snapshotted onto the `Combatant` (`crit_denom`) via `from_actor` / `from_enemy`, `respond_to?`-guarded so bare fixtures never crit.
- **Opt-in per fight.** `Game::Battle` gains a `criticals` flag; `deal_attack` rolls `@rng.random(crit_denom) == 0` and triples the damage, tagging the log entry `critical: true`. Off by default so seeded / headless fights stay reproducible; `Scene::Map` turns it on for the live game.
- **No crit on a same-side hit** (a confused ally striking an ally), matching EasyRPG.

## Grounding

Actor/enemy crit fields and the 1/N semantics from the LDB schema; the 3x multiplier and same-type exclusion from EasyRPG's `Algo::CalcNormalAttackEffect` / `CalcCriticalHitChance`.

## Tests

New `scripts/rpg2k_logic_check.rb` checks: a 1-in-1 attacker always crits for 3× with criticals on; no crit when the flag is off; no crit when the attacker's denominator is 0. **288 logic + 90 scene + 36 render checks pass; save-load OK.**

## Follow-up

Elemental attributes, `prevent_critical` gear (armor that blocks crits), and skill/item criticals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_