### PR TITLE
No-op indirect Control Variables/Switches targeting on id <= 0

### DIFF
--- a/changelog.d/rpg2k-indirect-target-noop-below-1.fixed.md
+++ b/changelog.d/rpg2k-indirect-target-noop-below-1.fixed.md
@@ -1,0 +1,9 @@
+- RPG Maker 2000: **Control Variables** / **Control Switches** indirect
+  ("pointer") *target* addressing now no-ops when the resolved switch/
+  variable id is 0 or negative, instead of writing to that bogus slot.
+  `Game::Interpreter#range`'s indirect branch had no bounds check at all,
+  so a command addressed through a pointer variable holding 0 or a
+  negative number wrote to that id rather than doing nothing, the way
+  RPG_RT's target-role indirect addressing does (the operand-role read
+  side already handled this correctly via each store's own missing-key
+  default). Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1589,6 +1589,20 @@ following this paragraph as the original record.
   variable inside its own write range is a different, unverified question).
   Covered by a new `scripts/rpg2k_logic_check.rb` check (a wide-range batch
   assign must not produce the same value in every variable).
+- ✅ **Indirect ("pointer") target addressing now no-ops on a resolved id
+  ≤0**, instead of writing switch/variable slot 0 or a negative one.
+  `Game::Interpreter#range`'s mode-2 (indirect) branch resolves the pointer
+  variable's value with no bounds check at all, and `Switches`/`Variables`
+  are plain Hash-backed with no guard in their write path either — so a
+  `Control Variables`/`Control Switches` command addressed indirectly
+  through a pointer variable holding 0 or a negative number was writing to
+  that bogus key rather than doing nothing, the way RPG_RT's target-role
+  indirect addressing does (the **operand**-role read side already handled
+  this correctly, via `Variables`/`Switches`' own missing-key default).
+  `range` now returns an already-empty range for a ≤0 resolved index,
+  reusing the same "does nothing" mechanism a descending batch range
+  already relies on. Covered by a new `scripts/rpg2k_logic_check.rb` check,
+  confirmed to fail against the pre-fix code before the fix.
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
@@ -2018,8 +2032,9 @@ not yet verified:
   past the configured max (used deliberately, though the site warns large
   indices measurably slow opening the Save screen — corroborated by an
   entire `09_bug/` page on the topic). Indirect addressing's failure mode
-  on an index ≤0 differs by role: the **target** form is a no-op, the
-  **operand** form resolves to 0.
+  on an index ≤0 differs by role: the **operand** form already resolved to
+  0 (`Variables`/`Switches`' own default for a missing key); the **target**
+  form is fixed now too, see below.
 - ✅ **Batch (range) operations requiring ascending order or silently no-op is
   confirmed already correct.** `Game::Interpreter#range` returns a batch's
   two ends verbatim with no ordering check, and Ruby's `(a..b).each` on a

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1206,8 +1206,17 @@ module Game
       mode = cmd.param(0)
       a = cmd.param(1)
       b = mode == 0 ? a : cmd.param(2)
-      a = variables[cmd.param(1)] if mode == 2 # indirect: id held in a variable
-      b = a if mode == 2
+      if mode == 2 # indirect: id held in a variable
+        a = variables[cmd.param(1)]
+        # RPG_RT's indirect *target* addressing (as opposed to an indirect
+        # operand read, which resolves a missing/out-of-range id to 0) is a
+        # no-op when the resolved id is <= 0, rather than writing switch/
+        # variable slot 0 or a negative one. An already-empty range gets the
+        # same "does nothing" result do_control_switches/do_control_vars
+        # already produce for a descending batch range.
+        return [1, 0] if a <= 0
+        b = a
+      end
       [a, b]
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3667,6 +3667,26 @@ check 'a descending batch range silently no-ops for both Switches and Variables'
   eq false, st.switches[3], 'switch 3 untouched by the descending-range batch'
 end
 
+check 'indirect ("pointer") target addressing no-ops when the resolved id is <= 0' do
+  # yado.tk: indirect addressing's failure mode on an index <=0 differs by
+  # role -- the *target* form (which switch/variable id gets written) is a
+  # no-op, unlike the *operand* form (the value read), which already
+  # resolves a missing/negative id to 0 via Variables/Switches' own default.
+  st = new_state
+  st.variables[10] = 0   # a pointer variable holding 0
+  st.variables[11] = -5  # a pointer variable holding a negative id
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CONTROL_VARS, [2, 10, 0, 0, 0, 99]), # mode 2 (indirect): target = var[10] = 0
+    FakeCmd.new(IC::CONTROL_VARS, [2, 11, 0, 0, 0, 99]), # target = var[11] = -5
+    FakeCmd.new(IC::CONTROL_SWITCHES, [2, 10, 0, 0]),    # same, for switches
+  ])
+  it.update
+  ok !st.variables.to_h.key?(0), 'nothing written to variable slot 0'
+  ok !st.variables.to_h.key?(-5), 'nothing written to a negative variable slot'
+  ok !st.switches.to_h.key?(0), 'nothing written to switch slot 0'
+end
+
 check 'Control Variables reads party gold and the timer (operand type 7)' do
   st = new_state
   st.party.gain_gold(500)


### PR DESCRIPTION
## Summary

yado.tk's Switches/Variables backlog note (`docs/TODO.md`): *"Indirect addressing's failure mode on an index ≤0 differs by role: the **target** form is a no-op, the **operand** form resolves to 0."*

`Game::Interpreter#range`'s indirect (mode 2) branch resolved the pointer variable's value with no bounds check at all, and `Switches`/`Variables` are plain Hash-backed with no guard in their write path either — so a `Control Variables`/`Control Switches` command addressed indirectly through a pointer variable holding 0 or a negative number was writing to that bogus key rather than doing nothing. The operand-role read side already handled this correctly, via `Variables`/`Switches`' own missing-key default (`@data[id] || 0`/`false`).

## Changes

- `range` now returns an already-empty range (`[1, 0]`) for a resolved indirect index ≤0, reusing the same "does nothing" mechanism a descending batch range (`a > b`) already produces via `(a..b).each` — no changes needed in `do_control_switches`/`do_control_vars` themselves.

## Testing

- `scripts/rpg2k_logic_check.rb`: 620 checks passing (1 new — indirect targeting through pointer variables holding `0` and `-5`, asserting nothing gets written to those switch/variable slots). Verified the new check actually fails against the pre-fix code (writes landing on slot `0` and a negative slot) before confirming the fix.
- `scripts/rpg2k_scene_check.rb`: 281 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-indirect-target-noop-below-1.fixed.md`.
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby runtime-logic fix covered by the harness above).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_