### PR TITLE
Move Event / Set Move Route can drive a boat, ship, or airship

### DIFF
--- a/changelog.d/vehicle-move-routes.added.md
+++ b/changelog.d/vehicle-move-routes.added.md
@@ -1,0 +1,16 @@
+- **A Move Event / Set Move Route can now drive a boat, ship, or airship**
+  directly, previously a silent no-op. A route steps a `Game::Character`
+  mirror against the vehicle's own passability (`vehicle_passable?`,
+  inheriting the existing ship-specific Through-Mode event-blocking rule),
+  writing the result back onto the vehicle each step; unlike the player or
+  events, a moving vehicle snaps tile to tile rather than sliding, matching
+  the existing Set Vehicle Location feel. A route on the currently-ridden
+  vehicle is dropped, since the party's own vehicle-following already
+  claims its position every frame. Change / Trade Event Location can now
+  target a vehicle too, and Proceed With Movement correctly waits on a
+  vehicle's forced route. A route's own Change Graphic sub-command applies
+  visibly without persisting to the saved vehicle data, reverting on
+  Transfer Player or save/load, the same shape as the equivalent hero
+  override. Smooth position interpolation, walk-cycle animation, and
+  hero/event collision with a moving unboarded vehicle remain unaddressed,
+  left as explicit follow-ups.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -278,7 +278,62 @@ The work below is roughly ordered by the critical path to a walkable game
   drawn at. And **Proceed With Movement drives the slide itself**, because the
   normal movement step is skipped while the interpreter waits on it; without
   that the route starts a step and then waits forever for a landing nothing is
-  advancing
+  advancing.
+  **Vehicle move-routes: a Move Event / Set Move Route targeting a boat, ship
+  or airship (10002-10004) now actually drives it**, previously a silent
+  no-op in `Scene::Map#apply_move_request` / `#char_location` /
+  `#set_char_location` (a literal `nil # vehicles are not modelled yet`,
+  despite the interpreter always decoding the target id fine).
+  `Game::Vehicle` (`mruby-rpg2k/mrblib/game.rb`) is plain save/render data —
+  position, facing, graphic — not a `Game::Character`, so it cannot be handed
+  to `Game::MoveRoute#step` directly; the fix mirrors the same "mirror a
+  `Game::Character`, write the result back" idiom the player's own forced
+  routes already use (`@player_char`/`start_player_route`): `#force_vehicle_route`
+  lazily builds a `Game::Character` mirror per type (`@vehicle_chars`), and
+  `#step_vehicle_routes` steps it each frame against a new `VehicleWorld`
+  (`scene/base.rb`, the same small `world` protocol `MapWorld` implements for
+  the hero/events, but routing passability through
+  `Scene::Map#vehicle_passable?` instead of the on-foot `#char_passable?` —
+  so a moving unboarded boat inherits the existing ship-specific Through-Mode
+  event-blocking quirk automatically). Unlike the player/events, a moving
+  vehicle is **not pixel-interpolated**: it snaps tile to tile at its route's
+  pace, the same instant feel Set Vehicle Location already had (a deliberate
+  scope choice, not an oversight — smooth sliding is a possible follow-up).
+  A route targeting the **currently-ridden** vehicle is dropped outright
+  (`force_vehicle_route`'s `@state.boarded == type` guard, checked again each
+  step): the party's own `#follow_vehicle` already claims the ridden
+  vehicle's position every frame, and no yado.tk source describes an
+  intentional "pilot the vehicle you're standing on by event" interaction, so
+  the simplest, safest reading is that boarding and a route on the same
+  vehicle just don't mix (a deliberate first-cut scope decision, not
+  something confirmed against real RPG_RT either way). A route's own
+  **Change Graphic** sub-command lands on the mirror, not on the persisted
+  `Game::Vehicle#charset_name`/`#charset_index` — `#vehicle_charset` /
+  `#vehicle_charset_index` prefer a live mirror's override, exactly the
+  not-persisted-like-the-dedicated-command shape `#player_draw_charset`
+  already established for the hero — so it reverts on Transfer Player (and
+  save/load, since Continue always builds a fresh `Scene::Map`) rather than
+  sticking the way the dedicated Change Vehicle Graphic command's write does.
+  Change / Trade Event Location targeting a vehicle now instantly repositions
+  it too (`#move_vehicle_to`), keeping a live route mirror in sync the same
+  way `#move_player_to` does for the hero. Proceed With Movement now also
+  waits on a vehicle's forced route (`#step_forced_movement`/
+  `#forced_movement_done?`), which would otherwise have resumed the
+  interpreter while the vehicle was still mid-route. **Out of scope for this
+  first cut, flagged as follow-ups**: smooth position interpolation for a
+  moving unboarded vehicle; walk-cycle animation (vehicles already only ever
+  draw one standing pattern regardless, even ridden, so this is a pre-existing
+  gap, not a regression); hero/event collision with a moving unboarded
+  vehicle (vehicles are not in the `@event_tiles` occupancy table); a vehicle
+  parked on a map other than the one currently loaded (nothing simulates an
+  unloaded map); autonomous move types for a vehicle (vehicles have no
+  "pages," only the forced route path applies). Covered by six new
+  `scripts/rpg2k_scene_check.rb` checks (driving an unboarded boat along a
+  route respecting `vehicle_passable?`; terrain blocking it the same way
+  ordinary sailing is blocked; a route on a ridden vehicle being dropped;
+  Change Event Location repositioning a vehicle; Proceed With Movement
+  waiting on a vehicle route; the Change Graphic override reverting on
+  Transfer Player), each confirmed to fail against the pre-fix code.
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented
@@ -309,8 +364,12 @@ The work below is roughly ordered by the critical path to a walkable game
   Event) command is now wired up too: it decodes the route packed into the
   command's parameters and applies it as a forced route to the target — a map
   event (including "this event") or the player, overriding page movement until
