### PR TITLE
Speak the shop screen's terms: greeting, prompts and menu labels

### DIFF
--- a/changelog.d/rpg2k-shop-terms.added.md
+++ b/changelog.d/rpg2k-shop-terms.added.md
@@ -1,0 +1,25 @@
+- **The shop screen now talks, in the database's own words.** RPG2000 gives
+  every shop one of three shopkeeper "voices" (`Open Shop`'s own type
+  parameter selects `shop_*1` / `_2` / `_3`), and none of the eleven term
+  categories that voice speaks through were ever read: the command menu's
+  Buy / Sell / Leave rows were hardcoded English, and the shop never greeted
+  the player, prompted them on the buy / sell / quantity screens, or spoke at
+  all beyond the mechanical lists. `Scene::Map#shop_terms` (mirroring the
+  existing `#inn_terms`) resolves the right voice with an English fallback
+  for a blank field, and `#shop_header` draws one extra line above whichever
+  screen is up: the shopkeeper's greeting on first opening the command menu,
+  switching to `shop_regreeting` once the player has gone into Buy or Sell at
+  all this visit (EasyRPG's `Window_Shop` keys this off a per-visit flag, not
+  a persisted "have I shopped here before"), and `shop_buy_select` /
+  `shop_sell_select` / `shop_buy_number` / `shop_sell_number` on their own
+  screens. The command row labels (`shop_buy` / `shop_sell` / `shop_leave`)
+  replace the hardcoded English outright, the same way EasyRPG's
+  `Window_Shop::Refresh` uses them as the row text directly rather than
+  combining them with anything.
+  Left composed: `shop_purchased` / `shop_sold`, the confirmation line after a
+  transaction completes — showing it needs a pause-for-keypress step this
+  screen's quantity-counter-then-back-to-list flow doesn't have yet, so it is
+  left for its own change rather than guessed at. Covered by a new check in
+  `scripts/rpg2k_scene_check.rb` walking a real shop from its first greeting
+  through Buy, the quantity prompt, and back to the command menu to see the
+  regreeting.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2275,11 +2275,55 @@ class RPG2k
         has_menu = req[:allow_buy] && req[:allow_sell]
         screen = has_menu ? :command : (req[:allow_buy] ? :buy : :sell)
         @shop = { model: model, has_menu: has_menu, screen: screen, index: 0,
-                  window: nil, gold: build_shop_gold_window }
+                  window: nil, gold: build_shop_gold_window,
+                  terms: shop_terms(req[:type]), browsed: false }
         draw_shop
       end
 
       def shop_gold_term; nonblank(db.term.gold, 'G'); end
+
+      # RPG2000 shop term set (1/2/3, one of three shopkeeper "voices") selected
+      # by Open Shop's own type parameter, mirroring #inn_terms. Blank database
+      # terms fall back to plain English so the window is never empty.
+      def shop_terms(type)
+        t = db.term
+        i = Game.clamp(type || 0, 0, 2)
+        {
+          greeting: nonblank([t.shop_greeting1, t.shop_greeting2, t.shop_greeting3][i], 'Welcome!'),
+          regreeting: nonblank([t.shop_regreeting1, t.shop_regreeting2, t.shop_regreeting3][i],
+                               'Is there anything else you need?'),
+          buy: nonblank([t.shop_buy1, t.shop_buy2, t.shop_buy3][i], 'Buy'),
+          sell: nonblank([t.shop_sell1, t.shop_sell2, t.shop_sell3][i], 'Sell'),
+          leave: nonblank([t.shop_leave1, t.shop_leave2, t.shop_leave3][i], 'Leave'),
+          buy_select: nonblank([t.shop_buy_select1, t.shop_buy_select2, t.shop_buy_select3][i],
+                               'What would you like to buy?'),
+          sell_select: nonblank([t.shop_sell_select1, t.shop_sell_select2, t.shop_sell_select3][i],
+                                'What would you like to sell?'),
+          buy_number: nonblank([t.shop_buy_number1, t.shop_buy_number2, t.shop_buy_number3][i],
+                               'How many will you buy?'),
+          sell_number: nonblank([t.shop_sell_number1, t.shop_sell_number2, t.shop_sell_number3][i],
+                                'How many will you sell?')
+        }
+      end
+
+      # The line shown above the current screen's selectable rows: the
+      # shopkeeper's greeting on first entering the command menu, the same
+      # shopkeeper asking "anything else?" on returning to it after browsing
+      # (EasyRPG's Window_Shop switches from `shop_greeting` to
+      # `shop_regreeting` once the player has entered Buy or Sell mode -- a
+      # per-visit flag, not a persisted "have I shopped here before"), and a
+      # prompt on the buy / sell / quantity screens themselves. nil for any
+      # other screen, which #draw_shop reads as "no header row".
+      def shop_header
+        t = @shop[:terms]
+        case @shop[:screen]
+        when :command then @shop[:browsed] ? t[:regreeting] : t[:greeting]
+        when :buy then t[:buy_select]
+        when :sell then t[:sell_select]
+        when :quantity
+          @shop[:quantity][:mode] == :buy ? t[:buy_number] : t[:sell_number]
+        end
+      end
 
       def build_shop_gold_window
         gw = 88
