### PR TITLE
Retry the external clones CI fetches its test beds with

### DIFF
--- a/changelog.d/ci-retry-external-clones.fixed.md
+++ b/changelog.d/ci-retry-external-clones.fixed.md
@@ -1,0 +1,14 @@
+- CI: the external test-bed / corescript **clones are retried** instead of
+  failing a job outright. `scripts/git-clone-retry.bash` wraps `git clone` with
+  four attempts and an exponential backoff, clearing the partial directory a
+  failed attempt leaves behind so the retry actually re-fetches rather than
+  dying on "already exists and is not an empty directory". The five scripts that
+  clone from an external host use it (`download-opengame-xp`,
+  `download-mv-corescript`, `download-mz-corescript`, `download-lunatic-core`,
+  `download-mtf-meido-action`). These run as `background: true` steps, so one
+  hiccup at the far end used to take a whole job down *before the compiler had
+  run at all* — it reads as a build failure and is not one; two different hosts
+  were seen doing it in the same evening. `wget` already retries on its own
+  (20 attempts by default), which is why only the clones needed this. Same shape
+  as `scripts/nix-develop.bash`: recover from a known transient failure where it
+  happens, rather than weakening the CI gate around it.

--- a/scripts/download-lunatic-core.bash
+++ b/scripts/download-lunatic-core.bash
@@ -2,6 +2,9 @@
 
 set -eux -o pipefail
 
+# Retried because these external clones fail intermittently in CI.
+. "$(dirname "$0")/git-clone-retry.bash"
+
 # Fetch a small, complete RPG Maker MV project to use as a test bed for the
 # JavaScript-maker (MV) support. KinoAR/Lunatic-Core ships the full MV
 # corescript (js/rpg_*.js + js/libs/pixi.js), a data/*.json database and img/
@@ -15,6 +18,6 @@ mkdir -p "$(dirname "$0")/../data"
 cd "$(dirname "$0")/../data"
 
 if [ ! -d Lunatic-Core ]; then
-    git clone --quiet --depth 1 https://github.com/KinoAR/Lunatic-Core.git \
+    clone_retry --quiet --depth 1 https://github.com/KinoAR/Lunatic-Core.git \
         Lunatic-Core
 fi

--- a/scripts/download-mtf-meido-action.bash
+++ b/scripts/download-mtf-meido-action.bash
@@ -8,12 +8,15 @@
 
 set -eux -o pipefail
 
+# Retried because these external clones fail intermittently in CI.
+. "$(dirname "$0")/git-clone-retry.bash"
+
 mkdir -p $(dirname $0)/../data
 
 cd $(dirname $0)/../data
 
 if [ ! -d mtf-meido-action ] ; then
-    git clone --quiet --depth 1 --filter=blob:none --sparse \
+    clone_retry --quiet --depth 1 --filter=blob:none --sparse \
         https://github.com/lychees/mtf-meido-action.git
     git -C mtf-meido-action sparse-checkout set Debug
 fi

--- a/scripts/download-mv-corescript.bash
+++ b/scripts/download-mv-corescript.bash
@@ -2,6 +2,9 @@
 
 set -eux -o pipefail
 
+# Retried because these external clones fail intermittently in CI.
+. "$(dirname "$0")/git-clone-retry.bash"
+
 # Fetch the MIT-licensed community RPG Maker MV corescript and build the engine
 # files into the committed sample project (data/mv-sample). The sample commits
 # only our authored data + shell; the engine (js/rpg_core.js ... and js/libs/*)
@@ -18,7 +21,7 @@ sample="$here/data/mv-sample"
 cache="$here/data/.mv-corescript"
 
 if [ ! -d "$cache" ]; then
-    git clone --quiet --depth 1 https://github.com/rpgtkoolmv/corescript.git "$cache"
+    clone_retry --quiet --depth 1 https://github.com/rpgtkoolmv/corescript.git "$cache"
 fi
 
 mkdir -p "$sample/js/libs"

