### PR TITLE
Make a claymore need both hands

### DIFF
--- a/changelog.d/two-handed-weapons.fixed.md
+++ b/changelog.d/two-handed-weapons.fixed.md
@@ -1,0 +1,13 @@
+- **A two-handed weapon now needs both hands.** The item row's `two_handed`
+  (両手持ち) was unread, so a claymore and a shield could be worn together and
+  both bonuses counted — and the flag is not rare: **35 of Nepheshel's 104
+  weapons** and **14 of mtf-meido-action's 26**, more than half that game's
+  arsenal. The weapon and shield slots are now mutually exclusive whenever either
+  holds a two-handed weapon, and **both** slots are tested, so equipping a shield
+  over a claymore drops the claymore just as the claymore drops the shield. The
+  flag only counts on a weapon, as RPG_RT tests the type alongside it. The
+  emptied hand returns its item to the bag rather than vanishing, since the equip
+  menu swaps through the inventory. A bulk `equip` (loading a save, initial
+  equipment) does not enforce it — RPG_RT stores what it stores. `double_hand`
+  (二刀流 on the actor row) is the opposite rule on the same pair and is left for
+  its own change. See ADR 0040.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1380,6 +1380,25 @@ The work below is roughly ordered by the critical path to a walkable game
   members who never fell rather than topping them up — the case that reading
   actually decides, since a single target would be hidden by the menu gate. See
   ADR 0039.
