### PR TITLE
Implement RPG2003-only event commands and class system

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@
   runs the ordinary command set plus the battle-only commands — Change Monster
   HP / MP / Condition, Show Hidden Monster, Change Battle Background, the battle
   Show Battle Animation, the battle Conditional Branch and Terminate Battle
+- The **RPG2003-only event commands** run too — the low opcodes the 2003 editor
+  emits for the features RPG2000 never had. **Change Class** (1008) moves an
+  actor to a database class, re-reading its growth curve, learn table and EXP
+  curve from the class row and honouring the command's skill and parameter modes
+  (keep / reset / add, keep / halve / reset); **Change Battle Commands** (1009)
+  edits an actor's battle-command list; **Force Flee** (1006), **Enable Combo**
+  (1007) and **Call Common Event** (1005) act inside a battle-event page; and the
+  English-release **Open Load Menu** (5001) / **Exit Game** (5002) leave the map
+  for the loader or quit
 - Message text reveals gradually (a typewriter effect; a button press completes
   it, then dismisses), expands the common control codes (`\v[n]` variable,
   `\n[n]` actor name, `\\`) and draws `\c[n]` colour changes

--- a/changelog.d/analyze-game-rpg2k3-opcodes.fixed.md
+++ b/changelog.d/analyze-game-rpg2k3-opcodes.fixed.md
@@ -1,0 +1,7 @@
+- `scripts/analyze_game.rb` listed Change Class and Change Battle Commands as
+  opcodes 12610 / 12710, which liblcf's `EventCommand::Code` enum does not
+  define at all — real RPG2003 data carrying either command was therefore
+  reported as an unnamed feature gap. They are 1008 / 1009; the table now names
+  the whole RPG2003-only block (1005–1009 and the 5001–5005 English-release
+  system commands), and the battle-only list covers the three that belong to a
+  troop page.

--- a/changelog.d/rpg2k3-event-commands.added.md
+++ b/changelog.d/rpg2k3-event-commands.added.md
@@ -1,0 +1,35 @@
+- RPG Maker 2003: the **RPG2003-only event commands** now run. The editor emits
+  these as low opcodes RPG2000 never had, and until now none of them had a
+  handler — the interpreter's opcode table stopped at the shared RPG2000 set.
+  Added, with the parameter layouts taken from liblcf's `EventCommand::Code`
+  enum and EasyRPG Player's own handlers rather than guessed:
+  - **Change Class** (1008) moves an actor to a database class (職業, chunk 30 —
+    `db.job`), following RPG_RT's order of operations: equipment is stripped
+    first, the class swap re-points the actor at the *class's* growth curve,
+    skill learn table and EXP curve (`Game::Actor#curve_row`, matching how
+    EasyRPG's `GetBaseMaxHp` / `LearnLevelSkills` / `CalculateExp` all branch on
+    `class_id > 0`), and EXP is reset to the new level's threshold even when the
+    level is unchanged. Both the skill mode (keep / reset / add) and the
+    parameter mode (keep / halve / the new class's level-1 or current-level
+    values) are honoured, as is the "show level-up message" flag. An actor whose
+    database row names a class reads its curves from startup.
+  - **Change Battle Commands** (1009) adds or removes an actor's battle commands
+    (戦闘コマンド, actor/class field 80), including RPG_RT's capacity rule — six
+    commands plus the trailing Row entry — and the "remove command 0" form that
+    clears the list back to Row alone.
+  - **Force Flee** (1006), **Enable Combo** (1007) and **Call Common Event**
+    (1005) in a troop's battle-event pages. Force Flee either grants the party a
+    guaranteed escape (the player still has to choose Flee) or sends one / every
+    troop member running — the member is hidden rather than killed, which takes
+    it out of the fight and drops its sprite, with the database's escape SE.
+  - The RPG2003 English-release system commands **Open Load Menu** (5001) and
+    **Exit Game** (5002), which leave the map for the loader and quit outright.
+    **Toggle Fullscreen** (5004) and **Open Video Options** (5005) are logged
+    no-ops: this build's display backend has neither mode, which is also what
+    EasyRPG does on a platform whose window cannot change.
+
+  A class change and its battle-command edits survive Save / Continue. RPG2000
+  data is unaffected — those databases carry no class table, so every actor stays
+  class-less and a Change Class targeting an undefined class changes nothing.
+  Covered by new checks in `scripts/rpg2k_logic_check.rb` and exercised against
+  the real RPG2003 test bed.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -417,6 +417,32 @@ The work below is roughly ordered by the critical path to a walkable game
   Three opcodes that never matched liblcf's `Code` enum were corrected in the
   same pass — Change Equipment is 10450 (10440 is Change Skills) and Game Over is
   12420 — so those commands are recognised in real game data at all.
