### PR TITLE
rpg2k: field Equip menu's candidate list draws an Up/Down/Same comparison arrow

### DIFF
--- a/changelog.d/equip-menu-compare-arrow.added.md
+++ b/changelog.d/equip-menu-compare-arrow.added.md
@@ -1,0 +1,12 @@
+- **The field Equip menu's candidate list now shows an Up/Down/Same
+  comparison indicator** against whatever the slot currently holds — RPG_RT
+  computes it from the *sum* of all four combat-stat equip-bonus fields
+  (`atk_points1`/`def_points1`/`spi_points1`/`agi_points1`), not a per-stat
+  verdict, so a candidate trading `-2` Atk for `+3` Def still draws a single
+  Up arrow rather than a mixed readout. `Scene::EquipMenu#build_cand_window`
+  draws it as a third column (`^`/`v`/`-`) between the item name and its bag
+  count; RPG_RT itself draws small triangle icons here, which this build has
+  no icon-cell blit for yet, so a plain glyph stands in. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a strictly-better, strictly-worse and
+  exactly-equal candidate against a fixed worn item), confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3261,9 +3261,28 @@ above are repeated here)
   ○/×/★/□ icon shown per-tile in the editor only means "at least one of
   the 4 directions is passable" — a tile can show ○ and still block the
   specific direction actually being attempted.
-- The shop equipment-comparison arrow (Up/Same/Down) is computed from the
-  **sum** of all four stat deltas between currently-equipped and
-  candidate item, not evaluated per-stat.
+- ✅ **The equip-menu comparison arrow (Up/Same/Down) is computed from the
+  sum of all four stat deltas between the currently-equipped and candidate
+  item, not evaluated per-stat.** (The bullet's own wording says "shop", but
+  RPG2000 shops never compare equipment stats — only the field Equip screen's
+  own candidate list does; `01_shoshin`/`11_db` both describe this same
+  indicator on that screen.) `Scene::EquipMenu#build_cand_window`
+  (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) drew each candidate as a bare
+  name + bag count, with no comparison of any kind. Fixed by summing each
+  side's `atk_points1`/`def_points1`/`spi_points1`/`agi_points1` fields (the
+  combat quarter of `Game::Actor::EQUIP_BONUS_FIELD`'s five, max HP/SP
+  excluded) via a new `#item_stat_sum`, and drawing a third column between
+  the name and count holding the *sign* of `candidate_sum - equipped_sum`
+  only — `^`/`v`/`-` for the whole combined delta, never a per-stat verdict,
+  which is the actual yado.tk claim (a candidate trading `-2` Atk for `+3`
+  Def still draws a single Up arrow). RPG_RT draws small triangle icons here;
+  this build has no icon-cell blit for them yet, so a plain glyph stands in
+  — a later, purely-visual refinement, not a behaviour gap. The "Remove"
+  entry draws no arrow (nothing to compare an empty slot's combined points
+  against is confirmed either way). Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a strictly-better, a strictly-worse
+  and an exactly-equal candidate against a fixed worn item each draw the
+  right glyph), confirmed to fail against the pre-fix code before the fix.
 - Text color slots 1-4 have hardcoded semantic roles (stat label /
   value-increase / value-decrease / low-HP-MP warning), and a State's own
   configured display-color field is a pointer into that **same** shared

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -182,6 +182,37 @@ class RPG2k
           Rect.new(0, @slot_index * LINE_H, @slot_window.contents.width, LINE_H)
       end
 
+      # yado.tk: the equip-list comparison arrow is the *sum* of all four
+      # combat-stat deltas between a candidate and whatever currently
+      # occupies the slot, not four separate per-stat verdicts -- a weapon
+      # that trades -2 Atk for +3 Def still draws a single Up arrow (net +1),
+      # never a mixed per-stat readout. The four fields are RPG2000's own
+      # "points1" equip-bonus set (`Game::Actor::EQUIP_BONUS_FIELD`'s combat
+      # quarter -- max HP/SP have no comparison arrow, only the four battle
+      # stats do).
+      STAT_POINT_FIELDS = [:atk_points1, :def_points1, :spi_points1, :agi_points1].freeze
+
+      # The summed equip-bonus points of item `id` (0 for an empty slot, a
+      # missing database row, or a fixture item lacking these fields).
+      def item_stat_sum(id)
+        return 0 if id.nil? || id == 0
+        row = @state.party.db_item(id)
+        return 0 unless row
+        STAT_POINT_FIELDS.reduce(0) do |s, f|
+          s + ((row.respond_to?(f) ? row.send(f) : nil) || 0)
+        end
+      end
+
+      # '^' the candidate's combined stat points beat what is equipped now,
+      # 'v' it falls short, '-' the two are equal (RPG_RT draws small
+      # triangle icons here; plain glyphs stand in since this build has no
+      # icon-cell blit for them yet).
+      def equip_compare_arrow(delta)
+        return '^' if delta > 0
+        return 'v' if delta < 0
+        '-'
+      end
+
       def build_cand_window
         @cand_window.dispose if @cand_window
         rows = candidates
@@ -193,11 +224,14 @@ class RPG2k
         @cand_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
+        equipped_sum = item_stat_sum(actor.equipment[@slot_index])
         rows.each_with_index do |(id, count), i|
           if id == 0
             c.draw_text 0, i * LINE_H, inner_w, LINE_H, "(Remove)"
           else
-            c.draw_text 0, i * LINE_H, inner_w - 40, LINE_H, item_name(id)
+            c.draw_text 0, i * LINE_H, inner_w - 80, LINE_H, item_name(id)
+            c.draw_text inner_w - 80, i * LINE_H, 40, LINE_H,
+                        equip_compare_arrow(item_stat_sum(id) - equipped_sum)
             c.draw_text inner_w - 40, i * LINE_H, 40, LINE_H, ":#{count}"
           end
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6537,6 +6537,35 @@ check 'Scene::EquipMenu: a cursed item refuses to open the item list for its own
   eq :items, scene.instance_variable_get(:@mode)
 end
 
+# A party whose db_item rows carry the four RPG2000 "points1" equip-bonus
+# fields, so the comparison-arrow math has real numbers to add up. Item 1
+# is what the weapon slot already holds; 2/3/4 strictly beat, strictly fall
+# short of and exactly match its single non-zero field (atk_points1).
+class EquipCompareParty < MenuStubParty
+  ITEMS = {
+    1 => OpenStruct.new(name: 'Worn', atk_points1: 10),
+    2 => OpenStruct.new(name: 'Better', atk_points1: 15),
+    3 => OpenStruct.new(name: 'Worse', atk_points1: 5),
+    4 => OpenStruct.new(name: 'Same', atk_points1: 10)
+  }.freeze
+  def db_item(id); ITEMS[id]; end
+  def equip_candidates(_slot, _actor = nil); [[2, 1], [3, 1], [4, 1]]; end
+end
+
+check 'Scene::EquipMenu: the candidate arrow sums all four stat deltas against the worn item (yado.tk)' do
+  state = Game::State.new(EquipCompareParty.new, 1, 0, 0)
+  state.party.actors.first.equipment[0] = 1 # weapon slot already holds item 1 (atk 10)
+  scene = menu_scene(RPG2k::Scene::EquipMenu, state)
+  scene.instance_variable_set(:@mode, :items)
+  scene.send(:build_cand_window)
+  texts = window_texts(scene.instance_variable_get(:@cand_window))
+  # Row 0 is "(Remove)" (one draw_text call); each candidate row after it is
+  # three calls -- name, arrow, count -- so the arrows land at 2, 5, 8.
+  eq '^', texts[2], 'a candidate with strictly more combined points draws Up'
+  eq 'v', texts[5], 'one with strictly fewer draws Down'
+  eq '-', texts[8], 'an exact match draws Same, not counted per-stat'
+end
+
 check 'the status screen gives the condition a labelled row' do
   st = menu_state
   texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)


### PR DESCRIPTION
## Summary

- yado.tk's `11_db` (database field semantics) sweep documents RPG2000's field Equip screen as showing an Up/Same/Down comparison indicator next to each candidate item in a slot's pick list, computed from the **sum** of all four combat-stat equip-bonus fields (`atk_points1`/`def_points1`/`spi_points1`/`agi_points1`) against whatever the slot currently holds — not a per-stat verdict, so a candidate trading `-2` Atk for `+3` Def still draws a single Up arrow.
- `Scene::EquipMenu#build_cand_window` (`mruby-rpg2k/mrblib/scene/equip_menu.rb`) drew each candidate as a bare item name + bag count, with no comparison at all — a genuine gap, not something already modelled elsewhere.
- Fixed with a new `#item_stat_sum` helper (sums the four `points1` fields off the item's database row, guarding a missing row/field the way the rest of this file does) and a third rendered column between the name and count holding `^`/`v`/`-` for the sign of `candidate_sum - equipped_sum`. RPG_RT itself draws small triangle icons here; this build has no icon-cell blit for them yet, so a plain glyph stands in as a later, purely-visual refinement.
- `docs/TODO.md`'s "shop equipment-comparison arrow" bullet is corrected in the same edit — RPG2000 shops never compare equipment stats, only the field Equip screen does — and moved to `✅ Fixed`.
- New changelog fragment: `changelog.d/equip-menu-compare-arrow.added.md`.

## Test plan

`ruby scripts/rpg2k_logic_check.rb` and `ruby scripts/rpg2k_scene_check.rb` both pass with zero failures, including the new check:

```
rpg2k logic check: 679 checks passed
rpg2k scene check: 337 checks passed
```

The new `scripts/rpg2k_scene_check.rb` check ("Scene::EquipMenu: the candidate arrow sums all four stat deltas against the worn item (yado.tk)") was confirmed to fail against the pre-fix code before the fix (`expected "^", got ":1"` — no arrow column existed at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAm8HGfjrakgLuSuQKD9nM)_