### PR TITLE
Block movement through upper-layer chipset obstacles

### DIFF
--- a/changelog.d/rpg2k-upper-chipset-passable.fixed.md
+++ b/changelog.d/rpg2k-upper-chipset-passable.fixed.md
@@ -1,0 +1,14 @@
+- **Upper-layer chipset decorations and obstacles now block movement.**
+  `Game::ChipSet` read the upper passage table for the counter flag alone;
+  ordinary movement (`char_passable?`, the party's own `passable?`, and the
+  jump-landing `char_can_land?`) only ever consulted the lower-layer table, so
+  anything drawn on the upper layer — a boulder, a fence post, a shop counter —
+  was walked straight through. `ChipSet#passable_tile?` / `#landable_tile?` now
+  mirror EasyRPG's `Game_Map::IsPassableTile`: an upper tile that blocks the
+  direction wins outright; one that permits it but lacks the passage byte's
+  `ABOVE_BIT` is solid ground in its own right and the check stops there;
+  otherwise (no upper tile, or one flagged `ABOVE_BIT` for a see-through
+  decoration like a painted rug) the lower layer's own passability decides, as
+  before. A shop/inn counter — impassable on every side with no `ABOVE_BIT` —
+  is exactly this case, so the fix also plugs the gap where a counter answered
+  the action button but could still be walked onto.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -420,16 +420,23 @@ module Game
     clamp(player_px - screen_px / 2, 0, max)
   end
 
-  # A chipset: its tile graphic name plus the lower-layer passability table.
-  # Passability is keyed by a chip index derived from the tile id following the
-  # EasyRPG block layout; unknown/out-of-range tiles are treated as passable so
-  # collision degrades safely.
+  # A chipset: its tile graphic name plus the lower- and upper-layer
+  # passability tables. Passability is keyed by a chip index derived from the
+  # tile id following the EasyRPG block layout; unknown/out-of-range tiles are
+  # treated as passable so collision degrades safely.
   class ChipSet
     # numpad direction -> passability bit.
     DIR_BIT = { 2 => 0x01, 4 => 0x02, 6 => 0x04, 8 => 0x08 }.freeze
     # The non-directional bits of the same passage byte (EasyRPG's `Passable`).
-    # Only the counter flag is read so far: it marks a tile you may talk *across*
-    # — the shop counter an NPC stands behind.
+    # `ABOVE_BIT` marks an upper tile as *see-through* ground rather than a
+    # solid object in its own right: `IsPassableTile` only falls through to
+    # the lower layer's own passability when this bit is set, so a
+    # painted-on decoration (a rug, a patch of flowers) still collides with
+    # whatever the lower layer says underneath it, while a genuine obstacle
+    # (a boulder, a fence post, a shop counter) is decided by the upper tile
+    # alone. `COUNTER_BIT` marks a tile you may talk *across* — the shop
+    # counter an NPC stands behind.
+    ABOVE_BIT = 0x20
     COUNTER_BIT = 0x40
     # Every directional bit ORed together, for a jump's any-side landing check.
     ALL_DIRS = (DIR_BIT[2] | DIR_BIT[4] | DIR_BIT[6] | DIR_BIT[8]).freeze
@@ -452,6 +459,17 @@ module Game
       @animation_type = c ? (c.animation_type || 0) : 0
       @animation_speed = c ? (c.animation_speed || 0) : 0
     end
+
+    # Passage byte for an upper-layer tile id, or nil when there is none to
+    # read: no table on this chipset, no id given, the id is 0 (RPG2000's "no
+    # upper tile here" sentinel), or it falls outside the table.
+    def upper_flags(upper_tile_id)
+      return nil if @passable_upper.nil? || upper_tile_id.nil? || upper_tile_id == 0
+      idx = upper_tile_id - ChipsetLayout::BLOCK_F
+      return nil if idx < 0 || idx >= @passable_upper.size
+      @passable_upper[idx]
+    end
+    private :upper_flags
 
     # Chip index into the lower passability table for a lower-layer tile id.
     def self.lower_index(tile_id)
@@ -489,15 +507,40 @@ module Game
 
     # Is this an upper-layer **counter** tile — one the action button reaches
     # across? RPG2000 marks shop and inn counters with it so the keeper can stand
