### PR TITLE
rpg2k: shop buy-list rows carry an equipment stat-comparison arrow

### DIFF
--- a/changelog.d/shop-equip-stat-arrow.added.md
+++ b/changelog.d/shop-equip-stat-arrow.added.md
@@ -1,0 +1,11 @@
+- **The Open Shop buy list now carries a stat-comparison indicator on
+  equippable goods**, matching the yado.tk finding that RPG_RT's own arrow
+  is one aggregate Up/Same/Down symbol from the *sum* of all four
+  battle-stat deltas (Atk/Def/Int/Agi) between the candidate and whatever
+  the party's front actor currently has worn in that slot, not four
+  separate per-stat arrows. `Game::Shop#stat_arrow` (`mruby-rpg2k/mrblib/
+  game.rb`) returns 1 / 0 / -1, or `nil` for a non-equipment good (a
+  medicine, a skill book) or an empty party; `Scene::Map#shop_lines`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) appends a ` +`/` -` suffix to the
+  buy-list row accordingly, leaving a same-value or non-equipment row
+  untouched.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3290,9 +3290,33 @@ above are repeated here)
   ○/×/★/□ icon shown per-tile in the editor only means "at least one of
   the 4 directions is passable" — a tile can show ○ and still block the
   specific direction actually being attempted.
