### PR TITLE
RPG2003's second timer, and the RPG2000 Game Over screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@
 - Message text reveals gradually (a typewriter effect; a button press completes
   it, then dismisses), expands the common control codes (`\v[n]` variable,
   `\n[n]` actor name, `\\`) and draws `\c[n]` colour changes
-- A countdown timer can be set/started/stopped from events
+- Countdown timers can be set/started/stopped from events — RPG2000's one and
+  RPG2003's second, each with its own on-screen window, read back by Control
+  Variables and Conditional Branch, and pausing for a battle unless the start
+  command said otherwise
 - Press the cancel button to open a menu (party status, Save, End Game); "New
   Game" state can be saved and reloaded from the title's "Continue"
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@
   and strength), Set
   Transparent Flag (hide/show the hero), Flash Sprite (pulse a character with a
   decaying colour), Enter/Exit Vehicle, Open Save Menu / Open Main Menu, Fade Out
-  BGM, Return to Title and Erase
+  BGM, Return to Title, Game Over (the database's `GameOver/` picture over its
+  game-over music, dismissed back to the title) and Erase
   Event (remove an event from
   the map) — **every RPG2000 event command now has a handler**. Events start on the action button, on
   player touch (walking into them),

--- a/changelog.d/rpg2k-game-over-screen.added.md
+++ b/changelog.d/rpg2k-game-over-screen.added.md
@@ -1,0 +1,10 @@
+- The **RPG2000 Game Over screen**. `Scene::GameOver` fills the screen with the
+  database's `GameOver/<name>` picture over its game-over music and returns to
+  the title on a button press. Both routes RPG_RT reaches it by now go through
+  it — the **Game Over** event command (12420) and a battle defeat whose
+  encounter says "game over" rather than running a `[Defeat]` handler — where
+  each used to drop straight back to the title with the run's ending unshown.
+  A button still held from the fight that caused the defeat cannot skip the
+  screen; it waits for a fresh press. A game that names no picture (or whose
+  file is missing) still reaches the screen, on plain black, with the failure
+  logged rather than the defeat itself failing.

--- a/changelog.d/rpg2k-timer-set-and-stop.fixed.md
+++ b/changelog.d/rpg2k-timer-set-and-stop.fixed.md
@@ -1,0 +1,8 @@
+- Two RPG_RT timer details, corrected against EasyRPG's `Game_Party` timer
+  block. **Set** seeds `seconds * 60 + 59`, not `seconds * 60`: the display shows
+  `frames / 60`, so a timer seeded exactly dropped a second after a single frame
+  instead of holding the number it was given for a whole second. And **stopping
+  a timer hides it** — `StopTimer` clears the visible flag as well as the running
+  one, and the countdown reaching zero goes through that same stop, which is how
+  a finished timer leaves the screen rather than sitting at `0:00`. This runtime
+  had taken the opposite reading (a stopped timer stayed on screen, frozen).

--- a/changelog.d/rpg2k3-second-timer.added.md
+++ b/changelog.d/rpg2k3-second-timer.added.md
@@ -1,0 +1,11 @@
+- **RPG2003's second countdown timer.** The Timer Operation command's sixth
+  parameter selects which timer it acts on — RPG2000 data never carries it, so it
+  reads 0 and addresses the only timer that edition has. The new timer is read
+  back by **Control Variables** (operand 7, selector 9) and by **Conditional
+  Branch** type 10, which is laid out exactly like the existing timer test, and
+  is drawn in its own window to the right of the first. The start operation's
+  second flag — **keep running in battle** — is honoured as well: without it a
+  timer pauses *and* hides for the duration of a fight rather than being stopped.
+  The countdown itself moves into a `Game::Timer` value object; both timers
+  persist in the save, and a save written before the second one existed still
+  loads.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -542,10 +542,22 @@ The work below is roughly ordered by the critical path to a walkable game
   the message/choice UI (those requests are skipped) — full parallel UI is a
   later refinement
 - 🚧 Screen effects — the game **timer** works (Timer Operation command +
-  `Game::State` countdown) and is now **drawn**: the start operation's
-  "show timer" flag sets a `timer_visible` state (persisted in the save), and
-  while set `Scene::Map` shows a small top-centre window counting down as
-  `M:SS`, independent of whether the timer is still running. The **Tint Screen**
+  `Game::Timer`) and is **drawn**: the start operation's "show timer" flag makes
+  `Scene::Map` show a small window counting down as `M:SS`. There are **two**
+  timers — RPG2003 adds a second, selected by the command's sixth parameter, read
+  back by Control Variables selector 9 and by Conditional Branch type 10, and
+  drawn in its own window to the right of the first (RPG_RT parks the pair at the
+  screen's left and right edges as digit sprites off the System graphic; drawing
+  them that way is a rendering-parity job of its own). The start operation's
+  second flag — **keep running in battle** — is honoured: without it a timer
+  pauses *and* hides for the duration of a fight rather than being stopped. Two
+  RPG_RT details this used to get wrong are fixed from EasyRPG's
+  `Game_Party` timer block: **set** seeds `seconds * 60 + 59` (so a freshly-set
+  timer holds the number it was given for a whole second instead of dropping one
+  after a single frame), and **stop hides it** — the countdown reaching zero goes
+  through that same stop, which is how a finished timer leaves the screen instead
+  of sitting at `0:00`. Both timers persist in the save, and a save written
+  before the second one existed still loads. The **Tint Screen**
   (11030) command now drives a
   `Game::Screen` tint state machine on `Game::State`: it interpolates the four
   RPG2000 channels (red/green/blue/saturation, 0..200) toward their target over

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -280,7 +280,8 @@ The work below is roughly ordered by the critical path to a walkable game
   polarity to items); states apply before HP so a revive skill (curing 戦闘不能)
   stands the ally up and its recovery then lands, and a cure skill is usable even
   at full HP. A **party wipe now ends the game** (a game-over-mode battle defeat
-  returns to the title — see the Enemy Encounter entry). Still remaining:
+  puts up the Game Over screen, then the title — see the Enemy Encounter
+  entry). Still remaining:
   inflicting states from **battle** (rolling `state_chance` / to-hit, the
   non-reverse item case, enemy attacks).
   **Show / Move / Erase
