### PR TITLE
Have the field audit flag its RPG2003 rows

### DIFF
--- a/changelog.d/field-audit-2k3-hint.changed.md
+++ b/changelog.d/field-audit-2k3-hint.changed.md
@@ -1,0 +1,12 @@
+- **The field audit tells you which rows are probably RPG2003.** `maker_version`
+  is written only by RPG2003 (RPG2000 omits the chunk), so a run covering one of
+  each can mark a field that an RPG2003 game sets and no RPG2000 one does —
+  16 of the 120 currently unread. That is the single most common reason a
+  high-ranked row turns out not to be work: `terrain.footstep` and the
+  `situation.hp_change_type` / `sp_change_type` pair have joined the `NOT_OURS`
+  table for exactly that reason. The mark is a filter, not a proof, in either
+  direction, and the script says so: an RPG2000 editor still writes fields
+  RPG_RT ignores, so `levitate` and `state_chance` are set by Nepheshel and are
+  2k3-only anyway, while a marked field can still be a real RPG2000 feature the
+  2000 test bed never used. Each game is now labelled `(2k)` / `(2k3)` in the
+  header, and the hint is suppressed when a run covers only one maker.

--- a/scripts/rpg2k_field_audit.rb
+++ b/scripts/rpg2k_field_audit.rb
@@ -67,7 +67,29 @@ NOT_OURS = {
                   'attacker; both test beds fill both fields with the same two ' \
                   'strings, so the data cannot settle it (ADR 0036)',
   enemy_critical: 'see actor_critical',
+  footstep: 'RPG2003 only — EasyRPG plays it from Game_Player::BeginMove ' \
+            'behind an IsRPG2k3() gate',
+  hp_change_type: 'RPG2003 only — the schema marks it so, and RPG2000 has one ' \
+                  'flat/percentage reading rather than a selector',
+  sp_change_type: 'see hp_change_type',
 }.freeze
+
+# `maker_version` is written only by RPG2003 (RPG2000 omits the chunk), so a run
+# that includes one of each can say something the row counts cannot: a field
+# **no RPG2000 game sets** is a candidate for being RPG2003-only, which is the
+# single most common reason a high-ranked row turns out not to be work.
+#
+# It is a filter, not a proof, in either direction. An RPG2000 editor still
+# writes fields RPG_RT ignores — `levitate` and `state_chance` in NOT_OURS above
+# are both set by Nepheshel and both 2k3-only — so an unmarked field can still be
+# 2k3-only, and a marked one can still be a real RPG2000 feature the 2000 test
+# bed simply never used.
+def maker_of(db)
+  v = db[22] && db[22].maker_version
+  v == 2003 ? :rpg2k3 : :rpg2k
+rescue StandardError
+  :rpg2k
+end
 
 # Array-length companions of a packed array. They are set whenever the array is,
 # and mean nothing on their own.
@@ -110,6 +132,8 @@ runtime = Dir[File.join(ROOT, 'mruby-rpg2k/mrblib/*.rb')]
 dbs = dirs.map do |d|
   [File.basename(d), LCF::Database.new(File.open(File.join(d, 'RPG_RT.ldb'), 'rb'))]
 end
+makers = dbs.map { |label, db| [label, maker_of(db)] }.to_h
+mixed = makers.values.uniq.size > 1
 
 rows = []
 LCF::Schema::DATABASE[:elements].each do |cid, spec|
@@ -138,15 +162,18 @@ LCF::Schema::DATABASE[:elements].each do |cid, spec|
     end
     total = counts.values.reduce(0) { |a, b| a + b }
     next if total.zero?
+    # Set by an RPG2003 game and by no RPG2000 one: suspect until checked.
+    only_2k3 = mixed && counts.all? { |label, n| makers[label] == :rpg2k3 || n.zero? }
     rows << { total: total, chunk: spec[:name], field: name, counts: counts,
-              named: runtime.include?(name.to_s) }
+              named: runtime.include?(name.to_s), only_2k3: only_2k3 }
   end
 end
 
 unread = rows.reject { |r| r[:named] }.sort_by { |r| -r[:total] }
 read = rows.size - unread.size
 
