### PR TITLE
Reduce CI log noise from fetch progress and ALSA warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          # Keep the checkout quiet. `show-progress` is what adds `--progress`
+          # to the fetch, which prints a "Receiving objects: NN%" line per
+          # update — a screenful of log before anything is built. Dropping the
+          # persisted credentials removes the other half: the post-job step
+          # otherwise walks all 14 submodules unsetting the `includeIf` config
+          # it added, ~10 `[command]git config ...` lines each. Nothing runs an
+          # authenticated git command after checkout (the download scripts
+          # clone public repositories), so both are pure noise. Same two
+          # settings on every checkout below.
+          show-progress: false
+          persist-credentials: false
 
       # Keep the tc39/test262 clone out of CI — `nix develop` fetches this flake
       # with submodules and would otherwise trip over quickjs-ng's unused nested
@@ -172,6 +183,12 @@ jobs:
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
       # check.
+      #
+      # The inline smokes run through `scripts/quiet_alsa.bash`, which drops the
+      # "cannot find card '0'" wall a runner without a sound device produces on
+      # every engine start (the same three patterns the boot-check scripts
+      # already strip) while preserving the engine's exit status and its
+      # `[MV-*]` markers.
       - parallel:
           - name: LCF test-bed smoke check
             run: nix develop -c ruby scripts/lcf_testbed_check.rb
@@ -226,7 +243,8 @@ jobs:
           - name: MV boot smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=100 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=100 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=5000 --game_dir data/Lunatic-Core \
                 --mv_screenshot=ss/mv_title.png
 
@@ -240,14 +258,16 @@ jobs:
           - name: MV real-game play smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=105 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=105 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/Lunatic-Core \
                 --mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png
 
           - name: MV sample smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=101 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=101 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=5000 --game_dir data/mv-sample \
                 --mv_new_game --mv_screenshot=ss/mv_sample.png
 
@@ -271,21 +291,24 @@ jobs:
           - name: MV battle smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=102 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=102 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=8000 --game_dir data/Lunatic-Core \
                 --mv_battle_test=1 --mv_screenshot=ss/mv_battle.png
 
           - name: MV movement smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=103 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=103 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_move_test
 
           - name: MV message smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=104 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=104 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_message_test --mv_screenshot=ss/mv_message.png
 
@@ -296,7 +319,8 @@ jobs:
           - name: MV menu smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=106 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=106 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_menu_test --mv_screenshot=ss/mv_menu.png
 
@@ -306,7 +330,8 @@ jobs:
           - name: MV save smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=107 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=107 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_save_test
 
@@ -318,7 +343,8 @@ jobs:
           - name: MV audio smoke test
             continue-on-error: true
             run: |
-              nix develop -c xvfb-run --server-num=108 timeout 120 ./build/rpg_maker_clone \
+              nix develop -c ./scripts/quiet_alsa.bash \
+                xvfb-run --server-num=108 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_audio_test
 
@@ -447,6 +473,9 @@ jobs:
           # The PR head for a `/preview` comment; empty everywhere else, which
           # is checkout's default of "the ref that triggered the workflow".
           ref: ${{ needs.preview-gate.outputs.head-sha }}
+          # Quiet fetch + no post-job credential unset walk; see the `build` job.
+          show-progress: false
+          persist-credentials: false
 
       # Same as the `build` job: keep the tc39/test262 clone out of the nix
       # submodule walk that `nix develop` triggers.
@@ -565,6 +594,9 @@ jobs:
         with:
           # LVGL is vendored as a submodule and linked into the firmware.
           submodules: recursive
+          # Quiet fetch + no post-job credential unset walk; see the `build` job.
+          show-progress: false
+          persist-credentials: false
 
       - uses: actions/setup-python@v7
         with:
@@ -580,7 +612,10 @@ jobs:
           restore-keys: pio-${{ runner.os }}-
 
       - name: Install PlatformIO
-        run: pip install --upgrade platformio
+        # -q keeps pip to warnings and errors: the resolver's per-package
+        # "Collecting/Downloading/Installing" chatter says nothing a green step
+        # does not already say.
+        run: pip install -q --disable-pip-version-check --upgrade platformio
 
       - name: Build firmware
         run: pio run -e wio
