### PR TITLE
Abort analyze_game.rb when its move-name table has drifted

### DIFF
--- a/changelog.d/analyze-game-move-name-drift-guard.added.md
+++ b/changelog.d/analyze-game-move-name-drift-guard.added.md
@@ -1,0 +1,10 @@
+- `scripts/analyze_game.rb` now refuses to run when its move-name table has
+  drifted from the runtime. `MOVE_NAMES` has silently disagreed with the ids it
+  describes before, and a drifted label table is worse than none: the report
+  keeps working and quietly attributes a game's commands to the wrong ones.
+  Names cannot be machine-checked in general — nothing in the runtime spells out
+  the string `MoveTowardHero` — but `Game::Interpreter::MoveCmd` pins four ids by
+  name (32..35, because those carry extra parameters the interpreter decodes),
+  and they sit exactly in the span where the last drift landed. A mismatch now
+  aborts with which side moved and what to check, instead of printing a
+  plausible-looking histogram.

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -142,6 +142,30 @@ SUPPORTED = Game::Interpreter::Cmd.constants
                                   .map { |c| Game::Interpreter::Cmd.const_get(c) }
                                   .to_set
 
+# Guard MOVE_NAMES against the runtime.
+#
+# This table has drifted from the ids it describes before, and a drifted label
+# table is worse than no table: the report keeps working and quietly attributes
+# a game's commands to the wrong ones. Names cannot be machine-checked in
+# general — nothing in the runtime spells out the string "MoveTowardHero" — but
+# the interpreter *does* pin four ids by name in Game::Interpreter::MoveCmd,
+# because those four carry extra parameters it has to decode. They sit right in
+# the 32..35 span where the last drift landed (the table had 32 Through(off),
+# 34 StopAnimOff, 35 ChangeGraphic), so checking them catches that whole class.
+#
+# Fail loudly rather than mislabelling: whichever side moved, the person who
+# moved it is the one who should hear about it.
+MC = Game::Interpreter::MoveCmd
+{ MC::SWITCH_ON => 'SwitchOn', MC::SWITCH_OFF => 'SwitchOff',
+  MC::CHANGE_GRAPHIC => 'ChangeGraphic',
+  MC::PLAY_SOUND => 'PlaySoundEffect' }.each do |id, name|
+  next if MOVE_NAMES[id] == name
+  abort "analyze_game.rb: MOVE_NAMES[#{id}] is #{MOVE_NAMES[id].inspect}, but " \
+        "Game::Interpreter::MoveCmd calls #{id} #{name}. One of them has " \
+        "drifted -- check both against liblcf's MoveCommand::Code before the " \
+        "move histogram is trusted again."
+end
+
 # Opcodes that do nothing at run time by design: developer comments and blank /
 # block-structure lines. The interpreter no-ops them, which is the correct
 # behaviour, so they count as "handled" and must not be reported as missing


### PR DESCRIPTION
`MOVE_NAMES` has disagreed with the ids it describes before, and the failure mode is quiet: the report keeps working and attributes a game's commands to the wrong ones. That has now happened twice in this one file — the 106xx event opcodes, then move ids from 23 onward — and both times the tool looked perfectly healthy while its output was wrong.

## Why a guard rather than deriving the names

Deriving `MOVE_NAMES` from the runtime is the obvious idea and it does not work: nothing in the runtime spells out the string `MoveTowardHero`. The constants are named `MOVE_TOWARD_HERO`, and mechanically transliterating them would produce a worse report than the hand-written names.

But `Game::Interpreter::MoveCmd` **does** pin four ids by name — `SWITCH_ON`, `SWITCH_OFF`, `CHANGE_GRAPHIC`, `PLAY_SOUND` at 32..35 — named there because they carry extra parameters the interpreter has to decode. And those four sit *exactly* in the span the last drift landed in:

| id | what the drifted table said | what MoveCmd says |
| --- | --- | --- |
| 32 | `Through(off)` | `SwitchOn` |
| 34 | `StopAnimOff` | `ChangeGraphic` |
| 35 | `ChangeGraphic` | `PlaySoundEffect` |

So four ids are enough to catch that whole class of shift, because a shift moves everything.

## Behaviour

On a mismatch the tool aborts before printing anything:

```
analyze_game.rb: MOVE_NAMES[32] is "Through(off)", but
Game::Interpreter::MoveCmd calls 32 SwitchOn. One of them has drifted --
check both against liblcf's MoveCommand::Code before the move histogram is
trusted again.
```

It deliberately does not guess which side is right — either the table or the runtime could be the one that moved, and whoever moved it is who should hear about it.

## Verification

Both directions, not just the happy one:

- Current tables: the tool runs clean, `--troops` output unchanged.
- Mutating one entry (`32 => 'Through(off)'`): aborts with the diagnostic above and **exit 1**, instead of printing a plausible-looking histogram.

My first attempt at that negative test failed for the wrong reason — I copied the script to `/tmp`, which broke its `__dir__`-relative loads. Re-ran it in place to be sure the guard, not the environment, was what fired.

## What this does not cover

`CODE_NAMES` remains unguarded. There is no equivalent hook: `Game::Interpreter::Cmd` names every opcode, but the report's display strings are stylistic (`ConditionalBranch(B)`, `BlankLine/End(no-op)`) and cannot be derived from constant names without making the report worse. Its 106xx drift was caught by reading real output, and for now that remains the only check on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrCZHpVgXjUuWXicivHN1v)_