### PR TITLE
RPG2k TODO sweep: has-item equip counting, move-route continuation across page switch

### DIFF
--- a/changelog.d/rpg2k-item-possession-counts-equipped.fixed.md
+++ b/changelog.d/rpg2k-item-possession-counts-equipped.fixed.md
@@ -1,0 +1,10 @@
+- RPG Maker 2000: `Game::Party#has_item?` — the "does the party have item X"
+  test behind Conditional Branch's item condition and an event page's item
+  appearance condition — now counts a copy currently equipped on any party
+  member, not only the bag. RPG_RT's own item-possession test reads this way
+  even though equipping an item removes it from the bag count `item_count`
+  reports (the numeric "item possession count" operand read by Control
+  Variables stays bag-only, matching RPG_RT's split between the two reads).
+  Previously an event gating on "if the party has the Iron Sword" would read
+  false the moment the sword was worn instead of held. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/changelog.d/rpg2k-move-route-continues-across-page-switch.fixed.md
+++ b/changelog.d/rpg2k-move-route-continues-across-page-switch.fixed.md
@@ -1,0 +1,8 @@
+- RPG Maker 2000: an event's custom move route now continues from where it
+  left off when a page switch selects a page carrying the byte-identical
+  route, instead of always restarting from the top. `Game::MoveRoute
+  .same_route?` compares the old and new page's route commands, repeat and
+  skippable flags, and `Scene::Map` carries the in-progress route object
+  across the page rebuild only when they match — matching RPG_RT, which
+  restarts on any other page switch (a different route, or no custom route).
+  Covered by new `scripts/rpg2k_scene_check.rb` checks.

--- a/changelog.d/rpg2k-overlap-forbidden-collision.added.md
+++ b/changelog.d/rpg2k-overlap-forbidden-collision.added.md
@@ -1,0 +1,9 @@
+- RPG Maker 2000: the event page's "doesn't overlap another event" flag
+  (`overlap_forbidden`, LCF page field 35) now gates collision. It is a
+  fourth, independent collision axis on top of priority type: a blocker with
+  the flag set collides with a mover regardless of the mover's own layer (a
+  below-characters "pen gate" still blocks a same-layer NPC wandering through
+  it), and a mover with the flag set likewise collides with a blocker of any
+  layer. Wired into every call site that already gated on layer — hero
+  movement, event movement/jump landing, and boat/ship/airship movement.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1555,6 +1555,20 @@ following this paragraph as the original record.
   custom route on one side) still restarts, matching RPG_RT. Covered by two
   new `scripts/rpg2k_scene_check.rb` checks (identical route keeps its place;
   a changed route restarts).
+- ✅ **The page-level "doesn't overlap another event" flag now gates
+  collision** (`overlap_forbidden`, LCF page field 35 — parsed since it was
+  added to the schema but never read). It is a *fourth*, independent
+  collision axis on top of priority type: a blocker with it set collides
+  regardless of the mover's layer (a below-characters "pen gate" still blocks
+  a same-layer NPC wandering through it), and a mover with it set likewise
+  collides with a blocker of any layer — wired into all five call sites that
+  already gated on layer (`passable?`, `char_passable?`, `char_can_land?`,
+  `vehicle_passable?`, `airship_landable?`), the same set the priority-type
+  fix above touches. `Game::Character` gained a matching `overlap_forbidden`
+  accessor, set from the active page in `build_event` alongside `layer`.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (a below-characters
+  blocker with the flag set still stops the hero; two events on different
+  layers no longer pass through each other when the blocker sets it).
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
@@ -1783,15 +1797,6 @@ triage, the same as the rest of this backlog.
 **Flagged for priority triage** — these look most likely to be genuine,
 actionable gaps based on this session's own reading of the current code,
 not yet verified:
-- The page-level **"doesn't overlap another event" flag** (`overlap_forbidden`
-  in `mruby-lcf/mrblib/schema.rb`) is parsed but — as far as a search of
-  `mruby-rpg2k/mrblib/scene/map.rb`'s passability code turned up — never
-  read by `passable?`/`char_passable?`. Per yado.tk this is a *fourth*,
-  independent collision axis on top of priority type: it forces collision
-  with events of *any* priority type, not just the same one (e.g. a
-  below-characters "pen gate" that must still block a same-layer NPC from
-  wandering through it). If genuinely unwired, this is a direct extension
-  of the priority-type collision fix already shipped this session.
 - **Parallel processes may be paused too broadly.** This codebase's
   `step_parallels` only runs when `!event_busy?`, and `event_busy?` is true
   for any foreground interpreter activity including an ordinary Show Text

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1536,6 +1536,13 @@ following this paragraph as the original record.
   changes the on-screen sprite (it applied to `@player_char` but the
   renderer never read it), and reverts on Transfer Player like real RPG_RT
   (not persistent like the dedicated Change Hero Graphic command).
+- ✅ **"Has item X" now counts an equipped copy, not just the bag**
+  (`Game::Party#has_item?`, behind Conditional Branch's item condition and an
+  event page's item appearance condition). Equipping an item removes it from
+  `item_count`'s bag tally, and RPG_RT's possession test still reads it as
+  held; the numeric "item possession count" operand (Control Variables) stays
+  bag-only, matching RPG_RT's own split between the two reads. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks.
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
@@ -1615,10 +1622,12 @@ Everything below is unverified against the codebase.
   ignored past it); Change Equipment creates/returns inventory copies
   implicitly; item list always sorts by database id, never acquisition
   order; "equipped item No." reads 0 when empty, and the 2nd weapon slot
-  reads through the *Shield* No. operand for dual-wield; "hero equips X"
-  and "has item X" conditions both count an equipped copy; "item possession
-  count" excludes equipped copies (must sum both for the true total); no
-  inventory is per-hero, always party-shared.
+  reads through the *Shield* No. operand for dual-wield; "item possession
+  count" excludes equipped copies (must sum both for the true total —
+  already true of the Control Variables item operand); no inventory is
+  per-hero, always party-shared. ("hero equips X" — the Conditional Branch
+  actor sub-condition — already reads `actor.equipped?` directly and was
+  fine; "has item X" was the actual gap, now fixed, see above.)
 - **Call Event** — doesn't move the target event, ignores its appearance
   conditions, can't cross maps, continues the *caller* right after itself
   once the callee finishes/cancels; a variable can't pick the called

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1543,6 +1543,18 @@ following this paragraph as the original record.
   held; the numeric "item possession count" operand (Control Variables) stays
   bag-only, matching RPG_RT's own split between the two reads. Covered by new
   `scripts/rpg2k_logic_check.rb` checks.
+- ✅ **Move route continuation across a page switch.** `build_event` used to
+  always build a fresh `Game::MoveRoute` on every page (re)selection, so a
+  custom route in progress restarted from the top on *any* page switch, even
+  one that changed nothing about the route. `Game::MoveRoute.same_route?`
+  compares two pages' raw `move_route` fields (commands, repeat, skippable)
+  byte-for-byte, and `Scene::Map#rebuild_events_preserving_positions` now
+  carries the **old route object** — index and done-ness included — across
+  the rebuild when both the old and new page are on a custom route and the
+  two describe the identical route; anything else (a different route, or no
+  custom route on one side) still restarts, matching RPG_RT. Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks (identical route keeps its place;
+  a changed route restarts).
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
@@ -1553,13 +1565,6 @@ following this paragraph as the original record.
   picking only the single highest-numbered page for map/common events.
 
 #### Confirmed genuine gaps, not yet fixed
-- **Move route continuation across a page switch.** Real RPG_RT: if a map
-  event's active page switches while its move route is executing, the route
-  restarts from the top — *unless* the old and new page's move-route
-  settings are byte-identical, in which case it continues seamlessly.
-  `build_event` always builds a fresh `Game::MoveRoute` on every page
-  (re)selection with no such comparison. Self-contained, no save-format
-  impact — a reasonable next pick.
 - **Common-event Parallel Process state should survive map changes and
   saves, unlike a map event's.** Within one map visit this is already
   modelled correctly (`step_parallel`'s `gate_switch` resumes the same

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3360,6 +3360,32 @@ module Game
       nil
     end
 
+    # True when two event pages' raw `move_route` fields (as read by
+    # #from_page — commands/repeat/skippable) describe the byte-identical
+    # route. This is RPG_RT's own test for whether a route executing when an
+    # event's active page switches continues seamlessly from where it left
+    # off (identical route) or restarts from the top (anything else,
+    # including no custom route at all).
+    def self.same_route?(a, b)
+      return true if a.nil? && b.nil?
+      return false if a.nil? || b.nil?
+      return false unless a.repeat == b.repeat && a.skippable == b.skippable
+      ca = a.commands || []
+      cb = b.commands || []
+      return false unless ca.size == cb.size
+      ca.each_index do |i|
+        x = ca[i]; y = cb[i]
+        return false unless x.command_id == y.command_id &&
+                             x.parameter_string == y.parameter_string &&
+                             x.parameter_a == y.parameter_a &&
+                             x.parameter_b == y.parameter_b &&
+                             x.parameter_c == y.parameter_c
+      end
+      true
+    rescue StandardError
+      false
+    end
+
     # Run the command under the cursor against `character`. Returns a status
     # symbol: :moved, :blocked, :turned, :waited, :effect or :done. A blocked
     # move on a non-skippable route stays on the same command so the next `step`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3155,7 +3155,7 @@ module Game
 
     attr_accessor :direction, :move_speed, :move_frequency
     attr_accessor :through, :facing_locked, :animation_stopped, :transparency
-    attr_accessor :layer
+    attr_accessor :layer, :overlap_forbidden
     attr_reader :graphic_name, :graphic_index, :x, :y
 
     # Placing a character outright -- Change Event Location, a page refresh
@@ -3179,6 +3179,7 @@ module Game
       @graphic_index = 0
       @jumped = false
       @layer = 1                # priority type: same as normal characters
+      @overlap_forbidden = false # LCF page field 35: collide regardless of layer
     end
 
     def set_graphic(name, index)

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2160,7 +2160,16 @@ module Game
     end
 
     def item_count(id); @items[id] || 0; end
-    def has_item?(id); item_count(id) > 0; end
+
+    # RPG_RT's item-possession test (Conditional Branch's item condition and an
+    # event page's item appearance condition, both routed through here) also
+    # counts a copy currently equipped on any party member — even though
+    # equipping an item removes it from the bag `item_count` reports. The
+    # numeric "item possession count" operand (Control Variables, item_operand
+    # above) stays bag-only, matching RPG_RT's own split between the two reads.
+    def has_item?(id)
+      item_count(id) > 0 || @actors.any? { |a| a.equipment.include?(id) }
+    end
 
     def gain_item(id, n = 1)
       c = item_count(id) + n

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1348,16 +1348,26 @@ class RPG2k
       # rather than snapping back to its spawn tile. Erased events stay erased,
       # and the parallel processes are rebuilt because a page change can add or
       # remove one.
+      #
+      # A custom move route in progress also carries its **execution state**
+      # across, but only when the old and new page describe the byte-identical
+      # route (`Game::MoveRoute.same_route?`) — RPG_RT restarts the route from
+      # the top on any other page switch, custom-route or not.
       def rebuild_events_preserving_positions
         placed = {}
-        @events.each { |e| placed[e[:id]] = e[:char] }
+        @events.each { |e| placed[e[:id]] = e }
         build_events
         @events.each do |e|
           old = placed[e[:id]]
           next unless old
-          e[:char].x = old.x
-          e[:char].y = old.y
-          e[:char].direction = old.direction
+          e[:char].x = old[:char].x
+          e[:char].y = old[:char].y
+          e[:char].direction = old[:char].direction
+          next unless e[:move_type] == Game::MoveType::CUSTOM &&
+                      old[:move_type] == Game::MoveType::CUSTOM
+          if Game::MoveRoute.same_route?(page_move_route(old[:page]), page_move_route(e[:page]))
+            e[:route] = old[:route]
+          end
         end
         rebuild_event_tiles
         build_parallels

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -661,6 +661,12 @@ class RPG2k
         ch.set_graphic(page_charset_name(page), page_charset_index(page))
         layer = page_layer(page)
         ch.layer = layer # collision (see #char_passable?) follows priority type too
+        # The page's "doesn't overlap" flag (LCF field 35) is a second,
+        # independent collision axis on top of priority type: it forces
+        # collision against a mover/blocker of *any* layer, not just a
+        # matching one (see #char_passable?/#char_can_land?/#passable?).
+        overlap_forbidden = page_overlap_forbidden(page)
+        ch.overlap_forbidden = overlap_forbidden
         move_type = page_move_type(page)
         route = move_type == Game::MoveType::CUSTOM ?
                 Game::MoveRoute.from_page(page_move_route(page)) : nil
@@ -675,7 +681,8 @@ class RPG2k
           # the sprite between tiles. move_count == TILE means "at rest".
           # `jumping` marks that slide as a hop, which is lifted along an arc
           # and is the one kind that slides across more than a single tile.
-          layer: layer, translucent: page_translucent(page),
+          layer: layer, overlap_forbidden: overlap_forbidden,
+          translucent: page_translucent(page),
           anim_type: page_anim_type(page), base_dir: dir,
           base_pattern: page_pattern(page), anim_phase: 0, anim_count: 0,
           moving: false, disp_x: ev.x, disp_y: ev.y, move_count: TILE,
@@ -723,6 +730,7 @@ class RPG2k
       def page_charset_name(page); page_field(:charset_name, nil) { page.charset_name }; end
       def page_charset_index(page); page_field(:charset_index, 0) { page.charset_index || 0 }; end
       def page_layer(page); page_field(:layer, 0) { page.layer || 0 }; end
+      def page_overlap_forbidden(page); page_field(:overlap_forbidden, false) { page.overlap_forbidden ? true : false }; end
       def page_pattern(page); page_field(:pattern, 1) { p = page.pattern; (0..2).include?(p) ? p : 1 }; end
       def page_anim_type(page); page_field(:anim_type, 0) { page.animation_type || 0 }; end
       def page_translucent(page); page_field(:translucent, false) { page.translucent ? true : false }; end
@@ -1002,7 +1010,7 @@ class RPG2k
       def airship_landable?(x, y)
         return false unless @map.in_bounds?(x, y)
         blocker = @event_tiles[[x, y]]
-        return false if blocker && blocker[:layer] == LAYER_SAME
+        return false if blocker && (blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden])
         row = terrain_row_at(x, y)
         return true if row.nil?
         row.airship_land ? true : false
@@ -1076,7 +1084,7 @@ class RPG2k
           return row.airship_pass ? true : false
         end
         blocker = @event_tiles[[x, y]]
-        return false if blocker && blocker[:layer] == LAYER_SAME
+        return false if blocker && (blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden])
         return passable?(x, y, dir) unless row
         type == :boat ? (row.boat_pass ? true : false) : (row.ship_pass ? true : false)
       end
@@ -1956,9 +1964,11 @@ class RPG2k
         return true if character.through
         nx, ny = Game::Character.step_tile(character.x, character.y, dir)
         return false unless @map.in_bounds?(nx, ny)
-        return false if nx == @state.x && ny == @state.y && character.layer == LAYER_SAME
+        if nx == @state.x && ny == @state.y
+          return false if character.layer == LAYER_SAME || character.overlap_forbidden
+        end
         blocker = @event_tiles[[nx, ny]]
-        return false if blocker && blocker[:layer] == character.layer
+        return false if blocker && (blocker[:layer] == character.layer || blocker[:overlap_forbidden])
         return true if @chipset.nil?
         @chipset.passable_tile?(@map.lower(character.x, character.y),
                                  @map.upper(character.x, character.y), dir) &&
@@ -1987,9 +1997,11 @@ class RPG2k
         return true if x == character.x && y == character.y
         return false unless @map.in_bounds?(x, y)
         # Same layer-gated occupancy rule as #char_passable? (see its comment).
-        return false if x == @state.x && y == @state.y && character.layer == LAYER_SAME
+        if x == @state.x && y == @state.y
+          return false if character.layer == LAYER_SAME || character.overlap_forbidden
+        end
         blocker = @event_tiles[[x, y]]
-        return false if blocker && blocker[:layer] == character.layer
+        return false if blocker && (blocker[:layer] == character.layer || blocker[:overlap_forbidden])
         return true if @chipset.nil?
         @chipset.landable_tile?(@map.lower(x, y), @map.upper(x, y))
       end
@@ -5011,8 +5023,10 @@ class RPG2k
         blocker = @event_tiles[[x, y]]
         # The hero is always a "normal character" for collision purposes: only
         # a same-layer event blocks it, a below/above-characters one is a
-        # decoration it walks straight over (see the LAYER_* comment).
-        return false if blocker && blocker[:layer] == LAYER_SAME
+        # decoration it walks straight over (see the LAYER_* comment) —
+        # unless that event's own "doesn't overlap" flag forces the block
+        # regardless of layer (LCF page field 35, #overlap_forbidden).
+        return false if blocker && (blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden])
         return true if @chipset.nil?
         @chipset.passable_tile?(@map.lower(@state.x, @state.y),
                                  @map.upper(@state.x, @state.y), dir) &&

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3503,6 +3503,39 @@ check 'equip_from_bag rejects a non-equippable or unheld item' do
   eq 0, a.equipment[0]
 end
 
+# RPG_RT's item-possession test counts an equipped copy even though equipping
+# removes it from the bag (yado.tk 011_siyou/): #has_item? -> true although
+# #item_count reads 0. The numeric possession-count operand stays bag-only.
+check 'party#has_item? counts a copy equipped on any member, not just the bag' do
+  items = { 7 => fake_item(atk: 15, type: 1) }   # weapon -> slot 0
+  st = equip_party(items)
+  a = st.party.leader
+  eq false, st.party.has_item?(7)          # not held at all
+  st.party.gain_item(7, 1)
+  ok st.party.equip_from_bag(a, 7)
+  eq 0, st.party.item_count(7)             # gone from the bag
+  eq true, st.party.has_item?(7)           # but still counts as "had"
+  eq 7, st.party.unequip_to_bag(a, 0)
+  eq 1, st.party.item_count(7)             # back in the bag
+  eq true, st.party.has_item?(7)
+end
+
+check 'Conditional Branch item test (type 4) sees an equipped copy too' do
+  items = { 7 => fake_item(atk: 15, type: 1) }
+  st = equip_party(items)
+  a = st.party.leader
+  st.party.gain_item(7, 1)
+  ok st.party.equip_from_bag(a, 7)
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONDITIONAL, [4, 7, 0], indent: 0), # has item 7?
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+            FakeCmd.new(IC::ELSE_BRANCH, [], indent: 0),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+            FakeCmd.new(IC::END_BRANCH, [], indent: 0)])
+  it.update
+  eq true, st.switches[1]                  # equipped counts as "has" -> if-branch
+end
+
 # -- Status screen (Game::Actor EXP-to-next) ---------------------------------
 
 check 'next_level_exp / exp_to_next track the curve across a level up' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -326,13 +326,15 @@ end
 # One event page. Defaults: an action-trigger, stationary event with no route.
 def page(x_move_type: Game::MoveType::STATIONARY, route: nil, trigger: 0,
          frequency: 6, direction: 2, charset_name: '', charset_index: 0,
-         layer: 0, pattern: 1, animation_type: 0, translucent: false)
+         layer: 0, pattern: 1, animation_type: 0, translucent: false,
+         overlap_forbidden: false)
   OpenStruct.new(
     condition: nil, direction: direction, move_type: x_move_type, move_speed: 3,
     move_frequency: frequency, charset_name: charset_name,
     charset_index: charset_index, trigger: trigger, event_commands: nil,
     move_route: route, layer: layer, pattern: pattern,
-    animation_type: animation_type, translucent: translucent
+    animation_type: animation_type, translucent: translucent,
+    overlap_forbidden: overlap_forbidden
   )
 end
 
@@ -833,6 +835,32 @@ check 'events on different layers pass through each other via Move Route' do
   40.times { scene.update }
   eq [3, 2], [ch.x, ch.y],
      "an above-layer mover should cross a below-layer event, got #{[ch.x, ch.y]}"
+end
+
+check 'a below-characters event with overlap_forbidden still blocks the hero' do
+  # The "doesn't overlap" page flag (LCF field 35) is a second, independent
+  # collision axis: it forces the block even though the layer alone would not.
+  pg = page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_BELOW, overlap_forbidden: true)
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.dir_value = 6 # hold right, toward the event at (1,0)
+  12.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [0, 0], [st.x, st.y], 'overlap_forbidden blocks the hero despite the mismatched layer'
+end
+
+check 'events on different layers no longer pass through when overlap_forbidden is set' do
+  # Same setup as the pass-through check above, but the below-layer event now
+  # carries overlap_forbidden — the above-layer mover must stop at its tile.
+  below = event(3, 2, page(layer: RPG2k::Scene::Map::LAYER_BELOW, overlap_forbidden: true))
+  mover = event(1, 2, page(x_move_type: Game::MoveType::CUSTOM,
+                           route: move_route([R::MOVE_RIGHT, R::MOVE_RIGHT], repeat: false),
+                           layer: RPG2k::Scene::Map::LAYER_ABOVE))
+  scene = new_scene({ 1 => below, 2 => mover }, player: [0, 0])
+  ch = chars(scene)[2]
+  40.times { scene.update }
+  eq [2, 2], [ch.x, ch.y],
+     "overlap_forbidden should stop the mover short of the blocker, got #{[ch.x, ch.y]}"
 end
 
 # Each tile's four passability bits mark whether *that tile's own* north/

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -690,6 +690,41 @@ check 'a page change keeps the event where it stands' do
   eq 1, chars(scene)[1].y
 end
 
+check 'an identical custom move route continues its progress across a page switch' do
+  route_cmds = [R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT]
+  p1 = page(x_move_type: Game::MoveType::CUSTOM,
+           route: move_route(route_cmds, repeat: false), charset_name: 'A')
+  p2 = page(x_move_type: Game::MoveType::CUSTOM,
+           route: move_route(route_cmds, repeat: false), charset_name: 'A')
+  scene = new_scene({ 1 => two_page_event(0, 1, 3, p1, p2) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  10.times { scene.update }
+  idx = event_hashes(scene)[1][:route].index
+  ok idx > 0, "expected progress before the switch (got #{idx})"
+  ok !event_hashes(scene)[1][:route].done?, 'not finished yet'
+
+  st.switches[3] = true
+  scene.update
+  eq idx, event_hashes(scene)[1][:route].index,
+     'the identical route kept its place instead of restarting'
+end
+
+check 'a different custom move route restarts from the top on a page switch' do
+  p1 = page(x_move_type: Game::MoveType::CUSTOM,
+           route: move_route([R::MOVE_RIGHT] * 5, repeat: false), charset_name: 'A')
+  p2 = page(x_move_type: Game::MoveType::CUSTOM,
+           route: move_route([R::MOVE_LEFT] * 5, repeat: false), charset_name: 'A')
+  scene = new_scene({ 1 => two_page_event(0, 1, 3, p1, p2) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  10.times { scene.update }
+  idx = event_hashes(scene)[1][:route].index
+  ok idx > 0, "expected progress before the switch (got #{idx})"
+
+  st.switches[3] = true
+  scene.update
+  eq 0, event_hashes(scene)[1][:route].index, 'a changed route restarts from the top'
+end
+
 check 'a refresh does not resurrect an erased event' do
   ic = Game::Interpreter::Cmd
   p1 = page(trigger: 3) # auto-start: erase myself


### PR DESCRIPTION
Small, independent RPG2k engine-logic fixes picked off `docs/TODO.md`'s yado.tk quirks backlog / "confirmed genuine gaps" list. Each is a separate commit; pushed here together rather than as separate PRs per this session's branch assignment.

## 1. Count an equipped copy in the party's has-item test

RPG2000's item-possession test — Conditional Branch's item condition and an event page's item appearance condition, both routed through `Game::Party#has_item?` — also counts a copy currently equipped on any party member, even though equipping an item removes it from the bag count `item_count` reports. This is documented in the yado.tk quirks backlog: *"'hero equips X' and 'has item X' conditions both count an equipped copy"*.

Previously an event gating on "if the party has the Iron Sword" would go **false** the moment the sword was worn instead of held in the bag.

- `Game::Party#has_item?` now also checks whether any party member has the item equipped, alongside the existing bag check.
- The numeric "item possession count" operand (Control Variables, `item_operand`) is untouched and stays bag-only — that already matches RPG_RT's own split between the two reads.
- Both callers of `has_item?` (Conditional Branch's item condition, and an event page's item appearance condition) pick up the fix for free since they share the one method.

## 2. Continue a move route across a page switch when it did not change

Real RPG_RT: if a map event's active page switches while its move route is executing, the route restarts from the top — *unless* the old and new page's move-route settings are byte-identical, in which case it continues seamlessly. `build_event` always built a fresh `Game::MoveRoute` on every page (re)selection with no such comparison, so a route in progress always restarted, even on a page switch that changed nothing about the route.

- `Game::MoveRoute.same_route?` compares two pages' raw `move_route` fields (commands, repeat, skippable) byte-for-byte.
- `Scene::Map#rebuild_events_preserving_positions` now carries the in-progress route object (its index and done-ness) across the rebuild when both the old and new page run a custom route and the two describe the identical route; anything else (a different route, or no custom route on one side) still restarts, matching RPG_RT.

## 3. Wire the event page's overlap_forbidden flag into collision

The page-level "doesn't overlap another event" flag (`overlap_forbidden`, LCF page field 35) was parsed by the schema but never read by any passability check. Per yado.tk it is a fourth, independent collision axis on top of priority type: it forces collision regardless of layer rather than only against a matching one — a below-characters "pen gate" must still block a same-layer NPC wandering through it.

- `Game::Character` gains a matching `overlap_forbidden` accessor, set from the active page in `build_event` alongside `layer`.
- Wired into every call site that already gated on layer: `passable?` (hero movement), `char_passable?`/`char_can_land?` (event movement/jump landing), and `vehicle_passable?`/`airship_landable?` (boat/ship/airship movement) — the same set of sites the existing priority-type collision fix touches.

## Testing

- `scripts/rpg2k_logic_check.rb`: 614 checks passing (2 new, for change 1).
- `scripts/rpg2k_scene_check.rb`: 276 checks passing (4 new: 2 for change 2, 2 for change 3).
- Documented in `changelog.d/rpg2k-item-possession-counts-equipped.fixed.md`, `changelog.d/rpg2k-move-route-continues-across-page-switch.fixed.md` and `changelog.d/rpg2k-overlap-forbidden-collision.added.md`.
- Native CTest suite not run (no C++/LCF-schema changes; all three are pure-Ruby runtime-logic fixes covered by the harnesses above).