### PR TITLE
rpg2k: a Common Event Parallel Process's Show Battle Animation now plays

### DIFF
--- a/changelog.d/parallel-process-battle-animation.fixed.md
+++ b/changelog.d/parallel-process-battle-animation.fixed.md
@@ -1,0 +1,21 @@
+- **A Common Event Parallel Process's Show Battle Animation (11210) now
+  actually plays**, instead of the "wait until it finishes" flag being
+  silently ignored. `Scene::Map#drive_parallel_wait`'s wait-kind dispatch had
+  no `:animation` branch, so a parallel process blocked on one fell into the
+  generic "background: ignore message/choice/teleport requests" case and was
+  `#resume`d immediately — the animation was never built or drawn. Fixed by
+  generalizing `#drive_map_animation`/`#init_map_animation`/
+  `#start_map_animation` to take the waiting interpreter explicitly (a new
+  `@map_animation_interp` tracks which one currently owns the single on-screen
+  animation slot, so `#step_map_animation`/`#step_animation_wait` resume the
+  right one rather than always the foreground `@interpreter`) and adding a
+  `:animation` branch to `#drive_parallel_wait` that reuses it — matching
+  yado.tk's "only one Battle Animation is ever on screen at a time" now
+  holding for a parallel-process request too, not just a foreground one. If
+  the slot is already held by a different interpreter's animation, the new
+  request simply waits its turn rather than modelling one animation cutting
+  another short (unconfirmed against real RPG_RT). Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (the parallel process is held while
+  the animation plays and resumes once it finishes; the animation actually
+  renders — sprite shown, flash fired — for a parallel-process request, not
+  just a foreground one), both confirmed to fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3011,6 +3011,32 @@ not yet verified:
   off the first); 1 frame = 1/30s, but a "Wait" frame is internally
   **two** consecutive 0.0s-wait frames, not one; chaining two Show Battle
   Animation calls back-to-back produces a visible one-frame stutter.
+  ✅ **A Common Event Parallel Process's own Show Battle Animation (11210)
+  now actually plays**, rather than its "wait until it finishes" flag being
+  silently ignored. `Scene::Map#drive_parallel_wait`'s wait-kind dispatch had
+  no `:animation` case at all, so a parallel process that issued one fell
+  into the generic "background: ignore message/choice/teleport requests"
+  branch and was `#resume`d on the very next frame — the animation was never
+  built, drawn, or waited on, only the foreground `@interpreter`'s own
+  requests ever reached `#drive_map_animation`. Fixed by generalizing
+  `#drive_map_animation`/`#init_map_animation`/`#start_map_animation` to take
+  the waiting interpreter explicitly — a new `@map_animation_interp` tracks
+  which one currently owns the single `@map_animation`/`@anim_wait` slot, so
+  `#step_map_animation`/`#step_animation_wait` resume the right one instead of
+  always the foreground `@interpreter` — and adding a `:animation` branch to
+  `#drive_parallel_wait` that drives the same shared renderer. This only
+  covers making a parallel process's request render and block that process at
+  all; the "only one at a time, second forcibly cuts off the first" precedence
+  rule between two *concurrent* requests (which interpreter, if any, gets
+  bumped) is intentionally left unmodelled — a request arriving while the slot
+  is held simply waits its turn — since resolving it needs a real RPG_RT
+  comparison this environment cannot run. The "Wait frame is two 0.0s frames"
+  and "back-to-back calls stutter" claims are likewise still open. Covered by
+  two new `scripts/rpg2k_scene_check.rb` checks (a parallel process's Show
+  Battle Animation holds it, then resumes once the animation finishes; the
+  animation actually renders — sprite shown, screen flash fired — for a
+  parallel-process request, not just a foreground one), both confirmed to
+  fail against the pre-fix code before the fix.
 - ✅ **A Timer with "valid during battle" checked force-ends the battle**
   the instant it reaches 0:00, regardless of encounter source (default or
   scripted) — an easy accidental trap if the same Timer is reused for a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -124,6 +124,11 @@ class RPG2k
         @wait_timer = nil
         @anim_wait = nil
         @map_animation = nil
+        # Which interpreter (the foreground event, or a parallel process) is
+        # waiting on @map_animation / @anim_wait right now -- see
+        # #drive_map_animation, so the right one gets #resume'd, not always
+        # the foreground @interpreter.
+        @map_animation_interp = nil
         # One window per timer (RPG2003 has two); built lazily when first shown.
         @timer_windows = [nil, nil]
         @timer_texts = [nil, nil]
@@ -1115,6 +1120,12 @@ class RPG2k
         elsif it.wait_kind == :key_input
           # Parallel processes commonly poll a key each frame into a variable.
           resolve_key_input(it)
+        elsif it.wait_kind == :animation
+          # A Show Battle Animation with its wait flag set, issued from a
+          # parallel process rather than the foreground event -- shares the
+          # same single on-screen animation slot #drive_map_animation already
+          # drives for the foreground, see there.
+          drive_map_animation(it)
         else
           it.resume # background: ignore message/choice/teleport requests
         end
@@ -2554,7 +2565,7 @@ class RPG2k
           when :return_title then perform_return_to_title
           when :game_over then perform_game_over
           when :name_input then drive_name_input
-          when :animation then drive_map_animation
+          when :animation then drive_map_animation(@interpreter)
           when :sprite_flash then @interpreter.resume unless sprite_flashing?
           when :save_menu then perform_event_save
           when :menu then perform_event_menu
@@ -4982,20 +4993,31 @@ class RPG2k
       ANIM_CELL = 96
       ANIM_SHEET_COLS = 5
 
-      # Drive a Show Battle Animation (11210) wait: play the animation over its
-      # target, then resume the event. When the animation's data / sheet is
+      # Drive a Show Battle Animation (11210) wait for interpreter `it` -- the
+      # foreground event, or a parallel process that issued one of its own (both
+      # share this one on-screen animation slot, matching yado.tk: only one
+      # battle animation is ever on screen at a time): play the animation over
+      # its target, then resume `it`. When the animation's data / sheet is
       # available it advances frame by frame (composited by #draw_map_animation),
       # firing the screen flashes its timings request; otherwise it degrades to a
-      # plain timed wait, so a cutscene paces the same as RPG_RT either way.
-      def drive_map_animation
-        init_map_animation if @map_animation.nil? && @anim_wait.nil?
+      # plain timed wait, so a cutscene paces the same as RPG_RT either way. If
+      # the slot is currently held by a *different* interpreter's animation, `it`
+      # simply waits its turn -- this build does not model one animation cutting
+      # another short, only that they cannot render concurrently.
+      def drive_map_animation(it)
+        if @map_animation.nil? && @anim_wait.nil?
+          @map_animation_interp = it
+          init_map_animation(it)
+        end
+        return unless @map_animation_interp.equal?(it)
         @map_animation ? step_map_animation : step_animation_wait
       end
 
-      # Begin the animation: build the frame-by-frame player from the request, or
-      # arm the timed-wait fallback when there is no drawable animation.
-      def init_map_animation
-        @map_animation = start_map_animation
+      # Begin the animation: build the frame-by-frame player from `it`'s
+      # request, or arm the timed-wait fallback when there is no drawable
+      # animation.
+      def init_map_animation(it)
+        @map_animation = start_map_animation(it)
         if @map_animation
           fire_animation_flashes(@map_animation) # frame 0 flashes
         else
@@ -5018,9 +5040,12 @@ class RPG2k
           # entry (see #animation_sheet) that a later replay of this
           # animation reuses, not something this one play owns.
           @map_animation = nil
-          # A battle animation is driven by the round rather than by an event
-          # command, so there is no paused interpreter waiting on it.
-          @interpreter.resume unless ma[:battle]
+          owner = @map_animation_interp
+          @map_animation_interp = nil
+          # A battle-round animation (#start_battle_animation) is driven by the
+          # round rather than by an event command, so it never set an owner --
+          # there is no paused interpreter waiting on it.
+          owner.resume unless ma[:battle] || owner.nil?
           return
         end
         fire_animation_flashes(ma)
@@ -5030,7 +5055,9 @@ class RPG2k
       def step_animation_wait
         if @anim_wait <= 0
           @anim_wait = nil
-          @interpreter.resume
+          owner = @map_animation_interp
+          @map_animation_interp = nil
+          owner.resume if owner
         else
           @anim_wait -= 1
         end
@@ -5038,8 +5065,8 @@ class RPG2k
 
       # Build the animation player, or nil when the animation is unknown or its
       # Battle/<name> sheet is missing (then the timed-wait fallback runs).
