### PR TITLE
Say what the potion did

### DIFF
--- a/changelog.d/item-and-recovery-messages.added.md
+++ b/changelog.d/item-and-recovery-messages.added.md
@@ -1,0 +1,13 @@
+- **A potion says what it did.** An item borrows the `use_item` term rather than
+  carrying a sentence of its own, and it is the one battle line RPG2000 builds
+  from two names — 「リトはポーションを使った！」 is the caster, は, the item and
+  the term. What a heal restored now reads in the game's own words too
+  (「リトのＨＰが 30 回復した！」), which the skill sentences left blank: a working
+  recovery printed its skill line and then nothing. The pool name comes from the
+  用語 `hp` / `mp` field rather than a literal — Nepheshel writes them full-width
+  as ＨＰ / ＭＰ and mtf-meido-action as HP / MP, so a hard-coded "HP" would be
+  wrong in exactly one of the two test beds — and a heal that filled both pools
+  says so once per pool. An item that did nothing keeps the composed wording,
+  since unlike a skill it has no `failure_message` to pick a sentence with. The
+  battle log's only remaining invention is the critical-hit line. See the second
+  addendum to ADR 0036.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -812,9 +812,18 @@ The work below is roughly ordered by the critical path to a walkable game
   `command_skill` / `command_skill_all` take a `skill_id:` and the enemy AI path
   sets it from its own action. A skill row with no sentence keeps the composed
   wording, as a blank term does.
-  Still held back on purpose: an **item** keeps its composed line
-  until the `use_item` term is read — a different shape from everything here —
-  and the **critical** line is left alone
+  **And a potion says what it did**: an item borrows the `use_item` term rather
+  than carrying a sentence of its own, and it is the one line RPG2000 builds from
+  *two* names — 「リトはポーションを使った！」 is the caster, は, the item and the
+  term. What a heal restored reads in the game's words too
+  (「リトのＨＰが 30 回復した！」), which the skill sentences had left blank. The
+  pool name comes from the 用語 `hp` / `mp` field rather than a literal —
+  Nepheshel writes them full-width as ＨＰ / ＭＰ and mtf as HP / MP, so a
+  hard-coded "HP" would be wrong in exactly one of the two test beds — and a heal
+  filling both pools says so once per pool. An item that did nothing keeps the
+  composed wording, since unlike a skill it has no `failure_message` to pick a
+  sentence with.
+  Still held back on purpose: the **critical** line is left alone
   because which side keys `actor_critical` / `enemy_critical` is genuinely
   unclear — EasyRPG picks `actor_critical` when the *target* is an ally, while
   会心 / 痛恨 read as the *attacker's* side, and both games fill both fields with

--- a/docs/adr/0036-battle-log-in-the-games-own-words.md
+++ b/docs/adr/0036-battle-log-in-the-games-own-words.md
@@ -146,3 +146,42 @@ keeping its line) and by `scripts/rpg2k_testbed_logic_check.rb`, which composes
 **every** real skill sentence in both games — asserting the second line is not
 prefixed with the caster's name — and checks every skill's `failure_message`
 indexes a 用語 line the table really has.
+
+## Addendum: what the potion did
+
+Date: 2026-08-06
+
+The second held-back item is now done, and with it the line that says what a
+heal actually restored — which the skill addendum above left blank, since a
+working recovery printed its skill sentence and then nothing.
+
+**An item borrows the `use_item` term** rather than carrying a sentence of its
+own, and it is the one line RPG2000 builds from *two* names:
+`caster + は + item + term` → 「リトはポーションを使った！」. (The `using_message`
+field on the item row is an int selecting a battle-animation layout, not a
+string; no RPG2000 item carries a sentence. Both test beds set `use_item` to
+「を使った！」.)
+
+**The recovery line names its pool from the table**: `name + の + pool + が␠ +
+amount + ␠ + hp_recovery` → 「リトのＨＰが 30 回復した！」, EasyRPG's
+`GetHpSpRecoveredMessage`. The pool name is the 用語 `hp` / `mp` field, not a
+literal — Nepheshel writes them full-width as ＨＰ / ＭＰ and mtf-meido-action as
+HP / MP, so a hard-coded "HP" would be wrong in exactly one of the two test beds.
+A heal that filled both pools says so once per pool.
+
+**An item that did nothing keeps the composed line.** Unlike a skill it has no
+`failure_message` to choose a sentence with, so RPG2000 gives it none, and the
+composed wording still says more than a bare 「使った！」 would.
+
+With this the battle log's only remaining invention is the critical-hit line,
+held back for the reason given in the base decision — which is a question about
+what RPG_RT does, not one this runtime can settle by reading more fields.
+
+Covered by `scripts/rpg2k_logic_check.rb` (the item line's two names, the
+recovery line's pool name from the table in both a full-width and an ASCII
+table, and nil rather than half a sentence when either the term or the pool name
+is blank), by `scripts/rpg2k_scene_check.rb` (a heal that filled one pool and one
+that filled both, an item that restored HP, one that only cured — where the state
+sentence carries it — and one that did nothing) and by
+`scripts/rpg2k_testbed_logic_check.rb`, which builds both lines out of each real
+term table.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4797,6 +4797,28 @@ module Game
       FAILURE_TERMS = [:skill_failure_a, :skill_failure_b, :skill_failure_c,
                        :dodge].freeze
 
