### PR TITLE
Run the XP screen effects: transitions, flash and shake

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@
   windowskin's blinking **pause arrow** while they hold text, as the genuine
   runtime does. `STEPS_SPEC` lets the wine comparison drive a game's opening
   cutscene instead of only walking around its start map
+- The **screen effects** run too: Prepare / Execute **Transition** (221/222)
+  holds the screen on a snapshot so a teleport or map change happens behind it,
+  then dissolves the still away — spread over real frames rather than blocking
+  in `Graphics.transition`, so the browser build's frame callback keeps its
+  budget — and **Screen Flash** / **Screen Shake** (224/225) carry RMXP's own
+  maths (an alpha that reaches zero exactly on the duration, a shake that
+  reverses past twice its power and settles back on centre) into the map
+  viewport's colour overlay and scroll origin
 
 ### RPG Maker VX / VX Ace
 

--- a/changelog.d/rpgxp-screen-effects.added.md
+++ b/changelog.d/rpgxp-screen-effects.added.md
@@ -1,0 +1,20 @@
+- RPG Maker **XP** events can now run the remaining screen effects: **Prepare
+  for Transition** (221) and **Execute Transition** (222), **Screen Flash**
+  (224) and **Screen Shake** (225).
+  - 221 holds the screen on a snapshot above everything, so the teleport, tint
+    or map change that follows happens behind it unseen; 222 dissolves that
+    still away over twenty frames. RMXP reaches the same ordering by *blocking*
+    in `Graphics.transition(20)` — its scene simply is not updated meanwhile —
+    but a twenty-frame loop inside one frame callback is what the browser build
+    cannot afford, so the interpreter suspends and the scene fades the still one
+    frame per update instead. Only the foreground interpreter freezes: a
+    background process is never suspended on a UI request, so its transition
+    would never dissolve and the screen would stay stuck on a snapshot.
+  - 224 and 225 go through a `Game::Screen` that carries RMXP's own maths — the
+    flash's alpha scaled by `(d - 1) / d` so it reaches zero exactly as its
+    duration runs out, and the shake's spring, which reverses past twice its
+    power and snaps back to centre on the last frame rather than being left off
+    to one side. The scene hands the results to the viewport that holds the map,
+    as its colour overlay and its scroll origin — where `Spriteset_Map` puts
+    them.
+  - Between them 871 uses in Pray for You.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -855,11 +855,12 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   unplayable, its `Audio/BGM` mixing `.MID` with `.mid` where the search only
   tried lower case. The **picture commands** (231–235, 471 uses) and the message
   **pause arrow** followed, with a `STEPS_SPEC` override on the comparison so a
-  game's opening cutscene can be driven rather than only its start map. What a
-  real XP game uses that we still skip: `221`/`222` (prepare/execute
-  transition), `224`/`225` (screen flash/shake), `203` (scroll map), `207` (show
-  animation) and `355` (script) — 221/222 want a look at `Graphics.transition`
-  first, since it blocks and drives its own frames.
+  game's opening cutscene can be driven rather than only its start map. The screen effects
+  followed — Prepare / Execute Transition (221/222) and Screen Flash / Shake
+  (224/225), 871 uses — with 222 suspending the interpreter and the scene fading
+  the frozen still per frame rather than calling the blocking
+  `Graphics.transition`. What a real XP game uses that we still skip: `203`
+  (scroll map), `207` (show animation) and `355` (script).
 - Reference for the RGSS game library:
   https://www.rpgmaker.fixato.org/Manual/RPGVXAce/rgss/
 

--- a/docs/adr/0027-rpgxp-released-game-parity.md
+++ b/docs/adr/0027-rpgxp-released-game-parity.md
@@ -8,7 +8,8 @@ Accepted — the data, script-host and boot checks run green on both the
 OpenGame.exe test bed and the packed *Pray for You* release; the wine comparison
 stays a manual/dev script, as in ADR 0021 / 0025.
 
-**Amended 2026-08-05: the picture layer and the message pause arrow landed**, and
+**Amended 2026-08-05: the picture layer, the message pause arrow and the screen
+effects (transitions, flash, shake) landed**, and
 `scripts/compare-rpgxp-wine.bash` grew a `STEPS_SPEC` override so a game's
 opening cutscene can be driven instead of only its start map. See the follow-ups
 below for what that closed and what it did not.
