### PR TITLE
rpg2k: standing on a Hero Touch event tile suppresses random encounters

### DIFF
--- a/changelog.d/rpg2k-hero-touch-tile-suppresses-encounters.fixed.md
+++ b/changelog.d/rpg2k-hero-touch-tile-suppresses-encounters.fixed.md
@@ -1,0 +1,9 @@
+- RPG Maker 2000: standing on a "Hero Touch" (trigger 1) event's own tile now
+  suppresses the wandering-monster random-encounter roll for that step, same
+  as flying or a forced-route step. `Scene::Map#check_random_encounter`
+  rolled for a fight on every ordinary step regardless of what stood on the
+  landed tile; it now looks up the tile the party just landed on via
+  `#event_at` and skips the roll (without accumulating that step) if the
+  tile's currently active event page is Hero Touch. A same-tile Event Touch
+  (trigger 2) event does not suppress it — only Hero Touch does. Covered by
+  two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1877,10 +1877,22 @@ Everything below is unverified against the codebase.
 - **Wait** — an inline "(W)" wait option is identical to a separate Wait
   command; Wait 0.0s is one frame, not zero (**confirmed correct**, see
   above).
-- **Encounter** — standing on a "hero touches event" tile suppresses random
-  encounters there (**related to the already-fixed priority-type work but
-  itself unverified** — check `try_encounter`/equivalent); Ctrl during test
-  play disables encounters.
+- **Encounter** — ✅ **standing on a "hero touches event" tile suppresses
+  random encounters there.** `Scene::Map#check_random_encounter` rolled for
+  a wandering-monster fight on every ordinary step regardless of what stood
+  on the landed tile; a Hero Touch (trigger 1) event's own tile answers
+  random encounters too (multiply corroborated — see the fuller writeup
+  under "Full-site sweep" below), which this codebase did not implement at
+  all. Fixed by adding an early-out, right after the existing flying
+  exemption: `event_at(@state.x, @state.y)` (the same tile lookup
+  `#try_action_trigger`/`#passable?` already use) and, if that tile holds an
+  event whose currently active page's trigger is `TRIGGER_PLAYER_TOUCH`,
+  the roll (and the encounter_total accumulation for that step) is skipped
+  entirely, exactly like flying or a forced-route step. A same-tile *Event
+  Touch* (trigger 2) event does **not** suppress it — only Hero Touch does —
+  covered by a new control case in `scripts/rpg2k_scene_check.rb`. Ctrl
+  during test play disabling encounters is a separate, still-open fact, not
+  addressed by this change.
 - **Screen Flash / Character Flash** — only one of each can be active at
   once (a second supersedes, doesn't stack); both are capped to 1/30s
   display while a Battle Animation plays concurrently (the animation's own
@@ -2150,9 +2162,13 @@ not yet verified:
   contact: fires instantly on overlap for a below/above-characters page,
   or repeatedly while a direction key is held against a same-as-characters
   (blocking) one.
-- Standing on a "Hero Touch" trigger's tile suppresses random encounters
-  there (multiply corroborated); moving via Set Move Route, Jump, or
-  holding Ctrl in test-play also all suppress encounters.
+- ✅ **Standing on a "Hero Touch" trigger's tile suppresses random
+  encounters there** (multiply corroborated) — see the fuller writeup under
+  "Untriaged backlog, from `2k/01_shoshin/011_siyou/`" above (the
+  `**Encounter**` bullet). Moving via Set Move Route or Jump already
+  suppressed encounters before this pass (the `@player_forced_step` /
+  random-encounters fix above); holding Ctrl in test-play doing the same is
+  a separate, still-open fact.
 
 **Move Route / Character Movement command**
 - Only **one pending move route per character** — issuing a second while

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5378,6 +5378,15 @@ class RPG2k
       # event, common event or forced route can be running underneath it.
       def check_random_encounter
         return if @state.party.flying?(@state)
+        # yado.tk quirk, multiply corroborated: a Hero Touch (trigger 1)
+        # event's own tile also answers random encounters -- the party can
+        # land on one without ever running it (an autonomously-moving event
+        # only fires its *Event Touch* trigger on overlap, never Hero Touch,
+        # see #touch_trigger?'s comment), and while standing there the
+        # wandering-monster roll is suppressed for that step, same as
+        # flying or a forced-route step above/below.
+        ev = event_at(@state.x, @state.y)
+        return if ev && ev[:trigger] == TRIGGER_PLAYER_TOUCH
         steps = current_encounter_steps
         if steps <= 0
           @state.encounter_total = 0

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6257,6 +6257,40 @@ check 'a forced move route does not roll for a random encounter' do
      'the whole forced route ran without ever rolling for an encounter'
 end
 
+check 'standing on a Hero Touch event tile suppresses the random-encounter roll' do
+  # yado.tk quirk, multiply corroborated: the tile under a Hero Touch
+  # (trigger 1) event answers random encounters too, not just the event
+  # itself. Without the fix, this guaranteed-roll setup (encount_steps 1,
+  # default terrain rate -- see the "opens a battle" check above) would
+  # start a battle on the very first check regardless.
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
+  touch = page(trigger: 1)
+  touch.event_commands = [ECmd.new(0)] # a real page needs *a* command list
+  scene = new_scene({ 1 => event(0, 0, touch) }, player: [0, 0], map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  scene.send(:check_random_encounter)
+  scene.update # give it a frame too, in case a battle wait was queued anyway
+  ok scene.instance_variable_get(:@battle_ui).nil?,
+     "the party is standing on a Hero Touch event's own tile: no roll"
+  eq 0, st.encounter_total, 'the step never accumulated, matching the flying early-out above'
+end
+
+check 'standing on an Event Touch tile still rolls for a random encounter' do
+  # Control for the Hero Touch check above: an otherwise-identical setup,
+  # but the event on the party's tile uses a different trigger (Event
+  # Touch, 2) -- the guaranteed roll must still fire, proving the
+  # suppression is keyed to the trigger type and not "any event is here".
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
+  other = page(trigger: 2)
+  other.event_commands = [ECmd.new(0)]
+  scene = new_scene({ 1 => event(0, 0, other) }, player: [0, 0], map_tree: tree)
+  scene.send(:check_random_encounter)
+  scene.update # the roll only queues a :battle wait; a frame turns it into @battle_ui
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui, 'an Event Touch event on the tile does not suppress the roll'
+  eq 1, ui[:troop].id, "the map tree node's own troop"
+end
+
 check "current_encounter_steps reads the map tree node's own setting, " \
      'overridden by Change Encounter Rate' do
   tree = fake_map_tree(1 => FakeEncounterNode.new({}, 25))


### PR DESCRIPTION
## Summary

yado.tk quirk, multiply corroborated in `docs/TODO.md` (both the "Encounter" bullet under "Untriaged backlog, from `2k/01_shoshin/011_siyou/`" and again under "Full-site sweep"): standing on a "Hero Touch" (trigger 1) event's own tile suppresses the wandering-monster random-encounter roll for that step.

`Scene::Map#check_random_encounter` already correctly skipped the roll during a forced-route step (`@player_forced_step`, matching the separate "Set Move Route/Jump suppress encounters" rule — left untouched here) and while flying, but it never checked whether the tile the party just landed on carries a Hero-Touch event before rolling.

- Fixed by adding an early-out right after the existing flying exemption in `mruby-rpg2k/mrblib/scene/map.rb#check_random_encounter`: look up the landed tile via `event_at(@state.x, @state.y)` (the same helper `#try_action_trigger`/`#passable?` already use) and skip the roll — without accumulating `encounter_total` for that step, exactly like the flying case — when that tile's currently active event page's trigger is `TRIGGER_PLAYER_TOUCH`.
- A same-tile *Event Touch* (trigger 2) event does **not** suppress it — only Hero Touch does.
- `docs/TODO.md` updated at both bullets (one marked ✅ with the full writeup, the other cross-referencing it).
- Changelog fragment added: `changelog.d/rpg2k-hero-touch-tile-suppresses-encounters.fixed.md`.

Confined strictly to `Scene::Map#check_random_encounter` in `mruby-rpg2k/mrblib/scene/map.rb` — does not touch `interpreter.rb#do_change_monster_hp` or `game.rb`'s `Game::Battle#deal_attack`/`#apply_skill_hit`, which are owned by the two sibling PRs in this same backlog sweep.

## Test plan

- Added two new checks to `scripts/rpg2k_scene_check.rb`:
  - `standing on a Hero Touch event tile suppresses the random-encounter roll` — a guaranteed-roll setup (`encount_steps` 1, default terrain rate) with a Hero Touch event on the party's own tile; asserts no battle opens and `encounter_total` never accumulated.
  - `standing on an Event Touch tile still rolls for a random encounter` — the same setup but with an Event Touch (trigger 2) event instead; asserts the battle still opens, proving the suppression is keyed to trigger type and not "any event is here".
- Confirmed the new suppression check **fails** against pre-fix code: `git stash push -- mruby-rpg2k/mrblib/scene/map.rb && ruby scripts/rpg2k_scene_check.rb` → 1 failure (the new check); `git stash pop` restores the fix and all checks pass again.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 657 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 307 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_