### PR TITLE
Implement the "attribute defense up/down" skill flag

### DIFF
--- a/changelog.d/skill-attribute-defence-shift.added.md
+++ b/changelog.d/skill-attribute-defence-shift.added.md
@@ -1,0 +1,13 @@
+- **A skill flagged "attribute defense up/down" now shifts the target's
+  elemental rank.** `Game::Party#battle_skill_command` computes the shift (one
+  attribute-defence step, direction from `reverse_state_effect`) for both
+  attack and buff/recovery skills, and `Game::Battle#apply_attr_shift` applies
+  it capped at ±1 from the rank the battle started at
+  (`Combatant#attr_base_ranks`) — repeat casts don't stack past the cap. It
+  resets at battle end for free: a `Combatant`'s `attr_ranks` is a fresh copy
+  of the database row, never written back to the actor. The direction (which
+  way `reverse_state_effect` shifts) is this build's own reading — reusing the
+  same polarity flag a skill's state effects already use — not confirmed
+  against real RPG_RT or either downloaded test bed, since neither ships a
+  skill with the flag set. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2409,11 +2409,29 @@ above are repeated here)
   occurrence never applies regardless of rank); Death/Knockout is exempt
   and always applies. Attribute resistance rank A-E maps to the Attribute
   database's own per-rank effect-% table (e.g. 50% halves).
-- A skill flagged "attribute defense up/down" shifts the target's
-  elemental rank by **exactly one step**, capped at ±1 from the
-  character's base rank, and **resets automatically at battle end**.
-  Attribute ranks must be configured strictly `A>B>C>D>E` for that ±1-step
-  logic to make sense.
+- ✅ A skill flagged "attribute defense up/down" (field 45,
+  `affect_attr_defence`) now shifts the target's rank for each attribute in
+  its `attribute_effects` list by **exactly one step**, capped at ±1 from the
+  rank the battle started at (`Game::Battle::Combatant#attr_base_ranks`), for
+  every attack (scope enemy) *and* buff/recovery-style (scope self/ally)
+  skill alike — `Game::Party#battle_skill_command` computes the shift on both
+  branches, `Game::Battle#apply_attr_shift` applies and caps it. It
+  **resets automatically at battle end** for free rather than needing an
+  explicit reset: `attr_ranks` is a fresh `Hash` built from the database row
+  on every `Combatant#attr_ranks_of` call (`Game::Actor#attribute_ranks`
+  caches nothing), and `Battle#apply_to_party` never writes it back to the
+  actor — so a shift dies with the Combatant along with everything else the
+  fight didn't ask to persist. **The direction is this build's own reading,
+  not confirmed against RPG_RT or either test bed**: it reuses
+  `reverse_state_effect` (unset = up/better, set = down/worse), the same
+  polarity flag a skill's state effects already use, on the assumption
+  RPG2000's skill editor drives one shared "raise/lower" toggle for both the
+  state-effect list and the attribute-defence list rather than a separate
+  field of its own — neither Nepheshel nor mtf-meido-action ships a skill
+  with the flag set, so there is nothing to check it against. Attribute
+  ranks must be configured strictly `A>B>C>D>E` for the ±1-step logic to make
+  sense. Covered by a new `scripts/rpg2k_logic_check.rb` check (both
+  directions, and that repeat casts don't stack past the cap).
 - Enemy group members are numbered by add-order; **lower number renders
   in front** (closer to camera); deleting a middle member shifts every
   later member's number down by one, which can silently repoint any

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2975,6 +2975,24 @@ module Game
       ids
     end
 
+    # Whether skill `sk` is flagged "attribute defence up/down" (`affect_attr_
+    # defence`, field 45) and, if so, which direction: -1 (up, a rank toward A
+    # / better resistance) or +1 (down, a rank toward E / worse). yado.tk's
+    # note on the feature ("shifts the target's elemental rank by exactly one
+    # step, capped at +-1 from the character's base rank, resets automatically
+    # at battle end") says what it does but not which flag chooses the
+    # direction; this reuses `reverse_state_effect` (field 20) on the
+    # assumption RPG2000's skill editor drives its one "raise/lower" toggle
+    # for both the state-effect list and the attribute-defence list, the same
+    # way it already does for state infliction vs cure (see
+    # #skill_cured_states) -- not confirmed against real RPG_RT or either test
+    # bed, since neither ships a skill with the flag set. nil when the skill
+    # does not touch attribute defence at all.
+    def skill_attr_shift(sk)
+      return nil unless sk.respond_to?(:affect_attr_defence) && sk.affect_attr_defence
+      sk.respond_to?(:reverse_state_effect) && sk.reverse_state_effect ? 1 : -1
+    end
+
     # The command numbers for casting `sk` from `caster` on `target` (both
     # Combatant snapshots): the caster's SP `cost`, and the signed HP / SP deltas
     # to the target — negative HP for an attack skill (base effect less a quarter
@@ -2983,6 +3001,12 @@ module Game
     def battle_skill_command(sk, caster, target)
       cost = skill_cost(sk, caster)
       base = skill_effect(sk, caster)
+      # Attribute-defence shifting isn't scoped to attack skills -- a "raise
+      # my own resistance" buff and a "lower the enemy's" debuff are both this
+      # same flag, just cast on a different side -- so it rides on both
+      # branches below rather than only the attack one.
+      shift = skill_attr_shift(sk)
+      shift_ids = shift ? skill_attributes(sk) : []
       if sk.scope == 0 || sk.scope == 1 # single or all enemies: an attack skill
         dmg = base - skill_defence_term(sk, target)
         dmg = 1 if dmg < 1
@@ -2993,9 +3017,10 @@ module Game
           # only on an *offensive* skill (EasyRPG's `skill.absorb_damage &&
           # !IsPositive()`), so it rides only on this branch: a healing skill
           # that sets it drains nothing.
-          absorb: skill_absorbs?(sk) }
+          absorb: skill_absorbs?(sk), attr_shift: shift, attr_ids: shift_ids }
       else
