### PR TITLE
Add Bitmap#blur and Bitmap#radial_blur

### DIFF
--- a/changelog.d/rgss-bitmap-blurs.added.md
+++ b/changelog.d/rgss-bitmap-blurs.added.md
@@ -1,0 +1,25 @@
+- **`RGSS::Bitmap#blur` and `#radial_blur`.** The last two `Bitmap` methods the
+  stock VX Ace scripts call (one use each — the title background and the
+  animation effects), and with them `Bitmap` is complete for that script set.
+  - `blur` is a 3×3 box blur run over a **snapshot** of the bitmap, so every
+    output pixel reads the original neighbourhood. Blurring in place would feed
+    already-blurred pixels back in and smear along the scan order rather than
+    evenly — the test pins the exact seam values a correct one produces (170 and
+    85 either side of a white/black edge), which is what catches that.
+  - `radial_blur(angle, division)` averages `division` copies of the image
+    spread evenly over `angle` degrees and **centred on the original**, so the
+    result is symmetric rather than smeared to one side. Samples that rotate off
+    the bitmap contribute nothing, keeping the corners from pulling in
+    transparent pixels. `division < 2` or `angle == 0` is the identity rather
+    than a divide by zero.
+  - Both average the channels **premultiplied by alpha**, so a transparent
+    neighbour contributes weight but no colour instead of dragging colour out of
+    an opaque pixel.
+
+  These are pure pixel work, so unlike the recent rendering additions they are
+  pinned in `mruby-rgss/test` rather than measured on a display. Worth noting
+  what that took: the obvious `radial_blur` assertions — a flat fill comes back
+  unchanged, a mark spreads — both pass even when the image is rotated about the
+  *wrong point*, because a flat fill is invariant under any rotation and a mark
+  spreads whatever it turns about. The test now asserts the swept arc is
+  mirror-symmetric about the centre column, which does catch it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -938,10 +938,20 @@ screen (544×416). Full rationale:
     redefined in mrblib (which loads after the C init and would shadow them).
     Measured by `RGSS.window_probe`: `drawn=[0,0,86] half=[0,0,43]
     closed=[0,0,0] toned=[86,0,86]`.
+  - ✅ **`Bitmap#blur` / `#radial_blur`** — the title background and the
+    animation effects. `blur` is a 3x3 box blur over a snapshot of the bitmap,
+    so each output pixel reads the original neighbourhood instead of feeding
+    already-blurred pixels back in; `radial_blur(angle, division)` averages
+    `division` rotated copies spread over `angle` degrees and centred on the
+    original. Both average premultiplied by alpha, so a transparent neighbour
+    contributes weight but no colour. Pure pixel work, so unlike the rest of
+    this section they are pinned in `mruby-rgss/test` rather than measured on a
+    display — down to the exact seam values (170/85 either side of a
+    white/black edge) and the mirror symmetry of the swept arc, which is what
+    actually pins the centre of rotation.
   - Remaining, all native `mruby-rgss` work: `Viewport#tone` on `Window`
     contents (a different composite path; RGSS keeps windows in their own
-    viewport, so a map tint does not tint the message window anyway) and
-    `Bitmap#blur`/`#radial_blur`.
+    viewport, so a map tint does not tint the message window anyway).
 - **Built-in title/map flow** — the reimplemented scene stack the RPG2000 and XP
   runtimes have (title → New Game → walkable map). Not written yet; a boot
   without the script host reports that instead of showing a blank window.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -41,8 +41,8 @@ first frame, not what RGSS3 defines.
   records.
 - **`Bitmap`** — `new` (~13), `draw_text` (~55), `fill_rect` (~14), `text_size`
   (~8), `gradient_fill_rect` (~5), `blt` (~3), `clear_rect` (~2), `get_pixel`
-  (~2), `stretch_blt`, `hue_change`, `clear`, `font`, `dispose`. _Complete for
-  the stock scripts bar the two blurs below._
+  (~2), `stretch_blt`, `hue_change`, `clear`, `font`, `dispose`, `blur`,
+  `radial_blur`. _Complete for the stock scripts._
 - **`Font`** — instance attributes plus the class defaults the scripts read
   (`default_size`, `default_bold`, `default_italic`).
 - **`Input`** — **RGSS2/RGSS3 spell keys as symbols** (`Input.trigger?(:C)`), and
