### PR TITLE
Localize UI text through database terms with English fallbacks

### DIFF
--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -80,9 +80,24 @@ class RPG2k
       # leaving the column blank), or a plain English stand-in for a database
       # that leaves the term unset.
       def normal_status_term
+        term(:normal_status, 'Normal')
+      end
+
+      # `db.term.<name>`, or `fallback` when the field is blank or the scene is
+      # built on a fixture database that carries no term table at all. Shared by
+      # every scene that draws vocabulary the database lets a project rename
+      # (menu commands, stat abbreviations, equipment slots, ...), so a bare or
+      # partially-filled database still reads as English rather than blank.
+      def term(name, fallback)
         t = db.respond_to?(:term) ? db.term : nil
-        s = t && t.respond_to?(:normal_status) ? t.normal_status : nil
-        s.nil? || s.to_s.empty? ? 'Normal' : s
+        s = t && t.respond_to?(name) ? t.send(name) : nil
+        nonblank(s, fallback)
+      end
+
+      # `s`, or `fallback` when `s` is nil/empty once stringified.
+      def nonblank(s, fallback)
+        s = s.to_s
+        s.empty? ? fallback : s
       end
     end
 

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -12,7 +12,6 @@ class RPG2k
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
-      SLOTS = ["Weapon", "Shield", "Armor", "Helmet", "Accessory"].freeze
 
       def initialize parent, state
         super parent
@@ -22,6 +21,10 @@ class RPG2k
         @slot_index = 0
         @cand_index = 0
         @mode = :slots          # :slots list, or :items candidate pick
+        @slots = [
+          term(:weapon, "Weapon"), term(:shield, "Shield"), term(:armor, "Armor"),
+          term(:helmet, "Helmet"), term(:accessory, "Accessory")
+        ]
         build_stats_window
         build_slot_window
       end
@@ -53,7 +56,7 @@ class RPG2k
         party = @state.party.actors
         if Input.trigger?(Input::B)
           @parent.pop
-        elsif Input.trigger?(Input::DOWN) && @slot_index < SLOTS.size - 1
+        elsif Input.trigger?(Input::DOWN) && @slot_index < @slots.size - 1
           @slot_index += 1
           refresh_slot_cursor
         elsif Input.trigger?(Input::UP) && @slot_index > 0
@@ -112,7 +115,7 @@ class RPG2k
       end
 
       def rebuild_for_actor
-        @slot_index = SLOTS.size - 1 if @slot_index >= SLOTS.size
+        @slot_index = @slots.size - 1 if @slot_index >= @slots.size
         build_stats_window
         build_slot_window
       end
@@ -127,18 +130,20 @@ class RPG2k
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
         a = actor
-        c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}  Lv #{a.level}"
+        c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}  #{term(:level_short, 'Lv')} #{a.level}"
         c.draw_text 0, LINE_H, inner_w, LINE_H,
-                    "HP #{a.hp}/#{a.max_hp}  MP #{a.mp}/#{a.max_mp}"
+                    "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
+                    "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
         c.draw_text 0, LINE_H * 2, inner_w, LINE_H,
-                    "Atk #{a.atk}  Def #{a.def}  Int #{a.int}  Agi #{a.agi}"
+                    "#{term(:attack, 'Atk')} #{a.atk}  #{term(:defense, 'Def')} #{a.def}  " \
+                    "#{term(:mind, 'Int')} #{a.int}  #{term(:agility, 'Agi')} #{a.agi}"
         @stats_window.contents = c
       end
 
       def build_slot_window
         @slot_window.dispose if @slot_window
         inner_w = SCREEN_W - Window::BORDER * 2
-        h = SLOTS.size * LINE_H
+        h = @slots.size * LINE_H
         y = LINE_H * 3 + Window::BORDER * 2
         @slot_window = Window.new(0, y, SCREEN_W, h + Window::BORDER * 2)
         @slot_window.z = 400
@@ -146,7 +151,7 @@ class RPG2k
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
         eq = actor.equipment
