### PR TITLE
Walk the party when an event walks it

### DIFF
--- a/changelog.d/player-forced-route-slide.added.md
+++ b/changelog.d/player-forced-route-slide.added.md
@@ -1,0 +1,9 @@
+- **A forced player route walks the party instead of teleporting it.**
+  `step_player_route` wrote the destination tile straight onto the state, so a
+  cutscene walking the hero across a room moved it a tile at a time while the
+  same hero, walking on input, interpolated smoothly. The party now slides
+  through the step, sharing the machinery ordinary walking already used, and a
+  forced **jump** arcs the hero exactly as it arcs an event.
+- A step in progress has to land before the next begins, which also caps a
+  forced route at the walking pace it is drawn at. Proceed With Movement drives
+  the slide itself, since the normal movement step is skipped while it waits.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -227,11 +227,24 @@ The work below is roughly ordered by the critical path to a walkable game
   landing. It was invisible while there was nothing on screen to notice it by.
   Events are what jump in the real games: of Nepheshel's 634 Begin Jump blocks,
   **632 drive an event** (625 of them a page's own autonomous route) and two the
-  player; mtf-meido-action's single block drives the player. The player's own
-  forced-route movement still snaps tile to tile — not only its jumps — which is
-  a separate gap: `step_player_route` sets the position outright where the
-  input path interpolates. Remaining: the player half, once forced player routes
-  interpolate at all
+  player; mtf-meido-action's single block drives the player.
+  **The player's forced routes interpolate now too**, which was the separate gap
+  that left: `step_player_route` wrote the destination tile straight onto the
+  state, so a cutscene walking the hero across a room teleported it a tile at a
+  time while the same hero, walking on input, slid smoothly. It shares the
+  machinery ordinary walking already had — `advance_player_slide` moves the party
+  a frame at a time and lands it — so a forced **jump** arcs the hero through the
+  same curve an event jumps through (`jump_offset_for`, one implementation for
+  both, so a jumping party member and a jumping NPC cannot rise differently).
+  Two rules fell out of it. A step in flight has to **land before the next
+  begins**: the route character runs ahead of the party (it is what the route
+  steps) and the party only catches up when the slide completes, so stepping
+  again mid-slide would leave the two more than a tile apart and stretch one
+  slide over the gap — which also caps a forced route at the walking pace it is
+  drawn at. And **Proceed With Movement drives the slide itself**, because the
+  normal movement step is skipped while the interpreter waits on it; without
+  that the route starts a step and then waits forever for a landing nothing is
+  advancing
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -554,9 +554,11 @@ class RPG2k
         @player_char = nil
         @player_route_timer = 0
 
-        # Player pixel position and step state.
+        # Player pixel position and step state. `player_jumping` marks the slide
+        # as a hop, which is lifted along an arc (see player_jump_offset).
         @moving = false
         @move_count = 0
+        @player_jumping = false
         @dest_x = @state.x
         @dest_y = @state.y
         @tile_colors = {}
@@ -1563,7 +1565,14 @@ class RPG2k
       JUMP_STEP_UNITS = 256              # EasyRPG's SCREEN_TILE_SIZE
       def event_jump_offset(e)
         return 0 unless e[:jumping] && e[:move_count] < TILE
-        remaining = (TILE - e[:move_count]) * (JUMP_STEP_UNITS / TILE)
+        jump_offset_for(e[:move_count])
+      end
+
+      # The arc itself, given how far through the hop the slide is (0..TILE).
+      # Shared by the event sprites and the hero, so a jumping party member and
+      # a jumping NPC rise by the same amount at the same point of the hop.
+      def jump_offset_for(move_count)
+        remaining = (TILE - move_count) * (JUMP_STEP_UNITS / TILE)
         half = JUMP_STEP_UNITS / 2
         h = (remaining > half ? JUMP_STEP_UNITS - remaining : remaining) / 8
         h < 5 ? h * 2 : h + 5
@@ -2124,9 +2133,8 @@ class RPG2k
       end
 
       # Drive the player along a forced route: the player has no Game::Character,
-      # so mirror one, step it against the map world and write the tile back to
-      # the state. Forced player steps snap tile-to-tile (no pixel interpolation)
-      # and suppress input movement while active.
+      # so mirror one, step it against the map world and slide the party after
+      # it. Input movement is suppressed while the route is active.
       def start_player_route(route, freq)
         @player_char = Game::Character.new(@state.x, @state.y, @state.direction)
         @player_char.move_frequency = valid_move_freq(freq) ||
@@ -2135,26 +2143,73 @@ class RPG2k
         @player_route_timer = 0
       end
 
+      # Take one step of the player's forced route, if its pacing timer is up.
+      #
+      # A step in progress has to land before the next one begins: the route
+      # character runs ahead of the party (it is what the route steps), and the
+      # party's own tile only catches up when the slide completes, so stepping
+      # again mid-slide would leave the two more than a tile apart and stretch
+      # one slide over the gap. That also caps a forced route at the walking
+      # pace, which is what it moves at on screen.
       def step_player_route
         return unless @player_route
+        return if @moving
         @player_route_timer -= 1
         return if @player_route_timer > 0
         @player_route_timer = EVENT_MOVE_DELAY[@player_char.move_frequency] || 40
-        was = [@state.x, @state.y]
+        ox = @player_char.x
+        oy = @player_char.y
         @player_route.step(@player_char, @world) unless @player_route.done?
-        @state.x = @player_char.x
-        @state.y = @player_char.y
         @state.direction = @player_char.direction
-        # A forced route walks the party as surely as the player does, so its
-        # moves count as steps too. One per landing, which makes a jump a single
-        # step rather than one per tile cleared. A route command that only turns
-        # or waits moves nothing and counts nothing.
-        note_party_step if [@state.x, @state.y] != was
-        @dest_x = @state.x
-        @dest_y = @state.y
-        @moving = false
-        @move_count = 0
+        if @player_char.x != ox || @player_char.y != oy || @player_char.jumped
+          start_player_slide
+        end
         @player_route = nil if @player_route.done?
+      end
+
+      # Begin the party's slide toward wherever the route character now stands.
+      # The party stays on its own tile until the slide lands (as it does for
+      # ordinary walking), so everything reading @state.x/y sees a character on a
+      # tile rather than between two.
+      def start_player_slide
+        @dest_x = @player_char.x
+        @dest_y = @player_char.y
+        @moving = true
+        @move_count = 0
+        @player_jumping = @player_char.jumped
+      end
+
+      # Advance the party's pixel slide by one frame, landing it on the
+      # destination tile when the slide completes. Returns true while a slide is
+      # still in progress.
+      #
+      # Shared by ordinary movement and by Proceed With Movement, which drives
+      # forced routes while the normal movement step is skipped -- without the
+      # slide progressing there, a forced route would start a step and then wait
+      # for a landing that never came.
+      def advance_player_slide
+        return false unless @moving
+        @move_count += SPEED
+        if @move_count >= TILE
+          @state.x = @dest_x
+          @state.y = @dest_y
+          @moving = false
+          @move_count = 0
+          @player_jumping = false
+          note_party_step
+          follow_vehicle if @state.boarded? # the ridden vehicle tracks the party
+        end
+        # True for the landing frame as well as the ones before it: that frame
+        # is spent finishing the step, not starting the next one.
+        true
+      end
+
+      # How far the party's sprite is lifted off the ground this frame, in
+      # pixels. The event arc, applied to the hero: a forced route is the only
+      # thing that can make the player jump, and RPG_RT hops it the same way.
+      def player_jump_offset
+        return 0 unless @player_jumping && @moving
+        jump_offset_for(@move_count)
       end
 
       # Advance every forced move route in progress one frame — the player's and
@@ -2163,6 +2218,7 @@ class RPG2k
       # Returns true once no forced route remains, so the caller can resume the
       # interpreter. A repeating forced route never reports done, matching RPG_RT.
       def step_forced_movement
+        advance_player_slide
         step_player_route
         @events.each { |e| step_forced_event(e) if e[:forced_route] }
         forced_movement_done?
@@ -4246,6 +4302,10 @@ class RPG2k
         @interpreter.resolver = build_resolver
         @interpreter.map_info = self
         build_parallels
+        # Any step in flight is dropped: the party arrives standing on the
+        # destination tile rather than sliding toward one on the map it left.
+        # A forced route can have a step in flight here -- it advances between
+        # events, and an auto-start page can teleport on the very next frame.
         @moving = false
         @move_count = 0
         @last_frame = nil
@@ -4695,18 +4755,7 @@ class RPG2k
       end
 
       def step_movement
-        if @moving
-          @move_count += SPEED
-          if @move_count >= TILE
-            @state.x = @dest_x
-            @state.y = @dest_y
-            @moving = false
-            @move_count = 0
-            note_party_step
-            follow_vehicle if @state.boarded? # the ridden vehicle tracks the party
-          end
-          return
-        end
+        return if advance_player_slide
 
         return if event_busy? # don't start a new move while an event runs
         return if @player_route # a forced route controls the player
@@ -4847,7 +4896,8 @@ class RPG2k
         draw_layers cam_x, cam_y
 
         @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
-        @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE)
+        @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE) -
+                           player_jump_offset
         # Reflect the Set Transparent Flag command (and any leader graphic flag)
         # every frame so the hero hides/shows as events toggle it.
         @player_sprite.visible = !player_hidden?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3681,6 +3681,125 @@ check 'a teleport is not a walked step' do
   eq 100, hero.hp
 end
 
+# A page that forces a route on the player: target 10001, freq 8, repeat off,
+# skippable on, then the route's own commands.
+def player_route_page(*cmds)
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [ECmd.new(Game::Interpreter::Cmd::MOVE_EVENT,
+                                [10001, 8, 0, 1, *cmds])]
+  pg
+end
+
+check 'a forced player route slides the party instead of snapping it' do
+  # It used to write the tile straight onto the state, so a cutscene walking the
+  # hero across a room teleported it a tile at a time while its own input-driven
+  # walking interpolated. The party is drawn between tiles now.
+  scene = new_scene({ 1 => event(3, 3, player_route_page(R::MOVE_RIGHT)) },
+                    player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  between = 0
+  30.times do
+    scene.update
+    px, = scene.send(:player_pixel)
+    between += 1 unless (px % Game::TILE).zero?
+  end
+  ok between > 0, 'the party was drawn part-way between two tiles'
+  eq 1, st.x, 'and it still arrives on the destination tile'
+  eq 0, st.y
+end
+
+check 'a forced route step lands before the next one starts' do
+  # The route character runs ahead of the party -- it is what the route steps --
+  # so a second step taken mid-slide would leave the two more than a tile apart
+  # and stretch one slide across the gap.
+  scene = new_scene({ 1 => event(3, 3, player_route_page(R::MOVE_RIGHT,
+                                                         R::MOVE_RIGHT)) },
+                    player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  60.times do
+    scene.update
+    dest = scene.instance_variable_get(:@dest_x)
+    ok (dest - st.x).abs <= 1,
+       "the slide never spans more than a tile (#{st.x} -> #{dest})"
+  end
+  eq 2, st.x, 'both steps ran'
+end
+
+check 'a forced player jump arcs the hero the way it arcs an event' do
+  scene = new_scene({ 1 => event(3, 3, player_route_page(R::BEGIN_JUMP,
+                                                         R::MOVE_RIGHT,
+                                                         R::MOVE_RIGHT,
+                                                         R::END_JUMP)) },
+                    player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  heights = []
+  40.times do
+    scene.update
+    h = scene.send(:player_jump_offset)
+    heights << h if scene.instance_variable_get(:@player_jumping)
+  end
+  eq 2, st.x, 'the hop cleared two tiles'
+  eq 21, heights.max, 'and rose to the same peak an event does'
+  peak = heights.index(heights.max)
+  ok heights[0...peak] == heights[0...peak].sort,
+     "rises to the peak: #{heights.inspect}"
+  # The ends of the arc, read off the shared curve rather than off a sampling
+  # frame -- the first frame after an update is already two pixels into the step.
+  eq 0, scene.send(:jump_offset_for, 0), 'the hop begins on the ground'
+  eq 0, scene.send(:jump_offset_for, Game::TILE), 'and ends on it'
+  eq 0, scene.send(:player_jump_offset), 'and the hero is back on it once landed'
+end
+
+check 'a forced player walk is never lifted' do
+  scene = new_scene({ 1 => event(3, 3, player_route_page(R::MOVE_RIGHT)) },
+                    player: [0, 0])
+  30.times do
+    scene.update
+    eq 0, scene.send(:player_jump_offset), 'a step is not a hop'
+  end
+end
+
+check 'a teleport lands the party on its tile, not mid-slide' do
+  # A teleport can land while a forced route has a step in flight: the route
+  # advances between events, and an auto-start page can fire on the very next
+  # frame. The party must arrive standing on the destination, not still sliding
+  # toward the tile it was walking to on the old map.
+  scene = new_scene({ 1 => event(3, 3, player_route_page(R::MOVE_RIGHT)) },
+                    player: [0, 0])
+  40.times do
+    break if scene.instance_variable_get(:@moving)
+    scene.update
+  end
+  ok scene.instance_variable_get(:@moving), 'a step really is in flight'
+
+  scene.send(:perform_teleport, [1, 4, 3, 0])
+  st = scene.instance_variable_get(:@state)
+  eq [4, 3], [st.x, st.y], 'the teleport landed'
+  eq false, scene.instance_variable_get(:@moving), 'and nothing is still sliding'
+  eq [4, 3], scene.send(:player_pixel).map { |v| v / Game::TILE },
+     'the sprite is drawn on that tile'
+  eq 0, scene.send(:player_jump_offset)
+end
+
+check 'Proceed With Movement finishes a sliding player route' do
+  # The interpreter parks on :movement until every forced route has finished,
+  # and the normal movement step is skipped while it waits -- so that path has to
+  # advance the slide itself. Without it the route starts a step, then waits
+  # forever for a landing nothing is driving, and the event never resumes.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [
+    ECmd.new(ic::MOVE_EVENT, [10001, 8, 0, 1, R::MOVE_RIGHT, R::MOVE_RIGHT]),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, []),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 9, 9, 0]),
+  ]
+  scene = new_scene({ 1 => event(3, 3, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  120.times { scene.update }
+  eq 2, st.x, 'the route walked the party two tiles east'
+  ok st.switches[9], 'and the event resumed once the movement was done'
+end
+
 check 'a forced player route walks the party, and its steps count' do
   # A route moves the party as surely as the player does, so its landings count
   # too -- an event that walks a poisoned party across a field should drain it.


### PR DESCRIPTION
## The gap

`step_player_route` wrote the destination tile straight onto the state, so a cutscene walking the hero across a room **teleported it a tile at a time** — while the same hero, walking on input, interpolated smoothly through every step.

#397 arced jumping events and named this as what it could not reach. Looking properly, jumps were only the visible half: the gap was *every* forced step, not only the hops.

## What changed

The party now slides through a forced step, sharing the machinery ordinary walking already had. `advance_player_slide` moves it a frame at a time and lands it on the destination, and both callers go through that one method rather than each having its own copy of the landing.

A forced **jump** arcs the hero through the same curve an event jumps through — `jump_offset_for` is one implementation for both, so a jumping party member and a jumping NPC cannot rise differently.

## Two rules that fell out of it

**A step in flight lands before the next begins.** The route character runs ahead of the party — it is what the route steps — and the party's own tile only catches up when the slide completes. Stepping again mid-slide would leave the two more than a tile apart and stretch one slide across the gap. This also caps a forced route at the walking pace it is drawn at, which is the honest consequence: a freq-8 route used to advance a tile per frame because nothing was being drawn between them.

**Proceed With Movement drives the slide itself.** The interpreter parks on `:movement` until every forced route finishes, and the normal movement step is skipped while it waits — so without advancing the slide there, a route starts a step and then waits forever for a landing nothing is driving, and the event never resumes. That is a deadlock this change would have introduced, so it has a check of its own.

## A redundant fix, caught by falsifying its own check

The first cut added a second `@moving` / `@move_count` reset beside the forced-route teardown in `perform_teleport`, on the reasoning that a route can be mid-slide when a map change lands.

Removing it, the check written to cover it **still passed** — `perform_teleport` already resets both at the end, and the two guards on the jump offset make the rest moot. So the code is gone, and the check now guards the reset that was already there (confirmed by removing *that* and watching it go red). Worth recording because the check looked like coverage while the code under it did nothing.

## Verification

- **6 new checks in `scripts/rpg2k_scene_check.rb`** — a forced route draws the party between tiles and still arrives on the destination; a slide never spans more than a tile; a forced jump arcs the hero to the same 21px peak, rising from and returning to the ground; a forced walk is never lifted; a teleport lands the party on its tile rather than mid-slide; and Proceed With Movement finishes a sliding route and resumes the event. **176 pass.**
- Every new check was confirmed to **fail when the behaviour it covers is removed** — the route snapping again, the land-before-stepping gate removed, the hero never lifted, the teleport reset removed, and Proceed With Movement no longer advancing the slide.
- `rpg2k_logic_check.rb` (541), `rpg2k_testbed_logic_check.rb` (59), `rpg2k_render_check.rb` (36), the 371,762-command soak and the LCF / XP / VX bed checks all pass.

With this, `docs/TODO.md`'s movement section has no remaining "snaps where RPG_RT interpolates" gap: events and the player both slide, on input and under a forced route, and both arc when they jump.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_