### PR TITLE
Supply the RGSS2 / RGSS3 built-ins VX / VX Ace scripts call

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@
   yet, and a boot without the host says so rather than opening a blank window.
   See
   [`docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md`](docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md)
+- The **RGSS2/RGSS3 built-ins** those scripts call on their way to a first frame
+  are in place: keys named as symbols (`Input.trigger?(:C)`, which VX and VX Ace
+  use exclusively), `Graphics.width`/`height`/`wait`/`fadeout`, the `Window`
+  open/close and padding surface with VX's `Window.new(x, y, w, h)` shape, the
+  `RPG::BGM`/`BGS`/`ME`/`SE` records **playing themselves**
+  (`$game_system.battle_bgm.play`), and RGSS3's `rgss_main` wrapper. What is
+  still missing before a VX game *draws* — the nine-sheet VX tilemap, viewport
+  tone/flash and scene transitions — is measured against the stock VX Ace script
+  set in
+  [`docs/rpgvx-rgss-api-gap.md`](docs/rpgvx-rgss-api-gap.md)
 - Have a VX / VX Ace project? `ruby scripts/rpgvx_testbed_check.rb path/to/Game`
   loads its whole database and reports any field the schema is missing — the
   editors are commercial and no open-source test bed exists, so that check is

--- a/changelog.d/rpgvx-rgss2-runtime.added.md
+++ b/changelog.d/rpgvx-rgss2-runtime.added.md
@@ -1,0 +1,35 @@
+- The **RGSS2 / RGSS3 built-ins** a VX / VX Ace project's own scripts call, so a
+  bundle can actually run on the script host (a VX game's engine *is* its script
+  bundle). Measured against the stock VX Ace script set — 109 sections, ~19.9k
+  lines — and tracked in
+  [`docs/rpgvx-rgss-api-gap.md`](docs/rpgvx-rgss-api-gap.md), the new
+  counterpart to the XP gap document:
+  - **`Input` symbol keys.** RGSS2/RGSS3 name keys as symbols
+    (`Input.trigger?(:C)`) and the stock scripts use *nothing else*, where XP
+    used integer constants. `RGSS::Input` now accepts either spelling through
+    one key table (`SYMBOL_KEYS`), leaving the XP/RPG2000 callers and the C++
+    input bridge untouched; an unrecognised key reads as unpressed and is
+    reported once instead of raising out of the game loop.
+  - **`Graphics.width`/`height`** (~82 uses: VX's camera and every window layout
+    are computed from them) via a new `resize_screen`, which each maker's boot
+    shell calls with its own resolution — the VX shell declares 544×416, the
+    size `src/main.cxx` opens the window at. Plus RGSS2's `wait`, `fadeout`,
+    `fadein` and `brightness`: the waits run **real frames**, so a scene that
+    holds for a fade takes the right time (`transition` now consumes its frames
+    too, instead of returning instantly).
+  - **`RPG::BGM`/`BGS`/`ME`/`SE` play themselves.** In RGSS2/RGSS3 the audio
+    records carry behaviour (`$game_system.battle_bgm.play`, `@map_bgm.replay`,
+    `RPG::BGM.fade(1000)`, `RPG::SE.stop`): `#play`/`#replay`/`#stop`/`#fade`
+    plus the class-side `last`/`stop`/`fade`, routed to `RGSS::Audio`, including
+    RGSS's "an empty name stops the channel" rule and the `last` slot a save
+    restores from.
+  - **`Window` RGSS2/RGSS3 surface** — `openness` with `open?`/`close?` (the
+    open/close animation the scripts drive themselves), `padding` /
+    `padding_bottom`, `arrows_visible`, `tone`, and the VX-shaped constructor
+    `Window.new(x, y, width, height)` alongside XP's optional-viewport form.
+  - **RGSS3 Kernel methods** — `rgss_main` (the entire `Main` section of every
+    VX Ace project), `rgss_stop`, `msgbox` / `msgbox_p` — and `Audio.setup_midi`.
+  `scripts/rpgvx_testbed_check.rb` now boots each generated project through a
+  `rgss_main { … }` Main that loads the database, plays its title BGM and waits
+  frames, so the path is exercised end to end; the rest is covered by new
+  `mruby-rgss/test` and `mruby-rpgvx/test` cases.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -708,14 +708,31 @@ screen (544×416). Full rationale:
   boots with no loose files. Same remaining gap as XP: graphics/audio are still
   read from loose files only.
 - 🚧 **Run the bundled scripts** — a VX/VX Ace game's engine is its script
-  bundle, so this is *the* path rather than a later refinement. The host already
-  runs (`RPGXP::ScriptHost`, ADR 0017) with the per-frame Fiber driver now
-  shared by both shells (`ScriptHost.build_driver`, ADR 0023); what is missing is
-  the RGSS2/RGSS3 halves of the `mruby-rgss` class library the stock scripts call
-  (the RGSS1 gap is tracked in
-  [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md); RGSS2 added
-  `Graphics.wait/fadeout`, `Window#openness`, `Cache`, and RGSS3 the `rgss_main`
-  wrapper and `Bitmap#draw_text` sizing the VX windows rely on).
+  bundle, so this is *the* path rather than a later refinement. The host runs
+  (`RPGXP::ScriptHost`, ADR 0017) with the per-frame Fiber driver shared by both
+  shells (`ScriptHost.build_driver`, ADR 0023), and the RGSS2/RGSS3 class
+  library is now measured, not guessed: the gap is tracked in
+  [`docs/rpgvx-rgss-api-gap.md`](rpgvx-rgss-api-gap.md), counted across the
+  stock VX Ace script set (109 sections, ~19.9k lines).
+  - ✅ The built-ins a bundle needs before it can draw anything: **symbol input
+    keys** (`Input.trigger?(:C)` — VX/VX Ace use nothing else, and the same key
+    table now serves all three makers), **`Graphics.width`/`height`** (declared
+    per maker via `resize_screen`; ~82 uses), **`Graphics.wait`/`fadeout`/
+    `fadein`/`brightness`**, **`Audio.setup_midi`**, the **`Window` RGSS2/RGSS3
+    surface** (`openness` + `open?`/`close?`, `padding`/`padding_bottom`,
+    `arrows_visible`, `tone`, and the `Window.new(x, y, w, h)` constructor),
+    **`RPG::BGM`/`BGS`/`ME`/`SE` playing themselves** (`#play`/`#replay`/
+    `#fade`, the class-side `last`/`stop`/`fade`), and the RGSS3 Kernel methods
+    **`rgss_main`** (the whole `Main` section of every VX Ace project),
+    `rgss_stop`, `msgbox`/`msgbox_p`.
+  - Remaining, all native `mruby-rgss` work and ordered by what blocks a
+    playable game: the **VX/VX Ace `Tilemap`** (nine `bitmaps` sheets + the
+    `flags` table instead of XP's single tileset/autotiles — without it a game
+    boots but no map draws), **`Viewport#tone`/`#color`/`#flash`** (VX does
+    every tint / flash / fade through the viewport, so all screen effects are
+    inert — the same native tone work the RPG2000 tint needs),
+    **`Graphics.freeze`/`transition`/`snap_to_bitmap`** (scene transitions),
+    the window open/close animation, and `Bitmap#blur`/`#radial_blur`.
 - **Built-in title/map flow** — the reimplemented scene stack the RPG2000 and XP
   runtimes have (title → New Game → walkable map). Not written yet; a boot
   without the script host reports that instead of showing a blank window.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -1,0 +1,151 @@
