### PR TITLE
rpg2k: Store Event ID still resolves a temporarily-erased event at its last tile

### DIFF
--- a/changelog.d/store-event-id-erased-event.fixed.md
+++ b/changelog.d/store-event-id-erased-event.fixed.md
@@ -1,0 +1,15 @@
+- **Store Event ID now still resolves a temporarily-erased event at the tile
+  it occupied when it was erased**, instead of reading back 0 there for the
+  rest of the visit. `Scene::Map#erase_event` dropped an erased event's tile
+  from `@event_tiles` outright — correct for collision and drawing, which
+  RPG_RT's Erase Event does stop, but `event_id_at` (the Store Event ID query)
+  read that same table, so it lost the id too, which yado.tk documents RPG_RT
+  keeps answering. `erase_event` now also freezes the tile in a new
+  `@erased_event_positions` (an erased event cannot move further, so one
+  snapshot at erasure time is enough), and `event_id_at` falls back to it,
+  still resolving several ids sharing a tile — live, erased, or a mix — to the
+  highest one, matching the existing overlapping-events rule. An event whose
+  current page conditions simply aren't met is a separate, still-open half of
+  the same yado.tk claim, left for a follow-up. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks, two confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3139,15 +3139,38 @@ level-up).
   the next-highest — so cut+paste (vs. drag) can silently renumber an
   event and break other commands' hardcoded numeric references. Only
   drag-and-drop reordering in the map tree preserves ids.
