### PR TITLE
PrayforYou is an RPG Maker XP game, not an RPG2000 one

### DIFF
--- a/changelog.d/prayforyou-is-an-xp-game.fixed.md
+++ b/changelog.d/prayforyou-is-an-xp-game.fixed.md
@@ -1,0 +1,11 @@
+- Corrected the engine `scripts/download-prayforyou.bash` fetches: "Pray for
+  You" is an RPG Maker **XP** game, not an RPG2000 one. Its `Game.ini` reads
+  `Library=RGSS103J.dll` / `Scripts=Data\Scripts.rxdata`, and the archive ships
+  `RGSS103J.dll`, `Game.exe` and a 14.8 MB packed `Game.rgssad` with no
+  `RPG_RT.ldb` / `.lmu` / `.lmt` anywhere. `run-rpg2k-rpgrt-wine.bash` had
+  listed it alongside Nepheshel as a classic `RPG_RT.exe` game, which it could
+  never have been. Both comments now say what it actually is — and it is a
+  genuinely useful test-bed for the **encrypted-archive** path, being a packed
+  release with no loose `Data/` directory: `RPGXP::RGSSAD.open` reads it
+  cleanly, 222 entries, with `Data\Scripts.rxdata` decrypting to 212792 bytes
+  that start with Marshal's 4 8 magic.

--- a/scripts/download-prayforyou.bash
+++ b/scripts/download-prayforyou.bash
@@ -6,6 +6,18 @@ mkdir -p $(dirname $0)/../data
 
 cd $(dirname $0)/../data
 
+# "Pray for You" -- an RPG Maker **XP** game, despite living among the RPG2000
+# download scripts. Its Game.ini reads `Library=RGSS103J.dll` /
+# `Scripts=Data\Scripts.rxdata`, and the archive ships RGSS103J.dll, Game.exe
+# and a 14.8 MB packed `Game.rgssad` with no RPG_RT.ldb / .lmu / .lmt in sight.
+# That makes it a useful test-bed for the **encrypted-archive** path
+# (mruby-rpgxp's rgssad reader) rather than for anything LCF: the whole database
+# lives inside the .rgssad with no loose Data/ directory to fall back on, which
+# is exactly the "packed release, no loose files" case that path exists for.
+# `RPGXP::RGSSAD.open` reads it cleanly -- 222 entries, with
+# `Data\Scripts.rxdata` coming out as 212792 bytes that start with Marshal's
+# 4 8 magic.
+#
 # See download-nepheshel.bash for why wget/unar are quietened.
 if [ ! -f PrayforYou.zip ] ; then
     wget -nv -O PrayforYou.zip "https://dl.fgamearchives.com/archives/win/3271/PrayforYou.zip"

--- a/scripts/run-rpg2k-rpgrt-wine.bash
+++ b/scripts/run-rpg2k-rpgrt-wine.bash
@@ -5,11 +5,17 @@
 # used by run-rpg2k-wine.bash.
 #
 # The repo's own rpg2k test-bed (mtf-meido-action) only ships EasyRPG's
-# Player.exe, and the classic RPG_RT.exe games referenced by the other download
-# scripts (Nepheshel, PrayforYou) live on hosts that are blocked from
+# Player.exe, and the one classic RPG_RT.exe game the other download scripts
+# fetch (Nepheshel) lives on a host that has been unreliable from
 # sandboxed/proxied CI. So this pulls "Song-of-the-Sea" (by lychees, the same
 # author as the mtf-meido-action test-bed), which ships a real 32-bit
 # RPG_RT.exe (RPG Maker 2003) directly in git.
+#
+# PrayforYou used to be listed here as a second RPG_RT.exe game. It is not one:
+# it is an RPG Maker *XP* project (Game.ini `Library=RGSS103J.dll`,
+# `Scripts=Data\Scripts.rxdata`, shipping RGSS103J.dll and a packed
+# Game.rgssad, with no RPG_RT.ldb / .lmu / .lmt anywhere), so it could never
+# have served as an RPG2000 runtime comparison. See download-prayforyou.bash.
 #
 # RPG_RT.exe is a 32-bit binary, so 32-bit wine is required:
 #   dpkg --add-architecture i386 && apt-get update


### PR DESCRIPTION
Found while hunting for an RPG2000 test bed with battle events: I downloaded PrayforYou expecting a `.ldb` and there isn't one.

`run-rpg2k-rpgrt-wine.bash` listed it beside Nepheshel as one of *"the classic RPG_RT.exe games referenced by the other download scripts"*, and `download-prayforyou.bash` said nothing at all about what it fetches. It could never have served as an RPG2000 runtime comparison:

```
Game.ini:  Library=RGSS103J.dll
           Scripts=Data\Scripts.rxdata
ships:     RGSS103J.dll, Game.exe, a 14.8 MB packed Game.rgssad
absent:    RPG_RT.ldb, RPG_RT.exe, any .lmu or .lmt
```

## It is not useless — it is a packed XP test bed

This is the part worth keeping. PrayforYou is a **packed release with no loose `Data/` directory**: the entire database lives inside `Game.rgssad`. That is precisely the "no loose files present" case `mruby-rpgxp`'s rgssad reader was built for, and the repo's own reader handles it:

```
$ RPGXP::RGSSAD.open('Game.rgssad')
entries: 222
  Data\Actors.rxdata
  Data\Animations.rxdata
  Data\Armors.rxdata
  ...
Data\Scripts.rxdata: 212792 bytes, starts [4, 8, 91, 108]   # Marshal 4.8 magic
```

I verified that rather than asserting it, because the comment now makes the claim. Both comments cite the measured numbers.

The upshot: someone looking for a packed XP test bed would have skipped past this as an RPG2000 download. Now they won't.

## One smaller correction

The same sentence claimed Nepheshel *and* PrayforYou both "live on hosts that are blocked from sandboxed/proxied CI". They are different hosts, and the PrayforYou one (`dl.fgamearchives.com`) fetched fine from this proxied sandbox — as did Nepheshel's, for that matter. I narrowed the claim to Nepheshel and softened it to "has been unreliable" rather than rewriting a CI-egress claim I cannot test from here. I did not touch the script's actual behaviour.

## Verification

`bash -n` on both touched scripts; comment-only changes otherwise, no behaviour touched. The archive listing above was produced by loading the repo's `mruby-rpgxp/mrblib/rgssad.rb` under CRuby against the real downloaded archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_