### PR TITLE
Enemy action patterns, battle backdrops, the generator chunks and a shop quantity counter

### DIFF
--- a/changelog.d/battle-backdrop-from-map-tree.added.md
+++ b/changelog.d/battle-backdrop-from-map-tree.added.md
@@ -1,0 +1,16 @@
+- Battles are now fought over the **backdrop the game actually specifies**
+  instead of a flat dark field. RPG2000 stores this on the map-tree node rather
+  than the map: `Game::Backdrop.name_for` reads the node's `backdrop_type` —
+  liblcf's BGMType_parent / _terrain / _specific, the editor's 親マップと同じ /
+  地形で指定 / 指定する — and `Scene::Map#encounter_backdrop` resolves it against
+  the terrain the party is standing on (the terrain row's `background_name`).
+  Inheriting maps walk up the tree, which is the common case and does real work:
+  491 of Nepheshel's 537 maps are type 0, and 475 of them reach their "black"
+  interior backdrop only through a parent, while all 13 of mtf-meido-action's
+  maps take the terrain branch instead (Grassland / Desert / Snow Field / ...).
+  The walk is bounded and cycle-safe, so a looping map tree ends at the terrain
+  rather than hanging the battle.
+- A monster that **transforms mid-fight is now redrawn** with the battler it
+  became — the combatant carries its `battler_name` and the battle screen
+  rebuilds any sprite whose graphic no longer matches, leaving unchanged ones
+  alone.

--- a/changelog.d/enemy-action-patterns.added.md
+++ b/changelog.d/enemy-action-patterns.added.md
@@ -1,0 +1,21 @@
+- RPG2000 enemies now run their **行動パターン** (action pattern, enemy chunk 42)
+  instead of only ever swinging their fists. `Game::EnemyAction` decodes the
+  table, and each turn `Game::Battle` keeps the entries whose condition holds and
+  picks one weighted by `rating` — EasyRPG's rating-based algorithm, including
+  the rule that drops anything more than 10 below the best rating, so a monster's
+  behaviour shifts as its better moves stop being valid. All eight condition
+  types are modelled (always / switch / turn / party size / HP% / SP% / party
+  level / fatigue), the turn condition reusing `Game::BattlePage.check_turns`.
+  Every action kind runs: **skills** (cast through the same pipeline the party
+  uses, so an enemy's spell is costed, elementally scaled, accuracy-rolled and —
+  finally — **inflicts its states on the party**, closing the last enemy-cast
+  gap), **transformations** into another database enemy, and the basic actions
+  (attack, dual attack, defend, observe, charge for a double-damage next blow,
+  self-destruction for `atk - def/2` across the party, escape, do nothing). An
+  action's post-run switch on/off is applied, so a monster's move can drive the
+  troop's battle-event pages. Enemies are fed the database and game state through
+  a new `Game::EnemyAi` collaborator, keeping `Game::Battle` itself database-free;
+  without one an enemy falls back to plain attacking exactly as before. This was
+  a large silent gap: 510 of the 959 enemy actions across the two test beds are
+  skills that never fired. Verified by running every troop in both test beds
+  (157 and 88 fights, no errors), where 1980 and 1193 skill casts now land.

--- a/changelog.d/map-unit-generator-chunks.added.md
+++ b/changelog.d/map-unit-generator-chunks.added.md
@@ -1,0 +1,17 @@
+- The last unaccounted-for **map-unit chunks are declared**, so a real `.lmu`
+  parses with nothing left over. Chunks 42, 50, 60–62 and 90 turn out not to be
+  the save/encounter/parallax metadata they were assumed to be — they are the
+  **RPG2003 random dungeon generator** block (`top_level`, `generator_height`,
+  and the nine room slots' `generator_x` / `generator_y` / `generator_tile_ids`)
+  plus the 2k3e save counter (`save_count_2k3e`). The wiki's マップ page does not
+  document them, so the ids, types and defaults are liblcf's
+  `LMU_Reader::ChunkMap` / `RPG::Map` (0x28..0x3E, 0x5A); the rest of the block
+  (40–56) is declared alongside them even though no test bed writes it. The
+  reading is confirmed against real bytes rather than merely tolerated: chunk 62
+  read as shorts gives ordinary tile ids (49, 10000/10001/10006/10007) where an
+  int32 reading gives numbers in the millions, and the fields mtf-meido-action
+  leaves out are exactly those already at their liblcf default, which is what an
+  eliding writer produces. `scripts/lcf_testbed_check.rb` now asserts the block's
+  shape on every map — nine coordinates, eighteen in-range tile ids, and every
+  field materialising from the file or its default. These are editor-only
+  settings; nothing reads them at run time.

--- a/changelog.d/shop-quantity-selector.added.md
+++ b/changelog.d/shop-quantity-selector.added.md
@@ -1,0 +1,12 @@
+- The shop now asks **how many**. Picking an item opens a quantity counter
+  instead of trading one unit per confirm: UP / DOWN step by one and
+  RIGHT / LEFT by ten (RPG_RT's horizontal axis, so filling a stack of 99 takes
+  a few presses rather than ninety-nine), and one confirm commits the whole
+  stack. `Game::Shop#max_buy` / `#max_sell` bound the counter by whichever of
+  affordability, the RPG2000 99-item cap and the party's holdings runs out
+  first — a price-0 good is limited only by the cap rather than dividing by
+  zero — and `buy(id, n)` / `sell(id, n)` are all-or-nothing, so a count beyond
+  what is allowed trades nothing rather than quietly trading fewer, and a zero
+  or negative count is refused outright. An item the party has no room for
+  never opens the counter, and cancelling it returns to the list having traded
+  nothing. Nepheshel opens 10 shops, so this is content a real game exercises.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -339,8 +339,19 @@ The work below is roughly ordered by the critical path to a walkable game
   price, sell at half, party 99-item / gold caps enforced), tracking whether
   anything was traded to pick the command's `[Transaction]` / `[No Transaction]`
   branches. The interpreter suspends on a `:shop` wait; `Scene::Map` drives the
-  buy / sell menus (one unit per confirm — the quantity selector is a later
-  refinement).
+  buy / sell menus. Picking an item opens a **quantity counter** rather than
+  trading a single unit: UP / DOWN step by one and RIGHT / LEFT by ten (RPG_RT's
+  horizontal axis, so a stack of 99 is a few presses rather than ninety-nine),
+  the count is clamped to `Game::Shop#max_buy` / `#max_sell` — whichever of
+  affordability, the 99-item cap and what the party holds binds first, with a
+  price-0 good limited only by the cap rather than dividing by zero — and one
+  confirm commits the whole stack through `buy(id, n)` / `sell(id, n)`. Those are
+  **all-or-nothing**: a count beyond what is allowed trades nothing rather than
+  quietly trading fewer, so no path can overspend, and a zero or negative count
+  is not a transaction (it cannot mint gold). An item with no room at all —
+  unaffordable, or already capped — does not open the counter, and cancelling it
+  returns to the list having traded nothing. Nepheshel opens 10 shops, so this is
+  exercised content rather than a hypothetical.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -421,7 +421,25 @@ The work below is roughly ordered by the critical path to a walkable game
   command (12420) and a battle defeat whose encounter says "game over" rather
   than running a `[Defeat]` handler. A game that names no picture (or whose file
   is missing) still reaches the screen, on plain black, rather than the defeat
-  failing. Still to come: the per-terrain backdrop.
+  failing.
+  **The battle backdrop is chosen from the game's own data now** rather than
+  always being the flat void. RPG2000 keeps it on the map-tree node, not the map:
+  `Game::Backdrop.name_for` reads the node's `backdrop_type`, a tri-state the
+  editor's map-properties dialog offers and liblcf spells
+  BGMType_parent / _terrain / _specific — 親マップと同じ (inherit), 地形で指定
+  (the terrain being fought on names it) or 指定する (this map pins one file) —
+  and the scene resolves it against the terrain under the party
+  (`Scene::Map#encounter_backdrop`, via the terrain row's `background_name`).
+  The inheriting case has to walk the tree, and it is the common one: **491 of
+  Nepheshel's 537 maps and 4 of mtf-meido-action's 13 are type 0** and answer only
+  through a parent. Resolving every map in both games shows the walk earning its
+  keep — 475 of Nepheshel's maps reach their "black" interior backdrop purely by
+  inheritance (plus one pinned boss backdrop) where a naive reading would leave
+  them all on the flat field, while all 13 of mtf-meido-action's maps vary with
+  the terrain fought on (Grassland / Desert / Snow Field / ...), the branch
+  Nepheshel never takes since it names no terrain backdrops at all. The walk is
+  bounded and cycle-safe, so a tree that loops ends at the terrain instead of
+  hanging the battle.
   **Enemies now run their 行動パターン** (action pattern, enemy chunk 42) rather
   than only ever attacking — the single biggest silent gap left in the battle
   system, since **510 of the 959 enemy actions across the two test beds are
@@ -461,11 +479,10 @@ The work below is roughly ordered by the critical path to a walkable game
   games (157 and 88 fights) completes without error with 1980 and 1193 skill
   casts landing where there were none. `ruby scripts/analyze_game.rb --enemies
   <game>` reports a game's patterns the way `--troops` reports its battle pages.
-  One presentation gap remains: a transformed monster fights with its new stats
-  and pattern but keeps its original battler sprite, because the battle screen
-  builds each sprite once from the troop member's `battler_name` — reloading it
-  mid-fight is a scene-side change left for the same pass that gives the battle
-  screen its per-terrain backdrop.
+  A **transformed monster is redrawn** with the battler it turned into: the
+  combatant carries its `battler_name`, and `Scene::Map#refresh_battle_sprites`
+  rebuilds any sprite whose battler no longer matches the one it was drawn from
+  (an unchanged battler is left alone, so the field does not churn every frame).
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,10 +8,26 @@
   `使用時アニメ` weapon fields (the shared `BATTLER_ANIMATION` union),
   skill switch/occasion chunks (13, 16, 18, 19), and the `battle_anime2`
   attack-motion + `基本と拡張`/`武器` pose object lists (chunks 2, 10, 11).
-  The remaining map-unit chunks that appear in real data (42, 50, 60–62, 90 —
-  save/encounter/parallax metadata) are **not documented on the wiki's マップ
-  page**, so they still need to be derived from the test-bed walk. These are
-  editor/battle/2003 details not on the walkable-game critical path
+  The map-unit chunks that used to be unaccounted for (42, 50, 60–62, 90) are
+  **declared now**. They are not the save/encounter/parallax metadata they were
+  guessed to be: they are the **RPG2003 random dungeon generator** block plus the
+  2k3e save counter, and since the wiki's マップ page does not document them the
+  ids, types and defaults come from liblcf's `LMU_Reader::ChunkMap` / `RPG::Map`
+  (0x28..0x3E, 0x5A) — chunk 42 is `top_level`, 50 `generator_height`, 60/61/62
+  the nine room slots' `generator_x` / `generator_y` / `generator_tile_ids`, 90
+  `save_count_2k3e`. The whole block (40–56 as well, which no test bed writes) is
+  declared so a real map parses with nothing left over. The bytes confirm the
+  reading rather than merely tolerating it: chunk 62 read as **shorts** yields
+  ordinary tile ids (49 lower-layer, 10000/10001/10006/10007 upper-layer) where
+  an int32 reading gives numbers in the millions, and the fields mtf-meido-action
+  omits are exactly the ones already at their liblcf default (`generator_width`
+  4, the six `true` flags) — which is what an eliding writer produces. Only that
+  game writes them at all, being the RPG2003 test bed; Nepheshel's 543 maps read
+  the whole block from its defaults. `lcf_testbed_check.rb` now asserts the
+  shape (nine coordinates, eighteen tile ids, every field materialising), and
+  that guard was checked by mis-declaring chunk 62 and watching it fail. These
+  remain editor-only details off the walkable-game critical path — nothing reads
+  them at run time, RPG_RT included
 - ✅ Show window component for title scene
 - ✅ Implement New Game functionality — builds the party, loads the start map
   and enters a walkable `Scene::Map` with events

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -281,9 +281,9 @@ The work below is roughly ordered by the critical path to a walkable game
   stands the ally up and its recovery then lands, and a cure skill is usable even
   at full HP. A **party wipe now ends the game** (a game-over-mode battle defeat
   puts up the Game Over screen, then the title — see the Enemy Encounter
-  entry). Still remaining:
-  inflicting states from **battle** (rolling `state_chance` / to-hit, the
-  non-reverse item case, enemy attacks).
+  entry). Enemies inflict states too now, by casting the status skills in their
+  action pattern (see the 行動パターン entry below). Still remaining here: the
+  non-reverse item case.
   **Show / Move / Erase
   Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
   (centre position, zoom, opacity, tone and the scroll-with-map flag) held on
@@ -421,7 +421,51 @@ The work below is roughly ordered by the critical path to a walkable game
   command (12420) and a battle defeat whose encounter says "game over" rather
   than running a `[Defeat]` handler. A game that names no picture (or whose file
   is missing) still reaches the screen, on plain black, rather than the defeat
-  failing. Still to come: enemy-cast infliction and the per-terrain backdrop.
+  failing. Still to come: the per-terrain backdrop.
+  **Enemies now run their 行動パターン** (action pattern, enemy chunk 42) rather
+  than only ever attacking — the single biggest silent gap left in the battle
+  system, since **510 of the 959 enemy actions across the two test beds are
+  skills** that could never fire. `Game::EnemyAction` decodes the table and
+  `Game::Battle#choose_enemy_action` picks from it each turn: a port of EasyRPG's
+  rating-based algorithm, which keeps the entries whose condition currently
+  holds, finds the highest `rating`, drops everything more than 10 below it
+  (`rating - max + 10`, floored at 0) and picks from the rest weighted by that
+  adjusted rating — so a monster's behaviour shifts through a fight as its
+  preferred moves stop being valid. All eight condition types resolve (always,
+  switch, turn, party size, own HP %, own SP %, party average level and party
+  fatigue), the turn condition reusing `Game::BattlePage.check_turns` with the
+  same base / multiple argument order, and an unknown type keeps the action out
+  of the running rather than firing it unchecked. Every kind executes: a
+  **skill** goes through the same command pipeline the party casts with (so an
+  enemy's spell is costed against its SP, scaled by the target's elemental
+  resistance, rolled for accuracy and **inflicts its states** — which is what
+  finally lets a monster poison or sleep the party, the last enemy-cast gap), an
+  ally-scoped skill **heals a fellow monster**, an all-scope skill hits every
+  living target in one action; a **transformation** re-points the combatant at
+  another database enemy (name, stats, ranks and its new pattern, HP/SP clamped
+  to the new maxima); and the basic actions cover attack, **dual attack** (two
+  swings, the second skipped if the first felled the target), **defend** (the
+  guard halves the next blow and expires at that enemy's next turn), observe,
+  **charge** (the next attack lands doubled — a critical takes precedence, per
+  EasyRPG's `CalcNormalAttackEffect` — then the charge is spent),
+  **self-destruction** (`atk - def/2` across the living party, killing the
+  caster, per `CalcSelfDestructEffect`), **escape** (out of play without counting
+  as a kill, like a page's Force Flee) and do-nothing. An action's post-run
+  switch on / off is applied, so a monster's move can drive the troop's
+  battle-event pages. `Game::Battle` stays database-free: it reaches the skill /
+  enemy tables, the switches and the party's average level through a new
+  `Game::EnemyAi` collaborator, and without one (the seeded harness fixtures) an
+  enemy falls back to plain attacking exactly as before, so every existing
+  result is unchanged. Exercised over real data: all 300 Nepheshel enemies and
+  all 115 of mtf-meido-action's decode a pattern, and running every troop in both
+  games (157 and 88 fights) completes without error with 1980 and 1193 skill
+  casts landing where there were none. `ruby scripts/analyze_game.rb --enemies
+  <game>` reports a game's patterns the way `--troops` reports its battle pages.
+  One presentation gap remains: a transformed monster fights with its new stats
+  and pattern but keeps its original battler sprite, because the battle screen
+  builds each sprite once from the troop member's `battler_name` — reloading it
+  mid-fight is a scene-side change left for the same pass that gives the battle
+  screen its per-terrain backdrop.
   **Every RPG2000 map / common-event command now has a handler.** The last gaps
   closed were Change Skills (10440), Simulated Attack (10500), Change Actor Face
   (10640), Enter/Exit Vehicle (10840), Flash Sprite (11320), Fade Out BGM

--- a/docs/adr/0029-enemy-action-patterns.md
+++ b/docs/adr/0029-enemy-action-patterns.md
@@ -1,0 +1,101 @@
+# 29. Enemy action patterns run through an injected AI collaborator
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+RPG2000 enemies are scripted. Each database enemy row carries a 行動パターン
+(action pattern, chunk 42): a list of entries, each with a condition, a `rating`
+priority, and a kind — a basic action (attack, dual attack, defend, observe,
+charge, self-destruct, escape, do nothing), a skill, or a transformation into
+another enemy. RPG_RT walks that table every turn and picks one entry.
+
+The schema had parsed this table for a long time, but nothing read it. Every
+enemy in every fight performed a plain basic attack. Tallying the two test beds
+showed how much that hid:
+
+| | enemies | actions | skills | basic |
+|---|---|---|---|---|
+| Nepheshel 2.06 | 300 | 656 | 357 | 299 |
+| mtf-meido-action | 115 | 303 | 153 | 150 |
+
+**510 of 959 actions — over half — are skills**, none of which could fire. That
+also left a standing gap noted in `docs/TODO.md`: states could be inflicted by
+the party's attack skills but never by an enemy, because the only thing an enemy
+ever did was swing.
+
+The obstacle was structural rather than algorithmic. `Game::Battle` is
+deliberately database-free: it runs on `Combatant` snapshots so a fight can be
+seeded and replayed deterministically by the check harnesses, and so the battle
+logic has no dependency on the LCF loaders. But an enemy's action pattern needs
+things only the outside world has — the skill table to cast from, the enemy
+table to transform into, the game switches for the switch condition and its
+post-run switch flips, and the party's average level. Reaching for `@db` inside
+`Game::Battle` would have dissolved that boundary and made every existing battle
+fixture depend on a database.
+
+## Decision
+
+Decode the table into plain data at the edge, and inject the rest as a
+collaborator.
+
+- **`Game::EnemyAction`** decodes one row of the table off the LCF row into
+  plain fields, with liblcf's `RPG::EnemyAction` constants for the kinds,
+  basic actions and condition types. `Game::Enemy` decodes its whole pattern at
+  construction (it already captures its other fields there, since the row is not
+  kept), and `Battle::Combatant` carries the list into the fight.
+
+- **`Game::EnemyAi`** is a small collaborator holding the database and game
+  state, exposing exactly what an action pattern needs: `skill(id)`,
+  `enemy(id)`, `skill_command(sk, caster, target)`, `switch?` / `set_switch`
+  and `party_level`. `Game::Battle` takes one as an optional last argument.
+
+- Selection is a port of EasyRPG's `EnemyAi::AlgorithmRatingBased`: keep the
+  entries whose condition holds, find the highest rating, adjust every survivor
+  to `rating - max + 10` floored at 0 (so anything more than 10 below the best
+  drops out), and pick weighted by the adjusted rating.
+
+- A skill action is cast through `Game::Party#battle_skill_command` — the very
+  method the party casts with — so an enemy's spell is costed, elementally
+  scaled, accuracy-rolled and inflicts its states by the same code the heroes
+  use, rather than by a parallel enemy-only implementation.
+
+Without an `EnemyAi`, an enemy runs whatever basic actions its pattern lists and
+degrades a skill or transformation it cannot resolve to a plain attack.
+
+## Consequences
+
+Enemies now fight the way their author scripted them: they cast, heal each
+other, transform, guard, charge, blow themselves up and run. Enemy-cast status
+infliction falls out for free rather than needing its own path, closing that
+TODO gap.
+
+Because the collaborator is optional and absent by default, every existing
+seeded fixture produces exactly the results it did before — the 428 pre-existing
+logic checks were unchanged by this work — while the live game gets the full
+behaviour. The same seam makes the new behaviour cheap to test: the checks
+inject a stub `EnemyAi` with a hand-built skill table, with no LCF data
+involved.
+
+The trade-off is one more constructor argument on `Game::Battle`, which now
+takes ten positional parameters and is at the point where an options hash would
+read better. That refactor is deliberately left out of this change so the
+diff stays about the AI; it should happen the next time that signature is
+touched.
+
+A transformed monster keeps its original battler sprite: the battle screen builds
+each sprite once from the troop member's `battler_name`, so swapping it mid-fight
+is a scene-side change this did not take on. The fight itself is correct — the
+combatant has the new stats, ranks and pattern.
+
+Two limits are known and deliberate. The turn condition is evaluated against the
+same battle-turn clock the troop's battle-event pages use, which counts the
+first round as turn 1 where RPG_RT's own counter is 0-based — being consistent
+with the existing pages matters more than matching the absolute number, and a
+game with a "from turn N, every M" enemy action would pin it down. And the
+per-battler dual attack hits one target twice; RPG2003's combo multipliers on
+top of it are not modelled, as that runtime's ATB layer does not exist here.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -928,10 +928,50 @@ module LCF
         36 => { name: :parallax_sx, type: :int, default: 0 },
         37 => { name: :parallax_autoloop_y, type: :bool, default: false },
         38 => { name: :parallax_sy, type: :int, default: 0 },
+        # --- RPG2003 random dungeon generator (マップ生成) -------------------
+        #
+        # Editor-only: the settings the "generate dungeon" tool was last run
+        # with, kept so reopening the map restores the dialog. RPG_RT never
+        # reads them at run time and neither does this runtime — they are
+        # declared so a real map parses completely rather than leaving live
+        # chunks unaccounted for.
+        #
+        # Not on the wiki's マップ page, so the ids and defaults are liblcf's
+        # LMU_Reader::ChunkMap / RPG::Map (0x28..0x3E and 0x5A). The test beds
+        # confirm the ones they exercise: mtf-meido-action writes top_level
+        # (42) on 8 maps, and generator_height (50) as 2 on all 13 — the fields
+        # it leaves out are exactly the ones already at their liblcf default
+        # (generator_width 4, the six `true` flags), which is what an eliding
+        # writer produces and is a good check that these defaults are right.
+        40 => { name: :generator_flag, type: :bool, default: false },
+        41 => { name: :generator_mode, type: :int, default: 0 },
+        42 => { name: :top_level, type: :bool, default: false },
+        48 => { name: :generator_tiles, type: :int, default: 0 },
+        49 => { name: :generator_width, type: :int, default: 4 },
+        50 => { name: :generator_height, type: :int, default: 1 },
+        51 => { name: :generator_surround, type: :bool, default: true },
+        52 => { name: :generator_upper_wall, type: :bool, default: true },
+        53 => { name: :generator_floor_b, type: :bool, default: true },
+        54 => { name: :generator_floor_c, type: :bool, default: true },
+        55 => { name: :generator_extra_b, type: :bool, default: true },
+        56 => { name: :generator_extra_c, type: :bool, default: true },
+        # Nine room slots. x/y are liblcf `uint32_t` vectors, read here as
+        # signed 32-bit — the values are map coordinates, so the two readings
+        # only differ above 2^31, which no map reaches. The tile ids are
+        # shorts: reading chunk 62 as int16 yields real RPG2000 tile ids
+        # (49 lower-layer, 10000/10001/10006/10007 upper-layer) where an int32
+        # reading gives nonsense, which is what pins the width down.
+        60 => { name: :generator_x, type: :int32_array },
+        61 => { name: :generator_y, type: :int32_array },
+        62 => { name: :generator_tile_ids, type: :int16_array },
         # width * height signed shorts, one tile id per cell.
         71 => { name: :lower_layer, type: :int16_array },
         72 => { name: :upper_layer, type: :int16_array },
         81 => { name: :events, type: :Array2D, elements: MAP_EVENT },
+        # The 2k3e ("RPG2003 English release") save counter, a second counter
+        # beside the ordinary one below. BER-encoded like every other int —
+        # mtf-meido-action's first map holds 593.
+        90 => { name: :save_count_2k3e, type: :int, default: 0 },
         91 => { name: :save_count, type: :int, default: 0 },
       }
     }

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3258,6 +3258,67 @@ module Game
     end
   end
 
+  # Which battle backdrop (Backdrop/<name>) a fight on a given map uses.
+  #
+  # RPG2000 does not store the backdrop on the map itself: each map-tree node
+  # (RPG_RT.lmt `map_properties`) carries a `backdrop_type` choosing between the
+  # three options the editor's map-properties dialog offers, and the type is a
+  # tri-state that has to be walked, not read:
+  #
+  #   0 親マップと同じ  inherit whatever the parent map resolves to
+  #   1 地形で指定      the backdrop named by the terrain being fought on
+  #   2 指定する        the map's own `backdrop_file`, for every fight on it
+  #
+  # (liblcf spells these BGMType_parent / _terrain / _specific — `background_type`
+  # reuses the BGM enum.) Both test beds need the walk: 491 of Nepheshel's 537
+  # maps and 4 of mtf-meido-action's 13 are type 0 and answer only through a
+  # parent. Nepheshel pins 24 maps to a file ("black" for its dark interiors, a
+  # boss backdrop for one fight) while naming no terrain backdrops at all;
+  # mtf-meido-action is the other way round, leaving its 9 type-1 maps to 10
+  # named terrains (Grassland, Snow Field, Desert, ...).
+  module Backdrop
+    TYPE_PARENT   = 0
+    TYPE_TERRAIN  = 1
+    TYPE_SPECIFIC = 2
+
+    # The backdrop name for a fight on `map_id` standing on terrain whose own
+    # backdrop is `terrain_name`. `properties` is the map tree's map_properties
+    # table (`[map_id]` -> a row exposing backdrop_type / backdrop_file /
+    # parent_map_id). Returns '' when nothing names one, which the scene draws as
+    # its flat field.
+    #
+    # An inheriting map walks up its parents; the walk is bounded and remembers
+    # where it has been, so a tree that loops (or a node that parents itself)
+    # ends at the terrain rather than hanging the battle.
+    def self.name_for(map_id, properties, terrain_name = '')
+      terrain_name = terrain_name.to_s
+      seen = {}
+      id = map_id.to_i
+      while id > 0 && !seen[id]
+        seen[id] = true
+        row = properties ? properties[id] : nil
+        return terrain_name unless row
+        case int_field(row, :backdrop_type)
+        when TYPE_SPECIFIC
+          return row.respond_to?(:backdrop_file) ? row.backdrop_file.to_s : ''
+        when TYPE_TERRAIN
+          return terrain_name
+        else
+          id = int_field(row, :parent_map_id)
+        end
+      end
+      # The root (or a loop): RPG_RT has nothing left to inherit, so the terrain
+      # answers.
+      terrain_name
+    end
+
+    def self.int_field(row, name)
+      return 0 unless row.respond_to?(name)
+      v = row.send(name)
+      v.nil? ? 0 : v.to_i
+    end
+  end
+
   # One entry of an enemy's 行動パターン (action pattern) table — the database
   # enemy row's chunk 42, decoded off the LCF row into plain data so the battle
   # simulation can pick an action without holding a database row.
@@ -3546,7 +3607,7 @@ module Game
                            :actor, :states, :state_turns, :crit_denom,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
                            :hit_rate, :state_ranks, :hidden, :battle_turn,
-                           :actions, :charged, :enemy_id) do
+                           :actions, :charged, :enemy_id, :battler_name) do
       def dead?; hp <= 0; end
 
       # RPG2003 counts turns per battler as well as per battle: this is how many
