### PR TITLE
Run RPG2000 troop battle-event pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,16 @@
   decaying colour), Enter/Exit Vehicle, Open Save Menu / Open Main Menu, Fade Out
   BGM, Return to Title and Erase
   Event (remove an event from
-  the map) — **every RPG2000 map / common-event command now has a handler**;
-  only the battle-page commands (13110–13410) are still to come. Events start on the action button, on
+  the map) — **every RPG2000 event command now has a handler**. Events start on the action button, on
   player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too
+- A troop's **battle-event pages** run during a fight: their conditions (switch,
+  variable, turn, enemy/actor HP) are re-checked each turn, and a matching page
+  runs the ordinary command set plus the battle-only commands — Change Monster
+  HP / MP / Condition, Show Hidden Monster, Change Battle Background, the battle
+  Show Battle Animation, the battle Conditional Branch and Terminate Battle
 - Message text reveals gradually (a typewriter effect; a button press completes
   it, then dismisses), expands the common control codes (`\v[n]` variable,
   `\n[n]` actor name, `\\`) and draws `\c[n]` colour changes

--- a/changelog.d/rpg2k-battle-event-pages.added.md
+++ b/changelog.d/rpg2k-battle-event-pages.added.md
@@ -1,0 +1,25 @@
+- RPG Maker 2000: **battle-event pages now run**, completing the RPG2000 event
+  command set. A troop's pages (`enemy_group` chunk 11, already decoded by the
+  LCF schema but until now unused) are evaluated by the new `Game::BattlePage`
+  at the start of every turn — its `flags` bitfield follows liblcf's
+  `TroopPageCondition::Flags` declaration order packed LSB-first, the same
+  convention `Game::EventPage` uses for map pages — and every page whose
+  condition holds runs, unlike a map event where only the highest page wins.
+  Switch, variable, turn (RPG2000's base/multiple turn arithmetic), enemy-HP and
+  actor-HP conditions are tested; a condition the runtime cannot answer (party
+  fatigue, the per-battler turn counters, the chosen-command test) fails its page
+  rather than letting it fire unchecked. Pages run through a `Game::Interpreter`
+  carrying a new `battle` context, so they have the whole ordinary command set
+  plus the battle-only commands: **Change Monster HP** (13110, with the constant
+  / variable / percent operands and the non-lethal floor), **Change Monster MP**
+  (13120), **Change Monster Condition** (13130), **Show Hidden Monster** (13150,
+  which builds the sprite the troop skipped), **Change Battle Background**
+  (13210, which now loads a real `Backdrop/<name>` image), the battle **Show
+  Battle Animation** (13260), **Conditional Branch** (13310 with its `_B`
+  else/end markers — switch, variable, actor-present / actor-status and
+  monster-present / monster-status tests) and **Terminate Battle** (13410, which
+  leaves the fight with no victory or defeat processing). A page's messages are
+  shown in a battle text panel and dismissed with a button. The battle-only
+  commands are no-ops in a map or common event, where RPG_RT cannot place them.
+  Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -398,11 +398,20 @@ The work below is roughly ordered by the critical path to a walkable game
   tests (the decision key started this event; the BGM has played through once).
   Three opcodes that never matched liblcf's `Code` enum were corrected in the
   same pass — Change Equipment is 10450 (10440 is Change Skills) and Game Over is
-  12420 — so those commands are recognised in real game data at all. Still TODO
-  here: **battle-page event commands** (13110–13410 and the `_B` conditional
-  markers), which need a battle-event interpreter the battle scene does not have
-  yet, and video playback for Play Movie (no decoder is linked in; the request is
-  logged). **Show Battle Animation** (11210) now plays on the map — the
+  12420 — so those commands are recognised in real game data at all.
+  **Battle-event pages now run too**: a troop's pages (`enemy_group` chunk 11)
+  are evaluated by `Game::BattlePage` at the start of every turn — switch,
+  variable, turn, enemy-HP and actor-HP conditions — and each matching page runs
+  through a `Game::Interpreter` carrying a `battle` context, so a page has the
+  whole ordinary command set plus **Change Monster HP / MP / Condition**
+  (13110 / 13120 / 13130), **Show Hidden Monster** (13150), **Change Battle
+  Background** (13210), the battle **Show Battle Animation** (13260),
+  **Conditional Branch** (13310 with its `_B` markers) and **Terminate Battle**
+  (13410). Messages from a page are shown in a battle panel. Still TODO here:
+  the per-battler turn counters and the party-fatigue / chosen-command
+  conditions (pages gated on those deliberately do not fire rather than firing
+  unchecked), and video playback for Play Movie (no decoder is linked in; the
+  request is logged). **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the
   target frame by frame and fires its screen flashes, holding the event with the
   wait flag (per-cell zoom / tone and target-only flashes are approximations for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2445,6 +2445,98 @@ module Game
     end
   end
 
+  # Evaluation of RPG2000 *battle*-event page conditions (troop chunk 11). A
+  # page fires when every sub-condition its `flags` bitfield enables holds.
+  #
+  # The bit values follow liblcf's `TroopPageCondition::Flags` declaration
+  # order (switch_a, switch_b, variable, turn, fatigue, enemy_hp, actor_hp,
+  # turn_enemy, turn_actor, command_actor) packed LSB-first — the same
+  # convention Game::EventPage above uses for map pages, which is validated
+  # against real games. Only the sub-conditions the battle context can answer
+  # are tested; one it cannot answer (see `ctx`) is treated as unmet rather
+  # than silently passing, so a page never fires on a condition we did not
+  # actually check.
+  module BattlePage
+    SWITCH_A      = 0x001
+    SWITCH_B      = 0x002
+    VARIABLE      = 0x004
+    TURN          = 0x008
+    FATIGUE       = 0x010
+    ENEMY_HP      = 0x020
+    ACTOR_HP      = 0x040
+    TURN_ENEMY    = 0x080
+    TURN_ACTOR    = 0x100
+    COMMAND_ACTOR = 0x200
+
+    # RPG2000's turn matcher (EasyRPG's `Game_Battle::CheckTurns`): with no
+    # `multiple` the turn must equal `base` exactly; otherwise it must be at or
+    # past `base` and an exact number of `multiple` steps beyond it. So
+    # base 0 / multiple 2 fires on turns 0, 2, 4, ...
+    def self.check_turns(turn, base, multiple)
+      return turn == base if multiple.nil? || multiple == 0
+      turn >= base && (turn - base) % multiple == 0
+    end
+
+    # Whether a battler's HP sits within a percentage window of its maximum
+    # (the enemy-HP / actor-HP conditions are expressed in percent).
+    def self.hp_within?(battler, min, max)
+      return false if battler.nil? || battler.max_hp.nil? || battler.max_hp <= 0
+      pct = battler.hp * 100 / battler.max_hp
+      pct >= min && pct <= max
+    end
+
+    # `ctx` is the battle context the interpreter also runs against; it answers
+    # `turn`, `enemy(index)`, `ally_by_actor_id(id)`, `enemy_turn(index)`,
+    # `actor_turn(id)` and `actor_command(id)`. A context that cannot answer a
+    # tested sub-condition fails the page.
+    def self.active?(cond, switches, variables, ctx)
+      return true if cond.nil?
+      flags = cond.flags || 0
+      return false if (flags & SWITCH_A) != 0 && !switches[cond.switch_a_id]
+      return false if (flags & SWITCH_B) != 0 && !switches[cond.switch_b_id]
+      if (flags & VARIABLE) != 0
+        return false if variables[cond.variable_id] < cond.variable_value
+      end
+      return false if (flags & TURN) != 0 &&
+                      !check_turns(ctx.turn, cond.turn_b, cond.turn_a)
+      if (flags & ENEMY_HP) != 0
+        return false unless hp_within?(ctx.enemy(cond.enemy_id),
+                                       cond.enemy_hp_min, cond.enemy_hp_max)
+      end
+      if (flags & ACTOR_HP) != 0
+        return false unless hp_within?(ctx.ally_by_actor_id(cond.actor_id),
+                                       cond.actor_hp_min, cond.actor_hp_max)
+      end
+      if (flags & TURN_ENEMY) != 0
+        t = ctx.enemy_turn(cond.turn_enemy_id)
+        return false if t.nil?
+        return false unless check_turns(t, cond.turn_enemy_b, cond.turn_enemy_a)
+      end
+      if (flags & TURN_ACTOR) != 0
+        t = ctx.actor_turn(cond.turn_actor_id)
+        return false if t.nil?
+        return false unless check_turns(t, cond.turn_actor_b, cond.turn_actor_a)
+      end
+      if (flags & COMMAND_ACTOR) != 0
+        return false unless ctx.actor_command(cond.command_actor_id) == cond.command_id
+      end
+      # The party-fatigue condition is an RPG2003 mechanic the runtime does not
+      # model; a page gated on it never fires rather than firing unchecked.
+      return false if (flags & FATIGUE) != 0
+      true
+    end
+
+    # Every [id, page] whose condition currently holds, in page order — unlike
+    # a map event (where the highest active page wins) RPG2000 runs *each*
+    # matching battle page.
+    def self.select_all(pages, switches, variables, ctx)
+      out = []
+      return out if pages.nil?
+      pages.each { |id, page| out << [id, page] if active?(page.condition, switches, variables, ctx) }
+      out
+    end
+  end
+
   # Common events: shared command lists that can auto-start or run in parallel.
   # start_term selects how they run (3 auto-start, 4 parallel, 5 called only);
   # when need_flag is set a common event is gated on switch_id.
@@ -2911,8 +3003,11 @@ module Game
   # not built yet, so for now this backs the Enemy Encounter reward model.
   class Enemy
     attr_reader :id, :name, :battler_name, :max_hp, :max_sp, :atk, :def, :spi,
-                :agi, :exp, :gold, :x, :y, :hidden, :drop_id, :drop_prob
+                :agi, :exp, :gold, :x, :y, :drop_id, :drop_prob
     attr_accessor :hp, :sp
+    # Whether the member starts the fight off-screen. Writable because the Show
+    # Hidden Monster battle-event command (13150) brings one in mid-fight.
+    attr_accessor :hidden
 
     def initialize(db, id, x = 0, y = 0, hidden = false)
       row = db.enemy[id]
@@ -2966,6 +3061,10 @@ module Game
   # simulation itself is still to come.
   class Troop
     attr_reader :id, :name, :members
+    # The troop's battle-event pages (chunk 11), each entry carrying a
+    # `condition` (see Game::BattlePage) and an `event` command list the battle
+    # interpreter runs. nil / empty for a troop that scripts nothing.
+    attr_reader :pages
 
     def initialize(db, id)
       row = db.enemy_group[id]
@@ -2974,6 +3073,7 @@ module Game
       @members = []
       # Array2D#each yields (id, entry); a plain Hash test double does the same.
       row.members.each { |_, m| @members << member(db, m) } if row && row.members
+      @pages = row && row.respond_to?(:pages) ? row.pages : nil
     end
 
     def total_exp;  @members.reduce(0) { |s, e| s + e.exp } end
@@ -3120,6 +3220,44 @@ module Game
 
     # Whether the party successfully escaped this fight.
     def escaped?; @escaped; end
+
+    # -- battle-event context -------------------------------------------------
+    #
+    # The protocol the troop's battle-event pages run against: Game::BattlePage
+    # tests their conditions through it and Game::Interpreter's battle commands
+    # (Change Monster HP / MP / Condition, the battle Conditional Branch, ...)
+    # act on it. Enemies are addressed by their 0-based index within the troop,
+    # the way the editor numbers them.
+
+    # Turns elapsed, counted from 0 before the first round has run — RPG2000's
+    # battle turn number, which the pages' turn conditions are written against.
+    def turn; @rounds; end
+
+    # The live combatant for troop member `index`, or nil when out of range.
+    def enemy(index)
+      return nil unless index.is_a?(Integer) && index >= 0
+      @enemies[index]
+    end
+
+    # The live combatant for the party member whose database actor id is `id`
+    # (nil when that actor is not in this fight).
+    def ally_by_actor_id(id)
+      @allies.find { |a| a.actor && a.actor.respond_to?(:id) && a.actor.id == id }
+    end
+
+    # RPG2000 also counts turns *per battler* and remembers each actor's chosen
+    # battle command; neither is modelled here, so the page conditions that read
+    # them report "unknown" (nil) and Game::BattlePage fails that page rather
+    # than firing it on an unchecked condition.
+    def enemy_turn(_index); nil; end
+    def actor_turn(_id); nil; end
+    def actor_command(_id); nil; end
+
+    # Terminate Battle (13410): abandon the fight outright. Unlike a victory or
+    # defeat this has no outcome to process, so it is kept as its own flag the
+    # scene polls rather than folded into #finished? / #result.
+    def terminate; @terminated = true; end
+    def terminated?; @terminated ? true : false; end
 
     # Persist the fight's outcome onto the real party: write each ally combatant's
     # final status set, HP and SP back to its source actor, so damage taken in

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -118,6 +118,19 @@ module Game
       CHANGE_MENU_ACCESS = 11960
       GAME_OVER        = 12420
       RETURN_TO_TITLE  = 12510
+      # Battle-only commands. These appear in a troop's battle-event pages
+      # (enemy_group chunk 11), never in a map or common event, and act on the
+      # running fight through Game::Interpreter#battle.
+      CHANGE_MONSTER_HP        = 13110
+      CHANGE_MONSTER_MP        = 13120
+      CHANGE_MONSTER_CONDITION = 13130
+      SHOW_HIDDEN_MONSTER      = 13150
+      CHANGE_BATTLE_BG         = 13210
+      SHOW_BATTLE_ANIM_B       = 13260
+      CONDITIONAL_B            = 13310
+      TERMINATE_BATTLE         = 13410
+      ELSE_BRANCH_B            = 23310
+      END_BRANCH_B             = 23311
     end
 
     # Move-command ids inside a Move Event that carry extra parameters (every
@@ -152,6 +165,8 @@ module Game
       @vehicle_toggle_requested = false
       @movie_request = nil
       @triggered_by_decision_key = false
+      @revealed_monsters = []
+      @battle_background = nil
       @input_variable = nil
       @input_digits = 1
       # Deterministic RNG for the Control Variables "random" operand (mruby has
@@ -174,6 +189,11 @@ module Game
     # (12010 type 8). Set by the owning scene when it launches a trigger-0 event;
     # false for auto-start, touch and parallel processes, and for common events.
     attr_accessor :triggered_by_decision_key
+    # The running fight a *battle*-event page acts on (see Game::Battle's
+    # "battle-event context" section). nil for map and common events, which is
+    # what makes the battle-only commands no-ops outside a battle — exactly as
+    # they are in RPG_RT, where the editor cannot even place them there.
+    attr_accessor :battle
     # Answers tile queries for Store Terrain / Event ID: responds to
     # `terrain_id(x, y)` and `event_id_at(x, y)`. Set by the owning scene; nil
     # makes those commands store 0 (the map is not queryable without it).
@@ -196,6 +216,8 @@ module Game
       @tiles_changed = false
       @vehicle_toggle_requested = false
       @movie_request = nil
+      @revealed_monsters = []
+      @battle_background = nil
       # Cleared per run so a reused interpreter (the shared foreground one, or a
       # looping parallel process) never inherits the previous event's trigger;
       # the scene sets it again right after #start for an action-key event.
@@ -328,6 +350,23 @@ module Game
       reqs = @sprite_flash_requests
       @sprite_flash_requests = []
       reqs
+    end
+
+    # Drain the Show Hidden Monster (13150) troop-member indices queued since the
+    # last call. The scene polls this and builds the sprites for the revealed
+    # members. Non-blocking.
+    def take_revealed_monsters
+      ids = @revealed_monsters
+      @revealed_monsters = []
+      ids
+    end
+
+    # Drain the Change Battle Background (13210) name queued since the last call,
+    # or nil. Non-blocking.
+    def take_battle_background
+      name = @battle_background
+      @battle_background = nil
+      name
     end
 
     # Upper bound on commands run in a single update, so a malformed loop cannot
@@ -681,6 +720,16 @@ module Game
       when Cmd::END_EVENT        then @index = @list.size
       when Cmd::LABEL            then nil # jump target only; Jump to Label finds it
       when Cmd::COMMENT, Cmd::COMMENT_2 then nil # developer annotation
+      when Cmd::CHANGE_MONSTER_HP        then do_change_monster_hp cmd
+      when Cmd::CHANGE_MONSTER_MP        then do_change_monster_mp cmd
+      when Cmd::CHANGE_MONSTER_CONDITION then do_change_monster_condition cmd
+      when Cmd::SHOW_HIDDEN_MONSTER      then do_show_hidden_monster cmd
+      when Cmd::CHANGE_BATTLE_BG         then do_change_battle_bg cmd
+      when Cmd::SHOW_BATTLE_ANIM_B       then do_show_battle_animation_b cmd
+      when Cmd::CONDITIONAL_B            then do_conditional_battle cmd
+      when Cmd::ELSE_BRANCH_B    then skip_to([Cmd::END_BRANCH_B], cmd.indent); consume
+      when Cmd::END_BRANCH_B     then nil
+      when Cmd::TERMINATE_BATTLE then do_terminate_battle cmd
       else nil # blank editor lines (codes 0 / 10) and RPG2003-only commands
       end
     end
@@ -1421,6 +1470,160 @@ module Game
         targets.each { |a| a.equip_item(item) }
       else
         targets.each { |a| a.unequip(cmd.param(4)) }
+      end
+    end
+
+    # -- battle-event commands ------------------------------------------------
+    #
+    # These only appear in a troop's battle-event pages and act on the fight the
+    # owning battle scene put in `@battle`. Without one (a stray battle command
+    # in a map event, or a headless check) every one of them is a no-op.
+
+    # The amount a Change Monster HP / MP command applies. param2 selects how
+    # param3 is read: 0 a constant, 1 the value of that variable, 2 (HP only) a
+    # percentage of the target's maximum. Mirrors EasyRPG's
+    # CommandChangeMonsterHP / CommandChangeMonsterMP.
+    def monster_change_amount(cmd, battler)
+      case cmd.param(2)
+      when 1 then variables[cmd.param(3)]
+      when 2 then cmd.param(3) * (battler.max_hp || 0) / 100
+      else cmd.param(3)
+      end
+    end
+
+    # Change Monster HP (13110): heal or hurt troop member param0. param1 is the
+    # direction (non-zero = lose HP), param2/param3 the amount (see above) and
+    # param4 whether the damage may be lethal — when it may not, the monster is
+    # left on 1 HP instead of going down.
+    def do_change_monster_hp(cmd)
+      target = @battle && @battle.enemy(cmd.param(0))
+      return unless target
+      amount = monster_change_amount(cmd, target)
+      amount = -amount if cmd.param(1) != 0
+      hp = target.hp + amount
+      floor = cmd.param(4) != 0 ? 0 : 1
+      hp = floor if hp < floor
+      hp = target.max_hp if target.max_hp && hp > target.max_hp
+      target.hp = hp
+    end
+
+    # Change Monster MP (13120): the SP counterpart. Same operand layout minus
+    # the percentage mode and the lethal flag.
+    def do_change_monster_mp(cmd)
+      target = @battle && @battle.enemy(cmd.param(0))
+      return unless target
+      amount = monster_change_amount(cmd, target)
+      amount = -amount if cmd.param(1) != 0
+      mp = (target.mp || 0) + amount
+      mp = 0 if mp < 0
+      mp = target.max_mp if target.max_mp && mp > target.max_mp
+      target.mp = mp
+    end
+
+    # Change Monster Condition (13130): inflict (param1 == 0) or cure the status
+    # param2 on troop member param0.
+    def do_change_monster_condition(cmd)
+      target = @battle && @battle.enemy(cmd.param(0))
+      return unless target
+      state_id = cmd.param(2)
+      return if state_id.nil? || state_id <= 0
+      states = target.states ||= []
+      if cmd.param(1) != 0
+        states.delete(state_id)
+      elsif !states.include?(state_id)
+        states.push(state_id)
+      end
+    end
+
+    # Show Hidden Monster (13150): bring troop member param0 — placed but held
+    # off-screen by its "invisible" flag — into the fight. Recorded as a one-shot
+    # request so the scene can build the sprite that was never made.
+    def do_show_hidden_monster(cmd)
+      return unless @battle
+      @revealed_monsters.push(cmd.param(0))
+    end
+
+    # Change Battle Background (13210): swap the backdrop to the Backdrop/<name>
+    # image the command string carries. Recorded for the scene to rebuild.
+    def do_change_battle_bg(cmd)
+      return unless @battle
+      @battle_background = (cmd.string || '').to_s
+    end
+
+    # Show Battle Animation (13260), the battle-page form of 11210. param0 is
+    # the animation, param1 the target troop member and param2 the wait flag.
+    # Raised through the same request/wait the map command uses, so the scene
+    # drives one animation player for both.
+    def do_show_battle_animation_b(cmd)
+      @battle_animation = { animation: cmd.param(0), target: cmd.param(1),
+                            wait: cmd.param(2) != 0, battle: true }
+      return unless cmd.param(2) != 0
+      @wait_kind = :animation
+      @waiting = true
+    end
+
+    # Terminate Battle (13410): end the fight immediately, with no victory or
+    # defeat processing. The rest of the page is abandoned, as in RPG_RT.
+    def do_terminate_battle(_cmd)
+      return unless @battle
+      @battle.terminate
+      @index = @list.size
+      @call_stack = []
+    end
+
+    # Conditional Branch (battle form, 13310). param0 selects the test:
+    #   0 switch param1 is on (param2 == 0) / off
+    #   1 variable param1 compared against param2/param3 by param4
+    #   2 actor param1 — sub-test param2: 0 in the party, 1 named param(?),
+    #     2 afflicted by state param3, 3 can use battle command param3
+    #   3 troop member param1 — sub-test param2: 0 present, 1 afflicted by
+    #     state param3
+    #   4 the currently-targeted troop member is param1
+    #   5 actor param1's chosen command is param2
+    # Tests 4 and 5 read live battle-UI state the runtime does not model; they
+    # report false rather than guessing, so the else branch runs.
+    def do_conditional_battle(cmd)
+      return if eval_battle_condition(cmd)
+      skip_to([Cmd::ELSE_BRANCH_B, Cmd::END_BRANCH_B], cmd.indent)
+      consume
+    end
+
+    def eval_battle_condition(cmd)
+      case cmd.param(0)
+      when 0
+        on = switches[cmd.param(1)]
+        cmd.param(2) == 0 ? on : !on
+      when 1
+        rhs = cmd.param(2) == 0 ? cmd.param(3) : variables[cmd.param(3)]
+        compare(variables[cmd.param(1)], rhs, cmd.param(4))
+      when 2 then battle_actor_condition(cmd)
+      when 3 then battle_enemy_condition(cmd)
+      else false
+      end
+    end
+
+    # An actor sub-condition: is the actor in this fight, and is it afflicted by
+    # the given status? The name / usable-command tests need data the battle
+    # context does not carry, so they report false.
+    def battle_actor_condition(cmd)
+      ally = @battle && @battle.ally_by_actor_id(cmd.param(1))
+      return false unless ally
+      case cmd.param(2)
+      when 0 then true                       # is in the party
+      when 2 then ally.state?(cmd.param(3))  # is afflicted by a status
+      else false
+      end
+    end
+
+    # A troop-member sub-condition: is the member still standing, and is it
+    # afflicted by the given status?
+    def battle_enemy_condition(cmd)
+      foe = @battle && @battle.enemy(cmd.param(1))
+      return false unless foe
+      case cmd.param(2)
+      when 0 then !foe.dead?
+      when 1 then foe.state?(cmd.param(3))
+      else false
       end
     end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2334,6 +2334,7 @@ class RPG2k
         when :ally_target then drive_battle_ally_target
         when :animate     then drive_battle_animate
         when :result      then drive_battle_result
+        when :event       then drive_battle_event
         end
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle failed: #{e.message}"
@@ -2358,10 +2359,19 @@ class RPG2k
                        skill_win: nil, item_win: nil, ally_win: nil,
                        action_win: nil, anim_timer: 0,
                        back_sprite: nil, enemy_sprites: nil,
-                       result_win: nil, result: nil }
+                       result_win: nil, result: nil,
+                       # The troop's battle-event pages: their own interpreter,
+                       # the message window they draw into, and which pages have
+                       # already fired this turn (RPG2000 runs a page once per
+                       # turn its condition holds, so this resets each round).
+                       events: Game::Interpreter.new(@state), event_win: nil,
+                       pages_run: {} }
+        @battle_ui[:events].battle = @battle_ui[:battle]
         build_battle_sprites
         refresh_battle_status
