### PR TITLE
Add mruby-enum-ext so Array#sort_by works in the built engine

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -2,6 +2,12 @@
 def rpg_maker_gems(conf)
   conf.gem core: 'mruby-array-ext'
   conf.gem core: 'mruby-hash-ext'
+  # Enumerable#sort_by / min_by / max_by / group_by etc. mruby-array-ext does not
+  # supply these — they live in mruby-enum-ext and are absent from the default
+  # gem set, so calling e.g. Array#sort_by raises NoMethodError in the built
+  # engine (the RPG2000 battle turn-order and message-pacing code both use it),
+  # while the CRuby host checks pass. See scripts/rpg2k_boot_check.bash.
+  conf.gem core: 'mruby-enum-ext'
   conf.gem core: 'mruby-io'
   conf.gem core: 'mruby-numeric-ext'
   # Fiber: the RGSS script host drives the game's bundled blocking main loop

--- a/changelog.d/mruby-enum-ext.fixed.md
+++ b/changelog.d/mruby-enum-ext.fixed.md
@@ -1,0 +1,5 @@
+Added `mruby-enum-ext` to the engine's gem set so `Enumerable#sort_by` (and
+`min_by` / `max_by` / `group_by`) work in the built engine. These are absent
+from the default mruby gem set, so code that called `Array#sort_by` — the
+RPG2000 battle turn-order and message-pacing paths — raised `NoMethodError` and
+aborted the native binary at runtime, even though the CRuby host checks passed.


### PR DESCRIPTION
## Summary
`Enumerable#sort_by` (and `min_by` / `max_by` / `group_by`) are not in the default mruby gem set, and `mruby-array-ext` — which the build already pulls in — does not supply them. So calling `Array#sort_by` raised `NoMethodError` and **aborted the native binary at runtime**, while the CRuby host checks (which run the same sources under CRuby, where `sort_by` always exists) passed clean.

This is the same mruby/CRuby divergence class the boot smoke test exists to catch (`Enumerable#none?`, `module_function` before it).

## Where it bit
- **Message pacing** (`Game::TextReveal#initialize`) — surfaced by the real-game boot smoke test aborting the moment Nepheshel's first autostart message opened (`game.rb: undefined method 'sort_by' for Array`).
- **Battle turn order** (`Game::Battle`, `game.rb:~3084`) — a latent crash that would fire whenever a native battle runs.

## Change
- `build_config.rb`: add `conf.gem core: 'mruby-enum-ext'` to the shared `rpg_maker_gems` set, with a comment on why.

## Validation
`mruby-enum-ext` ships its own `mrbtest` suite, run under this build's `enable_test`, so the `test` step exercises `sort_by` et al. natively. The `RPG2k real-game boot smoke test` step also boots the real engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_