### PR TITLE
Make a critical chance a probability, not a denominator

### DIFF
--- a/changelog.d/critical-hit-chance.fixed.md
+++ b/changelog.d/critical-hit-chance.fixed.md
@@ -1,0 +1,22 @@
+- **A weapon's critical-hit bonus counts now.** RPG2000 stores a critical chance
+  in two shapes — the actor row's 1-in-N denominator plus a flat percentage from
+  the equipped weapon — and this build modelled only the denominator, which has
+  nowhere to put "+10%". So all **75** of Nepheshel's `critical_hit` bonuses did
+  nothing. The chance is carried in basis points now and the two sources sum on
+  that scale (ADR 0034): with リト's 1/20 row, a +2% dagger gives 700 bp, a +10%
+  falchion 1500, and 滅びの剣's +60% 6500. Across every troop in the game the
+  party goes from **29 criticals to 141**, ending fights 240 swings sooner and
+  winning five more of its 157 fights.
+- **The bonus is read from weapons only**, which the data makes worth saying: of
+  the 75 items Nepheshel sets the field on, the six carrying **+100%** are all
+  armour or accessories (龍の鱗, 光の衣, 翼 …). Reading those would hand out gear
+  that criticals on every blow. RPG_RT iterates weapons and skips every armour
+  slot, so the field is inert outside the weapon slot — as its sibling `hit`
+  already was.
+- **New `Game::Rng#scaled`**, used by the crit roll. The generator's period is
+  prime, so `next_int % n` leaves the low `period % n` values over-represented.
+  At the small `n` every existing caller uses that is invisible; at the scale a
+  basis-point chance needs it is not — `random(10000) < 333` fires 3.562% of the
+  time where 1/30 is 3.333%, which would have quietly added a ~7% relative crit
+  boost on top of the feature. `#scaled` is monotonic and measures 3.335%.
+  `#random` is unchanged, so no other seeded result moves.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -534,9 +534,18 @@ The work below is roughly ordered by the critical path to a walkable game
   **damage variance** (a `var` of 4 for attacks, each skill's own `variance` for
   skills, spread via `Algo::VarianceAdjustEffect`), enabled for the live game and
   off for seeded / headless fights. A basic attack can land a **3x critical hit**
-  at the attacker's database 1-in-N chance (actor `critical_rate`, enemy
-  `critical_hit_chance`); no crit on a same-side hit. Characters wearing gear with
-  the **`prevent_critical`** flag can never be crit. Four more **equipment combat
+  at a chance carried in **basis points** (ADR 0034), summing the row's 1-in-N
+  (actor `critical_rate`, enemy `critical_hit_chance`) with the best equipped
+  **weapon**'s flat `critical_hit` percentage — the two shapes RPG2000 stores,
+  which only combine on a common scale, which is why a denominator could not hold
+  the weapon half and all 75 of Nepheshel's bonuses did nothing. Weapons only:
+  the six items carrying **+100%** are armour and accessories, and RPG_RT skips
+  every armour slot for this field, so reading them would have made gear that
+  crits on every blow. The roll draws through `Rng#scaled` rather than
+  `Rng#random`, because a modulus of the generator's prime period over-represents
+  its low values — harmless at the small `n` everything else uses, but at
+  basis-point scale it reads 1/30 as 3.56%. No crit on a same-side hit.
+  Characters wearing gear with the **`prevent_critical`** flag can never be crit. Four more **equipment combat
   flags** are read now (ADR 0033), each of them previously parsed and used by
   nothing: **二刀流** (`dual_attack`) makes a basic attack swing **twice** — 13 of
   Nepheshel's weapons — skipping the second blow when the first fells the target;
@@ -546,10 +555,9 @@ The work below is roughly ordered by the critical path to a walkable game
   flag ignores is the *target's* evasion; **MP消費半分** (`half_sp_cost`, any
   slot) halves a skill's cost rounding up; and **強力防御** (`strong_defence`, an
   actor-row flag 7 of Nepheshel's 50 actors carry including its hero) halves