--- a/scripts/download-mz-corescript.bash
+++ b/scripts/download-mz-corescript.bash
@@ -2,6 +2,9 @@
 
 set -eux -o pipefail
 
+# Retried because these external clones fail intermittently in CI.
+. "$(dirname "$0")/git-clone-retry.bash"
+
 # Fetch the RPG Maker MZ corescript (rmmz_*.js + libs/pixi.js ...) into the
 # committed sample project (data/mz-sample). The sample commits only our
 # authored data + shell; the engine is fetched here so it is never redistributed
@@ -20,7 +23,7 @@ sample="$here/data/mz-sample"
 cache="$here/data/.mz-corescript"
 
 if [ ! -d "$cache" ]; then
-    git clone --quiet --depth 1 https://github.com/stak/rmmz-corescript.git "$cache"
+    clone_retry --quiet --depth 1 https://github.com/stak/rmmz-corescript.git "$cache"
 fi
 
 mkdir -p "$sample/js/libs"

--- a/scripts/download-opengame-xp.bash
+++ b/scripts/download-opengame-xp.bash
@@ -8,12 +8,15 @@
 
 set -eux -o pipefail
 
+# Retried because these external clones fail intermittently in CI.
+. "$(dirname "$0")/git-clone-retry.bash"
+
 mkdir -p $(dirname $0)/../data
 
 cd $(dirname $0)/../data
 
 if [ ! -d OpenGame.exe ] ; then
-    git clone --quiet --depth 1 --filter=blob:none --sparse \
+    clone_retry --quiet --depth 1 --filter=blob:none --sparse \
         https://github.com/aphadeon/OpenGame.exe.git
     git -C OpenGame.exe sparse-checkout set Testbed/XP
 fi

--- a/scripts/git-clone-retry.bash
+++ b/scripts/git-clone-retry.bash
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# `git clone`, retried when it fails.
+#
+# Source this and call `clone_retry` with the arguments you would have given
+# `git clone`.
+#
+# Several CI jobs fetch a test-bed game or an engine corescript from an external
+# host, and those clones fail intermittently — not because anything is wrong
+# with the repository or the checkout, but because the far end (or the runner's
+# egress) hiccups for a moment. In the `wasm` job these fetches run as
+# `background: true` steps, so a single failed clone takes the whole job down
+# with it *before the compiler has run at all*, which reads like a build
+# failure and is not one. Two different hosts have done it:
+#
+#   * github.com/aphadeon/OpenGame.exe   (scripts/download-opengame-xp.bash)
+#   * github.com/rpgtkoolmv/corescript   (scripts/download-mv-corescript.bash)
+#
+# `wget` already retries on its own (20 attempts by default), so the archive
+# downloads never needed this; `git clone` does not retry at all, which is why
+# only the clones have been seen to fail.
+#
+# This is the same shape as scripts/nix-develop.bash, which retries the SQLite
+# lock contention that job parallelism provokes: recover from a known transient
+# failure at the point it happens rather than weakening the CI gate around it.
+# Every caller clones into a directory it has just checked does not exist, so a
+# repeat attempt costs nothing.
+
+# The directory `git clone` would create for these arguments: the last
+# non-option argument, or — when that is the URL, because no destination was
+# given — the URL's last path segment without its `.git` suffix. Used to clear a
+# partial clone before retrying.
+clone_target() {
+    local last='' arg
+    for arg in "$@"; do
+        case "$arg" in
+        -*) ;;
+        *) last="$arg" ;;
+        esac
+    done
+    case "$last" in
+    *://* | *@*:*)
+        last="${last##*/}"
+        printf '%s\n' "${last%.git}"
+        ;;
+    *) printf '%s\n' "$last" ;;
+    esac
+}
+
+# Attempts and the initial backoff are read here rather than at source time, so
+# a caller (or a test) can override them per invocation.
+clone_retry() {
+    local attempts=${GIT_CLONE_ATTEMPTS:-4}
+    local delay=${GIT_CLONE_RETRY_DELAY:-5}
+    local target attempt=1
+    target="$(clone_target "$@")"
+    while :; do
+        if git clone "$@"; then
+            return 0
+        fi
+        if [ "$attempt" -ge "$attempts" ]; then
+            echo "git clone failed after $attempts attempts: $*" >&2
+            return 1
+        fi
+        # A failed clone can leave a partial directory behind. Without clearing
+        # it the next attempt dies with "already exists and is not an empty
+        # directory" instead of actually retrying the fetch.
+        if [ -n "$target" ] && [ -e "$target" ]; then
+            rm -rf -- "$target"
+        fi
+        echo "git clone attempt $attempt/$attempts failed;" \
+            "retrying in ${delay}s: $*" >&2
+        sleep "$delay"
+        delay=$((delay * 2))
+        attempt=$((attempt + 1))
+    done
+}


