### PR TITLE
Use switch items (type 9) from the field menu

### DIFF
--- a/changelog.d/rpg2k-switch-item.added.md
+++ b/changelog.d/rpg2k-switch-item.added.md
@@ -1,0 +1,4 @@
+Switch items (item type 9) can now be used from the field item menu: using one
+turns on the game switch it names and consumes one from the bag.
+`Game::Party#use_switch_item` consumes the item and returns the switch id, and
+the item menu sets it — so events gated on that switch fire.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -536,9 +536,12 @@ The work below is roughly ordered by the critical path to a walkable game
   `can_cast?` / `skill_effect` / `cast_skill` for skills) and `Game::Actor`
   (`next_level_exp` / `exp_to_next` for status), covered by
   `scripts/rpg2k_logic_check.rb`; the RGSS windows are the untestable-here UI.
-  Switch (type 9) item use, teleport/escape/switch skill types, the battle-time
-  skill variance, the item usable-occasion gate, and two-handed / dual-wield
-  equipping are later refinements.
+  A **switch item** (type 9) is field-usable too: `Game::Party#use_switch_item`
+  consumes one and returns the game switch it turns on, which the item menu then
+  sets (matching EasyRPG, where the scene owns the switch table).
+  Teleport/escape/switch skill types, the battle-time skill variance, the item
+  usable-occasion gate, and two-handed / dual-wield equipping are later
+  refinements.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1493,11 +1493,12 @@ module Game
 
     # RPG2000 database item types. Types 1..5 are the equipment slots (see
     # Actor::EQUIP_ORDER); 6 is a healing medicine (薬); 7 is a skill book (本)
-    # that teaches a skill; 8 is a seed (種) that permanently raises a stat.
-    # Switch (9) menu use is a later refinement.
+    # that teaches a skill; 8 is a seed (種) that permanently raises a stat;
+    # 9 is a switch item (スイッチ) that turns on a game switch when used.
     ITEM_MEDICINE = 6
     ITEM_SKILL_BOOK = 7
     ITEM_SEED = 8
+    ITEM_SWITCH = 9
 
     # The database row for a held item id, or nil when the database has no item
     # table (a bare test fixture) or no such row.
@@ -1511,7 +1512,24 @@ module Game
     def field_usable?(id)
       it = db_item(id)
       return false unless it && item_count(id) > 0
-      it.type == ITEM_MEDICINE || it.type == ITEM_SKILL_BOOK || it.type == ITEM_SEED
+      it.type == ITEM_MEDICINE || it.type == ITEM_SKILL_BOOK ||
+        it.type == ITEM_SEED || it.type == ITEM_SWITCH
+    end
+
+    # Whether item `id` is a switch item (turns on a game switch when used).
+    def switch_item?(id)
+      it = db_item(id)
+      !it.nil? && it.type == ITEM_SWITCH
+    end
+
+    # Use a switch item from the field menu: consume one and return the id of the
+    # switch to turn on (the caller owns the switch table). nil when `id` is not a
+    # switch item the party holds, so nothing is consumed. Matches EasyRPG, where
+    # UseItem consumes and the scene flips the switch.
+    def use_switch_item(id)
+      return nil unless switch_item?(id) && item_count(id) > 0
+      lose_item(id, 1)
+      db_item(id).switch_id
     end
 
     # The bag's field-usable items as `[id, count]` pairs in ascending id order,
@@ -1562,6 +1580,8 @@ module Game
         !s.nil? && s != 0 && !actor.knows_skill?(s)
       when ITEM_SEED
         seed_boosts(it).any? { |b| b != 0 }
+      when ITEM_SWITCH
+        true # a switch item always flips its switch
       else
         false
       end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -4096,9 +4096,11 @@ class RPG2k
         return if items.empty?
         id, = items[@item_index]
         it = @state.party.db_item(id)
