### PR TITLE
Keep a key's trigger when its press and release land in one frame

### DIFF
--- a/changelog.d/input-tap-in-one-frame.fixed.md
+++ b/changelog.d/input-tap-in-one-frame.fixed.md
@@ -1,0 +1,9 @@
+- A key that is pressed and released between two frames is no longer swallowed.
+  Key transitions arrive in a buffer that `Graphics.update` drains once a frame
+  — the SDL keyboard watch, the browser build's on-screen keypad, the terminal
+  backends — and `RGSS::Input.release` cleared the key's *trigger* along with
+  its held state, so when a tap delivered both its press and its release into
+  the same drain the game saw a key that had never been pressed. A quick tap on
+  the browser keypad now registers, as does a synthesised key that lands on a
+  long frame. `Input.update` still clears every trigger at the end of the frame,
+  so no trigger outlives the frame it arrived in.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -828,11 +828,17 @@ module RGSS
       @count[index] = 0
     end
 
+    # A release clears the held state but deliberately leaves `triggered` alone.
+    # Transitions arrive in a buffer that is drained once a frame (the SDL key
+    # watch, the browser's on-screen keypad, the terminal backends), so a quick
+    # tap can deliver its press *and* its release into the same drain. Clearing
+    # the trigger here swallowed that tap completely -- the game saw a key that
+    # was never pressed. `update` clears every trigger at the end of the frame,
+    # so nothing can outlive the frame it arrived in either way.
     def self.release(key)
       index = key_index(key)
       return if index.nil?
       @pressed[index] = false
-      @triggered[index] = false
       @count[index] = 0
     end
 

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -585,6 +585,26 @@ assert "RGSS::Window API surface" do
   end
 end
 
+assert "RGSS::Input registers a tap that pressed and released in one frame" do
+  # Key transitions reach Input through a buffer drained once a frame, so a
+  # quick tap -- a browser keypad button, a synthesised key -- can deliver both
+  # its press and its release before the game looks. The trigger must survive
+  # to that look, and the key must read as no longer held.
+  begin
+    RGSS::Input.update
+    RGSS::Input.press(RGSS::Input::C)
+    RGSS::Input.release(RGSS::Input::C)
+    assert_true RGSS::Input.trigger?(RGSS::Input::C), "the tap must register"
+    assert_false RGSS::Input.press?(RGSS::Input::C), "and must not read as held"
+    # ... and only for the one frame.
+    RGSS::Input.update
+    assert_false RGSS::Input.trigger?(RGSS::Input::C)
+  ensure
+    RGSS::Input.release(RGSS::Input::C)
+    RGSS::Input.update
+  end
+end
+
 assert "RGSS::Input accepts RGSS2/RGSS3 symbol keys" do
   # VX and VX Ace name the keys with symbols (Input.trigger?(:C)); XP and the
   # C++ input bridge use the integer constants. Both must reach the same key.


### PR DESCRIPTION
Key transitions reach `RGSS::Input` through a buffer that `Graphics.update`
drains once a frame — the SDL keyboard watch, the browser build's on-screen
keypad (`src/wasm_keypad.cxx`), the terminal backends — so a quick tap can
deliver its press *and* its release into the same drain.

`Input.release` cleared the key's trigger along with its held state, so that
tap vanished: the game saw a key that had never been pressed. The browser
keypad is the case that matters, since a pointer tap is short by nature.

The trigger now survives the release. `Input.update` still clears every trigger
at the end of the frame, so nothing outlives the frame it arrived in, and the
key correctly reads as no longer held.

Found while chasing comparison runs (`scripts/compare-rpgxp-wine.bash`) where
our engine sat on the title screen with the genuine RGSS runtime already
walking the map: the synthesised Return had gone missing on a loaded machine.

### Checks

- New unit check in `mruby-rgss/test/test.rb`: a press+release with no frame in
  between must register a trigger, must not read as held, and must not survive
  the next `Input.update`.
- `cmake --build build -t test` — 3/3 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Gfz65XQy51ZNZ2Vo1TwVn)_