-  damage a second time while defending — a quarter, not a half. Still unread: a
-  weapon's **`critical_hit` bonus**, the largest count in that audit at 75 items,
-  which needs the crit model to move from a 1-in-N denominator to RPG_RT's
-  probability (`1/critical_hit_chance` plus the best weapon's percentage);
+  damage a second time while defending — a quarter, not a half. A weapon's
+  **`critical_hit` bonus**, the largest count in that audit at 75 items, is read
+  now too — see the critical-hit paragraph above and ADR 0034. Still unread:
   **`attack_all`** (7 weapons), whose handling is not in EasyRPG's `algo.cpp`
   with the others and is left declared rather than guessed; and **`preemptive`**
   / **`raise_evasion`**, the latter having nowhere to land until the to-hit

--- a/docs/adr/0034-critical-hit-chance.md
+++ b/docs/adr/0034-critical-hit-chance.md
@@ -1,0 +1,116 @@
+# 34. Critical-hit chance is a probability, not a denominator
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0033 read four equipment combat flags and deliberately left a fifth: a
+weapon's `critical_hit` bonus, the largest count in that audit at **75 of
+Nepheshel's items**. It was left because it is the one flag that cannot simply be
+read.
+
+RPG2000 stores a critical chance in two incompatible shapes. The actor row
+carries a **denominator** — `critical_rate` 20 means one blow in twenty — while a
+weapon carries a flat **percentage** on top. RPG_RT adds them:
+
+```cpp
+float crit_chance = dbActor->critical_hit ? 1.0f / dbActor->critical_hit_chance : 0.0f;
+float bonus = 0;
+ForEachEquipment<true, false>(GetWholeEquipment(),
+    [&](auto& item) { bonus = std::max(bonus, (float)item.critical_hit); }, weapon);
+return crit_chance + (bonus / 100.0f);
+```
+
+This build modelled only the denominator — `Combatant#crit_denom`, rolled as
+`rng.random(denom) == 0` — and a denominator has nowhere to put "+10%". So every
+one of those 75 bonuses did nothing.
+
+Two details of that snippet are worth stating, because both are easy to get
+wrong and the second nearly went wrong here:
+
+- The equipment bonus is the **best** weapon's, not the sum — `std::max`.
+- `ForEachEquipment<true, false>` is `<allow_weapon, allow_armor>`, so the field
+  is read **from weapons only**. That matters enormously in this data: of the
+  seventy-five items Nepheshel sets it on, the six carrying **+100%** are all
+  armour or accessories (龍の鱗, 光の衣, 翼 …). Reading them would have handed
+  out gear that criticals on every blow. The weapons that legitimately carry the
+  field run +2% to +60%. The field is simply inert outside the weapon slot,
+  exactly as its sibling `hit` already was.
+
+## Decision
+
+Carry the chance in **basis points** (1/10000) rather than as a denominator, and
+sum the two sources on that common scale: `10000 / critical_rate` from the row,
+plus the best equipped weapon's percentage times 100. `Combatant#crit_denom`
+becomes `crit_chance`, `Game::Enemy` computes the same way (enemies wear nothing,
+so there is no bonus to add), and `Battle#critical?` rolls under it.
+
+Basis points rather than percent because the base is often a fraction of one:
+1/30 is 333 bp, and rounding it to 3% would be a 10% error in the rate.
+
+### The roll needed its own draw
+
+`Rng#random(n)` is `next_int % n`, and the generator's period is **prime**
+(65537). A modulus of a prime period never divides evenly: the low
+`PERIOD % n` values come up once more often than the rest. At the scales the
+codebase already used — `random(30)`, `random(100)` — the surplus is a handful of
+draws out of thousands and is invisible.
+
+At scale 10000 it is not. The surplus is 5537 values, all bunched at the bottom
+of the range, which is precisely where a "roll under a small threshold" test
+looks. Measured over 200k draws, `random(10000) < 333` fires **3.562%** of the
+time where 1/30 is 3.333% — the representation change would have quietly handed
+every battler in both games a ~7% relative crit boost on top of the feature.
+
+So the crit roll uses a new `Rng#scaled(scale)` — `next_int * scale / PERIOD`
+— which is monotonic and therefore spreads the same unavoidable unevenness
+across the range instead of piling it under the threshold. Over the same 200k
+draws it puts 1/30 at 3.335% and 1/3 at 33.338%. `#random` is left alone: every
+existing caller uses a small `n` where it is fine, and changing it would reshuffle
+every seeded result in the project for no benefit.
+
+## Consequences
+
+The bonus reaches the roll. Against Nepheshel's real tables, with リト's
+`critical_rate` of 1/20:
+
+| | chance | rolled over 3000 swings |
+|---|---|---|
+| unarmed | 500 bp (5.00%) | — |
+| +2% オリハルコンナイフ | 700 bp (7.00%) | 7.4% |
+| +10% ファルシオン | 1500 bp (15.00%) | 15.9% |
+| +60% 滅びの剣 | 6500 bp (65.00%) | 68.0% |
+
+Wearing 龍の鱗 and 翼 — two +100% **armour** pieces — leaves the chance at the
+500 bp base, which is the point of the weapons-only rule.
+
+**Unlike ADR 0032 and 0033, this one moves the needle on seeded fights**, and it
+should. Running every troop in both test beds:
+
+| | Nepheshel | mtf-meido-action |
+|---|---|---|
+| criticals | 29 → **141** | 24 → 18 |
+| swings | 1847 → 1607 | 1726 → 1745 |
+| victories / defeats | 119/38 → **124/33** | 54/34 → 54/34 (unchanged) |
+
+Nepheshel's starting party carries a weapon whose bonus now counts, so it crits
+nearly five times as often, fights end sooner (240 fewer swings) and it wins five
+more of its 157 fights. mtf sets no weapon bonus at all, so its outcomes are
+identical and its small movement is the RNG stream reshuffling — the base rate
+itself is preserved, which the distribution check pins directly rather than
+inferring from a battle.
+
+Follow-ups from the ADR 0033 list that remain open: `attack_all` (7 weapons,
+whose handling is not in EasyRPG's `algo.cpp` with the others), `preemptive`
+(17 items) and `raise_evasion` (13, which has nowhere to land until the to-hit
+formula grows an evasion term separate from agility).
+
+Covered by `scripts/rpg2k_logic_check.rb`: the chance sums the row's 1-in-N with
+the best weapon bonus, takes the best rather than the sum across weapons, ignores
+the +100% armour, and still counts the weapon when the row never criticals on its
+own; plus a distribution check that pins `Rng#scaled` within 3% of the true rate
+at three thresholds and asserts the modulus overshoots at each.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1446,13 +1446,48 @@ module Game
       @hp
     end
 
-    # The actor's 1-in-N critical-hit chance from the database (0 = never), gated
-    # by `has_critical_rate` with `critical_rate` as the denominator (default 30,
-    # i.e. 1/30). A bare fixture without the fields never crits.
-    def crit_denominator
-      return 0 unless @db_row.respond_to?(:has_critical_rate) && @db_row.has_critical_rate
-      n = @db_row.respond_to?(:critical_rate) ? @db_row.critical_rate : 0
-      n && n > 0 ? n : 0
+    # The actor's chance to land a critical hit, in **basis points** (1/10000),
+    # which is RPG_RT's `Game_Actor::GetCriticalHitChance`:
+    #
+    #   1 / critical_rate   (when has_critical_rate)   +   best weapon bonus %
+    #
+    # The row supplies a 1-in-N base — `critical_rate` 30 means 1/30 — and the
+    # equipped weapons add a flat percentage on top, the **best** of them rather
+    # than the sum (EasyRPG takes a running `std::max` over the equipment). Basis
+    # points keep the whole thing in integers: 1/30 is 333, a +2% dagger is 200.
+    #
+    # A bare fixture without the fields never crits.
+    def crit_chance
+      base = 0
+      if @db_row.respond_to?(:has_critical_rate) && @db_row.has_critical_rate
+        n = @db_row.respond_to?(:critical_rate) ? @db_row.critical_rate : 0
+        base = 10_000 / n if n && n > 0
+      end
+      Game.clamp(base + weapon_crit_bonus, 0, 10_000)
+    end
+
+    # The best `critical_hit` percentage among the equipped **weapons**, in basis
+    # points. Weapons only, which the data makes worth stating: Nepheshel sets the
+    # field on 75 items, and the six carrying **+100%** are all armour or
+    # accessories (龍の鱗, 光の衣, 翼 …). Reading those would hand out gear that
+    # criticals on every single blow. RPG_RT does not — its
+    # `Game_Actor::GetCriticalHitChance` iterates `ForEachEquipment<true, false>`,
+    # allowing weapons and excluding every armour slot — so the field is inert
+    # outside the weapon slot, exactly as its sibling `hit` is (#attack_hit_rate
+    # already reads that weapon-only). The weapons that do carry it run +2% to
+    # +60%.
+    def weapon_crit_bonus
+      return 0 unless @db.respond_to?(:item)
+      best = 0
+      @equipment.each do |iid|
+        next if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next unless it && it.respond_to?(:type) && it.type == 1 # weapon slot
+        next unless it.respond_to?(:critical_hit)
+        pct = it.critical_hit || 0
+        best = pct if pct > best
+      end
+      best * 100
     end
 
     # Set HP to an absolute value, clamped to [0, max_hp], keeping the death
@@ -2621,18 +2656,39 @@ module Game
   # period (65536) and quality are more than enough for picking a walk
   # direction, and seeding it makes NPC wandering reproducible.
   class Rng
+    # The generator's period. Prime, which matters for #scaled below.
+    PERIOD = 65_537
+
     def initialize(seed = 1)
       @state = (seed & 0xFFFF) + 1
     end
 
     def next_int
-      @state = (@state * 75 + 74) % 65537
+      @state = (@state * 75 + 74) % PERIOD
     end
 
     # An integer in 0...n (0 when n <= 0).
     def random(n)
       return 0 if n <= 0
       next_int % n
+    end
+
+    # An integer in 0...scale, taken by scaling the generator's whole period
+    # rather than by taking a modulus of it.
+    #
+    # The distinction only starts to matter at a large scale. `PERIOD` is prime,
+    # so `next_int % scale` never divides evenly: the low `PERIOD % scale` values
+    # come up once more often than the rest. At `scale` 30 that skews a handful
+    # of draws out of two thousand and is invisible, which is why #random is fine
+    # for everything that uses it. At `scale` 10000 the surplus is 5537 values
+    # all bunched at the bottom — precisely where a "roll under a small
+    # threshold" test looks — and it reads a 3.33% chance as 3.56%. Scaling is
+    # monotonic, so the same unavoidable unevenness spreads across the range
+    # instead of piling up under the threshold: measured over 200k draws it puts
+    # 1/30 at 3.335% and 1/3 at 33.338%.
+    def scaled(scale)
+      return 0 if scale <= 0
+      next_int * scale / PERIOD
     end
   end
 
@@ -4263,14 +4319,15 @@ module Game
       @hidden = hidden ? true : false
       @hp = @max_hp
       @sp = @max_sp
-      # 1-in-N critical-hit chance (0 = never), from the enemy's critical_hit
-      # flag + critical_hit_chance denominator.
-      @crit_denom = if row && row.respond_to?(:critical_hit) && row.critical_hit
-                      n = row.respond_to?(:critical_hit_chance) ? row.critical_hit_chance : 0
-                      n && n > 0 ? n : 0
-                    else
-                      0
-                    end
+      # Critical-hit chance in basis points (1/10000; 0 = never), from the
+      # enemy's critical_hit flag and its 1-in-N critical_hit_chance. Enemies
+      # carry no equipment, so unlike an actor's there is no weapon bonus to add.
+      @crit_chance = if row && row.respond_to?(:critical_hit) && row.critical_hit
+                       n = row.respond_to?(:critical_hit_chance) ? row.critical_hit_chance : 0
+                       n && n > 0 ? 10_000 / n : 0
+                     else
+                       0
+                     end
       # Per-attribute defence ranks ({ attribute_id => rank 0..4 }) from the
       # enemy's attribute_ranks byte array, so an elemental attack scales its
       # damage by this monster's resistance. Captured now since `row` isn't kept.
@@ -4295,8 +4352,7 @@ module Game
     # This enemy's action pattern (Game::EnemyAction list, possibly empty).
     attr_reader :actions
 
-    attr_reader :crit_denom, :attribute_ranks, :state_ranks
-    def crit_denominator; @crit_denom; end
+    attr_reader :crit_chance, :attribute_ranks, :state_ranks
 
     # Base to-hit percentage for this enemy's normal attack (70 when the "miss"
     # flag is set, otherwise 90); fed into the battle's to-hit roll.
@@ -4430,7 +4486,7 @@ module Game
     # stat the skill formulas read as `int`.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
-                           :actor, :states, :state_turns, :crit_denom,
+                           :actor, :states, :state_turns, :crit_chance,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
                            :hit_rate, :state_ranks, :hidden, :battle_turn,
                            :actions, :charged, :enemy_id, :battler_name,
@@ -4476,9 +4532,9 @@ module Game
     # starts clean.
     def self.actor_states(a); a.respond_to?(:states) ? (a.states || []).dup : []; end
 
-    # A battler's critical-hit denominator (0 when it never crits, or the source
-    # lacks the field).
-    def self.crit_denom_of(b); b.respond_to?(:crit_denominator) ? b.crit_denominator : 0; end
+    # A battler's critical-hit chance in basis points (0 when it never crits, or
+    # the source lacks the field).
+    def self.crit_chance_of(b); b.respond_to?(:crit_chance) ? b.crit_chance : 0; end
 
     # Whether a battler's gear guards against critical hits.
     def self.prevents_crit_of(b); b.respond_to?(:prevents_critical?) && b.prevents_critical?; end
@@ -4502,7 +4558,7 @@ module Game
     def self.from_actor(a)
       c = Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
-                    nil, crit_denom_of(a), prevents_crit_of(a),
+                    nil, crit_chance_of(a), prevents_crit_of(a),
                     attr_ranks_of(a), atk_attrs_of(a), nil, hit_rate_of(a),
                     state_ranks_of(a))
       c.strikes = flag_of(a, :dual_attack?) ? 2 : 1
@@ -4520,7 +4576,7 @@ module Game
     def self.from_enemy(e)
       c = Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
                         nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
-                        crit_denom_of(e), prevents_crit_of(e),
+                        crit_chance_of(e), prevents_crit_of(e),
                         attr_ranks_of(e), atk_attrs_of(e), nil, hit_rate_of(e),
                         state_ranks_of(e))
       # A member the troop flagged invisible starts out of play until a Show