@@ -223,9 +223,32 @@ halves were confirmed non-vacuous by breaking them in turn.
 
 ### 5. `Bitmap#blur` / `#radial_blur`
 
-### 5. `Bitmap#blur` / `#radial_blur`
+### 5. `Bitmap#blur` / `#radial_blur` ✅
 
-One use each (title background, animation effects). Cosmetic.
+One use each (title background, animation effects), both native now.
+
+`blur` is a 3×3 box blur run over a snapshot of the bitmap, so every output
+pixel reads the *original* neighbourhood — blurring in place would feed
+already-blurred pixels back in and smear along the scan order instead of evenly.
+Edge pixels average only the neighbours that exist, so the border is not dragged
+toward transparent. RGSS's own blur takes no parameters, so there is nothing to
+tune.
+
+`radial_blur(angle, division)` averages `division` copies of the image spread
+evenly over `angle` degrees and centred on the original, so the result is
+symmetric rather than smeared to one side. Samples that rotate off the bitmap
+contribute nothing, which keeps the corners from pulling in transparent pixels.
+`division < 2` or `angle == 0` is the identity.
+
+Both average the channels **premultiplied by alpha**: a transparent neighbour
+then contributes weight but no colour, instead of dragging colour out of an
+opaque pixel.
+
+Unlike the rest of this document these are pure pixel work, so they are pinned
+properly in `mruby-rgss/test` rather than measured on a display — including the
+exact seam values a box blur produces (170 and 85 either side of a white/black
+edge) and the mirror symmetry of the swept arc, which is what actually pins the
+centre of rotation.
 
 ### 6. Reading graphics and audio out of the encrypted archive ✅
 
@@ -284,5 +307,5 @@ the only route to a real game. A bundle now **runs**: it loads its database,
 plays its music, reads input, drives frames, lays out its windows, draws its map,
 tints, flashes and fades the screen, dissolves between scenes, unrolls and tints
 its windows, and — packed or loose — finds its graphics and its music. What is
