### PR TITLE
A Show Text's open colour bleeds into an attached Show Choices list

### DIFF
--- a/changelog.d/choice-list-color-bleed.added.md
+++ b/changelog.d/choice-list-color-bleed.added.md
@@ -1,0 +1,10 @@
+- **A `\c[]` colour left open in a Show Text now bleeds into an attached
+  Show Choices list merged into the same window**, matching yado.tk — an
+  explicit `\c[0]` in the text is needed to stop the choices inheriting it.
+  `Game::Message.scan` takes an optional starting colour and reports the
+  colour still in effect at the end of the line; `Scene::Map` threads a
+  Show Text's trailing colour into the choice labels appended onto it
+  (chained across the labels themselves too), rather than always starting
+  choices at colour 0. The matching `\s[]` (speed) half of the yado.tk
+  finding is not addressed — this codebase drops `\s[]` outright, so there
+  is no speed state yet to bleed.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2315,10 +2315,23 @@ not yet verified:
   execution content (not just the next message) and is auto-cleared when
   the event ends, but not before — it must be explicitly "erased" to stop
   mid-event. It also shrinks the per-line text capacity vs. no portrait.
-- \c[]/\s[] (color/speed) control codes set inside Show Text **bleed into
+- 🚧 \c[]/\s[] (color/speed) control codes set inside Show Text **bleed into
   an attached Show Choices list** when the two merge into one window
   (≤4 combined lines) — an explicit `\c[0]` reset is needed to stop
-  choices inheriting the preceding text's color.
+  choices inheriting the preceding text's color. **The colour half is now
+  implemented**: `Game::Message.scan` takes an optional `start_color` and
+  reports the colour still in effect at the end of the line as `:end_color`
+  (`mruby-rpg2k/mrblib/game.rb`), and `Scene::Map#open_message` records a
+  Show Text's trailing colour on `@message`, which `#append_choice_lines`
+  now seeds its own scans with instead of always starting at 0 — chained
+  across the choice labels themselves too, so the whole merged window (text
+  then choices) reads as one continuous colour stream that an explicit
+  `\c[0]` breaks, matching the finding. **The speed half is not addressed**:
+  this codebase drops `\s[]` outright today (see the Message window doc
+  above, "the remaining display code (`\s` speed) is dropped") rather than
+  varying the reveal rate at all, so there is no speed *state* yet for
+  anything to bleed — implementing the bleed would first need `\s[]` itself,
+  a larger, separate feature.
 - `\>` (instant display) only affects the current line — must be repeated
   per line for a fully-instant multi-line message.
 - ✅ **`\<`, `\$`, `\^` each cost one character's worth of display time even

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -102,8 +102,14 @@ module Game
     #   :auto_close — `\^` (close the window without a keypress once revealed);
     #   :instants — [[start, end)] spans that reveal at once (`\>` … `\<`);
     #   :show_gold — `\$` (show the party's gold in a small window);
-    #   :length  — the visible character count (what the reveal counts).
-    def self.scan(text, variables, names)
+    #   :length  — the visible character count (what the reveal counts);
+    #   :end_color — the colour still in effect once the line ends, for a
+    #                caller that wants to carry it into the next scan (a Show
+    #                Choices list merged onto a preceding Show Text, e.g. —
+    #                see Scene::Map#append_choice_lines — inherits the text's
+    #                trailing colour, yado.tk). `start_color` seeds the run in
+    #                effect from the very first character.
+    def self.scan(text, variables, names, start_color = 0)
       segs = []
       pauses = []
       instants = []
@@ -111,7 +117,7 @@ module Game
       auto_close = false
       show_gold = false
       cur = ''
-      color = 0
+      color = start_color
       count = 0 # visible characters emitted so far (pause positions index this)
       i = 0
       n = text.nil? ? 0 : text.length
@@ -157,7 +163,8 @@ module Game
       segs << { text: cur, color: color } unless cur.empty?
       instants << [instant_start, count] if instant_start # unclosed `\>` runs to EOL
       { segments: segs, pauses: pauses, auto_close: auto_close,
-        instants: instants, show_gold: show_gold, length: count }
+        instants: instants, show_gold: show_gold, length: count,
+        end_color: color }
     end
 
     # Truncate per-line colour segments to the first `revealed` characters

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4778,7 +4778,13 @@ class RPG2k
                      inner_w: inner_w, seg_lines: seg_lines, face: face,
                      face_index: cfg.face_index,
                      face_x: face_right ? inner_w - FACE_SIZE : 0,
-                     text_x: text_x, text_w: text_w, gold_window: gold_window }
+                     text_x: text_x, text_w: text_w, gold_window: gold_window,
+                     # The colour still in effect once this text ends -- a Show
+                     # Choices later merged onto this same window (see
+                     # #append_choice_lines) inherits it rather than starting
+                     # back at the default (yado.tk: an explicit `\c[0]` is
+                     # needed in the text to stop the choices inheriting it).
+                     trailing_color: scans.empty? ? 0 : scans.last[:end_color] }
         draw_message_contents
         win.contents = contents
         @choice_index = 0
@@ -4794,7 +4800,16 @@ class RPG2k
         names = ->(id) { actor_name(id) }
         raw = (labels || [])
         raw = [''] if raw.empty?
-        scans = raw.map { |l| Game::Message.scan(l.to_s, @state.variables, names) }
+        # Each choice label inherits the colour the preceding text (or an
+        # earlier label) left off at, unless it sets its own -- the whole
+        # merged window reads as one continuous colour stream (yado.tk).
+        color = @message[:trailing_color] || 0
+        scans = raw.map do |l|
+          s = Game::Message.scan(l.to_s, @state.variables, names, color)
+          color = s[:end_color]
+          s
+        end
+        @message[:trailing_color] = color
         new_seg_lines = scans.map { |s| s[:segments] }
         @message[:choice_start] = @message[:seg_lines].length
         @message[:seg_lines] = @message[:seg_lines] + new_seg_lines

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -565,6 +565,25 @@ check 'Message.scan records pacing codes in revealed-char coordinates' do
   eq [{ at: 2, kind: :key }], s2[:pauses], '42 is two chars, so \\! sits at 2'
 end
 
+check 'Message.scan threads a starting/ending colour for a caller to chain across calls' do
+  vars = Object.new
+  def vars.[](_i); 0; end
+  names = ->(_i) { '' }
+  # No \c[] at all: the seeded start_color colours the segment and rides
+  # straight through to end_color, so a caller can chain scans across lines
+  # (Scene::Map#append_choice_lines threading a Show Text's trailing colour
+  # into an attached Show Choices list, yado.tk).
+  s = Game::Message.scan('plain', vars, names, 2)
+  eq 2, s[:segments].first[:color], 'the whole run picks up the seeded colour'
+  eq 2, s[:end_color], 'and it is still in effect at the end of the line'
+  # An explicit \c[] overrides it for the rest of the line.
+  s2 = Game::Message.scan('ab\c[5]cd', vars, names, 2)
+  eq [{ text: 'ab', color: 2 }, { text: 'cd', color: 5 }], s2[:segments]
+  eq 5, s2[:end_color], 'end_color reflects the last colour set, not the seed'
+  # Defaults to 0 when omitted, matching every existing call site.
+  eq 0, Game::Message.scan('x', vars, names)[:end_color]
+end
+
 check 'Message.scan flags \$ (show gold) and drops it from the text' do
   vars = Object.new
   def vars.[](_i); 0; end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1850,6 +1850,48 @@ check 'a Show Text keeps its window open when a Show Choices follows directly' d
   ok !st.switches[2], 'and the other did not'
 end
 
+def show_text_then_choices(text)
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_MESSAGE, [], indent: 0, string: text),
+    ECmd.new(ic::SHOW_CHOICES, [0], indent: 0), # cancel forbidden
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes'),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'no'),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  12.times { scene.update; break if scene.instance_variable_get(:@message) }
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # completes the reveal; window stays open
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # a Show Choices follows directly, so it keeps the window open
+  RGSS::Input.reset
+  choice_msg = nil
+  8.times do
+    scene.update
+    choice_msg = scene.instance_variable_get(:@message)
+    break if choice_msg && choice_msg[:choice]
+  end
+  choice_msg
+end
+
+check "a colour left open in a Show Text bleeds into an attached Show Choices list (yado.tk)" do
+  choice_msg = show_text_then_choices('\c[2]hi')
+  ok choice_msg && choice_msg[:choice], 'the choices appeared, merged into the same window'
+  choice_segs = choice_msg[:seg_lines][choice_msg[:choice_start]..]
+  ok choice_segs.all? { |segs| segs.all? { |s| s[:color] == 2 } },
+     "both choice labels inherit the text's trailing colour with no reset in either"
+end
+
+check 'an explicit \c[0] in the Show Text stops the colour bleeding into Show Choices' do
+  choice_msg = show_text_then_choices('\c[2]hi\c[0]')
+  choice_segs = choice_msg[:seg_lines][choice_msg[:choice_start]..]
+  ok choice_segs.all? { |segs| segs.all? { |s| s[:color] == 0 } },
+     'the reset before the text ends carries a colour 0 into the choices, not 2'
+end
+
 check 'a Show Text keeps its window open when an Input Number follows directly' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- yado.tk: `\c[]`/`\s[]` (color/speed) control codes set inside a Show Text
  bleed into an attached Show Choices list when the two merge into one
  window (≤4 combined lines) — an explicit `\c[0]` reset is needed to stop
  the choices inheriting the preceding text's colour.
- Confirmed the codebase previously did the opposite: `Game::Message.scan`
  (`mruby-rpg2k/mrblib/game.rb`) always initialized `color = 0`, and
  `Scene::Map#append_choice_lines` (`mruby-rpg2k/mrblib/scene/map.rb`)
  re-scanned each choice label fresh with no way to carry over a preceding
  Show Text's trailing colour — colour never bled.
- Fix (colour half only, see below): `Message.scan` now takes an optional
  `start_color` (default 0, every existing call site unaffected) and
  reports the colour still in effect at the end of the line as `:end_color`.
  `Scene::Map#open_message` records a shown text's trailing colour on
  `@message`; `#append_choice_lines` seeds its first choice label's scan
  with it instead of 0, and chains each subsequent label from where the
  previous one left off — so the whole merged window (text, then choices)
  reads as one continuous colour stream, which an explicit `\c[0]` in the
  text breaks, matching the finding.
- **Not addressed**: the `\s[]` (speed) half. This codebase drops `\s[]`
  outright today (never varies the reveal rate at all), so there is no
  speed *state* yet for anything to bleed — implementing that half would
  first need `\s[]` itself, a larger, separate feature. `docs/TODO.md`
  marks the bullet 🚧 rather than ✅ to reflect the split.

## Test plan

- [x] `scripts/rpg2k_logic_check.rb` — direct unit check of
  `Message.scan`'s new `start_color`/`:end_color`: a seeded colour with no
  `\c[]` rides straight through to `end_color`; an explicit `\c[]`
  overrides it for the rest of the line; omitting the argument still
  defaults to 0.
- [x] `scripts/rpg2k_scene_check.rb` — two integration checks driving a real
  Show Text → Show Choices merge: a `\c[2]` left open in the text colours
  both choice labels; an explicit `\c[0]` before the text ends resets it
  back to 0 for both. Confirmed the first fails against the pre-fix
  `game.rb`/`scene/map.rb` via `git stash`.
- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (646 checks).
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (304 checks).
- [x] `scripts/rpg2k_render_check.rb` passes (40 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_