### PR TITLE
Read the terrain under the party, and let it hurt

### DIFF
--- a/changelog.d/terrain-tags-and-terrain-damage.fixed.md
+++ b/changelog.d/terrain-tags-and-terrain-damage.fixed.md
@@ -1,0 +1,17 @@
+- **A chipset that stores no terrain table now reads terrain 1, not terrain 0.**
+  RPG_RT omits the whole 162-entry array when every tile of the chipset is
+  terrain 1, and that is what 96 of Nepheshel's 100 chipsets and 92 of
+  mtf-meido-action's do — so almost every tile in both games was reading an id no
+  database row matches. Store Terrain ID stored 0, boat / ship passability fell
+  back to on-foot passability instead of the terrain's `boat_pass` / `ship_pass`,
+  and the terrain battle backdrop never resolved. A tile id the chip index cannot
+  reach now reads the first lower tile's terrain, as RPG_RT does. See ADR 0034.
+- **地形ダメージ**: walking onto a tile whose terrain carries a `damage` value now
+  takes that much HP off every party member, unless they wear gear flagged
+  地形ダメージ無効 (`Game::Actor#prevents_terrain_damage?`, any slot — mtf's is a
+  pair of boots, Nepheshel's four include a swimsuit). Like the status slip
+  damage it shares a step with, it **cannot kill**: it floors at 1 HP, skips a
+  member already down, and flashes the screen red so the loss has somewhere to
+  show. Both test beds define damaging terrain (Nepheshel's ダメージ床１/２ at 1
+  and 10 HP, mtf's Poison Swamp and Damage Floor at 1 and 2) though neither
+  places one on a shipped map. Covered by the logic, scene and test-bed checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -573,6 +573,27 @@ The work below is roughly ordered by the critical path to a walkable game
   party through the real interval against it. Still unread: `affect_type` stat
   halving / doubling plus the RPG2003-only `avoid_attacks` / `reflect_magic`,
   which no state in either test bed sets.
+  **The ground drains it too** — RPG2000's 地形ダメージ, the 地形 row's `damage`
+  field (ADR 0034). Stepping onto a tile whose terrain carries one takes that
+  much HP off every member who is not already down and is not wearing gear
+  flagged 地形ダメージ無効 (`Actor#prevents_terrain_damage?`, read through the
+  same `equipment_flag?` helper as the combat flags, so any slot grants it —
+  mtf's is a pair of boots, Nepheshel's four include a swimsuit). It shares the
+  step counter, the "cannot kill, floors at 1 HP" rule and the one red flash with
+  the status slip above, so a step drains at most once from each and a teleport
+  drains nothing. Both test beds define damaging terrain — Nepheshel's ダメージ床
+  １/２ at 1 and 10 HP, mtf's Poison Swamp and Damage Floor at 1 and 2 — but a
+  sweep of all 543 and 13 shipped maps finds **no map that places one**, so this
+  is the rare rule the real data proves by its definition rather than its use.
+  The same work fixed the terrain **tag**, which the whole terrain table hangs
+  off: RPG_RT omits a chipset's 162-entry terrain array when every tile of it is
+  terrain 1, and 96 of Nepheshel's 100 chipsets and 92 of mtf's do exactly that.
+  Reading the absence as terrain 0 left 414,993 of Nepheshel's lower-layer tiles
+  (and 1,530 of mtf's) naming an id no row matches — Store Terrain ID stored 0,
+  boats and ships fell back to on-foot passability instead of the terrain's
+  `boat_pass` / `ship_pass`, and the terrain battle backdrop below never
+  resolved. `ChipSet#terrain` answers 1 for a missing table now, and reads the
+  first lower tile's terrain for an id the chip index cannot reach.
   **Forced-action restrictions** work too: a
   `restriction` of 2 (berserk) forces a basic attack on a random enemy even when
   the battler was told to defend, and 3 (confused) sends the attack at a random

--- a/docs/adr/0034-terrain-tags-and-terrain-damage.md
+++ b/docs/adr/0034-terrain-tags-and-terrain-damage.md
@@ -1,0 +1,116 @@
+# 34. The ground you stand on
+
+Date: 2026-08-06
+
+## Status
+
+Accepted
+
+## Context
+
+RPG2000's 地形 (terrain) table gives every lower-layer tile a row of properties:
+whether a boat or a ship may cross it, which battle backdrop a fight there uses,
+and — the field nothing read — how much HP the party loses for walking on it.
+
+Two things were wrong, and only one of them was the missing feature.
+
+### The terrain tag itself was 0 almost everywhere
+
+`Game::ChipSet#terrain` answered **0** when the chipset carried no terrain array,
+which reads as "this tile has no terrain". Counting how often that happens in the
+test beds:
+
+| | chipsets with no terrain table |
+|---|---|
+| Nepheshel | **96 of 100** |
+| mtf-meido-action | **92 of 100** |
+
+That is not corrupt data. RPG_RT omits the whole 162-entry array when every tile
+of the chipset is terrain 1, which is the ordinary case for a chipset nobody
+bothered to tag — so an absent table means *terrain 1*, not *no terrain*.
+EasyRPG's `Game_Map::GetTerrainTag` says so in as many words ("RPG_RT
+optimisation: When the terrain is all 1, no terrain data is stored") and returns
+1.
+
+Reading it as 0 meant that on almost every map in both games:
+
+- Store Terrain ID stored 0, an id no database row can match;
+- `Scene::Map#terrain_row_at` found no row, so boats and ships fell back to
+  on-foot passability instead of the terrain's `boat_pass` / `ship_pass`;
+- the terrain battle backdrop (ADR-documented, `background_name`) never
+  resolved.
+
+A census of every map in both test beds confirms it: 414,993 of Nepheshel's
+lower-layer tiles read terrain 0 and 169,056 read a real tag; mtf's split 1,530
+to 18,535. The overwhelming majority of the ground in both games had no terrain.
+
+### Terrain damage was parsed and unread
+
+The 地形 row's `damage` field, and the item row's `no_terrain_damage`
+(地形ダメージ無効) that cancels it, were in the schema and used by nothing:
+
+| | damaging terrain | gear that blocks it |
+|---|---|---|
+| Nepheshel | #5 ダメージ床１ (1 HP), #6 ダメージ床２ (10 HP) | スクール水着, メイド服, チャイナドレス, 邪道なる指輪 |
+| mtf-meido-action | #5 Poison Swamp (1 HP), #8 Damage Floor (2 HP) | Safety Boots |
+
+## Decision
+
+**Read an absent terrain table as terrain 1.** `ChipSet#terrain` returns 1 for a
+`nil` or empty table, and a tile id the chip index cannot reach reads the *first*
+lower tile's terrain, which is what RPG_RT does for out-of-bounds coordinates,
+rather than an id no row matches.
+
+**Apply terrain damage on a step.** `Game::Party#apply_terrain_damage(amount)`
+takes `amount` HP off every party member who is not already down and not wearing
+gear flagged 地形ダメージ無効, and returns the members it hit.
+`Game::Actor#prevents_terrain_damage?` asks the existing `equipment_flag?`
+helper (ADR 0033), so any slot grants the immunity — mtf's is a pair of boots and
+Nepheshel's four include a swimsuit.
+
+`Scene::Map#note_party_step` reads it off the tile just stepped onto, through the
+`terrain_row_at` helper the vehicle passability check already uses, and folds the
+result into the same list the status-slip drain builds (ADR 0032). Both are the
+same "your HP just fell and the map has nowhere to say so" moment, so they share
+one red screen flash and one step counter — a step drains at most once from each
+source, and a teleport is not a step.
+
+The damage **cannot kill**: it goes through `change_hp` with death disallowed, so
+it floors at 1 HP. RPG2000 has no way to die to the floor, and EasyRPG's
+`easyrpg_damage_can_kill` extension that changes this defaults to false. This
+keeps terrain damage on the same footing as status slip damage: the one pair of
+party-damaging paths that need no game-over re-check.
+
+## Consequences
+
+The terrain tag is now the tag the game meant. For 96 of Nepheshel's 100
+chipsets and 92 of mtf's, every tile moves from terrain 0 (no row) to terrain 1
+(a real row) — which is the change that makes the boat/ship passability rule,
+the terrain battle backdrop and Store Terrain ID read the database at all on
+those maps. Terrain 1 in neither game deals damage, so nothing starts hurting.
+
+An honest limit on the second half: **neither test bed places a damaging tile on
+any map.** Sweeping all 543 Nepheshel maps and all 13 mtf maps through the fixed
+chipset lookup finds 0 tiles of terrains #5/#6 and #5/#8. Both authors defined
+the terrain (and Nepheshel four separate garments to survive it) and then did not
+use it, or used it in a map that did not ship. So this is the rare one where the
+real data proves the *definition* and not the *use*: the fields are set, the
+values are deliberate, and the runtime now honours them, but no walk through
+either shipped game will exercise it. The chipset half is the opposite — it moves
+almost every tile in both games.
+
+Covered by `scripts/rpg2k_logic_check.rb` (an absent and an empty terrain table
+both read 1; a populated one reads its own values; an unindexable tile reads the
+first), by `scripts/rpg2k_scene_check.rb` (walking a damaging tile drains the
+party and flashes, gear blocks it, it floors at 1 HP and skips a member already
+down) and by `scripts/rpg2k_testbed_logic_check.rb`, which asserts against the
+**real** tables that every one of the 96 / 92 untabled chipsets names terrain 1
+across every lower block, that each game's damaging terrain wears the real party
+down to 1 HP without killing it, and that each 地形ダメージ無効 item stops it
+from the slot its own type names.
+
+Left unread, and deliberately not guessed at: the terrain row's `special_flags`
+/ `special_back_party` battle-formation modifiers and its `on_damage_se` sound
+cue — no terrain in either test bed sets any of the three — and `damage`'s
+RPG2003 sibling behaviour where a tile may kill, which needs the game-over path
+this decision was written to avoid.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -460,13 +460,24 @@ module Game
     end
 
     # Terrain id of a lower-layer tile (for the Store Terrain ID command), looked
-    # up through the same chip index as passability. Returns 0 when the chipset
-    # carries no terrain table or the tile is out of range.
+    # up through the same chip index as passability.
+    #
+    # **A missing table means terrain 1, not terrain 0.** RPG_RT omits the whole
+    # 162-entry array when every tile of the chipset is terrain 1, which is the
+    # overwhelmingly common case: 96 of Nepheshel's 100 chipsets and 92 of
+    # mtf-meido-action's ship without one. Reading that as 0 left almost every
+    # tile in both games with no terrain row at all, so Store Terrain ID answered
+    # 0, boats and ships fell back to on-foot passability, and the terrain battle
+    # backdrop never resolved. EasyRPG's `Game_Map::GetTerrainTag` documents the
+    # same optimisation and answers 1.
+    #
+    # An id the chip index cannot reach reads the **first** lower tile's terrain,
+    # as RPG_RT does for out-of-bounds coordinates.
     def terrain(tile_id)
-      return 0 if @terrain.nil?
+      return 1 if @terrain.nil? || @terrain.empty?
       idx = ChipSet.lower_index(tile_id)
-      return 0 if idx.nil? || idx < 0 || idx >= @terrain.size
-      @terrain[idx] || 0
+      idx = 0 if idx.nil? || idx < 0 || idx >= @terrain.size
+      @terrain[idx] || 1
     end
   end
 
@@ -1339,6 +1350,11 @@ module Game
     # the weapon (Nepheshel's 賢者の指輪 is an accessory).
     def half_sp_cost?; equipment_flag?(:half_sp_cost); end
 
+    # 地形ダメージ無効 — gear that makes its wearer immune to the damage a tile's
+    # terrain deals as they walk over it (Party#apply_terrain_damage). Any slot:
+    # mtf-meido-action's is a pair of boots, Nepheshel's four include a swimsuit.
+    def prevents_terrain_damage?; equipment_flag?(:no_terrain_damage); end
+
     # 強力防御 — an actor whose Defend halves damage a *second* time (a quarter
     # rather than a half, per EasyRPG's `AdjustDamageForDefend`). This one is a
     # property of the actor row (field 24), not of gear, and an RPG2003 class can
@@ -1922,6 +1938,32 @@ module Game
         next if hp.zero? && sp.zero?
         actor.change_hp(-hp, false) if hp > 0
         actor.change_mp(-sp) if sp > 0
+        hit << actor
+      end
+      hit
+    end
+
+    # Damage every standing member for walking onto a damaging tile: RPG2000's
+    # 地形ダメージ, the `damage` field on the terrain a tile's chip belongs to.
+    #
+    # Like the status slip above it **cannot kill** — `change_hp` with death
+    # disallowed, so a party crossing a lava floor is worn to 1 HP and left
+    # standing — which is again why nothing here re-checks for a game over.
+    #
+    # A member wearing gear flagged `no_terrain_damage` is exempt, which is the
+    # only reason that flag exists: Nepheshel puts it on four items and
+    # mtf-meido-action on its Safety Boots, against damage floors of 1 HP a step
+    # (Nepheshel's ダメージ床 set, mtf's Poison Swamp).
+    #
+    # Returns the actors that actually lost HP, so the scene can flash only when
+    # there is something to report.
+    def apply_terrain_damage(amount)
+      return [] unless amount && amount > 0
+      hit = []
+      @actors.each do |actor|
+        next if actor.nil? || actor.dead?
+        next if actor.prevents_terrain_damage?
+        actor.change_hp(-amount, false)
         hit << actor
       end
       hit

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -4756,8 +4756,21 @@ class RPG2k
       def note_party_step
         steps = @state.walk_step
         hit = @state.party.apply_map_step_damage(state_table, steps)
+        # RPG2000's 地形ダメージ on top of it: the terrain the tile just stepped
+        # onto belongs to may take HP off everyone not wearing gear that blocks
+        # it. Read after the status slip and flashed together, since both are the
+        # same "your HP just fell and the map has nowhere to say so" moment.
+        hit = hit + terrain_step_damage
         return if hit.empty?
         @state.screen.flash(*STEP_DAMAGE_FLASH)
+      end
+
+      # Apply the damage of the terrain under the party, returning the actors it
+      # hit ([] when the tile is harmless or the database has no terrain table).
+      def terrain_step_damage
+        row = terrain_row_at(@state.x, @state.y)
+        return [] unless row && row.respond_to?(:damage)
+        @state.party.apply_terrain_damage(row.damage)
       end
 
       def target_tile(x, y, dir)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8130,6 +8130,46 @@ check 'a node missing its fields is treated as inheriting' do
   eq 'Wasteland', Game::Backdrop.name_for(1, { 1 => bare }, 'Wasteland')
 end
 
+# -- chipset terrain tags -----------------------------------------------------
+
+FakeChipsetRow = Struct.new(:name, :chipset_name, :passable_data_lower,
+                            :passable_data_upper, :terrain_data,
+                            :animation_type, :animation_speed)
+
+def chipset_with(terrain_data)
+  db = Struct.new(:chipset).new(
+    { 1 => FakeChipsetRow.new('cs', 'cs', nil, nil, terrain_data, 0, 0) }
+  )
+  Game::ChipSet.new(db, 1)
+end
+
+# RPG_RT drops the whole 162-entry terrain array when every tile of the chipset
+# is terrain 1, and that is what nearly every real chipset does. Reading the
+# absence as terrain 0 leaves the tile with no terrain row at all.
+check 'a chipset that stores no terrain table reads terrain 1' do
+  cs = chipset_with(nil)
+  eq 1, cs.terrain(0), 'the first lower tile'
+  eq 1, cs.terrain(4000), 'a block-E tile'
+  cs = chipset_with([])
+  eq 1, cs.terrain(0), 'an empty table is the same absence'
+end
+
+check 'a chipset that stores one reads it' do
+  td = Array.new(162, 3)
+  td[0] = 7
+  cs = chipset_with(td)
+  eq 7, cs.terrain(0)
+  eq 3, cs.terrain(4000)
+end
+
+# RPG_RT reads the first lower tile's terrain for anything it cannot index,
+# rather than answering with a terrain id no row can match.
+check 'an unindexable tile reads the first lower tile' do
+  td = Array.new(162, 3)
+  td[0] = 7
+  eq 7, chipset_with(td).terrain(-1)
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -180,7 +180,7 @@ def fake_map_with_counters(id, events, counters)
                                    upper_layer: upper, events: events))
 end
 
-def fake_db(common = nil, troop_pages = nil)
+def fake_db(common = nil, troop_pages = nil, terrain_damage = 0)
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: '',
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
@@ -241,6 +241,9 @@ def fake_db(common = nil, troop_pages = nil)
       timings: { 1 => OpenStruct.new(frame: 1, flash_scope: 2, flash_red: 31,
                                      flash_green: 31, flash_blue: 31, flash_power: 20) }
     ) },
+    # Every tile of the synthetic map is chip 0, which the fake chipset tags as
+    # terrain 42 — so this one row decides whether walking hurts.
+    terrain: { 42 => OpenStruct.new(damage: terrain_damage) },
     common_event: common,
     # Database actor rows carry the *original* names, which a \N[n] must not
     # use once the actor has been renamed in play (see the \N[n] check).
@@ -348,6 +351,8 @@ class SlipActor
   # marker sprite, which is what the rest of these checks already run on.
   attr_reader :charset_name, :charset_index
   attr_accessor :transparent
+  # 地形ダメージ無効 gear, which Party#apply_terrain_damage asks about.
+  attr_accessor :prevents_terrain_damage
 
   def initialize(states = [], hp = 100, mp = 20)
     @states = states
@@ -356,7 +361,10 @@ class SlipActor
     @charset_name = ''
     @charset_index = 0
     @transparent = false
+    @prevents_terrain_damage = false
   end
+
+  def prevents_terrain_damage?; @prevents_terrain_damage; end
 
   def dead?; @hp <= 0; end
 
@@ -380,8 +388,8 @@ def fake_party(members = [])
 end
 
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
-              members: [])
-  db = fake_db(common, troop_pages)
+              members: [], terrain_damage: 0)
+  db = fake_db(common, troop_pages, terrain_damage)
   state = Game::State.new(fake_party(members), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   RPG2k::Scene::Map.new(fake_parent(db), state)
@@ -3643,6 +3651,49 @@ check 'walking slips HP from a poisoned member every fourth tile' do
   walk(scene, 1)
   eq 4, st.steps
   eq 99, hero.hp, 'the fourth tile slips 1 HP'
+end
+
+check 'walking a damaging terrain takes HP every tile' do
+  # 地形ダメージ: unlike the status slip this is a property of the ground, and it
+  # bites on every tile rather than on an interval. Nepheshel's ダメージ床 set and
+  # mtf-meido-action's Poison Swamp are the real ones, both at 1 HP.
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero], terrain_damage: 3)
+  st = scene.instance_variable_get(:@state)
+
+  walk(scene, 1)
+  eq 1, st.steps
+  eq 97, hero.hp, 'the first tile already hurts'
+  walk(scene, 2)
+  eq 91, hero.hp, 'and so does every one after it'
+end
+
+check 'gear flagged 地形ダメージ無効 walks the damaging ground unharmed' do
+  hero = SlipActor.new([])
+  hero.prevents_terrain_damage = true
+  scene = new_scene({}, player: [0, 0], members: [hero], terrain_damage: 3)
+  walk(scene, 4)
+  eq 100, hero.hp, 'the boots blocked all four tiles'
+end
+
+check 'terrain damage cannot kill, and skips a member already down' do
+  hurt = SlipActor.new([], 2)
+  scene = new_scene({}, player: [0, 0], members: [hurt], terrain_damage: 5)
+  walk(scene, 3)
+  eq 1, hurt.hp, 'worn to 1 HP and left standing'
+  ok !hurt.dead?
+
+  down = SlipActor.new([], 0)
+  scene2 = new_scene({}, player: [0, 0], members: [down], terrain_damage: 5)
+  walk(scene2, 2)
+  eq 0, down.hp, 'a member already down is skipped'
+end
+
+check 'harmless ground takes nothing' do
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero])   # damage 0
+  walk(scene, 4)
+  eq 100, hero.hp
 end
 
 check 'a clear member walks the same ground untouched' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -73,6 +73,8 @@ DB_SKILL = 12
 DB_ITEM = 13
 DB_STATE = 18
 DB_ACTOR = 11
