### PR TITLE
Charge display time for the \&lt;, \$, \^ message pacing codes

### DIFF
--- a/changelog.d/message-pacing-code-display-time.fixed.md
+++ b/changelog.d/message-pacing-code-display-time.fixed.md
@@ -1,0 +1,9 @@
+- **The `\<` (instant-span close), `\$` (show gold) and `\^` (auto-close)
+  message control codes now burn one tick of display time**, matching
+  yado.tk: they render no character but RPG_RT still advances the
+  typewriter counter for them, unlike `\c[]`/`\s[]` or `\>` (span open),
+  which stay free. `Game::Message.scan` advances its reveal-coordinate
+  `count` by one for those three codes; an instant span's own two
+  characters are unaffected (the tick lands right after the span closes,
+  not inside it), so text right after one of these codes now reveals one
+  frame later than before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2252,10 +2252,20 @@ not yet verified:
   (≤4 combined lines) — an explicit `\c[0]` reset is needed to stop
   choices inheriting the preceding text's color.
 - `\>` (instant display) only affects the current line — must be repeated
-  per line for a fully-instant multi-line message. `\<`, `\$`, `\^` each
-  cost one character's worth of display time even though they render
-  nothing; `\c[]`/`\s[]` cost none. `\^` doesn't work inside Show Choices
-  even though other codes do.
+  per line for a fully-instant multi-line message.
+- ✅ **`\<`, `\$`, `\^` each cost one character's worth of display time even
+  though they render nothing; `\c[]`/`\s[]` cost none.** `Game::Message.scan`
+  (`mruby-rpg2k/mrblib/game.rb`) now advances its `count` reveal-coordinate by
+  one for the closing `\<` of an instant span, `\$` (show gold) and `\^`
+  (auto-close) — the same coordinate space `\!`/`\./`\|` pauses and `\>`…`\<`
+  instant spans are recorded in — while leaving `\>` (span open) and
+  `\c[]`/`\s[]` untouched, matching the yado.tk finding that only those three
+  are "free". The instant span itself still only covers its literal
+  characters (the `\<` tick lands just after the span closes, not inside it),
+  so a pause or more text right after one of these three codes now reveals
+  one frame later than it would with the code removed — previously they were
+  pure no-ops in the reveal counter.
+- `\^` doesn't work inside Show Choices even though other codes do.
 - Message Options (window transparency/position) are **sticky global
   state** — once set, they apply to every subsequent message window for
   the rest of the game (or until reset), not scoped to the current event.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -133,13 +133,17 @@ module Game
           when '.'      then pauses << { at: count, kind: :quarter }
           when '|'      then pauses << { at: count, kind: :full }
           when '!'      then pauses << { at: count, kind: :key }
-          when '^'      then auto_close = true
-          when '$'      then show_gold = true # show the gold window
+          # `\^`, `\$` and the closing `\<` render nothing but still burn one
+          # tick of display time, same as a revealed character would (yado.tk);
+          # `\>` (span open) stays free, as does `\c[]`/`\s[]`.
+          when '^'      then auto_close = true; count += 1
+          when '$'      then show_gold = true; count += 1 # show the gold window
           when '>'      then instant_start = count if instant_start.nil?
           when '<'
             if instant_start
               instants << [instant_start, count]
               instant_start = nil
+              count += 1
             end
           # the remaining display code (`\s` speed) produces no characters and no
           # pacing here: dropped.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -556,7 +556,7 @@ check 'Message.scan records pacing codes in revealed-char coordinates' do
   def vars.[](i); { 3 => 42 }[i]; end
   names = ->(_i) { 'X' }
   s = Game::Message.scan('ab\.cd\|e\!f\^', vars, names)
-  eq 6, s[:length], '"abcdef" = 6 visible characters'
+  eq 7, s[:length], '"abcdef" = 6 visible characters + 1 tick for the trailing \\^'
   eq [{ at: 2, kind: :quarter }, { at: 4, kind: :full }, { at: 5, kind: :key }],
      s[:pauses]
   ok s[:auto_close], '\\^ sets auto_close'
@@ -571,7 +571,7 @@ check 'Message.scan flags \$ (show gold) and drops it from the text' do
   names = ->(_i) { '' }
   s = Game::Message.scan('Gold:\$ here', vars, names)
   ok s[:show_gold], '\\$ sets show_gold'
-  eq 'Gold: here'.length, s[:length], '\\$ emits no visible character'
+  eq 'Gold: here'.length + 1, s[:length], '\\$ emits no visible character but costs one tick'
   # No \$ -> flag stays off.
   ok !Game::Message.scan('plain', vars, names)[:show_gold]
 end
@@ -581,11 +581,29 @@ check 'Message.scan records \> \< instant spans (and an unclosed one to EOL)' do
   def vars.[](_i); 0; end
   names = ->(_i) { '' }
   s = Game::Message.scan('ab\>cd\<ef', vars, names)
-  eq 6, s[:length], '"abcdef" = 6 visible characters'
-  eq [[2, 4]], s[:instants], 'cd is the instant span'
+  eq 7, s[:length], '"abcdef" = 6 visible characters + 1 tick for the closing \\<'
+  eq [[2, 4]], s[:instants], 'cd is the instant span (the \\< tick lands after it)'
   # An unclosed \> runs to the end of the line.
   s2 = Game::Message.scan('ab\>cd', vars, names)
   eq [[2, 4]], s2[:instants]
+end
+
+check '\^, \$ and the closing \< each delay what follows by one reveal tick' do
+  vars = Object.new
+  def vars.[](_i); 0; end
+  names = ->(_i) { '' }
+  # A \! pause right after each code should land one position later than it
+  # would with no code there at all, since the code itself burns a tick.
+  baseline = Game::Message.scan('ab\!cd', vars, names)
+  eq [{ at: 2, kind: :key }], baseline[:pauses]
+  after_close = Game::Message.scan('ab\^\!cd', vars, names)
+  eq [{ at: 3, kind: :key }], after_close[:pauses], '\\^ pushes the pause one tick later'
+  after_gold = Game::Message.scan('ab\$\!cd', vars, names)
+  eq [{ at: 3, kind: :key }], after_gold[:pauses], '\\$ pushes the pause one tick later'
+  after_span = Game::Message.scan('ab\>x\<\!cd', vars, names)
+  eq [{ at: 4, kind: :key }], after_span[:pauses],
+     'the closing \\< pushes the pause one tick later (span "x" itself is unaffected)'
+  eq [[2, 3]], after_span[:instants], 'the instant span itself still only covers "x"'
 end
 
 check 'TextReveal reveals an instant span in a single advance' do


### PR DESCRIPTION
## Summary

- yado.tk documents that RPG_RT's message typewriter burns one tick of
  display time on the closing `\<` of an instant span, `\$` (show gold) and
  `\^` (auto-close) — even though none of the three render a visible
  character — while `\>` (span open) and `\c[]`/`\s[]` stay free.
  `Game::Message.scan` (`mruby-rpg2k/mrblib/game.rb`) previously never
  advanced its `count` reveal-coordinate for any of the three, so they were
  pure no-ops in the typewriter timing.
- Fix: advance `count` by one in the `'^'`, `'$'` and closing-`'<'` branches
  of `scan`. The instant span's own two characters are unaffected — the tick
  is recorded right after the span closes, not folded into it — so a pause
  or more text immediately following one of these three codes now reveals
  one frame later than before, matching the documented behavior.
- `docs/TODO.md` marks the bullet ✅ with the same detail; the previously
  merged `\^` doesn't work inside Show Choices" note is kept as its own
  still-open bullet (it isn't addressed by this change).

## Test plan

- [x] `scripts/rpg2k_logic_check.rb` — updated the three existing
  `Message.scan` assertions for the new tick counts and added a dedicated
  check (`\^, \$ and the closing \< each delay what follows by one reveal
  tick`) asserting a `\!` pause right after each code lands one position
  later than an equivalent message without the code, while confirming the
  instant span's own characters are unaffected. Confirmed the new/updated
  assertions fail against the pre-fix `game.rb` via `git stash`.
- [x] `scripts/rpg2k_scene_check.rb` — full suite still passes (297 checks).
- [x] `scripts/rpg2k_logic_check.rb` full suite passes (633 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_