-puts "rpg2k database field audit — #{dirs.size} game(s): #{dbs.map(&:first).join(', ')}"
+puts 'rpg2k database field audit — ' +
+     makers.map { |label, m| "#{label} (#{m == :rpg2k3 ? '2k3' : '2k'})" }.join(', ')
 puts
 puts format('%d scalar field(s) are set by at least one game; the runtime names ' \
             '%d of them and never names %d.', rows.size, read, unread.size)
@@ -157,8 +184,18 @@ known, fresh = unread.partition { |r| NOT_OURS.key?(r[:field]) }
 puts "-- set by a real game, never named by the runtime ------------------------"
 puts format('   %-16s %-28s %6s  %s', 'chunk', 'field', 'rows', 'per game')
 fresh.each do |r|
-  puts format('   %-16s %-28s %6d  %s', r[:chunk], r[:field], r[:total],
-              r[:counts].map { |k, v| "#{k}=#{v}" }.join(' '))
+  puts format('   %-16s %-28s %6d  %s%s', r[:chunk], r[:field], r[:total],
+              r[:counts].map { |k, v| "#{k}=#{v}" }.join(' '),
+              r[:only_2k3] ? '  [2k3 only?]' : '')
+end
+if mixed
+  n = fresh.count { |r| r[:only_2k3] }
+  puts
+  puts format('   [2k3 only?] marks the %d field(s) an RPG2003 game sets and no ' \
+              'RPG2000 one does — check whether RPG_RT reads it on RPG2000 at', n)
+  puts '   all before building it. A filter, not a proof, in either direction:'
+  puts '   an RPG2000 editor still writes fields RPG_RT ignores, so a field both'
+  puts '   makers set can be 2k3-only too (levitate and state_chance below are).'
 end
 
 unless known.empty?


### PR DESCRIPTION
Three times now a field near the top of `scripts/rpg2k_field_audit.rb` has turned out to be RPG2003-only, and so not work at all:

- `enemy.levitate` — *"2k does not support flying, albeit mentioned in the help file"*
- `item.state_chance` — an RPG2000 item cures its `state_set` unconditionally
- `terrain.footstep` — EasyRPG plays it from `Game_Player::BeginMove` behind an `IsRPG2k3()` gate (found this session, chasing the next task)

Plus the `situation.hp_change_type` / `sp_change_type` pair, which the schema already marks 2003.

Each cost a round of investigation to rule out. The audit should carry that signal itself.

## The signal

`maker_version` is written only by RPG2003 — RPG2000 omits the chunk — so a run covering one of each can say something the row counts cannot: **a field no RPG2000 game sets is a candidate for being RPG2003-only.** 16 of the 120 currently unread fields are marked `[2k3 only?]`.

```
rpg2k database field audit — Nepheshel206Nbeta (2k), Nepheshel206Rbeta (2k), Debug (2k3)

   skill            ignore_defense       33  Neph=13 Neph=13 Debug=7
   job              battler_animation    17  Neph=0  Neph=0  Debug=17  [2k3 only?]
   terrain          grid_top_y           10  Neph=0  Neph=0  Debug=10  [2k3 only?]
```

## It's a filter, not a proof — and the report says so

In **either** direction, which is the part worth stating rather than implying:

- An RPG2000 editor still writes fields RPG_RT ignores. `levitate` and `state_chance` are both set by Nepheshel and both 2k3-only, so they would *not* have been caught by this mark.
- A marked field can still be a real RPG2000 feature the 2000 test bed simply never used.

My first draft of the summary line claimed the mark would have caught every `NOT_OURS` entry except the critical terms. That was wrong for those two, and the corrected wording names them as the counterexample.

## Also

- Each game is labelled `(2k)` / `(2k3)` in the header.
- The three newly confirmed fields join the `NOT_OURS` table with their reasons.
- The hint is suppressed when a run covers only one maker, since it means nothing there.

## Verification

`ruby -c` clean; runs on all three test beds (hint shown) and on the RPG2003 game alone (hint suppressed, 0 marks); exits 0 either way. All `scripts/*_check.rb` suites still pass — it touches no runtime code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_