### PR TITLE
Show the gold window on \$ in a message

### DIFF
--- a/changelog.d/rpg2k-message-gold-window.added.md
+++ b/changelog.d/rpg2k-message-gold-window.added.md
@@ -1,0 +1,4 @@
+A message containing `\$` now shows the party's gold in a small window
+alongside the text (RPG2000's money display), which closes together with the
+message. `Game::Message.scan` flags the code and `Scene::Map` builds and tears
+down the gold window with the message.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -402,7 +402,8 @@ The work below is roughly ordered by the critical path to a walkable game
   dismissing), and the **pacing codes act**: `Game::Message.scan` surfaces
   `\!` (wait for a button), `\.` / `\|` (¼ / 1-second holds) and `\^` (close the
   window without a keypress) in revealed-character coordinates, and the reveal
-  halts at each until released. `\c[n]` **colour codes** are
+  halts at each until released. `\$` opens a small **gold window** (the party's
+  money) alongside the message, closed with it. `\c[n]` **colour codes** are
   drawn in colour: `Game::Message.parse` splits a line into `{text:, color:}`
   runs and `Scene::Map` draws each run in its palette colour, revealing across
   runs (`Game::Message.visible_segments`). **Message Options** (10120) and

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -32,10 +32,10 @@ module Game
 
   # Expansion of RPG2000 message control codes. `\v[n]` inserts variable n,
   # `\n[n]` the name of actor n, `\\` a literal backslash, `\_` a space; `\c[n]`
-  # changes colour. The pacing codes `\.`/`\|`/`\!` (waits) and `\^` (auto-close)
-  # are surfaced by #scan for the typewriter to act on; the remaining display
-  # codes (`\s` speed, `\>`/`\<`, `\$`) are dropped. `names` may be a Hash or any
-  # object responding to `[]`.
+  # changes colour. The pacing codes `\.`/`\|`/`\!` (waits), `\^` (auto-close) and
+  # `\$` (show the gold window) are surfaced by #scan for the scene to act on; the
+  # remaining display codes (`\s` speed, `\>`/`\<`) are dropped. `names` may be a
+  # Hash or any object responding to `[]`.
   module Message
     # Expand a line to its plain visible text (no colour information): the same
     # string the segments from #parse concatenate to.
@@ -62,11 +62,13 @@ module Game
     #   :pauses  — [{ at:, kind: }] for `\!` (:key, wait for a button), `\.`
     #              (:quarter) and `\|` (:full) timed holds;
     #   :auto_close — `\^` (close the window without a keypress once revealed);
+    #   :show_gold — `\$` (show the party's gold in a small window);
     #   :length  — the visible character count (what the reveal counts).
     def self.scan(text, variables, names)
       segs = []
       pauses = []
       auto_close = false
+      show_gold = false
       cur = ''
       color = 0
       count = 0 # visible characters emitted so far (pause positions index this)
@@ -91,8 +93,9 @@ module Game
           when '|'      then pauses << { at: count, kind: :full }
           when '!'      then pauses << { at: count, kind: :key }
           when '^'      then auto_close = true
-          # other display codes (`\s` speed, `\>`/`\<`, `\$`) produce no
-          # characters and no pacing here: dropped.
+          when '$'      then show_gold = true # show the gold window
+          # other display codes (`\s` speed, `\>`/`\<`) produce no characters and
+          # no pacing here: dropped.
           end
         else
           cur << ch
@@ -101,7 +104,8 @@ module Game
         end
       end
       segs << { text: cur, color: color } unless cur.empty?
-      { segments: segs, pauses: pauses, auto_close: auto_close, length: count }
+      { segments: segs, pauses: pauses, auto_close: auto_close,
+        show_gold: show_gold, length: count }
     end
 
     # Truncate per-line colour segments to the first `revealed` characters

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3144,10 +3144,12 @@ class RPG2k
         # the whole window.
         pauses = []
         auto_close = false
+        show_gold = false
         offset = 0
         scans.each_with_index do |s, li|
           s[:pauses].each { |p| pauses << { at: offset + p[:at], kind: p[:kind] } }
           auto_close ||= s[:auto_close]