-        draw_battle_command
+        # Turn-0 pages fire before the party is asked for its first command —
+        # this is where a troop's opening dialogue lives.
+        draw_battle_command unless run_battle_events
       end
 
       # RPG2000 is a front-view battle: the enemy troop is drawn as sprites over a
@@ -2387,13 +2397,42 @@ class RPG2k
       # A plain dark battle field behind the enemies. The real per-terrain
       # backdrop (Backdrop/<name>, chosen by the tile the encounter started on) is
       # still to come — the encounter request does not carry that terrain yet.
-      def build_battle_back
-        bmp = Bitmap.new(SCREEN_W, SCREEN_H)
-        bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(16, 16, 32, 255)
+      # Where a battle-event page's message panel sits — above the action banner,
+      # so a page talking mid-round does not fight it for the same row.
+      BATTLE_EVENT_MSG_Y = 8
+
+      def build_battle_back(name = nil)
+        bmp = battle_back_bitmap(name)
         spr = Sprite.new
         spr.bitmap = bmp
         spr.z = 5
         @battle_ui[:back_sprite] = spr
+      end
+
+      # The battle backdrop: the Backdrop/<name> image a Change Battle Background
+      # command (or the encounter) named, falling back to the flat colour field
+      # when there is no name or the file is missing — the same fallback the map
+      # uses for a missing chipset.
+      def battle_back_bitmap(name)
+        return Bitmap.new("Backdrop/#{name}") if name && !name.empty?
+        flat_battle_back
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle backdrop '#{name}' failed to load: #{e.message}"
+        flat_battle_back
+      end
+
+      def flat_battle_back
+        bmp = Bitmap.new(SCREEN_W, SCREEN_H)
+        bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(16, 16, 32, 255)
+        bmp
+      end
+
+      # Change Battle Background (13210): swap the backdrop mid-fight, releasing
+      # the sprite and bitmap the old one held.
+      def rebuild_battle_back(name)
+        dispose_battle_sprite(@battle_ui[:back_sprite])
+        @battle_ui[:back_sprite] = nil
+        build_battle_back(name)
       end
 
       # The battler graphic for `enemy` (Monster/<battler_name>, colour-keyed), or