@@ -4555,7 +4611,7 @@ module Game
     # `variance`, when true, applies RPG2000's +/- spread to each basic attack's
     # damage (a `var` of 4, per EasyRPG's Algo::VarianceAdjustEffect). `criticals`,
     # when true, lets a basic attack land a 3x critical at the attacker's 1-in-N
-    # `crit_denom` chance. `accuracy`, when true, rolls each basic attack's
+    # `crit_chance` (basis points). `accuracy`, when true, rolls each basic attack's
     # to-hit chance so it can miss (see #to_hit). All three are off by default so
     # a seeded fight is exactly reproducible; the live game turns them on.
     # `first_strike`, when true, gives the party a pre-emptive opening round: the
@@ -4595,6 +4651,13 @@ module Game
 
     # RPG2000 normal-attack damage variance on the 0-10 `var` scale.
     NORMAL_ATTACK_VARIANCE = 4
+
+    # Critical-hit chances are carried in basis points (1/10000) rather than as
+    # the 1-in-N denominator the database stores, because a weapon adds a flat
+    # *percentage* on top of the actor's 1/N and the two only combine on a common
+    # scale. Basis points keep that sum in integers: 1/30 is 333 and a +2% dagger
+    # is 200, so the pair is 533 rather than a rounded 3% or 5%.
+    CRIT_SCALE = 10_000
 
     # State `restriction` values (lcf::rpg::State::Restriction): the battler
     # cannot act (asleep / paralysed), is forced to attack a random enemy