@@ -600,11 +635,18 @@ jobs:
         with:
           # LVGL is vendored as a submodule and linked into the EBOOT.
           submodules: recursive
+          # Quiet fetch + no post-job credential unset walk; see the `build` job.
+          show-progress: false
+          persist-credentials: false
 
       - name: Build EBOOT (pspdev container)
         # The pspdev image ships psp-gcc, cmake and the psp-cmake wrapper (which
         # points CMake at the pspdev toolchain and provides create_pbp_file).
+        # Pull it up front with -q: an implicit pull from `docker run` prints a
+        # per-layer download/extract progress block, which `-q` reduces to the
+        # resolved digest.
         run: |
+          docker pull -q pspdev/pspdev:latest
           docker run --rm -v "$PWD:/src" -w /src pspdev/pspdev:latest sh -euc '
             psp-cmake -S app/psp -B build-psp
             cmake --build build-psp -j"$(nproc)"
@@ -648,9 +690,14 @@ jobs:
         # PPSSPP compiles its GL/Vulkan backends even for HEADLESS: its bundled
         # GLEW pulls in GL/glu.h, so libglu is required on top of libgl. Vulkan
         # and fontconfig headers are needed for the SDL/Linux frontend it links.
+        # -qq keeps apt to warnings and errors: the per-index "Get:N ..." and
+        # per-package "Selecting/Unpacking/Setting up ..." lines are noise on a
+        # step whose only interesting outcome is its exit code.
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
             build-essential cmake ninja-build pkg-config \
             libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev libvulkan-dev \
             libfontconfig1-dev zlib1g-dev
@@ -668,7 +715,7 @@ jobs:
       - name: Build PPSSPP headless
         run: |
           if [ ! -d ppsspp/.git ]; then
-            git clone --recursive --depth 1 -b "$PPSSPP_TAG" \
+            git clone --quiet --recursive --depth 1 -b "$PPSSPP_TAG" \
               https://github.com/hrydgard/ppsspp
           fi
           cmake -S ppsspp -B ppsspp/build -GNinja \
@@ -687,25 +734,31 @@ jobs:
           EBOOT="$GITHUB_WORKSPACE/eboot/EBOOT.PBP"
           ls -l "$EBOOT"
           cd ppsspp
-          # Capture the exact supported flags/renderers for reference.
-          echo "=== PPSSPPHeadless --help ==="
-          ./build/PPSSPPHeadless --help 2>&1 | head -80 || true
           # Run from the PPSSPP tree so it finds its assets/ (fonts, etc.).
-          # --timeout ends the otherwise-infinite bring-up loop; a non-zero exit
-          # from the timeout must not mask the heartbeat check, hence `|| true`.
           # The bring-up writes its markers with sceIoWrite(fd 1 and 2); PPSSPP
           # logs those, but below the default headless level, so --log is needed
           # to surface them (plain printf is an unimplemented HLE import under
           # PPSSPP). --timeout ends the otherwise-infinite bring-up loop; `|| true`
           # keeps its non-zero exit from masking the assertion below.
           # (--screenshot is a compare-against input in headless, not an output.)
-          echo "=== run ==="
+          #
+          # --log makes the emulator trace every HLE call, so the output goes to
+          # the log file rather than the console: the whole file is uploaded as
+          # the `psp-smoke` artifact below, and the lines that decide this step
+          # (the markers, or the tail when they are missing) are echoed here.
           ./build/PPSSPPHeadless --log --graphics=software --timeout=15 \
-            "$EBOOT" 2>&1 | tee "$GITHUB_WORKSPACE/headless.log" || true
+            "$EBOOT" > "$GITHUB_WORKSPACE/headless.log" 2>&1 || true
           echo "=== asserting the EBOOT booted (and ideally pumped frames) ==="
           # RPG2K_PSP_BOOT proves it booted with output captured; RPG2K_PSP_BRINGUP
           # (the per-second heartbeat) additionally proves the frame loop runs.
