### PR TITLE
Tint the map, not a black rectangle over it

### DIFF
--- a/changelog.d/screen-tone-viewport.added.md
+++ b/changelog.d/screen-tone-viewport.added.md
@@ -1,0 +1,10 @@
+- **A Tint Screen tints the map for real.** It was approximated by a black
+  overlay whose opacity tracked how far the tone's channels averaged *below*
+  neutral, so three of the four things the command can ask for did nothing:
+  brightening, the colour cast and saturation. Every map sprite now lives in one
+  `Viewport` and `Scene::Map#update_map_tone` sets that viewport's tone from
+  `Game::Screen#tint`, reusing the RPG2000→RGSS conversion the pictures already
+  use (saturation included, which RPG2000 counts down and RGSS counts up).
+  A viewport tints the sprites inside it and nothing else, which is the line the
+  screen tone needs: the map is tinted while pictures, the message window and the
+  weather / flash / fade overlays are not.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -92,8 +92,28 @@ The work below is roughly ordered by the critical path to a walkable game
   two animated block-C tiles, and water/animation frame cycling. Falls back to
   the previous solid-colour blocks when the chipset image is missing.
   Passability still drives collision. Geometry is pinned by
-  `scripts/rpg2k_render_check.rb`. Remaining: tile-replacement (Replace Chipset
-  Tiles) substitution and screen-tone tinting of tiles.
+  `scripts/rpg2k_render_check.rb`. **Replace Chipset Tiles** (Tile Substitution,
+  11750) is implemented — the swap is recorded on the `Game::Map` so passability
+  follows it, and the scene rebuilds both cached tile layers.
+  **The screen tone reaches the map** now as well. A Tint Screen used to be
+  approximated by a black overlay whose opacity tracked how far the channels
+  averaged *below* neutral, which left three of the four things the command can
+  ask for doing nothing at all: brightening (above neutral), the colour cast, and
+  saturation. Every map sprite — the parallax, both tile layers, the hero, the
+  vehicles and their shadow, and the battle-animation layer — now lives in one
+  `Viewport`, and `Scene::Map#update_map_tone` sets that viewport's tone from
+  `Game::Screen#tint`. A viewport is what carries a tone in RGSS, and it reaches
+  the sprites inside it and nothing else, which is exactly the line the screen
+  tone needs: the map is tinted while the pictures above it (which carry their
+  own tone), the message window and the weather / flash / fade overlays are not.
+  The channel conversion is the one the pictures already use
+  (`Scene::Map.tone_channel`), saturation included — RPG2000 counts it *down*
+  from 100 to mean less saturated, which inverts into RGSS's grey. The tone is
+  pushed only when it changes, so an untinted map pays nothing.
+  That this reaches the display rather than merely storing values is the point:
+  the earlier attempt did store them and the screen never changed, which is why
+  `RGSS.effect_probe` exists (`--rgss_effect_probe`, run under xvfb in CI) and
+  measures a real frame before and after a viewport tone.
 - ✅ Render parity with the genuine runtime —
   `scripts/compare-nepheshel-wine.bash` boots the real `RPG_RT.exe` under wine
   beside our engine on the same game and diffs the frames (ADR 0021). It first
@@ -176,7 +196,10 @@ The work below is roughly ordered by the critical path to a walkable game
   a single-tile step eases across over `TILE/SPEED` frames while the walk
   animation cycles, and a longer hop snaps. Grounded in the real Nepheshel data
   and pinned by `scripts/rpg2k_render_check.rb` /
-  `scripts/rpg2k_scene_check.rb`. Remaining polish: vehicle sprites
+  `scripts/rpg2k_scene_check.rb`. Vehicle sprites are drawn too: one sprite per
+  vehicle from its System CharSet graphic, hidden unless the vehicle is placed on
+  the current map, the ridden one following the party, and the airship floating
+  above a shadow sprite that marks the ground tile it is over
 - ✅ Movement & collision — grid movement with pixel interpolation, walk
   animation and edge/tile/event collision. Move-route *data* decodes
   (`LCF.parse_move_commands` / `LCF::MoveCommand`, wired into the event-page and
@@ -275,8 +298,8 @@ The work below is roughly ordered by the critical path to a walkable game
   Event) command is now wired up too: it decodes the route packed into the
   command's parameters and applies it as a forced route to the target — a map
   event (including "this event") or the player, overriding page movement until
-  it finishes. Still to come: vehicle targets (boat/ship/airship), which are not
-  modelled yet
+  it finishes. Vehicle targets (boat / ship / airship, 10002-10004) resolve as
+  well, so a route can drive one
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Change HP/MP, Full Heal, Change Parameters, Change EXP/Level, Change

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -480,6 +480,11 @@ class RPG2k
       # colours up by 8.
       STEP_DAMAGE_FLASH = [31 * 8, 10 * 8, 10 * 8, 20 * 8, 6].freeze
 
+      # Where the map viewport sits against the sprites drawn outside it. Under
+      # the picture layer (250), so pictures, the message window and the
+      # weather / flash / fade overlays all draw over a tinted map.
+      MAP_VIEWPORT_Z = 100
+
       # Frames waited between autonomous event steps, keyed by RPG2000 move
       # frequency (1 slowest .. 8 fastest). Placeholder pacing while events are
       # drawn as markers (no per-step pixel interpolation yet).
@@ -578,7 +583,7 @@ class RPG2k
         close_shop
         close_battle
         [@lower_sprite, @upper_sprite, @player_sprite, @parallax_sprite,
-         @picture_sprite, @fade_sprite, @flash_sprite, @tint_sprite,
+         @picture_sprite, @fade_sprite, @flash_sprite,
          @weather_sprite].each do |s|
           s.dispose if s
         end
@@ -586,6 +591,8 @@ class RPG2k
         (@timer_windows || []).each { |w| w.dispose if w }
         @airship_shadow.dispose if @airship_shadow
         @animation_sprite.dispose if @animation_sprite
+        # After the sprites it holds, so nothing is orphaned inside it.
+        @map_viewport.dispose if @map_viewport
         @flash_buffer.dispose if @flash_buffer
         @flash_out_buffer.dispose if @flash_out_buffer
         @chipset_bmp.dispose if @chipset_bmp
@@ -629,17 +636,30 @@ class RPG2k
       private
 
       def setup_sprites
-        @lower_sprite = Sprite.new
+        # Everything the map view is made of lives in one viewport, so RPG2000's
+        # Tint Screen can be applied to all of it at once (see #update_map_tone).
+        # A viewport is what carries a tone in RGSS, and it reaches the sprites
+        # inside it and nothing else -- which is the distinction the screen tone
+        # needs: the map is tinted, while the pictures above it (which carry
+        # their own tone), the message window and the weather / flash / fade
+        # overlays are not.
+        @map_viewport = Viewport.new(0, 0, SCREEN_W, SCREEN_H)
+        # Below the picture layer, so the z values inside keep their meaning
+        # relative to each other while the whole map sits under everything that
+        # draws over it.
+        @map_viewport.z = MAP_VIEWPORT_Z
+
+        @lower_sprite = Sprite.new(@map_viewport)
         @lower_sprite.z = 0
         @lower_bmp = Bitmap.new(COLS * TILE, ROWS * TILE)
         @lower_sprite.bitmap = @lower_bmp
 
-        @upper_sprite = Sprite.new
+        @upper_sprite = Sprite.new(@map_viewport)
         @upper_sprite.z = 200
         @upper_bmp = Bitmap.new(COLS * TILE, ROWS * TILE)
         @upper_sprite.bitmap = @upper_bmp
 
-        @player_sprite = Sprite.new
+        @player_sprite = Sprite.new(@map_viewport)
         @player_sprite.z = 100
         @player_bmp = Bitmap.new(Game::CharSet::WIDTH, Game::CharSet::HEIGHT)
         @player_sprite.bitmap = @player_bmp
@@ -649,7 +669,7 @@ class RPG2k
         @vehicle_sprites = {}
         @vehicle_bmps = {}
         Game::Vehicle::TYPES.each do |type|
-          spr = Sprite.new
+          spr = Sprite.new(@map_viewport)
           spr.z = 99
           spr.visible = false
           bmp = Bitmap.new(Game::CharSet::WIDTH, Game::CharSet::HEIGHT)
@@ -659,7 +679,7 @@ class RPG2k
         end
         # The airship floats above the ground; a shadow sprite on the tile below
         # it sells the altitude. A squat translucent dark blob approximates it.
-        @airship_shadow = Sprite.new
+        @airship_shadow = Sprite.new(@map_viewport)
         @airship_shadow.z = 98 # under the vehicles, over the ground / events
         @airship_shadow.visible = false
         shadow = Bitmap.new(TILE, TILE)
@@ -668,7 +688,7 @@ class RPG2k
 
         # A screen-sized layer the Show Battle Animation renderer composites the
         # current frame's cells into, over the map (above the hero).
-        @animation_sprite = Sprite.new
+        @animation_sprite = Sprite.new(@map_viewport)
         @animation_sprite.z = 150
         @animation_sprite.visible = false
         @animation_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
@@ -719,15 +739,6 @@ class RPG2k
         @flash_sprite.opacity = 0
         @flash_rgb = nil
 
-        # Tint Screen: a black overlay whose opacity approximates the tint's
-        # darkening (below flash / fade, over the map and UI). A full tone
-        # (colour cast, brightening, saturation) is native work still to come.
-        @tint_sprite = Sprite.new
-        @tint_sprite.z = 440
-        @tint_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
-        @tint_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, Color.new(0, 0, 0, 255)
-        @tint_sprite.bitmap = @tint_bmp
-        @tint_sprite.opacity = 0
 
         # Weather Effects: rain / snow particles drawn on a screen-sized layer
         # (under the flash / fade overlays), animated by @anim_frame.
@@ -745,7 +756,7 @@ class RPG2k
       def update_screen_overlay
         screen = @state.screen
         draw_transition_mask screen
-        @tint_sprite.opacity = tint_overlay_opacity(screen.tint)
+        update_map_tone screen.tint
 
         r, g, b, strength = screen.flash_color
         if strength <= 0
@@ -851,15 +862,34 @@ class RPG2k
         phase < 4 ? phase : 8 - phase
       end
 
-      # Approximate the darkening of a Tint Screen tone (`[r, g, b, sat]`, each
-      # 0..200 with 100 neutral) as the opacity of a black overlay: the further
-      # the channels average below neutral, the darker. Brightening (above 100),
-      # the colour cast and saturation need a real tone and are not applied.
-      def tint_overlay_opacity(tint)
-        r, g, b, = tint
-        avg = (r + g + b) / 3
-        return 0 if avg >= 100
-        (100 - avg) * 255 / 100
+      # Apply a Tint Screen tone (`[r, g, b, sat]`, each 0..200 with 100 neutral)
+      # to the whole map view, by setting it on the viewport every map sprite
+      # lives in.
+      #
+      # This used to be approximated by a black overlay whose opacity tracked how
+      # far the channels averaged *below* neutral, which meant brightening did
+      # nothing at all, a red tint did not read as red, and saturation was
+      # ignored -- three of the four things the command can ask for. A viewport
+      # carries a real tone, so all four work now.
+      #
+      # The channel conversion is the one the pictures already use
+      # (`Scene::Map.tone_channel`), including RPG2000's saturation running the
+      # other way from RGSS's grey: below 100 is *less* saturated, so a value
+      # under neutral becomes positive desaturation. Skipped entirely while the
+      # tone is neutral, so an untinted map never pays for it.
+      def update_map_tone(tint)
+        return unless @map_viewport
+        r, g, b, sat = tint
+        return if @map_tint == tint
+        @map_tint = tint.dup
+        @map_viewport.tone = Tone.new(Scene::Map.tone_channel(r),
+                                      Scene::Map.tone_channel(g),
+                                      Scene::Map.tone_channel(b),
+                                      -Scene::Map.tone_channel(sat))
+        @map_viewport.update if @map_viewport.respond_to?(:update)
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] screen tone failed, map drawn untinted: #{e.message}"
+        nil
       end
 
       # Create the buffer that carries the Show Picture layer. Pictures composite