-        # Only an all-ally medicine skips the target prompt; single-target
-        # medicines and skill books (always one actor) ask who to use it on.
-        if it && it.scope == 1 && it.type == Game::Party::ITEM_MEDICINE
+        # A switch item has no actor target; an all-ally medicine skips the
+        # target prompt; single-target medicines / skill books ask who to use on.
+        if it && it.type == Game::Party::ITEM_SWITCH
+          apply_switch_item(id)
+        elsif it && it.scope == 1 && it.type == Game::Party::ITEM_MEDICINE
           apply_item(id, nil)
         else
           @pending_item = id
@@ -4106,6 +4108,14 @@ class RPG2k
           @target_index = 0
           build_target_window
         end
+      end
+
+      # A switch item turns on its game switch (the party consumes one); the menu
+      # owns the switch table.
+      def apply_switch_item(id)
+        sid = @state.party.use_switch_item(id)
+        @state.switches[sid] = true if sid
+        show_message(sid ? "Switch turned on." : "It had no effect.", :used)
       end
 
       def update_target

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1369,16 +1369,16 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :price, :skill_id,
                       :atk_points2, :def_points2, :spi_points2, :agi_points2,
                       :occasion_battle, :state_set, :reverse_state_effect,
-                      :prevent_critical, :attribute_set)
+                      :prevent_critical, :attribute_set, :switch_id)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
-              attribute_set: nil)
+              attribute_set: nil, switch_id: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
-               prevent_crit, attribute_set)
+               prevent_crit, attribute_set, switch_id)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -1811,6 +1811,23 @@ check 'field_items lists only held medicines, in id order with counts' do
   st.party.gain_item(5, 1)
   st.party.gain_item(7, 1)   # weapon in the bag but not usable from the menu
   eq [[5, 1], [9, 2]], st.party.field_items
+end
+
+check 'a switch item is field-usable, effective, and flips its switch on use' do
+  items = { 4 => fake_item(type: 9, switch_id: 12, name: 'Whistle') }
+  st = item_party(items)
+  st.party.gain_item(4, 2)
+  eq [[4, 2]], st.party.field_items, 'switch items appear in the field menu'
+  ok st.party.switch_item?(4)
+  ok st.party.item_effective?(4, st.party.leader), 'a switch item is always effective'
+  # Using it consumes one and returns the switch to flip; the caller sets it.
+  sid = st.party.use_switch_item(4)
+  eq 12, sid, 'use returns the switch id'
+  eq 1, st.party.item_count(4), 'one is consumed'
+  st.switches[sid] = true
+  ok st.switches[12], 'the switch is now on'
+  # A non-switch (or absent) item flips nothing and consumes nothing.
+  ok st.party.use_switch_item(999).nil?, 'a non-switch item is not a switch use'
 end
 
 check 'item_recovery sums the flat amount and the percentage (integer math)' do


### PR DESCRIPTION
## Summary
A **switch item** (RPG2000 item type 9) turns on the game switch it names when used. It was previously a documented "later refinement"; now it works from the field item menu.

## Changes
- **`Game::Party`** — adds `switch_item?(id)` and `use_switch_item(id)`, which consumes one from the bag and returns the switch id to flip (nil when it isn't a held switch item). `field_usable?` and `item_effective?` now accept type-9 items. This matches EasyRPG, where `UseItem` consumes and the scene owns the switch table.
- **`Scene::ItemMenu`** — a switch item applies immediately (no actor-target prompt); the menu sets the returned switch on `@state.switches`.

## Notes
The usable-occasion gate and returning to the map so a triggered parallel runs remain later refinements (as noted in the TODO).

## Testing
- `scripts/rpg2k_logic_check.rb` — **308 checks pass** (adds: a switch item is field-usable and always effective; `use_switch_item` consumes one and returns the switch id; a non-switch/absent item flips nothing). Extended the `FakeItem` fixture with `switch_id`.
- `scripts/rpg2k_scene_check.rb` — **96 checks pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_