### PR TITLE
Read RPG2000 attribute / state rank rates from the database

### DIFF
--- a/changelog.d/rpg2k-battle-db-attribute-state-rates.changed.md
+++ b/changelog.d/rpg2k-battle-db-attribute-state-rates.changed.md
@@ -1,0 +1,13 @@
+- RPG Maker 2000: elemental damage and status infliction now read their **rank
+  rates from the database** instead of a hardcoded table. `Game::Battle` takes an
+  optional attribute (`property`) table and, via `attr_rate` / `state_rate`, reads
+  each attribute's own `a_rate` .. `e_rate` and each state's `situation`-table
+  rates for a target's A..E rank — so a game that customises an element's or a
+  status's effectiveness curve is honored, falling back to the RPG2000 defaults
+  (attributes 300/200/100/50/0, states 100/80/60/30/0) only when no table is
+  supplied. This also corrects the default **attribute** rank-A/B multipliers,
+  which were previously 200%/150% rather than liblcf's 300%/200%. Wired into the
+  live battle from the database `property` and `situation` tables. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks (a database attribute and a database state
+  each override the default rate), with the existing elemental checks updated to
+  the corrected defaults.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -380,9 +380,12 @@ The work below is roughly ordered by the critical path to a walkable game
   `critical_hit_chance`); no crit on a same-side hit. Characters wearing gear with
   the **`prevent_critical`** flag can never be crit. **Elemental attributes**
   scale damage too: a weapon's `attribute_set` / a skill's `attribute_effects`
-  are matched against the target's per-attribute defence ranks (A..E → 200 / 150
-  / 100 / 50 / 0 percent, strongest element winning), so a foe is hurt more by a
-  weakness and can fully nullify an element it is immune to. The party can also
+  are matched against the target's per-attribute defence ranks (A..E, strongest
+  element winning) — the rates come from each attribute's own `a_rate` .. `e_rate`
+  in the database `property` table (RPG2000 defaults 300 / 200 / 100 / 50 / 0),
+  and a status infliction likewise reads the `situation` table's per-state rates
+  — so a foe is hurt more by a weakness and can fully nullify an element it is
+  immune to. The party can also
   **flee**: `Battle#attempt_escape` rolls EasyRPG's agility-ratio chance
   (`150 - 100·enemyAgi/partyAgi`, clamped), a preemptive first strike always
   gets away, and a failed attempt forfeits the party's round (every member
@@ -403,8 +406,8 @@ The work below is roughly ordered by the critical path to a walkable game
   still computed per target's defence. **All-party items** (medicine scope 1)
   work the same way through `command_item_all`, healing / curing every living
   ally and consuming a single item for the whole volley. Still to come:
-  enemy-cast infliction, per-attribute rate overrides from the Attribute table,
-  the per-terrain backdrop and the RPG2000 Game Over graphic.
+  enemy-cast infliction, the per-terrain backdrop and the RPG2000 Game Over
+  graphic.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3273,8 +3273,13 @@ module Game
     # a seeded fight is exactly reproducible; the live game turns them on.
     # `first_strike`, when true, gives the party a pre-emptive opening round: the
     # enemies are caught off guard and skip their turn in round 1 only.
+    # `attributes` is an optional attribute-definition lookup (`[id]` -> a row
+    # exposing `a_rate` .. `e_rate`, e.g. the database's `property` table) so
+    # elemental damage reads each attribute's own rank rates; omitted, the
+    # RPG2000 default table applies.
     def initialize(allies, enemies, rng = nil, states = nil, variance = false,
-                   criticals = false, accuracy = false, first_strike = false)
+                   criticals = false, accuracy = false, first_strike = false,
+                   attributes = nil)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
@@ -3283,6 +3288,7 @@ module Game
       @criticals = criticals
       @accuracy = accuracy
       @first_strike = first_strike
+      @attributes = attributes
       @rounds = 0
       @result = nil
       @escaped = false     # set once the party successfully flees (#attempt_escape)
@@ -3712,11 +3718,24 @@ module Game
       d < 1 ? 1 : d
     end
 