+  **The RPG2003-only commands are handled now as well** — the low opcodes the
+  2003 editor emits for what RPG2000 never had, none of which had a handler
+  while the opcode table stopped at the shared set. **Change Class** (1008)
+  re-points an actor at a database class (職業, chunk 30 / `db.job`): equipment is
+  stripped, the class row takes over the growth curve, the learn table and the
+  EXP curve (`Game::Actor#curve_row`, mirroring how EasyRPG's `GetBaseMaxHp` /
+  `LearnLevelSkills` / `CalculateExp` branch on `class_id > 0`), EXP resets to
+  the new level's threshold, and the command's skill mode (keep / reset / add)
+  and parameter mode (keep / halve / the class's level-1 or current-level values)
+  both apply; an actor whose row names a class reads its curves from startup, and
+  the change survives Save / Continue. **Change Battle Commands** (1009) edits
+  the actor's 戦闘コマンド list with RPG_RT's six-plus-Row capacity rule.
+  **Force Flee** (1006), **Enable Combo** (1007) and **Call Common Event** (1005)
+  run inside a battle-event page — Force Flee either grants the party a
+  guaranteed escape or hides the troop members that run (out of the fight, not
+  killed), playing the database escape SE. **Open Load Menu** (5001) and **Exit
+  Game** (5002) leave the map for the loader / quit; **Toggle Fullscreen** (5004)
+  and **Open Video Options** (5005) are logged no-ops because this build's
+  display backend has neither, the same answer EasyRPG gives on a platform whose
+  window cannot change mode. Still open here: **Toggle ATB Mode** (5003), which
+  needs the RPG2003 ATB battle system this runtime does not model, so it is
+  deliberately left as a reported gap rather than a silent no-op; and the combo
+  an Enable Combo arms is recorded on the actor but never spent, for the same
+  reason. The opcodes were read out of liblcf's `EventCommand::Code` enum, which
+  also corrected `analyze_game.rb` — it had Change Class / Change Battle Commands
+  at 12610 / 12710, numbers the enum does not define at all.
   **Battle-event pages now run too**: a troop's pages (`enemy_group` chunk 11)
   are evaluated by `Game::BattlePage` at the start of every turn — switch,
   variable, turn, enemy-HP and actor-HP conditions — and each matching page runs

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -921,6 +921,14 @@ module Game
     # (状態) currently afflicting the actor.
     attr_reader :equipment, :skills, :states
 
+    # The actor's RPG2003 class (職業, database chunk 30 -- `db.job`), 0 for none.
+    # RPG2000 databases carry no class table, so this stays 0 there. With a class
+    # set, the class row -- not the actor row -- supplies the growth curve, the
+    # skill learn table and the EXP curve, exactly as RPG_RT reads them
+    # (EasyRPG's Game_Actor::GetBaseMaxHp / LearnLevelSkills / CalculateExp all
+    # branch on `class_id > 0`).
+    attr_reader :class_id
+
     def initialize(db, id)
       @db = db
       @id = id
@@ -933,6 +941,9 @@ module Game
       @charset_index = a.charset_index
       @transparent = a.respond_to?(:semi_transparent) ? (a.semi_transparent ? true : false) : false
       @db_row = a
+      set_class_id(a.respond_to?(:class_id) ? (a.class_id || 0) : 0)
+      @battle_commands = nil # lazily taken from the database on the first change
+      @battle_combo = nil
       @exp = 0
       @equipment = normalize_equipment(a.respond_to?(:initial_equipment) ? a.initial_equipment : nil)
       @skills = []
@@ -968,9 +979,10 @@ module Game
     end
 
     # The database learn table as [skill_id, level] pairs (empty for a row that
-    # exposes no learn table, e.g. the test fixtures).
+    # exposes no learn table, e.g. the test fixtures). Read from the class row
+    # when the actor has one (see #class_id).
     def learn_table
-      a = @db_row
+      a = curve_row
       return [] unless a.respond_to?(:skills) && a.skills
       out = []
       a.skills.each { |_i, l| out.push([l.skill_id, l.level]) }
@@ -1125,9 +1137,9 @@ module Game
     # curve (six shorts per level) via LCF::Array1D#int16_values; index it by
     # level, clamped to the curve's length. A row that only offers a single
     # `status` hash (the test fixtures, or a database without a curve) is treated
-    # as level-independent.
+    # as level-independent. With a class set the class row's curve wins.
     def base_stats(level)
-      a = @db_row
+      a = curve_row
       curve = a.respond_to?(:int16_values) ? a.int16_values(31) : nil
       if curve && curve.size >= STAT_NAMES.size
         levels = curve.size / STAT_NAMES.size
@@ -1401,7 +1413,135 @@ module Game
       recompute_stats
     end
 
+    # -- RPG2003 class (職業) and battle commands ----------------------------
+
+    # How Change Class (1008) treats the actor's skills, in the command's own
+    # parameter order.
+    CLASS_SKILL_NO_CHANGE = 0 # keep exactly the skills the actor already knows
+    CLASS_SKILL_RESET     = 1 # forget everything, then learn the new class's
+    CLASS_SKILL_ADD       = 2 # keep them and add the new class's on top
+
+    # How Change Class treats the six base parameters.
+    CLASS_PARAM_NO_CHANGE   = 0 # keep the values the actor had
+    CLASS_PARAM_HALF        = 1 # halve them
+    CLASS_PARAM_RESET_LV1   = 2 # take the new class's level-1 values
+    CLASS_PARAM_RESET_LEVEL = 3 # take the new class's values at the new level
+
+    # Change Class (event command 1008). Ported from EasyRPG's
+    # Game_Actor::ChangeClass, which is where the order of operations comes from:
+    #
+    # * every equipment slot is stripped first (RPG_RT always does this),
+    # * the base parameters in force *before* the change are captured, because
+    #   the "no change" and "halve" modes carry them across the class swap,
+    # * the class is swapped and the level set, which re-reads the growth curve,
+    #   the learn table and the EXP curve from the new class row (#curve_row),
+    # * EXP is reset to the new level's threshold -- RPG_RT does this even when
+    #   the level is unchanged,
+    # * and the skill mode is applied last, on top of whatever levelling learnt.
+    #
+    # Current HP/SP survive the change, re-clamped to the refreshed maxima.
+    # Returns whether the class actually changed — false for a class id this
+    # database does not define, which RPG_RT leaves entirely alone.
+    def change_class(class_id, new_level, skill_mode, param_mode)
+      return false if class_id > 0 && class_row_for(class_id).nil?
+
+      unequip(EQUIP_ORDER.size)
+      hp = @hp
+      mp = @mp
+      old_base = @base.dup
+      old_skills = @skills.dup
+
+      set_class_id(class_id)
+      set_level(Game.clamp(new_level || 1, 1, max_level))
+      @battle_commands = class_battle_commands
+      @exp = exp_for_level(@level)
+
+      case param_mode
+      when CLASS_PARAM_NO_CHANGE then @base = old_base
+      when CLASS_PARAM_HALF      then @base = old_base.map { |v| v / 2 }
+      when CLASS_PARAM_RESET_LV1 then @base = base_stats(1)
+      end
+      recompute_stats
+
+      @hp = Game.clamp(hp, 0, @max_hp) if hp
+      @mp = Game.clamp(mp, 0, @max_mp) if mp
+
+      case skill_mode
+      when CLASS_SKILL_NO_CHANGE then @skills = old_skills
+      when CLASS_SKILL_RESET     then @skills = []; learn_level_skills
+      end
+      true
+    end
+
+    # The actor's RPG2003 battle-command ids (戦闘コマンド, database field 80 --
+    # seven slots padded with -1, the 0 entry standing for the Row command).
+    # Until a Change Battle Commands (1009) edits them they are read straight
+    # from the database, which is also how RPG_RT defers materialising the list.
+    def battle_commands
+      @battle_commands ||= class_battle_commands
+    end
+
+    # Change Battle Commands (event command 1009). `add` inserts command `id`
+    # ahead of the Row entry; otherwise it is removed, and id 0 clears the whole
+    # list back to Row alone. Ported from EasyRPG's
+    # Game_Actor::ChangeBattleCommands, including its capacity rule: the list
+    # holds at most six real commands plus Row, so a seventh add is dropped.
+    def change_battle_commands(add, id)
+      cmds = battle_commands
+      if add
+        return if id.nil? || id <= 0 || cmds.include?(id)
+        kept = cmds.reject { |c| c == 0 || c == -1 }
+        return if kept.size >= 6
+        @battle_commands = kept + [id, 0]
+      elsif id == 0
+        @battle_commands = [0]
+      else
+        idx = cmds.index(id)
+        return unless idx
+        kept = cmds.dup
+        kept.delete_at(idx)
+        @battle_commands = kept
+      end
+    end
+
+    # Put the actor back into class `id` without any of Change Class's side
+    # effects (Continue restoring a saved class): the curves are re-read at the
+    # current level, but equipment, EXP and skills are restored separately from
+    # the save and must not be reset here.
+    def restore_class(id)
+      set_class_id(id)
+      set_level(@level)
+      @battle_commands = nil
+    end
+
+    # Replace the battle-command list (Continue restoring a saved one). nil keeps
+    # whatever the database / class defines.
+    def battle_commands=(ids)
+      @battle_commands = ids && !ids.empty? ? ids.dup : nil
+    end
+
+    # The RPG2003 battle combo an Enable Combo (1007) armed: the battle command
+    # to repeat and how many times. nil until a battle page arms one.
+    attr_reader :battle_combo
+
+    # Enable Combo (event command 1007): make `command_id` repeat `multiple`
+    # times when this actor uses it. Stored on the actor the way RPG_RT keeps it
+    # (EasyRPG's Game_Actor::SetBattleCombo); the ATB battle system that spends
+    # it is not modelled here, so this records the arming rather than acting.
+    def set_battle_combo(command_id, multiple)
+      @battle_combo = { command_id: command_id, multiple: multiple }
+    end
+
     private
+
+    # The battle-command list the actor's current class (or, class-less, its
+    # database row) defines. An edition / fixture row without the field yields
+    # the RPG2003 default of Row alone.
+    def class_battle_commands
+      row = @class_row || @db_row
+      list = row.respond_to?(:battle_commands) ? row.battle_commands : nil
+      list.is_a?(Array) && !list.empty? ? list.dup : [0]
+    end
 
     # EasyRPG's CalculateExp(n): the RPG2000 standard EXP curve summed over n
     # steps. Float arithmetic mirrors RPG_RT; the running total truncates toward
@@ -1420,9 +1560,35 @@ module Game
     end
 
     # Read a numeric EXP-curve field from the database row, defaulting when the
-    # row (a test fixture) does not carry it.
+    # row (a test fixture) does not carry it. The class row wins when the actor
+    # has a class, mirroring EasyRPG's CalculateExp.
     def db_exp_param(field)
-      @db_row.respond_to?(field) ? (@db_row.__send__(field) || EXP_DEFAULT) : EXP_DEFAULT
+      row = curve_row
+      row.respond_to?(field) ? (row.__send__(field) || EXP_DEFAULT) : EXP_DEFAULT
+    end
+
+    # The database row the level-scaled tables are read from: the class row (職業)
+    # when the actor has a class, the actor row otherwise. Only the growth curve,
+    # the learn table and the EXP curve follow the class -- the attribute / state
+    # ranks stay on the actor row, which is where RPG_RT keeps reading them.
+    def curve_row
+      @class_row || @db_row
+    end
+
+    # Point the actor at class `id` (0 = none), resolving its database row. A
+    # database with no class table (every RPG2000 game) or an unknown id leaves
+    # the actor class-less, so the actor row keeps supplying the curves.
+    def set_class_id(id)
+      @class_id = id && id > 0 ? id : 0
+      @class_row = @class_id > 0 ? class_row_for(@class_id) : nil
+      @class_id = 0 if @class_row.nil?
+    end
+
+    # The database class row for `id`, or nil when this database has no class
+    # table (RPG2000) or does not define that id.
+    def class_row_for(id)
+      return nil unless @db.respond_to?(:job) && @db.job
+      @db.job[id]
     end
   end
 
@@ -1456,7 +1622,12 @@ module Game
         meta[a.id] = { name: a.name, title: a.title,
                        charset_name: a.charset_name,
                        charset_index: a.charset_index,
-                       transparent: a.transparent, states: a.states.dup }
+                       transparent: a.transparent, states: a.states.dup,
+                       # RPG2003: a Change Class / Change Battle Commands is a
+                       # permanent edit, so it has to outlive Save / Continue the
+                       # way the name and sprite overrides do.
+                       class_id: a.class_id,
+                       battle_commands: a.battle_commands.dup }
       end
       { actor_ids: @actors.map { |a| a.id }, items: @items, gold: @gold,
         hp: hp, mp: mp, exp: exp, actor_meta: meta }
