### PR TITLE
Open the game's own menu in the boot check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,8 +308,9 @@ jobs:
           # catches mruby/CRuby divergence. Each bed runs *its own* engine —
           # there is no reimplemented flow any more (ADR 0030): the check taps
           # confirm on the game's own title screen, logs every scene it reaches
-          # as `[RPGXP-SCRIPTS]`/`[RPGXP-HOST-SCENE]`, and walks the party on the
-          # editor bed's map (`[RPGXP-HOST-MOVE]`). Two beds: the editor-shaped
+          # as `[RPGXP-SCRIPTS]`/`[RPGXP-HOST-SCENE]`, walks the party on the
+          # editor bed's map (`[RPGXP-HOST-MOVE]`) and opens that bed's own menu
+          # (`[RPGXP-HOST-MENU]`). Two beds: the editor-shaped
           # OpenGame test bed and the *released* Pray for You (Game.rgssad only,
           # several maps), on displays 112 and 113 — one per game (see the
           # reserved server-num map above). See

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@
   every scene the game reaches as `[RPGXP-HOST-SCENE]`. Pray for You walks its
   own `Scene_logo → Scene_Title → Scene_Map`; the test bed is then made to walk
   its party (`[RPGXP-HOST-MOVE]`), which is what proves a game's own
-  `Game_Player` is reading input and stepping across its own passability.
+  `Game_Player` is reading input and stepping across its own passability, and to
+  open its own menu (`[RPGXP-HOST-MENU]`) — the first thing a game draws out of
+  its own `Window` subclasses, windowskin and font.
   `scripts/rpgxp_script_host_check.rb` covers the same ground under CRuby —
   every section of both bundles evaluates, and the RGSS standard library behaves
 - `scripts/compare-rpgxp-wine.bash` diffs our frames against the **genuine RGSS

--- a/changelog.d/rgss-host-menu-test.added.md
+++ b/changelog.d/rgss-host-menu-test.added.md
@@ -1,0 +1,10 @@
+- **`--rgss_host_menu_test` opens a game's own menu.** Once the game is on its
+  own map — and done walking, when `--rgss_host_move_test` is on too — the host
+  presses cancel through the same input buffer a keyboard feeds and reports where
+  the game went as `[RPGXP-HOST-MENU] scene=.. opened=.. frame=..`, read from the
+  game's own `$scene`. That is the rung above walking: a menu is the first thing
+  a game draws out of its *own* `Window_Base` subclasses, its own windowskin, its
+  own font and its own `Bitmap#draw_text`, none of which a map scene touches.
+  `scripts/rpgxp_boot_check.bash` asserts it on the editor test bed (stock
+  scripts, menu enabled) in the same pass as the walk, and logs it for a released
+  game, which opens on a cutscene where a menu that does not open says nothing.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -170,6 +170,14 @@ as `[RPGXP-HOST-SCENE]` (read from the game's own `$scene` global). Reaching a
 second scene is what `scripts/rpgxp_boot_check.bash` now asserts — the proof that
 a game's engine took a keypress and acted on it, rather than merely drawing.
 
+`--rgss_host_move_test` and `--rgss_host_menu_test` are the two rungs above that,
+run in the same pass: walk the party across the game's own passability
+(`[RPGXP-HOST-MOVE]`), then press cancel and report where the game went
+(`[RPGXP-HOST-MENU]`). The menu is the interesting one for this document — it is
+the first thing a game draws out of its *own* `Window_Base` subclasses, its own
+windowskin, its own font and its own `Bitmap#draw_text`, none of which a map
+scene touches. Whatever it reports is the next entry here.
+
 ### 0e. `Kernel#Integer()` ✅ (the first thing New Game runs)
 
 With input working, both beds get *into* the game — and stop where every RGSS

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -238,14 +238,17 @@ class RPGXP
     #     off the game's own title screen without a keyboard.
     #   * with --rgss_host_move_test, walk the party once the game's own map
     #     scene is up and report whether it moved.
+    #   * with --rgss_host_menu_test, press cancel after that and report which
+    #     scene the game went to — its own menu, if it has one.
     def self.watch_frame
       @frames += 1
       report_scene
-      # While the move probe is holding a direction, stop tapping confirm: a
-      # confirm on a map talks to whatever is in front of the party, and a
-      # message window would swallow the walk.
-      confirm_tap if auto_new_game? && !probing_move?
+      # While a probe is driving the keyboard, stop tapping confirm: a confirm
+      # on a map talks to whatever is in front of the party, and a message
+      # window would swallow the walk — or pick an item out of the menu.
+      confirm_tap if auto_new_game? && !probing_move? && !probing_menu?
       move_probe if move_test?
+      menu_probe if menu_test?
     end
 
     def self.report_scene
@@ -355,6 +358,51 @@ class RPGXP
                       RGSS::Input::RIGHT, RGSS::Input::UP]
     end
 