+          show_gold ||= s[:show_gold]
           offset += plain[li].length
         end
 
@@ -3173,12 +3175,14 @@ class RPG2k
         # Plain messages type out gradually; choice lists appear at once.
         reveal = Game::TextReveal.new(plain, 0, pauses, auto_close)
         reveal.reveal_all if choice
+        # `\$` shows the party's gold in a small window alongside the message.
+        gold_window = show_gold ? build_inn_gold_window(nonblank(db.term.gold, 'G')) : nil
         @message = { window: win, choice: choice, count: plain.length,
                      reveal: reveal, contents: contents, inner_w: inner_w,
                      seg_lines: seg_lines, face: face,
                      face_index: cfg.face_index,
                      face_x: face_right ? inner_w - FACE_SIZE : 0,
-                     text_x: text_x, text_w: text_w }
+                     text_x: text_x, text_w: text_w, gold_window: gold_window }
         draw_message_contents
         win.contents = contents
         @choice_index = 0
@@ -3412,6 +3416,7 @@ class RPG2k
       def close_message
         return unless @message
         @message[:window].dispose
+        @message[:gold_window].dispose if @message[:gold_window]
         @message = nil
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -413,6 +413,17 @@ check 'Message.scan records pacing codes in revealed-char coordinates' do
   eq [{ at: 2, kind: :key }], s2[:pauses], '42 is two chars, so \\! sits at 2'
 end
 
+check 'Message.scan flags \$ (show gold) and drops it from the text' do
+  vars = Object.new
+  def vars.[](_i); 0; end
+  names = ->(_i) { '' }
+  s = Game::Message.scan('Gold:\$ here', vars, names)
+  ok s[:show_gold], '\\$ sets show_gold'
+  eq 'Gold: here'.length, s[:length], '\\$ emits no visible character'
+  # No \$ -> flag stays off.
+  ok !Game::Message.scan('plain', vars, names)[:show_gold]
+end
+
 # -- Screen (tint state machine) ---------------------------------------------
 
 check 'Screen starts neutral and settled' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -861,6 +861,28 @@ check 'a \\! pause holds the reveal until a button is pressed' do
   ok reveal.done?
 end
 
+check 'a message with \$ shows a gold window; a plain one does not' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'Rich! \\$')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message opened'
+  gw = msg[:gold_window]
+  ok gw, 'the \\$ gold window is present'
+  ok gw.visible, 'and visible'
+
+  # A plain message (no \$) shows no gold window.
+  auto2 = page(trigger: 3)
+  auto2.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hello')]
+  scene2 = new_scene({ 1 => event(2, 2, auto2) }, player: [5, 5])
+  msg2 = nil
+  12.times { scene2.update; msg2 = scene2.instance_variable_get(:@message); break if msg2 }
+  ok msg2, 'plain message opened'
+  ok msg2[:gold_window].nil?, 'no \\$ -> no gold window'
+end
+
 # Tick a scene until its message window opens (or give up after `limit` frames).
 def open_msg(scene, limit = 15)
   msg = nil


### PR DESCRIPTION
## Summary
RPG2000's `\$` message control code displays the party's current gold in a small window beside the text. It was previously parsed-and-dropped; now it acts.

## Changes
- **`Game::Message.scan`** — flags `\$` as `:show_gold` (it emits no visible character).
- **`Scene::Map#open_message`** — when any line requested it, builds a gold window (reusing the existing inn gold-window helper, top-right) and stores it on the message.
- **`Scene::Map#close_message`** — disposes the gold window with the message.

## Notes
The window reuses the inn's top-right gold display; the exact RPG_RT corner is a cosmetic detail that can be pinned by a wine diff later.

## Testing
- `scripts/rpg2k_logic_check.rb` — **295 checks pass** (adds: `\$` sets `:show_gold` and emits no character; absent → flag off).
- `scripts/rpg2k_scene_check.rb` — **95 checks pass** (adds: a `\$` message shows a visible gold window; a plain message shows none).

Core mruby only — no `sort_by`/enum-ext divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_