### PR TITLE
Make move-route jumps hop instead of walk

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 - Events move on their own: each event walks per its page's movement type
   (random, vertical/horizontal pacing, approaching or fleeing the hero) or runs a
   custom move route, paced by its move frequency and blocked by terrain, the
-  player and other events
+  player and other events. A route's **Begin Jump / End Jump** block hops to the
+  destination its enclosed moves add up to, in one move and testing only where it
+  lands — so a jump clears what it passes over, the way the real runtime's does
 - Tiles are blitted from the map's real ChipSet graphic — lower/upper chips,
   water and terrain autotiles assembled from quarter-tiles, and animated tiles —
   falling back to colour blocks only when the chipset image is missing

--- a/changelog.d/rpg2k-move-route-jump.fixed.md
+++ b/changelog.d/rpg2k-move-route-jump.fixed.md
@@ -1,0 +1,19 @@
+- **Move-route jumps hop rather than walk.** `Begin Jump` (24) and `End Jump`
+  (25) were treated as plain waits, so the moves between them stepped one tile
+  at a time: three route commands where RPG_RT runs one, and each intervening
+  tile tested for passability when a jump is precisely the thing that clears
+  them. `Game::MoveRoute#do_jump` ports EasyRPG's
+  `Game_Character::BeginMoveRouteJump` — the enclosed moves contribute a tile of
+  offset each without stepping, the face / turn commands only steer what the
+  next move contributes, and the character then lands on the summed destination
+  in a single move via the new `Game::Character#jump`, facing the jump's
+  dominant axis (vertical winning a tie) rather than its last move. Only the
+  landing tile is tested, through a new `can_land?` on the movement world
+  (`Scene::Map#char_can_land?`), because the genuine runtime skips the "may I
+  leave this tile" half of its check while jumping. A blocked landing behaves
+  like a blocked move — retried on a non-skippable route, stepped past on a
+  skippable one — and a `Begin Jump` with no `End Jump` unwinds the rest of the
+  route, as RPG_RT does. Nepheshel has 625 jump blocks, every one of them
+  enclosing a runtime-directed move (484 away from the hero, 188 toward it, 133
+  forward) rather than a literal direction; 141 enclose more than one, so those
+  now clear the tile they hop over.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -163,7 +163,24 @@ The work below is roughly ordered by the critical path to a walkable game
   move type or custom route (paced by move frequency) and keeps events off each
   other, the player and impassable tiles. Covered by
   `scripts/rpg2k_logic_check.rb` (pure logic) and `scripts/rpg2k_scene_check.rb`
-  (scene integration under host Ruby)
+  (scene integration under host Ruby).
+  **Jumps really jump now.** `Begin Jump` / `End Jump` were both treated as
+  waits, so the moves between them stepped one tile at a time — three route
+  commands where RPG_RT runs one, testing every tile on the way when a jump is
+  the thing that clears them. `Game::MoveRoute#do_jump` ports EasyRPG's
+  `BeginMoveRouteJump`: the enclosed moves contribute a tile of offset each
+  without stepping, faces and turns only steer what the next move contributes,
+  and `Game::Character#jump` lands the character on the summed destination in
+  one move, facing the jump's dominant axis (a tie going vertical) rather than
+  its last move. Only the landing is tested — a new `can_land?` on the movement
+  world (`Scene::Map#char_can_land?`), because the genuine runtime skips the
+  "may I leave this tile" half of its check while jumping. Nepheshel has 625 jump
+  blocks, every one enclosing a runtime-directed move (484 away from the hero,
+  188 toward it, 133 forward) rather than a literal direction, and 141 enclose
+  more than one, so those now clear the tile they hop over. Remaining: the visual
+  arc — RPG_RT lifts the sprite along the hop and this build snaps it to the
+  landing tile, which needs the same per-frame sprite offset the walk
+  interpolation already has
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2354,6 +2354,24 @@ module Game
       @y += dy
     end
 