-    # RPG2000's default attribute rate table: a defence rank of A..E (index 0..4)
-    # scales damage to 200 / 150 / 100 / 50 / 0 percent. (Per-attribute overrides
-    # from the database's Attribute table aren't modelled yet — every element uses
-    # these defaults.)
-    ATTR_RATE_PCT = [200, 150, 100, 50, 0].freeze
+    # RPG2000's default attribute rate table (liblcf's RPG::Attribute defaults):
+    # a defence rank of A..E (index 0..4) scales damage to 300 / 200 / 100 / 50 /
+    # 0 percent. Used as the fallback when the fight carries no attribute table
+    # (a bare fixture); a real database's per-attribute `a_rate` .. `e_rate`
+    # override it (see #attr_rate).
+    ATTR_RATE_PCT = [300, 200, 100, 50, 0].freeze
+
+    # The percentage a defence `rank` (0..4) scales damage for attribute `aid`:
+    # the attribute's own `a_rate` .. `e_rate` from the database `property` table
+    # when known, else the RPG2000 default table.
+    def attr_rate(aid, rank)
+      row = @attributes ? @attributes[aid] : nil
+      if row && row.respond_to?(:a_rate)
+        r = [row.a_rate, row.b_rate, row.c_rate, row.d_rate, row.e_rate][rank]
+        return r if r
+      end
+      ATTR_RATE_PCT[rank]
+    end
 
     # The percentage `attr_ids` scale damage against `target`: the strongest
     # (largest) rate among the attack's elements, per EasyRPG's
@@ -3731,7 +3750,7 @@ module Game
         rank = ranks[aid] || 2
         rank = 0 if rank < 0
         rank = 4 if rank > 4
-        pct = ATTR_RATE_PCT[rank]
+        pct = attr_rate(aid, rank)
         best = pct if best.nil? || pct > best
       end
       best || 100
@@ -3838,10 +3857,23 @@ module Game
       end
     end
 
-    # RPG2000's default state rate table: a susceptibility rank of A..E (index
-    # 0..4) scales an infliction chance to 100 / 80 / 60 / 30 / 0 percent.
-    # (Per-state overrides from the database's State table aren't modelled yet.)
+    # RPG2000's default state rate table (liblcf's RPG::State defaults): a
+    # susceptibility rank of A..E (index 0..4) scales an infliction chance to
+    # 100 / 80 / 60 / 30 / 0 percent. Used as the fallback; a state row that
+    # carries its own `a_rate` .. `e_rate` (the `situation` table) overrides it.
     STATE_RATE_PCT = [100, 80, 60, 30, 0].freeze
+
+    # The percentage a susceptibility `rank` (0..4) scales an infliction of state
+    # `sid`: the state's own `a_rate` .. `e_rate` from the situation table when
+    # known, else the RPG2000 default table.
+    def state_rate(sid, rank)
+      row = state_def(sid)
+      if row && row.respond_to?(:a_rate)
+        r = [row.a_rate, row.b_rate, row.c_rate, row.d_rate, row.e_rate][rank]
+        return r if r
+      end
+      STATE_RATE_PCT[rank]
+    end
 
     # The percentage a target's susceptibility scales an infliction of `sid`: its
     # rank in the target's `state_ranks` (default C / 60% for a listed-but-absent
@@ -3853,7 +3885,7 @@ module Game
       rank = ranks[sid] || 2
       rank = 0 if rank < 0
       rank = 4 if rank > 4
-      STATE_RATE_PCT[rank]
+      state_rate(sid, rank)
     end
 
     # Inflict a skill command's `inflict` states on `target`, each landing only if

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2354,10 +2354,12 @@ class RPG2k
         # The database's state table drives per-turn afflictions (poison slip,
         # sleep skip) in battle.
         situations = db.respond_to?(:situation) ? db.situation : nil
+        properties = db.respond_to?(:property) ? db.property : nil
         @battle_ui = { phase: :command, req: req, troop: troop,
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
                                                 situations, true, true, true,
-                                                req[:first_strike] ? true : false),
+                                                req[:first_strike] ? true : false,
+                                                properties),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4040,14 +4040,14 @@ end
 # A weapon / skill carries a set of elements; the target's per-element rank
 # (0=A weakest .. 4=E immune) scales the damage 200/150/100/50/0 percent.
 
-check 'battle: an element the target is weak to amplifies the damage (rank A = 200%)' do
+check 'battle: an element the target is weak to amplifies the damage (rank A = 300%)' do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.atk_attrs = [1]                               # weapon carries element 1
   slime = combatant('Slime', 0, 0, 5, 100_000)
-  slime.attr_ranks = { 1 => 0 }                      # rank A -> 200%
+  slime.attr_ranks = { 1 => 0 }                      # rank A -> 300% (RPG2000 default)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1)) # variance off
   bat.begin_round
-  eq 40, bat.step_action[:damage]                    # base 20 * 200%
+  eq 60, bat.step_action[:damage]                    # base 20 * 300%
 end
 
 check 'battle: an element the target resists halves the damage (rank D = 50%)' do
