### PR TITLE
Stop armour resisting fire spells

### DIFF
--- a/changelog.d/skill-defence-term.fixed.md
+++ b/changelog.d/skill-defence-term.fixed.md
@@ -1,0 +1,12 @@
+- **Armour no longer resists fire spells.** An enemy-scope skill's damage was
+  `effect - target.def / 4`, a defence term invented here; RPG_RT blunts a skill
+  with the **same two rates that built its effect** —
+  `physical_rate * def / 40 + magical_rate * spi / 80` — so a physical skill is
+  stopped by armour and a magical one by the target's spirit. The flat term only
+  coincided with that for a purely physical skill at rate 10: **211 of
+  Nepheshel's 276 enemy-scope skills and 112 of mtf-meido-action's 116** differ
+  from it, and **222 across the two games are purely magical**, every one of them
+  being blunted by a stat RPG_RT does not let them see. `ignore_defense` (防御無視,
+  13 and 7 skills) is read at the same time and skips the whole subtraction,
+  both halves. The `dmg < 1` floor is deliberately untouched — that is a separate
+  divergence from RPG_RT's floor of 0. See ADR 0041.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1399,6 +1399,24 @@ The work below is roughly ordered by the critical path to a walkable game
   members who never fell rather than topping them up — the case that reading
   actually decides, since a single target would be hidden by the menu gate. See
   ADR 0039.
+- ✅ **The skill damage defence term** (ADR 0041) — an enemy-scope skill's damage
+  was `skill_effect - target.def / 4`. The effect half was already RPG_RT's; the
+  defence half was invented here. RPG_RT blunts the skill with the **same two
+  rates that built the effect**: `physical_rate * def / 40 + magical_rate * spi /
+  80`, so a physical skill is stopped by armour and a magical one by the target's
+  spirit (and the divisors differ — spirit is worth half as much per point in
+  defence as in offence). The flat term coincides with that only for a purely
+  physical skill at rate 10: **211 of Nepheshel's 276 enemy-scope skills and 112
+  of mtf's 116** differ from it against a def-40/spirit-40 target. The column that
+  matters most is the **222 purely magical** skills across the two games — every
+  one was being blunted by the target's *armour*, a stat RPG_RT does not let them
+  see, so a plated knight resisted fire with his plate. `ignore_defense` (防御無視,
+  13 and 7 skills) is read at the same time and skips the **whole** subtraction,
+  not just the physical half. A missing stat absorbs nothing rather than raising,
+  and a skill costed against no target takes the full effect. Left alone: the
+  `dmg = 1 if dmg < 1` floor, where RPG_RT floors the effect at 0 and lets a 0
+  land as a "no damage" line — a separate divergence, visible in the log rather
+  than the formula, and folding it in would have hidden this change inside it.
 
 ## RPG Maker with RGSS (XP / VX / VXAce)
 

