### PR TITLE
Support RPG_RT.exe legacy CLI arguments (TestPlay, HideTitle, Window)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 - Displays the title image from the game's data
 - Shows a menu with options for New Game, Continue, and Shutdown
 - Supports keyboard navigation (up/down) and selection (enter/Z)
+- Understands `RPG_RT.exe`'s own legacy CLI arguments — the bare `TestPlay`,
+  `HideTitle` and `Window` words the RPG2000/2003 editor's Test Play button
+  launches the game with. `HideTitle` skips the title picture and centres the
+  command window, matching RPG_RT
 
 ### Map exploration
 - "New Game" builds the initial party from the database, reads the start

--- a/changelog.d/rpg2k-legacy-cli-args.added.md
+++ b/changelog.d/rpg2k-legacy-cli-args.added.md
@@ -1,0 +1,12 @@
+- **RPG2000/2003 now understands RPG_RT.exe's own legacy CLI arguments.** The
+  editor's Test Play button (and any shortcut built the same way) launches the
+  game as `Game.exe TestPlay HideTitle Window` — bare positional words instead
+  of `--flag=value` ones. `src/main.cxx`'s gflags parsing already left them
+  untouched and passed them straight through to `RPG2k.new(args)`, but nothing
+  read them there, so they were silently dropped. `RPG2k#initialize` now parses
+  them: `HideTitle` is read by `Scene::Title`, which skips the title picture
+  and centres the command window instead of docking it near where the picture
+  would have sat, matching RPG_RT. `TestPlay` is recorded on `RPG2k#test_play`
+  for future use. `Window` is accepted without complaint — this build's SDL
+  backend has no fullscreen mode to switch out of in the first place (see the
+  Toggle Fullscreen event command), so there is nothing left for it to do.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -300,9 +300,33 @@ class RPG2k
   HEIGHT = 240
 
 
-  attr_reader :db, :map_tree
+  attr_reader :db, :map_tree, :test_play
+  # Whether the title screen's background picture and command-window position
+  # should follow HideTitle (see Scene::Title). Named with a `?` since it
+  # answers a question, unlike the plain `test_play` value above.
+  def hide_title?; @hide_title; end
 
+  # RPG_RT.exe (and the RPG2000/2003 editor's own Test Play button) is launched
+  # with bare positional words instead of --flag=value ones, e.g.
+  # `Game.exe TestPlay HideTitle Window`. None of those look like a flag, so
+  # src/main.cxx's gflags parsing leaves them untouched and they arrive here as
+  # ordinary constructor args instead -- this is the one place that receives
+  # them, so it is the one place that has to understand them:
+  #
+  # - TestPlay: the editor is running the game, not a player. Recorded on
+  #   `test_play` for scenes to read; nothing here changes behaviour on it yet.
+  # - HideTitle: read by Scene::Title, which skips the title picture and
+  #   centres the command window instead of docking it to where the picture
+  #   would have been.
+  # - Window: RPG_RT defaults to fullscreen and this switches it to windowed.
+  #   This build's SDL backend has no fullscreen mode to begin with (see the
+  #   Toggle Fullscreen event command in interpreter.rb), so the word is
+  #   accepted -- it must not be treated as an unknown/invalid argument -- but
+  #   there is nothing left for it to switch.
   def initialize args
+    @test_play = args.include?('TestPlay')
+    @hide_title = args.include?('HideTitle')
+
     @db = LCF::Database.new File.open "#{GAME_DIR}/RPG_RT.ldb"
     @map_tree = LCF::MapTree.new File.open "#{GAME_DIR}/RPG_RT.lmt"
     @scenes = []

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -17,8 +17,12 @@ class RPG2k
       def initialize parent
         super parent
 
+        # HideTitle (RPG_RT.exe's own legacy CLI arg, parsed in RPG2k#initialize):
+        # no title picture, and the command window moves from RPG_RT's usual dock
+        # near the picture's bottom edge to the centre of the screen, since there
+        # is no picture left to dock against.
         @title = Sprite.new
-        @title.bitmap = Bitmap.new "Title/#{db.system.title}"
+        @title.bitmap = Bitmap.new "Title/#{db.system.title}" unless hide_title?
 
         @menu_items =
           [db.term.new_game, db.term.continue, db.term.shutdown].map(&:to_s)
@@ -34,7 +38,12 @@ class RPG2k
         window_height = content_h + Window::BORDER * 2
 
         window_x = (WIDTH - window_width) / 2
-        window_y = HEIGHT * BOTTOM_NUM / BOTTOM_DEN - window_height
+        window_y =
+          if hide_title?
+            (HEIGHT - window_height) / 2
+          else
+            HEIGHT * BOTTOM_NUM / BOTTOM_DEN - window_height
+          end
 
         @window = Window.new window_x, window_y, window_width, window_height
         skin = load_windowskin
