### PR TITLE
Implement random ("wandering monster") encounters

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@
   centre-to-border windows are drawn as a mask over the map; the styles that need
   the scene itself moved or resampled (scrolls, zoom, mosaic, wave, random
   blocks) still run as a fade of the correct length
+- **Random ("wandering monster") encounters** start a fight on their own while
+  the party walks around, not just from a scripted Enemy Encounter event
+  command: the map tree's own encounter list and step count drive the same
+  probability curve RPG_RT uses (the longer a walk goes without a fight, the
+  likelier the next step is to have one), a hit picks a troop from the map's
+  list (honouring each troop's own terrain restriction), and the party can be
+  ambushed by RPG2000's 1-in-32 first-strike roll. Flying past it on the
+  airship, or being marched by a forced move route, never rolls
 - A troop's **battle-event pages** run during a fight: their conditions (switch,
   variable, turn, enemy/actor HP, plus RPG2003's per-battler turn counters and
   party fatigue) are re-checked each turn, and a matching page runs the ordinary

--- a/changelog.d/rpg2k-random-encounters.added.md
+++ b/changelog.d/rpg2k-random-encounters.added.md
@@ -1,0 +1,31 @@
+- RPG Maker 2000: **random ("wandering monster") encounters** — until now the
+  only way to start a fight was a scripted Enemy Encounter event command; the
+  map tree's own encounter list (field 41 `enemy_groups`, field 44
+  `encount_steps`, 25 by default) went unread. `Scene::Map#check_random_encounter`
+  ports EasyRPG's `Game_Player::UpdateEncounterSteps`: every ordinary
+  (non-forced) step adds the tile's terrain `encounter_rate` (database terrain
+  field 3, 100 by default) to a running total, whose ratio to the map's step
+  count is looked up in RPG_RT's own encounter table to scale that step's
+  chance of a fight — a long walk with no encounter steadily grows more
+  likely to end in one. A hit picks a uniform-random troop from the current
+  map's own list, filtered by each troop's `terrain_set` (an omitted entry
+  defaults to allowed), and opens the battle through a new
+  `Game::Interpreter#start_random_battle` — the same request shape and
+  `:battle` wait an Enemy Encounter command builds, just with no
+  [Victory]/[Escape]/[Defeat] handler to route into. Escape is always allowed
+  and a wipe is always game over, since a random encounter carries none of an
+  Enemy Encounter command's own settings. First strike rolls RPG2000's own
+  1-in-32 chance (EasyRPG's `Rand::ChanceOf(1, 32)` under
+  `Feature::HasRpg2kBattleSystem`; 2003's back-attack/pincer terrain rolls are
+  a different battle system and do not apply here). Flying (the airship) is
+  RPG_RT's one blanket exemption; a forced move route (a Move Event on the
+  player, or Proceed With Movement) never rolls either, matching EasyRPG's own
+  gate on ordinary input-driven movement. `Change Encounter Rate` (11740)
+  overrides the map's own step count, and the running total persists across a
+  save (`Game::State#encounter_total`) the same way EasyRPG's own
+  `total_encounter_rate` does — the encounter-table row it reads is
+  deliberately not, matching EasyRPG's own unsaved `last_encounter_idx`.
+  Covered by new `scripts/rpg2k_scene_check.rb` checks (a guaranteed roll
+  opening the right troop, an empty list never firing, `terrain_set`
+  filtering, the airship exemption, a forced route never rolling, and the
+  step-count lookup/override/default/disable cases).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1230,6 +1230,42 @@ The work below is roughly ordered by the critical path to a walkable game
   `mruby-rgss/src/lib.cxx`. Note the obvious probe is misleading: the Nepheshel
   opening is nearly black (frame mean ~32/255), where a *subtractive* tint
   changes almost nothing even when it is working — use an additive one
