### PR TITLE
Track save / battle / win / defeat / escape counts

### DIFF
--- a/changelog.d/rpg2k-play-counters.added.md
+++ b/changelog.d/rpg2k-play-counters.added.md
@@ -1,0 +1,5 @@
+The RPG2000 play counters now advance and are readable through the Control
+Variables "Other" operand: the **save count** bumps on each save, and the
+**battle / win / defeat / escape counts** bump when an Enemy Encounter starts
+and resolves. All five persist in the save (and default to 0 in an older save),
+so events keyed on how many battles were fought or won now work.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -234,7 +234,9 @@ The work below is roughly ordered by the critical path to a walkable game
   Variables** reads not just constants and other variables but also a **random**
   range, an **actor stat** (level / EXP / HP / MP / max HP-MP / attack / defence /
   spirit / agility), an **item** count (number held, or number equipped across the
-  party), **game quantities** (party gold, timer seconds, party size) and a
+  party), **game quantities** (party gold, timer seconds, party size, and the
+  **save / battle / win / defeat / escape counts** — running tallies bumped by
+  Save and by each Enemy Encounter and its outcome, persisted in the save) and a
   **character position** (the hero's or a map event's map id / x / y / facing —
   an event's map id reads 0, matching an RPG_RT 2000 quirk; screen coordinates
   are not modelled).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3503,6 +3503,11 @@ module Game
     # a command overrides it (the map's own rate then applies). No encounter
     # subsystem consumes it yet — kept for save fidelity.
     attr_accessor :encounter_rate
+    # Running tallies RPG2000 keeps and exposes through the Control Variables
+    # "Other" operand: how many times the game was saved, and how many battles
+    # were fought / won / lost / escaped. All persist in the save.
+    attr_accessor :save_count, :battle_count, :win_count, :defeat_count,
+                  :escape_count
     # Teleport / Escape skill destinations registered by Set Teleport Target
     # (11810) and Set Escape Target (11830). `teleport_targets` is a hash keyed
     # by map id → `{ x:, y:, switch_id: }`; `escape_target` is nil or one such
@@ -3550,6 +3555,11 @@ module Game
       @memorized_bgm = nil
       @player_transparent = false
       @encounter_rate = nil
+      @save_count = 0
+      @battle_count = 0
+      @win_count = 0
+      @defeat_count = 0
+      @escape_count = 0
       @teleport_targets = {}
       @escape_target = nil
       @system_bgm = {}
@@ -3659,6 +3669,9 @@ module Game
         player_transparent: @player_transparent, weather: @weather.to_h,
         teleport_access: @teleport_access, escape_access: @escape_access,
         encounter_rate: @encounter_rate, teleport_targets: @teleport_targets,
+        save_count: @save_count, battle_count: @battle_count,
+        win_count: @win_count, defeat_count: @defeat_count,
+        escape_count: @escape_count,
         escape_target: @escape_target, system_bgm: @system_bgm,
         system_sfx: @system_sfx, screen_transitions: @screen_transitions,
         system_graphic: @system_graphic, font_id: @font_id,
@@ -4017,6 +4030,11 @@ module Game
       # Registries default empty / unset; a save written before these existed
       # simply restores nothing.
       state.encounter_rate = h[:encounter_rate]
+      state.save_count = h[:save_count] || 0
+      state.battle_count = h[:battle_count] || 0
+      state.win_count = h[:win_count] || 0
+      state.defeat_count = h[:defeat_count] || 0
+      state.escape_count = h[:escape_count] || 0
       state.teleport_targets = h[:teleport_targets] || {}
       state.escape_target = h[:escape_target]
       state.system_bgm = h[:system_bgm] || {}

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -412,6 +412,12 @@ module Game
     # command carries [Victory] / [Escape] / [Defeat] handler branches, jump into
     # the matching one. A game-over on defeat is the scene's concern.
     def resume_battle(result)
+      # Tally the outcome for the Control Variables "Other" operand.
+      case result
+      when :victory then @state.win_count += 1
+      when :defeat  then @state.defeat_count += 1
+      when :escape  then @state.escape_count += 1
+      end
       if result == :escape && @battle_escape_aborts
         @index = @list.size
         @call_stack = []
@@ -876,6 +882,7 @@ module Game
         allow_escape: escape_mode != 0, first_strike: cmd.param(5) != 0,
         defeat_game_over: cmd.param(4) == 0
       }
+      @state.battle_count += 1 # a battle was entered (Control Variables "Other")
       @wait_kind = :battle
       @waiting = true
     end
@@ -998,13 +1005,19 @@ module Game
     end
 
     # Operand type 7: a miscellaneous game quantity selected by param5 (0 party
