### PR TITLE
Fight in the game's own battle scene

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,8 +214,9 @@ jobs:
       # tests in CMakeLists.txt, all run by the `test` step below); MV runs=100..108,
       # the RPG2k
       # real-game boot smoke=109..110, the MZ boot smoke=111, the RPG XP
-      # real-game boot smoke=112..113 (one per game) and the RGSSAD
-      # packed-asset smoke=114..115
+      # real-game boot smoke=112..114 (one per game, plus the editor bed's
+      # second pass for the battle probe) and the RGSSAD
+      # packed-asset smoke=115..116
       # (two runs, one per arm of its A/B) below. Every
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
@@ -309,8 +310,9 @@ jobs:
           # there is no reimplemented flow any more (ADR 0030): the check taps
           # confirm on the game's own title screen, logs every scene it reaches
           # as `[RPGXP-SCRIPTS]`/`[RPGXP-HOST-SCENE]`, walks the party on the
-          # editor bed's map (`[RPGXP-HOST-MOVE]`) and opens that bed's own menu
-          # (`[RPGXP-HOST-MENU]`). Two beds: the editor-shaped
+          # editor bed's map (`[RPGXP-HOST-MOVE]`), opens that bed's own menu
+          # (`[RPGXP-HOST-MENU]`) and, in a second pass, fights in its own
+          # battle scene (`[RPGXP-HOST-BATTLE]`). Two beds: the editor-shaped
           # OpenGame test bed and the *released* Pray for You (Game.rgssad only,
           # several maps), on displays 112 and 113 — one per game (see the
           # reserved server-num map above). See
@@ -325,7 +327,7 @@ jobs:
           # in the archive — and asserts the engine finds it only when it is
           # there, which is what makes the check non-vacuous. Displays 114-115.
           - name: RGSSAD packed-asset smoke test
-            run: ./scripts/nix-develop.bash ./scripts/rgssad_asset_check.bash 114
+            run: ./scripts/nix-develop.bash ./scripts/rgssad_asset_check.bash 115
 
           - name: MV boot smoke test
             continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@
   its party (`[RPGXP-HOST-MOVE]`), which is what proves a game's own
   `Game_Player` is reading input and stepping across its own passability, and to
   open its own menu (`[RPGXP-HOST-MENU]`) — the first thing a game draws out of
-  its own `Window` subclasses, windowskin and font.
+  its own `Window` subclasses, windowskin and font — and, in a second pass, to
+  fight in its own battle scene (`[RPGXP-HOST-BATTLE]`), where every enemy is one
+  of its own `Sprite_Battler`s on top of `RPG::Sprite`.
   `scripts/rpgxp_script_host_check.rb` covers the same ground under CRuby —
   every section of both bundles evaluates, and the RGSS standard library behaves
 - `scripts/compare-rpgxp-wine.bash` diffs our frames against the **genuine RGSS

--- a/changelog.d/rgss-host-battle-test.added.md
+++ b/changelog.d/rgss-host-battle-test.added.md
@@ -1,0 +1,17 @@
+- **`--rgss_host_battle_test` fights in a game's own battle scene.** Once the
+  game is on its own map the host calls a battle exactly the way that game's own
+  Battle Processing command does — the same five `$game_temp` fields the stock
+  `Interpreter#command_301` sets — and reports where it got to as
+  `[RPGXP-HOST-BATTLE] scene=.. reached=.. frame=..`. This is the biggest
+  surface the boot check reaches: a battle builds the game's own
+  `Spriteset_Battle`, so every enemy is a `Sprite_Battler` on top of
+  `RPG::Sprite`, whose whiten/appear/collapse transitions, damage pop-up and
+  animation playback nothing had ever run. It is the one probe that *writes* to a
+  game's globals rather than only reading them, because no keypress starts a
+  battle; confirm taps keep running through it, which is what advances the game's
+  own party and actor command windows.
+- **The boot check gives it its own pass**, on the editor test bed only: a battle
+  is called from the map and the walk/menu pass ends inside the menu, and a
+  released game's opening is an event sequence a battle call would land in the
+  middle of. The reserved CI display numbers shift accordingly (the XP boot smoke
+  now takes 112..114, the RGSSAD A/B 115..116).

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -173,10 +173,29 @@ a game's engine took a keypress and acted on it, rather than merely drawing.
 `--rgss_host_move_test` and `--rgss_host_menu_test` are the two rungs above that,
 run in the same pass: walk the party across the game's own passability
 (`[RPGXP-HOST-MOVE]`), then press cancel and report where the game went
-(`[RPGXP-HOST-MENU]`). The menu is the interesting one for this document — it is
-the first thing a game draws out of its *own* `Window_Base` subclasses, its own
-windowskin, its own font and its own `Bitmap#draw_text`, none of which a map
-scene touches. Whatever it reports is the next entry here.
+(`[RPGXP-HOST-MENU]`). The menu matters here because it is the first thing a game
+draws out of its *own* `Window_Base` subclasses, its own windowskin, its own font
+and its own `Bitmap#draw_text`, none of which a map scene touches. The editor bed
+passed it first time — and then, with the confirm taps still running, walked on
+into its own `Scene_Item`:
+
+```
+[RPGXP-HOST-SCENE] Scene_Map frame=41
+[RPGXP-HOST-MOVE] start=9,7 end=9,8 moved=true frame=221
+[RPGXP-HOST-SCENE] Scene_Menu frame=242
+[RPGXP-HOST-MENU] scene=Scene_Menu opened=true frame=301
+[RPGXP-HOST-SCENE] Scene_Item frame=321
+```
+
+`--rgss_host_battle_test` is the rung above *that*, and takes its own pass: a
+battle is called from the map, and the pass above ends inside the menu. It sets
+the same five `$game_temp` fields the stock `Interpreter#command_301` does — the
+only probe here that writes to a game's globals rather than just reading them,
+because no keypress starts a battle — and reports `[RPGXP-HOST-BATTLE]`. It is
+the biggest surface of the lot: a battle builds the game's own
+`Spriteset_Battle`, so every enemy is a `Sprite_Battler` on top of the
+`RPG::Sprite` in gap 0, whose transitions, damage pop-up and animation playback
+nothing had run before. Whatever it reports is the next entry here.
 
 ### 0e. `Kernel#Integer()` ✅ (the first thing New Game runs)
 

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -240,6 +240,8 @@ class RPGXP
     #     scene is up and report whether it moved.
     #   * with --rgss_host_menu_test, press cancel after that and report which
     #     scene the game went to — its own menu, if it has one.
+    #   * with --rgss_host_battle_test, call a battle the way the game's own
+    #     Battle Processing command does and report whether it came up.
     def self.watch_frame
       @frames += 1
       report_scene
@@ -249,6 +251,7 @@ class RPGXP
       confirm_tap if auto_new_game? && !probing_move? && !probing_menu?
       move_probe if move_test?
       menu_probe if menu_test?
+      battle_probe if battle_test?
     end
 
     def self.report_scene
@@ -391,6 +394,57 @@ class RPGXP
       finish_menu_probe if step >= MENU_WAIT
     end
 
+    # Start a battle in the game's own engine and report where that got it.
+    #
+    # The rung above the menu, and the biggest surface left: a battle builds the
+    # game's own `Spriteset_Battle`, so every enemy is a `Sprite_Battler` —
+    # a subclass of the `RPG::Sprite` this gem supplies (rgss_library.rb), whose
+    # whiten/appear/collapse transitions, damage pop-up and animation playback
+    # nothing had ever run — on top of the battle status and command windows.
+    #
+    # Unlike the other probes this *writes* to the game's globals rather than
+    # only reading them. There is no keypress that starts a battle: the stock
+    # `Interpreter#command_301` (Battle Processing) sets exactly these five
+    # fields on `$game_temp` and lets `Scene_Map#update` do the rest, so this
+    # sets the same five. Walking into a random encounter would be the
+    # keypress-only alternative, and it is not deterministic enough for a check.
+    # Guarded on the setter existing, since a game may ship its own Game_Temp.
+    #
+    # Confirm taps keep running through the battle on purpose: that is what
+    # advances the game's own party and actor command windows once it is up.
+    BATTLE_SETTLE = 60      # frames on the map before calling the battle
+    BATTLE_WAIT = 120       # frames to let the game's own battle scene come up
+    BATTLE_TROOP_ID = 1
+
+    def self.battle_probe
+      return if @battle_done || @map_frame.nil?
+      elapsed = @frames - @map_frame
+      return if elapsed < BATTLE_SETTLE
+      if elapsed == BATTLE_SETTLE
+        call_battle
+        return
+      end
+      finish_battle_probe if elapsed >= BATTLE_SETTLE + BATTLE_WAIT
+    end
+
+    def self.call_battle
+      temp = $game_temp
+      return if temp.nil? || !temp.respond_to?(:battle_calling=)
+      temp.battle_troop_id = BATTLE_TROOP_ID
+      temp.battle_can_escape = true
+      temp.battle_can_lose = true
+      temp.battle_proc = nil
+      temp.battle_calling = true
+    end
+
+    def self.finish_battle_probe
+      @battle_done = true
+      scene = $scene
+      name = scene.nil? ? "?" : scene.class.to_s
+      $stderr.puts "[RPGXP-HOST-BATTLE] scene=#{name} " \
+                   "reached=#{name.include?("Scene_Battle")} frame=#{@frames}"
+    end
+
     def self.finish_menu_probe
       @menu_done = true
       scene = $scene
@@ -434,6 +488,12 @@ class RPGXP
 
     def self.menu_test?
       RGSS_HOST_MENU_TEST
+    rescue StandardError
+      false
+    end
+
+    def self.battle_test?
+      RGSS_HOST_BATTLE_TEST
     rescue StandardError
       false
     end

--- a/scripts/rgssad_asset_check.bash
+++ b/scripts/rgssad_asset_check.bash
@@ -44,7 +44,7 @@
 # the test.
 #
 # Usage: ./scripts/rgssad_asset_check.bash [server_num] [game_dir]
-#   server_num  xvfb-run --server-num to use (default 113; see the reserved
+#   server_num  xvfb-run --server-num to use (default 115; see the reserved
 #               display numbers in .github/workflows/build.yml)
 #   game_dir    defaults to the repo's RPG Maker XP test bed
 
@@ -52,7 +52,7 @@ set -eu -o pipefail
 
 cd "$(dirname "$0")/.."
 
-SERVER_NUM="${1:-113}"
+SERVER_NUM="${1:-115}"
 GAME="${2:-data/OpenGame.exe/Testbed/XP}"
 ENGINE="${ENGINE:-./build/rpg_maker_clone}"
 TIMEOUT_MS="${RGSSAD_TIMEOUT_MS:-20000}"

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -30,6 +30,13 @@
 #     classes, its own windowskin and its own font, none of which a map scene
 #     touches. Asserted on the editor bed (stock scripts, menu enabled), logged
 #     on the released game.
+#   * a second pass over the editor bed calls a battle the way the game's own
+#     Battle Processing command does and reports
+#     `[RPGXP-HOST-BATTLE] scene=.. reached=..`. Its own pass because a battle
+#     is called from the map and the pass above ends inside the menu; the editor
+#     bed only, because a released game's opening is an event sequence a battle
+#     call would land in the middle of. This is the biggest surface of the lot:
+#     every enemy in it is a `Sprite_Battler`, on top of `RPG::Sprite`.
 #   * a `script host failed` line fails the run: the game's own scripts stopping
 #     is the failure this check exists to catch.
 #
@@ -39,7 +46,9 @@
 #
 # Usage: ./scripts/rpgxp_boot_check.bash [server_num] [game_dir...]
 #   server_num  xvfb-run --server-num to use (default 112; see the reserved
-#               display numbers in .github/workflows/build.yml)
+#               display numbers in .github/workflows/build.yml). Each run takes
+#               the next one, so the two beds plus the editor bed's battle pass
+#               use 112..114.
 #   game_dir    defaults to the repo's two RPG Maker XP beds -- the editor-shaped
 #               OpenGame test bed and the released Pray for You
 
@@ -53,10 +62,10 @@ shift || true
 ENGINE="${ENGINE:-./build/rpg_maker_clone}"
 # Wall-clock budget per run. The engine counts it in Graphics.update, but what
 # has to fit inside it is a *frame* count -- the game's own title screen, then
-# the settle and the four held directions of the move probe -- and CI has no GPU,
-# so a 640x480 tilemap redraw is nowhere near the 40 fps RGSS nominally runs at.
-# 20s was enough to reach the map and not to finish the walk; this is sized so
-# the probe still lands at well under ten frames a second.
+# the settle, the four held directions of the move probe and the menu -- and CI
+# has no GPU, so a 640x480 tilemap redraw is nowhere near the 40 fps RGSS
+# nominally runs at. 20s was enough to reach the map and not to finish the walk;
+# this is sized so the probes still land at well under ten frames a second.
 TIMEOUT_MS="${RPGXP_TIMEOUT_MS:-45000}"
 
 GAMES=("$@")
@@ -153,6 +162,21 @@ for game in "${GAMES[@]}" ; do
     run_boot "${game}" "${num}" "script host" \
         "--rgss_host_move_test --rgss_host_menu_test" 2 "${markers[@]}" ||
         failed=$((failed + 1))
+    num=$((num + 1))
+
+    # Battle needs its own pass: it has to be called from the game's own map,
+    # and the pass above deliberately leaves the game inside its menu. Only the
+    # editor bed, whose stock database ships 32 troops -- a released game's
+    # opening is an event sequence that a battle call would land in the middle
+    # of, which says nothing about the engine.
+    case "${game}" in
+        *Testbed*)
+            run_boot "${game}" "${num}" "script host: battle" \
+                "--rgss_host_battle_test" 2 \
+                '\[RPGXP-HOST-BATTLE\] .*reached=true' ||
+                failed=$((failed + 1))
+            ;;
+    esac
 
     num=$((num + 1))
 done

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -96,6 +96,17 @@ DEFINE_bool(
     "is the first thing it draws out of its own Window classes, its own "
     "windowskin and its own font. Used by scripts/rpgxp_boot_check.bash");
 DEFINE_bool(
+    rgss_host_battle_test,
+    false,
+    "For the RGSS makers under the script host: once the game is on its own "
+    "map, start a battle the way its own Battle Processing event command does "
+    "(setting the same five $game_temp fields) and log which scene the game "
+    "reached as [RPGXP-HOST-BATTLE] (implies --rgss_host_new_game). The rung "
+    "above the menu: a battle builds the game's own Spriteset_Battle, so every "
+    "enemy is a Sprite_Battler on top of RPG::Sprite. Unlike the other probes "
+    "this writes to the game's globals, because no keypress starts a battle. "
+    "Used by scripts/rpgxp_boot_check.bash");
+DEFINE_bool(
     mv_new_game,
     false,
     "For RPG Maker MV: once the title screen appears, auto-select New Game so "
@@ -837,13 +848,16 @@ int main(int argc, char** argv) {
       M, mrb_obj_value(M->object_class),
       mrb_intern_lit(M, "RGSS_HOST_NEW_GAME"),
       mrb_bool_value(FLAGS_rgss_host_new_game || FLAGS_rgss_host_move_test ||
-                     FLAGS_rgss_host_menu_test));
+                     FLAGS_rgss_host_menu_test || FLAGS_rgss_host_battle_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RGSS_HOST_MOVE_TEST"),
                 mrb_bool_value(FLAGS_rgss_host_move_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RGSS_HOST_MENU_TEST"),
                 mrb_bool_value(FLAGS_rgss_host_menu_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RGSS_HOST_BATTLE_TEST"),
+                mrb_bool_value(FLAGS_rgss_host_battle_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));


### PR DESCRIPTION
The menu rung (#396) passed first time — and then went further than it was asked
to. With the confirm taps still running after the probe reported, the editor bed
walked on into its own `Scene_Item`:

```
[RPGXP-HOST-SCENE] Scene_Map frame=41
[RPGXP-HOST-MOVE] start=9,7 end=9,8 moved=true frame=221
[RPGXP-HOST-SCENE] Scene_Menu frame=242
[RPGXP-HOST-MENU] scene=Scene_Menu opened=true frame=301
[RPGXP-HOST-SCENE] Scene_Item frame=321
```

A game's own `Window_Command` took a keypress, its `Scene_Menu` pushed
`Scene_Item`, and that drew an item list — out of its own windowskin and font,
with nothing raising. (*Pray for You* reported `opened=false`, which is correct:
its opening cutscene disables the menu.)

## The next rung

Battle, and it is the biggest surface the boot check can reach. A battle builds
the game's own `Spriteset_Battle`, so every enemy is a `Sprite_Battler` — a
subclass of the `RPG::Sprite` this gem supplies — whose whiten/appear/collapse
transitions, floating damage pop-up and `RPG::Animation` playback **nothing has
ever run**. On top of that sit the battle status and command windows.

`--rgss_host_battle_test` sets the same five `$game_temp` fields the stock
`Interpreter#command_301` (Battle Processing) sets, and lets the game's own
`Scene_Map#update` do the rest:

```
[RPGXP-HOST-BATTLE] scene=Scene_Battle reached=true frame=221
```

Two things worth calling out:

- **This is the one probe that writes to a game's globals** rather than only
  reading them. There is no keypress that starts a battle, and walking into a
  random encounter is not deterministic enough for a check. The five fields are
  exactly what the game's own event command would set, and the setter is guarded
  in case a game ships its own `Game_Temp`.
- **Confirm taps keep running through the battle**, on purpose — that is what
  advances the game's own party and actor command windows once it is up.

## Its own pass

A battle is called from the map, and the walk/menu pass deliberately ends inside
the menu. Editor bed only: its stock database ships 32 troops (`Ghost*2`,
`Basilisk*2`, …), while a released game's opening is an event sequence a battle
call would land in the middle of. That is a third display, so the reserved
numbers in `build.yml` shift — XP boot smoke `112..114`, RGSSAD A/B `115..116`.

Whatever this reports is the next entry in `docs/rpgxp-rgss-api-gap.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_