### PR TITLE
Drop enemy treasure items on an RPG2000 battle victory

### DIFF
--- a/changelog.d/rpg2k-enemy-item-drops.added.md
+++ b/changelog.d/rpg2k-enemy-item-drops.added.md
@@ -1,0 +1,10 @@
+- RPG Maker 2000: **defeated enemies now drop their treasure items** on victory.
+  `Game::Enemy` reads the database `drop_id` / `drop_prob` fields, and the new
+  `Game::Troop#drops(rng)` rolls each member's drop probability as a percentage
+  (0..99 < prob, per EasyRPG's `Rand::PercentChance`) — a 100% drop is certain, a
+  0% never lands, and the same item can drop from several members. The battle
+  result screen grants the rolled items to the party bag (on the battle's own
+  RNG) alongside the EXP and gold, naming each in the victory window. Covered by
+  new `scripts/rpg2k_logic_check.rb` checks (the drop fields are read, certain
+  drops land while zero-chance / item-less foes are skipped, and the probability
+  actually gates the roll).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -317,7 +317,9 @@ The work below is roughly ordered by the critical path to a walkable game
   buy / sell menus (one unit per confirm — the quantity selector is a later
   refinement).
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
-  instantiate a database enemy group into live members and total its EXP / gold,
+  instantiate a database enemy group into live members and total its EXP / gold
+  (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,
+  granted to the bag on a win),
   and the command decodes its troop id, escape / defeat modes and first-strike
   and routes the `[Victory]` / `[Escape]` / `[Defeat]` handler branches on the
   outcome (the "end event processing" escape mode abandons the event). The

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2874,7 +2874,7 @@ module Game
   # not built yet, so for now this backs the Enemy Encounter reward model.
   class Enemy
     attr_reader :id, :name, :battler_name, :max_hp, :max_sp, :atk, :def, :spi,
-                :agi, :exp, :gold, :x, :y, :hidden
+                :agi, :exp, :gold, :x, :y, :hidden, :drop_id, :drop_prob
     attr_accessor :hp, :sp
 
     def initialize(db, id, x = 0, y = 0, hidden = false)
@@ -2892,6 +2892,10 @@ module Game
       @agi     = row ? row.agility : 0
       @exp     = row ? row.exp : 0
       @gold    = row ? row.gold : 0
+      # The item this enemy may drop on defeat (field 13, 0 = none) and its drop
+      # probability as a percentage (field 14; 0 for a fixture lacking it).
+      @drop_id   = row && row.respond_to?(:drop_id) ? (row.drop_id || 0) : 0
+      @drop_prob = row && row.respond_to?(:drop_prob) ? (row.drop_prob || 0) : 0
       @x = x
       @y = y
       @hidden = hidden ? true : false
@@ -2937,6 +2941,17 @@ module Game
 
     def total_exp;  @members.reduce(0) { |s, e| s + e.exp } end
     def total_gold; @members.reduce(0) { |s, e| s + e.gold } end
+
+    # The item ids the troop yields on victory: each member carrying a drop item
+    # rolls its `drop_prob` percentage against `rng` (0..99 < prob, EasyRPG's
+    # Rand::PercentChance), so a 100% drop is certain, a 0% never lands, and the
+    # same item can drop from several members. Returns the ids in member order.
+    def drops(rng)
+      @members.each_with_object([]) do |e, out|
+        next unless e.drop_id && e.drop_id > 0
+        out << e.drop_id if rng.random(100) < e.drop_prob
+      end
+    end
 
     private
 
@@ -3024,7 +3039,7 @@ module Game
 
     MAX_ROUNDS = 1000 # safety net against a stalemate (should never be reached)
 
-    attr_reader :allies, :enemies, :rounds, :result, :log
+    attr_reader :allies, :enemies, :rounds, :result, :log, :rng
 
     # `states` is an optional state-definition lookup (`[id]` -> a row exposing
     # `restriction` / `hp_change_val` / `hp_change_max` / `sp_change_val` /

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2625,6 +2625,13 @@ class RPG2k
         lines = ['Victory!']
         lines << "Gained #{exp} EXP." if exp > 0
         lines << "Found #{gold} gold." if gold > 0
+        # Each defeated enemy may drop its treasure item (rolled on the battle's
+        # own RNG); grant it to the bag and name it in the result window.
+        troop.drops(@battle_ui[:battle].rng).each do |iid|
+          @state.party.gain_item(iid, 1)
+          it = @state.party.db_item(iid)
+          lines << "Found #{it ? it.name : "item #{iid}"}."
+        end
         lines
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3769,7 +3769,7 @@ end
 # -- Enemy Encounter (troop model + command) ----------------------------------
 
 EnemyRow = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
-                      :agility, :exp, :gold)
+                      :agility, :exp, :gold, :drop_id, :drop_prob)
 GroupMember = Struct.new(:enemy_id, :x, :y, :invisible)
 GroupRow = Struct.new(:name, :members)
 BattleDB = Struct.new(:enemy, :enemy_group)
@@ -3811,6 +3811,37 @@ check 'Game::Enemy reads its combat stats from the database' do
   ok !e.dead?
   e.hp = 0
   ok e.dead?
+end
+
+check 'Game::Enemy reads its treasure drop id and probability' do
+  db = BattleDB.new({ 5 => EnemyRow.new('Golem', 100, 0, 10, 10, 5, 3, 20, 50, 7, 25) }, {})
+  e = Game::Enemy.new(db, 5)
+  eq 7, e.drop_id
+  eq 25, e.drop_prob
+  eq 0, Game::Enemy.new(battle_db, 2).drop_id, 'no drop when the row omits it'
+end
+
+check 'Troop#drops yields certain drops, skipping zero-chance / no-item foes' do
+  db = BattleDB.new(
+    { 2 => EnemyRow.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10, 7, 100),  # always drops 7
+      3 => EnemyRow.new('Bat',   12, 0, 6, 2, 2, 9, 3,  4, 9, 0),    # 0% -> never
+      4 => EnemyRow.new('Imp',   12, 0, 6, 2, 2, 9, 3,  4, 0, 100) },# no drop item
+    { 1 => GroupRow.new('Mob', { 1 => GroupMember.new(2, 0, 0, false),
+                                 2 => GroupMember.new(3, 0, 0, false),
+                                 3 => GroupMember.new(4, 0, 0, false) }) })
+  troop = Game::Troop.new(db, 1)
+  eq [7], troop.drops(Game::Rng.new(1)), 'only the 100% drop lands'
+end
+
+check 'Troop#drops rolls the drop probability on the given RNG' do
+  db = BattleDB.new(
+    { 2 => EnemyRow.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10, 7, 50) }, # 50% drop
+    { 1 => GroupRow.new('Mob', { 1 => GroupMember.new(2, 0, 0, false) }) })
+  troop = Game::Troop.new(db, 1)
+  rng = Game::Rng.new(1)                              # one RNG, many independent rolls
+  results = Array.new(40) { troop.drops(rng) }
+  ok results.any? { |r| r == [7] }, 'the 50% drop sometimes lands'
+  ok results.any?(&:empty?), 'and sometimes misses'
 end
 
 check 'a missing troop / enemy degrades to an empty, harmless model' do


### PR DESCRIPTION
## Summary

Adds **enemy item drops** to the RPG Maker 2000 victory rewards, extending the existing EXP/gold grant.

- `Game::Enemy` now reads the database `drop_id` (field 13) and `drop_prob` (field 14) fields.
- New `Game::Troop#drops(rng)` rolls each member's drop probability as a percentage — `rng.random(100) < drop_prob`, matching EasyRPG's `Rand::PercentChance` — so a 100% drop is certain, a 0% never lands, and the same item can drop from several members. Returns the item ids in member order.
- The battle result screen (`battle_result_lines`) grants the rolled items to the party bag on the battle's own RNG, alongside the EXP/gold, and names each in the victory window. `Game::Battle` exposes its `rng` so the roll shares the fight's deterministic seed.

Grounded against EasyRPG Player's enemy drop handling (`drop_id` / `drop_prob` + `Rand::PercentChance`).

## Testing

- `scripts/rpg2k_logic_check.rb` — 323 checks pass, including 3 new ones: `Game::Enemy` reads the drop id/probability (and defaults to none when absent), `Troop#drops` lands certain drops while skipping zero-chance and item-less foes, and the drop probability actually gates the roll (both lands and misses across repeated rolls on one RNG).
- Scene (96) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_