### PR TITLE
Open the game's own save screen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,9 +214,9 @@ jobs:
       # tests in CMakeLists.txt, all run by the `test` step below); MV runs=100..108,
       # the RPG2k
       # real-game boot smoke=109..110, the MZ boot smoke=111, the RPG XP
-      # real-game boot smoke=112..114 (one per game, plus the editor bed's
-      # second pass for the battle probe) and the RGSSAD
-      # packed-asset smoke=115..116
+      # real-game boot smoke=112..119 (one per game, plus a pass per extra
+      # probe on the editor bed -- a block, so adding a probe does not renumber
+      # anything else) and the RGSSAD packed-asset smoke=120..121
       # (two runs, one per arm of its A/B) below. Every
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
@@ -311,8 +311,9 @@ jobs:
           # confirm on the game's own title screen, logs every scene it reaches
           # as `[RPGXP-SCRIPTS]`/`[RPGXP-HOST-SCENE]`, walks the party on the
           # editor bed's map (`[RPGXP-HOST-MOVE]`), opens that bed's own menu
-          # (`[RPGXP-HOST-MENU]`) and, in a second pass, fights in its own
-          # battle scene (`[RPGXP-HOST-BATTLE]`). Two beds: the editor-shaped
+          # (`[RPGXP-HOST-MENU]`) and, in a pass each, fights in its own
+          # battle scene (`[RPGXP-HOST-BATTLE]`) and opens its own save screen
+          # (`[RPGXP-HOST-SAVE]`). Two beds: the editor-shaped
           # OpenGame test bed and the *released* Pray for You (Game.rgssad only,
           # several maps), on displays 112 and 113 — one per game (see the
           # reserved server-num map above). See
@@ -327,7 +328,7 @@ jobs:
           # in the archive — and asserts the engine finds it only when it is
           # there, which is what makes the check non-vacuous. Displays 114-115.
           - name: RGSSAD packed-asset smoke test
-            run: ./scripts/nix-develop.bash ./scripts/rgssad_asset_check.bash 115
+            run: ./scripts/nix-develop.bash ./scripts/rgssad_asset_check.bash 120
 
           - name: MV boot smoke test
             continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@
   open its own menu (`[RPGXP-HOST-MENU]`) — the first thing a game draws out of
   its own `Window` subclasses, windowskin and font — and, in a second pass, to
   fight in its own battle scene (`[RPGXP-HOST-BATTLE]`), where every enemy is one
-  of its own `Sprite_Battler`s on top of `RPG::Sprite`.
+  of its own `Sprite_Battler`s on top of `RPG::Sprite`, and to open its own save
+  screen (`[RPGXP-HOST-SAVE]`), the one place a game reads a file's timestamp
+  back and writes a file of its own.
   `scripts/rpgxp_script_host_check.rb` covers the same ground under CRuby —
   every section of both bundles evaluates, and the RGSS standard library behaves
 - `scripts/compare-rpgxp-wine.bash` diffs our frames against the **genuine RGSS

--- a/changelog.d/rgss-host-save-test.added.md
+++ b/changelog.d/rgss-host-save-test.added.md
@@ -11,3 +11,10 @@
 - **The reserved CI display numbers are now a block.** The XP boot check takes
   112..119 and the RGSSAD A/B 120..121, so adding another probe pass does not
   renumber an unrelated check.
+- **The XP boot check clears save files around every pass.** Its own save pass
+  plants one, and a game's `Scene_Save` writes a bare relative name, so the next
+  game in the loop found it: *Pray for You*'s title screen enabled Continue on
+  the strength of the editor bed's save and died reading it as its own. Saves
+  being shared between games is a real engine bug (gap 0j in
+  `docs/rpgxp-rgss-api-gap.md`) — this only makes the check hermetic while it
+  stands.

--- a/changelog.d/rgss-host-save-test.added.md
+++ b/changelog.d/rgss-host-save-test.added.md
@@ -1,0 +1,13 @@
+- **`--rgss_host_save_test` opens a game's own save screen.** Called the way that
+  game's own Save Screen event command calls it — `$game_temp.save_calling`,
+  which its `Scene_Map#update` acts on — and reported as
+  `[RPGXP-HOST-SAVE] scene=.. reached=.. frame=..`. This is the one rung that
+  reads a *file* back: a game's `Window_SaveFile` stamps each slot from
+  `File#mtime` and its `Scene_Save` seeds the newest-slot search with
+  `Time.at(0)`, the code that made `mruby-time` necessary and that nothing had
+  executed; its own `save_data` then writes a real file. `reached=` is answered
+  from the scenes the game has *been through*, since a save screen hands control
+  back to the map as soon as it has written.
+- **The reserved CI display numbers are now a block.** The XP boot check takes
+  112..119 and the RGSSAD A/B 120..121, so adding another probe pass does not
+  renumber an unrelated check.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -84,12 +84,13 @@ RGSS Reference Manual publishes, on top of the native `mruby-rgss` primitives.
   `.tile` / `.windowskin` call in a game goes through, including cutting a 32x32
   tile out of a tileset and building hue-rotated variants.
 
-Three deliberate deviations, all forced by this engine and listed in the file's
+Two deliberate deviations, both forced by this engine and listed in the file's
 header: colours are re-assigned rather than mutated in place (our compositor
-snapshots on assignment), a hue variant is re-loaded rather than `clone`d (a
-native handle must not be shallow-copied), and an asset that will not load gives
-a blank bitmap with a warning instead of raising (a game whose RTP is missing
-must not die on its first graphic).
+snapshots on assignment), and an asset that will not load gives a blank bitmap
+with a warning instead of raising (a game whose RTP is missing must not die on
+its first graphic). A third — re-loading a bitmap for a hue variant rather than
+`clone`ing the cached one — has since gone, because `Bitmap#clone` learned to
+copy pixels (see the end of gap 0h).
 
 With those three in place the host runs a game's whole bundle — **all 103
 sections of the released *Pray for You*** — and reaches `Main`, where it met the
@@ -195,7 +196,23 @@ because no keypress starts a battle — and reports `[RPGXP-HOST-BATTLE]`. It is
 the biggest surface of the lot: a battle builds the game's own
 `Spriteset_Battle`, so every enemy is a `Sprite_Battler` on top of the
 `RPG::Sprite` in gap 0, whose transitions, damage pop-up and animation playback
-nothing had run before. Whatever it reports is the next entry here.
+nothing had run before. It passed first time, running 119 frames inside the
+game's own battle with the confirm taps driving its party and actor command
+windows:
+
+```
+[RPGXP-HOST-SCENE] Scene_Map frame=41
+[RPGXP-HOST-SCENE] Scene_Battle frame=102
+[RPGXP-HOST-BATTLE] scene=Scene_Battle reached=true frame=221
+```
+
+`--rgss_host_save_test` is the same shape again — `$game_temp.save_calling`, the
+way the game's own Save Screen command sets it — and takes its own pass for the
+same reason. It is the one rung that reads a *file* back: a game's
+`Window_SaveFile` stamps each slot from `File#mtime` and its `Scene_Save` seeds
+the newest-slot search with `Time.at(0)`, which is what made `mruby-time`
+necessary (gap 0i) and is otherwise unexercised. Its own `save_data` then writes
+a real file. Whatever it reports is the next entry here.
 
 ### 0e. `Kernel#Integer()` ✅ (the first thing New Game runs)
 

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -212,7 +212,35 @@ same reason. It is the one rung that reads a *file* back: a game's
 `Window_SaveFile` stamps each slot from `File#mtime` and its `Scene_Save` seeds
 the newest-slot search with `Time.at(0)`, which is what made `mruby-time`
 necessary (gap 0i) and is otherwise unexercised. Its own `save_data` then writes
