### PR TITLE
Let what you are wearing change how you fight

### DIFF
--- a/changelog.d/equipment-combat-modifiers.fixed.md
+++ b/changelog.d/equipment-combat-modifiers.fixed.md
@@ -1,0 +1,24 @@
+- **Equipment combat flags now do what they advertise.** Four RPG2000 fields the
+  schema parsed and the runtime never read (ADR 0033):
+  - **二刀流 `dual_attack`** — the weapon swings twice per basic attack. Thirteen
+    of Nepheshel's weapons promise a second blow and delivered one. The second
+    swing is skipped when the first fells the target, the same rule the enemy's
+    own dual-attack action already followed.
+  - **必中 `ignore_evasion`** — the attack drops the agility term from the to-hit
+    roll, leaving the weapon's own hit rate. Thirteen more of Nepheshel's weapons
+    promise never to miss and missed; against an agility-999 foe the ダガー goes
+    from 82% to 98%. The wielder's *own* blindness still applies, since what the
+    flag ignores is the target's evasion.
+  - **MP消費半分 `half_sp_cost`** — skills cost half, rounded up so a 1-SP skill
+    still costs 1. Any slot grants it (Nepheshel's 賢者の指輪 is an accessory);
+    a 7-SP skill drops to 4.
+  - **強力防御 `strong_defence`** — Defend halves damage a *second* time, a
+    quarter rather than a half. Seven of Nepheshel's fifty actors have it,
+    including リト, its hero: 41 damage while guarding becomes 20.
+
+  Nothing else moved — every troop in both test beds (157 and 88 fights) gives
+  byte-identical results, since neither starting party wears the flagged gear.
+- **`scripts/rpg2k_testbed_logic_check.rb`** additionally asserts against the real
+  item and actor tables that every 二刀流 weapon grants two strikes, every 必中
+  weapon hits at its own rate against an unhittable target, and every MP消費半分
+  item halves a real skill's cost.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -536,7 +536,24 @@ The work below is roughly ordered by the critical path to a walkable game
   off for seeded / headless fights. A basic attack can land a **3x critical hit**
   at the attacker's database 1-in-N chance (actor `critical_rate`, enemy
   `critical_hit_chance`); no crit on a same-side hit. Characters wearing gear with
-  the **`prevent_critical`** flag can never be crit. **Elemental attributes**
+  the **`prevent_critical`** flag can never be crit. Four more **equipment combat
+  flags** are read now (ADR 0033), each of them previously parsed and used by
+  nothing: **二刀流** (`dual_attack`) makes a basic attack swing **twice** — 13 of
+  Nepheshel's weapons — skipping the second blow when the first fells the target;
+  **必中** (`ignore_evasion`, 13 more weapons) drops the agility term from the
+  to-hit roll so the weapon hits at its own rate (82% → 98% against an agi-999
+  foe), while the wielder's own blindness still applies on top, since what the
+  flag ignores is the *target's* evasion; **MP消費半分** (`half_sp_cost`, any
+  slot) halves a skill's cost rounding up; and **強力防御** (`strong_defence`, an
+  actor-row flag 7 of Nepheshel's 50 actors carry including its hero) halves
+  damage a second time while defending — a quarter, not a half. Still unread: a
+  weapon's **`critical_hit` bonus**, the largest count in that audit at 75 items,
+  which needs the crit model to move from a 1-in-N denominator to RPG_RT's
+  probability (`1/critical_hit_chance` plus the best weapon's percentage);
+  **`attack_all`** (7 weapons), whose handling is not in EasyRPG's `algo.cpp`
+  with the others and is left declared rather than guessed; and **`preemptive`**
+  / **`raise_evasion`**, the latter having nowhere to land until the to-hit
+  formula grows an evasion term separate from agility. **Elemental attributes**
   scale damage too: a weapon's `attribute_set` / a skill's `attribute_effects`
   are matched against the target's per-attribute defence ranks (A..E, strongest
   element winning) — the rates come from each attribute's own `a_rate` .. `e_rate`
