### PR TITLE
Pay out a crit chance at the rate it states

### DIFF
--- a/changelog.d/crit-roll-modulo-bias.fixed.md
+++ b/changelog.d/crit-roll-modulo-bias.fixed.md
@@ -1,0 +1,20 @@
+- **A critical chance is paid out at the rate it states.** Moving criticals to a
+  basis-point probability left the roll drawing through `Rng#random(10000)`, and
+  the generator's period is prime — so `next_int % 10000` leaves its lowest 5537
+  values over-represented, which is exactly the range a roll-under-a-small-
+  threshold test reads. Measured through the real `Battle#critical?`, every crit
+  chance fired about **7% more often** than its number said: a 333 bp chance
+  landing 3.562% instead of 3.330%, a 3333 bp chance 35.600% instead of 33.330%,
+  the same relative error at every threshold tested. The roll now draws through a
+  new **`Rng#scaled`**, which multiplies across the period rather than taking a
+  modulus of it; being monotonic it spreads the unavoidable unevenness across the
+  range instead of piling it under the threshold, and the same measurement reads
+  3.335% and 33.338%.
+
+  `Rng#random` is deliberately unchanged: every other caller passes a small `n`
+  where the same bias is a handful of draws in thousands, and touching it would
+  reshuffle every seeded result in the project for no gain.
+
+  Over every troop in both test beds the correction takes Nepheshel from 156
+  criticals to 141 and mtf-meido-action from 27 to 18 — the overshoot being paid
+  back — with Nepheshel's record going from 126 wins to 124 in its 157 fights.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -578,7 +578,19 @@ The work below is roughly ordered by the critical path to a walkable game
   `crit_chance`, and `Battle#critical?` rolls against it. Integer basis points
   rather than a float keeps the damage path on the arithmetic the rest of it
   uses; the cost is that a 1/30 row reads 333 bp (3.33% against 3.3333…%), one
-  crit fewer in ~300,000 swings. Only a **weapon** grants the bonus — the best
+  crit fewer in ~300,000 swings. Rounding was **not** the only cost, though, and
+  the other one was three orders of magnitude larger: the roll draws through
+  `Rng#scaled`, not `Rng#random`, because the generator's period is prime and
+  `next_int % 10000` therefore leaves its lowest 5537 values over-represented —
+  precisely the range a roll-under-a-small-threshold test reads. Measured through
+  the real `Battle#critical?`, that paid **every** crit chance out about 7% more
+  often than its number said (a 333 bp chance landing 3.56%, a 3333 bp chance
+  35.6%). `#scaled` multiplies across the period instead of taking a modulus of
+  it, which is monotonic and so spreads the unevenness rather than piling it
+  under the threshold; the same measurement then reads 3.335% and 33.338%.
+  `#random` is untouched — every other caller passes a small `n` where it is
+  correct enough, and changing it would reshuffle every seeded result for no
+  gain. Only a **weapon** grants the bonus — the best
   among those equipped, the same shape `attack_hit_rate` uses — and Nepheshel's
   own bytes are what settle that rather than an appeal to EasyRPG's structure:
   69 of the 75 are weapons with a spread of rates (2..100), while the other six

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2699,18 +2699,45 @@ module Game
   # period (65536) and quality are more than enough for picking a walk
   # direction, and seeding it makes NPC wandering reproducible.
   class Rng
+    # The generator's period. Prime, which is what makes #scaled necessary.
+    PERIOD = 65_537
+
     def initialize(seed = 1)
       @state = (seed & 0xFFFF) + 1
     end
 
     def next_int
-      @state = (@state * 75 + 74) % 65537
+      @state = (@state * 75 + 74) % PERIOD
     end
 
     # An integer in 0...n (0 when n <= 0).
     def random(n)
       return 0 if n <= 0
       next_int % n
