### PR TITLE
Grab the screen: snap_to_bitmap, real scene transitions, and a render probe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,8 +177,9 @@ jobs:
       # never collide. `xvfb-run -a` (auto-picked display) is deliberately
       # avoided: its server-number probe is not atomic, so concurrent -a runs
       # can grab the same display, killing one Xvfb out from under its client
-      # ("XIO: fatal IO error"). Reserved numbers: exe_open=99 (see the ctest
-      # `exe_open` test in CMakeLists.txt); MV runs=100..108, the RPG2k
+      # ("XIO: fatal IO error"). Reserved numbers: exe_open=99 and
+      # render_probe=98 (see those ctest tests in CMakeLists.txt, both run by
+      # the `test` step below); MV runs=100..108, the RPG2k
       # real-game boot smoke=109..110, the MZ boot smoke=111, and the RPG XP
       # real-game boot smoke=112 below. Every
       # smoke here must use a distinct --server-num (never `-a`), or its

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,8 +344,8 @@ if(NOT EMSCRIPTEN)
   # `-a`'s auto server-number probe is not atomic — concurrent probes can pick
   # the same display, so one Xvfb loses its server and the client dies with an
   # "XIO: fatal IO error". Each concurrent run gets its own reserved number
-  # (exe_open=99, MV runs=100..104 in .github/workflows/build.yml) so they can
-  # never collide.
+  # (exe_open=99, render_probe=98, MV runs=100..104 in
+  # .github/workflows/build.yml) so they can never collide.
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(exe_open_cmd xvfb-run --server-num=99
                      "--server-args=-screen 0 640x480x24" ${exe_open_cmd})
@@ -353,5 +353,24 @@ if(NOT EMSCRIPTEN)
   add_test(
     NAME exe_open
     COMMAND ${exe_open_cmd}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+  # The RGSS screen effects (Viewport#color, Viewport#tone) are native rendering
+  # that mruby_test cannot reach: that binary has no display, so a Viewport
+  # cannot even be constructed. This runs the real renderer and *measures* the
+  # frame through Graphics.snap_to_bitmap, so the failure mode where the effect
+  # code runs and the screen never changes fails a test instead of shipping. It
+  # needs no game directory — the probe builds its own sprite (RGSS.effect_probe
+  # in mruby-rgss/mrblib/lib.rb).
+  set(render_probe_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
+                       --rgss_effect_probe --width=544 --height=416)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(render_probe_cmd
+        xvfb-run --server-num=98 "--server-args=-screen 0 640x480x24"
+        ${render_probe_cmd})
+  endif()
+  add_test(
+    NAME render_probe
+    COMMAND ${render_probe_cmd}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/changelog.d/rgss-snap-to-bitmap-transitions.added.md
+++ b/changelog.d/rgss-snap-to-bitmap-transitions.added.md
@@ -1,0 +1,38 @@
+- **`RGSS::Graphics.snap_to_bitmap`, and real `freeze`/`transition` on top of
+  it — scenes dissolve into each other.** Every RGSS scene change goes through
+  `Scene_Base#perform_transition`: freeze the frame, build the next scene behind
+  it, dissolve the still away. Both halves were `warn_stub` no-ops that only
+  burned the right number of frames, and `snap_to_bitmap` (which `Scene_Title`
+  calls outright) did not exist at all.
+  - `snap_to_bitmap` is native: `lv_snapshot_take` re-renders the active screen's
+    object tree into an ARGB8888 buffer. That is the only capture that works on
+    every backend here — the SDL window, the terminal framebuffer and the wasm
+    canvas all buffer differently, and two of them render partially — and the
+    rows come back in the byte order `Bitmap` already uses, so they copy across
+    directly. The two bare-metal targets (Wio, PSP) keep `LV_USE_SNAPSHOT` off
+    and answer `nil`, saying so once rather than pretending.
+  - `freeze` keeps the snapshot; `transition` puts it on a full-screen sprite
+    above everything and steps its opacity to zero over `duration` frames, which
+    is RGSS's default dissolve. The `filename`/`vague` form (dissolving *through*
+    a transition image) still runs as a plain fade of the same length and says so
+    once.
+  Shared by the XP and VX/VX Ace script hosts, since both use the same
+  `mruby-rgss`.
+
+- **A render probe that can actually see the screen (`render_probe` ctest).**
+  `Viewport#color`, `Viewport#tone` and now the transitions are native rendering
+  that `mruby-rgss/test` cannot reach: that binary has no display, so a
+  `Viewport` cannot even be constructed there. The failure mode that leaves is
+  the dangerous one — the code runs, the values are stored, and the screen never
+  changes, which is exactly how an earlier RPG2000 screen tint shipped broken
+  (`docs/TODO.md`).
+  `RGSS.frame_mean` returns the frame's mean R/G/B (sampled on an 8px grid
+  through `snap_to_bitmap`), and `RGSS.effect_probe` drives a grey screen, a red
+  `Viewport#color`, an additive-blue `Viewport#tone` and a freeze/transition
+  round trip on a real display, measuring each against the last —
+  `base=[128,128,128] color=[191,63,63] tone=[128,128,255] cleared=[0,0,0]
+  mid=[94,94,94] after=[0,0,0]`. `rpg_maker_clone --rgss_effect_probe` runs it
+  and reports through the exit code; it needs no game directory, and CI runs it
+  as the `render_probe` ctest under xvfb (reserved display 98). The assertions
+  were confirmed non-vacuous by neutering `vp_refresh_overlay` and the transition
+  in turn — each broke exactly the check it should and nothing else.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -712,7 +712,8 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   tracked in [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md). `Font`,
   `Graphics` timing, `Input` and `Audio` are already covered; the open pieces are
   `Sprite` extended properties, and the empty `Window` / `Tilemap` / `Plane`