@@ -1474,10 +1645,14 @@ module Game
       mp = data[:mp] || {}
       meta = data[:actor_meta] || {}
       @actors.each do |a|
+        # The class comes back first: it decides which growth and EXP curves the
+        # restored EXP is then read against.
+        m = meta[a.id]
+        a.restore_class(m[:class_id]) if m && m[:class_id]
         a.set_exp(exp[a.id]) if exp[a.id]
         a.hp = hp[a.id] if hp[a.id]
         a.mp = mp[a.id] if mp[a.id]
-        apply_actor_meta(a, meta[a.id])
+        apply_actor_meta(a, m)
       end
     end
 
@@ -1492,6 +1667,7 @@ module Game
       end
       actor.transparent = m[:transparent] unless m[:transparent].nil?
       actor.states = m[:states] if m[:states]
+      actor.battle_commands = m[:battle_commands] if m[:battle_commands]
     end
 
     def each(&blk); @actors.each(&blk); end
@@ -3318,6 +3494,7 @@ module Game
       @result = nil
       @escaped = false     # set once the party successfully flees (#attempt_escape)
       @escape_chance = nil # lazily computed from agilities on the first attempt
+      @force_flee = false  # a battle page granted the party a guaranteed escape
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
       @pending = []  # extra hits of an all-target action, drained one per #step
@@ -3371,6 +3548,33 @@ module Game
     def enemy_turn(_index); nil; end
     def actor_turn(_id); nil; end
     def actor_command(_id); nil; end
+
+    # Force Flee (1006), target 0: let the party leave whenever it next tries.
+    # RPG_RT grants the escape rather than performing it, so the player still has
+    # to pick Flee — #attempt_escape then always succeeds.
+    def force_flee_party; @force_flee = true; end
+
+    # Whether a Force Flee has granted the party its guaranteed escape.
+    def force_flee?; @force_flee; end
+
+    # Force Flee, target 2: troop member `index` runs from the fight. The
+    # combatant is hidden, which takes it out of play (Combatant#out_of_play?)
+    # without counting as a kill. Returns whether anyone actually left, so the
+    # caller only plays the escape sound when one did.
+    def flee_enemy(index)
+      foe = enemy(index)
+      return false if foe.nil? || foe.dead? || foe.hidden
+      foe.hidden = true
+      true
+    end
+
+    # Force Flee, target 1: every troop member still standing runs. Returns the
+    # indices that left.
+    def flee_all_enemies
+      fled = []
+      @enemies.each_index { |i| fled.push(i) if flee_enemy(i) }
+      fled
+    end
 
     # Terminate Battle (13410): abandon the fight outright. Unlike a victory or
     # defeat this has no outcome to process, so it is kept as its own flag the
@@ -3471,14 +3675,15 @@ module Game
       @escape_chance = Game.clamp(150 - base, 0, 100)
     end
 
-    # Attempt to flee the fight. A `preemptive` first strike always succeeds;
-    # otherwise a 0..99 roll under #escape_chance wins. Success ends the battle as
-    # :escaped (#finished? / #escaped?); a failure raises the next attempt's
-    # chance by 10 (per EasyRPG) and returns false, leaving the fight running so
-    # the enemies still take their round.
+    # Attempt to flee the fight. A `preemptive` first strike always succeeds, as
+    # does an escape a Force Flee battle page has granted; otherwise a 0..99 roll
+    # under #escape_chance wins. Success ends the battle as :escaped (#finished? /
+    # #escaped?); a failure raises the next attempt's chance by 10 (per EasyRPG)
+    # and returns false, leaving the fight running so the enemies still take
+    # their round.
     def attempt_escape(preemptive = false)
       return false if finished?
-      if preemptive || @rng.random(100) < escape_chance
+      if preemptive || @force_flee || @rng.random(100) < escape_chance
         @escaped = true
         @result = :escaped
         true

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -11,6 +11,21 @@ module Game
   class Interpreter
     # RPG2000 event command opcodes (subset).
     module Cmd
+      # RPG2003-only commands. The editor emits these low opcodes for the
+      # features RPG2000 never had: the 100x block is the battle-event page's
+      # own extras plus the class / battle-command changes, and the 500x block
+      # is the "RPG2003 English release" (2k3e) system commands. The numbers are
+      # liblcf's `EventCommand::Code` enum, not a guess -- RPG2000 game data
+      # never carries them, so they only ever fire on a 2003 project.
+      CALL_COMMON_EVENT      = 1005
+      FORCE_FLEE             = 1006
+      ENABLE_COMBO           = 1007
+      CHANGE_CLASS           = 1008
+      CHANGE_BATTLE_COMMANDS = 1009
+      OPEN_LOAD_MENU         = 5001
+      EXIT_GAME              = 5002
+      TOGGLE_FULLSCREEN      = 5004
+      OPEN_VIDEO_OPTIONS     = 5005
       SHOW_MESSAGE     = 10110
       MESSAGE_2        = 20110
       MESSAGE_OPTIONS  = 10120
@@ -166,6 +181,7 @@ module Game
       @movie_request = nil
       @triggered_by_decision_key = false
       @revealed_monsters = []
+      @fled_monsters = []
       @battle_background = nil
       @input_variable = nil
       @input_digits = 1
@@ -217,6 +233,7 @@ module Game
       @vehicle_toggle_requested = false
       @movie_request = nil
       @revealed_monsters = []
+      @fled_monsters = []
       @battle_background = nil
       # Cleared per run so a reused interpreter (the shared foreground one, or a
       # looping parallel process) never inherits the previous event's trigger;
@@ -358,6 +375,15 @@ module Game
     def take_revealed_monsters
       ids = @revealed_monsters
       @revealed_monsters = []
+      ids
+    end
+
+    # Drain the Force Flee (1006) troop-member indices queued since the last
+    # call — the members that just ran from the fight. The scene polls this and
+    # drops their sprites. Non-blocking.
+    def take_fled_monsters
+      ids = @fled_monsters
+      @fled_monsters = []
       ids
     end
 
@@ -653,6 +679,8 @@ module Game
       when Cmd::CHANGE_CONDITION then do_change_condition cmd
       when Cmd::FULL_HEAL        then do_full_heal cmd
       when Cmd::SIMULATED_ATTACK then do_simulated_attack cmd
+      when Cmd::CHANGE_CLASS     then do_change_class cmd
+      when Cmd::CHANGE_BATTLE_COMMANDS then do_change_battle_commands cmd
       when Cmd::CHANGE_ACTOR_NAME   then do_change_actor_name cmd
       when Cmd::CHANGE_ACTOR_TITLE  then do_change_actor_title cmd
       when Cmd::CHANGE_ACTOR_SPRITE then do_change_actor_sprite cmd
@@ -716,6 +744,11 @@ module Game
       when Cmd::RETURN_TO_TITLE  then do_return_to_title cmd
       when Cmd::GAME_OVER        then do_game_over cmd
       when Cmd::CALL_EVENT       then do_call_event cmd
+      when Cmd::CALL_COMMON_EVENT then do_call_common_event cmd
+      when Cmd::OPEN_LOAD_MENU   then do_open_load_menu cmd
+      when Cmd::EXIT_GAME        then do_exit_game cmd
+      when Cmd::TOGGLE_FULLSCREEN then do_toggle_fullscreen cmd
+      when Cmd::OPEN_VIDEO_OPTIONS then do_open_video_options cmd
       when Cmd::ERASE_EVENT      then @erase_requested = true
       when Cmd::END_EVENT        then @index = @list.size
       when Cmd::LABEL            then nil # jump target only; Jump to Label finds it
@@ -724,6 +757,8 @@ module Game
       when Cmd::CHANGE_MONSTER_MP        then do_change_monster_mp cmd
       when Cmd::CHANGE_MONSTER_CONDITION then do_change_monster_condition cmd
       when Cmd::SHOW_HIDDEN_MONSTER      then do_show_hidden_monster cmd
+      when Cmd::FORCE_FLEE               then do_force_flee cmd
+      when Cmd::ENABLE_COMBO             then do_enable_combo cmd
       when Cmd::CHANGE_BATTLE_BG         then do_change_battle_bg cmd
       when Cmd::SHOW_BATTLE_ANIM_B       then do_show_battle_animation_b cmd
       when Cmd::CONDITIONAL_B            then do_conditional_battle cmd
@@ -1257,8 +1292,14 @@ module Game
     def queue_level_up_messages(actor, old_level, new_level)
       return unless new_level > old_level
       ((old_level + 1)..new_level).each do |lv|
-        @pending_messages.push(["#{actor.name} is now level #{lv}!"])
+        @pending_messages.push([level_up_message(actor, lv)])
       end
+    end
+
+    # The one line a level-up announces. RPG_RT phrases it from the database
+    # terms; this build uses a plain English line for now.
+    def level_up_message(actor, level)
+      "#{actor.name} is now level #{level}!"
     end
 
     # Enter the next queued level-up message as a :message wait; returns false
@@ -1349,6 +1390,44 @@ module Game
       stat_targets(cmd).each do |a|
         remove ? a.remove_state(state_id) : a.add_state(state_id)
       end
+    end
+
+    # -- RPG2003 class / battle commands --------------------------------------
+
+    # Change Class (1008), an RPG2003-only command: move the target actor(s) to
+    # database class param2 (0 = no class). param3 sets the level to 1 rather
+    # than keeping the current one, param4 is the skill mode and param5 the
+    # parameter mode (see Game::Actor::CLASS_SKILL_* / CLASS_PARAM_*), and param6
+    # is the "show level-up message" flag the Change Level command also carries.
+    # An RPG2000 project cannot emit this, and a database without a class table
+    # leaves every actor class-less, so the command self-limits to 2003 data.
+    def do_change_class(cmd)
+      class_id = cmd.param(2)
+      level_1 = cmd.param(3) != 0
+      skill_mode = cmd.param(4)
+      param_mode = cmd.param(5)
+      show_msg = cmd.param(6) != 0
+      stat_targets(cmd).each do |a|
+        before = a.level
+        next unless a.change_class(class_id, level_1 ? 1 : a.level,
+                                   skill_mode, param_mode)
+        # Unlike Change Level (which announces every level crossed) RPG_RT shows
+        # a single line here, and shows it whenever the class change taught new
+        # skills even if the level itself did not move (EasyRPG's ChangeClass).
+        next unless show_msg && a.level > 1
+        next unless a.level > before || skill_mode != Game::Actor::CLASS_SKILL_NO_CHANGE
+        @pending_messages.push([level_up_message(a, a.level)])
+      end
+      show_next_pending_message
+    end
+
+    # Change Battle Commands (1009), RPG2003-only: add (param3 non-zero) or
+    # remove battle command param2 from the target actor(s). Removing command 0
+    # clears the list back to the Row entry alone.
+    def do_change_battle_commands(cmd)
+      cmd_id = cmd.param(2)
+      add = cmd.param(3) != 0
+      stat_targets(cmd).each { |a| a.change_battle_commands(add, cmd_id) }
     end
 
     # -- actor identity / graphic ---------------------------------------------
@@ -1541,6 +1620,55 @@ module Game
     def do_show_hidden_monster(cmd)
       return unless @battle
       @revealed_monsters.push(cmd.param(0))
