### PR TITLE
Add copyable error reports for fatal Ruby exceptions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,8 +201,8 @@ jobs:
       # avoided: its server-number probe is not atomic, so concurrent -a runs
       # can grab the same display, killing one Xvfb out from under its client
       # ("XIO: fatal IO error"). Reserved numbers: exe_open=99,
-      # render_probe=98 and audio_probe=97 (see those ctest tests in
-      # CMakeLists.txt, all run by the `test` step below); MV runs=100..108,
+      # render_probe=98, audio_probe=97 and error_dump=96 (see those ctest
+      # tests in CMakeLists.txt, all run by the `test` step below); MV runs=100..108,
       # the RPG2k
       # real-game boot smoke=109..110, the MZ boot smoke=111, the RPG XP
       # real-game boot smoke=112 and the RGSSAD packed-asset smoke=113..114

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@
 
 # Runtime save artifacts written by the MV/websave (localStorage) shim.
 /save
+
+# The crash report the engine writes beside itself when it dies (--error_dump,
+# see src/error_dump.cxx). Running the engine from the source tree drops one
+# here; it belongs in a bug report, not in the repository.
+/error-report.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ if(EMSCRIPTEN)
 endif()
 
 add_executable(${PROJECT_NAME} src/main.cxx src/sdl_input.cxx src/sdl_audio.cxx
-                               src/log_console.cxx)
+                               src/log_console.cxx src/error_dump.cxx)
 target_link_libraries(
   ${PROJECT_NAME}
   mruby
@@ -254,6 +254,27 @@ target_link_libraries(
   ${GL_LIBS})
 target_include_directories(${PROJECT_NAME}
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rd/inicpp)
+
+# Stamp the build into the binary so a crash report says which build produced it
+# (src/error_dump.cxx). Read at configure time, not build time: a report that
+# names the commit the tree was configured at is enough to place a failure, and
+# re-running git on every build would rebuild the world on every commit. CI
+# configures a fresh checkout per run, so its reports name the exact commit.
+find_package(Git QUIET)
+set(RPG_BUILD_REVISION "unknown")
+if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --always --dirty --abbrev=12
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE RPG_GIT_DESCRIBE
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(RPG_GIT_DESCRIBE)
+    set(RPG_BUILD_REVISION "${RPG_GIT_DESCRIBE}")
+  endif()
+endif()
+target_compile_definitions(
+  ${PROJECT_NAME} PRIVATE "RPG_BUILD_REVISION=\"${RPG_BUILD_REVISION}\""
+                          "RPG_BUILD_TYPE=\"${CMAKE_BUILD_TYPE}\"")
 
 # MIDI instruments for SDL_mixer's built-in TiMidity synthesiser. A .mid holds
 # note events only, so without a GUS patch set MIDI music loads and then plays
@@ -391,6 +412,14 @@ if(NOT EMSCRIPTEN)
     COMMAND ruby ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_timidity_patches.rb
             ${TIMIDITY_ASSET_DIR})
 
+  # The Ruby half of the crash report — the $stderr tee whose ring buffer gives
+  # a report its "Recent log" section. Plain Ruby with no mruby dependencies, so
+  # it is checked on CRuby here as well as inside the built interpreter by
+  # mruby_test, and needs no display.
+  add_test(NAME error_report_capture
+           COMMAND ruby
+                   ${CMAKE_CURRENT_SOURCE_DIR}/scripts/error_report_check.rb)
+
   set(exe_open_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone --timeout_ms=100
                    --game_dir ./data/Nepheshel206beta/Nepheshel206Rbeta)
   # The SDL window backend needs a real display. Linux CI runners are headless,
@@ -453,4 +482,22 @@ if(NOT EMSCRIPTEN)
   # failing. It writes its own fixture into the working directory.
   set_tests_properties(audio_probe PROPERTIES ENVIRONMENT
                                               "SDL_AUDIODRIVER=dummy")
