### PR TITLE
ci: serialise nix store access through a nix-daemon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,12 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
 
+      # Serialise store access for the concurrent `nix develop` steps below.
+      # Must come before every nix command in the job, the warm-up included,
+      # since it is what exports NIX_REMOTE for the steps that follow.
+      - name: Start nix-daemon
+        run: ./scripts/start-nix-daemon.bash
+
       - run: nix develop -c echo test
 
       - name: cache rtp
@@ -514,6 +520,12 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
+
+      # As in the `build` job, and for the same reason: this job fans out into
+      # concurrent `nix develop` steps, so give them a daemon to serialise
+      # against. Before the warm-up, which is itself a nix command.
+      - name: Start nix-daemon
+        run: ./scripts/start-nix-daemon.bash
 
       # Realise the dev shell up front, exactly as the `build` job does. This
       # job fans out into concurrent `nix develop` steps below, and building the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,35 +94,41 @@ jobs:
       # so the wait always has a real step to join). Every write lands on a
       # git-ignored path (build/, data/*, scripts/*.zip, the fetched MV engine
       # files), so nothing here can race pre-commit's tracked-file `git diff`.
+      #
+      # Every step that can overlap another one enters the dev shell through
+      # scripts/nix-develop.bash rather than `nix develop` directly: CI has no
+      # nix-daemon, so concurrent nix processes contend for the store database
+      # lock and the loser aborts with "SQLite database ... is busy". The
+      # wrapper retries just that error; see the script for the details.
       - name: Download RTP
         id: dl-rtp
         background: true
         run: |
-          nix develop -c ./scripts/rtp_install.bash
-          nix develop -c ./scripts/rtp_xp_install.bash
+          ./scripts/nix-develop.bash ./scripts/rtp_install.bash
+          ./scripts/nix-develop.bash ./scripts/rtp_xp_install.bash
 
       - name: Download game
         id: dl-game
         background: true
         run: |
-          nix develop -c ./scripts/download-nepheshel.bash
-          nix develop -c ./scripts/download-mtf-meido-action.bash
-          nix develop -c ./scripts/download-opengame-xp.bash
+          ./scripts/nix-develop.bash ./scripts/download-nepheshel.bash
+          ./scripts/nix-develop.bash ./scripts/download-mtf-meido-action.bash
+          ./scripts/nix-develop.bash ./scripts/download-opengame-xp.bash
 
       - name: Download MV test game
         id: dl-mv
         background: true
-        run: nix develop -c ./scripts/download-lunatic-core.bash
+        run: ./scripts/nix-develop.bash ./scripts/download-lunatic-core.bash
 
       - name: Build MV sample engine
         id: dl-mv-sample
         background: true
-        run: nix develop -c ./scripts/download-mv-corescript.bash
+        run: ./scripts/nix-develop.bash ./scripts/download-mv-corescript.bash
 
       - name: Fetch MZ corescript
         id: dl-mz-sample
         background: true
-        run: nix develop -c ./scripts/download-mz-corescript.bash
+        run: ./scripts/nix-develop.bash ./scripts/download-mz-corescript.bash
 
       - name: pre-commit
         id: pre-commit
@@ -130,7 +136,7 @@ jobs:
         env:
           SKIP: nixfmt
         run: |
