### PR TITLE
Reassert an event's page Move Frequency once a forced route finishes

### DIFF
--- a/changelog.d/rpg2k-move-frequency-reasserts-after-forced-route.fixed.md
+++ b/changelog.d/rpg2k-move-frequency-reasserts-after-forced-route.fixed.md
@@ -1,0 +1,7 @@
+- RPG Maker 2000: an event's Move Frequency, as configured on its page, now
+  reasserts itself once a forced Move Route (Move Event / Set Move Route)
+  finishes, instead of staying at whatever a `Frequency Up`/`Frequency Down`
+  sub-command inside that route last left it at. `Scene::Map#step_event`
+  only set `move_frequency` from the page when the page was (re)built, so a
+  frequency change made mid-route leaked into whatever paced the event
+  afterwards. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2010,9 +2010,20 @@ not yet verified:
   transfer, unlike the dedicated Change Graphic event commands. (Already
   fixed for the hero this session; vehicles and, per one source, non-hero
   page-level graphic reverts on leave/return too, are not yet checked.)
-- Move Frequency set via a page always **reasserts itself** once a Move
-  Route's own route finishes — the page's own frequency wins going
-  forward, not the route's last-set value.
+- ✅ **Move Frequency set via a page now reasserts itself once a forced Move
+  Route finishes** — the page's own frequency wins going forward, not
+  whatever a Frequency Up/Down sub-command left it at. `Scene::Map#step_event`
+  set an event's `move_frequency` from its page only when the page was
+  (re)built, so a Move Event's route bumping frequency via `Frequency Up`/
+  `Frequency Down` leaked into whatever paced the event afterwards — an
+  autonomous move type, or a later route with no explicit override. The
+  moment a forced route finishes (`e[:forced_route] = nil`, already the
+  "revert to page movement" point), `move_frequency` is now reset from the
+  page too. Scoped to a forced route only — a page's *own* custom route
+  (`move_type: CUSTOM`) reasserting nothing is a different, unverified
+  question, since there is no separate "page movement" for it to revert to.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check, confirmed to fail
+  against the pre-fix code before the fix.
 - "Cancel All Designated Moves" aborts in-progress routes without
   unwinding side effects: a route cancelled mid-"Through Mode: Begin"
   leaves the character stuck pass-through; cancelling during an active

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1118,7 +1118,14 @@ class RPG2k
         oy = ch.y
         if forced
           forced.step(ch, @world) unless forced.done?
-          e[:forced_route] = nil if forced.done? # revert to page movement
+          if forced.done? # revert to page movement
+            e[:forced_route] = nil
+            # The page's own Move Frequency reasserts itself once the forced
+            # route finishes -- a Frequency Up/Down sub-command inside that
+            # route must not go on pacing the event after control reverts to
+            # its page, only for the duration of the route that issued it.
+            ch.move_frequency = page_move_frequency(e[:page])
+          end
         elsif e[:route]
           e[:route].step(ch, @world) unless e[:route].done?
         else

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1407,6 +1407,25 @@ check 'Move Event with "this event" moves the running event itself' do
   eq 2, c.x, 'it stayed on its column'
 end
 
+check 'Move Frequency reasserts the page value once a forced route finishes' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target event 2, freq 8 (route pacing), repeat off, skippable on: bump
+  # frequency twice then take one step, so the route finishes rather than
+  # looping forever.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT,
+    [2, 8, 0, 1, R::FREQ_UP, R::FREQ_UP, R::MOVE_RIGHT])]
+  target_page = page(frequency: 3) # the page's own configured frequency
+  mover = event(1, 1, target_page)
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => mover }, player: [5, 0])
+  eq 3, chars(scene)[2].move_frequency, 'starts at the page frequency'
+  40.times { scene.update }
+  ok chars(scene)[2].x > 1, 'the forced route ran and moved the event'
+  eq 3, chars(scene)[2].move_frequency,
+     'the page frequency reasserts itself once the forced route finishes, ' \
+     'not the Frequency Up value the route left it at'
+end
+
 check 'a forced player route suppresses input while it runs' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

yado.tk's Move Route backlog note (`docs/TODO.md`): *"Move Frequency set via a page always reasserts itself once a Move Route's own route finishes — the page's own frequency wins going forward, not the route's last-set value."*

`Scene::Map#step_event` only set an event's `move_frequency` from its page when the page was (re)built. A forced route (Move Event / Set Move Route) can bump it via a `Frequency Up`/`Frequency Down` sub-command, and once that route finished nothing reset it — the bumped value leaked into whatever paced the event afterwards (an autonomous move type, or a later route with no explicit override).

## Changes

- The moment a forced route finishes — already the "revert to page movement" point where `e[:forced_route]` is cleared — `move_frequency` is now reset from the page too.
- Scoped to a forced route only: a page's own custom route (`move_type: CUSTOM`) reasserting nothing is a different, unverified question, since there is no separate "page movement" for it to revert to.

## Testing

- `scripts/rpg2k_scene_check.rb`: 282 checks passing (1 new — a Move Event route that bumps frequency twice then finishes, asserting the event's `move_frequency` returns to the page's configured value rather than staying at the bumped one). Verified the new check actually fails against the pre-fix code (frequency stuck at the bumped value) before confirming the fix.
- `scripts/rpg2k_logic_check.rb`: 622 checks passing (unaffected, included for completeness).
- Documented in `changelog.d/rpg2k-move-frequency-reasserts-after-forced-route.fixed.md`.
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby scene-logic fix covered by the harness above).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_