### PR TITLE
Add F12 key support for return-to-title functionality

### DIFF
--- a/changelog.d/rpg2k-f12-return-to-title.added.md
+++ b/changelog.d/rpg2k-f12-return-to-title.added.md
@@ -1,0 +1,5 @@
+- **RPG2000/2003**: pressing **F12** now returns to the title screen from any
+  scene (map, menu, Game Over, ...), matching `RPG_RT.exe`'s reset hotkey.
+  Reuses the existing `return_to_title` teardown already used by the "End
+  Game" menu command and the Game Over screen. `RGSS::Input::F12` is now
+  defined for every maker's scripts to read as well.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1342,6 +1342,7 @@ module RGSS
     F7 = 17
     F8 = 18
     F9 = 19
+    F12 = 20
 
     # RGSS2 (VX) and RGSS3 (VX Ace) name the keys with **symbols** —
     # `Input.trigger?(:C)` — where RGSS1 (XP) used the integer constants above.
@@ -1354,13 +1355,13 @@ module RGSS
       UP: UP, DOWN: DOWN, LEFT: LEFT, RIGHT: RIGHT,
       A: A, B: B, C: C, X: X, Y: Y, Z: Z, L: L, R: R,
       SHIFT: SHIFT, CTRL: CTRL, ALT: ALT,
-      F5: F5, F6: F6, F7: F7, F8: F8, F9: F9
+      F5: F5, F6: F6, F7: F7, F8: F8, F9: F9, F12: F12
     }.freeze
 
-    @pressed = Array.new(20, false)
-    @triggered = Array.new(20, false)
-    @repeated = Array.new(20, false)
-    @count = Array.new(20, 0)
+    @pressed = Array.new(21, false)
+    @triggered = Array.new(21, false)
+    @repeated = Array.new(21, false)
+    @count = Array.new(21, 0)
 
     # Key index for either spelling. An unrecognised key reads as unpressed
     # rather than raising (a script may probe a key this build has no name for),

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -37,6 +37,7 @@ enum Key {
   KEY_A = 4,
   KEY_B = 5,
   KEY_C = 6,
+  KEY_F12 = 20,
 };
 
 // Terminals do not report key-release events, so a key is considered held for
@@ -95,7 +96,8 @@ struct KeyState {
   bool pressed = false;
   uint32_t expiry = 0;
 };
-KeyState g_keys[16];
+// Sized to KEY_F12 + 1 -- the highest key id this backend can produce.
+KeyState g_keys[21];
 
 // ---------------------------------------------------------------------------
 // Async stdout writer: a background thread drains queued frames so flush_cb
@@ -610,6 +612,30 @@ void terminal_poll(mrb_state* M) {
   for (size_t i = 0; i < buf.size();) {
     const unsigned char c = static_cast<unsigned char>(buf[i]);
     if (c == 0x1b && i + 2 < buf.size() && buf[i + 1] == '[') {
+      // F12 -- RPG_RT's return-to-title hotkey (RGSS::Input::F12, read by
+      // mruby-rpg2k's main_loop) -- arrives as a multi-digit CSI sequence
+      // terminated by '~' (`ESC [ 24 ~` in xterm and its descendants: foot,
+      // alacritty, kitty, gnome-terminal, wezterm, tmux, ...), unlike the
+      // single-letter arrow sequences below.
+      if (buf[i + 2] >= '0' && buf[i + 2] <= '9') {
+        size_t j = i + 2;
+        int value = 0;
+        while (j < buf.size() && buf[j] >= '0' && buf[j] <= '9') {
+          value = value * 10 + (buf[j] - '0');
+          ++j;
+        }
+        if (j < buf.size() && buf[j] == '~') {
+          if (value == 24)
+            hold_key(M, KEY_F12, now);
+          i = j + 1;
+        } else {
+          // No terminating '~' buffered yet; drop the digits read so far
+          // rather than replaying them through the plain-character switch.
+          i = j;
+        }
+        continue;
+      }
+
       switch (buf[i + 2]) {
         case 'A':
           hold_key(M, KEY_UP, now);

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1436,7 +1436,7 @@ assert "RGSS::Input accepts RGSS2/RGSS3 symbol keys" do
 
     # Every RGSS3 key name maps, and an unknown one reads as unpressed instead
     # of raising out of the game loop.
-    assert_equal 20, RGSS::Input::SYMBOL_KEYS.size
+    assert_equal 21, RGSS::Input::SYMBOL_KEYS.size
     RGSS::Input::SYMBOL_KEYS.each do |name, index|
       assert_equal index, RGSS::Input.key_index(name), "key #{name} maps wrong"
     end

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -559,7 +559,15 @@ class RPG2k
 
   def main_loop
     RGSS::Profiler.frame do
-      RGSS::Profiler.section("scene.update") { @scenes.last.update }
+      RGSS::Profiler.section("scene.update") do
+        # F12 is RPG_RT's "return to title" hotkey: it works from any scene
+        # (map, menu, game over, ...), not just ones that offer it as a menu
+        # command, so it is checked here rather than in an individual scene.
+        # Reuses the same teardown/rebuild return_to_title already does for
+        # the "End Game" menu command and the Game Over screen.
+        return_to_title if Input.trigger?(Input::F12)
+        @scenes.last.update
+      end
       RGSS::Profiler.section("input.update") { Input.update }
       Graphics.update
     end

--- a/src/sdl_input.cxx
+++ b/src/sdl_input.cxx
@@ -41,6 +41,7 @@ enum RgssKey {
   KEY_F7 = 17,
   KEY_F8 = 18,
   KEY_F9 = 19,
+  KEY_F12 = 20,
 };
 
 // Map an SDL keysym to an RGSS::Input key id, or -1 when the key is unbound.
@@ -100,6 +101,8 @@ int map_key(SDL_Keycode k) {
       return KEY_F8;
     case SDLK_F9:
       return KEY_F9;
+    case SDLK_F12:
+      return KEY_F12;
     default:
       return -1;
   }


### PR DESCRIPTION
## Summary
This PR adds support for the F12 key across the codebase, enabling a return-to-title hotkey feature that matches RPG_RT.exe's behavior. The F12 key can now be pressed from any scene (map, menu, Game Over, etc.) to return to the title screen.

## Key Changes
- **Input System**: Added `F12 = 20` constant to the Input module in both mruby-rgss and the SDL input handler
- **Input Arrays**: Expanded internal input state arrays (`@pressed`, `@triggered`, `@repeated`, `@count`) from size 20 to 21 to accommodate the new F12 key
- **Symbol Keys Mapping**: Updated `SYMBOL_KEYS` hash to include the F12 key mapping
- **Main Loop Integration**: Integrated F12 check into the main game loop to detect when F12 is pressed and trigger `return_to_title` from any scene
- **Tests**: Updated test assertion to expect 21 keys instead of 20 in `SYMBOL_KEYS`

## Implementation Details
- The F12 hotkey is checked in the main game loop's `scene.update` section before individual scene updates, ensuring it works globally across all scenes
- The implementation reuses the existing `return_to_title` method that handles teardown and rebuild, maintaining consistency with the "End Game" menu command and Game Over screen behavior
- SDL input mapping was updated to recognize `SDLK_F12` and map it to `KEY_F12`
- A changelog entry documents this as a new feature for RPG2000/2003 games

https://claude.ai/code/session_015vE5BAz9JHghH2uH6QJnZG