### PR TITLE
rpg2k: persist a Common Event's Parallel Process across teleport/save

### DIFF
--- a/changelog.d/common-event-parallel-process-persistence.fixed.md
+++ b/changelog.d/common-event-parallel-process-persistence.fixed.md
@@ -1,0 +1,18 @@
+- **A Common Event's Parallel Process now survives a Transfer Player and a
+  save/load, instead of always restarting from the top.** Within one map
+  visit this was already correct — `Scene::Map#step_parallel` resumes the
+  same `Game::Interpreter` across ticks, so a process paused by its own gate
+  switch turning off genuinely freezes at that exact command — but
+  `#perform_teleport` and `Scene::Map#initialize` unconditionally rebuilt
+  *every* parallel process via `#build_parallels`, and `Game::State` had no
+  field at all for an interpreter's position. `#build_parallels` now reuses
+  the still-running interpreter (call stack, in-flight Wait countdown,
+  everything) across a Transfer Player, since `Scene::Map` is the same
+  instance before and after; a genuine save/load restores a coarser
+  checkpoint — `Game::Interpreter#resumable_index`, persisted on the new
+  `Game::State#common_event_progress` — a command index the process can
+  safely resume at (skipping, not repeating, a Wait it was mid-way through).
+  A Map Event's own parallel process is unaffected and still restarts fresh
+  on every visit, as before. The `.lsd` export still does not carry this (LCF
+  save chunks 113/114 remain undocumented opaque blobs); only the portable
+  save does. See ADR 0044.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1791,6 +1791,53 @@ following this paragraph as the original record.
   reusing the same "does nothing" mechanism a descending batch range
   already relies on. Covered by a new `scripts/rpg2k_logic_check.rb` check,
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **A Common Event's Parallel Process now survives a Transfer Player and a
+  save/load**, instead of always restarting from the top. Within one map
+  visit this was already modelled correctly — `step_parallel`'s
+  `gate_switch` resumes the same interpreter, so a process paused by its own
+  gate switch turning off mid-run genuinely freezes at that exact command —
+  but `perform_teleport` and `Scene::Map#initialize` unconditionally rebuilt
+  *every* parallel process from scratch via `build_parallels`, and
+  `Game::State#to_h`/`to_lsd` had no field at all for an interpreter's
+  position. Fixed in two parts, matching the two ways this codebase's
+  `Scene::Map` is (re)built: `build_parallels` now keys its previous
+  `@parallels` entries by common-event id and, across a Transfer Player
+  (which mutates `@map`/`@state` on the *same* `Scene::Map` instance rather
+  than building a fresh one), reuses the still-running `Game::Interpreter`
+  entry outright — full fidelity (call stack, in-flight Wait countdown,
+  everything), since nothing is actually serialised. A genuine save/load
+  builds a brand-new `Scene::Map`, so there is no live object to reuse;
+  `Game::Interpreter#resumable_index` returns the interpreter's current
+  index whenever it is safely capturable (not paused inside a nested Call
+  Event, whose frames nothing tracks how to re-resolve — `@call_stack` must
+  be empty), `Scene::Map#step_parallel` records it on the new
+  `Game::State#common_event_progress` (id → index) every tick, and
+  `Scene::Map#new_parallel` seeds a fresh interpreter from it via the new
+  `Game::Interpreter#start_at` on the very first `build_parallels` for a
+  scene. A tick caught mid a nested call simply leaves the last known-good
+  checkpoint in place rather than clearing it, so a save taken there resumes
+  at the last clean position, not the top. A Map Event's own parallel
+  process is untouched — it has no common-event id to key either mechanism
+  off, and keeps restarting fresh on every visit, exactly as before. The
+  `.lsd` export still does not carry this: LCF save chunks 113
+  (`SAVE_FOREGROUND_EVENT`) and 114 (`SAVE_COMMON_EVENT`) are known to hold
+  exactly this kind of execution state (a real save taken from an on-screen
+  choice keeps that choice's option strings inside chunk 113's blob) but
+  their internal byte grammar is undocumented and stays an opaque
+  `int8_array`, so only the portable Marshal save persists a Common Event's
+  parallel-process position — decoding that grammar against a real save
+  taken mid a Parallel Process is a still-open follow-up. See ADR 0044.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks (the plain
+  `#resumable_index`/`#start_at` contract, including the nested-call-stack
+  and finished-process nil cases, and `common_event_progress` round-tripping
+  through `#to_h`/`.load`) and new `scripts/rpg2k_scene_check.rb` checks (an
+  end-to-end Transfer Player check proving both the command index and the
+  in-flight Wait countdown survive untouched; an end-to-end save/load check
+  built around this section's own example — a gate switch turning off
+  mid-run, then a save/load, then the switch turning back on; and a check
+  pinning that a map event's own parallel process still gets a brand-new
+  interpreter, restarting at index 0, on every visit), all confirmed to fail
+  against the pre-fix code before the fix.
 
 #### Confirmed already correct (no action needed)
 - Wait 0.0 seconds already costs exactly one frame (not a no-op) —
