### PR TITLE
Draw and move RPG Maker XP maps the way the genuine RGSS runtime does

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@
 - The engine reads `Game.ini`, shows the **title screen** (the game's title
   graphic behind a New Game / Continue / Shutdown window, with the database's
   title BGM and cursor/decision sound effects) and, on **New Game**, builds the
-  party and enters a walkable **map**: the three XP tile layers are drawn as
-  placeholder colour blocks (real tileset/autotile rendering is planned, as on
-  the RPG2000 side), the party leader walks from its character graphic, and
-  movement uses the tileset's passage flags with a follow camera
+  party and enters a walkable **map**: the three XP tile layers are drawn from
+  the project's real tileset — regular tiles blitted from the tileset graphic,
+  autotiles assembled from their quads and animated, and priority tiles sorted
+  above the characters — with the party leader and every event drawn from their
+  `Graphics/Characters` sheets (or the tile a page uses as its graphic), stacked
+  by screen row the way RMXP sorts them, and movement using the tileset's
+  passage flags with a follow camera
 - Both an **unpacked** project (a loose `Data/` folder) and an **encrypted
   archive** load: a packed release that ships only a `Game.rgssad` (RPG Maker XP;
   RPG Maker VX's same-format `Game.rgss2a` too) or a VX Ace `Game.rgss3a` is

--- a/changelog.d/bitmap-partial-opacity-blend.fixed.md
+++ b/changelog.d/bitmap-partial-opacity-blend.fixed.md
@@ -1,0 +1,15 @@
+- `Bitmap#blt` / `#stretch_blt` at partial opacity no longer darken what they
+  draw. They blended the source colour toward the destination even when the
+  destination was *transparent* — that is, toward black — while recording the
+  reduced alpha, so the later composite attenuated the same colour a second
+  time. Straight (non-premultiplied) source-over fixes it, and reduces to the
+  old formula when the destination is opaque, so blits onto an opaque bitmap are
+  unchanged (the RPG2000 title screen renders byte-for-byte as before). Measured
+  against the genuine RGSS runtime: a window background drawn at `back_opacity` 160
+  showed 8% of its windowskin where the real runtime shows 63% (= 160/255).
+- RPG Maker XP windows honour `back_opacity`, and their selection cursor is
+  drawn from the windowskin's own 32x32 cursor block (nine-sliced) rather than a
+  flat blue bar. The title screen sets 160, as RMXP's `Scene_Title` does, so the
+  title graphic shows through the menu the way it does in the real runtime: the
+  window's pixels went from 95% differing to 52%, the rest being text the
+  reference cannot draw (no font is installed in the wine prefix).

--- a/changelog.d/rpgxp-event-glide.changed.md
+++ b/changelog.d/rpgxp-event-glide.changed.md
@@ -1,0 +1,12 @@
+- RPG Maker XP events move the way RGSS moves them: a step claims the
+  destination tile at once (collision sees it immediately, as in the real
+  runtime) and the drawn position closes the gap at `2 ** move_speed` a frame
+  instead of teleporting a whole tile at a time. The walk row cycles off the
+  same animation counter RMXP uses -- 1.5 ticks a frame while walking, one a
+  frame for a page that animates on the spot, a new frame every
+  `18 - move_speed * 2` ticks -- and an event that has come to rest falls back
+  to its page's own frame. The wait between autonomous steps is now RMXP's
+  `(40 - frequency * 2) * (6 - frequency)` frames rather than the placeholder
+  table, and a move route's non-movement commands (turns, switches, a graphic
+  change) run in the same turn as the step that follows them instead of costing
+  a whole wait period each.

--- a/changelog.d/rpgxp-event-graphic-properties.fixed.md
+++ b/changelog.d/rpgxp-event-graphic-properties.fixed.md
@@ -1,0 +1,7 @@
+- RPG Maker XP events honour the rest of their page's graphic: its **opacity**,
+  its **blend type** and its **character hue**. All three were decoded and then
+  dropped, so a page that fades an event to a ghost, adds it to what is behind
+  it, or recolours a shared character sheet drew as a plain opaque copy of the
+  original. A move route's *Change Opacity* / *Change Blending* now reaches the
+  sprite as well, and the party leader's own `character_hue` is applied to the
+  player's graphic.

--- a/changelog.d/rpgxp-event-walk-animation.fixed.md
+++ b/changelog.d/rpgxp-event-walk-animation.fixed.md
@@ -1,0 +1,8 @@
+- RPG Maker XP map events animate again. `Game::Character#@pattern` was only
+  ever assigned when a page set the event's graphic, so every event stood frozen
+  on a single frame of its four-frame walk row while it roamed the map -- the
+  player animated, nobody else did. Characters now cycle their pattern on each
+  step, hold a standing animation for pages with `step_anime`, and fall back to
+  the page's own frame once they stop, as RMXP's `Game_Character#update` does.
+  Building an event also applies its page's `walk_anime` / `step_anime` flags,
+  which were decoded but never reached the character.

--- a/changelog.d/rpgxp-player-walk-rate.fixed.md
+++ b/changelog.d/rpgxp-player-walk-rate.fixed.md
@@ -1,0 +1,8 @@
+- The RPG Maker XP player's walk cycle runs at the real runtime's rate. Its
+  frame was keyed off the distance walked — `(@move_count / 8) % 4` — which ran
+  all four frames of the walk row inside a single tile, roughly three times too
+  fast. It now uses the animation counter every other character uses (1.5 ticks
+  a frame, a new frame every `18 - move_speed * 2` ticks) and returns to the
+  standing frame once the player stops. Finishing a step also starts the next
+  one in the same frame, so holding a direction no longer inserts a standing
+  frame at every tile boundary.

--- a/changelog.d/rpgxp-real-tilemap-and-event-sprites.added.md
+++ b/changelog.d/rpgxp-real-tilemap-and-event-sprites.added.md
@@ -1,0 +1,13 @@
+- RPG Maker XP maps now draw the project's **real tileset** instead of
+  placeholder colour blocks. `Scene::Map` builds the same objects RMXP's
+  `Spriteset_Map` does: a native `RGSS::Tilemap` fed the tileset graphic, the
+  seven autotiles and the map's data/priority Tables (so regular tiles are
+  blitted from the tileset, autotiles are assembled from their quads and
+  animated, and priority tiles sort above the characters), plus one sprite per
+  event drawn from its active page's graphic — a `Graphics/Characters` sheet, or
+  the tile id when the page uses a tile instead. An event whose graphic is empty
+  now draws nothing, as in RMXP, rather than the red marker the placeholder
+  renderer painted on it. Characters stack by the screen row they stand on
+  (RMXP's `screen_z`), so overlapping characters no longer draw in an arbitrary
+  order, and `always_on_top` pages sort above the priority layer. Verified
+  against the genuine RGSS runtime with `scripts/compare-rpgxp-wine.bash`.

--- a/changelog.d/rtp-lookup-per-maker.fixed.md
+++ b/changelog.d/rtp-lookup-per-maker.fixed.md
@@ -1,0 +1,9 @@
+- The RTP a project is given now follows its maker, and its own `Game.ini`.
+  RPG Maker VX and VX Ace projects were handed the **RPG2000** RTP path — a
+  directory that can never hold their assets — because only the RPG2000 and XP
+  registry keys were wired up. Each RGSS generation registers its RTPs under its
+  own key (`Software\Enterbrain\RGSS` for XP, `RGSS2` for VX, `RGSS3` for VX
+  Ace), and the value to read there is the RTP *name* the game asks for in
+  `Game.ini` (`RTP1=` for XP, `RTP=` for VX / VX Ace), so a project shipped
+  against a non-stock RTP resolves too instead of falling back to the default
+  name.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -632,11 +632,18 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   XP-styled window, title BGM / cursor & decision SE). `src/main.cxx` sizes the
   window to XP's native 640×480.
 - 🚧 **Map scene** — New Game builds the party from `System.party_members`,
-  loads the start map and enters a walkable `Scene::Map`: the three tile layers
-  render as placeholder colour blocks, the party leader is drawn from its
-  `Graphics/Characters` sheet, and movement is grid-based with tileset
-  passability and a follow camera. Real tileset/autotile blitting and event
-  sprites (events are markers for now) are the remaining rendering work.
+  loads the start map and enters a walkable `Scene::Map`. The three tile layers
+  now render through the native `RGSS::Tilemap` — the project's real tileset
+  graphic, the seven autotiles assembled from their quads and animated, and
+  priority tiles routed above the characters — exactly the objects RMXP's
+  `Spriteset_Map` builds. Every event draws from its active page's graphic (a
+  `Graphics/Characters` sheet, or the tile id a page uses instead); an event with
+  an empty graphic draws nothing, as in RMXP. Characters stack by the screen row
+  they stand on (`Sprite_Character#update`'s `screen_z`), with `always_on_top`
+  pages above the priority layer. Movement is grid-based with tileset passability
+  and a follow camera. Remaining: per-row priority interleaving rather than one
+  flat above-layer (ADR 0022), and the character effects the sprites ignore —
+  opacity, blend mode, hue and step animation.
 - 🚧 **Event system** — event pages select their active page by condition
   (`Game::EventPage`: switch / variable / self-switch, highest match wins) and a
   `Game::Interpreter` runs the XP command list with a suspend/resume model: Show

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -660,7 +660,13 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   `Game::MoveRoute` drive an event's page move type (fixed / random / approach)
   or custom move route (the full XP move-command set), paced by move frequency
   and blocked by terrain / the player / other events, and the **event-touch**
-  trigger fires when an event walks into the player. The interpreter's *Set Move
+  trigger fires when an event walks into the player. An event **glides** between
+  tiles the way RGSS moves a character: taking a step claims the destination
+  tile at once (that is what collision sees) and the drawn position closes the
+  128-unit gap at `2 ** move_speed` a frame, while the walk row cycles off the
+  same animation counter and falls back to the page's own frame once the event
+  comes to rest. The wait between autonomous steps is RMXP's
+  `(40 - frequency * 2) * (6 - frequency)` frames. The interpreter's *Set Move
   Route* (209) command is now wired up: it queues the `RPG::MoveRoute` packed
   into the command for its target — the player, "this event" or a map event id —
   and `Scene::Map` drains the queue and drives the target along the route in the

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1155,6 +1155,40 @@ void bmp_read(const Bitmap& b,
   a = bpp >= 4 ? p[3] : 255;
 }
 
+// Source-over composite of one pixel in *straight* (non-premultiplied) alpha.
+//
+// The obvious `src*a + dst*(255-a)` is only right when the destination is
+// opaque. Onto a transparent pixel -- which is transparent *black* -- it drags
+// the colour toward black while recording alpha `a`, so the composite that
+// later draws the bitmap over the screen attenuates the same colour a second
+// time. A window background blitted at RGSS's `back_opacity` 160 came out
+// showing 8% of its skin instead of 63% (measured against the genuine RGSS
+// runtime, which blends at exactly back_opacity/255).
+//
+// Straight alpha keeps the colour and lets the alpha carry the coverage:
+//   out_a   = sa + da*(1 - sa)
+//   out_rgb = (src*sa + dst*da*(1 - sa)) / out_a
+// which reduces to the old formula when da is 255, so blits onto an opaque
+// bitmap are unchanged.
+void blend_over(Bitmap& dst,
+                mrb_int x,
+                mrb_int y,
+                int r,
+                int g,
+                int b,
+                int sa,
+                int dr,
+                int dg,
+                int db,
+                int da) {
+  const int dw = da * (255 - sa) / 255;
+  const int out_a = sa + dw;
+  if (out_a <= 0)
+    return;
+  bmp_put(dst, x, y, (r * sa + dr * dw) / out_a, (g * sa + dg * dw) / out_a,
+          (b * sa + db * dw) / out_a, out_a);
+}
+
 mrb_value bmp_width(mrb_state* M, V self) {
   return mrb_fixnum_value(bmp_self(M, self).width);
 }
@@ -1420,10 +1454,7 @@ mrb_value bmp_blt(mrb_state* M, V self) {
       }
       int dr, dg, db, da;
       bmp_read(dst, dx, dy, dr, dg, db, da);
-      const int inv = 255 - alpha;
-      bmp_put(dst, dx, dy, (r * alpha + dr * inv) / 255,
-              (g * alpha + dg * inv) / 255, (bl * alpha + db * inv) / 255,
-              std::max(da, alpha));
+      blend_over(dst, dx, dy, r, g, bl, alpha, dr, dg, db, da);
     }
   }
   dst.dirty = true;
@@ -1472,10 +1503,7 @@ mrb_value bmp_stretch_blt(mrb_state* M, V self) {
       }
       int dr2, dg, db, da;
       bmp_read(dst, dx, dy, dr2, dg, db, da);
-      const int inv = 255 - alpha;
-      bmp_put(dst, dx, dy, (r * alpha + dr2 * inv) / 255,
-              (g * alpha + dg * inv) / 255, (bl * alpha + db * inv) / 255,
-              std::max(da, alpha));
+      blend_over(dst, dx, dy, r, g, bl, alpha, dr2, dg, db, da);
     }
   }
   dst.dirty = true;

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -495,22 +495,48 @@ class RPGXP
 
     # A movable grid entity (a map event, or the player). Directions are the
     # numpad convention shared with RPG2000: 2 down, 4 left, 6 right, 8 up.
+    #
+    # A character's *tile* is where it is going: taking a step moves (x, y) at
+    # once and leaves the drawn position, (real_x, real_y), to catch up a little
+    # every frame -- which is how RGSS models it, and why an event occupies its
+    # destination for collision the instant it sets off.
     class Character
       DIR_DELTA = { 2 => [0, 1], 4 => [-1, 0], 6 => [1, 0], 8 => [0, -1] }.freeze
+      # Sub-tile units RGSS counts a position in: real_x == x * UNIT means the
+      # character has arrived. A step covers UNIT units at 2**move_speed a
+      # frame, so speed 4 (the editor's default) crosses a tile in 8 frames.
+      UNIT = 128
       # 90-degree clockwise / counter-clockwise turns and the 180-degree flip.
       TURN_RIGHT = { 8 => 6, 6 => 2, 2 => 4, 4 => 8 }.freeze
       TURN_LEFT  = { 8 => 4, 4 => 2, 2 => 6, 6 => 8 }.freeze
       TURN_180   = { 8 => 2, 2 => 8, 4 => 6, 6 => 4 }.freeze
       CARDINALS = [2, 4, 6, 8].freeze
 
-      attr_accessor :x, :y, :direction, :move_speed, :move_frequency,
+      attr_accessor :direction, :move_speed, :move_frequency,
                     :through, :direction_fix, :walk_anime, :step_anime,
                     :always_on_top, :opacity, :blend_type
-      attr_reader :graphic_name, :graphic_hue, :pattern
+      attr_reader :x, :y, :graphic_name, :graphic_hue, :pattern,
+                  :real_x, :real_y, :stop_count
+
+      # Assigning a tile directly is a placement (a spawn or a teleport), not a
+      # step: the drawn position goes with it instead of gliding across the map.
+      def x=(v)
+        @x = v
+        @real_x = v * UNIT
+      end
+
+      def y=(v)
+        @y = v
+        @real_y = v * UNIT
+      end
 
       def initialize(x = 0, y = 0, direction = 2)
         @x = x
         @y = y
+        @real_x = x * UNIT
+        @real_y = y * UNIT
+        @anime_count = 0
+        @stop_count = 0
         @direction = direction
         @move_speed = 3
         @move_frequency = 3
@@ -535,17 +561,61 @@ class RPGXP
         @original_pattern = @pattern
       end
 
-      # Cycle the four-frame walk row, as RMXP's Game_Character#update does
-      # (`@pattern = (@pattern + 1) % 4`). Nothing else ever moved `@pattern`,
-      # so every event stood frozen on one frame while it walked around.
-      def advance_pattern
-        @pattern = (@pattern + 1) % 4
+      # Still short of the tile it is walking to.
+      def moving?
+        @real_x != @x * UNIT || @real_y != @y * UNIT
       end
 
-      # The frame a character rests on when it stops: RMXP returns to the page's
-      # own pattern unless the page asked for a standing animation.
-      def rest_pattern
-        @pattern = @original_pattern || 0
+      # The drawn position, in pixels, for a `tile`-pixel grid.
+      def pixel_x(tile)
+        @real_x * tile / UNIT
+      end
+
+      def pixel_y(tile)
+        @real_y * tile / UNIT
+      end
+
+      # One frame of this character: close the gap to the tile it stepped onto,
+      # and run the walk cycle. RMXP's Game_Character#update -- the walk row
+      # advances every `18 - move_speed * 2` animation ticks, counted at 1.5 a
+      # frame while walking and 1 a frame for a page that animates on the spot,
+      # and a character that has come to rest falls back to its page's own
+      # frame.
+      def update
+        moving? ? update_move : update_stop
+        return if @anime_count <= 18 - @move_speed * 2
+        @pattern = if !@step_anime && @stop_count > 0
+                     @original_pattern || 0
+                   else
+                     (@pattern + 1) % 4
+                   end
+        @anime_count = 0
+      end
+
+      def update_move
+        d = 2**@move_speed
+        @real_x = approach(@real_x, @x * UNIT, d)
+        @real_y = approach(@real_y, @y * UNIT, d)
+        if @walk_anime
+          @anime_count += 1.5
+        elsif @step_anime
+          @anime_count += 1
+        end
+      end
+
+      def update_stop
+        if @step_anime
+          @anime_count += 1
+        elsif @pattern != (@original_pattern || 0)
+          @anime_count += 1.5
+        end
+        @stop_count += 1
+      end
+
+      # Start the wait before this character's next autonomous step over again,
+      # as taking a step does.
+      def hold_still
+        @stop_count = 0
       end
 
       def self.step_tile(px, py, dir)
@@ -567,6 +637,7 @@ class RPGXP
         dx, dy = DIR_DELTA[dir] || [0, 0]
         @x += dx
         @y += dy
+        @stop_count = 0
       end
 
       # Move one tile diagonally; RMXP keeps a cardinal facing, favouring the
@@ -577,6 +648,7 @@ class RPGXP
         _, vy = DIR_DELTA[vertical] || [0, 0]
         @x += hx
         @y += vy
+        @stop_count = 0
       end
 
       def turn_right;  @direction = TURN_RIGHT[@direction] || @direction; end
@@ -599,6 +671,15 @@ class RPGXP
 
       def direction_away(tx, ty)
         TURN_180[direction_toward(tx, ty)] || @direction
+      end
+
+      private
+
+      # Step `pos` toward `goal` by at most `d`, never overshooting it.
+      def approach(pos, goal, d)
+        return [pos + d, goal].min if pos < goal
+        return [pos - d, goal].max if pos > goal
+        pos
       end
     end
 

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -524,6 +524,7 @@ class RPGXP
         @graphic_name = nil
         @graphic_hue = 0
         @pattern = 0
