### PR TITLE
rpg2k: a Change Encounter Rate override no longer survives a map change

### DIFF
--- a/changelog.d/encounter-rate-override-resets-on-map-change.fixed.md
+++ b/changelog.d/encounter-rate-override-resets-on-map-change.fixed.md
@@ -1,0 +1,18 @@
+- **A Change Encounter Rate override no longer survives a map change.**
+  `Game::State#encounter_rate` (Change Encounter Rate, 11740) had no
+  expiration of any kind — once set it silently overrode every future map's
+  own `encount_steps` for the rest of the game, save/load included. yado.tk
+  groups this together with Chipset Change, Panorama/Parallax Change and
+  Tile Replacement as one family of per-map runtime overrides that reset the
+  moment the party leaves and returns to a map, not just on save/load; the
+  other three were already confirmed correct here, and Change Encounter Rate
+  was the one still-open member of that family now that a working
+  wandering-monster system exists to read it at all (`Scene::Map
+  #current_encounter_steps`). `Scene::Map#perform_teleport` — the one method
+  every map change (an ordinary Transfer Player, a Teleport/Escape skill,
+  and by extension a same-map leave-and-return) already routes through —
+  now resets `@state.encounter_rate` to `nil` there too, alongside the
+  existing tileset/parallax/pan resets, so `#current_encounter_steps` falls
+  back to the destination map's own tree-node setting. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2251,11 +2251,20 @@ not yet verified:
   the destination's `.lmu` fresh) rather than reusing or caching one — so
   a substitution cannot survive a Teleport, including one back to the same
   map, without any explicit reset code needed. Regression-covered by a new
-  `scripts/rpg2k_scene_check.rb` check. **Encounter Steps Change is not
-  actionable yet**: `Game::State#encounter_rate` records the override and
-  round-trips through the save, but no random-encounter system reads it at
-  all (see the Screen effects section) — there is nothing to reset until
-  that system exists.
+  `scripts/rpg2k_scene_check.rb` check. ✅ **Encounter Steps Change is now
+  fixed too** — it had stopped being the "not actionable, no reader exists"
+  case this bullet originally described the moment the wandering-monster
+  system landed (`Scene::Map#current_encounter_steps` reads
+  `@state.encounter_rate` when set), but nothing then reset the override on
+  a map change the way the tileset/parallax/pan resets already did a few
+  lines up in the same method. `perform_teleport` now sets
+  `@state.encounter_rate = nil` alongside those, so a Change Encounter Rate
+  command's effect ends the moment the party leaves the map, matching this
+  bullet's other three confirmed members. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (an override recorded via Change
+  Encounter Rate, then a Teleport back to the same map id, falls back to
+  the map tree node's own `encount_steps`), confirmed to fail against the
+  pre-fix code before the fix.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5212,6 +5212,12 @@ class RPG2k
         # from (304, 352) -- entirely outside a 320x240 map, i.e. a blank screen.
         @state.screen.pan_clear
         @locked_cam = nil
+        # ... nor does a Change Encounter Rate override: the destination map's
+        # own encount_steps applies again (yado.tk, corroborated with Chipset/
+        # Panorama/Tile Replacement as one family of per-map runtime overrides
+        # that reset on any map change, not just a save/load) -- #current_encounter_steps
+        # falls back to the map's own rate whenever this is nil.
+        @state.encounter_rate = nil
         @tileset_id = nil # a Change Map Tileset override does not survive a teleport
         @chipset = build_chipset
         # The new map may use a different chipset graphic, so reload it too;

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2581,6 +2581,26 @@ check 'a teleport clears every shown picture' do
   ok st.pictures.empty?, 'the picture did not survive the map change'
 end
 
+check 'a Change Encounter Rate override does not survive a teleport' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::CHANGE_ENCOUNTER_RATE, [4]),
+    ECmd.new(ic::TELEPORT, [1, 4, 3]),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  eq 4, st.encounter_rate, 'the override took effect before the teleport'
+  20.times { scene.update }
+  eq 1, st.map_id, 'teleported'
+  eq nil, st.encounter_rate,
+     'the destination reverts to the map\'s own encount_steps, matching Chipset/' \
+     'Panorama/Tile Replacement -- an override does not survive any map change'
+  eq 25, scene.send(:current_encounter_steps),
+     "current_encounter_steps falls back to the map tree node's own setting again"
+end
+
 check 'the menu opens on cancel only when menu access is allowed' do
   scene = new_scene({}, player: [2, 2])
   parent = scene.instance_variable_get(:@parent)


### PR DESCRIPTION
## Summary

- `Scene::Map#perform_teleport` already resets the Change Map Tileset / Change Parallax Background / Pan Screen overrides the instant the party leaves a map, but `Game::State#encounter_rate` (set by Change Encounter Rate, 11740) had no such reset — once set, it silently overrode every later map's own `encount_steps` for the rest of the game, including across save/load.
- yado.tk groups this together with Chipset Change, Panorama/Parallax Change and Tile Replacement as one family of per-map runtime overrides that reset the moment the party leaves-and-returns to a map, not just on save/load. `docs/TODO.md` already had the other three confirmed correct, with Change Encounter Rate left as "not actionable yet" from before the wandering-monster encounter system (`Scene::Map#current_encounter_steps`) existed to read the override at all.
- Fix: `perform_teleport` now sets `@state.encounter_rate = nil` alongside the existing tileset/parallax/pan resets, so `#current_encounter_steps` falls back to the destination map's own tree-node `encount_steps` again.
- Docs: `docs/TODO.md`'s "Runtime per-map overrides..." bullet gets a ✅ update explaining the fix, and a new `changelog.d/encounter-rate-override-resets-on-map-change.fixed.md` fragment.

## Test plan

New `scripts/rpg2k_scene_check.rb` check: a Change Encounter Rate override takes effect, then a Teleport back to the same map id, then the override is gone and `current_encounter_steps` reads the map tree node's own setting again. Confirmed to fail against the pre-fix code (`RuntimeError: expected nil, got 4`) before the fix.

```
$ ruby scripts/rpg2k_logic_check.rb
...
rpg2k logic check: 680 checks passed

$ ruby scripts/rpg2k_scene_check.rb
...
rpg2k scene check: 339 checks passed
```

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GVCjV9eZfCoaTS1KXXkLmv)_