### PR TITLE
Report the parameter modes behind each opcode, and correct the transition blocker note

### DIFF
--- a/changelog.d/rpg2k-transition-blocker-correction.changed.md
+++ b/changelog.d/rpg2k-transition-blocker-correction.changed.md
@@ -1,0 +1,13 @@
+- **Corrected the note on what the remaining screen transitions need.** They were
+  written up as waiting for a screen capture the renderer does not have.
+  `RGSS::Graphics.snap_to_bitmap` does exist, is tested, is enabled on the builds
+  that draw (`LV_USE_SNAPSHOT`; the Wio/PSP builds compile it out and it answers
+  nil there), and the **RPG Maker XP scene already uses it** for its own
+  Prepare for Transition. `docs/TODO.md` now says what each remaining style
+  actually needs: the scrolls, combine / division and zoom want the overlay
+  painted as a full composite from a capture rather than as a mask (`blt` /
+  `stretch_blt`, no native work); only mosaic and wave want a native per-pixel
+  pass; and random blocks wants RPG_RT's incremental block paint. It also records
+  the one wrinkle a Show Screen has — its capture would include the erase overlay
+  currently hiding the scene — and that the RPG2003 test-bed uses zoom / mosaic /
+  wave twelve times, which is what makes the family worth finishing.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -780,7 +780,40 @@ The work below is roughly ordered by the critical path to a walkable game
   black mask cannot express — the scrolls and the combine / division pairs slide
   the live scene itself, zoom / mosaic / wave resample it, and random blocks wants
   thousands of block blits a frame — which run as a fade of the right length and
-  the right end state until the renderer can capture a screen and transform it.
+  the right end state for now.
+
+  **That remainder was written up as blocked on a screen capture the renderer
+  does not have. It is not: `RGSS::Graphics.snap_to_bitmap` exists, is tested
+  (`mruby-rgss/test/test.rb`), is enabled on the builds that draw
+  (`LV_USE_SNAPSHOT` in `include/lv_conf.h`; the Wio/PSP builds compile it out
+  and it answers nil there), and the **RPG Maker XP scene already uses it**
+  (`mruby-rpgxp/mrblib/scene.rb`) for exactly this — its own transitions.** The
+  same mistake as the fade/flash note below: a capability assumed missing that
+  was already there. What is actually left per style:
+
+  - **Scroll (settings 9–12)** and **combine / division (13–15)**: capture the
+    outgoing screen once when the transition starts, then each frame paint the
+    overlay as the full composite — black plus the capture blitted at the
+    sliding offset — rather than as a mask. `Bitmap#blt` is enough; no native
+    work. The overlay is opaque and above everything, so painting the whole
+    frame into it is what lets the scene appear to move, which a mask cannot do.
+  - **Zoom (16)**: the same, with `stretch_blt` instead of `blt`.
+  - **Mosaic (17) / wave (18)**: per-pixel resampling. `get_pixel`/`set_pixel`
+    exist but a full-screen loop per frame in Ruby is far too slow, so these are
+    the only two that genuinely want a native pass.
+  - **Random blocks (1–3)**: expressible as a mask already; it needs the
+    *incremental* paint RPG_RT uses (only the newly-covered blocks each frame,
+    ~120 of 4800) rather than repainting every block, which is why it was left.
+
+  One wrinkle a Show Screen has and an Erase does not: its capture is of the
+  screen being arrived at, and `snap_to_bitmap` grabs the rendered screen
+  *including* the erase overlay that is currently hiding it. RPG_RT's equivalent
+  draws everything below the transition layer only
+  (`Graphics::LocalDraw(..., GetZ() - 1)`); here that means hiding the fade
+  sprite around the snapshot. Worth confirming in the real binary before
+  building on it — the RPG2003 test-bed uses zoom / mosaic / wave twelve times,
+  which is what makes the family worth finishing (`ruby scripts/analyze_game.rb
+  --params --code 11010 data/mtf-meido-action/Debug`).
 
   The fade and flash overlays were listed here as blocked on `RGSS::Viewport`
   tone/alpha support in C++. **They were not**: `RGSS::Sprite#opacity` already

--- a/docs/rpg2000-sample-analysis.md
+++ b/docs/rpg2000-sample-analysis.md
@@ -87,14 +87,33 @@ exercises the commands its author reached for — `ChangeMonsterHP` (13110) and
 `TerminateBattle` (13410) never appear in Nepheshel, so they remain
 fixture-tested only.
 
