### PR TITLE
Stop a revive being spent as a potion

### DIFF
--- a/changelog.d/revive-only-items.fixed.md
+++ b/changelog.d/revive-only-items.fixed.md
@@ -1,0 +1,11 @@
+- **A revive item can no longer be spent as a potion.** The item row's `ko_only`
+  (蘇生専用) was unread, and all four items that set it across the test beds —
+  Nepheshel's ドラゴンブラッド, ドラゴンハート and 気付け薬 and mtf-meido-action's
+  Stimulant — cure 戦闘不能 *and* restore 25 / 100 / 3 / 25 percent of max HP.
+  Reading the flag as nothing did not just let the cure fire pointlessly on a
+  living ally (it is a no-op there anyway); it let the **HP restore** fire, so
+  every one of them worked as a percentage heal on a standing member, and the
+  menu offered them as effective. RPG_RT returns from the item algorithm before
+  *both* effects, so the answer is "does nothing at all". The rule gates the menu
+  and, per target, the use itself — so an all-party revive passes over the
+  members who never fell rather than topping them up. See ADR 0039.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1344,6 +1344,22 @@ The work below is roughly ordered by the critical path to a walkable game
   EasyRPG and deliberately left alone (`levitate` and `state_chance` are RPG2003
   only, `message_affected` has no known trigger, and the two critical-hit terms
   are side-keying-unresolved, ADR 0036), so nobody re-derives them.
+- ✅ **蘇生専用 items** (the item row's `ko_only`) — unread, and all four items
+  that set it across the test beds are revives that cure 戦闘不能 **and** restore
+  a percentage of max HP (Nepheshel's ドラゴンブラッド 25%, ドラゴンハート 100%,
+  気付け薬 3%; mtf's Stimulant 25%). That shape is what made the field matter:
+  reading it as nothing did not merely let the *cure* fire pointlessly on a
+  living ally — the cure is a no-op there anyway — it let the **HP restore**
+  fire, so all four were wastable as percentage heals and ドラゴンハート was a
+  full heal that way, with the field menu offering them as effective. RPG_RT
+  returns from the item algorithm **before both** the HP and the state effects
+  (EasyRPG's `Item::vExecute` puts the `ko_only && !IsDead()` return ahead of the
+  state loop, with the HP block further down), so the answer is "does nothing at
+  all". `Party#ko_only_blocked?` gates `item_effective?` (the menu greys it out)
+  and `use_medicine` **per target**, so an all-party revive passes over the
+  members who never fell rather than topping them up — the case that reading
+  actually decides, since a single target would be hidden by the menu gate. See
+  ADR 0039.
 
 ## RPG Maker with RGSS (XP / VX / VXAce)
 

--- a/docs/adr/0039-revive-only-items.md
+++ b/docs/adr/0039-revive-only-items.md
@@ -1,0 +1,66 @@
+# 39. A revive is not a potion
+
+Date: 2026-08-06
+
+## Status
+
+Accepted
+
+## Context
+
+The item row's `ko_only` (蘇生専用) marks an item that only works on a fallen
+target. Nothing read it, and the four items in the test beds that set it are all
+revives of the same shape:
+
+| item | cures | restores |
+|---|---|---|
+| Nepheshel ドラゴンブラッド | 戦闘不能 | 25% of max HP |
+| Nepheshel ドラゴンハート | 戦闘不能 | 100% |
+| Nepheshel 気付け薬 | 戦闘不能 | 3% |
+| mtf-meido-action Stimulant | 戦闘不能 | 25% |
+
+That shape is what makes the field matter. Reading `ko_only` as nothing did not
+merely let the *cure* fire pointlessly on a living ally — the cure is a no-op
+there anyway, since they do not carry 戦闘不能. It let the **HP restore** fire.
+All four are wastable on a standing, wounded ally as a percentage heal, and
+Nepheshel's ドラゴンハート is a full heal that way. The field menu offered them
+as effective, which is exactly when a player spends one.
+
+## Decision
+
+`ko_only` blocks the whole item, not just its states.
+
+RPG_RT returns from the item algorithm **before both** the HP and the state
+effects are computed — EasyRPG's `Item::vExecute` puts
+`if (item.ko_only && !GetTarget()->IsDead()) return SetIsSuccess();` ahead of the
+state loop, and the HP block is further down still. So the answer is "does
+nothing at all", not "cures nothing".
+
+`Party#ko_only_blocked?(it, actor)` is that test, and it gates two places:
+
+- **`item_effective?`** — so the menu greys the item out on a standing member
+  and a player cannot spend it by mistake.
+- **`use_medicine`** — per target, so an **all-party** revive passes over the
+  members who never fell rather than topping them up. That is the case the
+  "not even the HP" reading actually decides; with a single target the menu gate
+  would have hidden the difference.
+
+## Consequences
+
+Four revive items in the two games stop being percentage heals. Nothing else
+moves: an item without the flag takes the same path it always did, and a
+`ko_only` item on a fallen member still cures and still heals, exactly as before.
+
+Left alone: **an item that is `ko_only` and not a revive.** Neither test bed has
+one, and RPG_RT's rule as written would make such an item inert on everyone who
+is standing regardless of what else it does — which is what this implements, but
+without data behind it that is a consequence of the rule rather than a
+measurement.
+
+Covered by `scripts/rpg2k_logic_check.rb` (a revive is inert on a standing ally
+— menu gate, no HP, nothing spent — works fully on a fallen one, leaves an
+ordinary medicine untouched, and an all-party revive skips the members still
+standing) and by `scripts/rpg2k_testbed_logic_check.rb`, which drives **every**
+real 蘇生専用 item in both games at a standing party leader and then at a fallen
+one, first asserting that each really does restore HP when it works — the
+property that makes "not even the HP" a different answer from "cures nothing".

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2170,6 +2170,22 @@ module Game
       out
     end
 
+    # 蘇生専用 (`ko_only`): an item that does nothing at all to a target who is
+    # still standing. RPG_RT returns from the item algorithm *before* the HP and
+    # the state effects are computed (EasyRPG's `Item::vExecute`, whose
+    # `item.ko_only && !IsDead()` branch precedes both), so this is not "cures
+    # nothing" -- the percentage HP restore does not land either.
+    #
+    # Every such item in both test beds is a revive: Nepheshel's ドラゴンブラッド,
+    # ドラゴンハート and 気付け薬 and mtf-meido-action's Stimulant all cure
+    # 戦闘不能 and restore 25 / 100 / 3 / 25 percent of max HP. Reading the flag
+    # as nothing let all four be spent on a living, wounded ally for their HP.
+    def ko_only_blocked?(it, actor)
+      return false unless it.respond_to?(:ko_only) && it.ko_only
+      return false if actor.nil?
+      !actor.dead?
+    end
+
     # Whether using item `id` on `actor` would change anything, so the menu can
     # grey out a no-op. A medicine is effective when the target is below full
     # HP/SP and it restores some (RPG_RT forbids using a pure-recovery item on a
@@ -2180,6 +2196,7 @@ module Game
       return false unless it && actor
       case it.type
       when ITEM_MEDICINE
+        return false if ko_only_blocked?(it, actor)
         hp, mp = item_recovery(it, actor)
         (hp > 0 && actor.hp < actor.max_hp) || (mp > 0 && actor.mp < actor.max_mp) ||
           item_cured_states(it).any? { |s| actor.state?(s) }
@@ -2235,6 +2252,10 @@ module Game
       cured = item_cured_states(it)
       affected = []
       targets.each do |t|
+        # A 蘇生専用 item passes over anyone still standing without touching
+        # them -- not even the HP restore -- which is what keeps an all-party
+        # revive from topping up the members who never fell.
+        next if ko_only_blocked?(it, t)
         changed = false
         # Cure first: a revive item (curing 戦闘不能) stands the actor back up so
         # the HP recovery below lands instead of being blocked as a no-op.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1921,19 +1921,22 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :occasion_field2, :occasion_field1,
                       :dual_attack, :ignore_evasion, :half_sp_cost, :hit,
                       # 会心必殺: the weapon's own critical-hit percentage.
-                      :critical_hit)
+                      :critical_hit,
+                      # 蘇生専用: does nothing at all to a target still standing.
+                      :ko_only)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
               attribute_set: nil, switch_id: 0, occ_field: true,
               field_only: false, dual_attack: false, ignore_evasion: false,
-              half_sp_cost: false, hit: 0, critical_hit: 0)
+              half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
-               dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit)
+               dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
+               ko_only)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -8309,6 +8312,70 @@ check 'a recovery with no wording yields nil rather than half a sentence' do
   eq nil, BT.recovered(no_term, 'リト', 30, :hp)
   no_pool = Struct.new(:hp_recovery, :hp, :mp).new('回復した！', '', '')
   eq nil, BT.recovered(no_pool, 'リト', 30, :hp), 'the pool name matters too'
+end
+
+# -- 蘇生専用 items (ko_only) --------------------------------------------------
+# RPG_RT returns from the item algorithm *before* both the HP and the state
+# effects when the target is still standing, so a revive item is not merely
+# "cures nothing" on a living ally -- its percentage HP restore does not land
+# either. Every ko_only item in both test beds is a revive of exactly that shape.
+
+def revive_party
+  items = { 4 => fake_item(type: 6, rhp_rate: 25, state_set: [1], ko_only: true),
+            5 => fake_item(type: 6, rhp: 50) } # an ordinary medicine
+  item_party(items)
+end
+
+check 'a revive item does nothing to an ally who is still standing' do
+  st = revive_party
+  st.party.gain_item(4, 1)
+  hero = st.party.actor_by_id(1)
+  hero.change_hp(-60) # 40/100, wounded but up
+  eq false, st.party.item_effective?(4, hero), 'the menu greys it out'
+  eq [], st.party.use_item(4, hero)
+  eq 40, hero.hp, 'and not even the 25% HP lands'
+  eq 1, st.party.item_count(4), 'nothing is spent'
+end
+
+check 'the same item revives an ally who is down, HP and all' do
+  st = revive_party
+  st.party.gain_item(4, 1)
+  hero = st.party.actor_by_id(1)
+  hero.add_state(Game::Actor::DEATH_STATE)
+  ok hero.dead?
+  eq true, st.party.item_effective?(4, hero)
+  eq [hero], st.party.use_item(4, hero)
+  ok !hero.dead?, 'back on their feet'
+  # Standing up puts them on 1 HP first (the existing revive path), and the
+  # item's 25% of 100 lands on top of that.
+  eq 26, hero.hp, 'with the 25% the item restores'
+  eq 0, st.party.item_count(4), 'and it was spent'
+end
+
+check 'an ordinary medicine is unaffected by the rule' do
+  st = revive_party
+  st.party.gain_item(5, 1)
+  hero = st.party.actor_by_id(1)
+  hero.change_hp(-60)
+  eq true, st.party.item_effective?(5, hero)
+  eq [hero], st.party.use_item(5, hero)
+  eq 90, hero.hp
+end
+
+# An all-party revive passes over the members who never fell rather than topping
+# them up, which is the case the "not even the HP" reading decides.
+check 'an all-party revive skips the members still standing' do
+  items = { 4 => fake_item(type: 6, scope: 1, rhp_rate: 25, state_set: [1],
+                           ko_only: true) }
+  st = item_party(items)
+  st.party.gain_item(4, 1)
+  up = st.party.actor_by_id(1)
+  down = st.party.actor_by_id(2)
+  up.change_hp(-60)
+  down.add_state(Game::Actor::DEATH_STATE)
+  eq [down], st.party.use_item(4, nil)
+  eq 40, up.hp, 'the standing member is passed over'
+  ok !down.dead?, 'the fallen one is raised'
 end
 
 # -- chipset terrain tags -----------------------------------------------------

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -394,6 +394,51 @@ def combatant(name, atk, dfn, agi, hp, states = [])
   c
 end
 
+# 蘇生専用 (`ko_only`): an item that does nothing at all to a target still
+# standing -- not even its percentage HP restore, since RPG_RT returns from the
+# item algorithm before both effects. Every such item in both test beds is a
+# revive, which is the only shape that makes the distinction visible.
+def check_ko_only(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  items = db[DB_ITEM]
+  return unless items
+
+  ko = []
+  items.each { |id, it| ko << id if it.ko_only }
+  puts format('   items: %d 蘇生専用 (revive-only)', ko.size)
+  return if ko.empty?
+
+  check "#{name}: a real revive item is inert on a member still standing" do
+    party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+    hero = party.leader
+    ok hero, 'the game has a party to test with'
+    ko.each do |iid|
+      it = items[iid]
+      # Every one of them restores a *percentage* of max HP, which is what makes
+      # "not even the HP" a different answer from "cures nothing".
+      ok (it.recover_hp_rate || 0) > 0 || (it.recover_hp || 0) > 0,
+         "item ##{iid} (#{it.name}) restores something when it does work"
+      hero.clear_states
+      hero.set_hp(1)
+      eq false, party.item_effective?(iid, hero),
+         "item ##{iid} (#{it.name}) is inert on a standing member"
+      party.gain_item(iid, 1)
+      eq [], party.use_item(iid, hero)
+      eq 1, hero.hp, 'and left the HP alone'
+
+      # ... and does its job on one who has fallen.
+      hero.add_state(Game::Actor::DEATH_STATE)
+      eq true, party.item_effective?(iid, hero),
+         "item ##{iid} works on a fallen member"
+      eq [hero], party.use_item(iid, hero)
+      ok !hero.dead?, 'who is back on their feet'
+    end
+    hero.clear_states
+    hero.set_hp(hero.max_hp)
+  end
+end
+
 def check_states(dir)
   name = File.basename(dir)
   db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
@@ -1002,6 +1047,7 @@ dirs.each do |d|
   check_equipment(d)
   check_terrain(d)
   check_bush(d)
+  check_ko_only(d)
   check_items(d)
 end
 


### PR DESCRIPTION
The item row's `ko_only` (蘇生専用) marks an item that only works on a fallen target. Nothing read it, and all four items that set it across the test beds are revives of the same shape:

| item | cures | restores |
|---|---|---|
| Nepheshel ドラゴンブラッド | 戦闘不能 | 25% of max HP |
| Nepheshel ドラゴンハート | 戦闘不能 | **100%** |
| Nepheshel 気付け薬 | 戦闘不能 | 3% |
| mtf-meido-action Stimulant | 戦闘不能 | 25% |

## That shape is the whole point

Reading `ko_only` as nothing did **not** merely let the *cure* fire pointlessly on a living ally — the cure is a no-op there anyway, since a standing member doesn't carry 戦闘不能. It let the **HP restore** fire.

So all four were wastable on a standing, wounded ally as a percentage heal, ドラゴンハート being a *full heal* that way — and the field menu offered them as effective, which is exactly when a player spends one.

RPG_RT returns from the item algorithm **before both** effects: EasyRPG's `Item::vExecute` puts `if (item.ko_only && !GetTarget()->IsDead()) return SetIsSuccess();` ahead of the state loop, with the HP block further down still. The answer is "does nothing at all", not "cures nothing".

## Where it gates

`Party#ko_only_blocked?(it, actor)` gates two places:

- **`item_effective?`** — the menu greys it out on a standing member, so it can't be spent by mistake.
- **`use_medicine`, per target** — so an **all-party** revive passes over the members who never fell rather than topping them up. That's the case the "not even the HP" reading actually decides; with a single target the menu gate alone would have hidden the difference.

## Left alone

An item that is `ko_only` and *not* a revive. Neither test bed has one, and RPG_RT's rule as written makes such an item inert on anyone standing regardless of what else it does — which is what this implements, but without data behind it that's a consequence of the rule rather than a measurement.

## Verification

All 14 `scripts/*_check.rb` suites pass. 7 new checks; 2 logic and 3 test-bed fail against the pre-fix code (the two that pass pre-fix are the unchanged paths — a fallen target and an ordinary medicine — which is the point of including them).

- `rpg2k_logic_check.rb` (566, +4): a revive is inert on a standing ally (menu gate, no HP, nothing spent), works fully on a fallen one, leaves an ordinary medicine untouched, and an all-party revive skips the members still standing.
- `rpg2k_testbed_logic_check.rb` (100, +3): drives **every** real 蘇生専用 item in both games at a standing party leader and then at a fallen one — first asserting each really does restore HP when it works, the property that makes "not even the HP" a different answer from "cures nothing".

See `docs/adr/0039-revive-only-items.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_