### PR TITLE
rpg2k: re-triggering Play BGM with the same file no longer restarts it

### DIFF
--- a/changelog.d/bgm-same-file-no-restart.fixed.md
+++ b/changelog.d/bgm-same-file-no-restart.fixed.md
@@ -1,0 +1,13 @@
+- **Re-triggering Play BGM with the file already playing no longer restarts
+  it from the top.** `Game::Interpreter#play_audio`'s `:bgm` branch now
+  compares the command's filename against `@state.current_bgm` and skips
+  the redundant `RGSS::Audio.bgm_play` call (and the loop-tracking reset)
+  when the same file is already current, matching yado.tk's single-BGM-
+  channel finding. The state still records the command's latest
+  vol/tempo so Memorize BGM keeps stashing the most recently requested
+  settings. The other half of the finding — applying the new vol/tempo/pan
+  to the still-playing track in place — remains unaddressed: this build's
+  `RGSS::Audio` has no primitive to adjust an already-playing BGM without
+  restarting it (`bgm_play` is the only vol/pitch entry point and it always
+  restarts via SDL_mixer), so it is left documented as blocked in
+  `docs/TODO.md` rather than faked.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2295,14 +2295,28 @@ not yet verified:
   the running effect.
 
 **BGM / SE**
-- BGM has a **single channel** — a new Play BGM force-stops whatever's
+- 🚧 BGM has a **single channel** — a new Play BGM force-stops whatever's
   playing; re-triggering the exact same file that's already playing does
   **not** restart it (applies new vol/tempo/pan without a break); field
   and battle BGM sharing the same file continue seamlessly across the
   transition. Memorize/Play-Memorized BGM only remembers the *filename*,
   never playback position — replaying always restarts from the top, and
   uses the vol/tempo/pan settings active **at memorize time**, not replay
-  time.
+  time. **The no-restart half is now implemented**:
+  `Game::Interpreter#play_audio`'s `:bgm` branch (`mruby-rpg2k/mrblib/
+  interpreter.rb`) compares the command's filename against
+  `@state.current_bgm[:name]` and skips the `RGSS::Audio.bgm_play` call
+  (and the `bgm_looped` reset) when they match, so a same-file re-trigger
+  leaves the still-playing track alone. `@state.current_bgm` is still
+  updated unconditionally to the command's latest vol/tempo, so Memorize
+  BGM continues to stash whatever was most recently requested. **The
+  vol/tempo/pan-without-restart half is not addressed**: this build's
+  `RGSS::Audio` exposes no primitive to adjust an already-playing BGM's
+  volume, pitch, or pan in place — `bgm_play` (`mruby-rgss/src/audio.cxx`,
+  backed by `SDL_mixer`) is the only entry point that takes those
+  parameters, and it always starts playback from the top. Implementing
+  this half would need a new native backend primitive (e.g. an
+  `Mix_VolumeMusic`-style setter) that does not exist today.
 - SE is truly polyphonic (unlike BGM); SE "OFF" stops all playing SEs at
   once; SE never loops natively.
 - SE files must be WAVE; BGM accepts MIDI/WAVE/MP3 — an asymmetric format

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2782,11 +2782,22 @@ module Game
         # default to 100 when the command carries a shorter list.
         volume = cmd.parameters.size > 1 ? cmd.param(1) : 100
         pitch = cmd.parameters.size > 2 ? cmd.param(2) : 100
+        # BGM has a single channel, and RPG_RT special-cases re-triggering Play
+        # BGM with the file that's already current: it does NOT break and
+        # restart the track from the top the way any other Play BGM does
+        # (yado.tk). It also re-applies the command's vol/tempo/pan to the
+        # still-playing track, but RGSS::Audio here has no primitive for that
+        # (mruby-rgss/src/audio.cxx's bgm_play is the only vol/pitch entry
+        # point, and it always restarts via SDL_mixer) — that half is
+        # deliberately left unimplemented rather than faked; see docs/TODO.md.
+        same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == name
         # Track what is playing so Memorize BGM can stash it (RPG_RT keeps this
         # as the "current system BGM" regardless of whether playback succeeds).
         @state.current_bgm = { name: name, volume: volume, tempo: pitch }
-        @state.bgm_looped = false # a fresh track has not looped yet
-        RGSS::Audio.bgm_play(name, volume, pitch)
+        unless same_file_already_playing
+          @state.bgm_looped = false # a fresh track has not looped yet
+          RGSS::Audio.bgm_play(name, volume, pitch)
+        end
       else
         # PlaySE parameters: [volume, tempo, balance].
         volume = cmd.parameters.size > 0 ? cmd.param(0) : 100

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2042,6 +2042,38 @@ check 'Play Memorized BGM with nothing memorized does nothing' do
   eq nil, st.memorized_bgm
 end
 
+check 'Play BGM with the file already playing does not restart it' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # Same file re-triggered with different vol/tempo: RPG_RT keeps the track
+  # playing uninterrupted (single BGM channel, no break/restart) rather than
+  # calling into the backend a second time.
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::PLAY_BGM, [0, 50, 120], string: 'town'),
+  ])
+  it.update
+  names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
+  eq %w[town], names, 'only the first Play BGM actually reached the backend'
+  eq 'town', st.current_bgm[:name]
+  eq 50, st.current_bgm[:volume], 'state still tracks the latest requested volume'
+  eq 120, st.current_bgm[:tempo], 'state still tracks the latest requested tempo'
+end
+
+check 'Play BGM with a different file still restarts (or starts) playback' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::PLAY_BGM, [0, 100, 100], string: 'field'),
+  ])
+  it.update
+  names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
+  eq %w[town field], names, 'a different file always reaches the backend'
+end
+
 # -- actor HP / MP commands ---------------------------------------------------
 
 # A database row for an actor, and a fake DB exposing just what Game::Party /


### PR DESCRIPTION
## Summary

yado.tk documents that BGM has a single channel, and that re-triggering Play BGM with the *exact same file* that's already playing is special-cased by RPG_RT: it does **not** break and restart the track from the top the way any other Play BGM does. Instead the still-playing track keeps going, with the new command's volume/tempo/pan meant to apply to it in place.

**Gap found**: `Game::Interpreter#play_audio`'s `:bgm` branch in `mruby-rpg2k/mrblib/interpreter.rb` unconditionally called `RGSS::Audio.bgm_play(name, volume, pitch)` on every Play BGM, with no check against `@state.current_bgm` (which already exists and is populated for Memorize BGM / vehicle BGM purposes).

