### PR TITLE
Resolve "this event" and honour a Show Choices cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too
+- A command that names **"this event"** rather than an event id resolves to the
+  event running it, on both sides: the scene already steered Move Event and
+  friends that way, and the interpreter now answers the reads too — the
+  orientation conditional branch, the Control Variables character operand and a
+  Call Event onto another of this event's pages. **Show Choices** honours its
+  cancel setting as well: the cancel key picks the choice the command names, or
+  runs its dedicated **[Cancel]** branch, and a block that forbids cancelling
+  swallows the key
 - A troop's **battle-event pages** run during a fight: their conditions (switch,
   variable, turn, enemy/actor HP, plus RPG2003's per-battler turn counters and
   party fatigue) are re-checked each turn, and a matching page runs the ordinary

--- a/changelog.d/rpg2k-show-choices-cancel.fixed.md
+++ b/changelog.d/rpg2k-show-choices-cancel.fixed.md
@@ -1,0 +1,11 @@
+- **Show Choices honours its cancel setting.** The command's first parameter —
+  the cancel behaviour, which the interpreter used to ignore — is a 1-based
+  option index: 0 forbids cancelling, 1..4 makes the cancel key pick that
+  choice, and 5 runs a dedicated **[Cancel] branch**. That branch is stored as a
+  *fifth* option (index 4) with an empty label, which the choice window was
+  drawing as a blank extra row that shifted the routing of every option after
+  it. Only options 0..3 are listed now (EasyRPG's `GetChoices(4)`), and
+  `Scene::Map` backs out of a cancellable choice on the cancel key, playing the
+  system cancel sound; a block with cancel type 0 swallows the key as RPG_RT
+  does. 336 of Nepheshel's 349 choice blocks are cancellable and 27 carry a
+  [Cancel] branch that was previously unreachable.

--- a/changelog.d/rpg2k-this-event-refs.fixed.md
+++ b/changelog.d/rpg2k-this-event-refs.fixed.md
@@ -1,0 +1,12 @@
+- **"This event" (0 / 10005) now resolves on the read side of an event
+  command.** The write-side commands (Move Event, Change Event Location, Flash
+  Sprite) already reached the running event through the scene, but the commands
+  the interpreter answers itself did not: a **Conditional Branch** orientation
+  test on this event was always false, the **Control Variables** character
+  operand read its position as 0, and a **Call Event** naming another page of
+  this event silently did nothing. `Game::Interpreter#event_id` carries the
+  running map event's id (nil for a common event or a battle page, where RPG_RT
+  also has no "this event"), and every character reference goes through
+  `#character_ref` before it is looked up. Measured on the real Nepheshel data,
+  that is 223 of its 233 orientation branches, 239 of its 246 character-position
+  reads and 17 of its 33 map-event calls.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -425,6 +425,31 @@ The work below is roughly ordered by the critical path to a walkable game
   Three opcodes that never matched liblcf's `Code` enum were corrected in the
   same pass — Change Equipment is 10450 (10440 is Change Skills) and Game Over is
   12420 — so those commands are recognised in real game data at all.
+  **Coverage is measured per opcode, though, not per parameter combination**, and
+  the next pass closed two gaps a dispatched-but-partial handler was hiding —
+  both found by tallying the *parameter* modes the real Nepheshel data uses
+  against what each handler actually branches on:
+  - **"This event" (0 / 10005) now resolves on the read side.** The write-side
+    commands (Move Event, Change Event Location, Flash Sprite) queue their raw
+    target for the scene, which knows which event it is stepping, so those always
+    worked. The commands the interpreter answers itself did not: a **Conditional
+    Branch** orientation test on this event was always false (223 of Nepheshel's
+    233), the **Control Variables** character operand read its position as 0 (239
+    of 246) and a **Call Event** naming another page of this event silently did
+    nothing (17 of 33). `Game::Interpreter#event_id` now carries the running map
+    event's id — set by `Scene::Map` beside `map_info`, and re-attached on every
+    lap of a parallel process — and every character reference goes through
+    `#character_ref`. It is nil for a common event and a battle page, which have
+    no "this event" in RPG_RT either, so such a reference resolves to nothing.
+  - **Show Choices honours its cancel setting.** param0 is the cancel behaviour
+    as a 1-based option index: 0 forbids cancelling, 1..4 makes the cancel key
+    pick that choice, 5 runs a dedicated **[Cancel] branch** — which the editor
+    stores as a *fifth* option (index 4) with an empty label. It was being drawn
+    as a blank extra row that shifted the routing of every option below it. Only
+    options 0..3 are listed now (EasyRPG's `GetChoices(4)`), and `Scene::Map`
+    backs out of a cancellable choice on the cancel key with the system cancel
+    sound. 336 of Nepheshel's 349 choice blocks are cancellable; 27 carry a
+    [Cancel] branch that could not be reached before.
   **The RPG2003-only commands are handled now as well** — the low opcodes the
   2003 editor emits for what RPG2000 never had, none of which had a handler
   while the opcode table stopped at the shared set. **Change Class** (1008)

--- a/docs/rpg2000-sample-analysis.md
+++ b/docs/rpg2000-sample-analysis.md
@@ -87,6 +87,15 @@ exercises the commands its author reached for — `ChangeMonsterHP` (13110) and
 `TerminateBattle` (13410) never appear in Nepheshel, so they remain
 fixture-tested only.
 
+The first caveat is not hypothetical: tallying the *parameter* signatures behind
+each opcode (the same walk, grouped by `param(0..n)` instead of by code) turned
+up two commands that dispatched to a handler and still did the wrong thing —
+a "this event" (10005) character reference the read-side handlers could not
+resolve, and Show Choices ignoring its cancel setting, including the [Cancel]
+branch the editor stores as a fifth, blank-labelled option. Both are fixed; see
+the event-command interpreter entry in `docs/TODO.md`. A per-opcode 100 % is
+where that audit *starts*, not where it ends.
+
 ## The collection
 
 39 game projects plus two index files:

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -157,6 +157,21 @@ module Game
       PLAY_SOUND     = 35 # + file name (string) + volume, tempo, balance
     end
 
+    # Character reference ids a command uses instead of a map event id, from
+    # liblcf's `Game_Character::CharPlayer..CharThisEvent` (10002-10004, the
+    # three vehicle slots, sit between them and are only recognised by the scene,
+    # which owns the vehicles). **This event** is the event whose page is running
+    # the command list: the editor writes 10005, and a bare 0 means the same
+    # thing (RPG_RT's `GetCharacter` maps both), which is why every reference
+    # goes through #character_ref before it is looked up.
+    CHAR_PLAYER     = 10001
+    CHAR_THIS_EVENT = 10005
+
+    # Show Choices holds at most four selectable options; a fifth (index 4) is
+    # the optional [Cancel] branch, which is a jump target only and is never
+    # drawn in the window. Mirrors EasyRPG's `GetChoices(4)`.
+    MAX_CHOICES = 4
+
     # Upper bound on nested Call Event depth, so a common event that (directly or
     # indirectly) calls itself unwinds instead of growing the stack without end.
     MAX_CALL_DEPTH = 100
@@ -196,7 +211,7 @@ module Game
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
                 :teleport, :input_digits, :key_input_request, :inn_request,
                 :shop_request, :battle_request, :name_input_request,
-                :battle_animation
+                :battle_animation, :choice_cancel_type
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
@@ -214,6 +229,18 @@ module Game
     # `terrain_id(x, y)` and `event_id_at(x, y)`. Set by the owning scene; nil
     # makes those commands store 0 (the map is not queryable without it).
     attr_accessor :map_info
+    # The id of the map event whose page this interpreter is running, which is
+    # what a "this event" (0 / 10005) character reference resolves to. Set by the
+    # owning scene alongside #map_info; nil for a common event and for a battle
+    # page, neither of which has a map character of its own — a "this event"
+    # reference then resolves to nothing, exactly as it does in RPG_RT.
+    #
+    # The *write*-side commands (Move Event, Change Event Location, Flash Sprite)
+    # pass their raw target on to the scene, which already knows which event it
+    # is stepping. The read-side ones — Conditional Branch orientation, the
+    # Control Variables character operand and a Call Event naming a map event —
+    # are answered here, so they need the id too.
+    attr_accessor :event_id
 
     def start(commands)
       @list = commands || []
@@ -239,6 +266,11 @@ module Game
       # looping parallel process) never inherits the previous event's trigger;
       # the scene sets it again right after #start for an action-key event.
       @triggered_by_decision_key = false
+      # Cleared for the same reason as the trigger above: the shared foreground
+      # interpreter runs one event after another, and a stale id would answer a
+      # common event's "this event" reference with the last map event's position.
+      # The scene sets it again right after #start.
+      @event_id = nil
       # Messages queued by a stat command (a Change Level / Change EXP with its
       # "show message" flag set) and shown one after another before the event
       # continues. Drained by #resume, so it survives the reset_waits between
@@ -458,6 +490,25 @@ module Game
       reset_waits
     end
 
+    # Whether the cancel key may back out of the choice now on screen — false
+    # when nothing is being chosen, or when the block forbids cancelling
+    # (cancel type 0), where RPG_RT simply ignores the key.
+    def choice_cancellable?
+      @wait_kind == :choice && @choice_cancel_type > 0
+    end
+
+    # Cancel the choice on screen. Every allowed cancel type names an option in
+    # the same 1-based numbering, so cancelling is just picking option
+    # `type - 1`: type 2 of a two-option block picks the second choice, and
+    # type 5 picks option index 4, the [Cancel] branch. Returns false (and does
+    # nothing) when cancelling is not allowed, so the scene can leave the window
+    # up on the key.
+    def cancel_choice
+      return false unless choice_cancellable?
+      choose(@choice_cancel_type - 1)
+      true
+    end
+
     # Resume an Input Number request: store the entered `value` into the target
     # variable and continue. The owning scene drives a digit-entry widget while
     # the interpreter is paused on the :number wait, then calls this with the
@@ -625,6 +676,9 @@ module Game
       @wait_kind = nil
       @message_lines = nil
       @choice_labels = nil
+      # 0 = cancelling forbidden, which is also the right answer while nothing
+      # is being chosen (see #choice_cancellable?).
+      @choice_cancel_type = 0
       @wait_frames = 0
       @teleport = nil
       @key_input_request = nil
@@ -774,6 +828,10 @@ module Game
     #   0 – common event: param1 = common event id
     #   1 – map event:    param1 = event id, param2 = page number
     #   2 – map event, ids taken indirectly from variables
+    # The map-event id may be a "this event" reference (0 / 10005), which calls
+    # another page of the event already running — RPG_RT resolves the id through
+    # the same `GetCharacter` every other character reference uses, so a game can
+    # keep a page of shared subroutine commands on the event itself.
     # A missing/empty target is a no-op; recursion is bounded by MAX_CALL_DEPTH.
     def do_call_event(cmd)
       return unless @resolver
@@ -788,12 +846,31 @@ module Game
     def resolve_call(cmd)
       case cmd.param(0)
       when 0 then @resolver.common_event_commands(cmd.param(1))
-      when 1 then @resolver.map_event_commands(cmd.param(1), cmd.param(2))
-      when 2 then @resolver.map_event_commands(variables[cmd.param(1)],
-                                               variables[cmd.param(2)])
+      when 1 then map_event_call(cmd.param(1), cmd.param(2))
+      when 2 then map_event_call(variables[cmd.param(1)],
+                                 variables[cmd.param(2)])
       end
     rescue StandardError
       nil
+    end
+
+    # The command list of a map event's page, with the event id resolved through
+    # #character_ref so "this event" reaches the running event. An unresolvable
+    # reference (a common event calling "this event") has no page to run.
+    def map_event_call(event_ref, page)
+      id = character_ref(event_ref)
+      return nil if id.nil?
+      @resolver.map_event_commands(id, page)
+    end
+
+    # Translate a command's character reference into the map event id the scene
+    # can look up. "This event" (0 or 10005) becomes the id of the event running
+    # this command list — nil when there is none (a common event, a battle page).
+    # Every other reference, including the hero and the vehicle slots, passes
+    # through untouched for the caller to recognise.
+    def character_ref(ref)
+      return @event_id if ref == 0 || ref == CHAR_THIS_EVENT
+      ref
     end
 
     # -- flow helpers ---------------------------------------------------------
@@ -893,19 +970,31 @@ module Game
       end
     end
 
+    # Show Choices: collect the block's option labels and suspend on a :choice
+    # wait the owning scene answers with #choose (or #cancel_choice).
+    #
+    # param0 is the **cancel behaviour**, stored as a 1-based option index:
+    # 0 forbids cancelling, 1..4 makes the cancel key pick that choice (the
+    # editor's "「はい」/「いいえ」" default), and 5 runs a dedicated [Cancel]
+    # branch — which the editor writes as a *fifth* option, index 4, with an
+    # empty label. That branch is a jump target only: only options 0..3 are ever
+    # drawn (EasyRPG's `GetChoices(4)`), or the cancel branch would show up as a
+    # blank extra row and shift every label below it.
     def do_show_choices(cmd)
       labels = []
       i = @index
       while i < @list.size
         c = @list[i]
         break if c.indent == cmd.indent && c.code == Cmd::CHOICE_END
-        if c.indent == cmd.indent && c.code == Cmd::CHOICE_OPTION
+        if c.indent == cmd.indent && c.code == Cmd::CHOICE_OPTION &&
+           c.param(0) < MAX_CHOICES
           labels[c.param(0)] = c.string
         end
         i += 1
       end
       @choice_indent = cmd.indent
       @choice_labels = labels.compact
+      @choice_cancel_type = cmd.param(0)
       @wait_kind = :choice
       @waiting = true
     end
@@ -1118,16 +1207,18 @@ module Game
     end
 
     # Operand type 6: a positional value of a character. param5 selects it (10001
-    # the hero / party, a positive id a map event); param6 the value (0 map id,
-    # 1 x tile, 2 y tile, 3 facing in RPG2000's 2/4/6/8 numpad convention,
-    # 4 screen x, 5 screen y). Matching a long-standing RPG_RT quirk, a *map
-    # event's* map id reads 0. An unresolvable reference (no map_info hook,
-    # unknown event) reads 0.
+    # the hero / party, "this event" as 0 / 10005, any other positive id a map
+    # event); param6 the value (0 map id, 1 x tile, 2 y tile, 3 facing in
+    # RPG2000's 2/4/6/8 numpad convention, 4 screen x, 5 screen y). Matching a
+    # long-standing RPG_RT quirk, a *map event's* map id reads 0. An unresolvable
+    # reference (no map_info hook, unknown event, "this event" outside a map
+    # event) reads 0.
     def event_operand(cmd)
-      ref = cmd.param(5)
+      ref = character_ref(cmd.param(5))
       attr = cmd.param(6)
       return screen_operand(ref, attr) if attr == 4 || attr == 5
-      if ref == 10001 # the hero / party leader
+      return 0 if ref.nil?
+      if ref == CHAR_PLAYER # the hero / party leader
         case attr
         when 0 then @state.map_id
         when 1 then @state.x
@@ -1152,8 +1243,10 @@ module Game
     # The screen-coordinate selectors of operand 6 (attr 4 x / 5 y): where the
     # character currently sits in the view, which only the map scene can answer
     # because it owns the camera. Without that hook (a headless interpreter, or a
-    # battle page) there is no view to measure against, so it reads 0.
+    # battle page) there is no view to measure against, so it reads 0. `ref` has
+    # already been through #character_ref, so "this event" arrives as a real id.
     def screen_operand(ref, attr)
+      return 0 if ref.nil?
       return 0 unless @map_info.respond_to?(:character_screen_position)
       pos = @map_info.character_screen_position(ref)
       return 0 unless pos
@@ -1826,8 +1919,9 @@ module Game
         cmd.param(2) == 0 ? has : !has
       when 5 # actor: param1 id, param2 sub-condition (see actor_condition)
         actor_condition(cmd)
-      when 6 # orientation: is character param1 (10001 the hero, a positive id a
-             # map event) facing direction param2 (0 up / 1 right / 2 down / 3 left)?
+      when 6 # orientation: is character param1 (10001 the hero, 0 / 10005 this
+             # event, any other positive id a map event) facing direction param2
+             # (0 up / 1 right / 2 down / 3 left)?
         facing = character_facing(cmd.param(1))
         !facing.nil? && facing == FACING_NUMPAD[cmd.param(2)]
       when 7 # vehicle: true when the party is riding vehicle param1 (0 boat /
@@ -1847,13 +1941,16 @@ module Game
     FACING_NUMPAD = [8, 6, 2, 4].freeze
 
     # The numpad facing (2/4/6/8) of the character referenced by `ref` (10001 the
-    # hero, a positive id a map event), or nil when it can't be resolved (no
-    # map_info, an unknown event, or a still-unmodelled this-event / vehicle ref).
+    # hero, 0 / 10005 this event, any other positive id a map event), or nil when
+    # it can't be resolved (no map_info, an unknown event, a "this event" outside
+    # a map event, or a still-unmodelled vehicle ref).
     def character_facing(ref)
-      if ref == 10001
+      id = character_ref(ref)
+      return nil if id.nil?
+      if id == CHAR_PLAYER
         @state.direction
-      elsif ref > 0 && ref < 10000 && @map_info.respond_to?(:event_position)
-        pos = @map_info.event_position(ref)
+      elsif id > 0 && id < 10000 && @map_info.respond_to?(:event_position)
+        pos = @map_info.event_position(id)
         pos && pos[:direction]
       end
     end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1017,6 +1017,7 @@ class RPG2k
           @started_auto[ev[:id]] = true
           @active_event = ev
           @interpreter.start(ev[:commands])
+          @interpreter.event_id = ev[:id]
           return
         end
 
@@ -1062,6 +1063,7 @@ class RPG2k
         it.resolver = @interpreter.resolver
         it.map_info = self
         it.start(commands)
+        it.event_id = event && event[:id]
         { interp: it, commands: commands, gate_switch: gate_switch,
           wait_timer: nil, event: event }
       end
@@ -1086,6 +1088,10 @@ class RPG2k
           it.update
         else
           it.start(p[:commands]) # loop the process
+          # #start clears the "this event" id, so re-attach it on every lap or
+          # the second pass would answer the process's own position queries with
+          # nothing.
+          it.event_id = p[:event] && p[:event][:id]
           it.update
         end
         apply_interpreter_requests(it, p[:event])
@@ -1123,6 +1129,7 @@ class RPG2k
         @active_event = ev
         @interpreter.start(ev[:commands])
         @interpreter.triggered_by_decision_key = by_decision_key
+        @interpreter.event_id = ev[:id]
       end
 
       # On the action button, run the trigger-0 event the player is facing. The
@@ -3889,6 +3896,13 @@ class RPG2k
             index = @choice_index
             close_message
             @interpreter.choose(index)
+          elsif Input.trigger?(Input::B) && @interpreter.choice_cancellable?
+            # The Show Choices block says what cancelling means (pick a given
+            # choice, or run its [Cancel] branch); a block that forbids it
+            # swallows the key, as RPG_RT does.
+            play_system_se(SFX_CANCEL)
+            close_message
+            @interpreter.cancel_choice
           end
         else
           drive_text_message

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -738,6 +738,87 @@ check 'interpreter pauses on a message and resumes' do
   eq true, st.switches[2] # ran the command after the message
 end
 
+# -- Show Choices -------------------------------------------------------------
+
+# A Show Choices block: `cancel` is the command's cancel type, `options` the
+# option indices to emit (the editor writes 0..3 for the drawn choices and 4 for
+# the optional [Cancel] branch). Each branch sets switch `10 + index`, and the
+# command after the block sets switch 1, so a run says which branch was taken
+# and whether control came back.
+def choice_block(cancel, options)
+  cmds = [FakeCmd.new(IC::SHOW_CHOICES, [cancel], indent: 0)]
+  options.each do |i|
+    cmds << FakeCmd.new(IC::CHOICE_OPTION, [i], indent: 0,
+                                                string: i == 4 ? '' : "opt#{i}")
+    cmds << FakeCmd.new(IC::CONTROL_SWITCHES, [0, 10 + i, 10 + i, 0], indent: 1)
+  end
+  cmds << FakeCmd.new(IC::CHOICE_END, [], indent: 0)
+  cmds << FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 0)
+  cmds
+end
+
+def run_choice(cancel, options)
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start(choice_block(cancel, options))
+  it.update
+  [st, it]
+end
+
+check 'Show Choices lists its options and routes the chosen branch' do
+  st, it = run_choice(0, [0, 1, 2])
+  ok it.waiting?, 'Show Choices must pause the interpreter'
+  eq :choice, it.wait_kind
+  eq %w[opt0 opt1 opt2], it.choice_labels
+  it.choose(1)
+  it.update
+  eq true, st.switches[11], 'the second branch ran'
+  eq true, st.switches[1], 'and control returned after the block'
+end
+
+check 'Show Choices hides the [Cancel] branch from the drawn options' do
+  # Cancel type 5 stores the cancel branch as a fifth option (index 4) with an
+  # empty label. It is a jump target only — drawing it would add a blank row and
+  # shift every label after it.
+  _st, it = run_choice(5, [0, 1, 4])
+  eq %w[opt0 opt1], it.choice_labels
+end
+
+check 'Show Choices cancel type picks the option it names' do
+  # 0 = cancelling forbidden: the key is swallowed and the choice stays up.
+  st, it = run_choice(0, [0, 1])
+  eq false, it.choice_cancellable?
+  eq false, it.cancel_choice
+  ok it.waiting?, 'a non-cancellable choice stays on screen'
+  eq false, st.switches[1]
+
+  # 1..4 = cancel picks that choice (1-based), the editor's usual "no thanks".
+  st, it = run_choice(2, [0, 1])
+  ok it.choice_cancellable?
+  ok it.cancel_choice
+  it.update
+  eq true, st.switches[11], 'cancel picked the second choice'
+  eq true, st.switches[1]
+
+  # 5 = cancel runs the dedicated [Cancel] branch, stored at option index 4.
+  st, it = run_choice(5, [0, 1, 4])
+  ok it.cancel_choice
+  it.update
+  eq true, st.switches[14], 'cancel ran the [Cancel] branch'
+  eq false, st.switches[10]
+  eq false, st.switches[11]
+  eq true, st.switches[1]
+end
+
+check 'cancelling is only offered while a choice is on screen' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_MESSAGE, [], string: 'hello')])
+  it.update
+  eq false, it.choice_cancellable?, 'a plain message is not a choice'
+  eq false, it.cancel_choice
+end
+
 # -- Message Options / Change Face Graphic ------------------------------------
 
 check 'Message Options sets window position, transparency and continue flag' do
@@ -872,6 +953,33 @@ check 'Call Event with no resolver set is a safe no-op' do
             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
   it.update
   eq true, st.switches[1]
+end
+
+check 'Call Event runs another page of "this event" (map target 10005 / 0)' do
+  page2 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  [10005, 0].each do |ref|
+    st = new_state
+    it = Game::Interpreter.new(st)
+    it.resolver = FakeResolver.new(maps: { 7 => { 2 => page2 } })
+    it.start([FakeCmd.new(IC::CALL_EVENT, [1, ref, 2]),
+              FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+    it.event_id = 7 # the list belongs to map event 7
+    it.update
+    eq true, st.switches[9], "page 2 of this event ran (ref #{ref})"
+    eq true, st.switches[1], 'control returned to the caller'
+  end
+end
+
+check 'Call Event on "this event" from a common event is a no-op' do
+  st = new_state
+  page2 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(maps: { 7 => { 2 => page2 } })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [1, 10005, 2]),  # no event is running it
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq false, st.switches[9], 'there is no "this event" to call'
+  eq true, st.switches[1], 'and the caller carries on'
 end
 
 check 'Erase Event sets a one-shot request without pausing the interpreter' do
@@ -2605,6 +2713,35 @@ check 'Control Variables reads a map event position (operand type 6)' do
   eq 0, st.variables[5]                                          # unknown event reads 0
 end
 
+check 'Control Variables reads "this event" (operand 6, ref 10005 / 0)' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new                                  # event 7 at (2,3) dir 6
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 10005, 1]),  # this x
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 6, 10005, 2]),  # this y
+            FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 6, 0, 3]),      # this facing
+            FakeCmd.new(IC::CONTROL_VARS, [0, 4, 4, 0, 6, 10005, 4])]) # this screen x
+  it.event_id = 7 # the list belongs to map event 7
+  it.update
+  eq 2, st.variables[1]
+  eq 3, st.variables[2]
+  eq 6, st.variables[3]  # a bare 0 names this event too
+  eq 40, st.variables[4] # measured through the same camera hook as any event
+end
+
+check 'Control Variables "this event" reads 0 without a running map event' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 10005, 1]),
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 6, 10005, 4])])
+  st.variables[1] = 99
+  st.variables[2] = 99
+  it.update # a common event: no "this event" to resolve
+  eq 0, st.variables[1]
+  eq 0, st.variables[2]
+end
+
 check 'Control Variables reads an actor stat (operand type 5)' do
   st = party_state
   a = st.party.actor_by_id(1) # atk 10, max_hp 100
@@ -2701,8 +2838,9 @@ def run_actor_cond(params, string: '')
 end
 
 # Like run_actor_cond but with a FakeMapInfo hook set (event 7 at (2,3) dir 6),
-# for conditions that read map events.
-def run_cond_with_mapinfo(params)
+# for conditions that read map events. `event_id` says which map event is
+# running the list, which is what a "this event" reference resolves to.
+def run_cond_with_mapinfo(params, event_id: nil)
   st = party_state
   it = Game::Interpreter.new(st)
   it.map_info = FakeMapInfo.new
@@ -2711,6 +2849,7 @@ def run_cond_with_mapinfo(params)
             FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
             FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
             FakeCmd.new(IC::END_BRANCH, [], indent: 0)])
+  it.event_id = event_id
   it.update
   st
 end
@@ -2920,6 +3059,15 @@ check 'Conditional Branch: character orientation (type 6)' do
   eq true, run_cond_with_mapinfo([6, 7, 1]).switches[1]  # event faces right
   eq true, run_cond_with_mapinfo([6, 7, 0]).switches[2]  # not facing up -> else
   eq true, run_cond_with_mapinfo([6, 9, 1]).switches[2]  # unknown event -> else
+end
+
+check 'Conditional Branch orientation: "this event" (type 6, ref 10005 / 0)' do
+  # The event running the list is event 7, which FakeMapInfo faces right.
+  eq true, run_cond_with_mapinfo([6, 10005, 1], event_id: 7).switches[1]
+  eq true, run_cond_with_mapinfo([6, 10005, 0], event_id: 7).switches[2] # not up
+  eq true, run_cond_with_mapinfo([6, 0, 1], event_id: 7).switches[1] # 0 is the same ref
+  # A common event has no "this event", so the test cannot hold.
+  eq true, run_cond_with_mapinfo([6, 10005, 1]).switches[2]
 end
 
 # -- Input Number -------------------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -420,6 +420,31 @@ check 'parallel (trigger 4): a background event runs every frame' do
   ok v >= 8, "parallel event should have looped ~10 times, got #{v}"
 end
 
+check 'an auto-start event reads its own position ("this event", ref 10005)' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Control Variables: variable 1 = this event's x, variable 2 = its y.
+  auto.event_commands = [ECmd.new(ic::CONTROL_VARS, [0, 1, 1, 0, 6, 10005, 1]),
+                         ECmd.new(ic::CONTROL_VARS, [0, 2, 2, 0, 6, 10005, 2])]
+  scene = new_scene({ 4 => event(6, 3, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  5.times { scene.update }
+  eq 6, st.variables[1], 'this event\'s x'
+  eq 3, st.variables[2], 'this event\'s y'
+end
+
+check 'a parallel process keeps its "this event" id across laps' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4)
+  par.event_commands = [ECmd.new(ic::CONTROL_VARS, [0, 1, 1, 0, 6, 10005, 1])]
+  scene = new_scene({ 9 => event(7, 2, par) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  # Several laps: the interpreter restarts its list each time, which must not
+  # drop the id the reference resolves through.
+  10.times { scene.update }
+  eq 7, st.variables[1], 'the parallel event still knows its own x'
+end
+
 check 'parallel common event runs only while its switch gate is on' do
   ce = OpenStruct.new(start_term: 4, need_flag: true, switch_id: 2,
                       event: [add_var_cmd(3)])
@@ -850,6 +875,55 @@ check 'a message types out gradually, then a button completes and dismisses it' 
   ok !scene.instance_variable_get(:@message), 'message dismissed'
   5.times { RGSS::Input.reset; scene.update }
   ok st.switches[1], 'the interpreter resumed and ran the next command'
+end
+
+check 'the cancel key backs out of a Show Choices, per its cancel type' do
+  ic = Game::Interpreter::Cmd
+  # Cancel type 5: the block carries a [Cancel] branch as option index 4 (an
+  # empty label the window must not draw), which the cancel key runs.
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_CHOICES, [5], indent: 0),
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::CHOICE_OPTION, [4], indent: 0, string: ''),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'the choice window opened'
+  eq 1, msg[:count], 'only the drawn option is listed, not the [Cancel] branch'
+
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  ok !scene.instance_variable_get(:@message), 'cancel closed the choice window'
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[2], 'the [Cancel] branch ran'
+  ok !st.switches[1], 'and the drawn option did not'
+end
+
+check 'a Show Choices that forbids cancelling swallows the cancel key' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_CHOICES, [0], indent: 0), # cancel type 0
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'the choice window opened'
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  ok scene.instance_variable_get(:@message), 'the choice stayed on screen'
+  parent = scene.instance_variable_get(:@parent)
+  ok parent.pushed.empty?, 'and the cancel key did not leak to the main menu'
 end
 
 check 'a \\! pause holds the reveal until a button is pressed' do


### PR DESCRIPTION
Per-opcode coverage of Nepheshel's 184,166 event commands has been 100% for a
while, but that only says each command reaches a handler — not that the handler
reads every parameter mode the game uses. Tallying the parameter signatures
behind each opcode against what each handler branches on turned up two commands
that dispatched and still did the wrong thing.

"This event" (0 / 10005) only worked on the write side. Move Event, Change
Event Location and Flash Sprite queue their raw target for the scene, which
knows which event it is stepping. The commands the interpreter answers itself
had no way to identify the running event, so a Conditional Branch orientation
test on this event was always false (223 of Nepheshel's 233), the Control
Variables character operand read its position as 0 (239 of 246), and a Call
Event onto another page of this event silently did nothing (17 of 33).
Game::Interpreter#event_id now carries the running map event's id — set by
Scene::Map beside map_info, and re-attached on every lap of a parallel process,
whose interpreter restarts its list each time — and every character reference
goes through #character_ref. It is nil for a common event and a battle page,
which have no "this event" in RPG_RT either.

Show Choices ignored its first parameter, the cancel behaviour: a 1-based
option index where 0 forbids cancelling, 1..4 make the cancel key pick that
choice, and 5 runs a dedicated [Cancel] branch. The editor stores that branch
as a fifth option (index 4) with an empty label, which the window was drawing
as a blank extra row that shifted the routing of every option below it. Only
options 0..3 are listed now (EasyRPG's GetChoices(4)), and Scene::Map backs out
of a cancellable choice on the cancel key with the system cancel sound. 336 of
Nepheshel's 349 choice blocks are cancellable; 27 carry a [Cancel] branch that
could not be reached before.

Covered by new checks in scripts/rpg2k_logic_check.rb (423 pass) and
scripts/rpg2k_scene_check.rb (119 pass), and replayed over the real Nepheshel
data: every choice block now draws only real labels, all 27 cancel branches
route, and the whole command corpus runs with no handler raising.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D