### PR TITLE
rpg2k: an airship can't land on a tile a map event occupies

### DIFF
--- a/changelog.d/airship-landing-through-mode.fixed.md
+++ b/changelog.d/airship-landing-through-mode.fixed.md
@@ -1,0 +1,16 @@
+- **An airship can no longer land on a tile a map event occupies**, unless
+  that event's own move route has Through Mode on. `Scene::Map
+  #airship_landable?` gated its blocker check on the hero's own priority-type
+  occupancy test (`blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]`),
+  so a below/above-characters event — which airborne flight already ignores
+  entirely, since `#vehicle_passable?`'s airship branch never reads
+  `@event_tiles` — was also silently landable on, the same way the walking
+  hero correctly overlaps it. RPG_RT's landing rule is the vehicle-specific
+  one already fixed for a boarded boat/ship: any layer blocks, priority-type/
+  `overlap_forbidden` gating is ignored entirely, and only the blocking
+  event's own Through Mode lets it through. The blocker check is now
+  `blocker && !blocker[:char].through`, matching `#vehicle_passable?`'s
+  boat/ship branch exactly; flying itself, and the terrain's own
+  `airship_land` flag, are untouched. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix
+  code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2033,9 +2033,11 @@ Everything below is unverified against the codebase.
   checking against `step_parallel`/touch-trigger dispatch.
 - **Vehicles** — an unset vehicle defaults to map id 0, (0,0); Small/Large
   Ship aren't hardcoded to water, their passability follows the terrain
-  table's boat/ship-pass flags like any other vehicle rule; an airship
-  can't land on a tile a map event currently occupies; airships get no
-  random encounters by default; hero-targeted Set Move Route commands (Dash,
+  table's boat/ship-pass flags like any other vehicle rule; ✅ an airship
+  can't land on a tile a map event currently occupies (now fixed — see the
+  "Party / Actor / Vehicle" section under "Full-site sweep" below); airships
+  get no random encounters by default (**confirmed already correct**, same
+  section); hero-targeted Set Move Route commands (Dash,
   Jump, etc.) still run normally while mounted and must be manually guarded
   off; **setting a map event's trigger to Parallel Process and running "Set
   Vehicle Position" from it crashes RPG_RT** (any other trigger type does
@@ -2752,14 +2754,24 @@ not yet verified:
 - "Hero X is in the party" always evaluates in **database ID order**, not
   current seat/slot order — there is no built-in way to read a member's
   current seat position.
