### PR TITLE
Gate skill usability on weapon-type Attribute equip requirements

### DIFF
--- a/changelog.d/weapon-attribute-skill-gating.added.md
+++ b/changelog.d/weapon-attribute-skill-gating.added.md
@@ -1,0 +1,13 @@
+- **A skill whose Attack/Defense Attribute is weapon-type now needs a matching
+  weapon equipped to cast.** yado.tk: armour carrying the same attribute does
+  not satisfy the requirement, only a weapon does; skill usability modelled no
+  attribute-based equip-gating at all before this. `Game::Party
+  #weapon_attribute_ready?` checks each of a skill's `attribute_effects` ids
+  against the database `property` table's weapon/magic `type` field, and for
+  the weapon-type ones requires `Actor#weapon_attributes` (the equipped
+  weapon's own `attribute_set`, already used for battle damage scaling) to
+  cover all of them — a magic-type attribute gates nothing. Wired into
+  `#can_cast?`, the single choke point every cast path (field, battle,
+  escape/teleport/switch skills) already runs through. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the pre-fix
+  code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1723,11 +1723,13 @@ following this paragraph as the original record.
   literal top-left upper tile is the canonical "no tile" transparent chip,
   any other blank-looking one carries its own (possibly impassable)
   identity — content-authoring nuance, likely nothing to fix engine-side.
-- `028_tokushu_huka/` — a skill whose Attack/Defense Attribute is configured
+- ✅ `028_tokushu_huka/` — a skill whose Attack/Defense Attribute is configured
   as a **weapon** attribute (vs. a **magic** attribute) can only be used
   while a weapon carrying that same attribute is equipped; armour with the
-  same attribute does not satisfy it. Worth checking whether skill
-  usability currently models attribute-based equip-gating at all.
+  same attribute does not satisfy it. Skill usability modelled no
+  attribute-based equip-gating at all before this — see the "Database field
+  semantics" entry below, now implemented as `Game::Party#can_cast?` /
+  `#weapon_attribute_ready?`.
 - `033_load/` — editing a map in the *editor* after a save exists resets
   that save's event positions to default on load, and database edits (e.g.
   reordering Items) desync old saves since items are referenced by
@@ -2273,13 +2275,29 @@ not yet verified:
   priority gap to say whether the real messaging differs. Covered by new
   `scripts/rpg2k_logic_check.rb` checks (the pure `States.prune` rule, and
   one per infliction path), confirmed to fail against the pre-fix code.
-- A weapon-type Attribute (as opposed to a magic-type one) gates skill
+- ✅ A weapon-type Attribute (as opposed to a magic-type one) gates skill
   usability on having a matching-attribute **weapon** equipped — armor
   with the same attribute does not satisfy it (already flagged as a
   09_bug finding above; corroborated independently via the Attribute
-  database page too). Weapon-type × magic-type attribute stacking on one
-  attack **multiplies** the two rates as fractions (200%×50%=100%), not
-  an average despite the site's own wording.
+  database page too). `Game::Party#weapon_attribute_ready?` reads each of a
+  skill's `attribute_effects` ids, checks the database `property` table's
+  `type` field (0 weapon / 1 magic) for each, and — for the weapon-type ones
+  only — requires `Actor#weapon_attributes` (the union of the *equipped
+  weapon slot's* item(s) own `attribute_set`, already used for battle damage
+  scaling) to cover every one of them; a magic-type attribute, or a skill
+  with none at all, gates nothing. Wired into `#can_cast?`, the single choke
+  point every cast path (field, battle, escape/teleport/switch skills) already
+  runs through. A skill naming more than one weapon-type attribute needs all
+  of them covered (one weapon or several via dual-wield) — the literal reading
+  of "a weapon carrying **that** attribute", not confirmed against a
+  multi-attribute skill since neither test bed ships one. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the pre-fix
+  code. **Still open**: weapon-type × magic-type attribute stacking on one
+  attack **multiplies** the two rates as fractions (200%×50%=100%), not an
+  average despite the site's own wording — a separate question from equip
+  gating, in the damage formula (`Game::Battle#attr_multiplier` currently
+  takes the strongest single rate, not a weapon/magic product) rather than
+  usability.
 - Battle Animation: only one on screen at a time (a second forcibly cuts
   off the first); 1 frame = 1/30s, but a "Wait" frame is internally
   **two** consecutive 0.0s-wait frames, not one; chaining two Show Battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2751,11 +2751,47 @@ module Game
       sk.switch_id
     end
 
-    # Whether `caster` can cast skill `sid` right now: it knows the skill and can
-    # pay its SP cost.
+    # Whether `caster` can cast skill `sid` right now: it knows the skill, can
+    # pay its SP cost, and (see #weapon_attribute_ready?) is not missing a
+    # required weapon-type Attribute.
     def can_cast?(caster, sid)
       sk = db_skill(sid)
-      !sk.nil? && caster && caster.knows_skill?(sid) && caster.mp >= skill_cost(sk, caster)
+      !sk.nil? && caster && caster.knows_skill?(sid) &&
+        caster.mp >= skill_cost(sk, caster) && weapon_attribute_ready?(caster, sk)
+    end
+
+    # Whether `caster` satisfies `sk`'s weapon-type Attribute requirement, if
+    # it has one: a skill whose Attack/Defense Attribute (`attribute_effects`,
+    # the same field #skill_attributes reads for damage scaling) names an
+    # attribute the database flags weapon-type (the `property` table's `type`
+    # field, 0) can only be cast while a weapon carrying that same attribute
+    # is equipped -- armour carrying it does not satisfy the requirement
+    # (yado.tk 028_tokushu_huka, corroborated independently via the Attribute
+    # database page). A magic-type attribute (`type` 1), or a skill with no
+    # attribute at all, gates nothing. A skill naming more than one
+    # weapon-type attribute needs all of them covered, one weapon or several
+    # (dual-wield) between them -- there is no test-bed skill with two to
+    # confirm that against, so it is the direct reading of "a weapon carrying
+    # that same attribute" applied per attribute rather than a guess at
+    # something looser.
+    def weapon_attribute_ready?(caster, sk)
+      return true unless sk
+      ids = skill_attributes(sk).select { |aid| attribute_weapon_type?(aid) }
+      return true if ids.empty?
+      equipped = caster.respond_to?(:weapon_attributes) ? caster.weapon_attributes : []
+      ids.all? { |aid| equipped.include?(aid) }
+    end
+
+    # Whether attribute `aid` is the database's weapon-type (field 2, value 0,
+    # as opposed to magic-type 1). An id the `property` table does not define
+    # (a fixture, or an id past what a real database ever leaves undefined)
+    # reads as magic-type -- the permissive default, since gating a skill on
+    # an attribute this build cannot look up would lock it out with no way
+    # for the player to fix it.
+    def attribute_weapon_type?(aid)
+      return false unless @db.respond_to?(:property) && @db.property
+      row = @db.property[aid]
+      row && row.respond_to?(:type) && row.type == 0 ? true : false
     end
 
     # The base HP/SP amount a recovery skill restores, per RPG2000's formula

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2187,14 +2187,16 @@ class ClassedRow < SkillRow
 end
 
 class FakeActorDB
-  attr_reader :player, :system, :item, :skill, :job, :situation
-  def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil)
+  attr_reader :player, :system, :item, :skill, :job, :situation, :property
+  def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil,
+                 property = nil)
     @player = players
     @system = FakeActorSystem.new(party_ids)
     @item = items
     @skill = skills
     @job = jobs
     @situation = situation
+    @property = property
   end
 end
 
@@ -3422,6 +3424,45 @@ check 'field_skills lists only known field-usable ally skills; can_cast? checks 
   eq true, st.party.can_cast?(hero, 7)
   eq false, st.party.can_cast?(hero, 10)       # 99 SP > 30
   eq false, st.party.can_cast?(hero, 99)       # unknown skill
+end
+
+# A property/attribute row exposing just the weapon (0) / magic (1) `type`
+# flag the equip-gating check reads (field 2 of the real `property` row).
+AttrTypeRow = Struct.new(:type)
+
+check "can_cast?: a weapon-type Attribute skill needs a weapon carrying it equipped" do
+  # Attribute 1 is weapon-type, attribute 2 is magic-type.
+  props = { 1 => AttrTypeRow.new(0), 2 => AttrTypeRow.new(1) }
+  items = {
+    10 => fake_item(type: 1, name: 'Flame Sword', attribute_set: [true]),  # weapon, attr 1
+    11 => fake_item(type: 3, name: 'Flame Armor', attribute_set: [true]),  # armour, attr 1
+    12 => fake_item(type: 1, name: 'Plain Sword'),                        # weapon, no attrs
+  }
+  skills = {
+    7 => fake_skill(name: 'Fire Slash', scope: 0, sp_cost: 1, power: 10,
+                    attribute_effects: [true]),               # attr 1, weapon-type
+    8 => fake_skill(name: 'Ice Bolt', scope: 0, sp_cost: 1, power: 10,
+                    attribute_effects: [false, true]),        # attr 2, magic-type
+  }
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  st = Game::State.new(
+    Game::Party.new(FakeActorDB.new(players, [1], items, skills, {}, nil, props)), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(7)
+  hero.learn_skill(8)
+
+  eq false, st.party.can_cast?(hero, 7), 'no weapon at all -- the attribute is unmet'
+  hero.equip([12])
+  eq false, st.party.can_cast?(hero, 7), "a weapon that doesn't carry the attribute"
+  hero.equip([11])
+  eq false, st.party.can_cast?(hero, 7), 'armour carrying the attribute does not satisfy it'
+  hero.equip([10])
+  eq true, st.party.can_cast?(hero, 7), 'the matching weapon is equipped'
+
+  # The magic-type attribute never gates, equipped or not.
+  hero.equip([])
+  eq true, st.party.can_cast?(hero, 8)
 end
 
 check 'an all-ally heal skill heals the whole party (caster included) and spends SP' do


### PR DESCRIPTION
## Summary

yado.tk's `2k/09_bug/028_tokushu_huka/` finding (`docs/TODO.md`), corroborated independently via the Attribute database page: *"a skill whose Attack/Defense Attribute is configured as a **weapon** attribute (vs. a **magic** attribute) can only be used while a weapon carrying that same attribute is equipped; armour with the same attribute does not satisfy it."*

Skill usability modelled no attribute-based equip-gating at all before this — genuinely unimplemented, not a "confirm already correct" item.

## Changes

- `Game::Party#weapon_attribute_ready?` (`mruby-rpg2k/mrblib/game.rb`): for each id in a skill's `attribute_effects` (the same field `#skill_attributes` already reads for battle damage scaling), checks the database `property` table's `type` field (0 weapon / 1 magic). For the weapon-type ones only, requires `Actor#weapon_attributes` — the union of the equipped **weapon-slot** item's `attribute_set`, already used for battle damage scaling — to cover every one of them. A magic-type attribute, or a skill with no attribute at all, gates nothing. Armour carrying the attribute doesn't help, since `#weapon_attributes` only reads the weapon slot.
- `Game::Party#attribute_weapon_type?`: the `property` table lookup, defaulting an unknown/undefined attribute to magic-type (permissive — gating on an attribute this build can't look up would lock a skill out with no way for the player to fix it).
- Wired into `Game::Party#can_cast?`, the single choke point every cast path (field `cast_skill`, battle `battle_skill_command`/`command_skill`, and the Escape/Teleport/Switch skill types) already runs through, alongside the existing knows-it / can-afford-it checks.
- A skill naming more than one weapon-type attribute needs all of them covered (one weapon, or several via dual-wield) — the literal reading of "a weapon carrying **that** attribute," not confirmed against a real multi-attribute skill since neither downloaded test bed ships one. Flagged as such in `docs/TODO.md` rather than presented as verified.
- **Explicitly left alone**: the doc's neighboring note that weapon-type × magic-type attribute stacking on one attack multiplies the two rates as fractions (200%×50%=100%) rather than averaging. That's a separate question in the damage formula (`Game::Battle#attr_multiplier`, which currently takes the strongest single rate), not skill usability — still open, not touched by this PR.

## Testing

- `scripts/rpg2k_logic_check.rb`: 632 checks passing (1 new) — no weapon at all, a weapon lacking the attribute, armour carrying the attribute, the matching weapon equipped, and a magic-type attribute skill gating nothing either way. Confirmed to fail against the pre-fix code before the fix.
- `scripts/rpg2k_scene_check.rb`: 288 checks passing (unaffected).
- `scripts/rpg2k_render_check.rb`: 40 checks passing (unaffected).
- `scripts/rpg2k_testbed_logic_check.rb`: 94 checks passing against the real downloaded Nepheshel data (unaffected — `can_cast?`'s new gate is a no-op for every skill that names no weapon-type attribute).
- Native CTest suite not run (no C++/LCF-schema changes; pure-Ruby logic addition covered by the harnesses above).
- Already based on latest `master` (through PR #508) — no rebase needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_