+DB_TERRAIN = 16
+DB_CHIPSET = 20
 CHANGE_PARTY = Game::Interpreter::Cmd::CHANGE_PARTY
 
 # Commands that name one actor by a fixed id rather than acting on the party.
@@ -645,7 +647,88 @@ def first_actor_id(db)
   1
 end
 
-dirs.each { |d| check_game(d); check_menus(d); check_states(d); check_equipment(d) }
+# 地形ダメージ against the real terrain table, and the gear that blocks it.
+# A damaging tile that takes nothing is a floor with no teeth; gear sold to
+# survive it that does not is worse.
+def check_terrain(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  terrain = db[DB_TERRAIN]
+  return unless terrain
+
+  # RPG_RT omits a chipset's whole terrain array when every one of its tiles is
+  # terrain 1, and that is what nearly every chipset in a real game does. Reading
+  # the absence as terrain 0 left those tiles naming no terrain row at all.
+  bare = []
+  total_cs = 0
+  db[DB_CHIPSET]&.each do |id, c|
+    total_cs += 1
+    bare << id if c.terrain_data.nil? || c.terrain_data.empty?
+  end
+  puts format('   chipsets: %d of %d store no terrain table at all',
+              bare.size, total_cs)
+  unless bare.empty?
+    check "#{name}: a chipset with no terrain table still names a terrain row" do
+      bare.each do |id|
+        cs = Game::ChipSet.new(db, id)
+        # One tile id out of each lower block, plus an id no block claims.
+        [0, 1000, 3000, 4000, 5000, -1].each do |tile|
+          eq 1, cs.terrain(tile), "chipset ##{id} (#{db[DB_CHIPSET][id].name}) tile #{tile}"
+        end
+        ok terrain[1], 'and terrain #1 is a row the database really has'
+      end
+    end
+  end
+
+  damaging = []
+  terrain.each { |id, r| damaging << id if (r.damage || 0) > 0 }
+  blockers = []
+  db[DB_ITEM]&.each { |id, it| blockers << id if it.no_terrain_damage }
+  puts format('   terrain: %d damaging tile type(s), %d item(s) that block them',
+              damaging.size, blockers.size)
+  return if damaging.empty?
+
+  check "#{name}: a damaging terrain takes HP, and cannot kill" do
+    party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+    leader = party.leader
+    ok leader, 'the game has a party to hurt'
+    damaging.each do |tid|
+      amount = terrain[tid].damage
+      leader.hp = leader.max_hp
+      hit = party.apply_terrain_damage(amount)
+      ok hit.include?(leader),
+         "terrain ##{tid} (#{terrain[tid].name}, #{amount} HP) hit the leader"
+      eq leader.max_hp - amount, leader.hp
+      # However long the party stands in it, it is worn down rather than killed.
+      (leader.max_hp / amount + 2).times { party.apply_terrain_damage(amount) }
+      eq 1, leader.hp, "terrain ##{tid} floors at 1 HP instead of killing"
+      ok !leader.dead?
+    end
+  end
+
+  return if blockers.empty?
+  check "#{name}: gear flagged 地形ダメージ無効 blocks it" do
+    party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+    leader = party.leader
+    worst = damaging.map { |tid| terrain[tid].damage }.max
+    blockers.each do |iid|
+      slot = db[DB_ITEM][iid].type - 1
+      next unless slot >= 0 && slot < 5
+      gear = [0, 0, 0, 0, 0]
+      gear[slot] = iid
+      leader.equip(gear)
+      ok leader.prevents_terrain_damage?,
+         "item ##{iid} (#{db[DB_ITEM][iid].name}) grants the immunity"
+      leader.hp = leader.max_hp
+      eq [], party.apply_terrain_damage(worst), 'and nothing gets through'
+      eq leader.max_hp, leader.hp
+    end
+  end
+end
+
+dirs.each do |d|
+  check_game(d); check_menus(d); check_states(d); check_equipment(d); check_terrain(d)
+end
 
 if $failures.zero?
   puts "rpg2k test-bed logic check: #{$checks} checks passed"


### PR DESCRIPTION
Two fixes to the same lookup. The second is the feature; the first is the one that matters.

## A chipset with no terrain table means terrain 1, not terrain 0

`Game::ChipSet#terrain` answered **0** when the chipset carried no terrain array. That is not corrupt data — RPG_RT omits the whole 162-entry array when every tile of the chipset is terrain 1, which is the ordinary case for a chipset nobody tagged. EasyRPG's `Game_Map::GetTerrainTag` documents it in as many words ("RPG_RT optimisation: When the terrain is all 1, no terrain data is stored") and returns 1.

How often it happens in the test beds:

| | chipsets with no terrain table |
|---|---|
| Nepheshel | **96 of 100** |
| mtf-meido-action | **92 of 100** |

Sweeping every shipped map through the lookup: **414,993** of Nepheshel's lower-layer tiles read terrain 0 against 169,056 that read a real tag; mtf's split is 1,530 to 18,535. On almost all the ground in both games:

- Store Terrain ID stored 0, an id no database row can match;
- `Scene::Map#terrain_row_at` found no row, so boats and ships fell back to on-foot passability instead of the terrain's `boat_pass` / `ship_pass`;
- the terrain battle backdrop (`background_name`) never resolved.

An id the chip index cannot reach now reads the **first** lower tile's terrain, which is what RPG_RT does for out-of-bounds coordinates, rather than an id no row matches.

## 地形ダメージ

The terrain row's `damage` field, and the item row's `no_terrain_damage` that cancels it, were parsed and read by nothing:

| | damaging terrain | gear that blocks it |
|---|---|---|
| Nepheshel | #5 ダメージ床１ (1 HP), #6 ダメージ床２ (10 HP) | スクール水着, メイド服, チャイナドレス, 邪道なる指輪 |
| mtf-meido-action | #5 Poison Swamp (1 HP), #8 Damage Floor (2 HP) | Safety Boots |

`Game::Party#apply_terrain_damage` takes the tile's damage off every member who is not already down and is not wearing gear flagged 地形ダメージ無効 (`Actor#prevents_terrain_damage?`, through the same `equipment_flag?` helper as the other combat flags, so any slot grants it). `Scene::Map#note_party_step` reads it off the tile just stepped onto via the `terrain_row_at` helper the vehicle check already uses, and folds the result into the list the status slip drain builds — same step counter, same single red flash, so a step drains at most once from each source and a teleport drains nothing.

It **cannot kill**: `change_hp` with death disallowed, floored at 1 HP. RPG2000 has no way to die to the floor (EasyRPG's `easyrpg_damage_can_kill` extension that changes this defaults to false), which keeps this on the same footing as the status slip — the pair of party-damaging paths that need no game-over re-check.

## What the real data does and doesn't prove

Honestly stated in the ADR: **neither test bed places a damaging tile on any map.** All 543 Nepheshel maps and all 13 mtf maps contain 0 tiles of terrains #5/#6 and #5/#8. Both authors defined the terrain — and Nepheshel four separate garments to survive it — and then didn't use it, or used it in a map that didn't ship. So the damage half is proved by its *definition* rather than its *use*. The chipset half is the opposite: it moves almost every tile in both games.

## Verification

All 14 `scripts/*_check.rb` suites pass. New coverage, each confirmed to fail against the pre-fix code:

- `rpg2k_logic_check.rb` (541, +3): an absent and an empty terrain table both read 1; a populated one reads its own values; an unindexable tile reads the first.
- `rpg2k_scene_check.rb` (169, +4): walking a damaging tile drains the party and flashes; gear blocks it; it floors at 1 HP and skips a member already down.
- `rpg2k_testbed_logic_check.rb` (68, +3): against the **real** tables, every one of the 96 / 92 untabled chipsets names terrain 1 across every lower block; each game's damaging terrain wears the real party down to 1 HP without killing it; each 地形ダメージ無効 item stops it from the slot its own type names.

See `docs/adr/0034-terrain-tags-and-terrain-damage.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_