-The first caveat is not hypothetical: tallying the *parameter* signatures behind
-each opcode (the same walk, grouped by `param(0..n)` instead of by code) turned
-up two commands that dispatched to a handler and still did the wrong thing —
-a "this event" (10005) character reference the read-side handlers could not
-resolve, and Show Choices ignoring its cancel setting, including the [Cancel]
-branch the editor stores as a fifth, blank-labelled option. Both are fixed; see
-the event-command interpreter entry in `docs/TODO.md`. A per-opcode 100 % is
-where that audit *starts*, not where it ends.
+The first caveat is not hypothetical, and `--params` is the view that answers
+it:
+
+```bash
+ruby scripts/analyze_game.rb --params <game-dir>              # every opcode
+ruby scripts/analyze_game.rb --params --code 10140 <game-dir> # just one
+```
+
+For each opcode it lists, per parameter index, how many distinct values the game
+supplies and — when there are few enough to be a *mode selector* rather than an
+id or a coordinate — which ones. Read next to a handler's `case` arms, a value
+the game uses and the handler has no branch for is the bug. It reports rather
+than judging: nothing here can tell whether a handler covers a mode, only which
+modes are there to cover.
+
+That view found every event-command bug of the 2026-08 audit, none of which the
+per-opcode figure could see:
+
+| Command | What the handler ignored |
+| --- | --- |
+| Conditional Branch / Control Variables / Call Event | a "this event" (0 / 10005) reference the read side could not resolve |
+| Show Choices | the cancel setting, including the [Cancel] branch stored as a fifth, blank-labelled option |
+| Erase / Show Screen | the transition style, and the -1 that means "use the configured one" |
+| Move Event | Begin Jump / End Jump, which walked instead of hopping |
+| the twelve stat commands | the party-wipe re-check that ends the game |
+
+A per-opcode 100 % is where an audit *starts*, not where it ends.
 
 ## The collection
 

--- a/scripts/analyze_game.rb
+++ b/scripts/analyze_game.rb
@@ -15,7 +15,11 @@
 # implements.
 #
 # Usage:
-#   ruby scripts/analyze_game.rb [--json] [--troops] [--enemies] GAME_DIR [...]
+#   ruby scripts/analyze_game.rb [--json] [--troops] [--enemies]
+#                                [--params [--code N,N]] GAME_DIR [...]
+# `--params` reports the parameter *modes* behind each opcode — the view that
+# catches a command dispatched to a handler which ignores half of what the game
+# supplies, which per-opcode coverage cannot see. `--code` narrows it.
 # `--troops` reports the troops' battle-event pages instead: which condition
 # flag bits the game uses and which battle-only commands its pages run.
 # `--enemies` reports the enemies' action patterns (行動パターン): the kinds,
@@ -497,9 +501,82 @@ rescue StandardError => e
   warn "  enemy analysis failed for #{dir}: #{e.class}: #{e.message}"
 end
 
+# --params: the parameter *modes* behind each opcode.
+#
+# The coverage figures above are per **opcode**, and an opcode-complete runtime
+# can still be wrong: a command is dispatched to a handler that reads only some
+# of the parameter values the game supplies. Every event-command bug found in
+# the 2026-08 audit was of that shape — a "this event" reference the read side
+# could not resolve, a Show Choices cancel setting nobody looked at, an
+# Erase Screen transition style that was recorded and ignored.
+#
+# This is the view that finds them. For each opcode it lists, per parameter
+# index, how many distinct values the game supplies and — when there are few
+# enough to be a *mode selector* rather than an id or a coordinate — which ones.
+# Read it next to the handler's `case` arms: a value the game uses and the
+# handler has no branch for is the bug.
+#
+# It cannot decide anything on its own, so it reports rather than judging.
+MODE_VALUES_SHOWN = 10
+
+def report_params(dir, only_codes)
+  st = analyze_params(dir)
+  puts "== #{File.basename(dir.chomp('/'))} parameter modes =="
+  puts '   (per parameter index: distinct-value count, and the values when few'
+  puts '    enough to be a mode selector. Compare against the handler.)'
+  st.sort_by { |code, _| code }.each do |code, params|
+    next if only_codes && !only_codes.include?(code)
+    total = params[:count]
+    puts format('  %-28s %6d use(s)', cmd_label(code), total)
+    params[:values].sort.each do |idx, vals|
+      next if vals.size == 1 && vals.keys.first.to_i.zero? # an always-zero slot
+      shown =
+        if vals.size <= MODE_VALUES_SHOWN
+          vals.sort_by { |v, _| v.to_i }
+              .map { |v, n| "#{v}(#{n})" }.join(' ')
+        else
+          "#{vals.size} distinct"
+        end
+      puts format('      param%-2d %s', idx, shown)
+    end
+  end
+end
+
+# Tally, per opcode, the distinct values at each parameter index.
+def analyze_params(dir)
+  out = Hash.new { |h, k| h[k] = { count: 0, values: Hash.new { |g, i| g[i] = Hash.new(0) } } }
+  tally = lambda do |cmds|
+    next unless cmds
+    cmds.each do |c|
+      e = out[c.code]
+      e[:count] += 1
+      n = (c.parameters || []).size
+      n.times { |i| e[:values][i][c.param(i)] += 1 }
+    end
+  end
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  db.common_event&.each { |_id, ce| tally.call(ce.event) }
+  Dir[File.join(dir, 'Map*.lmu')].sort.each do |f|
+    lmu = LCF::MapUnit.new(File.open(f, 'rb'))
+    lmu.events.each { |_id, ev| ev.pages.each { |_pid, pg| tally.call(pg.event_commands) } }
+  rescue StandardError => e
+    warn "  #{File.basename(f)}: #{e.class}: #{e.message}"
+  end
+  out
+end
+
 json = ARGV.delete('--json')
 troops = ARGV.delete('--troops')
 enemies_only = ARGV.delete('--enemies')
