### PR TITLE
Implement airship landing and fly-over terrain restrictions

### DIFF
--- a/changelog.d/rpg2k-airship-landing-restrictions.added.md
+++ b/changelog.d/rpg2k-airship-landing-restrictions.added.md
@@ -1,0 +1,15 @@
+- **Airship landing and fly-over restrictions.** The airship now reads the two
+  terrain flags Set Vehicle Location left unused: `airship_pass` (a tile it may
+  fly over at all) and `airship_land` (a tile it may set down on), both default
+  true so ordinary maps behave exactly as before. Flying now checks
+  `airship_pass` through the same `vehicle_passable?` a boat / ship already used
+  for `boat_pass` / `ship_pass`, instead of the airship unconditionally clearing
+  every in-bounds tile. Disembarking the airship changed to match RPG_RT: it
+  lands **in place** — testing `airship_land` (and that no event sits on the
+  ground below) under the party's own tile — rather than stepping onto the tile
+  ahead the way a boat / ship disembarks onto the shore; landing where the
+  terrain forbids it leaves the party aboard. This was the one piece explicitly
+  left for later when vehicle boarding first landed. Covered by three new
+  checks in `scripts/rpg2k_scene_check.rb`: an `airship_pass: false` terrain
+  grounds the airship in place, an `airship_land: false` terrain refuses to let
+  the party disembark, and the default (both true) still lands normally.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1010,8 +1010,12 @@ The work below is roughly ordered by the critical path to a walkable game
   now). **Set Vehicle Location** (10850) and **Change Vehicle Graphic** (10650)
   place a boat / ship / airship and set its CharSet (persisted via
   `Game::Vehicle`), and the party can now **board and pilot** a placed vehicle on
-  the map (`Game::State#boarded`; airship flies over any tile, boat / ship follow
-  their terrain). Placed vehicles are **drawn on the map** from their CharSet, the
+  the map (`Game::State#boarded`; the airship flies over any tile whose terrain
+  allows it — the database terrain's `airship_pass` flag, default true — and
+  lands only where `airship_land` allows, touching down **in place** rather
+  than stepping onto the tile ahead the way a boat / ship disembarks onto the
+  shore; boat / ship follow their terrain's `boat_pass` / `ship_pass`).
+  Placed vehicles are **drawn on the map** from their CharSet, the
   ridden one following the party under the hero, and the **airship floats above a
   ground shadow**. Boarding **plays the vehicle's own BGM** (the database System
   boat / ship / airship music) and disembarking restores the map BGM. **Enter Hero Name**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -923,10 +923,20 @@ class RPG2k
         play_vehicle_bgm(type)
       end
 
-      # Step off the ridden vehicle onto the tile ahead when it is walkable on
-      # foot, leaving the vehicle on the tile the party vacates. A no-op when the
-      # way ahead is blocked (the party stays aboard).
+      # Step off the ridden vehicle. A boat / ship disembarks onto the tile
+      # ahead when it is walkable on foot, leaving the vehicle on the tile the
+      # party vacates; the airship instead lands in place — RPG_RT tests the
+      # terrain directly under it, not the tile ahead, since it has no "shore"
+      # to step onto. Either way a no-op when the landing spot is blocked (the
+      # party stays aboard).
       def disembark_vehicle
+        if @state.boarded == :airship
+          return unless airship_landable?(@state.x, @state.y)
+          follow_vehicle # the airship is left where it touched down
+          @state.boarded = nil
+          restore_pre_vehicle_bgm # the map BGM resumes
+          return
+        end
         fx, fy = target_tile(@state.x, @state.y, @state.direction)
         return unless passable?(fx, fy, @state.direction)
         follow_vehicle # the vehicle is left where the party is getting off
@@ -934,6 +944,17 @@ class RPG2k
         @state.y = fy
         @state.boarded = nil
         restore_pre_vehicle_bgm # the map BGM resumes
+      end
+
+      # Whether the airship may land on tile (x, y): the database terrain's
+      # airship_land flag (default true), with no event occupying the ground
+      # underneath. A tile with no terrain data (a bare fixture) is landable.
+      def airship_landable?(x, y)
+        return false unless @map.in_bounds?(x, y)
+        return false if @event_tiles[[x, y]]
+        row = terrain_row_at(x, y)
+        return true if row.nil?
+        row.airship_land ? true : false
       end
 
       # Play the vehicle's own BGM (the database System boat / ship / airship
@@ -990,15 +1011,20 @@ class RPG2k
       end
 
       # Whether vehicle `type` may enter tile (x, y) heading `dir`: the airship
-      # flies over any in-bounds tile; a boat / ship needs the tile's terrain to
-      # allow it (the database terrain's boat_pass / ship_pass flag) with no event
-      # in the way, falling back to on-foot passability when the map has no
-      # terrain data.
+      # flies over any in-bounds tile whose terrain allows it (the database
+      # terrain's airship_pass flag, default true, so it clears everything
+      # blocked on foot unless a map explicitly grounds it); a boat / ship needs
+      # the tile's terrain to allow it (boat_pass / ship_pass) with no event in
+      # the way, falling back to on-foot passability when the map has no terrain
+      # data.
       def vehicle_passable?(x, y, dir, type)
         return false unless @map.in_bounds?(x, y)
-        return true if type == :airship
-        return false if @event_tiles[[x, y]]
         row = terrain_row_at(x, y)
+        if type == :airship
+          return true if row.nil?
+          return row.airship_pass ? true : false
+        end
+        return false if @event_tiles[[x, y]]
         return passable?(x, y, dir) unless row
         type == :boat ? (row.boat_pass ? true : false) : (row.ship_pass ? true : false)
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -194,7 +194,8 @@ def fake_map_with_counters(id, events, counters)
                                    upper_layer: upper, events: events))
 end
 
-def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0)
+def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
+            airship_land: true, airship_pass: true)
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
@@ -290,8 +291,10 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0)
                                      flash_green: 31, flash_blue: 31, flash_power: 20) }
     ) },
     # Every tile of the synthetic map is chip 0, which the fake chipset tags as
-    # terrain 42 — so this one row decides whether walking hurts.
-    terrain: { 42 => OpenStruct.new(damage: terrain_damage, bush_depth: bush_depth) },
+    # terrain 42 — so this one row decides whether walking hurts, and (for the
+    # airship checks) whether it may fly over / land on any tile.
+    terrain: { 42 => OpenStruct.new(damage: terrain_damage, bush_depth: bush_depth,
+                                    airship_land: airship_land, airship_pass: airship_pass) },
     common_event: common,
     # Database actor rows carry the *original* names, which a \N[n] must not
     # use once the actor has been renamed in play (see the \N[n] check).
@@ -436,8 +439,10 @@ def fake_party(members = [])
 end
 
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
-              members: [], terrain_damage: 0, bush_depth: 0)
-  db = fake_db(common, troop_pages, terrain_damage, bush_depth)
+              members: [], terrain_damage: 0, bush_depth: 0,
+              airship_land: true, airship_pass: true)
+  db = fake_db(common, troop_pages, terrain_damage, bush_depth,
+               airship_land: airship_land, airship_pass: airship_pass)
   state = Game::State.new(fake_party(members), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   RPG2k::Scene::Map.new(fake_parent(db), state)
@@ -2785,6 +2790,60 @@ check 'the airship flies over a tile blocked on foot, and follows the party' do
   RGSS::Input.dir_value = 0
   ok st.x >= 1, 'the airship crossed the on-foot-blocked tile'
   eq [st.x, st.y], [air.x, air.y], 'the airship follows the party'
+end
+
+check 'the airship cannot fly over terrain whose airship_pass flag forbids it' do
+  scene = new_scene({}, player: [0, 0], airship_pass: false)
+  st = scene.instance_variable_get(:@state)
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 0 # the airship sits under the party; board in place
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'boarded the airship in place'
+  RGSS::Input.dir_value = 6
+  10.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [0, 0], [st.x, st.y], 'airship_pass: false grounded the airship in place'
+end
+
+check 'the airship cannot land where the terrain\'s airship_land flag forbids it' do
+  scene = new_scene({}, player: [0, 0], airship_land: false)
+  st = scene.instance_variable_get(:@state)
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 0
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'boarded the airship'
+  # Try to land again: every tile forbids it, so the party stays aboard.
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'airship_land: false kept the party aboard'
+end
+
+check 'the airship lands in place where the terrain allows it' do
+  scene = new_scene({}, player: [0, 0], airship_land: true)
+  st = scene.instance_variable_get(:@state)
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 0
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'boarded the airship'
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'landed where airship_land allows it'
+  eq [0, 0], [st.x, st.y], 'the party stands where the airship touched down'
+  eq [0, 0], [air.x, air.y], 'the airship stayed where it landed'
 end
 
 check 'Show Battle Animation with the wait flag holds the event then resumes' do


### PR DESCRIPTION
## Summary
Adds support for airship terrain restrictions using two previously unused database flags: `airship_pass` (controls fly-over) and `airship_land` (controls landing). Both default to true, preserving existing behavior on maps without explicit restrictions.

## Key Changes

- **Terrain flag support**: Extended the fake terrain database to include `airship_pass` and `airship_land` flags, with defaults matching RPG_RT behavior
- **Flight restrictions**: Modified `vehicle_passable?` to check the `airship_pass` flag when determining if an airship can fly over a tile, instead of unconditionally allowing flight over any in-bounds tile
- **Landing behavior**: Rewrote `disembark_vehicle` to handle airship landing differently from boats/ships:
  - Airships land **in place** (testing the terrain directly under the party)
  - Boats/ships continue to disembark onto the tile ahead (existing behavior)
  - Added `airship_landable?` method to validate landing spots, checking both the `airship_land` flag and event occupancy
- **Test coverage**: Added three comprehensive checks validating:
  - `airship_pass: false` grounds the airship in place
  - `airship_land: false` prevents disembarking
  - Default behavior (both true) allows normal flight and landing
- **Documentation**: Updated TODO.md to reflect the completed airship restriction feature

## Implementation Details

The airship now uses the same `vehicle_passable?` validation path as boats and ships, making the vehicle system more consistent. The key difference is that airships check terrain flags but ignore events during flight (events only block landing). Landing validation is separate from flight validation, allowing maps to restrict landing while permitting flight over certain tiles.

https://claude.ai/code/session_01CYo1cZJQiKdhpvvYzYot5n