+    # Land on (x, y) in one hop — the move-route Begin Jump / End Jump pair,
+    # whose enclosed moves name a destination rather than a path.
+    #
+    # RPG_RT faces the jump's **dominant axis**, vertical winning a tie, which is
+    # not the direction of the last enclosed move: a jump two right and two down
+    # lands facing down. A jump that ends where it started leaves the facing
+    # alone — the genuine runtime sets its movement direction there but never
+    # touches the sprite's, and this model has the one field for both.
+    def jump(x, y)
+      dx = x - @x
+      dy = y - @y
+      unless dx == 0 && dy == 0
+        face(dy.abs >= dx.abs ? (dy >= 0 ? 2 : 8) : (dx >= 0 ? 6 : 4))
+      end
+      @x = x
+      @y = y
+    end
+
     # Move one tile diagonally, combining a horizontal and a vertical direction.
     # RPG2000 keeps a cardinal facing on diagonals, so we face the vertical part.
     def move_diagonal(horizontal, vertical)
@@ -2525,7 +2543,9 @@ module Game
         character.face(Character::CARDINALS[world.random(4)]); [:turned, true]
       when FACE_HERO      then character.face(toward_hero(character, world)); [:turned, true]
       when FACE_AWAY_HERO then character.face(away_hero(character, world));  [:turned, true]
-      when WAIT, BEGIN_JUMP, END_JUMP then [:waited, true]
+      when WAIT       then [:waited, true]
+      when BEGIN_JUMP then do_jump(character, world)
+      when END_JUMP   then [:effect, true] # an End Jump with no Begin: skipped
       when LOCK_FACING   then character.facing_locked = true;  [:effect, true]
       when UNLOCK_FACING then character.facing_locked = false; [:effect, true]
       when SPEED_UP   then character.move_speed = [character.move_speed + 1, 6].min; [:effect, true]
@@ -2560,6 +2580,105 @@ module Game
       else
         character.face(dir) # an obstructed move still turns to face it
         @skippable ? [:blocked, true] : [:blocked, false]
+      end
+    end
+
+    # Begin Jump: the commands up to the matching End Jump do **not** step. They
+    # name the jump's *destination* — each move command contributes its direction
+    # as one tile of offset, each face / turn command only steers what the next
+    # move contributes — and the character then hops there in a single move,
+    # clearing whatever lies between. A port of EasyRPG's
+    # `Game_Character::BeginMoveRouteJump`.
+    #
+    # Only the landing tile is tested (`world.can_land?`), because the genuine
+    # runtime skips the "may I leave this tile" half of its passability check
+    # while jumping — that is what lets a jump cross a wall or a chasm at all.
+    # A blocked landing behaves like a blocked move: retried on a non-skippable
+    # route, stepped past on a skippable one.
+    def do_jump(character, world)
+      dx = 0
+      dy = 0
+      dir = character.direction
+      i = @index + 1
+      while i < @commands.size
+        id = @commands[i].command_id
+        if id >= MOVE_UP && id <= MOVE_FORWARD
+          dir = jump_move_direction(id, dir, character, world)
+          ddx, ddy = jump_delta(id, dir)
+          dx += ddx
+          dy += ddy
+        elsif id >= FACE_UP && id <= FACE_AWAY_HERO
+          dir = jump_face_direction(id, dir, character, world)
+        elsif id == END_JUMP
+          return land_jump(character, world, dx, dy, i)
+        end
+        # Any other command inside the block (a switch, a graphic change) is
+        # skipped, as RPG_RT skips it.
+        i += 1
+      end
+      # No End Jump before the route ran out: the jump is abandoned and the rest
+      # of the route goes with it, which is how RPG_RT unwinds the scan.
+      @index = @commands.size - 1
+      [:effect, true]
+    end
+
+    # Finish a jump scanned out to the End Jump at `end_index`.
+    def land_jump(character, world, dx, dy, end_index)
+      tx = character.x + dx
+      ty = character.y + dy
+      if character.through || world.can_land?(character, tx, ty)
+        character.jump(tx, ty)
+        @index = end_index
+        [:moved, true]
+      elsif @skippable
+        @index = end_index
+        [:blocked, true]
+      else
+        [:blocked, false] # retried from the Begin Jump next step
+      end
+    end
+
+    # The direction a move command inside a jump block contributes. The moves
+    # that would pick a direction at run time (random, toward / away from the
+    # hero) still pick one; Move Forward keeps the direction in hand.
+    def jump_move_direction(id, dir, character, world)
+      case id
+      when MOVE_UP, MOVE_RIGHT, MOVE_DOWN, MOVE_LEFT then MOVE_DIR[id]
+      when MOVE_RANDOM then Character::CARDINALS[world.random(4)]
+      when MOVE_TOWARD_HERO then toward_hero(character, world)
+      when MOVE_AWAY_HERO then away_hero(character, world)
+      else dir # Move Forward, and the diagonals (which carry their own delta)
+      end
+    end
+
+    # The tile offset a move command inside a jump block adds. A diagonal moves
+    # on both axes at once; everything else moves one tile along `dir`.
+    def jump_delta(id, dir)
+      if (pair = DIAGONAL[id])
+        horizontal, vertical = pair
+        hx, = Character::DIR_DELTA[horizontal] || [0, 0]
+        _, vy = Character::DIR_DELTA[vertical] || [0, 0]
+        [hx, vy]
+      else
+        Character::DIR_DELTA[dir] || [0, 0]
+      end
+    end
+
+    # The direction a face / turn command inside a jump block leaves in hand. It
+    # contributes no offset of its own — it only steers the next move command.
+    def jump_face_direction(id, dir, character, world)
+      case id
+      when FACE_UP, FACE_RIGHT, FACE_DOWN, FACE_LEFT then FACE_DIR[id]
+      when TURN_RIGHT then Character::TURN_RIGHT[dir] || dir
+      when TURN_LEFT  then Character::TURN_LEFT[dir]  || dir
+      when TURN_180   then Character::TURN_180[dir]   || dir
+      when TURN_RANDOM
+        world.random(2).zero? ? (Character::TURN_LEFT[dir] || dir)
+                             : (Character::TURN_RIGHT[dir] || dir)
+      when FACE_RANDOM then Character::CARDINALS[world.random(4)]
+      when FACE_HERO then toward_hero(character, world)
+      when FACE_AWAY_HERO then away_hero(character, world)
+      else dir
       end
     end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -360,6 +360,12 @@ class RPG2k
         @scene.char_passable?(character, dir)
       end
 
