### PR TITLE
Check the XP API list against the other game

### DIFF
--- a/changelog.d/xp-api-gap-second-game.changed.md
+++ b/changelog.d/xp-api-gap-second-game.changed.md
@@ -1,0 +1,7 @@
+- **The XP API-gap list is now checked against a second game.** It derives its
+  "needed" column from one test bed's 90 script sections, which is its obvious
+  weakness. Diffing the RGSS surface against `data/PrayforYou` — a released game
+  with 103 sections including a custom ATB battle system, its scripts inside an
+  encrypted `Game.rgssad` — turns up three calls the bed never makes
+  (`Font.default_name`, `RPG::Cache.animation`, `Table.new`) and none that only
+  the bed makes. All three are already provided.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -17,6 +17,25 @@ scripts (all 90 sections), by counting method/`.new`/constant usage — see the
 analysis approach in `scripts/rpgxp_script_host_check.rb`. Frequencies are
 approximate call counts across the bundle.
 
+**One test bed, but measured against the other.** Deriving the list from a single
+project is the obvious weakness of this document, so it was checked rather than
+left as a caveat. `data/PrayforYou` is a *released* game — 103 script sections
+against the bed's 90, including a custom ATB battle system, with its scripts
+inside an encrypted `Game.rgssad` rather than loose in `Data/`. Diffing the RGSS
+surface the two bundles call (the class-method and `.new` usage of `Graphics`,
+`Input`, `Audio`, `RPG::Cache`, `Font`, `Bitmap`, `Sprite`, `Viewport`, `Window`,
+`Plane`, `Tilemap` and the value types):
+
+| | |
+|---|---|
+| called by PrayforYou, not by the bed | **3** — `Font.default_name`, `RPG::Cache.animation`, `Table.new` |
+| called by the bed, not by PrayforYou | **0** |
+
+All three are provided (see the list below), so the released game asks for a
+strict superset of three already-implemented calls. That is evidence the
+single-project derivation is not as narrow as it looks, not proof — two games are
+still two games, and a static scan cannot see a call assembled with `send`.
+
 ## Already provided ✅
 
 These are complete enough for the stock scripts:


### PR DESCRIPTION
## The caveat

`docs/rpgxp-rgss-api-gap.md` calls itself "the whole XP roadmap", and derives its needed-API column from one project's 90 script sections. It says so plainly, which is honest — but it's also the document's obvious weakness: a list of what games ask for, built from a single game.

With both ⚠️ entries now closed (#426, #434), that caveat is the most load-bearing thing left in it.

## It was checkable

There's a second XP project in the tree, and it's the more demanding one. `data/PrayforYou` is a *released* game — 103 script sections against the bed's 90, including a custom ATB battle system, with its scripts inside an encrypted `Game.rgssad` rather than loose in `Data/`.

Diffing the RGSS surface both bundles call — the class-method and `.new` usage of `Graphics`, `Input`, `Audio`, `RPG::Cache`, `Font`, `Bitmap`, `Sprite`, `Viewport`, `Window`, `Plane`, `Tilemap` and the value types:

| | |
| --- | --- |
| called by PrayforYou, **not** by the bed | **3** — `Font.default_name`, `RPG::Cache.animation`, `Table.new` |
| called by the bed, **not** by PrayforYou | **0** |

All three are already provided. The released game asks for a strict superset of three implemented calls.

## Stated as evidence, not proof

Which is what it is, and the doc says so: two games are still two games, and a static scan can't see a call assembled with `send`. What it does establish is that the single-project derivation isn't as narrow as it looks — the more complex of the two games needed nothing new.

## Related, and deliberately not changed

While looking, I noticed the XP boot check drives the test bed through Menu, Item, Battle and Save but takes PrayforYou only to the map. That reads like a coverage hole until you read the reasoning: *"a released game's opening is an event sequence that a battle call would land in the middle of, which says nothing about the engine."* That's right, and forcing a battle into a cutscene would manufacture noise rather than coverage. Left alone.

Docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_014YGnHqkJBWbsWt1STHGK7D)_