@@ -148,11 +149,20 @@ screen). The rest is the windowskin background's shading.
   the same layering `Spriteset_Map` gets from `@viewport2`. RGSS's `ox`/`oy` are
   not wired to where a sprite draws here, so a centred origin is folded into the
   position instead, scaled by the zoom.
-- Still no handler: `221`/`222` (prepare/execute transition, 419 uses each),
-  `224`/`225` (screen flash/shake), `203` (scroll map), `207` (show animation)
-  and `355` (script). 221/222 want a look at `Graphics.transition` first: it
-  blocks and drives its own frames, which does not obviously compose with being
-  called from inside the scene's update.
+- **The screen effects are done too**: Prepare / Execute Transition (221/222)
+  and Screen Flash / Shake (224/225), 871 uses between them. The transition
+  question — `Graphics.transition` blocks and drives its own frames, which does
+  not compose with being called from inside the scene's update — resolved by not
+  calling it: the interpreter suspends on 222 the way it does on a Wait, and the
+  scene fades the frozen still one frame per update. That is the same ordering
+  RMXP gets from blocking (its scene is not updated during the twenty frames
+  either) without a twenty-frame loop inside one frame callback. Only the
+  foreground interpreter freezes the screen: a background process is never
+  suspended on a UI request, so its 222 would never dissolve the still and the
+  screen would stay stuck on a snapshot for good.
+- Still no handler: `203` (scroll map), `207` (show animation) and `355`
+  (script). 207 needs the animation system; 355 needs a decision about what a
+  game's inline Ruby should be evaluated against.
 - **Driving the reference past the opening needs 32-bit GStreamer.** Pray for
   You's opening plays MP3 BGM, and `RGSS103J.dll` decodes it through
   winegstreamer; without `gstreamer1.0-plugins-base:i386` (and friends) in the

--- a/mruby-rpgxp/mrblib/game.rb
+++ b/mruby-rpgxp/mrblib/game.rb
@@ -438,6 +438,77 @@ class RPGXP
       end
     end
 
+    # The screen-wide effects of RMXP's `Game_Screen` that are not the tone:
+    # Screen Flash (224) and Screen Shake (225). Pure data plus RMXP's own
+    # per-frame maths, so the scene only has to hand the results to a viewport
+    # (`color` for the flash, `ox` for the shake).
+    class Screen
+      # Flash colour as [red, green, blue, alpha]; alpha decays to zero over the
+      # flash's duration. Shake is a signed pixel offset.
+      attr_reader :flash_color, :shake
+
+      def initialize
+        @flash_color = [0.0, 0.0, 0.0, 0.0]
+        @flash_duration = 0
+        @shake = 0.0
+        @shake_power = 0
+        @shake_speed = 0
+        @shake_duration = 0
+        @shake_direction = 1
+      end
+
+      def flashing?; @flash_duration >= 1 || @flash_color[3] > 0; end
+      def shaking?;  @shake_duration >= 1 || @shake != 0; end
+
+      # Screen Flash (224): `color` is [r, g, b, a], `duration` in frames.
+      def start_flash(color, duration)
+        @flash_color = [color[0], color[1], color[2], color[3]]
+        @flash_duration = duration.to_i
+        return if @flash_duration >= 1
+        @flash_color[3] = 0.0
+      end
+
+      # Screen Shake (225): power and speed 1..9, duration in frames.
+      def start_shake(power, speed, duration)
+        @shake_power = power.to_i
+        @shake_speed = speed.to_i
+        @shake_duration = duration.to_i
+      end
+
+      def update
+        step_flash
+        step_shake
+      end
+
+      private
+
+      # RMXP fades the flash by scaling its alpha by (d - 1) / d each frame, so
+      # it reaches zero exactly as the duration runs out.
+      def step_flash
+        return if @flash_duration < 1
+        d = @flash_duration
+        @flash_color[3] = @flash_color[3] * (d - 1) / d
+        @flash_duration = d - 1
+      end
+
+      # RMXP's shake is a spring: the offset moves by power*speed/10 a frame and
+      # reverses whenever it passes twice the power, and on the last frame it
+      # snaps to zero rather than being left off-centre (the `@shake * (@shake +
+      # delta) < 0` test — the step that would cross the middle).
+      def step_shake
+        return if @shake_duration < 1 && @shake == 0
+        delta = (@shake_power * @shake_speed * @shake_direction) / 10.0
+        if @shake_duration <= 1 && @shake * (@shake + delta) < 0
+          @shake = 0.0
+        else
+          @shake += delta
+        end
+        @shake_direction = -1 if @shake > @shake_power * 2
+        @shake_direction = 1 if @shake < -@shake_power * 2
+        @shake_duration -= 1 if @shake_duration >= 1
+      end
+    end
+
     # One slot of RMXP's `$game_screen.pictures`: what Show Picture (231) put on
     # screen, and where a Move Picture (232) / Rotate Picture (233) / Change
     # Picture Tone (234) is taking it. Pure data plus the per-frame easing, the

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -100,7 +100,11 @@ class RPGXP
       TRANSPARENT     = 208
       MOVE_ROUTE      = 209
       WAIT_FOR_MOVE   = 210
