### PR TITLE
Check that MZ's save actually restores the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,12 @@
   frame inside `Scene_Battle.update`, freezing the fight before the first
   window opened. MZ's save path is a **promise chain** (JsonEx → pako
   → localforage) rather than MV's synchronous call, so the probe starts it and
-  polls until it settles, then re-enters the map the way `Scene_Load` does
+  polls until it settles, then re-enters the map the way `Scene_Load` does —
+  and the state is **checked back**: six fields (gold, a switch, a variable, an
+  actor's HP, the inventory, the player's position) are moved off their defaults
+  before the save, overwritten between the save and the load, and compared after
+  it, because a settled promise chain is also what a load that restores nothing
+  looks like
 - The menu is **used**, not just opened, for the same reason: `menu_play` mode
   hands the party a Potion and wounds the actor through event commands, then
   taps confirm through the command window, the item category, the item list and

--- a/changelog.d/mz-save-restore-check.changed.md
+++ b/changelog.d/mz-save-restore-check.changed.md
@@ -1,0 +1,12 @@
+- **MZ's save check now proves the state comes back.** `[MZ-SAVE] saved=true
+  exists=true loaded=true` said only that the promise chain settled — the slot
+  deflated, `savefileExists` found it and `loadGame` resolved — which is equally
+  true of a load that restores nothing, or one that quietly starts a new game.
+  The probe now moves six fields off their defaults before saving (gold, a
+  switch, a variable, an actor's HP, the inventory, the player's position),
+  overwrites every one of them between the save and the load, and compares what
+  comes back: `restored=true`, or both signatures printed so the failure names
+  the fields that did not survive. Arming the fields first is what makes it
+  bite — a fresh game and an unwritten save both read as the defaults. The
+  round-trip does work; with `loadGame` stubbed out, the three old claims still
+  pass while the new one fails.

--- a/docs/adr/0004-javascript-maker-mv-quickjs.md
+++ b/docs/adr/0004-javascript-maker-mv-quickjs.md
@@ -602,6 +602,36 @@ JavaScript loads and interprets the JSON.
       the checks distinguish "the run ended before the fight did" from "nothing
       was damaged" so the message names the real cause.
 
+    - **M6.3k — the save round-trip, verified rather than assumed (landed).**
+      The last assertion of the M6.3i shape was the save probe's: `saved=true
+      exists=true loaded=true` says the promise chain *settled* — the slot
+      deflated, `savefileExists` found it, `loadGame` resolved. All three are
+      true of a load that restores nothing, and of one that quietly starts a new
+      game instead.
+
+      The probe now moves six fields off their defaults before saving (gold, a
+      switch, a variable, an actor's HP, the inventory, the player's position),
+      overwrites every one of them *between* the save and the load, and compares
+      the state read back afterwards against the state read before. `restored=`
+      is that comparison; a mismatch prints both signatures, so the failure
+      names the fields that did not come back.
+
+      Arming the fields first is what makes the check real: a fresh game's state
+      and an unwritten save's state would both read as the defaults, so a probe
+      that saved the defaults could not tell `loadGame` from
+      `setupNewGame`. **The round-trip does work** (`restored=true` on the first
+      run) — but with `loadGame` stubbed to a resolved promise the old three
+      claims all still pass while the new one fails with the diff:
+
+      ```
+      [MZ-SAVE] saved=true exists=true loaded=true restored=false
+                before=[gold=1234 sw=1 var=4321 hp=289 items=5 pos=3,4]
+                after=[gold=2011 sw=0 var=9999 hp=252 items=3 pos=11,9]
+      ```
+
+      No new mode: the existing `save` mode's claim gets stronger, which is
+      cheaper than a ninth CI step for what is one flow.
+
   **Concrete boot map (verified by running the engine on the host).** MZ's boot
   differs from MV's in more than the renderer. Driving the shared host through a
   real MZ project (`MZ#boot_probe`) turned the earlier source-read guesses into

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -418,14 +418,73 @@ class MZ
             globalThis.__mzSaveResult =
               "error: " + String((e && e.message) || e);
           };
