### PR TITLE
rpg2k: Knockout state ignores a target's state-rank when inflicted by a skill

### DIFF
--- a/changelog.d/battle-knockout-state-ignores-rank.fixed.md
+++ b/changelog.d/battle-knockout-state-ignores-rank.fixed.md
@@ -1,0 +1,10 @@
+- **Inflicting the Knockout state (id 1) via a skill's state-effect list now
+  ignores the target's A-E resistance rank entirely**, matching yado.tk:
+  RPG2000 has no separate instant-death mechanic, so an "instant death"
+  spell is just a skill whose state-effect list names Knockout directly, and
+  the site documents its landing chance as governed solely by the skill's
+  own occurrence-rate operand, never scaled down by `state_ranks` the way
+  every other status is. `Game::Battle#state_susceptibility`
+  (`mruby-rpg2k/mrblib/game.rb`) now returns 100 unscaled whenever the
+  target state id is `Game::Actor::DEATH_STATE`, before consulting
+  `state_ranks` at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3156,9 +3156,29 @@ above are repeated here)
   but free if placed in a shop's own buy list.
 - State resistance rank A-E only gates **susceptibility** — the actual
   proc chance is entirely the *skill's own* occurrence-rate field (0%
-  occurrence never applies regardless of rank); Death/Knockout is exempt
-  and always applies. Attribute resistance rank A-E maps to the Attribute
-  database's own per-rank effect-% table (e.g. 50% halves).
+  occurrence never applies regardless of rank) — **confirmed already
+  correct**: `Game::Battle#roll_inflict` (`mruby-rpg2k/mrblib/game.rb`)
+  computes `prob = chance * state_susceptibility(target, sid) / 100`, so a
+  0% `chance` (the skill's own occurrence-rate operand) always yields
+  `prob = 0` regardless of what `state_susceptibility` scales it by.
+  Attribute resistance rank A-E already maps to the Attribute database's own
+  per-rank effect-% table too (`Game::Battle#attr_rate`, `a_rate`..`e_rate`
+  with a `[300, 200, 100, 50, 0]` fallback — **confirmed already correct**,
+  no change needed). ✅ **Death/Knockout is now exempt from rank scaling and
+  always lands at the skill's own occurrence rate.** RPG2000 has no separate
+  instant-death mechanic — an "instant death" spell is just a skill whose
+  state-effect list names Knockout (state id 1, `Game::Actor::DEATH_STATE`)
+  directly — but `state_susceptibility` scaled it through the target's
+  ordinary `state_ranks` lookup exactly like any other status, so a rank-E
+  ("immune") target silently blocked Knockout too, the opposite of the
+  yado.tk finding. Fixed with an early `return 100 if sid ==
+  Game::Actor::DEATH_STATE` before `state_susceptibility` ever consults
+  `state_ranks`, leaving `roll_inflict`'s already-carried/"already" handling
+  and every other state's rank scaling untouched. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a rank-E target still catches
+  Knockout; the same rank on an ordinary state — the control case — still
+  resists it, pinning the exemption to state id 1 specifically), the first
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ A skill flagged "attribute defense up/down" (field 45,
   `affect_attr_defence`) now shifts the target's rank for each attribute in
   its `attribute_effects` list by **exactly one step**, capped at ±1 from the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7231,7 +7231,13 @@ module Game
     # rank in the target's `state_ranks` (default C / 60% for a listed-but-absent
     # state, EasyRPG's GetStateProbability). 100 (unscaled) when the target (a
     # bare fixture) models no ranks, so a plain sim keeps landing every status.
+    # The Knockout state (id 1, `Game::Actor::DEATH_STATE`) is exempt from rank
+    # scaling entirely -- a skill's "state change" effect list can name it
+    # directly (RPG2000 has no separate instant-death mechanic), and yado.tk
+    # documents its infliction chance as governed solely by the skill's own
+    # occurrence-rate operand, never reduced by the target's A-E resistance rank.
     def state_susceptibility(target, sid)
+      return 100 if sid == Game::Actor::DEATH_STATE
       ranks = target.state_ranks
       return 100 if ranks.nil? || ranks.empty?
       rank = ranks[sid] || 2

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7112,9 +7112,13 @@ end
 # -- Battle state susceptibility (state_ranks) --------------------------------
 
 def poison_cast(foe, seed = 1)
+  poison_cast_state(foe, 3, seed)
+end
+
+def poison_cast_state(foe, state_id, seed = 1)
   mage = combatant_mp('Mage', 10, 0, 20, 100, 30)    # faster -> acts first
   b = Game::Battle.new([mage], [foe], Game::Rng.new(seed))
