### PR TITLE
Drain a poisoned party as it walks

### DIFF
--- a/changelog.d/map-step-slip-damage.added.md
+++ b/changelog.d/map-step-slip-damage.added.md
@@ -1,0 +1,13 @@
+- **A status condition can drain HP as the party walks**, RPG2000's field
+  poison. The `situation` row's `hp_change_map_steps` / `hp_change_map_val` pair
+  (and the matching SP pair) were parsed and read by nothing, so an ailment that
+  is *defined* as wearing the party down between fights did nothing outside
+  battle. `Game::State` now counts walked tiles and `Game::Party#apply_map_step_
+  damage` drains every afflicted member each time the count reaches a multiple of
+  that state's own interval, summing when two states slip on the same step. The
+  drain **cannot kill** — it floors at 1 HP, which is why nothing on this path
+  needs the game-over re-check the event commands that damage the party do — and
+  a member already down slips nothing. `Scene::Map` counts a step for the
+  player's own movement and for a forced move route, but not for a teleport
+  (the party arrives without walking), and flashes the screen red when a step
+  drains, since the map shows no HP for the loss to be visible on.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -522,11 +522,33 @@ The work below is roughly ordered by the critical path to a walkable game
   Silence silence** — a sealed actor's skills leave the battle menu and a sealed
   enemy's action entry stops firing. Nine of Nepheshel's 25 states and two of
   mtf's ten carry a reduced hit ratio, four and three a release chance, two and
-  one a seal. Still unread: **map-step slip damage**
-  (`hp_change_map_steps`, a status that drains HP as the party walks — only
-  mtf's Poison uses it, and it wants a step counter on `Game::State` nothing else
-  needs yet), and `affect_type` stat halving / doubling plus the RPG2003-only
-  `avoid_attacks` / `reflect_magic`, which no state in either test bed sets.
+  one a seal.
+  **A condition drains the party on the map now, too** — RPG2000's field poison,
+  the last of the 状態 row's simulation fields with a game behind it.
+  `hp_change_map_steps` / `hp_change_map_val` (and the matching SP pair) say how
+  many walked tiles pass between drains and how much each takes; nothing read
+  them, so an ailment defined as wearing the party down between fights did
+  nothing outside a fight. `Game::State` counts walked tiles, and
+  `Game::Party#apply_map_step_damage` drains every afflicted member whenever the
+  count reaches a multiple of that state's own interval — **summed** across two
+  slipping states rather than the worse one winning, which is the opposite of how
+  the battle side picks a single significant state. The drain **cannot kill**: it
+  goes through `change_hp` with death disallowed and floors at 1 HP, which is why
+  this is the one party-damaging path that needs no game-over re-check, and a
+  member already down slips nothing. `Scene::Map` counts a step for the player's
+  own movement **and** for a forced move route (an event that walks a poisoned
+  party across a field should drain it), one per landing so a jump counts once,
+  but **not** for a teleport — the party arrives without walking, and counting it
+  would let an event chain drain the party by shuffling it about. A draining step
+  flashes the screen red, because the map has no HP display for the loss to show
+  up on otherwise. The counter persists in the Marshal save; the `.lsd` keeps its
+  own in the inventory chunk (109), whose step / turn fields are still
+  deliberately undecoded, so a resumed real save starts counting from 0.
+  mtf-meido-action's Poison (1 HP every 4 steps) is the only state in either test
+  bed that carries the field, and `rpg2k_testbed_logic_check.rb` walks the real
+  party through the real interval against it. Still unread: `affect_type` stat
+  halving / doubling plus the RPG2003-only `avoid_attacks` / `reflect_magic`,
+  which no state in either test bed sets.
   **Forced-action restrictions** work too: a
   `restriction` of 2 (berserk) forces a basic attack on a random enemy even when
   the battler was told to defend, and 3 (confused) sends the attack at a random

--- a/docs/adr/0032-state-effects.md
+++ b/docs/adr/0032-state-effects.md
@@ -86,13 +86,30 @@ victory/defeat split, the same 1847 and 1726 swings, the same 501 and 708 misses
 The new code only fires when a state carries the field, so an unafflicted battler
 takes exactly the path it did.
 
-Two related gaps stay open and are now stated rather than implied:
+Two related gaps stayed open, and were stated rather than implied. The first is
+now closed:
 
 - **Map-step slip damage** (`hp_change_map_steps` / `hp_change_map_val`) — a
   status that drains HP as the party walks. mtf-meido-action's Poison is the only
   state in either bed that uses it (1 HP every 4 steps) and it needs a step
   counter on `Game::State` plus a hook in `Scene::Map` that nothing else wants
