### PR TITLE
Draw RGSS::Viewport#color and #flash

### DIFF
--- a/changelog.d/rgss-viewport-color-flash.added.md
+++ b/changelog.d/rgss-viewport-color-flash.added.md
@@ -1,0 +1,23 @@
+- **`RGSS::Viewport#color` and `#flash` are drawn.** RPG Maker VX / VX Ace do
+  every screen effect through the viewport rather than a sprite overlay — the
+  fade is `@viewport3.color.set(0, 0, 0, 255 - brightness)`, the flash is
+  `@viewport2.color`, and battle/skill animations call
+  `viewport.flash(color, duration)` — so with `Viewport` carrying no colour at
+  all, none of it reached the screen. It is now native (`mruby-rgss`): a colour
+  overlay canvas the size of the viewport, held above its content layer, with a
+  timed flash composited over the base colour and faded out linearly. The
+  overlay is repainted from `Viewport#update`, not only on assignment, because
+  the stock scripts mutate the colour **in place** (`viewport.color.set(...)`)
+  and call `update` every frame; the fill is skipped unless the effective colour
+  or the viewport size actually changed. This is the same "screen-sized colour
+  at an opacity" mechanism ADR 0021 measured working for the RPG2000 fade, moved
+  into the viewport so it clips, scrolls and hides with it — and available for
+  the RPG2000 side to adopt in place of its own overlay sprite.
+- `RGSS::Viewport#tone` is **kept but not drawn**, and says so once. Unlike a
+  colour, a tone rescales what is already drawn (desaturate toward luminance,
+  then offset each channel), so it needs a per-pixel pass over the viewport's
+  contents rather than one more layer on top — the same native work the RPG2000
+  screen tint is waiting on. Holding the value keeps a script's bookkeeping
+  consistent and makes the tint land the moment that pass exists. The measured
+  state of the whole RGSS2/RGSS3 surface is tracked in
+  [`docs/rpgvx-rgss-api-gap.md`](docs/rpgvx-rgss-api-gap.md).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -739,12 +739,21 @@ screen (544×416). Full rationale:
     `#fade`, the class-side `last`/`stop`/`fade`), and the RGSS3 Kernel methods
     **`rgss_main`** (the whole `Main` section of every VX Ace project),
     `rgss_stop`, `msgbox`/`msgbox_p`.
+  - ✅ **`Viewport#color` / `#flash`** — VX does every screen effect through the
+    viewport (`@viewport3.color.set(0, 0, 0, 255 - brightness)` is the fade,
+    `@viewport2.color` the flash, `viewport.flash` the animation flashes), so
+    these are now native: a colour overlay canvas the size of the viewport,
+    above its content layer, repainted from `#update` — which is what makes the
+    scripts' in-place `color.set(...)` visible. Same mechanism ADR 0021 measured
+    working for the RPG2000 fade, moved into the viewport so it clips and
+    scrolls with it.
   - Remaining, all native `mruby-rgss` work and ordered by what blocks a
     playable game: the **VX/VX Ace `Tilemap`** (nine `bitmaps` sheets + the
     `flags` table instead of XP's single tileset/autotiles — without it a game
-    boots but no map draws), **`Viewport#tone`/`#color`/`#flash`** (VX does
-    every tint / flash / fade through the viewport, so all screen effects are
-    inert — the same native tone work the RPG2000 tint needs),
+    boots but no map draws), **`Viewport#tone`** (unlike `color` a tone rescales
+    what is already drawn, so it needs a per-pixel pass over the viewport's
+    contents — the same native work the RPG2000 screen tint is waiting on, and
+    doing it once here would serve both),
     **`Graphics.freeze`/`transition`/`snap_to_bitmap`** (scene transitions),
     the window open/close animation, and `Bitmap#blur`/`#radial_blur`.
 - **Built-in title/map flow** — the reimplemented scene stack the RPG2000 and XP

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -99,22 +99,34 @@ the different **autotile geometry** (A1 water/A2 ground/A3 buildings/A4 walls
 and the direct B–E pages). Native work in `mruby-rgss/src/lib.cxx`, and the
 single biggest item here: without it a VX game boots but shows no map.
 