-  widgets, plus `Kernel#sprintf` and drawing `Graphics.transition/freeze`.
+  widgets, plus `Kernel#sprintf`. (`Graphics.freeze`/`transition` now draw, on
+  the native `Graphics.snap_to_bitmap` — see the VX section below.)
   Also reconcile the scripts' blocking main loop with the emscripten frame loop
   (Asyncify or a per-frame driver), and read graphics/audio out of the encrypted
   archive.
@@ -817,9 +818,28 @@ screen (544×416). Full rationale:
     the RPG2000 screen tint has been waiting on** (see the Screen effects section
     above): `apply_tone_px` is shared by all three composites, so the RPG2000
     side can adopt it instead of growing its own.
+  - ✅ **`Graphics.snap_to_bitmap` / `freeze` / `transition`** — scene
+    transitions. `snap_to_bitmap` is `lv_snapshot_take` into a `Bitmap`, the one
+    capture that works on every backend (the SDL window, the terminal
+    framebuffer and the wasm canvas all buffer differently, and two of them
+    render partially). `freeze` keeps the snapshot; `transition` shows it on a
+    full-screen sprite above everything and steps its opacity to zero, so the
+    next scene builds behind a fading still of the last — RGSS's default
+    dissolve. The `filename`/`vague` form runs as a plain fade and says so once.
+  - ✅ **A render probe that can see the screen.** The three items above are
+    native rendering that no unit test could reach: `mruby-rgss/test` has no
+    display, so a `Viewport` cannot even be constructed there, and the failure
+    mode that leaves is the one that hid the RPG2000 screen tint — the code
+    runs, the values are stored, and nothing changes. `RGSS.frame_mean` (the
+    frame's mean R/G/B, sampled on an 8px grid via `snap_to_bitmap`) and
+    `RGSS.effect_probe` close it: `rpg_maker_clone --rgss_effect_probe` drives a
+    grey screen, a red `Viewport#color`, an additive-blue `Viewport#tone` and a
+    freeze/transition round trip on a real display and measures each. It runs as
+    the `render_probe` ctest under xvfb (display 98) and needs no game. Verified
+    to have teeth by neutering `vp_refresh_overlay` and the transition in turn —
+    each broke exactly the assertion it should.
   - Remaining, all native `mruby-rgss` work and ordered by what blocks a
-    playable game: **`Graphics.freeze`/`transition`/`snap_to_bitmap`** (scene
-    transitions), `Viewport#tone` on `Window` contents (a different composite
+    playable game: `Viewport#tone` on `Window` contents (a different composite
     path; RGSS keeps windows in their own viewport, so a map tint does not tint
     the message window anyway), the window open/close animation, and
     `Bitmap#blur`/`#radial_blur`.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -155,13 +155,38 @@ puts windows in their own viewport, so a map tint does not tint the message
 window anyway) and `Graphics.brightness`, which stays tracked-not-drawn — VX
 fades through `@viewport3.color`, which does draw.
 
-### 3. `Graphics.freeze` / `transition` / `snap_to_bitmap` — no scene transitions
+### 3. `Graphics.freeze` / `transition` / `snap_to_bitmap` — scene transitions dissolve ✅
 
 `Scene_Base#perform_transition` freezes the frame and transitions into the next
 scene (~5 uses each), and `Scene_Title` snapshots the screen with
-`Graphics.snap_to_bitmap`. `freeze`/`transition` are stubs that now consume the
-right number of frames (so timing is right) but draw nothing; `snap_to_bitmap`
-and `play_movie` do not exist. Needs a native frame grab.
+`Graphics.snap_to_bitmap`.
+
+**`snap_to_bitmap` is native now**: `lv_snapshot_take` re-renders the active
+screen's object tree into an ARGB8888 buffer, which is the only capture that
+works on every backend here — the SDL window, the terminal framebuffer and the
+wasm canvas all buffer differently, and two of them render partially. The rows
+come back in the byte order `Bitmap` already uses, so they copy straight across.
+
+`freeze`/`transition` are built on it and are real: `freeze` keeps the snapshot,
+and `transition` puts it on a full-screen sprite above everything (`z` at
+`Graphics::TRANSITION_Z`) whose opacity is stepped to zero over `duration`
+frames, so the next scene builds itself behind a fading still of the last one —
+RGSS's default dissolve. The `filename`/`vague` form (dissolving *through* a
+transition image) still runs as a plain fade of the same length and says so once.
+
+Not covered: `play_movie` (there is no video decoder in the build).
+
+This is also what made the effects testable. `mruby-rgss/test` has no display —
+a `Viewport` cannot even be constructed there — so `Viewport#color`, `#tone` and
+the transitions all landed without a test that could see a pixel. `RGSS.frame_mean`
+(the mean R/G/B of the frame, sampled on an 8px grid) and `RGSS.effect_probe`
+close that: `rpg_maker_clone --rgss_effect_probe` drives a grey screen, a red
+`Viewport#color`, an additive-blue `Viewport#tone` and a freeze/transition round
+trip on a real display and measures each one. It runs as the `render_probe`
+ctest under xvfb, and it is the check that catches *the effect code runs and the
+screen does not change* — the failure mode that hid the RPG2000 screen tint
+(`docs/TODO.md`). Measured: `base=[128,128,128] color=[191,63,63]
+tone=[128,128,255] cleared=[0,0,0] mid=[94,94,94] after=[0,0,0]`.
 
 ### 4. Window open/close is not animated, and `Window#tone` is not applied
 
