### PR TITLE
Stop RPG2000's window replacing the native RGSS one

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -39,6 +39,12 @@ def rpg_maker_gems(conf)
   end
 
   conf.gem "#{MRUBY_ROOT}/../../mruby-lcf"
+  # mruby-rgss owns the shared RGSS namespace (Bitmap, Sprite, Viewport, Window,
+  # ...). Every maker gem below loads after it and *reopens* that namespace, so a
+  # class one of them defines under RGSS replaces mruby-rgss's for the whole
+  # process -- which is what RPG2k's window did to the native RGSS::Window until
+  # it became RPG2k::Window. Keep maker-specific classes under the maker's own
+  # namespace.
   conf.gem "#{MRUBY_ROOT}/../../mruby-rgss"
   conf.gem "#{MRUBY_ROOT}/../../mruby-rpg2k"
   conf.gem "#{MRUBY_ROOT}/../../mruby-rpgxp"

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -169,7 +169,51 @@ module RGSS
     sprite.dispose
     bitmap.dispose
     viewport.dispose
+    ok = false unless window_probe
     $stderr.puts "[RGSS-PROBE] #{ok ? "ok" : "failed"}"
+    ok
+  end
+
+  # Prove RGSS::Window is the native widget and that it draws.
+  #
+  # This exists because it silently was not. Every maker gem reopens the shared
+  # RGSS namespace and loads after mruby-rgss, so a class one of them defines
+  # under RGSS replaces this one for the whole process — which is what RPG2000's
+  # window did, leaving `Window.new` returning an object with no LVGL object
+  # behind it and `window_refresh` returning early forever. Nothing in-tree
+  # noticed, because nothing in-tree constructs an RGSS::Window: only a real
+  # XP/VX game's own scripts do (`Window_Base < Window`), through the script
+  # host.
+  #
+  # So: build one on an empty screen with a solid-blue background tile in its
+  # skin, and require that it is alive and that it covers the area it should.
+  def self.window_probe
+    skin = Bitmap.new(192, 128)
+    # The windowskin layout the native drawing reads: background tile at
+    # (0,0,128,128), frame at (128,0,64,64). Only the background is filled, so
+    # the frame contributes nothing and the measurement is pure area.
+    skin.fill_rect(0, 0, 128, 128, Color.new(0, 0, 255, 255))
+
+    win = Window.new(0, 0, 320, 240)
+    alive = !win.disposed?
+    win.windowskin = skin
+    Graphics.update
+    drawn = frame_mean
+
+    $stderr.puts "[RGSS-PROBE] window alive=#{alive} drawn=#{drawn.inspect}"
+
+    ok = true
+    unless alive
+      $stderr.puts "[RGSS-PROBE] FAIL Window.new produced no native object — " \
+                   "RGSS::Window has been replaced by another gem's class"
+      ok = false
+    end
+    unless drawn[2] > 20
+      $stderr.puts "[RGSS-PROBE] FAIL the window did not draw"
+      ok = false
+    end
+    win.dispose
+    skin.dispose
     ok
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -4056,8 +4056,17 @@ Bitmap& window_ensure_canvas(mrb_state* M,
   return c;
 }
 
+// An opacity ivar clamped to 0..255, defaulting to RGSS's 255 when the script
+// never assigned one. It used to read the ivar unconditionally, so setting a
+// windowskin on a window whose opacity had not been set was a TypeError on nil
+// -- window_init sets @contents_opacity but not @opacity or @back_opacity.
+// Nothing hit it while RGSS::Window was unreachable (see the note on
+// RPG2k::Window); it raises on the first real use once it is not.
 static mrb_int clamp_opacity(mrb_state* M, mrb_value self, const char* iv) {
-  mrb_int v = mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_cstr(M, iv)));
+  const mrb_value raw = mrb_iv_get(M, self, mrb_intern_cstr(M, iv));
+  if (mrb_nil_p(raw))
+    return 255;
+  const mrb_int v = mrb_as_int(M, raw);
   if (v < 0)
     return 0;
   if (v > 255)

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2,7 +2,7 @@ class Object
   include RGSS
 end
 