@@ -5348,7 +5411,7 @@ module Game
       b.max_hp = into.max_hp; b.max_mp = into.max_sp
       b.hp = b.hp > into.max_hp ? into.max_hp : b.hp
       b.mp = (b.mp || 0) > into.max_sp ? into.max_sp : b.mp
-      b.crit_denom = Battle.crit_denom_of(into)
+      b.crit_chance = Battle.crit_chance_of(into)
       b.attr_ranks = Battle.attr_ranks_of(into)
       b.state_ranks = Battle.state_ranks_of(into)
       b.hit_rate = Battle.hit_rate_of(into)
@@ -5452,11 +5515,15 @@ module Game
     end
 
     # Whether `b`'s attack criticals: enabled for the fight, the attacker has a
-    # non-zero 1-in-N `crit_denom`, and a 0..N-1 roll lands on 0.
+    # non-zero `crit_chance`, and a 0..9999 roll lands under it.
     def critical?(b)
       return false unless @criticals
-      denom = b.crit_denom
-      denom && denom > 0 && @rng.random(denom) == 0
+      chance = b.crit_chance
+      return false unless chance && chance > 0
+      # Basis points, so a +100% weapon (10000) crits on every blow. Drawn with
+      # Rng#scaled rather than #random: at this scale a modulus of the prime
+      # period skews small thresholds upward (see Rng#scaled).
+      @rng.scaled(CRIT_SCALE) < chance
     end
 
     # Whether `attacker`'s basic attack lands on `target`: a 0..99 roll under the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1816,7 +1816,8 @@ end
 # A database row for an actor, and a fake DB exposing just what Game::Party /
 # Game::Actor read (player table + the initial party list).
 FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
