### PR TITLE
Keep message window open for Show Choices/Input Number followups

### DIFF
--- a/changelog.d/rpg2k-message-window-followup.fixed.md
+++ b/changelog.d/rpg2k-message-window-followup.fixed.md
@@ -1,0 +1,14 @@
+- **Show Text keeps its window open for a Show Choices / Input Number that
+  follows directly.** `Scene::Map` used to close the message window
+  unconditionally once its text finished revealing, then build a brand-new
+  window (or, for Input Number, an unrelated small centred widget) for the
+  very next command — so a block like "How many potions?" followed by an
+  Input Number, or a message followed immediately by a yes/no Show Choices,
+  flickered the window shut and reopened it empty instead of appending the
+  choices or digit entry below the text already shown, as RPG_RT does.
+  `Game::Interpreter#do_show_message` now peeks at the next command (same
+  indent, nothing in between); when it is Show Choices or Input Number, the
+  scene keeps the same window and appends the choice list or digit cells
+  below the existing text instead of closing and rebuilding it. The window
+  still closes normally when nothing follows, or once the choice/number is
+  confirmed.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -212,7 +212,7 @@ module Game
     attr_reader :wait_kind, :message_lines, :choice_labels, :wait_frames,
                 :teleport, :input_digits, :key_input_request, :inn_request,
                 :shop_request, :battle_request, :name_input_request,
-                :battle_animation, :choice_cancel_type
+                :battle_animation, :choice_cancel_type, :message_followup
     # Resolves the command list a Call Event refers to (a common event, or a page
     # of a map event). Set by the owning scene; nil disables Call Event.
     attr_accessor :resolver
@@ -679,6 +679,7 @@ module Game
       @waiting = false
       @wait_kind = nil
       @message_lines = nil
+      @message_followup = nil
       @choice_labels = nil
       # 0 = cancelling forbidden, which is also the right answer while nothing
       # is being chosen (see #choice_cancellable?).
@@ -939,6 +940,19 @@ module Game
         @index += 1
       end
       @message_lines = lines
+      # RPG_RT keeps the same message window on screen when a Show Choices or
+      # Input Number command immediately follows (same indent, nothing else
+      # between): the typed-out lines stay up and the choices / digit entry
+      # appear below them, instead of the window closing and a new one
+      # opening. Peek at the next command now, before it runs, so the scene
+      # knows at reveal-completion time whether to keep the window.
+      next_cmd = @list[@index]
+      @message_followup =
+        if next_cmd && next_cmd.indent == cmd.indent && next_cmd.code == Cmd::SHOW_CHOICES
+          :choice
+        elsif next_cmd && next_cmd.indent == cmd.indent && next_cmd.code == Cmd::INPUT_NUMBER
+          :number
+        end
       @wait_kind = :message
       @waiting = true
     end
@@ -1498,6 +1512,10 @@ module Game
     def show_next_pending_message
       return false if @pending_messages.empty?
       @message_lines = @pending_messages.shift
+      # Not a user-authored Show Text block, so it never keeps the window open
+      # for a following Show Choices / Input Number -- clear any followup left
+      # over from an earlier, unrelated message.
+      @message_followup = nil
       @wait_kind = :message
       @waiting = true
       true

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1925,13 +1925,20 @@ class RPG2k
       end
 
       def drive_event
-        if @message
-          drive_message
+        # An Input Number that followed a Show Text draws its digit cells
+        # inside the still-open message window (see #open_number_input) --
+        # check it first so it takes over from the finished text reveal.
+        if @number_input
+          drive_number_input
           return
         end
 
-        if @number_input
-          drive_number_input
+        # A message window with a pending Show Choices / Input Number followup
+        # has finished typing and is just waiting on the interpreter to reach
+        # that next command (see #drive_text_message) -- fall through to the
+        # `waiting?` dispatch below instead of driving it as a live message.
+        if @message && !@message[:awaiting_followup]
+          drive_message
           return
         end
 
