### PR TITLE
Fix inverted front/back render order for enemy troop members

### DIFF
--- a/changelog.d/enemy-battler-render-order.fixed.md
+++ b/changelog.d/enemy-battler-render-order.fixed.md
@@ -1,0 +1,8 @@
+- **Enemy troop members now render front-to-back in the correct order.**
+  yado.tk: the lower-numbered (first-added) member should render closer to
+  the camera. `Scene::Map`'s battler sprite z-values were inverted — the
+  last-added member appeared on top instead of the first — since the
+  native renderer draws the highest-z sprite on top but the code assigned
+  z in ascending add-order. Fixed via a shared `#battler_z` helper used by
+  every place a battler sprite's depth is set (initial build, mid-fight
+  graphic change, Show Hidden Monster).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2677,10 +2677,22 @@ above are repeated here)
   ranks must be configured strictly `A>B>C>D>E` for the ±1-step logic to make
   sense. Covered by a new `scripts/rpg2k_logic_check.rb` check (both
   directions, and that repeat casts don't stack past the cap).
-- Enemy group members are numbered by add-order; **lower number renders
-  in front** (closer to camera); deleting a middle member shifts every
-  later member's number down by one, which can silently repoint any
-  battle-event command that names a member by number.
+- Enemy group members are numbered by add-order. ✅ **The lower-numbered
+  member renders in front (closer to camera)**: `Scene::Map#build_battle_sprites`
+  / `#rebuild_battler_sprite` / `#reveal_battle_monster`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) previously all set a battler sprite's
+  `z` to `100 + i` for add-order index `i`, but the native renderer draws the
+  *highest*-z sprite on top (`gfx_update`'s own "leaving the greatest z on
+  top") — so the code had it backwards, putting the *last*-added member in
+  front instead of the first. Now routed through a shared `#battler_z(i)`
+  that inverts the index (`100 + (members.size - 1 - i)`), so member 0 gets
+  the highest z of the group. Covered by a new assertion on the existing
+  `scripts/rpg2k_scene_check.rb` two-Slime battler-sprite check, confirmed to
+  fail against the pre-fix code. **Still open**: whether deleting a middle
+  member shifts every later member's number down by one (and whether a
+  battle-event command naming a member by number gets silently repointed by
+  it) is unverified — a separate question about troop-member identity/
+  numbering, not the render-order this PR fixes.
 - The "airborne" enemy display flag **only** changes its Y position on
   screen — it has no accuracy/hit-related effect. The "frequent miss"
   enemy option is a hardcoded 90%→70% drop to *normal-attack* accuracy

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2804,6 +2804,16 @@ class RPG2k
         draw_battle_command unless run_battle_events
       end
 
+      # A troop member's sprite depth for its add-order index `i` (0-based).
+      # RPG2000 numbers troop members by add-order and renders the
+      # **lower**-numbered member closer to the camera (yado.tk); the native
+      # renderer draws the *highest*-z sprite on top (see `gfx_update`'s own
+      # "leaving the greatest z on top"), so index 0 needs the highest z here
+      # -- the reverse of the add-order index itself.
+      def battler_z(i)
+        100 + (@battle_ui[:troop].members.size - 1 - i)
+      end
+
       # RPG2000 is a front-view battle: the enemy troop is drawn as sprites over a
       # battle background, while the party is represented by the status window (not
       # sprites). Build the backdrop and one sprite per visible troop member,
@@ -2818,7 +2828,7 @@ class RPG2k
           spr.bitmap = bmp
           spr.x = enemy.x - bmp.width / 2
           spr.y = enemy.y - bmp.height / 2
-          spr.z = 100 + i
+          spr.z = battler_z(i)
           spr
         end
         # The battler each sprite was drawn from, so a transformation mid-fight
@@ -2982,7 +2992,7 @@ class RPG2k
         spr.bitmap = bmp
         spr.x = member.x - bmp.width / 2
         spr.y = member.y - bmp.height / 2
-        spr.z = 100 + i
+        spr.z = battler_z(i)
         spr.visible = !foe.out_of_play?
         sprites[i] = spr
         dispose_battle_sprite(old)
@@ -3584,7 +3594,7 @@ class RPG2k
         spr.bitmap = bmp
         spr.x = member.x - bmp.width / 2
         spr.y = member.y - bmp.height / 2
-        spr.z = 100 + index
+        spr.z = battler_z(index)
         dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
         @battle_ui[:enemy_sprites][index] = spr
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4097,6 +4097,9 @@ check 'Enemy Encounter scene: draws a battler sprite per enemy, hidden on death'
   eq 80 - sprites[0].bitmap.height / 2, sprites[0].y, 'sprite centred on its y'
   ok sprites[0].z < 300, 'battlers sit below the UI windows (z >= 300)'
   ok ui[:back_sprite].z < sprites[0].z, 'the backdrop sits behind the battlers'
+  # yado.tk: troop members are numbered by add-order and the *lower*-numbered
+  # one renders in front (closer to camera) -- member 0 here, added first.
+  ok sprites[0].z > sprites[1].z, 'the lower-numbered troop member renders on top'
 
   battle_attack_to_end(scene) # both Slimes fall
   ok sprites.all? { |s| !s.visible }, 'a defeated enemy sprite is hidden'


### PR DESCRIPTION
## Summary

- yado.tk: enemy troop members are numbered by add-order, and the
  **lower-numbered member renders in front** (closer to camera).
- `Scene::Map`'s three battler-sprite z-assignment sites
  (`#build_battle_sprites`, `#rebuild_battler_sprite`,
  `#reveal_battle_monster` — `mruby-rpg2k/mrblib/scene/map.rb`) all set
  `spr.z = 100 + i` for add-order index `i`. But the native renderer draws
  the **highest**-z sprite on top (`gfx_update`'s own "leaving the greatest
  z on top" comment in `mruby-rgss/src/lib.cxx`), so ascending z by add-order
  put the *last*-added member in front — the exact opposite of the
  documented rule.
- Fix: a new shared `#battler_z(i)` inverts the index
  (`100 + (members.size - 1 - i)`), used at all three sites, so member 0
  (added first) gets the group's highest z.
- **Still open**: whether deleting a middle troop member shifts every later
  member's number down by one (and silently repoints battle-event commands
  that name a member by number) — a separate identity/numbering question
  from the render-order this PR fixes, left unverified in `docs/TODO.md`.

## Test plan

- [x] `scripts/rpg2k_scene_check.rb` — extended the existing two-Slime
  battler-sprite check with `sprites[0].z > sprites[1].z` (the
  first-added member renders on top). Confirmed it fails against the
  pre-fix `scene/map.rb` via `git stash`.
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (305 checks).
- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (650 checks).
- [x] `scripts/rpg2k_render_check.rb` passes (40 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_