-        SLOTS.each_with_index do |label, i|
+        @slots.each_with_index do |label, i|
           c.draw_text 0, i * LINE_H, 80, LINE_H, label
           c.draw_text 80, i * LINE_H, inner_w - 80, LINE_H, item_name(eq[i])
         end

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -197,7 +197,8 @@ class RPG2k
           # list, since it is where you pick who to use an antidote on.
           draw_actor_state c, a, 0, y, inner_w, LINE_H, @skin, 2
           c.draw_text 0, y + LINE_H, inner_w, LINE_H,
-                      "HP #{a.hp}/#{a.max_hp}  MP #{a.mp}/#{a.max_mp}"
+                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
+                      "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
         end
         @target_window.contents = c
         refresh_target_cursor

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2073,11 +2073,6 @@ class RPG2k
         }
       end
 
-      def nonblank(s, fallback)
-        s = s.to_s
-        s.empty? ? fallback : s
-      end
-
       def open_inn_window(req)
         terms = inn_terms(req[:type])
         gold_term = nonblank(db.term.gold, 'G')
@@ -2604,12 +2599,20 @@ class RPG2k
       end
 
       # The four per-actor commands, in menu order (the cursor row is 1 + index,
-      # below the actor-name header).
-      BATTLE_COMMANDS = %w[Attack Skill Item Defend].freeze
+      # below the actor-name header), read from the database's battle-command
+      # terms with the standard RPG2k labels as fallback.
+      def battle_commands
+        @battle_commands ||= [
+          term(:battle_attack, 'Attack'),
+          term(:battle_skill, 'Skill'),
+          term(:battle_item, 'Item'),
+          term(:battle_defend, 'Defend')
+        ]
+      end
 
       # Per-actor command menu: Attack, Skill, Item or Defend.
       def drive_battle_command
-        last = BATTLE_COMMANDS.length - 1
+        last = battle_commands.length - 1
         if Input.trigger?(Input::DOWN) && @battle_ui[:cmd] < last
           @battle_ui[:cmd] += 1
           draw_battle_command
@@ -3556,7 +3559,7 @@ class RPG2k
         actor = current_actor
         return unless actor
         @battle_ui[:cmd_win].dispose if @battle_ui[:cmd_win]
-        labels = [actor.name] + BATTLE_COMMANDS
+        labels = [actor.name] + battle_commands
         w = 96
         inner_h = labels.length * BATTLE_LINE_H
         win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -7,7 +7,16 @@ class RPG2k
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
-      COMMANDS = ["Item", "Skill", "Equip", "Status", "Save", "End Game"].freeze
+      # Command keys in menu order, paired with the database term (and its
+      # RPG_RT-standard English fallback) that names each on screen.
+      COMMAND_KEYS = [
+        [:item, :battle_item, "Item"],
+        [:skill, :battle_skill, "Skill"],
+        [:equip, :battle_equipment, "Equip"],
+        [:status, :status, "Status"],
+        [:save, :battle_save, "Save"],
+        [:end_game, :battle_end_game, "End Game"]
+      ].freeze
 
       def initialize parent, state
         super parent
@@ -15,6 +24,9 @@ class RPG2k
         @index = 0
         @message = nil
         @skin = make_windowskin
+        @commands = COMMAND_KEYS.map { |key, term_name, fallback|
+          [key, term(term_name, fallback)]
+        }
         build_windows
       end
 
@@ -27,7 +39,7 @@ class RPG2k
       def update
         return drive_message if @message
 
-        if Input.trigger?(Input::DOWN) && @index < COMMANDS.size - 1
+        if Input.trigger?(Input::DOWN) && @index < @commands.size - 1
           @index += 1
           refresh_cursor
         elsif Input.trigger?(Input::UP) && @index > 0
@@ -44,13 +56,13 @@ class RPG2k
 
       def build_windows
         cw = 108
-        @command = Window.new(0, 0, cw, COMMANDS.size * LINE_H + Window::BORDER * 2)
+        @command = Window.new(0, 0, cw, @commands.size * LINE_H + Window::BORDER * 2)
         @command.z = 400
         @command.windowskin = @skin
-        cc = Bitmap.new(cw - Window::BORDER * 2, COMMANDS.size * LINE_H)
+        cc = Bitmap.new(cw - Window::BORDER * 2, @commands.size * LINE_H)
         cc.font.color = Color.new(255, 255, 255, 255)
-        COMMANDS.each_with_index do |c, i|
-          cc.draw_text 0, i * LINE_H + 2, cc.width, LINE_H, c
+        @commands.each_with_index do |(_key, label), i|
+          cc.draw_text 0, i * LINE_H + 2, cc.width, LINE_H, label
         end
         @command.contents = cc
         refresh_cursor
@@ -68,7 +80,9 @@ class RPG2k
           # this panel is only 196px wide, so it goes where there is room.
           draw_actor_state sc, a, 0, y, sc.width, 14, @skin, 2
           sc.draw_text 0, y + 16, sc.width, 14,
-                       "Lv #{a.level}  HP #{a.hp}/#{a.max_hp}  MP #{a.mp}/#{a.max_mp}"
+                       "#{term(:level_short, 'Lv')} #{a.level}  " \
+                       "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
+                       "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
         end
         @status.contents = sc
       end
@@ -79,25 +93,26 @@ class RPG2k
       end
 
       def select_command
-        case COMMANDS[@index]
-        when "Item"
+        key, label = @commands[@index]
+        case key
+        when :item
           @parent.push Scene::ItemMenu.new(@parent, @state)
-        when "Skill"
+        when :skill
           @parent.push Scene::SkillMenu.new(@parent, @state)
-        when "Equip"
+        when :equip
           @parent.push Scene::EquipMenu.new(@parent, @state)
-        when "Status"
+        when :status
           @parent.push Scene::StatusMenu.new(@parent, @state)
-        when "Save"
+        when :save
           if @state.save_access
             show_message(@parent.save_game(@state) ? "Game saved." : "Save failed.")
           else
             show_message("You cannot save right now.")
           end
-        when "End Game"
+        when :end_game
           show_message("Returning to title...", :end_game)
         else
-          show_message("#{COMMANDS[@index]} is not implemented yet.")
+          show_message("#{label} is not implemented yet.")
         end
       end
 

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -164,14 +164,15 @@ class RPG2k
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
         a = caster
-        c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}   SP #{a.mp}/#{a.max_mp}"
+        mp_term = term(:mp_short, 'MP')
+        c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}   #{mp_term} #{a.mp}/#{a.max_mp}"
         if rows.empty?
           c.draw_text 0, head_h, inner_w, LINE_H, "No skills"
         else
           rows.each_with_index do |(sid, cost), i|
             y = head_h + i * LINE_H
             c.draw_text 0, y, inner_w - 40, LINE_H, skill_name(sid)
-            c.draw_text inner_w - 40, y, 40, LINE_H, "#{cost} SP"
+            c.draw_text inner_w - 40, y, 40, LINE_H, "#{cost} #{mp_term}"
           end
         end
         @skill_window.contents = c
@@ -204,7 +205,8 @@ class RPG2k
           # list, since it is where you pick who to use an antidote on.
           draw_actor_state c, a, 0, y, inner_w, LINE_H, @skin, 2
           c.draw_text 0, y + LINE_H, inner_w, LINE_H,
-                      "HP #{a.hp}/#{a.max_hp}  MP #{a.mp}/#{a.max_mp}"
+                      "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}  " \
+                      "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}"
         end
         @target_window.contents = c
         refresh_target_cursor

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -9,7 +9,6 @@ class RPG2k
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
-      SLOTS = ["Weapon", "Shield", "Armor", "Helmet", "Accessory"].freeze
       # The condition row: which line of the panel it is, its label, and where
       # the state itself starts (clear of the label).
       STATE_ROW = 4
@@ -21,6 +20,10 @@ class RPG2k
         @state = state
         @skin = make_windowskin
         @actor_index = 0
+        @slots = [
+          term(:weapon, "Weapon"), term(:shield, "Shield"), term(:armor, "Armor"),
+          term(:helmet, "Helmet"), term(:accessory, "Accessory")
+        ]
         build_window
       end
 
@@ -64,9 +67,12 @@ class RPG2k
         nxt = a.exp_to_next
         lines = [
           header,
-          "Lv #{a.level}    EXP #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
-          "HP #{a.hp}/#{a.max_hp}    MP #{a.mp}/#{a.max_mp}",
-          "Atk #{a.atk}   Def #{a.def}   Int #{a.int}   Agi #{a.agi}",
+          "#{term(:level_short, 'Lv')} #{a.level}    " \
+          "#{term(:exp_short, 'EXP')} #{a.exp}    Next #{nxt.nil? ? '---' : nxt}",
+          "#{term(:hp_short, 'HP')} #{a.hp}/#{a.max_hp}    " \
+          "#{term(:mp_short, 'MP')} #{a.mp}/#{a.max_mp}",
+          "#{term(:attack, 'Atk')} #{a.atk}   #{term(:defense, 'Def')} #{a.def}   " \
+          "#{term(:mind, 'Int')} #{a.int}   #{term(:agility, 'Agi')} #{a.agi}",
           # The condition gets a labelled row of its own, as on RPG_RT's status
           # screen (its Window_ActorInfo draws the label then the state). Only
           # the label goes through the flat pass below; the state itself is drawn
@@ -75,7 +81,7 @@ class RPG2k
           "",
         ]
         eqp = a.equipment
-        SLOTS.each_with_index { |label, i| lines.push("#{label}: #{item_name(eqp[i])}") }
+        @slots.each_with_index { |label, i| lines.push("#{label}: #{item_name(eqp[i])}") }
         lines.each_with_index do |line, i|
           c.draw_text 0, i * LINE_H, inner_w, LINE_H, line
         end

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -24,8 +24,11 @@ class RPG2k
         @title = Sprite.new
         @title.bitmap = load_title_picture unless hide_title?
 
-        @menu_items =
-          [db.term.new_game, db.term.continue, db.term.shutdown].map(&:to_s)
+        @menu_items = [
+          term(:new_game, 'New Game'),
+          term(:continue, 'Continue'),
+          term(:shutdown, 'Shutdown')
+        ]
         @selected_index = 0
 
         # RPG_RT sizes the window to the widest label plus one border on each


### PR DESCRIPTION
This change introduces a centralized localization system for UI text throughout the game scenes, allowing vocabulary to be customized via the database while maintaining English fallbacks for incomplete or fixture databases.

## Summary
Replaces hardcoded English strings with dynamic lookups to `db.term.<name>`, falling back to standard English labels when the database term is unavailable or empty. This enables projects to rename menu commands, stat abbreviations, equipment slots, and other UI vocabulary without modifying code.

## Key Changes

- **New `term(name, fallback)` helper in `Base`**: Centralized method to fetch database terms with fallback support, shared across all scenes
- **New `nonblank(s, fallback)` helper in `Base`**: Utility to return fallback when a value is nil or empty after stringification
- **Menu scene (`menu.rb`)**: 
  - Replaced `COMMANDS` constant with `COMMAND_KEYS` array pairing command symbols to term names and fallbacks
  - Commands now dynamically built from database terms in `initialize`
  - Updated `select_command` to use command keys instead of string matching
  
- **Equipment menu (`equip_menu.rb`)**: 
  - Replaced `SLOTS` constant with instance variable `@slots` built from database terms
  - Equipment slot labels now localized (weapon, shield, armor, helmet, accessory)
  
- **Status menu (`status_menu.rb`)**: 
  - Replaced `SLOTS` constant with instance variable `@slots` built from database terms
  - Stat abbreviations and labels now use database terms (Lv, HP, MP, Atk, Def, Int, Agi)
  
- **Skill menu (`skill_menu.rb`)**: 
  - Stat abbreviations now use database terms (HP, MP)
  
- **Item menu (`item_menu.rb`)**: 
  - Stat abbreviations now use database terms (HP, MP)
  
- **Battle system (`map.rb`)**: 
  - Replaced `BATTLE_COMMANDS` constant with `battle_commands` method that builds commands from database terms
  - Battle command labels now localized (Attack, Skill, Item, Defend)
  
- **Title screen (`title.rb`)**: 
  - Menu items now built from database terms with fallbacks (New Game, Continue, Shutdown)

## Implementation Details

- The `term` method gracefully handles databases without a term table (fixture databases used in tests)
- All fallback strings are standard RPG2k English labels, ensuring consistent appearance when database terms are unavailable
- Instance variables replace constants where needed to allow dynamic initialization based on database state
- Existing functionality is preserved; this is purely a localization refactor

https://claude.ai/code/session_01UXS5LtEjxLJ7eK7xSa1hPN