### PR TITLE
Honor \> \< instant-display message spans

### DIFF
--- a/changelog.d/rpg2k-message-instant-span.added.md
+++ b/changelog.d/rpg2k-message-instant-span.added.md
@@ -1,0 +1,5 @@
+Message text between `\>` and `\<` now reveals instantly instead of typing out
+character by character (RPG2000's instant-display span). `Game::Message.scan`
+records the spans and `Game::TextReveal` collapses each one in a single frame,
+while still stopping at any `\!` / `\.` / `\|` pause that falls inside the span.
+An unclosed `\>` runs to the end of the line.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -400,9 +400,11 @@ The work below is roughly ordered by the critical path to a walkable game
   `\_` space). Text now **reveals gradually** (a `Game::TextReveal` typewriter
   driven by `Scene::Map`, with a button press completing the reveal before
   dismissing), and the **pacing codes act**: `Game::Message.scan` surfaces
-  `\!` (wait for a button), `\.` / `\|` (¼ / 1-second holds) and `\^` (close the
-  window without a keypress) in revealed-character coordinates, and the reveal
-  halts at each until released. `\c[n]` **colour codes** are
+  `\!` (wait for a button), `\.` / `\|` (¼ / 1-second holds), `\^` (close the
+  window without a keypress) and `\>` / `\<` (an **instant span** that reveals in
+  one frame) in revealed-character coordinates; the reveal halts at each pause
+  until released and collapses each instant span (still stopping at a pause that
+  falls inside it). `\c[n]` **colour codes** are
   drawn in colour: `Game::Message.parse` splits a line into `{text:, color:}`
   runs and `Scene::Map` draws each run in its palette colour, revealing across
   runs (`Game::Message.visible_segments`). **Message Options** (10120) and

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -32,10 +32,10 @@ module Game
 
   # Expansion of RPG2000 message control codes. `\v[n]` inserts variable n,
   # `\n[n]` the name of actor n, `\\` a literal backslash, `\_` a space; `\c[n]`
-  # changes colour. The pacing codes `\.`/`\|`/`\!` (waits) and `\^` (auto-close)
-  # are surfaced by #scan for the typewriter to act on; the remaining display
-  # codes (`\s` speed, `\>`/`\<`, `\$`) are dropped. `names` may be a Hash or any
-  # object responding to `[]`.
+  # changes colour. The pacing codes `\.`/`\|`/`\!` (waits), `\^` (auto-close) and
+  # `\>`/`\<` (instant span) are surfaced by #scan for the typewriter to act on;
+  # the remaining display codes (`\s` speed, `\$`) are dropped. `names` may be a
+  # Hash or any object responding to `[]`.
   module Message
     # Expand a line to its plain visible text (no colour information): the same
     # string the segments from #parse concatenate to.
@@ -62,10 +62,13 @@ module Game
     #   :pauses  — [{ at:, kind: }] for `\!` (:key, wait for a button), `\.`
     #              (:quarter) and `\|` (:full) timed holds;
     #   :auto_close — `\^` (close the window without a keypress once revealed);
+    #   :instants — [[start, end)] spans that reveal at once (`\>` … `\<`);
     #   :length  — the visible character count (what the reveal counts).
     def self.scan(text, variables, names)
       segs = []
       pauses = []
+      instants = []
+      instant_start = nil # character index where an open `\>` span began
       auto_close = false
       cur = ''
       color = 0
@@ -91,8 +94,14 @@ module Game
           when '|'      then pauses << { at: count, kind: :full }
           when '!'      then pauses << { at: count, kind: :key }
           when '^'      then auto_close = true
-          # other display codes (`\s` speed, `\>`/`\<`, `\$`) produce no
-          # characters and no pacing here: dropped.
+          when '>'      then instant_start = count if instant_start.nil?
+          when '<'
+            if instant_start
+              instants << [instant_start, count]
+              instant_start = nil
+            end
+          # other display codes (`\s` speed, `\$`) produce no characters and no
+          # pacing here: dropped.
           end
         else
           cur << ch
