### PR TITLE
Fix the Nepheshel event commands that dispatched but did the wrong thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@
   cancel setting as well: the cancel key picks the choice the command names, or
   runs its dedicated **[Cancel]** branch, and a block that forbids cancelling
   swallows the key
+- **Erase / Show Screen** run the transition style the command asks for, each at
+  its own RPG2000 length — including "use the configured transition", which
+  reads the Change Screen Transitions setting seeded from the game's database.
+  The blinds, the vertical / horizontal stripes and the border-to-centre /
+  centre-to-border windows are drawn as a mask over the map; the styles that need
+  the scene itself moved or resampled (scrolls, zoom, mosaic, wave, random
+  blocks) still run as a fade of the correct length
 - A troop's **battle-event pages** run during a fight: their conditions (switch,
   variable, turn, enemy/actor HP, plus RPG2003's per-battler turn counters and
   party fatigue) are re-checked each turn, and a matching page runs the ordinary

--- a/changelog.d/rpg2k-screen-transitions.added.md
+++ b/changelog.d/rpg2k-screen-transitions.added.md
@@ -1,0 +1,19 @@
+- **Erase / Show Screen run their real transition.** The style in parameter 0
+  used to be recorded and ignored: every one of them ran the same 32-frame black
+  fade, including the **-1 "use the configured transition"** that is 2124 of
+  Nepheshel's 2146 Erase Screens. `Game::Transition` now ports EasyRPG's
+  transition model — the two parameter→style tables, each style's own length (35
+  frames for a fade, 41 for the shaped ones, 1 for a cut, 0 for "none") and the
+  frame-by-frame geometry — and a -1 resolves against the Change Screen
+  Transitions slot, which `Game::State#seed_screen_transitions` fills in from the
+  database's System settings at New Game and after a load. That command (10690)
+  therefore does something at run time now instead of only being saved.
+  `Scene::Map` paints the shaped transitions as a mask: the erase overlay goes
+  fully opaque and the regions of the map still showing through are punched back
+  out of it, which draws the blinds, the vertical / horizontal stripes and the
+  border-to-centre / centre-to-border windows for real. The styles a mask cannot
+  express — the scrolls and combine / division pairs (which slide the scene
+  itself), zoom / mosaic / wave (which resample it) and random blocks — run as a
+  fade of the correct length until the renderer can capture and transform a
+  screen. Geometry pinned by new checks in `scripts/rpg2k_logic_check.rb`, the
+  mask painting by `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -522,8 +522,9 @@ The work below is roughly ordered by the critical path to a walkable game
   through the message window before the event continues (a small reusable
   pending-message queue on the interpreter); **Change System Graphics** (10680)
   overrides the windowskin / font (save chunks 15 / 17; the scene reloads the
-  skin); **Change Screen Transitions** (10690) records the six teleport / battle
-  transition styles (save chunks 111–116; modelled for save fidelity); and **Game
+  skin); **Change Screen Transitions** (10690) sets the six teleport / battle
+  transition styles (save chunks 111–116), which an Erase / Show Screen's "use
+  the configured transition" now reads; and **Game
   Over** (12520) returns to the title — all handled. **Vehicle locations** (boat /
   ship / airship) also persist in the save (`Game::Vehicle`, `.lsd` chunks
   105–107 / the Marshal save).
@@ -593,13 +594,32 @@ The work below is roughly ordered by the critical path to a walkable game
   follow, and pan / reset scroll a pixel offset toward a target that `Scene::Map`
   adds to the camera (so — like the shake — the pan **is** visible; while locked
   the view holds where locking began). **Erase Screen** (11010) / **Show Screen**
-  (11020) drive `Game::Screen` too: a fade level (0 visible .. 255 black) that
-  eases like the tint over a fixed transition and is held erased until a Show,
-  recording the requested transition style (fade / block / stripe / scroll) for
-  fidelity while modelling only the fade — and the fade **is** drawn, by the
-  same screen-sized sprite mechanism as the flash. All share the `:screen` wait,
-  so event timing around them is correct. **Show Picture** now renders (see the
-  interpreter bullet above).
+  (11020) drive `Game::Screen` too: a fade level (0 visible .. 255 black) held
+  erased until a Show, drawn by the same screen-sized sprite mechanism as the
+  flash. All share the `:screen` wait, so event timing around them is correct.
+  **Show Picture** now renders (see the interpreter bullet above).
+
+  Those two commands now run their **actual transition style** rather than one
+  fixed fade. `Game::Transition` ports EasyRPG's transition model: the two
+  parameter → style tables (the same index means the "out" style to an erase and
+  the "in" style to a show), each style's own length — 35 frames for a fade, 41
+  for the shaped ones, 1 for a cut, 0 for "no transition" — and the frame-by-frame
+  geometry. Parameter **-1**, "use the configured transition", is by far the most
+  common value in real data (2124 of Nepheshel's 2146 Erase Screens) and used to
+  fall through unresolved; it now reads the Change Screen Transitions slot, which
+  `Game::State#seed_screen_transitions` fills in from the database's System
+  settings (chunks 61–66) at New Game and after a load — including a `.lsd` slot
+  the save left un-overridden, which comes back out of range rather than as a
+  setting. `Scene::Map` draws a shaped transition as a **mask**: the erase overlay
+  goes fully opaque and the regions of the map still showing through are punched
+  back out of it with `fill_rect`, which is exactly how RPG_RT composites the
+  screen being left against the screen being arrived at (one of the two is always
+  solid black). That draws the blinds, the vertical / horizontal stripes and the
+  border-to-centre / centre-to-border windows for real. Remaining: the styles a
+  black mask cannot express — the scrolls and the combine / division pairs slide
+  the live scene itself, zoom / mosaic / wave resample it, and random blocks wants
+  thousands of block blits a frame — which run as a fade of the right length and
+  the right end state until the renderer can capture a screen and transform it.
 
   The fade and flash overlays were listed here as blocked on `RGSS::Viewport`
   tone/alpha support in C++. **They were not**: `RGSS::Sprite#opacity` already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6,6 +6,11 @@
 # the not-yet-implemented map renderer, and unit-testable on its own.
 module Game
   TILE = 16 # tile size in pixels
+  # The RPG2000 screen, in pixels. `RPG2k::WIDTH`/`HEIGHT` are the same numbers
+  # on the scene side; the pure-logic half needs them for the screen-transition
+  # geometry, which cannot reach the scene.
+  SCREEN_W = 320
+  SCREEN_H = 240
 
   # Pixel geometry of a character-set (CharSet/*.png) graphic. A charset holds
   # 4x2 = 8 character templates; each template is 3 walk frames wide by 4
@@ -2831,6 +2836,314 @@ module Game
     end
   end
 
+  # The RPG2000 screen **transition** an Erase Screen (11010) / Show Screen
+  # (11020) runs, and the geometry it paints frame by frame.
+  #
+  # RPG_RT composites two full screens: the one being left and the one being
+  # arrived at, one of which is solid black (an erase ends black, a show starts
+  # black). Every transition is therefore a **black mask over the live scene** —
+  # the erase grows it, the show shrinks it — which is exactly what
+  # `Scene::Map`'s existing full-screen black overlay can express. This class
+  # owns the mask: `#visible_rects` returns the regions of the live scene showing
+  # through on the current frame, and the scene paints the overlay opaque and
+  # punches those out. The uniform fades stay a plain opacity ramp
+  # (`#black_alpha`), the cheap path they already were.
+  #
+  # Ported from EasyRPG Player's `Transition` (src/transition.{h,cpp}): the style
+  # ids are its `Transition::Type` enum in order, the command-parameter tables
+  # are its `Game_Interpreter::CommandEraseScreen` / `CommandShowScreen`
+  # switches, and the durations are its `GetDefaultFrames`.
+  class Transition
+    FADE_IN                 = 0
+    FADE_OUT                = 1
+    RANDOM_BLOCKS           = 2
+    RANDOM_BLOCKS_DOWN      = 3
+    RANDOM_BLOCKS_UP        = 4
+    BLIND_OPEN              = 5
+    BLIND_CLOSE             = 6
+    VERTICAL_STRIPES_IN     = 7
+    VERTICAL_STRIPES_OUT    = 8
+    HORIZONTAL_STRIPES_IN   = 9
+    HORIZONTAL_STRIPES_OUT  = 10
+    BORDER_TO_CENTER_IN     = 11
+    BORDER_TO_CENTER_OUT    = 12
+    CENTER_TO_BORDER_IN     = 13
+    CENTER_TO_BORDER_OUT    = 14
+    SCROLL_UP_IN            = 15
+    SCROLL_DOWN_IN          = 16
+    SCROLL_LEFT_IN          = 17
+    SCROLL_RIGHT_IN         = 18
+    SCROLL_UP_OUT           = 19
+    SCROLL_DOWN_OUT         = 20
+    SCROLL_LEFT_OUT         = 21
+    SCROLL_RIGHT_OUT        = 22
+    VERTICAL_COMBINE        = 23
+    VERTICAL_DIVISION       = 24
+    HORIZONTAL_COMBINE      = 25
+    HORIZONTAL_DIVISION     = 26
+    CROSS_COMBINE           = 27
+    CROSS_DIVISION          = 28
+    ZOOM_IN                 = 29
+    ZOOM_OUT                = 30
+    MOSAIC_IN               = 31
+    MOSAIC_OUT              = 32
+    WAVE_IN                 = 33
+    WAVE_OUT                = 34
+    CUT_IN                  = 35
+    CUT_OUT                 = 36
+    NONE                    = 37
+
+    # RPG2000's own transition **setting** numbering, 0..20, shared by three
+    # places: an Erase / Show Screen's parameter 0, the database System tab's six
+    # transition fields (chunks 61-66) and the Change Screen Transitions (10690)
+    # slots the save keeps (chunks 111-116). The same index means a different
+    # style depending on which direction it is read in, which is why there are
+    # two tables — EasyRPG's `Game_System::GetTransition` picks between them with
+    # `fades[which % 2]`, the erase slots being the even ones.
+    #
+    # Erase Screen's parameter 0 / an erase setting -> style. Anything past the
+    # table is NONE, RPG_RT's own `default:` arm (setting 20 is exactly that).
+    ERASE_STYLES = [
+      FADE_OUT, RANDOM_BLOCKS, RANDOM_BLOCKS_DOWN, RANDOM_BLOCKS_UP,
+      BLIND_CLOSE, VERTICAL_STRIPES_OUT, HORIZONTAL_STRIPES_OUT,
+      BORDER_TO_CENTER_OUT, CENTER_TO_BORDER_OUT, SCROLL_UP_OUT,
+      SCROLL_DOWN_OUT, SCROLL_LEFT_OUT, SCROLL_RIGHT_OUT, VERTICAL_DIVISION,
+      HORIZONTAL_DIVISION, CROSS_DIVISION, ZOOM_IN, MOSAIC_OUT, WAVE_OUT,
+      CUT_OUT
+    ].freeze
+
+    # Show Screen's parameter 0 / a show setting -> style: the same list in its
+    # "in" polarity.
+    SHOW_STYLES = [
+      FADE_IN, RANDOM_BLOCKS, RANDOM_BLOCKS_DOWN, RANDOM_BLOCKS_UP,
+      BLIND_OPEN, VERTICAL_STRIPES_IN, HORIZONTAL_STRIPES_IN,
+      BORDER_TO_CENTER_IN, CENTER_TO_BORDER_IN, SCROLL_UP_IN, SCROLL_DOWN_IN,
+      SCROLL_LEFT_IN, SCROLL_RIGHT_IN, VERTICAL_COMBINE, HORIZONTAL_COMBINE,
+      CROSS_COMBINE, ZOOM_OUT, MOSAIC_IN, WAVE_IN, CUT_IN
+    ].freeze
+
+    # Styles this build paints for real. The rest are the ones a black mask
+    # cannot express: the scrolls and the combine / division pairs slide the live
+    # scene itself, zoom / mosaic / wave resample it, and random blocks needs
+    # thousands of per-frame block blits. They run as a fade of the same length —
+    # the right duration and the right end state, the wrong texture — until the
+    # renderer can capture a screen and transform it.
+    DRAWN = [FADE_IN, FADE_OUT, BLIND_OPEN, BLIND_CLOSE, VERTICAL_STRIPES_IN,
+             VERTICAL_STRIPES_OUT, HORIZONTAL_STRIPES_IN,
+             HORIZONTAL_STRIPES_OUT, BORDER_TO_CENTER_IN, BORDER_TO_CENTER_OUT,
+             CENTER_TO_BORDER_IN, CENTER_TO_BORDER_OUT, CUT_IN, CUT_OUT,
+             NONE].freeze
+
+    # The highest setting index the numbering defines (20 = "no transition").
+    MAX_SETTING = 20
+
+    # Whether `v` is a usable setting index. A slot that is not — nil, or the
+    # "same as the database" marker RPG_RT saves — means "ask the database".
+    def self.setting?(v)
+      !v.nil? && v >= 0 && v <= MAX_SETTING
+    end
+
+    # The style an Erase Screen selects. `param` is the command's parameter 0 and
+    # `configured` the setting a **-1** ("use the configured transition") falls
+    # back to: the teleport-erase slot, itself seeded from the database. Both are
+    # setting indices, so the fallback goes through the same table.
+    def self.erase_style(param, configured)
+      style_for(ERASE_STYLES, param, configured)
+    end
+
+    def self.show_style(param, configured)
+      style_for(SHOW_STYLES, param, configured)
+    end
+
+    def self.style_for(table, param, configured)
+      setting = param < 0 ? configured : param
+      return NONE unless setting?(setting)
+      table[setting] || NONE
+    end
+
+    # How long a style runs, in frames (EasyRPG's `GetDefaultFrames`): the plain
+    # fades take 35, the instant cuts 1, NONE none at all, everything else 41 —
+    # which is why the stripe transitions tile the screen exactly (40 steps of a
+    # 6px / 8px pitch over 240 / 320 pixels).
+    def self.default_frames(style)
+      case style
+      when FADE_IN, FADE_OUT then 35
+      when CUT_IN, CUT_OUT   then 1
+      when NONE              then 0
+      else 41
+      end
+    end
+
+    attr_reader :style, :frames, :frame
+
+    # `erase` says which way the mask runs: true when black is arriving (Erase
+    # Screen), false when it is leaving (Show Screen).
+    def initialize(style, frames, width, height, erase)
+      @style = style
+      @frames = frames
+      @width = width
+      @height = height
+      @erase = erase
+      @frame = 0
+    end
+
+    def advance; @frame += 1 if @frame < @frames; end
+    def done?; @frame >= @frames; end
+
+    # Whether this style is drawn as a uniform black overlay (the fade family and
+    # every unported style) rather than as a mask of rectangles.
+    def uniform?
+      !DRAWN.include?(@style) || @style == FADE_IN || @style == FADE_OUT
+    end
+
+    # The overlay opacity for a uniform style, 0 (clear) .. 255 (black).
+    #
+    # EasyRPG ramps the arriving screen in over `total_frames - 2`, so the fade
+    # lands a couple of frames before the transition formally ends; that early
+    # landing is part of how an RPG2000 fade looks, so it is ported rather than
+    # tidied into a straight ramp.
+    def black_alpha
+      span = @frames - 2
+      level = span <= 0 ? 255 : 255 * (@frame + 1) / span
+      level = 255 if level > 255
+      @erase ? level : 255 - level
+    end
+
+    # The rectangles of the live scene showing through the black overlay this
+    # frame, each `[x, y, w, h]`. Only called for a non-uniform style; an empty
+    # list means the screen is entirely black.
+    #
+    # RPG_RT draws the screen being left, then the screen being arrived at over
+    # part of it — so the live regions are the arriving screen's on a Show and
+    # everything *else* on an Erase. For the two window transitions that means
+    # one polarity is a rectangle and the other is the four bands around it.
+    def visible_rects
+      case @style
+      when BLIND_OPEN, BLIND_CLOSE then blind_rects
+      when VERTICAL_STRIPES_IN, VERTICAL_STRIPES_OUT then vertical_stripe_rects
+      when HORIZONTAL_STRIPES_IN, HORIZONTAL_STRIPES_OUT then horizontal_stripe_rects
+      when BORDER_TO_CENTER_OUT then clip([border_to_center_rect])
+      when BORDER_TO_CENTER_IN  then around(border_to_center_rect)
+      when CENTER_TO_BORDER_IN  then clip([center_to_border_rect])
+      when CENTER_TO_BORDER_OUT then around(center_to_border_rect)
+      else [[0, 0, @width, @height]] # the cuts show the live screen for their one frame
+      end
+    end
+
+    private
+
+    # The frame index the geometry is drawn at, and the span it runs over —
+    # EasyRPG's `current_frame` and `total_frames - 1`.
+    def span; @frames - 1; end
+
+    # Blinds: 8-pixel bands, each closing (or opening) from its top edge by one
+    # pixel every five frames. The live band is what is left of the 8.
+    BLIND_BAND = 8
+
+    def blind_rects
+      shut = (@frame + 5) / 5
+      shut = BLIND_BAND if shut > BLIND_BAND
+      open_h = BLIND_BAND - shut
+      rects = []
+      bands = @height / BLIND_BAND
+      bands.times do |i|
+        # Closing shows the bottom of each band, opening the top of it.
+        if @style == BLIND_CLOSE
+          rects.push [0, i * BLIND_BAND + shut, @width, open_h] if open_h > 0
+        elsif shut > 0
+          rects.push [0, i * BLIND_BAND + open_h, @width, shut]
+        end
+      end
+      rects
+    end
+
+    # Vertical stripes: 3-pixel rows on a 6-pixel pitch, marching in from the top
+    # and the bottom at once. The arriving screen takes the rows at `i * 6` /
+    # `h - 3 - i * 6`, the leaving one keeps those at `i * 6 + 3` / `h - i * 6`.
+    STRIPE_H = 3
+    STRIPE_PITCH = 6
+
+    def vertical_stripe_rects
+      rects = []
+      if @erase
+        (span - (@frame + 1)).times do |i|
+          rects.push [0, i * STRIPE_PITCH + STRIPE_H, @width, STRIPE_H]
+          rects.push [0, @height - i * STRIPE_PITCH, @width, STRIPE_H]
+        end
+      else
+        (@frame + 1).times do |i|
+          rects.push [0, i * STRIPE_PITCH, @width, STRIPE_H]
+          rects.push [0, @height - STRIPE_H - i * STRIPE_PITCH, @width, STRIPE_H]
+        end
+      end
+      clip(rects)
+    end
+
+    # Horizontal stripes: the same march in columns, 4 pixels wide on an 8-pixel
+    # pitch, closing in from the left and right edges.
+    STRIPE_W = 4
+    STRIPE_COL_PITCH = 8
+
+    def horizontal_stripe_rects
+      rects = []
+      if @erase
+        (span - (@frame + 1)).times do |i|
+          rects.push [i * STRIPE_COL_PITCH + STRIPE_W, 0, STRIPE_W, @height]
+          rects.push [@width - i * STRIPE_COL_PITCH, 0, STRIPE_W, @height]
+        end
+      else
+        (@frame + 1).times do |i|
+          rects.push [i * STRIPE_COL_PITCH, 0, STRIPE_W, @height]
+          rects.push [@width - STRIPE_W - i * STRIPE_COL_PITCH, 0, STRIPE_W, @height]
+        end
+      end
+      clip(rects)
+    end
+
+    # Border to centre: the live scene shrinks toward the middle (erase) or the
+    # arriving one is revealed by that same shrinking window closing on it.
+    def border_to_center_rect
+      p = span <= 0 ? 1 : @frame
+      d = span <= 0 ? 1 : span
+      [(@width / 2) * p / d, (@height / 2) * p / d,
+       @width - @width * p / d, @height - @height * p / d]
+    end
+
+    # Centre to border: a window growing out of the middle onto which the
+    # arriving screen is drawn.
+    def center_to_border_rect
+      p = span <= 0 ? 1 : @frame
+      d = span <= 0 ? 1 : span
+      [@width / 2 - (@width / 2) * p / d, @height / 2 - (@height / 2) * p / d,
+       @width * p / d, @height * p / d]
+    end
+
+    # The four bands of screen left outside `rect` — the live scene when the
+    # arriving screen is the one inside the window rather than around it.
+    def around(rect)
+      x, y, w, h = rect
+      clip([[0, 0, @width, y],                              # above
+            [0, y + h, @width, @height - (y + h)],          # below
+            [0, y, x, h],                                   # left
+            [x + w, y, @width - (x + w), h]])               # right
+    end
+
+    # Drop rectangles that fell off the screen (the stripe marches overrun by a
+    # row or two at the end) and clamp the rest into it.
+    def clip(rects)
+      out = []
+      rects.each do |x, y, w, h|
+        next if w <= 0 || h <= 0 || x >= @width || y >= @height
+        x2 = x < 0 ? 0 : x
+        y2 = y < 0 ? 0 : y
+        w2 = x + w > @width ? @width - x2 : w - (x2 - x)
+        h2 = y + h > @height ? @height - y2 : h - (y2 - y)
+        out.push [x2, y2, w2, h2] if w2 > 0 && h2 > 0
+      end
+      out
+    end
+  end
+
   # Screen-effect state driven by the screen event commands. Models two effects
   # so far:
   #
@@ -2910,15 +3223,22 @@ module Game
     def panning?; @pan_x != @pan_tx || @pan_y != @pan_ty; end
 
     # Screen erasure level (0 fully visible .. 255 fully black). The scene draws
-    # a black overlay at this opacity — the native half still to come, like the
-    # tint and flash overlays — so the level is modelled but does not yet darken
-    # the screen.
-    def fade_level; @fade; end
+    # a black overlay at this opacity. While a shaped transition is running the
+    # overlay is a mask instead (see #transition), and this holds the level the
+    # screen settles at once it finishes.
+    def fade_level
+      return @fade unless @transition && @transition.uniform?
+      @transition.black_alpha
+    end
 
-    # The RPG2000 transition style requested by the last Erase / Show Screen
-    # (0 = fade, higher = block / stripe / scroll variants). Recorded for
-    # fidelity; only the fade is modelled.
+    # The RPG2000 transition style the last Erase / Show Screen selected (a
+    # Game::Transition constant).
     def fade_transition; @fade_transition; end
+
+    # The running Game::Transition, or nil between transitions. The scene reads
+    # it to paint the overlay: a uniform style is just #fade_level, a shaped one
+    # punches #visible_rects out of an opaque black overlay.
+    def transition; @transition && !@transition.done? ? @transition : nil; end
 
     # True while an erase / show fade is still in progress.
     def fading?; @fade_frames > 0; end
@@ -2975,17 +3295,18 @@ module Game
       end
     end
 
-    # Erase Screen: fade the screen out to black over `frames` frames using the
-    # given RPG2000 transition style. Held black afterwards until #show. A no-op
-    # (settles immediately) when the screen is already fully erased.
-    def erase(transition, frames)
-      fade_to(255, transition, frames)
+    # Erase Screen: take the screen to black in the given Game::Transition style,
+    # over that style's own length unless `frames` overrides it. Held black
+    # afterwards until #show. A no-op (settles immediately) when the screen is
+    # already fully erased — RPG_RT skips an erase-onto-erase outright.
+    def erase(style, frames = nil)
+      fade_to(255, style, frames, true)
     end
 
-    # Show Screen: fade the screen back in from black over `frames` frames. A
-    # no-op when the screen is already fully visible.
-    def show(transition, frames)
-      fade_to(0, transition, frames)
+    # Show Screen: bring the screen back from black in the given style. A no-op
+    # when the screen is already fully visible.
+    def show(style, frames = nil)
+      fade_to(0, style, frames, false)
     end
 
     # Pan-operation direction (RPG2000: 0 up, 1 right, 2 down, 3 left) -> unit
@@ -3036,24 +3357,41 @@ module Game
 
     private
 
-    # Start a fade toward `target` (0 visible / 255 black) over `frames` frames.
+    # Start a transition toward `target` (0 visible / 255 black) in `style`,
+    # running for `frames` frames or, when that is nil, the style's own length.
     # Already at the target -> settle immediately so the command does not wait.
-    def fade_to(target, transition, frames)
-      @fade_transition = transition
+    #
+    # Game::Transition::NONE is RPG_RT's "no transition at all": it neither
+    # animates nor changes whether the screen is erased, so it is dropped here
+    # rather than treated as an instant fade.
+    def fade_to(target, style, frames, erase)
+      style = Game::Transition::FADE_OUT if style.nil?
+      @fade_transition = style
+      return if style == Game::Transition::NONE
       @fade_target = target
+      frames = Game::Transition.default_frames(style) if frames.nil?
       if frames <= 0 || @fade == target
         @fade = target
         @fade_frames = 0
+        @transition = nil
       else
         @fade_frames = frames
+        @transition = Game::Transition.new(style, frames, Game::SCREEN_W,
+                                           Game::SCREEN_H, erase)
       end
     end
 
     def update_fade
       return if @fade_frames <= 0
+      # A shaped transition owns its own frame counter and paints a mask; a
+      # uniform one rides the plain level ramp. Either way the level lands on the
+      # target on the final frame, so the screen holds the right end state.
+      @transition.advance if @transition
       @fade += (@fade_target - @fade) / @fade_frames
       @fade_frames -= 1
-      @fade = @fade_target if @fade_frames.zero? # land exactly on the target
+      return unless @fade_frames.zero?
+      @fade = @fade_target # land exactly on the target
+      @transition = nil
     end
 
     def update_tint
@@ -4376,7 +4714,9 @@ module Game
       @escape_target = nil
       @system_bgm = {}
       @system_sfx = {}
-      @screen_transitions = Array.new(SCREEN_TRANSITION_SLOTS, 0)
+      # nil = "not configured yet"; #seed_screen_transitions fills each slot in
+      # from the database when the game starts.
+      @screen_transitions = Array.new(SCREEN_TRANSITION_SLOTS, nil)
       @system_graphic = nil
       @font_id = 0
       @weather = Weather.new
@@ -4473,11 +4813,42 @@ module Game
     # The six Change Screen Transitions (10690) slots (see #screen_transitions).
     SCREEN_TRANSITION_SLOTS = 6
 
-    # Change Screen Transitions: set slot `which` (0..5) to transition style
+    # The database System fields (chunks 61-66) backing those slots, in slot
+    # order: teleport erase / show, battle start erase / show, battle end erase /
+    # show. RPG_RT reads the database setting whenever the in-game slot has not
+    # been overridden, so the two lists have to line up.
+    DB_TRANSITION_FIELDS = [:transition_out, :transition_in,
+                            :battle_start_fadeout, :battle_start_fadein,
+                            :battle_end_fadeout, :battle_end_fadein].freeze
+
+    # Change Screen Transitions: set slot `which` (0..5) to transition setting
     # `style`. An out-of-range slot is ignored.
     def set_screen_transition(which, style)
       return unless which >= 0 && which < SCREEN_TRANSITION_SLOTS
       @screen_transitions[which] = style
+    end
+
+    # Fill any transition slot that does not hold a real setting index from the
+    # database's own System settings. Called when a game starts and after a save
+    # is restored, so an Erase / Show Screen's "use the configured transition"
+    # (-1) always has something to resolve against.
+    #
+    # A slot can arrive unset two ways: a fresh game has never had one, and a
+    # genuine `.lsd` stores a not-overridden slot as a marker rather than a
+    # setting (RPG_RT writes -1 when the value still matches the database, which
+    # the chunk's unsigned byte reads back out of range). Both mean the same
+    # thing — ask the database — so both are refilled here.
+    def seed_screen_transitions(db)
+      sys = db && db.respond_to?(:system) ? db.system : nil
+      DB_TRANSITION_FIELDS.each_with_index do |field, i|
+        next if Game::Transition.setting?(@screen_transitions[i])
+        v = sys && sys.respond_to?(field) ? sys.send(field) : nil
+        @screen_transitions[i] = Game::Transition.setting?(v) ? v : 0
+      end
+    rescue StandardError => e
+      # A database without the fields is not fatal — every slot then falls back
+      # to setting 0, the plain fade — but it should not pass unnoticed.
+      $stderr.puts "[RPG2k] screen transition defaults unreadable: #{e.message}"
     end
 
     # Change System Graphics: override the windowskin graphic (System/<name>) and
@@ -4757,12 +5128,15 @@ module Game
       state.escape_access = sys.escape_allowed unless sys.escape_allowed.nil?
       state.save_access = sys.save_allowed unless sys.save_allowed.nil?
       state.menu_access = sys.menu_allowed unless sys.menu_allowed.nil?
-      # Screen-transition slots (chunks 111..116), defaulting to 0 when unset.
+      # Screen-transition slots (chunks 111..116). A slot the save left
+      # un-overridden comes back out of range rather than as a setting, and
+      # #seed_screen_transitions refills those from the database below.
       state.screen_transitions = [
         sys.teleport_erase_transition, sys.teleport_show_transition,
         sys.battle_start_erase_transition, sys.battle_start_show_transition,
         sys.battle_end_erase_transition, sys.battle_end_show_transition
-      ].map { |v| v || 0 }
+      ]
+      state.seed_screen_transitions(db)
       # System windowskin / font override; an empty graphic means "use the
       # database default" (left unset).
       sg = sys.system_graphic
@@ -4871,11 +5245,13 @@ module Game
       state.escape_target = h[:escape_target]
       state.system_bgm = h[:system_bgm] || {}
       state.system_sfx = h[:system_sfx] || {}
-      # A save written before screen transitions existed restores all-default.
+      # A save written before screen transitions existed restores all-default,
+      # which the seeding below then fills in from the database.
       stx = h[:screen_transitions]
       if stx && stx.length == SCREEN_TRANSITION_SLOTS
         state.screen_transitions = stx.dup
       end
+      state.seed_screen_transitions(db)
       state.system_graphic = h[:system_graphic]
       state.font_id = h[:font_id] || 0
       if (v = h[:vehicles])

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2254,31 +2254,43 @@ module Game
     # screen effect's 0.1s-unit duration into a frame count.
     FRAMES_PER_TENTH = 6
 
-    # Fixed length of an Erase / Show Screen transition. RPG_RT runs these for a
-    # set per-style duration rather than an event-supplied one; this approximates
-    # the common fade at ~0.5s.
-    SCREEN_FADE_FRAMES = 32
-
-    # Erase Screen (11010) / Show Screen (11020): fade the whole screen out to
-    # black or back in over a fixed duration, using the transition style in
-    # param0 (0 = fade; higher = block / stripe / scroll variants, of which only
-    # the fade is modelled). Both always run their transition and pause the event
-    # until it settles — the owning scene advances Game::Screen each frame and
-    # resumes us on the :screen wait. Only the fade *level* is modelled; drawing
-    # the black overlay is the native refinement still pending for the tint and
-    # flash overlays too.
+    # Erase Screen (11010) / Show Screen (11020): take the whole screen to black
+    # or back, in the transition style param0 names. The style table and each
+    # style's own length live in Game::Transition; **param0 = -1 means "use the
+    # configured transition"**, which is the Change Screen Transitions (10690)
+    # slot for a teleport erase / show — itself seeded from the database. That is
+    # the overwhelmingly common value in real games (2124 of Nepheshel's 2146
+    # Erase Screens), so leaving it unresolved meant almost every fade in the
+    # game ran an unnamed style of a made-up length.
+    #
+    # Both pause the event until the transition settles — the owning scene
+    # advances Game::Screen each frame and resumes us on the :screen wait — but
+    # an instant style (the cuts, or a transition onto a screen already in that
+    # state) settles at once and does not wait at all.
     def do_erase_screen(cmd)
-      @state.screen.erase(cmd.param(0), SCREEN_FADE_FRAMES)
+      style = Game::Transition.erase_style(cmd.param(0), teleport_transition(0))
+      @state.screen.erase(style)
       return unless @state.screen.fading?
       @wait_kind = :screen
       @waiting = true
     end
 
     def do_show_screen(cmd)
-      @state.screen.show(cmd.param(0), SCREEN_FADE_FRAMES)
+      style = Game::Transition.show_style(cmd.param(0), teleport_transition(1))
+      @state.screen.show(style)
       return unless @state.screen.fading?
       @wait_kind = :screen
       @waiting = true
