### PR TITLE
Give RPG2000 actors a life outside the party

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,6 +270,15 @@ jobs:
               ./scripts/nix-develop.bash ruby scripts/rpg2k_scene_check.rb
               ./scripts/nix-develop.bash ruby scripts/rpg2k_render_check.rb
 
+          # The join of the two check kinds above: real test-bed databases
+          # (LCF test-bed smoke check's data) driven through the real
+          # Game::Interpreter, so a rule only genuine game data violates gets
+          # caught. Its first subject is Nepheshel's companion swaps — the
+          # party-roster bug of ADR 0030 passed every fixture check. Skips with
+          # exit 0 when no game has been downloaded.
+          - name: RPG2k test-bed logic check
+            run: ./scripts/nix-develop.bash ruby scripts/rpg2k_testbed_logic_check.rb
+
           - name: test
             run: |
               ./scripts/nix-develop.bash cmake --build build -t test

--- a/changelog.d/permanent-actor-roster.fixed.md
+++ b/changelog.d/permanent-actor-roster.fixed.md
@@ -1,0 +1,22 @@
+- **A party member who leaves and rejoins keeps everything they had.** RPG2000
+  actors now live in a permanent `Game::Actors` roster and the party is an
+  ordered list of ids into it (RPG_RT's `Game_Actors`, ADR 0030), instead of the
+  party owning its members and rebuilding them from the database row on every
+  Change Party Member. Nepheshel's whole companion mechanic runs on that command
+  — 5205 of them, 2835 adds and 2370 removes — so dismissing and re-summoning a
+  companion used to reset her from level 21 / 16682 EXP / nine learned skills to
+  level 1 / 0 EXP / one skill and undo any renaming. The roster is saved and
+  restored too: both the Marshal save and `Save<N>.lsd` chunk 108 now carry every
+  actor the party has ever held (which is what a genuine RPG_RT save holds), and
+  loading a real save no longer discards the companions who were away.
+- **`\N[n]` in a message names the live actor**, not the database row, so a hero
+  the player named through Enter Hero Name is called what they chose — Nepheshel
+  renames actor 1 and then refers to `\N[1]` in 34 messages. **`\N[0]`** is the
+  party leader; actor ids are 1-based, so it used to expand to nothing and left a
+  boss line reading `\n[0]よ…` without its subject.
+- **New check: `scripts/rpg2k_testbed_logic_check.rb`**, which drives a real test
+  bed's `RPG_RT.ldb` through the real `Game::Interpreter` — the join of
+  `lcf_testbed_check.rb` (real data, never run) and `rpg2k_logic_check.rb` (run,
+  never real data). It exists because the party-roster bug above passed every
+  fixture check while breaking the actual game. Runs in CI beside the other
+  RPG2k logic checks; a game with nothing to exercise is skipped, not failed.

--- a/changelog.d/permanent-actor-roster.fixed.md
+++ b/changelog.d/permanent-actor-roster.fixed.md
@@ -18,6 +18,13 @@
   command in Nepheshel (7805 — Change Skills on actor 1 alone is 2871) names a
   companion the game also dismisses, so 653 of the game's own commands per
   companion silently did nothing whenever that companion was away.
+- **Reading an actor sees one who is out of the party.** Control Variables'
+  actor-stat operand and Conditional Branch's actor tests (level / HP / name /
+  knows-skill / has-equipped / has-state) now read the roster; only the
+  "is in the party" test still asks the party, which is the split RPG_RT makes.
+  All 2436 of Nepheshel's actor-stat reads name a swappable companion and its
+  party status display is built out of them, so a dismissed member showed as
+  level 0; 243 conditionals took the wrong branch for the same reason.
 - **`\N[n]` in a message names the live actor**, not the database row, so a hero
   the player named through Enter Hero Name is called what they chose — Nepheshel
   renames actor 1 and then refers to `\N[1]` in 34 messages. **`\N[0]`** is the

--- a/changelog.d/permanent-actor-roster.fixed.md
+++ b/changelog.d/permanent-actor-roster.fixed.md
@@ -9,6 +9,15 @@
   restored too: both the Marshal save and `Save<N>.lsd` chunk 108 now carry every
   actor the party has ever held (which is what a genuine RPG_RT save holds), and
   loading a real save no longer discards the companions who were away.
+- **A command that names one actor now finds them even when they are out of the
+  party.** Change EXP / Level / Parameters / Skills / Equipment / HP / MP /
+  Condition / Full Heal / Simulated Attack with a fixed or variable-selected
+  target, and Change Actor Name / Title / Sprite / Face and Enter Hero Name, all
+  resolve through the roster the way RPG_RT's `Game_Actors` does; only the
+  "whole party" scope still means the current members. Every fixed-actor-id
+  command in Nepheshel (7805 — Change Skills on actor 1 alone is 2871) names a
+  companion the game also dismisses, so 653 of the game's own commands per
+  companion silently did nothing whenever that companion was away.
 - **`\N[n]` in a message names the live actor**, not the database row, so a hero
   the player named through Enter Hero Name is called what they chose — Nepheshel
   renames actor 1 and then refers to `\N[1]` in 34 messages. **`\N[0]`** is the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -52,7 +52,11 @@ CI after the download step), which parses a genuine game's
 synthetic unit tests can't; the gameplay logic (`game.rb`/`interpreter.rb`) is
 checked by `scripts/rpg2k_logic_check.rb` (pure move-route / interpreter logic)
 and `scripts/rpg2k_scene_check.rb` (the map scene driving event movement behind
-RGSS stubs).
+RGSS stubs). `scripts/rpg2k_testbed_logic_check.rb` is the join of the two
+kinds — a *real* game's `RPG_RT.ldb` driven through the *real*
+`Game::Interpreter` — for rules that only genuine data violates: its first
+subject is Nepheshel's companion swaps, where the party-roster bug of ADR 0030
+passed every fixture check while breaking the actual game.
 
 The work below is roughly ordered by the critical path to a walkable game
 (1 → 2 → 3 → 4/5/6 → 7/8/9); battle and full menus can follow.
@@ -287,7 +291,24 @@ The work below is roughly ordered by the critical path to a walkable game
   row's exp_basic/increase/correction) and **Change Level** rescales base stats
   through the per-level growth curve, both keeping EXP and level consistent
   without refilling current HP/MP, matching RPG_RT; Change Equipment folds an