-  b.command_skill(mage, foe, name: 'Poison', cost: 0, hp: -1, inflict: [3], chance: 100)
+  b.command_skill(mage, foe, name: 'Poison', cost: 0, hp: -1, inflict: [state_id], chance: 100)
   b.begin_round
   b.step_action
 end
@@ -7154,6 +7158,28 @@ check 'battle: a mid susceptibility (rank C 60%) both lands and resists' do
   end
   ok results.any? { |r| r == [3] }, 'a 60% status sometimes lands'
   ok results.any?(&:empty?), 'and sometimes is resisted'
+end
+
+check 'battle: Knockout (state 1) ignores state_ranks -- rank E still lands' do
+  # RPG2000 has no separate instant-death mechanic; a skill's state-effect list
+  # names Knockout (id 1, Game::Actor::DEATH_STATE) directly, and yado.tk
+  # documents its landing chance as governed solely by the skill's own
+  # occurrence-rate operand -- never scaled down by the target's A-E rank the
+  # way every other state is.
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.state_ranks = { Game::Actor::DEATH_STATE => 4 } # rank E -> 0% for any other state
+  e = poison_cast_state(foe, Game::Actor::DEATH_STATE)
+  eq [Game::Actor::DEATH_STATE], e[:inflicted], 'Knockout lands despite rank-E "immunity"'
+  ok foe.state?(Game::Actor::DEATH_STATE)
+end
+
+check 'battle: an ordinary state at the same rank E is still blocked' do
+  # Control: the same rank on a non-Knockout state id keeps resisting, proving
+  # the exemption above is specific to id 1, not a general susceptibility bypass.
+  foe = combatant('Foe', 0, 0, 5, 100)
+  foe.state_ranks = { 3 => 4 }
+  e = poison_cast_state(foe, 3)
+  eq [], e[:inflicted]
 end
 
 # A state the target already carries is not a silent no-op: RPG_RT reports it as


### PR DESCRIPTION
## Summary

- yado.tk's database-field sweep (`docs/TODO.md`'s "Database field semantics" bullet) documents that a state's A-E resistance rank only gates *susceptibility* — the actual proc chance comes from the skill's own occurrence-rate operand — **except for Knockout (state id 1)**, which is exempt from rank scaling entirely and always lands at the skill's raw occurrence rate. RPG2000 has no separate instant-death mechanic: an "instant death" spell is just a skill whose state-effect list names Knockout directly.
- `Game::Battle#state_susceptibility` (`mruby-rpg2k/mrblib/game.rb`) scaled Knockout through the target's ordinary `state_ranks` lookup exactly like any other status, so a rank-E ("immune") target silently blocked an instant-death skill too — the opposite of the documented behavior.
- Fixed with an early `return 100 if sid == Game::Actor::DEATH_STATE` in `state_susceptibility`, before `state_ranks` is ever consulted. Every other state's rank scaling, and `roll_inflict`'s already-carried/"already" handling, are untouched.
- While verifying this, confirmed two adjacent parts of the same yado.tk bullet already hold with no code change needed: the skill-occurrence-rate gate (`roll_inflict`'s `prob = chance * state_susceptibility / 100`, so `chance == 0` always yields `prob == 0`), and the Attribute A-E rank → per-rank effect-% mapping (`Game::Battle#attr_rate`). Both are now recorded in `docs/TODO.md` as confirmed-correct.

## Test plan

- Added two `scripts/rpg2k_logic_check.rb` checks: a rank-E target still catches Knockout when a skill's state-effect list names it directly; the same rank on an ordinary (non-Knockout) state — the control case — still resists, pinning the exemption to state id 1 specifically.
- Confirmed the new Knockout check fails against the pre-fix code (`git stash` on `game.rb` alone): `FAIL battle: Knockout (state 1) ignores state_ranks -- rank E still lands: RuntimeError: expected [1], got []`.
- Both gates pass clean on the current branch:

```
$ ruby scripts/rpg2k_logic_check.rb
rpg2k logic check: 679 checks passed

$ ruby scripts/rpg2k_scene_check.rb
rpg2k scene check: 332 checks passed
```

- `docs/TODO.md` updated in-place (Database field semantics section) and a `changelog.d/battle-knockout-state-ignores-rank.fixed.md` fragment added per house style.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfmtLYiNqFFX5o5LWC7euS)_