### PR TITLE
Confirm a descending batch range silently no-ops for Switches/Variables

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2020,11 +2020,15 @@ not yet verified:
   entire `09_bug/` page on the topic). Indirect addressing's failure mode
   on an index ≤0 differs by role: the **target** form is a no-op, the
   **operand** form resolves to 0.
-- **Batch (range) operations require ascending order or silently no-op** —
-  for both switches and variables, if the high end of a `[a〜b]` range is
-  smaller than the low end, the whole command does nothing (no error).
-  (A batch **random-assign** rolling independently per variable, not once
-  for the whole group, used to be a real gap here — now fixed, see below.)
+- ✅ **Batch (range) operations requiring ascending order or silently no-op is
+  confirmed already correct.** `Game::Interpreter#range` returns a batch's
+  two ends verbatim with no ordering check, and Ruby's `(a..b).each` on a
+  descending range already iterates zero times — so a `Control Switches` or
+  `Control Variables` batch whose high end is below its low end does nothing
+  at all, matching RPG_RT, with no dedicated guard needed. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check. (A batch **random-assign** rolling
+  independently per variable, not once for the whole group, used to be a
+  real gap here — now fixed, see below.)
 - The built-in random-number operand is a genuine non-seeded RNG (two New
   Games produce different sequences) and accepts negative ranges.
 - `\N[]`/`\V[]` control codes can nest (`\N[\V[1]]`), but only on

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3644,6 +3644,29 @@ check 'Control Variables batch random-assign rolls independently per variable' d
   ok vals.uniq.size > 1, "every variable in the batch got the same roll: #{vals}"
 end
 
+check 'a descending batch range silently no-ops for both Switches and Variables' do
+  # yado.tk: a batch (range) Control Switches/Variables whose high end is
+  # below its low end does nothing at all, no error. range(cmd) returns the
+  # two ends verbatim with no ordering check, and Ruby's (a..b).each on a
+  # descending range already iterates zero times, so this holds without any
+  # dedicated guard -- confirmed here rather than assumed.
+  st = new_state
+  st.variables[2] = 7
+  st.variables[3] = 7
+  st.switches[2] = false
+  st.switches[3] = false
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CONTROL_VARS, [1, 5, 2, 0, 0, 99]),  # mode 1, a=5, b=2 (descending): set 99
+    FakeCmd.new(IC::CONTROL_SWITCHES, [1, 5, 2, 0]),     # mode 1, a=5, b=2 (descending): turn on
+  ])
+  it.update
+  eq 7, st.variables[2], 'variable 2 untouched by the descending-range batch'
+  eq 7, st.variables[3], 'variable 3 untouched by the descending-range batch'
+  eq false, st.switches[2], 'switch 2 untouched by the descending-range batch'
+  eq false, st.switches[3], 'switch 3 untouched by the descending-range batch'
+end
+
 check 'Control Variables reads party gold and the timer (operand type 7)' do
   st = new_state
   st.party.gain_gold(500)


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s yado.tk backlog listed this as an unverified claim: for both Control Switches and Control Variables, a batch (range) whose high end is below its low end does nothing at all, no error.

It was already correct by construction:

- `Game::Interpreter#range` returns a batch's two ends verbatim, with no ordering check or swap (contrast with `random_operand`, which explicitly swaps `lo`/`hi` if given backwards).
- Ruby's `(a..b).each` on a descending range already iterates zero times — no dedicated guard was ever needed for either command.

## Changes

- No production code changed — this was already correct.
- Added a new `scripts/rpg2k_logic_check.rb` check: a descending-range `Control Variables`/`Control Switches` pair, asserting every id in the would-be range is untouched.
- Marked the item confirmed in `docs/TODO.md` (right next to the batch random-assign fix from the previous PR, which this one sits beside).

## Testing

- `scripts/rpg2k_logic_check.rb`: 619 checks passing (1 new).
- `scripts/rpg2k_scene_check.rb`: 281 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_