+        @original_pattern = 0
       end
 
       def set_graphic(name, hue = 0, direction = nil, pattern = nil)
@@ -531,6 +532,20 @@ class RPGXP
         @graphic_hue = hue || 0
         face(direction) if direction && direction > 0
         @pattern = pattern if pattern
+        @original_pattern = @pattern
+      end
+
+      # Cycle the four-frame walk row, as RMXP's Game_Character#update does
+      # (`@pattern = (@pattern + 1) % 4`). Nothing else ever moved `@pattern`,
+      # so every event stood frozen on one frame while it walked around.
+      def advance_pattern
+        @pattern = (@pattern + 1) % 4
+      end
+
+      # The frame a character rests on when it stops: RMXP returns to the page's
+      # own pattern unless the page asked for a standing animation.
+      def rest_pattern
+        @pattern = @original_pattern || 0
       end
 
       def self.step_tile(px, py, dir)

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -565,6 +565,10 @@ class RPGXP
           ch.through = page.through ? true : false
           ch.direction_fix = page.direction_fix ? true : false
           ch.always_on_top = page.always_on_top ? true : false
+          # RMXP's page defaults are walk_anime on, step_anime off; an absent
+          # field means the page never said, not "off".
+          ch.walk_anime = page.walk_anime.nil? ? true : (page.walk_anime ? true : false)
+          ch.step_anime = page.step_anime ? true : false
           g = page.graphic
           ch.set_graphic(g.character_name, g.character_hue, g.direction, g.pattern) if g
           move_type = page.move_type || 0
@@ -641,7 +645,10 @@ class RPGXP
       # by move frequency. Skipped once any event process is running this frame,
       # so the map holds still during messages.
       def step_events
-        @events.each { |_id, e| step_event(e) }
+        @events.each do |_id, e|
+          step_event(e)
+          step_idle_animation(e)
+        end
       end
 
       def step_event(e)
@@ -663,9 +670,43 @@ class RPGXP
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
           move_autonomous(e, dir) if dir
         end
-        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
+        if ch.x != ox || ch.y != oy
+          reoccupy(e, ox, oy)
+          animate_step e, ch
+        end
       rescue StandardError => ex
         $stderr.puts "[RGSS] event ##{e[:id]} movement failed: #{ex.message}"
+      end
+
+      # One frame of a character's walk cycle. RMXP animates a character that
+      # moved unless its page turned `walk_anime` off; a page with `step_anime`
+      # keeps animating while it stands still (handled in step_idle_animation).
+      def animate_step(e, ch)
+        e[:idle_anime] = 0
+        ch.advance_pattern if ch.walk_anime || ch.step_anime
+      end
+
+      # Pages with `step_anime` animate on the spot. Paced off the same frame
+      # counter as the walk cycle so a standing animation runs at a steady rate
+      # rather than at the event's move frequency.
+      IDLE_ANIME_FRAMES = 8
+
+      # RMXP's Game_Character#update_stop: a standing character with
+      # `step_anime` keeps cycling, and one without it falls back to the pose
+      # its page asked for once it has stopped walking. We step tile-to-tile
+      # rather than pixel-by-pixel, so "stopped" is a frame count instead of
+      # the end of an interpolation.
+      def step_idle_animation(e)
+        ch = e[:char]
+        return unless ch
+        e[:idle_anime] = (e[:idle_anime] || 0) + 1
+        if ch.step_anime
+          return if e[:idle_anime] < IDLE_ANIME_FRAMES
+          e[:idle_anime] = 0
+          ch.advance_pattern
+        elsif e[:idle_anime] >= (EVENT_MOVE_DELAY[ch.move_frequency] || 30)
+          ch.rest_pattern
+        end
       end
 
       # Advance an event's forced route one paced step, updating its occupied
@@ -677,7 +718,10 @@ class RPGXP
         ox = ch.x
         oy = ch.y
         forced[:route].step(ch, @world) unless forced[:route].done?
-        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
+        if ch.x != ox || ch.y != oy
+          reoccupy(e, ox, oy)
+          animate_step e, ch
+        end
         @forced_routes.delete(e[:id]) if forced[:route].done?
       rescue StandardError => ex
         $stderr.puts "[RGSS] event ##{e[:id]} forced move failed: #{ex.message}"

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -517,7 +517,9 @@ class RPGXP
         return nil unless actor
         name = actor.character_name
         return nil if name.nil? || name.empty?
-        Bitmap.new "Graphics/Characters/#{name}"
+        bmp = Bitmap.new "Graphics/Characters/#{name}"
+        hue_shift bmp, actor.character_hue
+        bmp
       rescue StandardError => e
         $stderr.puts "[RGSS] leader charset load failed, using marker: #{e.message}"
         nil
@@ -565,7 +567,13 @@ class RPGXP
           ch.walk_anime = page.walk_anime.nil? ? true : (page.walk_anime ? true : false)
           ch.step_anime = page.step_anime ? true : false
           g = page.graphic
-          ch.set_graphic(g.character_name, g.character_hue, g.direction, g.pattern) if g
+          if g
+            ch.set_graphic(g.character_name, g.character_hue, g.direction, g.pattern)
+            # RMXP's Game_Event#refresh takes these off the page's graphic too;
+            # a move route's Change Opacity / Change Blending then overrides them.
+            ch.opacity = g.opacity || 255
+            ch.blend_type = g.blend_type || 0
+          end
           move_type = page.move_type || 0
           route = Game::MoveRoute.from_page(page.move_route) if move_type == Game::MoveType::CUSTOM
         end
@@ -1166,6 +1174,9 @@ class RPGXP
         if name && !name.empty?
           charset = load_map_graphic("Characters", name)
           return nil unless charset
+          # RMXP caches character graphics per (name, hue); each event sprite
+          # owns its bitmap here, so rotate that copy in place.
+          hue_shift charset, g.character_hue
           w = Game::CharSet.cell_width(charset)
           h = Game::CharSet.cell_height(charset)
           new_event_sprite(Bitmap.new(w, h), charset, w, h)
@@ -1179,7 +1190,18 @@ class RPGXP
         sprite = Sprite.new
         sprite.bitmap = bitmap
         { sprite: sprite, bitmap: bitmap, charset: charset, w: w, h: h,
-          frame: nil }
+          frame: nil, opacity: nil, blend_type: nil }
+      end
+
+      # Rotate a character graphic's hue in place, as RPG::Cache.character does
+      # for a page (or an actor) that asked for a hue. A zero hue is a no-op,
+      # and a runtime without the operation must not cost us the sprite.
+      def hue_shift(bitmap, hue)
+        hue = hue.to_i
+        return if bitmap.nil? || hue % 360 == 0
+        bitmap.hue_change hue
+      rescue StandardError => e
+        $stderr.puts "[RGSS] hue #{hue} not applied: #{e.message}"
       end
 
       # Character stacking, as RMXP's Sprite_Character#update does it: a
@@ -1330,6 +1352,16 @@ class RPGXP
           s[:sprite].x = ch.pixel_x(TILE) - cam_x - (s[:w] - TILE) / 2
           s[:sprite].y = sy - (s[:h] - TILE)
           s[:sprite].z = character_z(sy, ch.always_on_top)
+          # Page graphic (or move-route) opacity and blending. Written only when
+          # they change: each one reaches into the native sprite.
+          if s[:opacity] != ch.opacity
+            s[:opacity] = ch.opacity
+            s[:sprite].opacity = ch.opacity
+          end
+          if s[:blend_type] != ch.blend_type
+            s[:blend_type] = ch.blend_type
+            s[:sprite].blend_type = ch.blend_type
+          end
           next unless s[:charset]
           frame = [ch.direction, ch.pattern]
           next if frame == s[:frame]

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -22,6 +22,10 @@ class RPGXP
       @skin = skin
       @active = true
       @cursor_rect = nil
+      # RGSS draws a window's background at `back_opacity` and leaves the frame
+      # opaque. 255 is the class default; the scenes that want to see through a
+      # window (RMXP's Scene_Title uses 160) set it themselves.
+      @back_opacity = 255
 
       @viewport = Viewport.new(x, y, [width, 1].max, [height, 1].max)
       @viewport.z = 100
@@ -61,6 +65,13 @@ class RPGXP
       draw_cursor
     end
 
+    attr_reader :back_opacity
+
+    def back_opacity=(v)
+      @back_opacity = v
+      draw_skin
+    end
+
     # Selection highlight, in contents coordinates (offset by the border).
     def cursor_rect=(rect)
       @cursor_rect = rect
@@ -86,7 +97,7 @@ class RPGXP
 
     def draw_skin_background
       @skin_bmp.stretch_blt Rect.new(2, 2, @width - 4, @height - 4), @skin,
-                            Rect.new(0, 0, 128, 128)
+                            Rect.new(0, 0, 128, 128), @back_opacity
     rescue StandardError
       draw_fallback
     end
@@ -122,6 +133,18 @@ class RPGXP
       @skin_bmp.fill_rect @width - 2, 0, 2, @height, edge
     end
 
