### PR TITLE
Let a skill or item be usable for the right reasons

### DIFF
--- a/changelog.d/skill-item-usability.fixed.md
+++ b/changelog.d/skill-item-usability.fixed.md
@@ -1,0 +1,39 @@
+- **Skills and items reach the battle menus at all.** Usability was decided from
+  the row's `occasion_field` / `occasion_battle` flags, but RPG2000 reads those
+  for **switch** skills only (ADR 0031) — the editor does not even offer the
+  checkboxes for any other kind, and neither test bed writes the chunks except on
+  its switch skills. Gating every skill on them left the battle skill menu
+  **empty in both test beds**: 306 skills in Nepheshel and 134 in
+  mtf-meido-action, none of them offered. Battle skill menus now hold 306 and
+  132, and battle item menus 34 and 7 where both held nothing.
+- **RPG2003 subskill categories are ordinary skills.** A 2003 game files each
+  skill under a custom battle command and the category id lands in the type
+  field, so testing `type == 0` rejected a skill for the sole reason that it was
+  sorted into a menu — **57 of mtf-meido-action's 134 skills** (43%), including
+  every one of its healing lines (Heal / Recovery / Cure / Raise are category 5).
+  Its field skill menu goes from 2 skills to 12.
+- **Item types 9 and 10 were swapped.** Type 9 is a special item (特殊) that
+  invokes a skill and type 10 is the switch item (スイッチ); this build had the
+  switch item at 9 and no notion of the special. Nepheshel's bytes settle it —
+  its 14 type-9 items each name a *distinct* skill of the same name while their
+  `switch_id` stays at the default, and its 41 type-10 items are the mirror
+  image. So all 14 special items used to flip switch **1**, which none of them
+  names, and the 41 real switch items never appeared in the bag.
+- **Special items now cast their skill**, with the item taking the place of the
+  SP cost — the user pays nothing and need not have learnt it. This is what
+  Nepheshel's whole thrown-bomb line is (火炎玉, 爆裂玉, 氷結玉, 雷撃玉 …).
+- **Switch skills now flip their switch.** That is how a Nepheshel player summons
+  and dismisses a companion (skills 120–125, ファルを召還 and friends), each
+  flipping the switch its common event watches — the player-facing half of the
+  companion mechanic whose actor side ADR 0030 fixed.
+- **Item occasion flags are read by the names the format actually uses.** The
+  runtime asked every item for `occasion_field`, a field no real row carries, so
+  the gate fell through to "assume usable" on all genuine data and never fired.
+  A medicine is now field-usable always and battle-usable unless `occasion_field1`
+  marks it field-only; a switch item reads its own `occasion_field2` /
+  `occasion_battle` pair.
+- **`scripts/rpg2k_testbed_logic_check.rb`** additionally asserts, against the
+  real databases, that no menu comes back empty, that no skill is castable from
+  neither menu, and that every special item names a real skill while every switch
+  item names a switch of its own. The empty battle menus were invisible to every
+  fixture check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -60,7 +60,10 @@ RGSS stubs). `scripts/rpg2k_testbed_logic_check.rb` is the join of the two
 kinds — a *real* game's `RPG_RT.ldb` driven through the *real*
 `Game::Interpreter` — for rules that only genuine data violates: its first
 subject is Nepheshel's companion swaps, where the party-roster bug of ADR 0030
-passed every fixture check while breaking the actual game.
+passed every fixture check while breaking the actual game. It also asks the real
+databases what the menus offer, which is how the empty battle skill menus of ADR
+0031 were found — 306 and 134 skills, none of them reachable, with every fixture
+check green.
 
 The work below is roughly ordered by the critical path to a walkable game
 (1 → 2 → 3 → 4/5/6 → 7/8/9); battle and full menus can follow.
@@ -929,14 +932,30 @@ The work below is roughly ordered by the critical path to a walkable game
   `can_cast?` / `skill_effect` / `cast_skill` for skills) and `Game::Actor`
   (`next_level_exp` / `exp_to_next` for status), covered by
   `scripts/rpg2k_logic_check.rb`; the RGSS windows are the untestable-here UI.