@@ -360,8 +361,8 @@ The work below is roughly ordered by the critical path to a walkable game
   on death) over a plain battle field. **Post-battle HP now persists to the
   party** — `Battle#apply_to_party` writes each survivor's final HP back through
   `Game::Actor#set_hp`, so damage sticks and a member reduced to 0 comes out
-  戦闘不能 — and a **defeat ends the game** (return to title via
-  `perform_game_over`) when the encounter's defeat mode is "game over" (no
+  戦闘不能 — and a **defeat ends the game** (the Game Over screen, then the title,
+  via `perform_game_over`) when the encounter's defeat mode is "game over" (no
   `[Defeat]` handler) and the party is wiped (`Game::Party#all_dead?`). **Status
   conditions carry through a battle**: a `Combatant` seeds its state set from its
   actor, a **battle medicine cures** its `state_set` (an antidote used mid-fight),
@@ -413,9 +414,14 @@ The work below is roughly ordered by the critical path to a walkable game
   buffered so the screen animates the volley hit by hit — with attack damage
   still computed per target's defence. **All-party items** (medicine scope 1)
   work the same way through `command_item_all`, healing / curing every living
-  ally and consuming a single item for the whole volley. Still to come:
-  enemy-cast infliction, the per-terrain backdrop and the RPG2000 Game Over
-  graphic.
+  ally and consuming a single item for the whole volley. The **RPG2000 Game Over
+  screen** exists now: `Scene::GameOver` fills the screen with the database's
+  `GameOver/<name>` picture over its game-over music and returns to the title on
+  a button press, reached by both routes RPG_RT uses — the Game Over event
+  command (12420) and a battle defeat whose encounter says "game over" rather
+  than running a `[Defeat]` handler. A game that names no picture (or whose file
+  is missing) still reaches the screen, on plain black, rather than the defeat
+  failing. Still to come: enemy-cast infliction and the per-terrain backdrop.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM
@@ -684,8 +690,8 @@ The work below is roughly ordered by the critical path to a walkable game
   **per-actor name/title overrides for non-leader** members (only the leader's
   name is in the title chunk)
 - Battle system — enemy groups, battle scene, actions/damage/states,
