### PR TITLE
Unroll and tint VX windows: Window#openness and Window#tone

### DIFF
--- a/changelog.d/rgss-window-openness-tone.added.md
+++ b/changelog.d/rgss-window-openness-tone.added.md
@@ -1,0 +1,33 @@
+- **VX windows unroll instead of popping, and `Window#tone` tints them.** The
+  last two behavioural gaps in the RGSS2/RGSS3 window (`docs/rpgvx-rgss-api-gap.md`
+  item 4). Both were stored-but-never-drawn: the value went in, the screen never
+  changed, and because the stock scripts only ever wait on the value they set
+  (`Window_Base#open` steps `openness` by 48 a frame and polls `open?`), a game
+  looked correct while every menu appeared instantly.
+  - **`openness`** now draws. The window unrolls from its horizontal centre
+    line: the frame is composited at `height * openness / 255` and the object
+    shifted down by half of what it lost, so it grows out of the middle the way
+    RGSS does. The 9-slice's corner height is clamped to half the drawn height,
+    so a part-open window keeps a frame rather than laying its top and bottom
+    borders over each other. Contents, cursor and pause arrow are hidden until it
+    is fully open — only the frame animates.
+  - **`Window#tone`** now draws, over the *background* only: applied to the
+    canvas right after the background tile and before the frame and contents go
+    on top, which confines it without a second buffer. Unlike `Viewport#tone` it
+    is not folded in by children — a window composites itself — but the
+    per-pixel maths is the same shared `apply_tone_px`, so the three tone paths
+    cannot drift apart. `Window#update` re-checks it, since the scripts mutate
+    the Tone in place (`window.tone.set(...)`); one comparison a frame when it
+    has not moved.
+  - Both are native and deliberately **not** redefined in mrblib. That loads
+    after the C init, so a Ruby accessor there shadows the native one and
+    silently goes back to storing a value that draws nothing — the trap that
+    `Viewport#tone` already had to be rescued from once.
+
+  Measured by `RGSS.window_probe` in the `render_probe` ctest, using area: a
+  320×240 solid-blue window on a 544×416 screen, so the frame's mean blue is the
+  fraction of the screen it covers — `drawn=[0,0,86] half=[0,0,43]
+  closed=[0,0,0] toned=[86,0,86]`. 43 is half of 86, and 86 is
+  255 × 320×240 / (544×416). Confirmed non-vacuous by breaking each half in
+  turn: drawing at full height regardless of openness fails the half and closed
+  checks, and skipping the tone pass fails only the tone check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -918,10 +918,21 @@ screen (544×416). Full rationale:
     the `render_probe` ctest under xvfb (display 98) and needs no game. Verified
     to have teeth by neutering `vp_refresh_overlay` and the transition in turn —
     each broke exactly the assertion it should.
-  - Remaining, all native `mruby-rgss` work and ordered by what blocks a
-    playable game: `Viewport#tone` on `Window` contents (a different composite
-    path; RGSS keeps windows in their own viewport, so a map tint does not tint
-    the message window anyway), the window open/close animation, and
+  - ✅ **`Window#openness` and `Window#tone`** — the VX open/close animation and
+    the windowskin tint. The window unrolls from its horizontal centre line: the
+    frame is composited at `height * openness / 255` and shifted down by half of
+    what it lost, with the 9-slice's corner height clamped to half the drawn
+    height so a part-open window keeps a frame; contents, cursor and pause arrow
+    stay hidden until it is fully open. The tone goes on the *background* only —
+    applied right after the background tile and before anything on top — through
+    the shared `apply_tone_px`, and is re-checked from `#update` because the
+    scripts mutate the Tone in place. Both native, and deliberately not
+    redefined in mrblib (which loads after the C init and would shadow them).
+    Measured by `RGSS.window_probe`: `drawn=[0,0,86] half=[0,0,43]
+    closed=[0,0,0] toned=[86,0,86]`.
+  - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
+    contents (a different composite path; RGSS keeps windows in their own
+    viewport, so a map tint does not tint the message window anyway) and
     `Bitmap#blur`/`#radial_blur`.
 - **Built-in title/map flow** — the reimplemented scene stack the RPG2000 and XP
   runtimes have (title → New Game → walkable map). Not written yet; a boot

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -188,11 +188,40 @@ screen does not change* — the failure mode that hid the RPG2000 screen tint
 (`docs/TODO.md`). Measured: `base=[128,128,128] color=[191,63,63]
 tone=[128,128,255] cleared=[0,0,0] mid=[94,94,94] after=[0,0,0]`.
 