+    # The selection highlight comes out of the windowskin, like everything else
+    # about a window: RGSS keeps a 32x32 cursor block at (128, 64) and
+    # nine-slices it over the cursor rect (CURSOR_EDGE-wide corners and edges,
+    # the middle stretched). Drawing a flat blue bar instead was the single
+    # biggest difference left on the title screen against the genuine runtime --
+    # its cursor is a thin outline over a nearly clear interior, ours was a solid
+    # slab. Falls back to the old hand-drawn bar when the project has no skin.
+    CURSOR_SRC_X = 128
+    CURSOR_SRC_Y = 64
+    CURSOR_SRC_SIZE = 32
+    CURSOR_EDGE = 4
+
     def draw_cursor
       @cursor_bmp.clear
       return unless @active && @cursor_rect
@@ -129,12 +152,52 @@ class RPGXP
       return if r.width <= 0 || r.height <= 0
       x = BORDER + r.x
       y = BORDER + r.y
-      @cursor_bmp.fill_rect x, y, r.width, r.height, Color.new(40, 72, 200, 160)
+      if @skin
+        draw_skin_cursor x, y, r.width, r.height
+      else
+        draw_fallback_cursor x, y, r.width, r.height
+      end
+    end
+
+    def draw_skin_cursor(x, y, w, h)
+      e = CURSOR_EDGE
+      sx = CURSOR_SRC_X
+      sy = CURSOR_SRC_Y
+      # The source block's middle span, between its corners.
+      m = CURSOR_SRC_SIZE - e * 2
+      iw = w - e * 2
+      ih = h - e * 2
+      s = @skin
+      # Corners.
+      @cursor_bmp.blt x, y, s, Rect.new(sx, sy, e, e)
+      @cursor_bmp.blt x + w - e, y, s, Rect.new(sx + e + m, sy, e, e)
+      @cursor_bmp.blt x, y + h - e, s, Rect.new(sx, sy + e + m, e, e)
+      @cursor_bmp.blt x + w - e, y + h - e, s,
+                      Rect.new(sx + e + m, sy + e + m, e, e)
+      return if iw <= 0 || ih <= 0
+      # Edges and the stretched middle.
+      @cursor_bmp.stretch_blt Rect.new(x + e, y, iw, e), s,
+                              Rect.new(sx + e, sy, m, e)
+      @cursor_bmp.stretch_blt Rect.new(x + e, y + h - e, iw, e), s,
+                              Rect.new(sx + e, sy + e + m, m, e)
+      @cursor_bmp.stretch_blt Rect.new(x, y + e, e, ih), s,
+                              Rect.new(sx, sy + e, e, m)
+      @cursor_bmp.stretch_blt Rect.new(x + w - e, y + e, e, ih), s,
+                              Rect.new(sx + e + m, sy + e, e, m)
+      @cursor_bmp.stretch_blt Rect.new(x + e, y + e, iw, ih), s,
+                              Rect.new(sx + e, sy + e, m, m)
+    rescue StandardError => e
+      $stderr.puts "[RGSS] windowskin cursor failed, using a plain bar: #{e.message}"
+      draw_fallback_cursor x, y, w, h
+    end
+
+    def draw_fallback_cursor(x, y, w, h)
+      @cursor_bmp.fill_rect x, y, w, h, Color.new(40, 72, 200, 160)
       border = Color.new(200, 216, 255, 255)
-      @cursor_bmp.fill_rect x, y, r.width, 2, border
-      @cursor_bmp.fill_rect x, y + r.height - 2, r.width, 2, border
-      @cursor_bmp.fill_rect x, y, 2, r.height, border
-      @cursor_bmp.fill_rect x + r.width - 2, y, 2, r.height, border
+      @cursor_bmp.fill_rect x, y, w, 2, border
+      @cursor_bmp.fill_rect x, y + h - 2, w, 2, border
+      @cursor_bmp.fill_rect x, y, 2, h, border
+      @cursor_bmp.fill_rect x + w - 2, y, 2, h, border
     end
   end
 
@@ -267,6 +330,9 @@ class RPGXP
         h = COMMANDS.size * LINE_H + Panel::BORDER * 2
         @command = Panel.new((WIDTH - w) / 2, HEIGHT - h - 64, w, h, @skin)
         @command.z = 200
+        # RMXP's Scene_Title: `@command_window.back_opacity = 160`, so the title
+        # graphic shows through the menu.
+        @command.back_opacity = 160
         contents = Bitmap.new(@command.inner_width, @command.inner_height)
         contents.font.color = Color.new(255, 255, 255, 255)
         COMMANDS.each_with_index do |c, i|

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -427,10 +427,6 @@ class RPGXP
       TILE_ID_BASE = 384
       MSG_LINE_H = 32
 
-      # Frames between autonomous event steps, keyed by RMXP move frequency
-      # (1 slowest .. 6 fastest). Placeholder pacing while events draw as markers.
-      EVENT_MOVE_DELAY = { 1 => 120, 2 => 60, 3 => 30, 4 => 15, 5 => 8, 6 => 4 }.freeze
-
       # Event-page start triggers (RPG::Event::Page#trigger).
       TRIGGER_ACTION       = 0 # player presses the action button facing it
       TRIGGER_PLAYER_TOUCH = 1 # player walks into it
@@ -471,7 +467,6 @@ class RPGXP
         @forced_routes = {}
         @player_route = nil
         @player_char = nil
-        @player_route_timer = 0
         # Event ids erased by an Erase Event (116) command: skipped when the event
         # list is rebuilt so they stay gone until the map is (re)loaded.
         @erased = {}
@@ -575,12 +570,11 @@ class RPGXP
           route = Game::MoveRoute.from_page(page.move_route) if move_type == Game::MoveType::CUSTOM
         end
         { id: id, ev: ev, page: page, char: ch, trigger: page && page.trigger,
-          move_type: move_type, route: route,
-          move_timer: EVENT_MOVE_DELAY[ch.move_frequency] || 30 }
+          move_type: move_type, route: route }
       rescue StandardError => e
         $stderr.puts "[RGSS] event ##{id} setup failed: #{e.message}"
         { id: id, ev: ev, page: nil, char: (@characters[id] ||= Game::Character.new(ev.x, ev.y)),
-          trigger: nil, move_type: 0, route: nil, move_timer: 30 }
+          trigger: nil, move_type: 0, route: nil }
       end
 
       def ev_direction(page)
@@ -641,13 +635,15 @@ class RPGXP
         drive_interpreter
       end
 
-      # Advance each event's autonomous / custom-route movement one frame, paced
-      # by move frequency. Skipped once any event process is running this frame,
-      # so the map holds still during messages.
+      # Advance each event one frame: its walk animation and the glide toward
+      # the tile it stepped onto, then -- once it has stood still long enough --
+      # its next autonomous or custom-route step. Skipped once any event process
+      # is running this frame, so the map holds still during messages.
       def step_events
         @events.each do |_id, e|
+          ch = e[:char]
+          ch.update if ch
           step_event(e)
-          step_idle_animation(e)
         end
       end
 
@@ -655,73 +651,58 @@ class RPGXP
         return if event_busy?
         ch = e[:char]
         return unless ch
+        # Still crossing a tile: nothing new starts until it arrives.
+        return if ch.moving?
         # A forced route (Set Move Route) overrides page movement until it is done.
         forced = @forced_routes[e[:id]]
         return step_forced_event(e, ch, forced) if forced
         return unless e[:page]
-        e[:move_timer] -= 1
-        return if e[:move_timer] > 0
-        e[:move_timer] = EVENT_MOVE_DELAY[ch.move_frequency] || 30
+        return if ch.stop_count <= move_wait(ch)
         ox = ch.x
         oy = ch.y
         if e[:route]
-          e[:route].step(ch, @world) unless e[:route].done?
+          run_route(e[:route], ch)
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
           move_autonomous(e, dir) if dir
         end
-        if ch.x != ox || ch.y != oy
-          reoccupy(e, ox, oy)
-          animate_step e, ch
-        end
+        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
       rescue StandardError => ex
         $stderr.puts "[RGSS] event ##{e[:id]} movement failed: #{ex.message}"
       end
 
-      # One frame of a character's walk cycle. RMXP animates a character that
-      # moved unless its page turned `walk_anime` off; a page with `step_anime`
-      # keeps animating while it stands still (handled in step_idle_animation).
-      def animate_step(e, ch)
-        e[:idle_anime] = 0
-        ch.advance_pattern if ch.walk_anime || ch.step_anime
+      # Frames an event stands still between steps, as RMXP paces autonomous
+      # movement: `(40 - frequency * 2) * (6 - frequency)`, so frequency 1 waits
+      # 190 frames and frequency 6 never waits at all. The glide itself is timed
+      # separately, by move speed.
+      def move_wait(ch)
+        f = ch.move_frequency || 3
+        (40 - f * 2) * (6 - f)
       end
 
-      # Pages with `step_anime` animate on the spot. Paced off the same frame
-      # counter as the walk cycle so a standing animation runs at a steady rate
-      # rather than at the event's move frequency.
-      IDLE_ANIME_FRAMES = 8
+      # One turn of a move route. A movement command ends the turn (the walk
+      # takes time); the commands that only have an effect -- turns, switches,
+      # a graphic change -- run straight away and the route carries on, as
+      # RMXP's move_type_custom does, so a route of them does not spend a whole
+      # wait period per command. Bounded so a route made only of effects cannot
+      # spin.
+      ROUTE_EFFECTS_PER_TURN = 64
 