-  equipped item's bonuses into the effective stats). **Control
+  equipped item's bonuses into the effective stats). **Change Party Member**
+  moves actors in and out of the party, and what it moves is an entry in a
+  **permanent roster** (`Game::Actors`, RPG_RT's `Game_Actors`): one
+  `Game::Actor` exists per database row for the whole session and the party is
+  only an ordered list of ids into it. That is the difference between a
+  companion who rejoins with the level, EXP, learned skills, equipment, statuses
+  and renamed name they left with and one rebuilt from the database row — which
+  is what used to happen, resetting a level-21 companion with 16682 EXP and nine
+  skills back to level 1 with one. Nepheshel's entire companion mechanic runs on
+  this command (**5205** of them: 2835 adds, 2370 removes, mostly the three
+  summonable party members and their alternates), and driving its real 召還 /
+  帰す common events through the interpreter is how both the break and the fix
+  were measured; the other test bed issues the command zero times, which is why
+  it hid for so long. The roster is what the **save** carries as well — the
+  Marshal save and `Save<N>.lsd` chunk 108 both hold every actor the party has
+  ever held, matching a genuine RPG_RT save, so a companion who is away when the
+  game is saved comes back intact instead of being dropped on load. See ADR
+  0030. **Control
   Variables** reads not just constants and other variables but also a **random**
   range, an **actor stat** (level / EXP / HP / MP / max HP-MP / attack / defence /
   spirit / agility, and the **id of the item in each of the five equipment
@@ -679,7 +700,13 @@ The work below is roughly ordered by the critical path to a walkable game
   105–107 / the Marshal save).
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`,
-  `\_` space). Text now **reveals gradually** (a `Game::TextReveal` typewriter
+  `\_` space). `\n[n]` names the **live** actor out of the roster rather than the
+  database row, so a hero the player named through Enter Hero Name is called what
+  they chose — Nepheshel renames actor 1 and then writes `\N[1]` in 34 messages —
+  and `\n[0]` is the **party leader** (actor ids are 1-based, so it used to
+  expand to nothing and left the boss line `\n[0]よ…` without its subject). An
+  actor the game has never instantiated still falls back to the database name.
+  Text now **reveals gradually** (a `Game::TextReveal` typewriter
   driven by `Scene::Map`, with a button press completing the reveal before
   dismissing), and the **pacing codes act**: `Game::Message.scan` surfaces
   `\!` (wait for a button), `\.` / `\|` (¼ / 1-second holds), `\^` (close the
@@ -876,7 +903,12 @@ The work below is roughly ordered by the critical path to a walkable game
   prefers it) are two fields the `.lsd` cannot yet carry: the **game timer**
   (liblcf's SaveSystem has no field for it — needs a documented chunk id) and
   **per-actor name/title overrides for non-leader** members (only the leader's
-  name is in the title chunk)
+  name is in the title chunk). Both save paths carry the **whole actor roster**,
+  not just the current party: chunk 108 holds one entry per actor the party has
+  ever held (which is what a genuine RPG_RT save holds), so a companion who is
+  out of the party when the game is saved is written out and read back rather
+  than being silently dropped — `.from_lsd` used to skip exactly those rows. See
+  ADR 0030
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations (large; Nepheshel uses the default RPG2000 battle). Needs real
   assets + the native build to develop against. The game-over scene is done

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -315,7 +315,15 @@ The work below is roughly ordered by the critical path to a walkable game
   and `Game_Actors::GetActor` otherwise. That too is the common case rather than
   a corner: all **7805** fixed-actor-id commands in Nepheshel name a companion it
   also dismisses (Change Skills on actor 1 alone is 2871), and 653 per companion
-  silently did nothing while that companion was away. See ADR 0030. **Control
+  silently did nothing while that companion was away. **Reading** an actor goes
+  the same way, with one deliberate exception: Conditional Branch's "is this
+  actor in the party" test really does ask the party, while its other six tests
+  (name / level / HP / knows-skill / has-equipped / has-state) and Control
+  Variables' actor-stat operand ask the actor — the split RPG_RT makes between
+  `IsActorInParty` and `Game_Actors::GetActor`. Nepheshel writes 28 of the first
+  and 243 of the second, and all **2436** of its actor-stat reads name a
+  swappable companion, which is why its party status display used to list a
+  dismissed member at level 0. See ADR 0030. **Control
   Variables** reads not just constants and other variables but also a **random**
   range, an **actor stat** (level / EXP / HP / MP / max HP-MP / attack / defence /
   spirit / agility, and the **id of the item in each of the five equipment

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -307,8 +307,15 @@ The work below is roughly ordered by the critical path to a walkable game
   it hid for so long. The roster is what the **save** carries as well — the
   Marshal save and `Save<N>.lsd` chunk 108 both hold every actor the party has
   ever held, matching a genuine RPG_RT save, so a companion who is away when the
-  game is saved comes back intact instead of being dropped on load. See ADR
-  0030. **Control
+  game is saved comes back intact instead of being dropped on load. The roster is
+  also what a command **naming one actor** resolves through — every command above
+  that takes a fixed or variable-selected actor rather than the whole party, plus
+  Change Actor Name / Title / Sprite / Face and Enter Hero Name — matching
+  RPG_RT's `GetActors`, which reads the party only for the "whole party" scope
+  and `Game_Actors::GetActor` otherwise. That too is the common case rather than
+  a corner: all **7805** fixed-actor-id commands in Nepheshel name a companion it
+  also dismisses (Change Skills on actor 1 alone is 2871), and 653 per companion
+  silently did nothing while that companion was away. See ADR 0030. **Control
   Variables** reads not just constants and other variables but also a **random**
   range, an **actor stat** (level / EXP / HP / MP / max HP-MP / attack / defence /
   spirit / agility, and the **id of the item in each of the five equipment

--- a/docs/adr/0030-permanent-actor-roster.md
+++ b/docs/adr/0030-permanent-actor-roster.md
@@ -125,6 +125,16 @@ Introduce `Game::Actors`, a permanent roster keyed by database id, and demote
   roster rather than better: before, a dismissed companion was rebuilt from the
   database anyway, so a missed Change Skills was masked by the larger reset;
   now the companion persists, so the skill is simply never learned.
+- **Reading an actor goes through the roster too**, and the split is the
+  interesting part. Conditional Branch type 5 has seven sub-conditions: "is in
+  the party" is a *party* question (`IsActorInParty`) and the other six —
+  name, level, HP, knows-skill, has-equipped, has-state — are *actor* questions
+  (`Game_Actors::GetActor`). Nepheshel writes 28 of the first kind and 243 of
+  the second, so answering both from the party sent 243 branches down the wrong
+  path whenever the companion they named was away. Control Variables' actor-stat
+  operand is the same: **all 2436** of Nepheshel's name a swappable companion,
+  and the game's party status display is built out of them, so a dismissed
+  member was listed at level 0.
 
 ## Consequences
 

--- a/docs/adr/0030-permanent-actor-roster.md
+++ b/docs/adr/0030-permanent-actor-roster.md
@@ -108,6 +108,23 @@ Introduce `Game::Actors`, a permanent roster keyed by database id, and demote
   now match what a genuine save holds.
 - `\N[n]` resolves the live roster actor, falling back to the database row for
   an actor the game has never instantiated; `\N[0]` is the party leader.
+- **A command that names one actor resolves through the roster, not the party.**
+  RPG_RT's `Game_Interpreter::GetActors` reads the party only for scope 0 ("the
+  whole party") and goes to `Game_Actors::GetActor` for a fixed or
+  variable-indexed id, so Change EXP / Level / Parameters / Skills / Equipment /
+  HP / MP / Condition / Full Heal / Simulated Attack and the four Change Actor
+  Name / Title / Sprite / Face commands (plus Enter Hero Name) all reach a
+  member who is currently away.
+
+  This is the other half of the same bug, and it is not a corner case:
+  **every** fixed-actor-id command in Nepheshel — 7805 of them, of which Change
+  Skills on actor 1 alone is 2871 — names an actor the game also dismisses. A
+  party-only lookup dropped the lot whenever the target happened to be out.
+  Measured per companion, 653 of the game's own commands change nothing at all
+  when run against an absent actor under the old lookup. It got worse with the
+  roster rather than better: before, a dismissed companion was rebuilt from the
+  database anyway, so a missed Change Skills was masked by the larger reset;
+  now the companion persists, so the skill is simply never learned.
 
 ## Consequences
 
@@ -129,10 +146,11 @@ object; the trade-off is that "roster" now means two things in the code's
 history (the old `.lsd` field name for the party id list is renamed
 `member_ids` at the one place both appear, to keep that straight).
 
-Follow-up this does not do: `Change Actor Name` / `Change Actor Title` (10610 /
-10620) still only find actors through `Party#actor_by_id`, so they act on
-current members only. Neither test bed uses either command, so there is nothing
-to measure the correct behaviour against yet.
+One shape of bug is closed off for good: "the party did not have that actor, so
+nothing happened" can no longer be a silent outcome. Every place that used to
+say *a no-op for an actor not in the party* now says what RPG_RT says, and the
+only remaining nil is an id the **database** has no row for — which is logged,
+once per id so a parallel process asking every frame cannot flood the log.
 
 Covered by `scripts/rpg2k_logic_check.rb` (rejoining keeps state; the roster
 builds each id once; the save carries actors who are out of the party) and
@@ -146,7 +164,11 @@ test bed's `RPG_RT.ldb` through the **real** `Game::Interpreter`, joining what
 real data) each do half of. It finds every actor a game's common events both add
 and remove, then runs the game's own commands to take each companion out and
 bring them back — across a plain swap, a Marshal save and a `.lsd` round trip.
-Nepheshel's three companions give 18 checks; against the old party model they
-fail with the state diff spelled out (`level 6 → 1`, `645 EXP → 0`, three skills
-→ one). A game with no companion swaps, like mtf-meido-action, is reported and
-skipped rather than failed. It runs in CI beside the other RPG2k logic checks.
+It also replays every fixed-actor-id command the game aims at each companion
+while that companion is out of the party, and asserts they are not all no-ops.
+
+Nepheshel's three companions give 24 checks; against the old party model they
+fail with the numbers spelled out (`level 6 → 1`, `645 EXP → 0`, three skills →
+one; `653 command(s) changed the absent actor`). A game with no companion swaps,
+like mtf-meido-action, is reported and skipped rather than failed. It runs in CI
+beside the other RPG2k logic checks.

--- a/docs/adr/0030-permanent-actor-roster.md
+++ b/docs/adr/0030-permanent-actor-roster.md
@@ -1,0 +1,152 @@
+# 30. Actors live in a permanent roster, not in the party list
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+`Game::Party` owned its members outright. `add_actor` built a fresh
+`Game::Actor` from the database row and pushed it; `remove_actor` dropped the
+object on the floor:
+
+```ruby
+def add_actor(id)
+  return if include_actor?(id)
+  @actors.push Actor.new(@db, id)      # <- rebuilt from the database, every time
+  @revision += 1
+end
+
+def remove_actor(id)
+  @actors.reject! { |a| a.id == id }   # <- the only reference; the actor is gone
+end
+```
+
+That is fine for a game whose party never changes. It is wrong for a game whose
+party changes constantly, and Nepheshel is exactly that game: its entire
+companion mechanic is Change Party Member (10330), which it issues **5205
+times** — 2835 adds and 2370 removes. Tallied by actor id:
+
+| actor | adds | removes |
+|---|---|---|
+| 2 ファル | 630 | 471 |
+| 3 ティララ | 630 | 471 |
+| 4 ディーヴァ | 630 | 471 |
+| 5 ファル (alt) | 312 | 316 |
+| 6 ティララ (alt) | 312 | 316 |
+| 7 ディーヴァ (alt) | 312 | 316 |
+| 1, 15 | 9 | 9 |
+
+Common event 1 (ファル召還, "summon Fal") adds actor 2; common event 2
+(ファルを帰す, "send Fal home") removes her. The player summons and dismisses
+companions all game long. Every dismissal threw the companion away and every
+summon rebuilt her from the database row, so a levelled companion came back as a
+level-1 stranger. Driving those two real common events through the interpreter
+against the real `RPG_RT.ldb` measures it exactly — level, EXP, name, HP and
+skill count before the swap versus after:
+
+```
+after levelling: id2 [21, 16682, "RENAMED", 3, 9]
+in party after remove: [15]
+after rejoin:    id2 [1, 0, "ファル", 30, 1]
+```
+
+Level 21 → 1. 16682 EXP → 0. Nine learned skills → one. The rename undone.
+Everything the player had invested in that companion, discarded on the round
+trip. (The other test bed, mtf-meido-action, issues no Change Party Member at
+all, which is why this went unnoticed: it is a Nepheshel-shaped bug.)
+
+The save layer had the same hole from the other end. `#to_h` and `#to_lsd` wrote
+one per-actor entry per *current member*, and `.from_lsd` skipped saved actors
+who were not in the party:
+
+```ruby
+(save[108] || []).each do |aid, sa|
+  next unless roster.include?(aid)      # <- a companion who is away is dropped
+```
+
+So even the actors that survived in memory did not survive a save.
+
+The `.lsd` format itself says what the model should be. `AGENTS.md` already
+records chunk 108 (`SAVE_PARTY_ACTOR`) as "one entry per actor the party has
+**ever** held" — a real Nepheshel save carries rows for companions who are not
+currently along. A table keyed by actor id, holding everyone the game has met,
+is not something to invent: it is what RPG_RT serialises, because RPG_RT keeps
+one `Game_Actor` per database row for the whole session (`Game_Actors`) and
+treats the party as nothing more than a list of ids into it.
+
+A second, smaller symptom shared the same root. The `\N[n]` message control code
+resolved through `@db.player[id].name` — the *database* row — so a hero the
+player had named could not be addressed by the name they chose. Nepheshel opens
+Enter Hero Name (10740) on actor 1 and then refers to `\N[1]` in 34 messages.
+`\N[0]` was worse than stale: actor ids are 1-based, so it resolved to nothing
+at all and rendered as the empty string, which is how a boss line reading
+`\n[0]よ…` ("…, you") lost its subject.
+
+## Decision
+
+Introduce `Game::Actors`, a permanent roster keyed by database id, and demote
+`Game::Party` to an ordered view over it.
+
+- `Actors#[]` builds an actor from the database on first request and caches it
+  from then on — RPG_RT's `Game_Actors::GetActor`. A missing row logs and
+  returns nil instead of raising, so a game that references an actor the
+  database lacks keeps running.
+- `Actors#existing` looks up **without** creating. Read paths use it, so merely
+  naming an actor in a message does not enrol them in the roster the save
+  writes out.
+- `Party#add_actor` takes its actor from the roster, so rejoining is literally
+  the same object; `Party#remove_actor` only edits the ordered list.
+- `Party#to_h` writes the per-actor tables for the whole roster and keeps
+  `actor_ids` as the party proper. `#load_state` restores every id the saved
+  tables mention, pulling each through the roster, so an actor who was away when
+  the game was saved comes back exactly as they left.
+- `State#to_lsd` writes chunk 108 from the roster and `.from_lsd` restores every
+  entry in it, dropping the `next unless roster.include?` guard. Both directions
+  now match what a genuine save holds.
+- `\N[n]` resolves the live roster actor, falling back to the database row for
+  an actor the game has never instantiated; `\N[0]` is the party leader.
+
+## Consequences
+
+Nepheshel's companion system works. A summoned companion keeps their level, EXP,
+learned skills, equipment, statuses, current HP/SP and any renaming across a
+dismissal, a re-summon, and a save taken while they are away — the same three
+figures as above now read `[21, 16682, "RENAMED", 3, 9]` at every step.
+
+Saves get slightly larger (per-actor rows for everyone met, not just the current
+party) and slightly more compatible: a real `.lsd` written by the editor with
+out-of-party companions in chunk 108 now loads them instead of discarding them.
+Older Marshal saves still load — an absent roster entry simply leaves that actor
+at their database defaults, which is what the old saves recorded anyway.
+
+The roster is reachable as `state.party.roster`. Placing it behind the party
+rather than on `Game::State` keeps every existing `state.party.*` call site
+working and keeps the two halves — who exists, who is fighting — owned by one
+object; the trade-off is that "roster" now means two things in the code's
+history (the old `.lsd` field name for the party id list is renamed
+`member_ids` at the one place both appear, to keep that straight).
+
+Follow-up this does not do: `Change Actor Name` / `Change Actor Title` (10610 /
+10620) still only find actors through `Party#actor_by_id`, so they act on
+current members only. Neither test bed uses either command, so there is nothing
+to measure the correct behaviour against yet.
+
+Covered by `scripts/rpg2k_logic_check.rb` (rejoining keeps state; the roster
+builds each id once; the save carries actors who are out of the party) and
+`scripts/rpg2k_scene_check.rb` (`\N[n]` names the live actor, `\N[0]` the
+leader).
+
+Fixtures were not enough to find this, so the change also adds
+`scripts/rpg2k_testbed_logic_check.rb`: a new harness that drives a **real**
+test bed's `RPG_RT.ldb` through the **real** `Game::Interpreter`, joining what
+`lcf_testbed_check.rb` (real data, not run) and `rpg2k_logic_check.rb` (run, not
+real data) each do half of. It finds every actor a game's common events both add
+and remove, then runs the game's own commands to take each companion out and
+bring them back — across a plain swap, a Marshal save and a `.lsd` round trip.
+Nepheshel's three companions give 18 checks; against the old party model they
+fail with the state diff spelled out (`level 6 → 1`, `645 EXP → 0`, three skills
+→ one). A game with no companion swaps, like mtf-meido-action, is reported and
+skipped rather than failed. It runs in CI beside the other RPG2k logic checks.

--- a/mruby-rpg2k/mrbgem.rake
+++ b/mruby-rpg2k/mrbgem.rake
@@ -5,4 +5,17 @@ MRuby::Gem::Specification.new('mruby-rpg2k') do |spec|
 
   add_dependency 'mruby-lcf'
   add_dependency 'mruby-rgss'
+
+  # Core *-ext gems whose methods this gem's Ruby actually calls. They are in the
+  # shared list in build_config.rb (rpg_maker_gems) so the full game build has
+  # them, but the dependency belongs here too — see AGENTS.md: a per-gem build
+  # only pulls the gem plus its declared dependencies, so an undeclared one is a
+  # NoMethodError waiting for the first gem-level test.
+  #   mruby-array-ext   Array#compact  (Show Choices' label list, the party
+  #                     roster's initial members)
+  #   mruby-numeric-ext Integer#zero?  (used across game.rb / main.rb)
+  #   mruby-enum-ext    Enumerable#sort_by / each_with_object
+  add_dependency 'mruby-array-ext'
+  add_dependency 'mruby-numeric-ext'
+  add_dependency 'mruby-enum-ext'
 end

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1643,21 +1643,69 @@ module Game
     end
   end
 
-  # The active party. On a new game it is seeded from the database's initial
-  # party list (System.party).
+  # Every actor the game has instantiated, keyed by database id — RPG_RT's
+  # `Game_Actors`. One `Game::Actor` exists per database row for the whole
+  # session and the party is only a list of ids into this table, which is why
+  # taking a member out of the party and putting them back keeps their level,
+  # EXP, equipment, learned skills, statuses and renamed name instead of
+  # rebuilding them from the database row.
+  #
+  # The save format says the same thing: `Save<N>.lsd`'s chunk 108
+  # (`SAVE_PARTY_ACTOR`) holds one entry per actor the party has *ever* held,
+  # not one per current member, so a roster is what that table serialises.
+  # See ADR 0030.
+  class Actors
+    def initialize(db)
+      @db = db
+      @all = {}
+    end
+
+    # The actor for `id`, built from the database on first request and cached
+    # from then on (RPG_RT's `Game_Actors::GetActor`). nil for a non-positive id
+    # or a row the database does not have — the miss is logged rather than
+    # raised, so a game that references a missing actor keeps running.
+    def [](id)
+      return nil if id.nil? || id <= 0
+      a = @all[id]
+      return a if a
+      @all[id] = Actor.new(@db, id)
+    rescue RuntimeError => e
+      $stderr.puts "[RPG2k] actor ##{id} could not be built: #{e.message}"
+      nil
+    end
+
+    # The actor for `id` only if it has already been instantiated, without
+    # creating one. Read paths (a `\N[n]` message code) use this so merely
+    # naming an actor does not enrol them in the roster the save writes out.
+    def existing(id); id.nil? ? nil : @all[id]; end
+
+    # Every instantiated actor, in ascending database id order.
+    def all; @all.keys.sort.map { |i| @all[i] }; end
+
+    def each(&blk); all.each(&blk); end
+  end
+
+  # The active party: an ordered subset of the `Actors` roster. On a new game it
+  # is seeded from the database's initial party list (System.party).
   class Party
     include Enumerable
 
     attr_reader :actors, :items, :gold
 
-    # Bumped whenever the roster or the bag changes — the two halves of the party
-    # an event page's conditions can test (see Switches#revision).
+    # The permanent actor roster this party draws from (see Game::Actors). The
+    # party owns it, so `State#party.roster` reaches every actor the game has
+    # met, including ones who have since left.
+    attr_reader :roster
+
+    # Bumped whenever the membership or the bag changes — the two halves of the
+    # party an event page's conditions can test (see Switches#revision).
     attr_reader :revision
 
-    def initialize(db, ids = nil)
+    def initialize(db, ids = nil, roster = nil)
       @db = db
+      @roster = roster || Actors.new(db)
       ids ||= db.system.party || []
-      @actors = ids.reject { |i| i.nil? || i <= 0 }.map { |i| Actor.new(db, i) }
+      @actors = ids.reject { |i| i.nil? || i <= 0 }.map { |i| @roster[i] }.compact
       @items = {}  # item id => count
       @gold = 0
       @revision = 0
@@ -1666,12 +1714,17 @@ module Game
     # Serialise the mutable party state (see State#to_h). Beyond HP/MP this keeps
     # the fields the Change Actor Name / Title / Sprite commands mutate, so those
     # edits survive a Save / Continue instead of reverting to the database row.
+    #
+    # The per-actor tables cover the whole **roster**, not just the current
+    # members: an actor the game has taken out of the party keeps their level,
+    # gear and name for when they rejoin, so the save has to carry them too.
+    # `actor_ids` is the party proper, in order.
     def to_h
       hp = {}
       mp = {}
       exp = {}
       meta = {}
-      @actors.each do |a|
+      @roster.each do |a|
         hp[a.id] = a.hp
         mp[a.id] = a.mp
         exp[a.id] = a.exp
@@ -1693,6 +1746,11 @@ module Game
     # from a saved party hash. EXP is restored first (it re-derives the level and
     # its base stats), then the saved HP/MP are laid over the recomputed maxima.
     # A save written before actor_meta existed simply keeps the database defaults.
+    #
+    # Every id the saved tables mention is restored, not just the current
+    # members, so an actor waiting out of the party comes back as they left
+    # (#to_h writes the whole roster). Actors are pulled through the roster, so
+    # restoring one that is not in the party enrols them there.
     def load_state(data)
       @revision += 1
       @items = data[:items] || {}
@@ -1701,14 +1759,20 @@ module Game
       hp = data[:hp] || {}
       mp = data[:mp] || {}
       meta = data[:actor_meta] || {}
-      @actors.each do |a|
+      ids = @actors.map { |a| a.id }
+      [exp, hp, mp, meta].each do |table|
+        table.keys.each { |id| ids.push(id) unless ids.include?(id) }
+      end
+      ids.each do |id|
+        a = @roster[id]
+        next unless a
         # The class comes back first: it decides which growth and EXP curves the
         # restored EXP is then read against.
-        m = meta[a.id]
+        m = meta[id]
         a.restore_class(m[:class_id]) if m && m[:class_id]
-        a.set_exp(exp[a.id]) if exp[a.id]
-        a.hp = hp[a.id] if hp[a.id]
-        a.mp = mp[a.id] if mp[a.id]
+        a.set_exp(exp[id]) if exp[id]
+        a.hp = hp[id] if hp[id]
+        a.mp = mp[id] if mp[id]
         apply_actor_meta(a, m)
       end
     end
@@ -1740,12 +1804,19 @@ module Game
     # Whether the whole party is knocked out (戦闘不能) -- the game-over condition.
     def all_dead?; !any_alive?; end
 
+    # Put an actor in the party. The actor comes from the roster, so one who has
+    # been in the party before rejoins with the level, EXP, gear, skills, statuses
+    # and name they left with rather than a fresh database row.
     def add_actor(id)
       return if include_actor?(id)
-      @actors.push Actor.new(@db, id)
+      a = @roster[id]
+      return unless a
+      @actors.push a
       @revision += 1
     end
 
+    # Take an actor out of the party. They stay in the roster (and in the save),
+    # which is what lets #add_actor give them back unchanged.
     def remove_actor(id)
       before = @actors.size
       @actors.reject! { |a| a.id == id }
@@ -5818,8 +5889,11 @@ module Game
       sys[132] = 1
       save[101] = sys
 
+      # Chunk 108 is the whole roster, one entry per actor the party has ever
+      # held — that is what a genuine RPG_RT save carries, and it is what lets an
+      # actor who is currently out of the party come back as they left.
       actors = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
-      @party.actors.each do |a|
+      @party.roster.each do |a|
         e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
         e[31] = a.level
         e[32] = a.exp
@@ -5875,21 +5949,25 @@ module Game
     def self.from_lsd(db, save)
       hero = save.hero
       inv = save.inventory
-      roster = inv.party || []
-      party = Party.new(db, roster)
+      member_ids = inv.party || []
+      party = Party.new(db, member_ids)
       items = {}
       ids = inv.item_ids || []
       counts = inv.item_counts || []
       ids.each_index { |i| items[ids[i]] = counts[i] || 0 }
       # Per-actor state comes from the SAVE_PARTY_ACTOR table (chunk 108), keyed
-      # by actor id. Restore each roster member's saved level (which rescales its
-      # base stats) and exp first, then its current HP/SP, so Continue resumes a
+      # by actor id. Restore each actor's saved level (which rescales its base
+      # stats) and exp first, then its current HP/SP, so Continue resumes a
       # levelled, wounded party rather than a fresh full-health one.
+      #
+      # Every entry is restored, not only the current members: the chunk is the
+      # roster (one row per actor the party has ever held), so an actor waiting
+      # out of the party is rebuilt here and rejoins as they left. Reading them
+      # through the roster is what enrols them.
       hp = {}
       mp = {}
       (save[108] || []).each do |aid, sa|
-        next unless roster.include?(aid)
-        actor = party.actor_by_id(aid)
+        actor = party.roster[aid]
         if actor
           actor.set_level(sa.level) if sa.level
           actor.exp = sa.exp if sa.exp

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1658,19 +1658,25 @@ module Game
     def initialize(db)
       @db = db
       @all = {}
+      @missing = {} # ids already reported, so a bad id in a loop logs once
     end
 
     # The actor for `id`, built from the database on first request and cached
     # from then on (RPG_RT's `Game_Actors::GetActor`). nil for a non-positive id
     # or a row the database does not have — the miss is logged rather than
-    # raised, so a game that references a missing actor keeps running.
+    # raised, so a game that references a missing actor keeps running. A command
+    # in a parallel process can ask every frame, so each bad id is reported once
+    # rather than filling the log.
     def [](id)
       return nil if id.nil? || id <= 0
       a = @all[id]
       return a if a
       @all[id] = Actor.new(@db, id)
     rescue RuntimeError => e
-      $stderr.puts "[RPG2k] actor ##{id} could not be built: #{e.message}"
+      unless @missing[id]
+        @missing[id] = true
+        $stderr.puts "[RPG2k] actor ##{id} could not be built: #{e.message}"
+      end
       nil
     end
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1080,7 +1080,7 @@ module Game
     # with the entered name. A no-op (no wait) for an actor not in the party, since
     # this build only instantiates party actors.
     def do_name_input(cmd)
-      actor = party.actor_by_id(cmd.param(0))
+      actor = identity_target(cmd)
       return unless actor
       @name_input_request = {
         actor_id: cmd.param(0), charset: cmd.param(1),
@@ -1487,12 +1487,23 @@ module Game
 
     # The actors a stat-change command targets. param0 selects the scope: 0 the
     # whole party, 1 a fixed actor id (param1), 2 the actor whose id is held in
-    # variable param1. Actors not in the party resolve to nothing.
+    # variable param1.
+    #
+    # Only scope 0 means "the party". A **named** actor is looked up in the
+    # roster, so the command reaches one who is currently out of the party —
+    # RPG_RT's `Game_Interpreter::GetActors`, which reads the party for scope 0
+    # and `Game_Actors::GetActor` for the other two. That distinction is the
+    # whole point in a game that swaps members: **every** fixed-id stat command
+    # in Nepheshel (7805 of them — Change Skills on actor 1 alone is 2871) names
+    # an actor the game also dismisses, so treating a named target as
+    # party-only silently dropped the lot whenever that actor was away. With
+    # actors persisting (ADR 0030) such a miss is permanent: the skill is never
+    # learned rather than being re-granted on the next rebuild.
     def stat_targets(cmd)
       case cmd.param(0)
       when 0 then party.actors
-      when 1 then [party.actor_by_id(cmd.param(1))].compact
-      when 2 then [party.actor_by_id(variables[cmd.param(1)])].compact
+      when 1 then [party.roster[cmd.param(1)]].compact
+      when 2 then [party.roster[variables[cmd.param(1)]]].compact
       else []
       end
     end
@@ -1609,22 +1620,27 @@ module Game
 
     # -- actor identity / graphic ---------------------------------------------
 
+    # Every command in this group names its actor by a fixed id in param0, and
+    # RPG_RT resolves all of them through `Game_Actors::GetActor` — the roster,
+    # not the party — so a companion who is currently away is still renamed,
+    # re-dressed and re-portraited, and has it waiting when they rejoin. nil only
+    # for an id the database has no row for.
+    def identity_target(cmd); party.roster[cmd.param(0)]; end
+
     # Change Actor Name: rename the actor whose id is param0 to the command
-    # string. A blank name is ignored (RPG_RT keeps the previous name), and an
-    # actor not in the party is a no-op — this build only instantiates party
-    # actors.
+    # string. A blank name is ignored (RPG_RT keeps the previous name).
     def do_change_actor_name(cmd)
       name = cmd.string
       return if name.nil? || name.empty?
-      actor = party.actor_by_id(cmd.param(0))
+      actor = identity_target(cmd)
       actor.name = name if actor
     end
 
     # Change Actor Title: set the title (class/subtitle shown on the status
     # screen) of the actor whose id is param0 to the command string. An empty
-    # string clears the title. A no-op for an actor not in the party.
+    # string clears the title.
     def do_change_actor_title(cmd)
-      actor = party.actor_by_id(cmd.param(0))
+      actor = identity_target(cmd)
       actor.title = cmd.string || '' if actor
     end
 
@@ -1632,9 +1648,9 @@ module Game
     # param0 a new CharSet graphic — the command string names the file, param1 is
     # the cell index and param2 the transparency flag (non-zero hides the sprite).
     # Records a one-shot request so the owning scene can reload the party leader's
-    # on-screen sprite; a no-op for an actor not in the party.
+    # on-screen sprite.
     def do_change_actor_sprite(cmd)
-      actor = party.actor_by_id(cmd.param(0))
+      actor = identity_target(cmd)
       return unless actor
       actor.set_charset(cmd.string || '', cmd.param(1))
       actor.transparent = cmd.param(2) != 0
@@ -1645,9 +1661,8 @@ module Game
     # graphic — the command string names the file and param1 the cell index. This
     # is the actor's own portrait (menus, the save-select screen), not the message
     # face a Change Face Graphic (10130) selects, so nothing on the map reloads.
-    # A no-op for an actor not in the party.
     def do_change_actor_face(cmd)
-      actor = party.actor_by_id(cmd.param(0))
+      actor = identity_target(cmd)
       return unless actor
       actor.set_faceset(cmd.string || '', cmd.param(1))
     end

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -524,7 +524,10 @@ module Game
     # paused on the :name_input wait, then calls this with the entered name.
     def resume_name_input(name)
       req = @name_input_request
-      actor = req && party.actor_by_id(req[:actor_id])
+      # Through the roster, matching the lookup #do_name_input opened the request
+      # with — otherwise naming a companion who is out of the party would put up
+      # the widget and then quietly drop what was typed.
+      actor = req && party.roster[req[:actor_id]]
       actor.name = name if actor && name && !name.empty?
       reset_waits
     end
@@ -1278,10 +1281,16 @@ module Game
     # attribute (0 level, 1 EXP, 2 HP, 3 MP, 4 max HP, 5 max MP, 6 attack,
     # 7 defence, 8 spirit, 9 agility, then 10..14 the id of the item in each
     # equipment slot — weapon, shield, armour, helmet, accessory, in the order
-    # Game::Actor::EQUIP_ORDER already stores them, 0 for an empty slot). An
-    # actor not in the party reads as 0.
+    # Game::Actor::EQUIP_ORDER already stores them, 0 for an empty slot).
+    #
+    # Read through the roster (RPG_RT's `Game_Actors::GetActor`), so a companion
+    # who is out of the party reports their real level and gear rather than 0.
+    # **Every** actor-stat read in Nepheshel — all 2436 — names a swappable
+    # companion, and its party status display is built out of them, so a
+    # dismissed member used to be listed at level 0. Only an id the database has
+    # no row for reads as 0.
     def actor_operand(cmd)
-      actor = party.actor_by_id(cmd.param(5))
+      actor = party.roster[cmd.param(5)]
       return 0 unless actor
       attr = cmd.param(6)
       case attr
@@ -1836,12 +1845,14 @@ module Game
       end
     end
 
-    # Enable Combo (1007), RPG2003-only: arm party actor param0's battle command
-    # param1 to repeat param2 times. Recorded on the actor; the ATB battle system
-    # that spends a combo is not modelled here, so nothing acts on it yet.
+    # Enable Combo (1007), RPG2003-only: arm actor param0's battle command param1
+    # to repeat param2 times. The actor is named by id, so it resolves through the
+    # roster like the other fixed-id commands. Recorded on the actor; the ATB
+    # battle system that spends a combo is not modelled here, so nothing acts on
+    # it yet.
     def do_enable_combo(cmd)
       return unless @battle
-      actor = party.actor_by_id(cmd.param(0))
+      actor = identity_target(cmd)
       return unless actor
       actor.set_battle_combo(cmd.param(1), cmd.param(2))
     end
@@ -2024,12 +2035,19 @@ module Game
     # Conditional type 5 (actor/hero): param1 is the actor id, param2 selects the
     # sub-condition — 0 in party, 1 name equals the command string, 2 level >=
     # param3, 3 HP >= param3, 4 knows skill param3, 5 has item param3 equipped,
-    # 6 afflicted by state param3. The stat checks need the actor to be in the
-    # party (the only actors this build instantiates); a missing actor is false.
+    # 6 afflicted by state param3.
+    #
+    # Only sub-condition 0 asks the party; the rest ask the **actor**, through
+    # the roster, exactly as RPG_RT splits them (`IsActorInParty` versus
+    # `Game_Actors::GetActor`). The distinction decides which branch runs, and
+    # real data leans on it: Nepheshel writes 28 "is in the party" tests and 243
+    # state tests, all of the latter naming a companion it also dismisses — so
+    # answering them from the party alone sent every one down the false branch
+    # while that companion was away. A missing database row is still false.
     def actor_condition(cmd)
       id = cmd.param(1)
       return party.include_actor?(id) if cmd.param(2) == 0
-      actor = party.actor_by_id(id)
+      actor = party.roster[id]
       return false unless actor
       case cmd.param(2)
       when 1 then actor.name == cmd.string

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -4065,12 +4065,38 @@ class RPG2k
       FACE_MARGIN = 4
 
       # Look up an actor name by id for the \n[] message control code.
+      #
+      # The **live** actor is what RPG_RT names here, not the database row: a
+      # hero the player named through Enter Hero Name (Nepheshel does exactly
+      # that, then refers to them as \N[1] in 34 messages) or renamed by a Change
+      # Actor Name has to be called what they are called now. Index **0** is the
+      # party leader — the hero — which is how a boss addresses the player
+      # character without knowing which actor id they are (`\n[0]よ…`).
+      #
+      # The roster is read without creating: naming an actor the game has never
+      # met falls through to the database row instead of enrolling them in the
+      # roster the save writes out.
       def actor_name(id)
-        a = @db.player[id]
-        a ? a.name.to_s : ''
+        a = id.to_i.zero? ? party_leader : roster_actor(id)
+        return a.name.to_s if a
+        row = @db.player[id]
+        row ? row.name.to_s : ''
       rescue StandardError => e
         $stderr.puts "[RPG2k] actor name ##{id} lookup failed: #{e.message}"
         ''
+      end
+
+      # The live actor `id`, if the game has one. nil for a scene fixture whose
+      # party is a stub without a roster.
+      def roster_actor(id)
+        party = @state.party
+        return nil unless party.respond_to?(:roster)
+        party.roster.existing(id)
+      end
+
+      def party_leader
+        party = @state.party
+        party.respond_to?(:leader) ? party.leader : nil
       end
 
       def open_message(lines, choice)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2027,6 +2027,37 @@ check 'a stat command naming a fixed actor reaches one who is out of the party' 
   eq leader_before + 9, st.party.leader.level, 'and does apply to the members present'
 end
 
+check 'reading an actor sees one who is out of the party; "in party" does not' do
+  db = roster_db
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  ic = Game::Interpreter::Cmd
+  interp = Game::Interpreter.new(st)
+
+  st.party.add_actor(2)
+  away = st.party.actor_by_id(2)
+  away.change_level_by(4)          # 3 -> 7
+  st.party.remove_actor(2)
+
+  # Control Variables operand 5: [.., .., .., .., 5 operand, actor id, attribute]
+  # attribute 0 = level. The absent ally reports their real level, not 0.
+  interp.start([FakeCmd.new(ic::CONTROL_VARS, [0, 1, 1, 0, 5, 2, 0])])
+  interp.update while interp.running? && !interp.waiting?
+  eq 7, st.variables[1], "an absent actor's level reads through"
+
+  # Conditional type 5: [5 type, actor id, sub-condition, value].
+  # Sub-condition 2 is "level >=" — asked of the actor, so it is true.
+  eq true, interp.send(:actor_condition, FakeCmd.new(ic::CONDITIONAL, [5, 2, 2, 7])),
+     'a level test sees the absent actor'
+  eq false, interp.send(:actor_condition, FakeCmd.new(ic::CONDITIONAL, [5, 2, 2, 8])),
+     'and compares properly'
+  # Sub-condition 0 is "is in the party" — that one really is about the party.
+  eq false, interp.send(:actor_condition, FakeCmd.new(ic::CONDITIONAL, [5, 2, 0, 0])),
+     '"in party" stays false while they are away'
+  st.party.add_actor(2)
+  eq true, interp.send(:actor_condition, FakeCmd.new(ic::CONDITIONAL, [5, 2, 0, 0])),
+     'and true once they rejoin'
+end
+
 check 'State save round-trips the message configuration' do
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1927,6 +1927,74 @@ check 'both timers round-trip through the save; an old save still loads' do
   eq 0, old.timer(1).seconds, 'and the second starts empty'
 end
 
+# -- the permanent actor roster (Game::Actors) --------------------------------
+#
+# Nepheshel drives its whole party mechanic through Change Party Member: it adds
+# and removes actors 2/3/4 and 5/6/7 thousands of times (630 adds + 471 removes
+# for actor 2 alone). Rebuilding the actor from the database on every add threw
+# away everything the player had earned, which is what these pin down.
+def roster_db
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
+    2 => FakePlayerRow.new('Ally', '', 0, 3, max_hp: 50, max_mp: 20, atk: 6, def: 5),
+  }
+  FakeActorDB.new(players, [1])
+end
+
+check 'an actor who leaves and rejoins the party keeps their state' do
+  db = roster_db
+  party = Game::Party.new(db)
+  party.add_actor(2)
+  ally = party.actor_by_id(2)
+  eq 3, ally.level, 'joins at the database initial level'
+  ally.set_level(9)
+  ally.name = 'Renamed'
+  ally.hp = 7
+  levelled_hp = ally.max_hp
+
+  party.remove_actor(2)
+  eq nil, party.actor_by_id(2), 'out of the party'
+  ok party.roster.existing(2), 'but still in the roster'
+
+  party.add_actor(2)
+  back = party.actor_by_id(2)
+  ok back.equal?(ally), 'the very same actor object rejoins'
+  eq 9, back.level, 'keeps the level they left with'
+  eq 'Renamed', back.name, 'keeps a renamed name'
+  eq 7, back.hp, 'keeps current HP'
+  eq levelled_hp, back.max_hp
+end
+
+check 'Actors builds each id once and reports a missing row as nil' do
+  roster = Game::Actors.new(roster_db)
+  a = roster[1]
+  ok a.equal?(roster[1]), 'the same instance comes back'
+  eq nil, roster.existing(2), 'existing() does not create'
+  ok roster[2], 'and [] does'
+  eq [1, 2], roster.all.map { |x| x.id }, 'all() is in id order'
+  eq nil, roster[0], 'a non-positive id has no actor'
+  eq nil, roster[99], 'nor does a row the database lacks'
+end
+
+check 'the save carries actors who are out of the party' do
+  db = roster_db
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.add_actor(2)
+  away = st.party.actor_by_id(2)
+  away.change_level_by(6)           # 3 -> 9, the Change Level command's path
+  away.name = 'Renamed'
+  st.party.remove_actor(2)          # leaves the party *before* the save
+
+  loaded = Game::State.load(db, st.to_h)
+  eq [1], loaded.party.actors.map { |a| a.id }, 'the party is just the leader'
+  restored = loaded.party.roster.existing(2)
+  ok restored, 'the absent member is still in the restored roster'
+  eq 9, restored.level
+  eq 'Renamed', restored.name
+  loaded.party.add_actor(2)
+  eq 9, loaded.party.actor_by_id(2).level, 'and rejoins at that level'
+end
+
 check 'State save round-trips the message configuration' do
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1995,6 +1995,38 @@ check 'the save carries actors who are out of the party' do
   eq 9, loaded.party.actor_by_id(2).level, 'and rejoins at that level'
 end
 
+check 'a stat command naming a fixed actor reaches one who is out of the party' do
+  db = roster_db
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  ic = Game::Interpreter::Cmd
+  interp = Game::Interpreter.new(st)
+
+  # Bring the ally in, then send them away again.
+  st.party.add_actor(2)
+  away = st.party.actor_by_id(2)
+  st.party.remove_actor(2)
+  eq nil, st.party.actor_by_id(2), 'actor 2 is not in the party'
+
+  # Scope 1 = "this actor", by fixed id: RPG_RT resolves it through the roster,
+  # so it lands on the absent ally rather than being dropped. Params are
+  # [scope, actor id, 0 add, 0 constant, amount, show-message].
+  eq 3, away.level, 'the ally starts at their database level'
+  interp.start([FakeCmd.new(ic::CHANGE_LEVEL, [1, 2, 0, 0, 7, 0])])
+  interp.update while interp.running? && !interp.waiting?
+  eq 10, away.level, 'Change Level reached the absent actor'
+
+  interp.start([FakeCmd.new(ic::CHANGE_ACTOR_NAME, [2], string: 'Away')])
+  interp.update while interp.running? && !interp.waiting?
+  eq 'Away', away.name, 'Change Actor Name reached the absent actor'
+
+  # Scope 0 = "the whole party" still means only the members present.
+  leader_before = st.party.leader.level
+  interp.start([FakeCmd.new(ic::CHANGE_LEVEL, [0, 0, 0, 0, 9, 0])])
+  interp.update while interp.running? && !interp.waiting?
+  eq 10, away.level, 'a party-wide change leaves the absent actor alone'
+  eq leader_before + 9, st.party.leader.level, 'and does apply to the members present'
+end
+
 check 'State save round-trips the message configuration' do
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -222,7 +222,11 @@ def fake_db(common = nil, troop_pages = nil)
                                      flash_green: 31, flash_blue: 31, flash_power: 20) }
     ) },
     common_event: common,
-    player: {}
+    # Database actor rows carry the *original* names, which a \N[n] must not
+    # use once the actor has been renamed in play (see the \N[n] check).
+    player: { 1 => OpenStruct.new(name: 'DbHero'),
+              2 => OpenStruct.new(name: 'DbAlly'),
+              3 => OpenStruct.new(name: 'DbStranger') }
   )
 end
 
@@ -1161,6 +1165,51 @@ check 'a \\! pause holds the reveal until a button is pressed' do
   5.times { RGSS::Input.reset; scene.update }
   eq 4, reveal.revealed, 'the remaining text revealed'
   ok reveal.done?
+end
+
+# A party whose actors have been renamed in play, backed by a roster, for the
+# \N[n] message-code check.
+class RosterStubActor
+  attr_reader :id, :charset_name, :charset_index, :transparent
+  attr_accessor :name
+  def initialize(id, name)
+    @id = id
+    @name = name
+    @charset_name = ''
+    @charset_index = 0
+    @transparent = false
+  end
+end
+class RosterStub
+  def initialize(h); @h = h; end
+  def existing(id); @h[id]; end
+end
+class RosterStubParty
+  attr_reader :actors, :roster, :revision
+  def initialize
+    hero = RosterStubActor.new(1, 'Named')      # renamed by Enter Hero Name
+    away = RosterStubActor.new(2, 'Levelled')   # met, then left the party
+    @actors = [hero]
+    @roster = RosterStub.new(1 => hero, 2 => away)
+    @revision = 0
+  end
+  def leader; @actors.first; end
+  def actor_by_id(id); @actors.find { |a| a.id == id }; end
+end
+
+check '\\N[n] names the live actor, and \\N[0] the party leader' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: '\\N[0]/\\N[1]/\\N[2]/\\N[3]')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  scene.instance_variable_get(:@state).instance_variable_set(:@party, RosterStubParty.new)
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message opened'
+  text = msg[:seg_lines].map { |segs| segs.map { |s| s[:text] }.join }.join
+  # \N[0] is the leader; 1 and 2 are live actors (2 is out of the party but in
+  # the roster); 3 has never been instantiated, so it falls back to its row.
+  eq 'Named/Named/Levelled/DbStranger', text
 end
 
 check 'a message with \$ shows a gold window; a plain one does not' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1180,8 +1180,12 @@ class RosterStubActor
     @transparent = false
   end
 end
+# Stands in for Game::Actors: `[]` is the get-or-create lookup the interpreter's
+# fixed-id commands use, `existing` the non-creating one \N[n] reads through.
+# The fixture is fixed, so both answer from the same table.
 class RosterStub
   def initialize(h); @h = h; end
+  def [](id); @h[id]; end
   def existing(id); @h[id]; end
 end
 class RosterStubParty
@@ -2165,10 +2169,15 @@ class NameStubActor
   def initialize(id, name); @id = id; @name = name; end
 end
 class NameStubParty
-  attr_reader :actors
+  attr_reader :actors, :roster
   attr_accessor :leader
   # leader stays nil (no sprite to render) — the name widget doesn't need it.
-  def initialize; @actors = [NameStubActor.new(1, 'Hero')]; @leader = nil; end
+  # Enter Hero Name names its actor by id, which resolves through the roster.
+  def initialize
+    @actors = [NameStubActor.new(1, 'Hero')]
+    @leader = nil
+    @roster = RosterStub.new(1 => @actors[0])
+  end
   def actor_by_id(id); @actors.find { |a| a.id == id }; end
 end
 
@@ -2216,9 +2225,14 @@ class LevelStubActor
   def change_level_by(n); @level += n; end
 end
 class LevelStubParty
-  attr_reader :actors
+  attr_reader :actors, :roster
   attr_accessor :leader
-  def initialize; @actors = [LevelStubActor.new]; @leader = nil; end
+  # A Change Level naming a fixed actor id resolves through the roster.
+  def initialize
+    @actors = [LevelStubActor.new]
+    @leader = nil
+    @roster = RosterStub.new(@actors[0].id => @actors[0])
+  end
   def actor_by_id(id); @actors.find { |a| a.id == id }; end
   # The stat commands re-check for a party wipe; this stub's actor is alive.
   def all_dead?; false; end

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -1,0 +1,238 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Run the RPG2000 game logic against the *real* test-bed databases.
+#
+# scripts/rpg2k_logic_check.rb exercises Game::* against hand-built fixtures and
+# scripts/lcf_testbed_check.rb parses the real games without running them. This
+# harness is the join: it loads a genuine RPG_RT.ldb through the pure-Ruby LCF
+# parser and drives the actual event commands the game ships through
+# Game::Interpreter, so a rule that only real data violates gets caught.
+#
+# It exists because of one such rule. Nepheshel's whole companion mechanic is
+# Change Party Member (5205 of them, none in the other test bed), and the party
+# used to rebuild an actor from the database row on every add — so a dismissed
+# companion came back at level 1 with none of their EXP, skills or renaming.
+# A fixture check passes either way; only the real game's add/remove pairs show
+# how much of the game that covers. See docs/adr/0030-permanent-actor-roster.md.
+#
+# Usage:
+#   ruby scripts/rpg2k_testbed_logic_check.rb [GAME_DIR ...]
+# With no arguments it scans ./data for directories containing an RPG_RT.ldb.
+# A game that ships no Change Party Member is reported and skipped, not failed;
+# exits non-zero on any violated invariant.
+
+require 'stringio'
+
+module LCF
+  # uni-algo stand-in, as in scripts/lcf_testbed_check.rb: only structural,
+  # encoding-independent invariants are asserted, so the shim never affects the
+  # result.
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{fffd}")
+  end
+
+  # The write direction, for the .lsd export round trip below.
+  def utf8_to_cp932(s)
+    s.dup.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+
+  def self.max_level; MODE == 2003 ? 99 : 50; end
+end
+
+# The two names Game::* references at load time; neither is reached from the
+# command paths under test (see scripts/rpg2k_logic_check.rb).
+module RGSS
+  module Audio
+    class << self
+      def bgm_play(*); end
+      def bgm_fade(*); end
+      def se_play(*); end
+    end
+  end
+  def self.warn_stub(*); end
+end
+
+root = File.expand_path('..', __dir__)
+load File.join(root, 'mruby-lcf/mrblib/lcf.rb')
+load File.join(root, 'mruby-lcf/mrblib/schema.rb')
+load File.join(root, 'mruby-rpg2k/mrblib/game.rb')
+load File.join(root, 'mruby-rpg2k/mrblib/interpreter.rb')
+
+# Database chunk ids used directly. `db.system` is unusable here — it resolves to
+# Kernel#system under CRuby (see AGENTS.md) — so the System section and its
+# initial-party field are read by id.
+DB_SYSTEM = 22
+SYS_PARTY = 22
+DB_COMMON_EVENT = 25
+CE_COMMANDS = 22
+CHANGE_PARTY = Game::Interpreter::Cmd::CHANGE_PARTY
+
+$failures = 0
+$checks = 0
+
+def check(name)
+  $checks += 1
+  yield
+rescue StandardError => e
+  $failures += 1
+  warn "  FAIL #{name}: #{e.class}: #{e.message}"
+  warn "    #{e.backtrace.first}"
+end
+
+def eq(expected, actual, msg = nil)
+  return if expected == actual
+  raise "expected #{expected.inspect}, got #{actual.inspect}#{msg ? " (#{msg})" : ''}"
+end
+
+def ok(cond, msg = 'expected truthy')
+  raise msg unless cond
+end
+
+# Every Change Party Member command in the game's common events, as
+# [command, add?, actor_id] — only the ones naming a constant actor id
+# (param1 == 0; the variable-indexed form depends on runtime state).
+def change_party_commands(db)
+  out = []
+  ce = db[DB_COMMON_EVENT]
+  return out unless ce
+  ce.each do |_id, ev|
+    cmds = ev[CE_COMMANDS]
+    next unless cmds.is_a?(Array)
+    cmds.each do |c|
+      next unless c.code == CHANGE_PARTY && c.param(1) == 0
+      out << [c, c.param(0) == 0, c.param(2)]
+    end
+  end
+  out
+end
+
+# Run a command list to completion through a real interpreter, releasing the
+# presentation waits (message / timed wait / screen effect) nothing is driving.
+def run(state, cmds, limit = 200)
+  interp = Game::Interpreter.new(state)
+  interp.start(cmds)
+  limit.times do
+    break unless interp.running?
+    interp.update
+    next unless interp.waiting?
+    break unless [:message, :wait, :screen].include?(interp.wait_kind)
+    interp.resume
+  end
+  interp
+end
+
+# A snapshot of everything a party member should not lose by stepping out.
+def snapshot(a)
+  { level: a.level, exp: a.exp, name: a.name, hp: a.hp, mp: a.mp,
+    skills: a.skills.dup.sort, equipment: a.equipment.dup, states: a.states.dup.sort }
+end
+
+def check_game(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  party_ids = db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil
+
+  swaps = change_party_commands(db)
+  adds = {}
+  removes = {}
+  swaps.each do |cmd, add, aid|
+    (add ? adds : removes)[aid] ||= cmd
+  end
+  # Actors the game both adds and removes: its swappable companions.
+  companions = adds.keys.select { |aid| removes.key?(aid) }.sort
+  puts "== #{name}: #{swaps.size} constant-id Change Party Member command(s) in " \
+       "its common events, #{companions.size} swappable companion(s) " \
+       "#{companions.inspect}"
+  if companions.empty?
+    puts '   (no companion swaps to exercise — skipped)'
+    return
+  end
+
+  companions.each do |aid|
+    check "#{name}: actor #{aid} survives a real remove/add pair" do
+      state = Game::State.new(Game::Party.new(db, party_ids), 1, 0, 0)
+      # Bring the companion in through the game's own add command, then give
+      # them something to lose.
+      run(state, [adds[aid]])
+      actor = state.party.actor_by_id(aid)
+      ok actor, "the game's own Change Party Member did not add actor #{aid}"
+      actor.change_level_by(5)
+      actor.name = "#{actor.name}+"
+      actor.hp = 1
+      before = snapshot(actor)
+      ok before[:level] > 1, 'the companion levelled up before the swap'
+
+      run(state, [removes[aid]])
+      eq nil, state.party.actor_by_id(aid), 'left the party'
+
+      run(state, [adds[aid]])
+      back = state.party.actor_by_id(aid)
+      ok back, 'rejoined the party'
+      eq before, snapshot(back), 'rejoined with everything they left with'
+    end
+
+    check "#{name}: actor #{aid} survives a save taken while away" do
+      state = Game::State.new(Game::Party.new(db, party_ids), 1, 0, 0)
+      run(state, [adds[aid]])
+      actor = state.party.actor_by_id(aid)
+      actor.change_level_by(5)
+      actor.name = "#{actor.name}+"
+      actor.hp = 1
+      before = snapshot(actor)
+      run(state, [removes[aid]])   # away when the game is saved
+
+      loaded = Game::State.load(db, state.to_h)
+      run(loaded, [adds[aid]])
+      back = loaded.party.actor_by_id(aid)
+      ok back, 'rejoined the reloaded party'
+      eq before, snapshot(back), 'rejoined intact after Save / Continue'
+    end
+
+    check "#{name}: actor #{aid} survives a .lsd round trip while away" do
+      state = Game::State.new(Game::Party.new(db, party_ids), 1, 0, 0)
+      run(state, [adds[aid]])
+      actor = state.party.actor_by_id(aid)
+      actor.change_level_by(5)
+      actor.hp = 1
+      before = snapshot(actor)
+      run(state, [removes[aid]])
+
+      # A genuine Save<N>.lsd keeps chunk 108 for every actor the party has
+      # held, so the export/import pair has to carry the absent companion too.
+      lsd = LCF::SaveData.new(StringIO.new(state.to_lsd.to_lcf))
+      ok lsd[108][aid], "chunk 108 holds the absent actor #{aid}"
+      loaded = Game::State.from_lsd(db, lsd)
+      run(loaded, [adds[aid]])
+      back = loaded.party.actor_by_id(aid)
+      ok back, 'rejoined after the .lsd round trip'
+      # The .lsd carries no per-actor name override for a non-leader member
+      # (only the title chunk's leader name), which is a known export gap — see
+      # docs/TODO.md. Everything else has a field and must come back.
+      [:level, :exp, :hp, :mp, :skills, :equipment, :states].each do |f|
+        eq before[f], snapshot(back)[f], "#{f} survived the .lsd round trip"
+      end
+    end
+  end
+end
+
+dirs = ARGV
+if dirs.empty?
+  dirs = Dir[File.join(root, 'data', '**', 'RPG_RT.ldb')].map { |f| File.dirname(f) }.sort
+end
+if dirs.empty?
+  puts 'no RPG2000 game dir found under ./data (download a test bed first) — skipped'
+  exit 0
+end
+
+dirs.each { |d| check_game(d) }
+
+if $failures.zero?
+  puts "rpg2k test-bed logic check: #{$checks} checks passed"
+else
+  warn "rpg2k test-bed logic check: #{$failures} of #{$checks} checks FAILED"
+  exit 1
+end

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -71,6 +71,22 @@ DB_COMMON_EVENT = 25
 CE_COMMANDS = 22
 CHANGE_PARTY = Game::Interpreter::Cmd::CHANGE_PARTY
 
+# Commands that name one actor by a fixed id rather than acting on the party.
+# RPG_RT resolves all of these through Game_Actors, so they reach a member who
+# is currently out of the party. `:scope` means param0 selects party (0) / this
+# actor (1) / variable-indexed actor (2) with the id in param1; `:actor0` means
+# param0 *is* the actor id.
+Cmd = Game::Interpreter::Cmd
+FIXED_ACTOR_COMMANDS = {
+  Cmd::CHANGE_EXP => :scope,       Cmd::CHANGE_LEVEL => :scope,
+  Cmd::CHANGE_PARAM => :scope,     Cmd::CHANGE_SKILLS => :scope,
+  Cmd::CHANGE_EQUIP => :scope,     Cmd::CHANGE_HP => :scope,
+  Cmd::CHANGE_MP => :scope,        Cmd::CHANGE_CONDITION => :scope,
+  Cmd::FULL_HEAL => :scope,        Cmd::SIMULATED_ATTACK => :scope,
+  Cmd::CHANGE_ACTOR_NAME => :actor0,   Cmd::CHANGE_ACTOR_TITLE => :actor0,
+  Cmd::CHANGE_ACTOR_SPRITE => :actor0, Cmd::CHANGE_ACTOR_FACE => :actor0,
+}.freeze
+
 $failures = 0
 $checks = 0
 
@@ -129,6 +145,27 @@ end
 def snapshot(a)
   { level: a.level, exp: a.exp, name: a.name, hp: a.hp, mp: a.mp,
     skills: a.skills.dup.sort, equipment: a.equipment.dup, states: a.states.dup.sort }
+end
+
+# Every fixed-actor-id command anywhere in the game (common events, troop pages
+# and map event pages), as { actor_id => [command, ...] }.
+def fixed_actor_commands(db, dir)
+  out = Hash.new { |h, k| h[k] = [] }
+  collect = lambda do |cmds|
+    next unless cmds.is_a?(Array)
+    cmds.each do |c|
+      layout = FIXED_ACTOR_COMMANDS[c.code] or next
+      aid = layout == :actor0 ? c.param(0) : (c.param(0) == 1 ? c.param(1) : nil)
+      out[aid] << c if aid && aid > 0
+    end
+  end
+  db[DB_COMMON_EVENT]&.each { |_id, ev| collect.call(ev[CE_COMMANDS]) }
+  db[15]&.each { |_g, g| g[11]&.each { |_p, pg| collect.call(pg[12]) } }
+  Dir[File.join(dir, 'Map*.lmu')].sort.each do |f|
+    mu = LCF::MapUnit.new(File.open(f, 'rb'))
+    mu[81]&.each { |_e, ev| ev[5]&.each { |_p, pg| collect.call(pg[52]) } }
+  end
+  out
 end
 
 def check_game(dir)
@@ -215,6 +252,35 @@ def check_game(dir)
       [:level, :exp, :hp, :mp, :skills, :equipment, :states].each do |f|
         eq before[f], snapshot(back)[f], "#{f} survived the .lsd round trip"
       end
+    end
+  end
+
+  # A command that names one actor by a fixed id acts on that actor wherever they
+  # are — RPG_RT looks them up in Game_Actors, not the party. In a game that
+  # swaps members this is not a corner case: every such command Nepheshel issues
+  # names a companion it also dismisses, so a party-only lookup drops all of
+  # them whenever the target happens to be away.
+  fixed = fixed_actor_commands(db, dir)
+  aimed_at_companions = fixed.select { |aid, _| companions.include?(aid) }
+  n = aimed_at_companions.values.map(&:size).inject(0) { |a, b| a + b }
+  puts "   #{n} fixed-actor-id command(s) name a swappable companion"
+
+  aimed_at_companions.keys.sort.each do |aid|
+    check "#{name}: fixed-id commands reach actor #{aid} while away" do
+      state = Game::State.new(Game::Party.new(db, party_ids), 1, 0, 0)
+      run(state, [adds[aid]])
+      ok state.party.actor_by_id(aid), "actor #{aid} joined"
+      run(state, [removes[aid]])
+      eq nil, state.party.actor_by_id(aid), "actor #{aid} is away"
+
+      # The game's own commands, run while the target is out of the party. Every
+      # one must find its actor; none may silently no-op.
+      away = state.party.roster.existing(aid)
+      ok away, 'the absent actor is still in the roster'
+      before = snapshot(away)
+      aimed_at_companions[aid].each { |c| run(state, [c]) }
+      ok snapshot(away) != before,
+         "#{aimed_at_companions[aid].size} command(s) changed the absent actor"
     end
   end
 end


### PR DESCRIPTION
RPG2000 actors now live in a permanent `Game::Actors` roster and the party is an ordered list of ids into it — RPG_RT's `Game_Actors`. Everything that names one actor resolves through that roster; only "the whole party" scopes still mean the current members. See [ADR 0030](docs/adr/0030-permanent-actor-roster.md).

## The bug

`Game::Party` owned its members outright:

```ruby
def add_actor(id)
  @actors.push Actor.new(@db, id)      # rebuilt from the database, every time
end
def remove_actor(id)
  @actors.reject! { |a| a.id == id }   # the only reference; the actor is gone
end
```

Fine for a game whose party never changes. **Nepheshel's entire companion mechanic is Change Party Member** — 5205 of them, 2835 adds and 2370 removes, almost all its three summonable members and their alternates.

Driving the game's own 召還 / 帰す common events through the interpreter against the real `RPG_RT.ldb` measures it — level, EXP, name, HP and skill count before the swap versus after:

```
after levelling: id2 [21, 16682, "RENAMED", 3, 9]
in party after remove: [15]
after rejoin:    id2 [1, 0, "ファル", 30, 1]
```

Level 21 → 1. 16682 EXP → 0. Nine learned skills → one. The rename undone. The other test bed, mtf-meido-action, issues the command **zero** times, which is why this hid.

Once actors persist, a second layer surfaces — everything that looked an actor up *in the party* silently missed whoever was away. That was previously masked, because a dismissed companion got rebuilt from the database anyway. In Nepheshel:

| path | commands naming a swappable companion |
|---|---|
| fixed-id stat & identity commands | **7805** (Change Skills on actor 1 alone: 2871) |
| Control Variables actor-stat operand | **2436** — *all* of them |
| Conditional Branch actor tests | **243** (branches taking the wrong path) |

Replaying the game's own commands against an absent companion measures **653 per companion that change nothing at all**. The status display is built from those variable reads, so a dismissed member was listed at level 0.

The save layer had the same hole from the other end: `#to_h` / `#to_lsd` wrote one entry per *current member*, and `.from_lsd` skipped saved actors not in the party — `next unless roster.include?(aid)`.

## What the format already said

`AGENTS.md` records chunk 108 (`SAVE_PARTY_ACTOR`) as "one entry per actor the party has **ever** held" — a real Nepheshel save carries rows for companions who are not currently along. A table keyed by actor id holding everyone the game has met is not something to invent: it is what RPG_RT serialises, because RPG_RT keeps one `Game_Actor` per database row for the whole session.

## The change

- **`Game::Actors`** — get-or-create by id (`Game_Actors::GetActor`), plus `#existing` which looks up *without* creating so a read path like `\N[n]` does not enrol an actor in the roster the save writes out. A missing database row logs once per id and returns nil.
- **`Party`** — `add_actor` takes its actor from the roster (rejoining is literally the same object); `remove_actor` only edits the ordered list.
- **Both save paths carry the roster.** `#to_h`/`#load_state` cover every id the tables mention; `#to_lsd` writes chunk 108 from the roster and `.from_lsd` restores every entry. A real `.lsd` with out-of-party companions now loads them. Older Marshal saves still load.
- **Naming one actor reaches them anywhere.** Change EXP / Level / Parameters / Skills / Equipment / HP / MP / Condition / Full Heal / Simulated Attack / Class / Battle Commands with a fixed or variable target, plus Change Actor Name / Title / Sprite / Face, Enter Hero Name and Enable Combo.
- **Reading an actor too — with one deliberate exception.** Conditional Branch's *"is this actor in the party"* still asks the party; its other six tests and Control Variables' actor-stat operand ask the actor. That is exactly RPG_RT's split between `IsActorInParty` and `Game_Actors::GetActor`, and the real data leans on both sides of it (28 vs 243).
- **`\N[n]` names the live actor**, not the database row, so a hero the player named through Enter Hero Name is called what they chose — Nepheshel renames actor 1 and then writes `\N[1]` in 34 messages. **`\N[0]` is the party leader**: actor ids are 1-based, so it expanded to nothing and left the boss line `\n[0]よ…` without its subject.

"The party did not have that actor" is no longer a silent outcome anywhere.

## New check

This passed **every** fixture check while breaking the actual game, so the change adds `scripts/rpg2k_testbed_logic_check.rb` — a real test bed's `RPG_RT.ldb` driven through the real `Game::Interpreter`, joining what `lcf_testbed_check.rb` (real data, never run) and `rpg2k_logic_check.rb` (run, never real data) each do half of.

It finds every actor a game's common events both add and remove, then uses the game's own commands to take each companion out and bring them back — across a plain swap, a Marshal save, and a `.lsd` round trip — and replays every fixed-id command the game aims at that companion while they are away. Nepheshel's three companions give 24 checks. Against the old model they fail with the numbers spelled out:

```
FAIL actor 2 survives a real remove/add pair:
  expected {:level=>6, :exp=>645, ..., :skills=>[1, 4, 11], ...},
       got {:level=>1, :exp=>0,   ..., :skills=>[1], ...}
FAIL fixed-id commands reach actor 2 while away:
  653 command(s) changed the absent actor
```

A game with no companion swaps is reported and skipped, not failed. Runs in CI beside the other RPG2k logic checks.

## Also

`mruby-rpg2k/mrbgem.rake` now declares the core `*-ext` gems its Ruby was already calling undeclared — `Array#compact` (7 uses), `Integer#zero?` (8), `Enumerable#sort_by` / `each_with_object`. Per `AGENTS.md` an undeclared one is a `NoMethodError` waiting for the first gem-level test.

## Testing

All CRuby checks pass: `rpg2k_logic_check` (505, +5 new), `rpg2k_scene_check` (149, +1 new), `rpg2k_testbed_logic_check` (24, new), `rpg2k_render_check`, `lcf_testbed_check`, `rpgxp_testbed_check`, `rpgvx_testbed_check`, `mv_testbed_check`, `mz_testbed_check`. Every new check was confirmed to fail against the pre-fix code. As a broad sanity sweep, all 21,430 command lists in Nepheshel's common events and map event pages were driven through the interpreter with no errors. The native build could not be exercised here (no nix/SDL2 in this environment) — CI covers it.

## Not done

The **screen tint** remains the largest open item in this area and still needs someone who can run the native binary — its failure mode is silent.