-                           :initial_level, :status, :strong_defence)
+                           :initial_level, :status, :strong_defence,
+                           :has_critical_rate, :critical_rate)
 # Like FakePlayerRow but exposing the full growth curve the way a real LCF row
 # does (six shorts per level via #int16_values(31)), so Actor scales its base
 # stats by level instead of using a single level-independent status hash.
@@ -1863,19 +1864,20 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :occasion_battle, :state_set, :reverse_state_effect,
                       :prevent_critical, :attribute_set, :switch_id,
                       :occasion_field2, :occasion_field1,
-                      :dual_attack, :ignore_evasion, :half_sp_cost, :hit)
+                      :dual_attack, :ignore_evasion, :half_sp_cost, :hit,
+                      :critical_hit)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
               attribute_set: nil, switch_id: 0, occ_field: true,
               field_only: false, dual_attack: false, ignore_evasion: false,
-              half_sp_cost: false, hit: 0)
+              half_sp_cost: false, hit: 0, critical_hit: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
-               dual_attack, ignore_evasion, half_sp_cost, hit)
+               dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -5180,9 +5182,67 @@ check 'without variance a seeded fight deals exactly the base damage' do
   eq 20, bat.step_action[:damage]                    # exact base, unaffected
 end
 
+check 'Rng#scaled keeps a small threshold honest where a modulus does not' do
+  # The generator's period is prime, so `next_int % 10000` leaves 5537 surplus
+  # values bunched at the bottom of the range — exactly where a "roll under a
+  # small threshold" test reads — and inflates it. #scaled spreads the same
+  # unevenness across the range instead. Pinned because the crit roll depends on
+  # it, and because the failure is a quiet few-percent drift, not a crash.
+  [[30, 333], [20, 500], [3, 3333]].each do |denom, bp|
+    trials = 40_000
+    modulo = Game::Rng.new(1)
+    scaled = Game::Rng.new(1)
+    m = s = 0
+    trials.times do
+      m += 1 if modulo.random(10_000) < bp
+      s += 1 if scaled.scaled(10_000) < bp
+    end
+    want = trials / denom.to_f
+    # The scaled draw lands within 3% (relative) of the true rate; the modulus
+    # overshoots by far more than that.
+    ok (s - want).abs < want * 0.03,
+       "1/#{denom}: scaled gave #{s}, wanted about #{want.round}"
+    ok m > s, "1/#{denom}: the modulus overshoots (#{m} vs #{s})"
+  end
+  eq 0, Game::Rng.new(1).scaled(0), 'a non-positive scale draws 0'
+end
+
+check 'crit chance sums the actor\'s 1-in-N with the best weapon bonus' do
+  # The database stores the actor's chance as a denominator and the weapon's as a
+  # percentage; the two only combine on a common scale, which is why the runtime
+  # carries basis points. 1/20 is 500 bp, a +10% blade adds 1000.
+  row = CurveRow.new('Hero', '', 0, 1, [100, 40, 10, 5, 5, 5])
+  row.has_critical_rate = true
+  row.critical_rate = 20
+  items = { 7 => fake_item(type: 1, atk: 5, critical_hit: 10),
+            8 => fake_item(type: 1, atk: 5, critical_hit: 2),
+            9 => fake_item(type: 3, dfn: 5, critical_hit: 100) } # armour!
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+
+  hero.equip([0, 0, 0, 0, 0])
+  eq 500, hero.crit_chance, 'unarmed: the row alone, 1/20'
+  hero.equip([7, 0, 0, 0, 0])
+  eq 1500, hero.crit_chance, '+10% weapon adds 1000 bp'
+  # Several weapons take the best, not the sum (EasyRPG keeps a running max).
+  hero.equip([8, 0, 0, 0, 0])
+  eq 700, hero.crit_chance, '+2% weapon adds 200 bp'
+  # Armour is ignored: RPG_RT reads the field for weapons only, and Nepheshel's
+  # six +100% items are all armour or accessories.
+  hero.equip([8, 0, 9, 0, 0])
+  eq 700, hero.crit_chance, 'the +100% armour contributes nothing'
+
+  # A row that never criticals stays at zero however good the weapon is.
+  row.has_critical_rate = false
+  bare = Game::Party.new(db).leader
+  bare.equip([7, 0, 0, 0, 0])
+  eq 1000, bare.crit_chance, 'no base, but the weapon still counts'
+end
+
 check 'battle: a critical hit triples the damage when the fight rolls one' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_denom = 1                                # 1-in-1 -> always crits