@@ -186,5 +211,6 @@ packed VX Ace game needs next after the tilemap.
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
 the only route to a real game. A bundle now **runs**: it loads its database,
 plays its music, reads input, drives frames, lays out its windows, draws its map,
-and tints, flashes and fades the screen. The largest remaining gaps are **scene
-transitions** (item 3) and reading assets out of an encrypted archive (item 6).
+tints, flashes and fades the screen, and dissolves between scenes. The largest
+remaining gap is **reading assets out of an encrypted archive** (item 6), which
+is what a packed release needs; items 4 and 5 are cosmetic.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -23,9 +23,12 @@ These are complete enough for the stock scripts:
   stock scripts._
 - **`Font`** — instance `name`/`size`/`bold`/`italic`/`shadow`/`outline`/`color`/
   `out_color`, class defaults (`default_name`/`default_size`/…), `exist?`.
-- **`Graphics`** — `frame_count`, `frame_rate`, `update`. _`freeze`,
-  `transition`, `frame_reset` exist but are `warn_stub` no-ops: the game runs but
-  the fade/transition is not drawn._
+- **`Graphics`** — `frame_count`, `frame_rate`, `update`, and `snap_to_bitmap` /
+  `freeze` / `transition`: the scene transition draws, as RGSS's default
+  dissolve of the frozen still over the incoming scene (see item 3 of the
+  [VX gap](rpgvx-rgss-api-gap.md), where it landed — the code is shared).
+  _`transition`'s `filename` form (dissolving through a transition image) runs as
+  a plain fade of the same length; `frame_reset` is still a `warn_stub` no-op._
 - **`Input`** — all key constants (`A`/`B`/`C`/`X`/`Y`/`Z`/`L`/`R`/`UP`…`F9`),
   `update`, `press?`, `trigger?` (~68), `repeat?` (~34), `press`/`release`,
   `dir4`/`dir8`.

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -729,7 +729,17 @@
  *==================*/
 
 /*1: Enable API to take snapshot for object*/
