### PR TITLE
Let the battle log speak the game's own language

### DIFF
--- a/changelog.d/battle-log-terms.changed.md
+++ b/changelog.d/battle-log-terms.changed.md
@@ -1,0 +1,16 @@
+- **The battle log speaks the game's own language.** It used to invent its
+  English ("Hero hits Slime for 42", "Slime defends") in a runtime for games that
+  are not in English and that ship their own wording for every one of those
+  lines. RPG2000 keeps them in the 用語 table as *predicates* the battler's name
+  goes in front of, and both test beds fill in **126 of the 127 fields** while
+  the runtime read two. `Game::States::BattleText` now composes them and the log
+  prints what the battler did and then what it did to the target, as RPG_RT does:
+  「スライムの攻撃！」 then 「リトは 7 のダメージを受けた！」 — including the
+  particle rule that is not in the database (に for one of theirs, は for one of
+  yours). Covers every basic action (attack, Defend, Observe, Charge,
+  self-destruct, flee, transform), both damage sides, no-damage and misses. A
+  blank term drops the whole entry back to the composed English, so an
+  English-release table with half the block empty still reads. Skills and items
+  keep their composed line until their own `using_message` is read, and the
+  critical-hit line is left alone because which side keys `actor_critical` /
+  `enemy_critical` is genuinely unclear. See ADR 0036.

--- a/changelog.d/skill-battle-messages.added.md
+++ b/changelog.d/skill-battle-messages.added.md
@@ -1,0 +1,14 @@
+- **A skill announces itself in its own words.** The skill row carries two
+  sentences of its own rather than borrowing a 用語 term, and they compose
+  differently: `using_message1` follows the caster's name like every other
+  predicate, while `using_message2` **stands alone** as a second line — so a
+  spell reads 「リトは炎を放った！」 then 「あたりが真っ赤に染まる！」, a caster and
+  then a scene. 229 of Nepheshel's 306 skills and 122 of mtf-meido-action's 134
+  set the first; 18 set the second. A skill that achieved nothing (a miss, or a
+  recovery that restored and cured nothing) takes its own failure sentence
+  instead of a damage line, chosen by the row's `failure_message` from the three
+  用語 failure lines plus the dodge line at index 3 — all four values are in real
+  use across the test beds. A skill row with no sentence keeps the composed
+  wording, since the bare damage line would lose the only thing naming what was
+  cast. Items still keep theirs: the `use_item` term is a different shape and its
+  own change. See the addendum to ADR 0036.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -797,10 +797,24 @@ The work below is roughly ordered by the critical path to a walkable game
   Defend, Observe, Charge, self-destruct, flee, transform — plus both damage
   sides, no-damage and misses; a blank term drops the **whole** entry back to the
   composed English, because a half-translated line reads worse than an English
-  one. Still held back on purpose: a **skill or item** keeps its composed line
-  until its own `using_message1` / `using_message2` / `use_item` is read (351 and
-  18 skills across the test beds set one), since the bare damage line would lose
-  the only thing naming what was cast; and the **critical** line is left alone
+  one.
+  **A skill says it in its own words**, which is why a spell reads differently
+  from a sword swing: the row carries two sentences of its own, and they compose
+  differently — `using_message1` follows the caster's name like every other
+  predicate while `using_message2` **stands alone** as a second line, so a spell
+  reads 「リトは炎を放った！」 then 「あたりが真っ赤に染まる！」, a caster and then a
+  scene. 229 of Nepheshel's 306 skills and 122 of mtf's 134 set the first, 18 the
+  second. A skill that achieved nothing — a miss, or a recovery that restored and
+  cured nothing — takes its own failure sentence rather than a damage line, picked
+  by the row's `failure_message` from the three 用語 failure lines plus the dodge
+  line at index 3; all four values are in real use (255/7/1/43 and 116/8/4/6).
+  This needed the skill's **id** on the log entry, which carried only its name, so
+  `command_skill` / `command_skill_all` take a `skill_id:` and the enemy AI path
+  sets it from its own action. A skill row with no sentence keeps the composed
+  wording, as a blank term does.
+  Still held back on purpose: an **item** keeps its composed line
+  until the `use_item` term is read — a different shape from everything here —
+  and the **critical** line is left alone
   because which side keys `actor_critical` / `enemy_critical` is genuinely
   unclear — EasyRPG picks `actor_critical` when the *target* is an ally, while
   会心 / 痛恨 read as the *attacker's* side, and both games fill both fields with

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -782,6 +782,29 @@ The work below is roughly ordered by the critical path to a walkable game
   combatant instead of queueing a request, so nothing told the panel it was
   stale — `apply_battle_event_requests` now rebuilds it, and a page that poisons
   the boss changes the screen as well as the fight.
