### PR TITLE
rpg2k: confirm bare-hand-attribute and 0%-rate elemental claims

### DIFF
--- a/changelog.d/rpg2k-bare-hand-attribute-confirmed.changed.md
+++ b/changelog.d/rpg2k-bare-hand-attribute-confirmed.changed.md
@@ -1,0 +1,6 @@
+- RPG Maker 2000: confirmed two more untriaged `docs/TODO.md` claims already
+  hold, no code change needed — bare-hand attacks carry no elemental
+  attribute (`Actor#weapon_attributes` only scans the weapon slot, so an
+  unarmed actor's scan finds nothing), and a full (0%) elemental resistance
+  deals exactly zero damage rather than healing (`Battle#apply_attr_multiplier`
+  computes `0 * dmg / 100`, never flipping sign on a matched 0% rate).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2551,8 +2551,17 @@ not yet verified:
 - Common events (including Parallel Process ones) **never run during
   battle**, even if their trigger switch flips mid-battle — execution is
   deferred until control returns to the map.
-- Bare-hand attacks carry no elemental attribute by default; an element's
-  effect-rate at 0% deals exactly zero damage (not healing).
+- ✅ **Bare-hand attacks carry no elemental attribute by default; an
+  element's effect-rate at 0% deals exactly zero damage (not healing).**
+  Confirmed already correct rather than left as an open claim:
+  `Actor#weapon_attributes` (`mruby-rpg2k/mrblib/game.rb`) only scans the
+  *weapon*-slot item(s) for an `attribute_set`, so an unarmed actor's loop
+  finds nothing and returns `[]` — no attribute at all, matching the site.
+  `Battle#apply_attr_multiplier` never flips a 0% rate into recovery: a
+  matched (non-nil) rate of exactly 0 takes the `elsif physical` /
+  `elsif magical` branch and computes `0 * dmg / 100 = 0`, not a sign flip —
+  so a full immunity zeroes the hit rather than healing the target. No code
+  change; the claim already held.
 - Battle Interrupt (from inside a battle event) satisfies **neither**
   the Win nor Lose branch of the enclosing Battle Processing command —
   it's a third, unlabeled outcome that resumes right after Branch End,


### PR DESCRIPTION
## Summary

Two more untriaged `docs/TODO.md` battle-system backlog claims, checked against the current code rather than left as open questions:

- **Bare-hand attacks carry no elemental attribute by default.** `Actor#weapon_attributes` only scans the *weapon*-slot item(s) for an `attribute_set`; an unarmed actor's scan finds nothing equipped in that slot and returns `[]`.
- **A full (0%) elemental resistance deals exactly zero damage, not healing.** `Battle#apply_attr_multiplier` computes `0 * dmg / 100` for a matched 0% rate — it scales toward zero rather than ever flipping the sign of the effect.

Both already held; no code change, just documentation confirming it with a citation so the next pass doesn't re-investigate blind.

## Test plan

Documentation-only change — no code touched, so no new checks are needed. Existing suites are unaffected.

https://claude.ai/code/session_01TyFbA9EkMdeUsdAkkCMX8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyFbA9EkMdeUsdAkkCMX8p)_