+      # Whether a jump may land on (x, y) — only the destination is tested, the
+      # tiles crossed on the way are not (see Game::MoveRoute#do_jump).
+      def can_land?(character, x, y)
+        @scene.char_can_land?(character, x, y)
+      end
+
       def hero_position
         s = @scene.state
         [s.x, s.y]
@@ -1979,6 +1985,35 @@ class RPG2k
       end
       # Called by MapWorld (an external collaborator) with an explicit receiver.
       public :char_passable?
+
+      # Collision test for a jump landing on (x, y): the same rules as a step —
+      # in bounds, not onto the player or another event, passable per the chipset
+      # — but applied to an arbitrary tile rather than the one ahead, and entered
+      # from the jump's dominant direction. The tiles the jump passes over are
+      # deliberately not tested: RPG_RT skips the "may I leave" half of its check
+      # while jumping, which is what lets a jump clear a wall.
+      def char_can_land?(character, x, y)
+        return true if character.through
+        return false unless @map.in_bounds?(x, y)
+        return false if x == @state.x && y == @state.y
+        return false if @event_tiles[[x, y]]
+        return true if @chipset.nil?
+        @chipset.passable?(@map.lower(x, y), jump_entry_direction(character, x, y))
+      end
+      public :char_can_land?
+
+      # The direction a jump from the character's tile enters (x, y) by: its
+      # dominant axis, vertical winning a tie, matching the facing Character#jump
+      # lands on.
+      def jump_entry_direction(character, x, y)
+        dx = x - character.x
+        dy = y - character.y
+        if dy.abs >= dx.abs
+          dy >= 0 ? 2 : 8
+        else
+          dx >= 0 ? 6 : 4
+        end
+      end
 
       # Terrain id of the lower-layer tile at (x, y), for the Store Terrain ID
       # command (0 when out of bounds or no chipset). Queried by the interpreter

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -76,6 +76,9 @@ class FakeWorld
     !@blocked.include?([x, y])
   end
 
+  # A jump only tests where it lands, never the tiles it crosses.
+  def can_land?(_character, x, y); !@blocked.include?([x, y]); end
+
   def hero_position; @hero; end
   def set_switch(id, on); @switches[id] = on; end
   def play_sound(*a); @sounds << a; end
@@ -193,6 +196,99 @@ check 'a blocked skippable move advances past the obstruction' do
   eq [0, 0], [c.x, c.y]
   eq :moved, route.step(c, w) # moved on to MOVE_DOWN
   eq [0, 1], [c.x, c.y]
