### PR TITLE
Scale RPG2000 battle damage by the target's elemental resistance

### DIFF
--- a/changelog.d/rpg2k-battle-elemental-attributes.added.md
+++ b/changelog.d/rpg2k-battle-elemental-attributes.added.md
@@ -1,0 +1,16 @@
+- RPG Maker 2000: **battle damage now respects elemental attributes**. A weapon's
+  `attribute_set` (surfaced via `Game::Actor#weapon_attributes`) and a skill's
+  `attribute_effects` (`Game::Party#skill_attributes`) name the elements an attack
+  carries; each battler's per-attribute defence ranks
+  (`Game::Actor#attribute_ranks` / `Game::Enemy#attribute_ranks`, read from the
+  database `attribute_ranks` byte array) are snapshotted onto the `Combatant`.
+  `Battle#deal_attack` and the skill path scale the base damage by the target's
+  resistance before variance and criticals — rank A..E maps to 200 / 150 / 100 /
+  50 / 0 percent, taking the strongest matching element (EasyRPG's
+  `Attribute::ApplyAttributeMultiplier`), so a foe takes extra damage from a
+  weakness and takes none at all from an element it is immune to. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks (weakness amplifies, resistance halves,
+  immunity nullifies, the strongest element wins, an unlisted element is
+  unchanged, and the readers feed the snapshot). Per-attribute rate overrides
+  from the database Attribute table (every element currently uses the RPG2000
+  defaults) remain a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -368,9 +368,14 @@ The work below is roughly ordered by the critical path to a walkable game
   off for seeded / headless fights. A basic attack can land a **3x critical hit**
   at the attacker's database 1-in-N chance (actor `critical_rate`, enemy
   `critical_hit_chance`); no crit on a same-side hit. Characters wearing gear with
-  the **`prevent_critical`** flag can never be crit. Still to come: enemy-cast
-  infliction, elemental attributes, all-target skill/item
-  scopes, the per-terrain backdrop and the RPG2000 Game Over graphic.
+  the **`prevent_critical`** flag can never be crit. **Elemental attributes**
+  scale damage too: a weapon's `attribute_set` / a skill's `attribute_effects`
+  are matched against the target's per-attribute defence ranks (A..E → 200 / 150
+  / 100 / 50 / 0 percent, strongest element winning), so a foe is hurt more by a
+  weakness and can fully nullify an element it is immune to. Still to come:
+  enemy-cast infliction, all-target skill/item scopes, per-attribute rate
+  overrides from the Attribute table, the per-terrain backdrop and the RPG2000
+  Game Over graphic.
   The remaining event commands (tile substitution and other native-render
   effects) are TODO. **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1140,6 +1140,36 @@ module Game
       end
     end
 
+    # The actor's per-attribute defence ranks as `{ attribute_id => rank }`, read
+    # from the database row's `attribute_ranks` byte array (rank 0 = A, most
+    # vulnerable .. 4 = E, immune). An attribute the row omits defaults to C
+    # (100%) at the battle layer. A fixture row without the field yields {}.
+    def attribute_ranks
+      ranks = {}
+      arr = @db_row.respond_to?(:attribute_ranks) ? @db_row.attribute_ranks : nil
+      return ranks unless arr
+      arr.each_with_index { |v, i| ranks[i + 1] = v }
+      ranks
+    end
+
+    # The elemental attribute ids carried by the equipped weapon(s) — the item's
+    # `attribute_set` bool array (field 66), a flag per attribute — used to scale
+    # a basic attack's damage by the target's resistance. No item table (a
+    # fixture) or an unarmed actor carries none.
+    def weapon_attributes
+      return [] unless @db.respond_to?(:item)
+      ids = []
+      @equipment.each do |iid|
+        next if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next unless it && it.respond_to?(:type) && it.type == 1 # weapon slot only
+        set = it.respond_to?(:attribute_set) ? it.attribute_set : nil
+        next unless set
+        set.each_with_index { |on, i| ids << (i + 1) if on }
+      end
+      ids.uniq
+    end
+
     # Coerce an equipment spec (an EQUIP_ORDER hash, an array of ids, or nil) to a
     # five-slot array of integer item ids.
     def normalize_equipment(spec)
