### PR TITLE
Implement remaining RPG2000 event commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@
   Call Event (run a common event / another event's page), Move Event (force a
   move route onto an event or the player), Halt All Movement (cancel every forced
   route), Change / Trade Event Location (snap or swap event/player tiles), Change
-  Map Tileset (swap the map's chipset), Weather Effects (set rain/snow type and
-  strength), Set
-  Transparent Flag (hide/show the hero), Return to Title and Erase
+  Map Tileset (swap the map's chipset), Tile Substitution (rewrite a tile id on a
+  map layer, drawing and passability both), Weather Effects (set rain/snow type
+  and strength), Set
+  Transparent Flag (hide/show the hero), Flash Sprite (pulse a character with a
+  decaying colour), Enter/Exit Vehicle, Open Save Menu / Open Main Menu, Fade Out
+  BGM, Return to Title and Erase
   Event (remove an event from
-  the map). Events start on the action button, on
+  the map) — **every RPG2000 map / common-event command now has a handler**;
+  only the battle-page commands (13110–13410) are still to come. Events start on the action button, on
   player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;

--- a/changelog.d/rpg2k-event-command-opcodes.fixed.md
+++ b/changelog.d/rpg2k-event-command-opcodes.fixed.md
@@ -1,0 +1,9 @@
+- RPG Maker 2000: corrected three event-command opcodes that did not match
+  liblcf's `Code` enum, so the commands are now recognised in real game data.
+  **Change Equipment** was dispatched on 10440, which is actually **Change
+  Skills** — it moves to 10450; **Game Over** was 12520 and is 12420. The same
+  106xx shift in `scripts/analyze_game.rb`'s label table (which named 10610
+  "ChangeVehicleGraphic" and reported the real 10660 / 10690 as "unknown") is
+  fixed too, and that tool's coverage list is now read out of
+  `Game::Interpreter::Cmd` instead of a hand-kept duplicate, so its
+  implemented / feature-gap figures cannot drift as commands land.

--- a/changelog.d/rpg2k-remaining-event-commands.added.md
+++ b/changelog.d/rpg2k-remaining-event-commands.added.md
@@ -1,0 +1,24 @@
+- RPG Maker 2000: the **remaining map / common-event commands** are now
+  implemented, closing the RPG2000 event-command set outside battle pages.
+  **Change Skills** (10440) teaches or removes a skill on the usual actor scopes
+  (constant or variable skill id, id 0 ignored); **Simulated Attack** (10500)
+  hurts the target actors with EasyRPG's `atk - def * p_def / 400 - spi *
+  p_spi / 800` formula, spread by ±(variance × 5) percent, floored at 0 and
+  optionally storing the damage in a variable; **Change Actor Face** (10640)
+  overrides an actor's FaceSet; **Enter/Exit Vehicle** (10840) boards or leaves a
+  vehicle from an event, reusing the action-button toggle; **Flash Sprite**
+  (11320) pulses a character with a decaying colour, drawn by toning its CharSet
+  frame (so the flash keeps the sprite's outline) and holding the event when its
+  wait flag is set; **Fade Out BGM** (11520) fades the music over the given
+  tenths of a second and forgets the current track; **Play Movie** (11560)
+  records and reports the request (no video decoder is linked in, so playback is
+  the one part not modelled); **Tile Substitution** (11750) rewrites a tile id on
+  a map layer through a `Game::Map` substitution table, so drawing *and*
+  passability follow the swap until the map is left; and **Open Save Menu**
+  (11910) / **Open Main Menu** (11950) hand control to the save and field menus
+  and resume the event afterwards. **Conditional Branch** gained its last two
+  RPG2000 tests: "the decision key started this event" (type 8, set by
+  `Scene::Map` when the action button launches a trigger-0 event) and "the BGM
+  has played through once" (type 9, detected from a `RGSS::Audio.bgm_pos` that
+  jumped backwards, which is how SDL_mixer loops a track). Covered by new checks
+  in `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -384,8 +384,19 @@ The work below is roughly ordered by the critical path to a walkable game
   enemy-cast infliction, all-target skill/item scopes, per-attribute rate
   overrides from the Attribute table, the per-terrain backdrop and the RPG2000
   Game Over graphic.
