### PR TITLE
rpg2k: field menu's End Game returns to title immediately

### DIFF
--- a/changelog.d/rpg2k-end-game-immediate-return-to-title.fixed.md
+++ b/changelog.d/rpg2k-end-game-immediate-return-to-title.fixed.md
@@ -1,0 +1,8 @@
+- **RPG2000/2003**: the field menu's **End Game** command now calls
+  `return_to_title` immediately, the same as F12 and the "Return to Title
+  Screen" event command, instead of first showing a "Returning to title..."
+  message and waiting on a second button press to dismiss it before tearing
+  the scene stack down. The extra confirmation step was pure added latency
+  measured with `RGSS::Profiler`: the teardown/rebuild itself costs the same
+  ~5ms whether triggered from the bare map or with the field menu open on
+  top, so the wait was not buying any safety, just an extra round-trip.

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -123,7 +123,7 @@ class RPG2k
             show_message("You cannot save right now.")
           end
         when :end_game
-          show_message("Returning to title...", :end_game)
+          @parent.return_to_title
         else
           show_message("#{label} is not implemented yet.")
         end
@@ -131,12 +131,10 @@ class RPG2k
 
       def drive_message
         return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
-        done = @message[:done]
         close_message
-        @parent.return_to_title if done == :end_game
       end
 
-      def show_message(text, done = nil)
+      def show_message(text)
         return if @message
         w = SCREEN_W - 40
         win = Window.new(20, SCREEN_H - 40, w, 14 + Window::BORDER * 2)
@@ -146,7 +144,7 @@ class RPG2k
         c.font.color = Color.new(255, 255, 255, 255)
         c.draw_text 0, 0, c.width, 14, text
         win.contents = c
-        @message = { window: win, done: done }
+        @message = { window: win }
       end
 
       def close_message

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6217,6 +6217,18 @@ check 'Scene::Menu: choosing Item pushes Scene::ItemMenu (and the rest their own
   end
 end
 
+check 'Scene::Menu: End Game returns to the title on the first press, like F12 and ' \
+      'the Return to Title Screen event command' do
+  scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
+  scene.instance_variable_set(:@index, 5)  # End Game, last of COMMAND_KEYS
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  ok scene.parent.returned_to_title,
+     'End Game hands control back to the app immediately, with no confirmation ' \
+     'message to dismiss first'
+end
+
 check 'the item / skill target list shows who is afflicted' do
   st = menu_state
   st.party.actors.first.add_state(4)                    # Sleep


### PR DESCRIPTION
## Summary

- Selecting **End Game** from the field menu (`mruby-rpg2k/mrblib/scene/menu.rb`) showed a "Returning to title..." message and waited for a *second* button press before calling `return_to_title` — unlike F12 and the "Return to Title Screen" event command, which call it immediately. `select_command`'s `:end_game` branch now calls `@parent.return_to_title` directly, matching those two paths.
- Removed the now-dead `done`-tracking machinery this left behind in `show_message`/`drive_message` (it existed only to special-case the `:end_game` message).
- Added a `Scene::Menu` regression check in `scripts/rpg2k_scene_check.rb` asserting End Game reaches `return_to_title` on the very first press.

## Why

Investigated via `RGSS::Profiler`, built natively and run headlessly against both `mtf-meido-action` and `Nepheshel` (see the two test-bed scripts). The scene teardown/rebuild `return_to_title` performs costs the same ~5ms whether triggered from the bare map or with the field menu open on top (menu dispose only added ~0.05ms). So the extra confirmation step wasn't buying any real safety margin against a slow teardown — it was just an extra round-trip (notice the message, press again) before the fast part even started.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 338 checks passed (including the new one)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 679 checks passed
- [x] `cmake --build build -t test` — 8/8 CTest suites passed
- [x] Native binary sanity-booted headlessly (`--rpg2k_new_game`) against Nepheshel under Xvfb with no crash

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FinxYwd9eV87XRhjyRYsLj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FinxYwd9eV87XRhjyRYsLj)_