### PR TITLE
Suppress Show/Move/Erase Picture while a message window or choice list is open

### DIFF
--- a/changelog.d/picture-commands-message-suppress.fixed.md
+++ b/changelog.d/picture-commands-message-suppress.fixed.md
@@ -1,0 +1,13 @@
+- **Show/Move/Erase Picture now no-op while a message window or choice list
+  is open**, matching yado.tk's stated unconditional RPG_RT limitation. This
+  was reachable in practice: `Scene::Map#step_parallels` (the earlier
+  "parallel processes were paused too broadly" fix) already keeps a parallel
+  process advancing during a message window opened by the foreground or by
+  another interpreter, and its picture commands used to apply immediately
+  regardless. `Game::Interpreter#do_show_picture`/`#do_move_picture`/
+  `#do_erase_picture` now check a new `Scene::Map#message_window_open?` hook
+  (queried through the existing `map_info` mechanism, same pattern as
+  `#event_position`/`#character_screen_position`) and no-op when it answers
+  true; a headless interpreter (no `map_info`, or a battle page) is
+  unaffected. The picture's *other* non-picture commands in the same
+  parallel process still keep running, unchanged.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2127,8 +2127,8 @@ not yet verified:
   without reaching a wait). (Picture commands specifically *are* suppressed
   during a message window per several other pages, which is a narrower,
   separate rule from whether the parallel process's own non-picture commands
-  keep ticking, and is **not** addressed by this change — still open if not
-  covered elsewhere.)
+  keep ticking, and was **not** addressed by this change — now fixed
+  separately, see the "Pictures" bullet under "Full-site sweep" below.)
 - ✅ **Timer max 99:59 (5999s), clamped not wrapped when set higher via a
   variable.** `Game::Timer#set` (`mruby-rpg2k/mrblib/game.rb`) computed
   `@frames = seconds * FPS + (FPS - 1)` with no upper bound at all, and
@@ -2377,10 +2377,37 @@ not yet verified:
 - Changing maps **auto-clears every picture** — except when the transfer
   was via Teleport or Escape, which is an explicit, deliberate exception
   (multiply corroborated).
-- Picture commands (Show/Move/Erase) are **fully suppressed while any
+- ✅ **Picture commands (Show/Move/Erase) are now fully suppressed while any
   message window or choice list is open**, anywhere, including inside an