-  yet, so it is left out rather than half-built.
+  yet, so it was left out rather than half-built. **Implemented since** — the
+  counter lives on `Game::State` (`#walk_step`), the drain in
+  `Game::Party#apply_map_step_damage`, and the field reading in
+  `Game::States.map_step_drain`. Three decisions worth recording, none of them
+  visible in the two fields themselves:
+  - **It sums, where the battle side picks.** Every effect above resolves
+    through the *significant* state, so two ailments give one behaviour. The map
+    drain instead adds each afflicted state's due amount, so a doubly-poisoned
+    member loses both.
+  - **It cannot kill.** The drain goes through `change_hp` with death
+    disallowed, flooring at 1 HP. That is RPG_RT's rule, and it is what keeps
+    this off the `check_game_over` path the twelve party-damaging event commands
+    are on — there is no way for walking to wipe the party.
+  - **A teleport is not a step.** A step is counted for the player's own
+    movement and for a forced move route, one per landing (so a jump counts
+    once). A teleport moves the party without walking it; counting it would let
+    an event chain drain a poisoned party by shuffling it between maps.
 - **`affect_type` stat halving / doubling** and the RPG2003-only `avoid_attacks`
   and `reflect_magic` — no state in either test bed sets any of them, so there is
   nothing to measure an implementation against.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1849,6 +1849,42 @@ module Game
     # Whether the whole party is knocked out (戦闘不能) -- the game-over condition.
     def all_dead?; !any_alive?; end
 
+    # RPG2000 field slip damage: apply every afflicted member's map-step drain
+    # for a party that has now walked `steps` tiles. Each state a member carries
+    # is asked for its due HP / SP loss (Game::States.map_step_drain) and the
+    # totals are applied once, so two slipping states stack rather than the
+    # worse one winning -- unlike the battle-side effects, which pick a single
+    # significant state.
+    #
+    # The HP drain **cannot kill**: it goes through change_hp with death
+    # disallowed, so a poisoned party is worn down to 1 HP and left standing.
+    # That is RPG_RT's rule, and it is why nothing on this path has to re-check
+    # for a game over the way the twelve event commands that *can* wipe the party
+    # do. A member who is already down slips nothing at all.
+    #
+    # `table` is the database `situation` array; a caller without one (the seeded
+    # harness fixtures) drains nothing. Returns the actors that actually lost
+    # something, so the scene can flash the screen only when there is something
+    # to report.
+    def apply_map_step_damage(table, steps)
+      hit = []
+      @actors.each do |actor|
+        next if actor.nil? || actor.dead?
+        hp = 0
+        sp = 0
+        actor.states.each do |id|
+          dhp, dsp = States.map_step_drain(id, table, steps)
+          hp += dhp
+          sp += dsp
+        end
+        next if hp.zero? && sp.zero?
+        actor.change_hp(-hp, false) if hp > 0
+        actor.change_mp(-sp) if sp > 0
+        hit << actor
+      end
+      hit
+    end
+
     # Put an actor in the party. The actor comes from the roster, so one who has
     # been in the party before rejoins with the level, EXP, gear, skills, statuses
     # and name they left with rather than a fresh database row.
@@ -4500,6 +4536,39 @@ module Game
       return nil unless predicate
       "#{battler_name}#{predicate}"
     end
+
+    # Map-step slip damage: RPG2000's field poison. A state drains HP every
+    # `hp_change_map_steps` tiles the party walks, by `hp_change_map_val` --
+    # and SP through the matching `sp_change_map_steps` / `sp_change_map_val`
+    # pair. Returns `[hp_loss, sp_loss]` for a party that has now walked `steps`
+    # tiles: each is the state's own amount when this step lands on a multiple of
+    # its interval, and 0 otherwise.
+    #
+    # Both halves need a positive interval *and* a positive amount. A row
+    # carrying one without the other is not configured for slip at all (every
+    # state in both test beds leaves both at 0 bar one), and guarding the
+    # interval is also what keeps the modulo off zero. `steps` of 0 drains
+    # nothing, so the counter must be advanced before this is asked -- otherwise
+    # the party's very first frame on a map would be a multiple of every
+    # interval.
+    def self.map_step_drain(id, table, steps)
+      r = row(id, table)
+      return [0, 0] if r.nil? || steps.nil? || steps <= 0
+      [drain(r, steps, :hp_change_map_steps, :hp_change_map_val),
+       drain(r, steps, :sp_change_map_steps, :sp_change_map_val)]
+    end
+
+    def self.drain(row, steps, steps_field, val_field)
+      interval = int_field(row, steps_field)
+      amount = int_field(row, val_field)
+      return 0 if interval <= 0 || amount <= 0
+      (steps % interval).zero? ? amount : 0
+    end
+
+    def self.int_field(row, name)
+      v = row.respond_to?(name) ? row.send(name) : nil
+      v.nil? ? 0 : v
+    end
   end
 
   # resolution. It works on Combatant snapshots, so the caller can resolve a
