### PR TITLE
Pin BattlePage.check_turns to its EasyRPG source

### DIFF
--- a/changelog.d/rpg2k-check-turns-provenance.changed.md
+++ b/changelog.d/rpg2k-check-turns-provenance.changed.md
@@ -1,0 +1,12 @@
+- RPG Maker 2000: recorded where `Game::BattlePage.check_turns` comes from and
+  pinned it to that source. Both the body and the argument order are EasyRPG
+  Player's — `Game_Battle::CheckTurns(turns, base, multiple)`, called as
+  `CheckTurns(GetTurn(), condition.turn_b, condition.turn_a)`, so `base` is the
+  page's `turn_b` and `multiple` its `turn_a`, which reads backwards from the
+  field names and is worth writing down. A new check cross-checks the Ruby
+  against that C expression over a grid of turn / base / multiple values, so the
+  simplification of the `multiple == 0` branch to `turn == base` stays honest.
+  The comment also now states what the real-game data can and cannot show: every
+  turn-gated page in the games checked so far has `turn_b == 0`, so a swapped
+  argument order would produce the same observed behaviour — the ordering rests
+  on the source, not on the data.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2527,10 +2527,26 @@ module Game
     TURN_ACTOR    = 0x100
     COMMAND_ACTOR = 0x200
 
-    # RPG2000's turn matcher (EasyRPG's `Game_Battle::CheckTurns`): with no
-    # `multiple` the turn must equal `base` exactly; otherwise it must be at or
-    # past `base` and an exact number of `multiple` steps beyond it. So
-    # base 0 / multiple 2 fires on turns 0, 2, 4, ...
+    # RPG2000's turn matcher: with no `multiple` the turn must equal `base`
+    # exactly; otherwise it must be at or past `base` and an exact number of
+    # `multiple` steps beyond it. So base 0 / multiple 2 fires on turns 0, 2,
+    # 4, ...
+    #
+    # Both the body and the argument order are taken from EasyRPG Player, not
+    # from guesswork: `Game_Battle::CheckTurns(int turns, int base, int
+    # multiple)` is `turns >= base && (turns - base) == 0` when multiple is 0
+    # (which is just `turns == base`, written that way below) and
+    # `turns >= base && (turns - base) % multiple == 0` otherwise; and
+    # `Game_Interpreter_Battle::AreConditionsMet` calls it as
+    # `CheckTurns(GetTurn(), condition.turn_b, condition.turn_a)` — so `base` is
+    # the page's `turn_b` and `multiple` its `turn_a`, which reads backwards
+    # from the field names and is exactly why it is worth writing down.
+    #
+    # Real data agrees but cannot by itself pin the order down: every turn-gated
+    # page in the games checked so far has `turn_b == 0` (156 pages at
+    # multiple 0, firing on turn 0; 9 at multiple 1, firing every turn), and a
+    # swapped order would produce the same two behaviours for those values. A
+    # game with a "from turn N, every M" page would settle it independently.
     def self.check_turns(turn, base, multiple)
       return turn == base if multiple.nil? || multiple == 0
       turn >= base && (turn - base) % multiple == 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5237,6 +5237,27 @@ check 'battle-event opcodes match the LCF Code enum' do
   eq 23311, IC::END_BRANCH_B
 end
 
+check 'BattlePage.check_turns matches EasyRPG CheckTurns exactly' do
+  # Transcribed from Game_Battle::CheckTurns(turns, base, multiple):
+  #   multiple == 0 -> turns >= base && (turns - base) == 0
+  #   otherwise     -> turns >= base && (turns - base) % multiple == 0
+  # Cross-check the Ruby against that C expression over a grid, so the
+  # simplification of the first branch to `turn == base` stays honest.
+  (0..8).each do |turn|
+    (0..4).each do |base|
+      (0..3).each do |mult|
+        want = if mult == 0
+                 turn >= base && (turn - base) == 0
+               else
+                 turn >= base && (turn - base) % mult == 0
+               end
+        got = BP.check_turns(turn, base, mult)
+        eq want, got, "turn=#{turn} base=#{base} multiple=#{mult}"
+      end
+    end
+  end
+end
+
 check 'BattlePage.check_turns matches RPG2000 turn arithmetic' do
   # No multiple: the turn must equal the base exactly.
   ok BP.check_turns(3, 3, 0)


### PR DESCRIPTION
A follow-up to #331. That PR validated the troop page condition *flags* against real bytes but left the turn matcher's provenance vague — I had described its argument order as unproven. Checking the source, it is not: it just was not written down.

## What the source says

```cpp
bool Game_Battle::CheckTurns(int turns, int base, int multiple) {
    if (multiple == 0) {
        return turns >= base && (turns - base) == 0;
    } else {
        return turns >= base && (turns - base) % multiple == 0;
    }
}
```

and `Game_Interpreter_Battle::AreConditionsMet` calls it as:

```cpp
CheckTurns(Game_Battle::GetTurn(), condition.turn_b, condition.turn_a)
```

So **`base` is the page's `turn_b` and `multiple` its `turn_a`** — which reads backwards from the field names, and is exactly the kind of thing that gets silently swapped later. Now recorded on `check_turns`.

The `multiple == 0` branch is `turns >= base && (turns - base) == 0`, which is just `turns == base` — the simplification the Ruby already had. Confirmed rather than assumed.

## Keeping it honest

A new check cross-checks the Ruby against that C expression over a grid of turn / base / multiple values, so the simplified branch cannot drift from the source it claims to implement:

```ruby
want = if mult == 0
         turn >= base && (turn - base) == 0
       else
         turn >= base && (turn - base) % mult == 0
       end
eq want, BP.check_turns(turn, base, mult)
```

## What the data can and cannot show

The comment now separates the two, because #331's write-up blurred them. Every turn-gated page in the games checked so far has `turn_b == 0` — 156 pages at multiple 0 (fire on turn 0) and 9 at multiple 1 (fire every turn). **A swapped argument order would produce the same two behaviours for those values**, so the real-game data neither confirms nor contradicts the ordering; it rests on the source. A game with a "from turn N, every M" page would settle it independently, and `analyze_game.rb --troops` will surface one the moment a test bed has it.

## Verification

`rpg2k_logic_check.rb` 378 (was 377) and `rpg2k_scene_check.rb` 111, both green. No runtime behaviour change — the grid check confirms `check_turns` was already correct; this PR adds the provenance and the test that holds it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_