### PR TITLE
Give a skill its own voice in the battle log

### DIFF
--- a/changelog.d/skill-battle-messages.added.md
+++ b/changelog.d/skill-battle-messages.added.md
@@ -1,0 +1,14 @@
+- **A skill announces itself in its own words.** The skill row carries two
+  sentences of its own rather than borrowing a 用語 term, and they compose
+  differently: `using_message1` follows the caster's name like every other
+  predicate, while `using_message2` **stands alone** as a second line — so a
+  spell reads 「リトは炎を放った！」 then 「あたりが真っ赤に染まる！」, a caster and
+  then a scene. 229 of Nepheshel's 306 skills and 122 of mtf-meido-action's 134
+  set the first; 18 set the second. A skill that achieved nothing (a miss, or a
+  recovery that restored and cured nothing) takes its own failure sentence
+  instead of a damage line, chosen by the row's `failure_message` from the three
+  用語 failure lines plus the dodge line at index 3 — all four values are in real
+  use across the test beds. A skill row with no sentence keeps the composed
+  wording, since the bare damage line would lose the only thing naming what was
+  cast. Items still keep theirs: the `use_item` term is a different shape and its
+  own change. See the addendum to ADR 0036.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -797,10 +797,24 @@ The work below is roughly ordered by the critical path to a walkable game
   Defend, Observe, Charge, self-destruct, flee, transform — plus both damage
   sides, no-damage and misses; a blank term drops the **whole** entry back to the
   composed English, because a half-translated line reads worse than an English
-  one. Still held back on purpose: a **skill or item** keeps its composed line
-  until its own `using_message1` / `using_message2` / `use_item` is read (351 and
-  18 skills across the test beds set one), since the bare damage line would lose
-  the only thing naming what was cast; and the **critical** line is left alone
+  one.
+  **A skill says it in its own words**, which is why a spell reads differently
+  from a sword swing: the row carries two sentences of its own, and they compose
+  differently — `using_message1` follows the caster's name like every other
+  predicate while `using_message2` **stands alone** as a second line, so a spell
+  reads 「リトは炎を放った！」 then 「あたりが真っ赤に染まる！」, a caster and then a
+  scene. 229 of Nepheshel's 306 skills and 122 of mtf's 134 set the first, 18 the
+  second. A skill that achieved nothing — a miss, or a recovery that restored and
+  cured nothing — takes its own failure sentence rather than a damage line, picked
+  by the row's `failure_message` from the three 用語 failure lines plus the dodge
+  line at index 3; all four values are in real use (255/7/1/43 and 116/8/4/6).
+  This needed the skill's **id** on the log entry, which carried only its name, so
+  `command_skill` / `command_skill_all` take a `skill_id:` and the enemy AI path
+  sets it from its own action. A skill row with no sentence keeps the composed
+  wording, as a blank term does.
+  Still held back on purpose: an **item** keeps its composed line
+  until the `use_item` term is read — a different shape from everything here —
+  and the **critical** line is left alone
   because which side keys `actor_critical` / `enemy_critical` is genuinely
   unclear — EasyRPG picks `actor_critical` when the *target* is an ally, while
   会心 / 痛恨 read as the *attacker's* side, and both games fill both fields with

--- a/docs/adr/0036-battle-log-in-the-games-own-words.md
+++ b/docs/adr/0036-battle-log-in-the-games-own-words.md
@@ -93,3 +93,56 @@ sentences still following the action ones) and by
 `scripts/rpg2k_testbed_logic_check.rb`, which composes every basic action
 sentence in **both real term tables** after a battler's name and checks that the
 two damage sides really are worded differently and take their own particles.
