### PR TITLE
Make RGSS script host the default boot path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,12 +288,16 @@ jobs:
 
           # The same guard for the RPG Maker XP runtime: the XP checks above run
           # mruby-rpgxp's sources under CRuby, so only booting the real binary
-          # catches mruby/CRuby divergence. `--rpgxp_new_game` drives each bed
-          # past its title into the start map and logs `[RPGXP-MAP]`, which the
-          # script asserts on. Two beds: the editor-shaped OpenGame test bed and
-          # the *released* Pray for You (Game.rgssad only, several maps), on
-          # displays 112 and 113 — one per game (see the reserved server-num map
-          # above). See docs/adr/0025-rpgxp-cross-runtime-testing.md.
+          # catches mruby/CRuby divergence. Each bed boots twice: once with no
+          # flags, where the RGSS script host — the default path — runs the
+          # game's own scripts and logs `[RPGXP-SCRIPTS]`, and once with
+          # `--rpgxp_new_game`, which drives the built-in flow past its title
+          # into the start map and logs `[RPGXP-MAP]`. Two beds: the
+          # editor-shaped OpenGame test bed and the *released* Pray for You
+          # (Game.rgssad only, several maps), on displays 112 and 113 — one per
+          # game (see the reserved server-num map above). See
+          # docs/adr/0025-rpgxp-cross-runtime-testing.md and
+          # docs/adr/0029-rgss-script-host-by-default.md.
           - name: RPG XP real-game boot smoke test
             run: ./scripts/nix-develop.bash ./scripts/rpgxp_boot_check.bash 112
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,13 @@
   `load_data`/`save_data` built-ins and evaluates each at the top level (via
   `mruby-eval`), then drives their blocking main loop one frame per callback
   through a Fiber, so the game's own title, menus, battle system and any
-  community scripts are what run. The reimplemented flow above stays as the
+  community scripts are what run. The classes the player supplies and no project
+  ships are supplied too — **`RPG::Sprite`** (the battler/character sprite base:
+  the whiten/appear/escape/collapse transitions, the floating damage pop-up,
+  blinking, and animation playback with each frame's sound and flash),
+  **`RPG::Weather`** and **`RPG::Cache`** — which is what a game's own
+  `class Sprite_Character < RPG::Sprite` needs to exist at all. The
+  reimplemented flow above stays as the
   fallback — for a project that ships no scripts, if the host fails to boot, and
   on demand with `--norgss_script_host` (or `RGSS_SCRIPT_HOST=0`); see
   [`docs/adr/0029-rgss-script-host-by-default.md`](docs/adr/0029-rgss-script-host-by-default.md)

--- a/README.md
+++ b/README.md
@@ -114,18 +114,25 @@
   decrypted transparently, so the database loads with no loose files present.
   Loose files, when present, shadow the archive (as in RGSS)
 - The window is sized to XP's native 640×480 automatically.
-- An experimental **RGSS script host** can run the game's own bundled scripts
-  (`Data/Scripts.rxdata`) unmodified — the way `RGSS104E.dll` does — instead of
-  the reimplemented flow: it decompresses the ~90 Ruby sections, supplies the
+- The **RGSS script host** is how a project boots by default: the game's own
+  bundled scripts (`Data/Scripts.rxdata`) run unmodified, the way `RGSS104E.dll`
+  runs them — the host decompresses the ~90 Ruby sections, supplies the
   `load_data`/`save_data` built-ins and evaluates each at the top level (via
-  `mruby-eval`) so the game drives itself. It is opt-in (`RGSS_SCRIPT_HOST`)
-  while the RGSS class library is completed; see
-  [`docs/adr/0017-rpgxp-rgss-script-host.md`](docs/adr/0017-rpgxp-rgss-script-host.md)
+  `mruby-eval`), then drives their blocking main loop one frame per callback
+  through a Fiber, so the game's own title, menus, battle system and any
+  community scripts are what run. The reimplemented flow above stays as the
+  fallback — for a project that ships no scripts, if the host fails to boot, and
+  on demand with `--norgss_script_host` (or `RGSS_SCRIPT_HOST=0`); see
+  [`docs/adr/0029-rgss-script-host-by-default.md`](docs/adr/0029-rgss-script-host-by-default.md)
+  and [`docs/adr/0017-rpgxp-rgss-script-host.md`](docs/adr/0017-rpgxp-rgss-script-host.md)
   (data layer: [`docs/adr/0010-rpgxp-rgss-data-layer.md`](docs/adr/0010-rpgxp-rgss-data-layer.md))
 - An XP project is exercised **against the genuine runtime as well as our own**,
   both reaching the same `[RPGXP-MAP]` marker (`--rpgxp_new_game` picks New Game
-  without input): `scripts/rpgxp_boot_check.bash` boots the native binary
-  headlessly (in CI), and `scripts/compare-rpgxp-wine.bash` diffs our frames
+  without input, and with it the built-in flow): `scripts/rpgxp_boot_check.bash`
+  boots the native binary headlessly (in CI) — once that way and once with no
+  flags, where the script host runs the game's own scripts and logs
+  `[RPGXP-SCRIPTS]`, so both boot paths are covered — and
+  `scripts/compare-rpgxp-wine.bash` diffs our frames
   against the **genuine RGSS runtime**, booting the project's own
   `Game.exe`/`RGSS104E.dll` under wine on the same key script (the XP twin of the
   RPG2000 comparison; install the RTP into that wine prefix with
@@ -200,10 +207,10 @@
   same reader the XP side uses, so a single-archive release loads too
 - The window is sized to VX's native 544×416 automatically
 - A VX/VX Ace game's engine *is* its script bundle, so a project that ships
-  `Data/Scripts.rvdata[2]` can be driven by the same experimental **RGSS script
-  host** as XP (`RGSS_SCRIPT_HOST`); the built-in title/map flow is not written
-  yet, and a boot without the host says so rather than opening a blank window.
-  See
+  `Data/Scripts.rvdata[2]` is driven by the same **RGSS script host** as XP, on
+  by default here too; there is no built-in title/map flow to fall back to, so a
+  project without scripts (or a boot with `RGSS_SCRIPT_HOST=0`) says so rather
+  than opening a blank window. See
   [`docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md`](docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md)
 - The **RGSS2/RGSS3 built-ins** those scripts call on their way to a first frame
   are in place: keys named as symbols (`Input.trigger?(:C)`, which VX and VX Ace

--- a/changelog.d/rgss-script-host-default.changed.md
+++ b/changelog.d/rgss-script-host-default.changed.md
@@ -27,6 +27,14 @@
   deviations this engine forces (listed in the file's header). A missing asset
   now yields a blank bitmap and a warning where RGSS raises, so a game whose RTP
   is not installed still boots.
+- **`Errno::ENOENT` exists, so a game's own `Main` cannot swallow every
+  exception.** The editor wraps every project's main loop in
+  `begin … rescue Errno::ENOENT`, mruby ships no `Errno`, and a rescue clause is
+  evaluated when an exception passes through it — so anything leaving the game
+  loop (including the timeout a headless run ends on) came back as
+  `NameError: uninitialized constant Errno`. `RGSSData#read_object` now raises
+  `Errno::ENOENT` with RGSS's message shape ("No such file or directory - <path>",
+  which that handler strips to name the file) on both the XP and VX sides.
 - `scripts/rpgxp_script_host_check.rb` **stops stubbing our own Ruby**: it loads
   the real `rgss_library.rb`, evaluates *every* section of a real bundle except
   `Main` (it used to evaluate a hand-picked subset), and drives the sprite

--- a/changelog.d/rgss-script-host-default.changed.md
+++ b/changelog.d/rgss-script-host-default.changed.md
@@ -35,6 +35,11 @@
   `NameError: uninitialized constant Errno`. `RGSSData#read_object` now raises
   `Errno::ENOENT` with RGSS's message shape ("No such file or directory - <path>",
   which that handler strips to name the file) on both the XP and VX sides.
+- **`Bitmap#draw_text` takes a `Rect`** as well as x/y/width/height, the way RGSS
+  overloads it (and the way `fill_rect` here already did). `Window_Command` — the
+  menu every title screen is built from — calls the Rect form, so without it a
+  game's own engine died at its first window with "wrong number of arguments
+  (given 2, expected 5..6)".
 - `scripts/rpgxp_script_host_check.rb` **stops stubbing our own Ruby**: it loads
   the real `rgss_library.rb`, evaluates *every* section of a real bundle except
   `Main` (it used to evaluate a hand-picked subset), and drives the sprite

--- a/changelog.d/rgss-script-host-default.changed.md
+++ b/changelog.d/rgss-script-host-default.changed.md
@@ -1,18 +1,35 @@
 - **The RGSS script host is now the default boot path.** An RPG Maker XP / VX /
   VX Ace project that ships `Data/Scripts.rxdata` / `Scripts.rvdata[2]` runs its
   own bundled Ruby — title, menus, battle system and any community scripts — the
-  way `RGSS104E.dll` runs it, instead of the reimplemented title/map flow. What
-  had kept it behind a flag is done: the `mruby-rgss` class library the stock
-  scripts call renders, `Kernel#sprintf`/`exit` are in the build, and the
-  scripts' blocking main loop is driven one frame per callback by the Fiber
-  driver (ADR 0023). `RGSS_SCRIPT_HOST` flips from an opt-in to an **opt-out**,
-  and now really reaches the engine: the native runtime resolves it (and the new
-  `--rgss_script_host` flag it seeds) and passes the answer to Ruby as a
-  constant, since this mruby build has no `ENV`. `--rpgxp_new_game` implies the
-  built-in flow too, being the flag that drives its title screen. The built-in
-  flow stays as the fallback for a project that ships no scripts and for a host
-  that fails to boot. `ScriptHost.run` logs
-  `[RPGXP-SCRIPTS] running N script sections`, and
-  `scripts/rpgxp_boot_check.bash` now boots each XP bed twice in CI — under the
-  host (failing if it fell back) and through the built-in flow into the map. See
-  ADR 0029.
+  way `RGSS104E.dll` runs it, instead of the reimplemented title/map flow. The
+  switch (`--rgss_script_host`, and the `RGSS_SCRIPT_HOST` environment variable
+  that seeds it) flips from an opt-in to an **opt-out**: `--norgss_script_host`
+  boots the built-in flow, which also stays as the automatic fallback for a
+  project that ships no scripts and for a host that fails to boot.
+  `--rpgxp_new_game` implies it too, being the flag that drives the built-in
+  title screen. `ScriptHost.run` logs `[RPGXP-SCRIPTS] running N script
+  sections`, and `scripts/rpgxp_boot_check.bash` now boots each XP bed twice in
+  CI — under the host (failing if it fell back) and through the built-in flow
+  into the map. See ADR 0029.
+- **The RGSS standard library a game is written against now exists**
+  (`mruby-rpgxp/mrblib/rgss_library.rb`): `RPG::Sprite`, `RPG::Weather` and
+  `RPG::Cache` are Ruby classes the *player* supplies, so no project ships them
+  — and without them a game stopped 21 sections into its own engine on
+  `class Sprite_Character < RPG::Sprite`. `RPG::Sprite` brings the battler
+  transitions (whiten / appear / escape / collapse), the floating damage pop-up
+  (white, green for recovery, `CRITICAL` above a critical hit), blinking, and
+  `RPG::Animation` playback over a sprite — 16 cell sprites aimed from each
+  frame's cell data, with the frame timings' sound effect and flash, following
+  the sprite as it moves; `RPG::Weather` brings rain, storm and snow;
+  `RPG::Cache` the bitmap cache every graphic a game loads goes through,
+  including cutting a tile out of a tileset and hue-rotated variants. Transcribed
+  from the definitions published in the RGSS Reference Manual, with three
+  deviations this engine forces (listed in the file's header). A missing asset
+  now yields a blank bitmap and a warning where RGSS raises, so a game whose RTP
+  is not installed still boots.
+- `scripts/rpgxp_script_host_check.rb` **stops stubbing our own Ruby**: it loads
+  the real `rgss_library.rb`, evaluates *every* section of a real bundle except
+  `Main` (it used to evaluate a hand-picked subset), and drives the sprite
+  effects, animation, weather and cache against fakes for the native classes
+  only. The empty `RPG::Sprite` stub it used to define is why the check stayed
+  green while no XP game could boot.

--- a/changelog.d/rgss-script-host-default.changed.md
+++ b/changelog.d/rgss-script-host-default.changed.md
@@ -1,0 +1,18 @@
+- **The RGSS script host is now the default boot path.** An RPG Maker XP / VX /
+  VX Ace project that ships `Data/Scripts.rxdata` / `Scripts.rvdata[2]` runs its
+  own bundled Ruby — title, menus, battle system and any community scripts — the
+  way `RGSS104E.dll` runs it, instead of the reimplemented title/map flow. What
+  had kept it behind a flag is done: the `mruby-rgss` class library the stock
+  scripts call renders, `Kernel#sprintf`/`exit` are in the build, and the
+  scripts' blocking main loop is driven one frame per callback by the Fiber
+  driver (ADR 0023). `RGSS_SCRIPT_HOST` flips from an opt-in to an **opt-out**,
+  and now really reaches the engine: the native runtime resolves it (and the new
+  `--rgss_script_host` flag it seeds) and passes the answer to Ruby as a
+  constant, since this mruby build has no `ENV`. `--rpgxp_new_game` implies the
+  built-in flow too, being the flag that drives its title screen. The built-in
+  flow stays as the fallback for a project that ships no scripts and for a host
+  that fails to boot. `ScriptHost.run` logs
+  `[RPGXP-SCRIPTS] running N script sections`, and
+  `scripts/rpgxp_boot_check.bash` now boots each XP bed twice in CI — under the
+  host (failing if it fell back) and through the built-in flow into the map. See
+  ADR 0029.

--- a/changelog.d/rpgxp-rgss-script-host.added.md
+++ b/changelog.d/rpgxp-rgss-script-host.added.md
@@ -4,8 +4,9 @@
   reuses stb_image's zlib decoder), installs the Kernel `load_data`/`save_data`
   built-ins through the project database, and evaluates each section at the top
   level so the game's own engine — title, map, event interpreter, battle — drives
-  itself. Requires the core `mruby-eval` gem. Opt-in for now
-  (`RGSS_SCRIPT_HOST`), with the built-in reimplemented flow (ADR 0010) as the
-  default and the fallback. Decoding, the built-ins and top-level evaluation of
+  itself. Requires the core `mruby-eval` gem. It landed opt-in
+  (`RGSS_SCRIPT_HOST`) and has since become the default boot path (ADR 0029),
+  with the built-in reimplemented flow (ADR 0010) as the fallback and the
+  `RGSS_SCRIPT_HOST=0` opt-out. Decoding, the built-ins and top-level evaluation of
   real script source are validated against the `OpenGame.exe` XP test bed by the
   new `scripts/rpgxp_script_host_check.rb` (run in CI). See ADR 0017.

--- a/changelog.d/rpgxp-script-host-fiber-driver.added.md
+++ b/changelog.d/rpgxp-script-host-fiber-driver.added.md
@@ -5,6 +5,6 @@
   exactly one game frame per call — which lets the web build's per-frame
   `emscripten_set_main_loop` callback keep control each frame instead of hanging on
   the scripts' blocking loop. The scripts run unmodified and no Asyncify is needed.
-  Gated behind the (off-by-default) `RGSS_SCRIPT_HOST` flag, so the built-in flow is
-  unchanged; `mruby-fiber` is added to the build. See
+  It was gated behind the `RGSS_SCRIPT_HOST` flag when it landed and drives every
+  boot now that the host is the default; `mruby-fiber` is added to the build. See
   `docs/adr/0023-rpgxp-script-host-frame-driver.md`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -883,33 +883,38 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
 - **Menus / save / battle** — the default menu screens, saving in the real
   `.rxdata` save format (a portable Marshal save is used for now), and the
   battle system.
-- 🚧 **Run the bundled RGSS scripts** — the largest direction: an `eval`-based
+- ✅ **Run the bundled RGSS scripts** — the largest direction: an `eval`-based
   host that runs `Data/Scripts.rxdata` unmodified against the RGSS class library
-  (the equivalent of the MV "embed the real engine" choice), which would also
-  run community scripts. The **host plumbing now exists** (ADR 0017): a native
-  `RGSS.zlib_inflate` decompresses the script sections, `RPGXP::RGSSData`
-  exposes `read_object`/`save_object`/`scripts`, and `RPGXP::ScriptHost`
-  installs the Kernel `load_data`/`save_data` built-ins and evaluates every
-  section at the top level (mruby-eval) so "Main" drives the game. Boot runs the
-  host when it is enabled (`RGSS_SCRIPT_HOST`, off by default) and the project
-  ships scripts, falling back to the built-in flow otherwise. Decoding, the
-  built-ins and top-level evaluation of real script source are covered by
-  `mruby-rpgxp/test` and `scripts/rpgxp_script_host_check.rb`. Remaining before
-  it can be the default: complete the `mruby-rgss` class library the stock
-  scripts call — the precise gap (measured against the real test-bed scripts) is
-  tracked in [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md). `Font`,
-  `Graphics` timing, `Input` and `Audio` are already covered; the open pieces are
-  `Sprite` extended properties, and the empty `Window` / `Tilemap` / `Plane`
-  widgets, plus `Kernel#sprintf`. (`Graphics.freeze`/`transition` now draw, on
-  the native `Graphics.snap_to_bitmap` — see the VX section below.)
-  Also reconcile the scripts' blocking main loop with the emscripten frame loop
-  (Asyncify or a per-frame driver). (Graphics and audio both come out of the
-  encrypted archive now — see Encrypted archives above.)
+  (the equivalent of the MV "embed the real engine" choice), which also runs
+  community scripts. Built by ADR 0017: a native `RGSS.zlib_inflate` decompresses
+  the script sections, `RPGXP::RGSSData` exposes
+  `read_object`/`save_object`/`scripts`, and `RPGXP::ScriptHost` installs the
+  Kernel `load_data`/`save_data` built-ins and evaluates every section at the top
+  level (mruby-eval) so "Main" drives the game. **It is now the default boot
+  path** (ADR 0029): a project that ships scripts runs its own engine, and the
+  built-in flow is the fallback for a script-less project, a host that fails to
+  boot, and the `RGSS_SCRIPT_HOST=0` opt-out (which `--rpgxp_new_game` implies,
+  since it drives the built-in title screen). What made the flip possible: the
+  `mruby-rgss` class library the stock scripts call is complete enough — `Font`,
+  `Graphics` timing, `Input`, `Audio`, `Sprite`'s extended properties and the
+  `Window`/`Tilemap`/`Plane` widgets all render, plus `Kernel#sprintf` and
+  `exit` — and the scripts' blocking main loop is reconciled with the emscripten
+  frame loop by the per-frame Fiber driver (ADR 0023), rather than Asyncify. The
+  remaining polish is tracked in
+  [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md). Decoding, the built-ins
+  and top-level evaluation of real script source are covered by
+  `mruby-rpgxp/test` and `scripts/rpgxp_script_host_check.rb`; CI also boots both
+  XP beds under the host natively (`scripts/rpgxp_boot_check.bash`, asserting the
+  `[RPGXP-SCRIPTS]` marker and no fallback). Still unverified: the frame driver
+  in a real **browser**. (Graphics and audio both come out of the encrypted
+  archive now — see Encrypted archives above.)
 - ✅ **Cross-runtime testing** — an XP project is booted natively and against the
   genuine runtime, both asserting the same `[RPGXP-MAP]` marker
-  (`--rpgxp_new_game` picks New Game without input):
-  `scripts/rpgxp_boot_check.bash` (the native binary, in CI — the guard against
-  mruby/CRuby divergence the CRuby-hosted checks cannot see) and
+  (`--rpgxp_new_game` picks New Game without input, and with it the built-in
+  flow): `scripts/rpgxp_boot_check.bash` (the native binary, in CI — the guard
+  against mruby/CRuby divergence the CRuby-hosted checks cannot see; it boots
+  each bed a second time with no flags, where the script host runs the game's own
+  scripts) and
   `scripts/compare-rpgxp-wine.bash`, which diffs our frames against the genuine
   `Game.exe` + `RGSS104E.dll` under wine, the XP twin of
   `compare-nepheshel-wine.bash`. That comparison is the harness the remaining
@@ -1089,8 +1094,10 @@ screen (544×416). Full rationale:
     contents (a different composite path; RGSS keeps windows in their own
     viewport, so a map tint does not tint the message window anyway).
 - **Built-in title/map flow** — the reimplemented scene stack the RPG2000 and XP
-  runtimes have (title → New Game → walkable map). Not written yet; a boot
-  without the script host reports that instead of showing a blank window.
+  runtimes have (title → New Game → walkable map). Not written yet; the script
+  host (on by default) runs a project that ships scripts, and a boot without it —
+  no script bundle, or `RGSS_SCRIPT_HOST=0` — reports that instead of showing a
+  blank window.
 - **A real test bed.** Neither editor nor its RTP is redistributable and no
   open-source VX/VX Ace project ships a genuine `Data/*.rvdata(2)` tree, so
   `scripts/rpgvx_testbed_check.rb` builds a full project per edition instead and

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -918,8 +918,12 @@ them, mirroring how the RPG2000 side was staged. Full rationale:
   `mruby-rgss` class library the stock scripts call is complete enough — `Font`,
   `Graphics` timing, `Input`, `Audio`, `Sprite`'s extended properties and the
   `Window`/`Tilemap`/`Plane` widgets all render, plus `Kernel#sprintf` and
-  `exit` — and the scripts' blocking main loop is reconciled with the emscripten
-  frame loop by the per-frame Fiber driver (ADR 0023), rather than Asyncify. The
+  `exit`; the scripts' blocking main loop is reconciled with the emscripten
+  frame loop by the per-frame Fiber driver (ADR 0023), rather than Asyncify; and
+  the **RGSS standard library** — `RPG::Sprite`, `RPG::Weather`, `RPG::Cache`,
+  the Ruby classes `RGSS104E.dll` supplies and no project ships — is now
+  supplied by `mruby-rpgxp/mrblib/rgss_library.rb`, without which a game stopped
+  21 sections in on `class Sprite_Character < RPG::Sprite`. The
   remaining polish is tracked in
   [`docs/rpgxp-rgss-api-gap.md`](rpgxp-rgss-api-gap.md). Decoding, the built-ins
   and top-level evaluation of real script source are covered by

--- a/docs/adr/0017-rpgxp-rgss-script-host.md
+++ b/docs/adr/0017-rpgxp-rgss-script-host.md
@@ -4,7 +4,10 @@ Date: 2026-08-04
 
 ## Status
 
-Accepted
+Accepted. The "opt-in for now" clause below is superseded by
+[ADR 0029](0029-rgss-script-host-by-default.md): the host is the default boot
+path and `RGSS_SCRIPT_HOST` is now the opt-out. Everything else here still
+describes the host as built.
 
 ## Context
 

--- a/docs/adr/0023-rpgxp-script-host-frame-driver.md
+++ b/docs/adr/0023-rpgxp-script-host-frame-driver.md
@@ -4,8 +4,10 @@ Date: 2026-08-04
 
 ## Status
 
-Accepted — driver implemented (gated behind `RGSS_SCRIPT_HOST`); needs a real
-project booted under the web build to verify end to end.
+Accepted — driver implemented. No longer gated: the host it drives is the
+default boot path ([ADR 0029](0029-rgss-script-host-by-default.md)), verified by
+booting both XP beds natively in CI. A real project under the *web* build is
+still the open verification.
 
 ## Context
 

--- a/docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md
+++ b/docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md
@@ -76,11 +76,13 @@ mirroring how the XP layer was staged (ADR 0010).
   the window to 544x416.
 - **Booting.** A VX/VX Ace game's engine *is* its script bundle, so rather than
   reimplementing a title/map flow first (the RPG2000/XP staging), the boot shell
-  runs the project's own scripts through the existing RGSS script host when it is
-  enabled (`RGSS_SCRIPT_HOST`, ADR 0017), driven by the same per-frame Fiber as
+  runs the project's own scripts through the existing RGSS script host (ADR 0017;
+  on by default since [ADR 0029](0029-rgss-script-host-by-default.md), with
+  `RGSS_SCRIPT_HOST=0` as the opt-out), driven by the same per-frame Fiber as
   XP (ADR 0023 — its construction moved into `RPGXP::ScriptHost.build_driver` so
-  both shells share one driver). Without the host the shell reports the pending
-  runtime instead of opening a blank window, as the MZ shell does.
+  both shells share one driver). Without the host — a project that ships no
+  scripts, or that opt-out — the shell reports the pending runtime instead of
+  opening a blank window, as the MZ shell does.
 - **Validation** (`scripts/rpgvx_testbed_check.rb`). Since no real bed can be
   downloaded, the check *builds* a complete project per edition — every `Data/`
   table, a map with an event, a common event, a script bundle — and drives the

