### PR TITLE
RPG2000/2003 event fidelity: battle-page conditions and Control Variables operands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too
 - A troop's **battle-event pages** run during a fight: their conditions (switch,
-  variable, turn, enemy/actor HP) are re-checked each turn, and a matching page
-  runs the ordinary command set plus the battle-only commands — Change Monster
-  HP / MP / Condition, Show Hidden Monster, Change Battle Background, the battle
-  Show Battle Animation, the battle Conditional Branch and Terminate Battle
+  variable, turn, enemy/actor HP, plus RPG2003's per-battler turn counters and
+  party fatigue) are re-checked each turn, and a matching page runs the ordinary
+  command set plus the battle-only commands — Change Monster HP / MP / Condition,
+  Show Hidden Monster, Change Battle Background, the battle Show Battle
+  Animation, the battle Conditional Branch and Terminate Battle. A page whose
+  condition box is entirely unticked never fires, which is how RPG_RT reads it
 - The **RPG2003-only event commands** run too — the low opcodes the 2003 editor
   emits for the features RPG2000 never had. **Change Class** (1008) moves an
   actor to a database class, re-reading its growth curve, learn table and EXP

--- a/changelog.d/battle-page-no-trigger-never-runs.fixed.md
+++ b/changelog.d/battle-page-no-trigger-never-runs.fixed.md
@@ -1,0 +1,8 @@
+- A troop battle-event page whose condition box is entirely unticked no longer
+  fires every turn. RPG_RT reads "no trigger" as **never**, not as "always"
+  (EasyRPG's `AreConditionsMet` opens with exactly that test), which is the
+  opposite of how every other RPG2000 page kind treats vacuously-satisfied
+  conditions — `Game::BattlePage.active?` had taken the natural reading. Both
+  test beds do carry such pages (446 of Nepheshel's 3265, all 88 of
+  mtf-meido-action's) and every one of them is empty, so no real game changes
+  behaviour; the rule is fixed before a game that puts commands on one is met.

--- a/changelog.d/control-variables-unknown-operand.fixed.md
+++ b/changelog.d/control-variables-unknown-operand.fixed.md
@@ -1,0 +1,6 @@
+- A **Control Variables** operand the runtime does not implement no longer
+  writes a junk value. The fallthrough returned `param5`, which is the operand's
+  own *selector* rather than any value — so RPG2003's battle operand (now
+  implemented) stored the troop member index in the target variable, and a
+  Maniac-patch operand would store an actor id or a switch number. Unknown
+  operands now read 0 and log which operand was asked for.

--- a/changelog.d/rpg2k-control-variables-operands.added.md
+++ b/changelog.d/rpg2k-control-variables-operands.added.md
@@ -1,0 +1,11 @@
+- **Control Variables** reads three more operands. A **character's screen
+  position** (operand 6, selectors 4 / 5) is measured against the live camera —
+  `Scene::Map#camera_position` is extracted out of `render` so the interpreter
+  can ask where the view is looking — with RPG_RT's own asymmetric offsets: X
+  from the tile's centre, Y from its bottom (EasyRPG's `GetScreenX` subtracts
+  half a tile after adding a whole one, `GetScreenY` only adds the whole one).
+  An **equipped item's id** (operand 5, selectors 10..14) reads the weapon,
+  shield, armour, helmet and accessory slots. And RPG2003's **battle operand**
+  (operand 8) reads a troop member's HP / SP / max HP-SP / attack / defence /
+  spirit / agility during a fight. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/changelog.d/rpg2k3-battle-page-conditions.added.md
+++ b/changelog.d/rpg2k3-battle-page-conditions.added.md
@@ -1,0 +1,18 @@
+- RPG Maker 2003: the troop battle-event page conditions that used to fail
+  unchecked now resolve. **Per-battler turn counters** — RPG2003 counts turns per
+  battler as well as per battle, so `Game::Battle::Combatant` carries its own
+  `battle_turn`, bumped as that battler's turn begins (EasyRPG's
+  `Scene_Battle::NextTurn`), and the `turn_enemy` / `turn_actor` conditions read
+  it through the same base/multiple turn arithmetic the battle-wide turn test
+  uses. **Party fatigue** is computed the way `Game_Party::GetFatigue` does —
+  HP two thirds of the weight, SP the other third, so a party at full HP with no
+  SP left still reads 33 and an SP-less party divides by 1 rather than 0 — and
+  the `fatigue` condition tests it against the page's window. Both were
+  previously listed as conditions the runtime could not answer, which meant a
+  page gated on either never fired.
+
+  The `command_actor` (chosen battle command) condition still fails its page
+  deliberately: RPG_RT only answers it for the battler whose action triggered
+  the check, and this runtime evaluates pages once per turn with no acting
+  battler — the same null-`source` case EasyRPG bails on. The reason is now
+  written down where the condition is evaluated.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -239,13 +239,21 @@ The work below is roughly ordered by the critical path to a walkable game
   equipped item's bonuses into the effective stats). **Control
   Variables** reads not just constants and other variables but also a **random**
   range, an **actor stat** (level / EXP / HP / MP / max HP-MP / attack / defence /
-  spirit / agility), an **item** count (number held, or number equipped across the
+  spirit / agility, and the **id of the item in each of the five equipment
+  slots**), an **item** count (number held, or number equipped across the
   party), **game quantities** (party gold, timer seconds, party size, and the
   **save / battle / win / defeat / escape counts** — running tallies bumped by
-  Save and by each Enemy Encounter and its outcome, persisted in the save) and a
-  **character position** (the hero's or a map event's map id / x / y / facing —
-  an event's map id reads 0, matching an RPG_RT 2000 quirk; screen coordinates
-  are not modelled).
+  Save and by each Enemy Encounter and its outcome, persisted in the save), a
+  **character position** (the hero's or a map event's map id / x / y / facing /
+  **screen x / y** — an event's map id reads 0, matching an RPG_RT 2000 quirk;
+  the screen coordinates are measured against the live camera, which
+  `Scene::Map#camera_position` now exposes, with RPG_RT's own asymmetric offsets:
+  X from the tile's centre, Y from its bottom) and, in a fight, a **monster
+  stat** (RPG2003's battle operand — HP / SP / max HP-SP / attack / defence /
+  spirit / agility of a troop member). An operand this build does not know (the
+  Maniac patch adds nine more) now reads **0 and logs**, where it used to return
+  the operand's own *selector* — so a 2003 game's battle operand wrote the troop
+  member index into the variable and looked like a plausible number.
   Conditional Branch covers switch / variable / **timer** / gold / item /
   **vehicle** (is the party aboard the boat / ship / airship) / **orientation**
   (is the hero or a map event facing a given direction) conditions and **all**

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -456,11 +456,22 @@ The work below is roughly ordered by the critical path to a walkable game
   <game>` reports a game's troop pages, and Nepheshel's 2819 conditional pages
   confirm the `switch_a` / `switch_b` / `turn` / `enemy_hp` bits and show that
   every battle-only command it uses has a handler (see the comment on
-  `Game::BattlePage` for what each bit is confirmed by). Still TODO here:
-  the per-battler turn counters and the party-fatigue / chosen-command
-  conditions (pages gated on those deliberately do not fire rather than firing
-  unchecked), and video playback for Play Movie (no decoder is linked in; the
-  request is logged). **Show Battle Animation** (11210) now plays on the map — the
+  `Game::BattlePage` for what each bit is confirmed by). The **RPG2003
+  conditions resolve now too**: each `Combatant` carries its own `battle_turn`,
+  bumped as that battler's turn begins (EasyRPG's `Scene_Battle::NextTurn`), so
+  `turn_enemy` / `turn_actor` read real per-battler counters through the same
+  base/multiple arithmetic; and `fatigue` is `Game_Party::GetFatigue`'s formula —
+  HP two thirds of the weight, SP the other third, an SP-less party dividing by
+  1 rather than 0. A page whose condition box is **entirely unticked never runs**,
+  which is RPG_RT's reading of "no trigger" and the opposite of how every other
+  RPG2000 page kind treats vacuous conditions; both test beds carry such pages
+  (446 of Nepheshel's 3265, all 88 of mtf-meido-action's) and every one is empty,
+  so no real game changes behaviour. Still TODO here: the `command_actor`
+  (chosen battle command) condition, which RPG_RT only answers for the battler
+  whose action triggered the check — this runtime evaluates pages once per turn
+  with no acting battler, the same null-`source` case EasyRPG bails on, so such a
+  page deliberately does not fire rather than firing unchecked; and video
+  playback for Play Movie (no decoder is linked in; the request is logged). **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the
   target frame by frame and fires its screen flashes, holding the event with the
   wait flag (per-cell zoom / tone and target-only flashes are approximations for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2738,11 +2738,19 @@ module Game
 
     # `ctx` is the battle context the interpreter also runs against; it answers
     # `turn`, `enemy(index)`, `ally_by_actor_id(id)`, `enemy_turn(index)`,
-    # `actor_turn(id)` and `actor_command(id)`. A context that cannot answer a
-    # tested sub-condition fails the page.
+    # `actor_turn(id)`, `fatigue` and `actor_command(id)`. A context that cannot
+    # answer a tested sub-condition fails the page.
     def self.active?(cond, switches, variables, ctx)
-      return true if cond.nil?
+      # A page whose condition box is entirely unticked never runs — RPG_RT
+      # treats "no trigger" as "never", not as "always" (EasyRPG's
+      # AreConditionsMet opens with exactly this test). Worth stating because the
+      # opposite reading is the natural one: every other page kind in RPG2000
+      # runs when its conditions are vacuously satisfied. Both test beds do have
+      # such pages (446 of Nepheshel's 3265, all 88 of mtf-meido-action's), and
+      # every one of them is empty, so the rule costs those games nothing.
+      return false if cond.nil?
       flags = cond.flags || 0
+      return false if flags == 0
       return false if (flags & SWITCH_A) != 0 && !switches[cond.switch_a_id]
       return false if (flags & SWITCH_B) != 0 && !switches[cond.switch_b_id]
       if (flags & VARIABLE) != 0
@@ -2771,9 +2779,11 @@ module Game
       if (flags & COMMAND_ACTOR) != 0
         return false unless ctx.actor_command(cond.command_actor_id) == cond.command_id
       end
-      # The party-fatigue condition is an RPG2003 mechanic the runtime does not
-      # model; a page gated on it never fires rather than firing unchecked.
-      return false if (flags & FATIGUE) != 0
+      if (flags & FATIGUE) != 0
+        f = ctx.fatigue
+        return false if f.nil?
+        return false if f < cond.fatigue_min || f > cond.fatigue_max
+      end
       true
     end
 
@@ -3385,8 +3395,18 @@ module Game
                            :action, :defending, :mp, :max_mp, :spi, :command,
                            :actor, :states, :state_turns, :crit_denom,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
-                           :hit_rate, :state_ranks, :hidden) do
+                           :hit_rate, :state_ranks, :hidden, :battle_turn) do
       def dead?; hp <= 0; end
+
+      # RPG2003 counts turns per battler as well as per battle: this is how many
+      # turns *this* battler has taken, which the troop pages' turn_enemy /
+      # turn_actor conditions are written against. Mirrors EasyRPG's
+      # Game_Battler::GetBattleTurn, which Scene_Battle's NextTurn(battler)
+      # increments as that battler's own turn begins (and ResetBattle zeroes).
+      # Struct members start nil, so the reader normalises rather than every
+      # construction site having to pass 0.
+      def turns_taken; battle_turn || 0; end
+      def next_battle_turn; self.battle_turn = turns_taken + 1; end
       # A troop member the editor placed but flagged invisible has not entered
       # the fight yet: it does not act, cannot be targeted and does not keep the
       # battle going. Show Hidden Monster (13150) clears the flag and brings it
@@ -3541,12 +3561,49 @@ module Game
       @allies.find { |a| a.actor && a.actor.respond_to?(:id) && a.actor.id == id }
     end
 
-    # RPG2000 also counts turns *per battler* and remembers each actor's chosen
-    # battle command; neither is modelled here, so the page conditions that read
-    # them report "unknown" (nil) and Game::BattlePage fails that page rather
-    # than firing it on an unchecked condition.
-    def enemy_turn(_index); nil; end
-    def actor_turn(_id); nil; end
+    # Turns taken by troop member `index` / by the party member whose database
+    # actor id is `id` — the RPG2003 per-battler turn counters the pages'
+    # turn_enemy / turn_actor conditions test (Combatant#turns_taken). nil for a
+    # battler that is not in this fight, which fails the page rather than
+    # answering a condition about someone who is not here.
+    def enemy_turn(index)
+      foe = enemy(index)
+      foe && foe.turns_taken
+    end
+
+    def actor_turn(id)
+      ally = ally_by_actor_id(id)
+      ally && ally.turns_taken
+    end
+
+    # The party's exhaustion, 0 (untouched) to 100 (wiped out) — the RPG2003
+    # `fatigue` page condition. Ported from EasyRPG's Game_Party::GetFatigue:
+    # HP is two thirds of the weight and SP one third, so a party at full HP with
+    # no SP left still only reaches 33. Written in integer arithmetic (mruby has
+    # no rounding helper here) with the same round-half-up the C++ does; an
+    # SP-less party divides by 1 rather than 0, exactly as the original notes.
+    def fatigue
+      return 0 if @allies.empty?
+      hp = 0; total_hp = 0; sp = 0; total_sp = 0
+      @allies.each do |a|
+        hp += a.hp
+        total_hp += a.max_hp || 0
+        sp += a.mp || 0
+        total_sp += a.max_mp || 0
+      end
+      return 0 if total_hp <= 0
+      total_sp = 1 if total_sp <= 0
+      num = 100 * (2 * hp * total_sp + sp * total_hp)
+      den = 3 * total_hp * total_sp
+      100 - (2 * num + den) / (2 * den)
+    end
+
+    # RPG2000 also remembers each actor's chosen battle command, which the
+    # `command_actor` page condition tests. RPG_RT only answers it for the
+    # battler whose action triggered the check (EasyRPG's AreConditionsMet bails
+    # on a null `source`), and this runtime evaluates pages once per turn with no
+    # acting battler, so the condition reports "unknown" (nil) and
+    # Game::BattlePage fails that page rather than firing it unchecked.
     def actor_command(_id); nil; end
 
     # Force Flee (1006), target 0: let the party leave whenever it next tries.
@@ -3608,6 +3665,10 @@ module Game
         return nil if @queue.empty? # hit MAX_ROUNDS
         b = @queue.shift
         next if b.dead?
+        # The battler's own turn starts here, whether or not it ends up able to
+        # act — RPG_RT bumps the per-battler counter as the turn begins, not
+        # once the action lands (EasyRPG's Scene_Battle::NextTurn).
+        b.next_battle_turn
         can_act = apply_turn_states(b)
         next if b.dead? || !can_act
         entry = record_action(strike(b))

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1106,19 +1106,27 @@ module Game
       when 5 then actor_operand(cmd)                       # an actor's stat
       when 6 then event_operand(cmd)                       # a character's position
       when 7 then other_operand(cmd)                       # gold / timer / ...
-      else cmd.param(5)
+      when 8 then enemy_operand(cmd)                       # a monster's stat (2003)
+      else
+        # An operand this build does not know (the Maniac patch adds 9..21).
+        # Reading 0 is the safe answer; returning param5 — which is the operand's
+        # *selector*, not a value — used to write the enemy index or actor id
+        # into the variable and look like a plausible number.
+        $stderr.puts "[RPG2k] Control Variables: unsupported operand #{cmd.param(4)}"
+        0
       end
     end
 
     # Operand type 6: a positional value of a character. param5 selects it (10001
     # the hero / party, a positive id a map event); param6 the value (0 map id,
-    # 1 x tile, 2 y tile, 3 facing, in RPG2000's 2/4/6/8 numpad convention).
-    # Screen coordinates (4 / 5) are not modelled and read 0, and -- matching a
-    # long-standing RPG_RT quirk -- a *map event's* map id also reads 0. An
-    # unresolvable reference (no map_info hook, unknown event) reads 0.
+    # 1 x tile, 2 y tile, 3 facing in RPG2000's 2/4/6/8 numpad convention,
+    # 4 screen x, 5 screen y). Matching a long-standing RPG_RT quirk, a *map
+    # event's* map id reads 0. An unresolvable reference (no map_info hook,
+    # unknown event) reads 0.
     def event_operand(cmd)
       ref = cmd.param(5)
       attr = cmd.param(6)
+      return screen_operand(ref, attr) if attr == 4 || attr == 5
       if ref == 10001 # the hero / party leader
         case attr
         when 0 then @state.map_id
@@ -1134,11 +1142,22 @@ module Game
         when 1 then pos[:x]
         when 2 then pos[:y]
         when 3 then pos[:direction]
-        else 0 # event map id (RPG2000 quirk) and screen coords read 0
+        else 0 # an event's map id reads 0 (the RPG2000 quirk)
         end
       else
         0
       end
+    end
+
+    # The screen-coordinate selectors of operand 6 (attr 4 x / 5 y): where the
+    # character currently sits in the view, which only the map scene can answer
+    # because it owns the camera. Without that hook (a headless interpreter, or a
+    # battle page) there is no view to measure against, so it reads 0.
+    def screen_operand(ref, attr)
+      return 0 unless @map_info.respond_to?(:character_screen_position)
+      pos = @map_info.character_screen_position(ref)
+      return 0 unless pos
+      attr == 4 ? pos[:x] : pos[:y]
     end
 
     # Operand type 4: a count for the item with id param5. param6 selects the
@@ -1164,11 +1183,15 @@ module Game
 
     # Operand type 5: a stat of the actor with id param5. param6 selects the
     # attribute (0 level, 1 EXP, 2 HP, 3 MP, 4 max HP, 5 max MP, 6 attack,
-    # 7 defence, 8 spirit, 9 agility). An actor not in the party reads as 0.
+    # 7 defence, 8 spirit, 9 agility, then 10..14 the id of the item in each
+    # equipment slot — weapon, shield, armour, helmet, accessory, in the order
+    # Game::Actor::EQUIP_ORDER already stores them, 0 for an empty slot). An
+    # actor not in the party reads as 0.
     def actor_operand(cmd)
       actor = party.actor_by_id(cmd.param(5))
       return 0 unless actor
-      case cmd.param(6)
+      attr = cmd.param(6)
+      case attr
       when 0 then actor.level
       when 1 then actor.exp
       when 2 then actor.hp
@@ -1179,6 +1202,28 @@ module Game
       when 7 then actor.def
       when 8 then actor.int
       when 9 then actor.agi
+      when 10, 11, 12, 13, 14 then actor.equipment[attr - 10] || 0
+      else 0
+      end
+    end
+
+    # Operand type 8: a stat of a monster in the running fight (RPG2003's battle
+    # operand). param5 is the troop member index — the editor's own numbering,
+    # the same one Change Monster HP uses — and param6 the attribute (0 HP,
+    # 1 SP, 2 max HP, 3 max SP, 4 attack, 5 defence, 6 spirit, 7 agility).
+    # Outside a battle, or for a member that is not in this troop, it reads 0.
+    def enemy_operand(cmd)
+      foe = @battle && @battle.enemy(cmd.param(5))
+      return 0 unless foe
+      case cmd.param(6)
+      when 0 then foe.hp
+      when 1 then foe.mp || 0
+      when 2 then foe.max_hp
+      when 3 then foe.max_mp || 0
+      when 4 then foe.atk
+      when 5 then foe.def
+      when 6 then foe.spi
+      when 7 then foe.agi
       else 0
       end
     end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -4127,7 +4127,13 @@ class RPG2k
         end
       end
 
-      def render
+      # The view's top-left corner in map pixels — where the camera is looking
+      # this frame. Extracted from #render so the Control Variables "screen
+      # coordinate" operand can ask for it too; it is a pure function of the
+      # hero position, the pan lock/offset and the shake, apart from `@locked_cam`
+      # being captured the first frame the camera locks (which is idempotent, so
+      # an extra caller cannot move the view).
+      def camera_position
         px, py = player_pixel
         screen = @state.screen
         hero_cx = Game.camera_offset(px + TILE / 2, SCREEN_W, @map.width * TILE)
@@ -4147,8 +4153,35 @@ class RPG2k
         # Screen shake slides the whole view horizontally (the player moves with
         # the map, so the entire screen shakes); the map edge may show a sliver
         # of void during the shake/pan, which is fine.
-        cam_x = base_x + ox - screen.shake_offset
-        cam_y = base_y + oy
+        [base_x + ox - screen.shake_offset, base_y + oy]
+      end
+
+      # Where a character sits on screen, for the Control Variables "character"
+      # operand's screen-coordinate selectors. `ref` is the operand's reference:
+      # 10001 the hero, a positive id a map event. nil when it names something
+      # this scene cannot place.
+      #
+      # RPG_RT measures X from the tile's centre and Y from its *bottom* — the
+      # asymmetry is real (EasyRPG's GetScreenX subtracts half a tile after
+      # adding a whole one, GetScreenY only adds the whole one), so it is
+      # reproduced rather than tidied up.
+      def character_screen_position(ref)
+        pixel =
+          if ref == 10001
+            player_pixel
+          else
+            e = @events.find { |ev| ev[:id] == ref }
+            e && event_pixel(e)
+          end
+        return nil unless pixel
+        cam_x, cam_y = camera_position
+        { x: pixel[0] - cam_x + TILE / 2, y: pixel[1] - cam_y + TILE }
+      end
+      public :camera_position, :character_screen_position
+
+      def render
+        px, py = player_pixel
+        cam_x, cam_y = camera_position
 
         draw_parallax cam_x, cam_y
         draw_layers cam_x, cam_y

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1235,6 +1235,17 @@ class FakeMapInfo
   def terrain_id(x, y); x * 10 + y; end
   def event_id_at(x, y); (x == 2 && y == 3) ? 7 : 0; end
   def event_position(id); id == 7 ? { x: 2, y: 3, direction: 6 } : nil; end
+  # The hero sits mid-screen; event 7 is up and to the left of it. Anything else
+  # is not on this map.
+  def character_screen_position(ref)
+    return { x: 160, y: 120 } if ref == 10001
+    ref == 7 ? { x: 40, y: 72 } : nil
+  end
+end
+
+# The same map without the camera hook, for the headless case.
+class FakeMapInfoNoCamera
+  def event_position(id); id == 7 ? { x: 2, y: 3, direction: 6 } : nil; end
 end
 
 check 'Store Terrain ID reads a constant tile and a variable-addressed tile' do
@@ -2608,6 +2619,59 @@ check 'Control Variables reads an actor stat (operand type 5)' do
   eq 42, st.variables[2]
   eq 100, st.variables[3]
   eq 8, st.variables[4]
+end
+
+check 'Control Variables reads a character screen position (operand 6, attr 4/5)' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 10001, 4]),  # hero screen x
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 6, 10001, 5]),  # hero screen y
+            FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 6, 7, 4]),      # event 7 screen x
+            FakeCmd.new(IC::CONTROL_VARS, [0, 4, 4, 0, 6, 9, 4])])     # not on this map
+  it.update
+  eq 160, st.variables[1]
+  eq 120, st.variables[2]
+  eq 40, st.variables[3]
+  eq 0, st.variables[4]
+end
+
+check 'a screen position with no camera to measure against reads 0' do
+  st = new_state
+  st.variables[1] = 99
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfoNoCamera.new   # answers positions, but owns no view
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 10001, 4])])
+  it.update
+  eq 0, st.variables[1]
+end
+
+check 'Control Variables reads an equipped item id (operand 5, attr 10..14)' do
+  st = party_state
+  a = st.party.actor_by_id(1)
+  a.equip([11, 0, 13, 0, 15])
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 5, 1, 10]),   # weapon
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 5, 1, 11]),   # shield (empty)
+            FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 5, 1, 12]),   # armour
+            FakeCmd.new(IC::CONTROL_VARS, [0, 4, 4, 0, 5, 1, 14]),   # accessory
+            FakeCmd.new(IC::CONTROL_VARS, [0, 5, 5, 0, 5, 1, 15])])  # unknown -> 0
+  it.update
+  eq 11, st.variables[1]
+  eq 0, st.variables[2]
+  eq 13, st.variables[3]
+  eq 15, st.variables[4]
+  eq 0, st.variables[5]
+end
+
+check 'the battle operand reads 0 outside a fight, not the member index' do
+  st = new_state
+  st.variables[1] = 99
+  it = Game::Interpreter.new(st) # no #battle set: a map / common event
+  # param5 is the troop member index; returning it would look like a real stat.
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 8, 3, 0])])
+  it.update
+  eq 0, st.variables[1]
 end
 
 check 'Control Variables actor operand reads 0 for an absent actor' do
@@ -5812,6 +5876,24 @@ check 'battle-only commands are no-ops outside a battle' do
 end
 
 # -- RPG2003 battle-page commands (Force Flee / Enable Combo / Call Common) ----
+
+check 'Control Variables reads a monster stat in battle (operand type 8)' do
+  b = battle_with(foe_hp: 80, foe_mp: 12)   # Slime: atk 5, def 0, agi 5
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 8, 0, 0]),   # HP
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 8, 0, 1]),   # SP
+            FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 8, 0, 4]),   # attack
+            FakeCmd.new(IC::CONTROL_VARS, [0, 4, 4, 0, 8, 0, 7]),   # agility
+            FakeCmd.new(IC::CONTROL_VARS, [0, 5, 5, 0, 8, 9, 0])])  # not in the troop
+  it.update
+  eq 80, st.variables[1]
+  eq 12, st.variables[2]
+  eq 5, st.variables[3]
+  eq 5, st.variables[4]
+  eq 0, st.variables[5]
+end
 
 check 'RPG2003 event opcodes match the LCF Code enum' do
   eq 1005, IC::CALL_COMMON_EVENT

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5444,6 +5444,7 @@ def battle_cond(flags, opts = {})
   c = FakeBattleCond.new(flags)
   c.variable_value = 0
   c.turn_a = 0; c.turn_b = 0
+  c.fatigue_min = 0; c.fatigue_max = 100
   c.enemy_hp_min = 0; c.enemy_hp_max = 100
   c.actor_hp_min = 0; c.actor_hp_max = 100
   c.turn_enemy_a = 0; c.turn_enemy_b = 0
@@ -5512,7 +5513,9 @@ check 'BattlePage.active? tests switch, variable and turn conditions' do
   st = new_state
   sw = st.switches
   vars = st.variables
-  eq true, BP.active?(nil, sw, vars, b), 'a page with no condition always fires'
+  # RPG_RT reads an entirely unticked condition box as "never", not "always".
+  eq false, BP.active?(nil, sw, vars, b), 'a page with no condition never fires'
+  eq false, BP.active?(battle_cond(0), sw, vars, b), 'nor one with no flags set'
 
   cond = battle_cond(BP::SWITCH_A, switch_a_id: 7)
   eq false, BP.active?(cond, sw, vars, b)
@@ -5548,13 +5551,92 @@ end
 check 'BattlePage.active? fails a condition the runtime cannot answer' do
   b = battle_with
   st = new_state
-  # Party fatigue is an RPG2003 mechanic that is not modelled, and the per-
-  # battler turn counters are not either: such a page must not fire unchecked.
-  eq false, BP.active?(battle_cond(BP::FATIGUE), st.switches, st.variables, b)
-  eq false, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 0),
-                       st.switches, st.variables, b)
+  # The chosen-command test needs the battler whose action triggered the check,
+  # which a once-per-turn evaluation has no equivalent of (RPG_RT bails on a
+  # null source too), so such a page must not fire unchecked.
   eq false, BP.active?(battle_cond(BP::COMMAND_ACTOR, command_actor_id: 1,
                                    command_id: 1), st.switches, st.variables, b)
+  # Nor may one keyed to a battler that is not in this fight.
+  eq false, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 9),
+                       st.switches, st.variables, b)
+  eq false, BP.active?(battle_cond(BP::TURN_ACTOR, turn_actor_id: 99),
+                       st.switches, st.variables, b)
+end
+
+# -- RPG2003 per-battler turn counters and party fatigue ----------------------
+
+check 'a battler counts its own turns as it takes them' do
+  hero = combatant('Hero', 40, 0, 20, 100)   # faster: acts first each round
+  hero.actor = FakeSourceActor.new(1)
+  slime = combatant('Slime', 5, 0, 5, 999)   # tanky, so the fight runs on
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  eq 0, b.enemy_turn(0), 'nobody has acted yet'
+  eq 0, b.actor_turn(1)
+
+  b.step                                     # the faster hero acts
+  eq 1, b.actor_turn(1)
+  eq 0, b.enemy_turn(0), 'the slower enemy has not had its turn yet'
+
+  b.step                                     # now the enemy
+  eq 1, b.enemy_turn(0)
+  b.step; b.step                             # a second round for both
+  eq 2, b.actor_turn(1)
+  eq 2, b.enemy_turn(0)
+
+  eq nil, b.enemy_turn(5), 'a member that is not in this fight is unknown'
+  eq nil, b.actor_turn(99)
+end
+
+check 'turn_enemy / turn_actor read the per-battler counters' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.actor = FakeSourceActor.new(1)
+  slime = combatant('Slime', 5, 0, 5, 999)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  st = new_state
+  # Turn 0 for everyone before anyone has acted.
+  eq true, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 0,
+                                  turn_enemy_b: 0, turn_enemy_a: 0),
+                      st.switches, st.variables, b)
+  eq false, BP.active?(battle_cond(BP::TURN_ENEMY, turn_enemy_id: 0,
+                                   turn_enemy_b: 1, turn_enemy_a: 0),
+                       st.switches, st.variables, b)
+  b.step; b.step # both battlers have now had a turn
+  eq 1, b.actor_turn(1)
+  eq true, BP.active?(battle_cond(BP::TURN_ACTOR, turn_actor_id: 1,
+                                  turn_actor_b: 1, turn_actor_a: 0),
+                      st.switches, st.variables, b)
+end
+
+check 'Battle#fatigue weights HP two thirds and SP one third' do
+  full = combatant_mp('Hero', 10, 0, 10, 100, 50)
+  b = Game::Battle.new([full], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1))
+  eq 0, b.fatigue, 'a party at full HP and SP is not tired at all'
+
+  full.hp = 0
+  eq 67, b.fatigue, 'no HP but full SP: HP is two thirds of the weight'
+  full.hp = 100
+  full.mp = 0
+  eq 33, b.fatigue, 'no SP but full HP: SP is the other third'
+  full.hp = 0
+  eq 100, b.fatigue, 'wiped out'
+
+  # An SP-less party divides by 1 rather than 0, so it never passes 66.
+  nosp = combatant('Hero', 10, 0, 10, 100)
+  b2 = Game::Battle.new([nosp], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1))
+  eq 33, b2.fatigue
+  nosp.hp = 0
+  eq 100, b2.fatigue
+end
+
+check 'the fatigue page condition tests the window' do
+  hero = combatant_mp('Hero', 10, 0, 10, 100, 50)
+  b = Game::Battle.new([hero], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1))
+  st = new_state
+  # "at least half worn down" fires only once the party is.
+  cond = battle_cond(BP::FATIGUE, fatigue_min: 50, fatigue_max: 100)
+  eq false, BP.active?(cond, st.switches, st.variables, b)
+  hero.hp = 0
+  eq true, BP.active?(cond, st.switches, st.variables, b)
 end
 
 check 'BattlePage.select_all returns every matching page in order' do
@@ -5565,9 +5647,10 @@ check 'BattlePage.select_all returns every matching page in order' do
     1 => FakePage.new(battle_cond(0), []),
     2 => FakePage.new(battle_cond(BP::SWITCH_A, switch_a_id: 2), []),
     3 => FakePage.new(battle_cond(BP::SWITCH_A, switch_a_id: 1), []),
+    4 => FakePage.new(battle_cond(BP::TURN, turn_b: 0, turn_a: 0), []),
   }
   got = BP.select_all(pages, st.switches, st.variables, b).map { |(id, _)| id }
-  eq [1, 3], got, 'unlike a map event, every matching battle page runs'
+  eq [3, 4], got, 'unlike a map event, every matching battle page runs'
 end
 
 check 'Change Monster HP damages a troop member, honouring the lethal flag' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1874,6 +1874,44 @@ check 'the choice window plays the cursor and decision system sounds' do
   ok !scene.instance_variable_get(:@message), 'the choice window closed on confirm'
 end
 
+check 'character_screen_position measures against the live camera' do
+  # A map small enough that the camera cannot scroll, so screen position is just
+  # the map position: the offsets RPG_RT applies are then visible on their own.
+  scene = new_scene({ 1 => event(3, 4, page) }, player: [1, 2])
+  tile = RPG2k::Scene::Map::TILE
+  eq [0, 0], scene.camera_position, 'a map smaller than the view cannot scroll'
+
+  hero = scene.character_screen_position(10001)
+  # X is measured from the tile's centre, Y from its bottom — RPG_RT's own
+  # asymmetry, which is the whole reason this is worth pinning down.
+  eq 1 * tile + tile / 2, hero[:x]
+  eq 2 * tile + tile, hero[:y]
+
+  ev = scene.character_screen_position(1)
+  eq 3 * tile + tile / 2, ev[:x]
+  eq 4 * tile + tile, ev[:y]
+
+  eq nil, scene.character_screen_position(99), 'no such event on this map'
+end
+
+check 'a scrolled camera shifts the screen position it reports' do
+  # A tall map so the follow camera actually scrolls, and the hero's screen
+  # position stops tracking its map position.
+  scene = new_scene({}, player: [1, 20])
+  w = 6; h = 40
+  tall = Game::Map.new(1, OpenStruct.new(
+    width: w, height: h, chipset_id: 1,
+    lower_layer: Array.new(w * h, 0), upper_layer: Array.new(w * h, 0),
+    events: {}))
+  scene.instance_variable_set(:@map, tall)
+  scene.instance_variable_get(:@state).map = tall
+
+  cam_y = scene.camera_position[1]
+  ok cam_y > 0, 'the camera scrolled down to follow the hero'
+  tile = RPG2k::Scene::Map::TILE
+  eq 20 * tile + tile - cam_y, scene.character_screen_position(10001)[:y]
+end
+
 check 'the message window moves away from the hero when not position-fixed' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2368,12 +2368,15 @@ end
 
 # -- battle-event pages --------------------------------------------------------
 
-# A troop battle-event page: `flags` 0 means "no condition", so it fires on turn
-# 0 as soon as the fight opens.
-def troop_page(cmds, flags = 0, opts = {})
+# A troop battle-event page. The default condition is the turn test at base 0 /
+# multiple 0, so the page fires on turn 0 as the fight opens -- an entirely
+# unticked condition box would never fire at all, which is how RPG_RT reads it
+# (see Game::BattlePage.active?).
+def troop_page(cmds, flags = Game::BattlePage::TURN, opts = {})
   cond = OpenStruct.new({ flags: flags, switch_a_id: 1, switch_b_id: 1,
                           variable_id: 1, variable_value: 0, turn_a: 0,
-                          turn_b: 0, enemy_id: 0, enemy_hp_min: 0,
+                          turn_b: 0, fatigue_min: 0, fatigue_max: 100,
+                          enemy_id: 0, enemy_hp_min: 0,
                           enemy_hp_max: 100, actor_id: 1, actor_hp_min: 0,
                           actor_hp_max: 100 }.merge(opts))
   OpenStruct.new(condition: cond, event: cmds)
@@ -2414,6 +2417,14 @@ check 'a battle page gated on an unmet condition does not fire' do
   scene, st = battle_scene_with_pages(pages)
   10.times { scene.update }
   ok !st.switches[14], 'the gated page stayed put'
+end
+
+check 'a battle page with no condition ticked at all never fires' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::CONTROL_SWITCHES, [0, 15, 15, 0])], 0) }
+  scene, st = battle_scene_with_pages(pages)
+  10.times { scene.update }
+  ok !st.switches[15], 'RPG_RT reads an unticked condition box as never, not always'
 end
 
 check 'Terminate Battle from a page ends the fight and resumes the event' do


### PR DESCRIPTION
Follow-up to #353. Two commits, both closing gaps where the runtime silently answered a query wrongly rather than failing loudly.

> **Scope note.** These landed as two commits on one branch because the branch is fixed for this session; they are independent and can be reviewed (or reverted) separately.

---

## 1. Resolve the RPG2003 battle-page turn and fatigue conditions

A troop battle-event page could be gated on RPG2003's per-battler turn counters or on party fatigue, and `Game::BattlePage` had no way to answer either — so it failed those pages rather than firing them unchecked. Both are answerable now.

**Per-battler turn counters.** RPG2003 counts turns per battler as well as per battle. `Game::Battle::Combatant` carries its own `battle_turn`, bumped as that battler's turn *begins* rather than when its action lands (EasyRPG's `Scene_Battle::NextTurn`), so `turn_enemy` and `turn_actor` read real counters through the same base/multiple turn arithmetic the battle-wide turn test already used. A battler not in this fight still reports unknown, which fails the page.

**Party fatigue.** `Game::Battle#fatigue` ports `Game_Party::GetFatigue`: HP is two thirds of the weight and SP the other third, so a party at full HP with no SP left reads 33, and an SP-less party divides by 1 rather than 0. Written in integer arithmetic with the same round-half-up the C++ does (mruby has no rounding helper here).

**`command_actor` stays deliberately unanswered.** Not merely unimplemented: RPG_RT only answers the chosen-command condition for the battler whose action triggered the check, and pages here are evaluated once per turn with no acting battler — the same null-`source` case EasyRPG bails on. Making it fire would be a divergence, not a fix. The reason is now recorded where the condition is evaluated.

**Behaviour change worth a reviewer's eye.** A page whose condition box is **entirely unticked** was firing every turn. RPG_RT reads "no trigger" as *never*, not *always* — the opposite of how every other RPG2000 page kind treats a vacuously satisfied condition, which is why the original reading was the natural one. Blast radius was checked first: both test beds carry such pages (446 of Nepheshel's 3265, all 88 of mtf-meido-action's) and **every one of them is empty**, so no real game changes behaviour. Three existing checks asserted the old behaviour and were updated deliberately.

---

## 2. Read the Control Variables operands that returned 0 or junk

- **Character screen position** (operand 6, selectors 4 / 5) read 0, because only the map scene knows where the camera is looking. The camera computation is lifted out of `Scene::Map#render` into `#camera_position` — it was already a pure function of the hero position, the pan lock and the shake — and `#character_screen_position` measures the hero or a map event against it. RPG_RT's offsets are asymmetric (X from the tile's centre, Y from its bottom), so they are reproduced rather than tidied up.
- **Equipped item ids** (operand 5, selectors 10..14) read the five slots in the order `Game::Actor::EQUIP_ORDER` already stores them.
- **RPG2003's battle operand** (operand 8) reads a troop member's HP / SP / max HP-SP / attack / defence / spirit / agility from the running fight.

That last one also fixes a junk read: unknown operands fell through to `cmd.param(5)`, which is the operand's *selector*, not a value. A 2003 game using the battle operand therefore stored the troop member index in the target variable — a small plausible-looking number, the worst kind of wrong. Unknown operands now read 0 and log which one was asked for.

---

## Testing

- `scripts/rpg2k_logic_check.rb` — 414 pass (11 new)
- `scripts/rpg2k_scene_check.rb` — 115 pass (3 new, pinning the screen offsets against both an unscrolled and a scrolled camera)
- `scripts/rpg2k_render_check.rb` — 36 pass
- `scripts/lcf_testbed_check.rb` — clean on both test beds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit