### PR TITLE
Lead the RPG2000 analysis with full-game coverage figures

### DIFF
--- a/changelog.d/analysis-doc-full-game-coverage.changed.md
+++ b/changelog.d/analysis-doc-full-game-coverage.changed.md
@@ -1,0 +1,12 @@
+- `docs/rpg2000-sample-analysis.md` now leads with **full-game** coverage
+  figures instead of the partial ones it was written from. The original pass
+  could only tally databases and common events (its own method note explains
+  why per-map data was unreliable); a run against Nepheshel whole — 543 maps,
+  11 362 map events, 20 925 pages, 505 common events, **184 166 event
+  commands** — reports **100 % correctly handled, 0 feature gaps across 0
+  distinct opcodes**, and `--troops` resolves every battle-only command its
+  3265 troop pages run. The "Recommended priorities" list is marked as
+  completed rather than outstanding. Two caveats are stated with the figures:
+  coverage is per *opcode*, not per parameter combination, and one game only
+  exercises the commands its author reached for — `ChangeMonsterHP` (13110)
+  and `TerminateBattle` (13410) never appear in it and stay fixture-tested.

--- a/docs/rpg2000-sample-analysis.md
+++ b/docs/rpg2000-sample-analysis.md
@@ -43,6 +43,50 @@ single largest category in real data and must not be counted as "missing":
 | **no-op by design** (`·`) | `Comment` (12410/22410) and blank/block-structure lines (codes 0 and 10 — empty, param-less). RPG_RT skips these and so does the interpreter; correctly handled, **not** a feature gap. |
 | **feature gap** (`✗`) | Unimplemented and would change behaviour if run. |
 
+## Full-game coverage (2026-08, supersedes the partial figures below)
+
+The figures further down were gathered from **databases and common events only**
+— the method note above records why per-map tallies could not be captured
+reliably in that pass. A later run against a complete game locally settles the
+coverage question outright.
+
+**Nepheshel** (`scripts/download-nepheshel.bash`), analysed whole:
+
+| | |
+| --- | --- |
+| maps | 543 |
+| map events | 11 362 |
+| event pages | 20 925 |
+| common events | 505 |
+| **event commands** | **184 166** |
+| implemented | 139 555 (75.8 %) |
+| no-op by design | 44 611 (24.2 %) |
+| **correctly handled** | **100.0 %** |
+| **genuine feature gaps** | **0, across 0 distinct opcodes** |
+
+Every event-command opcode a large, finished RPG2000 game uses now has a
+handler. Its troop battle-event pages are covered too — `--troops` reports 3265
+pages, 2819 of them conditional, and every battle-only command they run
+(Change Monster MP / Condition, Show Hidden Monster, Change Battle Background,
+the battle Show Battle Animation and 6577 battle Conditional Branches) resolves
+to a handler.
+
+Reproduce with:
+
+```bash
+./scripts/download-nepheshel.bash          # needs `unar`; outside the nix
+                                           # shell, extract with python zipfile
+ruby scripts/analyze_game.rb <game-dir>            # map + common events
+ruby scripts/analyze_game.rb --troops <game-dir>   # battle-event pages
+```
+
+Two caveats on what this does *not* prove. Coverage is measured per **opcode**,
+not per parameter combination: a command can be dispatched and still mishandle
+an operand mode the game happens not to use. And one game, however large, only
+exercises the commands its author reached for — `ChangeMonsterHP` (13110) and
+`TerminateBattle` (13410) never appear in Nepheshel, so they remain
+fixture-tested only.
+
 ## The collection
 
 39 game projects plus two index files:
@@ -189,6 +233,10 @@ runtime can execute virtually all of it.
    | **System overrides** ✅ | ChangeSystemBGM (10660), ChangeScreenTransitions (10690) — now implemented; they showed up as "unidentified" only because `analyze_game.rb`'s 106xx label table was shifted by one slot | Sample2, Sample3 |
 
 ## Recommended priorities for the interpreter
+
+**All of these have since been implemented** — the full-game figures at the top
+of this document record the result (0 feature gaps across 184 166 commands). The
+list is kept for the reasoning that drove the ordering, not as outstanding work.
 
 Ordered by real-world frequency across the analysed games:
 


### PR DESCRIPTION
`docs/rpg2000-sample-analysis.md` was written from a pass that could only read databases and common events — its own method note records that per-map tallies "were not reliably captured". Running the analyser over a complete game settles the coverage question those partial figures were reaching for.

## Nepheshel, whole

| | |
| --- | --- |
| maps | 543 |
| map events | 11 362 |
| event pages | 20 925 |
| common events | 505 |
| **event commands** | **184 166** |
| implemented | 139 555 (75.8 %) |
| no-op by design | 44 611 (24.2 %) |
| **correctly handled** | **100.0 %** |
| **genuine feature gaps** | **0, across 0 distinct opcodes** |

`--troops` resolves every battle-only command its 3265 troop pages run, too.

The "Recommended priorities for the interpreter" list is marked **completed** rather than outstanding — every item on it has landed. I kept the list: the reasoning that drove its ordering is worth having, only the TODO framing is stale.

## Caveats stated, not implied

Two things this does *not* prove, now written next to the figures rather than left for a reader to infer:

- **Coverage is per opcode, not per parameter combination.** A command can be dispatched and still mishandle an operand mode the game happens not to use.
- **One game only exercises what its author reached for.** `ChangeMonsterHP` (13110) and `TerminateBattle` (13410) never appear in Nepheshel, so they remain fixture-tested only.

I'd rather the document be honest about its reach than let "100%, zero gaps" read as stronger than it is.

## Reproducing

The doc now carries the commands. One wrinkle worth knowing: `download-nepheshel.bash` needs `unar`, which is not on `PATH` outside the nix dev shell — extract with python's `zipfile` if you hit that.

Docs and a changelog fragment only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_