### PR TITLE
Cap the active party at four members

### DIFF
--- a/changelog.d/rpg2k-party-max-size-cap.fixed.md
+++ b/changelog.d/rpg2k-party-max-size-cap.fixed.md
@@ -1,0 +1,6 @@
+- RPG Maker 2000: the active party now caps at four members, matching
+  RPG_RT (the editor never offers a fifth party slot). `Game::Party#add_actor`
+  had no size check at all, so a Change Party Member "Add" past the fourth
+  slot grew the party unbounded instead of silently no-op'ing. Leaving and
+  rejoining once a slot frees up still works. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1569,6 +1569,13 @@ following this paragraph as the original record.
   Covered by two new `scripts/rpg2k_scene_check.rb` checks (a below-characters
   blocker with the flag set still stops the hero; two events on different
   layers no longer pass through each other when the blocker sets it).
+- ✅ **The active party caps at four members.** `Game::Party#add_actor` had no
+  size check at all, so a Change Party Member "Add" past the fourth slot grew
+  `@actors` unbounded instead of no-op'ing the way RPG_RT does (the editor
+  never offers a fifth party slot). `Game::Party::MAX_SIZE` (4) now guards the
+  join; leaving and rejoining once a slot frees up still works, and nothing
+  about `remove_actor` or the roster's rejoin-with-preserved-state changed.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
@@ -1718,11 +1725,11 @@ Everything below is unverified against the codebase.
   it again, toggle its appearance switch, or issue any move-route command
   at it — "Cancel Move Route" alone does not clear it). Related to the
   already-fixed priority-type/touch-trigger work but distinct and unverified.
-- **Hero & party** — party caps at 4 (Change Party Member no-ops past that);
-  removing a hero preserves their equipment/level/EXP/HP/status; the field
-  sprite is always party member 1's; only the front member draws on the
-  field at all; a hero's name can't be copied to another via any built-in
-  command.
+- **Hero & party** — removing a hero preserves their equipment/level/EXP/HP/
+  status; the field sprite is always party member 1's; only the front member
+  draws on the field at all; a hero's name can't be copied to another via any
+  built-in command. (Party caps at 4, Change Party Member no-ops past that —
+  now fixed, see above.)
 - **Processing order** — map/common events process in ascending id order;
   "Get Event ID at coordinates" on overlapping events returns the
   **highest** id, not lowest/topmost-drawn; only one event/parallel-process

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1964,6 +1964,10 @@ module Game
   class Party
     include Enumerable
 
+    # RPG2000's active party roster caps at four members (the editor never
+    # offers a fifth slot); a Change Party Member "Add" beyond that no-ops.
+    MAX_SIZE = 4
+
     attr_reader :actors, :items, :gold
 
     # The permanent actor roster this party draws from (see Game::Actors). The
@@ -2142,9 +2146,12 @@ module Game
 
     # Put an actor in the party. The actor comes from the roster, so one who has
     # been in the party before rejoins with the level, EXP, gear, skills, statuses
-    # and name they left with rather than a fresh database row.
+    # and name they left with rather than a fresh database row. A no-op once the
+    # party already holds MAX_SIZE members, matching RPG_RT's Change Party
+    # Member "Add" against a full party (yado.tk: 主人公・パーティー・乗り物).
     def add_actor(id)
       return if include_actor?(id)
+      return if @actors.size >= MAX_SIZE
       a = @roster[id]
       return unless a
       @actors.push a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2189,6 +2189,23 @@ check 'an actor who leaves and rejoins the party keeps their state' do
   eq levelled_hp, back.max_hp
 end
 
+check 'add_actor no-ops once the party already holds MAX_SIZE (4) members' do
+  players = (1..5).to_h { |i| [i, FakePlayerRow.new("Actor#{i}", '', 0, 1, max_hp: 10)] }
+  db = FakeActorDB.new(players, [1])
+  party = Game::Party.new(db)
+  [2, 3, 4].each { |id| party.add_actor(id) }
+  eq [1, 2, 3, 4], party.actors.map(&:id), 'four members joined'
+
+  party.add_actor(5)
+  eq [1, 2, 3, 4], party.actors.map(&:id), 'a fifth add is a no-op on a full party'
+  eq false, party.include_actor?(5)
+
+  party.remove_actor(2)
+  party.add_actor(5)
+  eq [1, 3, 4, 5], party.actors.map(&:id),
+     'adding is allowed again once a member has left and freed a slot'
+end
+
 check 'Actors builds each id once and reports a missing row as nil' do
   roster = Game::Actors.new(roster_db)
   a = roster[1]


### PR DESCRIPTION
## Summary

yado.tk's "Hero & party" quirks note (`docs/TODO.md`): *"party caps at 4 (Change Party Member no-ops past that)"*. `Game::Party#add_actor` had no size check at all, so a Change Party Member "Add" past the fourth slot grew `@actors` unbounded instead of silently no-op'ing the way RPG_RT does — the editor never offers a fifth party slot in the first place.

## Changes

- Added `Game::Party::MAX_SIZE = 4` and a guard in `add_actor`: once the party already holds 4 members, a further add is a no-op (matching an already-in-party add, and matching how RPG_RT's own Change Party Member behaves against a full party).
- `remove_actor` and the roster's rejoin-with-preserved-state logic (an actor who leaves and rejoins keeps their level/EXP/gear/skills/statuses/name) are untouched — leaving and rejoining once a slot frees up still works.

## Testing

- `scripts/rpg2k_logic_check.rb`: 615 checks passing (1 new — builds a 5-actor roster, fills the party to 4, confirms a 5th add is a no-op, then confirms adding works again once a member leaves and frees a slot).
- `scripts/rpg2k_scene_check.rb`: 279 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-party-max-size-cap.fixed.md`.
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby runtime-logic fix covered by the harness above).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_