### PR TITLE
Build the engine without Nix, and prove it runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@
 # see src/error_dump.cxx). Running the engine from the source tree drops one
 # here; it belongs in a bug report, not in the repository.
 /error-report.md
+
+# Unicode mapping tables scripts/native-build-without-nix.bash downloads (the
+# flake supplies these through $cp932_table / $jis0208_table instead). They are
+# build inputs fetched on demand and checked against flake.nix's hashes, not
+# sources.
+/.native-build-tables

--- a/README.md
+++ b/README.md
@@ -409,6 +409,26 @@
   stream stays loadable even if the process is killed mid-run, so it is safe to
   trace a long session and stop it with `Ctrl-C`
 
+### Build natively without Nix
+
+- The supported build is the Nix flake (`nix develop`), which pins every
+  dependency. On a plain Debian/Ubuntu box that has a C++ toolchain but no Nix —
+  an agent container, a bare CI image — `scripts/native-build-without-nix.bash`
+  gets to the same place:
+
+  ```sh
+  scripts/native-build-without-nix.bash            # -> ./build/rpg_maker_clone
+  VERIFY=0 scripts/native-build-without-nix.bash   # build only, skip the checks
+  ```
+
+  It installs the SDL2 headers, initialises the `3rd/` submodules (empty in a
+  plain clone), puts `rake` where `/bin/sh` can find it — mruby builds itself
+  with it — and fetches the two Unicode mapping tables the flake supplies through
+  `$cp932_table` / `$jis0208_table`, checking each against flake.nix's own
+  sha256 so the build consumes the bytes Nix would hand it. It then proves the
+  result works rather than just linking: `--rgss_effect_probe` under Xvfb, which
+  measures real pixels, followed by both game boot checks on real project data.
+
 ### Play in the browser (WebAssembly)
 
 - The runtime cross-compiles to WebAssembly with Emscripten and ships a page

--- a/changelog.d/native-build-without-nix.added.md
+++ b/changelog.d/native-build-without-nix.added.md
@@ -1,0 +1,9 @@
+- **`scripts/native-build-without-nix.bash`** builds and render-verifies the
+  engine on a plain Debian/Ubuntu box, for an environment with a C++ toolchain
+  but no Nix. It installs the SDL2 headers, initialises the `3rd/` submodules,
+  puts `rake` where `/bin/sh` can find it (mruby builds itself with it) and
+  fetches the two Unicode mapping tables the flake supplies through
+  `$cp932_table` / `$jis0208_table` — verifying each against flake.nix's own
+  sha256, so the build consumes the same bytes Nix would hand it. It then runs
+  `--rgss_effect_probe` under Xvfb and both game boot checks. `docs/TODO.md` said
+  the binary could not be built or run in an agent environment; it can.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -44,8 +44,19 @@ teleport), open a menu, save, and continue. The remaining work is mostly **the
 parts that need the native build + real game assets to develop and verify**:
 authentic chipset/charset rendering, audio, and the battle system. Everything
 landed so far is exercised by unit tests (`mruby-lcf/test`) and by host harnesses
-that load the pure-Ruby sources under CRuby, since the full SDL/mruby binary
-can't be built or run in this environment. `scripts/rpg2k_command_soak.rb` adds
+that load the pure-Ruby sources under CRuby.
+**The native binary can be built and run without Nix after all** —
+`scripts/native-build-without-nix.bash` does it on a plain Debian/Ubuntu box, and
+this line used to say it could not. Nothing exotic was in the way: SDL2 headers,
+the `3rd/` submodules (empty in a plain clone), `rake` reachable from `/bin/sh`
+(mruby builds itself with it) and the two Unicode mapping tables the flake
+supplies through `$cp932_table` / `$jis0208_table` — downloaded and checked
+against flake.nix's own sha256 hashes, so the build consumes the bytes Nix would
+hand it. That matters because the CRuby harnesses cannot see mruby/CRuby
+divergence (ADR 0021's `module_function` and `Enumerable#none?` bugs both shipped
+through green checks) and cannot see rendering at all, while the native build
+reaches both: `--rgss_effect_probe` measures real pixels under Xvfb, and the two
+boot checks drive real game data to the map. `scripts/rpg2k_command_soak.rb` adds
 the other half of that coverage: it runs **every event command of every
 downloaded test-bed** (371,762 of them) through the interpreter and fails if one
 raises or reaches a handler's "I do not know this" arm, which is the parameter

