### PR TITLE
Close the last two named gaps: Bitmap#clone and the transition graphic

### DIFF
--- a/changelog.d/rgss-bitmap-clone.fixed.md
+++ b/changelog.d/rgss-bitmap-clone.fixed.md
@@ -1,0 +1,11 @@
+- **`RGSS::Bitmap#clone` / `#dup` copy the pixels.** RGSS's own `RPG::Cache`
+  builds a hue variant with `@cache[path].clone` followed by `hue_change`, so one
+  decode of a charset serves every hue a game asks for. mruby's `clone` left a
+  data object's native payload behind entirely, and a copy that merely *shared*
+  the buffer would have been worse — `hue_change` rewrites it in place, so it
+  would have recoloured the cached original along with the variant.
+  `initialize_copy` now copies the buffer, marks the copy dirty so anything
+  already showing it repaints, and gives it its own `Font` so a size or colour
+  set on the clone cannot reach back into the bitmap it came from. With that,
+  `RPG::Cache` is the definition RGSS publishes again, instead of loading the
+  file a second time per hue.

--- a/changelog.d/rgss-transition-graphic.added.md
+++ b/changelog.d/rgss-transition-graphic.added.md
@@ -1,0 +1,16 @@
+- **`Graphics.transition` dissolves through a transition graphic.** Given a
+  `filename`, the frozen still now gives way in the *shape* of that image
+  instead of fading flat: its brightness says when each pixel goes — dark first,
+  light last — and `vague` how soft the boundary between the two is. That is what
+  makes RPG Maker XP's default battle transition a pentagram rather than a fade,
+  and it is the form a released game reaches for. The shader-based players
+  evaluate `clamp((t - prog) / vague, 0, 1)` on the GPU; there is none here, so
+  `RGSS::Bitmap#_transition_alpha` rewrites the snapshot's alpha channel once per
+  frame. A graphic that will not load falls back to the plain fade and says so
+  once.
+- **`RGSS.effect_probe` measures the shape, not just the change.** A dissolve
+  that ignored its map would still change the frame, only uniformly — so the
+  probe half-dissolves a solid still through a left-to-right gradient and means
+  each edge of the screen separately, requiring the dark side to be gone while
+  the light side still stands. `RGSS.frame_mean` takes an optional region for
+  it.

--- a/docs/adr/0029-rgss-script-host-by-default.md
+++ b/docs/adr/0029-rgss-script-host-by-default.md
@@ -143,4 +143,4 @@ into an **opt-out**.
 - **Follow-up.** The frame driver has still never been verified in a real browser
   (the browser check was removed with ADR 0025), so the web build boots the host
   on the strength of the native runs alone. The two tilemap polish items in the
-  VX gap doc and the `Graphics.transition` image form remain open.
+  VX gap doc remain open; the `Graphics.transition` image form has since landed.

--- a/docs/adr/0030-rgss-only-the-games-own-engine.md
+++ b/docs/adr/0030-rgss-only-the-games-own-engine.md
@@ -90,5 +90,6 @@ does not run.
   exists and stays. This decision is about makers whose games *are* their scripts:
   XP, VX and VX Ace (the VX side never had a built-in flow to remove).
 - **Follow-up.** `docs/rpgxp-rgss-api-gap.md` is now the whole XP roadmap: the
-  open items are `Graphics.transition` with a transition image and whatever the
-  next boot check reports. (`Bitmap#clone` was the third and is now closed.)
+  open item is whatever the next boot check reports. (`Bitmap#clone` and
+  `Graphics.transition` with a transition image, the two named here when this was
+  written, are both closed.)

--- a/docs/adr/0030-rgss-only-the-games-own-engine.md
+++ b/docs/adr/0030-rgss-only-the-games-own-engine.md
@@ -90,5 +90,5 @@ does not run.
   exists and stays. This decision is about makers whose games *are* their scripts:
   XP, VX and VX Ace (the VX side never had a built-in flow to remove).
 - **Follow-up.** `docs/rpgxp-rgss-api-gap.md` is now the whole XP roadmap: the
-  open items are `Bitmap#clone`, `Graphics.transition` with a transition image,
-  and whatever the next boot check reports.
+  open items are `Graphics.transition` with a transition image and whatever the
+  next boot check reports. (`Bitmap#clone` was the third and is now closed.)

