### PR TITLE
Let a character walk behind a roof

### DIFF
--- a/changelog.d/tilemap-priority-strips.added.md
+++ b/changelog.d/tilemap-priority-strips.added.md
@@ -1,0 +1,9 @@
+- **A roof now sorts against the character standing under it.** RMXP's per-tile
+  priority put every priority tile above *every* character, so you always walked
+  in front of tree crowns and rooftops. Priority tiles are now drawn into
+  per-bucket canvas strips keyed on `ty + prio` — the same scale RMXP's own
+  `Game_Character#screen_z` puts characters on — so a character one row lower
+  sorts in front of a roof and one row higher sorts behind it. Strips are five
+  tile rows tall (a bucket can be reached from five different rows), lazily
+  allocated, and pooled by `bucket % 24` so a tall map cannot accumulate them.
+  See ADR 0022.

--- a/changelog.d/tilemap-strip-height-open.changed.md
+++ b/changelog.d/tilemap-strip-height-open.changed.md
@@ -1,0 +1,8 @@
+- **ADR 0022 now records what "one canvas strip per row" has to mean.** The
+  phrase did not say how tall a strip is, and both obvious readings fail: a
+  full-screen canvas per `ty + prio` bucket is 24.6 MiB for one map (21× today's
+  flat above-layer), while a one-tile-row strip cannot hold a bucket at all,
+  since bucket `B` spans rows `B-5 .. B-1`. That same arithmetic bounds a
+  workable strip at five rows. The cheap alternative — bucketing by row and
+  taking the highest priority in it — is ruled out by the test bed: 4 of its 9
+  priority-bearing rows carry more than one distinct priority, one of them three.

--- a/docs/adr/0022-rpgxp-tilemap-priority-layering.md
+++ b/docs/adr/0022-rpgxp-tilemap-priority-layering.md
@@ -77,6 +77,10 @@ spread across **per-row `z` strips** so they interleave with character sprites:
   it. Give the strip a `z` derived from the RMXP rule — the tile's on-screen foot
   row plus its priority — so it sorts into the character `z` continuum:
 
+  > **How tall a strip is, is not settled here — see "Strip height" below.** It
+  > is the one part of this design that has to be decided before implementing,
+  > because the obvious readings are respectively unaffordable and wrong.
+
   ```
   z = (ty + prio) * TILE_SIZE + TILE_SIZE - oy
   ```
@@ -126,6 +130,66 @@ spread across **per-row `z` strips** so they interleave with character sprites:
 Priority is looked up as `priorities[id]` for every tile id (autotile ids 48..383
 and regular ids ≥ 384 alike); an out-of-range id or a nil table is treated as
 priority 0.
