### PR TITLE
Draw the scroll and combine/division screen transitions for real

### DIFF
--- a/changelog.d/rpg2k-transition-scroll-combine.added.md
+++ b/changelog.d/rpg2k-transition-scroll-combine.added.md
@@ -1,0 +1,22 @@
+- **Erase / Show Screen's scroll and combine / division styles now paint real
+  pixels.** They used to run as a plain fade of the right length, the wrong
+  texture, on the assumption they needed a screen capture the renderer does not
+  have — `RGSS::Graphics.snap_to_bitmap` already exists and is what the RPG
+  Maker XP scene uses for its own transitions (see the prior "transition
+  blocker correction" note). `Scene::Map` now snapshots the screen once when
+  one of these starts and blits the capture back sliding into (or out of)
+  place every frame: the four scroll directions paste the whole capture at a
+  sliding offset, and vertical / horizontal / cross combine and division split
+  it into two (or four, for cross) pieces that slide together or apart.
+  `Game::Transition` stays pure logic — it only computes where each piece
+  goes (`#capture_ops`); Scene::Map does the actual blitting and disposes the
+  snapshot once the transition ends. Cross combine/division's exact quadrant
+  motion is this build's own reading (diagonal from each screen corner),
+  reasoned from the vertical/horizontal pair rather than confirmed against
+  RPG_RT, since neither test bed exercises that specific style. Zoom / mosaic /
+  wave and random blocks still fall through to the plain fade: zoom's own
+  in/out direction has nothing in either test bed to confirm it against, mosaic
+  and wave want a native per-pixel resample, and random blocks wants RPG_RT's
+  incremental per-frame block paint. Covered by new checks in
+  `scripts/rpg2k_scene_check.rb` (snapshot caching, per-style geometry at the
+  start and end of a transition, and the no-snapshot-backend fallback).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1152,9 +1152,10 @@ The work below is roughly ordered by the critical path to a walkable game
   and it answers nil there), and the **RPG Maker XP scene already uses it**
   (`mruby-rpgxp/mrblib/scene.rb`) for exactly this — its own transitions.** The
   same mistake as the fade/flash note below: a capability assumed missing that
-  was already there. What is actually left per style:
+  was already there. What was left per style (scroll and combine / division are
+  now done — see below):
 
-  - **Scroll (settings 9–12)** and **combine / division (13–15)**: capture the
+  - ✅ **Scroll (settings 9–12)** and **combine / division (13–15)**: capture the
     outgoing screen once when the transition starts, then each frame paint the
     overlay as the full composite — black plus the capture blitted at the
     sliding offset — rather than as a mask. `Bitmap#blt` is enough; no native
@@ -1177,6 +1178,28 @@ The work below is roughly ordered by the critical path to a walkable game
   building on it — the RPG2003 test-bed uses zoom / mosaic / wave twelve times,
   which is what makes the family worth finishing (`ruby scripts/analyze_game.rb
   --params --code 11010 data/mtf-meido-action/Debug`).
+
+  **Scroll and combine / division are done.** `Game::Transition#capture_ops`
+  computes, per style, where each piece of a captured screen goes this frame
+  (a plain offset for the four scroll directions; two sliding pieces for
+  vertical/horizontal combine and division; four for cross), staying pure
+  logic exactly like `#visible_rects` above — no `Graphics` access, so it is
+  unit-testable without a renderer. `Scene::Map#draw_captured_transition`
+  snapshots the screen once (on the frame a captured `Game::Transition`
+  instance first appears, by object identity, so a same-style transition
+  right after it still re-snapshots) and blits the pieces over a black fill
+  every frame after, disposing the snapshot once the transition ends. The
+  wrinkle above did not end up mattering in practice: a shaped transition still
+  runs a plain fade at the moment a captured one starts (the two families
+  never chain outside a hand-built sequence), so there was no erase overlay
+  hiding the scene to worry about excluding — worth revisiting if that
+  assumption stops holding. Cross combine/division's exact quadrant motion
+  (diagonal from each screen corner) is this build's own reading, not
+  confirmed against RPG_RT — neither test bed exercises that specific style,
+  so the vertical/horizontal pair's confirmed-by-name motion was extended
+  rather than guessed from nothing. Covered by new checks in
+  `scripts/rpg2k_scene_check.rb`. Zoom, mosaic/wave and random blocks are
+  still unbuilt, per the per-style breakdown above.
 
   The fade and flash overlays were listed here as blocked on `RGSS::Viewport`
   tone/alpha support in C++. **They were not**: `RGSS::Sprite#opacity` already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3943,17 +3943,30 @@ module Game
       CROSS_COMBINE, ZOOM_OUT, MOSAIC_IN, WAVE_IN, CUT_IN
     ].freeze
 
-    # Styles this build paints for real. The rest are the ones a black mask
-    # cannot express: the scrolls and the combine / division pairs slide the live
-    # scene itself, zoom / mosaic / wave resample it, and random blocks needs
-    # thousands of per-frame block blits. They run as a fade of the same length —
-    # the right duration and the right end state, the wrong texture — until the
-    # renderer can capture a screen and transform it.
+    # The scroll and combine / division styles: a black mask cannot express them
+    # (the true old/new pixels have to move), so Scene::Map instead snapshots the
+    # screen once via RGSS::Graphics.snap_to_bitmap when one of these starts and
+    # blits that capture per #capture_ops every frame -- see docs/TODO.md's
+    # "Screen effects" entry. This class stays pure logic (no Graphics access,
+    # per the SCREEN_W/H comment above): it only computes where each piece of
+    # the capture goes.
+    CAPTURED = [SCROLL_UP_IN, SCROLL_DOWN_IN, SCROLL_LEFT_IN, SCROLL_RIGHT_IN,
+                SCROLL_UP_OUT, SCROLL_DOWN_OUT, SCROLL_LEFT_OUT,
+                SCROLL_RIGHT_OUT, VERTICAL_COMBINE, VERTICAL_DIVISION,
+                HORIZONTAL_COMBINE, HORIZONTAL_DIVISION, CROSS_COMBINE,
+                CROSS_DIVISION].freeze
+
+    # Styles this build paints for real. Zoom / mosaic / wave still fall through
+    # to a plain fade: mosaic and wave want a native per-pixel resample and zoom's
+    # own IN/OUT direction (which way the picture scales) has nothing in either
+    # test bed to confirm it against, so it is left rather than guessed. Random
+    # blocks wants RPG_RT's incremental per-frame block paint, which a mask can
+    # express but this does not do yet either.
     DRAWN = [FADE_IN, FADE_OUT, BLIND_OPEN, BLIND_CLOSE, VERTICAL_STRIPES_IN,
              VERTICAL_STRIPES_OUT, HORIZONTAL_STRIPES_IN,
              HORIZONTAL_STRIPES_OUT, BORDER_TO_CENTER_IN, BORDER_TO_CENTER_OUT,
              CENTER_TO_BORDER_IN, CENTER_TO_BORDER_OUT, CUT_IN, CUT_OUT,
-             NONE].freeze
+             NONE, *CAPTURED].freeze
 
     # The highest setting index the numbering defines (20 = "no transition").
     MAX_SETTING = 20
@@ -4051,11 +4064,129 @@ module Game
       end
     end
 
+    # Whether this style is composited from a captured screen (see CAPTURED)
+    # rather than punched as a mask of the live one.
+    def captured?
+      CAPTURED.include?(@style)
+    end
+
+    # The captured screen's pieces for this frame, each `[dx, dy, sx, sy, sw,
+    # sh]` -- paste the capture's `[sx, sy, sw, sh]` region at `(dx, dy)`. Only
+    # called for a captured style; Scene::Map paints these over a black fill, so
+    # a piece that has slid off-screen just leaves black behind it.
+    def capture_ops
+      case @style
+      when SCROLL_UP_IN, SCROLL_DOWN_IN, SCROLL_LEFT_IN, SCROLL_RIGHT_IN,
+           SCROLL_UP_OUT, SCROLL_DOWN_OUT, SCROLL_LEFT_OUT, SCROLL_RIGHT_OUT
+        ox, oy = scroll_offset
+        [[ox, oy, 0, 0, @width, @height]]
+      when VERTICAL_COMBINE, VERTICAL_DIVISION
+        vertical_split_ops(@style == VERTICAL_COMBINE)
+      when HORIZONTAL_COMBINE, HORIZONTAL_DIVISION
+        horizontal_split_ops(@style == HORIZONTAL_COMBINE)
+      when CROSS_COMBINE, CROSS_DIVISION
+        cross_split_ops(@style == CROSS_COMBINE)
+      else
+        []
+      end
+    end
+
     private
 
     # The frame index the geometry is drawn at, and the span it runs over —
     # EasyRPG's `current_frame` and `total_frames - 1`.
     def span; @frames - 1; end
+
+    # `[p, d]` for the same frame0..1 linear ramp `border_to_center_rect` etc.
+    # use below, factored out for the capture-geometry helpers.
+    def frame_ratio
+      d = span
+      d <= 0 ? [1, 1] : [@frame, d]
+    end
+
+    # Scroll: the whole capture slides in from (or out to) one edge in a
+    # straight line, landing flush at (0, 0) -- RPG2000's curtain-style
+    # transition. "In" starts off-screen and ends in place (Show Screen, the
+    # arriving picture); "out" starts in place and ends off-screen (Erase
+    # Screen, the departing one), each direction sliding the way its name says.
+    def scroll_offset
+      p, d = frame_ratio
+      case @style
+      when SCROLL_UP_IN    then [0, @height - @height * p / d]
+      when SCROLL_DOWN_IN  then [0, -(@height - @height * p / d)]
+      when SCROLL_LEFT_IN  then [@width - @width * p / d, 0]
+      when SCROLL_RIGHT_IN then [-(@width - @width * p / d), 0]
+      when SCROLL_UP_OUT   then [0, -(@height * p / d)]
+      when SCROLL_DOWN_OUT then [0, @height * p / d]
+      when SCROLL_LEFT_OUT then [-(@width * p / d), 0]
+      when SCROLL_RIGHT_OUT then [@width * p / d, 0]
+      end
+    end
+
+    # Combine / division: the capture splits along one axis into two pieces
+    # that slide together (combine, a Show) or apart (division, an Erase).
+    # `top_h` / `left_w` is the first piece's share of the axis (integer half,
+    # remainder to the second piece so an odd dimension still tiles exactly).
+    def half(total)
+      h = total / 2
+      [h, total - h]
+    end
+
+    # Vertical split: a top piece and a bottom piece, sliding along y.
+    def vertical_split_ops(combine)
+      top_h, bottom_h = half(@height)
+      p, d = frame_ratio
+      if combine
+        top_dy = -top_h + top_h * p / d
+        bottom_dy = @height - bottom_h * p / d
+      else
+        top_dy = -(top_h * p / d)
+        bottom_dy = top_h + bottom_h * p / d
+      end
+      [[0, top_dy, 0, 0, @width, top_h],
+       [0, bottom_dy, 0, top_h, @width, bottom_h]]
+    end
+
+    # Horizontal split: a left piece and a right piece, sliding along x.
+    def horizontal_split_ops(combine)
+      left_w, right_w = half(@width)
+      p, d = frame_ratio
+      if combine
+        left_dx = -left_w + left_w * p / d
+        right_dx = @width - right_w * p / d
+      else
+        left_dx = -(left_w * p / d)
+        right_dx = left_w + right_w * p / d
+      end
+      [[left_dx, 0, 0, 0, left_w, @height],
+       [right_dx, 0, left_w, 0, right_w, @height]]
+    end
+
+    # Cross split: both axes at once, four quadrants each sliding diagonally
+    # from (combine) or to (division) their own screen corner. The exact
+    # quadrant motion is this build's own reading of "cross" -- reasoned from
+    # the vertical/horizontal pair rather than confirmed against RPG_RT, since
+    # neither test bed exercises this specific style.
+    def cross_split_ops(combine)
+      top_h, bottom_h = half(@height)
+      left_w, right_w = half(@width)
+      p, d = frame_ratio
+      if combine
+        top_dy = -top_h + top_h * p / d
+        bottom_dy = @height - bottom_h * p / d
+        left_dx = -left_w + left_w * p / d
+        right_dx = @width - right_w * p / d
+      else
+        top_dy = -(top_h * p / d)
+        bottom_dy = top_h + bottom_h * p / d
+        left_dx = -(left_w * p / d)
+        right_dx = left_w + right_w * p / d
+      end
+      [[left_dx, top_dy, 0, 0, left_w, top_h],
+       [right_dx, top_dy, left_w, 0, right_w, top_h],
+       [left_dx, bottom_dy, 0, top_h, left_w, bottom_h],
+       [right_dx, bottom_dy, left_w, top_h, right_w, bottom_h]]
+    end
 
     # Blinds: 8-pixel bands, each closing (or opening) from its top edge by one
     # pixel every five frames. The live band is what is left of the 8.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -312,6 +312,12 @@ class RPG2k
         # Whether the overlay currently holds a transition mask rather than the
         # solid black the opacity-only fade needs (see #draw_transition_mask).
         @fade_masked = false
+        # The screen snapshot a captured transition (scroll / combine /
+        # division, see Game::Transition::CAPTURED) composites from, and the
+        # transition object it was taken for -- so a second frame of the same
+        # transition reuses it instead of re-snapshotting every frame.
+        @transition_capture = nil
+        @captured_transition = nil
 
         @flash_sprite = Sprite.new
         @flash_sprite.z = 450
@@ -366,9 +372,13 @@ class RPG2k
       # stripes, a closing window) instead paints the bitmap: opaque black
       # everywhere, then the regions of the live scene still showing through
       # punched back out to fully transparent. `fill_rect` overwrites alpha, so
-      # the holes really are holes.
+      # the holes really are holes. A *captured* transition (scroll, combine /
+      # division) paints real pixels instead of holes -- see
+      # #draw_captured_transition.
       def draw_transition_mask(screen)
         tr = screen.transition
+        return draw_captured_transition(tr) if tr && tr.captured?
+        release_transition_capture
         if tr.nil? || tr.uniform?
           reset_fade_bitmap if @fade_masked
           @fade_sprite.opacity = screen.fade_level
@@ -383,6 +393,46 @@ class RPG2k
         # to the plain fade level, which still lands on the right end state.
         $stderr.puts "[RPG2k] screen transition draw failed: #{e.message}"
         @fade_sprite.opacity = screen.fade_level
+      end
+
+      # Paint a captured-style transition: the whole overlay is filled black,
+      # then each of the transition's #capture_ops pastes a piece of a screen
+      # snapshot at its sliding position, so a piece not yet in place just
+      # leaves the black behind it. The snapshot is taken once, the first frame
+      # this particular Game::Transition instance is drawn (identity, not
+      # value, so a same-style transition right after it still re-snapshots).
+      def draw_captured_transition(tr)
+        unless @captured_transition.equal?(tr)
+          @transition_capture.dispose if @transition_capture
+          @transition_capture = Graphics.snap_to_bitmap
+          @captured_transition = tr
+        end
+        cap = @transition_capture
+        unless cap
+          # The backend cannot snapshot (Wio/PSP, or a headless test double) --
+          # fall back to a plain fade, same as every style this build does not
+          # paint for real.
+          @fade_sprite.opacity = tr.black_alpha
+          return
+        end
+        @fade_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, OPAQUE_BLACK
+        tr.capture_ops.each do |dx, dy, sx, sy, sw, sh|
+          @fade_bmp.blt dx, dy, cap, Rect.new(sx, sy, sw, sh)
+        end
+        @fade_masked = true
+        @fade_sprite.opacity = 255
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] screen transition capture draw failed: #{e.message}"
+        @fade_sprite.opacity = tr.black_alpha
+      end
+
+      # Drop the held snapshot once no captured transition needs it -- holding
+      # a 320x240 bitmap between transitions would be a pointless leak.
+      def release_transition_capture
+        return unless @transition_capture
+        @transition_capture.dispose
+        @transition_capture = nil
+        @captured_transition = nil
       end
 
       # Restore the overlay to solid black after a shaped transition, so the

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -119,6 +119,11 @@ module RGSS
   module Graphics
     def self.frame_rate; 60; end
     def self.update; end
+    # A captured-transition check swaps this out for a Bitmap instance it can
+    # inspect (or nil, to exercise the "backend cannot snapshot" fallback);
+    # other checks never call it, since only a captured transition does.
+    class << self; attr_accessor :snapshot; end
+    def self.snap_to_bitmap; @snapshot; end
   end
 
   module Audio
@@ -4080,6 +4085,136 @@ check 'a shaped transition paints a mask into the fade layer' do
   scene.update
   eq 1, (fade.bitmap.fill_calls || []).length, 'repainted solid for the fade path'
   eq 255, fade.opacity, 'and the screen stays erased'
+end
+
+# A captured transition's blt calls are [dx, dy, src, src_rect]; this is the
+# [dx, dy] destination alone, which is what the geometry checks below compare.
+def blt_dest(call); call[0, 2]; end
+
+check 'a captured transition snapshots the screen once and blits it sliding into place' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  # Show is a no-op on an already-visible screen (#show / #erase both settle
+  # instantly onto their own target), so erase first -- same as a real Show
+  # Screen always follows some earlier Erase.
+  st.screen.erase(Game::Transition::FADE_OUT, 1)
+  2.times { scene.update }
+
+  snap = RGSS::Bitmap.new(320, 240)
+  RGSS::Graphics.snapshot = snap
+  st.screen.show(Game::Transition::SCROLL_UP_IN)
+  fade.bitmap.clear_blt_calls
+  scene.update
+  eq 255, fade.opacity, 'a captured style paints, so it is fully opaque like a mask'
+  blts = fade.bitmap.blt_calls || []
+  eq 1, blts.length, 'scroll pastes the whole capture in one piece'
+  dx, dy, src, rect = blts.first
+  eq 0, dx, 'scrolling up only moves along y'
+  ok dy > 0, 'frame 0 of scroll-up-in starts below the screen'
+  ok src.equal?(snap), 'blitted from the captured snapshot, not a fresh bitmap'
+  eq [0, 0, 320, 240], [rect.x, rect.y, rect.width, rect.height],
+     'the whole capture is the source, for a plain scroll'
+
+  # Advancing to the last frame the transition is still alive on settles it at
+  # (0, 0) -- flush, not still sliding. (One update further and Game::Screen
+  # nils the transition entirely, same as any other style once it completes;
+  # #update already spent one call above, hence frames - 3 here.)
+  mid = Game::Transition.default_frames(Game::Transition::SCROLL_UP_IN) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_blt_calls
+  scene.update
+  eq [0, 0], blt_dest(fade.bitmap.blt_calls.first), 'lands flush on the last live frame'
+
+  # The snapshot is taken exactly once per transition instance, not every frame.
+  st.screen.erase(Game::Transition::VERTICAL_DIVISION)
+  first_snap = RGSS::Bitmap.new(320, 240)
+  RGSS::Graphics.snapshot = first_snap
+  scene.update
+  RGSS::Graphics.snapshot = RGSS::Bitmap.new(320, 240) # a second snapshot, unused if caching works
+  fade.bitmap.clear_blt_calls
+  scene.update
+  ok fade.bitmap.blt_calls.all? { |c| c[2].equal?(first_snap) },
+     're-uses the snapshot taken when this transition started'
+ensure
+  RGSS::Graphics.snapshot = nil
+end
+
+check 'vertical division splits the capture into two pieces sliding apart' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  RGSS::Graphics.snapshot = RGSS::Bitmap.new(320, 240)
+
+  st.screen.erase(Game::Transition::VERTICAL_DIVISION)
+  fade.bitmap.clear_blt_calls
+  scene.update
+  blts = fade.bitmap.blt_calls
+  eq 2, blts.length, 'top half and bottom half, each their own piece'
+  top, bottom = blts
+  # Frame 1 (the first rendered frame -- #update already advanced once before
+  # drawing): barely split apart yet, close to the still-combined origin.
+  eq [0, -3], blt_dest(top), 'top half has only just started sliding up'
+  eq [0, 123], blt_dest(bottom), 'bottom half has only just started sliding down'
+  eq [0, 0, 320, 120], [top[3].x, top[3].y, top[3].width, top[3].height],
+     "the top half's own share of the capture"
+  eq [0, 120, 320, 120], [bottom[3].x, bottom[3].y, bottom[3].width, bottom[3].height],
+     "the bottom half's own share"
+
+  mid = Game::Transition.default_frames(Game::Transition::VERTICAL_DIVISION) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_blt_calls
+  scene.update
+  top, bottom = fade.bitmap.blt_calls
+  eq [0, -120], blt_dest(top), 'finished: the top half has slid fully off the top edge'
+  eq [0, 240], blt_dest(bottom), 'and the bottom half fully off the bottom edge'
+ensure
+  RGSS::Graphics.snapshot = nil
+end
+
+check 'cross combine assembles four quadrants from the screen corners' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  st.screen.erase(Game::Transition::FADE_OUT, 1) # show is a no-op unless erased first
+  2.times { scene.update }
+  RGSS::Graphics.snapshot = RGSS::Bitmap.new(320, 240)
+
+  st.screen.show(Game::Transition::CROSS_COMBINE)
+  fade.bitmap.clear_blt_calls
+  scene.update
+  blts = fade.bitmap.blt_calls
+  eq 4, blts.length, 'top-left/top-right/bottom-left/bottom-right'
+  dests = blts.map { |c| blt_dest(c) }
+  # Frame 1: each quadrant has only just started sliding in from its corner.
+  eq [[-156, -117], [316, -117], [-156, 237], [316, 237]], dests,
+     'each quadrant is still almost entirely off-screen past its own corner'
+
+  mid = Game::Transition.default_frames(Game::Transition::CROSS_COMBINE) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_blt_calls
+  scene.update
+  dests = fade.bitmap.blt_calls.map { |c| blt_dest(c) }
+  eq [[0, 0], [160, 0], [0, 120], [160, 120]], dests,
+     'finished: the four quadrants tile the screen exactly'
+ensure
+  RGSS::Graphics.snapshot = nil
+end
+
+check 'a captured transition falls back to a plain fade when the backend cannot snapshot' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+
+  RGSS::Graphics.snapshot = nil # e.g. the Wio/PSP builds, LV_USE_SNAPSHOT off
+  st.screen.erase(Game::Transition::SCROLL_LEFT_OUT, 4)
+  4.times { scene.update }
+  eq 255, fade.opacity, 'still lands on the right end state via the fade fallback'
+  ok (fade.bitmap.blt_calls || []).empty?, 'nothing to blit without a snapshot'
 end
 
 check 'Flash Screen drives the flash layer, and refills only on a colour change' do


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s "Screen effects" entry: Erase/Show Screen's scroll and combine/division transition styles ran as a plain fade of the right length but the wrong texture — recorded as blocked on a screen capture the renderer supposedly does not have. That block was already lifted by an earlier correction note: `RGSS::Graphics.snap_to_bitmap` exists and is what the RPG Maker XP scene already uses for its own transitions; nothing had wired it up for these styles yet.

## Changes

- `Game::Transition#capture_ops` (`mruby-rpg2k/mrblib/game.rb`): pure-logic geometry for the 8 scroll directions and vertical/horizontal/cross combine and division (14 styles) — no `Graphics` access, matching how `#visible_rects` already works for the mask-based styles.
- `Scene::Map#draw_captured_transition` (`mruby-rpg2k/mrblib/scene/map.rb`): snapshots the screen once per transition instance (by object identity, so a same-style transition right after it still re-snapshots) and blits the pieces sliding into/out of place each frame over a black fill, disposing the snapshot once the transition ends. Falls back to the existing plain-fade path if the backend can't snapshot (Wio/PSP builds, `LV_USE_SNAPSHOT` off).
- Cross combine/division's exact quadrant motion (diagonal from each screen corner) is this build's own reasoned extension of the vertical/horizontal pair — not confirmed against real RPG_RT, since neither downloaded test bed exercises that specific style. Flagged as such in `docs/TODO.md` rather than presented as verified.
- Zoom, mosaic/wave and random blocks are unchanged (still fall through to the plain fade) — zoom's own in/out direction has nothing in either test bed to confirm it against, mosaic/wave want a native per-pixel resample, and random blocks wants RPG_RT's incremental per-frame block paint.

## Testing

- `scripts/rpg2k_scene_check.rb`: 286 checks passing (5 new — snapshot caching across frames of the same transition instance, per-style geometry at the start and end of a transition for scroll/vertical-division/cross-combine, and the no-snapshot-backend fallback).
- `scripts/rpg2k_logic_check.rb`: 622 checks passing (unaffected).
- `scripts/rpg2k_render_check.rb`: 40 checks passing (unaffected).
- `scripts/rpg2k_testbed_logic_check.rb`: 94 checks passing against the real downloaded Nepheshel data (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby scene-logic addition covered by the harnesses above). No wine/native-build access in this environment, so the geometry is reasoned from the existing mask-style transitions' conventions rather than pixel-diffed against real RPG_RT — flagged explicitly in the docs/changelog rather than claimed as confirmed.
- Documented in `changelog.d/rpg2k-transition-scroll-combine.added.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_