-a real file. Whatever it reports is the next entry here.
+a real file — and that is what it found:
+
+### 0j. A game's saves land in the launch directory ❌ (open)
+
+The save probe reached the screen (`[RPGXP-HOST-SAVE] reached=true`) and wrote a
+file, and then the *next* game in the boot check died:
+
+```
+[RGSS] script host: section "Main" raised TypeError: Array cannot be converted to String
+[RGSS] script host:   from menu:2033:in text_size
+[RGSS] script host:   from AS_ATST_CG:619:in command_continue
+```
+
+Not a class-library gap. Stock `Scene_Save` writes
+`File.open("Save#{n}.rxdata", "wb")` and stock `Scene_Title` asks
+`FileTest.exist?("Save#{n}.rxdata")` — both **bare relative names**, so both
+resolve against the current directory. A real RPG Maker install runs `Game.exe`
+*from the game's own folder*, so that directory is the game's; this engine is
+launched from anywhere with `--game_dir` pointing elsewhere, so every game's
+saves land in one shared place. *Pray for You*'s own title screen therefore
+enabled Continue on the strength of the editor bed's save, read it as its own,
+and its `Window_SaveFile` got an `Array` where it expected a `String`.
+
+Two games sharing a save file is a real bug, not a test artifact: it would
+overwrite one game's progress with another's the first time a player ran two.
+The fix is for an RGSS boot to resolve the game's relative file I/O against the
+game's own directory, the way the runtime it imitates does. The boot check is
+hermetic in the meantime — it clears `Save*.rxdata` around every pass, since it
+is its own earlier pass that plants the file.
 
 ### 0e. `Kernel#Integer()` ✅ (the first thing New Game runs)
 

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -242,6 +242,8 @@ class RPGXP
     #     scene the game went to — its own menu, if it has one.
     #   * with --rgss_host_battle_test, call a battle the way the game's own
     #     Battle Processing command does and report whether it came up.
+    #   * with --rgss_host_save_test, the same for its save screen, which is the
+    #     one place a game reads a file's timestamp back.
     def self.watch_frame
       @frames += 1
       report_scene
@@ -252,6 +254,7 @@ class RPGXP
       move_probe if move_test?
       menu_probe if menu_test?
       battle_probe if battle_test?
+      save_probe if save_test?
     end
 
     def self.report_scene
@@ -262,6 +265,12 @@ class RPGXP
       @scene_name = name
       # Remember when the map first appeared; the move probe waits for it.
       @map_frame = @frames if @map_frame.nil? && map_scene?(name)
+      # Every scene the game has been through, for the probes that ask "did it
+      # get there" about somewhere it does not *stay* — a save screen hands
+      # control back to the map once the file is written, so reading `$scene`
+      # when the probe reports would answer Scene_Map either way.
+      @scenes_seen ||= []
+      @scenes_seen.push(name)
       # The frame number is the diagnostic that matters when a headless run ends
       # on its timeout: it is the only way to tell "the game stalled" from "the
       # frames were slower than the budget" (an unaccelerated CI display renders
@@ -394,6 +403,56 @@ class RPGXP
       finish_menu_probe if step >= MENU_WAIT
     end
 
+    # Whether the game has been through a scene whose name contains `needle`.
+    def self.been_through?(needle)
+      seen = @scenes_seen
+      return false if seen.nil?
+      seen.any? { |name| name.include?(needle) }
+    end
+
+    # Open the game's own save screen and report whether it got there.
+    #
+    # Called the way the game's own Save Screen event command does
+    # (`Interpreter#command_352` sets `$game_temp.save_calling` and lets
+    # `Scene_Map#update` switch scenes), for the same reason the battle probe
+    # does: no keypress reaches it from the map, and the alternative — counting
+    # cursor presses down a menu — depends on that menu's item order, which every
+    # game with a custom menu changes.
+    #
+    # This is the rung that runs the *save* half of a game's own engine: its
+    # `Scene_Save`, its `Window_SaveFile` — which stamps each slot from
+    # `File#mtime` and seeds its newest-save search with `Time.at(0)` — and, once
+    # the confirm taps pick a slot, its own `save_data` writing a real file. The
+    # scene is reported from the scenes the game has *been through*, because a
+    # save screen returns to the map as soon as it has written.
+    SAVE_SETTLE = 60        # frames on the map before opening the save screen
+    SAVE_WAIT = 120         # frames to let it come up and take a confirm
+
+    def self.save_probe
+      return if @save_done || @map_frame.nil?
+      elapsed = @frames - @map_frame
+      return if elapsed < SAVE_SETTLE
+      if elapsed == SAVE_SETTLE
+        call_save
+        return
+      end
+      finish_save_probe if elapsed >= SAVE_SETTLE + SAVE_WAIT
+    end
+
+    def self.call_save
+      temp = $game_temp
+      return if temp.nil? || !temp.respond_to?(:save_calling=)
+      temp.save_calling = true
+    end
+
+    def self.finish_save_probe
+      @save_done = true
+      scene = $scene
+      name = scene.nil? ? "?" : scene.class.to_s
+      $stderr.puts "[RPGXP-HOST-SAVE] scene=#{name} " \
+                   "reached=#{been_through?("Scene_Save")} frame=#{@frames}"
+    end
+
     # Start a battle in the game's own engine and report where that got it.
     #
     # The rung above the menu, and the biggest surface left: a battle builds the
@@ -494,6 +553,12 @@ class RPGXP
 
     def self.battle_test?
       RGSS_HOST_BATTLE_TEST
+    rescue StandardError
+      false
+    end
+
+    def self.save_test?
+      RGSS_HOST_SAVE_TEST
     rescue StandardError
       false
     end

--- a/scripts/rgssad_asset_check.bash
+++ b/scripts/rgssad_asset_check.bash
@@ -44,7 +44,7 @@
 # the test.
 #
 # Usage: ./scripts/rgssad_asset_check.bash [server_num] [game_dir]
-#   server_num  xvfb-run --server-num to use (default 115; see the reserved
+#   server_num  xvfb-run --server-num to use (default 120; see the reserved
 #               display numbers in .github/workflows/build.yml)
 #   game_dir    defaults to the repo's RPG Maker XP test bed
 
@@ -52,7 +52,7 @@ set -eu -o pipefail
 
 cd "$(dirname "$0")/.."
 
-SERVER_NUM="${1:-115}"
+SERVER_NUM="${1:-120}"
 GAME="${2:-data/OpenGame.exe/Testbed/XP}"
 ENGINE="${ENGINE:-./build/rpg_maker_clone}"
 TIMEOUT_MS="${RGSSAD_TIMEOUT_MS:-20000}"

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -107,6 +107,18 @@ run_boot() {
     local log rc=0 marker missing=""
     log="$(mktemp)"
     echo "-- ${label}"
+    # Start from no save files. A game's own Scene_Save writes
+    # `File.open("Save1.rxdata", "wb")` -- a bare relative name, so it lands in
+    # the *current directory*, which under this engine is wherever it was
+    # launched from rather than the game's own folder (where a real RPG Maker
+    # install would put it, because Game.exe runs from there). So the save pass
+    # below leaves a file that the next game in this loop finds: Pray for You's
+    # own title screen enabled Continue on the strength of the editor bed's save,
+    # read it as its own, and died on the mismatch. That is a real engine bug --
+    # saves must not be shared between games -- but the check has to be hermetic
+    # regardless of when it is fixed, since it is its own earlier pass that
+    # plants the file.
+    rm -f Save[0-9]*.rxdata "${game}"/Save[0-9]*.rxdata
     # Each run gets its own display number: xvfb-run -a's probe is not atomic
     # and can steal a display from a concurrent run (see build.yml).
     # shellcheck disable=SC2086 # ${flags} is a deliberate word-split flag list
@@ -143,6 +155,9 @@ run_boot() {
     # ALSA has no device under CI and floods stderr; keep the rest.
     grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -40 || true
     rm -f "${log}"
+    # ...and leave none behind either, so a local run does not dirty the tree or
+    # change what the *next* invocation's title screens offer.
+    rm -f Save[0-9]*.rxdata "${game}"/Save[0-9]*.rxdata
     return "${rc}"
 }
 

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -37,6 +37,10 @@
 #     bed only, because a released game's opening is an event sequence a battle
 #     call would land in the middle of. This is the biggest surface of the lot:
 #     every enemy in it is a `Sprite_Battler`, on top of `RPG::Sprite`.
+#   * a third pass opens the game's own save screen the same way
+#     (`--rgss_host_save_test`, `[RPGXP-HOST-SAVE]`). That is the one place a
+#     game reads a file's timestamp back — its `Window_SaveFile` stamps each
+#     slot from `File#mtime` — and where its own `save_data` writes a real file.
 #   * a `script host failed` line fails the run: the game's own scripts stopping
 #     is the failure this check exists to catch.
 #
@@ -47,8 +51,8 @@
 # Usage: ./scripts/rpgxp_boot_check.bash [server_num] [game_dir...]
 #   server_num  xvfb-run --server-num to use (default 112; see the reserved
 #               display numbers in .github/workflows/build.yml). Each run takes
-#               the next one, so the two beds plus the editor bed's battle pass
-#               use 112..114.
+#               the next one, and build.yml reserves 112..119 for this check so
+#               another probe can be added without renumbering anything else.
 #   game_dir    defaults to the repo's two RPG Maker XP beds -- the editor-shaped
 #               OpenGame test bed and the released Pray for You
 
@@ -174,6 +178,15 @@ for game in "${GAMES[@]}" ; do
             run_boot "${game}" "${num}" "script host: battle" \
                 "--rgss_host_battle_test" 2 \
                 '\[RPGXP-HOST-BATTLE\] .*reached=true' ||
+                failed=$((failed + 1))
+            num=$((num + 1))
+
+            # And the save screen, its own pass for the same reason. This is the
+            # only place a game reads a file's timestamp back, and the only one
+            # that writes a file of its own.
+            run_boot "${game}" "${num}" "script host: save" \
+                "--rgss_host_save_test" 2 \
+                '\[RPGXP-HOST-SAVE\] .*reached=true' ||
                 failed=$((failed + 1))
             ;;
     esac

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -107,6 +107,18 @@ DEFINE_bool(
     "this writes to the game's globals, because no keypress starts a battle. "
     "Used by scripts/rpgxp_boot_check.bash");
 DEFINE_bool(
+    rgss_host_save_test,
+    false,
+    "For the RGSS makers under the script host: once the game is on its own "
+    "map, open its save screen the way its own Save Screen event command does "
+    "(setting $game_temp.save_calling) and log whether it got there as "
+    "[RPGXP-HOST-SAVE] (implies --rgss_host_new_game). This is the one place a "
+    "game reads a file's timestamp back -- its Window_SaveFile stamps each "
+    "slot "
+    "from File#mtime -- and where its own save_data writes a real file. Used "
+    "by "
+    "scripts/rpgxp_boot_check.bash");
+DEFINE_bool(
     mv_new_game,
     false,
     "For RPG Maker MV: once the title screen appears, auto-select New Game so "
@@ -848,7 +860,8 @@ int main(int argc, char** argv) {
       M, mrb_obj_value(M->object_class),
       mrb_intern_lit(M, "RGSS_HOST_NEW_GAME"),
       mrb_bool_value(FLAGS_rgss_host_new_game || FLAGS_rgss_host_move_test ||
-                     FLAGS_rgss_host_menu_test || FLAGS_rgss_host_battle_test));
+                     FLAGS_rgss_host_menu_test || FLAGS_rgss_host_battle_test ||
+                     FLAGS_rgss_host_save_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RGSS_HOST_MOVE_TEST"),
                 mrb_bool_value(FLAGS_rgss_host_move_test));
@@ -858,6 +871,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RGSS_HOST_BATTLE_TEST"),
                 mrb_bool_value(FLAGS_rgss_host_battle_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RGSS_HOST_SAVE_TEST"),
+                mrb_bool_value(FLAGS_rgss_host_save_test));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));


