### PR TITLE
Auto-remove a state 10+ priority below the current highest

### DIFF
--- a/changelog.d/state-priority-crowding-out.added.md
+++ b/changelog.d/state-priority-crowding-out.added.md
@@ -1,0 +1,13 @@
+- **A state 10+ priority below the current highest is now auto-removed the
+  instant a new one lands.** yado.tk: multiple active states all still apply
+  mechanically (a hidden poison keeps ticking under a displayed confusion),
+  but RPG_RT crowds out anything trailing the top priority by that much —
+  either the new state pushes an existing low-priority one out, or an
+  existing high-priority one pushes the new arrival right back out.
+  `Game::States.prune` implements the rule (death exempt on both sides, same
+  as the existing display-priority logic in `Game::States.significant`) and
+  is now called from every state-infliction path: `Game::Actor#add_state`'s
+  callers (the Change Condition event command, field skill casting) via a new
+  `Game::Party#state_table` accessor, and `Game::Battle#roll_inflict` for
+  battle. Covered by new `scripts/rpg2k_logic_check.rb` checks, confirmed to
+  fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2248,11 +2248,31 @@ not yet verified:
   halving** of the given Attack Power — replicating a normal attack
   requires manually halving the parameter first. Defense-effectiveness
   100% = DEF/4 (not full DEF); Spirit-effectiveness 100% = Mind/8.