-  The remaining event commands (tile substitution and other native-render
-  effects) are TODO. **Show Battle Animation** (11210) now plays on the map — the
+  **Every RPG2000 map / common-event command now has a handler.** The last gaps
+  closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
+  (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM
+  (11520), Play Movie (11560), Tile Substitution (11750) and Open Save Menu /
+  Open Main Menu (11910 / 11950), together with the last two Conditional Branch
+  tests (the decision key started this event; the BGM has played through once).
+  Three opcodes that never matched liblcf's `Code` enum were corrected in the
+  same pass — Change Equipment is 10450 (10440 is Change Skills) and Game Over is
+  12420 — so those commands are recognised in real game data at all. Still TODO
+  here: **battle-page event commands** (13110–13410 and the `_B` conditional
+  markers), which need a battle-event interpreter the battle scene does not have
+  yet, and video playback for Play Movie (no decoder is linked in; the request is
+  logged). **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the
   target frame by frame and fires its screen flashes, holding the event with the
   wait flag (per-cell zoom / tone and target-only flashes are approximations for

--- a/docs/rpg2000-sample-analysis.md
+++ b/docs/rpg2000-sample-analysis.md
@@ -132,7 +132,7 @@ Common-event commands (161 total):
 | **ChangeFaceGraphic** | 4 | ✗ message face |
 | MemorizeBGM / PlayMemorizedBGM | 2 | ✓ BGM stack |
 | **EnemyEncounter** | 1 | ✗ battle |
-| unknown(10660) | 2 | ✗ unidentified 106xx opcode |
+| ChangeSystemBGM (10660) | 2 | ✓ (reported as `unknown(10660)` when this analysis ran — the tool's 106xx label table was shifted by one slot; fixed since) |
 
 Sample2's gaps are **presentational**: pictures, screen flash/tint, message
 face graphics, and battle entry — i.e. the cutscene and combat surface.
@@ -158,7 +158,7 @@ Common-event commands (1919 total):
 | JumpToLabel / Label | 114 | ✓ |
 | CallEvent | 30 | ✓ |
 | MoveEvent / Teleport / ShowMessage | 4 | ✓ |
-| MessageOptions, ProceedWithMovement, PanScreen, PlayerVisibility, MemorizeLocation, ChangeMainMenuAccess, unknown(10690) | 10 | ✗ |
+| MessageOptions, ProceedWithMovement, PanScreen, PlayerVisibility, MemorizeLocation, ChangeMainMenuAccess, ChangeScreenTransitions (10690, reported as `unknown` by the then-shifted label table) | 10 | ✓ all implemented since |
 
 Sample3's common events are effectively a **switch/variable state machine**
 (`ControlVars` alone is 22 % of all commands) — precisely the subset the
@@ -186,7 +186,7 @@ runtime can execute virtually all of it.
    | **BGM stack** ✅ | MemorizeBGM (11530), PlayMemorizedBGM (11540) — now implemented | Sample2 |
    | **Movement sync** ✅ | ProceedWithMovement (11340) — now implemented | Sample3 |
    | **Menu/telep. access, misc** ✅ | ChangeMainMenuAccess (11960), MemorizeLocation (10820) and PlayerVisibility (11310) — now implemented | Sample3 |
-   | **Unidentified** | code 10660, 10690 (106xx range) | Sample2, Sample3 |
+   | **System overrides** ✅ | ChangeSystemBGM (10660), ChangeScreenTransitions (10690) — now implemented; they showed up as "unidentified" only because `analyze_game.rb`'s 106xx label table was shifted by one slot | Sample2, Sample3 |
 
 ## Recommended priorities for the interpreter
 
@@ -224,8 +224,13 @@ Ordered by real-world frequency across the analysed games:
    `ChangeSaveAccess` (11930) (*implemented* — gate opening the menu and saving;
    covered by the same two harnesses), the teleport/escape access toggles,
    `PlayerVisibility`.
-7. **Identify opcodes 10660 and 10690** — unnamed in the current opcode table;
-   worth confirming against liblcf before implementing.
+7. ✅ **Opcodes 10660 and 10690** — confirmed against liblcf's `Code` enum as
+   `ChangeSystemBGM` and `ChangeScreenTransitions`; both are implemented. They
+   read as "unknown" here because `analyze_game.rb`'s label table for the 105xx /
+   106xx range was shifted by one slot (it named 10610 "ChangeVehicleGraphic"),
+   which has since been corrected. That tool now derives its coverage set from
+   `Game::Interpreter::Cmd`, so re-running it reports the current state rather
+   than a hand-kept snapshot.
 
 ## Recommended test-beds
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -984,16 +984,27 @@ module Game
       @charset_index = index
     end
 
-    # The actor's database FaceSet graphic (顔グラフィック), shown on the
-    # save-select screen (the SAVE_TITLE face slots) -- distinct from the message
-    # face configured per Show Message. Defaults to none when the database row
-    # (or edition) does not carry one.
+    # The actor's FaceSet graphic (顔グラフィック), shown on the save-select
+    # screen (the SAVE_TITLE face slots) -- distinct from the message face
+    # configured per Show Message. Comes from the database row until a Change
+    # Actor Face event command (10640) overrides it; defaults to none when the
+    # database row (or edition) does not carry one.
     def faceset_name
+      return @faceset_name if @faceset_name
       @db_row.respond_to?(:faceset_name) ? (@db_row.faceset_name || '') : ''
     end
 
     def faceset_index
+      return @faceset_index if @faceset_index
       @db_row.respond_to?(:faceset_index) ? (@db_row.faceset_index || 0) : 0
+    end
+
+    # Replace the actor's FaceSet graphic (the Change Actor Face event command):
+    # `name` is the file and `index` the cell within it. The override outlives
+    # the database default for the rest of the session.
+    def set_faceset(name, index)
+      @faceset_name = name || ''
+      @faceset_index = index || 0
     end
 
     # Whether the actor knows `skill_id`.
@@ -1982,20 +1993,46 @@ module Game
       @chipset_id = unit.chipset_id
       @lower = unit.lower_layer || []
       @upper = unit.upper_layer || []
+      # Tile Substitution (11750) rewrites, per layer: { old_id => new_id }. Kept
+      # as a lookup applied on read rather than as an edit of the layer arrays,
+      # the way RPG_RT does it — the map data stays pristine, a second
+      # substitution of the same tile replaces (not chains with) the first, and
+      # passability follows the substituted tile because every reader goes
+      # through #lower / #upper. Cleared with the map, so leaving resets it.
+      @substitutions = [{}, {}]
     end
 
     def in_bounds?(x, y)
       x >= 0 && y >= 0 && x < @width && y < @height
     end
 
-    def lower(x, y); tile(@lower, x, y); end
-    def upper(x, y); tile(@upper, x, y); end
+    def lower(x, y); tile(@lower, 0, x, y); end
+    def upper(x, y); tile(@upper, 1, x, y); end
+
+    # Tile Substitution: from now on draw (and treat) every `old_id` tile on
+    # `layer` (0 lower, 1 upper) as `new_id`. Substituting a tile back to itself
+    # drops the rewrite.
+    def substitute_tile(layer, old_id, new_id)
+      table = @substitutions[layer == 0 ? 0 : 1]
+      if old_id == new_id
+        table.delete(old_id)
+      else
+        table[old_id] = new_id
+      end
+    end
+
+    # Whether any tile on either layer is currently rewritten.
+    def substituted?
+      !@substitutions[0].empty? || !@substitutions[1].empty?
+    end
 
     private
 
-    def tile(layer, x, y)
+    def tile(layer, index, x, y)
       return nil unless in_bounds?(x, y)
-      layer[y * @width + x]
+      id = layer[y * @width + x]
+      table = @substitutions[index]
+      table.empty? ? id : (table[id] || id)
     end
   end
 
@@ -3518,6 +3555,11 @@ module Game
     # each nil or a `{ name:, volume:, tempo: }` hash. Play Memorized BGM (11540)
     # restores the stash. Persisted in the save so the memory survives a reload.
     attr_accessor :current_bgm, :memorized_bgm
+    # Whether the current BGM has wrapped back to its start at least once — the
+    # "BGM played once" conditional-branch test (12010 type 9). Cleared whenever
+    # a new BGM starts; set by Scene::Map, which watches `RGSS::Audio.bgm_pos`
+    # and treats a playback position that jumped backwards as a loop.
+    attr_accessor :bgm_looped
     # Whether the party leader's map sprite is hidden, toggled by the Set
     # Transparent Flag / Change Player Visibility (11310) event command. Defaults
     # off (the hero is shown) and is persisted in the save.
@@ -3576,6 +3618,7 @@ module Game
       @escape_access = false
       @current_bgm = nil
       @memorized_bgm = nil
+      @bgm_looped = false
       @player_transparent = false
       @encounter_rate = nil
       @save_count = 0

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -30,14 +30,17 @@ module Game
       CHANGE_EXP       = 10410
       CHANGE_LEVEL     = 10420
       CHANGE_PARAM     = 10430
-      CHANGE_EQUIP     = 10440
+      CHANGE_SKILLS    = 10440
+      CHANGE_EQUIP     = 10450
       CHANGE_HP        = 10460
       CHANGE_MP        = 10470
       CHANGE_CONDITION = 10480
       FULL_HEAL        = 10490
+      SIMULATED_ATTACK = 10500
       CHANGE_ACTOR_NAME   = 10610
       CHANGE_ACTOR_TITLE  = 10620
       CHANGE_ACTOR_SPRITE = 10630
+      CHANGE_ACTOR_FACE   = 10640
       CHANGE_VEHICLE_GRAPHIC = 10650
       CHANGE_SYSTEM_GFX   = 10680
       CHANGE_SYSTEM_BGM   = 10660
@@ -58,6 +61,7 @@ module Game
       INN_END          = 20732
       MEMORIZE_LOCATION = 10820
       RECALL_LOCATION   = 10830
+      ENTER_EXIT_VEHICLE = 10840
       SET_VEHICLE_LOCATION = 10850
       CHANGE_EVENT_LOCATION = 10860
       TRADE_EVENT_LOCATIONS = 10870
@@ -89,25 +93,31 @@ module Game
       ERASE_PICTURE    = 11130
       SHOW_BATTLE_ANIM = 11210
       PLAYER_VISIBILITY = 11310
+      FLASH_SPRITE     = 11320
       MOVE_EVENT       = 11330
       PROCEED_WITH_MOVEMENT = 11340
       HALT_ALL_MOVEMENT = 11350
       WAIT             = 11410
       PLAY_BGM         = 11510
+      FADEOUT_BGM      = 11520
       MEMORIZE_BGM     = 11530
       PLAY_MEMORIZED_BGM = 11540
       PLAY_SE          = 11550
+      PLAY_MOVIE       = 11560
       CHANGE_MAP_TILESET = 11710
       CHANGE_PARALLAX  = 11720
       CHANGE_ENCOUNTER_RATE = 11740
+      TILE_SUBSTITUTION = 11750
       SET_TELEPORT_TARGET = 11810
       CHANGE_TELEPORT_ACCESS = 11820
       SET_ESCAPE_TARGET   = 11830
       CHANGE_ESCAPE_ACCESS   = 11840
+      OPEN_SAVE_MENU   = 11910
       CHANGE_SAVE_ACCESS = 11930
+      OPEN_MAIN_MENU   = 11950
       CHANGE_MENU_ACCESS = 11960
+      GAME_OVER        = 12420
       RETURN_TO_TITLE  = 12510
-      GAME_OVER        = 12520
     end
 
     # Move-command ids inside a Move Event that carry extra parameters (every
@@ -132,11 +142,16 @@ module Game
       @resolver = nil
       @move_route_requests = []
       @location_requests = []
+      @sprite_flash_requests = []
       @erase_requested = false
       @halt_movement_requested = false
       @actor_graphic_changed = false
       @tileset_request = nil
       @parallax_changed = false
+      @tiles_changed = false
+      @vehicle_toggle_requested = false
+      @movie_request = nil
+      @triggered_by_decision_key = false
       @input_variable = nil
       @input_digits = 1
       # Deterministic RNG for the Control Variables "random" operand (mruby has
@@ -154,6 +169,11 @@ module Game
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
+    # Whether the action (decision) key started the event this interpreter is
+    # running — the "the decision key started this event" conditional-branch test
+    # (12010 type 8). Set by the owning scene when it launches a trigger-0 event;
+    # false for auto-start, touch and parallel processes, and for common events.
+    attr_accessor :triggered_by_decision_key
     # Answers tile queries for Store Terrain / Event ID: responds to
     # `terrain_id(x, y)` and `event_id_at(x, y)`. Set by the owning scene; nil
     # makes those commands store 0 (the map is not queryable without it).
@@ -166,12 +186,20 @@ module Game
       @call_stack = []
       @move_route_requests = []
       @location_requests = []
+      @sprite_flash_requests = []
       @erase_requested = false
       @halt_movement_requested = false
       @actor_graphic_changed = false
       @system_graphic_changed = false
       @tileset_request = nil
       @parallax_changed = false
+      @tiles_changed = false
+      @vehicle_toggle_requested = false
+      @movie_request = nil
+      # Cleared per run so a reused interpreter (the shared foreground one, or a
+      # looping parallel process) never inherits the previous event's trigger;
+      # the scene sets it again right after #start for an action-key event.
+      @triggered_by_decision_key = false
       # Messages queued by a stat command (a Change Level / Change EXP with its
       # "show message" flag set) and shown one after another before the event
       # continues. Drained by #resume, so it survives the reset_waits between
@@ -259,6 +287,47 @@ module Game
       v = @system_graphic_changed
       @system_graphic_changed = false
       v
+    end
+
+    # True (once) if a Tile Substitution (11750) rewrote a map tile since the
+    # last call, clearing the flag. The substitution itself is already recorded
+    # on Game::Map; the scene polls this only to know it must redraw the tile
+    # layers (its chipset buffers are cached between frames). Non-blocking.
+    def take_tiles_changed
+      v = @tiles_changed
+      @tiles_changed = false
+      v
+    end
+
+    # True (once) if an Enter/Exit Vehicle (10840) command ran since the last
+    # call, clearing the flag. The owning scene polls this after #update and
+    # boards the vehicle the party is standing on / facing, or disembarks the one
+    # it rides — the same toggle the action button performs. Non-blocking, as the
+    # command carries no wait flag.
+    def take_vehicle_toggle_request
+      v = @vehicle_toggle_requested
+      @vehicle_toggle_requested = false
+      v
+    end
+
+    # Drain the Play Movie (11560) request queued since the last call (a hash:
+    # name, x, y, width, height), or nil. Non-blocking.
+    def take_movie_request
+      req = @movie_request
+      @movie_request = nil
+      req
+    end
+
+    # Drain the Flash Sprite (11320) requests queued since the last call, each a
+    # hash `{ target:, red:, green:, blue:, power:, frames: }` with the Move Event
+    # target ids. The owning scene polls this after #update and starts the flash
+    # on the matching character; when the command carried its wait flag the
+    # interpreter is additionally paused on a :sprite_flash wait until the scene
+    # reports the flash done.
+    def take_sprite_flash_requests
+      reqs = @sprite_flash_requests
+      @sprite_flash_requests = []
+      reqs
     end
 
     # Upper bound on commands run in a single update, so a malformed loop cannot
@@ -538,16 +607,20 @@ module Game
       when Cmd::CHANGE_EXP       then do_change_exp cmd
       when Cmd::CHANGE_LEVEL     then do_change_level cmd
       when Cmd::CHANGE_PARAM     then do_change_params cmd
+      when Cmd::CHANGE_SKILLS    then do_change_skills cmd
       when Cmd::CHANGE_EQUIP     then do_change_equipment cmd
       when Cmd::CHANGE_HP        then do_change_hp cmd
       when Cmd::CHANGE_MP        then do_change_mp cmd
       when Cmd::CHANGE_CONDITION then do_change_condition cmd
       when Cmd::FULL_HEAL        then do_full_heal cmd
+      when Cmd::SIMULATED_ATTACK then do_simulated_attack cmd
       when Cmd::CHANGE_ACTOR_NAME   then do_change_actor_name cmd
       when Cmd::CHANGE_ACTOR_TITLE  then do_change_actor_title cmd
       when Cmd::CHANGE_ACTOR_SPRITE then do_change_actor_sprite cmd
+      when Cmd::CHANGE_ACTOR_FACE   then do_change_actor_face cmd
       when Cmd::CHANGE_VEHICLE_GRAPHIC then do_change_vehicle_graphic cmd
       when Cmd::SET_VEHICLE_LOCATION then do_set_vehicle_location cmd
+      when Cmd::ENTER_EXIT_VEHICLE then @vehicle_toggle_requested = true
       when Cmd::CONDITIONAL      then do_conditional cmd
       when Cmd::ELSE_BRANCH      then skip_to([Cmd::END_BRANCH], cmd.indent); consume
       when Cmd::END_BRANCH       then nil
@@ -574,17 +647,21 @@ module Game
       when Cmd::SHOW_BATTLE_ANIM then do_show_battle_animation cmd
       when Cmd::WEATHER_EFFECTS  then do_weather cmd
       when Cmd::PLAYER_VISIBILITY then do_player_visibility cmd
+      when Cmd::FLASH_SPRITE     then do_flash_sprite cmd
       when Cmd::MOVE_EVENT       then do_move_event cmd
       when Cmd::PROCEED_WITH_MOVEMENT then do_proceed_with_movement cmd
       when Cmd::HALT_ALL_MOVEMENT then @halt_movement_requested = true
       when Cmd::WAIT             then do_wait cmd
       when Cmd::PLAY_BGM         then play_audio(:bgm, cmd)
+      when Cmd::FADEOUT_BGM      then do_fadeout_bgm cmd
       when Cmd::MEMORIZE_BGM     then do_memorize_bgm cmd
       when Cmd::PLAY_MEMORIZED_BGM then do_play_memorized_bgm cmd
       when Cmd::PLAY_SE          then play_audio(:se, cmd)
+      when Cmd::PLAY_MOVIE       then do_play_movie cmd
       when Cmd::CHANGE_MAP_TILESET then @tileset_request = cmd.param(0)
       when Cmd::CHANGE_PARALLAX   then do_change_parallax cmd
       when Cmd::CHANGE_ENCOUNTER_RATE then @state.encounter_rate = cmd.param(0)
+      when Cmd::TILE_SUBSTITUTION then do_tile_substitution cmd
       when Cmd::SET_TELEPORT_TARGET then do_set_teleport_target cmd
       when Cmd::SET_ESCAPE_TARGET   then do_set_escape_target cmd
       when Cmd::CHANGE_SYSTEM_GFX     then do_change_system_graphic cmd
@@ -593,14 +670,18 @@ module Game
       when Cmd::CHANGE_TRANSITION    then @state.set_screen_transition(cmd.param(0), cmd.param(1))
       when Cmd::CHANGE_TELEPORT_ACCESS then @state.teleport_access = cmd.param(0) != 0
       when Cmd::CHANGE_ESCAPE_ACCESS then @state.escape_access = cmd.param(0) != 0
+      when Cmd::OPEN_SAVE_MENU   then do_open_save_menu cmd
       when Cmd::CHANGE_SAVE_ACCESS then @state.save_access = cmd.param(0) != 0
+      when Cmd::OPEN_MAIN_MENU   then do_open_main_menu cmd
       when Cmd::CHANGE_MENU_ACCESS then @state.menu_access = cmd.param(0) != 0
       when Cmd::RETURN_TO_TITLE  then do_return_to_title cmd
       when Cmd::GAME_OVER        then do_game_over cmd
       when Cmd::CALL_EVENT       then do_call_event cmd
       when Cmd::ERASE_EVENT      then @erase_requested = true
       when Cmd::END_EVENT        then @index = @list.size
-      else nil # unimplemented / no-op (labels, comments, ...)
+      when Cmd::LABEL            then nil # jump target only; Jump to Label finds it
+      when Cmd::COMMENT, Cmd::COMMENT_2 then nil # developer annotation
+      else nil # blank editor lines (codes 0 / 10) and RPG2003-only commands
       end
     end
 
@@ -1179,6 +1260,35 @@ module Game
       stat_targets(cmd).each { |a| a.full_heal }
     end
 
+    # Simulated Attack (10500): hurt the target actors with an attack that has no
+    # attacker — the event supplies the attack power itself. param0/param1 pick
+    # the targets (the shared scope layout); param2 is the attack strength,
+    # param3 how much the target's defence counts and param4 how much its spirit
+    # counts, each as a permille-style divisor, and param5 the damage spread.
+    # When param6 is set the damage dealt is also written into variable param7.
+    # The formula is EasyRPG Player's CommandSimulatedAttack, which mirrors
+    # RPG_RT: `atk - def * p_def / 400 - spi * p_spi / 800`, then spread by
+    # +/- (param5 * 5) percent and floored at 0. The hit can be lethal.
+    def do_simulated_attack(cmd)
+      atk = cmd.param(2)
+      damage = 0
+      stat_targets(cmd).each do |a|
+        damage = atk - (a.def * cmd.param(3)) / 400 - (a.int * cmd.param(4)) / 800
+        damage += damage * simulated_attack_spread(cmd.param(5)) / 100
+        damage = 0 if damage < 0
+        a.change_hp(-damage, true)
+      end
+      variables[cmd.param(7)] = damage if cmd.param(6) != 0
+    end
+
+    # A Simulated Attack's random damage spread, as a percentage in
+    # -(variance * 5) .. +(variance * 5). A variance of 0 never spreads.
+    def simulated_attack_spread(variance)
+      return 0 if variance.nil? || variance <= 0
+      span = variance * 5
+      @rng.random(span * 2 + 1) - span
+    end
+
     # Change Condition: inflict or cure a status condition on the target actors.
     # param0/param1 pick the targets (same scope layout as Change HP); param2 is
     # the operation (0 add / inflict, non-zero remove / cure) and param3 the state
@@ -1224,6 +1334,17 @@ module Game
       actor.set_charset(cmd.string || '', cmd.param(1))
       actor.transparent = cmd.param(2) != 0
       @actor_graphic_changed = true
+    end
+
+    # Change Actor Face (10640): give the actor whose id is param0 a new FaceSet
+    # graphic — the command string names the file and param1 the cell index. This
+    # is the actor's own portrait (menus, the save-select screen), not the message
+    # face a Change Face Graphic (10130) selects, so nothing on the map reloads.
+    # A no-op for an actor not in the party.
+    def do_change_actor_face(cmd)
+      actor = party.actor_by_id(cmd.param(0))
+      return unless actor
+      actor.set_faceset(cmd.string || '', cmd.param(1))
     end
 
     # The vehicle a vehicle command targets: param0 is 0 boat / 1 ship /
@@ -1274,11 +1395,25 @@ module Game
       stat_targets(cmd).each { |a| a.change_param(type, amount) }
     end
 
-    # Change Equipment. param2 selects the operation: 0 equips an item (param3 0
-    # = the item id in param4, 1 = the id held in variable param4) into the slot
-    # matching its type; 1 removes equipment, param4 selecting the slot (0..4, or
-    # 5 for every slot). Confirmed against real events, e.g. `[1, 3, 0, 0, 127]`
-    # equips armour 127 onto actor 3.
+    # Change Skills (10440): teach or remove a skill. param0/param1 pick the
+    # targets (the shared scope layout), param2 is the operation (0 learn, 1
+    # forget) and param3/param4 the skill operand (0 = the id in param4, 1 = the
+    # id held in variable param4). Skill id 0 is the editor's "none" and is
+    # ignored.
+    def do_change_skills(cmd)
+      skill_id = cmd.param(3) == 0 ? cmd.param(4) : variables[cmd.param(4)]
+      return if skill_id.nil? || skill_id <= 0
+      forget = cmd.param(2) != 0
+      stat_targets(cmd).each do |a|
+        forget ? a.forget_skill(skill_id) : a.learn_skill(skill_id)
+      end
+    end
+
+    # Change Equipment (10450). param2 selects the operation: 0 equips an item
+    # (param3 0 = the item id in param4, 1 = the id held in variable param4) into
+    # the slot matching its type; 1 removes equipment, param4 selecting the slot
+    # (0..4, or 5 for every slot). Confirmed against real events, e.g.
+    # `[1, 3, 0, 0, 127]` equips armour 127 onto actor 3.
     def do_change_equipment(cmd)
       targets = stat_targets(cmd)
       if cmd.param(2) == 0
@@ -1323,6 +1458,10 @@ module Game
              # 1 ship / 2 airship)
         v = cmd.param(1)
         v >= 0 && v < Vehicle::TYPES.size && @state.boarded == Vehicle::TYPES[v]
+      when 8 # the decision (action) key started this event
+        @triggered_by_decision_key ? true : false
+      when 9 # the BGM has played through at least once
+        @state.bgm_looped ? true : false
       else true
       end
     end
@@ -1534,6 +1673,62 @@ module Game
       @state.player_transparent = cmd.param(0) != 0
     end
 
+    # Flash Sprite (11320): pulse a character's sprite with a colour that decays
+    # to nothing. param0 is the target (the Move Event target scheme: 10001 the
+    # hero, 0 / 10005 this event, else a map event id), param1..3 the colour and
+    # param4 its strength — all four stored 0..31, so they are scaled by 8 to the
+    # 0..248 the renderer works in, as EasyRPG's CommandFlashSprite does — param5
+    # the duration in tenths of a second and param6 the wait flag. Queued for the
+    # owning scene (which owns the sprites); with the wait flag set the event also
+    # pauses on a :sprite_flash wait until the scene reports the flash finished.
+    FLASH_CHANNEL_SCALE = 8
+
+    def do_flash_sprite(cmd)
+      frames = cmd.param(5) * FRAMES_PER_TENTH
+      @sprite_flash_requests.push(
+        target: cmd.param(0),
+        red: cmd.param(1) * FLASH_CHANNEL_SCALE,
+        green: cmd.param(2) * FLASH_CHANNEL_SCALE,
+        blue: cmd.param(3) * FLASH_CHANNEL_SCALE,
+        power: cmd.param(4) * FLASH_CHANNEL_SCALE,
+        frames: frames
+      )
+      return unless cmd.param(6) != 0 && frames > 0
+      @wait_kind = :sprite_flash
+      @waiting = true
+    end
+
+    # Open Save Menu (11910): hand control to the save screen. Raised as a
+    # :save_menu request the owning scene answers by saving (and reporting the
+    # outcome), then resuming the event where it left off. A Change Save Access
+    # command that forbade saving also forbids this, matching RPG_RT.
+    def do_open_save_menu(_cmd)
+      @wait_kind = :save_menu
+      @waiting = true
+    end
+
+    # Open Main Menu (11950): open the field menu as though the player had
+    # pressed cancel. Raised as a :menu request the owning scene answers by
+    # pushing Scene::Menu; the event resumes once the player closes it. Unlike
+    # the cancel button this ignores the Change Main Menu Access flag — RPG_RT
+    # lets an event open the menu it has otherwise locked out.
+    def do_open_main_menu(_cmd)
+      @wait_kind = :menu
+      @waiting = true
+    end
+
+    # Tile Substitution (11750): from here on, draw and treat every occurrence of
+    # tile param1 on layer param0 (0 lower, 1 upper) as tile param2. Recorded on
+    # the current Game::Map (so passability follows the swap) and flagged so the
+    # scene redraws its cached tile layers. Non-blocking; the rewrite lasts until
+    # the map is left, as in RPG_RT.
+    def do_tile_substitution(cmd)
+      map = @state.map
+      return unless map.respond_to?(:substitute_tile)
+      map.substitute_tile(cmd.param(0), cmd.param(1), cmd.param(2))
+      @tiles_changed = true
+    end
+
     # Return to Title Screen: abandon the running game and go back to the title.
     # Raised as a :return_title request the owning scene answers by tearing the
     # play scenes down and showing a fresh title (there is nothing to resume, so
@@ -1543,7 +1738,7 @@ module Game
       @waiting = true
     end
 
-    # Game Over (12520): raised as a :game_over request the owning scene answers
+    # Game Over (12420): raised as a :game_over request the owning scene answers
     # by ending the game (RPG2000 shows the Game Over screen, then the title).
     # Like Return to Title there is nothing to resume — the event stops here.
     def do_game_over(_cmd)
@@ -1724,6 +1919,38 @@ module Game
       @state.weather.set(cmd.param(0), cmd.param(1))
     end
 
+    # Fade Out BGM (11520): fade the music to silence over param0 tenths of a
+    # second, then leave nothing playing. Clears the current-BGM record so a
+    # Memorize BGM taken afterwards memorises silence, as RPG_RT does.
+    # Non-blocking — the event runs on while the music fades.
+    MS_PER_TENTH = 100
+
+    def do_fadeout_bgm(cmd)
+      @state.current_bgm = nil
+      @state.bgm_looped = false
+      RGSS::Audio.bgm_fade(cmd.param(0) * MS_PER_TENTH)
+    rescue StandardError => e
+      $stderr.puts "[RPG2k] BGM fade-out failed: #{e.message}"
+      nil
+    end
+
+    # Play Movie (11560): show a video file over the map. The command string
+    # names the Movie/<name> file, param0 selects literal (0) or variable (1)
+    # placement, param1/param2 the top-left position and param3/param4 the size.
+    # No backend here decodes video, so the request is recorded for the scene
+    # (which logs it) rather than silently dropped; playback itself is the one
+    # part of the command that is not modelled.
+    def do_play_movie(cmd)
+      x = cmd.param(1)
+      y = cmd.param(2)
+      if cmd.param(0) != 0
+        x = variables[x]
+        y = variables[y]
+      end
+      @movie_request = { name: (cmd.string || '').to_s, x: x, y: y,
+                         width: cmd.param(3), height: cmd.param(4) }
+    end
+
     # Memorize BGM: stash a copy of the currently-playing BGM so a later Play
     # Memorized BGM can restore it (e.g. duck to a fanfare, then return). Nothing
     # playing memorises nothing. Non-blocking.
@@ -1820,6 +2047,7 @@ module Game
       return if bgm.nil? || bgm[:name].nil? || bgm[:name].empty?
       RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
       @state.current_bgm = bgm.dup
+      @state.bgm_looped = false
     rescue StandardError => e
       $stderr.puts "[RPG2k] memorized BGM playback failed: #{e.message}"
       nil
@@ -1836,6 +2064,7 @@ module Game
         # Track what is playing so Memorize BGM can stash it (RPG_RT keeps this
         # as the "current system BGM" regardless of whether playback succeeds).
         @state.current_bgm = { name: name, volume: volume, tempo: pitch }
+        @state.bgm_looped = false # a fresh track has not looped yet
         RGSS::Audio.bgm_play(name, volume, pitch)
       else
         # PlaySE parameters: [volume, tempo, balance].

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -521,6 +521,8 @@ class RPG2k
         @timer_window.dispose if @timer_window
         @airship_shadow.dispose if @airship_shadow
         @animation_sprite.dispose if @animation_sprite
+        @flash_buffer.dispose if @flash_buffer
+        @flash_out_buffer.dispose if @flash_out_buffer
         @chipset_bmp.dispose if @chipset_bmp
         @parallax_img.dispose if @parallax_img
       end
@@ -529,6 +531,8 @@ class RPG2k
         @state.tick_timer # the timer keeps counting during events too
         @state.screen.update # screen tint progresses every frame, even in events
         @state.update_pictures # picture moves progress every frame too
+        update_sprite_flashes # Flash Sprite decays during events too
+        watch_bgm_loop # so the "BGM played once" branch can be answered
         @anim_frame += 1 # water / animated tiles cycle even during events
         if event_busy?
           drive_event
@@ -1079,11 +1083,7 @@ class RPG2k
           it.start(p[:commands]) # loop the process
           it.update
         end
-        apply_move_requests(it, p[:event])
-        apply_location_requests(it, p[:event])
-        apply_erase_request(it, p[:event])
-        apply_tileset_request(it)
-        apply_parallax_request(it)
+        apply_interpreter_requests(it, p[:event])
       rescue StandardError
         nil
       end
@@ -1110,11 +1110,14 @@ class RPG2k
         @event_tiles[[x, y]]
       end
 
-      # Turn `ev` to face the player and run its command list.
-      def start_event(ev)
+      # Turn `ev` to face the player and run its command list. `by_decision_key`
+      # records that the action button (not a touch or auto-start) launched it,
+      # which the "the decision key started this event" conditional branch reads.
+      def start_event(ev, by_decision_key = false)
         ev[:char].face(ev[:char].direction_toward(@state.x, @state.y))
         @active_event = ev
         @interpreter.start(ev[:commands])
+        @interpreter.triggered_by_decision_key = by_decision_key
       end
 
       # On the action button, run the trigger-0 event the player is facing. The
@@ -1124,7 +1127,7 @@ class RPG2k
         return unless Input.trigger?(Input::C)
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
         ev = event_at(fx, fy)
-        start_event(ev) if ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands]
+        start_event(ev, true) if ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands]
       end
 
       # On the action button, board a placed vehicle the party is standing on
@@ -1500,6 +1503,193 @@ class RPG2k
         @parallax_img = nil
       end
 
+      # -- "BGM played once" ---------------------------------------------------
+
+      # Watch the music's playback position so the conditional branch that asks
+      # whether the BGM has played through at least once (12010 type 9) can be
+      # answered. SDL_mixer loops a track by seeking back to its start, so a
+      # position that jumped backwards is a loop; the flag is cleared whenever a
+      # new BGM starts (see Game::Interpreter#play_audio). A backend that cannot
+      # report a position always returns 0, which never counts as a loop.
+      def watch_bgm_loop
+        return if @bgm_pos_unavailable
+        return unless RGSS::Audio.respond_to?(:bgm_pos)
+        pos = RGSS::Audio.bgm_pos.to_i
+        prev = @bgm_pos || 0
+        @bgm_pos = pos
+        @state.bgm_looped = true if pos < prev && @state.current_bgm
+      rescue StandardError => e
+        # Report once and stop polling, rather than repeating the same failure
+        # sixty times a second; the branch then never reports a loop.
+        @bgm_pos_unavailable = true
+        $stderr.puts "[RPG2k] BGM position unavailable, 'BGM played once' " \
+                     "branches will not fire: #{e.message}"
+      end
+
+      # -- Tile Substitution ---------------------------------------------------
+
+      # A Tile Substitution rewrote a tile id on the current map (11750). The map
+      # itself already answers every lookup with the substituted tile
+      # (Game::Map#substitute_tile), and draw_layers rebuilds both tile buffers
+      # from those lookups every frame, so the swap is on screen on the next
+      # render with nothing to invalidate here. Draining the flag is what keeps
+      # the request from being reported again next step.
+      def apply_tile_substitution(interp)
+        interp.take_tiles_changed
+        nil
+      end
+
+      # -- Enter/Exit Vehicle --------------------------------------------------
+
+      # Board or leave a vehicle on the event's behalf (10840) — the same toggle
+      # the action button performs, so an event can put the party on the ship it
+      # just placed, or set them ashore.
+      def apply_vehicle_toggle(interp)
+        return unless interp.take_vehicle_toggle_request
+        if @state.boarded?
+          disembark_vehicle
+        else
+          board_vehicle
+        end
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Enter/Exit Vehicle failed: #{e.message}"
+        nil
+      end
+
+      # -- Play Movie ----------------------------------------------------------
+
+      # Report a Play Movie request (11560). No video decoder is linked in, so
+      # the movie cannot be shown; the request is logged rather than dropped in
+      # silence, so a game that plays a cut-scene here is visible in the trace.
+      def apply_movie_request(interp)
+        req = interp.take_movie_request
+        return if req.nil?
+        $stderr.puts "[RPG2k] Play Movie '#{req[:name]}' at (#{req[:x]}, #{req[:y]}) " \
+                     "#{req[:width]}x#{req[:height]}: video playback is not supported"
+      end
+
+      # -- Flash Sprite --------------------------------------------------------
+
+      # Start the character flashes an interpreter queued this step (11320). The
+      # hero and map events both keep their flash as a decaying colour the
+      # renderer tones their CharSet frame with; a target that cannot be resolved
+      # (a vehicle, or an unknown event id) simply flashes nothing.
+      def apply_sprite_flash_requests(interp, this_event)
+        reqs = interp.take_sprite_flash_requests
+        return if reqs.nil? || reqs.empty?
+        started = nil
+        reqs.each { |r| started = apply_sprite_flash(r, this_event) || started }
+        # A Flash Sprite that carried its wait flag paused the interpreter on a
+        # :sprite_flash wait; remember the flash it started so the wait releases
+        # on *that* character, not on some other one still flashing.
+        @flash_wait = started if interp.wait_kind == :sprite_flash
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Flash Sprite failed: #{e.message}"
+        nil
+      end
+
+      # Start one queued flash, returning the flash it attached to a character
+      # (nil when the target could not be resolved, so nothing flashes).
+      def apply_sprite_flash(r, this_event)
+        flash = { red: r[:red], green: r[:green], blue: r[:blue],
+                  power: r[:power], frames: r[:frames], total: r[:frames] }
+        return nil if flash[:frames] <= 0
+        case r[:target]
+        when MOVE_TARGET_PLAYER
+          @player_flash = flash
+          @last_frame = nil # force the hero's cached frame to be re-toned
+          flash
+        when 0, MOVE_TARGET_THIS
+          this_event ? (this_event[:flash] = flash) : nil
+        else
+          ev = @events.find { |e| e[:id] == r[:target] }
+          ev ? (ev[:flash] = flash) : nil
+        end
+      end
+
+      # Whether the flash a waiting Flash Sprite started is still running. The
+      # flash hash is decayed in place by update_sprite_flashes, so holding the
+      # reference is enough to see it run out even after the character has
+      # dropped it.
+      def sprite_flashing?
+        @flash_wait && @flash_wait[:frames] > 0 ? true : false
+      end
+
+      # Advance every running character flash one frame, dropping the ones that
+      # have decayed away. Called once per frame from #update, so a flash fades
+      # during messages and forced movement too, as RPG_RT's does.
+      def update_sprite_flashes
+        # Invalidate the hero's cached frame whenever a flash was running this
+        # tick — including the tick it ends on, so the last toned frame is
+        # replaced by the plain one instead of staying baked in.
+        @last_frame = nil if @player_flash
+        @player_flash = tick_flash(@player_flash)
+        @events.each { |e| e[:flash] = tick_flash(e[:flash]) if e[:flash] }
+      end
+
+      def tick_flash(flash)
+        return nil if flash.nil?
+        flash[:frames] -= 1
+        flash[:frames] > 0 ? flash : nil
+      end
+
+      # The RGSS tone that paints `flash` over a CharSet frame: the flash colour
+      # scaled by how much of the flash is left, added to every pixel (alpha is
+      # untouched, so the sprite keeps its shape).
+      def flash_tone(flash)
+        strength = flash[:power] * flash[:frames] / flash[:total]
+        Tone.new(flash[:red] * strength / 255, flash[:green] * strength / 255,
+                 flash[:blue] * strength / 255, 0)
+      end
+
+      # Scratch CharSet-sized buffers the flash pass uses: the frame is blitted
+      # into the first and toned into the second (tone_blt needs a same-size
+      # source and writes to a separate destination).
+      def flash_buffer
+        @flash_buffer ||= Bitmap.new(Game::CharSet::WIDTH, Game::CharSet::HEIGHT)
+      end
+
+      def flash_out_buffer
+        @flash_out_buffer ||= Bitmap.new(Game::CharSet::WIDTH, Game::CharSet::HEIGHT)
+      end
+
+      # -- Open Save Menu / Open Main Menu -------------------------------------
+
+      # Open Save Menu (11910): save the game on the event's behalf and report
+      # the outcome, then let the event continue. The clone has a single save
+      # slot (Scene::Menu's Save entry writes it), so there is no slot picker to
+      # show; a Change Save Access that forbade saving is honoured, as in RPG_RT.
+      def perform_event_save
+        if @state.save_access
+          saved = @parent.save_game(@state)
+          $stderr.puts "[RPG2k] Open Save Menu: #{saved ? 'saved' : 'save failed'}"
+        else
+          $stderr.puts '[RPG2k] Open Save Menu: saving is disabled'
+        end
+        @interpreter.resume
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Open Save Menu failed: #{e.message}"
+        @interpreter.resume
+      end
+
+      # Open Main Menu (11950): push the field menu over the map, then resume the
+      # event once the player closes it again. `@event_menu` marks that this
+      # scene is waiting on its own menu, so the event stays paused for exactly
+      # one visit instead of re-opening it every frame.
+      def perform_event_menu
+        if @event_menu
+          @event_menu = false
+          @interpreter.resume
+        else
+          @event_menu = true
+          @parent.push Scene::Menu.new(@parent, @state)
+        end
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Open Main Menu failed: #{e.message}"
+        @event_menu = false
+        @interpreter.resume
+      end
+
       # -- Move Event (Set Move Route) ----------------------------------------
 
       # Apply the Move Event requests an interpreter queued this step. `this_event`
@@ -1779,17 +1969,31 @@ class RPG2k
           when :game_over then perform_game_over
           when :name_input then drive_name_input
           when :animation then drive_map_animation
+          when :sprite_flash then @interpreter.resume unless sprite_flashing?
+          when :save_menu then perform_event_save
+          when :menu then perform_event_menu
           end
         else
           @interpreter.update
-          apply_move_requests(@interpreter, @active_event)
-          apply_location_requests(@interpreter, @active_event)
-          apply_erase_request(@interpreter, @active_event)
-          apply_halt_request(@interpreter)
-          apply_graphic_change(@interpreter)
-          apply_tileset_request(@interpreter)
-          apply_parallax_request(@interpreter)
+          apply_interpreter_requests(@interpreter, @active_event)
         end
+      end
+
+      # Drain every non-blocking request the interpreter queued this step and
+      # apply it to the map / scene. Shared by the foreground event and each
+      # parallel process, so both surfaces honour the same commands.
+      def apply_interpreter_requests(interp, this_event)
+        apply_move_requests(interp, this_event)
+        apply_location_requests(interp, this_event)
+        apply_erase_request(interp, this_event)
+        apply_halt_request(interp)
+        apply_graphic_change(interp)
+        apply_tileset_request(interp)
+        apply_parallax_request(interp)
+        apply_tile_substitution(interp)
+        apply_sprite_flash_requests(interp, this_event)
+        apply_vehicle_toggle(interp)
+        apply_movie_request(interp)
       end
 
       # Maps the interpreter's accepted-key symbols onto RGSS input buttons.
@@ -3911,7 +4115,32 @@ class RPG2k
         epx, epy = event_pixel(e)
         dx = epx - cam_x - (Game::CharSet::WIDTH - TILE) / 2
         dy = epy - cam_y - (Game::CharSet::HEIGHT - TILE)
-        bmp.blt dx, dy, charset, Rect.new(sx, sy, sw, sh), opacity
+        src = Rect.new(sx, sy, sw, sh)
+        toned = e[:flash] && flashed_charset(charset, src, e[:flash])
+        if toned
+          bmp.blt dx, dy, toned,
+                  Rect.new(0, 0, Game::CharSet::WIDTH, Game::CharSet::HEIGHT), opacity
+        else
+          bmp.blt dx, dy, charset, src, opacity
+        end
+      end
+
+      # A Flash-Sprite-tinted copy of one CharSet frame, or nil when the tone
+      # pass is unavailable. The frame is lifted into a scratch buffer (tone_blt
+      # works on same-size bitmaps) and toned with the flash's current colour,
+      # which brightens the sprite toward that colour without touching its alpha
+      # — so the flash keeps the character's outline instead of painting a
+      # rectangle over it.
+      def flashed_charset(charset, src, flash)
+        buf = flash_buffer
+        buf.clear
+        buf.blt 0, 0, charset, src
+        out = flash_out_buffer
+        out.tone_blt buf, flash_tone(flash)
+        out
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] sprite flash tone failed: #{e.message}"
+        nil
       end
 
       # Blit an event whose graphic is a chipset tile (16x16), aligned to its
@@ -3943,8 +4172,18 @@ class RPG2k
         @last_frame = frame
 
         rx, ry, rw, rh = Game::CharSet.frame_rect(@charset_index, @state.direction, pat)
+        src = Rect.new(rx, ry, rw, rh)
+        # A Flash Sprite aimed at the hero tones the frame as it is laid down
+        # (update_sprite_flashes invalidates @last_frame each frame it runs, so
+        # the fading colour is re-applied rather than baked in once).
+        toned = @player_flash && flashed_charset(@charset, src, @player_flash)
         @player_bmp.clear
-        @player_bmp.blt 0, 0, @charset, Rect.new(rx, ry, rw, rh)
+        if toned
+          @player_bmp.blt 0, 0, toned,
+                          Rect.new(0, 0, Game::CharSet::WIDTH, Game::CharSet::HEIGHT)
+        else
+          @player_bmp.blt 0, 0, @charset, src
+        end
       end
 
       # Deterministic, memoised colour for a tile id so distinct tiles read as

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -60,10 +60,10 @@ CODE_NAMES = {
   10440 => 'ChangeSkills',           10450 => 'ChangeEquipment',
   10460 => 'ChangeHP',               10470 => 'ChangeSP',          10480 => 'ChangeCondition',
   10490 => 'FullHeal',               10500 => 'SimulatedAttack',
-  10510 => 'ChangeHeroName',         10520 => 'ChangeHeroTitle',
-  10530 => 'ChangeSpriteAssociation',10540 => 'ChangeActorFace',
-  10610 => 'ChangeVehicleGraphic',   10620 => 'ChangeSystemBGM',   10630 => 'ChangeSystemSFX',
-  10640 => 'ChangeSystemGraphics',   10650 => 'ChangeScreenTransitions',
+  10610 => 'ChangeHeroName',         10620 => 'ChangeHeroTitle',
+  10630 => 'ChangeSpriteAssociation',10640 => 'ChangeActorFace',
+  10650 => 'ChangeVehicleGraphic',   10660 => 'ChangeSystemBGM',   10670 => 'ChangeSystemSFX',
+  10680 => 'ChangeSystemGraphics',   10690 => 'ChangeScreenTransitions',
   10710 => 'EnemyEncounter',         10720 => 'OpenStore',         10730 => 'ShowInn',
   10740 => 'EnterHeroName',
   10810 => 'Teleport',               10820 => 'MemorizeLocation',  10830 => 'RecallToLocation',
@@ -110,15 +110,16 @@ MOVE_NAMES = {
 # Event-command opcodes the runtime interpreter implements with a real handler
 # (mruby-rpg2k/mrblib/interpreter.rb `execute`). Structural markers the
 # interpreter consumes as control flow count as supported.
-SUPPORTED = [
-  10110, 20110, 10120, 10130, 10140, 20140, 20141, 10210, 10220, 10230, 10310,
-  10320, 10330, 10410, 10420, 10430, 10440, 10460, 10470, 10490, 12010, 22010, 22011,
-  12110, 12120,
-  12210, 12220, 22210, 12310, 12320, 12330, 10810, 10820, 10830, 10910, 10920,
-  11030, 11040, 11050, 11060, 11110, 11120, 11130, 11330, 11340, 11410, 11510, 11530, 11540, 11550,
-  11930,
-  11960,
-].to_set
+#
+# Read out of the interpreter's own opcode table rather than duplicated here:
+# every constant in `Game::Interpreter::Cmd` is either dispatched to a handler or
+# consumed as a branch marker, so the coverage figures cannot drift out of date
+# as commands land. interpreter.rb has no load-time dependency on RGSS or the
+# native parser, so it loads under CRuby exactly as the check scripts load it.
+load File.expand_path('../mruby-rpg2k/mrblib/interpreter.rb', __dir__)
+SUPPORTED = Game::Interpreter::Cmd.constants
+                                  .map { |c| Game::Interpreter::Cmd.const_get(c) }
+                                  .to_set
 
 # Opcodes that do nothing at run time by design: developer comments and blank /
 # block-structure lines. The interpreter no-ops them, which is the correct

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -22,6 +22,7 @@ module RGSS
     class << self
       attr_accessor :log
       def bgm_play(*a); (@log ||= []) << [:bgm, *a]; end
+      def bgm_fade(*a); (@log ||= []) << [:bgm_fade, *a]; end
       def se_play(*a);  (@log ||= []) << [:se, *a];  end
     end
   end
@@ -102,6 +103,12 @@ class FakeCmd
 end
 
 R = Game::MoveRoute
+
+# A 2x2 Game::Map over literal tile arrays, for the Tile Substitution checks.
+FakeMapUnit = Struct.new(:width, :height, :chipset_id, :lower_layer, :upper_layer)
+def fake_map_2x2(lower, upper)
+  Game::Map.new(1, FakeMapUnit.new(2, 2, 1, lower, upper))
+end
 
 # -- Character ----------------------------------------------------------------
 
@@ -4581,6 +4588,251 @@ check 'Battle end_round clears a queued Skill / Item command' do
   b.command_skill(mage, foe, name: 'Fire', cost: 6, hp: -30)
   b.run_round
   eq nil, mage.command, 'the command is cleared for the next round'
+end
+
+# -- newly-implemented event commands -----------------------------------------
+
+# The opcodes are the numbers real .ldb/.lmu data carries, so a typo here is a
+# command the runtime silently ignores. These pin the four that were wrong or
+# missing against liblcf's Code enum.
+check 'event-command opcodes match the LCF Code enum' do
+  eq 10440, IC::CHANGE_SKILLS
+  eq 10450, IC::CHANGE_EQUIP
+  eq 10500, IC::SIMULATED_ATTACK
+  eq 10640, IC::CHANGE_ACTOR_FACE
+  eq 10840, IC::ENTER_EXIT_VEHICLE
+  eq 11320, IC::FLASH_SPRITE
+  eq 11520, IC::FADEOUT_BGM
+  eq 11560, IC::PLAY_MOVIE
+  eq 11750, IC::TILE_SUBSTITUTION
+  eq 11910, IC::OPEN_SAVE_MENU
+  eq 11950, IC::OPEN_MAIN_MENU
+  eq 12420, IC::GAME_OVER
+  eq 12510, IC::RETURN_TO_TITLE
+end
+
+check 'Change Skills teaches and removes a skill' do
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  it = Game::Interpreter.new(st)
+  # scope 1 (fixed id), actor 1, op 0 (learn), operand const, skill 12
+  it.start([FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 0, 0, 12])])
+  it.update
+  ok hero.knows_skill?(12), 'the skill was learnt'
+
+  it.start([FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 1, 0, 12])]) # op 1 = forget
+  it.update
+  ok !hero.knows_skill?(12), 'the skill was forgotten'
+end
+
+check 'Change Skills reads the skill id from a variable and skips id 0' do
+  st = party_state
+  st.variables[4] = 21
+  hero = st.party.actor_by_id(1)
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 0, 1, 4]),  # operand type 1 -> var 4
+    FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 0, 0, 0]),  # skill 0 = "none"
+  ])
+  it.update
+  ok hero.knows_skill?(21), 'the variable named the skill'
+  ok !hero.knows_skill?(0), 'skill id 0 is ignored'
+end
+
+check 'Change Skills applies to the whole party with scope 0' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_SKILLS, [0, 0, 0, 0, 9])])
+  it.update
+  ok st.party.actors.all? { |a| a.knows_skill?(9) }, 'everyone learnt it'
+end
+
+check 'Simulated Attack damages the target by atk less its defence share' do
+  st = party_state
+  hero = st.party.actor_by_id(1) # def 8, hp 100
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 1, atk 50, def-weight 400, spi-weight 0, variance 0,
+  # store-damage flag 0.
+  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 50, 400, 0, 0, 0, 0])])
+  it.update
+  eq 58, hero.hp # 100 HP less (50 - 8 * 400 / 400) = 42 damage
+end
+
+check 'Simulated Attack stores the damage it dealt in a variable' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 30, 0, 0, 0, 1, 6])])
+  it.update
+  eq 30, st.variables[6]
+  eq 70, st.party.actor_by_id(1).hp
+end
+
+check 'Simulated Attack floors the damage at zero' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # An attack far weaker than the target's defence must heal nobody.
+  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 1, 4000, 0, 0, 1, 2])])
+  it.update
+  eq 0, st.variables[2]
+  eq 100, st.party.actor_by_id(1).hp
+end
+
+check 'Change Actor Face overrides the actor FaceSet' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_ACTOR_FACE, [1, 3], string: 'Faces1')])
+  it.update
+  hero = st.party.actor_by_id(1)
+  eq 'Faces1', hero.faceset_name
+  eq 3, hero.faceset_index
+  ok !it.waiting?, 'Change Actor Face must not pause the interpreter'
+end
+
+check 'Enter/Exit Vehicle raises a one-shot toggle request' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ENTER_EXIT_VEHICLE, [])])
+  it.update
+  ok !it.waiting?, 'Enter/Exit Vehicle must not pause the interpreter'
+  eq true, it.take_vehicle_toggle_request
+  eq false, it.take_vehicle_toggle_request, 'the request is one-shot'
+end
+
+check 'Flash Sprite queues a scaled flash and waits when asked' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # target the hero, colour 31/0/16, power 31, 5 tenths, wait flag set
+  it.start([FakeCmd.new(IC::FLASH_SPRITE, [10001, 31, 0, 16, 31, 5, 1])])
+  it.update
+  reqs = it.take_sprite_flash_requests
+  eq 1, reqs.size
+  eq 10001, reqs[0][:target]
+  eq [248, 0, 128, 248], [reqs[0][:red], reqs[0][:green], reqs[0][:blue],
+                          reqs[0][:power]]
+  eq 30, reqs[0][:frames] # 5 tenths at 6 frames each
+  eq :sprite_flash, it.wait_kind
+  eq [], it.take_sprite_flash_requests, 'the queue drains'
+end
+
+check 'Flash Sprite without its wait flag does not pause the interpreter' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::FLASH_SPRITE, [10001, 31, 31, 31, 31, 3, 0])])
+  it.update
+  ok !it.waiting?, 'no wait flag, no pause'
+  eq 1, it.take_sprite_flash_requests.size
+end
+
+check 'Fade Out BGM fades the music and forgets the current track' do
+  st = new_state
+  RGSS::Audio.log = []
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 100, 100], string: 'Town'),
+    FakeCmd.new(IC::FADEOUT_BGM, [20]), # 2 seconds
+  ])
+  it.update
+  eq nil, st.current_bgm, 'nothing is playing after a fade-out'
+  eq [:bgm_fade, 2000], RGSS::Audio.log.last, 'faded over 2000 ms'
+end
+
+check 'Play Movie records the request instead of dropping it' do
+  st = new_state
+  st.variables[8] = 40
+  st.variables[9] = 24
+  it = Game::Interpreter.new(st)
+  # position mode 1 = read x/y from variables 8 and 9
+  it.start([FakeCmd.new(IC::PLAY_MOVIE, [1, 8, 9, 160, 120], string: 'Opening')])
+  it.update
+  req = it.take_movie_request
+  eq({ name: 'Opening', x: 40, y: 24, width: 160, height: 120 }, req)
+  eq nil, it.take_movie_request, 'the request is one-shot'
+end
+
+check 'Tile Substitution rewrites a tile on the map and flags a redraw' do
+  st = new_state
+  st.map = fake_map_2x2([5, 5, 7, 5], [0, 0, 0, 0])
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::TILE_SUBSTITUTION, [0, 5, 9])]) # lower: 5 -> 9
+  it.update
+  eq 9, st.map.lower(0, 0)
+  eq 7, st.map.lower(0, 1), 'other tiles are untouched'
+  ok !it.waiting?, 'Tile Substitution must not pause the interpreter'
+  eq true, it.take_tiles_changed
+  eq false, it.take_tiles_changed, 'the flag is one-shot'
+end
+
+check 'Game::Map substitutions are per layer and undone by an identity swap' do
+  m = fake_map_2x2([1, 1, 1, 1], [1, 1, 1, 1])
+  m.substitute_tile(1, 1, 4) # upper only
+  eq 1, m.lower(0, 0)
+  eq 4, m.upper(0, 0)
+  ok m.substituted?
+  m.substitute_tile(1, 1, 1) # back to itself: drop the rewrite
+  eq 1, m.upper(0, 0)
+  ok !m.substituted?
+end
+
+check 'Open Save Menu and Open Main Menu pause on their own wait kinds' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::OPEN_SAVE_MENU, [])])
+  it.update
+  eq :save_menu, it.wait_kind
+  it.resume
+
+  it.start([FakeCmd.new(IC::OPEN_MAIN_MENU, [])])
+  it.update
+  eq :menu, it.wait_kind
+end
+
+check 'a conditional branch tests whether the decision key started the event' do
+  st = new_state
+  cmds = [
+    FakeCmd.new(IC::CONDITIONAL, [8], indent: 0),
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+    FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+    FakeCmd.new(IC::END_BRANCH, [], indent: 0),
+  ]
+  it = Game::Interpreter.new(st)
+  it.start(cmds)
+  it.update
+  eq 2, st.variables[1], 'not action-triggered: the else branch runs'
+
+  it.start(cmds)
+  it.triggered_by_decision_key = true
+  it.update
+  eq 1, st.variables[1], 'action-triggered: the true branch runs'
+end
+
+check 'a conditional branch tests whether the BGM has played through once' do
+  st = new_state
+  cond = [
+    FakeCmd.new(IC::CONDITIONAL, [9], indent: 0),
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+    FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+    FakeCmd.new(IC::END_BRANCH, [], indent: 0),
+  ]
+  it = Game::Interpreter.new(st)
+  it.start(cond)
+  it.update
+  eq 2, st.variables[1], 'a fresh track has not looped'
+
+  st.bgm_looped = true
+  it.start(cond)
+  it.update
+  eq 1, st.variables[1]
+end
+
+check 'starting a new BGM clears the "played once" flag' do
+  st = new_state
+  st.bgm_looped = true
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::PLAY_BGM, [0, 100, 100], string: 'Field')])
+  it.update
+  eq false, st.bgm_looped
 end
 
 # -- summary ------------------------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -48,6 +48,10 @@ module RGSS
     attr_reader :fill_calls
     def blt(*); end
     def stretch_blt(*); end
+    # Record the tone a Flash Sprite pass asks for, so the flash checks can
+    # assert the colour actually reached the renderer.
+    def tone_blt(src, tone); (@tone_calls ||= []) << [src, tone]; self; end
+    attr_reader :tone_calls
     # Record draw_text / blend_text calls so message-rendering checks can assert
     # which path (flat colour vs windowskin blend) was taken.
     def draw_text(*a); (@draw_calls ||= []) << a; end
@@ -62,6 +66,9 @@ module RGSS
   # A readable colour (the real Color stub above swallows its args); get_pixel
   # returns one of these so tests can inspect the sampled components.
   Color2 = Struct.new(:red, :green, :blue, :alpha)
+
+  # RGSS Tone, as tone_blt (the Flash Sprite pass) takes it.
+  Tone = Struct.new(:red, :green, :blue, :gray)
 
   class Sprite
     attr_accessor :bitmap, :x, :y, :z, :visible, :opacity
@@ -99,6 +106,11 @@ module RGSS
 
   module Audio
     def self.bgm_play(*); end
+    def self.bgm_fade(*); end
+    # Scriptable playback position, so the "BGM played once" watcher can be
+    # driven: a value that jumps backwards is how SDL_mixer reports a loop.
+    class << self; attr_accessor :pos; end
+    def self.bgm_pos; @pos || 0; end
     # Record se_play calls so system-SFX checks can assert which sound fired.
     class << self; attr_accessor :se_calls; end
     def self.se_play(*a); (@se_calls ||= []) << a; end
