### PR TITLE
Gate the field item menu on the usable-field occasion

### DIFF
--- a/changelog.d/rpg2k-item-field-occasion.added.md
+++ b/changelog.d/rpg2k-item-field-occasion.added.md
@@ -1,0 +1,4 @@
+The field item menu now honours an item's "usable in field" occasion: a
+medicine or switch item flagged battle-only (`occasion_field` off) no longer
+appears in the field item list, mirroring how the battle item list already
+hides field-only items. Skill books and seeds remain field-only as before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -546,10 +546,12 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_logic_check.rb`; the RGSS windows are the untestable-here UI.
   A **switch item** (type 9) is field-usable too: `Game::Party#use_switch_item`
   consumes one and returns the game switch it turns on, which the item menu then
-  sets (matching EasyRPG, where the scene owns the switch table).
-  Teleport/escape/switch skill types, the battle-time skill variance, the item
-  usable-occasion gate, and two-handed / dual-wield equipping are later
-  refinements.
+  sets (matching EasyRPG, where the scene owns the switch table). The **usable
+  occasion** is honoured on both sides: a medicine / switch item flagged
+  battle-only (`occasion_field` off) is hidden from the field menu, and one
+  flagged field-only is hidden from the battle item list (books / seeds stay
+  field-only). Teleport/escape/switch skill types, the battle-time skill
+  variance, and two-handed / dual-wield equipping are later refinements.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1508,12 +1508,23 @@ module Game
     end
 
     # Whether item `id` can be used from the field (main-menu) item screen: a
-    # medicine, a skill book or a seed the party actually holds.
+    # medicine or switch item the party holds whose "usable in field" occasion is
+    # set (a battle-only medicine is hidden here, mirroring #battle_usable?), or a
+    # skill book / seed (always field-only, no occasion to gate on).
     def field_usable?(id)
       it = db_item(id)
       return false unless it && item_count(id) > 0
-      it.type == ITEM_MEDICINE || it.type == ITEM_SKILL_BOOK ||
-        it.type == ITEM_SEED || it.type == ITEM_SWITCH
+      case it.type
+      when ITEM_MEDICINE, ITEM_SWITCH then field_item_occasion?(it)
+      when ITEM_SKILL_BOOK, ITEM_SEED then true
+      else false
+      end
+    end
+
+    # Whether item `it` may be used from the field menu. Defaults to usable when
+    # the row (a bare fixture) carries no `occasion_field` flag.
+    def field_item_occasion?(it)
+      it.respond_to?(:occasion_field) ? it.occasion_field : true
     end
 
     # Whether item `id` is a switch item (turns on a game switch when used).

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1369,16 +1369,16 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :price, :skill_id,
                       :atk_points2, :def_points2, :spi_points2, :agi_points2,
                       :occasion_battle, :state_set, :reverse_state_effect,
-                      :prevent_critical, :attribute_set, :switch_id)
+                      :prevent_critical, :attribute_set, :switch_id, :occasion_field)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
-              attribute_set: nil, switch_id: 0)
+              attribute_set: nil, switch_id: 0, occ_field: true)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
-               prevent_crit, attribute_set, switch_id)
+               prevent_crit, attribute_set, switch_id, occ_field)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -1827,6 +1827,23 @@ check 'field_items lists only held medicines, in id order with counts' do
   st.party.gain_item(5, 1)
   st.party.gain_item(7, 1)   # weapon in the bag but not usable from the menu
   eq [[5, 1], [9, 2]], st.party.field_items
+end
+
+check 'a battle-only medicine is hidden from the field menu but shown in battle' do
+  items = {
+    5 => fake_item(type: 6, rhp: 50, occ_field: true,  occ_battle: false), # field only
+    6 => fake_item(type: 6, rhp: 50, occ_field: false, occ_battle: true),  # battle only
+  }
+  st = item_party(items)
+  st.party.gain_item(5, 1)
+  st.party.gain_item(6, 1)
+  ok st.party.field_usable?(5), 'the field medicine is usable in the field'
+  ok !st.party.field_usable?(6), 'the battle-only medicine is hidden from the field'
+  eq [[5, 1]], st.party.field_items
+  # ... and the reverse holds for the battle item list.
+  ok st.party.battle_usable?(6), 'the battle-only medicine is usable in battle'
+  ok !st.party.battle_usable?(5), 'the field-only medicine is not usable in battle'
+  eq [[6, 1]], st.party.battle_items
 end
 
 check 'a switch item is field-usable, effective, and flips its switch on use' do


### PR DESCRIPTION
## Summary
The battle item list already hides items whose "usable in battle" occasion is off, but the **field** item menu ignored the parallel `occasion_field` flag — so a battle-only medicine wrongly appeared in the field menu. Now both sides gate symmetrically.

## Changes
- **`Game::Party#field_usable?`** — a medicine or switch item is field-usable only when its `occasion_field` is set; a battle-only one is hidden. Skill books and seeds stay unconditionally field-only (no occasion to gate, and no risk of hiding valid items from real data).
- **`Game::Party#field_item_occasion?`** (new) — mirrors `battle_item_occasion?`, defaulting to usable when a bare fixture carries no flag (so existing behavior/tests are unchanged).

## Testing
- `scripts/rpg2k_logic_check.rb` — **314 checks pass** (adds: a battle-only medicine is hidden from `field_items`/`field_usable?` but present in `battle_items`, and vice-versa). Extended the `FakeItem` fixture with `occasion_field`.
- `scripts/rpg2k_scene_check.rb` — **96 checks pass**.

Model-only, core mruby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWH32j1TFxEEZ3mAi6L7MW)_