+    end
+
+    # Force Flee (1006), RPG2003-only: make somebody leave the fight. param0
+    # picks who — 0 the party (which only *grants* the escape: the player still
+    # has to choose Flee, and then always succeeds), 1 every troop member still
+    # standing, 2 the single member param1. param2 is RPG_RT's "check the battle
+    # condition" flag, which suppresses the flee in a pincer / surround ambush;
+    # this runtime models neither formation, so every fight counts as a normal
+    # one and the flee always goes ahead. Enemies that leave are recorded so the
+    # scene can drop their sprites and play the escape sound.
+    def do_force_flee(cmd)
+      return unless @battle
+      case cmd.param(0)
+      when 0 then @battle.force_flee_party
+      when 1 then @fled_monsters.concat(@battle.flee_all_enemies)
+      when 2
+        index = cmd.param(1)
+        @fled_monsters.push(index) if @battle.flee_enemy(index)
+      end
+    end
+
+    # Enable Combo (1007), RPG2003-only: arm party actor param0's battle command
+    # param1 to repeat param2 times. Recorded on the actor; the ATB battle system
+    # that spends a combo is not modelled here, so nothing acts on it yet.
+    def do_enable_combo(cmd)
+      return unless @battle
+      actor = party.actor_by_id(cmd.param(0))
+      return unless actor
+      actor.set_battle_combo(cmd.param(1), cmd.param(2))
+    end
+
+    # Call Common Event (1005), the RPG2003 battle page's own call command:
+    # param0 is the common event id, and unlike the map's Call Event (12330)
+    # there is no map-event form. Runs through the same call stack.
+    def do_call_common_event(cmd)
+      return unless @resolver
+      cmds = common_event_commands(cmd.param(0))
+      return if cmds.nil? || cmds.empty?
+      return if @call_stack.size >= MAX_CALL_DEPTH
+      @call_stack.push [@list, @index]
+      @list = cmds
+      @index = 0
+    end
+
+    def common_event_commands(id)
+      @resolver.common_event_commands(id)
+    rescue StandardError => e
+      $stderr.puts "[RPG2k] Call Common Event #{id} failed: #{e.message}"
+      nil
     end
 
     # Change Battle Background (13210): swap the backdrop to the Backdrop/<name>
@@ -1939,6 +2067,37 @@ module Game
     def do_return_to_title(_cmd)
       @wait_kind = :return_title
       @waiting = true
+    end
+
+    # -- RPG2003 English-release (2k3e) system commands ------------------------
+
+    # Open Load Menu (5001): leave the map for the save-slot loader, the way
+    # Return to Title leaves it. Raised as a :load_menu request; there is nothing
+    # to resume, because whatever the player loads replaces this scene.
+    def do_open_load_menu(_cmd)
+      @wait_kind = :load_menu
+      @waiting = true
+    end
+
+    # Exit Game (5002): quit outright — the title screen's Shutdown entry, driven
+    # by an event. Raised as an :exit_game request the scene answers by leaving
+    # the process; nothing resumes.
+    def do_exit_game(_cmd)
+      @wait_kind = :exit_game
+      @waiting = true
+    end
+
+    # Toggle Fullscreen (5004) / Open Video Options (5005): the 2k3e display
+    # commands. This build's display backend offers neither a fullscreen toggle
+    # nor a video-options screen, so — like EasyRPG on a platform whose window
+    # cannot change mode — the command is a logged no-op rather than a silent
+    # one, and the event runs straight on.
+    def do_toggle_fullscreen(_cmd)
+      $stderr.puts '[RPG2k] Toggle Fullscreen: this display has no fullscreen mode'
+    end
+
+    def do_open_video_options(_cmd)
+      $stderr.puts '[RPG2k] Open Video Options: no video-options screen in this build'
     end
 
     # Game Over (12420): raised as a :game_over request the owning scene answers

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1677,6 +1677,26 @@ class RPG2k
         @interpreter.resume
       end
 
+      # Open Load Menu (5001, RPG2003): hand the game back to the loader, which
+      # replaces this scene with the loaded save's map. Nothing resumes here, so
+      # the interpreter is stopped rather than released — the same shape as
+      # Return to Title. A failed load leaves the player on this map, so the
+      # event is only stopped, never silently resumed into a discarded scene.
+      def perform_event_load
+        @interpreter.stop
+        @parent.continue_game
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Open Load Menu failed: #{e.message}"
+        @interpreter.stop
+      end
+
+      # Exit Game (5002, RPG2003): quit, the way the title screen's Shutdown
+      # entry does.
+      def perform_exit_game
+        @interpreter.stop
+        exit
+      end
+
       # Open Main Menu (11950): push the field menu over the map, then resume the
       # event once the player closes it again. `@event_menu` marks that this
       # scene is waiting on its own menu, so the event stays paused for exactly
@@ -1977,6 +1997,8 @@ class RPG2k
           when :sprite_flash then @interpreter.resume unless sprite_flashing?
           when :save_menu then perform_event_save
           when :menu then perform_event_menu
+          when :load_menu then perform_event_load
+          when :exit_game then perform_exit_game
           end
         else
           @interpreter.update
@@ -2375,6 +2397,9 @@ class RPG2k
                        events: Game::Interpreter.new(@state), event_win: nil,
                        pages_run: {} }
         @battle_ui[:events].battle = @battle_ui[:battle]
+        # A battle page can Call Common Event (1005), so it needs the same
+        # resolver the map's events run against.
+        @battle_ui[:events].resolver = @interpreter.resolver
         build_battle_sprites
         refresh_battle_status
         # Turn-0 pages fire before the party is asked for its first command —
@@ -2935,6 +2960,9 @@ class RPG2k
       # backdrop.
       def apply_battle_event_requests(it)
         it.take_revealed_monsters.each { |i| reveal_battle_monster(i) }
+        fled = it.take_fled_monsters
+        fled.each { |i| remove_fled_monster(i) }
+        play_escape_se unless fled.empty?
         name = it.take_battle_background
         rebuild_battle_back(name) unless name.nil?
       rescue StandardError => e
@@ -2960,6 +2988,22 @@ class RPG2k
         spr.z = 100 + index
         dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
         @battle_ui[:enemy_sprites][index] = spr
+      end
+
+      # Force Flee: the troop member ran, so drop its sprite. Game::Battle has
+      # already hidden the combatant (which takes it out of play without counting
+      # as a kill), and the troop member's own flag is set so a later rebuild does
+      # not draw it again.
+      def remove_fled_monster(index)
+        member = @battle_ui[:troop].members[index]
+        member.hidden = true if member
+        dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
+        @battle_ui[:enemy_sprites][index] = nil
+      end
+
+      # The escape sound RPG_RT plays when a Force Flee sends enemies running.
+      def play_escape_se
+        play_system_se(SFX_ESCAPE)
       end
 
       # Terminate Battle: leave the fight with no victory / defeat processing.
@@ -3857,8 +3901,14 @@ class RPG2k
       SFX_DECISION = 1
       SFX_CANCEL = 2
       SFX_BUZZER = 3