@@ -973,7 +990,9 @@ The work below is roughly ordered by the critical path to a walkable game
   not, on any genuine item. See ADR 0031. Remaining: **teleport / escape** skill
   types (one of each across both test beds; teleport wants a destination picker
   this build has no screen for, so `Party#unsupported_field_skill?` declares the
-  gap), the battle-time skill variance, and two-handed / dual-wield equipping.
+  gap), the battle-time skill variance, and two-handed / dual-wield **equipping**
+  (the equip screen's slot rules — a 二刀流 weapon's *combat* effect is read now,
+  see ADR 0033).
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/docs/adr/0033-equipment-combat-modifiers.md
+++ b/docs/adr/0033-equipment-combat-modifiers.md
@@ -1,0 +1,110 @@
+# 33. What you are wearing changes how you fight
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+`Game::Actor` already surfaced some of what equipment does in a fight — the
+weapon's base `hit`, its elemental `attribute_set`, and whether any piece of gear
+carries `prevent_critical`. The rest of RPG2000's equipment combat flags were
+parsed by the schema and read by nothing.
+
+Auditing the database fields the test beds set against the fields the runtime
+mentions anywhere turned up a cluster of them:
+
+| field | what it means | Nepheshel | mtf |
+|---|---|---|---|
+| `dual_attack` (二刀流) | the weapon swings twice | **13** weapons | 0 |
+| `ignore_evasion` (必中) | the attack cannot be evaded | **13** weapons | 0 |
+| `half_sp_cost` (MP消費半分) | skills cost half | **6** items | 1 |
+| `strong_defence` (強力防御) | Defend halves damage again | **7** actors | 0 |
+
+Read as behaviour: thirteen of Nepheshel's weapons advertise a second swing and
+delivered one; thirteen more promise never to miss and missed; six accessories
+promise cheaper magic and charged full price; and seven of its fifty actors —
+including リト, the hero — have a guard that should be twice as good as everyone
+else's and wasn't.
+
+None of it was reachable by the existing checks. `fake_item` had no member for
+any of the three item flags and `FakePlayerRow` had none for the actor one, so
+no fixture could express the difference between a 二刀流 blade and a plain one.
+
+## Decision
+
+Read the four fields, following RPG_RT:
+
+- **`dual_attack`** makes a basic attack land twice
+  (EasyRPG's `GetNumberOfAttacks`: `weapon.dual_attack ? 2 : 1`). A new
+  `Battle#swing` wraps `deal_attack` and returns an array for the second blow,
+  so the log reads exactly like the enemy's own dual-attack action — including
+  that rule's "the second swing only lands if the first did not fell the
+  target", which `swing` reuses rather than reinvents.
+- **`ignore_evasion`** drops the agility term from the to-hit calculation:
+  RPG_RT's `CalcNormalAttackToHit` returns before applying evasion for such a
+  weapon, leaving the weapon's own hit rate. The attacker's **own** statuses
+  still apply on top — what the flag ignores is the *target's* evasion, not a
+  blindness spoiling the wielder's aim (ADR 0032), and the two compose.
+- **`half_sp_cost`** halves a skill's cost, **rounding up**, so a 1-SP skill
+  still costs 1 (EasyRPG's `cost = (cost + 1) / 2`). Any slot grants it, not
+  just the weapon — Nepheshel's 賢者の指輪 is an accessory. `Party#skill_cost`
+  asks whatever it was handed, which is a `Game::Actor` in the menus and a battle
+  snapshot in a fight, so both paths get it from one place.
+- **`strong_defence`** halves damage a second time while defending — a quarter
+  rather than a half (`AdjustDamageForDefend` applies a second `dmg /= 2`). It is
+  a property of the actor row rather than of gear, and an RPG2003 class overrides
+  it the way it already overrides the growth curves.
+
+The three item flags are read through one `Actor#equipment_flag?` helper, since
+"any equipped piece carries this boolean" is the shape all of them share.
+`Combatant` grew four members (`strikes`, `ignores_evasion`, `strong_defence`,
+`half_sp_cost`) carried across by `from_actor`.
+
+## Consequences
+
+The gear does what it says, measured against the real tables:
+
+| | without | with |
+|---|---|---|
+| swings per attack (サクリファイス) | 1 | **2** |
+| to-hit vs an agi-999 foe (ダガー) | 82% | **98%** |
+| a 7-SP skill (賢者の指輪) | 7 SP | **4 SP** |
+| damage while defending (リト) | 41 | **20** |
+
+The last is one actor with only the flag toggled, so nothing but the flag
+accounts for it.
+
+Nothing else moved. Running every troop in both test beds — 157 fights and 88 —
+gives byte-identical results to before: the same outcomes, the same 1847 and 1726
+swings, the same 501 and 708 misses. Neither test bed's *starting* party wears
+any of the flagged gear, so the sweep exercises the unchanged path and confirms
+it is unchanged.
+
+Left for a follow-up, and deliberately not guessed at here:
+
+- **A weapon's `critical_hit` bonus** — 75 of Nepheshel's items carry one, the
+  largest count in the audit. It is the one flag that cannot simply be read,
+  because RPG_RT computes a *probability* (`1/critical_hit_chance` from the actor
+  plus the best weapon's `critical_hit` as a percentage) while this build models
+  criticals as a 1-in-N denominator. Folding the bonus in means moving that
+  representation to a probability, which touches every crit fixture and deserves
+  its own diff and its own before/after.
+- **`attack_all`** (7 weapons) — a normal attack that hits every enemy. Its
+  handling is not in `algo.cpp` with the others, and rather than guess at how the
+  damage and log entries should read it is left declared.
+- **`preemptive`** (17 items) and **`raise_evasion`** (13) — the first wants the
+  battle's `first_strike` wired to gear; the second has nowhere to land until
+  the to-hit formula grows a separate evasion term, since RPG2000's is expressed
+  purely in agility.
+
+Covered by `scripts/rpg2k_logic_check.rb` (a 二刀流 weapon swings twice and skips
+the second swing on a felled target; a 必中 weapon drops the evasion term but
+still suffers its wielder's blindness; 強力防御 halves what an ordinary guard
+leaves; MP消費半分 halves a cost rounding up, and a percentage cost too) and by
+`scripts/rpg2k_testbed_logic_check.rb`, which asserts against the **real** item
+and actor tables that every 二刀流 weapon in the game grants two strikes, every
+必中 weapon hits at its own rate against an unhittable target, and every
+MP消費半分 item halves a real skill's cost from the slot its own type names.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1302,6 +1302,45 @@ module Game
       best && best > 0 ? best : 90
     end
 
+    # Whether any equipped item carries boolean field `name`. The weapon combat
+    # flags below all work this way — one piece of gear is enough to grant them.
+    # `weapon_only` restricts the search to the weapon slot (item type 1), which
+    # is where RPG2000 keeps the attack modifiers.
+    def equipment_flag?(name, weapon_only = false)
+      return false unless @db.respond_to?(:item)
+      @equipment.any? do |iid|
+        next false if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next false unless it
+        next false if weapon_only && !(it.respond_to?(:type) && it.type == 1)
+        it.respond_to?(name) && it.send(name) ? true : false
+      end
+    end
+
+    # 二刀流 — an equipped weapon that swings **twice** per basic attack
+    # (EasyRPG's `GetNumberOfAttacks`: `weapon.dual_attack ? 2 : 1`). Nepheshel
+    # gives 13 of its weapons this.
+    def dual_attack?; equipment_flag?(:dual_attack, true); end
+
+    # 必中 — an equipped weapon whose attack cannot be evaded. RPG_RT's
+    # `CalcNormalAttackToHit` returns before it applies the agility / evasion
+    # term for such a weapon. 13 of Nepheshel's weapons carry it.
+    def ignores_evasion?; equipment_flag?(:ignore_evasion, true); end
+
+    # MP消費半分 — gear that halves what a skill costs to cast. Any slot, not just
+    # the weapon (Nepheshel's 賢者の指輪 is an accessory).
+    def half_sp_cost?; equipment_flag?(:half_sp_cost); end
+
+    # 強力防御 — an actor whose Defend halves damage a *second* time (a quarter
+    # rather than a half, per EasyRPG's `AdjustDamageForDefend`). This one is a
+    # property of the actor row (field 24), not of gear, and an RPG2003 class can
+    # override it the way it overrides the growth curves.
+    def strong_defence?
+      row = class_row_for(@class_id) if @class_id && @class_id > 0
+      row ||= @db_row
+      row.respond_to?(:strong_defence) ? (row.strong_defence ? true : false) : false
+    end
+
     # Coerce an equipment spec (an EQUIP_ORDER hash, an array of ids, or nil) to a
     # five-slot array of integer item ids.
     def normalize_equipment(spec)
@@ -2173,11 +2212,17 @@ module Game
     # percentage of the caster's max SP (sp_type 1). Mirrors EasyRPG's
     # CalculateSkillCost (the half-SP-cost modifier is a later refinement).
     def skill_cost(sk, caster)
-      if sk.sp_type == 1
-        caster.max_mp * (sk.sp_percent || 0) / 100
-      else
-        sk.sp_cost || 0
-      end
+      cost =
+        if sk.sp_type == 1
+          caster.max_mp * (sk.sp_percent || 0) / 100
+        else
+          sk.sp_cost || 0
+        end
+      # MP消費半分 gear halves the bill, rounding **up** so a 1-SP skill still
+      # costs 1 (EasyRPG's `cost = (cost + 1) / 2`). Asked of whatever the caller
+      # handed over — a Game::Actor in the menus, a battle snapshot in a fight.
+      return cost unless caster.respond_to?(:half_sp_cost?) && caster.half_sp_cost?
+      (cost + 1) / 2
     end
 
     # `caster`'s known skills usable from the field menu, as `[skill_id, cost]`
@@ -4388,8 +4433,21 @@ module Game
                            :actor, :states, :state_turns, :crit_denom,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
                            :hit_rate, :state_ranks, :hidden, :battle_turn,
-                           :actions, :charged, :enemy_id, :battler_name) do
+                           :actions, :charged, :enemy_id, :battler_name,
+                           # Equipment-granted combat modifiers (ADR 0033):
+                           # how many times a basic attack swings, whether it
+                           # can be evaded, whether Defend halves twice, and
+                           # whether skills cost half.
+                           :strikes, :ignores_evasion, :strong_defence,
+                           :half_sp_cost) do
       def dead?; hp <= 0; end
+
+      # Swings per basic attack: 2 with a 二刀流 weapon, 1 otherwise. Struct
+      # members start nil, so the reader normalises.
+      def strike_count; n = strikes; n && n > 1 ? n : 1; end
+      # Whether this battler's gear halves what a skill costs (Party#skill_cost
+      # asks whatever it is handed, actor or snapshot).
+      def half_sp_cost?; half_sp_cost ? true : false; end
 
       # RPG2003 counts turns per battler as well as per battle: this is how many
       # turns *this* battler has taken, which the troop pages' turn_enemy /
@@ -4442,12 +4500,20 @@ module Game
     def self.state_ranks_of(b); b.respond_to?(:state_ranks) ? b.state_ranks : {}; end
 
     def self.from_actor(a)
-      Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
+      c = Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
                     nil, crit_denom_of(a), prevents_crit_of(a),
                     attr_ranks_of(a), atk_attrs_of(a), nil, hit_rate_of(a),
                     state_ranks_of(a))