-        { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0 }
+        { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0,
+          attr_shift: shift, attr_ids: shift_ids }
       end
     end
 
@@ -5437,7 +5462,18 @@ module Game
                            # can be evaded, whether Defend halves twice, and
                            # whether skills cost half.
                            :strikes, :ignores_evasion, :strong_defence,
-                           :half_sp_cost) do
+                           :half_sp_cost,
+                           # The ranks #attr_ranks started the battle at --
+                           # never itself written to, only read to cap how far
+                           # an "attribute defence up/down" skill (see
+                           # #skill_attr_shift) may move #attr_ranks in either
+                           # direction. Since #attr_ranks is a fresh Hash per
+                           # Combatant (Game::Actor#attribute_ranks builds one
+                           # from the database row on every call, not a cached
+                           # one) and #apply_to_party never writes it back to
+                           # the actor, a shift is battle-scoped for free: it
+                           # dies with the Combatant, no separate reset needed.
+                           :attr_base_ranks) do
       def dead?; hp <= 0; end
 
       # Swings per basic attack: 2 with a 二刀流 weapon, 1 otherwise. Struct
@@ -5507,6 +5543,7 @@ module Game
       c.ignores_evasion = flag_of(a, :ignores_evasion?)
       c.strong_defence = flag_of(a, :strong_defence?)
       c.half_sp_cost = flag_of(a, :half_sp_cost?)
+      c.attr_base_ranks = c.attr_ranks.dup
       c
     end
 
@@ -5531,6 +5568,7 @@ module Game
       # The Monster/<name> graphic, carried so the battle screen can redraw a
       # combatant whose transformation swapped it.
       c.battler_name = e.respond_to?(:battler_name) ? e.battler_name : nil
+      c.attr_base_ranks = c.attr_ranks.dup
       c
     end
 
@@ -5884,12 +5922,13 @@ module Game
     # order by #apply_command when the round runs.
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
                       chance: 100, variance: 0, attributes: nil, skill_id: nil,
-                      absorb: false)
+                      absorb: false, attr_shift: nil, attr_ids: nil)
       ally.command = { kind: :skill, target: target, name: name,
                        skill_id: skill_id, absorb: absorb,
                        cost: cost, hp: hp, mp: mp,
                        inflict: inflict || [], chance: chance, variance: variance,
-                       attributes: attributes || [] }
+                       attributes: attributes || [],
+                       attr_shift: attr_shift, attr_ids: attr_ids || [] }
       ally.action = nil; ally.defending = false
     end
 
