### PR TITLE
rpg2k: a Teleport/Escape field skill's warp no longer clears Pictures

### DIFF
--- a/changelog.d/teleport-escape-skill-keeps-pictures.fixed.md
+++ b/changelog.d/teleport-escape-skill-keeps-pictures.fixed.md
@@ -1,0 +1,11 @@
+- **A Teleport/Escape field skill's warp no longer clears shown Pictures.**
+  `Scene::Map#perform_teleport` unconditionally erased every shown picture on
+  any map change, but yado.tk documents the Teleport/Escape skill/item's own
+  warp as a deliberate exception to that rule — only an ordinary map change
+  (the Transfer Player / Recall to Location event commands) clears pictures.
+  `perform_teleport` now takes a `keep_pictures:` flag, set from the
+  `@state.pending_teleport` call site the field skill's warp is applied
+  through; the interpreter's own `:teleport` wait (Transfer Player / Recall
+  to Location) keeps clearing pictures as before. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2395,7 +2395,22 @@ not yet verified:
   characters always draw below all pictures" as its own assertion.
 - Changing maps **auto-clears every picture** — except when the transfer
   was via Teleport or Escape, which is an explicit, deliberate exception
-  (multiply corroborated).
+  (multiply corroborated). ✅ **The Teleport/Escape skill/item half of this
+  is now implemented.** `Scene::Map#perform_teleport` (the one method both
+  an ordinary map change and a Teleport/Escape field skill's warp route
+  through — the latter via `@state.pending_teleport`, queued by
+  `Game::Party#cast_teleport_skill`/`#cast_escape_skill` and applied in
+  `Scene::Map#update`, see the "a pending teleport queued by the field
+  skill menu is applied" check) called `@state.erase_all_pictures`
+  unconditionally, so a Teleport/Escape warp wrongly dropped the party's
+  pictures the same way an ordinary Transfer Player does. `perform_teleport`
+  now takes a `keep_pictures:` keyword, `false` by default (the interpreter's
+  own `:teleport` wait — Transfer Player, Recall to Location — still clears
+  pictures, matching the already-covered "a teleport clears every shown
+  picture" check) and `true` at the `pending_teleport` call site. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check ("a Teleport/Escape field skill
+  warp does not clear shown pictures"), confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **Picture commands (Show/Move/Erase) are now fully suppressed while any
   message window or choice list is open**, anywhere, including inside an
   already-running parallel process — an unconditional engine limitation with

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -223,7 +223,7 @@ class RPG2k
             @state.boarded = nil
             restore_pre_vehicle_bgm
           end
-          perform_teleport(@state.pending_teleport)
+          perform_teleport(@state.pending_teleport, keep_pictures: true)
           @state.pending_teleport = nil
           animate_events
           render
@@ -4769,7 +4769,15 @@ class RPG2k
         tenths * fr / 10
       end
 
-      def perform_teleport(t)
+      # `keep_pictures` is false for an ordinary map transfer (the Transfer
+      # Player / Recall to Location event commands, which arrive via the
+      # interpreter's own `:teleport` wait) and true for the one documented
+      # exception: a Teleport or Escape field skill/item, whose destination
+      # arrives here via `@state.pending_teleport` instead (see #update).
+      # yado.tk: changing maps clears every shown picture *except* via a
+      # Teleport/Escape skill, a deliberate, distinct rule from an ordinary
+      # map change.
+      def perform_teleport(t, keep_pictures: false)
         map_id, x, y, dir = t
         @map = @parent.load_map(map_id)
         @state.map = @map
@@ -4782,8 +4790,9 @@ class RPG2k
         # the edition that added a per-picture "keep across map change" flag).
         # Without this, Nepheshel's opening leaves its full-screen credit
         # pictures on top of the first room and the map is never visible —
-        # exactly what the wine comparison showed (ADR 0021).
-        @state.erase_all_pictures
+        # exactly what the wine comparison showed (ADR 0021). Not for a
+        # Teleport/Escape skill's own warp, though — see `keep_pictures` above.
+        @state.erase_all_pictures unless keep_pictures
         # A Change Parallax Background override does not survive a teleport
         # either; the destination map's own panorama applies. Rebuild the
         # backdrop from the new map so it isn't drawn with the old one.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5932,6 +5932,19 @@ check 'Scene::Map: a pending teleport queued by the field skill menu is applied'
   ok state.pending_teleport.nil?, 'the request is consumed, not reapplied every frame'
 end
 
+check 'a Teleport/Escape field skill warp does not clear shown pictures' do
+  # Unlike the Transfer Player event command ('a teleport clears every shown
+  # picture' above), yado.tk documents the Teleport/Escape field skill's own
+  # warp as a deliberate exception -- pictures survive it.
+  scene = new_scene({}, player: [0, 0])
+  state = scene.instance_variable_get(:@state)
+  state.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
+  state.pending_teleport = [1, 3, 4, 6] # same map id, elsewhere on it, facing left
+  scene.update
+  eq 1, state.map_id, 'teleported'
+  ok state.pictures.key?(1), 'the picture survived the field-skill warp'
+end
+
 # One map-tree node's save/teleport/escape tri-states (parent_map_id left nil
 # -- MapAccess#allowed? reads a missing one as 0, the tree root). Mirrors
 # scripts/rpg2k_logic_check.rb's own fixture of the same name; reused here to


### PR DESCRIPTION
## Summary

- yado.tk's Picture quirks page states: changing maps auto-clears every shown Picture — **except** when the transfer was via a Teleport or Escape field skill/item, which is a documented, deliberate exception (`docs/TODO.md`'s "yado.tk quirks backlog" → "Full-site sweep" → **Pictures**).
- `Scene::Map#perform_teleport` is the one method both an ordinary map change (Transfer Player / Recall to Location, via the interpreter's own `:teleport` wait) and a Teleport/Escape field skill's warp (via `@state.pending_teleport`, queued by `Game::Party#cast_teleport_skill`/`#cast_escape_skill` and applied in `Scene::Map#update`) route through — and it called `@state.erase_all_pictures` unconditionally, so the skill/item warp wrongly dropped the party's pictures the same way an ordinary map change correctly does.
- `perform_teleport` now takes a `keep_pictures:` keyword (default `false`, preserving the existing, already-tested behavior for Transfer Player/Recall to Location), set to `true` only at the `pending_teleport` call site.

## Test plan

Regression check added to `scripts/rpg2k_scene_check.rb` ("a Teleport/Escape field skill warp does not clear shown pictures"), confirmed to fail against the pre-fix code (`RuntimeError: the picture survived the field-skill warp`) before the fix, and the existing "a teleport clears every shown picture" check confirms ordinary map transfers are unaffected.

```
$ ruby scripts/rpg2k_scene_check.rb
...
rpg2k scene check: 321 checks passed

$ ruby scripts/rpg2k_logic_check.rb
...
rpg2k logic check: 664 checks passed
```

Also updated `docs/TODO.md` to mark this half of the existing "Changing maps auto-clears every picture — except via Teleport or Escape" backlog bullet ✅, and added a `changelog.d/teleport-escape-skill-keeps-pictures.fixed.md` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMCTMUFTKhf8imAqP5PgqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMCTMUFTKhf8imAqP5PgqC)_