+      c.strikes = flag_of(a, :dual_attack?) ? 2 : 1
+      c.ignores_evasion = flag_of(a, :ignores_evasion?)
+      c.strong_defence = flag_of(a, :strong_defence?)
+      c.half_sp_cost = flag_of(a, :half_sp_cost?)
+      c
     end
+
+    # A boolean predicate on the source row, false for a fixture without it.
+    def self.flag_of(b, name); b.respond_to?(name) && b.send(name) ? true : false; end
 
     # Enemies have no source actor (that field stays nil), so the post-battle
     # write-back skips them; they carry no status set into this simple sim.
@@ -4769,10 +4835,19 @@ module Game
     # accuracy enabled (see #initialize).
     def to_hit(attacker, target)
       base = attacker.hit_rate || 90
-      src = attacker.agi
-      src = 1 if src < 1
-      tgt = target.agi
-      raw = Game.clamp(100 - (100 - base) * (src + tgt) / (2 * src), 0, 100)
+      # 必中: a weapon flagged `ignore_evasion` skips the agility term entirely —
+      # RPG_RT's `CalcNormalAttackToHit` returns before it applies evasion for
+      # such a weapon. The attacker's own statuses still spoil its aim, since
+      # what the flag ignores is the *target's* evasion, not the wielder's blind.
+      raw =
+        if attacker.ignores_evasion
+          Game.clamp(base, 0, 100)
+        else
+          src = attacker.agi
+          src = 1 if src < 1
+          tgt = target.agi
+          Game.clamp(100 - (100 - base) * (src + tgt) / (2 * src), 0, 100)
+        end
       raw * hit_modifier(attacker) / 100
     end
 
@@ -5021,7 +5096,7 @@ module Game
       end
       target = attack_target(b)
       return nil unless target
-      deal_attack(b, target)
+      swing(b, target)
     end
 
     # -- enemy AI (行動パターン) ------------------------------------------------
@@ -5295,6 +5370,17 @@ module Game
     # critical hit, then halved (min 1) if the target defends. A target immune to
     # the weapon's element (0% rate) takes no damage. The crit note rides on the
     # log entry.
+    # One basic attack, which a 二刀流 weapon makes land **twice** (EasyRPG's
+    # `GetNumberOfAttacks`). Returns a single log entry for the ordinary case and
+    # an array when the weapon swings again, so the log reads the same as the
+    # enemy's own dual-attack action — whose "the second swing only lands if the
+    # first did not fell the target" rule this follows too.
+    def swing(b, target)
+      first = deal_attack(b, target)
+      return first if b.strike_count < 2 || target.dead?
+      [first, deal_attack(b, target)]
+    end
+
     def deal_attack(b, target)
       # When accuracy is on, roll the attacker's to-hit chance: a miss deals no
       # damage and reads as `missed` on the log entry.
@@ -5321,7 +5407,14 @@ module Game
       elsif charged
         dmg *= 2
       end
-      dmg = [dmg / 2, 1].max if target.defending && dmg > 0
+      # Defending halves the blow, and 強力防御 halves it again — a quarter, not a
+      # half (EasyRPG's `AdjustDamageForDefend` applies the second `dmg /= 2`
+      # for a battler with strong defence). Seven of Nepheshel's 50 actors have
+      # it, including its hero.
+      if target.defending && dmg > 0
+        dmg = [dmg / 2, 1].max
+        dmg = [dmg / 2, 1].max if target.strong_defence
+      end
       target.hp -= dmg
       woke = target.dead? ? [] : shake_off_states(target)
       entry = { attacker: b.name, target: target.name, damage: dmg, critical: crit,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1816,7 +1816,7 @@ end
 # A database row for an actor, and a fake DB exposing just what Game::Party /
 # Game::Actor read (player table + the initial party list).
 FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
-                           :initial_level, :status)
+                           :initial_level, :status, :strong_defence)
 # Like FakePlayerRow but exposing the full growth curve the way a real LCF row
 # does (six shorts per level via #int16_values(31)), so Actor scales its base
 # stats by level instead of using a single level-independent status hash.
@@ -1862,17 +1862,20 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :atk_points2, :def_points2, :spi_points2, :agi_points2,
                       :occasion_battle, :state_set, :reverse_state_effect,
                       :prevent_critical, :attribute_set, :switch_id,
-                      :occasion_field2, :occasion_field1)
+                      :occasion_field2, :occasion_field1,
+                      :dual_attack, :ignore_evasion, :half_sp_cost, :hit)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
               attribute_set: nil, switch_id: 0, occ_field: true,
-              field_only: false)
+              field_only: false, dual_attack: false, ignore_evasion: false,
+              half_sp_cost: false, hit: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
-               prevent_crit, attribute_set, switch_id, occ_field, field_only)
+               prevent_crit, attribute_set, switch_id, occ_field, field_only,
+               dual_attack, ignore_evasion, half_sp_cost, hit)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -6228,6 +6231,119 @@ check 'battle: a sealing state blocks skills above its threshold' do
   eq true, bat.skill_sealed?(hero, physical), 'rate 4 reaches the level-2 seal'
   eq false, bat.skill_sealed?(hero, weak_phys), 'rate 1 stays under it'
   eq false, bat.skill_sealed?(hero, nil), 'a missing skill row is not sealed'
+end
+
+# -- equipment-granted combat modifiers (ADR 0033) ----------------------------
+#
+# A party built from a real database row, so the Actor -> Combatant plumbing that
+# carries these flags is what is under test, not a hand-set snapshot.
+def geared_party(items, strong_defence = false)
+  row = CurveRow.new('Hero', '', 0, 1, [200, 50, 20, 10, 10, 10])
+  row.strong_defence = strong_defence
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  Game::State.new(Game::Party.new(db), 1, 0, 0)
+end
+
+check 'battle: a 二刀流 weapon swings twice' do
+  items = { 7 => fake_item(type: 1, atk: 5, dual_attack: true),
+            8 => fake_item(type: 1, atk: 5) }
+  st = geared_party(items)
+  hero = st.party.leader
+  foe = combatant('Foe', 0, 0, 5, 10_000)
+
+  hero.equip([8, 0, 0, 0, 0])                      # plain weapon
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  eq 1, bat.allies[0].strike_count
+  entry = bat.send(:swing, bat.allies[0], foe)
+  ok entry.is_a?(Hash), 'one swing, one log entry'
+
+  hero.equip([7, 0, 0, 0, 0])                      # 二刀流
+  foe2 = combatant('Foe', 0, 0, 5, 10_000)
+  bat2 = Game::Battle.new([Game::Battle.from_actor(hero)], [foe2], Game::Rng.new(1))
+  eq 2, bat2.allies[0].strike_count
+  entries = bat2.send(:swing, bat2.allies[0], foe2)
+  eq 2, entries.size, 'two swings, two log entries'
+  ok entries[0][:damage] > 0 && entries[1][:damage] > 0
+
+  # The second swing is skipped when the first fells the target.
+  dying = combatant('Dying', 0, 0, 5, 1)
+  bat3 = Game::Battle.new([Game::Battle.from_actor(hero)], [dying], Game::Rng.new(1))
+  e3 = bat3.send(:swing, bat3.allies[0], dying)
+  ok e3.is_a?(Hash), 'a felled target is not struck again'
+end
+
+check 'battle: a 必中 weapon ignores the target\'s evasion' do
+  items = { 7 => fake_item(type: 1, atk: 5, hit: 90, ignore_evasion: true),
+            8 => fake_item(type: 1, atk: 5, hit: 90) }
+  st = geared_party(items)
+  hero = st.party.leader
+  swift = combatant('Swift', 0, 0, 999, 100)       # far faster than the hero
+
+  hero.equip([8, 0, 0, 0, 0])
+  plain = Game::Battle.new([Game::Battle.from_actor(hero)], [swift],
+                           Game::Rng.new(1), nil, false, false, true)
+  dodgy = plain.send(:to_hit, plain.allies[0], swift)
+  ok dodgy < 90, "a fast target evades (#{dodgy}% < the weapon's 90%)"
+
+  hero.equip([7, 0, 0, 0, 0])
+  sure = Game::Battle.new([Game::Battle.from_actor(hero)], [swift],
+                          Game::Rng.new(1), nil, false, false, true)
+  eq 90, sure.send(:to_hit, sure.allies[0], swift),
+     "必中 drops the evasion term, leaving the weapon's own hit rate"
+end
+
+check 'battle: 必中 still suffers the wielder\'s own blindness' do
+  # What the flag ignores is the *target's* evasion, not a status spoiling the
+  # attacker's aim, so Blind still applies on top.
+  states = { 3 => fake_state(reduce_hit_ratio: 50) }
+  items = { 7 => fake_item(type: 1, atk: 5, hit: 90, ignore_evasion: true) }
+  st = geared_party(items)
+  hero = st.party.leader
+  hero.equip([7, 0, 0, 0, 0])
+  swift = combatant('Swift', 0, 0, 999, 100)
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [swift],
+                         Game::Rng.new(1), states, false, false, true)
+  bat.allies[0].states = [3]
+  eq 45, bat.send(:to_hit, bat.allies[0], swift), 'the weapon is sure, the wielder is blind'
+end
+
+check 'battle: 強力防御 halves damage a second time' do
+  st = geared_party({}, true)
+  hero = st.party.leader
+  ok hero.strong_defence?, 'the row carries the flag'
+  brute = combatant('Brute', 200, 0, 5, 100)
+
+  [false, true].each_with_index do |flag, i|
+    bat = Game::Battle.new([Game::Battle.from_actor(hero)], [brute], Game::Rng.new(1))
+    d = bat.allies[0]
+    d.strong_defence = flag
+    d.defending = true
+    before = d.hp
+    bat.send(:deal_attack, brute, d)
+    @guard_damage ||= []
+    @guard_damage[i] = before - d.hp
+  end
+  ok @guard_damage[0] > 0
+  eq @guard_damage[0] / 2, @guard_damage[1],
+     'strong defence takes half of what an ordinary guard leaves'
+end
+
+check 'MP消費半分 gear halves a skill cost, rounding up' do
+  skills = { 1 => fake_skill(sp_cost: 7), 2 => fake_skill(sp_cost: 1),
+             3 => fake_skill(sp_type: 1, sp_percent: 20) }
+  items = { 9 => fake_item(type: 5, half_sp_cost: true) }  # an accessory
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [100, 40, 10, 5, 5, 5]) },
+                       [1], items, skills)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+  eq false, hero.half_sp_cost?
+  eq 7, st.party.skill_cost(db.skill[1], hero)
+  hero.equip([0, 0, 0, 0, 9])
+  ok hero.half_sp_cost?, 'the accessory grants it'
+  eq 4, st.party.skill_cost(db.skill[1], hero), '7 -> 4, rounded up'
+  eq 1, st.party.skill_cost(db.skill[2], hero), 'a 1-SP skill still costs 1'
+  # A percentage cost is halved the same way (20% of 40 max SP = 8 -> 4).
+  eq 4, st.party.skill_cost(db.skill[3], hero)
 end
 
 check 'Battle end_round clears a queued Skill / Item command' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -72,6 +72,7 @@ CE_COMMANDS = 22
 DB_SKILL = 12
 DB_ITEM = 13
 DB_STATE = 18
+DB_ACTOR = 11
 CHANGE_PARTY = Game::Interpreter::Cmd::CHANGE_PARTY
 
 # Commands that name one actor by a fixed id rather than acting on the party.
@@ -471,7 +472,86 @@ def check_states(dir)
   end
 end
 
-dirs.each { |d| check_game(d); check_menus(d); check_states(d) }
+# Equipment-granted combat modifiers, against the real item and actor tables.
+# A weapon flag the runtime never reads is a weapon whose selling point does
+# nothing — a 二刀流 blade that swings once, a 必中 dagger that misses. See
+# docs/adr/0033-equipment-combat-modifiers.md.
+def check_equipment(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  items = db[DB_ITEM]
+  return unless items
+
+  dual = []
+  sure = []
+  half = []
+  items.each do |id, it|
+    dual << id if it.type == 1 && it.dual_attack
+    sure << id if it.type == 1 && it.ignore_evasion
+    half << id if it.half_sp_cost
+  end
+  strong = []
+  db[DB_ACTOR]&.each { |id, r| strong << id if r.strong_defence }
+  puts format('   equipment: %d 二刀流, %d 必中, %d MP消費半分, %d 強力防御 actor(s)',
+              dual.size, sure.size, half.size, strong.size)
+
+  unless dual.empty?
+    check "#{name}: a 二刀流 weapon makes its wielder swing twice" do
+      dual.each do |iid|
+        a = Game::Actor.new(db, first_actor_id(db))
+        a.equip([iid, 0, 0, 0, 0])
+        eq true, a.dual_attack?, "item ##{iid} (#{items[iid].name}) grants it"
+        eq 2, Game::Battle.from_actor(a).strike_count
+      end
+    end
+  end
+
+  unless sure.empty?
+    check "#{name}: a 必中 weapon drops the evasion term" do
+      swift = combatant('Swift', 0, 0, 999, 100)
+      sure.each do |iid|
+        a = Game::Actor.new(db, first_actor_id(db))
+        a.equip([iid, 0, 0, 0, 0])
+        bat = Game::Battle.new([Game::Battle.from_actor(a)], [swift],
+                               Game::Rng.new(1), db[DB_STATE], false, false, true)
+        eq a.attack_hit_rate, bat.send(:to_hit, bat.allies[0], swift),
+           "item ##{iid} (#{items[iid].name}) hits at its own rate"
+      end
+    end
+  end
+
+  unless half.empty?
+    check "#{name}: MP消費半分 gear halves a skill's cost" do
+      party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+      sk = nil
+      db[DB_SKILL]&.each { |_i, s| sk ||= s if (s.sp_cost || 0) > 1 && s.sp_type == 0 }
+      next unless sk
+      a = Game::Actor.new(db, first_actor_id(db))
+      full = party.skill_cost(sk, a)
+      ok full > 1, "the sample skill costs more than 1 SP (#{full})"
+      half.each do |iid|
+        # Equip it in the slot its own type names (1..5 map to the five slots),
+        # so the flag is read off gear the actor is really wearing.
+        slot = items[iid].type - 1
+        next unless slot >= 0 && slot < 5
+        gear = [0, 0, 0, 0, 0]
+        gear[slot] = iid
+        a.equip(gear)
+        ok a.half_sp_cost?, "item ##{iid} (#{items[iid].name}) grants MP消費半分"
+        eq (full + 1) / 2, party.skill_cost(sk, a),
+           "and halves the #{full}-SP skill, rounding up"
+      end
+    end
+  end
+end
+
+# The lowest defined actor id in the database.
+def first_actor_id(db)
+  db[DB_ACTOR].each { |id, _r| return id }
+  1
+end
+
+dirs.each { |d| check_game(d); check_menus(d); check_states(d); check_equipment(d) }
 
 if $failures.zero?
   puts "rpg2k test-bed logic check: #{$checks} checks passed"


### PR DESCRIPTION
`Game::Actor` already surfaced a weapon's base `hit`, its elemental `attribute_set` and `prevent_critical`. Four more RPG2000 equipment combat flags were parsed by the schema and read by nothing. See [ADR 0033](docs/adr/0033-equipment-combat-modifiers.md).

## The audit

| field | what it means | Nepheshel | mtf |
|---|---|---|---|
| `dual_attack` (二刀流) | the weapon swings twice | **13** weapons | 0 |
| `ignore_evasion` (必中) | the attack cannot be evaded | **13** weapons | 0 |
| `half_sp_cost` (MP消費半分) | skills cost half | **6** items | 1 |
| `strong_defence` (強力防御) | Defend halves damage again | **7** actors | 0 |

Read as behaviour: thirteen of Nepheshel's weapons advertise a second swing and delivered one; thirteen more promise never to miss and missed; six accessories promise cheaper magic and charged full price; and seven of its fifty actors — including リト, the hero — have a guard that should be twice as good as everyone else's and wasn't.

None of it was reachable by the existing checks. `fake_item` had no member for any of the three item flags and `FakePlayerRow` none for the actor one, so **no fixture could tell a 二刀流 blade from a plain one**.

## The change

Following RPG_RT:

- **`dual_attack`** makes a basic attack land twice (`GetNumberOfAttacks`). A new `Battle#swing` wraps `deal_attack` and reuses the enemy dual-attack action's own *"the second swing only lands if the first did not fell the target"* rule rather than reinventing it — the log reads identically either way.
- **`ignore_evasion`** drops the agility term from the to-hit roll (`CalcNormalAttackToHit` returns before applying evasion), leaving the weapon's own hit rate. The wielder's **own** blindness still applies on top: what the flag ignores is the *target's* evasion, not a status spoiling the attacker's aim ([ADR 0032](docs/adr/0032-state-effects.md)). There's a check pinning that composition.
- **`half_sp_cost`** halves a cost, **rounding up** so a 1-SP skill still costs 1 (`cost = (cost + 1) / 2`). Any slot grants it — Nepheshel's 賢者の指輪 is an accessory. `Party#skill_cost` asks whatever it was handed, so the menus and a fight both get it from one place.
- **`strong_defence`** halves damage a second time while defending — a quarter, not a half (`AdjustDamageForDefend`). It's an actor-row property rather than gear, and an RPG2003 class overrides it the way it already overrides growth curves.

## Result

Measured against the real tables:

| | without | with |
|---|---|---|
| swings per attack (サクリファイス) | 1 | **2** |
| to-hit vs an agi-999 foe (ダガー) | 82% | **98%** |
| a 7-SP skill (賢者の指輪) | 7 SP | **4 SP** |
| damage while defending (リト) | 41 | **20** |

The last is one actor with only the flag toggled, so nothing but the flag accounts for it.

**Nothing else moved.** Every troop in both test beds — 157 fights and 88 — gives byte-identical results: same outcomes, same 1847 and 1726 swings, same 501 and 708 misses. Neither starting party wears the flagged gear, so the sweep exercises the unchanged path and confirms it's unchanged.

## Testing

`fake_item` and `FakePlayerRow` grew the four flags. New unit checks cover: a 二刀流 weapon swinging twice and skipping the second swing on a felled target; a 必中 weapon dropping the evasion term *and* still suffering its wielder's blindness; 強力防御 taking half of what an ordinary guard leaves; MP消費半分 halving flat and percentage costs, rounding up. All confirmed to fail against the pre-change code.

`scripts/rpg2k_testbed_logic_check.rb` asserts against the **real** item and actor tables that every 二刀流 weapon grants two strikes, every 必中 weapon hits at its own rate against an unhittable target, and every MP消費半分 item halves a real skill's cost from the slot its own type names.

All nine CRuby suites pass: `rpg2k_logic_check` (519, +5), `rpg2k_scene_check` (150), `rpg2k_testbed_logic_check` (54, +7), `rpg2k_render_check`, `lcf_testbed_check`, `rpgxp_testbed_check`, `rpgvx_testbed_check`, `mv_testbed_check`, `mz_testbed_check`. The native build could not be exercised here (no nix/SDL2) — CI covers it.

## Not done, deliberately

- **A weapon's `critical_hit` bonus** — 75 of Nepheshel's items carry one, the *largest* count in the audit. It's the one flag that can't simply be read: RPG_RT computes a probability (`1/critical_hit_chance` from the actor plus the best weapon's percentage) where this build models criticals as a 1-in-N denominator. Folding it in means moving that representation, which touches every crit fixture and deserves its own diff and its own before/after. That's the natural next PR.
- **`attack_all`** (7 weapons) — its handling isn't in EasyRPG's `algo.cpp` with the others, so rather than guess how the damage and log entries should read, it's left declared.
- **`preemptive`** (17 items) and **`raise_evasion`** (13) — the first wants the battle's `first_strike` wired to gear; the second has nowhere to land until the to-hit formula grows an evasion term separate from agility.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_