### PR TITLE
rpg2k: check battle-event pages between every acting battler

### DIFF
--- a/changelog.d/rpg2k-battle-events-per-battler.fixed.md
+++ b/changelog.d/rpg2k-battle-events-per-battler.fixed.md
@@ -1,0 +1,20 @@
+- RPG Maker 2000: **battle-event pages are checked between every acting
+  battler now, not just once per round.** EasyRPG's
+  `Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents` runs before the
+  round-start menu *and* — per its own comment — "before each battler acts
+  and also right after the last battler acts," so a page whose condition
+  turns true mid-round (an enemy's HP crossing a threshold from an earlier
+  attacker's hit, say) fires immediately, before the next battler in the same
+  round acts, rather than waiting for the next round's check.
+  `Scene::Map#drive_battle_animate` now checks for a matching page between
+  every battler's action (a `battler_boundary` flag set once
+  `Game::Battle#step_action` finishes draining one battler's whole action —
+  a dual-wield swing or an all-target Skill/Item queues several hits from the
+  *same* battler, and the check belongs between battlers, not between hits),
+  threading a `return_phase` through `#run_battle_events` /
+  `#leave_battle_event_phase` so a page started mid-round resumes the
+  animation loop afterward instead of jumping to the command menu partway
+  through a round. Every page still fires exactly once per turn regardless of
+  how many times it's checked. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix
+  code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2415,11 +2415,35 @@ not yet verified:
   substituted value/name is long.
 
 **Battle system (default)**