--- a/docs/adr/0041-skill-defence-term.md
+++ b/docs/adr/0041-skill-defence-term.md
@@ -1,0 +1,78 @@
+# 41. What blunts a spell
+
+Date: 2026-08-06
+
+## Status
+
+Accepted
+
+## Context
+
+An enemy-scope skill's damage was `skill_effect - target.def / 4`. The effect
+half was already RPG_RT's (`power + physical_rate * atk / 20 + magical_rate *
+spi / 40`); the defence half was invented here.
+
+RPG_RT blunts the skill with the **same two rates that built the effect**
+(EasyRPG's `Algo::CalcSkillEffect`):
+
+```
+effect -= physical_rate * target.def / 40
+effect -= magical_rate * target.spi / 80
+```
+
+So a physical skill is blunted by armour and a magical one by the target's
+spirit. A flat `def / 4` coincides with that only when the skill is purely
+physical at rate 10 — one shape out of many:
+
+| | enemy-scope skills | differ from `def / 4` * | **purely magical** |
+|---|---|---|---|
+| Nepheshel | 276 | **211** | **141** |
+| mtf-meido-action | 116 | **112** | **81** |
+
+\* against a def-40 / spirit-40 target.
+
+The purely magical column is the part that matters most. 222 skills across the
+two games have no physical component at all, and every one of them was being
+blunted by the target's **armour** — a stat RPG_RT does not let them see. A
+fully plated knight was resisting fire spells with his plate.
+
+Alongside it sat `ignore_defense` (防御無視), unread: 13 of Nepheshel's skills
+and 7 of mtf's, every armour-piercing spell in both games being blunted like any
+other.
+
+## Decision
+
+`Party#skill_defence_term(sk, target)` is the real term, and `ignore_defense`
+switches the whole subtraction off, as RPG_RT does — it skips both halves, not
+just the physical one.
+
+- **Both rates, each against its own stat.** `physical_rate * def / 40 +
+  magical_rate * spi / 80`. The two divisors differ, and that is RPG_RT's, not a
+  simplification: spirit is worth half as much per point in defence as it is in
+  offence (`/40` there against `/80` here).
+- **A missing stat absorbs nothing.** A battle fixture, or an enemy row that
+  leaves spirit out, reads 0 rather than raising — the term is a subtraction, so
+  absent means "no help" rather than "no answer".
+- **No target, no term.** An all-enemy skill is costed against `nil` before its
+  per-target effects are built, and takes the full effect there.
+
+## Consequences
+
+Almost every attack skill in both games now does different damage, and for 222
+of them the difference is qualitative rather than numeric: armour stops mattering
+to a spell.
+
+The floor is **left alone**: `dmg = 1 if dmg < 1`, where RPG_RT floors the effect
+at 0 and then lets a 0 land as a "no damage" line. That is a separate divergence
+about whether a skill can whiff for nothing, it is visible in the battle log
+rather than in the formula, and folding it in here would have hidden this change
+inside it.
+
+Covered by `scripts/rpg2k_logic_check.rb` (a physical skill blunted by armour and
+scaled by its own rate; a magical one blunted by spirit and **indifferent to
+armour**, shown by doubling each stat in turn; a skill with both rates taking
+both halves; 防御無視 skipping the whole term; and a statless target absorbing
+nothing) and by `scripts/rpg2k_testbed_logic_check.rb`, which computes the term
+for **every** enemy-scope skill in both games against a real target, checks each
+of the 222 purely magical ones reads the same through no armour and through 999,
+and checks every real 防御無視 skill is blunted by nothing at all.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2499,6 +2499,36 @@ module Game
         (sk.magical_rate || 0) * caster.int / 40
     end
 
+    # How much of an enemy-scope skill's effect the target's own stats absorb.
+    #
+    # RPG_RT scales the defence by the *same two rates* that built the effect --
+    # `physical_rate * def / 40 + magical_rate * spi / 80` (EasyRPG's
+    # `Algo::CalcSkillEffect`) -- so a physical skill is blunted by armour and a
+    # magical one by the target's spirit. This used to be a flat `def / 4`, which
+    # only coincides with the real term when the skill is purely physical at rate
+    # 10: 211 of Nepheshel's 276 enemy-scope skills and 112 of mtf's 116 differ
+    # from it against a def-40 / spirit-40 target, and 141 and 81 of them are
+    # *purely magical*, so they were being blunted by armour the caster's spell
+    # should not have cared about at all.
+    #
+    # 0 when the skill ignores defence (RPG_RT skips the whole subtraction) or
+    # there is no target to read stats from.
+    def skill_defence_term(sk, target)
+      return 0 if target.nil? || skill_ignores_defence?(sk)
+      dfn = (target.respond_to?(:def) ? target.def : 0) || 0
+      # A battle fixture (and an enemy row that leaves the field out) may carry
+      # no spirit at all; a missing stat absorbs nothing rather than raising.
+      spi = (target.respond_to?(:spi) ? target.spi : 0) || 0
+      (sk.physical_rate || 0) * dfn / 40 + (sk.magical_rate || 0) * spi / 80
+    end
+
+    # 防御無視 (`ignore_defense`): the effect lands undiminished. 13 of
+    # Nepheshel's skills and 7 of mtf's set it, and nothing read it, so every
+    # armour-piercing spell in both games was being blunted like any other.
+    def skill_ignores_defence?(sk)
+      sk.respond_to?(:ignore_defense) ? (sk.ignore_defense ? true : false) : false
+    end
+
     # The actors a field skill affects: the caster (scope 2), a chosen single ally
     # (scope 3), or the whole party (scope 4).
     def skill_targets(sk, caster, target)