-      # RMXP's Game_Character#update_stop: a standing character with
-      # `step_anime` keeps cycling, and one without it falls back to the pose
-      # its page asked for once it has stopped walking. We step tile-to-tile
-      # rather than pixel-by-pixel, so "stopped" is a frame count instead of
-      # the end of an interpolation.
-      def step_idle_animation(e)
-        ch = e[:char]
-        return unless ch
-        e[:idle_anime] = (e[:idle_anime] || 0) + 1
-        if ch.step_anime
-          return if e[:idle_anime] < IDLE_ANIME_FRAMES
-          e[:idle_anime] = 0
-          ch.advance_pattern
-        elsif e[:idle_anime] >= (EVENT_MOVE_DELAY[ch.move_frequency] || 30)
-          ch.rest_pattern
+      def run_route(route, ch)
+        ROUTE_EFFECTS_PER_TURN.times do
+          break if route.done?
+          break unless route.step(ch, @world) == :effect
         end
       end
 
       # Advance an event's forced route one paced step, updating its occupied
       # tile, and drop the route once a non-repeating one is exhausted.
       def step_forced_event(e, ch, forced)
-        forced[:timer] -= 1
-        return if forced[:timer] > 0
-        forced[:timer] = EVENT_MOVE_DELAY[ch.move_frequency] || 30
+        return if ch.stop_count <= move_wait(ch)
         ox = ch.x
         oy = ch.y
-        forced[:route].step(ch, @world) unless forced[:route].done?
-        if ch.x != ox || ch.y != oy
-          reoccupy(e, ox, oy)
-          animate_step e, ch
-        end
+        run_route(forced[:route], ch)
+        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
         @forced_routes.delete(e[:id]) if forced[:route].done?
       rescue StandardError => ex
         $stderr.puts "[RGSS] event ##{e[:id]} forced move failed: #{ex.message}"
@@ -763,15 +744,13 @@ class RPGXP
       def start_player_route(route)
         @player_char = Game::Character.new(@state.x, @state.y, @state.direction)
         @player_route = route
-        @player_route_timer = 0
       end
 
       def step_player_route
         return unless @player_route
-        @player_route_timer -= 1
-        return if @player_route_timer > 0
-        @player_route_timer = EVENT_MOVE_DELAY[@player_char.move_frequency] || 30
-        @player_route.step(@player_char, @world) unless @player_route.done?
+        @player_char.update
+        return if @player_char.moving? || @player_char.stop_count <= move_wait(@player_char)
+        run_route(@player_route, @player_char)
         @state.x = @player_char.x
         @state.y = @player_char.y
         @state.direction = @player_char.direction
@@ -793,7 +772,12 @@ class RPGXP
         nx, ny = Game::Character.step_tile(ch.x, ch.y, dir)
         if nx == @state.x && ny == @state.y
           ch.face(dir)
-          start_event(e) if e[:trigger] == TRIGGER_EVENT_TOUCH && list_nonempty?(page_list(e))
+          if e[:trigger] == TRIGGER_EVENT_TOUCH && list_nonempty?(page_list(e))
+            # Bumping into the player runs the event; wait a full move period
+            # before bumping again rather than re-running it every frame.
+            ch.hold_still
+            start_event(e)
+          end
         elsif @world.passable?(ch, dir)
           ch.move(dir)
         else
@@ -1342,8 +1326,8 @@ class RPGXP
           s[:sprite].visible = true
           # Character sheets are wider/taller than a tile: RMXP centres them on
           # the tile and stands them on its bottom edge, as the player is drawn.
-          sy = ch.y * TILE - cam_y
-          s[:sprite].x = ch.x * TILE - cam_x - (s[:w] - TILE) / 2
+          sy = ch.pixel_y(TILE) - cam_y
+          s[:sprite].x = ch.pixel_x(TILE) - cam_x - (s[:w] - TILE) / 2
           s[:sprite].y = sy - (s[:h] - TILE)
           s[:sprite].z = character_z(sy, ch.always_on_top)
           next unless s[:charset]

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -446,6 +446,8 @@ class RPGXP
         @dest_x = @state.x
         @dest_y = @state.y
         @last_frame = nil
+        @player_pattern = 0
+        @player_anime = 0
 
         @resolver = EventResolver.new(@db.common_events)
         @interpreter = Game::Interpreter.new(@state)
@@ -503,6 +505,7 @@ class RPGXP
             end
           end
         end
+        animate_player
         render
       end
 
@@ -922,6 +925,8 @@ class RPGXP
         @dest_x = x
         @dest_y = y
         @last_frame = nil
+        @player_pattern = 0
+        @player_anime = 0
         @characters = {} # new map: events start at their spawn tiles
         @forced_routes = {} # forced routes do not survive a map change
         @erased = {} # erased events reappear on a fresh map
@@ -1245,8 +1250,9 @@ class RPGXP
             @state.y = @dest_y
             @moving = false
             @move_count = 0
+          else
+            return # still crossing the tile: nothing new starts
           end
-          return
         end
 
         return if @player_route # a forced route controls the player
@@ -1372,9 +1378,26 @@ class RPGXP
         end
       end
 
+      # The player walks at SPEED pixels a frame, which is RMXP's move speed 4
+      # (2 ** 4 of the 128 units it counts a tile in), and its walk cycle runs
+      # off the same animation counter every other character uses: 1.5 ticks a
+      # frame, a new frame every 18 - move_speed * 2 ticks, back to the standing
+      # frame once it has stopped. Keying the frame off the distance walked
+      # instead -- (@move_count / 8) % 4 -- cycled all four frames within a
+      # single tile, about three times the real runtime's rate.
+      PLAYER_MOVE_SPEED = 4
+      PLAYER_ANIME_TICKS = 18 - PLAYER_MOVE_SPEED * 2
+
+      def animate_player
+        @player_anime += 1.5 if @moving || @player_pattern != 0
+        return if @player_anime <= PLAYER_ANIME_TICKS
+        @player_anime = 0
+        @player_pattern = @moving ? (@player_pattern + 1) % 4 : 0
+      end
+
       def draw_player_frame
         return unless @charset
-        pat = @moving ? Game::CharSet::PATTERNS[(@move_count / 8) % 4] : 0
+        pat = Game::CharSet::PATTERNS[@player_pattern]
         frame = [@state.direction, pat]
         return if frame == @last_frame
         @last_frame = frame

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -297,12 +297,12 @@ class RPGXP
       end
     end
 
-    # First walkable map slice: renders the three tile layers as placeholder
-    # colour blocks (real chipset/autotile blitting is future work), draws the
-    # party leader from its Character graphic and moves it on the grid with pixel
-    # interpolation, tileset collision and an edge-clamped follow camera. Map
-    # events are drawn as markers for now; running their command lists is the
-    # next milestone.
+    # The walkable map: the three tile layers render through the native
+    # RGSS::Tilemap (the real tileset graphic, autotiles assembled from their
+    # quads and animated, priority tiles sorted above the characters), the party
+    # leader and every event draw from their Character graphics, and movement is
+    # grid-based with pixel interpolation, tileset collision and an edge-clamped
+    # follow camera.
     # Resolves the command list a Call Common Event refers to (common events are
     # 1-based in the database array).
     class EventResolver
@@ -356,6 +356,9 @@ class RPGXP
       COLS = SCREEN_W / TILE + 1
       ROWS = SCREEN_H / TILE + 1
       SPEED = 4 # pixels/frame while stepping (must divide TILE)
+      # RMXP tile ids: 0 empty, 48..383 the seven autotiles, TILE_ID_BASE and up
+      # the tileset graphic in reading order.
+      TILE_ID_BASE = 384
       MSG_LINE_H = 32
 
       # Frames between autonomous event steps, keyed by RMXP move frequency
@@ -375,7 +378,6 @@ class RPGXP
         @map = state.map
         @tileset = Game::TileSet.new(@db, @map.tileset_id)
         @charset = load_charset
-        @tile_colors = {}
 
         @moving = false
         @move_count = 0
@@ -418,7 +420,8 @@ class RPGXP
       def dispose
         close_message
         close_number_input
-        [@lower_sprite, @upper_sprite, @player_sprite].each { |s| s.dispose if s }
+        @event_sprites.each_value { |s| s[:sprite].dispose } if @event_sprites
+        [@tilemap, @player_sprite].each { |s| s.dispose if s }
       end
 
       def update
@@ -472,6 +475,8 @@ class RPGXP
           @events[id] = entry
           @event_tiles[[entry[:char].x, entry[:char].y]] = entry if entry[:page]
         end
+        # A rebuild can have swapped which page (and so which graphic) is active.
+        refresh_event_sprites
       rescue StandardError => e
         $stderr.puts "[RGSS] event setup failed, map runs with no events: #{e.message}"
         @events = {}
@@ -973,18 +978,11 @@ class RPGXP
       end
 
       def setup_sprites
-        @lower_sprite = Sprite.new
-        @lower_sprite.z = 0
-        @lower_bmp = Bitmap.new(COLS * TILE, ROWS * TILE)
-        @lower_sprite.bitmap = @lower_bmp
-
-        @upper_sprite = Sprite.new
-        @upper_sprite.z = 200
-        @upper_bmp = Bitmap.new(COLS * TILE, ROWS * TILE)
-        @upper_sprite.bitmap = @upper_bmp
+        setup_tilemap
 
         @player_sprite = Sprite.new
-        @player_sprite.z = 100
+        # z is set per frame from the screen row the leader stands on, so
+        # characters overlap in the right order (see character_z).
         pw = @charset ? Game::CharSet.cell_width(@charset) : TILE
         ph = @charset ? Game::CharSet.cell_height(@charset) : TILE
         @player_bmp = Bitmap.new(pw, ph)
