### PR TITLE
rpg2k: battle turn-order agility ties among allies break by actor id

### DIFF
--- a/changelog.d/battle-turn-order-tie-actor-id.fixed.md
+++ b/changelog.d/battle-turn-order-tie-actor-id.fixed.md
@@ -1,0 +1,11 @@
+- **A battle turn-order tie between two allies now breaks by the lower
+  actor id, not party seat order.** `Game::Battle#turn_order` tie-broke an
+  agility tie by each battler's position in the `@allies + @enemies` array
+  (party seat/join order, which `Game::Party#add_actor` builds by append —
+  it can diverge from actor id once a member has left and rejoined behind a
+  different one). Real RPG_RT ties by actor id instead. Also hardened the
+  existing "an ally always acts before an equally-fast enemy" rule to key
+  off whether a `Combatant` carries a source actor at all, rather than
+  relying on every ally happening to sit at a lower array index than every
+  enemy. Regression coverage added to `scripts/rpg2k_logic_check.rb`,
+  confirmed to fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2695,8 +2695,32 @@ not yet verified:
   high-ATK, always-critical normal attack against a defenceless target
   clamps at 999 rather than the uncapped 6000 (2000 base × 3 crit), and an
   attack skill computing a raw 5000 HP hit likewise clamps at 999.
-- Turn-order tie-break on equal Agility: hero acts before an equal-agility
-  enemy; among tied heroes, lower actor ID acts first.
+- ✅ **Turn-order tie-break on equal Agility: an ally acts before an
+  equal-agility enemy; among tied allies, the lower actor id acts first.**
+  The ally-before-enemy half was already correct by construction —
+  `Game::Battle#turn_order`'s `sort_by` tie-broke on each battler's index in
+  `(@allies + @enemies).reject(&:out_of_play?).each_with_index`, and since
+  `@allies` is concatenated first, every surviving ally always carried a
+  lower index than every surviving enemy — but the **among-tied-allies**
+  half was a genuine gap: that same index reflects party **seat/join
+  order**, not actor id. `Game::Party#add_actor` (`mruby-rpg2k/mrblib/
+  game.rb`) appends to `@actors` on join, so seat order only matches id
+  order until a member has left and rejoined behind a different one (the
+  same seat-vs-id split already documented in the "Hero X is in the party"
+  bullet above) — at that point two same-agility allies would tie-break by
+  whichever happened to occupy the earlier seat, not by the lower id RPG_RT
+  actually uses. Fixed by widening `turn_order`'s sort key: a new
+  `b.actor ? 0 : 1` term ranks any battler carrying a source `Game::Actor`
+  (i.e. an ally — `Game::Battle.from_actor` always sets `Combatant#actor`,
+  and an enemy `Combatant` never does) ahead of one that doesn't,
+  independent of array position, making the ally-before-enemy rule
+  structural rather than incidental; the final tie key is `b.actor.id` for
+  an ally instead of the old positional `i`. An enemy tie has no documented
+  ordering rule and keeps its prior troop-definition-order tie-break via
+  `i`, unchanged. Covered by a new `scripts/rpg2k_logic_check.rb` check (two
+  allies seated out of id order, plus an equally-fast enemy, resolve
+  ally-id-1 → ally-id-2 → enemy), confirmed to fail against the pre-fix
+  code.
 - The party "exhaustion %" battle-event condition is computed as
   `100 − 100×((ΣHP/ΣMaxHP×2 + ΣMP/ΣMaxMP)÷3)` — HP weighted twice MP's
   weight.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6442,15 +6442,26 @@ module Game
       @queue = @queue.reject { |b| side_of(b) == :enemy } if @first_strike && @rounds == 1
     end
 