-- Battle events fire once per turn, right after hero action is decided
-  but before the turn resolves — never before action-select, never after
-  the battle ends. **Every** satisfied page fires that turn (lower page
-  number first), unlike map/common events (already confirmed correct
-  above).
+- ✅ **Battle pages are checked far more often than once per turn** — the
+  yado.tk phrasing above ("right after hero action is decided but before the
+  turn resolves") undersold it, and so did this runtime: EasyRPG's
+  `Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents` is called from two
+  places, `State_SelectOption` (before the round-start Fight/Auto/Escape menu
+  — the "before action-select" case this runtime already had) **and**, per
+  its own comment, from `ProcessSceneActionBattle`'s `ePreAction` substate,
+  which "happens before each battler acts and also right after the last
+  battler acts" — i.e. checked again before *every individual battler's*
+  action within the round, not just once at the start. A page whose
+  condition turns true mid-round (an enemy's HP crossing a threshold from an
+  earlier attacker's hit, say) used to sit until the *next* round's check;
+  real RPG_RT would run it immediately, before the next battler in the same
+  round even acts. `Scene::Map#drive_battle_animate` now checks between every
+  acting battler: a `battler_boundary` flag (set once `Game::Battle#step_action`
+  has drained the last buffered hit of one battler's action — a dual-wield
+  swing or an all-target Skill/Item queues several from the *same* battler,
+  and the check belongs between battlers, not between hits) triggers
+  `#run_battle_events` before the next `step_action` call, threading a new
+  `return_phase` (`:command` for the pre-existing between-rounds check,
+  `:animate` for this one) through to `#leave_battle_event_phase` so a page
+  started mid-round resumes the animation loop afterward instead of jumping
+  to the command menu partway through a round. **Every** satisfied page still
+  fires exactly once per turn regardless of how many times it is checked
+  (`pages_run`, unlike map/common events, already confirmed correct above) —
+  never before action-select (the original claim's other half already held),
+  never after the battle ends. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (an enemy-HP-conditioned page firing before the round settles back to
+  `:command`), confirmed to fail against the pre-fix code.
 - Damage is hard-capped below 1000 by engine spec; special-skill HP
   recovery is capped at 999 per use; item drop rate has a 1% floor.
 - Turn-order tie-break on equal Agility: hero acts before an equal-agility

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6274,6 +6274,15 @@ module Game
       end
     end
 
+    # Whether the entry #step_action just returned was the last buffered hit
+    # of its battler's action (a dual-wield swing or an all-target Skill/Item
+    # both queue several) -- true once nothing more of that battler's action
+    # remains to drain. The battle screen uses this to know when a *whole
+    # battler's turn* has finished, not just one hit of it, since a battle
+    # page is checked once per acting battler (see Scene::Map#run_battle_events),
+    # not once per hit.
+    def pending_empty?; @pending.empty?; end
+
     # Close a round begun with #begin_round: clear each ally's chosen action (so
     # the next round starts fresh) and settle the result once a side is wiped.
     def end_round

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2792,7 +2792,12 @@ class RPG2k
                        # already fired this turn (RPG2000 runs a page once per
                        # turn its condition holds, so this resets each round).
                        events: Game::Interpreter.new(@state), event_win: nil,
-                       pages_run: {} }
+                       pages_run: {},
+                       # Whether the just-drained #step_action entry finished
+                       # its battler's whole action (see #drive_battle_animate),
+                       # and which phase a running battle-event page resumes to
+                       # once it finishes (see #run_battle_events).
+                       battler_boundary: false, event_return_phase: :command }
         @battle_ui[:events].battle = @battle_ui[:battle]
         # A battle page can Call Common Event (1005), so it needs the same
         # resolver the map's events run against.
@@ -3387,6 +3392,18 @@ class RPG2k
           @battle_ui[:anim_timer] -= 1
           return
         end
+        # A battle page is checked once per *acting battler*, not once per
+        # round -- EasyRPG's CheckBattleEndAndScheduleEvents runs "before each
+        # battler acts and also right after the last battler acts" (the
+        # latter half is #finish_round_animation's own check, already in
+        # place). The boundary between two battlers' actions is exactly where
+        # the previous #step_action call left nothing buffered (a dual-wield
+        # swing or an all-target Skill/Item queues several hits from *one*
+        # battler; the check belongs between battlers, not between hits).
+        if @battle_ui[:battler_boundary]
+          @battle_ui[:battler_boundary] = false
+          return if run_battle_events(:animate)
+        end
         entry = @battle_ui[:battle].step_action
         if entry
           # An Item action consumes one from the real bag when it lands (so
@@ -3401,6 +3418,7 @@ class RPG2k
           # is, exactly as before.
           @battle_ui[:anim_timer] =
             start_battle_animation(entry) ? 0 : BATTLE_ANIM_FRAMES
+          @battle_ui[:battler_boundary] = @battle_ui[:battle].pending_empty?
         else
           finish_round_animation
         end
@@ -3480,7 +3498,14 @@ class RPG2k
       # page was started, so the caller knows whether to draw the command window
       # or hand the frame to the event. A troop that scripts nothing, or whose
       # pages have all fired, simply returns false.
-      def run_battle_events
+      #
+      # `return_phase` is where #leave_battle_event_phase resumes once the page
+      # (and any chained page after it) finishes: `:command` for the between-
+      # rounds check (the default -- the normal case, opening the next round's
+      # command menu), `:animate` for the between-battlers check
+      # (#drive_battle_animate), which needs to pick back up mid-round rather
+      # than restart the command phase.
+      def run_battle_events(return_phase = :command)
         ui = @battle_ui
         return false unless ui && ui[:troop].pages
         matched = Game::BattlePage.select_all(ui[:troop].pages, @state.switches,
@@ -3489,9 +3514,10 @@ class RPG2k
         return false unless entry
         ui[:pages_run][entry[0]] = true
         cmds = entry[1].event
-        return run_battle_events if cmds.nil? || cmds.empty? # empty page: try the next
+        return run_battle_events(return_phase) if cmds.nil? || cmds.empty? # empty page: try the next
         ui[:events].battle = ui[:battle]
         ui[:events].start(cmds)
+        ui[:event_return_phase] = return_phase
         ui[:phase] = :event
         true
       rescue StandardError => e
@@ -3624,15 +3650,22 @@ class RPG2k
         true
       end
 
-      # The running page finished: fire the next matching page, or hand the turn
-      # back — to the result window when the page decided the fight, otherwise to
-      # the party's command phase.
+      # The running page finished: fire the next matching page (chained pages
+      # keep the same return_phase, so a battler-boundary check that opens
+      # several pages in a row still resumes mid-round rather than jumping to
+      # the command phase partway through), or hand the turn back — to the
+      # result window when the page decided the fight, to the mid-round
+      # animation loop when this page was a between-battlers check, otherwise
+      # to the party's command phase (a between-rounds check, the default).
       def leave_battle_event_phase
         close_battle_event_window
-        return if run_battle_events
+        return_phase = @battle_ui[:event_return_phase] || :command
+        return if run_battle_events(return_phase)
         battle = @battle_ui[:battle]
         if battle.finished?
           enter_battle_result(battle.result)
+        elsif return_phase == :animate
+          @battle_ui[:phase] = :animate
         else
           @battle_ui[:phase] = :command
           draw_battle_command

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4678,6 +4678,35 @@ check 'a battle page with no condition ticked at all never fires' do
   ok !st.switches[15], 'RPG_RT reads an unticked condition box as never, not always'
 end
 
+# EasyRPG's CheckBattleEndAndScheduleEvents runs "before each battler acts and
+# also right after the last battler acts", not just once between rounds --
+# Scene::Map#drive_battle_animate now checks between every acting battler
+# (see @battle_ui[:battler_boundary]).
+check 'a battle page conditioned on enemy HP fires mid-round, before the round settles' do
+  ic = Game::Interpreter::Cmd
+  # True only once the first troop member's HP falls to half or less -- which
+  # only happens once the hero's own attack lands this round, never before.
+  pages = { 1 => troop_page([ECmd.new(ic::CONTROL_SWITCHES, [0, 20, 20, 0])],
+                            Game::BattlePage::ENEMY_HP, enemy_hp_max: 50) }
+  scene, st = battle_scene_with_pages(pages)
+  phase_when_fired = nil
+  60.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && %i[command target].include?(ui[:phase])
+    scene.update
+    RGSS::Input.triggered = []
+    ui = scene.instance_variable_get(:@battle_ui)
+    if st.switches[20] && phase_when_fired.nil?
+      phase_when_fired = ui && ui[:phase]
+    end
+    break if phase_when_fired
+  end
+  ok phase_when_fired, 'the page fired at all'
+  ok phase_when_fired != :command,
+     "fired mid-round (phase was #{phase_when_fired.inspect} when the switch " \
+     'landed), not only once the round settled back to :command for the next one'
+end
+
 check 'Terminate Battle from a page ends the fight and resumes the event' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }


### PR DESCRIPTION
## Summary

`docs/TODO.md` carried an untriaged backlog claim: "Battle events fire once per turn, right after hero action is decided but before the turn resolves." That phrasing turned out to undersell the real behavior, and this runtime only ever checked battle-event pages once per round to begin with.

Traced EasyRPG's actual source rather than trusting the claim at face value: `Scene_Battle_Rpg2k::CheckBattleEndAndScheduleEvents` is called from two places — before the round-start Fight/Auto/Escape menu (the "before action-select" case this runtime already had), **and**, per its own comment, from inside the per-battler action loop, which "happens before each battler acts and also right after the last battler acts." So a page whose condition turns true mid-round (an enemy's HP crossing a threshold from an earlier attacker's hit, say) should fire immediately, before the *next* battler in the same round even acts — not wait for the following round's check.

- `Game::Battle#pending_empty?` exposes whether the last `#step_action` entry drained the final buffered hit of one battler's action (a dual-wield swing or an all-target Skill/Item queues several hits from the *same* battler — the check belongs between battlers, not between hits).
- `Scene::Map#drive_battle_animate` sets a `battler_boundary` flag at that point and checks `run_battle_events` before pulling the next battler off the queue.
- `run_battle_events` / `leave_battle_event_phase` now thread a `return_phase` (`:command` for the pre-existing between-rounds check, `:animate` for this new one) so a page started mid-round resumes the animation loop afterward instead of jumping to the command menu partway through a round.
- Every page still fires exactly once per turn regardless of how many times it's checked (`pages_run`, unchanged).

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 657 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 306 checks passed
- [x] New check: an enemy-HP-conditioned page fires before the round settles back to `:command` — confirmed to **fail** against the pre-fix code by temporarily reverting the scene/game.rb changes and re-running just this check, then restored

https://claude.ai/code/session_01TyFbA9EkMdeUsdAkkCMX8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyFbA9EkMdeUsdAkkCMX8p)_