### PR TITLE
Resolve all-target battle skills and items (all-enemy / all-ally / all-party)

### DIFF
--- a/changelog.d/rpg2k-battle-all-party-items.added.md
+++ b/changelog.d/rpg2k-battle-all-party-items.added.md
@@ -1,0 +1,10 @@
+- RPG Maker 2000: battle **items can now target the whole party** (item scope 1).
+  `Game::Battle#command_item_all` queues a volley of per-member recoveries reusing
+  the all-target machinery, so an all-party potion / antidote heals HP / SP and
+  cures status from every living ally in one action — and a single item is
+  consumed for the volley (only the first hit carries `item_id`, so the scene's
+  per-entry bag deduction fires once). `Game::Party#item_all_allies?` flags a
+  scope-1 medicine, and the battle item menu casts it on the whole party without a
+  target prompt. Covered by new `scripts/rpg2k_logic_check.rb` checks (every ally
+  is healed for one consumed item, a party antidote cures each afflicted member
+  while leaving other statuses, and the scope flag is read).

--- a/changelog.d/rpg2k-battle-all-target-skills.added.md
+++ b/changelog.d/rpg2k-battle-all-target-skills.added.md
@@ -1,0 +1,14 @@
+- RPG Maker 2000: battle skills can now target **all enemies (scope 1)** or **all
+  allies (scope 4)**. `Game::Battle#command_skill_all` queues a volley — a list of
+  per-target `{ target, hp, mp }` effects (attack damage still varies with each
+  target's defence) — and `apply_command` spends the caster's SP once, then
+  applies the shared effect / infliction to every living target, producing one
+  log entry per hit. A new pending-hit buffer lets `#step` / `#step_action`
+  surface those hits one at a time, so the battle screen animates the volley
+  target by target; a volley skips foes already down and fizzles (no SP spent)
+  when every target has fallen. The battle menu now offers all-target skills
+  (`BATTLE_SKILL_SCOPES` gained 1 and 4) and casts them without a target prompt.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks (an all-enemy volley hits
+  every foe for one SP charge, an all-ally heal restores each member, downed
+  targets are skipped, an all-dead volley fizzles, and `run_round` surfaces every
+  hit). All-target *items* remain a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -400,9 +400,11 @@ The work below is roughly ordered by the critical path to a walkable game
   skill resolves against every living target in one action — `command_skill_all`
   spends the SP once and `apply_command` produces one log entry per target,
   buffered so the screen animates the volley hit by hit — with attack damage
-  still computed per target's defence. Still to come: enemy-cast infliction,
-  all-target *items*, per-attribute rate overrides from the Attribute table, the
-  per-terrain backdrop and the RPG2000 Game Over graphic.
+  still computed per target's defence. **All-party items** (medicine scope 1)
+  work the same way through `command_item_all`, healing / curing every living
+  ally and consuming a single item for the whole volley. Still to come:
+  enemy-cast infliction, per-attribute rate overrides from the Attribute table,
+  the per-terrain backdrop and the RPG2000 Game Over graphic.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -395,10 +395,14 @@ The work below is roughly ordered by the critical path to a walkable game
   (RPG2000's A..E table 100/80/60/30/0 percent), so a resistant foe shrugs it
   off and an immune one never catches it. A **pre-emptive first strike** (the
   Enemy Encounter's first-strike flag) gives the party a free opening round —
-  the ambushed enemies skip their turn in round 1 and rejoin from round 2. Still
-  to come: enemy-cast infliction, all-target skill/item scopes, per-attribute
-  rate overrides from the Attribute table, the per-terrain backdrop and the
-  RPG2000 Game Over graphic.
+  the ambushed enemies skip their turn in round 1 and rejoin from round 2.
+  **All-target skills** work too: a scope-1 (all enemies) or scope-4 (all allies)
+  skill resolves against every living target in one action — `command_skill_all`
+  spends the SP once and `apply_command` produces one log entry per target,
+  buffered so the screen animates the volley hit by hit — with attack damage
+  still computed per target's defence. Still to come: enemy-cast infliction,
+  all-target *items*, per-attribute rate overrides from the Attribute table, the
+  per-terrain backdrop and the RPG2000 Game Over graphic.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2022,6 +2022,13 @@ module Game
       hp, mp = item_recovery(it, target)
       { hp: hp, mp: mp, cured: item_cured_states(it) }
     end
+
+    # Whether medicine `it` targets the whole party (item scope 1) rather than a
+    # single ally (scope 0). The battle menu casts an all-party item on every
+    # living member at once, skipping target selection.
+    def item_all_allies?(it)
+      it.respond_to?(:scope) && it.scope == 1
+    end
   end
 
   # A loaded map (.lmu) plus convenience accessors for the two tile layers.
@@ -3484,6 +3491,17 @@ module Game
       ally.action = nil; ally.defending = false
     end
 
+    # Queue an all-ally Item for `ally` (an item scope 1, the whole party):
+    # `targets` is a list of per-member `{ target:, hp:, mp: }` recoveries. The
+    # shared `cured` states apply to each. One item is consumed for the volley
+    # (only the first produced entry carries `item_id`, so the scene's per-entry
+    # bag deduction fires once).
+    def command_item_all(ally, targets, item_id:, name:, cured: nil)
+      ally.command = { kind: :item, all: true, item_id: item_id, targets: targets,
+                       name: name, cured: cured || [] }
+      ally.action = nil; ally.defending = false
+    end
+
     # Execute one full round — living battlers act in agility order, allies using
     # their assigned action, enemies attacking a random party member — and return
     # the round's log entries. Ally commands are cleared afterwards for the next
@@ -3758,7 +3776,11 @@ module Game
       live = (cmd[:targets] || []).select { |t| t[:target] && !t[:target].dead? }
       return nil if live.empty?
       b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
-      live.map { |t| apply_skill_hit(b, t[:target], t[:hp] || 0, t[:mp] || 0, cmd) }
+      entries = live.map { |t| apply_skill_hit(b, t[:target], t[:hp] || 0, t[:mp] || 0, cmd) }
+      # An all-ally item is consumed once for the whole volley: keep item_id on
+      # the first hit only, so the scene's per-entry bag deduction fires once.
+      entries.each_with_index { |e, i| e[:item_id] = nil unless i.zero? } if cmd[:item_id]
+      entries
     end
 
     # Apply one skill / item effect from `b` to `target`: a negative `hp` is an

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1919,9 +1919,9 @@ module Game
     # all-target scopes (1 all enemies, 4 all allies) and the battle SP / damage
     # variance are later refinements.
 
-    # Single-target battle skill scopes: 0 single enemy, 2 the caster, 3 a single
-    # ally. (1 all enemies and 4 all allies are deferred.)
-    BATTLE_SKILL_SCOPES = [0, 2, 3].freeze
+    # Battle skill scopes the menu offers: 0 single enemy, 1 all enemies, 2 the
+    # caster, 3 a single ally, 4 all allies.
+    BATTLE_SKILL_SCOPES = [0, 1, 2, 3, 4].freeze
 
     # `actor`'s known normal skills usable in battle — flagged `occasion_battle`
     # with a single-target scope — as `[skill_id, cost]` pairs in ascending id
@@ -1941,11 +1941,14 @@ module Game
       sk.respond_to?(:occasion_battle) ? sk.occasion_battle : true
     end
 
-    # Whom a battle skill targets: :enemy (scope 0), :self (scope 2) or :ally (3).
+    # Whom a battle skill targets: :enemy (scope 0), :all_enemy (1), :self (2),
+    # :all_ally (4) or a single :ally (3, the default).
     def battle_skill_target(sk)
       case sk.scope
       when 0 then :enemy
+      when 1 then :all_enemy
       when 2 then :self
+      when 4 then :all_ally
       else :ally
       end
     end
@@ -1981,7 +1984,7 @@ module Game
     def battle_skill_command(sk, caster, target)
       cost = skill_cost(sk, caster)
       base = skill_effect(sk, caster)
-      if sk.scope == 0
+      if sk.scope == 0 || sk.scope == 1 # single or all enemies: an attack skill
         dmg = base - (target ? target.def / 4 : 0)
         dmg = 1 if dmg < 1
         { cost: cost, hp: -dmg, mp: 0,
@@ -3260,6 +3263,7 @@ module Game
       @escape_chance = nil # lazily computed from agilities on the first attempt
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
+      @pending = []  # extra hits of an all-target action, drained one per #step
     end
 
     # RPG2000 normal-attack damage variance on the 0-10 `var` scale.
@@ -3336,6 +3340,7 @@ module Game
     # battle is already decided (or has hit the round cap). Living battlers act
     # in agility order; a new round refills the queue.
     def step
+      return @pending.shift unless @pending.empty?
       loop do
         return nil if finished?
         refill_queue if @queue.empty?
@@ -3344,11 +3349,24 @@ module Game
         next if b.dead?
         can_act = apply_turn_states(b)
         next if b.dead? || !can_act
-        entry = strike(b)
+        entry = record_action(strike(b))
         next unless entry # attacker had no living target; try the next
-        @log << entry
         return entry
       end
+    end
+
+    # Log the result of a battler's action and return its first entry, buffering
+    # the rest. A basic attack / single-target skill returns one entry; an
+    # all-target skill returns an array — every entry is logged now (the effects
+    # all landed at once) but surfaced one per #step so the screen animates them
+    # in turn. nil (no living target) passes straight through.
+    def record_action(result)
+      return nil if result.nil?
+      entries = result.is_a?(Array) ? result : [result]
+      return nil if entries.empty?
+      entries.each { |e| @log << e }
+      @pending.concat(entries[1..-1])
+      entries.first
     end
 
     # Step the fight to completion and return :victory, :defeat or (if the party
@@ -3441,6 +3459,21 @@ module Game
       ally.action = nil; ally.defending = false
     end
 
+    # Queue an all-target Skill for `ally` (scope 1 all enemies / 4 all allies):
+    # `targets` is a list of per-target `{ target:, hp:, mp: }` effects (the same
+    # signed HP / SP deltas #command_skill takes, one per target, since attack
+    # damage varies with each target's defence). The SP `cost` is spent once when
+    # the action resolves; the shared `inflict` / `chance` / `variance` /
+    # `attributes` apply to every target. #apply_command produces one log entry
+    # per living target, drained one at a time by #step_action.
+    def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
+                          variance: 0, attributes: nil)
+      ally.command = { kind: :skill, all: true, targets: targets, name: name,
+                       cost: cost, inflict: inflict || [], chance: chance,
+                       variance: variance, attributes: attributes || [] }
+      ally.action = nil; ally.defending = false
+    end
+
     # Queue a single-target Item for `ally` on `target`: restore the HP / SP and
     # cure the status conditions from Game::Party#battle_item_command. `item_id`
     # rides along on the log entry so the scene consumes one from the bag when the
@@ -3470,6 +3503,7 @@ module Game
     # action rather than applying it all at once (#run_round is just this three-
     # step sequence run to completion). Counts towards the MAX_ROUNDS cap.
     def begin_round
+      @pending = []
       refill_queue
     end
 
@@ -3479,6 +3513,7 @@ module Game
     # the caller then clears commands with #end_round and either shows the result
     # or asks for the next round. Unlike #step it never starts a new round.
     def step_action
+      return @pending.shift unless @pending.empty? # drain a buffered all-target hit
       loop do
         return nil if finished? || @queue.empty?
         b = @queue.shift
@@ -3488,9 +3523,8 @@ module Game
         # turn is skipped.
         can_act = apply_turn_states(b)
         next if b.dead? || !can_act
-        entry = strike(b)
+        entry = record_action(strike(b))
         next unless entry
-        @log << entry
         return entry
       end
     end
@@ -3709,11 +3743,30 @@ module Game
     # restores HP / SP clamped to the target's maxima and reads as a `recover`.
     def apply_command(b)
       cmd = b.command
+      return apply_command_all(b, cmd) if cmd[:all]
       target = cmd[:target]
       return nil if target.nil? || target.dead?
       b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
-      hp = cmd[:hp] || 0
-      mp = cmd[:mp] || 0
+      apply_skill_hit(b, target, cmd[:hp] || 0, cmd[:mp] || 0, cmd)
+    end
+
+    # An all-target Skill (scope 1 all enemies / 4 all allies): spend the SP once,
+    # then apply the per-target effect to every living target, returning one log
+    # entry per hit (which #step_action surfaces one at a time). Fizzles — nil, no
+    # SP spent — when every listed target has already fallen this round.
+    def apply_command_all(b, cmd)
+      live = (cmd[:targets] || []).select { |t| t[:target] && !t[:target].dead? }
+      return nil if live.empty?
+      b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
+      live.map { |t| apply_skill_hit(b, t[:target], t[:hp] || 0, t[:mp] || 0, cmd) }
+    end
+
+    # Apply one skill / item effect from `b` to `target`: a negative `hp` is an
+    # attack (elemental scaling, variance, then state infliction, reading as a
+    # `skill:` hit), a non-negative one restores HP / SP and cures states (reading
+    # as a `recover`). Returns the log entry. Shared by single- and all-target
+    # commands.
+    def apply_skill_hit(b, target, hp, mp, cmd)
       if hp < 0
         dmg = -hp
         # An elemental skill scales its damage by the target's resistance first

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2616,6 +2616,10 @@ class RPG2k
           @battle_ui[:target_i] = 0
           @battle_ui[:phase] = :target
           draw_battle_target
+        when :all_enemy
+          apply_pending_skill_all(living_foes)
+        when :all_ally
+          apply_pending_skill_all(living_allies)
         else # :ally
           @battle_ui[:ally_i] = 0
           @battle_ui[:phase] = :ally_target
@@ -2634,6 +2638,28 @@ class RPG2k
                                           inflict: c[:inflict], chance: c[:chance],
                                           variance: c[:variance] || 0,
                                           attributes: c[:attributes])
+        @battle_ui[:pending] = nil
+        @battle_ui[:phase] = :command
+        advance_actor
+      end
+
+      # Commit the pending all-target skill on every `targets` combatant (all
+      # living enemies for an attack skill, all living allies for a heal): build
+      # one per-target effect from the model (attack damage varies with each
+      # target's defence) and queue them as a single volley. The shared SP cost /
+      # infliction ride along once.
+      def apply_pending_skill_all(targets)
+        sk = @battle_ui[:pending][:sk]
+        meta = @state.party.battle_skill_command(sk, current_actor, targets.first)
+        effects = targets.map do |t|
+          c = @state.party.battle_skill_command(sk, current_actor, t)
+          { target: t, hp: c[:hp], mp: c[:mp] }
+        end
+        @battle_ui[:battle].command_skill_all(current_actor, effects,
+                                              name: sk.name, cost: meta[:cost],
+                                              inflict: meta[:inflict], chance: meta[:chance],
+                                              variance: meta[:variance] || 0,
+                                              attributes: meta[:attributes])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2690,9 +2690,13 @@ class RPG2k
           it = @state.party.db_item(item_id)
           @battle_ui[:pending] = { kind: :item, item_id: item_id, it: it }
           close_battle_item
-          @battle_ui[:ally_i] = 0
-          @battle_ui[:phase] = :ally_target
-          draw_battle_ally_target
+          if @state.party.item_all_allies?(it)
+            apply_pending_item_all(living_allies)
+          else
+            @battle_ui[:ally_i] = 0
+            @battle_ui[:phase] = :ally_target
+            draw_battle_ally_target
+          end
         elsif Input.trigger?(Input::B)
           close_battle_item
           @battle_ui[:phase] = :command
@@ -2739,6 +2743,23 @@ class RPG2k
                                          item_id: pending[:item_id],
                                          name: pending[:it].name,
                                          hp: c[:hp], mp: c[:mp], cured: c[:cured])
+        @battle_ui[:pending] = nil
+        @battle_ui[:phase] = :command
+        advance_actor
+      end
+
+      # Commit an all-party item on every living ally: one per-member recovery
+      # from the model, queued as a single volley that consumes one item.
+      def apply_pending_item_all(targets)
+        pending = @battle_ui[:pending]
+        effects = targets.map do |t|
+          c = @state.party.battle_item_command(pending[:it], t)
+          { target: t, hp: c[:hp], mp: c[:mp] }
+        end
+        cured = @state.party.battle_item_command(pending[:it], targets.first)[:cured]
+        @battle_ui[:battle].command_item_all(current_actor, effects,
+                                             item_id: pending[:item_id],
+                                             name: pending[:it].name, cured: cured)
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4277,6 +4277,75 @@ check 'battle without first strike: both sides act in the opening round' do
   eq 2, b.run_round.length, 'both battlers act in round 1'
 end
 
+# -- Battle all-target skill scopes -------------------------------------------
+
+check 'battle: an all-enemy skill strikes every living foe, spending SP once' do
+  mage = combatant_mp('Mage', 10, 0, 20, 100, 30)    # fast: acts first
+  s1 = combatant('S1', 0, 0, 5, 100)
+  s2 = combatant('S2', 0, 0, 5, 100)
+  b = Game::Battle.new([mage], [s1, s2], Game::Rng.new(1))
+  b.command_skill_all(mage, [{ target: s1, hp: -20 }, { target: s2, hp: -20 }],
+                      name: 'Blizzard', cost: 6)
+  b.begin_round
+  e1 = b.step_action                                 # first hit surfaced now...
+  e2 = b.step_action                                 # ...second from the buffer
+  eq ['S1', 'S2'], [e1[:target], e2[:target]]
+  eq [20, 20], [e1[:damage], e2[:damage]]
+  eq [80, 80], [s1.hp, s2.hp]
+  eq 24, mage.mp, 'the SP cost is charged once for the whole volley'
+end
+
+check 'battle: an all-ally heal restores every living member' do
+  healer = combatant_mp('Healer', 10, 0, 20, 100, 30)
+  a1 = combatant('A1', 0, 0, 5, 100); a1.hp = 40
+  a2 = combatant('A2', 0, 0, 5, 100); a2.hp = 30
+  b = Game::Battle.new([healer, a1, a2], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  b.command_skill_all(healer, [{ target: a1, hp: 30 }, { target: a2, hp: 30 }],
+                      name: 'Heal All', cost: 8)
+  b.begin_round
+  e1 = b.step_action
+  b.step_action
+  ok e1[:recover], 'reads as a recovery'
+  eq [70, 60], [a1.hp, a2.hp]
+  eq 22, healer.mp
+end
+
+check 'battle: an all-enemy skill skips foes already down' do
+  mage = combatant_mp('Mage', 10, 0, 20, 100, 30)
+  downed = combatant('Downed', 0, 0, 5, 0)           # already KO'd
+  alive = combatant('Alive', 0, 0, 5, 100)
+  b = Game::Battle.new([mage], [downed, alive], Game::Rng.new(1))
+  b.command_skill_all(mage, [{ target: downed, hp: -20 }, { target: alive, hp: -20 }],
+                      name: 'Blizzard', cost: 6)
+  b.begin_round
+  e = b.step_action
+  eq 'Alive', e[:target], 'only the living foe is struck'
+  ok b.log.none? { |x| x[:target] == 'Downed' }, 'the downed foe is skipped'
+  eq 80, alive.hp
+  eq 24, mage.mp
+end
+
+check 'battle: an all-ally skill fizzles and spares SP when every target is down' do
+  healer = combatant_mp('Healer', 10, 0, 20, 100, 30)
+  downed = combatant('Downed', 0, 0, 5, 0)           # the only target, already KO'd
+  b = Game::Battle.new([healer, downed], [combatant('Foe', 0, 0, 1, 100)], Game::Rng.new(1))
+  b.command_skill_all(healer, [{ target: downed, hp: 30 }], name: 'Heal', cost: 8)
+  b.run_round
+  eq 30, healer.mp, 'a fizzled all-ally heal spends no SP'
+  ok b.log.none? { |x| x[:recover] }, 'nothing was healed'
+end
+
+check 'battle: run_round surfaces every hit of an all-enemy volley' do
+  mage = combatant_mp('Mage', 10, 0, 50, 100, 30)    # fastest: acts first
+  s1 = combatant('S1', 0, 0, 5, 100)
+  s2 = combatant('S2', 0, 0, 5, 100)
+  b = Game::Battle.new([mage], [s1, s2], Game::Rng.new(1))
+  b.command_skill_all(mage, [{ target: s1, hp: -20 }, { target: s2, hp: -20 }],
+                      name: 'Blizzard', cost: 6)
+  hits = b.run_round.select { |e| e[:skill] == 'Blizzard' }
+  eq 2, hits.length, 'both foes appear in the round log'
+end
+
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
                              mrate: 40, variance: 4) }
