### PR TITLE
Make the RGSS script host switchable, and say what stops it booting

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@
   (`Data/Scripts.rxdata`) unmodified — the way `RGSS104E.dll` does — instead of
   the reimplemented flow: it decompresses the ~90 Ruby sections, supplies the
   `load_data`/`save_data` built-ins and evaluates each at the top level (via
-  `mruby-eval`) so the game drives itself. It is opt-in (`RGSS_SCRIPT_HOST`)
-  while the RGSS class library is completed; see
+  `mruby-eval`) so the game drives itself. It is opt-in
+  (`--rgss_script_host`) while the RGSS class library is completed; see
   [`docs/adr/0017-rpgxp-rgss-script-host.md`](docs/adr/0017-rpgxp-rgss-script-host.md)
   (data layer: [`docs/adr/0010-rpgxp-rgss-data-layer.md`](docs/adr/0010-rpgxp-rgss-data-layer.md))
 - An XP project is exercised **against the genuine runtime as well as our own**,
@@ -201,7 +201,7 @@
 - The window is sized to VX's native 544×416 automatically
 - A VX/VX Ace game's engine *is* its script bundle, so a project that ships
   `Data/Scripts.rvdata[2]` can be driven by the same experimental **RGSS script
-  host** as XP (`RGSS_SCRIPT_HOST`); the built-in title/map flow is not written
+  host** as XP (`--rgss_script_host`); the built-in title/map flow is not written
   yet, and a boot without the host says so rather than opening a blank window.
   See
   [`docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md`](docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md)

--- a/changelog.d/rgss-script-host-flag.fixed.md
+++ b/changelog.d/rgss-script-host-flag.fixed.md
@@ -1,0 +1,15 @@
+- The **RGSS script host can actually be turned on**. Every document named
+  `RGSS_SCRIPT_HOST=1` as the opt-in, and it could never have worked: this mruby
+  build has no `ENV` (no `mruby-env` gem is vendored or configured), so
+  `ScriptHost.enabled?` returned false in every built engine, on every target,
+  and the host never ran. Only the CRuby harnesses — where `ENV` does exist —
+  ever exercised the switch, which is why the dead opt-in went unnoticed. The new
+  `--rgss_script_host` flag is published to the Ruby side as a constant, the way
+  `--rpgxp_new_game` already is; the environment variable is still honoured for
+  the harnesses.
+- A script-host boot failure now names the **section** that raised
+  (`section "Sprite_Character" raised NameError: ...`) instead of only the
+  exception, so a failure reads as a report about which part of the RGSS class
+  library is missing. Re-raised explicitly, because a bare `raise` in a rescue
+  loses the exception in this mruby build — the caller had been reporting an
+  empty `RuntimeError`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -891,13 +891,22 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   exposes `read_object`/`save_object`/`scripts`, and `RPGXP::ScriptHost`
   installs the Kernel `load_data`/`save_data` built-ins and evaluates every
   section at the top level (mruby-eval) so "Main" drives the game. Boot runs the
-  host when it is enabled (`RGSS_SCRIPT_HOST`, off by default) and the project
+  host when it is enabled (`--rgss_script_host`, off by default) and the project
   ships scripts, falling back to the built-in flow otherwise. Decoding, the
   built-ins and top-level evaluation of real script source are covered by
-  `mruby-rpgxp/test` and `scripts/rpgxp_script_host_check.rb`. Remaining before
+  `mruby-rpgxp/test` and `scripts/rpgxp_script_host_check.rb`. **The switch was
+  dead until now** — it was an `RGSS_SCRIPT_HOST` environment variable, and this
+  mruby has no `ENV`, so no built engine could ever turn the host on and it had
+  never run outside the CRuby harnesses. With `--rgss_script_host` it does, and a
+  boot failure names the section that raised. Remaining before
   it can be the default: complete the `mruby-rgss` class library the stock
-  scripts call — the precise gap (measured against the real test-bed scripts) is
-  tracked in [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md). `Font`,
+  scripts call — the precise gap (now *measured* by booting, not counted) is
+  tracked in [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md). The first
+  thing that stops the game's own engine is **`RPG::Sprite`**, which the script
+  bundle does not define (`RGSS104E.dll` supplies it, with `RPG::Weather`), so
+  `Sprite_Character < RPG::Sprite` is the first line that cannot run; most of
+  what it needs already exists as `Game::Animation` and the map scene's cell
+  blitting, written for Show Animation (207). `Font`,
   `Graphics` timing, `Input` and `Audio` are already covered; the open pieces are
   `Sprite` extended properties, and the empty `Window` / `Tilemap` / `Plane`
   widgets, plus `Kernel#sprintf`. (`Graphics.freeze`/`transition` now draw, on

--- a/docs/adr/0017-rpgxp-rgss-script-host.md
+++ b/docs/adr/0017-rpgxp-rgss-script-host.md
@@ -57,7 +57,7 @@ mruby's own `eval`, against the native `mruby-rgss` class library.
   project ships scripts; otherwise it uses the ADR 0010 built-in flow, which is
   also the fallback if the host fails to boot.
 
-**The host is opt-in for now** (the `RGSS_SCRIPT_HOST` env var, read by
+**The host is opt-in for now** (the `--rgss_script_host` flag, read by
 `ScriptHost.enabled?`),
 defaulting off, for three reasons: it cannot be built or run in the current CI
 sandbox (no SDL/mruby binary), the `mruby-rgss` class library is not yet

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -41,6 +41,36 @@ These are complete enough for the stock scripts:
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
+### 0. `RPG::Sprite` and `RPG::Weather` ❌ (the first thing that stops a boot)
+
+Measured, not counted: with `--rgss_script_host` the test bed now gets 21
+sections in before
+
+```
+[RGSS] script host: section "Sprite_Character" raised NameError: uninitialized constant RPG::Sprite
+```
+
+`RPG::Sprite` is **not in the script bundle** — the 90 sections of the
+`OpenGame.exe` bed define no such section, because `RGSS104E.dll` supplies it,
+along with `RPG::Weather`. `Sprite_Character < RPG::Sprite` is therefore the
+first line of the game's own engine that cannot run, and everything downstream
+(`Spriteset_Map`, `Scene_Map`, `Main`) is behind it.
+
+What RGSS's `RPG::Sprite` is: a `Sprite` subclass adding the battle/animation
+behaviour — `damage(value, critical)` (the floating damage number),
+`animation(animation, hit)` and `loop_animation` (playing an `RPG::Animation`
+over the sprite), `blink_on`/`blink_off`/`blink?`, `effect?`, and the battler
+transitions `whiten`/`black_out`/`appear`/`escape`/`collapse`, all advanced by
+its own `update`.
+
+Most of the animation half already exists in this tree, written for the
+built-in flow's Show Animation (207): `RPGXP::Game::Animation` decodes the frame
+timing and cell rows, and the map scene blits the cells. Lifting that into an
+`RPG::Sprite` the scripts can subclass is the next concrete step for the host.
+
+**This gap was invisible until now**, because the switch that turns the host on
+could not work in a built engine — see the note at the end of this document.
+
 ### 1. `Sprite` extended properties ✅ (opacity/zoom/angle/mirror/tone/color/src_rect/blend_type/bush_depth/flash all rendered)
 
 `mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,
@@ -183,3 +213,18 @@ driver ends the game on (see item 3 above / ADR 0023).
 - None of the above can be built or run in the current CI sandbox; each item is
   verified by `mruby-rgss/test` (compiled and run in CI) plus the host-side
   `scripts/rpgxp_script_host_check.rb`.
+
+## Why this list was never measured in the engine
+
+Until now the host could only be turned on by the `RGSS_SCRIPT_HOST` environment
+variable, and **this mruby build has no `ENV`** — no `mruby-env` gem is in
+`build_config.rb`, and none is vendored. `ScriptHost.enabled?` therefore returned
+false in every built engine, on every target, and the host never ran. Only the
+CRuby harnesses, where `ENV` does exist, ever exercised the switch, which is why
+the dead opt-in went unnoticed while the documents kept naming it.
+
+`--rgss_script_host` (published to the Ruby side as the `RGSS_SCRIPT_HOST`
+constant, the way `--rpgxp_new_game` is published as `RPGXP_NEW_GAME`) is the
+switch that works. The environment variable is still honoured for the harnesses.
+With it, the gaps above stop being static call counts and become what actually
+stops a boot — the section name is now reported with the failure.

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -226,7 +226,7 @@ class RPGVX
                  "loose or inside an encrypted archive) loads, but the built-in " \
                  "title/map flow is not written yet. A project that ships its " \
                  "scripts can be driven by the RGSS script host instead " \
-                 "(RGSS_SCRIPT_HOST=1). See " \
+                 "(--rgss_script_host). See " \
                  "docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md."
   end
 end

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -43,14 +43,31 @@ class RPGXP
       @driving = v
     end
 
-    # Whether to run the bundled scripts instead of the built-in flow: an
-    # explicit opt-in via the RGSS_SCRIPT_HOST env var (when the runtime exposes
-    # ENV). Off by default. Uses const_defined? rather than defined?(CONST),
-    # which raises on an undefined constant in this mruby build.
+    # Whether to run the bundled scripts instead of the built-in flow. Off by
+    # default; an explicit opt-in, from either of two places.
+    #
+    # **The `--rgss_script_host` flag** is the one that works in a built engine.
+    # src/main.cxx publishes it as the RGSS_SCRIPT_HOST constant, the way it
+    # publishes `--rpgxp_new_game` as RPGXP_NEW_GAME, and it is read through its
+    # own rescue because an undefined constant raises here (this mruby has no
+    # `defined?(CONST)`).
+    #
+    # **The RGSS_SCRIPT_HOST environment variable** is what every document used
+    # to name, and it could never have turned the host on: this mruby build has
+    # no ENV at all, so the check below was simply always false in the engine.
+    # Only the CRuby harnesses — where ENV does exist — ever saw it work, which
+    # is why the dead switch went unnoticed. It is still honoured, for them.
     def self.enabled?
+      return true if flag_enabled?
       return false unless Object.const_defined?(:ENV)
       flag = ENV[ENABLED_ENV]
       !(flag.nil? || flag.empty? || flag == "0" || flag == "false")
+    end
+
+    def self.flag_enabled?
+      RGSS_SCRIPT_HOST
+    rescue StandardError
+      false
     end
 
     # Run the project's bundled scripts to completion. `db` answers #scripts
@@ -73,7 +90,22 @@ class RPGXP
       sections.each do |name, source|
         # Evaluate through the top-level helper so a section's `class Scene_Title`
         # etc. define global (::) constants, as under RGSS — see rgss_eval_section.
-        rgss_eval_section(source, name)
+        #
+        # Name the section in the failure. The host is how a game's own engine
+        # runs, so a boot failure is a report about which part of the RGSS class
+        # library is still missing (docs/rpgxp-rgss-api-gap.md) — and "NameError:
+        # uninitialized constant RPG::Sprite" says nothing about *where* to look
+        # without it. Re-raised, so the caller still falls back to the built-in
+        # flow.
+        begin
+          rgss_eval_section(source, name)
+        rescue StandardError, ScriptError => e
+          $stderr.puts "[RGSS] script host: section #{name.inspect} raised " \
+                       "#{e.class}: #{e.message}"
+          # `raise` with no argument loses the exception in this mruby build
+          # (the caller saw a bare RuntimeError), so re-raise it explicitly.
+          raise e
+        end
       end
       true
     end

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -63,6 +63,15 @@ DEFINE_bool(
     "CI, in the browser build and beside the genuine RGSS runtime under wine; "
     "see scripts/rpgxp_boot_check.bash and scripts/compare-rpgxp-wine.bash)");
 DEFINE_bool(
+    rgss_script_host,
+    false,
+    "For RPG Maker XP / VX / VX Ace: run the game's own bundled scripts "
+    "(Data/Scripts.rxdata) instead of the reimplemented title/map flow, the "
+    "way RGSS10*.dll does. Off by default while the RGSS class library is "
+    "completed (docs/rpgxp-rgss-api-gap.md). This flag is the only way to turn "
+    "the host on in a built engine: the RGSS_SCRIPT_HOST environment variable "
+    "the docs used to name cannot work, because this mruby has no ENV");
+DEFINE_bool(
     mv_new_game,
     false,
     "For RPG Maker MV: once the title screen appears, auto-select New Game so "
@@ -716,6 +725,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RPGXP_NEW_GAME"),
                 mrb_bool_value(FLAGS_rpgxp_new_game));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RGSS_SCRIPT_HOST"),
+                mrb_bool_value(FLAGS_rgss_script_host));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));


### PR DESCRIPTION
With the XP event-command set finished (#361), the next tracked step was closing the `mruby-rgss` gap so the script host can run a game's own engine. Trying to actually do that turned up why the gap list had never been measured.

## The opt-in was dead

Every document — README, ADR 0017, ADR 0023, `docs/rpgxp-rgss-api-gap.md` — names `RGSS_SCRIPT_HOST=1` as the way to turn the host on. It could never have worked: **this mruby build has no `ENV`**. No `mruby-env` gem is vendored or configured, so `Object.const_defined?(:ENV)` is false, `ScriptHost.enabled?` returned false in every built engine on every target, and the host had never run.

Only the CRuby harnesses, where `ENV` does exist, ever exercised the switch — `rpgvx_testbed_check.rb` sets and clears `ENV["RGSS_SCRIPT_HOST"]` and passes. That is why a dead opt-in survived into four documents.

Verified from inside the engine rather than inferred, using the Script command from #361 as the probe:

```
[ENV-PROBE] ENV defined=false
[ENV-PROBE] enabled?=false
```

`--rgss_script_host` is the switch that works: `src/main.cxx` publishes it to the Ruby side as a constant, exactly as `--rpgxp_new_game` is published as `RPGXP_NEW_GAME`. The environment variable is still honoured for the harnesses.

## What it measures

A boot failure under the host is a report about which part of the RGSS class library is missing, so it now names the section that raised rather than only the exception. (Re-raised explicitly — a bare `raise` in a rescue loses the exception in this mruby, which is why the caller had been logging an empty `RuntimeError`.)

On the OpenGame test bed:

```
[RGSS] script host: section "Sprite_Character" raised NameError: uninitialized constant RPG::Sprite
```

`RPG::Sprite` is **not in the script bundle** — none of the bed's 90 sections define it, because `RGSS104E.dll` supplies it, along with `RPG::Weather`. So `Sprite_Character < RPG::Sprite` is the first line of a game's own engine that cannot run, and `Spriteset_Map` / `Scene_Map` / `Main` are all behind it.

Most of what `RPG::Sprite` needs already exists in the tree: `RPGXP::Game::Animation` decodes the frame timing and cell rows and the map scene blits the cells, written for Show Animation (207) in #361. Lifting that into a class the scripts can subclass is the next concrete step.

`docs/rpgxp-rgss-api-gap.md` now leads with that gap, and records why its list had only ever been static call counts.

## Testing

`ctest` green, XP data check, XP script-host check, **VX testbed check** (it drives the env-var path, so it exercises the compatibility branch), and both XP beds booting to `[RPGXP-MAP]`. The host itself is verified by running it: it engages, evaluates 21 sections, and fails where reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C72B3ponBjmrbm3EMYMT1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01C72B3ponBjmrbm3EMYMT1H)_