### PR TITLE
Confirm Call Event has no indirect mode for a common-event id

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1611,6 +1611,18 @@ following this paragraph as the original record.
   event selection: `Game::BattlePage.select_all` runs **every** satisfied
   page once per turn, lower page number first, vs. `Game::EventPage.select`
   picking only the single highest-numbered page for map/common events.
+- **Call Event has no indirect mode for a common-event id, matching
+  RPG2000's own editor.** `Game::Interpreter#resolve_call`'s mode 0 (common
+  event) arm always reads `cmd.param(1)` literally; only mode 2 (map event)
+  reads its ids out of variables (`map_event_call(variables[cmd.param(1)],
+  variables[cmd.param(2)])`). RPG2000's Call Event dialog genuinely offers
+  no "select the common event indirectly" option, so a designer wanting a
+  variable-selected common event has to build an if/elsif dispatcher chain
+  of literal Call Events — this codebase's command format already mirrors
+  that constraint rather than working around it. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a variable holding a different id
+  never steers mode 0's target; mode 2 genuinely does resolve both the event
+  and the page indirectly, making the asymmetry explicit).
 - **A Parallel Process that reaches its own end already costs exactly one
   frame before its next lap starts.** `Scene::Map#step_parallel` only
   restarts a finished process (`it.start` + `it.update`) the *next* time it
@@ -1724,12 +1736,13 @@ Everything below is unverified against the codebase.
   fine; "has item X" was the actual gap, now fixed, see above.)
 - **Call Event** — doesn't move the target event, ignores its appearance
   conditions, can't cross maps, continues the *caller* right after itself
-  once the callee finishes/cancels; a variable can't pick the called
-  common-event id directly (needs a dispatcher chain); calling a bad
-  event/page id raises specific distinct error dialogs; nesting caps at
-  1000; under heavy nested-Call-Event + multi-parallel-process load,
-  processing can freeze (workaround: a Wait:0.0s before the call). Battle
-  Events can't use Call Event through the normal editor at all.
+  once the callee finishes/cancels; calling a bad event/page id raises
+  specific distinct error dialogs; nesting caps at 1000; under heavy
+  nested-Call-Event + multi-parallel-process load, processing can freeze
+  (workaround: a Wait:0.0s before the call). Battle Events can't use Call
+  Event through the normal editor at all. ("A variable can't pick the
+  called common-event id directly" is confirmed already correct — see
+  below.)
 - **Wait** — an inline "(W)" wait option is identical to a separate Wait
   command; Wait 0.0s is one frame, not zero (**confirmed correct**, see
   above).

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1239,6 +1239,39 @@ check 'Call Event on "this event" from a common event is a no-op' do
   eq true, st.switches[1], 'and the caller carries on'
 end
 
+check 'Call Event has no indirect mode for a common event id (target 0 stays literal)' do
+  # yado.tk: "a variable can't pick the called common-event id directly (needs
+  # a dispatcher chain)" -- resolve_call's mode 0 (common event) arm always
+  # reads cmd.param(1) literally; there is no mode that reads a common-event
+  # id out of a variable the way mode 2 does for a map event (below). A
+  # variable holding a different id must not steer which common event runs.
+  st = new_state
+  st.variables[1] = 6 # if this leaked into the id, common event 6 would run
+  called5 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 5, 5, 0])]
+  called6 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 6, 6, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: { 5 => called5, 6 => called6 })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0])]) # mode 0, literal id 5
+  it.update
+  eq true, st.switches[5], 'the literal id (5) ran'
+  eq false, st.switches[6], 'the id sitting in variable 1 (6) was never consulted'
+end
+
+check 'Call Event mode 2 picks a map event and page indirectly through variables' do
+  # The map-event target genuinely does support indirect addressing (mode 2:
+  # "ids taken indirectly from variables"), unlike the common-event target
+  # above -- the asymmetry the yado.tk quirk describes.
+  st = new_state
+  st.variables[1] = 7 # event id
+  st.variables[2] = 2 # page number
+  page2 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(maps: { 7 => { 2 => page2 } })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [2, 1, 2])]) # mode 2, ids from var 1 / var 2
+  it.update
+  eq true, st.switches[9], 'the event/page named by the variables ran'
+end
+
 check 'Erase Event sets a one-shot request without pausing the interpreter' do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s Call Event backlog note: *"a variable can't pick the called common-event id directly (needs a dispatcher chain)."*

`Game::Interpreter#resolve_call` already gets this right: mode 0 (common event) always reads `cmd.param(1)` literally, and only mode 2 (map event) reads its ids out of variables via `map_event_call(variables[cmd.param(1)], variables[cmd.param(2)])`. RPG2000's own Call Event dialog offers no "select the common event indirectly" option, so this is a real editor constraint rather than a gap — a designer wanting a variable-selected common event has to build an if/elsif dispatcher chain of literal Call Events, and this codebase's command format already mirrors that rather than working around it.

## Changes

- No production code changed — this was already correct.
- Added two new `scripts/rpg2k_logic_check.rb` checks:
  - A variable holding a *different* id than the literal target must never steer which common event a mode-0 Call Event runs.
  - Mode 2 genuinely does resolve both the event id and the page indirectly through variables, making the documented asymmetry explicit and regression-locked (not just "mode 0 is broken," but "mode 0 correctly has no such path, unlike mode 2").
- Moved the item into a "Confirmed already correct" note in `docs/TODO.md`.

## Testing

- `scripts/rpg2k_logic_check.rb`: 622 checks passing (2 new).
- `scripts/rpg2k_scene_check.rb`: 281 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_