-  animations, game-over scene (large; Nepheshel uses the default RPG2000
-  battle). Needs real assets + the native build to develop against
+  animations (large; Nepheshel uses the default RPG2000 battle). Needs real
+  assets + the native build to develop against. The game-over scene is done
 - ✅ Menu screens — the Item, Skill, Equip and Status screens all exist now (see
   Menu scene above). The Skill screen's recovery formula (`power +
   physical_rate*atk/20 + magical_rate*spirit/40`) is the same one the battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4280,13 +4280,101 @@ module Game
     end
   end
 
+  # One of RPG_RT's countdown timers, driven by the Timer Operation command
+  # (10230). RPG2000 has a single one; RPG2003 adds a second, selected by that
+  # command's sixth parameter. Ported from EasyRPG's Game_Party timer block,
+  # which is where the two details this used to get wrong come from:
+  #
+  # * **Set** seeds `seconds * 60 + 59`, not `seconds * 60`. The display shows
+  #   `frames / 60`, so the extra 59 makes a freshly-set timer hold the number it
+  #   was given for a whole second before ticking down — seeded exactly, it would
+  #   drop a second after a single frame.
+  # * **Stop hides it.** `StopTimer` clears the visible flag as well as the
+  #   running one, and the countdown reaching zero goes through that same stop —
+  #   which is how a timer that runs out disappears rather than sitting at 0:00.
+  class Timer
+    FPS = 60
+
+    # Remaining time in frames; whether it is counting; whether it is drawn; and
+    # whether it keeps counting (and drawing) during a battle — the Timer
+    # Operation start command's second flag.
+    attr_accessor :frames, :running, :visible, :in_battle
+
+    def initialize
+      @frames = 0
+      @running = false
+      @visible = false
+      @in_battle = false
+    end
+
+    # Timer Operation, "set": load the timer with `seconds` (see the note above
+    # about the extra 59 frames).
+    def set(seconds)
+      @frames = seconds * FPS + (FPS - 1)
+    end
+
+    # Timer Operation, "start": begin counting, drawn or not, and in battle or
+    # not.
+    def start(visible, in_battle = false)
+      @running = true
+      @visible = visible
+      @in_battle = in_battle
+    end
+
+    # Timer Operation, "stop" — and where a finished countdown ends up.
+    def stop
+      @running = false
+      @visible = false
+    end
+
+    # Advance one frame, `battle` telling it whether a fight is running. Returns
+    # true on the frame the countdown reaches zero (RPG_RT counts that as the
+    # displayed seconds hitting 0, not the frame counter, so the last 59 frames
+    # of 0:00 never show).
+    def tick(battle = false)
+      return false unless @running && @frames > 0
+      return false if battle && !@in_battle
+      @frames -= 1
+      return false if seconds > 0
+      stop
+      true
+    end
+
+    # Remaining whole seconds — what every read of the timer reports.
+    def seconds; @frames / FPS; end
+
+    # Whether the timer should be drawn right now; a timer without the battle
+    # flag is hidden for the duration of a fight rather than stopped.
+    def drawn?(battle = false)
+      @visible && (!battle || @in_battle)
+    end
+
+    # The timer as RPG2000 draws it: whole minutes, a colon, then zero-padded
+    # seconds (e.g. 90 s -> "1:30"). Minutes are not capped at two digits. The
+    # seconds are padded by hand: this mruby build bundles no sprintf.
+    def display_text
+      s = seconds
+      secs = s % 60
+      "#{s / 60}:#{secs < 10 ? "0#{secs}" : secs}"
+    end
+
+    def to_h
+      { frames: @frames, running: @running, visible: @visible,
+        in_battle: @in_battle }
+    end
+
+    def load_h(h)
+      return unless h
+      @frames = h[:frames] || 0
+      @running = h[:running] || false
+      @visible = h[:visible] || false
+      @in_battle = h[:in_battle] || false
+    end
+  end
+
   class State
     attr_reader :party, :switches, :variables, :message_config, :screen, :weather
-    attr_accessor :map, :map_id, :x, :y, :direction, :timer_frames, :timer_running
-    # Whether the timer is shown on the map, set by the Timer Operation's start
-    # (the RPG2000 "show timer" flag). Counting (timer_running) and being drawn
-    # (timer_visible) are independent: a stopped timer stays on screen, frozen.
-    attr_accessor :timer_visible
+    attr_accessor :map, :map_id, :x, :y, :direction
     # Whether the player may open the main menu / save, toggled by the Change
     # Main Menu Access (11960) and Change Save Access (11930) event commands;
     # both default on and are persisted in the save.
@@ -4354,9 +4442,7 @@ module Game
       @map = nil
       @switches = Switches.new
       @variables = Variables.new
-      @timer_frames = 0
-      @timer_running = false
-      @timer_visible = false
+      @timers = [Timer.new, Timer.new]
       @message_config = MessageConfig.new
       @menu_access = true
       @save_access = true
@@ -4449,26 +4535,34 @@ module Game
     # "wait until done" flag).
     def pictures_moving?; @pictures.values.any?(&:moving?); end
 
-    # Advance the countdown timer one frame (call once per frame). Returns true
-    # on the frame the timer reaches zero.
-    def tick_timer
-      return false unless @timer_running && @timer_frames > 0
-      @timer_frames -= 1
-      @timer_running = false if @timer_frames <= 0
-      @timer_frames <= 0
+    # Advance both countdown timers one frame (call once per frame), `battle`
+    # telling them whether a fight is running. Returns true when either reached
+    # zero on this frame.
+    def tick_timer(battle = false)
+      finished = false
+      @timers.each { |t| finished = true if t.tick(battle) }
+      finished
     end
 
-    # Remaining timer seconds (assuming 60 fps).
-    def timer_seconds; @timer_frames / 60; end
-
-    # The timer as RPG2000 draws it: whole minutes, a colon, then zero-padded
-    # seconds (e.g. 90 s -> "1:30"). Minutes are not capped at two digits. The
-    # seconds are padded by hand: this mruby build bundles no sprintf.
-    def timer_display_text
-      s = timer_seconds
-      secs = s % 60
-      "#{s / 60}:#{secs < 10 ? "0#{secs}" : secs}"
+    # The Game::Timer for slot `id` — 0 the RPG2000 timer, 1 the second one
+    # RPG2003 adds. Any other id falls back to the first, so malformed data can
+    # never address a timer that does not exist.
+    def timer(id = 0)
+      @timers[id] || @timers[0]
     end
+
+    # -- single-timer shorthands ---------------------------------------------
+    #
+    # Everything written before the second timer existed talks to the first one,
+    # so these keep reading and writing it by name.
+    def timer_seconds; timer(0).seconds; end
+    def timer_display_text; timer(0).display_text; end
+    def timer_frames; timer(0).frames; end
+    def timer_frames=(v); timer(0).frames = v; end
+    def timer_running; timer(0).running; end
+    def timer_running=(v); timer(0).running = v; end
+    def timer_visible; timer(0).visible; end
+    def timer_visible=(v); timer(0).visible = v; end
 
     # The six Change Screen Transitions (10690) slots (see #screen_transitions).
     SCREEN_TRANSITION_SLOTS = 6
@@ -4493,8 +4587,13 @@ module Game
     def to_h
       { map_id: @map_id, x: @x, y: @y, direction: @direction,
         switches: @switches.to_h, variables: @variables.to_h,
-        party: @party.to_h, timer_frames: @timer_frames,
-        timer_running: @timer_running, timer_visible: @timer_visible,
+        party: @party.to_h,
+        # Both timers, plus the first one's fields under their old names so a
+        # save this build writes still loads in one that predates the second
+        # timer.
+        timers: @timers.map { |t| t.to_h },
+        timer_frames: timer_frames,
+        timer_running: timer_running, timer_visible: timer_visible,
         message_config: @message_config.to_h,
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
@@ -4845,9 +4944,15 @@ module Game
       state.direction = h[:direction] || 2
       state.switches.replace(h[:switches] || {})
       state.variables.replace(h[:variables] || {})
-      state.timer_frames = h[:timer_frames] || 0
-      state.timer_running = h[:timer_running] || false
-      state.timer_visible = h[:timer_visible] || false
+      # A save written since the second timer landed carries both; an older one
+      # only has the first timer's three fields.
+      if h[:timers]
+        h[:timers].each_with_index { |th, i| state.timer(i).load_h(th) }
+      else
+        state.timer_frames = h[:timer_frames] || 0
+        state.timer_running = h[:timer_running] || false
+        state.timer_visible = h[:timer_visible] || false
+      end
       state.message_config.load_h(h[:message_config])
       # Access flags default on; only an explicit stored value overrides them
       # (so a save written before these existed keeps the menu/save enabled).

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1235,13 +1235,14 @@ module Game
     def other_operand(cmd)
       case cmd.param(5)
       when 0 then party.gold
-      when 1 then @state.timer_seconds
+      when 1 then @state.timer(0).seconds
       when 2 then party.actors.size
       when 3 then @state.save_count
       when 4 then @state.battle_count
       when 5 then @state.win_count
       when 6 then @state.defeat_count
       when 7 then @state.escape_count
+      when 9 then @state.timer(1).seconds # RPG2003's second timer
       else 0
       end
     end
@@ -1261,15 +1262,18 @@ module Game
     # Timer: op 0 set (seconds), 1 start, 2 stop. Start carries the RPG2000
     # "show timer" flag in param 3 (param 4 is the run-in-battle flag, unused
     # here); stopping freezes the display but leaves it shown.
+    # Timer Operation (10230). param0 is the operation (0 set, 1 start,
+    # 2 stop); a set reads its seconds from param2, as a constant or through
+    # param1 == 1 as a variable; a start carries the "show the timer" flag in
+    # param3 and the "keep running in battle" flag in param4. param5 selects
+    # *which* timer — RPG2003 has a second one, and RPG2000 data simply never
+    # carries that parameter, so it reads 0 and addresses the only timer there.
     def do_timer(cmd)
+      t = @state.timer(cmd.param(5))
       case cmd.param(0)
-      when 0
-        sec = cmd.param(1) == 0 ? cmd.param(2) : variables[cmd.param(2)]
-        @state.timer_frames = sec * 60
-      when 1
-        @state.timer_running = true
-        @state.timer_visible = cmd.param(3) != 0
-      when 2 then @state.timer_running = false
+      when 0 then t.set(cmd.param(1) == 0 ? cmd.param(2) : variables[cmd.param(2)])
+      when 1 then t.start(cmd.param(3) != 0, cmd.param(4) != 0)
+      when 2 then t.stop
       end
     end
 
@@ -1817,8 +1821,7 @@ module Game
         rhs = cmd.param(2) == 0 ? cmd.param(3) : variables[cmd.param(3)]
         compare(variables[cmd.param(1)], rhs, cmd.param(4))
       when 2 # timer: param1 seconds, param2 comparison (0 >=, 1 <=)
-        cmd.param(2) == 0 ? @state.timer_seconds >= cmd.param(1) \
-                          : @state.timer_seconds <= cmd.param(1)
+        timer_condition(cmd, 0)
       when 3 # gold: param1 amount, param2 comparison (0 >=, 1 <=)
         cmd.param(2) == 0 ? party.gold >= cmd.param(1) : party.gold <= cmd.param(1)
       when 4 # item: param1 id, param2 (0 has / 1 not)
@@ -1838,8 +1841,18 @@ module Game
         @triggered_by_decision_key ? true : false
       when 9 # the BGM has played through at least once
         @state.bgm_looped ? true : false
+      when 10 # RPG2003's second timer, laid out exactly like type 2
+        timer_condition(cmd, 1)
       else true
       end
+    end
+
+    # The timer conditions (type 2 the first timer, type 10 RPG2003's second):
+    # param1 is the seconds to compare against and param2 the comparison
+    # (0 "at least", 1 "at most").
+    def timer_condition(cmd, id)
+      secs = @state.timer(id).seconds
+      cmd.param(2) == 0 ? secs >= cmd.param(1) : secs <= cmd.param(1)
     end
 
     # Orientation directions (0 up / 1 right / 2 down / 3 left) mapped to the

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3073,10 +3073,13 @@ class RPG2k
       # defeat (also the target of the Game Over event command). Stop the event
       # and return to the title screen — the faithful end state. (RPG2000 shows a
       # Game Over graphic first; that screen is native renderer work still to come.)
+      # Game Over (12420), and a battle defeat the encounter marked "game over":
+      # show the Game Over screen, which returns to the title once dismissed.
+      # Nothing resumes, so the event is stopped rather than released.
       def perform_game_over
         $stderr.puts '[RPG2k] game over'
         @interpreter.stop
-        @parent.return_to_title
+        @parent.show_game_over
       rescue StandardError => e
         $stderr.puts "[RPG2k] Game over failed: #{e.message}"
         @interpreter.stop
@@ -5396,6 +5399,66 @@ class RPG2k
       end
     end
 
+    # The RPG2000 Game Over screen: the database's `GameOver/<name>` picture
+    # filling the screen with its game-over music playing, dismissed by a button
+    # press, which returns to a fresh title.
+    #
+    # RPG_RT reaches this the same two ways this build does — the Game Over event
+    # command (12420) and a battle defeat whose encounter says "game over" rather
+    # than running a [Defeat] handler — so both go through Scene::GameOver rather
+    # than dropping straight back to the title as they used to.
+    class GameOver < Base
+      def initialize(parent)
+        super parent
+
+        @picture = Sprite.new
+        bmp = gameover_bitmap
+        @picture.bitmap = bmp if bmp
+        play_gameover_bgm
+        # RPG_RT ignores whatever key ended the fight; requiring a *fresh* press
+        # stops the button that closed the battle result from skipping the
+        # screen in the same frame.
+        @armed = false
+      end
+
+      def update
+        unless @armed
+          @armed = true unless Input.press?(Input::C) || Input.press?(Input::B)
+          return
+        end
+        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        parent.return_to_title
+      end
+
+      def dispose
+        @picture.dispose if @picture
+      end
+
+      private
+
+      # The database's game-over picture, or nil when the game names none (or the
+      # file is missing) — the screen then shows plain black, which is better
+      # than refusing to reach it at all.
+      def gameover_bitmap
+        name = db.system.gameover_name.to_s
+        return nil if name.empty?
+        Bitmap.new "GameOver/#{name}"
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] game over picture '#{name}' failed to load: #{e.message}"
+        nil
+      end
+
+      def play_gameover_bgm
+        bgm = db.system.gameover_music
+        return unless bgm
+        name = bgm.file
+        return if name.nil? || name.empty?
+        Audio.bgm_play name, (bgm.volume || 100), (bgm.pitch || 100)
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] game over BGM playback failed: #{e.message}"
+      end
+    end
+
     class Title < Base
       # Height of one selectable line. The shinonome font is 12px tall; the
       # extra space gives a little breathing room between entries.
@@ -5598,6 +5661,14 @@ class RPG2k
   def return_to_title
     @scenes.each { |s| s.dispose if s.respond_to?(:dispose) }
     @scenes = [Scene::Title.new(self)]
+  end
+
+  # Tear down all scenes and show the Game Over screen; dismissing it returns to
+  # the title. Replaces the stack the way return_to_title does rather than
+  # pushing, so the map underneath is gone for good — the run is over.
+  def show_game_over
+    @scenes.each { |s| s.dispose if s.respond_to?(:dispose) }
+    @scenes = [Scene::GameOver.new(self)]
   end
 
   # Load one map (.lmu) by id. Map files are named Map0001.lmu, Map0002.lmu, ...

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -482,8 +482,9 @@ class RPG2k
         @wait_timer = nil
         @anim_wait = nil
         @map_animation = nil
-        @timer_window = nil
-        @timer_text = nil
+        # One window per timer (RPG2003 has two); built lazily when first shown.
+        @timer_windows = [nil, nil]
+        @timer_texts = [nil, nil]
         @pre_vehicle_bgm = nil
         @choice_index = 0
         # The map event whose commands the foreground interpreter is running, so
@@ -523,7 +524,7 @@ class RPG2k
           s.dispose if s
         end
         (@vehicle_sprites || {}).each_value { |s| s.dispose if s }
-        @timer_window.dispose if @timer_window
+        (@timer_windows || []).each { |w| w.dispose if w }
         @airship_shadow.dispose if @airship_shadow
         @animation_sprite.dispose if @animation_sprite
         @flash_buffer.dispose if @flash_buffer
@@ -533,7 +534,10 @@ class RPG2k
       end
 
       def update
-        @state.tick_timer # the timer keeps counting during events too
+        # The timers keep counting during events too. A fight is running when the
+        # battle UI is up, and a timer without the "run in battle" flag pauses
+        # (and hides) for its duration rather than being stopped.
+        @state.tick_timer(!@battle_ui.nil?)
         @state.screen.update # screen tint progresses every frame, even in events
         @state.update_pictures # picture moves progress every frame too
         update_sprite_flashes # Flash Sprite decays during events too
@@ -4209,32 +4213,48 @@ class RPG2k
       TIMER_INNER_W = 40
       TIMER_INNER_H = 16
 
+      # Both timers are drawn the same way; RPG_RT puts the first at the screen's
+      # left edge and the second at its right, so the two are laid out that way
+      # here too (drawing them as digit sprites off the System graphic, the way
+      # RPG_RT actually does, is a rendering-parity job of its own).
       def draw_timer
-        unless @state.timer_visible
-          @timer_window.visible = false if @timer_window
+        battle = !@battle_ui.nil?
+        @timer_windows ||= [nil, nil]
+        @timer_texts ||= [nil, nil]
+        2.times { |id| draw_one_timer(id, battle) }
+      end
+
+      def draw_one_timer(id, battle)
+        timer = @state.timer(id)
+        unless timer.drawn?(battle)
+          w = @timer_windows[id]
+          w.visible = false if w
           return
         end
-        build_timer_window unless @timer_window
-        @timer_window.visible = true
-        text = @state.timer_display_text
-        return if text == @timer_text
+        @timer_windows[id] ||= build_timer_window(id)
+        win = @timer_windows[id]
+        win.visible = true
+        text = timer.display_text
+        return if text == @timer_texts[id]
 
-        @timer_text = text
-        c = @timer_window.contents
+        @timer_texts[id] = text
+        c = win.contents
         c.clear
         c.font.color = Color.new(255, 255, 255, 255)
         c.draw_text 0, 0, c.width, c.height, text, 1 # centre-aligned
       end
 
-      def build_timer_window
+      def build_timer_window(id)
         ow = TIMER_INNER_W + Window::BORDER * 2
         oh = TIMER_INNER_H + Window::BORDER * 2
-        win = Window.new((SCREEN_W - ow) / 2, 4, ow, oh)
+        # Timer 1 sits left of centre and timer 2 right of it, mirroring the
+        # edges RPG_RT parks them at while keeping this build's centred window.
+        x = id == 0 ? (SCREEN_W - ow) / 2 : SCREEN_W - ow - 4
+        win = Window.new(x, 4, ow, oh)
         win.z = 250 # above the map, below the message / menu windows (z 300+)
         win.windowskin = @windowskin
         win.contents = Bitmap.new(TIMER_INNER_W, TIMER_INNER_H)
-        @timer_window = win
-        @timer_text = nil
+        win
       end
 
       # Position and draw each vehicle placed on the current map. A parked vehicle

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1179,24 +1179,111 @@ check 'Timer Operation start carries the show-timer flag; text is M:SS' do
     FakeCmd.new(IC::TIMER_OPERATION, [1, 0, 0, 1, 0]),   # start, visible
   ])
   it.update
-  eq 90 * 60, st.timer_frames
+  # RPG_RT seeds seconds*60 + 59 so the display holds 1:30 for a whole second
+  # instead of dropping to 1:29 after one frame.
+  eq 90 * 60 + 59, st.timer_frames
   eq true, st.timer_running
   eq true, st.timer_visible, 'the show-timer flag turns the display on'
   eq '1:30', st.timer_display_text, '90 s reads as 1:30'
-  # Stopping freezes the count but leaves the display shown.
+  # Stopping clears the display too, which is how a countdown that runs out
+  # disappears rather than sitting at 0:00 (EasyRPG's Game_Party::StopTimer).
   it.start([FakeCmd.new(IC::TIMER_OPERATION, [2])])
   it.update
   eq false, st.timer_running
-  eq true, st.timer_visible, 'a stopped timer stays on screen'
-  # A start with the flag clear hides it again.
+  eq false, st.timer_visible, 'stopping hides the timer'
+  # A start with the flag clear leaves it hidden.
   it.start([FakeCmd.new(IC::TIMER_OPERATION, [1, 0, 0, 0, 0])])
   it.update
+  eq true, st.timer_running
   eq false, st.timer_visible, 'starting without the flag hides the timer'
   # Padding: seconds below ten keep a leading zero, minutes are uncapped.
   st.timer_frames = 5 * 60
   eq '0:05', st.timer_display_text
   st.timer_frames = 605 * 60 # 10 min 5 s
   eq '10:05', st.timer_display_text
+end
+
+check 'a countdown reaches zero on the displayed second, then stops and hides' do
+  t = Game::Timer.new
+  t.set(1)
+  t.start(true)
+  eq 119, t.frames, '1 s is 60 frames of countdown plus the 59-frame lead-in'
+  eq 1, t.seconds
+  59.times { ok !t.tick, 'still reads 0:01' }
+  eq 1, t.seconds, 'the full second is held, not lost on the first frame'
+  # RPG_RT ends the countdown the moment the *displayed* seconds hit zero, so
+  # the 59 frames that would still read 0:00 never run.
+  ok t.tick, 'the sixtieth tick empties it and reports the finish'
+  eq 0, t.seconds
+  eq false, t.running
+  eq false, t.visible, 'and it leaves the screen'
+  ok !t.tick, 'a stopped timer does not keep reporting'
+end
+
+check 'a timer only counts in battle when it carries the battle flag' do
+  t = Game::Timer.new
+  t.set(10)
+  t.start(true, false)
+  frames = t.frames
+  t.tick(true)
+  eq frames, t.frames, 'no battle flag: paused for the fight'
+  ok !t.drawn?(true), 'and hidden while it lasts'
+  ok t.drawn?(false), 'but shown again on the map'
+
+  t.in_battle = true
+  t.tick(true)
+  eq frames - 1, t.frames, 'with the flag it keeps counting'
+  ok t.drawn?(true), 'and keeps drawing'
+end
+
+check "Timer Operation addresses RPG2003's second timer through param5" do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::TIMER_OPERATION, [0, 0, 30]),           # timer 1 = 30 s
+    FakeCmd.new(IC::TIMER_OPERATION, [0, 0, 90, 0, 0, 1]),  # timer 2 = 90 s
+    FakeCmd.new(IC::TIMER_OPERATION, [1, 0, 0, 1, 1, 1]),   # start timer 2
+  ])
+  it.update
+  eq 30, st.timer(0).seconds
+  eq 90, st.timer(1).seconds
+  eq false, st.timer(0).running, 'the first timer was set but never started'
+  eq true, st.timer(1).running
+  eq true, st.timer(1).visible
+  eq true, st.timer(1).in_battle, 'param4 is the run-in-battle flag'
+  # RPG2000 data carries no sixth parameter, so it reads 0 and addresses the
+  # only timer that edition has.
+  eq 30, st.timer_seconds, 'the shorthand still means timer 1'
+end
+
+check 'Control Variables and Conditional Branch read the second timer' do
+  st = new_state
+  st.timer(0).set(10)
+  st.timer(1).set(50)
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 7, 1]),   # timer 1 secs
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 7, 9])])  # timer 2 secs
+  it.update
+  eq 10, st.variables[1]
+  eq 50, st.variables[2]
+
+  # Conditional type 10 is the second timer, laid out like type 2.
+  branch = lambda do |params|
+    [FakeCmd.new(IC::CONDITIONAL, params, indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 0, 1], indent: 1),
+     FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+     FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 0, 2], indent: 1),
+     FakeCmd.new(IC::END_BRANCH, [], indent: 0)]
+  end
+  it.start(branch.call([10, 40, 0])) # timer 2 at least 40 s
+  it.update
+  eq 1, st.variables[3]
+  it.start(branch.call([10, 40, 1])) # timer 2 at most 40 s
+  it.update
+  eq 2, st.variables[3]
+  it.start(branch.call([2, 40, 0]))  # timer 1 at least 40 s -> no
+  it.update
+  eq 2, st.variables[3], 'type 2 still reads the first timer'
 end
 
 # -- Memorize / Recall Location ----------------------------------------------
@@ -1466,6 +1553,25 @@ def party_state
                            max_hp: 50, max_mp: 20, atk: 6, def: 5),
   }
   Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2])), 1, 0, 0)
+end
+
+check 'both timers round-trip through the save; an old save still loads' do
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.timer(0).set(30); st.timer(0).start(true, true)
+  st.timer(1).set(90); st.timer(1).start(false, false)
+  loaded = Game::State.load(db, st.to_h)
+  eq 30, loaded.timer(0).seconds
+  eq true, loaded.timer(0).in_battle
+  eq 90, loaded.timer(1).seconds
+  eq false, loaded.timer(1).visible
+
+  # A save from before the second timer existed carries only the flat fields.
+  legacy = st.to_h
+  legacy.delete(:timers)
+  old = Game::State.load(db, legacy)
+  eq 30, old.timer(0).seconds, 'the first timer comes back from the old keys'
+  eq 0, old.timer(1).seconds, 'and the second starts empty'
 end
 
 check 'State save round-trips the message configuration' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -105,7 +105,11 @@ module RGSS
   end
 
   module Audio
-    def self.bgm_play(*); end
+    # Record bgm_play calls so BGM checks (the vehicle music, the Game Over
+    # screen) can assert which track started.
+    class << self; attr_accessor :bgm_calls; end
+    def self.bgm_play(*a); (@bgm_calls ||= []) << a; end
+    def self.reset_bgm; @bgm_calls = []; end
     def self.bgm_fade(*); end
     # Scriptable playback position, so the "BGM played once" watcher can be
     # driven: a value that jumps backwards is how SDL_mixer reports a loop.
@@ -169,7 +173,9 @@ def fake_db(common = nil, troop_pages = nil)
                            ship_music: OpenStruct.new(file: 'ShipBGM', volume: 80, pitch: 100),
                            airship_music: OpenStruct.new(file: 'AirBGM', volume: 80, pitch: 100),
                            cursor_se: OpenStruct.new(file: 'Cursor1', volume: 100, pitch: 100),
-                           decision_se: OpenStruct.new(file: 'Decision1', volume: 100, pitch: 100)),
+                           decision_se: OpenStruct.new(file: 'Decision1', volume: 100, pitch: 100),
+                           gameover_name: 'GameOver1',
+                           gameover_music: OpenStruct.new(file: 'GameOverBGM', volume: 90, pitch: 100)),
     # A second chipset (id 2) so Change Map Tileset has somewhere to swap to.
     chipset: { 1 => fake_chipset, 2 => fake_chipset('cs2') },
     # Terms the Show Inn window reads; blank greeting fields exercise the
@@ -278,6 +284,10 @@ class FakeParent
   # Return to Title Screen (12510) hands control back here; record that it fired.
   attr_reader :returned_to_title
   def return_to_title; @returned_to_title = true; end
+  # Game Over (12420) and a game-over battle defeat put up Scene::GameOver,
+  # which returns to the title once dismissed. Record that it was reached.
+  attr_reader :game_over_shown
+  def show_game_over; @game_over_shown = true; end
   # Open Save Menu (11910) saves through the app; record the calls.
   def saved; @saved ||= []; end
   def save_game(state); saved << state; true; end
@@ -1497,7 +1507,7 @@ check 'Enemy Encounter scene: a game-over defeat returns to the title' do
   # finish_battle wrote the wipe back to the party, then went to the title.
   ok st.party.all_dead?, 'the party was wiped out'
   parent = scene.instance_variable_get(:@parent)
-  ok parent.returned_to_title, 'a game-over defeat returns to the title screen'
+  ok parent.game_over_shown, 'a game-over defeat puts up the Game Over screen'
 end
 
 check 'Enemy Encounter scene: Flee (B on the first actor) runs Escape' do
@@ -1534,11 +1544,11 @@ check 'Enemy Encounter scene: a game-over defeat returns to the title' do
   scene.update
   battle_attack_to_end(scene) # the hero is worn down -> the defeat result shows
   parent = scene.instance_variable_get(:@parent)
-  ok !parent.returned_to_title, 'still on the defeat result, not yet game over'
+  ok !parent.game_over_shown, 'still on the defeat result, not yet game over'
   RGSS::Input.triggered = [RGSS::Input::C] # dismiss the defeat result
   scene.update
   RGSS::Input.triggered = []
-  ok parent.returned_to_title, 'a game-over defeat returned to the title'
+  ok parent.game_over_shown, 'a game-over defeat reached the Game Over screen'
   ok !st.switches[5], 'the rest of the event never ran'
 end
 
@@ -1554,10 +1564,56 @@ check 'Game Over event command returns to the title, abandoning the event' do
   parent = scene.instance_variable_get(:@parent)
   5.times do
     scene.update
-    break if parent.returned_to_title
+    break if parent.game_over_shown
   end
-  ok parent.returned_to_title, 'Game Over returned to the title'
+  ok parent.game_over_shown, 'Game Over put up the Game Over screen'
   ok !st.switches[5], 'the rest of the event never ran'
+end
+
+check 'the Game Over screen shows its picture, plays its BGM and waits' do
+  parent = fake_parent(fake_db)
+  Audio.reset_bgm
+  Input.reset
+  scene = RPG2k::Scene::GameOver.new(parent)
+  eq [['GameOverBGM', 90, 100]], Audio.bgm_calls, 'the database game-over music'
+  ok scene.instance_variable_get(:@picture).bitmap, 'the GameOver/ picture loaded'
+
+  scene.update
+  ok !parent.returned_to_title, 'it waits for a button'
+  Input.triggered = [Input::C]
+  scene.update
+  ok parent.returned_to_title, 'and then hands back to the title'
+  Input.reset
+end
+
+check 'a button still held from the battle does not skip the Game Over screen' do
+  parent = fake_parent(fake_db)
+  Input.reset
+  # The key that dismissed the defeat message is still down as the scene opens.
+  Input.triggered = [Input::C]
+  scene = RPG2k::Scene::GameOver.new(parent)
+  scene.update
+  ok !parent.returned_to_title, 'the held key is ignored'
+  Input.reset
+  scene.update                       # released: the screen arms
+  Input.triggered = [Input::C]
+  scene.update                       # pressed afresh
+  ok parent.returned_to_title, 'a fresh press dismisses it'
+  Input.reset
+end
+
+check 'a game with no game-over picture still reaches the screen' do
+  db = fake_db
+  db.system.gameover_name = ''
+  parent = fake_parent(db)
+  Input.reset
+  scene = RPG2k::Scene::GameOver.new(parent)
+  eq nil, scene.instance_variable_get(:@picture).bitmap, 'nothing to show'
+  scene.update
+  Input.triggered = [Input::B]
+  scene.update
+  ok parent.returned_to_title, 'and it still dismisses to the title'
+  Input.reset
 end
 
 check 'Change System Graphics reloads the windowskin from the override' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1965,12 +1965,13 @@ check 'the timer window shows M:SS while visible and hides when never shown' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)
   scene.update
-  ok scene.instance_variable_get(:@timer_window).nil?, 'no window until shown'
+  eq [nil, nil], scene.instance_variable_get(:@timer_windows),
+     'no window until shown'
   # Show a 75 s timer (Start with the show flag on).
   st.timer_frames = 75 * 60
   st.timer_visible = true
   scene.update
-  win = scene.instance_variable_get(:@timer_window)
+  win = scene.instance_variable_get(:@timer_windows)[0]
   ok win, 'the window is built on first display'
   ok win.visible, 'and shown'
   eq '1:15', win.contents.draw_calls.last[4], 'it draws the M:SS text'
@@ -1978,6 +1979,40 @@ check 'the timer window shows M:SS while visible and hides when never shown' do
   st.timer_visible = false
   scene.update
   ok !win.visible, 'clearing visibility hides the timer window'
+end
+
+check "RPG2003's second timer draws in its own window" do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  st.timer(1).set(30)
+  st.timer(1).start(true)
+  scene.update
+  wins = scene.instance_variable_get(:@timer_windows)
+  eq nil, wins[0], 'the first timer was never shown, so has no window'
+  ok wins[1], 'the second one does'
+  eq '0:30', wins[1].contents.draw_calls.last[4]
+  ok wins[1].x > (RPG2k::Scene::Map::SCREEN_W / 2),
+     'and sits to the right of the first, the way RPG_RT parks it'
+end
+
+check 'a timer without the battle flag pauses and hides for the fight' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  st.timer(0).set(30)
+  st.timer(0).start(true, false)  # visible, but not during battle
+  scene.update
+  ok scene.instance_variable_get(:@timer_windows)[0].visible
+
+  frames = st.timer(0).frames
+  scene.instance_variable_set(:@battle_ui, { phase: :command })
+  scene.update
+  eq frames, st.timer(0).frames, 'it stopped counting for the fight'
+  ok !scene.instance_variable_get(:@timer_windows)[0].visible, 'and is hidden'
+
+  st.timer(0).in_battle = true
+  scene.update
+  ok st.timer(0).frames < frames, 'with the battle flag it keeps counting'
+  ok scene.instance_variable_get(:@timer_windows)[0].visible, 'and drawing'
 end
 
 check 'boarding plays the vehicle BGM; disembarking restores the map BGM' do


### PR DESCRIPTION
Follow-up to #356. Two independent commits on one branch — the branch is fixed for this session, so follow-up work lands here rather than getting its own PR. They can be reviewed or reverted separately.

---

## 1. Add RPG2003's second timer, and fix two RPG_RT timer details

The countdown moves into a `Game::Timer` value object and `Game::State` holds two of them: RPG2000 has one timer, RPG2003 adds a second that the Timer Operation command selects with its sixth parameter. RPG2000 data never carries that parameter, so it reads 0 and addresses the only timer that edition has.

**The second timer** is readable everywhere the first one is — **Control Variables** operand 7 selector 9, and **Conditional Branch type 10**, which is laid out exactly like the existing timer test — and drawn in its own window to the right of the first. RPG_RT actually parks the pair at the screen's left and right edges as digit sprites blitted from the System graphic; drawing them that way is a rendering-parity job of its own, so this reuses the existing window widget for both and notes the difference.

**The battle flag.** The start operation's second parameter, "keep running in battle", is honoured. Without it a timer **pauses and hides** for the duration of a fight rather than being stopped, so it resumes where it left off afterwards.

**Two details this had wrong**, both corrected against EasyRPG's `Game_Party` timer block:

- **Set seeds `seconds * 60 + 59`**, not `seconds * 60`. The display shows `frames / 60`, so a timer seeded exactly dropped a second after a *single frame* instead of holding the number it was given for a whole second.
- **Stopping a timer hides it.** `StopTimer` clears the visible flag as well as the running one, and the countdown reaching zero goes through that same stop — which is how a finished timer leaves the screen instead of sitting at `0:00`. This runtime had taken the opposite reading ("a stopped timer stays on screen, frozen"), and the check that pinned that is updated with the provenance.

**Save compatibility.** Both timers persist. The save still writes the first timer's fields under their old names, so a save this build makes loads in one that predates the second timer; a save without the new `timers` key falls back to those fields. Checked in both directions.

---

## 2. Show the RPG2000 Game Over screen

Both routes RPG_RT reaches a game over by — the **Game Over** event command (12420) and a battle defeat whose encounter says "game over" rather than running a `[Defeat]` handler — dropped straight back to the title, so the run's ending was never shown.

`Scene::GameOver` fills the screen with the database's `GameOver/<name>` picture over its game-over music (System fields 18 and 38, both of which the two test-bed databases set) and returns to the title on a button press.

- **A held button cannot skip it.** The scene arms only once the key is released, so the press that dismissed the defeat message does not carry through the ending.
- **A missing picture does not break the defeat.** Nepheshel names `gameover`/`die` and ships the file; mtf-meido-action names `Game Over` but the file is not in the checkout. That second case is why the load is guarded — plain black with the failure logged, rather than the defeat failing.

---

## Testing

- `scripts/rpg2k_logic_check.rb` — 419 pass (5 new)
- `scripts/rpg2k_scene_check.rb` — 120 pass (5 new)
- `scripts/rpg2k_render_check.rb` — 36 pass
- `scripts/lcf_testbed_check.rb` — clean on both test beds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit