### PR TITLE
Graphics.frame_reset does what a game calls it for

### DIFF
--- a/changelog.d/rgss-frame-reset.added.md
+++ b/changelog.d/rgss-frame-reset.added.md
@@ -1,0 +1,8 @@
+- **`Graphics.frame_reset` does what a game calls it for.** RGSS's frame pacing
+  carries an absolute deadline, so after something slow — a map build, a big load
+  — it owes a burst of short frames, which is exactly what a game calls
+  `frame_reset` to avoid (`Scene_Map#transfer_player` and every map build do).
+  It was a `warn_stub`, so every booted game printed "not implemented yet" on its
+  way to the title screen: noise in the one log that is meant to be a bug list.
+  It now drops the deadline, and the next frame starts counting from then. With
+  it, a clean RGSS boot logs no stub warnings at all.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -34,7 +34,9 @@ These are complete enough for the stock scripts:
   [VX gap](rpgvx-rgss-api-gap.md), where it landed — the code is shared).
   `transition`'s `filename`/`vague` form dissolves through the transition
   graphic, so a battle transition is the shape its author drew rather than a
-  fade. _`frame_reset` is still a `warn_stub` no-op._
+  fade. `frame_reset` drops the pacing deadline, which is what a game calls it
+  for — after something slow, so the frames that follow are not shortened to
+  catch up. **No stub warning is left in a clean boot log.**
 - **`Input`** — all key constants (`A`/`B`/`C`/`X`/`Y`/`Z`/`L`/`R`/`UP`…`F9`),
   `update`, `press?`, `trigger?` (~68), `repeat?` (~34), `press`/`release`,
   `dir4`/`dir8`.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1194,9 +1194,6 @@ module RGSS
         nil
       end
 
-      def frame_reset
-        RGSS.warn_stub("Graphics.frame_reset")
-      end
     end
   end
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2619,6 +2619,30 @@ mrb_value input_push(mrb_state* M, mrb_value self) {
   return mrb_nil_value();
 }
 