@@ -992,6 +990,135 @@ class RPGXP
         unless @charset
           @player_bmp.fill_rect 4, 0, TILE - 8, ph, Color.new(240, 240, 80, 255)
         end
+
+        setup_event_sprites
+      end
+
+      # The map ground: an RGSS::Tilemap fed the tileset graphic, the seven
+      # autotiles and the map's own data/priority Tables, which is exactly what
+      # RMXP's Spriteset_Map builds. The renderer is native (mruby-rgss): it
+      # blits regular tiles from the tileset, assembles autotiles from their four
+      # quads, animates them, and routes priority tiles to a layer above the
+      # characters. Until now this scene painted a colour block per tile id --
+      # navigable, but nothing like the real map (the wine comparison in
+      # docs/adr/0025-rpgxp-cross-runtime-testing.md measured every map pixel as
+      # differing from the genuine runtime because of it).
+      #
+      # A missing tileset graphic must not take the map down: the Tilemap simply
+      # draws nothing, and the scene stays walkable.
+      def setup_tilemap
+        @tilemap = Tilemap.new
+        @tilemap.map_data = @map.data
+        ts = @db.tilesets[@map.tileset_id]
+        unless ts
+          $stderr.puts "[RGSS] map #{@state.map_id} has no tileset " \
+                       "##{@map.tileset_id}; drawing no ground"
+          return
+        end
+        @tilemap.priorities = ts.priorities
+        @tilemap.tileset = load_map_graphic("Tilesets", ts.tileset_name)
+        (ts.autotile_names || []).each_with_index do |name, i|
+          break if i >= 7 # RGSS has exactly seven autotile slots
+          bmp = load_map_graphic("Autotiles", name)
+          @tilemap.autotiles[i] = bmp if bmp
+        end
+      rescue StandardError => e
+        $stderr.puts "[RGSS] tilemap setup failed, map draws empty: #{e.message}"
+      end
+
+      # One Graphics/<dir>/<name> bitmap, or nil when the name is blank or the
+      # file is missing. Reported rather than swallowed, as the rest of the
+      # runtime does: a missing tile graphic is why a map would render bare.
+      def load_map_graphic(dir, name)
+        return nil if name.nil? || name.empty?
+        Bitmap.new "Graphics/#{dir}/#{name}"
+      rescue StandardError => e
+        $stderr.puts "[RGSS] #{dir}/#{name} load failed: #{e.message}"
+        nil
+      end
+
+      # Event sprites. RMXP draws an event from its active page's graphic: a
+      # Graphics/Characters sheet (four directions x four patterns), or the tile
+      # itself when the page picked a tile id instead. An event whose graphic is
+      # empty draws *nothing* -- which is why the red marker this scene used to
+      # paint into the ground layer is gone: it marked every invisible event, on
+      # pixels the genuine runtime leaves as plain map.
+      def setup_event_sprites
+        @event_sprites = {}
+        refresh_event_sprites
+      end
+
+      # Rebuild the sprites from the current pages. Page re-selection can swap an
+      # event's graphic (or remove it), so this runs whenever the event list is
+      # rebuilt, not only on entry.
+      def refresh_event_sprites
+        return unless @event_sprites
+        @event_sprites.each_value { |s| s[:sprite].dispose }
+        @event_sprites = {}
+        @events.each do |id, e|
+          s = build_event_sprite(e)
+          @event_sprites[id] = s if s
+        end
+      rescue StandardError => e
+        $stderr.puts "[RGSS] event sprite setup failed: #{e.message}"
+        @event_sprites ||= {}
+      end
+
+      def build_event_sprite(entry)
+        page = entry[:page]
+        g = page && page.graphic
+        return nil unless g
+        name = g.character_name
+        if name && !name.empty?
+          charset = load_map_graphic("Characters", name)
+          return nil unless charset
+          w = Game::CharSet.cell_width(charset)
+          h = Game::CharSet.cell_height(charset)
+          new_event_sprite(Bitmap.new(w, h), charset, w, h)
+        elsif g.tile_id && g.tile_id >= TILE_ID_BASE
+          bmp = tile_graphic(g.tile_id)
+          bmp && new_event_sprite(bmp, nil, TILE, TILE)
+        end
+      end
+
+      def new_event_sprite(bitmap, charset, w, h)
+        sprite = Sprite.new
+        sprite.bitmap = bitmap
+        { sprite: sprite, bitmap: bitmap, charset: charset, w: w, h: h,
+          frame: nil }
+      end
+
+      # Character stacking, as RMXP's Sprite_Character#update does it: a
+      # character's z follows the screen y of the tile it stands on, so whoever
+      # is further down the screen draws in front. An "always on top" event
+      # (RMXP's `always_on_top` page flag) jumps above the tilemap's priority
+      # layer instead. Everything stays under the fog/weather planes.
+      ALWAYS_ON_TOP_Z = 950
+
+      def character_z(screen_y, always_on_top)
+        return ALWAYS_ON_TOP_Z if always_on_top
+        # Feet-line y, clamped under the priority layer so a character near the
+        # bottom edge cannot outrank it.
+        z = screen_y + TILE
+        z < 0 ? 0 : (z > 890 ? 890 : z)
+      end
+
+      # A single map tile cut out of the tileset graphic, for an event whose page
+      # uses a tile id as its graphic (doors, chests laid into the map). Tile ids
+      # from TILE_ID_BASE up index the tileset in reading order.
+      def tile_graphic(tile_id)
+        ts = @tilemap && @tilemap.tileset
+        return nil unless ts
+        cols = ts.width / TILE
+        cols = 1 if cols < 1
+        idx = tile_id - TILE_ID_BASE
+        bmp = Bitmap.new(TILE, TILE)
+        bmp.blt 0, 0, ts, Rect.new((idx % cols) * TILE, (idx / cols) * TILE,
+                                   TILE, TILE)
+        bmp
+      rescue StandardError => e
+        $stderr.puts "[RGSS] event tile graphic #{tile_id} failed: #{e.message}"
+        nil
       end
 
       def step_movement
@@ -1064,46 +1191,58 @@ class RPGXP
         cam_x = Game.camera_offset(px + TILE / 2, SCREEN_W, @map.width * TILE)
         cam_y = Game.camera_offset(py + TILE / 2, SCREEN_H, @map.height * TILE)
 
-        draw_layers cam_x, cam_y
+        scroll_tilemap cam_x, cam_y
+        draw_event_sprites cam_x, cam_y
 
         pw = @player_bmp.width
         ph = @player_bmp.height
+        sy = py - cam_y
         @player_sprite.x = px - cam_x - (pw - TILE) / 2
-        @player_sprite.y = py - cam_y - (ph - TILE)
+        @player_sprite.y = sy - (ph - TILE)
+        @player_sprite.z = character_z(sy, false)
         draw_player_frame
       end
 
-      def draw_layers(cam_x, cam_y)
-        @lower_bmp.clear
-        @upper_bmp.clear
-        first_tx = cam_x / TILE
-        first_ty = cam_y / TILE
-        ox = cam_x % TILE
-        oy = cam_y % TILE
+      # Scroll the ground to the camera and let it animate. Each ox/oy write
+      # re-tiles the whole visible area natively, so only write them when the
+      # camera actually moved; #update then costs nothing on a map with no
+      # animated autotile.
+      def scroll_tilemap(cam_x, cam_y)
+        return unless @tilemap
+        if cam_x != @cam_x || cam_y != @cam_y
+          @cam_x = cam_x
+          @cam_y = cam_y
+          @tilemap.ox = cam_x
+          @tilemap.oy = cam_y
+        end
+        @tilemap.update
+      end
 
-        (0...ROWS).each do |ry|
-          (0...COLS).each do |rx|
-            tx = first_tx + rx
-            ty = first_ty + ry
-            next unless in_bounds?(tx, ty)
-            dx = rx * TILE - ox
-            dy = ry * TILE - oy
-
-            # Layers 0/1 to the lower sprite, layer 2 to the upper (drawn above
-            # the player), matching RMXP's three-layer stack.
-            b0 = @map.data[tx, ty, 0]
-            b1 = @map.data[tx, ty, 1]
-            @lower_bmp.fill_rect dx, dy, TILE, TILE, tile_color(b0)
-            @lower_bmp.fill_rect dx, dy, TILE, TILE, tile_color(b1) if b1 && b1 != 0
-
-            top = @map.data[tx, ty, 2]
-            @upper_bmp.fill_rect dx, dy, TILE, TILE, tile_color(top) if top && top != 0
-
-            if @event_tiles[[tx, ty]]
-              @lower_bmp.fill_rect dx + 4, dy + 4, TILE - 8, TILE - 8,
-                                   Color.new(230, 90, 90, 255)
-            end
+      def draw_event_sprites(cam_x, cam_y)
+        return unless @event_sprites
+        @event_sprites.each do |id, s|
+          e = @events[id]
+          # Erased, or its page went away between rebuilds: keep the sprite (the
+          # page may come back) but stop drawing it.
+          if e.nil? || e[:page].nil?
+            s[:sprite].visible = false
+            next
           end