-- The shop equipment-comparison arrow (Up/Same/Down) is computed from the
-  **sum** of all four stat deltas between currently-equipped and
-  candidate item, not evaluated per-stat.
+- ✅ **The shop equipment-comparison arrow (Up/Same/Down) is computed from the
+  sum of all four stat deltas between currently-equipped and candidate item,
+  not evaluated per-stat.** The Open Shop buy list (`Scene::Map#shop_lines`,
+  `mruby-rpg2k/mrblib/scene/map.rb`) drew a plain `name  price` row for every
+  good with no comparison indicator at all — this was a genuine gap, not
+  merely undrawn: nothing in `Game::Shop` computed the comparison either.
+  Fixed with `Game::Shop#stat_arrow(id)` (`mruby-rpg2k/mrblib/game.rb`): for
+  an equippable good (its database `type` field maps to one of the five
+  equipment slots, mirroring `Party#equip_slot_for`'s own `type - 1`), it
+  sums `atk_points1`/`def_points1`/`spi_points1`/`agi_points1` — the same
+  four stats the Equip screen's own stat readout shows, HP/MP excluded — for
+  the candidate and for whatever currently occupies that slot on the party's
+  **front** actor, and returns the sign of the difference (1 up / 0 same / -1
+  down); a non-equipment good (a medicine, a skill book) or an empty party
+  returns `nil`, drawing no suffix. `shop_lines` appends a ` +`/` -` marker to
+  the row accordingly. **Comparing against the front actor specifically is
+  this build's own reading, not confirmed against real RPG_RT**: the shop
+  screen has no actor-select UI the way the Equip menu does, and neither test
+  bed's shop stock exercises a multi-member party, so whether RPG_RT's own
+  arrow is keyed to the front actor, the whole party, or something else
+  stays an open question — flagged in the code rather than guessed past.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks (`stat_arrow` against
+  a stronger/weaker/identical candidate, a non-equipment good, an empty
+  slot, and an empty party) and a new `scripts/rpg2k_scene_check.rb` check
+  (the buy-list row text carries the right suffix, or none, per good),
+  confirmed to fail against the pre-fix code (`stat_arrow` undefined) before
+  the fix.
 - Text color slots 1-4 have hardcoded semantic roles (stat label /
   value-increase / value-decrease / low-HP-MP warning), and a State's own
   configured display-color field is a pointer into that **same** shared

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5036,6 +5036,54 @@ module Game
       @did_transaction = true
       true
     end
+
+    # The equipment slot (0..4) item `id` occupies by its database type, or nil
+    # when it is not equipment -- the same `type - 1` mapping
+    # `Party#equip_slot_for` uses, kept local so the shop's stat-arrow lookup
+    # below works against a bare `@db`/`@party` pair (this test suite's
+    # `ShopStubParty` included) without requiring the full `Party` interface.
+    def item_equip_slot(id)
+      it = @db.item[id]
+      return nil unless it
+      t = it.respond_to?(:type) ? it.type : nil
+      (t.is_a?(Integer) && t >= 1 && t <= 5) ? t - 1 : nil
+    end
+    private :item_equip_slot
+
+    # The four battle-stat equip-bonus fields the arrow below sums, in
+    # `Actor::EQUIP_BONUS_FIELD`'s own order minus max_hp/max_sp -- the same
+    # four stats the Equip screen's own stat readout shows.
+    STAT_ARROW_FIELDS = [:atk_points1, :def_points1, :spi_points1, :agi_points1].freeze
+
+    # Item `id`'s own contribution to those four stats (0 for a non-equipment
+    # item, a missing item, or item 0/nil -- "nothing currently worn there").
+    def item_stat_sum(id)
+      return 0 if id.nil? || id == 0
+      it = @db.item[id]
+      return 0 unless it
+      STAT_ARROW_FIELDS.sum { |f| it.respond_to?(f) ? (it.send(f) || 0) : 0 }
+    end
+    private :item_stat_sum
+
+    # The buy-list Up/Same/Down indicator (yado.tk): comparing an equippable
+    # `id` against whatever the party's front actor -- the shop screen has no
+    # actor-select UI, unlike the Equip menu -- currently has worn in that
+    # same slot. RPG_RT's own arrow is one aggregate symbol from the *sum* of
+    # all four battle-stat deltas, not four separate per-stat arrows, so a
+    # weapon trading Atk for Agi in a way that nets positive still shows Up.
+    # Returns 1 (up) / 0 (same) / -1 (down), or nil when there is nothing to
+    # compare -- `id` is not equipment, or the party has no front actor.
+    # Comparing against the *front* actor specifically is this build's own
+    # reading, not confirmed against real RPG_RT: neither test bed's shop
+    # stock exercises a multi-member party, so which actor (if the choice
+    # even varies per member) stays an open question.
+    def stat_arrow(id)
+      slot = item_equip_slot(id)
+      return nil if slot.nil?
+      leader = @party.actors[0]
+      return nil unless leader && leader.respond_to?(:equipment)
+      (item_stat_sum(id) - item_stat_sum(leader.equipment[slot])) <=> 0
+    end
   end
 
   # Which battle backdrop (Backdrop/<name>) a fight on a given map uses.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2840,7 +2840,15 @@ class RPG2k
           [["#{verb} #{m.name(q[:id])} x#{q[:count]}  " \
             "#{unit * q[:count]}#{shop_gold_term}", q[:id]]]
         when :buy
-          m.goods.map { |id| ["#{m.name(id)}  #{m.price(id)}#{shop_gold_term}", id] }
+          m.goods.map do |id|
+            # yado.tk: an equippable good's row carries a one-symbol Up/Same/
+            # Down indicator against the front actor's currently-worn item in
+            # that slot (Game::Shop#stat_arrow); a non-equipment good (a
+            # medicine, a skill book) gets no suffix at all, matching nil.
+            arrow = m.stat_arrow(id)
+            suffix = arrow == 1 ? ' +' : (arrow == -1 ? ' -' : '')
+            ["#{m.name(id)}  #{m.price(id)}#{shop_gold_term}#{suffix}", id]
+          end
         else # :sell
           m.sellable_items.map do |id|
             ["#{m.name(id)} x#{@state.party.item_count(id)}  " \

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5728,6 +5728,44 @@ check 'Shop max_buy of a free item is limited only by the cap' do
   eq 99, shop.max_buy(4), 'a price-0 good does not divide by zero'
 end
 
+check 'Shop stat_arrow compares an equippable good to the front actor\'s slot' do
+  items = {
+    1 => fake_item(name: 'Long Sword', type: 1, atk: 5, price: 100),  # stronger
+    2 => fake_item(name: 'Dagger', type: 1, atk: 1, price: 50),       # weaker
+    3 => fake_item(name: 'Short Sword', type: 1, atk: 3, price: 60),  # currently worn
+    5 => fake_item(name: 'Potion', type: 0, price: 40)                # not equipment
+  }
+  db = FakeActorDB.new(
+    { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) },
+    [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.actors.first.equip_item(3) # Short Sword worn (atk_points1 3)
+  shop = Game::Shop.new(db, st.party, items.keys, true, true)
+  eq 1, shop.stat_arrow(1), 'a stronger weapon shows up (+1)'
+  eq(-1, shop.stat_arrow(2), 'a weaker weapon shows down (-1)')
+  eq 0, shop.stat_arrow(3), 'the currently-worn item itself nets to same (0)'
+  eq nil, shop.stat_arrow(5), 'a non-equipment good has nothing to compare (nil)'
+end
+
+check 'Shop stat_arrow reads an empty equipment slot as contributing zero' do
+  items = { 1 => fake_item(name: 'Long Sword', type: 1, atk: 5, price: 100) }
+  db = FakeActorDB.new(
+    { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) },
+    [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  shop = Game::Shop.new(db, st.party, items.keys, true, true)
+  eq 1, shop.stat_arrow(1), 'nothing worn there compares as zero, so any bonus is up'
+end
+
+check 'Shop stat_arrow is nil with no front actor to compare against' do
+  items = { 1 => fake_item(name: 'Long Sword', type: 1, atk: 5, price: 100) }
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 5) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.actors.clear # an empty active party -- nothing to compare against
+  shop = Game::Shop.new(db, st.party, items.keys, true, true)
+  eq nil, shop.stat_arrow(1)
+end
+
 check 'Shop max_buy is 0 for unstocked goods and in a sell-only shop' do
   _st, shop = shop_setup(500, { 3 => 100 })
   eq 0, shop.max_buy(7), 'not stocked'

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3115,6 +3115,42 @@ check 'Open Shop scene: buying then leaving runs the Transaction branch' do
   ok !st.switches[2], 'the No Transaction branch was skipped'
 end
 
+# A shop model stub exposing exactly what Scene::Map#shop_lines reads for a
+# :buy screen (#goods/#name/#price/#stat_arrow), so the row's arrow-suffix
+# formatting can be pinned without teaching the shared fake_db item table any
+# equipment fields -- Game::Shop#stat_arrow's own correctness (comparing
+# against the party's front actor) is covered directly in
+# scripts/rpg2k_logic_check.rb.
+class ShopArrowStubModel
+  NAMES = { 1 => 'Up Sword', 2 => 'Down Sword', 3 => 'Potion' }.freeze
+  PRICES = { 1 => 100, 2 => 100, 3 => 40 }.freeze
+  ARROWS = { 1 => 1, 2 => -1, 3 => nil }.freeze
+  def goods; NAMES.keys; end
+  def name(id); NAMES[id]; end
+  def price(id); PRICES[id]; end
+  def stat_arrow(id); ARROWS[id]; end
+end
+
+check 'Open Shop buy list: an equippable good carries the stat-comparison arrow' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3, 5], indent: 0), # buy-only, goods 3/5
+    ECmd.new(ic::SHOP_END, [], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the shop opens straight to the buy list (buy-only)
+  shop = scene.instance_variable_get(:@shop)
+  shop[:model] = ShopArrowStubModel.new
+  scene.send(:draw_shop)
+  labels = shop[:window].contents.draw_calls.map { |a| a[4] }
+  ok labels.include?('Up Sword  100G +'), 'a stat-improving good is suffixed +'
+  ok labels.include?('Down Sword  100G -'), 'a stat-lowering good is suffixed -'
+  ok labels.include?('Potion  40G'), 'a non-equipment good gets no suffix at all'
+end
+
 check 'Open Shop scene: the buy list cursor wraps around' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- yado.tk: the shop's buy-list row for an equippable good carries a
  one-symbol Up/Same/Down indicator, computed from the *sum* of all four
  battle-stat deltas (Atk/Def/Spi/Agi) against whatever the party's front
  actor currently has worn in that slot — not four separate per-stat
  arrows, so a weapon trading Atk for Agi in a way that nets positive still
  shows Up.
- `Game::Shop` had no comparison logic at all, and `Scene::Map#shop_lines`
  drew a bare `name  price` row with no indicator.
- Adds `Game::Shop#stat_arrow(id)` (returns `1`/`0`/`-1`/`nil`) plus private
  helpers `item_equip_slot`/`item_stat_sum`; wired into `shop_lines`' `:buy`
  branch as a `' +'`/`' -'` suffix (no suffix for a non-equipment good or
  when there's nothing to compare against).
- Comparing against the *front* actor specifically is this build's own
  reading, flagged as such in `docs/TODO.md` — neither test bed's shop
  stock exercises a multi-member party, so whether RPG_RT varies the
  comparison actor stays an open, unconfirmed question.
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 682 checks pass (three new
      checks on `Game::Shop#stat_arrow`: stronger/weaker/identical
      candidate, non-equipment good, empty slot, empty party)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 338 checks pass (new check
      pinning the buy-list row's exact suffix text)
- All new checks confirmed to fail against the pre-fix code
  (`NoMethodError: undefined method 'stat_arrow'`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_