### PR TITLE
Skip PIXI's real render on headless MZ frames nobody looks at

### DIFF
--- a/changelog.d/mz-headless-render-skip.added.md
+++ b/changelog.d/mz-headless-render-skip.added.md
@@ -1,0 +1,19 @@
+- Even with the frame-pacing wait gone (`--no_render_wait`), a headless MZ
+  boot check was still spending most of its time on real work nobody looks
+  at: profiling `data/mz-sample`'s `play` mode showed PIXI's actual WebGL
+  render (software-rasterised on the surfaceless-EGL backend) at ~95% of the
+  per-frame JS pump, while the game-logic half of the same tick
+  (`SceneManager.updateMain`) cost almost nothing. Every `mz_boot_check.bash`
+  mode captures exactly one screenshot and otherwise reads JS/Ruby state, not
+  pixels, so a `--no_render_wait` run now wraps `Graphics._app.render` (once
+  `SceneManager.run` has built it) and suppresses it on every frame but the
+  one `#maybe_screenshot` is about to capture, forcing one real render right
+  before that read so the frame it gets is exactly what an unskipped run
+  would have shown. Scene transitions, fades and animation counters are
+  unaffected — they live entirely in the update half of the tick, never the
+  render — so the game state at capture time does not change, only the
+  wasted renders leading up to it. Measured against `data/mz-sample`: `play`
+  dropped from ~6.2s to ~2.1s with a byte-identical captured frame, and all
+  14 `mz_boot_check.bash` modes plus the cross-mode `mz_frame_check.rb`
+  sweep (54 checks, including the delicate animation-burst and
+  encounter-battle content checks) still pass.

--- a/mruby-mvjs/mrblib/mz.rb
+++ b/mruby-mvjs/mrblib/mz.rb
@@ -289,10 +289,50 @@ class MZ
     "addLoadListener: function(){}, volume: 0, pitch: 0, pan: 0, seek: 0 }; }; " \
     "})(globalThis);".freeze
 
+  # Installed only for headless/CI runs (see #render_skip_enabled?, gated on
+  # the same --no_render_wait flag as RGSS::Graphics.update's frame-pacing
+  # skip). Wraps PIXI's real render call so #main_loop can suppress it on
+  # every frame but the one #maybe_screenshot actually captures.
+  #
+  # Safe to skip almost every frame's render because nothing else looks at a
+  # pixel: `Graphics._onTick` (rmmz_core.js) runs `SceneManager.updateMain`
+  # — scene transitions, fades, animation counters, all of it — as a
+  # completely separate step from `this._app.render()`, and every
+  # `maybe_*_test`/`*_shot_ready?` probe in this file reads JS or Ruby state,
+  # never the framebuffer. So game state at the moment a capture is due is
+  # identical whether or not the frames leading up to it were ever rasterised
+  # — only the *pixels* of the skipped frames are lost, and nothing reads
+  # those. Measured on data/mz-sample's `play` mode: the real WebGL render
+  # was ~95% of the JS pump's time (software GL on the surfaceless-EGL
+  # backend), so skipping it on the frames nobody looks at is most of a
+  # headless run's cost.
+  #
+  # Installed once `Graphics._app` exists — `SceneManager.run` builds the
+  # PIXI.Application synchronously (Graphics.initialize -> _createPixiApp)
+  # before returning, so evaluating this right after the `SceneManager.run`
+  # call in #boot_probe always finds it. Guarded on `Graphics.__mzRealRender`
+  # so a second eval (there is none today) would not double-wrap.
+  RENDER_SKIP_BRIDGE_JS =
+    "(function(){ if (typeof Graphics === 'undefined' || !Graphics._app || " \
+    "Graphics.__mzRealRender) return; " \
+    "var app = Graphics._app; " \
+    "Graphics.__mzRealRender = app.render.bind(app); " \
+    "Graphics.__mzSkipRender = true; " \
+    "app.render = function(){ " \
+    "if (!Graphics.__mzSkipRender) Graphics.__mzRealRender(); }; " \
+    "Graphics.__mzForceRender = function(){ Graphics.__mzRealRender(); }; " \
+    "})();".freeze
+
   class << self
     # The canonical MZ script load order (see CORE_SCRIPTS).
     def core_scripts
       CORE_SCRIPTS
+    end
+
+    # The JS that lets headless/CI runs skip PIXI's real render on frames
+    # nobody looks at (see RENDER_SKIP_BRIDGE_JS).
+    def render_skip_bridge_js
+      RENDER_SKIP_BRIDGE_JS
     end
 
     # The JS that routes MZ's audio through RGSS::Audio: MV's shared bridge plus