-  already-running parallel process — stated as an unconditional engine
-  limitation with no workaround.
+  already-running parallel process — an unconditional engine limitation with
+  no workaround. This was a real, reachable gap: `Game::Interpreter#
+  do_show_picture`/`#do_move_picture`/`#do_erase_picture` called straight
+  into `Game::State#show_picture`/`#move_picture`/`#erase_picture` with no
+  gating at all, and the sibling "parallel processes were paused too
+  broadly" fix above (`Scene::Map#step_parallels`/`#parallels_paused?`)
+  means a parallel process keeps executing commands — including these three
+  — while the foreground (or another interpreter) has a message window or
+  choice list open. Fixed with a new `Scene::Map#message_window_open?`
+  predicate (`!!(@message || @number_input)`, true for a plain message, a
+  choice list, and a standalone or embedded Input Number widget, all of
+  which set one of those two ivars) queried by the interpreter through the
+  existing `map_info` hook — the same `@map_info.respond_to?(:x) &&
+  @map_info.x` pattern `#event_operand`/`#screen_operand` already use for
+  `#event_position`/`#character_screen_position` — so a headless interpreter
+  (no `map_info`, or a battle page) is unaffected. All three picture
+  commands now return immediately when it answers true; a suppressed Move
+  Picture's wait flag is not honoured either (nothing moved, so there is
+  nothing to wait for), matching "no workaround". Covered by four new
+  `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against the
+  pre-fix code: a direct interpreter poke while its own message window is
+  open, the same poke against an open choice list, and a full scene
+  simulation proving a parallel process's Show/Move/Erase Picture attempts
+  are dropped while a message window (opened via `#open_message`, sidestepping
+  the `#step_parallels`-before-`#start_autostart` ordering that would
+  otherwise let the parallel process's first lap land before the window is
+  actually open) is up and take effect on the very next lap once it closes —
+  while confirming the same process's non-picture commands (`Control
+  Variables`) keep advancing throughout, so the sibling fix stays intact.
 - Re-issuing **Show Picture** every tick (rather than reusing an
   already-shown picture via Move Picture) is expensive enough to cause
   real frame drops; Move Picture, even at 0.0s duration, is cheap and can

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2564,6 +2564,19 @@ module Game
       @waiting = true
     end
 
+    # Whether Show/Move/Erase Picture must no-op this call: per yado.tk, real
+    # RPG_RT fully suppresses all three picture commands while any message
+    # window or choice list is open, anywhere in the scene — including a
+    # picture command reached by an already-running parallel process while a
+    # *different* interpreter's message window sits on screen (parallel
+    # processes keep advancing during a message window, see
+    # Scene::Map#parallels_paused?; this is the narrower rule layered on top
+    # of that). Without a map_info hook (a headless interpreter, or a battle
+    # page) there is no message window to suppress against.
+    def picture_commands_suppressed?
+      @map_info.respond_to?(:message_window_open?) && @map_info.message_window_open?
+    end
+
     # Show Picture (11110): display picture param0 from the string file name at
     # the centre position param2/param3 (literal, or read from those variables
     # when the position-mode param1 is non-zero), at zoom param5 (%), transparency
@@ -2574,6 +2587,7 @@ module Game
     def do_show_picture(cmd)
       id = cmd.param(0)
       return if id <= 0
+      return if picture_commands_suppressed?
       @state.show_picture(id,
                           name: picture_name(cmd),
                           x: picture_coord(cmd, 2), y: picture_coord(cmd, 3),
@@ -2591,6 +2605,7 @@ module Game
     # and resumes us once none is moving. Same parameter layout as Show Picture,
     # plus the trailing duration/wait pair (EasyRPG's CommandMovePicture).
     def do_move_picture(cmd)
+      return if picture_commands_suppressed?
       id = cmd.param(0)
       frames = cmd.param(14) * FRAMES_PER_TENTH
       @state.move_picture(id, picture_coord(cmd, 2), picture_coord(cmd, 3),
@@ -2605,6 +2620,7 @@ module Game
 
     # Erase Picture (11130): remove picture param0 from the screen.
     def do_erase_picture(cmd)
+      return if picture_commands_suppressed?
       @state.erase_picture(cmd.param(0))
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -873,6 +873,21 @@ class RPG2k
         @message || @number_input || @interpreter.running? || @interpreter.waiting?
       end
 
+      # Whether a message window or choice list (Show Message / Show Choices /
+      # an Input Number embedded in one) is currently on screen -- queried by
+      # the interpreter via map_info (see #event_position, #character_screen_
+      # position for the same pattern) so Show/Move/Erase Picture can suppress
+      # themselves per yado.tk: picture commands are fully suppressed while any
+      # message window or choice list is open, anywhere in the scene, *including*
+      # a still-running parallel process (#step_parallels keeps parallel
+      # processes advancing during a message window; see #parallels_paused?,
+      # which does *not* treat a message window as a pause condition -- this is
+      # the separate, narrower rule that does).
+      def message_window_open?
+        !!(@message || @number_input)
+      end
+      public :message_window_open?
+
       # Whether #step_parallels should sit this frame out. Per yado.tk, real
       # RPG_RT only pauses background parallel processes for the Menu screen
       # (already structural here -- Scene::Map#update simply is not called

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1410,6 +1410,123 @@ check 'parallel processes keep running while a message window is open (yado.tk)'
      'the parallel process advances despite the open message window'
 end
 
+check 'Show Picture is suppressed even for the foreground interpreter whose own window is open (yado.tk)' do
+  # A foreground event can never naturally reach a picture command while
+  # parked on its own Show Text wait (the interpreter is blocked until the
+  # window closes), so this pokes the interpreter directly to prove the
+  # suppression rule lives on the command itself (shared by every
+  # interpreter, foreground or parallel) and not just on the natural
+  # scheduling that happens to keep a foreground event from self-colliding.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi')]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+
+  interp = scene.instance_variable_get(:@interpreter)
+  interp.send(:do_show_picture,
+             ECmd.new(ic::SHOW_PICTURE, [1, 0, 100, 100, 0, 100, 0, 0, 100, 100, 100, 100],
+                      string: 'pic'))
+  ok !st.pictures.key?(1),
+     'a picture command reaching the interpreter while its own message window is open must not apply'
+end
+
+check 'Show Picture is suppressed while a choice list is open (yado.tk)' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_CHOICES, [0], indent: 0), # cancel forbidden
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes'),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'no'),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'choice list opened'
+  ok msg[:choice], 'it is a choice window, not a plain message'
+
+  interp = scene.instance_variable_get(:@interpreter)
+  interp.send(:do_show_picture,
+             ECmd.new(ic::SHOW_PICTURE, [1, 0, 100, 100, 0, 100, 0, 0, 100, 100, 100, 100],
+                      string: 'pic'))
+  ok !st.pictures.key?(1), 'a picture command must not apply while a choice list is open'
+end
+
+check 'Show/Move/Erase Picture from an independently-running parallel process are ' \
+      'suppressed while a message window is open, and apply once it closes (yado.tk)' do
+  ic = Game::Interpreter::Cmd
+
+  # Each sub-case opens the message window directly (via the same #open_message
+  # the foreground driver itself calls) instead of racing an autostart trigger
+  # against the parallel process's very first frame -- #step_parallels already
+  # runs before #start_autostart each frame (see Scene::Map#update), so a
+  # naturally-triggered message would not be open yet for the parallel
+  # process's first lap, and these commands are non-blocking no-ops once
+  # applied, not something a later suppression could retract.
+
+  # -- Show Picture ---------------------------------------------------------
+  par = page(trigger: 4)
+  par.event_commands = [
+    ECmd.new(ic::SHOW_PICTURE, [1, 0, 100, 100, 0, 100, 0, 0, 100, 100, 100, 100],
+             string: 'pic'),
+    add_var_cmd(1),
+  ]
+  scene = new_scene({ 1 => event(4, 4, par) })
+  st = scene.instance_variable_get(:@state)
+  scene.send(:open_message, ['hi'], false)
+
+  10.times { scene.update }
+  ok !st.pictures.key?(1),
+     'Show Picture from a still-running parallel process must not apply while a message window is open'
+  ok st.variables[1] > 0,
+     'the parallel process keeps advancing its non-picture commands regardless -- the sibling ' \
+     '"parallel processes were paused too broadly" fix must stay intact'
+
+  scene.send(:close_message)
+  5.times { scene.update }
+  ok st.pictures.key?(1), 'Show Picture applies once the window closes'
+
+  # -- Move Picture -----------------------------------------------------------
+  par2 = page(trigger: 4)
+  par2.event_commands = [ECmd.new(ic::MOVE_PICTURE,
+                                  [1, 0, 200, 200, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0, 0, 0])]
+  scene2 = new_scene({ 1 => event(4, 4, par2) })
+  st2 = scene2.instance_variable_get(:@state)
+  st2.pictures[1] = Game::Picture.new(1, x: 100, y: 100)
+  scene2.send(:open_message, ['hi'], false)
+
+  10.times { scene2.update }
+  eq [100, 100], [st2.pictures[1].x, st2.pictures[1].y],
+     'Move Picture from the parallel process must not relocate it while the window is open'
+
+  scene2.send(:close_message)
+  5.times { scene2.update }
+  eq [200, 200], [st2.pictures[1].x, st2.pictures[1].y],
+     'Move Picture applies once the window closes'
+
+  # -- Erase Picture ----------------------------------------------------------
+  par3 = page(trigger: 4)
+  par3.event_commands = [ECmd.new(ic::ERASE_PICTURE, [1])]
+  scene3 = new_scene({ 1 => event(4, 4, par3) })
+  st3 = scene3.instance_variable_get(:@state)
+  st3.pictures[1] = Game::Picture.new(1, x: 100, y: 100)
+  scene3.send(:open_message, ['hi'], false)
+
+  10.times { scene3.update }
+  ok st3.pictures.key?(1), 'Erase Picture from the parallel process must not apply while the window is open'
+
+  scene3.send(:close_message)
+  5.times { scene3.update }
+  ok !st3.pictures.key?(1), 'Erase Picture applies once the window closes'
+end
+
 check 'parallel processes pause during battle' do
   ic = Game::Interpreter::Cmd
   par = page(trigger: 4)


### PR DESCRIPTION
## Summary

Per yado.tk, real RPG_RT unconditionally drops **Show/Move/Erase Picture** commands while any message window or choice list is open, anywhere — including inside an already-running parallel process. This was explicitly left open by the earlier "parallel processes were paused too broadly" fix (`docs/TODO.md`, the note right after it): that fix correctly made `Scene::Map#step_parallels` keep advancing a parallel process's *non-picture* commands during a message window, but `Game::Interpreter#do_show_picture`/`#do_move_picture`/`#do_erase_picture` had **no suppression at all** — they called straight into `Game::State#show_picture`/`#move_picture`/`#erase_picture`. So a parallel process's picture commands applied immediately even while a message window (opened by the foreground or another interpreter) was on screen, a genuine, reachable gap.

- Added `Scene::Map#message_window_open?` (`!!(@message || @number_input)` — true for a plain message, a choice list, and both the standalone and embedded Input Number widget, since all of those share one of those two ivars).
- The three picture commands now check it through the interpreter's existing `map_info` hook — the same `@map_info.respond_to?(:x) && @map_info.x` pattern already used by `#event_operand`/`#screen_operand` for `#event_position`/`#character_screen_position` — and no-op when it answers true. A headless interpreter (no `map_info`, or a battle page) is unaffected.
- A suppressed Move Picture's wait flag is not honoured either (nothing moved, so nothing to wait for), matching yado.tk's "no workaround" framing.

`docs/TODO.md` updated: the "Pictures" bullet under "Full-site sweep" is now ✅, and the earlier still-open note is cross-referenced to it.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 661 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 317 checks passed, including 4 new checks:
  - a direct interpreter poke proving Show Picture is suppressed even for the foreground interpreter whose own message window is open,
  - the same poke against an open choice list,
  - a combined scene simulation proving a parallel process's Show/Move/Erase Picture attempts are dropped while a message window is open and take effect on the very next lap once it closes — while confirming the same process's non-picture commands (`Control Variables`) keep advancing throughout, so the sibling "parallel processes were paused too broadly" fix stays intact.
- Confirmed all 3 new state-asserting checks fail against the pre-fix code (`git stash` the two `mrblib` files and re-run) before committing.
- Added `changelog.d/picture-commands-message-suppress.fixed.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_014pbhWHtUZ8QFjAKzGinBwY)_