### PR TITLE
Settle the tilemap priority z from RMXP's own formula

### DIFF
--- a/changelog.d/tilemap-priority-z-confirmed.changed.md
+++ b/changelog.d/tilemap-priority-z-confirmed.changed.md
@@ -1,0 +1,9 @@
+- **ADR 0022's tilemap priority `z` formula is confirmed rather than proposed.**
+  It was written with "the exact constant to be confirmed against the testbed
+  `Spriteset_Map` character-`z` formula". RMXP's own `Game_Character#screen_z`,
+  read out of the test bed's `Scripts.rxdata`, settles it: a character's `z` *is*
+  its on-screen pixel y, and a tile adds `priorities[tile_id] * 32` — so a
+  priority-`n` tile sorts as though it stood `n` rows lower, which is the
+  `(ty + prio) * 32 + 32 - oy` the ADR proposed. The derivation and the
+  `@always_on_top` ceiling (999) are recorded in the ADR and beside the interim
+  constant in `mruby-rgss/src/lib.cxx`.

--- a/docs/adr/0022-rpgxp-tilemap-priority-layering.md
+++ b/docs/adr/0022-rpgxp-tilemap-priority-layering.md
@@ -38,6 +38,14 @@ Two constraints make this more than a one-line change:
    game run"; priority layering additionally introduces new *z-ordered objects*
    and a custom dispose path, so a mistake risks a crash on map load, not just a
    cosmetic glitch. That raises the bar for landing it blind.
+
+   **Partly lifted since.** `scripts/native-build-without-nix.bash` builds the
+   engine on a plain box and runs `scripts/rpgxp_boot_check.bash` under Xvfb, so
+   crash-on-map-load — the failure this called out as worse than cosmetic — is now
+   catchable before review rather than after. What that still does *not* give is
+   the cosmetic half: the XP test bed ships no image assets, so its tilesets load
+   as blank bitmaps. Structure and survival are verifiable; a roof actually
+   occluding a character is not, and wants a project with real graphics.
 2. **The `z` scheme is shared with conventions set elsewhere.** Above-priority
    tiles must interleave with per-row character `z` values yet stay below
    fog/weather. A single flat "above" layer at one fixed `z` cannot satisfy both:
@@ -73,10 +81,28 @@ spread across **per-row `z` strips** so they interleave with character sprites:
   z = (ty + prio) * TILE_SIZE + TILE_SIZE - oy
   ```
 
-  (the exact constant to be confirmed against the testbed `Spriteset_Map`
-  character-`z` formula during in-game verification). Because each strip is at the
-  `z` of its own row, a character one row lower sorts in front of it and a
-  character one row higher sorts behind it — the per-row occlusion RMXP gives.
+  **Confirmed against the test bed's own scripts** (read out of
+  `data/OpenGame.exe/Testbed/XP/Data/Scripts.rxdata`), which is what this
+  originally left open. `Game_Character#screen_z` is:
+
+  ```ruby
+  z = (@real_y - $game_map.display_y + 3) / 4 + 32
+  return z + $game_map.priorities[@tile_id] * 32   if @tile_id > 0
+  ```
+
+  So a character's `z` **is its on-screen pixel y**, and RMXP adds `priority * 32`
+  for a tile — the same term, from the engine's own hand. Substituting the map's
+  units (`real_y = ty * 128`, and `display_y = oy * 4` because `Spriteset_Map`
+  sets `@tilemap.oy = $game_map.display_y / 4`) gives `ty * 32 + 32 - oy` for
+  priority 0, which is the formula above with `TILE_SIZE = 32`. A priority-`n`
+  tile therefore sorts as though it stood `n` rows lower, exactly as a tile event
+  does. `@always_on_top` returns 999 unconditionally, which is the ceiling the
+  strips must stay under.
+
+  Because each strip is at the `z` of its own row, a character one row lower sorts
+  in front of it and a character one row higher sorts behind it — the per-row
+  occlusion RMXP gives. The natural bucket key is `ty + prio` rather than `ty`,
+  since that is what the formula sorts on: one strip per distinct `ty + prio`.
 
 - **Strips are z-ordered companion objects.** Each strip is wrapped as an internal
   mruby data object (`mrb_data_object_alloc(... , &obj_type)`, then the same

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -3843,10 +3843,10 @@ int vx_tile_quads(int tile_id, int frame, bool table, VXQuad out[8]) {
 //     z = (real_y - display_y + 3) / 4 + 32          // the on-screen pixel y
 //     z += priorities[tile_id] * 32                  // ... for a tile
 //
-// so a character's z *is* its screen y, and a priority-n tile sorts as though it
-// stood n rows lower. In map units that is (ty + prio) * 32 + 32 - oy, which is
-// what a per-row strip must use; @always_on_top returns 999, the ceiling those
-// strips have to stay under.
+// so a character's z *is* its screen y, and a priority-n tile sorts as though
+// it stood n rows lower. In map units that is (ty + prio) * 32 + 32 - oy, which
+// is what a per-row strip must use; @always_on_top returns 999, the ceiling
+// those strips have to stay under.
 //
 // The constant below is the interim stand-in: above stock character sprites
 // (z ~ screen_y, up to ~512) but below the fog/weather planes (z ~ 1000/3000),

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -3835,10 +3835,22 @@ int vx_tile_quads(int tile_id, int frame, bool table, VXQuad out[8]) {
 // a single flat layer above the characters is only an approximation of RMXP's
 // per-row priority interleaving — it puts *every* priority tile above *every*
 // character, rather than only the ones on lower rows. The full per-row scheme
-// is designed in docs/adr/0022-rpgxp-tilemap-priority-layering.md. This
-// constant is picked to sit above stock character sprites (z ~ screen_y, up to
-// ~512) but below the fog/weather planes (z ~ 1000/3000); confirm it in-game
-// against the testbed Spriteset_Map before treating it as final.
+// is designed in docs/adr/0022-rpgxp-tilemap-priority-layering.md.
+//
+// That ADR's z formula is no longer a guess: RMXP's own Game_Character#screen_z
+// (read out of the test bed's Scripts.rxdata) is
+//
+//     z = (real_y - display_y + 3) / 4 + 32          // the on-screen pixel y
+//     z += priorities[tile_id] * 32                  // ... for a tile
+//
+// so a character's z *is* its screen y, and a priority-n tile sorts as though it
+// stood n rows lower. In map units that is (ty + prio) * 32 + 32 - oy, which is
+// what a per-row strip must use; @always_on_top returns 999, the ceiling those
+// strips have to stay under.
+//
+// The constant below is the interim stand-in: above stock character sprites
+// (z ~ screen_y, up to ~512) but below the fog/weather planes (z ~ 1000/3000),
+// and below the 999 an always-on-top character claims.
 static const mrb_int TILEMAP_ABOVE_Z = 900;
 
 // Redraw the visible part of the map. For each of the three map-data layers,


### PR DESCRIPTION
## What was open

ADR 0022 designs per-row priority layering for the XP `Tilemap` and leaves one thing unresolved:

> `z = (ty + prio) * TILE_SIZE + TILE_SIZE - oy`
>
> (the exact constant to be confirmed against the testbed `Spriteset_Map` character-`z` formula during in-game verification)

That uncertainty is the blocking part of the design — the whole scheme is a claim about where priority tiles sort against character sprites, and it was reasoning by analogy.

## RMXP answers it itself

`Game_Character#screen_z`, read out of the test bed's `Data/Scripts.rxdata`:

```ruby
z = (@real_y - $game_map.display_y + 3) / 4 + 32
return z + $game_map.priorities[@tile_id] * 32   if @tile_id > 0
```

A character's `z` **is its on-screen pixel y**, and the engine adds `priority * 32` for a tile — the same term the ADR proposed, from RMXP's own hand rather than by analogy.

Substituting the map's units — `real_y = ty * 128`, and `display_y = oy * 4` because `Spriteset_Map` sets `@tilemap.oy = $game_map.display_y / 4` — gives `ty * 32 + 32 - oy` at priority 0. That is the ADR's formula with `TILE_SIZE = 32`, and a priority-`n` tile sorts as though it stood `n` rows lower, exactly as a tile event does.

Two things fall out, both now recorded:

- **The bucket key for the strips is `ty + prio`, not `ty`** — that is what the formula sorts on, so one strip per distinct `ty + prio` rather than per row.
- **`@always_on_top` returns 999 unconditionally**, the ceiling the strips must stay under. The interim flat constant of 900 already respects it, which is worth knowing before anyone changes it.

## Also: the ADR's first constraint is half lifted

It says priority layering "cannot be verified headlessly", and that a mistake there "risks a crash on map load, not just a cosmetic glitch."

With `scripts/native-build-without-nix.bash` (previous PR) the XP boot check runs under Xvfb here, so **crash-on-map-load is catchable before review**. The cosmetic half is *not* lifted, and the ADR now says so plainly: the XP test bed ships no image assets, so its tilesets load as blank bitmaps — a roof actually occluding a character still can't be seen in this environment and wants a project with real graphics.

## Scope

**This is not the implementation.** It removes the design's open question and records the derivation next to where an implementer will need it. `mruby-rgss/src/lib.cxx` is comment-only.

## Verification

No behaviour change — but since `lib.cxx` was touched, it was compiled and run rather than assumed:

```
[RGSS-PROBE] ok
[RPGXP-HOST-SCENE] Scene_Map frame=102
[RPGXP-HOST-MOVE] start=1,0 end=12,14 moved=true frame=282
```

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_