### PR TITLE
Implement Escape and Teleport field skills with menu integration

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1293,13 +1293,31 @@ The work below is roughly ordered by the critical path to a walkable game
   with no map or interpreter behind it, so it still cannot tell "this skill is
   legitimately state-gated" from "no menu reaches this skill" on its own, and
   keeps deferring those two types to this note instead of flagging them as
-  unreachable. Left unbuilt still: the battle-time skill variance and
-  two-handed / dual-wield **equipping** (the equip screen's slot rules — a
-  二刀流 weapon's *combat* effect is read now, see ADR 0033), and a **special
-  item** (type 9) invoking an Escape/Teleport skill — `#field_usable?` does not
-  thread `Game::State` through to `#field_skill?` the way the field menu does,
-  so such an item (neither test bed has one) would still read as unusable
-  rather than warping.
+  unreachable. Left unbuilt still: the battle-time skill variance, and a
+  **special item** (type 9) invoking an Escape/Teleport skill —
+  `#field_usable?` does not thread `Game::State` through to `#field_skill?`
+  the way the field menu does, so such an item (neither test bed has one)
+  would still read as unusable rather than warping.
+  **Dual-wield equipping is done too, the opposite rule to two-handed.** A
+  weapon's own *combat* effect (a 二刀流 weapon swinging twice) was read
+  already (ADR 0033); what remained was the *actor*-row 二刀流 (`double_hand`,
+  4 of Nepheshel's actors and 1 of mtf's), which turns the shield slot into a
+  second weapon slot — ADR 0040 named this as the item its own two-handed-gear
+  rule left alone. `Game::Party#equip_candidates(slot, actor)` retargets the
+  shield slot to weapon-only candidates for such an actor, ported from
+  EasyRPG's `Window_EquipItem` (which does the identical retarget before
+  filtering, and rejects a shield there outright with no exception); a new
+  `#equip_candidate_for?` guards `#equip_from_bag` against the reverse. Placing
+  the result needed `Actor#equip_item` to take an explicit slot — its old
+  always-by-type mapping would put any weapon in slot 0, which is exactly
+  wrong for a second one — while the Change Equipment event command's own call
+  stays untouched (no notion of "the second weapon slot" there either,
+  matching `Game_Actor::ChangeEquipment`). Combat needed nothing: the weapon-
+  only scans behind `#attack_hit_rate` / `#weapon_crit_bonus` /
+  `#equipment_flag?` and the plain sum behind `#equip_bonus` already read every
+  equipped slot by the item's own *type*, not by slot index, so a second
+  weapon in the shield slot is picked up — the better of the two, for hit and
+  crit — the moment it is worn. See ADR 0040's addendum.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -504,13 +504,16 @@ The work below is roughly ordered by the critical path to a walkable game
   which `draw_weather` paints rain streaks (falling, wind-skewed 1×6 marks) or
   snow (drifting 2×2 flecks), the particle count scaling with strength and the
   positions advancing with the scene's animation frame so the field animates.
-  **Set Teleport / Escape Target** (11810 / 11830), **Change Encounter Rate**
-  (11740) and **Change System BGM** (10660) record their payloads
-  on `Game::State` — a per-map teleport-target registry, a single escape target,
-  the encounter step rate and per-slot system music overrides — and
-  round-trip through the save, but nothing consumes them yet (the Teleport /
-  Escape skills, encounter system and battle scene are not built), so
-  they are modelled for save fidelity like the access flags. **Change System
+  **Set Teleport / Escape Target** (11810 / 11830) record their payloads on
+  `Game::State` — a per-map teleport-target registry, a single escape target —
+  and round-trip through the save; the field menu's Escape / Teleport skill
+  types now consume them (see the field-skill-menu entry below) — an event can
+  register a destination for a warp spell to use. **Change Encounter Rate**
+  (11740) and **Change System BGM** (10660) record their payloads too — the
+  encounter step rate and per-slot system music overrides — and round-trip
+  through the save, but nothing consumes them yet (the encounter system and
+  battle scene's use of a system BGM slot are not built), so they are modelled
+  for save fidelity like the access flags. **Change System
   SFX** (10670) is now consumed on the map: the choice window plays the cursor
   sound as the selection moves and the decision sound on confirm, resolving a
   Change System SFX override on `Game::State` before the database default
@@ -1253,12 +1256,50 @@ The work below is roughly ordered by the critical path to a walkable game
   `occasion_field2` and `occasion_battle` (a switch item's own pair) — this build
   asked for `occasion_field`, a name no real row carries, so the gate silently
   never fired. An earlier version of this list claimed that gate worked; it did
-  not, on any genuine item. See ADR 0031. Remaining: **teleport / escape** skill
-  types (one of each across both test beds; teleport wants a destination picker
-  this build has no screen for, so `Party#unsupported_field_skill?` declares the
-  gap), the battle-time skill variance, and two-handed / dual-wield **equipping**
-  (the equip screen's slot rules — a 二刀流 weapon's *combat* effect is read now,
-  see ADR 0033).
+  not, on any genuine item. See ADR 0031. **Escape and Teleport skill types now
+  warp the party.** Both were declared unbuilt here — Escape wanting nothing
+  more than its one registered target and Teleport wanting "a destination
+  picker this build has no screen for" — and both gaps are closed the same way
+  EasyRPG's own `Scene_Skill` closes them: `Algo::IsSkillUsable`'s
+  `Type_escape` / `Type_teleport` arms (not in battle — already true, since
+  `#battle_skill?` excludes both types unconditionally; the party's access
+  flag; a registered target; not flying) became
+  `Game::Party#escape_skill_available?` / `#teleport_skill_available?`, read by
+  `#field_skill?` given the `Game::State` the field menu now passes it (every
+  older caller, including the fixture checks, still omits it and gets the old
+  "unsupported" reading). Casting spends SP through the same `#can_cast?` gate
+  every other field skill uses and returns the destination for
+  `Scene::SkillMenu` to queue on `Game::State#pending_teleport` rather than
+  jumping directly — the menu is not `Scene::Map` and has none of its map-load
+  machinery, so the actual jump happens back there, the way the interpreter's
+  own Teleport command already does, just queued from a different source and
+  picked up (then rendered immediately, not left a frame stale) the moment
+  `Scene::Map` is next on top of the scene stack. Escape warps straight to its
+  one target with no prompt, matching `Scene_Skill`'s own "no picker" branch;
+  Teleport opens a third list beside the skill/target ones, built from every
+  `Game::State#teleport_targets` entry and named through the map tree's own
+  `map_properties` (`Game_Map::GetMapName`), the same source the battle
+  backdrop's terrain walk already reads. A registered target's own `switch_id`
+  is round-tripped through the save but — like EasyRPG's `Window_Teleport`,
+  `Game_Targets` and `Scene_Teleport`, none of which read it back — still left
+  unconsumed here too; nothing in the reference implementation gates the list
+  by it, so filtering here would be a guess the real binary does not make.
+  Casting either skill also forces the party off a ridden boat or ship first
+  (mirroring `Game_Player::ForceGetOffVehicle`), leaving the vehicle parked
+  where it was boarded; the airship is not forced off because it is not
+  boarded off at all — `#flying?` (`state.boarded == :airship`) bars both
+  skills outright, the one vehicle RPG_RT excludes them from. `Party#unsupported_field_skill?`
+  stays (renamed in spirit, not in name): the testbed harness builds a party
+  with no map or interpreter behind it, so it still cannot tell "this skill is
+  legitimately state-gated" from "no menu reaches this skill" on its own, and
+  keeps deferring those two types to this note instead of flagging them as
+  unreachable. Left unbuilt still: the battle-time skill variance and
+  two-handed / dual-wield **equipping** (the equip screen's slot rules — a
+  二刀流 weapon's *combat* effect is read now, see ADR 0033), and a **special
+  item** (type 9) invoking an Escape/Teleport skill — `#field_usable?` does not
+  thread `Game::State` through to `#field_skill?` the way the field menu does,
+  so such an item (neither test bed has one) would still read as unusable
+  rather than warping.
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default

--- a/docs/adr/0040-two-handed-weapons.md
+++ b/docs/adr/0040-two-handed-weapons.md
@@ -71,3 +71,55 @@ a bulk equip restores a saved pair as-is) and by
 `scripts/rpg2k_testbed_logic_check.rb`, which equips **every** real two-handed
 weapon in both games over a real shield and asserts the hand empties, and asserts
 that no non-weapon in either game carries the flag.
+
+## Addendum: `double_hand` — the opposite rule
+
+Date: 2026-08-12
+
+The item left alone above is now implemented, ported from EasyRPG's
+`Window_EquipItem` (the equip menu's candidate-list window) and
+`Game_Actor::ForEachEquipment` rather than guessed at, since the flag has no
+byte pattern of its own to read the way a combat modifier's do — it is purely
+a menu-construction rule.
+
+`Window_EquipItem`'s constructor retargets the whole slot before it filters
+candidates: `if (equip_type == shield && actor.HasTwoWeapons()) equip_type =
+weapon`, and its shield case tests `item->type == Type_shield` with no
+double-hand exception at all — so a double-hand actor's shield slot lists
+weapons and *only* weapons, not weapons alongside shields.
+`Game::Party#equip_candidates(slot, actor)` does the same retargeting, and
+`#equip_candidate_for?` mirrors it as a guard on `#equip_from_bag`, so the two
+can never disagree about what a given slot will accept.
+
+The harder part was not the candidate list but *placing* the result:
+`Actor#equip_item`'s slot used to come from nowhere but the item's own type
+(weapon → 0, always), which is exactly wrong for a second weapon that has to
+land in slot 1. It now takes an optional explicit `slot`, and
+`Party#equip_from_bag` passes the one its candidate list was built for — the
+Change Equipment event command's own call is untouched (no slot argument, as
+before), matching EasyRPG's `Game_Actor::ChangeEquipment`, which likewise has
+no notion of "the second weapon slot" and always resolves a weapon to slot 0.
+
+Nothing about *combat* needed a change. `#attack_hit_rate`, `#weapon_crit_bonus`
+and the weapon-only arm of `#equipment_flag?` (二刀流 dual-attack, 必中
+ignore-evasion) already scan every equipped slot for an item whose own
+*type* reads as a weapon, never slot 0 by name, so once a second weapon
+occupies slot 1 they pick it up — and take the *better* of the two, mirroring
+`ForEachEquipment`'s own max-of-both-weapons reduction — for free. The stat
+sum (`#equip_bonus`) was already slot-agnostic for the same reason: it adds
+every equipped item's own bonus field regardless of which slot holds it.
+
+Left alone still: whether the equip screen's slot-1 *label* changes from
+"Shield" to something else for a double-hand actor. Nothing in
+`Window_EquipItem` (which only builds the candidate list) settles that, and it
+would need `Window_Equip`'s own row-label source — not checked here, so the
+label stays "Shield" regardless.
+
+Covered by `scripts/rpg2k_logic_check.rb`: a double-hand actor's shield slot
+offers the two held weapons and not the shield (with the ordinary weapon slot
+listing the same two, and an ordinary actor still offered the shield);
+equipping a second weapon from the bag lands it in slot 1, both weapons then
+contributing to attack, hit rate (the better of the two) and crit bonus;
+naming a shield for the shield slot directly is rejected and nothing is
+spent; and a two-handed weapon equipped as the *second* weapon still empties
+its neighbour, the same rule as the base ADR from the other slot.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2517,9 +2517,13 @@ module Game
     # has no target at all — it just turns its switch on. Nepheshel's companions
     # are summoned and dismissed exactly this way (skills 120–125, "ファルを召還"
     # and friends, each flipping the switch its common event watches).
-    def field_skills(caster)
+    #
+    # `state` is optional and only read for the Escape / Teleport types below —
+    # every other caller (the host-side fixture checks included) can omit it and
+    # gets the old scope/occasion-only behaviour.
+    def field_skills(caster, state = nil)
       return [] unless caster
-      caster.skills.sort.select { |sid| field_skill?(db_skill(sid)) }
+      caster.skills.sort.select { |sid| field_skill?(db_skill(sid), state) }
             .map { |sid| [sid, skill_cost(db_skill(sid), caster)] }
     end
 
@@ -2539,11 +2543,13 @@ module Game
     # An ordinary skill outside battle needs a target the field can offer (scope
     # >= 2, i.e. self or allies -- there is no enemy to aim at) and has to do
     # something once there: change HP/SP, or inflict a state.
-    def field_skill?(sk)
+    def field_skill?(sk, state = nil)
       return false unless sk
       case sk.type
-      when SKILL_ESCAPE, SKILL_TELEPORT
-        false # see #unsupported_field_skill?
+      when SKILL_TELEPORT
+        teleport_skill_available?(state)
+      when SKILL_ESCAPE
+        escape_skill_available?(state)
       when SKILL_SWITCH
         field_occasion?(sk)
       else
@@ -2555,12 +2561,77 @@ module Game
       end
     end
 
-    # Escape (type 1) and Teleport (type 2) skills warp the party to a memorised
-    # target. RPG_RT also gates them on the party's escape / teleport access and
-    # on a target having been memorised. Neither is offered yet: teleport needs a
-    # destination picker this build has no screen for. Between them the two test
-    # beds hold exactly one of each (mtf-meido-action's "Escape" and "Teleport"),
-    # so there is nothing here to measure a real implementation against.
+    # Whether the Escape skill type (1) is usable right now: the party's escape
+    # access is on, a Set Escape Target has registered a destination, and the
+    # party is not flying (boarded the airship). Mirrors EasyRPG's
+    # `Algo::IsSkillUsable`'s `Type_escape` arm, minus the "not in battle" term —
+    # #battle_skill? already excludes both types unconditionally, matching
+    # RPG_RT's own field-only offer of them. `state` is nil for callers that
+    # have none (bare fixtures, the fixture-only test harnesses), which reads as
+    # unusable exactly like the old "always false" behaviour.
+    def escape_skill_available?(state)
+      return false unless state
+      state.escape_access && !state.escape_target.nil? && !flying?(state)
+    end
+
+    # Whether the Teleport skill type (2) is usable right now: teleport access is
+    # on, at least one destination has been registered by a Set Teleport Target,
+    # and the party is not flying. Which registered destination is used is a
+    # separate choice the field menu offers (see Scene::SkillMenu) — unlike
+    # Escape, RPG_RT's Teleport type has more than one possible target and pops a
+    # picker (EasyRPG's `Scene_Teleport` / `Window_Teleport`, which lists every
+    # registered map by name and does not itself filter by the target's own
+    # switch field — that field round-trips through the save but the reference
+    # implementation never reads it back, so it is left unconsumed here too).
+    def teleport_skill_available?(state)
+      return false unless state
+      state.teleport_access && !state.teleport_targets.empty? && !flying?(state)
+    end
+
+    # Whether the party is currently riding the airship — the one vehicle RPG_RT
+    # bars Escape/Teleport from (a boat or ship is forced off first instead, see
+    # #cast_escape_skill / #cast_teleport_skill).
+    def flying?(state)
+      state.respond_to?(:boarded) && state.boarded == :airship
+    end
+
+    # Cast an Escape (type 1) skill: spend `caster`'s SP and return the
+    # registered escape destination as `{map_id:, x:, y:}` for the scene to jump
+    # to, or nil when `sid` is not a castable, available Escape skill. Matches
+    # EasyRPG's Scene_Skill, which jumps straight to `Game_Targets`' single
+    # escape target with no picker.
+    def cast_escape_skill(caster, sid, state)
+      sk = db_skill(sid)
+      return nil unless sk && sk.type == SKILL_ESCAPE
+      return nil unless can_cast?(caster, sid) && escape_skill_available?(state)
+      target = state.escape_target
+      return nil unless target
+      caster.change_mp(-skill_cost(sk, caster))
+      { map_id: target[:map_id], x: target[:x], y: target[:y] }
+    end
+
+    # Cast a Teleport (type 2) skill to the registered destination named by
+    # `map_id`: spend `caster`'s SP and return `{map_id:, x:, y:}`, or nil when
+    # `sid` is not a castable, available Teleport skill or `map_id` names no
+    # registered target (the picker only offers ids that do, so this is a
+    # defensive check rather than one real play can trigger).
+    def cast_teleport_skill(caster, sid, state, map_id)
+      sk = db_skill(sid)
+      return nil unless sk && sk.type == SKILL_TELEPORT
+      return nil unless can_cast?(caster, sid) && teleport_skill_available?(state)
+      target = state.teleport_targets[map_id]
+      return nil unless target
+      caster.change_mp(-skill_cost(sk, caster))
+      { map_id: map_id, x: target[:x], y: target[:y] }
+    end
+
+    # Whether `sk`'s field-menu offer depends on runtime state (`Game::State`)
+    # that a caller checking `#field_skill?` / `#battle_skill?` alone has no way
+    # to supply — the Escape (1) and Teleport (2) types, whose availability
+    # depends on the party's access flags and registered targets rather than the
+    # skill row alone. Used by the testbed harness, which builds a party with no
+    # running map/interpreter behind it, to tell "this skill type is legitimately
+    # state-gated" apart from "no menu offers this skill at all".
     def unsupported_field_skill?(sk)
       !sk.nil? && (sk.type == SKILL_ESCAPE || sk.type == SKILL_TELEPORT)
     end
@@ -6533,9 +6604,18 @@ module Game
     # Whether the Teleport and Escape skills are usable, toggled by the Change
     # Teleport Access (11820) and Change Escape Access (11840) event commands.
     # Default off — RPG2000 games enable these once the skill's targets are set —
-    # and persisted in the save. (The skills themselves are not executed yet, so
-    # these gate nothing at runtime; they are modelled for save fidelity.)
+    # and persisted in the save. Read by Game::Party#escape_skill_available? /
+    # #teleport_skill_available? to gate the field skill menu.
     attr_accessor :teleport_access, :escape_access
+    # A `{map_id:, x:, y:}` destination queued by an Escape / Teleport field
+    # skill (see Game::Party#cast_escape_skill / #cast_teleport_skill), picked up
+    # and cleared by Scene::Map#update on the next frame it runs. The menu
+    # scenes that cast these skills are not the map scene and have none of its
+    # map-load machinery, so — like the interpreter's own Teleport command — the
+    # actual jump happens back in Scene::Map, just queued from a different
+    # source. Transient: never persisted, since nothing can be mid-menu at a
+    # save (Save is a main-menu command, one level up from the skill screen).
+    attr_accessor :pending_teleport
     # The BGM currently playing and the one stashed by Memorize BGM (11530),
     # each nil or a `{ name:, volume:, tempo: }` hash. Play Memorized BGM (11540)
     # restores the stash. Persisted in the save so the memory survives a reload.
@@ -6600,6 +6680,7 @@ module Game
       @y = y
       @direction = 2
       @map = nil
+      @pending_teleport = nil
       @switches = Switches.new
       @variables = Variables.new
       @timers = [Timer.new, Timer.new]

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1263,16 +1263,20 @@ module Game
       @equipment.include?(item_id)
     end
 
-    # Equip a database item into the slot matching its type (weapon type 1 ->
-    # slot 0, shield 2 -> 1, armour 3 -> 2, helmet 4 -> 3, accessory 5 -> 4) and
-    # recompute the boosted stats. A non-equippable item, an unknown id, or a
-    # database without an item table is ignored. Drives the Change Equipment
-    # event command's equip operation.
-    def equip_item(item_id)
+    # Equip a database item into `slot`, defaulting to the one its own type
+    # matches (weapon type 1 -> slot 0, shield 2 -> 1, armour 3 -> 2, helmet
+    # 4 -> 3, accessory 5 -> 4), and recompute the boosted stats. An explicit
+    # `slot` is what a 二刀流 actor's second weapon needs: its type still says
+    # "weapon" (slot 0), but the equip menu is placing it in the shield slot
+    # (1) as the candidate list `Party#equip_candidates` offered it for. A
+    # non-equippable item, an unknown id, or a database without an item table
+    # is ignored. Drives the Change Equipment event command's equip operation
+    # (always by type, since that command names no slot).
+    def equip_item(item_id, slot = nil)
       return if item_id.nil? || item_id == 0 || !@db.respond_to?(:item)
       it = @db.item[item_id]
       return unless it
-      slot = it.type - 1
+      slot ||= it.type - 1
       return unless slot >= 0 && slot < EQUIP_ORDER.size
       @equipment[slot] = item_id
       freed = free_two_handed_slot(slot)
@@ -1492,6 +1496,25 @@ module Game
       row = class_row_for(@class_id) if @class_id && @class_id > 0
       row ||= @db_row
       row.respond_to?(:strong_defence) ? (row.strong_defence ? true : false) : false
+    end
+
+    # 二刀流 — an actor (or RPG2003 class) trait that turns the *shield* slot
+    # into a *second weapon* slot, unlike the item-row #dual_attack? above (a
+    # weapon that makes one basic attack swing twice — an unrelated flag that
+    # happens to share the same Japanese name). Same class-row-then-player-row
+    # lookup as #strong_defence?, since RPG2003 lets a class override it too
+    # (liblcf's `job` table carries the same field id). EasyRPG's
+    # `Window_EquipItem` retargets the whole shield slot to `weapon` before
+    # listing candidates for such an actor, and rejects a shield there
+    # outright — #equip_candidates does the retargeting; #attack_hit_rate,
+    # #weapon_crit_bonus and #equipment_flag?'s weapon-only search already
+    # scan every equipped slot for an item whose own *type* is a weapon rather
+    # than hard-coding slot 0, so once a second weapon sits in the shield slot
+    # they pick it up (and the better of the two) with no change of their own.
+    def double_hand?
+      row = class_row_for(@class_id) if @class_id && @class_id > 0
+      row ||= @db_row
+      row.respond_to?(:double_hand) ? (row.double_hand ? true : false) : false
     end
 
     # Coerce an equipment spec (an EQUIP_ORDER hash, an array of ids, or nil) to a
@@ -2426,27 +2449,54 @@ module Game
       (t >= 1 && t <= Actor::EQUIP_ORDER.size) ? t - 1 : nil
     end
 
-    # Held items equippable in equipment `slot` (0..4), as [id, count] pairs in
-    # ascending id order -- the candidate list for the equip menu's chosen slot.
-    def equip_candidates(slot)
+    # Held items equippable in equipment `slot` (0..4) on `actor`, as
+    # [id, count] pairs in ascending id order -- the candidate list for the
+    # equip menu's chosen slot. `actor` only matters for the shield slot (1):
+    # a 二刀流 (double_hand) actor's shield slot is a second weapon slot, so it
+    # lists weapons there instead of shields -- mirroring EasyRPG's
+    # `Window_EquipItem`, which retargets the whole slot to `weapon` for such
+    # an actor before filtering, rather than offering both kinds.
+    def equip_candidates(slot, actor = nil)
+      slot = Actor::WEAPON_SLOT if slot == Actor::SHIELD_SLOT && actor && actor.double_hand?
       @items.keys.sort.select { |id| item_count(id) > 0 && equip_slot_for(id) == slot }
             .map { |id| [id, item_count(id)] }
     end
 
-    # Equip bag item `item_id` on `actor`, moving it through the inventory the way
-    # the equip menu does: take one from the bag, equip it into the slot its type
-    # dictates, and return the previously-equipped item (if any) to the bag. A
-    # no-op returning false unless the party holds the item and it is equipment;
-    # true on success. (Unlike the Change Equipment event command, which does not
-    # touch the bag, the menu swaps through it.)
-    def equip_from_bag(actor, item_id)
+    # Whether held item `id` is a genuine #equip_candidates entry for `slot` on
+    # `actor` -- mirrors that method's own retargeting exactly, so a `slot`
+    # argument #equip_from_bag receives can never accept anything the
+    # candidate list would not itself have offered (in either direction: a
+    # 二刀流 actor's shield slot accepts a weapon, not a weapon *and* a shield).
+    def equip_candidate_for?(actor, id, slot)
+      base = equip_slot_for(id)
+      return false if base.nil?
+      if slot == Actor::SHIELD_SLOT && actor && actor.double_hand?
+        base == Actor::WEAPON_SLOT
+      else
+        base == slot
+      end
+    end
+
+    # Equip bag item `item_id` on `actor` into equipment `slot`, moving it
+    # through the inventory the way the equip menu does: take one from the bag,
+    # equip it into that slot, and return the previously-equipped item (if any)
+    # to the bag. `slot` defaults to the one the item's own type dictates (so
+    # the Item menu's field-usable-item paths that never pass one keep working
+    # unchanged); the equip menu always passes the slot its candidate list
+    # (#equip_candidates) was built for, which is what lets a 二刀流 actor's
+    # second weapon land in the shield slot rather than overwriting the first.
+    # A no-op returning false unless the party holds the item and it is a
+    # genuine candidate for that slot on that actor (#equip_candidate_for?);
+    # true on success. (Unlike the Change Equipment event command, which does
+    # not touch the bag, the menu swaps through it.)
+    def equip_from_bag(actor, item_id, slot = nil)
       return false unless actor && item_count(item_id) > 0
-      slot = equip_slot_for(item_id)
-      return false if slot.nil?
+      slot ||= equip_slot_for(item_id)
+      return false if slot.nil? || !equip_candidate_for?(actor, item_id, slot)
       previous = actor.equipment[slot]
       # A 両手持ち weapon empties the other hand; whatever it was holding comes
       # back to the bag alongside the item this slot displaced.
-      freed = actor.equip_item(item_id)
+      freed = actor.equip_item(item_id, slot)
       lose_item(item_id, 1)
       gain_item(previous, 1) if previous && previous != 0
       gain_item(freed, 1) if freed && freed != 0

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -188,6 +188,12 @@ module Game
       @move_route_requests = []
       @location_requests = []
       @sprite_flash_requests = []
+      # Also reset by #start/#stop; set here too so #resume's unconditional
+      # drain (see #resume) is safe even before this interpreter has ever run a
+      # command list -- a fresh map's Scene::Map now reaches it the moment an
+      # Escape/Teleport field skill queues a warp with no event having started
+      # the interpreter yet (see Game::State#pending_teleport).
+      @pending_messages = []
       @erase_requested = false
       @halt_movement_requested = false
       @actor_graphic_changed = false

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -439,6 +439,15 @@ class RPG2k
     scene.dispose if scene.respond_to?(:dispose)
   end
 
+  # Pop every scene down to (and stopping at) the base `Scene::Map`, disposing
+  # each in turn. Mirrors EasyRPG's `Scene::PopUntil(Scene::Map)`: casting an
+  # Escape / Teleport field skill closes the whole menu stack in one step
+  # rather than leaving the player to cancel out of it manually, matching
+  # RPG_RT's own "warp closes the menu" behaviour.
+  def pop_to_map
+    pop while @scenes.size > 1
+  end
+
   # Tear down all scenes and return to a fresh title screen.
   def return_to_title
     @scenes.each { |s| s.dispose if s.respond_to?(:dispose) }

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -6,8 +6,10 @@ class RPG2k
     # -- swapping the previously-worn item back into the bag -- or empties the
     # slot. The bag-aware equip logic is Game::Party#equip_candidates /
     # equip_from_bag / unequip_to_bag (host-tested); this is the RGSS UI over it,
-    # mirroring Scene::ItemMenu's helpers. Actor-cycling covers the party; two-
-    # handed weapons and dual-wield are later refinements.
+    # mirroring Scene::ItemMenu's helpers. A two-handed weapon empties the other
+    # hand (Actor#free_two_handed_slot) and a 二刀流 actor's shield slot lists
+    # weapons instead of shields (#equip_candidates, given `actor`) -- both
+    # handled by the party-level logic this scene just calls through to.
     class EquipMenu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
@@ -80,8 +82,10 @@ class RPG2k
       end
 
       def candidates
-        # The slot's fitting bag items, with a leading Remove entry (id 0).
-        @candidates ||= [[0, 0]] + @state.party.equip_candidates(@slot_index)
+        # The slot's fitting bag items, with a leading Remove entry (id 0). A
+        # 二刀流 actor's shield slot lists weapons instead of shields, which is
+        # why `actor` goes along -- see Game::Party#equip_candidates.
+        @candidates ||= [[0, 0]] + @state.party.equip_candidates(@slot_index, actor)
       end
 
       def update_items
@@ -105,7 +109,10 @@ class RPG2k
         if id == 0
           @state.party.unequip_to_bag(actor, @slot_index)
         else
-          @state.party.equip_from_bag(actor, id)
+          # Pass the slot the candidate list was built for -- a 二刀流 actor's
+          # second weapon has to land in the shield slot (1), which its own
+          # item type (weapon, slot 0) would not otherwise pick.
+          @state.party.equip_from_bag(actor, id, @slot_index)
         end
         leave_items
         rebuild_for_actor

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -156,6 +156,30 @@ class RPG2k
       end
 
       def update
+        # An Escape / Teleport field skill queues its destination here rather
+        # than jumping directly -- it is cast from the skill menu, a scene with
+        # none of this one's map-load machinery, and this scene does not even
+        # run its #update while that menu sits on top of it. Applied as the
+        # very first thing once this scene is on top again and then rendered
+        # immediately, the same way the interpreter's own Teleport command
+        # renders the destination map on the frame it lands (see the `:teleport`
+        # branch below) rather than leaving a stale frame up for one tick. The
+        # rest of this frame's simulation (timers, event stepping, movement) is
+        # skipped exactly as it already is on that frame -- #event_busy? holds
+        # it off there because the interpreter is mid-wait, and there is no
+        # interpreter wait to hold it off here, so it is skipped explicitly.
+        if @state.pending_teleport
+          if @state.boarded? && @state.boarded != :airship
+            follow_vehicle
+            @state.boarded = nil
+            restore_pre_vehicle_bgm
+          end
+          perform_teleport(@state.pending_teleport)
+          @state.pending_teleport = nil
+          animate_events
+          render
+          return
+        end
         # The timers keep counting during events too. A fight is running when the
         # battle UI is up, and a timer without the "run in battle" flag pauses
         # (and hides) for its duration rather than being stopped.

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -3,9 +3,15 @@ class RPG2k
     # The field skill screen (main menu -> Skill). Lists one party member's known
     # field-usable skills with their SP cost; LEFT/RIGHT cycle the caster. Casting
     # a single-ally skill (scope 3) asks who to use it on, while a self (2) or
-    # all-ally (4) skill applies at once, spending SP and restoring HP/SP. All the
+    # all-ally (4) skill applies at once, spending SP and restoring HP/SP. An
+    # Escape skill warps straight to the registered escape target with no
+    # prompt; a Teleport skill opens a third list of every registered
+    # destination (by map name) to choose from. Either warp closes the whole
+    # menu stack and queues the jump for Scene::Map to perform (see
+    # Game::State#pending_teleport) rather than applying anything here. All the
     # decision logic is on Game::Party (field_skills / skill_cost / can_cast? /
-    # skill_effect / cast_skill), host-tested; this is the RGSS UI over it.
+    # skill_effect / cast_skill / cast_escape_skill / cast_teleport_skill),
+    # host-tested; this is the RGSS UI over it.
     class SkillMenu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
@@ -18,8 +24,9 @@ class RPG2k
         @caster_index = 0
         @skill_index = 0
         @target_index = 0
+        @teleport_index = 0
         @pending_skill = nil
-        @mode = :skills          # :skills list, or :target selection
+        @mode = :skills          # :skills list, :target selection, or :teleport_target
         @message = nil
         build_skill_window
       end
@@ -28,11 +35,16 @@ class RPG2k
         close_message
         @skill_window.dispose if @skill_window
         @target_window.dispose if @target_window
+        @teleport_window.dispose if @teleport_window
       end
 
       def update
         return drive_message if @message
-        @mode == :target ? update_target : update_skills
+        case @mode
+        when :target then update_target
+        when :teleport_target then update_teleport_target
+        else update_skills
+        end
       end
 
       private
@@ -42,7 +54,7 @@ class RPG2k
       end
 
       def skills
-        @skills ||= @state.party.field_skills(caster)
+        @skills ||= @state.party.field_skills(caster, @state)
       end
 
       def skill_name(sid)
@@ -86,10 +98,19 @@ class RPG2k
         return if skills.empty?
         sid, = skills[@skill_index]
         sk = @state.party.db_skill(sid)
-        # A switch skill has no target at all; a self (2) or all-ally (4) skill
-        # needs no target prompt; a single-ally skill (3) asks which ally.
+        # A switch skill has no target at all; Escape warps straight to its one
+        # registered target; Teleport opens a list of every registered target;
+        # a self (2) or all-ally (4) skill needs no target prompt; a
+        # single-ally skill (3) asks which ally.
         if sk && sk.type == Game::Party::SKILL_SWITCH
           apply_switch_skill(sid)
+        elsif sk && sk.type == Game::Party::SKILL_ESCAPE
+          apply_escape_skill(sid)
+        elsif sk && sk.type == Game::Party::SKILL_TELEPORT
+          @pending_skill = sid
+          @mode = :teleport_target
+          @teleport_index = 0
+          build_teleport_window
         elsif sk && (sk.scope == 2 || sk.scope == 4)
           apply_skill(sid, nil)
         else
@@ -145,6 +166,65 @@ class RPG2k
         if @target_window
           @target_window.dispose
           @target_window = nil
+        end
+      end
+
+      def update_teleport_target
+        targets = teleport_targets
+        if Input.trigger?(Input::B)
+          leave_teleport_target
+        elsif Input.trigger?(Input::DOWN) && !targets.empty?
+          @teleport_index += 1
+          @teleport_index %= targets.size
+          refresh_teleport_cursor
+        elsif Input.trigger?(Input::UP) && !targets.empty?
+          @teleport_index -= 1
+          @teleport_index %= targets.size
+          refresh_teleport_cursor
+        elsif Input.trigger?(Input::C) && !targets.empty?
+          map_id, = targets[@teleport_index]
+          apply_teleport_skill(@pending_skill, map_id)
+        end
+      end
+
+      # Escape (type 1) warps to the single registered escape target with no
+      # picker (see the class comment). A successful cast closes the whole menu
+      # stack at once, matching RPG_RT: there is no field-menu message shown
+      # afterwards, since the map that would show it is gone before the next
+      # frame draws.
+      def apply_escape_skill(sid)
+        target = @state.party.cast_escape_skill(caster, sid, @state)
+        if target
+          queue_teleport(target)
+        else
+          show_message("It had no effect.")
+        end
+      end
+
+      # Teleport (type 2), once a destination is chosen from the list built by
+      # #build_teleport_window.
+      def apply_teleport_skill(sid, map_id)
+        target = @state.party.cast_teleport_skill(caster, sid, @state, map_id)
+        if target
+          queue_teleport(target)
+        else
+          show_message("It had no effect.")
+        end
+      end
+
+      # Queue the warp for Scene::Map (see Game::State#pending_teleport) and pop
+      # every menu on top of it in one step.
+      def queue_teleport(target)
+        @state.pending_teleport = [target[:map_id], target[:x], target[:y], 0]
+        @parent.pop_to_map
+      end
+
+      def leave_teleport_target
+        @pending_skill = nil
+        @mode = :skills
+        if @teleport_window
+          @teleport_window.dispose
+          @teleport_window = nil
         end
       end
 
@@ -223,6 +303,54 @@ class RPG2k
         @target_window.cursor_rect =
           Rect.new(0, @target_index * LINE_H * 2, @target_window.contents.width,
                    LINE_H * 2)
+      end
+
+      # The registered teleport destinations as `[map_id, name]` pairs,
+      # ascending by map id — the same order `Game::State#teleport_targets`
+      # (a plain hash built by Set Teleport Target) already keeps them in, and
+      # the same order EasyRPG's `Window_Teleport` lists them in (the order
+      # `Game_Targets::GetTeleportTargets` returns, sorted by map id on insert).
+      def teleport_targets
+        @state.teleport_targets.keys.sort.map { |id| [id, map_display_name(id)] }
+      end
+
+      # A map's editor name for the teleport picker, or its bare id when the
+      # tree carries no name for it (a bare fixture, or an id the tree does not
+      # know) — matching EasyRPG's `Game_Map::GetMapName`, which reads the same
+      # map-tree field this build's #map_properties elsewhere already exposes.
+      def map_display_name(map_id)
+        row = map_tree.respond_to?(:map_properties) ? map_tree.map_properties[map_id] : nil
+        name = row && row.respond_to?(:name) ? row.name.to_s : nil
+        name.nil? || name.empty? ? "Map #{map_id}" : name
+      end
+
+      def build_teleport_window
+        @teleport_window.dispose if @teleport_window
+        rows = teleport_targets
+        inner_w = SCREEN_W - Window::BORDER * 2
+        h = [rows.size, 1].max * LINE_H
+        @teleport_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
+                                      SCREEN_W, h + Window::BORDER * 2)
+        @teleport_window.z = 450
+        @teleport_window.windowskin = @skin
+        c = Bitmap.new(inner_w, h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        if rows.empty?
+          c.draw_text 0, 0, inner_w, LINE_H, "No destinations"
+        else
+          rows.each_with_index do |(_id, name), i|
+            c.draw_text 0, i * LINE_H, inner_w, LINE_H, name
+          end
+        end
+        @teleport_window.contents = c
+        refresh_teleport_cursor
+      end
+
+      def refresh_teleport_cursor
+        return unless @teleport_window
+        h = teleport_targets.empty? ? 0 : LINE_H
+        @teleport_window.cursor_rect =
+          Rect.new(0, @teleport_index * LINE_H, @teleport_window.contents.width, h)
       end
 
       def drive_message

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3210,6 +3210,62 @@ check 'a switch skill is cast for its switch, and only where its flags allow' do
   ok st.party.cast_switch_skill(hero, 99).nil?
 end
 
+check 'an Escape skill is hidden with no runtime state, then gated on access ' \
+      'and a registered target, and warps there for free -- but not while flying' do
+  skills = { 6 => fake_skill(name: 'Escape', type: Game::Party::SKILL_ESCAPE,
+                             sp_cost: 4) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(6)
+  # No state at all -- the bare #field_skill?(sk) a fixture check would call --
+  # reads exactly like the old "not built" behaviour.
+  eq [], st.party.field_skills(hero), 'unsupported with no state to gate on'
+  ok st.party.unsupported_field_skill?(st.party.db_skill(6))
+  ok st.party.cast_escape_skill(hero, 6, nil).nil?
+  # State present, but access off (the RPG2000 default) and no target set.
+  eq [], st.party.field_skills(hero, st)
+  st.escape_access = true
+  eq [], st.party.field_skills(hero, st), 'access alone is not enough -- no target yet'
+  st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
+  eq [[6, 4]], st.party.field_skills(hero, st)
+  before = hero.mp
+  eq({ map_id: 3, x: 4, y: 5 }, st.party.cast_escape_skill(hero, 6, st))
+  eq before - 4, hero.mp, "the warp costs the skill's SP like any other cast"
+  # Flying (boarded the airship) bars it even with access and a target set --
+  # EasyRPG's Algo::IsSkillUsable Type_escape arm reads Game_Player::IsFlying.
+  st.boarded = :airship
+  eq [], st.party.field_skills(hero, st), 'the airship blocks it'
+  ok st.party.cast_escape_skill(hero, 6, st).nil?
+  st.boarded = nil
+  # A skill that is not Escape casts nothing through the Escape path.
+  ok st.party.cast_escape_skill(hero, 99, st).nil?
+end
+
+check 'a Teleport skill lists every registered destination and warps to the ' \
+      'one chosen' do
+  skills = { 7 => fake_skill(name: 'Warp', type: Game::Party::SKILL_TELEPORT,
+                             sp_cost: 3) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(7)
+  eq [], st.party.field_skills(hero, st), 'no targets registered yet'
+  st.teleport_access = true
+  st.teleport_targets[10] = { x: 1, y: 2, switch_id: nil }
+  st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
+  eq [[7, 3]], st.party.field_skills(hero, st), 'access plus any target offers it'
+  before = hero.mp
+  eq({ map_id: 5, x: 8, y: 9 }, st.party.cast_teleport_skill(hero, 7, st, 5))
+  eq before - 3, hero.mp
+  # An id that was never registered casts nothing and spends nothing.
+  before = hero.mp
+  ok st.party.cast_teleport_skill(hero, 7, st, 999).nil?
+  eq before, hero.mp, 'an unknown destination spends no SP'
+  # Riding the airship bars Teleport the same way it bars Escape.
+  st.boarded = :airship
+  eq [], st.party.field_skills(hero, st)
+  ok st.party.cast_teleport_skill(hero, 7, st, 5).nil?
+end
+
 check 'a special item invokes its skill, free of SP and without knowing it' do
   # Type 9 is 特殊: the item names a skill in skill_id and casting it is what
   # using the item does. Nepheshel's whole thrown-bomb line works this way.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1947,7 +1947,12 @@ FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
                            # constructions above keep working; a row that names
                            # neither never crits, which is what a bare fixture
                            # wants.
-                           :has_critical_rate, :critical_rate)
+                           :has_critical_rate, :critical_rate,
+                           # 二刀流 -- turns the shield slot into a second
+                           # weapon slot (Actor#double_hand?). Appended last for
+                           # the same reason: every existing positional
+                           # construction keeps working with it defaulting nil.
+                           :double_hand)
 # Like FakePlayerRow but exposing the full growth curve the way a real LCF row
 # does (six shorts per level via #int16_values(31)), so Actor scales its base
 # stats by level instead of using a single level-independent status hash.
@@ -8733,6 +8738,78 @@ check 'a bulk equip restores a saved pair as-is' do
   hero = st.party.actor_by_id(1)
   hero.equip([2, 3, 0, 0, 0])
   eq [2, 3], hero.equipment[0, 2], 'loaded exactly as saved'
+end
+
+# -- 二刀流 actors (double_hand) -----------------------------------------------
+# An actor (or RPG2003 class) trait that turns the *shield* slot into a
+# *second weapon* slot -- the flag ADR 0040 flagged as "left alone" (the
+# opposite rule to two_handed above: that empties a hand, this fills it with
+# a weapon). 4 of Nepheshel's actors carry it and 1 of mtf-meido-action's.
+
+def double_hand_party(double_hand = true)
+  items = { 1 => fake_item(type: 1, atk: 20, hit: 95),                # sword
+            2 => fake_item(type: 1, atk: 15, hit: 85, critical_hit: 20), # dagger
+            3 => fake_item(type: 2, dfn: 10),                         # shield
+            4 => fake_item(type: 1, atk: 10, two_handed: 1) }         # claymore
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 8 })
+  row.double_hand = double_hand
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  Game::State.new(Game::Party.new(db), 1, 0, 0)
+end
+
+check 'a 二刀流 actor is offered weapons, not the shield, for the shield slot' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  [1, 2, 3].each { |id| st.party.gain_item(id, 1) }
+  eq [[1, 1], [2, 1]], st.party.equip_candidates(Game::Actor::SHIELD_SLOT, hero),
+     'the two swords, not the shield'
+  eq [[1, 1], [2, 1]], st.party.equip_candidates(Game::Actor::WEAPON_SLOT, hero),
+     'the ordinary weapon slot lists exactly the same two weapons'
+end
+
+check 'an ordinary actor is still offered the shield for the shield slot' do
+  st = double_hand_party(false)
+  hero = st.party.actor_by_id(1)
+  [1, 2, 3].each { |id| st.party.gain_item(id, 1) }
+  eq [[3, 1]], st.party.equip_candidates(Game::Actor::SHIELD_SLOT, hero)
+end
+
+check 'equipping a second weapon from the bag lands it in the shield slot' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(hero, 1, Game::Actor::WEAPON_SLOT), 'the sword, first hand'
+  ok st.party.equip_from_bag(hero, 2, Game::Actor::SHIELD_SLOT), 'the dagger, second hand'
+  eq [1, 2], hero.equipment[0, 2], 'both weapons are on, one per slot'
+  # Both weapons now contribute -- the existing per-item-type scans in
+  # attack_hit_rate / weapon_crit_bonus / equipment_flag? are slot-agnostic,
+  # so the second weapon in the shield slot needed no changes of its own.
+  eq 95, hero.attack_hit_rate, 'the better of the two weapons\' hit rates'
+  eq 20, hero.weapon_crit_bonus, 'the dagger\'s crit bonus, the sword carrying none'
+  eq 10 + 20 + 15, hero.atk, 'both weapons\' attack bonuses are summed in, like any slot'
+end
+
+check 'a shield is rejected for a 二刀流 actor\'s shield slot even named directly' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(3, 1)
+  ok !st.party.equip_from_bag(hero, 3, Game::Actor::SHIELD_SLOT),
+     'not a real candidate for that slot on this actor'
+  eq 0, hero.equipment[1], 'nothing was equipped'
+  eq 1, st.party.item_count(3), 'and the shield stayed in the bag'
+end
+
+check 'a two-handed second weapon still empties the shield-turned-weapon hand\'s neighbour' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(4, 1)
+  ok st.party.equip_from_bag(hero, 1, Game::Actor::WEAPON_SLOT)
+  ok st.party.equip_from_bag(hero, 4, Game::Actor::SHIELD_SLOT), 'the claymore, into the second hand'
+  eq 4, hero.equipment[1]
+  eq 0, hero.equipment[0], 'the two-handed claymore still claims the other hand'
 end
 
 # -- chipset terrain tags -----------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4618,7 +4618,7 @@ class WrapMenuParty < MenuStubParty
   def field_skills(_actor, _state = nil); [[10, 2], [11, 4]]; end
   def db_item(id); OpenStruct.new(name: "Item#{id}"); end
   def db_skill(id); OpenStruct.new(name: "Skill#{id}"); end
-  def equip_candidates(_slot); [[7, 2], [8, 1]]; end
+  def equip_candidates(_slot, _actor = nil); [[7, 2], [8, 1]]; end
 end
 
 def wrap_menu_state

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -370,6 +370,10 @@ class FakeParent
   def load_map(id); @map_maker.call(id); end
   # Scene::Map#try_open_menu pushes a Scene::Menu; record it instead.
   def push(scene); @pushed << scene; end
+  # An Escape / Teleport field skill closes the whole menu stack at once;
+  # record that it fired rather than modelling a real scene stack here.
+  attr_reader :pop_to_map_called
+  def pop_to_map; @pop_to_map_called = true; end
   # Return to Title Screen (12510) hands control back here; record that it fired.
   attr_reader :returned_to_title
   def return_to_title; @returned_to_title = true; end
@@ -4590,7 +4594,7 @@ class MenuStubParty
     @actors = [MenuStubActor.new]; @gold = 0; @leader = nil; @revision = 0
   end
   def field_items; []; end
-  def field_skills(_actor); []; end
+  def field_skills(_actor, _state = nil); []; end
 end
 
 def menu_scene(klass, state)
@@ -4611,7 +4615,7 @@ class WrapMenuParty < MenuStubParty
     @actors = [MenuStubActor.new, MenuStubActor.new]
   end
   def field_items; [[1, 3], [2, 1]]; end
