### PR TITLE
rpg2k: a fully-incapacitated party (e.g. all-Stone) is a battle loss

### DIFF
--- a/changelog.d/battle-party-wipe-incapacitation.fixed.md
+++ b/changelog.d/battle-party-wipe-incapacitation.fixed.md
@@ -1,0 +1,18 @@
+- **A battle now ends in defeat (or victory) the instant every battler on a
+  side is permanently unable to act, not only once every one of them is
+  literally at 0 HP** — a fully-Stoned party loses even though nobody was
+  ever damaged, matching デフォ戦botまとめ's "'party wipe' for game-over
+  purposes is defined as 'every member is both unable to act and does not
+  recover naturally,' not literally 'every member's HP is 0.'"
+  `Game::Battle#alive?` (`mruby-rpg2k/mrblib/game.rb`) only ever checked
+  `#out_of_play?` (dead or hidden), so a party entirely afflicted by a "do
+  nothing" restriction state that never wears off on its own read as still
+  fighting and ground all the way to the `MAX_ROUNDS` safety net before
+  finally resolving as a loss. A new `#incapacitated?` — dead/hidden, or
+  carrying a `RESTRICTION_DO_NOTHING` state whose `auto_release_prob` is
+  0 — now backs `#alive?` instead; a do-nothing state that *can* still shake
+  itself off on its own (Sleep, Paralysis with a nonzero `auto_release_prob`)
+  does not count, so the fight correctly keeps running while there is still
+  a chance someone wakes up. Applies symmetrically to enemies too. Covered by
+  three new `scripts/rpg2k_logic_check.rb` checks, one confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3553,15 +3553,37 @@ codebase yet):
   displayed value stays pinned at its old clamp until the raise actually
   pushes the real total back above it); a special skill's ability-value
   *decrease* rounds up on ÷2, a status effect's own halving rounds *down*;
-  "party wipe" for game-over purposes is defined as "every member is both
-  unable to act and does not recover naturally," not literally "every
-  member's HP is 0" (why Stone status can wipe a party without zeroing
-  anyone's HP — `Game::Battle#alive?`/`#finished?`, `mruby-rpg2k/mrblib/
-  game.rb`, still key off `Combatant#dead?`'s plain `hp <= 0` alone, so a
-  fully-Stoned party currently keeps grinding through `MAX_ROUNDS` rather
-  than losing immediately — a real, separate gap, not yet fixed); dual-
-  wielding's off-hand attack animation is offset by a few frames from the
-  main hand's. ✅ **Berserk/Confusion override target selection but still
+  dual-wielding's off-hand attack animation is offset by a few frames from
+  the main hand's. ✅ **"Party wipe" for game-over purposes is now "every
+  member is both unable to act and does not recover naturally," not
+  literally "every member's HP is 0"** — why Stone status can wipe a party
+  without zeroing anyone's HP. `Game::Battle#alive?` (`mruby-rpg2k/mrblib/
+  game.rb`) only ever asked `!b.out_of_play?` (dead or hidden), so a fully
+  restricted-but-undamaged party (every ally afflicted by a "do nothing"
+  state, RESTRICTION_DO_NOTHING, that never wears off on its own) read as
+  still fighting: `#finished?`/`#run` kept calling `#step`, which itself
+  never reaches an action for any of them (`apply_turn_states` returns
+  `can_act = false` for every one, `#step`'s inner loop just cycles to the
+  next battler), so the fight silently ground all the way to the
+  `MAX_ROUNDS` safety net before finally reading as a loss, rather than
+  ending the instant the last ally is afflicted. Fixed with a new
+  `#incapacitated?(b)`, used by `#alive?` in place of the bare
+  `!out_of_play?` check: true for a dead/hidden battler as before, or for
+  one carrying a state whose `restriction` is `RESTRICTION_DO_NOTHING` *and*
+  whose `auto_release_prob` is 0 — deliberately narrower than "any do-nothing
+  state," since a do-nothing state that *can* still shake itself off on its
+  own (Sleep, Paralysis with a nonzero `auto_release_prob`) does not count
+  towards a wipe, matching "does not recover naturally": the fight keeps
+  running, the same roll `#recovers_from_state?` would eventually use to
+  stand that battler back up. Applies symmetrically to both sides (an
+  all-Stoned enemy troop ends the fight in victory too), since nothing in
+  the source material suggests the rule is ally-only and `#alive?` was
+  already shared by both `@allies`/`@enemies` call sites. Covered by three
+  new `scripts/rpg2k_logic_check.rb` checks (a fully-Stoned party is a loss
+  with no HP ever moving, confirmed to fail against the pre-fix code before
+  the fix; a party-wide do-nothing state with a nonzero `auto_release_prob`
+  does *not* end the fight; one incapacitated ally among others is not a
+  wipe). ✅ **Berserk/Confusion override target selection but still
   honour "hits twice"/"ignores evasion," while Berserk additionally
   collapses an "attack all" weapon down to a single target and disables
   "always acts first."** `Game::Battle#strike`'s forced-restriction branch

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6492,7 +6492,26 @@ module Game
       @rng.random(100) < prob
     end
 