+/* RGSS's Graphics.snap_to_bitmap (and the freeze/transition built on it) needs
+ * to read back the rendered screen, which lv_snapshot_take does by re-rendering
+ * the object tree into a fresh buffer — the only way that works on every
+ * backend, since the SDL/terminal/wasm displays buffer differently. The module
+ * costs code space, so the two bare-metal targets (whose games never call it,
+ * and whose flash is the binding constraint) keep it out. */
+#if defined(WIO_TERMINAL) || defined(PSP_BUILD)
 #define LV_USE_SNAPSHOT 0
+#else
+#define LV_USE_SNAPSHOT 1
+#endif
 
 /*1: Enable system monitor component*/
 #define LV_USE_SYSMON   0

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -733,13 +733,11 @@
  * to read back the rendered screen, which lv_snapshot_take does by re-rendering
  * the object tree into a fresh buffer — the only way that works on every
  * backend, since the SDL/terminal/wasm displays buffer differently. The module
- * costs code space, so the two bare-metal targets (whose games never call it,
- * and whose flash is the binding constraint) keep it out. */
-#if defined(WIO_TERMINAL) || defined(PSP_BUILD)
-#define LV_USE_SNAPSHOT 0
-#else
+ * costs code space, but this file is only the desktop/wasm config: the two
+ * bare-metal targets carry their own minimal lv_conf.h (app/wio, app/psp) and
+ * leave this unset, so lv_conf_internal.h's default of 0 keeps it out of their
+ * flash — and mruby-rgss's `#if LV_USE_SNAPSHOT` fallback answers nil there. */
 #define LV_USE_SNAPSHOT 1
-#endif
 
 /*1: Enable system monitor component*/
 #define LV_USE_SYSMON   0

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -13,6 +13,150 @@ module RGSS
 
   # Color, Rect, Table and Tone are implemented in C (see src/lib.cxx).
 