+
+## Addendum: the skill's own voice
+
+Date: 2026-08-06
+
+The first of the two things held back above is now done. A skill does not use a
+term for "attacking" — it carries its **own** two sentences, which is the whole
+reason a spell reads differently from a sword swing:
+
+| | skills with `using_message1` | with `using_message2` |
+|---|---|---|
+| Nepheshel | **229** of 306 | **18** |
+| mtf-meido-action | **122** of 134 | 0 |
+
+They compose differently from each other, and that asymmetry is the rule worth
+recording: `using_message1` follows the caster's name like every other predicate,
+while `using_message2` **stands alone** as a second line (EasyRPG's
+`GetSkillSecondStartMessage2k` returns the field with nothing in front of it). So
+a spell reads 「リトは炎を放った！」 then 「あたりが真っ赤に染まる！」 — a caster and
+then a scene, not the caster twice.
+
+**A skill that achieved nothing takes its own failure sentence** instead of a
+damage line, and which one is again the skill row's choice: `failure_message`
+indexes the three 用語 failure lines, with 3 borrowing the dodge line. All four
+values are in real use — Nepheshel splits 255 / 7 / 1 / 43 and mtf 116 / 8 / 4 /
+6 — so the index-3 case is not a theoretical branch. "Achieved nothing" means a
+miss, or a recovery that restored no HP or SP and cured and inflicted nothing.
+
+Falling back stays all-or-nothing per entry, for the reason the base decision
+gives: a skill row with no sentence keeps the composed English, because the bare
+damage line would lose the only thing naming what was cast. That is what an
+English-release skill table looks like, and 77 of Nepheshel's own skills are in
+it.
+
+Plumbing this needed the skill's **id** on the log entry — the entry carried only
+the skill's name — so `command_skill` / `command_skill_all` take a `skill_id:`,
+the enemy AI path sets it from its own action, and both ride onto the entry.
+
+**An item still keeps its composed line.** Its sentence is the `use_item` term
+rather than a field of its own, and the RPG2000 branch of EasyRPG's
+`GetItemStartMessage2k` is a different shape from everything here; it is left for
+its own change rather than folded in.
+
+Covered by `scripts/rpg2k_logic_check.rb` (both sentences and the asymmetry
+between them, a skill with only the first, a skill with neither, a missing row,
+and each of the four `failure_message` values), by
+`scripts/rpg2k_scene_check.rb` (the log a real `Scene::Map` produces for a skill
+with both sentences, with one, with none, one that missed, a heal that restored
+nothing and one that worked, a skill's states still trailing it, and an item
+keeping its line) and by `scripts/rpg2k_testbed_logic_check.rb`, which composes
+**every** real skill sentence in both games — asserting the second line is not
+prefixed with the caster's name — and checks every skill's `failure_message`
+indexes a 用語 line the table really has.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4770,6 +4770,39 @@ module Game
       def self.dodge(terms, target_name)
         action(terms, target_name, :dodge)
       end
+
+      # A skill announces itself with its **own** two sentences rather than with
+      # a term, which is why a skill has a voice and a plain attack does not.
+      # `using_message1` follows the caster's name the way every other predicate
+      # does; `using_message2` stands alone as a second line (EasyRPG's
+      # `GetSkillSecondStartMessage2k` returns the field with no name in front),
+      # so a skill can read 「リトは炎を放った！」 / 「あたりが真っ赤に染まる！」.
+      #
+      # Returns [] when the skill sets neither, so the caller keeps its own line.
+      # 351 of the test beds' skills set the first and 18 the second.
+      def self.skill_start(skill_row, caster_name)
+        return [] unless skill_row
+        first = term(skill_row, :using_message1)
+        second = term(skill_row, :using_message2)
+        lines = []
+        lines << "#{caster_name}#{first}" if first
+        lines << second if second
+        lines
+      end
+
+      # A skill that achieved nothing. Which sentence says so is the skill row's
+      # own choice: `failure_message` indexes the three 用語 failure lines, and 3
+      # borrows the dodge line (EasyRPG's `GetSkillFailureMessage`). Worded from
+      # the target's side, like the dodge it can become.
+      FAILURE_TERMS = [:skill_failure_a, :skill_failure_b, :skill_failure_c,
+                       :dodge].freeze
+
+      def self.skill_failure(terms, skill_row, target_name)
+        i = skill_row && skill_row.respond_to?(:failure_message) ?
+              skill_row.failure_message : nil
+        f = FAILURE_TERMS[i || 0]
+        f && action(terms, target_name, f)
+      end
     end
 
     # Map-step slip damage: RPG2000's field poison. A state drains HP every