@@ -3622,6 +3683,9 @@ module Game
       # built from (which a transformation re-points at another enemy row).
       c.actions = e.respond_to?(:actions) ? (e.actions || []) : []
       c.enemy_id = e.respond_to?(:id) ? e.id : nil
+      # The Monster/<name> graphic, carried so the battle screen can redraw a
+      # combatant whose transformation swapped it.
+      c.battler_name = e.respond_to?(:battler_name) ? e.battler_name : nil
       c
     end
 
@@ -4380,6 +4444,7 @@ module Game
       b.hit_rate = Battle.hit_rate_of(into)
       b.actions = into.actions
       b.enemy_id = act.enemy_id
+      b.battler_name = into.battler_name
       { attacker: b.name, transform: true, target: into.name }
     end
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3235,24 +3235,49 @@ module Game
       @party.items.keys.select { |id| sellable?(id) }.sort
     end
 
-    # Buy one unit of `id`: must be stocked, buying allowed, affordable and not
-    # already capped at 99. Returns whether the purchase happened.
-    def buy(id)
-      return false unless @allow_buy && @goods.include?(id)
+    # The RPG2000 per-item stack cap: a party holds at most 99 of anything.
+    ITEM_CAP = 99
+
+    # How many of `id` the party could buy right now — what the quantity
+    # selector's cursor is bounded by. The binding constraint is whichever of
+    # affordability and the 99-item cap runs out first; a free item (price 0,
+    # which RPG2000 does allow a shop to stock) is limited only by the cap.
+    # 0 when the shop will not sell it at all.
+    def max_buy(id)
+      return 0 unless @allow_buy && @goods.include?(id)
+      room = ITEM_CAP - @party.item_count(id)
+      return 0 if room <= 0
       cost = price(id)
