### PR TITLE
RPG2000 battle refinements: hit/miss, state susceptibility, first strike

### DIFF
--- a/changelog.d/rpg2k-battle-first-strike.added.md
+++ b/changelog.d/rpg2k-battle-first-strike.added.md
@@ -1,0 +1,9 @@
+- RPG Maker 2000: a **pre-emptive first strike** now gives the party a free
+  opening round. The Enemy Encounter command's first-strike flag was already
+  decoded but ignored; `Game::Battle` now takes a `first_strike` option, and
+  `refill_queue` drops the enemies from round 1's turn order so only the party
+  acts while the ambushed foes skip their turn — they rejoin normally from the
+  second round. Wired into the live battle from the encounter request. Covered by
+  new `scripts/rpg2k_logic_check.rb` checks (the party acts first while enemies
+  skip round 1, enemies rejoin in round 2, and a normal encounter still has both
+  sides act in the opening round).

--- a/changelog.d/rpg2k-battle-hit-miss.added.md
+++ b/changelog.d/rpg2k-battle-hit-miss.added.md
@@ -1,0 +1,15 @@
+- RPG Maker 2000: **basic attacks can now miss**. `Game::Battle#to_hit` computes
+  an attacker's to-hit percentage from its base hit rate — an actor's equipped
+  weapon `hit` (`Game::Actor#attack_hit_rate`, unarmed default 90), an enemy's 90
+  or 70 when the database "miss" flag is set (`Game::Enemy#attack_hit_rate`) —
+  adjusted by the attacker/target agility ratio, matching EasyRPG's
+  `CalcNormalAttackToHit` / `CalcToHitAgiAdjustment` (which reduces to
+  `100 - (100 - base)·(srcAgi + tgtAgi)/(2·srcAgi)`, clamped 0..100), so a nimbler
+  target dodges more. The base hit rate is snapshotted onto the `Combatant`, and
+  `deal_attack` rolls it when the fight has accuracy enabled — a miss deals no
+  damage and tags the log entry `missed: true` (the battle screen banners "X
+  misses Y"). Accuracy is an opt-in `Game::Battle` flag the live game turns on,
+  off by default so seeded / headless fights stay reproducible. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks (the to-hit formula and its clamps,
+  accuracy-off always connects, a sure-miss deals no damage, and the roll both
+  lands and misses over many swings).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -386,10 +386,14 @@ The work below is roughly ordered by the critical path to a walkable game
   **flee**: `Battle#attempt_escape` rolls EasyRPG's agility-ratio chance
   (`150 - 100·enemyAgi/partyAgi`, clamped), a preemptive first strike always
   gets away, and a failed attempt forfeits the party's round (every member
-  skips, the enemies still act) while raising the next try by 10 points. Still
-  to come: enemy-cast infliction, all-target skill/item scopes, per-attribute
-  rate overrides from the Attribute table, the per-terrain backdrop and the
-  RPG2000 Game Over graphic.
+  skips, the enemies still act) while raising the next try by 10 points. Basic
+  attacks can also **miss**: `Battle#to_hit` takes the attacker's base hit rate
+  (weapon / unarmed 90, a "miss"-flagged enemy 70) and applies EasyRPG's
+  agility-ratio adjustment (`100 - (100 - base)*(srcAgi + tgtAgi)/(2*srcAgi)`),
+  so a nimble target dodges more; a missed swing deals no damage. Still to come:
+  enemy-cast infliction, all-target skill/item scopes, per-attribute rate
+  overrides from the Attribute table, the per-terrain backdrop and the RPG2000
+  Game Over graphic.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -390,10 +390,15 @@ The work below is roughly ordered by the critical path to a walkable game
   attacks can also **miss**: `Battle#to_hit` takes the attacker's base hit rate
   (weapon / unarmed 90, a "miss"-flagged enemy 70) and applies EasyRPG's
   agility-ratio adjustment (`100 - (100 - base)*(srcAgi + tgtAgi)/(2*srcAgi)`),