@@ -2743,6 +2782,145 @@ class RPG2k
           @battle_ui[:actor_i] = 0
           @battle_ui[:cmd] = 0
           @battle_ui[:phase] = :command
+          # A new turn re-arms every page: RPG2000 fires a battle page once per
+          # turn in which its condition holds, not once per battle.
+          @battle_ui[:pages_run] = {}
+          draw_battle_command unless run_battle_events
+        end
+      end
+
+      # -- battle-event pages --------------------------------------------------
+
+      # Start the next troop battle-event page whose condition holds and that has
+      # not yet fired this turn, switching to the :event phase. Returns whether a
+      # page was started, so the caller knows whether to draw the command window
+      # or hand the frame to the event. A troop that scripts nothing, or whose
+      # pages have all fired, simply returns false.
+      def run_battle_events
+        ui = @battle_ui
+        return false unless ui && ui[:troop].pages
+        matched = Game::BattlePage.select_all(ui[:troop].pages, @state.switches,
+                                              @state.variables, ui[:battle])
+        entry = matched.find { |(id, _)| !ui[:pages_run][id] }
+        return false unless entry
+        ui[:pages_run][entry[0]] = true
+        cmds = entry[1].event
+        return run_battle_events if cmds.nil? || cmds.empty? # empty page: try the next
+        ui[:events].battle = ui[:battle]
+        ui[:events].start(cmds)
+        ui[:phase] = :event
+        true
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle event page failed: #{e.message}"
+        false
+      end
+
+      # Advance the running battle-event page one frame. Battle pages use the
+      # ordinary command set (messages, switches, variables, audio) on top of the
+      # battle-only commands, so the interpreter is driven the same way the map
+      # drives an event — only the UI it may reach for is narrower.
+      def drive_battle_event
+        it = @battle_ui[:events]
+        apply_battle_event_requests(it)
+        return if finish_terminated_battle
+        if it.waiting?
+          drive_battle_event_wait(it)
+        elsif it.running?
+          it.update
+        else
+          leave_battle_event_phase
+        end
+      end
+
+      def drive_battle_event_wait(it)
+        case it.wait_kind
+        when :message, :choice then drive_battle_event_message(it)
+        when :wait
+          @battle_ui[:event_timer] ||= frames_from_tenths(it.wait_frames)
+          if @battle_ui[:event_timer] <= 0
+            @battle_ui[:event_timer] = nil
+            it.resume
+          else
+            @battle_ui[:event_timer] -= 1
+          end
+        else
+          # A battle page cannot open the map's teleport / shop / menu UI; those
+          # requests are released so the page runs on rather than wedging here.
+          it.resume
+        end
+      end
+
+      # Show the page's message lines in a battle text panel and dismiss it on a
+      # button press. A [Show Choices] in a battle page is displayed the same way
+      # and takes the first option, which is what the runtime can answer without
+      # a battle choice widget.
+      def drive_battle_event_message(it)
+        unless @battle_ui[:event_win]
+          lines = it.wait_kind == :choice ? it.choice_labels : it.message_lines
+          @battle_ui[:event_win] =
+            battle_text_window(lines || [], BATTLE_EVENT_MSG_Y, 340)
+          return # shown this frame; take the button from the next one
+        end
+        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        choice = it.wait_kind == :choice
+        close_battle_event_window
+        choice ? it.choose(0) : it.resume
+      end
+
+      def close_battle_event_window
+        return unless @battle_ui && @battle_ui[:event_win]
+        @battle_ui[:event_win].dispose
+        @battle_ui[:event_win] = nil
+      end
+
+      # Apply the requests a battle page queued: revealed troop members get the
+      # sprite they never had, and a Change Battle Background rebuilds the
+      # backdrop.
+      def apply_battle_event_requests(it)
+        it.take_revealed_monsters.each { |i| reveal_battle_monster(i) }
+        name = it.take_battle_background
+        rebuild_battle_back(name) unless name.nil?
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle event request failed: #{e.message}"
+        nil
+      end
+
+      # Show Hidden Monster: clear the member's hidden flag and build the sprite
+      # build_battle_sprites skipped, so it appears mid-fight.
+      def reveal_battle_monster(index)
+        member = @battle_ui[:troop].members[index]
+        return unless member && member.hidden
+        member.hidden = false
+        bmp = battler_bitmap(member)
+        spr = Sprite.new
+        spr.bitmap = bmp
+        spr.x = member.x - bmp.width / 2
+        spr.y = member.y - bmp.height / 2
+        spr.z = 100 + index
+        dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
+        @battle_ui[:enemy_sprites][index] = spr
+      end
+
+      # Terminate Battle: leave the fight with no victory / defeat processing.
+      # Returns whether the battle was ended, so the caller stops driving it.
+      def finish_terminated_battle
+        return false unless @battle_ui[:battle].terminated?
+        close_battle_event_window
+        finish_battle(:abort)
+        true
+      end
+
+      # The running page finished: fire the next matching page, or hand the turn
+      # back — to the result window when the page decided the fight, otherwise to
+      # the party's command phase.
+      def leave_battle_event_phase
+        close_battle_event_window
+        return if run_battle_events
+        battle = @battle_ui[:battle]
+        if battle.finished?
+          enter_battle_result(battle.result)
+        else
+          @battle_ui[:phase] = :command
           draw_battle_command
         end
       end
@@ -3019,7 +3197,8 @@ class RPG2k
         [@battle_ui[:status_win], @battle_ui[:cmd_win],
          @battle_ui[:target_win], @battle_ui[:skill_win],
          @battle_ui[:item_win], @battle_ui[:ally_win],
-         @battle_ui[:action_win], @battle_ui[:result_win]].each { |w| w.dispose if w }
+         @battle_ui[:action_win], @battle_ui[:result_win],
+         @battle_ui[:event_win]].each { |w| w.dispose if w }
         dispose_battle_sprite(@battle_ui[:back_sprite])
         (@battle_ui[:enemy_sprites] || []).each { |s| dispose_battle_sprite(s) }
         @battle_ui = nil

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4938,6 +4938,298 @@ check 'starting a new BGM clears the "played once" flag' do
   eq false, st.bgm_looped
 end
 
+# -- battle-event pages and their commands ------------------------------------
+
+BP = Game::BattlePage
+
+# A troop battle-event page: a condition plus the command list it runs.
+FakePage = Struct.new(:condition, :event)
+
+# A troop battle-event page condition. Only the fields a given check enables in
+# `flags` are read, so the rest can stay at their editor defaults.
+FakeBattleCond = Struct.new(:flags, :switch_a_id, :switch_b_id, :variable_id,
+                            :variable_value, :turn_a, :turn_b,
+                            :fatigue_min, :fatigue_max,
+                            :enemy_id, :enemy_hp_min, :enemy_hp_max,
+                            :actor_id, :actor_hp_min, :actor_hp_max,
+                            :turn_enemy_id, :turn_enemy_a, :turn_enemy_b,
+                            :turn_actor_id, :turn_actor_a, :turn_actor_b,
+                            :command_actor_id, :command_id)
+def battle_cond(flags, opts = {})
+  c = FakeBattleCond.new(flags)
+  c.variable_value = 0
+  c.turn_a = 0; c.turn_b = 0
+  c.enemy_hp_min = 0; c.enemy_hp_max = 100
+  c.actor_hp_min = 0; c.actor_hp_max = 100
+  c.turn_enemy_a = 0; c.turn_enemy_b = 0
+  c.turn_actor_a = 0; c.turn_actor_b = 0
+  opts.each { |k, v| c.send("#{k}=", v) }
+  c
+end
+
+# A battle whose allies carry a source actor id, so the actor-keyed conditions
+# and the battle Conditional Branch can find them.
+FakeSourceActor = Struct.new(:id)
+def battle_with(ally_hp: 100, foe_hp: 100, foe_mp: 8)
+  hero = combatant('Hero', 10, 0, 10, ally_hp)
+  hero.actor = FakeSourceActor.new(1)
+  foe = combatant_mp('Slime', 5, 0, 5, foe_hp, foe_mp)
+  Game::Battle.new([hero], [foe], Game::Rng.new(1))
+end
+
+check 'battle-event opcodes match the LCF Code enum' do
+  eq 13110, IC::CHANGE_MONSTER_HP
+  eq 13120, IC::CHANGE_MONSTER_MP
+  eq 13130, IC::CHANGE_MONSTER_CONDITION
+  eq 13150, IC::SHOW_HIDDEN_MONSTER
+  eq 13210, IC::CHANGE_BATTLE_BG
+  eq 13260, IC::SHOW_BATTLE_ANIM_B
+  eq 13310, IC::CONDITIONAL_B
+  eq 13410, IC::TERMINATE_BATTLE
+  eq 23310, IC::ELSE_BRANCH_B
+  eq 23311, IC::END_BRANCH_B
+end
+
+check 'BattlePage.check_turns matches RPG2000 turn arithmetic' do
+  # No multiple: the turn must equal the base exactly.
+  ok BP.check_turns(3, 3, 0)
+  ok !BP.check_turns(4, 3, 0)
+  # With a multiple: at or past the base, an exact number of steps beyond it.
+  ok BP.check_turns(0, 0, 2)
+  ok BP.check_turns(4, 0, 2)
+  ok !BP.check_turns(3, 0, 2)
+  ok !BP.check_turns(1, 2, 2), 'before the base never fires'
+end
+
+check 'BattlePage.active? tests switch, variable and turn conditions' do
+  b = battle_with
+  st = new_state
+  sw = st.switches
+  vars = st.variables
+  eq true, BP.active?(nil, sw, vars, b), 'a page with no condition always fires'
+
+  cond = battle_cond(BP::SWITCH_A, switch_a_id: 7)
+  eq false, BP.active?(cond, sw, vars, b)
+  sw[7] = true
+  eq true, BP.active?(cond, sw, vars, b)
+
+  vcond = battle_cond(BP::VARIABLE, variable_id: 3, variable_value: 5)
+  eq false, BP.active?(vcond, sw, vars, b)
+  vars[3] = 5
+  eq true, BP.active?(vcond, sw, vars, b), 'the test is >=, not =='
+
+  # Turn 0 before the first round has run.
+  eq true, BP.active?(battle_cond(BP::TURN, turn_b: 0, turn_a: 0), sw, vars, b)
+  eq false, BP.active?(battle_cond(BP::TURN, turn_b: 2, turn_a: 0), sw, vars, b)
+end
+
+check 'BattlePage.active? tests enemy and actor HP windows' do
+  b = battle_with(ally_hp: 100, foe_hp: 100)
+  st = new_state
+  # Wound the monster to 30%: a "50% or below" page now fires.
+  b.enemy(0).hp = 30
+  cond = battle_cond(BP::ENEMY_HP, enemy_id: 0, enemy_hp_min: 0, enemy_hp_max: 50)
+  eq true, BP.active?(cond, st.switches, st.variables, b)
+  b.enemy(0).hp = 90
+  eq false, BP.active?(cond, st.switches, st.variables, b)
+
+  acond = battle_cond(BP::ACTOR_HP, actor_id: 1, actor_hp_min: 0, actor_hp_max: 25)
+  eq false, BP.active?(acond, st.switches, st.variables, b)
+  b.ally_by_actor_id(1).hp = 10
+  eq true, BP.active?(acond, st.switches, st.variables, b)
+end
+
+check 'BattlePage.active? fails a condition the runtime cannot answer' do
+  b = battle_with
+  st = new_state
+  # Party fatigue is an RPG2003 mechanic that is not modelled, and the per-
+  # battler turn counters are not either: such a page must not fire unchecked.
+  eq false, BP.active?(battle_cond(BP::FATIGUE), st.switches, st.variables, b)
+  eq false, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 0),
+                       st.switches, st.variables, b)
+  eq false, BP.active?(battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1,
+                                   command_id: 1), st.switches, st.variables, b)
+end
+
+check 'BattlePage.select_all returns every matching page in order' do
+  b = battle_with
+  st = new_state
+  st.switches[1] = true
+  pages = {
+    1 => FakePage.new(battle_cond(0), []),
+    2 => FakePage.new(battle_cond(BP::SWITCH_A, switch_a_id: 2), []),
+    3 => FakePage.new(battle_cond(BP::SWITCH_A, switch_a_id: 1), []),
+  }
+  got = BP.select_all(pages, st.switches, st.variables, b).map { |(id, _)| id }
+  eq [1, 3], got, 'unlike a map event, every matching battle page runs'
+end
+
+check 'Change Monster HP damages a troop member, honouring the lethal flag' do
+  b = battle_with(foe_hp: 100)
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  # member 0, lose (1), constant operand (0), 30, lethal allowed (1)
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 30, 1])])
+  it.update
+  eq 70, b.enemy(0).hp
+
+  # A non-lethal hit far bigger than its HP leaves it on 1.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 999, 0])])
+  it.update
+  eq 1, b.enemy(0).hp
+
+  # A lethal one finishes it.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 999, 1])])
+  it.update
+  eq 0, b.enemy(0).hp
+  ok b.enemy(0).dead?
+end
+
+check 'Change Monster HP heals, reads a variable and a percentage' do
+  b = battle_with(foe_hp: 100)
+  st = new_state
+  st.variables[4] = 25
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  b.enemy(0).hp = 20
+  # gain (0), variable operand (1) -> variable 4 = 25
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 1, 4, 1])])
+  it.update
+  eq 45, b.enemy(0).hp
+
+  # percentage operand (2): 10% of max_hp (100) = 10
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 2, 10, 1])])
+  it.update
+  eq 55, b.enemy(0).hp
+
+  # Healing never exceeds the maximum.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 0, 999, 1])])
+  it.update
+  eq 100, b.enemy(0).hp
+end
+
+check 'Change Monster MP adjusts SP and clamps to its range' do
+  b = battle_with(foe_mp: 8)
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_MP, [0, 1, 0, 5])]) # lose 5
+  it.update
+  eq 3, b.enemy(0).mp
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_MP, [0, 1, 0, 99])])
+  it.update
+  eq 0, b.enemy(0).mp, 'SP floors at zero'
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_MP, [0, 0, 0, 99])])
+  it.update
+  eq 8, b.enemy(0).mp, 'and caps at the maximum'
+end
+
+check 'Change Monster Condition inflicts and cures a status' do
+  b = battle_with
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_CONDITION, [0, 0, 4])])
+  it.update
+  ok b.enemy(0).state?(4), 'the status was inflicted'
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_CONDITION, [0, 0, 4])])
+  it.update
+  eq [4], b.enemy(0).states, 'inflicting twice does not duplicate it'
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_CONDITION, [0, 1, 4])])
+  it.update
+  ok !b.enemy(0).state?(4), 'and it was cured'
+end
+
+check 'Show Hidden Monster and Change Battle Background raise one-shot requests' do
+  b = battle_with
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::SHOW_HIDDEN_MONSTER, [2]),
+            FakeCmd.new(IC::CHANGE_BATTLE_BG, [], string: 'Cave')])
+  it.update
+  eq [2], it.take_revealed_monsters
+  eq [], it.take_revealed_monsters, 'the queue drains'
+  eq 'Cave', it.take_battle_background
+  eq nil, it.take_battle_background, 'the request is one-shot'
+end
+
+check 'Terminate Battle ends the fight and abandons the rest of the page' do
+  b = battle_with
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  it.start([FakeCmd.new(IC::TERMINATE_BATTLE, []),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0])])
+  it.update
+  ok b.terminated?, 'the battle was told to end'
+  ok !st.switches[3], 'the rest of the page did not run'
+end
+
+check 'the battle Conditional Branch tests switches, variables and battlers' do
+  b = battle_with(foe_hp: 100)
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  # A branch body that sets variable 1 to 1; the else sets it to 2.
+  branch = lambda do |params|
+    [FakeCmd.new(IC::CONDITIONAL_B, params, indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+     FakeCmd.new(IC::ELSE_BRANCH_B, [], indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+     FakeCmd.new(IC::END_BRANCH_B, [], indent: 0)]
+  end
+
+  it.start(branch.call([0, 5, 0])) # switch 5 is on?
+  it.update
+  eq 2, st.variables[1], 'switch off: the else branch runs'
+  st.switches[5] = true
+  it.start(branch.call([0, 5, 0]))
+  it.update
+  eq 1, st.variables[1]
+
+  # type 3: troop member 0 is still standing
+  it.start(branch.call([3, 0, 0]))
+  it.update
+  eq 1, st.variables[1]
+  b.enemy(0).hp = 0
+  it.start(branch.call([3, 0, 0]))
+  it.update
+  eq 2, st.variables[1], 'a downed member fails the "is present" test'
+
+  # type 2: actor 1 is in the fight
+  it.start(branch.call([2, 1, 0]))
+  it.update
+  eq 1, st.variables[1]
+  it.start(branch.call([2, 99, 0]))
+  it.update
+  eq 2, st.variables[1], 'an actor not in the fight fails'
+end
+
+check 'battle-only commands are no-ops outside a battle' do
+  st = new_state
+  it = Game::Interpreter.new(st) # no #battle set: a map/common event
+  it.start([
+    FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 30, 1]),
+    FakeCmd.new(IC::SHOW_HIDDEN_MONSTER, [1]),
+    FakeCmd.new(IC::CHANGE_BATTLE_BG, [], string: 'Cave'),
+    FakeCmd.new(IC::TERMINATE_BATTLE, []),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0]),
+  ])
+  it.update
+  eq [], it.take_revealed_monsters
+  eq nil, it.take_battle_background
+  ok st.switches[2], 'the list still runs to the end'
+end
+
+check 'Show Battle Animation (battle form) waits like the map form' do
+  b = battle_with
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::SHOW_BATTLE_ANIM_B, [7, 0, 1])])
+  it.update
+  eq :animation, it.wait_kind
+  eq 7, it.battle_animation[:animation]
+  eq true, it.battle_animation[:battle]
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -162,7 +162,7 @@ def fake_chipset(name = 'cs')
                  terrain_data: td)
 end
 
