### PR TITLE
rpg2k: battle Item target picker respects an item's actor_set restriction

### DIFF
--- a/changelog.d/battle-item-actor-set-target-picker.fixed.md
+++ b/changelog.d/battle-item-actor-set-target-picker.fixed.md
@@ -1,0 +1,20 @@
+- **A battle Item command's ally-target picker now respects the item's
+  使用可能キャラ (`actor_set`) restriction**, instead of always offering
+  every living party member. `Game::Party#item_usable_by?` already gated a
+  restricted item's *effect* on the field menu (`use_medicine`'s per-target
+  `next if ... !item_usable_by?`) and greyed it out there
+  (`item_effective?`), but the battle screen's own single-target picker
+  (`Scene::Map#draw_battle_ally_target` / `#drive_battle_ally_target`) read
+  straight off `#living_allies` with no restriction awareness at all, so a
+  player could pick — and actually heal — a party member the item is not
+  usable on, something the field menu already refused to let happen. Fixed
+  with a new `Scene::Map#battle_ally_targets`, which narrows the candidate
+  list by `item_usable_by?` whenever the pending action is a Battle Item
+  (a pending skill is untouched, since `actor_set` only ever gates
+  equipment/items); `Game::Party#battle_item_command` itself stays pure
+  arithmetic, unchanged, since the gate is about which target may be offered
+  at all, not what the formula computes once one legitimately is. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check (a two-actor party where the
+  item excludes the second actor: the picker offers only the first, and
+  moving the cursor has nowhere to go), confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1679,14 +1679,24 @@ The work below is roughly ordered by the critical path to a walkable game
   (10450, `do_change_equipment` in `interpreter.rb`), which EasyRPG's
   `ChangeEquipment` gates through the identical `IsItemUsable` call — checked
   per target there too, since a command can target the whole party at once.
-  **Left open**: the battle screen's own ally-target picker for a restricted
-  medicine/item (`Scene::Map#draw_battle_ally_target`) still lists every
-  living ally regardless of the item's `actor_set` — the pure
-  `Game::Party#battle_item_command` formula is not wrong, nothing upstream of
-  it in the battle scene enforces the restriction on which target can be
-  chosen in the first place. Covered by new `scripts/rpg2k_logic_check.rb`
-  checks (the read itself, the all-party-scope per-target skip, menu
-  greying-out, equip-menu filtering, and the event command).
+  Covered by new `scripts/rpg2k_logic_check.rb` checks (the read itself, the
+  all-party-scope per-target skip, menu greying-out, equip-menu filtering,
+  and the event command). **The previously-left-open half is now fixed
+  too**: the battle screen's own ally-target picker
+  (`Scene::Map#draw_battle_ally_target` / `#drive_battle_ally_target`) used
+  to read straight off `#living_allies` with no `actor_set` awareness at
+  all, so a restricted medicine/item could still be picked — and its effect
+  actually applied — against a party member the field menu already refused
+  to let it touch. Fixed with a new `Scene::Map#battle_ally_targets`, which
+  narrows the candidate list by `item_usable_by?` whenever the pending
+  action is a Battle Item (a pending skill is untouched, since `actor_set`
+  never gates skills); `Game::Party#battle_item_command` itself stays pure
+  arithmetic, unchanged — the gate is about which target may be *offered* at
+  all, not what the formula computes once one legitimately is. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (a two-actor party where the item
+  excludes the second actor: the picker offers only the first, and moving
+  the cursor has nowhere to go), confirmed to fail against the pre-fix code
+  before the fix.
 
 ### yado.tk quirks backlog
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3248,7 +3248,11 @@ module Game
 
     # The HP / SP a medicine restores to a battle `target` (Combatant snapshot)
     # plus the status conditions it cures, as `{ hp:, mp:, cured: [ids] }` — the