-      return false if @party.gold < cost || @party.item_count(id) >= 99
-      @party.gain_gold(-cost)
-      @party.gain_item(id, 1)
+      return room if cost <= 0
+      affordable = @party.gold / cost
+      affordable < room ? affordable : room
+    end
+
+    # How many of `id` the party could sell — everything it holds, or 0 when the
+    # item cannot be sold here at all.
+    def max_sell(id)
+      @allow_sell && sellable?(id) ? @party.item_count(id) : 0
+    end
+
+    # Buy `n` units of `id` in one transaction: must be stocked, buying allowed,
+    # affordable and within the 99 cap. All-or-nothing — a count beyond what
+    # #max_buy allows buys nothing rather than silently buying fewer, so the
+    # caller cannot overspend by asking for too many. Returns whether it happened.
+    def buy(id, n = 1)
+      n = n.to_i
+      return false if n < 1 || n > max_buy(id)
+      @party.gain_gold(-price(id) * n)
+      @party.gain_item(id, n)
       @did_transaction = true
       true
     end
 
-    # Sell one unit of `id` at half price: must be allowed and sellable. Returns
-    # whether the sale happened.
-    def sell(id)
-      return false unless @allow_sell && sellable?(id)
-      @party.gain_gold(sell_price(id))
-      @party.gain_item(id, -1)
+    # Sell `n` units of `id` at half price each, all-or-nothing like #buy.
+    def sell(id, n = 1)
+      n = n.to_i
+      return false if n < 1 || n > max_sell(id)
+      @party.gain_gold(sell_price(id) * n)
+      @party.gain_item(id, -n)
       @did_transaction = true
       true
     end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3258,6 +3258,88 @@ module Game
     end
   end
 
+  # One entry of an enemy's 行動パターン (action pattern) table — the database
+  # enemy row's chunk 42, decoded off the LCF row into plain data so the battle
+  # simulation can pick an action without holding a database row.
+  #
+  # An enemy does not simply attack: each turn RPG_RT walks this table, keeps the
+  # entries whose `condition` currently holds, and picks one at random weighted
+  # by `rating` (see Game::Battle#choose_enemy_action). `kind` says what the
+  # chosen entry does — a basic action, a skill, or a transformation into another
+  # enemy — and an entry may also flip a switch once it has run.
+  #
+  # The field names and values are liblcf's RPG::EnemyAction. Real data uses
+  # nearly all of them: across the two test beds 510 of 959 actions are skills
+  # (which is why an enemy that only ever swung its fists was so far off), and
+  # every condition type except `sp` appears.
+  class EnemyAction
+    # `kind`: what the action does.
+    KIND_BASIC     = 0
+    KIND_SKILL     = 1
+    KIND_TRANSFORM = 2
+
+    # `basic`: which basic action, when kind is KIND_BASIC.
+    BASIC_ATTACK       = 0
+    BASIC_DUAL_ATTACK  = 1
+    BASIC_DEFEND       = 2
+    BASIC_OBSERVE      = 3
+    BASIC_CHARGE       = 4
+    BASIC_AUTODESTRUCT = 5
+    BASIC_ESCAPE       = 6
+    BASIC_NOTHING      = 7
+
+    # `condition_type`: what gates the action. The two `condition_param`s are the
+    # inclusive bounds of a range for the numeric conditions, and the turn
+    # condition's base / multiple pair.
+    COND_ALWAYS    = 0
+    COND_SWITCH    = 1
+    COND_TURN      = 2
+    COND_ACTORS    = 3
+    COND_HP        = 4
+    COND_SP        = 5
+    COND_PARTY_LVL = 6
+    COND_FATIGUE   = 7
+
+    attr_reader :kind, :basic, :skill_id, :enemy_id, :condition_type,
+                :condition_param1, :condition_param2, :switch_id, :switch_on,
+                :switch_on_id, :switch_off, :switch_off_id, :rating
+
+    # Read one action off an LCF row, tolerating a fixture that omits a field
+    # (the check harnesses build these by hand).
+    def initialize(row)
+      @kind             = int_of(row, :kind, 0)
+      @basic            = int_of(row, :basic, 0)
+      @skill_id         = int_of(row, :skill_id, 0)
+      @enemy_id         = int_of(row, :enemy_id, 0)
+      @condition_type   = int_of(row, :condition_type, 0)
+      @condition_param1 = int_of(row, :condition_param1, 0)
+      @condition_param2 = int_of(row, :condition_param2, 0)
+      @switch_id        = int_of(row, :switch_id, 0)
+      @switch_on_id     = int_of(row, :switch_on_id, 0)
+      @switch_off_id    = int_of(row, :switch_off_id, 0)
+      @switch_on        = bool_of(row, :switch_on)
+      @switch_off       = bool_of(row, :switch_off)
+      # The editor's default priority is 50; a row without one still competes.
+      @rating           = int_of(row, :rating, 50)
+    end
+
+    def skill?;     @kind == KIND_SKILL; end
+    def transform?; @kind == KIND_TRANSFORM; end
+    def basic?;     @kind == KIND_BASIC; end
+
+    private
+
+    def int_of(row, name, dflt)
+      return dflt unless row.respond_to?(name)
+      v = row.send(name)
+      v.nil? ? dflt : v.to_i
+    end
+
+    def bool_of(row, name)
+      row.respond_to?(name) && row.send(name) ? true : false
+    end
+  end
+
   # A single enemy instantiated from the database (chunk 14) for a battle: its
   # combat stats plus the EXP / gold it is worth and its battle-screen position.
   # Current HP / SP start full. The turn-based battle that would reduce them is
@@ -3316,7 +3398,15 @@ module Game
       # The "miss" flag (field 26): a flagged enemy is clumsier and attacks at a
       # 70% base hit rate rather than the usual 90% (EasyRPG's GetHitChance).
       @miss = row && row.respond_to?(:miss) ? (row.miss ? true : false) : false
+      # The 行動パターン table (field 42), decoded now since `row` isn't kept. An
+      # enemy whose row lists none falls back to plain attacking.
+      @actions = []
+      list = row && row.respond_to?(:actions) ? row.actions : nil
+      list.each { |_i, a| @actions << EnemyAction.new(a) } if list
     end
+
+    # This enemy's action pattern (Game::EnemyAction list, possibly empty).
+    attr_reader :actions
 
     attr_reader :crit_denom, :attribute_ranks, :state_ranks
     def crit_denominator; @crit_denom; end
@@ -3376,6 +3466,66 @@ module Game
   # every enemy is down or :defeat when the whole party is. `#step` performs one
   # action at a time and appends a `#log` entry, so an on-screen battle can
   # animate it action-by-action; `#run` steps to completion for a headless
+  # The outside world an enemy's 行動パターン needs, which Game::Battle itself
+  # deliberately does not hold: it works on Combatant snapshots and keeps no
+  # database. A skill action needs the skill table (and the party's own casting
+  # formulas, so an enemy's fireball is costed and scaled exactly like a hero's),
+  # a transformation needs the enemy table, and the switch / party-level
+  # conditions read live game state.
+  #
+  # Passed to Game::Battle as its `ai` collaborator. Every accessor tolerates a
+  # partial source so the check harnesses can hand in a stub (or nothing at all,
+  # in which case the enemies fall back to plain attacking as before).
+  class EnemyAi
+    def initialize(db, state)
+      @db = db
+      @state = state
+    end
+
+    # The database row for a skill / enemy id, or nil.
+    def skill(id)
+      @db && @db.respond_to?(:skill) ? @db.skill[id] : nil
+    end
+
+    # A freshly instantiated Game::Enemy for `id` — what a transformation turns
+    # into, read through the same constructor a troop member is built with (so it
+    # decodes its stats, ranks and its own action pattern). nil when unknown.
+    def enemy(id)
+      return nil unless @db && @db.respond_to?(:enemy) && id && id > 0
+      return nil unless @db.enemy[id]
+      Enemy.new(@db, id)
+    end
+
+    # The cast numbers for `sk` from `caster` on `target`, reusing Game::Party's
+    # own battle_skill_command so an enemy's skill costs and scales identically.
+    def skill_command(sk, caster, target)
+      party = @state && @state.respond_to?(:party) ? @state.party : nil
+      return nil unless party && party.respond_to?(:battle_skill_command)
+      party.battle_skill_command(sk, caster, target)
+    end
+
+    def switch?(id)
+      sw = @state && @state.respond_to?(:switches) ? @state.switches : nil
+      sw ? sw[id] : false
+    end
+
+    def set_switch(id, on)
+      sw = @state && @state.respond_to?(:switches) ? @state.switches : nil
+      sw[id] = on if sw && id && id > 0
+    end
+
+    # The party's average level, which the party_lvl action condition ranges
+    # over (EasyRPG's Game_Party::GetAverageLevel). 0 with no party.
+    def party_level
+      party = @state && @state.respond_to?(:party) ? @state.party : nil
+      actors = party && party.respond_to?(:actors) ? party.actors : nil
+      return 0 if actors.nil? || actors.empty?
+      total = 0
+      actors.each { |a| total += (a.respond_to?(:level) ? (a.level || 0) : 0) }
+      total / actors.size
+    end
+  end
+
   # resolution. It works on Combatant snapshots, so the caller can resolve a
   # battle without mutating the real party. This is a deliberately simple first
   # cut — escape and enemy-cast state infliction are still to come, and the
@@ -3395,7 +3545,8 @@ module Game
                            :action, :defending, :mp, :max_mp, :spi, :command,
                            :actor, :states, :state_turns, :crit_denom,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
-                           :hit_rate, :state_ranks, :hidden, :battle_turn) do
+                           :hit_rate, :state_ranks, :hidden, :battle_turn,
+                           :actions, :charged, :enemy_id) do
       def dead?; hp <= 0; end
 
       # RPG2003 counts turns per battler as well as per battle: this is how many
@@ -3467,6 +3618,10 @@ module Game
       # A member the troop flagged invisible starts out of play until a Show
       # Hidden Monster command brings it in (see Combatant#out_of_play?).
       c.hidden = e.respond_to?(:hidden) && e.hidden ? true : false
+      # The 行動パターン the AI picks from each turn, and the database id it was
+      # built from (which a transformation re-points at another enemy row).
+      c.actions = e.respond_to?(:actions) ? (e.actions || []) : []
+      c.enemy_id = e.respond_to?(:id) ? e.id : nil
       c
     end
 
@@ -3498,9 +3653,15 @@ module Game
     # exposing `a_rate` .. `e_rate`, e.g. the database's `property` table) so
     # elemental damage reads each attribute's own rank rates; omitted, the
     # RPG2000 default table applies.
+    # `ai` is an optional Game::EnemyAi giving the enemies' action patterns the
+    # database and game state they need (skill / enemy tables, switches, the
+    # party's average level). Without one an enemy can still run the basic
+    # actions its pattern lists, but a skill or transformation it cannot resolve
+    # falls back to a plain attack — which is exactly the old behaviour, so every
+    # existing fixture keeps its results.
     def initialize(allies, enemies, rng = nil, states = nil, variance = false,
                    criticals = false, accuracy = false, first_strike = false,
-                   attributes = nil)
+                   attributes = nil, ai = nil)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
@@ -3510,6 +3671,7 @@ module Game
       @accuracy = accuracy
       @first_strike = first_strike
       @attributes = attributes
+      @ai = ai
       @rounds = 0
       @result = nil
       @escaped = false     # set once the party successfully flees (#attempt_escape)
@@ -3951,9 +4113,281 @@ module Game
       end
       return apply_command(b) if b.command
       return nil if side_of(b) == :ally && b.defending # defending = no attack
+      # An enemy with a 行動パターン chooses from it rather than always swinging.
+      if side_of(b) == :enemy
+        # A guard raised last turn expires as this one begins (the allies' is
+        # cleared by #end_round; an enemy acts on its own schedule).
+        b.defending = false
+        act = choose_enemy_action(b)
+        return perform_enemy_action(b, act) if act
+      end
       target = attack_target(b)
       return nil unless target
       deal_attack(b, target)
