### PR TITLE
Clamp Timer Operation "set" to 99:59 (5999s) when fed a variable

### DIFF
--- a/changelog.d/timer-clamp-5999-via-variable.fixed.md
+++ b/changelog.d/timer-clamp-5999-via-variable.fixed.md
@@ -1,0 +1,7 @@
+- **A Timer Operation "set" sourced from a Variable now clamps to 99:59
+  (5999 s) instead of loading the raw value unbounded.** `Game::Timer#set`
+  had no upper bound, and Control Variables can feed it an arbitrary
+  player-reachable value through `Game::Interpreter#do_timer`. Real RPG_RT's
+  timer display never grows past two minute digits, so it caps a set that
+  high rather than wrapping. Added `Game::Timer::MAX_SECONDS = 5999` and a
+  clamp in `#set`, with regression coverage in `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2032,9 +2032,28 @@ not yet verified:
   separate rule from whether the parallel process's own non-picture commands
   keep ticking, and is **not** addressed by this change — still open if not
   covered elsewhere.)
+- ✅ **Timer max 99:59 (5999s), clamped not wrapped when set higher via a
+  variable.** `Game::Timer#set` (`mruby-rpg2k/mrblib/game.rb`) computed
+  `@frames = seconds * FPS + (FPS - 1)` with no upper bound at all, and
+  `Game::Interpreter#do_timer`'s Timer Operation "set" command can source
+  `seconds` from an arbitrary Control-Variables value
+  (`variables[cmd.param(2)]`), so an out-of-range variable reached the frame
+  counter unclamped. Real RPG_RT's timer display never grows past two minute
+  digits, so it caps the loaded value at 99:59 (5999 s) rather than wrapping
+  or overflowing. Fixed by adding `Game::Timer::MAX_SECONDS = 5999` and
+  clamping in `#set` (`seconds = MAX_SECONDS if seconds > MAX_SECONDS`)
+  before the frame math runs; 5999 s is confirmed to land exactly on 99:59
+  via `#seconds`/`#display_text` (5999 / 60 = 99 minutes remainder 59
+  seconds). Regression coverage added to `scripts/rpg2k_logic_check.rb`:
+  a direct `Game::Timer#set(9999)` clamps to 5999 s / "99:59", a Timer
+  Operation "set" sourced from a Control Variable holding 9999 clamps the
+  same way through the interpreter, and an ordinary in-range variable-sourced
+  set (30 s) is left untouched. The other numeric constants originally
+  bundled with this bullet (battle damage cap, HP recovery cap, switch/
+  variable caps and ranges, recursion ceiling, party/stack/picture caps, move
+  speed, transparency steps) remain unverified — see below.
 - **Numeric constants worth asserting directly**: battle damage hard-cap
-  under 1000; special-skill HP recovery cap 999; Timer max 99:59 (5999s),
-  clamped not wrapped when set higher via variable; switches/variables cap
+  under 1000; special-skill HP recovery cap 999; switches/variables cap
   at 5000 (expandable), variable value range −999999..999999 in RPG2000 vs
   7-digit in RPG2003 (already partially modelled per `LCF::MODE`, worth
   checking the variable-write clamp specifically); Call Event / Event Call

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7164,6 +7164,13 @@ module Game
   class Timer
     FPS = 60
 
+    # RPG_RT's timer display never grows past two minute digits, so 99:59
+    # (5999 s) is the largest value it can show; a Timer Operation "set"
+    # sourced from a Control Variables value (arbitrary, player-reachable —
+    # e.g. an accidental or intentional overflowed computation) is clamped to
+    # this ceiling rather than wrapping or overflowing the frame counter.
+    MAX_SECONDS = 5999
+
     # Remaining time in frames; whether it is counting; whether it is drawn; and
     # whether it keeps counting (and drawing) during a battle — the Timer
     # Operation start command's second flag.
@@ -7177,8 +7184,10 @@ module Game
     end
 
     # Timer Operation, "set": load the timer with `seconds` (see the note above
-    # about the extra 59 frames).
+    # about the extra 59 frames). Clamped to MAX_SECONDS (99:59) since this can
+    # be fed an out-of-range Variable value via Control Variables.
     def set(seconds)
