### PR TITLE
Add MZ in-game path probes: message, menu, save, and battle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,6 +349,39 @@ jobs:
             continue-on-error: true
             run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
 
+          # The rest of the in-game paths, one run each (the same shape as the
+          # MV smokes above), all through the same no-X headless launcher the
+          # play smoke uses. Each mode asserts its own success line, so a probe
+          # that merely ran cannot pass: the message window has to open
+          # (`[MZ-MSG] busy=true window_open=true`), Scene_Menu has to be
+          # reached (`[MZ-MENU] reached_menu=true`), the asynchronous save chain
+          # has to settle with the slot written and read back (`[MZ-SAVE]`), and
+          # Battle Processing has to land in Scene_Battle (`[MZ-BTL]`).
+          # Non-blocking while the MZ runtime is brought up, like the MV smokes.
+          - name: MZ message smoke test
+            continue-on-error: true
+            env:
+              MZ_MODE: message
+            run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
+
+          - name: MZ menu smoke test
+            continue-on-error: true
+            env:
+              MZ_MODE: menu
+            run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
+
+          - name: MZ save smoke test
+            continue-on-error: true
+            env:
+              MZ_MODE: save
+            run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
+
+          - name: MZ battle smoke test
+            continue-on-error: true
+            env:
+              MZ_MODE: battle
+            run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
+
           # Run the battle smoke against the real bed (Lunatic-Core): it ships
           # battlers and a battleback, so the captured Scene_Battle frame shows
           # an actual battle (enemy + battle log) rather than the art-less
@@ -469,6 +502,18 @@ jobs:
         with:
           name: mz-play-screenshot
           path: ss/mz_play.png
+          if-no-files-found: warn
+
+      - name: Upload MZ scene screenshots
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: mz-scene-screenshots
+          path: |
+            ss/mz_message.png
+            ss/mz_menu.png
+            ss/mz_save.png
+            ss/mz_battle.png
           if-no-files-found: warn
 
   # `/preview` command gate. Cloudflare previews are opt-in per pull request:

--- a/README.md
+++ b/README.md
@@ -247,12 +247,22 @@
   than the MV path and is still being brought up against real games — the
   headless CI smoke is what the claim rests on, and it is not yet a blocking
   check