-### 4. Window open/close is not animated, and `Window#tone` is not applied
+### 4. Window open/close animates, and `Window#tone` is applied ✅
 
-`openness` is stored and the scripts' open/close loops terminate correctly, but
-the native window is drawn full-size throughout, so a menu pops rather than
-unrolls. `Window#tone` (the windowskin colour tint) is likewise stored only.
+`openness` used to be stored while the window drew full-size throughout, so a
+menu popped rather than unrolled; `Window#tone` was stored only.
+
+**`openness` is drawn now.** The window unrolls from its horizontal centre line:
+the frame is composited at `height * openness / 255` and the object shifted down
+by half of what it lost, so it grows out of the middle the way RGSS does it. The
+9-slice's corner height is clamped to half the drawn height, so a part-open
+window keeps a frame instead of laying its top and bottom borders over each
+other. Contents, cursor and pause arrow are hidden until it is fully open —
+only the frame animates. `Window_Base#open` steps `openness` by 48 a frame, so
+this is the whole animation.
+
+**`Window#tone` is drawn too**, over the *background* only: it is applied to the
+canvas right after the background tile is laid down and before the frame and
+contents go on top, which confines it without a second buffer. Unlike
+`Viewport#tone` it is not folded in by children — a window composites itself, so
+it tones its own pixels — but the per-pixel maths is the same shared
+`apply_tone_px`, so the three tone paths cannot drift. `Window#update`
+re-checks it, because the scripts mutate the Tone in place
+(`window.tone.set(...)`); one comparison a frame when it has not moved.
+
+Both are native, and deliberately *not* redefined in mrblib: that loads after the
+C init, so a Ruby accessor there would shadow the native one and quietly go back
+to storing a value that draws nothing.
+
+Measured by `RGSS.window_probe` in the `render_probe` ctest — a 320×240
+solid-blue window on a 544×416 screen, so the frame's mean blue is the fraction
+of the screen it covers: `drawn=[0,0,86] half=[0,0,43] closed=[0,0,0]
+toned=[86,0,86]`. 43 is half of 86, and 86 is 255 × 320×240 / (544×416). Both
+halves were confirmed non-vacuous by breaking them in turn.
+
+### 5. `Bitmap#blur` / `#radial_blur`
 
 ### 5. `Bitmap#blur` / `#radial_blur`
 
@@ -253,6 +282,7 @@ a position for music that was not playing. Fixed while building the probe.
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
 the only route to a real game. A bundle now **runs**: it loads its database,
 plays its music, reads input, drives frames, lays out its windows, draws its map,
-tints, flashes and fades the screen, dissolves between scenes, and — packed or
-loose — finds its graphics and its music. What is left is cosmetic: the window
-open/close animation and `Window#tone` (item 4), and the two blurs (item 5).
+tints, flashes and fades the screen, dissolves between scenes, unrolls and tints
+its windows, and — packed or loose — finds its graphics and its music. What is
+left is `Bitmap#blur`/`#radial_blur` (item 5, one use each) and the two tilemap
+polish items in item 1.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -200,7 +200,24 @@ module RGSS
     Graphics.update
     drawn = frame_mean
 
-    $stderr.puts "[RGSS-PROBE] window alive=#{alive} drawn=#{drawn.inspect}"
+    # RGSS2/RGSS3 openness: the window unrolls from its centre line, so the area
+    # it covers scales with the value. Half-open must measure about half.
+    win.openness = 128
+    Graphics.update
+    half = frame_mean
+
+    win.openness = 0
+    Graphics.update
+    closed = frame_mean
+
+    win.openness = 255
+    win.tone = Tone.new(255, 0, 0, 0)
+    Graphics.update
+    toned = frame_mean
+
+    $stderr.puts "[RGSS-PROBE] window alive=#{alive} drawn=#{drawn.inspect} " \
+                 "half=#{half.inspect} closed=#{closed.inspect} " \
+                 "toned=#{toned.inspect}"
 
     ok = true
     unless alive
