### PR TITLE
Run an RGSS game from its own directory

### DIFF
--- a/changelog.d/rgss-host-save-test.added.md
+++ b/changelog.d/rgss-host-save-test.added.md
@@ -12,9 +12,7 @@
   112..119 and the RGSSAD A/B 120..121, so adding another probe pass does not
   renumber an unrelated check.
 - **The XP boot check clears save files around every pass.** Its own save pass
-  plants one, and a game's `Scene_Save` writes a bare relative name, so the next
-  game in the loop found it: *Pray for You*'s title screen enabled Continue on
-  the strength of the editor bed's save and died reading it as its own. Saves
-  being shared between games is a real engine bug (gap 0j in
-  `docs/rpgxp-rgss-api-gap.md`) — this only makes the check hermetic while it
-  stands.
+  plants one, and a title screen offers Continue when it finds one — which
+  changes what the confirm taps pick, so a later pass would drive a different
+  game. Finding that is also what turned up the engine bug fixed below: the save
+  was landing where the *next game* could read it.

--- a/changelog.d/rgss-random-seed.added.md
+++ b/changelog.d/rgss-random-seed.added.md
@@ -1,0 +1,11 @@
+- **`--rgss_random_seed` makes a headless RGSS run reproducible.** mruby seeds
+  its generator from the clock, and a game's own engine rolls constantly — the
+  encounter count as the party is placed, damage variance, the order the battlers
+  act in — so two runs of the same check drive two different games. Fine for a
+  player, useless for a check: the boot check's battle pass passed twice and then
+  failed inside the game's own `make_action_orders`, with no way to ask for that
+  run back. The seed is applied at the last moment before the game's own scripts
+  run, so nothing of ours can consume a value first and shift every roll the game
+  makes, and the host logs it. `0` (the default) leaves the clock seed alone.
+  `scripts/rpgxp_boot_check.bash` pins one and prints it, and
+  `RPGXP_RANDOM_SEED` overrides it for hunting a failure only some seeds reach.

--- a/changelog.d/rgss-run-from-game-dir.fixed.md
+++ b/changelog.d/rgss-run-from-game-dir.fixed.md
@@ -1,0 +1,17 @@
+- **An RGSS game runs from its own directory, so its saves stay its own.** A
+  game's scripts do relative file I/O with nothing to tell them where they are —
+  the stock `Scene_Save` writes `File.open("Save1.rxdata", "wb")` and the stock
+  `Scene_Title` asks `FileTest.exist?("Save1.rxdata")`. `RGSS104E.dll` never has
+  to think about it, because `Game.exe` is launched from the game's folder; this
+  engine is launched from anywhere with `--game_dir` pointing elsewhere, so every
+  game's saves landed in one shared place. The boot check caught what that means:
+  *Pray for You*'s own title screen offered Continue on the strength of the
+  editor test bed's save file, read it as its own, and died on the mismatch —
+  which with a player in the chair is one game overwriting another's progress.
+  `--game_dir` is now resolved to an absolute path and the engine changes into
+  it, for the RGSS makers only (the MV/MZ smokes write screenshots relative to
+  where they were invoked, and an LCF game's saves already go through this
+  engine's own code against the game directory). The font search's last-resort
+  relative `assets/fonts` is handed the launch directory explicitly, so a
+  source-tree run still finds it, and a crash report now records the working
+  directory alongside the game directory.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -214,7 +214,7 @@ the newest-slot search with `Time.at(0)`, which is what made `mruby-time`
 necessary (gap 0i) and is otherwise unexercised. Its own `save_data` then writes
 a real file — and that is what it found:
 
-### 0j. A game's saves land in the launch directory ❌ (open)
+### 0j. A game's saves landed in the launch directory ✅
 
 The save probe reached the screen (`[RPGXP-HOST-SAVE] reached=true`) and wrote a
 file, and then the *next* game in the boot check died:
@@ -237,10 +237,21 @@ and its `Window_SaveFile` got an `Array` where it expected a `String`.
 
 Two games sharing a save file is a real bug, not a test artifact: it would
 overwrite one game's progress with another's the first time a player ran two.
-The fix is for an RGSS boot to resolve the game's relative file I/O against the
-game's own directory, the way the runtime it imitates does. The boot check is
-hermetic in the meantime — it clears `Save*.rxdata` around every pass, since it
-is its own earlier pass that plants the file.
+
+An RGSS boot now **runs from the game's own directory** — `--game_dir` is
+resolved to an absolute path and the engine `chdir`s into it, so a game's
+relative file I/O resolves where the runtime it imitates would put it. Only the
+RGSS makers: the MV/MZ smokes write screenshots relative to wherever they were
+invoked, and an LCF game's saves are written by this engine's own code against
+the game directory already. The font search's last-resort relative
+`assets/fonts` is given the launch directory explicitly so a source-tree run
+still finds it.
+
+The boot check asserts the outcome rather than the mechanism: after the save
+pass, `Save1.rxdata` has to exist **in the bed's own directory**. It still
+clears save files around every pass, because a title screen offers Continue when
+it finds one and that changes which command the confirm taps pick — hermeticity,
+not the bug.
 
 ### 0e. `Kernel#Integer()` ✅ (the first thing New Game runs)
 

--- a/mruby-rpgxp/mrblib/script_host.rb
+++ b/mruby-rpgxp/mrblib/script_host.rb
@@ -108,6 +108,7 @@ class RPGXP
         return false
       end
       install_kernel(db)
+      seed_random
       # RGSS exposes the loaded sections as $RGSS_SCRIPTS ([id, name, source]);
       # some scripts read it (e.g. to hot-reload). Mirror that shape.
       idx = -1
@@ -142,6 +143,37 @@ class RPGXP
         end
       end
       true
+    end
+
+    # Pin the random number generator, when a headless run asked for it.
+    #
+    # mruby seeds from the clock and a game's own engine rolls constantly — the
+    # encounter count as the party is placed, damage variance, and the order the
+    # battlers act in — so two runs of the same check drive two different games.
+    # That is fine for a player and useless for a check: the battle probe passed
+    # twice and then failed inside the game's own `make_action_orders`, and there
+    # was no way to ask for that run back.
+    #
+    # Seeded here rather than in the native boot because this is the last moment
+    # before the game's own code runs, so nothing of ours can consume a value
+    # first and shift every roll the game makes.
+    def self.seed_random
+      seed = random_seed
+      return if seed.nil? || seed.zero?
+      $stderr.puts "[RPGXP-SCRIPTS] random seed #{seed}"
+      srand(seed)
+    rescue StandardError
+      # An mruby without Kernel#srand would be a build without mruby-random,
+      # which a game cannot run anyway; it is not this method's job to say so.
+      nil
+    end
+
+    # `--rgss_random_seed`, published by src/main.cxx. 0 (and the absent
+    # constant, under the CRuby harnesses) means "leave the clock seed alone".
+    def self.random_seed
+      RGSS_RANDOM_SEED
+    rescue StandardError
+      nil
     end
 
     # Whether this exception is the run *ending* rather than the game breaking.

--- a/scripts/rgssad_asset_check.bash
+++ b/scripts/rgssad_asset_check.bash
@@ -35,7 +35,10 @@
 #     this check ran in CI: it passed locally, where no wine prefix exists, and
 #     failed there.)
 #   * a loose file next to the working directory, since a bare relative name is
-#     tried first. Both runs use an absolute --game_dir and a scratch cwd.
+#     tried first. Both runs use an absolute --game_dir and a scratch cwd -- the
+#     engine now changes into the game's own directory for an RGSS boot anyway
+#     (gap 0j), which for these runs is the same place, so the cd below only
+#     pins down what would otherwise be left to that.
 #
 # The graphic is loaded by the *game's own* Scene_Title, through
 # `RPG::Cache.title` -- there is no built-in title screen any more (ADR 0030) --
@@ -134,7 +137,9 @@ for which in with without ; do
     # Each run gets its own display: xvfb-run -a's probe is not atomic and can
     # steal a display from a concurrent run (see build.yml). Run from the packed
     # directory so the loader's bare-relative first candidate cannot pick up a
-    # loose file from the repo either.
+    # loose file from the repo either -- which is where the engine puts itself
+    # for an RGSS boot now, so this states the requirement rather than creating
+    # it.
     if ! (cd "${WORK}/${which}" && \
           xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
             --game_dir "${WORK}/${which}" --rgss_host_new_game \

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -74,6 +74,14 @@ ENGINE="${ENGINE:-./build/rpg_maker_clone}"
 # nominally runs at. 20s was enough to reach the map and not to finish the walk;
 # this is sized so the probes still land at well under ten frames a second.
 TIMEOUT_MS="${RPGXP_TIMEOUT_MS:-45000}"
+# Pin the random number generator, so every run of this check drives the *same*
+# game. mruby seeds from the clock and a game's own engine rolls constantly --
+# the encounter count as the party is placed, damage variance, and the order the
+# battlers act in -- so without this the battle pass is a different fight every
+# time, and it showed: it passed twice and then failed inside the game's own
+# make_action_orders with no way to ask for that run back. Override to hunt a
+# failure that only some seeds reach.
+RANDOM_SEED="${RPGXP_RANDOM_SEED:-20260806}"
 
 GAMES=("$@")
 if [ "${#GAMES[@]}" -eq 0 ] ; then
@@ -122,6 +130,7 @@ run_boot() {
     # shellcheck disable=SC2086 # ${flags} is a deliberate word-split flag list
     if ! xvfb-run --server-num="${display}" timeout 180 "${ENGINE}" \
             --game_dir "${game}" ${flags} \
+            --rgss_random_seed="${RANDOM_SEED}" \
             --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
         echo "FAILED: ${game} (${label}): the engine exited non-zero" >&2
         rc=1
@@ -238,4 +247,4 @@ if [ "${failed}" -ne 0 ] ; then
 fi
 
 echo "rpgxp boot check: ${checked} game(s) ran their own scripts, off their own" \
-     "title screens and onto their own maps"
+     "title screens and onto their own maps (random seed ${RANDOM_SEED})"

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -41,6 +41,9 @@
 #     (`--rgss_host_save_test`, `[RPGXP-HOST-SAVE]`). That is the one place a
 #     game reads a file's timestamp back — its `Window_SaveFile` stamps each
 #     slot from `File#mtime` — and where its own `save_data` writes a real file.
+#     Where that file lands is asserted too: the stock `Scene_Save` writes a
+#     bare `"Save1.rxdata"`, so it proves the engine ran the game from its own
+#     directory rather than from wherever it was launched (gap 0j).
 #   * a `script host failed` line fails the run: the game's own scripts stopping
 #     is the failure this check exists to catch.
 #
@@ -107,17 +110,12 @@ run_boot() {
     local log rc=0 marker missing=""
     log="$(mktemp)"
     echo "-- ${label}"
-    # Start from no save files. A game's own Scene_Save writes
-    # `File.open("Save1.rxdata", "wb")` -- a bare relative name, so it lands in
-    # the *current directory*, which under this engine is wherever it was
-    # launched from rather than the game's own folder (where a real RPG Maker
-    # install would put it, because Game.exe runs from there). So the save pass
-    # below leaves a file that the next game in this loop finds: Pray for You's
-    # own title screen enabled Continue on the strength of the editor bed's save,
-    # read it as its own, and died on the mismatch. That is a real engine bug --
-    # saves must not be shared between games -- but the check has to be hermetic
-    # regardless of when it is fixed, since it is its own earlier pass that
-    # plants the file.
+    # Start from no save files. The save pass below leaves one, and a title
+    # screen offers Continue when it finds one -- which changes what the confirm
+    # taps pick, so a later pass (or a second invocation) would drive a different
+    # game. The repo root is swept too: it is where a save used to land before
+    # the engine learned to run from the game's own directory, and a stale one
+    # left over from then would still be found by a game launched from here.
     rm -f Save[0-9]*.rxdata "${game}"/Save[0-9]*.rxdata
     # Each run gets its own display number: xvfb-run -a's probe is not atomic
     # and can steal a display from a concurrent run (see build.yml).
@@ -155,9 +153,6 @@ run_boot() {
     # ALSA has no device under CI and floods stderr; keep the rest.
     grep -v 'ALSA lib\|snd_\|Unknown PCM' "${log}" | tail -40 || true
     rm -f "${log}"
-    # ...and leave none behind either, so a local run does not dirty the tree or
-    # change what the *next* invocation's title screens offer.
-    rm -f Save[0-9]*.rxdata "${game}"/Save[0-9]*.rxdata
     return "${rc}"
 }
 
@@ -199,15 +194,37 @@ for game in "${GAMES[@]}" ; do
             # And the save screen, its own pass for the same reason. This is the
             # only place a game reads a file's timestamp back, and the only one
             # that writes a file of its own.
-            run_boot "${game}" "${num}" "script host: save" \
-                "--rgss_host_save_test" 2 \
-                '\[RPGXP-HOST-SAVE\] .*reached=true' ||
+            if run_boot "${game}" "${num}" "script host: save" \
+                    "--rgss_host_save_test" 2 \
+                    '\[RPGXP-HOST-SAVE\] .*reached=true' ; then
+                # ...and it has to land in the *game's* directory. The stock
+                # Scene_Save writes a bare "Save1.rxdata", so where that file
+                # ends up is the whole of what the engine's run-from-the-game's-
+                # directory behaviour is worth: before it, the file landed
+                # wherever the engine was launched from and the next game found
+                # it (Pray for You offered Continue on the strength of the
+                # editor bed's save and died reading it as its own).
+                if [ ! -f "${game}/Save1.rxdata" ] ; then
+                    echo "FAILED: ${game} (script host: save): the game's own" \
+                         "save did not land in its own directory" >&2
+                    ls -1 Save[0-9]*.rxdata 2>/dev/null >&2 || true
+                    failed=$((failed + 1))
+                fi
+            else
                 failed=$((failed + 1))
+            fi
             ;;
     esac
 
     num=$((num + 1))
 done
+
+# The save pass leaves a real save file in the bed it ran on; take it back out
+# so a local run does not dirty the tree.
+for game in "${GAMES[@]}" ; do
+    rm -f "${game}"/Save[0-9]*.rxdata
+done
+rm -f Save[0-9]*.rxdata
 
 if [ "${checked}" -eq 0 ] ; then
     echo "FAILED: none of the requested game directories is present, so nothing" \

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -118,6 +118,18 @@ DEFINE_bool(
     "from File#mtime -- and where its own save_data writes a real file. Used "
     "by "
     "scripts/rpgxp_boot_check.bash");
+DEFINE_int64(
+    rgss_random_seed,
+    0,
+    "For the RGSS makers under the script host: seed the random number "
+    "generator with this value before the game's own scripts run, so a "
+    "headless "
+    "run drives the same game every time. mruby seeds from the clock, and a "
+    "game's own engine rolls constantly -- encounter counts, damage variance, "
+    "and the action order of a battle -- so without this a check that gets as "
+    "far as a fight is a different fight on every run. 0 leaves the clock seed "
+    "alone, which is what a player wants. Used by "
+    "scripts/rpgxp_boot_check.bash");
 DEFINE_bool(
     mv_new_game,
     false,
@@ -950,6 +962,9 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RGSS_HOST_SAVE_TEST"),
                 mrb_bool_value(FLAGS_rgss_host_save_test));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "RGSS_RANDOM_SEED"),
+                mrb_fixnum_value(FLAGS_rgss_random_seed));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "MV_SCREENSHOT"),
                 mrb_str_new_cstr(M, FLAGS_mv_screenshot.c_str()));

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -509,11 +509,20 @@ extern "C" void* mrb_basic_alloc_func(void* p, size_t size) {
 // Probed at run time, never at configure time, matching the MIDI patch set: the
 // download is independent of the configure, so an EXISTS check would freeze
 // whichever order the two happened to run in.
-void init_default_font() {
+void init_default_font(const std::string& launch_dir) {
   // Installed layout first, then the source tree, the same order sdl_audio.cxx
   // probes for the patch set.
   rgss::add_default_font_dir(RGSS_DEFAULT_FONT_INSTALL_DIR);
   rgss::add_default_font_dir(RGSS_DEFAULT_FONT_SOURCE_DIR);
+  // The font search's last resort is the *relative* "assets/fonts", for a run
+  // from the source tree or from beside an unpacked build. An RGSS boot has
+  // since moved into the game's own directory (see the chdir in main), where
+  // that would look for the game's fonts instead, so the launch directory is
+  // added here as an absolute path -- after the configure-time ones, which keep
+  // their priority.
+  if (!launch_dir.empty())
+    rgss::add_default_font_dir(
+        (fs::path(launch_dir) / "assets" / "fonts").string());
 
   const std::string& path = rgss::default_font_path();
   if (path.empty()) {
@@ -675,6 +684,16 @@ int main(int argc, char** argv) {
     FLAGS_game_dir = fs::current_path();
 #endif
   }
+  // Resolve it to an absolute path before anything reads it. Everything
+  // downstream treats the game directory as a base -- the data loaders, the
+  // asset search, the archive, the GAME_DIR constant handed to Ruby -- and the
+  // chdir below would otherwise pull a relative one out from under them.
+  {
+    std::error_code ec;
+    const fs::path absolute = fs::absolute(FLAGS_game_dir, ec);
+    if (!ec)
+      FLAGS_game_dir = absolute.lexically_normal().string();
+  }
   nglog::InitializeLogging(argv[0]);
 
 #ifdef __EMSCRIPTEN__
@@ -695,9 +714,9 @@ int main(int argc, char** argv) {
   // below: VX first (its archives, .rgss2a / .rgss3a, are *not* XP markers),
   // then Game.ini plus either a loose Data/System.rxdata or an XP archive,
   // since a packed release ships no loose Data/ folder.
+  const bool xp_game = is_xp_game(FLAGS_game_dir);
+  const bool vx_game = is_rpgvx_game(FLAGS_game_dir);
   {
-    const bool xp_game = is_xp_game(FLAGS_game_dir);
-    const bool vx_game = is_rpgvx_game(FLAGS_game_dir);
     gflags::CommandLineFlagInfo w_info, h_info;
     gflags::GetCommandLineFlagInfo("width", &w_info);
     gflags::GetCommandLineFlagInfo("height", &h_info);
@@ -712,10 +731,58 @@ int main(int argc, char** argv) {
     }
   }
 
+  // Where the engine was launched from, captured before the chdir below: the
+  // font search's relative fallback is resolved against it (init_default_font).
+  std::string launch_dir;
+  {
+    std::error_code ec;
+    const fs::path cwd = fs::current_path(ec);
+    if (!ec)
+      launch_dir = cwd.string();
+  }
+
+  // Run an RGSS game from its own directory, as the runtime it imitates does.
+  //
+  // A game's own scripts do relative file I/O and nothing tells them where they
+  // are: the stock Scene_Save writes `File.open("Save1.rxdata", "wb")` and the
+  // stock Scene_Title asks `FileTest.exist?("Save1.rxdata")` -- bare names,
+  // resolved against the working directory. RGSS104E.dll never has to think
+  // about it because Game.exe is launched from the game's folder, so that
+  // directory *is* the game's. This engine is launched from anywhere with
+  // --game_dir pointing elsewhere, so without this every game's saves land in
+  // one shared place; scripts/rpgxp_boot_check.bash caught the consequence when
+  // Pray for You's own title screen offered Continue on the strength of the
+  // editor test bed's save file, read it as its own and died on the mismatch
+  // (docs/rpgxp-rgss-api-gap.md, gap 0j). Two games overwriting each other's
+  // progress is the same bug with a player in the chair.
+  //
+  // The RGSS makers only. The MV/MZ smokes write screenshots to paths relative
+  // to wherever they were invoked, and an LCF game's saves are written by this
+  // engine's own code against the game directory already, so neither needs it
+  // and both would be disturbed by it.
+  if (xp_game || vx_game) {
+    std::error_code ec;
+    fs::current_path(fs::path(FLAGS_game_dir), ec);
+    if (ec)
+      LOG(WARNING) << "could not run from the game directory '"
+                   << FLAGS_game_dir << "': " << ec.message()
+                   << "; the game's saves will land in the working directory "
+                      "instead, where another game may find them";
+  }
+
   // Everything a crash report should say about this run but cannot work out
   // for itself. Recorded before anything can fail, so even a failure during
   // start-up carries it (see include/error_dump.hxx).
   error_dump_set_context("game dir", FLAGS_game_dir);
+  // Where relative paths in this run resolve — the game's own directory for an
+  // RGSS boot (see the chdir above), which is also where its saves and this
+  // report land, so a report can be found rather than guessed at.
+  {
+    std::error_code ec;
+    const fs::path cwd = fs::current_path(ec);
+    if (!ec)
+      error_dump_set_context("working dir", cwd.string());
+  }
   error_dump_set_context("screen", std::to_string(FLAGS_width) + "x" +
                                        std::to_string(FLAGS_height));
   error_dump_set_context("display backend", FLAGS_sixel   ? "sixel terminal"
@@ -783,7 +850,7 @@ int main(int argc, char** argv) {
   rgss_audio_init();
 
   // Before any game runs, so the first window drawn already has its font.
-  init_default_font();
+  init_default_font(launch_dir);
 
 #ifdef __EMSCRIPTEN__
   // mruby uses word boxing, which stores the type tag in the low 3 bits of each


### PR DESCRIPTION
Closes gap 0j, which the save probe (#404) found on its first run.

## The bug

A game's own scripts do relative file I/O and nothing tells them where they are.
The stock `Scene_Save` writes `File.open("Save1.rxdata", "wb")`; the stock
`Scene_Title` asks `FileTest.exist?("Save1.rxdata")`. `RGSS104E.dll` never has to
think about it, because `Game.exe` is launched from the game's folder — so that
directory *is* the game's. This engine is launched from anywhere with
`--game_dir` pointing elsewhere, so **every game's saves landed in one shared
place**.

The save probe made it concrete: the editor bed saved, and then the next game in
the check died.

```
[RGSS] script host: section "Main" raised TypeError: Array cannot be converted to String
[RGSS] script host:   from menu:2033:in text_size
[RGSS] script host:   from AS_ATST_CG:619:in command_continue
```

*Pray for You*'s own title screen offered Continue on the strength of the editor
bed's save file, read it as its own, and its `Window_SaveFile` got the character
array where it expected a subtitle string. With a player in the chair that is one
game overwriting another's progress.

## The fix

`--game_dir` is resolved to an absolute path — everything downstream treats it as
a base, including the `GAME_DIR` constant handed to Ruby — and the engine changes
into it.

**The RGSS makers only.** The MV/MZ smokes write screenshots relative to where
they were invoked, and an LCF game's saves already go through this engine's own
code against the game directory, so neither needs it and both would be disturbed
by it.

Two things that *were* relative to the launch directory keep working:

- the font search's last resort is a relative `assets/fonts`, for a run from the
  source tree or beside an unpacked build — so the launch directory is handed to
  `init_default_font` and added as an absolute path, after the configure-time
  ones, which keep their priority;
- a crash report now records the **working directory** next to the game
  directory, since that is where it and the saves now land.

## The check asserts the outcome, not the mechanism

After the save pass, `Save1.rxdata` has to exist **in the bed's own directory** —
the stock `Scene_Save` writes a bare name, so where that file lands is the whole
of what this is worth. The check still clears save files around every pass, but
for a different reason now: a title screen offers Continue when it finds one,
which changes what the confirm taps pick, so a later pass would otherwise drive a
different game.

`scripts/rgssad_asset_check.bash` already `cd`ed into the packed project for
exactly this reason; its comments now say that the engine does it too, so the
`cd` states the requirement rather than creating it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_