+    end
+
+    # An integer in 0...scale, taken by scaling the generator's whole period
+    # rather than by taking a modulus of it.
+    #
+    # `PERIOD` is prime, so `next_int % scale` never divides evenly: the lowest
+    # `PERIOD % scale` values come up once more often than the rest. At the sizes
+    # #random is used with — `random(100)`, `random(30)` — that surplus is a
+    # handful of draws in thousands and nothing notices.
+    #
+    # At `scale` 10000 it is 5537 values, and they sit at the **bottom** of the
+    # range, which is exactly where a "roll under a small threshold" test looks.
+    # Every such threshold then fires about 7% more often than it should — a
+    # 333 bp chance lands 3.56% of the time rather than 3.33%. Scaling is
+    # monotonic, so the same unavoidable unevenness is spread across the range
+    # instead of piling up under the threshold: measured over 200k draws it puts
+    # 1/30 at 3.335% and 1/3 at 33.338%.
+    #
+    # #random is deliberately left as it is. Every existing caller passes a small
+    # `n` where it is correct enough, and changing it would reshuffle every
+    # seeded result in the project to no purpose.
+    def scaled(scale)
+      return 0 if scale <= 0
+      next_int * scale / PERIOD
     end
   end
 
@@ -5665,7 +5692,11 @@ module Game
     def critical?(b)
       return false unless @criticals
       chance = b.crit_chance
-      chance && chance > 0 && @rng.random(CRIT_SCALE) < chance
+      # Drawn with Rng#scaled, not #random: at CRIT_SCALE a modulus of the
+      # generator's prime period over-represents the low values a small
+      # threshold tests against, and pays out every crit chance about 7% more
+      # often than the number says.
+      chance && chance > 0 && @rng.scaled(CRIT_SCALE) < chance
     end
 
     # Whether `attacker`'s basic attack lands on `target`: a 0..99 roll under the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5207,6 +5207,46 @@ check 'without variance a seeded fight deals exactly the base damage' do
   eq 20, bat.step_action[:damage]                    # exact base, unaffected
 end
 
+check 'Rng#scaled pays out a small threshold at its stated rate' do
+  # The generator's period is prime, so `next_int % scale` leaves the lowest
+  # `PERIOD % scale` values over-represented. At the sizes #random is used with
+  # that is invisible; at CRIT_SCALE the surplus is 5537 values sitting exactly
+  # where a roll-under-a-small-threshold test looks, and every such threshold
+  # fires about 7% too often. #scaled spreads it instead.
+  [[333, 30], [500, 20], [3333, 3]].each do |bp, denom|
+    trials = 40_000
+    modulo = Game::Rng.new(1)
+    scaled = Game::Rng.new(1)
+    m = s = 0
+    trials.times do
+      m += 1 if modulo.random(Game::CRIT_SCALE) < bp
+      s += 1 if scaled.scaled(Game::CRIT_SCALE) < bp
+    end
+    want = trials * bp / Game::CRIT_SCALE.to_f
+    ok (s - want).abs < want * 0.03,
+       "1/#{denom}: scaled gave #{s}, wanted about #{want.round}"
+    ok m > want * 1.03,
+       "1/#{denom}: the modulus overshoots by more than 3% (#{m} vs #{want.round})"
+  end
+  eq 0, Game::Rng.new(1).scaled(0), 'a non-positive scale draws 0'
+  ok Game::Rng.new(1).scaled(10).between?(0, 9), 'and a normal one stays in range'
+end
+
+check 'battle: a crit chance is paid out at the rate it states' do
+  # End to end through the real roll, which is what the bias actually reached.
+  chance = Game::CRIT_SCALE / 20                      # 1/20 -> 500 bp
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_chance = chance
+  foe = combatant('Foe', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, true)
+  trials = 40_000
+  crits = 0
+  trials.times { crits += 1 if bat.send(:critical?, hero) }
+  want = trials / 20.0
+  ok (crits - want).abs < want * 0.03,
+     "a 1-in-20 chance crit #{crits} times in #{trials}, wanted about #{want.round}"
+end
+
 check 'battle: a critical hit triples the damage when the fight rolls one' do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.crit_chance = Game::CRIT_SCALE                # certainty -> always crits
@@ -5325,6 +5365,9 @@ end
 class FixedRng
   def initialize(value); @value = value; end
   def random(n); n <= 0 ? 0 : @value % n; end
+  # The crit roll draws through #scaled; a fixture pinning an exact roll wants
+  # that value handed back untouched rather than rescaled.
+  def scaled(scale); scale <= 0 ? 0 : @value % scale; end
 end
 
 check 'battle: the crit roll is read against the basis-point scale' do


### PR DESCRIPTION
Follow-up to 87d13ff, which moved criticals to a basis-point probability. That change left the roll drawing through `Rng#random(10000)`, and at that scale the generator has a bias big enough to matter.

## The defect

The period is **prime** (65537), so `next_int % 10000` never divides evenly: the lowest `PERIOD % 10000` = 5537 values come up once more often than the rest. They sit at the **bottom** of the range — exactly where a roll-under-a-small-threshold test reads.

Measured through the merged `Battle#critical?` itself, 200k draws per row:

| chance | intended | delivered | error |
|---|---|---|---|
| 333 bp (1/30) | 3.330% | **3.562%** | +7.0% |
| 500 bp (1/20) | 5.000% | **5.347%** | +6.9% |
| 1000 bp (1/10) | 10.000% | **10.696%** | +7.0% |
| 3333 bp (1/3) | 33.330% | **35.600%** | +6.8% |
| 200 bp (1/50) | 2.000% | **2.140%** | +7.0% |

The *same* relative overshoot at every threshold — the signature of a systematic bias, not noise. Every crit chance in both games is paid out about 7% more often than its number says.

`docs/TODO.md` currently records the representation's only cost as rounding: *"a 1/30 row reads 333 bp (3.33% against 3.3333…%), one crit fewer in ~300,000 swings."* That's right about rounding and three orders of magnitude short of the real error, in the opposite direction. Corrected here.

## The fix

New `Rng#scaled(scale)` — `next_int * scale / PERIOD`. Multiplying across the period rather than taking a modulus of it is monotonic, so the same unavoidable unevenness spreads across the range instead of piling up under the threshold. The same measurement then reads 3.335% and 33.338%.

**`Rng#random` is deliberately untouched.** Every other caller passes a small `n` — `random(100)`, `random(30)` — where the identical bias is a handful of draws in thousands and nothing notices. Changing it would reshuffle every seeded result in the project for no gain.

## Effect

Over every troop in both test beds, the overshoot is paid back:

| | Nepheshel | mtf-meido-action |
|---|---|---|
| criticals | 156 → **141** | 27 → **18** |
| victories / defeats | 126/31 → **124/33** | 54/34 → 54/34 (unchanged) |

## Testing

Two new checks: a distribution check pinning `#scaled` within 3% of the true rate at three thresholds *and* asserting the modulus overshoots by more than 3% at each; plus an end-to-end one driving the real `Battle#critical?` 40k times at 1-in-20 and requiring the delivered rate to match. Both confirmed to fail against master — the second reports `a 1-in-20 chance crit 2128 times in 40000, wanted about 2000`.

`FixedRng`, the stub an existing check uses to pin an exact roll, grew `#scaled` so it keeps handing back the value it was given.

All nine CRuby suites pass: `rpg2k_logic_check` (540, +2), `rpg2k_scene_check` (165), `rpg2k_testbed_logic_check` (59), `rpg2k_render_check`, `lcf_testbed_check`, `rpgxp_testbed_check`, `rpgvx_testbed_check`, `mv_testbed_check`, `mz_testbed_check`. The native build could not be exercised here (no nix/SDL2) — CI covers it.

Supersedes #394, which reached 87d13ff's conclusions in parallel; this is the part of it that was not duplicated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_