--- a/docs/adr/0027-rpgxp-released-game-parity.md
+++ b/docs/adr/0027-rpgxp-released-game-parity.md
@@ -181,8 +181,9 @@ screen). The rest is the windowskin background's shading.
   evaluated at the top level as RGSS does, `$game_switches` and
   `$game_variables` are bound to the same state Control Switches / Control
   Variables write, and nothing else is provided — a game needing the rest of
-  RMXP's object graph wants `RGSS_SCRIPT_HOST`, which exists to give it all of
-  them. The interpreter *queues* the source rather than evaluating it, for the
+  RMXP's object graph wants the script host, which exists to give it all of them
+  (and is the default boot path since [ADR 0029](0029-rgss-script-host-by-default.md),
+  so this flow runs only as its fallback). The interpreter *queues* the source rather than evaluating it, for the
   same reason the other effect commands are queued and one specific to this one:
   `rpgxp_testbed_check.rb` drives the interpreter over real event lists under
   CRuby, and a data check must not run a game's scripts — one of Pray for You's

--- a/docs/adr/0029-rgss-script-host-by-default.md
+++ b/docs/adr/0029-rgss-script-host-by-default.md
@@ -45,6 +45,14 @@ before it could become the default. Each of those has since been closed:
   driver ends the game on, and graphics and audio now load out of an encrypted
   `Game.rgssad` / `.rgss2a` / `.rgss3a`, so a packed release runs from the
   scripts too.
+- **The last one, found by finally being able to run it.** Turning the host on in
+  a built engine (the `--rgss_script_host` flag, which replaced a dead
+  environment-variable switch) showed the bed stopping 21 sections in, on
+  `class Sprite_Character < RPG::Sprite`: `RPG::Sprite`, `RPG::Weather` and
+  `RPG::Cache` are Ruby classes **the player supplies**, so no project ships
+  them and this engine did not have them. They are implemented here — see the
+  Decision — which is what makes the default mean "the game's own engine runs"
+  rather than "the game's own engine is attempted".
 
 Meanwhile the VX / VX Ace runtime ([ADR 0024](0024-rpgvx-rgss2-rgss3-data-layer.md))
 has no reimplemented flow at all: for those editions the host is the *only* way a
@@ -53,8 +61,22 @@ construction" for a game it could have played.
 
 ## Decision
 
-Make the script host the **default** boot path for every RGSS maker, and turn
-`RGSS_SCRIPT_HOST` from an opt-in into an **opt-out**.
+Supply the missing half of the RGSS class library, then make the script host the
+**default** boot path for every RGSS maker, turning the switch from an opt-in
+into an **opt-out**.
+
+- **`mruby-rpgxp/mrblib/rgss_library.rb`** adds the three classes `RGSS104E.dll`
+  supplies as Ruby and no project ships: `RPG::Sprite` (the battler/character
+  sprite base — the timed whiten/appear/escape/collapse transitions, the floating
+  damage pop-up, blinking, and `RPG::Animation` playback through 16 cell sprites
+  with the frames' SE and flash timings), `RPG::Weather` (rain/storm/snow) and
+  `RPG::Cache` (the bitmap cache every graphic a game loads goes through).
+  Transcribed from the definitions published in the RGSS Reference Manual, on
+  top of the native `mruby-rgss` primitives, with three deviations this engine
+  forces — colours re-assigned rather than mutated in place, hue variants
+  re-loaded rather than `clone`d, and a bitmap that will not load standing in as
+  a blank rather than raising. `RGSS::Sprite` grew the `viewport` reader and
+  0-defaulting `x`/`y`/`z` readers those classes read back before writing.
 
 - `RPGXP::ScriptHost.enabled?` returns true unless something says otherwise.
   Two channels, because the two runtimes read their settings differently: the
@@ -86,6 +108,14 @@ Make the script host the **default** boot path for every RGSS maker, and turn
   code at zero) and once with `--rpgxp_new_game` (the built-in flow into the
   map). Both beds are covered — the editor-shaped OpenGame test bed and the
   released *Pray for You*.
+- **`scripts/rpgxp_script_host_check.rb` stops stubbing our own Ruby.** It used
+  to define an empty `RPG::Sprite` and evaluate a hand-picked "logic subset" of
+  the bundle, which is why it stayed green while no game could boot. It now
+  loads the real `rgss_library.rb`, evaluates **every** section but `Main`
+  against fakes for the *native* classes only, asserts `Sprite_Character` and
+  `Sprite_Battler` really do inherit `RPG::Sprite`, and drives the effects,
+  animation, weather and cache. Shimming native code is unavoidable in a CRuby
+  harness; shimming our own is how a gap hides.
 
 ## Consequences
 
@@ -95,9 +125,15 @@ Make the script host the **default** boot path for every RGSS maker, and turn
   project plays instead of printing "under construction".
 - **The fallback is now the exception**, which changes what a regression looks
   like: a game that used to reach the built-in map may now stop inside its own
-  scripts on an `mruby-rgss` method that is still missing. The failure is
-  reported and the built-in flow takes over, so a boot never ends at a blank
-  window, and `RGSS_SCRIPT_HOST=0` restores the old behaviour in one step.
+  scripts on an `mruby-rgss` method that is still missing. The failure names the
+  section, the built-in flow takes over, so a boot never ends at a blank window,
+  and `--norgss_script_host` restores the old behaviour in one step.
+- **Two Ruby files now have to agree with the game's own engine.**
+  `rgss_library.rb` is a transcription of code a game was written against, so it
+  is a compatibility surface, not ours to improve: the deviations are listed in
+  its header, and an "obvious" cleanup there (making `RPG::Weather`'s 1..40 loop
+  over a 0..39 array right, say) would change what a script reading `max` back
+  sees. The published definitions are the specification.
 - **The reimplementation keeps paying for itself.** It is what the wine
   comparison diffs against the genuine runtime, the fallback for script-less
   projects, and the only path on targets too small for the host — so this ADR

--- a/docs/adr/0029-rgss-script-host-by-default.md
+++ b/docs/adr/0029-rgss-script-host-by-default.md
@@ -1,0 +1,108 @@
+# 29. The RGSS script host is the default boot path
+
+Date: 2026-08-05
+
+## Status
+
+Accepted — supersedes the "opt-in for now" clause of
+[ADR 0017](0017-rpgxp-rgss-script-host.md) (the host itself is unchanged).
+
+## Context
+
+An RGSS project ships its whole engine — title, map, message system, menus,
+battle, plus whatever community scripts the author dropped in — as Ruby inside
+`Data/Scripts.rxdata` / `Scripts.rvdata[2]`. `RGSS104E.dll` boots a game by
+evaluating those sections in order; everything above the primitives is the
+game's own code.
+
+This project reached that point from two directions:
+
+- [ADR 0010](0010-rpgxp-rgss-data-layer.md) **reimplemented** XP's default
+  title/map/event flow against the database, the way `mruby-rpg2k` did for
+  RPG2000. It boots a stock project to a walkable map and now handles every
+  event command a real game uses ([ADR 0027](0027-rpgxp-released-game-parity.md)),
+  but by construction it can only ever reproduce the *default* engine: a game
+  with a custom menu, a custom battle system or any plugin script runs as though
+  none of that existed.
+- [ADR 0017](0017-rpgxp-rgss-script-host.md) added the **script host**, which
+  runs the bundled scripts unmodified through `mruby-eval` against the native
+  `mruby-rgss` class library.
+
+The host landed switched off, and ADR 0017 named exactly what had to be true
+before it could become the default. Each of those has since been closed:
+
+- **The RGSS class library was too thin.** `Sprite`'s extended properties, the
+  `Window` / `Tilemap` / `Plane` widgets, `Graphics.freeze`/`transition` and
+  `Kernel#sprintf` are all in place and rendering; the remaining entries in
+  [`docs/rpgxp-rgss-api-gap.md`](../rpgxp-rgss-api-gap.md) and
+  [`docs/rpgvx-rgss-api-gap.md`](../rpgvx-rgss-api-gap.md) are polish, not boot
+  blockers.
+- **The scripts' blocking main loop could not cooperate with the web build's
+  per-frame callback.** [ADR 0023](0023-rpgxp-script-host-frame-driver.md) drives
+  `Main` inside a `Fiber` that the wrapped `Graphics.update` yields once per
+  frame, so one browser callback is one game frame.
+- **`exit` and the archive.** `Kernel#exit` raises a catchable `SystemExit` the
+  driver ends the game on, and graphics and audio now load out of an encrypted
+  `Game.rgssad` / `.rgss2a` / `.rgss3a`, so a packed release runs from the
+  scripts too.
+
+Meanwhile the VX / VX Ace runtime ([ADR 0024](0024-rpgvx-rgss2-rgss3-data-layer.md))
+has no reimplemented flow at all: for those editions the host is the *only* way a
+project runs, and an off-by-default host meant a plain boot reported "under
+construction" for a game it could have played.
+
+## Decision
+
+Make the script host the **default** boot path for every RGSS maker, and turn
+`RGSS_SCRIPT_HOST` from an opt-in into an **opt-out**.
+
+- `RPGXP::ScriptHost.enabled?` returns true unless something says otherwise.
+  Two channels, because the two runtimes read their settings differently: the
+  native binary resolves `--rgss_script_host` (new, default true) and the
+  `RGSS_SCRIPT_HOST` environment variable — which seeds the flag, so an explicit
+  flag wins — and hands the answer to Ruby as an `RGSS_SCRIPT_HOST` **constant**,
+  the way `--rpgxp_new_game` is already passed down; the CRuby harnesses have no
+  such constant and set the variable, so `ENV` is consulted when it exists. This
+  matters: this mruby build has no `ENV`, so before this ADR a booted game could
+  not have read the variable at all. `DISABLED_VALUES` (`0`, `false`, `off`,
+  `no`) is the opt-out spelling, listed on both sides.
+- **The built-in flow stays, as the fallback**, on three paths that need no flag:
+  a project that ships no scripts, a host that raises on the way up (the existing
+  rescue in `RPGXP#drive_script_host` logs and pushes the built-in title scene),
+  and an explicit `RGSS_SCRIPT_HOST=0`.
+- **`--rpgxp_new_game` implies the built-in flow.** The flag drives the *built-in*
+  title screen (it picks New Game without input and logs `[RPGXP-MAP]`); the
+  game's own scripts show their own title and cannot be driven that way. Making
+  it select the built-in flow keeps the headless render checks —
+  `scripts/rpgxp_boot_check.bash`, `scripts/rgssad_asset_check.bash` and the wine
+  comparison of [ADR 0025](0025-rpgxp-cross-runtime-testing.md) — measuring the
+  reimplementation they were written to measure.
+- **`ScriptHost.run` logs `[RPGXP-SCRIPTS] running N script sections`**, the
+  script-host twin of `[RPGXP-MAP]`, so a headless run can assert that the host —
+  not the fallback — booted the game.
+- **CI boots each XP bed twice**: once with no flags (the host runs the game's
+  own scripts; the run fails if `[RPGXP-SCRIPTS]` is missing *or* a
+  `script host failed` fallback line appears, since the fallback keeps the exit
+  code at zero) and once with `--rpgxp_new_game` (the built-in flow into the
+  map). Both beds are covered — the editor-shaped OpenGame test bed and the
+  released *Pray for You*.
+
+## Consequences
+
+- **A game runs as its author wrote it.** Custom menus, custom battle systems and
+  community scripts — the whole reason the RGSS ecosystem exists — are on the
+  default path instead of behind an environment variable, and a VX / VX Ace
+  project plays instead of printing "under construction".
+- **The fallback is now the exception**, which changes what a regression looks
+  like: a game that used to reach the built-in map may now stop inside its own
+  scripts on an `mruby-rgss` method that is still missing. The failure is
+  reported and the built-in flow takes over, so a boot never ends at a blank
+  window, and `RGSS_SCRIPT_HOST=0` restores the old behaviour in one step.
+- **The reimplementation keeps paying for itself.** It is what the wine
+  comparison diffs against the genuine runtime, the fallback for script-less
+  projects, and the only path on targets too small for the host — so this ADR
+  reorders the two, it does not retire either.
+- **Follow-up.** The frame driver has still never been verified in a real browser
+  (the browser check was removed with ADR 0025), so the web build boots the host
+  on the strength of the native runs alone. The two tilemap polish items in the
+  VX gap doc and the `Graphics.transition` image form remain open.

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -303,7 +303,10 @@ a position for music that was not playing. Fixed while building the probe.
 ## What this means for turning the host on
 
 For VX / VX Ace the script host is not an alternative to a built-in flow — it is
