### PR TITLE
Pay out the rate a weapon advertises

### DIFF
--- a/changelog.d/weapon-critical-hit-bonus.added.md
+++ b/changelog.d/weapon-critical-hit-bonus.added.md
@@ -1,0 +1,11 @@
+- **A weapon's 会心必殺 rate now reaches the fight.** `critical_hit` (item field
+  18) is the largest unread field in the equipment audit — 75 of Nepheshel's
+  items carry one — and it could not simply be read, because RPG_RT *adds* the
+  weapon's percentage to the wielder's own 1-in-N rate and no denominator
+  expresses "1/30 and 20% more". Criticals are therefore modelled as a
+  probability: `Game::Actor#crit_chance` (and the enemy's) returns basis points
+  over `Game::CRIT_SCALE`, and `Battle#critical?` rolls against it.
+- **Only a weapon grants the bonus.** The six of Nepheshel's 75 items that are
+  not weapons carry exactly 100 apiece alongside a `hit` of 70 — another
+  weapon-only field — which is the editor leaving weapon fields untouched in the
+  record every item type shares, not six pieces of armour that always critical.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -568,10 +568,30 @@ The work below is roughly ordered by the critical path to a walkable game
   flag ignores is the *target's* evasion; **MP消費半分** (`half_sp_cost`, any
   slot) halves a skill's cost rounding up; and **強力防御** (`strong_defence`, an
   actor-row flag 7 of Nepheshel's 50 actors carry including its hero) halves
-  damage a second time while defending — a quarter, not a half. Still unread: a
-  weapon's **`critical_hit` bonus**, the largest count in that audit at 75 items,
-  which needs the crit model to move from a 1-in-N denominator to RPG_RT's
-  probability (`1/critical_hit_chance` plus the best weapon's percentage);
+  damage a second time while defending — a quarter, not a half.
+  A weapon's **会心必殺 rate** (`critical_hit`) is read now as well — the largest
+  count in that audit at **75 items** — and it is the one that could not simply
+  be read, because RPG_RT *adds* the weapon's percentage to the wielder's own
+  1-in-N rate and no denominator says "1/30 and 20% more". So criticals moved to
+  a **probability**: `Game::Actor#crit_chance` / `Game::Enemy#crit_chance` return
+  basis points over `Game::CRIT_SCALE` (10000), `Combatant` carries
+  `crit_chance`, and `Battle#critical?` rolls against it. Integer basis points
+  rather than a float keeps the damage path on the arithmetic the rest of it
+  uses; the cost is that a 1/30 row reads 333 bp (3.33% against 3.3333…%), one
+  crit fewer in ~300,000 swings. Only a **weapon** grants the bonus — the best
+  among those equipped, the same shape `attack_hit_rate` uses — and Nepheshel's
+  own bytes are what settle that rather than an appeal to EasyRPG's structure:
+  69 of the 75 are weapons with a spread of rates (2..100), while the other six
+  are armour and accessories carrying **exactly 100 apiece** next to a `hit` of
+  70, another weapon-only field. That is the editor leaving weapon fields
+  untouched in the record every item type shares, not six pieces of armour that
+  critical every swing. Unlike the four flags above this one is *meant* to move
+  the simulation, and it does: over every troop in both beds, Nepheshel goes from
+  124 wins in 157 fights to **130**, and from 1620 swings to **1442** — its
+  starting party wields a +2% weapon, lifting its hero from 500 bp to 700.
+  mtf-meido-action, which has no such weapon and puts every actor on the plain
+  1-in-30, drifts by five swings with no change of outcome: that is the roll
+  changing shape, not the bonus. Still unread:
   **`attack_all`** (7 weapons), whose handling is not in EasyRPG's `algo.cpp`
   with the others and is left declared rather than guessed; and **`preemptive`**
   / **`raise_evasion`**, the latter having nowhere to land until the to-hit

--- a/docs/adr/0033-equipment-combat-modifiers.md
+++ b/docs/adr/0033-equipment-combat-modifiers.md
@@ -83,7 +83,8 @@ swings, the same 501 and 708 misses. Neither test bed's *starting* party wears
 any of the flagged gear, so the sweep exercises the unchanged path and confirms
 it is unchanged.
 
-Left for a follow-up, and deliberately not guessed at here:
+Left for a follow-up, and deliberately not guessed at here. The first is now
+done:
 
 - **A weapon's `critical_hit` bonus** — 75 of Nepheshel's items carry one, the
   largest count in the audit. It is the one flag that cannot simply be read,
@@ -91,7 +92,7 @@ Left for a follow-up, and deliberately not guessed at here:
   plus the best weapon's `critical_hit` as a percentage) while this build models
   criticals as a 1-in-N denominator. Folding the bonus in means moving that
   representation to a probability, which touches every crit fixture and deserves
-  its own diff and its own before/after.
+  its own diff and its own before/after. **Done since** — see the addendum below.
 - **`attack_all`** (7 weapons) — a normal attack that hits every enemy. Its
   handling is not in `algo.cpp` with the others, and rather than guess at how the
   damage and log entries should read it is left declared.
@@ -108,3 +109,81 @@ leaves; MP消費半分 halves a cost rounding up, and a percentage cost too) and
 and actor tables that every 二刀流 weapon in the game grants two strikes, every
 必中 weapon hits at its own rate against an unhittable target, and every
 MP消費半分 item halves a real skill's cost from the slot its own type names.
+
+## Addendum: the 会心必殺 rate, and criticals as a probability
+
+Date: 2026-08-06
+
+The deferred item above is now implemented, and the reason it was deferred —
+that it forces a representation change — is the whole of the work.
+
+### Criticals became a probability
+
+RPG_RT adds a weapon's own `critical_hit` percentage to the wielder's 1-in-N
+rate. A denominator cannot say "1/30 and 20% more", so the chance is now carried
+as one: `Game::Actor#crit_chance` and `Game::Enemy#crit_chance` return **basis
+points** over `Game::CRIT_SCALE` (10000), `Combatant` carries `crit_chance` in
+place of `crit_denom`, and `Battle#critical?` rolls `random(CRIT_SCALE) <
+chance`.
+
+Basis points rather than a float, to keep the damage path on the integer
+arithmetic the rest of it uses. The base truncates there: a 1/30 row becomes 333
+bp, i.e. 3.33% against a true 3.3333…%, which is one crit fewer in roughly
+300,000 swings.
+
+### Only a weapon grants the bonus
+
+`Actor#weapon_crit_bonus` takes the **best** `critical_hit` among the equipped
+**weapons** (item type 1), the same shape `attack_hit_rate` already uses for the
+`hit` field. Nepheshel's bytes are what settle "weapons only" rather than an
+appeal to how the reference implementation is structured:
+
+| | count | rates |
+|---|---|---|
+| weapons carrying a bonus | **69** | a spread: 2, 5, 8, 10, 15, 20, 25, 30, 40, 60, 100 |
+| non-weapons carrying one | **6** | **100 apiece**, every one, alongside a `hit` of 70 |
+
+The six are four pieces of armour and two accessories. Six pieces of armour that
+critical on every swing is not a design; a uniform 100 sitting next to a `hit` of
+70 — another field the editor shows only for a weapon — is the editor leaving
+weapon fields untouched in the record every item type shares. mtf-meido-action
+carries neither kind, so Nepheshel is the only evidence either way, which is why
+the test-bed check asserts *both* halves: every weapon moves its wielder's rate
+by exactly its own percentage, and every non-weapon leaves it alone.
+
+One case is unobservable and therefore only pinned, not measured: an actor whose
+own `has_critical_rate` is off, wielding a weapon that crits. The two are
+separate additive terms, so the weapon still applies — but all 50 of Nepheshel's
+actors and all 14 of mtf's can crit, so no shipped data exercises it.
+
+### Before and after
+
+Running every troop in both beds with criticals, variance and accuracy on, seeded
+per troop — unlike the four flags above, this one is *meant* to move the
+simulation:
+
+| | fights | wins before | wins after | swings before | swings after |
+|---|---|---|---|---|---|
+| Nepheshel | 157 | 124 | **130** | 1620 | **1442** |
+| mtf-meido-action | 88 | 54 | 54 | 1688 | 1693 |
+
+Nepheshel's starting party wields a weapon carrying +2%, which lifts its hero
+from 500 bp to 700 — a 40% relative increase in how often it criticals. Six more
+fights won and 178 fewer swings to win them is that bonus finally being paid.
+
+mtf-meido-action has **no** weapon with the field and every actor on the plain
+1-in-30, so its drift (five swings, no change of outcome) is not the bonus at
+all: it is the roll changing shape. `random(30) == 0` and `random(10000) < 333`
+are the same rate to two decimal places but map a given RNG value differently, so
+a seeded fight diverges where a crit lands on one and not the other. That is the
+expected cost of the representation change, and it is bounded to 0.3% of swings
+in a game the feature does not otherwise touch.
+
+Covered by `scripts/rpg2k_logic_check.rb` (the row rate alone in basis points;
+a weapon adding its percentage; the best of two wielded weapons rather than their
+sum, and an armour contributing nothing; a weapon arming an actor whose own rate
+is off; a 100% weapon critting on every seed; the roll read against the scale
+with a fixed RNG, which is what distinguishes a probability from a denominator)
+and by `scripts/rpg2k_testbed_logic_check.rb`, which asserts against the **real**
+item table that each of the 69 weapons adds exactly its own rate and each of the
+6 non-weapons adds nothing.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6,6 +6,14 @@
 # the not-yet-implemented map renderer, and unit-testable on its own.
 module Game
   TILE = 16 # tile size in pixels