@@ -1852,20 +1899,6 @@ following this paragraph as the original record.
   recomputes the three that have a map-tree setting. Regression-covered by
   extending an existing `scripts/rpg2k_scene_check.rb` check to also assert
   Save access resets with Teleport/Escape and Menu access does not.
-
-#### Confirmed genuine gaps, not yet fixed
-- **Common-event Parallel Process state should survive map changes and
-  saves, unlike a map event's.** Within one map visit this is already
-  modelled correctly (`step_parallel`'s `gate_switch` resumes the same
-  interpreter; a map event's parallel process restarts via `new_parallel` on
-  every page reselect) — but `perform_teleport` and `Scene::Map#initialize`
-  unconditionally rebuild *every* parallel process from scratch via
-  `build_parallels`, and `Game::State#to_h`/`to_lsd` have no field for
-  interpreter/parallel continuation state at all (LCF save chunks 113/114
-  are explicitly documented as opaque/unimplemented in
-  `mruby-lcf/mrblib/schema.rb`). **Architecturally significant — needs a
-  design decision (new save-chunk plumbing) before starting, not a small
-  patch.** Candidate for its own ADR.
 
 #### Untriaged backlog, from `2k/09_bug/` (bugs/errors pages read so far)
 - `016_ikinari_end/` — a Parallel Process can observe an all-KO'd party and
@@ -1977,7 +2010,8 @@ Everything below is unverified against the codebase.
   a target inside a Common Event (no map-event context) raises the invalid-
   event error; **interrupting a Common Event's Parallel Process (its switch
   turns off mid-run) and re-enabling it resumes exactly where it left off**
-  — this is the same fact as the "Confirmed genuine gap" above, restated.
+  — ✅ the same fact as the fixed "A Common Event's Parallel Process now
+  survives a Transfer Player and a save/load" item above, restated.
 - **Move All / Force Complete Move** — blocks Event Content at that command
   until every targeted character's route finishes; same freeze conditions
   as Set Move Route above.
@@ -2216,10 +2250,11 @@ not yet verified:
   for Autorun specifically.
 - A **Common Event's** parallel-process state (its interpreter position)
   **resumes exactly where it left off** when re-enabled, indefinitely,
