### PR TITLE
Let a jump look like one

### DIFF
--- a/changelog.d/jump-arc.added.md
+++ b/changelog.d/jump-arc.added.md
@@ -1,0 +1,10 @@
+- **A jumping event now arcs instead of teleporting.** Begin Jump / End Jump
+  moved the character in one step and the sprite went with it, so the hop that
+  clears a chasm was drawn as a blink. The sprite slides across the whole hop and
+  is lifted along the way, a port of EasyRPG's `Game_Character::GetJumpHeight`
+  (peaking at 21px on a 16px tile). The lift is applied where the sprite is
+  blitted, not to its position, so the camera and the draw order still see it on
+  the ground.
+- **A jump that lands on the tile it left was impossible.** `char_can_land?`
+  refused it because the tile is occupied — by the jumper itself. RPG2000 hops in
+  place, and a character never blocks its own landing.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -204,10 +204,34 @@ The work below is roughly ordered by the critical path to a walkable game
   "may I leave this tile" half of its check while jumping. Nepheshel has 625 jump
   blocks, every one enclosing a runtime-directed move (484 away from the hero,
   188 toward it, 133 forward) rather than a literal direction, and 141 enclose
-  more than one, so those now clear the tile they hop over. Remaining: the visual
-  arc — RPG_RT lifts the sprite along the hop and this build snaps it to the
-  landing tile, which needs the same per-frame sprite offset the walk
-  interpolation already has
+  more than one, so those now clear the tile they hop over.
+  **The hop is drawn as one now, too.** The move happened in a single step and
+  the sprite went with it, so a jump — the move whose whole point is being
+  airborne — was a blink from one tile to another. A jumping event slides across
+  the *whole* hop (the one kind of move that does; anything else longer than a
+  step still snaps rather than streaking) and is lifted along the way by
+  `Scene::Map#event_jump_offset`, a port of EasyRPG's
+  `Game_Character::GetJumpHeight`: the height tracks the remaining step, peaks at
+  the midpoint and is then stretched — doubled while small, offset by 5 past 4 —
+  which is what makes the hop leave the ground sharply and hang near the top. It
+  peaks at 21px on a 16px tile, so a jumping sprite clearly leaves its row. The
+  lift is applied where the sprite is **blitted**, not to its position, so the
+  camera and the y-sorted draw order still see the character on the ground, as
+  RPG_RT does. `Game::Character#jumped` is what tells the renderer which kind of
+  move it is watching, since the distance cannot: a jump can land one tile away
+  or on the tile it left, and every ordinary move (including being *placed* by
+  Change Event Location) clears it.
+  Drawing the arc turned up a hop that could never happen: `char_can_land?`
+  refused a jump onto the character's **own** tile, because that tile is occupied
+  — by the jumper. RPG2000 hops in place, so a character no longer blocks its own
+  landing. It was invisible while there was nothing on screen to notice it by.
+  Events are what jump in the real games: of Nepheshel's 634 Begin Jump blocks,
+  **632 drive an event** (625 of them a page's own autonomous route) and two the
+  player; mtf-meido-action's single block drives the player. The player's own
+  forced-route movement still snaps tile to tile — not only its jumps — which is
+  a separate gap: `step_player_route` sets the position outright where the
+  input path interpolates. Remaining: the player half, once forced player routes
+  interpolate at all
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2728,9 +2728,16 @@ module Game
     # The four cardinal directions, indexable for random selection.
     CARDINALS = [2, 4, 6, 8].freeze
 
-    attr_accessor :x, :y, :direction, :move_speed, :move_frequency
+    attr_accessor :direction, :move_speed, :move_frequency
     attr_accessor :through, :facing_locked, :animation_stopped, :transparency
-    attr_reader :graphic_name, :graphic_index
+    attr_reader :graphic_name, :graphic_index, :x, :y
+
+    # Placing a character outright -- Change Event Location, a page refresh
+    # restoring where an event stood -- is not a move, so it clears #jumped.
+    # Without this a character that had jumped would arc again the next time
+    # something snapped it to a tile.
+    def x=(v); @x = v; @jumped = false; end
+    def y=(v); @y = v; @jumped = false; end
 
     def initialize(x = 0, y = 0, direction = 2)
       @x = x
@@ -2744,6 +2751,7 @@ module Game
       @transparency = 0         # 0 opaque .. 7 fully transparent
       @graphic_name = nil
       @graphic_index = 0
+      @jumped = false
     end
 
     def set_graphic(name, index)
@@ -2768,12 +2776,21 @@ module Game
       @direction = dir unless @facing_locked || dir.nil?
     end
 
+    # Whether the move just made was a jump (a Begin Jump / End Jump block)
+    # rather than a step. The renderer reads it to lift the sprite along an arc
+    # instead of sliding it flat, so it describes the *last* move and every
+    # ordinary move clears it. A jump that lands where it started still sets it:
+    # RPG_RT hops in place, and the flag rather than the distance is what says
+    # so.
+    attr_reader :jumped
+
     # Move one tile in `dir`, updating facing (subject to the lock).
     def move(dir)
       face(dir)
       dx, dy = DIR_DELTA[dir] || [0, 0]
       @x += dx
       @y += dy
+      @jumped = false
     end
 
     # Land on (x, y) in one hop — the move-route Begin Jump / End Jump pair,
@@ -2792,6 +2809,7 @@ module Game
       end
       @x = x
       @y = y
+      @jumped = true
     end
 
     # Move one tile diagonally, combining a horizontal and a vertical direction.
@@ -2802,6 +2820,7 @@ module Game
       _, vy = DIR_DELTA[vertical] || [0, 0]
       @x += hx
       @y += vy
+      @jumped = false
     end
 
     def turn_right;  @direction = TURN_RIGHT[@direction] || @direction; end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -1058,10 +1058,13 @@ class RPG2k
           # animation phase / counter, a mid-step "moving" flag, and the pixel
           # slide (display origin disp_x/disp_y + move_count 0..TILE) that eases
           # the sprite between tiles. move_count == TILE means "at rest".
+          # `jumping` marks that slide as a hop, which is lifted along an arc
+          # and is the one kind that slides across more than a single tile.
           layer: page_layer(page), translucent: page_translucent(page),
           anim_type: page_anim_type(page), base_dir: dir,
           base_pattern: page_pattern(page), anim_phase: 0, anim_count: 0,
-          moving: false, disp_x: ev.x, disp_y: ev.y, move_count: TILE }
+          moving: false, disp_x: ev.x, disp_y: ev.y, move_count: TILE,
+          jumping: false }
       end
 
       # Build the Call Event resolver for the current map: common events keyed by