+- MZ also **shows messages, opens the party menu, saves and fights**, each
+  exercised headlessly the way the MV path is: a message queued through
+  `$gameMessage` opens `Window_Message` over the map, `Scene_Map`'s own
+  `callMenu` reaches `Scene_Menu`, a save round-trips through the real
+  `DataManager` and a Battle Processing command run through the map interpreter
+  lands in `Scene_Battle`. MZ's save path is a **promise chain** (JsonEx → pako
+  → localforage) rather than MV's synchronous call, so the probe starts it and
+  polls until it settles, then re-enters the map the way `Scene_Load` does
 - The MZ engine is not redistributable (unlike MV's MIT corescript), so
   `data/mz-sample` commits only an authored database and art —
   `scripts/gen-mz-sample.py` writes both — and
   `scripts/download-mz-corescript.bash` fetches the engine at build time.
-  `scripts/mz_boot_check.bash` boots that bed headlessly and asserts the game
-  reaches the map and that a held key moves the player; `ruby
+  `scripts/mz_boot_check.bash` boots that bed headlessly and asserts what the
+  requested `MZ_MODE` claims — `play` (the default: the map is reached and a held
+  key moves the player), `message`, `menu`, `save` or `battle`, each with its own
+  success line so a probe that merely ran cannot pass; `ruby
   scripts/mz_testbed_check.rb path/to/Game` validates any MZ project's
   boot-critical data and system art without a build
 

--- a/changelog.d/mz-scene-probes.added.md
+++ b/changelog.d/mz-scene-probes.added.md
@@ -1,0 +1,12 @@
+- **RPG Maker MZ** now proves the rest of its in-game paths headlessly, not
+  just the boot and a walked map: `--mz_message_test` shows a message through
+  `$gameMessage` and reports whether `Window_Message` opened, `--mz_menu_test`
+  opens the party menu through `Scene_Map`'s own `callMenu` and reports whether
+  `Scene_Menu` was reached, `--mz_save_test` round-trips a save through the real
+  `DataManager` — MZ's save path is a **promise chain** (JSON → pako →
+  localforage), so the probe starts it and polls until it settles, then re-enters
+  the map the way `Scene_Load` does — and `--mz_battle_test=<troopId>` starts a
+  battle with a Battle Processing command run through the map interpreter and
+  reports whether `Scene_Battle` was reached. `scripts/mz_boot_check.bash` gained
+  an `MZ_MODE` (`play`/`message`/`menu`/`save`/`battle`) that drives each one and
+  asserts its success line, and CI runs all five against `data/mz-sample`.

--- a/data/mz-sample/README.md
+++ b/data/mz-sample/README.md
@@ -54,3 +54,11 @@ through `Scene_Boot` to the **title screen** and presents frames on-screen; add
 `--mz_new_game --mz_move_test` to advance into the start map and walk the
 player without any input, which is what `scripts/mz_boot_check.bash` asserts in
 CI (`--mz_screenshot=<path>` captures the frame).
+
+The other in-game paths have probes of their own — `--mz_message_test`,
+`--mz_menu_test`, `--mz_save_test` and `--mz_battle_test=1` (the bed's only
+troop) — each reached through the boot check's `MZ_MODE`:
+
+```
+MZ_MODE=battle scripts/mz_boot_check.bash
+```

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -287,6 +287,49 @@ JavaScript loads and interprets the JSON.
       were neutralised. Remaining: `.woff` font loading (the canvas text loader
       finds only `.ttf`/`.otf`, and MZ games ship `.woff`, so their text draws
       blank), verified against a real MZ project.
+    - **M6.3d — the rest of the in-game paths (landed).** Booting and walking is
+      not playing, so the four paths the MV side already proves are now driven on
+      MZ too, each behind its own launcher flag and each asserted by
+      `scripts/mz_boot_check.bash` under an `MZ_MODE`
+      (`play`/`message`/`menu`/`save`/`battle`): a message queued through
+      `$gameMessage` must open `Window_Message` (`--mz_message_test`),
+      `Scene_Map`'s own `callMenu` must reach `Scene_Menu` (`--mz_menu_test`), a
+      save must round-trip through the real `DataManager` (`--mz_save_test`), and
+      a Battle Processing command run through the map interpreter must land in
+      `Scene_Battle` (`--mz_battle_test=<troopId>`). Three things are worth
+      recording about how MZ differs from MV here:
+      1. **The save path is asynchronous.** MV's `DataManager.saveGame` returns a
+         boolean; MZ's returns a promise, and so does everything under it
+         (`objectToJson` → `jsonToZip` (pako) → `saveZip` → localforage, and the
+         mirror image on load). A probe that reads a return value therefore
+         cannot work: `MZ#maybe_save_test` starts the chain and polls a global
+         the chain parks its verdict on, one read per pumped frame — the pump
+         being what drains the microtasks the chain waits on. It also reads
+         `savefileExists` *after* the save resolves, because `saveToForage`
+         refreshes `StorageManager`'s key cache only at the end of its own chain,
+         and it finishes with `SceneManager.goto(Scene_Map)` the way
+         `Scene_Load.onLoadSuccess` does — a load throws the `$game*` objects
+         away and rebuilds them, so the running scene has to be rebuilt against
+         the new ones rather than left holding the discarded set. A re-entry that
+         throws is appended to the verdict, not allowed to overwrite it.
+      2. **The menu cannot be reached with a key.** rmmz's keyboard
+         `Input.keyMapper` has no `"menu"` binding (only the gamepad's Y), so the
+         probe sets `Scene_Map#menuCalling` — exactly what `isMenuCalled` sets —
+         and lets `updateCallMenu` run the real `callMenu` inside the scene loop.
+         It re-asserts the flag every frame, since `updateCallMenu` clears it on
+         any frame the menu is momentarily disabled (the New Game transfer still
+         settling right after the map arrives).
+      3. **The battle must be started from inside the scene loop**, for the same
+         reason as on MV: a bare `SceneManager.push(Scene_Battle)` leaves the map
+         active with the encounter effect frozen, because that effect only
+         advances while the scene is inactive. rmmz's `command301` takes the same
+         `[type, troopId, canEscape, canLose]` parameters as rmmv's, so the
+         injected command list is shared in shape with the MV probe.
+      No native gap turned up this time: the battle's encounter effect snapshots
+      the screen through `Bitmap.snap` → PIXI's `extract.canvas`, which reads the
+      FBO back with `gl.readPixels` and writes it through the canvas bridge's
+      `getImageData`/`putImageData` — a path the boot already exercised, since
+      `Scene_Title.terminate` snaps for the menu background on every New Game.
 
   **Concrete boot map (verified by running the engine on the host).** MZ's boot
   differs from MV's in more than the renderer. Driving the shared host through a

--- a/mruby-mvjs/mrbgem.rake
+++ b/mruby-mvjs/mrbgem.rake
@@ -14,6 +14,9 @@ MRuby::Gem::Specification.new('mruby-mvjs') do |spec|
   # the difference. (mruby core omits several stdlib methods into *-ext gems; the
   # rule is to depend on the providing core gem, see AGENTS.md.)
   add_dependency 'mruby-array-ext'
+  # Integer#zero? (the probe frame counters in mv.rb / mz.rb) is another of
+  # those: it lives in mruby-numeric-ext, not mruby's base Integer.
+  add_dependency 'mruby-numeric-ext'
 
   # The embedded JavaScript engine (quickjs-ng, vendored at 3rd/quickjs). The
   # header is needed to compile src/mvjs.cxx in every build (native and wasm);

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -46,6 +46,33 @@ class MZ
   # out and the map's own fade in all have to play out first.
   MAP_PROBE_FRAMES = 300
 
+  # Frames the message probe lets run after queueing its text, so
+  # `Window_Message` can open and draw before the state is read back.
+  MSG_PROBE_FRAMES = 45
+
+  # The line the message probe shows. ASCII, so it renders through whatever font
+  # the project ships (the test bed's authored one covers ASCII only).
+  MESSAGE_PROBE_TEXT = "MZ message smoke test".freeze
+
+  # Frames the menu probe keeps re-asserting `Scene_Map#menuCalling` before it
+  # gives up (see #maybe_menu_test).
+  MENU_PROBE_FRAMES = 60
+
+  # Frames the save probe waits for its promise chain to settle. MZ's save path
+  # is asynchronous end to end (`DataManager.saveGame` -> `StorageManager`'s
+  # JSON/deflate/localforage promises), so the result only lands some frames
+  # after the probe starts — see #maybe_save_test.
+  SAVE_PROBE_FRAMES = 300
+
+  # The save slot the save probe round-trips through.
+  SAVE_PROBE_SLOT = 1
+
+  # Frames to watch for `Scene_Battle` after the battle probe runs its Battle
+  # Processing command: New Game's fade, the map settle, the encounter effect
+  # (~60 frames) and Scene_Battle's own fade-in all have to play out first, and
+  # a headless software-GL frame is slower than 60Hz.
+  BATTLE_PROBE_FRAMES = 240
+
   # The files that unambiguously mark a directory as an RPG Maker MZ project:
   # the core engine script and the system database. MV uses `js/rpg_core.js`
   # instead, so the two never collide.
@@ -200,6 +227,127 @@ class MZ
       REQUIRED_MARKERS.all? { |m| File.exist?("#{dir}/#{m}") }
     end
 
+    # JS that queues one line of message text through rmmz's `$gameMessage`,
+    # the way an event's Show Text command does. `Scene_Map` (a `Scene_Message`)
+    # notices the pending text on its next update and opens `Window_Message`
+    # over it. Skipped while a message is already busy, so the probe never
+    # stacks onto a game's own dialogue. Split out so the injection is
+    # unit-testable without a booted engine.
+    def message_probe_js(text)
+      "(function(){ if (typeof $gameMessage === 'undefined' || !$gameMessage " \
+      "|| $gameMessage.isBusy()) return; " \
+      "$gameMessage.add(#{js_string(text)}); })();"
+    end
+
+    # JS that reads the message state back as "busy=<bool> window_open=<bool>":
+    # whether `$gameMessage` still holds text and whether the running scene's
+    # `Window_Message` has opened (`openness > 0`). One eval rather than two, so
+    # both halves describe the same frame.
+    def message_state_js
+      "(function(){ var busy = (typeof $gameMessage !== 'undefined' && " \
+      "$gameMessage && $gameMessage.isBusy()) ? true : false; " \
+      "var s = (typeof SceneManager !== 'undefined') ? SceneManager._scene : " \
+      "null; var open = (s && s._messageWindow && s._messageWindow.openness > " \
+      "0) ? true : false; return 'busy=' + busy + ' window_open=' + open; })();"
+    end
+
+    # JS that asks `Scene_Map` to open the party menu, by setting the very flag
+    # its own `updateCallMenu` acts on. rmmz's keyboard `Input.keyMapper` has no
+    # "menu" binding (only the gamepad's Y), so pressing a key cannot reach
+    # `isMenuCalled`; `menuCalling` is exactly what that predicate sets, so this
+    # takes the real `callMenu` path (SoundManager.playOk + push Scene_Menu)
+    # from inside the scene loop. Shared shape with MV#maybe_menu_test.
+    def menu_probe_js
+      "(function(){ var s = (typeof SceneManager !== 'undefined') ? " \
+      "SceneManager._scene : null; if (s && s.constructor && " \
+      "s.constructor.name === 'Scene_Map') s.menuCalling = true; })();"
+    end
+
+    # JS that starts a save + load round-trip through the real `DataManager` and
+    # parks the outcome on `__mzSaveResult` for #maybe_save_test to read back.
+    #
+    # Unlike MV's — which is synchronous — **MZ's save path is a promise
+    # chain**: `DataManager.saveGame` returns `StorageManager.saveObject(...)`,
+    # itself `objectToJson` -> `jsonToZip` (pako) -> `saveZip` -> localforage,
+    # and `loadGame` mirrors it. So the probe cannot read a return value; it
+    # kicks the chain off and the result appears frames later, once the host has
+    # pumped enough microtasks. `savefileExists` is read *after* the save
+    # resolves, because `saveToForage` only refreshes `StorageManager`'s key
+    # cache at the end of its own chain.
+    #
+    # The load re-creates the `$game*` objects from the file, so the probe
+    # finishes the way a real load does — `SceneManager.goto(Scene_Map)` — and
+    # the running scene is rebuilt against the restored objects instead of
+    # holding references to the ones the load threw away.
+    def save_probe_js(slot)
+      slot = slot.to_i
+      <<~JS
+        (function () {
+          globalThis.__mzSaveResult = "";
+          if (typeof DataManager === "undefined") {
+            globalThis.__mzSaveResult = "error: no DataManager"; return;
+          }
+          var fail = function (e) {
+            globalThis.__mzSaveResult =
+              "error: " + String((e && e.message) || e);
+          };
+          try {
+            var exists = false;
+            DataManager.saveGame(#{slot}).then(function () {
+              exists = !!DataManager.savefileExists(#{slot});
+              return DataManager.loadGame(#{slot});
+            }).then(function () {
+              globalThis.__mzSaveResult =
+                "saved=true exists=" + exists + " loaded=true";
+              try {
+                if (typeof SceneManager !== "undefined" &&
+                    typeof Scene_Map !== "undefined") {
+                  SceneManager.goto(Scene_Map);
+                }
+              } catch (e) {
+                // The round-trip itself succeeded, so its verdict is kept; the
+                // re-entry failure is appended rather than swallowed.
+                globalThis.__mzSaveResult +=
+                  " goto_error=" + String((e && e.message) || e);
+              }
+            })["catch"](fail);
+          } catch (e) { fail(e); }
+        })();
+      JS
+    end
+
+    # JS that reads back what #save_probe_js parked, or "" while the promise
+    # chain is still in flight.
+    def save_result_js
+      "(function(){ return (typeof __mzSaveResult === 'string') ? " \
+      "__mzSaveResult : ''; })();"
+    end
+
+    # JS that starts a battle against `troop_id` the way a game does: a **Battle
+    # Processing** event command (code 301) run through the *map interpreter*,
+    # not a bare `SceneManager.push(Scene_Battle)` from outside the scene loop.
+    # The bare push deadlocks — `Scene_Map.stop` starts the encounter effect,
+    # which only advances while the scene is inactive, so an out-of-loop push
+    # leaves the map active with the effect frozen and the pending battle never
+    # applies. rmmz's `command301` takes the same `[type, troopId, canEscape,
+    # canLose]` parameters as rmmv's, so the injected list is shared in shape
+    # with MV#maybe_battle_test.
+    def battle_probe_js(troop_id)
+      "(function(){ if (typeof $gameMap === 'undefined' || !$gameMap || " \
+      "!$gameMap._interpreter) return; $gameMap._interpreter.setup([" \
+      "{code:301,indent:0,parameters:[0,#{troop_id.to_i},true,false]}," \
+      "{code:0,indent:0,parameters:[]}], 0); })();"
+    end
+
+    # Quote a Ruby string as a single-quoted JavaScript string literal, escaping
+    # what would otherwise end or reopen it (backslash, quote, newline). The
+    # probe text is ASCII at every call site, so nothing else needs encoding.
+    def js_string(text)
+      escaped = text.to_s.gsub("\\", "\\\\\\\\").gsub("'", "\\\\'")
+                    .gsub("\n", "\\n")
+      "'#{escaped}'"
+    end
+
     # True where the WebGL-subset backend PIXI v5 needs (milestone M6.3) is
     # compiled in — the surfaceless-EGL GLES2 context (MV::GL). There MZ boots to
     # the title, plays and presents frames on-screen (see #start / #main_loop);
@@ -273,7 +421,11 @@ class MZ
     @scene = scene_name # read once a frame; the probes below all consult it
     log_scene_transition # trace progress (Scene_Boot -> Scene_Title -> Map)
     maybe_new_game # CI: auto-advance past the title to the first map
+    maybe_battle_test # CI: start a battle from the map and log Scene_Battle
     maybe_move_test # CI: hold a direction on the map and log that the player moved
+    maybe_message_test # CI: show a message on the map and log the window opened
+    maybe_menu_test # CI: open the menu on the map and log that Scene_Menu opened
+    maybe_save_test # CI: save+load round-trip on the map and log the result
     maybe_audio_test # CI: play an SE through the bridge and log it dispatched
     present
     maybe_screenshot # capture the presented frame once, if requested (CI)
@@ -438,15 +590,17 @@ class MZ
     end) == true
   end
 
-  # When --mz_new_game is set (CI) — or the movement probe is requested, which
-  # needs the map first — pick "New Game" once the title is up, so the game
-  # advances to its start map without any input and a headless run exercises the
-  # in-game render path instead of only the title. One-shot; a no-op during
-  # normal play (flags unset). Mirrors MV#maybe_new_game.
+  # When --mz_new_game is set (CI) — or any probe that needs the map first is
+  # requested — pick "New Game" once the title is up, so the game advances to
+  # its start map without any input and a headless run exercises the in-game
+  # render path instead of only the title. One-shot; a no-op during normal play
+  # (flags unset). Mirrors MV#maybe_new_game.
   def maybe_new_game
     return if @new_game_done
     return unless new_game_requested? || move_test_requested? ||
-                  audio_test_requested?
+                  audio_test_requested? || message_test_requested? ||
+                  menu_test_requested? || save_test_requested? ||
+                  battle_test_troop > 0
     return unless current_scene == "Scene_Title"
 
     @new_game_done = true
@@ -516,6 +670,189 @@ class MZ
     $stderr.puts "[MZ-MOVE] end #{player_tile} moved=#{@move_seen ? true : false}"
   rescue StandardError => e
     $stderr.puts "[MZ] move test error: #{e.message}"
+  end
+
+  # Whether --mz_message_test was requested (a launcher constant set by
+  # main.cxx). Implies New Game, since the probe needs the map.
+  def message_test_requested?
+    (begin
+      MZ_MESSAGE_TEST
+    rescue StandardError
+      false
+    end) == true
+  end
+
+  # When --mz_message_test is set (CI), once on the map queue a "Show Text"
+  # message through `$gameMessage`, let `Scene_Map`'s `Window_Message` open and
+  # draw it over a few frames, then log whether the window opened and is still
+  # showing the text. This drives the dialogue path every RPG uses (event ->
+  # $gameMessage -> Window_Message -> the native text render), so a headless run
+  # proves message boxes actually display rather than only that the map renders.
+  # One-shot; a no-op during normal play. Mirrors MV#maybe_message_test.
+  def maybe_message_test
+    return if @msg_test_done
+    return unless message_test_requested?
+    return unless current_scene == "Scene_Map"
+
+    @msg_frame ||= 0
+    if @msg_frame.zero?
+      MV::JS.eval(self.class.message_probe_js(MESSAGE_PROBE_TEXT))
+      $stderr.puts "[MZ] auto message test: queued a message"
+    end
+    @msg_frame += 1
+    return if @msg_frame < MSG_PROBE_FRAMES
+
+    @msg_test_done = true
+    state = MV::JS.eval(self.class.message_state_js)
+    $stderr.puts "[MZ-MSG] #{state.is_a?(String) ? state : ""}"
+  rescue StandardError => e
+    $stderr.puts "[MZ] message test error: #{e.message}"
+  end
+
+  # Whether --mz_menu_test was requested (a launcher constant set by main.cxx).
+  # Implies New Game, since the probe opens the menu from the map.
+  def menu_test_requested?
+    (begin
+      MZ_MENU_TEST
+    rescue StandardError
+      false
+    end) == true
+  end
+
+  # When --mz_menu_test is set (CI), once on the map open the party menu through
+  # `Scene_Map`'s own `callMenu` (see MZ.menu_probe_js) and log whether
+  # `Scene_Menu` actually opened. This drives the menu path every RPG uses (map
+  # -> Scene_Menu -> its command / status / gold windows, each of them a
+  # `Window_Selectable` whose rows stroke a background rect), so a headless run
+  # proves the menu opens and draws.
+  #
+  # The flag is re-asserted every frame rather than set once: `updateCallMenu`
+  # clears `menuCalling` on any frame the menu is momentarily disabled (an
+  # autorun event, or the New Game transfer still settling right after the map
+  # arrives), so a single set can be dropped before it ever fires. One-shot
+  # report. Mirrors MV#maybe_menu_test.
+  def maybe_menu_test
+    return if @menu_test_done
+    return unless menu_test_requested?
+    return unless @menu_requested || current_scene == "Scene_Map"
+
+    if current_scene == "Scene_Menu"
+      @menu_test_done = true
+      $stderr.puts "[MZ-MENU] reached_menu=true"
+      return
+    end
+
+    @menu_frame ||= 0
+    $stderr.puts "[MZ] auto menu test" if @menu_frame.zero?
+    @menu_frame += 1
+    @menu_requested = true
+    MV::JS.eval(self.class.menu_probe_js)
+    return if @menu_frame < MENU_PROBE_FRAMES
+
+    @menu_test_done = true
+    $stderr.puts "[MZ-MENU] reached_menu=false scene=#{current_scene}"
+  rescue StandardError => e
+    $stderr.puts "[MZ] menu test error: #{e.message}"
+  end
+
+  # Whether --mz_save_test was requested (a launcher constant set by main.cxx).
+  # Implies New Game, since the probe saves the state the map set up.
+  def save_test_requested?
+    (begin
+      MZ_SAVE_TEST
+    rescue StandardError
+      false
+    end) == true
+  end
+
+  # When --mz_save_test is set (CI), once on the map run a save + load
+  # round-trip through the real `DataManager` and log the result. This drives
+  # the save path every game relies on: `makeSaveContents` serialises the
+  # `$game*` objects, `StorageManager` deflates them through pako and writes the
+  # slot, `savefileExists` confirms it, and `loadGame` reads it back and rebuilds
+  # the game objects.
+  #
+  # MZ's chain is asynchronous (unlike MV's), so the probe starts it once and
+  # then polls `__mzSaveResult` on later frames — each pumped frame drains the
+  # promise microtasks the chain waits on. A chain that never settles is
+  # reported as a timeout rather than silently ending the run with no line.
+  # One-shot; a no-op during normal play.
+  def maybe_save_test
+    return if @save_test_done
+    return unless save_test_requested?
+    return unless @save_started || current_scene == "Scene_Map"
+
+    unless @save_started
+      @save_started = true
+      @save_frame = 0
+      MV::JS.eval(self.class.save_probe_js(SAVE_PROBE_SLOT))
+      $stderr.puts "[MZ] auto save test: slot #{SAVE_PROBE_SLOT}"
+      return
+    end
+
+    res = MV::JS.eval(self.class.save_result_js)
+    res = "" unless res.is_a?(String)
+    @save_frame += 1
+    if !res.empty?
+      @save_test_done = true
+      $stderr.puts "[MZ-SAVE] #{res}"
+    elsif @save_frame >= SAVE_PROBE_FRAMES
+      @save_test_done = true
+      $stderr.puts "[MZ-SAVE] the save round-trip never settled " \
+                   "(#{SAVE_PROBE_FRAMES} frames)"
+    end
+  rescue StandardError => e
+    $stderr.puts "[MZ] save test error: #{e.message}"
+  end
+
+  # The troop id requested by --mz_battle_test (a launcher constant set by
+  # main.cxx), or 0 when unset/disabled (e.g. under the test harness). Implies
+  # New Game, since the battle is started from the map.
+  def battle_test_troop
+    v = begin
+      MZ_BATTLE_TEST
+    rescue StandardError
+      0
+    end
+    v.is_a?(Integer) ? v : 0
+  end
+
+  # When --mz_battle_test=<troopId> is set (CI), start a battle against that
+  # troop once the map is up (see MZ.battle_probe_js) and log whether
+  # `Scene_Battle` was actually reached. This drives the whole combat entry path
+  # — the map interpreter's Battle Processing command, `BattleManager.setup`,
+  # the encounter effect (which snapshots the map through the WebGL frame
+  # extractor for the battle background) and Scene_Battle's own spriteset and
+  # windows — so a headless run proves a game can actually get into a fight.
+  # One-shot; a no-op otherwise. Mirrors MV#maybe_battle_test.
+  def maybe_battle_test
+    return if @battle_test_done
+
+    troop = battle_test_troop
+    return unless troop > 0
+
+    if @battle_requested
+      if current_scene == "Scene_Battle"
+        @battle_test_done = true
+        $stderr.puts "[MZ-BTL] reached_battle=true"
+        return
+      end
+      @battle_frame += 1
+      return if @battle_frame < BATTLE_PROBE_FRAMES
+
+      @battle_test_done = true
+      $stderr.puts "[MZ-BTL] reached_battle=false scene=#{current_scene}"
+      return
+    end
+
+    return unless current_scene == "Scene_Map"
+
+    @battle_requested = true
+    @battle_frame = 0
+    MV::JS.eval(self.class.battle_probe_js(troop))
+    $stderr.puts "[MZ] auto battle test: troop #{troop}"
+  rescue StandardError => e
+    $stderr.puts "[MZ] battle test error: #{e.message}"
   end
 
   # Whether --mz_audio_test was requested (a launcher constant set by main.cxx).

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -189,6 +189,172 @@ assert 'the MZ audio bridge queues ops and neutralises the eager preload' do
   assert_equal "audio/se/Beep", call[1]
 end
 
+assert 'MZ.message_probe_js queues text through $gameMessage' do
+  # Exercised against the real host with a stand-in $gameMessage, so this checks
+  # the injection's *effect*: it must call the engine's own Game_Message#add
+  # (what a Show Text command does) rather than poke at window state.
+  MV::JS.eval(
+    "globalThis.$gameMessage = { texts: [], busy: false, " \
+    "add: function (t) { this.texts.push(t); }, " \
+    "isBusy: function () { return this.busy; } };"
+  )
+  MV::JS.eval(MZ.message_probe_js("hello"))
+  assert_equal "hello", MV::JS.eval("$gameMessage.texts.join('|')")
+
+  # A message already on screen is left alone, so the probe never stacks onto a
+  # game's own dialogue.
+  MV::JS.eval("$gameMessage.busy = true;")
+  MV::JS.eval(MZ.message_probe_js("second"))
+  assert_equal "hello", MV::JS.eval("$gameMessage.texts.join('|')")
+end
+
+assert 'MZ.js_string escapes what it quotes' do
+  # The probe text is interpolated into a JS source string, so a quote or a
+  # backslash in it must not end (or reopen) the literal.
+  assert_equal "'plain'", MZ.js_string("plain")
+  assert_equal "'it\\'s'", MZ.js_string("it's")
+  assert_equal "'a\\\\b'", MZ.js_string("a\\b")
+  # And the result really is one string to the engine.
+  assert_equal "it's", MV::JS.eval("(#{MZ.js_string("it's")})")
+end
+
+assert 'MZ.message_state_js reports both halves of the message state' do
+  MV::JS.eval(
+    "globalThis.$gameMessage = { isBusy: function () { return true; } }; " \
+    "globalThis.SceneManager = { _scene: { _messageWindow: { openness: 255 } } };"
+  )
+  assert_equal "busy=true window_open=true", MV::JS.eval(MZ.message_state_js)
+
+  # A window that has not opened yet is reported as such, which is the whole
+  # point: queued text with a shut window means the message path is broken.
+  MV::JS.eval("SceneManager._scene._messageWindow.openness = 0;")
+  assert_equal "busy=true window_open=false", MV::JS.eval(MZ.message_state_js)
+end
+
+assert 'MZ.menu_probe_js sets the flag Scene_Map acts on, and only there' do
+  # rmmz's keyboard Input.keyMapper has no "menu" binding, so a key press cannot
+  # reach Scene_Map#isMenuCalled; `menuCalling` is exactly what that predicate
+  # sets, and updateCallMenu then runs the real callMenu.
+  MV::JS.eval(
+    "function Scene_Map() {} globalThis.Scene_Map = Scene_Map; " \
+    "globalThis.SceneManager = { _scene: new Scene_Map() };"
+  )
+  MV::JS.eval(MZ.menu_probe_js)
+  assert_equal true, MV::JS.eval("SceneManager._scene.menuCalling === true")
+
+  # Any other scene is left untouched — the menu is only ever called from the
+  # map, and Scene_Menu itself must not be poked while it is up.
+  MV::JS.eval(
+    "function Scene_Menu() {} globalThis.SceneManager._scene = new Scene_Menu();"
+  )
+  MV::JS.eval(MZ.menu_probe_js)
+  assert_equal true, MV::JS.eval("SceneManager._scene.menuCalling === undefined")
+end
+
+assert 'MZ.save_probe_js round-trips through DataManager across frames' do
+  # MZ's save path is a promise chain (unlike MV's synchronous one), so the
+  # probe cannot read a return value: it starts the chain and the result lands
+  # some pumped frames later. Driven here against the real host with a stand-in
+  # DataManager, which is what makes the asynchrony visible.
+  MV::JS.eval(<<~'JS')
+    globalThis.__mzCalls = [];
+    globalThis.DataManager = {
+      saveGame: function (id) { __mzCalls.push('save' + id); return Promise.resolve(0); },
+      loadGame: function (id) { __mzCalls.push('load' + id); return Promise.resolve(0); },
+      savefileExists: function (id) { __mzCalls.push('exists' + id); return true; }
+    };
+    // No scene stack here, so the probe skips the Scene_Map re-entry a real
+    // load ends with (covered separately below).
+    delete globalThis.SceneManager;
+    delete globalThis.Scene_Map;
+  JS
+  MV::JS.eval(MZ.save_probe_js(1))
+  # Nothing yet — every step of the chain settles on a later microtask turn.
+  assert_equal "", MV::JS.eval(MZ.save_result_js)
+
+  5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
+  assert_equal "saved=true exists=true loaded=true",
+               MV::JS.eval(MZ.save_result_js)
+  # The slot is honoured, and `savefileExists` is read *after* the save resolves
+  # — StorageManager only refreshes its key cache at the end of its own chain.
+  assert_equal "save1,exists1,load1", MV::JS.eval("__mzCalls.join(',')")
+end
+
+assert 'MZ.save_probe_js re-enters the map, and keeps its verdict if that fails' do
+  # A real load throws the $game* objects away and rebuilds them, so the probe
+  # finishes the way Scene_Load does — back into Scene_Map — rather than leaving
+  # the running scene holding references the load discarded.
+  MV::JS.eval(<<~'JS')
+    globalThis.DataManager = {
+      saveGame: function () { return Promise.resolve(0); },
+      loadGame: function () { return Promise.resolve(0); },
+      savefileExists: function () { return true; }
+    };
+    function Scene_Map() {}
+    globalThis.Scene_Map = Scene_Map;
+    globalThis.SceneManager = { went: null, goto: function (s) { this.went = s; } };
+  JS
+  MV::JS.eval(MZ.save_probe_js(1))
+  5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
+  assert_equal "saved=true exists=true loaded=true",
+               MV::JS.eval(MZ.save_result_js)
+  assert_equal true, MV::JS.eval("SceneManager.went === Scene_Map")
+
+  # A re-entry that throws must not turn a successful round-trip into a failure
+  # line — nor disappear silently.
+  MV::JS.eval("SceneManager.goto = function () { throw new Error('no stack'); };")
+  MV::JS.eval(MZ.save_probe_js(1))
+  5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
+  assert_equal "saved=true exists=true loaded=true goto_error=no stack",
+               MV::JS.eval(MZ.save_result_js)
+end
+
+assert 'MZ.save_probe_js reports a rejected chain instead of hanging' do
+  MV::JS.eval(
+    "globalThis.DataManager = { saveGame: function () { " \
+    "return Promise.reject(new Error('disk full')); } };"
+  )
+  MV::JS.eval(MZ.save_probe_js(2))
+  5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
+  assert_equal "error: disk full", MV::JS.eval(MZ.save_result_js)
+end
+
+assert 'MZ.battle_probe_js runs Battle Processing through the map interpreter' do
+  # Not a bare SceneManager.push(Scene_Battle): that deadlocks, because
+  # Scene_Map.stop starts the encounter effect and the effect only advances
+  # while the scene is inactive. Command 301 inside the map interpreter is the
+  # path the engine itself takes.
+  MV::JS.eval(
+    "globalThis.$gameMap = { _interpreter: { setup: function (list, id) { " \
+    "this.list = list; this.eventId = id; } } };"
+  )
+  MV::JS.eval(MZ.battle_probe_js(7))
+  assert_equal 301, MV::JS.eval("$gameMap._interpreter.list[0].code")
+  # [type, troopId, canEscape, canLose] — a direct designation of troop 7.
+  assert_equal "0,7,true,false",
+               MV::JS.eval("$gameMap._interpreter.list[0].parameters.join(',')")
+  # ...terminated by the end-of-list command, so the interpreter stops after it.
+  assert_equal 0, MV::JS.eval("$gameMap._interpreter.list[1].code")
+  assert_equal 0, MV::JS.eval("$gameMap._interpreter.eventId")
+end
+
+assert 'the MZ probes are inert before the engine defines their globals' do
+  # Every probe runs each frame from MZ#main_loop, including the frames before
+  # the boot has defined $gameMessage / SceneManager / $gameMap. None may throw.
+  MV::JS.eval(
+    "delete globalThis.$gameMessage; delete globalThis.SceneManager; " \
+    "delete globalThis.$gameMap; delete globalThis.Scene_Map;"
+  )
+  assert_nothing_raised { MV::JS.eval(MZ.message_probe_js("x")) }
+  assert_nothing_raised { MV::JS.eval(MZ.menu_probe_js) }
+  assert_nothing_raised { MV::JS.eval(MZ.battle_probe_js(1)) }
+  assert_equal "busy=false window_open=false", MV::JS.eval(MZ.message_state_js)
+  # ...and a save probe with no DataManager says so rather than never settling.
+  MV::JS.eval("delete globalThis.DataManager;")
+  MV::JS.eval(MZ.save_probe_js(1))
+  assert_equal "error: no DataManager", MV::JS.eval(MZ.save_result_js)
+end
+
 assert 'MZ.host_globals_js provides the FontFace MZ builds when a font is named' do
   MV::JS.eval(MZ.host_globals_js)
 

--- a/scripts/mz_boot_check.bash
+++ b/scripts/mz_boot_check.bash
@@ -3,8 +3,8 @@
 # Boot the built engine on the RPG Maker MZ test-bed (data/mz-sample) and drive
 # it into actual play: the rmmz corescript on PIXI v5 renders through the native
 # surfaceless-EGL GLES2 backend, `Scene_Boot` finishes loading and hands over to
-# `Scene_Title`, `--mz_new_game` picks New Game, and `--mz_move_test` then holds
-# a direction on the start map and reports whether the player actually walked.
+# `Scene_Title`, `--mz_new_game` picks New Game, and the requested probe then
+# exercises one in-game path and reports what happened.
 #
 # The engine is fetched by scripts/download-mz-corescript.bash; the authored
 # database and art (data/mz-sample/data, data/mz-sample/img — see
@@ -16,16 +16,28 @@
 #   [MZ-MAP]   reached the map at <x,y>
 #   [MZ-MOVE]  start <x,y> / end <x,y> moved=<bool>
 #   [MZ-AUDIO] op=<se_play> asset=<audio/se/Beep>
+#   [MZ-MSG]   busy=<bool> window_open=<bool>
+#   [MZ-MENU]  reached_menu=<bool>
+#   [MZ-SAVE]  saved=<bool> exists=<bool> loaded=<bool>
+#   [MZ-BTL]   reached_battle=<bool>
 #
-# or "[MZ] boot stopped at: <error>" when it stops short. This asserts the boot
-# marker, that the boot got past the loading scene, and — since the whole point
-# is proving input moves the player — that the move probe reports moved=true.
+# or "[MZ] boot stopped at: <error>" when it stops short. Every mode asserts the
+# boot marker and that the boot got past the loading scene; each then asserts
+# its own probe's success line, since a probe that merely *ran* proves nothing.
+#
+# The mode is picked with MZ_MODE (default `play`):
+#
+#   play      New Game -> map, hold a direction, play an SE  (the default smoke)
+#   message   New Game -> map, show a message
+#   menu      New Game -> map, open the party menu
+#   save      New Game -> map, save + load round-trip
+#   battle    New Game -> map, start a battle against MZ_TROOP (default 1)
 #
 # The MZ engine mirror is a CI-only fixture (© Gotcha Gotcha Games / KADOKAWA);
 # if it has not been fetched the check skips with a message rather than failing,
 # the same way the RPG2k/XP boot checks skip an absent downloaded game.
 #
-# Usage: ./scripts/mz_boot_check.bash [server_num] [game_dir]
+# Usage: MZ_MODE=<mode> ./scripts/mz_boot_check.bash [server_num] [game_dir]
 
 set -eu -o pipefail
 
@@ -34,11 +46,36 @@ cd "$(dirname "$0")/.."
 SERVER_NUM="${1:-111}"
 GAME="${2:-data/mz-sample}"
 ENGINE="${ENGINE:-./build/rpg_maker_clone}"
-# The run has to reach the title, start a New Game, load the map and then hold a
-# direction for the 80-frame probe, all on software GL — so it is given far more
-# in-game time than the MV smokes, which only need to boot.
+MODE="${MZ_MODE:-play}"
+TROOP="${MZ_TROOP:-1}"
+# The run has to reach the title, start a New Game, load the map and then play
+# out its probe, all on software GL — so it is given far more in-game time than
+# the MV smokes, which only need to boot.
 TIMEOUT_MS="${MZ_TIMEOUT_MS:-60000}"
-SHOT="${MZ_SCREENSHOT:-ss/mz_play.png}"
+
+case "${MODE}" in
+    play)
+        FLAGS=(--mz_new_game --mz_move_test --mz_audio_test)
+        DEFAULT_SHOT="ss/mz_play.png" ;;
+    message)
+        FLAGS=(--mz_message_test)
+        DEFAULT_SHOT="ss/mz_message.png" ;;
+    menu)
+        FLAGS=(--mz_menu_test)
+        DEFAULT_SHOT="ss/mz_menu.png" ;;
+    save)
+        # Non-visual, but a frame is still captured: a save that leaves the
+        # scene broken shows up in the picture.
+        FLAGS=(--mz_save_test)
+        DEFAULT_SHOT="ss/mz_save.png" ;;
+    battle)
+        FLAGS=("--mz_battle_test=${TROOP}")
+        DEFAULT_SHOT="ss/mz_battle.png" ;;
+    *)
+        echo "error: unknown MZ_MODE '${MODE}' (play|message|menu|save|battle)" >&2
+        exit 1 ;;
+esac
+SHOT="${MZ_SCREENSHOT:-${DEFAULT_SHOT}}"
 
 if [ ! -x "${ENGINE}" ] ; then
     echo "error: ${ENGINE} not built; run cmake --build build first" >&2