+      seconds = MAX_SECONDS if seconds > MAX_SECONDS
       @frames = seconds * FPS + (FPS - 1)
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1820,6 +1820,30 @@ check 'a timer only counts in battle when it carries the battle flag' do
   ok t.drawn?(true), 'and keeps drawing'
 end
 
+check 'Timer Operation "set" clamps to 99:59 (5999 s) when a Variable feeds it an out-of-range value' do
+  t = Game::Timer.new
+  # Direct clamp check: RPG_RT's timer display never grows past two minute
+  # digits, so a value above the 99:59 ceiling is clamped, not wrapped.
+  t.set(9999)
+  eq 5999, t.seconds, '9999 s clamps down to the 99:59 ceiling'
+  eq '99:59', t.display_text
+  eq Game::Timer::MAX_SECONDS * 60 + 59, t.frames
+
+  st = new_state
+  st.variables[1] = 9999 # a Control Variables value the player could reach
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::TIMER_OPERATION, [0, 1, 1])]) # set = var 1
+  it.update
+  eq 5999, st.timer(0).seconds, 'a variable-sourced set clamps the same way'
+  eq '99:59', st.timer_display_text
+
+  # An ordinary in-range set (constant or variable) is unaffected.
+  st.variables[2] = 30
+  it.start([FakeCmd.new(IC::TIMER_OPERATION, [0, 1, 2])]) # set = var 2
+  it.update
+  eq 30, st.timer(0).seconds, 'a normal small value is untouched by the clamp'
+end
+
 check "Timer Operation addresses RPG2003's second timer through param5" do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s yado.tk backlog flagged an unverified numeric constant: "Timer max 99:59 (5999s), clamped not wrapped when set higher via variable." A Timer Operation "set" command can source its seconds value from a Control-Variables value (arbitrary, player-reachable — `Game::Interpreter#do_timer` does `cmd.param(1) == 0 ? cmd.param(2) : variables[cmd.param(2)]`), and real RPG_RT clamps that to 99:59 (5999 s) rather than wrapping or overflowing.

**Gap confirmed**: `Game::Timer#set` (`mruby-rpg2k/mrblib/game.rb`) computed `@frames = seconds * FPS + (FPS - 1)` with no upper bound at all — a variable holding e.g. 9999 would load straight through unclamped.

## Changes

- Added `Game::Timer::MAX_SECONDS = 5999` and a clamp at the top of `#set`: `seconds = MAX_SECONDS if seconds > MAX_SECONDS`, with a comment explaining the yado.tk-documented reason (RPG_RT's timer display never grows past two minute digits). No pre-existing lower-bound handling existed to preserve.
- Confirmed 5999 s lands exactly on 99:59 via `#seconds`/`#display_text` (5999 / 60 = 99 remainder 59).
- Added regression coverage to `scripts/rpg2k_logic_check.rb`, next to the existing Timer checks: a direct `Game::Timer#set(9999)` clamps to 5999 s / `"99:59"`; a Timer Operation "set" sourced from a Control Variable holding 9999 clamps the same way through the interpreter; an ordinary in-range variable-sourced set (30 s) is left untouched.
- Split the compound "Numeric constants worth asserting directly" TODO bullet: the Timer-clamp part is marked `✅` with details of the fix; the other bundled constants (battle damage cap, HP recovery cap, switch/variable caps, recursion ceiling, party/stack/picture caps, move speed, transparency steps) remain explicitly unverified rather than being falsely marked done.
- Added a changelog fragment.

## Test plan

- Added the new check, ran `ruby scripts/rpg2k_logic_check.rb` — passes (647 checks, up from 646... actually 3 new assertions added across 1 new check).
- Confirmed the new check **fails** against the pre-fix code: `git stash push -- mruby-rpg2k/mrblib/game.rb` then re-ran the harness — the new check failed with `expected 5999, got 9999`, no other regressions. `git stash pop` restored the fix and the check passed again.
- `ruby scripts/rpg2k_logic_check.rb` — 647 checks pass.
- `ruby scripts/rpg2k_scene_check.rb` — 304 checks pass (unaffected).
- `ruby scripts/rpg2k_render_check.rb` — 40 checks pass (unaffected).
- Did not touch `interpreter.rb`'s `play_audio` or `scene/map.rb`'s `vehicle_passable?` — those belong to the two sibling parallel work streams in this same sweep.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_