+
+## Strip height: open
+
+Added 2026-08-06, before any implementation.
+
+"One canvas strip per row" above does not say how tall a strip is, and both
+readings that first suggest themselves fail. The numbers are for XP's viewport,
+which `Spriteset_Map` creates as `Viewport.new(0, 0, 640, 480)` — and the strips
+are sized from the viewport rect, exactly as the current single above-canvas is.
+Sixteen tile rows are visible (15 whole plus a partial) and priorities run 1..5,
+so `ty + prio` takes up to **21** distinct values.
+
+| reading | cost | verdict |
+|---|---|---|
+| a full-screen canvas per bucket, like today's single above layer | 1.17 MiB × 21 = **24.6 MiB** | unaffordable |
+| a one-tile-row strip per bucket | 80 KiB × 21 = 1.6 MiB | **wrong** — see below |
+| a five-row strip per bucket | 400 KiB × 21 = 8.2 MiB | plausible, still heavy |
+
+The one-row reading is not merely tight, it cannot express the layout. A bucket
+is keyed on `ty + prio`, so bucket `B` holds every tile with `ty = B - prio` for
+`prio` in 1..5 — up to **five different map rows**, each drawing at its own
+screen `y`. One row of pixels cannot hold them.
+
+That same arithmetic bounds the strip, which is where the third row of the table
+comes from: a bucket spans rows `B-5 .. B-1`, so a strip five tile rows tall,
+positioned at `(B - 5) * TILE_SIZE - oy`, covers every tile that can land in it.
+
+8.2 MiB is still seven times what the flat layer costs today, and this code is
+shared with the `psp` and `wio` targets, so the worst case wants to be much
+smaller than the worst case. Two levers, neither costed yet:
+
+- **Lazy allocation.** Only buckets that actually hold a tile need a strip. A map
+  whose tileset only uses priority 1 collapses the bucket set to one per row, and
+  a map with no priority tiles allocates nothing — which is also what keeps the
+  no-priority-table path free.
+- **~~Bucketing by row rather than by `ty + prio`~~ — ruled out by the data.**
+  One strip per *row* (16, not 21), one row tall, taking its `z` from the highest
+  priority it holds would be 1.3 MiB and simple. It is also an approximation: two
+  tiles on the same row with different priorities sort together where RMXP sorts
+  them apart. That looked like it might be harmless in practice, so the test bed
+  was asked — and it is not. Of the XP test bed's priority-bearing map rows,
+  **4 of 9 (44%) carry more than one distinct priority**, one of them three at
+  once:
+
+  | row | priorities present |
+  |---|---|
+  | 3 | 4, 5 |
+  | 4 | 3, 4 |
+  | 5 | **2, 3, 5** |
+  | 6 | 2, 4 |
+
+  So row-bucketing would visibly mis-sort the first map of the only XP project
+  available, not some hypothetical one. (One map, 15 rows — a small sample, and
+  the only sample there is.)
+
+What remains open is therefore narrower: the strip **height**, and how hard to
+lean on lazy allocation to keep the common case cheap. That is a
+memory-against-redraw trade on `psp` / `wio` hardware that cannot be profiled
+from the environment this was written in, so it is left open rather than guessed
+at.
 
 ## Consequences
 

--- a/docs/adr/0022-rpgxp-tilemap-priority-layering.md
+++ b/docs/adr/0022-rpgxp-tilemap-priority-layering.md
@@ -4,7 +4,7 @@ Date: 2026-08-04
 
 ## Status
 
-Proposed
+Accepted — implemented 2026-08-06.
 
 ## Context
 
@@ -185,13 +185,44 @@ smaller than the worst case. Two levers, neither costed yet:
   available, not some hypothetical one. (One map, 15 rows — a small sample, and
   the only sample there is.)
 
-What remains open is therefore narrower: the strip **height**, and how hard to
-lean on lazy allocation to keep the common case cheap. That is a
-memory-against-redraw trade on `psp` / `wio` hardware that cannot be profiled
-from the environment this was written in, so it is left open rather than guessed
-at.
+**Resolved as five-row strips, pooled and lazily allocated.** A strip is
+`TILEMAP_PRIO_SPAN` (5) rows tall and a tile of priority `p` lands at local row
+`5 - p`, which depends only on the priority and not on the row it came from.
+
+Two things the implementation added on top of the sketch above:
+
+- **Strips are pooled by `bucket % 24`, not keyed on the bucket.** Keyed on the
+  absolute bucket, walking down a 200-row map allocates a strip per row and never
+  releases one — 200 canvases for a map that shows twenty. The modulus only has
+  to exceed the number of buckets that can be visible at once (16 rows + 5 span =
+  21), and a slot is reused in place as the map scrolls rather than reallocated,
+  so scrolling costs nothing. The slot records which bucket it currently carries,
+  since that is what its position and `z` derive from.
+- **Only the XP path moved.** The VX / MV tile model routes on `flags & 0x10` and
+  keeps the single flat above-canvas; this ADR is about RMXP's `priorities`, and
+  widening it would have meant changing a second tile model with no test bed for
+  the priority behaviour.
 
 ## Consequences