**Fix (partial — see below)**: `play_audio`'s `:bgm` branch now compares the command's filename against `@state.current_bgm[:name]`. When they match, it skips the `RGSS::Audio.bgm_play` call and the `bgm_looped` reset, leaving the still-playing track alone. `@state.current_bgm` is still updated unconditionally to the command's latest volume/tempo, so Memorize BGM continues to stash whatever was most recently requested. A different file always still plays through normally.

**What's NOT addressed**: the "applies new vol/tempo/pan without a break" half of the finding. I checked this build's native audio surface (`mruby-rgss/src/audio.cxx`, `include/rgss_audio.hxx`, and the `RGSS::Audio` Ruby wrapper in `mruby-rgss/mrblib/lib.rb`) for a primitive that could adjust an already-playing BGM's volume, pitch, or pan without restarting it. There isn't one — `bgm_play` (backed by SDL_mixer) is the only entry point that takes those parameters, and it always starts playback from the top; there is no `Mix_VolumeMusic`-style setter, and the backend struct doesn't even carry a `pan` parameter today. Rather than fabricate an API that doesn't exist, I left this half unimplemented and documented it as blocked in `docs/TODO.md` and in code comments, mirroring how PR #(the "Show Text colour bleeds into Show Choices" PR, commit d267dd2) handled a similarly partial two-half yado.tk finding.

## Test plan

- Added two checks to `scripts/rpg2k_logic_check.rb`:
  - Play BGM `town` then Play BGM `town` again (different vol/tempo args) → exactly one `RGSS::Audio.bgm_play` call is logged, and `@state.current_bgm` reflects the *latest* requested vol/tempo.
  - Play BGM `town` then Play BGM `field` → two `RGSS::Audio.bgm_play` calls are logged (different file always restarts/starts).
- Confirmed the new checks **fail** against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/interpreter.rb` then re-run) with the expected `["town"]` vs `["town", "town"]` mismatch, then restored the fix and confirmed they pass.
- Ran the full check suite with zero regressions:
  - `ruby scripts/rpg2k_logic_check.rb` → 648 checks passed
  - `ruby scripts/rpg2k_scene_check.rb` → 304 checks passed
  - `ruby scripts/rpg2k_render_check.rb` → 40 checks passed
- Verified vehicle boarding BGM (`scene/map.rb`'s `play_vehicle_bgm`/`restore_pre_vehicle_bgm`) is untouched — it calls `RGSS::Audio.bgm_play` directly outside `play_audio` and always swaps to a different file, so it's unaffected by this change.

## Scope note

Per the parallel work-stream split, this PR touches only `mruby-rpg2k/mrblib/interpreter.rb`'s `play_audio`, `scripts/rpg2k_logic_check.rb`, `docs/TODO.md`, and a new changelog fragment — it does not touch `game.rb`'s `Game::Timer` or `scene/map.rb`'s `vehicle_passable?`, which are separate parallel PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_