@@ -4231,7 +4238,14 @@ class RPG2k
       end
 
       def open_message(lines, choice)
-        return if @message
+        if @message
+          # A Show Choices that directly follows a Show Text keeps the same
+          # window: append the choice list below the text already on screen
+          # instead of building a new window (see #drive_text_message).
+          return unless choice && @message[:awaiting_followup] == :choice
+          append_choice_lines(lines)
+          return
+        end
         names = ->(id) { actor_name(id) }
         raw = (lines || [])
         raw = [''] if raw.empty?
@@ -4283,8 +4297,8 @@ class RPG2k
         # `\$` shows the party's gold in a small window alongside the message.
         gold_window = show_gold ? build_inn_gold_window(nonblank(db.term.gold, 'G')) : nil
         @message = { window: win, choice: choice, count: plain.length,
-                     reveal: reveal, contents: contents, inner_w: inner_w,
-                     seg_lines: seg_lines, face: face,
+                     choice_start: 0, reveal: reveal, contents: contents,
+                     inner_w: inner_w, seg_lines: seg_lines, face: face,
                      face_index: cfg.face_index,
                      face_x: face_right ? inner_w - FACE_SIZE : 0,
                      text_x: text_x, text_w: text_w, gold_window: gold_window }
@@ -4292,6 +4306,32 @@ class RPG2k
         win.contents = contents
         @choice_index = 0
         set_choice_cursor if choice
+      end
+
+      # Append a Show Choices block's labels to the still-open message window
+      # from a Show Text that immediately preceded it (RPG_RT keeps one window
+      # for the pair: text on top, choices below). Reuses the existing window,
+      # contents bitmap and text layout; only the reveal and line list grow.
+      def append_choice_lines(labels)
+        @message[:awaiting_followup] = nil
+        names = ->(id) { actor_name(id) }
+        raw = (labels || [])
+        raw = [''] if raw.empty?
+        scans = raw.map { |l| Game::Message.scan(l.to_s, @state.variables, names) }
+        new_seg_lines = scans.map { |s| s[:segments] }
+        @message[:choice_start] = @message[:seg_lines].length
+        @message[:seg_lines] = @message[:seg_lines] + new_seg_lines
+        @message[:choice] = true
+        @message[:count] = new_seg_lines.length
+        # Choice lists appear at once, same as a standalone choice window; the
+        # text lines above are already fully revealed.
+        plain = @message[:seg_lines].map { |segs| segs.map { |s| s[:text] }.join }
+        reveal = Game::TextReveal.new(plain)
+        reveal.reveal_all
+        @message[:reveal] = reveal
+        draw_message_contents
+        @choice_index = 0
+        set_choice_cursor
       end
 
       # Vertical position of a `win_h`-tall message window for the configured
@@ -4409,8 +4449,9 @@ class RPG2k
 
       def set_choice_cursor
         return unless @message
+        offset = @message[:choice_start] || 0
         @message[:window].cursor_rect =
-          Rect.new(0, @choice_index * MSG_LINE_H,
+          Rect.new(0, (offset + @choice_index) * MSG_LINE_H,
                    @message[:window].contents.width, MSG_LINE_H)
       end
 
@@ -4517,7 +4558,15 @@ class RPG2k
         end
         # `\^` closes the finished window on its own; otherwise wait for a button.
         if reveal.auto_close? || pressed
-          close_message
+          followup = @interpreter.message_followup
+          if followup
+            # A Show Choices / Input Number immediately follows this Show Text:
+            # RPG_RT keeps the same window up, with the choices / digit entry
+            # appended below the text already shown, instead of closing it.
+            @message[:awaiting_followup] = followup
+          else
+            close_message
+          end
           @interpreter.resume
         else
           @message[:window].pause = true
@@ -4552,12 +4601,23 @@ class RPG2k
       # Pixels per digit cell in the Input Number widget.
       NUM_CELL = 16
 
-      # Open a digit-entry window for the Input Number command. A compact panel
-      # near the bottom of the screen shows `digits` cells with an editable
-      # cursor; the interpreter is resumed with the entered value on confirm.
+      # Open a digit-entry widget for the Input Number command. When it directly
+      # follows a Show Text (RPG_RT keeps one window for the pair -- see
+      # #drive_text_message), the cells are drawn into the still-open message
+      # window below the text already shown; otherwise a standalone compact
+      # panel opens near the bottom of the screen. Either way the interpreter
+      # is resumed with the entered value on confirm.
       def open_number_input(digits)
         return if @number_input
         model = Game::NumberInput.new(digits || 1)
+        if @message && @message[:awaiting_followup] == :number
+          @message[:awaiting_followup] = nil
+          x = @message[:inner_w] - model.digits * NUM_CELL
+          y = @message[:seg_lines].length * MSG_LINE_H
+          @number_input = { model: model, embedded: true, x: x, y: y }
+          draw_number_input
+          return
+        end
         inner_w = model.digits * NUM_CELL
         inner_h = MSG_LINE_H
         win_w = inner_w + Window::BORDER * 2
@@ -4575,15 +4635,24 @@ class RPG2k
         ni = @number_input
         return unless ni
         model = ni[:model]
-        c = ni[:contents]
-        c.clear
+        if ni[:embedded]
+          c = @message[:contents]
+          x0 = ni[:x]
+          y0 = ni[:y]
+          c.fill_rect x0, y0, model.digits * NUM_CELL, MSG_LINE_H, Color.new(0, 0, 0, 0)
+        else
+          c = ni[:contents]
+          x0 = 0
+          y0 = 0
+          c.clear
+        end
         (0...model.digits).each do |i|
-          x = i * NUM_CELL
+          x = x0 + i * NUM_CELL
           if i == model.cursor
-            c.fill_rect x, 1, NUM_CELL, MSG_LINE_H - 2, Color.new(40, 72, 200, 160)
+            c.fill_rect x, y0 + 1, NUM_CELL, MSG_LINE_H - 2, Color.new(40, 72, 200, 160)
           end
           c.font.color = Color.new(255, 255, 255, 255)
-          c.draw_text x, 0, NUM_CELL, MSG_LINE_H, model.digit(i).to_s, 1
+          c.draw_text x, y0, NUM_CELL, MSG_LINE_H, model.digit(i).to_s, 1
         end
       end
 
@@ -4604,14 +4673,16 @@ class RPG2k
           draw_number_input
         elsif Input.trigger?(Input::C)
           value = model.value
+          embedded = ni[:embedded]
           close_number_input
+          close_message if embedded
           @interpreter.resume_number(value)
         end
       end
 
       def close_number_input
         return unless @number_input
-        @number_input[:window].dispose
+        @number_input[:window].dispose if @number_input[:window]
         @number_input = nil
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1342,6 +1342,98 @@ check 'a message types out gradually, then a button completes and dismisses it' 
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
+check 'a Show Text keeps its window open when a Show Choices follows directly' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_MESSAGE, [], indent: 0, string: 'hello'),
+    ECmd.new(ic::SHOW_CHOICES, [0], indent: 0), # cancel forbidden
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'no'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  win = msg[:window]
+
+  scene.update # no input: text keeps revealing
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # completes the reveal; window stays open
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # would dismiss a lone message -- but a Show Choices follows directly
+  RGSS::Input.reset
+
+  choice_msg = nil
+  8.times do
+    scene.update
+    choice_msg = scene.instance_variable_get(:@message)
+    break if choice_msg && choice_msg[:choice]
+  end
+  ok choice_msg, 'the window is still open once the choices appear'
+  ok choice_msg[:window].equal?(win), 'the same window is reused, not closed and reopened'
+  eq 2, choice_msg[:count], 'both options are listed'
+  eq 1, choice_msg[:choice_start], 'the choices are appended below the one text line'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm option 0 ("yes")
+  scene.update
+  ok !scene.instance_variable_get(:@message), 'the window closes once the choice is made'
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[1], 'the chosen branch ran'
+  ok !st.switches[2], 'and the other did not'
+end
+
+check 'a Show Text keeps its window open when an Input Number follows directly' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_MESSAGE, [], indent: 0, string: 'hello'),
+    ECmd.new(ic::INPUT_NUMBER, [2, 5], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  win = msg[:window]
+
+  scene.update # no input: text keeps revealing
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # completes the reveal
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # would dismiss a lone message -- but Input Number follows directly
+  RGSS::Input.reset
+
+  ni = nil
+  8.times do
+    scene.update
+    ni = scene.instance_variable_get(:@number_input)
+    break if ni
+  end
+  ok ni, 'the number-entry widget opened'
+  ok ni[:embedded], 'it was embedded in the still-open message window, not a new one'
+  ok scene.instance_variable_get(:@message), 'the message window was not closed for it'
+  ok scene.instance_variable_get(:@message)[:window].equal?(win),
+     'the same window is reused, not closed and reopened'
+
+  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C]  # confirm
+  scene.update
+  ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
+  ok !scene.instance_variable_get(:@message), 'and the message window closed with it'
+  5.times { RGSS::Input.reset; scene.update }
+  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  ok st.switches[1], 'the interpreter resumed and ran the next command'
+end
+
 check 'the cancel key backs out of a Show Choices, per its cancel type' do
   ic = Game::Interpreter::Cmd
   # Cancel type 5: the block carries a [Cancel] branch as option index 4 (an


### PR DESCRIPTION
## Summary
This change implements RPG_RT's behavior of keeping a message window open when a Show Choices or Input Number command immediately follows a Show Text command. Previously, the window would close after text reveal completed, then a new window (or widget) would open for the next command, causing a visual flicker. Now the same window is reused with choices or digit entry appended below the already-displayed text.

## Key Changes

- **Interpreter**: Modified `do_show_message` to peek at the next command and set `@message_followup` to `:choice` or `:number` if Show Choices or Input Number immediately follows (same indent, nothing in between)

- **Scene::Map - Message handling**:
  - Changed `drive_event` to check `@number_input` first (takes priority over message driving)
  - Modified message driving condition to check `@message[:awaiting_followup]` flag, allowing the window to stay open when a followup is pending
  - Updated `open_message` to handle Show Choices that directly follow Show Text by appending choice lines to the existing window instead of creating a new one

- **Scene::Map - New method `append_choice_lines`**: Appends choice labels to an already-open message window, reusing the existing window, contents bitmap, and text layout. Sets `choice_start` to track where choices begin in the line list.

- **Scene::Map - Number input handling**:
  - Modified `open_number_input` to detect when it follows a Show Text and embed the digit cells in the message window instead of creating a standalone widget
  - Updated `draw_number_input` to support embedded mode (drawing into message window at specified coordinates) vs. standalone mode
  - Modified `close_number_input` to handle windows that may not exist (embedded case)
  - Updated `drive_number_input` to close the message window when an embedded number input is confirmed

- **Scene::Map - Choice cursor**: Modified `set_choice_cursor` to account for `choice_start` offset when positioning the cursor in a message window that contains both text and choices

- **Message state tracking**: Added `choice_start` field to message hash to track where choice lines begin, and `awaiting_followup` flag to indicate pending Show Choices/Input Number

## Notable Implementation Details

- The `@message_followup` flag is cleared when a pending message from the interpreter's internal queue (not user-authored) is shown, preventing stale state from affecting unrelated messages
- Embedded number input draws into the message window's contents bitmap at calculated coordinates below the text
- The same window object is reused throughout the text → choices/number sequence, only closing after the user confirms their choice or input

https://claude.ai/code/session_01F2dZ35pcr3mH4Kzr9sxdyd