### PR TITLE
Make the MZ smoke tests look at the picture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,6 +452,19 @@ jobs:
                 --timeout_ms=6000 --game_dir data/mv-sample \
                 --mv_new_game --mv_audio_test
 
+      # The five MZ smokes above each assert their own frame in isolation (the
+      # boot check runs scripts/mz_frame_check.rb --frame on what it captured).
+      # The comparisons between modes need all five frames, so they run here,
+      # after the parallel group's implicit wait: the message frame against the
+      # plain map frame, the menu and battle frames against it, and the
+      # post-save frame back on it. Reads only ss/mz_*.png, and skips cleanly
+      # when the MZ engine was not fetched and the smokes wrote nothing.
+      # Non-blocking, like the MZ smokes it reads.
+      - name: MZ frame check
+        continue-on-error: true
+        if: always()
+        run: ./scripts/nix-develop.bash ruby scripts/mz_frame_check.rb ss
+
       - name: Upload MV screenshot
         continue-on-error: true
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -308,6 +308,16 @@
   success line so a probe that merely ran cannot pass; `ruby
   scripts/mz_testbed_check.rb path/to/Game` validates any MZ project's
   boot-critical data and system art without a build
+- Those assertions all read the engine's **log**, which is how the empty frames
+  above went unnoticed for a milestone. `scripts/mz_frame_check.rb` reads the
+  **captured PNGs** instead: that each frame kept its art (a map frame that lost
+  its tiles is 99.5% a single colour; a message window whose contents never
+  uploaded has 18 distinct colours in its band where text puts 105), and that
+  each mode's frame differs from the plain map frame the way that mode claims —
+  the message window changes the bottom band and nothing above it, the menu and
+  battle scenes replace the screen, and the save round-trip lands back on the
+  map. Reverting the `texSubImage2D` fix leaves every boot-check mode reporting
+  OK and fails the frame check, which is the point of it
 
 ### Terminal gaming
 - Render the game to a terminal instead of an SDL window, using either the DEC

--- a/changelog.d/mz-frame-check.added.md
+++ b/changelog.d/mz-frame-check.added.md
@@ -1,0 +1,16 @@
+- **The MZ smoke tests now look at the picture.** Every assertion in
+  `scripts/mz_boot_check.bash` read the engine's *log* — Scene_Map was reached,
+  `Window_Message` reports itself open, the save chain settled — and none of them
+  looked at a pixel, which is how MZ spent a milestone passing every probe while
+  the captured frames were nearly empty. `scripts/mz_frame_check.rb` decodes the
+  captured PNGs (a small pure-Ruby reader for the subset stb_image_write emits)
+  and asks two things the log cannot answer. Per frame: the scene's art actually
+  reached it (a map frame that lost its tiles is 99.5% one colour against 68.5%
+  intact), and the message window's band carries enough distinct colours to mean
+  glyphs (105 with contents uploading, 18 without). Across frames: the message
+  frame differs from the plain map frame in the bottom band *and only there*, the
+  menu and battle frames replace it, and the post-save frame is back on it. The
+  boot check runs the single-frame half itself, so each mode still fails on its
+  own; the comparisons run once all five frames exist. Verified by rebuilding
+  with the `texSubImage2D` fix reverted: every boot-check mode still reports OK,
+  and the frame check fails.

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -401,6 +401,46 @@ JavaScript loads and interprets the JSON.
       The pattern is worth naming, because it is the third time in this
       milestone: **a capability proved on the wrong surface is not proved.** The
       stencil worked where nothing was drawn and was absent where everything is.
+    - **M6.3g — the smokes now read the frames (landed).** M6.3e and M6.3f were
+      both found by a human looking at pictures, because every automated
+      assertion in `scripts/mz_boot_check.bash` reads the engine's *log*:
+      `Scene_Map` was reached, `$gameMessage` is busy with `Window_Message`
+      open, the save chain settled. A frame can be empty while all of that is
+      true. `scripts/mz_frame_check.rb` closes that gap by decoding the captured
+      PNGs — a small pure-Ruby reader for the subset `stb_image_write` emits
+      (8-bit RGB/RGBA, non-interlaced, all five row filters).
+
+      It asks two kinds of question, because measuring showed that neither kind
+      alone is enough:
+
+      * **Per frame, absolute.** The M6.3e frames were not blank — the player
+        sprite and the touch-UI button still drew — so a "not a flat fill" floor
+        passes on them. What they had lost was the map: 99.5% of the play frame
+        was one colour against 68.5% intact. And the message band carries 105
+        distinct colours when the window's contents upload against 18 when only
+        its skin draws, because antialiased glyphs scatter intermediate colours
+        through it.
+      * **Across frames, relational.** Each mode's frame against the plain map
+        frame from `play`: the message frame differs in the bottom band (93.0%)
+        and barely outside it (0.3%), so the change is provably *the window*;
+        the menu and battle frames replace the screen (100.0%); the post-save
+        frame is the map again (0.2%), so a round-trip that returns to a wrecked
+        scene fails.
+
+      The relational half alone would **not** have caught M6.3e — that bug
+      degraded every frame identically, so the differences between modes
+      survived it intact (the window skin still drew, over a black map). This is
+      worth recording because the first draft of the check was relational only,
+      and rebuilding with the fix reverted disproved it: every mode still passed.
+      The absolute half was added from what that experiment measured, and the
+      same experiment is the check's non-vacuity proof — with `texSubImage2D`
+      reverted to a no-op, all five `mz_boot_check.bash` modes still report OK
+      while the frame check fails on the play frame's dominant colour and the
+      message band's colour count.
+
+      Which is the fourth instance of the milestone's pattern, one level up: **a
+      test written from a theory of the bug is not a test until the bug is put
+      back.**
 
   **Concrete boot map (verified by running the engine on the host).** MZ's boot
   differs from MV's in more than the renderer. Driving the shared host through a

--- a/scripts/mz_boot_check.bash
+++ b/scripts/mz_boot_check.bash
@@ -175,5 +175,20 @@ grep -E '\[MZ-BOOT\]|\[MZ-SCENE\]|\[MZ-MAP\]|\[MZ-MOVE\]|\[MZ-AUDIO\]|\[MZ-MSG\]
 # ALSA has no device under CI and floods stderr; keep the rest for context.
 grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -20 || true
 rm -f "${log}"
+
+# Everything above read the *log*. The captured frame is the other half of the
+# claim, and the two can disagree: with the M6.3e fix reverted every assertion
+# above still passes while the map is missing from the picture. Check what this
+# run actually drew; the cross-mode comparisons (a message window that changed
+# the frame, a menu that replaced it) need more than one mode's frame and run
+# from scripts/mz_frame_check.rb once they have all been captured.
+if command -v ruby >/dev/null 2>&1 ; then
+    ruby "$(dirname "$0")/mz_frame_check.rb" --frame "${SHOT}" ||
+        { echo "FAILED: ${GAME} (mode ${MODE}): the captured frame does not" \
+               "show what the log claims" >&2 ; exit 1 ; }
+else
+    echo "note: no ruby, so ${SHOT} was not checked"
+fi
+
 echo "mz boot check (${MODE}): OK"
 exit 0

--- a/scripts/mz_frame_check.rb
+++ b/scripts/mz_frame_check.rb
@@ -1,0 +1,391 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Assert that the frames scripts/mz_boot_check.bash captures actually show what
+# each mode claims. The boot check reads the engine's *log*: it proves MZ
+# reached Scene_Map, that `$gameMessage` is busy with `Window_Message` open,
+# that `Scene_Menu` was entered, that the save chain settled. None of that looks
+# at a pixel — which is how MZ spent a milestone passing every probe while the
+# captured PNGs were nearly empty (ADR 0004, M6.3e: `texSubImage2D` was a no-op
+# and `bufferData` dropped bare `ArrayBuffer`s, so the tile atlas, every window's
+# contents and every batched sprite were missing from frames the log called a
+# success). This script is the pixel half of those claims.
+#
+# It asks two different kinds of question, because one kind is not enough:
+#
+# **Did this frame keep its pixels?** (per frame, absolute)
+#   The M6.3e frames were not blank — the player sprite and the touch-UI button
+#   still drew — so "not a flat fill" passes on them. What they had lost was the
+#   *map*: 99.5% of the play frame was the clear colour against 68.5% for the
+#   fixed build. So a map-bearing frame must not be overwhelmingly one colour,
+#   and the message frame's window band must carry enough distinct colours to
+#   mean glyphs (antialiased text lands dozens of intermediate colours in it; a
+#   window whose contents bitmap never uploaded has only the skin's gradient —
+#   measured 105 colours against 18).
+#
+# **Did the thing this mode claims to show actually reach the frame?**
+#   (per mode, relational — each frame against the plain map frame from `play`)
+#   message  the bottom band changed a lot and the top band barely at all
+#            (a message window drew over the map, and only there)
+#   menu     nearly the whole screen changed (Scene_Menu replaced the map)
+#   battle   nearly the whole screen changed (Scene_Battle replaced the map)
+#   save     almost nothing changed (the round-trip landed back on an intact
+#            map — a save that returns to a wrecked or empty scene fails here)
+#
+# The relational half alone would *not* have caught M6.3e: that bug degraded
+# every frame the same way, so the differences between modes survived it intact
+# (the message window's skin still drew over a black map). The absolute half
+# alone would not catch a window that stops drawing while the map still does.
+# Verified rather than assumed: rebuilding with the M6.3e fix reverted, every
+# `mz_boot_check.bash` mode still reports OK, and this script fails on the play
+# frame's dominant colour (99.5%) and the message band's colour count (18).
+#
+# The thresholds come from measured runs of data/mz-sample and sit an order of
+# magnitude clear of the values they reject, so they are bounds on a nearly
+# binary signal rather than tuned tolerances. Two assumptions are specific to
+# that bed, and both are noted at the constants: its map is one screen wide (so
+# it does not scroll between captures), and its battle frame is legitimately
+# near-black because the sample ships no battler art.
+#
+# Modes whose frame is absent are skipped, so this is useful after a single
+# mode's run as well as after all five. With no frames at all it skips rather
+# than fails, the way the boot check skips a missing engine.
+#
+# Usage: ruby scripts/mz_frame_check.rb [ss_dir]        (default: ss)
+#        ruby scripts/mz_frame_check.rb --frame <png>   (one frame, no compare)
+
+require 'zlib'
+
+# -- a small PNG reader -------------------------------------------------------
+#
+# Only the subset stb_image_write emits (mruby-mvjs/src/mvjs.cxx writes the
+# screenshots through it): 8 bits per channel, RGB or RGBA, non-interlaced,
+# zlib-deflated, with any of the five per-row filters — stb picks among them per
+# row. Anything else raises rather than guessing.
+class Frame
+  attr_reader :path, :width, :height, :channels, :pixels
+
+  def initialize(path)
+    @path = path
+    data = File.binread(path)
+    raise 'not a PNG' unless data[0, 8] == "\x89PNG\r\n\x1a\n".b
+
+    idat = ''.b
+    bit_depth = colour_type = nil
+    pos = 8
+    while pos + 8 <= data.bytesize
+      length = data[pos, 4].unpack1('N')
+      type = data[pos + 4, 4]
+      body = data[pos + 8, length]
+      raise "truncated #{type} chunk" if body.nil? || body.bytesize < length
+
+      case type
+      when 'IHDR'
+        @width, @height, bit_depth, colour_type, _, _, interlace =
+          body.unpack('NNCCCCC')
+        raise 'interlaced PNGs are not supported' unless interlace.zero?
+      when 'IDAT' then idat << body
+      when 'IEND' then break
+      end
+      pos += 12 + length
+    end
+
+    unless bit_depth == 8 && [2, 6].include?(colour_type)
+      raise "#{bit_depth}-bit colour type #{colour_type} is not supported"
+    end
+    raise 'no image data' if idat.empty?
+
+    @channels = colour_type == 6 ? 4 : 3
+    @pixels = unfilter(Zlib::Inflate.inflate(idat))
+  end
+
+  # RGB at (x, y) as a 3-byte string. Alpha is ignored: these are opaque
+  # presented frames, and comparing colour alone keeps a frame captured as RGB
+  # comparable with one captured as RGBA.
+  def rgb(x, y)
+    @pixels.byteslice((y * @width + x) * @channels, 3)
+  end
+
+  def size
+    [@width, @height]
+  end
+
+  # Colour census of rows [y0, y1): [number of distinct colours, percentage of
+  # those pixels that are the single most common colour].
+  def census(y0 = 0, y1 = @height)
+    counts = Hash.new(0)
+    (y0...y1).each do |y|
+      (0...@width).each { |x| counts[rgb(x, y)] += 1 }
+    end
+    total = (y1 - y0) * @width
+    return [0, 0.0] if total.zero?
+
+    [counts.size, 100.0 * counts.values.max / total]
+  end
+
+  # Percentage of pixels in rows [y0, y1) whose colour differs from `other`'s.
+  def band_change(other, y0, y1)
+    changed = 0
+    total = 0
+    (y0...y1).each do |y|
+      (0...@width).each do |x|
+        total += 1
+        changed += 1 if rgb(x, y) != other.rgb(x, y)
+      end
+    end
+    total.zero? ? 0.0 : 100.0 * changed / total
+  end
+
+  private
+
+  def unfilter(raw)
+    bpp = @channels
+    stride = @width * bpp
+    out = ''.b
+    prev = "\0".b * stride
+    off = 0
+    @height.times do |row|
+      filter = raw.getbyte(off)
+      raise "the image ends after #{row} of #{@height} rows" if filter.nil?
+
+      off += 1
+      line = raw.byteslice(off, stride)
+      raise "row #{row} is short" if line.nil? || line.bytesize < stride
+
+      off += stride
+      b = line.bytes
+      case filter
+      when 0 then nil
+      when 1 then (bpp...stride).each { |i| b[i] = (b[i] + b[i - bpp]) & 0xff }
+      when 2 then (0...stride).each { |i| b[i] = (b[i] + prev.getbyte(i)) & 0xff }
+      when 3
+        (0...stride).each do |i|
+          left = i >= bpp ? b[i - bpp] : 0
+          b[i] = (b[i] + ((left + prev.getbyte(i)) >> 1)) & 0xff
+        end
+      when 4
+        (0...stride).each do |i|
+          a = i >= bpp ? b[i - bpp] : 0
+          up = prev.getbyte(i)
+          c = i >= bpp ? prev.getbyte(i - bpp) : 0
+          p = a + up - c
+          pa = (p - a).abs
+          pb = (p - up).abs
+          pc = (p - c).abs
+          pred = pa <= pb && pa <= pc ? a : (pb <= pc ? up : c)
+          b[i] = (b[i] + pred) & 0xff
+        end
+      else raise "unknown row filter #{filter}"
+      end
+      line = b.pack('C*')
+      out << line
+      prev = line
+    end
+    out
+  end
+end
+
+# -- thresholds (all measured on data/mz-sample) ------------------------------
+
+# A frame of one colour is a dead renderer. A floor, not the load-bearing check:
+# the M6.3e frames had a sprite and a button in them and clear it easily.
+MIN_COLOURS = 2
+
+# A frame that still has its map is a mix of tiles; one that lost them is the
+# clear colour with a few sprites on top. Measured: 68.5% for the fixed play
+# frame, 99.5% with the M6.3e fix reverted. Not applied to `battle`, whose frame
+# is legitimately 82.1% near-black — the sample ships no battler art or
+# battleback, the same reason MV runs its battle smoke against a real game.
+MAP_DOMINANT_MAX = 90.0
+
+# The message window covers roughly the bottom quarter of the screen: four lines
+# of text and its frame.
+MESSAGE_BAND_TOP = 0.75
+# Antialiased glyphs scatter dozens of intermediate colours through that band;
+# a window skin on its own is a short gradient. Measured: 105 colours with the
+# contents uploading, 18 without.
+MESSAGE_BAND_COLOURS_MIN = 40
+# How much of the band must differ from the plain map frame. Measured: 93.0%.
+MESSAGE_BAND_MIN = 40.0
+# Everything above the halfway line is map in both frames. Measured: 0.3%. The
+# allowance is what a scrolled map would cost; the sample's map is one screen
+# wide, so it does not scroll, and this stays near zero. On a bed whose map
+# scrolls between the two captures this is the assertion that would need
+# rethinking — its job is to prove the change was *the window* and not the whole
+# frame moving for an unrelated reason.
+MESSAGE_OUTSIDE_MAX = 25.0
+
+# A scene change repaints everything. Measured: 100.0% for both menu and battle.
+SCENE_CHANGE_MIN = 50.0
+
+# The save probe re-enters the map the way Scene_Load does, so its frame is the
+# map again. Measured: 0.2% (the player stands where the move probe left it).
+SAVE_CHANGE_MAX = 15.0
+
+# Modes whose frame still has the map in it, so MAP_DOMINANT_MAX applies —
+# including `menu`, which draws its windows over a blurred snapshot of it.
+MAP_MODES = %w[play message menu save].freeze
+MODES = %w[play message menu save battle].freeze
+
+$failures = 0
+$checks = 0
+
+def check(name)
+  $checks += 1
+  yield
+  puts "  ok   #{name}"
+rescue StandardError => e
+  $failures += 1
+  warn "  FAIL #{name}: #{e.message}"
+end
+
+def expect(cond, msg)
+  raise msg unless cond
+end
+
+def load_frame(path)
+  Frame.new(path)
+rescue StandardError => e
+  raise "#{File.basename(path)}: #{e.message}"
+end
+
+# -- per-frame checks ---------------------------------------------------------
+
+def check_frame(frame, label, reference_size, map_scene)
+  check "#{label}: is a readable frame" do
+    expect(frame.width.positive? && frame.height.positive?,
+           "#{frame.width}x#{frame.height} is not a picture")
+    expect(frame.size == reference_size,
+           "#{frame.width}x#{frame.height}, but the other frames are " \
+           "#{reference_size.join('x')} — the frames are not comparable")
+  end
+
+  colours, dominant = frame.census
+  check "#{label}: is not a flat fill" do
+    expect(colours >= MIN_COLOURS,
+           "the whole frame is one colour — nothing was drawn, or the " \
+           'presented buffer never reached the screenshot')
+  end
+
+  return unless map_scene
+
+  check "#{label}: the scene's art reached the frame" do
+    expect(dominant <= MAP_DOMINANT_MAX,
+           format('%.1f%% of the frame is a single colour (allow <= %.1f%%) — ' \
+                  'the scene reported itself drawn but its tiles are missing ' \
+                  'from the frame', dominant, MAP_DOMINANT_MAX))
+    puts format('       %d colours, %.1f%% dominant', colours, dominant)
+  end
+end
+
+# -- entry point --------------------------------------------------------------
+
+if ARGV.first == '--frame'
+  path = ARGV[1]
+  abort "usage: #{$PROGRAM_NAME} --frame <png>" if path.nil?
+  unless File.file?(path)
+    puts "skip: #{path} was not captured"
+    exit 0
+  end
+
+  puts "== #{path}"
+  name = File.basename(path, '.png')
+  mode = name.sub(/\Amz_/, '')
+  frame = load_frame(path)
+  check_frame(frame, name, frame.size, MAP_MODES.include?(mode))
+  puts format('%d checks, %d failures', $checks, $failures)
+  exit($failures.zero? ? 0 : 1)
+end
+
+dir = ARGV[0] || 'ss'
+paths = {}
+MODES.each do |mode|
+  path = File.join(dir, "mz_#{mode}.png")
+  paths[mode] = path if File.file?(path)
+end
+
+if paths.empty?
+  puts "skip #{dir}: no mz_*.png frames were captured " \
+       '(run scripts/mz_boot_check.bash first)'
+  exit 0
+end
+
+puts "== #{dir} (#{paths.keys.join(', ')})"
+
+loaded = {}
+paths.each do |mode, path|
+  loaded[mode] = load_frame(path)
+rescue StandardError => e
+  $checks += 1
+  $failures += 1
+  warn "  FAIL #{mode}: #{e.message}"
+end
+
+reference_size = loaded.values.first&.size
+loaded.each do |mode, frame|
+  check_frame(frame, mode, reference_size, MAP_MODES.include?(mode))
+end
+
+if (message = loaded['message'])
+  band_top = (message.height * MESSAGE_BAND_TOP).to_i
+  check 'message: the window has text in it' do
+    colours, = message.census(band_top, message.height)
+    expect(colours >= MESSAGE_BAND_COLOURS_MIN,
+           format('the message band has %d distinct colours (need >= %d) — ' \
+                  "the window's frame drew but its contents (the text) never " \
+                  'reached the texture', colours, MESSAGE_BAND_COLOURS_MIN))
+    puts format('       %d colours in the message band', colours)
+  end
+end
+
+play = loaded['play']
+if play.nil?
+  puts '  note: no play frame, so the cross-frame checks are skipped ' \
+       '(they all compare against the plain map)'
+else
+  height = play.height
+
+  if (message = loaded['message'])
+    check 'message: a window drew over the map, and only over the map' do
+      inside = message.band_change(play, (height * MESSAGE_BAND_TOP).to_i, height)
+      outside = message.band_change(play, 0, height / 2)
+      expect(inside >= MESSAGE_BAND_MIN,
+             format('the bottom band is %.1f%% different from the plain map ' \
+                    '(need >= %.1f%%) — Window_Message reported itself open ' \
+                    'but never reached the frame', inside, MESSAGE_BAND_MIN))
+      expect(outside <= MESSAGE_OUTSIDE_MAX,
+             format('the top half changed %.1f%% too (allow <= %.1f%%) — the ' \
+                    'whole frame moved, so the bottom band proves nothing ' \
+                    'about the message window', outside, MESSAGE_OUTSIDE_MAX))
+      puts format('       bottom %.1f%% changed, outside %.1f%%', inside, outside)
+    end
+  end
+
+  { 'menu' => 'Scene_Menu', 'battle' => 'Scene_Battle' }.each do |mode, scene|
+    next unless (frame = loaded[mode])
+
+    check "#{mode}: #{scene} repainted the screen" do
+      changed = frame.band_change(play, 0, height)
+      expect(changed >= SCENE_CHANGE_MIN,
+             format('only %.1f%% of the frame differs from the map ' \
+                    '(need >= %.1f%%) — %s was entered but the map is still ' \
+                    'what is on screen', changed, SCENE_CHANGE_MIN, scene))
+      puts format('       %.1f%% changed', changed)
+    end
+  end
+
+  if (save = loaded['save'])
+    check 'save: the round-trip landed back on an intact map' do
+      changed = save.band_change(play, 0, height)
+      expect(changed <= SAVE_CHANGE_MAX,
+             format('%.1f%% of the frame differs from the plain map ' \
+                    '(allow <= %.1f%%) — the save/load round-trip left ' \
+                    'something other than the map on screen',
+                    changed, SAVE_CHANGE_MAX))
+      puts format('       %.1f%% changed', changed)
+    end
+  end
+end
+
+puts format('%d checks, %d failures', $checks, $failures)
+exit($failures.zero? ? 0 : 1)


### PR DESCRIPTION
Follow-up to #373 and #375. Both of those bugs were found by a human looking at screenshots, not by CI — worth fixing, since every assertion in `scripts/mz_boot_check.bash` reads the engine's **log** (`Scene_Map` reached, `$gameMessage` busy with `Window_Message` open, the save chain settled) and none of them looks at a pixel. A frame can be empty while all of that is true, and for a milestone it was.

## What the check does

`scripts/mz_frame_check.rb` decodes the captured PNGs — a small pure-Ruby reader for the subset `stb_image_write` emits — and asks two kinds of question.

**Per frame, absolute.** The M6.3e frames were not blank: the player sprite and the touch-UI button still drew, so a "not a flat fill" floor passes on them. What they had lost was the map — 99.5% of the play frame was a single colour against 68.5% intact. And the message band holds 105 distinct colours when the window's contents upload against 18 when only its skin draws, because antialiased glyphs scatter intermediate colours through it.

**Across frames, relational.** Each mode's frame against the plain map frame from `play`:

| comparison | measured | what it proves |
| --- | --- | --- |
| message, bottom band | 93.0% changed | a window drew over the map… |
| message, above the halfway line | 0.3% changed | …and *only* there, so it was the window and not the frame moving |
| menu / battle, whole frame | 100.0% changed | the scene replaced the map |
| save, whole frame | 0.2% changed | the round-trip landed back on an intact map |

## Why both halves

The relational half alone would **not** have caught M6.3e: that bug degraded every frame identically, so the differences between modes survived it intact (the window skin still drew, over a black map).

I know because the first draft of this check was relational only, and I tested it by rebuilding with `texSubImage2D` reverted to a no-op — every mode still passed. The absolute half comes from what that experiment measured, and the same experiment is now the non-vacuity proof: **with the fix reverted, all five `mz_boot_check.bash` modes still report OK while the frame check fails** on the play frame's dominant colour (99.5%) and the message band's colour count (18).

## Wiring

- `mz_boot_check.bash` runs the single-frame half on what it just captured, so each mode still fails on its own.
- The cross-mode comparisons need all five frames, so they run as a CI step after the parallel group's implicit wait. Non-blocking, like the MZ smokes it reads; skips cleanly when the engine was not fetched.

## Testing

All five modes pass end to end on `data/mz-sample` (19 checks, 0 failures). `ctest` unchanged — only the pre-existing `exe_open` fails, which needs a downloaded game absent from this environment. Negative-tested three ways: synthetic frames (a `play` frame copied over `mz_message.png` fails the band check), the real reverted-fix build above, and absent/short/corrupt PNGs.

## Docs

ADR 0004 gains **M6.3g**; README and a `changelog.d/` fragment updated. It records the failed first draft, because that's the useful part: **a test written from a theory of the bug is not a test until the bug is put back.**

---
_Generated by [Claude Code](https://claude.ai/code/session_014B8H5L6jNJqN8HL7WGHbcS)_