-  it finishes. Vehicle targets (boat / ship / airship, 10002-10004) resolve as
-  well, so a route can drive one
+  it finishes. ✅ **Vehicle targets (boat / ship / airship, 10002-10004) now
+  drive the vehicle itself**, not just decode without effect as they used to
+  (this line previously overstated it — the interpreter always decoded the
+  target id fine, but `Scene::Map` silently no-opped it). See the "Vehicle
+  move-routes" paragraph in the Movement & collision entry above for the
+  implementation
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Change HP/MP, Full Heal, Change Parameters, Change EXP/Level, Change

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7215,9 +7215,11 @@ module Game
   # A boat / ship / airship's saved location. RPG2000 stores one per vehicle in
   # its own `.lsd` chunk (105 boat, 106 ship, 107 airship, each a SAVE_MOVABLE):
   # the map it sits on, its tile position and facing, and its on-map graphic.
-  # Only that saved location is modelled here -- enough to round-trip a save so a
-  # parked vehicle stays where the player left it. Boarding / piloting a vehicle
-  # is not built yet (`map_id` 0 means it has never been placed).
+  # This is plain data, not a Game::Character -- boarding (Scene::Map#board_vehicle
+  # et al.) and a Move Route driving one (Scene::Map#force_vehicle_route) both
+  # write straight into it (or a Game::Character mirror that writes back into
+  # it) rather than growing it into the Character protocol itself. `map_id` 0
+  # means it has never been placed.
   class Vehicle
     TYPES = [:boat, :ship, :airship].freeze
 

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -143,6 +143,49 @@ class RPG2k
       end
     end
 
+    # The same `world` protocol as MapWorld, for a Move Event / Set Move Route
+    # driving a vehicle (boat/ship/airship) rather than the hero or a map
+    # event. Passability routes through Scene::Map#vehicle_passable? (terrain
+    # boat_pass/ship_pass/airship_pass plus the vehicle-specific Through-Mode
+    # event-blocking rule) instead of the hero's on-foot #char_passable? —
+    # the only difference from MapWorld.
+    class VehicleWorld
+      def initialize(scene, rng, type)
+        @scene = scene
+        @rng = rng
+        @type = type
+      end
+
+      def passable?(character, dir)
+        @scene.vehicle_char_passable?(character, dir, @type)
+      end
+
+      def can_land?(character, x, y)
+        @scene.vehicle_char_can_land?(character, x, y, @type)
+      end
+
+      def hero_position
+        s = @scene.state
+        [s.x, s.y]
+      end
+
+      def set_switch(id, on)
+        @scene.state.switches[id] = on
+      end
+
+      def play_sound(name, volume, tempo, _balance)
+        return if name.nil? || name.empty?
+        RGSS::Audio.se_play(name, volume, tempo)
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] event SE '#{name}' playback failed: #{e.message}"
+        nil
+      end
+
+      def random(n)
+        @rng.random(n)
+      end
+    end
+
     # Resolves the command list a Call Event refers to. Common events are looked
     # up by id; a map event's page is fetched from the loaded map unit (best
     # effort — the page index follows the LCF page numbering).

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -61,7 +61,7 @@ class RPG2k
 
       # Move Event (Set Move Route) target ids: the player, the three vehicles
       # and "this event" (the event running the command). Any other id is a map
