### PR TITLE
rpg2k: Show Battle Animation's sprite is exempt from map screen tone

### DIFF
--- a/changelog.d/battle-animation-tone-exempt.fixed.md
+++ b/changelog.d/battle-animation-tone-exempt.fixed.md
@@ -1,0 +1,16 @@
+- **Show Battle Animation's sprite is no longer darkened/tinted by an active
+  Change Screen Tone.** `@animation_sprite` (`mruby-rpg2k/mrblib/scene/map.rb`,
+  the one renderer both a field/parallel-process Show Battle Animation and an
+  in-battle attack's own animation share) used to be a child of
+  `@map_viewport`, the same viewport `#update_map_tone` tints — so a Tint
+  Screen active on the map wrongly washed out every animation play too,
+  contradicting yado.tk's "pictures, screen/character flash, battle
+  animations, and message text are all completely unaffected even at a
+  maximal dark tone." Fixed by making it a top-level sprite (no viewport, so
+  no tone reaches it) and splitting the upper (above-character) chip layer
+  into its own `@upper_viewport`, tinted in lockstep with `@map_viewport` by
+  `#update_map_tone` — needed only so `@animation_sprite` can keep drawing in
+  its original slot (over the hero, under the upper chip layer) without
+  itself living inside either toned viewport. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against the
+  pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2666,6 +2666,31 @@ not yet verified:
   are all completely unaffected even at a maximal dark tone; Erase Screen,
   by contrast, hides literally everything. Screen tone **persists across
   map transfers** with no auto-reset (unlike most per-map overrides).