-def fake_db(common = nil)
+def fake_db(common = nil, troop_pages = nil)
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: '',
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
@@ -185,7 +185,8 @@ def fake_db(common = nil)
                                  gold: 10) },
     enemy_group: { 1 => OpenStruct.new(name: 'Slimes', members: {
       1 => OpenStruct.new(enemy_id: 2, x: 100, y: 80, invisible: false),
-      2 => OpenStruct.new(enemy_id: 2, x: 200, y: 80, invisible: false) }) },
+      2 => OpenStruct.new(enemy_id: 2, x: 200, y: 80, invisible: false) },
+      pages: troop_pages) },
     # A drawable battle animation (id 8): four frames, with a screen flash timing
     # on frame 1. (Id 7 is intentionally absent so that test exercises the
     # timed-wait fallback.)
@@ -290,8 +291,8 @@ def fake_party
   OpenStruct.new(leader: nil, actors: [])
 end
 
-def new_scene(events, player: [0, 0], common: nil, parallax: nil)
-  db = fake_db(common)
+def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil)
+  db = fake_db(common, troop_pages)
   state = Game::State.new(fake_party, 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   RPG2k::Scene::Map.new(fake_parent(db), state)
@@ -2362,6 +2363,120 @@ check 'the action key marks the event it started for the type-8 branch' do
   RGSS::Input.triggered = []
   3.times { scene.update }
   ok st.switches[9], 'the decision-key branch ran'
+end
+
+# -- battle-event pages --------------------------------------------------------
+
+# A troop battle-event page: `flags` 0 means "no condition", so it fires on turn
+# 0 as soon as the fight opens.
+def troop_page(cmds, flags = 0, opts = {})
+  cond = OpenStruct.new({ flags: flags, switch_a_id: 1, switch_b_id: 1,
+                          variable_id: 1, variable_value: 0, turn_a: 0,
+                          turn_b: 0, enemy_id: 0, enemy_hp_min: 0,
+                          enemy_hp_max: 100, actor_id: 1, actor_hp_min: 0,
+                          actor_hp_max: 100 }.merge(opts))
+  OpenStruct.new(condition: cond, event: cmds)
+end
+
+# Open a battle whose troop carries `pages`, running frames until the fight is
+# up. Returns [scene, state].
+def battle_scene_with_pages(pages)
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) }, troop_pages: pages)
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  [scene, st]
+end
+
+check 'a turn-0 battle-event page runs as the fight opens' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::CONTROL_SWITCHES, [0, 12, 12, 0])]) }
+  scene, st = battle_scene_with_pages(pages)
+  10.times do
+    scene.update
+    break if st.switches[12]
+  end
+  ok st.switches[12], 'the page ran before the command phase'
+  scene.update # the exhausted page hands the turn back
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui, 'the battle is still open'
+  eq :command, ui[:phase], 'and control returned to the party'
+end
+
+check 'a battle page gated on an unmet condition does not fire' do
+  ic = Game::Interpreter::Cmd
+  # Gated on switch 13, which is never set.
+  pages = { 1 => troop_page([ECmd.new(ic::CONTROL_SWITCHES, [0, 14, 14, 0])],
+                            Game::BattlePage::SWITCH_A, switch_a_id: 13) }
+  scene, st = battle_scene_with_pages(pages)
+  10.times { scene.update }
+  ok !st.switches[14], 'the gated page stayed put'
+end
+
+check 'Terminate Battle from a page ends the fight and resumes the event' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }
+  scene, _st = battle_scene_with_pages(pages)
+  12.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui).nil?
+  end
+  eq nil, scene.instance_variable_get(:@battle_ui),
+     'the battle closed without a result window'
+end
+
+check 'a page can wound a monster through Change Monster HP' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::CHANGE_MONSTER_HP, [0, 1, 0, 7, 1])]) }
+  scene, _st = battle_scene_with_pages(pages)
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :command
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  foe = ui[:battle].enemy(0)
+  eq foe.max_hp - 7, foe.hp, 'the page took 7 HP off the first troop member'
+end
+
+check 'Change Battle Background from a page rebuilds the backdrop sprite' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::CHANGE_BATTLE_BG, [], string: 'Cave')]) }
+  scene, _st = battle_scene_with_pages(pages)
+  before = nil
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    before ||= ui && ui[:back_sprite]
+    break if ui && ui[:phase] == :command
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui[:back_sprite], 'a backdrop is still in place'
+  ok !ui[:back_sprite].equal?(before), 'and it was rebuilt for the new name'
+end
+
+check 'a battle page shows its message in a battle panel and waits for a key' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_MESSAGE, [], string: 'It appears!'),
+                             ECmd.new(ic::CONTROL_SWITCHES, [0, 15, 15, 0])]) }
+  scene, st = battle_scene_with_pages(pages)
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:event_win]
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui[:event_win], 'the message panel is up'
+  ok !st.switches[15], 'the page is held at the message'
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  3.times { scene.update }
+  ok st.switches[15], 'the button dismissed it and the page ran on'
+  eq nil, scene.instance_variable_get(:@battle_ui)[:event_win],
+     'the panel closed with the message'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
Completes the RPG2000 event command set: the battle-only commands and the troop pages that carry them. Follow-up to #310, which closed the map / common-event side and left this as the documented remaining gap.