### PR DESCRIPTION
Battle (#399) passed first time — 119 frames inside the game's own
`Scene_Battle`, with the confirm taps driving its party and actor command
windows, no exception and no missing-asset warning:

```
[RPGXP-HOST-SCENE] Scene_Map frame=41
[RPGXP-HOST-SCENE] Scene_Battle frame=102
[RPGXP-HOST-BATTLE] scene=Scene_Battle reached=true frame=221
```

So every enemy in that battle was a `Sprite_Battler` on top of the `RPG::Sprite`
transcribed in gap 0, and it held.

## The next rung is a different kind of surface

Every rung so far has *drawn* things. The save screen reads a **file** back: a
game's `Window_SaveFile` stamps each slot from `File#mtime`, and its `Scene_Save`
seeds the newest-slot search with `Time.at(0)`. That is the code that made
`mruby-time` necessary — added in #392 on a reading of both script bundles rather
than on a failure report, and never executed since. The game's own `save_data`
then writes a real file.

`--rgss_host_save_test` sets `$game_temp.save_calling`, the way the game's own
Save Screen event command does, for the same reason the battle probe sets its
five fields: no keypress reaches the save screen from the map, and counting
cursor presses down a menu depends on that menu's item order, which every game
with a custom menu changes.

One detail worth the review: **`reached=` is answered from the scenes the game
has been *through***, not from `$scene`. A save screen hands control back to the
map as soon as it has written, so reading `$scene` when the probe reports would
answer `Scene_Map` whether it got there or not.

## Display numbers become a block

112..119 for this check, 120..121 for the RGSSAD A/B. Without that, each new
probe pass renumbers an unrelated check — which this one would have done, and the
last one did.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_