### PR TITLE
Add full-screen background to Enter Hero Name dialog

### DIFF
--- a/changelog.d/rpg2k-name-input-field-background.fixed.md
+++ b/changelog.d/rpg2k-name-input-field-background.fixed.md
@@ -1,0 +1,9 @@
+- **Enter Hero Name** now fills the screen behind its widget with the same
+  full-screen windowskin backdrop `Scene::Menu` and its Item/Skill/Equip/
+  Status sub-screens use (`Scene::Base#build_field_background`), instead of
+  leaving the frozen map (or nothing at all) showing through the gaps
+  between the face box, name-so-far field and character grid. Covers both
+  the Latin/digit grid and the hiragana/katakana grid. Covered by new checks
+  in `scripts/rpg2k_scene_check.rb` asserting the backdrop sprite is drawn
+  full-screen on both paths, and that the name-so-far field renders the
+  seeded characters with underscores past them.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4576,13 +4576,15 @@ class RPG2k
         req = @interpreter.name_input_request
         return @interpreter.resume_name_input('') unless req
         if @name_ui.nil?
+          background = build_field_background(@windowskin)
           if req[:charset] == 2
-            @name_ui = { name: req[:seed] || '', sel: 0, win: nil, kana: false }
+            @name_ui = { name: req[:seed] || '', sel: 0, win: nil, kana: false,
+                         background: background }
             draw_name_input
           else
             @name_ui = { name: req[:seed] || '', sel: 0, kana: true,
                          page: req[:charset] == 1 ? :katakana : :hiragana,
-                         actor_id: req[:actor_id] }
+                         actor_id: req[:actor_id], background: background }
             draw_kana_name_input
           end
           return
@@ -4829,6 +4831,7 @@ class RPG2k
 
       def close_name_input
         return unless @name_ui
+        @name_ui[:background].dispose if @name_ui[:background]
         if @name_ui[:kana]
           @name_ui[:face_win].dispose if @name_ui[:face_win]
           @name_ui[:name_win].dispose if @name_ui[:name_win]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3427,6 +3427,24 @@ check 'Enter Hero Name: typing on the grid and confirming renames the actor' do
   ok st.switches[5], 'the event resumed after entry'
 end
 
+check 'Enter Hero Name: draws a full-screen background behind the widget' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::NAME_INPUT, [1, 2, 0], indent: 0)] # actor 1, letters, no seed
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, NameStubParty.new)
+  6.times do
+    scene.update
+    break if scene.instance_variable_get(:@name_ui)
+  end
+  ui = scene.instance_variable_get(:@name_ui)
+  ok ui, 'the name-entry widget opened'
+  ok ui[:background], 'a field background sprite is drawn behind the widget'
+  eq RPG2k::WIDTH, ui[:background].bitmap.width, 'the backdrop covers the full screen width'
+  eq RPG2k::HEIGHT, ui[:background].bitmap.height, 'the backdrop covers the full screen height'
+end
+
 check 'Enter Hero Name: the character grid cursor wraps around' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
@@ -3502,6 +3520,14 @@ check 'Enter Hero Name: hiragana/katakana grid opens on the requested page, seed
   eq :katakana, ui[:page], 'charset 1 opens on the katakana page'
   eq 'Hero', ui[:name], 'seeded with the actor current name'
   eq 0, ui[:sel], 'cursor starts on the first cell'
+
+  ok ui[:background], 'a field background sprite is drawn behind the kana widget'
+  eq RPG2k::WIDTH, ui[:background].bitmap.width, 'the backdrop covers the full screen width'
+  eq RPG2k::HEIGHT, ui[:background].bitmap.height, 'the backdrop covers the full screen height'
+
+  field_text = ui[:name_win].contents.draw_calls.map { |c| c[4] }
+  eq %w[H e r o _ _], field_text,
+     'the name-so-far field shows the seeded characters, underscored past them'
 end
 
 check 'Enter Hero Name: typing a kana and confirming renames the actor' do


### PR DESCRIPTION
## Summary
The Enter Hero Name dialog now displays a full-screen windowskin backdrop behind its widget, matching the visual treatment used in other menu scenes. Previously, the frozen map or empty space was visible through gaps in the UI.

## Changes
- **Background sprite creation**: Added `build_field_background(@windowskin)` call when initializing the name input UI, storing the background sprite in the `@name_ui` hash for both Latin/digit and kana character grids
- **Proper cleanup**: Added disposal of the background sprite in `close_name_input` to prevent memory leaks
- **Test coverage**: Added comprehensive checks verifying:
  - Background sprite is created and drawn behind the widget on both input modes
  - Background covers the full screen dimensions (RPG2k::WIDTH × RPG2k::HEIGHT)
  - Name-so-far field correctly renders seeded characters with underscores for remaining slots
- **Changelog entry**: Documented the fix with details on the implementation and test coverage

## Implementation Details
The background is created once when the name input UI is first initialized and reused throughout the input session, then properly disposed when the dialog closes. This approach is consistent with how `Scene::Base#build_field_background` is used in other menu scenes.

https://claude.ai/code/session_015ZBPGkNbHt7b3DePzLJtgt