@@ -5973,6 +6042,15 @@ module Game
     # a command overrides it (the map's own rate then applies). No encounter
     # subsystem consumes it yet — kept for save fidelity.
     attr_accessor :encounter_rate
+    # How many tiles the party has walked. RPG2000 divides this into each
+    # status condition's own step interval to decide when a field ailment slips
+    # HP / SP (see Party#apply_map_step_damage), which is the only thing reading
+    # it so far -- the encounter system that would share it is not built. It
+    # persists in the Marshal save; the `.lsd` keeps its step counter in the
+    # inventory chunk (109), whose step / turn fields are deliberately still
+    # undecoded (see LCF::Schema::SAVE_INVENTORY), so a resumed real save starts
+    # its count from 0.
+    attr_accessor :steps
     # Running tallies RPG2000 keeps and exposes through the Control Variables
     # "Other" operand: how many times the game was saved, and how many battles
     # were fought / won / lost / escaped. All persist in the save.
@@ -6024,6 +6102,7 @@ module Game
       @bgm_looped = false
       @player_transparent = false
       @encounter_rate = nil
+      @steps = 0
       @save_count = 0
       @battle_count = 0
       @win_count = 0
@@ -6082,6 +6161,13 @@ module Game
 
     # Whether the party is aboard a vehicle.
     def boarded?; !@boarded.nil?; end
+
+    # Record one walked tile and return the new step count. Called by Scene::Map
+    # whenever the party lands on a new tile under its own movement -- a step the
+    # player took, or one a forced move route made it take. A teleport is not a
+    # step: the party arrives without walking, so RPG_RT does not count it and
+    # neither does this.
+    def walk_step; @steps += 1; end
 
     # Show (or replace) picture `id` with the given Picture options hash.
     def show_picture(id, opts)
@@ -6204,6 +6290,7 @@ module Game
         player_transparent: @player_transparent, weather: @weather.to_h,
         teleport_access: @teleport_access, escape_access: @escape_access,
         encounter_rate: @encounter_rate, teleport_targets: @teleport_targets,
+        steps: @steps,
         save_count: @save_count, battle_count: @battle_count,
         win_count: @win_count, defeat_count: @defeat_count,
         escape_count: @escape_count,
@@ -6581,6 +6668,7 @@ module Game
       # Registries default empty / unset; a save written before these existed
       # simply restores nothing.
       state.encounter_rate = h[:encounter_rate]
+      state.steps = h[:steps] || 0
       state.save_count = h[:save_count] || 0
       state.battle_count = h[:battle_count] || 0
       state.win_count = h[:win_count] || 0

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -354,8 +354,14 @@ class RPG2k
       # The single place the state table's display side is read, so the battle
       # status panel (which lays its own columns out and needs the pieces) and
       # the field windows (which draw straight) cannot drift apart.
+      # The database's status-condition table (the `situation` array), or nil for
+      # a scene built on a fixture database that has none.
+      def state_table
+        db.respond_to?(:situation) ? db.situation : nil
+      end
+
       def state_display(states)