@@ -4077,10 +4077,10 @@ check 'battle: the attribute multiplier takes the strongest matching element' do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.atk_attrs = [1, 2]                             # two elements
   slime = combatant('Slime', 0, 0, 5, 100_000)
-  slime.attr_ranks = { 1 => 3, 2 => 0 }              # resists 1 (50%), weak to 2 (200%)
+  slime.attr_ranks = { 1 => 3, 2 => 0 }              # resists 1 (50%), weak to 2 (300%)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
   bat.begin_round
-  eq 40, bat.step_action[:damage]                    # max(50%, 200%) -> 40
+  eq 60, bat.step_action[:damage]                    # max(50%, 300%) -> 60
 end
 
 check 'battle: an unlisted element deals full (C = 100%) damage' do
@@ -4096,11 +4096,42 @@ end
 check 'battle: an elemental skill scales its damage by the target resistance' do
   mage = combatant_mp('Mage', 10, 0, 20, 100, 30)
   slime = combatant('Slime', 0, 0, 5, 100_000)
-  slime.attr_ranks = { 3 => 0 }                      # weak to element 3 (200%)
+  slime.attr_ranks = { 3 => 0 }                      # weak to element 3 (300%)
   bat = Game::Battle.new([mage], [slime], Game::Rng.new(1)) # variance off
   bat.command_skill(mage, slime, name: 'Flame', cost: 0, hp: -30, attributes: [3])
   bat.begin_round
-  eq 60, bat.step_action[:damage]                    # 30 * 200%
+  eq 90, bat.step_action[:damage]                    # 30 * 300%
+end
+
+# A property/state row carrying the RPG2000 A..E rank rates (property table).
+RateRow = Struct.new(:a_rate, :b_rate, :c_rate, :d_rate, :e_rate)
+
+check "battle: a database attribute's own rank rates override the defaults" do
+  props = { 1 => RateRow.new(250, 180, 100, 40, 0) } # element 1: rank A = 250%
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1]
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.attr_ranks = { 1 => 0 }                      # rank A
+  # 9-arg: the attribute (property) table is the last arg.
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, false,
+                         false, false, props)
+  bat.begin_round
+  eq 50, bat.step_action[:damage]                    # 20 * 250% (its own rate, not 300)
+end
+
+check "battle: a database state's own rank rate gates the infliction" do
+  # A hardy status: state 3 is 0% at *every* rank, so even a fully-susceptible
+  # (rank A) target never catches it — the DB rate overrides the 100% default.
+  states = { 3 => RateRow.new(0, 0, 0, 0, 0) }
+  mage = combatant_mp('Mage', 10, 0, 20, 100, 30)
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.state_ranks = { 3 => 0 }                       # nominally fully susceptible
+  b = Game::Battle.new([mage], [foe], Game::Rng.new(1), states)
+  b.command_skill(mage, foe, name: 'Poison', cost: 0, hp: -1, inflict: [3], chance: 100)
+  b.begin_round
+  e = b.step_action
+  eq [], e[:inflicted], "the database rate (0%) overrides the rank-A default"
+  ok !foe.state?(3)
 end
 
 check 'Party#battle_skill_command carries the skill elemental attributes' do


### PR DESCRIPTION
## Summary

Makes RPG Maker 2000 elemental damage and status infliction **data-driven**: the A..E rank rates now come from the database instead of a hardcoded table.

- `Game::Battle` takes an optional attribute (`property`) table (9th ctor arg). `attr_rate(aid, rank)` reads that attribute's own `a_rate` .. `e_rate`; `state_rate(sid, rank)` reads the `situation` (state) table's rates (already available via the states lookup). Both fall back to the RPG2000 default tables when no row is supplied (a bare fixture).
- **Bug fix:** the hardcoded attribute default was `[200, 150, 100, 50, 0]`, but liblcf's `RPG::Attribute` defaults (and this repo's own schema, chunk 17 `property`) are **`[300, 200, 100, 50, 0]`**. Corrected — so a rank-A weakness is 300%, rank-B is 200%. The state default `[100, 80, 60, 30, 0]` already matched liblcf.
- Wired into the live battle from `db.property` (and the existing `db.situation`).

Grounded against liblcf `RPG::Attribute` / `RPG::State` field defaults and the repo's LDB schema.

## Testing

- `scripts/rpg2k_logic_check.rb` — 379 checks pass, including 2 new ones (a database attribute and a database state each override the default rate). The three existing elemental checks that encoded the old 200%/150% defaults were corrected to 300%/200%.
- Scene (111) and render (36) harnesses pass; save-load OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD1UxEqgD48eJDA3yVevj)_