### PR TITLE
Load a packed release's graphics out of the encrypted archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,8 +180,9 @@ jobs:
       # ("XIO: fatal IO error"). Reserved numbers: exe_open=99 and
       # render_probe=98 (see those ctest tests in CMakeLists.txt, both run by
       # the `test` step below); MV runs=100..108, the RPG2k
-      # real-game boot smoke=109..110, the MZ boot smoke=111, and the RPG XP
-      # real-game boot smoke=112 below. Every
+      # real-game boot smoke=109..110, the MZ boot smoke=111, the RPG XP
+      # real-game boot smoke=112 and the RGSSAD packed-asset smoke=113..114
+      # (two runs, one per arm of its A/B) below. Every
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
       # check.
@@ -250,6 +251,14 @@ jobs:
           # above). See docs/adr/0025-rpgxp-cross-runtime-testing.md.
           - name: RPG XP real-game boot smoke test
             run: nix develop -c ./scripts/rpgxp_boot_check.bash 112
+
+          # A released game keeps its Graphics/ inside the encrypted archive with
+          # nothing loose, so the native asset loaders have to read through it.
+          # Packs the same real test bed twice — with and without a title graphic
+          # in the archive — and asserts the engine finds it only when it is
+          # there, which is what makes the check non-vacuous. Displays 113-114.
+          - name: RGSSAD packed-asset smoke test
+            run: nix develop -c ./scripts/rgssad_asset_check.bash 113
 
           - name: MV boot smoke test
             continue-on-error: true

--- a/changelog.d/rgss-packed-graphics.added.md
+++ b/changelog.d/rgss-packed-graphics.added.md
@@ -1,0 +1,33 @@
+- **A packed RPG Maker release finds its graphics.** A released XP / VX / VX Ace
+  game ships one encrypted `Game.rgssad` / `.rgss2a` / `.rgss3a` holding its whole
+  tree — `Data/` *and* `Graphics/` and `Audio/` — with nothing loose on disk. The
+  data layer has read `Data/` out of it for a while, but the native asset loaders
+  only ever opened files, so a packed game booted with no art at all: every
+  `Cache.*` call in a game's own scripts is a `Bitmap.new("Graphics/…")`.
+  - The awkward part was never the decrypting (`RPGXP::RGSSAD` already did that)
+    but the plumbing: an asset is asked for by name from deep inside a bundle,
+    with no handle to thread down. So each maker's boot shell registers its
+    opened archive once as `RGSS.asset_archive`, and `Bitmap#initialize` consults
+    it after the loose-file search misses, trying the same extension candidates
+    (`.png`, `.jpg`, `.jpeg`, `.xyz`, `.bmp`). Loose files still shadow packed
+    ones, which is what RGSS itself does.
+  - The decoding is deliberately unchanged: `Bitmap#_init_file` and the new
+    `#_init_memory` share one `bmp_decode_into`, so a packed asset goes through
+    the same stb / XYZ / tolerant-PNG chain a loose one does. Those fallbacks are
+    exactly what a real RPG Maker project needs (indexed XYZ windowskins,
+    windowskin PNGs whose deflate stream strict inflaters reject), and the packed
+    path must not quietly lack them.
+  - A broken archive is a miss, not a crash: the read failure is reported to
+    `$stderr` and `Bitmap.new` still raises its own diagnostic naming the asset.
+  - `scripts/rgssad_asset_check.bash` (new, in CI) checks it end to end in the
+    real binary: the XP test bed is packed twice, differing only in whether its
+    title graphic is inside `Game.rgssad`, and the engine must find it in the
+    first run and report the miss in the second. The A/B is the point — a single
+    run would pass just as well if the archive were never consulted. Both
+    test-bed checks now pack a graphic alongside the data too, and the VX one
+    asserts that booting a packed project registers its archive at all.
+
+  Audio is not covered yet: `RGSS::Audio` plays through a C function table
+  (`include/rgss_audio.hxx`) whose entry points all take a path, so a packed BGM
+  needs that interface to grow memory variants. A packed game boots and draws,
+  but stays silent.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -693,9 +693,21 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   `RPGXP::RGSSData` falls back to whichever archive is present when a `.rxdata` is
   not loose on disk. Covered by `mruby-rpgxp/test` (v1 and v3 round-trips) and by
   `scripts/rpgxp_testbed_check.rb` (packs the real test bed as both `.rgssad` and
-  `.rgss3a` and reloads the whole DB through each). Remaining: reading
-  **graphics/audio** out of the archive (only the Ruby `Data/` path is wired; the
-  native `Bitmap`/`Audio` loaders still read loose files).
+  `.rgss3a` and reloads the whole DB through each). **Graphics come out of the
+  archive too**: the boot shell registers its opened archive as
+  `RGSS.asset_archive`, and `Bitmap#initialize` consults it after the loose-file
+  search misses, trying the same extension candidates — an asset is asked for by
+  name from deep inside a game's own scripts, so there is no handle to thread
+  down and the registry is what closes that. The bytes go through the same
+  decoder a loose file does (`_init_file` and `_init_memory` share
+  `bmp_decode_into`), so the stb / XYZ / tolerant-PNG fallbacks a real project
+  needs are not quietly missing from the packed path. Checked end to end in the
+  real binary by `scripts/rgssad_asset_check.bash`, which packs the test bed
+  twice — with and without a title graphic in the archive — and asserts the
+  engine finds it only when it is there; a single run would pass just as well if
+  the archive were never consulted. Remaining: **audio**, which plays through a C
+  function table (`include/rgss_audio.hxx`) whose entry points all take a path,
+  so a packed BGM needs that interface to grow memory variants.
 - **Menus / save / battle** — the default menu screens, saving in the real
   `.rxdata` save format (a portable Marshal save is used for now), and the
   battle system.
@@ -719,8 +731,8 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   widgets, plus `Kernel#sprintf`. (`Graphics.freeze`/`transition` now draw, on
   the native `Graphics.snap_to_bitmap` — see the VX section below.)
   Also reconcile the scripts' blocking main loop with the emscripten frame loop
