### PR TITLE
Implement cursed equipment slot locking in equip menu

### DIFF
--- a/changelog.d/rpg2k-cursed-equipment.added.md
+++ b/changelog.d/rpg2k-cursed-equipment.added.md
@@ -1,0 +1,18 @@
+- **呪われた装備 (cursed equipment) locks its own slot.** The item table's
+  `cursed` field (schema.rb:194, alongside the other armour-property flags)
+  was parsed but nothing consulted it, so a cursed weapon or armour piece
+  could be swapped or removed in the field like any other gear.
+  `Game::Actor#slot_cursed?` reads the item currently occupying a slot;
+  `Scene::EquipMenu` refuses to even open that slot's item list, the same
+  way it already does for `#equipment_fixed?` (an unrelated actor/class
+  trait). Same split as that flag: RPG_RT's own `Game_Actor::ChangeEquipment`
+  does not consult `cursed` either, so `Game::Party#equip_from_bag` /
+  `#unequip_to_bag` stay unguarded — a Change Equipment event command can
+  still force a cursed item off, only the menu gates on it. Not part of this:
+  the *other* "cursed" flag, on the state table (2003 only, `situation.cursed`
+  at schema.rb:403), which also locks equipment per EasyRPG's
+  `Game_Actor::IsEquipmentFixed` while an inflicted status carries that flag —
+  left unbuilt, same as before, since no state in either test bed carries it.
+  Covered by two new checks in `scripts/rpg2k_logic_check.rb` and one in
+  `scripts/rpg2k_scene_check.rb` (the gate is per-slot: a cursed weapon locks
+  only the weapon slot, an unrelated empty slot still opens).

--- a/changelog.d/rpg2k-menu-item-selection-confirmed.changed.md
+++ b/changelog.d/rpg2k-menu-item-selection-confirmed.changed.md
@@ -1,0 +1,11 @@
+- **Scene::Menu's Item command reaching Scene::ItemMenu is now covered by a
+  scene check, and its file comment no longer says otherwise.** The wiring
+  itself (`select_command`'s `@parent.push Scene::ItemMenu.new(...)`) has
+  been correct since `rpg2k-item-menu.added.md`, but the class comment at the
+  top of `menu.rb` still read "the item/skill/equip/status screens are
+  placeholders that report they are not implemented" — stale, and nothing in
+  `scripts/rpg2k_scene_check.rb` asserted that pressing C on Item actually
+  pushes a live `Scene::ItemMenu` rather than falling through to the generic
+  "not implemented yet" message. Corrected the comment and added a check that
+  drives each of the four scene-backed commands (Item, Skill, Equip, Status)
+  and asserts the pushed scene's class.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1566,6 +1566,23 @@ module Game
       row.respond_to?(:equipment_fixed) ? (row.equipment_fixed ? true : false) : false
     end
 
+    # 呪われた装備 -- an item flagged `cursed` (item field 29, alongside the other
+    # armour-property flags) refuses to leave the slot it is worn in: RPG_RT's
+    # equip menu will not remove or replace it. Unlike #equipment_fixed? above
+    # this is a property of the *item currently sitting in the slot*, not of
+    # the actor, so it is read fresh from whatever `slot` holds rather than
+    # cached. Same split as #equipment_fixed?: RPG_RT's Change Equipment event
+    # command still forces it off (`Game_Actor::ChangeEquipment` does not
+    # consult the flag either), so only the equip menu gates on this -- Game
+    # ::Party's #equip_from_bag / #unequip_to_bag stay unguarded on purpose.
+    def slot_cursed?(slot)
+      return false unless slot >= 0 && slot < EQUIP_ORDER.size && @db.respond_to?(:item)
+      item_id = @equipment[slot]
+      return false if item_id.nil? || item_id == 0
+      it = @db.item[item_id]
+      it && it.respond_to?(:cursed) ? (it.cursed ? true : false) : false
+    end
+
     # Coerce an equipment spec (an EQUIP_ORDER hash, an array of ids, or nil) to a
     # five-slot array of integer item ids.
     def normalize_equipment(spec)

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -74,10 +74,11 @@ class RPG2k
           @actor_index -= 1
           @actor_index %= party.size
           rebuild_for_actor
-        elsif Input.trigger?(Input::C) && !actor.equipment_fixed?
-          # 装備固定: RPG_RT refuses to even open the item list for such an
-          # actor (EasyRPG's Scene_Equip#UpdateEquipSelection), rather than
-          # opening it and rejecting whatever gets chosen there.
+        elsif Input.trigger?(Input::C) && !actor.equipment_fixed? && !actor.slot_cursed?(@slot_index)
+          # 装備固定 / 呪われた装備: RPG_RT refuses to even open the item list
+          # for such an actor, or for a slot currently holding a cursed item
+          # (EasyRPG's Scene_Equip#UpdateEquipSelection), rather than opening
+          # it and rejecting whatever gets chosen there.
           @cand_index = 0
           @mode = :items
           build_cand_window

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -1,8 +1,11 @@
 class RPG2k
   module Scene
     # Main menu, opened over the map with the cancel button. Shows party status
-    # and a command list. Save and End Game are wired up; the item/skill/equip/
-    # status screens are placeholders that report they are not implemented.
+    # and a command list. Item, Skill, Equip and Status each push their own
+    # scene (Scene::ItemMenu / SkillMenu / EquipMenu / StatusMenu); Save writes
+    # through the app and End Game returns to the title. Any further command
+    # (there are none left in COMMAND_KEYS today) falls back to a "not
+    # implemented yet" message.
     class Menu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2177,7 +2177,10 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :attack_all, :preemptive,
                       # 使用可能キャラ: the specific actor ids (0-based index,
                       # bool per actor) allowed to use/equip this item at all.
-                      :actor_set)
+                      :actor_set,
+                      # 呪われた装備: once equipped, the equip menu refuses to
+                      # remove or replace it (Actor#slot_cursed?).
+                      :cursed)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -2185,13 +2188,14 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               attribute_set: nil, switch_id: 0, occ_field: true,
               field_only: false, dual_attack: false, ignore_evasion: false,
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
-              two_handed: 0, attack_all: false, preemptive: false, actor_set: nil)
+              two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
+              cursed: false)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
-               ko_only, two_handed, attack_all, preemptive, actor_set)
+               ko_only, two_handed, attack_all, preemptive, actor_set, cursed)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -9846,6 +9850,50 @@ check 'equipment_fixed? does not itself block Party#equip_from_bag / #unequip_to
   eq 1, hero.equipment[0]
   ok st.party.unequip_to_bag(hero, 0) != 0
   eq 0, hero.equipment[0]
