### PR TITLE
Let the party flee an RPG2000 battle with an agility-based escape chance

### DIFF
--- a/changelog.d/rpg2k-battle-escape.added.md
+++ b/changelog.d/rpg2k-battle-escape.added.md
@@ -1,0 +1,11 @@
+- RPG Maker 2000: the party can now **flee a battle**. `Game::Battle#attempt_escape`
+  rolls the RPG2000 escape chance — EasyRPG's `150 - 100 · avg_enemy_agi /
+  avg_party_agi`, clamped to 0..100, so a nimbler party gets away more often —
+  and a preemptive first strike always succeeds. A successful escape ends the
+  fight as `:escaped` (`Battle#escaped?`); a failed attempt raises the next try
+  by 10 points and forfeits the party's round via the new `Battle#command_skip`,
+  so every member skips its turn while the enemies still act. The battle scene's
+  Escape command (cancel on the first actor's menu) now routes through this roll
+  instead of guaranteeing a getaway. Covered by new `scripts/rpg2k_logic_check.rb`
+  checks (agility-ratio chance and its clamps, a successful flee, the +10 on
+  failure, the preemptive auto-escape, a decided-fight no-op, and command_skip).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -380,10 +380,14 @@ The work below is roughly ordered by the critical path to a walkable game
   scale damage too: a weapon's `attribute_set` / a skill's `attribute_effects`
   are matched against the target's per-attribute defence ranks (A..E → 200 / 150
   / 100 / 50 / 0 percent, strongest element winning), so a foe is hurt more by a
-  weakness and can fully nullify an element it is immune to. Still to come:
-  enemy-cast infliction, all-target skill/item scopes, per-attribute rate
-  overrides from the Attribute table, the per-terrain backdrop and the RPG2000
-  Game Over graphic.
+  weakness and can fully nullify an element it is immune to. The party can also
+  **flee**: `Battle#attempt_escape` rolls EasyRPG's agility-ratio chance
+  (`150 - 100·enemyAgi/partyAgi`, clamped), a preemptive first strike always
+  gets away, and a failed attempt forfeits the party's round (every member
+  skips, the enemies still act) while raising the next try by 10 points. Still
+  to come: enemy-cast infliction, all-target skill/item scopes, per-attribute
+  rate overrides from the Attribute table, the per-terrain backdrop and the
+  RPG2000 Game Over graphic.
   The remaining event commands (tile substitution and other native-render
   effects) are TODO. **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2950,14 +2950,15 @@ module Game
     # Game::Enemy keeps the real party untouched by a resolved battle.
     # `action` is the ally's chosen attack target for the round (nil = none /
     # auto), `defending` halves damage taken that round, and `command` is a
-    # queued Skill / Item action (see Battle#apply_command); all three are
-    # cleared each round. Enemies leave them nil and attack a random party
+    # queued Skill / Item action (see Battle#apply_command); these are
+    # cleared each round. `skip` forfeits the turn outright (a failed escape).
+    # Enemies leave them nil and attack a random party
     # member. `mp` / `max_mp` carry SP (skills spend it) and `spi` is the spirit
     # stat the skill formulas read as `int`.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
                            :actor, :states, :state_turns, :crit_denom,
-                           :prevents_crit, :attr_ranks, :atk_attrs) do
+                           :prevents_crit, :attr_ranks, :atk_attrs, :skip) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
@@ -3034,6 +3035,8 @@ module Game
       @criticals = criticals
       @rounds = 0
       @result = nil
+      @escaped = false     # set once the party successfully flees (#attempt_escape)
+      @escape_chance = nil # lazily computed from agilities on the first attempt
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
     end
@@ -3048,8 +3051,12 @@ module Game
     RESTRICTION_ATTACK_ENEMY = 2
     RESTRICTION_ATTACK_ALLY  = 3
 
-    # True once one side has been wiped out (the battle is decided).
-    def finished?; !alive?(@allies) || !alive?(@enemies); end
+    # True once one side has been wiped out, or the party has fled — the battle
+    # is decided.
+    def finished?; @escaped || !alive?(@allies) || !alive?(@enemies); end
+
+    # Whether the party successfully escaped this fight.
+    def escaped?; @escaped; end
 
     # Persist the fight's outcome onto the real party: write each ally combatant's
     # final status set, HP and SP back to its source actor, so damage taken in
@@ -3085,10 +3092,11 @@ module Game
       end
     end
 
