### PR TITLE
Fix the shifted move-command names in analyze_game.rb

### DIFF
--- a/changelog.d/analyze-game-move-command-names.fixed.md
+++ b/changelog.d/analyze-game-move-command-names.fixed.md
@@ -1,0 +1,11 @@
+- `scripts/analyze_game.rb`'s move-route name table was shifted from id 23
+  onward, so the move-command histogram mislabelled most of what it reported:
+  it had 23 `SwitchOn`, 31 `Through(on)`, 35 `ChangeGraphic`, 37 `Wait` and
+  40 `LockFacing`, where liblcf's `MoveCommand::Code` — and the runtime's own
+  `Game::MoveRoute` / `Game::Interpreter::MoveCmd` constants, which real move
+  routes are actually decoded with — have 23 `Wait`, 26 `LockFacing`,
+  32 `SwitchOn`, 34 `ChangeGraphic` and 36 `Through(on)`. Nine of a real game's
+  twelve most-used move commands were reported under the wrong name (5148 `Wait`
+  steps appeared as `SwitchOn`). The runtime was never affected — this was a
+  reporting bug only, the same shape as the 106xx event-opcode shift fixed
+  earlier in the same file.

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -102,18 +102,30 @@ CODE_NAMES = {
   23310 => 'ElseBranch(B)',          23311 => 'EndBranch(B)',
 }.freeze
 
+# Move-route command ids. These match liblcf's MoveCommand::Code and, more to
+# the point, the runtime's own constants in Game::MoveRoute
+# (mruby-rpg2k/mrblib/game.rb) and Game::Interpreter::MoveCmd — which are the
+# numbers real move routes are decoded with, and are exercised every time a
+# Nepheshel map renders identically to RPG_RT.
+#
+# This table used to disagree with them from id 23 onward (it had 23 SwitchOn,
+# 31 Through(on), 35 ChangeGraphic, 37 Wait, 40 LockFacing), so the move
+# histogram mislabelled nine of the twelve most-used commands — a game's 5148
+# `Wait` steps were reported as `SwitchOn`. The runtime was never affected; only
+# this report was.
 MOVE_NAMES = {
   0 => 'MoveUp', 1 => 'MoveRight', 2 => 'MoveDown', 3 => 'MoveLeft',
   4 => 'MoveUpRight', 5 => 'MoveDownRight', 6 => 'MoveDownLeft', 7 => 'MoveUpLeft',
   8 => 'MoveRandom', 9 => 'MoveTowardHero', 10 => 'MoveAwayFromHero', 11 => 'MoveForward',
   12 => 'FaceUp', 13 => 'FaceRight', 14 => 'FaceDown', 15 => 'FaceLeft',
   16 => 'Turn90Right', 17 => 'Turn90Left', 18 => 'Turn180', 19 => 'Turn90RandomLR',
-  20 => 'TurnRandom', 21 => 'TurnTowardHero', 22 => 'TurnAwayFromHero',
-  23 => 'SwitchOn', 24 => 'SwitchOff', 25 => 'ChangeSpeed', 26 => 'ChangeFreq',
-  27 => 'WalkAnimOn', 28 => 'WalkAnimOff', 29 => 'FixDirOn', 30 => 'FixDirOff',
-  31 => 'Through(on)', 32 => 'Through(off)', 33 => 'StopAnimOn', 34 => 'StopAnimOff',
-  35 => 'ChangeGraphic', 36 => 'PlaySoundEffect', 37 => 'Wait',
-  38 => 'BeginJump', 39 => 'EndJump', 40 => 'LockFacing', 41 => 'UnlockFacing',
+  20 => 'FaceRandom', 21 => 'FaceTowardHero', 22 => 'FaceAwayFromHero',
+  23 => 'Wait', 24 => 'BeginJump', 25 => 'EndJump',
+  26 => 'LockFacing', 27 => 'UnlockFacing',
+  28 => 'SpeedUp', 29 => 'SpeedDown', 30 => 'FreqUp', 31 => 'FreqDown',
+  32 => 'SwitchOn', 33 => 'SwitchOff', 34 => 'ChangeGraphic', 35 => 'PlaySoundEffect',
+  36 => 'Through(on)', 37 => 'Through(off)', 38 => 'StopAnim', 39 => 'StartAnim',
+  40 => 'TransparencyUp', 41 => 'TransparencyDown',
 }.freeze
 
 # Event-command opcodes the runtime interpreter implements with a real handler


### PR DESCRIPTION
Found by running the analyzer over a full real game and noticing the move histogram claimed a game used 5148 `SwitchOn` move commands — which no game does.

`MOVE_NAMES` disagreed with liblcf's `MoveCommand::Code`, and more to the point with the **runtime's own** `Game::MoveRoute` / `Game::Interpreter::MoveCmd` constants — the numbers real move routes are actually decoded with — from id 23 onward:

| id | reported | actually |
| --- | --- | --- |
| 23 | `SwitchOn` | `Wait` |
| 26 | `ChangeFreq` | `LockFacing` |
| 31 | `Through(on)` | `FreqDown` |
| 35 | `ChangeGraphic` | `PlaySoundEffect` |
| 37 | `Wait` | `Through(off)` |
| 40 | `LockFacing` | `TransparencyUp` |

Nine of Nepheshel's twelve most-used move commands were reported under the wrong name. Before / after on the same data:

```diff
   MoveAwayFromHero       8237
   MoveTowardHero         7236
   MoveRandom             6036
-  SwitchOn               5148
+  Wait                   5148
   MoveForward            4042
   ...
-  Through(on)            2492
+  FreqDown               2492
-  FixDirOff              2363
+  FreqUp                 2363
```

**The runtime was never affected.** `Game::MoveRoute` has always used the correct constants — every pixel-identical Nepheshel map render exercises them. This is a reporting bug only, and the same shape as the 106xx event-opcode shift already fixed in this file: a hand-kept label table drifting from the enum it describes.

It matters because the report exists to prioritise work from real content. Anyone reading it would have concluded that switch-toggling dominates move routes, when it is actually `Wait` — and would have prioritised accordingly.

## Also confirmed while I was in there

Running the analyzer over the whole game (543 maps, 11,362 map events, 20,925 pages, 505 common events — **184,166 event commands**) reports **100% correctly handled, 0 feature gaps across 0 distinct opcodes**. Every event-command opcode a large, complete RPG2000 game uses now has a handler. I have not added that figure to `docs/rpg2000-sample-analysis.md` here — it belongs with a doc update rather than in a one-line fix — but it is worth someone recording.

## Verification

`ruby -c`, the corrected histogram re-run against Nepheshel (shown above), and `rpg2k_logic_check.rb` 385 — unchanged, since this touches an analysis script only and no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_