-          grep -qE 'RPG2K_PSP_(BOOT|BRINGUP)' "$GITHUB_WORKSPACE/headless.log"
+          if grep -qE 'RPG2K_PSP_(BOOT|BRINGUP)' "$GITHUB_WORKSPACE/headless.log"; then
+            grep -E 'RPG2K_PSP_(BOOT|BRINGUP)' "$GITHUB_WORKSPACE/headless.log" \
+              | head -5
+          else
+            echo "no bring-up marker in the emulator log; last 100 lines:"
+            tail -100 "$GITHUB_WORKSPACE/headless.log"
+            exit 1
+          fi
 
       - name: Upload smoke-test output
         if: always()
@@ -727,6 +780,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          # Quiet fetch + no post-job credential unset walk; see the `build` job.
+          show-progress: false
+          persist-credentials: false
 
       # Same as the `build` job — `nix build '.?submodules=1'` walks every entry
       # of every nested `.gitmodules`, so drop quickjs-ng's unused test262 entry

--- a/changelog.d/ci-quieter-logs.changed.md
+++ b/changelog.d/ci-quieter-logs.changed.md
@@ -1,0 +1,15 @@
+- CI logs only what the run is about. `actions/checkout` no longer prints
+  fetch progress (`show-progress: false`) nor the post-job walk that unsets
+  `includeIf` config for all 14 submodules (`persist-credentials: false`, on
+  every job); `wget`/`unar`/`git clone` in the download and RTP scripts run
+  quietly, so an archive no longer costs thousands of "downloading / extracting
+  <file>" lines; wine's `fixme:` stub chatter is off during the RTP installs
+  (`WINEDEBUG=fixme-all`, `err:`/`warn:` still print); the PSP smoke test writes
+  PPSSPP's `--log` HLE trace to the uploaded `psp-smoke` artifact instead of the
+  console, echoing the bring-up markers on success and the log tail on failure,
+  and its `--help` dump is gone; `apt-get`, `pip` and the pspdev `docker pull`
+  are quiet. The native MV/MZ smoke steps run through the new
+  `scripts/quiet_alsa.bash`, which strips the "cannot find card '0'" flood a
+  runner without a sound device produces — the same three patterns the boot
+  checks already filtered — while preserving the engine's exit status and its
+  `[MV-*]` markers.

--- a/scripts/download-lunatic-core.bash
+++ b/scripts/download-lunatic-core.bash
@@ -15,5 +15,6 @@ mkdir -p "$(dirname "$0")/../data"
 cd "$(dirname "$0")/../data"
 
 if [ ! -d Lunatic-Core ]; then
-    git clone --depth 1 https://github.com/KinoAR/Lunatic-Core.git Lunatic-Core
+    git clone --quiet --depth 1 https://github.com/KinoAR/Lunatic-Core.git \
+        Lunatic-Core
 fi

--- a/scripts/download-mtf-meido-action.bash
+++ b/scripts/download-mtf-meido-action.bash
@@ -13,7 +13,7 @@ mkdir -p $(dirname $0)/../data
 cd $(dirname $0)/../data
 
 if [ ! -d mtf-meido-action ] ; then
-    git clone --depth 1 --filter=blob:none --sparse \
+    git clone --quiet --depth 1 --filter=blob:none --sparse \
         https://github.com/lychees/mtf-meido-action.git
     git -C mtf-meido-action sparse-checkout set Debug
 fi

--- a/scripts/download-mv-corescript.bash
+++ b/scripts/download-mv-corescript.bash
@@ -18,7 +18,7 @@ sample="$here/data/mv-sample"
 cache="$here/data/.mv-corescript"
 
 if [ ! -d "$cache" ]; then
-    git clone --depth 1 https://github.com/rpgtkoolmv/corescript.git "$cache"
+    git clone --quiet --depth 1 https://github.com/rpgtkoolmv/corescript.git "$cache"
 fi
 
 mkdir -p "$sample/js/libs"

--- a/scripts/download-mz-corescript.bash
+++ b/scripts/download-mz-corescript.bash
@@ -20,7 +20,7 @@ sample="$here/data/mz-sample"
 cache="$here/data/.mz-corescript"
 
 if [ ! -d "$cache" ]; then
