### PR TITLE
Show the database's own Victory/Defeat wording in the battle result window

### DIFF
--- a/changelog.d/rpg2k-battle-result-victory-defeat-term.fixed.md
+++ b/changelog.d/rpg2k-battle-result-victory-defeat-term.fixed.md
@@ -1,0 +1,16 @@
+- **The battle result window now shows the database's own Victory / Defeat
+  wording**, not a hardcoded English sentence. The 用語 (vocabulary) table's
+  `victory` and `defeat` fields — the same table
+  `Game::States::BattleText` already reads every per-action battle log line
+  from — were parsed but never consulted here, so a fight always ended on
+  "Victory!" / "The party was defeated..." regardless of what the database
+  actually said. Those two strings are now exactly what shows when the field
+  is left blank, matching the fallback convention every other battle-log line
+  already follows, rather than the only wording a game ever showed.
+  `Game::Party`'s EXP / gold / item lines stay composed English for now: their
+  own terms (`exp_received`, the `gold_received_a` / `_b` pair,
+  `item_received`) are two- or three-part sentences with the number or item
+  name sandwiched between literal halves, and there's no real database on hand
+  to confirm which half goes where — left declared rather than guessed at.
+  Covered by two new checks in `scripts/rpg2k_scene_check.rb` (a database term
+  is shown verbatim; a blank one still falls back to the composed English).

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3632,14 +3632,26 @@ class RPG2k
 
       # The result window's text: the outcome, and on a win the EXP / gold gained
       # (granted here). RPG2000 shows this after the fight before returning to the
-      # map.
+      # map. The headline is the database's own wording -- the 用語 table's
+      # `victory` / `defeat` fields, the same table (and the same "falls back to
+      # composed English when the database leaves it blank" rule)
+      # Game::States::BattleText already reads every per-action line from, just
+      # two fields that table never touches. The two previously-hardcoded
+      # English sentences are now exactly that fallback rather than the only
+      # wording a game ever showed. The EXP / gold / item lines stay composed:
+      # their own terms (`exp_received`, the `gold_received_a` / `_b` pair,
+      # `item_received`) are two- or three-part sentences with the number or
+      # name sandwiched between literal halves, and nothing here confirms which
+      # half is which without a real database to check against -- left declared
+      # rather than guessed at, the same call this project already makes for a
+      # handful of other under-specified 用語 fields.
       def battle_result_lines(result, troop)
-        return ['The party was defeated...'] unless result == :victory
+        return [term(:defeat, 'The party was defeated...')] unless result == :victory
         exp = troop.total_exp
         gold = troop.total_gold
         @state.party.actors.each { |a| a.gain_exp(exp) }
         @state.party.gain_gold(gold)
-        lines = ['Victory!']
+        lines = [term(:victory, 'Victory!')]
         lines << "Gained #{exp} EXP." if exp > 0
         lines << "Found #{gold} gold." if gold > 0
         # Each defeated enemy may drop its treasure item (rolled on the battle's

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4232,6 +4232,38 @@ def window_texts(win)
   ((c.draw_calls || []) + (c.blend_calls || [])).map { |a| a[4] }
 end
 
+check 'Enemy Encounter scene: the result window shows the database Victory term' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.term.victory = '戦いに勝利した！' # left blank in fake_db's own term table
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, BattleStubParty.new)
+  scene.update
+  battle_attack_to_end(scene)
+  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  ok texts.any? { |t| t.include?('戦いに勝利した！') }, 'the database term is shown'
+  ok !texts.any? { |t| t.include?('Victory!') }, 'not the composed English fallback'
+end
+
+check 'Enemy Encounter scene: a blank database Victory/Defeat term falls back to English' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, second_switch_code: ic::DEFEAT_HANDLER)
+  scene = new_scene({ 1 => event(2, 2, auto) }) # fake_db leaves term.defeat blank
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party,
+                           BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
+  scene.update
+  battle_attack_to_end(scene)
+  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  ok texts.any? { |t| t.include?('The party was defeated...') },
+     'a blank database term still falls back to the composed English'
+end
+
 # Open a battle and run it up to the command phase, answering [scene, ui].
 def battle_at_command(pages = nil)
   scene, = battle_scene_with_pages(pages)


### PR DESCRIPTION
## Summary

The 用語 (vocabulary) table's `victory` / `defeat` fields — the same table `Game::States::BattleText` already reads every per-action battle log line from (ADR 0036) — were parsed off the database but never consulted by the battle result window. `battle_result_lines` hardcoded `"Victory!"` / `"The party was defeated..."` regardless of what the database actually said, so a translated (or simply re-worded) game's own text never showed on screen — the fight always ended in plain English no matter what.

## Key changes

- `Scene::Map#battle_result_lines` now routes the headline through `term(:victory, 'Victory!')` / `term(:defeat, 'The party was defeated...')` — the exact same "read the database term, fall back to composed English when it's blank" pattern already established for every other battle-log line. The two English sentences are now precisely that fallback rather than the only wording a game could ever show.

## Left composed (not a regression — was already English, stays English)

The EXP / gold / item lines. Their own terms (`exp_received`, the `gold_received_a` / `_b` pair, `item_received`) are two- or three-part sentences with the number or item name sandwiched between literal halves (the established convention for this table, e.g. `のダメージを与えた！` following a name+number rather than a %-substitution template) — but there's no real downloaded game database in this session to confirm which half goes on which side of the number. Left declared rather than guessed at, matching how this project already treats a handful of other under-specified 用語 fields.

## Testing

- `scripts/rpg2k_scene_check.rb`: 271 checks passing (2 new — a database `victory` term is shown verbatim instead of the English fallback; a blank `defeat` term still falls back to the composed English).
- `scripts/rpg2k_logic_check.rb`: 612 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-battle-result-victory-defeat-term.fixed.md`.

https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G)_