-  persisting in every future save even after the condition goes false —
-  the known "genuine gap" already tracked above. A **Map Event's** parallel
-  process always restarts from the top on every re-trigger (matches this
-  codebase's current — correct — per-visit behavior).
+  persisting in every future save even after the condition goes false — ✅
+  fixed, see "A Common Event's Parallel Process now survives a Transfer
+  Player and a save/load" above. A **Map Event's** parallel process always
+  restarts from the top on every re-trigger (matches this codebase's
+  current — correct — per-visit behavior).
 - Multiple simultaneous parallel processes are **not concurrent** — the
   engine advances one command block at a time, round-robin, yielding at a
   blocking command (Wait/Show Text/Show Picture), in definition/event-ID
@@ -2780,8 +2815,10 @@ BGM/SE playback position (always restarts a track from the beginning even
 though the *filename* is remembered); Screen Scroll offset (saved but
 documented as broken/buggy after resuming — the site explicitly
 recommends never saving mid-scroll). A **Common Event's** parallel-process
-position **does** survive save/load (the known genuine gap tracked
-above) — the asymmetry with map events is the point.
+position **does** survive save/load (✅ fixed for the portable Marshal save,
+see "A Common Event's Parallel Process now survives a Transfer Player and a
+save/load" above; the `.lsd` export still does not, chunks 113/114 remain
+opaque) — the asymmetry with map events is the point.
 
 State that persists across **both** map-revisit and save/load: a
 Common Event's parallel-process interpreter position (until explicitly

--- a/docs/adr/0044-common-event-parallel-process-persistence.md
+++ b/docs/adr/0044-common-event-parallel-process-persistence.md
@@ -1,0 +1,133 @@
+# 44. Common Event Parallel Process interpreter continuation
+
+Date: 2026-08-13
+
+## Status
+
+Accepted
+
+## Context
+
+`docs/TODO.md`'s "Common-event Parallel Process state should survive map
+changes and saves, unlike a map event's" gap: within one map visit,
+`Scene::Map#step_parallel` already resumes the same `Game::Interpreter`
+instance across ticks, so a Common Event Parallel Process paused mid-script
+(e.g. its gate switch turns off mid-run) genuinely freezes at that exact
+command and resumes exactly there once ticking continues -- this part was
+already correct. The two places that were not: `Scene::Map#perform_teleport`
+and `Scene::Map#initialize` both call `#build_parallels` unconditionally,
+which discards every parallel-process interpreter (map event and common
+event alike) and rebuilds them from scratch. And `Game::State#to_h` /
+`#to_lsd` have no field at all for a running interpreter's position, so even
+if `build_parallels` were fixed, a save/load could not carry the position
+across.
+
+A Map Event's own parallel process is a different, already-correct story and
+is not part of this gap: RPG_RT restarts it fresh on every page reselect
+(`Scene::Map#new_parallel` / the "map event parallel process restarts via
+`new_parallel` on every page reselect" fact already recorded in the TODO),
+and this ADR does not touch that.
+
+Two sub-problems, with different natural solutions:
+
+- **Transfer Player (in-session).** `#perform_teleport` mutates `@map` /
+  `@state` on the *same* `Scene::Map` instance -- it is not a fresh scene
+  object. That means the live `Game::Interpreter` for a still-running Common
+  Event parallel process (its call stack, its `waiting?`/`wait_kind` state,
+  even `Scene::Map`'s own per-process `wait_timer` countdown for a Wait
+  command in progress) is sitting right there in memory the whole time.
+  Nothing about it needs serialising to survive a teleport -- `build_parallels`
+  just has to stop throwing it away.
+- **Save / load.** `RPG2k#continue_game` builds a brand-new `Scene::Map` from
+  a loaded `Game::State`, with a brand-new `Game::Interpreter` for every
+  parallel process. There is no live object to keep here; the position has to
+  come from the state itself. But capturing genuinely arbitrary interpreter
+  state (a nested Call Event's call stack, in-flight non-`:wait` UI requests,
+  the `wait_timer` that lives on `Scene::Map`'s own parallel-process hash, not
+  the interpreter) means designing and round-tripping a real continuation
+  format through two different save encodings (the portable Marshal dump and
+  the real `.lsd`). The `.lsd` side already carries a signal that this is
+  larger than it looks: chunks 113 (foreground event) and 114 (common-event
+  table) exist in `LCF::Schema::SAVE_DATA` and are known to hold exactly this
+  kind of execution state (a real save taken from an on-screen choice keeps
+  that choice's option strings inside chunk 113's blob), but their internal
+  grammar is undocumented and left an opaque `int8_array` -- consistent with
+  this codebase's rule that every schema field cites a source (a wiki page or
+  a real-save decode), not a guess.
+
+## Decision
+
+- **Transfer Player: reuse the live interpreter, not a reconstruction.**
+  `Scene::Map#build_parallels` now keys its previous `@parallels` entries by
+  `common_event_id` before rebuilding, and for any common event id that
+  already had a running parallel-process entry, pushes that *same* hash
+  entry (interpreter, `wait_timer`, gate switch, everything) instead of
+  calling `#new_parallel` again. Map event entries are always rebuilt fresh
+  from the destination map's own event table -- unchanged, matching the
+  existing per-visit-reset behaviour. This gives full fidelity (call stack,
+  in-flight wait, everything) for free, because nothing is actually
+  serialised: it is the same Ruby object before and after the teleport.
+- **Save/load: a coarser, explicit checkpoint on `Game::State`.**
+  `Game::Interpreter#resumable_index` returns the interpreter's current
+  `@index` when it is safely capturable -- `@call_stack` empty (not paused
+  inside a nested Call Event, whose frames nothing tracks how to
+  re-resolve), and `@index` inside the list's bounds. It deliberately does
+  *not* exclude `waiting?`: a blocking command always advances `@index` past
+  itself before raising its wait, so the index is a valid resume point
+  either way -- restoring it just means a resumed process skips replaying
+  any remaining Wait duration rather than serving it again (the `wait_timer`
+  countdown itself lives on `Scene::Map`'s side, not the interpreter, and is
+  not part of this checkpoint). `Scene::Map#step_parallel` calls this after
+  every tick of a common-event parallel process and writes it to the new
+  `Game::State#common_event_progress` hash (id => index) -- but only when it
+  returns non-nil, so a tick caught mid a nested call simply leaves the last
+  known-good checkpoint in place rather than clearing it. `#common_event_progress`
+  round-trips through `#to_h` / `.load` like any other save field.
+  `Scene::Map#new_parallel` reads it back on the very first `#build_parallels`
+  for a scene (a fresh game, or the `Scene::Map.new` that Continue builds) and
+  calls the new `Game::Interpreter#start_at(commands, index)` -- `#start`
+  followed by seeking to that index, or the top if the index is out of range
+  (e.g. a stale save against edited event data).
+- **`.lsd` chunks 113/114 are left opaque, as before.** No schema or writer
+  changes there. Promoting them to a documented grammar needs a real save
+  taken mid a Common Event Parallel Process to decode against, the same
+  standard every other schema field in this codebase was held to (ADR
+  0018-0020's chunk work, the existing `SAVE_FOREGROUND_EVENT` /
+  `SAVE_COMMON_EVENT` opaque-blob comments) -- guessing a byte layout here
+  would violate that standard rather than extend it. This means the `.lsd`
+  export (`Game::State#to_lsd`) still does not carry a Common Event's
+  parallel-process position; only the portable Marshal save does. Tracked as
+  a named follow-up in `docs/TODO.md` rather than attempted here.
+
+## Consequences
+
+- **The primary reported gap is fixed for the common, in-session case with
+  full fidelity**, and for the save/load case with a documented, narrower
+  guarantee: a Common Event Parallel Process resumes exactly where it left
+  off across a Transfer Player (its call stack and any in-flight wait
+  countdown included, since the interpreter object itself is never rebuilt),
+  and resumes at its last cleanly-observed command index across a genuine
+  save/load (skipping past, not repeating, a Wait it happened to be mid-way
+  through, and restarting a call stack it happened to be paused inside).
+- **Map Event parallel processes are untouched.** They are never given a
+  `common_event_id`, so neither the teleport-time reuse nor the save-file
+  checkpoint ever applies to them; they keep restarting fresh on every page
+  reselect, exactly as before.
+- **Regression coverage** lives in `scripts/rpg2k_logic_check.rb` (the plain
+  `Game::Interpreter#resumable_index` / `#start_at` contract, including the
+  nested-call-stack and finished-process nil cases, and `Game::State
+  #common_event_progress` round-tripping through `#to_h` / `.load`) and
+  `scripts/rpg2k_scene_check.rb` (an end-to-end Transfer Player check proving
+  both the command index *and* the `wait_timer` countdown survive untouched;
+  an end-to-end save/load check built around the TODO's own example -- a
+  gate switch turning off mid-run, then a Marshal round trip, then the switch
+  turning back on; and a check pinning that a map event's own parallel
+  process still gets a brand-new interpreter, and restarts at index 0, on
+  every visit).
+- **Follow-up work**, both already named in `docs/TODO.md`: decoding chunks
+  113/114's real byte grammar against an actual save taken mid a Common Event
+  Parallel Process (needed before the `.lsd` export can carry this state
+  too); and, if it ever turns out to matter in practice, extending the
+  save/load checkpoint to a position inside a Call Common Event chain (not
+  attempted here since nothing currently records what a call-stack frame's
+  target was, only its return `[list, index]` pair).

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7455,6 +7455,21 @@ module Game
     # chunks 15 / 17); Scene::Map reloads the windowskin when the override
     # changes.
     attr_accessor :system_graphic, :font_id
+    # Last known-good resume position of each running Common Event Parallel
+    # Process, id => a command-list index (see Game::Interpreter
+    # #resumable_index). Unlike a Map Event's parallel process (which always
+    # restarts fresh on every re-trigger, per visit -- deliberately untouched
+    # here), a Common Event's own parallel-process position survives a map
+    # transfer *and* a save/load, so this is what a fresh Scene::Map (built by
+    # Continue, or after Return to Title -> New Game -> Continue) reads to
+    # resume it instead of starting at the top -- see Scene::Map#new_parallel.
+    # An ordinary Transfer Player, by contrast, does not go through this at
+    # all: Scene::Map#build_parallels keeps the live Game::Interpreter object
+    # across it, which preserves full fidelity (call stack, in-flight wait
+    # timer, everything), not just this coarser checkpoint. Persisted in the
+    # portable Marshal save; not yet in `.lsd` (chunks 113/114 are still
+    # opaque, see LCF::Schema::SAVE_FOREGROUND_EVENT / SAVE_COMMON_EVENT).
+    attr_accessor :common_event_progress
 
     def initialize(party, map_id, x, y)
       @party = party
@@ -7486,6 +7501,7 @@ module Game
       @escape_count = 0
       @teleport_targets = {}
       @escape_target = nil
+      @common_event_progress = {}
       @system_bgm = {}
       @system_sfx = {}
       # nil = "not configured yet"; #seed_screen_transitions fills each slot in
@@ -7667,6 +7683,7 @@ module Game
         teleport_access: @teleport_access, escape_access: @escape_access,
         encounter_rate: @encounter_rate, encounter_total: @encounter_total,
         teleport_targets: @teleport_targets,
+        common_event_progress: @common_event_progress,
         steps: @steps,
         save_count: @save_count, battle_count: @battle_count,
         win_count: @win_count, defeat_count: @defeat_count,
@@ -8056,6 +8073,7 @@ module Game
       state.defeat_count = h[:defeat_count] || 0
       state.escape_count = h[:escape_count] || 0
       state.teleport_targets = h[:teleport_targets] || {}
+      state.common_event_progress = h[:common_event_progress] || {}
       state.escape_target = h[:escape_target]
       state.system_bgm = h[:system_bgm] || {}
       state.system_sfx = h[:system_sfx] || {}

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -493,6 +493,41 @@ module Game
       true
     end
 
+    # The position to record for a Common Event Parallel Process that needs to
+    # resume here after a map load (see Game::State#common_event_progress),
+    # instead of restarting at the top -- or nil when the current position
+    # cannot be captured that way.
+    #
+    # @index always points at the next not-yet-executed command, whether or not
+    # we are currently #waiting? on it (a blocking command increments @index
+    # before raising its wait), so it is always a safe resume point on its
+    # own -- restoring it just means a resumed process skips replaying any
+    # remaining Wait duration rather than serving it again, which is the
+    # deliberate scope of what this captures. What it does *not* capture is a
+    # position inside a called list (@call_stack non-empty): unwinding that
+    # would need to re-resolve every pending caller frame (a common or map
+    # event id/page) from scratch, which nothing here tracks. A process
+    # captured mid-call simply keeps whatever position was last recorded before
+    # the call started (see Scene::Map#step_parallel, which only overwrites the
+    # stored checkpoint when this returns non-nil).
+    def resumable_index
+      return nil unless @running && @call_stack.empty?
+      return nil if @index <= 0 || @index >= @list.size
+      @index
+    end
+
+    # Start (or restart) at a previously #resumable_index-captured position
+    # instead of the top of the list. `commands` must be the same command list
+    # (or an equivalent rebuild of it, e.g. the same common event reloaded from
+    # the same database) the index was captured against -- like #start, this
+    # trusts its caller to be resuming the right process rather than validating
+    # it. An out-of-range index (a stale save against edited event data) falls
+    # back to the top, same as #start alone.
+    def start_at(commands, index)
+      start(commands)
+      @index = index if index && index > 0 && index < @list.size
+    end
+
     # Resume after a message/wait/teleport request has been handled.
     def resume
       # A stat command may have queued several level-up messages; show the next

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -927,31 +927,61 @@ class RPG2k
       # parallel trigger plus parallel common events. Each gets its own
       # Game::Interpreter, looped by #step_parallels; a common event that needs a
       # flag carries its gate switch so it only runs while that switch is on.
+      #
+      # A Common Event's own parallel process, unlike a Map Event's, keeps its
+      # interpreter position across a Transfer Player: called again by
+      # #perform_teleport on this same live Scene::Map, this reuses the
+      # still-running Game::Interpreter for any common event id it already had
+      # one for -- full fidelity (call stack, in-flight wait timer, everything,
+      # since it is the very same object), not a reconstruction -- instead of
+      # building a fresh one. Map events are always rebuilt fresh from the
+      # destination map's own event table, matching the existing per-visit-reset
+      # behaviour (unchanged). On the very first build for this scene (a brand
+      # new game, or the fresh Scene::Map Continue/#initialize builds from a
+      # loaded save), there is no previous @parallels to reuse from, so
+      # #new_parallel instead fast-forwards a fresh interpreter to whatever
+      # position #step_parallel last recorded on Game::State before the game
+      # was last saved (see Game::State#common_event_progress) -- a coarser,
+      # index-only continuation, since nothing was kept alive across a save to
+      # resume with full fidelity.
       def build_parallels
+        previous_common = {}
+        (@parallels || []).each do |p|
+          previous_common[p[:common_event_id]] = p if p[:common_event_id]
+        end
         @parallels = []
         @events.each do |e|
           next unless e[:trigger] == TRIGGER_PARALLEL && e[:commands]
-          @parallels.push new_parallel(e[:commands], nil, e)
+          @parallels.push new_parallel(e[:commands], nil, e, nil)
         end
         @common.each do |c|
           next unless c[:trigger] == Game::CommonEvent::PARALLEL && c[:commands]
-          @parallels.push new_parallel(c[:commands],
-                                       c[:need_flag] ? c[:switch_id] : nil, nil)
+          gate = c[:need_flag] ? c[:switch_id] : nil
+          @parallels.push(previous_common[c[:id]] ||
+                           new_parallel(c[:commands], gate, nil, c[:id]))
         end
       rescue StandardError
         @parallels = []
       end
 
       # Build one background process. `event` is the owning map event (so a Move
-      # Event targeting "this event" resolves) or nil for a common event.
-      def new_parallel(commands, gate_switch, event)
+      # Event targeting "this event" resolves) or nil for a common event;
+      # `common_event_id` is that common event's own id, nil for a map event --
+      # it keys both the teleport-time reuse in #build_parallels above and the
+      # save-file continuation this seeds from below.
+      def new_parallel(commands, gate_switch, event, common_event_id)
         it = Game::Interpreter.new(@state)
         it.resolver = @interpreter.resolver
         it.map_info = self
-        it.start(commands)
+        resume_at = common_event_id && @state.common_event_progress[common_event_id]
+        if resume_at
+          it.start_at(commands, resume_at)
+        else
+          it.start(commands)
+        end
         it.event_id = event && event[:id]
         { interp: it, commands: commands, gate_switch: gate_switch,
-          wait_timer: nil, event: event }
+          wait_timer: nil, event: event, common_event_id: common_event_id }
       end
 
       # Advance every background parallel process one frame. They loop their
@@ -977,7 +1007,10 @@ class RPG2k
           # resume, matching drive_event's foreground handling (see there for
           # why: Wait 0.0 sec must cost exactly one frame). Other wait kinds
           # keep their old one-frame-per-call pacing.
-          return apply_interpreter_requests(it, p[:event]) unless wait_kind == :wait && !it.waiting?
+          unless wait_kind == :wait && !it.waiting?
+            apply_interpreter_requests(it, p[:event])
+            return record_parallel_progress(p)
+          end
         end
         if it.running?
           it.update
@@ -990,8 +1023,25 @@ class RPG2k
           it.update
         end
         apply_interpreter_requests(it, p[:event])
+        record_parallel_progress(p)
       rescue StandardError
         nil
+      end
+
+      # Snapshot a Common Event Parallel Process's current position onto
+      # Game::State, so a fresh Scene::Map built later from this state (a
+      # genuine save/load, not a Transfer Player -- see #build_parallels) can
+      # resume it instead of restarting at the top. Only overwrites the stored
+      # checkpoint when the interpreter's position is cleanly capturable right
+      # now (see Game::Interpreter#resumable_index); a tick that returns nil
+      # (mid a nested Call Event) simply leaves the last known-good checkpoint
+      # in place rather than clearing it. A no-op for a map event's own
+      # parallel process (p[:common_event_id] is nil there), which never gets a
+      # checkpoint at all -- it always restarts fresh, unchanged.
+      def record_parallel_progress(p)
+        return unless p[:common_event_id]
+        idx = p[:interp].resumable_index
+        @state.common_event_progress[p[:common_event_id]] = idx if idx
       end
 
       def drive_parallel_wait(p, it)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1128,6 +1128,70 @@ check 'a self-calling common event terminates instead of hanging' do
   ok !it.running?, 'recursion was bounded and the process ended'
 end
 
