### PR TITLE
Add the Change Parallax Background event command (11720)

### DIFF
--- a/changelog.d/rpg2k-change-parallax-background.added.md
+++ b/changelog.d/rpg2k-change-parallax-background.added.md
@@ -1,0 +1,10 @@
+- RPG Maker 2000: the **Change Parallax Background** event command (11720) now
+  swaps a map's panorama at runtime. The interpreter records a
+  `Game::State#parallax` override — the `Panorama/<name>` image plus the
+  horizontal / vertical loop and autoscroll (enable + speed) settings, matching
+  EasyRPG's `SetParallax` parameter order — and raises a one-shot rebuild request
+  the map scene polls (`take_parallax_request`) to tear down and recreate the
+  parallax sprite mid-map. `Scene::Map#setup_parallax` now prefers the override
+  over the map's own panorama fields, and the override is dropped on the next map
+  change (like shown pictures), so a teleport restores the destination map's own
+  backdrop. Covered by new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -132,7 +132,12 @@ The work below is roughly ordered by the critical path to a walkable game
   in the real Nepheshel data (all 45 parallax maps' images resolve and every
   offset stays in range across a camera sweep) and pinned by
   `scripts/rpg2k_render_check.rb`. The scroll *rate* mirrors EasyRPG's formulae
-  but still wants a native/wine visual diff to confirm.
+  but still wants a native/wine visual diff to confirm. The **Change Parallax
+  Background** event command (11720) swaps this panorama at runtime — the
+  interpreter records a `Game::State#parallax` override (name + loop / autoscroll
+  settings, per EasyRPG's `SetParallax`) and flags a one-shot rebuild the scene
+  polls; the override is dropped on the next map change so the destination map's
+  own panorama returns.
 - ✅ Character sprites — the party leader and every map event render from their
   CharSet graphic (`Game::CharSet`, 4-direction, 3 walk frames). Events also
   draw a chipset tile when their graphic is a tile substitution (empty CharSet
@@ -188,7 +193,8 @@ The work below is roughly ordered by the critical path to a walkable game
   Erase / Show Screen, Tint Screen, Flash Screen, Shake Screen, Pan Screen,
   Show/Move/Erase Picture,
   Weather Effects, Call
-  Event, Move Event, Change / Trade Event Location, Change Map Tileset, Proceed
+  Event, Move Event, Change / Trade Event Location, Change Map Tileset,
+  Change Parallax Background, Proceed
   With Movement, Halt All Movement,
   Erase Event, Return to Title, End Event) with a per-frame step cap so a bad
   loop can't hang. **Memorize Location** stores the player's current map id, x and y

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3569,7 +3569,27 @@ module Game
       # Shown pictures, id => Game::Picture. Transient like @screen (RPG2000's
       # HUD pictures are re-shown by parallel events on load), so not serialised.
       @pictures = {}
+      # Runtime parallax override from a Change Parallax Background command (nil =
+      # use the map's own panorama). Transient like @pictures: RPG2000 resets it
+      # to the map's default on every map change, so it is not serialised.
+      @parallax = nil
     end
+
+    # The Change Parallax Background override (a hash of name / loop / autoscroll
+    # settings), or nil when the map's own panorama applies.
+    attr_reader :parallax
+
+    # Change Parallax Background: override the current map's panorama. `opts`
+    # carries :name, :loop_x, :loop_y, :auto_x, :sx, :auto_y, :sy (see the
+    # interpreter). An empty name leaves the backdrop blank. Scene::Map rebuilds
+    # its parallax sprite from this override.
+    def set_parallax(opts)
+      @parallax = opts
+    end
+
+    # Drop any parallax override so the map's own panorama applies again. Called
+    # on a map change, alongside erase_all_pictures.
+    def clear_parallax; @parallax = nil; end
 
     attr_reader :pictures, :vehicles
     # The vehicle the party is currently riding (:boat / :ship / :airship), or

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -98,6 +98,7 @@ module Game
       PLAY_MEMORIZED_BGM = 11540
       PLAY_SE          = 11550
       CHANGE_MAP_TILESET = 11710
+      CHANGE_PARALLAX  = 11720
       CHANGE_ENCOUNTER_RATE = 11740
       SET_TELEPORT_TARGET = 11810
       CHANGE_TELEPORT_ACCESS = 11820
@@ -135,6 +136,7 @@ module Game
       @halt_movement_requested = false
       @actor_graphic_changed = false
       @tileset_request = nil
+      @parallax_changed = false
       @input_variable = nil
       @input_digits = 1
       # Deterministic RNG for the Control Variables "random" operand (mruby has
@@ -169,6 +171,7 @@ module Game
       @actor_graphic_changed = false
       @system_graphic_changed = false
       @tileset_request = nil
+      @parallax_changed = false
       # Messages queued by a stat command (a Change Level / Change EXP with its
       # "show message" flag set) and shown one after another before the event
       # continues. Drained by #resume, so it survives the reset_waits between
@@ -218,6 +221,16 @@ module Game
       id = @tileset_request
       @tileset_request = nil
       id
+    end
+
+    # True (once) if a Change Parallax Background command replaced the map's
+    # panorama since the last call, clearing the flag. The owning scene polls
+    # this after #update and rebuilds the parallax sprite from the new override
+    # (Game::State#parallax). Non-blocking, like Change Map Tileset.
+    def take_parallax_request
+      v = @parallax_changed
+      @parallax_changed = false
+      v
     end
 
     # True (once) if a Halt All Movement command ran since the last call, clearing
@@ -564,6 +577,7 @@ module Game
       when Cmd::PLAY_MEMORIZED_BGM then do_play_memorized_bgm cmd
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
       when Cmd::CHANGE_MAP_TILESET then @tileset_request = cmd.param(0)
+      when Cmd::CHANGE_PARALLAX   then do_change_parallax cmd
       when Cmd::CHANGE_ENCOUNTER_RATE then @state.encounter_rate = cmd.param(0)
       when Cmd::SET_TELEPORT_TARGET then do_set_teleport_target cmd
       when Cmd::SET_ESCAPE_TARGET   then do_set_escape_target cmd
@@ -1744,6 +1758,21 @@ module Game
     def do_change_system_graphic(cmd)
       @state.set_system_graphic(cmd.string || '', cmd.param(1))
       @system_graphic_changed = true
+    end
+
+    # Change Parallax Background (11720): replace the current map's panorama at
+    # runtime. The command string names the Panorama/<name> image; param0/1 are
+    # the horizontal / vertical loop flags, param2/4 enable horizontal / vertical
+    # autoscroll and param3/5 give their speeds (per EasyRPG's SetParallax). An
+    # empty name clears the backdrop. Stored as a Game::State override (reset on
+    # the next map change, like shown pictures) and flagged so the scene rebuilds
+    # the parallax sprite mid-map.
+    def do_change_parallax(cmd)
+      @state.set_parallax(name: (cmd.string || '').to_s,
+                          loop_x: cmd.param(0) != 0, loop_y: cmd.param(1) != 0,
+                          auto_x: cmd.param(2) != 0, sx: cmd.param(3),
+                          auto_y: cmd.param(4) != 0, sy: cmd.param(5))
+      @parallax_changed = true
     end
 
     # Change System BGM: override one of the system music slots (battle,

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -780,17 +780,17 @@ class RPG2k
       # backdrop the plain void — when the map has no parallax or the image is
       # missing.
       def setup_parallax
-        u = @map.unit
-        return unless (u.parallax_flag rescue false)
-        name = (u.parallax_name rescue '').to_s
+        cfg = parallax_config
+        return unless cfg
+        name = cfg[:name].to_s
         return if name.empty?
         @parallax_img = Bitmap.new "Panorama/#{name}"
-        @par_loop_x = (u.parallax_loop_x rescue false) ? true : false
-        @par_loop_y = (u.parallax_loop_y rescue false) ? true : false
-        @par_auto_x = (u.parallax_autoloop_x rescue false) ? true : false
-        @par_auto_y = (u.parallax_autoloop_y rescue false) ? true : false
-        @par_sx = (u.parallax_sx rescue 0) || 0
-        @par_sy = (u.parallax_sy rescue 0) || 0
+        @par_loop_x = cfg[:loop_x] ? true : false
+        @par_loop_y = cfg[:loop_y] ? true : false
+        @par_auto_x = cfg[:auto_x] ? true : false
+        @par_auto_y = cfg[:auto_y] ? true : false
+        @par_sx = cfg[:sx] || 0
+        @par_sy = cfg[:sy] || 0
         @parallax_sprite = Sprite.new
         @parallax_sprite.z = -1
         @parallax_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
@@ -798,6 +798,22 @@ class RPG2k
       rescue StandardError => e
         $stderr.puts "[RPG2k] parallax load failed, no backdrop drawn: #{e.message}"
         @parallax_img = nil
+      end
+
+      # The parallax settings to draw: a Change Parallax Background override
+      # (Game::State#parallax) when one is active, otherwise the map's own
+      # panorama fields. nil when the map declares no parallax and none was set.
+      def parallax_config
+        ov = @state.parallax
+        return ov if ov
+        u = @map.unit
+        return nil unless (u.parallax_flag rescue false)
+        { name: (u.parallax_name rescue '').to_s,
+          loop_x: (u.parallax_loop_x rescue false),
+          loop_y: (u.parallax_loop_y rescue false),
+          auto_x: (u.parallax_autoloop_x rescue false),
+          auto_y: (u.parallax_autoloop_y rescue false),
+          sx: (u.parallax_sx rescue 0), sy: (u.parallax_sy rescue 0) }
       end
 
       # The CharSet bitmap for an event graphic `name`, cached (including a
@@ -1067,6 +1083,7 @@ class RPG2k
         apply_location_requests(it, p[:event])
         apply_erase_request(it, p[:event])
         apply_tileset_request(it)
+        apply_parallax_request(it)
       rescue StandardError
         nil
       end
@@ -1457,6 +1474,32 @@ class RPG2k
         nil
       end
 
+      # -- Change Parallax Background -----------------------------------------
+
+      # If the interpreter ran a Change Parallax Background this step, tear down
+      # the old panorama sprite and rebuild it from the new override
+      # (Game::State#parallax). The override lasts until the next map load (see
+      # perform_teleport, which clears it), when the map's own panorama returns.
+      def apply_parallax_request(interp)
+        return unless interp.take_parallax_request
+        dispose_parallax
+        setup_parallax
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Change Parallax Background failed: #{e.message}"
+        nil
+      end
+
+      # Release the current parallax sprite / buffers before a rebuild, so a
+      # mid-map panorama swap does not leak the old bitmaps.
+      def dispose_parallax
+        @parallax_sprite.dispose if @parallax_sprite
+        @parallax_bmp.dispose if @parallax_bmp
+        @parallax_img.dispose if @parallax_img
+        @parallax_sprite = nil
+        @parallax_bmp = nil
+        @parallax_img = nil
+      end
+
       # -- Move Event (Set Move Route) ----------------------------------------
 
       # Apply the Move Event requests an interpreter queued this step. `this_event`
@@ -1745,6 +1788,7 @@ class RPG2k
           apply_halt_request(@interpreter)
           apply_graphic_change(@interpreter)
           apply_tileset_request(@interpreter)
+          apply_parallax_request(@interpreter)
         end
       end
 
@@ -3061,6 +3105,12 @@ class RPG2k
         # pictures on top of the first room and the map is never visible —
         # exactly what the wine comparison showed (ADR 0021).
         @state.erase_all_pictures
+        # A Change Parallax Background override does not survive a teleport
+        # either; the destination map's own panorama applies. Rebuild the
+        # backdrop from the new map so it isn't drawn with the old one.
+        @state.clear_parallax
+        dispose_parallax
+        setup_parallax
         # ... nor does a Pan Screen offset / camera lock: the camera re-centres
         # on the hero on the new map. Nepheshel's opening pans a long way before
         # teleporting into the first room, and keeping that offset drew the room

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3052,6 +3052,40 @@ check 'Change Map Tileset queues a one-shot tileset request, non-blocking' do
   eq nil, it.take_tileset_request, 'and clears after the first read'
 end
 
+# -- Change Parallax Background -----------------------------------------------
+
+check 'Change Parallax Background records a state override, non-blocking' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  eq nil, st.parallax, 'no override to start (the map panorama applies)'
+  # string = panorama; [loop_x, loop_y, auto_x, sx, auto_y, sy].
+  it.start([FakeCmd.new(IC::CHANGE_PARALLAX, [1, 0, 1, 3, 0, -2], string: 'Sky'),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'Change Parallax must not pause the interpreter'
+  eq true, st.switches[1], 'the command after it still ran'
+  eq({ name: 'Sky', loop_x: true, loop_y: false, auto_x: true, sx: 3,
+       auto_y: false, sy: -2 }, st.parallax)
+end
+
+check 'Change Parallax Background flags a one-shot rebuild request' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_PARALLAX, [0, 0, 0, 0, 0, 0], string: 'Cave')])
+  it.update
+  eq true, it.take_parallax_request, 'the scene is told to rebuild once'
+  eq false, it.take_parallax_request, 'and the flag clears after one read'
+end
+
+check 'clear_parallax drops the override so the map panorama returns' do
+  st = party_state
+  st.set_parallax(name: 'Sky', loop_x: true, loop_y: true,
+                  auto_x: false, sx: 0, auto_y: false, sy: 0)
+  ok !st.parallax.nil?, 'override is set'
+  st.clear_parallax
+  eq nil, st.parallax, 'cleared on a map change'
+end
+
 # -- Weather Effects ----------------------------------------------------------
 
 check 'Weather Effects sets the weather type and strength, non-blocking' do