+      # An item has no sentence of its own — it borrows the `use_item` term, and
+      # is the one line RPG2000 builds from *two* names: 「リトはポーションを使っ
+      # た！」 is the caster, は, the item, and the term. (`item.using_message` is
+      # an int selecting a battle animation layout, not a string; no RPG2000 item
+      # carries a sentence.)
+      def self.item_start(terms, caster_name, item_name)
+        t = term(terms, :use_item)
+        t && "#{caster_name}#{ALLY_PARTICLE.strip}#{item_name}#{t}"
+      end
+
+      # 「リトのＨＰが 30 回復した！」 — what a potion or a cure spell restored.
+      # `points` is the 用語 name of the pool (`hp` / `mp`, which Nepheshel writes
+      # full-width as ＨＰ / ＭＰ and mtf-meido-action as HP / MP), and the shape
+      # is EasyRPG's `GetHpSpRecoveredMessage`: name, の, pool, "が ", the amount,
+      # a space, then the term.
+      def self.recovered(terms, target_name, value, points)
+        t = term(terms, :hp_recovery)
+        pool = term(terms, points)
+        return nil unless t && pool
+        "#{target_name}の#{pool}が #{value} #{t}"
+      end
+
       def self.skill_failure(terms, skill_row, target_name)
         i = skill_row && skill_row.respond_to?(:failure_message) ?
               skill_row.failure_message : nil

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -3671,6 +3671,7 @@ class RPG2k
         # sentences and takes the branch below.
         return [battle_action_line(e)] if e[:nothing]
         return battle_skill_body(e) if e[:skill_id]
+        return battle_item_body(e) if e[:item_id]
         return [battle_action_line(e)] if e[:recover] || e[:skill]
         t = db.respond_to?(:term) ? db.term : nil
         want_start = battle_start_field(e)
@@ -3726,8 +3727,49 @@ class RPG2k
           line = bt.skill_failure(t, row, e[:target].to_s)
           return line ? [line] : nil
         end
-        return [] if e[:recover]
+        return battle_recovery_lines(t, e) if e[:recover]
         return battle_result_line(t, e) ? [battle_result_line(t, e)] : nil
+      end
+
+      # An item borrows the `use_item` term rather than carrying a sentence of
+      # its own -- 「リトはポーションを使った！」 is the only line RPG2000 builds
+      # from two names -- and then says what it restored.
+      def battle_item_body(e)
+        bt = Game::States::BattleText
+        t = db.respond_to?(:term) ? db.term : nil
+        start = bt.item_start(t, e[:actor].to_s, e[:source].to_s)
+        return [battle_action_line(e)] unless start
+        rest =
+          if skill_achieved_nothing?(e)
+            # An item that did nothing has no `failure_message` to choose with,
+            # so RPG2000 has no sentence for it: the composed line still says
+            # more than the bare "used it" would.
+            nil
+          else
+            battle_recovery_lines(t, e)
+          end
+        return [battle_action_line(e)] unless rest
+        [start] + rest
+      rescue StandardError => ex
+        $stderr.puts "[RPG2k] item message lookup failed: #{ex.message}"
+        [battle_action_line(e)]
+      end
+
+      # What a heal restored: one line per pool it filled, in the game's own
+      # words (「リトのＨＰが 30 回復した！」). [] when it restored nothing but
+      # cured something -- the state sentences carry that -- and nil when the
+      # database has no wording, so the caller falls back whole.
+      def battle_recovery_lines(t, e)
+        bt = Game::States::BattleText
+        name = e[:target].to_s
+        lines = []
+        [[:hp, e[:recover_hp]], [:mp, e[:recover_mp]]].each do |pool, amount|
+          next unless amount && amount > 0
+          line = bt.recovered(t, name, amount, pool)
+          return nil unless line
+          lines << line
+        end
+        lines
       end
 
       # A skill with nothing to show for itself: a heal that restored no HP or SP

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8285,6 +8285,32 @@ check 'a skill picks which failure sentence says it did nothing' do
      BT.skill_failure(terms, nil, 'スライム'), 'no row falls to the first line'
 end
 