+    end
+
+    # The configured teleport transition **setting** a -1 falls back to: slot 0
+    # is the erase and slot 1 the show, in the same order Change Screen
+    # Transitions (10690) writes them and the save stores them (chunks 111/112).
+    # The state seeds these from the database when the game starts; setting 0,
+    # the plain fade, stands in for a state that never got the chance.
+    def teleport_transition(slot)
+      v = @state.screen_transitions[slot]
+      Game::Transition.setting?(v) ? v : 0
     end
 
     # Tint Screen: transition the shared screen tint to the RPG2000 channels

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -642,6 +642,9 @@ class RPG2k
         @fade_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(0, 0, 0, 255)
         @fade_sprite.bitmap = @fade_bmp
         @fade_sprite.opacity = 0
+        # Whether the overlay currently holds a transition mask rather than the
+        # solid black the opacity-only fade needs (see #draw_transition_mask).
+        @fade_masked = false
 
         @flash_sprite = Sprite.new
         @flash_sprite.z = 450
@@ -675,7 +678,7 @@ class RPG2k
       # over the command's duration.
       def update_screen_overlay
         screen = @state.screen
-        @fade_sprite.opacity = screen.fade_level
+        draw_transition_mask screen
         @tint_sprite.opacity = tint_overlay_opacity(screen.tint)
 
         r, g, b, strength = screen.flash_color
@@ -691,6 +694,44 @@ class RPG2k
         end
 
         draw_weather
+      end
+
+      # Fully opaque and fully clear black, for painting the erase overlay.
+      OPAQUE_BLACK = Color.new(0, 0, 0, 255)
+      CLEAR = Color.new(0, 0, 0, 0)
+
+      # Paint the screen-erasure overlay for this frame.
+      #
+      # A plain fade is just the overlay's opacity, and the bitmap stays the
+      # solid black it was built as — the cheap path, which is also every frame
+      # on which no transition is running. A *shaped* transition (blinds,
+      # stripes, a closing window) instead paints the bitmap: opaque black
+      # everywhere, then the regions of the live scene still showing through
+      # punched back out to fully transparent. `fill_rect` overwrites alpha, so
+      # the holes really are holes.
+      def draw_transition_mask(screen)
+        tr = screen.transition
+        if tr.nil? || tr.uniform?
+          reset_fade_bitmap if @fade_masked
+          @fade_sprite.opacity = screen.fade_level
+          return
+        end
+        @fade_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, OPAQUE_BLACK
+        tr.visible_rects.each { |x, y, w, h| @fade_bmp.fill_rect x, y, w, h, CLEAR }
+        @fade_masked = true
+        @fade_sprite.opacity = 255
+      rescue StandardError => e
+        # A drawing failure must not strand the screen mid-transition: fall back
+        # to the plain fade level, which still lands on the right end state.
+        $stderr.puts "[RPG2k] screen transition draw failed: #{e.message}"
+        @fade_sprite.opacity = screen.fade_level
+      end
+
+      # Restore the overlay to solid black after a shaped transition, so the
+      # opacity-only path draws a full-screen fade again.
+      def reset_fade_bitmap
+        @fade_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, OPAQUE_BLACK
+        @fade_masked = false
       end
 
       WEATHER_RAIN = 1
@@ -5610,6 +5651,9 @@ class RPG2k
     init = map_tree.initial
     state = Game::State.new Game::Party.new(@db), init.initial_map_id,
                             init.initial_x, init.initial_y
+    # The database's System tab configures the six screen transitions a
+    # "use the configured transition" (-1) Erase / Show Screen resolves against.
+    state.seed_screen_transitions @db
     state.map = load_map state.map_id
     # Build the play scene first; only tear down the title once it succeeds so a
     # data problem leaves the title intact instead of a blank screen.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1229,7 +1229,7 @@ end
 
 check 'Show Screen fades back in from black' do
   st = new_state
-  st.screen.erase(0, 32)
+  st.screen.erase(Game::Transition::FADE_OUT, 32)
   st.screen.update until !st.screen.fading? # start fully black
   eq 255, st.screen.fade_level
   it = Game::Interpreter.new(st)
@@ -1253,12 +1253,161 @@ end
 
 check 'Erase Screen records the transition style and ramps the level' do
   st = new_state
-  st.screen.erase(3, 32) # transition style 3 (a block/stripe variant)
-  eq 3, st.screen.fade_transition, 'the style is recorded for fidelity'
+  # Setting 2 is Random Blocks Down, one of the styles a black mask cannot
+  # express, so it runs as a fade of the same length.
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ERASE_SCREEN, [2])])
+  it.update
+  eq Game::Transition::RANDOM_BLOCKS_DOWN, st.screen.fade_transition
+  ok st.screen.transition.uniform?, 'an unported style falls back to the fade'
+  eq 41, st.screen.transition.frames, 'but keeps its own length'
   before = st.screen.fade_level
   st.screen.update
   ok st.screen.fade_level > before, 'the level eases toward black'
   ok st.screen.fade_level < 255, 'over time, not instantly'
