### PR TITLE
rpg2k: a move-route Face Direction sub-command overrides Direction Fix

### DIFF
--- a/changelog.d/move-route-face-direction-overrides-lock.fixed.md
+++ b/changelog.d/move-route-face-direction-overrides-lock.fixed.md
@@ -1,0 +1,12 @@
+- **A move-route "Face Direction" sub-command now always turns the sprite,
+  even right after a "Direction Fix ON" earlier in the same route.**
+  `Game::MoveRoute#apply_command`'s Face Up/Right/Down/Left/Random/Hero/
+  Away-from-Hero sub-commands routed through `Character#face`, which
+  respects the Direction Fix lock (`facing_locked`) — correct for the
+  *movement-driven* facing changes `#move`/`#jump`/`#move_diagonal` make as a
+  side effect, but not for an explicit Face Direction command, which RPG_RT
+  always honours regardless of the lock (the move-route Turn Right/Left/180/
+  Random sub-commands already bypassed it by writing `@direction` directly).
+  Fixed with a new lock-ignoring `Character#face!`, now used by all seven
+  Face Direction sub-commands. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check, confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2316,10 +2316,38 @@ not yet verified:
   (appearance-condition-unmet) map event.
 - "Through Mode: Begin" without a matching "End" leaves the character
   permanently able to pass through walls.
-- "Face Direction" always overrides Fixed Direction/Animation Type. After
-  Fixed-Direction movement (or after a diagonal move), "One Step Forward"
-  continues in the **last direction actually moved**, not the displayed
-  facing.
+- ✅ **A move-route "Face Direction" sub-command always overrides an earlier
+  "Direction Fix ON" (Lock Facing) in the same route.** Direction Fix only
+  ever suppresses the facing change an *ordinary move* would otherwise cause
+  (matching "Through Mode"'s and "Change Graphic"'s own don't-touch-explicit-
+  overrides pattern above) — it does not also swallow a later *explicit*
+  turn. `Game::MoveRoute#apply_command`'s Turn Right/Left/180/Random
+  sub-commands (`Character#turn_right`/`#turn_left`/`#turn_around`) already
+  wrote `@direction` directly, bypassing `facing_locked` entirely, but the
+  Face Up/Right/Down/Left/Random/Hero/Away-from-Hero sub-commands all routed
+  through `Character#face`, which *does* respect the lock
+  (`@direction = dir unless @facing_locked || dir.nil?`) — the same method
+  ordinary movement uses to update facing as a side effect, and correctly
+  should keep respecting it. Fixed by giving `Character` a second method,
+  `#face!` (lock-ignoring, mirrors the Turn commands' direct-write), and
+  routing the seven Face Direction sub-commands through it instead of
+  `#face`; `#move`/`#jump`/`#move_diagonal`'s own movement-driven facing
+  still goes through the original `#face` and still respects the lock,
+  unchanged. Covered by a new `scripts/rpg2k_logic_check.rb` check (Direction
+  Fix ON, then a Move Right that keeps the facing frozen, then a Face Up that
+  turns north despite the still-active lock), confirmed to fail against the
+  pre-fix code (asserting direction 8, getting 2) before the fix. **Still
+  open, a related but separate question, not addressed by this fix**: after a
+  Fixed-Direction move (or a diagonal move), "One Step Forward" is documented
+  to continue in the *last direction actually moved* rather than the
+  displayed facing — this codebase's `Game::Character` has only the one
+  `@direction` field for both (see its `#jump` doc comment), so implementing
+  this would need a second "last movement direction" field threaded through
+  `#move`/`#jump`/`#move_diagonal` and read by Move Route's `MOVE_FORWARD`
+  instead of `#direction`, a distinct enough change to scope out here. The
+  "Animation Type" half of the original claim (whether an Animation Type
+  setting is also overridden by a Face Direction command) is unverified
+  either way.
 - Jump needs paired Begin/End; movement commands between them sum into a
   net displacement vector (opposite-axis moves cancel); only the *landing*
   tile's passability is tested, tiles crossed are ignored; speed/direction

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3431,9 +3431,22 @@ module Game
       Character.step_tile(@x, @y, dir)
     end
 
-    # Turn to face `dir` without moving (a no-op while facing is locked).
+    # Turn to face `dir` without moving (a no-op while facing is locked) --
+    # movement-driven facing only (#move, #jump, #move_diagonal). An explicit
+    # Face Direction / Turn move-route sub-command always wins over a prior
+    # Direction Fix ON in the same route (yado.tk); see #face!.
     def face(dir)
       @direction = dir unless @facing_locked || dir.nil?
+    end
+
+    # Turn to face `dir`, ignoring the Direction Fix lock. The move-route
+    # "Face Up/Right/Down/Left/Random/Hero/Away from Hero" sub-commands use
+    # this (Turn Right/Left/180/Random already bypassed the lock by writing
+    # @direction directly) -- Direction Fix only suppresses the facing change
+    # that would otherwise happen from an ordinary move, not an explicit
+    # facing command issued later in the same route.
+    def face!(dir)
+      @direction = dir unless dir.nil?
     end
 
     # Whether the move just made was a jump (a Begin Jump / End Jump block)
@@ -3658,8 +3671,11 @@ module Game
         do_move(character, world, away_hero(character, world))
       when MOVE_FORWARD
         do_move(character, world, character.direction)
+      # A Face Direction sub-command always turns the sprite, even right after
+      # a Direction Fix ON earlier in the same route (yado.tk) -- #face!, not
+      # the lock-respecting #face movement uses.
       when FACE_UP, FACE_RIGHT, FACE_DOWN, FACE_LEFT
-        character.face(FACE_DIR[id]); [:turned, true]
+        character.face!(FACE_DIR[id]); [:turned, true]
       when TURN_RIGHT then character.turn_right;  [:turned, true]
       when TURN_LEFT  then character.turn_left;   [:turned, true]
       when TURN_180   then character.turn_around; [:turned, true]
@@ -3667,9 +3683,9 @@ module Game
         world.random(2) == 0 ? character.turn_right : character.turn_left
         [:turned, true]
       when FACE_RANDOM
-        character.face(Character::CARDINALS[world.random(4)]); [:turned, true]
-      when FACE_HERO      then character.face(toward_hero(character, world)); [:turned, true]
-      when FACE_AWAY_HERO then character.face(away_hero(character, world));  [:turned, true]
+        character.face!(Character::CARDINALS[world.random(4)]); [:turned, true]
+      when FACE_HERO      then character.face!(toward_hero(character, world)); [:turned, true]
+      when FACE_AWAY_HERO then character.face!(away_hero(character, world));  [:turned, true]
       when WAIT       then [:waited, true]
       when BEGIN_JUMP then do_jump(character, world)
       when END_JUMP   then [:effect, true] # an End Jump with no Begin: skipped

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -403,6 +403,23 @@ check 'face and turn commands change facing only' do
   eq [5, 5], [c.x, c.y]
 end
 
+check 'a Face Direction sub-command overrides an earlier Direction Fix ON in the same route' do
+  # yado.tk: Direction Fix only suppresses the facing change an ordinary move
+  # would otherwise cause -- an explicit Face Up/Right/Down/Left (or Turn)
+  # sub-command later in the same route still turns the sprite.
+  route = R.new([mc(R::LOCK_FACING), mc(R::MOVE_RIGHT), mc(R::FACE_UP)],
+                repeat: false)
+  c = Game::Character.new(5, 5, 2) # facing south
+  w = FakeWorld.new
+  route.step(c, w) # Direction Fix ON
+  eq true, c.facing_locked
+  route.step(c, w) # Move Right: steps east, facing stays south -- the lock holds
+  eq [6, 5], [c.x, c.y]
+  eq 2, c.direction
+  route.step(c, w) # Face Up: turns north despite the still-active lock
+  eq 8, c.direction
+end
+
 check 'switch on/off route commands drive the world switches' do
   route = R.new([mc(R::SWITCH_ON, a: 7), mc(R::SWITCH_OFF, a: 3)], repeat: false)
   c = Game::Character.new(0, 0)


### PR DESCRIPTION
## Summary

- yado.tk's move-route quirks page (`docs/TODO.md`'s "Move Route / Character Movement command" section) states that a "Face Direction" sub-command always turns the sprite, even right after a "Direction Fix ON" (Lock Facing) earlier in the same route — Direction Fix only ever suppresses the facing change an *ordinary move* would otherwise cause, not an explicit later turn.
- `Game::MoveRoute#apply_command`'s Face Up/Right/Down/Left/Random/Hero/Away-from-Hero sub-commands all routed through `Character#face`, which respects the `facing_locked` flag — correct for `#move`/`#jump`/`#move_diagonal`'s own movement-driven facing updates, but wrong for an explicit Face Direction command. The Turn Right/Left/180/Random sub-commands already bypassed the lock (by writing `@direction` directly), so this was an inconsistency between the two "explicit facing" command families, not a deliberate design choice.
- Fixed by adding a lock-ignoring `Character#face!` and routing the seven Face Direction sub-commands through it; `#face` (and everything that calls it for movement-driven facing) is unchanged.
- Scoped down from the full yado.tk bullet: the related "One Step Forward continues in the *last direction actually moved*, not the displayed facing" claim needs a second "last movement direction" field on `Game::Character` (today `@direction` serves both roles — see its `#jump` doc comment) and is recorded as a separate, still-open follow-up in `docs/TODO.md` rather than folded into this change. The "Animation Type" half of the original claim is also left unverified.

## Test plan

Both required checks pass, including the new regression check (confirmed to fail against the pre-fix code before the fix — asserting direction `8`, getting `2`):

```
$ ruby scripts/rpg2k_logic_check.rb
...
rpg2k logic check: 674 checks passed

$ ruby scripts/rpg2k_scene_check.rb
...
rpg2k scene check: 329 checks passed
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01ArUajHJYRYeQJdRuTXrCo6)_