@@ -2293,18 +2337,19 @@ class RPG2k
       # actions, the goods on the buy list, or the party's sellable items.
       def shop_lines
         m = @shop[:model]
+        t = @shop[:terms]
         case @shop[:screen]
         when :command
           rows = []
-          rows << ['Buy', :buy] if m.allow_buy?
-          rows << ['Sell', :sell] if m.allow_sell?
-          rows << ['Leave', :leave]
+          rows << [t[:buy], :buy] if m.allow_buy?
+          rows << [t[:sell], :sell] if m.allow_sell?
+          rows << [t[:leave], :leave]
           rows
         when :quantity
           # The counter is one row: how many, and what the stack comes to.
           q = @shop[:quantity]
           unit = q[:mode] == :buy ? m.price(q[:id]) : m.sell_price(q[:id])
-          verb = q[:mode] == :buy ? 'Buy' : 'Sell'
+          verb = q[:mode] == :buy ? t[:buy] : t[:sell]
           [["#{verb} #{m.name(q[:id])} x#{q[:count]}  " \
             "#{unit * q[:count]}#{shop_gold_term}", q[:id]]]
         when :buy
@@ -2320,8 +2365,14 @@ class RPG2k
       def draw_shop
         lines = shop_lines
         @shop[:index] = Game.clamp(@shop[:index], 0, [lines.length - 1, 0].max)
+        # The shopkeeper's line (greeting / regreeting / a buy-sell-quantity
+        # prompt) sits above the selectable rows as one extra line, the same
+        # layout #open_inn_window uses for its own greeting.
+        header = shop_header
+        offset = header ? 1 : 0
+        row_count = lines.length + offset
         inner_w = SCREEN_W - 20 - Window::BORDER * 2
-        inner_h = [lines.length, 1].max * SHOP_LINE_H
+        inner_h = [row_count, 1].max * SHOP_LINE_H
         @shop[:window].dispose if @shop[:window]
         win = Window.new(10, SCREEN_H - inner_h - Window::BORDER * 2 - 6,
                          SCREEN_W - 20, inner_h + Window::BORDER * 2)
@@ -2329,13 +2380,14 @@ class RPG2k
         win.windowskin = @windowskin
         c = Bitmap.new(inner_w, inner_h)
         c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, SHOP_LINE_H, header if header
         lines.each_with_index do |(label, _), i|
-          c.draw_text 0, i * SHOP_LINE_H, inner_w, SHOP_LINE_H, label
+          c.draw_text 0, (i + offset) * SHOP_LINE_H, inner_w, SHOP_LINE_H, label
         end
         win.contents = c
         unless lines.empty?
           win.cursor_rect =
-            Rect.new(0, @shop[:index] * SHOP_LINE_H, inner_w, SHOP_LINE_H)
+            Rect.new(0, (@shop[:index] + offset) * SHOP_LINE_H, inner_w, SHOP_LINE_H)
         end
         @shop[:window] = win
         draw_shop_gold
@@ -2454,6 +2506,10 @@ class RPG2k
       end
 
       def shop_switch(screen)
+        # Once the player has gone into Buy or Sell at all this visit, the
+        # shopkeeper's line on returning to the command menu switches from a
+        # first-time greeting to "anything else?" for the rest of it.
+        @shop[:browsed] = true if screen == :buy || screen == :sell
         @shop[:screen] = screen
         @shop[:index] = 0
         draw_shop

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4251,6 +4251,58 @@ def window_texts(win)
   ((c.draw_calls || []) + (c.blend_calls || [])).map { |a| a[4] }
 end
 
+check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each screen prompt' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.term.shop_greeting1 = 'いらっしゃいませ！'
+  db.term.shop_regreeting1 = '他に何かご入用ですか？'
+  db.term.shop_buy1 = '買う'
+  db.term.shop_sell1 = '売る'
+  db.term.shop_leave1 = 'やめる'
+  db.term.shop_buy_select1 = '何をお求めですか？'
+  db.term.shop_buy_number1 = 'いくつ買いますか？'
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0)]
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the command menu opens (mode 0: buy+sell)
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  texts = window_texts(shop[:window])
+  ok texts.any? { |t| t.include?('いらっしゃいませ！') }, 'the first-visit greeting shows'
+  ok texts.any? { |t| t.include?('買う') } && texts.any? { |t| t.include?('売る') } &&
+     texts.any? { |t| t.include?('やめる') }, 'the command row labels use the database terms'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Buy
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen]
+  ok window_texts(shop[:window]).any? { |t| t.include?('何をお求めですか？') },
+     'the buy list shows its own prompt above the goods'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # open the quantity counter for the first good
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :quantity, shop[:screen]
+  ok window_texts(shop[:window]).any? { |t| t.include?('いくつ買いますか？') },
+     'the quantity screen shows its own prompt'
+
+  RGSS::Input.triggered = [RGSS::Input::B] # back to the buy list
+  scene.update
+  RGSS::Input.triggered = []
+  RGSS::Input.triggered = [RGSS::Input::B] # back to the command menu
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  ok window_texts(shop[:window]).any? { |t| t.include?('他に何かご入用ですか？') },
+     'having browsed once, the shopkeeper asks "anything else?" rather than greeting again'
+end
+
 check 'Enemy Encounter scene: the result window shows the database Victory term' do
   ic = Game::Interpreter::Cmd
   db = fake_db


### PR DESCRIPTION
## Summary

RPG2000 gives every shop one of three shopkeeper "voices" — `Open Shop`'s own type parameter selects `shop_*1` / `_2` / `_3` — but none of the eleven `shop_` term categories were ever read. The command menu hardcoded "Buy" / "Sell" / "Leave" in English, and the shop otherwise never spoke: no greeting on entry, no prompt on the buy/sell/quantity screens, nothing beyond the mechanical item lists.

## Key changes

- `Scene::Map#shop_terms` resolves the selected voice (with an English fallback for a blank field), mirroring the existing `#inn_terms` pattern this codebase already established for the Inn screen.
- `#shop_header` draws one extra line above whichever screen is currently up:
  - The shopkeeper's `shop_greeting` on first opening the command menu, switching to `shop_regreeting` once the player has gone into Buy or Sell at all during this visit — EasyRPG's `Window_Shop` keys this off a per-visit flag, **not** a persisted "have I shopped here before" (confirmed by reading the actual condition: the mode flips inside `UpdateBuySelection`/`UpdateSellSelection`, not from any game-wide state).
  - `shop_buy_select` / `shop_sell_select` on the buy/sell list screens, `shop_buy_number` / `shop_sell_number` on the quantity screen.
- The command menu's row labels now use `shop_buy` / `shop_sell` / `shop_leave` directly as the whole label, matching EasyRPG's `Window_Shop::Refresh`, which uses them unmodified rather than combined with anything else.

## Left composed

`shop_purchased` / `shop_sold` — the confirmation line after a transaction completes. Showing it needs a pause-for-keypress step the current quantity-counter-then-back-to-list flow doesn't have yet, so it's left for its own change rather than guessed at.

## Testing

- `scripts/rpg2k_scene_check.rb`: 273 checks passing (1 new — walks a real shop from its first greeting through Buy, the quantity prompt, and back to the command menu to see the regreeting, with distinct term values so each screen's own wording is checked).
- `scripts/rpg2k_logic_check.rb`: 612 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-shop-terms.added.md`.

https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ7cLggK66PistB8swGv6G)_