+end
+
+# -- screen transitions (Game::Transition) ------------------------------------
+
+TR = Game::Transition
+
+check 'Erase / Show Screen map their parameter onto the RPG2000 style table' do
+  # The two directions read the same setting index differently.
+  eq TR::FADE_OUT,    TR.erase_style(0, 0)
+  eq TR::FADE_IN,     TR.show_style(0, 0)
+  eq TR::BLIND_CLOSE, TR.erase_style(4, 0)
+  eq TR::BLIND_OPEN,  TR.show_style(4, 0)
+  eq TR::CUT_OUT,     TR.erase_style(19, 0)
+  eq TR::CUT_IN,      TR.show_style(19, 0)
+  # Setting 20 and anything past the table are "no transition".
+  eq TR::NONE, TR.erase_style(20, 0)
+  eq TR::NONE, TR.erase_style(99, 0)
+  # -1 means "use the configured transition", which is itself a setting index.
+  eq TR::BLIND_CLOSE, TR.erase_style(-1, 4)
+  eq TR::BLIND_OPEN,  TR.show_style(-1, 4)
+  eq TR::NONE, TR.erase_style(-1, nil), 'an unconfigured slot has no style'
+end
+
+check 'each transition style runs for its own length' do
+  eq 35, TR.default_frames(TR::FADE_OUT)
+  eq 35, TR.default_frames(TR::FADE_IN)
+  eq 1,  TR.default_frames(TR::CUT_OUT)
+  eq 0,  TR.default_frames(TR::NONE)
+  eq 41, TR.default_frames(TR::BLIND_CLOSE), 'the shaped ones all take 41'
+end
+
+check 'Erase Screen resolves -1 against the configured transition' do
+  st = new_state
+  st.set_screen_transition(0, 4) # teleport erase -> blinds
+  st.set_screen_transition(1, 4) # teleport show  -> blinds
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ERASE_SCREEN, [-1])])
+  it.update
+  eq TR::BLIND_CLOSE, st.screen.fade_transition
+  ok !st.screen.transition.uniform?, 'the blinds are painted, not faded'
+  st.screen.update until !st.screen.fading?
+
+  it.resume
+  it.start([FakeCmd.new(IC::SHOW_SCREEN, [-1])])
+  it.update
+  eq TR::BLIND_OPEN, st.screen.fade_transition
+end
+
+check 'a cut transition takes a single frame, not a fade' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ERASE_SCREEN, [19]),   # cut out
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq TR::CUT_OUT, st.screen.fade_transition
+  eq 1, st.screen.transition.frames, 'a cut is one frame long, not 35'
+  # RPG_RT shows the live screen for that frame and lands black after it.
+  eq [[0, 0, 320, 240]], st.screen.transition.visible_rects
+  st.screen.update
+  ok !st.screen.fading?, 'and it is over after that one frame'
+  eq 255, st.screen.fade_level
+  it.resume
+  it.update
+  eq true, st.switches[1]
+end
+
+check '"no transition" neither animates nor changes the screen' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::ERASE_SCREEN, [20]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  eq TR::NONE, st.screen.fade_transition
+  eq 0, st.screen.fade_level, 'the screen is left exactly as it was'
+  ok !st.screen.erased?
+  eq true, st.switches[1], 'and nothing waited'
+end
+
+check 'a fade ramps the overlay opacity, an erase up and a show down' do
+  out = TR.new(TR::FADE_OUT, 35, 320, 240, true)
+  eq 255 * 1 / 33, out.black_alpha, 'the ramp runs over total - 2 frames'
+  32.times { out.advance }
+  eq 255, out.black_alpha, 'and lands fully black before the last frame'
+
+  into = TR.new(TR::FADE_IN, 35, 320, 240, false)
+  eq 255 - 255 / 33, into.black_alpha, 'a show is the same ramp inverted'
+  32.times { into.advance }
+  eq 0, into.black_alpha
+end
+
+check 'blinds close band by band and open the other way' do
+  # 8-pixel bands, one more pixel shut every five frames.
+  close = TR.new(TR::BLIND_CLOSE, 41, 320, 240, true)
+  rects = close.visible_rects
+  eq 30, rects.size, '240 / 8 bands still showing'
+  eq [0, 1, 320, 7], rects[0], 'one pixel of the first band has closed'
+  eq [0, 9, 320, 7], rects[1], 'and of the second'
+  4.times { close.advance }
+  eq [0, 1, 320, 7], close.visible_rects[0], 'still one pixel four frames in'
+  close.advance
+  eq [0, 2, 320, 6], close.visible_rects[0], 'a pixel more every five frames'
+
+  open = TR.new(TR::BLIND_OPEN, 41, 320, 240, false)
+  eq [0, 7, 320, 1], open.visible_rects[0], 'opening reveals from the bottom up'
+end
+
+check 'stripe transitions march in from both edges' do
+  # Vertical stripes: 3-pixel rows on a 6-pixel pitch. A show reveals the rows
+  # the arriving screen has taken; an erase keeps the ones it has not.
+  into = TR.new(TR::VERTICAL_STRIPES_IN, 41, 320, 240, false)
+  eq [[0, 0, 320, 3], [0, 237, 320, 3]], into.visible_rects
+  into.advance
+  eq 4, into.visible_rects.size, 'one row from each edge per frame'
+
+  out = TR.new(TR::VERTICAL_STRIPES_OUT, 41, 320, 240, true)
+  # 39 rows from each edge, less the bottom one RPG_RT places at y = h — off the
+  # screen on the first frame, and clipped away here rather than drawn.
+  eq 77, out.visible_rects.size, 'an erase starts with nearly every row live'
+  eq [0, 3, 320, 3], out.visible_rects[0]
+
+  # Horizontal stripes are the same march in 4-pixel columns on an 8-pixel pitch.
+  cols = TR.new(TR::HORIZONTAL_STRIPES_IN, 41, 320, 240, false)
+  eq [[0, 0, 4, 240], [316, 0, 4, 240]], cols.visible_rects
+end
+
+check 'the window transitions shrink, grow, and invert for the other direction' do
+  # Border to centre, erasing: the live scene is the shrinking centred window.
+  out = TR.new(TR::BORDER_TO_CENTER_OUT, 41, 320, 240, true)
+  eq [[0, 0, 320, 240]], out.visible_rects, 'the full screen on frame 0'
+  20.times { out.advance }
+  eq [[80, 60, 160, 120]], out.visible_rects, 'half way in, a half-size window'
+
+  # Showing, the arriving screen is *outside* that window, so the live regions
+  # are the four bands around it.
+  into = TR.new(TR::BORDER_TO_CENTER_IN, 41, 320, 240, false)
+  20.times { into.advance }
+  eq [[0, 0, 320, 60], [0, 180, 320, 60], [0, 60, 80, 120], [240, 60, 80, 120]],
+     into.visible_rects
+
+  # Centre to border grows a window out of the middle.
+  grow = TR.new(TR::CENTER_TO_BORDER_IN, 41, 320, 240, false)
+  20.times { grow.advance }
+  eq [[80, 60, 160, 120]], grow.visible_rects
 end
 
 check 'conditional branch on the timer' do
@@ -3342,7 +3491,11 @@ check 'Change Screen Transitions sets the chosen slot; round-trips through save'
                                      max_hp: 100, max_mp: 30, atk: 10, def: 8) }
   db = FakeActorDB.new(players, [1])
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
-  eq [0, 0, 0, 0, 0, 0], st.screen_transitions, 'all slots default to 0'
+  eq [nil] * 6, st.screen_transitions, 'a fresh state has no slot configured'
+  # Seeding fills every slot from the database's System settings; this fake
+  # database carries none, so each falls back to setting 0 (the plain fade).
+  st.seed_screen_transitions(db)
+  eq [0, 0, 0, 0, 0, 0], st.screen_transitions, 'seeded to the database defaults'
 
   it = Game::Interpreter.new(st)
   # Slot 2 (battle-start erase) -> style 5, slot 5 (battle-end show) -> style 9.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2313,13 +2313,39 @@ check 'Erase/Show Screen drives the fade layer opacity' do
   eq 0, fade.opacity, 'nothing erased yet, so the fade layer is invisible'
 
   st = scene.instance_variable_get(:@state)