@@ -5278,8 +5311,9 @@ module Game
     # recovery) computed by Game::Party#battle_skill_command. Resolved in agility
     # order by #apply_command when the round runs.
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
-                      chance: 100, variance: 0, attributes: nil)
+                      chance: 100, variance: 0, attributes: nil, skill_id: nil)
       ally.command = { kind: :skill, target: target, name: name,
+                       skill_id: skill_id,
                        cost: cost, hp: hp, mp: mp,
                        inflict: inflict || [], chance: chance, variance: variance,
                        attributes: attributes || [] }
@@ -5294,9 +5328,9 @@ module Game
     # `attributes` apply to every target. #apply_command produces one log entry
     # per living target, drained one at a time by #step_action.
     def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
-                          variance: 0, attributes: nil)
+                          variance: 0, attributes: nil, skill_id: nil)
       ally.command = { kind: :skill, all: true, targets: targets, name: name,
-                       cost: cost, inflict: inflict || [], chance: chance,
+                       skill_id: skill_id, cost: cost, inflict: inflict || [], chance: chance,
                        variance: variance, attributes: attributes || [] }
       ally.action = nil; ally.defending = false
     end
@@ -5691,6 +5725,7 @@ module Game
       cmd = @ai.skill_command(sk, b, targets.first)
       return enemy_fallback_attack(b) unless cmd
       b.command = skill_command_hash(sk, cmd, targets.first)
+      b.command[:skill_id] = act.skill_id
       if targets.size > 1
         # An all-target skill carries one effect per target, since attack damage
         # is computed against each target's own defence.
@@ -6012,7 +6047,8 @@ module Game
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
           inflicted: inflicted, already: already,
-          target_ally: ally?(target), skill: cmd[:name] }
+          target_ally: ally?(target), skill: cmd[:name],
+          skill_id: cmd[:skill_id] }
       else
         before_hp = target.hp
         before_mp = target.mp || 0
@@ -6023,7 +6059,7 @@ module Game
         cured = (cmd[:cured] || []).select { |s| target.state?(s) }
         target.states = (target.states || []) - cured unless cured.empty?
         { recover: true, actor: b.name, source: cmd[:name],
-          item_id: cmd[:item_id], target: target.name,
+          item_id: cmd[:item_id], skill_id: cmd[:skill_id], target: target.name,
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
           cured: cured, target_ally: ally?(target),
           target_hp: target.hp, target_mp: target.mp }

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3197,7 +3197,7 @@ class RPG2k
         sid, cost = @battle_ui[:skills][@battle_ui[:skill_i]]
         return if current_actor.mp < cost # can't afford: stay on the list
         sk = @state.party.db_skill(sid)
-        @battle_ui[:pending] = { kind: :skill, sk: sk }
+        @battle_ui[:pending] = { kind: :skill, sk: sk, sid: sid }
         close_battle_skill
         case @state.party.battle_skill_target(sk)
         when :self
@@ -3221,9 +3221,11 @@ class RPG2k
       # then move to the next actor.
       def apply_pending_skill(target)
         sk = @battle_ui[:pending][:sk]