-          nix develop -c pre-commit run -a || (
+          ./scripts/nix-develop.bash pre-commit run -a || (
             git diff --exit-code ;
             false
           )
@@ -138,22 +144,29 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.11
 
+      # Runs while the background steps above are still in flight, so it takes
+      # the retrying wrapper too.
       - name: cmake
         run: |
-          nix develop -c cmake -S . -B build -GNinja
+          ./scripts/nix-develop.bash cmake -S . -B build -GNinja
 
       - name: build
         run: |
-          nix develop -c cmake --build build
+          ./scripts/nix-develop.bash cmake --build build
 
       - name: sccache stats
         if: always()
+        # The background downloads can still be running here, so this needs the
+        # retrying wrapper too — in the mode that keeps nix's own stderr out of
+        # the captured stdout, which is going into the step summary verbatim.
+        env:
+          NIX_DEVELOP_SEPARATE_STREAMS: 1
         run: |
           {
             echo "## sccache stats"
             echo ""
             echo '```'
-            nix develop -c sccache --show-stats
+            ./scripts/nix-develop.bash sccache --show-stats
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -193,13 +206,13 @@ jobs:
       # `[MV-*]` markers.
       - parallel:
           - name: LCF test-bed smoke check
-            run: nix develop -c ruby scripts/lcf_testbed_check.rb
+            run: ./scripts/nix-develop.bash ruby scripts/lcf_testbed_check.rb
 
           - name: RPG XP test-bed smoke check
-            run: nix develop -c ruby scripts/rpgxp_testbed_check.rb
+            run: ./scripts/nix-develop.bash ruby scripts/rpgxp_testbed_check.rb
 
           - name: RPG XP script-host smoke check
-            run: nix develop -c ruby scripts/rpgxp_script_host_check.rb
+            run: ./scripts/nix-develop.bash ruby scripts/rpgxp_script_host_check.rb
 
           # RPG Maker VX / VX Ace data layer. Neither edition has a fetchable
           # open-source test bed (the editors and their RTPs are commercial), so
@@ -209,7 +222,7 @@ jobs:
           # in the schema. It also picks up any real VX/VX Ace project that a
           # future download step unpacks under data/.
           - name: RPG VX / VX Ace data check
-            run: nix develop -c ruby scripts/rpgvx_testbed_check.rb
+            run: ./scripts/nix-develop.bash ruby scripts/rpgvx_testbed_check.rb
 
           # Validate the committed MV test-bed database (data/mv-sample) before
           # the non-blocking native MV smokes below. Pure CRuby, no JS engine —
@@ -218,17 +231,17 @@ jobs:
           # committed bed so it stays deterministic even though this parallel
           # group may run alongside the MV game download.
           - name: MV test-bed data check
-            run: nix develop -c ruby scripts/mv_testbed_check.rb data/mv-sample
+            run: ./scripts/nix-develop.bash ruby scripts/mv_testbed_check.rb data/mv-sample
 
           - name: RPG2k game-logic checks
             run: |
-              nix develop -c ruby scripts/rpg2k_logic_check.rb
-              nix develop -c ruby scripts/rpg2k_scene_check.rb
-              nix develop -c ruby scripts/rpg2k_render_check.rb
+              ./scripts/nix-develop.bash ruby scripts/rpg2k_logic_check.rb
+              ./scripts/nix-develop.bash ruby scripts/rpg2k_scene_check.rb
+              ./scripts/nix-develop.bash ruby scripts/rpg2k_render_check.rb
 
           - name: test
             run: |
-              nix develop -c cmake --build build -t test
+              ./scripts/nix-develop.bash cmake --build build -t test
 
           # Boot the built engine on the real RPG2000/2003 test-beds and drive
           # it past the title into the map with --rpg2k_new_game. The CRuby host
@@ -240,7 +253,7 @@ jobs:
           # [RPG2k-MAP] marker fails this step. It uses display 109 and up, one
           # per game. See ADR 0021.
           - name: RPG2k real-game boot smoke test
-            run: nix develop -c ./scripts/rpg2k_boot_check.bash 109
+            run: ./scripts/nix-develop.bash ./scripts/rpg2k_boot_check.bash 109
 
           # The same guard for the RPG Maker XP runtime: the XP checks above run
           # mruby-rpgxp's sources under CRuby, so only booting the real binary
@@ -249,12 +262,12 @@ jobs:
           # the script asserts on. Display 112 (see the reserved server-num map
           # above). See docs/adr/0025-rpgxp-cross-runtime-testing.md.
           - name: RPG XP real-game boot smoke test
-            run: nix develop -c ./scripts/rpgxp_boot_check.bash 112
+            run: ./scripts/nix-develop.bash ./scripts/rpgxp_boot_check.bash 112
 
           - name: MV boot smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=100 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=5000 --game_dir data/Lunatic-Core \
                 --mv_screenshot=ss/mv_title.png
@@ -269,7 +282,7 @@ jobs:
           - name: MV real-game play smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=105 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/Lunatic-Core \
                 --mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png
@@ -277,7 +290,7 @@ jobs:
           - name: MV sample smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=101 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=5000 --game_dir data/mv-sample \
                 --mv_new_game --mv_screenshot=ss/mv_sample.png
@@ -291,7 +304,7 @@ jobs:
           # reserved server-num map above).
           - name: MZ boot smoke test
             continue-on-error: true
-            run: nix develop -c ./scripts/mz_boot_check.bash 111
+            run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
 
           # Run the battle smoke against the real bed (Lunatic-Core): it ships
           # battlers and a battleback, so the captured Scene_Battle frame shows
@@ -302,7 +315,7 @@ jobs:
           - name: MV battle smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=102 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=8000 --game_dir data/Lunatic-Core \
                 --mv_battle_test=1 --mv_screenshot=ss/mv_battle.png
@@ -310,7 +323,7 @@ jobs:
           - name: MV movement smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=103 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_move_test
@@ -318,7 +331,7 @@ jobs:
           - name: MV message smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=104 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_message_test --mv_screenshot=ss/mv_message.png
@@ -330,7 +343,7 @@ jobs:
           - name: MV menu smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=106 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_menu_test --mv_screenshot=ss/mv_menu.png
@@ -341,7 +354,7 @@ jobs:
           - name: MV save smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=107 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_save_test
@@ -354,7 +367,7 @@ jobs:
           - name: MV audio smoke test
             continue-on-error: true
             run: |
-              nix develop -c ./scripts/quiet_alsa.bash \
+              ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=108 timeout 120 ./build/rpg_maker_clone \
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_audio_test
@@ -502,6 +515,15 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
 
+      # Realise the dev shell up front, exactly as the `build` job does. This
+      # job fans out into concurrent `nix develop` steps below, and building the
+      # shell is the one part of them that writes to the Nix store database in
+      # bulk (registering every path it substitutes). Doing it once here, with
+      # no other nix process running, keeps those steps from racing each other
+      # for the store lock; it costs nothing overall because each of them would
+      # otherwise pay for the same realisation anyway.
+      - run: nix develop -c echo test
+
       # Fetch + build the MIT MV engine into the committed sample so it can be
       # bundled into the page as a one-click preset (WASM_SAMPLE_DIR below).
       # Like the `build` job's downloads, this is network-bound work that feeds
@@ -516,7 +538,7 @@ jobs:
       - name: Build MV sample engine
         id: mv-sample
         background: true
-        run: nix develop -c ./scripts/download-mv-corescript.bash
+        run: ./scripts/nix-develop.bash ./scripts/download-mv-corescript.bash
 
       # The project the browser smoke test below plays. Network-bound and
       # unrelated to the compile, so it overlaps the build like the MV fetch
@@ -524,7 +546,7 @@ jobs:
       - name: Download the RPG XP test bed
         id: xp-testbed
         background: true
-        run: nix develop -c ./scripts/download-opengame-xp.bash
+        run: ./scripts/nix-develop.bash ./scripts/download-opengame-xp.bash
 
       - uses: actions/cache@v6
         with:
@@ -554,7 +576,7 @@ jobs:
         # the sccache launcher the devShell exports (sccache cannot cache emcc).
         # WASM_SAMPLE_DIR bakes the MV sample into the page at /game_sample.
         run: |
-          nix develop -c env EM_CACHE="$HOME/.emscripten_cache" \
+          ./scripts/nix-develop.bash env EM_CACHE="$HOME/.emscripten_cache" \
             CMAKE_C_COMPILER_LAUNCHER=ccache \
             CMAKE_CXX_COMPILER_LAUNCHER=ccache \
             emcmake cmake -S . -B wasm-build -GNinja \
@@ -567,20 +589,26 @@ jobs:
       - name: Wait for the MV sample engine
         wait: [mv-sample]
 
+      # The RPG XP test bed is still downloading in the background here (its own
+      # barrier is further down), so this overlaps a second nix process.
       - name: build
         run: |
-          nix develop -c ccache --zero-stats
-          nix develop -c env EM_CACHE="$HOME/.emscripten_cache" \
+          ./scripts/nix-develop.bash ccache --zero-stats
+          ./scripts/nix-develop.bash env EM_CACHE="$HOME/.emscripten_cache" \
             cmake --build wasm-build
 
       - name: ccache stats
         if: always()
+        # As in the `build` job: the test-bed download may still be in flight,
+        # and this captures stdout into the step summary.
+        env:
+          NIX_DEVELOP_SEPARATE_STREAMS: 1
         run: |
           {
             echo "## ccache stats — wasm"
             echo ""
             echo '```'
-            nix develop -c ccache --show-stats
+            ./scripts/nix-develop.bash ccache --show-stats
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/scripts/nix-develop.bash
+++ b/scripts/nix-develop.bash
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# `nix develop -c "$@"`, retried when the Nix store database is locked.
+#
+# CI installs Nix single-user (nixbuild/nix-quick-install-action), so there is
+# no nix-daemon serialising store access: every `nix` process opens
+# /nix/var/nix/db/db.sqlite itself and takes the SQLite write lock directly.
+# The workflow deliberately runs several `nix develop` steps at once
+# (`background: true`), so two of them can want that lock at the same moment —
+# each registering the store paths it just substituted — and the loser dies
+# with
+#
+#     error: SQLite database '/nix/var/nix/db/db.sqlite' is busy
+#
+# SQLite returns SQLITE_BUSY immediately rather than waiting out the busy
+# timeout when a reader has to upgrade to a writer, and nix turns that straight
+# into a fatal error, so the step fails even though nothing is actually wrong.
+# Retry here instead, backing off to give the winner time to finish. Only that
+# error is retried; any other failure exits with the command's own status.
+# Every caller runs an idempotent command, so a repeat attempt costs nothing.
+#
+# The evaluation cache reports the same contention as
+# `error (ignored): SQLite database '.../eval-cache-v6/<hash>.sqlite' is busy`.
+# That one only loses a cache entry and nix carries on, so the pattern below
+# anchors at `^error:` to leave it alone.
+
+attempts=${NIX_DEVELOP_ATTEMPTS:-4}
+delay=${NIX_DEVELOP_RETRY_DELAY:-5}
+
+# Whether stdout has to stay free of nix's own diagnostics. Off by default: the
+# usual caller is a build or smoke check whose output goes straight to the CI
+# log, and folding stderr in keeps it streaming live, which matters when a step
+# hangs and the log is all there is to look at. Callers that *capture* stdout —
+# the `... >> "$GITHUB_STEP_SUMMARY"` stats steps — set this so a stray nix
+# warning cannot land in what they capture; the cost is that stderr is held
+# back until the command exits.
+separate=${NIX_DEVELOP_SEPARATE_STREAMS:-0}
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+for ((attempt = 1; ; attempt++)); do
+    set +e
+    if [ "$separate" = 1 ]; then
+        nix develop -c "$@" 2>"$log"
+        status=$?
+        cat "$log" >&2
+    else
+        # `tee` is what lets the retry check read nix's diagnostics while they
+        # still stream live, hence PIPESTATUS for the real exit status.
+        nix develop -c "$@" 2>&1 | tee "$log"
+        status=${PIPESTATUS[0]}
+    fi
+    set -e
+
+    if [ "$status" -eq 0 ]; then
+        exit 0
+    fi
+
+    if [ "$attempt" -ge "$attempts" ] ||
+        ! grep -qE "^error: SQLite database '.*' is busy" "$log"; then
+        exit "$status"
+    fi
+
+    echo "nix-develop.bash: Nix store is locked by a concurrent nix process," \
+        "retrying in ${delay}s (attempt $((attempt + 1))/${attempts})" >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+done

--- a/scripts/start-nix-daemon.bash
+++ b/scripts/start-nix-daemon.bash
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Start a nix-daemon for this job and point every later nix command at it.
+#
+# CI installs Nix single-user (nixbuild/nix-quick-install-action), so nothing
+# serialises store access: every `nix` process opens /nix/var/nix/db/db.sqlite
+# itself and takes the SQLite write lock directly. The `build` and `wasm` jobs
+# deliberately fan out into concurrent `nix develop` steps, so they contend for
+# that lock and the loser dies with
+#
+#     error: SQLite database '/nix/var/nix/db/db.sqlite' is busy
+#
+# scripts/nix-develop.bash recovers from that after the fact by retrying. A
+# daemon removes it at the source instead: every store operation is funnelled
+# through one process that serialises database access internally.
+#
+# The daemon started here runs as the runner user — the same user that already
+# owns /nix — so this buys serialisation only, not the privilege separation a
+# real multi-user install has. That is fine; serialisation is the entire point.
+#
+# Deliberately *not* a `background: true` step. Those are joined by the `wait:`
+# barriers and are expected to terminate, and a daemon never does. Backgrounding
+# it inside an ordinary step leaves it as an orphan that the runner reaps at job
+# end — the job logs already show it doing exactly that for sccache.
+
+socket="${NIX_STATE_DIR:-/nix/var/nix}/daemon-socket/socket"
+log="${RUNNER_TEMP:-/tmp}/nix-daemon.log"
+
+# `trusted-users` is read by the daemon at startup, so it has to be in place
+# before the daemon is launched. An untrusted client cannot select its own
+# substituters; the daemon's own configuration still applies, so the default
+# cache.nixos.org keeps working either way and this repository's flake carries
+# no `nixConfig` block that would need honouring. Appended rather than passed
+# through the action's `nix_conf` input because that input is documented to
+# write this very file, and whether it replaces or merges the defaults the
+# action itself sets (experimental-features, accept-flake-config) is not
+# specified — appending cannot clobber them.
+conf="${XDG_CONFIG_HOME:-$HOME/.config}/nix/nix.conf"
+mkdir -p "$(dirname "$conf")"
+if ! grep -q '^trusted-users' "$conf" 2>/dev/null; then
+    echo "trusted-users = root $(id -un)" >>"$conf"
+fi
+
+if [ -S "$socket" ]; then
+    echo "nix-daemon is already listening at $socket"
+else
+    mkdir -p "$(dirname "$socket")"
+
+    # `nix-daemon` is the stable spelling; `nix daemon` is the new-CLI one and
+    # needs the nix-command experimental feature. Prefer the former.
+    if command -v nix-daemon >/dev/null 2>&1; then
+        daemon=(nix-daemon)
+    else
+        daemon=(nix daemon)
+    fi
+
+    # Output goes to a file, never to the step's stdout: a backgrounded child
+    # holding that pipe open can keep the step from ever completing.
+    nohup "${daemon[@]}" >"$log" 2>&1 &
+
+    for _ in $(seq 100); do
+        [ -S "$socket" ] && break
+        sleep 0.2
+    done
+fi
+
+if [ ! -S "$socket" ]; then
+    echo "nix-daemon did not create $socket within 20s. Daemon log:" >&2
+    cat "$log" >&2 || true
+    exit 1
+fi
+
+# Every later step in this job talks to the daemon rather than the store.
+echo "NIX_REMOTE=daemon" >>"${GITHUB_ENV:-/dev/null}"
+export NIX_REMOTE=daemon
+
+# Proof that the client actually reached the daemon rather than silently
+# falling back to the local store: this prints `Store URL: daemon`. Kept
+# non-fatal so an older nix without `nix store info` cannot fail the step.
+nix store info || nix store ping || true


### PR DESCRIPTION
Draft — an alternative to #318, for evaluation rather than merge as-is.

## Why

CI installs Nix single-user (`nixbuild/nix-quick-install-action` — its README lists "Single-user installation (no `nix-daemon`)" as a feature), so nothing serialises store access. Every `nix` process opens `/nix/var/nix/db/db.sqlite` itself and takes the SQLite write lock directly. The `build` and `wasm` jobs deliberately fan out into concurrent `nix develop` steps, so they contend, and SQLite hands the loser `SQLITE_BUSY` immediately rather than waiting out the busy timeout. Nix turns that into a fatal `error: SQLite database '/nix/var/nix/db/db.sqlite' is busy` and the step dies.

#318 recovers from this after the fact by retrying. A daemon removes it at the source: with `NIX_REMOTE=daemon` every store operation is funnelled through one process that serialises database access internally.

## What this does

`scripts/start-nix-daemon.bash`, run as an ordinary step in `build` and `wasm` before any other nix command:

- Appends `trusted-users` to the user `nix.conf` *before* launching, since the daemon reads it at startup.
- Starts the daemon with `nohup` and output redirected to a file, then polls for the socket.
- Exports `NIX_REMOTE=daemon` via `$GITHUB_ENV` only once the socket exists, so a daemon that fails to come up fails the step loudly with its log instead of letting the job silently fall back to the local store.
- Prints `nix store info` as proof the client actually reached the daemon (`Store URL: daemon`).

Deliberately **not** a `background: true` step: those are joined by the `wait:` barriers and are expected to terminate, and a daemon never does. Backgrounded inside a normal step it becomes an orphan the runner reaps at job end — already how sccache behaves in these jobs.

## Open questions to settle before this is mergeable

1. **Is the client trusted?** `trusted-users` defaults to `root`. Whether a client is auto-trusted when it shares a UID with a non-root daemon is a code-level detail I could not confirm from the docs, so the script sets it explicitly rather than relying on it. Worth confirming the setting is actually taking effect. The usual symptom of an untrusted client is losing flake-supplied substituters — not applicable here, since `flake.nix` has no `nixConfig` block and the daemon's own config still provides cache.nixos.org.
2. **`nix_conf` semantics.** The input is documented to write `XDG_CONFIG_HOME/nix/nix.conf`, but whether it replaces or merges the defaults the action sets there (`experimental-features`, `accept-flake-config`) is unspecified. The script appends to that file for exactly this reason — if it turns out to merge, passing the input directly would be tidier.
3. **`cache-nix-action`'s post step** runs with the daemon still alive. Needs watching.
4. **The eval cache still contends.** `~/.cache/nix/eval-cache-v6/*.sqlite` is client-side, not daemon-mediated, so `error (ignored): ...eval-cache... is busy` will keep appearing. It is non-fatal, so no loss — but a daemon is not a total cleanup.

## How to evaluate

Stacked on #318 on purpose. The retry wrapper logs a line whenever it fires, so **a green run with no `nix-develop.bash: Nix store is locked` line is evidence the daemon absorbed the contention on its own** — at which point the wrapper could be reverted and this kept, or kept as a cheap backstop. Check the `Start nix-daemon` step for `Store URL: daemon` to confirm the daemon is genuinely in use.

Until #318 merges this diff shows both commits; afterwards only `afe611f`.

## The alternative worth weighing

`nix-quick-install-action`'s own README says that for daemon mode you "should probably use the Install Nix action instead, which sets up Nix in multi-user mode (daemon mode) using the official Nix installer." That is a one-line swap that configures `trusted-users` properly and manages the daemon under systemd, so it removes open question 1 entirely rather than leaving it to be tested around. The costs are install time (the action advertises ≈1s on Linux) and confirming `cache-nix-action` still behaves, since it is built around the quick-install action. If the daemon idea proves out, that route is probably the better long-term shape.

## Testing

Verified against a stubbed `nix-daemon`: happy path exports `NIX_REMOTE` and reports `Store URL: daemon`; the step returns promptly without the backgrounded daemon holding its stdout pipe open; re-running is idempotent (socket detected, `nix.conf` not duplicated); and a daemon that never creates the socket fails the step with its log. There is no nix in the dev container, so **CI on this PR is the first real test.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcLM2jf7TikTUFjqCS4A8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcLM2jf7TikTUFjqCS4A8T)_