+# RGSS2 / RGSS3 API gap for VX and VX Ace
+
+The [RGSS script host](adr/0017-rpgxp-rgss-script-host.md) runs a project's own
+script bundle unmodified. A VX / VX Ace game needs that more than an XP one
+does: its **entire engine** is the bundle (`rgss_main { SceneManager.run }` is
+the whole `Main` section), so there is no half-way point where a reimplemented
+title/map flow gets a real game running. What the scripts assume is the RGSS2 /
+RGSS3 class library, normally `RGSS200J.dll` / `RGSS300.dll`; this project
+supplies it as `mruby-rgss` (plus the RGSS2/RGSS3-only pieces in
+`mruby-rpgvx/mrblib/rgss2_runtime.rb`).
+
+This document is the VX/VX Ace counterpart of
+[`rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md): **what the stock scripts call**
+versus **what we provide**.
+
+## How the "needed" column was measured
+
+Against the **stock VX Ace script set** — 109 sections, ~19.9k lines, the same
+scripts every new VX Ace project ships with (the `rgss3_default_scripts`
+distribution of them; nothing is vendored into this repo). Counting
+method/`.new`/constant usage across the bundle gives the frequencies below.
+
+Two caveats, the same ones the XP document carries:
+
+- The counts are name-based, so a name that several classes share (`tone`,
+  `opacity`, `ox`, `padding`) is an upper bound rather than a per-class figure.
+  They are meant to rank the work, not to be exact.
+- `Main` is not part of the published set, so `rgss_main` shows up zero times
+  here despite being in every real project. It is implemented regardless.
+
+The measurement is also the reason this list is worth trusting over a reading of
+the reference manual: it says what a game actually touches on the way to its
+first frame, not what RGSS3 defines.
+
+## Provided ✅
+
+- **Value types** — `Table`, `Color`, `Tone`, `Rect` (native, with RGSS
+  `Marshal`), shared with the XP path.
+- **Data classes** — the whole RGSS2/RGSS3 `RPG::*` schema
+  (`mruby-rpgvx/mrblib/rgss2_data.rb`, ADR 0024), so `load_data` returns typed
+  records.
+- **`Bitmap`** — `new` (~13), `draw_text` (~55), `fill_rect` (~14), `text_size`
+  (~8), `gradient_fill_rect` (~5), `blt` (~3), `clear_rect` (~2), `get_pixel`
+  (~2), `stretch_blt`, `hue_change`, `clear`, `font`, `dispose`. _Complete for
+  the stock scripts bar the two blurs below._
+- **`Font`** — instance attributes plus the class defaults the scripts read
+  (`default_size`, `default_bold`, `default_italic`).
+- **`Input`** — **RGSS2/RGSS3 spell keys as symbols** (`Input.trigger?(:C)`), and
+  the stock scripts use nothing else: `:C` ×11, `:UP`/`:DOWN` ×7, `:B`/`:LEFT`/
+  `:RIGHT` ×6, `:A` ×5, `:L`/`:R` ×4, `:CTRL` ×2, `:F9` ×1 — zero uses of XP's
+  integer constants. `Input.press?`/`trigger?` (~30)/`repeat?` (~21)/`update`/
+  `dir4` now take either spelling (`RGSS::Input::SYMBOL_KEYS`), so the same key
+  table serves all three makers and the C++ input bridge is untouched.
+- **`Graphics`** — `width` (~50) / `height` (~32) (declared by each maker's boot
+  shell through `resize_screen`; VX is 544×416), `wait` (~2), `fadeout` (~3),
+  `fadein`, `brightness` (~3), `frame_count`, `frame_rate`, `update`. The waits
+  run real frames, so a scene that holds for a fade takes the right time.
+- **`Audio`** — `bgm`/`bgs`/`me`/`se` `play`/`stop`/`fade` (+ `bgm_pos`/
+  `bgs_pos`) resolved through `GAME_DIR`/`RTP_DIR`, and `setup_midi`.
+- **`RPG::BGM`/`BGS`/`ME`/`SE` playback** — the records play *themselves* in
+  RGSS2/RGSS3 (`$game_system.battle_bgm.play`): `#play` (~19), `#fade` (~6),
+  `#replay` (~3) and the class-side `last` / `stop` / `fade` (~20 together),
+  including the "empty name stops the channel" rule and the `last` slot a save
+  restores from (`mruby-rpgvx/mrblib/rgss2_runtime.rb`).
+- **`Window`** — the RGSS1 surface (`contents` ~84, `active` ~19, `cursor_rect`
+  ~9, `contents_opacity`, `windowskin`, `back_opacity`, `pause`, `opacity`,
+  geometry, `update`) plus the RGSS2/RGSS3 additions the scripts drive:
+  `openness` (~16) with `open?`/`close?` (~15), `padding` (~6) /
+  `padding_bottom` (~2), `arrows_visible`, `tone`, and the **VX-shaped
+  constructor** `Window.new(x, y, width, height)` alongside XP's optional
+  viewport.
+- **`Viewport`** — `new` (~9), `ox`/`oy`, `rect`, `z`, `visible`, `update`,
+  `dispose`.
+- **`Sprite`/`Plane`** — the extended properties the scripts set are stored and
+  (per the XP document) largely rendered: `opacity` (~41), `ox`/`oy` (~64),
+  `blend_type` (~19), `zoom_x`/`zoom_y` (~24), `angle` (~10), `mirror` (~9),
+  `src_rect` (~8), `bush_depth` (~5), `flash`.
+- **Kernel** — `load_data` (~28) / `save_data` from the script host, `rand`
+  (~37) from the core, and the RGSS2/RGSS3-only `rgss_main`, `rgss_stop`,
+  `msgbox` (~2) and `msgbox_p`.
+
+## Gaps ❌ (ordered by how much they block a playable VX game)
+
+### 1. `Tilemap` is XP-shaped — the map cannot draw
+
+`Spriteset_Map` builds the map with the RGSS2/RGSS3 tilemap:
+
+```ruby
+@tilemap = Tilemap.new(@viewport1)
+@tilemap.map_data  = $game_map.data
+@tilemap.bitmaps[i] = Cache.tileset(name)   # nine sheets: A1-A5, B-E
+@tilemap.flags     = @tileset.flags         # the 8192-entry Table
+```
+
+`mruby-rgss`'s `Tilemap` is the XP one: `tileset=` (one sheet), `autotiles`
+(seven) and `priorities`. VX/VX Ace need the **nine-sheet `bitmaps` array**, the
+**`flags` table** (passage/priority/counter/terrain bits packed per tile id) and
+the different **autotile geometry** (A1 water/A2 ground/A3 buildings/A4 walls
+and the direct B–E pages). Native work in `mruby-rgss/src/lib.cxx`, and the
+single biggest item here: without it a VX game boots but shows no map.
+
+### 2. `Viewport#tone` / `#color` / `#flash` — no screen tint, flash or fade
+
+VX/VX Ace do every screen effect through the viewport, not a sprite overlay:
+
+```ruby
+@viewport1.tone.set($game_map.screen.tone)              # tint
+@viewport2.color.set($game_map.screen.flash_color)      # flash
+@viewport3.color.set(0, 0, 0, 255 - $game_map.screen.brightness)  # fade
+viewport.flash(timing.flash_color, timing.flash_duration)         # animations
+```
+
+Our `Viewport` has none of these (`ox`/`oy`/`rect`/`z`/`visible` only), so tint,
+flash, fade-in/out and animation flashes are all inert. This is the same native
+tone work the RPG2000 side is waiting on (`docs/TODO.md`), and doing it once on
+`Viewport` would serve both. `Graphics.brightness` is tracked but not drawn for
+exactly this reason.
+
+### 3. `Graphics.freeze` / `transition` / `snap_to_bitmap` — no scene transitions
+
+`Scene_Base#perform_transition` freezes the frame and transitions into the next
+scene (~5 uses each), and `Scene_Title` snapshots the screen with
+`Graphics.snap_to_bitmap`. `freeze`/`transition` are stubs that now consume the
+right number of frames (so timing is right) but draw nothing; `snap_to_bitmap`
+and `play_movie` do not exist. Needs a native frame grab.
+
+### 4. Window open/close is not animated, and `Window#tone` is not applied
+
+`openness` is stored and the scripts' open/close loops terminate correctly, but
+the native window is drawn full-size throughout, so a menu pops rather than
+unrolls. `Window#tone` (the windowskin colour tint) is likewise stored only.
+
+### 5. `Bitmap#blur` / `#radial_blur`
+
+One use each (title background, animation effects). Cosmetic.
+
+### 6. Reading graphics/audio out of the encrypted archive
+
+Shared with the XP gap: `RPGVX::RGSSData` resolves `Data/*` through
+`Game.rgss2a`/`Game.rgss3a`, but the native `Bitmap`/`Audio` loaders only read
+loose files, so a packed release boots with no graphics. `Cache.*` (a script
+class) calls `Bitmap.new("Graphics/...")` for every asset, so this is what a
+packed VX Ace game needs next after the tilemap.
+
+## What this means for turning the host on
+
+For VX / VX Ace the script host is not an alternative to a built-in flow — it is
+the only route to a real game. With this round in place a bundle **runs**: it
+loads its database, plays its music, reads input, drives frames and lays out its
+windows. What it cannot yet do is **draw the map or any screen effect**, which
+is items 1–3, all native `mruby-rgss` work.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -268,6 +268,89 @@ module RGSS
     def stretch
       @stretch.nil? ? true : @stretch
     end
+
+    # ---- RGSS2 / RGSS3 (VX, VX Ace) additions ------------------------------
+    #
+    # The VX and VX Ace window model adds an open/close animation and a content
+    # padding the scripts drive themselves: `Window_Base#open`/`#close` step
+    # `openness` by 48 a frame and wait on `open?`/`close?`, and every VX window
+    # lays its contents out relative to `padding`. Measured in the stock VX Ace
+    # scripts: openness x16, open?/close? x15, padding x8, arrows_visible x1 (see
+    # docs/rpgvx-rgss-api-gap.md).
+    #
+    # These are plain state here: the native window is drawn at full size
+    # whatever `openness` says, so the open/close *animation* is not shown yet —
+    # but because the scripts only ever wait on the value they set, a window
+    # still opens, closes and lays out correctly.
+
+    # 0 (fully closed) .. 255 (fully open).
+    def openness
+      @openness.nil? ? 255 : @openness
+    end
+
+    def openness=(value)
+      value = 0 if value < 0
+      value = 255 if value > 255
+      @openness = value
+    end
+
+    def open?
+      openness == 255
+    end
+
+    def close?
+      openness.zero?
+    end
+
+    # The margin between the window frame and its contents. RGSS3's default is
+    # 12; the native drawing still insets contents by its own border, so this is
+    # the value the scripts compute layouts with.
+    def padding
+      @padding.nil? ? 12 : @padding
+    end
+
+    attr_writer :padding
+
+    def padding_bottom
+      @padding_bottom.nil? ? padding : @padding_bottom
+    end
+
+    attr_writer :padding_bottom
+
+    # Whether the scroll arrows are drawn on a window whose contents overflow.
+    def arrows_visible
+      @arrows_visible.nil? ? true : @arrows_visible
+    end
+
+    attr_writer :arrows_visible
+
+    def tone
+      @tone ||= Tone.new(0, 0, 0, 0)
+    end
+
+    attr_writer :tone
+
+    # RGSS2/RGSS3 construct a window with its geometry — `Window.new(x, y,
+    # width, height)` — where RGSS1 (XP) took an optional viewport and had the
+    # geometry assigned afterwards. Every VX/VX Ace window does the former
+    # (`Window_Base#initialize` calls `super(x, y, width, height)`), so accept
+    # both forms: four numbers are the VX shape, anything else goes to the
+    # native initializer unchanged.
+    alias_method :_rgss1_initialize, :initialize
+
+    def initialize(x = nil, y = nil, width = nil, height = nil)
+      if x.is_a?(Integer) && y.is_a?(Integer)
+        _rgss1_initialize
+        self.x = x
+        self.y = y
+        self.width = width.to_i
+        self.height = height.to_i
+      elsif x.nil?
+        _rgss1_initialize
+      else
+        _rgss1_initialize(x)
+      end
+    end
   end
 
   class RGSSError < StandardError
@@ -345,6 +428,13 @@ module RGSS
         _se_stop
       end
 
+      # RGSS2+. The VX/VX Ace scripts call it once at boot when the project asks
+      # for MIDI playback; SDL_mixer picks its own synth, so there is nothing to
+      # set up here.
+      def setup_midi
+        RGSS.warn_stub("Audio.setup_midi")
+      end
+
       private
 
       # First existing file for +filename+ under any (root, dir, extension)
@@ -384,9 +474,54 @@ module RGSS
   module Graphics
     @frame_count = 0
     @frame_rate = 40
+    # The game screen, in pixels. RGSS2 added Graphics.width/height, and the
+    # stock VX Ace scripts lean on them heavily (measured: width x50, height
+    # x32) for camera and window-layout maths, so a boot shell declares its
+    # resolution here with resize_screen — the VX/VX Ace one does (544x416,
+    # matching the window src/main.cxx opens). RGSS1 has no such method, so the
+    # XP resolution is the default and the XP/RPG2000 shells leave it alone.
+    @width = 640
+    @height = 480
+    @brightness = 255
 
     class << self
       attr_accessor :frame_count, :frame_rate
+      attr_reader :width, :height, :brightness
+
+      # RGSS2+. Also what the boot shells call to declare the screen size.
+      def resize_screen(width, height)
+        @width = width
+        @height = height
+      end
+
+      # Run `duration` frames. Real behaviour, not a stub: the scripts use it to
+      # hold a scene (fade-ins, message waits), and each update is a real frame.
+      def wait(duration)
+        duration.to_i.times { update }
+      end
+
+      # 0 (black) .. 255 (normal). Stored so a script's fade bookkeeping is
+      # consistent; the value is not applied to what is drawn yet — that needs
+      # the same native screen-tone support the RPG2000 tint is waiting on, so
+      # say so once rather than pretending the screen darkened.
+      def brightness=(value)
+        value = 0 if value < 0
+        value = 255 if value > 255
+        RGSS.warn_stub("Graphics.brightness= (tracked, not drawn)") unless value == 255
+        @brightness = value
+      end
+
+      # RGSS2+ fades: run the frames the fade would take (so the game's timing
+      # is right) and leave the brightness at its end value.
+      def fadeout(duration)
+        wait(duration)
+        self.brightness = 0
+      end
+
+      def fadein(duration)
+        wait(duration)
+        self.brightness = 255
+      end
 
       def freeze
         RGSS.warn_stub("Graphics.freeze")
@@ -394,6 +529,8 @@ module RGSS
 
       def transition(duration = 8, filename = nil, vague = 40)
         RGSS.warn_stub("Graphics.transition")
+        wait(duration)
+        @brightness = 255
       end
 
       def frame_reset
@@ -425,10 +562,34 @@ module RGSS
     F8 = 18
     F9 = 19
 
+    # RGSS2 (VX) and RGSS3 (VX Ace) name the keys with **symbols** —
+    # `Input.trigger?(:C)` — where RGSS1 (XP) used the integer constants above.
+    # The stock VX Ace scripts use symbols exclusively (measured: :C, :UP/:DOWN/
+    # :LEFT/:RIGHT, :B, :A, :L, :R, :CTRL, :F9 — see docs/rpgvx-rgss-api-gap.md),
+    # so map them onto the same key indices instead of keeping two key tables.
+    # An Integer is passed through untouched, so every XP / RPG2000 caller and
+    # the C++ input bridge are unaffected.
+    SYMBOL_KEYS = {
+      UP: UP, DOWN: DOWN, LEFT: LEFT, RIGHT: RIGHT,
+      A: A, B: B, C: C, X: X, Y: Y, Z: Z, L: L, R: R,
+      SHIFT: SHIFT, CTRL: CTRL, ALT: ALT,
+      F5: F5, F6: F6, F7: F7, F8: F8, F9: F9
+    }.freeze
+
     @pressed = Array.new(20, false)
     @triggered = Array.new(20, false)
     @repeated = Array.new(20, false)
     @count = Array.new(20, 0)
+
+    # Key index for either spelling. An unrecognised key reads as unpressed
+    # rather than raising (a script may probe a key this build has no name for),
+    # but it is reported once so the omission is visible in the log.
+    def self.key_index(key)
+      return key if key.is_a?(Integer)
+      index = SYMBOL_KEYS[key]
+      RGSS.warn_stub("Input key #{key.inspect}") if index.nil?
+      index
+    end
 
     def self.update
       # Key transitions are pushed in from C++ via .press / .release: the SDL
@@ -459,27 +620,34 @@ module RGSS
     end
 
     def self.press(key)
-      @pressed[key] = true
-      @triggered[key] = true
-      @count[key] = 0
+      index = key_index(key)
+      return if index.nil?
+      @pressed[index] = true
+      @triggered[index] = true
+      @count[index] = 0
     end
 
     def self.release(key)
-      @pressed[key] = false
-      @triggered[key] = false
-      @count[key] = 0
+      index = key_index(key)
+      return if index.nil?
+      @pressed[index] = false
+      @triggered[index] = false
+      @count[index] = 0
     end
 
     def self.press?(key)
-      @pressed[key]
+      index = key_index(key)
+      index.nil? ? false : @pressed[index]
     end
 
     def self.trigger?(key)
-      @triggered[key]
+      index = key_index(key)
+      index.nil? ? false : @triggered[index]
     end
 
     def self.repeat?(key)
-      @repeated[key]
+      index = key_index(key)
+      index.nil? ? false : @repeated[index]
     end
 
     def self.dir4

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -585,6 +585,104 @@ assert "RGSS::Window API surface" do
   end
 end
 
+assert "RGSS::Input accepts RGSS2/RGSS3 symbol keys" do
+  # VX and VX Ace name the keys with symbols (Input.trigger?(:C)); XP and the
+  # C++ input bridge use the integer constants. Both must reach the same key.
+  begin
+    RGSS::Input.press(RGSS::Input::C)
+    assert_true RGSS::Input.press?(:C), "a symbol must read the integer press"
+    assert_true RGSS::Input.trigger?(:C)
+    RGSS::Input.release(:C)
+    assert_false RGSS::Input.press?(RGSS::Input::C), "a symbol release must clear it"
+
+    RGSS::Input.press(:UP)
+    assert_true RGSS::Input.press?(RGSS::Input::UP), "a symbol press must set the key"
+    assert_equal 8, RGSS::Input.dir4
+
+    # Every RGSS3 key name maps, and an unknown one reads as unpressed instead
+    # of raising out of the game loop.
+    assert_equal 20, RGSS::Input::SYMBOL_KEYS.size
+    RGSS::Input::SYMBOL_KEYS.each do |name, index|
+      assert_equal index, RGSS::Input.key_index(name), "key #{name} maps wrong"
+    end
+    assert_false RGSS::Input.press?(:NO_SUCH_KEY)
+    assert_nil RGSS::Input.release(:NO_SUCH_KEY)
+  ensure
+    RGSS::Input.release(:UP)
+    RGSS::Input.release(:C)
+  end
+end
+
+assert "RGSS::Graphics reports and resizes the screen" do
+  # RGSS2 added Graphics.width/height; each maker's boot shell declares its own
+  # resolution, and the stock VX Ace scripts compute camera and window layouts
+  # from them.
+  begin
+    RGSS::Graphics.resize_screen(544, 416)
+    assert_equal 544, RGSS::Graphics.width
+    assert_equal 416, RGSS::Graphics.height
+
+    assert_equal 255, RGSS::Graphics.brightness
+    RGSS::Graphics.brightness = -5
+    assert_equal 0, RGSS::Graphics.brightness
+    RGSS::Graphics.brightness = 999
+    assert_equal 255, RGSS::Graphics.brightness
+  ensure
+    RGSS::Graphics.resize_screen(640, 480)
+    RGSS::Graphics.brightness = 255
+  end
+end
+
+assert "RGSS::Graphics.wait / fadeout drive real frames" do
+  # Graphics.update is native and needs a live display the headless test binary
+  # lacks, so count the frames through a stand-in — what is under test is that
+  # the RGSS2 waits run the frames the game's timing depends on.
+  class << RGSS::Graphics
+    alias _update_orig update
+    def update
+      $graphics_frames = ($graphics_frames || 0) + 1
+      nil
+    end
+  end
+  begin
+    $graphics_frames = 0
+    RGSS::Graphics.wait(3)
+    assert_equal 3, $graphics_frames
+
+    RGSS::Graphics.fadeout(2)
+    assert_equal 5, $graphics_frames
+    assert_equal 0, RGSS::Graphics.brightness
+
+    RGSS::Graphics.fadein(1)
+    assert_equal 6, $graphics_frames
+    assert_equal 255, RGSS::Graphics.brightness
+  ensure
+    class << RGSS::Graphics
+      alias update _update_orig
+    end
+    RGSS::Graphics.brightness = 255
+  end
+end
+
+assert "RGSS::Audio.setup_midi is a safe no-op" do
+  # RGSS2+; the VX/VX Ace scripts call it at boot when the project asks for
+  # MIDI. SDL_mixer picks its own synth, so there is nothing to configure.
+  assert_nil RGSS::Audio.setup_midi
+end
+
+assert "RGSS::Window RGSS2/RGSS3 API surface" do
+  # Window.new needs a live display (see the Tilemap note below), so assert the
+  # VX/VX Ace surface is defined; the behaviour of these accessors is exercised
+  # by the VX runtime checks (scripts/rpgvx_testbed_check.rb). The dual-form
+  # constructor (RGSS1's optional viewport / RGSS2's x, y, width, height) needs
+  # no assertion here: it aliases the native initialize at load, so a broken
+  # alias would fail the whole gem, not one test.
+  %i[openness openness= open? close? padding padding= padding_bottom
+     padding_bottom= arrows_visible arrows_visible= tone tone=].each do |m|
+    assert_true RGSS::Window.method_defined?(m), "Window##{m} missing"
+  end
+end
+
 assert "RGSS::Tilemap API surface" do
   # Tilemap is now native: Tilemap.new builds an lv_canvas the size of the
   # viewport and blits the visible tiles into it, so construction needs a live

--- a/mruby-rpgvx/mrbgem.rake
+++ b/mruby-rpgvx/mrbgem.rake
@@ -20,7 +20,7 @@ MRuby::Gem::Specification.new('mruby-rpgvx') do |spec|
   # Load order matters: lib.rb defines the RPGVX class and its WIDTH/HEIGHT/TILE
   # constants, which the data sources read at class-body evaluation time. Set the
   # order explicitly rather than relying on the default alphabetical glob.
-  spec.rbfiles = %w[lib rgss2_data rgss_data].map do |name|
+  spec.rbfiles = %w[lib rgss2_data rgss2_runtime rgss_data].map do |name|
     "#{dir}/mrblib/#{name}.rb"
   end
 end

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -100,6 +100,11 @@ class RPGVX
 
   def initialize(_args)
     @edition = self.class.detect(GAME_DIR)
+    # Declare the screen the window was opened at (src/main.cxx sizes it to the
+    # same numbers), so the scripts' `Graphics.width`/`height` — which VX's
+    # camera and every window layout are computed from — report VX's resolution
+    # rather than the RGSS default.
+    RGSS::Graphics.resize_screen(WIDTH, HEIGHT)
     @db = RGSSData.new(GAME_DIR, @edition) if @edition
     @title = read_title
     # A VX/VX Ace project's engine *is* its script bundle, so the script host is
@@ -140,6 +145,10 @@ class RPGVX
   # (src/main.cxx) call this.
   def main_loop
     return drive_script_host if @host_fiber
+    # The host game has ended (its Main returned, or a script stopped it); the
+    # web per-frame callback keeps calling this, so idle rather than reporting
+    # the pending built-in flow for a game that just ran.
+    return if @host_done
     warn_runtime_pending
   end
 
@@ -187,7 +196,9 @@ class RPGVX
       @host_fiber = nil
       @host_done = true
     end
-  rescue RGSS::Timeout
+  rescue RGSS::Timeout, SystemExit
+    # A clean end: the timeout guard fired, a script called `rgss_stop`, or one
+    # called `exit`. End the game rather than treating it as a boot failure.
     @host_fiber = nil
     @host_done = true
   rescue StandardError => e

--- a/mruby-rpgvx/mrblib/rgss2_runtime.rb
+++ b/mruby-rpgvx/mrblib/rgss2_runtime.rb
@@ -1,0 +1,217 @@
+# The RGSS2 / RGSS3 built-ins a VX / VX Ace project's own scripts call.
+#
+# The schema in rgss2_data.rb declares the `RPG::*` records as pure data, which
+# is all a database reader needs. The real RGSS2/RGSS3 library gives two of those
+# record classes *behaviour* as well, and adds a couple of Kernel methods, and
+# the stock scripts lean on both from their first frame:
+#
+#   * `RPG::BGM`/`BGS`/`ME`/`SE` play themselves — `$game_system.battle_bgm.play`,
+#     `@map_bgm.replay`, `RPG::BGM.fade(1000)`, `RPG::SE.stop`. Measured in the
+#     109 stock VX Ace sections: 19 `#play`, 6 `#fade`, 3 `#replay`, plus the
+#     class-level `last`/`stop`/`fade` (docs/rpgvx-rgss-api-gap.md).
+#   * `rgss_main` wraps the whole game loop in RGSS3 (`rgss_main { SceneManager
+#     .run }` is the entire Main section of every VX Ace project), and `msgbox` /
+#     `msgbox_p` are the RGSS2+ debug printers.
+#
+# All of it is plain Ruby over `RGSS::Audio`, so it is defined here rather than
+# in the native gem. The Kernel methods are RGSS2/RGSS3-only; XP scripts never
+# call them, so defining them globally costs the XP path nothing.
+class RPGVX
+  # Kept as a marker of where the behaviour below comes from, and so a caller can
+  # ask which edition's built-ins are installed.
+  RGSS_RUNTIME = "RGSS2/RGSS3".freeze
+end
+
+module RPG
+  # Playback behaviour shared by the four audio record classes. RGSS gives each
+  # of them `play`/`stop`/`fade` plus a class-side "last played" slot that the
+  # save data and `replay` restore from; the differences between the four are the
+  # `RGSS::Audio` entry points, which each subclass names below.
+  module AudioPlayback
+    # Empty name = "no music", which in RGSS stops the channel instead of
+    # playing silence. Volume/pitch default to the record's own.
+    def play(volume = nil, pitch = nil)
+      if name.nil? || name.empty?
+        self.class.stop
+      else
+        self.class.play_audio(name, volume || self.volume || 100,
+                              pitch || self.pitch || 100)
+        self.class.last = self
+      end
+    end
+
+    # Play this record again from its stored position. RGSS3's `RPG::BGM#replay`
+    # resumes at `pos` (the map BGM is replayed after a battle); the SDL_mixer
+    # backend cannot seek, so the position is kept for the save data and the
+    # track restarts. Same audible result for a looping BGM.
+    def replay
+      play
+    end
+
+    def stop
+      self.class.stop
+    end
+
+    def fade(time)
+      self.class.fade(time)
+    end
+
+    # Class-side helpers. `last` is the record most recently played on that
+    # channel (RGSS3 exposes it as `RPG::BGM.last`, which the save data stores);
+    # `stop` and `fade` act on the channel itself.
+    module ClassMethods
+      def last
+        @last ||= new_empty
+      end
+
+      def last=(record)
+        @last = record
+      end
+
+      def stop
+        stop_audio
+        @last = new_empty
+      end
+
+      def fade(time)
+        fade_audio(time)
+        @last = new_empty
+      end
+
+      # An "empty" record of this class: RGSS answers a nameless AudioFile for a
+      # channel that has never played, so a caller can always read `.last.name`.
+      def new_empty
+        record = new
+        record.name = ""
+        record.volume = 100
+        record.pitch = 100
+        record
+      end
+    end
+  end
+
+  class BGM
+    include AudioPlayback
+    extend AudioPlayback::ClassMethods
+
+    def self.play_audio(name, volume, pitch)
+      RGSS::Audio.bgm_play(name, volume, pitch)
+    end
+
+    def self.stop_audio
+      RGSS::Audio.bgm_stop
+    end
+
+    def self.fade_audio(time)
+      RGSS::Audio.bgm_fade(time)
+    end
+
+    # RGSS3 stamps the playing position onto the record it hands back, which is
+    # what a save stores so the BGM resumes where it left off (the SDL_mixer
+    # backend cannot seek on replay, but the value round-trips).
+    def self.last
+      record = (@last ||= new_empty)
+      record.pos = RGSS::Audio.bgm_pos
+      record
+    end
+  end
+
+  class BGS
+    include AudioPlayback
+    extend AudioPlayback::ClassMethods
+
+    def self.play_audio(name, volume, pitch)
+      RGSS::Audio.bgs_play(name, volume, pitch)
+    end
+
+    def self.stop_audio
+      RGSS::Audio.bgs_stop
+    end
+
+    def self.fade_audio(time)
+      RGSS::Audio.bgs_fade(time)
+    end
+
+    def self.last
+      record = (@last ||= new_empty)
+      record.pos = RGSS::Audio.bgs_pos
+      record
+    end
+  end
+
+  class ME
+    include AudioPlayback
+    extend AudioPlayback::ClassMethods
+
+    def self.play_audio(name, volume, pitch)
+      RGSS::Audio.me_play(name, volume, pitch)
+    end
+
+    def self.stop_audio
+      RGSS::Audio.me_stop
+    end
+
+    def self.fade_audio(time)
+      RGSS::Audio.me_fade(time)
+    end
+  end
+
+  class SE
+    include AudioPlayback
+    extend AudioPlayback::ClassMethods
+
+    def self.play_audio(name, volume, pitch)
+      RGSS::Audio.se_play(name, volume, pitch)
+    end
+
+    def self.stop_audio
+      RGSS::Audio.se_stop
+    end
+
+    # SE has no fade in RGSS; stopping is the only way to cut one short.
+    def self.fade_audio(_time)
+      stop_audio
+    end
+
+    # An SE is fire-and-forget: RGSS never reports a "last SE", and nothing in
+    # the stock scripts asks for one, so playing does not claim the slot.
+    def play(volume = nil, pitch = nil)
+      return if name.nil? || name.empty?
+      self.class.play_audio(name, volume || self.volume || 100,
+                            pitch || self.pitch || 100)
+    end
+  end
+end
+
+# RGSS3 Kernel methods. Defined on Object, the way the script host defines
+# load_data/save_data, so a bundled script reaches them at the top level.
+class Object
+  # RGSS3's game-loop wrapper: `rgss_main { SceneManager.run }` is the whole Main
+  # section of a VX Ace project. The real one re-runs its block when the player
+  # presses F12 (a `RGSSReset` reset) and swallows the reset otherwise; there is
+  # no reset key here, so it runs the block once and returns its value. Errors
+  # propagate, as they do in RGSS.
+  def rgss_main
+    yield
+  end
+
+  # RGSS3's "stop the game and wait" — used by the F12 reset path and by a
+  # script that wants to halt without exiting. Blocking forever would hang the
+  # per-frame driver, so this ends the game loop instead, which is what the
+  # player sees either way.
+  def rgss_stop
+    raise RGSS::Timeout, "rgss_stop"
+  end
+
+  # RGSS2+ debug message boxes. There is no dialog to open here, so they go to
+  # the log — visible, rather than silently dropped.
+  def msgbox(*args)
+    $stderr.puts "[RGSS2] msgbox: #{args.map { |a| a.to_s }.join}"
+    nil
+  end
+
+  def msgbox_p(*args)
+    $stderr.puts "[RGSS2] msgbox_p: #{args.map { |a| a.inspect }.join(", ")}"
+    nil
+  end
+end

--- a/mruby-rpgvx/test/rpgvx_test.rb
+++ b/mruby-rpgvx/test/rpgvx_test.rb
@@ -437,6 +437,127 @@ assert "VX Ace enemies carry the params array and drop table" do
   assert_equal 5, loaded.actions[0].rating
 end
 
+# ---- RGSS2 / RGSS3 built-ins ----------------------------------------------
+
+# The audio records play themselves in RGSS2/RGSS3 ($game_system.battle_bgm.play).
+# Capture what reaches RGSS::Audio; the native backend is absent here anyway, and
+# what is under test is the routing, the volume/pitch defaults and the
+# "last played" bookkeeping.
+#
+# The overrides only capture while a capture list is installed (inside
+# vx_capture_audio) and otherwise call straight through, so this file can never
+# disturb another gem's audio test whatever order the suites run in.
+class << RGSS::Audio
+  alias _vx_bgm_play_orig bgm_play
+  alias _vx_bgm_stop_orig bgm_stop
+  alias _vx_bgm_fade_orig bgm_fade
+  alias _vx_se_play_orig se_play
+  alias _vx_me_play_orig me_play
+
+  def bgm_play(name, volume = 100, pitch = 100)
+    return _vx_bgm_play_orig(name, volume, pitch) unless $vx_audio.is_a?(Array)
+    $vx_audio << [:bgm_play, name, volume, pitch]
+    nil
+  end
+
+  def bgm_stop
+    return _vx_bgm_stop_orig unless $vx_audio.is_a?(Array)
+    $vx_audio << [:bgm_stop]
+    nil
+  end
+
+  def bgm_fade(time)
+    return _vx_bgm_fade_orig(time) unless $vx_audio.is_a?(Array)
+    $vx_audio << [:bgm_fade, time]
+    nil
+  end
+
+  def se_play(name, volume = 100, pitch = 100)
+    return _vx_se_play_orig(name, volume, pitch) unless $vx_audio.is_a?(Array)
+    $vx_audio << [:se_play, name, volume, pitch]
+    nil
+  end
+
+  def me_play(name, volume = 100, pitch = 100)
+    return _vx_me_play_orig(name, volume, pitch) unless $vx_audio.is_a?(Array)
+    $vx_audio << [:me_play, name, volume, pitch]
+    nil
+  end
+end
+
+# Run a block with the audio capture installed; answers what was played.
+def vx_capture_audio
+  $vx_audio = []
+  yield
+  $vx_audio
+ensure
+  $vx_audio = nil
+end
+
+def vx_bgm(name, volume = nil, pitch = nil)
+  bgm = RPG::BGM.new
+  bgm.name = name
+  bgm.volume = volume
+  bgm.pitch = pitch
+  bgm
+end
+
+assert "RPG::BGM plays itself through RGSS::Audio" do
+  played = vx_capture_audio { vx_bgm("Theme1", 80, 110).play }
+  assert_equal [[:bgm_play, "Theme1", 80, 110]], played
+  # The record's own volume/pitch are the defaults, and a record with neither
+  # falls back to RGSS's 100/100.
+  played = vx_capture_audio { vx_bgm("Theme2").play }
+  assert_equal [[:bgm_play, "Theme2", 100, 100]], played
+end
+
+assert "RPG::BGM tracks the last played record" do
+  vx_capture_audio { vx_bgm("Field1", 90, 100).play }
+  assert_equal "Field1", RPG::BGM.last.name
+  assert_equal 90, RPG::BGM.last.volume
+
+  # #replay plays the same record again (RGSS3 resumes the map BGM this way).
+  played = vx_capture_audio { RPG::BGM.last.replay }
+  assert_equal [[:bgm_play, "Field1", 90, 100]], played
+
+  # Fading or stopping the channel clears it, so `last.name` is readable and
+  # empty rather than stale.
+  played = vx_capture_audio { RPG::BGM.fade(1000) }
+  assert_equal [[:bgm_fade, 1000]], played
+  assert_equal "", RPG::BGM.last.name
+end
+
+assert "a nameless RPG::BGM stops the channel instead of playing silence" do
+  assert_equal [[:bgm_stop]], vx_capture_audio { vx_bgm("").play }
+  assert_equal [[:bgm_stop]], vx_capture_audio { vx_bgm(nil).play }
+end
+
+assert "RPG::SE and RPG::ME play through their own channels" do
+  se = RPG::SE.new
+  se.name = "Cursor1"
+  se.volume = 60
+  assert_equal [[:se_play, "Cursor1", 60, 100]], vx_capture_audio { se.play }
+  # An SE is fire-and-forget: RGSS reports no "last SE".
+  assert_equal "", RPG::SE.last.name
+
+  me = RPG::ME.new
+  me.name = "Victory1"
+  assert_equal [[:me_play, "Victory1", 100, 100]], vx_capture_audio { me.play }
+  assert_equal "Victory1", RPG::ME.last.name
+end
+
+assert "RGSS3 Kernel built-ins" do
+  # `rgss_main { SceneManager.run }` is the whole Main section of a VX Ace
+  # project, so the host must supply it.
+  assert_equal 7, rgss_main { 7 }
+  # rgss_stop ends the game loop (the driver treats RGSS::Timeout as a clean
+  # end) rather than blocking the per-frame Fiber forever.
+  assert_raise(RGSS::Timeout) { rgss_stop }
+  # The RGSS2+ debug boxes have no dialog here; they log and return nil.
+  assert_nil msgbox("hello ", 1)
+  assert_nil msgbox_p([1, 2])
+end
+
 # ---- Encrypted archives ---------------------------------------------------
 
 assert "a VX database survives its .rgss2a (v1) archive" do

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -120,12 +120,47 @@ module RGSS
 
   class Timeout < StandardError; end
 
+  # Graphics is native. These stand-ins mirror the parts of mruby-rgss's module
+  # the VX path touches (the real ones are unit-tested in mruby-rgss/test):
+  # counting frames so the per-frame driver can be asserted, RGSS2's frame wait,
+  # and the screen size the boot shell declares.
   module Graphics
     @frames = 0
+    @width = 640
+    @height = 480
     class << self
-      attr_reader :frames
+      attr_reader :frames, :width, :height
       def update = @frames += 1
       def reset_frames = @frames = 0
+      def wait(duration) = duration.to_i.times { update }
+      def resize_screen(width, height)
+        @width = width
+        @height = height
+      end
+    end
+  end
+
+  # The audio backend is native (SDL_mixer); record what the RPG::BGM/SE/ME
+  # records route to it so the boot check can assert the game's own scripts
+  # actually reached it.
+  module Audio
+    @played = []
+    class << self
+      attr_reader :played
+      def reset = @played = []
+      def bgm_play(name, volume = 100, pitch = 100) = @played << [:bgm_play, name, volume, pitch]
+      def bgm_stop = @played << [:bgm_stop]
+      def bgm_fade(time) = @played << [:bgm_fade, time]
+      def bgm_pos = 0
+      def bgs_play(name, volume = 100, pitch = 100) = @played << [:bgs_play, name, volume, pitch]
+      def bgs_stop = @played << [:bgs_stop]
+      def bgs_fade(time) = @played << [:bgs_fade, time]
+      def bgs_pos = 0
+      def me_play(name, volume = 100, pitch = 100) = @played << [:me_play, name, volume, pitch]
+      def me_stop = @played << [:me_stop]
+      def me_fade(time) = @played << [:me_fade, time]
+      def se_play(name, volume = 100, pitch = 100) = @played << [:se_play, name, volume, pitch]
+      def se_stop = @played << [:se_stop]
     end
   end
 end
@@ -146,6 +181,7 @@ load File.join(ROOT, "mruby-rpgxp", "mrblib", "rgssad.rb")
 load File.join(ROOT, "mruby-rpgxp", "mrblib", "script_host.rb")
 load File.join(ROOT, "mruby-rpgvx", "mrblib", "lib.rb")
 load File.join(ROOT, "mruby-rpgvx", "mrblib", "rgss2_data.rb")
+load File.join(ROOT, "mruby-rpgvx", "mrblib", "rgss2_runtime.rb")
 load File.join(ROOT, "mruby-rpgvx", "mrblib", "rgss_data.rb")
 
 # --- A generated project, one per edition ----------------------------------
@@ -881,14 +917,19 @@ module Sample
   end
 
   # The script bundle: [id, name, zlib-deflated source] sections, exactly as XP
-  # stores them. A real game's Main boots its engine (`rgss_main { SceneManager
-  # .run }` in VX Ace); this one stands in for that — it reads the database back
-  # through the Kernel#load_data built-in the host installs and drives a few
-  # frames, so running it exercises the whole boot path (see Checker#check_boot).
+  # stores them. A real VX Ace game's Main is `rgss_main { SceneManager.run }`;
+  # this one has the same shape and calls the RGSS2/RGSS3 built-ins a real boot
+  # reaches in its first frames — the Kernel#load_data the host installs, the
+  # title BGM playing itself, and a frame wait — so running it exercises the
+  # whole boot path (see Checker#check_boot).
   def scripts(ext)
-    main = "$rgss_sample_title = load_data(\"Data/System#{ext}\").game_title\n" \
-           "3.times { Graphics.update }\n" \
-           "$rgss_sample_booted = true\n"
+    main = "rgss_main do\n" \
+           "  system = load_data(\"Data/System#{ext}\")\n" \
+           "  $rgss_sample_title = system.game_title\n" \
+           "  system.title_bgm.play\n" \
+           "  Graphics.wait(3)\n" \
+           "  $rgss_sample_booted = true\n" \
+           "end\n"
     [[1, "Main", Zlib::Deflate.deflate(main)],
      [2, "", Zlib::Deflate.deflate("# empty section\n")]]
   end
@@ -1102,6 +1143,7 @@ class Checker
     $rgss_sample_booted = nil
     $rgss_sample_title = nil
     RGSS::Graphics.reset_frames
+    RGSS::Audio.reset
     previous = ENV["RGSS_SCRIPT_HOST"]
 
     # Host off (the default): the shell must load the database, report the
@@ -1130,7 +1172,19 @@ class Checker
            "from inside the scripts")
     expect(RGSS::Graphics.frames == 3,
            "boot: #{RGSS::Graphics.frames} frames driven, expected 3")