-  so a nimble target dodges more; a missed swing deals no damage. Still to come:
-  enemy-cast infliction, all-target skill/item scopes, per-attribute rate
-  overrides from the Attribute table, the per-terrain backdrop and the RPG2000
-  Game Over graphic.
+  so a nimble target dodges more; a missed swing deals no damage. A skill's
+  **status infliction** is scaled by the target's `state_ranks` susceptibility
+  (RPG2000's A..E table 100/80/60/30/0 percent), so a resistant foe shrugs it
+  off and an immune one never catches it. A **pre-emptive first strike** (the
+  Enemy Encounter's first-strike flag) gives the party a free opening round —
+  the ambushed enemies skip their turn in round 1 and rejoin from round 2. Still
+  to come: enemy-cast infliction, all-target skill/item scopes, per-attribute
+  rate overrides from the Attribute table, the per-terrain backdrop and the
+  RPG2000 Game Over graphic.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1209,6 +1209,24 @@ module Game
       ids.uniq
     end
 
+    # The actor's basic-attack base hit rate (percent): the highest `hit` among
+    # the equipped weapons (item field 17), or the RPG2000 unarmed default of 90
+    # when nothing is equipped or the row omits it. Feeds the battle's to-hit
+    # roll (EasyRPG's Game_Actor::GetHitChance).
+    def attack_hit_rate
+      best = nil
+      if @db.respond_to?(:item)
+        @equipment.each do |iid|
+          next if iid.nil? || iid == 0
+          it = @db.item[iid]
+          next unless it && it.respond_to?(:type) && it.type == 1 # weapon slot
+          h = it.respond_to?(:hit) ? it.hit : nil
+          best = h if h && (best.nil? || h > best)
+        end
+      end
+      best && best > 0 ? best : 90
+    end
+
     # Coerce an equipment spec (an EQUIP_ORDER hash, an array of ids, or nil) to a
     # five-slot array of integer item ids.
     def normalize_equipment(spec)
@@ -2952,10 +2970,17 @@ module Game
       @attribute_ranks = {}
       arr = row && row.respond_to?(:attribute_ranks) ? row.attribute_ranks : nil
       arr.each_with_index { |v, i| @attribute_ranks[i + 1] = v } if arr
+      # The "miss" flag (field 26): a flagged enemy is clumsier and attacks at a
+      # 70% base hit rate rather than the usual 90% (EasyRPG's GetHitChance).
+      @miss = row && row.respond_to?(:miss) ? (row.miss ? true : false) : false
     end
 
     attr_reader :crit_denom, :attribute_ranks
     def crit_denominator; @crit_denom; end
+
+    # Base to-hit percentage for this enemy's normal attack (70 when the "miss"
+    # flag is set, otherwise 90); fed into the battle's to-hit roll.
+    def attack_hit_rate; @miss ? 70 : 90; end
 
     def dead?; @hp <= 0; end
   end
@@ -3021,7 +3046,8 @@ module Game
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
                            :actor, :states, :state_turns, :crit_denom,
-                           :prevents_crit, :attr_ranks, :atk_attrs, :skip) do
+                           :prevents_crit, :attr_ranks, :atk_attrs, :skip,
+                           :hit_rate) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
@@ -3051,11 +3077,15 @@ module Game
     # weapon's attribute_set); [] for an enemy or an unarmed / fixture attacker.
     def self.atk_attrs_of(b); b.respond_to?(:weapon_attributes) ? b.weapon_attributes : []; end
 
+    # A battler's basic-attack base hit rate (percent), or 90 (the RPG2000
+    # default) when the source (a bare fixture) doesn't model one.
+    def self.hit_rate_of(b); b.respond_to?(:attack_hit_rate) ? b.attack_hit_rate : 90; end
+
     def self.from_actor(a)
       Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
                     nil, crit_denom_of(a), prevents_crit_of(a),
-                    attr_ranks_of(a), atk_attrs_of(a))
+                    attr_ranks_of(a), atk_attrs_of(a), nil, hit_rate_of(a))
     end
 
     # Enemies have no source actor (that field stays nil), so the post-battle
@@ -3064,7 +3094,7 @@ module Game
       Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
                     nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
                     crit_denom_of(e), prevents_crit_of(e),