+      PREPARE_TRANSITION = 221
+      EXECUTE_TRANSITION = 222
       TINT_SCREEN     = 223
+      FLASH_SCREEN    = 224
+      SHAKE_SCREEN    = 225
       SHOW_PICTURE    = 231
       MOVE_PICTURE    = 232
       ROTATE_PICTURE  = 233
@@ -160,7 +164,9 @@ class RPGXP
         @tint_requests = []
         @location_requests = []
         @picture_requests = []
+        @screen_requests = []
         @erase_requested = false
+        @freeze_requested = false
         @running = true
         reset_waits
         self
@@ -174,6 +180,8 @@ class RPGXP
         @tint_requests = []
         @location_requests = []
         @picture_requests = []
+        @screen_requests = []
+        @freeze_requested = false
         @running = false
         reset_waits
       end
@@ -209,6 +217,14 @@ class RPGXP
         reqs
       end
 
+      # Drain the Screen Flash (224) / Screen Shake (225) requests queued since
+      # the last call. Each is a hash with an `:op` of :flash or :shake.
+      def take_screen_requests
+        reqs = @screen_requests || []
+        @screen_requests = []
+        reqs
+      end
+
       # Drain the Set Event Location (202) requests queued since the last call.
       def take_location_requests
         reqs = @location_requests || []
@@ -224,6 +240,17 @@ class RPGXP
         @picture_requests = []
         reqs
       end
+
+      # True (once) if a Prepare for Transition ran since the last call.
+      def take_freeze_request
+        v = @freeze_requested
+        @freeze_requested = false
+        v
+      end
+
+      # The transition graphic Execute Transition asked for ("" for a plain
+      # dissolve). Read by the scene when it starts the fade.
+      attr_reader :transition_name
 
       # Advance until the list finishes or a UI request suspends us. Runs at most
       # MAX_STEPS_PER_FRAME commands so a bad loop cannot hang the frame.
@@ -282,7 +309,9 @@ class RPGXP
         @tint_requests = []
         @location_requests = []
         @picture_requests = []
+        @screen_requests = []
         @erase_requested = false
+        @freeze_requested = false
         reset_waits
       end
 
@@ -296,6 +325,7 @@ class RPGXP
         @teleport = nil
         @input_variable = nil
         @input_digits = nil
+        @transition_name = nil
       end
 
       def switches;  @state.switches;  end
@@ -340,7 +370,11 @@ class RPGXP
         when TRANSPARENT     then do_transparent(cmd)
         when MOVE_ROUTE      then do_move_route(cmd)
         when WAIT_FOR_MOVE   then do_wait_for_move(cmd)
+        when PREPARE_TRANSITION then do_prepare_transition(cmd)
+        when EXECUTE_TRANSITION then do_execute_transition(cmd)
         when TINT_SCREEN     then do_tint_screen(cmd)
+        when FLASH_SCREEN    then do_flash_screen(cmd)
+        when SHAKE_SCREEN    then do_shake_screen(cmd)
         when SHOW_PICTURE, MOVE_PICTURE, ROTATE_PICTURE, PICTURE_TONE,
              ERASE_PICTURE then do_picture(cmd)
         when BATTLE_PROCESS  then do_battle_process(cmd)
