### PR TITLE
Confirm pictures composite in ascending id order, independent of show order

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1803,14 +1803,14 @@ Everything below is unverified against the codebase.
 - **Battle Event** — separate command set from Map/Common events entirely;
   no Pictures on the battle screen; Parallel Process can't run in battle;
   no further pages run once battle ends.
-- **Picture** — 50 independent slots, higher id draws on top; map/characters
-  always draw below all Pictures, Battle Animation + text window always
-  above; none show on Menu/Battle screens; halted entirely while a text
+- **Picture** — none show on Menu/Battle screens; halted entirely while a text
   window is up; **changing maps clears all Pictures — except via Teleport
   or Escape (skill/item), which don't clear them**; semi-transparent
   (1-99%) opacity costs noticeably more than fully opaque/transparent;
   Erase Picture is instant (no fade) — a gradual fade needs Move Picture to
-  the same spot at 0% opacity instead.
+  the same spot at 0% opacity instead. (50 slots with the higher id always
+  drawing on top, independent of show order, is confirmed already correct —
+  see below.)
 - **Map Event** — "hero touches event" does *not* fire in three specific
   cases: (a) the event has already logically started moving into its next
   tile (hit-test uses the target tile, even if the sprite still visually
@@ -2020,10 +2020,18 @@ not yet verified:
   `\S[]` clamps).
 
 **Pictures**
-- 50 concurrent picture slots; **higher id always draws on top**,
-  independent of show order. Map/characters always draw below all
-  pictures; Battle Animation and the text window always above all
-  pictures.
+- ✅ **50 concurrent picture slots; higher id always draws on top,
+  independent of show order — confirmed already correct.**
+  `Scene::Map#draw_pictures` composites `@state.pictures.keys.sort`, so the
+  lowest id is always drawn first and the highest id lands on top of it
+  regardless of the order Show Picture commands ran in; nothing sorts by
+  show/insertion order. The text window sits above the picture layer too
+  (`@picture_sprite.z = 250`, the message window's `z = 300`), already
+  covered by an existing check. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (two pictures shown out of id order,
+  asserting the composite draws the lower id first). Still open: Battle
+  Animation drawing above the picture layer specifically, and "map/
+  characters always draw below all pictures" as its own assertion.
 - Changing maps **auto-clears every picture** — except when the transfer
   was via Teleport or Escape, which is an explicit, deliberate exception
   (multiply corroborated).

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -52,7 +52,11 @@ module RGSS
     def blt(*a); (@blt_calls ||= []) << a; end
     attr_reader :blt_calls
     def clear_blt_calls; @blt_calls = []; end
-    def stretch_blt(*); end
+    # Recorded so the picture layering check can assert *which order* sources
+    # were composited in, not only that drawing happened.
+    def stretch_blt(*a); (@stretch_calls ||= []) << a; end
+    attr_reader :stretch_calls
+    def clear_stretch_calls; @stretch_calls = []; end
     # Record the tone a Flash Sprite pass asks for, so the flash checks can
     # assert the colour actually reached the renderer.
     def tone_blt(src, tone); (@tone_calls ||= []) << [src, tone]; self; end
@@ -2283,6 +2287,27 @@ check 'a shown picture renders through the scene and its move advances' do
   6.times { scene.update }
   ok !st.pictures_moving?, 'the move completed under the scene loop'
   eq 60, st.pictures[1].y, 'the picture reached its target'
+end
+
+check 'pictures composite in ascending id order, independent of show order' do
+  # yado.tk: 50 concurrent picture slots, higher id always draws on top,
+  # independent of show order. Shown here in the opposite order (2 then 1) so
+  # a pass that composited by show/insertion order instead of by id would
+  # fail this.
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  st.show_picture(2, name: 'picB', x: 160, y: 120, zoom: 100, opacity: 255)
+  st.show_picture(1, name: 'picA', x: 160, y: 120, zoom: 100, opacity: 255)
+  bmp = scene.instance_variable_get(:@picture_bmp)
+  bmp.clear_stretch_calls
+  scene.update
+  srcs = bmp.stretch_calls.map { |c| c[1] } # stretch_blt(dest, src, src_rect, opacity)
+  eq 2, srcs.size, 'both pictures drew'
+  # Picture 1 (id 1) composites first, so picture 2 (higher id) ends up on top.
+  pic_a_src = scene.send(:picture_src, 'picA', false)
+  pic_b_src = scene.send(:picture_src, 'picB', false)
+  eq [pic_a_src, pic_b_src], srcs,
+     'lower id drawn first, higher id drawn last (on top), regardless of show order'
 end
 
 check 'a toned picture is tinted before it is composited' do


### PR DESCRIPTION
## Summary

`docs/TODO.md` listed this as an unverified yado.tk quirk (stated in two places): 50 concurrent picture slots, higher id always draws on top regardless of show order.

`Scene::Map#draw_pictures` already gets this right: it composites `@state.pictures.keys.sort` every frame, so the lowest id is always drawn first and the highest id lands on top of it — nothing sorts by show/insertion order, and the Hash the pictures live in doesn't need to. The text window sitting above the picture layer (`@picture_sprite.z = 250`, below the message window's `z = 300`) was already covered by an existing check.

## Changes

- No production code changed — this was already correct.
- Extended the mock `Bitmap#stretch_blt` in `scripts/rpg2k_scene_check.rb` (previously a no-op) to record its calls the same way `blt` already does.
- Added a new check: show picture 2 before picture 1 (deliberately reversed), then assert the composite still draws picture 1's source first and picture 2's last — proving draw order follows id, not show order.
- Moved the confirmed clause out of both yado.tk bullets that stated it, leaving the still-open sub-claims (Battle Animation drawing above pictures, map/characters below pictures, the map-clear-on-teleport exception, opacity cost, Erase Picture fade) in place for future triage.

## Testing

- `scripts/rpg2k_scene_check.rb`: 281 checks passing (1 new).
- `scripts/rpg2k_logic_check.rb`: 617 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_