### PR TITLE
Confirm event hit-testing already uses the target tile mid-step

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1877,9 +1877,18 @@ Everything below is unverified against the codebase.
   drawing on top, independent of show order, is confirmed already correct —
   see below.)
 - **Map Event** — "hero touches event" does *not* fire in three specific
-  cases: (a) the event has already logically started moving into its next
+  cases: (a) ✅ the event has already logically started moving into its next
   tile (hit-test uses the target tile, even if the sprite still visually
-  overlaps the old one); (b) the event moved onto the hero's own tile
+  overlaps the old one) — **already correctly modelled**. `Scene::Map
+  #reoccupy` rewrites `@event_tiles` (what a touch trigger / the player's own
+  passability check reads) to the destination tile the instant a step
+  commits, in the same call that starts the pixel slide (`#start_event_slide`)
+  toward it — the vacated tile's hit-test clears immediately, well before
+  `#event_sliding?` (`disp_x`/`disp_y` catching up to the logical tile) says
+  the sprite has visually arrived. No code change; covered by a new
+  `scripts/rpg2k_scene_check.rb` check pinning that exact gap between the
+  logical and display position mid-step. (b) the event moved onto the hero's
+  own tile
   (event-initiated contact doesn't count for this trigger — **already
   correctly modelled**, `move_autonomous` only checks trigger 2 for that
   case); (c) hero and event simultaneously swap tiles by crossing paths —

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1486,6 +1486,38 @@ check 'Erase Event removes the running event from the map' do
   ok !tiles[[2, 2]], 'its occupied tile is cleared (no marker, no collision)'
 end
 
+check "an event's occupied tile updates the instant it steps, before the " \
+      "sprite finishes sliding (yado.tk: \"hero touches event\" case (a))" do
+  # A same-layer event stepping right once. RPG_RT's hit-test (what a
+  # touch-trigger or the player's own passability check reads) is grid-based
+  # on the character's *logical* tile, updated the moment the step commits --
+  # not the sprite's on-screen position, which eases toward it over several
+  # more frames (#event_sliding? / #reoccupy).
+  pg = page(x_move_type: Game::MoveType::CUSTOM,
+            route: move_route([R::MOVE_RIGHT], repeat: false, skippable: false),
+            frequency: 8)
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [5, 5])
+  tiles = scene.instance_variable_get(:@event_tiles)
+  ok tiles[[2, 2]] && tiles[[2, 2]][:id] == 1, 'starts on its own tile'
+
+  # Advance to the first frame the character's logical tile reads (3, 2).
+  ev = nil
+  20.times do
+    scene.update
+    ev = event_hashes(scene)[1]
+    break if [ev[:char].x, ev[:char].y] == [3, 2]
+  end
+  eq [3, 2], [ev[:char].x, ev[:char].y], 'the character stepped to (3, 2)'
+  ok ev[:moving], 'and the sprite is still easing toward it, not there yet'
+
+  tiles = scene.instance_variable_get(:@event_tiles)
+  ok tiles[[2, 2]].nil?,
+     "the vacated tile's hit-test cleared the instant the step committed, " \
+     'even though the sprite is still drawn overlapping it'
+  ok tiles[[3, 2]] && tiles[[3, 2]][:id] == 1,
+     'and the destination tile is claimed for hit-testing immediately too'
+end
+
 check 'Erase Event stops a parallel process that erases itself' do
   ic = Game::Interpreter::Cmd
   par = page(trigger: 4) # parallel: bump var 1, then erase myself


### PR DESCRIPTION
## Summary

yado.tk's Map Event backlog note (`docs/TODO.md`), case (a) of "'hero touches event' does not fire in three specific cases": *"the event has already logically started moving into its next tile (hit-test uses the target tile, even if the sprite still visually overlaps the old one)."*

Tracing the code found this already correct — no production code change, just regression coverage, the same shape as PR #498 (Call Event indirect-mode confirm).

## Investigation

`Scene::Map#reoccupy` rewrites `@event_tiles` — what a touch trigger and the player's own passability check both read — to the destination tile in the same call that starts the pixel slide (`#start_event_slide`) toward it:

```ruby
def reoccupy(e, ox, oy)
  @event_tiles.delete([ox, oy]) if @event_tiles[[ox, oy]].equal?(e)
  @event_tiles[[e[:char].x, e[:char].y]] = e
  start_event_slide(e, ox, oy)
end
```

So the vacated tile's hit-test clears — and the destination tile's is claimed — the instant a step commits, well before `#event_sliding?` (comparing `disp_x`/`disp_y`, the sprite's display origin, against the character's logical tile) says the sprite has visually caught up. Exactly the yado.tk-documented gap between logical and visual position.

## Changes

- No production code changed.
- `docs/TODO.md`: marked case (a) ✅, recording the mechanism.
- New `scripts/rpg2k_scene_check.rb` check: an event on a `CUSTOM` move route steps once; the check advances frame-by-frame to the exact moment the character's logical tile updates, asserts the sprite is still mid-slide (`event_sliding?` true) at that same moment, and asserts `@event_tiles` already shows the old tile vacated and the new tile claimed — pinning the gap the doc describes rather than just asserting the end state.

## Testing

- `scripts/rpg2k_scene_check.rb`: 289 checks passing (1 new).
- `scripts/rpg2k_logic_check.rb`: 632 checks passing (unaffected).
- `scripts/rpg2k_render_check.rb`: 40 checks passing (unaffected).
- Native CTest suite not run (no C++/LCF-schema changes).
- Already based on latest `master` (through PR #509) — no rebase needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_