@@ -57,7 +94,7 @@ fi
 mkdir -p "$(dirname "${SHOT}")"
 
 log="$(mktemp)"
-echo "== ${GAME}"
+echo "== ${GAME} (mode ${MODE})"
 # Run with NO X server reachable: SDL's headless "dummy" video driver instead of
 # Xvfb, and DISPLAY/XAUTHORITY scrubbed. MZ's renderer is off-screen (surfaceless
 # EGL + an FBO), but whenever an X server is present Mesa dispatches even a
@@ -69,7 +106,7 @@ echo "== ${GAME}"
 if ! env -u DISPLAY -u XAUTHORITY SDL_VIDEODRIVER=dummy \
         timeout 300 "${ENGINE}" \
         --game_dir "${GAME}" --timeout_ms="${TIMEOUT_MS}" \
-        --mz_new_game --mz_move_test --mz_audio_test \
+        "${FLAGS[@]}" \
         --mz_screenshot="${SHOT}" \
         >"${log}" 2>&1 ; then
     echo "FAILED: ${GAME}: the engine exited non-zero" >&2
@@ -79,7 +116,7 @@ if ! env -u DISPLAY -u XAUTHORITY SDL_VIDEODRIVER=dummy \
 fi
 
 fail() {
-    echo "FAILED: ${GAME}: $1" >&2
+    echo "FAILED: ${GAME} (mode ${MODE}): $1" >&2
     grep -iE '\[MZ|error|exception|webgl|indexeddb' "${log}" | tail -40 || true
     grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -40 || true
     rm -f "${log}"
@@ -96,20 +133,47 @@ if grep -q '\[MZ-BOOT\] booted to Scene_Boot' "${log}" ; then
     fail "the boot stopped on the loading scene (Scene_Boot)"
 fi
 
-grep -q '\[MZ-MAP\] reached the map' "${log}" ||
-    fail "New Game never reached the map ([MZ-MAP] missing)"
+# Every probe runs from the map, so New Game reaching it is common ground. Only
+# the play mode logs [MZ-MAP] (the movement probe prints it); the others prove
+# they got there by reaching Scene_Map.
+grep -q '\[MZ-SCENE\] Scene_Map' "${log}" ||
+    fail "New Game never reached the map (no [MZ-SCENE] Scene_Map)"
 
-grep -q '\[MZ-MOVE\].*moved=true' "${log}" ||
-    fail "input never moved the player ([MZ-MOVE] moved=true missing)"
+case "${MODE}" in
+    play)
+        grep -q '\[MZ-MAP\] reached the map' "${log}" ||
+            fail "New Game never reached the map ([MZ-MAP] missing)"
+        grep -q '\[MZ-MOVE\].*moved=true' "${log}" ||
+            fail "input never moved the player ([MZ-MOVE] moved=true missing)"
+        # The audio bridge: rmmz's AudioManager -> the op queue -> RGSS::Audio.
+        # Without it MZ's sound goes to the silent Web Audio stub and nothing
+        # reaches the mixer.
+        grep -q '\[MZ-AUDIO\]' "${log}" ||
+            fail "no audio op reached RGSS::Audio ([MZ-AUDIO] missing)"
+        ;;
+    message)
+        # Both halves matter: the text is still queued *and* Window_Message has
+        # actually opened over the map.
+        grep -q '\[MZ-MSG\] busy=true window_open=true' "${log}" ||
+            fail "the message window never opened ([MZ-MSG] busy/window_open)"
+        ;;
+    menu)
+        grep -q '\[MZ-MENU\] reached_menu=true' "${log}" ||
+            fail "the party menu never opened ([MZ-MENU] reached_menu=true)"
+        ;;
+    save)
+        grep -q '\[MZ-SAVE\] saved=true exists=true loaded=true' "${log}" ||
+            fail "the save/load round-trip failed ([MZ-SAVE] line)"
+        ;;
+    battle)
+        grep -q '\[MZ-BTL\] reached_battle=true' "${log}" ||
+            fail "the battle never started ([MZ-BTL] reached_battle=true)"
+        ;;
+esac
 