@@ -211,6 +228,25 @@ module RGSS
     unless drawn[2] > 20
       $stderr.puts "[RGSS-PROBE] FAIL the window did not draw"
       ok = false
+    end
+    if ok
+      # Generous bounds: what is checked is that openness *scales the drawn
+      # height*, not the exact ratio.
+      unless half[2] > drawn[2] / 4 && half[2] < drawn[2] * 3 / 4
+        $stderr.puts "[RGSS-PROBE] FAIL openness=128 covered #{half[2]} of " \
+                     "#{drawn[2]}, expected roughly half — the open/close " \
+                     "animation is not drawn"
+        ok = false
+      end
+      unless closed[2].zero?
+        $stderr.puts "[RGSS-PROBE] FAIL openness=0 still drew something"
+        ok = false
+      end
+      # An additive red tone over the blue background lifts red.
+      unless toned[0] > drawn[0] + 20
+        $stderr.puts "[RGSS-PROBE] FAIL Window#tone did not tint the background"
+        ok = false
+      end
     end
     win.dispose
     skin.dispose
@@ -637,20 +673,15 @@ module RGSS
     # scripts: openness x16, open?/close? x15, padding x8, arrows_visible x1 (see
     # docs/rpgvx-rgss-api-gap.md).
     #
-    # These are plain state here: the native window is drawn at full size
-    # whatever `openness` says, so the open/close *animation* is not shown yet —
-    # but because the scripts only ever wait on the value they set, a window
-    # still opens, closes and lays out correctly.
+    # `openness=` and `tone`/`tone=` are native (src/lib.cxx): both have to
+    # redraw, since the frame is drawn at a fraction of its height to animate the
+    # open/close and the tone tints the background. They must NOT be defined here
+    # — mrblib loads after the C init and would shadow them. `padding` and the
+    # rest below really are plain state the scripts drive.
 
     # 0 (fully closed) .. 255 (fully open).
     def openness
       @openness.nil? ? 255 : @openness
-    end
-
-    def openness=(value)
-      value = 0 if value < 0
-      value = 255 if value > 255
-      @openness = value
     end
 
     def open?
@@ -682,12 +713,6 @@ module RGSS
     end
 
     attr_writer :arrows_visible
-
-    def tone
-      @tone ||= Tone.new(0, 0, 0, 0)
-    end
-
-    attr_writer :tone
 
     # RGSS2/RGSS3 construct a window with its geometry — `Window.new(x, y,
     # width, height)` — where RGSS1 (XP) took an optional viewport and had the

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -4056,6 +4056,46 @@ Bitmap& window_ensure_canvas(mrb_state* M,
   return c;
 }
 
+// An integer ivar, or `dflt` when it was never assigned. The RGSS2/RGSS3-only
+// window attributes are plain state the scripts drive, so a window that
+// predates them -- an RGSS1 one, or a VX one before its first `openness=` --
+// has no such ivar at all.
+static mrb_int iv_int_or(mrb_state* M,
+                         mrb_value self,
+                         const char* iv,
+                         mrb_int dflt) {
+  const mrb_value v = mrb_iv_get(M, self, mrb_intern_cstr(M, iv));
+  return mrb_nil_p(v) ? dflt : mrb_as_int(M, v);
+}
+
+// RGSS2/RGSS3 Window#tone: a colour tone over the window's *background*, not
+// its frame and not its contents. Applied to the whole canvas right after the
+// background is laid down and before anything is drawn on top, which is what
+// confines it to the background without a second buffer.
+//
+// Unlike Viewport#tone this is not folded in by each child: a window composites
+// itself, so it tones its own pixels. The per-pixel maths is the shared
+// apply_tone_px, so the three tone paths cannot drift apart.
+static void window_apply_tone(mrb_state* M, mrb_value self, Bitmap& canvas) {
+  const mrb_value tv = mrb_iv_get(M, self, mrb_intern_lit(M, "@tone"));
+  if (!mrb_test(tv) || !DATA_PTR(tv))
+    return;
+  const Tone& tn = DataType<Tone>::get(M, tv);
+  if (!tone_is_set(tn))
+    return;
+  for (int y = 0; y < canvas.height; ++y) {
+    for (int x = 0; x < canvas.width; ++x) {
+      int r, g, b, a;
+      bmp_read(canvas, x, y, r, g, b, a);
+      if (a == 0)
+        continue;
+      apply_tone_px(r, g, b, tn);
+      bmp_put(canvas, x, y, r, g, b, a);
+    }
+  }
+  canvas.dirty = true;
+}
+
 // An opacity ivar clamped to 0..255, defaulting to RGSS's 255 when the script
 // never assigned one. It used to read the ivar unconditionally, so setting a
 // windowskin on a window whose opacity had not been set was a TypeError on nil
