### PR TITLE
Weapon x magic attribute stacking multiplies rather than picks the best

### DIFF
--- a/changelog.d/attribute-multiplier-weapon-magic-stacking.fixed.md
+++ b/changelog.d/attribute-multiplier-weapon-magic-stacking.fixed.md
@@ -1,0 +1,7 @@
+- **An attack naming both a weapon-type and a magic-type Attribute now
+  multiplies the two rates as fractions (200%×50%=100%)**, matching
+  yado.tk, instead of picking a single strongest-of-all-ids rate the way
+  `Game::Battle#attr_multiplier` did before. Same-type stacking is
+  unchanged: the strongest rate within each type bucket still wins, and a
+  type with no ids in the attack contributes 100% (unaffected), so a
+  single-type attack behaves exactly as before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2447,12 +2447,22 @@ not yet verified:
   of "a weapon carrying **that** attribute", not confirmed against a
   multi-attribute skill since neither test bed ships one. Covered by a new
   `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the pre-fix
-  code. **Still open**: weapon-type × magic-type attribute stacking on one
-  attack **multiplies** the two rates as fractions (200%×50%=100%), not an
-  average despite the site's own wording — a separate question from equip
-  gating, in the damage formula (`Game::Battle#attr_multiplier` currently
-  takes the strongest single rate, not a weapon/magic product) rather than
-  usability.
+  code. ✅ **Weapon-type × magic-type attribute stacking on one attack now
+  multiplies the two rates as fractions (200%×50%=100%)**, not the single
+  strongest-of-all-ids pick `Game::Battle#attr_multiplier` used before (an
+  EasyRPG `Attribute::ApplyAttributeMultiplier`-derived simplification this
+  method's own comment already flagged as not modelling the weapon/magic
+  split) — a separate question from equip gating, in the damage formula
+  rather than usability. `#attr_multiplier` now buckets `attr_ids` by the
+  same `property` table `type` field (a private `attribute_weapon_type?`
+  duplicated onto `Game::Battle`, since it reads `@attributes` — the table
+  `Game::Battle.new` is handed — rather than `Game::Party`'s live `@db`),
+  takes the strongest rate *within* each bucket (same-type stacking is
+  unchanged, the site's own wording never disputed that half), then
+  multiplies the two bucket results as fractions; a bucket with no ids
+  contributes 100% unchanged, so a single-type attack behaves exactly as
+  before. Covered by a new `scripts/rpg2k_logic_check.rb` check, confirmed to
+  fail against the pre-fix code.
 - Battle Animation: only one on screen at a time (a second forcibly cuts
   off the first); 1 frame = 1/30s, but a "Wait" frame is internally
   **two** consecutive 0.0s-wait frames, not one; chaining two Show Battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6829,23 +6829,46 @@ module Game
       ATTR_RATE_PCT[rank]
     end
 
-    # The percentage `attr_ids` scale damage against `target`: the strongest
-    # (largest) rate among the attack's elements, per EasyRPG's
-    # Attribute::ApplyAttributeMultiplier (the physical / magical split isn't
-    # modelled). 100 (unchanged) for an attribute-less attack; a rank the target
-    # doesn't list defaults to C (100%).
+    # Whether attribute `aid` is the database `property` table's weapon-type
+    # (field `type`, value 0, as opposed to magic-type 1) -- same field and
+    # same permissive default (an id the table doesn't define reads as
+    # magic-type) as `Game::Party#attribute_weapon_type?`, which this
+    # duplicates rather than shares since that method reads `@db.property`
+    # off a live database and this one reads `@attributes`, the same table
+    # handed to `Game::Battle.new` from a fixture-friendlier source.
+    def attribute_weapon_type?(aid)
+      row = @attributes ? @attributes[aid] : nil
+      row && row.respond_to?(:type) && row.type == 0 ? true : false
+    end
+
+    # The percentage `attr_ids` scale damage against `target`. yado.tk: an
+    # attack naming both a weapon-type and a magic-type attribute multiplies
+    # the two rates as fractions (e.g. 200% weapon x 50% magic = 100%), not a
+    # single strongest-of-all-ids pick the way EasyRPG's
+    # Attribute::ApplyAttributeMultiplier (this method's own prior model)
+    # does it. Within each type bucket the strongest (largest) rate among
+    # that bucket's ids still wins -- the doc only disputes cross-type
+    # combination, not same-type stacking. A bucket with no ids in it
+    # contributes 100% (unchanged), so an attack with only one type behaves
+    # exactly as before. 100 (unchanged) for an attribute-less attack; a rank
+    # the target doesn't list defaults to C (100%).
     def attr_multiplier(attr_ids, target)
       return 100 if attr_ids.nil? || attr_ids.empty?
       ranks = target.attr_ranks || {}
-      best = nil
+      weapon_best = nil
+      magic_best = nil
       attr_ids.each do |aid|
         rank = ranks[aid] || 2
         rank = 0 if rank < 0
         rank = 4 if rank > 4
         pct = attr_rate(aid, rank)
-        best = pct if best.nil? || pct > best
+        if attribute_weapon_type?(aid)
+          weapon_best = pct if weapon_best.nil? || pct > weapon_best
+        else
+          magic_best = pct if magic_best.nil? || pct > magic_best
+        end
       end
-      best || 100
+      (weapon_best || 100) * (magic_best || 100) / 100
     end
 
     # The most disruptive "forced action" restriction among `b`'s states (0 = act

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5973,6 +5973,36 @@ check 'battle: the attribute multiplier takes the strongest matching element' do
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
   bat.begin_round
   eq 60, bat.step_action[:damage]                    # max(50%, 300%) -> 60
+  # No attribute (property) table at all -> every id defaults to magic-type, so
+  # this is really a same-type case (see the multiply check below) rather than
+  # a counter-example to it.
+end
+
+check 'battle: a weapon-type and a magic-type element multiply instead of picking the strongest (yado.tk)' do
+  # Element 1 is weapon-type, element 2 magic-type (property table `type`
+  # field, as in the can_cast? weapon-attribute-gating check above).
+  props = { 1 => AttrTypeRow.new(0), 2 => AttrTypeRow.new(1) }
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1, 2]
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  slime.attr_ranks = { 1 => 0, 2 => 3 }  # weapon rank A (300%), magic rank D (50%)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, false,
+                         false, false, props)
+  bat.begin_round
+  eq 30, bat.step_action[:damage]  # 20 * (300% * 50%) = 20 * 150% = 30, not max(300,50)=60
+
+  # Within one type bucket, the strongest element still wins (the doc only
+  # disputes cross-type combination); a type with no ids at all contributes
+  # 100% unchanged.
+  props2 = { 1 => AttrTypeRow.new(0), 3 => AttrTypeRow.new(0) } # both weapon-type
+  hero2 = combatant('Hero', 40, 0, 20, 100)
+  hero2.atk_attrs = [1, 3]
+  slime2 = combatant('Slime', 0, 0, 5, 100_000)
+  slime2.attr_ranks = { 1 => 3, 3 => 0 } # weapon: resists 1 (50%), weak to 3 (300%)
+  bat2 = Game::Battle.new([hero2], [slime2], Game::Rng.new(1), nil, false, false,
+                          false, false, props2)
+  bat2.begin_round
+  eq 60, bat2.step_action[:damage] # max(50%, 300%) within the weapon bucket * 100% magic
 end
 
 check 'battle: an unlisted element deals full (C = 100%) damage' do