@@ -265,6 +277,9 @@ class FakeParent
   # Return to Title Screen (12510) hands control back here; record that it fired.
   attr_reader :returned_to_title
   def return_to_title; @returned_to_title = true; end
+  # Open Save Menu (11910) saves through the app; record the calls.
+  def saved; @saved ||= []; end
+  def save_game(state); saved << state; true; end
 end
 
 def fake_parent(db)
@@ -2214,6 +2229,139 @@ check 'Flash Screen drives the flash layer, and refills only on a colour change'
   eq 1, (flash.bitmap.fill_calls || []).length,
      'an unchanged colour does not re-fill the screen-sized layer'
   eq true, flash.opacity <= before, 'the flash decays'
+end
+
+# -- newly-wired event commands -----------------------------------------------
+
+IC2 = Game::Interpreter::Cmd
+
+# A parallel event whose page runs `cmds` every frame, so a check can drive any
+# command through the real scene without pressing buttons.
+def parallel_event(cmds, x = 2, y = 2)
+  pg = page(trigger: 4)
+  pg.event_commands = cmds
+  { 1 => event(x, y, pg) }
+end
+
+check 'Flash Sprite tones the flashed event and decays away' do
+  pg = page(trigger: 4, charset_name: 'Hero')
+  # Flash event 1 white at full power for 2 tenths (12 frames), no wait.
+  pg.event_commands = [ECmd.new(IC2::FLASH_SPRITE, [1, 31, 31, 31, 31, 2, 0])]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  scene.update
+  ev = event_hashes(scene)[1]
+  ok ev[:flash], 'the event carries a running flash'
+  out = scene.instance_variable_get(:@flash_out_buffer)
+  ok out && (out.tone_calls || []).length > 0, 'the flash reached tone_blt'
+  tone = out.tone_calls.last[1]
+  ok tone.red > 0 && tone.gray == 0, "flash tone brightens: #{tone.inspect}"
+end
+
+check 'Flash Sprite on the hero holds a waiting event until it decays' do
+  # 1 tenth (6 frames) with the wait flag set, then a variable bump that only
+  # runs once the flash is over.
+  cmds = [ECmd.new(IC2::FLASH_SPRITE, [10001, 31, 0, 0, 31, 1, 1]),
+          add_var_cmd(5)]
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  scene.update
+  ok scene.instance_variable_get(:@player_flash), 'the hero is flashing'
+  eq 0, st.variables[5], 'the event is held while the flash runs'
+  10.times { scene.update }
+  ok !scene.instance_variable_get(:@player_flash), 'the flash decayed away'
+  eq 1, st.variables[5], 'the event resumed once the flash finished'
+end
+
+check 'Tile Substitution rewrites the map the scene walks on' do
+  cmds = [ECmd.new(IC2::TILE_SUBSTITUTION, [0, 0, 41])]
+  scene = new_scene(parallel_event(cmds), player: [0, 0])
+  scene.update
+  eq 41, scene.instance_variable_get(:@state).map.lower(3, 3)
+end
+
+check 'Enter/Exit Vehicle boards the vehicle the party stands on' do
+  cmds = [ECmd.new(IC2::ENTER_EXIT_VEHICLE, [])]
+  scene = new_scene(parallel_event(cmds), player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = st.x
+  boat.y = st.y
+  scene.update
+  eq :boat, st.boarded
+  scene.update # the command runs again next loop and steps back off
+  eq nil, st.boarded
+end
+
+check 'Open Main Menu pushes the field menu and resumes when it closes' do
+  # A foreground event, not a parallel one: a background process resumes every
+  # UI wait itself, and Open Main Menu is a UI wait.
+  cmds = [ECmd.new(IC2::OPEN_MAIN_MENU, []), add_var_cmd(6)]
+  scene = new_scene({}, player: [0, 0])
+  parent = scene.instance_variable_get(:@parent)
+  st = scene.instance_variable_get(:@state)
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  scene.update # runs the command and raises the :menu wait
+  scene.update # the wait opens the menu
+  eq 1, parent.pushed.length, 'the menu scene was pushed'
+  eq 0, st.variables[6], 'the event is paused while the menu is open'
+  scene.update # back from the menu: the wait is released...
+  scene.update # ...and the next frame runs the rest of the event
+  eq 1, st.variables[6], 'the event resumed after the menu closed'
+end
+
+check 'Open Save Menu saves through the parent and resumes the event' do
+  cmds = [ECmd.new(IC2::OPEN_SAVE_MENU, []), add_var_cmd(7)]
+  scene = new_scene({}, player: [0, 0])
+  parent = scene.instance_variable_get(:@parent)
+  st = scene.instance_variable_get(:@state)
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  3.times { scene.update }
+  eq 1, parent.saved.length, 'the save went through the app'
+  eq 1, st.variables[7], 'the event continued afterwards'
+end
+
+check 'Open Save Menu honours a Change Save Access lock' do
+  cmds = [ECmd.new(IC2::OPEN_SAVE_MENU, []), add_var_cmd(8)]
+  scene = new_scene({}, player: [0, 0])
+  parent = scene.instance_variable_get(:@parent)
+  st = scene.instance_variable_get(:@state)
+  st.save_access = false
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  3.times { scene.update }
+  eq 0, parent.saved.length, 'saving was disabled, so nothing was written'
+  eq 1, st.variables[8], 'the event still continues past the locked save'
+end
+
+check 'a BGM position that jumps backwards counts as one play-through' do
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.current_bgm = { name: 'Town', volume: 100, tempo: 100 }
+  RGSS::Audio.pos = 5000
+  scene.update
+  ok !st.bgm_looped, 'still on the first play-through'
+  RGSS::Audio.pos = 10 # SDL_mixer seeks back to the start to loop
+  scene.update
+  ok st.bgm_looped, 'the wrap counted as a completed play-through'
+  RGSS::Audio.pos = 0
+end
+
+check 'the action key marks the event it started for the type-8 branch' do
+  pg = page(trigger: 0)
+  pg.event_commands = [
+    ECmd.new(IC2::CONDITIONAL, [8], indent: 0),
+    ECmd.new(Game::Interpreter::Cmd::CONTROL_SWITCHES, [0, 9, 9, 0], indent: 1),
+    ECmd.new(IC2::END_BRANCH, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 6 # face the event
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  3.times { scene.update }
+  ok st.switches[9], 'the decision-key branch ran'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
This PR completes the RPG2000 event-command implementation by adding handlers for 11 previously unimplemented commands and fixing 3 opcode misalignments with liblcf's Code enum.

## Summary
All RPG2000 map and common-event commands now have functional implementations. The changes include new character effects (Flash Sprite with toning), party management (Change Skills, Simulated Attack), UI integration (Open Save Menu, Open Main Menu), and map manipulation (Tile Substitution, Enter/Exit Vehicle).

## Key Changes

**New Event Commands Implemented:**
- **Change Skills** (10440): Teach or remove skills on actors with constant/variable skill IDs
- **Simulated Attack** (10500): Damage actors using `atk - def*p_def/400 - spi*p_spi/800` formula with variance and optional damage storage
- **Change Actor Face** (10640): Override an actor's FaceSet graphic
- **Enter/Exit Vehicle** (10840): Board or disembark vehicles from events
- **Flash Sprite** (11320): Pulse characters with decaying colour tones, with optional wait flag
- **Fade Out BGM** (11520): Fade music over specified duration and clear current track
- **Play Movie** (11560): Record movie requests (playback unsupported, logged to stderr)
- **Tile Substitution** (11750): Rewrite tile IDs on map layers with per-layer substitution tracking
- **Open Save Menu** (11910): Save game through parent app with access control
- **Open Main Menu** (11950): Push field menu scene and resume event on close

**Opcode Corrections:**
- Change Equipment moved from 10440 to 10450
- Game Over moved from 12520 to 12420
- System command opcodes (10660+) shifted to correct positions

**Supporting Infrastructure:**
- Added `triggered_by_decision_key` flag to Interpreter for conditional branch type 8 (action-key trigger detection)
- Implemented BGM loop detection via `watch_bgm_loop()` for conditional branch type 9
- Added sprite flash system with `@player_flash` and event-level flash tracking
- Implemented `flash_buffer` and `flash_out_buffer` for tone_blt rendering
- Refactored interpreter request handling into `apply_interpreter_requests()` for code reuse
- Added tile substitution layer tracking to Game::Map with `substitute_tile()` and `substituted?()` methods
- Added `set_faceset()` method to Actor for Change Actor Face persistence

**Scene Integration:**
- Flash Sprite waits drain in `drive_event()` via `sprite_flashing?()` check
- Save/Menu waits handled with `perform_event_save()` and `perform_event_menu()`
- Parallel events apply requests via shared `apply_interpreter_requests()` path
- Flash decay happens every frame in `update_sprite_flashes()` even during messages/movement

## Notable Implementation Details
- Flash Sprite uses tone_blt to overlay colour on CharSet frames, preserving sprite outline
- Tile Substitution stores rewrites as a lookup applied on read rather than modifying layer arrays
- BGM loop detection polls `RGSS::Audio.bgm_pos` and detects backwards position jumps
- Movie requests are logged to stderr since video playback is unsupported
- All new commands properly drain their request flags to prevent re-triggering

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v