### PR TITLE
rpg2k: an unrelated event's page change no longer restarts a Map Event's own Parallel Process

### DIFF
--- a/changelog.d/parallel-event-page-refresh-preserves-state.fixed.md
+++ b/changelog.d/parallel-event-page-refresh-preserves-state.fixed.md
@@ -1,0 +1,30 @@
+- **A Map Event's own Parallel Process no longer restarts from the top when
+  a *different* event's page flips.** `Scene::Map#pages_changed?` is a
+  map-wide check — any Control Switch/Variable/item/party write that flips
+  *any* event's active page runs `#rebuild_events_preserving_positions`,
+  which rebuilds every event's `Game::Character` and, via `#build_parallels`,
+  every parallel-process interpreter, event 1's parallel process included
+  even though event 1's own page never changed. `#build_parallels` had no
+  reuse mechanism for a Map Event's own parallel process at all (only a
+  Common Event's, keyed by common-event id, already survives this kind of
+  rebuild), so the bystander event's Parallel Process silently lost its
+  entire in-flight state — call stack, a paused Wait's countdown, everything
+  — and restarted at index 0 on every unrelated page flip anywhere on the
+  map. Fixed with a new `preserve_map_events:` keyword on `#build_parallels`,
+  passed only by `#rebuild_events_preserving_positions` (a same-map, in-place
+  page reselection, where a map event's own id still means the same thing
+  before and after) and left off at the other two call sites — the initial
+  build and a genuine Transfer Player — where a map event's parallel-process
+  id means nothing carried over from a different map/visit and a fresh
+  restart stays correct, matching the existing, still-passing "a map event's
+  parallel process always gets a brand-new interpreter every visit" check.
+  When set, a still-running Parallel Process whose own page selection did not
+  move (same `commands` array, checked by object identity) keeps its
+  interpreter across the rebuild; one whose own page *did* just change still
+  gets a fresh interpreter either way, matching yado.tk's "always restarts
+  from the top on every re-trigger". Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a bystander event's Parallel Process
+  — mid-Wait — keeps its marker-A/marker-B command position and in-flight
+  countdown intact across an unrelated event's switch-triggered page change),
+  confirmed to fail against the pre-fix code (marker A re-running) before the
+  fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2274,6 +2274,40 @@ not yet verified:
   Player and a save/load" above. A **Map Event's** parallel process always
   restarts from the top on every re-trigger (matches this codebase's
   current — correct — per-visit behavior).