+  # The mean R/G/B of the rendered frame, sampled on an 8px grid (a full
+  # per-pixel walk through get_pixel would take seconds). nil when the backend
+  # cannot snapshot. This is the measurement ADR 0021 used to prove the RPG2000
+  # fade reached the display, available to any caller now that
+  # Graphics.snap_to_bitmap exists.
+  def self.frame_mean
+    bmp = Graphics.snap_to_bitmap
+    return nil if bmp.nil?
+    r = 0
+    g = 0
+    b = 0
+    n = 0
+    y = 0
+    while y < bmp.height
+      x = 0
+      while x < bmp.width
+        c = bmp.get_pixel(x, y)
+        r += c.red.to_i
+        g += c.green.to_i
+        b += c.blue.to_i
+        n += 1
+        x += 8
+      end
+      y += 8
+    end
+    bmp.dispose
+    return nil if n.zero?
+    [r / n, g / n, b / n]
+  end
+
+  # Prove the viewport screen effects actually reach the display.
+  #
+  # Every effect below is native rendering that no unit test can see: the test
+  # binary has no display, so a Viewport cannot even be constructed there. The
+  # failure mode that leaves is the dangerous one — the code runs, the values are
+  # stored, and the screen never changes (exactly what happened to an earlier
+  # RPG2000 screen-tint attempt, see docs/TODO.md). So this drives the real
+  # renderer on a real display and *measures* the frame: grey screen, then a red
+  # colour overlay, then an additive-blue tone, each against the last, and
+  # finally a freeze/transition round trip.
+  #
+  # Run by `rpg_maker_clone --rgss_effect_probe` (under xvfb in CI). Returns true
+  # when every effect moved the pixels it should.
+  def self.effect_probe
+    # Take the screen size from a snapshot rather than Graphics.width/height:
+    # those are the values a game's resize_screen set, and there is no game here
+    # — the sprite has to cover what is actually on the display. Doubles as the
+    # check that this backend can snapshot at all.
+    shape = Graphics.snap_to_bitmap
+    if shape.nil?
+      $stderr.puts "[RGSS-PROBE] snap_to_bitmap unavailable on this backend"
+      return false
+    end
+    w = shape.width
+    h = shape.height
+    shape.dispose
+
+    viewport = Viewport.new(0, 0, w, h)
+    bitmap = Bitmap.new(w, h)
+    bitmap.fill_rect(0, 0, w, h, Color.new(128, 128, 128, 255))
+    sprite = Sprite.new(viewport)
+    sprite.bitmap = bitmap
+    Graphics.update
+    base = frame_mean
+
+    viewport.color = Color.new(255, 0, 0, 128)
+    viewport.update
+    Graphics.update
+    colored = frame_mean
+
+    viewport.color = Color.new(0, 0, 0, 0)
+    viewport.tone = Tone.new(0, 0, 255, 0)
+    viewport.update
+    Graphics.update
+    toned = frame_mean
+
+    viewport.tone = Tone.new(0, 0, 0, 0)
+    viewport.update
+
+    # The scene change: freeze the grey screen, then take the scene away — as a
+    # game does when it swaps scenes — and dissolve. `cleared` is the empty
+    # screen the dissolve runs over, `mid` is a frame from inside it (sampled by
+    # the hook below, since transition blocks until it is done) and `after` is
+    # where it ended. Between them they pin down both halves: the frozen still
+    # really goes up over the new scene, and it really comes down again.
+    Graphics.freeze
+    sprite.visible = false
+    Graphics.update
+    cleared = frame_mean
+
+    $rgss_probe_mid = nil
+    class << Graphics
+      alias_method :_probe_update, :update
+      def update
+        _probe_update
+        $rgss_probe_mid = RGSS.frame_mean if $rgss_probe_mid.nil?
+      end
+    end
+    Graphics.transition(4)
+    class << Graphics
+      alias_method :update, :_probe_update
+    end
+    mid = $rgss_probe_mid
+    after = frame_mean
+
+    $stderr.puts "[RGSS-PROBE] base=#{base.inspect} color=#{colored.inspect} " \
+                 "tone=#{toned.inspect} cleared=#{cleared.inspect} " \
+                 "mid=#{mid.inspect} after=#{after.inspect}"
+
+    ok = true
+    # A half-opaque red overlay pushes red up and the other channels down.
+    unless colored[0] > base[0] + 20 && colored[2] < base[2] - 20
+      $stderr.puts "[RGSS-PROBE] FAIL Viewport#color did not tint the frame"
+      ok = false
+    end
+    # An additive blue tone pushes blue up and leaves red alone.
+    unless toned[2] > base[2] + 20
+      $stderr.puts "[RGSS-PROBE] FAIL Viewport#tone did not tint the frame"
+      ok = false
+    end
+    if (cleared[0] - base[0]).abs < 20
+      $stderr.puts "[RGSS-PROBE] FAIL hiding the sprite did not change the frame"
+      ok = false
+    else
+      # Mid-dissolve the still is partly transparent, so the frame sits between
+      # the frozen screen and the scene behind it.
+      unless mid && (mid[0] - cleared[0]).abs > 20 && (mid[0] - base[0]).abs > 8
+        $stderr.puts "[RGSS-PROBE] FAIL Graphics.transition did not show the " \
+                     "frozen screen"
+        ok = false
+      end
+      if (after[0] - cleared[0]).abs > 8
+        $stderr.puts "[RGSS-PROBE] FAIL Graphics.transition left the frozen " \
+                     "screen up"
+        ok = false
+      end
+    end
+    sprite.dispose
+    bitmap.dispose
+    viewport.dispose
+    $stderr.puts "[RGSS-PROBE] #{ok ? "ok" : "failed"}"
+    ok
+  end
+
   class Bitmap
     def initialize f, s = nil
       if f.kind_of? String
@@ -510,6 +654,10 @@ module RGSS
     @width = 640
     @height = 480
     @brightness = 255
+    # The frozen screen a transition dissolves away sits above every game
+    # object; RGSS z values are ordinary integers, so pick one past anything a
+    # game would set.
+    TRANSITION_Z = 0x40000000
 
     class << self
       attr_accessor :frame_count, :frame_rate
