### PR TITLE
rpg2k: a Change Encounter Steps override does not survive a teleport

### DIFF
--- a/changelog.d/encounter-rate-teleport-reset.fixed.md
+++ b/changelog.d/encounter-rate-teleport-reset.fixed.md
@@ -1,0 +1,17 @@
+- **A Change Encounter Steps (11740) override no longer survives leaving and
+  returning to a map.** `Scene::Map#perform_teleport` already reset the
+  sibling per-map overrides on a Teleport (Chipset, Panorama, Pan/camera lock,
+  the hero's forced-route Change Graphic) but had no equivalent reset for
+  `Game::State#encounter_rate`, so a Change Encounter Steps command issued on
+  one map silently kept overriding `#current_encounter_steps` on every map
+  visited afterwards instead of yielding back to that new map's own
+  `encount_steps` — a real, reachable divergence now that random
+  ("wandering-monster") encounters read `encounter_rate` at all. Fixed by
+  clearing it in `#perform_teleport`, the single call site for both an
+  ordinary Transfer Player and a queued Teleport/Escape field-skill warp; the
+  value still round-trips through save/load undisturbed, matching yado.tk's
+  distinction between "resets on leaving-and-returning to the map" (Chipset/
+  Panorama/Encounter Steps/Tile Replacement) and "resets on save/load" (a
+  separate, narrower list this is not part of). Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix
+  code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2238,7 +2238,7 @@ not yet verified:
   be a non-issue rather than a gap — nothing here enforces a count ceiling on
   how many distinct ids get used, which is a different question from a single
   variable's *value* range, now fixed); picture id range 1-50.
-- **Runtime per-map overrides that reset on leaving-and-returning to the
+- ✅ **Runtime per-map overrides that reset on leaving-and-returning to the
   map**, not just on Transfer Player/save-load: Chipset Change, Panorama/
   parallax Change, Encounter Steps Change, Tile Replacement, and — per one
   source — Save/Teleport/Escape Prohibition changes. `perform_teleport`
@@ -2251,11 +2251,24 @@ not yet verified:
   the destination's `.lmu` fresh) rather than reusing or caching one — so
   a substitution cannot survive a Teleport, including one back to the same
   map, without any explicit reset code needed. Regression-covered by a new
-  `scripts/rpg2k_scene_check.rb` check. **Encounter Steps Change is not
-  actionable yet**: `Game::State#encounter_rate` records the override and
-  round-trips through the save, but no random-encounter system reads it at
-  all (see the Screen effects section) — there is nothing to reset until
-  that system exists.
+  `scripts/rpg2k_scene_check.rb` check. **Encounter Steps Change is now
+  fixed too.** It was flagged not-yet-actionable in an earlier pass —
+  `Game::State#encounter_rate` recorded the override and round-tripped
+  through the save, but no random-encounter system read it at all — and
+  stayed that way until this session's own wandering-monster-encounter work
+  (`Scene::Map#current_encounter_steps`) made it a genuine, reachable gap:
+  `#current_encounter_steps` reads `encounter_rate` when set, falling back to
+  the map-tree node's own `encount_steps`, but `perform_teleport` never
+  cleared it alongside the sibling tileset/parallax/pan resets right next to
+  it — so a Change Encounter Steps command issued on one map silently kept
+  overriding every map visited afterwards instead of yielding back to each
+  destination's own setting. Fixed by adding `@state.encounter_rate = nil` to
+  `perform_teleport`, the one call site both an ordinary Transfer Player and
+  a queued Teleport/Escape field-skill warp route through; the value still
+  round-trips through save/load untouched, matching the "leaving-and-
+  returning to the map" reset condition rather than a save/load one. Covered
+  by a new `scripts/rpg2k_scene_check.rb` check, confirmed to fail against
+  the pre-fix code before the fix.
 
 **Event triggers & page selection**
 - Map/common event page selection: only the single **highest-numbered**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5212,6 +5212,13 @@ class RPG2k
         # from (304, 352) -- entirely outside a 320x240 map, i.e. a blank screen.
         @state.screen.pan_clear
         @locked_cam = nil
+        # A Change Encounter Steps (11740) override does not survive a teleport
+        # either; the destination map's own encount_steps applies again, exactly
+        # like Chipset/Panorama above (yado.tk: this is one of the per-map
+        # overrides that resets on leaving-and-returning to a map, not just on
+        # save/load). #current_encounter_steps falls back to the map-tree node's
+        # own field once this is nil again.
+        @state.encounter_rate = nil
         @tileset_id = nil # a Change Map Tileset override does not survive a teleport
         @chipset = build_chipset
         # The new map may use a different chipset graphic, so reload it too;

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7213,6 +7213,22 @@ check 'a map with no tree data defaults to 25 encounter steps' do
   eq 25, scene.send(:current_encounter_steps)
 end
 
+check 'Change Encounter Rate does not survive leaving and returning to the map' do
+  # yado.tk: a Change Encounter Steps (11740) override is one of the per-map
+  # overrides (alongside Chipset/Panorama/Tile Substitution) that resets on
+  # leaving-and-returning to a map, not just on an ordinary Transfer Player to
+  # a *different* map -- #perform_teleport is the one call site for both.
+  tree = fake_map_tree(1 => FakeEncounterNode.new({}, 25))
+  scene = new_scene({}, map_tree: tree)
+  st = scene.instance_variable_get(:@state)
+  st.encounter_rate = 4
+  eq 4, scene.send(:current_encounter_steps), 'the override applies on the original map'
+
+  scene.send(:perform_teleport, [st.map_id, 0, 0, 0]) # leave and return to the same map
+  eq 25, scene.send(:current_encounter_steps),
+     "a fresh map load on Teleport drops the override, back to the tree node's own steps"
+end
+
 check 'an encounter-steps of 0 disables random encounters and resets the accumulator' do
   tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 0))
   scene = new_scene({}, map_tree: tree)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "runtime per-map overrides that reset on leaving-and-
  returning to the map" bullet listed Change Encounter Steps as "not
  actionable yet" because no random-encounter system read `Game::State
  #encounter_rate` at all. That premise went stale earlier today when
  random (wandering-monster) encounters landed and added
  `Scene::Map#current_encounter_steps`, which does read `encounter_rate`
  (falling back to the map-tree node's own `encount_steps` when unset) —
  but `perform_teleport` was never updated to reset it, unlike the sibling
  Chipset/Panorama/Pan overrides right next to it.
- That made the bullet's "not actionable" reasoning obsolete and turned it
  into a real bug: a Change Encounter Steps (11740) issued on one map
  silently kept overriding the encounter-steps setting on every map
  visited afterward, instead of yielding back to each destination's own
  configured value on a Transfer Player / Teleport-skill warp.
- Fixed with `@state.encounter_rate = nil` in `perform_teleport`, the one
  call site both an ordinary map change and a queued Teleport/Escape
  field-skill warp route through. The value still round-trips through
  save/load untouched, matching yado.tk's distinction between resetting on
  leave-and-return vs. on save/load.
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 680 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 339 checks pass (new check:
      Change Encounter Rate does not survive leaving and returning to the
      map — confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_