+    end
+
+    # -- enemy AI (行動パターン) ------------------------------------------------
+
+    # Pick the action `b` takes this turn from its pattern, or nil to fall back
+    # to a plain attack (no pattern, or nothing currently valid).
+    #
+    # Port of EasyRPG's EnemyAi::AlgorithmRatingBased: collect the ratings of the
+    # actions whose condition holds, find the highest, then drop every action
+    # more than 10 below it (`rating - max + 10`, floored at 0) and pick from
+    # what remains at random, weighted by the adjusted rating. So a boss's
+    # rating-50 attack and rating-48 spell both stay in the mix, while a
+    # rating-40 desperation move is excluded until the moves above it stop being
+    # valid — which is how an RPG2000 enemy's behaviour shifts as a fight goes on.
+    def choose_enemy_action(b)
+      list = b.actions
+      return nil if list.nil? || list.empty?
+      prios = []
+      max_prio = 0
+      list.each do |a|
+        r = enemy_action_valid?(b, a) ? a.rating : 0
+        r = 0 if r < 0
+        prios << r
+        max_prio = r if r > max_prio
+      end
+      return nil if max_prio <= 0
+      total = 0
+      prios = prios.map do |pr|
+        v = pr > 0 ? pr - max_prio + 10 : 0
+        v = 0 if v < 0
+        total += v
+        v
+      end
+      return nil if total <= 0
+      which = @rng.random(total)
+      chosen = nil
+      list.each_with_index do |a, i|
+        chosen = a
+        which -= prios[i]
+        break if which < 0
+      end
+      chosen
+    end
+
+    # Whether action `a`'s condition currently holds for enemy `b`. The condition
+    # types and their arithmetic are EasyRPG's EnemyAi::IsActionValid; the ranges
+    # are inclusive on both ends.
+    def enemy_action_valid?(b, a)
+      return false if a.skill? && !enemy_skill_ready?(b, a)
+      case a.condition_type
+      when EnemyAction::COND_ALWAYS
+        true
+      when EnemyAction::COND_SWITCH
+        @ai ? @ai.switch?(a.switch_id) : false
+      when EnemyAction::COND_TURN
+        # Same argument order as the battle pages' turn condition: the base is
+        # condition_param2 and the multiple condition_param1 (see
+        # BattlePage.check_turns, which documents why it reads backwards).
+        BattlePage.check_turns(turn, a.condition_param2, a.condition_param1)
+      when EnemyAction::COND_ACTORS
+        n = @allies.reject(&:out_of_play?).size
+        n >= a.condition_param1 && n <= a.condition_param2
+      when EnemyAction::COND_HP
+        within_percent?(b.hp, b.max_hp, a)
+      when EnemyAction::COND_SP
+        within_percent?(b.mp, b.max_mp, a)
+      when EnemyAction::COND_PARTY_LVL
+        return false unless @ai
+        lvl = @ai.party_level
+        lvl >= a.condition_param1 && lvl <= a.condition_param2
+      when EnemyAction::COND_FATIGUE
+        f = fatigue
+        f >= a.condition_param1 && f <= a.condition_param2
+      else
+        # An operand this build does not know stays out of the running rather
+        # than firing unchecked.
+        false
+      end
+    end
+
+    # Whether `cur` as a percentage of `max` falls inside the action's range.
+    def within_percent?(cur, max, a)
+      return false if max.nil? || max <= 0
+      pct = (cur || 0) * 100 / max
+      pct >= a.condition_param1 && pct <= a.condition_param2
+    end
+
+    # Whether `b` can actually cast the skill action `a`: the skill exists and it
+    # can pay the SP. An enemy that cannot afford its spell falls through to its
+    # other actions, the way RPG_RT skips an unusable one.
+    def enemy_skill_ready?(b, a)
+      return false unless @ai
+      sk = @ai.skill(a.skill_id)
+      return false unless sk
+      cmd = @ai.skill_command(sk, b, nil)
+      return false unless cmd
+      cost = cmd[:cost] || 0
+      cost <= 0 || (b.mp || 0) >= cost
+    end
+
+    # Run the action `b` chose and return its log entry (or entries). Any switch
+    # the action flips is applied once it has run.
+    def perform_enemy_action(b, act)
+      entry = if act.skill?
+                enemy_skill_action(b, act)
+              elsif act.transform?
+                enemy_transform_action(b, act)
+              else
+                enemy_basic_action(b, act)
+              end
+      apply_action_switches(act)
+      entry
+    end
+
+    # An action may switch a game switch on and/or off once it has run — how an
+    # enemy's move signals a troop's battle-event pages.
+    def apply_action_switches(act)
+      return unless @ai
+      @ai.set_switch(act.switch_on_id, true) if act.switch_on
+      @ai.set_switch(act.switch_off_id, false) if act.switch_off
+    end
+
+    # The basic actions (kind 0). Attack and dual attack go through the ordinary
+    # attack path (so accuracy, criticals, elements and variance all apply);
+    # the rest have no damage of their own and read as a plain note on the log.
+    def enemy_basic_action(b, act)
+      case act.basic
+      when EnemyAction::BASIC_DUAL_ATTACK
+        target = attack_target(b)
+        return nil unless target
+        first = deal_attack(b, target)
+        # The second swing only lands if the first did not fell the target.
+        return [first] if target.dead?
+        [first, deal_attack(b, target)]
+      when EnemyAction::BASIC_DEFEND
+        b.defending = true
+        { attacker: b.name, defend: true }
+      when EnemyAction::BASIC_OBSERVE
+        { attacker: b.name, observe: true }
+      when EnemyAction::BASIC_CHARGE
+        # The next attack this enemy lands does double damage (EasyRPG's
+        # IsCharged, spent in #deal_attack).
+        b.charged = true
+        { attacker: b.name, charge: true }
+      when EnemyAction::BASIC_AUTODESTRUCT
+        enemy_autodestruct(b)
+      when EnemyAction::BASIC_ESCAPE
+        # The enemy runs: out of play without counting as a kill, exactly as a
+        # battle page's Force Flee removes one.
+        b.hidden = true
+        { attacker: b.name, fled: true }
+      when EnemyAction::BASIC_NOTHING
+        { attacker: b.name, nothing: true }
+      else
+        target = attack_target(b)
+        target ? deal_attack(b, target) : nil
+      end
+    end
+
+    # Self-destruction (basic 5): the enemy blows itself up, hitting every living
+    # party member for `atk - def/2` (EasyRPG's CalcSelfDestructEffect, floored at
+    # 0 and spread by the usual variance), and dies doing it.
+    def enemy_autodestruct(b)
+      targets = @allies.reject(&:out_of_play?)
+      entries = targets.map do |t|
+        dmg = b.atk - t.def / 2
+        dmg = 0 if dmg < 0
+        dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
+        dmg = [dmg / 2, 1].max if t.defending && dmg > 0
+        t.hp -= dmg
+        { attacker: b.name, target: t.name, damage: dmg, critical: false,
+          autodestruct: true, target_hp: t.hp < 0 ? 0 : t.hp, defeated: t.dead? }
+      end
+      # The blast kills the caster whether or not it found anyone to hit.
+      b.hp = 0
+      entries.empty? ? { attacker: b.name, autodestruct: true } : entries
+    end
+
+    # A skill action (kind 1): cast through the same command pipeline the party
+    # uses, so an enemy's attack spell scales, rolls its accuracy and inflicts its
+    # states exactly like a hero's — which is what finally lets an enemy poison or
+    # sleep the party. A skill whose scope names the caster's own side heals /
+    # buffs a fellow monster instead.
+    def enemy_skill_action(b, act)
+      sk = @ai && @ai.skill(act.skill_id)
+      return enemy_fallback_attack(b) unless sk
+      targets = enemy_skill_targets(b, sk)
+      return enemy_fallback_attack(b) if targets.empty?
+      cmd = @ai.skill_command(sk, b, targets.first)
+      return enemy_fallback_attack(b) unless cmd
+      b.command = skill_command_hash(sk, cmd, targets.first)
+      if targets.size > 1
+        # An all-target skill carries one effect per target, since attack damage
+        # is computed against each target's own defence.
+        per = targets.map do |t|
+          c = @ai.skill_command(sk, b, t)
+          c ? { target: t, hp: c[:hp] || 0, mp: c[:mp] || 0 } : nil
+        end.compact
+        return enemy_fallback_attack(b) if per.empty?
+        b.command[:all] = true
+        b.command[:targets] = per
+        b.command[:target] = nil
+      end
+      entry = apply_command(b)
+      b.command = nil
+      entry
+    end
+
+    # Wrap the party's cast numbers in the command hash #apply_command consumes.
+    def skill_command_hash(sk, cmd, target)
+      { kind: :skill, target: target, name: skill_name_of(sk),
+        cost: cmd[:cost] || 0, hp: cmd[:hp] || 0, mp: cmd[:mp] || 0,
+        inflict: cmd[:inflict] || [], chance: cmd[:chance] || 100,
+        variance: cmd[:variance] || 0, attributes: cmd[:attributes] || [] }
+    end
+
+    def skill_name_of(sk)
+      sk.respond_to?(:name) ? sk.name.to_s : ''
+    end
+
+    # Who an enemy's skill hits, read from the caster's side of the field: a
+    # scope aimed at "enemies" (0 single / 1 all) means the party, and one aimed
+    # at "allies" (2 the caster / 3 single / 4 all) means the troop.
+    def enemy_skill_targets(b, sk)
+      scope = sk.respond_to?(:scope) ? sk.scope.to_i : 0
+      case scope
+      when 1 then @allies.reject(&:out_of_play?)
+      when 2 then [b]
+      when 3
+        own = @enemies.reject(&:out_of_play?)
+        own.empty? ? [] : [own[@rng.random(own.size)]]
+      when 4 then @enemies.reject(&:out_of_play?)
+      else
+        foes = @allies.reject(&:out_of_play?)
+        foes.empty? ? [] : [foes[@rng.random(foes.size)]]
+      end
+    end
+
+    # A transformation (kind 2): the monster becomes another database enemy,
+    # taking on its name, stats and battle graphic (and its action pattern) while
+    # keeping its place in the fight. Current HP / SP carry over clamped to the
+    # new maxima, matching RPG_RT's Game_Enemy::Transform.
+    def enemy_transform_action(b, act)
+      into = @ai && @ai.enemy(act.enemy_id)
+      return enemy_fallback_attack(b) unless into
+      b.name = into.name
+      b.atk = into.atk; b.def = into.def; b.agi = into.agi; b.spi = into.spi
+      b.max_hp = into.max_hp; b.max_mp = into.max_sp
+      b.hp = b.hp > into.max_hp ? into.max_hp : b.hp
+      b.mp = (b.mp || 0) > into.max_sp ? into.max_sp : b.mp
+      b.crit_denom = Battle.crit_denom_of(into)
+      b.attr_ranks = Battle.attr_ranks_of(into)
+      b.state_ranks = Battle.state_ranks_of(into)
+      b.hit_rate = Battle.hit_rate_of(into)
+      b.actions = into.actions
+      b.enemy_id = act.enemy_id
+      { attacker: b.name, transform: true, target: into.name }
+    end
+
+    # A skill / transformation that could not be resolved (no database to hand)
+    # degrades to a plain attack rather than costing the enemy its turn.
+    def enemy_fallback_attack(b)
+      target = attack_target(b)
+      target ? deal_attack(b, target) : nil
     end
 
     # `b` lands a basic attack on `target`: the base damage (scaled by the
@@ -3977,11 +4411,21 @@ module Game
       # No critical on a same-side hit (e.g. a confused ally striking an ally) or
       # against a target whose gear prevents criticals, matching EasyRPG.
       crit = critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit
-      dmg *= 3 if crit
+      # A charged-up attack (the enemy's Charge basic action) hits twice as hard,
+      # but a critical takes precedence over it — EasyRPG's CalcNormalAttackEffect
+      # applies one or the other, never both. The charge is spent either way.
+      charged = b.charged ? true : false
+      b.charged = false if charged
+      if crit
+        dmg *= 3
+      elsif charged
+        dmg *= 2
+      end
       dmg = [dmg / 2, 1].max if target.defending && dmg > 0
       target.hp -= dmg
       { attacker: b.name, target: target.name, damage: dmg, critical: crit,
-        target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead? }
+        charged: charged, target_hp: target.hp < 0 ? 0 : target.hp,
+        defeated: target.dead? }
     end
 
     # Whether `b`'s attack criticals: enabled for the fight, the attacker has a

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2428,7 +2428,7 @@ class RPG2k
       # centred on its database position. Hidden (invisible) members get no sprite
       # until a battle event reveals them — a mechanism still to come.
       def build_battle_sprites
-        build_battle_back
+        build_battle_back(encounter_backdrop)
         @battle_ui[:enemy_sprites] = @battle_ui[:troop].members.each_with_index.map do |enemy, i|
           next nil if enemy.hidden
           bmp = battler_bitmap(enemy)
@@ -2439,15 +2439,46 @@ class RPG2k
           spr.z = 100 + i
           spr
         end
+        # The battler each sprite was drawn from, so a transformation mid-fight
+        # is noticed and redrawn (see #refresh_battle_sprites).
+        @battle_ui[:sprite_names] = @battle_ui[:foes].map { |f| f.battler_name }
         refresh_battle_sprites
       end
 
-      # A plain dark battle field behind the enemies. The real per-terrain
-      # backdrop (Backdrop/<name>, chosen by the tile the encounter started on) is
-      # still to come — the encounter request does not carry that terrain yet.
       # Where a battle-event page's message panel sits — above the action banner,
       # so a page talking mid-round does not fight it for the same row.
       BATTLE_EVENT_MSG_Y = 8
+
+      # The backdrop this encounter fights over: whatever Game::Backdrop resolves
+      # for the current map, given the terrain the party is standing on. '' when
+      # nothing names one, which draws the flat field.
+      def encounter_backdrop
+        Game::Backdrop.name_for(@state.map_id, map_properties,
+                                terrain_backdrop(@state.x, @state.y))
+      end
+
+      # The map tree's map_properties table, or nil when this build has no tree
+      # (the scene harnesses construct a map directly).
+      def map_properties
+        return nil unless respond_to?(:map_tree) && map_tree
+        map_tree.respond_to?(:map_properties) ? map_tree.map_properties : nil
+      rescue StandardError
+        nil
+      end
+
+      # The backdrop named by the terrain of the tile at (x, y) — the database
+      # terrain row's `background_name` (field 4). '' when the tile, the terrain
+      # table or the field is missing.
+      def terrain_backdrop(x, y)
+        tid = terrain_id(x, y)
+        return '' unless tid && tid > 0 && db.respond_to?(:terrain)
+        row = db.terrain[tid]
+        return '' unless row && row.respond_to?(:background_name)
+        row.background_name.to_s
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] terrain backdrop lookup failed: #{e.message}"
+        ''
+      end
 
       def build_battle_back(name = nil)
         bmp = battle_back_bitmap(name)
@@ -2506,6 +2537,13 @@ class RPG2k
       def refresh_battle_sprites
         sprites = @battle_ui[:enemy_sprites]
         return unless sprites