-    # behind an impassable tile and still be talked to. Upper-layer ids start at
-    # BLOCK_F and index the upper passage table directly; anything below that is
-    # not an upper tile at all. A chipset without the table has no counters.
+    # behind an impassable tile and still be talked to. A chipset without the
+    # table has no counters.
     def counter?(upper_tile_id)
-      return false if @passable_upper.nil? || upper_tile_id.nil?
-      idx = upper_tile_id - ChipsetLayout::BLOCK_F
-      return false if idx < 0 || idx >= @passable_upper.size
-      flags = @passable_upper[idx]
+      flags = upper_flags(upper_tile_id)
       !flags.nil? && (flags & COUNTER_BIT) != 0
+    end
+
+    # Can a character enter this cell, moving in `dir`, once the upper layer's
+    # own passability is taken into account? Mirrors EasyRPG's
+    # `Game_Map::IsPassableTile`: an upper tile that blocks `dir` wins outright
+    # (this is how a counter, blocked on every side, refuses to be walked
+    # onto); one that permits it but is not flagged `ABOVE_BIT` is solid
+    # ground in its own right and the check stops there; otherwise — no upper
+    # tile at all, or one flagged `ABOVE_BIT` — the lower layer's own
+    # passability decides, exactly as `passable?` alone did before this upper
+    # check existed.
+    def passable_tile?(lower_tile_id, upper_tile_id, dir)
+      flags = upper_flags(upper_tile_id)
+      return passable?(lower_tile_id, dir) if flags.nil?
+      return false if (flags & (DIR_BIT[dir] || 0)) == 0
+      return true if (flags & ABOVE_BIT) == 0
+      passable?(lower_tile_id, dir)
+    end
+
+    # The jump-landing counterpart of `passable_tile?`, following `landable?`'s
+    # any-side rule for the upper layer too: an upper tile blocked from every
+    # direction refuses the landing outright, and `ABOVE_BIT` decides — same as
+    # `passable_tile?` — whether the lower layer also gets a say.
+    def landable_tile?(lower_tile_id, upper_tile_id)
+      flags = upper_flags(upper_tile_id)
+      return landable?(lower_tile_id) if flags.nil?
+      return false if (flags & ALL_DIRS) == 0
+      return true if (flags & ABOVE_BIT) == 0
+      landable?(lower_tile_id)
     end
 
     # Terrain id of a lower-layer tile (for the Store Terrain ID command), looked

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1846,7 +1846,9 @@ class RPG2k
       # `TURN_180[dir]`). A wall painted on either tile blocks the crossing —
       # checking only the destination (as this used to) missed a chip whose
       # *own* tile disallowed stepping off it, which is how one-way ledges and
-      # railings are authored.
+      # railings are authored. The upper layer gets the same two-sided check:
+      # an obstacle drawn on top of the ground (a boulder, a shop counter) is
+      # exactly as solid as a lower-layer wall.
       def char_passable?(character, dir)
         return true if character.through
         nx, ny = Game::Character.step_tile(character.x, character.y, dir)
@@ -1854,8 +1856,10 @@ class RPG2k
         return false if nx == @state.x && ny == @state.y
         return false if @event_tiles[[nx, ny]]
         return true if @chipset.nil?
-        @chipset.passable?(@map.lower(character.x, character.y), dir) &&
-          @chipset.passable?(@map.lower(nx, ny), Game::Character::TURN_180[dir] || dir)
+        @chipset.passable_tile?(@map.lower(character.x, character.y),
+                                 @map.upper(character.x, character.y), dir) &&
+          @chipset.passable_tile?(@map.lower(nx, ny), @map.upper(nx, ny),
+                                   Game::Character::TURN_180[dir] || dir)
       end
       # Called by MapWorld (an external collaborator) with an explicit receiver.
       public :char_passable?
@@ -1881,7 +1885,7 @@ class RPG2k
         return false if x == @state.x && y == @state.y
         return false if @event_tiles[[x, y]]
         return true if @chipset.nil?
-        @chipset.landable?(@map.lower(x, y))
+        @chipset.landable_tile?(@map.lower(x, y), @map.upper(x, y))
       end
       public :char_can_land?
 
@@ -4769,13 +4773,16 @@ class RPG2k
       # direction of travel from the player's current tile. Like
       # `char_passable?`, both sides of the boundary must agree — the tile
       # under the player's feet must allow exit toward `dir`, and (x, y) must
-      # allow entry from the opposite side.
+      # allow entry from the opposite side — and the upper layer at each tile
+      # gets the same say as the lower one.
       def passable?(x, y, dir)
         return false unless @map.in_bounds?(x, y)
         return false if @event_tiles[[x, y]]
         return true if @chipset.nil?
-        @chipset.passable?(@map.lower(@state.x, @state.y), dir) &&
-          @chipset.passable?(@map.lower(x, y), Game::Character::TURN_180[dir] || dir)
+        @chipset.passable_tile?(@map.lower(@state.x, @state.y),
+                                 @map.upper(@state.x, @state.y), dir) &&
+          @chipset.passable_tile?(@map.lower(x, y), @map.upper(x, y),
+                                   Game::Character::TURN_180[dir] || dir)
       end
 
       # Current player position in map pixels, interpolated during a step.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8675,6 +8675,82 @@ check 'landable? accepts a tile passable from any single side' do
   ok !chipset_with_passable(data).landable?(0), 'blocked on every side refuses the landing'
 end
 
+# -- upper-layer chipset passability -------------------------------------------
+
+def chipset_with_upper(lower_data, upper_data)
+  db = Struct.new(:chipset).new(
+    { 1 => FakeChipsetRow.new('cs', 'cs', lower_data, upper_data, nil, 0, 0) }
+  )
+  Game::ChipSet.new(db, 1)
+end
+
+BLOCK_F = Game::ChipsetLayout::BLOCK_F
+ABOVE = Game::ChipSet::ABOVE_BIT
+COUNTER = Game::ChipSet::COUNTER_BIT
+
+# No upper tile at all (id 0, or a chipset with no upper table): the upper
+# layer has nothing to say, so passability falls straight through to the
+# lower layer exactly as before the upper check existed.
+check 'passable_tile? with no upper tile falls through to the lower layer' do
+  lower = Array.new(162, 0)
+  lower[0] = Game::ChipSet::DIR_BIT[6]
+  cs = chipset_with_upper(lower, Array.new(144, 0))
+  ok cs.passable_tile?(0, 0, 6), 'lower allows Right, no upper tile'
+  ok !cs.passable_tile?(0, 0, 2), 'lower refuses Down, no upper tile'
+
+  cs_no_table = chipset_with_upper(lower, nil)
+  ok cs_no_table.passable_tile?(0, BLOCK_F, 6), 'no upper table at all defers to lower too'
+end
+
+# A solid object on the upper layer (all direction bits clear, ABOVE_BIT
+# clear) blocks movement outright, regardless of what the lower layer says --
+# this is the counter tiles fix generalised: a boulder or fence post is just
+# as impassable as a shop counter, and neither defers to the ground beneath.
+check 'passable_tile? refuses a solid upper-layer obstacle even over open ground' do
+  lower = Array.new(162, Game::ChipSet::ALL_DIRS) # wide open lower ground
+  upper = Array.new(144, 0)
+  upper[0] = 0 # blocked on every side, ABOVE_BIT clear
+  cs = chipset_with_upper(lower, upper)
+  ok !cs.passable_tile?(0, BLOCK_F, 2), 'a solid upper tile blocks Down'
+  ok !cs.passable_tile?(0, BLOCK_F, 6), 'and Right'
+
+  # A shop/inn counter is exactly this case, plus the counter flag.
+  upper[0] = COUNTER
+  ok !chipset_with_upper(lower, upper).passable_tile?(0, BLOCK_F, 6),
+     'a counter (blocked + COUNTER_BIT) is impassable to walk onto'
+end
+
+# ABOVE_BIT set: the upper tile permits the direction, but is "see-through"
+# ground, so the lower layer's own passability still gets the final word --
+# a decorative overlay does not override a wall painted underneath it.
+check 'passable_tile? with ABOVE_BIT still checks the lower layer' do
+  lower = Array.new(162, 0) # lower blocks everything
+  upper = Array.new(144, 0)
+  upper[0] = Game::ChipSet::ALL_DIRS | ABOVE
+  cs = chipset_with_upper(lower, upper)
+  ok !cs.passable_tile?(0, BLOCK_F, 6), 'upper allows Right, but the lower wall still refuses it'
+
+  lower[0] = Game::ChipSet::DIR_BIT[6]
+  ok chipset_with_upper(lower, upper).passable_tile?(0, BLOCK_F, 6),
+     'both layers now agree: passable'
+end
+
+check 'landable_tile? applies the same solid-vs-see-through rule to jumps' do
+  lower = Array.new(162, 0) # lower blocks every side
+  upper = Array.new(144, 0)
+  upper[0] = Game::ChipSet::DIR_BIT[8] # one open side, ABOVE_BIT clear
+  cs = chipset_with_upper(lower, upper)
+  ok cs.landable_tile?(0, BLOCK_F), 'a solid object open on one side is still landable'
+
+  upper[0] = 0
+  ok !chipset_with_upper(lower, upper).landable_tile?(0, BLOCK_F),
+     'blocked on every side refuses the landing'
+
+  upper[0] = Game::ChipSet::DIR_BIT[8] | ABOVE
+  ok !chipset_with_upper(lower, upper).landable_tile?(0, BLOCK_F),
+     'ABOVE_BIT set defers to the lower layer, which is fully blocked'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -914,6 +914,20 @@ check 'the reach stops after three counters, and at a non-counter tile' do
   ok !st2.switches[4], 'four counters is past the three-tile reach'
 end
 
+# A shop/inn counter is an impassable upper-layer tile, not just a talk-across
+# one: nothing in the chipset's lower table refuses the tile (fake_chipset has
+# none), so before Game::ChipSet read the upper passage table during movement
+# too, a walking party could step straight onto — and through — the counter.
+check 'a shop counter blocks walking onto it, not only the action button' do
+  scene = counter_scene({}, [[1, 0]], player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.direction = 6
+  RGSS::Input.dir_value = 6
+  10.times { scene.update }
+  eq 0, st.x, 'the party never left its tile'
+  eq 0, st.y
+end
+
 check 'an action event under the player answers the action button' do
   ic = Game::Interpreter::Cmd
   pg = page(trigger: 0)


### PR DESCRIPTION
## Summary
Upper-layer chipset tiles (decorations, obstacles, counters) now properly block character movement and jump landings, matching EasyRPG's behavior. Previously, only the lower-layer passability table was consulted during movement checks, allowing characters to walk through upper-layer obstacles.

## Key Changes

- **Added `ChipSet#passable_tile?` and `ChipSet#landable_tile?` methods** that check both upper and lower layer passability:
  - Upper tiles that block a direction refuse movement outright
  - Upper tiles without the `ABOVE_BIT` flag are solid obstacles (e.g., boulders, counters)
  - Upper tiles with `ABOVE_BIT` are see-through decorations that defer to the lower layer
  - No upper tile or nil upper table falls through to lower-layer passability

- **Introduced `ABOVE_BIT` (0x20) flag** to distinguish solid upper-layer obstacles from decorative overlays, with comprehensive documentation explaining the three-way passability logic

- **Updated movement checks** in `Scene::Map` to use the new methods:
  - `char_passable?` now checks upper tiles for both the source and destination
  - `char_can_land?` now checks upper tiles for jump landing validation
  - `passable?` (player movement) now checks upper tiles bidirectionally

- **Added `ChipSet#upper_flags` helper method** to safely retrieve passage flags from the upper table with proper bounds checking

- **Comprehensive test coverage** including:
  - Upper tiles with no data falling through to lower layer
  - Solid obstacles blocking movement regardless of lower layer
  - See-through decorations (ABOVE_BIT) respecting lower-layer passability
  - Shop counters now properly blocking walking onto them (not just action button reach)
  - Jump landing validation with upper-layer obstacles

## Implementation Details

The fix mirrors EasyRPG's `Game_Map::IsPassableTile` logic: upper-layer passability is checked first, and the `ABOVE_BIT` flag determines whether the lower layer also gets a say. This allows shop counters and other obstacles to be impassable while still supporting decorative overlays that don't override the ground beneath them.

https://claude.ai/code/session_01N8jLHbg1qHUs5ZCvoVfcuR