### PR TITLE
Keep invisible troop members out of the fight until revealed

### DIFF
--- a/changelog.d/rpg2k-hidden-monsters-out-of-battle.fixed.md
+++ b/changelog.d/rpg2k-hidden-monsters-out-of-battle.fixed.md
@@ -1,0 +1,14 @@
+- RPG Maker 2000: a troop member flagged **invisible** no longer fights while it
+  is still hidden. `Game::Battle::Combatant` gained the flag (carried through by
+  `Battle.from_enemy`) and an `out_of_play?` predicate — distinct from `dead?`,
+  which is purely about HP — and the battle now skips out-of-play battlers when
+  building the turn order, picking an attack target and deciding whether a side
+  is still standing; `Scene::Map#living_foes` skips them in the target cursor
+  too. Previously every troop entry became a full combatant regardless of its
+  invisible flag, so a monster with no sprite would attack the party, sit in the
+  target list and have to be killed before the fight could be won. **Show Hidden
+  Monster** (13150) now does what its name says: `reveal_battle_monster` clears
+  the flag on the combatant as well as the troop member, so the monster enters
+  the fight at that moment instead of having been in it all along. An
+  unrevealed member no longer keeps a battle alive after every visible monster
+  is down, matching RPG_RT.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3209,8 +3209,13 @@ module Game
                            :action, :defending, :mp, :max_mp, :spi, :command,
                            :actor, :states, :state_turns, :crit_denom,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
-                           :hit_rate, :state_ranks) do
+                           :hit_rate, :state_ranks, :hidden) do
       def dead?; hp <= 0; end
+      # A troop member the editor placed but flagged invisible has not entered
+      # the fight yet: it does not act, cannot be targeted and does not keep the
+      # battle going. Show Hidden Monster (13150) clears the flag and brings it
+      # in. Distinct from `dead?`, which is purely about HP.
+      def out_of_play?; dead? || hidden ? true : false; end
       # Spirit under the name Game::Party's skill formulas (#skill_effect,
       # #skill_cost) read on a caster.
       def int; spi; end
@@ -3258,11 +3263,15 @@ module Game
     # Enemies have no source actor (that field stays nil), so the post-battle
     # write-back skips them; they carry no status set into this simple sim.
     def self.from_enemy(e)
-      Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
-                    nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
-                    crit_denom_of(e), prevents_crit_of(e),
-                    attr_ranks_of(e), atk_attrs_of(e), nil, hit_rate_of(e),
-                    state_ranks_of(e))
+      c = Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
+                        nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
+                        crit_denom_of(e), prevents_crit_of(e),
+                        attr_ranks_of(e), atk_attrs_of(e), nil, hit_rate_of(e),
+                        state_ranks_of(e))
+      # A member the troop flagged invisible starts out of play until a Show
+      # Hidden Monster command brings it in (see Combatant#out_of_play?).
+      c.hidden = e.respond_to?(:hidden) && e.hidden ? true : false
+      c
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
@@ -3644,7 +3653,7 @@ module Game
       @rng.random(100) < prob
     end
 
-    def alive?(side); side.any? { |b| !b.dead? }; end
+    def alive?(side); side.any? { |b| !b.out_of_play? }; end
 
     def refill_queue
       @rounds += 1
@@ -3657,7 +3666,7 @@ module Game
 
     # Battlers ordered by agility (highest first); ties keep their listed order.
     def turn_order
-      (@allies + @enemies).each_with_index
+      (@allies + @enemies).reject(&:out_of_play?).each_with_index
                           .sort_by { |b, i| [-b.agi, i] }.map { |b, _| b }
     end
 
@@ -3790,7 +3799,7 @@ module Game
     def restricted_target(b, r)
       own = side_of(b) == :ally ? @allies : @enemies
       pool = r == RESTRICTION_ATTACK_ALLY ? own : (side_of(b) == :ally ? @enemies : @allies)
-      living = pool.reject(&:dead?)
+      living = pool.reject(&:out_of_play?)
       living.empty? ? nil : living[@rng.random(living.size)]
     end
 