--- a/docs/rpgvx-rgss-api-gap.md
+++ b/docs/rpgvx-rgss-api-gap.md
@@ -171,8 +171,14 @@ come back in the byte order `Bitmap` already uses, so they copy straight across.
 and `transition` puts it on a full-screen sprite above everything (`z` at
 `Graphics::TRANSITION_Z`) whose opacity is stepped to zero over `duration`
 frames, so the next scene builds itself behind a fading still of the last one —
-RGSS's default dissolve. The `filename`/`vague` form (dissolving *through* a
-transition image) still runs as a plain fade of the same length and says so once.
+RGSS's default dissolve. The `filename`/`vague` form dissolves *through* the
+transition graphic instead: its brightness says when each pixel gives way — dark
+first, light last — and `vague` how soft the boundary between the two is, which
+is what makes a battle transition the shape its author drew. The shader-based
+players evaluate `clamp((t - prog) / vague, 0, 1)` on the GPU; there is none
+here, so `Bitmap#_transition_alpha` rewrites the snapshot's alpha channel once
+per frame. A graphic that will not load falls back to the plain fade and says so
+once.
 
 Not covered: `play_movie` (there is no video decoder in the build).
 
@@ -187,6 +193,13 @@ ctest under xvfb, and it is the check that catches *the effect code runs and the
 screen does not change* — the failure mode that hid the RPG2000 screen tint
 (`docs/TODO.md`). Measured: `base=[128,128,128] color=[191,63,63]
 tone=[128,128,255] cleared=[0,0,0] mid=[94,94,94] after=[0,0,0]`.
+
+The transition graphic is measured there too, and it needs a different kind of
+assertion: a dissolve that ignored its map would still change the frame, just
+uniformly. So the probe half-dissolves a solid red still through a left-to-right
+gradient and means the quarter-screen at each edge separately — the dark side
+has to be gone while the light side is still standing. A flat fade moves both
+together, which is exactly the bug a whole-frame mean cannot see.
 
 ### 4. Window open/close animates, and `Window#tone` is applied ✅
 

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -32,8 +32,9 @@ These are complete enough for the stock scripts:
   `freeze` / `transition`: the scene transition draws, as RGSS's default
   dissolve of the frozen still over the incoming scene (see item 3 of the
   [VX gap](rpgvx-rgss-api-gap.md), where it landed — the code is shared).
-  _`transition`'s `filename` form (dissolving through a transition image) runs as
-  a plain fade of the same length; `frame_reset` is still a `warn_stub` no-op._
+  `transition`'s `filename`/`vague` form dissolves through the transition
+  graphic, so a battle transition is the shape its author drew rather than a
+  fade. _`frame_reset` is still a `warn_stub` no-op._
 - **`Input`** — all key constants (`A`/`B`/`C`/`X`/`Y`/`Z`/`L`/`R`/`UP`…`F9`),
   `update`, `press?`, `trigger?` (~68), `repeat?` (~34), `press`/`release`,
   `dir4`/`dir8`.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -224,10 +224,18 @@ object, which the four value types now define. Games do this constantly (the
 screen tone, the flash colour, a map's fog tone, a picture's tone), so it is on
 the path of anything that tints the screen.
 
-**Still open in the same family:** `Bitmap#clone` — RGSS's own `RPG::Cache`
-clones bitmaps for hue variants (ours re-loads instead, see gap 0), but a
-community script that clones one will raise the same way. It needs a real pixel
-copy, not a payload copy.
+**`Bitmap#clone` ✅, closed after the fact.** It was the one member of this family
+a payload copy could not fix: a `Bitmap` owns a pixel buffer, so a copy that
+shared it would have been worse than one with no payload at all. RGSS's own
+`RPG::Cache` builds every hue variant with
+`@cache[key] = @cache[path].clone; @cache[key].hue_change(hue)` — one decode per
+file however many hues a game asks for — and `hue_change` rewrites the buffer in
+place, so a shared buffer would recolour the cached original along with the
+variant. `initialize_copy` now copies the pixels, marks the copy dirty so
+anything already showing it repaints, and gives it its own `Font` so a size or
+colour set on the clone cannot reach back. `rgss_library.rb`'s `RPG::Cache` is
+the published definition again — the "reloads for a hue variant" deviation is
+gone from its header.
 
 ### 0g. `Table#[]=` past the edge ✅ (a write RGSS drops, we raised on)
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -39,17 +39,25 @@ module RGSS
   # cannot snapshot. This is the measurement ADR 0021 used to prove the RPG2000
   # fade reached the display, available to any caller now that
   # Graphics.snap_to_bitmap exists.