-      # event id. Vehicles are not modelled yet, so those targets are ignored.
+      # event id.
       MOVE_TARGET_PLAYER  = 10001
       MOVE_TARGET_BOAT    = 10002
       MOVE_TARGET_SHIP    = 10003
@@ -98,6 +98,11 @@ class RPG2k
         # routes / autonomous movement query the map.
         @rng = Game::Rng.new(0x2000)
         @world = MapWorld.new(self, @rng)
+        # One VehicleWorld per type, wrapping #vehicle_passable? instead of the
+        # hero's own on-foot #char_passable? -- see #force_vehicle_route.
+        @vehicle_worlds = Game::Vehicle::TYPES.each_with_object({}) do |type, h|
+          h[type] = VehicleWorld.new(self, @rng, type)
+        end
         # Erased events, and the state revision the active pages were chosen at.
         @erased_events = {}
         @page_revision = page_revision
@@ -136,6 +141,17 @@ class RPG2k
         # aborts an in-progress route without unwinding its side effects, so a
         # route cancelled mid-Through-Mode leaves the hero stuck pass-through.
         @player_through = false
+
+        # A forced move route applied to a vehicle by a Move Event, keyed by
+        # type (:boat/:ship/:airship). Unlike the player/events, a moving
+        # vehicle's position is not pixel-interpolated -- it snaps tile to
+        # tile at its route's pace, the same instant feel Set Vehicle
+        # Location already has -- so there is no slide/mirror-vs-render split
+        # to track here beyond the mirror `Game::Character` itself (see
+        # #force_vehicle_route).
+        @vehicle_chars = {}
+        @vehicle_routes = {}
+        @vehicle_route_timers = {}
 
         # Player pixel position and step state. `player_jumping` marks the slide
         # as a hop, which is lifted along an arc (see player_jump_offset).
@@ -251,6 +267,7 @@ class RPG2k
           else
             step_player_route
             step_events
+            step_vehicle_routes
             step_movement
             # Boarding / disembarking claims the action button when it applies;
             # otherwise it falls through to the usual event trigger.
@@ -1233,6 +1250,30 @@ class RPG2k
         type == :boat ? (row.boat_pass ? true : false) : (row.ship_pass ? true : false)
       end
 
+      # #vehicle_passable? wired to the move-route `world` protocol
+      # (VehicleWorld, scene/base.rb): a step ahead of `character` in `dir`,
+      # honouring the mirror's own Through Mode first exactly as
+      # #char_passable? does for the hero/events (a route's Through Mode
+      # Begin/End sub-commands work the same way on a vehicle mirror).
+      def vehicle_char_passable?(character, dir, type)
+        return true if character.through
+        nx, ny = Game::Character.step_tile(character.x, character.y, dir)
+        vehicle_passable?(nx, ny, dir, type)
+      end
+      # Called by VehicleWorld (an external collaborator) with an explicit receiver.
+      public :vehicle_char_passable?
+
+      # #vehicle_passable? for a jump landing on (x, y), mirroring
+      # #char_can_land?: an in-place hop always lands (the tile is already
+      # occupied by the mover itself), and Through Mode bypasses the check
+      # entirely, same as stepping.
+      def vehicle_char_can_land?(character, x, y, type)
+        return true if character.through
+        return true if x == character.x && y == character.y
+        vehicle_passable?(x, y, character.direction, type)
+      end
+      public :vehicle_char_can_land?
+
       # The database terrain row under tile (x, y), or nil when the chipset / map
       # carry no terrain data (e.g. the colour-block fallback or a bare fixture).
       def terrain_row_at(x, y)
@@ -1872,7 +1913,8 @@ class RPG2k
         when 0, MOVE_TARGET_THIS
           force_event_route(this_event, route, r[:frequency]) if this_event
         when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
-          nil # vehicles are not modelled yet
+          type = Game::Vehicle::TYPES[r[:target] - MOVE_TARGET_BOAT]
+          force_vehicle_route(type, route, r[:frequency])
         else
           ev = @events.find { |e| e[:id] == r[:target] }
           force_event_route(ev, route, r[:frequency]) if ev