-the only route to a real game. A bundle now **runs**: it loads its database,
+the only route to a real game, which is why it now runs **by default** here as on
+the XP side ([ADR 0029](adr/0029-rgss-script-host-by-default.md); the pending
+notice is what a project without scripts, or a boot with `RGSS_SCRIPT_HOST=0`,
+gets instead). A bundle now **runs**: it loads its database,
 plays its music, reads input, drives frames, lays out its windows, draws its map,
 tints, flashes and fades the screen, dissolves between scenes, unrolls and tints
 its windows, and — packed or loose — finds its graphics and its music. What is

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -115,6 +115,29 @@ loaded under CRuby too, where the real ones exist. `RGSSData#read_object` now
 raises `Errno::ENOENT` with RGSS's own message shape, so the handler above
 prints the filename it was written to print.
 
+### 0c. `Bitmap#draw_text`'s Rect form ✅ (the first window a game opens)
+
+RGSS overloads `draw_text` the way it overloads `fill_rect`:
+
+```ruby
+draw_text(x, y, width, height, str[, align])
+draw_text(rect, str[, align])
+```
+
+Only the first was implemented, and `Window_Command#draw_item` — the menu every
+title screen is built from — calls the second, so a game died at its first window
+with `ArgumentError: wrong number of arguments (given 2, expected 5..6)`. The
+native method now takes both, on the same `mrb_get_argc` branch `fill_rect`
+already used.
+
+Worth noting how this was found and bounded: `MRB_ARGS_*` does not enforce
+anything — the `mrb_get_args` format string does — so the arities a game can
+actually call are the union of the format strings in each native function. A
+sweep comparing every call site in both beds' bundles (193 sections) against
+those formats reports no other mismatch, and the calls it does resolve include
+the other overloaded ones (`fill_rect`, `gradient_fill_rect`, `blt`,
+`stretch_blt`), which were already right.
+
 **This gap was invisible for a long time**, for two compounding reasons: the
 switch that turns the host on could not work in a built engine (see the note at
 the end of this document), and `scripts/rpgxp_script_host_check.rb` *stubbed*

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -3,9 +3,10 @@
 The [RGSS script host](adr/0017-rpgxp-rgss-script-host.md) runs an RPG Maker XP
 project's own `Data/Scripts.rxdata` unmodified. The scripts assume the engine
 (normally `RGSS104E.dll`) supplies the RGSS class library; this project supplies
-it as `mruby-rgss`. This document tracks **what the stock scripts call** versus
-**what `mruby-rgss` provides**. The gaps that blocked a default-on host have
-closed and it is now the default boot path
+it as `mruby-rgss` natively, plus the three Ruby classes the player also ships
+(`mruby-rpgxp/mrblib/rgss_library.rb` — see gap 0). This document tracks **what
+the stock scripts call** versus **what the engine provides**. The gaps that
+blocked a default-on host have closed and it is now the default boot path
 ([ADR 0029](adr/0029-rgss-script-host-by-default.md)); what remains here is the
 polish list, and the measure of how far a game gets before it needs the
 built-in flow as a fallback.
@@ -44,35 +45,55 @@ These are complete enough for the stock scripts:
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
-### 0. `RPG::Sprite` and `RPG::Weather` ❌ (the first thing that stops a boot)
+### 0. The RGSS standard library — `RPG::Sprite`, `RPG::Weather`, `RPG::Cache` ✅ (was the first thing that stopped a boot)
 
-Measured, not counted: with `--rgss_script_host` the test bed now gets 21
-sections in before
+Measured, not counted: with the host on, the test bed used to get 21 sections in
+before
 
 ```
 [RGSS] script host: section "Sprite_Character" raised NameError: uninitialized constant RPG::Sprite
 ```
 
-`RPG::Sprite` is **not in the script bundle** — the 90 sections of the
-`OpenGame.exe` bed define no such section, because `RGSS104E.dll` supplies it,
-along with `RPG::Weather`. `Sprite_Character < RPG::Sprite` is therefore the
-first line of the game's own engine that cannot run, and everything downstream
-(`Spriteset_Map`, `Scene_Map`, `Main`) is behind it.
+None of these three is **in the script bundle** — the 90 sections of the
+`OpenGame.exe` bed define no such section, because `RGSS104E.dll` supplies them.
+`Sprite_Character < RPG::Sprite` was therefore the first line of the game's own
+engine that could not run, with everything downstream (`Spriteset_Map`,
+`Scene_Map`, `Main`) behind it, and `RPG::Cache` — which every graphic a game
+loads goes through — behind that at runtime.
 
-What RGSS's `RPG::Sprite` is: a `Sprite` subclass adding the battle/animation
-behaviour — `damage(value, critical)` (the floating damage number),
-`animation(animation, hit)` and `loop_animation` (playing an `RPG::Animation`
-over the sprite), `blink_on`/`blink_off`/`blink?`, `effect?`, and the battler
-transitions `whiten`/`black_out`/`appear`/`escape`/`collapse`, all advanced by
-its own `update`.
+They are plain Ruby in the real player too, so they are plain Ruby here:
+**`mruby-rpgxp/mrblib/rgss_library.rb`**, transcribed from the definitions the
+RGSS Reference Manual publishes, on top of the native `mruby-rgss` primitives.
 
-Most of the animation half already exists in this tree, written for the
-built-in flow's Show Animation (207): `RPGXP::Game::Animation` decodes the frame
-timing and cell rows, and the map scene blits the cells. Lifting that into an
-`RPG::Sprite` the scripts can subclass is the next concrete step for the host.
+- **`RPG::Sprite`** — a `Sprite` subclass adding the battle/animation behaviour:
+  `damage(value, critical)` (the floating damage number, white / green for
+  recovery / `CRITICAL` above it, arcing up and fading over 40 frames),
+  `animation(animation, hit)` and `loop_animation` (an `RPG::Animation` played
+  over the sprite through 16 cell sprites at z 2000, with the frame timings' SE
+  and flash), `blink_on`/`blink_off`/`blink?`, `effect?`, and the battler
+  transitions `whiten`/`appear`/`escape`/`collapse` — all advanced by its own
+  `update`, and its animation cells carried along when the sprite moves.
+- **`RPG::Weather`** — rain, storm and snow: 40 recycled drop sprites over three
+  bitmaps the class draws for itself.
+- **`RPG::Cache`** — the bitmap cache every `RPG::Cache.character` /
+  `.tile` / `.windowskin` call in a game goes through, including cutting a 32x32
+  tile out of a tileset and building hue-rotated variants.
 
-**This gap was invisible until now**, because the switch that turns the host on
-could not work in a built engine — see the note at the end of this document.
+Three deliberate deviations, all forced by this engine and listed in the file's
+header: colours are re-assigned rather than mutated in place (our compositor
+snapshots on assignment), a hue variant is re-loaded rather than `clone`d (a
+native handle must not be shallow-copied), and an asset that will not load gives
+a blank bitmap with a warning instead of raising (a game whose RTP is missing
+must not die on its first graphic).
+
+**This gap was invisible for a long time**, for two compounding reasons: the
+switch that turns the host on could not work in a built engine (see the note at
+the end of this document), and `scripts/rpgxp_script_host_check.rb` *stubbed*
+`RPG::Sprite` with an empty class and evaluated only a hand-picked logic subset,
+so it stayed green throughout. That harness now loads the real
+`rgss_library.rb`, evaluates **every** section except `Main`, and drives the
+effects, the animation, the weather and the cache against fakes for the native
+classes only.
 
 ### 1. `Sprite` extended properties ✅ (opacity/zoom/angle/mirror/tone/color/src_rect/blend_type/bush_depth/flash all rendered)
 
@@ -217,9 +238,11 @@ driver ends the game on (see item 3 above / ADR 0023).
   end; the native beds are booted under the host by
   `scripts/rpgxp_boot_check.bash` in CI, which asserts the host's
   `[RPGXP-SCRIPTS]` marker and fails if it fell back to the built-in flow.
-- None of the above can be built or run in the current CI sandbox; each item is
-  verified by `mruby-rgss/test` (compiled and run in CI) plus the host-side
-  `scripts/rpgxp_script_host_check.rb`.
+- None of the native items above can be built or run in the current CI sandbox;
+  each is verified by `mruby-rgss/test` (compiled and run in CI) plus the
+  host-side `scripts/rpgxp_script_host_check.rb`. The Ruby half (gap 0) is
+  verified for real by that harness — it loads `rgss_library.rb` itself rather
+  than stubbing it, which is the mistake that let gap 0 hide.
 
 ## Why this list was never measured in the engine
 

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -4,8 +4,11 @@ The [RGSS script host](adr/0017-rpgxp-rgss-script-host.md) runs an RPG Maker XP
 project's own `Data/Scripts.rxdata` unmodified. The scripts assume the engine
 (normally `RGSS104E.dll`) supplies the RGSS class library; this project supplies
 it as `mruby-rgss`. This document tracks **what the stock scripts call** versus
-**what `mruby-rgss` provides**, so the host can be turned on by default once the
-gaps close.
+**what `mruby-rgss` provides**. The gaps that blocked a default-on host have
+closed and it is now the default boot path
+([ADR 0029](adr/0029-rgss-script-host-by-default.md)); what remains here is the
+polish list, and the measure of how far a game gets before it needs the
+built-in flow as a fallback.
 
 The "needed" column is derived from the real `data/OpenGame.exe/Testbed/XP`
 scripts (all 90 sections), by counting method/`.new`/constant usage — see the
@@ -167,19 +170,23 @@ driver ends the game on (see item 3 above / ADR 0023).
 
 ## Notes
 
-- With the display classes now rendering, the remaining blocker to turning the
-  host on by default is reconciling the scripts' blocking `$scene.main while
-  $scene` loop with the web build's per-frame `emscripten_set_main_loop` callback
+- **The host is now on by default** ([ADR 0029](adr/0029-rgss-script-host-by-default.md));
+  `RGSS_SCRIPT_HOST=0` is the opt-out that restores the built-in flow, which also
+  remains the automatic fallback for a script-less project or a host that fails to
+  boot. The last blocker before that flip was reconciling the scripts' blocking
+  `$scene.main while $scene` loop with the web build's per-frame
+  `emscripten_set_main_loop` callback
   (the desktop build blocks fine; the web build calls `RPGXP#main_loop` once per
   browser frame, so an unmodified blocking script loop would hang the tab). This
   is now **implemented** ([ADR 0023](adr/0023-rpgxp-script-host-frame-driver.md)):
   when the host is enabled, `RPGXP` runs `Main` inside an mruby `Fiber` and the
   wrapped `Graphics.update` yields it once per frame, so `main_loop` drives one
-  game frame per browser callback. It is gated behind `RGSS_SCRIPT_HOST` (off by
-  default), so the built-in flow is unchanged. `exit` (used by the `Interpreter`)
-  is now wired too — it raises a `SystemExit` the driver ends the game on. The
-  remaining step is to boot a real project under the web build with the flag on and
-  confirm it end to end.
+  game frame per browser callback. `exit` (used by the `Interpreter`) is now
+  wired too — it raises a `SystemExit` the driver ends the game on. The remaining
+  step is to boot a real project under the **web** build and confirm it end to
+  end; the native beds are booted under the host by
+  `scripts/rpgxp_boot_check.bash` in CI, which asserts the host's
+  `[RPGXP-SCRIPTS]` marker and fails if it fell back to the built-in flow.
 - None of the above can be built or run in the current CI sandbox; each item is
   verified by `mruby-rgss/test` (compiled and run in CI) plus the host-side
   `scripts/rpgxp_script_host_check.rb`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -86,6 +86,35 @@ native handle must not be shallow-copied), and an asset that will not load gives
 a blank bitmap with a warning instead of raising (a game whose RTP is missing
 must not die on its first graphic).
 
+With those three in place the host runs a game's whole bundle — **all 103
+sections of the released *Pray for You*** — and reaches `Main`, where it met the
+next one:
+
+### 0b. `Errno::ENOENT` ✅ (an unresolvable rescue clause eats every exception)
+
+The editor writes this into the `Main` section of *every* project:
+
+```ruby
+begin
+  $scene = Scene_Title.new
+  $scene.main while $scene != nil
+  Graphics.transition(20)
+rescue Errno::ENOENT
+  print("Unable to find file #{$!.message.sub("No such file or directory - ", "")}.")
+end
+```
+
+mruby ships no `Errno` (no `mruby-errno` gem is vendored or configured). A rescue
+clause is evaluated when an exception passes through it, so *any* exception
+leaving the game loop — including the timeout a headless run ends on — came back
+as `NameError: uninitialized constant Errno`, which reads as "the game crashed"
+when the game was running fine. `rgss_library.rb` defines `Errno::ENOENT` (plus
+`EACCES`/`EEXIST`/`EINVAL`/`EISDIR`, so a script rescuing one of those does not
+hit the same trap) and `SystemCallError`, each only when absent — the file is
+loaded under CRuby too, where the real ones exist. `RGSSData#read_object` now
+raises `Errno::ENOENT` with RGSS's own message shape, so the handler above
+prints the filename it was written to print.
+
 **This gap was invisible for a long time**, for two compounding reasons: the
 switch that turns the host on could not work in a built engine (see the note at
 the end of this document), and `scripts/rpgxp_script_host_check.rb` *stubbed*

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -542,7 +542,30 @@ module RGSS
 
   class Sprite
     attr_reader :bitmap
-    attr_reader :x, :y, :z
+
+    # The viewport the sprite was created in (the native #initialize stores it to
+    # keep it alive). RPG::Sprite reads it to put its damage pop-up and animation
+    # cells in the same viewport as the battler — RGSS exposes it, and without the
+    # reader those sprites would land on the default screen viewport instead.
+    attr_reader :viewport
+
+    # Position. Native `x=`/`y=`/`z=` store these ivars, but nothing sets them
+    # before the first assignment, so the readers have to answer RGSS's default of
+    # 0 rather than nil: a sprite's `x` is read *before* it is written on every
+    # relative move (`RPG::Sprite#x=` computes the shift to carry its animation
+    # cells along, `RPG::Weather#update` scrolls each drop from where it is), and
+    # nil would raise there.
+    def x
+      @x || 0
+    end
+
+    def y
+      @y || 0
+    end
+
+    def z
+      @z || 0
+    end
 
     # RGSS Sprite properties the stock scripts set — opacity fades, zoom, angle,
     # tone/colour, scroll origin, mirror, bush depth, blend mode, source rect,

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2209,13 +2209,33 @@ void measure_text(std::string_view s, int& width, unsigned& height) {
   }
 }
 
