### PR TITLE
List the battle-only opcodes instead of matching a range

### DIFF
--- a/changelog.d/rpg2k-troop-page-flags-validated.added.md
+++ b/changelog.d/rpg2k-troop-page-flags-validated.added.md
@@ -1,10 +1,11 @@
 - RPG Maker 2000: `scripts/analyze_game.rb` gained a **`--troops`** mode that
   reports a game's troop battle-event pages — how many carry a condition, which
   condition-flag bits they use, the turn base/multiple pairs and enemy-HP windows
-  those bits imply, which battle-only commands the pages run, and whether any
-  command lacks a handler. This is what validates `Game::BattlePage`'s flag bit
-  assignments against **real bytes** rather than against liblcf's declaration
-  order alone, per ADR 0002.
+  those bits imply, which battle-only commands the pages run (an explicit code
+  set, so the ordinary ShowMessage / Comment continuation markers are not
+  miscounted as battle-only), and whether any command lacks a handler. This is
+  what validates `Game::BattlePage`'s flag bit assignments against **real bytes**
+  rather than against liblcf's declaration order alone, per ADR 0002.
   Run against Nepheshel (3265 troop pages, 2819 conditional) it confirms four
   bits: `switch_a` (0) and `switch_b` (1) — bit 1 only ever appears alongside
   bit 0 and those pages carry a *pair* of plausible switch ids; `turn` (3) — 156

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -321,6 +321,14 @@ end
 BATTLE_PAGE_FLAGS = %w[switch_a switch_b variable turn fatigue enemy_hp
                        actor_hp turn_enemy turn_actor command_actor].freeze
 
+# The commands that only exist inside a battle-event page. Listed explicitly
+# rather than matched as a numeric range: a range over 13000..24000 also catches
+# ShowMessage(cont.) 20110 and Comment(cont.) 22410, which are ordinary
+# continuation markers a battle page uses exactly as a map event does, and
+# reporting them under "battle-only" misrepresents what the page is doing.
+BATTLE_ONLY_CODES = [13110, 13120, 13130, 13150, 13210, 13260, 13310, 13410,
+                     23310, 23311].to_set
+
 def report_troops(dir)
   db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
   pages = 0
@@ -360,7 +368,7 @@ def report_troops(dir)
     puts 'enemy-HP windows (a non-default 0..100 proves the bit):'
     windows.uniq.each { |e, lo, hi| puts "  enemy #{e}: #{lo}..#{hi}%" }
   end
-  battle = cmds.keys.select { |c| c >= 13000 && c < 24000 }.sort
+  battle = cmds.keys.select { |c| BATTLE_ONLY_CODES.include?(c) }.sort
   unless battle.empty?
     puts 'battle-only commands used:'
     battle.each { |c| puts "  #{c} #{(CODE_NAMES[c] || '?').ljust(24)} x#{cmds[c]}" }


### PR DESCRIPTION
A bug in the `--troops` mode #331 added — my own, found while re-reading its output.

The "battle-only commands used" section selected codes with `c >= 13000 && c < 24000`. That range also catches **`20110` ShowMessage(cont.)** and **`22410` Comment(cont.)**, which are ordinary continuation markers a battle page uses exactly as a map event does. So Nepheshel's report credited it with 487 "battle-only" messages and 3 comments it never made:

```diff
 battle-only commands used:
   13120 ChangeMonsterMP          x21
   ...
   13310 ConditionalBranch(B)     x6577
-  20110 ShowMessage(cont.)       x487
-  22410 Comment(cont.)           x3
   23310 ElseBranch(B)            x936
   23311 EndBranch(B)             x6577
```

Naming the ten codes explicitly fixes it, and documents why a range is the wrong tool here so it does not come back.

This matters a little beyond tidiness: the section is evidence about which battle-only commands real games exercise, and I cited it in #331's write-up. Two of the ten rows were not evidence of that at all.

## Changelog

`--troops` is still unreleased, so rather than add a second fragment fixing a feature that never shipped, the pending `rpg2k-troop-page-flags-validated.added.md` is amended to describe the corrected behaviour. One accurate entry rather than an "added X" / "fixed X" pair for the same unreleased change.

## Verification

`--troops` re-run against both test beds — Nepheshel (the eight genuine battle-only codes, no continuation markers) and the RPG2003 mtf-meido-action (88 pages, no conditions, no commands; still handled without dividing by zero on an empty histogram). `rpg2k_logic_check.rb` 377, unchanged — this touches an analysis script only, no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_