@@ -125,6 +134,16 @@ class RPG2k
 
       def auto_continue?
         RPG2K_CONTINUE
+      rescue StandardError
+        false
+      end
+
+      # HideTitle, as RPG2k#initialize parsed it off RPG_RT.exe's legacy CLI
+      # arguments. Guarded the same way as the two flags above: a bare instance
+      # built without a real parent (see scripts/rpg2k_scene_check.rb's
+      # title_selector) answers false rather than raising.
+      def hide_title?
+        parent.hide_title?
       rescue StandardError
         false
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3197,6 +3197,42 @@ check 'neither flag set leaves the title screen waiting for input' do
   ok !scene.send(:auto_select?), 'no auto-select without a flag'
 end
 
+# -- RPG_RT.exe legacy CLI arg: HideTitle --------------------------------------
+#
+# RPG_RT.exe (and the RPG2000/2003 editor's own Test Play button) is launched
+# with bare positional words -- `Game.exe TestPlay HideTitle Window` -- rather
+# than --flag=value ones. RPG2k#initialize parses them off the args it is
+# already handed and exposes HideTitle as `hide_title?`; Scene::Title reads
+# that to skip the title picture and centre the command window instead of
+# docking it near where the picture would have sat. A full Scene::Title can be
+# built here (unlike RPG2k itself, which needs a real RPG_RT.ldb/.lmt) with a
+# minimal stand-in parent that only answers what Scene::Title reads.
+TitleParent = Struct.new(:db, :map_tree, :hide_title_flag) do
+  def hide_title?; hide_title_flag; end
+end
+
+check 'HideTitle hides the title picture and centres the command window' do
+  parent = TitleParent.new(fake_db, nil, true)
+  scene = RPG2k::Scene::Title.new(parent)
+  title = scene.instance_variable_get(:@title)
+  window = scene.instance_variable_get(:@window)
+  ok title.bitmap.nil?, 'no title picture is drawn'
+  eq (RPG2k::HEIGHT - window.height) / 2, window.y,
+     'the command window is centred vertically'
+end
+
+check 'without HideTitle the picture shows and the window docks near its foot' do
+  parent = TitleParent.new(fake_db, nil, false)
+  scene = RPG2k::Scene::Title.new(parent)
+  title = scene.instance_variable_get(:@title)
+  window = scene.instance_variable_get(:@window)
+  ok !title.bitmap.nil?, 'the title picture is drawn'
+  bottom_num = RPG2k::Scene::Title::BOTTOM_NUM
+  bottom_den = RPG2k::Scene::Title::BOTTOM_DEN
+  eq RPG2k::HEIGHT * bottom_num / bottom_den - window.height, window.y,
+     'the command window docks near the picture, as RPG_RT does'
+end
+
 # -- screen fade / flash overlays ---------------------------------------------
 #
 # Erase/Show Screen and Flash Screen are drawn as two full-screen colour sprites


### PR DESCRIPTION
## Summary
Add support for RPG_RT.exe's legacy command-line arguments that the RPG2000/2003 editor's Test Play button uses. The game now parses and respects `TestPlay`, `HideTitle`, and `Window` positional arguments instead of silently dropping them.

## Key Changes
- **RPG2k#initialize**: Parse legacy CLI arguments (`TestPlay`, `HideTitle`, `Window`) from the args array and expose them via `test_play` attribute and `hide_title?` method
- **Scene::Title**: Implement `HideTitle` behavior — skip loading the title picture and centre the command window vertically instead of docking it near the picture's bottom edge
- **Scene::Title#hide_title?**: Add defensive method that safely reads the parent's `hide_title?` flag with fallback to `false` for bare instances
- **Documentation**: Add comprehensive comments explaining the legacy CLI argument format and behavior, plus changelog entry and README updates

## Implementation Details
- The `HideTitle` flag changes the title scene layout: when enabled, the title picture bitmap is not loaded and the command window is centred vertically at `(HEIGHT - window_height) / 2` instead of positioned at `HEIGHT * BOTTOM_NUM / BOTTOM_DEN - window_height`
- A `TitleParent` struct is introduced in the test suite to allow testing Scene::Title with minimal parent objects
- The `Window` argument is accepted but has no effect since this SDL-based build has no fullscreen mode to toggle (as noted in the Toggle Fullscreen event command)
- All three arguments are documented with their original RPG_RT.exe semantics and current implementation status

https://claude.ai/code/session_01JC9Dn72ZuPsM659nqauMki

closes https://github.com/take-cheeze/rpg-maker-clone/issues/448