### PR TITLE
Fix bitmap load errors to report missing files, not stale decoder errors

### DIFF
--- a/changelog.d/bitmap-missing-file-diagnostic.fixed.md
+++ b/changelog.d/bitmap-missing-file-diagnostic.fixed.md
@@ -1,0 +1,22 @@
+- A graphic that is nowhere to be found is now reported as missing instead of
+  wearing the last decoder's error. `RGSS::Bitmap#initialize` fell back to
+  `Bitmap._load_error` / `Bitmap._stbi_error` whenever a name resolved to
+  nothing — but a name that matched no file never reaches a decoder, so those
+  globals still held some *earlier* image's failure. In practice that was always
+  stb's `no SOI`: both `stbi__load_main` and `stbi__info_main` try JPEG first,
+  and its header check fails on a PNG's magic without being cleared by the PNG's
+  later success. Every missing asset in a PNG game therefore came out as a JPEG
+  complaint about a file that was never opened — booting the packed *Pray for
+  You* said
+  `RPG::Cache: Graphics/Characters/023-Gunner01 did not load (Failed to init bitmap: … (no SOI))`
+  for what is simply an RPG Maker XP RTP charset the release does not pack (its
+  `Game.rgssad` holds 222 entries, none of them that one) with no RTP installed.
+  The loader now clears both diagnostics per load (`Bitmap._begin_load`) and
+  records whether any bytes reached a decoder (`Bitmap._decoder_ran?`), so the
+  same boot reports
+  `not found (tried .png/.jpg/.jpeg/.xyz/.bmp): GAME_DIR "…"; no RTP installed (RTP_DIR is empty); not in the encrypted archive`
+  — which names the search root that came up empty, and so the fix.
+- Failures now raise `RGSS::Bitmap::LoadError` (a `RuntimeError`, so existing
+  `rescue` clauses are unaffected), carrying the path and the reason apart.
+  `RPG::Cache` and `Graphics.transition` log the reason alone instead of
+  printing the file name twice on the same line.

--- a/docs/rpgxp-rgss-api-gap.md
+++ b/docs/rpgxp-rgss-api-gap.md
@@ -109,7 +109,14 @@ Two deliberate deviations, both forced by this engine and listed in the file's
 header: colours are re-assigned rather than mutated in place (our compositor
 snapshots on assignment), and an asset that will not load gives a blank bitmap
 with a warning instead of raising (a game whose RTP is missing must not die on
-its first graphic). A third — re-loading a bitmap for a hue variant rather than
+its first graphic). That warning says which of the search roots came up empty —
+`GAME_DIR`, `RTP_DIR`, the encrypted archive — because a released game
+references the RTP's own graphics without packing them, so "no RTP installed
+(`RTP_DIR` is empty)" is the usual answer and names the fix. It used to quote
+whatever decoder error the *previous* image had left in stb's never-cleared
+failure reason instead: always `no SOI`, stb's JPEG header check failing on a
+PNG's magic, about a file that was never opened. A third — re-loading a bitmap
+for a hue variant rather than
 `clone`ing the cached one — has since gone, because `Bitmap#clone` learned to
 copy pixels (see the end of gap 0h).
 

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -507,8 +507,27 @@ module RGSS
     # the extension are just more candidates.
     EXTENSIONS = [:png, :jpg, :jpeg, :xyz, :bmp].freeze
 
+    # Raised when a String load resolves to nothing loadable. Carries the two
+    # halves of the message separately so a caller that already names the file
+    # -- RPG::Cache logs every asset it stands a blank in for -- can report just
+    # the reason instead of printing the path twice. A RuntimeError, which is
+    # what `raise "..."` used to produce here, so `rescue` clauses around
+    # Bitmap.new keep working.
+    class LoadError < RuntimeError
+      def initialize(path, reason)
+        @path = path
+        @reason = reason
+        super("Failed to init bitmap: #{path} (#{reason})")
+      end
+
+      attr_reader :path, :reason
+    end
+
     def initialize f, s = nil
       if f.kind_of? String
+        # Forget the previous load's diagnostics, so a failure below reports
+        # this file's reason rather than some earlier image's.
+        Bitmap._begin_load
         i = self._init_file(f, s)
         [GAME_DIR, RTP_DIR].each do |d|
           next if d.nil? || d.empty?
@@ -521,17 +540,48 @@ module RGSS
         # archive with nothing loose on disk, so try that last — loose files
         # shadow the archive, which is what RGSS itself does.
         i = init_from_archive(f, s) unless i