+- ✅ Random ("wandering monster") encounters — until now the only way to start
+  a fight was a scripted Enemy Encounter event command; the map tree's own
+  encounter list (`map_properties` field 41 `enemy_groups`, field 44
+  `encount_steps`, 25 by default) went unread. `Scene::Map#check_random_encounter`
+  ports EasyRPG's `Game_Player::UpdateEncounterSteps`: every ordinary
+  (non-forced) step adds the stepped-on tile's terrain `encounter_rate`
+  (database terrain field 3, 100 by default) to a running total, whose ratio to
+  the map's step count is looked up in RPG_RT's own encounter table
+  (`ENCOUNTER_TABLE`) to scale that step's chance of a fight — the chance rises
+  the longer a walk goes without one, rather than staying flat. A hit picks a
+  uniform-random troop from the current map's own list, filtered by each
+  troop's `terrain_set` (enemy_group field 5; an entry too short to reach the
+  tile's terrain tag defaults to allowed, the same rule this runtime's other
+  bit tables already follow), and opens the battle through a new
+  `Game::Interpreter#start_random_battle` — the same request shape and
+  `:battle` wait an Enemy Encounter command builds, minus the
+  [Victory]/[Escape]/[Defeat] handler routing (a random encounter is not a
+  command in any list, so there is nothing to route back into): escape is
+  always allowed and a wipe is always game over. First strike rolls RPG2000's
+  own 1-in-32 chance (EasyRPG's `Rand::ChanceOf(1, 32)` under
+  `Feature::HasRpg2kBattleSystem`; 2003's back-attack / pincer terrain rolls
+  are a different battle system this runtime does not model). Flying (the
+  airship) is RPG_RT's one blanket exemption, matched here via
+  `Game::Party#flying?`; a forced move route (a Move Event on the player, or
+  Proceed With Movement) never rolls either, tracked by a new
+  `@player_forced_step` flag set at the two places a player slide can start —
+  matching EasyRPG's own gate on ordinary input-driven movement only.
+  `Change Encounter Rate` (11740) overrides the map's own step count for the
+  rest of the visit; the running total persists across a save
+  (`Game::State#encounter_total`, matching EasyRPG's own
+  `total_encounter_rate`), while the encounter-table row it last reached does
+  not, matching EasyRPG's own unsaved `last_encounter_idx`. Covered by new
+  `scripts/rpg2k_scene_check.rb` checks (a guaranteed roll opening the right
+  troop, an empty list never firing, `terrain_set` filtering, the airship
+  exemption, a forced route never rolling despite a guaranteed-roll setup, and
+  the step-count lookup / override / default / disable cases)
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7004,9 +7004,15 @@ module Game
     # off (the hero is shown) and is persisted in the save.
     attr_accessor :player_transparent
     # Random-encounter step rate set by Change Encounter Rate (11740); nil until
-    # a command overrides it (the map's own rate then applies). No encounter
-    # subsystem consumes it yet — kept for save fidelity.
+    # a command overrides it (the map's own rate then applies).
     attr_accessor :encounter_rate
+    # The wandering-monster accumulator Scene::Map's #check_random_encounter
+    # builds up each step (EasyRPG's Game_Player::total_encounter_rate) —
+    # persisted so a save mid-walk does not quietly reroll the chance of the
+    # next few steps. The table index that reads it (EasyRPG's
+    # last_encounter_idx) is deliberately *not* persisted, matching EasyRPG:
+    # it is a plain runtime counter, not part of the save.
+    attr_accessor :encounter_total
     # How many tiles the party has walked. RPG2000 divides this into each
     # status condition's own step interval to decide when a field ailment slips
     # HP / SP (see Party#apply_map_step_damage), which is the only thing reading
@@ -7068,6 +7074,7 @@ module Game
       @bgm_looped = false
       @player_transparent = false
       @encounter_rate = nil
+      @encounter_total = 0
       @steps = 0
       @save_count = 0
       @battle_count = 0
@@ -7255,7 +7262,8 @@ module Game
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
         player_transparent: @player_transparent, weather: @weather.to_h,
         teleport_access: @teleport_access, escape_access: @escape_access,
-        encounter_rate: @encounter_rate, teleport_targets: @teleport_targets,
+        encounter_rate: @encounter_rate, encounter_total: @encounter_total,
+        teleport_targets: @teleport_targets,
         steps: @steps,
         save_count: @save_count, battle_count: @battle_count,
         win_count: @win_count, defeat_count: @defeat_count,
@@ -7637,6 +7645,7 @@ module Game
       # Registries default empty / unset; a save written before these existed
       # simply restores nothing.
       state.encounter_rate = h[:encounter_rate]
+      state.encounter_total = h[:encounter_total] || 0
       state.steps = h[:steps] || 0
       state.save_count = h[:save_count] || 0
       state.battle_count = h[:battle_count] || 0

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1200,6 +1200,28 @@ module Game
       @waiting = true
     end
 
+    # Start a battle that no event triggered — a wandering-monster encounter
+    # the map rolled on its own (Scene::Map#check_random_encounter), which is
+    # not a command in any list. Same request shape #do_enemy_encounter
+    # builds and the same :battle wait, but with no [Victory]/[Escape]/[Defeat]
+    # handler to route into and nothing to end early on an "abort" escape
+    # mode, so #resume_battle's job shrinks to tallying the outcome and
+    # clearing the wait. Only valid while this interpreter is otherwise idle
+    # (Scene::Map only calls it from ordinary player movement, never while an
+    # event is running); escape is always allowed and a wipe is always game
+    # over, since a random encounter carries no encounter-specific settings of
+    # its own to say otherwise.
+    def start_random_battle(troop_id, first_strike: false)
+      @battle_has_handlers = false
+      @battle_escape_aborts = false
+      @battle_request = { troop_id: troop_id, allow_escape: true,
+                          first_strike: first_strike, defeat_game_over: true }
+      @state.battle_count += 1
+      @wait_kind = :battle
+      @waiting = true
+    end
+    public :start_random_battle
+
     # -- state commands -------------------------------------------------------
 
     def range(cmd)

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -148,6 +148,17 @@ class RPG2k
         @last_frame = nil
         # Frame counter driving the chipset's water/animated-tile animation.
         @anim_frame = 0
+        # Whether the slide in progress was started by a forced route (a Move
+        # Event on the player, or Proceed With Movement) rather than ordinary
+        # player-input walking. #check_random_encounter only rolls on the
+        # latter (see the comment there), matching EasyRPG's
+        # UpdateEncounterSteps, which UpdateNextMovementAction only calls from
+        # the input-driven path.
+        @player_forced_step = false
+        # The wandering-monster encounter table row #check_random_encounter is
+        # on (EasyRPG's Game_Player::last_encounter_idx) -- a plain runtime
+        # counter, not part of the save (see Game::State#encounter_total).
+        @encounter_idx = 0
 
         setup_sprites
         render
@@ -1970,6 +1981,7 @@ class RPG2k
         @moving = true
         @move_count = 0
         @player_jumping = @player_char.jumped
+        @player_forced_step = true
       end
 
       # Advance the party's pixel slide by one frame, landing it on the
@@ -1990,6 +2002,10 @@ class RPG2k
           @move_count = 0
           @player_jumping = false
           note_party_step
+          # Random (wandering-monster) encounters only roll for ordinary
+          # player-input steps, never for a forced route -- see
+          # #check_random_encounter and the @player_forced_step comment above.
+          check_random_encounter unless @player_forced_step
           follow_vehicle if @state.boarded? # the ridden vehicle tracks the party
         end
         # True for the landing frame as well as the ones before it: that frame
@@ -5180,6 +5196,7 @@ class RPG2k
         @dest_y = ny
         @moving = true
         @move_count = 0
+        @player_forced_step = false
       end
 
       # One tile walked. Advance the party's step counter and let RPG2000's field
@@ -5210,6 +5227,118 @@ class RPG2k
         row = terrain_row_at(@state.x, @state.y)
         return [] unless row && row.respond_to?(:damage)
         @state.party.apply_terrain_damage(row.damage)
+      end
+
+      # -- Random ("wandering monster") encounters -----------------------------
+      #
+      # Port of EasyRPG's Game_Player::UpdateEncounterSteps: each ordinary step
+      # adds the stepped-on tile's terrain encounter_rate (database terrain
+      # field 3, 100 by default) to a running total; the ratio of that total to
+      # the map's own encounter-steps setting selects a row of this table, and
+      # the row's multiplier scales the chance a fight starts *this* step. The
+      # ratio only grows (nothing decays it) until a fight actually starts, so
+      # a long walk with no encounter becomes steadily more likely to end in
+      # one -- RPG2000's answer to "I haven't been ambushed in ages".
+      ENCOUNTER_TABLE = [
+        [0, 0.0625], [20, 0.125], [40, 0.25], [60, 0.5], [100, 2.0],
+        [140, 4.0], [160, 8.0], [180, 16.0], [Float::INFINITY, 16.0]
+      ].freeze
+
+      # p scaled to basis points over this and rolled through Rng#scaled rather
+      # than #random -- the fix Battle#critical? needed (see Game::Rng#scaled):
+      # a plain modulus biases a small, threshold-sized chance high, and this
+      # table's lower rows (as little as 1/16 of 1/encounter_steps) are exactly
+      # that shape.
+      ENCOUNTER_CHANCE_SCALE = 1_000_000
+
+      # How many steps the map currently expects between encounters: a live
+      # Change Encounter Rate (11740) override when one is set, else the
+      # current map-tree node's own encount_steps (field 44, 25 by default --
+      # RPG2000's editor default). 0 (from either source) turns encounters off
+      # for this map outright, matching EasyRPG's own steps<=0 exit.
+      def current_encounter_steps
+        return @state.encounter_rate if @state.encounter_rate
+        row = map_node_properties
+        row && row.respond_to?(:encount_steps) ? row.encount_steps : 25
+      end
+
+      # The current map's own map-tree node row -- Game::MapAccess's per-id
+      # lookup, minus the "walk up to the parent" half of it: a map's random
+      # encounters are its own list end to end, RPG_RT never inherits one from
+      # an ancestor node the way it does Save/Teleport/Escape access.
+      def map_node_properties
+        props = map_properties
+        props ? props[@state.map_id] : nil
+      end
+
+      # Troop ids the party's current tile can start a fight from: the map's
+      # own encounter list (map-tree field 41), filtered by each troop's own
+      # terrain_set (enemy_group chunk field 5) -- a per-terrain-tag allow list
+      # a troop's editor page can restrict it to. An omitted entry (the array
+      # too short to reach this tile's tag) defaults to allowed, the same
+      # "missing entry reads as the field's default" rule the rest of this
+      # runtime's bit tables already follow.
+      def candidate_troops
+        row = map_node_properties
+        return [] unless row && row.respond_to?(:enemy_groups) && row.enemy_groups
+        tag = terrain_id(@state.x, @state.y)
+        row.enemy_groups.map { |_, e| e.enemy_group_id }.select do |tid|
+          troop_allowed_on_terrain?(tid, tag)
+        end
+      end
+
+      def troop_allowed_on_terrain?(tid, tag)
+        return true unless tag && tag > 0 && db.respond_to?(:enemy_group)
+        troop = db.enemy_group[tid]
+        return true unless troop
+        ts = troop.respond_to?(:terrain_set) ? troop.terrain_set : nil
+        return true unless ts
+        ts.size < tag || (ts[tag - 1] || 0) != 0
+      end
+
+      # One ordinary step's roll for a wandering-monster fight. A hit picks a
+      # uniform-random troop from #candidate_troops (an empty list -- a map
+      # with no encounter entries reaching this tile -- never interrupts the
+      # walk) and opens the battle exactly as an Enemy Encounter event command
+      # would, through the same Game::Interpreter#start_random_battle the
+      # interpreter exposes for it.
+      #
+      # Only ever called from ordinary player-input movement (see
+      # @player_forced_step), so the interpreter is always idle here -- no
+      # event, common event or forced route can be running underneath it.
+      def check_random_encounter
+        return if @state.party.flying?(@state)
+        steps = current_encounter_steps
+        if steps <= 0
+          @state.encounter_total = 0
+          @encounter_idx = 0
+          return
+        end
+        terrain = terrain_row_at(@state.x, @state.y)
+        rate = terrain && terrain.respond_to?(:encounter_rate) ? terrain.encounter_rate : 100
+        @state.encounter_total += rate
+        ratio = @state.encounter_total / steps
+        @encounter_idx += 1 while ratio >= ENCOUNTER_TABLE[@encounter_idx + 1][0]
+        pmod = ENCOUNTER_TABLE[@encounter_idx][1]
+        chance = pmod * rate / (100.0 * steps)
+        return unless roll_encounter_chance(chance)
+        @state.encounter_total = 0
+        @encounter_idx = 0
+        troops = candidate_troops
+        return if troops.empty?
+        troop_id = troops[@rng.random(troops.size)]
+        # RPG2000's own first-strike roll for a wandering encounter (EasyRPG's
+        # Rand::ChanceOf(1, 32) under Feature::HasRpg2kBattleSystem; 2003's
+        # back-attack / pincer terrain rolls are a different battle system's
+        # feature and do not apply here).
+        @interpreter.start_random_battle(troop_id, first_strike: @rng.random(32).zero?)
+      end
+
+      def roll_encounter_chance(p)
+        chance = (p * ENCOUNTER_CHANCE_SCALE).round
+        chance = ENCOUNTER_CHANCE_SCALE if chance > ENCOUNTER_CHANCE_SCALE
+        chance = 0 if chance < 0
+        @rng.scaled(ENCOUNTER_CHANCE_SCALE) < chance
       end
 
       def target_tile(x, y, dir)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -467,12 +467,14 @@ end
 
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
               members: [], terrain_damage: 0, bush_depth: 0,
-              airship_land: true, airship_pass: true)
+              airship_land: true, airship_pass: true, map_tree: nil)
   db = fake_db(common, troop_pages, terrain_damage, bush_depth,
                airship_land: airship_land, airship_pass: airship_pass)
   state = Game::State.new(fake_party(members), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
-  RPG2k::Scene::Map.new(fake_parent(db), state)
+  parent = fake_parent(db)
+  parent.map_tree = map_tree if map_tree
+  RPG2k::Scene::Map.new(parent, state)
 end
 
 # The scene builds a Game::Character per source event; movement updates those
@@ -6003,6 +6005,106 @@ check 'a transformed monster is redrawn with its new battler graphic' do
   same = ui[:enemy_sprites][0]
   scene.send(:refresh_battle_sprites)
   ok ui[:enemy_sprites][0].equal?(same), 'an unchanged battler is left alone'
+end
+
+# -- random ("wandering monster") encounters ----------------------------------
+#
+# Map-tree node field 41 (enemy_groups) / 44 (encount_steps), read the same
+# way #fake_map_tree already feeds Game::MapAccess's own per-node lookup.
+
+FakeEncounterNode = Struct.new(:enemy_groups, :encount_steps)
+
+check 'a random encounter opens a battle with the map-tree node\'s own troop' do
+  # encount_steps 1 with the default terrain rate (100) is a guaranteed roll
+  # on the very first step: ratio = 100/1 = 100, which lands on the table's
+  # pmod-2.0 row, and 2.0 * 100 / (100 * 1) is a 100% chance.
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
+  scene = new_scene({}, player: [0, 0], map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.dir_value = 6 # hold right
+  ui = nil
+  20.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui
+  end
+  RGSS::Input.dir_value = 0
+  ok ui, 'ordinary walking with a guaranteed roll opened a battle'
+  eq 1, ui[:troop].id, "the map tree node's own troop (id 1, the default Slimes)"
+  eq 0, st.encounter_total, 'the accumulator resets once a fight actually starts'
+end
+
+check 'an empty encounter list never starts a random battle' do
+  tree = fake_map_tree(1 => FakeEncounterNode.new({}, 1)) # same guaranteed roll, no troops
+  scene = new_scene({}, player: [0, 0], map_tree: tree)
+  RGSS::Input.dir_value = 6
+  15.times { scene.update }
+  RGSS::Input.dir_value = 0
+  ok scene.instance_variable_get(:@battle_ui).nil?,
+     'the roll succeeds but there is nothing to fight, so no battle opens'
+end
+
+check 'riding the airship skips the random-encounter roll entirely' do
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
+  scene = new_scene({}, player: [0, 0], map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  st.boarded = :airship
+  scene.send(:check_random_encounter)
+  ok scene.instance_variable_get(:@battle_ui).nil?, 'flying is RPG_RT\'s one blanket exemption'
+  eq 0, st.encounter_total, 'the accumulator never even started'
+end
+
+check 'a forced move route does not roll for a random encounter' do
+  # A Move Event route driving the player is a forced step (@player_forced_step),
+  # not ordinary input-driven walking -- EasyRPG's UpdateEncounterSteps only
+  # ever runs from the latter (see the comment on @player_forced_step).
+  ic = Game::Interpreter::Cmd
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
+  auto = page(trigger: 3)
+  # target 10001 (player), freq 8, repeat off, skippable on, three MOVE_RIGHTs.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT,
+                                  [10001, 8, 0, 1, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT])]
+  scene = new_scene({ 1 => event(3, 3, auto) }, player: [0, 0], map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  30.times { scene.update }
+  ok st.x > 0, "the forced route actually moved the player, at x=#{st.x}"
+  ok scene.instance_variable_get(:@battle_ui).nil?,
+     'the whole forced route ran without ever rolling for an encounter'
+end
+
+check "current_encounter_steps reads the map tree node's own setting, " \
+     'overridden by Change Encounter Rate' do
+  tree = fake_map_tree(1 => FakeEncounterNode.new({}, 25))
+  scene = new_scene({}, map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  eq 25, scene.send(:current_encounter_steps), "the map tree node's own encount_steps"
+  st.encounter_rate = 4
+  eq 4, scene.send(:current_encounter_steps), 'Change Encounter Rate (11740) overrides it'
+end
+
+check 'a map with no tree data defaults to 25 encounter steps' do
+  scene = new_scene({})
+  eq 25, scene.send(:current_encounter_steps)
+end
+
+check 'an encounter-steps of 0 disables random encounters and resets the accumulator' do
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 0))
+  scene = new_scene({}, map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  st.encounter_total = 55
+  scene.send(:check_random_encounter)
+  eq 0, st.encounter_total, 'the accumulator resets rather than piling up while encounters are off'
+  ok scene.instance_variable_get(:@battle_ui).nil?
+end
+
+check "a troop's terrain_set excludes it from a tile it does not cover" do
+  scene = new_scene({})
+  scene.db.enemy_group[9] = OpenStruct.new(name: 'Wolves', members: {}, terrain_set: [0])
+  ok !scene.send(:troop_allowed_on_terrain?, 9, 1), 'terrain_set[0] (tag 1) is 0: forbidden'
+  ok scene.send(:troop_allowed_on_terrain?, 9, 2),
+     'terrain_set is only one entry long: an omitted tag defaults to allowed'
+  ok scene.send(:troop_allowed_on_terrain?, 1, 1),
+     'the default Slimes group carries no terrain_set at all: always allowed'
 end
 
 # -- summary ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds support for random encounters that trigger automatically while the party walks around the map, matching RPG Maker 2000's encounter system. Previously, battles could only be started through scripted Enemy Encounter event commands.

## Key Changes

- **Scene::Map encounter logic** (`mruby-rpg2k/mrblib/scene/map.rb`):
  - Added `@player_forced_step` flag to distinguish between ordinary player-input movement and forced move routes (which never trigger encounters)
  - Added `@encounter_idx` runtime counter tracking the current row in the encounter probability table
  - Implemented `check_random_encounter` method that ports EasyRPG's `UpdateEncounterSteps`: accumulates terrain encounter rates each step, looks up the ratio in `ENCOUNTER_TABLE` to scale the chance, and rolls for a fight
  - Added `ENCOUNTER_TABLE` constant defining RPG2000's probability curve where longer walks without encounters become increasingly likely to trigger one
  - Implemented `current_encounter_steps` to read the map tree's step count (with `Change Encounter Rate` override support)
  - Implemented `candidate_troops` to filter the map's encounter list by each troop's `terrain_set` restrictions
  - Implemented `troop_allowed_on_terrain?` to check if a troop can spawn on a given terrain tag
  - Implemented `roll_encounter_chance` using scaled RNG to avoid bias on small probabilities
  - Set `@player_forced_step = true` when starting a forced move route, and `false` when starting ordinary input-driven movement
  - Only call `check_random_encounter` after ordinary steps, never after forced steps

- **Game::Interpreter** (`mruby-rpg2k/mrblib/interpreter.rb`):
  - Added `start_random_battle` method to initiate battles from random encounters (same request shape as Enemy Encounter commands, but with no handler routing and always-allowed escape)

- **Game::State** (`mruby-rpg2k/mrblib/game.rb`):
  - Added `@encounter_total` attribute to persist the encounter accumulator across saves (matching EasyRPG's `total_encounter_rate`)
  - Updated serialization (`to_h` and `load`) to include `encounter_total`

- **Test coverage** (`scripts/rpg2k_scene_check.rb`):
  - Added comprehensive checks for guaranteed rolls opening the correct troop, empty encounter lists never firing, terrain restrictions, airship exemption, forced routes never rolling, and step-count lookup/override/default/disable cases
  - Updated `new_scene` helper to support passing a `map_tree` parameter

- **Documentation**:
  - Updated `TODO.md` and `README.md` with feature description
  - Added changelog entry explaining the implementation

## Notable Implementation Details

- The encounter probability table uses a ratio-based lookup system where the accumulator grows unbounded until a fight starts, implementing RPG2000's "the longer you walk, the more likely an encounter" mechanic
- Terrain encounter rates (default 100) are added to the accumulator each step, allowing different terrain types to affect encounter frequency
- The encounter table row index is deliberately *not* persisted (only the accumulator is), matching EasyRPG's design
- First-strike probability uses RPG2000's 1-in-32 chance, rolled independently from the encounter trigger
- Flying on the airship is the only blanket exemption from random encounters
- Forced move routes (Move Event commands or Proceed With Movement) are tracked separately and never trigger encounters, matching EasyRPG's gate on input-driven movement only

https://claude.ai/code/session_01TyFbA9EkMdeUsdAkkCMX8p