+    # Press cancel on the game's own map and report where that took it.
+    #
+    # The rung above walking. A game's menu is the first thing it draws out of
+    # its *own* `Window_Base` subclasses — its windowskin, its font, its
+    # `Bitmap#draw_text`, its `Window_Selectable` cursor — none of which a map
+    # scene exercises, and all of which this engine supplies natively. So the
+    # scene name this reports is a one-line answer to "does the class library
+    # hold up once a game starts drawing its own UI".
+    #
+    # Deliberately only the *first* press: the stock `Scene_Map` opens
+    # `Scene_Menu` on `Input.trigger?(Input::B)`, and going deeper would be
+    # picking items out of a menu whose contents differ per game.
+    MENU_SETTLE = 20        # frames after the walk before pressing cancel
+    MENU_HOLD = 4           # frames the cancel key is held
+    MENU_WAIT = 60          # frames to let the game's own menu scene come up
+
+    def self.probing_menu?
+      menu_test? && !@menu_start.nil? && !@menu_done
+    end
+
+    def self.menu_probe
+      return if @menu_done || @map_frame.nil?
+      # Wait for the walk when there is one: a cancel press mid-walk would open
+      # the menu over it and the walk would report nothing.
+      return if move_test? && !@move_done
+      @menu_start ||= @frames
+      step = @frames - @menu_start - MENU_SETTLE
+      return if step < 0
+      RGSS::Input._push(RGSS::Input::B, true) if step.zero?
+      RGSS::Input._push(RGSS::Input::B, false) if step == MENU_HOLD
+      finish_menu_probe if step >= MENU_WAIT
+    end
+
+    def self.finish_menu_probe
+      @menu_done = true
+      scene = $scene
+      name = scene.nil? ? "?" : scene.class.to_s
+      # "Opened" means the game left its map for something else — which is what
+      # cancel does on a stock map, and what a game with its own menu script
+      # does too. A game that disables the menu, or one still in its opening
+      # cutscene, simply stays put and says so.
+      $stderr.puts "[RPGXP-HOST-MENU] scene=#{name} " \
+                   "opened=#{!map_scene?(name)} frame=#{@frames}"
+    end
+
     # The party leader's tile, or nil before the game has one.
     def self.player_tile
       player = $game_player
@@ -380,6 +428,12 @@ class RPGXP
 
     def self.move_test?
       RGSS_HOST_MOVE_TEST
+    rescue StandardError
+      false
+    end
+
+    def self.menu_test?
+      RGSS_HOST_MENU_TEST
     rescue StandardError
       false
     end

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -24,6 +24,12 @@
 #     which is asserted for the editor test bed: its start map is plain and
 #     walkable. A released game opens on a cutscene, so its walk is logged and
 #     not asserted.
+#   * then `--rgss_host_menu_test` presses cancel and reports where the game
+#     went as `[RPGXP-HOST-MENU] scene=.. opened=..`. That is the rung above
+#     walking: a game's menu is the first thing it draws out of its own Window
+#     classes, its own windowskin and its own font, none of which a map scene
+#     touches. Asserted on the editor bed (stock scripts, menu enabled), logged
+#     on the released game.
 #   * a `script host failed` line fails the run: the game's own scripts stopping
 #     is the failure this check exists to catch.
 #
@@ -75,14 +81,17 @@ num="${SERVER_NUM}"
 
 # One headless run of the engine.
 #   $1 game dir, $2 display number, $3 what the run is called in the log,
-#   $4 the marker its log must contain, $5 extra engine flags (may be empty),
-#   $6 how many [RPGXP-HOST-SCENE] lines the game must reach (0 = do not check)
+#   $4 extra engine flags (may be empty),
+#   $5 how many [RPGXP-HOST-SCENE] lines the game must reach (0 = do not check),
+#   $6.. the markers its log must contain (all of them)
 # A run fails when the engine exits non-zero (any uncaught mruby exception aborts
-# it), when its marker is missing, when the script host reported a failure inside
+# it), when a marker is missing, when the script host reported a failure inside
 # the game's own scripts, or when the game never got past its first scene.
 run_boot() {
-    local game="$1" display="$2" label="$3" marker="$4" flags="$5" scenes="${6:-0}"
-    local log rc=0
+    local game="$1" display="$2" label="$3" flags="$4" scenes="${5:-0}"
+    shift 5
+    local markers=("$@")
+    local log rc=0 marker missing=""
     log="$(mktemp)"
     echo "-- ${label}"
     # Each run gets its own display number: xvfb-run -a's probe is not atomic
@@ -93,14 +102,19 @@ run_boot() {
             --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
         echo "FAILED: ${game} (${label}): the engine exited non-zero" >&2
         rc=1
-    elif ! grep -q "${marker}" "${log}" ; then
-        echo "FAILED: ${game} (${label}): ${marker} missing" >&2
+    else
+        for marker in "${markers[@]}" ; do
+            grep -q "${marker}" "${log}" || missing="${missing} ${marker}"
+        done
+    fi
+    if [ "${rc}" -eq 0 ] && [ -n "${missing}" ] ; then
+        echo "FAILED: ${game} (${label}): missing${missing}" >&2
         rc=1
-    elif grep -q 'script host failed' "${log}" ; then
+    elif [ "${rc}" -eq 0 ] && grep -q 'script host failed' "${log}" ; then
         echo "FAILED: ${game} (${label}): the game's own scripts stopped" >&2
         grep 'script host failed' "${log}" >&2
         rc=1
-    elif [ "${scenes}" -gt 0 ] &&
+    elif [ "${rc}" -eq 0 ] && [ "${scenes}" -gt 0 ] &&
              [ "$(grep -c '\[RPGXP-HOST-SCENE\]' "${log}")" -lt "${scenes}" ] ; then
         # One scene means the game drew its title and stayed there: the keypress
         # never reached its own engine, or its first screen could not act on it.
@@ -108,8 +122,10 @@ run_boot() {
              "(wanted ${scenes} scenes)" >&2
         grep '\[RPGXP-HOST-SCENE\]' "${log}" >&2
         rc=1
-    else
-        grep "${marker}" "${log}"
+    elif [ "${rc}" -eq 0 ] ; then
+        for marker in "${markers[@]}" ; do
+            grep "${marker}" "${log}"
+        done
     fi
     # ALSA has no device under CI and floods stderr; keep the rest.
     grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -40 || true
@@ -125,15 +141,18 @@ for game in "${GAMES[@]}" ; do
     checked=$((checked + 1))
     echo "== ${game}"
 
-    # The editor test bed opens on a plain walkable map, so its walk is the
-    # assertion; a released game opens on a cutscene, where a walk that does not
-    # happen says nothing about the engine. Both log everything either way.
+    # The editor test bed opens on a plain walkable map with the stock scripts,
+    # so its walk and its menu are both assertions; a released game opens on a
+    # cutscene, where a walk that does not happen and a menu that does not open
+    # say nothing about the engine. Both log everything either way.
     case "${game}" in
-        *Testbed*) marker='\[RPGXP-HOST-MOVE\] .*moved=true' ;;
-        *)         marker='\[RPGXP-HOST-SCENE\]' ;;
+        *Testbed*) markers=('\[RPGXP-HOST-MOVE\] .*moved=true'
+                            '\[RPGXP-HOST-MENU\] .*opened=true') ;;
+        *)         markers=('\[RPGXP-HOST-SCENE\]') ;;
     esac
-    run_boot "${game}" "${num}" "script host" "${marker}" \
-        "--rgss_host_move_test" 2 || failed=$((failed + 1))
+    run_boot "${game}" "${num}" "script host" \
+        "--rgss_host_move_test --rgss_host_menu_test" 2 "${markers[@]}" ||
+        failed=$((failed + 1))
 
     num=$((num + 1))
 done

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -87,6 +87,15 @@ DEFINE_bool(
     "Used "
     "by scripts/rpgxp_boot_check.bash");
 DEFINE_bool(
+    rgss_host_menu_test,
+    false,
+    "For the RGSS makers under the script host: once the game is on its own "
+    "map (and done walking, if --rgss_host_move_test is on too) press the "
+    "cancel key and log which scene the game went to as [RPGXP-HOST-MENU] "
+    "(implies --rgss_host_new_game). The rung above walking: a game's own menu "
+    "is the first thing it draws out of its own Window classes, its own "
+    "windowskin and its own font. Used by scripts/rpgxp_boot_check.bash");
+DEFINE_bool(
     mv_new_game,
     false,
     "For RPG Maker MV: once the title screen appears, auto-select New Game so "
@@ -811,15 +820,19 @@ int main(int argc, char** argv) {
                 mrb_bool_value(FLAGS_rgss_script_host));
   // Whether the script host taps confirm on the game's own title screen (see
   // RPGXP::ScriptHost.watch_frame).
-  // The move probe implies the confirm tap: it has to get onto a map first,
-  // which means getting off the game's own title screen.
+  // The move and menu probes imply the confirm tap: both have to get onto a map
+  // first, which means getting off the game's own title screen.
   mrb_const_set(
       M, mrb_obj_value(M->object_class),
       mrb_intern_lit(M, "RGSS_HOST_NEW_GAME"),
-      mrb_bool_value(FLAGS_rgss_host_new_game || FLAGS_rgss_host_move_test));
+      mrb_bool_value(FLAGS_rgss_host_new_game || FLAGS_rgss_host_move_test ||
+                     FLAGS_rgss_host_menu_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RGSS_HOST_MOVE_TEST"),
                 mrb_bool_value(FLAGS_rgss_host_move_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RGSS_HOST_MENU_TEST"),
+                mrb_bool_value(FLAGS_rgss_host_menu_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));


### PR DESCRIPTION
The boot check gets each bed onto its own map and walks its party across its own
passability. The rung above that is the **menu**: it is the first thing a game
draws out of its *own* `Window_Base` subclasses, its own windowskin, its own font
and its own `Bitmap#draw_text` — none of which a map scene touches. That whole
surface is native code here, and nothing was exercising it against real game
scripts.

## What it does

`--rgss_host_menu_test` presses cancel through the same input buffer a keyboard
feeds — after the walk, when `--rgss_host_move_test` is on too, since a cancel
mid-walk would open the menu over it — and reports where the game went, read from
its own `$scene`:

```
[RPGXP-HOST-MENU] scene=Scene_Menu opened=true frame=301
```

Only the *first* press. The stock `Scene_Map` opens `Scene_Menu` on
`Input.trigger?(Input::B)`, and going deeper would mean picking items out of a
menu whose contents differ per game. Confirm taps stop while either probe is
driving the keyboard, for the same reason.

## The check

`scripts/rpgxp_boot_check.bash` runs it in the **same pass** as the walk rather
than a second boot — a run costs its whole timeout in wall clock, and the frame
budget has room (the map appears at frame 41, the walk finishes at 221, the menu
lands around 301, well inside the 45 s at the ~11 fps an unaccelerated CI display
manages). So `run_boot` now takes a list of markers instead of one and asserts
both on the editor bed (stock scripts, menu enabled). A released game opens on a
cutscene, where a menu that does not open says nothing about the engine, so there
it is logged.

## Why this is worth a CI round on its own

ADR 0030 moved the measure from "a stand-in agrees with itself" to "games get
further", and every gap since has been found by a game reaching somewhere new —
`Integer()` at New Game, `rand` placing the party, `Table#[]=` on a map,
`#clone` on a screen tone, `Math` on the first jump. The menu is the next place
worth reaching, and whatever it reports becomes the next entry in
`docs/rpgxp-rgss-api-gap.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_