+        sid = @battle_ui[:pending][:sid]
         c = @state.party.battle_skill_command(sk, current_actor, target)
         @battle_ui[:battle].command_skill(current_actor, target,
-                                          name: sk.name, cost: c[:cost],
+                                          name: sk.name, skill_id: sid,
+                                          cost: c[:cost],
                                           hp: c[:hp], mp: c[:mp],
                                           inflict: c[:inflict], chance: c[:chance],
                                           variance: c[:variance] || 0,
@@ -3240,13 +3242,15 @@ class RPG2k
       # infliction ride along once.
       def apply_pending_skill_all(targets)
         sk = @battle_ui[:pending][:sk]
+        sid = @battle_ui[:pending][:sid]
         meta = @state.party.battle_skill_command(sk, current_actor, targets.first)
         effects = targets.map do |t|
           c = @state.party.battle_skill_command(sk, current_actor, t)
           { target: t, hp: c[:hp], mp: c[:mp] }
         end
         @battle_ui[:battle].command_skill_all(current_actor, effects,
-                                              name: sk.name, cost: meta[:cost],
+                                              name: sk.name, skill_id: sid,
+                                              cost: meta[:cost],
                                               inflict: meta[:inflict], chance: meta[:chance],
                                               variance: meta[:variance] || 0,
                                               attributes: meta[:attributes])
@@ -3661,13 +3665,13 @@ class RPG2k
       # composed English for any field the database leaves blank — an
       # English-release table with half the battle terms empty still reads.
       def battle_action_body(e)
-        # A skill and an item announce themselves with their *own* sentence
-        # (`using_message1` / `using_message2`, `use_item`), which is a separate
-        # unread field and a separate change. Until then they keep the composed
-        # wording, because dropping to the bare damage line would lose the one
-        # thing that names what was cast. Same for "does nothing", which RPG_RT
-        # words from the state that caused it rather than from a term.
-        return [battle_action_line(e)] if e[:recover] || e[:skill] || e[:nothing]
+        # An item announces itself with the `use_item` term, still unread, and
+        # "does nothing" is worded by the state that caused it rather than by a
+        # term — both keep the composed wording. A skill has its own two
+        # sentences and takes the branch below.
+        return [battle_action_line(e)] if e[:nothing]
+        return battle_skill_body(e) if e[:skill_id]
+        return [battle_action_line(e)] if e[:recover] || e[:skill]
         t = db.respond_to?(:term) ? db.term : nil
         want_start = battle_start_field(e)
         want_result = battle_result_wanted?(e)
@@ -3682,6 +3686,57 @@ class RPG2k
         lines << start if start
         lines << result if result
         lines.empty? ? [battle_action_line(e)] : lines
+      end
+
+      # A skill's own two sentences, then what it did. `using_message1` follows
+      # the caster's name and `using_message2` stands alone as a second line, so
+      # a spell reads 「リトは炎を放った！」 / 「あたりが真っ赤に染まる！」 before
+      # 「スライムに 42 のダメージを与えた！」.
+      #
+      # A skill that achieved nothing takes its own failure sentence instead of a
+      # damage line — the skill row's `failure_message` picks which of the three
+      # 用語 failure lines (or the dodge line) says so.
+      #
+      # A skill row that sets no sentence at all keeps the composed wording, for
+      # the same reason a blank term does: the bare damage line would lose the
+      # only thing naming what was cast.
+      def battle_skill_body(e)
+        bt = Game::States::BattleText
+        row = db.respond_to?(:skill) && db.skill ? db.skill[e[:skill_id]] : nil
+        caster = (e[:recover] ? e[:actor] : e[:attacker]).to_s
+        lines = bt.skill_start(row, caster)
+        return [battle_action_line(e)] if lines.empty?
+        t = db.respond_to?(:term) ? db.term : nil
+        rest = battle_skill_result(t, row, e)
+        return [battle_action_line(e)] unless rest
+        lines + rest
+      rescue StandardError => ex
+        $stderr.puts "[RPG2k] skill message lookup failed: #{ex.message}"
+        [battle_action_line(e)]
+      end
+
+      # What the skill did: the damage / dodge line for an attack, nothing extra
+      # for a recovery that worked, and the failure sentence for one that did
+      # not. nil when a needed sentence is missing, so the caller falls back
+      # whole rather than printing half of one.
+      def battle_skill_result(t, row, e)
+        bt = Game::States::BattleText
+        return [] if e[:target].nil?
+        if skill_achieved_nothing?(e)
+          line = bt.skill_failure(t, row, e[:target].to_s)
+          return line ? [line] : nil
+        end
+        return [] if e[:recover]
+        return battle_result_line(t, e) ? [battle_result_line(t, e)] : nil
+      end
+
+      # A skill with nothing to show for itself: a heal that restored no HP or SP
+      # and cured nothing, or an attack that was dodged.
+      def skill_achieved_nothing?(e)
+        return true if e[:missed]
+        return false unless e[:recover]
+        (e[:recover_hp] || 0) <= 0 && (e[:recover_mp] || 0) <= 0 &&
+          (e[:cured] || []).empty? && (e[:inflicted] || []).empty?
       end
 
       # Which term words this entry's "so-and-so did a thing" line, or nil when

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8249,6 +8249,42 @@ check 'a blank or missing term yields nil rather than a bare name' do
      'a table without the field'
 end
 
+# A skill has a voice of its own where a plain attack has only a term.
+FakeSkillMsg = Struct.new(:using_message1, :using_message2, :failure_message)
+
+check 'a skill names itself: the first line takes the caster, the second stands alone' do
+  sk = FakeSkillMsg.new('は炎を放った！', 'あたりが真っ赤に染まる！', 0)
+  eq ['リトは炎を放った！', 'あたりが真っ赤に染まる！'], BT.skill_start(sk, 'リト')
+end
+
+check 'a skill with only a first sentence gives one line' do
+  eq ['リトは炎を放った！'],
+     BT.skill_start(FakeSkillMsg.new('は炎を放った！', '', 0), 'リト')
+end
+
+check 'a skill with no sentence at all gives none' do
+  eq [], BT.skill_start(FakeSkillMsg.new('', '', 0), 'リト')
+  eq [], BT.skill_start(nil, 'リト'), 'and so does a missing row'
+end
+
+# failure_message indexes the three 用語 failure lines; 3 borrows the dodge line.
+check 'a skill picks which failure sentence says it did nothing' do
+  terms = Struct.new(:skill_failure_a, :skill_failure_b, :skill_failure_c, :dodge)
+            .new('には効かなかった！', 'は平気だった！', 'は眠らなかった！',
+                 'は身をかわした！')
+  eq 'スライムには効かなかった！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 0), 'スライム')
+  eq 'スライムは平気だった！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 1), 'スライム')
+  eq 'スライムは眠らなかった！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 2), 'スライム')
+  eq 'スライムは身をかわした！',
+     BT.skill_failure(terms, FakeSkillMsg.new('', '', 3), 'スライム'),
+     'index 3 borrows the dodge line'
+  eq 'スライムには効かなかった！',
+     BT.skill_failure(terms, nil, 'スライム'), 'no row falls to the first line'
+end
+
 # -- chipset terrain tags -----------------------------------------------------
 
 FakeChipsetRow = Struct.new(:name, :chipset_name, :passable_data_lower,

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -221,7 +221,22 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0)
                          actor_damaged: 'のダメージを受けた！',
                          enemy_undamaged: 'にダメージを与えられない！',
                          actor_undamaged: 'はダメージを受けていない！',
-                         dodge: 'は身をかわした！'),
+                         dodge: 'は身をかわした！',
+                         skill_failure_a: 'には効かなかった！',
+                         skill_failure_b: 'は平気だった！',
+                         skill_failure_c: 'は眠らなかった！'),
+    # Skill rows for the battle log: RPG2000 gives each skill its own two
+    # sentences. Skill 8 sets both, 9 only the first, 10 neither (an
+    # English-release row), and 11 picks the second failure sentence.
+    skill: { 8 => OpenStruct.new(name: 'Fire', using_message1: 'は炎を放った！',
+                                 using_message2: 'あたりが真っ赤に染まる！',
+                                 failure_message: 0),
+             9 => OpenStruct.new(name: 'Heal', using_message1: 'は光をまとった！',
+                                 using_message2: '', failure_message: 0),
+             10 => OpenStruct.new(name: 'Mute', using_message1: '',
+                                  using_message2: '', failure_message: 0),
+             11 => OpenStruct.new(name: 'Sleep', using_message1: 'は呪文を唱えた！',
+                                  using_message2: '', failure_message: 2) },
     # The state table the battle status window and action banner read: a name, a
     # palette colour, the priority that decides which one a battler shows, and
     # RPG2000's own sentences for it landing and lifting. State 5 deliberately
@@ -3683,6 +3698,74 @@ check 'the state sentences still follow the action ones' do
                      { attacker: 'Slime', target: 'Hero', damage: 7,
                        inflicted: [3], target_ally: true })
   eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！', 'Hero is poisoned!'], lines
+end
+
+check 'a skill announces itself with its own two sentences, then the damage' do
+  scene, = battle_at_command
+  eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
+      'Slimeに 42 のダメージを与えた！'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 42, skill: 'Fire',
+                  skill_id: 8, target_ally: false })
+end
+
+check 'a skill with only a first sentence gives one line before the damage' do
+  scene, = battle_at_command
+  eq ['Heroは光をまとった！', 'Slimeに 5 のダメージを与えた！'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 5, skill: 'Heal',
+                  skill_id: 9, target_ally: false })
+end
+
+check 'a skill row with no sentence keeps the composed line' do
+  scene, = battle_at_command
+  eq ["Hero's Mute hits Slime for 5"],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 5, skill: 'Mute',
+                  skill_id: 10, target_ally: false })
+end
+
+check 'a skill that misses takes its own failure sentence, not the damage line' do
+  scene, = battle_at_command
+  eq ['Heroは呪文を唱えた！', 'Slimeは眠らなかった！'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 0, missed: true,
+                  skill: 'Sleep', skill_id: 11, target_ally: false })
+end
+
+check 'a heal that restored nothing reads as a failure' do
+  scene, = battle_at_command
+  eq ['Heroは光をまとった！', 'Heroには効かなかった！'],
+     scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
+                  target: 'Hero', recover_hp: 0, recover_mp: 0,
+                  cured: [], target_ally: true })
+end
+
+check 'a heal that worked says only what it was, not that it failed' do
+  scene, = battle_at_command
+  eq ['Heroは光をまとった！'],
+     scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
+                  target: 'Hero', recover_hp: 30, recover_mp: 0,
+                  cured: [], target_ally: true })
+end
+
+check 'a skill still trails the states it landed' do
+  scene, = battle_at_command
+  eq ['Heroは炎を放った！', 'あたりが真っ赤に染まる！',
+      'Slimeに 7 のダメージを与えた！', 'Slime looks ill!'],
+     scene.send(:battle_action_lines,
+                { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+                  skill_id: 8, inflicted: [3], target_ally: false })
+end
+
+check 'an item keeps its composed line: use_item is still unread' do
+  scene, = battle_at_command
+  ok scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Potion', item_id: 3,
+                  target: 'Hero', recover_hp: 30, target_ally: true })
+     .first.include?('Potion')
 end
 
 check 'the action banner announces the states an action landed and lifted' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -913,6 +913,50 @@ def check_terms(dir)
     end
   end
 
