### PR TITLE
Fix event-command step budget and Wait timing to match RPG_RT

### DIFF
--- a/changelog.d/event-processing-step-budget-and-wait-timing.fixed.md
+++ b/changelog.d/event-processing-step-budget-and-wait-timing.fixed.md
@@ -1,0 +1,21 @@
+- The event-command interpreter's per-frame step budget (`Game::Interpreter::MAX_STEPS`)
+  is now 10000, matching RPG_RT's own documented ceiling, instead of
+  1,000,000 -- a heavy or runaway event loop now visibly spreads across
+  several frames the way it does in RPG_RT, rather than finishing effectively
+  instantly. Within that budget, a Loop iteration, a Call Event round trip,
+  a Conditional Branch evaluation and the End Branch it falls through to now
+  cost more than one step each, per RPG_RT's measured event-command timings
+  (`el-flamen`'s `rpgTkool2000/commandSpec`). Call Event nesting
+  (`MAX_CALL_DEPTH`) is now bounded at 1000 levels rather than 100, matching
+  the documented real limit before RPG_RT aborts with an "invalid event call"
+  error.
+- `Wait 0.0 sec` now costs exactly one frame (1/60s) as documented
+  (`el-flamen`'s `rpgTkool2000/eventProcess`), for both the foreground event
+  and background parallel processes -- previously the scene's per-frame drive
+  loop spent an extra frame resuming a finished wait before it would run the
+  next command, so a `Wait 0.0` command cost two frames in the foreground and
+  three in a parallel process instead of one and two respectively. A parallel
+  process's own free one-frame gap between laps is unaffected, so stacking an
+  explicit `Wait 0.0` on top of it now gives the documented 2-frame (1/30s)
+  total gap. Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -174,7 +174,9 @@ module Game
 
     # Upper bound on nested Call Event depth, so a common event that (directly or
     # indirectly) calls itself unwinds instead of growing the stack without end.
-    MAX_CALL_DEPTH = 100
+    # RPG_RT allows 1000 levels (not counting the original caller) before it
+    # aborts the process with an "invalid event call" error.
+    MAX_CALL_DEPTH = 1000
 
     def initialize(state)
       @state = state
@@ -428,9 +430,11 @@ module Game
       name
     end
 
-    # Upper bound on commands run in a single update, so a malformed loop cannot
-    # hang the game loop.
-    MAX_STEPS = 1_000_000
+    # Upper bound on commands run in a single update (one map frame): RPG_RT
+    # processes at most 10000 "steps" of event commands per 1/60s frame, after
+    # which the rest waits for the next frame -- this is what makes a
+    # tight/heavy loop visibly slow down the game instead of freezing it.
+    MAX_STEPS = 10_000
 
     # Advance through commands until the list ends or a command asks to wait.
     # When the current (possibly called) list runs out, control returns to the
@@ -446,10 +450,27 @@ module Game
         cmd = @list[@index]
         @index += 1
         execute cmd
-        steps += 1
+        steps += step_cost(cmd.code)
         break if steps >= MAX_STEPS
       end
       @running = false if finished?
+    end
+
+    # Per-command cost against the MAX_STEPS budget. Most commands cost one
+    # step; a handful cost more because RPG_RT's own timing measurements show
+    # them taking roughly twice as long to process: each loop iteration (the
+    # End Loop marker looping back), a Call Event round trip, and a Conditional
+    # Branch evaluation that falls through to its else/end (an unmatched
+    # condition, or an End Branch reached after a matched one).
+    def step_cost(code)
+      case code
+      when Cmd::END_LOOP, Cmd::CALL_EVENT, Cmd::CALL_COMMON_EVENT, Cmd::END_BRANCH
+        2
+      when Cmd::CONDITIONAL
+        @last_condition_matched ? 1 : 2
+      else
+        1
+      end
     end
 
     # True when nothing is left to run: the current list is exhausted, no caller
@@ -1975,7 +1996,8 @@ module Game
     # -- conditional branch ---------------------------------------------------
 
     def do_conditional(cmd)
-      return if eval_condition(cmd) # fall through into the true branch
+      @last_condition_matched = eval_condition(cmd)
+      return if @last_condition_matched # fall through into the true branch
       skip_to([Cmd::ELSE_BRANCH, Cmd::END_BRANCH], cmd.indent)
       consume # step past the else/end marker to run the else body (or continue)
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -776,8 +776,16 @@ class RPG2k
         return if p[:gate_switch] && !@state.switches[p[:gate_switch]]
         it = p[:interp]
         if it.waiting?
+          wait_kind = it.wait_kind
           drive_parallel_wait(p, it)
-        elsif it.running?
+          # A plain Wait resolves the instant its timer elapses; keep spending
+          # this same frame's step budget instead of losing a frame to the
+          # resume, matching drive_event's foreground handling (see there for
+          # why: Wait 0.0 sec must cost exactly one frame). Other wait kinds
+          # keep their old one-frame-per-call pacing.
+          return apply_interpreter_requests(it, p[:event]) unless wait_kind == :wait && !it.waiting?
+        end
+        if it.running?
           it.update
         else
           it.start(p[:commands]) # loop the process
@@ -1944,7 +1952,17 @@ class RPG2k
           when :inn then drive_inn
           when :shop then drive_shop
           when :battle then drive_battle
-          when :wait then drive_wait
+          when :wait
+            drive_wait
+            # RPG_RT resumes a Wait the instant its timer elapses and keeps
+            # spending that same frame's step budget -- Wait 0.0 sec is
+            # documented as costing exactly one frame (1/60s), not two, so the
+            # command right after it must not wait for a second frame here.
+            unless @interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
+            return
           when :teleport then perform_teleport(@interpreter.teleport)
           when :movement then @interpreter.resume if step_forced_movement
           when :screen then @interpreter.resume unless @state.screen.busy?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1091,6 +1091,81 @@ check 'a self-calling common event terminates instead of hanging' do
   ok !it.running?, 'recursion was bounded and the process ended'
 end
 
+# A resolver that counts every Call Event lookup instead of answering with
+# real commands, so a Call Event round trip stays a one-command no-op (the
+# empty-target early return in do_call_event) whose count is still visible.
+class CountingResolver
+  attr_reader :calls
+  def initialize
+    @calls = 0
+  end
+
+  def common_event_commands(_id)
+    @calls += 1
+    []
+  end
+
+  def map_event_commands(_id, _page); nil; end
+end
+
+check 'a single update spends its 10000-step budget at the documented per-command cost' do
+  # RPG_RT's own timing measurements give most commands one step, but a Loop's
+  # End Loop marker and a Call Event round trip cost two -- see the event
+  # command spec. These two checks pin that MAX_STEPS (10000) is spent at
+  # those weights, not a flat one step per command.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::LOOP, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 1, 0, 1], indent: 0), # variable 1 += 1
+    FakeCmd.new(IC::END_LOOP, [], indent: 0),
+  ])
+  it.update
+  eq 3333, st.variables[1],
+     '10000 steps / (1 for the add + 2 for the loop-back) per iteration'
+
+  st2 = new_state
+  it2 = Game::Interpreter.new(st2)
+  it2.resolver = CountingResolver.new
+  it2.start(Array.new(6000) { FakeCmd.new(IC::CALL_EVENT, [0, 1, 0]) })
+  it2.update
+  eq 5000, it2.resolver.calls, '10000 steps / 2 per Call Event round trip'
+end
+
+check 'a Conditional Branch costs one step when matched, two when not' do
+  # Per the event command spec, a Conditional Branch evaluation is one step
+  # when it matches (falling through into the true body) and two when it does
+  # not. A block here is a bare [Conditional Branch, End Branch] pair (no
+  # body), which also exercises the asymmetry in how each path reaches End
+  # Branch: a match falls through to it as an ordinary next command (so it is
+  # separately dispatched and pays its own two-step cost, for 1+2=3 per
+  # block); a miss jumps straight past it via #skip_to/#consume inside the
+  # same do_conditional call, so it is never independently dispatched (just
+  # the 2-step miss, for 2 per block) -- cheaper overall despite costing more
+  # to evaluate.
+  st = new_state
+  st.switches[1] = true
+  matched = Game::Interpreter.new(st)
+  matched.start(Array.new(4000) {
+    [FakeCmd.new(IC::CONDITIONAL, [0, 1, 0], indent: 0), # switch 1 == on
+     FakeCmd.new(IC::END_BRANCH, [], indent: 0)]
+  }.flatten)
+  matched.update
+  eq 3333, matched.instance_variable_get(:@index) / 2,
+     '10000 steps / (1 to match + 2 for the End Branch it falls through to) per block'
+
+  st2 = new_state
+  st2.switches[1] = false
+  unmatched = Game::Interpreter.new(st2)
+  unmatched.start(Array.new(6000) {
+    [FakeCmd.new(IC::CONDITIONAL, [0, 1, 0], indent: 0), # switch 1 == on (it is not)
+     FakeCmd.new(IC::END_BRANCH, [], indent: 0)]
+  }.flatten)
+  unmatched.update
+  eq 5000, unmatched.instance_variable_get(:@index) / 2,
+     '10000 steps / 2 per miss, with no separate End Branch dispatch to pay for'
+end
+
 check 'Call Event with no resolver set is a safe no-op' do
   st = new_state
   it = Game::Interpreter.new(st)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -885,6 +885,39 @@ check 'parallel (trigger 4): a background event runs every frame' do
   ok v >= 8, "parallel event should have looped ~10 times, got #{v}"
 end
 