@@ -1832,6 +1862,17 @@ module Game
       sk.respond_to?(:variance) ? (sk.variance || 4) : 4
     end
 
+    # The elemental attribute ids a skill applies — its `attribute_effects` bool
+    # array (field 44), a flag per attribute — used to scale the skill's battle
+    # damage by the target's resistance. A fixture without the field applies none.
+    def skill_attributes(sk)
+      set = sk.respond_to?(:attribute_effects) ? sk.attribute_effects : nil
+      return [] unless set
+      ids = []
+      set.each_with_index { |on, i| ids << (i + 1) if on }
+      ids
+    end
+
     # The command numbers for casting `sk` from `caster` on `target` (both
     # Combatant snapshots): the caster's SP `cost`, and the signed HP / SP deltas
     # to the target — negative HP for an attack skill (base effect less a quarter
@@ -1845,7 +1886,7 @@ module Game
         dmg = 1 if dmg < 1
         { cost: cost, hp: -dmg, mp: 0,
           inflict: skill_state_ids(sk), chance: skill_hit(sk),
-          variance: skill_variance(sk) }
+          variance: skill_variance(sk), attributes: skill_attributes(sk) }
       else
         { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0 }
       end
@@ -2805,9 +2846,15 @@ module Game
                     else
                       0
                     end
+      # Per-attribute defence ranks ({ attribute_id => rank 0..4 }) from the
+      # enemy's attribute_ranks byte array, so an elemental attack scales its
+      # damage by this monster's resistance. Captured now since `row` isn't kept.
+      @attribute_ranks = {}
+      arr = row && row.respond_to?(:attribute_ranks) ? row.attribute_ranks : nil
+      arr.each_with_index { |v, i| @attribute_ranks[i + 1] = v } if arr
     end
 
-    attr_reader :crit_denom
+    attr_reader :crit_denom, :attribute_ranks
     def crit_denominator; @crit_denom; end
 
     def dead?; @hp <= 0; end
@@ -2847,8 +2894,9 @@ module Game
   # animate it action-by-action; `#run` steps to completion for a headless
   # resolution. It works on Combatant snapshots, so the caller can resolve a
   # battle without mutating the real party. This is a deliberately simple first
-  # cut — no skills, items, criticals, attributes, damage variance or escape yet
-  # — the turn-based battle *screen* and those refinements are still to come.
+  # cut — escape and enemy-cast state infliction are still to come, and the
+  # turn-based battle *screen* wires the refinements (skills, items, criticals,
+  # elemental attributes, damage variance) into a live fight.
   class Battle
     # A battler reduced to what the fight needs. Snapshotting Game::Actor /
     # Game::Enemy keeps the real party untouched by a resolved battle.
@@ -2861,7 +2909,7 @@ module Game
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
                            :actor, :states, :state_turns, :crit_denom,
-                           :prevents_crit) do
+                           :prevents_crit, :attr_ranks, :atk_attrs) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
@@ -2883,10 +2931,19 @@ module Game
     # Whether a battler's gear guards against critical hits.
     def self.prevents_crit_of(b); b.respond_to?(:prevents_critical?) && b.prevents_critical?; end
 
+    # A battler's per-attribute defence ranks ({ attribute_id => rank 0..4 }), or
+    # {} when the source (a bare fixture) doesn't model them.
+    def self.attr_ranks_of(b); b.respond_to?(:attribute_ranks) ? b.attribute_ranks : {}; end
+
+    # The elemental attribute ids a battler's basic attack carries (its equipped
+    # weapon's attribute_set); [] for an enemy or an unarmed / fixture attacker.
+    def self.atk_attrs_of(b); b.respond_to?(:weapon_attributes) ? b.weapon_attributes : []; end
+
     def self.from_actor(a)
       Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
-                    nil, crit_denom_of(a), prevents_crit_of(a))
+                    nil, crit_denom_of(a), prevents_crit_of(a),
+                    attr_ranks_of(a), atk_attrs_of(a))
     end
 
     # Enemies have no source actor (that field stays nil), so the post-battle
@@ -2894,7 +2951,8 @@ module Game
     def self.from_enemy(e)
       Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
                     nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
-                    crit_denom_of(e), prevents_crit_of(e))
+                    crit_denom_of(e), prevents_crit_of(e),
+                    attr_ranks_of(e), atk_attrs_of(e))
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -3002,10 +3060,11 @@ module Game
     # recovery) computed by Game::Party#battle_skill_command. Resolved in agility
     # order by #apply_command when the round runs.
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
-                      chance: 100, variance: 0)
+                      chance: 100, variance: 0, attributes: nil)
       ally.command = { kind: :skill, target: target, name: name,
                        cost: cost, hp: hp, mp: mp,
-                       inflict: inflict || [], chance: chance, variance: variance }
+                       inflict: inflict || [], chance: chance, variance: variance,
+                       attributes: attributes || [] }
       ally.action = nil; ally.defending = false
     end
 
@@ -3148,17 +3207,22 @@ module Game
       deal_attack(b, target)
     end
 
-    # `b` lands a basic attack on `target`: the base damage (optionally spread by
-    # variance), tripled on a critical hit, then halved (min 1) if the target
-    # defends. The crit note rides on the log entry.
+    # `b` lands a basic attack on `target`: the base damage (scaled by the
+    # target's elemental resistance, optionally spread by variance), tripled on a
+    # critical hit, then halved (min 1) if the target defends. A target immune to
+    # the weapon's element (0% rate) takes no damage. The crit note rides on the
+    # log entry.
     def deal_attack(b, target)
       dmg = Battle.attack_damage(b.atk, target.def)
-      dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance
+      # An elemental weapon scales its damage by the target's resistance before
+      # variance / criticals (EasyRPG's ApplyAttributeNormalAttackMultiplier).
+      dmg = dmg * attr_multiplier(b.atk_attrs, target) / 100
+      dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
       # No critical on a same-side hit (e.g. a confused ally striking an ally) or
       # against a target whose gear prevents criticals, matching EasyRPG.
       crit = critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit
       dmg *= 3 if crit
-      dmg = [dmg / 2, 1].max if target.defending
+      dmg = [dmg / 2, 1].max if target.defending && dmg > 0
       target.hp -= dmg
       { attacker: b.name, target: target.name, damage: dmg, critical: crit,
         target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead? }
@@ -3181,6 +3245,31 @@ module Game
       adj = 1 if adj < 1
       d = base + @rng.random(adj + 1) - adj / 2
       d < 1 ? 1 : d
+    end
+
+    # RPG2000's default attribute rate table: a defence rank of A..E (index 0..4)
+    # scales damage to 200 / 150 / 100 / 50 / 0 percent. (Per-attribute overrides
+    # from the database's Attribute table aren't modelled yet — every element uses
+    # these defaults.)
+    ATTR_RATE_PCT = [200, 150, 100, 50, 0].freeze
+
+    # The percentage `attr_ids` scale damage against `target`: the strongest
+    # (largest) rate among the attack's elements, per EasyRPG's
+    # Attribute::ApplyAttributeMultiplier (the physical / magical split isn't
+    # modelled). 100 (unchanged) for an attribute-less attack; a rank the target
+    # doesn't list defaults to C (100%).
+    def attr_multiplier(attr_ids, target)
+      return 100 if attr_ids.nil? || attr_ids.empty?
+      ranks = target.attr_ranks || {}
+      best = nil
+      attr_ids.each do |aid|
+        rank = ranks[aid] || 2
+        rank = 0 if rank < 0
+        rank = 4 if rank > 4
+        pct = ATTR_RATE_PCT[rank]
+        best = pct if best.nil? || pct > best
+      end
+      best || 100
     end
 
     # The most disruptive "forced action" restriction among `b`'s states (0 = act
@@ -3233,8 +3322,11 @@ module Game
       mp = cmd[:mp] || 0
       if hp < 0
         dmg = -hp
+        # An elemental skill scales its damage by the target's resistance first
+        # (EasyRPG's ApplyAttributeSkillMultiplier), then spreads by variance.
+        dmg = dmg * attr_multiplier(cmd[:attributes], target) / 100
         # Spread the skill's damage by its own variance when the fight rolls it.
