### PR TITLE
Parallelize RPG XP boot smoke test passes in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,10 +222,12 @@ jobs:
       # tests in CMakeLists.txt, all run by the `test` step below); MV runs=100..108,
       # the RPG2k
       # real-game boot smoke=109..110, the MZ boot smoke=111, the RPG XP
-      # real-game boot smoke=112..119 (one per game, plus a pass per extra
-      # probe on the editor bed -- a block, so adding a probe does not renumber
-      # anything else) and the RGSSAD packed-asset smoke=120..121
-      # (two runs, one per arm of its A/B) below. Every
+      # real-game boot smoke=112..119 (one per pass -- script host/battle/save
+      # on the editor bed plus script host on Pray for You, each its own step
+      # and its own display so they run concurrently rather than the four of
+      # them serially in one step; 116..119 stays free for another pass to be
+      # added without renumbering anything else) and the RGSSAD packed-asset
+      # smoke=120..121 (two runs, one per arm of its A/B) below. Every
       # smoke here must use a distinct --server-num (never `-a`), or its
       # non-atomic probe can steal exe_open's display and fail that required
       # check.
@@ -321,14 +323,45 @@ jobs:
           # editor bed's map (`[RPGXP-HOST-MOVE]`), opens that bed's own menu
           # (`[RPGXP-HOST-MENU]`) and, in a pass each, fights in its own
           # battle scene (`[RPGXP-HOST-BATTLE]`) and opens its own save screen
-          # (`[RPGXP-HOST-SAVE]`). Two beds: the editor-shaped
-          # OpenGame test bed and the *released* Pray for You (Game.rgssad only,
-          # several maps), on displays 112 and 113 — one per game (see the
-          # reserved server-num map above). See
+          # (`[RPGXP-HOST-SAVE]`). Two beds: the editor-shaped OpenGame test bed
+          # (script host, battle and save passes) and the *released* Pray for
+          # You (Game.rgssad only, several maps; script host pass only — see
+          # rpgxp_boot_check.bash). Each pass is a full headless engine boot on
+          # CI's unaccelerated renderer, and running the four of them serially
+          # in one step used to be this smoke's whole cost. RPGXP_BOOT_PASS
+          # (see that script's usage comment) lets each run as its own step
+          # here instead, on its own reserved display (112..115 — see the
+          # reserved server-num map above), so they overlap with each other
+          # and with every other step in this group rather than adding up. See
           # docs/adr/0025-rpgxp-cross-runtime-testing.md and
           # docs/adr/0030-rgss-only-the-games-own-engine.md.
-          - name: RPG XP real-game boot smoke test
-            run: ./scripts/nix-develop.bash ./scripts/rpgxp_boot_check.bash 112
+          - name: RPG XP real-game boot smoke test (script host, editor bed)
+            env:
+              RPGXP_BOOT_PASS: script_host
+            run: |
+              ./scripts/nix-develop.bash ./scripts/rpgxp_boot_check.bash 112 \
+                data/OpenGame.exe/Testbed/XP
+
+          - name: RPG XP real-game boot smoke test (battle, editor bed)
+            env:
+              RPGXP_BOOT_PASS: battle
+            run: |
+              ./scripts/nix-develop.bash ./scripts/rpgxp_boot_check.bash 113 \
+                data/OpenGame.exe/Testbed/XP
+
+          - name: RPG XP real-game boot smoke test (save, editor bed)
+            env:
+              RPGXP_BOOT_PASS: save
+            run: |
+              ./scripts/nix-develop.bash ./scripts/rpgxp_boot_check.bash 114 \
+                data/OpenGame.exe/Testbed/XP
+
+          - name: RPG XP real-game boot smoke test (script host, Pray for You)
+            env:
+              RPGXP_BOOT_PASS: script_host
+            run: |
+              ./scripts/nix-develop.bash ./scripts/rpgxp_boot_check.bash 115 \
+                data/PrayforYou
 
           # A released game keeps its Graphics/ inside the encrypted archive with
           # nothing loose, so the native asset loaders have to read through it.

--- a/changelog.d/ci-rpgxp-boot-check-parallel-passes.changed.md
+++ b/changelog.d/ci-rpgxp-boot-check-parallel-passes.changed.md
@@ -1,0 +1,6 @@
+- CI's RPG XP real-game boot smoke now runs its four engine-boot passes
+  (script host and battle and save on the editor test bed, script host on
+  Pray for You) as four separate, concurrent steps instead of one step that
+  ran them serially. `scripts/rpgxp_boot_check.bash` gained `RPGXP_BOOT_PASS`
+  to select a single pass per invocation; unset, it still runs every pass that
+  applies to each requested game, as before.

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -246,9 +246,20 @@ for game in "${GAMES[@]}" ; do
 
             # And the save screen, its own pass for the same reason. This is
             # the only place a game reads a file's timestamp back, and the
-            # only one that writes a file of its own.
+            # only one that writes a file of its own -- which the script_host
+            # and battle passes above cannot share the bed's directory with:
+            # a title screen offers Continue when it finds a save, changing
+            # what their confirm taps pick, and when RPGXP_BOOT_PASS splits
+            # these into concurrent CI steps a save written mid-run is exactly
+            # the kind of state a concurrent pass's own pre-run sweep (in
+            # run_boot, below) would delete out from under this one. Run it
+            # against a private copy of the bed instead, so its write can
+            # never race a sibling pass reading or cleaning the shared one.
             save)
-                if run_boot "${game}" "${num}" "script host: save" \
+                save_dir="${game}-save-copy"
+                rm -rf "${save_dir}"
+                cp -a "${game}" "${save_dir}"
+                if run_boot "${save_dir}" "${num}" "script host: save" \
                         "--rgss_host_save_test" 2 \
                         '\[RPGXP-HOST-SAVE\] .*reached=true' ; then
                     # ...and it has to land in the *game's* directory. The
@@ -258,17 +269,22 @@ for game in "${GAMES[@]}" ; do
                     # it, the file landed wherever the engine was launched
                     # from and the next game found it (Pray for You offered
                     # Continue on the strength of the editor bed's save and
-                    # died reading it as its own).
-                    if [ ! -f "${game}/Save1.rxdata" ] ; then
+                    # died reading it as its own). The private copy is still
+                    # the game's own directory as far as the engine is
+                    # concerned (it is exactly what --game_dir points at), so
+                    # the proof holds without touching the shared original.
+                    if [ ! -f "${save_dir}/Save1.rxdata" ] ; then
                         echo "FAILED: ${game} (script host: save): the" \
                              "game's own save did not land in its own" \
                              "directory" >&2
-                        ls -1 Save[0-9]*.rxdata 2>/dev/null >&2 || true
+                        ls -1 "${save_dir}"/Save[0-9]*.rxdata 2>/dev/null >&2 ||
+                            true
                         failed=$((failed + 1))
                     fi
                 else
                     failed=$((failed + 1))
                 fi
+                rm -rf "${save_dir}"
                 ;;
         esac
         num=$((num + 1))

--- a/scripts/rpgxp_boot_check.bash
+++ b/scripts/rpgxp_boot_check.bash
@@ -51,13 +51,24 @@
 # silently passed over -- but if *none* of them is present the check fails,
 # because then it proved nothing.
 #
-# Usage: ./scripts/rpgxp_boot_check.bash [server_num] [game_dir...]
+# Usage: RPGXP_BOOT_PASS=<pass> ./scripts/rpgxp_boot_check.bash [server_num] [game_dir...]
 #   server_num  xvfb-run --server-num to use (default 112; see the reserved
 #               display numbers in .github/workflows/build.yml). Each run takes
 #               the next one, and build.yml reserves 112..119 for this check so
 #               another probe can be added without renumbering anything else.
 #   game_dir    defaults to the repo's two RPG Maker XP beds -- the editor-shaped
 #               OpenGame test bed and the released Pray for You
+#   RPGXP_BOOT_PASS
+#               one of `script_host`, `battle`, `save`, or unset (default) to run
+#               every pass that applies to each requested game, as this script
+#               always did before this variable existed. The four passes across
+#               the two default beds are independent full engine boots that
+#               share nothing but the save-file sweep at the very end, so
+#               build.yml runs one per CI step (each on its own display number)
+#               instead of the four of them serially in one step -- see the
+#               `RPG XP real-game boot smoke` steps there. A pass that does not
+#               apply to a requested game (e.g. `battle` against a released
+#               game, which only ever gets a `script_host` pass) is skipped.
 
 set -eu -o pipefail
 
@@ -82,6 +93,17 @@ TIMEOUT_MS="${RPGXP_TIMEOUT_MS:-45000}"
 # make_action_orders with no way to ask for that run back. Override to hunt a
 # failure that only some seeds reach.
 RANDOM_SEED="${RPGXP_RANDOM_SEED:-20260806}"
+
+# Restrict this run to one pass (see the usage comment above). Empty means run
+# every pass that applies to each requested game, same as always.
+RPGXP_BOOT_PASS="${RPGXP_BOOT_PASS:-}"
+case "${RPGXP_BOOT_PASS}" in
+    ''|script_host|battle|save) ;;
+    *) echo "error: RPGXP_BOOT_PASS must be one of: script_host, battle, save" \
+            "(got '${RPGXP_BOOT_PASS}')" >&2
+       exit 1 ;;
+esac
+want_pass() { [ -z "${RPGXP_BOOT_PASS}" ] || [ "${RPGXP_BOOT_PASS}" = "$1" ] ; }
 
 GAMES=("$@")
 if [ "${#GAMES[@]}" -eq 0 ] ; then
@@ -170,62 +192,87 @@ for game in "${GAMES[@]}" ; do
         echo "skip ${game}: no Game.ini (run scripts/download-opengame-xp.bash first)"
         continue
     fi
-    checked=$((checked + 1))
-    echo "== ${game}"
 
     # The editor test bed opens on a plain walkable map with the stock scripts,
     # so its walk and its menu are both assertions; a released game opens on a
     # cutscene, where a walk that does not happen and a menu that does not open
-    # say nothing about the engine. Both log everything either way.
+    # say nothing about the engine. Both log everything either way. Only the
+    # editor bed gets a battle and a save pass -- see those cases below.
     case "${game}" in
         *Testbed*) markers=('\[RPGXP-HOST-MOVE\] .*moved=true'
-                            '\[RPGXP-HOST-MENU\] .*opened=true') ;;
-        *)         markers=('\[RPGXP-HOST-SCENE\]') ;;
+                            '\[RPGXP-HOST-MENU\] .*opened=true')
+                   is_testbed=1 ;;
+        *)         markers=('\[RPGXP-HOST-SCENE\]')
+                   is_testbed=0 ;;
     esac
-    run_boot "${game}" "${num}" "script host" \
-        "--rgss_host_move_test --rgss_host_menu_test" 2 "${markers[@]}" ||
-        failed=$((failed + 1))
-    num=$((num + 1))
 
-    # Battle needs its own pass: it has to be called from the game's own map,
-    # and the pass above deliberately leaves the game inside its menu. Only the
-    # editor bed, whose stock database ships 32 troops -- a released game's
-    # opening is an event sequence that a battle call would land in the middle
-    # of, which says nothing about the engine.
-    case "${game}" in
-        *Testbed*)
-            run_boot "${game}" "${num}" "script host: battle" \
-                "--rgss_host_battle_test" 2 \
-                '\[RPGXP-HOST-BATTLE\] .*reached=true' ||
-                failed=$((failed + 1))
-            num=$((num + 1))
+    passes=()
+    want_pass script_host && passes+=(script_host)
+    if [ "${is_testbed}" -eq 1 ] ; then
+        want_pass battle && passes+=(battle)
+        want_pass save && passes+=(save)
+    fi
+    if [ "${#passes[@]}" -eq 0 ] ; then
+        if [ -n "${RPGXP_BOOT_PASS}" ] ; then
+            echo "skip ${game}: no '${RPGXP_BOOT_PASS}' pass for this game"
+        fi
+        continue
+    fi
 
-            # And the save screen, its own pass for the same reason. This is the
-            # only place a game reads a file's timestamp back, and the only one
-            # that writes a file of its own.
-            if run_boot "${game}" "${num}" "script host: save" \
-                    "--rgss_host_save_test" 2 \
-                    '\[RPGXP-HOST-SAVE\] .*reached=true' ; then
-                # ...and it has to land in the *game's* directory. The stock
-                # Scene_Save writes a bare "Save1.rxdata", so where that file
-                # ends up is the whole of what the engine's run-from-the-game's-
-                # directory behaviour is worth: before it, the file landed
-                # wherever the engine was launched from and the next game found
-                # it (Pray for You offered Continue on the strength of the
-                # editor bed's save and died reading it as its own).
-                if [ ! -f "${game}/Save1.rxdata" ] ; then
-                    echo "FAILED: ${game} (script host: save): the game's own" \
-                         "save did not land in its own directory" >&2
-                    ls -1 Save[0-9]*.rxdata 2>/dev/null >&2 || true
+    checked=$((checked + 1))
+    echo "== ${game}"
+
+    for pass in "${passes[@]}" ; do
+        case "${pass}" in
+            script_host)
+                run_boot "${game}" "${num}" "script host" \
+                    "--rgss_host_move_test --rgss_host_menu_test" 2 \
+                    "${markers[@]}" ||
+                    failed=$((failed + 1))
+                ;;
+
+            # Battle needs its own pass: it has to be called from the game's
+            # own map, and the script_host pass above deliberately leaves the
+            # game inside its menu. Only the editor bed, whose stock database
+            # ships 32 troops -- a released game's opening is an event
+            # sequence that a battle call would land in the middle of, which
+            # says nothing about the engine.
+            battle)
+                run_boot "${game}" "${num}" "script host: battle" \
+                    "--rgss_host_battle_test" 2 \
+                    '\[RPGXP-HOST-BATTLE\] .*reached=true' ||
+                    failed=$((failed + 1))
+                ;;
+
+            # And the save screen, its own pass for the same reason. This is
+            # the only place a game reads a file's timestamp back, and the
+            # only one that writes a file of its own.
+            save)
+                if run_boot "${game}" "${num}" "script host: save" \
+                        "--rgss_host_save_test" 2 \
+                        '\[RPGXP-HOST-SAVE\] .*reached=true' ; then
+                    # ...and it has to land in the *game's* directory. The
+                    # stock Scene_Save writes a bare "Save1.rxdata", so where
+                    # that file ends up is the whole of what the engine's
+                    # run-from-the-game's-directory behaviour is worth: before
+                    # it, the file landed wherever the engine was launched
+                    # from and the next game found it (Pray for You offered
+                    # Continue on the strength of the editor bed's save and
+                    # died reading it as its own).
+                    if [ ! -f "${game}/Save1.rxdata" ] ; then
+                        echo "FAILED: ${game} (script host: save): the" \
+                             "game's own save did not land in its own" \
+                             "directory" >&2
+                        ls -1 Save[0-9]*.rxdata 2>/dev/null >&2 || true
+                        failed=$((failed + 1))
+                    fi
+                else
                     failed=$((failed + 1))
                 fi
-            else
-                failed=$((failed + 1))
-            fi
-            ;;
-    esac
-
-    num=$((num + 1))
+                ;;
+        esac
+        num=$((num + 1))
+    done
 done
 
 # The save pass leaves a real save file in the bed it ran on; take it back out


### PR DESCRIPTION
## Summary
Refactored the RPG XP real-game boot smoke test to run its four engine-boot passes as separate concurrent CI steps instead of serially in a single step. This reduces total CI time by allowing passes to overlap with each other and other CI steps.

## Key Changes

- **Added `RPGXP_BOOT_PASS` environment variable** to `scripts/rpgxp_boot_check.bash`:
  - Accepts values: `script_host`, `battle`, `save`, or empty (default)
  - When set, restricts execution to a single pass
  - When unset, runs all applicable passes for each game (preserves original behavior)
  - Includes validation to reject invalid values

- **Refactored pass execution logic**:
  - Moved pass selection logic before game checking to skip games that don't support a requested pass
  - Converted hardcoded sequential pass execution into a loop over selected passes
  - Properly handles game-specific pass availability (battle and save only on editor test bed)

- **Updated CI workflow** (`.github/workflows/build.yml`):
  - Split single "RPG XP real-game boot smoke test" step into four separate steps:
    - Script host pass on editor bed (display 112)
    - Battle pass on editor bed (display 113)
    - Save pass on editor bed (display 114)
    - Script host pass on Pray for You (display 115)
  - Each step runs on its own reserved display number, enabling concurrent execution
  - Updated documentation comments explaining the parallelization strategy

- **Added changelog entry** documenting the user-facing change

## Implementation Details

- The `want_pass()` helper function determines whether a pass should run based on the `RPGXP_BOOT_PASS` variable
- Pass applicability is determined upfront: script_host applies to all games, battle and save only to the editor test bed
- If a specific pass is requested but doesn't apply to any game, the script skips gracefully with an informational message
- Display numbers 116-119 remain reserved for future passes without requiring renumbering

https://claude.ai/code/session_012kqT7hJyrijSpqMHBm1f91