-  def self.frame_mean
+  #
+  # With a region it means only that part of the frame, which is what tells a
+  # *shaped* change from a uniform one: a flat fade moves every region together,
+  # a wipe does not.
+  def self.frame_mean(x0 = 0, y0 = 0, width = nil, height = nil)
     bmp = Graphics.snap_to_bitmap
     return nil if bmp.nil?
+    x1 = width.nil? ? bmp.width : x0 + width
+    y1 = height.nil? ? bmp.height : y0 + height
+    x1 = bmp.width if x1 > bmp.width
+    y1 = bmp.height if y1 > bmp.height
     r = 0
     g = 0
     b = 0
     n = 0
-    y = 0
-    while y < bmp.height
-      x = 0
-      while x < bmp.width
+    y = y0
+    while y < y1
+      x = x0
+      while x < x1
         c = bmp.get_pixel(x, y)
         r += c.red.to_i
         g += c.green.to_i
@@ -139,9 +147,21 @@ module RGSS
     mid = $rgss_probe_mid
     after = frame_mean
 
+    # The transition-*graphic* form: a still that gives way in the shape of a
+    # map rather than fading flat, which is what a game's battle transition and
+    # Pray for You's opening use. Driven at the pixel level — Bitmap#
+    # _transition_alpha is exactly what Graphics.transition calls once per frame
+    # — because the thing that has to be proved is that the per-pixel alpha it
+    # writes reaches the display, and a flat fade would move the whole frame
+    # together. Half a screen apart is the measurement: dark map values give way
+    # first, so at the halfway point the dark side is gone and the light side is
+    # still standing.
+    wipe_left, wipe_right = transition_shape_probe(w, h)
+
     $stderr.puts "[RGSS-PROBE] base=#{base.inspect} color=#{colored.inspect} " \
                  "tone=#{toned.inspect} cleared=#{cleared.inspect} " \
-                 "mid=#{mid.inspect} after=#{after.inspect}"
+                 "mid=#{mid.inspect} after=#{after.inspect} " \
+                 "wipe=#{wipe_left.inspect}/#{wipe_right.inspect}"
 
     ok = true
     # A half-opaque red overlay pushes red up and the other channels down.
@@ -171,12 +191,53 @@ module RGSS
         ok = false
       end
     end
+    # The still is red and the screen behind it is not, so the side still
+    # covered reads far redder than the side already given way. Equal halves
+    # would mean the map was ignored and this dissolved uniformly.
+    unless wipe_left && wipe_right && wipe_right[0] > wipe_left[0] + 40
+      $stderr.puts "[RGSS-PROBE] FAIL Graphics.transition's transition graphic " \
+                   "did not shape the dissolve"
+      ok = false
+    end
     sprite.dispose
     bitmap.dispose
     viewport.dispose
     ok = false unless window_probe
     $stderr.puts "[RGSS-PROBE] #{ok ? "ok" : "failed"}"
     ok
+  end
+
+  # Half-dissolve a solid still through a left-to-right gradient and answer the
+  # mean of the quarter-screen at each edge. Called by effect_probe; kept
+  # separate because it is a self-contained little scene of its own.
+  #
+  # The gradient is the simplest transition graphic there is — black on the left
+  # (gives way first), white on the right (last) — which makes the expected
+  # result a statement rather than a threshold: at the halfway point one edge is
+  # gone and the other is not.
+  def self.transition_shape_probe(w, h)
+    still = Bitmap.new(w, h)
+    still.fill_rect(0, 0, w, h, Color.new(255, 0, 0, 255))
+    map = Bitmap.new(w, h)
+    x = 0
+    while x < w
+      shade = w > 1 ? 255 * x / (w - 1) : 0
+      map.fill_rect(x, 0, 1, h, Color.new(shade, shade, shade, 255))
+      x += 1
+    end
+    shaped = still._transition_alpha(map, 0.5, 40 / 255.0)
+    cover = Sprite.new
+    cover.bitmap = still
+    cover.z = Graphics::TRANSITION_Z
+    Graphics.update
+    edge = w / 4
+    left = shaped ? frame_mean(0, 0, edge, h) : nil
+    right = shaped ? frame_mean(w - edge, 0, edge, h) : nil
+    cover.dispose
+    still.dispose
+    map.dispose
+    Graphics.update
+    [left, right]
   end
 
   # Prove RGSS::Window is the native widget and that it draws.
@@ -1074,9 +1135,13 @@ module RGSS
       # full-screen sprite above everything (z at the maximum) whose opacity is
       # stepped to zero — which is exactly RGSS's default fade.
       #
-      # The `filename`/`vague` form (dissolve through a transition *image*) is
-      # not modelled; such a transition still runs, as a plain fade over the same
-      # number of frames, and says so once.
+      # Given a `filename`, the still dissolves in the *shape* of that transition
+      # graphic instead: its brightness says when each pixel gives way, and
+      # `vague` how soft the boundary is. That is what makes RMXP's default
+      # battle transition a pentagram rather than a fade, and it is the form a
+      # released game reaches for (Pray for You opens with one). The pixel work
+      # is Bitmap#_transition_alpha; a graphic that will not load, or a snapshot
+      # with no alpha channel to dissolve, falls back to the plain fade.
       def freeze
         # nil when the backend cannot snapshot (it says so itself, once);
         # transition copes by falling back to a plain wait.
@@ -1085,21 +1150,47 @@ module RGSS
       end
 
       def transition(duration = 8, filename = nil, vague = 40)
-        RGSS.warn_stub("Graphics.transition with a transition image") if filename
         frozen = @frozen
         @frozen = nil
         @brightness = 255
         return wait(duration) if frozen.nil? || duration <= 0
 
+        map = _transition_map(filename)
         sprite = Sprite.new
         sprite.bitmap = frozen
         sprite.z = TRANSITION_Z
+        # `vague` is on the transition graphic's own 0..255 brightness scale.
+        softness = (vague.nil? ? 0 : vague) / 255.0
         duration.times do |i|
-          sprite.opacity = 255 - (255 * (i + 1) / duration)
+          if map
+            # One refusal is enough: a snapshot that cannot carry the dissolve
+            # will not start carrying it on a later frame, so drop the map and
+            # let the rest of the run fade.
+            unless frozen._transition_alpha(map, (i + 1).to_f / duration, softness)
+              map.dispose
+              map = nil
+            end
+          end
+          sprite.opacity = 255 - (255 * (i + 1) / duration) if map.nil?
           update
         end
+        map.dispose if map
         sprite.dispose
         frozen.dispose
+        nil
+      end
+
+      # The transition graphic, or nil to fade. RGSS is handed a project-relative
+      # path ("Graphics/Transitions/" + name, which is what the stock scenes
+      # build), so Bitmap's own search — loose file, RTP, then the encrypted
+      # archive — is the right resolver. A graphic that is not there must not end
+      # a scene change, so the failure is reported once and the fade stands in.
+      def _transition_map(filename)
+        return nil if filename.nil? || filename.empty?
+        Bitmap.new(filename)
+      rescue StandardError => e
+        RGSS.warn_once("Graphics.transition: #{filename} did not load " \
+                       "(#{e.message}); fading instead")
         nil
       end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1122,6 +1122,66 @@ mrb_value bmp_init_copy(mrb_state* M, V self) {
   return self;
 }
 
