### PR TITLE
Apply the map tree's per-map Save setting to menu Save access

### DIFF
--- a/changelog.d/rpg2k-map-tree-save-access.added.md
+++ b/changelog.d/rpg2k-map-tree-save-access.added.md
@@ -1,0 +1,15 @@
+- **The map tree's per-map Save setting (map_properties field 33) is now
+  applied.** RPG_RT lets a map's editor properties pin the menu's Save command
+  to Allow or Forbid, or inherit whatever the parent map resolves to; that
+  tri-state was parsed off `RPG_RT.lmt` but never fed into the runtime, so a
+  map that forbade saving in the editor never actually blocked it in play.
+  `Game::MapAccess.save_allowed?` walks "same as parent" nodes up the tree the
+  same way `Game::Backdrop.name_for` already does for `backdrop_type`,
+  defaulting to Allow at the root or on a loop. `Scene::Map` recomputes
+  `Game::State#save_access` from it on the initial map load and on every
+  Teleport, matching RPG_RT: a `Control Save Access` event command can still
+  override it for the rest of that map's visit, but the next map load
+  re-derives it from the tree again. Covered by nine new checks in
+  `scripts/rpg2k_logic_check.rb` (Allow/Forbid, single- and multi-level
+  inheritance, root/unknown-map/loop/self-parent defaults, and a node missing
+  the field).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4520,6 +4520,39 @@ module Game
     end
   end
 
+  # Whether the menu's Save command is usable on a given map.
+  #
+  # Each map-tree node (RPG_RT.lmt `map_properties` field 33, `:save`) is a
+  # tri-state, same shape as Backdrop's `backdrop_type`: 0 inherits whatever
+  # the parent map resolves to, 1 explicitly allows Save, 2 forbids it. RPG_RT
+  # re-derives this from scratch on every map load -- the initial map and every
+  # Teleport -- walking "same as parent" nodes up until one pins Allow/Forbid;
+  # a walk that runs off the root (or loops) defaults to Allow, the schema's
+  # own default for an unset field. This sits *underneath* the `Control Save
+  # Access` event command: that command's runtime toggle (`Game::State#save_access`)
+  # still wins for the rest of the current map's visit, but the next map load
+  # recomputes from the tree again, exactly as RPG_RT does.
+  module MapAccess
+    TRISTATE_PARENT = 0
+    TRISTATE_ALLOW  = 1
+    TRISTATE_FORBID = 2
+
+    def self.save_allowed?(map_id, properties)
+      seen = {}
+      id = map_id.to_i
+      while id > 0 && !seen[id]
+        seen[id] = true
+        row = properties ? properties[id] : nil
+        return true unless row
+        v = row.respond_to?(:save) ? row.save : nil
+        v = TRISTATE_ALLOW if v.nil? # schema default for an unset field
+        return v != TRISTATE_FORBID unless v == TRISTATE_PARENT
+        id = row.respond_to?(:parent_map_id) ? row.parent_map_id.to_i : 0
+      end
+      true
+    end
+  end
+
   # One entry of an enemy's 行動パターン (action pattern) table — the database
   # enemy row's chunk 42, decoded off the LCF row into plain data so the battle
   # simulation can pick an action without holding a database row.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -71,6 +71,7 @@ class RPG2k
       def initialize parent, state
         super parent
         @state = state
+        apply_map_save_access
         @map = state.map
         @chipset = build_chipset
         @chipset_bmp = load_chipset_graphic
@@ -2572,6 +2573,15 @@ class RPG2k
         nil
       end
 
+      # Re-derive the menu's Save access from the current map's tree setting
+      # (see Game::MapAccess). Runs on the initial map load and every Teleport,
+      # same as RPG_RT: a Control Save Access event command can still override
+      # it for the rest of that map's visit, but the next map load recomputes
+      # from the tree again.
+      def apply_map_save_access
+        @state.save_access = Game::MapAccess.save_allowed?(@state.map_id, map_properties)
+      end
+
       # The backdrop named by the terrain of the tile at (x, y) — the database
       # terrain row's `background_name` (field 4). '' when the tile, the terrain
       # table or the field is missing.
@@ -4227,6 +4237,7 @@ class RPG2k
         @map = @parent.load_map(map_id)
         @state.map = @map
         @state.map_id = map_id
+        apply_map_save_access
         @state.x = x
         @state.y = y
         @state.direction = dir if dir && dir > 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8272,6 +8272,63 @@ check 'a node missing its fields is treated as inheriting' do
   eq 'Wasteland', Game::Backdrop.name_for(1, { 1 => bare }, 'Wasteland')
 end
 
+# -- menu Save access resolution (map tree save field, 33) --------------------
+
+# One map-tree node's Save setting.
+class FakeSaveNode
+  attr_accessor :save, :parent_map_id
+  def initialize(save, parent = 0)
+    @save = save; @parent_map_id = parent
+  end
+end
+
+check 'save type 1 (Allow) lets the menu Save command through' do
+  props = { 1 => FakeSaveNode.new(1) }
+  eq true, Game::MapAccess.save_allowed?(1, props)
+end
+
+check 'save type 2 (Forbid) blocks the menu Save command' do
+  props = { 1 => FakeSaveNode.new(2) }
+  eq false, Game::MapAccess.save_allowed?(1, props)
+end
+
+check 'save type 0 inherits from the parent map' do
+  props = { 1 => FakeSaveNode.new(2), 2 => FakeSaveNode.new(0, 1) }
+  eq false, Game::MapAccess.save_allowed?(2, props), 'the parent pins Forbid'
+end
+
+check 'save inheritance walks more than one level' do
+  props = { 1 => FakeSaveNode.new(2),
+            2 => FakeSaveNode.new(0, 1),
+            3 => FakeSaveNode.new(0, 2) }
+  eq false, Game::MapAccess.save_allowed?(3, props)
+end
+
+check 'a map inheriting from the root defaults to Allow' do
+  props = { 1 => FakeSaveNode.new(0, 0) }   # parent 0 = the tree root
+  eq true, Game::MapAccess.save_allowed?(1, props)
+end
+
+check 'an unknown map id defaults to Allow' do
+  eq true, Game::MapAccess.save_allowed?(7, { 1 => FakeSaveNode.new(2) })
+  eq true, Game::MapAccess.save_allowed?(1, nil), 'and so does having no tree'
+end
+
+check 'a looping map tree ends at Allow instead of hanging' do
+  props = { 1 => FakeSaveNode.new(0, 2),
+            2 => FakeSaveNode.new(0, 1) }   # 1 -> 2 -> 1 -> ...
+  eq true, Game::MapAccess.save_allowed?(1, props)
+end
+
+check 'a map that parents itself defaults to Allow' do
+  eq true, Game::MapAccess.save_allowed?(1, { 1 => FakeSaveNode.new(0, 1) })
+end
+
+check 'a node missing its save field defaults to Allow' do
+  bare = Struct.new(:nothing).new(0)
+  eq true, Game::MapAccess.save_allowed?(1, { 1 => bare })
+end
+
 # -- battle log terms (Game::States::BattleText) ------------------------------
 
 BT = Game::States::BattleText


### PR DESCRIPTION
## Summary
- `RPG_RT.lmt`'s map tree stores a per-map Save setting (`map_properties` field 33, `:save`) that lets the editor pin a map's Save command to Allow/Forbid or inherit the parent map's setting. The schema parsed this field, but the runtime never applied it — `Scene::Menu`'s Save command only ever consulted the event-command-driven `save_access` flag, so a map that forbade saving in the editor never actually blocked it in play.
- Added `Game::MapAccess.save_allowed?`, which walks "same as parent" nodes up the map tree the same way `Game::Backdrop.name_for` already does for `backdrop_type`, defaulting to Allow at the root or on a loop.
- `Scene::Map` now recomputes `Game::State#save_access` from it on the initial map load and on every Teleport, matching RPG_RT: a `Control Save Access` event command can still override it for the rest of that map's visit, but the next map load re-derives it from the tree again.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 600 checks pass, including 9 new checks covering `Game::MapAccess.save_allowed?` (Allow/Forbid, single- and multi-level inheritance, root/unknown-map/loop/self-parent defaults, and a node missing the field).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 263 checks pass, no regressions (including the existing "Open Save Menu honours a Change Save Access lock" check).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tm9aZkoS3a3MhvPA9HBonB)_