### PR DESCRIPTION
Several jobs fetch a test-bed game or an engine corescript from an external host as a `background: true` step. Those clones fail intermittently — the far end (or the runner's egress) hiccups — and a single failure takes the **whole job** down with it *before the compiler has run at all*. It reads as a build failure and is not one.

Two different hosts did it in one evening, both in the `wasm` job, both after cmake configure and before any ninja build:

| PR | Failing step | Host |
| --- | --- | --- |
| #310 | `Download the RPG XP test bed` | `github.com/aphadeon/OpenGame.exe` |
| #319 | `Build MV sample engine` | `github.com/rpgtkoolmv/corescript` |

On #319 the XP test bed succeeded while the corescript failed, so this is not one bad URL — it is the unguarded pattern.

## The change

`scripts/git-clone-retry.bash` wraps `git clone` with four attempts and an exponential backoff. The five scripts that clone from an external host source it and call `clone_retry` in place of `git clone`:

- `download-opengame-xp.bash`
- `download-mv-corescript.bash`
- `download-mz-corescript.bash`
- `download-lunatic-core.bash`
- `download-mtf-meido-action.bash`

A failed clone can leave a partial directory behind, so the helper clears it between attempts — otherwise the retry dies on *"already exists and is not an empty directory"* instead of actually re-fetching.

`wget` already retries on its own (20 attempts by default), which is why only the clones have been seen to fail; the archive downloads are untouched.

## Why this rather than `continue-on-error`

The obvious alternative is to mark the download steps `continue-on-error: true`, which is what I first suggested on #310. On reflection that is the worse fix: `Build MV sample engine` feeds `WASM_SAMPLE_DIR`, so swallowing its failure would ship a page whose one-click sample preset is missing its engine — a silent, user-visible regression traded for a green tick.

Retrying instead addresses the actual cause (a transient fetch) and keeps every gate intact. It is also the shape the repo already uses: `scripts/nix-develop.bash` retries the SQLite lock contention that job parallelism provokes, for the same reason — recover from a known transient failure at the point it happens rather than weakening the CI gate around it. Every caller clones into a directory it has just checked does not exist, so a repeat attempt costs nothing.

## Verification

`bash -n` on every touched script, plus a behavioural test of the helper against a stub `git` on `PATH`:

- `clone_target` derives the right directory in all three calling shapes — explicit destination, no destination (derived from the URL, e.g. `OpenGame.exe.git` → `OpenGame.exe`), and an absolute cache path.
- A clone that fails twice then succeeds is retried exactly 3 times and lands its content, with the partial directory from the failed attempts cleared beforehand.
- Exhausting the attempts returns non-zero rather than looping, and makes exactly the configured number of attempts.

That test caught a real bug before it shipped: `GIT_CLONE_ATTEMPTS` / `GIT_CLONE_RETRY_DELAY` were read at *source* time, so they could not be overridden per call. They are read inside the function now.

The end-to-end path is also checked — running a download script from two different working directories confirms `. "$(dirname "$0")/git-clone-retry.bash"` resolves before the script `cd`s away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_