+params_only = ARGV.delete('--params')
+# --params may be narrowed to a comma-separated opcode list, e.g. --code 10140.
+code_arg = ARGV.index('--code')
+only_codes = nil
+if code_arg
+  ARGV.delete_at(code_arg)
+  only_codes = (ARGV.delete_at(code_arg) || '').split(',').map(&:to_i)
+  only_codes = nil if only_codes.empty?
+end
 games = ARGV.dup
 if games.empty?
   root = File.expand_path('../data', __dir__)
@@ -507,7 +584,7 @@ if games.empty?
 end
 if games.empty?
   warn 'usage: ruby scripts/analyze_game.rb [--json] [--troops] [--enemies] ' \
-       'GAME_DIR [GAME_DIR ...]'
+       '[--params [--code N,N]] GAME_DIR [GAME_DIR ...]'
   exit 1
 end
 
@@ -518,6 +595,11 @@ end
 
 if enemies_only
   games.each { |g| report_enemies(g) }
+  exit 0
+end
+
+if params_only
+  games.each { |g| report_params(g, only_codes) }
   exit 0
 end
 


### PR DESCRIPTION
Two commits, both about the repo saying accurate things about its own coverage. They share a PR because this session develops on one branch.

## 1. `analyze_game.rb --params`

`analyze_game.rb` measures coverage per **opcode**, and both test-beds read 100 %. That number is true, and it hid seven bugs across #366, #369, #370, #371 and #374 — an opcode-complete runtime can still dispatch a command to a handler that reads only some of the values the game supplies.

`docs/rpg2000-sample-analysis.md` has always flagged this as the first caveat on the figure. `--params` is the view that answers it.

```bash
ruby scripts/analyze_game.rb --params <game-dir>              # every opcode
ruby scripts/analyze_game.rb --params --code 10140 <game-dir> # just one
```

For each opcode it lists, per parameter index, how many distinct values the game supplies and — when there are few enough to be a *mode selector* rather than an id or a coordinate — which ones. Read next to a handler's `case` arms, a value the game uses and the handler has no branch for is the bug.

**It reports rather than judging.** Nothing here can tell whether a handler covers a mode, only which modes are there to cover.

This is the walk that found every event-command bug of the audit, done with throwaway scratch scripts five passes running. In-tree, the next pass starts where this one ended. It also earns itself immediately — see below.

## 2. Correcting what the remaining transitions are waiting for

In #366 I documented the styles a black mask cannot express as blocked *"until the renderer can capture a screen and transform it"*. **The renderer can.** `RGSS::Graphics.snap_to_bitmap` is implemented over `lv_snapshot_take`, has tests in `mruby-rgss/test/test.rb`, is enabled through `LV_USE_SNAPSHOT` for the builds that draw — and the **RPG Maker XP scene already calls it** for Prepare for Transition (221), the same mechanism.

That is the same mistake as the fade/flash note directly below it in the file, where overlays were listed as blocked on `Viewport` tone support that turned out to be unnecessary. Assuming a capability is missing without checking has now cost this area twice, so the note records what each style actually needs:

| Styles | Actually needs |
| --- | --- |
| scroll (9–12), combine / division (13–15) | overlay painted as a full composite from a capture rather than as a mask — `blt`, **no native work** |
| zoom (16) | the same with `stretch_blt` |
| mosaic (17), wave (18) | a native per-pixel pass — the only two that genuinely do |
| random blocks (1–3) | RPG_RT's *incremental* block paint (~120 newly-covered blocks a frame, not all 4800) |

It also records the wrinkle a Show Screen has and an Erase does not: its capture is of the screen being arrived at, which `snap_to_bitmap` would grab with the erase overlay still on top, where RPG_RT draws only below the transition layer.

The evidence that the family is worth finishing comes from the new flag — the RPG2003 test-bed's Erase Screens use styles 16, 17 and 18 twelve times:

```
  EraseScreen                      86 use(s)
      param0  -1(3) 0(54) 4(12) 16(1) 17(8) 18(3) 19(5)
```

## Verification

`scripts/rpg2k_logic_check.rb` 500 pass, `scripts/rpg2k_scene_check.rb` 148 pass. The existing `analyze_game.rb` modes are unchanged — the default report, `--troops` and `--enemies` all produce identical output on both test-beds, and Nepheshel still reads 184,166 commands at 100 %. The second commit is documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D