### PR TITLE
Update GitHub Actions artifact upload/download to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -787,7 +787,7 @@ jobs:
           '
 
       - name: Upload EBOOT
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: psp-eboot
           path: build-psp/EBOOT.PBP
@@ -815,7 +815,7 @@ jobs:
       PPSSPP_TAG: v1.17.1
     steps:
       - name: Download EBOOT
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: psp-eboot
           path: eboot
@@ -896,7 +896,7 @@ jobs:
 
       - name: Upload smoke-test output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: psp-smoke
           path: headless.log


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions artifact handling actions from v4 to v7 across the CI/CD workflow.

## Key Changes
- Updated `actions/upload-artifact` from v4 to v7 in three workflow jobs:
  - PSP EBOOT upload step
  - PSP smoke test output upload step
- Updated `actions/download-artifact` from v4 to v7 in the PPSSPP testing job:
  - EBOOT download step

## Details
These updates ensure the workflow uses the latest stable versions of the artifact actions, which may include performance improvements, bug fixes, and security updates. The v7 versions maintain backward compatibility with the existing configuration while providing enhanced functionality.

https://claude.ai/code/session_019gt4nubBRF6o4ynM4Nt78C