-  (Asyncify or a per-frame driver), and read graphics/audio out of the encrypted
-  archive.
+  (Asyncify or a per-frame driver), and read **audio** out of the encrypted
+  archive (graphics already come out of it — see Encrypted archives above).
 - ✅ **Cross-runtime testing** — an XP project is booted in every runtime it can
   run in, all asserting the same `[RPGXP-MAP]` marker (`--rpgxp_new_game` picks
   New Game without input): `scripts/rpgxp_boot_check.bash` (the native binary,
@@ -773,8 +785,9 @@ screen (544×416). Full rationale:
   `Data/System.rxdata` — and sizes the window to 544×416.
 - ✅ **Encrypted archives** — `Game.rgss2a` (v1) and `Game.rgss3a` (v3) load
   through the XP reader (`RPGXP::RGSSAD`) unchanged, so a single-archive release
-  boots with no loose files. Same remaining gap as XP: graphics/audio are still
-  read from loose files only.
+  boots with no loose files, and — like XP, through the same shared
+  `RGSS.asset_archive` the VX boot shell registers — finds its **graphics** in
+  there as well. Same remaining gap as XP: **audio** is still loose-file only.
 - 🚧 **Run the bundled scripts** — a VX/VX Ace game's engine is its script
   bundle, so this is *the* path rather than a later refinement. The host runs
   (`RPGXP::ScriptHost`, ADR 0017) with the per-frame Fiber driver shared by both

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -198,19 +198,44 @@ unrolls. `Window#tone` (the windowskin colour tint) is likewise stored only.
 
 One use each (title background, animation effects). Cosmetic.
 
-### 6. Reading graphics/audio out of the encrypted archive
+### 6. Reading graphics out of the encrypted archive ✅ (audio still to come)
 
-Shared with the XP gap: `RPGVX::RGSSData` resolves `Data/*` through
-`Game.rgss2a`/`Game.rgss3a`, but the native `Bitmap`/`Audio` loaders only read
-loose files, so a packed release boots with no graphics. `Cache.*` (a script
-class) calls `Bitmap.new("Graphics/...")` for every asset, so this is what a
-packed VX Ace game needs next after the tilemap.
+Shared with the XP gap. `RPGVX::RGSSData` has resolved `Data/*` through
+`Game.rgss2a`/`Game.rgss3a` for a while, but the native asset loaders only ever
+opened files, so a packed release booted with no art at all — and `Cache.*` (a
+script class) calls `Bitmap.new("Graphics/...")` for *every* asset.
+
+**Graphics now come out of the archive.** The awkward part is not the decrypting
+— `RPGXP::RGSSAD` already did that — but the plumbing: an asset is asked for by
+name from deep inside a game's own scripts, with no handle to thread down. So
+each boot shell registers its opened archive once as `RGSS.asset_archive`, and
+`Bitmap#initialize` consults it after the loose-file search misses, trying the
+same extension candidates (`.png`, `.jpg`, `.jpeg`, `.xyz`, `.bmp`). Loose files
+still shadow packed ones, which is what RGSS itself does.
+
+The decoding is unchanged, deliberately: `_init_file` and the new `_init_memory`
+share one `bmp_decode_into`, so a packed asset goes through the same stb, XYZ and
+tolerant-PNG path a loose one does — the fallbacks that a real RPG Maker project
+needs are not something the archive path can quietly lack.
+
+Verified end to end in the real binary by `scripts/rgssad_asset_check.bash`: the
+XP test bed is packed twice, differing only in whether its title graphic is
+inside `Game.rgssad`, and the engine must find it in the first and report the
+miss in the second. The A/B is the point — a single run would pass just as well
+if the archive were never consulted.
+
+**Audio is still loose-file only.** `RGSS::Audio` plays through a C function
+table (`include/rgss_audio.hxx`) whose entry points all take a path, so a packed
+BGM needs that interface to grow memory variants (SDL_mixer reads from an
+`SDL_RWops` happily enough). A packed game therefore boots and draws, but stays
+silent.
 
 ## What this means for turning the host on
 
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
 the only route to a real game. A bundle now **runs**: it loads its database,
 plays its music, reads input, drives frames, lays out its windows, draws its map,
-tints, flashes and fades the screen, and dissolves between scenes. The largest
-remaining gap is **reading assets out of an encrypted archive** (item 6), which
-is what a packed release needs; items 4 and 5 are cosmetic.
+tints, flashes and fades the screen, dissolves between scenes, and — packed or
+loose — finds its graphics. What is left is narrow: **packed audio** (the second
+half of item 6, a change to the audio backend's C interface), and the cosmetic
+items 4 and 5.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -13,6 +13,22 @@ module RGSS
 
   # Color, Rect, Table and Tone are implemented in C (see src/lib.cxx).
 
+  # The game's encrypted archive, for assets that are not on disk.
+  #
+  # A released RPG Maker game ships one Game.rgssad / .rgss2a / .rgss3a holding
+  # its whole tree — Data/ *and* Graphics/ and Audio/ — with nothing loose. The
+  # data layers open the archive themselves to read Data/, but assets are asked
+  # for by name from anywhere (`Cache.tileset(n)` -> `Bitmap.new("Graphics/...")`
+  # deep inside a game's own scripts), with no handle to thread through. So each
+  # maker's boot shell registers its archive here once and the loaders consult
+  # it after a loose file misses — loose shadows packed, as in RGSS.
+  #
+  # Anything answering `read(name) -> String or nil` will do; in practice it is
+  # an RPGXP::RGSSAD. nil means an unpacked project.
+  class << self
+    attr_accessor :asset_archive
+  end
+
   # The mean R/G/B of the rendered frame, sampled on an 8px grid (a full
   # per-pixel walk through get_pixel would take seconds). nil when the backend
   # cannot snapshot. This is the measurement ADR 0021 used to prove the RPG2000
@@ -158,22 +174,28 @@ module RGSS
   end
 
   class Bitmap
+    # RGSS resolves a bare asset name against several image formats, and the RPG
+    # Maker XP RTP genuinely mixes them: its windowskins and charsets are .png
+    # while its title backgrounds are .jpg, so a png-only search left every XP
+    # title screen on the fallback background (found by
+    # scripts/compare-rpgxp-wine.bash). stb decodes JPEG, so both spellings of
+    # the extension are just more candidates.
+    EXTENSIONS = [:png, :jpg, :jpeg, :xyz, :bmp].freeze
+
     def initialize f, s = nil
       if f.kind_of? String
         i = self._init_file(f, s)
         [GAME_DIR, RTP_DIR].each do |d|
           next if d.nil? || d.empty?
           i = self._init_file("#{d}/#{f}", s) unless i
-          # RGSS resolves a bare asset name against several image formats, and
-          # the RPG Maker XP RTP genuinely mixes them: its windowskins and
-          # charsets are .png while its title backgrounds are .jpg, so a
-          # png-only search left every XP title screen on the fallback
-          # background (found by scripts/compare-rpgxp-wine.bash). stb decodes
-          # JPEG, so both spellings of the extension are just more candidates.
-          [:png, :jpg, :jpeg, :xyz, :bmp].each do |ext|
+          EXTENSIONS.each do |ext|
             i = self._init_file("#{d}/#{f}.#{ext}", s) unless i
           end
         end
+        # A released game packs its whole Graphics/ tree into the encrypted
+        # archive with nothing loose on disk, so try that last — loose files
+        # shadow the archive, which is what RGSS itself does.
+        i = init_from_archive(f, s) unless i
         # Surface the decoder's own reason (e.g. an XYZ "bad dist" zlib error)
         # so failures are diagnosable instead of a bare "Failed to init bitmap".
         unless i
@@ -194,6 +216,33 @@ module RGSS
 
     def font=(f)
       @font = f
+    end
+
+    private
+
+    # Decode `f` out of the game's encrypted archive, if one is registered (see
+    # RGSS.asset_archive). Entry names are project-relative with the extension
+    # spelled out, so the same candidate list the loose-file search uses applies
+    # here — the archive itself normalises the '/' separators.
+    #
+    # Best effort: a broken archive must not take down a Bitmap.new that would
+    # otherwise raise its own diagnostic, so the read failure is logged and
+    # treated as a miss.
+    def init_from_archive(f, s)
+      archive = RGSS.asset_archive
+      return nil if archive.nil?
+      bytes = archive.read(f)
+      if bytes.nil?
+        EXTENSIONS.each do |ext|
+          bytes = archive.read("#{f}.#{ext}")
+          break if bytes
+        end
+      end
+      return nil if bytes.nil?
+      self._init_memory(bytes, s)
+    rescue StandardError => e
+      $stderr.puts "[RGSS] archive read failed for #{f}: #{e.message}"
+      nil
     end
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -528,36 +528,33 @@ static void set_bitmap_load_error(const char* fmt, ...) {
 // (windowskin) or other graphics as .xyz would otherwise fail to load. On
 // success returns a freshly stb-allocated buffer (free with stbi_image_free)
 // of width*height*4 bytes in LVGL's B, G, R, A byte order and sets *w/*h/*c;
-// returns nullptr when `f` is not a readable XYZ file. When `trans` is set the
+// returns nullptr when the bytes are not an XYZ image. When `trans` is set the
 // first palette entry is treated as the transparent colour, matching stb's
 // transparent-palette handling for PNGs.
-static uint8_t* load_xyz(const char* f, int* w, int* h, int* c, bool trans) {
-  std::FILE* fp = std::fopen(f, "rb");
-  if (!fp)
-    return nullptr;
-  std::fseek(fp, 0, SEEK_END);
-  const long sz = std::ftell(fp);
-  std::fseek(fp, 0, SEEK_SET);
-  if (sz < 8) {
-    std::fclose(fp);
-    return nullptr;
-  }
-  std::vector<uint8_t> data((size_t)sz);
-  const size_t got = std::fread(data.data(), 1, (size_t)sz, fp);
-  std::fclose(fp);
+//
+// Takes the bytes rather than a path so the same decoder serves a loose file
+// and an entry pulled out of an encrypted RGSSAD archive; `label` only names
+// the source in the diagnostics.
+static uint8_t* load_xyz_mem(const uint8_t* data,
+                             size_t sz,
+                             const char* label,
+                             int* w,
+                             int* h,
+                             int* c,
+                             bool trans) {
   // Not an XYZ file: stay silent and let the caller keep stb_image's own error.
-  if (got != (size_t)sz || std::memcmp(data.data(), "XYZ1", 4) != 0)
+  if (sz < 8 || std::memcmp(data, "XYZ1", 4) != 0)
     return nullptr;
 
   const int width = data[4] | (data[5] << 8);
   const int height = data[6] | (data[7] << 8);
   if (width <= 0 || height <= 0) {
     set_bitmap_load_error("XYZ: invalid dimensions %dx%d in '%s'", width,
-                          height, f);
+                          height, label);
     return nullptr;
   }
 
-  const char* stream = reinterpret_cast<const char*>(data.data() + 8);
+  const char* stream = reinterpret_cast<const char*>(data + 8);
   const int stream_len = (int)(sz - 8);
   // A 768-byte (256*3) RGB palette followed by one index per pixel.
   const long expected = 768L + (long)width * height;
@@ -576,7 +573,7 @@ static uint8_t* load_xyz(const char* f, int* w, int* h, int* c, bool trans) {
       set_bitmap_load_error(
           "XYZ %dx%d '%s': zlib inflate failed (%s); zlib header 0x%02x%02x, "
           "%d compressed bytes, expected %ld decompressed",
-          width, height, f, zerr, (unsigned)data[8], (unsigned)data[9],
+          width, height, label, zerr, (unsigned)data[8], (unsigned)data[9],
           stream_len, expected);
       return nullptr;
     }
@@ -586,7 +583,7 @@ static uint8_t* load_xyz(const char* f, int* w, int* h, int* c, bool trans) {
     set_bitmap_load_error(
         "XYZ %dx%d '%s': short data, got %d bytes, expected %ld (768 palette + "
         "%d pixels)",
-        width, height, f, outlen, expected, width * height);
+        width, height, label, outlen, expected, width * height);
     stbi_image_free(raw);
     return nullptr;
   }
@@ -845,42 +842,35 @@ uint32_t be32(const uint8_t* p) {
 
 }  // namespace png_tol
 
-// Decode `f` as a PNG using the tolerant inflater above. Returns a freshly
+// Decode `d` as a PNG using the tolerant inflater above. Returns a freshly
 // stb-allocated (free with stbi_image_free) width*height*4 B, G, R, A buffer
-// and sets *w/*h/*c, or nullptr when the file is not a PNG this fallback
+// and sets *w/*h/*c, or nullptr when the bytes are not a PNG this fallback
 // handles (non-interlaced; bit depth 8, or indexed 1/2/4). `trans` maps palette
 // index 0 to transparent, matching the primary loader's colour-key handling.
-static uint8_t* load_png_tolerant(const char* f,
-                                  int* wout,
-                                  int* hout,
-                                  int* c,
-                                  bool trans) {
-  std::FILE* fp = std::fopen(f, "rb");
-  if (!fp)
-    return nullptr;
-  std::fseek(fp, 0, SEEK_END);
-  const long sz = std::ftell(fp);
-  std::fseek(fp, 0, SEEK_SET);
+//
+// Takes the bytes rather than a path, like load_xyz_mem above, so an entry read
+// out of an encrypted RGSSAD archive gets the same fallback a loose file does;
+// `label` only names the source in the diagnostics.
+static uint8_t* load_png_tolerant_mem(const uint8_t* d,
+                                      size_t sz,
+                                      const char* label,
+                                      int* wout,
+                                      int* hout,
+                                      int* c,
+                                      bool trans) {
   static const uint8_t sig[8] = {0x89, 0x50, 0x4e, 0x47,
                                  0x0d, 0x0a, 0x1a, 0x0a};
-  if (sz < 8) {
-    std::fclose(fp);
-    return nullptr;
-  }
-  std::vector<uint8_t> d((size_t)sz);
-  const size_t got = std::fread(d.data(), 1, (size_t)sz, fp);
-  std::fclose(fp);
-  if (got != (size_t)sz || std::memcmp(d.data(), sig, 8) != 0)
+  if (sz < 8 || std::memcmp(d, sig, 8) != 0)
     return nullptr;
 
   int w = 0, h = 0, depth = 0, ct = 0, interlace = 0;
   std::vector<uint8_t> idat, plte, trns;
   size_t i = 8;
-  while (i + 8 <= (size_t)sz) {
-    const uint32_t len = png_tol::be32(d.data() + i);
-    const uint8_t* typ = d.data() + i + 4;
-    const uint8_t* body = d.data() + i + 8;
-    if (i + 12 + len > (size_t)sz)
+  while (i + 8 <= sz) {
+    const uint32_t len = png_tol::be32(d + i);
+    const uint8_t* typ = d + i + 4;
+    const uint8_t* body = d + i + 8;
+    if (i + 12 + len > sz)
       break;
     if (!std::memcmp(typ, "IHDR", 4) && len >= 13) {
       w = (int)png_tol::be32(body);
@@ -936,7 +926,7 @@ static uint8_t* load_png_tolerant(const char* f,
     set_bitmap_load_error(
         "PNG %dx%d depth %d colortype %d '%s': tolerant inflate produced too "
         "little data",
-        w, h, depth, ct, f);
+        w, h, depth, ct, label);
     return nullptr;
   }
 
@@ -1046,19 +1036,46 @@ mrb_value bmp_init_size(mrb_state* M, mrb_value self) {
   return self;
 }
 
-mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
-  const char* f;
-  mrb_bool trans = false;
-  mrb_get_args(M, "z|b", &f, &trans);
+// Read a whole file. Answers false when it cannot be opened or read fully, so
+// the caller can fall through to the next candidate path in silence.
+static bool slurp_file(const char* f, std::vector<uint8_t>& out) {
+  std::FILE* fp = std::fopen(f, "rb");
+  if (!fp)
+    return false;
+  std::fseek(fp, 0, SEEK_END);
+  const long sz = std::ftell(fp);
+  std::fseek(fp, 0, SEEK_SET);
+  if (sz <= 0) {
+    std::fclose(fp);
+    return false;
+  }
+  out.resize((size_t)sz);
+  const size_t got = std::fread(out.data(), 1, (size_t)sz, fp);
+  std::fclose(fp);
+  return got == (size_t)sz;
+}
+
+// Decode image bytes into `self` (a Bitmap). Shared by Bitmap#_init_file and
+// #_init_memory: everything below is format work with no notion of where the
+// bytes came from, which is what lets an entry pulled out of an encrypted
+// RGSSAD archive go through the exact same decoders — stb, then the XYZ and
+// tolerant-PNG fallbacks — as a loose file. `label` only names the source in
+// the diagnostics. Answers false when nothing could decode it.
+static bool bmp_decode_into(mrb_state* M,
+                            mrb_value self,
+                            const uint8_t* data,
+                            size_t size,
+                            const char* label,
+                            bool trans) {
   int w, h, c;
   stbi__png_transparent_palette = trans;
-  // Every loader here hands back LVGL's B, G, R(, A) byte order (see load_xyz
-  // and load_png_tolerant, which build it themselves). stb decodes to
-  // R, G, B(, A), so its output is swapped below instead of relying on the
-  // vendored palette-only BGR hack: that covered indexed PNGs (all an RPG2000
-  // project has) and left every truecolour PNG and every JPEG with red and
-  // blue exchanged -- which is what an RPG Maker XP RTP is full of. Caught by
-  // diffing against the genuine RGSS runtime, see
+  // Every loader here hands back LVGL's B, G, R(, A) byte order (see
+  // load_xyz_mem and load_png_tolerant_mem, which build it themselves). stb
+  // decodes to R, G, B(, A), so its output is swapped below instead of relying
+  // on the vendored palette-only BGR hack: that covered indexed PNGs (all an
+  // RPG2000 project has) and left every truecolour PNG and every JPEG with red
+  // and blue exchanged -- which is what an RPG Maker XP RTP is full of. Caught
+  // by diffing against the genuine RGSS runtime, see
   // docs/adr/0025-rpgxp-cross-runtime-testing.md.
   stbi__png_to_bgr_palette = false;
   // The channel count has to be decided before decoding, because the bitmap's
@@ -1069,38 +1086,27 @@ mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
   // (truecolour + alpha, loaded opaque) hit exactly that.
   int probe_w = 0, probe_h = 0, probe_c = 0;
   const bool has_alpha =
-      stbi_info(f, &probe_w, &probe_h, &probe_c) && probe_c == 4;
+      stbi_info_from_memory(data, (int)size, &probe_w, &probe_h, &probe_c) &&
+      probe_c == 4;
   const int req = (trans || has_alpha) ? 4 : 3;
   // Whether the pixels came from stb (R, G, B order, so they need the swap) or
   // from one of the fallbacks above, which already emit LVGL's order.
   bool from_stb = true;
-  std::shared_ptr<uint8_t> img(stbi_load(f, &w, &h, &c, req), stbi_image_free);
+  std::shared_ptr<uint8_t> img(
+      stbi_load_from_memory(data, (int)size, &w, &h, &c, req), stbi_image_free);
   if (!img) {
     from_stb = false;
-    img.reset(load_xyz(f, &w, &h, &c, trans), stbi_image_free);
+    img.reset(load_xyz_mem(data, size, label, &w, &h, &c, trans),
+              stbi_image_free);
   }
   // stb_image rejects some valid-enough PNGs (e.g. RPG Maker windowskins whose
   // deflate stream references a zero pre-history, giving "bad dist"); retry
   // with the tolerant PNG decoder before giving up.
   if (!img)
-    img.reset(load_png_tolerant(f, &w, &h, &c, trans), stbi_image_free);
-  if (!img) {
-    // Some archives store filenames in NFD form while the game data refers to
-    // them in NFC (or vice versa); retry with the decomposed form before giving
-    // up so accented paths still resolve.
-    const std::string nfd_f = una::norm::to_nfd_utf8(f);
-    from_stb = true;
-    img.reset(stbi_load(nfd_f.c_str(), &w, &h, &c, req), stbi_image_free);
-    if (!img) {
-      from_stb = false;
-      img.reset(load_xyz(nfd_f.c_str(), &w, &h, &c, trans), stbi_image_free);
-    }
-    if (!img)
-      img.reset(load_png_tolerant(nfd_f.c_str(), &w, &h, &c, trans),
-                stbi_image_free);
-    if (!img)
-      return mrb_nil_value();
-  }
+    img.reset(load_png_tolerant_mem(data, size, label, &w, &h, &c, trans),
+              stbi_image_free);
+  if (!img)
+    return false;
   // The fallbacks always produce 4 channels; stb produced exactly what was
   // requested.
   const int channels = from_stb ? req : 4;
@@ -1113,6 +1119,44 @@ mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
     for (size_t i = 0; i + 3 <= bmp.buffer.size(); i += (size_t)channels)
       std::swap(p[i], p[i + 2]);
   }
+  return true;
+}
+
+mrb_value bmp_init_file(mrb_state* M, mrb_value self) {
+  const char* f;
+  mrb_bool trans = false;
+  mrb_get_args(M, "z|b", &f, &trans);
+  std::vector<uint8_t> data;
+  if (slurp_file(f, data) &&
+      bmp_decode_into(M, self, data.data(), data.size(), f, trans))
+    return self;
+  // Some archives store filenames in NFD form while the game data refers to
+  // them in NFC (or vice versa); retry with the decomposed form before giving
+  // up so accented paths still resolve.
+  const std::string nfd_f = una::norm::to_nfd_utf8(f);
+  if (nfd_f != f && slurp_file(nfd_f.c_str(), data) &&
+      bmp_decode_into(M, self, data.data(), data.size(), nfd_f.c_str(), trans))
+    return self;
+  return mrb_nil_value();
+}
+
+// Ruby: Bitmap#_init_memory(bytes, transparent = false) -> self or nil.
+//
+// The same decode as #_init_file over bytes already in hand. RGSS's Cache
+// asks for every asset by name (`Bitmap.new("Graphics/Titles/...")`), and a
+// released game packs those names into its encrypted Game.rgssad / .rgss2a /
+// .rgss3a with nothing loose on disk — so the Ruby loader falls back to the
+// archive and hands the decrypted bytes here.
+mrb_value bmp_init_memory(mrb_state* M, mrb_value self) {
+  const char* data;
+  mrb_int size;
+  mrb_bool trans = false;
+  mrb_get_args(M, "s|b", &data, &size, &trans);
+  if (size <= 0)
+    return mrb_nil_value();
+  if (!bmp_decode_into(M, self, reinterpret_cast<const uint8_t*>(data),
+                       (size_t)size, "<archive entry>", trans))
+    return mrb_nil_value();
   return self;
 }
 
@@ -5046,6 +5090,11 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   RClass* bmp = mrb_define_class_under(M, m, "Bitmap", M->object_class);
   MRB_SET_INSTANCE_TT(bmp, MRB_TT_DATA);
   mrb_define_method(M, bmp, "_init_size", bmp_init_size, MRB_ARGS_REQ(2));
+  // Decode from bytes already in hand — how an asset packed into an encrypted
+  // RGSSAD archive is loaded (mrblib/lib.rb's Bitmap#initialize falls back to
+  // it when no loose file matches).
+  mrb_define_method(M, bmp, "_init_memory", bmp_init_memory,
+                    MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
   mrb_define_method(M, bmp, "_init_file", bmp_init_file,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
   mrb_define_class_method(M, bmp, "_load_error", bmp_load_error,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -395,6 +395,143 @@ assert "RGSS::Bitmap reports a detailed reason when an XYZ fails to decode" do
   end
 end
 
+# ---- Loading assets out of an encrypted archive ---------------------------
+#
+# A released RPG Maker game packs its whole Graphics/ tree into Game.rgssad /
+# .rgss2a / .rgss3a with nothing loose on disk, so the loose-file search finds
+# nothing and every asset has to come out of the archive. The reader itself is
+# RPGXP::RGSSAD (tested in mruby-rpgxp, which also covers the end-to-end path);
+# what is checked here is mruby-rgss's half — that Bitmap consults whatever is
+# registered as RGSS.asset_archive, tries the same extension candidates the
+# loose search does, and decodes the bytes through the same decoders.
+#
+# The fixture is the 3x2 XYZ picture used above: palette 0 = (10,20,30),
+# 1 = red, 2 = green.
+XYZ_3X2 = "\x58\x59\x5a\x31\x03\x00\x02\x00\x78\x9c\xe3\x12\x91\xfb\xcf\xc0" \
+          "\xc0\x00\xc2\xa3\x60\x14\x8c\x3c\xc0\xc8\xc4\xc4\xc8\x00\x00\xb4" \
+          "\x8b\x02\x41"
+
+# Stands in for an RPGXP::RGSSAD: anything answering read(name) -> String or
+# nil will do. Records its lookups so the candidate order can be asserted.
+class FakeArchive
+  def initialize(entries)
+    @entries = entries
+    @asked = []
+  end
+
+  attr_reader :asked
+
+  def read(name)
+    @asked << name
+    @entries[name]
+  end
+end
+
+assert "RGSS::Bitmap decodes packed bytes exactly as it decodes a file" do
+  # Same picture, same expectations as the loose-file XYZ tests above — the two
+  # paths share one decoder (bmp_decode_into), and this is what pins that.
+  archive = FakeArchive.new({ "Graphics/System/Window" => XYZ_3X2 })
+  RGSS.asset_archive = archive
+  begin
+    b = RGSS::Bitmap.new("Graphics/System/Window")
+    assert_equal 3, b.width
+    assert_equal 2, b.height
+    px = b.get_pixel(0, 0)
+    assert_equal 10.0, px.red
+    assert_equal 20.0, px.green
+    assert_equal 30.0, px.blue
+    assert_equal 255.0, px.alpha
+    assert_equal 255.0, b.get_pixel(1, 0).red
+    assert_equal 255.0, b.get_pixel(2, 0).green
+    # The transparent-colour flag reaches the packed path too.
+    t = RGSS::Bitmap.new("Graphics/System/Window", true)
+    assert_equal 0.0, t.get_pixel(0, 0).alpha
+    assert_equal 255.0, t.get_pixel(1, 0).alpha
+  ensure
+    RGSS.asset_archive = nil
+  end
+end
+
+assert "RGSS::Bitmap reports undecodable packed bytes instead of crashing" do
+  archive = FakeArchive.new({ "Graphics/System/Junk" => "not an image at all" })
+  RGSS.asset_archive = archive
+  begin
+    assert_raise(RuntimeError) { RGSS::Bitmap.new("Graphics/System/Junk") }
+  ensure
+    RGSS.asset_archive = nil
+  end
+end
+
+assert "RGSS::Bitmap loads a packed asset through RGSS.asset_archive" do
+  archive = FakeArchive.new({ "Graphics/System/Window.xyz" => XYZ_3X2 })
+  RGSS.asset_archive = archive
+  begin
+    b = RGSS::Bitmap.new("Graphics/System/Window")
+    assert_equal 3, b.width
+    assert_equal 255.0, b.get_pixel(2, 0).green
+    # The bare name is tried before the extension candidates, exactly as the
+    # loose-file search does it.
+    assert_equal "Graphics/System/Window", archive.asked.first
+    assert_true archive.asked.include?("Graphics/System/Window.xyz")
+  ensure
+    RGSS.asset_archive = nil
+  end
+end
+
+assert "RGSS::Bitmap prefers a loose file over the archive" do
+  # RGSS lets a loose file shadow the packed entry; the archive must not even be
+  # consulted when one is found. The loose copy here is the raw-DEFLATE spelling
+  # of the same picture, so a wrong pick still decodes and only `asked` tells
+  # them apart.
+  loose = "\x58\x59\x5a\x31\x03\x00\x02\x00\xe3\x12\x91\xfb\xcf\xc0\xc0\x00" \
+          "\xc2\xa3\x60\x14\x8c\x3c\xc0\xc8\xc4\xc4\xc8\x00\x00"
+  path = "test-packed-shadow.xyz"
+  File.open(path, "wb") { |io| io.write(loose) }
+  archive = FakeArchive.new({ path => XYZ_3X2 })
+  RGSS.asset_archive = archive
+  begin
+    b = RGSS::Bitmap.new(path)
+    assert_equal 3, b.width
+    assert_true archive.asked.empty?, "archive was consulted: #{archive.asked}"
+  ensure
+    RGSS.asset_archive = nil
+    File.delete(path) if File.exist?(path)
+  end
+end
+
+assert "RGSS::Bitmap still raises its own diagnostic when the archive misses" do
+  archive = FakeArchive.new({})
+  RGSS.asset_archive = archive
+  begin
+    err = nil
+    begin
+      RGSS::Bitmap.new("Graphics/System/Missing")
+    rescue => e
+      err = e.message
+    end
+    assert_true !err.nil?, "expected a load failure"
+    assert_true err.include?("Graphics/System/Missing"), "message: #{err}"
+  ensure
+    RGSS.asset_archive = nil
+  end
+end
+
+assert "RGSS::Bitmap survives an archive that raises" do
+  # A corrupt archive must not turn a missing-asset error into a crash: the read
+  # failure is reported and treated as a miss, so the loader's own diagnostic is
+  # what reaches the caller.
+  broken = Object.new
+  def broken.read(_name)
+    raise "archive is corrupt"
+  end
+  RGSS.asset_archive = broken
+  begin
+    assert_raise(RuntimeError) { RGSS::Bitmap.new("Graphics/System/Window") }
+  ensure
+    RGSS.asset_archive = nil
+  end
+end
+
 assert "RGSS::Profiler is inert until enabled" do
   # The standalone test binary never calls profiler_configure, so profiling is
   # off by default: query methods report the disabled state and the block-timing

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -106,6 +106,10 @@ class RPGVX
     # rather than the RGSS default.
     RGSS::Graphics.resize_screen(WIDTH, HEIGHT)
     @db = RGSSData.new(GAME_DIR, @edition) if @edition
+    # A packed release holds its Graphics/ and Audio/ trees in the same archive
+    # as its Data/, and assets are asked for by name from deep inside the game's
+    # own scripts, so the loaders need it globally (see RGSS.asset_archive).
+    RGSS.asset_archive = @db.archive if @db
     @title = read_title
     # A VX/VX Ace project's engine *is* its script bundle, so the script host is
     # the only path that can currently run one. Off by default, like XP's.

--- a/mruby-rpgvx/mrblib/rgss_data.rb
+++ b/mruby-rpgvx/mrblib/rgss_data.rb
@@ -81,6 +81,11 @@ class RPGVX
       !@archive.nil?
     end
 
+    # The opened archive, or nil for an unpacked project. A packed release keeps
+    # its Graphics/ and Audio/ trees in here too, so the boot shell hands this to
+    # RGSS.asset_archive and the native asset loaders read through it.
+    attr_reader :archive
+
     def vxace?
       @edition == :vxace
     end

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -36,6 +36,10 @@ class RPGXP
   def initialize(_args)
     @title = read_ini_title
     @db = RGSSData.new(GAME_DIR)
+    # A packed release holds its Graphics/ and Audio/ trees in the same archive
+    # as its Data/, and assets are asked for by name from deep inside the game's
+    # own scripts, so the loaders need it globally (see RGSS.asset_archive).
+    RGSS.asset_archive = @db.archive
     @scenes = []
     # When the script host is enabled and the project ships its scripts, the
     # game's own Ruby drives everything (see script_host.rb); skip building the

--- a/mruby-rpgxp/mrblib/rgss_data.rb
+++ b/mruby-rpgxp/mrblib/rgss_data.rb
@@ -276,6 +276,11 @@ class RPGXP
       !@archive.nil?
     end
 
+    # The opened archive, or nil for an unpacked project. A packed release keeps
+    # its Graphics/ and Audio/ trees in here too, so the boot shell hands this to
+    # RGSS.asset_archive and the native asset loaders read through it.
+    attr_reader :archive
+
     # Read + Marshal-parse an arbitrary project-relative file, exactly like
     # RGSS's Kernel#load_data ("Data/System.rxdata", "Data/Scripts.rxdata", a
     # "Save1.rxdata" in the game root, ...). A loose file on disk shadows the

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -934,6 +934,42 @@ assert "RGSSAD round-trips an entry larger than the mruby array cap" do
   end
 end
 
+# The whole point of the archive for a released game: its Graphics/ tree is in
+# there too, and `Cache.*` asks for those by name through Bitmap.new. mruby-rgss
+# covers its half against a stand-in archive; this is the end-to-end one, a real
+# packed archive decoded into a real Bitmap, for both archive versions.
+#
+# The picture is the 3x2 XYZ used in mruby-rgss's loader tests: palette
+# 0 = (10,20,30), 1 = red, 2 = green. Note the entry name uses RGSSAD's native
+# '\' separators while the lookup uses '/', which is how a game spells it.
+assert "a packed graphic loads into a Bitmap through RGSS.asset_archive" do
+  xyz = "\x58\x59\x5a\x31\x03\x00\x02\x00\x78\x9c\xe3\x12\x91\xfb\xcf\xc0" \
+        "\xc0\x00\xc2\xa3\x60\x14\x8c\x3c\xc0\xc8\xc4\xc4\xc8\x00\x00\xb4" \
+        "\x8b\x02\x41"
+  [:pack_v1, :pack_v3].each do |packer|
+    files = [
+      ["Data\\System.rxdata", Marshal.dump([1, 2, 3])],
+      ["Graphics\\Titles\\Castle.xyz", xyz]
+    ]
+    a = RPGXP::RGSSAD.new(RPGXP::RGSSAD.send(packer, files))
+    RGSS.asset_archive = a
+    begin
+      # No loose file anywhere: this can only have come out of the archive, and
+      # only by trying the ".xyz" candidate against the bare name the game uses.
+      b = RGSS::Bitmap.new("Graphics/Titles/Castle")
+      assert_equal 3, b.width, "#{packer}: width"
+      assert_equal 2, b.height, "#{packer}: height"
+      assert_equal 10.0, b.get_pixel(0, 0).red, "#{packer}: pixel"
+      assert_equal 255.0, b.get_pixel(2, 0).green, "#{packer}: pixel"
+      # The data entries still read back, so registering the archive for assets
+      # has not disturbed what it was already doing.
+      assert_equal [1, 2, 3], Marshal.load(a.read("Data/System.rxdata"))
+    ensure
+      RGSS.asset_archive = nil
+    end
+  end
+end
+
 # ---- Autonomous event movement: Character / MoveRoute / MoveType -----------
 
 # World stand-in for the movement engine.

--- a/scripts/rgssad_asset_check.bash
+++ b/scripts/rgssad_asset_check.bash
@@ -22,6 +22,20 @@
 # A change that quietly stopped consulting the archive turns the first run into
 # the second, and this fails.
 #
+# The archive has to be the *only* possible source for that graphic, or the two
+# runs are indistinguishable and neither proves anything. Two things could
+# otherwise supply it, and both are shut off below:
+#
+#   * the RTP. `Bitmap#initialize` searches RTP_DIR after GAME_DIR, and CI
+#     installs the real RPG Maker XP RTP -- which ships 001-Title01, the very
+#     graphic the test bed asks for. The engine finds the RTP through a wine
+#     registry under $WINEPREFIX, so pointing that at an empty directory leaves
+#     RTP_DIR empty. (This is what the "without" guard caught the first time
+#     this check ran in CI: it passed locally, where no wine prefix exists, and
+#     failed there.)
+#   * a loose file next to the working directory, since a bare relative name is
+#     tried first. Both runs use an absolute --game_dir and a scratch cwd.
+#
 # The engine also aborts on an uncaught mruby exception, so both runs reaching
 # [RPGXP-MAP] is part of the test.
 #
@@ -49,8 +63,17 @@ if [ ! -f "${GAME}/Data/System.rxdata" ] ; then
     exit 1
 fi
 
+ENGINE="$(readlink -f "${ENGINE}")"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "${WORK}"' EXIT
+
+# Shut the RTP off: an empty prefix has no wine registry, so xp_rtp_path() finds
+# nothing and the engine sets RTP_DIR to "" (see src/main.cxx). Without this the
+# CI runner's installed XP RTP supplies 001-Title01 to both runs and the A/B
+# below measures nothing.
+export WINEPREFIX="${WORK}/empty-wineprefix"
+mkdir -p "${WINEPREFIX}"
 
 # Pack the bed's real Data/ into two archives. `with` also carries a title
 # graphic named after the project's own System.title_name, which is the file the
@@ -105,10 +128,13 @@ for which in with without ; do
     log="${WORK}/${which}.log"
     echo "== packed ${which} the title graphic"
     # Each run gets its own display: xvfb-run -a's probe is not atomic and can
-    # steal a display from a concurrent run (see build.yml).
-    if ! xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
+    # steal a display from a concurrent run (see build.yml). Run from the packed
+    # directory so the loader's bare-relative first candidate cannot pick up a
+    # loose file from the repo either.
+    if ! (cd "${WORK}/${which}" && \
+          xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
             --game_dir "${WORK}/${which}" --rpgxp_new_game \
-            --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
+            --timeout_ms="${TIMEOUT_MS}") >"${log}" 2>&1 ; then
         echo "FAILED: packed ${which}: the engine exited non-zero" >&2
         fail=1
     elif ! grep -q '\[RPGXP-MAP\]' "${log}" ; then

--- a/scripts/rgssad_asset_check.bash
+++ b/scripts/rgssad_asset_check.bash
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# Boot a *packed* RPG Maker XP release and confirm the engine finds its art
+# inside the encrypted archive.
+#
+# Why this exists: a released game ships one Game.rgssad holding its whole tree
+# -- Data/ and Graphics/ and Audio/ -- with nothing loose on disk. The data
+# layer has read Data/ out of the archive for a while, but the native asset
+# loaders only ever opened files, so a packed release booted with no graphics at
+# all. Bitmap now falls back to RGSS.asset_archive, and this is the check that
+# the whole chain works in the real binary: boot shell registers the archive ->
+# Bitmap#initialize misses on disk and asks it -> the entry decrypts -> the
+# native decoder reads the bytes.
+#
+# It is an A/B, not a single run, so it cannot pass vacuously. The same project
+# is packed twice, differing only in whether the title graphic is inside the
+# archive:
+#
+#   with    -> the engine must NOT log "title graphic load failed"
+#   without -> it must, and must still boot (a missing asset is not fatal)
+#
+# A change that quietly stopped consulting the archive turns the first run into
+# the second, and this fails.
+#
+# The engine also aborts on an uncaught mruby exception, so both runs reaching
+# [RPGXP-MAP] is part of the test.
+#
+# Usage: ./scripts/rgssad_asset_check.bash [server_num] [game_dir]
+#   server_num  xvfb-run --server-num to use (default 113; see the reserved
+#               display numbers in .github/workflows/build.yml)
+#   game_dir    defaults to the repo's RPG Maker XP test bed
+
+set -eu -o pipefail
+
+cd "$(dirname "$0")/.."
+
+SERVER_NUM="${1:-113}"
+GAME="${2:-data/OpenGame.exe/Testbed/XP}"
+ENGINE="${ENGINE:-./build/rpg_maker_clone}"
+TIMEOUT_MS="${RGSSAD_TIMEOUT_MS:-20000}"
+
+if [ ! -x "${ENGINE}" ] ; then
+    echo "error: ${ENGINE} not built; run cmake --build build first" >&2
+    exit 1
+fi
+if [ ! -f "${GAME}/Data/System.rxdata" ] ; then
+    echo "FAILED: ${GAME} has no Data/System.rxdata; run" \
+         "scripts/download-opengame-xp.bash first" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Pack the bed's real Data/ into two archives. `with` also carries a title
+# graphic named after the project's own System.title_name, which is the file the
+# title scene asks for; `without` is otherwise identical. Neither directory has a
+# loose Data/ or Graphics/, so the archive is the only possible source.
+#
+# The picture is a 3x2 XYZ (RPG Maker's own indexed format, decoded natively):
+# "XYZ1", uint16 LE width/height, then a zlib stream of a 768-byte palette plus
+# one index per pixel.
+ruby - "${GAME}" "${WORK}" <<'RUBY'
+require "fileutils"
+
+# Marshal instantiates by name, so the RGSS value types have to exist before the
+# database loads. Only presence matters here (the real ones are native); this
+# mirrors what scripts/rpgxp_testbed_check.rb sets up.
+class Table; def self._load(s) = allocate; end
+class Color; def self._load(s) = allocate; end
+class Tone;  def self._load(s) = allocate; end
+class Rect;  def self._load(s) = allocate; end
+
+load File.join(Dir.pwd, "mruby-rpgxp/mrblib/rgssad.rb")
+load File.join(Dir.pwd, "mruby-rpgxp/mrblib/rgss_data.rb")
+
+game, work = ARGV
+data = Dir[File.join(game, "Data", "*.rxdata")].sort.map do |f|
+  ["Data/#{File.basename(f)}", File.binread(f)]
+end
+abort "no Data/*.rxdata under #{game}" if data.empty?
+
+# Ask the project which title graphic it wants, through the same schema the
+# engine uses, so the title scene really does look for the file we pack.
+title = RPGXP::RGSSData.new(game).system.title_name
+abort "#{game} names no title graphic" if title.nil? || title.empty?
+puts "title graphic: #{title}"
+
+xyz = ("\x58\x59\x5a\x31\x03\x00\x02\x00\x78\x9c\xe3\x12\x91\xfb\xcf\xc0" \
+       "\xc0\x00\xc2\xa3\x60\x14\x8c\x3c\xc0\xc8\xc4\xc4\xc8\x00\x00\xb4" \
+       "\x8b\x02\x41").b
+
+{ "with" => data + [["Graphics/Titles/#{title}.xyz", xyz]],
+  "without" => data }.each do |which, files|
+  dir = File.join(work, which)
+  FileUtils.mkdir_p dir
+  File.binwrite(File.join(dir, "Game.rgssad"), RPGXP::RGSSAD.pack_v1(files))
+  File.write(File.join(dir, "Game.ini"), "[Game]\nTitle=Packed XP\n")
+end
+RUBY
+
+fail=0
+num="${SERVER_NUM}"
+for which in with without ; do
+    log="${WORK}/${which}.log"
+    echo "== packed ${which} the title graphic"
+    # Each run gets its own display: xvfb-run -a's probe is not atomic and can
+    # steal a display from a concurrent run (see build.yml).
+    if ! xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
+            --game_dir "${WORK}/${which}" --rpgxp_new_game \
+            --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
+        echo "FAILED: packed ${which}: the engine exited non-zero" >&2
+        fail=1
+    elif ! grep -q '\[RPGXP-MAP\]' "${log}" ; then
+        echo "FAILED: packed ${which}: never reached the map ([RPGXP-MAP] missing)" >&2
+        fail=1
+    fi
+    grep '\[RPGXP-MAP\]' "${log}" || true
+    num=$((num + 1))
+done
+
+if grep -q 'title graphic load failed' "${WORK}/with.log" ; then
+    echo "FAILED: the title graphic was in the archive and the engine did not" \
+         "find it -- the packed-asset path is broken" >&2
+    grep 'title graphic load failed' "${WORK}/with.log" >&2
+    fail=1
+fi
+# The other half of the A/B: without the entry the load must fail, or the check
+# above proves nothing (e.g. a loose copy leaking in from somewhere).
+if ! grep -q 'title graphic load failed' "${WORK}/without.log" ; then
+    echo "FAILED: the title graphic was NOT in the archive and the engine" \
+         "loaded one anyway -- this check cannot tell the two apart" >&2
+    fail=1
+fi
+
+if [ "${fail}" -ne 0 ] ; then
+    # ALSA has no device under CI and floods stderr; keep the rest.
+    for which in with without ; do
+        echo "--- packed ${which}" >&2
+        grep -v 'ALSA lib\|snd_\|Unknown PCM' "${WORK}/${which}.log" | tail -30 >&2 || true
+    done
+    exit 1
+fi
+
+echo "rgssad asset check: a packed release loaded its title graphic out of" \
+     "Game.rgssad (and reported the miss when it was not packed)"

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -120,6 +120,13 @@ module RGSS
 
   class Timeout < StandardError; end
 
+  # The packed archive the asset loaders read through. Native Bitmap/Audio
+  # consult this after a loose file misses (mruby-rgss/mrblib/lib.rb); here it
+  # only has to exist so the boot shell's registration can be asserted.
+  class << self
+    attr_accessor :asset_archive
+  end
+
   # Graphics is native. These stand-ins mirror the parts of mruby-rgss's module
   # the VX path touches (the real ones are unit-tested in mruby-rgss/test):
   # counting frames so the per-frame driver can be asserted, RGSS2's frame wait,
@@ -1244,6 +1251,16 @@ class Checker
     files = Dir[File.join(dir, "Data", "*#{ext}")].sort.map do |f|
       ["Data\\#{File.basename(f)}", File.binread(f)]
     end
+    # A released game packs its Graphics/ tree in the same archive as its Data/,
+    # and that is the only copy — nothing is loose on disk. Pack one so the
+    # asset side of the archive is covered too. (A 3x2 XYZ: palette 0 is
+    # (10,20,30), 1 red, 2 green. Decoding it is mruby-rgss's job and is tested
+    # there; what matters here is that a game's own '/'-spelled name resolves.)
+    graphic = "\x58\x59\x5a\x31\x03\x00\x02\x00\x78\x9c\xe3\x12\x91\xfb\xcf\xc0" \
+              "\xc0\x00\xc2\xa3\x60\x14\x8c\x3c\xc0\xc8\xc4\xc4\xc8\x00\x00\xb4" \
+              "\x8b\x02\x41".b
+    graphic_entry = "Graphics\\System\\Window.xyz"
+    files += [[graphic_entry, graphic]]
     archive_name = RPGVX.info(edition)[:archive]
     archive = edition == :vxace ? RPGXP::RGSSAD.pack_v3(files)
                                 : RPGXP::RGSSAD.pack_v1(files)
@@ -1279,9 +1296,29 @@ class Checker
       packed.save_object({ "slot" => 1 }, "Save1#{ext}")
       expect(packed.read_object("Save1#{ext}") == { "slot" => 1 },
              "#{archive_name}: save_object/read_object round-trip failed")
+
+      # The asset half. A game asks for a graphic by its bare, '/'-spelled name
+      # (`Cache.system("Window")` -> `Bitmap.new("Graphics/System/Window")`), so
+      # the archive has to answer that spelling, and the boot shell has to have
+      # registered the archive for the loaders to reach at all — nothing else
+      # threads a handle down to Bitmap.new.
+      expect(packed.archive.read("Graphics/System/Window.xyz") == graphic,
+             "#{archive_name}: a packed graphic did not read back by its " \
+             "'/'-spelled name")
+      RGSS.asset_archive = nil
+      begin
+        with_game_dir(tmp) { RPGVX.new([]) }
+        expect(RGSS.asset_archive.equal?(packed.archive) ||
+               (!RGSS.asset_archive.nil? &&
+                RGSS.asset_archive.read("Graphics/System/Window.xyz") == graphic),
+               "#{archive_name}: booting a packed project did not register the " \
+               "archive with RGSS.asset_archive, so its Graphics/ is unreachable")
+      ensure
+        RGSS.asset_archive = nil
+      end
     end
-    puts "  archive: packed #{files.size} entries; DB loads identically " \
-         "through #{archive_name}"
+    puts "  archive: packed #{files.size} entries (Data/ + a graphic); DB and " \
+         "assets both load through #{archive_name}"
   rescue StandardError => ex
     fail "#{dir}: archive check raised: #{ex.class}: #{ex.message}"
   end

--- a/scripts/rpgxp_testbed_check.rb
+++ b/scripts/rpgxp_testbed_check.rb
@@ -256,10 +256,21 @@ class Checker
   # exercising the RGSSAD reader against real file sizes/contents and the
   # RGSSData archive fallback end to end. Both the v1 (`.rgssad`, XP/VX) and v3
   # (`.rgss3a`, VX Ace) formats are checked against the same real data.
+  # A 3x2 XYZ picture (palette 0 = (10,20,30), 1 red, 2 green), packed alongside
+  # the data so the asset half of the archive is covered too. Decoding it is
+  # native and is tested in mruby-rgss; what matters here is that the name a
+  # game actually uses resolves.
+  GRAPHIC_XYZ = ("\x58\x59\x5a\x31\x03\x00\x02\x00\x78\x9c\xe3\x12\x91\xfb" \
+                 "\xcf\xc0\xc0\x00\xc2\xa3\x60\x14\x8c\x3c\xc0\xc8\xc4\xc4" \
+                 "\xc8\x00\x00\xb4\x8b\x02\x41").b
+
   def check_archive(dir, disk)
     files = Dir[File.join(dir, "Data", "*.rxdata")].sort.map do |f|
       ["Data\\#{File.basename(f)}", File.binread(f)]
     end
+    # A released game packs Graphics/ into the same archive as Data/, with no
+    # loose copy on disk — so this is the only route to the game's art.
+    files += [["Graphics\\Titles\\Castle.xyz", GRAPHIC_XYZ]]
     check_archive_format(disk, files, 1, "Game.rgssad",
                          RPGXP::RGSSAD.pack_v1(files))
     check_archive_format(disk, files, 3, "Game.rgss3a",
@@ -294,8 +305,17 @@ class Checker
         expect(pm.width == dm.width && pm.height == dm.height,
                "#{filename}: Map#{id} dimensions differ from on-disk")
       end
+      # The asset half: a game asks by the bare, '/'-spelled name
+      # (`Bitmap.new("Graphics/Titles/Castle")`), so the archive has to answer
+      # that spelling, and the boot shell hands this same object to
+      # RGSS.asset_archive for the native loaders to read through.
+      expect(!packed.archive.nil?, "#{filename}: packed project exposes no archive")
+      expect(packed.archive.read("Graphics/Titles/Castle.xyz") == GRAPHIC_XYZ,
+             "#{filename}: a packed graphic did not read back by its " \
+             "'/'-spelled name")
     end
-    puts "  archive: packed #{files.size} entries; DB loads identically through #{filename}"
+    puts "  archive: packed #{files.size} entries (Data/ + a graphic); DB and " \
+         "assets both load through #{filename}"
   end
 
   def report


### PR DESCRIPTION
Item 6 of [`docs/rpgvx-rgss-api-gap.md`](https://github.com/take-cheeze/rpg-maker-clone/blob/master/docs/rpgvx-rgss-api-gap.md), the graphics half — shared with the XP gap, and the largest thing still standing between a *released* RPG Maker game and this engine.

## The problem

A released XP / VX / VX Ace game ships one encrypted `Game.rgssad` / `.rgss2a` / `.rgss3a` holding its whole tree — `Data/` **and** `Graphics/` and `Audio/` — with nothing loose on disk. The data layer has read `Data/` out of it for a while, but the native asset loaders only ever opened files, so a packed game booted with no art at all. Every `Cache.*` call in a game's own scripts is a `Bitmap.new("Graphics/…")`.

## The plumbing, which was the awkward part

Not the decrypting — `RPGXP::RGSSAD` already did that. The problem is that an asset is asked for by name from deep inside a bundle, with no handle to thread down: `Cache.tileset(n)` → `Bitmap.new("Graphics/…")`, several script layers below anything that knows a project exists.

So each maker's boot shell registers its opened archive once as `RGSS.asset_archive`, and `Bitmap#initialize` consults it after the loose-file search misses, trying the same extension candidates (`.png`, `.jpg`, `.jpeg`, `.xyz`, `.bmp`). Loose files still shadow packed ones, which is what RGSS itself does.

## The decoding is deliberately unchanged

`Bitmap#_init_file` and the new `#_init_memory` share one `bmp_decode_into`, so a packed asset goes through the same stb → XYZ → tolerant-PNG chain a loose one does. Those fallbacks are exactly what a real RPG Maker project needs — indexed XYZ windowskins, windowskin PNGs whose deflate stream strict inflaters reject — and the packed path must not quietly lack them.

Getting there meant giving `load_xyz` and `load_png_tolerant` memory-based cores. Both used to slurp a file first and only their diagnostics ever knew the path, so this is mostly a hoist; the file entry point now slurps and delegates, which also folds the NFD-retry into one place.

A broken archive is a miss, not a crash: the read failure goes to `$stderr` and `Bitmap.new` still raises its own diagnostic naming the asset.

## Verification

**End to end in the real binary** — `scripts/rgssad_asset_check.bash` (new, in CI). The XP test bed is packed twice, differing *only* in whether its title graphic is inside `Game.rgssad`, and the engine must find it in the first run and report the miss in the second:

```
title graphic: 001-Title01
== packed with the title graphic
[RPGXP-MAP] map=1 x=9 y=7
== packed without the title graphic
[RPGXP-MAP] map=1 x=9 y=7
rgssad asset check: a packed release loaded its title graphic out of Game.rgssad
(and reported the miss when it was not packed)
```

The A/B is the point. A single run would pass just as well if the archive were never consulted — the "without" arm is what makes the "with" arm mean something. Here is the difference it is measuring, from the two logs:

| | `title graphic load failed` in the log? |
| --- | --- |
| graphic packed into `Game.rgssad` | no — loaded from the archive |
| graphic not packed | yes — and still boots; a missing asset is not fatal |

Neither directory has a loose `Data/` **or** `Graphics/`, so the archive is the only possible source.

**Unit tests** — 7 new. `mruby-rgss/test` covers its half against a stand-in archive (decode parity with the file path including the transparent-colour flag, the candidate order, loose-shadows-packed, the diagnostic surviving an archive miss, and an archive that raises being recovered from). `mruby-rpgxp/test` has the end-to-end one: a real packed archive, both v1 and v3, decoded into a real `Bitmap`.

Confirmed non-vacuous by deleting the archive fallback: 3 crashes and 3 tests stop passing. The VX test-bed assertion was checked the same way — dropping `RGSS.asset_archive = @db.archive` from the boot shell fails it for both editions.

**Test beds** — both `rpgxp_testbed_check.rb` and `rpgvx_testbed_check.rb` now pack a graphic alongside the data and assert it reads back by the `/`-spelled name a game actually uses; the VX one additionally boots the packed project and asserts the archive got registered at all. Run against the real downloaded XP bed and the generated VX/VX Ace beds, both green.

`mruby_test` 1695 assertions / 0 failures, `render_probe` passing, `rpgxp_boot_check.bash` passing.

## Not covered

Audio. `RGSS::Audio` plays through a C function table (`include/rgss_audio.hxx`) whose entry points all take a path, so a packed BGM needs that interface to grow memory variants (SDL_mixer reads from an `SDL_RWops` happily enough). That is an ABI change across eight entry points and belongs in its own change. A packed game now boots and draws, but stays silent — written up in the gap doc and `docs/TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_