-                    attr_ranks_of(e), atk_attrs_of(e))
+                    attr_ranks_of(e), atk_attrs_of(e), nil, hit_rate_of(e))
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -3086,16 +3116,18 @@ module Game
     # `variance`, when true, applies RPG2000's +/- spread to each basic attack's
     # damage (a `var` of 4, per EasyRPG's Algo::VarianceAdjustEffect). `criticals`,
     # when true, lets a basic attack land a 3x critical at the attacker's 1-in-N
-    # `crit_denom` chance. Both off by default so a seeded fight is exactly
-    # reproducible; the live game turns them on.
+    # `crit_denom` chance. `accuracy`, when true, rolls each basic attack's
+    # to-hit chance so it can miss (see #to_hit). All three are off by default so
+    # a seeded fight is exactly reproducible; the live game turns them on.
     def initialize(allies, enemies, rng = nil, states = nil, variance = false,
-                   criticals = false)
+                   criticals = false, accuracy = false)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
       @states = states
       @variance = variance
       @criticals = criticals
+      @accuracy = accuracy
       @rounds = 0
       @result = nil
       @escaped = false     # set once the party successfully flees (#attempt_escape)
@@ -3215,6 +3247,20 @@ module Game
         @escape_chance = escape_chance + 10
         false
       end
+    end
+
+    # `attacker`'s to-hit percentage against `target` for a basic attack: the
+    # attacker's base hit rate (weapon / unarmed 90, a "miss" enemy 70), adjusted
+    # by the agility ratio — EasyRPG's CalcToHitAgiAdjustment, which simplifies to
+    # `100 - (100 - base) * (srcAgi + tgtAgi) / (2 * srcAgi)` — so a nimbler
+    # target dodges more. Clamped to 0..100. Only consulted when the fight has
+    # accuracy enabled (see #initialize).
+    def to_hit(attacker, target)
+      base = attacker.hit_rate || 90
+      src = attacker.agi
+      src = 1 if src < 1
+      tgt = target.agi
+      Game.clamp(100 - (100 - base) * (src + tgt) / (2 * src), 0, 100)
     end
 
     # Queue a single-target Skill for `ally`: cast on `target` (an enemy for an
@@ -3380,6 +3426,13 @@ module Game
     # the weapon's element (0% rate) takes no damage. The crit note rides on the
     # log entry.
     def deal_attack(b, target)
+      # When accuracy is on, roll the attacker's to-hit chance: a miss deals no
+      # damage and reads as `missed` on the log entry.
+      if @accuracy && !hits?(b, target)
+        return { attacker: b.name, target: target.name, damage: 0, missed: true,
+                 critical: false, target_hp: target.hp < 0 ? 0 : target.hp,
+                 defeated: false }
+      end
       dmg = Battle.attack_damage(b.atk, target.def)
       # An elemental weapon scales its damage by the target's resistance before
       # variance / criticals (EasyRPG's ApplyAttributeNormalAttackMultiplier).
@@ -3401,6 +3454,12 @@ module Game
       return false unless @criticals
       denom = b.crit_denom
       denom && denom > 0 && @rng.random(denom) == 0
+    end
+
+    # Whether `attacker`'s basic attack lands on `target`: a 0..99 roll under the
+    # #to_hit chance.
+    def hits?(attacker, target)
+      @rng.random(100) < to_hit(attacker, target)
     end
 
     # Spread `base` by a `var` (0-10) amount: an adjustment of `var*base/10` (min

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1191,6 +1191,18 @@ module Game
       ranks
     end
 
+    # The actor's per-state susceptibility ranks as `{ state_id => rank }`, read
+    # from the database row's `state_ranks` byte array (rank 0 = A, most
+    # susceptible .. 4 = E, immune). Scales how often a status effect lands on
+    # this actor. A fixture row without the field yields {}.
+    def state_ranks
+      ranks = {}
+      arr = @db_row.respond_to?(:state_ranks) ? @db_row.state_ranks : nil
+      return ranks unless arr
+      arr.each_with_index { |v, i| ranks[i + 1] = v }
+      ranks
+    end
+
     # The elemental attribute ids carried by the equipped weapon(s) — the item's
     # `attribute_set` bool array (field 66), a flag per attribute — used to scale
     # a basic attack's damage by the target's resistance. No item table (a