-        # Surface the decoder's own reason (e.g. an XYZ "bad dist" zlib error)
-        # so failures are diagnosable instead of a bare "Failed to init bitmap".
-        unless i
-          detail = Bitmap._load_error
-          detail = Bitmap._stbi_error if detail.nil? || detail.empty?
-          detail = detail.nil? || detail.empty? ? "" : " (#{detail})"
-          raise "Failed to init bitmap: #{f}#{detail}"
-        end
+        raise LoadError.new(f, Bitmap.failure_reason(f)) unless i
       else
         self._init_size(f, s)
       end
+    end
+
+    # Why the load of `f` failed, for the exception #initialize raises.
+    #
+    # Two quite different failures used to read the same way. A file that was
+    # found and rejected by a decoder has a real reason to report — an XYZ's
+    # "bad dist" zlib error, say — and that is what `_load_error` /
+    # `_stbi_error` carry. A name that matched nothing anywhere never reached a
+    # decoder, and reporting those globals then quotes some *earlier* image's
+    # failure: in practice always stb's "no SOI", because stb tries JPEG first
+    # and leaves that complaint behind after every successful PNG. Released
+    # games are full of this case — they reference the RTP's graphics without
+    # packing them — so a missing RTP looked like a corrupt JPEG.
+    #
+    # `_decoder_ran?` tells the two apart; when nothing was decoded, name the
+    # places that were searched instead, since which of them is empty is the
+    # actual diagnosis.
+    def self.failure_reason(f)
+      if _decoder_ran?
+        detail = _load_error
+        detail = _stbi_error if detail.nil? || detail.empty?
+        return detail unless detail.nil? || detail.empty?
+        return "no decoder recognised the file"
+      end
+
+      where = []
+      where << "GAME_DIR \"#{GAME_DIR}\"" unless GAME_DIR.nil? || GAME_DIR.empty?
+      where << if RTP_DIR.nil? || RTP_DIR.empty?
+                 "no RTP installed (RTP_DIR is empty)"
+               else
+                 "RTP_DIR \"#{RTP_DIR}\""
+               end
+      where << if RGSS.asset_archive.nil?
+                 "no encrypted archive registered"
+               else
+                 "not in the encrypted archive"
+               end
+      "not found (tried .#{EXTENSIONS.join("/.")}): #{where.join("; ")}"
     end
 
     # Font used by #draw_text. Created lazily from the current defaults.
@@ -1257,6 +1307,10 @@ module RGSS
       def _transition_map(filename)
         return nil if filename.nil? || filename.empty?
         Bitmap.new(filename)