### PR DESCRIPTION
## Summary

- yado.tk (explicitly flagged as "Still open" in a prior PR in this sweep):
  when an attack names both a weapon-type and a magic-type Attribute, real
  RPG_RT **multiplies** the two rates as fractions (e.g. 200%×50%=100%), not
  a single strongest-of-all-ids pick.
- `Game::Battle#attr_multiplier` (`mruby-rpg2k/mrblib/game.rb`) took the
  single strongest rate across every id in the attack regardless of type —
  its own comment already flagged this as an EasyRPG
  `Attribute::ApplyAttributeMultiplier`-derived simplification that doesn't
  model the weapon/magic split.
- Fix: `#attr_multiplier` now buckets `attr_ids` by the database `property`
  table's weapon(0)/magic(1) `type` field (a private `attribute_weapon_type?`
  duplicated onto `Game::Battle`, since it reads `@attributes` — the table
  handed to `Game::Battle.new` — rather than `Game::Party`'s live `@db`),
  takes the strongest rate *within* each bucket (same-type stacking is
  unchanged — the site's own wording never disputed that half), then
  multiplies the two bucket results as fractions. A bucket with no ids
  contributes 100% (unchanged), so a single-type attack behaves exactly as
  before.

## Test plan

- [x] `scripts/rpg2k_logic_check.rb` — added a check asserting a weapon-type
  rank-A (300%) + magic-type rank-D (50%) attack deals 150% damage
  (multiplied), not 300% (the old best-of-all pick), plus a same-type
  sanity check that two weapon-type ids still take the strongest within
  that bucket. Confirmed the multiply check fails against the pre-fix
  `game.rb` via `git stash` (`expected 30, got 60`).
- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (648 checks).
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (304 checks).
- [x] `scripts/rpg2k_render_check.rb` passes (40 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_