### PR TITLE
Make MZ actually draw: the WebGL wrapper was dropping its pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,16 @@
   lands in `Scene_Battle`. MZ's save path is a **promise chain** (JsonEx → pako
   → localforage) rather than MV's synchronous call, so the probe starts it and
   polls until it settles, then re-enters the map the way `Scene_Load` does
+- All of that is **on screen**, not just in the scene graph: the title and its
+  command window, the map with the player sprite and the touch UI, message
+  windows with their text, and the party menu over a blurred map background. It
+  used to draw only the tilemap, because two calls in the native WebGL wrapper
+  quietly dropped their data — `texSubImage2D` (a no-op, so every bitmap
+  redrawn after its first upload was lost: window contents, text, the tile
+  atlas) and `bufferData` with a bare `ArrayBuffer`, which is what PIXI's sprite
+  batcher uploads, so every batched sprite drew from an empty vertex buffer.
+  Both are covered at the pixel level on the real EGL backend by
+  `mruby-mvjs/test/gl_test.rb`
 - The MZ engine is not redistributable (unlike MV's MIT corescript), so
   `data/mz-sample` commits only an authored database and art —
   `scripts/gen-mz-sample.py` writes both — and

--- a/changelog.d/mz-webgl-sprite-upload.fixed.md
+++ b/changelog.d/mz-webgl-sprite-upload.fixed.md
@@ -1,0 +1,23 @@
+- **RPG Maker MZ now actually draws.** The engine booted, played and presented
+  frames, but everything except the tilemap came out blank — no title screen, no
+  characters, no windows, no text. Two gaps in the native WebGL wrapper
+  (`mruby-mvjs/src/mvwebgl.cxx`) were swallowing the pixels:
+  - `texSubImage2D` was a no-op. PIXI re-uploads a texture whose size has not
+    changed with it rather than `texImage2D`, so **every bitmap redrawn after
+    its first upload** was lost — window contents, rendered text, and the tile
+    pages rmmz's `Tilemap` sub-uploads into its 2048×2048 atlas. Both overloads
+    (sized/typed-array and canvas/image source) now reach GL.
+  - `bufferData`/`bufferSubData` accepted only a typed-array *view*, but WebGL's
+    `BufferSource` is `ArrayBufferView | ArrayBuffer`, and PIXI v5's sprite
+    batcher uploads its interleaved vertex block as the bare `ArrayBuffer`
+    behind its views (`ViewableBuffer.rawBinaryData`). That upload silently
+    became zero-length, so every batched sprite drew from an empty vertex
+    buffer — degenerate triangles, no fragments — which is exactly why the
+    tilemap (rmmz's own renderer, with its own geometry) was the only thing on
+    screen.
+
+  MZ now renders its title screen and command window, the map with the player
+  sprite and touch UI, message windows with their text, and the full party menu
+  over a blurred map background. Both fixes are covered at the pixel level on
+  the real EGL backend by `mruby-mvjs/test/gl_test.rb`, and `--mz_battle_test`
+  now waits for `Scene_Battle`'s fade-in before capturing its screenshot.

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -325,11 +325,55 @@ JavaScript loads and interprets the JSON.
          advances while the scene is inactive. rmmz's `command301` takes the same
          `[type, troopId, canEscape, canLose]` parameters as rmmv's, so the
          injected command list is shared in shape with the MV probe.
-      No native gap turned up this time: the battle's encounter effect snapshots
-      the screen through `Bitmap.snap` → PIXI's `extract.canvas`, which reads the
-      FBO back with `gl.readPixels` and writes it through the canvas bridge's
-      `getImageData`/`putImageData` — a path the boot already exercised, since
-      `Scene_Title.terminate` snaps for the menu background on every New Game.
+      No native gap turned up in the *probes*: the battle's encounter effect
+      snapshots the screen through `Bitmap.snap` → PIXI's `extract.canvas`, which
+      reads the FBO back with `gl.readPixels` and writes it through the canvas
+      bridge's `getImageData`/`putImageData` — a path the boot already exercised,
+      since `Scene_Title.terminate` snaps for the menu background on every New
+      Game. Reading the frames those probes captured is what found the next two.
+    - **M6.3e — the frames were empty (landed).** Every probe above passed while
+      the captured PNGs were **blank**: the scene graph was right and nothing but
+      the tilemap reached the framebuffer. Two calls in the wrapper accepted
+      their arguments and threw the pixels away:
+      1. **`texSubImage2D` was a no-op.** PIXI re-uploads a texture whose
+         dimensions have not changed with `texSubImage2D` rather than
+         `texImage2D`, so the *first* upload of a `Bitmap` (usually while it is
+         still blank) was the only one that ever reached GL. Everything a game
+         paints after that — window contents, rendered text, the tileset pages
+         rmmz's `Tilemap` sub-uploads into its 2048×2048 atlas — was dropped.
+         Both overloads are implemented now, the sized/typed-array one and the
+         canvas/image-source one.
+      2. **`bufferData` rejected a bare `ArrayBuffer`.** WebGL's `BufferSource`
+         is `ArrayBufferView | ArrayBuffer`; the byte extractor (`view_bytes`)
+         handled only views, and PIXI v5's sprite batcher uploads its whole
+         interleaved vertex block as the raw `ArrayBuffer` behind its views
+         (`ViewableBuffer.rawBinaryData`). The upload silently became
+         **zero-length**, so every batched sprite drew from an empty vertex
+         buffer: degenerate triangles, no fragments, no GL error. That is
+         precisely why the tilemap was the only visible thing — rmmz's `Tilemap`
+         is a separate `ObjectRenderer` with its own geometry, uploaded from a
+         `Float32Array` view.
+
+      How it was found is worth keeping, because both failures are invisible to
+      every check that stops at "did it run": the probes reported success, the
+      draws were issued, `glGetError` stayed 0, the shaders compiled and PIXI's
+      own attribute wiring (locations, strides, offsets, normalisation) read back
+      correct. Forcing the batch fragment shader to emit solid red and seeing
+      *nothing* was what proved the fragments never existed, which pointed at the
+      vertex stage; logging the actual byte counts at every `bufferData` /
+      `bufferSubData` then showed the batcher's vertex uploads going in at
+      **0 bytes** while its index uploads went in at 48. The lesson is the same
+      one M6.3c drew about stubs, one level further out: **a screenshot nobody
+      reads is not evidence.** `mruby-mvjs/test/gl_test.rb` now asserts both at
+      the pixel level on the real EGL backend, and each test was checked to fail
+      with the fix reverted.
+
+      With both fixed, MZ draws its title screen and command window, the map with
+      the player sprite and touch UI, message windows with their text, and the
+      party menu over a blurred map background. The battle screenshot waits for
+      `Scene_Battle`'s fade-in before capturing; the bed's own battle frame stays
+      near-black because the authored sample ships no battler art or battleback,
+      the same reason MV runs its battle smoke against a real downloaded game.
 
   **Concrete boot map (verified by running the engine on the host).** MZ's boot
   differs from MV's in more than the renderer. Driving the shared host through a

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -887,10 +887,24 @@ class MZ
     $stderr.puts "[MZ] audio test error: #{e.message}"
   end
 
+  # Frames to let run before capturing — a couple of seconds, enough for the
+  # boot to reach a scene and its images to load and draw.
+  SHOT_DELAY_FRAMES = 120
+
+  # Extra frames to run after the battle probe reports, before capturing. The
+  # probe fires the moment `Scene_Battle` exists, and the scene starts faded
+  # out (`startFadeIn`), so shooting on arrival photographs a black screen.
+  BATTLE_SHOT_GRACE_FRAMES = 90
+
   # If a screenshot path was requested (`--mz_screenshot`), write the presented
-  # WebGL frame to it once, a couple of seconds in — enough for the boot to
-  # reach a scene and its images to load and draw. Used to capture the visual
+  # WebGL frame to it once, a couple of seconds in. Used to capture the visual
   # output in CI; a no-op during normal play (no path configured).
+  #
+  # A battle probe also has to have finished, plus its fade-in: the encounter
+  # effect, its flash and `Scene_Battle`'s own fade take longer than the fixed
+  # delay, so capturing on frame count alone photographs the fade — a black
+  # frame — rather than the battle the run is about. Both waits are bounded (the
+  # probe gives up after BATTLE_PROBE_FRAMES), so this cannot wait forever.
   def maybe_screenshot
     return if @shot_taken
 
@@ -902,7 +916,8 @@ class MZ
     return if path.nil? || path.empty?
 
     @frames = (@frames || 0) + 1
-    return if @frames < 120
+    return if @frames < SHOT_DELAY_FRAMES
+    return if battle_test_troop > 0 && !battle_shot_ready?
 
     @shot_taken = true
     handle = mz_gl_handle
@@ -910,6 +925,15 @@ class MZ
     $stderr.puts "[MZ] screenshot #{ok ? "saved" : "failed"}: #{path}"
   rescue StandardError => e
     $stderr.puts "[MZ] screenshot error: #{e.message}"
+  end
+
+  # Has the battle probe reported *and* had BATTLE_SHOT_GRACE_FRAMES to fade in?
+  # Latches the frame the probe finished on, so the grace period is counted from
+  # there rather than from the start of the run.
+  def battle_shot_ready?
+    return false unless @battle_test_done
+    @battle_done_frame ||= @frames
+    @frames - @battle_done_frame >= BATTLE_SHOT_GRACE_FRAMES
   end
 
   # The on-screen surface MZ's WebGL frame is presented onto: one full-screen

--- a/mruby-mvjs/src/mvwebgl.cxx
+++ b/mruby-mvjs/src/mvwebgl.cxx
@@ -88,10 +88,20 @@ std::vector<double> num_array(JSContext* ctx, JSValueConst v) {
   return out;
 }
 
-// Raw bytes of a TypedArray/ArrayBuffer view, for bufferData / texImage2D /
+// Raw bytes of a WebGL `BufferSource`, for bufferData / texImage2D /
 // readPixels where the byte layout (Float32, Uint16, ...) must be preserved
 // rather than coerced through double. `*hold` keeps the backing ArrayBuffer
-// alive; the caller frees it after the GL call. Returns nullptr for non-views.
+// alive; the caller frees it after the GL call. Returns nullptr for anything
+// that is neither a view nor a buffer.
+//
+// **A bare `ArrayBuffer` counts.** WebGL's `BufferSource` is
+// `ArrayBufferView | ArrayBuffer`, and PIXI v5 uploads the sprite batcher's
+// whole vertex block as the raw `ArrayBuffer` behind its interleaved views
+// (`ViewableBuffer.rawBinaryData`). Handling only views made that upload
+// silently zero-length, so every batched sprite drew from an empty vertex
+// buffer — degenerate triangles, no fragments — which is why MZ rendered its
+// tilemap (a separate rmmz renderer with its own geometry) and nothing else:
+// no characters, no windows, no text.
 uint8_t* view_bytes(JSContext* ctx,
                     JSValueConst v,
                     size_t* out_len,
@@ -100,12 +110,23 @@ uint8_t* view_bytes(JSContext* ctx,
   JSValue ab = JS_GetTypedArrayBuffer(ctx, v, &off, &len, &bpe);
   if (JS_IsException(ab)) {
     JS_FreeValue(ctx, ab);
-    // A non-view argument set a TypeError; clear it so it can't contaminate the
-    // next eval (the WebGL callers only ever pass views or null).
+    // Not a view. Clear the TypeError it set so it cannot contaminate the next
+    // eval, then try the value itself as an ArrayBuffer.
     JS_FreeValue(ctx, JS_GetException(ctx));
-    *hold = JS_UNDEFINED;
-    *out_len = 0;
-    return nullptr;
+    size_t raw = 0;
+    uint8_t* p = JS_GetArrayBuffer(ctx, &raw, v);
+    if (!p) {
+      // Neither view nor buffer (e.g. null): clear again and report nothing.
+      JS_FreeValue(ctx, JS_GetException(ctx));
+      *hold = JS_UNDEFINED;
+      *out_len = 0;
+      return nullptr;
+    }
+    // JS_GetArrayBuffer borrows; the caller frees `*hold`, so dup to keep the
+    // buffer alive across the GL call exactly as the view path does.
+    *hold = JS_DupValue(ctx, v);
+    *out_len = raw;
+    return p;
   }
   size_t sz = 0;
   uint8_t* p = JS_GetArrayBuffer(ctx, &sz, ab);
@@ -929,6 +950,57 @@ JSValue js_gl_tex_image_2d_canvas(JSContext* ctx,
   return JS_UNDEFINED;
 }
 
+// texSubImage2D(target, level, xoffset, yoffset, w, h, format, type,
+//               ArrayBufferView|null) — the sized/typed-array overload, the
+// counterpart of js_gl_tex_image_2d. A null view is a no-op rather than a GL
+// call: unlike texImage2D (where null *allocates* storage) a null sub-upload
+// has no meaning, and GLES2 would reject it.
+JSValue js_gl_tex_sub_image_2d(JSContext* ctx,
+                               JSValueConst,
+                               int argc,
+                               JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)))
+    return JS_UNDEFINED;
+  if (argc <= 9 || JS_IsNull(argv[9]) || JS_IsUndefined(argv[9]))
+    return JS_UNDEFINED;
+  JSValue hold;
+  size_t len = 0;
+  uint8_t* p = view_bytes(ctx, argv[9], &len, &hold);
+  if (p)
+    glTexSubImage2D(
+        static_cast<GLenum>(gi(ctx, argc, argv, 1)), gi(ctx, argc, argv, 2),
+        gi(ctx, argc, argv, 3), gi(ctx, argc, argv, 4), gi(ctx, argc, argv, 5),
+        gi(ctx, argc, argv, 6), static_cast<GLenum>(gi(ctx, argc, argv, 7)),
+        static_cast<GLenum>(gi(ctx, argc, argv, 8)), p);
+  JS_FreeValue(ctx, hold);
+  return JS_UNDEFINED;
+}
+
+// texSubImage2D from a 2D canvas/image source: write the source's RGBA buffer
+// into an already-allocated texture at (xoffset, yoffset). This is the call
+// that carries most of MZ's actual pixels: PIXI re-uploads a texture whose
+// dimensions have not changed with texSubImage2D rather than texImage2D, so
+// every bitmap redrawn after its first upload — window contents, rendered text,
+// a Bitmap the game paints into — arrives here, and rmmz's Tilemap fills its
+// 2048x2048 tile atlas by sub-uploading each tileset page into a quadrant of
+// it.
+JSValue js_gl_tex_sub_image_2d_canvas(JSContext* ctx,
+                                      JSValueConst,
+                                      int argc,
+                                      JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)))
+    return JS_UNDEFINED;
+  int cw = 0, ch = 0;
+  const uint8_t* px = mv_canvas_pixels(gi(ctx, argc, argv, 7), &cw, &ch);
+  if (px)
+    glTexSubImage2D(static_cast<GLenum>(gi(ctx, argc, argv, 1)),
+                    gi(ctx, argc, argv, 2), gi(ctx, argc, argv, 3),
+                    gi(ctx, argc, argv, 4), cw, ch,
+                    static_cast<GLenum>(gi(ctx, argc, argv, 5)),
+                    static_cast<GLenum>(gi(ctx, argc, argv, 6)), px);
+  return JS_UNDEFINED;
+}
+
 JSValue js_gl_generate_mipmap(JSContext* ctx,
                               JSValueConst,
                               int argc,
@@ -1380,7 +1452,25 @@ const char* kWebGLPreamble = R"MVJS(
       // Image-element uploads and Y-flip handling: M6.3c.
     }
   };
-  P.texSubImage2D = function () {};  // M6.3c
+  // texSubImage2D has the same two overloads as texImage2D, one argument
+  // shorter (there is no internalformat or border): the 9-argument sized form
+  // with a typed array, and the 7-argument form taking a canvas/image source.
+  // Both matter — see the native side; a no-op here loses every texture update
+  // that follows the first upload, which is most of what MZ draws.
+  P.texSubImage2D = function (target, level, xoff, yoff, a, b, c, d, e) {
+    if (arguments.length >= 9) {
+      // (target, level, xoffset, yoffset, w, h, format, type, pixels)
+      g.__mv_glTexSubImage2D(this.__gl, target, level, xoff, yoff, a, b, c, d, e);
+    } else {
+      // (target, level, xoffset, yoffset, format, type, source)
+      var src = c;
+      if (src && src.__h !== undefined) {
+        g.__mv_glTexSubImage2DCanvas(this.__gl, target, level, xoff, yoff, a, b, src.__h);
+      } else if (src && src.canvas && src.canvas.__h !== undefined) {
+        g.__mv_glTexSubImage2DCanvas(this.__gl, target, level, xoff, yoff, a, b, src.canvas.__h);
+      }
+    }
+  };
   P.generateMipmap = function (t) { g.__mv_glGenerateMipmap(this.__gl, t); };
   P.deleteTexture = function (t) { g.__mv_glDeleteTexture(this.__gl, t); };
 