+  hero.crit_chance = Game::Battle::CRIT_SCALE        # 100% -> always crits
   slime = combatant('Slime', 0, 0, 5, 100_000)
   # 6-arg: variance off, criticals on.
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
@@ -5194,7 +5254,7 @@ end
 
 check 'battle: no critical when the fight has criticals off' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_denom = 1                                # would always crit, but...
+  hero.crit_chance = Game::Battle::CRIT_SCALE        # would always crit, but...
   slime = combatant('Slime', 0, 0, 5, 100_000)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))  # 3-arg: crit off
   bat.begin_round
@@ -5203,8 +5263,8 @@ check 'battle: no critical when the fight has criticals off' do
   ok !e[:critical]
 end
 
-check 'battle: a zero crit_denom never criticals even with criticals on' do
-  hero = combatant('Hero', 40, 0, 20, 100)           # crit_denom nil -> never
+check 'battle: a zero crit_chance never criticals even with criticals on' do
+  hero = combatant('Hero', 40, 0, 20, 100)           # crit_chance nil -> never
   slime = combatant('Slime', 0, 0, 5, 100_000)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
   bat.begin_round
@@ -5215,7 +5275,7 @@ end
 
 check 'battle: gear that prevents criticals blocks the 3x hit' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_denom = 1                                # would always crit...