@@ -4476,17 +4545,20 @@ check 'battle_skills lists the caster\'s battle-usable skills with SP cost' do
     8  => fake_skill(name: 'Heal', scope: 3, sp_cost: 5, power: 20, mrate: 40, hp: true),
     9  => fake_skill(name: 'Guard', scope: 2, sp_cost: 3, power: 10, hp: true),
     10 => fake_skill(name: 'FieldOnly', scope: 3, sp_cost: 4, hp: true, occ_battle: false),
-    11 => fake_skill(name: 'AllFoes', scope: 1, sp_cost: 8, power: 20) # scope 1 deferred
+    11 => fake_skill(name: 'AllFoes', scope: 1, sp_cost: 8, power: 20),  # all enemies
+    12 => fake_skill(name: 'AllHeal', scope: 4, sp_cost: 7, power: 20, hp: true) # all allies
   }
   st = skill_party(skills)
   hero = st.party.actor_by_id(1)
-  [7, 8, 9, 10, 11].each { |s| hero.learn_skill(s) }
+  [7, 8, 9, 10, 11, 12].each { |s| hero.learn_skill(s) }
   caster = Game::Battle.from_actor(hero)
-  eq [[7, 6], [8, 5], [9, 3]], st.party.battle_skills(hero, caster),
-     'single-target battle skills only, in id order'
-  eq :enemy, st.party.battle_skill_target(st.party.db_skill(7))
-  eq :ally,  st.party.battle_skill_target(st.party.db_skill(8))
-  eq :self,  st.party.battle_skill_target(st.party.db_skill(9))
+  eq [[7, 6], [8, 5], [9, 3], [11, 8], [12, 7]], st.party.battle_skills(hero, caster),
+     'single- and all-target battle skills, in id order (field-only excluded)'
+  eq :enemy,     st.party.battle_skill_target(st.party.db_skill(7))
+  eq :ally,      st.party.battle_skill_target(st.party.db_skill(8))
+  eq :self,      st.party.battle_skill_target(st.party.db_skill(9))
+  eq :all_enemy, st.party.battle_skill_target(st.party.db_skill(11))
+  eq :all_ally,  st.party.battle_skill_target(st.party.db_skill(12))
 end
 
 check 'battle_skill_command yields attack damage, ally heal and self recovery' do

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4346,6 +4346,45 @@ check 'battle: run_round surfaces every hit of an all-enemy volley' do
   eq 2, hits.length, 'both foes appear in the round log'
 end
 