-    # same recovery and (antidote / herb) cure the field menu applies.
+    # same recovery and (antidote / herb) cure the field menu applies. Pure
+    # arithmetic: an actor_set (使用可能キャラ) restriction is a question of
+    # which target may be *offered* at all, not of what this formula computes
+    # once one legitimately is — see `Scene::Map#battle_ally_targets`, which is
+    # where that gate actually lives for a battle-cast item.
     def battle_item_command(it, target)
       hp, mp = item_recovery(it, target)
       { hp: hp, mp: mp, cured: item_cured_states(it) }

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3252,6 +3252,28 @@ class RPG2k
       end
 
       def living_allies; @battle_ui[:allies].reject(&:dead?); end
+
+      # Living allies selectable as a manually-chosen Battle Item target right
+      # now: `#living_allies` narrowed by the pending item's own 使用可能キャラ
+      # (`actor_set`) restriction when there is one -- the same per-recipient
+      # gate `Game::Party#use_medicine` already applies in the field menu
+      # (`Game::Party#item_usable_by?`), which this picker had never
+      # consulted at all, so a party member the item cannot affect used to be
+      # offered as a choice anyway rather than not appearing in the first
+      # place. A pending skill is untouched -- actor_set only gates
+      # equipment/items, never skills. `@state.party` not answering
+      # `item_usable_by?` (a battle test's stub party, which never models
+      # equipment restrictions) degrades to "unrestricted", the same default
+      # the real method itself falls back to for an item with no actor_set at
+      # all.
+      def battle_ally_targets
+        allies = living_allies
+        return allies unless pending_kind == :item
+        return allies unless @state.party.respond_to?(:item_usable_by?)
+        it = @battle_ui[:pending] && @battle_ui[:pending][:it]
+        return allies unless it
+        allies.select { |a| a.actor.nil? || @state.party.item_usable_by?(it, a.actor.id) }
+      end
       # Targetable foes: alive *and* in play, so a troop member still flagged
       # invisible never appears in the target cursor.
       def living_foes;   @battle_ui[:foes].reject(&:out_of_play?); end
@@ -3534,7 +3556,7 @@ class RPG2k
       # -- Ally target (heal skill / medicine) --------------------------------
 
       def drive_battle_ally_target
-        allies = living_allies
+        allies = battle_ally_targets
         if Input.trigger?(Input::DOWN) && !allies.empty?
           @battle_ui[:ally_i] += 1
           @battle_ui[:ally_i] %= allies.length
@@ -3543,7 +3565,7 @@ class RPG2k
           @battle_ui[:ally_i] -= 1
           @battle_ui[:ally_i] %= allies.length
           draw_battle_ally_target
-        elsif Input.trigger?(Input::C)
+        elsif Input.trigger?(Input::C) && !allies.empty?
           target = allies[@battle_ui[:ally_i]]
           close_battle_ally_target
           if pending_kind == :skill
@@ -4385,10 +4407,12 @@ class RPG2k
         @battle_ui[:item_win] = nil
       end
 
-      # The living party members as heal targets ("Name HP h/mh"), with a cursor.
+      # The living party members selectable as a heal target ("Name HP h/mh"),
+      # with a cursor -- narrowed by #battle_ally_targets when a pending item's
+      # actor_set excludes some of them.
       def draw_battle_ally_target
         @battle_ui[:ally_win].dispose if @battle_ui[:ally_win]
-        labels = living_allies.map do |a|
+        labels = battle_ally_targets.map do |a|
           "#{a.name}  #{a.hp < 0 ? 0 : a.hp}/#{a.max_hp}"
         end
         @battle_ui[:ally_win] =

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1439,8 +1439,8 @@ class BattleStubActor
   attr_reader :id, :name, :atk, :def, :agi, :int, :max_hp, :max_mp, :skills
   # Defaults are strong enough to beat the two-Slime troop the scene db defines;
   # a defeat test passes weaker stats.
-  def initialize(atk: 40, dfn: 20, agi: 20, hp: 200, mp: 20, int: 20, skills: [])
-    @exp = 0; @id = 1; @name = 'Hero'
+  def initialize(atk: 40, dfn: 20, agi: 20, hp: 200, mp: 20, int: 20, skills: [], id: 1)
+    @exp = 0; @id = id; @name = 'Hero'
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
     @mp = mp; @max_mp = mp; @int = int; @skills = skills
   end
@@ -4723,6 +4723,47 @@ check 'Enemy Encounter scene: the ally target cursor wraps around' do
   eq 1, ui[:ally_i], 'Up from the first ally wraps to the last (2 actors)'
   press_key(scene, RGSS::Input::DOWN)
   eq 0, ui[:ally_i], 'Down from the last ally wraps to the first'
+end
+
+# Two actors (distinct ids) with an item_usable_by? that restricts the
+# Potion (item 5) to actor 1 only -- a real Game::Party derives this from the
+# item's 使用可能キャラ / actor_set field (Game::Party#item_usable_by?); this
+# stub hardcodes the same answer so the scene-level wiring can be checked
+# without building a full item database.
+class BattleRestrictedItemParty < BattleMagicParty
+  def initialize(hurt: false)
+    super(hurt: hurt)
+    @hero2 = BattleStubActor.new(atk: 10, agi: 5, mp: 5, hp: 150, id: 2)
+    @actors = [@hero, @hero2]
+  end
+  def item_usable_by?(_it, actor_id); actor_id != 2; end
+end
+
+check "Enemy Encounter scene: a restricted item's ally-target picker skips the actor it excludes" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleRestrictedItemParty.new)
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN) # Skill -> Item
+  press_key(scene, RGSS::Input::C)    # open the item list
+  press_key(scene, RGSS::Input::C)    # choose the Potion -> ally target
+  eq :ally_target, ui[:phase]
+  eq 2, ui[:allies].reject(&:dead?).length, 'both actors are alive and in the fight'
+  targets = scene.send(:battle_ally_targets)
+  eq 1, targets.length, 'the restricted actor never appears as a choice'
+  eq 1, targets.first.actor.id, 'only the allowed actor is offered'
+  eq 0, ui[:ally_i], 'starts on the sole remaining candidate'
+  press_key(scene, RGSS::Input::DOWN)
+  eq 0, ui[:ally_i], 'a single candidate has nowhere to move to, unlike the ' \
+                     'unrestricted two-actor cursor above'
+  press_key(scene, RGSS::Input::C) # confirm -> queues the item on the allowed actor
+  eq :command, ui[:phase], 'hero 2 still has to pick their own action'
+  eq ui[:allies].first, ui[:allies].first.command[:target],
+     'the queued Item command targets actor 1, never the restricted actor 2'
 end
 
 check 'Enemy Encounter scene: draws a battler sprite per enemy, hidden on death' do


### PR DESCRIPTION
## Summary
- The "使用可能キャラ item restriction" (`actor_set`/`actor_set_size`, item
  fields 62/61) bullet in `docs/TODO.md` left one gap explicitly open: the
  battle screen's own ally-target picker for a restricted medicine/item
  (`Scene::Map#draw_battle_ally_target`) still listed every living ally
  regardless of the item's `actor_set` restriction — nothing upstream of it
  in the battle scene enforced the same restriction `Game::Party
  #item_usable_by?`/`#use_medicine` already apply in the field menu.
- `drive_battle_ally_target`/`draw_battle_ally_target` both called
  `living_allies` directly. A new `Scene::Map#battle_ally_targets` narrows
  `living_allies` by `item_usable_by?` when the pending action is a Battle
  Item (skills are untouched — `actor_set` only gates items/equipment), and
  is wired into both the picker's navigation and its label list, plus an
  empty-list guard on the confirm key so a fully-excluded item can't be
  confirmed onto nothing.
- `docs/TODO.md`'s "Left open" note is resolved in place with a citation of
  the fix and its regression coverage.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 677 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 333 checks pass (new check: a
      restricted item's ally-target picker skips the actor it excludes —
      confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_