@@ -1513,6 +1603,8 @@ void mv_install_webgl(JSContext* ctx) {
   reg(ctx, g, "__mv_glTexParameteri", js_gl_tex_parameteri, 4);
   reg(ctx, g, "__mv_glTexImage2D", js_gl_tex_image_2d, 10);
   reg(ctx, g, "__mv_glTexImage2DCanvas", js_gl_tex_image_2d_canvas, 7);
+  reg(ctx, g, "__mv_glTexSubImage2D", js_gl_tex_sub_image_2d, 10);
+  reg(ctx, g, "__mv_glTexSubImage2DCanvas", js_gl_tex_sub_image_2d_canvas, 8);
   reg(ctx, g, "__mv_glGenerateMipmap", js_gl_generate_mipmap, 2);
   reg(ctx, g, "__mv_glDeleteTexture", js_gl_delete_texture, 2);
   reg(ctx, g, "__mv_glCreateFramebuffer", js_gl_create_framebuffer, 1);

--- a/mruby-mvjs/test/gl_test.rb
+++ b/mruby-mvjs/test/gl_test.rb
@@ -296,3 +296,148 @@ assert 'the stencil test masks a draw, the way MZ clips its windows' do
   assert_true parts[1].to_i > 200 # right: drawn
   assert_true parts[0].to_i < 60  # left: masked out
 end
+
+assert 'bufferData accepts a bare ArrayBuffer, the way PIXI uploads a sprite batch' do
+  skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
+
+  # WebGL's `BufferSource` is `ArrayBufferView | ArrayBuffer`, and PIXI v5's
+  # sprite batcher uploads its whole interleaved vertex block as the raw
+  # ArrayBuffer behind its views (`ViewableBuffer.rawBinaryData`). The wrapper
+  # used to read bytes only out of a *view*, so that upload silently became
+  # zero-length and every batched sprite drew from an empty vertex buffer —
+  # degenerate triangles, no fragments. That is why MZ drew its tilemap (rmmz's
+  # own renderer, with its own geometry) and nothing else: no characters, no
+  # windows, no text.
+  #
+  # Reproduce it at the pixel level: write a full-viewport quad through a
+  # Float32Array view but hand `bufferData` the *buffer*, then draw green.
+  out = MV::JS.eval(<<~'JS')
+    (function () {
+      var W = 32, H = 32;
+      var cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+      var gl = cv.getContext('webgl');
+      if (!gl) return 'no-context';
+      function shader(type, src) {
+        var s = gl.createShader(type);
+        gl.shaderSource(s, src); gl.compileShader(s);
+        return gl.getShaderParameter(s, gl.COMPILE_STATUS) ? s : null;
+      }
+      var vs = shader(gl.VERTEX_SHADER,
+        '#version 100\nattribute vec2 aPos;\nvoid main(){ gl_Position = vec4(aPos,0.0,1.0); }\n');
+      var fs = shader(gl.FRAGMENT_SHADER,
+        '#version 100\nprecision mediump float;\nvoid main(){ gl_FragColor = vec4(0.0,1.0,0.0,1.0); }\n');
+      if (!vs || !fs) return 'shader-failed';
+      var p = gl.createProgram();
+      gl.attachShader(p, vs); gl.attachShader(p, fs);
+      gl.bindAttribLocation(p, 0, 'aPos');
+      gl.linkProgram(p);
+      if (!gl.getProgramParameter(p, gl.LINK_STATUS)) return 'link-failed';
+      gl.useProgram(p);
+      gl.viewport(0, 0, W, H);
+      gl.clearColor(0.0, 0.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+
+      // The data is written through a view; the *buffer* is what is uploaded.
+      var view = new Float32Array([-1,-1, 1,-1, -1,1, 1,-1, 1,1, -1,1]);
+      var buf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.bufferData(gl.ARRAY_BUFFER, view.buffer, gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      gl.finish();
+
+      var px = new Uint8Array(4);
+      gl.readPixels(W / 2, H / 2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px);
+      return px[0] + ',' + px[1] + ',' + px[2];
+    })()
+  JS
+
+  assert_false ["no-context", "shader-failed", "link-failed"].include?(out)
+  rgb = out.split(",").map { |v| v.to_i }
+  assert_equal 3, rgb.size
+  assert_true rgb[1] > 200 # green: the quad drew, so the buffer carried data
+  assert_true rgb[0] < 60
+end
+
+assert 'texSubImage2D updates a texture after its first upload' do
+  skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
+
+  # PIXI re-uploads a texture whose dimensions have not changed with
+  # texSubImage2D rather than texImage2D, so every bitmap redrawn after its
+  # first upload arrives there — window contents, rendered text, a Bitmap the
+  # game paints into — and rmmz's Tilemap fills its tile atlas by sub-uploading
+  # each tileset page into a quadrant. The wrapper used to accept the call and
+  # throw it away, which left all of those showing whatever the texture held on
+  # its first upload (usually nothing).
+  #
+  # Upload a red 2x2 texture, overwrite it with green through texSubImage2D,
+  # then sample it onto a full-viewport quad.
+  out = MV::JS.eval(<<~'JS')
+    (function () {
+      var W = 32, H = 32;
+      var cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+      var gl = cv.getContext('webgl');
+      if (!gl) return 'no-context';
+      function shader(type, src) {
+        var s = gl.createShader(type);
+        gl.shaderSource(s, src); gl.compileShader(s);
+        return gl.getShaderParameter(s, gl.COMPILE_STATUS) ? s : null;
+      }
+      var vs = shader(gl.VERTEX_SHADER,
+        '#version 100\nattribute vec2 aPos;\nvarying vec2 vUv;\n' +
+        'void main(){ vUv = aPos * 0.5 + 0.5; gl_Position = vec4(aPos,0.0,1.0); }\n');
+      var fs = shader(gl.FRAGMENT_SHADER,
+        '#version 100\nprecision mediump float;\nvarying vec2 vUv;\n' +
+        'uniform sampler2D uTex;\nvoid main(){ gl_FragColor = texture2D(uTex, vUv); }\n');
+      if (!vs || !fs) return 'shader-failed';
+      var p = gl.createProgram();
+      gl.attachShader(p, vs); gl.attachShader(p, fs);
+      gl.bindAttribLocation(p, 0, 'aPos');
+      gl.linkProgram(p);
+      if (!gl.getProgramParameter(p, gl.LINK_STATUS)) return 'link-failed';
+      gl.useProgram(p);
+      gl.viewport(0, 0, W, H);
+
+      var red = new Uint8Array(2 * 2 * 4);
+      var green = new Uint8Array(2 * 2 * 4);
+      for (var i = 0; i < 4; i++) {
+        red[i * 4] = 255; red[i * 4 + 3] = 255;
+        green[i * 4 + 1] = 255; green[i * 4 + 3] = 255;
+      }
+      var tex = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, red);
+      // The update under test: same size, so this is the call PIXI makes.
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 2, 2, gl.RGBA, gl.UNSIGNED_BYTE, green);
+      gl.uniform1i(gl.getUniformLocation(p, 'uTex'), 0);
+
+      var view = new Float32Array([-1,-1, 1,-1, -1,1, 1,-1, 1,1, -1,1]);
+      var buf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.bufferData(gl.ARRAY_BUFFER, view, gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+      gl.clearColor(0.0, 0.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      gl.finish();
+
+      var px = new Uint8Array(4);
+      gl.readPixels(W / 2, H / 2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px);
+      return px[0] + ',' + px[1] + ',' + px[2];
+    })()
+  JS
+
+  assert_false ["no-context", "shader-failed", "link-failed"].include?(out)
+  rgb = out.split(",").map { |v| v.to_i }
+  assert_equal 3, rgb.size
+  # Green means the sub-upload landed; red means it was dropped and the first
+  # upload is all the texture ever got.
+  assert_true rgb[1] > 200
+  assert_true rgb[0] < 60
+end


### PR DESCRIPTION
Every MZ probe from #368 passed while the frames it captured were **blank**. The scene graph was right and nothing but the tilemap reached the framebuffer, because two calls in the native WebGL wrapper (`mruby-mvjs/src/mvwebgl.cxx`) accepted their arguments and threw the data away.

## The two gaps

**`texSubImage2D` was a no-op.** PIXI re-uploads a texture whose dimensions have not changed with `texSubImage2D` rather than `texImage2D`, so the *first* upload of a `Bitmap` — usually while it is still blank — was the only one that ever reached GL. Everything a game paints after that was lost: window contents, rendered text, and the tileset pages rmmz's `Tilemap` sub-uploads into its 2048×2048 atlas. Both overloads are implemented now, the sized/typed-array one and the canvas/image-source one.

**`bufferData` rejected a bare `ArrayBuffer`.** WebGL's `BufferSource` is `ArrayBufferView | ArrayBuffer`, but `view_bytes` handled only views — and PIXI v5's sprite batcher uploads its whole interleaved vertex block as the raw `ArrayBuffer` behind its views (`ViewableBuffer.rawBinaryData`). That upload silently became **zero-length**, so every batched sprite drew from an empty vertex buffer: degenerate triangles, no fragments, no GL error. Hence the tilemap being the only visible thing — it is a separate `ObjectRenderer` with its own geometry, uploaded from a `Float32Array` view.

With both fixed, MZ draws its title screen and command window, the map with the player sprite and touch UI, message windows with their text, and the party menu over a blurred map background.

## How it was found

Neither failure is visible to a check that stops at "did it run": the probes reported success, the draws were issued, `glGetError` stayed 0, the shaders compiled, and PIXI's own attribute wiring (locations, strides, offsets, normalisation) read back correct. What pinned it down was reading the captured PNGs rather than the pass/fail lines, then:

- forcing the batch fragment shader to emit solid red and seeing **nothing**, which ruled out shading and pointed at the vertex stage;
- logging the actual byte counts at every `bufferData` / `bufferSubData`, which showed the batcher's vertex uploads going in at **0 bytes** while its index uploads went in at 48.

The lesson is the one ADR 0004 M6.3c drew about stubs, one level further out: **a screenshot nobody reads is not evidence.**

## Testing

- `mruby-mvjs/test/gl_test.rb` gains two pixel-level assertions on the real EGL backend — a quad uploaded through a bare `ArrayBuffer`, and a texture overwritten via `texSubImage2D`. Each was checked to **fail with its fix reverted**, so neither is vacuous.
- `cmake --build build -t test` / `ctest`: `mruby_test` passes (1758 assertions). The only failing test is the pre-existing `exe_open`, which needs a downloaded game absent from this environment.
- All five `scripts/mz_boot_check.bash` modes (`play`, `message`, `menu`, `save`, `battle`) pass against `data/mz-sample`, and their captured frames now show real content.
- `--mz_battle_test` now waits for `Scene_Battle`'s fade-in before capturing, so the artifact is the battle rather than the fade. That frame stays near-black on purpose: the authored sample ships no battler art or battleback, the same reason the MV battle smoke runs against a real downloaded game.

## Docs

ADR 0004 gains milestone **M6.3e** recording both gaps and how they were found; README and a `changelog.d/` fragment updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_014B8H5L6jNJqN8HL7WGHbcS)_