+end
+
+# -- Begin Jump / End Jump ----------------------------------------------------
+
+check 'a jump block hops to its accumulated destination in one step' do
+  # Two rights and a down inside the block: one hop to (2, 1), not three steps.
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_RIGHT),
+                 mc(R::MOVE_DOWN), mc(R::END_JUMP), mc(R::MOVE_DOWN)],
+                repeat: false)
+  c = Game::Character.new(0, 0)
+  w = FakeWorld.new
+  eq :moved, route.step(c, w)
+  eq [2, 1], [c.x, c.y], 'landed on the summed offset'
+  eq :moved, route.step(c, w) # the command after End Jump runs next
+  eq [2, 2], [c.x, c.y]
+end
+
+check 'a jump faces its dominant axis, not its last move' do
+  # Two right, two down: a tie on distance, which RPG_RT settles vertically.
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_RIGHT),
+                 mc(R::MOVE_DOWN), mc(R::MOVE_DOWN), mc(R::END_JUMP)])
+  c = Game::Character.new(0, 0, 8)
+  route.step(c, FakeWorld.new)
+  eq [2, 2], [c.x, c.y]
+  eq 2, c.direction, 'a tie faces vertically'
+
+  # Three right, one down: horizontal now dominates.
+  route2 = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_RIGHT),
+                  mc(R::MOVE_RIGHT), mc(R::MOVE_DOWN), mc(R::END_JUMP)])
+  c2 = Game::Character.new(0, 0, 8)
+  route2.step(c2, FakeWorld.new)
+  eq 6, c2.direction
+end
+
+check 'faces inside a jump steer the next move without moving anything' do
+  # Face left, then Move Forward: one tile left, even though the character
+  # started facing down.
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::FACE_LEFT), mc(R::MOVE_FORWARD),
+                 mc(R::END_JUMP)])
+  c = Game::Character.new(5, 5, 2)
+  eq :moved, route.step(c, FakeWorld.new)
+  eq [4, 5], [c.x, c.y]
+end
+
+check 'a jump only tests where it lands, not what it clears' do
+  # (1, 0) is a wall; the jump passes straight over it onto (2, 0).
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_RIGHT),
+                 mc(R::END_JUMP)])
+  c = Game::Character.new(0, 0)
+  eq :moved, route.step(c, FakeWorld.new(blocked: [[1, 0]]))
+  eq [2, 0], [c.x, c.y], 'cleared the tile in between'
+end
+
+check 'a jump onto a blocked tile is retried, or skipped when skippable' do
+  cmds = [mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::END_JUMP),
+          mc(R::MOVE_DOWN)]
+  w = FakeWorld.new(blocked: [[1, 0]])
+
+  route = R.new(cmds, repeat: false, skippable: false)
+  c = Game::Character.new(0, 0)
+  eq :blocked, route.step(c, w)
+  eq [0, 0], [c.x, c.y]
+  eq 0, route.index, 'stays on the Begin Jump so the hop is retried'
+
+  skip = R.new(cmds, repeat: false, skippable: true)
+  c2 = Game::Character.new(0, 0)
+  eq :blocked, skip.step(c2, w)
+  eq [0, 0], [c2.x, c2.y]
+  eq :moved, skip.step(c2, w), 'stepped past the whole block'
+  eq [0, 1], [c2.x, c2.y]
+end
+
+check 'a jump toward the hero hops the way the hero lies' do
+  # Nepheshel's roaming monsters: every one of its 625 jump blocks encloses a
+  # runtime-directed move like this one rather than a literal direction.
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_TOWARD_HERO), mc(R::END_JUMP)])
+  c = Game::Character.new(0, 0)
+  eq :moved, route.step(c, FakeWorld.new(hero: [5, 0]))
+  eq [1, 0], [c.x, c.y]
+
+  away = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_AWAY_HERO), mc(R::END_JUMP)])
+  c2 = Game::Character.new(5, 5)
+  eq :moved, away.step(c2, FakeWorld.new(hero: [9, 5]))
+  eq [4, 5], [c2.x, c2.y]
+end
+
+check 'a Begin Jump with no End Jump abandons the rest of the route' do
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_DOWN)],
+                repeat: false)
+  c = Game::Character.new(0, 0)
+  route.step(c, FakeWorld.new)
+  eq [0, 0], [c.x, c.y], 'nothing moved'
+  ok route.done?, 'and the route unwound rather than stepping the moves'
 end
 
 check 'a "through" character ignores collision' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -336,6 +336,21 @@ check 'a custom-route event walks right and is blocked by the map edge' do
   eq 1, c.y
 end
 
