### PR TITLE
Re-select event pages when conditions change; talk across counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@
   player touch (walking into them),
   on event touch (they walk into the player), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
-  auto-start and parallel common events run too
+  auto-start and parallel common events run too. Pages are re-selected **while
+  the map runs**, so setting the switch an event's page 2 waits on turns it into
+  that page there and then — keeping where it stands — rather than only on the
+  next visit to the map
 - A command that names **"this event"** rather than an event id resolves to the
   event running it, on both sides: the scene already steered Move Event and
   friends that way, and the interpreter now answers the reads too — the

--- a/changelog.d/rpg2k-counter-tiles.fixed.md
+++ b/changelog.d/rpg2k-counter-tiles.fixed.md
@@ -1,0 +1,12 @@
+- **The action button reaches across a counter, and answers an event underfoot.**
+  Pressing it only ever looked at the one tile the party faced. RPG_RT looks in
+  three places (EasyRPG's `Game_Player::CheckActionEvent`): the tile the party is
+  *standing on* — which is how a trigger-0 event on a doorway answers the button
+  — the tile ahead, and then, when that tile is a **counter**, straight through
+  it to whoever stands behind, up to three counters deep. A counter is an
+  upper-layer tile flagged in the chipset's upper passage table (`Game::ChipSet`
+  now reads it, alongside the lower table it already had), and it is how every
+  RPG2000 shop and inn is built: an impassable counter with the keeper behind it.
+  Two of Nepheshel's 100 chipsets define counter tiles and 25 of its maps place
+  203 of them — its shops and inns — so those keepers could not be spoken to at
+  all.

