### PR TITLE
A comparator that answers -2 no longer ends a battle

### DIFF
--- a/changelog.d/rgss-array-sort-minus-two.fixed.md
+++ b/changelog.d/rgss-array-sort-minus-two.fixed.md
@@ -1,0 +1,13 @@
+- **A battle no longer ends on an `ArgumentError` when two battlers are two
+  points apart.** mruby's `Array#sort` / `#sort!` use `-2` as their "the block
+  did not answer with a number" sentinel *and* assign the block's own answer to
+  the same variable, so a comparator that legitimately answers `-2` raises
+  `comparison failed`. Ruby only specifies the *sign* of a comparator, and
+  RGSS's own scripts return a difference — `Scene_Battle#make_action_orders`
+  sorts the battlers by `b.current_action.speed - a.current_action.speed`, which
+  every RPG Maker XP game runs at the start of every battle turn. Any two
+  battlers whose speeds differed by exactly two ended the game. The comparator's
+  answer is now normalised to -1/0/1, which makes the sentinel unreachable while
+  keeping mruby's C sort underneath; an answer that is genuinely unusable still
+  raises what it always did. Engine-wide, since it is mruby's arithmetic and the
+  RPG2000 runtime sorts with difference blocks too.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -385,6 +385,49 @@ need it. The rest of the sweep came back clean: `Marshal` (mruby-marshal),
 neither bundle touches `Dir`, `Struct`, `Set`, `ObjectSpace` or the metaprogramming
 gems.
 
+### 0k. `Array#sort!` with a comparator that answers -2 ✅ (every battle turn)
+
+The battle probe reached phase 4 and the game died there:
+
+```
+[RGSS] script host: section "Main" raised ArgumentError: comparison failed
+[RGSS] script host:   from Scene_Battle 4:65:in sort!
+[RGSS] script host:   from Scene_Battle 4:65:in make_action_orders
+[RGSS] script host:   from Scene_Battle 4:42:in start_phase4
+```
+
+Not a missing method — an **mruby bug**. `sort_cmp` (`3rd/mruby/src/array.c`)
+uses `-2` as its "the block did not answer with a number" sentinel and assigns
+the block's own answer to the same variable, so a comparator that legitimately
+answers `-2` is indistinguishable from a broken one. Ruby only ever specifies
+the *sign* of a comparator, and RGSS's scripts return a **difference**:
+
+```ruby
+@action_battlers.sort! {|a, b|
+  b.current_action.speed - a.current_action.speed }
+```
+
+`Scene_Battle#make_action_orders`, which every RPG Maker XP game runs at the
+start of every battle turn. Any two battlers whose speeds differ by exactly two,
+in that order, end the game. An instrumented run showed it plainly — speeds
+`59, 56, 66, 62, 60, 57`, every one a valid Integer, and the comparison that
+raised was `62 - 60`.
+
+`mruby-rgss/mrblib/array_sort.rb` normalises a comparator's answer to -1/0/1,
+which makes the sentinel unreachable while keeping mruby's C sort underneath. An
+answer that is genuinely unusable still raises mruby's own "comparison failed".
+Engine-wide rather than RGSS-only: it is mruby's arithmetic, and the RPG2000
+runtime sorts with difference blocks too.
+
+**Worth recording how it was caught**, because nothing static would have found
+it: the failure was random — six battlers give fifteen pairs, so about half of
+all runs contain one differing by two — and mruby seeds from the clock, so CI
+passed and failed by turns. Pinning the seed (`--rgss_random_seed`) made it
+reproducible, and being able to build the engine without Nix made it
+reproducible *locally*, where the sort block could be instrumented to print what
+it actually returned. Every static reading of `agi`, `rand` and `Integer()` said
+the speeds were Integers, and they were.
+
 ### 1. `Sprite` extended properties ✅ (opacity/zoom/angle/mirror/tone/color/src_rect/blend_type/bush_depth/flash all rendered)
 
 `mruby-rgss` `Sprite` has `bitmap`/`bitmap=`, `x`/`x=`, `y`/`y=`, `z`/`z=`,