-  st.screen.erase(0, 1) # fade fully out over one frame
+  st.screen.erase(Game::Transition::FADE_OUT, 1) # fade fully out over one frame
   4.times { scene.update }
   eq 255, fade.opacity, 'a completed Erase Screen leaves the screen black'
 
-  st.screen.show(0, 1)
+  st.screen.show(Game::Transition::FADE_IN, 1)
   4.times { scene.update }
   eq 0, fade.opacity, 'Show Screen brings it back'
+end
+
+check 'a shaped transition paints a mask into the fade layer' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+
+  # Blinds close: the overlay goes fully opaque and the bands still showing the
+  # map are punched back out of it, rather than the whole screen dimming.
+  st.screen.erase(Game::Transition::BLIND_CLOSE)
+  fade.bitmap.fill_calls.clear if fade.bitmap.fill_calls
+  scene.update
+  eq 255, fade.opacity, 'the mask itself carries the shape, not the opacity'
+  fills = fade.bitmap.fill_calls || []
+  eq 31, fills.length, 'one full-screen black fill, then 30 band holes'
+  eq [0, 0, 320, 240], fills.first[0, 4], 'blacked out first'
+  eq [0, 1, 320, 7], fills[1][0, 4], 'then the open part of band 0'
+
+  # Once it finishes the overlay is solid black again, so the next plain fade
+  # does not inherit the holes.
+  st.screen.update until !st.screen.fading?
+  fade.bitmap.fill_calls.clear
+  scene.update
+  eq 1, (fade.bitmap.fill_calls || []).length, 'repainted solid for the fade path'
+  eq 255, fade.opacity, 'and the screen stays erased'
 end
 
 check 'Flash Screen drives the flash layer, and refills only on a colour change' do


### PR DESCRIPTION
Per-**opcode** coverage of Nepheshel's 184,166 event commands has read 100 % for a while, but that only says each command reaches a handler — not that the handler reads every parameter mode the game uses, which `docs/rpg2000-sample-analysis.md` flags as the first caveat on that figure. Tallying the parameter signatures behind each opcode against what each handler actually branches on turned up three commands that dispatched and still did the wrong thing.

## 1. "This event" (0 / 10005) was unresolved on the read side

The write-side commands (Move Event, Change Event Location, Flash Sprite) queue their raw target for the scene, which knows which event it is stepping — those always worked. The commands the interpreter answers itself had no way to identify the running event:

| Command | Broken behaviour | Nepheshel sites |
| --- | --- | --- |
| Conditional Branch, orientation (12010 type 6) | always false | 223 of 233 |
| Control Variables, character operand (10220 operand 6) | position read 0 | 239 of 246 |
| Call Event → map event (12330 mode 1) | silent no-op | 17 of 33 |

`Game::Interpreter#event_id` now carries the running map event's id — set by `Scene::Map` beside `map_info`, and re-attached on every lap of a parallel process, whose interpreter restarts its list each time — and every character reference goes through `#character_ref`. It is nil for a common event and for a battle page, neither of which has a "this event" in RPG_RT either.

## 2. Show Choices ignored its cancel setting

Parameter 0 is the cancel behaviour, stored as a 1-based option index: 0 forbids cancelling, 1..4 make the cancel key pick that choice, and 5 runs a dedicated **[Cancel]** branch. The editor writes that branch as a *fifth* option (index 4) with an empty label — which the choice window was drawing as a blank extra row that also shifted the routing of every option below it.

Only options 0..3 are listed now (EasyRPG's `GetChoices(4)`), and `Scene::Map` backs out of a cancellable choice on the cancel key with the system cancel sound; a block with cancel type 0 swallows the key as RPG_RT does. 336 of Nepheshel's 349 choice blocks are cancellable, and 27 carry a [Cancel] branch that could not be reached before.

## 3. Erase / Show Screen ran one fixed fade

The transition style in parameter 0 was recorded and ignored: every Erase / Show Screen ran the same 32-frame black fade. That included **-1**, "use the configured transition", which is 2124 of Nepheshel's 2146 Erase Screens and had nothing to resolve against — Change Screen Transitions (10690) stored its six slots for save fidelity only, and nothing seeded them from the database.

`Game::Transition` ports EasyRPG Player's transition model (`src/transition.{h,cpp}` plus the two `Game_Interpreter` switches). Reading the source rather than working from the editor's list settled something useful: the database System fields (chunks 61–66), the save's Change Screen Transitions slots (111–116) and the command's parameter 0 all share **one 0..20 setting numbering**, read as the "out" style by an erase and the "in" style by a show (`fades[which % 2]`). So the mapping is two tables, not a special case per source.

- Each style keeps its own length: 35 frames for a fade, 41 for the shaped ones, 1 for a cut, 0 for "no transition".
- `Game::State#seed_screen_transitions` fills the six slots from the database at New Game and after a load — including a `.lsd` slot the save left un-overridden, which comes back out of range rather than as a setting. Change Screen Transitions therefore does something at run time now.
- RPG_RT composites the screen being left against the screen being arrived at, and one of the two is always solid black — so every transition is a **black mask over the live scene**, which is what `Scene::Map`'s full-screen overlay already is. A shaped transition now paints it: opaque black, then the regions still showing the map punched back out with `fill_rect`. That draws the blinds, the vertical / horizontal stripes and the border-to-centre / centre-to-border windows for real.

Remaining, and documented as such: the styles a mask cannot express — the scrolls and the combine / division pairs slide the live scene itself, zoom / mosaic / wave resample it, and random blocks wants thousands of block blits a frame. They run as a fade of the right length and the right end state until the renderer can capture and transform a screen.

## Verification

- `scripts/rpg2k_logic_check.rb` 432 pass (+18), `scripts/rpg2k_scene_check.rb` 120 pass (+5), `scripts/rpg2k_render_check.rb` 36 pass, `scripts/lcf_testbed_check.rb` clean.
- Replayed against the real Nepheshel data: all 349 choice blocks draw only real labels, all 27 cancel branches route into their body, every Erase / Show Screen resolves to a drawn style (the -1s to the database's fade, plus its blinds and its cuts — the latter now one frame instead of thirty-two), and the whole 184k-command corpus runs with no handler raising and no unsupported-operand log.

Two things this does **not** prove. The transition geometry is pinned against EasyRPG's formulae, not against pixels: there is no native build in this environment, so `compare-nepheshel-wine.bash` could not diff the new masks against RPG_RT — a wine diff on a map that uses blinds would be the real confirmation. And the C++ CTest suite was not run for the same reason; the change is pure mruby Ruby, which those tests do not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_