+  # Denominator a critical-hit chance is expressed over -- basis points, so
+  # 10000 is certainty and an actor's 1/30 row rate is 333. RPG_RT adds a
+  # weapon's own percentage to the wielder's rate, which a 1-in-N denominator
+  # cannot express, so the chance is carried as a probability and the whole
+  # damage path stays on integer arithmetic. See Actor#crit_chance.
+  CRIT_SCALE = 10_000
+  # ... and what one percentage point of it is worth.
+  CRIT_PERCENT = CRIT_SCALE / 100
   # The RPG2000 screen, in pixels. `RPG2k::WIDTH`/`HEIGHT` are the same numbers
   # on the scene side; the pure-logic half needs them for the screen-transition
   # geometry, which cannot reach the scene.
@@ -1446,13 +1454,47 @@ module Game
       @hp
     end
 
-    # The actor's 1-in-N critical-hit chance from the database (0 = never), gated
-    # by `has_critical_rate` with `critical_rate` as the denominator (default 30,
-    # i.e. 1/30). A bare fixture without the fields never crits.
-    def crit_denominator
-      return 0 unless @db_row.respond_to?(:has_critical_rate) && @db_row.has_critical_rate
-      n = @db_row.respond_to?(:critical_rate) ? @db_row.critical_rate : 0
-      n && n > 0 ? n : 0
+    # The actor's critical-hit chance in basis points (0 = never): the row's own
+    # 1-in-`critical_rate` rate, gated by `has_critical_rate`, **plus** the
+    # equipped weapon's `critical_hit` percentage. RPG_RT adds the two, which is
+    # why this is a probability rather than the 1-in-N denominator it used to
+    # be -- there is no denominator that expresses "1/30 and 20% more".
+    #
+    # Basis points (1/10000) rather than a float, to stay with the integer
+    # arithmetic the rest of the damage path uses. The base truncates there: a
+    # 1/30 row is 333 bp, i.e. 3.33% against a true 3.333...%, which is one crit
+    # fewer in roughly 300,000 swings.
+    def crit_chance
+      base = 0
+      if @db_row.respond_to?(:has_critical_rate) && @db_row.has_critical_rate
+        n = @db_row.respond_to?(:critical_rate) ? @db_row.critical_rate : 0
+        base = CRIT_SCALE / n if n && n > 0
+      end
+      base + weapon_crit_bonus * CRIT_PERCENT
+    end
+
+    # 会心必殺 -- the best `critical_hit` percentage among the equipped weapons
+    # (item field 18), the bonus #crit_chance adds to the actor's own rate.
+    #
+    # **Weapons only** (item type 1), like #attack_hit_rate and the other attack
+    # modifiers. The field is one the editor shows for a weapon and no other kind
+    # of item, and Nepheshel says so in its bytes: 69 of its 75 items carrying a
+    # non-zero value are weapons with a spread of rates (2..100), while the other
+    # six are armour and accessories carrying **exactly** 100 apiece -- alongside
+    # a `hit` of 70, another weapon-only field. Six pieces of armour that always
+    # critical is not a design; it is the editor leaving weapon fields untouched
+    # in a record every item type shares.
+    def weapon_crit_bonus
+      return 0 unless @db.respond_to?(:item)
+      best = 0
+      @equipment.each do |iid|
+        next if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next unless it && it.respond_to?(:type) && it.type == 1
+        c = it.respond_to?(:critical_hit) ? it.critical_hit : nil
+        best = c if c && c > best
+      end
+      best
     end
 
     # Set HP to an absolute value, clamped to [0, max_hp], keeping the death
@@ -4299,14 +4341,15 @@ module Game
       @hidden = hidden ? true : false
       @hp = @max_hp
       @sp = @max_sp