-    git clone --depth 1 https://github.com/stak/rmmz-corescript.git "$cache"
+    git clone --quiet --depth 1 https://github.com/stak/rmmz-corescript.git "$cache"
 fi
 
 mkdir -p "$sample/js/libs"

--- a/scripts/download-nepheshel.bash
+++ b/scripts/download-nepheshel.bash
@@ -6,10 +6,13 @@ mkdir -p $(dirname $0)/../data
 
 cd $(dirname $0)/../data
 
+# `wget -nv` / `unar -q`: without a terminal wget still prints a dot-progress
+# line per 50 KiB and unar names every file it extracts, which is thousands of
+# lines of CI log for one archive. Errors and the final summary still print.
 if [ ! -f Nepheshel206beta.zip ] ; then
-    wget -O Nepheshel206beta.zip "https://til.sakura.ne.jp/soft_free/nepheshel/Nepheshel206beta.zip"
+    wget -nv -O Nepheshel206beta.zip "https://til.sakura.ne.jp/soft_free/nepheshel/Nepheshel206beta.zip"
 fi
 
 if [ ! -d Nepheshel206beta ] ; then
-    unar Nepheshel206beta.zip
+    unar -q Nepheshel206beta.zip
 fi

--- a/scripts/download-opengame-xp.bash
+++ b/scripts/download-opengame-xp.bash
@@ -13,7 +13,7 @@ mkdir -p $(dirname $0)/../data
 cd $(dirname $0)/../data
 
 if [ ! -d OpenGame.exe ] ; then
-    git clone --depth 1 --filter=blob:none --sparse \
+    git clone --quiet --depth 1 --filter=blob:none --sparse \
         https://github.com/aphadeon/OpenGame.exe.git
     git -C OpenGame.exe sparse-checkout set Testbed/XP
 fi

--- a/scripts/download-prayforyou.bash
+++ b/scripts/download-prayforyou.bash
@@ -6,10 +6,11 @@ mkdir -p $(dirname $0)/../data
 
 cd $(dirname $0)/../data
 
+# See download-nepheshel.bash for why wget/unar are quietened.
 if [ ! -f PrayforYou.zip ] ; then
-    wget -O PrayforYou.zip "https://dl.fgamearchives.com/archives/win/3271/PrayforYou.zip"
+    wget -nv -O PrayforYou.zip "https://dl.fgamearchives.com/archives/win/3271/PrayforYou.zip"
 fi
 
 if [ ! -d PrayforYou ] ; then
-    unar PrayforYou.zip
+    unar -q PrayforYou.zip
 fi

--- a/scripts/quiet_alsa.bash
+++ b/scripts/quiet_alsa.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Run a command with ALSA's "no sound card" flood filtered out of its output.
+#
+# CI runners have no audio device, so every engine run prints a wall of
+# `ALSA lib confmisc.c:...: cannot find card '0'` / `snd_...` / `Unknown PCM`
+# lines that says nothing about the check being run. The boot checks
+# (rpg2k_boot_check.bash, mz_boot_check.bash) already strip exactly these three
+# patterns from the logs they print; this wrapper lets the smoke steps in
+# .github/workflows/build.yml do the same without each one re-spelling the
+# pipeline.
+#
+# The command's exit status is preserved (`pipefail` plus a filter that always
+# succeeds), so a failing engine still fails the step, and every non-ALSA line —
+# including the `[MV-*]` / `[MZ-*]` markers the smokes assert on — is passed
+# through untouched.
+#
+# Usage: ./scripts/quiet_alsa.bash <command> [args...]
+
+set -u -o pipefail
+
+"$@" 2>&1 | { grep -vE 'ALSA lib|snd_|Unknown PCM' || true; }

--- a/scripts/rtp_install.bash
+++ b/scripts/rtp_install.bash
@@ -4,12 +4,15 @@ set -eux
 
 cd $(dirname $0)
 
+# `wget -nv` / `unar -q`: without a terminal wget still prints a dot-progress
+# line per 50 KiB and unar names every file it extracts — the RTP archive alone
+# is thousands of lines of CI log. Errors and the final summary still print.
 if [ ! -f 2000rtp.zip ] ; then