+          ch = e[:char]
+          s[:sprite].visible = true
+          # Character sheets are wider/taller than a tile: RMXP centres them on
+          # the tile and stands them on its bottom edge, as the player is drawn.
+          sy = ch.y * TILE - cam_y
+          s[:sprite].x = ch.x * TILE - cam_x - (s[:w] - TILE) / 2
+          s[:sprite].y = sy - (s[:h] - TILE)
+          s[:sprite].z = character_z(sy, ch.always_on_top)
+          next unless s[:charset]
+          frame = [ch.direction, ch.pattern]
+          next if frame == s[:frame]
+          s[:frame] = frame
+          rect = Game::CharSet.frame_rect(s[:charset], ch.direction, ch.pattern)
+          s[:bitmap].clear
+          s[:bitmap].blt 0, 0, s[:charset], rect
         end
       end
 
@@ -1118,14 +1257,6 @@ class RPGXP
         @player_bmp.blt 0, 0, @charset, rect
       end
 
-      # Deterministic placeholder colour per tile id (empty tiles are a dark
-      # void), the same navigable stand-in the RPG2000 map scene uses.
-      def tile_color(id)
-        return (@void ||= Color.new(16, 16, 28, 255)) if id.nil? || id == 0
-        @tile_colors[id] ||= Color.new(40 + (id * 37) % 180,
-                                       40 + (id * 71) % 180,
-                                       60 + (id * 143) % 160, 255)
-      end
     end
   end
 end

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -973,6 +973,22 @@ assert "Game::Character move / face / turns / toward" do
   assert_equal 4, RPGXP::Game::Character.new(4, 4).direction_away(10, 4)
 end
 
+assert "Game::Character cycles its walk pattern and rests on the page's frame" do
+  c = RPGXP::Game::Character.new(0, 0)
+  # A page that stands on frame 1 (RMXP's Graphic#pattern).
+  c.set_graphic("hero", 0, 2, 1)
+  assert_equal 1, c.pattern
+  c.advance_pattern
+  assert_equal 2, c.pattern
+  3.times { c.advance_pattern } # 3, 0, 1 -- wraps at four frames
+  assert_equal 1, c.pattern
+  c.advance_pattern
+  assert_equal 2, c.pattern
+  # Standing still returns to the page's own frame, not to 0.
+  c.rest_pattern
+  assert_equal 1, c.pattern
+end
+
 assert "Game::MoveRoute moves forward and repeats" do
   route = RPGXP::Game::MoveRoute.new([mv(12)], true, false) # Move Forward, repeat
   c = RPGXP::Game::Character.new(0, 0, 6) # facing right

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -973,19 +973,41 @@ assert "Game::Character move / face / turns / toward" do
   assert_equal 4, RPGXP::Game::Character.new(4, 4).direction_away(10, 4)
 end
 
+assert "Game::Character glides to the tile it stepped onto" do
+  c = RPGXP::Game::Character.new(1, 1)
+  c.move_speed = 4 # 2**4 of 128 units a frame: eight frames a tile
+  c.move(6)
+  # The tile is taken at once (that is what collision sees) but the character
+  # is still drawn on the one it left.
+  assert_equal 2, c.x
+  assert_equal 32, c.pixel_x(32)
+  assert_true c.moving?
+  7.times { c.update }
+  assert_true c.moving?
+  c.update
+  assert_false c.moving?
+  assert_equal 64, c.pixel_x(32)
+  # Placing a character (a spawn or a teleport) is not a step: it does not glide.
+  c.x = 9
+  assert_false c.moving?
+  assert_equal 288, c.pixel_x(32)
+end
+
 assert "Game::Character cycles its walk pattern and rests on the page's frame" do
   c = RPGXP::Game::Character.new(0, 0)
   # A page that stands on frame 1 (RMXP's Graphic#pattern).
   c.set_graphic("hero", 0, 2, 1)
+  c.move_speed = 4 # animation ticks 1.5 a frame, cycling every 18 - 4 * 2
   assert_equal 1, c.pattern
-  c.advance_pattern
-  assert_equal 2, c.pattern
-  3.times { c.advance_pattern } # 3, 0, 1 -- wraps at four frames
+  c.move(2)
+  6.times { c.update } # 9.0 ticks: not there yet
   assert_equal 1, c.pattern
-  c.advance_pattern
+  c.update # 10.5 ticks
   assert_equal 2, c.pattern
-  # Standing still returns to the page's own frame, not to 0.
-  c.rest_pattern
+  # Once it has arrived and stood still a moment it falls back to the page's
+  # own frame, not to frame 0.
+  20.times { c.update }
+  assert_false c.moving?
   assert_equal 1, c.pattern
 end
 

--- a/scripts/compare-rpgxp-wine.bash
+++ b/scripts/compare-rpgxp-wine.bash
@@ -136,8 +136,19 @@ STEPS=(
     "walk-up Up*3"
 )
 
+# The reference's screen is taller than the game by the window manager's frame.
+# On a 640x480 screen matchbox sizes the *framed* window to the screen, leaving
+# the genuine runtime a 640x460 client and clipping the game's bottom 20 rows
+# off-screen -- which the diff then counted as 20 rows of pure difference on
+# every frame (70% of the residual on a map step, measured). Giving the screen
+# the frame's height back and cropping the capture to the game's own 640x480
+# compares like with like. Our engine's window needs no such room: it is sized
+# to the screen and undecorated.
+REF_SCREEN_PAD="${REF_SCREEN_PAD:-20}"
+
 start_ref() {
-    Xvfb "${REF_DISPLAY}" -screen 0 640x480x24 >/tmp/rpgxp-ref-xvfb.log 2>&1 &
+    Xvfb "${REF_DISPLAY}" -screen 0 "640x$((480 + REF_SCREEN_PAD))x24" \
+        >/tmp/rpgxp-ref-xvfb.log 2>&1 &
     PIDS+=($!)
     sleep 2
     DISPLAY="${REF_DISPLAY}" matchbox-window-manager -use_titlebar no \
@@ -183,9 +194,39 @@ send_keys() {
     done
 }
 
+# Capture one display, cropped to the game's own 640x480 picture (the
+# reference's screen is taller by the window manager's frame, see
+# REF_SCREEN_PAD).
 capture() {
     local disp="$1" out="$2"
-    DISPLAY="${disp}" xwd -root -silent | convert xwd:- png:"${out}"
+    DISPLAY="${disp}" xwd -root -silent |
+        convert xwd:- -crop '640x480+0+0' +repage png:"${out}"
+}
+
+# How many rows of the reference frame the genuine runtime actually painted.
+# matchbox keeps its frame even with the titlebar off and sizes the *framed*
+# window to the screen, so RGSS gets a client area shorter than 640x480 (640x460
+# here) and the rest of the capture stays black -- 12,800 pixels of pure
+# measurement artifact per frame, which swamped the real difference. Comparing
+# only the rows both runtimes painted keeps the count honest; the written frames
+# are still the full captures. Detected from the reference rather than assumed,
+# so a different window manager just yields a different (or no) trim, and only
+# ever shrinks the compared area.
+compare_height() {
+    local img="$1" bbox h y
+    bbox=$(identify -format '%@' "${img}" 2>/dev/null) || bbox=""
+    # "WxH+X+Y" of the non-border content; only trust it when it starts at the
+    # top-left, i.e. the frame is aligned and only the bottom is missing.
+    case "${bbox}" in
+        *+0+0)
+            h="${bbox#*x}"
+            h="${h%%+*}"
+            ;;
+        *) h=480 ;;
+    esac
+    y="${h:-480}"
+    if [ "${y}" -lt 400 ] || [ "${y}" -gt 480 ] ; then y=480 ; fi
+    echo "${y}"
 }
 
 start_ref
@@ -222,9 +263,18 @@ for step in "${STEPS[@]}" ; do
              "check /tmp/rpgxp-ref-player.log" >&2
     fi
 
-    total=$(identify -format '%[fx:w*h]' "${ref}")
-    differing=$(compare -metric AE -fuzz "${DIFF_FUZZ:-3%}" "${ref}" "${our}" \
-        null: 2>&1 || true)
+    # Compare only the rows the genuine runtime painted (see compare_height).
+    # Measured once, from the first frame, so every step reports on the same
+    # area.
+    if [ -z "${CMP_H:-}" ] ; then
+        CMP_H=$(compare_height "${ref}")
+        [ "${CMP_H}" -lt 480 ] &&
+            echo "note: the reference painted ${CMP_H} of 480 rows (its window" \
+                 "manager's frame took the rest); diffing that area" >&2
+    fi
+    total=$((640 * CMP_H))
+    differing=$(compare -metric AE -fuzz "${DIFF_FUZZ:-3%}" \
+        "${ref}[640x${CMP_H}+0+0]" "${our}[640x${CMP_H}+0+0]" null: 2>&1 || true)
     printf '%-16s differing pixels: %s / %s\n' "${label}" "${differing}" "${total}"
 done
 