-- Vehicles: an un-placed vehicle defaults to Map ID 0, (0,0). An airship's
-  *initial* position can be set on unlandable terrain and boarded there
-  without issue (the landability check is skipped only for the starting
-  placement), but it can never land on a tile a map event occupies
-  regardless of terrain, and Set Vehicle Location has **no** landability
-  validation at all (will happily place it somewhere unlandable). Random
-  encounters stay active on ships (governed by terrain settings) but are
-  **hard-disabled** on airships with no database toggle.
+- Vehicles: an un-placed vehicle defaults to Map ID 0, (0,0) — **confirmed
+  already correct**, `Game::Vehicle#initialize`'s own defaults
+  (`mruby-rpg2k/mrblib/game.rb`). An airship's *initial* position can be set
+  on unlandable terrain and boarded there without issue (the landability
+  check is skipped only for the starting placement) — already true here too,
+  since nothing validates a vehicle's position outside of `#disembark_vehicle`
+  — and Set Vehicle Location has **no** landability validation at all (will
+  happily place it somewhere unlandable) — likewise already correct,
+  `Game::Interpreter#do_set_vehicle_location` writes the given map/x/y
+  straight through with no passability check of any kind. Random encounters
+  stay active on ships (governed by terrain settings) but are **hard-disabled**
+  on airships with no database toggle — already correct too,
+  `Scene::Map#check_random_encounter`'s `return if @state.party.flying?(@state)`
+  early-out (`Game::Party#flying?` — true only while `boarded == :airship`)
+  skips the roll entirely regardless of terrain, with no equivalent early-out
+  for a boarded boat/ship. ("It can never land on a tile a map event occupies
+  regardless of terrain" was the one genuine gap in this bullet — now fixed,
+  see below.)
 - ✅ **Small/large ships can never overlap an event's tile even with a
   passable graphic + below-characters priority** (which *does* let the
   walking hero overlap it fine via the already-implemented priority-type
@@ -2782,6 +2794,25 @@ not yet verified:
   by a new `scripts/rpg2k_scene_check.rb` check (a boarded boat is stopped
   by a below-characters event on an otherwise boat-passable tile; setting
   that event's own Through Mode on lets the boat sail through it).
+- ✅ **An airship can never land on a tile a map event occupies, regardless
+  of terrain** — the same vehicle-specific Through-Mode rule as the boat/ship
+  fix directly above, applied to landing rather than sailing. Flying itself
+  already ignored events entirely (`#vehicle_passable?`'s airship branch
+  never reads `@event_tiles`, so an airship can cruise directly over a
+  below-characters event a walking hero would just as happily overlap), but
+  `Scene::Map#airship_landable?` — the one place events reach it at all, via
+  `#disembark_vehicle`'s airship branch — was gating its own blocker check on
+  the hero's priority-type occupancy test
+  (`blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden]`), the exact
+  same reused-hero-rule mistake the boat/ship fix above already corrected for
+  sailing: a below-characters event was silently landable on instead of
+  refusing the landing. The blocker check is now `blocker &&
+  !blocker[:char].through`, textually identical to `#vehicle_passable?`'s
+  boat/ship branch; the terrain's own `airship_land` flag and flight itself
+  are untouched. Covered by a new `scripts/rpg2k_scene_check.rb` check (an
+  airship boarded directly over a below-characters event cannot land there
+  despite `airship_land: true`; turning that event's own Through Mode on lets
+  it land), confirmed to fail against the pre-fix code before the fix.
 
 **Save / Load persistence — consolidated master list**
 Runtime state that does **not** survive a map re-visit (leave and return,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1153,14 +1153,22 @@ class RPG2k
       end
 
       # Whether the airship may land on tile (x, y): the database terrain's
-      # airship_land flag (default true), with no LAYER_SAME event occupying
-      # the ground underneath (a below/above-layer event doesn't collide, same
-      # as ordinary movement). A tile with no terrain data (a bare fixture) is
-      # landable.
+      # airship_land flag (default true), with no map event occupying the
+      # ground underneath at all — yado.tk: an airship can never land on a
+      # tile a map event occupies, regardless of terrain. Flying itself
+      # ignores events entirely (#vehicle_passable?'s airship branch never
+      # reads @event_tiles, so the airship can cruise directly over a
+      # below-characters event a walking hero would just as happily overlap),
+      # so this is the one place events reach it at all — and, once they do,
+      # this follows the same vehicle-specific rule #vehicle_passable? already
+      # uses for a boat/ship (`!blocker[:char].through`): any layer blocks,
+      # priority-type/overlap_forbidden gating is ignored entirely, and only
+      # the blocking event's own Through Mode lets it through. A tile with no
+      # terrain data (a bare fixture) is landable.
       def airship_landable?(x, y)
         return false unless @map.in_bounds?(x, y)
         blocker = @event_tiles[[x, y]]
-        return false if blocker && (blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden])
+        return false if blocker && !blocker[:char].through
         row = terrain_row_at(x, y)
         return true if row.nil?
         row.airship_land ? true : false

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3499,6 +3499,43 @@ check 'the airship lands in place where the terrain allows it' do
   eq [0, 0], [air.x, air.y], 'the airship stayed where it landed'
 end
 
+check 'the airship cannot land on a tile a map event occupies unless it has Through Mode on' do
+  # yado.tk: an airship can never land on a tile a map event occupies,
+  # regardless of terrain. Flying itself ignores events entirely
+  # (#vehicle_passable?'s airship branch never reads @event_tiles), so the
+  # airship can cruise -- and be boarded -- directly over a below-characters
+  # event a walking hero would just as happily overlap; landing there must
+  # still refuse it, the same vehicle-specific "any layer, only the blocking
+  # event's own Through Mode lets it through" rule already confirmed for a
+  # boarded boat/ship (see the boat/below-characters-event check above).
+  blocker = event(0, 0, page(trigger: 0, layer: RPG2k::Scene::Map::LAYER_BELOW))
+  scene = new_scene({ 1 => blocker }, player: [0, 0], airship_land: true)
+  st = scene.instance_variable_get(:@state)
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 0
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'boarded the airship in place, directly over the event'
+  # Try to land: the below-characters event on this tile still blocks it,
+  # despite airship_land: true and despite its layer being one the hero's own
+  # passability would happily overlap.
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :airship, st.boarded, 'a below-characters event on the tile still blocked landing'
+
+  # Turn the blocking event's own Through Mode on and try again: now it lands.
+  chars(scene)[1].through = true
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = []
+  ok !st.boarded?, 'Through Mode on the blocking event let the airship land'
+  eq [0, 0], [st.x, st.y], 'the party stands where the airship touched down'
+end
+
 check 'Show Battle Animation with the wait flag holds the event then resumes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `Scene::Map#airship_landable?` gated its blocker check on the hero's own
  priority-type occupancy test (`blocker[:layer] == LAYER_SAME ||
  blocker[:overlap_forbidden]`), so a below/above-characters map event was
  silently landable on — even though flight itself already ignores events
  entirely (`#vehicle_passable?`'s airship branch never reads
  `@event_tiles`), so an airship could cruise over and board directly above
  such a tile.
- yado.tk documents landing as a vehicle-specific rule: any layer blocks it,
  and only the blocking event's own Through Mode lets the airship touch
  down there — the same rule already fixed for boat/ship sailing in an
  earlier PR. The blocker check is now `blocker && !blocker[:char].through`,
  textually identical to `#vehicle_passable?`'s boat/ship branch. Flying
  itself and the terrain's own `airship_land` flag are untouched.
- `docs/TODO.md` is updated: the claim is moved from untriaged to ✅ Fixed
  (with cross-references from both of its earlier mentions in the file), and
  the other claims bundled in the same "Vehicles" bullet (un-placed vehicle
  defaults to map 0/(0,0); no landability validation on Set Vehicle
  Location; airships hard-disabling random encounters) are confirmed already
  correct by reading the code, so they're recorded as such instead of left
  unverified.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 662 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 315 checks pass (new check
      confirmed to fail against the pre-fix code: an airship boarded
      directly over a below-characters event could land there despite
      `airship_land: true`; turning that event's own Through Mode on is
      required for landing to succeed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_