### PR TITLE
Give MZ's render textures the stencil its windows mask with

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,11 @@
   redrawn after its first upload was lost: window contents, text, the tile
   atlas) and `bufferData` with a bare `ArrayBuffer`, which is what PIXI's sprite
   batcher uploads, so every batched sprite drew from an empty vertex buffer.
-  Both are covered at the pixel level on the real EGL backend by
+  Overlapping **windows clip each other** properly too: MZ draws every scene
+  inside a filter render texture (each scene carries a `ColorFilter`), and the
+  wrapper's renderbuffer calls were stubs, so the stencil `WindowLayer` masks
+  with had nothing to write to and every window overpainted its neighbours. All
+  three are covered at the pixel level on the real EGL backend by
   `mruby-mvjs/test/gl_test.rb`
 - The MZ engine is not redistributable (unlike MV's MIT corescript), so
   `data/mz-sample` commits only an authored database and art —

--- a/changelog.d/mz-render-texture-stencil.fixed.md
+++ b/changelog.d/mz-render-texture-stencil.fixed.md
@@ -1,0 +1,17 @@
+- **MZ's windows clip each other again.** The WebGL wrapper's renderbuffer calls
+  (`createRenderbuffer` / `bindRenderbuffer` / `renderbufferStorage` /
+  `framebufferRenderbuffer` / `deleteRenderbuffer`) were stubs, on the assumption
+  that only the main FBO — which `mvgl.cxx` builds with its own packed
+  DEPTH24_STENCIL8 buffer — ever needs a depth/stencil attachment. MZ never
+  draws a scene there: every `Scene_Base` carries a `ColorFilter`, so the scene
+  renders into a **filter render texture** and only the filter's output quad
+  touches the main FBO. rmmz's `WindowLayer.render` asks PIXI for a stencil on
+  whatever framebuffer is current (`renderer.framebuffer.forceStencil()`) and
+  masks each window against the ones in front of it; with no attachment the
+  stencil test always passed, so overlapping windows overpainted their
+  neighbours. The five calls now map onto GL, translating the two WebGL1-only
+  enums GLES2 lacks — the combined `DEPTH_STENCIL` internal format becomes
+  `DEPTH24_STENCIL8`, and `DEPTH_STENCIL_ATTACHMENT` becomes an attach to both
+  the depth and the stencil point. Covered at the pixel level by a new
+  `mruby-mvjs/test/gl_test.rb` case that masks *inside* a framebuffer-attached
+  render texture, which the stubs failed.

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -374,6 +374,33 @@ JavaScript loads and interprets the JSON.
       `Scene_Battle`'s fade-in before capturing; the bed's own battle frame stays
       near-black because the authored sample ships no battler art or battleback,
       the same reason MV runs its battle smoke against a real downloaded game.
+    - **M6.3f — the stencil never reached the surface MZ draws on (landed).**
+      M6.3c mapped `stencilFunc`/`Op`/`Mask` onto GL so `WindowLayer`'s
+      per-window clipping would clip, and proved it on the main FBO — which
+      `mvgl.cxx` builds with a packed DEPTH24_STENCIL8 buffer. But **MZ never
+      draws a scene into that FBO**: `Scene_Base` puts a `ColorFilter` on every
+      scene, so the scene renders into a filter *render texture* and only the
+      filter's output quad reaches the main FBO. rmmz's `WindowLayer.render`
+      calls `renderer.framebuffer.forceStencil()`, which has PIXI attach a
+      stencil renderbuffer to whatever framebuffer is current — and the
+      wrapper's five renderbuffer entry points were stubs
+      (`createRenderbuffer` returned 0, the rest were no-ops), on the assumption
+      that only the main FBO ever needed one. With no attachment the stencil
+      test always passes, so every window overpainted its neighbours.
+
+      All five now map onto GL, translating the two WebGL1 enums GLES2 has no
+      equivalent for: the combined `DEPTH_STENCIL` internal format becomes
+      `DEPTH24_STENCIL8` (the OES_packed_depth_stencil value `mvgl.cxx` already
+      uses), and the combined `DEPTH_STENCIL_ATTACHMENT` point becomes an attach
+      to *both* `DEPTH_ATTACHMENT` and `STENCIL_ATTACHMENT`, which is what a
+      packed buffer feeds. `gl_test` gains a masking case bound to a
+      framebuffer whose colour target is a texture and whose depth/stencil is a
+      renderbuffer — the arrangement PIXI builds — and it fails with the stubs
+      restored.
+
+      The pattern is worth naming, because it is the third time in this
+      milestone: **a capability proved on the wrong surface is not proved.** The
+      stencil worked where nothing was drawn and was absent where everything is.
 
   **Concrete boot map (verified by running the engine on the host).** MZ's boot
   differs from MV's in more than the renderer. Driving the shared host through a

--- a/mruby-mvjs/src/mvwebgl.cxx
+++ b/mruby-mvjs/src/mvwebgl.cxx
@@ -34,6 +34,22 @@
 #include <cstring>
 #include <vector>
 
+// GLES2 has no packed depth/stencil renderbuffer format in its base header; the
+// value is the one OES_packed_depth_stencil defines, which mvgl.cxx already
+// uses for the main FBO's own attachment.
+#ifndef GL_DEPTH24_STENCIL8
+#define GL_DEPTH24_STENCIL8 0x88F0
+#endif
+// WebGL1-only enums, absent from GLES2: a combined internal format and a
+// combined attachment point. Both are translated below (see
+// js_gl_*renderbuffer*).
+#ifndef GL_DEPTH_STENCIL
+#define GL_DEPTH_STENCIL 0x84F9
+#endif
+#ifndef GL_DEPTH_STENCIL_ATTACHMENT
+#define GL_DEPTH_STENCIL_ATTACHMENT 0x821A
+#endif
+
 namespace {
 
 // The GL contexts backing live WebGLRenderingContext objects, referenced from
@@ -1065,6 +1081,91 @@ JSValue js_gl_framebuffer_texture_2d(JSContext* ctx,
   return JS_UNDEFINED;
 }
 
+// -- renderbuffers -----------------------------------------------------------
+//
+// These back the depth/stencil attachment PIXI adds to a *render texture*'s
+// framebuffer. They used to be stubs (createRenderbuffer returned 0, the rest
+// were no-ops) on the assumption that only the main FBO — which mvgl.cxx builds
+// with its own packed DEPTH24_STENCIL8 buffer — ever needs one. That is not how
+// MZ renders: `Scene_Base` puts a `ColorFilter` on every scene, so the scene is
+// drawn into a filter render texture and only the filter's output quad touches
+// the main FBO. rmmz's `WindowLayer.render` asks for a stencil there
+// (`renderer.framebuffer.forceStencil()`) and then masks each window against
+// the ones in front of it; with no attachment the stencil test always passes,
+// so every window overpainted its neighbours.
+//
+// Two WebGL1 enums have no GLES2 equivalent and are translated here: the
+// combined `DEPTH_STENCIL` internal format becomes `DEPTH24_STENCIL8`, and the
+// combined `DEPTH_STENCIL_ATTACHMENT` point becomes an attach to both the depth
+// and the stencil attachment (which is what the packed buffer feeds).
+
+JSValue js_gl_create_renderbuffer(JSContext* ctx,
+                                  JSValueConst,
+                                  int argc,
+                                  JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)))
+    return JS_NewInt32(ctx, 0);
+  GLuint r = 0;
+  glGenRenderbuffers(1, &r);
+  return JS_NewInt32(ctx, static_cast<int32_t>(r));
+}
+
+JSValue js_gl_bind_renderbuffer(JSContext* ctx,
+                                JSValueConst,
+                                int argc,
+                                JSValueConst* argv) {
+  if (bind(gi(ctx, argc, argv, 0)))
+    glBindRenderbuffer(static_cast<GLenum>(gi(ctx, argc, argv, 1)),
+                       static_cast<GLuint>(gi(ctx, argc, argv, 2)));
+  return JS_UNDEFINED;
+}
+
+// renderbufferStorage(target, internalformat, width, height)
+JSValue js_gl_renderbuffer_storage(JSContext* ctx,
+                                   JSValueConst,
+                                   int argc,
+                                   JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)))
+    return JS_UNDEFINED;
+  GLenum fmt = static_cast<GLenum>(gi(ctx, argc, argv, 2));
+  if (fmt == GL_DEPTH_STENCIL)
+    fmt = GL_DEPTH24_STENCIL8;
+  glRenderbufferStorage(static_cast<GLenum>(gi(ctx, argc, argv, 1)), fmt,
+                        gi(ctx, argc, argv, 3), gi(ctx, argc, argv, 4));
+  return JS_UNDEFINED;
+}
+
+// framebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
+JSValue js_gl_framebuffer_renderbuffer(JSContext* ctx,
+                                       JSValueConst,
+                                       int argc,
+                                       JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)))
+    return JS_UNDEFINED;
+  const GLenum target = static_cast<GLenum>(gi(ctx, argc, argv, 1));
+  const GLenum attach = static_cast<GLenum>(gi(ctx, argc, argv, 2));
+  const GLenum rbtarget = static_cast<GLenum>(gi(ctx, argc, argv, 3));
+  const GLuint rb = static_cast<GLuint>(gi(ctx, argc, argv, 4));
+  if (attach == GL_DEPTH_STENCIL_ATTACHMENT) {
+    glFramebufferRenderbuffer(target, GL_DEPTH_ATTACHMENT, rbtarget, rb);
+    glFramebufferRenderbuffer(target, GL_STENCIL_ATTACHMENT, rbtarget, rb);
+  } else {
+    glFramebufferRenderbuffer(target, attach, rbtarget, rb);
+  }
+  return JS_UNDEFINED;
+}
+
+JSValue js_gl_delete_renderbuffer(JSContext* ctx,
+                                  JSValueConst,
+                                  int argc,
+                                  JSValueConst* argv) {
+  if (bind(gi(ctx, argc, argv, 0))) {
+    GLuint r = static_cast<GLuint>(gi(ctx, argc, argv, 1));
+    glDeleteRenderbuffers(1, &r);
+  }
+  return JS_UNDEFINED;
+}
+
 JSValue js_gl_check_framebuffer_status(JSContext* ctx,
                                        JSValueConst,
                                        int argc,
@@ -1480,11 +1581,16 @@ const char* kWebGLPreamble = R"MVJS(
   P.framebufferTexture2D = function (t, a, tt, tex, l) { g.__mv_glFramebufferTexture2D(this.__gl, t, a, tt, tex || 0, l); };
   P.checkFramebufferStatus = function (t) { return g.__mv_glCheckFramebufferStatus(this.__gl, t); };
   P.deleteFramebuffer = function (f) { g.__mv_glDeleteFramebuffer(this.__gl, f); };
-  P.createRenderbuffer = function () { return 0; };
-  P.bindRenderbuffer = function () {};
-  P.renderbufferStorage = function () {};
-  P.framebufferRenderbuffer = function () {};
-  P.deleteRenderbuffer = function () {};
+  // Renderbuffers back the depth/stencil a render texture's framebuffer needs.
+  // MZ reaches these through rmmz's WindowLayer, which asks PIXI for a stencil
+  // on whatever framebuffer is current — always a filter target, since every
+  // scene carries a ColorFilter — and then masks each window against the ones
+  // in front of it. See the native side for the two WebGL1 enums translated.
+  P.createRenderbuffer = function () { return g.__mv_glCreateRenderbuffer(this.__gl); };
+  P.bindRenderbuffer = function (t, r) { g.__mv_glBindRenderbuffer(this.__gl, t, r || 0); };
+  P.renderbufferStorage = function (t, f, w, h) { g.__mv_glRenderbufferStorage(this.__gl, t, f, w, h); };
+  P.framebufferRenderbuffer = function (t, a, rt, r) { g.__mv_glFramebufferRenderbuffer(this.__gl, t, a, rt, r || 0); };
+  P.deleteRenderbuffer = function (r) { g.__mv_glDeleteRenderbuffer(this.__gl, r); };
 
   // Draw & read.
   P.drawArrays = function (m, f, c) { g.__mv_glDrawArrays(this.__gl, m, f, c); };
@@ -1610,6 +1716,12 @@ void mv_install_webgl(JSContext* ctx) {
   reg(ctx, g, "__mv_glCreateFramebuffer", js_gl_create_framebuffer, 1);
   reg(ctx, g, "__mv_glBindFramebuffer", js_gl_bind_framebuffer, 3);
   reg(ctx, g, "__mv_glFramebufferTexture2D", js_gl_framebuffer_texture_2d, 6);
+  reg(ctx, g, "__mv_glCreateRenderbuffer", js_gl_create_renderbuffer, 1);
+  reg(ctx, g, "__mv_glBindRenderbuffer", js_gl_bind_renderbuffer, 3);
+  reg(ctx, g, "__mv_glRenderbufferStorage", js_gl_renderbuffer_storage, 5);
+  reg(ctx, g, "__mv_glFramebufferRenderbuffer", js_gl_framebuffer_renderbuffer,
+      5);
+  reg(ctx, g, "__mv_glDeleteRenderbuffer", js_gl_delete_renderbuffer, 2);
   reg(ctx, g, "__mv_glCheckFramebufferStatus", js_gl_check_framebuffer_status,
       2);
   reg(ctx, g, "__mv_glDeleteFramebuffer", js_gl_delete_framebuffer, 2);

--- a/mruby-mvjs/test/gl_test.rb
+++ b/mruby-mvjs/test/gl_test.rb
@@ -441,3 +441,106 @@ assert 'texSubImage2D updates a texture after its first upload' do
   assert_true rgb[1] > 200
   assert_true rgb[0] < 60
 end
+
+assert 'the stencil test masks inside a render texture, where MZ actually draws' do
+  skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
+
+  # The masking test above works on the main FBO, which mvgl.cxx builds with its
+  # own packed DEPTH24_STENCIL8 buffer. MZ never draws a scene there: every
+  # `Scene_Base` carries a `ColorFilter`, so the scene renders into a *filter
+  # render texture* and only the filter's output quad reaches the main FBO.
+  # rmmz's `WindowLayer.render` asks PIXI for a stencil on whatever framebuffer
+  # is current (`renderer.framebuffer.forceStencil()` -> createRenderbuffer +
+  # renderbufferStorage(DEPTH_STENCIL) + framebufferRenderbuffer) and masks each
+  # window against the ones in front of it. While those three were stubs no
+  # attachment existed, the stencil test always passed, and every window
+  # overpainted its neighbours.
+  #
+  # Same shape as the FBO test, but bound to a framebuffer whose colour target
+  # is a texture and whose depth/stencil is a renderbuffer. Returns
+  # "status,left,right".
+  out = MV::JS.eval(<<~'JS')
+    (function () {
+      var W = 64, H = 64;
+      var cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+      var gl = cv.getContext('webgl');
+      if (!gl) return 'no-context';
+      function shader(type, src) {
+        var s = gl.createShader(type);
+        gl.shaderSource(s, src); gl.compileShader(s);
+        return gl.getShaderParameter(s, gl.COMPILE_STATUS) ? s : null;
+      }
+      var vs = shader(gl.VERTEX_SHADER,
+        '#version 100\nattribute vec2 aPos;\nvoid main(){ gl_Position = vec4(aPos,0.0,1.0); }\n');
+      var fs = shader(gl.FRAGMENT_SHADER,
+        '#version 100\nprecision mediump float;\nuniform vec4 uCol;\nvoid main(){ gl_FragColor = uCol; }\n');
+      if (!vs || !fs) return 'shader-failed';
+      var p = gl.createProgram();
+      gl.attachShader(p, vs); gl.attachShader(p, fs);
+      gl.bindAttribLocation(p, 0, 'aPos');
+      gl.linkProgram(p);
+      if (!gl.getProgramParameter(p, gl.LINK_STATUS)) return 'link-failed';
+      gl.useProgram(p);
+      var uCol = gl.getUniformLocation(p, 'uCol');
+
+      // A render texture, the way PIXI builds one for a filter pass...
+      var tex = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, W, H, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+      var fbo = gl.createFramebuffer();
+      gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+      gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+      // ...plus the stencil forceStencil() attaches. The combined WebGL1 enums
+      // (DEPTH_STENCIL / DEPTH_STENCIL_ATTACHMENT) are what PIXI passes.
+      var rb = gl.createRenderbuffer();
+      gl.bindRenderbuffer(gl.RENDERBUFFER, rb);
+      gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, W, H);
+      gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, rb);
+      var status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+      if (status !== gl.FRAMEBUFFER_COMPLETE) return 'fbo-' + status;
+
+      gl.viewport(0, 0, W, H);
+      var buf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+      function quad(x0, x1) {
+        gl.bufferData(gl.ARRAY_BUFFER,
+          new Float32Array([x0,-1, x1,-1, x0,1, x1,-1, x1,1, x0,1]), gl.STATIC_DRAW);
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+      }
+
+      gl.clearColor(0.0, 0.0, 0.0, 1.0);
+      gl.clearStencil(0);
+      gl.clear(gl.COLOR_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+      gl.enable(gl.STENCIL_TEST);
+      gl.stencilMask(0xff);
+      gl.stencilFunc(gl.ALWAYS, 1, 0xff);
+      gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
+      gl.uniform4f(uCol, 0.0, 0.0, 0.0, 1.0);
+      quad(-1.0, 0.0);                       // stamp the left half
+      gl.stencilFunc(gl.EQUAL, 0, 0xff);
+      gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+      gl.uniform4f(uCol, 0.0, 1.0, 0.0, 1.0);
+      quad(-1.0, 1.0);                       // green, only where unstamped
+      gl.finish();
+
+      var l = new Uint8Array(4), r = new Uint8Array(4);
+      gl.readPixels(W / 4, H / 2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, l);
+      gl.readPixels(W * 3 / 4, H / 2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, r);
+      gl.disable(gl.STENCIL_TEST);
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+      return 'ok,' + l[1] + ',' + r[1];
+    })()
+  JS
+
+  parts = out.split(",")
+  # A framebuffer that never got its renderbuffer reports itself here rather
+  # than as a confusing colour comparison.
+  assert_equal "ok", parts[0]
+  assert_equal 3, parts.size
+  assert_true parts[2].to_i > 200 # right: drawn
+  assert_true parts[1].to_i < 60  # left: masked out
+end


### PR DESCRIPTION
Follow-up to #373, found while reading the frames it produced.

## The gap

ADR 0004 M6.3c mapped `stencilFunc`/`stencilOp`/`stencilMask` onto GL so rmmz's `WindowLayer` per-window clipping would clip, and proved it at the pixel level — **on the main FBO**, which `mvgl.cxx` builds with its own packed DEPTH24_STENCIL8 buffer.

MZ never draws a scene into that FBO. `Scene_Base` puts a `ColorFilter` on every scene, so the scene renders into a filter **render texture** and only the filter's output quad reaches the main FBO. `WindowLayer.render` calls `renderer.framebuffer.forceStencil()`, which has PIXI attach a stencil renderbuffer to whatever framebuffer is current — and the wrapper's five renderbuffer entry points were stubs (`createRenderbuffer` returned 0, the rest no-ops), on the assumption that only the main FBO ever needed one. With no attachment the stencil test always passes, so every window overpainted its neighbours.

## The fix

All five map onto GL now, translating the two WebGL1 enums GLES2 has no equivalent for:

- the combined `DEPTH_STENCIL` internal format becomes `DEPTH24_STENCIL8` (the `OES_packed_depth_stencil` value `mvgl.cxx` already uses for the main FBO);
- the combined `DEPTH_STENCIL_ATTACHMENT` point becomes an attach to **both** `DEPTH_ATTACHMENT` and `STENCIL_ATTACHMENT`, which is what a packed buffer feeds.

## Testing

- `mruby-mvjs/test/gl_test.rb` gains a masking case bound to a framebuffer whose colour target is a texture and whose depth/stencil is a renderbuffer — the arrangement PIXI builds. It reports an incomplete framebuffer as itself rather than as a colour comparison, and it **fails with the stubs restored** (the masked half comes back green), so it is not vacuous.
- `ctest`: `mruby_test` passes. The only failing test is the pre-existing `exe_open`, which needs a downloaded game absent from this environment.
- All five `scripts/mz_boot_check.bash` modes still pass against `data/mz-sample`, and the menu frame is unchanged — the sample's windows do not overlap, so the mechanism is what the test proves, not the screenshot.

## Docs

ADR 0004 gains milestone **M6.3f**; README and a `changelog.d/` fragment updated. The pattern is worth naming, since it is the third time in this milestone: **a capability proved on the wrong surface is not proved.** The stencil worked where nothing was drawn and was absent where everything is.

---
_Generated by [Claude Code](https://claude.ai/code/session_014B8H5L6jNJqN8HL7WGHbcS)_