### PR TITLE
End the game when an event wipes the party

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@
   BGM, Return to Title, Game Over (the database's `GameOver/` picture over its
   game-over music, dismissed back to the title) and Erase
   Event (remove an event from
-  the map) — **every RPG2000 event command now has a handler**. Events start on the action button, on
+  the map) — **every RPG2000 event command now has a handler**. An event that
+  **wipes the party** ends the game the same way, without needing a Game Over
+  command: every command that can knock the last member out re-checks, as the
+  real runtime does, so a damage floor that kills you is fatal. Events start on the action button, on
   player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;

--- a/changelog.d/rpg2k-party-wipe-game-over.fixed.md
+++ b/changelog.d/rpg2k-party-wipe-game-over.fixed.md
@@ -1,0 +1,15 @@
+- **An event that wipes the party now ends the game.** Game Over only ever
+  followed a lost *battle*; the twelve commands that can knock the party out on
+  the map — Change Party Member / EXP / Level / Parameters / Skills / Equipment
+  / HP / MP / Condition, Full Heal, Simulated Attack and (RPG2003) Change Class
+  — each re-check for it in RPG_RT and drop straight into Game Over, and none of
+  them did here. A Simulated Attack damage floor strong enough to kill the party
+  (Nepheshel has 850 Simulated Attacks) left the player walking around the map
+  with a dead party. `Game::Interpreter#check_game_over` ports EasyRPG's
+  `CheckGameOver`, including both of its guards: a battle-event page leaves
+  defeat to the battle's own `[Defeat]` handler, and an **empty** party is not a
+  wipe — a game that has taken every member away is between members, not over.
+  It suspends on the same `:game_over` wait the Game Over command (12420)
+  already raises, so the scene tears down exactly as before, and a Change EXP /
+  Level / Class that kills the party goes to Game Over instead of announcing the
+  level-up, matching RPG_RT's ordering.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -298,7 +298,16 @@ The work below is roughly ordered by the critical path to a walkable game
   stands the ally up and its recovery then lands, and a cure skill is usable even
   at full HP. A **party wipe now ends the game** (a game-over-mode battle defeat
   puts up the Game Over screen, then the title — see the Enemy Encounter
-  entry). Still remaining:
+  entry), and **so does one an event causes**: the twelve commands that can
+  knock the party out on the map — Change Party Member / EXP / Level /
+  Parameters / Skills / Equipment / HP / MP / Condition, Full Heal, Simulated
+  Attack and Change Class — each re-check afterwards, through
+  `Game::Interpreter#check_game_over` (EasyRPG's `CheckGameOver`), and suspend on
+  the same `:game_over` wait the Game Over command raises. Both of RPG_RT's
+  guards come with it: a battle-event page leaves defeat to the fight's own
+  `[Defeat]` handler, and an **empty** party is not a wipe. Without this a
+  Simulated Attack damage floor — Nepheshel runs 850 of them — could kill the
+  party and leave the player walking the map with it. Still remaining:
   inflicting states from **battle** (rolling `state_chance` / to-hit, the
   non-reverse item case, enemy attacks).
   **Show / Move / Erase

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1388,6 +1388,31 @@ module Game
       else
         party.remove_actor(actor)
       end
+      check_game_over
+    end
+
+    # Did that command just wipe the party? RPG_RT re-asks after **every**
+    # command that can knock a member out — Change Party Member / EXP / Level /
+    # Parameters / Skills / Equipment / HP / MP / Condition, Full Heal, Simulated
+    # Attack and Change Class — and drops straight into Game Over when the answer
+    # is yes outside battle. Without it a Simulated Attack floor trap (850 of them
+    # in Nepheshel) leaves the player walking around a map with a dead party.
+    #
+    # Two guards come with it, both EasyRPG's `Game_Interpreter::CheckGameOver`:
+    # a **battle** page resolves its own defeat through the battle's own handler,
+    # and an **empty** party is explicitly allowed — a game that has taken every
+    # member away is between members, not over.
+    #
+    # Suspends on the same :game_over wait the Game Over command (12420) raises,
+    # so the scene tears the play scenes down exactly as it already does. Returns
+    # true when it fired, so a caller can drop what it was about to do.
+    def check_game_over
+      return false if @battle
+      return false if party.actors.empty?
+      return false unless party.all_dead?
+      @wait_kind = :game_over
+      @waiting = true
+      true
     end
 
     # -- actor EXP / level ----------------------------------------------------
@@ -1408,6 +1433,9 @@ module Game
         a.gain_exp(amount)
         queue_level_up_messages(a, before, a.level) if show_msg
       end
+      # RPG_RT asks about the wipe first: a level change that killed the party
+      # goes to Game Over instead of announcing the level-up.
+      return if check_game_over
       show_next_pending_message
     end
 
@@ -1425,6 +1453,7 @@ module Game
         a.change_level_by(amount)
         queue_level_up_messages(a, before, a.level) if show_msg
       end
+      return if check_game_over
       show_next_pending_message
     end
 
@@ -1480,16 +1509,19 @@ module Game
       amount = stat_amount(cmd)
       allow_death = cmd.param(5) != 0
       stat_targets(cmd).each { |a| a.change_hp(amount, allow_death) }
+      check_game_over
     end
 
     def do_change_mp(cmd)
       amount = stat_amount(cmd)
       stat_targets(cmd).each { |a| a.change_mp(amount) }
+      check_game_over
     end
 
     # Full recovery: restore HP and MP to their maxima for the target actors.
     def do_full_heal(cmd)
       stat_targets(cmd).each { |a| a.full_heal }
+      check_game_over
     end
 
     # Simulated Attack (10500): hurt the target actors with an attack that has no
@@ -1511,6 +1543,7 @@ module Game
         a.change_hp(-damage, true)
       end
       variables[cmd.param(7)] = damage if cmd.param(6) != 0
+      check_game_over
     end
 
     # A Simulated Attack's random damage spread, as a percentage in
@@ -1532,6 +1565,7 @@ module Game
       stat_targets(cmd).each do |a|
         remove ? a.remove_state(state_id) : a.add_state(state_id)
       end
+      check_game_over
     end
 
     # -- RPG2003 class / battle commands --------------------------------------
@@ -1560,6 +1594,7 @@ module Game
         next unless a.level > before || skill_mode != Game::Actor::CLASS_SKILL_NO_CHANGE
         @pending_messages.push([level_up_message(a, a.level)])
       end
+      return if check_game_over
       show_next_pending_message
     end
 
@@ -1663,6 +1698,7 @@ module Game
       amount = cmd.param(4) == 0 ? cmd.param(5) : variables[cmd.param(5)]
       amount = -amount if cmd.param(2) != 0
       stat_targets(cmd).each { |a| a.change_param(type, amount) }
+      check_game_over # a lowered max HP can knock the party out
     end
 
     # Change Skills (10440): teach or remove a skill. param0/param1 pick the
@@ -1677,6 +1713,7 @@ module Game
       stat_targets(cmd).each do |a|
         forget ? a.forget_skill(skill_id) : a.learn_skill(skill_id)
       end
+      check_game_over
     end
 
     # Change Equipment (10450). param2 selects the operation: 0 equips an item
@@ -1692,6 +1729,7 @@ module Game
       else
         targets.each { |a| a.unequip(cmd.param(4)) }
       end
+      check_game_over # losing an item's max-HP bonus can knock the party out
     end
 
     # -- battle-event commands ------------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2311,6 +2311,81 @@ check 'Change HP allow-death flag chooses the floor (0 vs 1)' do
   eq 0, a.hp
 end
 
+# -- party wipe -> Game Over --------------------------------------------------
+
+check 'a Change HP that wipes the party goes to Game Over' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  # Scope 0 (the whole party), lethal, more damage than anyone has.
+  it.start([FakeCmd.new(IC::CHANGE_HP, [0, 0, 1, 0, 9999, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok st.party.all_dead?, 'the party is down'
+  ok it.waiting?, 'the event stops on the wipe'
+  eq :game_over, it.wait_kind
+  eq false, st.switches[1], 'the command after it never ran'
+end
+
+check 'a Simulated Attack that wipes the party goes to Game Over' do
+  # Nepheshel's damage floors are Simulated Attacks (850 of them); one strong
+  # enough to kill the party ends the game rather than leaving it walking.
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [0, 0, 9999, 0, 0, 0, 0, 0])])
+  it.update
+  ok st.party.all_dead?
+  eq :game_over, it.wait_kind
+end
+
+check 'a survivable hit leaves the event running' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_HP, [0, 0, 1, 0, 10, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !st.party.all_dead?
+  ok !it.waiting?, 'nothing to stop for'
+  eq true, st.switches[1]
+end
+
+check 'curing the death state clears the Game Over condition' do
+  st = party_state
+  st.party.actors.each { |a| a.set_hp(0) }
+  ok st.party.all_dead?, 'everyone is down to start with'
+  it = Game::Interpreter.new(st)
+  # Change Condition removing state 1 revives; the wipe check then passes.
+  it.start([FakeCmd.new(IC::CHANGE_CONDITION, [0, 0, 1, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !st.party.all_dead?, 'the party is back up'
+  ok !it.waiting?
+  eq true, st.switches[1]
+end
+
+check 'an empty party is not a Game Over, and a battle page never triggers one' do
+  # RPG_RT allows a party with no members at all — a game between members is not
+  # a game that has ended.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100) }, [])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq 0, st.party.actors.size
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_HP, [0, 0, 1, 0, 9999, 1]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.waiting?, 'no members, no wipe'
+  eq true, st.switches[1]
+
+  # A battle page leaves defeat to the battle's own [Defeat] handler.
+  st2 = party_state
+  it2 = Game::Interpreter.new(st2)
+  # Any battle context will do: the check only asks whether one is present.
+  it2.battle = Object.new
+  it2.start([FakeCmd.new(IC::CHANGE_HP, [0, 0, 1, 0, 9999, 1])])
+  it2.update
+  ok st2.party.all_dead?
+  ok !it2.waiting?, 'the battle resolves its own defeat'
+end
+
 check 'Change HP heals with a variable operand' do
   st = party_state
   st.variables[3] = 25

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1659,6 +1659,49 @@ check 'Game Over event command returns to the title, abandoning the event' do
   ok !st.switches[5], 'the rest of the event never ran'
 end
 
+# A one-member party for the wipe check: the scene's usual fake party is empty,
+# which RPG_RT (rightly) does not treat as a Game Over.
+class WipeStubActor
+  attr_reader :id
+  attr_accessor :hp
+  def initialize; @id = 1; @hp = 30; end
+  def change_hp(amount, allow_death)
+    @hp += amount
+    floor = allow_death ? 0 : 1
+    @hp = floor if @hp < floor
+  end
+  def dead?; @hp <= 0; end
+end
+
+class WipeStubParty
+  attr_reader :actors
+  attr_accessor :leader
+  def initialize; @actors = [WipeStubActor.new]; @leader = nil; end
+  def actor_by_id(id); @actors.find { |a| a.id == id }; end
+  def all_dead?; @actors.all? { |a| a.dead? }; end
+end
+
+check 'an event that wipes the party drops into Game Over' do
+  # No Game Over command anywhere — the wipe itself is what ends the game, the
+  # way a Simulated Attack floor trap does in a real game.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::CHANGE_HP, [0, 0, 1, 0, 9999, 1], indent: 0), # party, lethal
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, WipeStubParty.new)
+  parent = scene.instance_variable_get(:@parent)
+  5.times do
+    scene.update
+    break if parent.game_over_shown
+  end
+  ok parent.game_over_shown, 'the wipe put up the Game Over screen'
+  ok !st.switches[5], 'and the rest of the event never ran'
+end
+
 check 'the Game Over screen shows its picture, plays its BGM and waits' do
   parent = fake_parent(fake_db)
   Audio.reset_bgm
@@ -1780,6 +1823,8 @@ class LevelStubParty
   attr_accessor :leader
   def initialize; @actors = [LevelStubActor.new]; @leader = nil; end
   def actor_by_id(id); @actors.find { |a| a.id == id }; end
+  # The stat commands re-check for a party wipe; this stub's actor is alive.
+  def all_dead?; false; end
 end
 
 check 'Change Level show-message: the scene shows a message per level, then resumes' do


### PR DESCRIPTION
Third pass of the same audit (#366, #369), this time comparing our stat-changing handlers against EasyRPG's line by line rather than only their parameter modes. That surfaced something none of the parameter tallies would have: a call the handlers were all missing.

## The gap

Game Over only ever followed a lost **battle**. RPG_RT re-checks for a party wipe after every command that can knock a member out, and drops straight into Game Over when one has happened outside battle — `Game_Interpreter::CheckGameOver`, called from twelve places:

| | |
| --- | --- |
| Change Party Member (10330) | Change EXP (10410) |
| Change Level (10420) | Change Parameters (10430) |
| Change Skills (10440) | Change Equipment (10450) |
| Change HP (10460) | Change MP (10470) |
| Change Condition (10480) | Full Heal (10490) |
| Simulated Attack (10500) | Change Class (1008) |

None of them did it here. The consequence is easiest to see through Simulated Attack — the command RPG2000 games use for damage floors and traps, which Nepheshel runs **850** times: one strong enough to kill the party left the player walking around the map with a dead one, indefinitely.

The less obvious members of that list matter too, and they are why the check belongs on all twelve rather than just the damaging ones: Change Parameters can lower a max HP under the current HP, Change Equipment can strip the item whose max-HP bonus was keeping someone up, and Change Condition can inflict the death state directly.

## The fix

`Game::Interpreter#check_game_over` ports `CheckGameOver`, both of its guards included:

- A **battle-event page** never triggers it — the fight resolves its own defeat through the `[Defeat]` handler.
- An **empty party** never triggers it either. That is RPG_RT's own `GetBattlerCount() > 0` test, and it is a real distinction rather than a degenerate case: a game that has taken every member away is between members, not over. (Our `Party#all_dead?` reports an empty party as wiped, so this guard is load-bearing.)

It suspends on the same `:game_over` wait the Game Over command (12420) already raises, so `Scene::Map` tears the play scenes down through the path that was already there — no new scene wiring. Change EXP / Change Level / Change Class check **before** showing their level-up message, so a level change that killed the party goes to Game Over rather than announcing a level-up first, which is the order EasyRPG uses.

## Verification

- `scripts/rpg2k_logic_check.rb` 449 pass (+5): the wipe, a survivable hit that leaves the event running, a revive clearing the condition, the empty party, and the battle page.
- `scripts/rpg2k_scene_check.rb` 127 pass (+1): a lethal event driven through the scene to the real Game Over screen, with no Game Over command anywhere in it.
- `scripts/rpg2k_render_check.rb` 36 pass, whole-corpus interpreter soak over Nepheshel's 184,166 commands still raises nothing.

Same standing caveat as the last two: no native build here, so nothing is confirmed against RPG_RT's pixels — this is checked against EasyRPG's logic and our own harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_