### PR TITLE
Focus the game window before every synthesised key in the XP comparison

### DIFF
--- a/changelog.d/rpgxp-compare-window-focus.fixed.md
+++ b/changelog.d/rpgxp-compare-window-focus.fixed.md
@@ -1,0 +1,6 @@
+- `scripts/compare-rpgxp-wine.bash` focuses each runtime's window before it
+  synthesises a key. Both runtimes map a window and then resize it to the game's
+  resolution, and when the resize won that race the window manager left the
+  window unfocused, every key went to the root window instead, and the run
+  reported the whole map as differing -- a harness artifact that reads exactly
+  like an engine that ignored New Game and sat on the title screen.

--- a/scripts/compare-rpgxp-wine.bash
+++ b/scripts/compare-rpgxp-wine.bash
@@ -166,10 +166,26 @@ start_ours() {
     sleep "${OUR_BOOT_WAIT:-8}"
 }
 
+# Point the display's input focus at the game, before every key. A window
+# manager focuses a window when it maps, and both runtimes map one and then
+# resize it to the game's resolution -- and when the resize wins that race the
+# window ends up unfocused, every synthesised key goes to the root window, and
+# the run looks like an engine that ignored New Game and sat on the title
+# screen. Each display runs exactly one game, so its only visible window is the
+# one that should have the keys.
+focus_window() {
+    local disp="$1" id
+    id=$(DISPLAY="${disp}" xdotool search --onlyvisible --name . 2>/dev/null |
+             tail -1)
+    [ -n "${id}" ] || return 0
+    DISPLAY="${disp}" xdotool windowactivate --sync "${id}" 2>/dev/null || true
+}
+
 # Hold each key for ~120ms: both runtimes poll the keyboard once a frame and
 # drop a key that goes down and up between two polls.
 send_keys() {
     local disp="$1" ; shift
+    focus_window "${disp}"
     for spec in "$@" ; do
         [ "${spec}" = "-" ] && continue
         local k="${spec%%\**}" n=1


### PR DESCRIPTION
`scripts/compare-rpgxp-wine.bash` drives both runtimes headlessly with
`xdotool`, which sends keys to whatever window the display's input focus is on.

Both runtimes map a window and then resize it to the game's resolution, and when
the resize won that race the window manager left the window unfocused. Every key
then went to the root window, our engine never left the title screen, and the run
reported ~100% of the map as differing — three comparison runs were read as a
renderer regression before the cause turned out to be the harness.

Each display runs exactly one game, so activating its only visible window before
each key is unambiguous.

### Checks

- Two consecutive full comparison runs against the genuine RGSS runtime on the
  OpenGame.exe XP test bed reached the map and reported the usual ~0.5–2%
  difference, instead of the ~100% a lost keypress produces.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Gfz65XQy51ZNZ2Vo1TwVn)_