+  hero.crit_chance = Game::Battle::CRIT_SCALE        # would always crit...
   slime = combatant('Slime', 0, 0, 5, 100_000)
   slime.prevents_crit = true                         # ...but the target is guarded
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)


### PR DESCRIPTION
[ADR 0033](docs/adr/0033-equipment-combat-modifiers.md) read four equipment combat flags and deliberately left a fifth: a weapon's `critical_hit` bonus, the largest count in that audit at **75 of Nepheshel's items**. This is that follow-up. See [ADR 0034](docs/adr/0034-critical-hit-chance.md).

## Why it needed its own PR

RPG2000 stores a critical chance in two incompatible shapes. The actor row carries a **denominator** — `critical_rate` 20 means one blow in twenty — while a weapon carries a flat **percentage** on top. RPG_RT adds them:

```cpp
float crit_chance = dbActor->critical_hit ? 1.0f / dbActor->critical_hit_chance : 0.0f;
float bonus = 0;
ForEachEquipment<true, false>(GetWholeEquipment(),
    [&](auto& item) { bonus = std::max(bonus, (float)item.critical_hit); }, weapon);
return crit_chance + (bonus / 100.0f);
```

This build modelled only the denominator (`crit_denom`, rolled as `rng.random(denom) == 0`), and a denominator has nowhere to put "+10%". So all 75 bonuses did nothing. The chance is carried in **basis points** now and both sources sum on that scale.