@@ -5898,14 +5937,18 @@ module Game
     # signed HP / SP deltas #command_skill takes, one per target, since attack
     # damage varies with each target's defence). The SP `cost` is spent once when
     # the action resolves; the shared `inflict` / `chance` / `variance` /
-    # `attributes` apply to every target. #apply_command produces one log entry
-    # per living target, drained one at a time by #step_action.
+    # `attributes` / `attr_shift` / `attr_ids` apply to every target -- unlike
+    # damage, which attribute (or none) a skill affects and which way is a
+    # property of the skill itself, not of who it lands on. #apply_command
+    # produces one log entry per living target, drained one at a time by
+    # #step_action.
     def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
                           variance: 0, attributes: nil, skill_id: nil,
-                          absorb: false)
+                          absorb: false, attr_shift: nil, attr_ids: nil)
       ally.command = { kind: :skill, all: true, targets: targets, name: name,
                        skill_id: skill_id, absorb: absorb, cost: cost, inflict: inflict || [], chance: chance,
-                       variance: variance, attributes: attributes || [] }
+                       variance: variance, attributes: attributes || [],
+                       attr_shift: attr_shift, attr_ids: attr_ids || [] }
       ally.action = nil; ally.defending = false
     end
 
@@ -6627,12 +6670,18 @@ module Game
         end
         target.hp -= dmg
         b.hp = [b.hp + absorbed, b.max_hp].min if absorbed > 0
-        # An attack skill may inflict its states on a surviving target, each
-        # rolled against the skill's accuracy.
-        inflicted, already = target.dead? ? [[], []] : roll_inflict(target, cmd)
+        # An attack skill may inflict its states -- and shift attribute
+        # defence ranks -- on a surviving target, each rolled/applied only if
+        # it lived through the damage.
+        if target.dead?
+          inflicted = already = shifted = []
+        else
+          inflicted, already = roll_inflict(target, cmd)
+          shifted = apply_attr_shift(target, cmd)
+        end
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
-          inflicted: inflicted, already: already,
+          inflicted: inflicted, already: already, attr_shifted: shifted,
           target_ally: ally?(target), skill: cmd[:name],
           skill_id: cmd[:skill_id], target_index: @enemies.index(target),
           absorbed_hp: absorbed }
@@ -6645,13 +6694,39 @@ module Game
         # unconditionally, matching the field item cure.
         cured = (cmd[:cured] || []).select { |s| target.state?(s) }
         target.states = (target.states || []) - cured unless cured.empty?
+        shifted = target.dead? ? [] : apply_attr_shift(target, cmd)
         { recover: true, actor: b.name, source: cmd[:name],
           item_id: cmd[:item_id], skill_id: cmd[:skill_id], target: target.name,
           target_index: @enemies.index(target),
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
-          cured: cured, target_ally: ally?(target),
+          cured: cured, target_ally: ally?(target), attr_shifted: shifted,
           target_hp: target.hp, target_mp: target.mp }
       end
+    end
+
+    # Shift `target`'s attribute-defence ranks per `cmd[:attr_shift]` (see
+    # #skill_attr_shift): one step per landing, capped at +-1 from the rank
+    # the battle started with (Combatant#attr_base_ranks) rather than
+    # stacking further on repeat casts, and always inside the valid 0..4
+    # (A..E) range. Returns the attribute ids actually moved -- an attribute
+    # already at its cap, or a skill that doesn't touch attribute defence at
+    # all, moves nothing.
+    def apply_attr_shift(target, cmd)
+      shift = cmd[:attr_shift]
+      ids = cmd[:attr_ids]
+      return [] unless shift && ids && !ids.empty?
+      target.attr_ranks ||= {}
+      base = target.attr_base_ranks || {}
+      moved = []
+      ids.each do |aid|
+        b = Game.clamp(base[aid] || 2, 0, 4)
+        cur = target.attr_ranks[aid] || b
+        nxt = Game.clamp(cur + shift, Game.clamp(b - 1, 0, 4), Game.clamp(b + 1, 0, 4))
+        next if nxt == cur
+        target.attr_ranks[aid] = nxt
+        moved << aid
+      end
+      moved
     end
 
     # RPG2000's default state rate table (liblcf's RPG::State defaults): a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3132,7 +3132,9 @@ class RPG2k
                                           hp: c[:hp], mp: c[:mp],
                                           inflict: c[:inflict], chance: c[:chance],
                                           variance: c[:variance] || 0,
-                                          attributes: c[:attributes])
+                                          attributes: c[:attributes],
+                                          attr_shift: c[:attr_shift],
+                                          attr_ids: c[:attr_ids])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor
@@ -3157,7 +3159,9 @@ class RPG2k
                                               cost: meta[:cost],
                                               inflict: meta[:inflict], chance: meta[:chance],
                                               variance: meta[:variance] || 0,
-                                              attributes: meta[:attributes])
+                                              attributes: meta[:attributes],
+                                              attr_shift: meta[:attr_shift],
+                                              attr_ids: meta[:attr_ids])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2100,15 +2100,20 @@ FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost
                        :state_effects, :reverse_state_effect, :hit, :variance,
                        :attribute_effects, :switch_id,
                        # 防御無視: the effect lands undiminished.
-                       :ignore_defense)
+                       :ignore_defense,
+                       # 属性有効度変化 (attribute defence up/down, field 45):
+                       # shifts the target's rank for each attribute_effects id
+                       # by one step, direction shared with reverse_state_effect.
+                       :affect_attr_defence)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
                occ_battle: true, state_effects: nil, reverse_state: false, hit: 100,
                variance: 4, attribute_effects: nil, switch_id: 1,
-               ignore_defense: false)
+               ignore_defense: false, affect_attr_defence: false)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
                 prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
-                variance, attribute_effects, switch_id, ignore_defense)
+                variance, attribute_effects, switch_id, ignore_defense,
+                affect_attr_defence)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
 # per-turn slip damage (hp/sp change), action restriction and auto-recovery.
@@ -6423,13 +6428,61 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   # magical_rate 40), so RPG_RT blunts it with the target's *spirit* and not at
   # all with its armour: 32 - (0*8/40 + 40*16/80) = 32 - 8 = 24.
   eq({ cost: 6, hp: -24, mp: 0, inflict: [], chance: 100, variance: 4,
-       attributes: [], absorb: false },
+       attributes: [], absorb: false, attr_shift: nil, attr_ids: [] },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
-  eq({ cost: 5, hp: 32, mp: 0 },
+  eq({ cost: 5, hp: 32, mp: 0, attr_shift: nil, attr_ids: [] },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))
   # Cure affects HP and SP: effect = 10 + 40*12/40 = 22
-  eq({ cost: 4, hp: 22, mp: 22 },
+  eq({ cost: 4, hp: 22, mp: 22, attr_shift: nil, attr_ids: [] },
      st.party.battle_skill_command(st.party.db_skill(9), caster, nil))
+end
+
+check 'a skill flagged "attribute defence up/down" shifts the target rank, ' \
+      'capped at +-1 from base' do
+  # scope 3 (single, non-attack) so this exercises the shift without also
+  # tripping battle_skill_command's separate "scope 0/1 always deals at
+  # least 1 damage" behaviour -- a different, pre-existing question.
+  down = fake_skill(name: 'Weaken Fire', scope: 3, sp_cost: 0, power: 0,
+                    attribute_effects: [1], affect_attr_defence: true,
+                    reverse_state: true) # down: toward a worse (higher) rank
+  up = fake_skill(name: 'Ward Fire', scope: 3, sp_cost: 0, power: 0,
+                  attribute_effects: [1], affect_attr_defence: true,
+                  reverse_state: false) # up: toward a better (lower) rank
+  skills = { 7 => down, 8 => up }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.attr_ranks = { 1 => 2 }        # C to start
+  foe.attr_base_ranks = { 1 => 2 }
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+
+  c = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  eq 1, c[:attr_shift], 'reverse_state_effect set -> down (worse)'
+  eq [1], c[:attr_ids]
+  bat.command_skill(caster, foe, name: 'Weaken Fire', cost: c[:cost],
+                    hp: c[:hp], mp: c[:mp], attr_shift: c[:attr_shift],
+                    attr_ids: c[:attr_ids])
+  bat.run_round
+  eq 3, foe.attr_ranks[1], 'shifted one step down (C -> D)'
+
+  # A second cast does not stack past the +-1 cap from the base rank (2).
+  bat.command_skill(caster, foe, name: 'Weaken Fire', cost: c[:cost],
+                    hp: c[:hp], mp: c[:mp], attr_shift: c[:attr_shift],
+                    attr_ids: c[:attr_ids])
+  bat.run_round
+  eq 3, foe.attr_ranks[1], 'capped at one step from base, does not keep sliding'
+
+  # The opposite skill shifts it back the other way, past base and up to its
+  # own +-1 (better) cap -- three casts, still capped at one step from base.
+  c2 = st.party.battle_skill_command(st.party.db_skill(8), caster, foe)
+  eq(-1, c2[:attr_shift], 'reverse_state_effect unset -> up (better)')
+  3.times do
+    bat.command_skill(caster, foe, name: 'Ward Fire', cost: c2[:cost],
+                      hp: c2[:hp], mp: c2[:mp], attr_shift: c2[:attr_shift],
+                      attr_ids: c2[:attr_ids])
+    bat.run_round
+  end
+  eq 1, foe.attr_ranks[1], 'capped one step better than base (C -> B)'
 end
 
 check 'a battle attack skill inflicts its state_effects on a surviving enemy' do


### PR DESCRIPTION
## Summary

yado.tk's Database field semantics backlog (`docs/TODO.md`, from the `11_db/` sweep): *"A skill flagged 'attribute defense up/down' shifts the target's elemental rank by **exactly one step**, capped at ±1 from the character's base rank, and **resets automatically at battle end**. Attribute ranks must be configured strictly `A>B>C>D>E` for that ±1-step logic to make sense."*

The skill row's `affect_attr_defence` flag (field 45) was parsed but nothing read it — genuinely unimplemented, not a "confirm already correct" item.

## Changes

- `Game::Party#skill_attr_shift(sk)`: whether a skill is flagged `affect_attr_defence` and, if so, which direction (`-1` up/better, `+1` down/worse).
- `Game::Party#battle_skill_command`: computes the shift and the affected attribute ids (its existing `skill_attributes`) on **both** branches — the attack (scope enemy) branch and the buff/recovery (scope self/ally) branch — since a "raise my own resistance" and a "lower the enemy's" are the same flag on different-scoped skills.
- `Game::Battle#apply_attr_shift`: applies the shift to a target `Combatant`, capped at ±1 from `Combatant#attr_base_ranks` (the rank the battle started at) — a repeat cast doesn't keep sliding past the cap — and never on an already-dead target.
- `Game::Battle::Combatant` gains `attr_base_ranks`, seeded once in `from_actor`/`from_enemy`.
- `command_skill` / `command_skill_all` and the two scene call sites (`apply_pending_skill` / `apply_pending_skill_all`) thread `attr_shift`/`attr_ids` through so the battle screen's skill-casting path actually reaches this.

**The battle-end reset needed no explicit hook.** `Combatant#attr_ranks` is a fresh `Hash` built from the database row on every `Game::Actor#attribute_ranks` call (nothing cached), and `Battle#apply_to_party` only ever writes back `states`/`hp`/`mp` — never `attr_ranks`. A shift therefore dies with the `Combatant` the same way every other battle-only field already does.

**One thing is a documented assumption, not a confirmed fact**: which way `reverse_state_effect` shifts the rank. It reuses the same polarity flag a skill's state effects already use (`skill_cured_states`/`skill_inflicted_states`), on the premise that RPG2000's skill editor drives one shared "raise/lower" toggle for both the state-effect list and the attribute-defence list rather than a separate field. Neither Nepheshel nor mtf-meido-action ships a skill with `affect_attr_defence` set, so there's nothing in either test bed to check this against — flagged explicitly in `docs/TODO.md` and the changelog rather than presented as verified.

## Testing

- `scripts/rpg2k_logic_check.rb`: 623 checks passing (2 new — one exercising both shift directions and the stacking cap over repeat casts; one updated for the two new `battle_skill_command` output keys).
- `scripts/rpg2k_scene_check.rb`: 288 checks passing (unaffected).
- `scripts/rpg2k_render_check.rb`: 40 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby battle-logic addition covered by the harness above).
- Rebased onto latest `master` before pushing; full check suite re-run clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_