### PR TITLE
Convert a teleport's RPG2003 arrival facing

### DIFF
--- a/changelog.d/rpg2k-teleport-facing.fixed.md
+++ b/changelog.d/rpg2k-teleport-facing.fixed.md
@@ -1,0 +1,14 @@
+- **A teleport's arrival facing is converted, not passed through raw.** Teleport
+  (10810) takes an RPG2003 fourth parameter: the direction to arrive in, 1-based
+  over the editor's up / right / down / left, with 0 meaning "keep the current
+  facing". The runtime — and `Game::State#direction` — speak RPG2000's 2/4/6/8
+  numpad instead, and the raw value was being assigned straight to it. Two of the
+  four values (1 and 3, the editor's *up* and *down*) are not directions in that
+  convention at all, so they left the party facing something with no movement
+  delta and no CharSet row; a third was simply the wrong direction, and only
+  "left" lined up by coincidence. Measured on the RPG2003 test-bed
+  (`scripts/download-mtf-meido-action.bash`): 25 of its 26 teleports set a
+  facing, and 22 of them arrived wrong. An RPG2000 project writes 0 here — the
+  edition has no such argument — so Nepheshel's 2021 teleports were unaffected,
+  which is why converting unconditionally is the same as EasyRPG's
+  `IsRPG2k3Commands` guard for the games that can emit it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -248,7 +248,13 @@ The work below is roughly ordered by the critical path to a walkable game
   Change Parallax Background, Proceed
   With Movement, Halt All Movement,
   Erase Event, Return to Title, End Event) with a per-frame step cap so a bad
-  loop can't hang. **Memorize Location** stores the player's current map id, x and y
+  loop can't hang. **Teleport** (10810) honours RPG2003's arrival-facing
+  argument: it is 1-based over the editor's up / right / down / left, not the
+  2/4/6/8 numpad the runtime speaks, and was being assigned raw — leaving two of
+  the four values (the editor's *up* and *down*) as numbers that are not
+  directions at all. The RPG2003 test-bed sets a facing on 25 of its 26
+  teleports; an RPG2000 project writes 0 there, so Nepheshel's 2021 were
+  unaffected. **Memorize Location** stores the player's current map id, x and y
   into three variables, and **Recall to Location** teleports back to a location
   held in three variables (routed through the same teleport the Teleport command
   uses). **Call Event**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2041,10 +2041,28 @@ module Game
 
     # -- UI / map requests ----------------------------------------------------
 
+    # Teleport (10810): move the party to map param0 at (param1, param2).
+    #
+    # param3 is an **RPG2003** addition: the facing to arrive in, 1-based over
+    # the editor's up / right / down / left, with 0 meaning "keep the current
+    # one". It is not the runtime's 2/4/6/8 numpad direction, and passing it
+    # through raw set two of the four values to numbers that are not directions
+    # at all (1 and 3, which no delta or charset row matches) and a third to the
+    # wrong one — only "left" happened to line up. An RPG2000 project writes 0
+    # here, so converting unconditionally is the same as EasyRPG's
+    # `IsRPG2k3Commands` guard for the games that can emit it.
     def do_teleport(cmd)
-      @teleport = [cmd.param(0), cmd.param(1), cmd.param(2), cmd.param(3)]
+      @teleport = [cmd.param(0), cmd.param(1), cmd.param(2),
+                   teleport_facing(cmd.param(3))]
       @wait_kind = :teleport
       @waiting = true
+    end
+
+    # The numpad facing a Teleport's 1-based direction argument names, or 0 for
+    # "keep the current facing" (which is what an out-of-range value means too).
+    def teleport_facing(param)
+      return 0 unless param && param >= 1 && param <= FACING_NUMPAD.size
+      FACING_NUMPAD[param - 1]
     end
 
     # Memorize Location: store the player's current map id, x and y into the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1667,6 +1667,35 @@ check 'Recall to Location issues a teleport from the stored variables' do
   eq [3, 6, 2, 0], it.teleport # keeps the current facing (direction 0)
 end
 
+check 'Teleport converts its RPG2003 facing argument to a numpad direction' do
+  # param3 is 1-based over the editor's up / right / down / left; the runtime
+  # (and Game::State#direction) speak the 2/4/6/8 numpad. Passing it through
+  # raw made 1 and 3 into numbers that are not directions at all.
+  { 1 => 8, 2 => 6, 3 => 2, 4 => 4 }.each do |param, numpad|
+    st = new_state
+    it = Game::Interpreter.new(st)
+    it.start([FakeCmd.new(IC::TELEPORT, [5, 3, 9, param])])
+    it.update
+    eq [5, 3, 9, numpad], it.teleport, "facing argument #{param}"
+  end
+end
+
+check 'Teleport with no facing argument keeps the current one' do
+  # 0 is what an RPG2000 project writes — the edition that has no such argument.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::TELEPORT, [5, 3, 9, 0])])
+  it.update
+  eq [5, 3, 9, 0], it.teleport, 'nothing to face, so the scene leaves it alone'
+
+  # An out-of-range value means the same rather than an invalid direction.
+  st2 = new_state
+  it2 = Game::Interpreter.new(st2)
+  it2.start([FakeCmd.new(IC::TELEPORT, [5, 3, 9, 9])])
+  it2.update
+  eq [5, 3, 9, 0], it2.teleport
+end
+
 # -- Store Terrain ID / Store Event ID ---------------------------------------
 
 # A map_info hook: terrain id is x*10+y, and an event id 7 sits at (2, 3) facing

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1283,6 +1283,19 @@ check 'Recall to Location teleports the player to the stored position' do
   eq 1, st.map_id, 'on the recalled map'
 end
 
+check 'a teleport lands the party facing the direction it asked for' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # RPG2003's facing argument: 1 = up, which the runtime speaks as numpad 8.
+  auto.event_commands = [ECmd.new(ic::TELEPORT, [1, 4, 3, 1])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # facing down to start with
+  20.times { scene.update }
+  eq [4, 3], [st.x, st.y], 'arrived at the destination'
+  eq 8, st.direction, 'and turned to face up'
+end
+
 check 'a teleport clears every shown picture' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
First find using the `--params` view merged in #376 — which is what made this visible at all.

## The gap

Teleport (10810) takes a fourth parameter in RPG2003: the direction to arrive in, **1-based over the editor's up / right / down / left**, with 0 meaning "keep the current facing". The runtime — and `Game::State#direction` — speak RPG2000's **2/4/6/8 numpad**. The raw parameter was being assigned straight across:

| param3 | means | we set | numpad meaning |
| --- | --- | --- | --- |
| 1 | up | 1 | **not a direction** |
| 2 | right | 2 | down — wrong |
| 3 | down | 3 | **not a direction** |
| 4 | left | 4 | left — correct by coincidence |

Two of the four values match no movement delta and no CharSet row, so a party told to arrive facing up or down arrived facing nothing in particular.

## What it costs

The RPG2003 test-bed sets a facing on **25 of its 26 teleports**, and 22 of them landed wrong — 8 asked for up, 14 for down, 3 for left:

```
  Teleport                         26 use(s)
      param3  0(1) 1(8) 3(14) 4(3)
```

An RPG2000 project writes 0 here, the edition having no such argument. Nepheshel's **2021** teleports all do, which is why `--params` does not even list a `param3` row for it — and why converting unconditionally is equivalent to EasyRPG's `IsRPG2k3Commands` guard for the games that can emit it, without plumbing the edition into the interpreter.

## The fix

The interpreter converts through the `FACING_NUMPAD` table it already has for the orientation conditional branch, so the scene keeps receiving a direction in the one convention it uses. Out-of-range values mean "keep the current facing" rather than an invalid direction.

## Verification

- `scripts/rpg2k_logic_check.rb` 502 pass (+2): all four facings, plus the absent and out-of-range cases.
- `scripts/rpg2k_scene_check.rb` 149 pass (+1): a teleport driven through the real scene, confirming the party arrives at the destination *and* turned to face up.
- `scripts/rpg2k_render_check.rb` 36 pass.

Unlike the last few rendering-adjacent changes this one is fully verifiable here — it is a value conversion, and the scene check reads the resulting direction directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_