### PR TITLE
Opening the Menu auto-cancels an Erase Screen black-out

### DIFF
--- a/changelog.d/menu-cancels-erase-screen.fixed.md
+++ b/changelog.d/menu-cancels-erase-screen.fixed.md
@@ -1,0 +1,6 @@
+- **Opening the Menu (Save included) now auto-cancels an active Erase Screen
+  black-out**, with no "Show Screen" involved — matching yado.tk: RPG_RT
+  never restores the black-out once the menu has been opened and closed.
+  `Scene::Menu#initialize` instantly clears `Game::Screen`'s fade level via
+  an explicit zero-frame `#show`, leaving an already-visible screen
+  untouched.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1938,7 +1938,8 @@ Everything below is unverified against the codebase.
   can be called except the dedicated Save-screen command; can't open during
   battle; opening it pauses *all* event processing including active
   timers/parallel processes; Erase Screen's black-out is undone if the
-  player opens and closes the menu.
+  player opens and closes the menu (✅ implemented — see the "Screen
+  effects" bullet below, same fact from a different site page).
 - **Load** — resuming mid-Autorun/mid-Parallel-Process picks up exactly
   where it left off, *unless* the map was edited/re-saved since, in which
   case that event restarts from the top (edge case, likely not applicable
@@ -2218,8 +2219,17 @@ not yet verified:
   are all completely unaffected even at a maximal dark tone; Erase Screen,
   by contrast, hides literally everything. Screen tone **persists across
   map transfers** with no auto-reset (unlike most per-map overrides).
-- **Erase Screen's blackout is auto-cancelled by opening and closing the
-  Menu or Save screen**, even though no "Show Screen" ran.
+- ✅ **Erase Screen's blackout is auto-cancelled by opening and closing the
+  Menu or Save screen**, even though no "Show Screen" ran. `Scene::Menu`
+  (Save is one of its commands, not a scene of its own — see the Menu screen
+  bullet above) now calls `@state.screen.show(Game::Transition::CUT_IN, 0)`
+  in its `#initialize`, the instant the menu opens: an explicit `frames: 0`
+  forces a same-frame settle to fully visible regardless of the style's own
+  length, and `Game::Transition::CUT_IN` (rather than `NONE`, which is a
+  true no-op) so an already-visible screen is left alone. `Game::Screen` is
+  shared off `Game::State` between `Scene::Map` and `Scene::Menu`, so
+  nothing re-erases it on return — matching RPG_RT never restoring the
+  black-out once the menu has been opened and closed.
 - Shake strength increases in fixed 2px increments per level; duration 0
   or flash intensity 0 both produce no visible effect (too brief to
   render, not merely "instant").

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -27,6 +27,12 @@ class RPG2k
         @commands = COMMAND_KEYS.map { |key, term_name, fallback|
           [key, term(term_name, fallback)]
         }
+        # yado.tk: opening the Menu (Save included — it has no scene of its own,
+        # see the :save command below) auto-cancels an Erase Screen black-out
+        # with no "Show Screen" involved, and RPG_RT never restores it when the
+        # menu closes. An instant cut rather than #show's default fade, since
+        # this snap happens the moment the menu opens, not over 35 frames.
+        @state.screen.show(Game::Transition::CUT_IN, 0)
         build_windows
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5275,6 +5275,23 @@ check 'the menu party list shows each member condition' do
   ok !texts.include?('Normal'), 'the normal term is replaced, not added to'
 end
 
+check 'opening Scene::Menu auto-cancels an Erase Screen black-out (yado.tk)' do
+  st = menu_state
+  st.screen.erase(Game::Transition::FADE_OUT, 1) # settle fully erased
+  eq 255, st.screen.fade_level, 'erased before the menu opens'
+  menu_scene(RPG2k::Scene::Menu, st)
+  eq 0, st.screen.fade_level,
+     'opening the menu instantly clears the black-out with no Show Screen'
+  ok !st.screen.fading?, 'no fade animation left running'
+end
+
+check 'opening Scene::Menu leaves an already-visible screen alone' do
+  st = menu_state
+  eq 0, st.screen.fade_level, 'starts fully visible'
+  menu_scene(RPG2k::Scene::Menu, st)
+  eq 0, st.screen.fade_level, 'still fully visible'
+end
+
 check 'Scene::Menu: the main command cursor wraps around' do
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@index), 'starts on the first command'


### PR DESCRIPTION
## Summary

- yado.tk: Erase Screen's black-out is auto-cancelled by opening and closing
  the Menu or Save screen, even though no "Show Screen" ever ran — a real
  RPG_RT quirk this from-scratch engine should reproduce for parity, not a
  bug to fix away.
- `Game::Screen` lives on the shared `Game::State` (`mruby-rpg2k/mrblib/game.rb`),
  so `Scene::Map` and `Scene::Menu` (Save is one of Menu's commands, not its
  own scene) see the same instance — nothing was clearing the fade level on
  the round trip, so our engine previously (incorrectly) kept the black-out
  intact across a Menu visit.
- Fix: `Scene::Menu#initialize` (`mruby-rpg2k/mrblib/scene/menu.rb`) now calls
  `@state.screen.show(Game::Transition::CUT_IN, 0)` — an explicit `frames: 0`
  forces an immediate same-frame settle to fully visible regardless of the
  style's own default length, and `CUT_IN` rather than `Game::Transition::NONE`
  (which is a genuine no-op) so this actually clears the level. `#show`
  already no-ops harmlessly when the screen is already fully visible.
- `docs/TODO.md` marks the yado.tk "Screen effects" bullet ✅ with the detail,
  and cross-references the same fact documented separately under the
  "Menu screen" bullet (a different site page saying the same thing).

## Test plan

- [x] `scripts/rpg2k_scene_check.rb` — added two checks: erasing the screen
  then opening `Scene::Menu` instantly clears `fade_level` to 0 with no
  fade animation left running; opening the menu on an already-visible
  screen leaves it alone. Confirmed the first check fails against the
  pre-fix `scene/menu.rb` via `git stash`.
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (299 checks).
- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (633 checks,
  unaffected by this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_