@@ -550,14 +698,40 @@ module RGSS
         self.brightness = 255
       end
 
+      # RGSS's scene change: `freeze` grabs the current screen and `transition`
+      # dissolves it away over `duration` frames, so the next scene builds itself
+      # behind a still of the last one. Both are real now, on the native
+      # snap_to_bitmap: freeze keeps the snapshot, and transition shows it on a
+      # full-screen sprite above everything (z at the maximum) whose opacity is
+      # stepped to zero — which is exactly RGSS's default fade.
+      #
+      # The `filename`/`vague` form (dissolve through a transition *image*) is
+      # not modelled; such a transition still runs, as a plain fade over the same
+      # number of frames, and says so once.
       def freeze
-        RGSS.warn_stub("Graphics.freeze")
+        # nil when the backend cannot snapshot (it says so itself, once);
+        # transition copes by falling back to a plain wait.
+        @frozen = snap_to_bitmap
+        nil
       end
 
       def transition(duration = 8, filename = nil, vague = 40)
-        RGSS.warn_stub("Graphics.transition")
-        wait(duration)
+        RGSS.warn_stub("Graphics.transition with a transition image") if filename
+        frozen = @frozen
+        @frozen = nil
         @brightness = 255
+        return wait(duration) if frozen.nil? || duration <= 0
+
+        sprite = Sprite.new
+        sprite.bitmap = frozen
+        sprite.z = TRANSITION_Z
+        duration.times do |i|
+          sprite.opacity = 255 - (255 * (i + 1) / duration)
+          update
+        end
+        sprite.dispose
+        frozen.dispose
+        nil
       end
 
       def frame_reset

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2349,6 +2349,55 @@ lv_display_t* get_display(mrb_state* M) {
   return reinterpret_cast<lv_display_t*>(mrb_cptr(v));
 }
 
+// Report an unimplemented path through RGSS.warn_stub, which dedupes by name.
+void RGSS_warn_stub(mrb_state* M, const char* name) {
+  mrb_funcall(M, mrb_obj_value(mrb_module_get(M, "RGSS")), "warn_stub", 1,
+              mrb_str_new_cstr(M, name));
+}
+
+// RGSS Graphics.snap_to_bitmap: the rendered screen as a Bitmap.
+//
+// lv_snapshot_take re-renders the active screen's object tree into a fresh
+// buffer, which is the only capture that works on every backend here -- the SDL
+// window, the terminal framebuffer and the wasm canvas all buffer differently,
+// and two of them render partially. The buffer comes back in LVGL's ARGB8888
+// byte order (B, G, R, A), the same layout Bitmap uses, so the rows copy
+// straight across (honouring the snapshot's stride, which is padded).
+//
+// Answers nil where the module is compiled out (the Wio/PSP builds) rather than
+// pretending, and says so once.
+mrb_value gfx_snap_to_bitmap(mrb_state* M, mrb_value self) {
+#if LV_USE_SNAPSHOT
+  lv_obj_t* screen = lv_display_get_screen_active(get_display(M));
+  if (!screen)
+    return mrb_nil_value();
+  lv_draw_buf_t* snap = lv_snapshot_take(screen, LV_COLOR_FORMAT_ARGB8888);
+  if (!snap) {
+    RGSS_warn_stub(M, "Graphics.snap_to_bitmap (snapshot failed)");
+    return mrb_nil_value();
+  }
+  const mrb_int w = snap->header.w;
+  const mrb_int h = snap->header.h;
+  RClass* bmp_class =
+      mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Bitmap");
+  const mrb_value out =
+      DataType<Bitmap>::make(M, bmp_class, w, h, LV_COLOR_FORMAT_ARGB8888);
+  Bitmap& b = DataType<Bitmap>::get(M, out);
+  const uint32_t stride = snap->header.stride;
+  for (mrb_int y = 0; y < h; ++y) {
+    const uint8_t* src = snap->data + static_cast<size_t>(y) * stride;
+    uint8_t* dst = b.buffer.data() + static_cast<size_t>(y) * w * 4;
+    std::memcpy(dst, src, static_cast<size_t>(w) * 4);
+  }
+  b.dirty = true;
+  lv_draw_buf_destroy(snap);
+  return out;
+#else
+  RGSS_warn_stub(M, "Graphics.snap_to_bitmap");
+  return mrb_nil_value();
+#endif
+}
+
 const mrb_data_type obj_type = {"lv_obj_t", free_obj};
 
 // LVGL fires LV_EVENT_DELETE when an object is destroyed, including when its