@@ -950,6 +984,57 @@ class RPGXP
         @wait_kind = :move_completion
         @waiting = true
         @index += 1
+      end
+
+      # Screen Flash (224): [RPG::Color, duration]. Screen Shake (225): [power,
+      # speed, duration]. Neither pauses -- RMXP writes into $game_screen and
+      # Spriteset_Map catches up next frame -- so both are queued for the scene,
+      # which owns the screen viewport they act on.
+      #
+      # The Color is passed through as the object, not unpacked into numbers
+      # here, for the same reason Change Screen Color Tone (223) passes its Tone
+      # through: this file is driven under CRuby over real event lists by
+      # scripts/rpgxp_testbed_check.rb, where the RGSS value types are Marshal
+      # shims with no component readers. The scene -- which only ever runs in the
+      # real build -- reads the channels.
+      def do_flash_screen(cmd)
+        color = param(cmd, 0)
+        @index += 1
+        return unless color
+        @screen_requests << { op: :flash, duration: param(cmd, 1, 0).to_i,
+                              color: color }
+      end
+
+      def do_shake_screen(cmd)
+        @index += 1
+        @screen_requests << { op: :shake, power: param(cmd, 0, 0).to_i,
+                              speed: param(cmd, 1, 0).to_i,
+                              duration: param(cmd, 2, 0).to_i }
+      end
+
+      # Prepare for Transition (221): freeze the screen as it is now. RMXP's
+      # `command_221` is a bare `Graphics.freeze`; a game pairs it with a
+      # teleport, a tint or a map change and then dissolves the still away with
+      # 222, so the change itself is never seen. Does not pause.
+      def do_prepare_transition(_cmd)
+        @index += 1
+        @freeze_requested = true
+      end
+
+      # Execute Transition (222): [transition graphic name]. Dissolve the frozen
+      # still away. RMXP hands this to Scene_Map, which calls the *blocking*
+      # `Graphics.transition(20)` — so the interpreter does not advance for those
+      # 20 frames. Ours suspends instead and lets the scene fade the still one
+      # frame per update: same ordering, without a 20-frame loop inside a single
+      # frame callback (which is what the browser build could not afford, see
+      # docs/adr/0023-rpgxp-script-host-frame-driver.md).
+      TRANSITION_FRAMES = 20
+
+      def do_execute_transition(cmd)
+        @index += 1
+        @transition_name = param(cmd, 0, "")
+        @wait_kind = :transition
+        @waiting = true
       end
 
       # Change Screen Color Tone (223): [RPG::Tone, duration in frames]. Like

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -518,6 +518,10 @@ class RPGXP
         # not).
         @pictures = {}
         @picture_sprites = {}
+        # RMXP's $game_screen flash / shake, applied to the screen viewport that
+        # holds the map (see setup_sprites) -- the flash as its colour overlay,
+        # the shake as its scroll origin, exactly where Spriteset_Map puts them.
+        @screen = Game::Screen.new
 
         @resolver = EventResolver.new(@db.common_events)
         @interpreter = Game::Interpreter.new(@state)
@@ -554,6 +558,7 @@ class RPGXP
         close_message
         close_number_input
         @event_sprites.each_value { |s| s[:sprite].dispose } if @event_sprites
+        dispose_frozen
         @picture_sprites.each_value { |e| e[:sprite].dispose } if @picture_sprites
         [@tilemap, @player_sprite, @screen_viewport,
          @picture_viewport].each { |s| s.dispose if s }
@@ -579,6 +584,7 @@ class RPGXP
         end
         animate_player
         step_tone_change
+        step_screen_effects
         update_pictures
         render
       end
@@ -804,6 +810,110 @@ class RPGXP
         $stderr.puts "[RGSS] Set Move Route apply failed: #{e.message}"
       end
 
