### PR TITLE
Confirm a Change Map Tileset override does not survive save/Continue

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1795,11 +1795,14 @@ Everything below is unverified against the codebase.
 - **Load** — resuming mid-Autorun/mid-Parallel-Process picks up exactly
   where it left off, *unless* the map was edited/re-saved since, in which
   case that event restarts from the top (edge case, likely not applicable
-  here — no "map data changed since save" concept); a runtime Change
-  Tileset override does not survive save/load, reverting to the map's own
-  configured tileset (**worth checking** — `apply_tileset_request`/
-  `@tileset_id` currently only resets on teleport per the code read this
-  session; unclear whether it also resets on save/load).
+  here — no "map data changed since save" concept). **A runtime Change
+  Tileset override not surviving save/load is confirmed already correct**:
+  `@tileset_id` is a `Scene::Map` instance variable, not a `Game::State`
+  field — `to_h`/`to_lsd` have nothing named `tileset`/`chipset` at all — and
+  `RPG2k#continue_game` always builds a **fresh** `Scene::Map` from the
+  loaded state, so the override cannot follow it even though nothing
+  explicitly clears it the way `perform_teleport` does. Regression-covered
+  by a new `scripts/rpg2k_scene_check.rb` check.
 
 #### Full-site sweep (all remaining ~457 pages, 34 batches)
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1556,6 +1556,25 @@ check 'Change Map Tileset rebuilds the map chipset from the new id' do
   eq 2, scene.instance_variable_get(:@tileset_id), 'the override id is recorded'
 end
 
+check 'Change Map Tileset override does not survive save/Continue' do
+  # Continue reconstructs a fresh Scene::Map from the saved Game::State alone
+  # (RPG2k#continue_game); the override lives only on the old scene's
+  # @tileset_id, which Game::State#to_h/#to_lsd have no field for, so it
+  # cannot follow into the new scene -- the destination reverts to the map's
+  # own configured tileset, matching RPG_RT.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::CHANGE_MAP_TILESET, [2])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  5.times { scene.update }
+  eq 'cs2', scene.instance_variable_get(:@chipset).name, 'the override took effect'
+
+  fresh = RPG2k::Scene::Map.new(scene.parent, scene.instance_variable_get(:@state))
+  eq nil, fresh.instance_variable_get(:@tileset_id), 'no override on the fresh scene'
+  eq 'cs', fresh.instance_variable_get(:@chipset).name,
+     "the fresh scene rebuilds the chipset from the map's own tileset id"
+end
+
 check 'Input Number opens a widget; confirming stores the entered value' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

`docs/TODO.md` flagged this as worth checking: a runtime Change Map Tileset override was only confirmed reset on Teleport (`perform_teleport` explicitly clears `@tileset_id`); it was unclear whether it also resets on save/load.

It turns out to already be correct by construction, for the same shape of reason as the Tile Substitution / Teleport confirmation merged earlier this session:

- `@tileset_id` lives on the `Scene::Map` instance, not on `Game::State` — `to_h`/`to_lsd` have no `tileset`/`chipset` field at all.
- `RPG2k#continue_game` always builds a **fresh** `Scene::Map` from the loaded state rather than reusing the old one.

The override has nowhere to persist to and no scene to survive on, so it's gone on Continue even though nothing explicitly clears it the way `perform_teleport` does for a Teleport.

## Changes

- No production code changed — this was already correct.
- Added a new `scripts/rpg2k_scene_check.rb` check: run Change Map Tileset, confirm the chipset swaps, then construct a fresh `Scene::Map` from the same `Game::State` the way Continue does and assert the chipset reverts to the map's own configured tileset.
- Moved the item from the yado.tk untriaged backlog to a confirmation note in `docs/TODO.md`.

## Testing

- `scripts/rpg2k_scene_check.rb`: 279 checks passing (1 new).
- `scripts/rpg2k_logic_check.rb`: 614 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_