### PR TITLE
rpg2k: weapon/magic attribute stacking, actor_set item restriction

### DIFF
--- a/changelog.d/rpg2k-attribute-weapon-magic-stacking.fixed.md
+++ b/changelog.d/rpg2k-attribute-weapon-magic-stacking.fixed.md
@@ -1,0 +1,14 @@
+- RPG Maker 2000: an attack carrying both a **weapon-type and a magic-type**
+  elemental attribute at once now scales damage correctly. EasyRPG's
+  `Attribute::ApplyAttributeMultiplier` keeps the strongest rate *within*
+  each type (physical/weapon and magical/magic tracked independently) and,
+  when both are present, **multiplies** the two as successive percentage
+  scalings of the damage (200% × 50% nets 100%, not an average and not just
+  the single strongest rate across every attribute regardless of type — the
+  previous behaviour). `Game::Battle#apply_attr_multiplier` (renamed from
+  `#attr_multiplier`, which returned a percentage the caller then applied —
+  the truncation order between that and the two-step scaling isn't always
+  the same, so it now takes and returns the actual damage figure, matching
+  `ApplyAttributeMultiplier`'s own signature) reads each attribute's type
+  off the same `property` table `#attr_rate` already uses. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/changelog.d/rpg2k-item-actor-set-restriction.added.md
+++ b/changelog.d/rpg2k-item-actor-set-restriction.added.md
@@ -1,0 +1,15 @@
+- RPG Maker 2000: an item or piece of gear reserved for a **named character**
+  (the `actor_set` / `actor_set_size` fields, parsed but never consulted
+  before) is now actually restricted to them — it could previously be
+  equipped or used by anyone. `Party#item_usable_by?(it, actor_id)` reads the
+  restriction (an entry the array is too short to reach defaults to allowed,
+  matching EasyRPG's `Game_Actor::IsItemUsable`), wired into `item_effective?`
+  (menu grey-out), `use_medicine` / `use_skill_book` / `use_seed` /
+  `use_special_item` (the effect itself — `use_medicine` checks it per target
+  so a restricted member is skipped even under an all-party scope),
+  `equip_candidates` / `equip_candidate_for?` (the equip menu), and the
+  **Change Equipment** event command (10450), which EasyRPG's own
+  `ChangeEquipment` gates through the identical check. Left open: the battle
+  screen's ally-target picker for a restricted item still lists every living
+  ally — noted in `docs/TODO.md` as a follow-up rather than silently
+  inconsistent. Covered by new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1602,6 +1602,32 @@ The work below is roughly ordered by the critical path to a walkable game
   which turns the shield slot into a second weapon slot — the same pair and the
   opposite rule, and the menu's candidate list for slot 1 has to change with it.
   See ADR 0040.
+- ✅ **使用可能キャラ item restriction** (`actor_set` / `actor_set_size`, item
+  field 62/61) — parsed by the schema but never consulted, so an item or piece
+  of gear reserved for one named character (a signature weapon, a class-locked
+  scroll) could be equipped or used by anyone. `Party#item_usable_by?(it,
+  actor_id)` reads the bit at `actor_id - 1`, defaulting an entry the array is
+  too short to reach to allowed — the same "missing = the field's default"
+  reading every other bit-array field here follows (EasyRPG's
+  `Game_Actor::IsItemUsable`). Wired into every path that reaches an item:
+  `item_effective?` (menu grey-out) and `use_medicine` / `use_skill_book` /
+  `use_seed` / `use_special_item` (the effect itself — `use_medicine` checks it
+  **per target** the same way `ko_only_blocked?` already had to, so a
+  restricted member is skipped even under an all-party scope rather than only
+  being caught by the single-target menu gate); `equip_candidates` /
+  `equip_candidate_for?` (the equip menu's own candidate list and
+  `equip_from_bag`'s validation); and the **Change Equipment** event command
+  (10450, `do_change_equipment` in `interpreter.rb`), which EasyRPG's
+  `ChangeEquipment` gates through the identical `IsItemUsable` call — checked
+  per target there too, since a command can target the whole party at once.
+  **Left open**: the battle screen's own ally-target picker for a restricted
+  medicine/item (`Scene::Map#draw_battle_ally_target`) still lists every
+  living ally regardless of the item's `actor_set` — the pure
+  `Game::Party#battle_item_command` formula is not wrong, nothing upstream of
+  it in the battle scene enforces the restriction on which target can be
+  chosen in the first place. Covered by new `scripts/rpg2k_logic_check.rb`
+  checks (the read itself, the all-party-scope per-target skip, menu
+  greying-out, equip-menu filtering, and the event command).
 
 ### yado.tk quirks backlog
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2428,12 +2428,24 @@ not yet verified:
   of "a weapon carrying **that** attribute", not confirmed against a
   multi-attribute skill since neither test bed ships one. Covered by a new
   `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the pre-fix
-  code. **Still open**: weapon-type × magic-type attribute stacking on one
-  attack **multiplies** the two rates as fractions (200%×50%=100%), not an
-  average despite the site's own wording — a separate question from equip
-  gating, in the damage formula (`Game::Battle#attr_multiplier` currently
-  takes the strongest single rate, not a weapon/magic product) rather than
-  usability.
+  code. **Weapon-type × magic-type attribute stacking is built now too** — a
+  separate question from equip gating, in the damage formula rather than
+  usability. EasyRPG's `Attribute::ApplyAttributeMultiplier` keeps the
+  *strongest* rate within each type (physical/weapon and magical/magic
+  tracked independently) and, when an attack carries both at once,
+  **multiplies** the two as successive percentage scalings of the damage
+  (200%×50% nets 100%, not an average and not just the single strongest
+  rate across every attribute regardless of type). `Game::Battle#apply_attr_multiplier`
+  (renamed from `#attr_multiplier`, which returned a percentage rather than
+  the scaled damage — the truncation order between the two isn't always the
+  same, so it now takes and returns the actual damage figure, matching
+  `ApplyAttributeMultiplier`'s own signature) reads each attribute's type
+  off the same `@attributes` (`property`) table `#attr_rate` already uses.
+  RPG2000 attribute rates never go negative, so EasyRPG's "one side
+  negative" fallback branch (a 2003 `attribute.type` add-on) never applies
+  here. Covered by new `scripts/rpg2k_logic_check.rb` checks (both types at
+  once multiplying, and two attributes of the *same* type still keeping the
+  strongest rather than multiplying against each other).
 - Battle Animation: only one on screen at a time (a second forcibly cuts
   off the first); 1 frame = 1/30s, but a "Wait" frame is internally
   **two** consecutive 0.0s-wait frames, not one; chaining two Show Battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6721,7 +6721,7 @@ module Game
       dmg = Battle.attack_damage(effective_atk(b), effective_def(target))
       # An elemental weapon scales its damage by the target's resistance before
       # variance / criticals (EasyRPG's ApplyAttributeNormalAttackMultiplier).
-      dmg = dmg * attr_multiplier(b.atk_attrs, target) / 100
+      dmg = apply_attr_multiplier(dmg, b.atk_attrs, target)
       dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
       # No critical on a same-side hit (e.g. a confused ally striking an ally) or
       # against a target whose gear prevents criticals, matching EasyRPG.
@@ -6829,23 +6829,57 @@ module Game
       ATTR_RATE_PCT[rank]
     end
 
-    # The percentage `attr_ids` scale damage against `target`: the strongest
-    # (largest) rate among the attack's elements, per EasyRPG's
-    # Attribute::ApplyAttributeMultiplier (the physical / magical split isn't
-    # modelled). 100 (unchanged) for an attribute-less attack; a rank the target
-    # doesn't list defaults to C (100%).
-    def attr_multiplier(attr_ids, target)
-      return 100 if attr_ids.nil? || attr_ids.empty?
+    # Whether attribute `aid` is the database's weapon-type (property field 2,
+    # value 0) rather than magic-type (1) -- the same reading
+    # Game::Party#attribute_weapon_type? uses (for skill-usability gating),
+    # duplicated here since Battle reaches the property table through its own
+    # `@attributes` rather than a database reference shared with Party. An id
+    # the table doesn't define reads as magic-type, the permissive default
+    # #attribute_weapon_type? also falls back to.
+    def attribute_physical?(aid)
+      row = @attributes ? @attributes[aid] : nil
+      row && row.respond_to?(:type) && row.type == 0 ? true : false
+    end
+
+    # Scale `dmg` by `attr_ids`'s rate against `target`'s per-attribute
+    # defence ranks: EasyRPG's Attribute::ApplyAttributeMultiplier. Each
+    # attribute is either weapon-type (physical) or magic-type; the
+    # strongest (largest) rate *within* each type is kept, and an attack
+    # carrying both types at once multiplies the two rates as two successive
+    # percentage scalings of `dmg` -- not an average, and not just the
+    # single strongest rate across every attribute regardless of type (a
+    # 200%-physical, 50%-magical attack nets 100%, not 200%). Ported
+    # truncation-order and all (`magical * (physical * dmg / 100) / 100`)
+    # rather than precomputing a combined percentage first, since the two
+    # can round differently. Unchanged for an attribute-less attack; a rank
+    # the target doesn't list defaults to C (100%). RPG2000 attribute rates
+    # never go negative, so EasyRPG's "one side is negative" fallback branch
+    # (2003's `attribute.type` add-on) never applies here.
+    def apply_attr_multiplier(dmg, attr_ids, target)
+      return dmg if attr_ids.nil? || attr_ids.empty?
       ranks = target.attr_ranks || {}
-      best = nil
+      physical = nil
+      magical = nil
       attr_ids.each do |aid|
         rank = ranks[aid] || 2
         rank = 0 if rank < 0
         rank = 4 if rank > 4
         pct = attr_rate(aid, rank)
-        best = pct if best.nil? || pct > best
+        if attribute_physical?(aid)
+          physical = pct if physical.nil? || pct > physical
+        else
+          magical = pct if magical.nil? || pct > magical
+        end
       end
-      best || 100
+      if physical && magical
+        magical * (physical * dmg / 100) / 100
+      elsif physical
+        physical * dmg / 100
+      elsif magical
+        magical * dmg / 100
+      else
+        dmg
+      end
     end
 
     # The most disruptive "forced action" restriction among `b`'s states (0 = act
@@ -6929,7 +6963,7 @@ module Game
         dmg = -hp
         # An elemental skill scales its damage by the target's resistance first
         # (EasyRPG's ApplyAttributeSkillMultiplier), then spreads by variance.
-        dmg = dmg * attr_multiplier(cmd[:attributes], target) / 100
+        dmg = apply_attr_multiplier(dmg, cmd[:attributes], target)
         # Spread the skill's damage by its own variance when the fight rolls it.
         dmg = varied(dmg, cmd[:variance]) if @variance && dmg > 0 && cmd[:variance] && cmd[:variance] > 0
         # 吸収: the caster takes what the target loses, and can take no more than

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2378,6 +2378,25 @@ module Game
       !actor.dead?
     end
 
+    # 使用可能キャラ (`actor_set`, item field 62): whether item `it` names
+    # `actor_id` among the specific characters allowed to use or equip it at
+    # all. The one restriction list gates both uses (EasyRPG's
+    # `Game_Actor::IsItemUsable`, read by `Game_Party::IsItemUsable`'s
+    # per-target overload for using an item and by `ChangeEquipment` for
+    # equipping one) — a book, seed, medicine or piece of gear can all be
+    # limited to a named cast member this way, not just weapons/armour. An
+    # actor id the array is too short to reach defaults to allowed, the same
+    # "missing entry reads as the field's default" rule this runtime's other
+    # bit-array fields (terrain_set, class_set-adjacent ones) already follow.
+    def item_usable_by?(it, actor_id)
+      return true unless it.respond_to?(:actor_set) && it.actor_set
+      return true if actor_id.nil?
+      set = it.actor_set
+      idx = actor_id - 1
+      return true if idx < 0 || set.size <= idx
+      set[idx] ? true : false
+    end
+
     # Whether using item `id` on `actor` would change anything, so the menu can
     # grey out a no-op. A medicine is effective when the target is below full
     # HP/SP and it restores some (RPG_RT forbids using a pure-recovery item on a
@@ -2386,6 +2405,7 @@ module Game
     def item_effective?(id, actor)
       it = db_item(id)
       return false unless it && actor
+      return false unless item_usable_by?(it, actor.id)
       case it.type
       when ITEM_MEDICINE
         return false if ko_only_blocked?(it, actor)
@@ -2429,6 +2449,7 @@ module Game
     # have learnt the skill. One is consumed only when the cast actually did
     # something, matching how the other item kinds here refuse to be wasted.
     def use_special_item(it, id, actor)
+      return [] unless actor && item_usable_by?(it, actor.id)
       affected = cast_skill(actor, it.skill_id, actor, true)
       lose_item(id, 1) unless affected.empty?
       affected
@@ -2446,8 +2467,10 @@ module Game
       targets.each do |t|
         # A 蘇生専用 item passes over anyone still standing without touching
         # them -- not even the HP restore -- which is what keeps an all-party
-        # revive from topping up the members who never fell.
-        next if ko_only_blocked?(it, t)
+        # revive from topping up the members who never fell. An actor_set
+        # restriction does the same for a member the item simply is not
+        # usable on, even under an all-party scope.
+        next if ko_only_blocked?(it, t) || !item_usable_by?(it, t.id)
         changed = false
         # Cure first: a revive item (curing 戦闘不能) stands the actor back up so
         # the HP recovery below lands instead of being blocked as a no-op.
@@ -2474,7 +2497,8 @@ module Game
     # actor who already knows the skill, does nothing and is not consumed.
     def use_skill_book(it, id, actor)
       skill = it.skill_id
-      return [] unless actor && skill && skill != 0 && !actor.knows_skill?(skill)
+      return [] unless actor && item_usable_by?(it, actor.id) &&
+                       skill && skill != 0 && !actor.knows_skill?(skill)
       actor.learn_skill(skill)
       lose_item(id, 1)
       [actor]
@@ -2495,7 +2519,7 @@ module Game
     # through Actor#change_param, so RPG2000's stat caps hold). Consumes one when
     # it carries any boost; a seed with no boost does nothing and is not consumed.
     def use_seed(it, id, actor)
-      return [] unless actor
+      return [] unless actor && item_usable_by?(it, actor.id)
       boosts = seed_boosts(it)
       return [] unless boosts.any? { |b| b != 0 }
       boosts.each_index { |i| actor.change_param(i, boosts[i]) if boosts[i] != 0 }
@@ -2516,25 +2540,33 @@ module Game
 
     # Held items equippable in equipment `slot` (0..4) on `actor`, as
     # [id, count] pairs in ascending id order -- the candidate list for the
-    # equip menu's chosen slot. `actor` only matters for the shield slot (1):
-    # a 二刀流 (double_hand) actor's shield slot is a second weapon slot, so it
-    # lists weapons there instead of shields -- mirroring EasyRPG's
+    # equip menu's chosen slot. `actor` matters two ways: for the shield slot
+    # (1), a 二刀流 (double_hand) actor's shield slot is a second weapon slot,
+    # so it lists weapons there instead of shields -- mirroring EasyRPG's
     # `Window_EquipItem`, which retargets the whole slot to `weapon` for such
-    # an actor before filtering, rather than offering both kinds.
+    # an actor before filtering, rather than offering both kinds; and an
+    # actor_set restriction (#item_usable_by?) drops an item this particular
+    # actor cannot wear at all, matching `Game_Actor::IsItemUsable` (which
+    # `ChangeEquipment` reads the same way). Both actor-dependent filters are
+    # simply skipped when no `actor` is given.
     def equip_candidates(slot, actor = nil)
       slot = Actor::WEAPON_SLOT if slot == Actor::SHIELD_SLOT && actor && actor.double_hand?
-      @items.keys.sort.select { |id| item_count(id) > 0 && equip_slot_for(id) == slot }
-            .map { |id| [id, item_count(id)] }
+      @items.keys.sort.select do |id|
+        item_count(id) > 0 && equip_slot_for(id) == slot &&
+          (actor.nil? || item_usable_by?(db_item(id), actor.id))
+      end.map { |id| [id, item_count(id)] }
     end
 
     # Whether held item `id` is a genuine #equip_candidates entry for `slot` on
-    # `actor` -- mirrors that method's own retargeting exactly, so a `slot`
-    # argument #equip_from_bag receives can never accept anything the
-    # candidate list would not itself have offered (in either direction: a
-    # 二刀流 actor's shield slot accepts a weapon, not a weapon *and* a shield).
+    # `actor` -- mirrors that method's own retargeting and actor_set filter
+    # exactly, so a `slot` argument #equip_from_bag receives can never accept
+    # anything the candidate list would not itself have offered (in either
+    # direction: a 二刀流 actor's shield slot accepts a weapon, not a weapon
+    # *and* a shield; an actor this item is not usable by accepts nothing).
     def equip_candidate_for?(actor, id, slot)
       base = equip_slot_for(id)
       return false if base.nil?
+      return false if actor && !item_usable_by?(db_item(id), actor.id)
       if slot == Actor::SHIELD_SLOT && actor && actor.double_hand?
         base == Actor::WEAPON_SLOT
       else

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1849,7 +1849,12 @@ module Game
       targets = stat_targets(cmd)
       if cmd.param(2) == 0
         item = cmd.param(3) == 0 ? cmd.param(4) : variables[cmd.param(4)]
-        targets.each { |a| a.equip_item(item) }
+        it = @state.party.db_item(item)
+        # An actor_set restriction blocks this command the same way it blocks
+        # the equip menu (EasyRPG's ChangeEquipment reads Game_Actor::
+        # IsItemUsable too) -- per target, since one target of a multi-actor
+        # command might be allowed the item and another not.
+        targets.each { |a| a.equip_item(item) if @state.party.item_usable_by?(it, a.id) }
       else
         targets.each { |a| a.unequip(cmd.param(4)) }
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5972,7 +5972,12 @@ check 'battle: an elemental skill scales its damage by the target resistance' do
 end
 
 # A property/state row carrying the RPG2000 A..E rank rates (property table).
-RateRow = Struct.new(:a_rate, :b_rate, :c_rate, :d_rate, :e_rate)
+# `type` (weapon 0 / magic 1, property field 2) is appended rather than
+# fitted in at its real field position so the existing 5-positional-arg
+# calls below keep working unmodified -- omitted, it defaults to nil, which
+# #attribute_physical? already reads as "magic-type" the same way an
+# attribute the table doesn't define at all does.
+RateRow = Struct.new(:a_rate, :b_rate, :c_rate, :d_rate, :e_rate, :type)
 
 check "battle: a database attribute's own rank rates override the defaults" do
   props = { 1 => RateRow.new(250, 180, 100, 40, 0) } # element 1: rank A = 250%
@@ -5985,6 +5990,38 @@ check "battle: a database attribute's own rank rates override the defaults" do
                          false, false, props)
   bat.begin_round
   eq 50, bat.step_action[:damage]                    # 20 * 250% (its own rate, not 300)
+end
+
+check 'battle: a weapon-type and a magic-type attribute on one attack multiply, ' \
+     'not just the strongest rate' do
+  props = { 1 => RateRow.new(200, 150, 100, 50, 0, 0),  # weapon-type
+            2 => RateRow.new(200, 150, 100, 50, 0, 1) } # magic-type
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1, 2]
+  foe = combatant('Foe', 0, 0, 5, 100_000)
+  foe.attr_ranks = { 1 => 0, 2 => 3 } # weapon rank A (200%), magic rank D (50%)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false,
+                         false, false, props)
+  bat.command_attack(hero, foe)
+  bat.begin_round
+  # base atk damage = 40 / 2 - 0 / 4 = 20; 200% weapon * 50% magic = 100%,
+  # unchanged at 20 -- not 40, which is what "the single strongest rate
+  # (200%) wins regardless of type" would have given.
+  eq 20, bat.step_action[:damage]
+end
+
+check 'battle: two attributes of the same type keep the strongest rate, not multiply' do
+  props = { 1 => RateRow.new(200, 150, 100, 50, 0, 0),
+            2 => RateRow.new(200, 150, 100, 50, 0, 0) } # both weapon-type
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1, 2]
+  foe = combatant('Foe', 0, 0, 5, 100_000)
+  foe.attr_ranks = { 1 => 3, 2 => 0 } # 50% and 200%, same type: keep the 200%
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false,
+                         false, false, props)
+  bat.command_attack(hero, foe)
+  bat.begin_round
+  eq 40, bat.step_action[:damage] # base 20 * 200%, not 200% * 200%
 end
 
 check "battle: a database state's own rank rate gates the infliction" do

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2118,7 +2118,10 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       # 全体化: spreads a basic Attack across the target's whole
                       # side. 先制攻撃: jumps a basic Attack to the front of the
                       # round's turn order.