-        table = db.respond_to?(:situation) ? db.situation : nil
+        table = state_table
         id = Game::States.significant(states, table)
         return [normal_status_term, 0] unless id
         [Game::States.name(id, table) || "state #{id}",
@@ -466,6 +472,13 @@ class RPG2k
       ROWS = SCREEN_H / TILE + 1
       # Pixels moved per frame while stepping between tiles (must divide TILE).
       SPEED = 2
+
+      # The screen flash a step's slip damage fires: a brief red pulse, so the
+      # drain is not silent on a map that shows no HP. Given as the Game::Screen
+      # flash arguments (r, g, b, power, frames) on the 0..255 scale, the same
+      # one the battle-animation flashes reach by scaling their 0..31 database
+      # colours up by 8.
+      STEP_DAMAGE_FLASH = [31 * 8, 10 * 8, 10 * 8, 20 * 8, 6].freeze
 
       # Frames waited between autonomous event steps, keyed by RPG2000 move
       # frequency (1 slowest .. 8 fastest). Placeholder pacing while events are
@@ -2088,10 +2101,16 @@ class RPG2k
         @player_route_timer -= 1
         return if @player_route_timer > 0
         @player_route_timer = EVENT_MOVE_DELAY[@player_char.move_frequency] || 40
+        was = [@state.x, @state.y]
         @player_route.step(@player_char, @world) unless @player_route.done?
         @state.x = @player_char.x
         @state.y = @player_char.y
         @state.direction = @player_char.direction
+        # A forced route walks the party as surely as the player does, so its
+        # moves count as steps too. One per landing, which makes a jump a single
+        # step rather than one per tile cleared. A route command that only turns
+        # or waits moves nothing and counts nothing.
+        note_party_step if [@state.x, @state.y] != was
         @dest_x = @state.x
         @dest_y = @state.y
         @moving = false
@@ -4636,6 +4655,7 @@ class RPG2k
             @state.y = @dest_y
             @moving = false
             @move_count = 0
+            note_party_step
             follow_vehicle if @state.boarded? # the ridden vehicle tracks the party
           end
           return
@@ -4674,6 +4694,23 @@ class RPG2k
         @dest_y = ny
         @moving = true
         @move_count = 0
+      end
+
+      # One tile walked. Advance the party's step counter and let RPG2000's field
+      # slip damage act on it: a status condition carrying a map-step interval
+      # (mtf-meido-action's Poison, 1 HP every 4 steps, is the only one in either
+      # test bed) drains its afflicted members every time the count reaches a
+      # multiple of that interval.
+      #
+      # The drain cannot kill -- Party#apply_map_step_damage floors it at 1 HP --
+      # so unlike the event commands that damage the party this needs no game-over
+      # check. It flashes the screen red instead, because otherwise the HP would
+      # simply fall with nothing on screen saying why: the map has no HP display.
+      def note_party_step
+        steps = @state.walk_step
+        hit = @state.party.apply_map_step_damage(state_table, steps)
+        return if hit.empty?
+        @state.screen.flash(*STEP_DAMAGE_FLASH)
       end
 
       def target_tile(x, y, dir)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1910,7 +1910,12 @@ FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           # after the simulation fields so the positional
                           # constructions above keep working.
                           :name, :color, :priority,
-                          :message_actor, :message_enemy, :message_recovery)
+                          :message_actor, :message_enemy, :message_recovery,
+                          # ... and the map-step slip pair: how many walked tiles
+                          # between drains and how much each drain takes, for HP
+                          # and SP. Appended last, for the same reason.
+                          :hp_change_map_steps, :hp_change_map_val,
+                          :sp_change_map_steps, :sp_change_map_val)
 # A state row carrying only the fields a check names, with the rest at the
 # database defaults — notably reduce_hit_ratio 100, which is "does not blind".
 def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
@@ -1918,12 +1923,14 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                reduce_hit_ratio: 100, restrict_skill: false, restrict_skill_level: 0,
                restrict_magic: false, restrict_magic_level: 0,
                name: '', color: Game::States::DEFAULT_COLOR, priority: 50,
-               actor_msg: nil, enemy_msg: nil, recovery_msg: nil)
+               actor_msg: nil, enemy_msg: nil, recovery_msg: nil,
+               hp_map_steps: 0, hp_map_val: 0, sp_map_steps: 0, sp_map_val: 0)
   FakeStateDef.new(restriction, hp_val, hp_max, sp_val, sp_max, hold_turn,
                    auto_release, release_by_attack, reduce_hit_ratio,
                    restrict_skill, restrict_skill_level,
                    restrict_magic, restrict_magic_level,
-                   name, color, priority, actor_msg, enemy_msg, recovery_msg)
+                   name, color, priority, actor_msg, enemy_msg, recovery_msg,
+                   hp_map_steps, hp_map_val, sp_map_steps, sp_map_val)
 end
 # An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
@@ -6274,6 +6281,120 @@ check 'a battle log entry records which side the target was on' do
   b2.run_round
   heal = b2.log.find { |e| e[:recover] }
   eq true, heal[:target_ally], 'a party target is an ally'
