### PR TITLE
Announce a status the target already had

### DIFF
--- a/changelog.d/state-already-message.added.md
+++ b/changelog.d/state-already-message.added.md
@@ -1,0 +1,12 @@
+- **A status the target already has is announced instead of going silent** — the
+  状態 row's `message_already` (「はすでに毒に冒されている！」), the fifth of its
+  sentences and the one nothing read. RPG_RT counts an already-carried state as a
+  **success** and decides that *before* rolling the skill's accuracy, so a Poison
+  Sting on an already-poisoned foe always reports, and a 0%-accuracy skill reports
+  too. `Game::Battle#roll_inflict` returns the already-carried states beside the
+  landed ones, the battle log entry carries them, and the action banner prints the
+  state's own sentence — one wording for both sides, with the composed fallback
+  kept for a database that leaves it blank. 15 of Nepheshel's 25 states and 7 of
+  mtf-meido-action's 10 fill the field in. `message_affected` stays deliberately
+  unread: EasyRPG defines its helper and never calls it, so nothing pins when
+  RPG_RT prints it. See the addendum to ADR 0032.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -607,6 +607,16 @@ The work below is roughly ordered by the critical path to a walkable game
   enemy's action entry stops firing. Nine of Nepheshel's 25 states and two of
   mtf's ten carry a reduced hit ratio, four and three a release chance, two and
   one a seal.
+  **And a status the target already has is announced** rather than going silent,
+  in the state row's own `message_already` (「はすでに毒に冒されている！」, 15 of
+  Nepheshel's states and 7 of mtf's). RPG_RT counts an already-carried state as a
+  *success* and settles that **before** rolling the skill's accuracy, so a Poison
+  Sting on an already-poisoned foe always reports and a 0%-accuracy skill reports
+  too — making the report depend on the roll would be the natural guess and it is
+  wrong. `roll_inflict` returns the already-carried states beside the landed ones
+  and the action banner prints the sentence, one wording for both sides.
+  `message_affected` is deliberately still unread: EasyRPG defines its helper and
+  never calls it from either battle scene, so nothing pins when RPG_RT prints it.
   **A condition drains the party on the map now, too** — RPG2000's field poison,
   the last of the 状態 row's simulation fields with a game behind it.
   `hp_change_map_steps` / `hp_change_map_val` (and the matching SP pair) say how

--- a/docs/adr/0032-state-effects.md
+++ b/docs/adr/0032-state-effects.md
@@ -122,3 +122,48 @@ three against the **real** 状態 tables: every blinding state scales accuracy b
 exactly its own ratio, the game's most-releasable state does come off within 200
 blows, and every sealing state seals some magic while leaving rate-0 skills
 alone.
+
+## Addendum: the sentence for a state that was already there
+
+Date: 2026-08-06
+
+The state row carries a fifth sentence beside the four above: `message_already`,
+for something trying to inflict a state the target is **already** carrying —
+「はすでに毒に冒されている！」. It was parsed and unread, and the runtime went
+silent in exactly that case: `roll_inflict` skipped a state the target had and
+reported nothing.
+
+Silence is the wrong answer, and not for a cosmetic reason. RPG_RT counts an
+already-carried state as a **success**, and it decides that *before* rolling the
+skill's accuracy — EasyRPG's `AddAffectedState(StateEffect::AlreadyInflicted)`
+`continue`s ahead of the `PercentChance`. So a Poison Sting on an already
+poisoned foe always announces itself, where a roll would have gone quiet some of
+the time, and a 0%-accuracy skill announces it too. Making the report depend on
+the roll would have been the natural guess and it is wrong.
+
+`roll_inflict` now returns `[inflicted, already]`, the battle entry carries
+`already:`, and `Scene::Map#battle_state_lines` prints
+`Game::States.already_message` for each — one wording for both sides, like the
+recovery line rather than the split actor/enemy inflict pair. The scene keeps its
+composed fallback for a database that leaves the sentence blank.
+
+15 of Nepheshel's 25 states and 7 of mtf-meido-action's 10 fill the field in,
+against 99 and 40 skills that name at least one state — so this is text the games
+wrote and expected to see.
+
+**`message_affected` is deliberately still unread.** 15 and 4 states fill it in,
+and the wordings (「は眠っている・・・」, 「は麻痺していて動けない！」,
+「は毒で80のダメージを受けた!」) read like the line for a turn a state costs the
+battler. But EasyRPG defines `GetStateAffectedMessage` and never calls it from
+either battle scene, so there is nothing to pin *when* RPG_RT prints it. Guessing
+would put invented text in the battle log, which is the thing this ADR set out to
+stop.
+
+Covered by `scripts/rpg2k_logic_check.rb` (an already-carried state reports
+rather than lands, does so at 0% accuracy, does so for an immune target, does not
+stack, and a clear target reports nothing), by `scripts/rpg2k_scene_check.rb`
+(the sentence reaches the action banner for an ally and an enemy target alike,
+and a state with no sentence still gets announced) and by
+`scripts/rpg2k_testbed_logic_check.rb`, which composes every real
+`message_already` in both games after two different battler names and drives a
+real state through a 0%-accuracy skill.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4668,6 +4668,15 @@ module Game
       message(battler_name, field(id, table, :message_recovery))
     end
 