-                      :attack_all, :preemptive)
+                      :attack_all, :preemptive,
+                      # 使用可能キャラ: the specific actor ids (0-based index,
+                      # bool per actor) allowed to use/equip this item at all.
+                      :actor_set)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -2126,13 +2129,13 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               attribute_set: nil, switch_id: 0, occ_field: true,
               field_only: false, dual_attack: false, ignore_evasion: false,
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
-              two_handed: 0, attack_all: false, preemptive: false)
+              two_handed: 0, attack_all: false, preemptive: false, actor_set: nil)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
-               ko_only, two_handed, attack_all, preemptive)
+               ko_only, two_handed, attack_all, preemptive, actor_set)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -3065,6 +3068,23 @@ check 'Change Equipment command equips into the type slot and removes' do
   eq 8, a.equipment[2] # armour still on
 end
 
+check 'Change Equipment command respects an actor_set restriction, per actor' do
+  items = { 7 => fake_item(atk: 15, type: 1, actor_set: [true, false]) } # actor 1 only
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]),
+      2 => CurveRow.new('Ally', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1, 2], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  eq 18, hero.atk, 'Hero (actor 1) is allowed the item'
+  eq 7, hero.equipment[0]
+
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 2, 0, 0, 7])]); it.update }
+  eq 3, ally.atk, 'Ally (actor 2) is restricted away from it: the command is a no-op'
+  eq 0, ally.equipment[0]
+end
+
 # -- Field item menu (Game::Party medicine use) ------------------------------
 
 # A two-actor party (Hero max 100/30, Ally max 50/20) plus the given item table,