-      def start_map_animation
-        req = @interpreter.battle_animation
+      def start_map_animation(it)
+        req = it.battle_animation
         return nil unless req
         tx, ty = animation_target_pixel(req[:target])
         build_animation(req[:animation], tx, ty)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4194,6 +4194,53 @@ check 'Show Battle Animation plays: an animation sprite shows and a flash fires'
   ok !spr.visible, 'the animation sprite is hidden once it finishes'
 end
 
+# yado.tk: only one Battle Animation is ever on screen at once -- true of the
+# map-level Show Battle Animation command (11210) same as an in-battle one.
+# That only means anything if a *parallel process* can show one at all: before
+# this fix, #drive_parallel_wait's wait-kind dispatch had no :animation branch,
+# so it fell into the generic "background: ignore message/choice/teleport
+# requests" case and called #resume immediately -- the animation was never
+# built or drawn, and the "wait until it finishes" flag did nothing.
+check "a Common Event Parallel Process's Show Battle Animation (wait) actually plays and blocks it" do
+  ic = Game::Interpreter::Cmd
+  # animation 7 has no drawable data in the fake db (see the fallback-wait
+  # check above), so this exercises the timed-wait fallback path.
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [7, 10001, 1], indent: 0),
+                              ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  3.times { scene.update }
+  ok !st.switches[5],
+     'the parallel process must be held while the animation plays, not resumed at once'
+  60.times { scene.update } # outlast the fallback animation length
+  ok st.switches[5], 'the parallel process resumes once the animation finishes'
+end
+
+check "a Common Event Parallel Process's Show Battle Animation draws a sprite and flash" do
+  ic = Game::Interpreter::Cmd
+  # animation 8 is the drawable one in the fake db (see the foreground check
+  # above) -- this pins that a parallel process's request reaches the same
+  # renderer, not just that its own wait resolves.
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),
+                              ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  spr = scene.instance_variable_get(:@animation_sprite)
+  shown = false
+  flashed = false
+  40.times do
+    scene.update
+    shown ||= spr.visible
+    flashed ||= st.screen.flashing?
+    break if st.switches[6]
+  end
+  ok shown, 'the animation sprite was shown while the parallel process\'s animation played'
+  ok flashed, 'a screen-flash timing fired during it'
+  ok st.switches[6], 'the parallel process resumed after the animation'
+end
+
 check 'a vehicle placed on the current map is drawn; one off-map or absent is not' do
   scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary

yado.tk's "Battle Animation" quirk (Full-site sweep, Battle system section) states only one Battle Animation is ever on screen at a time. Checking that against the code turned up a real gap: a **Common Event Parallel Process**'s own Show Battle Animation (11210) command with the "wait until it finishes" flag checked was silently inert.

`Scene::Map#drive_parallel_wait`'s wait-kind dispatch had no `:animation` branch, so a parallel process blocked on one fell into the generic `else` case ("background: ignore message/choice/teleport requests") and was `#resume`d on the very next frame — the animation was never built, drawn, or waited on. Only the foreground `@interpreter`'s own Show Battle Animation ever reached `#drive_map_animation`.

## Fix

- Generalized `#drive_map_animation`/`#init_map_animation`/`#start_map_animation` to take the waiting interpreter explicitly, with a new `@map_animation_interp` tracking which one currently owns the single `@map_animation`/`@anim_wait` slot — so `#step_map_animation`/`#step_animation_wait` resume the *right* interpreter instead of always the foreground one.
- Added an `:animation` branch to `#drive_parallel_wait` that reuses the same driver.
- Scope note: this only makes a parallel process's request render and correctly block that process. The "second forcibly cuts off the first" precedence rule between two truly *concurrent* requests is intentionally left unmodelled (a later request just waits its turn for the slot) since resolving that needs a real RPG_RT/wine comparison this environment can't run — documented as still-open in `docs/TODO.md`.

## Test plan

New `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against the pre-fix code (`git stash` the map.rb change and re-run — 2 failures, exactly the new checks):
- a parallel process's Show Battle Animation (wait) holds it, then resumes once the animation finishes
- the animation actually renders (sprite shown, screen flash fired) for a parallel-process request, not just a foreground one

```
$ ruby scripts/rpg2k_scene_check.rb
rpg2k scene check: 341 checks passed

$ ruby scripts/rpg2k_logic_check.rb
rpg2k logic check: 680 checks passed
```

Also updated `docs/TODO.md` (Full-site sweep → Battle system) and added `changelog.d/parallel-process-battle-animation.fixed.md` per house style.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8WRijfsiEK7kvxbZiw3fd)_