-    puts "  boot: script host ran the bundled scripts over #{RGSS::Graphics.frames} frames"
+    # The RGSS2/RGSS3 built-ins the scripts called on the way: the title BGM
+    # played itself through RPG::BGM#play (rgss2_runtime.rb) and is remembered
+    # as the channel's last record.
+    expect(RGSS::Audio.played == [[:bgm_play, "Theme1", 100, 100]],
+           "boot: title BGM did not reach Audio (got #{RGSS::Audio.played.inspect})")
+    expect(RPG::BGM.last.name == "Theme1",
+           "boot: RPG::BGM.last is #{RPG::BGM.last.name.inspect}, expected \"Theme1\"")
+    expect(RGSS::Graphics.width == RPGVX::WIDTH &&
+           RGSS::Graphics.height == RPGVX::HEIGHT,
+           "boot: the shell did not declare VX's screen size to Graphics")
+    puts "  boot: script host ran the bundled scripts over " \
+         "#{RGSS::Graphics.frames} frames (rgss_main, load_data, " \
+         "RPG::BGM#play, Graphics.wait)"
   rescue StandardError => ex
     fail "#{dir}: boot raised: #{ex.class}: #{ex.message}"
   ensure


### PR DESCRIPTION
Follow-up to #285. A VX or VX Ace game's engine *is* its script bundle, so the RGSS script host is the only route to running one — and the bundle assumes the RGSS2/RGSS3 class library from its first frame. This supplies the tractable half of that library and **measures** the rest.