+check 'a custom-route jump clears a tile and stops at the map edge' do
+  # Begin Jump / two rights / End Jump: a two-tile hop per route lap, which
+  # lands on tiles a walking route would have had to step through.
+  ev = event(0, 1, page(x_move_type: Game::MoveType::CUSTOM,
+                        route: move_route([R::BEGIN_JUMP, R::MOVE_RIGHT,
+                                           R::MOVE_RIGHT, R::END_JUMP])))
+  scene = new_scene({ 1 => ev }, player: [0, 0])
+  200.times { scene.update }
+  c = chars(scene)[1]
+  # The map is 6 wide, so hops from x = 0 land on 2 and 4; 6 is off the map, so
+  # the event holds at 4 rather than clipping to the edge the way a step does.
+  eq 4, c.x, 'hopped two tiles at a time and stopped when the landing left the map'
+  eq 1, c.y
+end
+
 check 'a random-mover roams but stays in bounds and off the player tile' do
   ev = event(3, 2, page(x_move_type: Game::MoveType::RANDOM))
   scene = new_scene({ 1 => ev }, player: [0, 0])


### PR DESCRIPTION
Continuing the parameter-level audit of real Nepheshel data that #366 started, now over the 58,019 move-route commands rather than the event commands.

Two things came out of that sweep. Message control codes are **fine** — every code Nepheshel actually writes is handled, including the uppercase `\V` / `\N` it prefers (250 and 30 uses) and the `\.` / `\|` / `\!` / `\^` / `\$` pacing codes; only `\s` (speed), used once, is dropped. Jumps were not.

## The gap

`Begin Jump` (24) and `End Jump` (25) were both treated as plain waits:

```ruby
when WAIT, BEGIN_JUMP, END_JUMP then [:waited, true]
```

so the moves between them stepped one tile at a time. That is three route commands where RPG_RT runs one, and it tests every tile along the way — when clearing those tiles is the whole point of a jump.

## The fix

`Game::MoveRoute#do_jump` ports EasyRPG's `Game_Character::BeginMoveRouteJump`:

- The moves inside the block contribute a tile of offset each **without stepping**; the face and turn commands only steer what the next move contributes; anything else in the block is skipped, as RPG_RT skips it.
- `Game::Character#jump` lands the character on the summed destination in a single move, facing the jump's **dominant axis** with vertical winning a tie — which is not the direction of the last enclosed move. A hop two right and two down lands facing down. A jump that ends where it started leaves the facing alone: the genuine runtime sets only its movement direction there, and this model has one field for both.
- Only the landing tile is tested, through a new `can_land?` on the movement world (`Scene::Map#char_can_land?`, entering from the jump's dominant direction). That mirrors `Game_Map::CheckOrMakeWayEx`, which skips the "may I leave this tile" half of its check while jumping — the reason a jump can cross a wall at all.
- A blocked landing behaves like a blocked move: retried on a non-skippable route, stepped past on a skippable one. A `Begin Jump` with no `End Jump` unwinds the rest of the route, as RPG_RT does.

## What it changes in the real game

Nepheshel has 625 jump blocks. Every one encloses a **runtime-directed** move rather than a literal direction — 484 away from the hero, 188 toward it, 133 forward — which is its roaming monsters. 141 enclose more than one move, so those now clear the tile they hop over instead of walking into it, and all 625 cost one route step rather than three.

Worth being precise about the scale: for a block enclosing a single move, the landing tile is the same one a step would have reached, so the visible change there is pacing rather than reachability. The multi-move blocks are where the destination itself differs.

## Verification

- `scripts/rpg2k_logic_check.rb` 444 pass (+7 new, covering the accumulated destination, dominant-axis facing, faces steering without moving, clearing an intervening wall, blocked-landing retry vs skip, the toward/away-hero pattern Nepheshel actually uses, and an unterminated block).
- `scripts/rpg2k_scene_check.rb` 126 pass (+1, driving a jumping event through the scene's real collision).
- `scripts/rpg2k_render_check.rb` 36 pass, `scripts/lcf_testbed_check.rb` clean, and the whole-corpus interpreter soak still raises nothing.

Remaining, and noted in `docs/TODO.md`: the visual arc. RPG_RT lifts the sprite along the hop; this build snaps it to the landing tile, which needs the same per-frame sprite offset the walk interpolation already has. As with #366 there is no native build in this environment, so nothing here is confirmed against RPG_RT's pixels — the geometry is pinned against EasyRPG's formulae.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_