+  # A skill's own two sentences, against the real skill table. Only a real game
+  # can say these are predicates the caster's name goes in front of (the first)
+  # and a standalone line (the second) -- a fixture is written to match the code.
+  first = []
+  second = []
+  failures = Hash.new(0)
+  db[DB_SKILL]&.each do |id, sk|
+    first << id unless sk.using_message1.to_s.empty?
+    second << id unless sk.using_message2.to_s.empty?
+    failures[sk.failure_message || 0] += 1
+  end
+  puts format('   skills: %d with a first sentence, %d with a second; ' \
+              'failure_message %s',
+              first.size, second.size,
+              failures.sort.map { |k, v| "#{k}:#{v}" }.join(' '))
+
+  unless first.empty?
+    check "#{name}: every skill sentence composes the way RPG_RT prints it" do
+      first.each do |id|
+        sk = db[DB_SKILL][id]
+        lines = bt.skill_start(sk, 'リト')
+        eq "リト#{sk.using_message1}", lines[0], "skill ##{id} (#{sk.name})"
+        if sk.using_message2.to_s.empty?
+          eq 1, lines.size, "skill ##{id} has only a first line"
+        else
+          # The second line stands alone -- no name in front of it.
+          eq sk.using_message2, lines[1], "skill ##{id} second line"
+          ok !lines[1].start_with?('リト'), 'and it is not prefixed'
+        end
+      end
+    end
+
+    check "#{name}: every skill's failure_message names a real 用語 line" do
+      db[DB_SKILL].each do |id, sk|
+        i = sk.failure_message || 0
+        ok i >= 0 && i < Game::States::BattleText::FAILURE_TERMS.size,
+           "skill ##{id} (#{sk.name}) failure_message #{i} is in range"
+        line = bt.skill_failure(terms, sk, 'スライム')
+        ok line && line.start_with?('スライム'),
+           "skill ##{id} composes a failure sentence"
+      end
+    end
+  end
+
   return unless bt.term(terms, :enemy_damaged) && bt.term(terms, :actor_damaged)
   check "#{name}: the damage sentence differs by side, and carries the number" do
     foe = bt.damage(terms, 'スライム', 42, false)


