### PR TITLE
Play the database's per-hit battle sound effects

### DIFF
--- a/changelog.d/rpg2k-battle-hit-sfx.added.md
+++ b/changelog.d/rpg2k-battle-hit-sfx.added.md
@@ -1,0 +1,23 @@
+- **Battle hits now play the database's per-hit sound effects.** The System
+  table's `enemy_damaged_se`, `actor_damaged_se`, `dodge_se`, `enemy_death_se`
+  and `item_se` fields (alongside the already-consumed cursor / decision /
+  cancel / buzzer / battle-start / escape slots) were parsed but never played,
+  so a fight ran through its damage, dodges, kills and item use in silence.
+  `Scene::Map` now fires the matching cue the moment each lands — a hit on
+  either side, a miss, a defeated enemy and an item used — reusing the exact
+  `play_system_se` / Change System SFX override mechanism the existing system
+  sounds already go through, extended with five more slots
+  (`Scene::Map::DB_SE_FIELD`) that keep counting through the database's own
+  field order so a `Change System SFX` command naming any of them still lands
+  on the right one. Independent checks, not a single winner-takes-it: a
+  killing blow plays its damage sound and then its death cry, matching
+  EasyRPG's `Scene_Battle_Rpg2k` firing `SFX_EnemyDamage` and `SFX_EnemyKill`
+  as separate calls rather than one replacing the other. Left silent:
+  `enemy_attack_se`, RPG_RT's sound for the *start* of an enemy's swing before
+  the hit lands — this build's round animation has no separate wind-up moment
+  to hang that on (a plain attack is one step: land the hit, then banner and
+  pace by it), so the slot is declared (for the numbering and for Change
+  System SFX overrides to land correctly) but not yet played, rather than
+  played at the wrong moment. Covered by new assertions in three existing
+  `scripts/rpg2k_scene_check.rb` checks (a landed hit plays its damage SE, a
+  fallen enemy plays its death SE, and a used item plays its own cue).

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2704,9 +2704,11 @@ module Game
     end
 
     # Change System SFX: override one of the system sound slots (cursor,
-    # decision, cancel, ...) selected by param0. string = file name, param1
-    # volume, param2 tempo, param3 balance. Stored for save fidelity like the
-    # system BGM; nothing plays these yet.
+    # decision, cancel, the battle per-hit sounds, ...) selected by param0.
+    # string = file name, param1 volume, param2 tempo, param3 balance. The map
+    # scene (Scene::Map::DB_SE_FIELD) already plays most of these slots at the
+    # moments they name; a slot beyond the ones it plays is still stored for
+    # save fidelity, matching the system BGM.
     def do_change_system_sfx(cmd)
       @state.system_sfx[cmd.param(0)] = {
         name: cmd.string, volume: cmd.param(1),

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3106,6 +3106,7 @@ class RPG2k
           refresh_battle_status
           refresh_battle_sprites
           show_battle_action(entry)
+          play_battle_action_se(entry)
           # When an animation plays, it is the wait; otherwise the banner timer
           # is, exactly as before.
           @battle_ui[:anim_timer] =
@@ -3838,6 +3839,23 @@ class RPG2k
         lines = battle_action_lines(entry)
         y = SCREEN_H - lines.length * BATTLE_LINE_H - Window::BORDER * 2 - 6
         @battle_ui[:action_win] = battle_text_window(lines, y, 340)
+      end
+
+      # The system SFX a landed action plays, alongside its banner. Each check
+      # is independent rather than an elsif chain -- RPG_RT plays its own cue
+      # for each thing that happened to the same hit, not one sound standing in
+      # for all of them: a killing blow plays the damage sound and then the
+      # death cry, and an item that lands a hit plays the item's own cue
+      # alongside the hit's (EasyRPG's Scene_Battle_Rpg2k fires
+      # SFX_EnemyDamage / SFX_AllyDamage and, on top of a kill, SFX_EnemyKill,
+      # as separate calls rather than one replacing another).
+      def play_battle_action_se(entry)
+        play_system_se(SFX_DODGE) if entry[:missed]
+        if entry[:damage] && entry[:damage] > 0
+          play_system_se(entry[:target_ally] ? SFX_ACTOR_DAMAGE : SFX_ENEMY_DAMAGE)
+        end
+        play_system_se(SFX_ENEMY_DEATH) if entry[:defeated] && !entry[:target_ally]
+        play_system_se(SFX_ITEM) if entry[:item_id]
       end
 
       # The conditions the action just landed or lifted, one sentence each under
@@ -4668,9 +4686,34 @@ class RPG2k
       # runs from a fight (Force Flee, 1006).
       SFX_BATTLE = 4
       SFX_ESCAPE = 5
+      # The rest of that same run of fields (47..52): the per-hit sounds a fight
+      # itself plays. Slot numbers keep counting up through the database's own
+      # field order (field - 41) even for the one left unplayed below, since a
+      # Change System SFX command's slot argument is that same raw index and has
+      # to land on the right entry whichever slot it names -- skipping a number
+      # here would silently mis-target every slot after it.
+      SFX_ENEMY_ATTACK = 6
+      SFX_ENEMY_DAMAGE = 7
+      SFX_ACTOR_DAMAGE = 8
+      SFX_DODGE = 9
+      SFX_ENEMY_DEATH = 10
+      SFX_ITEM = 11
       DB_SE_FIELD = { SFX_CURSOR => :cursor_se, SFX_DECISION => :decision_se,
                       SFX_CANCEL => :cancel_se, SFX_BUZZER => :buzzer_se,
-                      SFX_BATTLE => :battle_se, SFX_ESCAPE => :escape_se }.freeze
+                      SFX_BATTLE => :battle_se, SFX_ESCAPE => :escape_se,
+                      SFX_ENEMY_ATTACK => :enemy_attack_se,
+                      SFX_ENEMY_DAMAGE => :enemy_damaged_se,
+                      SFX_ACTOR_DAMAGE => :actor_damaged_se,
+                      SFX_DODGE => :dodge_se, SFX_ENEMY_DEATH => :enemy_death_se,
+                      SFX_ITEM => :item_se }.freeze
+      # `enemy_attack_se` (slot 6) is declared above so the slot numbering and
+      # Change System SFX overrides both land correctly, but nothing calls
+      # `play_system_se(SFX_ENEMY_ATTACK)` yet: RPG_RT plays it at the start of
+      # an enemy's swing, before the hit lands, and this build's round animation
+      # has no separate wind-up moment to hang that on -- a plain attack is one
+      # step (land the hit, then banner and pace by it), not a swing-then-impact
+      # pair. Playing it at the same moment as the impact sound would be a
+      # different, unverified timing rather than a faithful one.
 
       # Play a system sound effect by slot, preferring a Change System SFX
       # override held on the game state and falling back to the database's own

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -204,6 +204,12 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                            airship_music: OpenStruct.new(file: 'AirBGM', volume: 80, pitch: 100),
                            cursor_se: OpenStruct.new(file: 'Cursor1', volume: 100, pitch: 100),
                            decision_se: OpenStruct.new(file: 'Decision1', volume: 100, pitch: 100),
+                           # The battle per-hit sounds (Scene::Map::DB_SE_FIELD).
+                           enemy_damaged_se: OpenStruct.new(file: 'EnemyHit', volume: 100, pitch: 100),
+                           actor_damaged_se: OpenStruct.new(file: 'ActorHit', volume: 100, pitch: 100),
+                           dodge_se: OpenStruct.new(file: 'Dodge1', volume: 100, pitch: 100),
+                           enemy_death_se: OpenStruct.new(file: 'EnemyKill', volume: 100, pitch: 100),
+                           item_se: OpenStruct.new(file: 'ItemUse', volume: 100, pitch: 100),
                            gameover_name: 'GameOver1',
                            gameover_music: OpenStruct.new(file: 'GameOverBGM', volume: 90, pitch: 100)),
     # A second chipset (id 2) so Change Map Tileset has somewhere to swap to.
@@ -2545,9 +2551,12 @@ check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Vi
   st.instance_variable_set(:@party, BattleStubParty.new)
   scene.update # opens the per-actor command menu (Attack / Defend)
   eq 0, st.party.gold, 'no rewards mid-battle'
+  RGSS::Audio.reset_se
   battle_attack_to_end(scene) # Attack the Slimes each round until they fall
   eq 20, st.party.gold, 'gained the troop gold (2 Slimes x 10)'
   eq 10, st.party.actors.first.exp, 'gained the troop EXP (2 Slimes x 5)'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'EnemyKill' },
+     'both fallen Slimes played the enemy-death SE'
   ok !st.switches[1], 'showing the Victory result'
   RGSS::Input.triggered = [RGSS::Input::C] # dismiss result
   scene.update
@@ -3466,9 +3475,11 @@ check 'Enemy Encounter scene: the round animates action by action, not at once' 
   eq :animate, ui[:phase], 'the commanded round now plays out as an animation'
   eq 0, ui[:battle].log.length, 'no hit has landed the instant the round starts'
 
+  RGSS::Audio.reset_se
   scene.update # lands exactly the first action of the round
   eq 1, ui[:battle].log.length, 'one attack landed on the first animation step'
   ok ui[:action_win], 'and it is bannered on screen'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'EnemyHit' }, 'and its damage SE played'
   # The timer holds the next action back, so a mid-timer frame lands nothing more.
   scene.update
   eq 1, ui[:battle].log.length, 'the next action waits out BATTLE_ANIM_FRAMES'
@@ -3571,9 +3582,11 @@ check 'Enemy Encounter scene: using an Item heals and consumes one from the bag'
   eq 2, st.party.item_count(5), 'the potion is not spent until the action lands'
 
   hp_before = ui[:allies].first.hp
+  RGSS::Audio.reset_se
   scene.update                          # the Hero uses the Potion first
   eq 1, st.party.item_count(5), 'one potion consumed when the item action landed'
   eq 20, ui[:allies].first.hp - hp_before, 'the Hero was healed 20 HP'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'ItemUse' }, 'the item SE played too'
 end
 
 check 'Enemy Encounter scene: the command and target cursors wrap around' do


### PR DESCRIPTION
## Summary

The System table's `enemy_damaged_se`, `actor_damaged_se`, `dodge_se`, `enemy_death_se` and `item_se` fields were parsed off the database but never played — only the six earlier system-sound slots (cursor / decision / cancel / buzzer / battle-start / escape) were wired through `play_system_se`. A fight ran through its damage, dodges, kills and item use in total silence.

## Key changes

- `Scene::Map#play_battle_action_se` fires the matching cue the instant each battle action lands (hooked in right where the round-animation loop already banners and logs the hit), reusing the exact `play_system_se` / Change System SFX override mechanism the existing slots already go through.
- `Scene::Map::DB_SE_FIELD` grows five more slots. The numbering keeps counting through the database's own field order (`field - 41`) *including* the one left unplayed, so a `Change System SFX` event command naming any of these slots still lands on the correct one — skipping a number would have silently mis-targeted every slot after it.
- Each cue is independent, not a single winner: a killing blow plays its damage sound **and then** its death cry, matching EasyRPG's `Scene_Battle_Rpg2k`, which fires `SFX_EnemyDamage` and `SFX_EnemyKill` as separate calls rather than one replacing the other.

## Left silent

`enemy_attack_se` — RPG_RT's sound for the *start* of an enemy's swing, before the hit lands. This build's round animation has no separate wind-up moment to hang that on (a plain attack is one step: land the hit, then banner and pace by it, not a swing-then-impact pair), so the slot is declared — for the numbering above and so a Change System SFX override still lands on the right entry — but not yet played, rather than played at the wrong moment.

## Testing

- `scripts/rpg2k_scene_check.rb`: 271 checks passing (3 existing checks extended with SE assertions — a landed hit plays its damage SE, a fallen enemy plays its death SE, and a used item plays its own cue).
- `scripts/rpg2k_logic_check.rb`: 612 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-battle-hit-sfx.added.md`.

https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G)_