### PR TITLE
rgss: match genuine RPG_RT key-repeat timing

### DIFF
--- a/changelog.d/rgss-input-repeat-timing.fixed.md
+++ b/changelog.d/rgss-input-repeat-timing.fixed.md
@@ -1,0 +1,7 @@
+- **`RGSS::Input` key-repeat timing** now matches the genuine RPG_RT.exe
+  (RPG Maker 2000 runtime), measured by holding a direction key on a title
+  menu under wine and timing the cursor's moves: a held key repeats after 24
+  frames (~400ms @60fps) instead of 30 (~500ms), then every 4 frames (~67ms)
+  instead of every 6 (~100ms). This shared `Input` module backs RPG2k, RPGXP
+  and RPGVX menu/map navigation, so the shorter, snappier repeat now applies
+  across all three engines.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1400,11 +1400,14 @@ module RGSS
       # triggered), so a tap that landed since the last call is visible now.
       _poll
 
-      # Update repeat state
+      # Update repeat state. Timings measured against the genuine RPG_RT.exe
+      # (RPG Maker 2000 runtime) under wine: holding a direction key on a
+      # title/menu cursor moves once immediately, then again after 24 frames
+      # (~400ms @60fps), then every 4 frames (~67ms) after that.
       @pressed.each_index do |i|
         if @pressed[i]
           @count[i] += 1
-          if @count[i] >= 30 && @count[i] % 6 == 0
+          if @count[i] >= 24 && @count[i] % 4 == 0
             @repeated[i] = true
           else
             @repeated[i] = false


### PR DESCRIPTION
## Summary

- `RGSS::Input`'s key-repeat delay felt too long compared to the genuine RPG Maker 2000 runtime.
- Measured the real `RPG_RT.exe` (Nepheshel test-bed) under wine: booted it headlessly via Xvfb, held a direction key on the title menu, and captured screenshots at ~100-115fps to time exactly when the cursor moved between menu rows (detected by tracking the green cursor-box outline's pixel color per row).
- Across 5 trials (~210 steady-state intervals), the genuine runtime's first repeat fires at **24 held frames** (~400ms @60fps) and repeats every **4 frames** (~67ms) after that — versus this engine's previous 30 frames (~500ms) and every 6 frames (~100ms). The measured averages (384ms / 66.6ms) match the 24/4-frame theoretical values (383.3ms / 66.7ms) far better than any nearby alternative, and were cross-checked against the title cursor's own idle-blink animation (200ms = 12 frames @60fps) to confirm the frame-rate assumption.
- `RGSS::Input` is shared by RPG2k, RPGXP and RPGVX menu/map navigation (RPG2k depends on `mruby-rgss`), so this shortens repeat delay across all three engines.

## Test plan

- [x] `ruby -c mruby-rgss/mrblib/lib.rb` — syntax check passes.
- [x] No existing test pins the previous 30/6 constants (searched `mruby-rgss/test/test.rb`).
- [ ] CI build/test suite (submodules weren't checked out locally, so the full C++/mruby build wasn't run in this environment).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TyN4N1GVdSybiPt7FAZ4Nu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyN4N1GVdSybiPt7FAZ4Nu)_