### PR TITLE
Remove MRB_STR_LENGTH_MAX cap for unlimited string support

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -149,10 +149,13 @@ if wio
     [conf.cc, conf.cxx].each do |t|
       t.flags = t.flags.flatten.delete_if { |v| v == '-O0' }
       t.flags += cpu_flags
-      # Bare-metal newlib: give game data (maps/images loaded as strings) room
-      # beyond the 1 MiB default cap. Actual RAM fit is a separate concern
-      # handled by the streaming rework (P3).
-      t.defines << 'MRB_STR_LENGTH_MAX=4194304'
+      # Bare-metal newlib falls through mruby's string.c to a 1 MiB default cap
+      # (see below); game data (maps/images loaded as strings, and whole packed
+      # archives read in one shot by RGSSAD.open) can exceed that many times
+      # over, so disable the cap outright (0 = unlimited), matching what
+      # mruby already does for free on Linux/macOS/BSD. Actual RAM fit is a
+      # separate concern handled by the streaming rework (P3).
+      t.defines << 'MRB_STR_LENGTH_MAX=0'
     end
     conf.linker.flags += cpu_flags
 
@@ -197,9 +200,12 @@ if psp
       t.defines << 'PSP_BUILD'
       # newlib on the PSP defines none of __linux__/__APPLE__/__*BSD__, so
       # mruby's string.c falls through to the 1 MiB MRB_STR_LENGTH_MAX cap and
-      # rejects larger strings. Game data (maps, images loaded as strings) can
-      # exceed 1 MiB, so raise it to 4 MiB, matching the wasm/Wio builds.
-      t.defines << 'MRB_STR_LENGTH_MAX=4194304'
+      # rejects larger strings. Game data (maps, images loaded as strings, and
+      # whole packed archives read in one shot by RGSSAD.open) can exceed that
+      # many times over, so disable the cap outright (0 = unlimited), matching
+      # the wasm/Wio builds and what mruby already does for free on
+      # Linux/macOS/BSD.
+      t.defines << 'MRB_STR_LENGTH_MAX=0'
     end
     conf.linker.flags += cpu_flags
 
@@ -227,12 +233,15 @@ if emscripten
 
     [conf.cc, conf.cxx].each do |t|
       t.flags = t.flags.flatten.delete_if { |v| v == "-O0" }
-      # Raise the maximum string length to 4 MiB. On native platforms mruby
-      # defaults MRB_STR_LENGTH_MAX to 0 (unlimited), but Emscripten defines
-      # none of __linux__/__APPLE__/__*BSD__, so string.c falls through to the
-      # 1 MiB cap and rejects larger strings with "string too long". Game data
-      # (maps, images loaded as strings) can exceed 1 MiB, so bump it to 4 MiB.
-      t.defines << 'MRB_STR_LENGTH_MAX=4194304'
+      # On native platforms mruby defaults MRB_STR_LENGTH_MAX to 0 (unlimited),
+      # but Emscripten defines none of __linux__/__APPLE__/__*BSD__, so
+      # string.c falls through to a 1 MiB cap and rejects larger strings with
+      # "string too long". Game data (maps, images loaded as strings) routinely
+      # exceeds 1 MiB, and RGSSAD.open reads a whole packed archive into a
+      # single String, so any fixed cap just moves the crash to a bigger file
+      # (e.g. a real archive of 5.5 MiB blew past a prior 4 MiB cap here).
+      # Disable the cap outright, matching the native builds.
+      t.defines << 'MRB_STR_LENGTH_MAX=0'
     end
 
     rpg_maker_gems(conf)

--- a/changelog.d/rgssad-wasm-string-length-cap.fixed.md
+++ b/changelog.d/rgssad-wasm-string-length-cap.fixed.md
@@ -1,0 +1,17 @@
+- RPG Maker XP/VX archives bigger than 4 MiB now open on the WebAssembly
+  (browser) build. `RGSSAD.open` (`mruby-rpgxp/mrblib/rgssad.rb`, reused by VX
+  through `RPGXP::RGSSAD`) reads a whole packed `Game.rgssad` / `.rgss2a` /
+  `.rgss3a` into a single mruby `String` up front, before any per-entry
+  decryption happens. `build_config.rb`'s Emscripten (and PSP, Wio)
+  cross builds define `MRB_STR_LENGTH_MAX` because those platforms fall
+  through mruby's `string.c` to a 1 MiB default cap that native
+  Linux/macOS/BSD builds never hit; a prior fix raised it to 4 MiB to cover
+  large decrypted entries (`rpgxp-rgssad-large-entry.fixed.md`), but a whole
+  archive is routinely bigger than any individual entry, so any fixed cap
+  just relocates the crash to a bigger file — a real release's 5.5 MiB
+  `Game.rgssad` raised `Errno::ENOENT: No such file or directory -
+  Data/System.rxdata` at boot, because the archive open failed silently
+  (`open_archive`'s rescue logs `[RGSS] failed to open archive ...: string
+  too long` and treats it as absent) and no loose `Data/` shadowed it. The
+  cap is now disabled outright (`MRB_STR_LENGTH_MAX=0`), matching what mruby
+  already does for free on the native platforms.


### PR DESCRIPTION
## Summary
This change removes the fixed string length cap (`MRB_STR_LENGTH_MAX=4194304`) across all cross-platform builds (WebAssembly, PSP, and Wio) by setting it to `0` (unlimited), matching the behavior of native Linux/macOS/BSD builds.

## Key Changes
- **WebAssembly (Emscripten)**: Changed `MRB_STR_LENGTH_MAX` from `4194304` (4 MiB) to `0` (unlimited)
- **PSP build**: Changed `MRB_STR_LENGTH_MAX` from `4194304` (4 MiB) to `0` (unlimited)
- **Wio build**: Changed `MRB_STR_LENGTH_MAX` from `4194304` (4 MiB) to `0` (unlimited)
- Updated all associated comments to explain the rationale and document real-world issues with fixed caps

## Motivation
The previous 4 MiB cap was insufficient for real-world RPG Maker archives. `RGSSAD.open` reads entire packed archives (`.rgssad`, `.rgss2a`, `.rgss3a`) into a single mruby `String` before decryption, and archives routinely exceed 4 MiB. A real release with a 5.5 MiB `Game.rgssad` would fail silently during archive loading, causing boot failures with cryptic errors like `Errno::ENOENT: No such file or directory - Data/System.rxdata`.

By disabling the cap entirely on platforms that require it (those without `__linux__`, `__APPLE__`, or `*BSD` defines), we match the unlimited behavior that mruby already provides on native platforms, eliminating arbitrary file size restrictions.

https://claude.ai/code/session_014GDgnD4bxcGDxULT88NRT7