-- "Get Event ID at Location" on overlapping events returns the
-  **highest** id among them (0 if none); it still returns an id for a
-  temporarily-erased event or one whose current page conditions aren't
-  met; and — importantly for anything simulating pixel-precise hit
-  detection — the id-lookup position **snaps to an event's destination
-  tile the instant it begins moving**, not once the visual slide
-  completes, which is a documented source of "the bullet visually
-  connected but registered as a miss" bugs in custom battle-system
-  tutorials.
+- ✅ **"Get Event ID at Location" now still resolves a temporarily-erased
+  event at the tile it occupied when it was erased**, instead of reading
+  back 0 there for the rest of the visit — matching yado.tk's claim that
+  RPG_RT keeps answering even though the erased event no longer draws,
+  moves or blocks. `Scene::Map#erase_event` (`mruby-rpg2k/mrblib/
+  scene/map.rb`) used to drop the event from `@event_tiles` — the same
+  table `#event_id_at` (the Store Event ID query) reads — unconditionally
+  on erasure; it now also freezes the tile in a new
+  `@erased_event_positions` hash (an erased event cannot move any further,
+  so one snapshot taken at erasure time is enough) that `#event_id_at`
+  falls back to. The pre-existing "highest id among several events sharing
+  a tile" rule (confirmed already correct — see the "Processing order"
+  bullet above) now spans live and erased events together: several ids on
+  one tile, in any live/erased mix, still resolve to the highest of them.
+  **The other half of this same claim — an event whose current page
+  conditions simply aren't met — is separate and still open**: such an
+  event never gets a `Game::Character` built at all (`#build_events` skips
+  it outright whenever no page's conditions are satisfied), so there is no
+  position to answer from without first deciding what "its" position even
+  means while hidden, which would need a real RPG_RT comparison to pin
+  down rather than a guess. The "id-lookup position snaps to an event's
+  destination tile the instant it begins moving" half of the original
+  bullet was already confirmed correct earlier, under the `Map Event`
+  "hero touches event" bullet above (`#reoccupy` rewrites this same
+  `@event_tiles` table the instant a step commits, well before the visual
+  slide catches up) — `#event_id_at` reads that same table, so the same
+  fact already covered it. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (an erased event alone on a tile
+  still answers with its id; an erased event still outranks a lower-id
+  live event sharing its tile; a live event still outranks a lower-id
+  erased one), two confirmed to fail against the pre-fix code before the
+  fix.
 
 **Database field semantics** (from the `11_db/` sweep, 48 findings — the
 single densest source in this pass; only the ones not already listed

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -105,6 +105,12 @@ class RPG2k
         end
         # Erased events, and the state revision the active pages were chosen at.
         @erased_events = {}
+        # An erased event's tile at the moment it was erased (yado.tk: "Get
+        # Event ID at Location" still resolves an id there, unlike collision
+        # and drawing, which #erase_event already drops it from). Keyed
+        # separately from @erased_events since this needs the position, not
+        # just the flag.
+        @erased_event_positions = {}
         @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver
@@ -1589,6 +1595,10 @@ class RPG2k
         @erased_events[ev[:id]] = true
         tile = [ev[:char].x, ev[:char].y]
         @event_tiles.delete(tile) if @event_tiles[tile].equal?(ev)
+        # Frozen at the tile it occupied right before erasure -- an erased
+        # event cannot move any further, and #event_id_at still needs it (see
+        # there) even though it no longer blocks or draws.
+        @erased_event_positions[ev[:id]] = tile
         @parallels.reject! { |p| p[:event].equal?(ev) } if @parallels
       end
 
@@ -2438,9 +2448,25 @@ class RPG2k
 
       # Id of the event standing on tile (x, y), for the Store Event ID command
       # (0 when no event is there). Queried by the interpreter via map_info.
+      # Ties (several events sharing a tile, live or erased) resolve to the
+      # highest id, matching #rebuild_event_tiles' own last-write-wins order.
+      # A **temporarily-erased** event still answers here even though it no
+      # longer blocks or draws (yado.tk: "Get Event ID at Location... still
+      # returns an id for a temporarily-erased event") -- #erase_event freezes
+      # its tile in @erased_event_positions instead of dropping it outright.
+      # An event whose current page conditions aren't met is a separate,
+      # still-open half of the same claim: it never gets a Game::Character
+      # built at all (see #build_events), so there is no position to answer
+      # from without deciding what "its" position even means while hidden --
+      # unverified, left for a follow-up.
       def event_id_at(x, y)
+        best = 0
         ev = @event_tiles[[x, y]]
-        ev ? ev[:id] : 0
+        best = ev[:id] if ev
+        @erased_event_positions.each do |id, tile|
+          best = id if tile == [x, y] && id > best
+        end
+        best
       end
       public :event_id_at
 
@@ -5169,6 +5195,7 @@ class RPG2k
         # Both are per-visit: an Erase Event does not follow the party to the
         # next map, and the destination's pages are chosen fresh.
         @erased_events = {}
+        @erased_event_positions = {}
         @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2587,6 +2587,43 @@ check 'Store Event ID resolves two events on the same tile to the highest id' do
   eq 5, st.variables[2], 'the higher-id event wins the shared tile, not the lower one'
 end
 
+check 'Store Event ID still resolves a temporarily-erased event at its last tile' do
+  # yado.tk: "Get Event ID at Location" still returns an id for a
+  # temporarily-erased event, unlike collision/drawing, which #erase_event
+  # already drops it from (@event_tiles). Event 2 erases itself on its own
+  # autostart page; nothing else ever stands on (3, 1).
+  ic = Game::Interpreter::Cmd
+  erasing = page(trigger: 3)
+  erasing.event_commands = [ECmd.new(ic::ERASE_EVENT, [])]
+  scene = new_scene({ 2 => event(3, 1, erasing) }, player: [5, 5])
+  10.times { scene.update }
+  eq 0, event_hashes(scene).size, 'the event is gone from the live list'
+  eq 2, scene.event_id_at(3, 1), 'its id still answers the query at its last tile'
+  eq 0, scene.event_id_at(0, 0), 'an ordinary empty tile still answers 0'
+end
+
+check 'a temporarily-erased event still outranks a lower-id live event on the same tile' do
+  ic = Game::Interpreter::Cmd
+  erasing = page(trigger: 3)
+  erasing.event_commands = [ECmd.new(ic::ERASE_EVENT, [])]
+  scene = new_scene({ 5 => event(3, 1, erasing), 2 => event(3, 1, page) },
+                    player: [5, 5])
+  10.times { scene.update }
+  eq 5, scene.event_id_at(3, 1),
+     'the erased higher id still wins over the live lower-id event'
+end
+
+check 'a live event still outranks a lower-id temporarily-erased event on the same tile' do
+  ic = Game::Interpreter::Cmd
+  erasing = page(trigger: 3)
+  erasing.event_commands = [ECmd.new(ic::ERASE_EVENT, [])]
+  scene = new_scene({ 2 => event(3, 1, erasing), 5 => event(3, 1, page) },
+                    player: [5, 5])
+  10.times { scene.update }
+  eq 5, scene.event_id_at(3, 1),
+     'the live higher id wins over the erased lower-id event'
+end
+
 check 'Proceed With Movement holds the interpreter until a forced route finishes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- yado.tk's "Get Event ID at Location" bullet (`docs/TODO.md`, "Map/Event ID assignment & tile occupancy") claims RPG_RT still answers with an event's id at the tile it occupied even after an Erase Event, unlike collision/drawing, which the erase does stop.
- `Scene::Map#erase_event` dropped the erased event's tile from `@event_tiles` outright — the same table `#event_id_at` (the Store Event ID query) reads — so the query silently read back 0 there for the rest of the map visit instead.
- `erase_event` now also freezes the tile in a new `@erased_event_positions` hash (an erased event can't move any further, so one snapshot at erasure time is enough), and `#event_id_at` falls back to it, keeping the pre-existing "highest id wins on a shared tile" rule across live and erased events together.
- The other half of the same yado.tk claim — an event whose current page conditions simply aren't met — is left as a separate, still-open follow-up in `docs/TODO.md`: such an event never gets a `Game::Character` built at all, so there's no position to answer from without a real RPG_RT comparison to decide what "its" position even means while hidden.

## Test plan

Both verification scripts pass, including three new `scripts/rpg2k_scene_check.rb` checks (two confirmed to fail against the pre-fix code before the fix):

```
$ ruby scripts/rpg2k_logic_check.rb
...
rpg2k logic check: 677 checks passed

$ ruby scripts/rpg2k_scene_check.rb
...
rpg2k scene check: 335 checks passed
```

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KqAq1LMSSeMmM6bqQcRpq1)_