### PR TITLE
Hard-cap special-skill HP recovery at 999

### DIFF
--- a/changelog.d/battle-recovery-cap.fixed.md
+++ b/changelog.d/battle-recovery-cap.fixed.md
@@ -1,0 +1,6 @@
+- **Special-skill HP recovery is now hard-capped at 999 per use**, matching
+  yado.tk and mirroring the existing battle damage cap: RPG_RT's heal popup
+  is the same fixed 3-digit widget as the damage one, so a single heal
+  can't display (or apply) more than 999 no matter how large
+  `recover_hp_rate` × max HP computes it. `Game::Battle::RECOVER_CAP = 999`
+  clamps the recovery amount before it's added to HP.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2090,9 +2090,24 @@ not yet verified:
   bundled with this bullet (battle damage cap, HP recovery cap, switch/
   variable caps and ranges, recursion ceiling, party/stack/picture caps, move
   speed, transparency steps) remain unverified — see below.
-- **Numeric constants worth asserting directly**: special-skill HP
-  recovery cap 999 (battle damage's own hard-cap under 1000 is now ✅
-  above); switches/variables cap
+- ✅ **Special-skill HP recovery is capped at 999 per use** — the same
+  fixed-3-digit-popup reasoning as the battle damage cap above, for the
+  opposite direction. `Game::Battle#apply_skill_hit`'s recovery branch
+  (`mruby-rpg2k/mrblib/game.rb`) clamped the healed amount only by the
+  target's `max_hp`, never by any fixed digit cap — since `max_hp` and a
+  skill/item's `recover_hp_rate`-of-`max_hp` can both exceed 999, a single
+  heal could legitimately compute (and apply) well past what RPG_RT's
+  heal popup — the same fixed 3-digit widget as the damage one — could ever
+  display. Fixed by adding `Game::Battle::RECOVER_CAP = 999` next to the
+  existing `DAMAGE_CAP` and clamping the recovery amount to it before it's
+  added to `target.hp`, in the one method (shared by single- and all-target
+  commands) that applies it — the field-menu item-use path
+  (`Game::Party#item_recovery`) doesn't show the same fixed-width popup and
+  is a separate, unconfirmed question left open. Regression coverage added
+  to `scripts/rpg2k_logic_check.rb`: a recovery skill computing a raw 5000
+  HP heal against a high-max-HP target clamps at 999, confirmed to fail
+  against the pre-fix code.
+- **Numeric constants worth asserting directly**: switches/variables cap
   at 5000 (expandable), variable value range −999999..999999 in RPG2000 vs
   7-digit in RPG2003 (already partially modelled per `LCF::MODE`, worth
   checking the variable-write clamp specifically); Call Event / Event Call