-  A **switch item** (type 9) is field-usable too: `Game::Party#use_switch_item`
-  consumes one and returns the game switch it turns on, which the item menu then
-  sets (matching EasyRPG, where the scene owns the switch table). The **usable
-  occasion** is honoured on both sides: a medicine / switch item flagged
-  battle-only (`occasion_field` off) is hidden from the field menu, and one
-  flagged field-only is hidden from the battle item list (books / seeds stay
-  field-only). Teleport/escape/switch skill types, the battle-time skill
-  variance, and two-handed / dual-wield equipping are later refinements.
+  A **switch item** (type **10**, not 9 — see below) is field-usable too:
+  `Game::Party#use_switch_item` consumes one and returns the game switch it turns
+  on, which the item menu then sets (matching EasyRPG, where the scene owns the
+  switch table). A **special item** (type 9, 特殊) invokes the skill named in its
+  `skill_id`, with the item standing in for the SP cost — the user pays nothing
+  and need not have learnt it, which is what Nepheshel's whole thrown-bomb line
+  is. **Switch skills** (type 3) flip their switch: that is how a Nepheshel
+  player summons and dismisses a companion.
+
+  What decides usability is the **type**, not the occasion flags, and getting
+  that wrong used to leave the battle skill menu **empty in both test beds** —
+  306 skills and 134 skills, none offered. `occasion_field` / `occasion_battle`
+  gate **switch skills only** (RPG_RT reads them in one arm of
+  `Algo::IsSkillUsable`, and the editor only offers the checkboxes there); an
+  RPG2003 **subskill category** (type >= 4) is an ordinary skill filed under a
+  custom battle command, which is 57 of mtf-meido-action's 134 including all its
+  healing; and an item's occasion flags are `occasion_field1` (bars battle use),
+  `occasion_field2` and `occasion_battle` (a switch item's own pair) — this build
+  asked for `occasion_field`, a name no real row carries, so the gate silently
+  never fired. An earlier version of this list claimed that gate worked; it did
+  not, on any genuine item. See ADR 0031. Remaining: **teleport / escape** skill
+  types (one of each across both test beds; teleport wants a destination picker
+  this build has no screen for, so `Party#unsupported_field_skill?` declares the
+  gap), the battle-time skill variance, and two-handed / dual-wield equipping.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/docs/adr/0031-skill-and-item-usability.md
+++ b/docs/adr/0031-skill-and-item-usability.md
@@ -1,0 +1,156 @@
+# 31. What makes a skill or item usable is its type, not its occasion flags
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+The RPG2000 runtime decided whether a skill or item could be used from a menu by
+reading the row's "usable in field / usable in battle" flags:
+
+```ruby
+sk && sk.type == SKILL_NORMAL && sk.occasion_field && sk.scope >= 2   # field
+sk && sk.type == SKILL_NORMAL && battle_occasion?(sk) && ...          # battle
+```
+
+Both halves of that are wrong, and the result was stark. Teaching a test bed's
+party every skill in its database and handing it one of every item, then asking
+what the menus offer:
+
+| | Nepheshel 2.06 | mtf-meido-action |
+|---|---|---|
+| skills in the database | 306 | 134 |
+| **battle skill menu** | **0** | **0** |
+| field skill menu | 30 | 2 |
+| items in the database | 1200 | 100 |
+| **battle item menu** | **0** | **0** |
+| field item menu | 41 | 14 |
+
+**Neither game could use a single skill or item in a fight.** Every fixture check
+passed throughout, because the fixtures were built to the same wrong model.
+
+Three separate mistakes produced that.
+
+### The occasion flags gate switch skills only
+
+`occasion_field` (chunk 18, default true) and `occasion_battle` (chunk 19,
+default false) are not general "where can this be used" flags. RPG_RT reads them
+in one place — the `Type_switch` arm of `Algo::IsSkillUsable` — and the RPG2000
+editor only shows the 使用可能な場面 checkboxes for a スイッチ skill at all.
+Everything else is decided by type, scope and effect.
+
+The bytes say the same thing, and say it precisely. Chunk presence across the two
+test beds:
+
+- Nepheshel writes chunk 18 for **6** of its 306 skills and chunk 19 for **12** —
+  and those 12 are *exactly* its 12 switch skills, the 6 being the subset that is
+  battle-only.
+- mtf-meido-action, which has **no** switch skill, writes neither chunk for any
+  of its 134 skills.
+
+So on real data `occasion_battle` was almost always the default `false`, and
+gating on it emptied the battle menu.
+
+### RPG2003 files skills under numbered categories
+
+liblcf's `Skill::Type` runs `normal=0, teleport=1, escape=2, switch=3,
+subskill=4` — and 2003 numbers each custom battle command from 4 up, putting the
+category id in the same field. `type == SKILL_NORMAL` therefore rejects an
+ordinary skill for the sole reason that a 2003 game sorted it into a menu.
+That is **57 of mtf-meido-action's 134 skills** (43%), including every one of its
+healing lines — Heal, Recovery, Cure and Raise are all category 5 — and its
+elemental attack lines.
+
+### Item types 9 and 10 were read one place out
+
+liblcf's `Item::Type` ends `material=8, special=9, switch=10`. This build had
+`ITEM_SWITCH = 9` and no notion of a special item, so the two were swapped.
+Nepheshel settles it from the bytes:
+
+- its **14 type-9 items** each carry a *distinct* `skill_id` naming a skill of
+  the same name (item 天使の翼 → skill 天使の翼, 火炎玉 → 火炎玉) with
+  `switch_id` left at the default 1;
+- its **41 type-10 items** are the mirror image — 41 distinct `switch_id`s, with
+  `skill_id` left at the default.
+
+Reading 9 as "switch" made all 14 special items flip switch **1**, a switch they
+never named, and left the 41 real switch items unrecognised and absent from the
+bag.
+
+A fourth, quieter mistake sat underneath: the runtime asked every item for
+`occasion_field`, a field **no real item row has**. RPG2000 gives an item three
+occasion fields with three different jobs (`occasion_field1` bars battle use,
+`occasion_field2` and `occasion_battle` are the switch item's own pair), so the
+lookup fell through to its "no flag, assume usable" default on every genuine item
+and the gate never once fired. Only the fixtures, which did define that name,
+ever exercised it — which is why `docs/TODO.md` claimed a behaviour that never
+happened on real data.
+
+## Decision
+
+Decide usability the way RPG_RT does, from `Algo::IsSkillUsable` and
+`Game_Party::IsItemUsable`:
+
+- **Skills.** Escape and teleport are never usable in battle; a switch skill
+  consults `occasion_battle` / `occasion_field`; anything else (normal or a 2003
+  subskill category) is always usable in battle, and usable in the field when its
+  scope reaches an ally and it does something there — changes HP/SP, or touches a
+  state. `Party.normal_skill?` is `type == 0 || type >= 4`.
+- **Items.** A medicine is always field-usable and battle-usable unless
+  `occasion_field1` marks it field-only. A switch item reads its own pair,
+  `occasion_field2` and `occasion_battle`. A **special** item defers entirely to
+  the skill it invokes, on both sides.
+- **Special items cast their skill**, with the item standing in for the SP cost:
+  the user pays nothing and need not have learnt the skill. `Party#cast_skill`
+  grew a `free` flag for exactly that.
+- **Switch skills flip their switch**, `Party#cast_switch_skill` returning the
+  switch id for the scene to set — the same split `use_switch_item` already used,
+  since the switch table lives on the state rather than the party.
+
+## Consequences
+
+The menus fill in:
+
+| | Nepheshel (before → after) | mtf (before → after) |
+|---|---|---|
+| battle skill menu | 0 → **306** | 0 → **132** |
+| field skill menu | 30 → 28 | 2 → **12** |
+| battle item menu | 0 → **34** | 0 → **7** |
+| field item menu | 41 → **69** | 14 → 14 |
+
+The field skill menu gets slightly *smaller* for Nepheshel, and that is the
+change working: a skill that reaches an ally but changes nothing there — a pure
+battle stat buff — no longer appears in a menu where it could do nothing.
+mtf's field menu grows sixfold because its healing was all filed under category
+5. Nepheshel's field item list grows by the 41 switch items it never showed and
+loses the 13 thrown bombs that belong in a fight, which are exactly the items its
+battle list gains alongside 20 medicines.
+
+Nepheshel's companion summoning becomes reachable by the player: skills 120–125
+(ファルを召還 and friends) are switch skills, and casting one now flips the
+switch its common event watches. That completes the mechanic whose actor side
+ADR 0030 fixed.
+
+Escape (type 1) and teleport (type 2) skills are still not offered — teleport
+needs a destination picker this build has no screen for, and between them the two
+test beds hold exactly one of each, so there is nothing to measure a real
+implementation against. `Party#unsupported_field_skill?` names them so the gap is
+declared rather than implied, and the test-bed check excludes them by that
+predicate instead of by accident.
+
+The fixtures were part of the problem, so they moved too: `fake_item` now carries
+`occasion_field1` / `occasion_field2` under the names the format uses, and four
+checks that asserted the old model were rewritten to the real rule rather than
+deleted.
+
+Covered by `scripts/rpg2k_logic_check.rb` (subskill categories behave as ordinary
+skills; a switch skill casts for its switch and honours its flags; a special item
+invokes its skill free of SP; medicine and switch items read their own occasion
+fields) and by `scripts/rpg2k_testbed_logic_check.rb`, which now asserts against
+the **real** databases that no menu comes back empty, that no skill is castable
+from neither menu, and that every special item names a real skill while every
+switch item names a switch of its own rather than the default 1. That last set is
+the guard this needed: the emptiness was invisible to every fixture.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1850,14 +1850,25 @@ module Game
       @gold = 999_999 if @gold > 999_999
     end
 
-    # RPG2000 database item types. Types 1..5 are the equipment slots (see
-    # Actor::EQUIP_ORDER); 6 is a healing medicine (薬); 7 is a skill book (本)
-    # that teaches a skill; 8 is a seed (種) that permanently raises a stat;
-    # 9 is a switch item (スイッチ) that turns on a game switch when used.
+    # RPG2000 database item types (liblcf's `RPG::Item::Type`). Types 1..5 are the
+    # equipment slots (see Actor::EQUIP_ORDER); 6 is a healing medicine (薬);
+    # 7 is a skill book (本) that teaches a skill; 8 is a seed (種, 素材) that
+    # permanently raises a stat; **9 is a special item (特殊) that invokes a
+    # skill** and **10 is a switch item (スイッチ)** that turns on a game switch.
+    #
+    # Those last two used to be numbered one lower, which put every one of them
+    # on the wrong branch. Nepheshel settles it from the bytes: its 14 type-9
+    # items each carry a *distinct* `skill_id` naming a skill of the same name
+    # (item 天使の翼 → skill 天使の翼, 火炎玉 → 火炎玉) with `switch_id` left at
+    # the default 1, while its 41 type-10 items are the mirror image — 41 distinct
+    # `switch_id`s and `skill_id` left at the default. Reading 9 as "switch" made
+    # the 14 special items flip switch **1** (the default they never set) and left
+    # the 41 real switch items unrecognised, so they never appeared in the bag.
     ITEM_MEDICINE = 6
     ITEM_SKILL_BOOK = 7
     ITEM_SEED = 8
-    ITEM_SWITCH = 9
+    ITEM_SPECIAL = 9
+    ITEM_SWITCH = 10
 
     # The database row for a held item id, or nil when the database has no item
     # table (a bare test fixture) or no such row.
@@ -1870,20 +1881,51 @@ module Game
     # medicine or switch item the party holds whose "usable in field" occasion is
     # set (a battle-only medicine is hidden here, mirroring #battle_usable?), or a
     # skill book / seed (always field-only, no occasion to gate on).
+    #
+    # A **special** item defers to the skill it invokes, as RPG_RT does
+    # (`Game_Party::IsItemUsable` hands a Type_special straight to
+    # `IsSkillUsable`): the item's own occasion flags say nothing useful about a
+    # thrown bomb. That is what keeps Nepheshel's 火炎玉 out of the field menu —
+    # its skill targets an enemy — while 天使の翼, whose skill targets an ally,
+    # stays in.
     def field_usable?(id)
       it = db_item(id)
       return false unless it && item_count(id) > 0
       case it.type
-      when ITEM_MEDICINE, ITEM_SWITCH then field_item_occasion?(it)
-      when ITEM_SKILL_BOOK, ITEM_SEED then true
+      when ITEM_MEDICINE, ITEM_SKILL_BOOK, ITEM_SEED then true
+      when ITEM_SWITCH then item_field_occasion?(it)
+      when ITEM_SPECIAL then field_skill?(db_skill(it.skill_id))
       else false
       end
     end
 
-    # Whether item `it` may be used from the field menu. Defaults to usable when
-    # the row (a bare fixture) carries no `occasion_field` flag.
-    def field_item_occasion?(it)
-      it.respond_to?(:occasion_field) ? it.occasion_field : true
+    # An item's occasion flags, read by the **field name the format actually
+    # uses**. RPG2000 gives an item three of them and they are not
+    # interchangeable (EasyRPG's `Game_Party::IsItemUsable`):
+    #
+    #   occasion_field1 (37) — set means "field only", i.e. **bars battle use**;
+    #                          it is what gates a medicine in a fight.
+    #   occasion_field2 (57) — a **switch** item's field flag.
+    #   occasion_battle (58) — a **switch** item's battle flag.
+    #
+    # This build used to ask every item for `occasion_field`, which is not a
+    # field either real row has — so the lookup fell through to its "no flag,
+    # assume usable" default on every genuine item and the gate never once fired.
+    # Only hand-built fixtures, which did define that name, ever exercised it.
+    def item_field_occasion?(it)
+      return it.occasion_field2 if it.respond_to?(:occasion_field2)
+      true
+    end
+
+    def item_battle_occasion?(it)
+      return it.occasion_battle if it.respond_to?(:occasion_battle)
+      true
+    end
+
+    # Whether `it` is flagged field-only (occasion_field1), which is what keeps a
+    # medicine out of a battle.
+    def item_field_only?(it)
+      it.respond_to?(:occasion_field1) ? it.occasion_field1 : false
     end
 
     # Whether item `id` is a switch item (turns on a game switch when used).
@@ -1952,6 +1994,10 @@ module Game
         seed_boosts(it).any? { |b| b != 0 }
       when ITEM_SWITCH
         true # a switch item always flips its switch
+      when ITEM_SPECIAL
+        # Judged by the skill it invokes, exactly as casting that skill would be
+        # -- but free: the item is the cost, and its user need not know the skill.
+        skill_effective?(actor, it.skill_id, actor, true)
       else
         false
       end
@@ -1968,8 +2014,19 @@ module Game
       when ITEM_MEDICINE then use_medicine(it, id, actor)
       when ITEM_SKILL_BOOK then use_skill_book(it, id, actor)
       when ITEM_SEED then use_seed(it, id, actor)
+      when ITEM_SPECIAL then use_special_item(it, id, actor)
       else []
       end
+    end
+
+    # A special item (特殊) invokes the skill in its `skill_id` on `actor`, with
+    # the item taking the place of the SP cost: the user pays nothing and need not
+    # have learnt the skill. One is consumed only when the cast actually did
+    # something, matching how the other item kinds here refuse to be wasted.
+    def use_special_item(it, id, actor)
+      affected = cast_skill(actor, it.skill_id, actor, true)
+      lose_item(id, 1) unless affected.empty?
+      affected
     end
 
     # A single-target medicine (scope 0) heals `actor`; an all-ally medicine
@@ -2083,10 +2140,27 @@ module Game
     end
 
     # RPG2000 skill type (field 8): 0 normal (an HP/SP/stat effect), 1 teleport,
-    # 2 escape, 3 switch. The field skill menu casts normal skills; the
-    # teleport/escape/switch types are later refinements. Skill scope (field 12):
-    # 0 single enemy, 1 all enemies, 2 the caster, 3 a single ally, 4 all allies.
+    # 2 escape, 3 switch. Skill scope (field 12): 0 single enemy, 1 all enemies,
+    # 2 the caster, 3 a single ally, 4 all allies.
     SKILL_NORMAL = 0
+    SKILL_TELEPORT = 1
+    SKILL_ESCAPE = 2
+    SKILL_SWITCH = 3
+    # RPG2003 numbers its **subskill** categories from 4 up (liblcf's
+    # `Skill::Type_subskill`): a 2003 game sorts its skills into custom battle
+    # commands, and the category id lands in this same field. Such a skill is an
+    # ordinary skill — the number only says which menu it is filed under.
+    SKILL_SUBSKILL = 4
+
+    # Whether `sk` behaves as an ordinary HP/SP/stat skill: type 0, or any RPG2003
+    # subskill category. Testing `type == SKILL_NORMAL` instead hid **57 of
+    # mtf-meido-action's 134 skills** — 43% of the game, including every one of
+    # its healing lines (Heal / Recovery / Cure / Raise are category 5) and its
+    # elemental attack lines — from both the field menu and the battle menu.
+    def self.normal_skill?(sk)
+      t = sk.type
+      t == SKILL_NORMAL || t >= SKILL_SUBSKILL
+    end
 
     # The database row for a skill id, or nil when the database has no skill table
     # (a bare fixture) or no such row.
@@ -2106,15 +2180,82 @@ module Game
       end
     end
 
-    # `caster`'s known skills usable from the field menu -- normal skills flagged
-    # `occasion_field` that target the caster or an ally (scope >= 2) -- as
-    # `[skill_id, cost]` pairs in ascending id order.
+    # `caster`'s known skills usable from the field menu, as `[skill_id, cost]`
+    # pairs in ascending id order: anything flagged `occasion_field` that either
+    # behaves as an ordinary skill and targets the caster or an ally (scope >= 2,
+    # since the field menu has no enemy to aim at) or is a **switch** skill, which
+    # has no target at all — it just turns its switch on. Nepheshel's companions
+    # are summoned and dismissed exactly this way (skills 120–125, "ファルを召還"
+    # and friends, each flipping the switch its common event watches).
     def field_skills(caster)
       return [] unless caster
-      caster.skills.sort.select do |sid|
-        sk = db_skill(sid)
-        sk && sk.type == SKILL_NORMAL && sk.occasion_field && sk.scope >= 2
-      end.map { |sid| [sid, skill_cost(db_skill(sid), caster)] }
+      caster.skills.sort.select { |sid| field_skill?(db_skill(sid)) }
+            .map { |sid| [sid, skill_cost(db_skill(sid), caster)] }
+    end
+
+    # Whether skill row `sk` belongs in the field menu.
+    #
+    # The `occasion_field` / `occasion_battle` flags gate **switch skills only**.
+    # That is not a simplification — it is what RPG_RT does (EasyRPG's
+    # `Algo::IsSkillUsable` reads them in the `Type_switch` arm and nowhere
+    # else), and the RPG2000 editor only offers the 使用可能な場面 checkboxes for
+    # a スイッチ skill in the first place. The bytes agree exactly: Nepheshel
+    # writes chunks 18/19 for 12 of its 306 skills and those 12 are precisely its
+    # 12 switch skills, while mtf-meido-action, which has no switch skill, writes
+    # neither chunk for any of its 134. Gating every skill on `occasion_battle`
+    # (default false, so almost never set) is what used to leave the battle skill
+    # menu holding 12 skills in one game and none at all in the other.
+    #
+    # An ordinary skill outside battle needs a target the field can offer (scope
+    # >= 2, i.e. self or allies -- there is no enemy to aim at) and has to do
+    # something once there: change HP/SP, or inflict a state.
+    def field_skill?(sk)
+      return false unless sk
+      case sk.type
+      when SKILL_ESCAPE, SKILL_TELEPORT
+        false # see #unsupported_field_skill?
+      when SKILL_SWITCH
+        field_occasion?(sk)
+      else
+        return false unless sk.scope >= 2
+        # The raw state set, not #skill_inflicted_states: a plain antidote cures
+        # rather than inflicts (`reverse_state_effect` off), and curing poison
+        # between fights is the whole point of the field skill menu.
+        sk.affect_hp || sk.affect_sp || !skill_state_ids(sk).empty?
+      end
+    end
+
+    # Escape (type 1) and Teleport (type 2) skills warp the party to a memorised
+    # target. RPG_RT also gates them on the party's escape / teleport access and
+    # on a target having been memorised. Neither is offered yet: teleport needs a
+    # destination picker this build has no screen for. Between them the two test
+    # beds hold exactly one of each (mtf-meido-action's "Escape" and "Teleport"),
+    # so there is nothing here to measure a real implementation against.
+    def unsupported_field_skill?(sk)
+      !sk.nil? && (sk.type == SKILL_ESCAPE || sk.type == SKILL_TELEPORT)
+    end
+
+    # Whether a **switch** skill's field / battle occasion flag is set. Defaults
+    # to usable when the row (a bare fixture) carries no flag.
+    def field_occasion?(sk)
+      sk.respond_to?(:occasion_field) ? sk.occasion_field : true
+    end
+
+    # Whether skill `sid` is a switch skill (turns a game switch on, no target).
+    def switch_skill?(sid)
+      sk = db_skill(sid)
+      !sk.nil? && sk.type == SKILL_SWITCH
+    end
+
+    # Cast a switch skill: spend the caster's SP and return the id of the switch
+    # to turn on, so the caller can flip it (the switch table lives on the state,
+    # not the party -- the same split #use_switch_item already uses). nil when
+    # `sid` is not a switch skill the caster can cast, and then nothing is spent.
+    def cast_switch_skill(caster, sid)
+      return nil unless switch_skill?(sid) && can_cast?(caster, sid)
+      sk = db_skill(sid)
+      caster.change_mp(-skill_cost(sk, caster))
+      sk.switch_id
     end
 
     # Whether `caster` can cast skill `sid` right now: it knows the skill and can
@@ -2175,9 +2316,9 @@ module Game
     # out a no-op (e.g. a heal on an already-full ally). Requires the caster to be
     # able to cast it at all. A skill that cures a condition the target actually
     # has (or inflicts one it lacks) is usable even when HP/SP are full.
-    def skill_effective?(caster, sid, target)
+    def skill_effective?(caster, sid, target, free = false)
       sk = db_skill(sid)
-      return false unless sk && can_cast?(caster, sid)
+      return false unless sk && (free ? !caster.nil? : can_cast?(caster, sid))
       amount = skill_effect(sk, caster)
       cured = skill_cured_states(sk)
       inflicted = skill_inflicted_states(sk)
@@ -2196,9 +2337,13 @@ module Game
     # costs nothing. States are applied before HP so a cure that clears the death
     # state revives the target and the recovery then lands. Returns the affected
     # actors.
-    def cast_skill(caster, sid, target = nil)
+    #
+    # `free` casts without the knows-it / can-afford-it gate and without spending
+    # SP: a **special item** invokes its skill that way, since the item is the
+    # cost and the user need not have learnt the skill at all.
+    def cast_skill(caster, sid, target = nil, free = false)
       sk = db_skill(sid)
-      return [] unless sk && can_cast?(caster, sid)
+      return [] unless sk && (free ? !caster.nil? : can_cast?(caster, sid))
       amount = skill_effect(sk, caster)
       cured = skill_cured_states(sk)
       inflicted = skill_inflicted_states(sk)
@@ -2224,7 +2369,7 @@ module Game
         changed ||= t.hp != before_hp || t.mp != before_mp
         affected.push(t) if changed
       end
-      caster.change_mp(-skill_cost(sk, caster)) unless affected.empty?
+      caster.change_mp(-skill_cost(sk, caster)) unless free || affected.empty?
       affected
     end
 
@@ -2241,20 +2386,33 @@ module Game
     # caster, 3 a single ally, 4 all allies.
     BATTLE_SKILL_SCOPES = [0, 1, 2, 3, 4].freeze
 
-    # `actor`'s known normal skills usable in battle — flagged `occasion_battle`
-    # with a single-target scope — as `[skill_id, cost]` pairs in ascending id
-    # order. `caster` is the battle snapshot the SP cost is figured from.
+    # `actor`'s known skills usable in battle, as `[skill_id, cost]` pairs in
+    # ascending id order: those flagged `occasion_battle` that either behave as an
+    # ordinary skill with a scope the battle menu can aim, or are a **switch**
+    # skill (no target — Nepheshel's 突撃準備 / 呪文詠唱 charge-ups are these).
+    # `caster` is the battle snapshot the SP cost is figured from.
     def battle_skills(actor, caster)
       return [] unless actor && caster
-      actor.skills.sort.select do |sid|
-        sk = db_skill(sid)
-        sk && sk.type == SKILL_NORMAL && battle_occasion?(sk) &&
-          BATTLE_SKILL_SCOPES.include?(sk.scope)
-      end.map { |sid| [sid, skill_cost(db_skill(sid), caster)] }
+      actor.skills.sort.select { |sid| battle_skill?(db_skill(sid)) }
+           .map { |sid| [sid, skill_cost(db_skill(sid), caster)] }
     end
 
-    # Whether skill `sk` may be used in battle. Defaults to usable when the row
-    # (a bare fixture) carries no `occasion_battle` flag.
+    # Whether skill row `sk` belongs in the battle menu. Mirrors #field_skill?:
+    # the occasion flags gate switch skills only, an escape / teleport skill is
+    # never usable in a fight, and an ordinary skill always is — RPG_RT asks
+    # nothing else of it once a battle is running.
+    def battle_skill?(sk)
+      return false unless sk
+      case sk.type
+      when SKILL_ESCAPE, SKILL_TELEPORT then false
+      when SKILL_SWITCH then battle_occasion?(sk)
+      else BATTLE_SKILL_SCOPES.include?(sk.scope)
+      end
+    end
+
+    # Whether a **switch** skill's battle occasion flag is set (see
+    # #field_skill? for why only switch skills consult these). Defaults to usable
+    # when the row (a bare fixture) carries no flag.
     def battle_occasion?(sk)
       sk.respond_to?(:occasion_battle) ? sk.occasion_battle : true
     end
@@ -2314,17 +2472,19 @@ module Game
     end
 
     # Whether item `id` can be used in battle: a medicine flagged occasion_battle
-    # the party actually holds.
+    # the party actually holds, or a **special** item whose skill is battle-usable
+    # (the same deferral #field_usable? makes). Nepheshel's whole thrown-bomb line
+    # — 火炎玉, 爆裂玉, 氷結玉, 雷撃玉 and the rest — is special items, so this is
+    # what puts them in the battle item list at all.
     def battle_usable?(id)
       it = db_item(id)
       return false unless it && item_count(id) > 0
-      it.type == ITEM_MEDICINE && battle_item_occasion?(it)
-    end
-
-    # Whether medicine `it` may be used in battle. Defaults to usable when the row
-    # (a bare fixture) carries no `occasion_battle` flag.
-    def battle_item_occasion?(it)
-      it.respond_to?(:occasion_battle) ? it.occasion_battle : true
+      case it.type
+      when ITEM_MEDICINE then !item_field_only?(it)
+      when ITEM_SWITCH then item_battle_occasion?(it)
+      when ITEM_SPECIAL then battle_skill?(db_skill(it.skill_id))
+      else false
+      end
     end
 
     # The bag's battle-usable items as `[id, count]` pairs in ascending id order.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -5229,16 +5229,30 @@ class RPG2k
         it = @state.party.db_item(id)
         # A switch item has no actor target; an all-ally medicine skips the
         # target prompt; single-target medicines / skill books ask who to use on.
+        # A special item follows the *skill* it invokes, since that is what
+        # decides the scope — self (2) or all-ally (4) needs no prompt.
         if it && it.type == Game::Party::ITEM_SWITCH
           apply_switch_item(id)
+        elsif it && it.type == Game::Party::ITEM_SPECIAL
+          sk = @state.party.db_skill(it.skill_id)
+          if sk && (sk.scope == 2 || sk.scope == 4)
+            apply_item(id, nil)
+          else
+            prompt_item_target(id)
+          end
         elsif it && it.scope == 1 && it.type == Game::Party::ITEM_MEDICINE
           apply_item(id, nil)
         else
-          @pending_item = id
-          @mode = :target
-          @target_index = 0
-          build_target_window
+          prompt_item_target(id)
         end
+      end
+
+      # Ask which party member the pending item is used on.
+      def prompt_item_target(id)
+        @pending_item = id
+        @mode = :target
+        @target_index = 0
+        build_target_window
       end
 
       # A switch item turns on its game switch (the party consumes one); the menu
@@ -5728,9 +5742,11 @@ class RPG2k
         return if skills.empty?
         sid, = skills[@skill_index]
         sk = @state.party.db_skill(sid)
-        # A self (2) or all-ally (4) skill needs no target prompt; a single-ally
-        # skill (3) asks which ally.
-        if sk && (sk.scope == 2 || sk.scope == 4)
+        # A switch skill has no target at all; a self (2) or all-ally (4) skill
+        # needs no target prompt; a single-ally skill (3) asks which ally.
+        if sk && sk.type == Game::Party::SKILL_SWITCH
+          apply_switch_skill(sid)
+        elsif sk && (sk.scope == 2 || sk.scope == 4)
           apply_skill(sid, nil)
         else
           @pending_skill = sid
@@ -5761,6 +5777,19 @@ class RPG2k
           show_message("It had no effect.")
         else
           show_message("#{caster.name} casts #{skill_name(sid)}!", :cast)
+        end
+      end
+
+      # A switch skill (type 3) spends its SP and turns on a game switch, with
+      # nothing to target. This is how a Nepheshel player summons and dismisses a
+      # companion — the switch is what its common event watches.
+      def apply_switch_skill(sid)
+        switch = @state.party.cast_switch_skill(caster, sid)
+        if switch
+          @state.switches[switch] = true
+          show_message("#{caster.name} casts #{skill_name(sid)}!", :cast)
+        else
+          show_message("It had no effect.")
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1850,36 +1850,43 @@ end
 FakeActorSystem = Struct.new(:party)
 # A database item row exposing the equipment-bonus fields Game::Actor reads plus
 # the medicine recovery/scope fields Game::Party#use_item reads.
+# The occasion fields are named the way the real item row names them:
+# `occasion_field1` (37) bars battle use, `occasion_field2` (57) is a switch
+# item's field flag and `occasion_battle` (58) its battle flag. This fixture used
+# to offer a single `occasion_field`, a name no genuine row carries — which is
+# exactly how the runtime's gate came to read a field that was never there.
 FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :max_hp_points, :max_sp_points, :type, :name, :scope,
                       :recover_hp, :recover_hp_rate, :recover_sp, :recover_sp_rate,
                       :price, :skill_id,
                       :atk_points2, :def_points2, :spi_points2, :agi_points2,
                       :occasion_battle, :state_set, :reverse_state_effect,
-                      :prevent_critical, :attribute_set, :switch_id, :occasion_field)
+                      :prevent_critical, :attribute_set, :switch_id,
+                      :occasion_field2, :occasion_field1)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
-              attribute_set: nil, switch_id: 0, occ_field: true)
+              attribute_set: nil, switch_id: 0, occ_field: true,
+              field_only: false)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
-               prevent_crit, attribute_set, switch_id, occ_field)
+               prevent_crit, attribute_set, switch_id, occ_field, field_only)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
                        :sp_percent, :power, :physical_rate, :magical_rate,
                        :affect_hp, :affect_sp, :occasion_battle,
                        :state_effects, :reverse_state_effect, :hit, :variance,
-                       :attribute_effects)
+                       :attribute_effects, :switch_id)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
                occ_battle: true, state_effects: nil, reverse_state: false, hit: 100,
-               variance: 4, attribute_effects: nil)
+               variance: 4, attribute_effects: nil, switch_id: 1)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
                 prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
-                variance, attribute_effects)
+                variance, attribute_effects, switch_id)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
 # per-turn slip damage (hp/sp change), action restriction and auto-recovery.
@@ -2748,25 +2755,44 @@ check 'field_items lists only held medicines, in id order with counts' do
   eq [[5, 1], [9, 2]], st.party.field_items
 end
 
-check 'a battle-only medicine is hidden from the field menu but shown in battle' do
+check 'a field-only medicine is kept out of battle; every medicine is in the field' do
+  # RPG2000 gives a medicine exactly one occasion flag, `occasion_field1`, and it
+  # only ever *subtracts*: set, the medicine is field-only. There is no way to
+  # make a medicine battle-only, which is why `field_usable?` asks nothing of it
+  # (EasyRPG: `return !in_battle || !item->occasion_field1`).
   items = {
-    5 => fake_item(type: 6, rhp: 50, occ_field: true,  occ_battle: false), # field only
-    6 => fake_item(type: 6, rhp: 50, occ_field: false, occ_battle: true),  # battle only
+    5 => fake_item(type: 6, rhp: 50),                     # usable anywhere
+    6 => fake_item(type: 6, rhp: 50, field_only: true),   # field only
   }
   st = item_party(items)
   st.party.gain_item(5, 1)
   st.party.gain_item(6, 1)
-  ok st.party.field_usable?(5), 'the field medicine is usable in the field'
-  ok !st.party.field_usable?(6), 'the battle-only medicine is hidden from the field'
-  eq [[5, 1]], st.party.field_items
-  # ... and the reverse holds for the battle item list.
-  ok st.party.battle_usable?(6), 'the battle-only medicine is usable in battle'
-  ok !st.party.battle_usable?(5), 'the field-only medicine is not usable in battle'
-  eq [[6, 1]], st.party.battle_items
+  ok st.party.field_usable?(5), 'an ordinary medicine is usable in the field'
+  ok st.party.field_usable?(6), 'and so is a field-only one'
+  eq [[5, 1], [6, 1]], st.party.field_items
+  ok st.party.battle_usable?(5), 'the ordinary medicine is usable in battle'
+  ok !st.party.battle_usable?(6), 'the field-only one is not'
+  eq [[5, 1]], st.party.battle_items
+end
+
+check 'a switch item reads its own pair of occasion flags' do
+  # A switch item is the one item kind gated on both sides, and by its *own*
+  # fields: occasion_field2 (57) and occasion_battle (58).
+  items = {
+    5 => fake_item(type: 10, switch_id: 3, occ_field: true,  occ_battle: false),
+    6 => fake_item(type: 10, switch_id: 4, occ_field: false, occ_battle: true),
+  }
+  st = item_party(items)
+  st.party.gain_item(5, 1)
+  st.party.gain_item(6, 1)
+  eq [[5, 1]], st.party.field_items, 'only the field-flagged switch item'
+  eq [[6, 1]], st.party.battle_items, 'only the battle-flagged one'
 end
 
 check 'a switch item is field-usable, effective, and flips its switch on use' do
-  items = { 4 => fake_item(type: 9, switch_id: 12, name: 'Whistle') }
+  # Type 10 is the switch item (スイッチ); 9 is the special item that invokes a
+  # skill. This fixture said 9, which is what the runtime used to believe too.
+  items = { 4 => fake_item(type: 10, switch_id: 12, name: 'Whistle') }
   st = item_party(items)
   st.party.gain_item(4, 2)
   eq [[4, 2]], st.party.field_items, 'switch items appear in the field menu'
@@ -2946,14 +2972,74 @@ end
 
 # A two-actor party (Hero atk 10 / spirit 12 / max SP 30, Ally max HP 50) plus
 # the given skill table, for the field-skill checks.
-def skill_party(skills)
+def skill_party(skills, items = {})
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,
                            max_hp: 100, max_mp: 30, atk: 10, def: 8, int: 12, agi: 7),
     2 => FakePlayerRow.new('Ally', '', 0, 3,
                            max_hp: 50, max_mp: 20, atk: 6, def: 5, int: 4, agi: 6),
   }
-  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], {}, skills)), 1, 0, 0)
+  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items, skills)), 1, 0, 0)
+end
+
+check 'an RPG2003 subskill category behaves as an ordinary skill' do
+  # Types from 4 up are 2003's custom battle-command categories, not a different
+  # kind of skill. mtf-meido-action files 57 of its 134 skills that way — every
+  # healing line among them — so reading type != 0 as "not a real skill" hid
+  # them from both menus.
+  skills = {
+    1 => fake_skill(scope: 3, sp_cost: 1, power: 10, hp: true),          # type 0
+    2 => fake_skill(scope: 3, sp_cost: 1, power: 10, hp: true, type: 5), # subskill
+    3 => fake_skill(scope: 0, sp_cost: 1, power: 10, type: 7),           # subskill, foes
+  }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  [1, 2, 3].each { |s| hero.learn_skill(s) }
+  eq [[1, 1], [2, 1]], st.party.field_skills(hero), 'the subskill heal is offered'
+  caster = Game::Battle.from_actor(hero)
+  eq [[1, 1], [2, 1], [3, 1]], st.party.battle_skills(hero, caster)
+end
+
+check 'a switch skill is cast for its switch, and only where its flags allow' do
+  skills = {
+    4 => fake_skill(name: 'Summon', type: 3, sp_cost: 6, switch_id: 17),
+    5 => fake_skill(name: 'Boost', type: 3, sp_cost: 2, switch_id: 18,
+                    occ: false, occ_battle: true),
+  }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  [4, 5].each { |s| hero.learn_skill(s) }
+  caster = Game::Battle.from_actor(hero)
+  # Skill 4 is field+battle by default; 5 is flagged battle-only.
+  eq [[4, 6]], st.party.field_skills(hero), 'the battle-only switch skill is hidden'
+  eq [[4, 6], [5, 2]], st.party.battle_skills(hero, caster)
+  ok st.party.switch_skill?(4)
+  before = hero.mp
+  eq 17, st.party.cast_switch_skill(hero, 4), 'casting returns the switch to flip'
+  eq before - 6, hero.mp, 'and spends the SP'
+  # A non-switch skill is not one, and spends nothing.
+  ok st.party.cast_switch_skill(hero, 99).nil?
+end
+
+check 'a special item invokes its skill, free of SP and without knowing it' do
+  # Type 9 is 特殊: the item names a skill in skill_id and casting it is what
+  # using the item does. Nepheshel's whole thrown-bomb line works this way.
+  skills = { 8 => fake_skill(name: 'Elixir', scope: 3, sp_cost: 99,
+                             power: 40, hp: true) }
+  items = { 3 => fake_item(type: 9, skill_id: 8, name: 'Vial') }
+  st = skill_party(skills, items)
+  hero = st.party.actor_by_id(1)
+  hero.change_hp(-50)
+  hero.mp = 0                                   # cannot afford the skill itself
+  ok !hero.knows_skill?(8), 'and has never learnt it'
+  st.party.gain_item(3, 2)
+  ok st.party.field_usable?(3), 'its skill targets an ally, so the field offers it'
+  ok st.party.item_effective?(3, hero)
+  affected = st.party.use_item(3, hero)
+  eq [hero], affected
+  eq 90, hero.hp, 'the skill landed'
+  eq 0, hero.mp, 'no SP was spent'
+  eq 1, st.party.item_count(3), 'one was consumed'
 end
 
 check 'a field heal skill restores HP by the RPG2000 formula and spends SP' do
@@ -2974,16 +3060,20 @@ check 'a field heal skill restores HP by the RPG2000 formula and spends SP' do
 end
 
 check 'field_skills lists only known field-usable ally skills; can_cast? checks SP' do
+  # What keeps an ordinary skill out of the field menu is its *scope* and whether
+  # it does anything at all — not `occasion_field`, which RPG2000 only reads for
+  # a switch skill (skill 9 here carries it off and is listed all the same).
   skills = {
     7  => fake_skill(scope: 3, sp_cost: 5, power: 10, hp: true),        # usable
     8  => fake_skill(scope: 0, sp_cost: 1, power: 10, hp: true),        # enemy scope
-    9  => fake_skill(scope: 3, occ: false, sp_cost: 1, power: 10, hp: true), # not field
+    9  => fake_skill(scope: 3, occ: false, sp_cost: 1, power: 10, hp: true),
     10 => fake_skill(scope: 4, sp_cost: 99, power: 10, hp: true),       # too costly
+    11 => fake_skill(scope: 3, sp_cost: 1, power: 10),                  # affects nothing
   }
   st = skill_party(skills)
   hero = st.party.actor_by_id(1)               # max SP 30
-  [7, 8, 9, 10].each { |s| hero.learn_skill(s) }
-  eq [[7, 5], [10, 99]], st.party.field_skills(hero)  # ally-scope, field-usable
+  [7, 8, 9, 10, 11].each { |s| hero.learn_skill(s) }
+  eq [[7, 5], [9, 1], [10, 99]], st.party.field_skills(hero)
   eq true, st.party.can_cast?(hero, 7)
   eq false, st.party.can_cast?(hero, 10)       # 99 SP > 30
   eq false, st.party.can_cast?(hero, 99)       # unknown skill
@@ -5702,16 +5792,22 @@ check 'battle_skills lists the caster\'s battle-usable skills with SP cost' do
     7  => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 20, mrate: 40),
     8  => fake_skill(name: 'Heal', scope: 3, sp_cost: 5, power: 20, mrate: 40, hp: true),
     9  => fake_skill(name: 'Guard', scope: 2, sp_cost: 3, power: 10, hp: true),
-    10 => fake_skill(name: 'FieldOnly', scope: 3, sp_cost: 4, hp: true, occ_battle: false),
+    # `occasion_battle` off does *not* keep an ordinary skill out of a fight:
+    # RPG2000 reads that flag for switch skills only, and once a battle is
+    # running every other skill is usable. Skill 13 is a switch skill, which is
+    # the one kind the flag really does exclude.
+    10 => fake_skill(name: 'NotFlagged', scope: 3, sp_cost: 4, hp: true, occ_battle: false),
     11 => fake_skill(name: 'AllFoes', scope: 1, sp_cost: 8, power: 20),  # all enemies
-    12 => fake_skill(name: 'AllHeal', scope: 4, sp_cost: 7, power: 20, hp: true) # all allies
+    12 => fake_skill(name: 'AllHeal', scope: 4, sp_cost: 7, power: 20, hp: true), # all allies
+    13 => fake_skill(name: 'Summon', type: 3, sp_cost: 2, occ_battle: false)
   }
   st = skill_party(skills)
   hero = st.party.actor_by_id(1)
-  [7, 8, 9, 10, 11, 12].each { |s| hero.learn_skill(s) }
+  [7, 8, 9, 10, 11, 12, 13].each { |s| hero.learn_skill(s) }
   caster = Game::Battle.from_actor(hero)
-  eq [[7, 6], [8, 5], [9, 3], [11, 8], [12, 7]], st.party.battle_skills(hero, caster),
-     'single- and all-target battle skills, in id order (field-only excluded)'
+  eq [[7, 6], [8, 5], [9, 3], [10, 4], [11, 8], [12, 7]],
+     st.party.battle_skills(hero, caster),
+     'every ordinary skill, in id order; the unflagged switch skill excluded'
   eq :enemy,     st.party.battle_skill_target(st.party.db_skill(7))
   eq :ally,      st.party.battle_skill_target(st.party.db_skill(8))
   eq :self,      st.party.battle_skill_target(st.party.db_skill(9))
@@ -5899,9 +5995,9 @@ check 'Battle command_item restores HP and tags the entry for bag consumption' d
 end
 
 check 'battle_items lists battle medicines; battle_item_command recovers' do
-  items = { 5 => fake_item(type: 6, rhp: 40),                    # battle medicine
-            6 => fake_item(type: 6, rhp: 20, occ_battle: false), # field-only
-            7 => fake_item(type: 1, atk: 5) }                    # a weapon
+  items = { 5 => fake_item(type: 6, rhp: 40),                     # battle medicine
+            6 => fake_item(type: 6, rhp: 20, field_only: true),   # field-only
+            7 => fake_item(type: 1, atk: 5) }                     # a weapon
   st = item_party(items)
   st.party.gain_item(5, 2)
   st.party.gain_item(6, 1)

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -69,6 +69,8 @@ DB_SYSTEM = 22
 SYS_PARTY = 22
 DB_COMMON_EVENT = 25
 CE_COMMANDS = 22
+DB_SKILL = 12
+DB_ITEM = 13
 CHANGE_PARTY = Game::Interpreter::Cmd::CHANGE_PARTY
 
 # Commands that name one actor by a fixed id rather than acting on the party.
@@ -294,7 +296,88 @@ if dirs.empty?
   exit 0
 end
 
-dirs.each { |d| check_game(d) }
+# What the menus offer a party that knows everything and carries one of each.
+#
+# A real game's skills and items have to reach its menus, and "reaches nothing"
+# is the failure this catches: gating every skill on `occasion_battle` (a flag
+# RPG2000 only writes for switch skills) left the battle skill menu **empty in
+# both test beds** — 306 skills and 134 skills, none of them offered — while
+# every fixture check passed.
+def check_menus(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+  leader = party.leader
+  unless leader
+    puts "   (no party leader — menus skipped)"
+    return
+  end
+  skill_ids = []
+  db[DB_SKILL]&.each { |id, _| skill_ids << id }
+  skill_ids.each { |id| leader.learn_skill(id) }
+  leader.mp = 99_999                     # affordability is not what is under test
+  db[DB_ITEM]&.each { |id, _| party.gain_item(id, 1) }
+
+  field_skills = party.field_skills(leader)
+  battle_skills = party.battle_skills(leader, leader)
+  field_items = party.field_items
+  battle_items = party.battle_items
+  puts format('   menus: %d/%d skills field/battle, %d/%d items field/battle ' \
+              '(of %d skills, %d items)',
+              field_skills.size, battle_skills.size, field_items.size,
+              battle_items.size, skill_ids.size, party.items.size)
+
+  check "#{name}: the battle skill menu is not empty" do
+    ok battle_skills.size > 0, "#{skill_ids.size} skills, none offered in battle"
+  end
+  check "#{name}: the field skill menu is not empty" do
+    ok field_skills.size > 0, "#{skill_ids.size} skills, none offered in the field"
+  end
+  check "#{name}: the field item menu is not empty" do
+    ok field_items.size > 0, 'the bag holds one of everything and offers nothing'
+  end
+
+  # Every skill kind the game actually uses has to be reachable somewhere: a
+  # skill offered in neither menu is one no player can ever cast. Escape and
+  # teleport skills are the known exception (see Party#unsupported_field_skill?).
+  check "#{name}: no skill is unreachable from both menus" do
+    unreachable = skill_ids.reject do |id|
+      sk = party.db_skill(id)
+      next true if party.unsupported_field_skill?(sk)
+      party.field_skill?(sk) || party.battle_skill?(sk)
+    end
+    eq [], unreachable.first(8), "#{unreachable.size} skill(s) castable nowhere"
+  end
+
+  # Special items (type 9) invoke a skill; switch items (type 10) flip a switch.
+  # Reading those two the other way round put the special items on the switch
+  # branch, where they flipped the switch id they never set — the default, 1.
+  special = []
+  switch = []
+  db[DB_ITEM]&.each do |id, it|
+    special << id if it.type == Game::Party::ITEM_SPECIAL
+    switch << id if it.type == Game::Party::ITEM_SWITCH
+  end
+  return if special.empty? && switch.empty?
+  puts "   #{special.size} special item(s), #{switch.size} switch item(s)"
+
+  check "#{name}: special items invoke a real skill, switch items a real switch" do
+    special.each do |id|
+      sk = party.db_skill(party.db_item(id).skill_id)
+      ok sk, "special item ##{id} names a skill that exists"
+      ok party.field_usable?(id) || party.battle_usable?(id),
+         "special item ##{id} (#{sk.name}) is usable somewhere"
+    end
+    switch.each do |id|
+      sid = party.db_item(id).switch_id
+      ok sid && sid > 1,
+         "switch item ##{id} names a switch of its own, not the default 1"
+      ok party.switch_item?(id), "switch item ##{id} is recognised as one"
+    end
+  end
+end
+
+dirs.each { |d| check_game(d); check_menus(d) }
 
 if $failures.zero?
   puts "rpg2k test-bed logic check: #{$checks} checks passed"


### PR DESCRIPTION
Usability was decided from the row's `occasion_field` / `occasion_battle` flags. RPG2000 reads those for **switch skills only**. See [ADR 0031](docs/adr/0031-skill-and-item-usability.md).

## The measurement

Teach a test bed's party every skill in its database, hand it one of every item, and ask what the menus offer:

| | Nepheshel 2.06 | mtf-meido-action |
|---|---|---|
| skills in the database | 306 | 134 |
| **battle skill menu** | **0** | **0** |
| field skill menu | 30 | 2 |
| **battle item menu** | **0** | **0** |
| field item menu | 41 | 14 |

**Neither game could use a single skill or item in a fight.** Every fixture check passed throughout — the fixtures were built to the same wrong model.

## Three mistakes, one measurement

**The occasion flags gate switch skills only.** RPG_RT reads them in one arm of `Algo::IsSkillUsable`, and the RPG2000 editor only shows the 使用可能な場面 checkboxes for a スイッチ skill. The bytes say it precisely — chunk presence across the two beds:

- Nepheshel writes chunk 18 for **6** of 306 skills and chunk 19 for **12**, and those 12 are *exactly* its 12 switch skills.
- mtf-meido-action, which has **no** switch skill, writes neither chunk for any of its 134.

So `occasion_battle` was almost always its default `false`, and gating on it emptied the battle menu.

**RPG2003 files skills under numbered categories.** liblcf's `Skill::Type` runs `normal=0, teleport=1, escape=2, switch=3, subskill=4`, and 2003 numbers each custom battle command from 4 up into that same field. `type == SKILL_NORMAL` therefore rejected a skill for the sole reason that a 2003 game sorted it into a menu — **57 of mtf's 134 skills** (43%), including every one of its healing lines (Heal / Recovery / Cure / Raise are category 5).

**Item types 9 and 10 were swapped.** liblcf ends `material=8, special=9, switch=10`; this build had `ITEM_SWITCH = 9` and no notion of a special item. Nepheshel settles it: its **14 type-9 items** each carry a *distinct* `skill_id` naming a skill of the same name (item 天使の翼 → skill 天使の翼) with `switch_id` at the default, and its **41 type-10 items** are the mirror image. So all 14 special items flipped switch **1** — a switch none of them names — and the 41 real switch items never appeared in the bag.

A quieter fourth sat underneath: the runtime asked every item for `occasion_field`, **a field no real item row has**. RPG2000 gives an item three occasion fields with three different jobs, so the lookup fell through to its "no flag, assume usable" default on every genuine item and the gate never once fired. Only fixtures, which did define that name, ever exercised it — which is why `docs/TODO.md` claimed a behaviour that never happened. That claim is corrected in this PR rather than left standing.

## The change

Decide usability the way RPG_RT does (`Algo::IsSkillUsable`, `Game_Party::IsItemUsable`):

- **Skills** — escape/teleport never in battle; a switch skill consults its flags; anything else (normal or 2003 subskill) is always usable in battle, and usable in the field when its scope reaches an ally and it does something there.
- **Items** — a medicine is always field-usable, and battle-usable unless `occasion_field1` marks it field-only; a switch item reads its own `occasion_field2` / `occasion_battle` pair; a **special** item defers entirely to the skill it invokes.
- **Special items cast their skill**, the item standing in for the SP cost — the user pays nothing and need not have learnt it. Nepheshel's whole thrown-bomb line is these.
- **Switch skills flip their switch** — how a Nepheshel player summons and dismisses a companion (skills 120–125, ファルを召還 and friends), each flipping the switch its common event watches. That completes the mechanic whose actor side [#381](https://github.com/take-cheeze/rpg-maker-clone/pull/381) fixed.

## Result

| | Nepheshel (before → after) | mtf (before → after) |
|---|---|---|
| battle skill menu | 0 → **306** | 0 → **132** |
| field skill menu | 30 → 28 | 2 → **12** |
| battle item menu | 0 → **34** | 0 → **7** |
| field item menu | 41 → **69** | 14 → 14 |

Nepheshel's field skill menu gets slightly *smaller*, and that is the change working: a skill that reaches an ally but changes nothing there — a pure battle stat buff — no longer sits in a menu where it can do nothing. Its field item list grows by the 41 switch items it never showed and loses the 13 thrown bombs that belong in a fight, which are exactly what its battle list gains alongside 20 medicines.

## Testing

`scripts/rpg2k_testbed_logic_check.rb` now asks the **real** databases what the menus offer: no menu comes back empty, no skill is castable from neither menu, every special item names a real skill and every switch item names a switch of its own rather than the default 1. That is the guard this needed — the emptiness was invisible to every fixture.

New unit checks cover subskill categories, switch-skill casting, special items, and the medicine/switch occasion fields. Four existing checks asserted the old model and were **rewritten to the real rule rather than deleted**; `fake_item` now carries `occasion_field1` / `occasion_field2` under the names the format uses.

All nine CRuby suites pass: `rpg2k_logic_check` (511, +7), `rpg2k_scene_check` (150), `rpg2k_testbed_logic_check` (38, +14), `rpg2k_render_check`, `lcf_testbed_check`, `rpgxp_testbed_check`, `rpgvx_testbed_check`, `mv_testbed_check`, `mz_testbed_check`. The native build could not be exercised here (no nix/SDL2) — CI covers it.

## Not done

Escape (type 1) and teleport (type 2) skills are still not offered — teleport wants a destination picker this build has no screen for, and the two test beds hold exactly one of each, so there is nothing to measure an implementation against. `Party#unsupported_field_skill?` names them so the gap is declared rather than implied, and the test-bed check excludes them by that predicate rather than by accident.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_