### PR TITLE
rpg2k: Simulated Attack (Damage Processing) hard-caps damage at 999

### DIFF
--- a/changelog.d/simulated-attack-damage-cap.fixed.md
+++ b/changelog.d/simulated-attack-damage-cap.fixed.md
@@ -1,0 +1,10 @@
+- **Simulated Attack (10500) damage is now hard-capped at 999**, matching
+  the same fixed-three-digit-popup cap already applied to a normal attack,
+  an attack skill/item, an enemy self-destruct, and per-turn state slip
+  damage (`Game::Battle::DAMAGE_CAP`). This raw event command computes its
+  own damage independently of `Game::Battle` and had no such ceiling, so a
+  high enough Attack Power parameter could deal (and report, via its
+  store-in-variable option) far more than RPG_RT's damage display could
+  ever show. `Game::Interpreter#do_simulated_attack` now clamps its
+  computed damage to `Game::Battle::DAMAGE_CAP` before applying it to HP
+  or writing it to a variable.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2695,6 +2695,24 @@ not yet verified:
   high-ATK, always-critical normal attack against a defenceless target
   clamps at 999 rather than the uncapped 6000 (2000 base × 3 crit), and an
   attack skill computing a raw 5000 HP hit likewise clamps at 999.
+  **A fifth site was missed by this fix and is now covered too: Simulated
+  Attack (10500, "Damage Processing" in the yado.tk write-up), the raw
+  event command that hurts a target with no attacker at all.**
+  `Game::Interpreter#do_simulated_attack` (`mruby-rpg2k/mrblib/
+  interpreter.rb`) computes its own damage independently of `Game::Battle` —
+  `atk - def * p_def / 400 - int * p_spi / 800`, matching the yado.tk
+  finding that this command's defence/spirit "effectiveness" percentages
+  divide by 4 and 8 respectively rather than the normal attack's own
+  `ATK÷2 − DEF÷4` formula (**confirmed already correct**, no change needed
+  for the formula itself) — and had no ceiling on the result, so a large
+  enough Attack Power parameter could apply (and report through the
+  command's store-in-variable option) far more than 999 in one hit. Fixed
+  by clamping to the same `Game::Battle::DAMAGE_CAP` before it reaches
+  `Actor#change_hp` or the result variable. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a 5000-power Simulated Attack
+  against a defenceless, high-max-HP target clamps at 999, both in the HP
+  change and the stored variable), confirmed to fail against the pre-fix
+  code.
 - Turn-order tie-break on equal Agility: hero acts before an equal-agility
   enemy; among tied heroes, lower actor ID acts first.
 - The party "exhaustion %" battle-event condition is computed as
@@ -2737,12 +2755,17 @@ not yet verified:
   member and a wounded one confirms the Skill/Item path skips the downed
   member entirely while still healing the wounded member normally (true
   both before and after, since that path was never broken).
-- Damage Processing (the raw event command) uses a **different formula**
-  from the built-in normal attack: normal attack = `(ATK÷2) − (DEF÷4)`,
-  but this command computes `AttackPower − (DEF÷4)` with **no automatic
-  halving** of the given Attack Power — replicating a normal attack
-  requires manually halving the parameter first. Defense-effectiveness
-  100% = DEF/4 (not full DEF); Spirit-effectiveness 100% = Mind/8.
+- ✅ Damage Processing (the raw event command, Simulated Attack 10500) uses a
+  **different formula** from the built-in normal attack: normal attack =
+  `(ATK÷2) − (DEF÷4)`, but this command computes `AttackPower − (DEF÷4)`
+  with **no automatic halving** of the given Attack Power — replicating a
+  normal attack requires manually halving the parameter first.
+  Defense-effectiveness 100% = DEF/4 (not full DEF); Spirit-effectiveness
+  100% = Mind/8. **Confirmed already correct** —
+  `Game::Interpreter#do_simulated_attack` already implements exactly this
+  formula — but the command was missing the same 999 damage cap every other
+  damage path has, which is now fixed; see the fuller writeup under the
+  "Damage is hard-capped below 1000 (999)" bullet above.
 - ✅ Multiple active states: only the highest-priority one is **displayed**
   (`Game::States.significant`, unchanged), but all active states still
   mechanically apply (a hidden poison keeps ticking under a displayed

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1709,6 +1709,11 @@ module Game
     # The formula is EasyRPG Player's CommandSimulatedAttack, which mirrors
     # RPG_RT: `atk - def * p_def / 400 - spi * p_spi / 800`, then spread by
     # +/- (param5 * 5) percent and floored at 0. The hit can be lethal.
+    #
+    # RPG_RT's damage popup is a fixed three digits (the same reasoning behind
+    # `Game::Battle::DAMAGE_CAP` on the normal-attack/skill/self-destruct/
+    # slip-damage paths), so a Simulated Attack's own computed damage is
+    # clamped at 999 too before it reaches HP or the result variable.
     def do_simulated_attack(cmd)
       atk = cmd.param(2)
       damage = 0
@@ -1716,6 +1721,7 @@ module Game
         damage = atk - (a.def * cmd.param(3)) / 400 - (a.int * cmd.param(4)) / 800
         damage += damage * simulated_attack_spread(cmd.param(5)) / 100
         damage = 0 if damage < 0
+        damage = Battle::DAMAGE_CAP if damage > Battle::DAMAGE_CAP
         a.change_hp(-damage, true)
       end
       variables[cmd.param(7)] = damage if cmd.param(6) != 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8171,6 +8171,22 @@ check 'Simulated Attack floors the damage at zero' do
   eq 100, st.party.actor_by_id(1).hp
 end
 
+# Same fixed-3-digit-popup reasoning as the normal-attack/skill/self-destruct/
+# slip-damage cap (Game::Battle::DAMAGE_CAP) applies to this raw event
+# command's own damage too -- it shares no code path with any of those four,
+# so it needed its own clamp.
+check 'Simulated Attack hard-caps damage at 999, matching the battle damage cap' do
+  players = { 1 => FakePlayerRow.new('Tank', '', 0, 5, max_hp: 5000, max_mp: 0, atk: 0, def: 0) }
+  st = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1])), 1, 0, 0)
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 1, atk 5000, def-weight 0, spi-weight 0, variance 0,
+  # store-damage flag 1 -> var 1.
+  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 5000, 0, 0, 0, 1, 1])])
+  it.update
+  eq 999, st.variables[1], 'capped, not the uncapped 5000'
+  eq 5000 - 999, st.party.actor_by_id(1).hp
+end
+
 check 'Change Actor Face overrides the actor FaceSet' do
   st = party_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s yado.tk backlog documents Simulated Attack (event command
  10500, "Damage Processing" in the site's own terms) as using a different
  damage formula from the built-in normal attack (`AttackPower − DEF/4 −
  MIND/8`, with no automatic ATK halving). Reading `Game::Interpreter#do_simulated_attack`
  confirms that formula was already implemented correctly — nothing to fix
  there.
- What it was missing: the same fixed-three-digit-popup damage cap
  (`Game::Battle::DAMAGE_CAP = 999`) already applied to the four
  `Game::Battle` damage paths (normal attack, attack skill/item, enemy
  self-destruct, per-turn state slip damage). Simulated Attack computes its
  own damage entirely independently of `Game::Battle`, so it never got that
  clamp — a high enough Attack Power parameter could deal (and report
  through the command's store-in-variable option) far more than RPG_RT's
  display could ever show in one hit.
- `Game::Interpreter#do_simulated_attack` now clamps its computed damage to
  `Game::Battle::DAMAGE_CAP` before it reaches `Actor#change_hp` or the
  result variable — the same one-line pattern the four existing sites use.
- `docs/TODO.md` updated: the existing damage-cap ✅ entry now notes this
  fifth site, and the separate "Damage Processing uses a different formula"
  bullet is marked ✅ (formula confirmed already correct; cap now fixed),
  pointing back at the fuller writeup.
- `changelog.d/simulated-attack-damage-cap.fixed.md` added per the repo's
  changelog-fragment convention.

## Test plan

```
$ ruby scripts/rpg2k_logic_check.rb
...
rpg2k logic check: 674 checks passed

$ ruby scripts/rpg2k_scene_check.rb
...
rpg2k scene check: 329 checks passed
```

The new check ("Simulated Attack hard-caps damage at 999, matching the
battle damage cap") was confirmed to fail against the pre-fix code
(`expected 999, got 5000`) before the fix was applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSS9VMgeb54NSmJG1wAJ4v)_