@@ -1915,7 +1957,8 @@ class RPG2k
         when 0, MOVE_TARGET_THIS
           this_event ? [this_event[:char].x, this_event[:char].y] : nil
         when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
-          nil # vehicles are not modelled yet
+          v = @state.vehicle(Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT])
+          [v.x, v.y]
         else
           ev = @events.find { |e| e[:id] == target }
           ev ? [ev[:char].x, ev[:char].y] : nil
@@ -1930,7 +1973,7 @@ class RPG2k
         when 0, MOVE_TARGET_THIS
           move_event_to(this_event, x, y) if this_event
         when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
-          nil # vehicles are not modelled yet
+          move_vehicle_to(Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT], x, y)
         else
           ev = @events.find { |e| e[:id] == target }
           move_event_to(ev, x, y) if ev
@@ -1964,6 +2007,24 @@ class RPG2k
         reoccupy(ev, ox, oy)
       end
 
+      # Snap a vehicle to a tile (Change / Trade Event Location targeting a
+      # vehicle). A vehicle draws tile-snapped already (#draw_vehicles), so
+      # this is the whole of it -- no render slide to kick off. Keeps a
+      # forced route's mirror in sync too, the same reason #move_player_to
+      # does, so an in-flight route steps on from the new tile rather than
+      # immediately correcting the teleport back.
+      def move_vehicle_to(type, x, y)
+        v = @state.vehicle(type)
+        v.map_id = @state.map_id
+        v.x = x
+        v.y = y
+        ch = @vehicle_chars[type]
+        if ch
+          ch.x = x
+          ch.y = y
+        end
+      end
+
       # Give a map event a forced route, overriding its page movement until the
       # route finishes (a repeating route runs until replaced). It steps on the
       # next frame, paced by the requested frequency when one was given.
@@ -1971,6 +2032,56 @@ class RPG2k
         ev[:forced_route] = route
         ev[:forced_freq] = valid_move_freq(freq)
         ev[:move_timer] = 0
+      end
+
+      # Give vehicle `type` a forced route (Move Event / Set Move Route
+      # targeting a boat/ship/airship). A no-op when the vehicle is not
+      # placed on the current map (nothing here simulates a map that is not
+      # loaded) or is currently ridden -- the party's own #follow_vehicle
+      # already claims the ridden vehicle's position every frame, and RPG_RT
+      # has no documented "pilot the vehicle you're standing on by event"
+      # interaction, so the simplest, safest reading is that boarding and a
+      # route on the same vehicle just don't mix.
+      def force_vehicle_route(type, route, freq)
+        v = @state.vehicle(type)
+        return unless v.placed? && v.map_id == @state.map_id
+        return if @state.boarded == type
+        ch = (@vehicle_chars[type] ||= Game::Character.new(v.x, v.y, v.direction))
+        ch.x = v.x
+        ch.y = v.y
+        ch.direction = v.direction
+        ch.move_frequency = valid_move_freq(freq) || ch.move_frequency
+        @vehicle_routes[type] = route
+        @vehicle_route_timers[type] = 0
+      end
+
+      # Advance every vehicle's forced route one frame, each paced by its own
+      # timer. Unlike the player/events, a moving vehicle is not
+      # pixel-interpolated: it snaps straight onto the mirror's tile the
+      # instant a step lands (#draw_vehicles already draws a vehicle
+      # tile-snapped, whether parked, ridden, or -- now -- mid-route), so
+      # there is no separate slide phase to drive here.
+      def step_vehicle_routes
+        Game::Vehicle::TYPES.each { |type| step_vehicle_route(type) }
+      end
+
+      def step_vehicle_route(type)
+        route = @vehicle_routes[type]
+        return unless route
+        return if @state.boarded == type # frozen while ridden, see #force_vehicle_route
+        ch = @vehicle_chars[type]
+        @vehicle_route_timers[type] -= 1
+        return if @vehicle_route_timers[type] > 0
+        @vehicle_route_timers[type] = EVENT_MOVE_DELAY[ch.move_frequency] || 40
+        route.step(ch, @vehicle_worlds[type]) unless route.done?
+        v = @state.vehicle(type)
+        v.x = ch.x
+        v.y = ch.y
+        v.direction = ch.direction
+        @vehicle_routes[type] = nil if route.done?
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] vehicle move route failed: #{e.message}"
+        @vehicle_routes[type] = nil # drop a broken route so Proceed does not hang
       end
 
       # Drive the player along a forced route: the player has no Game::Character,
