### PR TITLE
rpg2k: message \N[]/\V[] control codes accept a nested \V[n] argument

### DIFF
--- a/changelog.d/message-nested-variable-argument.fixed.md
+++ b/changelog.d/message-nested-variable-argument.fixed.md
@@ -1,0 +1,12 @@
+- **`\N[]`/`\V[]` message control codes now accept a nested `\V[n]` as their
+  own argument** (yado.tk: `\N[\V[1]]` names the actor whose id is variable
+  1's *value*, and `\V[\V[1]]` displays variable 1's value indirectly). The
+  bracket reader `Game::Message.read_bracket` used to stop at the first `]`
+  it saw, so `\N[\V[1]]` read its argument as the literal text `"\V[1"` (an
+  actor id of 0, since `.to_i` on that string is 0) and left the outer `]`
+  behind as stray text in the message. It now balances nested `[`/`]` pairs,
+  and a new `Game::Message.resolve_arg` recursively unwraps a `\v[]`/`\V[]`
+  argument to the variable's value before it reaches the actor-name/variable
+  lookup; a plain numeric argument (`\N[5]`, `\V[1]`) resolves exactly as
+  before. Covered by a new `scripts/rpg2k_logic_check.rb` check, confirmed
+  to fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2512,10 +2512,27 @@ not yet verified:
   real gap here — now fixed, see below.)
 - The built-in random-number operand is a genuine non-seeded RNG (two New
   Games produce different sequences) and accepts negative ranges.
-- `\N[]`/`\V[]` control codes can nest (`\N[\V[1]]`), but only on
-  post-"VALUE!" engine versions. An out-of-range `\N[]` argument crashes
-  the game; the same for `\V[]`/`\C[]`/`\S[]` degrades gracefully (e.g.
-  `\S[]` clamps).
+- ✅ **`\N[]`/`\V[]` control codes now accept a nested `\V[n]` as their own
+  argument** (`\N[\V[1]]` names the actor whose id is variable 1's *value*;
+  `\V[\V[1]]` displays variable 1's value indirectly) — this build has no
+  notion of the "post-VALUE!" engine-version gate the site names, so the
+  behaviour is implemented unconditionally, matching every real-world game
+  this codebase's test beds are drawn from. `Game::Message.read_bracket`
+  (`mruby-rpg2k/mrblib/game.rb`) used to stop at the first `]`, so
+  `\N[\V[1]]`'s argument read as the literal text `"\V[1"` (`.to_i` = 0, the
+  wrong actor) with the outer `]` left behind as stray text in the message;
+  it now balances nested `[`/`]` pairs, and a new `Game::Message.resolve_arg`
+  recursively unwraps a `\v[]`/`\V[]` argument to the variable's value before
+  the actor-name/variable lookup runs, leaving a plain numeric argument
+  (`\N[5]`, `\V[1]`) resolved exactly as before. `\C[]`/`\S[]` are untouched
+  — the site's wording doesn't name them as nesting-capable, only as
+  degrading gracefully out of range, which they already do (`\C[]` falls
+  back to a flat colour for an out-of-range index, already implemented;
+  `\S[]` is dropped outright today, a separate open question tracked in the
+  Message window doc above). An out-of-range `\N[]` argument crashing real
+  RPG_RT is a genuine engine crash, not reproduced here. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the
+  pre-fix code.
 
 **Pictures**
 - ✅ **50 concurrent picture slots; higher id always draws on top,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -128,8 +128,8 @@ module Game
           i += 2
           arg, i = read_bracket(text, i)
           case code
-          when 'v', 'V' then (s = variables[arg.to_i].to_s; cur << s; count += s.length) if arg
-          when 'n', 'N' then (s = (names[arg.to_i] || '').to_s; cur << s; count += s.length) if arg
+          when 'v', 'V' then (s = variables[resolve_arg(arg, variables)].to_s; cur << s; count += s.length) if arg
+          when 'n', 'N' then (s = (names[resolve_arg(arg, variables)] || '').to_s; cur << s; count += s.length) if arg
           when "\\"     then cur << "\\"; count += 1
           when '_'      then cur << ' '; count += 1 # half-width space
           when 'c', 'C' # colour change: close the current run, switch colour
@@ -193,13 +193,34 @@ module Game
     end
 
     # Read an optional "[digits]" argument at position i; returns [value, new_i].
+    # Brackets nest (yado.tk: `\N[]`/`\V[]` accept a `\V[n]` argument in place
+    # of a literal number, e.g. `\N[\V[1]]`), so an inner `[`/`]` pair widens
+    # the scan rather than closing it early -- otherwise `\N[\V[1]]` would read
+    # its argument as only `\V[1` (stopping at the *inner* `]`) and leave the
+    # outer `]` behind as stray literal text.
     def self.read_bracket(text, i)
       return [nil, i] unless i < text.length && text[i] == '['
       j = i + 1