+  **The pictures / flash / message-text halves were already correct**:
+  `Scene::Map#setup_sprites` (`mruby-rpg2k/mrblib/scene/map.rb`) always built
+  `@picture_sprite`/`@flash_sprite`/`@fade_sprite`/`@weather_sprite` and every
+  message window as plain top-level sprites, never children of the toned
+  `@map_viewport`, so `#update_map_tone`'s viewport tone never reached them —
+  no code change needed. ✅ **Battle animations were the one genuine gap, now
+  fixed.** `@animation_sprite` — the single shared renderer both a field/
+  parallel-process Show Battle Animation (11210) and an in-battle attack's own
+  animation play through (`#step_map_animation`) — was a child of
+  `@map_viewport` too, so an active Tint Screen wrongly darkened/tinted every
+  animation play along with the tiles and hero. Fixed by making it a
+  top-level sprite (outside any toned viewport) and splitting the upper
+  (above-character) chip layer into its own `@upper_viewport`, tinted in
+  lockstep with `@map_viewport` by `#update_map_tone` — needed only so
+  `@animation_sprite` keeps drawing in its original slot (over the hero,
+  under the upper chip layer; gfx_update's per-parent z sort compares a
+  Viewport as one block against its siblings, so pulling one sprite out of a
+  shared viewport changes only whether that viewport's tone reaches it, not
+  where it draws relative to the layers around it) without itself living
+  inside either toned viewport. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (the upper chip layer still takes the
+  identical tone `@map_viewport` does; the animation sprite's viewport is
+  neither of the two tinted ones, and it still draws between the player and
+  upper-layer sprites), both confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **Erase Screen's blackout is auto-cancelled by opening and closing the
   Menu or Save screen**, even though no "Show Screen" ran. `Scene::Menu`
   (Save is one of its commands, not a scene of its own — see the Menu screen

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -207,8 +207,9 @@ class RPG2k
         (@timer_windows || []).each { |w| w.dispose if w }
         @airship_shadow.dispose if @airship_shadow
         @animation_sprite.dispose if @animation_sprite
-        # After the sprites it holds, so nothing is orphaned inside it.
+        # After the sprites they hold, so nothing is orphaned inside them.
         @map_viewport.dispose if @map_viewport
+        @upper_viewport.dispose if @upper_viewport
         @flash_buffer.dispose if @flash_buffer
         @flash_out_buffer.dispose if @flash_out_buffer
         @chipset_bmp.dispose if @chipset_bmp
@@ -311,8 +312,17 @@ class RPG2k
         @lower_bmp = Bitmap.new(COLS * TILE, ROWS * TILE)
         @lower_sprite.bitmap = @lower_bmp
 
-        @upper_sprite = Sprite.new(@map_viewport)
-        @upper_sprite.z = 200
+        # The upper (above-character) chip layer lives in its own viewport
+        # rather than @map_viewport, purely so a Show Battle Animation sprite
+        # can be sandwiched between the two (see @animation_sprite below)
+        # without moving into or out of a toned viewport itself -- it keeps
+        # exactly the tone @map_viewport gets, applied in lockstep by
+        # #update_map_tone, matching "the map tile+character layer" the
+        # yado.tk finding scopes Change Screen Tone to.
+        @upper_viewport = Viewport.new(0, 0, SCREEN_W, SCREEN_H)
+        @upper_viewport.z = 200 # same top-level slot the sprite held inside @map_viewport
+        @upper_sprite = Sprite.new(@upper_viewport)
+        @upper_sprite.z = 200 # sole child of @upper_viewport, so this is only for parity
         @upper_bmp = Bitmap.new(COLS * TILE, ROWS * TILE)
         @upper_sprite.bitmap = @upper_bmp
 
@@ -345,8 +355,22 @@ class RPG2k
         @airship_shadow.bitmap = shadow
 
         # A screen-sized layer the Show Battle Animation renderer composites the
-        # current frame's cells into, over the map (above the hero).
-        @animation_sprite = Sprite.new(@map_viewport)
+        # current frame's cells into, over the map (above the hero). A
+        # top-level sprite, not a child of @map_viewport: yado.tk documents
+        # Change Screen Tone as affecting only the map tile+character layer --
+        # pictures, screen/character flash, battle animations and message text
+        # all stay unaffected even at a maximal dark tone, but this sprite used
+        # to live inside the same toned viewport as the tiles and hero, so an
+        # active map tone wrongly tinted every Show Battle Animation (11210)
+        # play, both the field/parallel-process one and an in-battle attack's
+        # own, since both render through this one shared sprite (#step_map_animation).
+        # Its z (150) is unchanged, so it still draws in the same slot between
+        # @map_viewport (z 100) and the upper layer's own @upper_viewport
+        # (z 200) it always has -- top-level z ordering compares a Viewport as
+        # one block against its siblings (gfx_update's per-parent z sort), so
+        # pulling this one sprite out changes only whether the map's tone
+        # reaches it, not where it draws relative to the layers around it.
+        @animation_sprite = Sprite.new
         @animation_sprite.z = 150
         @animation_sprite.visible = false
         @animation_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
@@ -567,8 +591,14 @@ class RPG2k
       end
 
       # Apply a Tint Screen tone (`[r, g, b, sat]`, each 0..200 with 100 neutral)
-      # to the whole map view, by setting it on the viewport every map sprite
-      # lives in.
+      # to the map tile+character layer, by setting it on the two viewports
+      # that layer's sprites live in -- @map_viewport (tiles below the upper
+      # chip layer, the hero, vehicles) and @upper_viewport (the above-character
+      # chip layer, split out so @animation_sprite can sit between the two
+      # without itself being a child of either, see its own comment). Both get
+      # the identical tone in lockstep, so the split is invisible to anything
+      # that only cares about "is the map tinted" -- only @animation_sprite,
+      # the picture layer and everything above it are exempt.
       #
       # This used to be approximated by a black overlay whose opacity tracked how
       # far the channels averaged *below* neutral, which meant brightening did
@@ -586,11 +616,20 @@ class RPG2k
         r, g, b, sat = tint
         return if @map_tint == tint
         @map_tint = tint.dup
-        @map_viewport.tone = Tone.new(Scene::Map.tone_channel(r),
-                                      Scene::Map.tone_channel(g),
-                                      Scene::Map.tone_channel(b),
-                                      -Scene::Map.tone_channel(sat))
+        tr = Scene::Map.tone_channel(r)
+        tg = Scene::Map.tone_channel(g)
+        tb = Scene::Map.tone_channel(b)
+        tsat = -Scene::Map.tone_channel(sat)
+        @map_viewport.tone = Tone.new(tr, tg, tb, tsat)
         @map_viewport.update if @map_viewport.respond_to?(:update)
+        if @upper_viewport
+          # A separate Tone instance, not the same object shared across both
+          # viewports -- Tone has mutable component setters (red=, etc.), so
+          # aliasing one between two viewports would risk a later in-place
+          # tweak to one silently retuning the other.
+          @upper_viewport.tone = Tone.new(tr, tg, tb, tsat)
+          @upper_viewport.update if @upper_viewport.respond_to?(:update)
+        end
       rescue StandardError => e
         $stderr.puts "[RPG2k] screen tone failed, map drawn untinted: #{e.message}"
         nil

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -615,6 +615,14 @@ end
 # owning sprites of their own.
 MAP_LAYER_IVARS = %i[@parallax_sprite @lower_sprite @airship_shadow
                      @player_sprite @animation_sprite @upper_sprite].freeze
+# The subset of MAP_LAYER_IVARS the map's own tone must actually reach --
+# @animation_sprite is deliberately excluded: it sits at its own z between
+# @player_sprite and @upper_sprite (so the order test above still holds), but
+# it is Show Battle Animation's shared renderer, and yado.tk documents battle
+# animations as tone-exempt just like a picture -- it lives outside both
+# @map_viewport and @upper_viewport for exactly this reason (see
+# Scene::Map#setup_sprites).
+MAP_TONED_IVARS = (MAP_LAYER_IVARS - %i[@animation_sprite]).freeze
 # ... and everything that draws *over* the map, which the screen tone must not
 # touch: pictures carry their own tone, and the weather / flash / fade overlays
 # are screen effects in their own right.
@@ -4378,20 +4386,52 @@ end
 check 'the tone reaches the map layers and nothing above them' do
   scene = tint_scene(0, 0, 0, 100, 0, 0)
   vp = scene.instance_variable_get(:@map_viewport)
-  MAP_LAYER_IVARS.each do |i|
+  vp2 = scene.instance_variable_get(:@upper_viewport)
+  ok vp2, 'the upper chip layer has its own viewport'
+  ok vp2.tone, 'a tone reached the upper viewport too'
+  eq vp.tone, vp2.tone,
+     'the upper chip layer takes the identical tone as the rest of the map'
+  MAP_TONED_IVARS.each do |i|
     spr = scene.instance_variable_get(i)
     next unless spr # a layer this scene did not build
-    ok spr.viewport.equal?(vp), "#{i} is tinted with the map"
+    ok spr.viewport.equal?(vp) || spr.viewport.equal?(vp2),
+       "#{i} is tinted with the map"
   end
   ABOVE_MAP_IVARS.each do |i|
     spr = scene.instance_variable_get(i)
     next unless spr
-    ok !spr.viewport.equal?(vp),
+    ok !spr.viewport.equal?(vp) && !spr.viewport.equal?(vp2),
        "#{i} must not be tinted -- it draws over the map"
   end
   scene.instance_variable_get(:@vehicle_sprites).each_value do |spr|
     ok spr.viewport.equal?(vp), 'a vehicle is tinted with the map it sits on'
   end
+end
+
+# yado.tk: "Change Screen Tone affects only the map tile+character layer --
+# pictures, screen/character flash, battle animations, and message text are
+# all completely unaffected even at a maximal dark tone." @animation_sprite
+# (Show Battle Animation's shared renderer, field/parallel-process and
+# in-battle alike, see Scene::Map#step_map_animation) used to live inside
+# @map_viewport along with the tiles and hero, so an active map tone wrongly
+# tinted every animation play too. Confirmed to fail against the pre-fix code
+# (the sprite's viewport equalled @map_viewport).
+check "an active map tone does not reach Show Battle Animation's sprite" do
+  scene = tint_scene(0, 0, 0, 100, 0, 0)
+  vp = scene.instance_variable_get(:@map_viewport)
+  vp2 = scene.instance_variable_get(:@upper_viewport)
+  spr = scene.instance_variable_get(:@animation_sprite)
+  ok spr, 'the animation sprite exists'
+  ok !spr.viewport, 'it is a top-level sprite, not a child of any toned viewport'
+  ok !spr.viewport.equal?(vp) && !spr.viewport.equal?(vp2),
+     'either way, it does not share a viewport with the tinted map layers'
+  # And it still draws in the same slot it always has: over the hero, under
+  # the upper (above-character) chip layer -- the tone fix must not have
+  # reordered anything.
+  ok spr.z > sprite_z(scene, :@player_sprite),
+     'still drawn over the player sprite'
+  ok spr.z < sprite_z(scene, :@upper_sprite),
+     'still drawn under the upper chip layer'
 end
 
 check 'the choice window plays the cursor and decision system sounds' do


### PR DESCRIPTION
## Summary
- yado.tk scopes Change Screen Tone to only the map tile+character layer —
  pictures, screen/character flash, battle animations and message text stay
  unaffected even at a maximal dark tone.
- The pictures/flash/message-text halves were already correct (those
  sprites are top-level, never children of the toned `@map_viewport`), but
  `@animation_sprite` — the one sprite both a field/parallel-process Show
  Battle Animation (11210) and an in-battle attack's own animation render
  through (`#step_map_animation`) — was a `@map_viewport` child, so an
  active tone wrongly tinted every animation play along with the tiles and
  hero.
- `@animation_sprite` is now top-level (no viewport, so no tone reaches
  it). To preserve its exact prior visual stacking (over the hero, under
  the above-character chip layer) without touching the still-open "does a
  battle animation draw above the picture layer?" question elsewhere in
  `docs/TODO.md`, the upper chip layer moves into its own `@upper_viewport`,
  tinted in lockstep with `@map_viewport` by `#update_map_tone` (two
  separate `Tone` instances, since `Tone` has mutable setters and sharing
  one would risk aliasing). Top-level z ordering compares a viewport as one
  block against its siblings, so pulling `@animation_sprite` out of
  `@map_viewport` changes only whether the tone reaches it, not where it
  draws relative to the layers around it.
- `docs/TODO.md` updated ✅, also recording the pictures/flash/message
  halves as already correct.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 680 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 343 checks pass (new check: an
      active map tone does not reach Show Battle Animation's sprite;
      updated the existing "tone reaches the map layers" check for the
      viewport split — both confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_