@@ -2075,6 +2186,7 @@ class RPG2k
         advance_player_slide
         step_player_route
         @events.each { |e| step_forced_event(e) if e[:forced_route] }
+        step_vehicle_routes
         forced_movement_done?
       end
 
@@ -2103,7 +2215,8 @@ class RPG2k
       # exists under the CRuby host checks but not in the shipped engine.
       def forced_movement_done?
         return false if @player_route
-        !@events.any? { |e| e[:forced_route] }
+        return false if @events.any? { |e| e[:forced_route] }
+        !@vehicle_routes.values.any? { |route| route }
       end
 
       # A move frequency the request may override the target's pace with (1..8),
@@ -4676,6 +4789,13 @@ class RPG2k
         # unlike the dedicated Change Hero Graphic command.
         @player_char = nil
         @player_through = false # ... nor does Through Mode
+        # Same for a vehicle's own forced route / Change Graphic override
+        # (#force_vehicle_route, #vehicle_charset): none of it survives a
+        # teleport, since the mirror was simulating movement against the map
+        # being left, not whatever loads next.
+        @vehicle_chars = {}
+        @vehicle_routes = {}
+        @vehicle_route_timers = {}
         # Both are per-visit: an Erase Event does not follow the party to the
         # next map, and the destination's pages are chosen fresh.
         @erased_events = {}
@@ -5655,34 +5775,51 @@ class RPG2k
           spr.x = sx
           spr.y = sy
           spr.visible = true
-          draw_vehicle_frame(type, v, charset)
+          draw_vehicle_frame(type, v, charset, vehicle_charset_index(v))
         end
       end
 
       # Blit the vehicle's CharSet cell into its sprite buffer (standing pattern),
       # skipping the redraw when the graphic/index/direction haven't changed since
       # the last frame — mirrors draw_player_frame's @last_frame memo.
-      def draw_vehicle_frame(type, v, charset)
-        frame = [v.charset_index, v.direction, charset.object_id]
+      def draw_vehicle_frame(type, v, charset, index)
+        frame = [index, v.direction, charset.object_id]
         return if frame == @vehicle_last_frame[type]
         @vehicle_last_frame[type] = frame
 
-        rx, ry, rw, rh = Game::CharSet.frame_rect(v.charset_index, v.direction, 1)
+        rx, ry, rw, rh = Game::CharSet.frame_rect(index, v.direction, 1)
         bmp = @vehicle_bmps[type]
         bmp.clear
         bmp.blt 0, 0, charset, Rect.new(rx, ry, rw, rh)
       end
 
-      # The CharSet graphic for a vehicle: its own (set by Change Vehicle Graphic /
-      # the initial placement) or the database default (System boat/ship/airship
-      # name), loaded through the shared event-charset cache. nil when it has none.
+      # The CharSet graphic for a vehicle: a Set Move Route "Change Graphic"
+      # override on its forced-route mirror (@vehicle_chars[v.type]) takes
+      # first priority -- exactly the same not-persisted-like-the-dedicated-
+      # command shape as the hero's own #player_draw_charset (see its
+      # comment): the override lives on the mirror, not on `v` itself, so it
+      # never survives a save/load or map transfer, only the current visit.
+      # Absent that, its own graphic (set by Change Vehicle Graphic / the
+      # initial placement) or the database default (System boat/ship/airship
+      # name). Loaded through the shared event-charset cache; nil when it has
+      # none.
       def vehicle_charset(v)
+        mirror = @vehicle_chars[v.type]
+        return event_charset(mirror.graphic_name) if mirror && mirror.graphic_name
         name = v.charset_name
         if (name.nil? || name.empty?)
           field = "#{v.type}_name"
           name = @db.system.send(field) if @db.system.respond_to?(field)
         end
         event_charset(name)