@@ -5124,6 +5173,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
 
   RClass* gfx = mrb_define_module_under(M, m, "Graphics");
   mrb_define_module_function(M, gfx, "update", gfx_update, MRB_ARGS_NONE());
+  // RGSS2+: the rendered screen as a Bitmap. Graphics.freeze/transition are
+  // built on it (mrblib/lib.rb), and RGSS.effect_probe measures with it.
+  mrb_define_module_function(M, gfx, "snap_to_bitmap", gfx_snap_to_bitmap,
+                             MRB_ARGS_NONE());
 
   profiler_init(M);
 

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -695,6 +695,25 @@ assert "RGSS::Viewport RGSS2/RGSS3 screen-effect surface" do
   end
 end
 
+assert "RGSS::Graphics scene-transition surface" do
+  # snap_to_bitmap grabs the rendered screen, so it needs a live display the
+  # headless test binary lacks — as do freeze/transition, which are built on it.
+  # What *can* be checked here is that they exist and that the natives are not
+  # shadowed: mrblib loads after the C init, so a stray Ruby-side definition of
+  # snap_to_bitmap would silently replace the real one (the mistake that had to
+  # be undone for Viewport#tone). Actually drawing them is measured on a real
+  # display by the `render_probe` ctest — see RGSS.effect_probe.
+  %i[snap_to_bitmap freeze transition wait fadeout fadein update].each do |m|
+    assert_true RGSS::Graphics.respond_to?(m), "Graphics.#{m} missing"
+  end
+  %i[frame_mean effect_probe].each do |m|
+    assert_true RGSS.respond_to?(m), "RGSS.#{m} missing"
+  end
+  # The frozen still has to sit above anything a game sets, and RGSS z values
+  # are plain integers.
+  assert_true RGSS::Graphics::TRANSITION_Z > 0xffffff
+end
+
 # The VX / VX Ace tile geometry is pure arithmetic, so it is pinned here even
 # though drawing needs a display. Every expectation below was taken from a
 # differential run against the MIT RPG Maker MV corescript

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -104,6 +104,15 @@ DEFINE_bool(
     "bridge (implies --mv_new_game to reach the map) and log whether the op "
     "reached RGSS::Audio and the asset resolves, so a headless run confirms "
     "the audio path works. Used in CI");
+DEFINE_bool(
+    rgss_effect_probe,
+    false,
+    "Drive the RGSS screen effects on a real display and measure the rendered "
+    "frame (RGSS.effect_probe): a grey screen, then a viewport colour overlay, "
+    "then a viewport tone, each compared against the last. Exits 0 only if the "
+    "pixels actually moved. Needs no game; run under xvfb in CI as the "
+    "render_probe ctest — the one check that can catch \"the effect code runs "
+    "and the screen does not change\"");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -628,6 +637,18 @@ int main(int argc, char** argv) {
   }
   return EXIT_SUCCESS;
 #else
+  // The render probe needs the display and mruby, but no game: it builds its
+  // own viewport/sprite and measures the frame. Run it here, before the
+  // game-class dispatch, and report through the exit code.
+  if (FLAGS_rgss_effect_probe) {
+    const mrb_value ok = mrb_funcall(
+        M, mrb_obj_value(mrb_module_get(M, "RGSS")), "effect_probe", 0);
+    CHECK_NO_EXC(M);
+    rgss_audio_shutdown();
+    gflags::ShutDownCommandLineFlags();
+    return mrb_test(ok) ? EXIT_SUCCESS : EXIT_FAILURE;
+  }
+
   mrb_value game_obj;
   if (fs::exists(game_dir_path / "RPG_RT.ldb")) {
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &args);


