### PR TITLE
Add field menu background to match RPG_RT appearance

### DIFF
--- a/changelog.d/menu-scene-background.added.md
+++ b/changelog.d/menu-scene-background.added.md
@@ -1,0 +1,8 @@
+- **The field menu (Scene::Menu) now has a proper background** instead of
+  showing the frozen map through the gaps between its windows. The whole
+  screen is filled with the windowskin's own background chip — the same
+  32x32 tile every `RPG2k::Window` stretches over its own interior — stretched
+  across the full 320x240, matching RPG_RT's menu backdrop. New
+  `Scene::Base#build_field_background` is shared so the item/skill/equip/
+  status sub-screens get the same treatment for free, since they never pop
+  the menu underneath them.

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -25,6 +25,34 @@ class RPG2k
         nil
       end
 
+      # Full-screen backdrop for the field menu scenes (Menu and its Item/
+      # Skill/Equip/Status sub-screens), which have no map of their own behind
+      # them. RPG_RT fills the whole screen with the windowskin's own
+      # background chip -- the same 32x32 tile every RPG2k::Window stretches
+      # over its own interior, see Window#draw_background -- stretched over
+      # the full 320x240 instead, so gaps between windows read as the same
+      # material rather than showing whatever scene happens to sit underneath.
+      # Given a nil skin (load failed) this is a plain black sprite, matching
+      # Window's own fallback panel look. z sits above the map's own tiles,
+      # characters, pictures and animations (Scene::Map tops out at 250 for
+      # its picture layer) so none of them show through, but below its
+      # screen-wide weather/flash/fade effects (430/450/500) and the menu's
+      # own windows (400) -- Scene::Map is never popped while a menu sits on
+      # top of it, so all of that keeps rendering regardless of scene.
+      def build_field_background(skin)
+        sprite = Sprite.new
+        sprite.z = 300
+        bmp = Bitmap.new(RPG2k::WIDTH, RPG2k::HEIGHT)
+        if skin
+          bmp.stretch_blt Rect.new(0, 0, RPG2k::WIDTH, RPG2k::HEIGHT), skin,
+                          Rect.new(0, 0, 32, 32)
+        else
+          bmp.fill_rect 0, 0, RPG2k::WIDTH, RPG2k::HEIGHT, Color.new(0, 0, 0, 255)
+        end
+        sprite.bitmap = bmp
+        sprite
+      end
+
       # Draw `text` the way RPG_RT draws every piece of window text: a shadow
       # glyph one pixel down and right filled from the System image's shadow
       # block, then the glyph itself filled from colour `idx`'s 16x16 swatch, so

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -24,6 +24,7 @@ class RPG2k
         @index = 0
         @message = nil
         @skin = make_windowskin
+        @background = build_field_background(@skin)
         @commands = COMMAND_KEYS.map { |key, term_name, fallback|
           [key, term(term_name, fallback)]
         }
@@ -38,6 +39,7 @@ class RPG2k
 
       def dispose
         close_message
+        @background.dispose if @background
         @command.dispose if @command
         @status.dispose if @status
       end


### PR DESCRIPTION
## Summary
The field menu (Scene::Menu) and its sub-screens now display a proper full-screen background instead of showing the frozen map through window gaps. This matches RPG_RT's behavior of filling the screen with the windowskin's background chip.

## Changes
- **New `Scene::Base#build_field_background` method**: Creates a full-screen sprite (320x240) filled with the windowskin's 32x32 background tile stretched across the entire screen. Falls back to solid black if the skin fails to load, matching Window's fallback appearance.
- **Scene::Menu integration**: Instantiates the background sprite during initialization and properly disposes it on cleanup.
- **Z-ordering**: Background sprite positioned at z=300, sitting above map tiles/characters/pictures/animations but below window layers (z=400) and screen effects like weather/flash/fade (z=430-500).
- **Shared implementation**: The new method is defined in Scene::Base so item/skill/equip/status sub-screens automatically inherit the same background treatment without additional code.

## Implementation Details
- The background uses `Bitmap#stretch_blt` to tile the 32x32 windowskin chip across the full screen dimensions
- Z-ordering ensures the background doesn't obscure map elements while preventing the map from showing through window gaps
- Scene::Map remains active underneath menu scenes, so its rendering continues unaffected

https://claude.ai/code/session_019PA8mbdJ6PpksTR2jWoF2v