+        # A transformation swaps a monster's graphic mid-fight, so redraw any
+        # combatant no longer wearing the battler its sprite was built from
+        # before deciding what is visible.
+        names = (@battle_ui[:sprite_names] ||= [])
+        @battle_ui[:foes].each_with_index do |foe, i|
+          rebuild_battler_sprite(i, foe) if sprites[i] && names[i] != foe.battler_name
+        end
         @battle_ui[:foes].each_with_index do |foe, i|
           spr = sprites[i]
           # Out of play, not merely dead: a monster that has fled (its own Escape
@@ -2514,6 +2552,25 @@ class RPG2k
           # keep it out of the target cursor.
           spr.visible = !foe.out_of_play? if spr
         end
+      end
+
+      # Redraw troop slot `i` with `foe`'s current battler graphic, keeping its
+      # place and depth, and release the sprite and bitmap the old one held.
+      def rebuild_battler_sprite(i, foe)
+        sprites = @battle_ui[:enemy_sprites]
+        member = @battle_ui[:troop].members[i]
+        return unless member
+        old = sprites[i]
+        bmp = battler_bitmap(foe)
+        spr = Sprite.new
+        spr.bitmap = bmp
+        spr.x = member.x - bmp.width / 2
+        spr.y = member.y - bmp.height / 2
+        spr.z = 100 + i
+        spr.visible = !foe.out_of_play?
+        sprites[i] = spr
+        dispose_battle_sprite(old)
+        @battle_ui[:sprite_names][i] = foe.battler_name
       end
 
       def living_allies; @battle_ui[:allies].reject(&:dead?); end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2392,7 +2392,11 @@ class RPG2k
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
                                                 situations, true, true, true,
                                                 req[:first_strike] ? true : false,
-                                                properties),
+                                                properties,
+                                                # Lets the troop run its 行動パターン:
+                                                # skills, transformations and the
+                                                # switch / party-level conditions.
+                                                Game::EnemyAi.new(db, @state)),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],
@@ -2504,7 +2508,11 @@ class RPG2k
         return unless sprites
         @battle_ui[:foes].each_with_index do |foe, i|
           spr = sprites[i]
-          spr.visible = !foe.dead? if spr
+          # Out of play, not merely dead: a monster that has fled (its own Escape
+          # action, or a page's Force Flee) or one still flagged invisible is off
+          # the field and must not be drawn — the same test #living_foes uses to
+          # keep it out of the target cursor.
+          spr.visible = !foe.out_of_play? if spr
         end
       end
 
@@ -3108,9 +3116,26 @@ class RPG2k
           "#{e[:actor]}'s #{e[:source]}: #{e[:target]} #{body}"
         elsif e[:missed]
           "#{e[:attacker]} misses #{e[:target]}"
+        elsif e[:transform]
+          "#{e[:attacker]} transforms!"
+        elsif e[:defend]
+          "#{e[:attacker]} defends"
+        elsif e[:observe]
+          "#{e[:attacker]} watches closely"
+        elsif e[:charge]
+          "#{e[:attacker]} gathers strength"
+        elsif e[:fled]
+          "#{e[:attacker]} flees!"
+        elsif e[:nothing]
+          "#{e[:attacker]} does nothing"
         else
-          hits = e[:skill] ? "'s #{e[:skill]} hits" : ' hits'
+          hits = if e[:autodestruct] then ' blows itself up on'
+                 elsif e[:skill] then "'s #{e[:skill]} hits"
+                 else ' hits'
+                 end
           line = "#{e[:attacker]}#{hits} #{e[:target]} for #{e[:damage]}"
+          line += ' (critical!)' if e[:critical]
+          line += ' (charged)' if e[:charged]
           line += ' — defeated!' if e[:defeated]
           line
         end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -2202,7 +2202,11 @@ class RPG2k
           open_shop(req) # opened this frame; take input from the next one
           return
         end
-        @shop[:screen] == :command ? drive_shop_command : drive_shop_list
+        case @shop[:screen]
+        when :command  then drive_shop_command
+        when :quantity then drive_shop_quantity
+        else drive_shop_list
+        end
       end
 
       def open_shop(req)
@@ -2236,6 +2240,13 @@ class RPG2k
           rows << ['Sell', :sell] if m.allow_sell?
           rows << ['Leave', :leave]
           rows
+        when :quantity
+          # The counter is one row: how many, and what the stack comes to.
+          q = @shop[:quantity]
+          unit = q[:mode] == :buy ? m.price(q[:id]) : m.sell_price(q[:id])
+          verb = q[:mode] == :buy ? 'Buy' : 'Sell'
+          [["#{verb} #{m.name(q[:id])} x#{q[:count]}  " \
+            "#{unit * q[:count]}#{shop_gold_term}", q[:id]]]
         when :buy
           m.goods.map { |id| ["#{m.name(id)}  #{m.price(id)}#{shop_gold_term}", id] }
         else # :sell
@@ -2299,12 +2310,70 @@ class RPG2k
         if shop_move_cursor(lines)
           # cursor moved
         elsif Input.trigger?(Input::C) && !lines.empty?
-          id = lines[@shop[:index]][1]
-          @shop[:screen] == :buy ? @shop[:model].buy(id) : @shop[:model].sell(id)
-          draw_shop # refresh gold and, after a sale, the (shrunk) list
+          open_shop_quantity(lines[@shop[:index]][1])
         elsif Input.trigger?(Input::B)
           @shop[:has_menu] ? shop_switch(:command) : leave_shop
         end
+      end
+
+      # How far LEFT / RIGHT jump the quantity cursor — RPG_RT's shop counter
+      # moves in tens on the horizontal axis so a stack of 99 is a few presses
+      # away rather than ninety-nine.
+      SHOP_QUANTITY_STEP = 10
+
+      # Picking an item opens the quantity counter rather than transacting one
+      # unit: RPG2000 asks how many, bounded by what the party can afford, the
+      # 99-item cap, or (selling) what it holds. An item with no room at all —
+      # unaffordable, already capped — never opens the counter.
+      def open_shop_quantity(id)
+        model = @shop[:model]
+        max = @shop[:screen] == :buy ? model.max_buy(id) : model.max_sell(id)
+        return if max < 1
+        @shop[:quantity] = { id: id, count: 1, max: max, mode: @shop[:screen] }
+        @shop[:screen] = :quantity
+        draw_shop
+      end
+
+      # Drive the quantity counter: UP / DOWN by one, RIGHT / LEFT by ten (both
+      # clamped to 1..max), C commits the whole stack in one transaction and B
+      # goes back to the list having bought nothing.
+      def drive_shop_quantity
+        q = @shop[:quantity]
+        if shop_quantity_move(q)
+          draw_shop
+        elsif Input.trigger?(Input::C)
+          model = @shop[:model]
+          q[:mode] == :buy ? model.buy(q[:id], q[:count]) : model.sell(q[:id], q[:count])
+          close_shop_quantity
+        elsif Input.trigger?(Input::B)
+          close_shop_quantity
+        end
+      end
+
+      # Apply one frame of quantity input; returns whether the count changed.
+      def shop_quantity_move(q)
+        before = q[:count]
+        if Input.trigger?(Input::UP)
+          q[:count] += 1
+        elsif Input.trigger?(Input::DOWN)
+          q[:count] -= 1
+        elsif Input.trigger?(Input::RIGHT)
+          q[:count] += SHOP_QUANTITY_STEP
+        elsif Input.trigger?(Input::LEFT)
+          q[:count] -= SHOP_QUANTITY_STEP
+        else
+          return false
+        end
+        q[:count] = Game.clamp(q[:count], 1, q[:max])
+        q[:count] != before
+      end
+
+      # Leave the counter for the list it was opened from, refreshing the gold
+      # and (after a sale) the shrunk list.
+      def close_shop_quantity
+        @shop[:screen] = @shop[:quantity][:mode]
+        @shop[:quantity] = nil
+        draw_shop
       end
 
       # Move the shop cursor with Up / Down; returns true if it moved.

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -15,9 +15,12 @@
 # implements.
 #
 # Usage:
-#   ruby scripts/analyze_game.rb [--json] [--troops] GAME_DIR [GAME_DIR ...]
+#   ruby scripts/analyze_game.rb [--json] [--troops] [--enemies] GAME_DIR [...]
 # `--troops` reports the troops' battle-event pages instead: which condition
 # flag bits the game uses and which battle-only commands its pages run.
+# `--enemies` reports the enemies' action patterns (行動パターン): the kinds,
+# basic actions, conditions and rating spread the game's monsters are scripted
+# with, which is what Game::Battle's enemy AI has to cover.
 # With no GAME_DIR it scans ./data for directories containing an RPG_RT.ldb.
 #
 # Only structural, encoding-independent facts are reported, so the Windows-31J
@@ -428,20 +431,93 @@ rescue StandardError => e
   warn "  troop analysis failed for #{dir}: #{e.class}: #{e.message}"
 end
 