--- a/scripts/compare-rpgxp-wine.bash
+++ b/scripts/compare-rpgxp-wine.bash
@@ -213,20 +213,23 @@ capture() {
 # so a different window manager just yields a different (or no) trim, and only
 # ever shrinks the compared area.
 compare_height() {
-    local img="$1" bbox h y
-    bbox=$(identify -format '%@' "${img}" 2>/dev/null) || bbox=""
-    # "WxH+X+Y" of the non-border content; only trust it when it starts at the
-    # top-left, i.e. the frame is aligned and only the bottom is missing.
-    case "${bbox}" in
-        *+0+0)
-            h="${bbox#*x}"
-            h="${h%%+*}"
-            ;;
-        *) h=480 ;;
-    esac
-    y="${h:-480}"
-    if [ "${y}" -lt 400 ] || [ "${y}" -gt 480 ] ; then y=480 ; fi
-    echo "${y}"
+    local img="$1" y mean
+    # Walk up from the bottom for the first row the runtime drew anything on.
+    # Deliberately not ImageMagick's -trim: that keys on the *corner* colour, so
+    # on a dark title screen it finds no border and reports the full height,
+    # silently putting the artifact back into the count. Never trims more than
+    # MAX_TRIM rows, so a genuinely black-bottomed frame cannot shrink the
+    # comparison away.
+    local max_trim=80
+    for y in $(seq 479 -1 $((480 - max_trim))) ; do
+        mean=$(convert "${img}[640x1+0+${y}]" -format '%[fx:mean>0.004]' info: \
+                   2>/dev/null || echo 1)
+        if [ "${mean}" = "1" ] ; then
+            echo $((y + 1))
+            return
+        fi
+    done
+    echo 480
 }
 
 start_ref

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -224,9 +224,37 @@ fs::path rtp_path() {
       ini["Software\\\\ASCII\\\\RPG2000"]["\"RuntimePackagePath\""]);
 }
 
-fs::path xp_rtp_path() {
+// The RTP a project asks for, from its own Game.ini: RPG Maker XP writes
+// `RTP1=Standard` (plus optional RTP2/RTP3 slots), VX and VX Ace a single
+// `RTP=RPGVX` / `RTP=RPGVXAce`. That name is the registry *value* the runtime
+// looks up under its edition's key, so reading it here resolves a project that
+// ships with a differently named RTP instead of assuming the stock one.
+std::string ini_rtp_name(const fs::path& game_dir) {
+  const fs::path ini_path = game_dir / "Game.ini";
+  if (!fs::exists(ini_path))
+    return std::string();
+  inicpp::IniManager ini(ini_path.string());
+  std::string name = ini["Game"].toString("RTP1");
+  if (name.empty())
+    name = ini["Game"].toString("RTP");
+  return name;
+}
+
+// Each RGSS generation registers its RTPs under its own key, keyed by RTP name:
+// RGSS (XP) -> "Standard", RGSS2 (VX) -> "RPGVX", RGSS3 (VX Ace) -> "RPGVXAce".
+fs::path rgss_rtp_path(const std::string& rgss_key,
+                       const std::string& name,
+                       const char* fallback) {
   inicpp::IniManager ini = get_reg("system.reg");
-  return reg2path(ini["Software\\\\Enterbrain\\\\RGSS\\\\RTP"]["\"Standard\""]);
+  const std::string section =
+      "Software\\\\Enterbrain\\\\" + rgss_key + "\\\\RTP";
+  const std::string value =
+      "\"" + (name.empty() ? std::string(fallback) : name) + "\"";
+  return reg2path(ini[section][value]);
+}
+
+fs::path xp_rtp_path(const fs::path& game_dir) {
+  return rgss_rtp_path("RGSS", ini_rtp_name(game_dir), "Standard");
 }
 
 // RPG Maker VX / VX Ace projects look like XP ones from the outside — a
@@ -240,6 +268,19 @@ bool is_rpgvx_game(const fs::path& gd) {
   return fs::exists(gd / "Data" / "System.rvdata2") ||
          fs::exists(gd / "Data" / "System.rvdata") ||
          fs::exists(gd / "Game.rgss3a") || fs::exists(gd / "Game.rgss2a");
+}
+
+// VX Ace (RGSS3) rather than VX (RGSS2); only meaningful for a VX-family
+// project. The two editions install their RTPs under different keys.
+bool is_rpgvxace_game(const fs::path& gd) {
+  return fs::exists(gd / "Data" / "System.rvdata2") ||
+         fs::exists(gd / "Game.rgss3a");
+}
+
+fs::path vx_rtp_path(const fs::path& gd) {
+  const bool ace = is_rpgvxace_game(gd);
+  return rgss_rtp_path(ace ? "RGSS3" : "RGSS2", ini_rtp_name(gd),
+                       ace ? "RPGVXAce" : "RPGVX");
 }
 
 // An RPG Maker XP project: Game.ini plus either a loose Data/System.rxdata or
@@ -550,19 +591,23 @@ int main(int argc, char** argv) {
   // RPG_RT.ini's FullPackageFlag=1 marks a self-contained game; honour it by
   // clearing RTP_DIR so bitmap lookups never reach into the installed RTP.
   //
-  // The two makers register their RTP under different keys and lay it out
-  // differently, so pick by project type: RPG Maker XP resolves
-  // Software\Enterbrain\RGSS\RTP\Standard (whose tree is rooted at Graphics/
-  // and Audio/, matching the "Graphics/Titles/..." paths XP data stores),
-  // RPG2000 resolves Software\ASCII\RPG2000\RuntimePackagePath. Only the
-  // RPG2000 key was wired up before, so an XP project could never find its RTP
-  // art and every asset fell back to a placeholder (found while bringing up
+  // Each maker registers its RTP under its own key and lays it out differently,
+  // so pick by project type: RPG Maker XP resolves
+  // Software\Enterbrain\RGSS\RTP (whose tree is rooted at Graphics/ and Audio/,
+  // matching the "Graphics/Titles/..." paths XP data stores), VX and VX Ace the
+  // same shape under RGSS2 / RGSS3, and RPG2000
+  // Software\ASCII\RPG2000\RuntimePackagePath. Only the RPG2000 key was wired
+  // up before, so an XP project could never find its RTP art and every asset
+  // fell back to a placeholder (found while bringing up
   // scripts/compare-rpgxp-wine.bash, which needs both runtimes to draw the same
-  // pictures to be worth anything).
+  // pictures to be worth anything) -- and a VX project still resolved the
+  // RPG2000 path, which can never hold its assets.
+  const fs::path game_dir = FLAGS_game_dir;
   const std::string rtp_dir =
-      full_package_flag(FLAGS_game_dir)
-          ? std::string()
-          : (is_xp_game(FLAGS_game_dir) ? xp_rtp_path() : rtp_path()).string();
+      full_package_flag(game_dir) ? std::string()
+      : is_xp_game(game_dir)      ? xp_rtp_path(game_dir).string()
+      : is_rpgvx_game(game_dir)   ? vx_rtp_path(game_dir).string()
+                                  : rtp_path().string();
   mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "RTP_DIR"),
                 mrb_str_new_cstr(M, rtp_dir.c_str()));
 #endif


### PR DESCRIPTION
Six commits that close the visible gaps between our RPG Maker XP map scene and
Enterbrain's RGSS runtime, each measured by booting both on the same project —
the OpenGame.exe "Testbed/XP" — and diffing the frames with
`scripts/compare-rpgxp-wine.bash`. They build on each other in the same files,
so they come as one chain; the two fixes from the same session that stand alone
are in #313 and #314.

### What changes

1. **The map draws from the real tileset.** `Scene::Map` rendered the three tile
   layers as placeholder colour blocks. It now feeds the native `Tilemap` the
   tileset graphic, its seven autotiles and the priority table, and draws each
   event from its page's character sheet (or tile id) with RMXP's screen-y
   stacking. Map difference against the reference: 100% of pixels → ~0.5%.
2. **Partial-opacity blits composite in straight alpha.** `Bitmap#blt` /
   `#stretch_blt` blended the source toward the destination even where the
   destination was *transparent* — toward black — while also recording the
   reduced alpha, so the later composite attenuated the same colour twice. The
   new form reduces to the old one when the destination is opaque, so blits onto
   an opaque bitmap are unchanged (the RPG2000 title screen renders
   byte-for-byte as before). XP windows now honour `back_opacity` and draw their
   cursor from the windowskin's own 32x32 block.
3. **Events animate.** `Game::Character#@pattern` was only ever assigned when a
   page set the graphic, so every event stood frozen on one frame of its
   four-frame walk row while it roamed. A page's `walk_anime` / `step_anime`
   flags were decoded and never handed to the character either.
4. **Events glide between tiles, at RMXP's pace.** A step now claims the
   destination tile at once (which is what collision sees) while `real_x/real_y`
   close the 128-unit gap at `2 ** move_speed` a frame; the walk row runs off
   RMXP's animation counter and rests on the page's own frame. Autonomous steps
   wait `(40 - frequency * 2) * (6 - frequency)` frames instead of a placeholder
   table, and a route's non-movement commands run in the turn of the step that
   follows them, as `move_type_custom` does.
5. **Event graphic opacity, blending and hue are applied.** All three were
   decoded and dropped; *Change Opacity* / *Change Blending* in a move route now
   reach the sprite, and the party leader's `character_hue` is applied too.
6. **The player walks at the runtime's animation rate.** Its frame came from the
   distance walked — `(@move_count / 8) % 4` — cycling the whole row inside one
   tile, about three times too fast.

Along the way the XP runtime also learned to find the RTP per maker (the
`Software\Enterbrain\RGSS\RTP` key, with the name from `Game.ini`), to load
truecolour and JPEG assets correctly, and to size the browser display to XP's
640x480.

### Checks

- `cmake --build build -t test` — 3/3 passing, including new
  `Game::Character` checks for the glide and the walk cycle.
- `scripts/rpgxp_boot_check.bash` — boots the test bed into the map scene.
- Against the genuine RGSS runtime under wine: title 227,389 → ~28,000 differing
  pixels (the remainder is text the reference cannot draw — no font in the wine
  prefix), map 307,200 (100%) → 470–6,000 (0.15–2%), the rest being the roaming
  NPC, which our RNG walks elsewhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Gfz65XQy51ZNZ2Vo1TwVn)_