### PR TITLE
Update mruby-stringio submodule to take-cheeze fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 	url = https://github.com/mattn/mruby-onig-regexp.git
 [submodule "3rd/mruby-stringio"]
 	path = 3rd/mruby-stringio
-	url = https://github.com/ksss/mruby-stringio.git
+	url = https://github.com/take-cheeze/mruby-stringio.git
 [submodule "3rd/uni-algo"]
 	path = 3rd/uni-algo
 	url = https://github.com/uni-algo/uni-algo.git


### PR DESCRIPTION
## Summary
This PR updates the mruby-stringio submodule to use the fork maintained by take-cheeze instead of the original ksss repository, and pulls in the latest changes from that fork.

## Changes
- Updated `.gitmodules` to point the mruby-stringio submodule to `https://github.com/take-cheeze/mruby-stringio.git`
- Updated the submodule commit reference to the latest version from the take-cheeze fork

## Details
This change switches the source of the mruby-stringio dependency from the original ksss repository to the take-cheeze maintained fork. This may include bug fixes, improvements, or compatibility updates from the new fork maintainer.

https://claude.ai/code/session_01MhV64BVj4GRiF1Wz7a1WF9