+# Labels for the enemy action-pattern fields (lcf::rpg::EnemyAction), used by
+# --enemies. Read alongside Game::EnemyAction, which defines the same constants.
+ACTION_KINDS = { 0 => 'basic', 1 => 'skill', 2 => 'transform' }.freeze
+ACTION_BASICS = { 0 => 'attack', 1 => 'dual attack', 2 => 'defend',
+                  3 => 'observe', 4 => 'charge', 5 => 'self-destruct',
+                  6 => 'escape', 7 => 'do nothing' }.freeze
+ACTION_CONDS = { 0 => 'always', 1 => 'switch', 2 => 'turn', 3 => 'party size',
+                 4 => 'own HP %', 5 => 'own SP %', 6 => 'party level',
+                 7 => 'party fatigue' }.freeze
+
+# What a game's enemies are actually scripted to do (enemy chunk 42), so the
+# runtime's AI coverage can be checked against real content the same way
+# --troops checks the battle pages. An enemy that only ever attacks is cheap to
+# support and badly wrong for these games: over half of every action here is a
+# skill.
+def report_enemies(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  enemies = 0
+  patternless = 0
+  actions = 0
+  kinds = Hash.new(0)
+  basics = Hash.new(0)
+  conds = Hash.new(0)
+  ratings = Hash.new(0)
+  switched = 0
+  db.enemy.each do |_id, row|
+    enemies += 1
+    list = (row.respond_to?(:actions) ? row.actions : nil)
+    if list.nil? || list.to_a.empty?
+      patternless += 1
+      next
+    end
+    list.each do |_ai, a|
+      actions += 1
+      k = a.kind.to_i
+      kinds[k] += 1
+      basics[a.basic.to_i] += 1 if k.zero?
+      conds[a.condition_type.to_i] += 1
+      ratings[a.rating.to_i] += 1
+      switched += 1 if a.switch_on || a.switch_off
+    end
+  end
+
+  puts "\n== #{dir} enemy action patterns =="
+  puts "enemies: #{enemies}  without a pattern: #{patternless}  actions: #{actions}"
+  return if actions.zero?
+  puts 'kind:'
+  kinds.sort_by { |_, n| -n }.each do |k, n|
+    puts format('  %-10s %4d  (%d%%)', ACTION_KINDS[k] || k.to_s, n, n * 100 / actions)
+  end
+  puts 'basic action:'
+  basics.sort_by { |_, n| -n }.each do |b, n|
+    puts format('  %-14s %4d', ACTION_BASICS[b] || b.to_s, n)
+  end
+  puts 'condition:'
+  conds.sort_by { |_, n| -n }.each do |c, n|
+    puts format('  %-14s %4d', ACTION_CONDS[c] || c.to_s, n)
+  end
+  # The spread matters: the selector drops anything more than 10 below the best
+  # valid rating, so a game using a single rating never exercises that rule.
+  puts "ratings in use: #{ratings.keys.sort.inspect}"
+  puts "actions that flip a switch when they run: #{switched}"
+rescue StandardError => e
+  warn "  enemy analysis failed for #{dir}: #{e.class}: #{e.message}"
+end
+
 json = ARGV.delete('--json')
 troops = ARGV.delete('--troops')
+enemies_only = ARGV.delete('--enemies')
 games = ARGV.dup
 if games.empty?
   root = File.expand_path('../data', __dir__)
   games = Dir.glob(File.join(root, '**', 'RPG_RT.ldb')).map { |f| File.dirname(f) }.sort
 end
 if games.empty?
-  warn 'usage: ruby scripts/analyze_game.rb [--json] [--troops] GAME_DIR [GAME_DIR ...]'
+  warn 'usage: ruby scripts/analyze_game.rb [--json] [--troops] [--enemies] ' \
+       'GAME_DIR [GAME_DIR ...]'
   exit 1
 end
 
 if troops
   games.each { |g| report_troops(g) }
+  exit 0
+end
+
+if enemies_only
+  games.each { |g| report_enemies(g) }
   exit 0
 end
 

--- a/scripts/lcf_testbed_check.rb
+++ b/scripts/lcf_testbed_check.rb
@@ -126,11 +126,46 @@ class Checker
       upper = lmu.upper_layer
       fail "#{base}: lower layer #{lower.size} != #{w}x#{h}" if lower && lower.size != w * h
       fail "#{base}: upper layer #{upper.size} != #{w}x#{h}" if upper && upper.size != w * h
+      check_generator(base, lmu)
       lmu.events.each { |_id, _ev| @events += 1 }
       @maps += 1
     end
   rescue => ex
     fail "#{dir}: #{ex.class}: #{ex.message}"
+  end
+
+  # The RPG2003 dungeon-generator block (chunks 40-62) and the 2k3e save counter
+  # (90). These are not documented on the 200X wiki's マップ page, so their ids,
+  # types and defaults come from liblcf — which means they are worth asserting
+  # against real bytes rather than trusting.
+  #
+  # Two things could silently go wrong: an id could be attached to the wrong
+  # field (the values would still parse, just as the wrong thing), and a width
+  # could be misread (chunk 62 is shorts, and reading it as int32 yields
+  # plausible-looking large numbers rather than an error). Both are caught by
+  # checking that what comes out is the shape the format promises.
+  def check_generator(base, lmu)
+    # Every declared field must materialise, from the file or from its default,
+    # so a map that omits the whole block still answers.
+    fail "#{base}: generator_width did not default" if lmu.generator_width.nil?
+    fail "#{base}: generator_surround did not default" if lmu.generator_surround.nil?
+    h = lmu.generator_height
+    fail "#{base}: generator_height #{h.inspect} not a positive int" if h.nil? || h < 1
+
+    # The room slots are parallel arrays: nine x/y coordinates and their tile
+    # ids. A wrong element width would change these counts.
+    gx = lmu.generator_x
+    gy = lmu.generator_y
+    fail "#{base}: generator_x is #{gx.size} values, expected 9" if gx && gx.size != 9
+    fail "#{base}: generator_y is #{gy.size} values, expected 9" if gy && gy.size != 9
+
+    ids = lmu.generator_tile_ids
+    return unless ids
+    fail "#{base}: generator_tile_ids is #{ids.size} values, expected 18" if ids.size != 18
+    # Read as shorts these are ordinary RPG2000 tile ids; read as int32 they run
+    # into the millions. Bound them by the same range the map layers use.
+    bad = ids.reject { |t| t >= 0 && t <= 20_000 }
+    fail "#{base}: generator_tile_ids out of tile range: #{bad.first(4).inspect}" unless bad.empty?
   end
 
   def report

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6347,6 +6347,415 @@ check 'Show Hidden Monster reveals through the interpreter and the battle' do
   ok !b.enemy(0).out_of_play?
 end
 
+# -- enemy action patterns (行動パターン) --------------------------------------
+
+# A stand-in for one row of an enemy's action table; EnemyAction reads whichever
+# fields are present, so a test only names the ones it cares about.
+class FakeAction
+  attr_accessor :kind, :basic, :skill_id, :enemy_id, :condition_type,
+                :condition_param1, :condition_param2, :switch_id, :switch_on,
+                :switch_on_id, :switch_off, :switch_off_id, :rating
+
+  def initialize(h = {})
+    h.each { |k, v| send("#{k}=", v) }
+    @rating ||= 50
+  end
+end
+
+def enemy_action(h = {})
+  Game::EnemyAction.new(FakeAction.new(h))
+end
+
+# A battle whose single monster runs `actions`, against one hero.
+def ai_battle(actions, ai = nil, foe: nil, hero: nil, seed: 1)
+  hero ||= combatant('Hero', 40, 0, 20, 500)
+  foe ||= combatant('Slime', 40, 0, 5, 500)
+  foe.actions = actions
+  # The skill formulas read the caster's spirit; a bare Combatant leaves it nil.
+  hero.spi ||= 0
+  foe.spi ||= 0
+  Game::Battle.new([hero], [foe], Game::Rng.new(seed), nil, false, false, false,
+                   false, nil, ai)
+end
+
+# One enemy action resolved: the log entry its turn produced.
+def enemy_entry(actions, ai = nil, foe: nil, hero: nil, seed: 1)
+  b = ai_battle(actions, ai, foe: foe, hero: hero, seed: seed)
+  b.begin_round
+  # The hero is faster (agi 20 vs 5), so drain its action first.
+  b.step_action
+  b.step_action
+end
+
+check 'EnemyAction decodes a database action row' do
+  a = enemy_action(kind: 1, skill_id: 7, condition_type: 4,
+                   condition_param1: 0, condition_param2: 50, rating: 80)
+  ok a.skill?, 'kind 1 is a skill'
+  eq 7, a.skill_id
+  eq 4, a.condition_type
+  eq 50, a.condition_param2
+  eq 80, a.rating
+end
+
+check 'EnemyAction defaults the rating to the editor default of 50' do
+  eq 50, enemy_action(kind: 0).rating
+end
+
+check 'an enemy with no action pattern still attacks (unchanged behaviour)' do
+  e = enemy_entry([])
+  eq 'Slime', e[:attacker]
+  eq 20, e[:damage], 'a plain attack, exactly as before'
+end
+
+check 'an enemy defends instead of attacking when its pattern says so' do
+  e = enemy_entry([enemy_action(kind: 0, basic: 2)])
+  eq true, e[:defend]
+  ok e[:damage].nil?, 'a guard deals no damage'
+end
+
+check 'a defending enemy takes half damage from the next blow' do
+  hero = combatant('Hero', 40, 0, 5, 500)     # slower, so the foe guards first
+  foe = combatant('Slime', 40, 0, 20, 500)
+  b = ai_battle([enemy_action(kind: 0, basic: 2)], nil, foe: foe, hero: hero)
+  b.begin_round
+  eq true, b.step_action[:defend], 'the faster monster guards'
+  eq 10, b.step_action[:damage], 'base 20 halved by the guard'
+end
+
+check "an enemy's guard expires on its next turn" do
+  hero = combatant('Hero', 40, 0, 5, 500)
+  foe = combatant('Slime', 40, 0, 20, 500)
+  # Round 1 guards; round 2 attacks (and so drops the guard).
+  b = ai_battle([enemy_action(kind: 0, basic: 2)], nil, foe: foe, hero: hero)
+  b.begin_round; b.step_action; b.step_action; b.end_round
+  b.begin_round
+  b.step_action                               # the monster guards again
+  eq 10, b.step_action[:damage], 'still guarding within the round'
+  ok foe.defending, 'the guard is up'
+  b.end_round
+  b.begin_round
+  b.step_action
+  ok foe.defending, 're-raised by the same pattern'
+end
+
+check 'a charge doubles the enemy next attack, then is spent' do
+  # Two entries: charge (rating 50) then attack. Charge first via a turn gate.
+  foe = combatant('Slime', 40, 0, 5, 500)
+  charge = enemy_action(kind: 0, basic: 4)
+  b = ai_battle([charge], nil, foe: foe)
+  b.begin_round; b.step_action
+  eq true, b.step_action[:charge], 'the monster gathers strength'
+  ok foe.charged, 'the charge is held'
+  # Swap in a plain attack for the next turn and check it lands doubled.
+  foe.actions = [enemy_action(kind: 0, basic: 0)]
+  b.end_round; b.begin_round; b.step_action
+  e = b.step_action
+  eq 40, e[:damage], 'base 20 doubled by the charge'
+  eq true, e[:charged]
+  ok !foe.charged, 'and the charge is spent'
+end
+
+check 'a dual attack strikes twice in one turn' do
+  b = ai_battle([enemy_action(kind: 0, basic: 1)])
+  b.begin_round
+  b.step_action                                # the hero
+  first = b.step_action
+  second = b.step_action
+  eq 'Slime', first[:attacker]
+  eq 'Slime', second[:attacker], 'the same monster swings again'
+  eq 20, first[:damage]
+  eq 20, second[:damage]
+end
+
+check 'an observing / idle enemy does nothing but still reads on the log' do
+  eq true, enemy_entry([enemy_action(kind: 0, basic: 3)])[:observe]
+  eq true, enemy_entry([enemy_action(kind: 0, basic: 7)])[:nothing]
+end
+
+check 'an escaping enemy leaves the fight without counting as a kill' do
+  hero = combatant('Hero', 40, 0, 20, 500)
+  foe = combatant('Slime', 40, 0, 5, 500)
+  b = ai_battle([enemy_action(kind: 0, basic: 6)], nil, foe: foe, hero: hero)
+  b.begin_round
+  b.step_action
+  eq true, b.step_action[:fled]
+  ok foe.hidden, 'out of play'
+  ok !foe.dead?, 'but not defeated'
+  eq :victory, b.run, 'the fight is over with the troop gone'
+end
+
+check 'self-destruction hits the party for atk - def/2 and kills the caster' do
+  hero = combatant('Hero', 40, 10, 20, 500)
+  foe = combatant('Bomb', 60, 0, 5, 500)
+  b = ai_battle([enemy_action(kind: 0, basic: 5)], nil, foe: foe, hero: hero)
+  b.begin_round
+  b.step_action
+  e = b.step_action
+  eq true, e[:autodestruct]
+  eq 55, e[:damage], '60 - 10/2'
+  ok foe.dead?, 'the bomb dies doing it'
+end
+
+# -- the rating-weighted choice ------------------------------------------------
+
+check 'an action more than 10 below the best rating is never chosen' do
+  # rating 50 vs 39: 39 - 50 + 10 = -1 -> floored to 0, so it never comes up.
+  acts = [enemy_action(kind: 0, basic: 0, rating: 50),
+          enemy_action(kind: 0, basic: 2, rating: 39)]
+  20.times do |i|
+    e = enemy_entry(acts, nil, seed: i + 1)
+    ok e[:defend].nil?, "the rating-39 guard stays out (seed #{i + 1})"
+  end
+end
+
+check 'an action within 10 of the best rating does come up' do
+  # Drawn from one continuously advancing RNG rather than 30 fresh seeds: this
+  # engine's LCG is seeded as `seed + 1` and reseeding it that narrowly gives a
+  # badly clustered first draw, which would test the RNG rather than the choice.
+  acts = [enemy_action(kind: 0, basic: 0, rating: 50),
+          enemy_action(kind: 0, basic: 2, rating: 45)]
+  b = ai_battle(acts)
+  seen = {}
+  40.times do
+    b.begin_round
+    b.step_action                              # the hero
+    e = b.step_action                          # the monster
+    seen[e && e[:defend] ? :defend : :attack] = true
+    b.end_round
+  end
+  ok seen[:attack], 'the attack comes up'
+  ok seen[:defend], 'and so does the rating-45 guard'
+end
+
+# -- the action conditions -----------------------------------------------------
+
+check 'an HP-range action only fires inside its window' do
+  # Only valid below 50% HP; with no other valid action the enemy falls back to
+  # a plain attack, so the guard appearing is the signal.
+  act = enemy_action(kind: 0, basic: 2, condition_type: 4,
+                     condition_param1: 0, condition_param2: 50)
+  healthy = combatant('Slime', 40, 0, 5, 500)
+  ok enemy_entry([act], nil, foe: healthy)[:defend].nil?, 'at full HP it does not fire'
+  hurt = combatant('Slime', 40, 0, 5, 500)
+  hurt.hp = 100                                # 20% of 500
+  eq true, enemy_entry([act], nil, foe: hurt)[:defend], 'below 50% it fires'
+end
+
+check 'a switch-gated action reads the live switch through the AI env' do
+  st = new_state
+  ai = Game::EnemyAi.new(nil, st)
+  act = enemy_action(kind: 0, basic: 2, condition_type: 1, switch_id: 3)
+  ok enemy_entry([act], ai)[:defend].nil?, 'switch off: not valid'
+  st.switches[3] = true
+  eq true, enemy_entry([act], ai)[:defend], 'switch on: fires'
+end
+
+check 'a switch-gated action is invalid with no AI env to ask' do
+  act = enemy_action(kind: 0, basic: 2, condition_type: 1, switch_id: 3)
+  ok enemy_entry([act], nil)[:defend].nil?, 'falls back to attacking'
+end
+
+check 'an actor-count action ranges over the living party' do
+  act = enemy_action(kind: 0, basic: 2, condition_type: 3,
+                     condition_param1: 2, condition_param2: 4)
+  ok enemy_entry([act], nil)[:defend].nil?, 'a party of one is below the range'
+end
+
+check 'a turn-gated action uses the battle turn clock' do
+  # base 0 / multiple 2 -> turns 0, 2, 4 ... (Game::BattlePage.check_turns)
+  act = enemy_action(kind: 0, basic: 2, condition_type: 2,
+                     condition_param1: 2, condition_param2: 0)
+  b = ai_battle([act])
+  b.begin_round                                # turn 1: no match
+  b.step_action
+  ok b.step_action[:defend].nil?, 'turn 1 does not match'
+  b.end_round
+  b.begin_round                                # turn 2: matches
+  b.step_action
+  eq true, b.step_action[:defend], 'turn 2 matches'
+end
+
+check 'a party-level action reads the average level through the AI env' do
+  st = party_state
+  ai = Game::EnemyAi.new(nil, st)
+  # Two actors at levels 5 and 3, so the party average is 4 — not the leader's.
+  lvl = ai.party_level
+  eq 4, lvl, 'the average, not the leader'
+  hit = enemy_action(kind: 0, basic: 2, condition_type: 6,
+                     condition_param1: lvl, condition_param2: lvl + 10)
+  miss = enemy_action(kind: 0, basic: 2, condition_type: 6,
+                      condition_param1: lvl + 5, condition_param2: lvl + 10)
+  eq true, enemy_entry([hit], ai)[:defend], 'inside the level range'
+  ok enemy_entry([miss], ai)[:defend].nil?, 'outside it'
+end
+
+check 'an unknown condition type keeps the action out of the running' do
+  act = enemy_action(kind: 0, basic: 2, condition_type: 99)
+  ok enemy_entry([act], nil)[:defend].nil?, 'not fired unchecked'
+end
+
+# -- post-action switches ------------------------------------------------------
+
+check 'an action flips its switches once it has run' do
+  st = new_state
+  ai = Game::EnemyAi.new(nil, st)
+  st.switches[9] = true
+  act = enemy_action(kind: 0, basic: 0, switch_on: true, switch_on_id: 8,
+                     switch_off: true, switch_off_id: 9)
+  enemy_entry([act], ai)
+  eq true, st.switches[8], 'switched on'
+  eq false, st.switches[9], 'and off'
+end
+
+# -- skill actions -------------------------------------------------------------
+
+# A minimal skill row for the AI env to resolve.
+class FakeAiSkill
+  attr_accessor :name, :scope, :sp_type, :sp_cost, :sp_percent, :power,
+                :physical_rate, :magical_rate, :hit, :variance, :state_effects,
+                :attribute_effects, :affect_hp, :affect_sp
+
+  def initialize(h = {})
+    @name = 'Spell'; @scope = 0; @sp_type = 0; @sp_cost = 0; @power = 0
+    @physical_rate = 0; @magical_rate = 0; @hit = 100; @variance = 0
+    @affect_hp = true; @affect_sp = false
+    h.each { |k, v| send("#{k}=", v) }
+  end
+end
+
+# An AI env whose skill table is a fixed hash, casting through a real party.
+class FakeAiEnv < Game::EnemyAi
+  def initialize(skills, state)
+    super(nil, state)
+    @skills = skills
+  end
+
+  def skill(id); @skills[id]; end
+end
+
+def skill_ai(skills)
+  FakeAiEnv.new(skills, party_state)
+end
+
+check 'an enemy casts an attack skill from its pattern' do
+  ai = skill_ai(1 => FakeAiSkill.new(name: 'Fire', scope: 0, power: 30))
+  foe = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  e = enemy_entry([enemy_action(kind: 1, skill_id: 1)], ai, foe: foe)
+  eq 'Fire', e[:skill], 'the skill is named on the log'
+  ok e[:damage] > 0, 'and it hurt'
+end
+
+check "an enemy's attack skill inflicts its states — enemy-cast infliction" do
+  # state_effects marks state 2; scope 0 makes it an attack skill, whose states
+  # roll against the skill's accuracy (100 here, so it always lands).
+  sk = FakeAiSkill.new(name: 'Poison Sting', scope: 0, power: 20, hit: 100,
+                       state_effects: [0, 1])
+  ai = skill_ai(1 => sk)
+  hero = combatant('Hero', 40, 0, 20, 500)
+  foe = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  e = enemy_entry([enemy_action(kind: 1, skill_id: 1)], ai, foe: foe, hero: hero)
+  eq [2], e[:inflicted], 'the party member is poisoned by the monster'
+  ok hero.state?(2), 'and carries the state'
+end
+
+check 'an enemy heals a fellow monster with an ally-scoped skill' do
+  ai = skill_ai(1 => FakeAiSkill.new(name: 'Heal', scope: 3, power: 50,
+                                     affect_hp: true))
+  hero = combatant('Hero', 40, 0, 30, 500)
+  medic = combatant_mp('Medic', 10, 0, 5, 500, 100)
+  medic.actions = [enemy_action(kind: 1, skill_id: 1)]
+  hurt = combatant('Brute', 10, 0, 1, 500)
+  hurt.hp = 100
+  [hero, medic, hurt].each { |c| c.spi ||= 0 }
+  b = Game::Battle.new([hero], [medic, hurt], Game::Rng.new(1), nil, false,
+                       false, false, false, nil, ai)
+  b.begin_round
+  b.step_action                                # the hero swings
+  e = b.step_action                            # the medic casts
+  eq true, e[:recover], 'a recovery, not an attack'
+  ok e[:recover_hp] > 0, 'HP restored to a monster'
+end
+
+check 'an all-enemies skill hits every party member at once' do
+  ai = skill_ai(1 => FakeAiSkill.new(name: 'Blast', scope: 1, power: 30))
+  a = combatant('A', 10, 0, 30, 500)
+  bb = combatant('B', 10, 0, 29, 500)
+  foe = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  foe.actions = [enemy_action(kind: 1, skill_id: 1)]
+  [a, bb, foe].each { |c| c.spi ||= 0 }
+  bat = Game::Battle.new([a, bb], [foe], Game::Rng.new(1), nil, false, false,
+                         false, false, nil, ai)
+  bat.begin_round
+  bat.step_action; bat.step_action             # both heroes
+  hits = [bat.step_action, bat.step_action]
+  eq %w[A B], hits.map { |h| h[:target] }.sort, 'both members are hit'
+  eq 1, hits.map { |h| h[:attacker] }.uniq.size, 'by the one monster'
+end
+
+check 'an enemy that cannot pay a skill SP cost falls back to attacking' do
+  ai = skill_ai(1 => FakeAiSkill.new(name: 'Fire', scope: 0, power: 30,
+                                     sp_cost: 50))
+  foe = combatant_mp('Slime', 40, 0, 5, 500, 10)   # only 10 SP
+  e = enemy_entry([enemy_action(kind: 1, skill_id: 1)], ai, foe: foe)
+  ok e[:skill].nil?, 'no spell'
+  eq 20, e[:damage], 'a plain attack instead'
+end
+
+check 'a skill action with no AI env to resolve it degrades to an attack' do
+  e = enemy_entry([enemy_action(kind: 1, skill_id: 1)], nil)
+  ok e[:skill].nil?
+  eq 20, e[:damage]
+end
+
+check 'casting spends the enemy SP' do
+  ai = skill_ai(1 => FakeAiSkill.new(name: 'Fire', scope: 0, power: 30,
+                                     sp_cost: 12))
+  foe = combatant_mp('Slime', 40, 0, 5, 500, 100)
+  enemy_entry([enemy_action(kind: 1, skill_id: 1)], ai, foe: foe)
+  eq 88, foe.mp, '100 - 12'
+end
+
+# -- transformation ------------------------------------------------------------
+
+check 'a transformation re-points the monster at another database enemy' do
+  # A tiny stand-in database exposing one enemy row.
+  row = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                   :agility, :exp, :gold).new('Dragon', 900, 50, 90, 40, 30,
+                                              25, 0, 0)
+  db = Struct.new(:enemy).new({ 1 => row })
+  ai = Game::EnemyAi.new(db, new_state)
+  foe = combatant('Slime', 40, 0, 5, 500)
+  e = enemy_entry([enemy_action(kind: 2, enemy_id: 1)], ai, foe: foe)
+  eq true, e[:transform]
+  eq 'Dragon', foe.name, 'the monster is now a Dragon'
+  eq 90, foe.atk, 'with its stats'
+  eq 900, foe.max_hp
+end
+
+check 'a transformation into an unknown enemy degrades to an attack' do
+  ai = Game::EnemyAi.new(nil, new_state)
+  e = enemy_entry([enemy_action(kind: 2, enemy_id: 99)], ai)
+  ok e[:transform].nil?
+  eq 20, e[:damage]
+end
+
+# -- the database path ---------------------------------------------------------
+
+check 'Game::Enemy decodes its action pattern off the database row' do
+  arow = FakeAction.new(kind: 1, skill_id: 4, rating: 60)
+  erow = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                    :agility, :exp, :gold, :actions)
+             .new('Imp', 30, 5, 12, 4, 3, 8, 7, 3, { 1 => arow })
+  db = Struct.new(:enemy).new({ 1 => erow })
+  e = Game::Enemy.new(db, 1)
+  eq 1, e.actions.size
+  ok e.actions.first.skill?
+  eq 4, e.actions.first.skill_id
+  eq 60, e.actions.first.rating
+  eq e.actions, Game::Battle.from_enemy(e).actions,
+     'and the combatant carries it into the fight'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4245,6 +4245,85 @@ check 'Shop sell refuses unowned, price-0 (key), or in a buy-only shop' do
   ok !shop3.sell(3)
 end
 
