### PR TITLE
Event touch from both sides, and draw a picture's tone

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@
   command: every command that can knock the last member out re-checks, as the
   real runtime does, so a damage floor that kills you is fatal. Events start on the action button, on
   player touch (walking into them),
-  on event touch (they walk into the player), auto-start, or run continuously as
+  on event touch (either they walk into the party or the party walks into them —
+  which is how a game's roaming monsters start a fight), auto-start, or run continuously as
   a parallel background process, gated by their page/switch conditions;
   auto-start and parallel common events run too. Pages are re-selected **while
   the map runs**, so setting the switch an event's page 2 waits on turns it into

--- a/changelog.d/rpg2k-event-touch-both-ways.fixed.md
+++ b/changelog.d/rpg2k-event-touch-both-ways.fixed.md
@@ -1,0 +1,12 @@
+- **Walking into an event-touch event now sets it off.** RPG_RT tests the two
+  touch triggers as one set on every player-side path (EasyRPG's
+  `{Trigger_touched, Trigger_collision}` in `Game_Player::Update` /
+  `UpdateMovement`), so the asymmetry is not the one the trigger names suggest:
+  an **event touch** (2) fires whether it walked into the party or the party
+  walked into it, while a **player touch** (1) fires only on the party's own
+  move — the event side checks trigger 2 alone. This build only accepted
+  trigger 1 when the party moved, so a trigger-2 event could be set off solely
+  by walking into *you*. Nepheshel has 9,637 trigger-2 pages (6,912 carrying
+  commands) — its roaming monsters — and 3,972 of them are **stationary**, which
+  can never walk into anything: 1,259 of those carry commands, so that content
+  could not be reached at all.

--- a/changelog.d/rpg2k-picture-tone.added.md
+++ b/changelog.d/rpg2k-picture-tone.added.md
@@ -1,0 +1,17 @@
+- **A picture's tone is drawn.** Show / Move Picture carry four RPG2000 tone
+  channels (red / green / blue / saturation, 0..200 with 100 neutral); they were
+  parsed, moved and saved, but never reached the screen, so a picture asked for
+  at 30 % brightness rendered at full. `Scene::Map` now tones the source through
+  the native `Bitmap#tone_blt` before compositing it, caching the result per
+  image + tone so the software pass runs when the tint changes rather than every
+  frame, and skipping it altogether for a neutral picture. The channel
+  conversion truncates toward zero to match the reference's C++ integer
+  arithmetic rather than Ruby's flooring, and RPG2000's saturation — which
+  counts *down* from 100 to mean less saturated — is inverted into RGSS's grey,
+  which counts up. Measured on the RPG2003 test-bed
+  (`scripts/download-mtf-meido-action.bash`), which leans on pictures far harder
+  than Nepheshel: **128 of its 315 Show Pictures and 17 of its 117 Move Pictures
+  carry a non-default tone**, 95 of them the same heavy darkening and 10 fully
+  black. This uses the path pictures already draw through — a blit into the
+  shared picture bitmap — not the per-frame `Sprite#bitmap=` swap that the
+  map-layer tint attempt found does not reach the display.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -200,8 +200,11 @@ The work below is roughly ordered by the critical path to a walkable game
   item menu. Writing a value already held does not count, so a parallel process
   setting the same flag every frame costs a sweep rather than a rebuild.
   All five start triggers run: **action button**
-  (0), **player touch** (1, walking into the event), **event touch** (2, the
-  event walking into the player), **auto-start** (3) and **parallel** (4, a
+  (0), **player touch** (1, the party walking into the event), **event touch**
+  (2, which fires from **either** side — the event walking into the party *or*
+  the party walking into the event, because RPG_RT tests the two touch triggers
+  as one set on every player-side path while the event side tests only trigger 2),
+  **auto-start** (3) and **parallel** (4, a
   background interpreter per event, driven by `Scene::Map#step_parallels`). A
   page's autonomous move type / custom move route also drives the event at
   runtime (see Movement & collision). The interpreter's *Set Move Route* (Move

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -336,8 +336,19 @@ The work below is roughly ordered by the critical path to a walkable game
   parameter to its target over the duration and its wait flag suspends the
   interpreter (`:picture`) until the move settles; `Scene::Map` composites the
   pictures (id-ordered, zoomed via `stretch_blt`, at their opacity) into a layer
-  above the map and below the message window. Picture **tone** is carried but not
-  yet drawn (needs the same native tone support as the screen tint). **Weather
+  above the map and below the message window. Picture **tone** is **drawn** now:
+  the source is toned through the native `Bitmap#tone_blt` before compositing,
+  cached per image + tone so the software pass runs on a tint change rather than
+  every frame, and skipped entirely for a neutral picture. The channel conversion
+  truncates toward zero to match the reference's C++ integer arithmetic (Ruby's
+  `/` would floor, putting a channel one unit out), and RPG2000's saturation —
+  which counts *down* from 100 to mean less saturated — inverts into RGSS's grey,
+  which counts up. Unlike the map-layer tint this rides the path pictures already
+  draw through (a blit into the shared picture bitmap), not the per-frame
+  `Sprite#bitmap=` swap that attempt found does not reach the display. The
+  RPG2003 test-bed is what justifies it: 128 of its 315 Show Pictures and 17 of
+  its 117 Move Pictures carry a non-default tone, against 1 in all of Nepheshel.
+  **Weather
   Effects** (11070) records the map weather type (none / rain / snow) and strength
   on `Game::State`, and `Scene::Map` now draws it: a screen-sized overlay sprite
   (z 430, above the weather-less tint layer and below the animation layer) onto

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1228,6 +1228,12 @@ class RPG2k
         ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands] ? true : false
       end
 
+      # Whether a trigger is one of the two the party can set off by walking into
+      # the event (see the note in #try_move).
+      def touch_trigger?(trigger)
+        trigger == TRIGGER_PLAYER_TOUCH || trigger == TRIGGER_EVENT_TOUCH
+      end
+
       # Whether (x, y) carries an upper-layer counter tile.
       def counter_tile?(x, y)
         return false if @chipset.nil? || !@map.in_bounds?(x, y)
@@ -4315,9 +4321,16 @@ class RPG2k
           # events (you cannot trigger them from the water / air).
           return unless vehicle_passable?(nx, ny, dir, @state.boarded)
         else
-          # Walking into a player-touch (trigger 1) event runs it instead of moving.
+          # Walking into a touch event runs it instead of moving. **Both** touch
+          # triggers answer here: RPG_RT tests them as one set on every
+          # player-side path (EasyRPG's `{Trigger_touched, Trigger_collision}` in
+          # `Game_Player::Update` / `UpdateMovement`), so the asymmetry is not
+          # the one the trigger names suggest — an "event touch" (2) event fires
+          # whether it walked into the party or the party walked into it, while
+          # a "player touch" (1) fires only on the party's own move (the event
+          # side checks trigger 2 alone, see #move_autonomous).
           touched = event_at(nx, ny)
-          if touched && touched[:trigger] == TRIGGER_PLAYER_TOUCH && touched[:commands]
+          if touched && touch_trigger?(touched[:trigger]) && touched[:commands]
             start_event(touched)
             return
           end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -822,6 +822,9 @@ class RPG2k
         @picture_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
         @picture_sprite.bitmap = @picture_bmp
         @picture_srcs = {}
+        # Toned copies of those sources, keyed by image + tone (see
+        # #toned_picture_src).
+        @picture_tone_cache = {}
       end
 
       # Load (and cache) a picture's source image (Picture/<name>). `transparent`
@@ -4566,9 +4569,65 @@ class RPG2k
         pics.keys.sort.each { |id| draw_picture pics[id], cam_x, cam_y }
       end
 
+      # A picture's RPG2000 tone channel (0..200, 100 neutral) as an RGSS Tone
+      # component (-255..255), the same conversion the screen tint uses.
+      #
+      # The division truncates **toward zero**, not toward negative infinity as
+      # Ruby's `/` would: the reference does this in C++ integer arithmetic, so a
+      # channel of 30 is -178 rather than the -179 flooring gives. One unit of
+      # 255 is invisible, but a rounding rule is worth getting on purpose.
+      def self.tone_channel(v)
+        n = ((v || 100) - 100) * 255
+        n < 0 ? -(-n / 100) : n / 100
+      end
+
+      # Whether a picture asks for any tint at all.
+      def toned?(pic)
+        pic.red != 100 || pic.green != 100 || pic.blue != 100 ||
+          pic.saturation != 100
+      end
+
+      # The picture's source with its tone baked in, cached per (image, tone) so
+      # the software tone pass runs when the tint changes rather than every
+      # frame. `Bitmap#tone_blt` writes to a *separate* destination on purpose —
+      # toning in place would re-tone the same pixels each frame and walk the
+      # image to black — so the scratch is a same-size bitmap per cache entry.
+      #
+      # This rides the path pictures already draw through: the result is blitted
+      # into the shared picture bitmap, which is mutated in place. It is not the
+      # per-frame `Sprite#bitmap=` swap that the map-layer tint attempt found
+      # does not reach the display (see the screen-effects note in docs/TODO.md).
+      def toned_picture_src(pic, src)
+        key = [pic.name, pic.use_transparent_color,
+               pic.red, pic.green, pic.blue, pic.saturation]
+        cached = @picture_tone_cache[key]
+        return cached if cached
+        scratch = Bitmap.new(src.width, src.height)
+        tone = Tone.new(Scene::Map.tone_channel(pic.red),
+                        Scene::Map.tone_channel(pic.green),
+                        Scene::Map.tone_channel(pic.blue),
+                        # RPG2000's saturation runs the other way from RGSS's
+                        # grey: below 100 is *less* saturated, so a value under
+                        # neutral becomes positive desaturation.
+                        Scene::Map.tone_channel(pic.saturation) * -1)
+        scratch.tone_blt src, tone
+        # Bounded so a picture cycling through tones cannot grow it without end;
+        # the oldest entry goes first.
+        @picture_tone_cache.delete(@picture_tone_cache.keys.first) if
+          @picture_tone_cache.size >= PICTURE_TONE_CACHE_MAX
+        @picture_tone_cache[key] = scratch
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] picture ##{pic.id} tone failed, drawn untinted: #{e.message}"
+        nil
+      end
+
+      # How many toned picture variants to keep before evicting the oldest.
+      PICTURE_TONE_CACHE_MAX = 16
+
       def draw_picture(pic, cam_x, cam_y)
         src = picture_src(pic.name, pic.use_transparent_color)
         return unless src
+        src = (toned_picture_src(pic, src) || src) if toned?(pic)
         zw = src.width * pic.zoom / 100
         zh = src.height * pic.zoom / 100
         return if zw <= 0 || zh <= 0

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -503,6 +503,33 @@ check 'player-touch (trigger 1): walking into an event runs it, no move' do
   eq [0, 0], [st.x, st.y], 'player did not step onto the event'
 end
 
+check 'event-touch (trigger 2) also fires when the player walks into it' do
+  # RPG_RT tests both touch triggers as one set on the player's own move — so a
+  # trigger-2 event fires from either side, which is how Nepheshel's roaming
+  # monsters (9,637 trigger-2 pages) start a fight when you walk into them.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 2) # event touch, standing still
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # hold right, into the event at (1,0)
+  6.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[6], 'walking into an event-touch event ran it'
+  eq [0, 0], [st.x, st.y], 'and the party did not step onto it'
+end
+
+check 'an action event is not set off by walking into it' do
+  # The pairing is only the two touch triggers: trigger 0 still needs the button.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 0)
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0])]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6
+  6.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok !st.switches[6], 'an action event ignores being walked into'
+end
+
 check 'event-touch (trigger 2): an event walking into the player runs it' do
   ic = Game::Interpreter::Cmd
   pg = page(x_move_type: Game::MoveType::TOWARD, trigger: 2, frequency: 8)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1549,6 +1549,47 @@ check 'a shown picture renders through the scene and its move advances' do
   eq 60, st.pictures[1].y, 'the picture reached its target'
 end
 
+check 'a toned picture is tinted before it is composited' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  # A darkened picture: RPG2000's 30/30/30/100 is the tone 128 of the RPG2003
+  # test-bed's 315 Show Pictures ask for.
+  st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255,
+                     red: 30, green: 30, blue: 30, saturation: 100)
+  scene.update
+  toned = scene.instance_variable_get(:@picture_tone_cache)
+  ok toned && toned.size == 1, 'the source was toned into a scratch bitmap'
+  _src, tone = toned.values.first.tone_calls.first
+  # (30 - 100) * 255 / 100 = -178 on each colour channel, no desaturation.
+  eq [-178, -178, -178, 0], [tone.red, tone.green, tone.blue, tone.gray]
+
+  # Drawing again reuses the cache rather than re-toning every frame.
+  scene.update
+  eq 1, scene.instance_variable_get(:@picture_tone_cache).size
+  eq 1, toned.values.first.tone_calls.size, 'toned once, not once per frame'
+end
+
+check 'an untinted picture skips the tone pass entirely' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
+  scene.update
+  eq 0, scene.instance_variable_get(:@picture_tone_cache).size,
+     'a neutral tone costs no work'
+end
+
+check 'a picture saturation below neutral desaturates' do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255,
+                     red: 100, green: 100, blue: 100, saturation: 0)
+  scene.update
+  toned = scene.instance_variable_get(:@picture_tone_cache)
+  _src, tone = toned.values.first.tone_calls.first
+  # RPG2000 counts down from 100 to "less saturated"; RGSS counts grey up.
+  eq [0, 0, 0, 255], [tone.red, tone.green, tone.blue, tone.gray]
+end
+
 check 'coloured message text blends with the windowskin swatch when present' do
   scene = new_scene({})
   skin = RGSS::Bitmap.new('System/skin')


