### PR TITLE
Answer #disposed? with the disposed state, not the live one

### DIFF
--- a/changelog.d/rgss-disposed-inverted.fixed.md
+++ b/changelog.d/rgss-disposed-inverted.fixed.md
@@ -1,0 +1,12 @@
+- **Fixed: `#disposed?` answered the opposite of the truth on every RGSS display
+  object.** `Bitmap`, `Sprite`, `Viewport`, `Plane`, `Tilemap` and `Window` all
+  share one native `disposed?`, and it returned whether the object was *alive* —
+  so a fresh bitmap reported itself disposed and a freed one reported itself
+  fine. RGSS scripts guard cleanup and redraws with exactly this
+  (`unless bitmap.disposed?`, `return if @sprite.disposed?`), so inverted it
+  means skipping work on a live object and reaching into a freed one.
+
+  Nothing in the engine read the value, which is why it survived: the tests only
+  asserted the method *existed*. There is now one that checks what it answers,
+  on `Bitmap` — the one display class that needs no display, so the behaviour can
+  be pinned headlessly.

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2229,8 +2229,14 @@ mrb_value bmp_text_size(mrb_state* M, mrb_value self) {
       M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Rect"), 4, args);
 }
 
+// RGSS #disposed?: whether #dispose has already run. The data pointer is
+// cleared exactly when it does (see obj_dispose), so a null pointer *is* the
+// disposed state -- this used to answer the other way round, reporting every
+// live object as disposed and every disposed one as live. The stock scripts
+// guard cleanup and redraws with it (`unless bitmap.disposed?`), so inverted it
+// meant skipping work on a live object and touching a freed one.
 mrb_value obj_disposed(mrb_state* M, mrb_value self) {
-  return mrb_bool_value(DATA_PTR(self));
+  return mrb_bool_value(DATA_PTR(self) == nullptr);
 }
 
 mrb_value obj_dispose(mrb_state* M, mrb_value self) {

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -130,6 +130,21 @@ assert "RGSS::Bitmap pixel operations" do
   assert_equal 0.0, b.get_pixel(3, 3).alpha
 end
 
+assert "RGSS::Bitmap#disposed? reports the disposed state, not the live one" do
+  # Every display class shares this pair (Viewport/Sprite/Plane/Tilemap/Window
+  # too), but Bitmap is the one that needs no display, so it is where the
+  # behaviour can be pinned. `disposed?` used to answer whether the object was
+  # *alive*, which inverts every `unless x.disposed?` guard the stock scripts
+  # use around cleanup and redraws.
+  b = RGSS::Bitmap.new(2, 2)
+  assert_false b.disposed?, "a fresh bitmap is not disposed"
+  b.dispose
+  assert_true b.disposed?, "a disposed bitmap reports disposed"
+  # Disposing twice is a no-op rather than a double free.
+  b.dispose
+  assert_true b.disposed?
+end
+
 assert "RGSS::Bitmap blt" do
   src = RGSS::Bitmap.new(2, 2)
   src.fill_rect(0, 0, 2, 2, RGSS::Color.new(0, 128, 0, 255))


### PR DESCRIPTION
`Bitmap`, `Sprite`, `Viewport`, `Plane`, `Tilemap` and `Window` all share one native `disposed?`:

```cpp
mrb_value obj_disposed(mrb_state* M, mrb_value self) {
  return mrb_bool_value(DATA_PTR(self));   // true while the object is ALIVE
}
```

`dispose()` clears that pointer, so the answer was inverted: a fresh bitmap reported itself disposed, and a freed one reported itself fine.

RGSS scripts guard cleanup and redraws with exactly this — `unless bitmap.disposed?`, `return if @sprite.disposed?` — so inverted it means skipping work on a live object and reaching into a freed one. It matters most on the script-host path, where a game's own scripts do the disposing.

Nothing in the engine read the value, which is why it survived: the existing tests only assert the method *exists* (`method_defined?`). There is now one that checks what it answers, on `Bitmap` — the one display class that needs no display, so the behaviour can be pinned headlessly:

```ruby
b = RGSS::Bitmap.new(2, 2)
assert_false b.disposed?
b.dispose
assert_true b.disposed?
b.dispose            # twice is a no-op, not a double free
assert_true b.disposed?
```

Confirmed non-vacuous by restoring the old expression, which fails it (`KO: 1`). `mruby_test` 1706 assertions / 0 failures with the fix; `render_probe` and `audio_probe` also green.

## How I found it

Chasing why the VX window open/close animation I was building measured no change on screen. My diagnostics kept saying `disposed=false` on a window whose data pointer was clearly null, and it took a while to realise the reading was backwards, not the pointer.

That investigation turned up a second, larger problem which I'm sending separately: `mruby-rpg2k/mrblib/main.rb` defines its own `module RGSS; class Window` — an RPG2000-style window built from a Viewport plus Sprites — and `mruby-rpg2k` loads after `mruby-rgss` in `build_config.rb`, so its `initialize` replaces the native one process-wide. The native `RGSS::Window` (9-slice frame, cursor, pause arrow, contents, openness) is currently unreachable: every `Window.new` returns an object with no LVGL object attached. Neither `mruby-rpgxp` nor `mruby-rpgvx` constructs a `Window`, so nothing in-tree noticed — but a real XP/VX game run through the script host would get RPG2000 windows with no backing object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_