@@ -967,6 +1007,19 @@ class MZ
   end
 
   private
+
+  # Whether this is a headless/CI run that should skip PIXI's real WebGL
+  # render on frames nobody looks at (see RENDER_SKIP_BRIDGE_JS) and the
+  # on-screen present() readback (see #present) that exists only to display
+  # frames nobody is watching. Reuses --no_render_wait (native-side constant,
+  # src/main.cxx): a run that has already opted out of real-time frame
+  # pacing has no use for intermediate renders or a live on-screen picture
+  # either — both flags exist for the same headless-smoke-test case.
+  def render_skip_enabled?
+    NO_RENDER_WAIT
+  rescue StandardError
+    false
+  end
 
   # Advance the JavaScript host by one frame. This is the whole of MZ's update:
   # `SceneManager.run` hands the loop to `Graphics.startGameLoop`, which starts
@@ -2209,11 +2262,29 @@ class MZ
     return if equip_test_requested? && !equip_shot_ready?
 
     @shot_taken = true
+    force_render_before_capture
     handle = mz_gl_handle
     ok = handle && handle > 0 && MV::JS.screenshot_gl(path, handle)
     $stderr.puts "[MZ] screenshot #{ok ? "saved" : "failed"}: #{path}"
   rescue StandardError => e
     $stderr.puts "[MZ] screenshot error: #{e.message}"
+  end
+
+  # Render-skip runs (see #render_skip_enabled?) never let PIXI rasterise a
+  # frame except this one: `screenshot_gl` reads the WebGL FBO directly, so
+  # without a real render just before it the capture would read back whatever
+  # a run that skips almost every frame's render last happened to draw —
+  # stale, or on a run whose render was skipped from the very first frame,
+  # never drawn at all. `Graphics.__mzForceRender` (RENDER_SKIP_BRIDGE_JS)
+  # renders once with the game state already current as of this frame's
+  # `#pump_frame`, so the capture is exactly what an unskipped run would have
+  # shown here. A no-op (and safe to call) when render-skip was never armed.
+  def force_render_before_capture
+    return unless render_skip_enabled?
+    MV::JS.eval(
+      "(function(){ if (typeof Graphics !== 'undefined' && " \
+      "Graphics.__mzForceRender) Graphics.__mzForceRender(); })();"
+    )
   end
 
   # Has the battle probe reported *and* had BATTLE_SHOT_GRACE_FRAMES to fade in?
@@ -2359,8 +2430,14 @@ class MZ
   # the WebGL canvas' FBO during SceneManager.update; MV::JS.present_gl reads that
   # FBO back and blits it into the sprite's bitmap (marking it dirty) so the next
   # Graphics.update draws it.
+  #
+  # Skipped entirely on a render-skip run (#render_skip_enabled?): its whole
+  # purpose is a live picture for something watching the screen, and nothing
+  # is — the captured screenshot reads the WebGL FBO straight (see
+  # #force_render_before_capture), never this bitmap.
   def present
     return unless @screen_bitmap
+    return if render_skip_enabled?
     handle = mz_gl_handle
     unless @present_logged
       @present_logged = true
@@ -2448,6 +2525,12 @@ class MZ
       "try { SceneManager.run(Scene_Boot); } catch(e){ SceneManager.__mzErr = " \
       "(e && (e.stack || e.message)) || String(e); } })();"
     )
+
+    # Headless/CI only (see #render_skip_enabled?): `SceneManager.run` above
+    # built `Graphics._app` synchronously, so the render-skip bridge can be
+    # installed right away and cover every frame from here on, including the
+    # boot-probe loop below.
+    MV::JS.eval(self.class.render_skip_bridge_js) if render_skip_enabled?
 
     # Drive frames until the boot scene hands over to the next one (normally
     # Scene_Title). Scene_Boot is a *loading* scene: it polls its database,

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -189,6 +189,51 @@ assert 'the MZ audio bridge queues ops and neutralises the eager preload' do
   assert_equal "audio/se/Beep", call[1]
 end
 
+assert 'MZ.render_skip_bridge_js only wraps once Graphics._app exists' do
+  js = MZ.render_skip_bridge_js
+  assert_true js.include?("Graphics._app")
+  # The idempotency guard: a second eval must not double-wrap an already
+  # wrapped render (see the effect test below for what double-wrapping would
+  # do — call the real render twice per app.render() call).
+  assert_true js.include?("Graphics.__mzRealRender")
+end
+
+assert 'the MZ render-skip bridge suppresses render() until forced' do
+  # Exercised against the real host with a stand-in Graphics/PIXI.Application,
+  # so this checks the bridge's *effect* rather than its text. rmmz itself is a
+  # fetched, CI-only fixture and is not present in this test build.
+  MV::JS.eval(
+    "globalThis.__mzRenderCalls = 0; " \
+    "globalThis.Graphics = { _app: { render: function () { " \
+    "__mzRenderCalls++; } } };"
+  )
+  MV::JS.eval(MZ.render_skip_bridge_js)
+
+  # Armed by default: the wrapped app.render() must not reach the real one.
+  assert_equal true, MV::JS.eval("Graphics.__mzSkipRender")
+  MV::JS.eval("Graphics._app.render();")
+  assert_equal 0, MV::JS.eval("__mzRenderCalls")
+
+  # Flipping the flag off (as a live game, or #present's real-play path, would
+  # leave it) lets frames through again.
+  MV::JS.eval("Graphics.__mzSkipRender = false; Graphics._app.render();")
+  assert_equal 1, MV::JS.eval("__mzRenderCalls")
+
+  # __mzForceRender reaches the real render regardless of the flag — this is
+  # what MZ#force_render_before_capture calls right before a screenshot, so a
+  # capture on a skip-armed run still shows the current frame.
+  MV::JS.eval("Graphics.__mzSkipRender = true;")
+  MV::JS.eval("Graphics.__mzForceRender();")
+  assert_equal 2, MV::JS.eval("__mzRenderCalls")
+
+  # Idempotent: re-evaluating (boot_probe guards on this too, but the bridge
+  # must not misbehave if it were ever run twice) leaves the real render
+  # called exactly once per forced/unsuppressed call, not twice.
+  MV::JS.eval(MZ.render_skip_bridge_js)
+  MV::JS.eval("Graphics.__mzForceRender();")
+  assert_equal 3, MV::JS.eval("__mzRenderCalls")
+end
+
 assert 'MZ.message_probe_js queues text through $gameMessage' do
   # Exercised against the real host with a stand-in $gameMessage, so this checks
   # the injection's *effect*: it must call the engine's own Game_Message#add


### PR DESCRIPTION
## Summary
- Follow-up to #487 (the `--no_render_wait` frame-pacing fix): profiling `data/mz-sample`'s `play` mode showed PIXI's software-rasterised WebGL render (`Graphics._app.render`) at ~95% of the JS pump's per-frame time, dwarfing the actual game-logic update.
- Every `mz_boot_check.bash` mode only ever reads pixels once — the one screenshot it captures — so a `--no_render_wait` run now wraps `Graphics._app.render` and suppresses it on every frame but that one, forcing a real render right before the capture so it matches an unskipped run exactly.
- Scene transitions, fades, and animation counters live entirely in `SceneManager.updateMain` (the update half of the tick), never in `render()`, so game state at capture time is unaffected — only the wasted intermediate renders are skipped.

## Key changes
- `mruby-mvjs/mrblib/mz.rb`: new `RENDER_SKIP_BRIDGE_JS` bridge (installed once `Graphics._app` exists, right after `SceneManager.run`), `#render_skip_enabled?` (reuses the existing `NO_RENDER_WAIT` constant), `#present` now a no-op on render-skip runs (nothing watches the on-screen bitmap headlessly), and `#maybe_screenshot` forces one real render immediately before reading the WebGL FBO.
- `mruby-mvjs/test/mz_test.rb`: unit tests exercising the bridge's text and its effect against a stand-in `Graphics`/PIXI.Application (suppressed by default, unsuppressed on flag flip, force-render bypasses the flag, idempotent re-eval).
- `changelog.d/mz-headless-render-skip.added.md`.

## Test plan
- [x] `ctest --test-dir build -R mruby_test` (includes the new `mz_test.rb` specs) — passing
- [x] All 14 `scripts/mz_boot_check.bash` modes (play, message, equip, message_play, shop, encounter, common, transfer, menu, menu_play, animation, save, battle, battle_play) — all `OK`
- [x] `scripts/mz_frame_check.rb ss` cross-mode sweep — 54 checks, 0 failures (including the animation-burst and encounter-battle content checks)
- [x] `play` mode's captured screenshot is byte-identical to a non-render-skip capture
- [x] Timing: `play` mode dropped from ~6.2s to ~2.1s on this host; the full 14-mode matrix finished in well under a minute total

https://claude.ai/code/session_01WrH5AFgsg2p9ZU37drWqqg


---
_Generated by [Claude Code](https://claude.ai/code/session_01WrH5AFgsg2p9ZU37drWqqg)_