### PR TITLE
rpg2k: hard-cap battle damage at 999

### DIFF
--- a/changelog.d/battle-damage-cap-and-no-revive-heal.fixed.md
+++ b/changelog.d/battle-damage-cap-and-no-revive-heal.fixed.md
@@ -1,0 +1,17 @@
+- **Battle damage is hard-capped at 999.** `Game::Battle` had no ceiling on
+  a single hit's damage anywhere: a normal attack (including a ×3 critical
+  or a ×2 charged blow), an attack skill/item, an enemy self-destruct, and
+  per-turn state slip damage could all subtract an uncapped amount from a
+  target's HP, something RPG_RT's fixed three-digit damage popup could
+  never even display. Added `Game::Battle::DAMAGE_CAP = 999` and clamped
+  the final per-hit value at every one of those sites right before it
+  lands.
+
+- **An in-battle heal cannot revive a downed (0 HP) combatant** — verified
+  already correct, not a bug. `Game::Battle#apply_command` /
+  `#apply_command_all` were already gating every Skill/Item command on the
+  target's `dead?` state before it ever reaches the HP-raising code, the
+  in-battle mirror of `Game::Actor#change_hp`'s field-side `return @hp if
+  dead?` guard. No behaviour change here; comments were added documenting
+  the parity, and regression coverage was added alongside the damage-cap
+  fix above.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2078,8 +2078,9 @@ not yet verified:
   bundled with this bullet (battle damage cap, HP recovery cap, switch/
   variable caps and ranges, recursion ceiling, party/stack/picture caps, move
   speed, transparency steps) remain unverified — see below.
-- **Numeric constants worth asserting directly**: battle damage hard-cap
-  under 1000; special-skill HP recovery cap 999; switches/variables cap
+- **Numeric constants worth asserting directly**: special-skill HP
+  recovery cap 999 (battle damage's own hard-cap under 1000 is now ✅
+  above); switches/variables cap
   at 5000 (expandable), variable value range −999999..999999 in RPG2000 vs
   7-digit in RPG2003 (already partially modelled per `LCF::MODE`, worth
   checking the variable-write clamp specifically); Call Event / Event Call
@@ -2420,8 +2421,32 @@ not yet verified:
   the battle ends. **Every** satisfied page fires that turn (lower page
   number first), unlike map/common events (already confirmed correct
   above).
-- Damage is hard-capped below 1000 by engine spec; special-skill HP
-  recovery is capped at 999 per use; item drop rate has a 1% floor.
+- ✅ **Damage is hard-capped below 1000 (999) by engine spec.** RPG_RT's
+  battle damage popup is a fixed three digits, so no single hit — however
+  the underlying ATK/DEF/attribute/variance math computes it — can ever
+  apply more than 999 to a target's HP in one go. `Game::Battle`
+  (`mruby-rpg2k/mrblib/game.rb`) had no such ceiling anywhere on its damage
+  path: a normal attack (`#deal_attack`, including a critical's ×3 or a
+  charged hit's ×2), an attack skill/item (`#apply_skill_hit`'s negative-HP
+  branch, both single- and all-target), an enemy's self-destruct
+  (`#enemy_autodestruct`), and per-turn state slip damage
+  (`#apply_turn_states`) all subtracted whatever they computed straight from
+  `target.hp` with no upper bound — a high enough ATK/attack-power stat
+  could one-shot for thousands, something the original engine's fixed-width
+  damage display could never even show. Fixed by adding
+  `Game::Battle::DAMAGE_CAP = 999` and clamping the final per-hit damage
+  value (after variance/attribute scaling and the crit/charge/defend
+  multipliers, so the *displayed* number is what's capped) at each of the
+  four sites above, right before it's subtracted from HP. Special-skill HP
+  recovery's own 999-per-use cap and the item drop rate's 1% floor —
+  bundled into this same bullet originally — are separate, still-unverified
+  facts and remain open (see the "Numeric constants worth asserting
+  directly" bullet above, which has had "battle damage hard-cap under 1000"
+  removed now that it's covered here).
+  Regression coverage added to `scripts/rpg2k_logic_check.rb`: a
+  high-ATK, always-critical normal attack against a defenceless target
+  clamps at 999 rather than the uncapped 6000 (2000 base × 3 crit), and an
+  attack skill computing a raw 5000 HP hit likewise clamps at 999.
 - Turn-order tie-break on equal Agility: hero acts before an equal-agility
   enemy; among tied heroes, lower actor ID acts first.
 - The party "exhaustion %" battle-event condition is computed as
@@ -2435,10 +2460,28 @@ not yet verified:
   state, then rolls RNG against those weights. A turn-condition shorthand
   like "3×?+5" means: first candidate on turn 5, then every 3 turns
   after.
-- Enemy HP-increase **cannot revive** a downed (0 HP) enemy; healing a
-  knocked-out ally's HP likewise does **not** clear the KO/death state —
-  it must be cleared separately via Change State or Full Recovery even
-  after HP is restored above 0.
+- ✅ **In-battle HP-increase cannot revive a downed (0 HP) combatant** —
+  already correctly implemented, not a gap. `Game::Battle#apply_command` /
+  `#apply_command_all` (`mruby-rpg2k/mrblib/game.rb`) gate every Skill/Item
+  command — single- and all-target alike — on `target.dead?` (`hp <= 0`)
+  *before* ever calling `#apply_skill_hit`: a command aimed at a downed
+  combatant fizzles outright (no SP spent, no log entry, HP untouched)
+  rather than reaching `#apply_skill_hit`'s HP-raising branch at all. That
+  is the in-battle mirror of the field-side rule
+  `Game::Actor#change_hp` already enforces with its own `return @hp if
+  dead?` guard (unchanged by this PR — it was already correct); the field
+  and battle paths now document the same reasoning at both sites so the
+  parity is explicit rather than coincidental. Verified — not fixed, since
+  no bug existed here — with regression coverage in
+  `scripts/rpg2k_logic_check.rb`: an all-ally heal aimed at both a downed
+  member and a wounded one skips the downed member entirely (HP stays 0)
+  while still healing the wounded member normally, confirmed to hold
+  against the pre-this-PR code exactly as it does after (this fact was
+  never broken; the two facts were bundled in one backlog line, and only
+  the damage-cap half above needed an actual fix). An explicit state-cure
+  (Full Recovery, a revive item/skill) remains the only modelled way to
+  stand a downed combatant back up, and does so by writing HP directly
+  rather than through this command path.
 - Damage Processing (the raw event command) uses a **different formula**
   from the built-in normal attack: normal attack = `(ATK÷2) − (DEF÷4)`,
   but this command computes `AttackPower − (DEF÷4)` with **no automatic

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5776,6 +5776,15 @@ module Game
 
     MAX_ROUNDS = 1000 # safety net against a stalemate (should never be reached)
 
+    # RPG_RT's battle damage popup is a fixed three digits, so every single hit
+    # -- normal attack, dual-wield swing, attack-skill, self-destruct, and
+    # per-turn state slip damage alike -- is hard-clamped to 999 before it is
+    # subtracted from the target's HP, no matter how large the underlying ATK/
+    # DEF/attribute math computes. A yado.tk-quirks build with no cap could
+    # one-shot a target well past what the original engine could ever display
+    # or apply in a single blow.
+    DAMAGE_CAP = 999
+
     attr_reader :allies, :enemies, :rounds, :result, :log, :rng
 
     # `states` is an optional state-definition lookup (`[id]` -> a row exposing
@@ -6342,6 +6351,7 @@ module Game
           next
         end
         hp = state_field(d, :hp_change_val) + b.max_hp * state_field(d, :hp_change_max) / 100
+        hp = DAMAGE_CAP if hp > DAMAGE_CAP # 999 hard-cap applies to slip damage too
         b.hp -= hp if hp > 0
         if b.max_mp && b.mp
           sp = state_field(d, :sp_change_val) + b.max_mp * state_field(d, :sp_change_max) / 100
@@ -6625,6 +6635,7 @@ module Game
         dmg = 0 if dmg < 0
         dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
         dmg = [dmg / 2, 1].max if t.defending && dmg > 0
+        dmg = DAMAGE_CAP if dmg > DAMAGE_CAP
         t.hp -= dmg
         { attacker: b.name, target: t.name, damage: dmg, critical: false,
           autodestruct: true, target_hp: t.hp < 0 ? 0 : t.hp, defeated: t.dead?,
@@ -6776,6 +6787,9 @@ module Game
         dmg = [dmg / 2, 1].max
         dmg = [dmg / 2, 1].max if target.strong_defence
       end
+      # RPG_RT's damage popup tops out at three digits -- a crit/charge blow
+      # that would compute past it still only ever takes 999.
+      dmg = DAMAGE_CAP if dmg > DAMAGE_CAP
       target.hp -= dmg
       woke = target.dead? ? [] : shake_off_states(target)
       entry = { attacker: b.name, target: target.name, damage: dmg, critical: crit,
@@ -6965,6 +6979,15 @@ module Game
     # then a negative-HP command (an attack skill) subtracts HP and reads like an
     # attack (`skill:` names it), while a recovery command (heal skill / medicine)
     # restores HP / SP clamped to the target's maxima and reads as a `recover`.
+    #
+    # This `target.dead?` gate is also what keeps a plain heal from reviving a
+    # downed (0 HP) combatant: a fizzled command never reaches #apply_skill_hit
+    # at all, so its HP-raising branch never runs against a dead target in the
+    # first place -- the in-battle mirror of Game::Actor#change_hp's own
+    # `return @hp if dead?` guard on the field. An explicit state-cure (Full
+    # Recovery, a revive item/skill) is the only thing modelled here that can
+    # stand a combatant back up, and it does so by writing HP directly rather
+    # than through this command path.
     def apply_command(b)
       cmd = b.command
       return apply_command_all(b, cmd) if cmd[:all]
@@ -6977,7 +7000,10 @@ module Game
     # An all-target Skill (scope 1 all enemies / 4 all allies): spend the SP once,
     # then apply the per-target effect to every living target, returning one log
     # entry per hit (which #step_action surfaces one at a time). Fizzles — nil, no
-    # SP spent — when every listed target has already fallen this round.
+    # SP spent — when every listed target has already fallen this round. Same
+    # per-target `dead?` filter as #apply_command, and for the same reason: a
+    # downed member of an all-ally heal is skipped rather than topped up back to
+    # life (see #apply_command's comment).
     def apply_command_all(b, cmd)
       live = (cmd[:targets] || []).select { |t| t[:target] && !t[:target].dead? }
       return nil if live.empty?
@@ -7002,6 +7028,9 @@ module Game
         dmg = apply_attr_multiplier(dmg, cmd[:attributes], target)
         # Spread the skill's damage by its own variance when the fight rolls it.
         dmg = varied(dmg, cmd[:variance]) if @variance && dmg > 0 && cmd[:variance] && cmd[:variance] > 0
+        # Same 999 hard-cap as a normal attack (#deal_attack), applied before
+        # absorption so a drain skill can't smuggle a bigger hit past it either.
+        dmg = DAMAGE_CAP if dmg > DAMAGE_CAP
         # 吸収: the caster takes what the target loses, and can take no more than
         # the target has. EasyRPG clamps the effect to the target's current HP
         # *before* applying it ("Only absorb the hp that were left"), so a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5886,6 +5886,21 @@ check 'battle: a zero crit_chance never criticals even with criticals on' do
   ok !e[:critical]
 end
 
+# RPG_RT's damage popup is a fixed three digits, so a single hit can never
+# apply more than 999 -- even an absurdly high-ATK critical against a
+# defenceless target (Game::Battle::DAMAGE_CAP).
+check 'battle: a normal-attack critical hard-caps damage at 999' do
+  hero = combatant('Hero', 4000, 0, 20, 100)         # base 2000, uncapped x3 crit = 6000
+  hero.crit_chance = Game::CRIT_SCALE                # always crits
+  slime = combatant('Slime', 0, 0, 5, 100_000)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
+  bat.begin_round
+  e = bat.step_action
+  eq true, e[:critical]
+  eq 999, e[:damage], 'capped, not the uncapped 6000 (2000 base x3 crit)'
+  eq 100_000 - 999, slime.hp
+end
+
 # A party whose actors carry their own critical-hit rate, for the weapon-bonus
 # checks: the hero crits 1-in-30 (RPG2000's own default), the ally never does.
 def crit_party(items)
@@ -6966,6 +6981,39 @@ check 'Battle command_skill resolves an attack skill: damage lands, SP is spent'
   eq 70, foe.hp
   eq 4, mage.mp, 'the caster paid 6 SP'
   ok e[:skill] && !e[:recover], 'an attack skill reads as an attack, not a recovery'
+end
+
+check 'Battle command_skill: an attack skill also hard-caps at 999' do
+  mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  foe  = combatant('Foe', 0, 0, 5, 100_000)
+  b = Game::Battle.new([mage], [foe], Game::Rng.new(1))
+  b.command_skill(mage, foe, name: 'Meteor', cost: 10, hp: -5000)
+  b.begin_round
+  e = b.step_action
+  eq 999, e[:damage], 'capped, not the uncapped 5000'
+  eq 100_000 - 999, foe.hp
+end
+
+check 'battle: an all-ally heal skips a downed member but still heals the wounded' do
+  # Mirrors Game::Actor#change_hp's `return @hp if dead?` guard on the field: a
+  # downed (0 HP) Combatant is filtered out before #apply_skill_hit's HP-raising
+  # branch ever runs, so a heal cannot silently revive it -- only an explicit
+  # state-cure (not modelled by a plain recovery command) stands it back up.
+  healer = combatant_mp('Healer', 0, 0, 20, 100, 10)
+  downed = combatant('Downed', 0, 0, 5, 50)
+  downed.hp = 0
+  wounded = combatant('Wounded', 0, 0, 4, 50)
+  wounded.hp = 20
+  foe = combatant('Foe', 0, 0, 1, 100)
+  b = Game::Battle.new([healer, downed, wounded], [foe], Game::Rng.new(1))
+  b.command_skill_all(healer, [{ target: downed, hp: 40 }, { target: wounded, hp: 40 }],
+                      name: 'Heal All', cost: 6)
+  b.begin_round
+  e = b.step_action
+  eq 'Wounded', e[:target], 'the downed member is skipped entirely, not merely left at 0'
+  eq 50, wounded.hp, 'clamped to max HP (20 + 40 -> 50): no regression on a live target'
+  eq 0, downed.hp, 'still 0 -- a heal cannot revive it'
+  eq 4, healer.mp, 'SP is spent since the volley still landed on the wounded ally'
 end
 
 check 'Battle command_skill resolves a heal, clamped to max HP' do


### PR DESCRIPTION
## Summary

Implements the "Battle system (default)" backlog item from `docs/TODO.md` covering two related facts:

1. **Damage is hard-capped below 1000 (999) by engine spec.** `Game::Battle` (`mruby-rpg2k/mrblib/game.rb`) had no ceiling anywhere on its damage-application path — a normal attack (`#deal_attack`, including a critical's ×3 or a charged hit's ×2), an attack skill/item (`#apply_skill_hit`'s negative-HP branch, both single- and all-target commands), an enemy self-destruct (`#enemy_autodestruct`), and per-turn state slip damage (`#apply_turn_states`) all subtracted whatever they computed straight from `target.hp`/`b.hp` with no upper bound. RPG_RT's battle damage popup is a fixed three digits, so no single hit can ever exceed 999 in the original engine. Fixed by adding `Game::Battle::DAMAGE_CAP = 999` and clamping the final per-hit damage value (after variance/attribute scaling and the crit/charge/defend multipliers) at each of those four sites, right before it's subtracted from HP.

2. **In-battle HP-increase cannot revive a downed (0 HP) combatant** — investigated and found **already correctly implemented**, not a gap. `Game::Battle#apply_command` / `#apply_command_all` already gate every Skill/Item command (single- and all-target) on `target.dead?` (`hp <= 0`) *before* ever calling `#apply_skill_hit` — a command aimed at a downed combatant fizzles outright (no SP spent, no log entry, HP untouched) rather than reaching the HP-raising branch at all. This is the in-battle mirror of the field-side rule `Game::Actor#change_hp` already enforces with its own `return @hp if dead?` guard. No behavior change was needed for this half; I added comments documenting the parity between the two call sites and added explicit regression coverage.

`docs/TODO.md` is updated: the damage-cap bullet is marked ✅ with details, the no-revive bullet is marked ✅ noting it was already correct (not a fix), and the "battle damage hard-cap" mention in the separate "Numeric constants worth asserting directly" bullet is removed now that it's covered above (HP recovery cap and item drop rate floor — bundled in the original doc line — remain open/unverified, out of scope for this PR).

## Test plan

- Added regression tests to `scripts/rpg2k_logic_check.rb`:
  - A high-ATK, always-critical normal attack against a defenceless target clamps at 999 rather than the uncapped 6000 (2000 base × 3 crit).
  - An attack skill computing a raw 5000 HP hit likewise clamps at 999.
  - An all-ally heal aimed at both a downed member and a wounded member skips the downed member entirely (HP stays 0, no revival) while still healing the wounded member normally (no regression).
- Confirmed the two new damage-cap tests **fail** against pre-fix code (`git stash push -- mruby-rpg2k/mrblib/game.rb`, re-run, `expected 999, got 6000` / `got 5000`) and pass again after restoring the fix. The heal/no-revive test passes both before and after, confirming that half was never broken.
- `ruby scripts/rpg2k_logic_check.rb` — 660 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 305 checks passed.
- `ruby scripts/rpg2k_render_check.rb` — 40 checks passed.
- Confirmed no existing damage-value assertion elsewhere in either check script relied on a value above 999 or on a heal reviving a KO'd combatant.

This PR only touches `mruby-rpg2k/mrblib/game.rb`'s `Game::Battle` class (`deal_attack`, `apply_skill_hit`, `apply_command`, `apply_command_all`, `apply_turn_states`, `enemy_autodestruct`), `scripts/rpg2k_logic_check.rb`, `docs/TODO.md`, and a new changelog fragment — it does not touch `interpreter.rb`'s `do_change_monster_hp` or `scene/map.rb`'s `check_random_encounter`, which are covered by sibling PRs in this same backlog sweep.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_