+# #resumable_index / #start_at back a Common Event Parallel Process's own
+# save-file continuation (Game::State#common_event_progress, driven by
+# Scene::Map -- see scripts/rpg2k_scene_check.rb for the end-to-end version
+# through an actual map/save round trip). These pin the plain interpreter-level
+# contract in isolation.
+check '#resumable_index captures a clean mid-list position; #start_at resumes there' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  commands = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0]),
+              FakeCmd.new(IC::WAIT, [1]),
+              FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0]),
+              FakeCmd.new(IC::WAIT, [1]),
+              FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0])]
+  ok it.resumable_index.nil?, 'nothing captured before the process even starts'
+  it.start(commands)
+  it.update # switch 1 on, then parks at the first Wait
+  eq true, st.switches[1]
+  eq 2, it.resumable_index, 'parked right after the Wait, at the next command'
+
+  it2 = Game::Interpreter.new(new_state)
+  it2.start_at(commands, it.resumable_index)
+  it2.update
+  st2 = it2.instance_variable_get(:@state)
+  eq false, st2.switches[1], '#start_at does not replay commands before the captured index'
+  eq true, st2.switches[2], 'it resumes exactly at the captured index'
+  ok it2.waiting?, 'and parks again at the second Wait, same as a fresh run would'
+end
+
+check '#resumable_index is nil while paused mid a nested Call Event' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  called = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0]),
+            FakeCmd.new(IC::WAIT, [1])]
+  it.resolver = FakeResolver.new(common: { 5 => called })
+  it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),
+            FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update # enters the call, runs its first command, parks on its Wait
+  eq true, st.switches[9], 'inside the called common event'
+  eq false, st.switches[1], 'the caller has not resumed yet'
+  ok it.running?, 'still running, parked inside the call'
+  ok it.resumable_index.nil?,
+     'a position inside a called list is not capturable -- resuming it would ' \
+     'need to re-resolve the pending caller frame, which nothing here tracks ' \
+     '(see Game::Interpreter#resumable_index)'
+end
+
+check '#resumable_index is nil once the process has finished' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+  it.update
+  ok !it.running?
+  ok it.resumable_index.nil?, 'nothing to resume once the list is exhausted'
+end
+
+check '#start_at falls back to the top for an out-of-range index' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  commands = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])]
+  it.start_at(commands, 99) # stale index, e.g. edited event data since the save
+  it.update
+  eq true, st.switches[1], 'an out-of-range index is ignored, same as a fresh #start'
+end
+
 # A resolver that counts every Call Event lookup instead of answering with
 # real commands, so a Call Event round trip stays a one-command no-op (the
 # empty-target early return in do_call_event) whose count is still visible.