-    # Battlers ordered by agility (highest first, ties keeping their listed
-    # order) -- except a battler whose round is about to be a basic Attack
-    # with a `preemptive` weapon equipped sorts before everyone else
-    # (EasyRPG's `CreateExecutionOrder` adding 9999 to such a battler's
-    # computed order, which in practice always outruns ordinary agility).
-    # Ties between two preemptive battlers still fall back to agility.
+    # Battlers ordered by agility (highest first) -- except a battler whose
+    # round is about to be a basic Attack with a `preemptive` weapon equipped
+    # sorts before everyone else (EasyRPG's `CreateExecutionOrder` adding
+    # 9999 to such a battler's computed order, which in practice always
+    # outruns ordinary agility). Ties between two preemptive battlers still
+    # fall back to agility. On an agility tie, an ally always acts before an
+    # enemy (whether `Combatant#actor` is set ranks 0 below an unset one's 1,
+    # independent of either's magnitude, rather than relying on array
+    # position happening to list every ally before every enemy); among tied
+    # allies specifically, the
+    # **lower actor id** acts first -- not party seat/join order, which can
+    # diverge from id order once a member has left and rejoined in a
+    # different slot (`Game::Party#add_actor` appends to `@actors` in join
+    # order, not id order -- see the "seat order" note on `Party#actors`).
+    # An enemy tie has no documented ordering rule, so it keeps its troop
+    # (definition) order via `i`, same as before.
     def turn_order
       (@allies + @enemies).reject(&:out_of_play?).each_with_index
-                          .sort_by { |b, i| [preemptive_boost?(b) ? 0 : 1, -effective_agi(b), i] }
+                          .sort_by { |b, i| [preemptive_boost?(b) ? 0 : 1, -effective_agi(b),
+                                              b.actor ? 0 : 1, b.actor ? b.actor.id : i] }
                           .map { |b, _| b }
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7490,6 +7490,25 @@ check 'battle: a state that halves AGI drops a battler behind a slower one in tu
   eq [slow, fast], bat2.send(:turn_order), 'halved to 10 agi: now behind the foe'
 end
 
+# Anything responding to #id, standing in for the Game::Actor a real allied
+# Combatant carries in its #actor field (see Game::Battle.from_actor).
+FakeActorRef = Struct.new(:id)
+
+check 'battle: an agility tie among allies breaks by actor id, not seat order' do
+  # Actor id 2 sits in the party's first seat, actor id 1 in the second --
+  # mirrors a party where a lower-id member left and rejoined behind a
+  # higher-id one, so seat order and id order genuinely disagree.
+  b = combatant('B', 0, 0, 10, 100)
+  b.actor = FakeActorRef.new(2)
+  a = combatant('A', 0, 0, 10, 100)
+  a.actor = FakeActorRef.new(1)
+  foe = combatant('Foe', 0, 0, 10, 100) # also agi 10, but has no #actor at all
+  bat = Game::Battle.new([b, a], [foe], Game::Rng.new(1))
+  eq [a, b, foe], bat.send(:turn_order),
+     "actor id 1 acts before id 2 despite sitting in the later seat; both allies " \
+     'still act before the equally-fast foe'
+end
+
 check 'battle: a self-destruct also reads state-adjusted ATK / DEF' do
   states = { 1 => fake_state(affect_type: 1, affect_attack: true) } # double
   bomber = combatant('Bomber', 40, 0, 5, 1)


### PR DESCRIPTION
## Summary
- yado.tk: on an agility tie, an ally always acts before an enemy, and among
  tied allies the **lower actor id** acts first — not party seat/join order.
- `Game::Battle#turn_order` tie-broke using each battler's positional index
  in `(@allies + @enemies)`, i.e. party seat order. `Game::Party#add_actor`
  appends to `@actors` on join, so seat order only equals actor-id order
  until a member leaves and rejoins behind a differently-ordered one (the
  same seat-vs-id divergence already documented elsewhere in the file for
  "Hero X is in the party").
- The sort key now uses `has_actor?` (making "ally before enemy on a tie"
  structural — an ally `Combatant` always carries `Combatant#actor`, an
  enemy never does — instead of relying on array-position coincidence) and
  the actor's database id for allies instead of the old positional index.
  Enemy-vs-enemy ties are untouched (still troop/definition order — no
  documented rule found for that case).
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 674 checks pass (new check: an
      agility tie among allies breaks by actor id, not seat order —
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 329 checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_