### PR TITLE
Let an antidote cure something

### DIFF
--- a/changelog.d/medicine-cure-polarity.fixed.md
+++ b/changelog.d/medicine-cure-polarity.fixed.md
@@ -1,0 +1,11 @@
+- **Antidotes cure again.** A medicine's `state_set` names the conditions it
+  **cures**, and `reverse_state_effect` is what flips it into inflicting them —
+  the same polarity a skill already used. It was read the other way round, so a
+  medicine cured only when the flag was *set*, and **no item in either test bed
+  sets it**: Nepheshel's アンチドーテ and ユニコーンの角 (all fifteen states),
+  its 気付け薬 / ドラゴンブラッド / ドラゴンハート (戦闘不能 alone, i.e. revives)
+  and ten more, plus mtf-meido-action's four, all cured nothing — in the field
+  menu and in battle alike, where such an item also failed to count as usable
+  against an afflicted target.
+- A medicine that really does inflict (the flag set) is left unbuilt rather than
+  guessed at: no item in either test bed sets it.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -400,10 +400,23 @@ The work below is roughly ordered by the critical path to a walkable game
   `add_state` / `remove_state` / `state?`; **Full Recovery clears it**), which
   persists in both the Marshal save and the `.lsd` (chunk 108 fields 81/82,
   previously parsed-but-unused) and is restored by `from_lsd`, so a real save's
-  status ailments survive. The **item menu cures states**: a medicine with
-  `reverse_state_effect` set removes its `state_set` conditions from the target
-  (an antidote / herb — unconditional, matching EasyRPG's item algorithm), and
-  such an item now counts as usable when the target is afflicted even at full HP.
+  status ailments survive. The **item menu cures states**: a medicine's `state_set`
+  names the conditions it **cures**, and using it removes them from the target
+  (unconditional, matching EasyRPG's item algorithm); such an item counts as
+  usable when the target is afflicted even at full HP.
+  That polarity was read backwards at first — curing only when
+  `reverse_state_effect` was *set* — and **no item in either test bed sets it**,
+  so every shipped curative item was inert, in the menu and in a fight alike.
+  Nepheshel has thirteen medicines naming states without the flag
+  (アンチドーテ and ユニコーンの角 name all fifteen states; 気付け薬 /
+  ドラゴンブラッド / ドラゴンハート name 戦闘不能 alone, so they are revives)
+  and mtf-meido-action four. `reverse_state_effect` is what flips a medicine into
+  *inflicting*, exactly as it does for a skill; nothing in either bed sets it, so
+  that half is left unbuilt rather than guessed at. A fixture check cannot catch
+  a polarity error — it is written to match whatever the code does, and four of
+  them encoded the wrong reading quite happily — so
+  `rpg2k_testbed_logic_check.rb` now asserts against the **real** item table that
+  every curative medicine cures exactly the states it names.
   The **death state (戦闘不能, id 1)** is **coupled to HP** (EasyRPG's
   `kDeathID`): lethal `change_hp` knocks the actor out and inflicts state 1
   (zeroing HP), a downed actor can't be healed by HP changes, and curing the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2119,13 +2119,25 @@ module Game
     end
 
     # The status-condition ids a medicine cures. RPG2000 items list affected
-    # states in `state_set` (a 0/1 byte per state, index i -> state id i+1); when
-    # `reverse_state_effect` is set the item *removes* them (an antidote / herb),
-    # which is the only item-state effect the field menu applies -- an item that
-    # would *inflict* states (the non-reverse case, rolled against state_chance) is
-    # left to battle. Curing is unconditional, matching EasyRPG's item algorithm.
+    # states in `state_set` (a 0/1 byte per state, index i -> state id i+1), and a
+    # medicine **cures** them; `reverse_state_effect` is what flips it into
+    # inflicting them, exactly as it does for a skill (see #skill_state_ids).
+    # Curing is unconditional, matching EasyRPG's item algorithm.
+    #
+    # The polarity used to be read the other way round -- cures only when the
+    # flag is *set* -- which meant no shipped curative item cured anything.
+    # Neither test bed sets the flag on any item at all, while Nepheshel has 13
+    # medicines naming states without it and mtf-meido-action one: アンチドーテ
+    # and ユニコーンの角 name all fifteen states, and 気付け薬 / ドラゴンブラッド
+    # name state 1 alone, which is 戦闘不能 -- they are revives. Reading those as
+    # "cures nothing" made every antidote and every revive item in both games
+    # inert, in the menu and in a fight alike.
+    #
+    # A medicine that really does *inflict* (the flag set) is left unbuilt rather
+    # than guessed at: no item in either bed sets it, so there is nothing to
+    # measure an implementation against.
     def item_cured_states(it)
-      return [] unless it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+      return [] if it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
       set = it.state_set
       return [] unless set
       out = []

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2965,9 +2965,11 @@ check 'use_item restores MP and item_effective? tracks the SP deficit' do
   eq 0, st.party.item_count(6)
 end
 
-check 'a cure medicine (reverse_state_effect) removes only its listed states' do
+check 'a cure medicine removes only its listed states' do
   # state_set: byte per state, index i -> state id i+1; states 3 and 7 marked.
-  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1, 0, 0, 0, 1], reverse_state: true) }
+  # No reverse flag -- that is what a real curative item looks like, and every
+  # one in both test beds leaves it unset.
+  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1, 0, 0, 0, 1]) }
   st = item_party(items)
   st.party.gain_item(5, 2)
   hero = st.party.leader