### PR DESCRIPTION
Two findings from the sixth and seventh passes of the audit (#366, #369, #370, #371). They are separate changes in separate commits; they share a PR because this session develops on one branch.

## 1. An event-touch event now fires when the party walks into it

The two touch triggers are not the mirror image their names imply.

| | party moves into event | event moves into party |
| --- | --- | --- |
| **player touch** (1) | fires | — |
| **event touch** (2) | **fires** | fires |

RPG_RT tests them as one set on every *player*-side path — EasyRPG's `{Trigger_touched, Trigger_collision}` in `Game_Player::Update` and `UpdateMovement` — while the *event* side tests `Trigger_collision` alone (`Game_Event::CheckEventCollision`).

This build had a strict one-to-one, so a trigger-2 event could be set off **solely by walking into you**, never by you walking into it.

Nepheshel has **9,637 trigger-2 pages** (6,912 carrying commands) — its roaming monsters, and how the game starts nearly every fight. **3,972 are stationary**, which can never walk into anything; **1,259 of those carry commands**, so that content was unreachable outright. The fix is on the player side only; the event side was already right.

## 2. A picture's tone is drawn

Show / Move Picture carry four RPG2000 tone channels (0..200, 100 neutral). They were parsed, eased by a move and saved — but never reached the screen, so a picture asked for at 30 % brightness rendered at full, and one asked for at 0 rendered fully lit.

`Scene::Map` now tones the source through the native `Bitmap#tone_blt` before compositing, cached per image + tone so the software pass runs on a tint change rather than every frame, and skipped entirely for a neutral picture. Two conversion details are deliberate: the channel arithmetic truncates toward zero to match the reference's C++ integer division (Ruby's `/` floors, which puts a channel one unit out), and RPG2000's saturation counts *down* from 100 to mean less saturated, which inverts into RGSS's grey, which counts up.

**This does not use the path that was already tried and dropped.** `docs/TODO.md` records a map-layer tint attempt abandoned because a per-frame `Sprite#bitmap=` swap does not reach the display. Here the toned bitmap is blitted into the shared picture bitmap, which is mutated in place — the route pictures already draw through.

### Why this one is justified by new evidence

Nepheshel barely uses picture tone (1 command in the whole game), which is presumably why it stayed unimplemented. I pulled in the repo's **RPG2003 test-bed** (`scripts/download-mtf-meido-action.bash`) and it has a completely different profile: 479 of its 3,430 commands are picture commands, and **128 of its 315 Show Pictures and 17 of its 117 Move Pictures carry a non-default tone** — 95 of them the same heavy darkening, 10 fully black.

## Two negative results, also worth recording

Both were checked against the data *before* building anything, and both said don't:

- **Random encounters.** All 538 of Nepheshel's maps have an empty encounter list — it is a symbol-encounter game whose fights come from its 5,494 Enemy Encounter commands. The subsystem would have been unexercised by the test-bed.
- **Terrain damage.** Nepheshel's database defines three damaging terrains (two damage floors and a healing floor at −1), but **zero map tiles use them**. Its damage floors are Simulated Attacks instead.

## Verification

`scripts/rpg2k_scene_check.rb` 139 pass (+5 across the two changes), `scripts/rpg2k_logic_check.rb` 449, `scripts/rpg2k_render_check.rb` 36, and `scripts/lcf_testbed_check.rb` clean over both test-beds (1,099 maps now that the 2003 game is downloaded).

Standing caveat, and it bites harder on the picture tone than on anything so far: there is no native build here, so the Ruby harness can prove `tone_blt` is called with the right Tone but **not** that the toned pixels reach the display. That is exactly the failure mode that sank the earlier map-layer attempt. The reasoning for why this path differs is above, but a native run is what would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D