@@ -2970,12 +2982,17 @@ module Game
       @attribute_ranks = {}
       arr = row && row.respond_to?(:attribute_ranks) ? row.attribute_ranks : nil
       arr.each_with_index { |v, i| @attribute_ranks[i + 1] = v } if arr
+      # Per-state susceptibility ranks ({ state_id => rank 0..4 }) from the
+      # enemy's state_ranks byte array, scaling how often a status lands on it.
+      @state_ranks = {}
+      sr = row && row.respond_to?(:state_ranks) ? row.state_ranks : nil
+      sr.each_with_index { |v, i| @state_ranks[i + 1] = v } if sr
       # The "miss" flag (field 26): a flagged enemy is clumsier and attacks at a
       # 70% base hit rate rather than the usual 90% (EasyRPG's GetHitChance).
       @miss = row && row.respond_to?(:miss) ? (row.miss ? true : false) : false
     end
 
-    attr_reader :crit_denom, :attribute_ranks
+    attr_reader :crit_denom, :attribute_ranks, :state_ranks
     def crit_denominator; @crit_denom; end
 
     # Base to-hit percentage for this enemy's normal attack (70 when the "miss"
@@ -3047,7 +3064,7 @@ module Game
                            :action, :defending, :mp, :max_mp, :spi, :command,
                            :actor, :states, :state_turns, :crit_denom,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
-                           :hit_rate) do
+                           :hit_rate, :state_ranks) do
       def dead?; hp <= 0; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
@@ -3081,11 +3098,16 @@ module Game
     # default) when the source (a bare fixture) doesn't model one.
     def self.hit_rate_of(b); b.respond_to?(:attack_hit_rate) ? b.attack_hit_rate : 90; end
 
+    # A battler's per-state susceptibility ranks ({ state_id => rank 0..4 }), or
+    # {} when the source (a bare fixture) doesn't model them.
+    def self.state_ranks_of(b); b.respond_to?(:state_ranks) ? b.state_ranks : {}; end
+
     def self.from_actor(a)
       Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
                     nil, crit_denom_of(a), prevents_crit_of(a),
-                    attr_ranks_of(a), atk_attrs_of(a), nil, hit_rate_of(a))
+                    attr_ranks_of(a), atk_attrs_of(a), nil, hit_rate_of(a),
+                    state_ranks_of(a))
     end
 
     # Enemies have no source actor (that field stays nil), so the post-battle
@@ -3094,7 +3116,8 @@ module Game
       Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
                     nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
                     crit_denom_of(e), prevents_crit_of(e),
-                    attr_ranks_of(e), atk_attrs_of(e), nil, hit_rate_of(e))
+                    attr_ranks_of(e), atk_attrs_of(e), nil, hit_rate_of(e),
+                    state_ranks_of(e))
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -3576,15 +3599,35 @@ module Game
       end
     end
 
+    # RPG2000's default state rate table: a susceptibility rank of A..E (index
+    # 0..4) scales an infliction chance to 100 / 80 / 60 / 30 / 0 percent.
+    # (Per-state overrides from the database's State table aren't modelled yet.)
+    STATE_RATE_PCT = [100, 80, 60, 30, 0].freeze
+
+    # The percentage a target's susceptibility scales an infliction of `sid`: its
+    # rank in the target's `state_ranks` (default C / 60% for a listed-but-absent
+    # state, EasyRPG's GetStateProbability). 100 (unscaled) when the target (a
+    # bare fixture) models no ranks, so a plain sim keeps landing every status.
+    def state_susceptibility(target, sid)
+      ranks = target.state_ranks
+      return 100 if ranks.nil? || ranks.empty?
+      rank = ranks[sid] || 2
+      rank = 0 if rank < 0
+      rank = 4 if rank > 4
+      STATE_RATE_PCT[rank]
+    end
+
     # Inflict a skill command's `inflict` states on `target`, each landing only if