+      end
+
+      # The CharSet cell index to go with #vehicle_charset, from the same
+      # mirror-first source.
+      def vehicle_charset_index(v)
+        mirror = @vehicle_chars[v.type]
+        return mirror.graphic_index if mirror && mirror.graphic_name
+        v.charset_index
       end
 
       # Composite the Show Picture layer into its buffer, drawing lowest-id first

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2291,6 +2291,32 @@ check 'Proceed With Movement holds the interpreter until a forced route finishes
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
+check "Proceed With Movement also waits on a vehicle's forced route" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::MOVE_EVENT,
+             [10002, 4, 0, 0, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT]),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, []),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(0, 4, auto) }, player: [5, 5], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+
+  10.times { scene.update } # mid-route: still sailing, switch not yet flipped
+  ok boat.x < 3, "route still in progress, at x=#{boat.x}"
+  ok !st.switches[1],
+     "the command after Proceed With Movement waits on the vehicle's own route"
+
+  200.times { scene.update } # enough frames for the freq-4 route to finish
+  eq 3, boat.x, 'the boat reached the end of its route'
+  ok st.switches[1], 'the interpreter resumed and ran the next command'
+end
+
 check 'Tint Screen with a wait holds the interpreter until the tint settles' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
@@ -3330,6 +3356,72 @@ check 'a boarded boat cannot overlap a below-characters event unless it has Thro
   eq 0, st.x, 'only moved along the column it was already sailing'
   ok st.y > 1,
      "Through Mode on the blocking event let the boat pass it (was at y=1, now #{st.y})"