-        dmg = varied(dmg, cmd[:variance]) if @variance && cmd[:variance] && cmd[:variance] > 0
+        dmg = varied(dmg, cmd[:variance]) if @variance && dmg > 0 && cmd[:variance] && cmd[:variance] > 0
         target.hp -= dmg
         # An attack skill may inflict its states on a surviving target, each
         # rolled against the skill's accuracy.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2329,7 +2329,8 @@ class RPG2k
                                           name: sk.name, cost: c[:cost],
                                           hp: c[:hp], mp: c[:mp],
                                           inflict: c[:inflict], chance: c[:chance],
-                                          variance: c[:variance] || 0)
+                                          variance: c[:variance] || 0,
+                                          attributes: c[:attributes])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1324,28 +1324,30 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :price, :skill_id,
                       :atk_points2, :def_points2, :spi_points2, :agi_points2,
                       :occasion_battle, :state_set, :reverse_state_effect,
-                      :prevent_critical)
+                      :prevent_critical, :attribute_set)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
-              state_set: nil, reverse_state: false, prevent_crit: false)
+              state_set: nil, reverse_state: false, prevent_crit: false,
+              attribute_set: nil)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
-               prevent_crit)
+               prevent_crit, attribute_set)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
                        :affect_hp, :affect_sp, :occasion_battle,
-                       :state_effects, :reverse_state_effect, :hit, :variance)
+                       :state_effects, :reverse_state_effect, :hit, :variance,
+                       :attribute_effects)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
                occ_battle: true, state_effects: nil, reverse_state: false, hit: 100,
-               variance: 4)
+               variance: 4, attribute_effects: nil)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
                 prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
-                variance)
+                variance, attribute_effects)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
 # per-turn slip damage (hp/sp change), action restriction and auto-recovery.
@@ -3832,6 +3834,103 @@ check 'Actor#prevents_critical? reads equipped prevent-critical gear' do
   eq true, Game::Battle.from_actor(a).prevents_crit  # carried onto the combatant
 end
 
+# -- Battle elemental attributes ----------------------------------------------
+# A weapon / skill carries a set of elements; the target's per-element rank
+# (0=A weakest .. 4=E immune) scales the damage 200/150/100/50/0 percent.
+
+check 'battle: an element the target is weak to amplifies the damage (rank A = 200%)' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1]                               # weapon carries element 1
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.attr_ranks = { 1 => 0 }                      # rank A -> 200%
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1)) # variance off
+  bat.begin_round
+  eq 40, bat.step_action[:damage]                    # base 20 * 200%
+end
+
+check 'battle: an element the target resists halves the damage (rank D = 50%)' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1]
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.attr_ranks = { 1 => 3 }                      # rank D -> 50%
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  bat.begin_round
+  eq 10, bat.step_action[:damage]
+end
+
+check 'battle: an element the target is immune to deals no damage (rank E = 0%)' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  slime.attr_ranks = { 1 => 4 }                      # rank E -> 0%
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  bat.begin_round
+  e = bat.step_action
+  eq 0, e[:damage]
+  eq 100, slime.hp, 'no HP lost'
+  ok !e[:defeated]
+end
+
+check 'battle: the attribute multiplier takes the strongest matching element' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1, 2]                             # two elements
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.attr_ranks = { 1 => 3, 2 => 0 }              # resists 1 (50%), weak to 2 (200%)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  bat.begin_round
+  eq 40, bat.step_action[:damage]                    # max(50%, 200%) -> 40
+end
+
+check 'battle: an unlisted element deals full (C = 100%) damage' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [5]                               # slime lists no rank for 5
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.attr_ranks = { 1 => 0 }
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  bat.begin_round
+  eq 20, bat.step_action[:damage]                    # unchanged base
+end
+
+check 'battle: an elemental skill scales its damage by the target resistance' do
+  mage = combatant_mp('Mage', 10, 0, 20, 100, 30)
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.attr_ranks = { 3 => 0 }                      # weak to element 3 (200%)
+  bat = Game::Battle.new([mage], [slime], Game::Rng.new(1)) # variance off
+  bat.command_skill(mage, slime, name: 'Flame', cost: 0, hp: -30, attributes: [3])
+  bat.begin_round
+  eq 60, bat.step_action[:damage]                    # 30 * 200%
+end
+
+check 'Party#battle_skill_command carries the skill elemental attributes' do
+  skills = { 7 => fake_skill(name: 'Ice', scope: 0, power: 20, mrate: 40,
+                             attribute_effects: [false, false, true]) } # element 3
+  st = skill_party(skills)
+  mage = Game::Battle.from_actor(st.party.actor_by_id(1))
+  slime = combatant('Slime', 0, 0, 5, 100)
+  c = st.party.battle_skill_command(st.party.db_skill(7), mage, slime)
+  eq [3], c[:attributes]
+end
+
+check 'Actor weapon/attribute readers feed the combatant snapshot' do
+  items = { 7 => fake_item(type: 1, atk: 10, attribute_set: [true, false, true]) }
+  st = item_party(items)                             # elements 1 & 3 on the weapon
+  a = st.party.actor_by_id(1)
+  eq [], a.weapon_attributes, 'nothing equipped yet'
+  a.equip([7, 0, 0, 0, 0])
+  eq [1, 3], a.weapon_attributes
+  eq [1, 3], Game::Battle.from_actor(a).atk_attrs, 'carried onto the combatant'
+end
+
+check 'Game::Enemy reads its per-attribute defence ranks' do
+  ranks_row = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                         :agility, :exp, :gold, :attribute_ranks)
+  db = BattleDB.new({ 5 => ranks_row.new('Golem', 100, 0, 10, 10, 5, 3, 20, 50,
+                                          [2, 4, 0]) }, {})
+  e = Game::Enemy.new(db, 5)
+  eq({ 1 => 2, 2 => 4, 3 => 0 }, e.attribute_ranks)
+  eq({ 1 => 2, 2 => 4, 3 => 0 }, Game::Battle.from_enemy(e).attr_ranks)
+end
+
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
                              mrate: 40, variance: 4) }