+check 'Shop max_buy is bounded by what the party can afford' do
+  st, shop = shop_setup(450, { 3 => 100 })
+  eq 4, shop.max_buy(3), '450 gold buys four at 100'
+  st.party.gain_gold(-450)
+  eq 0, shop.max_buy(3), 'and none when broke'
+end
+
+check 'Shop max_buy is bounded by the 99-item cap, not just gold' do
+  st, shop = shop_setup(999_999, { 3 => 1 })
+  eq 99, shop.max_buy(3), 'rich enough for more, but 99 is the cap'
+  st.party.gain_item(3, 90)
+  eq 9, shop.max_buy(3), 'only the remaining room'
+  st.party.gain_item(3, 9)
+  eq 0, shop.max_buy(3), 'full'
+end
+
+check 'Shop max_buy of a free item is limited only by the cap' do
+  _st, shop = shop_setup(0, { 4 => 0 })
+  eq 99, shop.max_buy(4), 'a price-0 good does not divide by zero'
+end
+
+check 'Shop max_buy is 0 for unstocked goods and in a sell-only shop' do
+  _st, shop = shop_setup(500, { 3 => 100 })
+  eq 0, shop.max_buy(7), 'not stocked'
+  _st2, shop2 = shop_setup(500, { 3 => 100 }, allow_buy: false, allow_sell: true)
+  eq 0, shop2.max_buy(3), 'this shop does not sell'
+end
+
+check 'Shop max_sell is what the party holds, and 0 when it cannot be sold' do
+  st, shop = shop_setup(0, { 3 => 100 })
+  st.party.gain_item(3, 7)
+  eq 7, shop.max_sell(3)
+  st2, shop2 = shop_setup(0, { 4 => 0 })
+  st2.party.gain_item(4, 3)
+  eq 0, shop2.max_sell(4), 'a price-0 key item cannot be sold'
+  st3, shop3 = shop_setup(0, { 3 => 100 }, allow_buy: true, allow_sell: false)
+  st3.party.gain_item(3, 3)
+  eq 0, shop3.max_sell(3), 'this shop does not buy'
+end
+
+check 'Shop buys a whole stack in one transaction' do
+  st, shop = shop_setup(500, { 3 => 100 })
+  ok shop.buy(3, 4), 'four at once'
+  eq 100, st.party.gold, '500 - 4*100'
+  eq 4, st.party.item_count(3)
+end
+
+check 'Shop sells a whole stack in one transaction' do
+  st, shop = shop_setup(0, { 3 => 100 })
+  st.party.gain_item(3, 5)
+  ok shop.sell(3, 3), 'three at once'
+  eq 150, st.party.gold, '3 * 50'
+  eq 2, st.party.item_count(3)
+end
+
+check 'a stack beyond what the party can afford buys nothing at all' do
+  st, shop = shop_setup(500, { 3 => 100 })
+  ok !shop.buy(3, 6), 'six would cost 600'
+  eq 500, st.party.gold, 'no gold spent'
+  eq 0, st.party.item_count(3), 'and no partial purchase'
+  ok !shop.did_transaction
+end
+
+check 'a stack beyond what the party holds sells nothing at all' do
+  st, shop = shop_setup(0, { 3 => 100 })
+  st.party.gain_item(3, 2)
+  ok !shop.sell(3, 3)
+  eq 0, st.party.gold
+  eq 2, st.party.item_count(3), 'the items are untouched'
+end
+
+check 'a zero or negative quantity is not a transaction' do
+  st, shop = shop_setup(500, { 3 => 100 })
+  ok !shop.buy(3, 0)
+  ok !shop.buy(3, -2), 'a negative count cannot mint gold'
+  eq 500, st.party.gold
+  ok !shop.did_transaction
+end
+
 check 'Shop sellable_items lists only held, priced goods in id order' do
   st, shop = shop_setup(0, { 3 => 100, 5 => 40, 8 => 0 })
   st.party.gain_item(8, 1) # price 0 -> not sellable

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6756,6 +6756,71 @@ check 'Game::Enemy decodes its action pattern off the database row' do
      'and the combatant carries it into the fight'
 end
 
+# -- battle backdrop resolution (map tree backdrop_type) -----------------------
+
+# One map-tree node's backdrop settings.
+class FakeMapNode
+  attr_accessor :backdrop_type, :backdrop_file, :parent_map_id
+  def initialize(type, file = '', parent = 0)
+    @backdrop_type = type; @backdrop_file = file; @parent_map_id = parent
+  end
+end
+
+check 'backdrop type 2 uses the map own file, whatever the terrain says' do
+  props = { 1 => FakeMapNode.new(2, 'black') }
+  eq 'black', Game::Backdrop.name_for(1, props, 'Grassland')
+end
+
+check 'backdrop type 1 uses the terrain backdrop' do
+  props = { 1 => FakeMapNode.new(1, 'ignored') }
+  eq 'Grassland', Game::Backdrop.name_for(1, props, 'Grassland')
+  eq '', Game::Backdrop.name_for(1, props, ''), 'and nothing when the terrain names none'
+end
+
+check 'backdrop type 0 inherits from the parent map' do
+  props = { 1 => FakeMapNode.new(2, 'cave'),
+            2 => FakeMapNode.new(0, '', 1) }
+  eq 'cave', Game::Backdrop.name_for(2, props, 'Grassland'), 'the parent pins a file'
+end
+
+check 'backdrop inheritance walks more than one level' do
+  props = { 1 => FakeMapNode.new(2, 'boss'),
+            2 => FakeMapNode.new(0, '', 1),
+            3 => FakeMapNode.new(0, '', 2) }
+  eq 'boss', Game::Backdrop.name_for(3, props, 'Grassland')
+end
+
+check 'an inherited terrain type resolves to the terrain, not the parent file' do
+  props = { 1 => FakeMapNode.new(1, 'unused'),
+            2 => FakeMapNode.new(0, '', 1) }
+  eq 'Desert', Game::Backdrop.name_for(2, props, 'Desert')
+end
+
+check 'a map inheriting from the root falls back to the terrain' do
+  props = { 1 => FakeMapNode.new(0, '', 0) }   # parent 0 = the tree root
+  eq 'Snow Field', Game::Backdrop.name_for(1, props, 'Snow Field')
+end
+
+check 'an unknown map id falls back to the terrain' do
+  eq 'Swamp', Game::Backdrop.name_for(7, { 1 => FakeMapNode.new(2, 'x') }, 'Swamp')
+  eq 'Swamp', Game::Backdrop.name_for(1, nil, 'Swamp'), 'and so does having no tree'
+end
+
+check 'a looping map tree ends at the terrain instead of hanging' do
+  props = { 1 => FakeMapNode.new(0, '', 2),
+            2 => FakeMapNode.new(0, '', 1) }   # 1 -> 2 -> 1 -> ...
+  eq 'Forest1', Game::Backdrop.name_for(1, props, 'Forest1')
+end
+
+check 'a map that parents itself ends at the terrain' do
+  eq 'Ruins1', Game::Backdrop.name_for(1, { 1 => FakeMapNode.new(0, '', 1) }, 'Ruins1')
+end
+
+check 'a node missing its fields is treated as inheriting' do
+  bare = Struct.new(:nothing).new(0)
+  eq 'Wasteland', Game::Backdrop.name_for(1, { 1 => bare }, 'Wasteland')
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1455,7 +1455,13 @@ check 'Open Shop scene: buying then leaving runs the Transaction branch' do
   st.instance_variable_set(:@party, ShopStubParty.new(500))
   3.times { scene.update } # the shop opens straight to the buy list (buy-only)
   ok !st.switches[1] && !st.switches[2], 'still shopping'
