### PR TITLE
A battle-valid Timer reaching 0:00 force-ends the fight

### DIFF
--- a/changelog.d/battle-timer-force-ends-fight.fixed.md
+++ b/changelog.d/battle-timer-force-ends-fight.fixed.md
@@ -1,0 +1,6 @@
+- **A Timer with "valid during battle" checked now force-ends the fight the
+  instant it reaches 0:00**, regardless of encounter source, matching
+  yado.tk. `Scene::Map#update` previously discarded `Game::State#tick_timer`'s
+  return value; it now calls `#finish_battle(:abort)` — the same outcome
+  Terminate Battle produces, reachable from any battle phase — the moment a
+  battle-flagged timer expires mid-fight.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2381,10 +2381,21 @@ not yet verified:
   off the first); 1 frame = 1/30s, but a "Wait" frame is internally
   **two** consecutive 0.0s-wait frames, not one; chaining two Show Battle
   Animation calls back-to-back produces a visible one-frame stutter.
-- A Timer with "valid during battle" checked **force-ends the battle**
+- ✅ **A Timer with "valid during battle" checked force-ends the battle**
   the instant it reaches 0:00, regardless of encounter source (default or
   scripted) — an easy accidental trap if the same Timer is reused for a
-  non-combat countdown.
+  non-combat countdown. `Game::Timer#tick` (`mruby-rpg2k/mrblib/game.rb`)
+  already returned `true` on exactly that frame — it only ever does so for a
+  timer carrying the battle flag while a fight is running, since one without
+  it is held frozen (never reaching zero) for the duration — but
+  `Scene::Map#update` threw the `Game::State#tick_timer` return value away.
+  Now, when it reports a finish while `@battle_ui` is present, the scene
+  calls `#finish_battle(:abort)` directly, the same outcome Terminate
+  Battle's own `#finish_terminated_battle` produces, just reachable from any
+  battle phase (command/target/event/result) rather than only from a running
+  battle-event page. Matches Terminate Battle in satisfying neither the
+  Win/Escape/Defeat handler branch — an unlabeled third outcome the event
+  resumes past.
 - Common events (including Parallel Process ones) **never run during
   battle**, even if their trigger switch flips mid-battle — execution is
   deferred until control returns to the map.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -215,8 +215,17 @@ class RPG2k
         end
         # The timers keep counting during events too. A fight is running when the
         # battle UI is up, and a timer without the "run in battle" flag pauses
-        # (and hides) for its duration rather than being stopped.
-        @state.tick_timer(!@battle_ui.nil?)
+        # (and hides) for its duration rather than being stopped. A timer that
+        # *does* carry the flag force-ends the battle outright the instant it
+        # reaches 0:00 (yado.tk), regardless of encounter source (default or
+        # scripted) -- #tick_timer only ever reports true for one mid-battle
+        # (an in_battle-less timer is held frozen instead, never reaching zero
+        # then), so any true here is unambiguously that case. Mirrors Terminate
+        # Battle's own :abort outcome (#finish_terminated_battle), just reachable
+        # from any battle phase rather than only the battle-event one.
+        if @state.tick_timer(!@battle_ui.nil?) && @battle_ui
+          finish_battle(:abort)
+        end
         @state.screen.update # screen tint progresses every frame, even in events
         @state.update_pictures # picture moves progress every frame too
         update_sprite_flashes # Flash Sprite decays during events too

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4602,6 +4602,26 @@ check 'Terminate Battle from a page ends the fight and resumes the event' do
      'the battle closed without a result window'
 end
 
+check 'a battle-valid Timer reaching 0:00 force-ends the fight (yado.tk)' do
+  scene, st = battle_scene_with_pages({})
+  10.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+  end
+  ok scene.instance_variable_get(:@battle_ui), 'the battle opened'
+  # A timer already at 0:00-next-tick, marked to count during battle.
+  t = st.timer(0)
+  t.frames = 1
+  t.running = true
+  t.visible = true
+  t.in_battle = true
+  scene.update
+  eq nil, scene.instance_variable_get(:@battle_ui),
+     'the battle force-ends the instant the timer reaches 0:00, mid-command-phase'
+  ok !st.switches[1] && !st.switches[2] && !st.switches[3],
+     'no Win/Escape/Defeat handler matched -- an unlabeled third outcome, same as Terminate Battle'
+end
+
 check 'a page can wound a monster through Change Monster HP' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::CHANGE_MONSTER_HP, [0, 1, 0, 7, 1])]) }


### PR DESCRIPTION
## Summary

- yado.tk: a Timer with "valid during battle" checked force-ends the battle
  the instant it reaches 0:00, regardless of encounter source (default or
  scripted) — an easy accidental trap if the same Timer is reused for a
  non-combat countdown.
- `Game::Timer#tick` (`mruby-rpg2k/mrblib/game.rb`) already returns `true`
  on exactly that frame — it only ever does so for a timer carrying the
  battle flag while a fight is running, since a timer without the flag is
  held frozen (never reaching zero) for the duration instead. But
  `Scene::Map#update` (`mruby-rpg2k/mrblib/scene/map.rb`) discarded
  `Game::State#tick_timer`'s return value — the only caller in the codebase
  — so this never had any effect.
- Fix: when `#tick_timer` reports a finish while `@battle_ui` is present,
  `#update` now calls `#finish_battle(:abort)` directly — the same outcome
  Terminate Battle's own `#finish_terminated_battle` produces (satisfying
  neither the Win/Escape/Defeat handler branch, an unlabeled third outcome
  the event resumes past), just reachable from any battle phase
  (command/target/event/result) rather than only from a running
  battle-event page, since a Timer can expire at any point mid-fight.
  `#finish_battle`/`#close_battle` are already nil-safe about which windows
  happen to be open, so this is safe from any phase.

## Test plan

- [x] `scripts/rpg2k_scene_check.rb` — added a check that opens a real
  battle via `battle_scene_with_pages({})`, sets timer 0 one frame from
  expiry with the battle flag on, and asserts `@battle_ui` becomes `nil`
  (mid `:command` phase) with none of the Win/Escape/Defeat switches set.
  Confirmed it fails against the pre-fix `scene/map.rb` via `git stash`
  (the battle stayed open).
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (302 checks).
- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (633 checks).
- [x] `scripts/rpg2k_render_check.rb` passes (40 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_