### PR DESCRIPTION
Item 3 of [`docs/rpgvx-rgss-api-gap.md`](https://github.com/take-cheeze/rpg-maker-clone/blob/master/docs/rpgvx-rgss-api-gap.md) — and, more importantly, the first test in this branch that can actually see the screen.

## `Graphics.snap_to_bitmap`

Every RGSS scene change goes through `Scene_Base#perform_transition`: freeze the frame, build the next scene behind it, dissolve the still away. Both halves were `warn_stub` no-ops that only burned the right number of frames, and `snap_to_bitmap` (which `Scene_Title` calls outright) did not exist at all.

`lv_snapshot_take` re-renders the active screen's object tree into an ARGB8888 buffer. That is the only capture that works on every backend here — the SDL window, the terminal framebuffer and the wasm canvas all buffer differently, and two of them render partially — and the rows come back in the byte order `Bitmap` already uses, so they copy across directly. `LV_USE_SNAPSHOT` is enabled everywhere except the two bare-metal targets (Wio, PSP), where it answers `nil` and says so once rather than pretending.

## `freeze` / `transition`

`freeze` keeps the snapshot; `transition` puts it on a full-screen sprite above everything (`z` at `Graphics::TRANSITION_Z`) and steps its opacity to zero over `duration` frames, so the next scene builds itself behind a fading still of the last one — RGSS's default dissolve. The `filename`/`vague` form (dissolving *through* a transition image) still runs as a plain fade of the same length and says so once.

Shared by the XP and VX/VX Ace script hosts, since both use the same `mruby-rgss`.

## A render probe that can see the screen

`Viewport#color`, `Viewport#tone` and now the transitions are native rendering that `mruby-rgss/test` cannot reach: that binary has no display, so a `Viewport` cannot even be constructed there. Three rendering features have landed on this branch without a test observing a single pixel, and the failure mode that leaves is the dangerous one — the code runs, the values are stored, and the screen never changes. That is exactly how an earlier RPG2000 screen tint shipped broken (`docs/TODO.md`).

`RGSS.frame_mean` returns the frame's mean R/G/B (sampled on an 8px grid through `snap_to_bitmap`). `RGSS.effect_probe` drives a grey screen, a red `Viewport#color`, an additive-blue `Viewport#tone` and a freeze/transition round trip on a real display, measuring each against the last. `rpg_maker_clone --rgss_effect_probe` runs it and reports through the exit code; it needs no game directory, and it runs as the `render_probe` ctest under xvfb (reserved display 98, alongside `exe_open`'s 99).

Because `transition` blocks until it is done, the probe aliases `Graphics.update` for the duration to sample a frame from *inside* the dissolve — without that, "never put the still up" and "never took it down" are indistinguishable.

## Verification

Built and run locally (a full non-nix build: apt SDL2/EGL, the unicode mapping tables fetched by hand):

```
[RGSS-PROBE] base=[128, 128, 128] color=[191, 63, 63] tone=[128, 128, 255] cleared=[0, 0, 0] mid=[94, 94, 94] after=[0, 0, 0]
[RGSS-PROBE] ok
```

Every number is the predicted one: grey 128; a half-opaque red overlay giving 128 + 127/2 ≈ 191 red and 128/2 = 64 blue; an additive blue tone clamping to 255; the empty screen at 0; and the still at 3/4 opacity over black giving 96.

The assertions were then confirmed **non-vacuous** by two negative controls:

| Break | Result |
| --- | --- |
| `vp_refresh_overlay` early-returns | `FAIL Viewport#color did not tint the frame`, exit 1 — and the tone check still passed, correctly, since tone uses a different mechanism |
| `transition` falls back to `wait` | `mid=[0, 0, 0]`, `FAIL Graphics.transition did not show the frozen screen`, exit 1 |

Both reverted. `ctest` afterwards: `mruby_test` 1688 assertions / 0 failures, `render_probe` passed. (`exe_open` fails locally only because the Nepheshel test bed is not downloaded here.)

`mruby-rgss/test` also gains a surface assertion for the new methods — mrblib loads after the C init, so a stray Ruby-side `snap_to_bitmap` would silently shadow the native one, which is the mistake that had to be undone for `Viewport#tone`.

## Docs

- `docs/rpgvx-rgss-api-gap.md` item 3 → ✅, with the measured numbers. The largest remaining VX gap is now reading assets out of an encrypted archive (item 6).
- `docs/rpgxp-rgss-api-gap.md` — `Graphics` updated, since XP gets this too.
- `docs/TODO.md` — the VX subsection, and the XP line that listed `transition`/`freeze` as undrawn.
- `changelog.d/rgss-snap-to-bitmap-transitions.added.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_