-  RGSS::Input.triggered = [RGSS::Input::C] # buy the first good (id 3 @ 100)
+  # Picking a good opens the quantity counter; a second confirm commits it.
+  RGSS::Input.triggered = [RGSS::Input::C] # select the first good (id 3 @ 100)
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  eq 500, st.party.gold, 'nothing is spent just by opening the counter'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the default quantity of 1
   scene.update
   RGSS::Input.triggered = []
   scene.update
@@ -1466,6 +1472,120 @@ check 'Open Shop scene: buying then leaving runs the Transaction branch' do
   scene.update # the Transaction branch runs
   ok st.switches[1], 'the Transaction branch ran (a purchase happened)'
   ok !st.switches[2], 'the No Transaction branch was skipped'
+end
+
+
+# Open a buy-only shop stocking goods 3 (100g) and 5, with `gold` on hand, and
+# advance to the quantity counter for the first good.
+def shop_quantity_scene(gold)
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3, 5], indent: 0),
+    ECmd.new(ic::SHOP_END, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(gold))
+  3.times { scene.update }
+  press(scene, RGSS::Input::C) # select the first good -> the counter
+  [scene, st]
+end
+
+# Send one triggered button and let the scene settle.
+def press(scene, button)
+  RGSS::Input.triggered = [button]
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+end
+
+check 'Open Shop scene: the quantity counter opens on a chosen good' do
+  scene, _st = shop_quantity_scene(500)
+  shop = scene.instance_variable_get(:@shop)
+  eq :quantity, shop[:screen], 'the counter is up'
+  eq 1, shop[:quantity][:count], 'starting at one'
+  eq 3, shop[:quantity][:id]
+  eq 5, shop[:quantity][:max], '500 gold buys five at 100'
+end
+
+check 'Open Shop scene: the counter steps by one and clamps to its bounds' do
+  scene, _st = shop_quantity_scene(500)
+  shop = scene.instance_variable_get(:@shop)
+  press(scene, RGSS::Input::UP)
+  eq 2, shop[:quantity][:count]
+  press(scene, RGSS::Input::DOWN)
+  eq 1, shop[:quantity][:count]
+  press(scene, RGSS::Input::DOWN)
+  eq 1, shop[:quantity][:count], 'never below one'
+  5.times { press(scene, RGSS::Input::UP) }
+  eq 5, shop[:quantity][:count], 'never past what the party can afford'
+end
+
+check 'Open Shop scene: the counter steps by ten on the horizontal axis' do
+  scene, _st = shop_quantity_scene(999_999)
+  shop = scene.instance_variable_get(:@shop)
+  eq 99, shop[:quantity][:max], 'rich enough to hit the item cap'
+  press(scene, RGSS::Input::RIGHT)
+  eq 11, shop[:quantity][:count], '1 + 10'
+  press(scene, RGSS::Input::LEFT)
+  eq 1, shop[:quantity][:count]
+  20.times { press(scene, RGSS::Input::RIGHT) }
+  eq 99, shop[:quantity][:count], 'clamped at the cap'
+end
+
+check 'Open Shop scene: confirming the counter buys the whole stack at once' do
+  scene, st = shop_quantity_scene(500)
+  press(scene, RGSS::Input::UP)
+  press(scene, RGSS::Input::UP)   # three
+  press(scene, RGSS::Input::C)
+  eq 200, st.party.gold, '500 - 3*100'
+  eq 3, st.party.item_count(3), 'three bought in one confirm'
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen], 'and it returns to the buy list'
+end
+
+check 'Open Shop scene: cancelling the counter buys nothing' do
+  scene, st = shop_quantity_scene(500)
+  press(scene, RGSS::Input::UP)
+  press(scene, RGSS::Input::B)
+  eq 500, st.party.gold, 'no gold spent'
+  eq 0, st.party.item_count(3)
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen], 'back on the buy list'
+end
+
+check 'Open Shop scene: the counter sells a whole stack too' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # mode 2 = sell-only, so the shop opens straight onto the sell list.
+  auto.event_commands = [
+    ECmd.new(ic::OPEN_SHOP, [2, 0, 0, 0, 3], indent: 0),
+    ECmd.new(ic::SHOP_END, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(0))
+  st.party.gain_item(3, 5)
+  3.times { scene.update }
+  press(scene, RGSS::Input::C)          # pick the held item -> the counter
+  shop = scene.instance_variable_get(:@shop)
+  eq :quantity, shop[:screen]
+  eq :sell, shop[:quantity][:mode], 'selling, not buying'
+  eq 5, shop[:quantity][:max], 'bounded by what is held'
+  press(scene, RGSS::Input::UP)
+  press(scene, RGSS::Input::UP)         # three
+  press(scene, RGSS::Input::C)
+  eq 150, st.party.gold, '3 * half of 100'
+  eq 2, st.party.item_count(3)
+end
+
+check 'Open Shop scene: an unaffordable good never opens the counter' do
+  scene, st = shop_quantity_scene(50)   # good 3 costs 100
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen], 'still on the list'
+  ok shop[:quantity].nil?, 'no counter for something out of reach'
+  eq 50, st.party.gold
 end
 
 check 'Open Shop scene: leaving without buying runs the No Transaction branch' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2327,6 +2327,26 @@ check 'Enemy Encounter scene: draws a battler sprite per enemy, hidden on death'
   ok sprites.all? { |s| !s.visible }, 'a defeated enemy sprite is hidden'
 end
 
+check 'Enemy Encounter scene: a monster that leaves the field is not drawn' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_to_command(scene)
+  sprites = ui[:enemy_sprites]
+  ok sprites[0].visible, 'drawn to begin with'
+  # Out of play without being dead — an enemy that ran (its own Escape action or
+  # a page's Force Flee), which used to stay on screen because visibility keyed
+  # off `dead?` alone.
+  ui[:foes][0].hidden = true
+  scene.send(:refresh_battle_sprites)
+  ok !sprites[0].visible, 'a monster that fled is taken off the field'
+  ok !ui[:foes][0].dead?, 'without counting as a kill'
+  ok sprites[1].visible, 'its companion is untouched'
+end
+
 # -- headless title auto-select (--rpg2k_new_game / --rpg2k_continue) ---------
 #
 # Both flags exist so a headless run can leave the title screen without input:

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2736,6 +2736,29 @@ check 'a hidden troop member is not targetable until it is revealed' do
   ok ui[:enemy_sprites][1], 'with a sprite built for it'
 end
 
+check 'a transformed monster is redrawn with its new battler graphic' do
+  scene, _st = battle_scene_with_pages(nil)
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :command
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  before = ui[:enemy_sprites][0]
+  ok before, 'the monster is on the field'
+  # What Game::Battle's transform action does to the combatant.
+  ui[:foes][0].battler_name = 'Dragon'
+  ui[:foes][0].name = 'Dragon'
+  scene.send(:refresh_battle_sprites)
+  ok !ui[:enemy_sprites][0].equal?(before), 'its sprite is rebuilt'
+  eq 'Dragon', ui[:sprite_names][0], 'and tracked against the new battler'
+  ok ui[:enemy_sprites][0].visible, 'still on the field'
+  # A second refresh with nothing changed must not churn the sprite again.
+  same = ui[:enemy_sprites][0]
+  scene.send(:refresh_battle_sprites)
+  ok ui[:enemy_sprites][0].equal?(same), 'an unchanged battler is left alone'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
Four self-contained RPG2000 changes, each picked by measuring what the two test-bed games actually use. Every suite passes: **479 logic / 133 scene / 36 render** checks plus a clean parse of 1099 maps.

---

## 1. Enemies run their 行動パターン instead of only ever attacking

Each database enemy row carries an action pattern (chunk 42) of conditioned, rating-weighted entries. The schema has parsed it for a long time but nothing read it, so **every enemy in every fight performed a plain basic attack**.

That hid a lot:

| | enemies | actions | **skills** | basic |
|---|---|---|---|---|
| Nepheshel 2.06 | 300 | 656 | **357** | 299 |
| mtf-meido-action | 115 | 303 | **153** | 150 |

**510 of 959 enemy actions — over half — are skills that could never fire.** It also explains a gap listed separately in the TODO: states could be inflicted by the party but never by a monster, because swinging was the only thing a monster did.

`Game::EnemyAction` decodes the table and `Game::Battle#choose_enemy_action` picks from it each turn — a port of EasyRPG's rating-based algorithm, which keeps the entries whose condition holds, finds the best rating and drops everything more than 10 below it before picking weighted by the remainder. So a monster's behaviour shifts through a fight as its preferred moves stop qualifying. All eight condition types resolve; an unknown type stays out of the running rather than firing unchecked.

Every kind executes. A **skill** goes through the same pipeline the party casts with, so it is costed against SP, elementally scaled, accuracy-rolled and **inflicts its states** — closing the enemy-cast gap — and an ally-scoped one heals a fellow monster. A **transformation** re-points the combatant at another enemy row. The basic actions cover attack, dual attack, defend (expiring at that enemy's next turn), observe, charge (doubling the next blow, with a critical taking precedence, then spent), self-destruction (`atk - def/2` across the party, killing the caster), escape and do-nothing. An action's post-run switch flip is applied, so a monster's move can drive the troop's battle-event pages.

The selection threshold, self-destruct formula and charge rule come from the EasyRPG sources rather than guesswork.

`Game::Battle` stays database-free — it reaches the outside world through a new injected `Game::EnemyAi`. Without one an enemy falls back to plain attacking, so all pre-existing seeded fixtures are unchanged. Architecture recorded in **ADR 0029**.

**Also fixes a real defect this exposed:** the battle screen keyed sprite visibility off `dead?` alone, so a monster that fled — or one flagged invisible at troop setup — stayed drawn, even though the target cursor already excluded it. That bug predates this work.

Verified on real data: all 415 enemies across both games decode a pattern, and running **every** troop (157 and 88 fights) completes with zero errors, with **1980 and 1193 skill casts** now landing where there were none.

## 2. Battles are fought over the game's own backdrop

Every fight used the same flat dark field. The `Backdrop/<name>` loader already existed — it just never had a name at the *start* of a fight.

RPG2000 keeps this on the **map-tree node**, not the map, as a tri-state `backdrop_type`: 親マップと同じ (inherit), 地形で指定 (the terrain names it), 指定する (this map pins a file). I confirmed the enum against liblcf rather than inferring it, though the data had already suggested it.

**The inheriting case is the common one and the walk earns its keep.** 491 of Nepheshel's 537 maps are type 0. Resolving every map in both games:

- **Nepheshel** — 475 maps reach their `"black"` interior backdrop *purely through inheritance*, plus one pinned boss backdrop. Without the parent walk all 491 would fall back to the flat void.
- **mtf-meido-action** — all 13 maps take the terrain branch instead (Grassland / Desert / Snow Field / …), which Nepheshel never does since it names no terrain backdrops at all.

The two games exercise opposite branches. The walk is bounded and cycle-safe, so a looping tree ends at the terrain rather than hanging the battle — covered by self-parenting and 1→2→1 tests.

Also closes the loose end from part 1: a **transformed monster is now redrawn** with the battler it became, and an unchanged battler is left alone so the field doesn't churn.

## 3. The last unaccounted-for map chunks

Six top-level chunks in real `.lmu` files had no schema entry — 42, 50, 60, 61, 62, 90. The TODO guessed "save/encounter/parallax metadata". **They are not**: they are the RPG2003 random dungeon-generator block plus the 2k3e save counter.

The wiki doesn't document them, so ids/types/defaults come from liblcf — but two checks against real bytes did the actual work:

- **Chunk 62 read as shorts** gives ordinary tile ids (49 lower-layer, 10000/10001/10006/10007 upper-layer); as int32 it gives numbers in the millions. That pins the element width down — an int32 misreading wouldn't error, it would just be silently wrong.
- **The fields mtf-meido-action omits are exactly those already at their liblcf default** (`generator_width` 4, the six `true` flags) — what an eliding writer produces, an independent confirmation of the defaults.

Chunk 90 is a BER int (593 on the first map), not the little-endian short it superficially looks like.

`lcf_testbed_check.rb` now asserts the block's shape on every map. **I verified the guard bites** by mis-declaring chunk 62 as int32 and watching it fail on both count and range before restoring it.

## 4. The shop asks how many

Buying twenty potions meant twenty confirms. `Game::Shop` gained `max_buy` / `max_sell` — bounded by whichever of affordability, the 99-item cap and the party's holdings runs out first, with a price-0 good limited by the cap alone rather than dividing by zero. `buy` / `sell` take a count defaulting to 1, so existing callers are untouched.

Two properties worth noting, both asserted: transactions are **all-or-nothing** (asking for more than allowed trades nothing rather than quietly trading fewer, so no path can overspend), and a **zero or negative count is refused** rather than minting gold.

Scene-side, picking an item opens a counter: UP/DOWN by one, RIGHT/LEFT by ten — the coarse step goes on the horizontal axis because that's what RPG_RT does, making a 99-stack a few presses instead of ninety-nine.

**One deliberate behaviour change:** an existing scene test that bought on a single confirm now presses twice, and additionally asserts nothing is spent by merely opening the counter.

Chosen over the other open gap here — Move Event vehicle targets — because neither test bed contains a *single* vehicle reference, while Nepheshel opens 10 shops.

---

## Not included, deliberately

I investigated the **screen tint** (night/cave scenes currently get only a black overlay approximating darkening) and found the previous attempt had taken the wrong path: it used `Bitmap#tone_blt` plus per-frame `Sprite#bitmap=` swaps, when `Sprite#tone=` and `Viewport#tone=` already exist and re-composite properly via `spr_bind_display`.

**I did not ship a fix.** There's no SDL2 in this environment, so I can't build the native binary — and this is exactly a change whose failure mode is "code looks right, screen doesn't change". That is what happened last time and was correctly reverted; guessing twice would be worse. Recording the lead here rather than in the TODO, since it's unverified: if someone picks this up, `Sprite#tone=` / `Viewport#tone=` looks more promising than the `tone_blt` path the TODO currently points at.

## Testing

```
rpg2k logic check:  479 checks passed
rpg2k scene check:  133 checks passed
rpg2k render check:  36 checks passed
lcf testbed check:  1099 maps, 22858 events, 116042 move commands — clean
```

`scripts/analyze_game.rb` gains `--enemies`, reporting a game's action patterns the way `--troops` reports its battle pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_