+
+  # The crash report end to end, in the real binary: raise a Ruby exception and
+  # check the report that comes out still carries the exception, its backtrace,
+  # the log captured before it and the run context, and that the file a reporter
+  # would attach holds the same text. Nothing else can catch a report that
+  # quietly lost a section — by the time one is wanted, the crash has happened.
+  # Runs in the build directory, where the probe writes and then removes its
+  # report file. Reserved display 96 (see the exe_open note above).
+  set(error_dump_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
+                     --error_dump_probe --error_dump=error-report-probe.md)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(error_dump_cmd xvfb-run --server-num=96
+                       "--server-args=-screen 0 640x480x24" ${error_dump_cmd})
+  endif()
+  add_test(
+    NAME error_dump
+    COMMAND ${error_dump_cmd}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/README.md
+++ b/README.md
@@ -283,6 +283,37 @@
   [`docs/deploy.md`](docs/deploy.md) for the one-time repo setup (Pages source +
   Cloudflare secrets).
 
+### Reporting an error
+
+When the engine dies on a Ruby exception it no longer just prints a backtrace
+and quits — it assembles **one copy-pasteable report** so a bug can be reported
+without a terminal, a build tree or a rebuild. The report holds the exception
+and its backtrace, the revision and build type it came from, the platform, the
+project that was loaded, where the engine caught the failure, and the tail of
+the runtime log (the `[RPG2k]` / `[RGSS]` lines that led up to it — usually the
+part that explains it). Nothing else is collected.
+
+- **In the browser**, a crash replaces the frozen canvas with an error panel
+  holding the report and a **Copy error report** button (or **Download** for a
+  `.md` file). The page adds what only it knows: the address, the browser, which
+  project was loaded and its own log tail. A problem that does *not* crash the
+  game — a wrong picture, silence where there should be music — has the same
+  report a click away under *Runtime log → Copy diagnostics*. Errors thrown by
+  the page or the wasm runtime itself are reported the same way.
+- **On the desktop**, the report is printed to stderr between
+  `----- BEGIN RPG MAKER CLONE ERROR REPORT -----` / `----- END ... -----`
+  markers and written to `error-report.md` in the working directory. Point it
+  somewhere else with `--error_dump=path/to/report.md`, or pass an empty value
+  to write no file.
+- The log tail comes from `RGSS::ErrorReport`, which tees `$stderr` through a
+  bounded ring buffer (`mruby-rgss/mrblib/error_report.rb`); nothing about the
+  existing logging changes. The report path is itself tested end to end —
+  `--error_dump_probe` raises a real exception and checks the resulting report
+  still carries the exception, the backtrace, the captured log and the run
+  context (the `error_dump` ctest), and `scripts/error_report_check.rb` checks
+  the capture on CRuby. See
+  [`docs/adr/0027-copyable-error-report.md`](docs/adr/0027-copyable-error-report.md).
+
 ### Audio
 
 - `RGSS::Audio` plays real music and sound through an

--- a/changelog.d/copyable-error-report.added.md
+++ b/changelog.d/copyable-error-report.added.md
@@ -1,0 +1,13 @@
+- **Copyable error reports.** A fatal Ruby exception now produces one
+  self-contained Markdown report — the exception and its backtrace, the build
+  revision and type, the platform, the loaded project, where the engine caught
+  it, and the tail of the runtime log — instead of a bare backtrace. In the
+  browser a crash raises an error panel with **Copy error report** / **Download**
+  (and *Runtime log → Copy diagnostics* for problems that do not crash the
+  game); on the desktop the report is printed between `----- BEGIN RPG MAKER
+  CLONE ERROR REPORT -----` markers and written to `error-report.md`
+  (`--error_dump`). The log tail is captured by `RGSS::ErrorReport`, which tees
+  `$stderr` through a bounded ring buffer. Checked end to end by the new
+  `error_dump` ctest (`--error_dump_probe` raises a real exception and reads the
+  report back) and by `scripts/error_report_check.rb`. See
+  `docs/adr/0027-copyable-error-report.md`.

--- a/docs/adr/0027-copyable-error-report.md
+++ b/docs/adr/0027-copyable-error-report.md
@@ -1,0 +1,99 @@
+# 27. One copyable error report on every fatal path
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+Until now a fatal Ruby exception was reported by printing the class, the message
+and mruby's backtrace, and then quitting (`CHECK_NO_EXC` and the two
+`mrb_print_backtrace` sites in `src/main.cxx`). That is enough for whoever is
+sitting at a terminal with the source tree open, and close to useless for
+everyone else:
+
+- It says nothing about *which* build failed, which project was loaded or where
+  in the engine the failure was caught — all of which a maintainer has to ask
+  for before a report can be placed at all.
+- It drops the runtime log, which is normally where the actual reason is: the
+  `[RPG2k]` / `[RGSS]` lines the runtime logs when an asset is missing or a data
+  field falls back to a default (the logging AGENTS.md requires) scroll past and
+  are gone.
+- In the browser — the way most people meet this engine, via the GitHub Pages
+  build — there is no terminal at all. The backtrace lands in a collapsed
+  "Runtime log" panel behind a frozen canvas, and the reporter has no plausible
+  path from "it broke" to a bug report that anyone can act on.
+
+So the failure mode was not "errors are silenced" (they are not) but "the
+evidence never reaches a bug report".
+
+## Decision
+
+Every fatal path assembles **one self-contained Markdown report** and offers it
+for copying, rather than printing fragments.
+
+- `src/error_dump.cxx` (`include/error_dump.hxx`) builds it: the build revision
+  and type stamped in at configure time, the platform, the mruby version, the
+  run context (game directory, screen size, display backend, detected maker,
+  the site that caught the failure), the exception with its backtrace, and the
+  runtime log tail. `error_dump_report` prints it between
+  `----- BEGIN RPG MAKER CLONE ERROR REPORT -----` / `----- END ... -----`
+  markers, writes it to the `--error_dump` file (default `error-report.md`;
+  empty disables) and hands the text back.
+- The log tail is captured in Ruby: `RGSS::ErrorReport`
+  (`mruby-rgss/mrblib/error_report.rb`) tees `$stderr` through a bounded ring
+  buffer at start-up. `$stderr` is the runtime's logging convention, so this
+  needs no change at any of the ~180 existing call sites, and every write still
+  reaches the real `$stderr` untouched.
+- The browser shell (`src/shell.html`) watches its log for the markers, folds
+  the engine's report together with what only the page knows (address, browser,
+  loaded project, its own log tail) and shows it in an error panel with **Copy
+  error report** / **Download**. The same report is available without a crash
+  under *Runtime log → Copy diagnostics*, and page/wasm errors
+  (`window.onerror`, unhandled rejections, `Module.onAbort`) go through the same
+  panel.
+
+Markers were chosen over an exported `rpg_error_dump()` the page would `ccall`:
+the report already has to reach stderr for the desktop case, the page already
+mirrors stderr, and scraping keeps the JS side working for aborts where calling
+back into the runtime is not safe.
+
+The report path is tested rather than assumed, because a report that quietly
+lost half its content is worse than no report and is only discovered when a
+crash has already happened:
+
+- `--error_dump_probe` (the `error_dump` ctest) raises a real exception through
+  the real path in the real binary and asserts the report still carries the
+  exception, a backtrace naming the raising frame, the log line written before
+  the raise and the run context, and that the written file matches what was
+  printed.
+- `scripts/error_report_check.rb` checks the capture itself on CRuby (partial
+  writes, bounding, truncation, forwarding, single installation), and
+  `mruby-rgss/test/test.rb` asserts the same behaviour inside the built
+  interpreter.
+
+## Consequences
+
+- A player can report a crash by pasting one block, from the browser, with no
+  tooling. A maintainer gets the build, the project and the log without a
+  round-trip.
+- The desktop run writes `error-report.md` into the working directory on a
+  crash. It is overwritten per crash and disabled with `--error_dump=`.
+- The revision in the report is stamped at **configure** time, not build time:
+  committing without re-configuring leaves it pointing at the older commit.
+  Re-running git on every build would rebuild the world on every commit, and CI
+  configures a fresh checkout per run, so its reports name the exact commit.
+- The tee means `$stderr` is no longer the object mruby-io created. It forwards
+  everything and delegates the rest of the IO surface, but code that checks
+  `$stderr.is_a?(IO)` (nothing does today) would see the tee instead.
+- The markers are a contract between `include/error_dump.hxx` and
+  `src/shell.html`; changing one without the other silently loses the browser
+  panel. Both files say so.
+- The native `start` path now returns `EXIT_FAILURE` after reporting instead of
+  aborting through ng-log's `CHECK`, so a crash exits cleanly (1) rather than on
+  a signal, with the report as the last thing printed.
+- Not done here: copying to the system clipboard from the desktop build. X11 and
+  Wayland hand clipboard ownership to the running process, so a report copied on
+  the way out would vanish with it — the file is the honest answer there.

--- a/include/error_dump.hxx
+++ b/include/error_dump.hxx
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string>
+
+#include <mruby.h>
+
+// One copy-pasteable crash report.
+//
+// When the engine dies on an mruby exception it used to print the class, the
+// message and mruby's own backtrace and quit. That is enough for whoever is
+// sitting at a terminal and nowhere near enough for a bug report: it says
+// nothing about which build, which project or which runtime log lines led up to
+// it, and in the browser it is buried in a collapsed panel. So every fatal path
+// now goes through error_dump_report, which assembles all of that into one
+// Markdown block a player can hand over as-is.
+//
+// The block is printed to stderr between the markers below, written to the
+// --error_dump file, and -- in the browser, where there is no terminal to copy
+// from -- scraped off the log by the shell page (src/shell.html), which offers
+// it as "Copy error report".
+
+// Fence the report so a reader (the shell page, or a human scrolling a log)
+// can tell exactly where it starts and ends. Keep these in sync with the
+// matching strings in src/shell.html.
+constexpr char ERROR_DUMP_BEGIN[] =
+    "----- BEGIN RPG MAKER CLONE ERROR REPORT -----";
+constexpr char ERROR_DUMP_END[] =
+    "----- END RPG MAKER CLONE ERROR REPORT -----";
+
+// Record a fact about this run for the report's "Run" section: the game
+// directory, the detected project type, the window size. Facts appear in the
+// order first set; setting a key again replaces its value.
+void error_dump_set_context(const char* key, const std::string& value);
+
+// Start capturing the runtime log (RGSS::ErrorReport.install, see
+// mruby-rgss/mrblib/error_report.rb) so a report can carry the messages that
+// preceded the failure. Call once, right after the interpreter is opened. A
+// no-op when the gem is absent (the standalone mruby test binary).
+void error_dump_install(mrb_state* M);
+
+// Report the exception pending on M -- print it between the markers, write the
+// --error_dump file and hand the text back -- then clear it. Returns an empty
+// string when nothing was pending, so this is safe to call on any bail-out
+// path. `where` names the engine site that caught it ("the frame loop", ...).
+std::string error_dump_report(mrb_state* M, const char* where);
+
+// Raise a real exception and read the resulting report back, checking it kept
+// the message, the backtrace and the captured log. Returns EXIT_SUCCESS /
+// EXIT_FAILURE; drives --error_dump_probe and the error_dump ctest.
+int error_dump_run_probe(mrb_state* M);