+end
+
+check 'States.map_step_drain: a slip lands only on a multiple of its interval' do
+  # mtf-meido-action's Poison, the only state in either test bed that slips on
+  # the map: 1 HP every 4 walked tiles.
+  table = { 2 => fake_state(name: 'Poison', hp_map_steps: 4, hp_map_val: 1) }
+  eq [0, 0], Game::States.map_step_drain(2, table, 1)
+  eq [0, 0], Game::States.map_step_drain(2, table, 3)
+  eq [1, 0], Game::States.map_step_drain(2, table, 4)
+  eq [0, 0], Game::States.map_step_drain(2, table, 5)
+  eq [1, 0], Game::States.map_step_drain(2, table, 8)
+  # Step 0 is a multiple of every interval, so it has to be excluded outright --
+  # otherwise standing still on a fresh map would drain on the first frame.
+  eq [0, 0], Game::States.map_step_drain(2, table, 0)
+  # The SP half is the same field pair; nothing in either test bed uses it.
+  sp = { 3 => fake_state(name: 'Drain', sp_map_steps: 2, sp_map_val: 3) }
+  eq [0, 3], Game::States.map_step_drain(3, sp, 2)
+  eq [0, 0], Game::States.map_step_drain(3, sp, 3)
+end
+
+check 'States.map_step_drain: a half-configured row drains nothing' do
+  # A state needs both an interval and an amount. Guarding the interval is also
+  # what keeps the modulo off zero, which is how every ordinary state's row
+  # arrives -- both fields defaulting to 0.
+  table = { 1 => fake_state(name: 'Interval only', hp_map_steps: 4),
+            2 => fake_state(name: 'Amount only', hp_map_val: 5),
+            3 => fake_state(name: 'Ordinary') }
+  eq [0, 0], Game::States.map_step_drain(1, table, 4)
+  eq [0, 0], Game::States.map_step_drain(2, table, 4)
+  eq [0, 0], Game::States.map_step_drain(3, table, 4)
+  eq [0, 0], Game::States.map_step_drain(9, table, 4), 'an id the table lacks'
+  eq [0, 0], Game::States.map_step_drain(1, nil, 4), 'no table at all'
+end
+
+check 'a walked step slips HP from the afflicted and leaves the clear alone' do
+  table = { 2 => fake_state(name: 'Poison', hp_map_steps: 4, hp_map_val: 1) }
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.add_state(2)
+  before_hero = hero.hp
+  before_ally = ally.hp
+
+  eq [], st.party.apply_map_step_damage(table, 3), 'not a multiple: nobody hit'
+  eq before_hero, hero.hp
+
+  hit = st.party.apply_map_step_damage(table, 4)
+  eq [hero], hit, 'only the afflicted member is reported'
+  eq before_hero - 1, hero.hp
+  eq before_ally, ally.hp, 'the clear member does not slip'
+
+  # No table (the seeded harness fixtures) drains nothing rather than raising.
+  eq [], st.party.apply_map_step_damage(nil, 4)
+end
+
+check 'map slip damage cannot kill: it floors at 1 HP' do
+  # RPG_RT wears a poisoned party down and leaves it standing, which is why
+  # nothing on this path re-checks for a game over the way the event commands
+  # that damage the party do.
+  table = { 2 => fake_state(name: 'Poison', hp_map_steps: 1, hp_map_val: 30) }
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2)
+  hero.set_hp(20)
+  st.party.apply_map_step_damage(table, 1)
+  eq 1, hero.hp, 'a drain bigger than the remaining HP stops at 1'
+  eq false, hero.dead?
+  st.party.apply_map_step_damage(table, 2)
+  eq 1, hero.hp, 'and walking on keeps it there'
+  eq false, st.party.all_dead?
+
+  # A member already down slips nothing at all.
+  ally = st.party.actor_by_id(2)
+  ally.add_state(2)
+  ally.set_hp(0)
+  eq [hero], st.party.apply_map_step_damage(table, 3)
+end
+
+check 'two slipping states stack rather than the worse one winning' do
+  # The battle-side effects pick a single significant state; the map drain is
+  # summed, so a doubly-afflicted member loses both amounts on a step that is a
+  # multiple of each interval.
+  table = { 2 => fake_state(name: 'Poison', hp_map_steps: 2, hp_map_val: 1),
+            3 => fake_state(name: 'Bleed', hp_map_steps: 3, hp_map_val: 5,
+                            sp_map_steps: 6, sp_map_val: 4) }
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2)
+  hero.add_state(3)
+  hp = hero.hp
+  mp = hero.mp
+
+  st.party.apply_map_step_damage(table, 2)
+  eq hp - 1, hero.hp, 'step 2: poison only'
+  st.party.apply_map_step_damage(table, 3)
+  eq hp - 6, hero.hp, 'step 3: bleed only'
+  st.party.apply_map_step_damage(table, 6)
+  eq hp - 12, hero.hp, 'step 6: both, summed'
+  eq mp - 4, hero.mp, 'and the SP half of the same state'
+end
+
+check 'the walked-step count advances and round-trips through the save' do
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq 0, st.steps, 'a new game has walked nowhere'
+  eq 1, st.walk_step
+  eq 3, (st.walk_step; st.walk_step)
+  eq 3, st.steps
+  eq 3, Game::State.load(db, st.to_h).steps
+  # A save written before the counter existed restores 0 rather than nil, which
+  # would make the modulo raise on the next step.
+  h = st.to_h
+  h.delete(:steps)
+  eq 0, Game::State.load(db, h).steps
 end
 
 check 'battle: a blinding state cuts its victim\'s accuracy by reduce_hit_ratio' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -204,10 +204,15 @@ def fake_db(common = nil, troop_pages = nil)
                                      message_actor: ' falls!',
                                      message_enemy: ' is struck down!',
                                      message_recovery: ' stands up!'),