+      rescue Bitmap::LoadError => e
+        RGSS.warn_once("Graphics.transition: #{filename} did not load " \
+                       "(#{e.reason}); fading instead")
+        nil
       rescue StandardError => e
         RGSS.warn_once("Graphics.transition: #{filename} did not load " \
                        "(#{e.message}); fading instead")

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -560,6 +560,21 @@ mrb_value table_load(mrb_state* M, V self) {
 // subsequent extension attempts.
 static std::string g_bitmap_load_error;
 
+// Whether any decoder was handed bytes at all since the current Bitmap load
+// began. Both diagnostics above are *globals that survive a failed load*: stb
+// keeps its failure reason until the next decode sets one, and
+// g_bitmap_load_error until the next decoder fails. A name that matched no file
+// anywhere -- the RTP asset a released game references but does not pack --
+// runs no decoder, so reporting either of them attributes some earlier file's
+// error to it. Worse, stb's reason after *any* successful PNG is "no SOI": both
+// stbi__load_main and stbi__info_main try JPEG first, and its header check
+// fails on a PNG's magic without clearing the reason on the PNG's later
+// success. Every missing asset in a PNG game therefore came out as
+// "(no SOI)" -- a JPEG complaint about a file that was never opened. This flag
+// lets the Ruby loader say "not found" instead. Reset per load by
+// `Bitmap._begin_load`, read back through `Bitmap._decoder_ran?`.
+static bool g_bitmap_decoder_ran = false;
+
 static void set_bitmap_load_error(const char* fmt, ...) {
   char buf[512];
   va_list ap;
@@ -1072,11 +1087,34 @@ mrb_value bmp_load_error(mrb_state* M, V self) {
 }
 
 // Ruby: Bitmap._stbi_error -> stb_image's raw failure reason for the most
-// recent decode attempt (e.g. "bad dist", "unknown image type").
+// recent decode attempt (e.g. "bad dist", "unknown image type"). Only
+// meaningful when `_decoder_ran?` says this load reached a decoder; stb never
+// clears it, so otherwise it is whatever some earlier image left behind.
 mrb_value bmp_stbi_error(mrb_state* M, V self) {
   (void)self;
   const char* r = stbi_failure_reason();
   return mrb_str_new_cstr(M, r ? r : "");
+}
+
+// Ruby: Bitmap._begin_load -> nil. Drops the diagnostics left by whatever
+// loaded last, so a failure reports this load's reason or none at all. Called
+// once per Bitmap#initialize, before the candidate search -- not per candidate,
+// which would throw away the very message a failed decode is trying to report
+// while the loader goes on to try the remaining extensions.
+mrb_value bmp_begin_load(mrb_state* M, V self) {
+  (void)M;
+  (void)self;
+  g_bitmap_load_error.clear();
+  g_bitmap_decoder_ran = false;
+  return mrb_nil_value();
+}
+
+// Ruby: Bitmap._decoder_ran? -> whether any bytes reached a decoder since
+// `_begin_load` (see g_bitmap_decoder_ran).
+mrb_value bmp_decoder_ran(mrb_state* M, V self) {
+  (void)M;
+  (void)self;
+  return mrb_bool_value(g_bitmap_decoder_ran);
 }
 
 mrb_value bmp_init_size(mrb_state* M, mrb_value self) {
@@ -1216,6 +1254,8 @@ static bool bmp_decode_into(mrb_state* M,
                             const char* label,
                             bool trans) {
   int w, h, c;
+  // Bytes in hand: from here on a failure is a decoder's, and worth reporting.
+  g_bitmap_decoder_ran = true;
   stbi__png_transparent_palette = trans;
   // Every loader here hands back LVGL's B, G, R(, A) byte order (see
   // load_xyz_mem and load_png_tolerant_mem, which build it themselves). stb
@@ -5857,6 +5897,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_class_method(M, bmp, "_load_error", bmp_load_error,
                           MRB_ARGS_NONE());
   mrb_define_class_method(M, bmp, "_stbi_error", bmp_stbi_error,
+                          MRB_ARGS_NONE());
+  mrb_define_class_method(M, bmp, "_begin_load", bmp_begin_load,
+                          MRB_ARGS_NONE());
+  mrb_define_class_method(M, bmp, "_decoder_ran?", bmp_decoder_ran,
                           MRB_ARGS_NONE());
   mrb_define_method(M, bmp, "width", bmp_width, MRB_ARGS_NONE());
   mrb_define_method(M, bmp, "height", bmp_height, MRB_ARGS_NONE());

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -804,6 +804,67 @@ assert "RGSS::Bitmap reports a detailed reason when an XYZ fails to decode" do
   end
 end
 
+assert "RGSS::Bitmap reports a missing file as missing, not as the last decoder error" do
+  # A name that matches nothing reaches no decoder, so the only diagnostics
+  # available are the ones an *earlier* image left in stb's (never-cleared)
+  # failure reason. Quoting those is worse than saying nothing: stb tries JPEG
+  # first and its header check fails on a PNG's magic without being cleared by
+  # the PNG's later success, so after any successful PNG the stale reason is
+  # "no SOI" — and every missing asset in a PNG game (a released project's RTP
+  # references, above all) was reported as a JPEG complaint about a file that
+  # was never opened.
+  #
+  # The successful load first is what makes this an A/B: without it there is no
+  # stale reason to leak and the second half passes vacuously.
+  bytes = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52" \
+          "\x00\x00\x00\x04\x00\x00\x00\x01\x08\x00\x00\x00\x00\xdc\x57\x50" \
+          "\x11\x00\x00\x00\x0b\x49\x44\x41\x54\x78\x01\x63\x00\x62\x4e\x00" \
+          "\x00\x0e\x00\x0a\x61\xd4\xa9\x6f\x00\x00\x00\x00\x49\x45\x4e\x44" \
+          "\xae\x42\x60\x82"
+  path = "test-stale-reason.png"
+  File.open(path, "wb") { |io| io.write(bytes) }
+  begin
+    RGSS::Bitmap.new(path)
+    stale = RGSS::Bitmap._stbi_error
+    assert_true !stale.empty?, "expected stb to leave a reason behind"
+
+    err = nil
+    begin
+      RGSS::Bitmap.new("Graphics/Characters/023-Gunner01")
+    rescue => e
+      err = e.message
+    end
+    assert_true !err.nil?, "expected a load failure"
+    assert_false RGSS::Bitmap._decoder_ran?, "nothing should have been decoded"
+    assert_true err.include?("not found"), "message: #{err}"
+    # The actionable part: which search root came up empty. Here (and in a
+    # packed release with no RTP installed) that is the RTP.
+    assert_true err.include?("RTP"), "message: #{err}"
+    assert_false err.include?(stale), "message quotes a stale reason: #{err}"
+  ensure
+    File.delete(path) if File.exist?(path)
+  end
+end
+
+assert "RGSS::Bitmap::LoadError carries the path and reason apart" do
+  # RPG::Cache logs the file it is standing a blank bitmap in for, so it needs
+  # the reason without the path in front of it — the two used to be available
+  # only glued together in the message, and the log said the path twice.
+  err = nil
+  begin
+    RGSS::Bitmap.new("Graphics/Characters/023-Gunner01")
+  rescue RGSS::Bitmap::LoadError => e
+    err = e
+  end
+  assert_true !err.nil?, "expected a Bitmap::LoadError"
+  assert_equal "Graphics/Characters/023-Gunner01", err.path
+  assert_true err.reason.include?("not found"), "reason: #{err.reason}"
+  assert_false err.reason.include?(err.path), "reason repeats the path"
+  # Still a RuntimeError, which is what `rescue` clauses around Bitmap.new (and
+  # the assert_raise below) have always caught.
+  assert_true err.kind_of?(RuntimeError)
+end
+
 # ---- Loading assets out of an encrypted archive ---------------------------
 #
 # A released RPG Maker game packs its whole Graphics/ tree into Game.rgssad /

--- a/mruby-rpgxp/mrblib/rgss_library.rb
+++ b/mruby-rpgxp/mrblib/rgss_library.rb
@@ -211,6 +211,13 @@ module RPG
     # boot carries on.
     def self.load_file(path)
       RGSS::Bitmap.new(path)
+    rescue RGSS::Bitmap::LoadError => e
+      # The loader's own reason -- a decoder's complaint, or which of the search
+      # roots came up empty. Taken off the exception rather than out of its
+      # message, which spells the path out again in front of it.
+      $stderr.puts "[RGSS] RPG::Cache: #{path} did not load (#{e.reason}); " \
+                   "using a blank bitmap"
+      nil
     rescue StandardError => e
       $stderr.puts "[RGSS] RPG::Cache: #{path} did not load (#{e.message}); " \
                    "using a blank bitmap"

--- a/scripts/rpgxp_script_host_check.rb
+++ b/scripts/rpgxp_script_host_check.rb
@@ -74,10 +74,23 @@ module RGSS
   # Records draws instead of rasterising. A path containing "Missing" stands in
   # for an asset that will not load, so the cache's fallback can be checked.
   class Bitmap
+    # Mirrors the native RGSS::Bitmap::LoadError (mruby-rgss/mrblib/lib.rb):
+    # RPG::Cache rescues it by name to log the reason without the path, so the
+    # stand-in has to carry the same class and readers.
+    class LoadError < RuntimeError
+      def initialize(path, reason)
+        @path = path
+        @reason = reason
+        super("Failed to init bitmap: #{path} (#{reason})")
+      end
+
+      attr_reader :path, :reason
+    end
+
     attr_reader :width, :height, :texts, :hue, :path
     def initialize(a, b = nil)
       if a.is_a?(String)
-        raise "Failed to init bitmap: #{a}" if a.include?("Missing")
+        raise LoadError.new(a, "not found") if a.include?("Missing")
         @path = a
         @width = @height = 64
       else


### PR DESCRIPTION
## Summary

When a bitmap file cannot be found, the loader now reports it as missing rather than quoting a stale decoder error from a previous image. This fixes a confusing diagnostic where missing RTP assets were reported as JPEG corruption errors.

## Key Changes

- **New `Bitmap::LoadError` exception class**: Replaces generic string errors with a structured exception that carries the file path and reason separately. This allows callers like `RPG::Cache` to log the reason without duplicating the path.

- **Diagnostic tracking for decoder invocations**: Added `Bitmap._begin_load` to reset error state at the start of each load attempt, and `Bitmap._decoder_ran?` to distinguish between:
  - Files that reached a decoder (report the decoder's error)
  - Files that matched nothing (report which search roots were empty)

- **Improved failure messages**: When a file is not found, the error now lists the search locations checked (`GAME_DIR`, `RTP_DIR`, encrypted archive) and which one came up empty, rather than quoting stb_image's stale "no SOI" error from a previous PNG load.

- **Updated error handling in dependent code**: `RPG::Cache.load_file` and `Graphics.transition` now catch `Bitmap::LoadError` specifically to extract and log just the reason, avoiding duplicate path reporting.

## Implementation Details

- The C++ layer tracks `g_bitmap_decoder_ran` to record whether bytes reached any decoder since the current load began
- `Bitmap._begin_load` clears both `g_bitmap_load_error` and the decoder-ran flag before attempting to load
- `Bitmap.failure_reason` uses `_decoder_ran?` to choose between reporting decoder diagnostics or search location information
- The test harness (`rpgxp_script_host_check.rb`) mirrors the new `LoadError` class for compatibility
- Comprehensive test coverage validates that missing files are reported correctly and that the exception carries path/reason separately

https://claude.ai/code/session_01Aam9ngFBvzoPs8Dmad3iX6