+      # The slots keep the database's own order (System fields 41..52), so slot 4
+      # is Battle Start and slot 5 Escape — the sound RPG_RT plays when someone
+      # runs from a fight (Force Flee, 1006).
+      SFX_BATTLE = 4
+      SFX_ESCAPE = 5
       DB_SE_FIELD = { SFX_CURSOR => :cursor_se, SFX_DECISION => :decision_se,
-                      SFX_CANCEL => :cancel_se, SFX_BUZZER => :buzzer_se }.freeze
+                      SFX_CANCEL => :cancel_se, SFX_BUZZER => :buzzer_se,
+                      SFX_BATTLE => :battle_se, SFX_ESCAPE => :escape_se }.freeze
 
       # Play a system sound effect by slot, preferring a Change System SFX
       # override held on the game state and falling back to the database's own

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -52,6 +52,18 @@ CODE_NAMES = {
   # carry no string and no parameters). RPG_RT skips them and so does the
   # interpreter (`else nil`), so they are correctly handled, not feature gaps.
   0  => 'BlankLine/End(no-op)', 10 => 'BlankLine(no-op)',
+  # RPG2003-only commands. The editor emits these low opcodes for the features
+  # RPG2000 never had — the 100x block for the battle-event page extras plus the
+  # class / battle-command changes, the 500x block for the "RPG2003 English
+  # release" (2k3e) system commands. They used to be listed here as 12610 /
+  # 12710, which are not opcodes liblcf defines at all, so real 2003 data
+  # carrying a Change Class was reported as an unnamed gap.
+  1005 => 'CallCommonEvent',         1006 => 'ForceFlee',
+  1007 => 'EnableCombo',             1008 => 'ChangeClass',
+  1009 => 'ChangeBattleCommands',
+  5001 => 'OpenLoadMenu',            5002 => 'ExitGame',
+  5003 => 'ToggleAtbMode',           5004 => 'ToggleFullscreen',
+  5005 => 'OpenVideoOptions',
   10110 => 'ShowMessage',            20110 => 'ShowMessage(cont.)',
   10120 => 'MessageOptions',         10130 => 'ChangeFaceGraphic',
   10140 => 'ShowChoice',             20140 => 'ShowChoiceOption', 20141 => 'ShowChoiceEnd',
@@ -92,7 +104,6 @@ CODE_NAMES = {
   12310 => 'EndEventProcessing',     12320 => 'EraseEvent',        12330 => 'CallEvent',
   12410 => 'Comment',                22410 => 'Comment(cont.)',
   12420 => 'GameOver',               12510 => 'ReturnToTitleScreen',
-  12610 => 'ChangeClass',            12710 => 'ChangeBattleCommands',
   # Battle-only: these appear in a troop's battle-event pages, never in a map or
   # common event. Reported by --troops.
   13110 => 'ChangeMonsterHP',        13120 => 'ChangeMonsterMP',
@@ -338,7 +349,8 @@ BATTLE_PAGE_FLAGS = %w[switch_a switch_b variable turn fatigue enemy_hp
 # ShowMessage(cont.) 20110 and Comment(cont.) 22410, which are ordinary
 # continuation markers a battle page uses exactly as a map event does, and
 # reporting them under "battle-only" misrepresents what the page is doing.
-BATTLE_ONLY_CODES = [13110, 13120, 13130, 13150, 13210, 13260, 13310, 13410,
+BATTLE_ONLY_CODES = [1005, 1006, 1007,
+                     13110, 13120, 13130, 13150, 13210, 13260, 13310, 13410,
                      23310, 23311].to_set
 
 def report_troops(dir)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1406,13 +1406,44 @@ end
 FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           :sp_change_val, :sp_change_max,
                           :hold_turn, :auto_release_prob)
+# An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
+# table, EXP curve and battle-command list, exposed the way a real LCF row is.
+class JobRow
+  attr_reader :name, :skills, :battle_commands,
+              :exp_basic, :exp_increase, :exp_correction
+  def initialize(name, curve, learns = [], battle_commands = nil,
+                 exp_basic: 30, exp_increase: 30, exp_correction: 0)
+    @name = name
+    @curve = curve
+    @skills = FakeLearnTable.new(learns)
+    @battle_commands = battle_commands
+    @exp_basic = exp_basic
+    @exp_increase = exp_increase
+    @exp_correction = exp_correction
+  end
+
+  def int16_values(idx); idx == 31 ? @curve : nil; end
+end
+
+# An actor row that starts out in a class (RPG2003 field 57) and carries its own
+# battle-command list (field 80).
+class ClassedRow < SkillRow
+  attr_reader :class_id, :battle_commands
+  def initialize(name, cs, ci, level, curve, learns, class_id, battle_commands = nil)
+    super(name, cs, ci, level, curve, learns)
+    @class_id = class_id
+    @battle_commands = battle_commands
+  end
+end
+
 class FakeActorDB
-  attr_reader :player, :system, :item, :skill
-  def initialize(players, party_ids, items = {}, skills = {})
+  attr_reader :player, :system, :item, :skill, :job
+  def initialize(players, party_ids, items = {}, skills = {}, jobs = {})
     @player = players
     @system = FakeActorSystem.new(party_ids)
     @item = items
     @skill = skills
+    @job = jobs
   end
 end
 
@@ -1608,6 +1639,182 @@ check 'Actor learns skills from the growth table up to its level' do
   # restoring a saved set replaces it.
   a.skills = [1, 2, 2, 0]
   eq [1, 2], a.skills.sort
+end
+
+# -- RPG2003 class (Change Class 1008 / Change Battle Commands 1009) ----------
+
+# A party of one whose actor row and class rows are all set up for the class
+# checks: the actor is a level-3 "Fighter" curve, class 1 is twice as strong and
+# class 2 half as strong, and each class teaches its own skill.
+def class_db(class_id = 0, actor_learns = [[10, 1]])
+  actor_curve = [] # levels 1..3, six stats each
+  3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
+  job1 = [] # class 1: double the actor's HP curve, distinct battle stats
+  3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
+  job2 = []
+  3.times { |i| job2.concat([50 + i * 10, 10, 5 + i, 4, 3, 2]) }
+  players = {
+    1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, actor_learns, class_id,
+                        [1, 2, 0, -1, -1, -1, -1]),
+  }
+  jobs = {
+    1 => JobRow.new('Warrior', job1, [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
+    2 => JobRow.new('Mage', job2, [[31, 1]]),
+  }
+  FakeActorDB.new(players, [1], {}, {}, jobs)
+end
+
+def class_state(class_id = 0, actor_learns = [[10, 1]])
+  Game::State.new(Game::Party.new(class_db(class_id, actor_learns)), 1, 0, 0)
+end
+
+check 'an actor with a startup class reads its curve, learn table and EXP from it' do
+  a = class_state(1).party.actor_by_id(1)
+  eq 1, a.class_id
+  eq 220, a.max_hp, "class 1's level-3 max HP, not the actor row's 120"
+  eq [21, 22], a.skills.sort, "the class's learn table, not the actor's skill 10"
+  # A database with no class table (every RPG2000 game) leaves the actor
+  # class-less, so nothing changes for 2000 data.
+  b = party_state.party.actor_by_id(1)
+  eq 0, b.class_id
+end
+
+check 'Change Class swaps the growth curve and resets EXP' do
+  st = class_state
+  a = st.party.actor_by_id(1)
+  eq 0, a.class_id
+  eq 120, a.max_hp
+  it = Game::Interpreter.new(st)
+  # scope 1 (fixed actor 1), class 2, keep level, skills add, params reset-level.
+  it.start([FakeCmd.new(IC::CHANGE_CLASS,
+                        [1, 1, 2, 0, Game::Actor::CLASS_SKILL_ADD,
+                         Game::Actor::CLASS_PARAM_RESET_LEVEL, 0])])
+  it.update
+  eq 2, a.class_id
+  eq 3, a.level, 'the level is kept when the "level 1" flag is off'
+  eq 70, a.max_hp, "class 2's level-3 max HP"
+  eq a.exp_for_level(3), a.exp, 'RPG_RT resets EXP to the level threshold'
+  ok a.skills.include?(31), "the new class's skill was added"
+  ok a.skills.include?(10), 'and the actor kept what it already knew'
+end
+
+check 'Change Class parameter modes carry, halve or reset the base stats' do
+  keep = class_state.party.actor_by_id(1)
+  before = keep.max_hp
+  keep.change_class(1, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                    Game::Actor::CLASS_PARAM_NO_CHANGE)
+  eq before, keep.max_hp, 'no-change carries the pre-swap stats across'
+
+  half = class_state.party.actor_by_id(1)
+  half.change_class(1, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                    Game::Actor::CLASS_PARAM_HALF)
+  eq before / 2, half.max_hp, 'halve applies to the pre-swap stats'
+
+  lv1 = class_state.party.actor_by_id(1)
+  lv1.change_class(1, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                   Game::Actor::CLASS_PARAM_RESET_LV1)
+  eq 200, lv1.max_hp, "reset-to-level-1 takes the new class's first row"
+  eq 3, lv1.level, 'while the level itself still moves'
+end
+
+check 'Change Class skill modes keep, replace or add to the known skills' do
+  keep = class_state.party.actor_by_id(1)
+  keep.change_class(1, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                    Game::Actor::CLASS_PARAM_NO_CHANGE)
+  eq [10], keep.skills, 'no-change leaves the skill set exactly as it was'
+
+  reset = class_state.party.actor_by_id(1)
+  reset.change_class(1, 3, Game::Actor::CLASS_SKILL_RESET,
+                     Game::Actor::CLASS_PARAM_NO_CHANGE)
+  eq [21, 22], reset.skills.sort, "reset forgets everything but the class's"
+
+  add = class_state.party.actor_by_id(1)
+  add.change_class(1, 3, Game::Actor::CLASS_SKILL_ADD,
+                   Game::Actor::CLASS_PARAM_NO_CHANGE)
+  eq [10, 21, 22], add.skills.sort, 'add keeps both sets'
+end
+
+check 'Change Class to level 1 rewinds the level; an unknown class is a no-op' do
+  a = class_state.party.actor_by_id(1)
+  a.change_class(1, 1, Game::Actor::CLASS_SKILL_RESET,
+                 Game::Actor::CLASS_PARAM_RESET_LEVEL)
+  eq 1, a.level
+  eq 200, a.max_hp
+  eq [21], a.skills, 'only the level-1 class skill is learnt'
+
+  b = class_state(1).party.actor_by_id(1)
+  eq false, b.change_class(99, 3, 0, 0), 'an undefined class changes nothing'
+  eq 1, b.class_id
+  eq 220, b.max_hp, 'and leaves the stats it had'
+end
+
+check 'Change Class shows one level-up line when it taught skills' do
+  st = class_state
+  it = Game::Interpreter.new(st)
+  # class 1, keep level 3, skills reset, params reset-level, show message on.
+  it.start([FakeCmd.new(IC::CHANGE_CLASS,
+                        [1, 1, 1, 0, Game::Actor::CLASS_SKILL_RESET,
+                         Game::Actor::CLASS_PARAM_RESET_LEVEL, 1])])
+  it.update
+  eq :message, it.wait_kind
+  eq ['Hero is now level 3!'], it.message_lines
+  it.resume
+  it.update
+  ok !it.waiting?, 'a class change announces one line, not one per level'
+end
+
+check 'Change Class stays quiet when the level held and no skills moved' do
+  st = class_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_CLASS,
+                        [1, 1, 1, 0, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                         Game::Actor::CLASS_PARAM_NO_CHANGE, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'nothing to announce'
+  eq true, st.switches[1]
+end
+
+check 'Change Battle Commands adds, removes and clears the command list' do
+  st = class_state
+  a = st.party.actor_by_id(1)
+  eq [1, 2, 0, -1, -1, -1, -1], a.battle_commands, 'straight from the database'
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_BATTLE_COMMANDS, [1, 1, 5, 1])]) # add cmd 5
+  it.update
+  eq [1, 2, 5, 0], a.battle_commands, 'the new command lands before Row'
+  a.change_battle_commands(true, 5)
+  eq [1, 2, 5, 0], a.battle_commands, 'adding a command it already has is a no-op'
+  a.change_battle_commands(false, 2)
+  eq [1, 5, 0], a.battle_commands, 'removing drops just that entry'
+  a.change_battle_commands(false, 0)
+  eq [0], a.battle_commands, 'removing command 0 clears back to Row alone'
+end
+
+check 'Change Battle Commands stops at six commands plus Row' do
+  a = class_state.party.actor_by_id(1)
+  (3..8).each { |id| a.change_battle_commands(true, id) }
+  eq [1, 2, 3, 4, 5, 6, 0], a.battle_commands, 'the seventh add is dropped'
+end
+
+check 'a class change takes the class battle commands' do
+  a = class_state.party.actor_by_id(1)
+  a.change_class(1, 3, 0, 0)
+  eq [3, 0, -1, -1, -1, -1, -1], a.battle_commands
+end
+
+check 'a class change and its battle commands survive Save / Continue' do
+  st = class_state
+  st.party.actor_by_id(1).change_class(1, 3, Game::Actor::CLASS_SKILL_RESET,
+                                       Game::Actor::CLASS_PARAM_RESET_LEVEL)
+  st.party.actor_by_id(1).change_battle_commands(true, 7)
+  saved = st.to_h
+
+  restored = Game::State.load(class_db, saved)
+  a = restored.party.actor_by_id(1)
+  eq 1, a.class_id
+  eq 220, a.max_hp, "the class's curve, not the actor row's"
+  eq [3, 7, 0], a.battle_commands
 end
 
 check 'Change HP command damages a fixed actor' do
@@ -5509,13 +5716,139 @@ check 'battle-only commands are no-ops outside a battle' do
     FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 30, 1]),
     FakeCmd.new(IC::SHOW_HIDDEN_MONSTER, [1]),
     FakeCmd.new(IC::CHANGE_BATTLE_BG, [], string: 'Cave'),
