### PR TITLE
Show the database's Escape success/failure wording in battle

### DIFF
--- a/changelog.d/rpg2k-battle-escape-messages.added.md
+++ b/changelog.d/rpg2k-battle-escape-messages.added.md
@@ -1,0 +1,14 @@
+- **Fleeing a battle now says so, in the database's own words.** The 用語
+  table's `escape_success` / `escape_failure` fields were parsed but never
+  shown: a successful flee closed the battle with no message at all, and a
+  failed one logged only to the console. A successful Escape now routes
+  through the same result window a win or a loss already shows (worded from
+  `escape_success`, falling back to composed English when the database leaves
+  it blank), so it reads and pauses for confirmation exactly like a Victory or
+  Defeat rather than snapping straight back to the map. A failed attempt
+  banners `escape_failure` low on screen — the same transient window a landed
+  hit already banners on, now factored out as `#show_battle_banner` so both
+  share it — while the round continues around it. Covered by new checks in
+  `scripts/rpg2k_scene_check.rb` (a successful flee opens the result window
+  and shows the escape_success wording before running the event's Escape
+  handler).

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2766,15 +2766,19 @@ class RPG2k
       end
 
       # Escape command (cancel on the first actor's menu): roll the party's
-      # agility-based escape chance. On success flee the fight; on a failed roll
-      # the party forfeits the round — every member skips and only the enemies
-      # act — and the next attempt is likelier (Game::Battle#attempt_escape).
+      # agility-based escape chance. On success show the result window (the
+      # database's own `escape_success` wording, like a victory or defeat) and
+      # flee once it is dismissed; on a failed roll the party forfeits the
+      # round — every member skips and only the enemies act, bannered with
+      # `escape_failure` the same way a landed hit is — and the next attempt is
+      # likelier (Game::Battle#attempt_escape).
       def try_battle_escape
         battle = @battle_ui[:battle]
         if battle.attempt_escape
-          finish_battle(:escape)
+          enter_battle_result(:escape)
         else
           $stderr.puts '[RPG2k battle] escape failed'
+          show_battle_banner([term(:escape_failure, "Couldn't escape!")])
           living_allies.each { |a| battle.command_skip(a) }
           start_round_animation
         end
@@ -3647,6 +3651,7 @@ class RPG2k
       # rather than guessed at, the same call this project already makes for a
       # handful of other under-specified 用語 fields.
       def battle_result_lines(result, troop)
+        return [term(:escape_success, 'Escaped!')] if result == :escape
         return [term(:defeat, 'The party was defeated...')] unless result == :victory
         exp = troop.total_exp
         gold = troop.total_gold
@@ -3835,8 +3840,15 @@ class RPG2k
       # reads on screen as well as its HP tick. Replaced by the next action's
       # banner and dropped when the round settles.
       def show_battle_action(entry)
+        show_battle_banner(battle_action_lines(entry))
+      end
+
+      # The low action banner itself, shared by a landed hit (#show_battle_action)
+      # and a failed Escape attempt: both are transient status text over the
+      # still-running fight, replaced by whatever banners next and dropped when
+      # the round settles.
+      def show_battle_banner(lines)
         @battle_ui[:action_win].dispose if @battle_ui[:action_win]
-        lines = battle_action_lines(entry)
         y = SCREEN_H - lines.length * BATTLE_LINE_H - Window::BORDER * 2 - 6
         @battle_ui[:action_win] = battle_text_window(lines, y, 340)
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2620,6 +2620,12 @@ check 'Enemy Encounter scene: Flee (B on the first actor) runs Escape' do
   RGSS::Input.triggered = [RGSS::Input::B] # Flee (cancel on the first actor)
   scene.update
   RGSS::Input.triggered = []
+  ui = scene.instance_variable_get(:@battle_ui)
+  eq :result, ui[:phase], 'a successful flee shows the result window too, like a win or a loss'
+  ok !st.switches[2], 'the Escape handler has not run yet -- the result is still up'
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the result
+  scene.update
+  RGSS::Input.triggered = []
   3.times { scene.update } # interpreter resumes -> Escape handler
   eq 0, st.party.gold, 'fleeing grants nothing'
   ok !st.switches[1], 'the Victory handler was skipped'
@@ -4275,6 +4281,24 @@ check 'Enemy Encounter scene: a blank database Victory/Defeat term falls back to
   texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
   ok texts.any? { |t| t.include?('The party was defeated...') },
      'a blank database term still falls back to the composed English'
+end
+
+check 'Enemy Encounter scene: a successful Flee shows the database escape_success term' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  2.times { scene.update }
+  RGSS::Input.triggered = [RGSS::Input::B] # Flee
+  scene.update
+  RGSS::Input.triggered = []
+  ui = scene.instance_variable_get(:@battle_ui)
+  eq :result, ui[:phase]
+  texts = window_texts(ui[:result_win])
+  ok texts.any? { |t| t.include?('Escaped!') },
+     'fake_db leaves escape_success blank, so this is the composed English fallback'
 end
 
 # Open a battle and run it up to the command phase, answering [scene, ui].


### PR DESCRIPTION
## Summary

The 用語 (vocabulary) table's `escape_success` / `escape_failure` fields were parsed off the database but never shown. A successful battle flee closed the fight instantly with no message at all, and a failed attempt only logged to the console (`$stderr.puts`), invisible in-game.

## Key changes

- A successful Escape now routes through `enter_battle_result(:escape)` — the same result window Victory/Defeat already use (from #480/#479's term work) — worded from `escape_success` and falling back to composed English when the database leaves it blank. It now reads and pauses for confirmation exactly like a Victory or Defeat, rather than snapping straight back to the map.
- A failed attempt banners `escape_failure` low on screen while the round continues, the same transient window a landed hit already banners its line on — factored out as `Scene::Map#show_battle_banner` so `#show_battle_action` and the escape-failure path share one implementation instead of two copies.

## Testing

- `scripts/rpg2k_scene_check.rb`: 272 checks passing (the existing Flee test now expects and dismisses the result window; a new check confirms it shows the `escape_success` wording before the event's Escape handler runs).
- `scripts/rpg2k_logic_check.rb`: 612 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-battle-escape-messages.added.md`.

https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G)_