@@ -4055,7 +4154,8 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # atk 10, spi 12, maxSP 30
   foe = combatant('Foe', 0, 8, 5, 100)                      # def 8
   # skill_effect = 20 + 40*12/40 = 32; attack dmg = 32 - 8/4 = 30
-  eq({ cost: 6, hp: -30, mp: 0, inflict: [], chance: 100, variance: 4 },
+  eq({ cost: 6, hp: -30, mp: 0, inflict: [], chance: 100, variance: 4,
+       attributes: [] },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
   eq({ cost: 5, hp: 32, mp: 0 },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))


### PR DESCRIPTION
## Summary

Adds **elemental attributes** to the RPG Maker 2000 battle damage model. A weapon's `attribute_set` and a skill's `attribute_effects` name the elements an attack carries; each battler's per-attribute defence ranks scale the incoming damage.

- `Game::Actor#weapon_attributes` reads the equipped weapon's `attribute_set` (item field 66); `Game::Party#skill_attributes` reads a skill's `attribute_effects` (field 44).
- `Game::Actor#attribute_ranks` / `Game::Enemy#attribute_ranks` read the database `attribute_ranks` byte array. Both the attack's element ids and the target's ranks are snapshotted onto the `Combatant` (`atk_attrs` / `attr_ranks`).
- `Battle#deal_attack` and the skill damage path scale the base damage by the target's resistance **before** variance and criticals — rank A..E → 200 / 150 / 100 / 50 / 0 percent, taking the **strongest** matching element (per EasyRPG's `Attribute::ApplyAttributeMultiplier`). A target immune to the element (rank E) takes no damage.

The multiplier defaults to 100% (unchanged) for an attribute-less attack, so every existing seeded/exact-damage test is untouched. Wired into the live battle screen via `main.rb`'s `apply_pending_skill`.

Known simplifications (documented as follow-ups): the physical/magical attribute split isn't modelled, and per-attribute rate overrides from the database Attribute table aren't read yet — every element uses the RPG2000 default rates.

## Testing

- `scripts/rpg2k_logic_check.rb` — 303 checks pass, including 9 new ones: weakness amplifies (200%), resistance halves (50%), immunity nullifies (0%), the strongest element wins, an unlisted element is unchanged, an elemental skill scales, `battle_skill_command` carries the attributes, and the actor/enemy readers feed the snapshot.
- Scene (94) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_