-      j += 1 while j < text.length && text[j] != ']'
+      depth = 1
+      while j < text.length && depth > 0
+        depth += 1 if text[j] == '['
+        depth -= 1 if text[j] == ']'
+        j += 1 if depth > 0
+      end
       val = text[(i + 1)...j]
-      j += 1 if j < text.length # consume ']'
+      j += 1 if j < text.length # consume the matching ']'
       [val, j]
+    end
+
+    # Resolve a control code's bracket argument to the integer it names,
+    # recursively unwrapping a nested `\v[]`/`\V[]` (yado.tk: `\N[\V[1]]`
+    # substitutes variable 1's *value* as the actor id, not the literal text
+    # "\V[1]"; `\V[\V[1]]` reads the same way for indirect variable display).
+    # A plain numeric argument resolves the same as before (`"3".to_i`).
+    def self.resolve_arg(arg, variables)
+      return 0 if arg.nil?
+      m = /\A\\[vV]\[(.*)\]\z/m.match(arg)
+      m ? variables[resolve_arg(m[1], variables)].to_i : arg.to_i
     end
   end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -851,6 +851,20 @@ check 'Message.expand fills v/n codes and drops display codes' do
   eq '', Game::Message.expand(nil, vars, names)
 end
 
+check 'Message.expand resolves a nested \V[] argument inside \N[]/\V[] (yado.tk indirect addressing)' do
+  vars = Game::Variables.new
+  vars[1] = 5   # \N[\V[1]] should name actor #5, not actor #0
+  vars[5] = 42  # \V[\V[1]] should display variable #5's value...
+  names = { 5 => 'Aria' }
+  eq 'Aria', Game::Message.expand('\N[\V[1]]', vars, names)
+  eq '42', Game::Message.expand('\V[\V[1]]', vars, names)
+  # A plain numeric argument is unaffected by the bracket-balancing change.
+  eq 'Aria', Game::Message.expand('\N[5]', vars, names)
+  eq '5', Game::Message.expand('\V[1]', vars, names)
+  # No stray ']' leaks into the text from the outer bracket.
+  eq 'Aria!', Game::Message.expand('\N[\V[1]]!', vars, names)
+end
+
 check 'Message.parse splits colour runs and expands codes within them' do
   vars = Game::Variables.new
   vars[3] = 7


### PR DESCRIPTION
## Summary

- Yado.tk's quirks backlog (`docs/TODO.md`, "Variables & Switches" under the "Full-site sweep") documents that RPG2000's `\N[]`/`\V[]` message control codes accept a nested `\V[n]` as their own argument — `\N[\V[1]]` names the actor whose id is variable 1's *value*, and `\V[\V[1]]` displays variable 1's value indirectly.
- `Game::Message.read_bracket` (`mruby-rpg2k/mrblib/game.rb`) stopped scanning at the *first* `]` it saw, so `\N[\V[1]]`'s argument read as the literal text `"\V[1"` (`.to_i` → 0, the wrong actor) and left the outer `]` behind as stray text in the rendered message.
- `read_bracket` now balances nested `[`/`]` pairs, and a new `Game::Message.resolve_arg` recursively unwraps a `\v[]`/`\V[]` argument to the named variable's value before the actor-name/variable lookup runs. A plain numeric argument (`\N[5]`, `\V[1]`) resolves exactly as before — verified by the existing checks, unchanged.
- This build has no notion of the "post-VALUE!" engine-version gate the site names for this quirk, so the behaviour is implemented unconditionally, matching every real-world game this codebase's test beds are drawn from.
- `\C[]`/`\S[]` are untouched: the site names them only in the context of degrading gracefully on an out-of-range argument (not nesting), and they already do — `\C[]` already falls back to a flat colour for an out-of-range index, and `\S[]` is dropped outright today (a separate, larger open question already tracked in the Message window doc). An out-of-range `\N[]` argument crashing real RPG_RT is a genuine engine crash, not reproduced here.
- `docs/TODO.md` updated to ✅ with the code citation and what pins it; `changelog.d/message-nested-variable-argument.fixed.md` added per house style.

## Test plan

New `scripts/rpg2k_logic_check.rb` check added, confirmed to fail against the pre-fix code (`RuntimeError: expected "Aria", got "]"`) before the fix, and to pass after.

```
$ ruby scripts/rpg2k_logic_check.rb
rpg2k logic check: 680 checks passed

$ ruby scripts/rpg2k_scene_check.rb
rpg2k scene check: 336 checks passed
```

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01HS4KqoVXBoN58KrNrkJGFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HS4KqoVXBoN58KrNrkJGFX)_