+
+Measured on the XP test bed, booted under Xvfb:
+
+- **Four strips, not twenty-one.** The visible map allocates buckets 7, 8, 10 and
+  18 — matching the priorities the survey above found on rows 3..6 — so 1.6 MiB
+  of canvases against the flat layer's 1.17 MiB, rather than the 24.6 MiB the
+  naive reading would have cost.
+- **The `z` values are the formula.** Bucket 7 takes `z = 7*32 + 32 - 0 = 256`,
+  bucket 18 takes 608. A character standing on row 7 computes the same 256 from
+  RMXP's own `screen_z`, which is the point: the two sort against each other
+  because they are on one scale.
+- `--rgss_effect_probe` still passes, and both boot checks still drive real game
+  data to the map — the crash-on-map-load risk this ADR called out as worse than
+  cosmetic.
+
+Still unverified here: that a roof *visually* occludes a character. The XP test
+bed ships no image assets, so its tilesets load as blank bitmaps. Structure,
+placement, `z` and survival are checked; appearance wants a project with real
+graphics.
 
 - **Correct occlusion.** Characters walk behind roofs/tree crowns above them and
   in front of the same tiles below them, the defining RMXP map look, for the

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -2,6 +2,7 @@
 #include <mruby/array.h>
 #include <mruby/class.h>
 #include <mruby/data.h>
+#include <mruby/hash.h>
 #include <mruby/string.h>
 #include <mruby/value.h>
 #include <mruby/variable.h>