@@ -101,7 +110,9 @@ module Game
         end
       end
       segs << { text: cur, color: color } unless cur.empty?
-      { segments: segs, pauses: pauses, auto_close: auto_close, length: count }
+      instants << [instant_start, count] if instant_start # unclosed `\>` runs to EOL
+      { segments: segs, pauses: pauses, auto_close: auto_close,
+        instants: instants, length: count }
     end
 
     # Truncate per-line colour segments to the first `revealed` characters
@@ -212,7 +223,9 @@ module Game
     # coordinates, sorted ascending; the reveal will not advance past the next
     # unreleased one until the owner calls #release_pause. `auto_close` is the
     # `\^` flag (close the window without a keypress once fully revealed).
-    def initialize(lines, revealed = 0, pauses = [], auto_close = false)
+    # `instants` are [start, end) spans (`\>` … `\<`) that appear in one frame.
+    def initialize(lines, revealed = 0, pauses = [], auto_close = false,
+                   instants = [])
       @lines = lines || []
       @total = 0
       @lines.each { |l| @total += l.length }
@@ -221,6 +234,7 @@ module Game
       # has no Array#sort_by (the native engine aborts on it).
       @pauses = (pauses || []).sort { |a, b| a[:at] <=> b[:at] }
       @auto_close = auto_close ? true : false
+      @instants = instants || []
       @released = 0 # how many leading pauses the owner has let through
     end
 
@@ -237,12 +251,23 @@ module Game
     end
 
     # Reveal `n` more characters (default 1), never past the total nor past the
-    # next unreleased pause.
+    # next unreleased pause. When the newly revealed position lands inside an
+    # instant (`\>` … `\<`) span, the whole span appears at once (still capped at
+    # the pause limit).
     def advance(n = 1)
       n = 0 if n < 0
       stop = next_pause
       limit = stop ? stop[:at] : @total
-      @revealed = Game.clamp(@revealed + n, 0, limit)
+      pos = Game.clamp(@revealed + n, 0, limit)
+      pos = through_instant(pos) if pos > @revealed
+      @revealed = Game.clamp(pos, 0, limit)
+    end
+
+    # If the next character to reveal (`pos`) falls inside an instant span, jump
+    # to that span's end so it shows in one frame; otherwise return `pos`.
+    def through_instant(pos)
+      @instants.each { |a, b| return b if pos >= a && pos < b }
+      pos
     end
 
     # The next pause that still gates advancement (unreleased), or nil.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3143,10 +3143,12 @@ class RPG2k
         # the visible length of the lines before it) so one reveal counter drives
         # the whole window.
         pauses = []
+        instants = []
         auto_close = false
         offset = 0
         scans.each_with_index do |s, li|
           s[:pauses].each { |p| pauses << { at: offset + p[:at], kind: p[:kind] } }
+          (s[:instants] || []).each { |a, b| instants << [offset + a, offset + b] }
           auto_close ||= s[:auto_close]
           offset += plain[li].length
         end
@@ -3171,7 +3173,7 @@ class RPG2k
         contents = Bitmap.new(inner_w, inner_h)
 
         # Plain messages type out gradually; choice lists appear at once.
