### PR TITLE
Track the BGM position from the clock, not from the decoder

### DIFF
--- a/changelog.d/bgm-position-without-decoder-poll.fixed.md
+++ b/changelog.d/bgm-position-without-decoder-poll.fixed.md
@@ -1,0 +1,10 @@
+- RPG Maker 2000 games with MIDI music no longer crawl. The runtime polls the
+  BGM's playback position every frame to answer the *"BGM played once"*
+  conditional branch, and `Mix_GetMusicPosition` is not a cheap getter: measured
+  against SDL_mixer's MIDI decoder it took **1–3 seconds** to return — and then
+  returned "unsupported" anyway, so the poll bought nothing. Nepheshel's opening
+  ran at **0.5–5 frames a second**; it now holds 15–23. The position is tracked
+  from the clock instead (the track's start time and its duration, asked for
+  once per track), which is all the loop detection needs, and a stream whose
+  length the decoder cannot report reads as position 0 throughout — the same
+  answer a backend with no position support already gave.

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -51,6 +51,19 @@ std::string g_bgm_path;
 int g_bgm_volume = 100;
 bool g_me_active = false;  // an ME is playing over the (suspended) BGM
 
+// Playback position of the music stream, tracked from the clock rather than
+// asked of the decoder. Mix_GetMusicPosition is not a cheap getter: on the MIDI
+// decoder it costs *hundreds of milliseconds* a call, and the RPG2000 runtime
+// polls the position every frame to answer the "BGM played once" branch, which
+// dragged Nepheshel's opening (135 .mid tracks) from 60 frames a second to
+// under two. The only consumer is that loop detection, which needs no more than
+// a value that wraps when the track restarts -- so the start time plus the
+// track's duration answers it for free. Zero duration (an unknown-length
+// stream) reports position 0 throughout, exactly as a backend that cannot
+// report a position does.
+Uint64 g_music_start_ms = 0;
+int g_music_duration_ms = 0;
+
 // Loaded SE / BGS samples, keyed by path so repeated plays don't re-decode.
 std::unordered_map<std::string, Mix_Chunk*> g_chunks;
 
@@ -98,6 +111,15 @@ bool play_music(const std::string& path, int volume, int loops) {
                  << "': " << Mix_GetError();
     return false;
   }
+  // Start the clock this stream's position is read off (see g_music_start_ms).
+  // The duration is asked for once per track here, not once per frame.
+  g_music_start_ms = SDL_GetTicks64();
+  g_music_duration_ms = 0;
+#if defined(SDL_MIXER_VERSION_ATLEAST) && SDL_MIXER_VERSION_ATLEAST(2, 6, 0)
+  const double seconds = Mix_MusicDuration(g_music);
+  if (seconds > 0.0)
+    g_music_duration_ms = (int)(seconds * 1000.0);
+#endif
   return true;
 }
 
@@ -128,15 +150,13 @@ void bgm_fade(int ms) {
     Mix_FadeOutMusic(ms);
 }
 
+// Milliseconds into the current BGM, wrapping every time the loop restarts.
+// Read from the clock, not from the decoder -- see g_music_start_ms.
 int bgm_pos(void) {
-#if defined(SDL_MIXER_VERSION_ATLEAST) && SDL_MIXER_VERSION_ATLEAST(2, 6, 0)
-  if (g_music && !g_me_active) {
-    double sec = Mix_GetMusicPosition(g_music);
-    if (sec >= 0.0)
-      return (int)(sec * 1000.0);
-  }
-#endif
-  return 0;
+  if (!g_music || g_me_active || !g_bgm_valid || g_music_duration_ms <= 0)
+    return 0;
+  const Uint64 elapsed = SDL_GetTicks64() - g_music_start_ms;
+  return (int)(elapsed % (Uint64)g_music_duration_ms);
 }
 
 // -- BGS --------------------------------------------------------------------


### PR DESCRIPTION
RPG2000's *"BGM played once"* conditional branch is answered by watching the
music's playback position, which `Scene::Map#watch_bgm_loop` polls every frame.
That poll went straight into `Mix_GetMusicPosition` — and on SDL_mixer's MIDI
decoder that call takes **1–3 seconds** to return, then returns `-1`
("unsupported"), so sixty calls a second bought exactly nothing.

Nepheshel is 135 `.mid` tracks. Its opening ran at **0.5–5 frames a second**,
with 92–99% of every frame inside that one getter.

### Measurement

`--profile`, driving the opening with the same key script both times:

```
before   fps: 60 60 60 60 | 3.6 22.5 22.6 22.0 21.6 7.5 5.3 1.1 5.4 2.1 2.8 3.2 3.7 2.2 3.0
after    fps: 60 60 60 60 | 3.8 22.4 22.6 22.8 22.4 21.9 22.3 23.0 22.6 19.2 19.2 15.0 15.8 17.2 18.3

before   u.bgm avg=417.22ms max=848.47ms  (94% of the frame)
after    u.bgm avg=0.02ms
```

and, logged directly from the backend:

```
Mix_MusicDuration('.../Music/op.mid')  = -1s
Mix_GetMusicPosition -> -1s in 1016ms
Mix_GetMusicPosition -> -1s in 3057ms
```

### The change

`play_music` records when the stream started and asks for its duration once;
`bgm_pos` returns the elapsed time modulo that duration. Loop detection only
needs a value that wraps when the track restarts, which this gives exactly, with
no call into the mixer on the per-frame path. A stream whose length the decoder
will not report reads as position 0 throughout — the same answer the old path
produced for MIDI, minus the seconds.

The remaining ~22 fps ceiling on this map is unrelated: it is the per-tile Ruby
redraw in `draw_layers` (~19 ms a frame), which the XP scene has already moved
off onto the native `Tilemap`.

### Checks

- `cmake --build build -t test` — 3/3 passing.
- `scripts/rpg2k_boot_check.bash` — boots Nepheshel into the map.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Gfz65XQy51ZNZ2Vo1TwVn)_