@@ -26,6 +27,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <dirent.h>
@@ -3853,6 +3855,113 @@ int vx_tile_quads(int tile_id, int frame, bool table, VXQuad out[8]) {
 // and below the 999 an always-on-top character claims.
 static const mrb_int TILEMAP_ABOVE_Z = 900;
 
+// RMXP priorities run 1..5, so the bucket a priority tile sorts into --
+// `ty + prio`, per the formula above -- can be reached from any of five map
+// rows: bucket B holds every tile with `ty = B - prio`, i.e. rows B-5..B-1.
+// A strip is therefore five tile rows tall, positioned at (B-5)*TILE_SIZE - oy,
+// and a tile of priority p lands at local row (5 - p) inside it -- which
+// depends only on the priority, not on the row it came from.
+//
+// Sizing this correctly matters: a full-screen canvas per bucket would be
+// 1.17 MiB x 21 = 24.6 MiB for one map, and a one-row strip cannot hold a
+// bucket at all. See "Strip height" in the ADR.
+static const int TILEMAP_PRIO_SPAN = 5;
+
+// Strips are pooled by `bucket % TILEMAP_STRIP_SLOTS` rather than by the bucket
+// itself, which is what keeps the set bounded on a tall map. Keyed on the
+// absolute bucket, walking down a 200-row map would allocate a strip per row
+// and never let one go -- 200 x 400 KiB of canvases for a map only ever showing
+// twenty of them.
+//
+// The modulus has to exceed the number of buckets that can be visible at once,
+// or two live buckets would collide in one slot: a viewport shows at most
+// (height / TILE_SIZE) + 1 rows, and a bucket reaches TILEMAP_PRIO_SPAN rows
+// further down, so 16 + 5 = 21 for XP's 480px viewport. 24 leaves headroom
+// without materially raising the ceiling, since no more than 21 slots can be
+// occupied at a time whatever the modulus.
+static const int TILEMAP_STRIP_SLOTS = 24;
+
+// Fetch (creating on first use) the canvas strip for priority bucket `b`.
+//
+// Strips live in @_tm_strips, an mruby Hash keyed by bucket, so the GC keeps
+// them alive and tilemap_dispose can walk them. Allocation is lazy and per
+// bucket: a map with no priority tiles allocates nothing, and a tileset using
+// only priority 1 allocates one strip per occupied row rather than 21.
+//
+// Each strip is a z-ordered companion object registered the same way a Sprite
+// is (wrap pattern + register_zobj), so gfx_update's shared z sort interleaves
+// it with the character sprites that share the viewport -- which is the whole
+// point of the exercise.
+Bitmap* tilemap_strip(mrb_state* M, mrb_value self, int b, int w) {
+  mrb_value strips = mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_strips"));
+  if (!mrb_hash_p(strips)) {
+    strips = mrb_hash_new(M);
+    mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_strips"), strips);
+  }
+  const int slot =
+      ((b % TILEMAP_STRIP_SLOTS) + TILEMAP_STRIP_SLOTS) % TILEMAP_STRIP_SLOTS;
+  const mrb_value key = mrb_fixnum_value(slot);
+  const mrb_value found = mrb_hash_get(M, strips, key);
+  if (mrb_test(found) && DATA_PTR(found)) {
+    // The slot may have been holding a different bucket before the map
+    // scrolled; it is reused in place rather than reallocated, so record which
+    // bucket it carries now for the placement pass.
+    mrb_iv_set(M, found, mrb_intern_lit(M, "@_bucket"), mrb_fixnum_value(b));
+    return &DataType<Bitmap>::get(
+        M, mrb_iv_get(M, found, mrb_intern_lit(M, "@_bitmap")));
+  }
+  if (w <= 0)
+    return nullptr;
+  // Everything below allocates; keep it out of the GC's way until the strip is
+  // reachable from the hash.
+  const int arena = mrb_gc_arena_save(M);
+  const mrb_value vp = mrb_iv_get(M, self, mrb_intern_lit(M, "@viewport"));
+  const int h = TILEMAP_PRIO_SPAN * TILE_SIZE;
+  lv_obj_t* c = lv_canvas_create(parent_object(M, vp));
+  lv_obj_set_pos(c, 0, 0);
+  const mrb_value obj = mrb_obj_value(
+      mrb_data_object_alloc(M, mrb_obj_class(M, self), c, &obj_type));
+  lv_obj_set_user_data(c, mrb_ptr(obj));
+  lv_obj_add_event_cb(c, on_lv_delete, LV_EVENT_DELETE, nullptr);
+  register_zobj(M, obj);
+  RClass* bmp_class =
+      mrb_class_get_under(M, mrb_module_get(M, "RGSS"), "Bitmap");
+  const mrb_value bmp_v =
+      DataType<Bitmap>::make(M, bmp_class, w, h, LV_COLOR_FORMAT_ARGB8888);
+  Bitmap& bmp = DataType<Bitmap>::get(M, bmp_v);
+  std::fill(bmp.buffer.begin(), bmp.buffer.end(), static_cast<uint8_t>(0));
+  lv_canvas_set_buffer(c, bmp.buffer.data(), w, h, LV_COLOR_FORMAT_ARGB8888);
+  mrb_iv_set(M, obj, mrb_intern_lit(M, "@_bitmap"), bmp_v);
+  mrb_iv_set(M, obj, mrb_intern_lit(M, "@_bucket"), mrb_fixnum_value(b));
+  mrb_hash_set(M, strips, key, obj);
+  mrb_gc_arena_restore(M, arena);
+  return &bmp;
+}
+
+// Every strip currently allocated, as [bucket, obj] pairs. Empty before the
+// first priority tile is drawn.
+using TilemapStrip = std::pair<int, mrb_value>;
+
+std::vector<TilemapStrip> tilemap_strips(mrb_state* M, mrb_value self) {
+  std::vector<TilemapStrip> out;
+  const mrb_value strips =
+      mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_strips"));
+  if (!mrb_hash_p(strips))
+    return out;
+  const mrb_value keys = mrb_hash_keys(M, strips);
+  for (mrb_int i = 0; i < RARRAY_LEN(keys); ++i) {
+    const mrb_value k = mrb_ary_ref(M, keys, i);
+    const mrb_value v = mrb_hash_get(M, strips, k);
+    if (!mrb_test(v) || !DATA_PTR(v))
+      continue;
+    // The bucket the slot currently carries, which is what its position and z
+    // are derived from -- not the slot index the hash is keyed by.
+    const mrb_value b = mrb_iv_get(M, v, mrb_intern_lit(M, "@_bucket"));
+    out.push_back({mrb_test(b) ? static_cast<int>(mrb_as_int(M, b)) : 0, v});
+  }
+  return out;
+}
+
 // Redraw the visible part of the map. For each of the three map-data layers,
 // the tiles overlapping the viewport (given ox/oy) are blitted from the tileset
 // (regular tiles, id >= 384) or assembled from the four autotile quads (id
@@ -4084,6 +4193,15 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
   const int frame_idx = (anim / 16) % 4;
   bool any_anim = false;
 
+  // Buckets that received a tile this frame. A strip that misses out is hidden
+  // rather than freed, so scrolling back does not reallocate it.
+  std::vector<int> used_buckets;
+  for (const auto& e : tilemap_strips(M, self)) {
+    Bitmap& b = DataType<Bitmap>::get(
+        M, mrb_iv_get(M, e.second, mrb_intern_lit(M, "@_bitmap")));
+    std::fill(b.buffer.begin(), b.buffer.end(), static_cast<uint8_t>(0));
+  }
+
   int tx0 = static_cast<int>(ox) / TILE_SIZE;
   int ty0 = static_cast<int>(oy) / TILE_SIZE;
   if (tx0 < 0)
@@ -4107,14 +4225,29 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
         if (id < 48)  // 0 = empty; 1..47 are the unused blank autotile
           continue;
         const int dx0 = tx * TILE_SIZE - static_cast<int>(ox);
-        const int dy0 = ty * TILE_SIZE - static_cast<int>(oy);
-        // Priority 0 -> ground canvas; priority >= 1 -> above canvas (when one
-        // exists). An out-of-range id or nil table means priority 0.
+        int dy0 = ty * TILE_SIZE - static_cast<int>(oy);
+        // Priority 0 -> ground canvas. Priority 1..5 -> the strip for bucket
+        // ty + prio, where it sits at local row (SPAN - prio); the strip itself
+        // is placed and z-sorted below, once the whole map has been walked. An
+        // out-of-range id or nil table means priority 0, and a priority beyond
+        // the 1..5 the editor offers falls back to the ground rather than
+        // indexing off the end of a strip.
         const int prio =
             (pr && id >= 0 && id < static_cast<int>(pr->data.size()))
                 ? pr->data[id]
                 : 0;
-        Bitmap& target = (prio > 0 && above) ? *above : dst;
+        Bitmap* target_p = &dst;
+        if (prio >= 1 && prio <= TILEMAP_PRIO_SPAN) {
+          const int bucket = ty + prio;
+          if (Bitmap* strip = tilemap_strip(M, self, bucket, dst.width)) {
+            target_p = strip;
+            dy0 = (TILEMAP_PRIO_SPAN - prio) * TILE_SIZE;
+            if (std::find(used_buckets.begin(), used_buckets.end(), bucket) ==
+                used_buckets.end())
+              used_buckets.push_back(bucket);
+          }
+        }
+        Bitmap& target = *target_p;
         if (id < 384) {
           // Autotile: id/48 selects autotiles[0..6], id%48 the 48-shape quad
           // assembly. Uses the first animation frame (x offset 0).
@@ -4150,6 +4283,48 @@ void tilemap_refresh(mrb_state* M, mrb_value self) {
   mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_animated"),
              mrb_bool_value(any_anim));
   tilemap_apply_viewport_tone(M, self, dst, above);
+
+  // Place every strip and give it the z its bucket sorts at. Both depend on oy,
+  // so both are refreshed here rather than once at creation -- this runs on
+  // every scroll, which is exactly when they move.
+  const Tone strip_tone =
+      viewport_tone(M, mrb_iv_get(M, self, mrb_intern_lit(M, "@viewport")));
+  for (const auto& e : tilemap_strips(M, self)) {
+    lv_obj_t* sc = reinterpret_cast<lv_obj_t*>(DATA_PTR(e.second));
+    if (!sc)
+      continue;
+    const bool used = std::find(used_buckets.begin(), used_buckets.end(),
+                                e.first) != used_buckets.end();
+    if (!used) {
+      lv_obj_add_flag(sc, LV_OBJ_FLAG_HIDDEN);
+      continue;
+    }
+    lv_obj_remove_flag(sc, LV_OBJ_FLAG_HIDDEN);
+    const int top_row = e.first - TILEMAP_PRIO_SPAN;
+    lv_obj_set_pos(sc, 0, top_row * TILE_SIZE - static_cast<int>(oy));
+    mrb_iv_set(M, e.second, mrb_intern_lit(M, "@z"),
+               mrb_fixnum_value(e.first * TILE_SIZE + TILE_SIZE -
+                                static_cast<mrb_int>(oy)));
+    Bitmap& sb = DataType<Bitmap>::get(
+        M, mrb_iv_get(M, e.second, mrb_intern_lit(M, "@_bitmap")));
+    if (tone_is_set(strip_tone)) {
+      for (int y = 0; y < sb.height; ++y) {
+        for (int x = 0; x < sb.width; ++x) {
+          int r, g, bl, a;
+          bmp_read(sb, x, y, r, g, bl, a);
+          if (a == 0)
+            continue;
+          apply_tone_px(r, g, bl, strip_tone);
+          bmp_put(sb, x, y, r, g, bl, a);
+        }
+      }
+    }
+    sb.dirty = true;
+    lv_obj_invalidate(sc);
+  }
+  if (!used_buckets.empty())
+    update_z(M);
+
   if (above)
     above->dirty = true;
   lv_obj_invalidate(obj);
@@ -4234,6 +4409,11 @@ mrb_value tilemap_dispose(mrb_state* M, mrb_value self) {
       mrb_iv_get(M, self, mrb_intern_lit(M, "@_tm_above_obj"));
   if (mrb_test(above) && DATA_PTR(above))
     obj_dispose(M, above);
+  // Each priority strip is its own LVGL object in the z set; disposing the
+  // tilemap alone would leave them on screen and sorting.
+  for (const auto& e : tilemap_strips(M, self))
+    obj_dispose(M, e.second);
+  mrb_iv_set(M, self, mrb_intern_lit(M, "@_tm_strips"), mrb_nil_value());
   return obj_dispose(M, self);
 }
 


### PR DESCRIPTION
## The gap

RMXP gives every tile a priority: 0 is ground, ≥ 1 means the tile stands up out of the map and must draw **above** a character standing lower on the screen but **below** one standing higher. That per-row interleaving is what lets you walk behind a tree's crown while standing in front of its trunk.

All priority tiles went to one flat canvas at a fixed z above every character — so you always walked in front of every roof.

## What changed

Priority tiles now go to per-bucket canvas strips keyed on `ty + prio`, each taking `z = (ty + prio) * 32 + 32 - oy`.

That is the scale RMXP puts *characters* on. `Game_Character#screen_z` is the character's on-screen pixel y, and adds `priorities[tile_id] * 32` for a tile. Tiles and characters sort against each other because they're on one scale, not two.

A strip is **five rows tall** because bucket `B` holds every tile with `ty = B - prio` for `prio` in 1..5 — five different map rows, each drawing at its own screen y. A tile of priority `p` lands at local row `5 - p`, which depends only on the priority.

## Two things beyond the ADR's sketch

**Strips are pooled by `bucket % 24`, not keyed on the bucket.** Keyed on the bucket, walking down a 200-row map allocates a strip per row and never releases one — 200 canvases for a map showing twenty. The modulus only has to exceed the buckets visible at once (16 rows + 5 span = 21), and a slot is reused in place as the map scrolls, so scrolling reallocates nothing. **I found this by watching the diagnostic below, not by reasoning about it** — the first version had the leak.

**Only the XP path moved.** VX/MV routes on `flags & 0x10` and keeps the flat above-canvas. This ADR is about RMXP's `priorities`, and there's no test bed for the VX priority behaviour.

## Verified by running it

Which is new here — ADR 0022 held this back partly because it couldn't be, and #412 changed that. On the XP test bed under Xvfb:

| | |
| --- | --- |
| strips allocated | **4** (buckets 7, 8, 10, 18) — matching the priorities the survey found on rows 3–6 |
| memory | **1.6 MiB** vs the flat layer's 1.17 MiB — not the 24.6 MiB a full-screen-per-bucket reading would cost |
| z values | bucket 7 → **256**, which is exactly what a character on row 7 computes from `screen_z` |

`--rgss_effect_probe` passes; both boot checks still drive real game data to the map — the crash-on-map-load risk the ADR called out as worse than cosmetic. 562 logic and 219 scene checks pass (untouched by this).

## Not verified here

**That a roof visually occludes a character.** The XP test bed ships no image assets, so tilesets load as blank bitmaps. Structure, placement, z and survival are checked; appearance is not, and wants a project with real graphics.

## Scope note

This PR started as the design analysis alone (ADR "Strip height" section — why a full-screen canvas per bucket is unaffordable, why a one-row strip cannot work, and the test-bed data ruling out the cheap row-bucketing alternative: 4 of 9 priority-bearing rows carry more than one priority). The implementation is a second commit on top, and the ADR moves Proposed → Accepted.