-- Multiple active states: only the highest-priority one is **displayed**,
-  but all active states still mechanically apply (a hidden poison keeps
-  ticking under a displayed confusion); a state ≥10 priority below the
-  current highest is auto-removed; ties go to the higher state ID. State
-  #1 (Knockout) is **hardcoded** regardless of its own configured data.
+- ✅ Multiple active states: only the highest-priority one is **displayed**
+  (`Game::States.significant`, unchanged), but all active states still
+  mechanically apply (a hidden poison keeps ticking under a displayed
+  confusion — already true, since the map/battle slip-damage and
+  turn-restriction passes walk the whole `states` array, not just the
+  significant one). **A state ≥10 priority below the current highest is now
+  auto-removed** (`Game::States.prune`, called the instant a *new* state
+  lands — a state may itself immediately push an existing one out, or be
+  pushed out itself by one already held that outranks it by the gap).
+  Unlike `#significant`, ties don't matter for pruning — only the *value* of
+  the top priority does, so several states sharing it all survive; "ties go
+  to the higher state ID" is about which one **displays**, not which ones
+  live. State #1 (Knockout) is exempt on both sides — it is never pruned and
+  its own priority is never consulted as "the current highest" either,
+  matching `#significant`'s existing death special-case; knockout is tracked
+  through HP/`Actor#dead?`, not through this ranking. Wired into every
+  infliction path: `Game::Actor#add_state` callers (`Change Condition`, field
+  `cast_skill`) via a new `Game::Party#state_table` accessor, and
+  `Game::Battle#roll_inflict` via the battle's own state table. One
+  simplification, not confirmed against real RPG_RT: a state's accuracy-roll
+  "landed" report is unconditional even where pruning removes it again the
+  same instant — no test bed exercises two states with a large enough
+  priority gap to say whether the real messaging differs. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks (the pure `States.prune` rule, and
+  one per infliction path), confirmed to fail against the pre-fix code.
 - A weapon-type Attribute (as opposed to a magic-type one) gates skill
   usability on having a matching-attribute **weapon** equipped — armor
   with the same attribute does not satisfy it (already flagged as a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2578,6 +2578,13 @@ module Game
       @db.skill[id]
     end
 
+    # The database's state (`situation`) table, for Game::States lookups --
+    # priority, display name/colour, message text. nil for a fixture without
+    # one, which every Game::States accessor already tolerates.
+    def state_table
+      @db.respond_to?(:situation) ? @db.situation : nil
+    end
+
     # The SP `caster` pays to cast skill `sk`: a fixed cost (sp_type 0) or a
     # percentage of the caster's max SP (sp_type 1). Mirrors EasyRPG's
     # CalculateSkillCost (the half-SP-cost modifier is a later refinement).
@@ -2872,12 +2879,18 @@ module Game
             changed = true
           end
         end
+        landed = false
         inflicted.each do |s|
           unless t.state?(s)
             t.add_state(s)
             changed = true
+            landed = true
           end
         end
+        # RPG_RT's crowding-out rule (see Game::States::PRUNE_GAP): a state
+        # just landed may itself immediately push out one already held, or
+        # be pushed out by one already held that outranks it.
+        t.states = Game::States.prune(t.states, state_table) if landed
         before_hp = t.hp
         before_mp = t.mp
         t.change_hp(amount) if sk.affect_hp && amount > 0
@@ -5225,6 +5238,37 @@ module Game
       best
     end
 
+    # A state's own `priority` field (0 for an unknown id or a fixture row
+    # that omits it), the same lookup #significant makes per-id.
+    def self.priority_of(id, table)
+      r = row(id, table)
+      r && r.respond_to?(:priority) ? (r.priority || 0) : 0
+    end
+
+    # How far below the current top priority a state may sit before RPG_RT
+    # drops it outright (yado.tk: multiple active states all still apply
+    # mechanically, but one 10+ priority below the current highest is
+    # auto-removed).
+    PRUNE_GAP = 10
+
+    # `ids` after RPG_RT's crowding-out rule: any state 10+ priority below the
+    # current highest-priority state it carries is dropped. Only the *value*
+    # of the top priority matters here (unlike #significant, no id is singled
+    # out), so ties do not change what survives -- everything within the gap
+    # of the top, however many states share it, stays. Death (DEATH_ID) is
+    # exempt on both sides: it never gets pruned, and (matching #significant,
+    # which never even reads its priority) it does not count toward "the
+    # current highest" either -- knockout is tracked through HP/#dead?, not
+    # through this ranking. `ids` with one or fewer non-death entries has
+    # nothing to compare, and comes back unchanged.
+    def self.prune(ids, table)
+      return ids if ids.nil? || ids.size <= 1
+      ranked = ids.reject { |id| id == DEATH_ID }
+      return ids if ranked.size <= 1
+      top = ranked.map { |id| priority_of(id, table) }.max
+      ids.select { |id| id == DEATH_ID || priority_of(id, table) > top - PRUNE_GAP }
+    end
+
     # The state's display name, or nil when the table does not name it (a
     # fixture, or an id the database does not define).
     def self.name(id, table)
@@ -6782,7 +6826,10 @@ module Game
         end
         prob = chance * state_susceptibility(target, sid) / 100
         next unless @rng.random(100) < prob
-        target.states = (target.states || []) + [sid]
+        # RPG_RT's crowding-out rule (Game::States::PRUNE_GAP): the state
+        # that just landed may itself immediately push out one already
+        # held, or be pushed out by one already held that outranks it.
+        target.states = Game::States.prune((target.states || []) + [sid], @states)
         inflicted << sid
       end
       [inflicted, already]

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1653,7 +1653,15 @@ module Game
       state_id = cmd.param(3)
       remove = cmd.param(2) != 0
       stat_targets(cmd).each do |a|
-        remove ? a.remove_state(state_id) : a.add_state(state_id)
+        if remove
+          a.remove_state(state_id)
+        else
+          a.add_state(state_id)
+          # RPG_RT's crowding-out rule (Game::States::PRUNE_GAP): a state
+          # just inflicted may push out (or itself be pushed out by) one
+          # already held that outranks it by 10+ priority.
+          a.states = Game::States.prune(a.states, party.state_table)
+        end
       end
       check_game_over
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2187,13 +2187,14 @@ class ClassedRow < SkillRow
 end
 
 class FakeActorDB
-  attr_reader :player, :system, :item, :skill, :job
-  def initialize(players, party_ids, items = {}, skills = {}, jobs = {})
+  attr_reader :player, :system, :item, :skill, :job, :situation
+  def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil)
     @player = players
     @system = FakeActorSystem.new(party_ids)
     @item = items
     @skill = skills
     @job = jobs
+    @situation = situation
   end
 end
 
@@ -6884,6 +6885,113 @@ check 'States.significant: an id the table does not define reads as priority 0' 
   eq 9, Game::States.significant([9], table), 'but alone it is still what shows'
   # With no table at all every state ties at 0, so the highest id shows.
   eq 9, Game::States.significant([2, 9], nil)
+end
+
+check 'States.prune: a state 10+ priority below the current top is dropped' do
+  table = { 2 => display_state(name: 'Poison', priority: 30),
+            3 => display_state(name: 'Sleep',  priority: 70) }
+  eq [3], Game::States.prune([2, 3], table), 'Poison (30) trails Sleep (70) by 40'
+  # Order in the returned list follows the input order, not id/priority order.
+  eq [3], Game::States.prune([3, 2], table)
+end
+
+check 'States.prune: a gap of exactly 10 is enough to drop it, 9 is not' do
+  table = { 2 => display_state(name: 'A', priority: 30),
+            3 => display_state(name: 'B', priority: 39) }
+  eq [2, 3], Game::States.prune([2, 3], table), 'a 9-point gap survives'
+  table[3] = display_state(name: 'B', priority: 40)
+  eq [3], Game::States.prune([2, 3], table), 'a 10-point gap ("10+ below") drops it'
+end
+
+check 'States.prune: states sharing the top priority all survive' do
+  table = { 2 => display_state(name: 'A', priority: 70),
+            3 => display_state(name: 'B', priority: 70),
+            5 => display_state(name: 'C', priority: 20) }
+  eq [2, 3], Game::States.prune([2, 3, 5], table)
+end
+
+check 'States.prune: death is exempt both ways' do
+  table = { 4 => display_state(name: 'Poison', priority: 30) }
+  # Carrying death alongside a low-priority state does not drop the state --
+  # death's priority is never consulted, matching #significant.
+  eq [1, 4], Game::States.prune([1, 4], table)
+  # And death itself is never dropped, however it compares.
+  table[9] = display_state(name: 'Overwhelm', priority: 999)
+  eq [1, 9], Game::States.prune([1, 4, 9], table)
+end
+
+check 'States.prune: a single (or no) non-death state has nothing to compare' do
+  table = { 4 => display_state(name: 'Poison', priority: 30) }
+  eq [4], Game::States.prune([4], table)
+  eq [1, 4], Game::States.prune([1, 4], table)
+  eq [], Game::States.prune([], table)
+  eq nil, Game::States.prune(nil, table)
+end
+
+# A party (same actors as party_state) whose database also carries a state
+# (situation) table, for the Change Condition / cast_skill / battle pruning
+# checks below, none of which party_state or skill_party's plain FakeActorDB
+# gives a table to prune against.
+def party_state_with_states(states, skills = {})
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8, int: 12, agi: 7),
+    2 => FakePlayerRow.new('Ally', '', 0, 3,
+                           max_hp: 50, max_mp: 20, atk: 6, def: 5, int: 4, agi: 6),
+  }
+  Game::State.new(
+    Game::Party.new(FakeActorDB.new(players, [1, 2], {}, skills, {}, states)), 1, 0, 0)
+end
+
+check 'Change Condition prunes a state it displaces, and one that displaces it' do
+  states = { 2 => display_state(name: 'Poison', priority: 30),
+             3 => display_state(name: 'Petrify', priority: 90) }
+  st = party_state_with_states(states)
+  interp = Game::Interpreter.new(st)
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2) # seed with the low-priority state directly
+
+  ic = Game::Interpreter::Cmd
+  # Inflict the much-higher-priority state: it displaces Poison.
+  interp.start([FakeCmd.new(ic::CHANGE_CONDITION, [1, 1, 0, 3])])
+  interp.update
+  eq [3], hero.states, 'Petrify (90) pushed Poison (30) out on landing'
+
+  # A low-priority state inflicted onto an already-high-priority target is
+  # itself immediately pushed back out.
+  interp.start([FakeCmd.new(ic::CHANGE_CONDITION, [1, 1, 0, 2])])
+  interp.update
+  eq [3], hero.states, 'Poison could not gain a foothold against Petrify'
+end
+
+check "a field skill inflicting a state prunes the target's state set" do
+  states = { 2 => display_state(name: 'Poison', priority: 30),
+            3 => display_state(name: 'Petrify', priority: 90) }
+  skills = { 7 => fake_skill(name: 'Petrify Touch', scope: 0, sp_cost: 0,
+                             state_effects: [0, 0, 1], reverse_state: true) } # -> state 3, inflict
+  st = party_state_with_states(states, skills)
+  target = st.party.actor_by_id(1)
+  target.add_state(2)
+  st.party.cast_skill(target, 7, target, true)
+  eq [3], target.states, 'the field-cast Petrify displaced the held Poison'
+end
+
+check "a battle attack skill inflicting a state prunes the target's state set" do
+  states = { 2 => display_state(name: 'Poison', priority: 30),
+             3 => display_state(name: 'Petrify', priority: 90) }
+  skills = { 7 => fake_skill(name: 'Petrify Sting', scope: 0, sp_cost: 3, power: 20,
+                             mrate: 40, state_effects: [0, 0, 1], hit: 100) } # -> state 3
+  st = party_state_with_states(states, skills)
+  mage = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.states = [2]
+  bat = Game::Battle.new([mage], [foe], Game::Rng.new(1), states)
+  c = st.party.battle_skill_command(st.party.db_skill(7), mage, foe)
+  eq [3], c[:inflict]
+  bat.command_skill(mage, foe, name: 'Petrify Sting', cost: c[:cost],
+                    hp: c[:hp], mp: c[:mp], inflict: c[:inflict], chance: c[:chance])
+  bat.run_round
+  eq [3], foe.states, 'the battle-inflicted Petrify displaced the held Poison'
 end
 
 check 'States.name / color fall back when the row does not say' do


### PR DESCRIPTION
## Summary

yado.tk's "Battle system (default)" backlog note (`docs/TODO.md`): *"Multiple active states: only the highest-priority one is displayed, but all active states still mechanically apply (a hidden poison keeps ticking under a displayed confusion); a state ≥10 priority below the current highest is auto-removed; ties go to the higher state ID. State #1 (Knockout) is hardcoded regardless of its own configured data."*

The "all states still mechanically apply" half was already true (map/battle slip damage and turn restrictions already walk the whole `states` array, not just the displayed one). The auto-removal half was genuinely unimplemented — every infliction path just appended, nothing ever pruned.

## Changes

- `Game::States.priority_of` / `Game::States.prune` (`mruby-rpg2k/mrblib/game.rb`): given a battler's held state ids and the database's state table, drops any (non-death) state whose priority trails the current top (non-death) priority by 10 or more. Only the *value* of the top priority matters — unlike `#significant`'s display pick, ties don't change what survives (several states sharing the top priority all live). Death (state 1) is exempt on both sides: never pruned, and never counted toward "the current highest" — matching `#significant`'s existing death special-case, since knockout is tracked through HP/`Actor#dead?` rather than this ranking.
- `Game::Party#state_table`: a small new accessor (`@db.situation`, tolerating a fixture without one) so callers outside `Party` can reach the state table the same way `db_skill`/`db_item` already do.
- Wired into every infliction path:
  - `Game::Actor#add_state`'s callers — the Change Condition event command (`mruby-rpg2k/mrblib/interpreter.rb`) and field skill casting (`Party#cast_skill`) — prune via `party.state_table` / `state_table` right after a state lands.
  - `Game::Battle#roll_inflict` prunes via the battle's own state table after a battle-inflicted state lands.

**One simplification, flagged rather than guessed at**: a state's accuracy-roll "landed" report stays unconditional even where pruning removes it again the same instant (no test bed exercises two states with a priority gap large enough to say whether real RPG_RT's messaging differs).

## Testing

- `scripts/rpg2k_logic_check.rb`: 631 checks passing (8 new) — the pure `States.prune` rule (gap dropped, exact-10 boundary, ties surviving, death exempt both ways, single/empty input), plus one integration check per infliction path (Change Condition, field `cast_skill`, battle `roll_inflict`), each confirmed to fail against the pre-fix code before the fix.
- `scripts/rpg2k_scene_check.rb`: 288 checks passing (unaffected).
- `scripts/rpg2k_render_check.rb`: 40 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby battle-logic addition covered by the harness above).
- Already based on latest `master` (through PR #506) — no rebase needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_