@@ -2981,7 +2983,7 @@ check 'a cure medicine (reverse_state_effect) removes only its listed states' do
 end
 
 check 'a cure medicine on an unafflicted, full target does nothing / not consumed' do
-  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true) }
+  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1]) }
   st = item_party(items)
   st.party.gain_item(5, 1)
   hero = st.party.leader                        # full HP, no states
@@ -2991,7 +2993,7 @@ check 'a cure medicine on an unafflicted, full target does nothing / not consume
 end
 
 check 'a heal+cure item counts either the heal or the cure as a use' do
-  items = { 5 => fake_item(type: 6, rhp: 40, state_set: [0, 0, 1], reverse_state: true) }
+  items = { 5 => fake_item(type: 6, rhp: 40, state_set: [0, 0, 1]) }
   st = item_party(items)
   st.party.gain_item(5, 3)
   hero = st.party.leader
@@ -3005,10 +3007,16 @@ check 'a heal+cure item counts either the heal or the cure as a use' do
   eq 1, st.party.item_count(5)
 end
 
-check 'a non-reverse item lists no cured states (infliction is battle-only)' do
+check 'a reverse medicine cures nothing: inflicting is deliberately unbuilt' do
+  # The flag flips a medicine from curing to inflicting, the same way it does for
+  # a skill. No item in either test bed sets it, so there is nothing to measure
+  # an implementation of the inflict half against and it is left unbuilt -- but
+  # such an item must not be treated as a cure either.
   st = item_party({})
-  it = fake_item(type: 6, state_set: [0, 0, 1], reverse_state: false)
+  it = fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true)
   eq [], st.party.item_cured_states(it)
+  eq [3], st.party.item_cured_states(fake_item(type: 6, state_set: [0, 0, 1])),
+     'the same row without the flag does cure'
 end
 
 check 'field_items includes skill books alongside medicines' do
@@ -6271,8 +6279,8 @@ check 'battle_items lists battle medicines; battle_item_command recovers' do
 end
 
 check 'a battle item cures the target status; states carry out via apply_to_party' do
-  # An antidote (reverse item curing state 3) used in battle on a poisoned ally.
-  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true) }
+  # An antidote (a medicine curing state 3) used in battle on a poisoned ally.
+  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1]) }
   st = item_party(items)
   st.party.gain_item(5, 1)
   ally = st.party.actor_by_id(1)

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -726,8 +726,70 @@ def check_terrain(dir)
   end
 end
 
+# Curative items, against the real item table. A fixture cannot catch a field
+# read with the wrong polarity — it is written to match whatever the code does —
+# so only a real game's antidotes can say which way round `reverse_state_effect`
+# goes. Nepheshel's アンチドーテ and ユニコーンの角 name all fifteen states and
+# 気付け薬 names 戦闘不能 alone; none of them sets the flag.
+def check_items(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  items = db[DB_ITEM]
+  return unless items
+
+  curative = []
+  reversed = []
+  items.each do |id, it|
+    next unless it.type == 6 # medicine
+    set = it.state_set
+    next unless set.respond_to?(:each_index)
+    ids = []
+    set.each_index { |i| ids << (i + 1) if set[i] && set[i] != 0 }
+    next if ids.empty?
+    (it.reverse_state_effect ? reversed : curative) << [id, ids]
+  end
+  puts format('   items: %d curative medicine(s), %d with reverse_state_effect',
+              curative.size, reversed.size)
+  return if curative.empty?
+
+  check "#{name}: every curative medicine actually cures what it names" do
+    party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+    actor = party.leader
+    ok actor, 'the initial party has a leader to heal'
+    curative.each do |iid, ids|
+      row = items[iid]
+      eq ids, party.item_cured_states(row),
+         "item ##{iid} (#{row.name}) should cure #{ids.size} state(s)"
+
+      # ... and using it really lifts them, including from a downed actor: a
+      # medicine naming state 1 is a revive, and several of these name only it.
+      # HP first, then the states: set_hp with a positive value *clears* the
+      # death state, so afflicting before healing would quietly undo state 1 --
+      # and state 1 is the only one several of these name.
+      actor.clear_states
+      actor.set_hp(actor.max_hp)
+      ids.each { |sid| actor.add_state(sid) }
+      party.gain_item(iid, 1)
+      ok party.item_effective?(iid, actor),
+         "item ##{iid} (#{row.name}) is offered to an afflicted target"
+      party.use_item(iid, actor)
+      ids.each do |sid|
+        eq false, actor.state?(sid),
+           "item ##{iid} (#{row.name}) left state #{sid} on"
+      end
+    end
+    actor.clear_states
+    actor.set_hp(actor.max_hp)
+  end
+end
+
 dirs.each do |d|
-  check_game(d); check_menus(d); check_states(d); check_equipment(d); check_terrain(d)
+  check_game(d)
+  check_menus(d)
+  check_states(d)
+  check_equipment(d)
+  check_terrain(d)
+  check_items(d)
 end
 
 if $failures.zero?


### PR DESCRIPTION
## The bug

A medicine's `state_set` names the conditions it **cures**, and `reverse_state_effect` is what flips it into *inflicting* them — the same polarity a skill already used, and which this codebase already documented for skills. `item_cured_states` read it the other way round: it returned the set only when the flag was **set**.

**No item in either test bed sets that flag.**

| game | medicines naming states, flag unset | flag set |
| --- | --- | --- |
| Nepheshel | **13** | 0 |
| mtf-meido-action | **4** | 0 |

So every curative item in both games cured nothing — in the field menu and in a fight alike, where such an item also failed to count as usable against an afflicted target, so it could not even be selected.

What those items are is what settles the reading:

| item | states named |
| --- | --- |
| アンチドーテ (Antidote) | all fifteen |
| ユニコーンの角 (Unicorn Horn) | all fifteen |
| 気付け薬, ドラゴンブラッド, ドラゴンハート | 戦闘不能 alone — they are **revives** |

An antidote that cannot cure poison and a revive that cannot raise the dead are hard to read as anything but a field taken backwards.

## What changed

One line of polarity in `Game::Party#item_cured_states`, plus the comment that explains which way round it goes and why.

A medicine that really does inflict (the flag set) is **left unbuilt** rather than guessed at — nothing in either bed sets it, so there is nothing to measure an implementation against. The same rule ADR 0032 applied to `avoid_attacks` and `reflect_magic`.

## Why the checks did not catch it

Four fixture checks had encoded the wrong reading. They were written to match the code, so they passed either way — which is exactly what a fixture cannot do for a polarity: `fake_item(..., reverse_state: true)` is only "the curative case" if you already believe the flag means cure.

They are corrected, and the one that asserted *"a non-reverse item lists no cured states (infliction is battle-only)"* — which stated the bug as intended behaviour — is inverted into a check that pins the reverse case as deliberately unbuilt while asserting the same row **without** the flag does cure.

The reading is now held by real data. A new `check_items` in `scripts/rpg2k_testbed_logic_check.rb` asserts against the genuine item table that every curative medicine cures exactly the states it names, and that using it lifts them from a real party member — **state 1 included**, which is the case that catches an ordering mistake: `set_hp` to full quietly clears the death state, so afflicting before healing would have silently undone the only state several of these items name. My first draft of the check had that order wrong and failed on ドラゴンブラッド, which is how I found it.

## Verification

- **546 logic, 180 scene, 71 test-bed, 36 render checks** and the 371,762-command soak pass.
- Reverting the polarity fails **4 fixture checks and 3 real-data checks** — the fixtures only after correcting them, the real-data ones unconditionally.
- `check_items` reports the per-game counts alongside the existing tallies, so an item that grows the flag becomes visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_