-  wget https://cdn.tkool.jp/updata/rtp/2000rtp.zip
+  wget -nv https://cdn.tkool.jp/updata/rtp/2000rtp.zip
 fi
 
 if [ ! -d RTP* ] ; then
-  unar -e cp932 2000rtp.zip
+  unar -q -e cp932 2000rtp.zip
 fi
 
 if [ ! -f RTP2000RTP.exe ] ; then
@@ -26,6 +29,10 @@ Xvfb "${DISPLAY}" -screen 0 1920x1080x24 &
 
 export WINEDLLOVERRIDES="mscoree,mshtml="
 export LC_ALL=ja_JP.UTF-8
+# Silence wine's `fixme:` channel only — unimplemented-stub chatter that says
+# nothing about this install. `err:`/`warn:` still print, and the `ls` below
+# still fails the script if the RTP did not land.
+export WINEDEBUG=fixme-all
 
 winecfg /v win10
 cp setup.iss "${WINEPREFIX}/drive_c"

--- a/scripts/rtp_xp_install.bash
+++ b/scripts/rtp_xp_install.bash
@@ -4,12 +4,13 @@ set -eux
 
 cd $(dirname $0)
 
+# See rtp_install.bash for why wget/unar are quietened.
 if [ ! -f xp_rtp103.zip ] ; then
-  wget https://cdn.tkool.jp/updata/rtp/xp_rtp103.zip
+  wget -nv https://cdn.tkool.jp/updata/rtp/xp_rtp103.zip
 fi
 
 if [ ! -d RPGXP_RTP103 ] ; then
-  unar -e cp932 xp_rtp103.zip
+  unar -q -e cp932 xp_rtp103.zip
 fi
 
 if [ ! -v WINEPREFIX ] ; then
@@ -21,6 +22,9 @@ Xvfb "${DISPLAY}" -screen 0 1920x1080x24 &
 
 export WINEDLLOVERRIDES="mscoree,mshtml="
 export LC_ALL=ja_JP.UTF-8
+# Drop wine's `fixme:` stub chatter; `err:`/`warn:` still print. See
+# rtp_install.bash.
+export WINEDEBUG=fixme-all
 
 winecfg /v win10
 cp setup.iss "${WINEPREFIX}/drive_c"


### PR DESCRIPTION
## Summary
This PR significantly reduces CI log verbosity by suppressing non-essential output from various build and test steps, making logs easier to read and focusing on actual failures and important information.

## Key Changes

- **GitHub Actions checkout**: Added `show-progress: false` and `persist-credentials: false` to all checkout steps to eliminate fetch progress lines and post-job credential cleanup walks across 14 submodules
- **New script `scripts/quiet_alsa.bash`**: Filters out ALSA "cannot find card '0'" warnings that flood logs on runners without audio devices, while preserving command exit status and engine markers
- **MV/MZ smoke tests**: Wrapped all smoke test commands with `quiet_alsa.bash` to suppress audio device warnings
- **Download scripts**: Added `-nv` flag to `wget` and `-q` flag to `unar` in all RTP and game data download scripts to suppress progress output
- **Git clones**: Added `--quiet` flag to all `git clone` commands in download scripts
- **Wine configuration**: Added `WINEDEBUG=fixme-all` to RTP install scripts to silence stub implementation warnings while preserving errors
- **Package managers**: 
  - Made `apt-get` quiet with `-qq` flag and added `DEBIAN_FRONTEND=noninteractive`
  - Made `pip` quiet with `-q --disable-pip-version-check` flags
  - Made `docker pull` quiet with `-q` flag
- **PSP smoke test**: Refactored to write PPSSPP's HLE trace log to file instead of console, echoing only bring-up markers on success or log tail on failure; removed `--help` dump

## Implementation Details

- All changes preserve command exit statuses and error reporting—failures still fail the step
- Important markers like `[MV-*]` and `[MZ-*]` are preserved through the ALSA filter
- The `quiet_alsa.bash` wrapper uses `pipefail` and a filter that always succeeds to maintain proper error propagation
- Comments explain the rationale for each quieting measure to aid future maintenance
- A changelog entry documents all user-visible improvements

https://claude.ai/code/session_01MxcQvMxehmhwWL1Ks6QUdZ