### PR TITLE
Apply the map tree's per-map Teleport/Escape settings to field skill access

### DIFF
--- a/changelog.d/rpg2k-map-tree-teleport-escape-access.added.md
+++ b/changelog.d/rpg2k-map-tree-teleport-escape-access.added.md
@@ -1,0 +1,24 @@
+- **The map tree's per-map Teleport and Escape settings (map_properties
+  fields 31 and 32) are now applied**, the same way field 33 (Save) already
+  was. RPG_RT.lmt lets each map pin the Escape / Teleport field skill types to
+  Allow or Forbid, or inherit whatever the parent map resolves to, and the
+  fields were parsed off `RPG_RT.lmt` but never fed into the runtime — so a
+  dungeon the editor marked "no Teleport" never actually blocked it, and
+  (since RPG2000's own schema default for the field is Allow) most maps'
+  Escape / Teleport skills stayed permanently unusable outside a `Change
+  Teleport/Escape Access` event command, when RPG_RT allows them by default
+  almost everywhere. `Game::MapAccess.teleport_allowed?` / `#escape_allowed?`
+  share the exact tree walk `#save_allowed?` already used (confirmed against
+  EasyRPG's `Game_Map::Setup`, which re-derives all three
+  `Game_System::Allow*` flags from their map-tree fields identically on every
+  map load). `Scene::Map#apply_map_access` (renamed from
+  `#apply_map_save_access`, now setting all three) recomputes
+  `Game::State#teleport_access` / `#escape_access` alongside `#save_access` on
+  the initial map load and on every Teleport: a `Control Teleport/Escape
+  Access` event command can still override either for the rest of that map's
+  visit, but the next map load re-derives it from the tree again, exactly as
+  RPG_RT does. Covered by new checks in `scripts/rpg2k_logic_check.rb` (each
+  method reads its own field rather than borrowing Save's, inheritance, and
+  the Allow defaults) and `scripts/rpg2k_scene_check.rb` (`Scene::Map` reaches
+  a real map tree on both the initial load and a Teleport to a second map with
+  the opposite settings).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4641,31 +4641,50 @@ module Game
     end
   end
 
-  # Whether the menu's Save command is usable on a given map.
+  # Whether the menu's Save command, and the Escape / Teleport field skill
+  # types, are usable on a given map.
   #
-  # Each map-tree node (RPG_RT.lmt `map_properties` field 33, `:save`) is a
-  # tri-state, same shape as Backdrop's `backdrop_type`: 0 inherits whatever
-  # the parent map resolves to, 1 explicitly allows Save, 2 forbids it. RPG_RT
-  # re-derives this from scratch on every map load -- the initial map and every
-  # Teleport -- walking "same as parent" nodes up until one pins Allow/Forbid;
-  # a walk that runs off the root (or loops) defaults to Allow, the schema's
-  # own default for an unset field. This sits *underneath* the `Control Save
-  # Access` event command: that command's runtime toggle (`Game::State#save_access`)
-  # still wins for the rest of the current map's visit, but the next map load
-  # recomputes from the tree again, exactly as RPG_RT does.
+  # Each map-tree node (RPG_RT.lmt `map_properties` field 33 `:save`, 31
+  # `:teleport`, 32 `:escape`) is a tri-state, same shape as Backdrop's
+  # `backdrop_type`: 0 inherits whatever the parent map resolves to, 1
+  # explicitly allows it, 2 forbids it. RPG_RT re-derives all three from
+  # scratch on every map load -- the initial map and every Teleport --
+  # walking "same as parent" nodes up until one pins Allow/Forbid; a walk that
+  # runs off the root (or loops) defaults to Allow, the schema's own default
+  # for an unset field (EasyRPG's `Game_Map::Setup` does the identical walk
+  # for all three fields, feeding `Game_System::SetAllowSave` /
+  # `SetAllowTeleport` / `SetAllowEscape`). This sits *underneath* the
+  # `Control Save/Teleport/Escape Access` event commands: those commands'
+  # runtime toggles (`Game::State#save_access` / `#teleport_access` /
+  # `#escape_access`) still win for the rest of the current map's visit, but
+  # the next map load recomputes from the tree again, exactly as RPG_RT does.
   module MapAccess
     TRISTATE_PARENT = 0
     TRISTATE_ALLOW  = 1
     TRISTATE_FORBID = 2
 
     def self.save_allowed?(map_id, properties)
+      allowed?(map_id, properties, :save)
+    end
+
+    def self.teleport_allowed?(map_id, properties)
+      allowed?(map_id, properties, :teleport)
+    end
+
+    def self.escape_allowed?(map_id, properties)
+      allowed?(map_id, properties, :escape)
+    end
+
+    # The tree walk shared by all three: read tri-state `field` off `map_id`'s
+    # node, following "same as parent" up until a node pins Allow/Forbid.
+    def self.allowed?(map_id, properties, field)
       seen = {}
       id = map_id.to_i
       while id > 0 && !seen[id]
         seen[id] = true
         row = properties ? properties[id] : nil
         return true unless row
-        v = row.respond_to?(:save) ? row.save : nil
+        v = row.respond_to?(field) ? row.send(field) : nil
         v = TRISTATE_ALLOW if v.nil? # schema default for an unset field
         return v != TRISTATE_FORBID unless v == TRISTATE_PARENT
         id = row.respond_to?(:parent_map_id) ? row.parent_map_id.to_i : 0
@@ -6684,11 +6703,15 @@ module Game
     # Main Menu Access (11960) and Change Save Access (11930) event commands;
     # both default on and are persisted in the save.
     attr_accessor :menu_access, :save_access
-    # Whether the Teleport and Escape skills are usable, toggled by the Change
-    # Teleport Access (11820) and Change Escape Access (11840) event commands.
-    # Default off — RPG2000 games enable these once the skill's targets are set —
-    # and persisted in the save. Read by Game::Party#escape_skill_available? /
-    # #teleport_skill_available? to gate the field skill menu.
+    # Whether the Teleport and Escape skills are usable. Toggled directly by
+    # the Change Teleport Access (11820) and Change Escape Access (11840)
+    # event commands, but also recomputed from the current map's own tree
+    # setting on every map load and Teleport (`Scene::Map#apply_map_access`,
+    # `Game::MapAccess.teleport_allowed?` / `#escape_allowed?`) -- so a value
+    # set here is only the *initial* one (before any map has loaded), matching
+    # `#save_access`. Persisted in the save. Read by
+    # Game::Party#escape_skill_available? / #teleport_skill_available? to gate
+    # the field skill menu.
     attr_accessor :teleport_access, :escape_access
     # A `{map_id:, x:, y:}` destination queued by an Escape / Teleport field
     # skill (see Game::Party#cast_escape_skill / #cast_teleport_skill), picked up

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -71,7 +71,7 @@ class RPG2k
       def initialize parent, state
         super parent
         @state = state
-        apply_map_save_access
+        apply_map_access
         @map = state.map
         @chipset = build_chipset
         @chipset_bmp = load_chipset_graphic
@@ -2597,13 +2597,17 @@ class RPG2k
         nil
       end
 
-      # Re-derive the menu's Save access from the current map's tree setting
-      # (see Game::MapAccess). Runs on the initial map load and every Teleport,
-      # same as RPG_RT: a Control Save Access event command can still override
-      # it for the rest of that map's visit, but the next map load recomputes
-      # from the tree again.
-      def apply_map_save_access
-        @state.save_access = Game::MapAccess.save_allowed?(@state.map_id, map_properties)
+      # Re-derive the menu's Save access, and the Escape / Teleport field
+      # skill types' access, from the current map's tree settings (see
+      # Game::MapAccess). Runs on the initial map load and every Teleport,
+      # same as RPG_RT: a Control Save/Teleport/Escape Access event command
+      # can still override any of them for the rest of that map's visit, but
+      # the next map load recomputes all three from the tree again.
+      def apply_map_access
+        props = map_properties
+        @state.save_access = Game::MapAccess.save_allowed?(@state.map_id, props)
+        @state.teleport_access = Game::MapAccess.teleport_allowed?(@state.map_id, props)
+        @state.escape_access = Game::MapAccess.escape_allowed?(@state.map_id, props)
       end
 
       # The backdrop named by the terrain of the tile at (x, y) — the database
@@ -4261,7 +4265,7 @@ class RPG2k
         @map = @parent.load_map(map_id)
         @state.map = @map
         @state.map_id = map_id
-        apply_map_save_access
+        apply_map_access
         @state.x = x
         @state.y = y
         @state.direction = dir if dir && dir > 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8390,6 +8390,45 @@ check 'a node missing its save field defaults to Allow' do
   eq true, Game::MapAccess.save_allowed?(1, { 1 => bare })
 end
 
+# -- field Teleport/Escape access resolution (map tree fields 31, 32) --------
+#
+# The identical tri-state walk as Save above (field 33), just read off a
+# different pair of fields -- confirmed against EasyRPG's Game_Map::Setup,
+# which re-derives Game_System::AllowTeleport/AllowEscape from these two
+# fields on every map load exactly as it does AllowSave. Since #allowed? is
+# shared with #save_allowed? and its walk (inherit, loop, unknown map, root,
+# a field-less node) is already exhaustively covered above, these checks only
+# have to show each method reads its own field rather than borrowing #save's.
+
+class FakeAccessNode
+  attr_accessor :save, :teleport, :escape, :parent_map_id
+  def initialize(save, teleport, escape, parent = 0)
+    @save = save; @teleport = teleport; @escape = escape; @parent_map_id = parent
+  end
+end
+
+check 'teleport_allowed? and escape_allowed? each read their own field' do
+  props = { 1 => FakeAccessNode.new(1, 2, 1) }   # save Allow, teleport Forbid, escape Allow
+  eq true,  Game::MapAccess.save_allowed?(1, props)
+  eq false, Game::MapAccess.teleport_allowed?(1, props), 'teleport is the one forbidden here'
+  eq true,  Game::MapAccess.escape_allowed?(1, props)
+end
+
+check 'teleport/escape access inherits from the parent map' do
+  props = { 1 => FakeAccessNode.new(1, 2, 2),
+            2 => FakeAccessNode.new(1, 0, 0, 1) }
+  eq false, Game::MapAccess.teleport_allowed?(2, props), 'the parent pins Forbid'
+  eq false, Game::MapAccess.escape_allowed?(2, props)
+end
+
+check 'an unknown map, missing field or missing tree defaults teleport/escape to Allow' do
+  eq true, Game::MapAccess.teleport_allowed?(7, { 1 => FakeAccessNode.new(1, 2, 2) })
+  eq true, Game::MapAccess.escape_allowed?(1, nil)
+  bare = Struct.new(:nothing).new(0)
+  eq true, Game::MapAccess.teleport_allowed?(1, { 1 => bare })
+  eq true, Game::MapAccess.escape_allowed?(1, { 1 => bare })
+end
+
 # -- battle log terms (Game::States::BattleText) ------------------------------
 
 BT = Game::States::BattleText

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -363,7 +363,12 @@ end
 # what perform_teleport (and Recall to Location) calls to swap maps; it hands
 # back a fresh empty map for the requested id.
 class FakeParent
-  attr_reader :db, :map_tree, :pushed
+  attr_reader :db, :pushed
+  # Writable (unlike `db`): a test that needs Scene::Map#apply_map_access to
+  # see a real map tree sets this directly, since the default (nil) is what
+  # every other check wants -- no tree, so save/teleport/escape all default
+  # to Allow.
+  attr_accessor :map_tree
   def initialize(db, &map_maker)
     @db = db
     @map_tree = nil
@@ -4945,6 +4950,34 @@ check 'Scene::Map: a pending teleport queued by the field skill menu is applied'
   eq 4, state.y
   eq 6, state.direction
   ok state.pending_teleport.nil?, 'the request is consumed, not reapplied every frame'
+end
+
+# One map-tree node's save/teleport/escape tri-states (parent_map_id left nil
+# -- MapAccess#allowed? reads a missing one as 0, the tree root). Mirrors
+# scripts/rpg2k_logic_check.rb's own fixture of the same name; reused here to
+# prove Scene::Map actually reaches Game::MapAccess, not just that the module
+# answers correctly in isolation.
+FakeAccessNode = Struct.new(:save, :teleport, :escape, :parent_map_id)
+
+def fake_map_tree(props)
+  Struct.new(:map_properties).new(props)
+end
+
+check 'Scene::Map re-derives Teleport/Escape access from the map tree on load and on Teleport' do
+  parent = fake_parent(fake_db)
+  parent.map_tree = fake_map_tree(
+    1 => FakeAccessNode.new(1, 2, 1), # map 1: teleport forbidden, escape allowed
+    2 => FakeAccessNode.new(1, 1, 2)  # map 2: teleport allowed, escape forbidden
+  )
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  scene = RPG2k::Scene::Map.new(parent, state)
+  eq false, state.teleport_access, 'map 1 forbids Teleport'
+  eq true, state.escape_access, 'map 1 allows Escape'
+
+  scene.send(:perform_teleport, [2, 0, 0, 0])
+  eq true, state.teleport_access, 'map 2 allows Teleport'
+  eq false, state.escape_access, 'map 2 forbids Escape'
 end
 
 check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around' do


### PR DESCRIPTION
## Summary

Extends the map tree's per-map **Save** access resolution (`map_properties` field 33, merged in #475/#473) to the identical fields for **Teleport** (31) and **Escape** (32). RPG_RT.lmt lets each map pin the Escape/Teleport field skill types to Allow/Forbid or inherit the parent map's setting; those fields were parsed but never fed into the runtime.

Confirmed against EasyRPG's `Game_Map::Setup`, which re-derives `Game_System::AllowSave` / `AllowTeleport` / `AllowEscape` from their respective map-tree fields identically on every map load.

## Key changes

- `Game::MapAccess.save_allowed?` is refactored into a shared `#allowed?` tree walk, reused by two new methods: `#teleport_allowed?` / `#escape_allowed?`.
- `Scene::Map#apply_map_access` (renamed from `#apply_map_save_access`) now recomputes `Game::State#save_access`, `#teleport_access` and `#escape_access` together, on the initial map load and on every Teleport.
- A `Control Teleport/Escape Access` event command still overrides either flag for the rest of the current map's visit — the next map load re-derives it from the tree again, exactly as it already did for Save.

## Behavior note

Since RPG2000's schema default for these fields is **Allow**, this changes the practical default for the Escape/Teleport field skills added in #474: they are now usable on most maps out of the box, rather than only after an explicit `Change Teleport/Escape Access` event command — matching real RPG_RT behavior rather than the more conservative "off until an event turns it on" reading those skills originally shipped with.

## Testing

- `scripts/rpg2k_logic_check.rb`: 610 checks passing (3 new — each access method reads its own field rather than borrowing Save's, inheritance, and the Allow defaults).
- `scripts/rpg2k_scene_check.rb`: 268 checks passing (1 new — `Scene::Map` reaches a real map tree on both the initial load and a Teleport to a second map with the opposite settings).
- Documented in `changelog.d/rpg2k-map-tree-teleport-escape-access.added.md`.

https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G)_