@@ -3801,7 +3810,7 @@ module Game
       if side_of(b) == :ally && b.action && !b.action.dead?
         return b.action
       end
-      foes = (side_of(b) == :ally ? @enemies : @allies).reject(&:dead?)
+      foes = (side_of(b) == :ally ? @enemies : @allies).reject(&:out_of_play?)
       foes.empty? ? nil : foes[@rng.random(foes.size)]
     end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2473,7 +2473,9 @@ class RPG2k
       end
 
       def living_allies; @battle_ui[:allies].reject(&:dead?); end
-      def living_foes;   @battle_ui[:foes].reject(&:dead?);   end
+      # Targetable foes: alive *and* in play, so a troop member still flagged
+      # invisible never appears in the target cursor.
+      def living_foes;   @battle_ui[:foes].reject(&:out_of_play?); end
       def current_actor; living_allies[@battle_ui[:actor_i]]; end
 
       # The real Game::Actor behind the current battler (the snapshots are built
@@ -2946,6 +2948,10 @@ class RPG2k
         member = @battle_ui[:troop].members[index]
         return unless member && member.hidden
         member.hidden = false
+        # Bring the combatant into the fight as well, not just the sprite: until
+        # now it took no turn and could not be targeted (Combatant#out_of_play?).
+        foe = @battle_ui[:battle].enemy(index)
+        foe.hidden = false if foe
         bmp = battler_bitmap(member)
         spr = Sprite.new
         spr.bitmap = bmp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5529,6 +5529,72 @@ check 'Show Battle Animation (battle form) waits like the map form' do
   eq true, it.battle_animation[:battle]
 end
 
+# -- hidden troop members stay out of the fight --------------------------------
+
+# A troop member the editor flagged invisible: from_enemy must carry that
+# through, so the combatant starts out of play.
+FakeHiddenEnemy = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp, :sp,
+                             :max_sp, :spi, :hidden)
+def hidden_enemy(name, hidden, hp: 100, atk: 20)
+  FakeHiddenEnemy.new(name, atk, 0, 5, hp, hp, 0, 0, 0, hidden)
+end
+
+check 'Battle.from_enemy carries the troop member invisible flag' do
+  ok Game::Battle.from_enemy(hidden_enemy('Lurker', true)).out_of_play?
+  ok !Game::Battle.from_enemy(hidden_enemy('Slime', false)).out_of_play?
+  # out_of_play? is not dead? -- a hidden monster is at full HP, just absent.
+  ok !Game::Battle.from_enemy(hidden_enemy('Lurker', true)).dead?
+end
+
+check 'a hidden monster takes no turn and cannot be attacked' do
+  hero = combatant('Hero', 20, 0, 30, 100)   # fastest, acts first
+  seen = Game::Battle.from_enemy(hidden_enemy('Slime', false, hp: 100))
+  lurker = Game::Battle.from_enemy(hidden_enemy('Lurker', true, hp: 100, atk: 40))
+  b = Game::Battle.new([hero], [seen, lurker], Game::Rng.new(1))
+  b.run_round
+  eq 100, lurker.hp, 'the hidden monster was never hit'
+  ok seen.hp < 100, 'the visible one took the hero\'s attack'
+  ok hero.hp > 60, "the hidden monster did not attack back (hero #{hero.hp})"
+end
+
+check 'a battle ends when every visible monster is down, hidden ones aside' do
+  hero = combatant('Hero', 20, 0, 30, 100)
+  seen = Game::Battle.from_enemy(hidden_enemy('Slime', false, hp: 1))
+  lurker = Game::Battle.from_enemy(hidden_enemy('Lurker', true, hp: 100))
+  b = Game::Battle.new([hero], [seen, lurker], Game::Rng.new(1))
+  b.run_round
+  ok seen.dead?, 'the visible monster fell'
+  ok b.finished?, 'an unrevealed monster does not keep the fight going'
+  eq :victory, b.result
+end
+
+check 'revealing a hidden monster brings it into the fight' do
+  hero = combatant('Hero', 20, 0, 30, 100)
+  lurker = Game::Battle.from_enemy(hidden_enemy('Lurker', true, hp: 100, atk: 40))
+  b = Game::Battle.new([hero], [lurker], Game::Rng.new(1))
+  ok b.finished?, 'with only a hidden monster there is nothing to fight'
+
+  lurker.hidden = false # what Show Hidden Monster (13150) does
+  ok !b.finished?, 'once revealed the fight is on'
+  b.run_round
+  ok lurker.hp < 100, 'it can now be attacked'
+end
+
+check 'Show Hidden Monster reveals through the interpreter and the battle' do
+  b = battle_with(foe_hp: 100)
+  b.enemy(0).hidden = true
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::SHOW_HIDDEN_MONSTER, [0])])
+  it.update
+  eq [0], it.take_revealed_monsters, 'the scene is told which member to reveal'
+  # The interpreter queues the request; the scene clears the flag on both the
+  # troop member and the combatant (see Scene::Map#reveal_battle_monster).
+  ok b.enemy(0).out_of_play?, 'still out of play until the scene applies it'
+  b.enemy(0).hidden = false
+  ok !b.enemy(0).out_of_play?
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2480,6 +2480,28 @@ check 'a battle page shows its message in a battle panel and waits for a key' do
      'the panel closed with the message'
 end
 