+# An item borrows the use_item term rather than carrying a sentence, and is the
+# one line RPG2000 builds from two names.
+check 'an item line is the caster, the item and the term' do
+  t = Struct.new(:use_item).new('を使った！')
+  eq 'リトはポーションを使った！', BT.item_start(t, 'リト', 'ポーション')
+  eq nil, BT.item_start(Struct.new(:use_item).new(''), 'リト', 'ポーション')
+end
+
+# 「リトのＨＰが 30 回復した！」 — name, の, the pool's own 用語 name, が, the
+# amount, the term. Both pool names come from the table too, which is why
+# Nepheshel's read ＨＰ / ＭＰ full-width and mtf's read HP / MP.
+check 'a recovery names the pool from the table, not from a literal' do
+  t = Struct.new(:hp_recovery, :hp, :mp).new('回復した！', 'ＨＰ', 'ＭＰ')
+  eq 'リトのＨＰが 30 回復した！', BT.recovered(t, 'リト', 30, :hp)
+  eq 'リトのＭＰが 12 回復した！', BT.recovered(t, 'リト', 12, :mp)
+  ascii = Struct.new(:hp_recovery, :hp, :mp).new('回復した！', 'HP', 'MP')
+  eq 'リトのHPが 30 回復した！', BT.recovered(ascii, 'リト', 30, :hp)
+end
+
+check 'a recovery with no wording yields nil rather than half a sentence' do
+  no_term = Struct.new(:hp_recovery, :hp, :mp).new('', 'ＨＰ', 'ＭＰ')
+  eq nil, BT.recovered(no_term, 'リト', 30, :hp)
+  no_pool = Struct.new(:hp_recovery, :hp, :mp).new('回復した！', '', '')
+  eq nil, BT.recovered(no_pool, 'リト', 30, :hp), 'the pool name matters too'
+end
+
 # -- chipset terrain tags -----------------------------------------------------
 
 FakeChipsetRow = Struct.new(:name, :chipset_name, :passable_data_lower,

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -224,7 +224,9 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0)
                          dodge: 'は身をかわした！',
                          skill_failure_a: 'には効かなかった！',
                          skill_failure_b: 'は平気だった！',
-                         skill_failure_c: 'は眠らなかった！'),
+                         skill_failure_c: 'は眠らなかった！',
+                         use_item: 'を使った！', hp_recovery: '回復した！',
+                         hp: 'ＨＰ', mp: 'ＭＰ'),
     # Skill rows for the battle log: RPG2000 gives each skill its own two
     # sentences. Skill 8 sets both, 9 only the first, 10 neither (an
     # English-release row), and 11 picks the second failure sentence.
@@ -3742,13 +3744,52 @@ check 'a heal that restored nothing reads as a failure' do
                   cured: [], target_ally: true })
 end
 
-check 'a heal that worked says only what it was, not that it failed' do
+check 'a heal that worked says what it restored, in the game own words' do
   scene, = battle_at_command
-  eq ['Heroは光をまとった！'],
+  eq ['Heroは光をまとった！', 'HeroのＨＰが 30 回復した！'],
      scene.send(:battle_action_lines,
                 { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
                   target: 'Hero', recover_hp: 30, recover_mp: 0,
                   cured: [], target_ally: true })
+end
+
+check 'a heal that filled both pools says so once per pool' do
+  scene, = battle_at_command
+  eq ['Heroは光をまとった！', 'HeroのＨＰが 30 回復した！',
+      'HeroのＭＰが 12 回復した！'],
+     scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Heal', skill_id: 9,
+                  target: 'Hero', recover_hp: 30, recover_mp: 12,
+                  cured: [], target_ally: true })
+end
+
+check 'an item names itself with the caster, the item and the term' do
+  scene, = battle_at_command
+  eq ['HeroはPotionを使った！', 'HeroのＨＰが 30 回復した！'],
+     scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Potion', item_id: 3,
+                  target: 'Hero', recover_hp: 30, recover_mp: 0,
+                  cured: [], target_ally: true })
+end
+
+check 'an item that only cured says so through the state sentence' do
+  scene, = battle_at_command
+  eq ['HeroはAntidoteを使った！', 'Hero is cured.'],
+     scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Antidote', item_id: 5,
+                  target: 'Hero', recover_hp: 0, recover_mp: 0,
+                  cured: [3], target_ally: true })
+end
+
+check 'an item that did nothing keeps the composed line' do
+  scene, = battle_at_command
+  # RPG2000 gives an item no failure sentence to choose from -- unlike a skill,
+  # it has no failure_message -- so the composed wording still says more.
+  ok scene.send(:battle_action_lines,
+                { recover: true, actor: 'Hero', source: 'Potion', item_id: 3,
+                  target: 'Hero', recover_hp: 0, recover_mp: 0,
+                  cured: [], target_ally: true })
+     .first.include?('no effect')
 end
 
 check 'a skill still trails the states it landed' do