+  **The action lines come from the 用語 table now too** (ADR 0036), which is the
+  larger half of the same argument: every round prints an action, where only some
+  print a state. The log used to invent its English ("Hero hits Slime for 42");
+  a field-by-field audit found both test beds filling in **126 of the 127 term
+  fields** while the runtime read two of them. `Game::States::BattleText` composes
+  them as the predicates they are, and `battle_action_body` prints what the
+  battler did and then what it did to the target, the way RPG_RT splits it:
+  「スライムの攻撃！」 then 「リトは 7 のダメージを受けた！」. The particle is the
+  one part not in the database — に for one of theirs, は for one of yours,
+  pairing with the two `enemy_damaged` / `actor_damaged` predicates (the CP932
+  branch of EasyRPG's `GetDamagedMessage`, and this build decodes every string as
+  CP932 so there is no other branch). Every basic action is covered — attack,
+  Defend, Observe, Charge, self-destruct, flee, transform — plus both damage
+  sides, no-damage and misses; a blank term drops the **whole** entry back to the
+  composed English, because a half-translated line reads worse than an English
+  one. Still held back on purpose: a **skill or item** keeps its composed line
+  until its own `using_message1` / `using_message2` / `use_item` is read (351 and
+  18 skills across the test beds set one), since the bare damage line would lose
+  the only thing naming what was cast; and the **critical** line is left alone
+  because which side keys `actor_critical` / `enemy_critical` is genuinely
+  unclear — EasyRPG picks `actor_critical` when the *target* is an ally, while
+  会心 / 痛恨 read as the *attacker's* side, and both games fill both fields with
+  the same two strings so the data cannot settle it.
   The **field windows show a condition too** — the menu party list, the item and
   skill target lists and the status screen (a labelled row of its own), which are
   the three RPG_RT draws one in (`Window_MenuStatus`, `Window_ActorTarget`,

--- a/docs/adr/0036-battle-log-in-the-games-own-words.md
+++ b/docs/adr/0036-battle-log-in-the-games-own-words.md
@@ -1,0 +1,95 @@
+# 36. The battle log speaks the game's own language
+
+Date: 2026-08-06
+
+## Status
+
+Accepted
+
+## Context
+
+The battle log invented its English. `Scene::Map#battle_action_line` composed
+"Hero hits Slime for 42", "Slime defends", "Hero misses Slime" — strings written
+here, in a runtime for games that are not in English and that ship their own
+wording for every one of those lines.
+
+RPG2000 keeps those sentences in the 用語 (term) table, as *predicates* rather
+than templates: the database stores 「の攻撃！」 and RPG_RT prints the battler's
+name in front of it. A field-by-field audit of the two test beds against the
+runtime source says how much of it was going unread:
+
+| | term fields filled in | fields the runtime names |
+|---|---|---|
+| Nepheshel / mtf-meido-action | **126 of 127** | 2 (`gold`, `normal_status`) |
+
+The battle block alone is fourteen sentences both games wrote and neither could
+show: 「の攻撃！」, 「は身を守っている」, 「は様子を見ている・・・」,
+「のダメージを与えた！」, 「はダメージを受けていない！」, 「は身をかわした！」 and
+the rest.
+
+ADR 0032 already made this argument for the *state* sentences and took them from
+the database, noting that a defeat should read 「スライムを倒した！」 rather than
+an invented English string. This is the same argument for the action itself, and
+it is the larger half: every round prints an action line, where only some print a
+state line.
+
+## Decision
+
+`Game::States::BattleText` composes the term table's battle sentences, and
+`Scene::Map#battle_action_body` builds the log from it.
+
+- **Predicates, not templates.** Every builder is `name + field`. The
+  `%S`-placeholder form EasyRPG supports is an RPG2003 / 2k3E feature and is not
+  this runtime's job.
+- **More than one line.** RPG_RT prints what the battler *did* and then what it
+  did *to the target* as separate messages, so `battle_action_body` returns an
+  array: 「スライムの攻撃！」 then 「リトは 7 のダメージを受けた！」.
+- **The particle is the rule that is not in the database.** The damage line is
+  `name + particle + value + " " + predicate`, and RPG_RT picks the particle by
+  side — に for one of theirs, は for one of yours — pairing with the two
+  predicates `enemy_damaged` / `actor_damaged`. This is the CP932 branch of
+  EasyRPG's `GetDamagedMessage`; the Western-encoding branch uses a plain space
+  for both, and this build decodes every string as CP932
+  (`LCF.cp932_to_utf8`), so there is no second branch to take.
+- **All or nothing per entry.** A blank term drops the whole entry back to the
+  composed English. A half-translated line — 「スライムの攻撃！」 with no damage
+  sentence under it — reads worse than the English one, and an English-release
+  table with half the battle block empty is a real shape.
+
+## Consequences
+
+Both test beds now narrate their own fights. Every basic action (attack, Defend,
+Observe, Charge, self-destruct, flee, transform), every damage line from either
+side, every no-damage line and every miss comes out of the table; all 7 of the
+basic action sentences are filled in in both games, as are both damage
+predicates and `dodge`.
+
+Two things are deliberately **not** in this change, and both are held back for a
+reason rather than forgotten:
+
+- **A skill and an item keep their composed line.** They announce themselves with
+  their *own* sentence — the skill row's `using_message1` / `using_message2`
+  (351 and 18 skills across the test beds set one) and the `use_item` term — not
+  with a term for "attacking". Reading those is a separate change; until then,
+  dropping a skill entry to the bare damage line would lose the only thing that
+  names what was cast, so skills and items are excluded whole.
+- **The critical-hit line.** `actor_critical` / `enemy_critical` (「会心の一撃！！」
+  / 「痛恨の一撃！！」) are filled in in both games, but which side keys them is
+  genuinely unclear: EasyRPG's `GetCriticalHitMessage` picks `actor_critical`
+  when the **target** is an ally, while the words themselves follow the Dragon
+  Quest convention where 会心 is *your* blow landing and 痛恨 is one landing on
+  you — which is the attacker's side, i.e. the opposite. One of those readings is
+  wrong and the test-bed data cannot settle it, since both games fill both fields
+  with the same two strings. Getting it backwards would put the wrong sentence on
+  every critical, so the line is left as it was rather than guessed at.
+
+Covered by `scripts/rpg2k_logic_check.rb` (each builder's shape, the two damage
+predicates and their particles, and that a blank / missing / absent term yields
+nil rather than a bare name), by `scripts/rpg2k_scene_check.rb` (the log a real
+`Scene::Map` produces for an attack from either side, a miss, a no-damage blow,
+each targetless basic action, an autodestruct's two lines, the all-or-nothing
+fallback on a blank term, a skill keeping its composed line, and the state
+sentences still following the action ones) and by
+`scripts/rpg2k_testbed_logic_check.rb`, which composes every basic action
+sentence in **both real term tables** after a battler's name and checks that the
+two damage sides really are worded differently and take their own particles.

--- a/docs/adr/0036-battle-log-in-the-games-own-words.md
+++ b/docs/adr/0036-battle-log-in-the-games-own-words.md
@@ -93,3 +93,56 @@ sentences still following the action ones) and by
 `scripts/rpg2k_testbed_logic_check.rb`, which composes every basic action
 sentence in **both real term tables** after a battler's name and checks that the
 two damage sides really are worded differently and take their own particles.
+
+## Addendum: the skill's own voice
+
+Date: 2026-08-06
+
+The first of the two things held back above is now done. A skill does not use a
+term for "attacking" — it carries its **own** two sentences, which is the whole
+reason a spell reads differently from a sword swing:
+
+| | skills with `using_message1` | with `using_message2` |
+|---|---|---|
+| Nepheshel | **229** of 306 | **18** |
+| mtf-meido-action | **122** of 134 | 0 |
+
+They compose differently from each other, and that asymmetry is the rule worth
+recording: `using_message1` follows the caster's name like every other predicate,
+while `using_message2` **stands alone** as a second line (EasyRPG's
+`GetSkillSecondStartMessage2k` returns the field with nothing in front of it). So
+a spell reads 「リトは炎を放った！」 then 「あたりが真っ赤に染まる！」 — a caster and
+then a scene, not the caster twice.
+
+**A skill that achieved nothing takes its own failure sentence** instead of a
+damage line, and which one is again the skill row's choice: `failure_message`
+indexes the three 用語 failure lines, with 3 borrowing the dodge line. All four
+values are in real use — Nepheshel splits 255 / 7 / 1 / 43 and mtf 116 / 8 / 4 /
+6 — so the index-3 case is not a theoretical branch. "Achieved nothing" means a
+miss, or a recovery that restored no HP or SP and cured and inflicted nothing.
+
+Falling back stays all-or-nothing per entry, for the reason the base decision
+gives: a skill row with no sentence keeps the composed English, because the bare
+damage line would lose the only thing naming what was cast. That is what an
+English-release skill table looks like, and 77 of Nepheshel's own skills are in
+it.
+
+Plumbing this needed the skill's **id** on the log entry — the entry carried only
+the skill's name — so `command_skill` / `command_skill_all` take a `skill_id:`,
+the enemy AI path sets it from its own action, and both ride onto the entry.
+
+**An item still keeps its composed line.** Its sentence is the `use_item` term
+rather than a field of its own, and the RPG2000 branch of EasyRPG's
+`GetItemStartMessage2k` is a different shape from everything here; it is left for
+its own change rather than folded in.
+
+Covered by `scripts/rpg2k_logic_check.rb` (both sentences and the asymmetry
+between them, a skill with only the first, a skill with neither, a missing row,
+and each of the four `failure_message` values), by
+`scripts/rpg2k_scene_check.rb` (the log a real `Scene::Map` produces for a skill
+with both sentences, with one, with none, one that missed, a heal that restored
+nothing and one that worked, a skill's states still trailing it, and an item
+keeping its line) and by `scripts/rpg2k_testbed_logic_check.rb`, which composes
+**every** real skill sentence in both games — asserting the second line is not
+prefixed with the caster's name — and checks every skill's `failure_message`
+indexes a 用語 line the table really has.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4770,6 +4770,39 @@ module Game
       def self.dodge(terms, target_name)
         action(terms, target_name, :dodge)
       end
+
+      # A skill announces itself with its **own** two sentences rather than with
+      # a term, which is why a skill has a voice and a plain attack does not.
+      # `using_message1` follows the caster's name the way every other predicate
+      # does; `using_message2` stands alone as a second line (EasyRPG's
+      # `GetSkillSecondStartMessage2k` returns the field with no name in front),
+      # so a skill can read 「リトは炎を放った！」 / 「あたりが真っ赤に染まる！」.
+      #
+      # Returns [] when the skill sets neither, so the caller keeps its own line.
+      # 351 of the test beds' skills set the first and 18 the second.
+      def self.skill_start(skill_row, caster_name)
+        return [] unless skill_row
+        first = term(skill_row, :using_message1)
+        second = term(skill_row, :using_message2)
+        lines = []
+        lines << "#{caster_name}#{first}" if first
+        lines << second if second
+        lines
+      end
+
+      # A skill that achieved nothing. Which sentence says so is the skill row's
+      # own choice: `failure_message` indexes the three 用語 failure lines, and 3
+      # borrows the dodge line (EasyRPG's `GetSkillFailureMessage`). Worded from
+      # the target's side, like the dodge it can become.
+      FAILURE_TERMS = [:skill_failure_a, :skill_failure_b, :skill_failure_c,
+                       :dodge].freeze
+
+      def self.skill_failure(terms, skill_row, target_name)
+        i = skill_row && skill_row.respond_to?(:failure_message) ?
+              skill_row.failure_message : nil
+        f = FAILURE_TERMS[i || 0]
+        f && action(terms, target_name, f)
+      end
     end
 
     # Map-step slip damage: RPG2000's field poison. A state drains HP every
@@ -5278,8 +5311,9 @@ module Game
     # recovery) computed by Game::Party#battle_skill_command. Resolved in agility
     # order by #apply_command when the round runs.
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
-                      chance: 100, variance: 0, attributes: nil)
+                      chance: 100, variance: 0, attributes: nil, skill_id: nil)
       ally.command = { kind: :skill, target: target, name: name,
+                       skill_id: skill_id,
                        cost: cost, hp: hp, mp: mp,
                        inflict: inflict || [], chance: chance, variance: variance,
                        attributes: attributes || [] }
@@ -5294,9 +5328,9 @@ module Game
     # `attributes` apply to every target. #apply_command produces one log entry
     # per living target, drained one at a time by #step_action.
     def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
-                          variance: 0, attributes: nil)
+                          variance: 0, attributes: nil, skill_id: nil)
       ally.command = { kind: :skill, all: true, targets: targets, name: name,
-                       cost: cost, inflict: inflict || [], chance: chance,
+                       skill_id: skill_id, cost: cost, inflict: inflict || [], chance: chance,
                        variance: variance, attributes: attributes || [] }
       ally.action = nil; ally.defending = false
     end
@@ -5691,6 +5725,7 @@ module Game
       cmd = @ai.skill_command(sk, b, targets.first)
       return enemy_fallback_attack(b) unless cmd
       b.command = skill_command_hash(sk, cmd, targets.first)
+      b.command[:skill_id] = act.skill_id
       if targets.size > 1
         # An all-target skill carries one effect per target, since attack damage
         # is computed against each target's own defence.
@@ -6012,7 +6047,8 @@ module Game
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
           inflicted: inflicted, already: already,
-          target_ally: ally?(target), skill: cmd[:name] }
+          target_ally: ally?(target), skill: cmd[:name],
+          skill_id: cmd[:skill_id] }
       else
         before_hp = target.hp
         before_mp = target.mp || 0
@@ -6023,7 +6059,7 @@ module Game
         cured = (cmd[:cured] || []).select { |s| target.state?(s) }
         target.states = (target.states || []) - cured unless cured.empty?
         { recover: true, actor: b.name, source: cmd[:name],
-          item_id: cmd[:item_id], target: target.name,
+          item_id: cmd[:item_id], skill_id: cmd[:skill_id], target: target.name,
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
           cured: cured, target_ally: ally?(target),
           target_hp: target.hp, target_mp: target.mp }

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4713,6 +4713,65 @@ module Game
       "#{battler_name}#{predicate}"
     end
 
+    # The 用語 (term) table's battle sentences, composed the way RPG2000 does.
+    #
+    # Every one of these fields is a *predicate*, not a template: the database
+    # stores 「の攻撃！」 and RPG_RT puts the battler's name in front of it. The
+    # `%S`-style placeholders EasyRPG supports are an RPG2003 / 2k3E feature, so
+    # this side of it is pure concatenation with one Japanese particle.
+    #
+    # Both test beds fill in 126 of the 127 term fields, and until now the
+    # runtime read two of them (`gold`, `normal_status`): the battle log spoke
+    # invented English while the game's own words sat unread in the table.
+    #
+    # Each builder returns nil when the field is blank, so the caller can keep
+    # its composed English for a database that leaves one out.
+    module BattleText
+      # The particle between a battler's name and the number of a damage line.
+      # RPG_RT picks it by side -- は for one of yours, に for one of theirs --
+      # and follows the number with a space. This is the CP932 branch of
+      # EasyRPG's `GetDamagedMessage`; the Western-encoding branch uses a plain
+      # space for both, and this build decodes every string as CP932 (see
+      # LCF.cp932_to_utf8), so there is no second branch to take.
+      ALLY_PARTICLE = 'は '.freeze
+      ENEMY_PARTICLE = 'に '.freeze
+
+      def self.term(terms, name)
+        v = terms && terms.respond_to?(name) ? terms.send(name) : nil
+        v.nil? || v.to_s.empty? ? nil : v.to_s
+      end
+
+      # `name + predicate` — the shape of every "so-and-so did a thing" line:
+      # the attack itself (`attacking`), Defend (`defending`), Observe
+      # (`observing`), Charge (`focus`), an enemy blowing itself up
+      # (`autodestruction`), one fleeing (`enemy_escape`) and one transforming
+      # (`enemy_transform`).
+      def self.action(terms, battler_name, field)
+        t = term(terms, field)
+        t && "#{battler_name}#{t}"
+      end
+
+      # 「スライムに 42 のダメージを与えた！」 / 「リトは 42 のダメージを受けた！」
+      # — the same sentence from the two sides, which is why the table holds two
+      # predicates and one particle rule rather than two whole templates.
+      def self.damage(terms, target_name, value, ally)
+        t = term(terms, ally ? :actor_damaged : :enemy_damaged)
+        return nil unless t
+        "#{target_name}#{ally ? ALLY_PARTICLE : ENEMY_PARTICLE}#{value} #{t}"
+      end
+
+      # A blow that got through for nothing: no number and no particle.
+      def self.undamaged(terms, target_name, ally)
+        action(terms, target_name, ally ? :actor_undamaged : :enemy_undamaged)
+      end
+
+      # A miss. RPG2000 words it from the target's side ("...は身をかわした！"),
+      # which is why one term serves both sides.
+      def self.dodge(terms, target_name)
+        action(terms, target_name, :dodge)
+      end
+    end
+
     # Map-step slip damage: RPG2000's field poison. A state drains HP every
     # `hp_change_map_steps` tiles the party walks, by `hp_change_map_val` --
     # and SP through the matching `sp_change_map_steps` / `sp_change_map_val`
