### PR TITLE
ci: stop deploy-pages inheriting preview-gate's skip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1140,7 +1140,18 @@ jobs:
   # deployment" → Source = "GitHub Actions" to be enabled once for the repo.
   deploy-pages:
     needs: wasm
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    # `!cancelled()` is load-bearing, not decoration. A skip propagates down the
+    # whole `needs` chain, not just one link: `preview-gate` is skipped outside
+    # the `/preview` flow, and although `wasm` opts out of that with its own
+    # `!cancelled()` and runs to success, this job inherited the skip through it
+    # and never published. Every condition below was satisfied on those runs —
+    # it never got to evaluate them. A status-check function is what overrides
+    # the inherited skip, so the `wasm` result has to be spelled out explicitly
+    # once it is there (that is what `!cancelled()` gives up).
+    if: >-
+      ${{ !cancelled() && needs.wasm.result == 'success'
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/changelog.d/deploy-pages-inherited-skip.fixed.md
+++ b/changelog.d/deploy-pages-inherited-skip.fixed.md
@@ -1,0 +1,12 @@
+- **The GitHub Pages deploy has been silently skipping since 2026-08-04**, so
+  the published page has been stale for two days — every change merged in that
+  window, the MIDI fixes included, is on `master` and not on the site.
+  `deploy-pages` was not failing and its own condition was never wrong: it
+  inherited a *skip*. A skipped job propagates down the entire `needs` chain,
+  and moving the Cloudflare preview behind a `/preview` comment gave `wasm` a
+  `needs: preview-gate` — a job that is skipped on every push. `wasm` overrode
+  that for itself with `!cancelled()` and ran to success, but `deploy-pages`
+  sits downstream of `wasm` and had no status-check function of its own, so the
+  skip carried straight through it. Its `if` now starts with `!cancelled()`,
+  which overrides the inherited skip, and states `needs.wasm.result == 'success'`
+  explicitly, since that is the check `!cancelled()` gives up.


### PR DESCRIPTION
**The GitHub Pages deploy has been skipping on every push to `master` since 2026-08-04.** The published page is two days stale — everything merged in that window, including the MIDI fixes from #388, is on `master` and not on the site.

## What is actually happening

Nothing failed, and `deploy-pages`' own condition was never wrong. It inherited a *skip*.

7abc504 moved the Cloudflare preview behind a `/preview` comment, which gave `wasm` a `needs: preview-gate`. `preview-gate` only runs on that comment, so it is skipped on every push. `wasm` opts out of the skip with its own `!cancelled()` and runs to success — but a skip propagates down the **whole** `needs` chain, not one link of it, and `deploy-pages` sits downstream of `wasm` with no status-check function of its own. The skip carried through the successful job into it.

From run [31063205366](https://github.com/take-cheeze/rpg-maker-clone/actions/runs/31063205366) (`event: push`, `head_branch: master`):

```
preview-gate    skipped
  └─ wasm       success     ← both patch-set checks passed
       └─ deploy-pages   skipped
```

Its condition was `github.event_name == 'push' && github.ref == 'refs/heads/master'`. Both halves were true. It never got to evaluate them.

The hazard was already known one level up — the `wasm` job's comment says *"`preview-gate` is skipped outside the comment flow — which would skip this job along with it"* — it just wasn't carried to the job downstream of `wasm`.

## The fix

```yaml
if: >-
  ${{ !cancelled() && needs.wasm.result == 'success'
      && github.event_name == 'push'
      && github.ref == 'refs/heads/master' }}
```

`!cancelled()` is what overrides an inherited skip. Adding it also gives up the implicit "every dependency succeeded" gate, so `needs.wasm.result == 'success'` is spelled out alongside it rather than left implied — otherwise this would publish a page from a failed build.

`preview-cloudflare` needs no change: on a `/preview` run `preview-gate` succeeds, so nothing in its chain is skipped.

## Verifying

This one can only really be confirmed after merge — the fix has to be on `master` for a push run to exercise it. Once merged, the `deploy-pages` job on that push should run rather than skip, and the site should pick up the merged MIDI work. Worth a glance at the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G3giQd6V1dBzg95JeeQmv

---
_Generated by [Claude Code](https://claude.ai/code/session_015G3giQd6V1dBzg95JeeQmv)_