@@ -3685,6 +3705,56 @@ check 'equip_from_bag rejects a non-equippable or unheld item' do
   eq false, st.party.equip_from_bag(a, 7)   # not held
   eq 1, st.party.item_count(5)              # untouched
   eq 0, a.equipment[0]
+end
+
+# -- 使用可能キャラ (actor_set): items/gear restricted to named characters ----
+
+check 'item_usable_by? reads actor_set, defaulting a missing entry to allowed' do
+  restricted = fake_item(type: 6, rhp: 10, actor_set: [true, false]) # only actor 1
+  unrestricted = fake_item(type: 6, rhp: 10)                        # no actor_set at all
+  st = skill_party({})
+  ok st.party.item_usable_by?(restricted, 1), 'actor 1 is explicitly allowed'
+  eq false, st.party.item_usable_by?(restricted, 2), 'actor 2 is explicitly excluded'
+  ok st.party.item_usable_by?(restricted, 3), 'actor_set too short to reach id 3: defaults to allowed'
+  ok st.party.item_usable_by?(unrestricted, 2), 'no actor_set at all: unrestricted'
+end
+
+check 'a medicine restricted by actor_set only heals the actors it names, ' \
+     'even under an all-party scope' do
+  items = { 5 => fake_item(type: 6, scope: 1, rhp: 20, actor_set: [true, false]) } # actor 1 only
+  st = skill_party({}, items)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.change_hp(-50)
+  ally.change_hp(-50)
+  st.party.gain_item(5, 1)
+  affected = st.party.use_item(5, nil) # all-ally: target arg ignored
+  eq [hero], affected, 'only the named actor is healed, even though the item is scope 1 (all allies)'
+  eq hero.max_hp - 30, hero.hp, 'Hero was healed by 20'
+  eq ally.max_hp - 50, ally.hp, "Ally's HP is untouched"
+end
+
+check 'item_effective? is false for an actor an actor_set restriction excludes' do
+  items = { 5 => fake_item(type: 6, rhp: 20, actor_set: [true, false]) }
+  st = skill_party({}, items)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  hero.change_hp(-10)
+  ally.change_hp(-10)
+  ok st.party.item_effective?(5, hero)
+  eq false, st.party.item_effective?(5, ally), 'restricted away, even though it would otherwise heal'
+end
+
+check 'equip_candidates / equip_from_bag respect an actor_set restriction' do
+  items = { 7 => fake_item(atk: 15, type: 1, actor_set: [true, false]) } # actor 1 only
+  st = skill_party({}, items)
+  hero = st.party.actor_by_id(1)
+  ally = st.party.actor_by_id(2)
+  st.party.gain_item(7, 2)
+  eq [[7, 2]], st.party.equip_candidates(0, hero)
+  eq [], st.party.equip_candidates(0, ally), "the ally isn't offered a weapon reserved for the hero"
+  ok st.party.equip_from_bag(hero, 7)
+  eq false, st.party.equip_from_bag(ally, 7), 'and cannot force-equip it either'
 end
 
 # RPG_RT's item-possession test counts an equipped copy even though equipping


