### PR TITLE
Say how to check formatting without inventing a diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,15 @@
   result works rather than just linking: `--rgss_effect_probe` under Xvfb, which
   measures real pixels, followed by both game boot checks on real project data.
 
+- **Formatting is checked by `build`, not by a lint job** — pre-commit runs there
+  as a background step, so a formatting slip fails `build` with no compile error
+  in the log. Locally, `clang-format --dry-run --Werror <file>`, run **from
+  inside the repository**: clang-format finds `.clang-format` by walking up from
+  the file's own directory, so checking a copy under `/tmp` quietly falls back to
+  LLVM defaults and invents a diff of hundreds of unrelated lines. The script's
+  header notes the two smaller traps as well — a genuine but narrow clang-format
+  version difference, and why a line-length grep is not a substitute.
+
 ### Play in the browser (WebAssembly)
 
 - The runtime cross-compiles to WebAssembly with Emscripten and ships a page

--- a/changelog.d/native-build-format-notes.changed.md
+++ b/changelog.d/native-build-format-notes.changed.md
@@ -1,0 +1,12 @@
+- **`scripts/native-build-without-nix.bash` now says how to check formatting.**
+  The `build` job runs pre-commit as a background step, so a formatting slip
+  fails `build` with no compile error in the log. The working local check is
+  `clang-format --dry-run --Werror <file>` run *inside* the repository —
+  clang-format locates `.clang-format` by walking up from the file's own
+  directory, so checking a copy under `/tmp` falls back to LLVM defaults
+  (`PointerAlignment: Right` where this repo sets `Left`) and fabricates a diff
+  of hundreds of unrelated lines. Also recorded: the narrow real version
+  difference (clang-format 18 flags three pre-existing lines in
+  `mruby-rgss/src/lib.cxx` that CI accepts), and why a line-length grep is not a
+  substitute — several tracked files hold lines clang-format cannot break, and
+  `awk` counts bytes, so an em-dash makes a legal line look over-length.

--- a/scripts/native-build-without-nix.bash
+++ b/scripts/native-build-without-nix.bash
@@ -36,6 +36,39 @@ set -euo pipefail
 #   VERIFY=0 scripts/native-build-without-nix.bash         # build only, no probe/boot checks
 #
 # Needs root for the apt step (skipped when the headers are already present).
+#
+# ---------------------------------------------------------------------------
+# Checking formatting here, which is fiddlier than it looks
+#
+# The `build` job runs pre-commit as a background step, so a formatting slip
+# fails CI as `build` rather than as a lint job -- worth knowing before you go
+# looking for a compile error that is not there. Its clang-format hook is
+# `language: system`, i.e. whatever `clang-format` is on PATH, and this
+# container's is not the version CI's Nix `clang-tools` supplies.
+#
+# The check that works:
+#
+#   clang-format --dry-run --Werror <file>      # run from inside the repo
+#
+# Three traps, in the order they will catch you:
+#
+#   * Run it *inside the repository*. clang-format finds `.clang-format` by
+#     walking up from the file's own directory, so checking a copy in /tmp
+#     silently formats to LLVM defaults instead -- `PointerAlignment: Right`
+#     where this repo sets Left -- and produces a diff of hundreds of unrelated
+#     lines that looks like a version disagreement and is not one.
+#   * There *is* a real version difference on top of that, but it is small: this
+#     container's clang-format 18 flags three pre-existing lines in
+#     mruby-rgss/src/lib.cxx (`double T::* Field` twice, `const int
+#     (*quad_table)[4][2]`) that CI is happy with. Read the violations your
+#     change caused and leave the rest alone; do not run `clang-format -i` over
+#     a whole file.
+#   * A plain line-length grep is not a substitute. `ColumnLimit` is 80, but
+#     several tracked files hold longer lines that clang-format has no way to
+#     break and accepts as they are (include/lv_conf.h, mruby-mvjs/src/*.cxx).
+#     Length also has to be counted in *characters*: awk counts bytes, and an
+#     em-dash is three of them, so `awk 'length($0) > 80'` reports comment lines
+#     that are perfectly legal.
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 build_dir="${1:-$root/build}"


### PR DESCRIPTION
## Why

`scripts/native-build-without-nix.bash` gives this container compile, render and boot verification — but not the formatting gate, and the gate is where #416 actually failed CI. `build` runs pre-commit as a background step, so a formatting slip fails **`build`** with no compile error anywhere in the log. That alone is worth writing down.

## The check, and the qualifier that matters

```sh
clang-format --dry-run --Werror <file>   # run from INSIDE the repository
```

clang-format locates `.clang-format` by walking up from the **file's own directory**. Check a copy under `/tmp` and it silently falls back to LLVM defaults — `PointerAlignment: Right` where this repo sets `Left` — and fabricates a diff of hundreds of unrelated lines.

## Correcting the record on #416

I made exactly that mistake while fixing #416, and reported from it. That PR's description and commit message claim clang-format wanted `Bitmap &target` over the repo's `Bitmap& target`, offered as evidence of a version disagreement. **It was an artifact of testing outside the repo.** With the repo's own config, clang-format here wants no such thing.

The conclusion I drew from it — don't run `clang-format -i` over a whole file — happens to still be right, but for a much narrower reason than I gave.

## What the real version difference is

This container's clang-format 18 flags **three** pre-existing lines in `mruby-rgss/src/lib.cxx` that CI accepts:

- `template <class T, double T::* Field>` (twice)
- `const int (*quad_table)[4][2]`

So: read the violations your change caused, leave the rest alone.

## Why a line-length grep is not a substitute

It's the obvious thing to reach for, and it's wrong twice over:

- `ColumnLimit` is 80, but several tracked files hold longer lines clang-format has no way to break and accepts as they are — `include/lv_conf.h`, `mruby-mvjs/src/*.cxx`. I confirmed all of them are clang-format-clean.
- Length has to be counted in **characters**. `awk` counts bytes and an em-dash is three, so `awk 'length($0) > 80'` reports **eight** violations in `lib.cxx` where there is **one**. Trusting it would mean "fixing" seven innocent lines.

## Verification

Docs only — the script's header, a README bullet, and a changelog fragment. Checked with the command it documents (no C++ files changed) and with the `trailing-whitespace` / `end-of-file-fixer` hooks.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_