### PR TITLE
rpg2k: a boarded boat/ship can now be blocked by an event's own Through Mode

### DIFF
--- a/changelog.d/vehicle-passability-through-mode.fixed.md
+++ b/changelog.d/vehicle-passability-through-mode.fixed.md
@@ -1,0 +1,15 @@
+- **A boarded boat or ship can no longer overlap a below/above-characters
+  event's tile.** `Scene::Map#vehicle_passable?`'s boat/ship branch reused
+  the hero's own priority-type-gated occupancy test
+  (`blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]`), so a
+  below-characters event with a passable graphic — which the walking hero
+  correctly overlaps via that same gating — was silently sailed straight
+  through by a ship too. RPG_RT's ship rule is a real divergence from the
+  hero's: a ship ignores priority type entirely and is blocked by *any*
+  event unless that event's own move route has Through Mode on. The blocker
+  check is now `blocker && !blocker[:char].through`, reading the same
+  `Game::Character#through` accessor the hero's own Through Mode already
+  uses; the airship branch (which flies over every event, unaffected) and
+  the hero's own passability rules are untouched. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2498,12 +2498,29 @@ not yet verified:
   regardless of terrain, and Set Vehicle Location has **no** landability
   validation at all (will happily place it somewhere unlandable). Random
   encounters stay active on ships (governed by terrain settings) but are
-  **hard-disabled** on airships with no database toggle. Small/large ships
-  can never overlap an event's tile even with a passable graphic +
-  below-characters priority (which *does* let the walking hero overlap it
-  fine) — ships need the event's own move route to use Through Mode
-  instead; this is a real divergence from the hero's priority-type-gated
-  passability already implemented.
+  **hard-disabled** on airships with no database toggle.
+- ✅ **Small/large ships can never overlap an event's tile even with a
+  passable graphic + below-characters priority** (which *does* let the
+  walking hero overlap it fine via the already-implemented priority-type
+  gating) — a ship needs the *blocking event's own* move route to have
+  Through Mode on instead; ships ignore priority-type/`overlap_forbidden`
+  gating for this purpose entirely and just check the blocked event's own
+  Through Mode flag. `Scene::Map#vehicle_passable?`'s boat/ship branch
+  (`mruby-rpg2k/mrblib/scene/map.rb`) used to reuse the exact same
+  `blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]` occupancy
+  test the hero's own `passable?`/`char_passable?` use, so a below-
+  characters event never blocked a ship at all — the opposite of RPG_RT,
+  which always blocks a ship on such a tile unless that specific event has
+  Through Mode enabled. The blocker check is now `blocker &&
+  !blocker[:char].through`, reading the same `Game::Character#through`
+  accessor (`attr_accessor :through`, toggled by the Set Move Route
+  Through Mode ON/OFF commands) that the hero's own Through Mode already
+  uses — this is a one-line, ship-specific divergence from the hero's rule,
+  not a change to the hero's passability or to the airship branch (which
+  ignores events entirely and flies over everything, unaffected). Covered
+  by a new `scripts/rpg2k_scene_check.rb` check (a boarded boat is stopped
+  by a below-characters event on an otherwise boat-passable tile; setting
+  that event's own Through Mode on lets the boat sail through it).
 
 **Save / Load persistence — consolidated master list**
 Runtime state that does **not** survive a map re-visit (leave and return,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1209,6 +1209,17 @@ class RPG2k
       # the tile's terrain to allow it (boat_pass / ship_pass) with no event in
       # the way, falling back to on-foot passability when the map has no terrain
       # data.
+      #
+      # A boat / ship's event-blocking rule is a real divergence from the
+      # hero's own (yado.tk quirk): the walking hero is priority-type-gated —
+      # a below/above-characters event with a passable graphic never blocks it
+      # (see `passable?` / `char_passable?`, which key off `blocker[:layer]`).
+      # A ship ignores that entirely and just asks whether the blocking
+      # event's *own* move route has Through Mode on
+      # (`blocker[:char].through`, the same accessor `char_passable?` and
+      # `passable?` check for the mover's own Through Mode) — a below-
+      # characters, passable-graphic event the hero strolls over still stops
+      # a ship dead unless that specific event has Through Mode enabled.
       def vehicle_passable?(x, y, dir, type)
         return false unless @map.in_bounds?(x, y)
         row = terrain_row_at(x, y)
@@ -1217,7 +1228,7 @@ class RPG2k
           return row.airship_pass ? true : false
         end
         blocker = @event_tiles[[x, y]]
-        return false if blocker && (blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden])
+        return false if blocker && !blocker[:char].through
         return passable?(x, y, dir) unless row
         type == :boat ? (row.boat_pass ? true : false) : (row.ship_pass ? true : false)
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -205,7 +205,7 @@ def fake_map_with_counters(id, events, counters)
 end
 
 def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
-            airship_land: true, airship_pass: true)
+            airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false)
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
@@ -310,7 +310,8 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
     # terrain 42 — so this one row decides whether walking hurts, and (for the
     # airship checks) whether it may fly over / land on any tile.
     terrain: { 42 => OpenStruct.new(damage: terrain_damage, bush_depth: bush_depth,
-                                    airship_land: airship_land, airship_pass: airship_pass) },
+                                    airship_land: airship_land, airship_pass: airship_pass,
+                                    boat_pass: boat_pass, ship_pass: ship_pass) },
     common_event: common,
     # Database actor rows carry the *original* names, which a \N[n] must not
     # use once the actor has been renamed in play (see the \N[n] check).
@@ -467,9 +468,11 @@ end
 
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
               members: [], terrain_damage: 0, bush_depth: 0,
-              airship_land: true, airship_pass: true, map_tree: nil)
+              airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
+              map_tree: nil)
   db = fake_db(common, troop_pages, terrain_damage, bush_depth,
-               airship_land: airship_land, airship_pass: airship_pass)
+               airship_land: airship_land, airship_pass: airship_pass,
+               boat_pass: boat_pass, ship_pass: ship_pass)
   state = Game::State.new(fake_party(members), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   parent = fake_parent(db)
@@ -3287,6 +3290,46 @@ check 'boarding a boat and disembarking onto the shore' do
   ok !st.boarded?, 'disembarked back onto foot'
   eq [0, 0], [st.x, st.y], 'stepped off onto the shore tile'
   eq [0, 1], [boat.x, boat.y], 'the boat stayed where the party left it'
+end
+
+check 'a boarded boat cannot overlap a below-characters event unless it has Through Mode on' do
+  # yado.tk: a below-characters, passable-graphic event lets the *walking*
+  # hero overlap it fine (LAYER_BELOW is not LAYER_SAME, see the priority-type
+  # checks above) -- but a ship ignores that gating entirely and just asks
+  # whether the blocking event's own move route has Through Mode on. Put a
+  # LAYER_BELOW event one tile past a boarded boat, on a boat_pass tile, and
+  # confirm the boat is stopped cold by it despite the layer mismatch that
+  # would let the hero glide over it.
+  blocker = event(0, 2, page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_BELOW))
+  scene = new_scene({ 1 => blocker }, player: [0, 0], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face down, toward (0, 1)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat ahead'
+  eq [0, 1], [st.x, st.y], 'stepped onto the boat tile'
+
+  RGSS::Input.dir_value = 2 # hold down, toward the below-characters event
+  20.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [0, 1], [st.x, st.y],
+     'a below-characters event stops a boat even though its layer would let ' \
+     "the hero overlap it (got #{[st.x, st.y]})"
+
+  # Turn the blocking event's own Through Mode on and try again: now the boat
+  # passes it, matching real RPG_RT's ship-specific rule.
+  chars(scene)[1].through = true
+  RGSS::Input.dir_value = 2
+  20.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq 0, st.x, 'only moved along the column it was already sailing'
+  ok st.y > 1,
+     "Through Mode on the blocking event let the boat pass it (was at y=1, now #{st.y})"
 end
 
 check 'the airship flies over a tile blocked on foot, and follows the party' do


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s Party/Actor/Vehicle backlog note (yado.tk): *"Small/large ships can never overlap an event's tile even with a passable graphic + below-characters priority (which *does* let the walking hero overlap it fine) — ships need the event's own move route to use Through Mode instead; this is a real divergence from the hero's priority-type-gated passability already implemented."*

This was a genuine gap. `Scene::Map#vehicle_passable?`'s boat/ship branch (`mruby-rpg2k/mrblib/scene/map.rb`) reused the *exact same* occupancy test the hero's own `passable?`/`char_passable?` use:

```ruby
blocker = @event_tiles[[x, y]]
return false if blocker && (blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden])
```

That's correct for the hero — a below/above-characters event is a decoration it walks straight over — but wrong for a ship: real RPG_RT's ship rule ignores priority type entirely and is always blocked by *any* event unless that specific event's own move route has Through Mode on.

## Fix

`vehicle_passable?`'s boat/ship branch now checks the blocking event's own Through Mode instead of its layer:

```ruby
blocker = @event_tiles[[x, y]]
return false if blocker && !blocker[:char].through
```

This reads the same `Game::Character#through` accessor (`attr_accessor :through`, toggled by the Set Move Route Through Mode ON/OFF commands) that the hero's own Through Mode plumbing already established in #504 (the sibling PR in this sweep) reads/writes — no new accessor needed.

**Explicitly untouched:**
- The airship branch of the same method (`type == :airship`) — airships fly over every event regardless, unaffected.
- The hero's own `passable?` / `char_passable?` / `char_can_land?` — still correctly priority-type-gated (`blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]`).
- `overlap_forbidden` for the hero's rule stays exactly as-is; it simply isn't part of the ship's rule at all (the ship's rule is Through-Mode-only).

## Testing

- New `scripts/rpg2k_scene_check.rb` check: boards a boat, places a `LAYER_BELOW` event (passable-graphic priority type) one tile ahead on an otherwise `boat_pass: true` water tile, and confirms the boat is stopped cold by it — despite the layer mismatch that would let the walking hero glide straight over the same event. Then flips that event's own `Game::Character#through` to `true` and confirms the boat now sails through it.
  - Confirmed the new check **fails** against the pre-fix code (`git stash` on `mruby-rpg2k/mrblib/scene/map.rb`) — the boat sailed straight through the below-characters event even with Through Mode off — then restored the fix and confirmed it passes.
  - Added `boat_pass:`/`ship_pass:` keyword plumbing to the test bed's `fake_db`/`new_scene` helpers (mirroring the existing `airship_land:`/`airship_pass:` pattern) since no prior test needed to drive a boat/ship across open water.
- `ruby scripts/rpg2k_scene_check.rb`: 305 checks passing (1 new), no regressions — including the existing boat boarding/disembarking and airship-over-events checks.
- `ruby scripts/rpg2k_logic_check.rb`: 646 checks passing, unaffected.
- `ruby scripts/rpg2k_render_check.rb`: 40 checks passing, unaffected.
- `docs/TODO.md` updated: split the fixed sentence out of the multi-fact "Vehicles:" bullet into its own `✅` entry (the rest of that bullet — airship initial-position/landability quirks, Set Vehicle Location validation, encounter toggles — remains unverified backlog).
- `changelog.d/vehicle-passability-through-mode.fixed.md` added.

Scoped to `mruby-rpg2k/mrblib/scene/map.rb`, `scripts/rpg2k_scene_check.rb`, `docs/TODO.md`, and the new changelog fragment only — does not touch `Game::Timer` (game.rb) or `Game::Interpreter#play_audio` (interpreter.rb), the two other parallel work streams in this sweep.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_