### PR TITLE
rpg2k: a Move Route Change Graphic override survives a bystander's page-change rebuild

### DIFF
--- a/changelog.d/move-route-graphic-survives-bystander-page-change.fixed.md
+++ b/changelog.d/move-route-graphic-survives-bystander-page-change.fixed.md
@@ -1,0 +1,25 @@
+- **A map event's Move Route "Change Graphic" override no longer resets when
+  a *different* event's page flips.** `Scene::Map#pages_changed?` is a
+  map-wide check — any Control Switch/Variable/item/party write that flips
+  *any* event's active page triggers `#rebuild_events_preserving_positions`,
+  which rebuilds every event's `Game::Character` from scratch via
+  `#build_event`, and `#build_event` always sets `graphic_name`/
+  `graphic_index` fresh from whichever page it was just given (unlike
+  Through Mode/Direction Fix/Stop Animation/Transparency, which no page ever
+  sets, already fixed the same way for those four). An event whose own page
+  never changed still lost whatever a Set Move Route Change Graphic
+  sub-command had drawn it as, silently snapping back to its page's own base
+  sprite the instant some *other* event's Control Switch/Variable write flipped
+  a page anywhere on the map — well before the map transfer/save-load yado.tk
+  documents the override as actually reverting on (unlike the dedicated
+  Change Graphic event command). Fixed by carrying `graphic_name`/
+  `graphic_index` across the rebuild too, but only for a bystander whose own
+  page selection did not move (`old[:page].equal?(e[:page])`, the same
+  page-identity test `#pages_changed?` and the move-route-continuation check
+  already use) — an event whose own page genuinely does change to a
+  different base sprite still gets that new page's own graphic, not a stale
+  override painted back over it. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a bystander event's override survives
+  an unrelated event's switch-triggered page change, while a third event's
+  own page change to a different base sprite still wins), confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2428,9 +2428,38 @@ not yet verified:
   can't change mid-jump.
 - A move-route "Change Graphic" sub-command (hero, event, or vehicle) is
   **not persistent** — it reverts to the base graphic on save-load or map
-  transfer, unlike the dedicated Change Graphic event commands. (Already
-  fixed for the hero this session; vehicles and, per one source, non-hero
-  page-level graphic reverts on leave/return too, are not yet checked.)
+  transfer, unlike the dedicated Change Graphic event commands. ✅ **All three
+  targets are now confirmed correct.** The hero was fixed earlier this
+  session (`@player_char` reset on Transfer Player, see the "Fixed" section
+  above). A vehicle's own override was already correct by construction: the
+  Set Move Route vehicle work (see the "Full-site sweep" Event system section
+  below) landed its Change Graphic on a `Game::Character` mirror
+  (`@vehicle_chars`), never on the persisted `Game::Vehicle#charset_name`/
+  `#charset_index`, and `perform_teleport` clears `@vehicle_chars` outright —
+  reverting it on Transfer Player and save/load (`Scene::Map#initialize`
+  always builds a fresh `Scene::Map`) exactly like the hero, no code change
+  needed. **A map event's own override had a real, narrower gap**: it did
+  correctly revert on an actual map transfer (`build_events` derives
+  `graphic_name`/`graphic_index` fresh from the page every time, and a
+  Transfer Player never preserves anything), but
+  `Scene::Map#rebuild_events_preserving_positions` — the same in-place,
+  same-map rebuild that carries position/direction/Through Mode/Direction
+  Fix/Stop Animation/Transparency across an *unrelated* event's page change
+  (see the "Move Route / Character Movement command" fixes above) — had no
+  such carry-over for the graphic override, so any other event's Control
+  Switch/Variable write anywhere on the map silently snapped a bystander's
+  overridden sprite back to its page's own base graphic, well before any
+  genuine map transfer. Fixed by carrying `graphic_name`/`graphic_index`
+  across that rebuild too, but — unlike the four flags, which no page ever
+  sets — only for a bystander whose own page selection did not move
+  (`old[:page].equal?(e[:page])`, the same page-identity test
+  `#pages_changed?` and the move-route-continuation check already use): an
+  event whose own page genuinely changes to a different base sprite still
+  gets that new page's graphic, not a stale override painted back over it.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a bystander's
+  override survives an unrelated event's switch-triggered page change, while
+  a third event's own page change to a different base sprite still wins),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **Move Frequency set via a page now reasserts itself once a forced Move
   Route finishes** — the page's own frequency wins going forward, not
   whatever a Frequency Up/Down sub-command left it at. `Scene::Map#step_event`

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1689,6 +1689,22 @@ class RPG2k
       # other event's Control Switch/Variable/item write flips a page anywhere
       # on the map — the same "must be explicitly ended or it never turns back
       # off" state yado.tk documents for Through Mode specifically.
+      #
+      # A Move Route **Change Graphic** override is carried across the same
+      # way, but only for a bystander whose own page selection did not move
+      # (`old[:page].equal?(e[:page])`, the same page-identity test
+      # #pages_changed? and the move-route-continuation check just below both
+      # use) — unlike the four flags above, `#build_event` *does* set
+      # `graphic_name`/`graphic_index` from the page every time
+      # (`page_charset_name`/`page_charset_index`), so a genuine page switch
+      # for *this* event (a different page with its own different base
+      # sprite) must still win outright rather than have a stale override
+      # painted back over it. yado.tk documents the override as reverting on
+      # a real map transfer/save-load (unlike the dedicated Change Graphic
+      # event command) but says nothing about it surviving *this* event's own
+      # page reselecting — while an untouched bystander event, whose page
+      # never moved at all, has no such excuse to lose it either, the same
+      # reasoning already applied to Through Mode above.
       def rebuild_events_preserving_positions
         placed = {}
         @events.each { |e| placed[e[:id]] = e }