-# The audio bridge: rmmz's AudioManager -> the op queue -> RGSS::Audio. Without
-# it MZ's sound goes to the silent Web Audio stub and nothing reaches the mixer.
-grep -q '\[MZ-AUDIO\]' "${log}" ||
-    fail "no audio op reached RGSS::Audio ([MZ-AUDIO] missing)"
-
-grep -E '\[MZ-BOOT\]|\[MZ-SCENE\]|\[MZ-MAP\]|\[MZ-MOVE\]|\[MZ-AUDIO\]|\[MZ\] screenshot' "${log}"
+grep -E '\[MZ-BOOT\]|\[MZ-SCENE\]|\[MZ-MAP\]|\[MZ-MOVE\]|\[MZ-AUDIO\]|\[MZ-MSG\]|\[MZ-MENU\]|\[MZ-SAVE\]|\[MZ-BTL\]|\[MZ\] screenshot' "${log}"
 # ALSA has no device under CI and floods stderr; keep the rest for context.
 grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -20 || true
 rm -f "${log}"
-echo "mz boot check: OK"
+echo "mz boot check (${MODE}): OK"
 exit 0

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -126,6 +126,34 @@ DEFINE_bool(
     "bridge (implies --mz_new_game to reach the map) and log whether the op "
     "reached RGSS::Audio and the asset resolves, so a headless run confirms "
     "the audio path works. Used in CI");