The LCF schema already decoded `enemy_group` chunk 11 — each troop page's `condition` (all 23 fields) and its `event` command list. Nothing read it until now, so this is wiring up decoded-but-unused data rather than new parsing.

## Page conditions

`Game::BattlePage` evaluates a page's condition at the start of every turn. Its `flags` bitfield follows liblcf's `TroopPageCondition::Flags` declaration order packed LSB-first — the same convention `Game::EventPage` already uses for map pages. Switch, variable, turn (RPG2000's base/multiple arithmetic, `CheckTurns`), enemy-HP and actor-HP conditions are tested.

Unlike a map event, where the highest active page wins, **every** matching battle page runs. Pages re-arm each turn, so a page fires once per turn its condition holds, not once per battle.

## Commands

Pages run through a `Game::Interpreter` carrying a new `battle` context (implemented by `Game::Battle`), so they get the whole ordinary command set — messages, switches, variables, audio — plus:

| Code | Command | Notes |
| --- | --- | --- |
| 13110 | Change Monster HP | constant / variable / percent operands, non-lethal floor |
| 13120 | Change Monster MP | clamps to 0..max |
| 13130 | Change Monster Condition | inflict / cure |
| 13150 | Show Hidden Monster | builds the sprite `build_battle_sprites` skipped |
| 13210 | Change Battle Background | now loads a real `Backdrop/<name>` |
| 13260 | Show Battle Animation | the battle form of 11210 |
| 13310 | Conditional Branch | with its `_B` else/end markers |
| 13410 | Terminate Battle | leaves the fight with no result processing |

The battle-only commands are no-ops in a map or common event, where the editor cannot place them. A page's messages are shown in a battle text panel and dismissed with a button.

Two prior stubs fell out of this: the battle backdrop was always a flat colour field and now loads its real image, and hidden troop members finally have the reveal mechanism the code comment had been promising.

## Deliberately not done

Three condition types read state the runtime does not model — party fatigue (an RPG2003 mechanic), the per-battler turn counters, and the actor's chosen battle command. **A page gated on any of those does not fire.** That is the conservative direction: firing on an unchecked condition would run cutscenes at wrong moments, which is far harder to notice than one that stays quiet. Called out in the code, the changelog fragment and `docs/TODO.md`.

Also: a `[Show Choices]` inside a battle page takes the first option, since there is no battle choice widget.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `rpg2k_logic_check.rb` | 342 | **357** |
| `rpg2k_scene_check.rb` | 105 | **111** |
| `rpg2k_render_check.rb` | 36 | 36 |

`mv_testbed_check.rb data/mv-sample` and `rpgvx_testbed_check.rb` also clean.

New coverage spans the turn arithmetic, each condition type (including that the unanswerable ones fail), every new command, and end-to-end through the real battle scene: a page firing on turn 0, a gated page staying put, Terminate Battle closing the fight, Change Monster HP wounding a member, the backdrop rebuilding, and a message panel holding the page until a keypress.

One caveat on rigour: opcodes and command semantics were checked against liblcf / EasyRPG source, but the condition flags' bit-packing is inferred from liblcf's declaration order plus the identical convention the map-page code already uses (which *is* validated against real games). I could not prove the packing byte-for-byte against a real RPG2000 game with battle events — no test-bed is downloaded in this environment. That reasoning is stated in the code comment rather than presented as measured fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_