### PR TITLE
Prevent websave.json test artifact by keeping MV localStorage in-memory

### DIFF
--- a/changelog.d/no-websave-test-artifact.fixed.md
+++ b/changelog.d/no-websave-test-artifact.fixed.md
@@ -1,0 +1,3 @@
+- Keep MV host localStorage tests in memory until a game base directory is
+  configured, preventing `save/websave.json` artifacts in the mruby test working
+  directory.

--- a/mruby-mvjs/src/mvjs.cxx
+++ b/mruby-mvjs/src/mvjs.cxx
@@ -48,6 +48,7 @@ namespace {
 // `MV::JS.base_dir=` at boot; while empty, paths pass through untouched (so the
 // host specs, which read fixtures by their own paths, are unaffected).
 std::string g_base_dir;
+int g_base_dir_version = 0;
 
 // Read a whole file into `out`. Returns false if it cannot be opened.
 bool read_file(const char* path, std::string& out) {
@@ -204,7 +205,16 @@ mrb_value js_set_base_dir(mrb_state* mrb, mrb_value self) {
   g_base_dir.assign(p, static_cast<size_t>(len));
   while (!g_base_dir.empty() && g_base_dir.back() == '/')
     g_base_dir.pop_back();
+  ++g_base_dir_version;
   return mrb_nil_value();
+}
+
+// __mv_baseDirVersion() -> base-dir generation, or -1 when game-relative writes
+// are not rooted at a game dir. Tests that exercise the host without booting a
+// game leave the base dir empty; in that mode localStorage should stay in
+// memory instead of creating save/ artifacts in the test working directory.
+JSValue js_base_dir_version(JSContext* ctx, JSValueConst, int, JSValueConst*) {
+  return JS_NewInt32(ctx, g_base_dir.empty() ? -1 : g_base_dir_version);
 }
 
 // The host-global bootstrap, evaluated once when the context is created. Kept
@@ -412,9 +422,18 @@ const char* kHostPreamble = R"MVJS(
   (function () {
     var FILE = 'save/websave.json';
     var store = null;
+    var loadedVersion = null;
+    function storageVersion() {
+      return typeof g.__mv_baseDirVersion === 'function'
+        ? g.__mv_baseDirVersion() : -1;
+    }
+    function persistent() { return storageVersion() >= 0; }
     function load() {
-      if (store) return;
+      var version = storageVersion();
+      if (store && loadedVersion === version) return;
+      loadedVersion = version;
       store = {};
+      if (!persistent()) return;
       try {
         if (g.__mv_existsSync(FILE)) {
           var txt = g.__mv_readFileSync(FILE);
@@ -423,6 +442,7 @@ const char* kHostPreamble = R"MVJS(
       } catch (e) { store = {}; }
     }
     function persist() {
+      if (!persistent()) return;
       try { g.__mv_writeFileSync(FILE, JSON.stringify(store)); } catch (e) {}
     }
     g.localStorage = {
@@ -605,6 +625,9 @@ void install_host_globals(JSContext* ctx) {
       JS_NewCFunction(ctx, js_write_file, "__mv_writeFileSync", 2));
   JS_SetPropertyStr(ctx, global, "__mv_existsSync",
                     JS_NewCFunction(ctx, js_file_exists, "__mv_existsSync", 1));
+  JS_SetPropertyStr(
+      ctx, global, "__mv_baseDirVersion",
+      JS_NewCFunction(ctx, js_base_dir_version, "__mv_baseDirVersion", 0));
   JS_FreeValue(ctx, global);
 
   JSValue r = JS_Eval(ctx, kHostPreamble, std::strlen(kHostPreamble),

--- a/mruby-mvjs/test/host_test.rb
+++ b/mruby-mvjs/test/host_test.rb
@@ -122,11 +122,19 @@ assert 'MV host provides navigator/location/performance' do
 end
 
 assert 'MV host localStorage stores and retrieves values in memory' do
-  MV::JS.eval("localStorage.setItem('save1', 'data')")
-  assert_equal "data", MV::JS.eval("localStorage.getItem('save1')")
-  assert_nil MV::JS.eval("localStorage.getItem('missing')")
-  MV::JS.eval("localStorage.removeItem('save1')")
-  assert_nil MV::JS.eval("localStorage.getItem('save1')")
+  File.delete("save/websave.json") if File.exist?("save/websave.json")
+  begin
+    MV::JS.base_dir = ""
+    MV::JS.eval("localStorage.setItem('save1', 'data')")
+    assert_equal "data", MV::JS.eval("localStorage.getItem('save1')")
+    assert_nil MV::JS.eval("localStorage.getItem('missing')")
+    assert_equal false, File.exist?("save/websave.json")
+    MV::JS.eval("localStorage.removeItem('save1')")
+    assert_nil MV::JS.eval("localStorage.getItem('save1')")
+    assert_equal false, File.exist?("save/websave.json")
+  ensure
+    File.delete("save/websave.json") if File.exist?("save/websave.json")
+  end
 end
 
 assert 'MV host require("path") provides join/dirname/basename/extname' do


### PR DESCRIPTION
### Motivation
- Tests that exercise the MV JavaScript host without booting a game were creating `save/websave.json` in the test working directory; the intent is to avoid producing that 3rd-party test artifact when no game `base_dir` is configured.

### Description
- Add a base-dir generation counter (`g_base_dir_version`) and expose it to JS via `__mv_baseDirVersion` so the host can tell when a game base directory is configured.
- Change the host JS preamble's `localStorage` shim to remain purely in-memory unless `__mv_baseDirVersion` indicates a configured base dir, skipping reads/writes of `save/websave.json` when unrooted.
- Add a small test change to `mruby-mvjs/test/host_test.rb` that sets `MV::JS.base_dir = ""` and asserts `save/websave.json` is not created, and add a changelog fragment `changelog.d/no-websave-test-artifact.fixed.md` describing the fix.

### Testing
- `clang-format -i mruby-mvjs/src/mvjs.cxx` was run successfully.
- Ruby syntax checks `ruby -c mruby-mvjs/test/host_test.rb` and `ruby -c mruby-mvjs/test/save_test.rb` succeeded (syntax OK).
- `git diff --check` returned no issues for the edited files.
- `cmake -S . -B build` / `cmake --build build -t test` were not executed to completion due to missing SDL2 development config on the machine, so the full CTest suite was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a769f4794908327a72a2ed9ea073b3d)