+check 'a hidden troop member is not targetable until it is revealed' do
+  scene, _st = battle_scene_with_pages(nil)
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :command
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  eq 2, ui[:foes].length
+  # Hide the second member the way an invisible troop entry would have.
+  ui[:foes][1].hidden = true
+  ui[:troop].members[1].hidden = true
+  targets = scene.send(:living_foes)
+  eq 1, targets.length, 'the target cursor skips the hidden member'
+  ok !targets.include?(ui[:foes][1])
+
+  scene.send(:reveal_battle_monster, 1)
+  ok !ui[:foes][1].hidden, 'revealing clears the combatant flag, not just the sprite'
+  eq 2, scene.send(:living_foes).length, 'and it becomes targetable'
+  ok ui[:enemy_sprites][1], 'with a sprite built for it'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
A gameplay bug found by pulling on a thread from #319. `build_battle_sprites` skips hidden troop members — but `open_battle` still turns every member into a combatant:

```ruby
foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
```

`from_enemy` ignored the invisible flag entirely. So a hidden monster:

- **took a turn and attacked the party** from behind no sprite — unexplained damage from nowhere
- **sat in the target cursor** as a blank row the player could select
- **had to be killed** before the battle could be won

It also quietly made **Show Hidden Monster (13150)** a no-op in every sense that mattered: the command built a sprite for a monster that had been fighting since round one. I added that command in #319 and did not notice, because the sprite it produces looks exactly right.

## The fix

`Combatant` gains the flag and an `out_of_play?` predicate — deliberately *not* folded into `dead?`, which is purely about HP; a hidden monster is at full health, just absent. The battle consults it in the four places that decide participation:

| | |
|---|---|
| `turn_order` | out-of-play battlers take no turn |
| `attack_target` | cannot be picked as a target |
| `restricted_target` | nor by a berserk / confused forced attack |
| `alive?` | does not keep its side standing |

`Scene::Map#living_foes` uses it for the target cursor, and `reveal_battle_monster` now clears it on the **combatant** as well as the troop member, so a revealed monster joins the fight at that moment instead of retroactively.

## A behaviour worth calling out

An unrevealed member no longer keeps the battle alive once every visible monster is down. That is what RPG_RT does — a troop can define an ambush that simply never springs, and the fight ends in victory. Worth flagging because it is the one change here that ends a battle *earlier* than before.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `rpg2k_logic_check.rb` | 380 | **385** |
| `rpg2k_scene_check.rb` | 111 | **112** |
| `rpg2k_render_check.rb` | 36 | 36 |

The new checks pin each claim rather than just the happy path: that `out_of_play?` is not `dead?`; that a hidden monster is neither hit nor hits back over a full round; that victory lands when the last *visible* monster falls; that clearing the flag makes an already-constructed battle fightable again; and, at scene level, that the target cursor skips a hidden member and that `reveal_battle_monster` clears the combatant flag and builds the sprite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_