-        reveal = Game::TextReveal.new(plain, 0, pauses, auto_close)
+        reveal = Game::TextReveal.new(plain, 0, pauses, auto_close, instants)
         reveal.reveal_all if choice
         @message = { window: win, choice: choice, count: plain.length,
                      reveal: reveal, contents: contents, inner_w: inner_w,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -413,6 +413,40 @@ check 'Message.scan records pacing codes in revealed-char coordinates' do
   eq [{ at: 2, kind: :key }], s2[:pauses], '42 is two chars, so \\! sits at 2'
 end
 
+check 'Message.scan records \> \< instant spans (and an unclosed one to EOL)' do
+  vars = Object.new
+  def vars.[](_i); 0; end
+  names = ->(_i) { '' }
+  s = Game::Message.scan('ab\>cd\<ef', vars, names)
+  eq 6, s[:length], '"abcdef" = 6 visible characters'
+  eq [[2, 4]], s[:instants], 'cd is the instant span'
+  # An unclosed \> runs to the end of the line.
+  s2 = Game::Message.scan('ab\>cd', vars, names)
+  eq [[2, 4]], s2[:instants]
+end
+
+check 'TextReveal reveals an instant span in a single advance' do
+  # "ab" normal, "cd" instant (\> \<), "ef" normal -> instant span [2, 4).
+  r = Game::TextReveal.new(['abcdef'], 0, [], false, [[2, 4]])
+  r.advance(1)
+  eq 1, r.revealed, 'the first normal char reveals one at a time'
+  r.advance(1)                          # lands at 2 -> inside the span -> jump to 4
+  eq 4, r.revealed, 'the instant span appears at once'
+  r.advance(1)
+  eq 5, r.revealed, 'normal characters resume after the span'
+end
+
+check 'an instant span still stops at a pause inside it' do
+  # instant [1, 5) but a \! pause sits at 3: the span cannot leap past the pause.
+  r = Game::TextReveal.new(['abcdef'], 0, [{ at: 3, kind: :key }], false, [[1, 5]])
+  r.advance(1)                          # 0 -> 1 (span start); capped at the pause 3
+  eq 3, r.revealed, 'the instant leap is capped at the pause'
+  ok r.pending_pause, 'the pause gates the span'
+  r.release_pause
+  r.advance(1)                          # 3 -> 4, still inside the span -> jump to 5
+  eq 5, r.revealed, 'the rest of the span reveals once released'
+end
+
 # -- Screen (tint state machine) ---------------------------------------------
 
 check 'Screen starts neutral and settled' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -861,6 +861,22 @@ check 'a \\! pause holds the reveal until a button is pressed' do
   ok reveal.done?
 end
 
+check 'a \> \< instant span reveals far faster than the typewriter' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # 'a', a long instant span 'bcdefghij', then 'z' (11 visible characters).
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'a\\>bcdefghij\\<z')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  # At 2 chars/frame the plain typewriter would show ~4 characters in two frames;
+  # the instant span collapses, so 'a' + the whole span is already out.
+  2.times { RGSS::Input.reset; scene.update }
+  ok reveal.revealed >= 10, 'the instant span revealed all at once, not 2/frame'
+end
+
 # Tick a scene until its message window opens (or give up after `limit` frames).
 def open_msg(scene, limit = 15)
   msg = nil


### PR DESCRIPTION
## Summary
Completes the RPG2000 message pacing codes: text between `\>` and `\<` now reveals in a single frame instead of typing out character by character. This was the one pacing code deferred when the others (`\!`, `\.`, `\|`, `\^`) landed.

## Changes
- **`Game::Message.scan`** — records instant spans as `:instants` `[[start, end)]` in revealed-character coordinates (an unclosed `\>` runs to end-of-line).
- **`Game::TextReveal`** — takes the spans; `advance` jumps the cursor through a span the moment it enters one, so the whole span appears at once. A pause (`\!` / `\.` / `\|`) that falls inside a span still gates it — the leap is capped at the pause.
- **`Scene::Map#open_message`** — lifts each line's spans into global reveal coordinates alongside the pauses.

## Testing
- `scripts/rpg2k_logic_check.rb` — **297 checks pass** (adds: `scan` span recording incl. an unclosed `\>`; a span revealing in one advance; a span capped by a pause inside it).
- `scripts/rpg2k_scene_check.rb` — **95 checks pass** (adds an end-to-end check: a long instant span reveals far faster than the 2-chars/frame typewriter).

Uses only core mruby (`each`, no `sort_by`/enum-ext), so no native/CRuby divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_