@@ -4641,6 +4705,25 @@ check 'player_transparent round-trips through the save' do
   legacy = st.to_h
   legacy.delete(:player_transparent)
   eq false, Game::State.load(db, legacy).player_transparent
+end
+
+check 'common_event_progress (a Parallel Process interpreter checkpoint) round-trips through the save' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.common_event_progress[7] = 3
+  st.common_event_progress[12] = 0 # a real index, not a "no checkpoint" marker
+  loaded = Game::State.load(db, st.to_h)
+  eq({ 7 => 3, 12 => 0 }, loaded.common_event_progress)
+  # A save written before this field existed restores an empty table, so every
+  # common event's parallel process simply starts at the top -- the same
+  # behaviour as before this change existed at all.
+  legacy = st.to_h
+  legacy.delete(:common_event_progress)
+  eq({}, Game::State.load(db, legacy).common_event_progress)
 end
 
 check 'Return to Title Screen raises a :return_title request' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1212,6 +1212,125 @@ check 'parallel common event runs only while its switch gate is on' do
   ok st.variables[3] > 0, 'it should run once the gate switch is on'
 end
 
+# A Common Event's own Parallel Process, unlike a Map Event's, is supposed to
+# keep running from wherever it was across a Transfer Player and a save/load
+# (docs/TODO.md's "Common-event Parallel Process state should survive map
+# changes and saves, unlike a map event's"). The three checks below pin the
+# fix: full fidelity across a Transfer Player (the live interpreter object is
+# kept), a coarser index-only continuation across a save/load (Game::State
+# #common_event_progress), and that a map event's own parallel process is left
+# exactly as before -- always a fresh restart, per visit.
+
+check "a common event's Parallel Process interpreter survives a Transfer Player" do
+  ic = Game::Interpreter::Cmd
+  # Marker A, a multi-frame Wait, marker B: parks mid-list on the Wait, so a
+  # teleport mid-countdown can be told apart from a fresh restart (which would
+  # bump marker A a second time and reset the countdown).
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [add_var_cmd(3), ECmd.new(ic::WAIT, [3]), add_var_cmd(4)])
+  scene = new_scene({}, common: { 7 => ce })
+  st = scene.instance_variable_get(:@state)
+  scene.update # marker A runs, then parks on the Wait (18 frames: Wait 0.3s)
+  eq 1, st.variables[3], 'marker A ran once, before the wait'
+  eq 0, st.variables[4], 'the wait has not elapsed yet'
+
+  # Scene::Map is reused in place across a Transfer Player (#perform_teleport
+  # mutates @map/@state in place, unlike Continue's fresh Scene::Map.new), so
+  # the fix only has to keep #build_parallels from discarding the still-live
+  # Game::Interpreter -- and its own in-flight wait countdown -- for this
+  # common event.
+  scene.send(:perform_teleport, [2, 0, 0, 0])
+  eq 1, st.variables[3], 'the teleport must not have restarted the process from the top'
+  eq 0, st.variables[4], 'nor reset the in-flight wait to a fresh countdown'
+
+  # The wait's countdown had not yet been touched pre-teleport (its timer only
+  # initialises on the next tick after the Wait command runs, see
+  # #drive_parallel_wait, which also spends that first tick), so it takes
+  # exactly 19 more ticks post-teleport to elapse (18 frames counted down plus
+  # the tick that observes zero and resumes) -- proving the countdown itself
+  # carried over untouched, not just the command index. One tick later the
+  # process loops and marker A legitimately runs again, so this stops short of
+  # that.
+  19.times { scene.update }
+  eq 1, st.variables[3], 'marker A still has not re-run'
+  eq 1, st.variables[4], 'the wait elapsed after exactly its original countdown'
+end
+
+check "Transfer Player reuses a common event's Parallel Process interpreter " \
+      "object, but always rebuilds a map event's" do
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 4)
+  pg.event_commands = [add_var_cmd(1)]
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [add_var_cmd(2), ECmd.new(ic::WAIT, [3])])
+  events = { 1 => event(2, 2, pg) }
+  db = fake_db({ 7 => ce })
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, events)
+  # A custom map_maker that hands back the same event table on every load, so
+  # the map event's own parallel process still exists post-teleport to compare
+  # against -- new_scene's default fake_parent always teleports into an empty
+  # map (see the "Tile Substitution does not survive..." check above), which
+  # would make this comparison vacuous for the map-event side.
+  parent = FakeParent.new(db) { |id| fake_map(id, events) }
+  scene = RPG2k::Scene::Map.new(parent, state)
+
+  scene.update
+  parallels_before = scene.instance_variable_get(:@parallels)
+  common_before = parallels_before.find { |p| p[:common_event_id] == 7 }[:interp]
+  map_before = parallels_before.find { |p| p[:event] }[:interp]
+
+  scene.send(:perform_teleport, [1, 0, 0, 0]) # leave and return to the same map
+
+  parallels_after = scene.instance_variable_get(:@parallels)
+  common_after = parallels_after.find { |p| p[:common_event_id] == 7 }[:interp]
+  map_after = parallels_after.find { |p| p[:event] }[:interp]
+  ok common_before.equal?(common_after),
+     "a common event's parallel process keeps its own interpreter across a teleport"
+  ok !map_before.equal?(map_after),
+     "a map event's parallel process still gets a brand-new interpreter every " \
+     'visit -- unaffected by the reuse above, unchanged from before this fix'
+  ok map_after.instance_variable_get(:@index).zero?,
+     "the rebuilt map event's parallel process starts over at the top"
+end
+
+check "a common event's Parallel Process resumes where it left off after a " \
+      'save/load, not from the top' do
+  ic = Game::Interpreter::Cmd
+  # This is the TODO's own example: a Common Event's Parallel Process whose
+  # gate switch turns off mid-run. Marker A / Wait / marker B / Wait / marker C
+  # tells apart "resumed right after the wait it was parked at" from "restarted
+  # at the top" (which would bump marker A again instead of leaving it alone).
+  ce = OpenStruct.new(start_term: 4, need_flag: true, switch_id: 2,
+                      event: [add_var_cmd(3), ECmd.new(ic::WAIT, [1]),
+                              add_var_cmd(4), ECmd.new(ic::WAIT, [1]),
+                              add_var_cmd(5)])
+  db = fake_db({ 7 => ce })
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+
+  state.switches[2] = true # the gate opens
+  scene.update # marker A runs, then parks at the first Wait
+  eq 1, state.variables[3], 'marker A ran before the wait'
+  state.switches[2] = false # "its switch turns off mid-run" -- ticking stops here
+
+  # A Marshal round trip stands in for an actual save/load, exactly like the
+  # other State round-trip checks in scripts/rpg2k_logic_check.rb.
+  restored = Game::State.load(db, Marshal.load(Marshal.dump(state.to_h)))
+  restored.map = fake_map(1, {})
+  eq false, restored.switches[2], 'the save preserved the gate switch off'
+  eq 1, restored.variables[3], 'and the run-so-far progress'
+
+  fresh = RPG2k::Scene::Map.new(fake_parent(db), restored)
+  restored.switches[2] = true # re-enable it, as the TODO's own example does
+  fresh.update
+  eq 1, restored.variables[3],
+     'must NOT restart from the top (that would bump this a second time)'
+  eq 1, restored.variables[4], 'instead it resumes right where the save left it'
+  eq 0, restored.variables[5], 'and parks again at the second wait, same as before the save'
+end
+
 # A lightweight party for the inn tests: resume_inn only needs gold + a party
 # roster whose members respond to full_heal, and Scene::Map reads party.leader.
 class InnStubActor


