### PR TITLE
Measure the windowskin rectangles instead of assuming them

### DIFF
--- a/changelog.d/windowskin-rect-probe.added.md
+++ b/changelog.d/windowskin-rect-probe.added.md
@@ -1,0 +1,9 @@
+- **The RMXP windowskin source rectangles are measured rather than assumed.**
+  `RGSS.windowskin_rect_probe` (part of `--rgss_effect_probe`, run under Xvfb)
+  paints each source region of a synthetic skin its own primary — the background
+  tile, the four frame corners and the top edge — renders a window from it and
+  reads back which colour landed where. The existing `window_probe` could not:
+  it uses a deliberately flat skin, so it measures the area a window covers and
+  every source rect could be wrong while it still passed. The new probe was
+  confirmed to catch a wrong rect, by pointing the top-right corner at the
+  top-left one and the background at the frame and watching each fail.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -490,10 +490,18 @@ text, selection cursor and message pause. The content blit already clips to the
 content area (its source rect is the content-area size, so taller `contents` are
 cropped and scrolled, not overflowed). `stretch=` picks between the stretched
 (default) windowskin background and a tiled one (the 128×128 tile repeated at 1:1
-across the window). **Remaining:** the RMXP windowskin source-rect constants are
-best-effort until a game exercises them.
+across the window). The RMXP windowskin **source rectangles are measured**, not
+best-effort as they were: `RGSS.windowskin_rect_probe`
+(`--rgss_effect_probe`, run under Xvfb) paints each source region of a synthetic
+skin its own primary — background, the four frame corners, the top edge — renders
+a window from it and reads back which colour landed where. `window_probe` beside
+it cannot do this: it uses a deliberately flat skin, so it measures area and
+every source rect could be wrong while it still passed. Confirmed to catch a
+wrong rect, not merely to pass: pointing the top-right corner at the top-left
+one, and the background at the frame, each fail the probe with the region
+named.
 
-### 3. `Tilemap` ⚠️ (tiles + animated autotiles + interim priority split rendered)
+### 3. `Tilemap` ✅ (tiles + animated autotiles + per-row priority interleaving)
 
 `Tilemap` is now **native** (`mruby-rgss/src/lib.cxx`): `Tilemap.new` creates an
 `lv_canvas` the size of the viewport (or screen) and `tilemap_refresh` draws the

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -203,6 +203,7 @@ module RGSS
     bitmap.dispose
     viewport.dispose
     ok = false unless window_probe
+    ok = false unless windowskin_rect_probe
     $stderr.puts "[RGSS-PROBE] #{ok ? "ok" : "failed"}"
     ok
   end
@@ -312,6 +313,74 @@ module RGSS
       unless toned[0] > drawn[0] + 20
         $stderr.puts "[RGSS-PROBE] FAIL Window#tone did not tint the background"
         ok = false
+      end
+    end
+    win.dispose
+    skin.dispose
+    ok
+  end
+
+  # Prove the RMXP windowskin *source rectangles* are the right ones.
+  #
+  # window_probe above deliberately uses a flat skin, so it measures area and
+  # nothing else — every source rect could be wrong and it would still pass.
+  # The constants they encode were best-effort until a real game exercised them,
+  # and a game with a real windowskin still would not say *which* rect was
+  # misread: a wrong corner offset looks like a slightly odd border.
+  #
+  # So paint each source region its own primary and read back where it landed.
+  # RMXP's layout, as the native drawing reads it: the 128x128 background tile
+  # at (0,0), and a 64x64 frame at (128,0) 9-sliced with 16px corners — so the
+  # frame's four corners sit at (128,0), (176,0), (128,48) and (176,48), and its
+  # top edge is the 32px-wide strip between them at (144,0).
+  def self.windowskin_rect_probe
+    w = 320
+    h = 240
+    b = 16
+    skin = Bitmap.new(192, 128)
+    skin.fill_rect(0, 0, 128, 128, Color.new(0, 255, 0, 255))     # background
+    skin.fill_rect(128, 0, b, b, Color.new(255, 0, 0, 255))       # frame TL
+    skin.fill_rect(176, 0, b, b, Color.new(0, 0, 255, 255))       # frame TR
+    skin.fill_rect(128, 48, b, b, Color.new(255, 255, 255, 255))  # frame BL
+    skin.fill_rect(176, 48, b, b, Color.new(255, 255, 0, 255))    # frame BR
+    skin.fill_rect(144, 0, 32, b, Color.new(255, 0, 255, 255))    # frame top
+
+    win = Window.new(0, 0, w, h)
+    win.windowskin = skin
+    Graphics.update
+
+    # Each region of the drawn window, and the colour its source rect should
+    # have put there.
+    # Sample inside the corner, so a one-off cannot average two regions.
+    c = b - 2
+    want = [
+      ['top-left', frame_mean(1, 1, c, c), [255, 0, 0]],
+      ['top-right', frame_mean(w - b + 1, 1, c, c), [0, 0, 255]],
+      ['bottom-left', frame_mean(1, h - b + 1, c, c), [255, 255, 255]],
+      ['bottom-right', frame_mean(w - b + 1, h - b + 1, c, c), [255, 255, 0]],
+      ['top edge', frame_mean(w / 2, 1, 32, c), [255, 0, 255]],
+      ['background', frame_mean(w / 2, h / 2, 32, 32), [0, 255, 0]],
+    ]
+    ok = true
+    want.each do |name, got, exp|
+      if got.nil?
+        $stderr.puts "[RGSS-PROBE] windowskin: no frame to sample"
+        ok = false
+        break
+      end
+      $stderr.puts "[RGSS-PROBE] windowskin #{name}=#{got.inspect} " \
+                   "want~#{exp.inspect}"
+      # Generous: the check is which source rect landed here, and the six
+      # answers are far apart in colour space, so a loose threshold cannot
+      # confuse two of them.
+      3.times do |i|
+        hi = exp[i] > 127
+        if hi ? got[i] < 128 : got[i] > 127
+          $stderr.puts "[RGSS-PROBE] FAIL windowskin #{name} drew " \
+                       "#{got.inspect}, expected about #{exp.inspect} — the " \
+                       'source rect for that region is wrong'
+          ok = false
+        end
       end
     end
     win.dispose


### PR DESCRIPTION
## What was left

The XP API-gap doc listed one remaining item on `Window`:

> **Remaining:** the RMXP windowskin source-rect constants are best-effort until a game exercises them.

A game exercising them wouldn't have settled it either — a misread rect shows up as a *slightly odd border*, which nobody reports as a bug.

And `window_probe` can't settle it **by design**. It fills the skin flat blue so "the frame contributes nothing and the measurement is pure area". Every source rect could be wrong and it would still pass.

## What this adds

`windowskin_rect_probe` paints each source region its own primary, renders a window from that skin, and reads back which colour landed where:

| source rect in the skin | region of the drawn window | colour |
| --- | --- | --- |
| `(0,0,128,128)` background tile | interior | green |
| `(128,0,16,16)` frame TL | top-left corner | red |
| `(176,0,16,16)` frame TR | top-right corner | blue |
| `(128,48,16,16)` frame BL | bottom-left corner | white |
| `(176,48,16,16)` frame BR | bottom-right corner | yellow |
| `(144,0,32,16)` frame top edge | between the top corners | magenta |

All six land exactly where RMXP says — not approximately:

```
[RGSS-PROBE] windowskin top-left=[255, 0, 0] want~[255, 0, 0]
[RGSS-PROBE] windowskin top-right=[0, 0, 255] want~[0, 0, 255]
[RGSS-PROBE] windowskin bottom-left=[255, 255, 255] want~[255, 255, 255]
[RGSS-PROBE] windowskin bottom-right=[255, 255, 0] want~[255, 255, 0]
[RGSS-PROBE] windowskin top edge=[255, 0, 255] want~[255, 0, 255]
[RGSS-PROBE] windowskin background=[0, 255, 0] want~[0, 255, 0]
```

## Confirmed to catch a wrong rect

Which for a probe is the only claim worth making — a probe that passes proves nothing until you've seen it fail. Both breakages were built and run:

- Top-right corner's source pointed at the top-left one → `FAIL windowskin top-right drew [255, 0, 0], expected about [0, 0, 255]`
- Background pointed at the frame → `FAIL windowskin background`

The six colours are far apart in colour space, so the threshold is deliberately loose: what's under test is *which rect landed here*, not a shade.

## Also

Marks `Tilemap` ✅ in the same doc. Its heading still read "interim priority split rendered", which stopped being true when the per-row strips landed in #426.

Runs inside the existing `--rgss_effect_probe`, so it's covered by whatever already invokes that under Xvfb — no new CI wiring. The XP boot check still passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_