### PR TITLE
Let a game's own engine read the keyboard

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -23,6 +23,12 @@ def rpg_maker_gems(conf)
   # bundled scripts, which format numbers with sprintf ("%02d" clocks, "%04d"
   # ids, "%+d", "%0*d", …). Not in the default gem set, so pull it in explicitly.
   conf.gem core: 'mruby-sprintf'
+  # Kernel#Integer(): every RGSS game clamps its battler stats through it —
+  # `n = [[Integer(n), 1].max, 999999].min` in Game_Battler_1, which runs the
+  # moment a party member is built — so a game's own engine died on New Game
+  # with "undefined method 'Integer'" without this. Same gem supplies Float() /
+  # String() / Array(), which community scripts reach for.
+  conf.gem core: 'mruby-kernel-ext'
   # mruby 4.0 removed the mruby-print gem; Kernel#p / #print live in the core
   # now, and mruby-io (above) supplies Kernel#print / #puts / #printf.
 

--- a/build_config.rb
+++ b/build_config.rb
@@ -29,6 +29,13 @@ def rpg_maker_gems(conf)
   # with "undefined method 'Integer'" without this. Same gem supplies Float() /
   # String() / Array(), which community scripts reach for.
   conf.gem core: 'mruby-kernel-ext'
+  # Kernel#rand: a game's own scripts roll dice constantly — `Game_Player`
+  # makes its encounter count with `rand(n) + rand(n) + 1` the moment New Game
+  # places the party, damage variance uses it, and RPG::Weather scatters its
+  # drops with it. This engine's own code deliberately uses seeded LCGs instead
+  # (its runs are diffed frame by frame against the genuine runtimes), which is
+  # why the gem was never needed until games ran their own code.
+  conf.gem core: 'mruby-random'
   # mruby 4.0 removed the mruby-print gem; Kernel#p / #print live in the core
   # now, and mruby-io (above) supplies Kernel#print / #puts / #printf.
 

--- a/changelog.d/rgss-host-input.fixed.md
+++ b/changelog.d/rgss-host-input.fixed.md
@@ -1,0 +1,18 @@
+- **A game running its own engine can now be played.** An RGSS scene loop is
+  `loop { Graphics.update; Input.update; update; … }`, and this engine drained
+  the keyboard backends' buffered transitions inside `Graphics.update` — which
+  the game's own `Input.update` then wiped (a trigger lives one frame) before the
+  scene read it. `Input.trigger?` was permanently false under the RGSS script
+  host: no New Game on a game's title screen, no message advance, no menu; only
+  held state (`press?`, `dir4`) worked. The drain moved to `Input.update`, where
+  RGSS says input refreshes — expire last frame's triggers, apply this frame's
+  transitions, then the repeat bookkeeping. The built-in RPG2000/XP flows and the
+  MV/MZ bridges call `Input.update` once a frame as well, so their timing is
+  unchanged.
+- **`--rgss_host_new_game`** taps the confirm key on a game's own title screen so
+  a headless run gets into the game without a keyboard — the script-host twin of
+  `--rpgxp_new_game`, which drives the *built-in* title instead — and the host
+  logs each scene the game reaches as `[RPGXP-HOST-SCENE]`, read from the game's
+  own `$scene`. `scripts/rpgxp_boot_check.bash` now requires both XP beds to
+  reach a *second* scene, so "the game drew its title and sat there" fails the
+  check.

--- a/changelog.d/rgss-host-kernel-integer.fixed.md
+++ b/changelog.d/rgss-host-kernel-integer.fixed.md
@@ -1,0 +1,11 @@
+- **`Kernel#Integer()` is in the build** (`mruby-kernel-ext`). Every RGSS game
+  clamps its battler stats through it — `n = [[Integer(n), 1].max, 999999].min`
+  in `Game_Battler_1`, which runs the moment a party member is built — so a game
+  running its own scripts died on New Game with "undefined method 'Integer'".
+  Covered by an availability test, so it fails in the test binary rather than in
+  a player's game.
+- A script-host failure now reports **where in the game's own scripts** it
+  happened: up to a dozen backtrace frames, named by editor section and line
+  (`Game_Battler_1:61`), because each section is evaluated under its own name.
+  Past the title screen "Main raised NoMethodError" could otherwise mean any of a
+  hundred scripts.

--- a/changelog.d/rgss-host-new-game.fixed.md
+++ b/changelog.d/rgss-host-new-game.fixed.md
@@ -1,0 +1,16 @@
+- **`Kernel#rand` is in the build** (`mruby-random`). A game's own scripts roll
+  dice constantly — `Game_Player#make_encounter_count` does
+  `rand(n) + rand(n) + 1` the moment New Game places the party — so a game died
+  there with "undefined method 'rand' for Game_Player". This engine's own code
+  uses seeded LCGs (its runs are diffed frame by frame against the genuine
+  runtimes), which is why the gem was never needed until games ran their own
+  code; `RPG::Weather` needs it too.
+- **`Table#[]=` drops a write past the edge instead of raising.** RGSS ignores
+  such a write without looking at the value, and a game's scripts lean on that:
+  *Pray for You*'s `map_light` walks `for x in 0..(self.width)` — inclusive — and
+  runs `@passages_data[x, y] |= 0x0f`, where the out-of-range read is `nil`,
+  `nil | 0x0f` is `true`, and that `true` came back as the value. Converting the
+  arguments before the bounds check turned it into "TypeError: true cannot be
+  converted to Integer" and ended the game on New Game. In-range writes of a
+  non-Integer still raise, and out-of-range reads still answer `nil` (which the
+  stock scripts test for).

--- a/changelog.d/rgss-value-type-clone.fixed.md
+++ b/changelog.d/rgss-value-type-clone.fixed.md
@@ -1,0 +1,13 @@
+- **`Color`, `Tone`, `Rect` and `Table` survive `#clone` / `#dup`.** mruby's
+  clone/dup allocate a bare object of the same class and copy only its instance
+  variables, so a copied value type carried no native payload and the first read
+  raised "uninitialized RGSS::Tone". A game's own scripts copy these constantly —
+  `@tone_target = tone.clone` in `Game_Screen`, `@flash_color = color.clone`, a
+  map's fog tone, a picture's — so anything that tinted or flashed the screen
+  ended the game. The four types now define `initialize_copy`, which is what
+  clone and dup call. (`Bitmap#clone` is still unimplemented: it needs a real
+  pixel copy.)
+- A script-host **timeout is no longer reported as a crash**. It is how a
+  headless run ends — the driver already treated it as a clean end — but it was
+  being printed as `section "Main" raised RGSS::Timeout` with a backtrace, which
+  made a passing run read like a broken one.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -203,6 +203,31 @@ needed it (`RPG::Weather` scatters its drops with `rand` too — that would have
 been the next report). Added to `build_config.rb` with the dependency edge in
 `mrbgem.rake`.
 
+### 0h. `#clone` / `#dup` on the value types ✅ (where a game's screen tone stopped it)
+
+With `rand` and the table write fixed, both beds reach **`Scene_Map`** — the test
+bed goes `Scene_Title → Scene_Map` and runs to the timeout, the released game
+`Scene_logo → Scene_Title → Scene_Map`. The next report:
+
+```
+[RGSS] script host: section "Main" raised TypeError: uninitialized RGSS::Tone
+[RGSS] script host:   from Game_Screen:102:in red
+[RGSS] script host:   from Game_Screen:102:in update
+```
+
+`Game_Screen#start_tone_change` keeps `@tone_target = tone.clone`, and mruby's
+`clone`/`dup` allocate a bare object of the same class and copy only its
+instance variables — so a cloned `Color`/`Tone`/`Rect`/`Table` carried no native
+payload and the first read of it raised. Both call `initialize_copy` on the new
+object, which the four value types now define. Games do this constantly (the
+screen tone, the flash colour, a map's fog tone, a picture's tone), so it is on
+the path of anything that tints the screen.
+
+**Still open in the same family:** `Bitmap#clone` — RGSS's own `RPG::Cache`
+clones bitmaps for hue variants (ours re-loads instead, see gap 0), but a
+community script that clones one will raise the same way. It needs a real pixel
+copy, not a payload copy.
+
 ### 0g. `Table#[]=` past the edge ✅ (a write RGSS drops, we raised on)
 
 ```

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -138,6 +138,33 @@ those formats reports no other mismatch, and the calls it does resolve include
 the other overloaded ones (`fill_rect`, `gradient_fill_rect`, `blt`,
 `stretch_blt`), which were already right.
 
+### 0d. `Input.trigger?` in a game's own loop ✅ (nothing a game could be *played* with)
+
+An RGSS scene loop reads input right after refreshing it:
+
+```ruby
+loop { Graphics.update; Input.update; update; break if $scene != self }
+```
+
+This engine drained the backends' buffered key transitions inside
+`Graphics.update`, and `Input.update` expires the previous frame's triggers — so
+every key applied on the first line was wiped by the second before the scene read
+it on the third. `Input.trigger?` was **permanently false** for a game running
+its own engine: no New Game on its title screen, no message advance, no menu.
+Only held state (`press?`, and so `dir4`/`dir8` movement) worked.
+
+RGSS's contract is that `Input.update` is what refreshes input, so the drain
+moved there (`RGSS::Input._poll`, native): expire the old triggers, apply this
+frame's transitions, then run the repeat bookkeeping. The built-in RPG2000/XP
+flows and the MV/MZ bridges call `Input.update` once a frame too, so their timing
+is unchanged.
+
+`--rgss_host_new_game` then makes a headless run *play*: it taps confirm through
+the same buffer the SDL backend feeds, and every scene the game reaches is logged
+as `[RPGXP-HOST-SCENE]` (read from the game's own `$scene` global). Reaching a
+second scene is what `scripts/rpgxp_boot_check.bash` now asserts — the proof that
+a game's engine took a keypress and acted on it, rather than merely drawing.
+
 **This gap was invisible for a long time**, for two compounding reasons: the
 switch that turns the host on could not work in a built engine (see the note at
 the end of this document), and `scripts/rpgxp_script_host_check.rb` *stubbed*

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -41,7 +41,10 @@ These are complete enough for the stock scripts:
 - **`Viewport`** — `new` (~7), `ox`/`oy`, `rect`, `z`, `visible`, `update`,
   `dispose`.
 - **Kernel** — `load_data` (~27) and `save_data` are supplied by the script host
-  (`Object#load_data`/`#save_data` → the project database); `rand` (~36) is core.
+  (`Object#load_data`/`#save_data` → the project database); `rand` (~36) and
+  `Integer()` come from the `mruby-random` / `mruby-kernel-ext` core gems, which
+  had to be added to the build (see gap 0e — neither is in mruby's default set,
+  and this list called `rand` "core" until a game proved otherwise).
 
 ## Gaps ❌ / ⚠️ (ordered by how much they block a boot)
 
@@ -181,7 +184,41 @@ A failure inside a game's own scripts now also prints **where**: the host report
 up to a dozen backtrace frames with the section name and line
 (`Game_Battler_1:61`), since each section is evaluated under its editor name.
 Past the title screen, "Main raised NoMethodError" can otherwise mean any of a
-hundred scripts.
+hundred scripts. It paid for itself on the next run, naming both of these:
+
+### 0f. `Kernel#rand` ✅ (the first thing New Game does after building the party)
+
+```
+[RGSS] script host: section "Main" raised NoMethodError: undefined method 'rand' for Game_Player
+[RGSS] script host:   from Game_Player:88:in make_encounter_count
+[RGSS] script host:   from Game_Player:57:in moveto
+[RGSS] script host:   from Scene_Title:134:in command_new_game
+```
+
+`Game_Player#make_encounter_count` rolls `rand(n) + rand(n) + 1` as the party is
+placed. `Kernel#rand` is the **mruby-random** core gem, which was not in the
+build: this engine's own code uses seeded LCGs instead, because its runs are
+diffed frame by frame against the genuine runtimes, so nothing here had ever
+needed it (`RPG::Weather` scatters its drops with `rand` too — that would have
+been the next report). Added to `build_config.rb` with the dependency edge in
+`mrbgem.rake`.
+
+### 0g. `Table#[]=` past the edge ✅ (a write RGSS drops, we raised on)
+
+```
+[RGSS] script host: section "Main" raised TypeError: true cannot be converted to Integer
+[RGSS] script host:   from map_light:265:in []=
+```
+
+*Pray for You*'s `map_light` script walks `for x in 0..(self.width)` — inclusive,
+so one past the edge — and runs `@passages_data[x, y] |= 0x0f`. Out there the
+read answers `nil`, `nil | 0x0f` is `true`, and that `true` arrives as the value
+of a write RGSS was always going to ignore. `Table#[]=` converted its arguments
+before the bounds check, so it raised instead of dropping the write. The bounds
+check now comes first and the value is converted only when it is going to be
+stored; an *in-range* write of a non-Integer still raises. Out-of-range **reads**
+keep answering `nil` — the stock scripts test for exactly that
+(`tile_id = self.data[x,y,i]; if tile_id == nil`).
 
 **This gap was invisible for a long time**, for two compounding reasons: the
 switch that turns the host on could not work in a built engine (see the note at

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -165,6 +165,24 @@ as `[RPGXP-HOST-SCENE]` (read from the game's own `$scene` global). Reaching a
 second scene is what `scripts/rpgxp_boot_check.bash` now asserts — the proof that
 a game's engine took a keypress and acted on it, rather than merely drawing.
 
+### 0e. `Kernel#Integer()` ✅ (the first thing New Game runs)
+
+With input working, both beds get *into* the game — and stop where every RGSS
+game builds its party: `Game_Battler_1` clamps each stat through
+`n = [[Integer(n), 1].max, 999999].min`, and mruby's `Kernel#Integer` lives in
+the **mruby-kernel-ext** core gem, which was not in the build. Added to
+`build_config.rb` and depended on in `mruby-rpgxp/mrbgem.rake` (the dependency
+edge orders its initialization, the same reason `mruby-sprintf` is declared
+there), with an availability test so its absence fails in the test binary rather
+than on a player's New Game. The same gem supplies `Float()` / `String()` /
+`Array()`, which neither stock bundle uses but community scripts do.
+
+A failure inside a game's own scripts now also prints **where**: the host reports
+up to a dozen backtrace frames with the section name and line
+(`Game_Battler_1:61`), since each section is evaluated under its editor name.
+Past the title screen, "Main raised NoMethodError" can otherwise mean any of a
+hundred scripts.
+
 **This gap was invisible for a long time**, for two compounding reasons: the
 switch that turns the host on could not work in a built engine (see the note at
 the end of this document), and `scripts/rpgxp_script_host_check.rb` *stubbed*

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1161,17 +1161,32 @@ module RGSS
       index
     end
 
+    # RGSS's contract: "updates input data — as a rule, call once per frame",
+    # and every key a game reads afterwards reflects what this call sampled. So
+    # this is where the backends' buffered transitions are applied (`_poll`,
+    # native: the SDL window backend via src/sdl_input.cxx, the terminal
+    # backends, wio/psp), *after* the previous frame's triggers expire and
+    # *before* the repeat bookkeeping runs over the new state.
+    #
+    # The order is what makes a game's own engine playable. An RGSS scene loop is
+    #
+    #   loop { Graphics.update; Input.update; update; break if $scene != self }
+    #
+    # so while the drain lived in Graphics.update, every transition it applied
+    # was wiped by the game's own Input.update on the very next line, before the
+    # scene read it: `Input.trigger?` was permanently false under the script host
+    # and no bundled game could be played. The built-in RPG2000/XP flows and the
+    # MV/MZ bridges all call Input.update once a frame as well, so their timing
+    # is unchanged (they read the state on the following frame either way).
     def self.update
-      # Key transitions are pushed in from C++ via .press / .release: the SDL
-      # window backend (src/sdl_input.cxx -> rgss_sdl_poll) and the terminal
-      # backends (rgss_terminal_poll) both drain their events during
-      # Graphics.update. This method only advances the per-frame trigger/repeat
-      # bookkeeping over that state.
-
-      # Reset triggered state after each frame
+      # Last frame's triggers expire first: a trigger lives exactly one frame.
       @triggered.each_index do |i|
         @triggered[i] = false
       end
+
+      # Then this frame's transitions arrive (.press / .release set pressed and
+      # triggered), so a tap that landed since the last call is visible now.
+      _poll
 
       # Update repeat state
       @pressed.each_index do |i|

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -423,26 +423,37 @@ mrb_value table_get(mrb_state* M, V self) {
   return mrb_fixnum_value(t.data[i]);
 }
 
+// A write outside the table is dropped, and the value is only converted once it
+// is going to be stored. The order matters, because a game's own scripts lean
+// on it: Pray for You's `map_light` walks `for x in 0..(self.width)` —
+// inclusive, so one past the edge — and does `@passages_data[x, y] |= 0x0f`. At
+// the edge the read answers nil, `nil | 0x0f` is `true`, and that `true` comes
+// back here as the value of a write RGSS was always going to ignore. Converting
+// the arguments up front (mrb_get_args "ii|ii") raised "TypeError: true cannot
+// be converted to Integer" instead, which killed the game on New Game. An
+// *in-range* write of a non-Integer still raises, as it should.
 mrb_value table_set(mrb_state* M, V self) {
-  mrb_int p0, p1, p2 = 0, p3 = 0;
-  mrb_get_args(M, "ii|ii", &p0, &p1, &p2, &p3);
-  mrb_int argc = mrb_get_argc(M);
-  mrb_int x = p0, y = 0, z = 0, v;
+  mrb_value a0, a1, a2 = mrb_nil_value(), a3 = mrb_nil_value();
+  mrb_get_args(M, "oo|oo", &a0, &a1, &a2, &a3);
+  const mrb_int argc = mrb_get_argc(M);
+  mrb_int x = mrb_as_int(M, a0), y = 0, z = 0;
+  mrb_value v;
   if (argc == 2) {
-    v = p1;
+    v = a1;
   } else if (argc == 3) {
-    y = p1;
-    v = p2;
+    y = mrb_as_int(M, a1);
+    v = a2;
   } else {
-    y = p1;
-    z = p2;
-    v = p3;
+    y = mrb_as_int(M, a1);
+    z = mrb_as_int(M, a2);
+    v = a3;
   }
   Table& t = DataType<Table>::get(M, self);
-  long i = table_index(t, x, y, z);
-  if (i >= 0)
-    t.data[i] = (int16_t)v;
-  return mrb_fixnum_value(v);
+  const long i = table_index(t, x, y, z);
+  if (i < 0)
+    return v;
+  t.data[i] = (int16_t)mrb_as_int(M, v);
+  return v;
 }
 
 mrb_value table_resize(mrb_state* M, V self) {

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -413,6 +413,28 @@ mrb_value table_init(mrb_state* M, V self) {
   return self;
 }
 
+// RGSS's value types are copied with #clone / #dup throughout a game's own
+// scripts — `@tone_target = tone.clone` in Game_Screen, `@flash_color =
+// color.clone`, Game_Map's fog tone, Game_Picture's. mruby's clone/dup allocate
+// a bare object of the same class and copy only its instance variables, so the
+// copy came back with no native payload at all and the first read of it raised
+// "uninitialized RGSS::Tone" — which is where Pray for You stopped once it
+// reached its map and the screen tone started moving. Both clone and dup call
+// initialize_copy on the new object, so this is where the payload is copied.
+template <class T>
+mrb_value data_init_copy(mrb_state* M, V self) {
+  V other;
+  mrb_get_args(M, "o", &other);
+  if (mrb_obj_equal(M, self, other))
+    return self;
+  const T& src = DataType<T>::get(M, other);
+  if (DATA_PTR(self))
+    DataType<T>::get(M, self) = src;
+  else
+    DataType<T>::alloc_obj(M, self) = src;
+  return self;
+}
+
 mrb_value table_get(mrb_state* M, V self) {
   mrb_int x, y = 0, z = 0;
   mrb_get_args(M, "i|ii", &x, &y, &z);
@@ -5171,6 +5193,8 @@ void define_rect(mrb_state* M, RClass* m) {
         return self;
       },
       MRB_ARGS_OPT(4));
+  mrb_define_method(M, rect, "initialize_copy", data_init_copy<Rect>,
+                    MRB_ARGS_REQ(1));
   mrb_define_method(
       M, rect, "set",
       [](mrb_state* M, V self) {
@@ -5551,6 +5575,9 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   MRB_SET_INSTANCE_TT(color, MRB_TT_DATA);
   mrb_define_method(M, color, "initialize", color_init,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  // #clone / #dup, which a game's scripts use on these constantly.
+  mrb_define_method(M, color, "initialize_copy", data_init_copy<Color>,
+                    MRB_ARGS_REQ(1));
   mrb_define_method(M, color, "set", color_set,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(3));
   mrb_define_method(M, color, "red", component_get<Color, &Color::red>,
@@ -5581,6 +5608,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   MRB_SET_INSTANCE_TT(tone, MRB_TT_DATA);
   mrb_define_method(M, tone, "initialize", tone_init,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, tone, "initialize_copy", data_init_copy<Tone>,
+                    MRB_ARGS_REQ(1));
   mrb_define_method(M, tone, "set", tone_set,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(3));
   mrb_define_method(M, tone, "red", component_get<Tone, &Tone::red>,
@@ -5610,6 +5639,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   MRB_SET_INSTANCE_TT(table, MRB_TT_DATA);
   mrb_define_method(M, table, "initialize", table_init,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
+  mrb_define_method(M, table, "initialize_copy", data_init_copy<Table>,
+                    MRB_ARGS_REQ(1));
   mrb_define_method(M, table, "[]", table_get,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
   mrb_define_method(M, table, "[]=", table_set,

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -51,6 +51,11 @@ extern "C" void rgss_terminal_poll(mrb_state* M);
 // backend is active and has captured key events; drains them into RGSS::Input.
 extern "C" void rgss_sdl_poll(mrb_state* M);
 
+// Defined in input_bridge.cxx (same gem).  Buffers one already-translated key
+// transition, the way the executable's SDL event watch does; exposed to Ruby as
+// RGSS::Input._push so a headless test can drive an input frame.
+extern "C" void rgss_sdl_input_push(int key, bool press);
+
 // Defined in input_bridge.cxx (same gem).  The latest pointer state captured by
 // the SDL backend (0 / not-pressed under the other backends); exposed to Ruby
 // as RGSS.mouse_x / mouse_y / mouse_pressed? so MV's TouchInput bridge can read
@@ -2449,9 +2454,20 @@ void update_z(mrb_state* M) {
   mrb_iv_set(M, mod, mrb_intern_lit(M, "_z_updated"), mrb_true_value());
 }
 
-mrb_value gfx_update(mrb_state* M, mrb_value self) {
-  const mrb_value rgss_mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
-
+// Drain every backend's buffered key transitions into RGSS::Input. Called from
+// Input.update (mrblib/lib.rb) — *not* from Graphics.update, which is where
+// this used to live and where it silently broke every game that runs its own
+// engine: an RGSS scene loop is
+//
+//   loop { Graphics.update; Input.update; update; break if $scene != self }
+//
+// so transitions applied during Graphics.update were wiped by the game's own
+// Input.update (which expires the previous frame's triggers) before the scene
+// read them — `Input.trigger?` could never be true under the script host, and
+// no game could be played. RGSS's contract is that Input.update is what
+// refreshes input, so that is where the drain belongs; the built-in flows call
+// it once a frame too, so their timing is unchanged.
+mrb_value input_poll(mrb_state* M, mrb_value self) {
   rgss_terminal_poll(M);
   rgss_sdl_poll(M);
 #if defined(WIO_TERMINAL)
@@ -2460,6 +2476,22 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
 #if defined(PSP_BUILD)
   rgss_psp_poll(M);
 #endif
+  return mrb_nil_value();
+}
+
+// Push a key transition into the same buffer the SDL backend feeds, from Ruby.
+// The headless tests use it to drive the loop above without a window.
+mrb_value input_push(mrb_state* M, mrb_value self) {
+  mrb_int key;
+  mrb_bool press;
+  mrb_get_args(M, "ib", &key, &press);
+  rgss_sdl_input_push(static_cast<int>(key), press);
+  return mrb_nil_value();
+}
+
+mrb_value gfx_update(mrb_state* M, mrb_value self) {
+  const mrb_value rgss_mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
+
   rgss_audio_frame();
 
   if (mrb_const_defined(M, mrb_obj_value(M->object_class),
@@ -5599,6 +5631,13 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
       MRB_ARGS_NONE());
   mrb_define_method(M, table, "_dump", table_dump, MRB_ARGS_REQ(1));
   mrb_define_class_method(M, table, "_load", table_load, MRB_ARGS_REQ(1));
+
+  // RGSS::Input is otherwise pure Ruby (mrblib/lib.rb reopens this module); the
+  // two native hooks are the backend drain Input.update calls and the test-side
+  // push that stands in for a keyboard.
+  RClass* input = mrb_define_module_under(M, m, "Input");
+  mrb_define_module_function(M, input, "_poll", input_poll, MRB_ARGS_NONE());
+  mrb_define_module_function(M, input, "_push", input_push, MRB_ARGS_REQ(2));
 
   RClass* gfx = mrb_define_module_under(M, m, "Graphics");
   mrb_define_module_function(M, gfx, "update", gfx_update, MRB_ARGS_NONE());

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -94,6 +94,40 @@ assert "RGSS::Table 3D and resize" do
   assert_equal 99, t[1, 2, 3] # preserved through resize
 end
 
+# A write past the edge is dropped without the value ever being looked at, which
+# a game's own scripts lean on. Pray for You's `map_light` walks
+# `for x in 0..(self.width)` — inclusive, so one past the end — and runs
+# `@passages_data[x, y] |= 0x0f`: out there the read answers nil, `nil | 0x0f` is
+# `true`, and that `true` arrives as the value of a write RGSS was always going
+# to ignore. Converting arguments before the bounds check turned it into
+# "TypeError: true cannot be converted to Integer" and killed the game on New
+# Game.
+assert "RGSS::Table drops out-of-range writes without reading the value" do
+  t = RGSS::Table.new(2, 2)
+  t[0, 0] = 5
+
+  assert_nil t[2, 0], "a read past the edge is nil"
+  assert_nil t[0, 2]
+  assert_nil t[-1, 0]
+
+  # The exact shape from the game: nil | 0x0f == true, written back past the edge.
+  value = t[2, 0] | 0x0f
+  assert_true value == true, "nil | 0x0f should be true, as in RGSS"
+  t[2, 0] = value
+  t[0, -1] = true
+  assert_equal 5, t[0, 0], "the dropped writes must not disturb the table"
+
+  # In range, a non-Integer is still a TypeError.
+  raised = false
+  begin
+    t[0, 0] = true
+  rescue TypeError
+    raised = true
+  end
+  assert_true raised, "an in-range write of true must still raise"
+  assert_equal 5, t[0, 0]
+end
+
 assert "RGSS::Table marshal round-trip" do
   t = RGSS::Table.new(2, 2)
   t[0, 0] = 1

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1083,6 +1083,41 @@ assert "RGSS::Input registers a tap that pressed and released in one frame" do
   end
 end
 
+# The order inside Input.update is what makes a game's own engine playable. An
+# RGSS scene loop reads input *after* calling Input.update:
+#
+#   loop { Graphics.update; Input.update; update; break if $scene != self }
+#
+# so a transition applied anywhere before that Input.update — which is where the
+# backends' buffer used to be drained, in Graphics.update — was wiped by it
+# before the scene ever looked. `Input.trigger?` was permanently false for a game
+# running under the script host: no New Game, no message advance, no menu.
+# Input.update now expires the old triggers, *then* drains the buffer.
+assert "RGSS::Input.update applies buffered keys, so a scene loop sees them" do
+  begin
+    RGSS::Input.update
+    # A key arrives between frames, exactly as the SDL event watch buffers it.
+    RGSS::Input._push(RGSS::Input::C, true)
+    # The scene loop's Input.update. (Graphics.update needs a live display the
+    # test binary lacks — and no longer touches input, which is the fix.)
+    RGSS::Input.update
+    assert_true RGSS::Input.trigger?(RGSS::Input::C),
+                "the game's own Input.update swallowed the key"
+    assert_true RGSS::Input.press?(RGSS::Input::C), "the key should read as held"
+    # A trigger still lives exactly one frame; the hold outlasts it.
+    RGSS::Input.update
+    assert_false RGSS::Input.trigger?(RGSS::Input::C)
+    assert_true RGSS::Input.press?(RGSS::Input::C)
+    # And the release arrives the same way.
+    RGSS::Input._push(RGSS::Input::C, false)
+    RGSS::Input.update
+    assert_false RGSS::Input.press?(RGSS::Input::C)
+  ensure
+    RGSS::Input.release(RGSS::Input::C)
+    RGSS::Input.update
+  end
+end
+
 assert "RGSS::Input accepts RGSS2/RGSS3 symbol keys" do
   # VX and VX Ace name the keys with symbols (Input.trigger?(:C)); XP and the
   # C++ input bridge use the integer constants. Both must reach the same key.

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -102,6 +102,53 @@ end
 # to ignore. Converting arguments before the bounds check turned it into
 # "TypeError: true cannot be converted to Integer" and killed the game on New
 # Game.
+# A game's own scripts copy these constantly — `@tone_target = tone.clone` in
+# Game_Screen, `@flash_color = color.clone`, Game_Map's fog tone, Game_Picture's
+# — and mruby's clone/dup allocate a bare object of the same class, copying only
+# instance variables. Without initialize_copy the copy carried no native payload
+# at all and the first read raised "uninitialized RGSS::Tone", which is where a
+# released game stopped once it reached its map and the screen tone moved.
+assert "RGSS value types survive #clone and #dup" do
+  color = RGSS::Color.new(10, 20, 30, 40)
+  [color.clone, color.dup].each do |copy|
+    assert_equal 10.0, copy.red
+    assert_equal 20.0, copy.green
+    assert_equal 30.0, copy.blue
+    assert_equal 40.0, copy.alpha
+    # A copy is its own object: changing it must not move the original.
+    copy.set(1, 2, 3, 4)
+    assert_equal 1.0, copy.red
+    assert_equal 10.0, color.red
+  end
+
+  tone = RGSS::Tone.new(-5, 0, 5, 50)
+  [tone.clone, tone.dup].each do |copy|
+    assert_equal(-5.0, copy.red)
+    assert_equal 5.0, copy.blue
+    assert_equal 50.0, copy.gray
+  end
+  # The shape Game_Screen#update runs every frame while a tone is changing.
+  target = tone.clone
+  moving = RGSS::Tone.new(0, 0, 0, 0)
+  moving.red = (moving.red * 3 + target.red) / 4
+  assert_equal(-1.25, moving.red) # components are floats, as in RGSS
+
+  rect = RGSS::Rect.new(1, 2, 3, 4)
+  copy = rect.clone
+  assert_equal 1, copy.x
+  assert_equal 4, copy.height
+  copy.set(9, 9, 9, 9)
+  assert_equal 1, rect.x, "the original rect moved with its copy"
+
+  table = RGSS::Table.new(2, 2)
+  table[1, 1] = 7
+  tcopy = table.clone
+  assert_equal 7, tcopy[1, 1]
+  assert_equal 2, tcopy.xsize
+  tcopy[1, 1] = 8
+  assert_equal 7, table[1, 1], "the original table shares its copy's storage"
+end
+
 assert "RGSS::Table drops out-of-range writes without reading the value" do
   t = RGSS::Table.new(2, 2)
   t[0, 0] = 5

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2328,10 +2328,12 @@ module Game
     end
   end
 
-  # A tiny deterministic pseudo-random generator. mruby is built here without
-  # the `mruby-random` gem (see build_config.rb), so `Kernel#rand` is not
-  # available; move routes and autonomous movement need *some* randomness, so we
-  # supply our own. This is a small LCG (multiplier 75, modulus the prime 65537)
+  # A tiny deterministic pseudo-random generator. `Kernel#rand` does exist in
+  # this build (mruby-random, added for the RGSS script host — a game's own
+  # scripts call it), but it is unseeded: move routes and autonomous movement
+  # are diffed frame by frame against the genuine runtime
+  # (scripts/compare-nepheshel-wine.bash), which needs the same rolls every run,
+  # so they keep this one. This is a small LCG (multiplier 75, modulus the prime 65537)
   # whose arithmetic stays within a signed 32-bit `mrb_int` — no value ever
   # reaches 2**31 — so it never has to promote to a bigint on this target. The
   # period (65536) and quality are more than enough for picking a walk

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -200,8 +200,9 @@ module Game
       @battle_background = nil
       @input_variable = nil
       @input_digits = 1
-      # Deterministic RNG for the Control Variables "random" operand (mruby has
-      # no Kernel#rand here); seeded like the map scene's own RNG.
+      # Deterministic RNG for the Control Variables "random" operand (Kernel#rand
+      # exists but is unseeded, and these runs are diffed); seeded like the map
+      # scene's own RNG.
       @rng = Game::Rng.new(0x2000)
       reset_waits
     end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -472,8 +472,9 @@ class RPG2k
         @started_auto = {}
         @started_common = {}
         @common = Game::CommonEvent.load(@db)
-        # Deterministic RNG (mruby has no Kernel#rand here) and the adapter that
-        # lets move routes / autonomous movement query the map.
+        # Deterministic RNG (Kernel#rand exists but is unseeded, and these runs
+        # are diffed against the genuine runtime) and the adapter that lets move
+        # routes / autonomous movement query the map.
         @rng = Game::Rng.new(0x2000)
         @world = MapWorld.new(self, @rng)
         # Erased events, and the state revision the active pages were chosen at.

--- a/mruby-rpgxp/mrbgem.rake
+++ b/mruby-rpgxp/mrbgem.rake
@@ -26,6 +26,9 @@ MRuby::Gem::Specification.new('mruby-rpgxp') do |spec|
   # Declared here for the same reason as mruby-sprintf above: the dependency edge
   # is what orders its initialization before this gem.
   add_dependency 'mruby-kernel-ext'
+  # Kernel#rand, which a game's scripts roll for encounters and damage variance
+  # (and RPG::Weather for its drops). Same ordering reason.
+  add_dependency 'mruby-random'
   # Numeric#zero?, used by the Scroll Map offset and the pause-arrow animation.
   # Same story as mruby-sprintf above: it is enabled in build_config.rb, but
   # without the dependency edge to order its initialization before this gem the

--- a/mruby-rpgxp/mrbgem.rake
+++ b/mruby-rpgxp/mrbgem.rake
@@ -22,6 +22,10 @@ MRuby::Gem::Specification.new('mruby-rpgxp') do |spec|
   # gem: without the edge, gem init order left Kernel#sprintf undefined when the
   # host loaded, so the scripts' "%02d"/"%04d" formatting raised NoMethodError.
   add_dependency 'mruby-sprintf'
+  # Kernel#Integer(), which every game's Game_Battler_1 clamps its stats with.
+  # Declared here for the same reason as mruby-sprintf above: the dependency edge
+  # is what orders its initialization before this gem.
+  add_dependency 'mruby-kernel-ext'
   # Numeric#zero?, used by the Scroll Map offset and the pause-arrow animation.
   # Same story as mruby-sprintf above: it is enabled in build_config.rb, but
   # without the dependency edge to order its initialization before this gem the

--- a/mruby-rpgxp/mrblib/interpreter.rb
+++ b/mruby-rpgxp/mrblib/interpreter.rb
@@ -13,7 +13,7 @@
 
 class RPGXP
   module Game
-    # Small deterministic RNG (mruby has no seeded Kernel#rand here), used by the
+    # Small deterministic RNG (Kernel#rand exists but is unseeded), used by the
     # "set variable to a random value" operand so runs are reproducible.
     class Rng
       def initialize(seed = 12_345)

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -131,6 +131,11 @@ class RPGXP
         begin
           rgss_eval_section(source, name)
         rescue StandardError, ScriptError => e
+          # A timeout is how a *headless* run ends, not how it fails: the driver
+          # treats it as a clean end (RPGXP#drive_script_host). Reporting it as
+          # "section Main raised …" with a backtrace made a passing CI run read
+          # like a crashed one.
+          raise e if quiet_end?(e)
           $stderr.puts "[RGSS] script host: section #{name.inspect} raised " \
                        "#{e.class}: #{e.message}"
           report_backtrace(e)
@@ -140,6 +145,16 @@ class RPGXP
         end
       end
       true
+    end
+
+    # Whether this exception is the run *ending* rather than the game breaking.
+    # Only the timeout qualifies here: `exit` raises SystemExit, which is not a
+    # StandardError and never reaches the rescue above. Guarded, because the
+    # CRuby harnesses load this file without RGSS::Timeout defined.
+    def self.quiet_end?(e)
+      RGSS.const_defined?(:Timeout) && e.is_a?(RGSS::Timeout)
+    rescue StandardError
+      false
     end
 
     # Where in the *game's own scripts* a failure happened. The section name and

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -178,9 +178,64 @@ class RPGXP
         alias_method :_update_native, :update
         def update
           _update_native
-          Fiber.yield if ::RPGXP::ScriptHost.driving?
+          return unless ::RPGXP::ScriptHost.driving?
+          ::RPGXP::ScriptHost.watch_frame
+          Fiber.yield
         end
       end
+    end
+
+    # Frames the host has driven, and the last scene it reported.
+    @frames = 0
+    @scene_name = nil
+
+    # Called once per driven frame, from the wrapper above. Two jobs, both about
+    # being able to *see* what a game's own engine is doing from a log:
+    #
+    #   * report each scene the game moves to. `$scene` is the game's own global
+    #     (RGSS's Main loops `$scene.main while $scene != nil`), so this reads
+    #     what it already publishes and modifies nothing. The marker is the
+    #     script-host twin of the built-in flow's [RPGXP-MAP].
+    #   * with --rgss_host_new_game, tap the confirm key so a headless run gets
+    #     off the game's title screen without a keyboard — the script-host twin
+    #     of --rpgxp_new_game (which drives the *built-in* title instead).
+    def self.watch_frame
+      @frames += 1
+      report_scene
+      confirm_tap if auto_new_game?
+    end
+
+    def self.report_scene
+      scene = $scene
+      return if scene.nil?
+      name = scene.class.to_s
+      return if name == @scene_name
+      @scene_name = name
+      $stderr.puts "[RPGXP-HOST-SCENE] #{name}"
+    end
+
+    # A tap a second in, repeated every second: pushed through the same buffer
+    # the SDL backend feeds, so the game's own Input.update applies it exactly as
+    # it would a real key. Repeated because a game's first screen is its own
+    # business — a notice, a language picker, a title menu whose first item is
+    # not New Game — and one press cannot know which.
+    CONFIRM_EVERY = 60
+    CONFIRM_HOLD = 4
+
+    def self.confirm_tap
+      phase = @frames % CONFIRM_EVERY
+      return if @frames < CONFIRM_EVERY
+      RGSS::Input._push(RGSS::Input::C, true) if phase == 0
+      RGSS::Input._push(RGSS::Input::C, false) if phase == CONFIRM_HOLD
+    end
+
+    # `--rgss_host_new_game`, published by src/main.cxx as a constant (this mruby
+    # build has no ENV). Read through its own rescue: the constant is absent
+    # under the CRuby harnesses, and an undefined constant raises here.
+    def self.auto_new_game?
+      RGSS_HOST_NEW_GAME
+    rescue StandardError
+      false
     end
   end
 end

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -133,12 +133,36 @@ class RPGXP
         rescue StandardError, ScriptError => e
           $stderr.puts "[RGSS] script host: section #{name.inspect} raised " \
                        "#{e.class}: #{e.message}"
+          report_backtrace(e)
           # `raise` with no argument loses the exception in this mruby build
           # (the caller saw a bare RuntimeError), so re-raise it explicitly.
           raise e
         end
       end
       true
+    end
+
+    # Where in the *game's own scripts* a failure happened. The section name and
+    # exception alone say what is missing but not where — and once a game is past
+    # its title screen, "Main raised NoMethodError" can mean any of a hundred
+    # scripts. Each section is evaluated under its editor name (rgss_eval_section
+    # passes it to eval), so the frames read like `Game_Battler_1:61`, which is
+    # the line to open in the editor. Best effort: an mruby build without
+    # backtraces just prints nothing extra.
+    BACKTRACE_FRAMES = 12
+
+    def self.report_backtrace(e)
+      return unless e.respond_to?(:backtrace)
+      frames = e.backtrace
+      return if frames.nil? || frames.empty?
+      frames.first(BACKTRACE_FRAMES).each do |frame|
+        $stderr.puts "[RGSS] script host:   from #{frame}"
+      end
+      dropped = frames.size - BACKTRACE_FRAMES
+      $stderr.puts "[RGSS] script host:   ... #{dropped} more" if dropped > 0
+    rescue StandardError
+      # A backtrace is a diagnostic, never a second failure.
+      nil
     end
 
     # The database the Kernel built-ins (Object#load_data / #save_data, defined

--- a/mruby-rpgxp/test/rpgxp_test.rb
+++ b/mruby-rpgxp/test/rpgxp_test.rb
@@ -1856,6 +1856,22 @@ end
 # Fiber (ADR 0023) and ends the game when one calls `exit` (raised as a catchable
 # SystemExit). Confirm all three gems are linked into the build — without
 # invoking `exit`, which would terminate the test runner.
+# Kernel#Integer(), from mruby-kernel-ext. Every RGSS game clamps its battler
+# stats through it — `n = [[Integer(n), 1].max, 999999].min` in Game_Battler_1,
+# which runs the moment a party member is built — so a missing one does not
+# surface until a player presses New Game. The gem is declared in
+# build_config.rb and depended on in mrbgem.rake; this is what makes its absence
+# fail here instead of in a booted game.
+assert "Kernel#Integer is available for the script host" do
+  assert_equal 7, Integer(7)
+  assert_equal 7, Integer("7")
+  assert_equal 0, Integer(0)
+  # The stock clamp is `[[Integer(n), 1].max, 999999].min`, which is what a
+  # game's maxhp= setter runs.
+  assert_equal 999999, [[Integer(1_000_000), 1].max, 999999].min
+  assert_equal 1, [[Integer(-5), 1].max, 999999].min
+end
+
 assert "eval, Fiber and Kernel#exit / SystemExit are available for the script host" do
   # mruby-eval is what makes the whole host possible; script_host.rb calls
   # Kernel#eval unconditionally because this gem is a hard dependency

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -15,10 +15,13 @@
 # The engine aborts on an uncaught mruby exception, so simply running it is most
 # of the test. Each game is booted twice, once per path into a running game:
 #
-#   1. **The default**: no flags, so the RGSS script host runs the project's own
-#      Data/Scripts.rxdata (ADR 0029) and logs `[RPGXP-SCRIPTS]`. A host that
-#      fails falls back to the built-in flow without changing the exit code, so
-#      the run also fails on a `script host failed` line.
+#   1. **The default**: the RGSS script host runs the project's own
+#      Data/Scripts.rxdata (ADR 0029). `--rgss_host_new_game` taps confirm on the
+#      game's own title screen and each scene the game reaches is logged as
+#      `[RPGXP-HOST-SCENE]`, so reaching a *second* one means the game's engine
+#      took a keypress and started something. A host that fails falls back to the
+#      built-in flow without changing the exit code, so the run also fails on a
+#      `script host failed` line.
 #   2. **The built-in reimplemented flow**: `--rpgxp_new_game` selects New Game
 #      without input (which also pins the boot to that flow) and logs the
 #      `[RPGXP-MAP]` marker, pushing the run past the title screen into the map
@@ -66,13 +69,15 @@ num="${SERVER_NUM}"
 
 # One headless run of the engine.
 #   $1 game dir, $2 display number, $3 what the run is called in the log,
-#   $4 the marker its log must contain, $5 extra engine flags (may be empty)
+#   $4 the marker its log must contain, $5 extra engine flags (may be empty),
+#   $6 how many [RPGXP-HOST-SCENE] lines the game must reach (0 = do not check)
 # A run fails when the engine exits non-zero (any uncaught mruby exception aborts
-# it), when its marker is missing, or when the script host reported a boot
-# failure and quietly fell back to the built-in flow -- that fallback keeps the
-# exit code at zero, so without the third test a broken default would pass.
+# it), when its marker is missing, when the script host reported a boot failure
+# and quietly fell back to the built-in flow -- that fallback keeps the exit code
+# at zero, so without that test a broken default would pass -- or when the game
+# never got past its first scene.
 run_boot() {
-    local game="$1" display="$2" label="$3" marker="$4" flags="$5"
+    local game="$1" display="$2" label="$3" marker="$4" flags="$5" scenes="${6:-0}"
     local log rc=0
     log="$(mktemp)"
     echo "-- ${label}"
@@ -91,6 +96,14 @@ run_boot() {
         echo "FAILED: ${game} (${label}): the script host fell back to the built-in flow" >&2
         grep 'script host failed' "${log}" >&2
         rc=1
+    elif [ "${scenes}" -gt 0 ] &&
+             [ "$(grep -c '\[RPGXP-HOST-SCENE\]' "${log}")" -lt "${scenes}" ] ; then
+        # One scene means the game drew its title and stayed there: the keypress
+        # never reached its own engine, or its first screen could not act on it.
+        echo "FAILED: ${game} (${label}): the game never left its first scene" \
+             "(wanted ${scenes} scenes)" >&2
+        grep '\[RPGXP-HOST-SCENE\]' "${log}" >&2
+        rc=1
     else
         grep "${marker}" "${log}"
     fi
@@ -108,11 +121,14 @@ for game in "${GAMES[@]}" ; do
     checked=$((checked + 1))
     echo "== ${game}"
 
-    # 1. The default boot: no flags, so the RGSS script host runs the game's own
-    #    Data/Scripts.rxdata (ADR 0029) and logs how many sections it evaluated.
-    #    This is the pass that proves the default path works on the real binary.
-    run_boot "${game}" "${num}" "script host (default)" '\[RPGXP-SCRIPTS\]' "" ||
-        failed=$((failed + 1))
+    # 1. The default boot: no flags but `--rgss_host_new_game`, so the RGSS
+    #    script host runs the game's own Data/Scripts.rxdata (ADR 0029), taps
+    #    confirm on the game's own title screen and logs every scene the game
+    #    reaches. Asserting on the *second* scene is what makes this more than a
+    #    "did not crash" check: it means the game's own title screen took a
+    #    keypress and started something.
+    run_boot "${game}" "${num}" "script host (default)" '\[RPGXP-HOST-SCENE\]' \
+        "--rgss_host_new_game" 2 || failed=$((failed + 1))
 
     # 2. The built-in reimplemented flow, which `--rpgxp_new_game` selects (it
     #    drives the built-in title screen, so it also switches the host off --

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -491,6 +491,61 @@ FakeSE = Struct.new(:name, :volume, :pitch)
 FakeAnimation = Struct.new(:frame_max, :animation_name, :animation_hue,
                            :position, :frames, :timings)
 
+# Project-independent: the per-frame watch the driver installs. It reports each
+# scene a game moves to — read from the game's own `$scene`, which RGSS's Main
+# loops on — as the marker scripts/rpgxp_boot_check.bash asserts a game got past
+# its title with. Reported once per scene, not once per frame.
+def check_scene_reporting
+  errors = 0
+  check = lambda do |cond, msg|
+    next 0 if cond
+    warn "  FAIL #{msg}"
+    1
+  end
+
+  # Stand-ins for a game's own scene classes.
+  Object.const_set(:HostCheckSceneTitle, Class.new) unless Object.const_defined?(:HostCheckSceneTitle)
+  Object.const_set(:HostCheckSceneMap, Class.new) unless Object.const_defined?(:HostCheckSceneMap)
+
+  lines = []
+  previous_scene = $scene
+  captured = $stderr
+  begin
+    $stderr = FakeErr.new(lines)
+    $scene = HostCheckSceneTitle.new
+    3.times { RPGXP::ScriptHost.watch_frame }
+    $scene = HostCheckSceneMap.new
+    RPGXP::ScriptHost.watch_frame
+    $scene = nil
+    RPGXP::ScriptHost.watch_frame
+  ensure
+    $stderr = captured
+    $scene = previous_scene
+  end
+
+  markers = lines.grep(/\[RPGXP-HOST-SCENE\]/)
+  errors += check.call(markers.size == 2,
+                       "expected one marker per scene, got #{markers.inspect}")
+  errors += check.call(markers[0].to_s.include?("HostCheckSceneTitle") &&
+                       markers[1].to_s.include?("HostCheckSceneMap"),
+                       "the markers do not name the scenes (#{markers.inspect})")
+  # Without the native --rgss_host_new_game constant nothing is synthesised: a
+  # normal boot must not press keys at the player.
+  errors += check.call(RPGXP::ScriptHost.auto_new_game? == false,
+                       "auto_new_game? is on without the flag")
+  puts "  [RPGXP-HOST-SCENE] is reported once per scene the game reaches" if errors.zero?
+  errors
+end
+
+# Collects what the host writes to stderr.
+class FakeErr
+  def initialize(lines); @lines = lines; end
+  def puts(*args); args.flatten.each { |a| @lines << a.to_s }; end
+  def write(s); @lines << s.to_s; end
+  def print(*args); args.each { |a| @lines << a.to_s }; end
+  def flush; end
+end
+
 # Project-independent: the host is the default boot path (ADR 0029), and
 # RGSS_SCRIPT_HOST is the opt-out that restores the built-in flow. Guarding it
 # here as well as in mruby-rpgxp/test keeps the two spellings of the rule (the
@@ -553,7 +608,8 @@ games = discover_games(File.expand_path("../data", __dir__)) if games.empty?
 
 # The project-independent checks run first, so they still guard the rules when
 # no test bed has been downloaded.
-errors = check_enabled_default + check_run_defines_top_level + check_rgss_library
+errors = check_enabled_default + check_run_defines_top_level + check_rgss_library +
+         check_scene_reporting
 
 if games.empty?
   warn "no XP test-bed game found (run scripts/download-opengame-xp.bash first)"

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -78,6 +78,16 @@ DEFINE_bool(
     "out); an explicit --rgss_script_host on the command line wins over it. "
     "See docs/adr/0029-rgss-script-host-by-default.md");
 DEFINE_bool(
+    rgss_host_new_game,
+    false,
+    "For the RGSS makers under the script host: tap the confirm key on the "
+    "game's own title screen once a second, so a headless run gets into the "
+    "game without a keyboard, and log each scene the game reaches as "
+    "[RPGXP-HOST-SCENE]. The script-host twin of --rpgxp_new_game, which "
+    "drives "
+    "the *built-in* title screen (and with it the built-in flow) instead. Used "
+    "by scripts/rpgxp_boot_check.bash");
+DEFINE_bool(
     mv_new_game,
     false,
     "For RPG Maker MV: once the title screen appears, auto-select New Game so "
@@ -783,6 +793,11 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RGSS_SCRIPT_HOST"),
                 mrb_bool_value(FLAGS_rgss_script_host));
+  // Whether the script host taps confirm on the game's own title screen (see
+  // RPGXP::ScriptHost.watch_frame).
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RGSS_HOST_NEW_GAME"),
+                mrb_bool_value(FLAGS_rgss_host_new_game));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));


### PR DESCRIPTION
Follow-up to #367, which made the RGSS script host the default boot path. That
landed with CI green, but green only meant *a game boots and does not crash* —
because a game running its own engine could never receive a keypress.

## The bug

An RGSS scene loop, in every game the editor generates:

```ruby
loop { Graphics.update; Input.update; update; break if $scene != self }
```

This engine drained the keyboard backends' buffered transitions inside
`Graphics.update`, and `Input.update` expires the previous frame's triggers — so
every key applied on line 1 was wiped on line 2 before the scene read it on
line 3. `Input.trigger?` was **permanently false** for a game running its own
scripts: no New Game on its title screen, no message advance, no menu. Only held
state (`press?`, and so `dir4`/`dir8` movement) ever worked.

That is why both XP beds sat on their title screens for the full 20-second
timeout in every CI run so far, and nothing in the log looked wrong.

## The fix

RGSS's contract is that `Input.update` is what refreshes input, so that is where
the drain belongs (`RGSS::Input._poll`, native):

1. expire last frame's triggers — a trigger lives exactly one frame,
2. apply this frame's transitions,
3. run the repeat bookkeeping over the new state.

The built-in RPG2000/XP flows and the MV/MZ bridges call `Input.update` once a
frame too, and read the state on the following frame either way, so their timing
is unchanged.

## Proving it, rather than assuming it

- **`--rgss_host_new_game`** taps the confirm key on a game's own title screen,
  pushed through the same buffer the SDL backend feeds so the game's own
  `Input.update` applies it exactly as it would a real key. It is the
  script-host twin of `--rpgxp_new_game`, which drives the *built-in* title
  screen (and with it the built-in flow).
- The host reports each scene a game reaches as **`[RPGXP-HOST-SCENE]`**, read
  from the game's own `$scene` global — nothing in the game is modified.
- `scripts/rpgxp_boot_check.bash` now requires both XP beds to reach a **second**
  scene under the host. "Drew its title and sat there" fails the check instead
  of passing it, which is exactly what the previous green run was doing.

## Tests

- `mruby-rgss/test`: drives the scene loop's ordering through the real input
  buffer (`RGSS::Input._push`) — a key pushed between frames must survive the
  game's own `Input.update`, the trigger must last exactly one frame, and the
  hold must outlast it.
- `scripts/rpgxp_script_host_check.rb`: the scene marker is reported once per
  scene (not once per frame), and nothing synthesises keys without the flag.
- Both CRuby harnesses and the XP/VX data checks pass locally against the real
  OpenGame test bed and the released *Pray for You*.

Gap doc updated (`docs/rpgxp-rgss-api-gap.md`, entry 0d) and a changelog
fragment added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_