@@ -3758,14 +3799,6 @@ check 'a skill still trails the states it landed' do
      scene.send(:battle_action_lines,
                 { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
                   skill_id: 8, inflicted: [3], target_ally: false })
-end
-
-check 'an item keeps its composed line: use_item is still unread' do
-  scene, = battle_at_command
-  ok scene.send(:battle_action_lines,
-                { recover: true, actor: 'Hero', source: 'Potion', item_id: 3,
-                  target: 'Hero', recover_hp: 30, target_ally: true })
-     .first.include?('Potion')
 end
 
 check 'the action banner announces the states an action landed and lifted' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -957,6 +957,27 @@ def check_terms(dir)
     end
   end
 
+  if bt.term(terms, :use_item) && bt.term(terms, :hp_recovery)
+    check "#{name}: the item and recovery lines build from the real table" do
+      it = db[DB_ITEM] && db[DB_ITEM][1]
+      if it
+        line = bt.item_start(terms, 'リト', it.name)
+        ok line.start_with?("リトは#{it.name}"),
+           'the caster, は and the item name lead it'
+        ok line.end_with?(terms.use_item), 'and the term closes it'
+      end
+      # The pool name is the table's too, which is why one game reads ＨＰ and
+      # the other HP -- a literal "HP" would be wrong in exactly one of them.
+      %i[hp mp].each do |pool|
+        next unless bt.term(terms, pool)
+        r = bt.recovered(terms, 'リト', 30, pool)
+        ok r.include?(terms.send(pool).to_s), "the #{pool} line names the pool"
+        ok r.include?('30') && r.end_with?(terms.hp_recovery),
+           'with the amount and the term'
+      end
+    end
+  end
+
   return unless bt.term(terms, :enemy_damaged) && bt.term(terms, :actor_damaged)
   check "#{name}: the damage sentence differs by side, and carries the number" do
     foe = bt.damage(terms, 'スライム', 42, false)


### PR DESCRIPTION
Finishes the battle log's two remaining fields, and the line the skill sentences left blank: a working recovery printed its skill line and then **nothing at all**.

## An item borrows the term — and is the one line built from two names

An item carries no sentence of its own. It uses the `use_item` term, and RPG2000 builds the line from *two* names, which nothing else in the log does:

```
リトはポーションを使った！     ← caster + は + item + use_item
リトのＨＰが 30 回復した！
```

(The `using_message` field on the item row is an **int** selecting a battle-animation layout, not a string — no RPG2000 item carries a sentence. Both test beds set `use_item` to 「を使った！」.)

## The recovery line names its pool from the table

`name + の + pool + が␠ + amount + ␠ + hp_recovery`, per EasyRPG's `GetHpSpRecoveredMessage`. The pool name is the 用語 `hp` / `mp` field, **not a literal**:

| | `hp` | `mp` |
|---|---|---|
| Nepheshel | ＨＰ (full-width) | ＭＰ |
| mtf-meido-action | HP | MP |

A hard-coded `"HP"` would be wrong in exactly one of the two test beds — which is the whole reason this is a field and not a string in the code. A heal that filled both pools says so once per pool.

## An item that did nothing keeps the composed line

Unlike a skill it has no `failure_message` to choose a sentence with, so RPG2000 gives it none, and the composed wording still says more than a bare 「使った！」 would. An item that only *cured* says so through the state sentence, which already carries that.

## What's left

The battle log's only remaining invention is the critical-hit line, held back for the reason ADR 0036 gives — which side keys `actor_critical` / `enemy_critical` is a question about what RPG_RT does, not one this runtime can settle by reading more fields.

## Verification

All 14 `scripts/*_check.rb` suites pass. 13 new checks, all confirmed to fail against the pre-fix code (4 logic, 5 scene, 4 test-bed):

- `rpg2k_logic_check.rb` (562, +3): the item line's two names, the recovery line's pool name from the table in both a full-width and an ASCII table, and nil rather than half a sentence when either the term or the pool name is blank.
- `rpg2k_scene_check.rb` (219, +5): a heal that filled one pool and one that filled both, an item that restored HP, one that only cured, and one that did nothing.
- `rpg2k_testbed_logic_check.rb` (97, +3): builds both lines out of each **real** term table, checking the pool name that comes back is the one that table holds.

See the second addendum to `docs/adr/0036-battle-log-in-the-games-own-words.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_