+                 # Poison also slips on the map, the way mtf-meido-action's does
+                 # (the only state in either test bed that carries the field):
+                 # 1 HP every 4 walked tiles.
                  3 => OpenStruct.new(name: 'Poison', color: 2, priority: 30,
                                      message_actor: ' is poisoned!',
                                      message_enemy: ' looks ill!',
-                                     message_recovery: ' is cured.'),
+                                     message_recovery: ' is cured.',
+                                     hp_change_map_steps: 4,
+                                     hp_change_map_val: 1),
                  4 => OpenStruct.new(name: 'Sleep', color: 4, priority: 80),
                  5 => OpenStruct.new(name: 'Silence', color: 5, priority: 10) },
     # A tiny item table the Open Shop window prices its goods from.
@@ -330,15 +335,54 @@ def fake_parent(db)
   FakeParent.new(db) { |id| fake_map(id, {}) }
 end
 
-def fake_party
-  # `revision` is what the scene watches to know a page condition may have
-  # changed; a test bumps it to ask for a refresh.
-  OpenStruct.new(leader: nil, actors: [], revision: 0)
+# A party member reduced to what map-step slip damage touches. Building a
+# database actor needs a whole row; what these checks want to know is only what
+# walking does to one, so the double answers the same contract
+# Party#apply_map_step_damage calls -- and its own HP floor is deliberately not
+# modelled, so the check reads the floor the *party* applies rather than one the
+# fixture faked.
+class SlipActor
+  attr_reader :states, :hp, :mp
+  # The scene draws whoever leads the party, so the double also answers the
+  # three graphic fields that path reads. A blank charset falls back to the
+  # marker sprite, which is what the rest of these checks already run on.
+  attr_reader :charset_name, :charset_index
+  attr_accessor :transparent
+
+  def initialize(states = [], hp = 100, mp = 20)
+    @states = states
+    @hp = hp
+    @mp = mp
+    @charset_name = ''
+    @charset_index = 0
+    @transparent = false
+  end
+
+  def dead?; @hp <= 0; end
+
+  def change_hp(delta, allow_death = true)
+    floor = allow_death ? 0 : 1
+    @hp = [[@hp + delta, floor].max, 100].min
+  end
+
+  def change_mp(delta); @mp = [@mp + delta, 0].max; end
 end
 
-def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil)
+def fake_party(members = [])
+  # A real Game::Party rather than a stand-in: Scene::Map runs the party through
+  # Party#apply_map_step_damage on every walked tile, so the fixture has to
+  # answer the real interface. It starts empty -- `system.party` is [] and the
+  # movement / event checks have no members to care about -- and takes any it
+  # needs from the caller.
+  party = Game::Party.new(OpenStruct.new(system: OpenStruct.new(party: [])))
+  members.each { |m| party.actors << m }
+  party
+end
+
+def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
+              members: [])
   db = fake_db(common, troop_pages)
-  state = Game::State.new(fake_party, 1, player[0], player[1])
+  state = Game::State.new(fake_party(members), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   RPG2k::Scene::Map.new(fake_parent(db), state)
 end
@@ -3484,6 +3528,97 @@ check 'the field windows resolve the same condition the battle panel does' do
                          .instance_variable_get(:@status))
   ok texts.include?('Sleep'), 'the significant state wins here as well'
   ok !texts.include?('Silence'), 'and the outranked one is not shown'