+      # Apply the Screen Flash (224) / Screen Shake (225) requests an interpreter
+      # queued this frame.
+      def apply_screen_requests(interp)
+        reqs = interp.take_screen_requests
+        return if reqs.nil? || reqs.empty?
+        reqs.each do |r|
+          if r[:op] == :flash
+            @screen.start_flash(color_values(r[:color]), r[:duration])
+          else
+            @screen.start_shake(r[:power], r[:speed], r[:duration])
+          end
+        end
+      rescue StandardError => e
+        $stderr.puts "[RGSS] screen effect failed: #{e.message}"
+      end
+
+      # One frame of the flash decay and the shake spring, handed to the screen
+      # viewport. Only written when something is actually running, and only when
+      # the value changed: each write re-composites the viewport natively.
+      def step_screen_effects
+        return unless @screen && @screen_viewport
+        return unless @screen.flashing? || @screen.shaking? || @screen_dirty
+        @screen.update
+        c = @screen.flash_color
+        if @flash_shown != c[3]
+          @flash_shown = c[3]
+          @screen_viewport.color = Color.new(c[0], c[1], c[2], c[3])
+        end
+        shake = @screen.shake.to_i
+        if @shake_shown != shake
+          @shake_shown = shake
+          @screen_viewport.ox = shake
+        end
+        @screen_viewport.update
+        # Keep stepping for one more frame after everything stopped, so the last
+        # write (back to no tint, no offset) actually lands.
+        @screen_dirty = @screen.flashing? || @screen.shaking?
+      rescue StandardError => e
+        $stderr.puts "[RGSS] screen effect step failed: #{e.message}"
+        @screen_dirty = false
+      end
+
+      # Only the foreground interpreter freezes the screen. A background (parallel)
+      # process is never suspended on a UI request -- step_parallel resumes those
+      # at once so the loop keeps running -- so its Execute Transition would
+      # never dissolve the still, leaving the screen stuck on a snapshot for
+      # good. Its 221 is simply not applied.
+      #
+      # Prepare for Transition (221): hold the screen exactly as it is now, on a
+      # sprite above everything, so the teleport / tint / map change that follows
+      # happens behind it unseen. RGSS's own Graphics.freeze snapshot, kept as
+      # scene state instead of inside Graphics because the dissolve below has to
+      # run one frame per update rather than in a blocking loop.
+      def apply_freeze_request(interp)
+        return unless interp.take_freeze_request
+        dispose_frozen
+        bmp = RGSS::Graphics.snap_to_bitmap
+        unless bmp
+          # A backend that cannot snapshot says so itself, once; the transition
+          # then degrades to a plain wait, which is what Graphics.transition does.
+          return
+        end
+        @frozen = { bitmap: bmp, sprite: Sprite.new }
+        @frozen[:sprite].bitmap = bmp
+        @frozen[:sprite].z = RGSS::Graphics::TRANSITION_Z
+      rescue StandardError => e
+        $stderr.puts "[RGSS] Prepare for Transition failed: #{e.message}"
+        @frozen = nil
+      end
+
+      # Execute Transition (222): dissolve the frozen still away over
+      # Interpreter::TRANSITION_FRAMES frames, resuming the interpreter when it
+      # is gone. RMXP reaches the same ordering by *blocking* in
+      # Graphics.transition(20) — the scene simply is not updated during it — but
+      # a 20-frame loop inside one frame callback is what the browser build
+      # cannot afford, so the wait is spread over real frames instead.
+      def drive_transition
+        unless @frozen
+          @interpreter.resume # nothing frozen: 222 without a 221, or no snapshot
+          return
+        end
+        total = Game::Interpreter::TRANSITION_FRAMES
+        @transition_step = (@transition_step || 0) + 1
+        if @transition_step >= total
+          dispose_frozen
+          @transition_step = nil
+          @interpreter.resume
+          return
+        end
+        @frozen[:sprite].opacity = 255 - (255 * @transition_step / total)
+      rescue StandardError => e
+        $stderr.puts "[RGSS] Execute Transition failed: #{e.message}"
+        dispose_frozen
+        @transition_step = nil
+        @interpreter.resume
+      end
+
+      def dispose_frozen
+        return unless @frozen
+        @frozen[:sprite].dispose
+        @frozen[:bitmap].dispose
+        @frozen = nil
+      end
+
       # Apply the picture (231..235) requests an interpreter queued this frame,
       # against the picture list this scene owns.
       def apply_picture_requests(interp)
@@ -829,6 +939,11 @@ class RPGXP
         when :tone   then pic.start_tone_change(tone_values(r[:tone]), r[:duration])
         when :erase  then pic.erase
         end