@@ -4088,8 +4128,25 @@ void window_refresh(mrb_state* M, mrb_value self) {
     return;
   const mrb_int w =
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@width")));
-  const mrb_int h =
+  const mrb_int full_h =
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@height")));
+  // RGSS2/RGSS3 openness: the window unrolls from its horizontal centre line,
+  // so it is drawn at a fraction of its height and shifted down by half of what
+  // it lost. Every VX window opens and closes this way (`Window_Base#open`
+  // steps openness by 48 a frame), and RGSS hides the contents until it is
+  // fully open. 255 -- the default, and every RGSS1 window -- is the ordinary
+  // full draw.
+  const mrb_int openness = std::min<mrb_int>(
+      255, std::max<mrb_int>(0, iv_int_or(M, self, "@openness", 255)));
+  const mrb_int h = full_h * openness / 255;
+  lv_obj_set_y(obj, (int32_t)(iv_int_or(M, self, "@y", 0) + (full_h - h) / 2));
+  if (h <= 0) {
+    // Fully closed: nothing to draw, and a zero-height canvas is not a valid
+    // LVGL buffer, so size the object away instead.
+    lv_obj_set_size(obj, (int32_t)w, 0);
+    lv_obj_invalidate(obj);
+    return;
+  }
   window_ensure_canvas(M, self, w, h);
   const mrb_value canvas =
       mrb_iv_get(M, self, mrb_intern_lit(M, "@_win_canvas"));
@@ -4125,35 +4182,62 @@ void window_refresh(mrb_state* M, mrb_value self) {
         }
       }
     }
+    // The tone tints the background only, so it goes on before the frame and
+    // the contents are drawn over it.
+    window_apply_tone(M, self, DataType<Bitmap>::get(M, canvas));
     // Frame: the 64x64 border at (128,0), a 9-slice with 16px corners/margins.
-    const mrb_value tl[] = {mrb_fixnum_value(0), mrb_fixnum_value(0), skin,
-                            make_rect(M, 128, 0, b, b), mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, blt, 5, tl);
-    const mrb_value tr[] = {mrb_fixnum_value(w - b), mrb_fixnum_value(0), skin,
-                            make_rect(M, 176, 0, b, b), mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, blt, 5, tr);
-    const mrb_value bl[] = {mrb_fixnum_value(0), mrb_fixnum_value(h - b), skin,
-                            make_rect(M, 128, 48, b, b), mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, blt, 5, bl);
-    const mrb_value br[] = {mrb_fixnum_value(w - b), mrb_fixnum_value(h - b),
-                            skin, make_rect(M, 176, 48, b, b),
-                            mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, blt, 5, br);
-    const mrb_value top[] = {make_rect(M, b, 0, w - 2 * b, b), skin,
-                             make_rect(M, 144, 0, 32, b), mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, sblt, 4, top);
-    const mrb_value bottom[] = {make_rect(M, b, h - b, w - 2 * b, b), skin,
-                                make_rect(M, 144, 48, 32, b),
-                                mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, sblt, 4, bottom);
-    const mrb_value left[] = {make_rect(M, 0, b, b, h - 2 * b), skin,
-                              make_rect(M, 128, 16, b, 32),
+    // The corner shrinks vertically with a part-open window, so a half-unrolled
+    // one keeps a frame instead of drawing its top and bottom borders over each
+    // other (h is the *drawn* height -- see openness above).
+    const mrb_int bv = std::min<mrb_int>(b, h / 2);
+    if (bv > 0) {
+      const mrb_value tl[] = {mrb_fixnum_value(0), mrb_fixnum_value(0), skin,
+                              make_rect(M, 128, 0, b, bv),
                               mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, sblt, 4, left);
-    const mrb_value right[] = {make_rect(M, w - b, b, b, h - 2 * b), skin,
-                               make_rect(M, 176, 16, b, 32),
+      mrb_funcall_argv(M, canvas, blt, 5, tl);
+      const mrb_value tr[] = {mrb_fixnum_value(w - b), mrb_fixnum_value(0),
+                              skin, make_rect(M, 176, 0, b, bv),
+                              mrb_fixnum_value(op)};
+      mrb_funcall_argv(M, canvas, blt, 5, tr);
+      const mrb_value bl[] = {mrb_fixnum_value(0), mrb_fixnum_value(h - bv),
+                              skin, make_rect(M, 128, 64 - bv, b, bv),
+                              mrb_fixnum_value(op)};
+      mrb_funcall_argv(M, canvas, blt, 5, bl);
+      const mrb_value br[] = {mrb_fixnum_value(w - b), mrb_fixnum_value(h - bv),
+                              skin, make_rect(M, 176, 64 - bv, b, bv),
+                              mrb_fixnum_value(op)};
+      mrb_funcall_argv(M, canvas, blt, 5, br);
+      const mrb_value top[] = {make_rect(M, b, 0, w - 2 * b, bv), skin,
+                               make_rect(M, 144, 0, 32, bv),
                                mrb_fixnum_value(op)};
-    mrb_funcall_argv(M, canvas, sblt, 4, right);
+      mrb_funcall_argv(M, canvas, sblt, 4, top);
+      const mrb_value bottom[] = {make_rect(M, b, h - bv, w - 2 * b, bv), skin,
+                                  make_rect(M, 144, 64 - bv, 32, bv),
+                                  mrb_fixnum_value(op)};
+      mrb_funcall_argv(M, canvas, sblt, 4, bottom);
+    }
+    if (h > 2 * bv) {
+      const mrb_value left[] = {make_rect(M, 0, bv, b, h - 2 * bv), skin,
+                                make_rect(M, 128, 16, b, 32),
+                                mrb_fixnum_value(op)};
+      mrb_funcall_argv(M, canvas, sblt, 4, left);
+      const mrb_value right[] = {make_rect(M, w - b, bv, b, h - 2 * bv), skin,
+                                 make_rect(M, 176, 16, b, 32),
+                                 mrb_fixnum_value(op)};
+      mrb_funcall_argv(M, canvas, sblt, 4, right);
+    }
+  } else {
+    // No windowskin: the tone still applies to whatever background there is.
+    window_apply_tone(M, self, DataType<Bitmap>::get(M, canvas));
+  }
+
+  // Everything below is window *furniture* -- contents, cursor, pause arrow --
+  // which RGSS hides entirely while a window is opening or closing. Only the
+  // frame animates.
+  if (openness < 255) {
+    mrb_gc_arena_restore(M, arena);
+    lv_obj_invalidate(obj);
+    return;
   }
 
   const mrb_value cont = mrb_iv_get(M, self, mrb_intern_lit(M, "@contents"));
@@ -4373,10 +4457,65 @@ mrb_value window_set_stretch(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// A single number standing for a Tone's four channels, so a change can be
+// spotted with one comparison. Shared with the viewport's tone tracking.
+double vp_tone_key(const Tone& t);
+
+// RGSS2/RGSS3 Window#openness: 0 (closed) .. 255 (open). Native rather than
+// plain state because assigning it has to redraw -- the frame is drawn at a
+// fraction of its height (see window_refresh), which *is* the open/close
+// animation. `Window_Base#open` steps this by 48 a frame.
+mrb_value window_set_openness(mrb_state* M, mrb_value self) {
+  mrb_int v;
+  mrb_get_args(M, "i", &v);
+  v = std::min<mrb_int>(255, std::max<mrb_int>(0, v));
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@openness"), mrb_fixnum_value(v));
+  window_refresh(M, self);
+  return mrb_fixnum_value(v);
+}
+
+// RGSS2/RGSS3 Window#tone, created on first read like the viewport's so
+// `window.tone.set(...)` has something to mutate.
+mrb_value window_tone(mrb_state* M, mrb_value self) {
+  mrb_value t = mrb_iv_get(M, self, mrb_intern_lit(M, "@tone"));
+  if (mrb_nil_p(t)) {
+    const mrb_value args[] = {mrb_fixnum_value(0), mrb_fixnum_value(0),
+                              mrb_fixnum_value(0), mrb_fixnum_value(0)};
+    t = mrb_obj_new(
+        M, mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Tone"), 4, args);
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@tone"), t);
+  }
+  return t;
+}
+
+mrb_value window_set_tone(mrb_state* M, mrb_value self) {
+  mrb_value t;
+  mrb_get_args(M, "o", &t);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@tone"), t);
+  window_refresh(M, self);
+  return t;
+}
+
+// Whether the tone changed since the last check. The scripts mutate the Tone
+// *in place* (`window.tone.set(...)`) and call update every frame, so
+// assignment alone is not enough to notice -- the same reason Viewport#tone is
+// re-checked from its own update. One comparison when it did not move.
+bool window_sync_tone(mrb_state* M, mrb_value self) {
+  const mrb_value tv = mrb_iv_get(M, self, mrb_intern_lit(M, "@tone"));
+  const double key = (mrb_test(tv) && DATA_PTR(tv))
+                         ? vp_tone_key(DataType<Tone>::get(M, tv))
+                         : 0.0;
+  const mrb_value prev = mrb_iv_get(M, self, mrb_intern_lit(M, "@_tone_key"));
+  if (mrb_float_p(prev) && mrb_float(prev) == key)
+    return false;
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tone_key"), mrb_float_value(M, key));
+  return true;
+}
+
 // Per-frame tick: advance the blink/pause animation and, when the window has a
 // visible cursor or is paused, redraw so the animation and any in-place
 // cursor_rect mutation show. Windows without a cursor or pause need no
-// per-frame work.
+// per-frame work beyond the tone check, which is one comparison.
 mrb_value window_update(mrb_state* M, mrb_value self) {
   const mrb_int anim =
       mrb_as_int(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@_anim")));
@@ -4388,7 +4527,8 @@ mrb_value window_update(mrb_state* M, mrb_value self) {
                           DataType<Rect>::get(M, cr).width > 0;
   const bool paused =
       mrb_test(mrb_iv_get(M, self, mrb_intern_lit(M, "@pause")));
-  if (has_cursor || paused)
+  const bool tone_moved = window_sync_tone(M, self);
+  if (has_cursor || paused || tone_moved)
     window_refresh(M, self);
   return self;
 }
@@ -5124,6 +5264,13 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, window, "pause=", window_set_pause, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "stretch=", window_set_stretch, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "update", window_update, MRB_ARGS_NONE());
+  // RGSS2 / RGSS3 (VX, VX Ace): the open/close animation and the background
+  // tone. Native because both have to redraw -- and so they must NOT be
+  // redefined in mrblib, which loads after this and would shadow them.
+  mrb_define_method(M, window, "openness=", window_set_openness,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(M, window, "tone", window_tone, MRB_ARGS_NONE());
+  mrb_define_method(M, window, "tone=", window_set_tone, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "z=", obj_set_z, MRB_ARGS_REQ(1));
   mrb_define_method(M, window, "visible", obj_visible, MRB_ARGS_NONE());
   mrb_define_method(M, window, "visible=", obj_set_visible, MRB_ARGS_REQ(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -957,15 +957,22 @@ end
 
 assert "RGSS::Window RGSS2/RGSS3 API surface" do
   # Window.new needs a live display (see the Tilemap note below), so assert the
-  # VX/VX Ace surface is defined; the behaviour of these accessors is exercised
-  # by the VX runtime checks (scripts/rpgvx_testbed_check.rb). The dual-form
-  # constructor (RGSS1's optional viewport / RGSS2's x, y, width, height) needs
-  # no assertion here: it aliases the native initialize at load, so a broken
-  # alias would fail the whole gem, not one test.
+  # VX/VX Ace surface is defined; what these accessors actually *draw* is
+  # measured on a real display by RGSS.window_probe (the render_probe ctest).
+  # The dual-form constructor (RGSS1's optional viewport / RGSS2's x, y, width,
+  # height) needs no assertion here: it aliases the native initialize at load, so
+  # a broken alias would fail the whole gem, not one test.
   %i[openness openness= open? close? padding padding= padding_bottom
      padding_bottom= arrows_visible arrows_visible= tone tone=].each do |m|
     assert_true RGSS::Window.method_defined?(m), "Window##{m} missing"
   end
+  # `openness=`, `tone` and `tone=` must stay native: each redraws, and a
+  # plain-Ruby accessor would store the value and animate nothing. mrblib loads
+  # after the C init, so re-adding one there silently shadows the native and the
+  # window stops opening. That cannot be told apart from here — this mruby has no
+  # instance_method/source_location to ask with — so the guard is
+  # RGSS.window_probe, which measures the area the window covers at three
+  # openness values and fails if it does not change.
 end
 
 assert "RGSS::Viewport RGSS2/RGSS3 screen-effect surface" do


### PR DESCRIPTION
Item 4 of [`docs/rpgvx-rgss-api-gap.md`](https://github.com/take-cheeze/rpg-maker-clone/blob/master/docs/rpgvx-rgss-api-gap.md), unblocked by [#332](https://github.com/take-cheeze/rpg-maker-clone/pull/332) — the native `RGSS::Window` had to be reachable before either of these could draw anything.

Both were stored-but-never-drawn, and that combination is the quiet kind: the value goes in, the screen never changes, and because the stock scripts only ever wait on the value they set (`Window_Base#open` steps `openness` by 48 a frame and polls `open?`), a game looks correct while every menu appears instantly.

## `openness`

The window unrolls from its horizontal centre line: the frame is composited at `height * openness / 255` and the object shifted down by half of what it lost, so it grows out of the middle the way RGSS does. The 9-slice's corner height is clamped to half the drawn height, so a part-open window keeps a frame rather than laying its top and bottom borders over each other. Contents, cursor and pause arrow stay hidden until it is fully open — only the frame animates.

## `Window#tone`

Applied to the **background** only: laid on the canvas right after the background tile and before the frame and contents go over it, which confines it without needing a second buffer. Unlike `Viewport#tone` it is not folded in by children — a window composites itself, so it tones its own pixels — but the per-pixel maths is the same shared `apply_tone_px`, so the three tone paths cannot drift apart. `Window#update` re-checks it, because the scripts mutate the Tone in place (`window.tone.set(...)`); one comparison a frame when it has not moved.

Both are native, and deliberately **not** redefined in mrblib. That loads after the C init, so a Ruby accessor there shadows the native one and silently goes back to storing a value that draws nothing — the trap `Viewport#tone` had to be rescued from once already.

## Verification

`RGSS.window_probe` measures **area**: a 320×240 solid-blue window on a 544×416 screen, so the frame's mean blue is the fraction of the screen it covers.

```
[RGSS-PROBE] window alive=true drawn=[0, 0, 86] half=[0, 0, 43] closed=[0, 0, 0] toned=[86, 0, 86]
```

| | measured | expected |
| --- | --- | --- |
| fully open | 86 | 255 × 320×240 / (544×416) = 86.5 |
| `openness = 128` | 43 | half of 86 |
| `openness = 0` | 0 | nothing drawn |
| red tone, fully open | red 86 | additive +255 clamps, so red reaches the coverage value |

Confirmed non-vacuous by breaking each half in turn — and each broke only its own assertion:

- drawing at full height regardless of openness → `FAIL openness=128 covered 86 of 86` and `FAIL openness=0 still drew something`, tone still fine
- skipping the tone pass → `FAIL Window#tone did not tint the background`, animation still fine

Also green: ctest 3/3 (`mruby_test` 1707, `render_probe`, `audio_probe`), the three RPG2000 checks, XP and VX test beds, and the XP, RPG2003 and packed-archive boot smokes.

One note on the tests: I tried to pin "these accessors must stay native" headlessly via `instance_method(...).source_location`, but this mruby has neither, so the check crashed. Removed it rather than leave something that only appeared to guard — `window_probe` is the real guard, since a Ruby setter that merely stores fails the half and closed measurements.

## Where VX stands

A bundle now loads its database, plays its music, reads input, drives frames, lays out its windows, draws its map, tints/flashes/fades the screen, dissolves between scenes, unrolls and tints its windows, and finds its graphics and music packed or loose. What remains is `Bitmap#blur`/`#radial_blur` (one use each) and two tilemap polish items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_