-### 2. `Viewport#tone` / `#color` / `#flash` — no screen tint, flash or fade
+### 2. `Viewport#tone` — no screen tint (`#color` / `#flash` now draw ✅)
 
 VX/VX Ace do every screen effect through the viewport, not a sprite overlay:
 
 ```ruby
-@viewport1.tone.set($game_map.screen.tone)              # tint
-@viewport2.color.set($game_map.screen.flash_color)      # flash
-@viewport3.color.set(0, 0, 0, 255 - $game_map.screen.brightness)  # fade
-viewport.flash(timing.flash_color, timing.flash_duration)         # animations
+@viewport1.tone.set($game_map.screen.tone)              # tint          ❌
+@viewport2.color.set($game_map.screen.flash_color)      # flash         ✅
+@viewport3.color.set(0, 0, 0, 255 - $game_map.screen.brightness)  # fade ✅
+viewport.flash(timing.flash_color, timing.flash_duration)  # animations ✅
 ```
 
-Our `Viewport` has none of these (`ox`/`oy`/`rect`/`z`/`visible` only), so tint,
-flash, fade-in/out and animation flashes are all inert. This is the same native
-tone work the RPG2000 side is waiting on (`docs/TODO.md`), and doing it once on
-`Viewport` would serve both. `Graphics.brightness` is tracked but not drawn for
-exactly this reason.
+**`Viewport#color` and `#flash` are implemented natively**: a colour overlay
+canvas the size of the viewport, held above its content layer and refreshed from
+`#update` — which is what makes the scripts' in-place `color.set(...)` visible,
+since they mutate the Color object and call `update` every frame. It is the same
+"screen-sized colour at an opacity" mechanism ADR 0021 measured working for the
+RPG2000 fade, moved into the viewport so it clips, scrolls and hides with it. So
+the **screen fade** (`Graphics.fadeout`/`fadein` via viewport3), the **flash**,
+and **animation flashes** all reach the display.
+
+**`tone` is still missing.** Unlike `color`, a tone *rescales what is already
+drawn* (desaturate toward luminance, then offset each channel), which cannot be
+one more layer on top — it needs a per-pixel pass over the viewport's contents.
+That is the same native work the RPG2000 screen tint is waiting on
+(`docs/TODO.md`), and doing it once on `Viewport` would serve both.
+`Viewport#tone=` keeps the value (so a script's bookkeeping stays consistent and
+the tint lands the moment the pass exists) and reports once that it is not drawn;
+`Graphics.brightness` is tracked-not-drawn for the same reason.
 
 ### 3. `Graphics.freeze` / `transition` / `snap_to_bitmap` — no scene transitions
 
