### PR TITLE
rpg2k: Berserk collapses attack-all and drops the preemptive jump; forced attacks honour dual-wield

### DIFF
--- a/changelog.d/battle-berserk-attack-all-preemptive.fixed.md
+++ b/changelog.d/battle-berserk-attack-all-preemptive.fixed.md
@@ -1,0 +1,21 @@
+- **A Berserk-style forced "attack enemy" restriction now collapses an
+  attack-all weapon down to its single forced target and drops the weapon's
+  own "always acts first" turn-order jump**, matching the site's
+  デフォ戦botまとめ trivia: a forced restriction "overrides target selection
+  but still honour[s] 'hits twice'/'ignores evasion,' while Berserk
+  additionally collapses an 'attack all' weapon down to a single target and
+  disables 'always acts first'." `Game::Battle#strike`
+  (`mruby-rpg2k/mrblib/game.rb`) previously spread an attack-all weapon
+  across the whole opposing side under *both* the attack-enemy (Berserk) and
+  attack-ally (Confusion) restrictions alike, and `#preemptive_boost?` kept
+  the preemptive turn-order jump for both too; both are now scoped to
+  attack-ally only, matching Confusion's still-normal spread while Berserk
+  forces a single hit with no jump. The restricted branch also switched from
+  a bare `#deal_attack` to the same `#swing` an ordinary Attack uses, so a
+  dual-wield weapon's extra hit — previously dropped under either forced
+  restriction, an unconfirmed simplification the trivia turns out to
+  contradict — now lands under both. Covered by four new `scripts/
+  rpg2k_logic_check.rb` checks (Berserk plus attack-all hits one target; a
+  preemptive weapon's jump is dropped under Berserk; Berserk still swings a
+  dual-wield weapon twice; a confused, attack-all, dual-wield attacker swings
+  twice per target), all four confirmed to fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3510,15 +3510,47 @@ codebase yet):
   "party wipe" for game-over purposes is defined as "every member is both
   unable to act and does not recover naturally," not literally "every
   member's HP is 0" (why Stone status can wipe a party without zeroing