--- a/scripts/native-build-without-nix.bash
+++ b/scripts/native-build-without-nix.bash
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Build and render-verify the engine on a plain Debian/Ubuntu box, without Nix.
+#
+# The supported way to build this project is the Nix flake (`nix develop`), which
+# pins every dependency. This script is the fallback for an environment that has
+# a C++ toolchain but no Nix -- notably an agent container, where the absence of
+# a native build was long assumed to be permanent. It is not: everything the
+# flake supplies has a plain equivalent, and the four things that actually block
+# a from-scratch build are unremarkable.
+#
+#   1. SDL2 and SDL2_mixer headers.        CMakeLists.txt does find_package(SDL2 REQUIRED).
+#   2. The `3rd/` submodules.              A plain clone leaves them empty and the
+#                                          configure fails on missing CMakeLists.
+#   3. `rake` on PATH.                     mruby builds itself with it, through /bin/sh,
+#                                          so an rbenv shim that is only on the
+#                                          interactive PATH is not enough.
+#   4. Two Unicode mapping tables.         mruby-lcf/cp932_to_unicode.rb and
+#                                          mruby-rgss/gen_shinonome_data.rb read them
+#                                          from $cp932_table / $jis0208_table, which the
+#                                          flake sets from fetchurl. They are downloaded
+#                                          here and checked against the flake's own
+#                                          sha256 hashes, so the build consumes the same
+#                                          bytes Nix would hand it -- not a lookalike.
+#
+# Why bother: the Ruby harnesses (rpg2k_logic_check.rb and friends) load the
+# runtime's pure-Ruby sources under *CRuby*, which cannot see mruby/CRuby
+# divergence, and cannot see rendering at all. A native build reaches both --
+# `--rgss_effect_probe` measures real pixels, and the boot checks drive real game
+# data to the map. See docs/adr/0021 and 0022.
+#
+# Usage:
+#   scripts/native-build-without-nix.bash [BUILD_DIR]      # default: ./build
+#   VERIFY=0 scripts/native-build-without-nix.bash         # build only, no probe/boot checks
+#
+# Needs root for the apt step (skipped when the headers are already present).
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_dir="${1:-$root/build}"
+tables="${TABLES_DIR:-$root/.native-build-tables}"
+
+say() { printf '\n== %s\n' "$*"; }
+
+say "1/5 system packages"
+if pkg-config --exists sdl2 && pkg-config --exists SDL2_mixer; then
+  echo "SDL2 and SDL2_mixer already present"
+else
+  # A stale package index 404s on the individual .deb files, which reads as a
+  # network failure rather than the cache miss it is -- so always refresh first.
+  apt-get update -qq
+  apt-get install -y --no-install-recommends \
+    libsdl2-dev libsdl2-mixer-dev xvfb cmake ninja-build g++
+fi
+
+say "2/5 submodules"
+# --depth 1: the history of thirteen vendored dependencies is not wanted, and
+# quickjs's test262 submodule alone is enormous (the .gitmodules entry marks it
+# to be skipped, which only holds if it is never asked for).
+git -C "$root" submodule update --init --recursive --depth 1
+
+say "3/5 rake on PATH"
+if /bin/sh -c 'command -v rake' >/dev/null 2>&1; then
+  echo "rake already reachable from /bin/sh"
+else
+  rake_bin="$(command -v rake || true)"
+  [ -n "$rake_bin" ] || { echo "no rake found; gem install rake" >&2; exit 1; }
+  ln -sf "$rake_bin" /usr/local/bin/rake
+  echo "linked $rake_bin -> /usr/local/bin/rake"
+fi
+
+say "4/5 Unicode mapping tables"
+mkdir -p "$tables"
+# url, destination, and the sha256 flake.nix pins for it (base64, as Nix prints).
+fetch_table() {
+  local url="$1" dest="$2" want="$3"
+  if [ ! -s "$dest" ]; then
+    curl -fsSL -o "$dest" "$url"
+  fi
+  local got
+  got="$(python3 -c 'import hashlib,base64,sys; print(base64.b64encode(hashlib.sha256(open(sys.argv[1],"rb").read()).digest()).decode())' "$dest")"
+  if [ "$got" != "$want" ]; then
+    echo "hash mismatch for $dest" >&2
+    echo "  flake.nix pins $want" >&2
+    echo "  downloaded     $got" >&2
+    exit 1
+  fi
+  echo "$(basename "$dest"): hash matches flake.nix"
+}
+fetch_table \
+  'https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WindowsBestFit/bestfit932.txt' \
+  "$tables/bestfit932.txt" 'JhTP6jXDyGxB0zGYeTqEykTt7jzw7gATphpD+6Ts4zE='
+fetch_table \
+  'https://www.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/JIS0208.TXT' \
+  "$tables/JIS0208.TXT" 'HFcYcEV/Gcl3IGMfqD7kkVSalroUNtoSlnhqZ9hjLoc='
+export cp932_table="$tables/bestfit932.txt"
+export jis0208_table="$tables/JIS0208.TXT"
+
+say "5/5 configure and build -> $build_dir"
+cmake -S "$root" -B "$build_dir" -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build "$build_dir" -j"$(nproc)"
+echo "built $build_dir/rpg_maker_clone"
+
+if [ "${VERIFY:-1}" = "0" ]; then
+  echo "VERIFY=0; skipping the render and boot checks"
+  exit 0
+fi
+
+say "render check: --rgss_effect_probe under Xvfb"
+# The probe is the one thing that proves a screen effect reached the *display*
+# rather than merely storing its values -- the failure an earlier screen-tint
+# attempt shipped with. It prints [RGSS-PROBE] ok only when the measured frame
+# moved for every effect.
+xvfb-run -a "$build_dir/rpg_maker_clone" --rgss_effect_probe
+
+say "boot checks: real game data to the map"
+ENGINE="$build_dir/rpg_maker_clone" xvfb-run -a bash "$root/scripts/rpg2k_boot_check.bash"
+ENGINE="$build_dir/rpg_maker_clone" xvfb-run -a bash "$root/scripts/rpgxp_boot_check.bash"
+
+say "done: built, render-verified and booted"


### PR DESCRIPTION
## The claim this removes

`docs/TODO.md` said:

> the full SDL/mruby binary can't be built or run in this environment

That wasn't a throwaway line — it shaped what got attempted. Rendering work was treated as unverifiable from an agent environment and deferred on those grounds, and I nearly deferred more of it myself on the same reasoning. **It isn't true**, and nothing exotic was in the way:

| blocker | why it bites |
| --- | --- |
| SDL2 / SDL2_mixer headers | `find_package(SDL2 REQUIRED)` |
| the `3rd/` submodules | empty in a plain clone, so configure fails on missing `CMakeLists.txt` files |
| `rake` reachable from `/bin/sh` | mruby builds itself with it — an rbenv shim only on the interactive PATH is not enough |
| two Unicode mapping tables | read from `$cp932_table` / `$jis0208_table`, which the flake supplies via `fetchurl` |

One aside worth knowing: the apt step 404s on individual `.deb` files if the package index is stale, which reads as a network failure rather than the cache miss it is. The script always refreshes first.

## What this adds

`scripts/native-build-without-nix.bash` does all four and builds. The Nix flake stays the supported path — this is the fallback for a box with a C++ toolchain and no Nix.

The tables are **checked against flake.nix's own sha256 hashes**, so the build consumes the bytes Nix would hand it rather than a lookalike; a mismatch stops the run and prints both hashes.

It doesn't stop at linking, which is the part that matters:

- **`--rgss_effect_probe` under Xvfb** — the check that *measures real pixels* rather than trusting that a stored value reached the display. That probe exists because an earlier screen-tint attempt stored its values and never changed the screen.
- **Both game boot checks** — real project data driven to the map.

That combination is what the CRuby harnesses cannot give: they can't see mruby/CRuby divergence (ADR 0021's `module_function` and `Enumerable#none?` bugs both shipped through green checks) and can't see rendering at all.

## Verification

Run **by executing the script against an empty build directory** — not by writing down the steps I'd taken by hand, which is the failure mode a setup script is most prone to:

```
== 1/5 system packages … == 5/5 configure and build -> /tmp/verify
bestfit932.txt: hash matches flake.nix
JIS0208.TXT: hash matches flake.nix
[RGSS-PROBE] ok
[RPG2k-MAP] map=371 x=10 y=7      # Nepheshel
[RPG2k-MAP] map=7 x=11 y=7        # mtf-meido-action
[RPGXP-HOST-MOVE] start=9,7 end=9,8 moved=true frame=221
== done: built, render-verified and booted
```

`SCRIPT_EXIT=0`. The 546 logic and 186 scene checks still pass (this touches no runtime code).

## What it unblocks

ADR 0022's Tilemap per-row priority layering is the last substantial `Tilemap` gap, and it was held back partly because a mistake there "risks a crash on map load, not just a cosmetic glitch," raising the bar for landing it blind. With a local build plus the boot checks, crash-on-map-load is now catchable before review rather than after.

One honest limit: the XP test bed ships no image assets, so its tilesets load as blank bitmaps. That's enough to verify no-crash and z-ordering structurally, but not to eyeball a roof occluding a character.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_