--- a/mruby-rgss/mrblib/error_report.rb
+++ b/mruby-rgss/mrblib/error_report.rb
@@ -1,0 +1,164 @@
+module RGSS
+  # The runtime-log tail that a crash report carries.
+  #
+  # When the engine dies, the exception alone rarely explains why: the reason is
+  # in the `[RPG2k]` / `[RGSS]` lines the runtime logged on the way down (a
+  # missing asset, a data field that fell back to a default, an unimplemented
+  # command). Those go to `$stderr`, which on a desktop scrolls past and in the
+  # browser lives in a collapsed panel — neither ends up in a bug report.
+  #
+  # So `install` tees `$stderr` through a ring buffer of the last MAX_LINES
+  # lines. Nothing about the existing logging changes (every write still reaches
+  # the real `$stderr`); the tail is simply also kept in memory, and
+  # `error_dump_report` (src/error_dump.cxx) folds it into the report the player
+  # copies. `$stderr` is teed and `$stdout` is not: `$stderr` is where the
+  # runtime logs its diagnostics by convention (see the Error Handling section
+  # of AGENTS.md).
+  module ErrorReport
+    # How much log to keep. Enough to cover a scene transition and the loads it
+    # triggers, small enough that the report stays pasteable.
+    MAX_LINES = 200
+
+    # A single runaway line (a dumped table, a decoded blob) must not blow up
+    # the report on its own.
+    MAX_LINE_CHARS = 500
+
+    # Forwards every write to the real $stderr and records whole lines. Only the
+    # writing methods are spelled out; anything else a caller expects of an IO
+    # (flush, sync, fileno, tty?, ...) is delegated, so this stands in for
+    # $stderr without pretending to be a full IO.
+    class Tee
+      attr_reader :io
+
+      def initialize(io)
+        @io = io
+      end
+
+      def write(*args)
+        args.each { |a| ErrorReport.record(a.to_s) }
+        @io.write(*args)
+      end
+
+      def print(*args)
+        args.each { |a| ErrorReport.record(a.to_s) }
+        @io.print(*args)
+      end
+
+      def puts(*args)
+        ErrorReport.record(ErrorReport.puts_text(args))
+        @io.puts(*args)
+      end
+
+      def <<(text)
+        ErrorReport.record(text.to_s)
+        @io << text
+        self
+      end
+
+      def method_missing(name, *args, &block)
+        @io.__send__(name, *args, &block)
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        @io.respond_to?(name, include_private)
+      end
+    end
+
+    @lines = []
+    @partial = ""
+    @installed = false
+
+    class << self
+      # The recorded lines, oldest first, newline-free.
+      attr_reader :lines
+    end
+
+    # Tee $stderr through the ring buffer. Called once at start-up (from
+    # error_dump_install in src/error_dump.cxx, right after the interpreter is
+    # opened) and a no-op afterwards, so a second call cannot stack two tees and
+    # record every line twice. Returns true when it installed the tee.
+    def self.install
+      return false if @installed
+      @installed = true
+      $stderr = Tee.new($stderr)
+      true
+    end
+
+    def self.installed?
+      @installed
+    end
+
+    # What IO#puts writes for `args`: every argument on its own line, one bare
+    # newline when there are none, no second newline after an argument that
+    # already ends in one, and nested arrays flattened.
+    def self.puts_text(args)
+      return "\n" if args.empty?
+      out = ""
+      args.each do |a|
+        if a.is_a?(Array)
+          out += puts_text(a)
+        else
+          s = a.to_s
+          out += s
+          out += "\n" unless s[-1] == "\n"
+        end
+      end
+      out
+    end
+
+    # Record raw log output. Writes arrive in arbitrary chunks (a `puts` is one
+    # call, a `print` per fragment is many), so text is buffered until a newline
+    # completes a line.
+    def self.record(text)
+      parts = (@partial + text.to_s).split("\n", -1)
+      @partial = parts.pop || ""
+      parts.each { |line| push(line) }
+      nil
+    end
+
+    # The recorded log as one string, newest lines last, at most `limit` of
+    # them. Empty when nothing was recorded — a report then simply has no log
+    # section rather than an empty fence.
+    def self.log_tail(limit = MAX_LINES)
+      tail = @lines
+      tail = tail[-limit, limit] if limit && tail.size > limit
+      tail = tail + [@partial] unless @partial.empty?
+      return "" if tail.empty?
+      tail.join("\n") + "\n"
+    end
+
+    # Drop everything recorded so far. Used by the tests; the runtime never
+    # needs it, as the ring buffer bounds itself.
+    def self.clear
+      @lines = []
+      @partial = ""
+      nil
+    end
+
+    def self.push(line)
+      line = line[0, MAX_LINE_CHARS] + "..." if line.size > MAX_LINE_CHARS
+      @lines << line
+      @lines.shift while @lines.size > MAX_LINES
+      nil
+    end
+
+    # The report path can only be trusted if it has been walked: a report that
+    # dropped the backtrace or the log is worth nothing, and a crash is a bad
+    # time to find out. `probe!` logs a line and then raises from a nested call,
+    # so the engine side (error_dump_run_probe in src/error_dump.cxx, driven by
+    # --error_dump_probe and the error_dump ctest) can read the resulting report
+    # back and check both survived. The constants are the needles it looks for;
+    # it reads them from here rather than repeating the strings.
+    PROBE_LOG_LINE = "[ErrorDump-PROBE] a log line written before the raise"
+    PROBE_MESSAGE = "error dump probe raise"
+
+    def self.probe!
+      $stderr.puts PROBE_LOG_LINE
+      probe_raise
+    end
+
+    def self.probe_raise
+      raise PROBE_MESSAGE
+    end
+  end
+end

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1001,6 +1001,69 @@ assert "RGSS.warn_once reports each message only once" do
   assert_equal "[RGSS] warn-once-test-message", sink.lines[0]
 end
 
+# RGSS::ErrorReport keeps the tail of the runtime log so a crash report can
+# carry the messages that led up to the failure (src/error_dump.cxx). The same
+# behaviour is checked on CRuby by scripts/error_report_check.rb, which can
+# cover more of it; these assert it inside the built interpreter, where the
+# String and Array methods the buffer leans on are the mruby ones.
+assert "RGSS::ErrorReport records whole lines and bounds the buffer" do
+  RGSS::ErrorReport.clear
+  RGSS::ErrorReport.record("[RPG2k] split ")
+  RGSS::ErrorReport.record("across writes\n")
+  assert_equal ["[RPG2k] split across writes"], RGSS::ErrorReport.lines
+
+  RGSS::ErrorReport.clear
+  (RGSS::ErrorReport::MAX_LINES + 10).times { |i| RGSS::ErrorReport.record("line #{i}\n") }
+  assert_equal RGSS::ErrorReport::MAX_LINES, RGSS::ErrorReport.lines.size
+  assert_equal "line 10", RGSS::ErrorReport.lines[0]
+  RGSS::ErrorReport.clear
+end
+
+assert "RGSS::ErrorReport.log_tail keeps an unterminated last line" do
+  # The last thing a dying runtime logs is often the interesting line, and it
+  # may never get its newline.
+  RGSS::ErrorReport.clear
+  RGSS::ErrorReport.record("[RPG2k] done\n")
+  RGSS::ErrorReport.record("[RPG2k] mid-write")
+  assert_equal "[RPG2k] done\n[RPG2k] mid-write\n", RGSS::ErrorReport.log_tail
+  RGSS::ErrorReport.clear
+end
+
+assert "RGSS::ErrorReport::Tee forwards every write and records it" do
+  RGSS::ErrorReport.clear
+  sink = WarnOnceSink.new
+  tee = RGSS::ErrorReport::Tee.new(sink)
+  tee.puts "[RPG2k] through the tee"
+  tee.write "[RPG2k] written\n"
+  assert_equal ["[RPG2k] through the tee", "[RPG2k] written\n"], sink.lines
+  assert_equal "[RPG2k] through the tee\n[RPG2k] written\n",
+               RGSS::ErrorReport.log_tail
+  RGSS::ErrorReport.clear
+end
+
+assert "RGSS::ErrorReport.probe! raises after logging its marker line" do
+  # The engine's --error_dump_probe drives this to check a real report keeps the
+  # exception, its backtrace and the captured log; assert here that the probe
+  # itself does what that check assumes.
+  RGSS::ErrorReport.clear
+  original = $stderr
+  sink = WarnOnceSink.new
+  raised = nil
+  begin
+    $stderr = RGSS::ErrorReport::Tee.new(sink)
+    begin
+      RGSS::ErrorReport.probe!
+    rescue RuntimeError => e
+      raised = e
+    end
+  ensure
+    $stderr = original
+  end
+  assert_equal RGSS::ErrorReport::PROBE_MESSAGE, raised.message
+  assert_equal [RGSS::ErrorReport::PROBE_LOG_LINE], RGSS::ErrorReport.lines
+  RGSS::ErrorReport.clear
+end
+
 assert "RGSS::Window RGSS2/RGSS3 API surface" do
   # Window.new needs a live display (see the Tilemap note below), so assert the
   # VX/VX Ace surface is defined; what these accessors actually *draw* is

--- a/scripts/error_report_check.rb
+++ b/scripts/error_report_check.rb
@@ -1,0 +1,175 @@
+#!/usr/bin/env ruby
+# Check the runtime-log capture that feeds the copyable error report.
+#
+# RGSS::ErrorReport tees $stderr into a bounded ring buffer so a crash report
+# can carry the `[RPG2k]` / `[RGSS]` lines that led up to the failure (see
+# mruby-rgss/mrblib/error_report.rb and src/error_dump.cxx). Its whole job is
+# bookkeeping — buffering partial writes, bounding the buffer, forwarding every
+# write untouched — which is exactly the kind of thing that breaks silently:
+# a dropped forward would swallow the game's log, and an unbounded buffer would
+# leak for as long as the game runs.
+#
+# The file is plain Ruby with no mruby dependencies, so this runs it on CRuby
+# and needs no engine build. The same behaviour is asserted inside the built
+# interpreter by mruby-rgss/test/test.rb (the mruby_test ctest).
+#
+# Usage: ruby scripts/error_report_check.rb
+
+require 'stringio'
+
+require_relative '../mruby-rgss/mrblib/error_report'
+
+failures = []
+
+def check(failures, name)
+  yield
+  puts "ok - #{name}"
+rescue StandardError => e
+  failures << "#{name}: #{e.message}"
+  warn "FAIL - #{name}: #{e.message}"
+end
+
+def assert(cond, message = 'assertion failed')
+  raise message unless cond
+end
+
+def assert_equal(expected, actual)
+  raise "expected #{expected.inspect}, got #{actual.inspect}" unless expected == actual
+end
+
+report = RGSS::ErrorReport
+
+check(failures, 'whole lines are recorded and read back in order') do
+  report.clear
+  report.record("[RPG2k] first\n")
+  report.record("[RPG2k] second\n")
+  assert_equal ['[RPG2k] first', '[RPG2k] second'], report.lines
+  assert_equal "[RPG2k] first\n[RPG2k] second\n", report.log_tail
+end
+
+check(failures, 'a line split across writes is joined') do
+  report.clear
+  report.record('[RGSS] half ')
+  report.record("and half\n")
+  assert_equal ['[RGSS] half and half'], report.lines
+end
+
+check(failures, 'an unterminated trailing write still reaches the tail') do
+  # The last thing a dying runtime logs is often exactly the interesting line,
+  # and it may never get its newline. It must not be swallowed.
+  report.clear
+  report.record("done\n")
+  report.record('in progress')
+  assert_equal ['done'], report.lines
+  assert_equal "done\nin progress\n", report.log_tail
+end
+
+check(failures, 'the buffer is bounded to MAX_LINES') do
+  report.clear
+  (RGSS::ErrorReport::MAX_LINES + 50).times { |i| report.record("line #{i}\n") }
+  assert_equal RGSS::ErrorReport::MAX_LINES, report.lines.size
+  assert_equal 'line 50', report.lines.first
+  assert_equal "line #{RGSS::ErrorReport::MAX_LINES + 49}", report.lines.last
+end
+
+check(failures, 'log_tail honours a smaller limit') do
+  report.clear
+  5.times { |i| report.record("line #{i}\n") }
+  assert_equal "line 3\nline 4\n", report.log_tail(2)
+end
+
+check(failures, 'a runaway line is truncated') do
+  report.clear
+  report.record('x' * (RGSS::ErrorReport::MAX_LINE_CHARS + 100) + "\n")
+  assert_equal RGSS::ErrorReport::MAX_LINE_CHARS + 3, report.lines.first.size
+  assert report.lines.first.end_with?('...'), 'truncation is not marked'
+end
+
+check(failures, 'log_tail is empty when nothing was recorded') do
+  report.clear
+  assert_equal '', report.log_tail
+end
+
+check(failures, 'the tee forwards every write to the real $stderr') do
+  report.clear
+  sink = StringIO.new
+  tee = RGSS::ErrorReport::Tee.new(sink)
+  tee.puts '[RPG2k] via puts'
+  tee.print '[RPG2k] via print'
+  tee.print "\n"
+  tee.write "[RPG2k] via write\n"
+  tee << "[RPG2k] via shovel\n"
+  expected = "[RPG2k] via puts\n[RPG2k] via print\n" \
+             "[RPG2k] via write\n[RPG2k] via shovel\n"
+  assert_equal expected, sink.string
+  assert_equal expected, report.log_tail
+end
+
+check(failures, 'puts records what IO#puts writes') do
+  report.clear
+  sink = StringIO.new
+  tee = RGSS::ErrorReport::Tee.new(sink)
+  tee.puts                         # a bare newline
+  tee.puts "already terminated\n"  # not given a second newline
+  tee.puts 'a', 'b'                # one line each
+  tee.puts ['c', 'd']              # arrays are flattened
+  assert_equal sink.string, report.log_tail
+end
+
+check(failures, 'the tee delegates the rest of the IO surface') do
+  sink = StringIO.new
+  tee = RGSS::ErrorReport::Tee.new(sink)
+  tee.flush
+  assert tee.respond_to?(:flush), 'delegated methods are not answered by respond_to?'
+  assert_equal sink, tee.io
+end
+
+check(failures, 'probe! logs its marker line and then raises') do
+  # What the engine's --error_dump_probe assumes when it reads a report back
+  # (error_dump_run_probe in src/error_dump.cxx).
+  report.clear
+  sink = StringIO.new
+  tee = RGSS::ErrorReport::Tee.new(sink)
+  raised = nil
+  begin
+    original = $stderr
+    $stderr = tee
+    begin
+      RGSS::ErrorReport.probe!
+    rescue RuntimeError => e
+      raised = e
+    end
+  ensure
+    $stderr = original
+  end
+  assert_equal RGSS::ErrorReport::PROBE_MESSAGE, raised && raised.message
+  assert_equal [RGSS::ErrorReport::PROBE_LOG_LINE], report.lines
+  assert raised.backtrace.any? { |f| f.include?('probe_raise') },
+         'probe! does not raise from a nested frame'
+end
+
+check(failures, 'install tees $stderr exactly once') do
+  report.clear
+  original = $stderr
+  begin
+    assert RGSS::ErrorReport.install, 'the first install did not report installing'
+    assert $stderr.is_a?(RGSS::ErrorReport::Tee), '$stderr was not teed'
+    teed = $stderr
+    assert_equal false, RGSS::ErrorReport.install
+    assert teed.equal?($stderr), 'a second install stacked another tee'
+    assert RGSS::ErrorReport.installed?
+    $stderr.puts '[RPG2k] through the installed tee'
+    assert_equal ['[RPG2k] through the installed tee'], report.lines
+  ensure
+    $stderr = original
+  end
+end
+
+if failures.empty?
+  puts "error report: #{RGSS::ErrorReport::MAX_LINES}-line log capture — OK"
+  exit 0
+end
+
+warn ''
+failures.each { |f| warn "failed: #{f}" }
+abort 'RGSS::ErrorReport log capture is broken'