-module RGSS
+class RPG2k
   # RPG Maker 2000 style window. The visual is assembled from a "windowskin"
   # System graphic laid out in the classic 160x80 arrangement:
   #
@@ -15,6 +15,13 @@ module RGSS
   # frame), the selection cursor, and the contents (text and other graphics
   # drawn by callers). Keeping them apart means updating the cursor or the text
   # no longer forces the skin to be re-blitted.
+  #
+  # RPG2k::Window, not RGSS::Window: this is the RPG Maker 2000 window, and the
+  # RGSS one is a different widget with a different windowskin layout that a
+  # real XP/VX game's own scripts subclass (`Window_Base < Window`). Defining
+  # this one under RGSS used to replace that native class for the whole process,
+  # since mruby-rpg2k loads after mruby-rgss -- see the note in build_config.rb.
+  # Every use is inside `class RPG2k`, so the bare name still resolves here.
   class Window
     # Windows are drawn above ordinary background sprites (which default to
     # z == 0), so give the backing viewport a high z by default.
@@ -288,9 +295,7 @@ module RGSS
       @cursor_bmp.fill_rect x + w - 1, y, 1, h, border
     end
   end
-end
 
-class RPG2k
   WIDTH = 320
   HEIGHT = 240
 


### PR DESCRIPTION
Follow-up to [#330](https://github.com/take-cheeze/rpg-maker-clone/pull/330), and the reason I was chasing that one.

## The collision

`mruby-rpg2k/mrblib/main.rb` defined `module RGSS; class Window` — the RPG Maker 2000 window, assembled from a Viewport plus three Sprites against a 160×80 windowskin. Every maker gem reopens the shared `RGSS` namespace, and `mruby-rpg2k` loads *after* `mruby-rgss` in `build_config.rb`, so that class replaced the native `RGSS::Window` **for the whole process**.

The native one is a different widget entirely: a single canvas with a 9-slice frame from the RGSS windowskin layout, a blinking cursor, the pause arrow and blitted contents. It has been unreachable. `Window.new` ran RPG2000's `initialize`, so the mruby wrapper never received an LVGL object and `window_refresh` returned early forever.

Nothing in-tree noticed, because nothing in-tree constructs an `RGSS::Window` — neither `mruby-rpgxp` nor `mruby-rpgvx` does. Only a real XP/VX game's own scripts do, through the script host (`Window_Base < Window`), which is exactly the path the VX work has been building toward.

## The fix

It becomes `RPG2k::Window`. All 26 uses are inside `class RPG2k`, so the bare name still resolves to it by lexical scope and no call site changes — the class body moves as-is. `build_config.rb` gains a note at the gem list about why maker-specific classes have to stay under the maker's own namespace, so this can't silently recur.

## A second bug fell out immediately

Making the class reachable surfaced this on the very first `windowskin=`:

```
TypeError: nil cannot be converted to Integer
```

`clamp_opacity` read `@opacity` with `mrb_as_int`, and `window_init` sets `@contents_opacity` but not `@opacity` or `@back_opacity`. It now defaults to RGSS's 255. That it had never been hit is its own evidence the class was dead code.

## Regression guard

The render probe grows a window section — build a `Window`, require it to be alive, and measure that it covers the area it should:

```
[RGSS-PROBE] window alive=true drawn=[0, 0, 86]
```

A 320×240 solid-blue window on a 544×416 screen gives mean blue 86, and 255 × 320×240 / (544×416) = 86.5. Under the old shadowing this failed at `alive` — I watched it do so while diagnosing this, with `Window.new` returning `disposed?` true and `window_init` never running.

## Verification

The risk here is regressing the RPG2000 runtime, so that got the attention: `rpg2k_logic_check` (369), `rpg2k_scene_check` (111), `rpg2k_render_check` (36), and a real-game boot — I downloaded the RPG2003 test bed (`mtf-meido-action`) so a genuine game actually draws windows through the renamed class, and it reaches its map. Plus ctest 3/3 (`mruby_test`, `render_probe`, `audio_probe`), the LCF/XP/VX test beds, and the XP and packed-archive boot smokes. Re-run after rebasing onto current master.

With this in, the VX window open/close animation and `Window#tone` (gap item 4) finally have a working class to sit on — that's next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_