-  anyone's HP); dual-wielding's off-hand attack animation is offset by a
-  few frames from the main hand's; Berserk/Confusion override target
-  selection but still honour "hits twice"/"ignores evasion," while Berserk
-  additionally collapses an "attack all" weapon down to a single target
-  and disables "always acts first"; and hit rate has both a floor and a
-  ceiling relative to the skill's *configured* rate depending on relative
-  Agility (a 90%-accuracy skill can't exceed 95% actual hit even against a
-  much slower target; an 80% one caps at 90%; the same skew works in
-  reverse against a much faster target).
+  anyone's HP — `Game::Battle#alive?`/`#finished?`, `mruby-rpg2k/mrblib/
+  game.rb`, still key off `Combatant#dead?`'s plain `hp <= 0` alone, so a
+  fully-Stoned party currently keeps grinding through `MAX_ROUNDS` rather
+  than losing immediately — a real, separate gap, not yet fixed); dual-
+  wielding's off-hand attack animation is offset by a few frames from the
+  main hand's. ✅ **Berserk/Confusion override target selection but still
+  honour "hits twice"/"ignores evasion," while Berserk additionally
+  collapses an "attack all" weapon down to a single target and disables
+  "always acts first."** `Game::Battle#strike`'s forced-restriction branch
+  (shared by both, `RESTRICTION_ATTACK_ENEMY`/`_ALLY`) called a bare
+  `#deal_attack` instead of the `#swing` an ordinary Attack uses, so
+  dual-wield's extra hit never landed under either restriction (必中 already
+  worked either way, since `#to_hit` reads `attacker.ignores_evasion`
+  regardless of which method calls it); attack-all spread across the whole
+  opposing side under Berserk exactly as it does under Confusion, with no
+  single-target collapse; and `#preemptive_boost?` granted the "always acts
+  first" turn-order jump to both restrictions alike. Fixed by routing the
+  restricted branch through `#swing` (dual-wield restored for both), scoping
+  the attack-all spread to `RESTRICTION_ATTACK_ALLY` only (Berserk now always
+  hits its single forced target via `#swing` directly, so the now-redundant
+  `#attack_side` helper was removed in favour of the existing `#swing_side`),
+  and returning `false` from `#preemptive_boost?` for `RESTRICTION_ATTACK_ENEMY`
+  before the existing `RESTRICTION_ATTACK_ALLY` case. Covered by four new
+  `scripts/rpg2k_logic_check.rb` checks (Berserk plus attack-all hits one
+  target; a preemptive weapon's jump is dropped under Berserk; Berserk still
+  swings a dual-wield weapon twice; a confused, attack-all, dual-wield
+  attacker swings twice per target), all four confirmed to fail against the
+  pre-fix code. **Confirmed already correct, no change needed**: hit rate's
+  floor/ceiling relative to a skill's configured rate by relative Agility (a
+  90%-accuracy skill can't exceed 95% actual hit even against a much slower
+  target; an 80% one caps at 90%). `Game::Battle#to_hit`'s existing
+  `100 - (100 - base) * (src + tgt) / (2 * src)` (EasyRPG's
+  `CalcToHitAgiAdjustment`, already ported for the "hit rate has both a
+  floor and a ceiling" claim above) already produces exactly this: as the
+  target's agility shrinks toward 0 relative to the attacker's, the ratio
+  term approaches 1/2, so hit approaches `50 + base/2` — 95 for a 90-rate
+  skill, 90 for an 80-rate one, matching both cited numbers as an emergent
+  property of the formula rather than a separate clamp. The reverse-skew
+  half (a much *faster* target) already floors at the existing `Game.clamp(…,
+  0, 100)`, unverified against a specific nonzero floor since neither test
+  bed's own accuracy math suggests RPG_RT keeps one there.
 
 ## RPG Maker with RGSS (XP / VX / VXAce)
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6529,14 +6529,18 @@ module Game
     # Whether `b`'s action this round earns the `preemptive` weapon's
     # turn-order jump: only a basic Attack qualifies (a Skill, Item or Defend
     # with the same weapon equipped keeps its ordinary agility slot, matching
-    # `CreateExecutionOrder`'s own `Type::Normal` guard), including a
-    # forced attack-enemy/attack-ally restriction, which is still a basic
-    # Attack under the hood. `preemptive` is actor-only (see Combatant), so
-    # an enemy never qualifies.
+    # `CreateExecutionOrder`'s own `Type::Normal` guard). A forced
+    # attack-ally restriction (confusion) still counts, since the confused
+    # battler is still swinging a basic Attack under the hood; a forced
+    # attack-enemy restriction (berserk) does not -- per the site's own
+    # デフォ戦botまとめ trivia, berserk specifically drops the weapon's
+    # preemptive jump on top of forcing the target. `preemptive` is
+    # actor-only (see Combatant), so an enemy never qualifies either way.
     def preemptive_boost?(b)
       return false unless b.preemptive
       r = battler_restriction(b)
-      return true if r == RESTRICTION_ATTACK_ENEMY || r == RESTRICTION_ATTACK_ALLY
+      return false if r == RESTRICTION_ATTACK_ENEMY
+      return true if r == RESTRICTION_ATTACK_ALLY
       b.command.nil? && !b.defending && !b.skip
     end
 
@@ -6547,12 +6551,23 @@ module Game
       # A battler that forfeited its turn (a failed escape) does nothing.
       return nil if b.skip
       # A "forced action" restriction (berserk / confused) overrides the chosen
-      # command / defend with a basic attack on a forced target.
+      # command / defend with a basic attack on a forced target -- still an
+      # ordinary basic Attack under the hood otherwise, so dual-wield's extra
+      # swing and 必中's evasion-skip both still apply (デフォ戦botまとめ:
+      # forced restrictions "override target selection but still honour
+      # 'hits twice'/'ignores evasion'"), via the same #swing an unforced
+      # Attack uses rather than a bare #deal_attack.
       r = battler_restriction(b)
       if r == RESTRICTION_ATTACK_ENEMY || r == RESTRICTION_ATTACK_ALLY
         target = restricted_target(b, r)
         return nil unless target
-        return b.attack_all ? attack_side(b, side_targets(target)) : deal_attack(b, target)
+        # Berserk (attack-enemy) forces a single target even with an
+        # attack_all weapon in hand; confusion (attack-ally) still spreads
+        # one, same as an unforced Attack would (デフォ戦botまとめ: "Berserk
+        # additionally collapses an 'attack all' weapon down to a single
+        # target").
+        return swing_side(b, side_targets(target)) if r == RESTRICTION_ATTACK_ALLY && b.attack_all
+        return swing(b, target)
       end
       return apply_command(b) if b.command
       return nil if side_of(b) == :ally && b.defending # defending = no attack
@@ -6588,14 +6603,6 @@ module Game
       # log entry) explodes it into [key, value] pairs rather than wrapping
       # it, since Hash is Enumerable. Same guard #record_action already uses.
       targets.flat_map { |t| r = swing(b, t); r.is_a?(Array) ? r : [r] }
-    end
-
-    # attack_all under a forced restriction (berserk / confused): one hit per
-    # target, matching the single-target restricted branch's own use of
-    # #deal_attack rather than #swing (a forced attack does not get the
-    # dual-wield bonus either).
-    def attack_side(b, targets)
-      targets.map { |t| deal_attack(b, t) }
     end
 
     # -- enemy AI (行動パターン) ------------------------------------------------

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7506,6 +7506,50 @@ check 'battle: a berserk battler (restriction 2) attacks despite defending' do
   eq 80, slime.hp                                         # ...but berserk forced a 20 hit
 end
 
+# デフォ戦botまとめ: "Berserk/Confusion override target selection but still
+# honour 'hits twice'/'ignores evasion,' while Berserk additionally collapses
+# an 'attack all' weapon down to a single target and disables 'always acts
+# first'." The confusion half (attack_all still spreading, hit-twice/必中
+# unaffected either way) was already covered by the 全体化/必中 checks above;
+# these four pin the berserk-specific divergence.
+check 'battle: a berserk battler with an attack_all weapon still hits only one target' do
+  states = { 7 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0) } # attack-enemy (berserk)
+  hero = combatant('Hero', 20, 0, 20, 100)
+  hero.states = [7]
+  hero.attack_all = true                                  # 全体化, would spread unforced
+  foe1 = combatant('Foe1', 0, 5, 5, 50)
+  foe2 = combatant('Foe2', 0, 5, 5, 50)
+  bat = Game::Battle.new([hero], [foe1, foe2], Game::Rng.new(1), states)
+  entry = bat.send(:strike, hero)
+  ok entry.is_a?(Hash), 'berserk forces a single target even with 全体化 equipped'
+  ok foe1.hp == 50 || foe2.hp == 50, 'only one of the two enemies actually took a hit'
+end
+
+check 'battle: a berserk battler still swings twice with a 二刀流 weapon' do
+  states = { 7 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0) } # attack-enemy (berserk)
+  hero = combatant('Hero', 20, 0, 20, 100)
+  hero.states = [7]
+  hero.strikes = 2                                        # 二刀流
+  slime = combatant('Slime', 0, 0, 5, 999)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  entries = bat.send(:strike, hero)
+  eq 2, entries.size, "berserk still gets the weapon's dual-wield extra swing"
+end
+
+check 'battle: a confused, dual-wielding, attack_all battler swings twice per target' do
+  states = { 6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0) } # attack-ally (confusion)
+  hero = combatant('Hero', 20, 0, 1, 100)
+  hero.states = [6]
+  hero.attack_all = true
+  hero.strikes = 2                                        # 二刀流
+  ally2 = combatant('Ally2', 0, 0, 5, 999)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero, ally2], [slime], Game::Rng.new(1), states)
+  entries = bat.send(:strike, hero)
+  eq 4, entries.size,
+     'the confused, 全体化, 二刀流 attacker swings twice at itself and twice at its ally'
+end
+
 # -- stat-halving/doubling states (affect_type / affect_attack & friends) ----
 
 check 'battle: a state that halves ATK weakens a basic attack' do
@@ -8133,6 +8177,19 @@ check '先制攻撃 does not jump the turn order for a Skill, Item or Defend' do
   bat.command_defend(bat.allies[0])
   eq [fast_foe, bat.allies[0]], bat.send(:turn_order),
      'Defend keeps the ordinary agility slot, even with the weapon still equipped'
+end
+
+check "battle: berserk drops a 先制攻撃 weapon's turn-order jump" do
+  items = { 7 => fake_item(type: 1, atk: 5, preemptive: true) }
+  states = { 9 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0) } # attack-enemy (berserk)
+  st = geared_party(items)
+  hero = st.party.leader
+  hero.equip([7, 0, 0, 0, 0])                             # 先制攻撃
+  fast_foe = combatant('FastFoe', 0, 0, 999, 100)          # far faster than the hero
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [fast_foe], Game::Rng.new(1), states)
+  bat.allies[0].states = [9]
+  eq [fast_foe, bat.allies[0]], bat.send(:turn_order),
+     "berserk drops the weapon's jump: agility alone decides again"
 end
 
 check 'battle: 強力防御 halves damage a second time' do


### PR DESCRIPTION
## Summary

From `docs/TODO.md`'s viprpg-dev wiki backlog (`2000/デフォ戦/デフォ戦botまとめ` trivia dump): "Berserk/Confusion override target selection but still honour 'hits twice'/'ignores evasion,' while Berserk additionally collapses an 'attack all' weapon down to a single target and disables 'always acts first'."

`Game::Battle#strike`'s forced-restriction branch (shared by both `RESTRICTION_ATTACK_ENEMY`/Berserk and `RESTRICTION_ATTACK_ALLY`/Confusion) had three divergences from that claim:

- It called a bare `#deal_attack` instead of the `#swing` an ordinary Attack uses, so a dual-wield (二刀流) weapon's extra hit never landed under **either** forced restriction (必中/`ignores_evasion` already worked correctly either way, since `#to_hit` reads it regardless of which method calls it).
- An attack-all (全体化) weapon spread across the whole opposing side under **Berserk** exactly as it does under Confusion — no single-target collapse.
- `#preemptive_boost?` granted the weapon's "always acts first" turn-order jump to **both** restrictions alike.

### Fix

- Route the restricted branch through `#swing` instead of `#deal_attack`, restoring dual-wield's extra hit under both restrictions.
- Scope the attack-all spread to `RESTRICTION_ATTACK_ALLY` (Confusion) only; Berserk now always resolves to its single forced target via `#swing`. The now-redundant `#attack_side` helper (which duplicated `#swing_side`'s logic once both used `#swing`) was removed.
- `#preemptive_boost?` now returns `false` for `RESTRICTION_ATTACK_ENEMY` before the existing `RESTRICTION_ATTACK_ALLY` case.

Also updates `docs/TODO.md`'s デフォ戦botまとめ paragraph: marks this bullet ✅, records the hit-rate floor/ceiling claim in the same paragraph as **confirmed already correct** (it falls out of the existing `CalcToHitAgiAdjustment` port as `50 + base/2` when the target's agility → 0 relative to the attacker's — 95 for a 90-rate skill, 90 for an 80-rate one, matching both cited numbers), and flags the "party wipe via permanent incapacitation, not literal all-HP-zero" claim as a real, separate, not-yet-fixed gap (`Game::Battle#alive?`/`#finished?` still key off `Combatant#dead?`'s plain `hp <= 0`).

## Test plan

- Added four checks to `scripts/rpg2k_logic_check.rb`:
  - Berserk plus an attack-all weapon hits only one target.
  - Berserk drops a preemptive weapon's turn-order jump.
  - Berserk still swings a dual-wield weapon twice.
  - A confused, attack-all, dual-wield attacker swings twice per target (4 hits across 2 allies).
- All four confirmed to fail against the pre-fix code (verified via `git stash`), and pass after the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 684 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 342 checks passed (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nj74waS2pnQhM2ERBRB6ia)_