### PR TITLE
rpg2k: clamp Control Variables writes to RPG_RT's ±999999 range

### DIFF
--- a/changelog.d/rpg2k-variable-range-clamp.fixed.md
+++ b/changelog.d/rpg2k-variable-range-clamp.fixed.md
@@ -1,0 +1,9 @@
+- RPG Maker 2000: a **Control Variables** write now clamps to RPG_RT's
+  ±999999 range instead of overflowing. `Game::Variables#[]=` had no bound at
+  all, so a Control Variables assign/add sourced from a large constant, an
+  Input Number, or an expression like the standard `x1.5` = `x15/10`
+  workaround (which can legitimately overshoot mid-computation) landed
+  outside the range the real engine ever allows a variable to hold. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check (an over/under-range constant
+  assign clamps at the boundary; an in-range add that would overflow clamps
+  too), confirmed to fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2166,15 +2166,32 @@ not yet verified:
   to `scripts/rpg2k_logic_check.rb`: a recovery skill computing a raw 5000
   HP heal against a high-max-HP target clamps at 999, confirmed to fail
   against the pre-fix code.
-- **Numeric constants worth asserting directly**: switches/variables cap
-  at 5000 (expandable), variable value range −999999..999999 in RPG2000 vs
-  7-digit in RPG2003 (already partially modelled per `LCF::MODE`, worth
-  checking the variable-write clamp specifically); Call Event / Event Call
-  recursion ceiling of 1000; party cap of 4; item/equipment stack cap 99;
-  picture id range 1-50; move speed 1-6 (default 4), each step exactly
-  doubling/halving 2px/frame at standard speed (8 frames/tile, matching
-  `TILE`/`SPEED`already in this codebase — worth cross-checking the exact
-  numbers); character transparency 8 discrete steps (0..7).
+- ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
+  (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
+  of overflowing. `Game::Variables#[]=` had no bound at all, so a Control
+  Variables assign/add sourced from a large constant, an Input Number, or an
+  expression like the standard `×1.5` = `×15÷10` workaround (which can
+  legitimately overshoot mid-computation, per the "Variables & Switches"
+  bullet above) landed outside the range the real engine ever lets a variable
+  hold. Fixed with a local `Game::Variables::MAX`/`MIN` pair rather than a
+  reference to `LCF.var_max`/`var_min` directly — this file deliberately
+  touches neither RGSS nor the native LCF parser at load time (see
+  `scripts/rpg2k_logic_check.rb`'s header), so the bound is its own constant,
+  matching the existing `EXP_MAX`/`DAMAGE_CAP`/`RECOVER_CAP` pattern rather
+  than a cross-gem call. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (an over/under-range constant assign clamps at the boundary; an
+  in-range add that would overflow clamps too), confirmed to fail against the
+  pre-fix code. **Other numeric constants in this same bullet are already
+  confirmed correct, no code change needed**: Call Event / Event Call
+  recursion ceiling of 1000 (`MAX_CALL_DEPTH`, `interpreter.rb`); party cap of
+  4 (`Game::Party::MAX_SIZE`); item/equipment stack cap 99 and gold cap
+  999999 (`Party#add_item`/`#gain_gold`); move speed 1-6 via `SPEED_UP`/
+  `SPEED_DOWN` clamping to `[1, 6]`; character transparency 8 discrete steps
+  (`TRANSP_UP`/`TRANSP_DOWN` clamping to `[0, 7]`). **Still open**:
+  switches/variables capping at 5000 (configurable in the editor, so this may
+  be a non-issue rather than a gap — nothing here enforces a count ceiling on
+  how many distinct ids get used, which is a different question from a single
+  variable's *value* range, now fixed); picture id range 1-50.
 - **Runtime per-map overrides that reset on leaving-and-returning to the
   map**, not just on Transfer Player/save-load: Chipset Change, Panorama/
   parallax Change, Encounter Steps Change, Tile Replacement, and — per one

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1008,6 +1008,19 @@ module Game
 
   # Game variables: a 1-indexed set of integers, defaulting to 0.
   class Variables
+    # RPG_RT clamps a variable's value to a fixed range rather than letting it
+    # overflow -- +-999999 in RPG2000 (mruby-lcf's LCF.var_min/max carry the
+    # same figures for the schema side, but this file deliberately touches
+    # neither RGSS nor the native LCF parser at load time, so the bound is
+    # its own local constant rather than a cross-gem reference). Multiplying
+    # before dividing (the standard `x1.5` = `x15/10` workaround) can
+    # legitimately blow past +-999999 mid-expression, and Control Variables
+    # can also assign an arbitrary Input Number / random / constant straight
+    # past the range, so the clamp belongs on the single write path every
+    # source funnels through, not on any one caller.
+    MAX = 999_999
+    MIN = -999_999
+
     # See Switches#revision: page conditions read variables too.
     attr_reader :revision
 
@@ -1015,6 +1028,8 @@ module Game
     def [](id); @data[id] || 0; end
 
     def []=(id, v)
+      v = MAX if v > MAX
+      v = MIN if v < MIN
       return v if self[id] == v
       @data[id] = v
       @revision += 1

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3900,6 +3900,29 @@ check 'Control Variables batch random-assign rolls independently per variable' d
   ok vals.uniq.size > 1, "every variable in the batch got the same roll: #{vals}"
 end
 
+check 'a variable clamps to +-999999 instead of overflowing' do
+  # RPG_RT never lets a variable's stored value leave +-999999 in RPG2000
+  # (+-9999999 in RPG2003, LCF.var_max/var_min) -- a Control Variables write
+  # that would land outside it clamps at the boundary instead.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1_500_000]),   # var 1 = 1500000 (constant operand)
+    FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 0, -1_500_000]),  # var 2 = -1500000
+  ])
+  it.update
+  eq 999_999, st.variables[1], 'an over-range constant assign clamps at the max'
+  eq(-999_999, st.variables[2], 'an under-range constant assign clamps at the min')
+
+  # A batch add that pushes an in-range value past the ceiling clamps too,
+  # not just a single out-of-range assign.
+  st.variables[3] = 999_998
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 1, 0, 10])]) # var 3 += 10
+  it2.update
+  eq 999_999, st.variables[3], 'an add that overflows the range clamps at the max'
+end
+
 check 'a descending batch range silently no-ops for both Switches and Variables' do
   # yado.tk: a batch (range) Control Switches/Variables whose high end is
   # below its low end does nothing at all, no error. range(cmd) returns the


### PR DESCRIPTION
## Summary
- `Game::Variables#[]=` had no bound at all, so a Control Variables assign/add
  (a large constant, an Input Number, or an expression like the standard
  `×1.5` = `×15÷10` workaround, which can legitimately overshoot
  mid-computation) could push a variable outside the range the real RPG_RT
  engine ever lets one hold (±999999 in RPG2000).
- Adds a local `Game::Variables::MAX`/`MIN` pair rather than reaching into
  `LCF.var_max`/`var_min` directly — `game.rb` deliberately touches neither
  RGSS nor the native LCF parser at load time (see the header of
  `scripts/rpg2k_logic_check.rb`), so this follows the same local-constant
  pattern already used for `EXP_MAX`/`DAMAGE_CAP`/`RECOVER_CAP`.
- `docs/TODO.md`'s "Numeric constants worth asserting directly" bullet is
  updated: the variable-range clamp is now marked fixed, and the other
  constants bundled in that bullet (recursion ceiling, party cap, item/gold
  caps, move speed, transparency steps) are confirmed already correct by
  reading the code, so they no longer need re-checking.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 662 checks pass (new check
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 314 checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_