@@ -1449,7 +1452,9 @@ class RPG2k
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
           move_autonomous(e, dir) if dir
         end
-        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
+        # A jump that lands where it started still needs the render slide, so
+        # the hop is visible; an ordinary step only when the tile changed.
+        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy || ch.jumped
       rescue StandardError => ex
         $stderr.puts "[RPG2k] event ##{e[:id]} movement failed: #{ex.message}"
         nil
@@ -1483,8 +1488,11 @@ class RPG2k
       # Whether an event is mid-step: its display origin has not yet caught up to
       # its logical tile (the slide started by reoccupy is still in progress).
       def event_sliding?(e)
-        e[:move_count] < TILE &&
-          (e[:disp_x] != e[:char].x || e[:disp_y] != e[:char].y)
+        return false unless e[:move_count] < TILE
+        # A jump that lands on its own tile moves the sprite nowhere but is
+        # still in progress, so it cannot be recognised by the displacement.
+        e[:jumping] ||
+          e[:disp_x] != e[:char].x || e[:disp_y] != e[:char].y
       end
 
       # Move an autonomous event one step in `dir`. Walking into the player fires
@@ -1515,19 +1523,50 @@ class RPG2k
       end
 
       # Begin a render slide for event `e` that just stepped off (ox, oy): the
-      # sprite eases from that tile to its new one over TILE/SPEED frames. Only
-      # single-tile cardinal steps slide; a longer hop (a jump, or a diagonal of
-      # more than one tile) snaps so the sprite never streaks across the map.
+      # sprite eases from that tile to its new one over TILE/SPEED frames.
+      #
+      # A single-tile cardinal step slides, and so does a **jump**, however far
+      # it goes -- RPG_RT carries the sprite across the whole hop and lifts it
+      # along the way (see event_jump_offset), which is the point of a jump
+      # clearing the tiles between. Anything else -- a multi-tile displacement
+      # that is not a jump -- snaps, so a sprite never streaks across the map.
       def start_event_slide(e, ox, oy)
-        if (e[:char].x - ox).abs + (e[:char].y - oy).abs == 1
+        jumped = e[:char].jumped
+        if jumped || (e[:char].x - ox).abs + (e[:char].y - oy).abs == 1
           e[:disp_x] = ox
           e[:disp_y] = oy
           e[:move_count] = 0
+          e[:jumping] = jumped
         else
           e[:disp_x] = e[:char].x
           e[:disp_y] = e[:char].y
           e[:move_count] = TILE
+          e[:jumping] = false
         end
+      end
+
+      # How far event `e`'s sprite is lifted off the ground this frame, in
+      # pixels: 0 unless a jump is in progress, otherwise RPG_RT's arc.
+      #
+      # A port of EasyRPG's `Game_Character::GetJumpHeight`, kept in its own
+      # 256-per-tile units so the formula reads as it does there: the height
+      # rises and falls linearly with the remaining step, peaking at the
+      # midpoint, and is then stretched -- doubled while small, offset by 5 once
+      # past 4 -- which is what makes the hop leave the ground sharply and hang
+      # near the top. The peak is 21px on a 16px tile, so a jumping sprite
+      # clearly leaves its row.
+      #
+      # The lift is applied where the sprite is blitted, not inside #event_pixel:
+      # RPG_RT raises the drawn character without moving it, so its logical
+      # position -- what the camera follows and what the draw order sorts on --
+      # stays on the ground.
+      JUMP_STEP_UNITS = 256              # EasyRPG's SCREEN_TILE_SIZE
+      def event_jump_offset(e)
+        return 0 unless e[:jumping] && e[:move_count] < TILE
+        remaining = (TILE - e[:move_count]) * (JUMP_STEP_UNITS / TILE)
+        half = JUMP_STEP_UNITS / 2
+        h = (remaining > half ? JUMP_STEP_UNITS - remaining : remaining) / 8
+        h < 5 ? h * 2 : h + 5
       end
 
       # Current position of event `e` in map pixels, interpolated from its
@@ -2140,7 +2179,9 @@ class RPG2k
         oy = ch.y
         e[:forced_route].step(ch, @world) unless e[:forced_route].done?
         e[:forced_route] = nil if e[:forced_route].done?
-        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy
+        # A jump that lands where it started still needs the render slide, so
+        # the hop is visible; an ordinary step only when the tile changed.
+        reoccupy(e, ox, oy) if ch.x != ox || ch.y != oy || ch.jumped
       rescue StandardError => ex
         $stderr.puts "[RPG2k] forced movement failed: #{ex.message}"
         e[:forced_route] = nil # drop a broken route so Proceed does not hang
@@ -2186,6 +2227,12 @@ class RPG2k
       # while jumping, which is what lets a jump clear a wall.
       def char_can_land?(character, x, y)
         return true if character.through
+        # A hop that lands on the tile it left is always allowed: the character
+        # occupies that tile itself, so every occupancy test below would refuse
+        # it and RPG2000's hop-in-place could never happen. Found by drawing the
+        # arc -- the in-place hop was silently impossible before there was
+        # anything on screen to notice it by.
+        return true if x == character.x && y == character.y
         return false unless @map.in_bounds?(x, y)
         return false if x == @state.x && y == @state.y
         return false if @event_tiles[[x, y]]
@@ -5146,7 +5193,7 @@ class RPG2k
         sx, sy, sw, sh = Game::CharSet.frame_rect(e[:char].graphic_index, dir, col)
         epx, epy = event_pixel(e)
         dx = epx - cam_x - (Game::CharSet::WIDTH - TILE) / 2
-        dy = epy - cam_y - (Game::CharSet::HEIGHT - TILE)
+        dy = epy - cam_y - (Game::CharSet::HEIGHT - TILE) - event_jump_offset(e)
         src = Rect.new(sx, sy, sw, sh)
         toned = e[:flash] && flashed_charset(charset, src, e[:flash])
         if toned
@@ -5183,7 +5230,7 @@ class RPG2k
         sx, sy, sw, sh = Game::ChipsetLayout.event_tile_rect(e[:char].graphic_index)
         epx, epy = event_pixel(e)
         dx = epx - cam_x
-        dy = epy - cam_y
+        dy = epy - cam_y - event_jump_offset(e)
         bmp.blt dx, dy, @chipset_bmp, Rect.new(sx, sy, sw, sh), opacity
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -213,6 +213,55 @@ check 'a jump block hops to its accumulated destination in one step' do
   eq [2, 2], [c.x, c.y]
 end
 
+check 'a character records that its last move was a jump' do
+  # The renderer lifts a jumping sprite along an arc, and needs to be told which
+  # kind of move it is watching. Distance cannot say so: a jump can land one
+  # tile away, or on the tile it left.
+  c = Game::Character.new(0, 0)
+  w = FakeWorld.new
+  eq false, c.jumped, 'a fresh character has not jumped'
+
+  c.move(6)
+  eq false, c.jumped, 'an ordinary step is not a jump'
+
+  R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::END_JUMP)],
+        repeat: false).step(c, w)
+  eq true, c.jumped, 'a one-tile hop is still a jump'
+
+  c.move(6)
+  eq false, c.jumped, 'and the next step clears it'
+
+  c.move_diagonal(6, 2)
+  eq false, c.jumped, 'a diagonal step is not a jump either'
+end
+
+check 'a jump that lands where it started still counts as a jump' do
+  # RPG_RT hops in place, so the flag rather than the displacement is what the
+  # renderer has to go on.
+  c = Game::Character.new(3, 3, 8)
+  R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_LEFT), mc(R::END_JUMP)],
+        repeat: false).step(c, FakeWorld.new)
+  eq [3, 3], [c.x, c.y], 'back where it started'
+  eq true, c.jumped
+  eq 8, c.direction, 'and a jump going nowhere leaves the facing alone'
+end
+
+check 'placing a character outright is not a jump' do
+  # Change Event Location snaps a character to a tile. Without clearing the
+  # flag, an event that had jumped would arc again the next time one moved it.
+  c = Game::Character.new(0, 0)
+  R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::END_JUMP)],
+        repeat: false).step(c, FakeWorld.new)
+  eq true, c.jumped
+  c.x = 5
+  eq false, c.jumped
+  R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_DOWN), mc(R::END_JUMP)],
+        repeat: false).step(c, FakeWorld.new)
+  eq true, c.jumped
+  c.y = 9
+  eq false, c.jumped
+end
+
 check 'a jump faces its dominant axis, not its last move' do
   # Two right, two down: a tie on distance, which RPG_RT settles vertically.
   route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_RIGHT),

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -430,6 +430,93 @@ check 'a custom-route jump clears a tile and stops at the map edge' do
   eq 1, c.y
 end
 
+check 'a jumping event slides across the whole hop instead of snapping' do
+  # A two-tile hop used to jump the sprite straight to the landing tile: only a
+  # single-tile step slid, and a jump is never that. The event is the subject
+  # here because it is what jumps in the real games -- 632 of Nepheshel's 634
+  # Begin Jump blocks drive an event (625 of them a page's own route), against
+  # two that drive the player.
+  ev = event(0, 1, page(x_move_type: Game::MoveType::CUSTOM,
+                        route: move_route([R::BEGIN_JUMP, R::MOVE_RIGHT,
+                                           R::MOVE_RIGHT, R::END_JUMP])))
+  scene = new_scene({ 1 => ev }, player: [5, 5])
+  seen = []
+  60.times do
+    scene.update
+    e = scene.instance_variable_get(:@events).first
+    seen << scene.send(:event_pixel, e)[0] if e[:jumping]
+  end
+  ok seen.size >= 4, "the hop was drawn over several frames, got #{seen.size}"
+  ok seen.uniq.size > 1, 'and the sprite actually travelled'
+  ok seen.min >= 0 && seen.max <= 4 * Game::TILE,
+     "the slide stayed between the take-off and landing tiles: #{seen.minmax}"
+end
+
+check 'a jumping sprite is lifted off the ground and comes back down' do
+  ev = event(0, 1, page(x_move_type: Game::MoveType::CUSTOM,
+                        route: move_route([R::BEGIN_JUMP, R::MOVE_RIGHT,
+                                           R::MOVE_RIGHT, R::END_JUMP])))
+  scene = new_scene({ 1 => ev }, player: [5, 5])
+  heights = []
+  40.times do
+    scene.update
+    e = scene.instance_variable_get(:@events).first
+    heights << scene.send(:event_jump_offset, e) if e[:jumping]
+  end
+  ok heights.max > 0, 'the sprite left the ground'
+  eq 21, heights.max, "RPG_RT's arc peaks at 21px on a 16px tile"
+  # It is an arc, not a step up: it rises from nothing and returns.
+  peak = heights.index(heights.max)
+  ok peak > 0, 'the hop starts on the ground'
+  ok heights[0...peak] == heights[0...peak].sort,
+     "rises to the peak: #{heights.inspect}"
+end
+
+check 'an event that walks is never lifted' do
+  ev = event(0, 1, page(x_move_type: Game::MoveType::CUSTOM,
+                        route: move_route([R::MOVE_RIGHT])))
+  scene = new_scene({ 1 => ev }, player: [5, 5])
+  40.times do
+    scene.update
+    e = scene.instance_variable_get(:@events).first
+    eq false, e[:jumping], 'a walking step is not a hop'
+    eq 0, scene.send(:event_jump_offset, e)
+  end
+end
+
+check 'a jump that lands on its own tile still hops visibly' do
+  # Nothing moves, so the slide cannot be recognised from the displacement --
+  # only the jump flag says the sprite should leave the ground at all.
+  ev = event(2, 1, page(x_move_type: Game::MoveType::CUSTOM,
+                        route: move_route([R::BEGIN_JUMP, R::MOVE_RIGHT,
+                                           R::MOVE_LEFT, R::END_JUMP])))
+  scene = new_scene({ 1 => ev }, player: [5, 5])
+  lifted = 0
+  40.times do
+    scene.update
+    e = scene.instance_variable_get(:@events).first
+    lifted += 1 if scene.send(:event_jump_offset, e) > 0
+  end
+  ok lifted > 0, 'a hop in place still leaves the ground'
+  c = chars(scene)[1]
+  eq [2, 1], [c.x, c.y], 'and it landed back where it started'
+end
+
+check 'Change Event Location does not arc the event it snaps' do
+  # A snap moves an event further than a step, which is exactly the shape that
+  # now slides when it is a jump. It must not be mistaken for one.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [ECmd.new(ic::CHANGE_EVENT_LOCATION, [1, 0, 4, 2])]
+  scene = new_scene({ 1 => event(0, 1, page), 2 => event(5, 5, pg) },
+                    player: [5, 0])
+  20.times { scene.update }
+  e = scene.instance_variable_get(:@events).find { |x| x[:id] == 1 }
+  eq [4, 2], [e[:char].x, e[:char].y], 'the snap landed'
+  eq false, e[:jumping], 'a snap is not a hop'
+  eq 0, scene.send(:event_jump_offset, e), 'so the sprite is not lifted'
+end
+
 # -- event page refresh -------------------------------------------------------
 
 # An event with two pages: page 1 unconditional, page 2 gated on switch


### PR DESCRIPTION
## The gap

Begin Jump / End Jump moved the character in a single step and the sprite went with it, so the move whose whole point is *being airborne* was drawn as a blink from one tile to the next. `start_event_slide` snapped it deliberately — only a single-tile cardinal step slid, and a jump is never that.

## What changed

A jumping event now **slides across the whole hop** — the one kind of move that does; anything else longer than a step still snaps rather than streaking across the map — and `Scene::Map#event_jump_offset` **lifts the sprite along the way**.

The arc is a port of EasyRPG's `Game_Character::GetJumpHeight`, kept in its 256-per-tile units so the formula reads as it does there: the height tracks the remaining step, peaks at the midpoint, then is stretched — doubled while small, offset by 5 once past 4 — which is what makes the hop leave the ground sharply and hang near the top. It peaks at **21px on a 16px tile**, so a jumping sprite clearly leaves its row.

The lift is applied **where the sprite is blitted, not to its position**. RPG_RT raises the drawn character without moving it, so the camera and the y-sorted draw order still see it on the ground.

`Game::Character#jumped` is what tells the renderer which kind of move it is watching, because the distance cannot — a jump can land one tile away, or on the tile it left. Every ordinary move clears it, **including being placed** by Change Event Location, without which a snapped event would arc.

## A hop that could never happen

Drawing the arc turned one up. `char_can_land?` refused a jump onto the character's **own** tile, because that tile is occupied — by the jumper itself. RPG2000 hops in place, so a character no longer blocks its own landing.

Flagging it because **this is a movement change, not only a visual one**: a zero-displacement jump used to be blocked (retried, or skipped on a skippable route) and now succeeds. It was invisible while there was nothing on screen to notice it by, which is how it survived the original jump work.

## Who actually jumps

Counted rather than assumed — and worth noting the TODO's existing figure of 625 checks out, but only once you look in the right place: they are in event pages' own autonomous routes, not in Move Event commands.

| | event page's own route | Move Event → this event | → another event | → the player |
| --- | --- | --- | --- | --- |
| Nepheshel | **625** | 4 | 3 | 2 |
| mtf-meido-action | 0 | 0 | 0 | 1 |

So **632 of Nepheshel's 634 blocks drive an event**, which is what this change covers.

The player's own forced-route movement still snaps tile to tile — **not only its jumps**: `step_player_route` sets the position outright where the input path interpolates. That is a separate and larger gap, so it is stated in `docs/TODO.md` rather than half-built here; the three player jumps across both beds sit inside it.

## Verification

- **3 new checks in `scripts/rpg2k_logic_check.rb`** — a character records that its last move was a jump and an ordinary step or diagonal clears it; a jump landing where it started still counts (and leaves the facing alone); placing a character outright is not a jump. **541 pass.**
- **5 new checks in `scripts/rpg2k_scene_check.rb`** — the hop is drawn over several frames and travels between the take-off and landing tiles; the sprite is lifted and returns, peaking at exactly 21px; a walking event is never lifted; a hop in place still leaves the ground; a Change Event Location snap neither hops nor lifts. **170 pass.**
- Every new check was confirmed to **fail when the behaviour it covers is removed** — six deliberate breakages: the jump snapping again, the lift returning 0, the arc without its stretch (peak drops to 16), the own-tile landing blocked again, the `jumped` flag never set, and placing not clearing it.
- `rpg2k_testbed_logic_check.rb` (59), `rpg2k_render_check.rb` (36), the 371,762-command soak and the LCF / XP / VX bed checks all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_