+      end
+
+      # An RPG::Color from the data as the four numbers Game::Screen keeps.
+      def color_values(color)
+        [color.red, color.green, color.blue, color.alpha]
       end
 
       # An RPG::Tone from the data as the four numbers Game::Picture keeps.
@@ -1114,6 +1229,7 @@ class RPGXP
           when :wait     then drive_wait
           when :teleport then perform_teleport(@interpreter.teleport)
           when :move_completion then drive_move_completion
+          when :transition then drive_transition
           end
         else
           @interpreter.update
@@ -1121,6 +1237,8 @@ class RPGXP
           apply_tint_requests(@interpreter)
           apply_location_requests(@interpreter)
           apply_picture_requests(@interpreter)
+          apply_freeze_request(@interpreter)
+          apply_screen_requests(@interpreter)
           apply_erase_request(@interpreter, @running_event_id)
           finish_event unless @interpreter.running? || @interpreter.waiting?
         end
@@ -1240,6 +1358,7 @@ class RPGXP
           apply_tint_requests(it)
           apply_location_requests(it)
           apply_picture_requests(it)
+          apply_screen_requests(it)
           apply_erase_request(it, p[:id])
         else
           it.start(p[:list], @state.map_id, p[:id]) # loop the process
@@ -1248,6 +1367,7 @@ class RPGXP
           apply_tint_requests(it)
           apply_location_requests(it)
           apply_picture_requests(it)
+          apply_screen_requests(it)
           apply_erase_request(it, p[:id])
         end
       rescue StandardError

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -814,6 +814,100 @@ assert "Interpreter: set move route resolves the target" do
   assert_true it4.take_move_route_requests.empty?
 end
 
+assert "Game::Screen decays a flash to nothing over its duration" do
+  sc = RPGXP::Game::Screen.new
+  assert_false sc.flashing?
+  sc.start_flash([255, 255, 255, 255], 4)
+  assert_true sc.flashing?
+  4.times { sc.update }
+  assert_equal 0.0, sc.flash_color[3]
+  assert_false sc.flashing?
+  # A zero duration is an immediate clear, not a permanent tint.
+  sc.start_flash([255, 0, 0, 255], 0)
+  assert_equal 0.0, sc.flash_color[3]
+end
+
+assert "Game::Screen shakes and settles back on centre" do
+  sc = RPGXP::Game::Screen.new
+  assert_equal 0.0, sc.shake
+  sc.start_shake(5, 5, 20)
+  sc.update
+  # power * speed / 10 the first frame.
+  assert_equal 2.5, sc.shake
+  # It reverses once it passes twice the power, so it never runs away.
+  40.times { sc.update }
+  assert_true sc.shake.abs <= 5 * 2 + 2.5
+  # And it ends centred rather than stuck off to one side.
+  60.times { sc.update }
+  assert_equal 0.0, sc.shake
+  assert_false sc.shaking?
+end
+
+assert "Interpreter: flash and shake queue without pausing" do
+  s = new_state
+  it = RPGXP::Game::Interpreter.new(s)
+  it.start([
+    cmd(224, [Color.new(255, 255, 255, 200), 10], 0),
+    cmd(225, [6, 7, 30], 0),
+    cmd(121, [5, 5, 0], 0)
+  ], 1, 7)
+  it.update
+  assert_false it.waiting?
+  assert_true s.switches[5]
+  reqs = it.take_screen_requests
+  assert_equal 2, reqs.size
+  assert_equal :flash, reqs[0][:op]
+  # The Color object is passed through untouched (the scene reads its channels).
+  assert_equal 200.0, reqs[0][:color].alpha
+  assert_equal 10, reqs[0][:duration]
+  assert_equal :shake, reqs[1][:op]
+  assert_equal 6, reqs[1][:power]
+  assert_equal 7, reqs[1][:speed]
+  assert_equal 30, reqs[1][:duration]
+  assert_true it.take_screen_requests.empty?
+
+  # A flash with no Color object is dropped rather than raising.
+  it2 = RPGXP::Game::Interpreter.new(s)
+  it2.start([cmd(224, [nil, 10], 0), cmd(121, [6, 6, 0], 0)], 1, 7)
+  it2.update
+  assert_true it2.take_screen_requests.empty?
+  assert_true s.switches[6]
+end
+
+assert "Interpreter: prepare/execute transition freezes then suspends" do
+  s = new_state
+  it = RPGXP::Game::Interpreter.new(s)
+  it.start([
+    cmd(221, [], 0),                # Prepare for Transition (does not pause)
+    cmd(121, [5, 5, 0], 0),         # so this still runs this frame
+    cmd(222, ["Blind"], 0),         # Execute Transition (pauses)
+    cmd(121, [6, 6, 0], 0)          # must NOT run until the fade is over
+  ], 1, 7)
+  it.update
+  assert_true s.switches[5]
+  assert_true it.waiting?
+  assert_equal :transition, it.wait_kind
+  assert_equal "Blind", it.transition_name
+  assert_false s.switches[6]
+  # The scene takes the freeze once, then resumes when the still has faded.
+  assert_true it.take_freeze_request
+  assert_false it.take_freeze_request
+  it.resume
+  assert_false it.waiting?
+  assert_true s.switches[6]
+end
+
+assert "Interpreter: a transition with no graphic name still suspends" do
+  s = new_state
+  it = RPGXP::Game::Interpreter.new(s)
+  it.start([cmd(222, [""], 0)], 1, 7)
+  it.update
+  assert_true it.waiting?
+  assert_equal "", it.transition_name
+  # No 221 ran, so there is nothing for the scene to dissolve.
+  assert_false it.take_freeze_request
+end
+
 assert "Game::Picture eases a move onto its target and stops there" do
   p = RPGXP::Game::Picture.new(1)
   p.show("CG1", 0, 0, 0, 100, 100, 255, 0)


