### PR TITLE
rpg2k: an unrelated event's page change no longer resets another event's Through Mode

### DIFF
--- a/changelog.d/event-page-refresh-preserves-move-route-state.fixed.md
+++ b/changelog.d/event-page-refresh-preserves-move-route-state.fixed.md
@@ -1,0 +1,19 @@
+- **An event's Through Mode, Direction Fix, Stop Animation and Transparency
+  no longer reset when a *different* event's page flips.** `Scene::Map
+  #pages_changed?` is a map-wide check — any Control Switch/Variable write,
+  item change or party change that flips *any* event's active page triggers
+  `#rebuild_events_preserving_positions`, which rebuilds every event's
+  `Game::Character` from scratch via `build_events`. The old-to-new copy loop
+  only carried `x`/`y`/`direction` (and, conditionally, an in-progress custom
+  route) across that rebuild, so an event whose own page never changed still
+  had its Through Mode / Direction Fix / Stop Animation / Transparency
+  silently reset to their `Game::Character#initialize` defaults — none of
+  which a page ever sets; they only ever change via a Move Route's Through
+  Mode, Direction Fix, Stop/Start Animation or Transparency Up/Down
+  sub-commands, and are documented (yado.tk) to stick until explicitly
+  changed. Fixed by carrying those four fields across the rebuild the same
+  way position/direction already are. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a bystander event's Through Mode,
+  Direction Fix, Stop Animation and Transparency all survive an unrelated
+  event's switch-triggered page change), confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2314,8 +2314,28 @@ not yet verified:
   control-lock freeze if the hero is the target. The same freeze class
   applies to Move-All/jump-landing targeting a currently-hidden
   (appearance-condition-unmet) map event.
-- "Through Mode: Begin" without a matching "End" leaves the character
-  permanently able to pass through walls.
+- ✅ **"Through Mode: Begin" without a matching "End" leaves the character
+  *permanently* able to pass through walls — including across an unrelated
+  event's page change**, which used to silently turn it back off.
+  `Scene::Map#pages_changed?` is a map-wide check (see the "Event triggers &
+  page selection" section below), so any Control Switch/Variable/item/party
+  write that flips *any* event's active page runs
+  `#rebuild_events_preserving_positions`, which rebuilds **every** event's
+  `Game::Character` from scratch via `#build_events` — including events whose
+  own page never changed. The old-to-new copy loop only carried `x`/`y`/
+  `direction` (and, conditionally, an in-progress custom route) across that
+  rebuild; `through`, `facing_locked`, `animation_stopped` and `transparency`
+  were left at `Game::Character#initialize`'s defaults (Through Mode off,
+  Direction Fix off, animation running, fully opaque) on the fresh object,
+  silently undoing whatever a Move Route's Through Mode/Direction Fix/Stop
+  Animation/Transparency Up-Down sub-commands had set on an event that was
+  never touched by whatever triggered the rebuild — the opposite of "must be
+  explicitly ended or it never turns back off". Fixed by carrying those four
+  fields across the rebuild the same way position/direction already are.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a bystander event's
+  Through Mode, Direction Fix, Stop Animation and Transparency all survive a
+  *different* event's switch-triggered page change), confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **A move-route "Face Direction" sub-command always overrides an earlier
   "Direction Fix ON" (Lock Facing) in the same route.** Direction Fix only
   ever suppresses the facing change an *ordinary move* would otherwise cause

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1626,6 +1626,21 @@ class RPG2k
       # across, but only when the old and new page describe the byte-identical
       # route (`Game::MoveRoute.same_route?`) — RPG_RT restarts the route from
       # the top on any other page switch, custom-route or not.
+      #
+      # This sweep runs whenever *any* event's page selection changes
+      # (#pages_changed? is a map-wide check, not per-event — see
+      # #refresh_event_pages), so `build_events` above just replaced every
+      # event's `Game::Character` with a brand-new one, including events whose
+      # own page never changed. A fresh `Game::Character` always starts with
+      # Through Mode off, facing unlocked, animation running and full opacity
+      # (`Game::Character#initialize`) — none of which a page ever sets (see
+      # `#build_event`, which never touches these four); they only ever change
+      # via a Move Route's Through Mode / Direction Fix / Stop Animation /
+      # Transparency sub-commands. Carrying x/y/direction across but not these
+      # would silently wipe an unrelated event's Through Mode the instant some
+      # other event's Control Switch/Variable/item write flips a page anywhere
+      # on the map — the same "must be explicitly ended or it never turns back
+      # off" state yado.tk documents for Through Mode specifically.
       def rebuild_events_preserving_positions
         placed = {}
         @events.each { |e| placed[e[:id]] = e }
@@ -1636,6 +1651,10 @@ class RPG2k
           e[:char].x = old[:char].x
           e[:char].y = old[:char].y
           e[:char].direction = old[:char].direction
+          e[:char].through = old[:char].through
+          e[:char].facing_locked = old[:char].facing_locked
+          e[:char].animation_stopped = old[:char].animation_stopped
+          e[:char].transparency = old[:char].transparency
           next unless e[:move_type] == Game::MoveType::CUSTOM &&
                       old[:move_type] == Game::MoveType::CUSTOM
           if Game::MoveRoute.same_route?(page_move_route(old[:page]), page_move_route(e[:page]))

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -689,6 +689,43 @@ check 'flipping a switch re-selects an event page mid-map' do
   ok st.switches[5], 'and its parallel process now runs'
 end
 
+check "an unrelated event's page change does not reset another event's " \
+      'Through Mode / Direction Fix / Stop Animation / Transparency' do
+  # Event 1 (the bystander) never changes page; event 2 is the one gated on
+  # switch 3. #pages_changed? is a map-wide check, so flipping the switch
+  # rebuilds *every* event's Game::Character, event 1's included, even though
+  # event 1's own page selection never moves. These four fields are only ever
+  # set by a Move Route sub-command (Through Mode / Direction Fix / Stop
+  # Animation / Transparency Up-Down) -- a page never assigns them -- so a
+  # fresh Game::Character always starts back at their defaults; carrying
+  # position across the rebuild but not these would silently wipe them.
+  bystander = page(trigger: 0, charset_name: 'Bystander')
+  p1 = page(trigger: 0, charset_name: 'Villager')
+  p2 = page(trigger: 4, charset_name: 'Ghost')
+  scene = new_scene({ 1 => event(1, 1, bystander),
+                      2 => two_page_event(2, 2, 3, p1, p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.update
+
+  ch = event_hashes(scene)[1][:char]
+  ch.through = true
+  ch.facing_locked = true
+  ch.animation_stopped = true
+  ch.transparency = 5
+
+  st.switches[3] = true # only event 2's page condition is gated on this
+  5.times { scene.update }
+
+  ev2 = event_hashes(scene)[2]
+  eq 4, ev2[:trigger], "event 2's page did flip (switch 3 went on)"
+
+  ch = event_hashes(scene)[1][:char]
+  ok ch.through, "event 1's Through Mode survived event 2's page rebuild"
+  ok ch.facing_locked, "event 1's Direction Fix survived it too"
+  ok ch.animation_stopped, 'as did Stop Animation'
+  eq 5, ch.transparency, 'and Transparency Up/Down'
+end
+
 check 'a page change keeps the event where it stands' do
   # The event walks east on page 1; when it flips to page 2 it must stay put
   # rather than snapping back to its spawn tile.


### PR DESCRIPTION
## Summary

- `Scene::Map#pages_changed?` is a map-wide check (see `docs/TODO.md`'s "Event triggers & page selection" section) — any Control Switch/Variable/item/party write that flips *any* event's active page runs `#rebuild_events_preserving_positions`, which rebuilds **every** event's `Game::Character` from scratch via `#build_events`, including events whose own page selection never changed.
- The old-to-new copy loop only ever carried `x`/`y`/`direction` (and, conditionally, an in-progress custom route) across that rebuild. `through`, `facing_locked`, `animation_stopped` and `transparency` — state a page never sets; it only ever changes via a Move Route's Through Mode / Direction Fix / Stop Animation / Transparency Up-Down sub-commands — were left at `Game::Character#initialize`'s defaults on the fresh object, silently wiping whatever an untouched bystander event had set, the moment some *other* event's page flipped anywhere on the map.
- This directly contradicted the documented yado.tk rule that Through Mode "must be explicitly ended or it never turns back off."
- Fixed by carrying those four fields across the rebuild the same way position/direction already are (`mruby-rpg2k/mrblib/scene/map.rb`, `#rebuild_events_preserving_positions`).
- `docs/TODO.md`'s yado.tk backlog entry for this claim is updated to ✅, and a `changelog.d/` fragment is added.

## Test plan

New `scripts/rpg2k_scene_check.rb` check: a bystander event's Through Mode/Direction Fix/Stop Animation/Transparency are set directly, then a *different* event's page is flipped via a switch write; asserts the bystander's state survives the resulting rebuild. Confirmed to fail against the pre-fix code with exactly the expected error (`event 1's Through Mode survived event 2's page rebuild`).

Both required check scripts pass with zero failures, including the new check:

```
$ ruby scripts/rpg2k_logic_check.rb
...
rpg2k logic check: 675 checks passed

$ ruby scripts/rpg2k_scene_check.rb
...
rpg2k scene check: 331 checks passed
```

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnenFLMmuWB6qB1DUGpbK7)_