### PR TITLE
Remove .envrc configuration file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,0 @@
-use flake
-
-export LANG=ja_JP.UTF-8
-export DOCKER_DEFAULT_PLATFORM=linux/amd64
-export SDL_AUDIODRIVER=pulseaudio


### PR DESCRIPTION
## Summary
This change removes the `.envrc` file that was used for direnv-based environment configuration.

## Key Changes
- Removed `.envrc` file containing:
  - Flake integration (`use flake`)
  - Language locale setting (`LANG=ja_JP.UTF-8`)
  - Docker platform configuration (`DOCKER_DEFAULT_PLATFORM=linux/amd64`)
  - SDL audio driver setting (`SDL_AUDIODRIVER=pulseaudio`)

## Rationale
The direnv configuration is no longer needed for this project. Environment setup may now be handled through alternative means such as shell configuration, documentation, or other tooling.

https://claude.ai/code/session_01XLGutKreP5tSCpMrAW5pKD