## Measured, not guessed

The needed surface was counted across the **stock VX Ace script set** — 109 sections, ~19.9k lines, the scripts every new VX Ace project ships with (nothing is vendored into this repo). The result is the new [`docs/rpgvx-rgss-api-gap.md`](docs/rpgvx-rgss-api-gap.md), the counterpart to `docs/rpgxp-rgss-api-gap.md`. It says what a game actually touches on the way to a first frame, not what RGSS3 defines — which is how the priorities below were picked.

## Engine (`mruby-rgss`) — additive, XP / RPG2000 callers untouched

- **`Input` symbol keys.** RGSS2/RGSS3 name keys as symbols (`Input.trigger?(:C)`) and the stock scripts use **nothing else** (`:C` ×11, `:UP`/`:DOWN` ×7, … , zero uses of XP's integer constants) — so this was a hard blocker: `@pressed[:C]` cannot index the key array. One key table (`SYMBOL_KEYS`) now serves either spelling, and the C++ input bridge keeps passing integers. An unrecognised key reads as unpressed and is reported once rather than raising out of the game loop.
- **`Graphics.width`/`height`** (~82 uses — VX's camera and every window layout are computed from them) via a new `resize_screen` that a boot shell calls with its own resolution. Plus RGSS2's `wait`, `fadeout`, `fadein` and `brightness`: the waits run **real frames**, so a scene that holds for a fade takes the right time. `transition` now consumes its frames too instead of returning instantly — nothing in the tree called it before (the script host is opt-in), so no existing path shifts.
- **`Window`**: `openness` with `open?`/`close?` (the open/close loops the scripts drive themselves), `padding`/`padding_bottom`, `arrows_visible`, `tone`, and the VX-shaped constructor `Window.new(x, y, width, height)` alongside XP's optional-viewport form.
- **`Audio.setup_midi`**.

## VX / VX Ace (`mruby-rpgvx/mrblib/rgss2_runtime.rb`)

- **The audio records play themselves.** In RGSS2/RGSS3 `RPG::BGM`/`BGS`/`ME`/`SE` carry behaviour (`$game_system.battle_bgm.play`, `@map_bgm.replay`, `RPG::BGM.fade(1000)`, `RPG::SE.stop` — ~30 sites): `#play`/`#replay`/`#stop`/`#fade` and the class-side `last`/`stop`/`fade` over `RGSS::Audio`, including RGSS's "an empty name stops the channel" rule and the `last` slot a save restores from.
- **RGSS3 Kernel methods** — `rgss_main` (the entire `Main` section of every VX Ace project), `rgss_stop`, `msgbox`/`msgbox_p`.
- The shell declares VX's 544×416 screen to `Graphics` at boot and ends the game cleanly on `SystemExit` / `rgss_stop`.

## What still blocks a *playable* VX game (all native, documented in the gap doc)

1. The **VX/VX Ace `Tilemap`** — nine `bitmaps` sheets (A1–A5, B–E) and the `flags` table instead of XP's single tileset/autotiles. Without it a game boots but no map draws.
2. **`Viewport#tone`/`#color`/`#flash`** — VX does every tint / flash / fade through the viewport, so all screen effects are inert. Same native tone work the RPG2000 tint is waiting on.
3. **`Graphics.freeze`/`transition`/`snap_to_bitmap`** — scene transitions.

## Testing

- New `mruby-rgss/test` cases: symbol keys alongside integers (including every RGSS3 key name and the unknown-key path), `Graphics` geometry/brightness clamping, and `wait`/`fadeout`/`fadein` driving real frames through a stand-in `update` (the native one needs a live display the headless test binary lacks). The VX `Window` accessors are surface-asserted, as `Sprite`/`Tilemap` already are.
- New `mruby-rpgvx/test` cases for the audio records (routing, volume/pitch defaults, `last` bookkeeping, the empty-name rule) and the RGSS3 Kernel methods. The `RGSS::Audio` capture only intercepts inside its helper and otherwise calls straight through, so it cannot disturb `mruby-rgss`'s own audio test whatever order the suites run in.
- `scripts/rpgvx_testbed_check.rb` now boots each generated project through a `rgss_main { … }` Main that loads the database via `Kernel#load_data`, plays its title BGM and waits frames — so the whole path (detection → database → host → per-frame Fiber driver → RGSS2 built-ins) runs end to end for both editions, loose and packed.

Verified locally: the VX check is green for both editions; the new engine behaviour was exercised under a real mruby interpreter built from the pinned submodule (symbol keys, `Graphics` waits, the dual-form `Window.new`, and every audio/Kernel built-in); every changed `.rb` parses under mruby 4.0's `mrbc`; the RPG2000 logic/scene checks still pass. The native SDL/mruby binary cannot be built in this environment, so CI is the first full build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_