### PR TITLE
Add optional mold linker support for faster builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,25 @@ endif()
 
 project(rpg_maker_clone C CXX)
 
+# Link with mold instead of the toolchain's default linker (bfd on the
+# nix/apt GCC builds) when it's available -- mold is dramatically faster on
+# this project's link steps (the main executable plus every 3rd/* static lib
+# and test binary). Doesn't apply to Emscripten, which always links through
+# wasm-ld regardless of -fuse-ld. check_linker_flag needs CMake 3.18, one
+# above this project's 3.10 floor, so an older cmake just skips the upgrade
+# and falls back to the default linker instead of failing to configure.
+option(USE_MOLD "Link with mold when available" ON)
+if(USE_MOLD AND NOT EMSCRIPTEN AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+  include(CheckLinkerFlag)
+  check_linker_flag(CXX "-fuse-ld=mold" CXX_LINKER_SUPPORTS_MOLD)
+  if(CXX_LINKER_SUPPORTS_MOLD)
+    message(STATUS "Linking with mold")
+    add_link_options("-fuse-ld=mold")
+  else()
+    message(STATUS "mold not available, using the default linker")
+  endif()
+endif()
+
 if(EMSCRIPTEN)
   # Emscripten ships SDL2 and SDL2_mixer as "ports": -sUSE_SDL=2 /
   # -sUSE_SDL_MIXER=2 provide both the headers (needed while compiling lvgl's

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,17 @@ endif()
 
 project(rpg_maker_clone C CXX)
 
-# Link with mold instead of the toolchain's default linker (bfd on the
-# nix/apt GCC builds) when it's available -- mold is dramatically faster on
-# this project's link steps (the main executable plus every 3rd/* static lib
-# and test binary). Doesn't apply to Emscripten, which always links through
-# wasm-ld regardless of -fuse-ld. check_linker_flag needs CMake 3.18, one
-# above this project's 3.10 floor, so an older cmake just skips the upgrade
-# and falls back to the default linker instead of failing to configure.
+# Link with mold instead of the toolchain's default linker (bfd on the nix/apt
+# GCC builds) when it's available -- mold is dramatically faster on this
+# project's link steps (the main executable plus every 3rd/* static lib and test
+# binary). Doesn't apply to Emscripten, which always links through wasm-ld
+# regardless of -fuse-ld. check_linker_flag needs CMake 3.18, one above this
+# project's 3.10 floor, so an older cmake just skips the upgrade and falls back
+# to the default linker instead of failing to configure.
 option(USE_MOLD "Link with mold when available" ON)
-if(USE_MOLD AND NOT EMSCRIPTEN AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+if(USE_MOLD
+   AND NOT EMSCRIPTEN
+   AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
   include(CheckLinkerFlag)
   check_linker_flag(CXX "-fuse-ld=mold" CXX_LINKER_SUPPORTS_MOLD)
   if(CXX_LINKER_SUPPORTS_MOLD)


### PR DESCRIPTION
## Summary
Added optional support for linking with the mold linker when available, which significantly speeds up link times on this project. The feature is configurable and gracefully falls back to the default linker if mold is unavailable or if CMake version requirements aren't met.

## Key Changes
- Added `USE_MOLD` CMake option (enabled by default) to control mold linker usage
- Implemented linker detection using `check_linker_flag()` (requires CMake 3.18+)
- Automatically applies `-fuse-ld=mold` flag when mold is available and supported
- Gracefully handles cases where:
  - CMake version is below 3.18 (falls back to default linker)
  - Emscripten is being used (always uses wasm-ld)
  - mold is not available on the system
- Added informative status messages indicating which linker is being used

## Implementation Details
- The check only runs when `USE_MOLD` is ON, CMake >= 3.18, and not building for Emscripten
- Uses CMake's `CheckLinkerFlag` module to safely test linker support before applying the flag
- Applies the linker option globally via `add_link_options()` for all targets

https://claude.ai/code/session_01SxkFEC96MmchXQHdPxBNrG