+DEFINE_bool(
+    mz_message_test,
+    false,
+    "For RPG Maker MZ: once on the map, show a text message (implies "
+    "--mz_new_game to reach the map) and log whether the message window "
+    "opened, so a headless run confirms the message/window path renders. "
+    "Used in CI");
+DEFINE_bool(
+    mz_menu_test,
+    false,
+    "For RPG Maker MZ: once on the map, open the party menu (implies "
+    "--mz_new_game to reach the map) and log whether Scene_Menu opened, so a "
+    "headless run confirms the menu path works. Used in CI");
+DEFINE_bool(
+    mz_save_test,
+    false,
+    "For RPG Maker MZ: once on the map, save to a slot and load it back "
+    "(implies --mz_new_game to reach the map) and log whether the save/load "
+    "round-trip succeeded, so a headless run confirms the save path works. "
+    "MZ's save chain is asynchronous, so the result is reported once it "
+    "settles. Used in CI");
+DEFINE_int32(
+    mz_battle_test,
+    0,
+    "For RPG Maker MZ: once on the map, start a battle against this troop id "
+    "(implies --mz_new_game to reach the map) and log whether Scene_Battle was "
+    "reached, so a headless run confirms the combat entry path works. 0 "
+    "disables. Used in CI");
 DEFINE_string(
     mz_screenshot,
     "",
@@ -749,6 +777,18 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MZ_AUDIO_TEST"),
                 mrb_bool_value(FLAGS_mz_audio_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MZ_MESSAGE_TEST"),
+                mrb_bool_value(FLAGS_mz_message_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MZ_MENU_TEST"),
+                mrb_bool_value(FLAGS_mz_menu_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MZ_SAVE_TEST"),
+                mrb_bool_value(FLAGS_mz_save_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MZ_BATTLE_TEST"),
+                mrb_fixnum_value(FLAGS_mz_battle_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MZ_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mz_screenshot.c_str()));


### PR DESCRIPTION
Extends RPG Maker MZ headless testing to cover four critical in-game paths beyond the existing boot and movement tests: message display, menu navigation, save/load, and combat entry.

## Summary

This change adds comprehensive smoke tests for RPG Maker MZ's core gameplay systems by implementing four new launcher flags (`--mz_message_test`, `--mz_menu_test`, `--mz_save_test`, `--mz_battle_test`) that exercise real engine paths and verify they work correctly in a headless environment.

## Key Changes

- **Message probe** (`--mz_message_test`): Queues text through `$gameMessage` and verifies `Window_Message` opens and renders
- **Menu probe** (`--mz_menu_test`): Opens the party menu via `Scene_Map#menuCalling` and confirms `Scene_Menu` is reached
- **Save probe** (`--mz_save_test`): Performs a full save/load round-trip through the real `DataManager` promise chain and verifies the slot persists
- **Battle probe** (`--mz_battle_test=<troopId>`): Starts combat via Battle Processing command through the map interpreter and confirms `Scene_Battle` is reached

## Notable Implementation Details

- **Asynchronous save handling**: MZ's save path is a promise chain (JSON → pako deflate → localforage), unlike MV's synchronous call. The probe starts the chain and polls `__mzSaveResult` on subsequent frames as microtasks settle, then re-enters the map via `SceneManager.goto(Scene_Map)` the way `Scene_Load` does
- **Menu flag re-assertion**: The menu flag is set every frame since `updateCallMenu` clears it when the menu is momentarily disabled (e.g., during New Game transfer)
- **Battle Processing path**: Uses the map interpreter's command 301 rather than a bare `SceneManager.push()`, which would deadlock because the encounter effect only advances while the scene is inactive
- **Defensive JS injection**: All probes check for undefined globals and return gracefully before the engine boots, preventing errors during early frames
- **Test infrastructure**: Added comprehensive unit tests for each probe's JS generation and behavior, plus CI integration with mode-based test selection via `MZ_MODE` environment variable

https://claude.ai/code/session_014B8H5L6jNJqN8HL7WGHbcS