+// Frame pacing state, shared with Graphics.frame_reset below. See the long note
+// in gfx_update for why the deadline is absolute rather than "sleep whatever is
+// left of a frame".
+uint32_t g_next_frame = 0;
+uint32_t g_period_acc = 0;
+bool g_paced = false;
+
+// RGSS Graphics.frame_reset: "resets the screen refresh timing", called after
+// something slow so the game does not then run fast catching up. The pacing
+// below carries an absolute deadline forward, so after a long stall it owes a
+// burst of short frames -- the very thing a game calls this to avoid. It does
+// re-base itself once it is more than a frame behind, which is why a game could
+// get away without this, but only after spending that frame: `Scene_Map#
+// transfer_player` and every map build call frame_reset precisely so the frame
+// they were on is not the one that pays.
+//
+// Dropping the deadline is the whole implementation: the next update sees
+// !g_paced and starts counting from then.
+mrb_value gfx_frame_reset(mrb_state* M, mrb_value self) {
+  (void)M;
+  g_paced = false;
+  return self;
+}
+
 mrb_value gfx_update(mrb_state* M, mrb_value self) {
   const mrb_value rgss_mod = mrb_obj_value(mrb_module_get(M, "RGSS"));
 
@@ -2732,20 +2756,17 @@ mrb_value gfx_update(mrb_state* M, mrb_value self) {
   // A frame is 1000/60 ms, which is not an integer, so the deadline steps by
   // 17,17,16,... driven by a 1/60-ms remainder accumulator rather than a flat
   // 16 (which would run 4% fast).
-  static uint32_t next_frame = 0;
-  static uint32_t period_acc = 0;
-  static bool paced = false;
   const uint32_t now = lv_tick_get();
-  period_acc += 1000;
-  const uint32_t period = period_acc / 60;
-  period_acc %= 60;
-  if (!paced ||
-      static_cast<int32_t>(now - next_frame) > static_cast<int32_t>(period)) {
-    next_frame = now;
-    paced = true;
+  g_period_acc += 1000;
+  const uint32_t period = g_period_acc / 60;
+  g_period_acc %= 60;
+  if (!g_paced ||
+      static_cast<int32_t>(now - g_next_frame) > static_cast<int32_t>(period)) {
+    g_next_frame = now;
+    g_paced = true;
   }
-  next_frame += period;
-  const int32_t sleep = static_cast<int32_t>(next_frame - lv_tick_get());
+  g_next_frame += period;
+  const int32_t sleep = static_cast<int32_t>(g_next_frame - lv_tick_get());
   if (sleep > 0) {
     // Report the idle wait so the profiler can subtract it: the frame spans the
     // whole main_loop iteration (see RGSS::Profiler.frame), and we want its
@@ -5801,6 +5822,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   // RGSS2+: the rendered screen as a Bitmap. Graphics.freeze/transition are
   // built on it (mrblib/lib.rb), and RGSS.effect_probe measures with it.
   mrb_define_module_function(M, gfx, "snap_to_bitmap", gfx_snap_to_bitmap,
+                             MRB_ARGS_NONE());
+  mrb_define_module_function(M, gfx, "frame_reset", gfx_frame_reset,
                              MRB_ARGS_NONE());
 
   profiler_init(M);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -243,6 +243,46 @@ end
 # game runs at the start of every battle turn — so two battlers whose speeds
 # differed by exactly two ended the game. The speeds below are the ones a real
 # battle produced when it did.
+# Collects what a stub would have written, for the frame_reset test below.
+# Defined before the assert that uses it: mrbtest runs a block as it meets it,
+# so a helper declared further down the file is not there yet.
+class FrameResetErr
+  def initialize(lines); @lines = lines; end
+  def puts(*args); args.flatten.each { |a| @lines << a.to_s }; end
+  def write(s); @lines << s.to_s; end
+  def print(*args); args.each { |a| @lines << a.to_s }; end
+  def flush; end
+end
+
+# RGSS Graphics.frame_reset "resets the screen refresh timing": a game calls it
+# after something slow so the frames that follow are not shortened to catch up.
+# It used to be a warn_stub, which meant every booted game printed
+# "not implemented yet" on its way to the title screen -- noise in the one log
+# that is meant to be the bug list. The pacing it drives is a real absolute
+# deadline (gfx_update), so this is a real method now; what a unit test can see
+# is that it is native, callable and harmless.
+assert "RGSS::Graphics.frame_reset is a real method, not a stub" do
+  assert_true RGSS::Graphics.respond_to?(:frame_reset)
+  # Answers the module, and is safe to call before any frame has been drawn --
+  # a game's Scene_Title calls it before its first Graphics.update.
+  assert_equal RGSS::Graphics, RGSS::Graphics.frame_reset
+  assert_equal RGSS::Graphics, RGSS::Graphics.frame_reset
+
+  # And it says nothing. A stub announces itself once through RGSS.warn_stub;
+  # capturing stderr is how the harnesses check that, and here there must be
+  # nothing to capture.
+  said = []
+  captured = $stderr
+  begin
+    $stderr = FrameResetErr.new(said)
+    RGSS::Graphics.frame_reset
+  ensure
+    $stderr = captured
+  end
+  assert_equal [], said
+end
+
+
 assert "Array#sort survives a comparator that answers -2" do
   speeds = [59, 56, 66, 62, 60, 57]  # 62 and 60 are the pair that killed it
   assert_equal [66, 62, 60, 59, 57, 56], speeds.sort { |a, b| b - a }


### PR DESCRIPTION
`Graphics.frame_reset` was the last `warn_stub` a clean RGSS boot still
produced — every game printed "not implemented yet" on its way to the title
screen, which is noise in the one log that is meant to be the bug list.

It turns out not to be a no-op, because the pacing it drives is real.

## Why it has a job

`gfx_update` paces against an **absolute deadline** rather than sleeping
whatever is left of a frame — ADR 0021's finding, that sleeping the remainder let
`lv_delay_ms`'s overshoot accumulate until 9 ms of work per frame settled at
44 fps instead of 60. After a long stall that deadline is in the past, so the
frames that follow owe catch-up: exactly what a game calls `frame_reset` to
avoid.

The pacing does re-base itself once it is more than a frame behind, which is why
a game could get away without this — but only after spending that frame.
`Scene_Map#transfer_player` and every map build call `frame_reset` precisely so
the frame they are on is not the one that pays.

Dropping the deadline is the whole implementation; the next update sees it unset
and starts counting from then. The pacing state moves to file scope so
`frame_reset` can reach it.

## Verified

On the built engine (which I can now do locally, thanks to #412): the test bed
boots to its map, walks, and opens its own menu with **no stub line anywhere in
the log**.

```
[RPGXP-HOST-SCENE] Scene_Title frame=1
[RPGXP-HOST-SCENE] Scene_Map frame=41
[RPGXP-HOST-MOVE]  start=9,7 end=9,8 moved=true frame=221
[RPGXP-HOST-SCENE] Scene_Menu frame=242
[RPGXP-HOST-MENU]  scene=Scene_Menu opened=true frame=301
[RPGXP-HOST-SCENE] Scene_Item frame=321
```

`mruby_test`, `render_probe`, `error_dump` and `error_report_capture` all pass
locally.

The unit test pins what a test with no display can see: that the method is
native, answers the module, is safe to call before any frame has been drawn (a
game's `Scene_Title` does), and — the point of the change — says nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_