--- a/changelog.d/rpg2k-event-page-refresh.fixed.md
+++ b/changelog.d/rpg2k-event-page-refresh.fixed.md
@@ -1,0 +1,17 @@
+- **Event pages re-select when their conditions change.** A page's conditions
+  read the switches, the variables, the party roster and its items, but the
+  pages were only ever chosen when the map loaded — so an event kept whichever
+  page it started the visit with until the player left the map and came back.
+  That breaks the idiom every RPG2000 game is built on: talk to someone, set a
+  switch, and they turn into their page 2. `Scene::Map#refresh_event_pages`
+  re-selects every event's page whenever anything a condition reads has changed,
+  carrying each event's **position and facing** across (RPG_RT changes an
+  event's page, not where it stands) and rebuilding the parallel processes,
+  since a page change can add or remove one. Erased events stay erased. Rather
+  than flagging each command the way RPG_RT's `Game_Map::SetNeedRefresh` does —
+  which misses any path that is not an event command, such as using an item from
+  the menu — `Game::Switches`, `Game::Variables` and `Game::Party` each carry a
+  revision counter the scene watches, so every writer is covered by
+  construction. Writing a value that is already there does not count, so a
+  parallel process setting the same switch every frame costs nothing, and the
+  per-frame sweep rebuilds only when a page has actually flipped.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -184,7 +184,22 @@ The work below is roughly ordered by the critical path to a walkable game
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented
-  (`Game::EventPage`), and all five start triggers now run: **action button**
+  (`Game::EventPage`) and **re-evaluated while the map runs**, not just when it
+  loads. They were selected once in `build_events`, so an event kept whichever
+  page it started the visit with however the state moved — talk to an NPC, set
+  the switch meant to turn it into its page 2, and nothing happened until the
+  party left and came back. `Scene::Map#refresh_event_pages` re-selects whenever
+  anything a condition reads has changed, carrying each event's position and
+  facing across (RPG_RT changes an event's page, not where it stands) and
+  rebuilding the parallel processes, since a page change can add or remove one;
+  an erased event stays erased for the visit. RPG_RT flags this per command
+  (`Game_Map::SetNeedRefresh` from Control Switches / Variables, Change Items,
+  Change Party Member) — this build instead gives `Game::Switches`,
+  `Game::Variables` and `Game::Party` revision counters and watches those, which
+  covers every writer including the ones that are not event commands, like the
+  item menu. Writing a value already held does not count, so a parallel process
+  setting the same flag every frame costs a sweep rather than a rebuild.
+  All five start triggers run: **action button**
   (0), **player touch** (1, walking into the event), **event touch** (2, the
   event walking into the player), **auto-start** (3) and **parallel** (4, a
   background interpreter per event, driven by `Scene::Map#step_parallels`). A

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -848,21 +848,47 @@ module Game
 
   # Game switches: a 1-indexed set of booleans, defaulting to false.
   class Switches
-    def initialize; @data = {}; end
+    # Bumped on every change of value. An event page's conditions are read from
+    # the switches, the variables, the party roster and its items, so the map
+    # scene watches these counters to know when a page might have flipped and
+    # its events need re-selecting (see Scene::Map#refresh_event_pages). Writing
+    # the value a switch already holds does not count as a change — a parallel
+    # process that sets the same flag every frame must not keep the map busy.
+    attr_reader :revision
+
+    def initialize; @data = {}; @revision = 0; end
     def [](id); @data[id] || false; end
-    def []=(id, v); @data[id] = v ? true : false; end
+
+    def []=(id, v)
+      nv = v ? true : false
+      return nv if self[id] == nv
+      @data[id] = nv
+      @revision += 1
+      nv
+    end
+
     def flip(id); self[id] = !self[id]; end
     def to_h; @data; end
-    def replace(h); @data = h || {}; end
+    def replace(h); @data = h || {}; @revision += 1; end
   end
 
   # Game variables: a 1-indexed set of integers, defaulting to 0.
   class Variables
-    def initialize; @data = {}; end
+    # See Switches#revision: page conditions read variables too.
+    attr_reader :revision
+
+    def initialize; @data = {}; @revision = 0; end
     def [](id); @data[id] || 0; end
-    def []=(id, v); @data[id] = v; end
+
+    def []=(id, v)
+      return v if self[id] == v
+      @data[id] = v
+      @revision += 1
+      v
+    end
+
     def to_h; @data; end
-    def replace(h); @data = h || {}; end
+    def replace(h); @data = h || {}; @revision += 1; end
   end
 
   # A digit-entry model backing the Input Number event command: `digits` cells,
@@ -1604,12 +1630,17 @@ module Game
 
     attr_reader :actors, :items, :gold
 
+    # Bumped whenever the roster or the bag changes — the two halves of the party
+    # an event page's conditions can test (see Switches#revision).
+    attr_reader :revision
+
     def initialize(db, ids = nil)
       @db = db
       ids ||= db.system.party || []
       @actors = ids.reject { |i| i.nil? || i <= 0 }.map { |i| Actor.new(db, i) }
       @items = {}  # item id => count
       @gold = 0
+      @revision = 0
     end
 
     # Serialise the mutable party state (see State#to_h). Beyond HP/MP this keeps
@@ -1643,6 +1674,7 @@ module Game
     # its base stats), then the saved HP/MP are laid over the recomputed maxima.
     # A save written before actor_meta existed simply keeps the database defaults.
     def load_state(data)
+      @revision += 1
       @items = data[:items] || {}
       @gold = data[:gold] || 0
       exp = data[:exp] || {}
@@ -1691,9 +1723,14 @@ module Game
     def add_actor(id)
       return if include_actor?(id)
       @actors.push Actor.new(@db, id)
+      @revision += 1
     end
 
-    def remove_actor(id); @actors.reject! { |a| a.id == id }; end
+    def remove_actor(id)
+      before = @actors.size
+      @actors.reject! { |a| a.id == id }
+      @revision += 1 unless @actors.size == before
+    end
 
     def item_count(id); @items[id] || 0; end
     def has_item?(id); item_count(id) > 0; end
@@ -1702,7 +1739,10 @@ module Game
       c = item_count(id) + n
       c = 0 if c < 0
       c = 99 if c > 99
+      return c if @items[id] == c
       @items[id] = c
+      @revision += 1
+      c
     end
 
     def lose_item(id, n = 1); gain_item(id, -n); end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -394,6 +394,10 @@ module Game
   class ChipSet
     # numpad direction -> passability bit.
     DIR_BIT = { 2 => 0x01, 4 => 0x02, 6 => 0x04, 8 => 0x08 }.freeze
+    # The non-directional bits of the same passage byte (EasyRPG's `Passable`).
+    # Only the counter flag is read so far: it marks a tile you may talk *across*
+    # — the shop counter an NPC stands behind.
+    COUNTER_BIT = 0x40
 
     attr_reader :name, :graphic, :animation_type, :animation_speed
 
@@ -402,6 +406,9 @@ module Game
       @name = c ? c.name : ''
       @graphic = c ? c.chipset_name : ''
       @passable_lower = c ? c.passable_data_lower : nil
+      # The upper layer's own passage table, which is where the counter flag
+      # lives (the lower table has no room for it).
+      @passable_upper = c ? c.passable_data_upper : nil
       @terrain = c ? c.terrain_data : nil
       # Water-animation parameters (chipset chunks 11/12): the animation "type"
       # (0 = 3-frame back-and-forth, 1 = 3-frame cycle) and speed flag (0 slow,
@@ -429,6 +436,19 @@ module Game
       flags = @passable_lower[idx]
       return true if flags.nil?
       (flags & (DIR_BIT[dir] || 0)) != 0
+    end
+
+    # Is this an upper-layer **counter** tile — one the action button reaches
+    # across? RPG2000 marks shop and inn counters with it so the keeper can stand
+    # behind an impassable tile and still be talked to. Upper-layer ids start at
+    # BLOCK_F and index the upper passage table directly; anything below that is
+    # not an upper tile at all. A chipset without the table has no counters.
+    def counter?(upper_tile_id)
+      return false if @passable_upper.nil? || upper_tile_id.nil?
+      idx = upper_tile_id - ChipsetLayout::BLOCK_F
+      return false if idx < 0 || idx >= @passable_upper.size
+      flags = @passable_upper[idx]
+      !flags.nil? && (flags & COUNTER_BIT) != 0
     end
 
     # Terrain id of a lower-layer tile (for the Store Terrain ID command), looked

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1194,12 +1194,44 @@ class RPG2k
 
       # On the action button, run the trigger-0 event the player is facing. The
       # faced event turns toward the player before its commands run.
+      # RPG_RT looks through at most three counter tiles in a row before giving
+      # up (EasyRPG's `Game_Player::CheckActionEvent`).
+      MAX_COUNTER_REACH = 3
+
       def try_action_trigger
         return if event_busy?
         return unless Input.trigger?(Input::C)
+        # An action event **under the player** fires too: RPG_RT checks the tile
+        # the party is standing on before the one it faces, which is how a
+        # trigger-0 event on a doorway tile answers the action button.
+        here = event_at(@state.x, @state.y)
+        return start_event(here, true) if actionable?(here)
+
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
         ev = event_at(fx, fy)
-        start_event(ev, true) if ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands]
+        return start_event(ev, true) if actionable?(ev)
+
+        # Nothing on the faced tile: if it is a **counter** — a shop or inn
+        # counter, marked in the chipset's upper-layer passage table — look
+        # across it for whoever is standing behind, up to three counters deep.
+        MAX_COUNTER_REACH.times do
+          break unless counter_tile?(fx, fy)
+          fx, fy = target_tile(fx, fy, @state.direction)
+          ev = event_at(fx, fy)
+          return start_event(ev, true) if actionable?(ev)
+        end
+        nil
+      end
+
+      # Whether an event can answer the action button.
+      def actionable?(ev)
+        ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands] ? true : false
+      end
+
+      # Whether (x, y) carries an upper-layer counter tile.
+      def counter_tile?(x, y)
+        return false if @chipset.nil? || !@map.in_bounds?(x, y)
+        @chipset.counter?(@map.upper(x, y))
       end
 
       # On the action button, board a placed vehicle the party is standing on

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -476,6 +476,9 @@ class RPG2k
         # lets move routes / autonomous movement query the map.
         @rng = Game::Rng.new(0x2000)
         @world = MapWorld.new(self, @rng)