+- ✅ **A Map Event's own Parallel Process no longer restarts from the top
+  when a *different* event's page flips.** `Scene::Map#pages_changed?` (see
+  above) is a map-wide check — any Control Switch/Variable/item/party write
+  that flips *any* event's active page runs
+  `#rebuild_events_preserving_positions`, which rebuilds every event's
+  `Game::Character` and, via `#build_parallels`, every parallel-process
+  interpreter, an unrelated bystander event's parallel process included even
+  though that event's own page never changed. `#build_parallels` had no
+  reuse mechanism for a Map Event's own parallel process at all — only a
+  Common Event's, keyed by common-event id, already survived this kind of
+  rebuild (see the already-fixed Common Event bullet just above) — so the
+  bystander's Parallel Process silently lost its entire in-flight state
+  (call stack, a paused Wait's countdown, everything) and restarted at index
+  0 on every unrelated page flip anywhere on the map — a stricter, more
+  frequent reset than "restarts from the top on every re-trigger" describes,
+  since nothing about *this* event was re-triggered at all. Fixed with a new
+  `preserve_map_events:` keyword on `#build_parallels`, passed only by
+  `#rebuild_events_preserving_positions` (a same-map, in-place page
+  reselection, where a map event's own id still means the same thing before
+  and after) and left off at the other two call sites — the initial build
+  and a genuine Transfer Player — where a map event's parallel-process id
+  means nothing carried over from a different map/visit and a fresh restart
+  stays correct (unchanged, still pinned by the existing "a map event's
+  parallel process still gets a brand-new interpreter every visit" check).
+  When set, a still-running Parallel Process whose own page selection did
+  not move (the same `commands` array, compared by object identity) keeps
+  its interpreter across the rebuild; one whose own page *did* just change
+  still gets a fresh interpreter either way, so "always restarts from the
+  top on every re-trigger" (the bullet just above) is untouched. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check (a bystander event's Parallel
+  Process — mid-Wait — keeps its command position and in-flight countdown
+  intact across an unrelated event's switch-triggered page change),
+  confirmed to fail against the pre-fix code (the bystander's first command
+  re-running) before the fix.
 - Multiple simultaneous parallel processes are **not concurrent** — the
   engine advances one command block at a time, round-robin, yielding at a
   blocking command (Wait/Show Text/Show Picture), in definition/event-ID

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -950,24 +950,62 @@ class RPG2k
       # one for -- full fidelity (call stack, in-flight wait timer, everything,
       # since it is the very same object), not a reconstruction -- instead of
       # building a fresh one. Map events are always rebuilt fresh from the
-      # destination map's own event table, matching the existing per-visit-reset
-      # behaviour (unchanged). On the very first build for this scene (a brand
-      # new game, or the fresh Scene::Map Continue/#initialize builds from a
-      # loaded save), there is no previous @parallels to reuse from, so
-      # #new_parallel instead fast-forwards a fresh interpreter to whatever
-      # position #step_parallel last recorded on Game::State before the game
-      # was last saved (see Game::State#common_event_progress) -- a coarser,
-      # index-only continuation, since nothing was kept alive across a save to
-      # resume with full fidelity.
-      def build_parallels
+      # destination map's own event table on a genuine map change (Transfer
+      # Player, or the very first build for this scene), matching the existing
+      # per-visit-reset behaviour: a real "visit" gives a map event's own
+      # parallel process no id that means anything on the map being left, so
+      # there is nothing sound to reuse.
+      #
+      # `preserve_map_events:` is the one exception, passed only by
+      # #rebuild_events_preserving_positions: that call does not change maps at
+      # all, it just re-selects pages after a Control Switch/Variable/item/party
+      # write, and #pages_changed? triggering it is a map-wide check -- any
+      # *other* event's page flipping runs this same rebuild, discarding and
+      # rebuilding every event's Game::Character (see #build_events), this
+      # event's included, even though this event's own page selection never
+      # moved. Without this, a Map Event's Parallel Process would restart from
+      # the top (losing its call stack and any in-flight Wait countdown, the
+      # same fidelity #resumable_index cannot capture) every time some
+      # unrelated event on the map reselected its page -- not on this event's
+      # own re-trigger, which does still restart it fresh, matching yado.tk's
+      # "always restarts from the top on every re-trigger". A map event whose
+      # own page selection *did* just change (a different `page`, so a
+      # different `commands` array -- #build_event always builds a fresh
+      # Game::Character/command list from the freshly-selected page) still gets
+      # a brand new interpreter either way, exactly as before.
+      #
+      # On the very first build for this scene (a brand new game, or the fresh
+      # Scene::Map Continue/#initialize builds from a loaded save), there is no
+      # previous @parallels to reuse from, so #new_parallel instead
+      # fast-forwards a fresh interpreter to whatever position #step_parallel
+      # last recorded on Game::State before the game was last saved (see
+      # Game::State#common_event_progress) -- a coarser, index-only
+      # continuation, since nothing was kept alive across a save to resume with
+      # full fidelity.
+      def build_parallels(preserve_map_events: false)
         previous_common = {}
+        previous_map = {}
         (@parallels || []).each do |p|
-          previous_common[p[:common_event_id]] = p if p[:common_event_id]
+          if p[:common_event_id]
+            previous_common[p[:common_event_id]] = p
+          elsif preserve_map_events && p[:event]
+            previous_map[p[:event][:id]] = p
+          end
         end
         @parallels = []
         @events.each do |e|
           next unless e[:trigger] == TRIGGER_PARALLEL && e[:commands]
-          @parallels.push new_parallel(e[:commands], nil, e, nil)
+          prior = previous_map[e[:id]]
+          if prior && prior[:commands].equal?(e[:commands])
+            # Same page, same command list -- only the surrounding
+            # Game::Character objects were rebuilt (see #build_events), so keep
+            # the still-running interpreter and just re-point its bookkeeping
+            # at this rebuild's fresh event hash.
+            prior[:event] = e
+            @parallels.push prior
+          else
+            @parallels.push new_parallel(e[:commands], nil, e, nil)
+          end
         end
         @common.each do |c|
           next unless c[:trigger] == Game::CommonEvent::PARALLEL && c[:commands]
@@ -1643,7 +1681,11 @@ class RPG2k
           end
         end
         rebuild_event_tiles
-        build_parallels
+        # This is an in-place page reselection, not a map change -- a map
+        # event's own Parallel Process id still means the same thing before
+        # and after, so a still-running one whose own page did not change
+        # keeps its interpreter (see #build_parallels).
+        build_parallels(preserve_map_events: true)
         # The event the foreground interpreter is running may have just been
         # rebuilt; re-point it so "this event" still reaches the live character.
         @active_event = @events.find { |e| e[:id] == @active_event[:id] } if @active_event

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1294,6 +1294,54 @@ check "Transfer Player reuses a common event's Parallel Process interpreter " \
      "the rebuilt map event's parallel process starts over at the top"
 end
 
+check "an unrelated event's page change does not restart another event's " \
+      'own Parallel Process' do
+  ic = Game::Interpreter::Cmd
+  # Event 1's own page never changes -- it is a bystander -- but its Parallel
+  # Process runs marker A, parks on a 0.3s Wait, then runs marker B, so a
+  # restart (which would re-run marker A instead of resuming the same
+  # countdown) can be told apart from a genuine resume, mirroring this same
+  # section's own "Transfer Player reuses a common event's ... interpreter"
+  # check's timing setup above -- the difference here is nothing changes maps
+  # at all, only an *unrelated* event's own page selection flips.
+  par = page(trigger: 4)
+  par.event_commands = [add_var_cmd(1), ECmd.new(ic::WAIT, [3]), add_var_cmd(2)]
+  p1 = page(trigger: 0, charset_name: 'Villager')
+  p2 = page(trigger: 0, charset_name: 'Ghost')
+  scene = new_scene({ 1 => event(2, 2, par),
+                      2 => two_page_event(5, 5, 3, p1, p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  scene.update # marker A runs, then event 1 parks on the 0.3s Wait
+  eq 1, st.variables[1], 'marker A ran once, before the wait'
+  eq 0, st.variables[2], 'the wait has not elapsed yet'
+
+  # Flipping switch 3 only changes event 2's own page selection -- event 1's
+  # page (and its already-running Parallel Process) never moves -- but
+  # #pages_changed? is a map-wide check, so this still runs
+  # #rebuild_events_preserving_positions, which used to discard and rebuild
+  # *every* map event's Parallel Process interpreter, event 1's included.
+  st.switches[3] = true
+  scene.update
+  ok event_hashes(scene)[2][:page].equal?(p2),
+     "event 2's own page did flip (switch 3 went on)"
+  eq 1, st.variables[1],
+     "event 1's Parallel Process must not have restarted -- marker A would " \
+     're-run and bump this to 2'
+  eq 0, st.variables[2], 'nor reset the in-flight wait to a fresh countdown'
+
+  # The common-event Transfer Player check above needs 19 more ticks because
+  # `perform_teleport` itself does not tick the wait timer -- only the
+  # `scene.update` calls that follow do. Here, unlike there, the switch-flip
+  # frame just above *is* a full `scene.update`, so it already spent the
+  # first of those 19 ticks (the one that initialises the timer from nil and
+  # takes its first decrement, per #drive_parallel_wait) -- 18 more are
+  # exactly enough for the remaining countdown to elapse.
+  18.times { scene.update }
+  eq 1, st.variables[1], 'marker A still has not re-run'
+  eq 1, st.variables[2], 'the wait elapsed after exactly its original countdown'
+end
+
 check "a common event's Parallel Process resumes where it left off after a " \
       'save/load, not from the top' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary
- `Scene::Map#pages_changed?`/`#rebuild_events_preserving_positions` is a
  map-wide check: any event's page reselecting (a Control Switch/Variable/
  item/party write) triggers a full rebuild of every event, which discarded
  and rebuilt every Map Event's own Parallel Process interpreter too — even
  one whose own page never changed. yado.tk documents a Map Event's own
  parallel process as restarting from the top "on every re-trigger", not on
  every unrelated event's page change elsewhere on the map.
- `#build_parallels` gains a `preserve_map_events:` keyword, passed only
  from `#rebuild_events_preserving_positions`: when true, a still-running
  interpreter is kept whenever its owning event's page (and thus `commands`
  array, compared by object identity — the same page never produces a
  different array) is unchanged, re-pointing its bookkeeping at the
  rebuild's fresh event hash. A page that *did* change, or a genuine map
  transfer (the other two `build_parallels` call sites, untouched), still
  gets a brand-new interpreter as before.
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 676 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 331 checks pass (new check: an
      unrelated event's page change does not restart another event's own
      Parallel Process — a marker-A/Wait(0.3s)/marker-B sequence
      distinguishes a restart from a genuine resume, confirmed to fail
      against the pre-fix code before the fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_