### PR TITLE
Decode an LCF nested table once, not on every read

### DIFF
--- a/changelog.d/lcf-nested-table-decode-cache.fixed.md
+++ b/changelog.d/lcf-nested-table-decode-cache.fixed.md
@@ -1,0 +1,10 @@
+- Starting an RPG Maker 2000 game no longer freezes for seconds. An `LCF`
+  chunk holding a nested table (`:Array1D` / `:Array2D`) was re-parsed in full on
+  *every* read, and the runtime reads the same ones over and over: building the
+  party alone asks for `db.item` thirty times — `Game::Actor#equip_bonus`, six
+  stats across five equipment slots — so New Game on Nepheshel spent **7.7
+  seconds** inside one `recompute_stats`, in a single blocked frame. Nested
+  tables are now decoded once and kept (and dropped again when the chunk under
+  them is rewritten or deleted), which takes that frame to 0.5 s and the whole
+  transition second from 3.8 to 28.7 frames a second. Scalars and strings are
+  still decoded per read, so callers keep getting their own object.

--- a/mruby-lcf/mrblib/lcf.rb
+++ b/mruby-lcf/mrblib/lcf.rb
@@ -436,8 +436,24 @@ module LCF
 
     attr_reader :schema
 
+    # Decode a chunk to its Ruby value. Nested tables are decoded once and kept:
+    # a :Array1D / :Array2D chunk re-parses its *whole* table on every read, and
+    # the runtime asks for the same one over and over -- building a party alone
+    # reads `db.item` thirty times (Game::Actor#equip_bonus, six stats over five
+    # equipment slots), which cost 7.7 seconds on Nepheshel's database. Only the
+    # container types are cached: they are read-only to callers (Array1D exposes
+    # no field writers), where a scalar or String decode is cheap and handing out
+    # the same mutable object would change what a caller can do with it. The two
+    # writers below, #[]= and #delete, drop the cached decode with the bytes.
     def [] idx
-      LCF.to_rb @data[idx], @schema[:elements][idx]
+      cached = @decoded && @decoded[idx]
+      return cached if cached
+      value = LCF.to_rb @data[idx], @schema[:elements][idx]
+      if value.is_a?(Array1D) || value.is_a?(Array2D)
+        @decoded ||= {}
+        @decoded[idx] = value
+      end
+      value
     end
 
     # True when a chunk with this id was physically present in the file, before
@@ -466,6 +482,7 @@ module LCF
     def delete idx
       was = @data[idx]
       @data[idx] = nil
+      @decoded.delete(idx) if @decoded
       was
     end
 
@@ -481,6 +498,7 @@ module LCF
       else
         raise "cannot encode chunk #{idx} without a schema"
       end
+      @decoded.delete(idx) if @decoded
       value
     end
 

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -489,6 +489,27 @@ assert 'Array1D#[]= re-encodes int and string fields through the schema' do
   assert_equal "newchr", reread.charset_name
 end
 
+assert 'Array1D hands out one decoded nested table, and re-decodes after a write' do
+  # Decoding a nested table re-parses the whole thing, and the runtime asks for
+  # the same one over and over (Game::Actor#equip_bonus reads db.item thirty
+  # times to build a party), so a container decode is kept. It must still be
+  # dropped when the chunk underneath is rewritten or removed.
+  learning = lcf_array2d([[1, lcf_array1d([lcf_int_field(1, 3)])]])
+  schema = { elements: LCF::Schema::DATABASE[:elements][11][:elements] }
+  a = LCF::Array1D.new(lcf_array1d([lcf_field(63, learning)]), schema)
+  first = a[63]
+  assert_true first.is_a?(LCF::Array2D)
+  assert_true first.equal?(a[63]), "a nested table must be decoded once"
+  # A scalar is cheap to decode and is not cached, so callers still get their
+  # own object to do as they like with.
+  a[63] = LCF::Array2D.new(lcf_array2d([[2, lcf_array1d([lcf_int_field(1, 9)])]]),
+                           schema[:elements][63])
+  assert_false first.equal?(a[63]), "a rewritten chunk must decode afresh"
+  assert_nil a[63][1]
+  a.delete 63
+  assert_nil a[63]
+end
+
 assert 'Array2D#to_lcf reproduces its source bytes' do
   e1 = lcf_array1d([lcf_int_field(31, 1)])
   e3 = lcf_array1d([lcf_int_field(31, 5), lcf_int_field(32, 307)])


### PR DESCRIPTION
`LCF::Array1D#[]` decoded its chunk on every access, and for the container types
that means re-parsing the whole table. The runtime asks for the same tables
constantly: `Game::Actor#equip_bonus` reads `db.item` once per equipment slot per
stat, so building a two-actor party asks thirty times.

On Nepheshel's database that is ~256 ms a call. **New Game spent 7.7 seconds
inside one `recompute_stats`**, in a single frame — with no input pumped, so from
the outside it looks exactly like a keypress that went missing.

### Measurement

`--profile`, selecting New Game on Nepheshel (the second containing the
transition):

```
before   fps=3.8   frame(work) avg=243ms  max=7781ms
after    fps=28.7  frame(work) avg=18.6ms max=530ms
```

narrowed down section by section: `n.party` 7,757 ms → `a.level` 7,747 ms →
`l.stats` 7,684 ms → `e.tbl` (`@db.item`) avg 256 ms × 30 calls.

### The change

Nested tables (`:Array1D` / `:Array2D`) are decoded once per chunk and kept. They
are read-only to callers — `Array1D` exposes no field writers — and the two
writers that do exist, `#[]=` and `#delete`, drop the cached decode along with
the bytes. Scalars and strings stay per-read: decoding them is cheap, and handing
out one shared mutable object would change what a caller may do with it.

### Checks

- `cmake --build build -t test` — 3/3 passing, including a new check that the
  nested decode is shared and that a write drops it. I verified that check is
  real by removing the invalidation and watching it fail:
  `Assertion[3] a rewritten chunk must decode afresh. Expected true to be false.`
- `ruby scripts/lcf_testbed_check.rb` — all test-bed data parses cleanly.
- `ruby scripts/rpg2k_logic_check.rb` (342), `rpg2k_scene_check.rb` (105),
  `rpg2k_render_check.rb` (36) — all passing.
- `scripts/rpg2k_boot_check.bash` and `scripts/rpgxp_boot_check.bash` — both boot
  into the map.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Gfz65XQy51ZNZ2Vo1TwVn)_