-left is `Bitmap#blur`/`#radial_blur` (item 5, one use each) and the two tilemap
-polish items in item 1.
+left is the two tilemap polish items in item 1 — the flat "above characters"
+layer and the A2 table edge.

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1376,6 +1376,126 @@ mrb_value bmp_gradient_fill_rect(mrb_state* M, V self) {
 // RGSS Bitmap#hue_change(hue): rotate every pixel's hue by `hue` degrees,
 // preserving saturation, value and alpha (an RGB -> HSV -> RGB pass, matching
 // RMXP's hue rotation). A hue of 0 (mod 360) is a no-op.
+// RGSS Bitmap#blur: soften the whole bitmap in place.
+//
+// A 3x3 box blur, run over a copy so every output pixel reads the *original*
+// neighbourhood -- blurring in place would feed already-blurred pixels back in
+// and smear along the scan order rather than evenly. Edge pixels average only
+// the neighbours that exist, so the border is not darkened toward transparent.
+//
+// The channels are averaged premultiplied by alpha, which is what stops a
+// transparent neighbour dragging colour out of an opaque pixel: a transparent
+// pixel has no colour to contribute, only weight. RGSS's own blur is a
+// fixed, mild one with no parameters, so there is nothing here to tune.
+mrb_value bmp_blur(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  if (b.width < 1 || b.height < 1)
+    return self;
+  const std::vector<uint8_t> src = b.buffer;
+  // Read through the untouched copy, not the bitmap being written.
+  auto read_src = [&](int32_t x, int32_t y, int& r, int& g, int& bl, int& a) {
+    const unsigned bpp = lv_color_format_get_size(b.format);
+    const uint8_t* p = src.data() + ((size_t)y * b.width + x) * bpp;
+    bl = p[0];
+    g = p[1];
+    r = p[2];
+    a = bpp >= 4 ? p[3] : 255;
+  };
+  for (int32_t y = 0; y < b.height; ++y) {
+    for (int32_t x = 0; x < b.width; ++x) {
+      int rs = 0, gs = 0, bs = 0, as = 0, n = 0;
+      for (int32_t dy = -1; dy <= 1; ++dy) {
+        for (int32_t dx = -1; dx <= 1; ++dx) {
+          const int32_t sx = x + dx, sy = y + dy;
+          if (sx < 0 || sy < 0 || sx >= b.width || sy >= b.height)
+            continue;
+          int r, g, bl, a;
+          read_src(sx, sy, r, g, bl, a);
+          rs += r * a / 255;
+          gs += g * a / 255;
+          bs += bl * a / 255;
+          as += a;
+          ++n;
+        }
+      }
+      if (n == 0)
+        continue;
+      const int a = as / n;
+      // Undo the premultiply. A fully transparent result has no colour to
+      // recover, so leave it black rather than dividing by zero.
+      const int r = a > 0 ? std::min(255, rs * 255 / n / a) : 0;
+      const int g = a > 0 ? std::min(255, gs * 255 / n / a) : 0;
+      const int bl = a > 0 ? std::min(255, bs * 255 / n / a) : 0;
+      bmp_put(b, x, y, r, g, bl, a);
+    }
+  }
+  b.dirty = true;
+  return self;
+}
+
+// RGSS Bitmap#radial_blur(angle, division): a rotational blur about the centre.
+//
+// `division` copies of the image, spread evenly over `angle` degrees and
+// centred on the original (so the result is symmetric rather than smeared to
+// one side), averaged together. Sampling is nearest-neighbour; samples that
+// rotate off the bitmap contribute nothing, which keeps the corners from
+// pulling in transparent pixels and going dark. As in #blur the average is
+// taken premultiplied.
+//
+// division < 2 or angle == 0 is the identity, matching "no rotation to spread
+// over" rather than dividing by zero.
+mrb_value bmp_radial_blur(mrb_state* M, V self) {
+  Bitmap& b = bmp_self(M, self);
+  mrb_int angle, division;
+  mrb_get_args(M, "ii", &angle, &division);
+  if (division < 2 || angle == 0 || b.width < 1 || b.height < 1)
+    return self;
+  const std::vector<uint8_t> src = b.buffer;
+  const unsigned bpp = lv_color_format_get_size(b.format);
+  auto read_src = [&](int32_t x, int32_t y, int& r, int& g, int& bl, int& a) {
+    const uint8_t* p = src.data() + ((size_t)y * b.width + x) * bpp;
+    bl = p[0];
+    g = p[1];
+    r = p[2];
+    a = bpp >= 4 ? p[3] : 255;
+  };
+  const double cx = (b.width - 1) / 2.0;
+  const double cy = (b.height - 1) / 2.0;
+  const double span = angle * 3.14159265358979323846 / 180.0;
+  for (int32_t y = 0; y < b.height; ++y) {
+    for (int32_t x = 0; x < b.width; ++x) {
+      int rs = 0, gs = 0, bs = 0, as = 0, n = 0;
+      for (mrb_int k = 0; k < division; ++k) {
+        // -span/2 .. +span/2, so the unrotated image sits in the middle.
+        const double t = (double)k / (double)(division - 1) - 0.5;
+        const double th = span * t;
+        const double s = std::sin(th), c = std::cos(th);
+        const double dx = x - cx, dy = y - cy;
+        const int32_t sx = (int32_t)std::lround(cx + dx * c - dy * s);
+        const int32_t sy = (int32_t)std::lround(cy + dx * s + dy * c);
+        if (sx < 0 || sy < 0 || sx >= b.width || sy >= b.height)
+          continue;
+        int r, g, bl, a;
+        read_src(sx, sy, r, g, bl, a);
+        rs += r * a / 255;
+        gs += g * a / 255;
+        bs += bl * a / 255;
+        as += a;
+        ++n;
+      }
+      if (n == 0)
+        continue;
+      const int a = as / n;
+      const int r = a > 0 ? std::min(255, rs * 255 / n / a) : 0;
+      const int g = a > 0 ? std::min(255, gs * 255 / n / a) : 0;
+      const int bl = a > 0 ? std::min(255, bs * 255 / n / a) : 0;
+      bmp_put(b, x, y, r, g, bl, a);
+    }
+  }
+  b.dirty = true;
+  return self;
+}
+
 mrb_value bmp_hue_change(mrb_state* M, V self) {
   Bitmap& b = bmp_self(M, self);
   mrb_int hue;
@@ -5300,6 +5420,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "gradient_fill_rect", bmp_gradient_fill_rect,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(4));
   mrb_define_method(M, bmp, "hue_change", bmp_hue_change, MRB_ARGS_REQ(1));
+  // RGSS2/RGSS3 blurs: one use each in the stock scripts (the title background
+  // and the animation effects).
+  mrb_define_method(M, bmp, "blur", bmp_blur, MRB_ARGS_NONE());
+  mrb_define_method(M, bmp, "radial_blur", bmp_radial_blur, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -231,6 +231,81 @@ assert "RGSS::Bitmap gradient_fill_rect" do
   assert_equal 255.0, v.get_pixel(1, 8).blue  # bottom row is color2
 end
 
+assert "RGSS::Bitmap#blur softens edges and leaves flat areas alone" do
+  # A flat fill has nothing to average against itself, so a correct box blur is
+  # the identity on it. This is the property that catches a blur which drags in
+  # the transparent border or drifts along the scan order.
+  flat = RGSS::Bitmap.new(4, 4)
+  flat.fill_rect(0, 0, 4, 4, RGSS::Color.new(80, 120, 160, 255))
+  flat.blur
+  px = flat.get_pixel(1, 1)
+  assert_equal 80.0, px.red
+  assert_equal 120.0, px.green
+  assert_equal 160.0, px.blue
+  assert_equal 255.0, px.alpha
+
+  # A hard vertical edge: left half white, right half black. After the blur the
+  # two columns either side of the seam must move toward each other, and the
+  # far columns must not (their 3x3 neighbourhood is still uniform).
+  edge = RGSS::Bitmap.new(6, 3)
+  edge.fill_rect(0, 0, 3, 3, RGSS::Color.new(255, 255, 255, 255))
+  edge.fill_rect(3, 0, 3, 3, RGSS::Color.new(0, 0, 0, 255))
+  edge.blur
+  assert_equal 255.0, edge.get_pixel(0, 1).red, "far side of the edge moved"
+  assert_equal 0.0, edge.get_pixel(5, 1).red, "far side of the edge moved"
+  left = edge.get_pixel(2, 1).red
+  right = edge.get_pixel(3, 1).red
+  assert_true left < 255.0 && left > 0.0, "seam not softened: #{left}"
+  assert_true right < 255.0 && right > 0.0, "seam not softened: #{right}"
+  assert_true left > right, "the gradient runs the wrong way"
+
+  # Blurring reads a snapshot, so it cannot feed its own output back in: the
+  # column left of the seam sees one dark neighbour column out of three.
+  assert_equal 170.0, left   # (255 + 255 + 0) / 3
+  assert_equal 85.0, right   # (255 + 0 + 0) / 3
+end
+
+assert "RGSS::Bitmap#radial_blur spins around the centre" do
+  # Radially symmetric input is a fixed point of a rotation about the centre, so
+  # a flat fill must come back unchanged however hard it is blurred.
+  flat = RGSS::Bitmap.new(9, 9)
+  flat.fill_rect(0, 0, 9, 9, RGSS::Color.new(0, 0, 255, 255))
+  flat.radial_blur(90, 8)
+  assert_equal 255.0, flat.get_pixel(4, 4).blue
+  assert_equal 255.0, flat.get_pixel(0, 4).blue
+
+  # An asymmetric mark must smear along the arc it sweeps. A single bright pixel
+  # directly above the centre of a 9x9 sits at (4, 0), radius 4; blurred over
+  # +/-45 degrees it sweeps row 1 from about x=1 to x=7.
+  #
+  # The arc is *symmetric about the centre column*, and that is what pins the
+  # centre of rotation: a flat fill is invariant under rotation about any point,
+  # and a mark spreads whatever point it turns about, so neither of those alone
+  # would notice the centre being wrong.
+  mark = RGSS::Bitmap.new(9, 9)
+  mark.fill_rect(0, 0, 9, 9, RGSS::Color.new(0, 0, 0, 255))
+  mark.fill_rect(4, 0, 1, 1, RGSS::Color.new(255, 0, 0, 255))
+  mark.radial_blur(90, 9)
+  assert_true mark.get_pixel(4, 0).red < 255.0, "the mark did not spread"
+  swept = (0...9).select { |x| mark.get_pixel(x, 1).red > 0 }
+  assert_true swept.size >= 2, "no arc swept through row 1: #{swept.inspect}"
+  swept.each do |x|
+    mirror = 8 - x
+    assert_equal mark.get_pixel(x, 1).red, mark.get_pixel(mirror, 1).red,
+                 "arc is lopsided at x=#{x} vs #{mirror}: not turning about " \
+                 "the centre"
+  end
+
+  # Degenerate arguments are the identity, not a divide by zero.
+  same = RGSS::Bitmap.new(4, 4)
+  same.fill_rect(0, 0, 4, 4, RGSS::Color.new(10, 20, 30, 255))
+  same.fill_rect(0, 0, 1, 1, RGSS::Color.new(200, 0, 0, 255))
+  same.radial_blur(0, 8)
+  assert_equal 200.0, same.get_pixel(0, 0).red
+  same.radial_blur(90, 1)
+  assert_equal 200.0, same.get_pixel(0, 0).red
+end
+
 assert "RGSS::Bitmap hue_change" do
   # A 120-degree hue rotation maps the primaries exactly: R -> G -> B -> R,
   # preserving saturation, value and alpha.


### PR DESCRIPTION
Item 5 of [`docs/rpgvx-rgss-api-gap.md`](https://github.com/take-cheeze/rpg-maker-clone/blob/master/docs/rpgvx-rgss-api-gap.md) — the last two `Bitmap` methods the stock VX Ace scripts call (one use each: the title background and the animation effects). With these, `Bitmap` is complete for that script set.

## `blur`

A 3×3 box blur run over a **snapshot** of the bitmap, so every output pixel reads the *original* neighbourhood. Blurring in place would feed already-blurred pixels back in and smear along the scan order rather than evenly. Edge pixels average only the neighbours that exist, so the border is not dragged toward transparent. RGSS's own blur takes no parameters, so there is nothing to tune.

## `radial_blur(angle, division)`

`division` copies of the image, spread evenly over `angle` degrees and **centred on the original**, averaged — so the result is symmetric rather than smeared to one side. Samples that rotate off the bitmap contribute nothing, which keeps the corners from pulling in transparent pixels. `division < 2` or `angle == 0` is the identity rather than a divide by zero.

Both average the channels **premultiplied by alpha**, so a transparent neighbour contributes weight but no colour instead of dragging colour out of an opaque pixel.

## Testing

Unlike the recent rendering work, these are pure pixel operations, so they are pinned in `mruby-rgss/test` rather than measured on a display. The blur test asserts the exact seam values a correct box blur produces — 170 and 85 either side of a white/black edge, i.e. `(255+255+0)/3` and `(255+0+0)/3` — which is what catches the in-place variant, and that a flat fill is unchanged.

**The `radial_blur` test is worth a note.** My first version asserted the two obvious things: a flat fill comes back unchanged, and an off-centre mark spreads. Both pass even when the image is rotated about the **wrong point** — a flat fill is invariant under rotation about *any* point, and a mark spreads whatever it turns about. I only found that because I ran a negative control moving the centre to `x = 0` and the test stayed green.

It now asserts the swept arc is mirror-symmetric about the centre column, which does catch it:

```
- Assertion[4] no arc swept through row 1: [5].
- Assertion[5] arc is lopsided at x=5 vs 3: not turning about the centre.
```

Negative controls on both, each failing only its own assertions: reading the live buffer instead of the snapshot breaks the blur seam values, and moving the rotation centre breaks the arc symmetry.

Full sweep green: ctest 3/3 (`mruby_test` 1711, `render_probe`, `audio_probe`), the three RPG2000 checks, the XP and VX test beds, and the XP and RPG2003 boot smokes.

## Where VX stands

A bundle now loads its database, plays its music, reads input, drives frames, lays out its windows, draws its map, tints/flashes/fades the screen, dissolves between scenes, unrolls and tints its windows, and finds its graphics and music packed or loose. What's left in the gap doc is the two tilemap polish items — the flat "above characters" layer and the A2 table edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6qabrU6vjHQf26SXcwtMF)_