@@ -5611,7 +5670,8 @@ module Game
         dmg = [dmg / 2, 1].max if t.defending && dmg > 0
         t.hp -= dmg
         { attacker: b.name, target: t.name, damage: dmg, critical: false,
-          autodestruct: true, target_hp: t.hp < 0 ? 0 : t.hp, defeated: t.dead? }
+          autodestruct: true, target_hp: t.hp < 0 ? 0 : t.hp, defeated: t.dead?,
+          target_ally: ally?(t) }
       end
       # The blast kills the caster whether or not it found anyone to hit.
       b.hp = 0
@@ -5729,7 +5789,7 @@ module Game
       if @accuracy && !hits?(b, target)
         return { attacker: b.name, target: target.name, damage: 0, missed: true,
                  critical: false, target_hp: target.hp < 0 ? 0 : target.hp,
-                 defeated: false }
+                 defeated: false, target_ally: ally?(target) }
       end
       dmg = Battle.attack_damage(b.atk, target.def)
       # An elemental weapon scales its damage by the target's resistance before

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3197,7 +3197,7 @@ class RPG2k
         sid, cost = @battle_ui[:skills][@battle_ui[:skill_i]]
         return if current_actor.mp < cost # can't afford: stay on the list
         sk = @state.party.db_skill(sid)
-        @battle_ui[:pending] = { kind: :skill, sk: sk }
+        @battle_ui[:pending] = { kind: :skill, sk: sk, sid: sid }
         close_battle_skill
         case @state.party.battle_skill_target(sk)
         when :self
@@ -3221,9 +3221,11 @@ class RPG2k
       # then move to the next actor.
       def apply_pending_skill(target)
         sk = @battle_ui[:pending][:sk]