+end
+
+# -- 呪われた装備 cursed items (Actor#slot_cursed?) ----------------------------
+# The item's own `cursed` flag, not an actor/class trait: once a cursed item
+# sits in a slot the equip menu refuses to reopen that slot's item list, the
+# same way it does for #equipment_fixed?. Read fresh off whatever occupies the
+# slot, so equipping a cursed item and then a non-cursed one over it (via a
+# caller that is not gated, e.g. an event command) clears the lock again.
+
+check 'Actor#slot_cursed? reads the equipped item\'s own flag' do
+  items = { 1 => fake_item(type: 1, atk: 20, cursed: true),
+            2 => fake_item(type: 1, atk: 5) }
+  row = FakePlayerRow.new('Hero', '', 0, 5, { max_hp: 10 })
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+
+  ok !hero.slot_cursed?(Game::Actor::WEAPON_SLOT), 'empty slot is never cursed'
+
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(hero, 2)
+  ok !hero.slot_cursed?(Game::Actor::WEAPON_SLOT), 'a plain weapon does not lock the slot'
+
+  st.party.gain_item(1, 1)
+  ok st.party.equip_from_bag(hero, 1)
+  ok hero.slot_cursed?(Game::Actor::WEAPON_SLOT), 'the cursed weapon locks its own slot'
+  ok !hero.slot_cursed?(Game::Actor::SHIELD_SLOT), 'an unrelated empty slot is unaffected'
+end
+
+check 'slot_cursed? does not itself block Party#equip_from_bag / #unequip_to_bag' do
+  # Same split as #equipment_fixed?: the gate belongs to the equip menu, not
+  # the bag-swap logic, so a caller that already knows better (an event
+  # command, this test) can still force a cursed item off.
+  items = { 1 => fake_item(type: 1, atk: 20, cursed: true) }
+  row = FakePlayerRow.new('Hero', '', 0, 5, { max_hp: 10 })
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  ok st.party.equip_from_bag(hero, 1)
+  ok hero.slot_cursed?(Game::Actor::WEAPON_SLOT)
+  ok st.party.unequip_to_bag(hero, 0) != 0
+  eq 0, hero.equipment[0]
+  ok !hero.slot_cursed?(Game::Actor::WEAPON_SLOT), 'empty again, no longer cursed'
 end
 
 # -- chipset terrain tags -----------------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5386,6 +5386,8 @@ class MenuStubActor
   def add_state(id); @states.push(id) unless @states.include?(id); end
   attr_accessor :equipment_fixed_flag
   def equipment_fixed?; !!@equipment_fixed_flag; end