-    # a 0..99 roll comes in under the skill's `chance` (its accuracy). Skips a
-    # state the target already carries. Returns the states actually inflicted.
+    # a 0..99 roll comes in under the skill's `chance` (its accuracy) scaled by
+    # the target's per-state susceptibility. Skips a state the target already
+    # carries. Returns the states actually inflicted.
     def roll_inflict(target, cmd)
       chance = cmd[:chance] || 100
       inflicted = []
       (cmd[:inflict] || []).each do |sid|
         next if target.state?(sid)
-        next unless @rng.random(100) < chance
+        prob = chance * state_susceptibility(target, sid) / 100
+        next unless @rng.random(100) < prob
         target.states = (target.states || []) + [sid]
         inflicted << sid
       end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3142,8 +3142,10 @@ module Game
     # `crit_denom` chance. `accuracy`, when true, rolls each basic attack's
     # to-hit chance so it can miss (see #to_hit). All three are off by default so
     # a seeded fight is exactly reproducible; the live game turns them on.
+    # `first_strike`, when true, gives the party a pre-emptive opening round: the
+    # enemies are caught off guard and skip their turn in round 1 only.
     def initialize(allies, enemies, rng = nil, states = nil, variance = false,
-                   criticals = false, accuracy = false)
+                   criticals = false, accuracy = false, first_strike = false)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
@@ -3151,6 +3153,7 @@ module Game
       @variance = variance
       @criticals = criticals
       @accuracy = accuracy
+      @first_strike = first_strike
       @rounds = 0
       @result = nil
       @escaped = false     # set once the party successfully flees (#attempt_escape)
@@ -3414,7 +3417,11 @@ module Game
 
     def refill_queue
       @rounds += 1
-      @queue = turn_order unless @rounds > MAX_ROUNDS
+      return if @rounds > MAX_ROUNDS
+      @queue = turn_order
+      # A pre-emptive first strike catches the enemies off guard: they skip the
+      # opening round, so only the party acts in round 1.
+      @queue = @queue.reject { |b| side_of(b) == :enemy } if @first_strike && @rounds == 1
     end
 
     # Battlers ordered by agility (highest first); ties keep their listed order.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2350,7 +2350,8 @@ class RPG2k
         situations = db.respond_to?(:situation) ? db.situation : nil
         @battle_ui = { phase: :command, req: req, troop: troop,
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
-                                                situations, true, true, true),
+                                                situations, true, true, true,
+                                                req[:first_strike] ? true : false),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2350,7 +2350,7 @@ class RPG2k
         situations = db.respond_to?(:situation) ? db.situation : nil
         @battle_ui = { phase: :command, req: req, troop: troop,
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
-                                                situations, true, true),
+                                                situations, true, true, true),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],
@@ -2809,6 +2809,8 @@ class RPG2k
           parts << "#{e[:recover_mp]} MP" if e[:recover_mp] && e[:recover_mp] > 0
           body = parts.empty? ? 'no effect' : "+#{parts.join(' / ')}"
           "#{e[:actor]}'s #{e[:source]}: #{e[:target]} #{body}"
+        elsif e[:missed]
+          "#{e[:attacker]} misses #{e[:target]}"
         else
           hits = e[:skill] ? "'s #{e[:skill]} hits" : ' hits'
           line = "#{e[:attacker]}#{hits} #{e[:target]} for #{e[:damage]}"

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4188,6 +4188,64 @@ check 'command_skip forfeits an ally turn while the enemies still act' do
   ok hero.hp < 100, 'but the slime still struck back'
 end
 
+# -- Battle hit / miss (accuracy) ---------------------------------------------
+
+check 'Battle#to_hit uses the base hit rate adjusted by the agility ratio' do
+  b = Game::Battle.new([combatant('H', 0, 0, 10, 10)],
+                       [combatant('E', 0, 0, 10, 10)], Game::Rng.new(1))
+  atk = b.allies.first
+  tgt = b.enemies.first
+  atk.hit_rate = 90
+  eq 90, b.to_hit(atk, tgt), 'equal agility -> the base hit rate'
+  tgt.agi = 30                                       # a 3x faster target dodges more
+  eq 80, b.to_hit(atk, tgt), '100 - 10*(10+30)/(2*10) = 80'
+  tgt.agi = 0                                        # a motionless target
+  eq 95, b.to_hit(atk, tgt), '100 - 10*(10+0)/(2*10) = 95'
+end
+
+check 'Battle#to_hit clamps to 0..100 and a 100% base never misses' do
+  b = Game::Battle.new([combatant('H', 0, 0, 10, 10)],
+                       [combatant('E', 0, 0, 999, 10)], Game::Rng.new(1))
+  atk = b.allies.first
+  atk.hit_rate = 100
+  eq 100, b.to_hit(atk, b.enemies.first), 'a perfect base stays 100 despite fast target'
+end
+
+check 'with accuracy off a basic attack always connects' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.hit_rate = 1                                  # would nearly always miss...
+  slime = combatant('Slime', 0, 0, 20, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1)) # accuracy off (default)
+  b.begin_round
+  e = b.step_action
+  eq 20, e[:damage], '...but accuracy is off, so it lands for full damage'
+  ok !e[:missed]
+end
+
+check 'with accuracy on a sure-miss attack deals no damage' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.hit_rate = 0                                  # 0% base, equal agility -> 0% hit
+  slime = combatant('Slime', 0, 0, 20, 100)
+  # 7-arg: variance off, criticals off, accuracy on.
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, false, true)
+  b.begin_round
+  e = b.step_action
+  eq 0, e[:damage]
+  ok e[:missed], 'flagged as a miss'
+  eq 100, slime.hp, 'no HP lost'
+end
+
+check 'with accuracy on the to-hit roll both lands and misses over many swings' do
+  hero = combatant('Hero', 40, 0, 10, 1_000_000)
+  hero.hit_rate = 50                                 # equal agility -> 50% to hit
+  slime = combatant('Slime', 0, 0, 10, 1_000_000)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, false, true)
+  40.times { b.run_round }
+  swings = b.log.select { |e| e[:attacker] == 'Hero' }
+  ok swings.any? { |e| e[:missed] }, 'a 50% attacker whiffs sometimes'
+  ok swings.any? { |e| !e[:missed] }, 'and connects sometimes'
+end
+
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
                              mrate: 40, variance: 4) }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4246,6 +4246,37 @@ check 'with accuracy on the to-hit roll both lands and misses over many swings' 
   ok swings.any? { |e| !e[:missed] }, 'and connects sometimes'
 end
 
+# -- Battle first strike (pre-emptive) ----------------------------------------
+
+check 'battle first strike: the party acts while the enemies skip round 1' do
+  hero = combatant('Hero', 40, 0, 5, 100)            # slower than the slime...
+  slime = combatant('Slime', 40, 0, 50, 100)         # ...which would normally go first
+  # 8-arg: variance / criticals / accuracy off, first_strike on.
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, false, false, true)
+  entries = b.run_round
+  eq 1, entries.length, 'only the party acts in the opening round'
+  eq 'Hero', entries.first[:attacker], 'the hero strikes first despite lower agility'
+  eq 100, hero.hp, 'the ambushed slime never swung'
+  eq 80, slime.hp, 'but the hero connected'
+end
+
+check 'battle first strike: the enemies rejoin from the second round' do
+  hero = combatant('Hero', 8, 0, 5, 100)
+  slime = combatant('Slime', 40, 0, 50, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, false, false, true)
+  b.run_round                                        # round 1: only the hero
+  eq 100, hero.hp, 'no enemy action in the pre-emptive round'
+  b.run_round                                        # round 2: the slime strikes back
+  ok hero.hp < 100, 'the enemy acts normally from round 2'
+end
+
+check 'battle without first strike: both sides act in the opening round' do
+  hero = combatant('Hero', 8, 0, 5, 100)
+  slime = combatant('Slime', 8, 0, 50, 100)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1)) # no first strike
+  eq 2, b.run_round.length, 'both battlers act in round 1'
+end
+
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
                              mrate: 40, variance: 4) }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4529,6 +4529,53 @@ check 'a skill-inflicted "do nothing" state then skips the enemy turn' do
   eq hp_before, hero.hp, 'the sleeping foe did not attack'
 end
 