### PR DESCRIPTION
**Stacked on #418** — based on `claude/rpg2k-battle-log-terms` so the diff shows only this change. GitHub will retarget it to `master` once #418 merges.

#418 took the battle log's *action* lines from the 用語 table and explicitly held skills back. This is that follow-up.

## A skill does not borrow a term — it has two sentences of its own

Which is the whole reason a spell reads differently from a sword swing:

| | skills with `using_message1` | with `using_message2` |
|---|---|---|
| Nepheshel | **229** of 306 | **18** |
| mtf-meido-action | **122** of 134 | 0 |

The two compose **differently**, and that asymmetry is the rule worth recording. `using_message1` follows the caster's name like every other predicate; `using_message2` **stands alone** as a second line — EasyRPG's `GetSkillSecondStartMessage2k` returns the field with nothing in front of it. So a spell reads:

```
リトは炎を放った！
あたりが真っ赤に染まる！
スライムに 42 のダメージを与えた！
```

A caster and then a scene, not the caster twice. Prefixing the second line would have been the obvious guess and it's wrong.

## A skill that achieved nothing says so in its own way

It takes its own failure sentence instead of a damage line, and which one is again the row's choice: `failure_message` indexes the three 用語 failure lines, with **3 borrowing the dodge line**. All four values are in real use:

| | 0 | 1 | 2 | 3 |
|---|---|---|---|---|
| Nepheshel | 255 | 7 | 1 | **43** |
| mtf-meido-action | 116 | 8 | 4 | **6** |

So the index-3 case is not a theoretical branch. "Achieved nothing" means a miss, or a recovery that restored no HP or SP and cured and inflicted nothing.

## Fallback and plumbing

A skill row with no sentence keeps the composed English — the same all-or-nothing rule a blank term takes in #418, for the same reason: the bare damage line would lose the only thing naming what was cast. 77 of Nepheshel's own skills set nothing.

This needed the skill's **id** on the log entry, which carried only its name, so `command_skill` / `command_skill_all` take a `skill_id:` and the enemy AI path sets it from its own action.

**An item still keeps its composed line.** Its sentence is the `use_item` term rather than a field of its own, and the RPG2000 branch of `GetItemStartMessage2k` is a different shape from everything here; left for its own change.

## Verification

All 14 `scripts/*_check.rb` suites pass. 17 new checks on top of #418's:

- `rpg2k_logic_check.rb` (559, +4): both sentences and the asymmetry between them, a skill with only the first, one with neither, a missing row, and each of the four `failure_message` values including the dodge-borrowing one.
- `rpg2k_scene_check.rb` (216, +8): the log a real `Scene::Map` produces for a skill with both sentences, with one, with none, one that missed, a heal that restored nothing and one that worked, a skill's states still trailing it, and an item keeping its line.
- `rpg2k_testbed_logic_check.rb` (94, +6): composes **every** real skill sentence in both games — asserting the second line is *not* prefixed with the caster's name, which only real text can establish — and checks every skill's `failure_message` indexes a 用語 line the table really has.

See the addendum to `docs/adr/0036-battle-log-in-the-games-own-words.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_