--- a/src/error_dump.cxx
+++ b/src/error_dump.cxx
@@ -1,0 +1,311 @@
+// Crash reporting: turn a fatal mruby exception into one copy-pasteable block.
+// See include/error_dump.hxx for what this is for and how the browser shell
+// picks the block up.
+
+#include "error_dump.hxx"
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <mruby/array.h>
+#include <mruby/class.h>
+#include <mruby/string.h>
+#include <mruby/variable.h>
+#include <mruby/version.h>
+
+#include <gflags/gflags.h>
+
+// Stamped in by the build (see CMakeLists.txt). Defaulted so the file still
+// compiles in a build that does not define them.
+#ifndef RPG_BUILD_REVISION
+#define RPG_BUILD_REVISION "unknown"
+#endif
+#ifndef RPG_BUILD_TYPE
+#define RPG_BUILD_TYPE "unknown"
+#endif
+
+DEFINE_string(
+    error_dump,
+    "error-report.md",
+    "Write the crash report to this file (relative paths resolve against the "
+    "working directory) when the engine dies on a Ruby exception, so it can be "
+    "attached to a bug report. The same text is always printed to stderr. Pass "
+    "an empty value to write no file. Ignored in the browser build, where the "
+    "page offers the report for copy/download instead");
+
+namespace {
+
+std::vector<std::pair<std::string, std::string>>& context() {
+  static std::vector<std::pair<std::string, std::string>> ctx;
+  return ctx;
+}
+
+const char* platform_name() {
+#if defined(__EMSCRIPTEN__)
+  return "WebAssembly (browser)";
+#elif defined(_WIN32)
+  return "Windows";
+#elif defined(__APPLE__)
+  return "macOS";
+#elif defined(__linux__)
+  return "Linux";
+#else
+  return "unknown";
+#endif
+}
+
+std::string to_std_string(mrb_value v) {
+  if (!mrb_string_p(v))
+    return std::string();
+  return std::string(RSTRING_PTR(v), static_cast<size_t>(RSTRING_LEN(v)));
+}
+
+// mrb_funcall on a VM that just died can raise again (a broken #message, a
+// missing method); a report is worth having even then, so swallow that second
+// failure and answer nil. The caller must have cleared mrb->exc first --
+// mruby refuses to run with one pending.
+mrb_value call(mrb_state* M, mrb_value recv, const char* name) {
+  const mrb_value v = mrb_funcall(M, recv, name, 0);
+  if (M->exc) {
+    M->exc = nullptr;
+    return mrb_nil_value();
+  }
+  return v;
+}
+
+// The constant `name` under `owner`, or nil when it is not defined. Asking
+// mrb_const_get for a missing constant raises, which is exactly what a report
+// path must not do.
+mrb_value const_or_nil(mrb_state* M, mrb_value owner, const char* name) {
+  if (!mrb_class_p(owner) && !mrb_module_p(owner))
+    return mrb_nil_value();
+  const mrb_sym sym = mrb_intern_cstr(M, name);
+  if (!mrb_const_defined(M, owner, sym))
+    return mrb_nil_value();
+  return mrb_const_get(M, owner, sym);
+}
+
+mrb_value error_report_module(mrb_state* M) {
+  const mrb_value rgss =
+      const_or_nil(M, mrb_obj_value(M->object_class), "RGSS");
+  return const_or_nil(M, rgss, "ErrorReport");
+}
+
+// The tail of the runtime log, as RGSS::ErrorReport recorded it. Empty when the
+// gem is absent or nothing was logged.
+std::string runtime_log_tail(mrb_state* M) {
+  if (M == nullptr)
+    return std::string();
+  const mrb_value mod = error_report_module(M);
+  if (mrb_nil_p(mod))
+    return std::string();
+  return to_std_string(call(M, mod, "log_tail"));
+}
+
+void append_fenced(std::string& out, const std::string& body) {
+  out += "```\n";
+  out += body;
+  if (body.empty() || body[body.size() - 1] != '\n')
+    out += "\n";
+  out += "```\n\n";
+}
+
+std::string build(mrb_state* M, mrb_value exc, const char* where) {
+  std::string r;
+  r += "# RPG Maker Clone error report\n\n";
+  r += "The engine stopped with an error. Paste this whole block into the bug "
+       "report -- it is what the maintainers need to place the failure.\n\n";
+
+  r += "## Build\n\n";
+  r += "- revision: " RPG_BUILD_REVISION
+       " (stamped when the build was "
+       "configured)\n";
+  r += "- build type: " RPG_BUILD_TYPE "\n";
+  r += std::string("- platform: ") + platform_name() + " (" +
+       std::to_string(sizeof(void*) * 8) + "-bit)\n";
+  r += "- mruby: " MRUBY_VERSION "\n\n";
+
+  r += "## Run\n\n";
+  r += std::string("- caught at: ") + (where ? where : "(unspecified)") + "\n";
+  for (const auto& kv : context())
+    r += "- " + kv.first + ": " + kv.second + "\n";
+  r += "\n";
+
+  r += "## Error\n\n";
+  if (M == nullptr || mrb_nil_p(exc)) {
+    r += "No Ruby exception was pending; see the log below.\n\n";
+  } else {
+    const std::string cls = mrb_obj_classname(M, exc);
+    append_fenced(r, cls + ": " + to_std_string(call(M, exc, "message")));
+
+    // mruby's own printer walks the backtrace from the outermost frame to the
+    // innermost, which is where the exception was actually raised; keep that
+    // order so a report reads like the trace people already know.
+    const mrb_value bt = call(M, exc, "backtrace");
+    if (mrb_array_p(bt) && RARRAY_LEN(bt) > 0) {
+      std::string trace = "trace (most recent call last):\n";
+      for (mrb_int i = RARRAY_LEN(bt) - 1; i >= 0; --i)
+        trace += "\t" + to_std_string(RARRAY_PTR(bt)[i]) + "\n";
+      r += "### Backtrace\n\n";
+      append_fenced(r, trace);
+    } else {
+      // mruby drops every frame whose bytecode carries no debug info, so an
+      // empty backtrace means the failing code was compiled without it rather
+      // than that the exception came from nowhere. Say which, so a report
+      // arriving without a trace is not mistaken for one that lost it.
+      r += "### Backtrace\n\nNot available (the failing code was compiled "
+           "without debug info).\n\n";
+    }
+  }
+
+  const std::string log = runtime_log_tail(M);
+  if (!log.empty()) {
+    r += "## Recent log\n\n";
+    append_fenced(r, log);
+  }
+  return r;
+}
+
+bool write_report_file(const std::string& report, std::string* path_out) {
+#ifdef __EMSCRIPTEN__
+  // The browser filesystem is a throwaway in-memory tree, so a file there
+  // reaches nobody; the page hands the report over instead (src/shell.html).
+  (void)report;
+  (void)path_out;
+  return false;
+#else
+  if (FLAGS_error_dump.empty())
+    return false;
+  std::ofstream out(FLAGS_error_dump.c_str(),
+                    std::ios::binary | std::ios::trunc);
+  if (!out)
+    return false;
+  out << report;
+  out.close();
+  if (!out)
+    return false;
+  *path_out = FLAGS_error_dump;
+  return true;
+#endif
+}
+
+}  // namespace
+
+void error_dump_set_context(const char* key, const std::string& value) {
+  for (auto& kv : context()) {
+    if (kv.first == key) {
+      kv.second = value;
+      return;
+    }
+  }
+  context().emplace_back(key, value);
+}
+
+void error_dump_install(mrb_state* M) {
+  if (M == nullptr)
+    return;
+  const int ai = mrb_gc_arena_save(M);
+  const mrb_value mod = error_report_module(M);
+  if (!mrb_nil_p(mod))
+    call(M, mod, "install");
+  mrb_gc_arena_restore(M, ai);
+}
+
+std::string error_dump_report(mrb_state* M, const char* where) {
+  if (M == nullptr || M->exc == nullptr)
+    return std::string();
+
+  // Building the report calls back into Ruby (#message, #backtrace, the log
+  // tail), which mruby will not do with an exception pending -- so clear it,
+  // and keep the object alive through the arena while it is no longer the VM's.
+  const mrb_value exc = mrb_obj_value(M->exc);
+  const int ai = mrb_gc_arena_save(M);
+  M->exc = nullptr;
+  mrb_gc_protect(M, exc);
+
+  const std::string report = build(M, exc, where);
+
+  M->exc = nullptr;
+  mrb_gc_arena_restore(M, ai);
+
+  std::fprintf(stderr, "%s\n%s%s\n", ERROR_DUMP_BEGIN, report.c_str(),
+               ERROR_DUMP_END);
+  std::string path;
+  if (write_report_file(report, &path))
+    std::fprintf(stderr, "[ErrorDump] report written to %s\n", path.c_str());
+  std::fflush(stderr);
+  return report;
+}
+
+int error_dump_run_probe(mrb_state* M) {
+  const mrb_value mod = error_report_module(M);
+  if (mrb_nil_p(mod)) {
+    std::fprintf(stderr,
+                 "[ErrorDump-PROBE] FAIL RGSS::ErrorReport is not defined\n");
+    return EXIT_FAILURE;
+  }
+  const std::string log_line =
+      to_std_string(const_or_nil(M, mod, "PROBE_LOG_LINE"));
+  const std::string message =
+      to_std_string(const_or_nil(M, mod, "PROBE_MESSAGE"));
+
+  mrb_funcall(M, mod, "probe!", 0);
+  if (M->exc == nullptr) {
+    std::fprintf(stderr, "[ErrorDump-PROBE] FAIL the probe did not raise\n");
+    return EXIT_FAILURE;
+  }
+
+  const std::string report = error_dump_report(M, "the error-dump probe");
+
+  struct Check {
+    const char* what;
+    std::string needle;
+  };
+  const Check checks[] = {
+      // The exception itself, class and message both.
+      {"the exception", "RuntimeError: " + message},
+      // The backtrace: probe! raises from a second method, so a trace that
+      // survived the report carries both frames.
+      {"the backtrace", "trace (most recent call last):"},
+      {"the raising frame", "probe_raise"},
+      // The runtime log the tee captured before the raise -- the part of a
+      // report that is easiest to lose and hardest to notice missing.
+      {"the captured log", log_line},
+      {"the run context", "- caught at: the error-dump probe"},
+  };
+
+  bool ok = true;
+  for (const Check& c : checks) {
+    if (c.needle.empty() || report.find(c.needle) == std::string::npos) {
+      std::fprintf(stderr, "[ErrorDump-PROBE] FAIL the report is missing %s\n",
+                   c.what);
+      ok = false;
+    }
+  }
+
+#ifndef __EMSCRIPTEN__
+  // The file a reporter attaches must hold the same text that was printed.
+  if (!FLAGS_error_dump.empty()) {
+    std::ifstream in(FLAGS_error_dump.c_str(), std::ios::binary);
+    const std::string written((std::istreambuf_iterator<char>(in)),
+                              std::istreambuf_iterator<char>());
+    if (written != report) {
+      std::fprintf(stderr,
+                   "[ErrorDump-PROBE] FAIL %s does not hold the printed "
+                   "report\n",
+                   FLAGS_error_dump.c_str());
+      ok = false;
+    }
+    in.close();
+    std::remove(FLAGS_error_dump.c_str());
+  }
+#endif
+
+  std::fprintf(stderr, "[ErrorDump-PROBE] %s\n", ok ? "ok" : "failed");
+  return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <regex>
+#include <string>
 
 #include <lvgl.h>
 #include <mruby.h>
@@ -16,6 +17,7 @@
 #include <ng-log/logging.h>
 #include <inicpp.hpp>
 
+#include "error_dump.hxx"
 #include "iterm.hxx"
 #include "log_console.hxx"
 #include "profiler.hxx"
@@ -121,6 +123,15 @@ DEFINE_bool(
     "(RGSS.audio_probe). Exits 0 only if the archived one played too. Needs no "
     "game; run with SDL_AUDIODRIVER=dummy in CI as the audio_probe ctest, "
     "which decodes and mixes with no sound card");
+DEFINE_bool(
+    error_dump_probe,
+    false,
+    "Raise a real Ruby exception through the crash-report path and read the "
+    "report back (error_dump_run_probe): it must carry the exception, its "
+    "backtrace and the runtime log captured before the raise, and the "
+    "--error_dump file must hold the same text that was printed. Exits 0 only "
+    "then. Needs no game; run as the error_dump ctest — a report that silently "
+    "lost half its content is worse than no report at all");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -362,27 +373,25 @@ extern "C" void rgss_sdl_input_init(void);
 extern "C" void rgss_audio_init(void);
 extern "C" void rgss_audio_shutdown(void);
 
-// Report an mruby exception (class, message, and Ruby backtrace) and bail out
-// of main(). Preferred over ng-log's CHECK: it prints the actual mruby error
-// detail, and under Emscripten ng-log's fatal path traps anyway (it formats
-// through std::ios callbacks that don't survive the wasm function-pointer
-// table), so we use mruby's own stdio-based printer, which also reaches the
-// browser console.
-#define CHECK_NO_EXC(M)                                                        \
-  do {                                                                         \
-    if ((M)->exc) {                                                            \
-      mrb_value exc__ = mrb_obj_value((M)->exc);                               \
-      (M)->exc = nullptr;                                                      \
-      mrb_value msg__ = mrb_funcall(M, exc__, "message", 0);                   \
-      std::fprintf(stderr, "mruby error: %s: %s\n",                            \
-                   mrb_obj_classname(M, exc__),                                \
-                   mrb_string_value_cstr(M, &msg__));                          \
-      /* mrb_print_backtrace reads mrb->exc, so restore it around the call. */ \
-      (M)->exc = mrb_obj_ptr(exc__);                                           \
-      mrb_print_backtrace(M);                                                  \
-      (M)->exc = nullptr;                                                      \
-      return EXIT_FAILURE;                                                     \
-    }                                                                          \
+// Report an mruby exception and bail out of main(). Preferred over ng-log's
+// CHECK: it reports the actual mruby error detail, and under Emscripten
+// ng-log's fatal path traps anyway (it formats through std::ios callbacks that
+// don't survive the wasm function-pointer table), while error_dump_report goes
+// through plain stdio, which also reaches the browser console.
+//
+// The report is the copy-pasteable block described in include/error_dump.hxx --
+// the exception, its backtrace, this build and the runtime log leading up to it
+// -- so a player can hand a bug report over without a terminal. `where` is
+// stringised from the failing line, since these sites are otherwise
+// indistinguishable in a report.
+#define CHECK_NO_EXC_STR2(x) #x
+#define CHECK_NO_EXC_STR(x) CHECK_NO_EXC_STR2(x)
+#define CHECK_NO_EXC(M)                                                 \
+  do {                                                                  \
+    if ((M)->exc) {                                                     \
+      error_dump_report(M, "src/main.cxx:" CHECK_NO_EXC_STR(__LINE__)); \
+      return EXIT_FAILURE;                                              \
+    }                                                                   \
   } while (0)
 
 #ifdef __EMSCRIPTEN__
@@ -399,11 +408,16 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
 
   const fs::path game_dir_path = "/game";
   mrb_value game_obj;
+  // Which maker was detected is recorded for the crash report before the
+  // runtime is built, so a report from a failed construction still says what
+  // the engine thought it was loading.
   if (fs::exists(game_dir_path / "RPG_RT.ldb")) {
+    error_dump_set_context("project", "RPG Maker 2000/2003 (RPG_RT.ldb)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &em_args);
   } else if (is_rpgvx_game(game_dir_path)) {
     // RPG Maker VX / VX Ace: checked before the XP branch below, which only
     // looks for Game.ini — a VX project has one too. See mruby-rpgvx.
+    error_dump_set_context("project", "RPG Maker VX / VX Ace");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGVX"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "Game.ini")) {
     // RPG Maker XP renders at 640x480. Native main() sizes the display from
@@ -420,6 +434,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
       std::fprintf(stderr, "[RPGXP] display sized to %dx%d\n", RPGXP_WIDTH,
                    RPGXP_HEIGHT);
     }
+    error_dump_set_context("project", "RPG Maker XP (Game.ini)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
              fs::exists(game_dir_path / "data" / "System.json")) {
@@ -428,12 +443,14 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
     // PIXI v5 (WebGL-only); the WebGL backend it needs is not built yet, so
     // this reports the pending state instead of the "no project found" error
     // below (see mruby-mvjs/mrblib/mz.rb, docs/adr/0004 M6).
+    error_dump_set_context("project", "RPG Maker MZ (js/rmmz_core.js)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "MZ"), 1, &em_args);
   } else if (fs::exists(game_dir_path / "js" / "rpg_core.js") &&
              fs::exists(game_dir_path / "data" / "System.json")) {
     // RPG Maker MV: a JavaScript project (js/rpg_core.js + data/System.json).
     // Mirrors MV::REQUIRED_MARKERS; the embedded JS host runs the game's own
     // scripts (see mruby-mvjs). Lets the shell loader run MV projects too.
+    error_dump_set_context("project", "RPG Maker MV (js/rpg_core.js)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "MV"), 1, &em_args);
   } else {
     std::fprintf(stderr,
@@ -445,8 +462,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
     return 1;
   }
   if (M->exc) {
-    mrb_print_backtrace(M);
-    M->exc = nullptr;
+    error_dump_report(M, "loading the project");
     return 1;
   }
 
@@ -457,7 +473,7 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
   main_loop_ = [M, game_obj]() {
     mrb_funcall(M, game_obj, "main_loop", 0);
     if (M->exc) {
-      mrb_print_backtrace(M);
+      error_dump_report(M, "the frame loop");
       emscripten_cancel_main_loop();
     }
   };
@@ -502,6 +518,16 @@ int main(int argc, char** argv) {
       }
     }
   }
+
+  // Everything a crash report should say about this run but cannot work out
+  // for itself. Recorded before anything can fail, so even a failure during
+  // start-up carries it (see include/error_dump.hxx).
+  error_dump_set_context("game dir", FLAGS_game_dir);
+  error_dump_set_context("screen", std::to_string(FLAGS_width) + "x" +
+                                       std::to_string(FLAGS_height));
+  error_dump_set_context("display backend", FLAGS_sixel   ? "sixel terminal"
+                                            : FLAGS_iterm ? "iTerm2 terminal"
+                                                          : "SDL window");
 
   // Configure profiling before mruby is opened so the allocator hook, if it is
   // installed below, sees the right enabled state from its first call. A
@@ -583,6 +609,10 @@ int main(int argc, char** argv) {
 #endif
   mrb_state* M = mrb.get();
   CHECK_NO_EXC(M);
+
+  // Start tailing the runtime log now, so anything the game reports on its way
+  // down is in the crash report — including whatever the boot itself logs.
+  error_dump_install(M);
 
   rgss_set_display(M, display.get());
 
@@ -690,6 +720,16 @@ int main(int argc, char** argv) {
   }
   return EXIT_SUCCESS;
 #else
+  // The crash-report probe is the odd one out: it *wants* an exception, so it
+  // cannot go through the "call it and CHECK_NO_EXC" shape below. It raises
+  // through the real reporting path and reads the report back itself.
+  if (FLAGS_error_dump_probe) {
+    const int rc = error_dump_run_probe(M);
+    rgss_audio_shutdown();
+    gflags::ShutDownCommandLineFlags();
+    return rc;
+  }
+
   // The probes need the display, the audio backend and mruby, but no game: each
   // builds what it measures. Run them here, before the game-class dispatch, and
   // report through the exit code.
@@ -706,18 +746,23 @@ int main(int argc, char** argv) {
   }
 
   mrb_value game_obj;
+  // Record the detected maker for the crash report before the runtime is built
+  // (see the same dispatch in rpg_start_game above).
   if (fs::exists(game_dir_path / "RPG_RT.ldb")) {
+    error_dump_set_context("project", "RPG Maker 2000/2003 (RPG_RT.ldb)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &args);
   } else if (fs::exists(game_dir_path / "js" / "rmmz_core.js") &&
              fs::exists(game_dir_path / "data" / "System.json")) {
     // RPG Maker MZ: a JavaScript game (js/rmmz_core.js) with a JSON database.
     // Shares MV's JS host but needs a WebGL backend (not built yet), so it
     // reports the pending state. See mruby-mvjs/mrblib/mz.rb, docs/adr/0004 M6.
+    error_dump_set_context("project", "RPG Maker MZ (js/rmmz_core.js)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "MZ"), 1, &args);
   } else if (fs::exists(game_dir_path / "js" / "rpg_core.js") &&
              fs::exists(game_dir_path / "data" / "System.json")) {
     // RPG Maker MV: a JavaScript game (js/rpg_core.js) with a JSON database.
     // See docs/adr/0004-javascript-maker-mv-quickjs.md.
+    error_dump_set_context("project", "RPG Maker MV (js/rpg_core.js)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "MV"), 1, &args);
   } else if (is_rpgvx_game(game_dir_path)) {
     // RPG Maker VX / VX Ace: a Marshal database like XP's under a different
@@ -726,8 +771,10 @@ int main(int argc, char** argv) {
     // loads; the built-in title/map flow is still to come, so an unpacked
     // project reports that unless the RGSS script host is enabled. See
     // mruby-rpgvx and docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md.
+    error_dump_set_context("project", "RPG Maker VX / VX Ace");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGVX"), 1, &args);
   } else if (fs::exists(game_dir_path / "Game.ini")) {
+    error_dump_set_context("project", "RPG Maker XP (Game.ini)");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGXP"), 1, &args);
   } else {
     CHECK(false) << "Unknown game directory: " << game_dir_path;
@@ -735,10 +782,15 @@ int main(int argc, char** argv) {
   CHECK_NO_EXC(M);
 
   mrb_funcall(M, game_obj, "start", 0);
+  // The game ran to its end or died in it; either way this is the last chance
+  // to report, so the exception goes out as a full report rather than as a
+  // backtrace plus an ng-log abort.
   if (M->exc) {
-    mrb_print_backtrace(M);
+    error_dump_report(M, "the running game");
+    rgss_audio_shutdown();
+    gflags::ShutDownCommandLineFlags();
+    return EXIT_FAILURE;
   }
-  CHECK(!M->exc);
 
   rgss_audio_shutdown();
   gflags::ShutDownCommandLineFlags();

--- a/src/shell.html
+++ b/src/shell.html
@@ -126,7 +126,7 @@
       #status.busy { color: var(--accent); }
       details { width: min(560px, 100%); }
       summary { cursor: pointer; color: var(--muted); font-size: 12px; }
-      #log {
+      #log, #crashText {
         margin-top: 8px;
         max-height: 180px;
         overflow: auto;
@@ -139,6 +139,22 @@
         white-space: pre-wrap;
         word-break: break-word;
       }
+
+      /* --- Crash report ------------------------------------------------- */
+      /* Shown when the engine (or the page) hits an error, holding the report
+         the buttons copy. Bordered in the error colour so it is unmistakably
+         not part of the normal loader chrome. */
+      #crash { border-color: var(--error); }
+      #crash h2 { font-size: 15px; margin: 0; color: var(--error); }
+      #crash .hint { text-align: left; margin: 0; }
+      #crash a { color: var(--accent); font-size: 12px; text-decoration: none; }
+      #crash a:hover { text-decoration: underline; }
+      button.secondary {
+        background: transparent;
+        color: var(--fg);
+        border: 1px solid var(--border);
+      }
+      .copied { color: var(--accent); font-size: 12px; }
 
       /* --- On-screen keypad -------------------------------------------- */
       #keypad {
@@ -293,9 +309,34 @@
       <p class="hint">Arrows / WASD to move · Z / Enter confirm · X / Esc cancel · click the canvas to give it focus</p>
     </div>
 
+    <!-- Unhidden by showCrash() when the engine dies or the page throws. The
+         report inside is what a bug report needs, ready to copy in one click. -->
+    <div class="panel" id="crash" hidden>
+      <h2>The game hit an error</h2>
+      <p class="hint">
+        Copy the report below into a bug report — it carries the error and its
+        backtrace, which build this is, which project was loaded and the log
+        leading up to the failure. Nothing else is collected.
+      </p>
+      <div class="row">
+        <button type="button" id="copyReport">Copy error report</button>
+        <button type="button" id="downloadReport" class="secondary">Download</button>
+        <a href="https://github.com/take-cheeze/rpg-maker-clone/issues/new" target="_blank" rel="noopener" id="issueLink">Open an issue ↗</a>
+        <span class="copied" id="copyNote"></span>
+      </div>
+      <pre id="crashText"></pre>
+    </div>
+
     <details>
       <summary>Runtime log</summary>
       <pre id="log"></pre>
+      <!-- The same report, for a problem that did not crash the engine (a wrong
+           picture, silence where there should be music): there is nothing to
+           paste from a browser console most players never open. -->
+      <div class="row" style="margin-top:8px">
+        <button type="button" id="copyDiagnostics" class="secondary">Copy diagnostics</button>
+        <span class="copied" id="diagNote"></span>
+      </div>
     </details>
 
     <script type="text/javascript">
@@ -336,14 +377,149 @@
         try { history.replaceState(null, '', s ? '?' + s : location.pathname); } catch (e) {}
       }
 
-      function log(text) {
-        logEl.textContent += text + '\n';
-        logEl.scrollTop = logEl.scrollHeight;
-      }
       function setStatus(text, kind) {
         statusEl.textContent = text;
         statusEl.className = kind || '';
       }
+
+      // --- Error reporting ---------------------------------------------------
+      // A crash in the browser leaves a frozen canvas and, at best, a wall of
+      // text in a panel nobody opens — so nothing useful ever reaches a bug
+      // report. The engine prints one self-contained report (the error, its
+      // backtrace, the build, the project, the runtime log tail) between the
+      // markers below; the page watches its log for them, adds what only the
+      // browser knows, and offers the result as one click of "Copy error
+      // report". Keep the markers in sync with include/error_dump.hxx.
+      var ERROR_DUMP_BEGIN = '----- BEGIN RPG MAKER CLONE ERROR REPORT -----';
+      var ERROR_DUMP_END = '----- END RPG MAKER CLONE ERROR REPORT -----';
+      var LOG_TAIL_LINES = 200;
+
+      var crashEl = document.getElementById('crash');
+      var crashTextEl = document.getElementById('crashText');
+      var copyNoteEl = document.getElementById('copyNote');
+      var diagNoteEl = document.getElementById('diagNote');
+
+      var logLines = [];      // the page's own bounded log tail
+      var engineReport = '';  // the last report the engine printed, if any
+      var dumpLines = null;   // non-null while one is being read off the log
+      var lastReport = '';    // what the buttons copy
+      var currentProject = '';
+
+      function noteLogLine(text) {
+        var line = text.replace(/\s+$/, '');
+        if (line === ERROR_DUMP_BEGIN) { dumpLines = []; return; }
+        if (dumpLines) {
+          if (line !== ERROR_DUMP_END) { dumpLines.push(text); return; }
+          engineReport = dumpLines.join('\n');
+          dumpLines = null;
+          showCrash();
+          return;
+        }
+        // The report's own lines are kept out of the tail below: they are
+        // already in engineReport, and repeating them would bury the log.
+        logLines.push(text);
+        if (logLines.length > LOG_TAIL_LINES) logLines.shift();
+      }
+
+      function log(text) {
+        logEl.textContent += text + '\n';
+        logEl.scrollTop = logEl.scrollHeight;
+        String(text).split('\n').forEach(noteLogLine);
+      }
+
+      function fenced(text) {
+        return '```\n' + text + '\n```\n\n';
+      }
+
+      // The whole report: whatever the engine produced (absent when the failure
+      // was in the page itself), then the browser side of the story.
+      function buildReport(kind, detail) {
+        var out = engineReport
+          ? engineReport.replace(/\s*$/, '') + '\n\n'
+          : '# RPG Maker Clone error report\n\n';
+        out += '## Browser\n\n';
+        out += '- page: ' + location.href + '\n';
+        out += '- user agent: ' + navigator.userAgent + '\n';
+        out += '- project: ' + (currentProject || '(none loaded)') + '\n';
+        out += '- when: ' + new Date().toISOString() + '\n\n';
+        if (detail) {
+          out += '### ' + kind + '\n\n' + fenced(detail);
+        }
+        if (logLines.length) {
+          out += '## Page log (last ' + logLines.length + ' lines)\n\n';
+          out += fenced(logLines.join('\n'));
+        }
+        return out;
+      }
+
+      function showCrash(kind, detail) {
+        lastReport = buildReport(kind, detail);
+        crashTextEl.textContent = lastReport;
+        crashEl.hidden = false;
+        setStatus('The game hit an error — copy the report below.', 'error');
+        crashEl.scrollIntoView({ block: 'nearest' });
+      }
+
+      async function copyText(text) {
+        try {
+          await navigator.clipboard.writeText(text);
+          return true;
+        } catch (e) {
+          // Blocked (an insecure origin, or a browser that wants the older
+          // API); fall through to the selection-based copy, which works there.
+        }
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        var ok = false;
+        try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+        document.body.removeChild(ta);
+        return ok;
+      }
+
+      function note(el, ok) {
+        el.textContent = ok
+          ? 'Copied.'
+          : 'Could not reach the clipboard — select the report and copy it.';
+        setTimeout(function () { el.textContent = ''; }, 5000);
+      }
+
+      document.getElementById('copyReport').addEventListener('click', async function () {
+        note(copyNoteEl, await copyText(lastReport || buildReport()));
+      });
+
+      document.getElementById('downloadReport').addEventListener('click', function () {
+        var blob = new Blob([lastReport || buildReport()], { type: 'text/markdown' });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = 'rpg-maker-clone-error-report.md';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(function () { URL.revokeObjectURL(url); }, 0);
+      });
+
+      // Not everything worth reporting kills the engine: a wrong picture or a
+      // silent BGM leaves the game running with the reason sitting in the log.
+      document.getElementById('copyDiagnostics').addEventListener('click', async function () {
+        note(diagNoteEl, await copyText(buildReport()));
+      });
+
+      // A wasm trap, or a bug in this page, never reaches the engine's report
+      // path — it surfaces as a JS error. Report those the same way.
+      window.addEventListener('error', function (e) {
+        var err = e.error;
+        showCrash('Page error', err && err.stack ? err.stack : (e.message || String(e)));
+      });
+      window.addEventListener('unhandledrejection', function (e) {
+        var r = e.reason;
+        showCrash('Unhandled promise rejection', r && r.stack ? r.stack : String(r));
+      });
 
       // --- Emscripten module wiring -----------------------------------------
       var runtimeReady = false;
@@ -360,6 +536,9 @@
         })(),
         print: function (t) { log(t); },
         printErr: function (t) { log(t); },
+        // The runtime gave up (an assertion, an out-of-memory, a trap). It
+        // prints no report of its own from here, so build one from the page.
+        onAbort: function (what) { showCrash('Runtime abort', String(what)); },
         onRuntimeInitialized: function () {
           runtimeReady = true;
           loadBtn.disabled = false;
@@ -528,6 +707,7 @@
         }
         try {
           setStatus('Starting the bundled sample…');
+          currentProject = 'the bundled sample';
           copyTree('/game_sample', '/game');
           var rc = Module.ccall('rpg_start_game', 'number', [], []);
           if (rc !== 0) throw new Error('runtime returned ' + rc);
@@ -630,6 +810,7 @@
         if (!runtimeReady) return;
         loadBtn.disabled = true;
         fileInput.disabled = true;
+        currentProject = label;
         try {
           setStatus('Loading ' + label + '…', 'busy');
           var buf = await getBuffer();


### PR DESCRIPTION
## Summary

When the engine encounters a fatal Ruby exception, it now generates a self-contained, copy-pasteable Markdown error report instead of just printing a backtrace. This report includes the exception details, backtrace, build information, runtime context, and the tail of the runtime log — everything needed for a bug report without requiring access to a terminal or source tree.

## Key Changes

- **Error report generation** (`src/error_dump.cxx`, `include/error_dump.hxx`): New module that assembles crash reports containing:
  - Build revision and type (stamped at configure time)
  - Platform and mruby version information
  - Run context (game directory, screen size, display backend, etc.)
  - Exception class, message, and Ruby backtrace
  - Tail of the runtime log (last 200 lines)
  - Reports are printed to stderr between markers and written to `--error_dump` file (default: `error-report.md`)

- **Runtime log capture** (`mruby-rgss/mrblib/error_report.rb`): New `RGSS::ErrorReport` module that:
  - Tees `$stderr` through a bounded ring buffer at startup
  - Captures whole lines from partial writes
  - Truncates runaway lines to prevent report bloat
  - Provides `probe!` method for testing the entire report path

- **Browser integration** (`src/shell.html`): Enhanced error handling that:
  - Watches stderr log for error report markers
  - Displays crash reports in an error panel with **Copy error report** and **Download** buttons
  - Adds browser-specific context (URL, user agent, loaded project)
  - Provides **Copy diagnostics** button for non-fatal issues
  - Handles page/wasm errors through the same reporting mechanism

- **Testing and validation**:
  - `--error_dump_probe` flag runs a real exception through the report path and validates all components are present
  - `scripts/error_report_check.rb` tests the log capture on CRuby (partial writes, bounding, truncation, forwarding)
  - `mruby-rgss/test/test.rb` asserts capture behavior in the built interpreter

- **Build integration** (`CMakeLists.txt`): 
  - Stamps build revision (from `git describe`) and build type into the binary
  - Adds `error_dump` ctest for validation
  - Adds `error_report_check` ctest for Ruby-side validation

- **Documentation**: Updated README with error reporting workflow and added ADR 0027 explaining the design rationale

## Implementation Details

- The report path is thoroughly tested because a report that silently loses content is worse than no report
- Log capture uses `$stderr` (the runtime's logging convention) so no changes needed at ~180 existing logging call sites
- Every write still reaches the real `$stderr` untouched; the tee is transparent
- Browser scraping via markers was chosen over a C callback to keep the page working even when calling back into the runtime is unsafe
- Single-installation guard prevents stacking multiple tees on `$stderr`

https://claude.ai/code/session_01MC99p4R3gDAAc1PWXDrU7C