### PR TITLE
Validate the troop battle-event page flags against real bytes

### DIFF
--- a/changelog.d/rpg2k-troop-page-flags-validated.added.md
+++ b/changelog.d/rpg2k-troop-page-flags-validated.added.md
@@ -1,0 +1,20 @@
+- RPG Maker 2000: `scripts/analyze_game.rb` gained a **`--troops`** mode that
+  reports a game's troop battle-event pages — how many carry a condition, which
+  condition-flag bits they use, the turn base/multiple pairs and enemy-HP windows
+  those bits imply, which battle-only commands the pages run, and whether any
+  command lacks a handler. This is what validates `Game::BattlePage`'s flag bit
+  assignments against **real bytes** rather than against liblcf's declaration
+  order alone, per ADR 0002.
+  Run against Nepheshel (3265 troop pages, 2819 conditional) it confirms four
+  bits: `switch_a` (0) and `switch_b` (1) — bit 1 only ever appears alongside
+  bit 0 and those pages carry a *pair* of plausible switch ids; `turn` (3) — 156
+  pages fire on turn 0 and 9 fire every turn, exactly the two shapes
+  `check_turns` produces; and `enemy_hp` (5) — every page carries a deliberate
+  `0..30%` window rather than the `0..100` default, which a wrong bit could not
+  survive. The remaining bits are unused by that game and still rest on the
+  declaration order, but the data shows the order is not shifted. It also
+  confirms **every battle-only command Nepheshel's pages use has a handler**
+  (Change Monster MP / Condition, Show Hidden Monster, Change Battle Background,
+  the battle Show Battle Animation, and 6577 battle Conditional Branches with
+  their matching `_B` end markers). The battle opcodes are named in the report's
+  label table too.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -416,7 +416,12 @@ The work below is roughly ordered by the critical path to a walkable game
   (13110 / 13120 / 13130), **Show Hidden Monster** (13150), **Change Battle
   Background** (13210), the battle **Show Battle Animation** (13260),
   **Conditional Branch** (13310 with its `_B` markers) and **Terminate Battle**
-  (13410). Messages from a page are shown in a battle panel. Still TODO here:
+  (13410). Messages from a page are shown in a battle panel. The flag bits are
+  **validated against real bytes** — `ruby scripts/analyze_game.rb --troops
+  <game>` reports a game's troop pages, and Nepheshel's 2819 conditional pages
+  confirm the `switch_a` / `switch_b` / `turn` / `enemy_hp` bits and show that
+  every battle-only command it uses has a handler (see the comment on
+  `Game::BattlePage` for what each bit is confirmed by). Still TODO here:
   the per-battler turn counters and the party-fatigue / chosen-command
   conditions (pages gated on those deliberately do not fire rather than firing
   unchecked), and video playback for Play Movie (no decoder is linked in; the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2481,11 +2481,30 @@ module Game
   # The bit values follow liblcf's `TroopPageCondition::Flags` declaration
   # order (switch_a, switch_b, variable, turn, fatigue, enemy_hp, actor_hp,
   # turn_enemy, turn_actor, command_actor) packed LSB-first — the same
-  # convention Game::EventPage above uses for map pages, which is validated
-  # against real games. Only the sub-conditions the battle context can answer
-  # are tested; one it cannot answer (see `ctx`) is treated as unmet rather
-  # than silently passing, so a page never fires on a condition we did not
-  # actually check.
+  # convention Game::EventPage above uses for map pages.
+  #
+  # Four of those bits are confirmed against real bytes (Nepheshel, 3265 troop
+  # pages, 2819 of them conditional — `ruby scripts/analyze_game.rb --troops`):
+  #
+  #   * bit 0 SWITCH_A (2650 pages) and bit 1 SWITCH_B (468) — bit 1 only ever
+  #     appears together with bit 0, as `flags=0x003`, and those pages carry a
+  #     *pair* of plausible switch ids (11/5, 12/6, 13/7), which is what two
+  #     switch conditions look like and not what any other field would.
+  #   * bit 3 TURN (165) — 156 pages are base 0 / multiple 0 (fire on turn 0,
+  #     the opening page) and 9 are base 0 / multiple 1 (fire every turn),
+  #     exactly the two shapes #check_turns produces.
+  #   * bit 5 ENEMY_HP (4) — every one carries a non-default `0..30%` window
+  #     ("the boss enrages below 30% HP"). A default window would prove nothing;
+  #     a deliberate one could not survive a wrong bit.
+  #
+  # Bits 2 (VARIABLE), 4 (FATIGUE), 6 (ACTOR_HP) and 7-9 (the per-battler turn
+  # and command tests) are unused by that game, so their positions rest on the
+  # liblcf declaration order alone. What the data does establish is that the
+  # order is not shifted: a shift would have moved the confirmed four.
+  #
+  # Only the sub-conditions the battle context can answer are tested; one it
+  # cannot answer (see `ctx`) is treated as unmet rather than silently passing,
+  # so a page never fires on a condition we did not actually check.
   module BattlePage
     SWITCH_A      = 0x001
     SWITCH_B      = 0x002

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -15,7 +15,9 @@
 # implements.
 #
 # Usage:
-#   ruby scripts/analyze_game.rb [--json] GAME_DIR [GAME_DIR ...]
+#   ruby scripts/analyze_game.rb [--json] [--troops] GAME_DIR [GAME_DIR ...]
+# `--troops` reports the troops' battle-event pages instead: which condition
+# flag bits the game uses and which battle-only commands its pages run.
 # With no GAME_DIR it scans ./data for directories containing an RPG_RT.ldb.
 #
 # Only structural, encoding-independent facts are reported, so the Windows-31J
@@ -91,6 +93,13 @@ CODE_NAMES = {
   12410 => 'Comment',                22410 => 'Comment(cont.)',
   12420 => 'GameOver',               12510 => 'ReturnToTitleScreen',
   12610 => 'ChangeClass',            12710 => 'ChangeBattleCommands',
+  # Battle-only: these appear in a troop's battle-event pages, never in a map or
+  # common event. Reported by --troops.
+  13110 => 'ChangeMonsterHP',        13120 => 'ChangeMonsterMP',
+  13130 => 'ChangeMonsterCondition', 13150 => 'ShowHiddenMonster',
+  13210 => 'ChangeBattleBG',         13260 => 'ShowBattleAnimation(B)',
+  13310 => 'ConditionalBranch(B)',   13410 => 'TerminateBattle',
+  23310 => 'ElseBranch(B)',          23311 => 'EndBranch(B)',
 }.freeze
 
 MOVE_NAMES = {
@@ -303,15 +312,81 @@ def to_h(st)
   }
 end
 
+# Troop battle-event pages: which condition-flag bits real games actually use,
+# and which battle-only commands their pages run. This is what validates
+# Game::BattlePage's flag bit assignments against real bytes rather than against
+# liblcf's declaration order alone -- a page's condition fields are only
+# meaningful if the bit that gates them is the one we think it is (see the
+# comment on Game::BattlePage).
+BATTLE_PAGE_FLAGS = %w[switch_a switch_b variable turn fatigue enemy_hp
+                       actor_hp turn_enemy turn_actor command_actor].freeze
+
+def report_troops(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  pages = 0
+  conditional = 0
+  bits = Hash.new(0)
+  cmds = Hash.new(0)
+  windows = []
+  turns = Hash.new(0)
+  db.enemy_group.each do |_gid, group|
+    next unless group.respond_to?(:pages) && group.pages
+    group.pages.each do |_pid, page|
+      pages += 1
+      cond = page.condition
+      flags = cond && cond.flags ? cond.flags : 0
+      conditional += 1 if flags != 0
+      BATTLE_PAGE_FLAGS.each_index { |b| bits[b] += 1 if (flags & (1 << b)) != 0 }
+      # The two sub-conditions whose *values* prove the bit: a deliberate HP
+      # window (rather than the 0..100 default) and the turn base/multiple pair.
+      windows << [cond.enemy_id, cond.enemy_hp_min, cond.enemy_hp_max] if (flags & 0x020) != 0
+      turns["base=#{cond.turn_b} multiple=#{cond.turn_a}"] += 1 if (flags & 0x008) != 0
+      (page.event || []).each { |c| cmds[c.code] += 1 }
+    end
+  end
+
+  puts "\n== #{dir} troop battle-event pages =="
+  puts "pages: #{pages}  with a condition: #{conditional}"
+  puts 'condition flag bits in use:'
+  BATTLE_PAGE_FLAGS.each_index do |b|
+    next if bits[b].zero?
+    puts format('  bit %d (0x%03x) %-14s %d pages', b, 1 << b, BATTLE_PAGE_FLAGS[b], bits[b])
+  end
+  unless turns.empty?
+    puts 'turn conditions:'
+    turns.sort_by { |_, n| -n }.each { |k, n| puts "  #{k}  x#{n}" }
+  end
+  unless windows.empty?
+    puts 'enemy-HP windows (a non-default 0..100 proves the bit):'
+    windows.uniq.each { |e, lo, hi| puts "  enemy #{e}: #{lo}..#{hi}%" }
+  end
+  battle = cmds.keys.select { |c| c >= 13000 && c < 24000 }.sort
+  unless battle.empty?
+    puts 'battle-only commands used:'
+    battle.each { |c| puts "  #{c} #{(CODE_NAMES[c] || '?').ljust(24)} x#{cmds[c]}" }
+  end
+  missing = cmds.keys.reject { |c| SUPPORTED.include?(c) || NOOP_BY_DESIGN.include?(c) }.sort
+  puts(missing.empty? ? 'every command these pages use has a handler' :
+       "commands with NO handler: #{missing.inspect}")
+rescue StandardError => e
+  warn "  troop analysis failed for #{dir}: #{e.class}: #{e.message}"
+end
+
 json = ARGV.delete('--json')
+troops = ARGV.delete('--troops')
 games = ARGV.dup
 if games.empty?
   root = File.expand_path('../data', __dir__)
   games = Dir.glob(File.join(root, '**', 'RPG_RT.ldb')).map { |f| File.dirname(f) }.sort
 end
 if games.empty?
-  warn 'usage: ruby scripts/analyze_game.rb [--json] GAME_DIR [GAME_DIR ...]'
+  warn 'usage: ruby scripts/analyze_game.rb [--json] [--troops] GAME_DIR [GAME_DIR ...]'
   exit 1
+end
+
+if troops
+  games.each { |g| report_troops(g) }
+  exit 0
 end
 
 stats = games.map { |g| analyze(g) }


### PR DESCRIPTION
Retires the one caveat I put in writing on #319. `Game::BattlePage`'s condition-flag bit assignments rested on liblcf's `TroopPageCondition::Flags` declaration order plus the convention the map event-page code already uses. ADR 0002 asks for field meanings to be proven against real data — so this proves them.

## `analyze_game.rb --troops`

A new mode reporting a game's troop battle-event pages: how many carry a condition, which flag bits they use, the turn base/multiple pairs and enemy-HP windows those bits imply, which battle-only commands the pages run, and whether any command lacks a handler. The battle opcodes are named in the label table too, so the report is readable rather than a list of numbers.

## What the data says

Nepheshel — **3265 troop pages, 2819 conditional**:

```
condition flag bits in use:
  bit 0 (0x001) switch_a       2650 pages
  bit 1 (0x002) switch_b       468 pages
  bit 3 (0x008) turn           165 pages
  bit 5 (0x020) enemy_hp       4 pages
turn conditions:
  base=0 multiple=0  x156
  base=0 multiple=1  x9
enemy-HP windows (a non-default 0..100 proves the bit):
  enemy 0: 0..30%
  enemy 3: 0..30%
```

Four bits confirmed:

- **`switch_a` (0) / `switch_b` (1)** — bit 1 only ever appears *alongside* bit 0, as `flags=0x003`, and those pages carry a **pair** of plausible switch ids (11/5, 12/6, 13/7). That is what two switch conditions look like and not what any other field would.
- **`turn` (3)** — 156 pages are base 0 / multiple 0 (fire on turn 0, the opening page) and 9 are base 0 / multiple 1 (fire every turn): exactly the two shapes `BattlePage.check_turns` produces.
- **`enemy_hp` (5)** — every one carries a deliberate `0..30%` window rather than the `0..100` default. "The boss enrages below 30% HP." A default window would prove nothing; a deliberate one cannot survive a wrong bit.

Bits 2 (`variable`), 4 (`fatigue`), 6 (`actor_hp`) and 7–9 (the per-battler turn and command tests) are **unused by that game** and still rest on the declaration order. The code comment now says exactly which bits are measured and which are not, instead of hedging over all of them equally. What the data *does* establish is that the order is not shifted — a shift would have moved the confirmed four.

## Command coverage, incidentally

```
battle-only commands used:
  13120 ChangeMonsterMP          x21
  13130 ChangeMonsterCondition   x12
  13150 ShowHiddenMonster        x7
  13210 ChangeBattleBG           x1
  13260 ShowBattleAnimation(B)   x1404
  13310 ConditionalBranch(B)     x6577
  23310 ElseBranch(B)            x936
  23311 EndBranch(B)             x6577
every command these pages use has a handler
```

`13310` and `23311` match at exactly 6577 — every battle conditional has its end marker, and 936 have an else. That is the structure #319 implemented, confirmed against a real game rather than a fixture.

`ChangeMonsterHP` (13110) and `TerminateBattle` (13410) do not appear in this game, so they remain fixture-tested only.

## Verification

`rpg2k_logic_check.rb` 369, `rpg2k_scene_check.rb` 111, `rpg2k_render_check.rb` 36 — all pass, unchanged by this PR (it adds an analysis mode and a comment; no runtime behaviour changes). `--troops` was also run against the RPG2003 test bed (mtf-meido-action), which has 88 troop pages with no conditions and no commands — it handles that cleanly rather than dividing by zero on an empty histogram.

Both games are fetched by the existing `scripts/download-*.bash`; nothing new is committed under `data/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_