+end
+
+# Frames one walked tile takes: TILE / SPEED of movement, plus the frame that
+# starts the step. Walking `n` tiles needs a little slack on top, and the fixture
+# map is 6 wide, so a rightward walk has room for four.
+def walk(scene, tiles, dir = 6)
+  RGSS::Input.dir_value = dir
+  ((RPG2k::Scene::Map::TILE / RPG2k::Scene::Map::SPEED + 1) * tiles + 2).times do
+    scene.update
+  end
+  RGSS::Input.reset
+end
+
+check 'walking slips HP from a poisoned member every fourth tile' do
+  # The fixture's Poison carries mtf-meido-action's map-step fields. Nothing
+  # showed a field ailment doing anything before this: it sat on the actor and
+  # the party walked on untouched.
+  hero = SlipActor.new([3])                             # Poison
+  scene = new_scene({}, player: [0, 0], members: [hero])
+  st = scene.instance_variable_get(:@state)
+
+  walk(scene, 3)
+  eq 3, st.steps, 'three tiles walked'
+  eq 100, hero.hp, 'not a multiple of the interval yet'
+
+  walk(scene, 1)
+  eq 4, st.steps
+  eq 99, hero.hp, 'the fourth tile slips 1 HP'
+end
+
+check 'a clear member walks the same ground untouched' do
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero])
+  st = scene.instance_variable_get(:@state)
+  walk(scene, 4)
+  eq 4, st.steps
+  eq 100, hero.hp, 'no state, no slip'
+  eq false, st.screen.flashing?, 'and nothing flashes'
+end
+
+check 'a step that slips flashes the screen' do
+  # The map shows no HP, so without this the drain would be silent.
+  hero = SlipActor.new([3])
+  scene = new_scene({}, player: [0, 0], members: [hero])
+  st = scene.instance_variable_get(:@state)
+  walk(scene, 3)
+  eq false, st.screen.flashing?, 'a step that drains nothing does not flash'
+  walk(scene, 1)
+  ok st.screen.flashing?, 'the draining step does'
+end
+
+check 'a teleport is not a walked step' do
+  # The party arrives without walking, so RPG_RT does not count it. Counting it
+  # would let an event chain drain a poisoned party by moving it around.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [ECmd.new(ic::TELEPORT, [1, 4, 3])]
+  hero = SlipActor.new([3])
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0], members: [hero])
+  st = scene.instance_variable_get(:@state)
+  20.times { scene.update }
+  eq [4, 3], [st.x, st.y], 'the teleport landed'
+  eq 0, st.steps, 'and counted no steps'
+  eq 100, hero.hp
+end
+
+check 'a forced player route walks the party, and its steps count' do
+  # A route moves the party as surely as the player does, so its landings count
+  # too -- an event that walks a poisoned party across a field should drain it.
+  ic = Game::Interpreter::Cmd
+  # target 10001 (player), freq 8, repeat off, skippable on, one step east.
+  route_page = lambda do |cmd|
+    pg = page(trigger: 3)
+    pg.event_commands = [ECmd.new(ic::MOVE_EVENT, [10001, 8, 0, 1, cmd])]
+    pg
+  end
+
+  scene = new_scene({ 1 => event(3, 3, route_page.call(R::MOVE_RIGHT)) },
+                    player: [0, 0], members: [SlipActor.new([3])])
+  st = scene.instance_variable_get(:@state)
+  40.times { scene.update }
+  eq 1, st.x, 'the route stepped the party one tile east'
+  eq 1, st.steps, 'and that landing counted'
+
+  # A route command that only turns moves nothing, so it counts nothing.
+  scene2 = new_scene({ 1 => event(3, 3, route_page.call(R::FACE_LEFT)) },
+                     player: [0, 0], members: [SlipActor.new([3])])
+  st2 = scene2.instance_variable_get(:@state)
+  40.times { scene2.update }
+  eq [0, 0], [st2.x, st2.y], 'the party did not move'
+  eq 0, st2.steps
 end
 
 check 'a transformed monster is redrawn with its new battler graphic' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -401,13 +401,17 @@ def check_states(dir)
   blinding = []
   waking = []
   sealing = []
+  slipping = []
   states.each do |id, r|
     blinding << id if r.reduce_hit_ratio && r.reduce_hit_ratio < 100
     waking << id if (r.release_by_attack || 0) > 0
     sealing << id if r.restrict_magic || r.restrict_skill
+    slipping << id if (r.hp_change_map_steps || 0) > 0 &&
+                      (r.hp_change_map_val || 0) > 0
   end
-  puts format('   states: %d blinding, %d shaken off by a blow, %d sealing',
-              blinding.size, waking.size, sealing.size)
+  puts format('   states: %d blinding, %d shaken off by a blow, %d sealing, ' \
+              '%d slipping on the map',
+              blinding.size, waking.size, sealing.size, slipping.size)
 
   unless blinding.empty?
     check "#{name}: a blinding state cuts accuracy" do
@@ -467,6 +471,47 @@ def check_states(dir)
            "state ##{sid} (#{states[sid].name}) seals no magic at all"
         eq 0, physical_sealed,
            "state ##{sid} left rate-0 skills alone"
+      end
+    end
+  end
+
+  unless slipping.empty?
+    check "#{name}: a map-slipping state drains on its own step interval" do
+      # The real party, walking the real interval. mtf-meido-action's Poison is
+      # the only state in either test bed that carries the field (1 HP every 4
+      # steps), so this is the check that says the reading is right rather than
+      # merely self-consistent.
+      party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+      ok !party.actors.empty?, 'the initial party has members to poison'
+      slipping.each do |sid|
+        row = states[sid]
+        every = row.hp_change_map_steps
+        amount = row.hp_change_map_val
+        actor = party.actors.first
+        actor.clear_states
+        actor.set_hp(actor.max_hp)
+        actor.add_state(sid)
+
+        # Every step short of the interval leaves it alone ...
+        (1...every).each do |s|
+          eq [], party.apply_map_step_damage(states, s),
+             "state ##{sid} (#{row.name}) drained on step #{s} of #{every}"
+        end
+        # ... and the one that reaches it takes exactly the row's amount.
+        before = actor.hp
+        eq [actor], party.apply_map_step_damage(states, every)
+        eq before - amount, actor.hp,
+           "state ##{sid} (#{row.name}) should drain #{amount} HP every " \
+           "#{every} steps"
+
+        # It never kills: walk far enough to drain the member's whole HP bar
+        # several times over, and it is still standing.
+        laps = actor.max_hp / amount + 5
+        laps.times { |i| party.apply_map_step_damage(states, (i + 1) * every) }
+        eq 1, actor.hp, "state ##{sid} (#{row.name}) wore it below 1 HP"
+        ok !actor.dead?, 'field slip damage must not knock a member out'
+        actor.clear_states
+        actor.set_hp(actor.max_hp)
       end
     end
   end


