### PR TITLE
Gate debugging and CI tooling behind test-play mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
         The command line you ran, the game data used, and the steps to get
         there. A `scripts/*_check.rb` invocation that fails is ideal.
       placeholder: |
-        ./scripts/nix-develop.bash ./build/rpg_maker_clone --rpg2k_new_game data/Nepheshel
+        ./scripts/nix-develop.bash ./build/rpg_maker_clone --test_play --rpg2k_new_game data/Nepheshel
         1. New Game
         2. Walk two tiles up
     validations:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,7 +335,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=100 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=5000 --game_dir data/Lunatic-Core \
+                --timeout_ms=5000 --game_dir data/Lunatic-Core --test_play \
                 --mv_screenshot=ss/mv_title.png
 
           # Drive the real downloaded MV test bed (Lunatic-Core) past the title
@@ -350,7 +350,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=105 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=6000 --game_dir data/Lunatic-Core \
+                --timeout_ms=6000 --game_dir data/Lunatic-Core --test_play \
                 --mv_new_game --mv_move_test --mv_screenshot=ss/mv_play.png
 
           - name: MV sample smoke test
@@ -358,7 +358,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=101 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=5000 --game_dir data/mv-sample \
+                --timeout_ms=5000 --game_dir data/mv-sample --test_play \
                 --mv_new_game --mv_screenshot=ss/mv_sample.png
 
           # Play RPG Maker MZ (M6.3c): the fetched rmmz corescript + PIXI v5 on
@@ -562,7 +562,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=102 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=8000 --game_dir data/Lunatic-Core \
+                --timeout_ms=8000 --game_dir data/Lunatic-Core --test_play \
                 --mv_battle_test=1 --mv_screenshot=ss/mv_battle.png
 
           - name: MV movement smoke test
@@ -570,7 +570,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=103 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=6000 --game_dir data/mv-sample \
+                --timeout_ms=6000 --game_dir data/mv-sample --test_play \
                 --mv_new_game --mv_move_test
 
           - name: MV message smoke test
@@ -578,7 +578,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=104 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=6000 --game_dir data/mv-sample \
+                --timeout_ms=6000 --game_dir data/mv-sample --test_play \
                 --mv_new_game --mv_message_test --mv_screenshot=ss/mv_message.png
 
           # Confirm the menu path works: New Game -> map, then open the party
@@ -590,7 +590,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=106 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=6000 --game_dir data/mv-sample \
+                --timeout_ms=6000 --game_dir data/mv-sample --test_play \
                 --mv_new_game --mv_menu_test --mv_screenshot=ss/mv_menu.png
 
           # Confirm the save path works: New Game -> map, then a save+load
@@ -601,7 +601,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=107 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=6000 --game_dir data/mv-sample \
+                --timeout_ms=6000 --game_dir data/mv-sample --test_play \
                 --mv_new_game --mv_save_test
 
           # Confirm the audio path works: New Game -> map, then play the sample's
@@ -614,7 +614,7 @@ jobs:
             run: |
               ./scripts/nix-develop.bash ./scripts/quiet_alsa.bash \
                 xvfb-run --server-num=108 timeout 120 ./build/rpg_maker_clone \
-                --timeout_ms=6000 --game_dir data/mv-sample \
+                --timeout_ms=6000 --game_dir data/mv-sample --test_play \
                 --mv_new_game --mv_audio_test
 
       # The five MZ smokes above each assert their own frame in isolation (the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,7 +595,7 @@ if(NOT EMSCRIPTEN)
   # needs no game directory — the probe builds its own sprite (RGSS.effect_probe
   # in mruby-rgss/mrblib/lib.rb).
   set(render_probe_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
-                       --rgss_effect_probe --width=544 --height=416)
+                       --test_play --rgss_effect_probe --width=544 --height=416)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(render_probe_cmd
         xvfb-run --server-num=98 "--server-args=-screen 0 640x480x24"
@@ -611,7 +611,7 @@ if(NOT EMSCRIPTEN)
   # binary installs no audio backend, so every Audio call there is a no-op and a
   # broken memory path looks exactly like a working one. See RGSS.audio_probe.
   set(audio_probe_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
-                      --rgss_audio_probe)
+                      --test_play --rgss_audio_probe)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(audio_probe_cmd xvfb-run --server-num=97
                         "--server-args=-screen 0 640x480x24" ${audio_probe_cmd})
@@ -635,7 +635,8 @@ if(NOT EMSCRIPTEN)
   # Runs in the build directory, where the probe writes and then removes its
   # report file. Reserved display 96 (see the exe_open note above).
   set(error_dump_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
-                     --error_dump_probe --error_dump=error-report-probe.md)
+                     --test_play --error_dump_probe
+                     --error_dump=error-report-probe.md)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(error_dump_cmd xvfb-run --server-num=96
                        "--server-args=-screen 0 640x480x24" ${error_dump_cmd})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,8 +594,8 @@ if(NOT EMSCRIPTEN)
   # code runs and the screen never changes fails a test instead of shipping. It
   # needs no game directory — the probe builds its own sprite (RGSS.effect_probe
   # in mruby-rgss/mrblib/lib.rb).
-  set(render_probe_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
-                       --test_play --rgss_effect_probe --width=544 --height=416)
+  set(render_probe_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone --test_play
+                       --rgss_effect_probe --width=544 --height=416)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(render_probe_cmd
         xvfb-run --server-num=98 "--server-args=-screen 0 640x480x24"
@@ -610,8 +610,8 @@ if(NOT EMSCRIPTEN)
   # encrypted archive, and check both reach the mixer. mruby_test cannot — that
   # binary installs no audio backend, so every Audio call there is a no-op and a
   # broken memory path looks exactly like a working one. See RGSS.audio_probe.
-  set(audio_probe_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
-                      --test_play --rgss_audio_probe)
+  set(audio_probe_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone --test_play
+                      --rgss_audio_probe)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(audio_probe_cmd xvfb-run --server-num=97
                         "--server-args=-screen 0 640x480x24" ${audio_probe_cmd})
@@ -634,9 +634,8 @@ if(NOT EMSCRIPTEN)
   # quietly lost a section — by the time one is wanted, the crash has happened.
   # Runs in the build directory, where the probe writes and then removes its
   # report file. Reserved display 96 (see the exe_open note above).
-  set(error_dump_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone
-                     --test_play --error_dump_probe
-                     --error_dump=error-report-probe.md)
+  set(error_dump_cmd ${CMAKE_CURRENT_BINARY_DIR}/rpg_maker_clone --test_play
+                     --error_dump_probe --error_dump=error-report-probe.md)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(error_dump_cmd xvfb-run --server-num=96
                        "--server-args=-screen 0 640x480x24" ${error_dump_cmd})

--- a/README.md
+++ b/README.md
@@ -419,19 +419,25 @@
   on `stderr` and scribble over the terminal picture. The last few messages are
   tailed (newest at the bottom, coloured by severity: dim info, yellow warnings,
   red errors). On by default; turn it off with `--noterm_console` or change how
-  many rows it reserves with `--term_console_lines=N` (default 5):
+  many rows it reserves with `--term_console_lines=N` (default 5). Like the
+  profiler below, the log console and the stats overlay (`--term_stats`) are
+  test-play-only: they need either the project's own `Game.ini` `[Game]
+  Test=1` or an explicit `--test_play`, and are silently disabled otherwise:
 
   ```sh
-  ./rpg_maker_clone --sixel --term_console_lines=8 --game_dir path/to/game
+  ./rpg_maker_clone --sixel --test_play --term_console_lines=8 --game_dir path/to/game
   ```
 
 ### Profiling
 
+- Debugging tooling, so it only runs during test play: either the project's
+  own `Game.ini` `[Game] Test=1` or an explicit `--test_play` is required, or
+  the flags below are ignored
 - Measure where frame time goes with the built-in CPU/memory profiler, enabled
   with `--profile`:
 
   ```sh
-  ./rpg_maker_clone --profile --game_dir path/to/game
+  ./rpg_maker_clone --test_play --profile --game_dir path/to/game
   ```
 
 - About once a second (tune with `--profile_interval_ms=N`) it prints a summary
@@ -454,7 +460,7 @@
   (implies `--profile`):
 
   ```sh
-  ./rpg_maker_clone --profile_trace=trace.json --game_dir path/to/game
+  ./rpg_maker_clone --test_play --profile_trace=trace.json --game_dir path/to/game
   ```
 
   Every frame and section is streamed as a Chrome Trace Event and the memory

--- a/changelog.d/test-play-gated-debug-tooling.added.md
+++ b/changelog.d/test-play-gated-debug-tooling.added.md
@@ -1,0 +1,12 @@
+- **Debugging and CI-automation tooling now requires test play.** A new
+  `--test_play` flag (and, for RPG2000/2003, XP and VX/VX Ace projects, the
+  project's own `Game.ini` `[Game] Test=1` — the same signal the RPG Maker
+  editors' Test Play button writes) marks a run as a playtest. The profiler
+  (`--profile`/`--profile_trace`), the terminal log console and stats overlay
+  (`--term_console`/`--term_stats`), the `--rgss_effect_probe`/
+  `--rgss_audio_probe`/`--error_dump_probe` self-probes, and every headless
+  input-injection flag (`--rpg2k_new_game`, `--rpg2k_continue`,
+  `--rgss_host_*`, `--mv_*`, `--mz_*`) now do nothing outside test play — a
+  released game launched plainly ignores all of them, whatever is on its
+  command line. CI passes `--test_play` explicitly wherever it relies on this
+  tooling.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -323,8 +323,15 @@ class RPG2k
   #   Toggle Fullscreen event command in interpreter.rb), so the word is
   #   accepted -- it must not be treated as an unknown/invalid argument -- but
   #   there is nothing left for it to switch.
+  #
+  # `test_play` is also true when src/main.cxx resolved this run as test play
+  # some other way -- the project's own Game.ini `[Game] Test=1`, or an
+  # explicit --test_play -- since a RPG_RT.exe launched by the real editor
+  # always carries the TestPlay word too; TEST_PLAY only exists when this is
+  # the native binary (see scripts/rpg2k_scene_check.rb, which loads this file
+  # under plain CRuby and never defines it).
   def initialize args
-    @test_play = args.include?('TestPlay')
+    @test_play = args.include?('TestPlay') || native_test_play?
     @hide_title = args.include?('HideTitle')
 
     @db = LCF::Database.new File.open "#{GAME_DIR}/RPG_RT.ldb"
@@ -332,6 +339,14 @@ class RPG2k
     @scenes = []
     push Scene::Title.new self
   end
+
+  # See the TEST_PLAY comment on #initialize above.
+  def native_test_play?
+    TEST_PLAY
+  rescue StandardError
+    false
+  end
+  private :native_test_play?
 
   def push scene
     @scenes.push scene

--- a/scripts/compare-nepheshel-save-wine.bash
+++ b/scripts/compare-nepheshel-save-wine.bash
@@ -134,7 +134,7 @@ start_ours() {
     PIDS+=($!)
     sleep 1
     DISPLAY="${OUR_DISPLAY}" "${ENGINE}" --game_dir "${GAME_DIR}" \
-        --rpg2k_continue --timeout_ms="${OUR_TIMEOUT_MS:-300000}" \
+        --test_play --rpg2k_continue --timeout_ms="${OUR_TIMEOUT_MS:-300000}" \
         >/tmp/neph-save-our-player.log 2>&1 &
     PIDS+=($!)
     sleep "${OUR_BOOT_WAIT:-10}"

--- a/scripts/mz_boot_check.bash
+++ b/scripts/mz_boot_check.bash
@@ -177,7 +177,7 @@ echo "== ${GAME} (mode ${MODE})"
 # (LVGL v9.5 requires a window; the dummy driver provides one without a display.)
 if ! env -u DISPLAY -u XAUTHORITY SDL_VIDEODRIVER=dummy \
         timeout "$(( TIMEOUT_MS / 1000 + 30 ))" "${ENGINE}" \
-        --game_dir "${GAME}" --timeout_ms="${TIMEOUT_MS}" \
+        --game_dir "${GAME}" --timeout_ms="${TIMEOUT_MS}" --test_play \
         "${FLAGS[@]}" \
         --mz_screenshot="${SHOT}" \
         >"${log}" 2>&1 ; then

--- a/scripts/native-build-without-nix.bash
+++ b/scripts/native-build-without-nix.bash
@@ -158,7 +158,7 @@ say "render check: --rgss_effect_probe under Xvfb"
 # rather than merely storing its values -- the failure an earlier screen-tint
 # attempt shipped with. It prints [RGSS-PROBE] ok only when the measured frame
 # moved for every effect.
-xvfb-run -a "$build_dir/rpg_maker_clone" --rgss_effect_probe
+xvfb-run -a "$build_dir/rpg_maker_clone" --test_play --rgss_effect_probe
 
 say "boot checks: real game data to the map"
 ENGINE="$build_dir/rpg_maker_clone" xvfb-run -a bash "$root/scripts/rpg2k_boot_check.bash"

--- a/scripts/rgssad_asset_check.bash
+++ b/scripts/rgssad_asset_check.bash
@@ -142,7 +142,7 @@ for which in with without ; do
     # it.
     if ! (cd "${WORK}/${which}" && \
           xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
-            --game_dir "${WORK}/${which}" --rgss_host_new_game \
+            --game_dir "${WORK}/${which}" --test_play --rgss_host_new_game \
             --timeout_ms="${TIMEOUT_MS}") >"${log}" 2>&1 ; then
         echo "FAILED: packed ${which}: the engine exited non-zero" >&2
         fail=1

--- a/scripts/rpg2k_boot_check.bash
+++ b/scripts/rpg2k_boot_check.bash
@@ -61,7 +61,7 @@ for game in "${GAMES[@]}" ; do
     # Each game gets its own display number: xvfb-run -a's probe is not atomic
     # and can steal a display from a concurrent run (see build.yml).
     if ! xvfb-run --server-num="${num}" timeout 180 "${ENGINE}" \
-            --game_dir "${game}" --rpg2k_new_game \
+            --game_dir "${game}" --test_play --rpg2k_new_game \
             --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
         echo "FAILED: ${game}: the engine exited non-zero" >&2
         failed=$((failed + 1))

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -129,7 +129,7 @@ run_boot() {
     # and can steal a display from a concurrent run (see build.yml).
     # shellcheck disable=SC2086 # ${flags} is a deliberate word-split flag list
     if ! xvfb-run --server-num="${display}" timeout 180 "${ENGINE}" \
-            --game_dir "${game}" ${flags} \
+            --game_dir "${game}" --test_play ${flags} \
             --rgss_random_seed="${RANDOM_SEED}" \
             --timeout_ms="${TIMEOUT_MS}" >"${log}" 2>&1 ; then
         echo "FAILED: ${game} (${label}): the engine exited non-zero" >&2

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -36,6 +36,18 @@ DEFINE_int64(timeout_ms, -1, "timeout to exit");
 DEFINE_int64(width, 320, "width of the window");
 DEFINE_int64(height, 240, "height of the window");
 DEFINE_string(game_dir, "", "Game directory");
+DEFINE_bool(
+    test_play,
+    false,
+    "Explicitly mark this run as a Test Play launch, the same way the RPG "
+    "Maker editors' own Test Play button does (Game.ini's [Game] Test=1 for "
+    "RPG2000/2003, XP and VX/VX Ace projects is read automatically and does "
+    "not need this). The engine's own debugging and CI-automation tooling "
+    "-- --profile, --term_console, --term_stats, the --error_dump_probe / "
+    "--rgss_effect_probe / --rgss_audio_probe ctest probes, and the "
+    "--rpg2k_*/--rgss_host_*/--mv_*/--mz_* headless-drive flags -- only take "
+    "effect when the run is in test play; a released game launched without "
+    "Test=1 or --test_play ignores all of them");
 DEFINE_string(
     mv_screenshot,
     "",
@@ -467,6 +479,20 @@ std::string ini_rtp_name(const fs::path& game_dir) {
   return name;
 }
 
+// The RPG Maker editors (2000/2003, XP, VX/VX Ace) write `Test=1` into a
+// project's own Game.ini for the duration of a Test Play launch and strip it
+// again for a real build, so it is the authentic on-disk signal that this run
+// is a playtest rather than a released game -- unlike the CLI, which anyone
+// launching the binary controls either way. MV/MZ projects carry no Game.ini
+// at all; --test_play is the only signal for those.
+bool game_ini_test_flag(const fs::path& game_dir) {
+  const fs::path ini_path = game_dir / "Game.ini";
+  if (!fs::exists(ini_path))
+    return false;
+  inicpp::IniManager ini(ini_path.string());
+  return ini["Game"].toInt("Test") != 0;
+}
+
 // Each RGSS generation registers its RTPs under its own key, keyed by RTP name:
 // RGSS (XP) -> "Standard", RGSS2 (VX) -> "RPGVX", RGSS3 (VX Ace) -> "RPGVXAce".
 fs::path rgss_rtp_path(const std::string& rgss_key,
@@ -770,6 +796,91 @@ static bool script_host_env_enabled(const std::string& value) {
   return !(value == "0" || value == "false" || value == "off" || value == "no");
 }
 
+// Every flag below is debugging or CI-automation tooling: a profiler, a
+// terminal log/stats overlay, headless input-injection ("drive the game as if
+// testing it") and the render/audio/error-report self-probes. None of it
+// should be reachable against a released game -- one launched with neither
+// Game.ini's own Test=1 nor an explicit --test_play -- no matter what is on
+// its command line, so this resets each one to its default and says why
+// whenever the run asked for it anyway. --rgss_script_host is deliberately
+// not touched: it is not a debug feature but the only way an RGSS game runs
+// at all (docs/adr/0029-rgss-script-host-by-default.md).
+static void disable_non_test_play_flags() {
+  auto reset_bool = [](bool& flag, const char* name) {
+    if (flag) {
+      LOG(ERROR) << "--" << name
+                 << " is test-play-only tooling; ignoring outside test play "
+                    "(no Game.ini [Game] Test=1 and no --test_play)";
+      flag = false;
+    }
+  };
+  auto reset_int = [](auto& flag, const char* name) {
+    if (flag != 0) {
+      LOG(ERROR) << "--" << name
+                 << " is test-play-only tooling; ignoring outside test play "
+                    "(no Game.ini [Game] Test=1 and no --test_play)";
+      flag = 0;
+    }
+  };
+  auto reset_string = [](std::string& flag, const char* name) {
+    if (!flag.empty()) {
+      LOG(ERROR) << "--" << name
+                 << " is test-play-only tooling; ignoring outside test play "
+                    "(no Game.ini [Game] Test=1 and no --test_play)";
+      flag.clear();
+    }
+  };
+
+  reset_bool(FLAGS_rpg2k_new_game, "rpg2k_new_game");
+  reset_bool(FLAGS_rpg2k_continue, "rpg2k_continue");
+  reset_bool(FLAGS_rgss_host_new_game, "rgss_host_new_game");
+  reset_bool(FLAGS_rgss_host_move_test, "rgss_host_move_test");
+  reset_bool(FLAGS_rgss_host_menu_test, "rgss_host_menu_test");
+  reset_bool(FLAGS_rgss_host_battle_test, "rgss_host_battle_test");
+  reset_bool(FLAGS_rgss_host_save_test, "rgss_host_save_test");
+  reset_int(FLAGS_rgss_random_seed, "rgss_random_seed");
+  reset_bool(FLAGS_mv_new_game, "mv_new_game");
+  reset_int(FLAGS_mv_battle_test, "mv_battle_test");
+  reset_bool(FLAGS_mv_move_test, "mv_move_test");
+  reset_bool(FLAGS_mv_message_test, "mv_message_test");
+  reset_bool(FLAGS_mv_menu_test, "mv_menu_test");
+  reset_bool(FLAGS_mv_save_test, "mv_save_test");
+  reset_bool(FLAGS_mv_audio_test, "mv_audio_test");
+  reset_string(FLAGS_mv_screenshot, "mv_screenshot");
+  reset_bool(FLAGS_mz_new_game, "mz_new_game");
+  reset_bool(FLAGS_mz_move_test, "mz_move_test");
+  reset_bool(FLAGS_mz_audio_test, "mz_audio_test");
+  reset_bool(FLAGS_mz_message_test, "mz_message_test");
+  reset_bool(FLAGS_mz_animation_test, "mz_animation_test");
+  reset_bool(FLAGS_mz_equip_test, "mz_equip_test");
+  reset_bool(FLAGS_mz_message_play, "mz_message_play");
+  reset_bool(FLAGS_mz_shop_test, "mz_shop_test");
+  reset_bool(FLAGS_mz_encounter_test, "mz_encounter_test");
+  reset_bool(FLAGS_mz_common_event_test, "mz_common_event_test");
+  reset_bool(FLAGS_mz_transfer_test, "mz_transfer_test");
+  reset_bool(FLAGS_mz_menu_test, "mz_menu_test");
+  reset_bool(FLAGS_mz_menu_play, "mz_menu_play");
+  reset_bool(FLAGS_mz_save_test, "mz_save_test");
+  reset_int(FLAGS_mz_battle_test, "mz_battle_test");
+  reset_bool(FLAGS_mz_battle_play, "mz_battle_play");
+  reset_string(FLAGS_mz_screenshot, "mz_screenshot");
+  reset_bool(FLAGS_rgss_effect_probe, "rgss_effect_probe");
+  reset_bool(FLAGS_rgss_audio_probe, "rgss_audio_probe");
+  reset_bool(FLAGS_error_dump_probe, "error_dump_probe");
+  reset_bool(FLAGS_profile, "profile");
+  reset_string(FLAGS_profile_trace, "profile_trace");
+
+  // --term_console/--term_stats default to *on*, but only have any effect
+  // once a terminal backend (--sixel/--iterm) is active; only warn when that
+  // is actually the case, so an ordinary SDL-window launch stays quiet.
+  if ((FLAGS_sixel || FLAGS_iterm) && (FLAGS_term_console || FLAGS_term_stats))
+    LOG(ERROR) << "--term_console/--term_stats are test-play-only tooling; "
+                  "disabled outside test play (no Game.ini [Game] Test=1 and "
+                  "no --test_play)";
+  FLAGS_term_console = false;
+  FLAGS_term_stats = false;
+}
+
 int main(int argc, char** argv) {
   // Seed the script-host flag from the environment *before* parsing, so an
   // explicit --rgss_script_host on the command line still wins. The variable is
@@ -801,6 +912,18 @@ int main(int argc, char** argv) {
       FLAGS_game_dir = absolute.lexically_normal().string();
   }
   nglog::InitializeLogging(argv[0]);
+
+  // Whether this run is a Test Play launch: either the project's own
+  // Game.ini says so (the RPG Maker editors' own signal, for 2000/2003, XP
+  // and VX/VX Ace projects) or --test_play was passed explicitly (the only
+  // signal available for MV/MZ projects, which carry no Game.ini, and for CI).
+  // A released game launched plainly has neither, so the debugging and
+  // CI-automation flags below all stay off for it regardless of what else is
+  // on the command line.
+  const bool is_test_mode =
+      FLAGS_test_play || game_ini_test_flag(FLAGS_game_dir);
+  if (!is_test_mode)
+    disable_non_test_play_flags();
 
 #ifdef __EMSCRIPTEN__
   // The page has no terminal and no log file anyone can reach: ng-log's files
@@ -1037,6 +1160,12 @@ int main(int argc, char** argv) {
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "TIMEOUT_MS"),
                 mrb_fixnum_value(FLAGS_timeout_ms));
+  // Whether this run is a Test Play launch (Game.ini's own Test=1, or
+  // --test_play): the one native-side signal every maker's Ruby can consult,
+  // the same way RPG2000/2003's own `TestPlay` launch word or MV/MZ's
+  // `Utils.isOptionValid('test')` would.
+  mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "TEST_PLAY"),
+                mrb_bool_value(is_test_mode));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RPG2K_NEW_GAME"),
                 mrb_bool_value(FLAGS_rpg2k_new_game));

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -1164,8 +1164,8 @@ int main(int argc, char** argv) {
   // --test_play): the one native-side signal every maker's Ruby can consult,
   // the same way RPG2000/2003's own `TestPlay` launch word or MV/MZ's
   // `Utils.isOptionValid('test')` would.
-  mrb_const_set(M, mrb_obj_value(M->object_class), mrb_intern_lit(M, "TEST_PLAY"),
-                mrb_bool_value(is_test_mode));
+  mrb_const_set(M, mrb_obj_value(M->object_class),
+                mrb_intern_lit(M, "TEST_PLAY"), mrb_bool_value(is_test_mode));
   mrb_const_set(M, mrb_obj_value(M->object_class),
                 mrb_intern_lit(M, "RPG2K_NEW_GAME"),
                 mrb_bool_value(FLAGS_rpg2k_new_game));


### PR DESCRIPTION
## Summary

This change introduces a `--test_play` flag and gates all debugging and CI-automation tooling behind test-play mode, ensuring that released games launched without explicit test-play markers cannot access profiling, terminal overlays, headless input injection, or self-probe features.

## Key Changes

- **New `--test_play` flag**: Explicitly marks a run as a test-play launch, matching the behavior of RPG Maker editors' Test Play button
- **Game.ini Test flag detection**: Added `game_ini_test_flag()` function to read the `[Game] Test=1` setting from Game.ini for RPG2000/2003, XP, and VX/VX Ace projects
- **Test-play mode determination**: The engine now determines test-play status from either:
  - The project's own `Game.ini [Game] Test=1` (for classic RPG Maker projects)
  - An explicit `--test_play` command-line flag (for MV/MZ projects and CI)
- **Tooling gating**: Implemented `disable_non_test_play_flags()` to reset all debugging and CI flags when not in test-play mode, with appropriate error logging
- **Gated features**: The following now require test-play mode:
  - Profiler (`--profile`, `--profile_trace`)
  - Terminal overlays (`--term_console`, `--term_stats`)
  - Self-probes (`--rgss_effect_probe`, `--rgss_audio_probe`, `--error_dump_probe`)
  - All headless input-injection flags (`--rpg2k_*`, `--rgss_host_*`, `--mv_*`, `--mz_*`)
- **Native constant**: Added `TEST_PLAY` constant exposed to mruby scripts, allowing Ruby code to detect test-play mode
- **Ruby integration**: Updated RPG2000 Scene initialization to check both the `TestPlay` command-line argument and the native `TEST_PLAY` constant
- **Documentation and CI updates**: Updated README, build scripts, test scripts, and CI workflows to include `--test_play` where debugging tooling is used

## Implementation Details

- The test-play determination happens early in `main()` after logging initialization but before any game-specific setup
- A released game launched without test-play markers will silently ignore all debugging flags, regardless of command-line arguments
- Error messages are logged when test-play-only flags are used outside test-play mode, explaining why they're being ignored
- The `--rgss_script_host` flag is deliberately excluded from gating as it's required for RGSS games to run at all, not a debug feature

https://claude.ai/code/session_01Ay1jhb9PTvHuoc9aVinAt3