### PR DESCRIPTION
## Summary

Implements the RPG Maker 2000 **Change Parallax Background** event command (11720), which swaps a map's panorama at runtime.

- The interpreter's `do_change_parallax` records a `Game::State#parallax` override — the `Panorama/<name>` image plus the horizontal/vertical loop and autoscroll (enable + speed) settings, following EasyRPG's `SetParallax` parameter order (`string`, `params[0..5]`).
- It raises a one-shot rebuild flag (`take_parallax_request`) the map scene polls after `#update` — mirroring the existing Change Map Tileset pattern — so the parallax sprite is torn down and recreated mid-map (non-blocking; the rest of the command list runs on).
- `Scene::Map#setup_parallax` now consults a `parallax_config` helper that prefers the override over the map's own `parallax_*` fields.
- The override is transient (not serialised, like shown pictures) and cleared on the next map change; `perform_teleport` now also rebuilds the panorama so the destination map's own backdrop applies (previously the parallax wasn't rebuilt on teleport at all).

Parameter layout grounded against EasyRPG Player's `Game_Interpreter::CommandChangePBG` / `Game_Map::SetParallax`.

## Testing

- `scripts/rpg2k_logic_check.rb` — 309 checks pass, including 3 new ones: the override hash is recorded and the following command still runs (non-blocking), the one-shot rebuild request reports once then clears, and `clear_parallax` drops the override.
- Scene (95) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_