+        # Erased events, and the state revision the active pages were chosen at.
+        @erased_events = {}
+        @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver
         @interpreter.map_info = self
@@ -549,6 +552,9 @@ class RPG2k
         update_sprite_flashes # Flash Sprite decays during events too
         watch_bgm_loop # so the "BGM played once" branch can be answered
         @anim_frame += 1 # water / animated tiles cycle even during events
+        # An event page's conditions may have just stopped (or started) holding;
+        # re-select before anything reads a trigger or a graphic this frame.
+        refresh_event_pages
         if event_busy?
           drive_event
         else
@@ -969,6 +975,7 @@ class RPG2k
         evs = @map.unit.events
         return unless evs
         evs.each do |id, ev|
+          next if @erased_events[id] # an Erase Event lasts the whole visit
           selected = Game::EventPage.select(ev.pages, @state.switches,
                                             @state.variables, @state.party)
           next unless selected
@@ -991,7 +998,9 @@ class RPG2k
         move_type = page_move_type(page)
         route = move_type == Game::MoveType::CUSTOM ?
                 Game::MoveRoute.from_page(page_move_route(page)) : nil
-        { id: id, char: ch, trigger: page_trigger(page),
+        # `page` is kept so a refresh can tell whether the conditions still pick
+        # the same one (see #pages_changed?).
+        { id: id, char: ch, page: page, trigger: page_trigger(page),
           commands: page_commands(page), move_type: move_type, route: route,
           move_timer: EVENT_MOVE_DELAY[ch.move_frequency] || 40,
           # Rendering state: the page's static graphic fields, a live walk
@@ -1464,9 +1473,97 @@ class RPG2k
       # the next map (re)load, matching RPG2000's Erase Event.
       def erase_event(ev)
         @events.delete(ev)
+        # Remembered so a page refresh cannot resurrect it: an Erase Event lasts
+        # for the rest of the visit to the map, whatever its conditions do next.
+        @erased_events[ev[:id]] = true
         tile = [ev[:char].x, ev[:char].y]
         @event_tiles.delete(tile) if @event_tiles[tile].equal?(ev)
         @parallels.reject! { |p| p[:event].equal?(ev) } if @parallels
+      end
+
+      # -- page refresh -------------------------------------------------------
+
+      # An event's active page is chosen by its conditions, and those read the
+      # switches, the variables, the party roster and its items. Change one and
+      # the choice can change with it — the "talk to me once and I turn into my
+      # page 2" idiom every RPG2000 game is built on. The pages were only ever
+      # selected when the map loaded, so an event kept whichever page it started
+      # the visit with until the player left and came back.
+      #
+      # RPG_RT re-selects them whenever those four things change (its
+      # `Game_Map::SetNeedRefresh`, set by Control Switches / Variables, Change
+      # Items and Change Party Member). Rather than flagging each command — which
+      # silently misses any path that is not an event command, like using an item
+      # from the menu — this watches the revision counters those four carry, so
+      # every writer is covered by construction.
+      def page_revision
+        rev(@state.switches) + rev(@state.variables) + rev(@state.party)
+      end
+
+      # A collaborator's revision counter, or 0 for one that keeps none (the
+      # party stand-ins some harnesses pass in). A source that cannot report a
+      # change simply never asks for a refresh.
+      def rev(o)
+        o.respond_to?(:revision) && o.revision ? o.revision : 0
+      end
+
+      # Re-select every event's page if anything a condition reads has changed.
+      # The sweep is cheap (a few comparisons per event) and does nothing at all
+      # unless a page actually flipped, so a parallel process writing a variable
+      # every frame costs a sweep, not a rebuild.
+      def refresh_event_pages
+        rev = page_revision
+        return if rev == @page_revision
+        @page_revision = rev
+        return unless pages_changed?
+        rebuild_events_preserving_positions
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] event page refresh failed: #{e.message}"
+      end
+
+      # Whether any event's conditions now pick a different page than the one it
+      # is running. Walks the *map's* events rather than the live list, so it
+      # also catches an event that has no active page at all right now and has
+      # just gained one — those are absent from @events entirely.
+      def pages_changed?
+        evs = @map.unit.events
+        return false unless evs
+        live = {}
+        @events.each { |e| live[e[:id]] = e }
+        changed = false
+        evs.each do |id, src|
+          next if changed || @erased_events[id]
+          selected = Game::EventPage.select(src.pages, @state.switches,
+                                            @state.variables, @state.party)
+          page = selected && selected[1]
+          e = live[id]
+          changed = true unless page.equal?(e && e[:page])
+        end
+        changed
+      end
+
+      # Rebuild the runtime events for the newly-selected pages, carrying each
+      # event's **position and facing** across — RPG_RT changes an event's page,
+      # not where it stands, so an NPC that flips to page 2 stays where it was
+      # rather than snapping back to its spawn tile. Erased events stay erased,
+      # and the parallel processes are rebuilt because a page change can add or
+      # remove one.
+      def rebuild_events_preserving_positions
+        placed = {}
+        @events.each { |e| placed[e[:id]] = e[:char] }
+        build_events
+        @events.each do |e|
+          old = placed[e[:id]]
+          next unless old
+          e[:char].x = old.x
+          e[:char].y = old.y
+          e[:char].direction = old.direction
+        end
+        rebuild_event_tiles
+        build_parallels
+        # The event the foreground interpreter is running may have just been
+        # rebuilt; re-point it so "this event" still reaches the live character.
+        @active_event = @events.find { |e| e[:id] == @active_event[:id] } if @active_event
       end
 
       # -- Halt All Movement --------------------------------------------------
@@ -3730,6 +3827,10 @@ class RPG2k
         @started_common = {}
         @active_event = nil
         @player_route = nil # a forced player route does not survive a teleport
+        # Both are per-visit: an Erase Event does not follow the party to the
+        # next map, and the destination's pages are chosen fresh.
+        @erased_events = {}
+        @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver
         @interpreter.map_info = self

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -298,7 +298,9 @@ def fake_parent(db)
 end
 
 def fake_party
-  OpenStruct.new(leader: nil, actors: [])
+  # `revision` is what the scene watches to know a page condition may have
+  # changed; a test bumps it to ask for a refresh.
+  OpenStruct.new(leader: nil, actors: [], revision: 0)
 end
 
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil)
@@ -349,6 +351,86 @@ check 'a custom-route jump clears a tile and stops at the map edge' do
   # the event holds at 4 rather than clipping to the edge the way a step does.
   eq 4, c.x, 'hopped two tiles at a time and stopped when the landing left the map'
   eq 1, c.y