+    FakeCmd.new(IC::FORCE_FLEE, [1, 0, 1]),
+    FakeCmd.new(IC::ENABLE_COMBO, [1, 4, 3]),
     FakeCmd.new(IC::TERMINATE_BATTLE, []),
     FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0]),
   ])
   it.update
   eq [], it.take_revealed_monsters
+  eq [], it.take_fled_monsters
   eq nil, it.take_battle_background
   ok st.switches[2], 'the list still runs to the end'
+end
+
+# -- RPG2003 battle-page commands (Force Flee / Enable Combo / Call Common) ----
+
+check 'RPG2003 event opcodes match the LCF Code enum' do
+  eq 1005, IC::CALL_COMMON_EVENT
+  eq 1006, IC::FORCE_FLEE
+  eq 1007, IC::ENABLE_COMBO
+  eq 1008, IC::CHANGE_CLASS
+  eq 1009, IC::CHANGE_BATTLE_COMMANDS
+  eq 5001, IC::OPEN_LOAD_MENU
+  eq 5002, IC::EXIT_GAME
+  eq 5004, IC::TOGGLE_FULLSCREEN
+  eq 5005, IC::OPEN_VIDEO_OPTIONS
+end
+
+check 'Force Flee target 0 grants the party a guaranteed escape' do
+  b = escape_battle(5, 20)                 # 0% by agility: never flees on its own
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::FORCE_FLEE, [0, 0, 0])])
+  it.update
+  ok b.force_flee?, 'the escape is granted...'
+  ok !b.escaped?, '...but not taken until the party chooses Flee'
+  ok b.attempt_escape, 'and then it always succeeds'
+  eq :escaped, b.result
+  eq [], it.take_fled_monsters, 'no troop member left'
+end
+
+check 'Force Flee target 2 takes one troop member out of the fight' do
+  hero = combatant('Hero', 10, 0, 10, 100)
+  foes = [combatant('Slime', 5, 0, 5, 30), combatant('Bat', 5, 0, 5, 30)]
+  b = Game::Battle.new([hero], foes, Game::Rng.new(1))
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::FORCE_FLEE, [2, 1, 0])])
+  it.update
+  eq [1], it.take_fled_monsters
+  ok b.enemy(1).hidden, 'the member is hidden, not killed'
+  ok b.enemy(1).hp > 0
+  ok !b.finished?, 'the other member keeps the fight going'
+  eq [], it.take_fled_monsters, 'the queue drains'
+end
+
+check 'Force Flee target 1 empties the troop and ends the fight' do
+  hero = combatant('Hero', 10, 0, 10, 100)
+  foes = [combatant('Slime', 5, 0, 5, 30), combatant('Bat', 5, 0, 5, 0)]
+  b = Game::Battle.new([hero], foes, Game::Rng.new(1))
+  it = Game::Interpreter.new(new_state)
+  it.battle = b
+  it.start([FakeCmd.new(IC::FORCE_FLEE, [1, 0, 0])])
+  it.update
+  eq [0], it.take_fled_monsters, 'only the member still standing ran'
+  ok b.finished?, 'nobody is left to fight'
+  ok b.enemy(0).hp > 0, 'the runaway was not killed to end it'
+  b.end_round # the scene settles the outcome at the end of the turn
+  eq :victory, b.result
+end
+
+check 'Enable Combo arms a battle combo on a party actor' do
+  st = class_state
+  it = Game::Interpreter.new(st)
+  it.battle = battle_with
+  it.start([FakeCmd.new(IC::ENABLE_COMBO, [1, 4, 3]),
+            FakeCmd.new(IC::ENABLE_COMBO, [99, 1, 2])]) # not in the party
+  it.update
+  eq({ command_id: 4, multiple: 3 }, st.party.actor_by_id(1).battle_combo)
+end
+
+check 'Call Common Event runs the common event and returns to the page' do
+  st = new_state
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: { 4 => called })
+  it.start([FakeCmd.new(IC::CALL_COMMON_EVENT, [4]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq true, st.switches[9], 'the common event ran'
+  eq true, st.switches[1], 'and control came back'
+end
+
+check 'Call Common Event with no resolver or an unknown id is a safe no-op' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CALL_COMMON_EVENT, [4]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq true, st.switches[1]
+
+  st2 = new_state
+  it2 = Game::Interpreter.new(st2)
+  it2.resolver = FakeResolver.new(common: {})
+  it2.start([FakeCmd.new(IC::CALL_COMMON_EVENT, [4]),
+             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it2.update
+  eq true, st2.switches[1]
+end
+
+# -- RPG2003 English-release (2k3e) system commands ---------------------------
+
+check 'Open Load Menu and Exit Game raise their scene requests' do
+  it = Game::Interpreter.new(new_state)
+  it.start([FakeCmd.new(IC::OPEN_LOAD_MENU, [])])
+  it.update
+  ok it.waiting?
+  eq :load_menu, it.wait_kind
+
+  it2 = Game::Interpreter.new(new_state)
+  it2.start([FakeCmd.new(IC::EXIT_GAME, [])])
+  it2.update
+  ok it2.waiting?
+  eq :exit_game, it2.wait_kind
+end
+
+check 'Toggle Fullscreen / Open Video Options run on without pausing' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::TOGGLE_FULLSCREEN, []),
+            FakeCmd.new(IC::OPEN_VIDEO_OPTIONS, []),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'neither command blocks the event'
+  eq true, st.switches[1]
 end
 
 check 'Show Battle Animation (battle form) waits like the map form' do


### PR DESCRIPTION
This PR adds support for RPG Maker 2003's exclusive event commands and class system, which were previously unimplemented despite being present in 2003 game data.

## Summary
RPG2003 introduced several new features that RPG2000 never had, emitted as low opcodes (100x and 500x ranges) that the interpreter's opcode table previously ignored. This change implements the full class system and related event commands, allowing 2003 games to properly handle actor class changes, battle command customization, and battle-page-specific commands.

## Key Changes

**Class System (Database & Actor)**
- Added `JobRow` class to represent RPG2003 database classes (職業, chunk 30) with their own growth curves, skill learn tables, and EXP curves
- Added `ClassedRow` class for actors that start in a class
- Extended `FakeActorDB` to include a `job` table for test fixtures
- Added `class_id` attribute to `Game::Actor` with lazy initialization from the database
- Implemented `curve_row` method that returns the class row when an actor has a class, otherwise the actor row — this mirrors how EasyRPG's `GetBaseMaxHp`, `LearnLevelSkills`, and `CalculateExp` all branch on `class_id > 0`

**Change Class Command (1008)**
- Implemented `Game::Actor#change_class` following RPG_RT's order of operations: unequip all items, capture old stats, swap the class, reset EXP to the new level's threshold, apply parameter mode (keep/halve/reset to level-1 or current level), and apply skill mode (keep/reset/add)
- Current HP/SP survive the change, re-clamped to new maxima
- Returns false for undefined classes, leaving the actor unchanged
- Integrated with the interpreter's `do_change_class` command handler with proper level-up messaging

**Change Battle Commands (1009)**
- Implemented `Game::Actor#change_battle_commands` to add/remove battle commands with RPG_RT's capacity rule: six commands plus the trailing Row entry (command 0)
- Removing command 0 clears the list back to Row alone
- Added `battle_commands` property that lazily reads from the database until explicitly changed
- Class changes automatically update the battle command list from the new class

**Battle-Page Commands**
- **Force Flee (1006)**: Target 0 grants the party a guaranteed escape (player still chooses Flee); target 1 makes all standing troop members flee; target 2 hides a single member. Fled enemies are tracked and their sprites removed from the scene.
- **Enable Combo (1007)**: Arms a battle command to repeat multiple times on an actor
- **Call Common Event (1005)**: Executes a common event from within a battle page and returns

**System Commands (RPG2003 English Release)**
- **Open Load Menu (5001)**: Hands control to the loader to restore a save
- **Exit Game (5002)**: Quits the game
- **Toggle Fullscreen (5004)** and **Open Video Options (5005)**: Run without blocking

**Save/Continue Support**
- Class changes and battle command customizations persist across Save/Continue via the actor metadata system
- Class is restored before EXP to ensure EXP is read against the correct growth curve

## Implementation Details

- The class row's growth curve, learn table, and EXP curve take precedence over the actor row when `class_id > 0`, but attribute/state ranks remain on the actor row (matching RPG_RT behavior)
- RPG2000 databases have no class table, so actors remain class-less (class_id = 0) and use their own curves
- Battle command lists are materialized lazily from the database and only stored when explicitly changed
- The interpreter now properly routes RPG2003-only opcodes that were previously ignored
- Test fixtures include comprehensive checks for all class system modes and edge cases

https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit