### PR TITLE
Parallel processes keep running during message windows

### DIFF
--- a/changelog.d/parallel-processes-run-during-messages.fixed.md
+++ b/changelog.d/parallel-processes-run-during-messages.fixed.md
@@ -1,0 +1,8 @@
+- **Background parallel processes now keep advancing during a message
+  window or while a foreground event is parked on a blocking wait**
+  (Show Text, Wait, ...), matching yado.tk: real RPG_RT only suspends them
+  for the Menu and Battle screens, not for an ordinary message box.
+  `Scene::Map#step_parallels` runs every frame now, gated by a narrower
+  `#parallels_paused?` (true only during battle, or while the foreground
+  interpreter is actively grinding through non-blocking commands) instead
+  of the old, much broader `event_busy?`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1963,17 +1963,31 @@ triage, the same as the rest of this backlog.
 **Flagged for priority triage** — these look most likely to be genuine,
 actionable gaps based on this session's own reading of the current code,
 not yet verified:
-- **Parallel processes may be paused too broadly.** This codebase's
-  `step_parallels` only runs when `!event_busy?`, and `event_busy?` is true
-  for any foreground interpreter activity including an ordinary Show Text
-  window. Multiple independent yado.tk pages state real RPG_RT parallel
-  processes keep advancing during a message window / ordinary foreground
-  event and are suspended only by the **Menu screen and the Battle
-  screen** — a message box is not one of the pause conditions. (Picture
-  commands specifically *are* suppressed during a message window per
-  several other pages, which is a narrower, separate rule from whether the
-  parallel process's own non-picture commands keep ticking.) Worth
-  re-reading `step_parallels`/`event_busy?` against this distinction.
+- ✅ **Parallel processes were paused too broadly.** `Scene::Map#step_parallels`
+  used to only run when `!event_busy?`, and `event_busy?` is true for any
+  foreground interpreter activity including an ordinary Show Text window.
+  Multiple independent yado.tk pages state real RPG_RT parallel processes
+  keep advancing during a message window / ordinary foreground event and are
+  suspended only by the **Menu screen and the Battle screen** — a message
+  box is not one of the pause conditions. Fixed: `#step_parallels` is now
+  called unconditionally every frame (before the foreground gets a chance to
+  start anything, matching a separately-documented "if both fire the same
+  frame, parallel process goes first"), gated by a new, narrower
+  `#parallels_paused?` instead of `event_busy?` — true only while a battle is
+  in progress (`@battle_ui`, the Menu screen's pause is already structural:
+  `Scene::Map#update` simply is not called while `Scene::Menu` sits on top)
+  or the foreground interpreter is actively grinding through non-blocking
+  commands ("parallel processes keep running during an Autorun's *blocking*
+  waits (Show Text/Wait) but are blocked while the Autorun executes
+  non-blocking commands" — `Game::Interpreter#running?` stays true for a
+  foreground event's *entire* lifetime including while parked waiting, so
+  `!waiting?` is what actually isolates the still-bursting case, in practice
+  a command list heavy enough to spill past one frame's `MAX_STEPS` budget
+  without reaching a wait). (Picture commands specifically *are* suppressed
+  during a message window per several other pages, which is a narrower,
+  separate rule from whether the parallel process's own non-picture commands
+  keep ticking, and is **not** addressed by this change — still open if not
+  covered elsewhere.)
 - **Numeric constants worth asserting directly**: battle damage hard-cap
   under 1000; special-skill HP recovery cap 999; Timer max 99:59 (5999s),
   clamped not wrapped when set higher via variable; switches/variables cap

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -225,6 +225,14 @@ class RPG2k
         # An event page's conditions may have just stopped (or started) holding;
         # re-select before anything reads a trigger or a graphic this frame.
         refresh_event_pages
+        # Parallel processes run every frame on their own schedule, independent
+        # of whatever the foreground is doing (yado.tk: a message window or a
+        # foreground event parked on a blocking wait is not a pause condition,
+        # only a battle or an actively-bursting foreground event is -- see
+        # #parallels_paused?). Stepped before the foreground gets a chance to
+        # start anything this frame, matching "if both are set to fire the
+        # same frame, parallel process goes first".
+        step_parallels unless parallels_paused?
         if event_busy?
           drive_event
         else
@@ -232,7 +240,6 @@ class RPG2k
           if event_busy?
             drive_event
           else
-            step_parallels
             step_player_route
             step_events
             step_movement
@@ -840,6 +847,23 @@ class RPG2k
         @message || @number_input || @interpreter.running? || @interpreter.waiting?
       end
 
+      # Whether #step_parallels should sit this frame out. Per yado.tk, real
+      # RPG_RT only pauses background parallel processes for the Menu screen
+      # (already structural here -- Scene::Map#update simply is not called
+      # while Scene::Menu sits on top) and the Battle screen; a message window
+      # or a foreground event parked on a blocking wait (Show Text, Wait, ...)
+      # is *not* a pause condition, only a foreground event actively grinding
+      # through non-blocking commands is ("parallel processes keep running
+      # during an Autorun's blocking waits ... but are blocked while the
+      # Autorun executes non-blocking commands"). `@interpreter.running?`
+      # stays true for a foreground event's whole lifetime, including while
+      # it is parked waiting, so `!waiting?` is what actually isolates the
+      # still-bursting case (in practice: a command list heavy enough to spill
+      # past a single frame's MAX_STEPS budget without hitting a wait).
+      def parallels_paused?
+        !@battle_ui.nil? || (@interpreter.running? && !@interpreter.waiting?)
+      end
+
       # Start the first not-yet-run auto-start process in the foreground: map
       # events with an auto-start trigger, then auto-start common events (whose
       # switch gate, if any, is on). Each runs at most once per visit so an
@@ -907,8 +931,9 @@ class RPG2k
       # Advance every background parallel process one frame. They loop their
       # command list and honour Wait; as background processes they do not drive
       # the message/choice/teleport UI (those requests are simply resumed so the
-      # process keeps running). Called only while the foreground is idle, so
-      # parallels pause during messages and foreground events.
+      # process keeps running). Called every frame regardless of a message
+      # window or a parked foreground event -- see #parallels_paused? for the
+      # (narrower) actual pause conditions.
       def step_parallels
         # Iterate a copy: an Erase Event in a parallel process removes it from
         # @parallels mid-loop (see erase_event).

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1391,7 +1391,7 @@ check 'Key Input Proc ignores keys it was not told to accept' do
   ok st.switches[5]
 end
 
-check 'parallel processes pause while a foreground event is running' do
+check 'parallel processes keep running while a message window is open (yado.tk)' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi')]
@@ -1399,9 +1399,37 @@ check 'parallel processes pause while a foreground event is running' do
   par.event_commands = [add_var_cmd(1)]
   scene = new_scene({ 1 => event(2, 2, auto), 2 => event(4, 4, par) })
   10.times { scene.update }
-  # The autostart event opens a message and waits for input we never give, so
-  # the foreground stays busy and the parallel process never advances.
-  eq 0, scene.instance_variable_get(:@state).variables[1]
+  # The autostart event opens a message and waits for input we never give, but
+  # per yado.tk a message box is not a pause condition for parallel processes
+  # -- only the Menu/Battle screens are (and Menu already is, structurally:
+  # Scene::Map#update does not run while it sits on top).
+  ok scene.instance_variable_get(:@state).variables[1] > 0,
+     'the parallel process advances despite the open message window'
+end
+
+check 'parallel processes pause during battle' do
+  ic = Game::Interpreter::Cmd
+  par = page(trigger: 4)
+  par.event_commands = [add_var_cmd(1)]
+  scene = new_scene({ 1 => event(4, 4, par) })
+  scene.instance_variable_set(:@battle_ui, { phase: :command })
+  10.times { scene.update }
+  eq 0, scene.instance_variable_get(:@state).variables[1],
+     'a parallel process must not advance while a battle is in progress'
+end
+
+check 'parallels_paused? treats a still-bursting foreground interpreter as busy' do
+  # A command list heavy enough to spill past one frame's MAX_STEPS budget
+  # without reaching a wait leaves the interpreter running? but not waiting? --
+  # exactly the "executes non-blocking commands" case yado.tk says pauses
+  # parallel processes (unlike being parked on a blocking wait, which does not).
+  scene = new_scene({})
+  interp = scene.instance_variable_get(:@interpreter)
+  interp.instance_variable_set(:@running, true)
+  interp.instance_variable_set(:@waiting, false)
+  ok scene.send(:parallels_paused?), 'still-bursting (running, not waiting) pauses parallels'
+  interp.instance_variable_set(:@waiting, true)
+  ok !scene.send(:parallels_paused?), 'parked on a wait (running and waiting) does not'
 end
 
 check 'Move Event forces a target map event onto a route' do


### PR DESCRIPTION
## Summary

- yado.tk (multiple independent site pages): real RPG_RT background parallel
  processes keep advancing during a message window / an ordinary foreground
  event parked on a blocking wait, and are suspended only by the **Menu
  screen and the Battle screen** — a message box is not one of the pause
  conditions. This codebase's `Scene::Map#step_parallels`
  (`mruby-rpg2k/mrblib/scene/map.rb`) used to only run when `!event_busy?`,
  and `event_busy?` is true for *any* foreground interpreter activity,
  including an ordinary Show Text window — much broader than real RPG_RT.
- Fix: `#step_parallels` now runs unconditionally every frame, before the
  foreground gets a chance to start anything (matching a separately
  documented "if both fire the same frame, parallel process goes first"),
  gated by a new, narrower `#parallels_paused?` instead of `event_busy?`:
  - True while a battle is in progress (`@battle_ui`). The **Menu screen**'s
    pause needed no code change — it's already structural, since
    `Scene::Map#update` (and thus `#step_parallels`) simply is not called
    while `Scene::Menu` sits on top of the scene stack.
  - True while the foreground interpreter is actively grinding through
    non-blocking commands, per yado.tk: "parallel processes keep running
    during an Autorun's *blocking* waits (Show Text/Wait) but are blocked
    while the Autorun executes non-blocking commands." `Game::Interpreter
    #running?` stays true for a foreground event's *entire* lifetime
    including while parked on a wait, so `!waiting?` is what actually
    isolates the still-bursting case — in practice a command list heavy
    enough to spill past one frame's `MAX_STEPS` budget without reaching a
    wait.
- Picture commands specifically *are* suppressed during a message window
  per several other yado.tk pages — a narrower, separate rule from whether
  a parallel process's own non-picture commands keep ticking, and **not**
  addressed by this change (left as a still-open note in `docs/TODO.md`).

## Test plan

- [x] `scripts/rpg2k_scene_check.rb` — replaced the one pre-existing check
  that codified the old (incorrect) behavior with three checks: a parallel
  process keeps advancing while an autostart event's message window sits
  open and unanswered; a parallel process does *not* advance while
  `@battle_ui` is set; and a direct unit check of `#parallels_paused?`
  distinguishing "running and waiting" (parked, not paused) from "running
  and not waiting" (still bursting, paused). Confirmed all three fail
  against the pre-fix `scene/map.rb` via `git stash`.
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (301 checks).
- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (633 checks).
- [x] `scripts/rpg2k_render_check.rb` passes (40 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_