-    # gold, 1 timer seconds, 2 the number of party members). Other selectors
-    # (steps, play time, save / battle counts) are not modelled and read as 0.
+    # gold, 1 timer seconds, 2 party members, 3 save count, 4 battle count,
+    # 5 win count, 6 defeat count, 7 escape/run count). Remaining RPG2003-only
+    # selectors are not modelled and read as 0.
     def other_operand(cmd)
       case cmd.param(5)
       when 0 then party.gold
       when 1 then @state.timer_seconds
       when 2 then party.actors.size
+      when 3 then @state.save_count
+      when 4 then @state.battle_count
+      when 5 then @state.win_count
+      when 6 then @state.defeat_count
+      when 7 then @state.escape_count
       else 0
       end
     end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -4979,6 +4979,7 @@ class RPG2k
   # State#to_lsd, so the slot is readable by real RPG_RT/EasyRPG tooling. The
   # export is best-effort: a failure there is logged but never fails the save.
   def save_game state, slot = 1
+    state.save_count += 1 # RPG2000 counts each save; persisted in the dump below
     data = Marshal.dump state.to_h
     File.open(save_path(slot), "wb") { |f| f.write data }
     export_lsd(state, slot)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1439,6 +1439,22 @@ check 'State save round-trips the message configuration' do
   legacy_loaded = Game::State.load(db, legacy)
   eq true, legacy_loaded.menu_access, 'absent menu access defaults on'
   eq true, legacy_loaded.save_access, 'absent save access defaults on'
+
+  # The save / battle tallies round-trip, and default to 0 in a legacy save.
+  st.save_count = 4
+  st.battle_count = 7
+  st.win_count = 5
+  st.defeat_count = 1
+  st.escape_count = 1
+  counted = Game::State.load(db, st.to_h)
+  eq 4, counted.save_count, 'save count round-trips'
+  eq 7, counted.battle_count, 'battle count round-trips'
+  eq 5, counted.win_count
+  eq 1, counted.defeat_count
+  eq 1, counted.escape_count
+  legacy2 = st.to_h
+  legacy2.delete(:battle_count)
+  eq 0, Game::State.load(db, legacy2).battle_count, 'absent battle count defaults 0'
 end
 
 check 'Vehicle: unplaced by default, placed once positioned' do
@@ -2237,6 +2253,41 @@ check 'Control Variables reads the party size (operand type 7, selector 2)' do
   it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 7, 2])]) # var1 = party size
   it.update
   eq 2, st.variables[1]
+end
+
+check 'Control Variables reads the save / battle / win / defeat / escape counts' do
+  st = new_state
+  st.save_count = 3
+  st.battle_count = 9
+  st.win_count = 6
+  st.defeat_count = 1
+  st.escape_count = 2
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 7, 3]),   # save count
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 7, 4]),   # battle count
+            FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 7, 5]),   # win count
+            FakeCmd.new(IC::CONTROL_VARS, [0, 4, 4, 0, 7, 6]),   # defeat count
+            FakeCmd.new(IC::CONTROL_VARS, [0, 5, 5, 0, 7, 7])])  # escape count
+  it.update
+  eq 3, st.variables[1]
+  eq 9, st.variables[2]
+  eq 6, st.variables[3]
+  eq 1, st.variables[4]
+  eq 2, st.variables[5]
+end
+
+check 'battle counters advance: Enemy Encounter and its outcome' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # Enemy Encounter (troop 1, no handlers): suspends on a :battle wait.
+  it.start([FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 1, 0, 0, 0, 0])])
+  it.update
+  eq 1, st.battle_count, 'entering a battle bumps the battle count'
+  eq 0, st.win_count
+  it.resume_battle(:victory)
+  eq 1, st.win_count, 'a victory bumps the win count'
+  eq 0, st.defeat_count
+  eq 0, st.escape_count
 end
 
 check 'Control Variables reads item count and equipped count (operand type 4)' do


### PR DESCRIPTION
## Summary
RPG2000's Control Variables **"Other"** operand exposes five running tallies (selectors 3–7) that were previously modelled as `0`. They're now tracked and readable.

## Changes
- **`Game::State`** — adds `save_count`, `battle_count`, `win_count`, `defeat_count`, `escape_count` (default 0), round-tripped through `to_h` / `from_h` (an older save without them loads as 0).
- **`save_game`** (`main.rb`) — bumps `save_count` before serializing, so the dump records the new count (matching RPG_RT).
- **Interpreter** — `do_enemy_encounter` bumps `battle_count` when a battle is entered; `resume_battle` bumps `win_count` / `defeat_count` / `escape_count` by outcome. `other_operand` selectors 3–7 read them (order matches EasyRPG: save, battle, win, defeat, run/escape).

## Testing
- `scripts/rpg2k_logic_check.rb` — **308 checks pass** (adds: Control Variables reading all five counts; the counters advancing on Enemy Encounter + a `:victory` outcome; and the counts round-tripping through a save, defaulting to 0 when absent).
- `scripts/rpg2k_scene_check.rb` — **95 checks pass**.

Model-only, core mruby — no rendering or native path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_