### PR TITLE
Roll a batch Control Variables random-assign independently per variable

### DIFF
--- a/changelog.d/rpg2k-control-vars-batch-random-independent.fixed.md
+++ b/changelog.d/rpg2k-control-vars-batch-random-independent.fixed.md
@@ -1,0 +1,8 @@
+- RPG Maker 2000: a batch (range) **Control Variables** random-assign now
+  rolls independently for each variable in the range, matching RPG_RT —
+  `Var[1..5] = random 1~6` is five separate dice, not one roll broadcast to
+  all five. `Game::Interpreter#do_control_vars` used to evaluate its operand
+  once before the range loop and reuse that single value for every id;
+  harmless for a constant or a variable/item/actor read, but wrong for the
+  random operand. Every other operand type keeps its existing once-up-front
+  evaluation. Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1576,6 +1576,19 @@ following this paragraph as the original record.
   join; leaving and rejoining once a slot frees up still works, and nothing
   about `remove_actor` or the roster's rejoin-with-preserved-state changed.
   Covered by a new `scripts/rpg2k_logic_check.rb` check.
+- ✅ **A batch (range) Control Variables random-assign now rolls
+  independently per variable**, not once for the whole group.
+  `Game::Interpreter#do_control_vars` computed its operand value a single
+  time before the range loop and applied that one value to every id in the
+  range — harmless for a constant or a variable/item/actor read, but wrong
+  for a random operand (type 3), where `Var[1..5] = random 1~6` must be five
+  separate dice, not one roll broadcast to all five. The random case is now
+  re-evaluated per id inside the loop; every other operand type keeps its
+  existing once-up-front evaluation, since nothing establishes RPG_RT
+  re-reads a *non-random* source per id (a self-referential range reading a
+  variable inside its own write range is a different, unverified question).
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (a wide-range batch
+  assign must not produce the same value in every variable).
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
@@ -2010,8 +2023,8 @@ not yet verified:
 - **Batch (range) operations require ascending order or silently no-op** —
   for both switches and variables, if the high end of a `[a〜b]` range is
   smaller than the low end, the whole command does nothing (no error).
-  A batch **random-assign** rolls *independently per variable* in the
-  range, not once for the whole group.
+  (A batch **random-assign** rolling independently per variable, not once
+  for the whole group, used to be a real gap here — now fixed, see below.)
 - The built-in random-number operand is a genuine non-seeded RNG (two New
   Games produce different sequences) and accepts negative ranges.
 - `\N[]`/`\V[]` control codes can nest (`\N[\V[1]]`), but only on

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1226,8 +1226,13 @@ module Game
     def do_control_vars(cmd)
       a, b = range(cmd)
       op = cmd.param(3)  # 0 =, 1 +, 2 -, 3 *, 4 /, 5 %
-      val = operand_value(cmd)
-      (a..b).each { |id| variables[id] = apply(op, variables[id], val) }
+      # A random operand (type 3) rolls independently for each variable in the
+      # range, matching RPG_RT -- a batch "Var[1..5] = random 1~6" is five
+      # separate dice, not one roll broadcast to all five. Every other operand
+      # type is evaluated once up front, as before.
+      random = cmd.param(4) == 3
+      val = operand_value(cmd) unless random
+      (a..b).each { |id| variables[id] = apply(op, variables[id], random ? operand_value(cmd) : val) }
     end
 
     def operand_value(cmd)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3628,6 +3628,22 @@ check 'Control Variables random operand stays within its range' do
   end
 end
 
+check 'Control Variables batch random-assign rolls independently per variable' do
+  # RPG_RT rolls a fresh random value for each variable in a range assign,
+  # not once for the whole batch -- a range [1..5] = random 1~1000000 is five
+  # separate dice, not one broadcast value. A wide range makes two equal
+  # rolls astronomically unlikely, so any duplicate across the batch would
+  # mean the same draw got copied everywhere instead of being reused.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # mode 1 (range): ids 1..5, op 0 (set), operand type 3 (random), [1, 1000000].
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [1, 1, 5, 0, 3, 1, 1_000_000])])
+  it.update
+  vals = (1..5).map { |id| st.variables[id] }
+  ok vals.all? { |v| v >= 1 && v <= 1_000_000 }, "a value fell outside the range: #{vals}"
+  ok vals.uniq.size > 1, "every variable in the batch got the same roll: #{vals}"
+end
+
 check 'Control Variables reads party gold and the timer (operand type 7)' do
   st = new_state
   st.party.gain_gold(500)


### PR DESCRIPTION
## Summary

yado.tk's Control Variables backlog note (`docs/TODO.md`): *"A batch random-assign rolls independently per variable in the range, not once for the whole group."*

`Game::Interpreter#do_control_vars` evaluated its operand once before the range loop and reused that single value for every id in the range. Harmless for a constant or a variable/item/actor read, but wrong for the random operand (type 3): `Var[1..5] = random 1~6` was rolling **one** die and copying it into all five variables, instead of five separate dice.

## Changes

- The random operand case (`cmd.param(4) == 3`) is now re-evaluated per id inside the range loop.
- Every other operand type keeps its existing once-up-front evaluation — nothing establishes RPG_RT re-reads a *non-random* source per id (a self-referential range reading a variable inside its own write range is a different, unverified question, left untouched).

## Testing

- `scripts/rpg2k_logic_check.rb`: 618 checks passing (1 new — a wide-range batch random assign, asserting the resulting variables aren't all identical). Verified the new check actually fails against the pre-fix code (every variable landing on the same roll) before confirming the fix.
- `scripts/rpg2k_scene_check.rb`: 281 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-control-vars-batch-random-independent.fixed.md`.
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby runtime-logic fix covered by the harness above).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_