-      # 1-in-N critical-hit chance (0 = never), from the enemy's critical_hit
-      # flag + critical_hit_chance denominator.
-      @crit_denom = if row && row.respond_to?(:critical_hit) && row.critical_hit
-                      n = row.respond_to?(:critical_hit_chance) ? row.critical_hit_chance : 0
-                      n && n > 0 ? n : 0
-                    else
-                      0
-                    end
+      # Critical-hit chance in basis points (0 = never), from the enemy's
+      # critical_hit flag and its 1-in-`critical_hit_chance` rate. An enemy has
+      # no equipment, so unlike an actor's this is the whole of it.
+      @crit_chance = if row && row.respond_to?(:critical_hit) && row.critical_hit
+                       n = row.respond_to?(:critical_hit_chance) ? row.critical_hit_chance : 0
+                       n && n > 0 ? CRIT_SCALE / n : 0
+                     else
+                       0
+                     end
       # Per-attribute defence ranks ({ attribute_id => rank 0..4 }) from the
       # enemy's attribute_ranks byte array, so an elemental attack scales its
       # damage by this monster's resistance. Captured now since `row` isn't kept.
@@ -4331,8 +4374,7 @@ module Game
     # This enemy's action pattern (Game::EnemyAction list, possibly empty).
     attr_reader :actions
 
-    attr_reader :crit_denom, :attribute_ranks, :state_ranks
-    def crit_denominator; @crit_denom; end
+    attr_reader :crit_chance, :attribute_ranks, :state_ranks
 
     # Base to-hit percentage for this enemy's normal attack (70 when the "miss"
     # flag is set, otherwise 90); fed into the battle's to-hit roll.
@@ -4588,7 +4630,7 @@ module Game
     # stat the skill formulas read as `int`.
     Combatant = Struct.new(:name, :atk, :def, :agi, :hp, :max_hp,
                            :action, :defending, :mp, :max_mp, :spi, :command,
-                           :actor, :states, :state_turns, :crit_denom,
+                           :actor, :states, :state_turns, :crit_chance,
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
                            :hit_rate, :state_ranks, :hidden, :battle_turn,
                            :actions, :charged, :enemy_id, :battler_name,
@@ -4634,9 +4676,9 @@ module Game
     # starts clean.
     def self.actor_states(a); a.respond_to?(:states) ? (a.states || []).dup : []; end
 
-    # A battler's critical-hit denominator (0 when it never crits, or the source
-    # lacks the field).
-    def self.crit_denom_of(b); b.respond_to?(:crit_denominator) ? b.crit_denominator : 0; end
+    # A battler's critical-hit chance in basis points (0 when it never crits, or
+    # the source lacks the field).
+    def self.crit_chance_of(b); b.respond_to?(:crit_chance) ? b.crit_chance : 0; end
 
     # Whether a battler's gear guards against critical hits.
     def self.prevents_crit_of(b); b.respond_to?(:prevents_critical?) && b.prevents_critical?; end
@@ -4660,7 +4702,7 @@ module Game
     def self.from_actor(a)
       c = Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
-                    nil, crit_denom_of(a), prevents_crit_of(a),
+                    nil, crit_chance_of(a), prevents_crit_of(a),
                     attr_ranks_of(a), atk_attrs_of(a), nil, hit_rate_of(a),
                     state_ranks_of(a))
       c.strikes = flag_of(a, :dual_attack?) ? 2 : 1
@@ -4678,7 +4720,7 @@ module Game
     def self.from_enemy(e)
       c = Combatant.new(e.name, e.atk, e.def, e.agi, e.hp, e.max_hp,
                         nil, false, e.sp, e.max_sp, e.spi, nil, nil, [], nil,
-                        crit_denom_of(e), prevents_crit_of(e),
+                        crit_chance_of(e), prevents_crit_of(e),
                         attr_ranks_of(e), atk_attrs_of(e), nil, hit_rate_of(e),
                         state_ranks_of(e))
       # A member the troop flagged invisible starts out of play until a Show
@@ -4712,8 +4754,8 @@ module Game
     # cannot act); omitted, states are inert as before.
     # `variance`, when true, applies RPG2000's +/- spread to each basic attack's
     # damage (a `var` of 4, per EasyRPG's Algo::VarianceAdjustEffect). `criticals`,
-    # when true, lets a basic attack land a 3x critical at the attacker's 1-in-N
-    # `crit_denom` chance. `accuracy`, when true, rolls each basic attack's
+    # when true, lets a basic attack land a 3x critical at the attacker's
+    # `crit_chance` (basis points). `accuracy`, when true, rolls each basic attack's
     # to-hit chance so it can miss (see #to_hit). All three are off by default so
     # a seeded fight is exactly reproducible; the live game turns them on.
     # `first_strike`, when true, gives the party a pre-emptive opening round: the
@@ -5514,7 +5556,7 @@ module Game
       b.max_hp = into.max_hp; b.max_mp = into.max_sp
       b.hp = b.hp > into.max_hp ? into.max_hp : b.hp
       b.mp = (b.mp || 0) > into.max_sp ? into.max_sp : b.mp