+
+          // One line covering the save's main contents: the party (gold and
+          // inventory), an actor (HP), the switch and variable tables, and the
+          // player's position on the map. Read before saving and again after
+          // loading; the round-trip is only a round-trip if they match.
+          var sig = function () {
+            var a = $gameActors ? $gameActors.actor(1) : null;
+            var it = (typeof $dataItems !== "undefined") ? $dataItems[1] : null;
+            return "gold=" + $gameParty.gold() +
+              " sw=" + ($gameSwitches.value(1) ? 1 : 0) +
+              " var=" + $gameVariables.value(1) +
+              " hp=" + (a ? a.hp : -1) +
+              " items=" + (it ? $gameParty.numItems(it) : -1) +
+              " pos=" + $gamePlayer.x + "," + $gamePlayer.y;
+          };
+
+          // Move every field off its default *before* saving. Without this the
+          // check would pass on an engine that quietly started a new game
+          // instead of loading one: a fresh game's state and an unwritten
+          // save's state would both read as the defaults. (These are the same
+          // calls the editor's Change Gold / Control Switches / Control
+          // Variables / Change Items / Change HP commands make. Unlike the
+          // menu probe, which drives them through the interpreter because a
+          // game really does hand out its first items from an event, how this
+          // state came to exist has no bearing on whether it serialises.)
+          var arm = function () {
+            $gameParty.gainGold(1234);
+            $gameSwitches.setValue(1, true);
+            $gameVariables.setValue(1, 4321);
+            if (typeof $dataItems !== "undefined" && $dataItems[1]) {
+              $gameParty.gainItem($dataItems[1], 5);
+            }
+            var a = $gameActors ? $gameActors.actor(1) : null;
+            if (a) { a.setHp(Math.max(1, a.mhp - 111)); }
+            $gamePlayer.locate(3, 4);
+          };
+
+          // Overwrite all of it between the save and the load, so a load that
+          // restores nothing cannot be mistaken for one that restored
+          // everything. Every field moves somewhere the armed state is not.
+          var clobber = function () {
+            $gameParty.gainGold(777);
+            $gameSwitches.setValue(1, false);
+            $gameVariables.setValue(1, 9999);
+            if (typeof $dataItems !== "undefined" && $dataItems[1]) {
+              $gameParty.loseItem($dataItems[1], 2);
+            }
+            var a = $gameActors ? $gameActors.actor(1) : null;
+            if (a) { a.setHp(Math.max(1, a.hp - 37)); }
+            $gamePlayer.locate(11, 9);
+          };
+
           try {
             var exists = false;
+            arm();
+            var before = sig();
             DataManager.saveGame(#{slot}).then(function () {
               exists = !!DataManager.savefileExists(#{slot});
+              clobber();
               return DataManager.loadGame(#{slot});
             }).then(function () {
+              var after = sig();
               globalThis.__mzSaveResult =
-                "saved=true exists=" + exists + " loaded=true";
+                "saved=true exists=" + exists + " loaded=true restored=" +
+                (after === before) +
+                (after === before ? "" :
+                  " before=[" + before + "] after=[" + after + "]");
               try {
                 if (typeof SceneManager !== "undefined" &&
                     typeof Scene_Map !== "undefined") {

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -251,16 +251,75 @@ assert 'MZ.menu_probe_js sets the flag Scene_Map acts on, and only there' do
   assert_equal true, MV::JS.eval("SceneManager._scene.menuCalling === undefined")
 end
 
+# A stand-in for the `$game*` objects the save probe's signature reads, plus a
+# DataManager that really does round-trip them: `saveGame` snapshots the state
+# and `loadGame` puts it back. The probe now arms those fields, clobbers them
+# between the save and the load and compares what returns (`restored=`), so a
+# fake that only resolves promises would no longer be testing the probe's actual
+# claim — it would be testing the failure path. That path is covered too, by the
+# spec that hands back a load which restores nothing.
+MZ_SAVE_FAKE_JS = <<~'JS'
+  globalThis.__mzCalls = [];
+  globalThis.__mzSnap = null;
+  globalThis.$gameParty = {
+    _gold: 0, _items: {},
+    gold: function () { return this._gold; },
+    gainGold: function (n) { this._gold += n; },
+    numItems: function (it) { return this._items[it.id] || 0; },
+    gainItem: function (it, n) { this._items[it.id] = (this._items[it.id] || 0) + n; },
+    loseItem: function (it, n) { this.gainItem(it, -n); }
+  };
+  globalThis.$gameSwitches = {
+    _d: {},
+    value: function (i) { return !!this._d[i]; },
+    setValue: function (i, v) { this._d[i] = v; }
+  };
+  globalThis.$gameVariables = {
+    _d: {},
+    value: function (i) { return this._d[i] || 0; },
+    setValue: function (i, v) { this._d[i] = v; }
+  };
+  globalThis.$gameActors = {
+    _a: { hp: 400, mhp: 400, setHp: function (v) { this.hp = v; } },
+    actor: function () { return this._a; }
+  };
+  globalThis.$gamePlayer = {
+    x: 8, y: 6,
+    locate: function (x, y) { this.x = x; this.y = y; }
+  };
+  globalThis.$dataItems = [null, { id: 1, name: 'Potion' }];
+
+  globalThis.__mzDump = function () {
+    return JSON.stringify({
+      gold: $gameParty._gold, items: $gameParty._items,
+      sw: $gameSwitches._d, vars: $gameVariables._d,
+      hp: $gameActors._a.hp, x: $gamePlayer.x, y: $gamePlayer.y
+    });
+  };
+  globalThis.__mzRestore = function (json) {
+    var o = JSON.parse(json);
+    $gameParty._gold = o.gold; $gameParty._items = o.items;
+    $gameSwitches._d = o.sw; $gameVariables._d = o.vars;
+    $gameActors._a.hp = o.hp; $gamePlayer.x = o.x; $gamePlayer.y = o.y;
+  };
+JS
+
 assert 'MZ.save_probe_js round-trips through DataManager across frames' do
   # MZ's save path is a promise chain (unlike MV's synchronous one), so the
   # probe cannot read a return value: it starts the chain and the result lands
   # some pumped frames later. Driven here against the real host with a stand-in
   # DataManager, which is what makes the asynchrony visible.
+  MV::JS.eval(MZ_SAVE_FAKE_JS)
   MV::JS.eval(<<~'JS')
-    globalThis.__mzCalls = [];
     globalThis.DataManager = {
-      saveGame: function (id) { __mzCalls.push('save' + id); return Promise.resolve(0); },
-      loadGame: function (id) { __mzCalls.push('load' + id); return Promise.resolve(0); },
+      saveGame: function (id) {
+        __mzCalls.push('save' + id); __mzSnap = __mzDump();
+        return Promise.resolve(0);
+      },
+      loadGame: function (id) {
+        __mzCalls.push('load' + id); __mzRestore(__mzSnap);
+        return Promise.resolve(0);
+      },
       savefileExists: function (id) { __mzCalls.push('exists' + id); return true; }
     };
     // No scene stack here, so the probe skips the Scene_Map re-entry a real
@@ -273,7 +332,9 @@ assert 'MZ.save_probe_js round-trips through DataManager across frames' do
   assert_equal "", MV::JS.eval(MZ.save_result_js)
 
   5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
-  assert_equal "saved=true exists=true loaded=true",
+  # `restored=true` is the claim that matters: the fields the probe armed came
+  # back after being overwritten. The three before it only say the chain ran.
+  assert_equal "saved=true exists=true loaded=true restored=true",
                MV::JS.eval(MZ.save_result_js)
   # The slot is honoured, and `savefileExists` is read *after* the save resolves
   # — StorageManager only refreshes its key cache at the end of its own chain.
@@ -284,10 +345,11 @@ assert 'MZ.save_probe_js re-enters the map, and keeps its verdict if that fails'
   # A real load throws the $game* objects away and rebuilds them, so the probe
   # finishes the way Scene_Load does — back into Scene_Map — rather than leaving
   # the running scene holding references the load discarded.
+  MV::JS.eval(MZ_SAVE_FAKE_JS)
   MV::JS.eval(<<~'JS')
     globalThis.DataManager = {
-      saveGame: function () { return Promise.resolve(0); },
-      loadGame: function () { return Promise.resolve(0); },
+      saveGame: function () { __mzSnap = __mzDump(); return Promise.resolve(0); },
+      loadGame: function () { __mzRestore(__mzSnap); return Promise.resolve(0); },
       savefileExists: function () { return true; }
     };
     function Scene_Map() {}
@@ -296,7 +358,7 @@ assert 'MZ.save_probe_js re-enters the map, and keeps its verdict if that fails'
   JS
   MV::JS.eval(MZ.save_probe_js(1))
   5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
-  assert_equal "saved=true exists=true loaded=true",
+  assert_equal "saved=true exists=true loaded=true restored=true",
                MV::JS.eval(MZ.save_result_js)
   assert_equal true, MV::JS.eval("SceneManager.went === Scene_Map")
 
@@ -305,11 +367,40 @@ assert 'MZ.save_probe_js re-enters the map, and keeps its verdict if that fails'
   MV::JS.eval("SceneManager.goto = function () { throw new Error('no stack'); };")
   MV::JS.eval(MZ.save_probe_js(1))
   5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
-  assert_equal "saved=true exists=true loaded=true goto_error=no stack",
+  assert_equal "saved=true exists=true loaded=true restored=true " \
+               "goto_error=no stack",
                MV::JS.eval(MZ.save_result_js)
 end
 
+assert 'MZ.save_probe_js catches a load that settles but restores nothing' do
+  # The failure the three older claims cannot see. `loadGame` resolves, so
+  # `saved`/`exists`/`loaded` are all true — and the state it was supposed to
+  # bring back is still the clobbered one. This is what `restored=` is for, and
+  # it is why the probe arms the fields first: a load that quietly started a new
+  # game would leave the defaults, which is only distinguishable from a restored
+  # save if the saved state was never the defaults.
+  MV::JS.eval(MZ_SAVE_FAKE_JS)
+  MV::JS.eval(<<~'JS')
+    globalThis.DataManager = {
+      saveGame: function () { __mzSnap = __mzDump(); return Promise.resolve(0); },
+      loadGame: function () { return Promise.resolve(0); },
+      savefileExists: function () { return true; }
+    };
+    delete globalThis.SceneManager;
+    delete globalThis.Scene_Map;
+  JS
+  MV::JS.eval(MZ.save_probe_js(1))
+  5.times { |i| MV::JS.pump(i * (1000.0 / 60.0)) }
+  res = MV::JS.eval(MZ.save_result_js)
+  assert_equal true, res.include?("loaded=true restored=false")
+  # Both signatures are printed, so the line names the fields that did not come
+  # back rather than only that something did not.
+  assert_equal true, res.include?("before=[gold=1234 sw=1 var=4321")
+  assert_equal true, res.include?("after=[gold=2011 sw=0 var=9999")
+end
+
 assert 'MZ.save_probe_js reports a rejected chain instead of hanging' do
+  MV::JS.eval(MZ_SAVE_FAKE_JS)
   MV::JS.eval(
     "globalThis.DataManager = { saveGame: function () { " \
     "return Promise.reject(new Error('disk full')); } };"

--- a/scripts/mz_boot_check.bash
+++ b/scripts/mz_boot_check.bash
@@ -21,7 +21,8 @@
 #   [MZ-MENUPLAY] hp_before=<n> hp_after=<n> items_before=<n> items_after=<n>
 #              healed=<bool> used=<bool> returned=<bool> scene=<scene>
 #   [MZ-ANIM]  data=<bool> mv=<bool> sprites=<n> cells=<n> played=<bool>
-#   [MZ-SAVE]  saved=<bool> exists=<bool> loaded=<bool>
+#   [MZ-SAVE]  saved=<bool> exists=<bool> loaded=<bool> restored=<bool>
+#              [before=<state> after=<state>, when they differ]
 #   [MZ-BTL]   reached_battle=<bool>
 #   [MZ-BTLPLAY] hp_before=<n> hp_after=<n> alive=<n> damaged=<bool>
 #              ended=<bool> scene=<scene>
@@ -37,7 +38,7 @@
 #   menu      New Game -> map, open the party menu
 #   menu_play    ... and then *use that menu*: heal with an item, back out
 #   animation New Game -> map, play an animation on the player
-#   save      New Game -> map, save + load round-trip
+#   save      New Game -> map, save + load round-trip, state verified back
 #   battle    New Game -> map, start a battle against MZ_TROOP (default 1)
 #   battle_play  ... and then *play that battle out* to its end
 #
@@ -228,6 +229,16 @@ case "${MODE}" in
     save)
         grep -q '\[MZ-SAVE\] saved=true exists=true loaded=true' "${log}" ||
             fail "the save/load round-trip failed ([MZ-SAVE] line)"
+        # `loaded=true` only says the promise chain settled — the slot
+        # decompressed and `extractSaveContents` ran. It is true of a load that
+        # restores nothing, and of one that quietly starts a new game instead.
+        # `restored=true` is the round-trip: gold, a switch, a variable, an
+        # actor's HP, the inventory and the player's position are moved off
+        # their defaults before the save, overwritten between the save and the
+        # load, and read back identical afterwards. A mismatch prints both
+        # states, so the failure names the field that did not come back.
+        grep -q '\[MZ-SAVE\].*restored=true' "${log}" ||
+            fail "the save did not restore the game state ([MZ-SAVE] restored=true)"
         ;;
     battle)
         grep -q '\[MZ-BTL\] reached_battle=true' "${log}" ||


### PR DESCRIPTION
`[MZ-SAVE] saved=true exists=true loaded=true` says the promise chain **settled**: the slot deflated, `savefileExists` found it, `loadGame` resolved. All three are equally true of a load that restores nothing, and of one that quietly starts a new game instead. After #387 and #402 it was the last assertion of that shape left — a claim about the machinery running rather than about the thing working.

The probe now moves six fields off their defaults **before** saving (gold, a switch, a variable, an actor's HP, the inventory, the player's position), overwrites every one of them **between** the save and the load, and compares what comes back afterwards. `restored=` is that comparison; on a mismatch both signatures are printed, so the line names the fields that did not survive rather than only that something did not.

Arming the fields first is what makes the check bite: a fresh game's state and an unwritten save's state both read as the defaults, so a probe that saved the defaults could not tell `loadGame` from `setupNewGame`.

## What it found

**The round-trip works** — `restored=true` on the first run. So, like the menu in #402, this is coverage rather than a fix.

The control is the interesting part. With `loadGame` stubbed to a bare resolved promise, the three old claims all still pass:

```
[MZ-SAVE] saved=true exists=true loaded=true restored=false
          before=[gold=1234 sw=1 var=4321 hp=289 items=5 pos=3,4]
          after=[gold=2011 sw=0 var=9999 hp=252 items=3 pos=11,9]
```

That control is now permanent rather than a one-off I ran by hand: `mruby-mvjs/test/mz_test.rb` gains a `DataManager` fake that genuinely round-trips the state (`saveGame` snapshots, `loadGame` restores), and a new case where the load settles and restores nothing. The two existing save specs are updated to assert `restored=true` — they had been passing a fake whose `loadGame` did nothing at all, which is exactly the hole this closes.

## Scope

No new mode and no new CI step: the existing `save` mode's claim gets stronger, which is cheaper than a ninth step for what is one flow. The probe reads the state through the same `$game*` calls the editor's Change Gold / Control Switches / Control Variables / Change Items / Change HP commands make — but directly rather than through the map interpreter, unlike #402's menu setup: there the event command *was* the thing being reproduced (a game hands out its first items from an event), whereas here how the state came to exist has no bearing on whether it serialises.

## Testing

All eight `mz_boot_check.bash` modes pass on `data/mz-sample`; the cross-mode frame check is 32 checks / 0 failures. `ctest` has only the pre-existing `exe_open` failure, which needs a game absent from this environment — `mruby_test` passes with the new specs (it caught the probe change before CI would have, which is the specs earning their keep).

## Docs

ADR 0004 gains **M6.3k**; README and a `changelog.d/` fragment updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_014B8H5L6jNJqN8HL7WGHbcS)_