### PR TITLE
Add issue and pull request label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug report
+description: The engine does something the real RPG Maker runtime does not
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The Engine / Platform / Component pickers below are turned into
+        `engine:*`, `platform:*` and `component:*` labels automatically
+        (`.github/workflows/issue-labels.yml`). Pick what you know and leave
+        the rest — a maintainer can always add the missing ones.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What the engine did, and what the real runtime does instead.
+      placeholder: |
+        Walking into the chest on the first map plays the SE twice.
+        RPG_RT plays it once.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: >
+        The command line you ran, the game data used, and the steps to get
+        there. A `scripts/*_check.rb` invocation that fails is ideal.
+      placeholder: |
+        ./scripts/nix-develop.bash ./build/rpg_maker_clone --rpg2k_new_game data/Nepheshel
+        1. New Game
+        2. Walk two tiles up
+    validations:
+      required: true
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Engine
+      description: Which RPG Maker edition's game data shows the problem.
+      multiple: true
+      options:
+        - RPG Maker 2000
+        - RPG Maker 2003
+        - RPG Maker XP
+        - RPG Maker VX
+        - RPG Maker VX Ace
+        - RPG Maker MV
+        - RPG Maker MZ
+        - Not engine specific / unsure
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Where you saw it. Leave empty when it is not target specific.
+      multiple: true
+      options:
+        - Browser / WebAssembly
+        - Terminal (sixel / iTerm2)
+        - Linux (SDL)
+        - Windows
+        - PSP
+        - Wio Terminal
+        - Other platform
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the engine you think it lives in.
+      multiple: true
+      options:
+        - Graphics / rendering
+        - Audio
+        - Input
+        - mruby runtime
+        - JavaScript runtime (MV/MZ)
+        - Game data / file formats
+        - Save / load
+        - Event interpreter
+        - Scenes / menus / windows
+        - Battle
+        - Build / packaging
+        - CI
+        - Docs
+        - Scripts & test beds
+        - Not sure
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, error dump
+      description: >
+        Anything the engine printed, plus a screenshot when it is a rendering
+        problem. Rendered as code, so no backticks needed.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Blank issues stay on: a one-line note about a wrong pixel should not have to
+# go through a form. The forms exist so the common reports carry their labels.
+blank_issues_enabled: true
+contact_links:
+  - name: Label taxonomy
+    url: https://github.com/take-cheeze/rpg-maker-clone/blob/master/docs/labels.md
+    about: What engine:*, platform:*, component:*, type:* and status:* mean.
+  - name: Contributor guide
+    url: https://github.com/take-cheeze/rpg-maker-clone/blob/master/AGENTS.md
+    about: Branch, changelog fragment, ADR and pull request conventions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+name: Feature request
+description: Something the engine cannot do yet
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The Engine / Platform / Component pickers below are turned into
+        `engine:*`, `platform:*` and `component:*` labels automatically
+        (`.github/workflows/issue-labels.yml`).
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What should it do
+      description: >
+        The behaviour you want, and — when it exists in the real editor or
+        runtime — what that one does, so there is something to match.
+      placeholder: |
+        Support the 2003 battle system's ATB gauge: RPG_RT fills it from
+        the actor's agility …
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: The game or workflow that needs it.
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Engine
+      description: Which RPG Maker edition this is about.
+      multiple: true
+      options:
+        - RPG Maker 2000
+        - RPG Maker 2003
+        - RPG Maker XP
+        - RPG Maker VX
+        - RPG Maker VX Ace
+        - RPG Maker MV
+        - RPG Maker MZ
+        - Not engine specific / unsure
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Leave empty when it is not target specific.
+      multiple: true
+      options:
+        - Browser / WebAssembly
+        - Terminal (sixel / iTerm2)
+        - Linux (SDL)
+        - Windows
+        - PSP
+        - Wio Terminal
+        - Other platform
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the engine it would land in.
+      multiple: true
+      options:
+        - Graphics / rendering
+        - Audio
+        - Input
+        - mruby runtime
+        - JavaScript runtime (MV/MZ)
+        - Game data / file formats
+        - Save / load
+        - Event interpreter
+        - Scenes / menus / windows
+        - Battle
+        - Build / packaging
+        - CI
+        - Docs
+        - Scripts & test beds
+        - Not sure

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,262 @@
+# Path-based labels for pull requests, applied by actions/labeler
+# (.github/workflows/labeler.yml). Every label used here must exist in
+# .github/labels.yml — scripts/label_config_check.rb enforces that.
+#
+# The rules only cover paths whose engine / platform / component is
+# unambiguous. The big mixed files (mruby-rpg2k/mrblib/game.rb holds the
+# chipset, the message window, the battle and the weather) deliberately get no
+# component label: the labeler never removes labels (`sync-labels: false`), so
+# whatever a human adds by hand stays put.
+#
+# Note: this config is read from `master`, because the workflow runs on
+# `pull_request_target` so that pull requests from forks can be labelled. A
+# change to the rules below therefore only takes effect once it is merged.
+
+# --- engine ----------------------------------------------------------------
+
+"engine:rpg2k":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rpg2k/**"
+          - "mruby-lcf/**"
+          - "scripts/rpg2k*"
+          - "scripts/lcf_*"
+          - "scripts/gen-rpg2k-save.rb"
+          - "scripts/gen-lcf-save-wine.bash"
+          - "scripts/*nepheshel*"
+          - "scripts/download-prayforyou.bash"
+          - "scripts/rtp_install.bash"
+          - "scripts/analyze_game.rb"
+          - "docs/rpg2000-sample-analysis.md"
+
+"engine:rpg2k3":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*rpg2k3*"
+          - "**/*rpg2003*"
+
+"engine:xp":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rpgxp/**"
+          - "scripts/rpgxp*"
+          - "scripts/compare-rpgxp-wine.bash"
+          - "scripts/download-opengame-xp.bash"
+          - "scripts/rtp_xp_install.bash"
+          - "scripts/rgssad_asset_check.bash"
+          - "docs/rpgxp-rgss-api-gap.md"
+
+# VX and VX Ace share one data layer (mruby-rpgvx serves RGSS2 and RGSS3, see
+# ADR 0024), so a change there lands on both editions.
+"engine:vx":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rpgvx/**"
+          - "scripts/rpgvx*"
+          - "docs/rpgvx-rgss-api-gap.md"
+
+"engine:vxace":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rpgvx/**"
+          - "scripts/rpgvx*"
+          - "docs/rpgvx-rgss-api-gap.md"
+          - "**/*vxace*"
+          - "**/*rgss3*"
+
+"engine:mv":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-mvjs/mrblib/mv.rb"
+          - "mruby-mvjs/test/mv_test.rb"
+          - "data/mv-sample/**"
+          - "scripts/*mv*"
+
+"engine:mz":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-mvjs/mrblib/mz.rb"
+          - "mruby-mvjs/test/mz_test.rb"
+          - "data/mz-sample/**"
+          - "scripts/*mz*"
+
+# --- platform --------------------------------------------------------------
+# platform:linux has no rules: the SDL sources it would match are the shared
+# desktop path, so it is added by hand when a problem is Linux specific.
+
+"platform:wasm":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/shell.html"
+          - "src/wasm_keypad.cxx"
+          - "cors-proxy/**"
+          - "cmake/emscripten-probe-cache.cmake"
+          - "scripts/*emscripten*"
+          - "scripts/serve.py"
+          - "docs/deploy.md"
+          - "docs/cors-proxy.md"
+
+"platform:terminal":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rgss/src/sixel.cxx"
+          - "mruby-rgss/src/terminal.cxx"
+          - "mruby-rgss/src/iterm.cxx"
+          - "include/sixel.hxx"
+          - "include/terminal.hxx"
+          - "include/iterm.hxx"
+          - "include/log_console.hxx"
+          - "src/log_console.cxx"
+
+"platform:windows":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "scripts/setup.iss"
+          - "scripts/*wine*"
+
+"platform:psp":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/psp/**"
+          - "mruby-rgss/src/psp*.cxx"
+          - "include/psp.hxx"
+
+"platform:wio":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/wio/**"
+          - "mruby-rgss/src/wio*.cxx"
+          - "include/wio.hxx"
+          - "include/lv_conf.h"
+          - "platformio.ini"
+
+# --- component -------------------------------------------------------------
+
+"component:graphics":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rgss/mrblib/lib.rb"
+          - "mruby-rgss/src/lib.cxx"
+          - "mruby-rgss/src/sixel.cxx"
+          - "mruby-rgss/src/terminal.cxx"
+          - "mruby-rgss/src/iterm.cxx"
+          - "mruby-rgss/src/default_font.cxx"
+          - "mruby-rgss/gen_shinonome_data.rb"
+          - "include/rgss_bitmap.hxx"
+          - "include/default_font.hxx"
+          - "mruby-mvjs/src/mvgl.*"
+          - "mruby-mvjs/src/mvwebgl.cxx"
+          - "mruby-mvjs/src/mvcanvas.cxx"
+          - "assets/fonts/**"
+          - "scripts/*font*"
+          - "scripts/*render*"
+          - "scripts/*frame_check*"
+
+"component:audio":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rgss/src/audio.cxx"
+          - "include/rgss_audio.hxx"
+          - "src/sdl_audio.cxx"
+          - "assets/timidity/**"
+          - "scripts/*timidity*"
+          - "scripts/download-freepats.bash"
+          - "scripts/quiet_alsa.bash"
+          - "mruby-mvjs/test/audio_test.rb"
+
+"component:input":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rgss/src/*input*.cxx"
+          - "src/sdl_input.cxx"
+          - "src/wasm_keypad.cxx"
+          - "mruby-mvjs/test/input_test.rb"
+          - "mruby-mvjs/test/touch_test.rb"
+
+"component:runtime-mruby":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "build_config.rb"
+          - "build_config.rb.lock"
+          - "**/mrbgem.rake"
+
+"component:runtime-js":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-mvjs/src/**"
+          - "mruby-mvjs/test/js_test.rb"
+          - "mruby-mvjs/test/host_test.rb"
+          - "mruby-mvjs/test/gl_test.rb"
+          - "mruby-mvjs/test/canvas_test.rb"
+          - "scripts/skip-quickjs-test262.bash"
+
+"component:data":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-lcf/**"
+          - "mruby-rpgxp/mrblib/rgss_data.rb"
+          - "mruby-rpgxp/mrblib/rgssad.rb"
+          - "mruby-rpgvx/mrblib/*data*.rb"
+          - "data/**"
+          - "scripts/*testbed*"
+          - "scripts/gen-mv-sample.py"
+          - "scripts/gen-mz-sample.py"
+          - "scripts/analyze_game.rb"
+
+"component:save":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*save*"
+          - "**/*lsd*"
+
+"component:events":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rpg2k/mrblib/interpreter.rb"
+          - "scripts/rpg2k_command_soak.rb"
+          - "scripts/rpg2k_logic_check.rb"
+
+"component:scenes":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "mruby-rpg2k/mrblib/main.rb"
+          - "scripts/*scene*"
+          - "scripts/*menu*"
+
+"component:battle":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*battle*"
+
+"component:build":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "CMakeLists.txt"
+          - "**/CMakeLists.txt"
+          - "cmake/**"
+          - "flake.nix"
+          - "flake.lock"
+          - "platformio.ini"
+          - ".gitmodules"
+          - "3rd/**"
+          - "scripts/Dockerfile"
+          - "scripts/setup.iss"
+          - "scripts/nix-develop.bash"
+
+"component:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - ".pre-commit-config.yaml"
+
+"component:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+          - "changelog.d/**"
+
+"component:tooling":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "scripts/**"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -161,3 +161,11 @@
 - name: "dependencies"
   color: "0366d6"
   description: "Dependency updates (used by dependabot)"
+# Dependabot puts these on the pull requests it opens and recreates them if
+# they go missing, so they are listed with the colour and wording it uses.
+- name: "github_actions"
+  color: "000000"
+  description: "Pull requests that update GitHub Actions code"
+- name: "submodules"
+  color: "000000"
+  description: "Pull requests that update submodules code"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,163 @@
+# The repository's issue / pull-request label taxonomy.
+#
+# This file is the source of truth: `scripts/sync_github_labels.rb` (run by
+# `.github/workflows/labels.yml` on every push to master that touches it)
+# creates and updates the labels below on GitHub. Deleting a label here does
+# *not* delete it on GitHub unless the sync is run with `--prune`.
+#
+# Four groups, each `<group>:<value>` and each its own colour:
+#
+#   engine:*     which RPG Maker family the issue is about
+#   platform:*   which build target it shows up on
+#   component:*  which part of the engine it lives in
+#   type:*       what kind of work it is
+#   status:*     why it is not moving
+#
+# An issue or PR normally carries one `type:`, plus whichever engine /
+# platform / component labels actually apply — several of each is fine (a
+# tilemap fix can be `engine:xp` + `engine:vx` + `component:graphics`).
+#
+# See docs/labels.md for what each label means in practice.
+
+# --- engine ----------------------------------------------------------------
+# The RPG Maker edition whose games or runtime behaviour is at stake. Use the
+# edition the *game data* comes from, not the code that happens to implement
+# it: an LCF schema fix that only matters for 2003 data is `engine:rpg2k3`.
+- name: "engine:rpg2k"
+  color: "6f42c1"
+  description: "RPG Maker 2000 games (LCF data, RPG_RT parity)"
+- name: "engine:rpg2k3"
+  color: "6f42c1"
+  description: "RPG Maker 2003 specifics (battle system, 2003-only data)"
+- name: "engine:xp"
+  color: "6f42c1"
+  description: "RPG Maker XP games (RGSS1, RGSSAD)"
+- name: "engine:vx"
+  color: "6f42c1"
+  description: "RPG Maker VX games (RGSS2)"
+- name: "engine:vxace"
+  color: "6f42c1"
+  description: "RPG Maker VX Ace games (RGSS3)"
+- name: "engine:mv"
+  color: "6f42c1"
+  description: "RPG Maker MV games (JS corescript, MV plugins)"
+- name: "engine:mz"
+  color: "6f42c1"
+  description: "RPG Maker MZ games (MZ corescript, effekseer)"
+
+# --- platform --------------------------------------------------------------
+# The build target the problem is specific to. Leave all of these off when the
+# change is target independent — that is the common case.
+- name: "platform:wasm"
+  color: "0e8a16"
+  description: "Emscripten / browser build, GitHub Pages, cors-proxy"
+- name: "platform:terminal"
+  color: "0e8a16"
+  description: "Terminal rendering: sixel, iTerm2 inline images, log console"
+- name: "platform:linux"
+  color: "0e8a16"
+  description: "Native SDL desktop build on Linux"
+- name: "platform:windows"
+  color: "0e8a16"
+  description: "Windows build and installer (scripts/setup.iss), wine harnesses"
+- name: "platform:psp"
+  color: "0e8a16"
+  description: "PlayStation Portable port (app/psp)"
+- name: "platform:wio"
+  color: "0e8a16"
+  description: "Wio Terminal / PlatformIO embedded port (app/wio)"
+- name: "platform:other"
+  color: "0e8a16"
+  description: "A target with no label of its own yet"
+
+# --- component -------------------------------------------------------------
+# Which part of the engine the work lands in. Mostly assigned automatically
+# from the changed paths on pull requests (see .github/labeler.yml).
+- name: "component:graphics"
+  color: "1d76db"
+  description: "Rendering: bitmaps, tilemaps, sprites, windows, fonts"
+- name: "component:audio"
+  color: "1d76db"
+  description: "BGM/BGS/SE playback, MIDI, timidity patches"
+- name: "component:input"
+  color: "1d76db"
+  description: "Key/pad/touch input and the per-platform input bridges"
+- name: "component:runtime-mruby"
+  color: "1d76db"
+  description: "mruby VM, mrbgems, mruby/CRuby divergence"
+- name: "component:runtime-js"
+  color: "1d76db"
+  description: "QuickJS host for MV/MZ: JS bindings, canvas, WebGL"
+- name: "component:data"
+  color: "1d76db"
+  description: "Game data and file formats: LCF, RGSS marshal, RGSSAD, MV/MZ JSON"
+- name: "component:save"
+  color: "1d76db"
+  description: "Save/load: LSD read & write, save schema, continue"
+- name: "component:events"
+  color: "1d76db"
+  description: "Event interpreter, event commands, move routes"
+- name: "component:scenes"
+  color: "1d76db"
+  description: "Scenes and UI flow: title, map, menus, message windows"
+- name: "component:battle"
+  color: "1d76db"
+  description: "Battle scenes and combat maths"
+- name: "component:build"
+  color: "1d76db"
+  description: "CMake, nix flake, PlatformIO, submodules, packaging"
+- name: "component:ci"
+  color: "1d76db"
+  description: "GitHub Actions workflows, caching, deploys"
+- name: "component:docs"
+  color: "1d76db"
+  description: "README, /docs, ADRs, changelog fragments"
+- name: "component:tooling"
+  color: "1d76db"
+  description: "scripts/, test beds, parity harnesses, download helpers"
+
+# --- type ------------------------------------------------------------------
+- name: "type:bug"
+  color: "d93f0b"
+  description: "Something behaves differently from the real RPG Maker runtime"
+- name: "type:feature"
+  color: "d93f0b"
+  description: "Support something the engine cannot do yet"
+- name: "type:parity"
+  color: "d93f0b"
+  description: "Match RPG_RT / corescript behaviour pixel- or rule-for-rule"
+- name: "type:refactor"
+  color: "d93f0b"
+  description: "Internal cleanup with no behaviour change"
+- name: "type:chore"
+  color: "d93f0b"
+  description: "Dependencies, housekeeping, repository plumbing"
+- name: "type:question"
+  color: "d93f0b"
+  description: "A question about the project rather than a change to it"
+
+# --- status ----------------------------------------------------------------
+- name: "status:blocked"
+  color: "fbca04"
+  description: "Waiting on something else before it can move"
+- name: "status:needs-info"
+  color: "fbca04"
+  description: "Needs a repro, a game, or a log before it can be worked on"
+
+# --- GitHub defaults worth keeping ------------------------------------------
+# Listed so `--prune` does not sweep them away.
+- name: "good first issue"
+  color: "7057ff"
+  description: "A small, self-contained place to start"
+- name: "help wanted"
+  color: "008672"
+  description: "Extra attention is welcome here"
+- name: "duplicate"
+  color: "cfd3d7"
+  description: "Already tracked somewhere else"
+- name: "wontfix"
+  color: "ffffff"
+  description: "Deliberately not being worked on"
+- name: "dependencies"
+  color: "0366d6"
+  description: "Dependency updates (used by dependabot)"

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,47 @@
+# Turn the Engine / Platform / Component pickers of an issue form into labels.
+#
+# The form's `labels:` key only covers the fixed one (`type:bug`); everything
+# the reporter picked is text in the issue body until this maps it back —
+# see scripts/issue_form_labels.rb.
+name: Issue labeler
+
+on:
+  issues:
+    types: [ opened, edited ]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: issue-labels-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+          persist-credentials: false
+
+      # The body is untrusted input, so it reaches ruby through the
+      # environment, never through the shell command line. The script maps it
+      # against a fixed table and can only ever print labels from that table.
+      - id: map
+        name: Map form answers to labels
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          labels="$(ruby scripts/issue_form_labels.rb | paste -sd, -)"
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
+          echo "mapped: ${labels:-none}"
+
+      - name: Apply labels
+        if: steps.map.outputs.labels != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: ${{ steps.map.outputs.labels }}
+        run: gh issue edit "$NUMBER" --add-label "$LABELS"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,30 @@
+# Label pull requests from the paths they touch, per .github/labeler.yml.
+#
+# `pull_request_target` rather than `pull_request` so a pull request from a
+# fork can be labelled too (the `/preview` flow in build.yml already expects
+# fork branches). Nothing from the pull request is checked out or run here —
+# the action only reads the changed file list and the rules on master — so the
+# write-scoped token never meets the branch's code.
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # Add only. A label a maintainer put on by hand stays on even when no
+          # path matches it any more.
+          sync-labels: false

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,47 @@
+# Keep the repository's labels in step with .github/labels.yml.
+#
+# Runs on every push to master that touches the definitions, so editing the
+# file *is* editing the labels. Nothing is ever deleted automatically: the
+# manual run takes a `prune` box for that, so a label somebody added by hand
+# survives an ordinary sync.
+name: Labels
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/labels.yml'
+      - 'scripts/sync_github_labels.rb'
+  workflow_dispatch:
+    inputs:
+      prune:
+        description: 'Delete labels that .github/labels.yml does not define'
+        type: boolean
+        default: false
+
+permissions:
+  # Labels live on the issues API, and that is all this needs.
+  issues: write
+
+# One sync at a time; a queued run would only fight the one in flight.
+concurrency:
+  group: labels
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+          persist-credentials: false
+
+      # `inputs.prune` is a typed boolean, and empty on a push, so the
+      # expression can only ever expand to `--prune` or nothing.
+      - name: Sync labels
+        run: ruby scripts/sync_github_labels.rb ${{ inputs.prune && '--prune' || '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,15 @@ repos:
       entry: cmake-format -i
       language: system
       files: ".*\\.cmake|CMakeLists.txt"
+    # The label taxonomy is spread over three files that have to agree
+    # (definitions, path rules, issue forms) and only fails in production, on
+    # a real issue or pull request. Check it here instead.
+    - id: label-config
+      name: label config
+      entry: ruby scripts/label_config_check.rb
+      language: system
+      pass_filenames: false
+      files: "^(\\.github/(labels|labeler)\\.yml|\\.github/ISSUE_TEMPLATE/.*|scripts/(issue_form_labels|label_config_check)\\.rb)$"
     # - id: ls
     #   name: show files
     #   language: system

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,12 @@ directly. Before opening one:
 - **Add a changelog fragment.** Drop one `changelog.d/<slug>.<category>.md` file
   per change instead of editing `CHANGELOG.md` (see the Documentation
   Requirements above and `changelog.d/README.md`).
+- **Check the labels.** A pull request is labelled from its changed paths
+  automatically (`.github/labeler.yml`), but the rules skip the mixed files —
+  add the `engine:`, `platform:`, `component:` and `type:` labels the diff
+  really carries. `docs/labels.md` explains the taxonomy; the labels themselves
+  are defined in `.github/labels.yml`, and adding one there is a normal part of
+  a pull request.
 - **Record an ADR when the change is architectural.** New dependencies,
   patterns, integrations or schema changes get a `docs/adr/` entry (see below),
   and user-facing capabilities get matching `/docs` and `README.md` updates.

--- a/changelog.d/issue-pr-label-taxonomy.added.md
+++ b/changelog.d/issue-pr-label-taxonomy.added.md
@@ -1,0 +1,9 @@
+- Issues and pull requests now carry a **label taxonomy**: `engine:` (2000,
+  2003, XP, VX, VX Ace, MV, MZ), `platform:` (wasm, terminal, linux, windows,
+  psp, wio, other), `component:` (graphics, audio, input, the mruby and JS
+  runtimes, data, save, events, scenes, battle, build, ci, docs, tooling),
+  `type:` and `status:`. `.github/labels.yml` is the source of truth and is
+  applied by `scripts/sync_github_labels.rb`; pull requests are labelled from
+  their changed paths, and the new issue forms map their Engine / Platform /
+  Component pickers to the same labels. `scripts/label_config_check.rb` (run
+  from pre-commit) keeps the three configs in agreement. See `docs/labels.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,3 +97,5 @@
 
 ## Development flow
 - For basic testing run `clear ; cmake --build build && cmake --build build -t test` to run basic tests
+- Issues and pull requests are labelled by engine, platform, component and type
+  — see `docs/labels.md` for the taxonomy and how the labels get applied

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,108 @@
+# Issue and pull-request labels
+
+Labels answer three questions about a report before anybody opens it: **which
+RPG Maker edition**, **which target**, and **which part of the engine**. Plus
+what kind of work it is, and why it is not moving.
+
+The definitions live in [`.github/labels.yml`](../.github/labels.yml) — that
+file is the source of truth, and editing it on `master` re-applies the labels
+to GitHub (see [Syncing](#syncing) below).
+
+## Groups
+
+| Group | Meaning | Values |
+| --- | --- | --- |
+| `engine:` | The RPG Maker edition whose games or runtime behaviour is at stake | `rpg2k`, `rpg2k3`, `xp`, `vx`, `vxace`, `mv`, `mz` |
+| `platform:` | The build target it is specific to | `wasm`, `terminal`, `linux`, `windows`, `psp`, `wio`, `other` |
+| `component:` | The part of the engine it lives in | `graphics`, `audio`, `input`, `runtime-mruby`, `runtime-js`, `data`, `save`, `events`, `scenes`, `battle`, `build`, `ci`, `docs`, `tooling` |
+| `type:` | The kind of work | `bug`, `feature`, `parity`, `refactor`, `chore`, `question` |
+| `status:` | Why it is not moving | `blocked`, `needs-info` |
+
+An issue normally carries one `type:` plus whichever engine / platform /
+component labels apply. Several of each is normal and correct — a tilemap
+priority fix is `engine:xp` + `engine:vx` + `component:graphics`, because one
+code path serves both editions.
+
+Some choices worth knowing:
+
+- **`engine:` follows the game data, not the code.** An LCF schema change that
+  only matters for 2003 data is `engine:rpg2k3` even though it lands in
+  `mruby-lcf`, which 2000 shares.
+- **`engine:vx` and `engine:vxace` travel together** by default: one data layer
+  serves RGSS2 and RGSS3 (ADR 0024). Drop one when a change really is
+  Ace-only.
+- **Leave `platform:` off** unless the problem is target specific. Most changes
+  are not.
+- **`type:parity` is the repo's own axis**: the behaviour is implemented, it
+  just does not match RPG_RT / the corescript yet. The wine comparison
+  harnesses (`scripts/compare-*-wine.bash`) produce these.
+- **`component:runtime-mruby` is the mruby VM and its gems** (`build_config.rb`,
+  `mrbgem.rake`, mruby/CRuby divergence). Ruby code that implements a *game*
+  belongs to whatever it implements — `component:events`, `component:scenes`, …
+- **`component:runtime-js` is the QuickJS host** for MV/MZ: the bindings,
+  canvas and WebGL under `mruby-mvjs/src`. The corescript-facing Ruby
+  (`mv.rb`, `mz.rb`) is `engine:mv` / `engine:mz` work.
+
+## How labels get applied
+
+**Pull requests** are labelled from their changed paths by
+[`actions/labeler`](../.github/workflows/labeler.yml), using the rules in
+[`.github/labeler.yml`](../.github/labeler.yml). The rules only cover paths
+whose engine / platform / component is unambiguous; the big mixed files
+(`mruby-rpg2k/mrblib/game.rb` holds the chipset, the message window, the battle
+*and* the weather) get none, so add those by hand. Labelling never removes
+anything (`sync-labels: false`), so a hand-added label survives the next push.
+
+Because the workflow runs on `pull_request_target` — so pull requests from
+forks can be labelled at all — the rules are read from `master`. A change to
+`.github/labeler.yml` therefore only takes effect once it is merged.
+
+**Issues** opened through a form
+([`.github/ISSUE_TEMPLATE`](../.github/ISSUE_TEMPLATE)) carry their `type:`
+label from the form itself, and their Engine / Platform / Component pickers are
+mapped to labels by
+[`scripts/issue_form_labels.rb`](../scripts/issue_form_labels.rb), run by
+[`.github/workflows/issue-labels.yml`](../.github/workflows/issue-labels.yml)
+on open and on edit. Blank issues stay enabled; they just arrive unlabelled.
+
+Everything the two automations can apply is checked against the definitions by
+`scripts/label_config_check.rb`, which runs from pre-commit (and so in CI):
+
+```bash
+ruby scripts/label_config_check.rb
+```
+
+It fails on a label that no longer exists, an issue-form option nobody mapped,
+a dropdown option containing a comma (the answer line is comma separated and
+could not be split), a bad colour, and a labeler rule with no globs. It also
+runs a handful of cases through the issue-body parser.
+
+## Syncing
+
+`.github/labels.yml` is applied to GitHub by
+[`scripts/sync_github_labels.rb`](../scripts/sync_github_labels.rb), which
+[`.github/workflows/labels.yml`](../.github/workflows/labels.yml) runs on every
+push to `master` that touches it. To try it locally against the real
+repository:
+
+```bash
+gh auth status                                     # needs an authenticated gh
+ruby scripts/sync_github_labels.rb --dry-run       # print what would change
+ruby scripts/sync_github_labels.rb                 # create / update
+```
+
+Creating and updating are idempotent. **Deleting is opt-in**: a label that is
+not in the file is left alone unless the sync is run with `--prune` (or the
+manual *Labels* workflow run is started with the `prune` box ticked), so a
+label added by hand in the issue tracker is not swept away by the next edit.
+
+## Adding a label
+
+1. Add it to `.github/labels.yml` — group prefix, six-digit colour matching the
+   rest of its group, and a description that says when to use it.
+2. If it can be inferred from changed paths, add a rule to
+   `.github/labeler.yml`.
+3. If a reporter should be able to pick it, add the option to the issue forms
+   and map it in `scripts/issue_form_labels.rb`.
+4. `ruby scripts/label_config_check.rb`, then open the pull request. The label
+   appears on GitHub when it merges.

--- a/scripts/issue_form_labels.rb
+++ b/scripts/issue_form_labels.rb
@@ -1,0 +1,140 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Turn the Engine / Platform / Component answers of an issue form into
+# repository labels.
+#
+# GitHub renders an issue form (.github/ISSUE_TEMPLATE/*.yml) into Markdown:
+# every field becomes an `### <field label>` heading followed by the answer,
+# and a `multiple: true` dropdown puts its picks on one comma-separated line.
+#
+#     ### Engine
+#
+#     RPG Maker 2000, RPG Maker MZ
+#
+#     ### Platform
+#
+#     _No response_
+#
+# So the mapping is a lookup from the answer strings the form offers to the
+# labels in .github/labels.yml. Both sides are pinned by
+# scripts/label_config_check.rb: every option the templates offer must appear
+# here, and every label named here must exist in .github/labels.yml.
+#
+# Usage:
+#
+#     ISSUE_BODY="$(...)" ruby scripts/issue_form_labels.rb   # body from the env
+#     ruby scripts/issue_form_labels.rb -                     # body from stdin
+#     ruby scripts/issue_form_labels.rb issue.md              # body from a file
+#
+# Prints one label per line (nothing at all when nothing matched), which is
+# what .github/workflows/issue-labels.yml feeds to `gh issue edit --add-label`.
+
+module IssueFormLabels
+  # Answers that deliberately map to no label ("unsure", "not sure") are listed
+  # with nil rather than left out, so the config check can tell a deliberate
+  # no-op from an option somebody forgot to map.
+  ANSWER_LABELS = {
+    'Engine' => {
+      'RPG Maker 2000' => 'engine:rpg2k',
+      'RPG Maker 2003' => 'engine:rpg2k3',
+      'RPG Maker XP' => 'engine:xp',
+      'RPG Maker VX' => 'engine:vx',
+      'RPG Maker VX Ace' => 'engine:vxace',
+      'RPG Maker MV' => 'engine:mv',
+      'RPG Maker MZ' => 'engine:mz',
+      'Not engine specific / unsure' => nil
+    }.freeze,
+    'Platform' => {
+      'Browser / WebAssembly' => 'platform:wasm',
+      'Terminal (sixel / iTerm2)' => 'platform:terminal',
+      'Linux (SDL)' => 'platform:linux',
+      'Windows' => 'platform:windows',
+      'PSP' => 'platform:psp',
+      'Wio Terminal' => 'platform:wio',
+      'Other platform' => 'platform:other'
+    }.freeze,
+    'Component' => {
+      'Graphics / rendering' => 'component:graphics',
+      'Audio' => 'component:audio',
+      'Input' => 'component:input',
+      'mruby runtime' => 'component:runtime-mruby',
+      'JavaScript runtime (MV/MZ)' => 'component:runtime-js',
+      'Game data / file formats' => 'component:data',
+      'Save / load' => 'component:save',
+      'Event interpreter' => 'component:events',
+      'Scenes / menus / windows' => 'component:scenes',
+      'Battle' => 'component:battle',
+      'Build / packaging' => 'component:build',
+      'CI' => 'component:ci',
+      'Docs' => 'component:docs',
+      'Scripts & test beds' => 'component:tooling',
+      'Not sure' => nil
+    }.freeze
+  }.freeze
+
+  # What GitHub writes for a field the reporter left empty.
+  NO_RESPONSE = '_No response_'
+
+  # The body split into `heading => text`, for the `###` headings only. A
+  # reporter's own `###` inside a textarea answer starts a section too; that is
+  # harmless, because only the three headings above are ever read back.
+  def self.sections(body)
+    result = {}
+    heading = nil
+    body.to_s.gsub("\r\n", "\n").each_line do |line|
+      if (m = line.match(/\A###\s+(.*?)\s*\z/))
+        heading = m[1]
+        result[heading] ||= +''
+      elsif heading
+        result[heading] << line
+      end
+    end
+    result
+  end
+
+  # The picks under one heading. Dropdown answers arrive comma separated (no
+  # option may contain a comma — the config check enforces that); checkbox
+  # answers, should a form switch to them, arrive as `- [X] option` lines.
+  def self.answers(body, heading)
+    text = sections(body)[heading]
+    return [] if text.nil?
+
+    text.each_line.flat_map do |line|
+      line = line.strip
+      next [] if line.empty? || line == NO_RESPONSE
+
+      if (m = line.match(/\A- \[([ xX])\]\s*(.*)\z/))
+        m[1] == ' ' ? [] : [m[2].strip]
+      else
+        line.split(',').map(&:strip).reject(&:empty?)
+      end
+    end
+  end
+
+  # Every label the body asks for, in taxonomy order, without duplicates.
+  # Answers the form does not offer are reported on stderr and skipped: a stale
+  # bookmark of an older form should not fail the labelling of a fresh issue.
+  def self.labels(body, warn_io: $stderr)
+    ANSWER_LABELS.flat_map do |heading, mapping|
+      answers(body, heading).filter_map do |answer|
+        unless mapping.key?(answer)
+          warn_io&.puts("issue_form_labels: unknown #{heading} answer #{answer.inspect}")
+          next
+        end
+        mapping[answer]
+      end
+    end.uniq
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  body =
+    case ARGV[0]
+    when nil then ENV['ISSUE_BODY'].to_s
+    when '-' then $stdin.read
+    else File.read(ARGV[0])
+    end
+
+  puts IssueFormLabels.labels(body)
+end

--- a/scripts/label_config_check.rb
+++ b/scripts/label_config_check.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Keep the three halves of the label taxonomy in agreement:
+#
+#   .github/labels.yml            the labels that exist (source of truth)
+#   .github/labeler.yml           path rules for pull requests
+#   .github/ISSUE_TEMPLATE/*.yml  the form pickers, mapped by
+#                                 scripts/issue_form_labels.rb
+#
+# A label typo'd in one of the last three is invisible in production: the
+# labeler silently creates a stray label, `gh issue edit --add-label` fails on
+# the issue nobody is watching. So this runs from pre-commit (and therefore in
+# CI) over every one of them, plus a few cases for the issue-body parser.
+#
+#     ruby scripts/label_config_check.rb
+
+require 'set'
+require 'yaml'
+require_relative 'issue_form_labels'
+
+ROOT = File.expand_path('..', __dir__)
+LABELS_FILE = File.join(ROOT, '.github/labels.yml')
+LABELER_FILE = File.join(ROOT, '.github/labeler.yml')
+TEMPLATE_GLOB = File.join(ROOT, '.github/ISSUE_TEMPLATE/*.yml')
+
+GROUPS = %w[engine platform component type status].freeze
+
+@errors = []
+
+def error(message)
+  @errors << message
+end
+
+def rel(path)
+  path.sub("#{ROOT}/", '')
+end
+
+# --- .github/labels.yml ----------------------------------------------------
+
+definitions = YAML.safe_load_file(LABELS_FILE)
+error("#{rel(LABELS_FILE)}: expected a list of entries") unless definitions.is_a?(Array)
+definitions = [] unless definitions.is_a?(Array)
+
+names = []
+definitions.each_with_index do |label, i|
+  where = "#{rel(LABELS_FILE)} entry #{i + 1}"
+  unless label.is_a?(Hash)
+    error("#{where}: expected a mapping, got #{label.class}")
+    next
+  end
+
+  name = label['name']
+  error("#{where}: missing a name") if name.to_s.empty?
+  error("#{where} (#{name}): duplicate name") if names.include?(name)
+  names << name
+
+  color = label['color'].to_s
+  error("#{where} (#{name}): color #{color.inspect} is not six hex digits") unless color.match?(/\A[0-9a-f]{6}\z/)
+
+  error("#{where} (#{name}): missing a description") if label['description'].to_s.empty?
+
+  next unless name.to_s.include?(':')
+
+  group = name.split(':', 2).first
+  error("#{where} (#{name}): unknown group #{group.inspect}, expected one of #{GROUPS.join(', ')}") unless
+    GROUPS.include?(group)
+end
+
+known = names.to_set
+
+# --- .github/labeler.yml ---------------------------------------------------
+
+rules = YAML.safe_load_file(LABELER_FILE)
+if rules.is_a?(Hash)
+  rules.each do |label, matchers|
+    error("#{rel(LABELER_FILE)}: #{label.inspect} is not in #{rel(LABELS_FILE)}") unless known.include?(label)
+
+    globs = Array(matchers).flat_map do |matcher|
+      next [] unless matcher.is_a?(Hash)
+
+      Array(matcher['changed-files']).flat_map { |m| m.is_a?(Hash) ? m.values.flatten : [] }
+    end
+    error("#{rel(LABELER_FILE)}: #{label.inspect} has no globs") if globs.empty?
+  end
+else
+  error("#{rel(LABELER_FILE)}: expected a mapping of label => rules")
+end
+
+# --- issue forms and their mapping -----------------------------------------
+
+IssueFormLabels::ANSWER_LABELS.each do |heading, mapping|
+  mapping.each do |answer, label|
+    next if label.nil?
+
+    error("scripts/issue_form_labels.rb: #{heading}/#{answer.inspect} maps to #{label.inspect}, " \
+          "which is not in #{rel(LABELS_FILE)}") unless known.include?(label)
+  end
+end
+
+templates = Dir[TEMPLATE_GLOB].reject { |path| File.basename(path) == 'config.yml' }.sort
+error("no issue forms found under #{rel(File.dirname(TEMPLATE_GLOB))}") if templates.empty?
+
+templates.each do |path|
+  form = YAML.safe_load_file(path)
+  Array(form['labels']).each do |label|
+    error("#{rel(path)}: default label #{label.inspect} is not in #{rel(LABELS_FILE)}") unless known.include?(label)
+  end
+
+  Array(form['body']).each do |field|
+    next unless field.is_a?(Hash)
+
+    attributes = field['attributes'] || {}
+    heading = attributes['label']
+    mapping = IssueFormLabels::ANSWER_LABELS[heading]
+    next if mapping.nil?
+
+    unless field['type'] == 'dropdown'
+      error("#{rel(path)}: the #{heading.inspect} field is a #{field['type']}, " \
+            'but the label mapping parses it as a dropdown')
+      next
+    end
+
+    Array(attributes['options']).each do |option|
+      error("#{rel(path)}: #{heading} option #{option.inspect} contains a comma, which the " \
+            'comma-separated answer line cannot be split on') if option.to_s.include?(',')
+
+      error("#{rel(path)}: #{heading} option #{option.inspect} is not mapped in " \
+            'scripts/issue_form_labels.rb') unless mapping.key?(option)
+    end
+  end
+end
+
+# --- the parser itself -----------------------------------------------------
+
+body = <<~BODY
+  ### What happened
+
+  The chest plays its SE twice.
+
+  ### Engine
+
+  RPG Maker 2000, RPG Maker MZ
+
+  ### Platform
+
+  _No response_
+
+  ### Component
+
+  Audio, Scenes / menus / windows
+BODY
+
+expected = %w[engine:rpg2k engine:mz component:audio component:scenes]
+got = IssueFormLabels.labels(body, warn_io: nil)
+error("issue form parse: expected #{expected.inspect}, got #{got.inspect}") unless got == expected
+
+# CRLF (what a browser posts), an unmapped leftover answer and the "unsure"
+# options that deliberately produce nothing.
+crlf = "### Engine\r\n\r\nRPG Maker XP, RPG Maker 3000\r\n\r\n### Component\r\n\r\nNot sure\r\n"
+got = IssueFormLabels.labels(crlf, warn_io: nil)
+error("issue form parse (CRLF): expected [\"engine:xp\"], got #{got.inspect}") unless got == ['engine:xp']
+
+# A body with no form at all (a blank issue) asks for no labels.
+got = IssueFormLabels.labels("Just a note about a wrong pixel.\n", warn_io: nil)
+error("issue form parse (free text): expected [], got #{got.inspect}") unless got.empty?
+
+# --- report ----------------------------------------------------------------
+
+if @errors.empty?
+  puts "label config OK: #{names.size} labels, #{rules.is_a?(Hash) ? rules.size : 0} labeler rules, " \
+       "#{templates.size} issue forms"
+  exit 0
+end
+
+@errors.each { |message| warn "error: #{message}" }
+exit 1

--- a/scripts/sync_github_labels.rb
+++ b/scripts/sync_github_labels.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Push .github/labels.yml to the repository's GitHub labels.
+#
+# Creating a label is idempotent (`gh label create --force` updates an existing
+# one), so this can run on every push that touches the file. Deleting is not:
+# a label missing from the file is left alone unless `--prune` is passed, so a
+# label somebody added by hand in the issue tracker survives a sync.
+#
+#     ruby scripts/sync_github_labels.rb                # create / update
+#     ruby scripts/sync_github_labels.rb --dry-run      # show what it would do
+#     ruby scripts/sync_github_labels.rb --prune        # also delete the rest
+#
+# Needs the `gh` CLI authenticated (GH_TOKEN in CI) and, unless `--repo` is
+# given, a repository it can infer (GH_REPO or the current checkout).
+
+require 'json'
+require 'optparse'
+require 'yaml'
+
+options = { file: File.expand_path('../.github/labels.yml', __dir__), prune: false, dry_run: false }
+
+OptionParser.new do |opts|
+  opts.banner = 'Usage: ruby scripts/sync_github_labels.rb [options]'
+  opts.on('--file PATH', 'Label definitions (default .github/labels.yml)') { |v| options[:file] = v }
+  opts.on('--repo OWNER/NAME', 'Repository to sync (default: gh’s current one)') { |v| options[:repo] = v }
+  opts.on('--prune', 'Delete labels that the file does not define') { options[:prune] = true }
+  opts.on('-n', '--dry-run', 'Print the changes without making them') { options[:dry_run] = true }
+end.parse!
+
+REPO_ARGS = options[:repo] ? ['--repo', options[:repo]] : []
+
+def gh_capture(*args)
+  out = IO.popen(['gh', *args], &:read)
+  raise "gh #{args.join(' ')} failed" unless $?.success?
+
+  out
+end
+
+def gh_run(*args, dry_run:)
+  if dry_run
+    puts "  would run: gh #{args.join(' ')}"
+    return
+  end
+  raise "gh #{args.join(' ')} failed" unless system('gh', *args)
+end
+
+desired = YAML.safe_load_file(options[:file])
+unless desired.is_a?(Array) && desired.all? { |l| l.is_a?(Hash) && l['name'] }
+  abort "#{options[:file]}: expected a list of { name, color, description } entries"
+end
+
+existing = JSON.parse(gh_capture('label', 'list', *REPO_ARGS, '--limit', '200', '--json', 'name,color,description'))
+by_name = existing.to_h { |l| [l['name'], l] }
+
+created = updated = unchanged = 0
+desired.each do |label|
+  name = label['name']
+  color = label['color'].to_s.delete_prefix('#')
+  description = label['description'].to_s
+  current = by_name[name]
+
+  if current && current['color'].to_s.casecmp?(color) && current['description'].to_s == description
+    unchanged += 1
+    next
+  end
+
+  puts(current ? "update #{name}" : "create #{name}")
+  gh_run('label', 'create', name, *REPO_ARGS, '--color', color, '--description', description, '--force',
+         dry_run: options[:dry_run])
+  current ? updated += 1 : created += 1
+end
+
+pruned = 0
+if options[:prune]
+  (by_name.keys - desired.map { |l| l['name'] }).each do |name|
+    puts "delete #{name}"
+    gh_run('label', 'delete', name, *REPO_ARGS, '--yes', dry_run: options[:dry_run])
+    pruned += 1
+  end
+end
+
+puts "#{created} created, #{updated} updated, #{unchanged} unchanged, #{pruned} deleted" \
+     "#{options[:dry_run] ? ' (dry run)' : ''}"


### PR DESCRIPTION
Establish a comprehensive labeling system for issues and pull requests to improve organization and discoverability.

## Summary
This change introduces a complete label taxonomy for the repository with automated labeling workflows. Issues and pull requests are now categorized by RPG Maker engine edition, target platform, component, work type, and status.

## Key Changes

- **Label definitions** (`.github/labels.yml`): Defined 47 labels across 5 groups:
  - `engine:` (rpg2k, rpg2k3, xp, vx, vxace, mv, mz)
  - `platform:` (wasm, terminal, linux, windows, psp, wio, other)
  - `component:` (graphics, audio, input, runtime-mruby, runtime-js, data, save, events, scenes, battle, build, ci, docs, tooling)
  - `type:` (bug, feature, parity, refactor, chore, question)
  - `status:` (blocked, needs-info)

- **Path-based PR labeling** (`.github/labeler.yml`): Automatic labels applied to pull requests based on changed file paths, with rules for each engine, platform, and component

- **Issue form labeling** (`scripts/issue_form_labels.rb`): Maps form dropdown answers to labels for bug reports and feature requests

- **Validation tooling** (`scripts/label_config_check.rb`): Pre-commit hook that ensures consistency across label definitions, path rules, and issue forms

- **GitHub workflows**:
  - `.github/workflows/labeler.yml`: Applies path-based labels to PRs via `actions/labeler`
  - `.github/workflows/issue-labels.yml`: Maps issue form answers to labels on open/edit
  - `.github/workflows/labels.yml`: Syncs label definitions to GitHub on changes

- **Issue templates**: Added bug report and feature request forms with Engine/Platform/Component pickers

- **Documentation** (`docs/labels.md`): Comprehensive guide explaining the taxonomy, how labels are applied, and syncing process

## Implementation Details

- Labels are read from `master` in PR workflows (`pull_request_target`) to support fork PRs
- Path rules only cover unambiguous paths; mixed files get labels added manually
- The labeler never removes labels, preserving hand-added ones
- Issue form options are validated to prevent commas (which would break comma-separated parsing)
- All three label sources (definitions, path rules, forms) are cross-checked by the validation script

https://claude.ai/code/session_01BxJnfWJnPSVdYqyBybiNka