@@ -145,7 +157,7 @@ packed VX Ace game needs next after the tilemap.
 ## What this means for turning the host on
 
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
-the only route to a real game. With this round in place a bundle **runs**: it
-loads its database, plays its music, reads input, drives frames and lays out its
-windows. What it cannot yet do is **draw the map or any screen effect**, which
-is items 1–3, all native `mruby-rgss` work.
+the only route to a real game. A bundle now **runs**: it loads its database,
+plays its music, reads input, drives frames, lays out its windows, and fades and
+flashes the screen. What it cannot yet do is **draw the map** (item 1) or tint it
+(item 2's remaining half), both native `mruby-rgss` work.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -353,6 +353,28 @@ module RGSS
     end
   end
 
+  # RGSS Viewport. Native (src/lib.cxx): the clipping frame, its scrolled
+  # content layer, `rect`/`ox`/`oy`/`z`/`visible`, and — for the RGSS2/RGSS3
+  # screen effects — `color`/`color=` and `flash`, drawn as a colour overlay
+  # above the viewport's contents and refreshed from `update`. This reopening
+  # only adds the tone.
+  class Viewport
+    # A viewport `tone` rescales what is already drawn (desaturate toward
+    # luminance, then offset each channel), which — unlike `color` — cannot be
+    # expressed as one more layer on top: it needs the same per-pixel pass the
+    # RPG2000 screen tint is waiting on (docs/TODO.md, docs/rpgvx-rgss-api-gap.md).
+    # The value is kept so a script's bookkeeping is consistent and so the tint
+    # lands the moment that pass exists; it is not drawn, and says so once.
+    def tone
+      @tone ||= Tone.new(0, 0, 0, 0)
+    end
+
+    def tone=(value)
+      RGSS.warn_stub("Viewport#tone= (tracked, not drawn)")
+      @tone = value
+    end
+  end
+
   class RGSSError < StandardError
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -3792,6 +3792,10 @@ mrb_value make_rect(mrb_state* M, mrb_int x, mrb_int y, mrb_int w, mrb_int h) {
       M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Rect"), 4, args);
 }
 
+// Repaint the viewport's colour/flash overlay (defined with the rest of the
+// overlay below; declared here because a rect change has to resize it).
+void vp_refresh_overlay(mrb_state* M, mrb_value self);
+
 // Push the stored @rect / @ox / @oy onto the underlying LVGL objects: the outer
 // frame takes the rect's position and size (and clips to it), while the inner
 // content layer is shifted by (-ox, -oy) to scroll its sprites.
@@ -3812,6 +3816,9 @@ void vp_apply(mrb_state* M, mrb_value self) {
   lv_obj_set_pos(inner, -(mrb_fixnum_p(ox) ? mrb_fixnum(ox) : 0),
                  -(mrb_fixnum_p(oy) ? mrb_fixnum(oy) : 0));
   lv_obj_set_size(inner, w, h);
+
+  // The colour overlay covers the frame, so a resized viewport resizes it.
+  vp_refresh_overlay(M, self);
 }
 
 mrb_value vp_init(mrb_state* M, mrb_value self) {
@@ -3896,9 +3903,198 @@ mrb_value vp_set_oy(mrb_state* M, mrb_value self) {
   return mrb_fixnum_value(v);
 }
 
-// Present so the game loop can drive per-frame behaviour (flash, etc.); no
-// animated viewport effects are modelled yet, so this is a no-op.
+// ---- Viewport colour overlay ----------------------------------------------
+//
+// RGSS's `Viewport#color` is a flat colour laid over everything the viewport
+// draws, and `#flash` is the same thing on a countdown. VX / VX Ace do every
+// screen effect this way — `Spriteset_Map` fades with
+// `@viewport3.color.set(0, 0, 0, 255 - brightness)` and flashes with
+// `@viewport2.color.set(...)` — and the RPG2000 runtime wants the same
+// mechanism for its screen fade/flash.
+//
+// LVGL cannot tint a container, but it can draw one more child on top of one:
+// the overlay is a canvas the size of the viewport, filled with the effective
+// colour, held as the outer frame's last child so it composites above the
+// content layer. The z sweep in gfx_update only reorders *registered* objects,
+// which all live inside that content layer, so the overlay stays on top without
+// taking part in z ordering. This is the same "screen-sized colour at an
+// opacity" ADR 0021 measured working for the RPG2000 fade, moved into the
+// viewport so it clips, scrolls and hides with it.
+//
+// Note the overlay is refreshed from `#update`, not only on assignment: the
+// stock scripts mutate the colour *in place* (`viewport.color.set(...)`) and
+// call `viewport.update` every frame, so re-reading it per frame is what makes
+// an in-place change visible. The fill is skipped unless the effective colour
+// actually changed, so a static viewport costs one comparison a frame.
+
+// The overlay canvas, created on demand. The outer frame's only other child is
+// the content layer built by vp_init (index 0), and lv_obj_move_foreground
+// keeps the overlay last, so index 1 identifies it without keeping a pointer
+// alive across a GC.
+lv_obj_t* vp_overlay(mrb_state* M, mrb_value self, bool create) {
+  lv_obj_t* outer = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  if (!outer)
+    return nullptr;
+  if (lv_obj_t* existing = lv_obj_get_child(outer, 1))
+    return existing;
+  if (!create)
+    return nullptr;
+
+  lv_obj_t* ov = lv_canvas_create(outer);
+  lv_obj_remove_style_all(ov);
+  lv_obj_set_pos(ov, 0, 0);
+  // Never take pointer events, and always draw last among the outer frame's
+  // children (the content layer is the only other one).
+  lv_obj_remove_flag(ov, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_move_foreground(ov);
+  return ov;
+}
+
+// The colour the overlay should show: the viewport's `color`, with the flash
+// colour composited over it (src-over) while a flash is running. RGSS fades a
+// flash out linearly over its duration.
+Color vp_effective_color(mrb_state* M, mrb_value self) {
+  Color out{0, 0, 0, 0};
+  const mrb_value color_v = mrb_iv_get(M, self, mrb_intern_lit(M, "@color"));
+  if (mrb_test(color_v) && DATA_PTR(color_v))
+    out = DataType<Color>::get(M, color_v);
+
+  const mrb_value count_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_count"));
+  const mrb_value flash_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_color"));
+  const mrb_int count = mrb_fixnum_p(count_v) ? mrb_fixnum(count_v) : 0;
+  if (count > 0 && mrb_test(flash_v) && DATA_PTR(flash_v)) {
+    const mrb_value dur_v =
+        mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_duration"));
+    const mrb_int duration = mrb_fixnum_p(dur_v) ? mrb_fixnum(dur_v) : count;
+    const Color f = DataType<Color>::get(M, flash_v);
+    const double fade = duration > 0 ? (double)count / (double)duration : 1.0;
+    const double a = (f.alpha / 255.0) * fade;
+    out.red = f.red * a + out.red * (1.0 - a);
+    out.green = f.green * a + out.green * (1.0 - a);
+    out.blue = f.blue * a + out.blue * (1.0 - a);
+    out.alpha = 255.0 * a + out.alpha * (1.0 - a);
+  }
+  return out;
+}
+
+// Repaint the overlay from the current colour/flash state. Allocates (or
+// resizes) its buffer to the viewport rect, and hides it entirely when the
+// effective colour is transparent so a viewport with no effect draws nothing
+// extra.
+void vp_refresh_overlay(mrb_state* M, mrb_value self) {
+  lv_obj_t* outer = reinterpret_cast<lv_obj_t*>(DATA_PTR(self));
+  if (!outer)
+    return;
+  const Color c = vp_effective_color(M, self);
+  const bool visible = c.alpha > 0.0;
+  lv_obj_t* ov = vp_overlay(M, self, visible);
+  if (!ov)
+    return;
+  if (!visible) {
+    lv_obj_add_flag(ov, LV_OBJ_FLAG_HIDDEN);
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@_overlay_key"), mrb_nil_value());
+    return;
+  }
+
+  Rect& r =
+      DataType<Rect>::get(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@rect")));
+  const mrb_int w = std::max<mrb_int>(r.width, 1);
+  const mrb_int h = std::max<mrb_int>(r.height, 1);
+
+  // Skip the fill when neither the colour nor the size changed since the last
+  // one: #update runs this every frame. The channels are 0..255, so packing
+  // them with the size into two doubles stays exact and allocates nothing.
+  const double color_key =
+      ((std::floor(c.red) * 256.0 + std::floor(c.green)) * 256.0 +
+       std::floor(c.blue)) *
+          256.0 +
+      std::floor(c.alpha);
+  const double size_key = (double)w * 65536.0 + (double)h;
+  const mrb_value prev_color =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@_overlay_key"));
+  const mrb_value prev_size =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@_overlay_size"));
+  if (mrb_float_p(prev_color) && mrb_float(prev_color) == color_key &&
+      mrb_float_p(prev_size) && mrb_float(prev_size) == size_key) {
+    lv_obj_remove_flag(ov, LV_OBJ_FLAG_HIDDEN);
+    return;
+  }
+
+  const mrb_value cur = mrb_iv_get(M, self, mrb_intern_lit(M, "@_overlay_bmp"));
+  mrb_value bmp_v = cur;
+  if (mrb_nil_p(cur) || DataType<Bitmap>::get(M, cur).width != w ||
+      DataType<Bitmap>::get(M, cur).height != h) {
+    RClass* bmp_class =
+        mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Bitmap");
+    bmp_v =
+        DataType<Bitmap>::make(M, bmp_class, w, h, LV_COLOR_FORMAT_ARGB8888);
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@_overlay_bmp"), bmp_v);
+    Bitmap& nb = DataType<Bitmap>::get(M, bmp_v);
+    lv_canvas_set_buffer(ov, nb.buffer.data(), w, h, LV_COLOR_FORMAT_ARGB8888);
+    lv_obj_set_size(ov, w, h);
+  }
+
+  Bitmap& b = DataType<Bitmap>::get(M, bmp_v);
+  for (mrb_int y = 0; y < h; ++y)
+    for (mrb_int x = 0; x < w; ++x)
+      bmp_put(b, x, y, c.red, c.green, c.blue, c.alpha);
+  b.dirty = true;
+  lv_obj_remove_flag(ov, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_move_foreground(ov);
+  lv_obj_invalidate(ov);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_overlay_key"),
+             mrb_float_value(M, color_key));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_overlay_size"),
+             mrb_float_value(M, size_key));
+}
+
+mrb_value vp_color(mrb_state* M, mrb_value self) {
+  mrb_value c = mrb_iv_get(M, self, mrb_intern_lit(M, "@color"));
+  if (mrb_nil_p(c)) {
+    const mrb_value args[] = {mrb_fixnum_value(0), mrb_fixnum_value(0),
+                              mrb_fixnum_value(0), mrb_fixnum_value(0)};
+    c = mrb_obj_new(
+        M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Color"), 4, args);
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@color"), c);
+  }
+  return c;
+}
+
+mrb_value vp_set_color(mrb_state* M, mrb_value self) {
+  mrb_value c;
+  mrb_get_args(M, "o", &c);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@color"), c);
+  vp_refresh_overlay(M, self);
+  return c;
+}
+
+// Viewport#flash(color, duration): show `color` over the viewport, fading out
+// over `duration` frames of #update. A nil colour is RGSS's "empty" flash,
+// which for a viewport means no overlay at all.
+mrb_value vp_flash(mrb_state* M, mrb_value self) {
+  mrb_value color;
+  mrb_int duration;
+  mrb_get_args(M, "oi", &color, &duration);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_color"), color);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_duration"),
+             mrb_fixnum_value(duration));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_count"),
+             mrb_fixnum_value(mrb_nil_p(color) ? 0 : duration));
+  vp_refresh_overlay(M, self);
+  return mrb_nil_value();
+}
+
+// One frame: advance a running flash and repaint the overlay from the current
+// colour (which the scripts mutate in place).
 mrb_value vp_update(mrb_state* M, mrb_value self) {
+  const mrb_value count_v =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@flash_count"));
+  if (mrb_fixnum_p(count_v) && mrb_fixnum(count_v) > 0)
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@flash_count"),
+               mrb_fixnum_value(mrb_fixnum(count_v) - 1));
+  vp_refresh_overlay(M, self);
   return mrb_nil_value();
 }
 
@@ -4136,6 +4332,11 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, vp, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, vp, "visible=", obj_set_visible, MRB_ARGS_REQ(1));
   mrb_define_method(M, vp, "update", vp_update, MRB_ARGS_NONE());
+  // RGSS2/RGSS3 do every screen effect through the viewport: a flat colour over
+  // everything it draws, and a timed flash. See vp_refresh_overlay.
+  mrb_define_method(M, vp, "color", vp_color, MRB_ARGS_NONE());
+  mrb_define_method(M, vp, "color=", vp_set_color, MRB_ARGS_REQ(1));
+  mrb_define_method(M, vp, "flash", vp_flash, MRB_ARGS_REQ(2));
   mrb_define_method(M, vp, "dispose", obj_dispose, MRB_ARGS_NONE());
   mrb_define_method(M, vp, "disposed?", obj_disposed, MRB_ARGS_NONE());
 

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -683,6 +683,17 @@ assert "RGSS::Window RGSS2/RGSS3 API surface" do
   end
 end
 
+assert "RGSS::Viewport RGSS2/RGSS3 screen-effect surface" do
+  # Viewport.new needs a live display the headless test binary lacks (see the
+  # Tilemap note below), so assert the surface. `color`/`flash` are native and
+  # draw a colour overlay above the viewport's contents; `tone` is Ruby-side and
+  # tracked-but-not-drawn.
+  %i[color color= flash tone tone= update ox oy rect rect= z= visible
+     visible= dispose disposed?].each do |m|
+    assert_true RGSS::Viewport.method_defined?(m), "Viewport##{m} missing"
+  end
+end
+
 assert "RGSS::Tilemap API surface" do
   # Tilemap is now native: Tilemap.new builds an lv_canvas the size of the
   # viewport and blits the visible tiles into it, so construction needs a live


### PR DESCRIPTION
Item 2 of [`docs/rpgvx-rgss-api-gap.md`](docs/rpgvx-rgss-api-gap.md), and the first of the native pieces.

RPG Maker VX / VX Ace do **every screen effect through the viewport** rather than a sprite overlay:

```ruby
@viewport3.color.set(0, 0, 0, 255 - $game_map.screen.brightness)  # the screen fade
@viewport2.color.set($game_map.screen.flash_color)                # the screen flash
viewport.flash(timing.flash_color, timing.flash_duration)         # animation flashes
```

Our `Viewport` carried no colour at all (`ox`/`oy`/`rect`/`z`/`visible` only), so none of that reached the screen — a VX game would fade to nothing and flash invisibly.

## How

A colour overlay canvas the size of the viewport, created on demand as the outer frame's **last child**, so it composites above the content layer. The z sweep in `gfx_update` only reorders *registered* objects, and those all live inside that content layer, so the overlay stays on top without taking part in z ordering. A running flash is composited over the base colour (src-over) and faded out linearly over its duration.

Two details worth review:

- **Repainted from `#update`, not only on assignment.** The stock scripts mutate the colour *in place* (`viewport.color.set(...)`) and call `viewport.update` every frame, so re-reading it per frame is the only thing that makes an in-place change visible. To keep that cheap the fill is skipped unless the effective colour or the viewport size actually changed (two packed doubles compared, no allocation), so a static viewport costs one comparison a frame.
- **A rect change resizes the overlay**, via a `vp_refresh_overlay` call from `vp_apply`.

