### PR TITLE
Confirm Jump to Label matches all three documented yado.tk facts

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1584,6 +1584,20 @@ following this paragraph as the original record.
   event selection: `Game::BattlePage.select_all` runs **every** satisfied
   page once per turn, lower page number first, vs. `Game::EventPage.select`
   picking only the single highest-numbered page for map/common events.
+- **Jump to Label already matches the three documented yado.tk facts.**
+  `Game::Interpreter#do_jump_label` does a linear scan of `@list` (the
+  current page/common-event's own flat command array) from index 0 and
+  returns on the first `Label` command whose id matches, which is all three
+  claims at once: it can only ever land inside the *same* block since
+  nothing else is searched (no cross-page/event list exists to jump into);
+  it works from any position because the scan always restarts at 0
+  regardless of where `@index` currently sits, so a jump issued before,
+  after, or anywhere around the target label finds it the same way; and a
+  duplicate label id always resolves to the first (topmost) occurrence
+  because `each_with_index` returns on its first match. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a duplicate-label jump lands on the
+  earlier one, not the later one; a jump issued mid-block, not as the first
+  command, still finds its target and skips the commands in between).
 - **Change Menu Prohibit already persists across map transfers; Change Save
   Prohibit and Teleport/Escape Prohibit already do not** (yado.tk: a real,
   asymmetric rule across three similar-sounding commands). Confirmed by
@@ -1796,9 +1810,6 @@ Everything below is unverified against the codebase.
   battle; opening it pauses *all* event processing including active
   timers/parallel processes; Erase Screen's black-out is undone if the
   player opens and closes the menu.
-- **Label** — only jumps within the same Event Content block (not across
-  events/pages); works from anywhere in the block; a duplicate label number
-  always jumps to the first (topmost) occurrence.
 - **Load** — resuming mid-Autorun/mid-Parallel-Process picks up exactly
   where it left off, *unless* the map was edited/re-saved since, in which
   case that event restarts from the top (edge case, likely not applicable

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1166,6 +1166,43 @@ check 'a Conditional Branch costs one step when matched, two when not' do
      '10000 steps / 2 per miss, with no separate End Branch dispatch to pay for'
 end
 
+check 'Jump to Label targets the first (topmost) occurrence of a duplicate label' do
+  # do_jump_label scans @list from the top and returns on the first match, so
+  # a duplicate label id always resolves to the earlier one -- confirmed by
+  # having a Jump to Label choose between two Label 1 markers and checking
+  # which side's variable write actually ran.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::JUMP_TO_LABEL, [1], indent: 0),               # 0: jump to label 1
+    FakeCmd.new(IC::LABEL, [1], indent: 0),                       # 1: first label 1 (correct target)
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 0), # 2: variable 1 = 1
+    FakeCmd.new(IC::JUMP_TO_LABEL, [9], indent: 0),               # 3: skip past the duplicate
+    FakeCmd.new(IC::LABEL, [1], indent: 0),                       # 4: duplicate label 1 (must never be the target)
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 99], indent: 0), # 5: would prove the duplicate ran
+    FakeCmd.new(IC::LABEL, [9], indent: 0),                       # 6: end marker
+    FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 0, 1], indent: 0), # 7: variable 2 = 1 (reached the end)
+  ])
+  it.update
+  eq 1, st.variables[1], 'landed on the first Label 1, not the duplicate'
+  eq 1, st.variables[2], 'execution continued on to complete normally'
+end
+
+check 'Jump to Label works from any position in the block, not just the start' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 5], indent: 0),  # 0: variable 1 = 5 (runs before the jump)
+    FakeCmd.new(IC::JUMP_TO_LABEL, [7], indent: 0),                # 1: jump to label 7, mid-block
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 999], indent: 0), # 2: dead code, must be skipped
+    FakeCmd.new(IC::LABEL, [7], indent: 0),                        # 3: label 7
+    FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 0, 1], indent: 0),  # 4: variable 2 = 1
+  ])
+  it.update
+  eq 5, st.variables[1], 'the jump skipped the dead command instead of falling through to it'
+  eq 1, st.variables[2], 'and landed on the label to run what follows it'
+end
+
 check 'Call Event with no resolver set is a safe no-op' do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

`docs/TODO.md` listed three unverified Label/Jump to Label quirks from yado.tk: it only jumps within the same block (not across events/pages), it works from anywhere in the block, and a duplicate label id always resolves to the first (topmost) occurrence.

`Game::Interpreter#do_jump_label` already gets all three right: it does a linear scan of `@list` (the current page/common-event's own flat command array) from index 0 and returns on the first `Label` command whose id matches.

- **Same block only** — there's no cross-list search at all; `@list` is whatever command array `Interpreter#start` was given, so a jump can only ever land inside it.
- **Works from anywhere** — the scan always restarts at index 0 regardless of where `@index` currently sits, so a jump issued before, after, or anywhere around the target label finds it the same way.
- **Duplicate → first occurrence** — `each_with_index` returns on its first match.

## Changes

- No production code changed — this was already correct.
- Added two new `scripts/rpg2k_logic_check.rb` checks: a duplicate-label jump lands on the earlier `Label`, not the later one; a jump issued mid-block (not as the first command) still finds its target and skips the commands in between.
- Moved the item from the yado.tk untriaged backlog to a confirmation note in `docs/TODO.md`.

## Testing

- `scripts/rpg2k_logic_check.rb`: 617 checks passing (2 new).
- `scripts/rpg2k_scene_check.rb`: 279 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_