-    def alive?(side); side.any? { |b| !b.out_of_play? }; end
+    # Whether `b` counts as out of the fight for win/loss purposes: dead or
+    # hidden (#out_of_play?), or locked into a "do nothing" restriction by a
+    # state with zero chance of ever shaking itself off. デフォ戦botまとめ:
+    # "party wipe" for game-over purposes means every member is both unable
+    # to act *and* does not recover naturally, not literally "every member's
+    # HP is 0" -- why a fully-Stoned party loses instantly even though nobody
+    # was ever damaged. A do-nothing state that *can* still clear itself
+    # (Sleep, Paralysis with a nonzero auto_release_prob) does not count: the
+    # fight keeps running, the same way #recovers_from_state? would
+    # eventually stand that battler back up on its own.
+    def incapacitated?(b)
+      return true if b.out_of_play?
+      (b.states || []).any? do |id|
+        d = state_def(id)
+        d && state_field(d, :restriction) == RESTRICTION_DO_NOTHING &&
+          state_field(d, :auto_release_prob) <= 0
+      end
+    end
+
+    def alive?(side); side.any? { |b| !incapacitated?(b) }; end
 
     def refill_queue
       @rounds += 1

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7483,6 +7483,42 @@ check 'battle state at 0% auto_release_prob never wears off on its own' do
   eq true, hero.state?(5)                            # 0% -> stays for the whole fight
 end
 
+# デフォ戦botまとめ: "'party wipe' for game-over purposes is defined as 'every
+# member is both unable to act and does not recover naturally,' not literally
+# 'every member's HP is 0' (why Stone status can wipe a party without zeroing
+# anyone's HP)." A do-nothing state that *can* still shake itself off (Sleep,
+# Paralysis with a nonzero auto_release_prob) does not count -- only a state
+# with zero chance of ever clearing does.
+check 'battle: a fully-Stoned party is a loss even though nobody took damage' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) } # do-nothing, 0% auto-release
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [8]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  ok bat.finished?, 'the whole party is incapacitated with no way back'
+  eq :defeat, bat.run
+  eq 100, hero.hp                                    # never actually damaged
+end
+
+check 'battle: a party-wide do-nothing state that can wear off keeps the fight going' do
+  states = { 9 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 50) } # do-nothing, 50% auto-release
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.states = [9]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  ok !bat.finished?, 'sleep/paralysis-style states can still recover on their own'
+end
+
+check 'battle: one incapacitated ally among others is not a party wipe' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) } # do-nothing, 0% auto-release
+  stoned = combatant('Stoned', 40, 0, 20, 100)
+  stoned.states = [8]
+  healthy = combatant('Healthy', 40, 0, 20, 100)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([stoned, healthy], [slime], Game::Rng.new(1), states)
+  ok !bat.finished?, 'a still-able ally keeps the party in the fight'
+end
+
 check 'battle: a confused battler (restriction 3) attacks its own side' do
   states = { 6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0) } # attack-ally (confusion)
   hero = combatant('Hero', 40, 0, 1, 100)                 # slow: the foe acts first


### PR DESCRIPTION
## Summary
- viprpg-dev wiki (デフォ戦botまとめ): "party wipe" for game-over purposes
  means every member is both unable to act *and* does not recover
  naturally — not literally "every member's HP is 0". This is why a Stone
  status can wipe a party without ever zeroing anyone's HP.
- `Game::Battle#alive?` only ever asked `!out_of_play?` (dead-by-HP or
  hidden), so a party entirely afflicted by a permanent "do nothing"
  restriction state never registered as defeated — the fight ground on to
  the `MAX_ROUNDS` (1000) safety net instead of ending the instant the
  last member was afflicted.
- New `Game::Battle#incapacitated?(b)`: true for dead/hidden as before, or
  for a battler carrying a state with `restriction == RESTRICTION_DO_NOTHING`
  **and** `auto_release_prob <= 0` (permanently unable to act, permanently
  unable to recover on its own — reusing the same fields
  `#recovers_from_state?` already reads). `#alive?` now uses it instead of
  the bare `out_of_play?` check. A do-nothing state that *can* still clear
  itself (Sleep, Paralysis with a nonzero `auto_release_prob`) does not
  count, so those fights keep running unaffected. Applies symmetrically to
  both allies and enemies since `#alive?` is shared between both sides.
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 687 checks pass (three new: a
      fully-Stoned party is a loss with no HP ever moving, confirmed to fail
      against the pre-fix code; a party-wide do-nothing state with nonzero
      `auto_release_prob` does not end the fight; one incapacitated ally
      among others is not a wipe)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 344 checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_