This is the same "screen-sized colour at an opacity" mechanism ADR 0021 measured working for the RPG2000 fade — moved into the viewport so it clips, scrolls and hides with it, and now available for the RPG2000 side to adopt in place of its own overlay sprite.

## `Viewport#tone` is deliberately *not* drawn

It is kept (Ruby-side) and reports once that it is not drawn. Unlike a colour, a tone **rescales what is already drawn** (desaturate toward luminance, then offset each channel), so it cannot be one more layer on top — it needs a per-pixel pass over the viewport's contents, which is the same native work the RPG2000 screen tint is waiting on. Holding the value keeps a script's bookkeeping consistent and makes the tint land the moment that pass exists. Documented as the remaining half of gap item 2 rather than approximated with an overlay that would look plausible and be wrong.

## Testing

This is native rendering code, and `Viewport.new` needs a live display the headless test binary lacks — so the honest summary of what is verified:

- **The C++ compiles and type-checks locally.** I initialised the `lvgl`/`uni-algo`/`stb` submodules and ran `g++ -fsyntax-only` over `mruby-rgss/src/lib.cxx` with the real headers, and confirmed the check is meaningful by breaking an LVGL call on purpose and watching it fail. So the LVGL/mruby API use is checked, not guessed.
- `mruby-rgss/test` gains a Viewport surface assertion (matching how `Sprite`/`Plane`/`Tilemap` are covered), and the Ruby-side `tone` accessor is exercised under a real mruby interpreter.
- The VX check and the RPG2000 logic/scene checks still pass; `clang-format` is clean.

What I **cannot** verify here is that the pixels land — there is no headless render assertion for the RGSS path (the RPG2000 comparison harness of ADR 0021 needs wine + a display). If you want that pinned in CI, the natural follow-up is a small frame-measurement smoke like the one that ADR describes; say the word and I'll add it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_