+  attr_accessor :cursed_slot
+  def slot_cursed?(slot); @cursed_slot == slot; end
 end
 
 class MenuStubParty
@@ -5749,6 +5751,26 @@ check 'Scene::EquipMenu: 装備固定 refuses to open the item list for that act
   # The second party member is not locked -- switching to them and pressing C
   # opens the list as normal, so the gate really is per-actor.
   RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :items, scene.instance_variable_get(:@mode)
+end
+
+check 'Scene::EquipMenu: a cursed item refuses to open the item list for its own slot' do
+  state = wrap_menu_state
+  state.party.actors.first.cursed_slot = 0                # the weapon slot
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :slots, scene.instance_variable_get(:@mode), 'the cursed slot stays closed'
+
+  # The shield slot is not cursed -- moving down to it and pressing C opens
+  # the list as normal, so the gate really is per-slot, not per-actor.
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
   scene.update
   RGSS::Input.reset
   RGSS::Input.triggered = [RGSS::Input::C]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5472,6 +5472,27 @@ check 'Scene::Menu: the main command cursor wraps around' do
   eq 0, scene.instance_variable_get(:@index), 'Down from the last command wraps to the first'
 end
 
+check 'Scene::Menu: choosing Item pushes Scene::ItemMenu (and the rest their own scenes)' do
+  # COMMAND_KEYS order is Item, Skill, Equip, Status, Save, End Game; the first
+  # four each push their own scene onto the parent stack rather than falling
+  # into the generic "not implemented yet" message -- confirm the field Item
+  # command actually reaches Scene::ItemMenu, and its neighbours are not stubs.
+  {
+    0 => RPG2k::Scene::ItemMenu,
+    1 => RPG2k::Scene::SkillMenu,
+    2 => RPG2k::Scene::EquipMenu,
+    3 => RPG2k::Scene::StatusMenu,
+  }.each do |index, klass|
+    scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
+    scene.instance_variable_set(:@index, index)
+    RGSS::Input.triggered = [RGSS::Input::C]
+    scene.update
+    RGSS::Input.reset
+    pushed = scene.parent.pushed.last
+    ok pushed.is_a?(klass), "command ##{index} pushes a live #{klass}, got #{pushed.class}"
+  end
+end
+
 check 'the item / skill target list shows who is afflicted' do
   st = menu_state
   st.party.actors.first.add_state(4)                    # Sleep


### PR DESCRIPTION
## Summary
Adds support for the cursed equipment flag that prevents equipped items from being removed or replaced via the equip menu. The `cursed` field from the item database is now properly consulted to lock equipment slots, matching RPG_RT's behavior.

## Key Changes
- **Item schema**: Added `cursed` field to `FakeItem` struct in test helpers, with default value `false`
- **Game logic**: Implemented `Game::Actor#slot_cursed?` method that reads the cursed flag from the item currently occupying a given equipment slot
- **Equip menu**: Modified `Scene::EquipMenu#update_slots` to check `slot_cursed?` alongside `equipment_fixed?` before allowing the item list to open
- **Test coverage**: Added comprehensive tests covering:
  - Cursed items locking their own slots while leaving other slots unaffected
  - Verification that `Party#equip_from_bag` and `#unequip_to_bag` remain unguarded (matching RPG_RT's Change Equipment event command behavior)
  - Scene-level test confirming the equip menu refuses to open a cursed item's slot

## Implementation Details
- The cursed flag is read fresh from the equipped item each time, not cached, so swapping a cursed item for a non-cursed one via event commands immediately clears the lock
- Follows the same architectural split as `equipment_fixed?`: the gate is in the menu UI layer, not in the party/actor bag-swap logic, allowing event commands to bypass it
- Only affects the equip menu; Change Equipment event commands can still force cursed items off (consistent with RPG_RT)
- Per-slot locking: a cursed weapon only locks the weapon slot; other slots remain accessible

https://claude.ai/code/session_01Frii22A1TAcG3Lky5eRuhx