@@ -2478,11 +2493,11 @@ not yet verified:
   value (after variance/attribute scaling and the crit/charge/defend
   multipliers, so the *displayed* number is what's capped) at each of the
   four sites above, right before it's subtracted from HP. Special-skill HP
-  recovery's own 999-per-use cap and the item drop rate's 1% floor —
-  bundled into this same bullet originally — are separate, still-unverified
-  facts and remain open (see the "Numeric constants worth asserting
-  directly" bullet above, which has had "battle damage hard-cap under 1000"
-  removed now that it's covered here).
+  recovery's own 999-per-use cap — bundled into this same bullet
+  originally — is now ✅ too, its own bullet above (`RECOVER_CAP`); the
+  item drop rate's 1% floor remains open (see the "Numeric constants worth
+  asserting directly" bullet above, which has had both of these removed now
+  that they're covered).
   Regression coverage added to `scripts/rpg2k_logic_check.rb`: a
   high-ATK, always-critical normal attack against a defenceless target
   clamps at 999 rather than the uncapped 6000 (2000 base × 3 crit), and an

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5785,6 +5785,12 @@ module Game
     # or apply in a single blow.
     DAMAGE_CAP = 999
 
+    # Same fixed-width-popup reasoning as DAMAGE_CAP, for the opposite
+    # direction: RPG_RT's HP-recovery popup is the same fixed 3-digit widget
+    # as the damage one, so a single heal can't display (or apply) more than
+    # 999 either, no matter how large `recover_hp_rate` x max_hp computes it.
+    RECOVER_CAP = 999
+
     attr_reader :allies, :enemies, :rounds, :result, :log, :rng
 
     # `states` is an optional state-definition lookup (`[id]` -> a row exposing
@@ -7070,6 +7076,7 @@ module Game
       else
         before_hp = target.hp
         before_mp = target.mp || 0
+        hp = RECOVER_CAP if hp > RECOVER_CAP
         target.hp = [target.hp + hp, target.max_hp].min if hp > 0
         target.mp = [before_mp + mp, target.max_mp].min if mp > 0 && target.max_mp
         # Cure the item's status conditions from the target (an antidote / herb),

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6994,6 +6994,23 @@ check 'Battle command_skill: an attack skill also hard-caps at 999' do
   eq 100_000 - 999, foe.hp
 end
 
+check 'Battle command_skill: a recovery skill also hard-caps at 999 (yado.tk)' do
+  # Same fixed-width-popup reasoning as the damage cap above, for a heal:
+  # a high max_hp target given a huge recovery amount clamps at 999, not
+  # the uncapped raw value, before it is added to (and re-clamped by) HP.
+  mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  ally = combatant('Ally', 0, 0, 5, 100_000)
+  ally.hp = 1
+  foe = combatant('Foe', 0, 0, 1, 100)
+  b = Game::Battle.new([mage, ally], [foe], Game::Rng.new(1))
+  b.command_skill(mage, ally, name: 'Mega Heal', cost: 10, hp: 5000)
+  b.command_defend(ally)
+  b.begin_round
+  e = b.step_action # the faster mage heals first
+  eq 1000, ally.hp, 'capped to +999 (1 + 999), not the uncapped 5000'
+  eq 999, e[:recover_hp], 'capped, not the uncapped 5000'
+end
+
 check 'battle: an all-ally heal skips a downed member but still heals the wounded' do
   # Mirrors Game::Actor#change_hp's `return @hp if dead?` guard on the field: a
   # downed (0 HP) Combatant is filtered out before #apply_skill_hit's HP-raising


### PR DESCRIPTION
## Summary

- yado.tk (explicitly flagged as still-open in the prior battle-damage-cap
  PR): special-skill HP recovery is capped at 999 per use, the same
  fixed-3-digit-popup reasoning as the battle damage cap, for the opposite
  direction.
- `Game::Battle#apply_skill_hit`'s recovery branch (`mruby-rpg2k/mrblib/game.rb`)
  clamped the healed amount only by the target's `max_hp`, never by any
  fixed digit cap. Since `max_hp` and a skill/item's `recover_hp_rate`-of-
  `max_hp` can both exceed 999, a single heal could legitimately compute
  (and apply) well past what RPG_RT's heal popup — the same fixed 3-digit
  widget as the damage one — could ever display.
- Fix: added `Game::Battle::RECOVER_CAP = 999` next to the existing
  `DAMAGE_CAP` and clamped the recovery amount to it before it's added to
  `target.hp`, in the one method (shared by single- and all-target
  commands) that applies it.
- **Not addressed**: the field-menu item-use path (`Game::Party#item_recovery`)
  doesn't show the same fixed-width popup and is a separate, unconfirmed
  question — left open in `docs/TODO.md`.

## Test plan

- [x] `scripts/rpg2k_logic_check.rb` — added a check: a recovery skill
  computing a raw 5000 HP heal against a high-max-HP (100,000) target
  clamps at +999, not the uncapped value. Confirmed it fails against the
  pre-fix `game.rb` via `git stash` (`expected 1000, got 5001`).
- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (661 checks).
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (308 checks).
- [x] `scripts/rpg2k_render_check.rb` passes (40 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_