-      b.crit_denom = Battle.crit_denom_of(into)
+      b.crit_chance = Battle.crit_chance_of(into)
       b.attr_ranks = Battle.attr_ranks_of(into)
       b.state_ranks = Battle.state_ranks_of(into)
       b.hit_rate = Battle.hit_rate_of(into)
@@ -5618,11 +5660,12 @@ module Game
     end
 
     # Whether `b`'s attack criticals: enabled for the fight, the attacker has a
-    # non-zero 1-in-N `crit_denom`, and a 0..N-1 roll lands on 0.
+    # non-zero `crit_chance`, and a 0..9999 roll lands under it. A chance at or
+    # above CRIT_SCALE always crits, which is what a weapon carrying 100% means.
     def critical?(b)
       return false unless @criticals
-      denom = b.crit_denom
-      denom && denom > 0 && @rng.random(denom) == 0
+      chance = b.crit_chance
+      chance && chance > 0 && @rng.random(CRIT_SCALE) < chance
     end
 
     # Whether `attacker`'s basic attack lands on `target`: a 0..99 roll under the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1816,7 +1816,14 @@ end
 # A database row for an actor, and a fake DB exposing just what Game::Party /
 # Game::Actor read (player table + the initial party list).
 FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
-                           :initial_level, :status, :strong_defence)
+                           :initial_level, :status, :strong_defence,
+                           # The actor's own critical-hit rate: whether it crits
+                           # at all, and the 1-in-N denominator it crits at.
+                           # Appended after strong_defence so the positional
+                           # constructions above keep working; a row that names
+                           # neither never crits, which is what a bare fixture
+                           # wants.
+                           :has_critical_rate, :critical_rate)
 # Like FakePlayerRow but exposing the full growth curve the way a real LCF row
 # does (six shorts per level via #int16_values(31)), so Actor scales its base
 # stats by level instead of using a single level-independent status hash.
@@ -1863,19 +1870,21 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :occasion_battle, :state_set, :reverse_state_effect,
                       :prevent_critical, :attribute_set, :switch_id,
                       :occasion_field2, :occasion_field1,
-                      :dual_attack, :ignore_evasion, :half_sp_cost, :hit)
+                      :dual_attack, :ignore_evasion, :half_sp_cost, :hit,
+                      # 会心必殺: the weapon's own critical-hit percentage.
+                      :critical_hit)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
               attribute_set: nil, switch_id: 0, occ_field: true,
               field_only: false, dual_attack: false, ignore_evasion: false,
-              half_sp_cost: false, hit: 0)
+              half_sp_cost: false, hit: 0, critical_hit: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
-               dual_attack, ignore_evasion, half_sp_cost, hit)
+               dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -5200,7 +5209,7 @@ end
 
 check 'battle: a critical hit triples the damage when the fight rolls one' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_denom = 1                                # 1-in-1 -> always crits
+  hero.crit_chance = Game::CRIT_SCALE                # certainty -> always crits
   slime = combatant('Slime', 0, 0, 5, 100_000)
   # 6-arg: variance off, criticals on.
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
@@ -5212,7 +5221,7 @@ end
 
 check 'battle: no critical when the fight has criticals off' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_denom = 1                                # would always crit, but...
+  hero.crit_chance = Game::CRIT_SCALE                # would always crit, but...
   slime = combatant('Slime', 0, 0, 5, 100_000)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))  # 3-arg: crit off
   bat.begin_round
@@ -5221,8 +5230,8 @@ check 'battle: no critical when the fight has criticals off' do
   ok !e[:critical]
 end
 
-check 'battle: a zero crit_denom never criticals even with criticals on' do
-  hero = combatant('Hero', 40, 0, 20, 100)           # crit_denom nil -> never
+check 'battle: a zero crit_chance never criticals even with criticals on' do
+  hero = combatant('Hero', 40, 0, 20, 100)           # crit_chance nil -> never
   slime = combatant('Slime', 0, 0, 5, 100_000)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
   bat.begin_round
@@ -5231,9 +5240,128 @@ check 'battle: a zero crit_denom never criticals even with criticals on' do
   ok !e[:critical]
 end
 
+# A party whose actors carry their own critical-hit rate, for the weapon-bonus
+# checks: the hero crits 1-in-30 (RPG2000's own default), the ally never does.
+def crit_party(items)
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           { max_hp: 100, atk: 40, def: 0, agi: 20 },
+                           false, true, 30),
+    2 => FakePlayerRow.new('Ally', '', 0, 3,
+                           { max_hp: 50, atk: 6, def: 0, agi: 4 },
+                           false, false, 0),
+  }
+  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items)), 1, 0, 0)
+end
+
+check 'Actor#crit_chance: the row rate alone, in basis points' do
+  st = crit_party({})
+  eq Game::CRIT_SCALE / 30, st.party.actor_by_id(1).crit_chance
+  eq 333, st.party.actor_by_id(1).crit_chance, '1-in-30 is 3.33%'
+  eq 0, st.party.actor_by_id(2).crit_chance, 'an actor that never crits'
+end
+
+check 'Actor#crit_chance: an equipped weapon adds its own percentage' do
+  # The whole point of the probability model: RPG_RT adds the weapon's rate to
+  # the wielder's, which no 1-in-N denominator can express.
+  items = { 7 => fake_item(type: 1, atk: 5, critical_hit: 20) }
+  st = crit_party(items)
+  a = st.party.actor_by_id(1)
+  eq 333, a.crit_chance, 'unarmed: the row rate'
+  a.equip([7, 0, 0, 0, 0])
+  eq 333 + 20 * Game::CRIT_PERCENT, a.crit_chance
+  eq 2333, a.crit_chance, '3.33% + 20% = 23.33%'
+end
+
+check 'Actor#crit_chance: the best weapon wins, and only a weapon counts' do
+  # `type` is what separates them. The armour case is not hypothetical: six of
+  # Nepheshel's items carrying the field are armour and accessories, every one
+  # of them at exactly 100 alongside a weapon-only `hit` of 70 -- the editor
+  # leaving weapon fields alone in a record every item type shares, not six
+  # pieces of armour that always critical.
+  items = { 7 => fake_item(type: 1, critical_hit: 20),   # weapon
+            8 => fake_item(type: 1, critical_hit: 5),    # a second weapon
+            9 => fake_item(type: 3, critical_hit: 100) } # armour
+  st = crit_party(items)
+  a = st.party.actor_by_id(1)
+  a.equip([8, 7, 0, 0, 0])
+  eq 333 + 20 * Game::CRIT_PERCENT, a.crit_chance,
+     'the better of two wielded weapons, not their sum'
+  a.equip([0, 0, 9, 0, 0])
+  eq 333, a.crit_chance, 'the armour contributes nothing'
+end
+
+check 'Actor#crit_chance: a weapon arms an actor whose own rate is off' do
+  # The two are separate additive terms in RPG_RT, so the actor flag is not a
+  # master switch over the weapon. Unobservable in either test bed -- all 50 of
+  # Nepheshel's actors can crit -- so this pins the reading rather than a
+  # measured behaviour.
+  items = { 7 => fake_item(type: 1, critical_hit: 20) }
+  st = crit_party(items)
+  ally = st.party.actor_by_id(2)
+  eq 0, ally.crit_chance
+  ally.equip([7, 0, 0, 0, 0])
+  eq 20 * Game::CRIT_PERCENT, ally.crit_chance
+end
+
+check 'battle: a 100% weapon crits every swing, and still triples' do
+  st = crit_party({ 7 => fake_item(type: 1, critical_hit: 100) })
+  hero = st.party.actor_by_id(1)
+  hero.equip([7, 0, 0, 0, 0])
+  c = Game::Battle.from_actor(hero)
+  ok c.crit_chance >= Game::CRIT_SCALE, 'certainty or better'
+  # A chance at or over the scale must land on every roll, whatever the seed.
+  5.times do |i|
+    slime = combatant('Slime', 0, 0, 5, 100_000)
+    bat = Game::Battle.new([Game::Battle.from_actor(hero)], [slime],
+                           Game::Rng.new(i + 1), nil, false, true)
+    bat.begin_round
+    eq true, bat.step_action[:critical], "seed #{i + 1}"
+  end
+end
+
+# An Rng that always answers the same number, so a roll's boundary can be read
+# off exactly instead of inferred from a sample.
+class FixedRng
+  def initialize(value); @value = value; end
+  def random(n); n <= 0 ? 0 : @value % n; end
+end
+
+check 'battle: the crit roll is read against the basis-point scale' do
+  # A rate of N must crit on a roll of N-1 and not on N. This is what says the
+  # chance is a probability over CRIT_SCALE rather than a denominator: 5000 bp
+  # and "1 in 2" sample the same, but only one of them answers this.
+  [[4999, true], [5000, false], [5001, false]].each do |roll, want|
+    hero = combatant('Hero', 40, 0, 20, 100)
+    hero.crit_chance = 5000
+    slime = combatant('Slime', 0, 0, 5, 100_000)
+    bat = Game::Battle.new([hero], [slime], FixedRng.new(roll), nil, false, true)
+    bat.begin_round
+    eq want, bat.step_action[:critical], "a 5000 bp rate on a roll of #{roll}"
+  end
+end
+
+check 'battle: the crit rate is the chance, not a 1-in-N denominator' do
+  # A 2500 bp battler crits about a quarter of the time; the old model could
+  # only have said "1 in 4" and had no way to add a weapon's 20% to it.
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_chance = 2500
+  crits = 0
+  400.times do |i|
+    h = combatant('Hero', 40, 0, 20, 100)
+    h.crit_chance = 2500
+    slime = combatant('Slime', 0, 0, 5, 100_000)
+    bat = Game::Battle.new([h], [slime], Game::Rng.new(i + 1), nil, false, true)
+    bat.begin_round
+    crits += 1 if bat.step_action[:critical]
+  end
+  ok crits > 60 && crits < 140,
+     "expected roughly a quarter of 400 swings to crit, got #{crits}"
+end
+
 check 'battle: gear that prevents criticals blocks the 3x hit' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_denom = 1                                # would always crit...
+  hero.crit_chance = Game::CRIT_SCALE                # would always crit...
   slime = combatant('Slime', 0, 0, 5, 100_000)
   slime.prevents_crit = true                         # ...but the target is guarded
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -530,15 +530,21 @@ def check_equipment(dir)
   dual = []
   sure = []
   half = []
+  crit_weapons = []
+  crit_others = []
   items.each do |id, it|
     dual << id if it.type == 1 && it.dual_attack
     sure << id if it.type == 1 && it.ignore_evasion
     half << id if it.half_sp_cost
+    next unless (it.critical_hit || 0) > 0
+    (it.type == 1 ? crit_weapons : crit_others) << id
   end
   strong = []
   db[DB_ACTOR]&.each { |id, r| strong << id if r.strong_defence }
-  puts format('   equipment: %d 二刀流, %d 必中, %d MP消費半分, %d 強力防御 actor(s)',
-              dual.size, sure.size, half.size, strong.size)
+  puts format('   equipment: %d 二刀流, %d 必中, %d MP消費半分, %d 強力防御 actor(s), ' \
+              '%d 会心必殺 weapon(s) (+%d non-weapon)',
+              dual.size, sure.size, half.size, strong.size,
+              crit_weapons.size, crit_others.size)
 
   unless dual.empty?
     check "#{name}: a 二刀流 weapon makes its wielder swing twice" do
@@ -585,6 +591,49 @@ def check_equipment(dir)
         ok a.half_sp_cost?, "item ##{iid} (#{items[iid].name}) grants MP消費半分"
         eq (full + 1) / 2, party.skill_cost(sk, a),
            "and halves the #{full}-SP skill, rounding up"
+      end
+    end
+  end
+
+  unless crit_weapons.empty?
+    check "#{name}: a 会心必殺 weapon adds its own rate to its wielder's" do
+      aid = first_actor_id(db)
+      # Stripped, not fresh: an actor is built wearing its initial equipment,
+      # which for Nepheshel's first actor is already a 会心必殺 weapon.
+      bare = Game::Actor.new(db, aid)
+      bare.equip([0, 0, 0, 0, 0])
+      base = bare.crit_chance
+      crit_weapons.each do |iid|
+        a = Game::Actor.new(db, aid)
+        a.equip([iid, 0, 0, 0, 0])
+        eq base + items[iid].critical_hit * Game::CRIT_PERCENT, a.crit_chance,
+           "item ##{iid} (#{items[iid].name}) adds #{items[iid].critical_hit}%"
+        ok a.crit_chance > base, 'and the weapon really moves the rate'
+      end
+    end
+  end
+
+  unless crit_others.empty?
+    check "#{name}: a non-weapon's critical_hit field is left alone" do
+      # These are not gear that always criticals -- they are the editor leaving
+      # weapon-only fields untouched in the record every item type shares. Each
+      # one carries exactly 100 alongside a `hit` of 70, another weapon field,
+      # which is the pattern rather than a design.
+      aid = first_actor_id(db)
+      bare = Game::Actor.new(db, aid)
+      bare.equip([0, 0, 0, 0, 0])
+      base = bare.crit_chance
+      crit_others.each do |iid|
+        it = items[iid]
+        slot = it.type - 1
+        next unless slot >= 0 && slot < 5
+        gear = [0, 0, 0, 0, 0]
+        gear[slot] = iid
+        a = Game::Actor.new(db, aid)
+        a.equip(gear)
+        eq base, a.crit_chance,
+           "item ##{iid} (#{it.name}, type #{it.type}, +#{it.critical_hit}) " \
+           'must not arm its wearer'
       end
     end
   end


### PR DESCRIPTION
## The gap

`critical_hit` (item field 18) is the largest unread field in ADR 0033's equipment audit — **75 of Nepheshel's items carry one** — and the one that could not simply be read, which is why that ADR deferred it explicitly.

RPG_RT **adds** a weapon's own percentage to the wielder's 1-in-N rate. No denominator says *"1/30 and 20% more"*, so folding the bonus in means changing how a critical chance is represented at all.

## What changed

**Criticals became a probability.** `Game::Actor#crit_chance` and `Game::Enemy#crit_chance` return **basis points** over `Game::CRIT_SCALE` (10000), `Combatant` carries `crit_chance` in place of `crit_denom`, and `Battle#critical?` rolls `random(CRIT_SCALE) < chance`.

Integer basis points rather than a float, to keep the damage path on the arithmetic the rest of it uses. The cost is stated rather than hidden: a 1/30 row reads 333 bp — 3.33% against a true 3.3333…%, one crit fewer in roughly 300,000 swings.

**Only a weapon grants the bonus** — the best among those equipped, the same shape `attack_hit_rate` already uses for `hit`.

## What the real data settled

Nepheshel's bytes decide "weapons only", rather than an appeal to how the reference implementation is structured:

| | count | rates |
| --- | --- | --- |
| weapons carrying a bonus | **69** | a spread: 2, 5, 8, 10, 15, 20, 25, 30, 40, 60, 100 |
| non-weapons carrying one | **6** | **100 apiece**, every one, next to a `hit` of 70 |

The six are four pieces of armour and two accessories. Six pieces of armour that critical on every swing is not a design; a uniform 100 sitting beside a `hit` of 70 — another field the editor shows only for a weapon — is the editor leaving weapon fields untouched in the record every item type shares. mtf-meido-action carries neither kind, so Nepheshel is the only evidence either way, which is why the test-bed check asserts **both** halves.

One case is unobservable and therefore only pinned, not measured: an actor whose own `has_critical_rate` is off wielding a weapon that crits. The two are separate additive terms, so the weapon still applies — but all 50 of Nepheshel's actors and all 14 of mtf's can crit, so no shipped data exercises it. Said so in the check and the ADR rather than presented as measured.

## Before and after

Unlike the four flags in ADR 0033 — which were verified by a **byte-identical** troop sweep — this one is *meant* to move the simulation. Every troop in both beds, criticals / variance / accuracy on, seeded per troop:

| | fights | wins before | wins after | swings before | swings after |
| --- | --- | --- | --- | --- | --- |
| Nepheshel | 157 | 124 | **130** | 1620 | **1442** |
| mtf-meido-action | 88 | 54 | 54 | 1688 | 1693 |

Nepheshel's starting party wields a weapon carrying +2%, lifting its hero from 500 bp to 700 — a 40% relative increase in how often it criticals. Six more fights won, and 178 fewer swings to win them, is that bonus finally being paid.

mtf-meido-action has **no** weapon with the field and every actor on the plain 1-in-30, so its drift is not the bonus: it is the roll changing shape. `random(30) == 0` and `random(10000) < 333` are the same rate to two decimal places but map a given RNG value differently, so a seeded fight diverges where a crit lands on one and not the other. Bounded to five swings — 0.3% — with no change of outcome, in a game the feature does not otherwise touch.

## Verification

- **6 new checks in `scripts/rpg2k_logic_check.rb`** — the row rate alone in basis points; a weapon adding its percentage; the best of two wielded weapons rather than their sum, with an armour contributing nothing; a weapon arming an actor whose own rate is off; a 100% weapon critting on every seed; and the roll read against the scale with a fixed RNG (4999 crits, 5000 does not), which is what distinguishes a probability from a denominator. **538 pass.**
- **2 new checks in `scripts/rpg2k_testbed_logic_check.rb`** against the **real** item table: each of the 69 weapons adds exactly its own rate, and each of the 6 non-weapons adds nothing. It reports the per-game counts alongside the existing 二刀流 / 必中 / MP消費半分 / 強力防御 tallies. **59 pass.**
- Every new check was confirmed to **fail when the behaviour it covers is removed** — bonus not added, non-weapons counted, weapons summed instead of best, and the roll reverted to a 1-in-N shape. That last one is worth noting: it did **not** fail until the fixed-RNG boundary check was added, because a single-term rate samples identically either way. The statistical check alone would have passed a wrong model.
- `rpg2k_scene_check.rb` (165), `rpg2k_render_check.rb` (36), the 371,762-command soak, and the LCF / XP / VX bed checks all pass.

Docs: ADR 0033 gains an addendum with the decision and the measured before/after; `docs/TODO.md` and a changelog fragment updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_