--- a/mruby-rgss/mrblib/array_sort.rb
+++ b/mruby-rgss/mrblib/array_sort.rb
@@ -1,0 +1,60 @@
+# Array#sort / #sort! with a comparator that answers -2.
+#
+# mruby uses -2 as its "the block did not answer with a number" sentinel *and*
+# assigns the block's own answer to the same variable (3rd/mruby/src/array.c,
+# sort_cmp):
+#
+#     mrb_value c = mrb_yield_argv(mrb, blk, 2, args);
+#     if (mrb_nil_p(c) || !mrb_fixnum_p(c)) { cmp = -2; }
+#     else { cmp = mrb_fixnum(c); }
+#     ...
+#     if (cmp == -2) { mrb_raise(mrb, E_ARGUMENT_ERROR, "comparison failed"); }
+#
+# so a comparator that legitimately answers -2 raises `ArgumentError:
+# comparison failed`. Ruby only ever specifies the *sign* of a comparator, and
+# RGSS's own scripts are written to return a difference rather than -1/0/1:
+#
+#     @action_battlers.sort! {|a, b|
+#       b.current_action.speed - a.current_action.speed }
+#
+# — `Scene_Battle#make_action_orders`, which every RPG Maker XP game runs at the
+# start of every battle turn. Two battlers whose speeds differ by exactly two,
+# in that order, end the game. That is why the boot check's battle pass failed
+# on about half of all random seeds and passed on the rest
+# (docs/rpgxp-rgss-api-gap.md, gap 0k).
+#
+# Normalising the answer to -1/0/1 makes the sentinel unreachable while keeping
+# mruby's own C sort underneath, so the cost is one extra block call per
+# comparison rather than a sort written in Ruby. A comparator that answers
+# something *not* comparable still raises mruby's own "comparison failed",
+# because nil is what that path hands back.
+#
+# Engine-wide rather than RGSS-only: this is mruby's arithmetic, and the
+# RPG2000 runtime sorts with difference blocks too.
+class Array
+  alias_method :_rgss_native_sort, :sort
+  alias_method :_rgss_native_sort!, :sort!
+
+  def sort(&block)
+    return _rgss_native_sort if block.nil?
+    _rgss_native_sort { |a, b| RGSS._comparison_sign(block.call(a, b)) }
+  end
+
+  def sort!(&block)
+    return _rgss_native_sort! if block.nil?
+    _rgss_native_sort! { |a, b| RGSS._comparison_sign(block.call(a, b)) }
+  end
+end
+
+module RGSS
+  # The sign of a comparator's answer, or nil when it has none — nil is what
+  # mruby's sort treats as a failed comparison, so an unusable answer still
+  # raises exactly what it raised before.
+  def self._comparison_sign(value)
+    return -1 if value < 0
+    return 1 if value > 0
+    0
+  rescue StandardError
+    nil
+  end
+end

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -233,6 +233,39 @@ assert "RGSS::Bitmap#_transition_alpha dissolves in the shape of a map" do
   end
 end
 
+# mruby's Array#sort / #sort! use -2 as the "the block did not answer with a
+# number" sentinel *and* assign the block's own answer to the same variable
+# (3rd/mruby/src/array.c, sort_cmp), so a comparator that legitimately answers
+# -2 raised `ArgumentError: comparison failed`. Ruby only specifies the *sign* of
+# a comparator, and RGSS's own scripts return a difference:
+# `Scene_Battle#make_action_orders` sorts the battlers by
+# `b.current_action.speed - a.current_action.speed`, which every RPG Maker XP
+# game runs at the start of every battle turn — so two battlers whose speeds
+# differed by exactly two ended the game. The speeds below are the ones a real
+# battle produced when it did.
+assert "Array#sort survives a comparator that answers -2" do
+  speeds = [59, 56, 66, 62, 60, 57]  # 62 and 60 are the pair that killed it
+  assert_equal [66, 62, 60, 59, 57, 56], speeds.sort { |a, b| b - a }
+
+  in_place = speeds.dup
+  in_place.sort! { |a, b| b - a }
+  assert_equal [66, 62, 60, 59, 57, 56], in_place
+
+  # The sentinel itself, and its mirror, on the smallest array that reaches it.
+  assert_equal [3, 1], [1, 3].sort { |a, b| b - a }
+  assert_equal [1, 3], [3, 1].sort { |a, b| a - b }
+
+  # Sorting without a block is untouched.
+  assert_equal [1, 2, 3], [3, 1, 2].sort
+  plain = [3, 1, 2]
+  plain.sort!
+  assert_equal [1, 2, 3], plain
+
+  # And a comparator with no usable answer still fails the way it always did.
+  assert_raise(ArgumentError) { [1, 2].sort { |_a, _b| nil } }
+  assert_raise(ArgumentError) { [1, 2].sort! { |_a, _b| "no" } }
+end
+
 assert "RGSS::Table drops out-of-range writes without reading the value" do
   t = RGSS::Table.new(2, 2)
   t[0, 0] = 5


### PR DESCRIPTION
The XP boot check's battle pass has been failing intermittently on master
([run 1206](https://github.com/take-cheeze/rpg-maker-clone/actions/runs/31066754386/job/92505957578)):

```
[RGSS] script host: section "Main" raised ArgumentError: comparison failed
[RGSS] script host:   from Scene_Battle 4:65:in sort!
[RGSS] script host:   from Scene_Battle 4:65:in make_action_orders
[RGSS] script host:   from Scene_Battle 4:42:in start_phase4
```

It is not a missing method. It is an **mruby bug**, and it ends a battle in
every RPG Maker XP game that draws the wrong numbers.

## The bug

`sort_cmp` (`3rd/mruby/src/array.c`) uses `-2` as its "the block did not answer
with a number" sentinel, *and* assigns the block's own answer to the same
variable:

```c
mrb_value c = mrb_yield_argv(mrb, blk, 2, args);
if (mrb_nil_p(c) || !mrb_fixnum_p(c)) { cmp = -2; }
else { cmp = mrb_fixnum(c); }
...
if (cmp == -2) { mrb_raise(mrb, E_ARGUMENT_ERROR, "comparison failed"); }
```

So a comparator that legitimately answers `-2` is indistinguishable from a
broken one. Ruby only ever specifies the *sign* of a comparator, and RGSS's
scripts return a **difference**:

```ruby
@action_battlers.sort! {|a, b|
  b.current_action.speed - a.current_action.speed }
```

`Scene_Battle#make_action_orders` — which every XP game runs at the start of
every battle turn. Any two battlers whose speeds differ by exactly two, in that
order, end the game.

An instrumented local run said it outright:

```
[DBG] 0 Game_Enemy speed=59/Integer     [DBG] cmp Game_Enemy/Game_Enemy -> -3/Integer
[DBG] 1 Game_Enemy speed=56/Integer     [DBG] cmp Game_Enemy/Game_Actor -> 10/Integer
[DBG] 2 Game_Actor speed=66/Integer     ...
[DBG] 3 Game_Actor speed=62/Integer     [DBG] cmp Game_Actor/Game_Actor -> -2/Integer
[DBG] 4 Game_Actor speed=60/Integer     ArgumentError: comparison failed
```

Every value a valid Integer. `62 - 60` is what raised.

## The fix

`mruby-rgss/mrblib/array_sort.rb` normalises a comparator's answer to `-1/0/1`,
which makes the sentinel unreachable while keeping mruby's C sort underneath —
the cost is one extra block call per comparison rather than a sort written in
Ruby. A comparator with no usable answer still raises mruby's own
`comparison failed`, because `nil` is what that path hands back.

Engine-wide rather than RGSS-only: this is mruby's arithmetic, and the RPG2000
runtime sorts with difference blocks too.

## Verified locally

Seeds **2, 3, 6, 7** reproduced the crash before this change and pass after.
Seeds 1, 4, 5, 8, 9 and the boot check's pinned `20260806` always passed — which
is why master looks green while every player's battles are a coin flip. The unit
test pins the exact case, including that a genuinely unusable comparator still
raises.

## How it was caught

Worth recording, because nothing static would have found it — I traced `agi`,
`rand`, `Integer()` and `Integer#/` through mruby's sources and the real test-bed
data, and every one of them correctly said "Integer".

Two changes from earlier today are what made it findable. `--rgss_random_seed`
(#409) turned "fails about half the time" into a reproducible case; the non-Nix
build (#412) let me build and instrument the engine in an agent container, where
the sort block could be made to print what it actually returned. Before those,
this was another blind CI round-trip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_