### PR DESCRIPTION
## Summary

Fixes the `docs/TODO.md` "Common-event Parallel Process state should survive map changes and saves, unlike a map event's" gap.

Within one map visit, a Common Event's Parallel Process interpreter position was already resumed correctly (`Scene::Map#step_parallel`'s `gate_switch` resumes the same interpreter). But `perform_teleport` and `Scene::Map#initialize` unconditionally rebuilt *every* parallel process from scratch via `build_parallels`, and `Game::State` had no field at all for interpreter/parallel-continuation state.

This is scoped per the task's own permission to narrow an architecturally-significant gap into a smaller, verifiably-correct PR (see ADR 0044 for the full write-up):

- **Transfer Player (in-session):** `build_parallels` now keys its previous `@parallels` entries by common-event id and reuses the still-running `Game::Interpreter` across a teleport, since `Scene::Map` is the *same instance* before and after (`perform_teleport` mutates `@map`/`@state` in place). This needs no serialization and preserves **full fidelity** — call stack, in-flight Wait countdown, everything.
- **Save/load:** a genuine save/load builds a brand-new `Scene::Map`, so there's no live object to reuse. `Game::Interpreter#resumable_index` captures the interpreter's current command index whenever it's safely capturable (not paused mid a nested Call Event, whose frames nothing tracks how to re-resolve). `Scene::Map#step_parallel` records it every tick onto the new `Game::State#common_event_progress` (id → index); `Scene::Map#new_parallel` seeds a fresh interpreter from it via the new `Game::Interpreter#start_at`.
- A **Map Event's** own parallel process is untouched — no common-event id, so neither mechanism applies; it still restarts fresh on every visit.
- The `.lsd` export is deliberately left alone: LCF save chunks 113/114 are known to hold this kind of state but their internal byte grammar is undocumented (would need a real save decode to add honestly, matching this codebase's existing standard for schema fields) — tracked as a named follow-up in `docs/TODO.md`, not attempted here. Only the portable Marshal save carries the new field.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 667 checks passed (5 new: `Game::Interpreter#resumable_index`/`#start_at` contract incl. nested-call-stack and finished-process nil cases, and `Game::State#common_event_progress` round-tripping through `#to_h`/`.load`).
- `ruby scripts/rpg2k_scene_check.rb` — 317 checks passed (3 new end-to-end checks: a Transfer Player check proving both the command index *and* the in-flight Wait countdown survive untouched; a save/load check built around the TODO's own example — a gate switch turning off mid-run, then a Marshal round trip, then the switch turning back on; and a check pinning that a map event's own parallel process still gets a brand-new interpreter, restarting at index 0, on every visit).
- All 8 new checks confirmed to **fail against the pre-fix code** (verified by stashing the implementation changes and re-running, keeping only the new checks).
- `ruby scripts/rpg2k_render_check.rb` — 40 checks passed (unaffected, run for completeness).
- `scripts/rpg2k_testbed_logic_check.rb` / `scripts/rpg2k_save_load_check.rb` — skipped gracefully (no test-bed game data in this environment); unaffected by this change regardless (additive fields with safe defaults).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GZK9D6VnLND288MR1YTwZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZK9D6VnLND288MR1YTwZr)_