-    # Step the fight to completion and return :victory or :defeat.
+    # Step the fight to completion and return :victory, :defeat or (if the party
+    # fled via #attempt_escape) :escaped.
     def run
       step until finished? || @rounds > MAX_ROUNDS
-      @result = alive?(@allies) ? :victory : :defeat
+      @result ||= alive?(@allies) ? :victory : :defeat
     end
 
     # Assign an ally's action for the coming round: attack `target`, or defend
@@ -3100,6 +3108,50 @@ module Game
 
     def command_defend(ally)
       ally.action = nil; ally.defending = true; ally.command = nil
+    end
+
+    # Forfeit `ally`'s action for the round — it neither attacks nor gains a
+    # defend's damage cut — used when a failed escape costs the party its turn.
+    # Cleared with the other commands at #end_round.
+    def command_skip(ally)
+      ally.action = nil; ally.defending = false; ally.command = nil; ally.skip = true
+    end
+
+    # Average agility of the living battlers on `side` (0 when the side is wiped).
+    def avg_agi(side)
+      living = side.reject(&:dead?)
+      return 0 if living.empty?
+      living.reduce(0) { |s, b| s + b.agi } / living.size
+    end
+
+    # The party's current escape chance as a percentage (0..100). On the first
+    # attempt it is EasyRPG's InitEscapeChance -- 150 - 100 * enemyAgi / partyAgi,
+    # clamped -- so a nimbler party flees more often and a slower one struggles;
+    # an agility-less party falls back to a coin toss. Each failed attempt adds
+    # 10 (see #attempt_escape).
+    def escape_chance
+      return @escape_chance unless @escape_chance.nil?
+      pa = avg_agi(@allies)
+      ea = avg_agi(@enemies)
+      base = pa > 0 ? 100 * ea / pa : 100
+      @escape_chance = Game.clamp(150 - base, 0, 100)
+    end
+
+    # Attempt to flee the fight. A `preemptive` first strike always succeeds;
+    # otherwise a 0..99 roll under #escape_chance wins. Success ends the battle as
+    # :escaped (#finished? / #escaped?); a failure raises the next attempt's
+    # chance by 10 (per EasyRPG) and returns false, leaving the fight running so
+    # the enemies still take their round.
+    def attempt_escape(preemptive = false)
+      return false if finished?
+      if preemptive || @rng.random(100) < escape_chance
+        @escaped = true
+        @result = :escaped
+        true
+      else
+        @escape_chance = escape_chance + 10
+        false
+      end
     end
 
     # Queue a single-target Skill for `ally`: cast on `target` (an enemy for an
@@ -3173,8 +3225,10 @@ module Game
     # Close a round begun with #begin_round: clear each ally's chosen action (so
     # the next round starts fresh) and settle the result once a side is wiped.
     def end_round
-      @allies.each { |a| a.action = nil; a.defending = false; a.command = nil }
-      @result = alive?(@allies) ? :victory : :defeat if finished?
+      @allies.each do |a|
+        a.action = nil; a.defending = false; a.command = nil; a.skip = false
+      end
+      @result = alive?(@allies) ? :victory : :defeat if finished? && !@escaped
     end
 
     private
@@ -3241,6 +3295,8 @@ module Game
     # has no living target). A defending target takes half damage (min 1). An
     # ally with a queued Skill / Item command resolves that instead.
     def strike(b)
+      # A battler that forfeited its turn (a failed escape) does nothing.
+      return nil if b.skip
       # A "forced action" restriction (berserk / confused) overrides the chosen
       # command / defend with a basic attack on a forced target.
       r = battler_restriction(b)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2249,12 +2249,27 @@ class RPG2k
           select_battle_command
         elsif Input.trigger?(Input::B)
           if @battle_ui[:actor_i].zero?
-            finish_battle(:escape) if @battle_ui[:req][:allow_escape]
+            try_battle_escape if @battle_ui[:req][:allow_escape]
           else
             @battle_ui[:actor_i] -= 1 # re-command the previous member
             @battle_ui[:cmd] = 0
             draw_battle_command
           end
+        end
+      end
+
+      # Escape command (cancel on the first actor's menu): roll the party's
+      # agility-based escape chance. On success flee the fight; on a failed roll
+      # the party forfeits the round — every member skips and only the enemies
+      # act — and the next attempt is likelier (Game::Battle#attempt_escape).
+      def try_battle_escape
+        battle = @battle_ui[:battle]
+        if battle.attempt_escape
+          finish_battle(:escape)
+        else
+          $stderr.puts '[RPG2k battle] escape failed'
+          living_allies.each { |a| battle.command_skip(a) }
+          start_round_animation
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4078,6 +4078,61 @@ check 'Game::Enemy reads its per-attribute defence ranks' do
   eq({ 1 => 2, 2 => 4, 3 => 0 }, Game::Battle.from_enemy(e).attr_ranks)
 end
 
+# -- Battle escape ------------------------------------------------------------
+
+def escape_battle(party_agi, enemy_agi, seed = 1)
+  Game::Battle.new([combatant('Hero', 0, 0, party_agi, 10)],
+                   [combatant('Slime', 8, 0, enemy_agi, 10)], Game::Rng.new(seed))
+end
+
+check 'Battle#escape_chance scales with the agility ratio, clamped 0..100' do
+  eq 50,  escape_battle(10, 10).escape_chance, 'equal agility -> 150 - 100 = 50'
+  eq 100, escape_battle(20, 5).escape_chance,  'a much faster party clamps at 100'
+  eq 0,   escape_battle(5, 20).escape_chance,  'a much slower party clamps at 0'
+end
+
+check 'Battle#attempt_escape flees the fight when the roll succeeds' do
+  b = escape_battle(20, 5)                            # 100% chance
+  ok b.attempt_escape, 'a 100% chance always flees'
+  ok b.finished?, 'the fight is over'
+  ok b.escaped?, 'flagged as escaped'
+  eq :escaped, b.run, 'and the result stays :escaped'
+end
+
+check 'a failed escape raises the next attempt chance by 10, fight continues' do
+  b = escape_battle(5, 20)                            # 0% chance -> always fails
+  eq 0, b.escape_chance, 'a much slower party starts at 0%'
+  ok !b.attempt_escape, 'and cannot flee'
+  eq 10, b.escape_chance, 'but the next attempt is 10 points likelier'
+  ok !b.finished?, 'the fight is still on'
+  ok !b.escaped?
+end
+
+check 'a preemptive escape always succeeds regardless of the roll' do
+  b = escape_battle(5, 20)                            # 0% by agility...
+  ok b.attempt_escape(true), '...but a first strike guarantees the getaway'
+  eq :escaped, b.result
+end
+
+check 'attempt_escape is a no-op once the battle is already decided' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  downed = combatant('Slime', 0, 0, 5, 0)            # already wiped -> victory
+  b = Game::Battle.new([hero], [downed], Game::Rng.new(1))
+  ok b.finished?, 'enemies already down'
+  ok !b.attempt_escape, 'no escape from a decided fight'
+  ok !b.escaped?
+end
+
+check 'command_skip forfeits an ally turn while the enemies still act' do
+  hero = combatant('Hero', 40, 0, 20, 100)           # faster, acts first
+  slime = combatant('Slime', 20, 0, 5, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  b.command_skip(hero)
+  b.run_round
+  eq 100, slime.hp, 'the hero forfeited its attack'
+  ok hero.hp < 100, 'but the slime still struck back'
+end
+
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
                              mrate: 40, variance: 4) }


### PR DESCRIPTION
## Summary

Adds **party escape** to the RPG Maker 2000 battle model — previously the scene's Escape command was a guaranteed getaway.

- `Game::Battle#attempt_escape` rolls the RPG2000 escape chance: `escape_chance = clamp(150 − 100·avg_enemy_agi/avg_party_agi, 0, 100)`, so a nimbler party gets away more often. A `preemptive` first strike always succeeds.
- A success ends the fight as `:escaped` (`Battle#escaped?`, `#finished?`, `#run` all honor it). A failure raises the next attempt's chance by 10 points and forfeits the party's round via the new `Battle#command_skip` — every member skips its turn (no attack, no defend bonus) while the enemies still act.
- The battle scene's Escape command (cancel on the first actor's menu) now routes through `attempt_escape` instead of unconditionally fleeing; on failure it commands every living ally to skip and plays out the enemies' round.

Formula grounded against EasyRPG Player's `Scene_Battle::TryEscape` / `InitEscapeChance`.

## Testing

- `scripts/rpg2k_logic_check.rb` — 319 checks pass, including 6 new ones: the agility-ratio chance and its 0/100 clamps, a successful flee ending as `:escaped`, the +10 bump on a failed attempt (fight continues), the preemptive auto-escape, a no-op on an already-decided fight, and `command_skip` forfeiting a turn while the enemy still strikes.
- Scene (96) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_