+    # ... and for one the target **already** carried when something tried to
+    # inflict it again ("はすでに毒に冒されている！"). One wording for both sides,
+    # like the recovery line. RPG_RT treats this as a result worth announcing
+    # rather than a silent no-op, which is why the field exists at all: 15 of
+    # Nepheshel's 25 states and 7 of mtf-meido-action's 10 fill it in.
+    def self.already_message(id, table, battler_name)
+      message(battler_name, field(id, table, :message_already))
+    end
+
     def self.field(id, table, name)
       r = row(id, table)
       v = r && r.respond_to?(name) ? r.send(name) : nil
@@ -5914,10 +5923,11 @@ module Game
         target.hp -= dmg
         # An attack skill may inflict its states on a surviving target, each
         # rolled against the skill's accuracy.
-        inflicted = target.dead? ? [] : roll_inflict(target, cmd)
+        inflicted, already = target.dead? ? [[], []] : roll_inflict(target, cmd)
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
-          inflicted: inflicted, target_ally: ally?(target), skill: cmd[:name] }
+          inflicted: inflicted, already: already,
+          target_ally: ally?(target), skill: cmd[:name] }
       else
         before_hp = target.hp
         before_mp = target.mp || 0
@@ -5968,19 +5978,30 @@ module Game
 
     # Inflict a skill command's `inflict` states on `target`, each landing only if
     # a 0..99 roll comes in under the skill's `chance` (its accuracy) scaled by
-    # the target's per-state susceptibility. Skips a state the target already
-    # carries. Returns the states actually inflicted.
+    # the target's per-state susceptibility.
+    #
+    # Returns `[inflicted, already]`: the states that landed, and the ones the
+    # target was already carrying. The second list is not a list of failures —
+    # RPG_RT counts a state the target already has as a **success** and says so
+    # ("X is already poisoned!"), *without* rolling the accuracy first
+    # (EasyRPG's `AddAffectedState(... AlreadyInflicted)`, which `continue`s
+    # before the `PercentChance`). A Poison Sting on a poisoned foe therefore
+    # always reports, where a roll would sometimes have gone quiet.
     def roll_inflict(target, cmd)
       chance = cmd[:chance] || 100
       inflicted = []
+      already = []
       (cmd[:inflict] || []).each do |sid|
-        next if target.state?(sid)
+        if target.state?(sid)
+          already << sid
+          next
+        end
         prob = chance * state_susceptibility(target, sid) / 100
         next unless @rng.random(100) < prob
         target.states = (target.states || []) + [sid]
         inflicted << sid
       end
-      inflicted
+      [inflicted, already]
     end
   end
 

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3908,6 +3908,13 @@ class RPG2k
           lines << (Game::States.inflict_message(id, table, name, ally) ||
                     "#{name} is #{state_label(id, table)}")
         end
+        # A state the target already carried when the skill tried to inflict it
+        # again. RPG_RT announces it rather than going quiet, in the state's own
+        # words ("はすでに毒に冒されている！"), and reports it as a *success*.
+        (entry[:already] || []).each do |id|
+          lines << (Game::States.already_message(id, table, name) ||
+                    "#{name} is already #{state_label(id, table)}")
+        end
         # `cured` is a medicine or a cure skill lifting a state; `woke` is a blow
         # shaking one off (a state's `release_by_attack`). Both are the state
         # lifting, which has one wording whichever side it happened to.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6200,6 +6200,53 @@ check 'battle: a mid susceptibility (rank C 60%) both lands and resists' do
   ok results.any?(&:empty?), 'and sometimes is resisted'
 end
 