+check 'Wait 0.0 sec pauses a foreground event for exactly one frame' do
+  # RPG_RT pauses a Wait 0.0 command and resumes it on the very next frame,
+  # since 0 seconds have already elapsed by then -- so it costs exactly one
+  # frame (1/60s), the same as any other single-frame pause, not two.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+                       ECmd.new(ic::WAIT, [0]), # 0.0 seconds
+                       ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0])]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  ok st.switches[1], 'the command before the wait ran on the first frame'
+  ok !st.switches[2], 'the command after Wait 0.0 must not run on that same frame'
+  scene.update
+  ok st.switches[2], 'Wait 0.0 sec costs exactly one frame, not two'
+end
+
+check 'Wait 0.0 sec doubles a parallel process lap gap to two frames' do
+  # A parallel process already gets a free one-frame gap between laps with no
+  # explicit wait at all (the check above). Adding a Wait 0.0 stacks one more
+  # frame on top, for a 2-frame (1/30s) gap -- not the free gap alone, and not
+  # three frames from an extra "detect it finished" frame.
+  pg = page(trigger: 4)
+  pg.event_commands = [add_var_cmd(1), ECmd.new(Game::Interpreter::Cmd::WAIT, [0])]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  4.times { scene.update }
+  eq 2, st.variables[1], 'two laps (increment + wait) should have run in four frames'
+  scene.update
+  eq 3, st.variables[1], 'a third lap starts on the fifth frame'
+end
+
 check 'an auto-start event reads its own position ("this event", ref 10005)' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
This PR corrects the event-command interpreter's per-frame step budget and command timing to match RPG_RT's actual behavior, making heavy event loops visibly spread across frames instead of completing instantly.

## Summary of Changes

The event interpreter now accurately models RPG_RT's command execution timing:
- **Step budget**: Reduced from 1,000,000 to 10,000 steps per frame (1/60s), matching RPG_RT's documented ceiling
- **Per-command costs**: Most commands cost 1 step, but Loop iterations, Call Events, Conditional Branches, and End Branch markers now cost 2 steps each, reflecting RPG_RT's measured timings
- **Wait 0.0 sec timing**: Fixed to cost exactly one frame as documented, instead of two (foreground) or three (parallel processes)
- **Call Event nesting**: Increased `MAX_CALL_DEPTH` from 100 to 1000 levels, matching RPG_RT's actual limit before aborting with an "invalid event call" error

## Key Implementation Details

**Step cost calculation** (`interpreter.rb`):
- Added `step_cost(code)` method that returns 2 for `END_LOOP`, `CALL_EVENT`, `CALL_COMMON_EVENT`, and `END_BRANCH`
- `CONDITIONAL` branches cost 1 when matched, 2 when not (tracked via `@last_condition_matched`)
- All other commands cost 1 step

**Wait 0.0 sec fix** (`scene/map.rb`):
- Foreground events: Resume and continue executing in the same frame when a Wait finishes, rather than waiting for the next frame
- Parallel processes: Apply the same logic to avoid losing a frame on resume
- This preserves the natural one-frame gap between parallel process laps while allowing explicit `Wait 0.0` to add exactly one more frame

**Testing**:
- Added comprehensive checks in `rpg2k_logic_check.rb` verifying the 10,000-step budget is spent at documented per-command costs
- Added checks in `rpg2k_scene_check.rb` confirming `Wait 0.0 sec` costs exactly one frame for both foreground and parallel events

https://claude.ai/code/session_01H76VgxiyG3C9weYM5fyi6a