### PR TITLE
rpg2k: confirm Show Hidden Monster reveals a reinforcement before a premature battle-end

### DIFF
--- a/changelog.d/battle-hidden-monster-reveal-confirmed.changed.md
+++ b/changelog.d/battle-hidden-monster-reveal-confirmed.changed.md
@@ -1,0 +1,8 @@
+- **Show Hidden Monster (Enemy Appearance) is confirmed rather than an open
+  yado.tk claim.** A scripted reinforcement can't be lost to a premature
+  victory when the enemies visible so far are wiped before its own Show
+  Hidden Monster command fires: the mid-round battle-page check already lands
+  strictly before the round's own `battle.finished?` test, so the
+  reinforcement's `hidden` flag is always cleared in time. Targeting an
+  already-revealed troop member is also confirmed as the silent no-op it
+  should be. Covered by a new `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3070,10 +3070,31 @@ not yet verified:
   the Win nor Lose branch of the enclosing Battle Processing command —
   it's a third, unlabeled outcome that resumes right after Branch End,
   and only increments the battle-count stat (not loss/escape counts).
-- Enemy Appearance targeting an already-appeared enemy is a silent no-op;
-  if all *currently-present* enemies are wiped before a scripted
-  reinforcement's appearance command fires, the battle just ends and that
-  reinforcement never spawns.
+- ✅ **Enemy Appearance (Show Hidden Monster) already gets both halves of this
+  right.** Targeting an already-appeared enemy is a silent no-op:
+  `Scene::Map#reveal_battle_monster` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  returns immediately once `member.hidden` is already false, before touching
+  the sprite or the combatant. The "reinforcement never spawns" half looked
+  like a real gap on paper — `Game::Battle::Combatant#out_of_play?` treats a
+  still-hidden troop member as not-alive
+  (`dead? || hidden`), so `#finished?` would read a fight as won the instant
+  the only *visible* enemy died, if a scripted reinforcement's own Show
+  Hidden Monster hadn't cleared its `hidden` flag yet — but it already has to
+  have, by construction: this is exactly the race the "Battle pages are
+  checked far more often" fix above (`@battle_ui[:battler_boundary]`) closes.
+  A battle page conditioned on the dying enemy's HP gets to run — and, via
+  `#apply_battle_event_requests`, have its Show Hidden Monster command take
+  effect — at the battler boundary right after the killing blow, strictly
+  before `#drive_battle_animate`'s next `step_action` call (finding nothing
+  left pending for the round) reaches `#finish_round_animation`'s own
+  `battle.finished?` check; the two are sequential states in the same phase
+  machine (`:event` must finish and return to `:animate` before `:animate`
+  can ever reach that check again), not a race that can land either way.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a reinforcement
+  hidden behind an Enemy-HP-conditioned page is revealed while the battle is
+  still running, never after it has already settled into `:result`; a second
+  reveal of an already-visible member is confirmed to be a sprite-rebuild
+  no-op), confirmed to fail if the battler-boundary check is disabled.
 - **Documented race condition**: a Battle Processing "Lose: Branch"
   that revives the party can still lose to an erroneous instant Game Over
   if a Parallel Process is running concurrently — the parallel process's

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5542,6 +5542,71 @@ check 'a battle page conditioned on enemy HP fires mid-round, before the round s
      'landed), not only once the round settled back to :command for the next one'
 end
 
