### PR TITLE
Find a version-manager rake in the non-Nix build

### DIFF
--- a/changelog.d/native-build-rake-lookup.fixed.md
+++ b/changelog.d/native-build-rake-lookup.fixed.md
@@ -1,0 +1,7 @@
+- **`scripts/native-build-without-nix.bash` finds a version-manager `rake`.** A
+  version manager (rbenv, asdf, rvm) puts `rake` in a per-version bin that is only
+  on an *interactive* PATH, so the script's `command -v rake` missed it even
+  though `rake` works in a terminal — and its advice, "gem install rake", is then
+  both wrong and, behind a proxy that blocks rubygems, impossible. It now asks
+  Ruby where its own gem executables live (`Gem.bindir`) before giving up, and
+  says what it actually tried when it does.

--- a/scripts/native-build-without-nix.bash
+++ b/scripts/native-build-without-nix.bash
@@ -65,7 +65,20 @@ if /bin/sh -c 'command -v rake' >/dev/null 2>&1; then
   echo "rake already reachable from /bin/sh"
 else
   rake_bin="$(command -v rake || true)"
-  [ -n "$rake_bin" ] || { echo "no rake found; gem install rake" >&2; exit 1; }
+  # A version manager (rbenv, asdf, rvm) puts rake in a per-version bin that is
+  # only on an *interactive* PATH, so `command -v` misses it here even though
+  # `rake` works in a terminal -- and "gem install rake" is then both wrong and,
+  # behind a proxy that blocks rubygems, impossible. Ruby knows where its own
+  # gem executables live, so ask it before giving up.
+  if [ -z "$rake_bin" ] && command -v ruby >/dev/null 2>&1; then
+    gem_bin="$(ruby -e 'print Gem.bindir' 2>/dev/null || true)"
+    [ -n "$gem_bin" ] && [ -x "$gem_bin/rake" ] && rake_bin="$gem_bin/rake"
+  fi
+  [ -n "$rake_bin" ] || {
+    echo "no rake found on PATH, and ruby -e 'print Gem.bindir' has none" >&2
+    echo "install it with: gem install rake" >&2
+    exit 1
+  }
   ln -sf "$rake_bin" /usr/local/bin/rake
   echo "linked $rake_bin -> /usr/local/bin/rake"
 fi


### PR DESCRIPTION
`scripts/native-build-without-nix.bash` (#412) gave up on a box where `rake` was
installed and working:

```
== 3/5 rake on PATH
no rake found; gem install rake
```

A version manager — rbenv here, but asdf and rvm do the same — puts `rake` in a
per-version bin directory that is only on an **interactive** PATH, so
`command -v rake` misses it from a script even though the same command works in a
terminal. The script's own comment anticipates half of this ("an rbenv shim that
is only on the interactive PATH is not enough") but only for `/bin/sh`; the
lookup that feeds it has the same blind spot one level up.

Its advice is then wrong twice over: `rake` is already installed, and behind a
proxy that blocks rubygems `gem install` fails too — which is precisely the
environment the script exists for.

Ruby knows where its own gem executables live, so ask it. `Gem.bindir` resolves
to the per-version bin under every version manager, and to the system gem bin
without one:

```
$ env -i PATH=/usr/bin:/bin:/usr/local/bin bash -c '...'
resolved: /opt/rbenv/versions/3.3.6/bin/rake
```

Verified on that bare PATH, which is the shape a fresh container hands a script.
The failure message now says what was tried rather than prescribing a fix that
may not apply.

Found by using the script for what it was written for: this is what stood between
me and a native build in an agent container, and once past it the build gave the
local reproduction that found the `Array#sort` `-2` crash (#419).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSgYZ71saBBgw1m2tNYDBz)_