@@ -910,7 +940,7 @@ class RPG2k
         @par_auto_y = cfg[:auto_y] ? true : false
         @par_sx = cfg[:sx] || 0
         @par_sy = cfg[:sy] || 0
-        @parallax_sprite = Sprite.new
+        @parallax_sprite = Sprite.new(@map_viewport)
         @parallax_sprite.z = -1
         @parallax_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
         @parallax_sprite.bitmap = @parallax_bmp

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -72,13 +72,21 @@ module RGSS
 
   class Sprite
     attr_accessor :bitmap, :x, :y, :z, :visible, :opacity
-    def initialize(*); end
+    # Which viewport the sprite was built in, so the tone checks can assert that
+    # the map layers share one and the overlays do not.
+    attr_reader :viewport
+    def initialize(viewport = nil, *); @viewport = viewport; end
     def dispose; end
   end
 
   class Viewport
     attr_accessor :z, :visible, :rect
-    def initialize(*); end
+    # The screen tone rides on a viewport (Scene::Map#update_map_tone), so the
+    # stub records what was set on it and how often it was pushed.
+    attr_accessor :tone, :color
+    attr_reader :updates
+    def initialize(*); @updates = 0; end
+    def update; @updates += 1; end
     def dispose; end
   end
 
@@ -523,6 +531,53 @@ check 'Change Event Location does not arc the event it snaps' do
   eq [4, 2], [e[:char].x, e[:char].y], 'the snap landed'
   eq false, e[:jumping], 'a snap is not a hop'
   eq 0, scene.send(:event_jump_offset, e), 'so the sprite is not lifted'
+end
+
+# The map's own sprite layers, in the order they must composite. Events are not
+# here because they are blitted into the two tile-layer buffers rather than
+# owning sprites of their own.
+MAP_LAYER_IVARS = %i[@parallax_sprite @lower_sprite @airship_shadow
+                     @player_sprite @animation_sprite @upper_sprite].freeze
+# ... and everything that draws *over* the map, which the screen tone must not
+# touch: pictures carry their own tone, and the weather / flash / fade overlays
+# are screen effects in their own right.
+ABOVE_MAP_IVARS = %i[@picture_sprite @weather_sprite @flash_sprite
+                     @fade_sprite].freeze
+
+def sprite_z(scene, ivar)
+  s = scene.instance_variable_get(ivar)
+  s && s.z
+end
+
+check 'the map layers composite in a fixed order, under the overlays' do
+  # Pinned because the screen tone moves every one of these into a viewport:
+  # the tone has to reach the map and nothing above it, and the order within the
+  # map has to survive the move.
+  # With a panorama, so the parallax layer is built and pinned too.
+  scene = new_scene({}, parallax: {
+    parallax_flag: true, parallax_name: 'BG',
+    parallax_loop_x: true, parallax_loop_y: true,
+    parallax_autoloop_x: false, parallax_sx: 0,
+    parallax_autoloop_y: false, parallax_sy: 0
+  })
+  zs = MAP_LAYER_IVARS.map { |i| [i, sprite_z(scene, i)] }
+  zs.each { |i, z| ok !z.nil?, "#{i} exists and has a z" }
+  ordered = zs.map { |_i, z| z }
+  eq ordered.sort, ordered, "map layers out of order: #{zs.inspect}"
+
+  top = ordered.max
+  ABOVE_MAP_IVARS.each do |i|
+    z = sprite_z(scene, i)
+    next if z.nil? # a layer this scene has not built
+    ok z > top, "#{i} (z=#{z}) must draw over the map (top z=#{top})"
+  end
+
+  # The three vehicles sit between the shadow and the hero.
+  vs = scene.instance_variable_get(:@vehicle_sprites)
+  vs.each_value do |s|
+    ok s.z > sprite_z(scene, :@airship_shadow), 'a vehicle is over its shadow'
+    ok s.z < sprite_z(scene, :@player_sprite), 'and under a party riding it'
+  end
 end
 
 # -- event page refresh -------------------------------------------------------
@@ -2585,24 +2640,88 @@ check 'the airship floats above a ground shadow; a boat casts none' do
   ok !shadow.visible, 'a boat casts no airship shadow'
 end
 
-check 'Tint Screen darkens the view through a black overlay; neutral clears it' do
+def tint_scene(*params)
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
-  # Tint to (0,0,0) sat 100 instantly (0 tenths), no wait — a full darken.
-  auto.event_commands = [ECmd.new(ic::TINT_SCREEN, [0, 0, 0, 100, 0, 0], indent: 0)]
+  auto.event_commands = [ECmd.new(ic::TINT_SCREEN, params, indent: 0)]
   scene = new_scene({ 1 => event(2, 2, auto) })
-  st = scene.instance_variable_get(:@state)
   5.times { scene.update }
-  tint = scene.instance_variable_get(:@tint_sprite)
-  ok tint.opacity > 200, 'a black tint darkens the screen'
-  # A half-darken (50,50,50) reads as roughly half opacity.
-  st.screen.tint_to(50, 50, 50, 100, 0)
-  scene.update
-  ok tint.opacity > 100 && tint.opacity < 160, 'a partial tint is partly opaque'
-  # Neutral (100,100,100) clears the overlay.
-  st.screen.tint_to(100, 100, 100, 100, 0)
-  scene.update
-  eq 0, tint.opacity, 'a neutral tint clears the overlay'
+  scene
+end
+
+def map_tone(scene)
+  scene.instance_variable_get(:@map_viewport).tone
+end
+
+check 'Tint Screen darkens the map through the viewport tone' do
+  # Tint to (0,0,0) sat 100 instantly (0 tenths), no wait -- a full darken.
+  scene = tint_scene(0, 0, 0, 100, 0, 0)
+  t = map_tone(scene)
+  ok t, 'a tone reached the viewport'
+  eq(-255, t.red, 'a black tint takes every channel to the floor')
+  eq(-255, t.green)
+  eq(-255, t.blue)
+  eq 0, t.gray, 'and leaves saturation alone'
+end
+
+check 'Tint Screen brightens, which the old overlay could not do at all' do
+  # Above neutral. The black overlay approximated only darkening, so this used
+  # to be silently ignored -- the screen simply did not change.
+  scene = tint_scene(200, 200, 200, 100, 0, 0)
+  t = map_tone(scene)
+  eq 255, t.red, 'a full brighten reaches the ceiling'
+  eq 255, t.green
+  eq 255, t.blue
+end
+
+check 'Tint Screen casts a colour, not just a brightness' do
+  # Red up, green and blue down: a red wash. An overlay of one opacity cannot
+  # express this -- it can only darken every channel by the same amount.
+  scene = tint_scene(200, 50, 50, 100, 0, 0)
+  t = map_tone(scene)
+  eq 255, t.red
+  eq(-127, t.green, 'truncating toward zero, as the picture tone does')
+  eq(-127, t.blue)
+  ok t.red > t.green && t.red > t.blue, 'the cast really is red'
+end
+
+check "Tint Screen's saturation inverts into RGSS grey" do
+  # RPG2000 counts saturation *down* from 100 to mean less saturated; RGSS grey
+  # counts up. A fully desaturated tint is therefore full grey.
+  scene = tint_scene(100, 100, 100, 0, 0, 0)
+  t = map_tone(scene)
+  eq 255, t.gray, 'saturation 0 is fully grey'
+  eq 0, t.red, 'with the channels untouched'
+end
+
+check 'a neutral tint leaves the map alone, and is not re-pushed every frame' do
+  scene = tint_scene(100, 100, 100, 100, 0, 0)
+  t = map_tone(scene)
+  eq 0, t.red
+  eq 0, t.gray
+  vp = scene.instance_variable_get(:@map_viewport)
+  before = vp.updates
+  10.times { scene.update }
+  eq before, vp.updates, 'an unchanging tone is set once, not once a frame'
+end
+
+check 'the tone reaches the map layers and nothing above them' do
+  scene = tint_scene(0, 0, 0, 100, 0, 0)
+  vp = scene.instance_variable_get(:@map_viewport)
+  MAP_LAYER_IVARS.each do |i|
+    spr = scene.instance_variable_get(i)
+    next unless spr # a layer this scene did not build
+    ok spr.viewport.equal?(vp), "#{i} is tinted with the map"
+  end
+  ABOVE_MAP_IVARS.each do |i|
+    spr = scene.instance_variable_get(i)
+    next unless spr
+    ok !spr.viewport.equal?(vp),
+       "#{i} must not be tinted -- it draws over the map"
+  end
+  scene.instance_variable_get(:@vehicle_sprites).each_value do |spr|
+    ok spr.viewport.equal?(vp), 'a vehicle is tinted with the map it sits on'
+  end
 end
 
 check 'the choice window plays the cursor and decision system sounds' do


### PR DESCRIPTION
## The gap

A Tint Screen was approximated by a black overlay whose opacity tracked how far the tone's channels averaged **below** neutral. That left three of the four things the command can ask for doing nothing at all:

| the command asks for | before | after |
| --- | --- | --- |
| darkening | approximated | real |
| **brightening** (channels above 100) | **ignored** | real |
| **colour cast** | **ignored** — one opacity can only darken every channel equally | real |
| **saturation** | **ignored** | real |

## What changed

Every map sprite now lives in one `Viewport` — the parallax, both tile layers, the hero, the vehicles and their shadow, and the battle-animation layer — and `Scene::Map#update_map_tone` sets that viewport's tone from `Game::Screen#tint`.

A viewport is what carries a tone in RGSS, and it reaches the sprites inside it and nothing else. That is exactly the line the screen tone needs: **the map is tinted, while the pictures above it (which carry their own tone), the message window and the weather / flash / fade overlays are not.**

The channel conversion is the one the pictures already use (`Scene::Map.tone_channel`), saturation included — RPG2000 counts it *down* from 100 to mean less saturated, which inverts into RGSS's grey. The tone is pushed only when it changes, so an untinted map pays nothing.

## Why this reaches the display when the last attempt didn't

`docs/TODO.md` records an earlier RPG2000 screen-tint attempt that stored its values and never changed the screen — the dangerous failure mode, since the code runs and nothing looks wrong. That is why `RGSS.effect_probe` exists (`--rgss_effect_probe`, run under xvfb in CI): it drives the real renderer on a real display and **measures the frame** before and after a viewport tone, failing loudly if the pixels don't move.

So the viewport route is not an assumption — it is the one screen effect this repo already proves reaches the display. That is also what makes this much smaller than I first thought: no per-draw-path software toning, one viewport.

## Reviewing the restructure

Moving every map sprite into a viewport is a change to compositing, and z-order is what could regress. So the map's draw order is **pinned first, against the old code** — parallax → lower tiles → airship shadow → vehicles → hero → animations → upper tiles, with pictures / weather / flash / fade all above — and that same check still passes after the move. It is the check to look at first.

## Verification

- **7 new checks in `scripts/rpg2k_scene_check.rb`** — the compositing-order pin above; a black tint taking every channel to the floor; a **brighten**, which the old overlay could not express at all; a **red cast** reading as red rather than as uniform darkening; saturation inverting into RGSS grey; a neutral tint clearing the tone and not being re-pushed each frame; and the tone reaching every map layer and no overlay. **186 pass.**
- Every new check was confirmed to **fail when the behaviour it covers is removed** — the tone never set, saturation not inverted, the dirty check dropped, a map layer left outside the viewport, and an overlay wrongly put inside it.
- `rpg2k_logic_check.rb` (546), `rpg2k_testbed_logic_check.rb` (71), `rpg2k_render_check.rb` (36), the 371,762-command soak and the LCF / XP / VX bed checks all pass.

## Docs

Three stale "Remaining" claims corrected while looking for this work — **Replace Chipset Tiles**, **vehicle sprites** and **vehicle Move Event targets** are all implemented, and the TODO still listed them as open. I lost two false starts to them before checking the code, which is the argument for fixing them here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_