+# A state the target already carries is not a silent no-op: RPG_RT reports it as
+# a success in the state's own words, and it does so *without* rolling the
+# skill's accuracy first.
+check 'battle: a status the target already has reports "already", not a landing' do
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.states = [3]
+  e = poison_cast(foe)
+  eq [], e[:inflicted], 'nothing new landed'
+  eq [3], e[:already], 'but the attempt is announced'
+  ok foe.state?(3), 'and the state is still there, once'
+  eq 1, foe.states.count { |s| s == 3 }, 'not stacked'
+end
+
+check 'battle: "already" is reported even at 0% accuracy' do
+  skills = { 7 => fake_skill(name: 'Dud', scope: 0, sp_cost: 3, power: 20,
+                             mrate: 40, state_effects: [0, 0, 1], hit: 0) }
+  st = skill_party(skills)
+  mage = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.states = [3]
+  c = st.party.battle_skill_command(st.party.db_skill(7), mage, foe)
+  eq 0, c[:chance]
+  bat = Game::Battle.new([mage], [foe], Game::Rng.new(1))
+  bat.command_skill(mage, foe, name: 'Dud', cost: c[:cost], hp: c[:hp], mp: c[:mp],
+                    inflict: c[:inflict], chance: c[:chance])
+  bat.begin_round
+  eq [3], bat.step_action[:already], 'the roll is skipped, so it always reports'
+end
+
+check 'battle: an immune target that already has the state still reports it' do
+  # Susceptibility gates the *roll*, and there is no roll for a state already
+  # carried -- a rank-E foe that is somehow already poisoned still says so.
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.state_ranks = { 3 => 4 }
+  foe.states = [3]
+  e = poison_cast(foe)
+  eq [], e[:inflicted]
+  eq [3], e[:already]
+end
+
+check 'battle: a clear target reports nothing as already' do
+  foe = combatant('Foe', 0, 0, 5, 100)
+  e = poison_cast(foe)
+  eq [3], e[:inflicted]
+  eq [], e[:already]
+end
+
 check 'Battle command_skill resolves an attack skill: damage lands, SP is spent' do
   mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
   foe  = combatant('Foe', 0, 0, 5, 100)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -219,6 +219,7 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0)
                                      message_actor: ' is poisoned!',
                                      message_enemy: ' looks ill!',
                                      message_recovery: ' is cured.',
+                                     message_already: ' is already poisoned!',
                                      hp_change_map_steps: 4,
                                      hp_change_map_val: 1),
                  4 => OpenStruct.new(name: 'Sleep', color: 4, priority: 80),
@@ -3632,6 +3633,32 @@ check 'being downed is announced with the death state own sentence' do
                defeated: true, target_ally: true })
   ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
       .include?('Hero falls!'), 'and the actor wording'
+end
+
+check 'a status the target already had is announced, in the state own words' do
+  scene, = battle_at_command
+  scene.send(:show_battle_action,
+             { attacker: 'Slime', target: 'Hero', damage: 3,
+               already: [3], target_ally: true })
+  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+      .include?('Hero is already poisoned!'),
+     'one wording, whichever side the target is on'
+  scene.send(:show_battle_action,
+             { attacker: 'Hero', target: 'Slime', damage: 3,
+               already: [3], target_ally: false })
+  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+      .include?('Slime is already poisoned!')
+end
+
+check 'an already-carried state with no sentence still gets announced' do
+  scene, = battle_at_command
+  # State 4 (Sleep) has a name but no message_already, which is what an
+  # English-release database looks like.
+  scene.send(:show_battle_action,
+             { attacker: 'Slime', target: 'Hero', damage: 3,
+               already: [4], target_ally: true })
+  ok window_texts(scene.instance_variable_get(:@battle_ui)[:action_win])
+      .include?('Hero is already Sleep'), 'the scene composes its own wording'
 end
 
 check 'a state the database gives no sentence still gets announced' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -404,16 +404,54 @@ def check_states(dir)
   waking = []
   sealing = []
   slipping = []
+  already = []
   states.each do |id, r|
     blinding << id if r.reduce_hit_ratio && r.reduce_hit_ratio < 100
     waking << id if (r.release_by_attack || 0) > 0
     sealing << id if r.restrict_magic || r.restrict_skill
     slipping << id if (r.hp_change_map_steps || 0) > 0 &&
                       (r.hp_change_map_val || 0) > 0
+    already << id unless r.message_already.to_s.empty?
   end
   puts format('   states: %d blinding, %d shaken off by a blow, %d sealing, ' \
-              '%d slipping on the map',
-              blinding.size, waking.size, sealing.size, slipping.size)
+              '%d slipping on the map, %d with an "already" sentence',
+              blinding.size, waking.size, sealing.size, slipping.size,
+              already.size)
+
+  unless already.empty?
+    # A fixture cannot say whether the sentence is worded from the speaker's
+    # side (as message_actor / message_enemy are) or shared -- it is written to
+    # match whatever the code does. Only a real game's own text can: every one
+    # of these reads as a complete predicate after the battler's name, and one
+    # sentence serves both sides.
+    check "#{name}: an 'already' sentence composes after either battler's name" do
+      already.each do |sid|
+        row = states[sid]
+        line = Game::States.already_message(sid, states, 'スライム')
+        eq "スライム#{row.message_already}", line,
+           "state ##{sid} (#{row.name})"
+        eq "リト#{row.message_already}",
+           Game::States.already_message(sid, states, 'リト'),
+           'and the same sentence for the other side'
+      end
+    end
+
+    # The rule that makes the field reachable at all: a state the target already
+    # carries reports without rolling, so even a 0%-accuracy skill says so.
+    check "#{name}: a real state already carried reports without a roll" do
+      sid = already.first
+      foe = combatant('Foe', 0, 0, 5, 1000, [sid])
+      bat = Game::Battle.new([combatant('A', 10, 0, 10, 100)], [foe],
+                             Game::Rng.new(1), states)
+      e = bat.send(:apply_skill_hit, bat.allies[0], foe, -1,
+                   0, { name: 'X', inflict: [sid], chance: 0 })
+      eq [], e[:inflicted]
+      eq [sid], e[:already],
+         "state ##{sid} (#{states[sid].name}) is announced at 0% accuracy"
+      ok Game::States.already_message(sid, states, foe.name),
+         'and the database has the sentence to announce it with'
+    end
+  end
 
   unless blinding.empty?
     check "#{name}: a blinding state cuts accuracy" do


### PR DESCRIPTION
The 状態 row carries a fifth sentence beside the four the runtime already prints: `message_already`, for something trying to inflict a state the target is **already** carrying — 「はすでに毒に冒されている！」. Nothing read it, and the runtime went silent in exactly that case: `roll_inflict` skipped a state the target had and reported nothing.

## Silence is the wrong answer, and not cosmetically

RPG_RT counts an already-carried state as a **success**, and it settles that *before* rolling the skill's accuracy — EasyRPG's `AddAffectedState(StateEffect::AlreadyInflicted)` `continue`s ahead of the `PercentChance`.

So a Poison Sting on an already-poisoned foe **always** announces itself, where a roll would have gone quiet some of the time, and a 0%-accuracy skill announces it too. Making the report depend on the roll would have been the natural guess, and it is wrong. That is the whole substance of the change; the sentence itself is the visible part.

`roll_inflict` now returns `[inflicted, already]`, the battle entry carries `already:`, and `Scene::Map#battle_state_lines` prints `Game::States.already_message` for each — one wording for both sides, like the recovery line rather than the split actor/enemy inflict pair. The scene keeps its composed fallback for a database that leaves the sentence blank.

## The data

| | states with `message_already` | skills naming ≥1 state | items naming ≥1 state |
|---|---|---|---|
| Nepheshel | **15** of 25 | 99 | 77 |
| mtf-meido-action | **7** of 10 | 40 | 8 |

Text the games wrote and expected to see: 「はすでに毒に冒されている！」, 「はすでに暗闇に閉ざされている！」, 「はすでに眠っている！」.

## What stays unread, and why

**`message_affected`** — 15 and 4 states fill it in, and the wordings (「は眠っている・・・」, 「は麻痺していて動けない！」, 「は毒で80のダメージを受けた!」) read like the line for a turn a state costs the battler. But EasyRPG defines `GetStateAffectedMessage` and never calls it from either battle scene, so there is nothing to pin *when* RPG_RT prints it. Guessing would put invented text in the battle log, which is the thing ADR 0032 set out to stop.

## Verification

All 14 `scripts/*_check.rb` suites pass. 11 new checks, all confirmed to fail against the pre-fix code (5 logic, 3 scene, 3 test-bed):

- `rpg2k_logic_check.rb` (550, +5): an already-carried state reports rather than lands, does so at 0% accuracy, does so for a rank-E immune target, does not stack the state, and a clear target reports nothing.
- `rpg2k_scene_check.rb` (188, +2): the sentence reaches the action banner for an ally and an enemy target alike, and a state whose row has no sentence still gets announced.
- `rpg2k_testbed_logic_check.rb` (77, +4): composes **every** real `message_already` in both games after two different battler names — only a real game's text can say the sentence is shared rather than side-worded, since a fixture is written to match whatever the code does — and drives a real state through a 0%-accuracy skill.

See the addendum to `docs/adr/0032-state-effects.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_