@@ -1703,6 +1719,9 @@ class RPG2k
           e[:char].facing_locked = old[:char].facing_locked
           e[:char].animation_stopped = old[:char].animation_stopped
           e[:char].transparency = old[:char].transparency
+          if old[:page].equal?(e[:page])
+            e[:char].set_graphic(old[:char].graphic_name, old[:char].graphic_index)
+          end
           next unless e[:move_type] == Game::MoveType::CUSTOM &&
                       old[:move_type] == Game::MoveType::CUSTOM
           if Game::MoveRoute.same_route?(page_move_route(old[:page]), page_move_route(e[:page]))

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -726,6 +726,50 @@ check "an unrelated event's page change does not reset another event's " \
   eq 5, ch.transparency, 'and Transparency Up/Down'
 end
 
+check "an unrelated event's page change does not reset another event's Move " \
+      "Route Change Graphic override, but the event's own page change still wins" do
+  # Event 1 is the bystander (own page never changes) and carries a Move
+  # Route Change Graphic override, poked directly onto its Character the same
+  # way the Through Mode check above pokes its four flags -- equivalent to
+  # what a Set Move Route Change Graphic sub-command applies via
+  # Character#set_graphic. Event 2 flips to a page gated on switch 3, the
+  # same map-wide #pages_changed? trigger that rebuilds every event's
+  # Character. Event 3 *also* changes its own page (same switch) to one with
+  # a different base charset and carries no override of its own: that page's
+  # own new graphic must still win outright, since #build_event always
+  # derives graphic_name/graphic_index fresh from whichever page is selected
+  # -- unlike Through Mode et al., a page *does* set this field, so only a
+  # bystander whose own page selection did not move gets its override carried
+  # forward.
+  bystander = page(trigger: 0, charset_name: 'Bystander')
+  p1 = page(trigger: 0, charset_name: 'Villager')
+  p2 = page(trigger: 4, charset_name: 'Ghost')
+  own_p1 = page(trigger: 0, charset_name: 'OwnBefore')
+  own_p2 = page(trigger: 0, charset_name: 'OwnAfter')
+  scene = new_scene({ 1 => event(1, 1, bystander),
+                      2 => two_page_event(2, 2, 3, p1, p2),
+                      3 => two_page_event(3, 3, 3, own_p1, own_p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.update
+
+  event_hashes(scene)[1][:char].set_graphic('Override', 4)
+
+  st.switches[3] = true # flips event 2's own page and event 3's own page alike
+  5.times { scene.update }
+
+  ev2 = event_hashes(scene)[2]
+  eq 4, ev2[:trigger], "event 2's page did flip (switch 3 went on)"
+
+  ch1 = event_hashes(scene)[1][:char]
+  eq 'Override', ch1.graphic_name,
+     "event 1's Move Route Change Graphic override survived event 2's page rebuild"
+  eq 4, ch1.graphic_index
+
+  ch3 = event_hashes(scene)[3][:char]
+  eq 'OwnAfter', ch3.graphic_name,
+     "event 3's own page change still wins over whatever it was drawing before"
+end
+
 check 'a page change keeps the event where it stands' do
   # The event walks east on page 1; when it flips to page 2 it must stay put
   # rather than snapping back to its spawn tile.


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s Move Route bullet notes a Move Route "Change Graphic"
  sub-command override reverts on save-load/map transfer, unlike the
  dedicated Change Graphic command — but left the vehicle and non-hero
  page-level cases unchecked. The vehicle case is already correctly
  handled (`@vehicle_chars` mirror cleared on `perform_teleport`, confirmed
  by reading the code, no change needed).
- The map-event case had a real, narrower gap than the TODO's framing:
  `Scene::Map#rebuild_events_preserving_positions` (the same in-place,
  same-map rebuild already fixed today for Through Mode/Direction Fix/Stop
  Animation/Transparency) never carried a Move Route Change Graphic
  override across the rebuild. Since that rebuild fires whenever *any*
  event's page flips anywhere on the map, an event's own overridden sprite
  was silently snapped back to its page's base graphic by a totally
  unrelated event's Control Switch/Variable write — well before any genuine
  map transfer/save-load, the only place yado.tk documents the override as
  reverting.
- `rebuild_events_preserving_positions` now carries `graphic_name`/
  `graphic_index` from the old to the new `Game::Character`, but only when
  the event's own page selection did not move (`old[:page].equal?(e[:page])`)
  — unlike the four flags fixed earlier today, `#build_event` derives the
  graphic fresh from the page every time, so a genuine same-event page
  change to a different base sprite must still win rather than have a stale
  override painted back over it.
- `docs/TODO.md` bullet expanded to ✅, citing all three cases (hero already
  fixed earlier today, vehicle confirmed already correct, map-event now
  fixed).

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 679 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 337 checks pass (new checks
      cover both the bystander-preservation case and the own-page-change
      regression guard; confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_