### PR TITLE
Prevent critical hits against RPG2000 characters with prevent-critical gear

### DIFF
--- a/changelog.d/rpg2k-battle-prevent-critical.added.md
+++ b/changelog.d/rpg2k-battle-prevent-critical.added.md
@@ -1,0 +1,10 @@
+- RPG Maker 2000: **gear can now shield its wearer from critical hits**. Items
+  carrying the database `prevent_critical` flag (RPG2000 armor with "prevent
+  critical hits") are surfaced through `Game::Actor#prevents_critical?`, which
+  scans the actor's equipped items, and the result is snapshotted onto the
+  `Combatant` (`prevents_crit`). In `deal_attack` the critical roll is now gated
+  on the target: a battler protected by prevent-critical gear can never be crit,
+  so the attack lands for its ordinary damage even when the attacker's chance
+  rolls a hit. Matches EasyRPG's `Game_Battler::PreventsCritical`. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks (prevent-critical gear blocks the 3x hit;
+  `Game::Actor#prevents_critical?` reads the equipped flag).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -363,8 +363,9 @@ The work below is roughly ordered by the critical path to a walkable game
   skills, spread via `Algo::VarianceAdjustEffect`), enabled for the live game and
   off for seeded / headless fights. A basic attack can land a **3x critical hit**
   at the attacker's database 1-in-N chance (actor `critical_rate`, enemy
-  `critical_hit_chance`); no crit on a same-side hit. Still to come: enemy-cast
-  infliction, elemental attributes, `prevent_critical` gear, all-target skill/item
+  `critical_hit_chance`); no crit on a same-side hit. Characters wearing gear with
+  the **`prevent_critical`** flag can never be crit. Still to come: enemy-cast
+  infliction, elemental attributes, all-target skill/item
   scopes, the per-terrain backdrop and the RPG2000 Game Over graphic.
   The remaining event commands (tile substitution and other native-render
   effects) are TODO. **Show Battle Animation** (11210) now plays on the map — the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1073,6 +1073,18 @@ module Game
       total
     end
 
+    # Whether any equipped item guards against critical hits (the armour
+    # `prevent_critical` flag, item field 25). A database with no item table
+    # (the test fixtures) or an item lacking the flag contributes nothing.
+    def prevents_critical?
+      return false unless @db.respond_to?(:item)
+      @equipment.any? do |iid|
+        next false if iid.nil? || iid == 0
+        it = @db.item[iid]
+        it && it.respond_to?(:prevent_critical) && it.prevent_critical
+      end
+    end
+
     # Coerce an equipment spec (an EQUIP_ORDER hash, an array of ids, or nil) to a
     # five-slot array of integer item ids.
     def normalize_equipment(spec)
@@ -2793,7 +2805,8 @@ module Game
     # stat the skill formulas read as `int`.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
-                           :actor, :states, :state_turns, :crit_denom) do
+                           :actor, :states, :state_turns, :crit_denom,
+                           :prevents_crit) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
@@ -2812,10 +2825,13 @@ module Game
     # lacks the field).
     def self.crit_denom_of(b); b.respond_to?(:crit_denominator) ? b.crit_denominator : 0; end
 
+    # Whether a battler's gear guards against critical hits.
+    def self.prevents_crit_of(b); b.respond_to?(:prevents_critical?) && b.prevents_critical?; end
+
     def self.from_actor(a)
       Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
-                    nil, crit_denom_of(a))
+                    nil, crit_denom_of(a), prevents_crit_of(a))
     end
 
     # Enemies have no source actor (that field stays nil), so the post-battle
@@ -2823,7 +2839,7 @@ module Game
     def self.from_enemy(e)
       Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
                     nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
-                    crit_denom_of(e))
+                    crit_denom_of(e), prevents_crit_of(e))
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -3083,9 +3099,9 @@ module Game
     def deal_attack(b, target)
       dmg = Battle.attack_damage(b.atk, target.def)
       dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance
-      # No critical on a same-side hit (e.g. a confused ally striking an ally),
-      # matching EasyRPG.
-      crit = critical?(b) && side_of(b) != side_of(target)
+      # No critical on a same-side hit (e.g. a confused ally striking an ally) or
+      # against a target whose gear prevents criticals, matching EasyRPG.
+      crit = critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit
       dmg *= 3 if crit
       dmg = [dmg / 2, 1].max if target.defending
       target.hp -= dmg

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1283,14 +1283,16 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :recover_hp, :recover_hp_rate, :recover_sp, :recover_sp_rate,
                       :price, :skill_id,
                       :atk_points2, :def_points2, :spi_points2, :agi_points2,
-                      :occasion_battle, :state_set, :reverse_state_effect)
+                      :occasion_battle, :state_set, :reverse_state_effect,
+                      :prevent_critical)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
-              state_set: nil, reverse_state: false)
+              state_set: nil, reverse_state: false, prevent_crit: false)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
-               atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state)
+               atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
+               prevent_crit)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -3766,6 +3768,28 @@ check 'battle: a zero crit_denom never criticals even with criticals on' do
   e = bat.step_action
   eq 20, e[:damage]
   ok !e[:critical]
+end
+
+check 'battle: gear that prevents criticals blocks the 3x hit' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_denom = 1                                # would always crit...
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.prevents_crit = true                         # ...but the target is guarded
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
+  bat.begin_round
+  e = bat.step_action
+  eq 20, e[:damage]                                  # base, crit blocked
+  ok !e[:critical]
+end
+
+check 'Actor#prevents_critical? reads equipped prevent-critical gear' do
+  items = { 8 => fake_item(type: 2, prevent_crit: true) } # a piece of armour
+  st = item_party(items)
+  a = st.party.actor_by_id(1)
+  eq false, a.prevents_critical?                     # nothing equipped yet
+  a.equip([0, 8, 0, 0, 0])                           # equip item 8
+  eq true, a.prevents_critical?
+  eq true, Game::Battle.from_actor(a).prevents_crit  # carried onto the combatant
 end
 
 check 'battle skill damage varies by the skill variance when the fight rolls it' do


### PR DESCRIPTION
## Summary

RPG2000 armor can carry a "prevent critical hits" flag. This extends the criticals feature (#291) so that a battler wearing such gear can never be crit.

- Add `Game::Actor#prevents_critical?`, which scans the actor's equipped items for the database `prevent_critical` flag.
- Snapshot the result onto the `Combatant` (`prevents_crit`) via a new `Game::Battle.prevents_crit_of`, threaded into `from_actor` / `from_enemy`.
- Gate the critical roll in `deal_attack` on the **target**: a protected battler is never crit, so the attack lands for its ordinary damage even when the attacker's chance rolls a hit.

Matches EasyRPG's `Game_Battler::PreventsCritical`.

## Testing

- `scripts/rpg2k_logic_check.rb` — 291 checks pass, including two new ones: prevent-critical gear blocks the 3x hit, and `Game::Actor#prevents_critical?` reads the equipped flag.
- Scene (92) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_