+// One frame of RGSS's Graphics.transition(duration, filename, vague) with a
+// transition *graphic*: a greyscale image whose brightness at each pixel says
+// when that pixel gives way to the new screen. Dark areas go first, light ones
+// last, and `vague` is how soft the boundary between the two is -- which is how
+// a game gets a spiral wipe, a shatter, or the pentagram RMXP ships as its
+// default battle transition, instead of a flat fade.
+//
+// `self` is the frozen frame (Graphics.freeze's snapshot, which the transition
+// draws over the new screen); this rewrites its **alpha** so it dissolves in
+// the shape of the map, and the caller shows it through an ordinary Sprite. Per
+// pixel, with t the map's brightness and prog the frame's progress, both 0..1:
+//
+//     keep = clamp((t - prog) / vague, 0, 1)
+//
+// which is the same expression the shader-based players evaluate on the GPU;
+// there is no shader here, so it runs over the buffer once per frame. `keep`
+// only ever falls as prog advances, so the snapshot can be rewritten in place.
+// A `vague` of 0 is the hard-edged wipe RGSS gives that argument.
+//
+// The map is sampled nearest-neighbour, so a transition graphic that is not the
+// screen's size still covers it (RGSS's own are 640x480, but community ones are
+// not always). Greyscale means any one channel will do; red, as the shader
+// players read.
+mrb_value bmp_transition_alpha(mrb_state* M, V self) {
+  V map_v;
+  mrb_float prog, vague;
+  mrb_get_args(M, "off", &map_v, &prog, &vague);
+  Bitmap& dst = DataType<Bitmap>::get(M, self);
+  const Bitmap& map = DataType<Bitmap>::get(M, map_v);
+  const unsigned bpp = lv_color_format_get_size(dst.format);
+  const unsigned map_bpp = lv_color_format_get_size(map.format);
+  // Without an alpha channel on the still there is nothing to dissolve, and
+  // without colour channels on the map there is no brightness to read. Either
+  // way the caller's plain fade is a better answer than a no-op.
+  if (bpp < 4 || map_bpp < 3 || dst.width <= 0 || dst.height <= 0 ||
+      map.width <= 0 || map.height <= 0)
+    return mrb_false_value();
+  for (int32_t y = 0; y < dst.height; ++y) {
+    const int32_t my =
+        static_cast<int32_t>(static_cast<int64_t>(y) * map.height / dst.height);
+    uint8_t* row = dst.buffer.data() + static_cast<size_t>(y) * dst.width * bpp;
+    const uint8_t* map_row =
+        map.buffer.data() + static_cast<size_t>(my) * map.width * map_bpp;
+    for (int32_t x = 0; x < dst.width; ++x) {
+      const int32_t mx =
+          static_cast<int32_t>(static_cast<int64_t>(x) * map.width / dst.width);
+      const double t = map_row[static_cast<size_t>(mx) * map_bpp + 2] / 255.0;
+      double keep = vague <= 0.0 ? (t > prog ? 1.0 : 0.0) : (t - prog) / vague;
+      if (keep < 0.0)
+        keep = 0.0;
+      else if (keep > 1.0)
+        keep = 1.0;
+      row[static_cast<size_t>(x) * bpp + 3] =
+          static_cast<uint8_t>(keep * 255.0 + 0.5);
+    }
+  }
+  dst.dirty = true;
+  return mrb_true_value();
+}
+
 // Read a whole file. Answers false when it cannot be opened or read fully, so
 // the caller can fall through to the next candidate path in silence.
 static bool slurp_file(const char* f, std::vector<uint8_t>& out) {
@@ -5577,6 +5637,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
   // #clone / #dup: a real pixel copy, which RPG::Cache's hue variants need.
   mrb_define_method(M, bmp, "initialize_copy", bmp_init_copy, MRB_ARGS_REQ(1));
+  // One frame of Graphics.transition's transition-graphic form; answers false
+  // when this bitmap cannot carry the dissolve, so the caller can plain-fade.
+  mrb_define_method(M, bmp, "_transition_alpha", bmp_transition_alpha,
+                    MRB_ARGS_REQ(3));
   mrb_define_class_method(M, bmp, "_load_error", bmp_load_error,
                           MRB_ARGS_NONE());
   mrb_define_class_method(M, bmp, "_stbi_error", bmp_stbi_error,

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1085,6 +1085,43 @@ mrb_value bmp_init_size(mrb_state* M, mrb_value self) {
   return self;
 }
 
+// RGSS's own RPG::Cache clones a cached bitmap before recolouring it:
+//
+//     @cache[key] = @cache[path].clone
+//     @cache[key].hue_change(hue)
+//
+// so the plain and hue-rotated variants of a charset share one decode of the
+// file. mruby's clone/dup copy the instance variables and then call
+// initialize_copy, which for a data object is the only place the native payload
+// can be copied -- without this the copy carried no pixels at all and the first
+// use of it raised "uninitialized RGSS::Bitmap", which is why RPG::Cache here
+// used to load the file a second time instead.
+//
+// The pixels are *copied*, not shared, and that is the whole point: hue_change
+// rewrites the buffer in place, so a shallow copy would have recoloured the
+// cache's original along with the variant. The copy starts dirty so anything
+// already showing it repaints, and gets its own Font, so setting a size or
+// colour on the clone cannot reach back into the bitmap it came from.
+mrb_value bmp_init_copy(mrb_state* M, V self) {
+  V other;
+  mrb_get_args(M, "o", &other);
+  if (mrb_obj_equal(M, self, other))
+    return self;
+  const Bitmap& src = DataType<Bitmap>::get(M, other);
+  Bitmap& dst = DATA_PTR(self)
+                    ? DataType<Bitmap>::get(M, self)
+                    : DataType<Bitmap>::alloc_obj(M, self, src.width,
+                                                  src.height, src.format);
+  dst = src;
+  dst.dirty = true;
+
+  const mrb_sym font_iv = mrb_intern_lit(M, "@font");
+  const V font = mrb_iv_get(M, self, font_iv);
+  if (!mrb_nil_p(font))
+    mrb_iv_set(M, self, font_iv, mrb_funcall(M, font, "dup", 0));
+  return self;
+}
+
 // Read a whole file. Answers false when it cannot be opened or read fully, so
 // the caller can fall through to the next candidate path in silence.
 static bool slurp_file(const char* f, std::vector<uint8_t>& out) {
@@ -5538,6 +5575,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
   mrb_define_method(M, bmp, "_init_file", bmp_init_file,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
+  // #clone / #dup: a real pixel copy, which RPG::Cache's hue variants need.
+  mrb_define_method(M, bmp, "initialize_copy", bmp_init_copy, MRB_ARGS_REQ(1));
   mrb_define_class_method(M, bmp, "_load_error", bmp_load_error,
                           MRB_ARGS_NONE());
   mrb_define_class_method(M, bmp, "_stbi_error", bmp_stbi_error,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -187,6 +187,52 @@ assert "RGSS::Bitmap#clone copies pixels, not the handle" do
                "hue_change on a clone recoloured the cached original"
 end
 
+# Graphics.transition's transition-*graphic* form: the frozen frame gives way in
+# the shape of a greyscale map — dark first, light last — with `vague` setting how
+# soft the boundary is. That is what makes RMXP's default battle transition a
+# pentagram rather than a fade. The shader-based players evaluate
+# `clamp((t - prog) / vague, 0, 1)` on the GPU; there is none here, so it runs over
+# the buffer, and this is where the arithmetic is pinned down. Whether the alpha
+# it writes reaches the display is the separate job of RGSS.effect_probe.
+assert "RGSS::Bitmap#_transition_alpha dissolves in the shape of a map" do
+  still = RGSS::Bitmap.new(4, 1)
+  still.fill_rect(0, 0, 4, 1, RGSS::Color.new(255, 0, 0, 255))
+  # A left-to-right ramp: 0.0, 0.33, 0.67, 1.0 of the way through the wipe.
+  map = RGSS::Bitmap.new(4, 1)
+  [0, 85, 170, 255].each_with_index do |v, i|
+    map.set_pixel(i, 0, RGSS::Color.new(v, v, v, 255))
+  end
+  vague = 40 / 255.0 # RGSS's default, on the map's own 0..255 scale
+
+  # Alpha is how much of the still *remains*, so a pixel at 0 has given way.
+  assert_true still._transition_alpha(map, 0.5, vague)
+  assert_equal 0, still.get_pixel(0, 0).alpha.to_i, "the darkest pixel went first"
+  assert_equal 0, still.get_pixel(1, 0).alpha.to_i
+  assert_equal 255, still.get_pixel(2, 0).alpha.to_i
+  assert_equal 255, still.get_pixel(3, 0).alpha.to_i,
+               "the lightest pixel should go last"
+  # Only the coverage changes; the still's colours are left alone.
+  assert_equal 255, still.get_pixel(3, 0).red.to_i
+
+  # `vague` is the width of the band in between, so a pixel inside it is part
+  # way out rather than all or nothing...
+  still._transition_alpha(map, 0.62, vague)
+  edge = still.get_pixel(2, 0).alpha.to_i
+  assert_true edge > 0 && edge < 255, "vague did not soften the boundary (#{edge})"
+
+  # ...and a vague of 0 is the hard-edged wipe RGSS gives that argument: at the
+  # same point in the same map, that pixel is all or nothing.
+  still._transition_alpha(map, 0.62, 0.0)
+  assert_equal 255, still.get_pixel(2, 0).alpha.to_i
+  assert_equal 0, still.get_pixel(1, 0).alpha.to_i
+
+  # And at the end of the wipe nothing of the still is left, whatever the map.
+  still._transition_alpha(map, 1.0, vague)
+  4.times do |i|
+    assert_equal 0, still.get_pixel(i, 0).alpha.to_i, "pixel #{i} survived the wipe"
+  end
+end
+
 assert "RGSS::Table drops out-of-range writes without reading the value" do
   t = RGSS::Table.new(2, 2)
   t[0, 0] = 5

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -149,6 +149,44 @@ assert "RGSS value types survive #clone and #dup" do
   assert_equal 7, table[1, 1], "the original table shares its copy's storage"
 end
 
+# RGSS's own RPG::Cache builds a hue variant with `@cache[path].clone` followed
+# by `hue_change`, so one decode serves every hue a game asks for. That only
+# works if the copy owns its pixels: hue_change rewrites the buffer in place, so
+# a shallow copy would recolour the cached original along with the variant, and a
+# copy with no payload at all — what mruby's clone gives a data object without
+# initialize_copy — raises on first use.
+assert "RGSS::Bitmap#clone copies pixels, not the handle" do
+  bmp = RGSS::Bitmap.new(4, 3)
+  bmp.set_pixel(0, 0, RGSS::Color.new(255, 0, 0, 255))
+  bmp.set_pixel(3, 2, RGSS::Color.new(0, 255, 0, 255))
+
+  [bmp.clone, bmp.dup].each do |copy|
+    assert_equal 4, copy.width
+    assert_equal 3, copy.height
+    assert_equal 255, copy.get_pixel(0, 0).red.to_i
+    assert_equal 255, copy.get_pixel(3, 2).green.to_i
+
+    # Writing the copy must not reach the original — the case RPG::Cache hits
+    # the moment a second hue is asked for.
+    copy.set_pixel(0, 0, RGSS::Color.new(0, 0, 255, 255))
+    assert_equal 255, copy.get_pixel(0, 0).blue.to_i
+    assert_equal 255, bmp.get_pixel(0, 0).red.to_i,
+                 "the original bitmap shares its copy's pixels"
+    assert_equal 0, bmp.get_pixel(0, 0).blue.to_i
+
+    # ...and neither must its font, which the scripts set per draw.
+    copy.font.size = 9
+    assert_equal 9, copy.font.size
+    assert_not_equal 9, bmp.font.size
+  end
+
+  # The whole point, in the shape RPG::Cache uses it.
+  variant = bmp.clone
+  variant.hue_change(120)
+  assert_equal 255, bmp.get_pixel(0, 0).red.to_i,
+               "hue_change on a clone recoloured the cached original"
+end
+
 assert "RGSS::Table drops out-of-range writes without reading the value" do
   t = RGSS::Table.new(2, 2)
   t[0, 0] = 5

--- a/mruby-rpgxp/mrblib/rgss_library.rb
+++ b/mruby-rpgxp/mrblib/rgss_library.rb
@@ -25,9 +25,6 @@
 #     is baked into a pre-composited scratch bitmap when it is *assigned*
 #     (mruby-rgss), so mutating the Color object in place would change nothing on
 #     screen. Every `color.set` below is `self.color = RGSS::Color.new(...)`.
-#   * **`RPG::Cache` reloads a bitmap for a hue variant** instead of RGSS's
-#     `@cache[path].clone`: a Bitmap here wraps a native handle, and a shallow
-#     copy would give two Ruby objects one buffer to free.
 #   * **A missing asset yields a blank 32x32 bitmap and a warning**, where RGSS
 #     raises. A game whose RTP is not installed must not die on its first
 #     graphic, and with no second engine to fall back to (ADR 0030) a raise here
@@ -117,7 +114,7 @@ module RPG
         @cache[path] = bitmap
       end
       return bitmap if hue == 0
-      hued(path, filename, hue, bitmap)
+      hued(path, hue, bitmap)
     end
 
     def self.animation(filename, hue)
@@ -194,19 +191,18 @@ module RPG
       GC.start if Object.const_defined?(:GC)
     end
 
-    # A hue-rotated copy, cached under its own key. RGSS clones the cached bitmap
-    # and rotates the clone; a native handle cannot be shallow-copied, so this
-    # loads the file a second time instead. `base` is the hue-0 bitmap already in
-    # the cache, returned when there is nothing to reload — an empty name, or a
-    # file that did not load, where rotating the stand-in would only give the
-    # caller a *differently* blank bitmap.
-    def self.hued(path, filename, hue, base)
-      cached = @cache["#{path}\t#{hue}"]
+    # A hue-rotated copy, cached under its own key — RGSS's own
+    # `@cache[key] = @cache[path].clone; @cache[key].hue_change(hue)`, so the
+    # file is decoded once however many hues a game asks for. `base` is the hue-0
+    # bitmap already in the cache; `RGSS::Bitmap#initialize_copy` copies its
+    # pixels, so rotating the copy leaves the cached original alone.
+    def self.hued(path, hue, base)
+      key = "#{path}\t#{hue}"
+      cached = @cache[key]
       return cached unless cached.nil? || cached.disposed?
-      bitmap = filename == "" ? nil : load_file(path)
-      return base if bitmap.nil?
+      bitmap = base.clone
       bitmap.hue_change(hue)
-      @cache["#{path}\t#{hue}"] = bitmap
+      @cache[key] = bitmap
     end
 
     # Load one file, or report it and let the caller stand in. RGSS raises here;

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -461,6 +461,15 @@ def check_rgss_library
   hued = RPG::Cache.character("Hero", 120)
   errors += check.call(!hued.equal?(plain) && hued.hue == 120,
                        "RPG::Cache did not build a hue variant")
+  # The variant is a *copy* of the cached bitmap, as RGSS's own version is
+  # (`@cache[path].clone`), and hue_change rewrites pixels in place — so a copy
+  # that shared them would recolour every later user of the plain charset too.
+  # The native side is where that can actually go wrong (RGSS::Bitmap
+  # #initialize_copy); this only holds the contract the cache is written to.
+  errors += check.call(plain.hue.nil?,
+                       "building a hue variant recoloured the cached original")
+  errors += check.call(hued.equal?(RPG::Cache.character("Hero", 120)),
+                       "RPG::Cache rebuilt a cached hue variant")
   errors += check.call(RPG::Cache.character("", 0).width == 32,
                        "an empty name did not give a blank bitmap")
   errors += check.call(RPG::Cache.picture("MissingOnPurpose").width == 32,


### PR DESCRIPTION
ADR 0030 left `docs/rpgxp-rgss-api-gap.md` as the whole XP roadmap and named two
open items. This closes both. They are separate commits, and both are the same
kind of thing — a piece of the RGSS class library a game's own scripts call that
this engine answered with an approximation.

## 1. `Bitmap#clone` copies pixels, so `RPG::Cache` can clone

RGSS's own `RPG::Cache` builds a hue variant the way its published source does:

```ruby
@cache[key] = @cache[path].clone
@cache[key].hue_change(hue)
```

one decode of a charset serving however many hues a game asks for.

mruby's `clone`/`dup` copy a data object's instance variables and leave the
native payload behind, so the copy had no pixels and raised on first use. For the
value types #377 answered with a payload copy — but a `Bitmap` *owns a buffer*,
and sharing it would have been worse than the bug it fixed: `hue_change` rewrites
the buffer in place, so a shared buffer would recolour the cached original along
with the variant, silently, on every charset a game tints. That is why
`rgss_library.rb` deviated and loaded the file a second time per hue.

`initialize_copy` now copies the buffer, marks the copy dirty so anything already
showing it repaints, and gives it its own `Font`. `RPG::Cache` is the published
definition again and the deviation is gone from that file's header.

**Tests.** `mruby-rgss/test/test.rb` writes pixels, clones, mutates the copy and
checks the original is untouched — including through a real `hue_change`, the
exact case the cache hits; that is where a shared buffer would be caught, and it
only runs in CI. `scripts/rpgxp_script_host_check.rb` cannot see a shared buffer
(its `Bitmap` is a fake that records draws), so it asserts the contract the cache
is written to instead.

## 2. `Graphics.transition` dissolves through its transition graphic

Given a `filename`, RGSS takes the frozen still away in the **shape** of that
image rather than fading it flat: the graphic is greyscale, its brightness says
when each pixel gives way — dark first, light last — and `vague` is how soft the
boundary is. That is what makes RMXP's default battle transition a pentagram
instead of a fade, and it is the form a released game reaches for.

The shader-based players evaluate `clamp((t - prog) / vague, 0, 1)` per pixel on
the GPU. There is no shader here, so `Bitmap#_transition_alpha` rewrites the
snapshot's alpha channel over the buffer once per frame — the snapshot is already
what the transition draws over the incoming scene, and `keep` only ever falls as
the wipe advances, so it can be rewritten in place. The map is sampled
nearest-neighbour so a graphic that is not the screen's size still covers it, and
a graphic that will not load falls back to the fade.

**Measuring it needed a different assertion than the other effects.** A dissolve
that ignored its map would still change the frame — just uniformly — so the
whole-frame mean `RGSS.effect_probe` uses cannot see that bug. The probe now
half-dissolves a solid still through a left-to-right gradient and means the
quarter-screen at *each edge* separately: the dark side has to be gone while the
light side is still standing. `RGSS.frame_mean` takes an optional region for it.
The unit test pins the arithmetic itself, which needs no display.

## Note on scope

Two logical changes in one PR, against the usual one-per-PR convention. They are
the two items ADR 0030 named together, they touch the same file, and the second
was written on top of the first rather than waiting for it to merge. Split on
request — the commits are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_