### PR TITLE
Fix GitHub Actions permissions for PR comment reactions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -431,10 +431,13 @@ jobs:
     # shape that label is meant for, and it bills at a lower rate.
     runs-on: ubuntu-slim
     permissions:
-      # Read the PR to find its head commit; write reactions on the comment
-      # (a PR conversation comment is an issue comment, hence `issues`).
-      pull-requests: read
-      issues: write
+      # Read the PR to find its head commit, and write the 👀 reaction on the
+      # comment. The reaction goes through `/issues/comments/{id}/reactions`,
+      # but this job only ever runs on a pull request's conversation comment
+      # (see the `if` above), and GitHub authorises those against the pull
+      # request the comment belongs to — `issues: write` is not enough, the
+      # POST 403s without `pull-requests: write`.
+      pull-requests: write
     outputs:
       head-sha: ${{ steps.pr.outputs.head-sha }}
     env:
@@ -449,6 +452,10 @@ jobs:
             --jq '"head-sha=\(.head.sha)"' >> "$GITHUB_OUTPUT"
 
       - name: Acknowledge the command
+        # The reaction is only a visible "the run started" hint, and this job is
+        # what gates the preview build and deploy. Don't let a failed ack cost
+        # someone their preview.
+        continue-on-error: true
         run: |
           gh api --silent -X POST \
             "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID/reactions" \


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to use the correct permissions for adding reactions to pull request comments, and made the reaction step resilient to failures.

## Key Changes
- Changed `issues: write` to `pull-requests: write` in the job permissions, as GitHub requires `pull-requests: write` to add reactions to comments on pull requests (the `/issues/comments/{id}/reactions` endpoint is authorized against the PR context, not the issues context)
- Added `continue-on-error: true` to the "Acknowledge the command" step to prevent failed reaction attempts from blocking the preview build and deploy
- Improved permission comments to clarify the authorization requirements and explain why `pull-requests: write` is necessary

## Implementation Details
The workflow was attempting to add a 👀 reaction to a PR comment to indicate that a command run has started. While the endpoint path uses `/issues/comments/`, GitHub's authorization for pull request comments requires `pull-requests: write` permission rather than `issues: write`. The `continue-on-error` flag ensures that transient failures or permission issues with the reaction don't prevent the actual preview build and deployment from proceeding.

https://claude.ai/code/session_01HsNS9H39keBpff8FZEkHxs