+// RGSS Bitmap#draw_text, in both the forms RGSS documents:
+//
+//   draw_text(x, y, width, height, str[, align])
+//   draw_text(rect, str[, align])
+//
+// The Rect form is not a nicety -- `Window_Command#draw_item`, the menu every
+// game's title screen is built from, calls it -- so a bitmap that only took the
+// four-number form stopped a game's own engine at its first window with
+// "wrong number of arguments (given 2, expected 5..6)". Same argc branch as
+// #fill_rect, which RGSS overloads the same way.
 mrb_value bmp_draw_text(mrb_state* M, mrb_value self) {
   auto& bmp = bmp_self(M, self);
 
   mrb_int x, y, w, h, len;
   mrb_int align = 0;
   const char* s;
-  mrb_get_args(M, "iiiis|i", &x, &y, &w, &h, &s, &len, &align);
+  if (mrb_get_argc(M) <= 3) {
+    V r;
+    mrb_get_args(M, "os|i", &r, &s, &len, &align);
+    Rect& rc = DataType<Rect>::get(M, r);
+    x = rc.x;
+    y = rc.y;
+    w = rc.width;
+    h = rc.height;
+  } else {
+    mrb_get_args(M, "iiiis|i", &x, &y, &w, &h, &s, &len, &align);
+  }
   const std::string_view sv(s, len);
 
   // Prefer the game's TrueType font (RPG Maker XP/VX ship one under Fonts/),
@@ -5474,8 +5494,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "tone_blt", bmp_tone_blt, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "stretch_blt", bmp_stretch_blt,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  // Both RGSS forms: (x, y, width, height, str[, align]) and (rect, str[,
+  // align]).
   mrb_define_method(M, bmp, "draw_text", bmp_draw_text,
-                    MRB_ARGS_REQ(5) | MRB_ARGS_OPT(1));
+                    MRB_ARGS_REQ(2) | MRB_ARGS_OPT(4));
   mrb_define_method(M, bmp, "blend_text", bmp_blend_text,
                     MRB_ARGS_REQ(10) | MRB_ARGS_OPT(1));
   mrb_define_method(M, bmp, "text_size", bmp_text_size, MRB_ARGS_REQ(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -381,6 +381,39 @@ assert "RGSS::Bitmap#draw_text renders in the font colour" do
   assert_equal 0.0, drawn.blue
 end
 
+# RGSS overloads #draw_text: a Rect stands in for x/y/width/height, the way
+# #fill_rect takes either. It is not a nicety — `Window_Command#draw_item`, the
+# menu every RPG Maker XP title screen is built from, calls
+# `contents.draw_text(rect, text)` — so with only the four-number form a game's
+# own engine died at its first window ("wrong number of arguments (given 2,
+# expected 5..6)"), which is how the script-host boot check found this.
+assert "RGSS::Bitmap#draw_text takes a Rect as well as x/y/width/height" do
+  pixels = lambda do |bitmap|
+    seen = []
+    0.upto(bitmap.height - 1) do |y|
+      0.upto(bitmap.width - 1) do |x|
+        seen.push([x, y]) if bitmap.get_pixel(x, y).alpha > 0
+      end
+    end
+    seen
+  end
+
+  numbers = RGSS::Bitmap.new(64, 24)
+  numbers.draw_text(8, 4, 40, 16, "Hi", 1)
+  rect = RGSS::Bitmap.new(64, 24)
+  assert_equal rect, rect.draw_text(RGSS::Rect.new(8, 4, 40, 16), "Hi", 1)
+
+  drawn = pixels.call(rect)
+  assert_true drawn.size > 0, "the Rect form drew nothing"
+  assert_equal pixels.call(numbers), drawn,
+               "the Rect form drew somewhere else than x/y/width/height"
+
+  # Without an align argument, as Window_Command calls it.
+  plain = RGSS::Bitmap.new(64, 24)
+  plain.draw_text(RGSS::Rect.new(0, 0, 64, 24), "Hi")
+  assert_true pixels.call(plain).size > 0, "the 2-argument Rect form drew nothing"
+end
+
 # The fallback for projects that ship no font. RGSS.default_font_path finds the
 # bundled default font (assets/fonts) — downloaded rather than committed, so nil
 # is a normal answer here — and Font.default_path is the opt-in switch each

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -117,7 +117,9 @@ class RPGVX
     RGSS.asset_archive = @db.archive if @db
     @title = read_title
     # A VX/VX Ace project's engine *is* its script bundle, so the script host is
-    # the only path that can currently run one. Off by default, like XP's.
+    # the only path that can run one — and it is on by default, like XP's. The
+    # pending-runtime notice below is what a project without scripts (or a boot
+    # with RGSS_SCRIPT_HOST=0) gets instead.
     @use_script_host = @db && RPGXP::ScriptHost.enabled? && @db.scripts?
     setup_script_host_driver if @use_script_host
   rescue StandardError => e
@@ -225,8 +227,9 @@ class RPGVX
                  "database (Data/*#{@edition ? self.class.data_ext(@edition) : ".rvdata"}, " \
                  "loose or inside an encrypted archive) loads, but the built-in " \
                  "title/map flow is not written yet. A project that ships its " \
-                 "scripts can be driven by the RGSS script host instead " \
-                 "(RGSS_SCRIPT_HOST=1). See " \
+                 "scripts is run by the RGSS script host instead, which is on " \
+                 "by default — so this project either ships none or was booted " \
+                 "with RGSS_SCRIPT_HOST=0. See " \
                  "docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md."
   end
 end

--- a/mruby-rpgvx/mrblib/rgss_data.rb
+++ b/mruby-rpgvx/mrblib/rgss_data.rb
@@ -106,7 +106,10 @@ class RPGVX
     # RGSS's Kernel#load_data ("Data/System.rvdata2", "Save1.rvdata2", ...). A
     # loose file on disk shadows the archive, matching RGSS; when there is none
     # the entry is pulled from the encrypted archive. The RGSS script host uses
-    # this to feed Kernel#load_data.
+    # this to feed Kernel#load_data. A file in neither place raises
+    # Errno::ENOENT, the exception RGSS raises and a game's scripts are written
+    # to handle, with RGSS's own message shape — same as the XP side (see
+    # mruby-rpgxp/mrblib/rgss_library.rb, which defines it for this build).
     def read_object(relative_path)
       full = "#{@game_dir}/#{relative_path}"
       return File.open(full, "rb") { |f| Marshal.load(f.read) } if File.exist?(full)
@@ -114,7 +117,7 @@ class RPGVX
         bytes = @archive.read(relative_path)
         return Marshal.load(bytes) if bytes
       end
-      raise "cannot load #{relative_path}: no loose file and no archive entry"
+      raise Errno::ENOENT.new(relative_path)
     end
 
     # Marshal-dump `obj` to a project-relative file (RGSS's Kernel#save_data).

--- a/mruby-rpgxp/mrbgem.rake
+++ b/mruby-rpgxp/mrbgem.rake
@@ -34,7 +34,11 @@ MRuby::Gem::Specification.new('mruby-rpgxp') do |spec|
   # constants (and pulls RGSS into Object), which the scene/game sources read at
   # class-body evaluation time. Set the order explicitly rather than relying on
   # the default alphabetical glob.
-  spec.rbfiles = %w[lib rgss_data script_host rgssad game interpreter scene].map do |name|
+  # rgss_library defines RPG::Sprite (a subclass of the native RGSS::Sprite) at
+  # load time, so it comes after lib.rb pulls RGSS in; the script host evaluates
+  # a game's own scripts against it.
+  spec.rbfiles = %w[lib rgss_data rgss_library script_host rgssad game
+                    interpreter scene].map do |name|
     "#{dir}/mrblib/#{name}.rb"
   end
 end

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -47,10 +47,13 @@ class RPGXP
     # own scripts, so the loaders need it globally (see RGSS.asset_archive).
     RGSS.asset_archive = @db.archive
     @scenes = []
-    # When the script host is enabled and the project ships its scripts, the
-    # game's own Ruby drives everything (see script_host.rb); skip building the
-    # built-in title scene, which #start would otherwise run instead.
-    @use_script_host = ScriptHost.enabled? && @db.scripts?
+    # The default path: when the project ships its scripts, the game's own Ruby
+    # drives everything (see script_host.rb); skip building the built-in title
+    # scene, which #start would otherwise run instead. The built-in flow takes
+    # over for a project that ships no scripts, when the host is switched off
+    # (--norgss_script_host / RGSS_SCRIPT_HOST=0, or --rpgxp_new_game below), and
+    # if the host fails to boot (see #drive_script_host).
+    @use_script_host = ScriptHost.enabled? && @db.scripts? && !builtin_flow_forced?
     if @use_script_host
       # The scripts own their whole blocking main loop; drive it one frame at a
       # time through a Fiber so the web build's per-frame callback still gets
@@ -167,6 +170,23 @@ class RPGXP
   end
 
   private
+
+  # `--rpgxp_new_game` drives the *built-in* title screen (Scene::Title picks New
+  # Game without input and logs [RPGXP-MAP]) — the game's own scripts show their
+  # own title and cannot be driven that way. The flag therefore means "run the
+  # built-in flow", so the headless render checks that pass it
+  # (scripts/rpgxp_boot_check.bash, scripts/rgssad_asset_check.bash) keep
+  # measuring the reimplementation now that the script host is the default.
+  #
+  # Read through its own begin/rescue like Scene::Title#auto_new_game?: the
+  # constant is defined by the native binary (src/main.cxx) and absent under the
+  # CRuby harnesses, and Module#const_get is not something this mruby build is
+  # known to carry.
+  def builtin_flow_forced?
+    RPGXP_NEW_GAME
+  rescue StandardError
+    false
+  end
 
   # Build the driver Fiber for the bundled scripts (which installs the per-frame
   # Graphics.update yield). Only reached when the host is enabled, so the

--- a/mruby-rpgxp/mrblib/rgss_data.rb
+++ b/mruby-rpgxp/mrblib/rgss_data.rb
@@ -286,6 +286,11 @@ class RPGXP
     # "Save1.rxdata" in the game root, ...). A loose file on disk shadows the
     # archive, matching RGSS; when there is none the entry is pulled from the
     # encrypted archive. The RGSS script host uses this to feed Kernel#load_data.
+    # A file that is in neither place raises Errno::ENOENT with RGSS's own
+    # message ("No such file or directory - <path>"), because that is the
+    # exception a game is written to handle: the stock "Main" rescues it and
+    # prints the filename out of the message (see rgss_library.rb). It is a
+    # StandardError, so callers that rescue broadly are unaffected.
     def read_object(relative_path)
       full = "#{@game_dir}/#{relative_path}"
       return File.open(full, "rb") { |f| Marshal.load(f.read) } if File.exist?(full)
@@ -293,7 +298,7 @@ class RPGXP
         bytes = @archive.read(relative_path)
         return Marshal.load(bytes) if bytes
       end
-      raise "cannot load #{relative_path}: no loose file and no archive entry"
+      raise Errno::ENOENT.new(relative_path)
     end
 
     # Marshal-dump `obj` to a project-relative file (RGSS's Kernel#save_data).

--- a/mruby-rpgxp/mrblib/rgss_library.rb
+++ b/mruby-rpgxp/mrblib/rgss_library.rb
@@ -1,0 +1,692 @@
+# The RGSS standard library — the Ruby classes RGSS104E.dll supplies to a game,
+# which its script bundle does not contain.
+#
+# An RPG Maker XP project ships ~90 script sections and *none* of them defines
+# `RPG::Cache`, `RPG::Sprite` or `RPG::Weather`: the player provides those three,
+# so the editor leaves them out of every project. That is why the script host
+# (script_host.rb) could not boot a game — the bundle's 24th section opens with
+# `class Sprite_Character < RPG::Sprite`, and the constant did not exist:
+#
+#   [RGSS] script host: section "Sprite_Character" raised
+#          NameError: uninitialized constant RPG::Sprite
+#
+# with `Spriteset_Map`, `Scene_Map` and `Main` all behind it. These are the RGSS
+# equivalents of what `mruby-rgss` already supplies natively (Bitmap, Sprite,
+# Viewport, Window, …) — plain Ruby in the real player too, which is why they are
+# plain Ruby here, transcribed from the definitions published in the RGSS
+# Reference Manual so a game's own engine sees the behaviour it was written
+# against. See docs/adr/0029-rgss-script-host-by-default.md.
+#
+# **Deliberate deviations from the published source**, all forced by this engine
+# rather than chosen:
+#
+#   * **Colours are re-assigned, never mutated in place.** RGSS's version does
+#     `self.color.set(...)` and `self.color.alpha = ...`; here a Sprite's colour
+#     is baked into a pre-composited scratch bitmap when it is *assigned*
+#     (mruby-rgss), so mutating the Color object in place would change nothing on
+#     screen. Every `color.set` below is `self.color = RGSS::Color.new(...)`.
+#   * **`RPG::Cache` reloads a bitmap for a hue variant** instead of RGSS's
+#     `@cache[path].clone`: a Bitmap here wraps a native handle, and a shallow
+#     copy would give two Ruby objects one buffer to free.
+#   * **A missing asset yields a blank 32x32 bitmap and a warning**, where RGSS
+#     raises. A game whose RTP is not installed must not die on its first
+#     graphic — the built-in flow already draws placeholders for the same reason.
+#   * **Fully-qualified `RGSS::` names**, so the file also loads under the CRuby
+#     harness (scripts/rpgxp_script_host_check.rb), which shims those classes.
+#   * Integer conversions where RGSS relies on Ruby's implicit Float→Integer in
+#     the native setters (`opacity`).
+#
+# Every method RGSS publishes keeps its exact name — a game's scripts call and
+# override them (`dispose_damage`, `update_animation`, `animation_set_sprites`, …)
+# and a custom battle system routinely reopens this class. The handful of helpers
+# that are *ours* (extracted from RGSS's inline code) are prefixed `_rgss_` so
+# they cannot collide with something a script defines. For the same reason this
+# file is not a place to tidy: the published definitions are the specification,
+# quirks included (`RPG::Weather` loops 1..40 over a 0..39 array, so a game asking
+# for 40 drops gets 39 — in the real player too).
+
+module RPG
+  # The bitmap cache. Every graphic a game loads goes through here — the scripts
+  # call `RPG::Cache.character(name, hue)`, `.tile(tileset, id, hue)`,
+  # `.windowskin(name)` and so on — so it is also what keeps a map from reloading
+  # its charsets every frame.
+  module Cache
+    @cache = {}
+
+    # A blank bitmap stands in for both an empty name (RGSS's own behaviour) and
+    # an asset that will not load (ours — see the header).
+    BLANK_SIZE = 32
+
+    def self.load_bitmap(folder_name, filename, hue = 0)
+      path = folder_name + filename
+      bitmap = @cache[path]
+      if bitmap.nil? || bitmap.disposed?
+        bitmap = filename == "" ? blank : (load_file(path) || blank)
+        @cache[path] = bitmap
+      end
+      return bitmap if hue == 0
+      hued(path, filename, hue, bitmap)
+    end
+
+    def self.animation(filename, hue)
+      load_bitmap("Graphics/Animations/", filename, hue)
+    end
+
+    def self.autotile(filename)
+      load_bitmap("Graphics/Autotiles/", filename)
+    end
+
+    def self.battleback(filename)
+      load_bitmap("Graphics/Battlebacks/", filename)
+    end
+
+    def self.battler(filename, hue)
+      load_bitmap("Graphics/Battlers/", filename, hue)
+    end
+
+    def self.character(filename, hue)
+      load_bitmap("Graphics/Characters/", filename, hue)
+    end
+
+    def self.fog(filename, hue)
+      load_bitmap("Graphics/Fogs/", filename, hue)
+    end
+
+    def self.gameover(filename)
+      load_bitmap("Graphics/Gameovers/", filename)
+    end
+
+    def self.icon(filename)
+      load_bitmap("Graphics/Icons/", filename)
+    end
+
+    def self.panorama(filename, hue)
+      load_bitmap("Graphics/Panoramas/", filename, hue)
+    end
+
+    def self.picture(filename)
+      load_bitmap("Graphics/Pictures/", filename)
+    end
+
+    def self.tileset(filename)
+      load_bitmap("Graphics/Tilesets/", filename)
+    end
+
+    def self.title(filename)
+      load_bitmap("Graphics/Titles/", filename)
+    end
+
+    def self.windowskin(filename)
+      load_bitmap("Graphics/Windowskins/", filename)
+    end
+
+    # One 32x32 tile cut out of the tileset, as a map event's "graphic is a tile"
+    # setting needs. Tile ids start at 384, laid out 8 per row.
+    def self.tile(filename, tile_id, hue)
+      key = "#{filename}\t#{tile_id}\t#{hue}"
+      bitmap = @cache[key]
+      return bitmap unless bitmap.nil? || bitmap.disposed?
+      bitmap = RGSS::Bitmap.new(32, 32)
+      x = (tile_id - 384) % 8 * 32
+      y = (tile_id - 384) / 8 * 32
+      bitmap.blt(0, 0, tileset(filename), RGSS::Rect.new(x, y, 32, 32))
+      bitmap.hue_change(hue) unless hue == 0
+      @cache[key] = bitmap
+    end
+
+    # RGSS empties the cache between scenes (its `Scene_*` do this on a map
+    # change) and collects. Keep the same contract; the bitmaps themselves are
+    # freed by the GC with their handles.
+    def self.clear
+      @cache = {}
+      GC.start if Object.const_defined?(:GC)
+    end
+
+    # A hue-rotated copy, cached under its own key. RGSS clones the cached bitmap
+    # and rotates the clone; a native handle cannot be shallow-copied, so this
+    # loads the file a second time instead. `base` is the hue-0 bitmap already in
+    # the cache, returned when there is nothing to reload — an empty name, or a
+    # file that did not load, where rotating the stand-in would only give the
+    # caller a *differently* blank bitmap.
+    def self.hued(path, filename, hue, base)
+      cached = @cache["#{path}\t#{hue}"]
+      return cached unless cached.nil? || cached.disposed?
+      bitmap = filename == "" ? nil : load_file(path)
+      return base if bitmap.nil?
+      bitmap.hue_change(hue)
+      @cache["#{path}\t#{hue}"] = bitmap
+    end
+
+    # Load one file, or report it and let the caller stand in. RGSS raises here;
+    # a game whose RTP is missing would then die on its first graphic, so the
+    # failure is reported once per path (the cache means one attempt each) and the
+    # boot carries on.
+    def self.load_file(path)
+      RGSS::Bitmap.new(path)
+    rescue StandardError => e
+      $stderr.puts "[RGSS] RPG::Cache: #{path} did not load (#{e.message}); " \
+                   "using a blank bitmap"
+      nil
+    end
+
+    def self.blank
+      RGSS::Bitmap.new(BLANK_SIZE, BLANK_SIZE)
+    end
+  end
+
+  # The sprite base class every battler and character sprite in a game subclasses
+  # (`Sprite_Character < RPG::Sprite`, `Sprite_Battler < RPG::Sprite`). It adds
+  # the timed battle effects — whiten / appear / escape / collapse, the floating
+  # damage pop-up, blinking — and plays `RPG::Animation`s over the sprite, all
+  # advanced one frame at a time by #update.
+  class Sprite < ::RGSS::Sprite
+    # Animations whose position is "screen" (3) are drawn once no matter how many
+    # targets they play on, so RGSS tracks which ones a frame has already built
+    # sprites for and clears the list at the end of every #update.
+    @@_animations = []
+    # Animation graphics are shared between the sprites playing them; the count
+    # says when the last player is done and the bitmap can go.
+    @@_reference_count = {}
+
+    def initialize(viewport = nil)
+      super(viewport)
+      @_whiten_duration = 0
+      @_appear_duration = 0
+      @_escape_duration = 0
+      @_collapse_duration = 0
+      @_damage_duration = 0
+      @_animation_duration = 0
+      @_blink = false
+    end
+
+    def dispose
+      dispose_damage
+      dispose_animation
+      dispose_loop_animation
+      super
+    end
+
+    # A weak white flash — a battler acting.
+    def whiten
+      self.blend_type = 0
+      self.color = RGSS::Color.new(255, 255, 255, 128)
+      self.opacity = 255
+      @_whiten_duration = 16
+      @_appear_duration = 0
+      @_escape_duration = 0
+      @_collapse_duration = 0
+    end
+
+    # Fade in — a revived actor, an appearing enemy.
+    def appear
+      self.blend_type = 0
+      self.color = RGSS::Color.new(0, 0, 0, 0)
+      self.opacity = 0
+      @_appear_duration = 16
+      @_whiten_duration = 0
+      @_escape_duration = 0
+      @_collapse_duration = 0
+    end
+
+    # Fade out — an enemy running away.
+    def escape
+      self.blend_type = 0
+      self.color = RGSS::Color.new(0, 0, 0, 0)
+      self.opacity = 255
+      @_escape_duration = 32
+      @_whiten_duration = 0
+      @_appear_duration = 0
+      @_collapse_duration = 0
+    end
+
+    # Red-tinted fade — a battler dying.
+    def collapse
+      self.blend_type = 1
+      self.color = RGSS::Color.new(255, 64, 64, 255)
+      self.opacity = 255
+      @_collapse_duration = 48
+      @_whiten_duration = 0
+      @_appear_duration = 0
+      @_escape_duration = 0
+    end
+
+    # The damage pop-up: white for damage, green for recovery, the text as given
+    # for "Miss", with an optional CRITICAL above it. Drawn into its own bitmap
+    # on a sprite at z 3000 that floats up and fades over 40 frames.
+    def damage(value, critical)
+      dispose_damage
+      damage_string = value.is_a?(Numeric) ? value.abs.to_s : value.to_s
+      bitmap = RGSS::Bitmap.new(160, 48)
+      bitmap.font.name = "Arial Black"
+      bitmap.font.size = 32
+      bitmap.font.color = RGSS::Color.new(0, 0, 0)
+      bitmap.draw_text(-1, 12 - 1, 160, 36, damage_string, 1)
+      bitmap.draw_text(+1, 12 - 1, 160, 36, damage_string, 1)
+      bitmap.draw_text(-1, 12 + 1, 160, 36, damage_string, 1)
+      bitmap.draw_text(+1, 12 + 1, 160, 36, damage_string, 1)
+      bitmap.font.color = if value.is_a?(Numeric) && value < 0
+                            RGSS::Color.new(176, 255, 144)
+                          else
+                            RGSS::Color.new(255, 255, 255)
+                          end
+      bitmap.draw_text(0, 12, 160, 36, damage_string, 1)
+      if critical
+        bitmap.font.size = 20
+        bitmap.font.color = RGSS::Color.new(0, 0, 0)
+        bitmap.draw_text(-1, -1, 160, 20, "CRITICAL", 1)
+        bitmap.draw_text(+1, -1, 160, 20, "CRITICAL", 1)
+        bitmap.draw_text(-1, +1, 160, 20, "CRITICAL", 1)
+        bitmap.draw_text(+1, +1, 160, 20, "CRITICAL", 1)
+        bitmap.font.color = RGSS::Color.new(255, 255, 255)
+        bitmap.draw_text(0, 0, 160, 20, "CRITICAL", 1)
+      end
+      @_damage_sprite = ::RGSS::Sprite.new(self.viewport)
+      @_damage_sprite.bitmap = bitmap
+      @_damage_sprite.ox = 80
+      @_damage_sprite.oy = 20
+      @_damage_sprite.x = self.x
+      @_damage_sprite.y = self.y - self.oy / 2
+      @_damage_sprite.z = 3000
+      @_damage_duration = 40
+    end
+
+    # Play `animation` (an RPG::Animation) once over this sprite. Sixteen cell
+    # sprites are built at z 2000 and re-aimed each animation frame; `hit` is what
+    # the animation's SE/flash timings test.
+    def animation(animation, hit)
+      dispose_animation
+      @_animation = animation
+      return if @_animation.nil?
+      @_animation_hit = hit
+      @_animation_duration = @_animation.frame_max
+      bitmap = Cache.animation(@_animation.animation_name,
+                              @_animation.animation_hue)
+      _rgss_retain(bitmap)
+      @_animation_sprites = []
+      if @_animation.position != 3 || !@@_animations.include?(animation)
+        16.times do
+          sprite = ::RGSS::Sprite.new(self.viewport)
+          sprite.bitmap = bitmap
+          sprite.visible = false
+          @_animation_sprites.push(sprite)
+        end
+        @@_animations.push(animation) unless @@_animations.include?(animation)
+      end
+      update_animation
+    end
+
+    # The same, looping — a state animation on a battler, which runs until it is
+    # replaced or cleared with nil.
+    def loop_animation(animation)
+      return if animation == @_loop_animation
+      dispose_loop_animation
+      @_loop_animation = animation
+      return if @_loop_animation.nil?
+      @_loop_animation_index = 0
+      bitmap = Cache.animation(@_loop_animation.animation_name,
+                              @_loop_animation.animation_hue)
+      _rgss_retain(bitmap)
+      @_loop_animation_sprites = []
+      16.times do
+        sprite = ::RGSS::Sprite.new(self.viewport)
+        sprite.bitmap = bitmap
+        sprite.visible = false
+        @_loop_animation_sprites.push(sprite)
+      end
+      update_loop_animation
+    end
+
+    def dispose_damage
+      return if @_damage_sprite.nil?
+      @_damage_sprite.bitmap.dispose
+      @_damage_sprite.dispose
+      @_damage_sprite = nil
+      @_damage_duration = 0
+    end
+
+    def dispose_animation
+      return if @_animation_sprites.nil?
+      _rgss_release(@_animation_sprites[0])
+      @_animation_sprites.each { |sprite| sprite.dispose }
+      @_animation_sprites = nil
+      @_animation = nil
+    end
+
+    def dispose_loop_animation
+      return if @_loop_animation_sprites.nil?
+      _rgss_release(@_loop_animation_sprites[0])
+      @_loop_animation_sprites.each { |sprite| sprite.dispose }
+      @_loop_animation_sprites = nil
+      @_loop_animation = nil
+    end
+
+    def blink_on
+      return if @_blink
+      @_blink = true
+      @_blink_count = 0
+    end
+
+    def blink_off
+      return unless @_blink
+      @_blink = false
+      self.color = RGSS::Color.new(0, 0, 0, 0)
+    end
+
+    def blink?
+      @_blink
+    end
+
+    # True while any one-shot effect is still running. A battle scene waits on
+    # this before moving on, so the durations below are what pace it. Neither the
+    # looping animation nor the blink counts, by RGSS's definition.
+    def effect?
+      @_whiten_duration > 0 ||
+        @_appear_duration > 0 ||
+        @_escape_duration > 0 ||
+        @_collapse_duration > 0 ||
+        @_damage_duration > 0 ||
+        @_animation_duration > 0
+    end
+
+    # One frame of every effect. Called from each subclass's own #update (via
+    # `super`), so it runs once per game frame.
+    def update
+      super
+      if @_whiten_duration > 0
+        @_whiten_duration -= 1
+        self.color = RGSS::Color.new(255, 255, 255,
+                                     128 - (16 - @_whiten_duration) * 10)
+      end
+      if @_appear_duration > 0
+        @_appear_duration -= 1
+        self.opacity = (16 - @_appear_duration) * 16
+      end
+      if @_escape_duration > 0
+        @_escape_duration -= 1
+        self.opacity = 256 - (32 - @_escape_duration) * 10
+      end
+      if @_collapse_duration > 0
+        @_collapse_duration -= 1
+        self.opacity = 256 - (48 - @_collapse_duration) * 6
+      end
+      _rgss_update_damage if @_damage_duration > 0
+      # Animations advance every other frame — RGSS's animations are 2 game
+      # frames per animation frame.
+      if !@_animation.nil? && (RGSS::Graphics.frame_count % 2 == 0)
+        @_animation_duration -= 1
+        update_animation
+      end
+      if !@_loop_animation.nil? && (RGSS::Graphics.frame_count % 2 == 0)
+        update_loop_animation
+        @_loop_animation_index += 1
+        @_loop_animation_index %= @_loop_animation.frame_max
+      end
+      _rgss_update_blink if @_blink
+      @@_animations.clear
+    end
+
+    # The pop-up's arc: up fast, up slow, back down, then fading out. Split out of
+    # #update (RGSS has it inline) only to keep that method readable.
+    def _rgss_update_damage
+      @_damage_duration -= 1
+      case @_damage_duration
+      when 38, 39 then @_damage_sprite.y -= 4
+      when 36, 37 then @_damage_sprite.y -= 2
+      when 34, 35 then @_damage_sprite.y += 2
+      when 28, 29, 30, 31, 32, 33 then @_damage_sprite.y += 4
+      end
+      @_damage_sprite.opacity = 256 - (12 - @_damage_duration) * 32
+      dispose_damage if @_damage_duration == 0
+    end
+
+    def _rgss_update_blink
+      @_blink_count = (@_blink_count + 1) % 32
+      alpha = @_blink_count < 16 ? (16 - @_blink_count) * 6 : (@_blink_count - 16) * 6
+      self.color = RGSS::Color.new(255, 255, 255, alpha)
+    end
+
+    def update_animation
+      unless @_animation_duration > 0
+        dispose_animation
+        return
+      end
+      frame_index = @_animation.frame_max - @_animation_duration
+      cell_data = @_animation.frames[frame_index].cell_data
+      animation_set_sprites(@_animation_sprites, cell_data, @_animation.position)
+      @_animation.timings.each do |timing|
+        animation_process_timing(timing, @_animation_hit) if timing.frame == frame_index
+      end
+    end
+
+    def update_loop_animation
+      frame_index = @_loop_animation_index
+      cell_data = @_loop_animation.frames[frame_index].cell_data
+      animation_set_sprites(@_loop_animation_sprites, cell_data,
+                            @_loop_animation.position)
+      @_loop_animation.timings.each do |timing|
+        animation_process_timing(timing, true) if timing.frame == frame_index
+      end
+    end
+
+    # Aim the 16 cell sprites for one animation frame. `cell_data` is a Table of
+    # [cell, field]: the 192x192 pattern index into the animation sheet, then the
+    # offset, zoom, angle, mirror, opacity and blend the editor set for it.
+    def animation_set_sprites(sprites, cell_data, position)
+      16.times do |i|
+        sprite = sprites[i]
+        pattern = cell_data[i, 0]
+        if sprite.nil? || pattern.nil? || pattern == -1
+          sprite.visible = false unless sprite.nil?
+          next
+        end
+        sprite.visible = true
+        sprite.src_rect = RGSS::Rect.new(pattern % 5 * 192, pattern / 5 * 192,
+                                         192, 192)
+        if position == 3
+          # "Screen": centred on the viewport, near its bottom.
+          if self.viewport.nil?
+            sprite.x = 320
+            sprite.y = 240
+          else
+            sprite.x = self.viewport.rect.width / 2
+            sprite.y = self.viewport.rect.height - 160
+          end
+        else
+          sprite.x = self.x - self.ox + self.src_rect.width / 2
+          sprite.y = self.y - self.oy + self.src_rect.height / 2
+          sprite.y -= self.src_rect.height / 4 if position == 0   # over the target
+          sprite.y += self.src_rect.height / 4 if position == 2   # under it
+        end
+        sprite.x += cell_data[i, 1]
+        sprite.y += cell_data[i, 2]
+        sprite.z = 2000
+        sprite.ox = 96
+        sprite.oy = 96
+        sprite.zoom_x = cell_data[i, 3] / 100.0
+        sprite.zoom_y = cell_data[i, 3] / 100.0
+        sprite.angle = cell_data[i, 4]
+        sprite.mirror = (cell_data[i, 5] == 1)
+        sprite.opacity = (cell_data[i, 6] * self.opacity / 255.0).to_i
+        sprite.blend_type = cell_data[i, 7]
+      end
+    end
+
+    # An animation frame's SE and flash, if this frame carries one and its
+    # hit/miss condition holds.
+    def animation_process_timing(timing, hit)
+      return unless timing.condition == 0 ||
+                    (timing.condition == 1 && hit == true) ||
+                    (timing.condition == 2 && hit == false)
+      se = timing.se
+      if !se.nil? && se.name != ""
+        RGSS::Audio.se_play("Audio/SE/" + se.name, se.volume, se.pitch)
+      end
+      case timing.flash_scope
+      when 1 then self.flash(timing.flash_color, timing.flash_duration * 2)
+      when 2
+        unless self.viewport.nil?
+          self.viewport.flash(timing.flash_color, timing.flash_duration * 2)
+        end
+      when 3 then self.flash(nil, timing.flash_duration * 2)
+      end
+    end
+
+    # Moving the sprite carries its animation cells along, so an animation stays
+    # on a battler that is walking forward to attack.
+    def x=(x)
+      _rgss_shift_animation_sprites(x - self.x, 0)
+      super
+    end
+
+    def y=(y)
+      _rgss_shift_animation_sprites(0, y - self.y)
+      super
+    end
+
+    def _rgss_shift_animation_sprites(sx, sy)
+      return if sx == 0 && sy == 0
+      [@_animation_sprites, @_loop_animation_sprites].each do |sprites|
+        next if sprites.nil?
+        sprites.each do |sprite|
+          next if sprite.nil?
+          sprite.x += sx unless sx == 0
+          sprite.y += sy unless sy == 0
+        end
+      end
+    end
+
+    # Animation graphics are shared: count the players so the last one out frees
+    # the bitmap.
+    def _rgss_retain(bitmap)
+      @@_reference_count[bitmap] = (@@_reference_count[bitmap] || 0) + 1
+    end
+
+    def _rgss_release(sprite)
+      return if sprite.nil?
+      bitmap = sprite.bitmap
+      return if bitmap.nil?
+      count = (@@_reference_count[bitmap] || 1) - 1
+      @@_reference_count[bitmap] = count
+      bitmap.dispose if count <= 0
+    end
+  end
+
+  # Rain, storm and snow — what Change Weather Effects drives on the map. Forty
+  # sprites recycled as they fall off the screen, drawn from three bitmaps the
+  # class draws for itself (RGSS ships no weather graphics).
+  class Weather
+    SPRITE_COUNT = 40
+
+    def initialize(viewport = nil)
+      @type = 0
+      @max = 0
+      @ox = 0
+      @oy = 0
+      color1 = RGSS::Color.new(255, 255, 255, 255)
+      color2 = RGSS::Color.new(255, 255, 255, 128)
+      @rain_bitmap = RGSS::Bitmap.new(7, 56)
+      7.times { |i| @rain_bitmap.fill_rect(6 - i, i * 8, 1, 8, color1) }
+      @storm_bitmap = RGSS::Bitmap.new(34, 64)
+      32.times do |i|
+        @storm_bitmap.fill_rect(33 - i, i * 2, 1, 2, color2)
+        @storm_bitmap.fill_rect(32 - i, i * 2, 1, 2, color1)
+        @storm_bitmap.fill_rect(31 - i, i * 2, 1, 2, color2)
+      end
+      @snow_bitmap = RGSS::Bitmap.new(6, 6)
+      @snow_bitmap.fill_rect(0, 1, 6, 4, color2)
+      @snow_bitmap.fill_rect(1, 0, 4, 6, color2)
+      @snow_bitmap.fill_rect(1, 2, 4, 2, color1)
+      @snow_bitmap.fill_rect(2, 1, 2, 4, color1)
+      @sprites = []
+      SPRITE_COUNT.times do
+        sprite = RGSS::Sprite.new(viewport)
+        sprite.z = 1000
+        sprite.visible = false
+        sprite.opacity = 0
+        @sprites.push(sprite)
+      end
+    end
+
+    attr_reader :type, :max, :ox, :oy
+
+    def dispose
+      @sprites.each { |sprite| sprite.dispose }
+      @rain_bitmap.dispose
+      @storm_bitmap.dispose
+      @snow_bitmap.dispose
+    end
+
+    def type=(type)
+      return if @type == type
+      @type = type
+      bitmap = case @type
+               when 1 then @rain_bitmap
+               when 2 then @storm_bitmap
+               when 3 then @snow_bitmap
+               end
+      _rgss_each_sprite do |sprite, i|
+        sprite.visible = (i <= @max)
+        sprite.bitmap = bitmap
+      end
+    end
+
+    def ox=(ox)
+      return if @ox == ox
+      @ox = ox
+      @sprites.each { |sprite| sprite.ox = @ox }
+    end
+
+    def oy=(oy)
+      return if @oy == oy
+      @oy = oy
+      @sprites.each { |sprite| sprite.oy = @oy }
+    end
+
+    def max=(max)
+      return if @max == max
+      @max = [[max, 0].max, SPRITE_COUNT].min
+      _rgss_each_sprite { |sprite, i| sprite.visible = (i <= @max) }
+    end
+
+    # Fall one frame: each drop moves and fades, and one that has faded out or
+    # left the screen is thrown back to a random spot above it.
+    def update
+      return if @type == 0
+      1.upto(@max) do |i|
+        sprite = @sprites[i]
+        break if sprite.nil?
+        case @type
+        when 1
+          sprite.x -= 2
+          sprite.y += 16
+          sprite.opacity -= 8
+        when 2
+          sprite.x -= 8
+          sprite.y += 16
+          sprite.opacity -= 12
+        when 3
+          sprite.x -= 2
+          sprite.y += 8
+          sprite.opacity -= 8
+        end
+        x = sprite.x - @ox
+        y = sprite.y - @oy
+        next unless sprite.opacity < 64 || x < -50 || x > 750 || y < -300 || y > 500
+        sprite.x = rand(800) - 50 + @ox
+        sprite.y = rand(800) - 200 + @oy
+        sprite.opacity = 255
+      end
+    end
+
+    # RGSS indexes the sprite array 1..40 while filling it 0..39, so slot 40 is
+    # always nil and slot 0 is never shown. Kept — a game that sets `max` to 40
+    # gets 39 drops in the real player too, and the sprite count is what a script
+    # reading `max` back expects.
+    def _rgss_each_sprite
+      1.upto(SPRITE_COUNT) do |i|
+        sprite = @sprites[i]
+        yield(sprite, i) unless sprite.nil?
+      end
+    end
+  end
+end

--- a/mruby-rpgxp/mrblib/rgss_library.rb
+++ b/mruby-rpgxp/mrblib/rgss_library.rb
@@ -45,6 +45,57 @@
 # quirks included (`RPG::Weather` loops 1..40 over a 0..39 array, so a game asking
 # for 40 drops gets 39 — in the real player too).
 
+# Ruby's own `Errno`, which this mruby build does not ship (no mruby-errno gem is
+# vendored or configured) and which every RGSS game needs to *exist*, whether or
+# not it is ever raised. The editor writes this into the "Main" section of every
+# project:
+#
+#   begin
+#     $scene = Scene_Title.new
+#     $scene.main while $scene != nil
+#     Graphics.transition(20)
+#   rescue Errno::ENOENT
+#     print("Unable to find file #{$!.message.sub("No such file or directory - ", "")}.")
+#   end
+#
+# A rescue clause is evaluated when an exception passes through it, so with no
+# `Errno` *any* exception leaving the game loop — including the timeout a
+# headless run ends on — turned into `NameError: uninitialized constant Errno`.
+# That reads as "the game crashed" when the game was running fine: it is what
+# scripts/rpgxp_boot_check.bash caught the first time it booted a released game
+# under the host.
+#
+# ENOENT is the one RGSS itself raises (RPGXP::RGSSData#read_object does now, with
+# the same message shape, so the handler above prints the filename it was written
+# to print). The others are here so a script that rescues one resolves the
+# constant rather than losing its real exception to a NameError.
+# Each definition is guarded: this file is also loaded by the CRuby harnesses
+# (scripts/rpgxp_script_host_check.rb), where Ruby's real Errno already exists and
+# must not be redefined — the shapes match, so the guard is what keeps this a
+# *fill-in* rather than a monkeypatch.
+class SystemCallError < StandardError
+end unless Object.const_defined?(:SystemCallError)
+
+module Errno
+  # RGSS's message is "No such file or directory - <path>", and the stock Main
+  # strips that prefix to name the file — so the argument is the *path*, as in
+  # CRuby, not the whole message.
+  unless const_defined?(:ENOENT)
+    class ENOENT < SystemCallError
+      PREFIX = "No such file or directory".freeze
+
+      def initialize(path = nil)
+        super(path.nil? || path.empty? ? PREFIX : "#{PREFIX} - #{path}")
+      end
+    end
+  end
+
+  class EACCES < SystemCallError; end unless const_defined?(:EACCES)
+  class EEXIST < SystemCallError; end unless const_defined?(:EEXIST)
+  class EINVAL < SystemCallError; end unless const_defined?(:EINVAL)
+  class EISDIR < SystemCallError; end unless const_defined?(:EISDIR)
+end
+
 module RPG
   # The bitmap cache. Every graphic a game loads goes through here — the scripts
   # call `RPG::Cache.character(name, hue)`, `.tile(tileset, id, hue)`,

--- a/mruby-rpgxp/mrblib/scene.rb
+++ b/mruby-rpgxp/mrblib/scene.rb
@@ -873,10 +873,11 @@ class RPGXP
       #   * the RMXP globals this runtime can honestly back are bound to it --
       #     `$game_switches` and `$game_variables` reach the same switches and
       #     variables the Control Switches / Control Variables commands write;
-      #   * anything else a script reaches for is simply not there. The built-in
-      #     flow is a reimplementation, not RGSS; a game that needs the rest of
-      #     RMXP's object graph wants RGSS_SCRIPT_HOST, which exists to give it
-      #     all of them.
+      #   * anything else a script reaches for is simply not there. This flow is
+      #     a reimplementation, not RGSS; a game that needs the rest of RMXP's
+      #     object graph wants the script host, which exists to give it all of
+      #     them — and which is the default boot path, so a game only lands here
+      #     when it ships no scripts or the host was opted out of / fell back.
       #
       # A script that raises must not take the map down with it: the failure is
       # reported (never swallowed) and the event carries on.

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -13,21 +13,34 @@
 # section against the top level using its editor name — so the game's own logic
 # runs unmodified, rather than the reimplemented default flow in game.rb/scene.rb.
 #
-# It is the alternative to that reimplementation (see
-# docs/adr/0017-rpgxp-rgss-script-host.md). Because the scripts drive their own
-# blocking main loop and lean on the full RGSS class library, the host is an
-# opt-in path for now (RPGXP::ScriptHost.enabled?), with the built-in flow as the
-# default and the fallback. `Kernel#eval` comes from the core mruby-eval gem,
-# a hard dependency of this gem (mruby-rpgxp/mrbgem.rake).
+# It was built as the alternative to that reimplementation (see
+# docs/adr/0017-rpgxp-rgss-script-host.md) and is now the **default** path
+# (docs/adr/0029-rgss-script-host-by-default.md): a project that ships scripts
+# ships its own engine, so running them is what running the game means. The
+# built-in flow stays as the fallback — for a project that ships no scripts, when
+# the host fails to boot, and whenever the opt-out (RGSS_SCRIPT_HOST=0) is set.
+# `Kernel#eval` comes from the core mruby-eval gem, a hard dependency of this gem
+# (mruby-rpgxp/mrbgem.rake).
 class RPGXP
   # Defined with explicit `def self.` singleton methods (not a bare
   # `module_function`, which this mruby build does not apply to later defs) so
   # the host is callable as RPGXP::ScriptHost.<method>.
   module ScriptHost
-    # Environment variable / constant that turns the script host on. Off by
-    # default: the built-in flow is the verified path, and running the bundled
-    # scripts needs both eval and a complete-enough RGSS class library.
+    # Environment variable that switches the script host off. The host is on by
+    # default, so this is an *opt-out*: set RGSS_SCRIPT_HOST to one of
+    # DISABLED_VALUES to boot the built-in reimplemented flow instead (what the
+    # headless render checks compare against, and the escape hatch for a project
+    # whose scripts the host cannot yet run). The native binary spells the same
+    # switch --norgss_script_host.
     ENABLED_ENV = "RGSS_SCRIPT_HOST".freeze
+
+    # The values that turn the host *off*, compared literally in lower case (no
+    # String#downcase, which this mruby build is not known to carry — the same
+    # reason the rest of this gem sticks to the common subset). Anything else —
+    # including "1" — leaves the host on. src/main.cxx carries the same list for
+    # the environment variable it reads on the Ruby side's behalf; keep them
+    # together.
+    DISABLED_VALUES = ["0", "false", "off", "no"].freeze
 
     # True while the host's blocking `Main` runs inside the driver Fiber (see
     # RPGXP#setup_script_host_driver). The wrapped Graphics.update reads this to
@@ -43,14 +56,30 @@ class RPGXP
       @driving = v
     end
 
-    # Whether to run the bundled scripts instead of the built-in flow: an
-    # explicit opt-in via the RGSS_SCRIPT_HOST env var (when the runtime exposes
-    # ENV). Off by default. Uses const_defined? rather than defined?(CONST),
-    # which raises on an undefined constant in this mruby build.
+    # Whether to run the bundled scripts instead of the built-in flow. **On by
+    # default**: an RGSS project's scripts *are* its engine, so running them is
+    # the faithful boot; the built-in reimplementation is the fallback for a
+    # project that ships none. Only an explicit opt-out turns it off.
+    #
+    # Two ways in, because the two runtimes read their settings differently:
+    #
+    #   * the native binary resolves --rgss_script_host and the
+    #     RGSS_SCRIPT_HOST environment variable itself and sets the
+    #     RGSS_SCRIPT_HOST *constant* (src/main.cxx) — this build's mruby has no
+    #     ENV, so that is the only channel that reaches a booted game;
+    #   * the CRuby harnesses (scripts/*_check.rb) have no such constant and set
+    #     the environment variable directly, so ENV is read when it exists.
+    #
+    # With neither present — an embedded target, or a host-side unit test — the
+    # default stands. const_defined? rather than defined?(CONST), which raises on
+    # an undefined constant in this mruby build.
     def self.enabled?
-      return false unless Object.const_defined?(:ENV)
+      return RGSS_SCRIPT_HOST if Object.const_defined?(:RGSS_SCRIPT_HOST)
+      return true unless Object.const_defined?(:ENV)
       flag = ENV[ENABLED_ENV]
-      !(flag.nil? || flag.empty? || flag == "0" || flag == "false")
+      # Unset or empty is "not asked for either way" — the default wins.
+      return true if flag.nil? || flag.empty?
+      !DISABLED_VALUES.include?(flag)
     end
 
     # Run the project's bundled scripts to completion. `db` answers #scripts
@@ -70,6 +99,10 @@ class RPGXP
       # some scripts read it (e.g. to hot-reload). Mirror that shape.
       idx = -1
       $RGSS_SCRIPTS = sections.map { |name, source| [idx += 1, name, source] }
+      # A machine-readable marker, the script-host twin of the built-in flow's
+      # [RPGXP-MAP]: it is what a headless run (scripts/rpgxp_boot_check.bash)
+      # asserts on to prove the host — not the built-in flow — booted the game.
+      $stderr.puts "[RPGXP-SCRIPTS] running #{sections.size} script sections"
       sections.each do |name, source|
         # Evaluate through the top-level helper so a section's `class Scene_Title`
         # etc. define global (::) constants, as under RGSS — see rgss_eval_section.

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -1746,6 +1746,34 @@ assert "RPG::Sprite is the native Sprite plus the RGSS effect surface" do
   end
 end
 
+# Errno, which mruby does not ship and every RGSS game's "Main" names:
+#
+#   begin ... $scene.main while $scene != nil ... rescue Errno::ENOENT
+#
+# A rescue clause is evaluated when an exception passes through it, so without
+# the constant *any* exception leaving a game's main loop became
+# "NameError: uninitialized constant Errno" — the boot check caught exactly that
+# on a released game, where the ordinary end-of-run timeout was rewritten into a
+# crash. What matters is that a foreign exception passes through the clause.
+assert "Errno::ENOENT exists so a game's `rescue Errno::ENOENT` resolves" do
+  assert_true Object.const_defined?(:Errno), "Errno missing"
+  assert_true Errno::ENOENT.ancestors.include?(StandardError)
+  # RGSS's message shape: the stock Main strips the prefix to name the file.
+  assert_equal "No such file or directory - Data/Foo.rxdata",
+               Errno::ENOENT.new("Data/Foo.rxdata").message
+  passed_through = false
+  begin
+    begin
+      raise "not a file error"
+    rescue Errno::ENOENT
+      # Unreachable — and before Errno existed, getting here raised NameError.
+    end
+  rescue StandardError => e
+    passed_through = e.message == "not a file error"
+  end
+  assert_true passed_through, "a foreign exception did not survive the rescue clause"
+end
+
 assert "RPG::Weather offers the surface Spriteset_Map drives" do
   methods = RPG::Weather.instance_methods
   %i[type= max= ox= oy= update dispose type max ox oy].each do |name|

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -1728,6 +1728,48 @@ assert "ScriptHost.run returns false when the project ships no scripts" do
   assert_false RPGXP::ScriptHost.run(FakeScriptDB.new([]))
 end
 
+# The RGSS standard library (mrblib/rgss_library.rb) — the classes RGSS104E.dll
+# supplies and no project ships. These tests run in the *built* engine, where
+# RPG::Sprite really does subclass the native RGSS::Sprite; they are what would
+# catch the library being dropped from the gem's rbfiles, or a native base class
+# losing a method it is built on. Sprite/Viewport instances need a live display
+# the headless test binary lacks (see mruby-rgss's own tests), so the behaviour
+# of the effects is checked against fakes in scripts/rpgxp_script_host_check.rb
+# and what is pinned here is the shape a game's scripts subclass.
+assert "RPG::Sprite is the native Sprite plus the RGSS effect surface" do
+  assert_equal RGSS::Sprite, RPG::Sprite.superclass
+  methods = RPG::Sprite.instance_methods
+  # Everything Sprite_Battler and Sprite_Character call on their superclass.
+  %i[whiten appear escape collapse damage animation loop_animation
+     blink_on blink_off blink? effect? update dispose].each do |name|
+    assert_true methods.include?(name), "RPG::Sprite##{name} missing"
+  end
+end
+
+assert "RPG::Weather offers the surface Spriteset_Map drives" do
+  methods = RPG::Weather.instance_methods
+  %i[type= max= ox= oy= update dispose type max ox oy].each do |name|
+    assert_true methods.include?(name), "RPG::Weather##{name} missing"
+  end
+end
+
+# RPG::Cache is the one part that runs headlessly: it only builds Bitmaps.
+assert "RPG::Cache caches by path and stands in for what will not load" do
+  RPG::Cache.clear
+  # Nothing on disk under this name, and RGSS would raise; the cache reports it
+  # and hands back a blank so a missing RTP cannot end a boot.
+  missing = RPG::Cache.picture("NoSuchPictureHere")
+  assert_equal 32, missing.width
+  assert_equal 32, missing.height
+  # An empty name is RGSS's own "no graphic", also a blank.
+  assert_equal 32, RPG::Cache.character("", 0).width
+  # Same path, same object — a map redrawing its charsets every frame must not
+  # reload them.
+  assert_true RPG::Cache.picture("NoSuchPictureHere").equal?(missing)
+  RPG::Cache.clear
+  assert_false RPG::Cache.picture("NoSuchPictureHere").equal?(missing)
+end
+
 # The host is the default boot path (ADR 0029): with neither the native binary's
 # RGSS_SCRIPT_HOST constant nor an opt-out in the environment, enabled? is true.
 # This runs in the *built* engine, which is where a divergence between the CRuby

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -1728,6 +1728,38 @@ assert "ScriptHost.run returns false when the project ships no scripts" do
   assert_false RPGXP::ScriptHost.run(FakeScriptDB.new([]))
 end
 
+# The host is the default boot path (ADR 0029): with neither the native binary's
+# RGSS_SCRIPT_HOST constant nor an opt-out in the environment, enabled? is true.
+# This runs in the *built* engine, which is where a divergence between the CRuby
+# harness and mruby would show — including ENV being absent here, which must
+# still leave the host on rather than raise.
+assert "ScriptHost.enabled? defaults on" do
+  assert_true RPGXP::ScriptHost.enabled?
+  # The opt-out list the native runtime mirrors (src/main.cxx) — kept in the
+  # test so a spelling cannot silently drop out of one side.
+  assert_equal ["0", "false", "off", "no"], RPGXP::ScriptHost::DISABLED_VALUES
+  assert_equal "RGSS_SCRIPT_HOST", RPGXP::ScriptHost::ENABLED_ENV
+end
+
+# The environment channel, when this build has an ENV to read (the native binary
+# resolves the variable in C++ instead — see enabled?).
+assert "ScriptHost.enabled? honours the RGSS_SCRIPT_HOST opt-out in ENV" do
+  skip "no ENV in this build" unless Object.const_defined?(:ENV)
+  previous = ENV[RPGXP::ScriptHost::ENABLED_ENV]
+  begin
+    ENV[RPGXP::ScriptHost::ENABLED_ENV] = ""      # unset, as a plain boot is
+    assert_true RPGXP::ScriptHost.enabled?
+    RPGXP::ScriptHost::DISABLED_VALUES.each do |off|
+      ENV[RPGXP::ScriptHost::ENABLED_ENV] = off
+      assert_false RPGXP::ScriptHost.enabled?, "#{off.inspect} should disable the host"
+    end
+    ENV[RPGXP::ScriptHost::ENABLED_ENV] = "1"
+    assert_true RPGXP::ScriptHost.enabled?
+  ensure
+    ENV[RPGXP::ScriptHost::ENABLED_ENV] = previous.nil? ? "" : previous
+  end
+end
+
 assert "ScriptHost.install_kernel wires load_data / save_data round-trip" do
   db = FakeScriptDB.new([["x", "0"]])
   RPGXP::ScriptHost.install_kernel(db)

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -1155,8 +1155,9 @@ class Checker
   end
 
   # Boot the project the way src/main.cxx does: construct the shell (which
-  # detects the edition and loads the database) with the RGSS script host on, and
-  # let it drive the game's own scripts to completion. The sample's Main section
+  # detects the edition and loads the database) and let the RGSS script host —
+  # the default boot path — drive the game's own scripts to completion, then do
+  # it again with the RGSS_SCRIPT_HOST opt-out set. The sample's Main section
   # reads the database back through the host's Kernel#load_data and drives three
   # frames, so this covers detection -> database -> host -> per-frame Fiber
   # driver end to end.
@@ -1167,9 +1168,10 @@ class Checker
     RGSS::Audio.reset
     previous = ENV["RGSS_SCRIPT_HOST"]
 
-    # Host off (the default): the shell must load the database, report the
-    # pending built-in flow and return — not run anything, and not hang.
-    ENV.delete("RGSS_SCRIPT_HOST")
+    # Host explicitly off (RGSS_SCRIPT_HOST=0, the opt-out from its default-on):
+    # the shell must load the database, report the pending built-in flow and
+    # return — not run anything, and not hang.
+    ENV["RGSS_SCRIPT_HOST"] = "0"
     with_game_dir(dir) do
       game = RPGVX.new([])
       expect(game.db.is_a?(RPGVX::RGSSData), "boot: no database without the script host")
@@ -1178,7 +1180,8 @@ class Checker
     expect($rgss_sample_booted.nil?,
            "boot: the bundled scripts ran even though the host is disabled")
 
-    ENV["RGSS_SCRIPT_HOST"] = "1"
+    # Host on because nothing said otherwise — the default a real boot gets.
+    ENV.delete("RGSS_SCRIPT_HOST")
     with_game_dir(dir) do
       game = RPGVX.new([])
       expect(game.edition == edition,

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -13,9 +13,16 @@
 # scripts/compare-rpgxp-wine.bash.
 #
 # The engine aborts on an uncaught mruby exception, so simply running it is most
-# of the test; `--rpgxp_new_game` selects New Game without input and logs the
-# `[RPGXP-MAP]` marker this asserts on, which is what pushes the run past the
-# title screen into the map scene and its renderer.
+# of the test. Each game is booted twice, once per path into a running game:
+#
+#   1. **The default**: no flags, so the RGSS script host runs the project's own
+#      Data/Scripts.rxdata (ADR 0029) and logs `[RPGXP-SCRIPTS]`. A host that
+#      fails falls back to the built-in flow without changing the exit code, so
+#      the run also fails on a `script host failed` line.
+#   2. **The built-in reimplemented flow**: `--rpgxp_new_game` selects New Game
+#      without input (which also pins the boot to that flow) and logs the
+#      `[RPGXP-MAP]` marker, pushing the run past the title screen into the map
+#      scene and its renderer -- the path compare-rpgxp-wine.bash measures.
 #
 # Game directories that are not present are skipped with a message rather than
 # silently passed over -- but if *none* of them is present the check fails,
@@ -57,30 +64,63 @@ checked=0
 failed=0
 num="${SERVER_NUM}"
 
+# One headless run of the engine.
+#   $1 game dir, $2 display number, $3 what the run is called in the log,
+#   $4 the marker its log must contain, $5 extra engine flags (may be empty)
+# A run fails when the engine exits non-zero (any uncaught mruby exception aborts
+# it), when its marker is missing, or when the script host reported a boot
+# failure and quietly fell back to the built-in flow -- that fallback keeps the
+# exit code at zero, so without the third test a broken default would pass.
+run_boot() {
+    local game="$1" display="$2" label="$3" marker="$4" flags="$5"
+    local log rc=0
+    log="$(mktemp)"
+    echo "-- ${label}"
+    # Each run gets its own display number: xvfb-run -a's probe is not atomic
+    # and can steal a display from a concurrent run (see build.yml).
+    # shellcheck disable=SC2086 # ${flags} is a deliberate word-split flag list
+    if ! xvfb-run --server-num="${display}" timeout 180 "${ENGINE}" \
+            --game_dir "${game}" ${flags} \
+            --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
+        echo "FAILED: ${game} (${label}): the engine exited non-zero" >&2
+        rc=1
+    elif ! grep -q "${marker}" "${log}" ; then
+        echo "FAILED: ${game} (${label}): ${marker} missing" >&2
+        rc=1
+    elif grep -q 'script host failed' "${log}" ; then
+        echo "FAILED: ${game} (${label}): the script host fell back to the built-in flow" >&2
+        grep 'script host failed' "${log}" >&2
+        rc=1
+    else
+        grep "${marker}" "${log}"
+    fi
+    # ALSA has no device under CI and floods stderr; keep the rest.
+    grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -40 || true
+    rm -f "${log}"
+    return "${rc}"
+}
+
 for game in "${GAMES[@]}" ; do
     if [ ! -f "${game}/Game.ini" ] ; then
         echo "skip ${game}: no Game.ini (run scripts/download-opengame-xp.bash first)"
         continue
     fi
     checked=$((checked + 1))
-    log="$(mktemp)"
     echo "== ${game}"
-    # Each game gets its own display number: xvfb-run -a's probe is not atomic
-    # and can steal a display from a concurrent run (see build.yml).
-    if ! xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
-            --game_dir "${game}" --rpgxp_new_game \
-            --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
-        echo "FAILED: ${game}: the engine exited non-zero" >&2
+
+    # 1. The default boot: no flags, so the RGSS script host runs the game's own
+    #    Data/Scripts.rxdata (ADR 0029) and logs how many sections it evaluated.
+    #    This is the pass that proves the default path works on the real binary.
+    run_boot "${game}" "${num}" "script host (default)" '\[RPGXP-SCRIPTS\]' "" ||
         failed=$((failed + 1))
-    elif ! grep -q '\[RPGXP-MAP\]' "${log}" ; then
-        echo "FAILED: ${game}: never reached the map scene ([RPGXP-MAP] missing)" >&2
-        failed=$((failed + 1))
-    else
-        grep '\[RPGXP-MAP\]' "${log}"
-    fi
-    # ALSA has no device under CI and floods stderr; keep the rest.
-    grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -40 || true
-    rm -f "${log}"
+
+    # 2. The built-in reimplemented flow, which `--rpgxp_new_game` selects (it
+    #    drives the built-in title screen, so it also switches the host off --
+    #    see RPGXP#builtin_flow_forced?). This is the render path
+    #    scripts/compare-rpgxp-wine.bash measures against the genuine runtime.
+    run_boot "${game}" "${num}" "built-in flow (--rpgxp_new_game)" '\[RPGXP-MAP\]' \
+        "--rpgxp_new_game" || failed=$((failed + 1))
+
     num=$((num + 1))
 done
 
@@ -91,8 +131,9 @@ if [ "${checked}" -eq 0 ] ; then
 fi
 
 if [ "${failed}" -ne 0 ] ; then
-    echo "rpgxp boot check: ${failed} of ${checked} game(s) FAILED" >&2
+    echo "rpgxp boot check: ${failed} of $((checked * 2)) run(s) FAILED" >&2
     exit 1
 fi
 
-echo "rpgxp boot check: ${checked} game(s) booted into the map"
+echo "rpgxp boot check: ${checked} game(s) booted twice -- their own scripts" \
+     "under the script host, and the built-in flow into the map"

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -183,6 +183,51 @@ def check_run_defines_top_level
   0
 end
 
+# Project-independent: the host is the default boot path (ADR 0029), and
+# RGSS_SCRIPT_HOST is the opt-out that restores the built-in flow. Guarding it
+# here as well as in mruby-rpgxp/test keeps the two spellings of the rule (the
+# CRuby harness and the built engine) from drifting apart.
+def check_enabled_default
+  previous = ENV["RGSS_SCRIPT_HOST"]
+  errors = 0
+  check = lambda do |want, msg|
+    next 0 if RPGXP::ScriptHost.enabled? == want
+    warn "  FAIL #{msg}"
+    1
+  end
+
+  ENV.delete("RGSS_SCRIPT_HOST")
+  errors += check.call(true, "ScriptHost.enabled? is false with RGSS_SCRIPT_HOST unset")
+  ENV["RGSS_SCRIPT_HOST"] = ""
+  errors += check.call(true, "an empty RGSS_SCRIPT_HOST should leave the default (on)")
+  RPGXP::ScriptHost::DISABLED_VALUES.each do |off|
+    ENV["RGSS_SCRIPT_HOST"] = off
+    errors += check.call(false, "RGSS_SCRIPT_HOST=#{off} did not switch the host off")
+  end
+  ENV["RGSS_SCRIPT_HOST"] = "1"
+  errors += check.call(true, "RGSS_SCRIPT_HOST=1 did not keep the host on")
+
+  # The native binary has no ENV to offer the Ruby side, so it resolves
+  # --rgss_script_host / RGSS_SCRIPT_HOST itself and passes the answer down as a
+  # constant (src/main.cxx). That channel wins over the environment.
+  begin
+    Object.const_set(:RGSS_SCRIPT_HOST, false)
+    errors += check.call(false, "the RGSS_SCRIPT_HOST constant did not switch the host off")
+    Object.send(:remove_const, :RGSS_SCRIPT_HOST)
+    Object.const_set(:RGSS_SCRIPT_HOST, true)
+    ENV["RGSS_SCRIPT_HOST"] = "0"
+    errors += check.call(true, "the RGSS_SCRIPT_HOST constant should win over the environment")
+  ensure
+    Object.send(:remove_const, :RGSS_SCRIPT_HOST) if Object.const_defined?(:RGSS_SCRIPT_HOST)
+  end
+
+  puts "  ScriptHost.enabled? defaults on; #{RPGXP::ScriptHost::DISABLED_VALUES.join('/')} opt out " \
+       "(env or the native RGSS_SCRIPT_HOST constant)" if errors.zero?
+  errors
+ensure
+  previous.nil? ? ENV.delete("RGSS_SCRIPT_HOST") : ENV["RGSS_SCRIPT_HOST"] = previous
+end
+
 # Every XP project under `root` that carries scripts: an editor project (a loose
 # Data/Scripts.rxdata) or a *released* one, which keeps Scripts.rxdata inside its
 # encrypted Game.rgssad with no loose Data/ to glob for.
@@ -198,14 +243,18 @@ end
 games = ARGV.dup
 games = discover_games(File.expand_path("../data", __dir__)) if games.empty?
 
+# The project-independent checks run first, so they still guard the rules when
+# no test bed has been downloaded.
+errors = check_enabled_default + check_run_defines_top_level
+
 if games.empty?
   warn "no XP test-bed game found (run scripts/download-opengame-xp.bash first)"
-  exit 0
+  exit(errors.zero? ? 0 : 1)
 end
 
 checker = Checker.new
 games.each { |g| checker.check_game(g) }
-errors = checker.errors + check_run_defines_top_level
+errors += checker.errors
 if errors.zero?
   puts "OK: XP script host decodes, installs built-ins and evaluates real scripts"
 else

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -14,9 +14,18 @@
 # the data layer.
 #
 # It does NOT run the "Main" section (that would start the game's blocking main
-# loop and needs the full RGSS graphics/audio library); it evaluates a load-safe
-# logic subset to prove real script source decodes, inflates and evaluates into
+# loop and needs the full RGSS graphics/audio library); it evaluates every other
+# section to prove real script source decodes, inflates and evaluates into
 # top-level classes with their real methods.
+#
+# The RGSS *standard library* — RPG::Cache, RPG::Sprite, RPG::Weather, which the
+# player supplies and no project ships — is loaded here from the real
+# mruby-rpgxp/mrblib/rgss_library.rb and exercised against fake native classes.
+# It used to be stubbed with empty classes, and that stub is precisely why this
+# check stayed green while the engine could not boot a game past
+# `class Sprite_Character < RPG::Sprite` (see the RPG::Sprite entry in
+# docs/rpgxp-rgss-api-gap.md). Shimming a *native* class here is unavoidable;
+# shimming our own Ruby is how a gap hides.
 #
 # Usage:
 #   ruby scripts/rpgxp_script_host_check.rb [GAME_DIR ...]
@@ -28,33 +37,130 @@ require "zlib"
 # --- RGSS value-type + native shims (native classes in the real build) ------
 
 class Table; def self._load(s); allocate; end; end
-class Color; def self._load(s); allocate; end; end
 class Tone;  def self._load(s); allocate; end; end
-class Rect;  def self._load(s); allocate; end; end
 
-# RGSS.zlib_inflate is a native module function in the real build (mruby-rgss,
-# via stb_image's zlib decoder). Provide the CRuby equivalent so the shared
-# RGSSData#scripts decoder runs here unchanged.
+# The native classes mruby-rgss implements in C++, as far as the RGSS standard
+# library below drives them: enough to record what it asked for, so the checks
+# can assert on it. Everything here is a *stand-in for native code*; our own Ruby
+# is always loaded for real.
 module RGSS
+  # RGSS.zlib_inflate is a native module function in the real build (via
+  # stb_image's zlib decoder). Provide the CRuby equivalent so the shared
+  # RGSSData#scripts decoder runs here unchanged.
   def self.zlib_inflate(bytes)
     Zlib::Inflate.inflate(bytes)
   end
+
+  class Color
+    attr_accessor :red, :green, :blue, :alpha
+    def initialize(r, g, b, a = 255); set(r, g, b, a); end
+    def set(r, g, b, a = 255); @red, @green, @blue, @alpha = r, g, b, a; end
+    def self._load(_s); allocate; end
+  end
+
+  class Rect
+    attr_accessor :x, :y, :width, :height
+    def initialize(x = 0, y = 0, w = 0, h = 0); set(x, y, w, h); end
+    def set(x, y, w, h); @x, @y, @width, @height = x, y, w, h; end
+    def self._load(_s); allocate; end
+  end
+
+  class Font
+    attr_accessor :name, :size, :color
+    def initialize; @name = "Arial"; @size = 22; @color = Color.new(255, 255, 255); end
+  end
+
+  # Records draws instead of rasterising. A path containing "Missing" stands in
+  # for an asset that will not load, so the cache's fallback can be checked.
+  class Bitmap
+    attr_reader :width, :height, :texts, :hue, :path
+    def initialize(a, b = nil)
+      if a.is_a?(String)
+        raise "Failed to init bitmap: #{a}" if a.include?("Missing")
+        @path = a
+        @width = @height = 64
+      else
+        @width, @height = a, b
+      end
+      @texts = []
+      @disposed = false
+    end
+    def font; @font ||= Font.new; end
+    def draw_text(*args); @texts << args; end
+    def fill_rect(*); end
+    def blt(*); end
+    def hue_change(hue); @hue = hue; end
+    def dispose; @disposed = true; end
+    def disposed?; @disposed; end
+  end
+
+  class Sprite
+    attr_accessor :bitmap, :ox, :oy, :visible, :zoom_x, :zoom_y, :angle,
+                  :mirror, :blend_type, :src_rect, :color, :tone
+    attr_reader :viewport, :opacity, :flashes
+    def initialize(viewport = nil)
+      @viewport = viewport
+      @opacity = 255
+      @ox = @oy = 0
+      @src_rect = Rect.new(0, 0, 0, 0)
+      @flashes = []
+      @disposed = false
+    end
+    def x; @x || 0; end
+    def y; @y || 0; end
+    def z; @z || 0; end
+    attr_writer :x, :y, :z
+    # The native setter takes an Integer and clamps it to 0..255 — RGSS's own
+    # fades deliberately overshoot (`appear` ends on 256, `collapse` on -32), so
+    # a fake that stored those verbatim would report opacities the engine can
+    # never show. A Float raises there, so it raises here too.
+    def opacity=(value)
+      raise TypeError, "opacity= got #{value.class}" unless value.is_a?(Integer)
+      @opacity = value < 0 ? 0 : (value > 255 ? 255 : value)
+    end
+    def flash(color, duration); @flashes << [color, duration]; end
+    def update; end
+    def dispose; @disposed = true; end
+    def disposed?; @disposed; end
+  end
+
+  class Viewport
+    attr_reader :rect, :flashes
+    def initialize(rect); @rect = rect; @flashes = []; end
+    def flash(color, duration); @flashes << [color, duration]; end
+  end
+
+  module Graphics
+    class << self; attr_accessor :frame_count; end
+    @frame_count = 0
+  end
+
+  module Audio
+    class << self; attr_reader :played; end
+    @played = []
+    def self.se_play(name, volume = 100, pitch = 100); @played << [name, volume, pitch]; end
+    def self.reset; @played = []; end
+  end
 end
+
+# The real runtime pulls RGSS into the top level (mruby-rpgxp/mrblib/lib.rb), so
+# the scripts' bare `Sprite`/`Bitmap`/`Color` resolve. Do the same here.
+class Object; include RGSS; end
+Color = RGSS::Color
+Rect = RGSS::Rect
 
 # --- Load the real sources --------------------------------------------------
 
 mrblib = File.expand_path("../mruby-rpgxp/mrblib", __dir__)
 load File.join(mrblib, "rgss_data.rb")
 load File.join(mrblib, "rgssad.rb")
+load File.join(mrblib, "rgss_library.rb")
 load File.join(mrblib, "script_host.rb")
 
-# Native RGSS base classes the default scripts subclass at load time.
-%w[Sprite Plane Window Tilemap Viewport Bitmap].each do |c|
+# The remaining native classes the stock scripts subclass or instantiate at load
+# time, which the RGSS standard library above does not drive.
+%w[Plane Window Tilemap].each do |c|
   Object.const_set(c, Class.new) unless Object.const_defined?(c)
-end
-module RPG
-  class Sprite < ::Sprite; end unless const_defined?(:Sprite)
-  class Weather; end unless const_defined?(:Weather)
 end
 
 class Checker
@@ -126,13 +232,18 @@ class Checker
     puts "  Kernel#load_data returns RPG::System (start_map_id=#{sys.start_map_id})"
   end
 
-  # Evaluate the logic subset the way the host does and confirm the real classes
-  # and event-command methods land at the top level.
+  # Evaluate the bundle the way the host does and confirm the real classes and
+  # event-command methods land at the top level.
+  #
+  # *Every* section except "Main" is evaluated, not a hand-picked logic subset:
+  # a section that cannot even be defined is what stops a boot, and the one that
+  # did (`class Sprite_Character < RPG::Sprite`) sat outside the old subset. Main
+  # is still skipped — it starts the game's blocking main loop.
   def check_eval_subset(sections)
     top = TOPLEVEL_BINDING
     evaled = 0
     sections.each do |name, source|
-      next unless LOGIC_SECTIONS.include?(name)
+      next if name == "Main"
       begin
         eval(source, top, name, 1)
         evaled += 1
@@ -140,8 +251,12 @@ class Checker
         fail "eval #{name.inspect}: #{e.class}: #{e.message}"
       end
     end
-    expect(evaled == LOGIC_SECTIONS.size,
-           "evaluated #{evaled}/#{LOGIC_SECTIONS.size} logic sections")
+    expect(evaled == sections.size - 1,
+           "evaluated #{evaled}/#{sections.size - 1} sections (Main excluded)")
+    LOGIC_SECTIONS.each do |name|
+      expect(sections.any? { |s, _| s == name },
+             "the bundle no longer ships #{name.inspect} — is this an XP project?")
+    end
     expect(Object.const_defined?(:Interpreter), "Interpreter class not defined")
     expect(Object.const_defined?(:Game_System), "Game_System class not defined")
     if Object.const_defined?(:Interpreter)
@@ -151,7 +266,19 @@ class Checker
       expect(methods.include?(:command_121),
              "Interpreter#command_121 (Control Switches) missing")
     end
-    puts "  evaluated #{evaled} logic sections; Interpreter/Game_System defined with real commands"
+    # The sprites that stopped the boot: both subclass the RGSS standard
+    # library's RPG::Sprite, so this is what proves the class is really there and
+    # really usable as a superclass.
+    %w[Sprite_Character Sprite_Battler].each do |name|
+      unless Object.const_defined?(name)
+        fail "#{name} not defined"
+        next
+      end
+      expect(Object.const_get(name).ancestors.include?(RPG::Sprite),
+             "#{name} does not inherit RPG::Sprite")
+    end
+    puts "  evaluated #{evaled} sections; Interpreter/Game_System defined with " \
+         "real commands, Sprite_Character/Sprite_Battler on RPG::Sprite"
   end
 
   def report
@@ -182,6 +309,161 @@ def check_run_defines_top_level
   puts "  ScriptHost.run defines section classes at the top level"
   0
 end
+
+# Project-independent: the RGSS standard library the player supplies
+# (mruby-rpgxp/mrblib/rgss_library.rb). Driven against the fake native classes at
+# the top of this file, so the *behaviour* a game's own engine depends on —
+# not merely the existence of the constants — is checked on every run.
+def check_rgss_library
+  errors = 0
+  check = lambda do |cond, msg|
+    next 0 if cond
+    warn "  FAIL #{msg}"
+    1
+  end
+
+  viewport = RGSS::Viewport.new(RGSS::Rect.new(0, 0, 640, 480))
+  sprite = RPG::Sprite.new(viewport)
+  sprite.x = 100
+  sprite.y = 200
+
+  # The battler transitions are timed effects: `effect?` is what a battle scene
+  # waits on, so each has to start one and each has to end.
+  errors += check.call(!sprite.effect?, "a fresh RPG::Sprite reports an effect")
+  sprite.whiten
+  errors += check.call(sprite.effect?, "whiten did not start an effect")
+  16.times { sprite.update }
+  errors += check.call(!sprite.effect?, "whiten never ended (16 frames)")
+  sprite.appear
+  16.times { sprite.update }
+  errors += check.call(sprite.opacity == 255, "appear ended at opacity #{sprite.opacity}")
+  sprite.escape
+  32.times { sprite.update }
+  errors += check.call(!sprite.effect?, "escape never ended (32 frames)")
+  sprite.collapse
+  48.times { sprite.update }
+  errors += check.call(!sprite.effect?, "collapse never ended (48 frames)")
+
+  # The damage pop-up: its own sprite at z 3000, the number drawn unsigned, a
+  # recovery in green, CRITICAL above it, gone after 40 frames.
+  sprite.damage(120, true)
+  pop = sprite.instance_variable_get(:@_damage_sprite)
+  errors += check.call(!pop.nil? && pop.z == 3000, "damage pop-up is not at z 3000")
+  drawn = pop.nil? ? [] : pop.bitmap.texts.map { |t| t[4] }
+  errors += check.call(drawn.include?("120"), "damage did not draw its value")
+  errors += check.call(drawn.include?("CRITICAL"), "a critical did not draw CRITICAL")
+  40.times { sprite.update }
+  errors += check.call(!sprite.effect?, "the damage pop-up never expired")
+  sprite.damage(-30, false)
+  recovery = sprite.instance_variable_get(:@_damage_sprite)
+  errors += check.call(!recovery.nil? &&
+                       recovery.bitmap.texts.map { |t| t[4] }.include?("30"),
+                       "recovery did not draw its value unsigned")
+  sprite.dispose_damage
+
+  sprite.blink_on
+  errors += check.call(sprite.blink?, "blink_on did not turn blinking on")
+  sprite.update
+  errors += check.call(!sprite.effect?, "blinking must not count as an effect")
+  sprite.blink_off
+  errors += check.call(!sprite.blink?, "blink_off did not turn blinking off")
+
+  # An animation over the sprite: 16 cell sprites aimed from the frame's cell
+  # data, the timing's SE played and its flash fired. Full opacity first — the
+  # collapse above faded the sprite out, and a cell's opacity is scaled by the
+  # sprite's, so the cells would be invisible too (which is RGSS's own rule).
+  sprite.opacity = 255
+  RGSS::Audio.reset
+  cells = FakeTable.new([[3, 10, -20, 200, 45, 1, 128, 1]] +
+                        Array.new(15) { [-1, 0, 0, 100, 0, 0, 255, 0] })
+  flash_color = RGSS::Color.new(255, 255, 255, 255)
+  animation = FakeAnimation.new(
+    2, "Anim1", 0, 1, [FakeFrame.new(cells), FakeFrame.new(cells)],
+    [FakeTiming.new(0, 0, FakeSE.new("Hit", 80, 100), 1, flash_color, 5)]
+  )
+  sprite.animation(animation, true)
+  cell_sprites = sprite.instance_variable_get(:@_animation_sprites)
+  errors += check.call(cell_sprites.size == 16,
+                       "#{cell_sprites.size} animation cell sprites, expected 16")
+  cell = cell_sprites[0]
+  errors += check.call(cell.visible, "the first animation cell is not visible")
+  errors += check.call(cell.src_rect.x == 3 % 5 * 192 && cell.src_rect.width == 192,
+                       "animation cell reads the wrong 192x192 patch")
+  errors += check.call(cell.z == 2000, "animation cell is not at z 2000")
+  errors += check.call(cell.zoom_x == 2.0, "animation cell zoom is #{cell.zoom_x}")
+  errors += check.call(cell.angle == 45, "animation cell angle is #{cell.angle}")
+  errors += check.call(cell.mirror, "animation cell is not mirrored")
+  errors += check.call(cell.opacity == 128, "animation cell opacity is #{cell.opacity}")
+  errors += check.call(!cell_sprites[1].visible, "an unused cell is visible")
+  errors += check.call(RGSS::Audio.played == [["Audio/SE/Hit", 80, 100]],
+                       "the timing's SE did not play (#{RGSS::Audio.played.inspect})")
+  errors += check.call(sprite.flashes == [[flash_color, 10]],
+                       "the timing's flash did not fire (#{sprite.flashes.inspect})")
+  moved_from = cell.x
+  sprite.x = sprite.x + 40
+  errors += check.call(cell.x - moved_from == 40,
+                       "animation cells did not follow the sprite")
+  RGSS::Graphics.frame_count = 0
+  sprite.update
+  errors += check.call(sprite.effect?, "the animation ended a frame early")
+  RGSS::Graphics.frame_count = 2
+  sprite.update
+  errors += check.call(!sprite.effect?, "the animation never ended")
+
+  # Weather: 40 recycled drops, only `max` of them shown, each moving per frame.
+  weather = RPG::Weather.new(viewport)
+  errors += check.call(weather.type == 0 && weather.max == 0,
+                       "weather does not start clear")
+  weather.type = 1
+  weather.max = 20
+  drops = weather.instance_variable_get(:@sprites)
+  errors += check.call(drops[1].visible && !drops[25].visible,
+                       "weather shows the wrong number of drops")
+  errors += check.call(drops[1].bitmap.width == 7, "rain drops use the wrong bitmap")
+  weather.ox = 5
+  errors += check.call(drops[0].ox == 5, "weather ox did not reach its sprites")
+  before = [drops[1].x, drops[1].y]
+  weather.update
+  errors += check.call([drops[1].x, drops[1].y] != before, "no weather drop moved")
+
+  # The cache: one bitmap per path, a hue variant of its own, a blank for an
+  # empty name, and — our deviation from RGSS — a blank for an asset that will
+  # not load rather than a raise that would end the game.
+  plain = RPG::Cache.character("Hero", 0)
+  errors += check.call(plain.equal?(RPG::Cache.character("Hero", 0)),
+                       "RPG::Cache reloaded a cached bitmap")
+  hued = RPG::Cache.character("Hero", 120)
+  errors += check.call(!hued.equal?(plain) && hued.hue == 120,
+                       "RPG::Cache did not build a hue variant")
+  errors += check.call(RPG::Cache.character("", 0).width == 32,
+                       "an empty name did not give a blank bitmap")
+  errors += check.call(RPG::Cache.picture("MissingOnPurpose").width == 32,
+                       "a missing asset did not fall back to a blank bitmap")
+  errors += check.call(RPG::Cache.tile("Grass", 384 + 9, 0).width == 32,
+                       "RPG::Cache.tile did not cut a 32x32 tile")
+  RPG::Cache.clear
+  errors += check.call(!RPG::Cache.character("Hero", 0).equal?(plain),
+                       "RPG::Cache.clear did not empty the cache")
+
+  if errors.zero?
+    puts "  RGSS standard library: RPG::Sprite effects/animation, RPG::Weather " \
+         "and RPG::Cache behave"
+  end
+  errors
+end
+
+# Stand-ins for the RPG::Animation records the editor stores (the real ones come
+# from rgss_data.rb, built by Marshal); `cell_data` is a Table, indexed [cell,
+# field].
+FakeTable = Struct.new(:rows) do
+  def [](i, j); rows[i] ? rows[i][j] : nil; end
+end
+FakeFrame = Struct.new(:cell_data)
+FakeTiming = Struct.new(:frame, :condition, :se, :flash_scope, :flash_color,
+                        :flash_duration)
+FakeSE = Struct.new(:name, :volume, :pitch)
+FakeAnimation = Struct.new(:frame_max, :animation_name, :animation_hue,
+                           :position, :frames, :timings)
 
 # Project-independent: the host is the default boot path (ADR 0029), and
 # RGSS_SCRIPT_HOST is the opt-out that restores the built-in flow. Guarding it
@@ -245,7 +527,7 @@ games = discover_games(File.expand_path("../data", __dir__)) if games.empty?
 
 # The project-independent checks run first, so they still guard the rules when
 # no test bed has been downloaded.
-errors = check_enabled_default + check_run_defines_top_level
+errors = check_enabled_default + check_run_defines_top_level + check_rgss_library
 
 if games.empty?
   warn "no XP test-bed game found (run scripts/download-opengame-xp.bash first)"

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -33,6 +33,7 @@
 # Exits non-zero if any invariant is violated.
 
 require "zlib"
+require "tmpdir"
 
 # --- RGSS value-type + native shims (native classes in the real build) ------
 
@@ -229,7 +230,20 @@ class Checker
     sys = obj.send(:load_data, "Data/System.rxdata")
     expect(sys.is_a?(RPG::System), "load_data did not return an RPG::System")
     expect(sys.start_map_id.to_i > 0, "load_data System.start_map_id not positive")
-    puts "  Kernel#load_data returns RPG::System (start_map_id=#{sys.start_map_id})"
+    # A file in neither the game directory nor the archive raises RGSS's own
+    # Errno::ENOENT, which is what the stock "Main" rescues and reports.
+    missing = begin
+                obj.send(:load_data, "Data/NoSuchFile.rxdata")
+                "no exception"
+              rescue Errno::ENOENT => e
+                e.message
+              rescue StandardError => e
+                "wrong class: #{e.class}: #{e.message}"
+              end
+    expect(missing == "No such file or directory - Data/NoSuchFile.rxdata",
+           "load_data on a missing file gave #{missing.inspect}")
+    puts "  Kernel#load_data returns RPG::System (start_map_id=#{sys.start_map_id}) " \
+         "and raises Errno::ENOENT for a missing file"
   end
 
   # Evaluate the bundle the way the host does and confirm the real classes and
@@ -426,6 +440,18 @@ def check_rgss_library
   weather.update
   errors += check.call([drops[1].x, drops[1].y] != before, "no weather drop moved")
 
+  # Errno, which every game's "Main" names in `rescue Errno::ENOENT` and mruby
+  # does not ship. The clause is evaluated when an exception passes through it,
+  # so a missing constant turned any exception leaving the game loop into a
+  # NameError. CRuby has its own Errno, so what is checked here is the *shape*
+  # our fill-in has to match (rgss_library.rb only defines what is absent).
+  errors += check.call(Errno::ENOENT.ancestors.include?(StandardError),
+                       "Errno::ENOENT is not a StandardError")
+  errors += check.call(
+    Errno::ENOENT.new("Data/Foo.rxdata").message ==
+      "No such file or directory - Data/Foo.rxdata",
+    "Errno::ENOENT's message is not RGSS's shape (the stock Main strips it)"
+  )
   # The cache: one bitmap per path, a hue variant of its own, a blank for an
   # empty name, and — our deviation from RGSS — a blank for an asset that will
   # not load rather than a raise that would end the game.

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -61,7 +61,22 @@ DEFINE_bool(
     "the game advances into its start map without input, and log the map it "
     "reaches as [RPGXP-MAP]. Used to smoke-test the RGSS path headlessly (in "
     "CI, in the browser build and beside the genuine RGSS runtime under wine; "
-    "see scripts/rpgxp_boot_check.bash and scripts/compare-rpgxp-wine.bash)");
+    "see scripts/rpgxp_boot_check.bash and scripts/compare-rpgxp-wine.bash). "
+    "It is the *built-in* title screen this drives, so the flag also runs the "
+    "built-in reimplemented flow in place of the default RGSS script host "
+    "(equivalent to --norgss_script_host)");
+DEFINE_bool(
+    rgss_script_host,
+    true,
+    "For the RGSS makers (XP / VX / VX Ace): run the project's own bundled "
+    "scripts (Data/Scripts.rxdata, Scripts.rvdata[2]) the way RGSS104E.dll "
+    "does. On by default; --norgss_script_host boots the built-in "
+    "reimplemented "
+    "title/map flow instead, which is also what a project shipping no scripts "
+    "and a script host that fails to boot fall back to. The RGSS_SCRIPT_HOST "
+    "environment variable seeds this flag (set it to 0/false/off/no to opt "
+    "out); an explicit --rgss_script_host on the command line wins over it. "
+    "See docs/adr/0029-rgss-script-host-by-default.md");
 DEFINE_bool(
     mv_new_game,
     false,
@@ -534,7 +549,24 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
 }
 #endif
 
+// The value RGSS_SCRIPT_HOST asks for. The script host is on by default, so the
+// variable is an opt-out and only these spellings mean "off" -- the same list
+// RPGXP::ScriptHost::DISABLED_VALUES holds on the Ruby side (empty, unset or
+// anything else leaves the host on).
+static bool script_host_env_enabled(const std::string& value) {
+  return !(value == "0" || value == "false" || value == "off" || value == "no");
+}
+
 int main(int argc, char** argv) {
+  // Seed the script-host flag from the environment *before* parsing, so an
+  // explicit --rgss_script_host on the command line still wins. The variable is
+  // the documented opt-out and this mruby build has no ENV for the Ruby side to
+  // read, so the native runtime resolves it and hands Ruby the answer as the
+  // RGSS_SCRIPT_HOST constant below.
+  if (const char* host_env = std::getenv("RGSS_SCRIPT_HOST"))
+    if (*host_env != '\0')
+      FLAGS_rgss_script_host = script_host_env_enabled(host_env);
+
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   if (FLAGS_game_dir.empty()) {
 #ifdef __EMSCRIPTEN__
@@ -716,6 +748,13 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RPGXP_NEW_GAME"),
                 mrb_bool_value(FLAGS_rpgxp_new_game));
+  // Whether the RGSS script host runs the project's own scripts (the default)
+  // or the built-in flow does. Resolved from --rgss_script_host and the
+  // RGSS_SCRIPT_HOST environment variable above, because the Ruby side cannot
+  // read the environment in this build (RPGXP::ScriptHost.enabled?).
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RGSS_SCRIPT_HOST"),
+                mrb_bool_value(FLAGS_rgss_script_host));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));
@@ -835,8 +874,9 @@ int main(int argc, char** argv) {
     // RPG Maker VX / VX Ace: a Marshal database like XP's under a different
     // extension (Data/*.rvdata[2]) and schema. Checked before the XP branch,
     // which only looks for Game.ini — a VX project has one too. The database
-    // loads; the built-in title/map flow is still to come, so an unpacked
-    // project reports that unless the RGSS script host is enabled. See
+    // loads and the RGSS script host (the default path) runs the project's own
+    // scripts; the built-in title/map flow is still to come, so a project that
+    // ships no scripts — or a boot with RGSS_SCRIPT_HOST=0 — reports that. See
     // mruby-rpgvx and docs/adr/0024-rpgvx-rgss2-rgss3-data-layer.md.
     error_dump_set_context("project", "RPG Maker VX / VX Ace");
     game_obj = mrb_obj_new(M, mrb_class_get(M, "RPGVX"), 1, &args);


### PR DESCRIPTION
The RGSS script host is now the default boot path for RPG Maker XP/VX/VX Ace projects, replacing the opt-in model. Projects that ship bundled scripts now run their own engine (title, menus, battle system, community scripts) the way `RGSS104E.dll` does, instead of falling back to the reimplemented flow.

## Key Changes

- **Script host enabled by default**: `RPGXP::ScriptHost.enabled?` now returns `true` unless explicitly disabled via `RGSS_SCRIPT_HOST=0` (or equivalent `--norgss_script_host` flag). The opt-out values are `0`, `false`, `off`, `no`.

- **Native binary integration**: The C++ runtime now resolves `--rgss_script_host` (default true) and the `RGSS_SCRIPT_HOST` environment variable, passing the result to Ruby as the `RGSS_SCRIPT_HOST` constant since this mruby build has no `ENV`.

- **Built-in flow as fallback**: The reimplemented title/map flow remains available for:
  - Projects that ship no scripts
  - When the script host fails to boot (logged as "script host failed")
  - Explicit opt-out via `RGSS_SCRIPT_HOST=0` or `--norgss_script_host`
  - When `--rpgxp_new_game` is used (which drives the built-in title screen)

- **Logging markers**: `ScriptHost.run` now logs `[RPGXP-SCRIPTS] running N script sections` to distinguish the script host path from the built-in flow's `[RPGXP-MAP]` marker.

- **CI testing**: `scripts/rpgxp_boot_check.bash` now boots each XP test bed twice:
  1. With no flags (script host runs the game's own scripts, must see `[RPGXP-SCRIPTS]`)
  2. With `--rpgxp_new_game` (built-in flow into the map, must see `[RPGXP-MAP]`)

- **Documentation**: Added ADR 0029 explaining the decision, rationale, and consequences. Updated existing ADRs and docs to reflect the new default.

## Implementation Details

- The `DISABLED_VALUES` list is maintained in both Ruby (`mruby-rpgxp/mrblib/script_host.rb`) and C++ (`src/main.cxx`) to prevent drift.
- `--rpgxp_new_game` now implies the built-in flow by checking `builtin_flow_forced?`, ensuring headless render checks continue measuring the reimplementation.
- The frame driver (ADR 0023) that reconciles the scripts' blocking loop with per-frame callbacks is no longer gated behind the flag.
- VX/VX Ace projects now boot via the script host by default (previously the only path, but now explicitly the default).

https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz