### PR TITLE
RPG2k TODO triage: Menu access and Tile Substitution reset behavior

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1837,12 +1837,21 @@ not yet verified:
 - **Runtime per-map overrides that reset on leaving-and-returning to the
   map**, not just on Transfer Player/save-load: Chipset Change, Panorama/
   parallax Change, Encounter Steps Change, Tile Replacement, and — per one
-  source — Save/Teleport/Escape Prohibition changes. This codebase's
-  `perform_teleport` already resets several of these (tileset, parallax,
-  pan) on a *map change*; yado.tk's phrasing ("leaving and returning to
-  the map") is consistent with that, but Encounter Steps and Tile
-  Replacement specifically aren't confirmed reset anywhere in the code
-  read this session — worth checking.
+  source — Save/Teleport/Escape Prohibition changes. `perform_teleport`
+  resets tileset/parallax/pan on a *map change*, and Save/Teleport/Escape
+  Prohibition are confirmed correct above (`apply_map_access`). **Tile
+  Replacement is confirmed correct too**, for a different reason than the
+  other three: a Tile Substitution is recorded directly on the live
+  `Game::Map` object (`Game::Map#substitute_tile`), and `perform_teleport`
+  always rebuilds `@map` from scratch (`@parent.load_map`, which re-parses
+  the destination's `.lmu` fresh) rather than reusing or caching one — so
+  a substitution cannot survive a Teleport, including one back to the same
+  map, without any explicit reset code needed. Regression-covered by a new
+  `scripts/rpg2k_scene_check.rb` check. **Encounter Steps Change is not
+  actionable yet**: `Game::State#encounter_rate` records the override and
+  round-trips through the save, but no random-encounter system reads it at
+  all (see the Screen effects section) — there is nothing to reset until
+  that system exists.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1577,6 +1577,21 @@ following this paragraph as the original record.
   event selection: `Game::BattlePage.select_all` runs **every** satisfied
   page once per turn, lower page number first, vs. `Game::EventPage.select`
   picking only the single highest-numbered page for map/common events.
+- **Change Menu Prohibit already persists across map transfers; Change Save
+  Prohibit and Teleport/Escape Prohibit already do not** (yado.tk: a real,
+  asymmetric rule across three similar-sounding commands). Confirmed by
+  reading `Scene::Map#apply_map_access`, which re-derives `save_access` /
+  `teleport_access` / `escape_access` from the map tree's own per-map
+  tri-states (LMT `map_properties` fields 33/31/32) on the initial map load
+  and on every Teleport, while `menu_access` is untouched there — and the map
+  tree schema (`mruby-lcf/mrblib/schema.rb`) confirms *why*: RPG2000 never
+  offers a per-map Menu setting at all, only Save/Teleport/Escape, so there
+  is nothing for Menu access to be re-derived from. A `Control Menu/Save/
+  Teleport/Escape Access` event command can still override any of the four
+  for the rest of the current visit; only the next map load or Teleport
+  recomputes the three that have a map-tree setting. Regression-covered by
+  extending an existing `scripts/rpg2k_scene_check.rb` check to also assert
+  Save access resets with Teleport/Escape and Menu access does not.
 
 #### Confirmed genuine gaps, not yet fixed
 - **Common-event Parallel Process state should survive map changes and
@@ -1828,11 +1843,6 @@ not yet verified:
   the map") is consistent with that, but Encounter Steps and Tile
   Replacement specifically aren't confirmed reset anywhere in the code
   read this session — worth checking.
-- **Change Menu Prohibit persists across map transfers; Change Save
-  Prohibit and Teleport/Escape Prohibit do not** (revert to the destination
-  map's own configured setting on the next transfer) — a real, asymmetric
-  rule across three very similar-sounding commands, worth getting right
-  rather than treating all three the same.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4074,6 +4074,22 @@ check 'Tile Substitution rewrites the map the scene walks on' do
   eq 41, scene.instance_variable_get(:@state).map.lower(3, 3)
 end
 
+check 'Tile Substitution does not survive leaving and returning to the map' do
+  # RPG_RT re-reads the map fresh on every Teleport (see #perform_teleport's
+  # own chipset/parallax/pan comments for the sibling per-visit overrides this
+  # matches); a substitution recorded on the old Game::Map object does not
+  # follow the new one it builds, even when the destination is the same map.
+  cmds = [ECmd.new(IC2::TILE_SUBSTITUTION, [0, 0, 41])]
+  scene = new_scene(parallel_event(cmds), player: [0, 0])
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  eq 41, st.map.lower(3, 3), 'the substitution took on the original map'
+
+  scene.send(:perform_teleport, [st.map_id, 0, 0, 0]) # leave and return to the same map
+  eq 0, st.map.lower(3, 3),
+     'a fresh map load on Teleport drops the substitution'
+end
+
 check 'Enter/Exit Vehicle boards the vehicle the party stands on' do
   cmds = [ECmd.new(IC2::ENTER_EXIT_VEHICLE, [])]
   scene = new_scene(parallel_event(cmds), player: [0, 0])

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5149,21 +5149,30 @@ def fake_map_tree(props)
   Struct.new(:map_properties).new(props)
 end
 
-check 'Scene::Map re-derives Teleport/Escape access from the map tree on load and on Teleport' do
+check 'Scene::Map re-derives Save/Teleport/Escape access from the map tree ' \
+     'on load and on Teleport, but leaves Menu access alone' do
   parent = fake_parent(fake_db)
   parent.map_tree = fake_map_tree(
-    1 => FakeAccessNode.new(1, 2, 1), # map 1: teleport forbidden, escape allowed
-    2 => FakeAccessNode.new(1, 1, 2)  # map 2: teleport allowed, escape forbidden
+    1 => FakeAccessNode.new(2, 2, 1), # map 1: save+teleport forbidden, escape allowed
+    2 => FakeAccessNode.new(1, 1, 2)  # map 2: save+teleport allowed, escape forbidden
   )
   state = Game::State.new(fake_party, 1, 0, 0)
   state.map = fake_map(1, {})
   scene = RPG2k::Scene::Map.new(parent, state)
+  eq false, state.save_access, 'map 1 forbids Save'
   eq false, state.teleport_access, 'map 1 forbids Teleport'
   eq true, state.escape_access, 'map 1 allows Escape'
 
+  # A Control Menu Access override mid-visit -- unlike Save/Teleport/Escape,
+  # Menu access has no map-tree setting at all (RPG2000 never offers one) and
+  # so is never re-derived; it must still read false after the transfer below.
+  state.menu_access = false
   scene.send(:perform_teleport, [2, 0, 0, 0])
+  eq true, state.save_access, 'map 2 allows Save'
   eq true, state.teleport_access, 'map 2 allows Teleport'
   eq false, state.escape_access, 'map 2 forbids Escape'
+  eq false, state.menu_access,
+     'Menu access is not re-derived from the tree; it persists across the transfer'
 end
 
 check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around' do


### PR DESCRIPTION
## Summary

Two yado.tk quirks-backlog items in `docs/TODO.md` turned out to already be correctly implemented — this PR confirms both by reading the code against the documented RPG_RT behavior, adds a regression test for each so the correctness doesn't rest on inspection alone, and moves each item from the untriaged backlog into a "confirmed already correct" note.

## 1. Menu access persists across a map transfer; Save/Teleport/Escape access do not

yado.tk documents an asymmetric rule across three similar-sounding commands: Change Menu Prohibit persists across map transfers, while Change Save Prohibit and Teleport/Escape Prohibit revert to the destination map's own configured setting.

`Scene::Map#apply_map_access` already re-derives `save_access`/`teleport_access`/`escape_access` from the map tree's per-map tri-states on the initial map load and on every Teleport, while `menu_access` is untouched there. The map tree schema confirms *why*: RPG2000 offers no per-map Menu setting at all (only Save/Teleport/Escape fields exist on a map-tree node), so there's nothing for Menu access to be re-derived from.

Extended the existing `Scene::Map re-derives Teleport/Escape access...` scene check to also assert Save access resets alongside Teleport/Escape and Menu access does not.

## 2. Tile Substitution does not survive leaving and returning to a map

yado.tk lists Tile Replacement among per-map overrides that should reset on leaving and returning to a map; the doc flagged this as unconfirmed.

It already holds, for a different reason than the sibling overrides `perform_teleport` explicitly resets (tileset/parallax/pan): a Tile Substitution is recorded directly on the live `Game::Map` object (`Game::Map#substitute_tile`), and `perform_teleport` always rebuilds `@map` from scratch via `@parent.load_map`, which re-parses the destination's `.lmu` fresh rather than reusing or caching a map instance. A substitution can't survive a Teleport — including one back to the same map — with no explicit reset code needed.

Also noted in the doc: Encounter Steps Change isn't actionable yet, since no random-encounter system reads the recorded override at all — there's nothing to reset until that system exists.

## Testing

- `scripts/rpg2k_scene_check.rb`: 278 checks passing (2 new — one extends an existing map-access check, one new for the tile-substitution reset).
- `scripts/rpg2k_logic_check.rb`: 614 checks passing (unaffected).
- No production code changed in either commit — both are confirmations backed by new regression tests plus `docs/TODO.md` updates.
- Native CTest suite not run (no C++/LCF-schema changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_