### PR TITLE
Change Monster HP: a positive amount can no longer revive a downed enemy

### DIFF
--- a/changelog.d/change-monster-hp-no-revive.fixed.md
+++ b/changelog.d/change-monster-hp-no-revive.fixed.md
@@ -1,0 +1,11 @@
+- **Change Monster HP (13110) can no longer revive a downed (0 HP)
+  enemy.** `Game::Interpreter#do_change_monster_hp` applied its delta
+  straight to the `Game::Battle::Combatant`, so a positive amount on an
+  already-dead troop member (`Combatant#dead?` is `hp <= 0`)
+  unconditionally raised its HP back above 0. A positive amount on an
+  already-dead target is now a no-op, mirroring the guard
+  `Game::Actor#change_hp` already has on the field/actor side
+  (`return @hp if dead?`); a further (negative) hit on a dead enemy is
+  unaffected and still re-clamps to the command's own lethal-flag floor.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check, confirmed to
+  fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2435,10 +2435,21 @@ not yet verified:
   state, then rolls RNG against those weights. A turn-condition shorthand
   like "3×?+5" means: first candidate on turn 5, then every 3 turns
   after.
-- Enemy HP-increase **cannot revive** a downed (0 HP) enemy; healing a
-  knocked-out ally's HP likewise does **not** clear the KO/death state —
-  it must be cleared separately via Change State or Full Recovery even
-  after HP is restored above 0.
+- ✅ **Enemy HP-increase cannot revive a downed (0 HP) enemy, and healing a
+  knocked-out ally's HP likewise does not clear the KO/death state.** The
+  actor/field half was already correct: `Game::Actor#change_hp` returns
+  early with `return @hp if dead?`, so no HP change (heal or further
+  damage) touches a downed party member until Change State or Full
+  Recovery clears the death state. The enemy/battle half was the gap —
+  `Game::Interpreter#do_change_monster_hp` (Change Monster HP, code
+  13110) applied its delta straight to the `Game::Battle::Combatant`
+  with no such guard, so a positive amount on a 0 HP enemy (`dead?` is
+  `hp <= 0` for a Combatant) unconditionally raised it back above 0,
+  silently reviving it. Fixed by making a positive amount a no-op once
+  the target is already dead, mirroring `Actor#change_hp`; a further
+  (negative) hit on an already-dead enemy is untouched by the guard and
+  simply re-clamps to the command's existing lethal-flag floor as
+  before.
 - Damage Processing (the raw event command) uses a **different formula**
   from the built-in normal attack: normal attack = `(ATK÷2) − (DEF÷4)`,
   but this command computes `AttackPower − (DEF÷4)` with **no automatic

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1888,6 +1888,12 @@ module Game
       return unless target
       amount = monster_change_amount(cmd, target)
       amount = -amount if cmd.param(1) != 0
+      # yado.tk quirk: a downed (0 HP) enemy stays down. A positive amount
+      # here is a no-op on an already-dead target -- like Game::Actor#change_hp,
+      # clearing the KO needs Change State / Full Recovery even after this
+      # would otherwise put it back above 0. A further (negative) hit on a
+      # dead target is left alone: it just re-clamps to the same floor below.
+      return if target.dead? && amount > 0
       hp = target.hp + amount
       floor = cmd.param(4) != 0 ? 0 : 1
       hp = floor if hp < floor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8323,6 +8323,20 @@ check 'Change Monster HP damages a troop member, honouring the lethal flag' do
   it.update
   eq 0, b.enemy(0).hp
   ok b.enemy(0).dead?
+
+  # yado.tk quirk: a positive HP change cannot revive a downed enemy --
+  # it stays dead at 0 HP until Change State / Full Recovery clears it.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 0, 0, 999, 1])])
+  it.update
+  eq 0, b.enemy(0).hp, 'HP-increase must not revive a downed enemy'
+  ok b.enemy(0).dead?
+
+  # A further (negative) hit on an already-dead enemy is unaffected by the
+  # guard above -- it just re-clamps to the same floor as before.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [0, 1, 0, 30, 1])])
+  it.update
+  eq 0, b.enemy(0).hp, 'further damage on a dead enemy stays at the lethal floor'
+  ok b.enemy(0).dead?
 end
 
 check 'Change Monster HP heals, reads a variable and a percentage' do


### PR DESCRIPTION
## Summary

- yado.tk quirks backlog item: "Enemy HP-increase cannot revive a downed (0 HP) enemy; healing a knocked-out ally's HP likewise does not clear the KO/death state — it must be cleared separately via Change State or Full Recovery even after HP is restored above 0."
- The actor/field half was already correct: `Game::Actor#change_hp` (`mruby-rpg2k/mrblib/game.rb`) already returns early with `return @hp if dead?`, so no HP change touches a downed party member until the death state is cleared via Change State / Full Recovery.
- The enemy/battle half had the actual gap: `Game::Interpreter#do_change_monster_hp` (`mruby-rpg2k/mrblib/interpreter.rb`, the "Change Monster HP" battle-event command, code 13110) applied its delta straight to the `Game::Battle::Combatant` struct with no dead-target guard. `Combatant#dead?` is simply `hp <= 0`, so a positive amount on an already-dead troop member unconditionally pushed its HP back above 0, silently reviving it.
- Fix: a positive amount is now a no-op once the target Combatant is already dead, mirroring `Actor#change_hp`'s guard. A further (negative) hit on an already-dead enemy is left untouched by the guard — it just re-clamps to the command's existing lethal-flag floor as before, so damage-side behavior is unchanged.
- Updated `docs/TODO.md` to mark the bullet done, explaining both halves (actor side already correct, enemy side fixed here).
- Added `changelog.d/change-monster-hp-no-revive.fixed.md`.

## Test plan

- Extended the existing "Change Monster HP damages a troop member, honouring the lethal flag" check in `scripts/rpg2k_logic_check.rb` with two new assertions: (1) a positive HP-change on an already-dead enemy leaves it at 0 HP / dead, (2) a further negative hit on an already-dead enemy is unaffected by the new guard and stays at the lethal floor.
- Confirmed the new assertions FAIL against the pre-fix code (`git stash push -- mruby-rpg2k/mrblib/interpreter.rb`, rerun, saw `expected 0, got 100`), then `git stash pop` to restore the fix and confirmed they pass.
- `ruby scripts/rpg2k_logic_check.rb` — 657 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 305 checks passed.
- `ruby scripts/rpg2k_render_check.rb` — 40 checks passed.

## Scope note

This PR only touches `mruby-rpg2k/mrblib/interpreter.rb`'s `do_change_monster_hp`, `scripts/rpg2k_logic_check.rb`, `docs/TODO.md`, and a new changelog fragment. It does not touch `game.rb`'s `Game::Battle#deal_attack`/`#apply_skill_hit` or `scene/map.rb`'s `check_random_encounter`, which are separate parallel work streams.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_