@@ -2691,7 +2721,7 @@ module Game
       cost = skill_cost(sk, caster)
       base = skill_effect(sk, caster)
       if sk.scope == 0 || sk.scope == 1 # single or all enemies: an attack skill
-        dmg = base - (target ? target.def / 4 : 0)
+        dmg = base - skill_defence_term(sk, target)
         dmg = 1 if dmg < 1
         { cost: cost, hp: -dmg, mp: 0,
           inflict: skill_state_ids(sk), chance: skill_hit(sk),

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1943,14 +1943,17 @@ FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost
                        :sp_percent, :power, :physical_rate, :magical_rate,
                        :affect_hp, :affect_sp, :occasion_battle,
                        :state_effects, :reverse_state_effect, :hit, :variance,
-                       :attribute_effects, :switch_id)
+                       :attribute_effects, :switch_id,
+                       # 防御無視: the effect lands undiminished.
+                       :ignore_defense)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
                occ_battle: true, state_effects: nil, reverse_state: false, hit: 100,
-               variance: 4, attribute_effects: nil, switch_id: 1)
+               variance: 4, attribute_effects: nil, switch_id: 1,
+               ignore_defense: false)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
                 prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
-                variance, attribute_effects, switch_id)
+                variance, attribute_effects, switch_id, ignore_defense)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
 # per-turn slip damage (hp/sp change), action restriction and auto-recovery.
@@ -6095,8 +6098,11 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   st = skill_party(skills)
   caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # atk 10, spi 12, maxSP 30
   foe = combatant('Foe', 0, 8, 5, 100)                      # def 8
-  # skill_effect = 20 + 40*12/40 = 32; attack dmg = 32 - 8/4 = 30
-  eq({ cost: 6, hp: -30, mp: 0, inflict: [], chance: 100, variance: 4,
+  foe.spi = 16
+  # skill_effect = 20 + 40*12/40 = 32. Fire is purely magical (physical_rate 0,
+  # magical_rate 40), so RPG_RT blunts it with the target's *spirit* and not at
+  # all with its armour: 32 - (0*8/40 + 40*16/80) = 32 - 8 = 24.
+  eq({ cost: 6, hp: -24, mp: 0, inflict: [], chance: 100, variance: 4,
        attributes: [], absorb: false },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
   eq({ cost: 5, hp: 32, mp: 0 },
@@ -8436,6 +8442,78 @@ check 'an all-party revive skips the members still standing' do
   eq [down], st.party.use_item(4, nil)
   eq 40, up.hp, 'the standing member is passed over'
   ok !down.dead?, 'the fallen one is raised'
+end
+
+# -- the skill damage defence term --------------------------------------------
+# RPG_RT blunts an enemy-scope skill with the *same two rates* that built its
+# effect: physical_rate * def / 40 + magical_rate * spi / 80. A flat def/4 only
+# coincides with that when the skill is purely physical at rate 10.
+
+def defence_party
+  skills = {
+    1 => fake_skill(name: 'Slash', scope: 0, power: 20, prate: 10, mrate: 0),
+    2 => fake_skill(name: 'Bolt',  scope: 0, power: 20, prate: 0,  mrate: 40),
+    3 => fake_skill(name: 'Pierce', scope: 0, power: 20, prate: 10, mrate: 0,
+                    ignore_defense: true),
+    4 => fake_skill(name: 'Mixed', scope: 0, power: 20, prate: 10, mrate: 40),
+  }
+  skill_party(skills)
+end
+
+check 'a physical skill is blunted by armour, scaled by its own rate' do
+  st = defence_party
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # atk 10, spi 12
+  foe = combatant('Foe', 0, 40, 5, 100)
+  foe.spi = 40
+  # effect = 20 + 10*10/20 = 25; term = 10*40/40 + 0 = 10
+  eq(-15, st.party.battle_skill_command(st.party.db_skill(1), caster, foe)[:hp])
+end
+
+# The case a flat def/4 gets most wrong: armour should not blunt a spell at all.
+check 'a magical skill is blunted by spirit, not by armour' do
+  st = defence_party
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 40, 5, 100)
+  foe.spi = 40
+  # effect = 20 + 40*12/40 = 32; term = 0 + 40*40/80 = 20
+  eq(-12, st.party.battle_skill_command(st.party.db_skill(2), caster, foe)[:hp])
+
+  # Doubling the armour changes nothing; doubling the spirit is what bites.
+  armoured = combatant('Foe', 0, 80, 5, 100)
+  armoured.spi = 40
+  eq(-12, st.party.battle_skill_command(st.party.db_skill(2), caster, armoured)[:hp],
+     'armour is irrelevant to a spell')
+  wise = combatant('Foe', 0, 40, 5, 100)
+  wise.spi = 80
+  eq(-1, st.party.battle_skill_command(st.party.db_skill(2), caster, wise)[:hp],
+     'spirit is what resists it (floored at 1)')
+end
+
+check 'a skill with both rates takes both halves of the term' do
+  st = defence_party
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 40, 5, 100)
+  foe.spi = 40
+  # effect = 20 + 10*10/20 + 40*12/40 = 37; term = 10*40/40 + 40*40/80 = 30
+  eq(-7, st.party.battle_skill_command(st.party.db_skill(4), caster, foe)[:hp])
+end
+
+check '防御無視 skips the whole term, armour and spirit alike' do
+  st = defence_party
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 40, 5, 100)
+  foe.spi = 40
+  # effect = 25, and nothing is taken off it
+  eq(-25, st.party.battle_skill_command(st.party.db_skill(3), caster, foe)[:hp])
+end
+
+check 'a target that carries no stats absorbs nothing rather than raising' do
+  st = defence_party
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  bare = combatant('Bare', 0, 0, 5, 100) # spi nil
+  eq(-25, st.party.battle_skill_command(st.party.db_skill(1), caster, bare)[:hp])
+  eq(-32, st.party.battle_skill_command(st.party.db_skill(2), caster, nil)[:hp],
+     'and no target at all takes the full effect')
 end
 
 # -- chipset terrain tags -----------------------------------------------------

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -399,6 +399,72 @@ end
 # standing -- not even its percentage HP restore, since RPG_RT returns from the
 # item algorithm before both effects. Every such item in both test beds is a
 # revive, which is the only shape that makes the distinction visible.
+# The skill damage defence term, against the real skill table. Only a real game
+# can say how much of its arsenal the old flat `def / 4` got wrong, and that the
+# bulk of it is *purely magical* -- skills a target's armour should not touch.
+def check_skill_defence(dir)
+  name = File.basename(dir)
+  db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
+  skills = db[DB_SKILL]
+  return unless skills
+
+  atk = []
+  ignoring = []
+  magical = 0
+  skills.each do |id, sk|
+    next unless sk.scope == 0 || sk.scope == 1
+    atk << id
+    ignoring << id if sk.ignore_defense
+    magical += 1 if (sk.physical_rate || 0).zero? && (sk.magical_rate || 0) > 0
+  end
+  puts format('   skills: %d enemy-scope, %d 防御無視, %d purely magical',
+              atk.size, ignoring.size, magical)
+  return if atk.empty?
+
+  party = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+
+  check "#{name}: every enemy-scope skill takes its own two-rate defence term" do
+    foe = combatant('Foe', 0, 40, 5, 1000)
+    foe.spi = 40
+    atk.each do |id|
+      sk = skills[id]
+      want = if sk.ignore_defense
+               0
+             else
+               (sk.physical_rate || 0) * 40 / 40 + (sk.magical_rate || 0) * 40 / 80
+             end
+      eq want, party.send(:skill_defence_term, sk, foe), "skill ##{id} (#{sk.name})"
+    end
+  end
+
+  check "#{name}: a purely magical skill is indifferent to armour" do
+    soft = combatant('Soft', 0, 0, 5, 1000)
+    soft.spi = 40
+    hard = combatant('Hard', 0, 999, 5, 1000)
+    hard.spi = 40
+    n = 0
+    atk.each do |id|
+      sk = skills[id]
+      next unless (sk.physical_rate || 0).zero? && (sk.magical_rate || 0) > 0
+      n += 1
+      eq party.send(:skill_defence_term, sk, soft),
+         party.send(:skill_defence_term, sk, hard),
+         "skill ##{id} (#{sk.name}) reads the same through any armour"
+    end
+    ok n > 0, "#{n} purely magical skill(s) checked"
+  end
+
+  return if ignoring.empty?
+  check "#{name}: a real 防御無視 skill is blunted by nothing at all" do
+    hard = combatant('Hard', 0, 999, 5, 1000)
+    hard.spi = 999
+    ignoring.each do |id|
+      eq 0, party.send(:skill_defence_term, skills[id], hard),
+         "skill ##{id} (#{skills[id].name})"
+    end
+  end
+end
+
 def check_ko_only(dir)
   name = File.basename(dir)
   db = LCF::Database.new(File.open(File.join(dir, 'RPG_RT.ldb'), 'rb'))
@@ -1129,6 +1195,7 @@ dirs.each do |d|
   check_terrain(d)
   check_bush(d)
   check_ko_only(d)
+  check_skill_defence(d)
   check_items(d)
 end
 


### PR DESCRIPTION
I went to read `skill.ignore_defense` (33 rows, top of the audit's remaining list) and found the term it's supposed to switch off was invented here.

An enemy-scope skill's damage was `skill_effect - target.def / 4`. The *effect* half was already RPG_RT's (`power + physical_rate·atk/20 + magical_rate·spi/40`). The *defence* half was not.

RPG_RT blunts the skill with the **same two rates that built the effect** (EasyRPG's `Algo::CalcSkillEffect`):

```
effect -= physical_rate * target.def / 40
effect -= magical_rate * target.spi / 80
```

A physical skill is stopped by armour, a magical one by the target's spirit. The divisors differ, and that's RPG_RT's rather than a simplification — spirit is worth half as much per point in defence as it is in offence.

## How much of the arsenal that gets wrong

A flat `def / 4` coincides with the real term only for a purely physical skill at rate 10 — one shape out of many:

| | enemy-scope skills | differ from `def / 4`\* | **purely magical** |
|---|---|---|---|
| Nepheshel | 276 | **211** | **141** |
| mtf-meido-action | 116 | **112** | **81** |

\* against a def-40 / spirit-40 target

The last column is the one that matters. **222 skills across the two games have no physical component at all**, and every one was being blunted by the target's *armour* — a stat RPG_RT does not let them see. A fully plated knight was resisting fire spells with his plate.

## And the flag that started this

`ignore_defense` (防御無視) — 13 of Nepheshel's skills, 7 of mtf's — was unread, so every armour-piercing spell in both games was blunted like any other. It now skips the **whole** subtraction, both halves rather than just the physical one, as RPG_RT does.

## Details

- **A missing stat absorbs nothing.** A battle fixture, or an enemy row leaving spirit out, reads 0 rather than raising — the term is a subtraction, so absent means "no help", not "no answer".
- **No target, no term.** An all-enemy skill is costed against `nil` before its per-target effects are built, and takes the full effect there.
- **The floor is left alone.** `dmg = 1 if dmg < 1`, where RPG_RT floors the effect at 0 and lets a 0 land as a "no damage" line. That's a separate divergence — about whether a skill can whiff for nothing, visible in the battle log rather than in the formula — and folding it in would have hidden this change inside it.

## Verification

All 14 `scripts/*_check.rb` suites pass. 8 new checks; 13 failures against the pre-fix code (4 logic, 9 test-bed).

One existing check encoded the old formula (`32 - 8/4 = 30` on a purely magical skill). I rewrote it to the real rule rather than deleting it, and gave the fixture a spirit stat so the magical term is actually exercised: `32 - (0·8/40 + 40·16/80) = 24`.

- `rpg2k_logic_check.rb` (576, +5): a physical skill blunted by armour and scaled by its own rate; a magical one blunted by spirit and **indifferent to armour**, shown by doubling each stat in turn; a skill with both rates taking both halves; 防御無視 skipping the whole term; a statless target absorbing nothing.
- `rpg2k_testbed_logic_check.rb` (118, +6): computes the term for **every** enemy-scope skill in both games against a real target; checks each of the 222 purely magical ones reads the same through no armour and through 999; checks every real 防御無視 skill is blunted by nothing at all.

See `docs/adr/0041-skill-defence-term.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVp5bNuyLC6pUPsbWR6Hit)_