-  def field_skills(_actor); [[10, 2], [11, 4]]; end
+  def field_skills(_actor, _state = nil); [[10, 2], [11, 4]]; end
   def db_item(id); OpenStruct.new(name: "Item#{id}"); end
   def db_skill(id); OpenStruct.new(name: "Skill#{id}"); end
   def equip_candidates(_slot); [[7, 2], [8, 1]]; end
@@ -4718,6 +4722,127 @@ check 'Scene::SkillMenu: the skill list, caster and target cursors wrap around' 
   scene.update
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@target_index), 'Down from the last ally wraps to the first'
+end
+
+# A party whose only two skills are Escape (30) and Teleport (31), each
+# offered once #escape_access / #teleport_access and a target are set on the
+# real Game::State that holds it -- Game::Party's own decision logic
+# (#field_skill? / #cast_escape_skill / #cast_teleport_skill) is covered by
+# scripts/rpg2k_logic_check.rb; this stub only has to hand the scene something
+# that behaves the same way, so the checks below stay about the RGSS wiring
+# (does casting queue a teleport and close the menu?) rather than repeating
+# that coverage under RGSS stubs.
+class EscapeTeleportStubParty < MenuStubParty
+  ESCAPE_SID = 30
+  TELEPORT_SID = 31
+
+  def field_skills(_actor, state = nil)
+    return [] unless state
+    rows = []
+    rows << [ESCAPE_SID, 5] if state.escape_access && state.escape_target
+    if state.teleport_access && !state.teleport_targets.empty?
+      rows << [TELEPORT_SID, 3]
+    end
+    rows
+  end
+
+  def db_skill(id)
+    case id
+    when ESCAPE_SID then OpenStruct.new(name: 'Escape', type: Game::Party::SKILL_ESCAPE)
+    when TELEPORT_SID then OpenStruct.new(name: 'Warp', type: Game::Party::SKILL_TELEPORT)
+    end
+  end
+
+  def cast_escape_skill(_caster, sid, state)
+    return nil unless sid == ESCAPE_SID && state.escape_target
+    state.escape_target
+  end
+
+  def cast_teleport_skill(_caster, sid, state, map_id)
+    return nil unless sid == TELEPORT_SID
+    target = state.teleport_targets[map_id]
+    return nil unless target
+    { map_id: map_id, x: target[:x], y: target[:y] }
+  end
+end
+
+def escape_teleport_state
+  st = Game::State.new(EscapeTeleportStubParty.new, 1, 0, 0)
+  st.escape_access = true
+  st.escape_target = { map_id: 9, x: 1, y: 2, switch_id: nil }
+  st.teleport_access = true
+  st.teleport_targets[10] = { x: 11, y: 12, switch_id: nil }
+  st.teleport_targets[20] = { x: 21, y: 22, switch_id: nil }
+  st
+end
+
+check 'Scene::SkillMenu: an Escape skill queues its target and closes the menu' do
+  parent = fake_parent(fake_db)
+  state = escape_teleport_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  eq [[30, 5], [31, 3]], scene.send(:skills), 'Escape (registered target) then Teleport'
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm the first row, Escape
+  scene.update
+  RGSS::Input.reset
+  eq [9, 1, 2, 0], state.pending_teleport, 'queued straight from the one registered escape target'
+  ok parent.pop_to_map_called, 'the whole menu stack closes rather than staying open'
+end
+
+check 'Scene::SkillMenu: a Teleport skill opens a destination list and queues the chosen one' do
+  parent = fake_parent(fake_db)
+  state = escape_teleport_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto Teleport (row 2)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  eq :teleport_target, scene.instance_variable_get(:@mode)
+  eq [[10, 'Map 10'], [20, 'Map 20']], scene.send(:teleport_targets),
+     'both registered destinations, ascending by map id, named by their bare id ' \
+     '(this fixture parent carries no map tree)'
+  ok state.pending_teleport.nil?, 'opening the list does not warp yet'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the second destination (map 20)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm it
+  scene.update
+  RGSS::Input.reset
+  eq [20, 21, 22, 0], state.pending_teleport
+  ok parent.pop_to_map_called
+end
+
+check 'Scene::SkillMenu: cancelling the destination list returns to the skill list' do
+  parent = fake_parent(fake_db)
+  state = escape_teleport_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto Teleport (row 2)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  eq :teleport_target, scene.instance_variable_get(:@mode)
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  eq :skills, scene.instance_variable_get(:@mode)
+  ok state.pending_teleport.nil?
+  ok !parent.pop_to_map_called
+end
+
+check 'Scene::Map: a pending teleport queued by the field skill menu is applied' do
+  scene = new_scene({}, player: [0, 0])
+  state = scene.instance_variable_get(:@state)
+  state.pending_teleport = [1, 3, 4, 6] # same map id, elsewhere on it, facing left
+  scene.update
+  eq 1, state.map_id
+  eq 3, state.x
+  eq 4, state.y
+  eq 6, state.direction
+  ok state.pending_teleport.nil?, 'the request is consumed, not reapplied every frame'
 end
 
 check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around' do


### PR DESCRIPTION
Adds full support for Escape (type 1) and Teleport (type 2) field skills, enabling the party to warp to registered destinations from the field skill menu.

## Summary
Previously, Escape and Teleport skills were declared unsupported. This change implements both skill types with proper gating, menu UI, and scene integration, matching the reference implementation's behavior.

## Key Changes

- **Game::Party skill availability logic**: Added `escape_skill_available?` and `teleport_skill_available?` methods that gate skills on party access flags, registered targets, and airship status (flying blocks both). Updated `field_skill?` to accept optional `Game::State` parameter for runtime gating.

- **Skill casting methods**: Implemented `cast_escape_skill` and `cast_teleport_skill` that validate availability, spend SP, and return destination coordinates for the scene to queue.

- **Scene::SkillMenu enhancements**: 
  - Added teleport destination picker UI (`@teleport_window`, `@teleport_index`, `:teleport_target` mode)
  - Escape skills warp immediately to their single registered target
  - Teleport skills open a destination list (sorted by map ID, named via map tree)
  - Both skill types queue the warp on `Game::State#pending_teleport` and close the entire menu stack via `pop_to_map`

- **Scene::Map integration**: Added handling for `pending_teleport` at the start of `update`, forcing the party off boats/ships before warping (airship blocks both skill types outright), then performing the teleport and rendering immediately without further simulation that frame.

- **Scene stack management**: Added `pop_to_map` method to `Scene::Manager` to close all menus in one step when a warp is queued, matching RPG_RT's behavior.

- **State persistence**: Added `pending_teleport` attribute to `Game::State` for transient warp queueing (never saved, since menus cannot be open during save).

- **Test coverage**: Added comprehensive checks for Escape/Teleport skill availability, casting, destination selection, and Scene::Map integration.

## Implementation Details

- Escape warps to a single pre-registered target with no picker, spending SP like any field skill
- Teleport displays all registered destinations from `Game::State#teleport_targets`, sorted by map ID and named via `map_tree.map_properties` (matching EasyRPG's `Game_Map::GetMapName`)
- Both skills' `switch_id` fields are persisted but not consumed (matching reference implementation)
- Warp queuing happens through `Game::State#pending_teleport` rather than direct jumping, allowing Scene::Map to handle map loading and rendering
- Airship blocks both skill types; boats/ships are automatically disembarked before warping

https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G