+# yado.tk (`2k/01_shoshin/011_siyou/`, Enemy Appearance / Show Hidden Monster):
+# a scripted reinforcement can be lost if all *currently-present* enemies die
+# before its own appearance command fires -- the battle would just end. This
+# is already avoided here as a side effect of the "checked far more often"
+# fix above: #run_battle_events fires at the battler boundary right after the
+# killing blow, strictly before drive_battle_animate's next step_action call
+# (finding nothing pending) reaches #finish_round_animation's own
+# `battle.finished?` check -- so a Show Hidden Monster queued by that page has
+# already cleared the reinforcement's `hidden` flag (via
+# #apply_battle_event_requests, driven every frame the page is running) well
+# before the round could settle into a premature victory.
+check 'a battle page reveals a reinforcement before the round can end in a premature victory (yado.tk)' do
+  ic = Game::Interpreter::Cmd
+  # Fires the instant troop member 0's HP hits 0, showing hidden troop member
+  # 1 -- the "boss dies, a fresh enemy steps in" script the site describes.
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_HIDDEN_MONSTER, [1])],
+                            Game::BattlePage::ENEMY_HP, enemy_id: 0, enemy_hp_max: 0) }
+  scene, st = battle_scene_with_pages(pages)
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :command
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  # Troop member 1 stands in for a placed-but-invisible reinforcement.
+  ui[:foes][1].hidden = true
+  ui[:troop].members[1].hidden = true
+  # The killing blow that ends member 0's HP at exactly 0, matching a 0%..0%
+  # Enemy HP page condition -- this build's battle HP is not floor-clamped
+  # mid-fight, only written back through Battle#apply_to_party at battle end,
+  # so an *overkill* hit landing well past 0 would never satisfy a 0% window;
+  # exactly 0 sidesteps that separate, unverified question and isolates the
+  # one this check is actually about.
+  ui[:battle].enemy(0).hp = 0
+  # Simulate the exact moment drive_battle_animate lands right after the
+  # battler whose action just landed that blow: the battler-boundary flag it
+  # sets (see @battle_ui[:battler_boundary]) is what gives every battle page
+  # one more chance to fire before step_action next finds nothing pending and
+  # the round settles via #finish_round_animation's own `battle.finished?`
+  # check.
+  ui[:phase] = :animate
+  ui[:battler_boundary] = true
+  revealed_before_victory = nil
+  20.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    break unless ui
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break unless ui
+    next if ui[:foes][1].hidden
+    revealed_before_victory = ui[:phase] != :result
+    break
+  end
+  ok !revealed_before_victory.nil?, 'the reinforcement was revealed within the budget'
+  ok revealed_before_victory,
+     'it was revealed before the round could settle into a premature victory, not after'
+  # Enemy Appearance targeting an already-appeared enemy is a silent no-op:
+  # #reveal_battle_monster returns immediately once `hidden` is already false,
+  # so a second reveal neither rebuilds the sprite nor errors.
+  sprite_before = ui[:enemy_sprites][1]
+  scene.send(:reveal_battle_monster, 1)
+  eq sprite_before, scene.instance_variable_get(:@battle_ui)[:enemy_sprites][1],
+     'revealing an already-visible member again is a no-op, not a sprite rebuild'
+end
+
 check 'Terminate Battle from a page ends the fight and resumes the event' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }


### PR DESCRIPTION
## Summary

Triaged a yado.tk backlog item from `docs/TODO.md`'s "Untriaged backlog, from `2k/01_shoshin/011_siyou/`" section (Battle system bullet):

> Enemy Appearance targeting an already-appeared enemy is a silent no-op; if all *currently-present* enemies are wiped before a scripted reinforcement's appearance command fires, the battle just ends and that reinforcement never spawns.

Both halves of this claim already hold in the codebase, no code change needed:

- **Already-appeared no-op**: `Scene::Map#reveal_battle_monster` returns immediately once `member.hidden` is already `false`, before touching the sprite or the combatant.
- **Reinforcement never spawns**: this looked like a real gap at first read — `Game::Battle::Combatant#out_of_play?` treats a still-hidden troop member as not-alive (`dead? || hidden`), so `#finished?` would read the fight as won the instant the only *visible* enemy died, if a scripted reinforcement's own Show Hidden Monster page hadn't cleared its `hidden` flag yet. But it already has to have, by construction: this is exactly the race an earlier session's "Battle pages are checked far more often" fix (`@battle_ui[:battler_boundary]`) closes. A battle page conditioned on the dying enemy's HP gets to run — and have its Show Hidden Monster command take effect via `#apply_battle_event_requests` — at the battler boundary right after the killing blow, strictly before `#drive_battle_animate`'s next `step_action` call (finding nothing left pending for the round) reaches `#finish_round_animation`'s own `battle.finished?` check. The two are sequential states in the same phase machine (`:event` must finish and return to `:animate` before `:animate` can ever reach that check again), not a race that can land either way.

## Changes

- `docs/TODO.md`: moved the bullet into "confirmed already correct" style with the citation above.
- `scripts/rpg2k_scene_check.rb`: new check driving a synthetic 2-member troop — member 0 killed exactly at 0 HP (avoiding this build's separate, unverified overkill-goes-negative-mid-fight question), member 1 hidden as the reinforcement, a page conditioned on member 0's HP hitting 0% that fires Show Hidden Monster on member 1. Asserts the reinforcement is revealed while the battle is still running (never after it has settled into `:result`), and that a second reveal of an already-visible member is a no-op rather than a sprite rebuild.
- `changelog.d/battle-hidden-monster-reveal-confirmed.changed.md`: changelog fragment.

## Verification

- Confirmed the new check is a meaningful regression pin: temporarily disabling the `battler_boundary` mid-round check in `drive_battle_animate` makes it fail (battle ends in premature victory instead of revealing the reinforcement); restored before committing.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 680 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 343 checks passed (new check confirmed to fail against the battler-boundary-disabled variant, and pass on the actual code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HrpJ4mC5ATFfydfaURsnhZ)_