### PR TITLE
Add --script flag, fix title menu cursor wrap, and stop BGM on selection

### DIFF
--- a/changelog.d/main-script-flag.added.md
+++ b/changelog.d/main-script-flag.added.md
@@ -1,0 +1,5 @@
+- **`--script <file>`** runs an mruby script directly as the entry point
+  instead of booting a detected RPG Maker project, with `ARGV`/`$0` set up the
+  same way a native `ruby` invocation would. Not available in the emscripten
+  build. `scripts/preview_image.rb` is a first user: it loads a single
+  `Bitmap` into a `Sprite` for a quick visual check.

--- a/changelog.d/title-cursor-wraps.fixed.md
+++ b/changelog.d/title-cursor-wraps.fixed.md
@@ -1,0 +1,4 @@
+- **RPG2000 title menu cursor wraps around.** `Scene::Title` only moved the
+  cursor while `@selected_index` stayed inside the command list, so pressing Up
+  on New Game or Down on Shutdown did nothing — RPG_RT wraps to the other end
+  instead. Up/Down now wrap `@selected_index` modulo the fixed 3-command list.

--- a/changelog.d/title-stop-bgm-on-select.fixed.md
+++ b/changelog.d/title-stop-bgm-on-select.fixed.md
@@ -1,0 +1,4 @@
+- **Title BGM no longer bleeds into the next scene.** Confirming a title
+  command (New Game, Continue, or Shutdown) left the title BGM playing under
+  the map/load screen; `Scene::Title` now calls `Audio.bgm_stop` before
+  dispatching the selection, matching RPG_RT.


### PR DESCRIPTION
This PR introduces a new command-line feature and fixes two RPG2000 title scene behaviors to better match RPG_RT.

## Summary
Three improvements to the mruby runtime and RPG2000 title scene behavior:

## Key Changes
- **Add `--script` flag**: Enables running mruby scripts directly as the entry point instead of auto-detecting and booting an RPG Maker project. Sets up `ARGV` and `$0` the same way native `ruby` would. Not available in emscripten builds. Includes a new `scripts/preview_image.rb` utility for quick visual inspection of `Bitmap` objects in a `Sprite`.

- **Fix title menu cursor wrapping**: The title scene cursor now wraps around when pressing Up on "New Game" or Down on "Shutdown", matching RPG_RT behavior. Previously, `@selected_index` remained inside the command list bounds while the cursor display didn't move, creating an inconsistency. Now wraps `@selected_index` modulo the fixed 3-command list.

- **Stop title BGM on command selection**: The title background music no longer bleeds into the next scene (map or load screen). `Scene::Title` now calls `Audio.bgm_stop` before dispatching the selected command, matching RPG_RT behavior.

## Implementation Details
All changes are documented in the changelog entries and represent behavioral fixes and new functionality aligned with RPG_RT compatibility.

https://claude.ai/code/session_018rcKLaY1GJb3HoSYDTmx9t