+end
+
+# -- event page refresh -------------------------------------------------------
+
+# An event with two pages: page 1 unconditional, page 2 gated on switch
+# `switch_id`. Later pages win, so page 2 takes over the moment the switch goes
+# on — the "talk to me once and I become someone else" idiom.
+def two_page_event(x, y, switch_id, page1, page2)
+  page2.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A,
+                                   switch_a_id: switch_id)
+  OpenStruct.new(x: x, y: y, pages: { 1 => page1, 2 => page2 })
+end
+
+check 'flipping a switch re-selects an event page mid-map' do
+  ic = Game::Interpreter::Cmd
+  # Page 1 is a stationary NPC; page 2 is a parallel process that sets switch 5.
+  p1 = page(trigger: 0, charset_name: 'Villager')
+  p2 = page(trigger: 4, charset_name: 'Ghost')
+  p2.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])]
+  scene = new_scene({ 1 => two_page_event(2, 2, 3, p1, p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  5.times { scene.update }
+  ev = event_hashes(scene)[1]
+  eq 0, ev[:trigger], 'page 1 is active while switch 3 is off'
+  ok !st.switches[5], 'so the page-2 parallel process is not running'
+
+  st.switches[3] = true
+  5.times { scene.update }
+  ev = event_hashes(scene)[1]
+  eq 4, ev[:trigger], 'switch 3 flipped the event to page 2'
+  ok st.switches[5], 'and its parallel process now runs'
+end
+
+check 'a page change keeps the event where it stands' do
+  # The event walks east on page 1; when it flips to page 2 it must stay put
+  # rather than snapping back to its spawn tile.
+  p1 = page(x_move_type: Game::MoveType::CUSTOM, route: move_route([R::MOVE_RIGHT]))
+  p2 = page(trigger: 0, charset_name: 'Stopped')
+  scene = new_scene({ 1 => two_page_event(0, 1, 3, p1, p2) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  60.times { scene.update }
+  moved_x = chars(scene)[1].x
+  ok moved_x > 0, "the event walked east first (got #{moved_x})"
+
+  st.switches[3] = true
+  scene.update
+  eq moved_x, chars(scene)[1].x, 'the page change left it where it was'
+  eq 1, chars(scene)[1].y
+end
+
+check 'a refresh does not resurrect an erased event' do
+  ic = Game::Interpreter::Cmd
+  p1 = page(trigger: 3) # auto-start: erase myself
+  p1.event_commands = [ECmd.new(ic::ERASE_EVENT, [])]
+  p2 = page(trigger: 0)
+  scene = new_scene({ 1 => two_page_event(2, 2, 3, p1, p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  10.times { scene.update }
+  ok event_hashes(scene)[1].nil?, 'the event erased itself'
+
+  st.switches[3] = true # would select page 2 if it were still around
+  5.times { scene.update }
+  ok event_hashes(scene)[1].nil?, 'an Erase Event outlasts a page refresh'
+end
+
+check 'an event with no matching page drops off the map, and comes back' do
+  # Only one page, gated on switch 3: with it off there is no active page at all.
+  only = page(trigger: 0)
+  only.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A,
+                                  switch_a_id: 3)
+  scene = new_scene({ 1 => OpenStruct.new(x: 2, y: 2, pages: { 1 => only }) },
+                    player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  ok event_hashes(scene)[1].nil?, 'no page holds, so nothing is on the map'
+
+  st.switches[3] = true
+  scene.update
+  ok event_hashes(scene)[1], 'the condition now holds, so the event appears'
 end
 
 check 'a random-mover roams but stays in bounds and off the player tile' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -162,8 +162,22 @@ def fake_chipset(name = 'cs')
   # every tile of the synthetic all-zero map maps to).
   td = Array.new(162, 0)
   td[0] = 42
+  # The upper passage table marks chip 0 as a counter, so a test can lay a
+  # counter tile by putting BLOCK_F in the upper layer.
+  up = Array.new(144, 0)
+  up[0] = Game::ChipSet::COUNTER_BIT
   OpenStruct.new(name: name, chipset_name: name, passable_data_lower: nil,
-                 terrain_data: td)
+                 passable_data_upper: up, terrain_data: td)
+end
+
+# A map whose upper layer carries a counter tile at each of `counters`.
+def fake_map_with_counters(id, events, counters)
+  w = 6; h = 5
+  upper = Array.new(w * h, 1) # 1 is not an upper tile id, so: no counter
+  counters.each { |x, y| upper[y * w + x] = Game::ChipsetLayout::BLOCK_F }
+  Game::Map.new(id, OpenStruct.new(width: w, height: h, chipset_id: 1,
+                                   lower_layer: Array.new(w * h, 0),
+                                   upper_layer: upper, events: events))
 end
 
 def fake_db(common = nil, troop_pages = nil)
@@ -510,6 +524,70 @@ check 'action (trigger 0) does not fire on mere contact' do
   6.times { scene.update }
   st = scene.instance_variable_get(:@state)
   ok !st.switches[4], 'a trigger-0 event must not run just from being bumped'
+end
+
+# A scene on a map with counter tiles, for the talk-across-a-counter checks.
+def counter_scene(events, counters, player:)
+  db = fake_db
+  state = Game::State.new(fake_party, 1, player[0], player[1])
+  state.map = fake_map_with_counters(1, events, counters)
+  RPG2k::Scene::Map.new(fake_parent(db), state)
+end
+
+check 'the action button reaches across a shop counter' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 0)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  # Player at (0,0) facing east; (1,0) is the counter, the keeper is at (2,0).
+  scene = counter_scene({ 1 => event(2, 0, pg) }, [[1, 0]], player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 6
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  5.times { scene.update }
+  ok st.switches[4], 'talked to the keeper standing behind the counter'
+end
+
+check 'the reach stops after three counters, and at a non-counter tile' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 0)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  # (1,0) is a counter but (2,0) is not, so the event at (3,0) is out of reach.
+  scene = counter_scene({ 1 => event(3, 0, pg) }, [[1, 0]], player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 6
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  5.times { scene.update }
+  ok !st.switches[4], 'the run of counters ended, so nothing was reached'
+
+  # Four counters deep is one more than RPG_RT looks through.
+  far = counter_scene({ 1 => event(5, 0, pg) },
+                      [[1, 0], [2, 0], [3, 0], [4, 0]], player: [0, 0])
+  st2 = far.instance_variable_get(:@state)
+  st2.direction = 6
+  RGSS::Input.triggered = [RGSS::Input::C]
+  far.update
+  RGSS::Input.reset
+  5.times { far.update }
+  ok !st2.switches[4], 'four counters is past the three-tile reach'
+end
+
+check 'an action event under the player answers the action button' do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 0)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0])]
+  # The event shares the player's tile — RPG_RT checks there before the tile
+  # ahead, which is how a trigger-0 event on a doorway answers the button.
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [2, 2])
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  5.times { scene.update }
+  ok st.switches[4], 'the event under the party ran'
 end
 
 # CONTROL_VARS params to add `by` to variable `id`:


### PR DESCRIPTION
Passes four and five of the audit (#366, #369, #370). Two commits, both found by asking what RPG_RT does that we never call — neither is in the interpreter.

*(Second commit note: I had held this back to keep one change per PR, but leaving a commit unpushed in an ephemeral container risks losing it, so both are here. They are independent and reviewable separately.)*

---

# 1. Event pages never re-selected (`5924f9e`)

## The gap

An event page's conditions read the switches, the variables, the party roster and its items. But the pages were only ever selected in `build_events`, which runs in exactly two places — when the scene is built, and when the party changes map.

So an event kept whichever page it started the visit with, no matter what happened to the state its conditions test. Talk to an NPC, set the switch that is supposed to turn it into its page 2, and **nothing happens** until you leave the map and come back.

That idiom is the backbone of RPG2000 event design. Nepheshel has 20,925 pages across 11,362 events, with 4,466 Control Switches driving them.

## The fix

RPG_RT re-selects on demand: `Game_Map::SetNeedRefresh`, set by Control Switches, Control Variables, Change Items and Change Party Member, answered by a refresh that re-runs each event's page selection.

Flagging the commands is the one part I deliberately did **not** copy — it misses every path that is not an event command, starting with using an item from the menu. Instead `Game::Switches`, `Game::Variables` and `Game::Party` each carry a revision counter and the scene watches their sum, so every writer is covered by construction. Those three are exactly the inputs `Game::EventPage.select` already takes, so the counters and the conditions cannot drift apart.

Two things keep the cost down:

- Writing a value something already holds does not bump the counter, so a parallel process setting the same flag every frame does not keep the map busy.
- When the counter does move, a cheap sweep asks whether any event's conditions now pick a *different* page, and only then are the events rebuilt. The sweep walks the map's events rather than the live list, so it also catches an event that currently has no active page and has just gained one.

The rebuild carries each event's **position and facing** across — RPG_RT changes an event's page, not where it stands, so an NPC that flips to page 2 stays where it walked to rather than snapping back to its spawn tile — and rebuilds the parallel processes, because a page change can add or remove one. Erased events are remembered per visit so a refresh cannot resurrect them.

## Verification

Four new checks in `scripts/rpg2k_scene_check.rb`, each driving the real scene: a switch flipping an event onto a page with a different trigger *and* a live parallel process; position surviving the page change; an erased event staying erased; an event with no matching page dropping off the map and returning when its condition holds again.

---

# 2. The action button looked at one tile (`feb5fc8`)

## The gap

Pressing it only ever checked the tile the party faced. RPG_RT checks three places (EasyRPG's `Game_Player::CheckActionEvent`):

- the tile the party is **standing on** — how a trigger-0 event laid on a doorway answers the button;
- the tile ahead;
- and, when that tile is a **counter**, straight through it to whoever stands behind — up to three counters deep, RPG_RT's own limit.

A counter is an upper-layer tile carrying the counter bit in the chipset's **upper** passage table. `Game::ChipSet` only modelled the lower table, so it had no way to know one existed; it now reads the upper table too and answers `#counter?`.

## Why it matters

That flag is how every RPG2000 shop and inn is laid out: an impassable counter tile with the keeper behind it, reachable only by talking across. Measured on the real data — **2 of Nepheshel's 100 chipsets** define counter tiles and **25 of its maps place 203** of them. Its shops and inns, including the Map0016 shop whose Buy / Sell / Cancel choice block turned up in pass one. None of those keepers could be spoken to.

## Verification

Three new checks in `scripts/rpg2k_scene_check.rb`: talking across a counter, the reach stopping both at a non-counter tile and past the three-counter limit, and an action event sharing the player's tile.

---

## Together

`scripts/rpg2k_scene_check.rb` 134 pass (+7), `scripts/rpg2k_logic_check.rb` 449, `scripts/rpg2k_render_check.rb` 36, `scripts/lcf_testbed_check.rb` clean.

Same standing caveat as the rest of the series: no native build here, so this is checked against EasyRPG's logic and our harnesses, not RPG_RT's pixels. Both of these would show up immediately in a playthrough, though — a two-page NPC and a shop counter are on the wine harness's existing maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D