## The trap in the data

`ForEachEquipment<true, false>` is `<allow_weapon, allow_armor>` — **weapons only**. That matters enormously here: of the 75 items Nepheshel sets the field on, the six carrying **+100%** are all armour or accessories (龍の鱗, 光の衣, 翼 …). Reading them would have handed out gear that criticals on **every blow**.

I'd written it to scan all equipment first, saw the +100% armour in the output, and went back to the source rather than shipping it. The weapons that legitimately carry the field run +2% to +60%.

## The other trap: the roll needed its own draw

`Rng#random(n)` is `next_int % n`, and the generator's period is **prime** (65537). A modulus of a prime period never divides evenly — the low `PERIOD % n` values come up once more often. At the small `n` every existing caller uses, that's a handful of draws out of thousands and invisible.

At scale 10000 it is not. The surplus is 5537 values bunched at the bottom of the range — precisely where a "roll under a small threshold" test looks. Measured over 200k draws:

| | 1/30 | 1/20 | 1/3 |
|---|---|---|---|
| exact | 3.333% | 5.000% | 33.333% |
| `random(10000) < bp` | **3.562%** | **5.347%** | **35.600%** |
| `scaled(10000) < bp` | 3.335% | 5.004% | 33.338% |

The representation change alone would have quietly handed every battler in both games a ~7% relative crit boost *on top of* the feature. New `Rng#scaled` is monotonic, so the same unavoidable unevenness spreads across the range instead of piling under the threshold. **`#random` is untouched** — every existing caller uses a small `n` where it's fine, and changing it would reshuffle every seeded result in the project for no benefit.

## Result

Against Nepheshel's real tables, with リト's `critical_rate` of 1/20:

| | chance | rolled over 3000 swings |
|---|---|---|
| unarmed | 500 bp (5.00%) | — |
| +2% オリハルコンナイフ | 700 bp (7.00%) | 7.4% |
| +10% ファルシオン | 1500 bp (15.00%) | 15.9% |
| +60% 滅びの剣 | 6500 bp (65.00%) | 68.0% |

Wearing 龍の鱗 *and* 翼 — two +100% armour pieces — leaves it at the 500 bp base.

## This one moves seeded fights

Unlike ADRs 0032 and 0033, where I could report "byte-identical", this changes battle outcomes — and it should:

| | Nepheshel | mtf-meido-action |
|---|---|---|
| criticals | 29 → **141** | 24 → 18 |
| swings | 1847 → 1607 | 1726 → 1745 |
| victories / defeats | 119/38 → **124/33** | 54/34 → 54/34 (unchanged) |

Nepheshel's starting party carries a weapon whose bonus now counts, so it crits nearly five times as often, fights end 240 swings sooner, and it wins five more of its 157. mtf sets no weapon bonus at all — its outcomes are identical and its small movement is the RNG stream reshuffling. The base rate itself is preserved, pinned directly by the distribution check rather than inferred from a battle.

## Testing

New checks: the chance sums the row's 1-in-N with the best weapon bonus; takes the **best** across weapons rather than the sum; ignores the +100% armour; still counts the weapon when the row never criticals on its own; and a distribution check pinning `Rng#scaled` within 3% of the true rate at three thresholds while asserting the modulus overshoots at each. All confirmed to fail against the pre-change code. Existing crit fixtures moved from `crit_denom = 1` to `crit_chance = CRIT_SCALE`.

All nine CRuby suites pass: `rpg2k_logic_check` (521, +2), `rpg2k_scene_check` (150), `rpg2k_testbed_logic_check` (54), `rpg2k_render_check`, `lcf_testbed_check`, `rpgxp_testbed_check`, `rpgvx_testbed_check`, `mv_testbed_check`, `mz_testbed_check`. The native build could not be exercised here (no nix/SDL2) — CI covers it.

## Still open

From the ADR 0033 list: `attack_all` (7 weapons, handling not in EasyRPG's `algo.cpp` with the others), `preemptive` (17 items), and `raise_evasion` (13, nowhere to land until the to-hit formula grows an evasion term separate from agility).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_