+        sid = @battle_ui[:pending][:sid]
         c = @state.party.battle_skill_command(sk, current_actor, target)
         @battle_ui[:battle].command_skill(current_actor, target,
-                                          name: sk.name, cost: c[:cost],
+                                          name: sk.name, skill_id: sid,
+                                          cost: c[:cost],
                                           hp: c[:hp], mp: c[:mp],
                                           inflict: c[:inflict], chance: c[:chance],
                                           variance: c[:variance] || 0,
@@ -3240,13 +3242,15 @@ class RPG2k
       # infliction ride along once.
       def apply_pending_skill_all(targets)
         sk = @battle_ui[:pending][:sk]
+        sid = @battle_ui[:pending][:sid]
         meta = @state.party.battle_skill_command(sk, current_actor, targets.first)
         effects = targets.map do |t|
           c = @state.party.battle_skill_command(sk, current_actor, t)
           { target: t, hp: c[:hp], mp: c[:mp] }
         end
         @battle_ui[:battle].command_skill_all(current_actor, effects,
-                                              name: sk.name, cost: meta[:cost],
+                                              name: sk.name, skill_id: sid,
+                                              cost: meta[:cost],
                                               inflict: meta[:inflict], chance: meta[:chance],
                                               variance: meta[:variance] || 0,
                                               attributes: meta[:attributes])
@@ -3661,13 +3665,13 @@ class RPG2k
       # composed English for any field the database leaves blank — an
       # English-release table with half the battle terms empty still reads.
       def battle_action_body(e)
-        # A skill and an item announce themselves with their *own* sentence
-        # (`using_message1` / `using_message2`, `use_item`), which is a separate
-        # unread field and a separate change. Until then they keep the composed
-        # wording, because dropping to the bare damage line would lose the one
-        # thing that names what was cast. Same for "does nothing", which RPG_RT
-        # words from the state that caused it rather than from a term.
-        return [battle_action_line(e)] if e[:recover] || e[:skill] || e[:nothing]
+        # An item announces itself with the `use_item` term, still unread, and
+        # "does nothing" is worded by the state that caused it rather than by a
+        # term — both keep the composed wording. A skill has its own two
+        # sentences and takes the branch below.
+        return [battle_action_line(e)] if e[:nothing]
+        return battle_skill_body(e) if e[:skill_id]
+        return [battle_action_line(e)] if e[:recover] || e[:skill]
         t = db.respond_to?(:term) ? db.term : nil
         want_start = battle_start_field(e)
         want_result = battle_result_wanted?(e)
@@ -3682,6 +3686,57 @@ class RPG2k
         lines << start if start
         lines << result if result
         lines.empty? ? [battle_action_line(e)] : lines
+      end
+
+      # A skill's own two sentences, then what it did. `using_message1` follows
+      # the caster's name and `using_message2` stands alone as a second line, so
+      # a spell reads 「リトは炎を放った！」 / 「あたりが真っ赤に染まる！」 before
+      # 「スライムに 42 のダメージを与えた！」.
+      #
+      # A skill that achieved nothing takes its own failure sentence instead of a
+      # damage line — the skill row's `failure_message` picks which of the three
+      # 用語 failure lines (or the dodge line) says so.
+      #
+      # A skill row that sets no sentence at all keeps the composed wording, for
+      # the same reason a blank term does: the bare damage line would lose the
+      # only thing naming what was cast.
+      def battle_skill_body(e)
+        bt = Game::States::BattleText
+        row = db.respond_to?(:skill) && db.skill ? db.skill[e[:skill_id]] : nil
+        caster = (e[:recover] ? e[:actor] : e[:attacker]).to_s
+        lines = bt.skill_start(row, caster)
+        return [battle_action_line(e)] if lines.empty?
+        t = db.respond_to?(:term) ? db.term : nil
+        rest = battle_skill_result(t, row, e)
+        return [battle_action_line(e)] unless rest
+        lines + rest
+      rescue StandardError => ex
+        $stderr.puts "[RPG2k] skill message lookup failed: #{ex.message}"
+        [battle_action_line(e)]
+      end
+
+      # What the skill did: the damage / dodge line for an attack, nothing extra
+      # for a recovery that worked, and the failure sentence for one that did
+      # not. nil when a needed sentence is missing, so the caller falls back
+      # whole rather than printing half of one.
+      def battle_skill_result(t, row, e)
+        bt = Game::States::BattleText
+        return [] if e[:target].nil?
+        if skill_achieved_nothing?(e)
+          line = bt.skill_failure(t, row, e[:target].to_s)
+          return line ? [line] : nil
+        end
+        return [] if e[:recover]
+        return battle_result_line(t, e) ? [battle_result_line(t, e)] : nil
+      end
+
+      # A skill with nothing to show for itself: a heal that restored no HP or SP
+      # and cured nothing, or an attack that was dodged.
+      def skill_achieved_nothing?(e)
+        return true if e[:missed]
+        return false unless e[:recover]
+        (e[:recover_hp] || 0) <= 0 && (e[:recover_mp] || 0) <= 0 &&
+          (e[:cured] || []).empty? && (e[:inflicted] || []).empty?
       end
 
       # Which term words this entry's "so-and-so did a thing" line, or nil when

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3650,9 +3650,83 @@ class RPG2k
         end
       end
 
+      # What an action says, in the game's own words. RPG2000 keeps the sentences
+      # in the 用語 table as *predicates* — 「の攻撃！」, 「のダメージを与えた！」 —
+      # and RPG_RT prints the battler's name in front of each. Both test beds
+      # fill 126 of the 127 fields in, so a log that invents its own English is
+      # ignoring text the author wrote.
+      #
+      # RPG_RT says it in more than one line: what the battler did, then what it
+      # did to the target. This returns them in that order, and falls back to the
+      # composed English for any field the database leaves blank — an
+      # English-release table with half the battle terms empty still reads.
+      def battle_action_body(e)
+        # A skill and an item announce themselves with their *own* sentence
+        # (`using_message1` / `using_message2`, `use_item`), which is a separate
+        # unread field and a separate change. Until then they keep the composed
+        # wording, because dropping to the bare damage line would lose the one
+        # thing that names what was cast. Same for "does nothing", which RPG_RT
+        # words from the state that caused it rather than from a term.
+        return [battle_action_line(e)] if e[:recover] || e[:skill] || e[:nothing]
+        t = db.respond_to?(:term) ? db.term : nil
+        want_start = battle_start_field(e)
+        want_result = battle_result_wanted?(e)
+        start = want_start && battle_start_line(t, e, want_start)
+        result = want_result && battle_result_line(t, e)
+        # All or nothing per entry: a half-translated line ("スライムの攻撃！"
+        # with no damage sentence under it) reads worse than the composed
+        # English, so a blank term drops the whole entry back to the fallback.
+        return [battle_action_line(e)] if (want_start && !start) ||
+                                          (want_result && !result)
+        lines = []
+        lines << start if start
+        lines << result if result
+        lines.empty? ? [battle_action_line(e)] : lines
+      end
+
+      # Which term words this entry's "so-and-so did a thing" line, or nil when
+      # RPG2000 has none for it — a skill or an item names itself instead (its
+      # own `using_message` is a separate field, still unread), and "does
+      # nothing" is a state's own sentence rather than a term.
+      def battle_start_field(e)
+        return nil if e[:recover] || e[:skill] || e[:nothing]
+        return :enemy_transform if e[:transform]
+        return :defending if e[:defend]
+        return :observing if e[:observe]
+        return :focus if e[:charge]
+        return :enemy_escape if e[:fled]
+        return :autodestruction if e[:autodestruct]
+        :attacking
+      end
+
+      def battle_start_line(t, e, field)
+        Game::States::BattleText.action(t, e[:attacker].to_s, field)
+      end
+
+      # Does this entry report on a target at all? A Defend, a flee or an
+      # autodestruct that found nobody has no one to report on.
+      def battle_result_wanted?(e)
+        return false if e[:recover] || e[:target].nil?
+        e[:missed] || !e[:damage].nil? ? true : false
+      end
+
+      # What it did to that target: a miss, a blow that got through for nothing,
+      # or the damage.
+      def battle_result_line(t, e)
+        bt = Game::States::BattleText
+        name = e[:target].to_s
+        ally = e[:target_ally] ? true : false
+        return bt.dodge(t, name) if e[:missed]
+        return bt.damage(t, name, e[:damage], ally) if e[:damage] > 0
+        bt.undamaged(t, name, ally)
+      end
+
       # A one-line description of a battle log entry, for the on-screen banner and
       # the console trace. A recovery (heal skill / medicine) reads as a restore;
       # a skill attack names the skill; a plain attack is "A hits B for N".
+      #
+      # This is the fallback now: it words an entry whose terms the database left
+      # blank. `battle_action_body` prefers the game's own sentences.
       def battle_action_line(e)
         if e[:recover]
           parts = []
@@ -3690,7 +3764,7 @@ class RPG2k
       # changed. `log_round` traces all of it and `show_battle_action` banners
       # all of it, so the console and the screen never disagree.
       def battle_action_lines(entry)
-        [battle_action_line(entry)] + battle_state_lines(entry)
+        battle_action_body(entry) + battle_state_lines(entry)
       end
 
       # The result window's text: the outcome, and on a win the EXP / gold gained

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8185,6 +8185,70 @@ check 'a node missing its fields is treated as inheriting' do
   eq 'Wasteland', Game::Backdrop.name_for(1, { 1 => bare }, 'Wasteland')
 end
 
+# -- battle log terms (Game::States::BattleText) ------------------------------
+
+BT = Game::States::BattleText
+
+# The 用語 table stores predicates, not templates: RPG_RT prints the battler's
+# name and then the field, with one particle rule for the damage line.
+FakeTerms = Struct.new(:attacking, :defending, :observing, :focus,
+                       :autodestruction, :enemy_escape, :enemy_transform,
+                       :enemy_damaged, :actor_damaged,
+                       :enemy_undamaged, :actor_undamaged, :dodge)
+
+def fake_terms
+  FakeTerms.new('の攻撃！', 'は身を守っている', 'は様子を見ている・・・',
+                'は力をためている・・・', 'は自爆した！', 'は逃げてしまった！',
+                'は別のモンスターに変身した！',
+                'のダメージを与えた！', 'のダメージを受けた！',
+                'にダメージを与えられない！', 'はダメージを受けていない！',
+                'は身をかわした！')
+end
+
+check 'an action line is the battler name and the term, nothing else' do
+  t = fake_terms
+  eq 'スライムの攻撃！', BT.action(t, 'スライム', :attacking)
+  eq 'リトは身を守っている', BT.action(t, 'リト', :defending)
+  eq 'リトは様子を見ている・・・', BT.action(t, 'リト', :observing)
+  eq 'スライムは力をためている・・・', BT.action(t, 'スライム', :focus)
+  eq 'スライムは自爆した！', BT.action(t, 'スライム', :autodestruction)
+  eq 'スライムは逃げてしまった！', BT.action(t, 'スライム', :enemy_escape)
+end
+
+# The two damage predicates differ, and so does the particle: RPG_RT says
+# "...に N のダメージを与えた！" of a foe and "...は N のダメージを受けた！" of
+# one of yours.
+check 'the damage line picks its predicate and particle by side' do
+  t = fake_terms
+  eq 'スライムに 42 のダメージを与えた！', BT.damage(t, 'スライム', 42, false)
+  eq 'リトは 42 のダメージを受けた！', BT.damage(t, 'リト', 42, true)
+end
+
+check 'a blow that lands for nothing has no number and no particle' do
+  t = fake_terms
+  eq 'スライムにダメージを与えられない！', BT.undamaged(t, 'スライム', false)
+  eq 'リトはダメージを受けていない！', BT.undamaged(t, 'リト', true)
+end
+
+check 'a miss is worded from the target side, one term for both' do
+  t = fake_terms
+  eq 'スライムは身をかわした！', BT.dodge(t, 'スライム')
+  eq 'リトは身をかわした！', BT.dodge(t, 'リト')
+end
+
+# A database that leaves a battle term blank (an English release often does)
+# must not produce a half-sentence — the caller keeps its own wording instead.
+check 'a blank or missing term yields nil rather than a bare name' do
+  blank = FakeTerms.new('', '', '', '', '', '', '', '', '', '', '', '')
+  eq nil, BT.action(blank, 'リト', :attacking)
+  eq nil, BT.damage(blank, 'リト', 42, true)
+  eq nil, BT.undamaged(blank, 'リト', true)
+  eq nil, BT.dodge(blank, 'リト')
+  eq nil, BT.action(nil, 'リト', :attacking), 'no term table at all'
+  eq nil, BT.action(Struct.new(:nothing).new(0), 'リト', :attacking),
+     'a table without the field'
+end
+
 # -- chipset terrain tags -----------------------------------------------------
 
 FakeChipsetRow = Struct.new(:name, :chipset_name, :passable_data_lower,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8249,6 +8249,42 @@ check 'a blank or missing term yields nil rather than a bare name' do
      'a table without the field'
 end
 
+# A skill has a voice of its own where a plain attack has only a term.
+FakeSkillMsg = Struct.new(:using_message1, :using_message2, :failure_message)
+
+check 'a skill names itself: the first line takes the caster, the second stands alone' do
+  sk = FakeSkillMsg.new('は炎を放った！', 'あたりが真っ赤に染まる！', 0)
+  eq ['リトは炎を放った！', 'あたりが真っ赤に染まる！'], BT.skill_start(sk, 'リト')
+end
+
+check 'a skill with only a first sentence gives one line' do
+  eq ['リトは炎を放った！'],
+     BT.skill_start(FakeSkillMsg.new('は炎を放った！', '', 0), 'リト')
+end
+
+check 'a skill with no sentence at all gives none' do
+  eq [], BT.skill_start(FakeSkillMsg.new('', '', 0), 'リト')
+  eq [], BT.skill_start(nil, 'リト'), 'and so does a missing row'
+end
+
+# failure_message indexes the three 用語 failure lines; 3 borrows the dodge line.
+check 'a skill picks which failure sentence says it did nothing' do
+  terms = Struct.new(:skill_failure_a, :skill_failure_b, :skill_failure_c, :dodge)
+            .new('には効かなかった！', 'は平気だった！', 'は眠らなかった！',
+                 'は身をかわした！')
+  eq 'スライムには効かなかった！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 0), 'スライム')
+  eq 'スライムは平気だった！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 1), 'スライム')
+  eq 'スライムは眠らなかった！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 2), 'スライム')
+  eq 'スライムは身をかわした！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 3), 'スライム'),
+     'index 3 borrows the dodge line'
+  eq 'スライムには効かなかった！',
+     BT.skill_failure(terms, nil, 'スライム'), 'no row falls to the first line'
+end
+
 # -- chipset terrain tags -----------------------------------------------------
 
 FakeChipsetRow = Struct.new(:name, :chipset_name, :passable_data_lower,

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -221,7 +221,22 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0)
                          actor_damaged: 'のダメージを受けた！',
                          enemy_undamaged: 'にダメージを与えられない！',
                          actor_undamaged: 'はダメージを受けていない！',
-                         dodge: 'は身をかわした！'),
+                         dodge: 'は身をかわした！',
+                         skill_failure_a: 'には効かなかった！',
+                         skill_failure_b: 'は平気だった！',
+                         skill_failure_c: 'は眠らなかった！'),
+    # Skill rows for the battle log: RPG2000 gives each skill its own two
+    # sentences. Skill 8 sets both, 9 only the first, 10 neither (an
+    # English-release row), and 11 picks the second failure sentence.
+    skill: { 8 => OpenStruct.new(name: 'Fire', using_message1: 'は炎を放った！',
+                                 using_message2: 'あたりが真っ赤に染まる！',
+                                 failure_message: 0),
+             9 => OpenStruct.new(name: 'Heal', using_message1: 'は光をまとった！',
+                                 using_message2: '', failure_message: 0),
+             10 => OpenStruct.new(name: 'Mute', using_message1: '',
+                                  using_message2: '', failure_message: 0),
+             11 => OpenStruct.new(name: 'Sleep', using_message1: 'は呪文を唱えた！',
+                                  using_message2: '', failure_message: 2) },
     # The state table the battle status window and action banner read: a name, a
     # palette colour, the priority that decides which one a battler shows, and
     # RPG2000's own sentences for it landing and lifting. State 5 deliberately
@@ -3683,6 +3698,74 @@ check 'the state sentences still follow the action ones' do
                      { attacker: 'Slime', target: 'Hero', damage: 7,
                        inflicted: [3], target_ally: true })
   eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！', 'Hero is poisoned!'], lines
+end
+
+check 'a skill announces itself with its own two sentences, then the damage' do
+  scene, = battle_at_command
+  eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
+      'Slimeに 42 のダメージを与えた！'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 42, skill: 'Fire',
+                  skill_id: 8, target_ally: false })
+end
+
+check 'a skill with only a first sentence gives one line before the damage' do
+  scene, = battle_at_command
+  eq ['Heroは光をまとった！', 'Slimeに 5 のダメージを与えた！'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 5, skill: 'Heal',
+                  skill_id: 9, target_ally: false })
+end
+
+check 'a skill row with no sentence keeps the composed line' do
+  scene, = battle_at_command
+  eq ["Hero's Mute hits Slime for 5"],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 5, skill: 'Mute',
+                  skill_id: 10, target_ally: false })
+end
+
+check 'a skill that misses takes its own failure sentence, not the damage line' do
+  scene, = battle_at_command
+  eq ['Heroは呪文を唱えた！', 'Slimeは眠らなかった！'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 0, missed: true,
+                  skill: 'Sleep', skill_id: 11, target_ally: false })
+end
+
+check 'a heal that restored nothing reads as a failure' do
+  scene, = battle_at_command
+  eq ['Heroは光をまとった！', 'Heroには効かなかった！'],
+     scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
+                  target: 'Hero', recover_hp: 0, recover_mp: 0,
+                  cured: [], target_ally: true })
+end
+
+check 'a heal that worked says only what it was, not that it failed' do
+  scene, = battle_at_command
+  eq ['Heroは光をまとった！'],
+     scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
+                  target: 'Hero', recover_hp: 30, recover_mp: 0,
+                  cured: [], target_ally: true })
+end
+
+check 'a skill still trails the states it landed' do
+  scene, = battle_at_command
+  eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
+      'Slimeに 7 のダメージを与えた！', 'Slime looks ill!'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+                  skill_id: 8, inflicted: [3], target_ally: false })
+end
+
+check 'an item keeps its composed line: use_item is still unread' do
+  scene, = battle_at_command
+  ok scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Potion', item_id: 3,
+                  target: 'Hero', recover_hp: 30, target_ally: true })
+     .first.include?('Potion')
 end
 
 check 'the action banner announces the states an action landed and lifted' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -208,7 +208,20 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0)
     # Terms the Show Inn window reads; blank greeting fields exercise the
     # scene's English fallbacks. `normal_status` is what the battle status
     # window shows for a battler carrying no state.
-    term: OpenStruct.new(gold: 'G', normal_status: 'Normal'),
+    # The battle sentences RPG_RT keeps in the 用語 table, as *predicates* the
+    # battler's name goes in front of. `observing` is deliberately left blank so
+    # the scene's fallback wording is exercised.
+    term: OpenStruct.new(gold: 'G', normal_status: 'Normal',
+                         attacking: 'の攻撃！', defending: 'は身を守っている',
+                         observing: '', focus: 'は力をためている・・・',
+                         autodestruction: 'は自爆した！',
+                         enemy_escape: 'は逃げてしまった！',
+                         enemy_transform: 'は変身した！',
+                         enemy_damaged: 'のダメージを与えた！',
+                         actor_damaged: 'のダメージを受けた！',
+                         enemy_undamaged: 'にダメージを与えられない！',
+                         actor_undamaged: 'はダメージを受けていない！',
+                         dodge: 'は身をかわした！'),
     # The state table the battle status window and action banner read: a name, a
     # palette colour, the priority that decides which one a battler shows, and
     # RPG2000's own sentences for it landing and lifting. State 5 deliberately
@@ -3588,6 +3601,88 @@ check 'Change Monster Condition on a battle page shows on the status window' do
   # ...and the panel says so without waiting for the next action to redraw it.
   ok window_texts(ui[:status_win]).include?('Poison'),
      'the status window was rebuilt after the page ran'
+end
+
+# -- the battle log in the game's own words ------------------------------------
+
+check 'a plain attack reads as RPG_RT words it: the attack, then the damage' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Hero', target: 'Slime', damage: 42,
+                       target_ally: false })
+  eq ['Heroの攻撃！', 'Slimeに 42 のダメージを与えた！'], lines
+end
+
+check 'and from the other side, with the other predicate and particle' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Slime', target: 'Hero', damage: 7,
+                       target_ally: true })
+  eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！'], lines
+end
+
+check 'a miss reads as the target dodging' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Hero', target: 'Slime', damage: 0,
+                       missed: true, target_ally: false })
+  eq ['Heroの攻撃！', 'Slimeは身をかわした！'], lines
+end
+
+check 'a blow that gets through for nothing says so' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Hero', target: 'Slime', damage: 0,
+                       target_ally: false })
+  eq ['Heroの攻撃！', 'Slimeにダメージを与えられない！'], lines
+end
+
+check 'the basic actions with no target are one line each' do
+  scene, = battle_at_command
+  eq ['Slimeは身を守っている'],
+     scene.send(:battle_action_lines, { attacker: 'Slime', defend: true })
+  eq ['Slimeは力をためている・・・'],
+     scene.send(:battle_action_lines, { attacker: 'Slime', charge: true })
+  eq ['Slimeは逃げてしまった！'],
+     scene.send(:battle_action_lines, { attacker: 'Slime', fled: true })
+  eq ['Slimeは変身した！'],
+     scene.send(:battle_action_lines, { attacker: 'Slime', transform: true,
+                                        target: 'Bat' })
+end
+
+check 'an autodestruct names itself and then the damage it did' do
+  scene, = battle_at_command
+  eq ['Slimeは自爆した！', 'Heroは 20 のダメージを受けた！'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Slime', target: 'Hero', damage: 20,
+                  autodestruct: true, target_ally: true })
+end
+
+# A database that leaves a battle term blank must not produce a half-sentence.
+check 'a blank term drops the whole entry back to the composed wording' do
+  scene, = battle_at_command
+  # `observing` is blank in the fixture, so Observe cannot be worded from the
+  # table and the entry falls back whole rather than printing a bare name.
+  eq ['Slime watches closely'],
+     scene.send(:battle_action_lines, { attacker: 'Slime', observe: true })
+end
+
+check 'a skill keeps its composed line until its own sentence is read' do
+  scene, = battle_at_command
+  # using_message1 / use_item are still unread; dropping to the bare damage line
+  # would lose the only thing naming what was cast.
+  eq ["Hero's Venom hits Slime for 7"],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Venom',
+                  target_ally: false })
+end
+
+check 'the state sentences still follow the action ones' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Slime', target: 'Hero', damage: 7,
+                       inflicted: [3], target_ally: true })
+  eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！', 'Hero is poisoned!'], lines
 end
 
 check 'the action banner announces the states an action landed and lifted' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -883,7 +883,54 @@ def check_items(dir)
   end
 end
 
+# The 用語 (term) table's battle sentences, against the real thing. Both test
+# beds fill in 126 of the 127 fields; a fixture cannot say whether a field is a
+# predicate the name goes in front of or a whole sentence, because it is written
+# to match whatever the code does. Only the games' own text can.
+DB_TERM = 21
+BASIC_TERMS = [:attacking, :defending, :observing, :focus, :autodestruction,
+               :enemy_escape, :enemy_transform].freeze
+
+def check_terms(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  terms = db[DB_TERM]
+  return unless terms
+  bt = Game::States::BattleText
+
+  filled = BASIC_TERMS.select { |f| bt.term(terms, f) }
+  puts format('   terms: %d of %d basic action sentences, damage %s, dodge %s',
+              filled.size, BASIC_TERMS.size,
+              bt.term(terms, :enemy_damaged) ? 'yes' : 'no',
+              bt.term(terms, :dodge) ? 'yes' : 'no')
+  return if filled.empty?
+
+  check "#{name}: every basic action sentence composes after a battler's name" do
+    filled.each do |f|
+      line = bt.action(terms, 'スライム', f)
+      eq "スライム#{terms.send(f)}", line, "term #{f}"
+      ok line.length > terms.send(f).length, 'the name really is in front of it'
+    end
+  end
+
+  return unless bt.term(terms, :enemy_damaged) && bt.term(terms, :actor_damaged)
+  check "#{name}: the damage sentence differs by side, and carries the number" do
+    foe = bt.damage(terms, 'スライム', 42, false)
+    ally = bt.damage(terms, 'リト', 42, true)
+    ok foe.include?('42') && ally.include?('42'), 'both name the amount'
+    ok foe.include?(terms.enemy_damaged), 'the foe predicate'
+    ok ally.include?(terms.actor_damaged), 'the ally predicate'
+    ok foe != ally.sub('リト', 'スライム'),
+       'the two sides really are worded differently'
+    # The particle is what makes them read as Japanese rather than as two names
+    # glued to numbers, and it is the one part not in the database.
+    ok foe.start_with?('スライムに '), 'a foe takes に'
+    ok ally.start_with?('リトは '), 'one of yours takes は'
+  end
+end
+
 dirs.each do |d|
+  check_terms(d)
   check_game(d)
   check_menus(d)
   check_states(d)

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -913,6 +913,50 @@ def check_terms(dir)
     end
   end
 
+  # A skill's own two sentences, against the real skill table. Only a real game
+  # can say these are predicates the caster's name goes in front of (the first)
+  # and a standalone line (the second) -- a fixture is written to match the code.
+  first = []
+  second = []
+  failures = Hash.new(0)
+  db[DB_SKILL]&.each do |id, sk|
+    first << id unless sk.using_message1.to_s.empty?
+    second << id unless sk.using_message2.to_s.empty?
+    failures[sk.failure_message || 0] += 1
+  end
+  puts format('   skills: %d with a first sentence, %d with a second; ' \
+              'failure_message %s',
+              first.size, second.size,
+              failures.sort.map { |k, v| "#{k}:#{v}" }.join(' '))
+
+  unless first.empty?
+    check "#{name}: every skill sentence composes the way RPG_RT prints it" do
+      first.each do |id|
+        sk = db[DB_SKILL][id]
+        lines = bt.skill_start(sk, 'リト')
+        eq "リト#{sk.using_message1}", lines[0], "skill ##{id} (#{sk.name})"
+        if sk.using_message2.to_s.empty?
+          eq 1, lines.size, "skill ##{id} has only a first line"
+        else
+          # The second line stands alone -- no name in front of it.
+          eq sk.using_message2, lines[1], "skill ##{id} second line"
+          ok !lines[1].start_with?('リト'), 'and it is not prefixed'
+        end
+      end
+    end
+
+    check "#{name}: every skill's failure_message names a real 用語 line" do
+      db[DB_SKILL].each do |id, sk|
+        i = sk.failure_message || 0
+        ok i >= 0 && i < Game::States::BattleText::FAILURE_TERMS.size,
+           "skill ##{id} (#{sk.name}) failure_message #{i} is in range"
+        line = bt.skill_failure(terms, sk, 'スライム')
+        ok line && line.start_with?('スライム'),
+           "skill ##{id} composes a failure sentence"
+      end
+    end
+  end
+
   return unless bt.term(terms, :enemy_damaged) && bt.term(terms, :actor_damaged)
   check "#{name}: the damage sentence differs by side, and carries the number" do
     foe = bt.damage(terms, 'スライム', 42, false)


### PR DESCRIPTION
> **Note:** #420 was stacked on this branch and has since merged **into it**, so this PR now delivers both changes — the term-driven action lines *and* the skill sentences #420 added. The "held back" section below is updated accordingly.

The battle log invented its English — "Hero hits Slime for 42", "Slime defends", "Hero misses Slime" — in a runtime for games that are not in English and that ship their own wording for every one of those lines.

RPG2000 keeps them in the 用語 (term) table, as **predicates** rather than templates: the database stores 「の攻撃！」 and RPG_RT prints the battler's name in front of it. A field-by-field audit of both test beds against the runtime source says how much was going unread:

| | term fields filled in | fields the runtime named |
|---|---|---|
| Nepheshel / mtf-meido-action | **126 of 127** | 2 (`gold`, `normal_status`) |

ADR 0032 already made this argument for the *state* sentences. This is the same argument for the action itself, and the larger half — every round prints an action line, where only some print a state line.

## Part 1 — the action lines

`Game::States::BattleText` composes the sentences; `Scene::Map#battle_action_body` builds the log from them.

- **More than one line.** RPG_RT prints what the battler *did* and then what it did *to the target* as separate messages: 「スライムの攻撃！」 then 「リトは 7 のダメージを受けた！」.
- **The particle is the rule that isn't in the database.** `name + particle + value + " " + predicate`, picked by side — に for one of theirs, は for one of yours — pairing with the two `enemy_damaged` / `actor_damaged` predicates. This is the CP932 branch of EasyRPG's `GetDamagedMessage`; the Western branch uses a plain space for both, and this build decodes every string as CP932 (`LCF.cp932_to_utf8`), so there's no other branch to take.
- **All or nothing per entry.** A blank term drops the whole entry back to the composed English. A half-translated line — 「スライムの攻撃！」 with no damage sentence under it — reads worse than the English one, and an English-release table with half the battle block empty is a real shape.

Covered: attack, Defend, Observe, Charge, self-destruct, flee, transform; both damage sides; no-damage blows; misses. All 7 basic action sentences are filled in in both games, as are both damage predicates and `dodge`.

## Part 2 — the skill's own voice (was #420)

A skill does not borrow a term; it carries two sentences of its own, which is why a spell reads differently from a sword swing:

| | skills with `using_message1` | with `using_message2` |
|---|---|---|
| Nepheshel | **229** of 306 | **18** |
| mtf-meido-action | **122** of 134 | 0 |

The two compose **differently**, and that asymmetry is the rule worth recording. `using_message1` follows the caster's name like every other predicate; `using_message2` **stands alone** as a second line — EasyRPG's `GetSkillSecondStartMessage2k` returns the field with nothing in front of it:

```
リトは炎を放った！
あたりが真っ赤に染まる！
スライムに 42 のダメージを与えた！
```

A caster and then a scene, not the caster twice. Prefixing the second line would have been the obvious guess and it's wrong.

**A skill that achieved nothing takes its own failure sentence** instead of a damage line, chosen by the row's `failure_message` from the three 用語 failure lines, with **3 borrowing the dodge line**. All four values are in real use:

| | 0 | 1 | 2 | 3 |
|---|---|---|---|---|
| Nepheshel | 255 | 7 | 1 | **43** |
| mtf-meido-action | 116 | 8 | 4 | **6** |

So index 3 is not a theoretical branch. "Achieved nothing" means a miss, or a recovery that restored no HP or SP and cured and inflicted nothing.

This needed the skill's **id** on the log entry, which carried only its name, so `command_skill` / `command_skill_all` take a `skill_id:` and the enemy AI path sets it from its own action.

## Still held back on purpose

- **An item keeps its composed line.** Its sentence is the `use_item` term rather than a field of its own, and the RPG2000 branch of `GetItemStartMessage2k` is a different shape from everything here; left for its own change.
- **The critical-hit line.** `actor_critical` / `enemy_critical` (「会心の一撃！！」 / 「痛恨の一撃！！」) are filled in in both games, but which side keys them is genuinely unclear: EasyRPG's `GetCriticalHitMessage` picks `actor_critical` when the **target** is an ally, while the words follow the Dragon Quest convention where 会心 is *your* blow landing and 痛恨 is one landing on you — the attacker's side, i.e. the opposite. One reading is wrong and the data can't settle it, since both games fill both fields with the same two strings. Getting it backwards would put the wrong sentence on every critical, so the line is left as it was rather than guessed at.

## Verification

All 14 `scripts/*_check.rb` suites pass. 37 new checks across both parts; the two harnesses that reference `BattleText` fail to load at all against the pre-fix code, and the scene check reports 8 hard failures.

- `rpg2k_logic_check.rb` (559, +9): each builder's shape, the two damage predicates and their particles, a blank / missing / absent term yielding nil rather than a bare name; both skill sentences and the asymmetry between them, a skill with only the first, one with neither, a missing row, and each of the four `failure_message` values.
- `rpg2k_scene_check.rb` (216, +17): the log a real `Scene::Map` produces for an attack from either side, a miss, a no-damage blow, each targetless basic action, an autodestruct's two lines, the all-or-nothing fallback on a blank term, the state sentences still following the action ones; and for a skill with both sentences, with one, with none, one that missed, a heal that restored nothing and one that worked, plus an item keeping its line.
- `rpg2k_testbed_logic_check.rb` (94, +12): composes every basic action sentence and **every** real skill sentence in both games — asserting the second skill line is *not* prefixed with the caster's name, and that the two damage sides really are worded differently and take their own particles, neither of which a fixture can establish since it's written to match whatever the code does — and checks every skill's `failure_message` indexes a 用語 line the table really has.

See `docs/adr/0036-battle-log-in-the-games-own-words.md` and its addendum.