### PR DESCRIPTION
## Summary

Two more verified-against-source fixes, following on from #516 (already merged).

- **Weapon-type × magic-type elemental attribute stacking.** `Battle#attr_multiplier` took the single strongest rate among an attack's elemental attributes regardless of type. EasyRPG's `Attribute::ApplyAttributeMultiplier` actually tracks physical (weapon-type) and magical (magic-type) attributes separately — strongest rate *within* each type — and when an attack carries both at once, multiplies the two as successive percentage scalings of the damage (200% × 50% nets 100%, not 200% and not an average). This was explicitly named as an open gap in `docs/TODO.md`. Renamed to `apply_attr_multiplier` and changed its contract to take/return the actual damage rather than a percentage, since the real function's truncation order (`magical * (physical * dmg / 100) / 100`) doesn't always match a precomputed combined-percentage shortcut.

- **`actor_set` (使用可能キャラ / usable-characters) item restriction.** A genuinely unread schema field (item field 61/62) — an item or piece of gear reserved for one named character could previously be equipped or used by anyone. `Party#item_usable_by?(it, actor_id)` reads the restriction (an entry the array is too short to reach defaults to allowed, matching EasyRPG's `Game_Actor::IsItemUsable`), wired into `item_effective?` (menu grey-out), `use_medicine` / `use_skill_book` / `use_seed` / `use_special_item` (the effect itself — `use_medicine` checks it per target so a restricted member is skipped even under an all-party scope), `equip_candidates` / `equip_candidate_for?` (the equip menu), and the **Change Equipment** event command (10450), which EasyRPG's own `ChangeEquipment` gates through the identical check. Left open on purpose: the battle screen's own ally-target picker for a restricted item still lists every living ally — noted as a follow-up in `docs/TODO.md` rather than left silently inconsistent, since the pure `battle_item_command` formula isn't wrong, nothing upstream of it in the scene enforces the restriction on which target can even be chosen.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 653 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 304 checks passed
- [x] New checks for both fixes (attribute stacking: both types multiplying vs. same-type keeping the strongest; actor_set: the read itself, all-party-scope per-target skip, menu greying-out, equip-menu filtering, the event command)

https://claude.ai/code/session_01TyFbA9EkMdeUsdAkkCMX8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyFbA9EkMdeUsdAkkCMX8p)_