+- ✅ **両手持ち weapons** (the item row's `two_handed`) — unread, so a claymore
+  and a shield could be worn together and both bonuses counted. Not a rare flag:
+  **35 of Nepheshel's 104 weapons** and **14 of mtf's 26**, more than half that
+  game's arsenal. ADR 0033 audited the equipment *combat* flags and did not reach
+  this one, because it is not a modifier but a constraint on what may be worn at
+  once. The weapon and shield slots are now mutually exclusive whenever **either**
+  holds a two-handed weapon — both slots are tested, so equipping a shield over a
+  claymore drops the claymore just as the claymore drops the shield; reading only
+  the incoming item would let the shield win by going second. The flag counts
+  only on a weapon, as RPG_RT tests the type alongside it (and no non-weapon in
+  either game carries it, which the test-bed check asserts). The emptied hand
+  returns its item to the bag rather than vanishing, since the equip menu swaps
+  through the inventory. A bulk `equip` — loading a save, initial equipment —
+  does **not** enforce it: RPG_RT stores what it stores, and enforcing on load
+  would silently drop a shield the save really held. Left for its own change:
+  `double_hand` (二刀流 on the *actor* row, 4 Nepheshel actors and 1 of mtf's),
+  which turns the shield slot into a second weapon slot — the same pair and the
+  opposite rule, and the menu's candidate list for slot 1 has to change with it.
+  See ADR 0040.
 
 ## RPG Maker with RGSS (XP / VX / VXAce)
 

--- a/docs/adr/0040-two-handed-weapons.md
+++ b/docs/adr/0040-two-handed-weapons.md
@@ -1,0 +1,73 @@
+# 40. A claymore needs both hands
+
+Date: 2026-08-06
+
+## Status
+
+Accepted
+
+## Context
+
+The item row's `two_handed` (両手持ち) marks a weapon that needs the shield hand
+as well. Nothing read it, so a two-handed weapon and a shield could be worn
+together and both bonuses counted.
+
+It is not a rare flag:
+
+| | two-handed | of weapons | shields in the game |
+|---|---|---|---|
+| Nepheshel | **35** | 104 | 20 |
+| mtf-meido-action | **14** | 26 | 8 |
+
+More than half of mtf's arsenal, and a third of Nepheshel's — every claymore,
+great sword and hammer in either game was quietly worth a shield's defence more
+than it should have been.
+
+ADR 0033 audited the equipment combat flags and did not reach this one, because
+it is not a combat modifier: it is a constraint on what may be worn at once.
+
+## Decision
+
+The weapon slot and the shield slot are mutually exclusive whenever **either**
+holds a two-handed weapon. Filling one clears the other, matching EasyRPG's
+`Game_Actor::ChangeEquipment`, which does `ChangeEquipment(other_slot, 0)` after
+writing the slot.
+
+- **Both slots are tested, not just the one being filled.** Equipping a shield
+  over a claymore has to drop the claymore, exactly as equipping the claymore
+  drops the shield. Reading only the incoming item would let the shield win by
+  going second.
+- **The flag only means anything on a weapon.** RPG_RT tests
+  `item->type == Type_weapon && item->two_handed`, so a shield that happens to
+  carry the bit does not claim the other hand. Neither test bed has one, which is
+  itself worth asserting.
+- **The emptied hand goes back to the bag.** `Party#equip_from_bag` swaps through
+  the inventory, so `Actor#equip_item` returns what it displaced and the caller
+  returns it — otherwise equipping a claymore would destroy the shield rather
+  than unequip it.
+- **A bulk `equip(ids)` does not enforce it.** That path restores a saved
+  loadout and sets initial equipment; RPG_RT stores what it stores, and EasyRPG
+  enforces the rule only in `ChangeEquipment`. Enforcing it on load would
+  silently drop a shield the save really held.
+
+## Consequences
+
+49 weapons across the two games claim the hand they need. No actor in either
+game *starts* with a two-handed weapon and a shield, so nothing about the opening
+loadouts changes; the difference is in the equip menu and in the Change Equipment
+event command, which is where the pairing could be made.
+
+Left alone: **`double_hand`** (二刀流 on the *actor* row, 4 of Nepheshel's actors
+and 1 of mtf's), which turns the shield slot into a second weapon slot. It is the
+same pair of slots and the opposite rule, and it wants its own change — the
+menu's candidate list for slot 1 has to change with it, which this does not
+touch.
+
+Covered by `scripts/rpg2k_logic_check.rb` (a two-handed weapon empties the shield
+hand and a shield knocks the two-handed weapon off, a one-handed pair lives
+together, the other three slots are untouched, a shield carrying the flag does
+not claim a hand, the emptied hand returns to the bag rather than vanishing, and
+a bulk equip restores a saved pair as-is) and by
+`scripts/rpg2k_testbed_logic_check.rb`, which equips **every** real two-handed
+weapon in both games over a real shield and asserts the hand empties, and asserts
+that no non-weapon in either game carries the flag.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1010,6 +1010,11 @@ module Game
     # Equipment slots, in save/database order: weapon, shield, armour, helmet,
     # accessory.
     EQUIP_ORDER = [:weapon, :shield, :armor, :helmet, :accessory].freeze
+    # The two slots 両手持ち makes mutually exclusive, and the item type the flag
+    # is read on.
+    WEAPON_SLOT = 0
+    SHIELD_SLOT = 1
+    ITEM_WEAPON = 1
 
     # The equipped item ids, one per EQUIP_ORDER slot (0 = an empty slot), the
     # ids of the skills the actor knows, and the ids of the status conditions
@@ -1211,7 +1216,47 @@ module Game
       slot = it.type - 1
       return unless slot >= 0 && slot < EQUIP_ORDER.size
       @equipment[slot] = item_id
+      freed = free_two_handed_slot(slot)
       recompute_stats
+      freed
+    end
+
+    # 両手持ち — a weapon that needs both hands. RPG_RT keeps the weapon and the
+    # shield slots mutually exclusive whenever either of them holds a two-handed
+    # *weapon*: filling one clears the other (EasyRPG's `Game_Actor::
+    # ChangeEquipment`, which does `ChangeEquipment(other_slot, 0)` after the
+    # slot is written). 35 of Nepheshel's 104 weapons are two-handed and 14 of
+    # mtf-meido-action's 26 -- more than half of that game's arsenal -- and
+    # nothing read the field, so a claymore and a shield could be worn together
+    # and both bonuses counted.
+    #
+    # `slot` is the one just filled; only the weapon (0) and shield (1) pair is
+    # affected, and the check reads *both* of them because equipping a shield
+    # over a two-handed weapon has to drop the weapon just as equipping the
+    # weapon drops the shield.
+    # Returns the item id it displaced, or nil -- the equip menu swaps through
+    # the bag, so what the other hand was holding has to go back there rather
+    # than vanish.
+    def free_two_handed_slot(slot)
+      return nil unless slot == WEAPON_SLOT || slot == SHIELD_SLOT
+      other = slot == WEAPON_SLOT ? SHIELD_SLOT : WEAPON_SLOT
+      held = @equipment[other]
+      return nil if held.nil? || held == 0
+      return nil unless two_handed?(@equipment[slot]) || two_handed?(held)
+      @equipment[other] = 0
+      held
+    end
+
+    # Is `item_id` a two-handed weapon? The flag only means anything on a weapon
+    # (type 1): RPG_RT tests the type alongside it, so a shield that happens to
+    # carry the bit does not claim the other hand.
+    def two_handed?(item_id)
+      return false if item_id.nil? || item_id == 0 || !@db.respond_to?(:item)
+      it = @db.item[item_id]
+      return false unless it && it.type == ITEM_WEAPON
+      it.respond_to?(:two_handed) ? ((it.two_handed || 0) != 0) : false
+    rescue StandardError
+      false
     end
 
     # Clear an equipment slot: 0..4 empties that one slot, EQUIP_ORDER.size (5)
@@ -2340,9 +2385,12 @@ module Game
       slot = equip_slot_for(item_id)
       return false if slot.nil?
       previous = actor.equipment[slot]
-      actor.equip_item(item_id)
+      # A 両手持ち weapon empties the other hand; whatever it was holding comes
+      # back to the bag alongside the item this slot displaced.
+      freed = actor.equip_item(item_id)
       lose_item(item_id, 1)
       gain_item(previous, 1) if previous && previous != 0
+      gain_item(freed, 1) if freed && freed != 0
       true
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1923,20 +1923,23 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       # 会心必殺: the weapon's own critical-hit percentage.
                       :critical_hit,
                       # 蘇生専用: does nothing at all to a target still standing.
-                      :ko_only)
+                      :ko_only,
+                      # 両手持ち: a weapon that claims the shield hand too.
+                      :two_handed)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
               state_set: nil, reverse_state: false, prevent_crit: false,
               attribute_set: nil, switch_id: 0, occ_field: true,
               field_only: false, dual_attack: false, ignore_evasion: false,
-              half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false)
+              half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
+              two_handed: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
-               ko_only)
+               ko_only, two_handed)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -8376,6 +8379,91 @@ check 'an all-party revive skips the members still standing' do
   eq [down], st.party.use_item(4, nil)
   eq 40, up.hp, 'the standing member is passed over'
   ok !down.dead?, 'the fallen one is raised'
+end
+
+# -- 両手持ち weapons (two_handed) --------------------------------------------
+# RPG_RT keeps the weapon and shield slots mutually exclusive whenever either
+# holds a two-handed weapon: filling one clears the other. 35 of Nepheshel's 104
+# weapons are two-handed and 14 of mtf-meido-action's 26.
+
+def two_handed_party
+  items = { 1 => fake_item(type: 1, atk: 20),                     # one-handed
+            2 => fake_item(type: 1, atk: 40, two_handed: 1),      # a claymore
+            3 => fake_item(type: 2, dfn: 10),                     # a shield
+            4 => fake_item(type: 3, dfn: 4) }                     # body armour
+  item_party(items)
+end
+
+check 'a two-handed weapon empties the shield hand' do
+  st = two_handed_party
+  hero = st.party.actor_by_id(1)
+  hero.equip_item(3)
+  eq 3, hero.equipment[1], 'shield on'
+  hero.equip_item(2)
+  eq 2, hero.equipment[0]
+  eq 0, hero.equipment[1], 'and the shield is off'
+end
+
+# The check reads both slots, so it works the other way round too.
+check 'a shield knocks off the two-handed weapon already worn' do
+  st = two_handed_party
+  hero = st.party.actor_by_id(1)
+  hero.equip_item(2)
+  hero.equip_item(3)
+  eq 3, hero.equipment[1]
+  eq 0, hero.equipment[0], 'the claymore had to go'
+end
+
+check 'a one-handed weapon and a shield live together' do
+  st = two_handed_party
+  hero = st.party.actor_by_id(1)
+  hero.equip_item(1)
+  hero.equip_item(3)
+  eq [1, 3], hero.equipment[0, 2]
+end
+
+check 'the rule only touches the two hands' do
+  st = two_handed_party
+  hero = st.party.actor_by_id(1)
+  hero.equip_item(4) # body armour
+  hero.equip_item(2) # claymore
+  eq 4, hero.equipment[2], 'the armour is untouched'
+  eq 2, hero.equipment[0]
+end
+
+# The flag means nothing on a non-weapon: RPG_RT tests the type alongside it.
+check 'a shield carrying the flag does not claim the other hand' do
+  items = { 1 => fake_item(type: 1, atk: 20),
+            3 => fake_item(type: 2, dfn: 10, two_handed: 1) }
+  st = item_party(items)
+  hero = st.party.actor_by_id(1)
+  hero.equip_item(1)
+  hero.equip_item(3)
+  eq [1, 3], hero.equipment[0, 2], 'both stay on'
+end
+
+# The menu swaps through the bag, so the hand it empties must give its item back.
+check 'equipping from the bag returns the emptied hand to the bag' do
+  st = two_handed_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(2, 1)
+  st.party.gain_item(3, 1)
+  ok st.party.equip_from_bag(hero, 3), 'shield on'
+  eq 0, st.party.item_count(3), 'and out of the bag'
+  ok st.party.equip_from_bag(hero, 2), 'now the claymore'
+  eq 2, hero.equipment[0]
+  eq 0, hero.equipment[1]
+  eq 1, st.party.item_count(3), 'the shield came back rather than vanishing'
+  eq 0, st.party.item_count(2)
+end
+
+# Restoring a saved loadout is not an equip action: RPG_RT stores what it stores,
+# and EasyRPG enforces the rule only in ChangeEquipment.
+check 'a bulk equip restores a saved pair as-is' do
+  st = two_handed_party
+  hero = st.party.actor_by_id(1)
+  hero.equip([2, 3, 0, 0, 0])
+  eq [2, 3], hero.equipment[0, 2], 'loaded exactly as saved'
 end
 
 # -- chipset terrain tags -----------------------------------------------------

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -440,6 +440,53 @@ def check_ko_only(dir)
   end
 end
 
+# 両手持ち — a weapon that claims the shield hand too. A fixture cannot say what
+# fraction of a real arsenal is two-handed, nor that the flag never lands on a
+# shield; both matter, because the rule reads the item's *type* alongside it.
+def check_two_handed(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  items = db[DB_ITEM]
+  return unless items
+
+  two = []
+  weapons = 0
+  shields = 0
+  odd = []
+  items.each do |id, it|
+    weapons += 1 if it.type == 1
+    shields += 1 if it.type == 2
+    next if (it.two_handed || 0) == 0
+    two << id
+    odd << id unless it.type == 1
+  end
+  puts format('   items: %d 両手持ち of %d weapon(s), %d shield(s)',
+              two.size, weapons, shields)
+  return if two.empty? || shields.zero?
+
+  check "#{name}: every real two-handed weapon empties the shield hand" do
+    party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+    hero = party.leader
+    ok hero, 'the game has someone to equip'
+    shield = nil
+    items.each { |id, it| shield ||= id if it.type == 2 }
+    two.each do |wid|
+      hero.equip([0, 0, 0, 0, 0])
+      hero.equip_item(shield)
+      eq shield, hero.equipment[1], 'the shield went on'
+      hero.equip_item(wid)
+      eq wid, hero.equipment[0], "weapon ##{wid} (#{items[wid].name}) went on"
+      eq 0, hero.equipment[1], 'and took the shield hand with it'
+    end
+    hero.equip([0, 0, 0, 0, 0])
+  end
+
+  check "#{name}: the flag never lands on something that is not a weapon" do
+    eq [], odd,
+       'a non-weapon carrying the bit would claim a hand it has no business in'
+  end
+end
+
 def check_states(dir)
   name = File.basename(dir)
   db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
@@ -1105,6 +1152,7 @@ dirs.each do |d|
   check_terrain(d)
   check_bush(d)
   check_ko_only(d)
+  check_two_handed(d)
   check_items(d)
 end
 


### PR DESCRIPTION
The item row's `two_handed` (両手持ち) marks a weapon that needs the shield hand too. Nothing read it, so a two-handed weapon and a shield could be worn together and both bonuses counted.

It is not a rare flag:

| | two-handed | of weapons | shields in the game |
|---|---|---|---|
| Nepheshel | **35** | 104 | 20 |
| mtf-meido-action | **14** | 26 | 8 |

More than half of mtf's arsenal, a third of Nepheshel's — every claymore, great sword and hammer in either game was quietly worth a shield's defence more than it should have been.

ADR 0033 audited the equipment *combat* flags and didn't reach this one, because it isn't a modifier: it's a constraint on what may be worn at once.

## The rule

The weapon and shield slots are mutually exclusive whenever **either** holds a two-handed weapon — matching EasyRPG's `Game_Actor::ChangeEquipment`, which does `ChangeEquipment(other_slot, 0)` after writing the slot.

- **Both slots are tested, not just the one being filled.** Equipping a shield over a claymore has to drop the claymore, exactly as the claymore drops the shield. Reading only the incoming item would let the shield win by going second — the easy version of this change, and wrong.
- **The flag only counts on a weapon.** RPG_RT tests `item->type == Type_weapon && item->two_handed`, so a shield carrying the bit doesn't claim the other hand. Neither test bed has one, which the test-bed check asserts rather than assumes.
- **The emptied hand goes back to the bag.** `Party#equip_from_bag` swaps through the inventory, so `equip_item` returns what it displaced and the caller hands it back — otherwise equipping a claymore would *destroy* the shield rather than unequip it.
- **A bulk `equip(ids)` doesn't enforce it.** That path restores a saved loadout and sets initial equipment; RPG_RT stores what it stores, and EasyRPG enforces only in `ChangeEquipment`. Enforcing on load would silently drop a shield the save really held.

## Scope

No actor in either game *starts* with a two-handed weapon and a shield, so opening loadouts don't change. The difference is in the equip menu and the Change Equipment event command — where the pairing could actually be made.

**`double_hand`** (二刀流 on the *actor* row, 4 Nepheshel actors and 1 of mtf's) is left for its own change: it's the same pair of slots and the opposite rule, turning the shield slot into a second weapon slot, and the menu's candidate list for slot 1 has to change with it.

## Verification

All 14 `scripts/*_check.rb` suites pass. 9 new checks; 6 fail against the pre-fix code (3 logic, 3 test-bed) — the three that pass pre-fix are the cases that must *not* change (a one-handed pair, the other slots, a bulk equip), included on purpose.

- `rpg2k_logic_check.rb` (573, +7): a two-handed weapon empties the shield hand and a shield knocks the two-handed weapon off, a one-handed pair lives together, the other three slots are untouched, a shield carrying the flag doesn't claim a hand, the emptied hand returns to the bag rather than vanishing, and a bulk equip restores a saved pair as-is.
- `rpg2k_testbed_logic_check.rb` (112, +2): equips **every** real two-handed weapon in both games over a real shield and asserts the hand empties; and asserts no non-weapon in either game carries the flag.

See `docs/adr/0040-two-handed-weapons.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_