+# -- Battle state susceptibility (state_ranks) --------------------------------
+
+def poison_cast(foe, seed = 1)
+  mage = combatant_mp('Mage', 10, 0, 20, 100, 30)    # faster -> acts first
+  b = Game::Battle.new([mage], [foe], Game::Rng.new(seed))
+  b.command_skill(mage, foe, name: 'Poison', cost: 0, hp: -1, inflict: [3], chance: 100)
+  b.begin_round
+  b.step_action
+end
+
+check 'battle: an immune target (state rank E) never catches the status' do
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.state_ranks = { 3 => 4 }                       # rank E -> 0% susceptibility
+  e = poison_cast(foe)
+  eq [], e[:inflicted], 'immunity blocks a sure-fire status'
+  ok !foe.state?(3)
+end
+
+check 'battle: a susceptible target (state rank A) catches a sure status' do
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.state_ranks = { 3 => 0 }                       # rank A -> 100%
+  e = poison_cast(foe)
+  eq [3], e[:inflicted]
+  ok foe.state?(3)
+end
+
+check 'battle: infliction is unscaled when the target models no state ranks' do
+  foe = combatant('Foe', 0, 0, 5, 100)               # state_ranks nil (a bare fixture)
+  e = poison_cast(foe)
+  eq [3], e[:inflicted], 'a fixture still catches a 100% status'
+end
+
+check 'battle: a mid susceptibility (rank C 60%) both lands and resists' do
+  rng = Game::Rng.new(1)                             # one RNG across many casts
+  results = Array.new(40) do
+    foe = combatant('Foe', 0, 0, 5, 100)
+    foe.state_ranks = { 3 => 2 }                     # rank C -> 60%
+    mage = combatant_mp('Mage', 10, 0, 20, 100, 30)
+    b = Game::Battle.new([mage], [foe], rng)
+    b.command_skill(mage, foe, name: 'Poison', cost: 0, hp: -1, inflict: [3], chance: 100)
+    b.begin_round
+    b.step_action[:inflicted]
+  end
+  ok results.any? { |r| r == [3] }, 'a 60% status sometimes lands'
+  ok results.any?(&:empty?), 'and sometimes is resisted'
+end
+
 check 'Battle command_skill resolves an attack skill: damage lands, SP is spent' do
   mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
   foe  = combatant('Foe', 0, 0, 5, 100)


### PR DESCRIPTION
Three related RPG Maker 2000 battle refinements, each independently tested and documented.

## 1. Hit / miss (evasion) on basic attacks

- `Game::Battle#to_hit(attacker, target)` — the attacker's base hit rate adjusted by the attacker/target agility ratio, matching EasyRPG's `CalcNormalAttackToHit` + `CalcToHitAgiAdjustment` (`100 − (100 − base)·(srcAgi + tgtAgi)/(2·srcAgi)`, clamped 0..100).
- Base rate: `Game::Actor#attack_hit_rate` (equipped-weapon `hit`, unarmed 90); `Game::Enemy#attack_hit_rate` (90, or 70 with the "miss" flag). Snapshotted onto the `Combatant`.
- `deal_attack` rolls it under a new opt-in **accuracy** flag; a miss deals no damage and tags the entry `missed: true` ("X misses Y" banner). Off by default so seeded tests stay reproducible; the live game enables it.

## 2. Status infliction scaled by the target's state susceptibility

- `Game::Actor#state_ranks` / `Game::Enemy#state_ranks` read the database `state_ranks` byte array; snapshotted onto the `Combatant`.
- `roll_inflict` scales a skill's infliction chance by the target's per-state rank rate — RPG2000's default A..E table 100/80/60/30/0 percent (C for a listed-but-absent state), per EasyRPG's `GetStateProbability` — so a resistant foe shrugs off a status and an immune one (rank E) never catches it.
- Non-invasive: a target modeling no ranks keeps landing every status at full chance.

## 3. Pre-emptive first strike

- The Enemy Encounter command's first-strike flag was decoded but ignored. `Game::Battle` now takes a `first_strike` option and `refill_queue` drops the enemies from round 1's turn order, so the party gets a free opening round and the ambushed foes rejoin from round 2. Wired into the live battle from the encounter request.

## Testing

- `scripts/rpg2k_logic_check.rb` — 354 checks pass, including 12 new ones across the three features.
- Scene (105) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj