### PR TITLE
Use the MZ menu, and find the bed had nothing in it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,6 +391,22 @@ jobs:
               MZ_MODE: menu
             run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
 
+          # Opening Scene_Menu is the same size of claim as reaching
+          # Scene_Battle was — it holds the instant the scene is pushed, before
+          # its first update — and the step above had been green on a bed whose
+          # item database was empty, where the menu has nothing to do at all.
+          # This mode uses the menu: the party is given a Potion and the actor
+          # is wounded through event commands, then confirm walks the command
+          # window, the item category, the item list and the actor window, and
+          # cancel unwinds back to the map. It asserts `healed=true` (an item's
+          # effect reached an actor's HP), `used=true` (the inventory paid for
+          # it) and `returned=true` (the stack unwound). See ADR 0004 M6.3j.
+          - name: MZ menu-play smoke test
+            continue-on-error: true
+            env:
+              MZ_MODE: menu_play
+            run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
+
           # The animation path, which nothing else here touches. MZ picks
           # between two animation systems by data shape: an animation carrying
           # a `frames` array draws as sprites (Sprite_AnimationMV), anything
@@ -430,13 +446,15 @@ jobs:
           # first broken update. This mode plays the fight out — confirm is
           # tapped through the party/actor/target windows until an enemy takes
           # damage and the victory sequence hands back to the map — and asserts
-          # `damaged=true ended=true`. Longer timeout: several turns of software
-          # GL. See ADR 0004 M6.3i.
+          # `damaged=true ended=true`. See ADR 0004 M6.3i. The timeout is left
+          # to the script's per-mode default (this fight needs the most room of
+          # any mode, and an override here is what would silently cut it short
+          # on a slow runner); the run ends as soon as the probe reports, so the
+          # ceiling costs nothing when the fight is quick.
           - name: MZ battle-play smoke test
             continue-on-error: true
             env:
               MZ_MODE: battle_play
-              MZ_TIMEOUT_MS: "120000"
             run: ./scripts/nix-develop.bash ./scripts/mz_boot_check.bash 111
 
           # Run the battle smoke against the real bed (Lunatic-Core): it ships

--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@
   window opened. MZ's save path is a **promise chain** (JsonEx → pako
   → localforage) rather than MV's synchronous call, so the probe starts it and
   polls until it settles, then re-enters the map the way `Scene_Load` does
+- The menu is **used**, not just opened, for the same reason: `menu_play` mode
+  hands the party a Potion and wounds the actor through event commands, then
+  taps confirm through the command window, the item category, the item list and
+  the actor window until the item heals and is spent, and cancel back out to the
+  map. It asserts the HP rose, the inventory paid for it and the map came back.
+  That walk worked first time — but it found the bed had shipped **no items at
+  all**, so `Scene_Item` had been opening onto an empty list, and `menu` mode
+  reported the same `reached_menu=true` either way
 - All of that is **on screen**, not just in the scene graph: the title and its
   command window, the map with the player sprite and the touch UI, message
   windows with their text, and the party menu over a blurred map background. It
@@ -289,9 +297,13 @@
   `scripts/download-mz-corescript.bash` fetches the engine at build time.
   `scripts/mz_boot_check.bash` boots that bed headlessly and asserts what the
   requested `MZ_MODE` claims — `play` (the default: the map is reached and a held
-  key moves the player), `message`, `menu`, `animation`, `save`, `battle` or
-  `battle_play`, each with its own success line so a probe that merely ran
-  cannot pass; `ruby
+  key moves the player), `message`, `menu`, `menu_play`, `animation`, `save`,
+  `battle` or `battle_play`, each with its own success line so a probe that
+  merely ran cannot pass. A run ends as soon as its probes have reported rather
+  than idling out its `--timeout_ms`, so the budget is a ceiling for the slowest
+  host instead of the time every run takes — a cut-off run reports nothing at
+  all, which had made a battle that was still swinging look like one that never
+  landed a hit; `ruby
   scripts/mz_testbed_check.rb path/to/Game` validates any MZ project's
   boot-critical data and system art without a build
 - Those assertions all read the engine's **log**, which is how the empty frames

--- a/changelog.d/mz-menu-play.added.md
+++ b/changelog.d/mz-menu-play.added.md
@@ -1,0 +1,24 @@
+- **MZ's menu is now driven the way a player drives it.** `--mz_menu_play`
+  (`MZ_MODE=menu_play`) hands the party a Potion and wounds the actor through
+  Change Items / Change HP event commands, then taps confirm through
+  `Window_MenuCommand`, the item category, the item list and the actor window,
+  and cancel back out — asserting the item healed (`healed=true`), the inventory
+  paid for it (`used=true`) and the map came back (`returned=true`). The
+  existing check only asserted `Scene_Menu` was *reached*, which is true the
+  instant the scene is pushed, before its first update — the same shape of claim
+  that had hidden MZ's frozen battles. The menu itself turned out to work first
+  time, but the walk found the test bed shipping **no items at all**
+  (`Items.json` was `[null]`), so `Scene_Item` had been opening onto an empty
+  list with nothing in the project to use; the bed now authors a Potion, and the
+  old check still reports `reached_menu=true` on the empty bed the new one fails
+  on.
+- **A smoke run now ends when its probes have reported, not when its clock runs
+  out.** The probes give up after so many *frames* while `--timeout_ms` counts
+  *milliseconds*, and a headless software-GL frame costs far more wall clock on
+  a loaded host — so a run could be cut off mid-probe, and a cut-off run prints
+  no report at all. That is how a battle that was landing damage and cycling
+  turns came to be reported as "no attack ever damaged an enemy". Runs now stop
+  as soon as every requested probe has had its say (the eight MZ modes take
+  11–116s each rather than a flat 60s), the two play-out modes get ceilings
+  sized for the slowest host instead of the fastest, and the checks say "the run
+  ended before the fight did" when that is what happened.

--- a/data/mz-sample/data/Items.json
+++ b/data/mz-sample/data/Items.json
@@ -1,1 +1,1 @@
-[null]
+[null,{"id":1,"name":"Potion","note":"","description":"Restores HP.","iconIndex":0,"itypeId":1,"price":50,"consumable":true,"scope":7,"occasion":0,"speed":0,"successRate":100,"repeats":1,"tpGain":0,"hitType":0,"animationId":0,"damage":{"type":0,"elementId":0,"formula":"0","variance":20,"critical":false},"effects":[{"code":11,"dataId":0,"value1":0,"value2":100}]}]

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -549,6 +549,59 @@ JavaScript loads and interprets the JSON.
         silently in this host, which is worth remembering the next time a scene
         looks alive and does nothing.
 
+    - **M6.3j — the menu, actually used (landed).** M6.3i's finding was about a
+      *shape* of assertion, not about battles: `[MZ-MENU] reached_menu=true` is
+      the same claim `reached_battle=true` was — true the instant the scene is
+      pushed, before its first update — and the menu was the last in-game system
+      still resting on it. `--mz_menu_play` (`MZ_MODE=menu_play`) uses the menu
+      instead: confirm walks `Window_MenuCommand` to Item, the item category,
+      the item list and the actor window; then cancel unwinds the stack back to
+      the map. It asserts `healed=true used=true returned=true` — an item's
+      effect reached an actor's HP, the inventory paid for it, and the menu
+      handed the player back.
+
+      **The menu worked.** Unlike the battle, the walk came out right on the
+      first run (`hp_before=100 hp_after=200 items_before=3 items_after=2`), so
+      this milestone adds coverage rather than a fix. Two things had been hiding
+      behind the old assertion anyway:
+
+      * **The bed had no items at all.** `Items.json` was `[null]`, so
+        `Scene_Item` opened onto an empty list and there was nothing in the
+        project to use, equip or sell. A menu with nothing in it cannot tell a
+        working item path from a broken one, which is why the bed now authors a
+        Potion (`scope` 7 so the actor window is in the flow, flat `value2`
+        recovery so the probe can assert a figure). Running the new mode against
+        the old empty bed fails on `healed=true` — while the old `menu` mode
+        still reports `reached_menu=true` on that same run, which is the whole
+        point.
+      * **A healing item is only selectable while someone is hurt**
+        (`Game_Action.testApply` → `isItemEffectsValid`), and MZ has no
+        starting-inventory field. So the probe arms the party first — Change
+        Items and Change HP, run through the *map interpreter* as the event
+        commands a real project would use, the same way M6.3i's Battle
+        Processing is injected rather than calling `SceneManager.push`.
+
+    - **M6.3j (cont.) — the run budget was in the wrong unit.** Adding the mode
+      surfaced a defect in every mode: a probe gives up after so many *frames*,
+      the engine after so many *milliseconds* (`--timeout_ms`), and a headless
+      software-GL frame costs far more wall clock on a loaded host than on a
+      fast one. On this container the battle play-out — green in CI and locally
+      at M6.3i — now ran out of wall clock mid-fight, having landed 41 damage
+      and cycled several turns, and the check reported **"no attack ever
+      damaged an enemy"**: a cut-off run prints no report at all, and the
+      absence of the line was being read as the thing under test never
+      happening. Exactly the M6.3e/M6.3i failure mode, one layer out.
+
+      Two changes. `MZ#finish_when_probes_done` ends the run as soon as every
+      requested probe has reported and the screenshot is taken (raising
+      `RGSS::Timeout`, the same path the engine's own budget unwinds through),
+      so `--timeout_ms` becomes a true ceiling rather than the running time —
+      the eight modes now take 11–116s each instead of a flat 60s, and
+      `battle_play` completes where it used to be cut off. The two play-out
+      modes then get ceilings sized for the slowest host (180s and 280s), and
+      the checks distinguish "the run ended before the fight did" from "nothing
+      was damaged" so the message names the real cause.
+
   **Concrete boot map (verified by running the engine on the host).** MZ's boot
   differs from MV's in more than the renderer. Driving the shared host through a
   real MZ project (`MZ#boot_probe`) turned the earlier source-read guesses into

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -58,6 +58,29 @@ class MZ
   # gives up (see #maybe_menu_test).
   MENU_PROBE_FRAMES = 60
 
+  # The menu-play probe's setup and bounds (see #maybe_menu_play_test). The
+  # party is given `MENU_PLAY_ITEMS` of item `MENU_PLAY_ITEM_ID` and the actor
+  # is wounded by `MENU_PLAY_WOUND` HP *before* the menu opens, both through the
+  # map interpreter — a healing item is only selectable while someone is hurt,
+  # and the party starts with nothing (MZ has no starting-inventory field; a
+  # game hands out its first items from an event, which is exactly what the
+  # setup runs).
+  MENU_PLAY_ITEM_ID = 1
+  MENU_PLAY_ITEMS = 3
+  MENU_PLAY_WOUND = 300
+
+  # Frames to give the menu play-out, and how often it taps a key. Same edge
+  # reasoning as the battle probe: rmmz reports a trigger on the key's edge, so
+  # a held key advances one window and then nothing. The bound is generous —
+  # every window in the chain fades in, and a headless software-GL frame is
+  # slower than 60Hz.
+  MENU_PLAY_FRAMES = 900
+  MENU_PLAY_TAP_PERIOD = 12
+
+  # Frames the menu-play setup waits for its event commands to take effect
+  # before reporting that the bed could not be prepared.
+  MENU_PLAY_SETUP_FRAMES = 180
+
   # The animation the animation probe plays, and how long it keeps replaying it
   # (see #maybe_animation_test). The test bed authors animation 1 as an
   # MV-format burst centred on its target; a project without it logs
@@ -280,6 +303,54 @@ class MZ
       "(function(){ var s = (typeof SceneManager !== 'undefined') ? " \
       "SceneManager._scene : null; if (s && s.constructor && " \
       "s.constructor.name === 'Scene_Map') s.menuCalling = true; })();"
+    end
+
+    # JS that sets the menu-play probe's starting condition the way a game
+    # does: **Change Items** (code 126) and **Change HP** (code 311) run
+    # through the *map interpreter*, not by reaching into `$gameParty` and
+    # `$gameActors` from outside. Same reasoning as the battle probe's code
+    # 301 — the engine path a real project takes is the one worth driving, and
+    # `command126`/`command311` are where the party inventory and an actor's HP
+    # are actually written.
+    #
+    # `[itemId, operation, operandType, operand]` for 126 and
+    # `[actorSource, actorId, operation, operandType, operand, allowDeath]` for
+    # 311, both with operation 0 = increase / 1 = decrease and operand type
+    # 0 = constant, exactly as the editor emits them.
+    def menu_play_setup_js(item_id, count, wound)
+      "(function(){ if (typeof $gameMap === 'undefined' || !$gameMap || " \
+      "!$gameMap._interpreter) return; $gameMap._interpreter.setup([" \
+      "{code:126,indent:0,parameters:[#{item_id.to_i},0,0,#{count.to_i}]}," \
+      "{code:311,indent:0,parameters:[0,1,1,0,#{wound.to_i},false]}," \
+      "{code:0,indent:0,parameters:[]}], 0); })();"
+    end
+
+    # JS that reads back what the menu play-out is doing: the first actor's HP,
+    # how many of the probe's item the party holds, and which window currently
+    # has the cursor.
+    #
+    # The window is read by walking the scene's own window layer and reporting
+    # the first *active* `Window_Selectable` rather than by naming the fields of
+    # each scene (`_categoryWindow`, `_itemWindow`, `_actorWindow`, …): the
+    # chain crosses two scenes, and a flow that stalls stalls *somewhere* — the
+    # constructor name says where without the probe having to enumerate every
+    # place it could be.
+    def menu_play_state_js(item_id)
+      "(function(){ var hp = -1, mhp = -1, n = -1; " \
+      "if (typeof $gameActors !== 'undefined' && $gameActors) { " \
+      "var a = $gameActors.actor(1); if (a) { hp = a.hp; mhp = a.mhp; } } " \
+      "if (typeof $gameParty !== 'undefined' && $gameParty && " \
+      "typeof $dataItems !== 'undefined' && $dataItems[#{item_id.to_i}]) " \
+      "n = $gameParty.numItems($dataItems[#{item_id.to_i}]); " \
+      "var s = (typeof SceneManager !== 'undefined') ? SceneManager._scene : " \
+      "null; var w = '', idx = -1; " \
+      "var layer = s ? s._windowLayer : null; " \
+      "var kids = layer ? layer.children : null; " \
+      "if (kids) { for (var i = 0; i < kids.length; i++) { var c = kids[i]; " \
+      "if (c && c.active && c.constructor && c.index) { " \
+      "w = c.constructor.name; idx = c.index(); break; } } } " \
+      "return 'hp=' + hp + ' mhp=' + mhp + ' items=' + n + " \
+      "' win=' + (w || '-') + ' idx=' + idx; })();"
     end
 
     # JS that asks for an animation on the player through `$gameTemp`, exactly
@@ -524,13 +595,16 @@ class MZ
     maybe_move_test # CI: hold a direction on the map and log that the player moved
     maybe_message_test # CI: show a message on the map and log the window opened
     maybe_animation_test # CI: play an animation on the player and log it drew
+    maybe_menu_play_setup # CI: arm the party (item + a wound) before the menu
     maybe_menu_test # CI: open the menu on the map and log that Scene_Menu opened
+    maybe_menu_play_test # CI: use that menu and log the item healed and was spent
     maybe_save_test # CI: save+load round-trip on the map and log the result
     maybe_audio_test # CI: play an SE through the bridge and log it dispatched
     present
     maybe_screenshot # capture the presented frame once, if requested (CI)
     RGSS::Input.update
     RGSS::Graphics.update
+    finish_when_probes_done # CI: stop once every probe has had its say
   end
 
   private
@@ -965,6 +1039,11 @@ class MZ
   def maybe_menu_test
     return if @menu_test_done
     return unless menu_test_requested?
+    # With --mz_menu_play the menu has to open onto a prepared party, so the
+    # menu waits for #maybe_menu_play_setup. It would not open during the setup
+    # event anyway (`updateCallMenu` disables the menu while an event runs), so
+    # without this the probe would burn its whole frame budget being ignored.
+    return if menu_play_requested? && !@menu_play_ready
     return unless @menu_requested || current_scene == "Scene_Map"
 
     if current_scene == "Scene_Menu"
@@ -984,6 +1063,144 @@ class MZ
     $stderr.puts "[MZ-MENU] reached_menu=false scene=#{current_scene}"
   rescue StandardError => e
     $stderr.puts "[MZ] menu test error: #{e.message}"
+  end
+
+  # Whether --mz_menu_play was requested (a launcher constant set by main.cxx).
+  # Implies --mz_menu_test, since the play-out starts from the open menu.
+  def menu_play_requested?
+    (begin
+      MZ_MENU_PLAY
+    rescue StandardError
+      false
+    end) == true
+  end
+
+  # When --mz_menu_play is set (CI), give the party the probe's item and wound
+  # the actor while still on the map, then let the menu open (see
+  # #maybe_menu_test). Both go through the map interpreter as the event commands
+  # a game would use — see MZ.menu_play_setup_js.
+  #
+  # A menu opened onto the bed's untouched party has nothing to do: the party
+  # holds no items, and even holding one, a full-HP actor greys the row out
+  # (`Game_Action.testApply`) and confirm buzzes. The setup is what makes the
+  # play-out a test of the menu rather than of an empty list.
+  #
+  # If the setup never takes it gives up rather than blocking the menu forever;
+  # the play report then lands with `healed=false`, which fails the check
+  # loudly instead of the run timing out with nothing said.
+  def maybe_menu_play_setup
+    return if @menu_play_ready
+    return unless menu_play_requested?
+    return unless current_scene == "Scene_Map"
+
+    @menu_setup_frame ||= 0
+    if @menu_setup_frame.zero?
+      $stderr.puts "[MZ] auto menu play: preparing the party"
+      MV::JS.eval(
+        self.class.menu_play_setup_js(MENU_PLAY_ITEM_ID, MENU_PLAY_ITEMS,
+                                      MENU_PLAY_WOUND)
+      )
+    end
+    @menu_setup_frame += 1
+
+    state = MV::JS.eval(self.class.menu_play_state_js(MENU_PLAY_ITEM_ID))
+    hp = MZ.state_field(state, "hp")
+    mhp = MZ.state_field(state, "mhp")
+    items = MZ.state_field(state, "items")
+
+    if !hp.nil? && !mhp.nil? && hp.positive? && hp < mhp && items.to_i.positive?
+      @menu_play_ready = true
+      @menu_play_hp0 = hp
+      @menu_play_items0 = items
+      $stderr.puts "[MZ-MENUPLAY] setup #{state}"
+      return
+    end
+    return if @menu_setup_frame < MENU_PLAY_SETUP_FRAMES
+
+    @menu_play_ready = true
+    $stderr.puts "[MZ-MENUPLAY] setup never took: #{state}"
+  rescue StandardError => e
+    $stderr.puts "[MZ] menu play setup error: #{e.message}"
+  end
+
+  # When --mz_menu_play is set (CI), once `Scene_Menu` is up, *use* it: tap
+  # confirm through the command window (Item), the item category, the item list
+  # and the actor window until the potion is spent and the actor's HP rises,
+  # then tap cancel back out until the map returns.
+  #
+  # The existing menu probe proves the menu can be **opened**, which is a much
+  # smaller claim than the menu working — it holds the instant `Scene_Menu` is
+  # pushed, before the scene's first update. Everything a player does with the
+  # menu is untested by it: `Window_MenuCommand` taking a command,
+  # `Scene_Item`'s category and item lists, an item's effects reaching an
+  # actor's HP through `Game_Action`, the inventory losing the consumed item,
+  # and cancel unwinding the whole stack back to the map.
+  #
+  # Like the battle play-out this drives real key presses rather than calling
+  # the scenes' methods: the windows *are* what is under test, so reaching past
+  # them into `Game_Party#consumeItem` would test the part that already worked.
+  #
+  # The report is one-shot and lands the moment the map comes back, so a run
+  # that finishes early does not stall.
+  def maybe_menu_play_test
+    return if @menu_play_done
+    return unless menu_play_requested?
+    return unless @menu_play_started || current_scene == "Scene_Menu"
+
+    @menu_play_frame ||= 0
+    state = MV::JS.eval(self.class.menu_play_state_js(MENU_PLAY_ITEM_ID))
+    hp = MZ.state_field(state, "hp")
+    items = MZ.state_field(state, "items")
+
+    if @menu_play_frame.zero?
+      @menu_play_started = true
+      $stderr.puts "[MZ] auto menu play: #{state}"
+    end
+    @menu_play_frame += 1
+    @menu_play_hp = hp
+    @menu_play_items = items
+    @menu_play_state = state
+    @menu_play_healed ||= !hp.nil? && !@menu_play_hp0.nil? &&
+                          hp > @menu_play_hp0
+    @menu_play_used ||= !items.nil? && !@menu_play_items0.nil? &&
+                        items < @menu_play_items0
+    # Latched for the screenshot: the target window is the frame worth keeping
+    # (see #menu_play_shot_ready?).
+    @menu_play_at_actor ||= state.to_s.include?("win=Window_MenuActor")
+
+    # Trace on change rather than on a timer: a menu that is being walked prints
+    # a line per window, and one that is stuck prints nothing after the first —
+    # which is the diagnosis.
+    if state != @menu_play_last_state
+      @menu_play_last_state = state
+      $stderr.puts "[MZ-MENUPLAY] state #{state}"
+    end
+
+    # Confirm walks in; once the item has actually been spent, cancel walks the
+    # window stack back out to the map. Both are tapped, not held, for the same
+    # edge-trigger reason as the battle probe.
+    used = @menu_play_healed && @menu_play_used
+    RGSS::Input.release(RGSS::Input::C)
+    RGSS::Input.release(RGSS::Input::B)
+    if (@menu_play_frame % MENU_PLAY_TAP_PERIOD).zero?
+      RGSS::Input.press(used ? RGSS::Input::B : RGSS::Input::C)
+    end
+
+    returned = used && current_scene == "Scene_Map"
+    return if !returned && @menu_play_frame < MENU_PLAY_FRAMES
+
+    @menu_play_done = true
+    RGSS::Input.release(RGSS::Input::C)
+    RGSS::Input.release(RGSS::Input::B)
+    $stderr.puts "[MZ-MENUPLAY] hp_before=#{@menu_play_hp0} " \
+                 "hp_after=#{@menu_play_hp} items_before=#{@menu_play_items0} " \
+                 "items_after=#{@menu_play_items} " \
+                 "healed=#{@menu_play_healed ? true : false} " \
+                 "used=#{@menu_play_used ? true : false} " \
+                 "returned=#{returned ? true : false} scene=#{current_scene} " \
+                 "last=[#{@menu_play_state}]"
+  rescue StandardError => e
+    $stderr.puts "[MZ] menu play error: #{e.message}"
   end
 
   # Whether --mz_save_test was requested (a launcher constant set by main.cxx).
@@ -1155,6 +1372,7 @@ class MZ
     return if @frames < SHOT_DELAY_FRAMES
     return if battle_test_troop > 0 && !battle_shot_ready?
     return if animation_test_requested? && !animation_shot_ready?
+    return if menu_play_requested? && !menu_play_shot_ready?
 
     @shot_taken = true
     handle = mz_gl_handle
@@ -1182,6 +1400,70 @@ class MZ
   # drew still produces the screenshot that shows it.
   def animation_shot_ready?
     @anim_cells_now || @anim_test_done
+  end
+
+  # End the run once every probe that was asked for has reported and the
+  # screenshot has been taken, rather than idling until `--timeout_ms`.
+  #
+  # The two budgets are in different units, and that is the whole problem: a
+  # probe gives up after so many *frames*, the engine after so many
+  # *milliseconds*. A headless software-GL frame costs far more wall clock on a
+  # slow or loaded host than on a fast one, so the same run that reports in half
+  # its budget on one machine is cut off mid-probe on another — and a cut-off
+  # run prints no report at all, which reads downstream as "the thing under test
+  # never happened" rather than "the run ended early". The battle play-out hit
+  # exactly this: the fight was landing damage and cycling turns, and the check
+  # said no attack ever damaged an enemy.
+  #
+  # Finishing when the work is done decouples them: `--timeout_ms` can be set
+  # generously enough for the slowest host without every run on a fast one
+  # taking that long. `RGSS::Timeout` is what the engine itself raises to unwind
+  # the loop (see #start), so this ends the run on the same path.
+  #
+  # Only ever fires when at least one probe was requested — normal play, and
+  # Emscripten (which calls #main_loop directly, outside the rescue), never set
+  # those flags.
+  def finish_when_probes_done
+    pending = [
+      [move_test_requested?, @move_test_done],
+      [message_test_requested?, @msg_test_done],
+      [animation_test_requested?, @anim_test_done],
+      [menu_test_requested?, @menu_test_done],
+      [menu_play_requested?, @menu_play_done],
+      [save_test_requested?, @save_test_done],
+      [battle_test_troop > 0, @battle_test_done],
+      [battle_play_requested?, @btl_play_done],
+      [audio_test_requested?, @audio_test_done],
+    ]
+    requested = pending.select { |asked, _| asked }
+    return if requested.empty?
+    return unless requested.all? { |_, done| done }
+    return if screenshot_requested? && !@shot_taken
+
+    $stderr.puts "[MZ] every probe reported; ending the run"
+    raise RGSS::Timeout, "probes finished"
+  end
+
+  # Whether a screenshot was asked for (a launcher constant set by main.cxx).
+  def screenshot_requested?
+    path = begin
+      MZ_SCREENSHOT
+    rescue StandardError
+      ""
+    end
+    !(path.nil? || path.empty?)
+  end
+
+  # Is this a frame worth photographing for the menu play-out? The fixed delay
+  # alone lands wherever the walk happens to be — including back on the map, if
+  # the setup event is still running — and a map frame proves nothing about the
+  # menu. Waiting for the actor window puts the picture at the deepest point of
+  # the flow: the item list with the target selection over it, one tap before
+  # the item is spent. Bounded the same way the animation's is: once the probe
+  # has finished (@menu_play_done) the frame is taken regardless, so a run that
+  # never got there still produces the screenshot that shows where it stopped.
+  def menu_play_shot_ready?
+    @menu_play_at_actor || @menu_play_done
   end
 
   # The on-screen surface MZ's WebGL frame is presented onto: one full-screen

--- a/scripts/gen-mz-sample.py
+++ b/scripts/gen-mz-sample.py
@@ -598,8 +598,32 @@ write("Troops.json", [None, {
                "span": 0}],
 }])
 
+# --- Items -----------------------------------------------------------------
+# One usable item, so the menu has something to *do*. An empty Items.json is
+# valid and the menu still opens on it — Scene_Item just shows an empty list —
+# which is exactly the hole M6.3j closes: a bed with nothing to use cannot tell
+# a working item path from a broken one.
+#
+# `scope` 7 (one ally) is what puts the actor-selection window in the flow, and
+# `occasion` 0 (always) keeps it usable from the menu. The recovery is flat
+# (`value2`), not a fraction of max HP (`value1`), so the probe can assert an
+# exact figure. Note that a HP-recovery item is only *enabled* in the list while
+# someone is hurt (`Game_Action.testApply` -> `isItemEffectsValid`), so the
+# probe wounds the actor before opening the menu; on a full-HP party the row is
+# greyed out and confirm buzzes.
+POTION_HEAL = 100
+
+write("Items.json", [None, {
+    "id": 1, "name": "Potion", "note": "", "description": "Restores HP.",
+    "iconIndex": 0, "itypeId": 1, "price": 50, "consumable": True,
+    "scope": 7, "occasion": 0, "speed": 0, "successRate": 100, "repeats": 1,
+    "tpGain": 0, "hitType": 0, "animationId": 0,
+    "damage": {"type": 0, "elementId": 0, "formula": "0", "variance": 20,
+               "critical": False},
+    "effects": [{"code": 11, "dataId": 0, "value1": 0, "value2": POTION_HEAL}],
+}])
+
 # --- Empty-but-valid database files ----------------------------------------
-write("Items.json", [None])
 write("Weapons.json", [None])
 write("Armors.json", [None])
 

--- a/scripts/mz_boot_check.bash
+++ b/scripts/mz_boot_check.bash
@@ -18,6 +18,8 @@
 #   [MZ-AUDIO] op=<se_play> asset=<audio/se/Beep>
 #   [MZ-MSG]   busy=<bool> window_open=<bool>
 #   [MZ-MENU]  reached_menu=<bool>
+#   [MZ-MENUPLAY] hp_before=<n> hp_after=<n> items_before=<n> items_after=<n>
+#              healed=<bool> used=<bool> returned=<bool> scene=<scene>
 #   [MZ-ANIM]  data=<bool> mv=<bool> sprites=<n> cells=<n> played=<bool>
 #   [MZ-SAVE]  saved=<bool> exists=<bool> loaded=<bool>
 #   [MZ-BTL]   reached_battle=<bool>
@@ -33,6 +35,7 @@
 #   play      New Game -> map, hold a direction, play an SE  (the default smoke)
 #   message   New Game -> map, show a message
 #   menu      New Game -> map, open the party menu
+#   menu_play    ... and then *use that menu*: heal with an item, back out
 #   animation New Game -> map, play an animation on the player
 #   save      New Game -> map, save + load round-trip
 #   battle    New Game -> map, start a battle against MZ_TROOP (default 1)
@@ -56,7 +59,18 @@ TROOP="${MZ_TROOP:-1}"
 # The run has to reach the title, start a New Game, load the map and then play
 # out its probe, all on software GL — so it is given far more in-game time than
 # the MV smokes, which only need to boot.
-TIMEOUT_MS="${MZ_TIMEOUT_MS:-60000}"
+#
+# This is a ceiling, not a running time: the engine now ends the run as soon as
+# every requested probe has reported (MZ#finish_when_probes_done), so a mode
+# that finishes in ten seconds takes ten seconds whatever this says. It only has
+# to be generous enough for the *slowest* host, because the two budgets are in
+# different units — a probe gives up after so many frames, this after so many
+# milliseconds, and a headless software-GL frame costs far more wall clock on a
+# loaded machine. Set too tight, a run is cut off mid-probe and reports nothing,
+# which reads downstream as the thing under test never happening (see the
+# `cut off` diagnostics below). The play-out modes drive several turns / a whole
+# window stack, so they get the most room.
+DEFAULT_TIMEOUT_MS=60000
 
 case "${MODE}" in
     play)
@@ -68,6 +82,10 @@ case "${MODE}" in
     menu)
         FLAGS=(--mz_menu_test)
         DEFAULT_SHOT="ss/mz_menu.png" ;;
+    menu_play)
+        FLAGS=(--mz_menu_test --mz_menu_play)
+        DEFAULT_TIMEOUT_MS=180000
+        DEFAULT_SHOT="ss/mz_menu_play.png" ;;
     animation)
         FLAGS=(--mz_animation_test)
         DEFAULT_SHOT="ss/mz_animation.png" ;;
@@ -81,13 +99,15 @@ case "${MODE}" in
         DEFAULT_SHOT="ss/mz_battle.png" ;;
     battle_play)
         FLAGS=("--mz_battle_test=${TROOP}" --mz_battle_play)
+        DEFAULT_TIMEOUT_MS=280000
         DEFAULT_SHOT="ss/mz_battle_play.png" ;;
     *)
         echo "error: unknown MZ_MODE '${MODE}'" \
-             "(play|message|menu|animation|save|battle|battle_play)" >&2
+             "(play|message|menu|menu_play|animation|save|battle|battle_play)" >&2
         exit 1 ;;
 esac
 SHOT="${MZ_SCREENSHOT:-${DEFAULT_SHOT}}"
+TIMEOUT_MS="${MZ_TIMEOUT_MS:-${DEFAULT_TIMEOUT_MS}}"
 
 if [ ! -x "${ENGINE}" ] ; then
     echo "error: ${ENGINE} not built; run cmake --build build first" >&2
@@ -116,7 +136,7 @@ echo "== ${GAME} (mode ${MODE})"
 # path and MZ boots. The SERVER_NUM arg is kept for compatibility but unused.
 # (LVGL v9.5 requires a window; the dummy driver provides one without a display.)
 if ! env -u DISPLAY -u XAUTHORITY SDL_VIDEODRIVER=dummy \
-        timeout 300 "${ENGINE}" \
+        timeout "$(( TIMEOUT_MS / 1000 + 30 ))" "${ENGINE}" \
         --game_dir "${GAME}" --timeout_ms="${TIMEOUT_MS}" \
         "${FLAGS[@]}" \
         --mz_screenshot="${SHOT}" \
@@ -173,6 +193,25 @@ case "${MODE}" in
         grep -q '\[MZ-MENU\] reached_menu=true' "${log}" ||
             fail "the party menu never opened ([MZ-MENU] reached_menu=true)"
         ;;
+    menu_play)
+        grep -q '\[MZ-MENU\] reached_menu=true' "${log}" ||
+            fail "the party menu never opened ([MZ-MENU] reached_menu=true)"
+        # Opening Scene_Menu is the *small* claim — it holds the instant the
+        # scene is pushed. These are the menu being used: `healed=true` means an
+        # item's effect reached an actor's HP through the command window, the
+        # item list and the actor window; `used=true` means the inventory paid
+        # for it (a heal without a spend would mean the item was never really
+        # consumed); `returned=true` means cancel unwound the window stack all
+        # the way back to the map instead of the menu trapping the player.
+        grep -q '\[MZ-MENUPLAY\] hp_before=' "${log}" ||
+            fail "the run ended before the menu walk did — no [MZ-MENUPLAY] report (raise MZ_TIMEOUT_MS)"
+        grep -q '\[MZ-MENUPLAY\].*healed=true' "${log}" ||
+            fail "the item never healed the actor ([MZ-MENUPLAY] healed=true)"
+        grep -q '\[MZ-MENUPLAY\].*used=true' "${log}" ||
+            fail "the item was never consumed ([MZ-MENUPLAY] used=true)"
+        grep -q '\[MZ-MENUPLAY\].*returned=true' "${log}" ||
+            fail "the menu never handed back to the map ([MZ-MENUPLAY] returned=true)"
+        ;;
     animation)
         # Three separate claims, and the last is the one that matters. `mv=true`
         # says the data picked the sprite-sheet animation system rather than
@@ -204,6 +243,11 @@ case "${MODE}" in
         # `ended=true` means the victory sequence ran and handed the scene back
         # to the map, rather than the fight stalling — which is exactly how this
         # mode found the bed's battles frozen (see ADR 0004 M6.3i).
+        # A run cut off by --timeout_ms prints no report at all, and saying
+        # "no attack ever damaged an enemy" about a fight that was still
+        # swinging would be a lie about the cause. Separate the two.
+        grep -q '\[MZ-BTLPLAY\] hp_before=' "${log}" ||
+            fail "the run ended before the fight did — no [MZ-BTLPLAY] report (raise MZ_TIMEOUT_MS)"
         grep -q '\[MZ-BTLPLAY\].*damaged=true' "${log}" ||
             fail "no attack ever damaged an enemy ([MZ-BTLPLAY] damaged=true)"
         grep -q '\[MZ-BTLPLAY\].*ended=true' "${log}" ||
@@ -211,7 +255,7 @@ case "${MODE}" in
         ;;
 esac
 
-grep -E '\[MZ-BOOT\]|\[MZ-SCENE\]|\[MZ-MAP\]|\[MZ-MOVE\]|\[MZ-AUDIO\]|\[MZ-MSG\]|\[MZ-MENU\]|\[MZ-ANIM\]|\[MZ-SAVE\]|\[MZ-BTL\]|\[MZ-BTLPLAY\]|\[MZ\] screenshot' "${log}"
+grep -E '\[MZ-BOOT\]|\[MZ-SCENE\]|\[MZ-MAP\]|\[MZ-MOVE\]|\[MZ-AUDIO\]|\[MZ-MSG\]|\[MZ-MENU\]|\[MZ-MENUPLAY\]|\[MZ-ANIM\]|\[MZ-SAVE\]|\[MZ-BTL\]|\[MZ-BTLPLAY\]|\[MZ\] screenshot' "${log}"
 # ALSA has no device under CI and floods stderr; keep the rest for context.
 grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -20 || true
 rm -f "${log}"

--- a/scripts/mz_frame_check.rb
+++ b/scripts/mz_frame_check.rb
@@ -259,8 +259,10 @@ SAVE_CHANGE_MAX = 15.0
 # Every mode's frame must carry its scene's art, so MAP_DOMINANT_MAX applies to
 # all of them — `menu` included, which draws its windows over a blurred
 # snapshot of the map, and both battle modes, which draw a battler and the
-# status window over the battleback.
-MODES = %w[play message menu save battle battle_play animation].freeze
+# status window over the battleback. `menu_play`'s frame lands deeper in the
+# same stack (the item list with the actor window over it, see M6.3j), so it is
+# held to the same bar.
+MODES = %w[play message menu menu_play save battle battle_play animation].freeze
 
 $failures = 0
 $checks = 0
@@ -393,7 +395,8 @@ else
     end
   end
 
-  { 'menu' => 'Scene_Menu', 'battle' => 'Scene_Battle',
+  { 'menu' => 'Scene_Menu', 'menu_play' => 'Scene_Item',
+    'battle' => 'Scene_Battle',
     'battle_play' => 'Scene_Battle' }.each do |mode, scene|
     next unless (frame = loaded[mode])
 

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -174,6 +174,15 @@ DEFINE_bool(
     "--mz_new_game to reach the map) and log whether Scene_Menu opened, so a "
     "headless run confirms the menu path works. Used in CI");
 DEFINE_bool(
+    mz_menu_play,
+    false,
+    "For RPG Maker MZ: once the menu --mz_menu_test opens, use it — walk the "
+    "command window to Item, pick the party's healing item, pick the wounded "
+    "actor, and back out to the map — and log whether the item actually "
+    "healed and was consumed. Opening Scene_Menu says the scene was "
+    "constructed, not that the menu works; this covers what lies between. "
+    "Implies --mz_menu_test. Used in CI");
+DEFINE_bool(
     mz_save_test,
     false,
     "For RPG Maker MZ: once on the map, save to a slot and load it back "
@@ -862,6 +871,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MZ_MENU_TEST"),
                 mrb_bool_value(FLAGS_mz_menu_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "MZ_MENU_PLAY"),
+                mrb_bool_value(FLAGS_mz_menu_play));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MZ_SAVE_TEST"),
                 mrb_bool_value(FLAGS_mz_save_test));


### PR DESCRIPTION
The menu smoke asserted `Scene_Menu` was reached — the same claim `reached_battle=true` was, and true the instant the scene is pushed, *before its first update*. After #387 the menu was the last in-game system still resting on that shape of assertion.

`--mz_menu_play` (`MZ_MODE=menu_play`) uses the menu instead: confirm walks `Window_MenuCommand` to Item, the item category, the item list and the actor window; cancel unwinds the stack back to the map. It asserts the item **healed** an actor, the inventory **paid** for it, and the map **came back**.

## What it found

**The menu worked** — the walk came out right on the first run:

```
[MZ-MENUPLAY] hp_before=100 hp_after=200 items_before=3 items_after=2 healed=true used=true returned=true scene=Scene_Map
```

So this milestone adds coverage rather than a fix. What the walk did find is that **the test bed had no items at all**: `Items.json` was `[null]`, so `Scene_Item` had been opening onto an empty list, with nothing in the project to use, equip or sell. A menu with nothing in it cannot tell a working item path from a broken one.

The bed now authors a Potion — `scope` 7 (one ally) so the actor window is in the flow, flat `value2` recovery so the probe can assert a figure. Two things follow from rmmz's own rules: a healing item is only *selectable* while someone is hurt (`Game_Action.testApply` → `isItemEffectsValid`), and MZ has no starting-inventory field. So the probe arms the party first — **Change Items** and **Change HP**, run through the *map interpreter* as the event commands a real project would use, the same way #387's Battle Processing is injected rather than calling `SceneManager.push`.

Run against the old empty bed, the new mode fails on `healed=true` — while `MZ_MODE=menu` still reports `reached_menu=true` on that same run, which is the whole point:

```
FAILED: data/mz-sample (mode menu_play): the item never healed the actor ([MZ-MENUPLAY] healed=true)
[MZ-MENUPLAY] setup never took: hp=100 mhp=400 items=-1 win=- idx=-1
```

## The run budget was in the wrong unit

Adding the mode surfaced a defect in **every** mode. A probe gives up after so many *frames*; the engine after so many *milliseconds* (`--timeout_ms`). A headless software-GL frame costs far more wall clock on a loaded host than on a fast one, so the same run that reports in half its budget on one machine is cut off mid-probe on another — and a cut-off run prints **no report at all**.

On this container the battle play-out — green in CI and locally at M6.3i — ran out of clock mid-fight, having landed 41 damage and cycled several turns, and the check said:

```
FAILED: no attack ever damaged an enemy ([MZ-BTLPLAY] damaged=true)
[MZ-BTLPLAY] state hp=59 max=100 alive=1 phase=input win=actor input=1 …
```

The absence of the line was being read as the thing under test never happening. Exactly the M6.3e/M6.3i failure mode, one layer out. Given more clock the same fight resolves identically (`hp_before=100 hp_after=0 ended=true`).

Two changes. `MZ#finish_when_probes_done` ends a run as soon as every requested probe has reported and the screenshot is taken, unwinding through the same `RGSS::Timeout` the engine's own budget raises — so `--timeout_ms` becomes a true **ceiling** rather than the running time. The two play-out modes then get ceilings sized for the slowest host, and the checks distinguish *"the run ended before the fight did"* from *"nothing was damaged"*. The CI step's `MZ_TIMEOUT_MS: 120000` override is gone with it: an override there is precisely what would cut the fight short again on a slow runner.

| mode | before | after |
|---|---|---|
| play / message / menu / save | 60s | 14–15s |
| menu_play | — | 22s |
| animation | 60s | 26s |
| battle | 60s | 28s |
| battle_play | **cut off at 60s** | 114s (ceiling 280s) |

## Testing

All eight `mz_boot_check.bash` modes pass on `data/mz-sample`; the cross-mode frame check is 28 → **32 checks / 0 failures** with `menu_play` added to it (its frame lands on the item list with the actor window over it, one tap before the item is spent — 1525 colours, 29.4% dominant). `ctest` unchanged: only the pre-existing `exe_open` fails, which needs a game absent from this environment.

## Docs

ADR 0004 gains **M6.3j** (and its follow-on note on the budget units); README and a `changelog.d/` fragment updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_014B8H5L6jNJqN8HL7WGHbcS)_