+# -- Battle all-party items ---------------------------------------------------
+
+check 'battle: an all-party item heals every ally and is consumed once' do
+  healer = combatant('Healer', 0, 0, 20, 100)        # acts first
+  a1 = combatant('A1', 0, 0, 5, 100); a1.hp = 40
+  a2 = combatant('A2', 0, 0, 5, 100); a2.hp = 50
+  b = Game::Battle.new([healer, a1, a2], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  b.command_item_all(healer, [{ target: a1, hp: 30 }, { target: a2, hp: 30 }],
+                     item_id: 5, name: 'Party Potion')
+  b.begin_round
+  e1 = b.step_action
+  e2 = b.step_action
+  eq 5, e1[:item_id], 'the first hit consumes the item'
+  eq nil, e2[:item_id], 'the rest do not — one item for the whole volley'
+  eq [70, 80], [a1.hp, a2.hp]
+  ok e1[:recover] && e2[:recover]
+end
+
+check 'battle: an all-party antidote cures the status from each afflicted ally' do
+  healer = combatant('Healer', 0, 0, 20, 100)
+  a1 = combatant('A1', 0, 0, 5, 100); a1.states = [3]
+  a2 = combatant('A2', 0, 0, 5, 100); a2.states = [3, 4]
+  b = Game::Battle.new([healer, a1, a2], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1))
+  b.command_item_all(healer, [{ target: a1, hp: 0 }, { target: a2, hp: 0 }],
+                     item_id: 6, name: 'Party Antidote', cured: [3])
+  b.begin_round
+  b.step_action; b.step_action
+  ok !a1.state?(3), 'a1 is cured'
+  ok !a2.state?(3), 'a2 is cured'
+  ok a2.state?(4), 'a2 keeps its other status'
+end
+
+check 'Party#item_all_allies? flags a whole-party item (scope 1)' do
+  st = item_party({ 5 => fake_item(type: 6, scope: 1, rhp: 20),
+                    6 => fake_item(type: 6, scope: 0, rhp: 20) })
+  ok st.party.item_all_allies?(st.party.db_item(5)), 'scope 1 -> all allies'
+  ok !st.party.item_all_allies?(st.party.db_item(6)), 'scope 0 -> single ally'
+end
+
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
                              mrate: 40, variance: 4) }

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2029,6 +2029,7 @@ class BattleMagicParty
   end
   def db_item(id); id == 5 ? OpenStruct.new(name: 'Potion') : nil; end
   def battle_item_command(_it, _target); { hp: 20, mp: 0 }; end
+  def item_all_allies?(it); it.respond_to?(:scope) && it.scope == 1; end
 end
 
 # Open a battle and step to the per-actor command menu.


### PR DESCRIPTION
## Summary

Implements **all-target battle skills and items** for RPG Maker 2000 — previously deferred.

### All-target skills (scope 1 all enemies / 4 all allies)
- `Game::Battle#command_skill_all(ally, targets, ...)` queues a volley of per-target `{ target:, hp:, mp: }` effects (attack damage still varies with each target's defence).
- `apply_command` routes an `all:` command to `apply_command_all`, which spends the caster's SP **once**, then applies the shared effect + state infliction to every **living** target via the extracted `apply_skill_hit` helper — one log entry per hit.
- Menu wiring: `BATTLE_SKILL_SCOPES` gained 1 and 4; `battle_skill_target` returns `:all_enemy` / `:all_ally`; the scene casts them without a target prompt (`apply_pending_skill_all`).

### All-party items (item scope 1)
- `Game::Battle#command_item_all` reuses the same machinery to heal HP/SP and cure status from every living ally. A **single item** is consumed for the volley — `apply_command_all` keeps `item_id` on the first hit only, so the scene's per-entry bag deduction fires once.
- `Game::Party#item_all_allies?` flags a scope-1 medicine; the battle item menu casts it on the whole party without a target prompt (`apply_pending_item_all`).

### Shared machinery
- A new **pending-hit buffer** (`@pending`) lets `#step` / `#step_action` surface a volley's hits one at a time (`record_action`), so the battle screen animates it target by target. A volley skips targets already down and fizzles (no SP / no item consumed) when every target has fallen. The single-target path is unchanged (refactored to share `apply_skill_hit`).

## Testing

- `scripts/rpg2k_logic_check.rb` — 377 checks pass, including 8 new ones across all-target skills (volley hits every foe for one SP charge, all-ally heal, downed targets skipped, all-dead fizzle, `run_round` surfaces every hit) and all-party items (every ally healed for one consumed item, party antidote cures each member, scope flag read). The existing `battle_skills` test was updated for all-scope skills now being usable.
- Scene (111) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj