### PR TITLE
Remove the unused 3rd/timidity submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,6 @@
 [submodule "third_party/cmdline"]
 	path = 3rd/cmdline
 	url = https://github.com/tanakh/cmdline.git
-[submodule "third_party/timidity"]
-	path = 3rd/timidity
-	url = https://git.code.sf.net/p/timidity/git
-	ignore = dirty
 [submodule "third_party/lvgl"]
 	path = 3rd/lvgl
 	url = https://github.com/lvgl/lvgl.git

--- a/changelog.d/remove-timidity-submodule.removed.md
+++ b/changelog.d/remove-timidity-submodule.removed.md
@@ -1,0 +1,7 @@
+- The `3rd/timidity` submodule (TiMidity++ 2.15.0) is removed. It was never
+  built: ADR 0006 weighed linking it for MIDI playback and chose SDL_mixer
+  instead, which carries its own TiMidity codec, so nothing in `CMakeLists.txt`,
+  `platformio.ini`, `flake.nix`, `build_config.rb` or any source file ever
+  referenced it. It was 8.4 MiB of GPL autoconf application that every clone and
+  every CI checkout paid for and no build consumed. The ADR references to it are
+  left as written — they record what was considered at the time.


### PR DESCRIPTION
## Summary

`3rd/timidity` pinned TiMidity++ 2.15.0 as a submodule and **was never built**. ADR 0006 weighed linking it to synthesise MIDI and chose SDL_mixer instead — which already carries its own TiMidity codec — so no build ever consumed it.

What it did cost: **8.4 MiB** of GPL autoconf application fetched by every clone and by all six CI checkouts (`Entering '3rd/timidity'` appears in each job's log), plus a standing implication that building it was a direction someone might take.

## Verification

Nothing outside `.gitmodules` and ADR prose referenced the path:

```
$ git grep -n "3rd/timidity\|third_party/timidity"
docs/adr/0006-audio-sdl-mixer.md:32:  the bundled `3rd/timidity` for MIDI) ourselves.
```

No reference in `CMakeLists.txt`, `platformio.ini`, `flake.nix`, `build_config.rb`, `.github/workflows/build.yml`, or any `.c`/`.cxx`/`.hxx`/`.rb` source. It is a pure deletion — no build input changes.

## What is deliberately *not* changed

The ADR references stay exactly as written. ADRs are a historical record: ADR 0006 correctly documents that linking the vendored TiMidity++ was on the table when that decision was made, and rewriting it to pretend the submodule was never there would falsify the record. The changelog entry carries the "and it was later removed" half.

## Relationship to #305

Independent, and branched from `master` rather than stacked. #305 (MIDI playback via SDL_mixer's built-in TiMidity + a downloaded FreePats patch set) is what makes this submodule definitively dead, and its ADR 0026 records TiMidity++ as the rejected option with the reasoning — but neither PR needs the other to merge, and they touch no common files.

One ordering note: ADR 0026 in #305 currently says the submodule "stays unbuilt". If this merges first I'll adjust that wording on #305 to say it was removed.

## Recovering it

If it is ever wanted back, the pin is in this commit's parent: `git show 7c001a4^:.gitmodules` has the URL, and `git ls-tree 7c001a4^ 3rd/timidity` has the commit SHA (`98254ed`, "Bump version to 2.15.0").

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDfFDQFUCUwVaPAKyU4F9Z)_