### PR DESCRIPTION
Follow-up to #351, closing out the screen commands ADR 0027's histogram named as unhandled — 871 uses between them in Pray for You.

## Transitions (221 / 222)

**Prepare for Transition** holds the screen on a snapshot above everything, so the teleport, tint or map change that follows happens behind it unseen. **Execute Transition** dissolves that still away over twenty frames.

The open question from #351 was `Graphics.transition`: it blocks and drives its own frames, which does not compose with being called from inside the scene's update. Resolved by not calling it. RMXP gets its ordering by blocking — `Scene_Map` calls `Graphics.transition(20)` and simply is not updated during those frames — so 222 suspends the interpreter the way a Wait does and the scene fades the still one frame per update. Same ordering, no twenty-frame loop inside a single frame callback (the constraint that made the script host need a Fiber driver, ADR 0023).

Only the foreground interpreter freezes the screen: `step_parallel` resumes a background process straight away on any UI request, so a parallel's 222 would never dissolve the still and the screen would stay stuck on a snapshot for good.

## Flash and shake (224 / 225)

A `Game::Screen` carries RMXP's own maths — the flash's alpha scaled by `(d - 1) / d` so it reaches zero exactly as its duration runs out, and the shake's spring, which reverses past twice its power and snaps back to centre on the last frame rather than being left off to one side. The scene hands the results to the viewport that holds the map, as its colour overlay and its scroll origin, where `Spriteset_Map` puts them.

## A regression the CRuby data check caught

Worth recording, since it is the harness earning its keep: unpacking the flash's `RPG::Color` into numbers inside the interpreter broke `scripts/rpgxp_testbed_check.rb` on eight of Pray for You's maps. That harness drives `interpreter.rb` over real event lists under CRuby with Marshal shims for the RGSS value types, and those shims have no component readers. The Color is passed through as the object instead — exactly as Change Screen Color Tone already passes its Tone — and the scene, which only ever runs in the real build, reads the channels.

## Testing

Green: 1735 mruby tests / 0 failures (new unit tests cover the flash decay, the shake's reversal and settle, and the interpreter queueing for all four commands), both XP beds booting to `[RPGXP-MAP]`, the data check (70 maps / 1109 event pages / 15,812 commands), the script-host check and the RGSSAD packed-asset check. The wine comparison is unchanged at ~75,655 differing pixels on the walk steps — expected, since that frame does not exercise these commands.

Still open after this: `203` (scroll map), `207` (show animation) and `355` (script). 207 needs the animation system; 355 needs a decision about what a game's inline Ruby should be evaluated against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C72B3ponBjmrbm3EMYMT1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01C72B3ponBjmrbm3EMYMT1H)_