### PR DESCRIPTION
## The gap

RPG2000's field poison. The `situation` row's `hp_change_map_steps` / `hp_change_map_val` pair — and the matching SP pair — say how many walked tiles pass between drains and how much each takes. Both were parsed and read by **nothing**, so a status whose whole definition is *wearing the party down between fights* did nothing at all outside a fight.

This is the last of the 状態 row's simulation fields with a game behind it; ADR 0032 listed it as deliberately left out rather than half-built, because it needed a step counter and a scene hook nothing else wanted yet.

## What changed

`Game::States.map_step_drain` reads the pair, `Game::State` counts walked tiles (`#walk_step`) and `Game::Party#apply_map_step_damage` drains every afflicted member whenever the count reaches a multiple of that state's own interval.

Three decisions the two fields do not state themselves:

**It sums, where the battle side picks.** Every other state effect resolves through the *significant* state — death first, then priority — so two ailments give one behaviour. The map drain instead adds each afflicted state's due amount, so a doubly-poisoned member loses both.

**It cannot kill.** The drain goes through `change_hp` with death disallowed, flooring at 1 HP. That is RPG_RT's rule, and it is what keeps this off the `check_game_over` path the twelve party-damaging event commands are on: no amount of walking can wipe the party, so nothing here has to re-check. A member already down slips nothing.

**A teleport is not a step.** `Scene::Map` counts a step for the player's own movement **and** for a forced move route — an event that walks a poisoned party across a field should drain it — one per landing, so a jump counts once rather than once per tile cleared. A teleport moves the party without walking it; counting it would let an event chain drain a poisoned party by shuffling it between maps.

A draining step **flashes the screen red**, because the map has no HP display for the loss to show up on otherwise.

The counter persists in the Marshal save. The `.lsd` keeps its own in the inventory chunk (109), whose step / turn fields are still deliberately undecoded, so a resumed real save starts counting from 0 — stated rather than silently assumed.

## What the real data settled

Surveyed before writing anything, per ADR 0002:

| game | states | carrying a map-step slip |
| --- | --- | --- |
| Nepheshel (N / R) | 25 each | **0** |
| mtf-meido-action | 10 | **1** — Poison, 1 HP every 4 steps |

So the feature has exactly one real subject, and `rpg2k_testbed_logic_check.rb` walks the **real party through the real interval** against it — every step short of the interval leaves it alone, the one that reaches it takes exactly the row's amount, and draining the whole HP bar several times over leaves the member standing at 1. It reports the per-game count alongside the existing blinding / release / sealing tallies, so a game that grows one is visible.

## Verification

- **6 new checks in `scripts/rpg2k_logic_check.rb`** — the modulo in both directions, step 0 excluded (it is a multiple of every interval), a half-configured row draining nothing, the clear member left alone, the 1 HP floor, two states stacking, and the counter round-tripping through the save including a save written before it existed. **531 pass.**
- **5 new checks in `scripts/rpg2k_scene_check.rb`** — walking four tiles drains a poisoned member and not a clear one, the flash fires only on a draining step, a teleport counts no step, and a forced route counts one per landing but nothing for a turn. **165 pass.**
- **1 new check in `scripts/rpg2k_testbed_logic_check.rb`** against the real tables (above). **55 pass.**
- Every new check was confirmed to **fail when the behaviour it covers is removed** — nine deliberate breakages run in turn (modulo ignored, floor removed, `dead?` guard dropped, sum→max, persistence dropped, each of the two scene hooks, the flash, and a step wrongly counted on teleport), rather than trusting a green run.
- `scripts/rpg2k_command_soak.rb` (371,762 commands, clean), `rpg2k_render_check.rb`, `lcf_testbed_check.rb`, `rpgxp_testbed_check.rb` and `rpgvx_testbed_check.rb` all pass — no regressions.

## One thing worth a reviewer's eye

`Scene::Map` now runs the party through a real `Game::Party` on every step, and the scene harness's party was an `OpenStruct` stand-in that could not answer. I replaced the stand-in with the **real class** rather than stubbing the method onto it — all 160 pre-existing scene checks pass against it unchanged. Party members in those checks are a small `SlipActor` double, since what they need to know is what a step does to a member, not how a database row builds one.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_