### PR TITLE
Confirm overlapping events resolve Get Event ID to the highest id

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1745,10 +1745,18 @@ Everything below is unverified against the codebase.
   built-in command. (Party caps at 4, Change Party Member no-ops past that —
   now fixed, see above.)
 - **Processing order** — map/common events process in ascending id order;
-  "Get Event ID at coordinates" on overlapping events returns the
-  **highest** id, not lowest/topmost-drawn; only one event/parallel-process
-  advances per tick engine-wide (round robin, not true concurrency) — a
-  process that hits Wait/Show-Text yields to the others that tick.
+  only one event/parallel-process advances per tick engine-wide (round
+  robin, not true concurrency) — a process that hits Wait/Show-Text yields
+  to the others that tick. **"Get Event ID at coordinates" on overlapping
+  events resolving to the highest id is confirmed already correct**:
+  `Scene::Map#build_events` walks the map's event table (`LCF::Array2D`,
+  always ascending id — a plain Ruby Array iterated low to high) into
+  `@events` in that order, and `#rebuild_event_tiles` writes
+  `@event_tiles[[x, y]]` once per event in that same order, so the *last*
+  write — the highest id — is what ends up on a shared tile and what
+  `event_id_at` reads back; nothing sorts by draw order or picks the
+  lowest/topmost. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  (two events sharing a tile, `Store Event ID` resolves to the higher one).
 - **Battle Animation** — only one can display at once (second supersedes);
   each frame is exactly 1/30s; targeting a Vehicle position reads that
   vehicle's live x/y even from a different map than the one shown.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2036,6 +2036,23 @@ check 'Store Terrain / Event ID query the map through the scene' do
   eq 0, st.variables[3], 'no event at the empty tile'
 end
 
+check 'Store Event ID resolves two events on the same tile to the highest id' do
+  # A real map's event table is id-indexed and always iterates ascending
+  # (LCF::Array2D#each), so #rebuild_event_tiles -- last write to a shared
+  # tile wins -- always leaves the *highest*-id event as what a query
+  # resolves to, matching yado.tk's "Get Event ID at coordinates on
+  # overlapping events returns the highest id, not lowest/topmost-drawn".
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::STORE_EVENT_ID, [0, 3, 1, 2])]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(3, 1, page),
+                      5 => event(3, 1, page) },
+                    player: [5, 5])
+  10.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  eq 5, st.variables[2], 'the higher-id event wins the shared tile, not the lower one'
+end
+
 check 'Proceed With Movement holds the interpreter until a forced route finishes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

`docs/TODO.md` flagged this as an unverified yado.tk quirk: "Get Event ID at coordinates" on overlapping events returns the **highest** id, not lowest/topmost-drawn.

It was already correct by construction:

- `Scene::Map#build_events` walks the map's event table (`LCF::Array2D`, a plain Ruby Array iterated low to high via `each_with_index` — always ascending id) into `@events` in that order.
- `#rebuild_event_tiles` writes `@event_tiles[[x, y]]` once per event in that same order, so the *last* write to a shared tile is always the highest id — and that's what `event_id_at` reads back.

Nothing sorts by draw order or picks the lowest/topmost; it falls out entirely from ascending iteration + last-write-wins.

## Changes

- No production code changed — this was already correct.
- Added a new `scripts/rpg2k_scene_check.rb` check: two stationary events sharing a tile, `Store Event ID` resolves to the higher one.
- Moved the item into a confirmation note in `docs/TODO.md`.

## Testing

- `scripts/rpg2k_scene_check.rb`: 280 checks passing (1 new).
- `scripts/rpg2k_logic_check.rb`: 617 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_