+end
+
+check 'Move Event drives an unboarded boat along a route, respecting vehicle_passable?' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10002 (boat), freq 8, repeat off, skippable on, MOVE_RIGHT.
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10002, 8, 0, 1, R::MOVE_RIGHT])]
+  scene = new_scene({ 1 => event(0, 4, auto) }, player: [5, 0], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  40.times { scene.update }
+  ok boat.x > 0, "the boat should have sailed east under its own route, at x=#{boat.x}"
+  eq 1, boat.y, 'it stayed on its row'
+  eq 6, boat.direction, 'facing the direction it moved (MOVE_RIGHT)'
+end
+
+check "a boat's move route is blocked by terrain the same way ordinary sailing is" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::MOVE_EVENT, [10002, 8, 0, 1, R::MOVE_RIGHT])]
+  # boat_pass left false (the default): the whole map is unsailable.
+  scene = new_scene({ 1 => event(0, 4, auto) }, player: [5, 0])
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  20.times { scene.update }
+  eq 0, boat.x, 'terrain blocked it before it ever moved'
+end
+
+check 'a Move Route request targeting a currently-ridden vehicle is ignored' do
+  scene = new_scene({}, player: [0, 0], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  st.direction = 2 # face down, toward (0, 1)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat'
+  route = Game::MoveRoute.new([Game::MoveCommand.new(R::MOVE_RIGHT)],
+                              repeat: false, skippable: true)
+  scene.send(:force_vehicle_route, :boat, route, 8)
+  eq nil, scene.instance_variable_get(:@vehicle_routes)[:boat],
+     'the route request was dropped rather than fighting #follow_vehicle'
+end
+
+check 'Change Event Location repositions a vehicle' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # target 10002 (boat), absolute mode, x=3, y=2.
+  auto.event_commands = [ECmd.new(ic::CHANGE_EVENT_LOCATION, [10002, 0, 3, 2])]
+  scene = new_scene({ 1 => event(0, 4, auto) }, player: [5, 0])
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 0
+  3.times { scene.update }
+  eq [3, 2], [boat.x, boat.y], 'the boat was repositioned by Change Event Location'
 end
 
 check 'the airship flies over a tile blocked on foot, and follows the party' do
@@ -6128,6 +6220,31 @@ check 'a forced route Change Graphic overrides the hero sprite, reverting on Tra
   eq scene.instance_variable_get(:@charset), charset2,
      'Transfer Player reverted to the leader\'s own charset'
   eq scene.instance_variable_get(:@charset_index), index2
+end
+
+check 'a vehicle Change Graphic overrides its sprite without persisting to Game::Vehicle' do
+  ic = Game::Interpreter::Cmd
+  name = 'other'
+  params = [10002, 8, 0, 1, R::CHANGE_GRAPHIC, name.length, 3]
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [ECmd.new(ic::MOVE_EVENT, params, string: name)]
+  scene = new_scene({ 1 => event(3, 3, pg) }, player: [5, 5], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  5.times { scene.update }
+  charset = scene.send(:vehicle_charset, boat)
+  index = scene.send(:vehicle_charset_index, boat)
+  ok charset, 'the overridden charset bitmap loaded'
+  eq 3, index, 'the overridden graphic index applied'
+  eq '', boat.charset_name, 'not written to the persisted Game::Vehicle, only the route mirror'
+  eq 0, boat.charset_index
+
+  scene.send(:perform_teleport, [1, 0, 0, 0])
+  ok scene.instance_variable_get(:@vehicle_chars)[:boat].nil?,
+     'Transfer Player drops the mirror, reverting the override'
 end
 
 check 'a teleport lands the party on its tile, not mid-slide' do


### PR DESCRIPTION
## Summary

Real feature gap, not a quirk fix: `Scene::Map#apply_move_request` / `#char_location` / `#set_char_location` (`mruby-rpg2k/mrblib/scene/map.rb`) literally no-op'd for `MOVE_TARGET_BOAT/SHIP/AIRSHIP` — a Move Event / Set Move Route targeting a vehicle silently did nothing, though the interpreter always decoded the target id fine.

`Game::Vehicle` (`mruby-rpg2k/mrblib/game.rb`) is plain save/render data (position, facing, graphic) — not a `Game::Character` — so it can't be handed to `Game::MoveRoute#step` directly. This mirrors the same "mirror a `Game::Character`, write the result back" idiom the player's own forced routes already use (`@player_char`/`start_player_route`):

- `#force_vehicle_route` lazily builds a `Game::Character` mirror per type (`@vehicle_chars`); `#step_vehicle_routes` steps it each frame against a new `VehicleWorld` (`mruby-rpg2k/mrblib/scene/base.rb`) — the same small `world` protocol `MapWorld` implements for the hero/events, but routing passability through `Scene::Map#vehicle_passable?` instead of the on-foot `#char_passable?`, so a moving unboarded boat inherits the existing ship-specific Through-Mode event-blocking quirk automatically.
- Unlike the player/events, a moving vehicle is **not pixel-interpolated** — it snaps tile to tile at its route's pace, matching the instant feel `Set Vehicle Location` already has (a deliberate scope choice for this first PR).
- A route targeting the **currently-ridden** vehicle is dropped outright: the party's own `#follow_vehicle` already claims the ridden vehicle's position every frame, and there's no documented RPG_RT "pilot the vehicle you're standing on by event" interaction.
- A route's own **Change Graphic** sub-command lands on the mirror, not the persisted `Game::Vehicle#charset_name`/`#charset_index` — `#vehicle_charset`/`#vehicle_charset_index` prefer a live mirror's override, mirroring `#player_draw_charset`'s existing not-persisted shape for the hero, so it reverts on Transfer Player / save-load rather than sticking.
- **Change / Trade Event Location** targeting a vehicle now instantly repositions it (`#move_vehicle_to`), keeping a live route mirror in sync.
- **Proceed With Movement** now also waits on a vehicle's forced route (`#step_forced_movement`/`#forced_movement_done?`), which previously would have resumed the interpreter while the vehicle was still mid-route.
- Drive-by: fixed the stale `Game::Vehicle` class comment ("boarding/piloting is not built yet" — it has been, elsewhere) and `docs/TODO.md`'s overstated "vehicle targets resolve... so a route can drive one" line (only the interpreter's decoding ever worked; now the claim is actually true).

**Explicitly out of scope for this first PR** (documented as follow-ups in `docs/TODO.md`): smooth position interpolation for a moving unboarded vehicle; walk-cycle animation (a pre-existing gap — vehicles never animate a walk cycle even ridden, so no regression here); hero/event collision with a moving unboarded vehicle (vehicles aren't in the `@event_tiles` occupancy table); a vehicle parked on a map other than the one currently loaded; autonomous move types (vehicles have no "pages," only the forced route path applies).

## Test plan

Six new `scripts/rpg2k_scene_check.rb` checks, each confirmed to fail against the pre-fix code via `git stash`:
- Move Event drives an unboarded boat along a route, respecting `vehicle_passable?` (including facing direction).
- The route is blocked by terrain the same way ordinary sailing is.
- A route targeting a currently-ridden vehicle is dropped.
- Change Event Location repositions a vehicle.
- Proceed With Movement waits on a vehicle's forced route (mirrors the existing player/event version of this test).
- A vehicle's Change Graphic override applies visibly without persisting to `Game::Vehicle`, reverting on Transfer Player.

- [x] Full `scripts/rpg2k_logic_check.rb` suite passes (661 checks).
- [x] Full `scripts/rpg2k_scene_check.rb` suite passes (314 checks).
- [x] `scripts/rpg2k_render_check.rb` passes (40 checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwFpisR1qheRuDwjH7Bmc3)_