### PR TITLE
rpg2k: Control Variables' character-position operand now resolves vehicles

### DIFF
--- a/changelog.d/control-variables-vehicle-position.fixed.md
+++ b/changelog.d/control-variables-vehicle-position.fixed.md
@@ -1,0 +1,21 @@
+- **Control Variables' character-position operand (type 6) now resolves a
+  vehicle target (boat/ship/airship, ref 10002-10004)** instead of always
+  reading 0 — the viprpg-dev wiki's "Vehicles" findings note a vehicle's
+  x/y/screen-x/y can be read via variable ops even from a map other than the
+  one it currently occupies. `Game::Interpreter#event_operand`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) only recognised the hero (ref 10001)
+  and map event ids (1-9999); a vehicle ref fell through to the same "no
+  match" branch a nonexistent map event does. A new `#vehicle_operand` reads
+  the target `Game::Vehicle` straight off `Game::State` (map id, x, y,
+  facing) — no scene hook needed, since (unlike a map event) a vehicle's
+  position is tracked independently of whichever map is currently loaded,
+  and `Scene::Map#follow_vehicle` already keeps a ridden vehicle's stored
+  position live every step. Unlike a map event's own map-id read (a
+  long-standing RPG_RT quirk that always answers 0), a vehicle's map id
+  operand returns its real value, the same way the hero's own does. Screen
+  x/y (attr 4/5) are unchanged — they still read 0 for a vehicle, the same
+  degenerate answer an unresolvable map-event screen position already gets.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (a boat and an
+  airship's map id/x/y/facing read correctly from an interpreter on an
+  unrelated map; an unplaced vehicle reads its (0,0) default), confirmed to
+  fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2085,9 +2085,28 @@ Everything below is unverified against the codebase.
   Jump, etc.) still run normally while mounted and must be manually guarded
   off; **setting a map event's trigger to Parallel Process and running "Set
   Vehicle Position" from it crashes RPG_RT** (any other trigger type does
-  not) — an authentic engine crash, probably not worth reproducing; a
+  not) — an authentic engine crash, probably not worth reproducing; ✅ a
   vehicle's x/y/screen-x/y can be read via variable ops from a different map
-  than it currently occupies.
+  than it currently occupies — `Game::Interpreter#event_operand`'s Control
+  Variables "character position" operand (type 6) recognised the hero (ref
+  10001) and map event ids, but a vehicle ref (10002-10004, boat/ship/
+  airship) fell through to the same "no match" branch a nonexistent map
+  event does, always reading 0. A new `#vehicle_operand` reads the target
+  `Game::Vehicle` straight off `Game::State` — map id, x, y, facing — which
+  needs no scene hook at all, since a vehicle (unlike a map event) is
+  tracked independently of whichever map is currently loaded, and
+  `Scene::Map#follow_vehicle` already keeps a ridden vehicle's stored
+  position live every step. A vehicle's map id operand returns its real
+  value rather than the map-event quirk's hardcoded 0, the same way the
+  hero's own map id read already does. **Screen x/y (attr 4/5) are not
+  covered by this fix** — those still read 0 for a vehicle, the same
+  degenerate answer an unresolvable map-event screen position already gets,
+  since resolving them would need a scene-side camera hook this fix
+  deliberately avoids depending on. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a boat and an airship's map id/x/y/
+  facing read correctly from an interpreter positioned on an unrelated map;
+  an unplaced vehicle reads its (0,0) default), confirmed to fail against
+  the pre-fix code before the fix.
 - **Battle Event** — separate command set from Map/Common events entirely;
   no Pictures on the battle screen; Parallel Process can't run in battle;
   no further pages run once battle ends.

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -165,6 +165,8 @@ module Game
     # thing (RPG_RT's `GetCharacter` maps both), which is why every reference
     # goes through #character_ref before it is looked up.
     CHAR_PLAYER     = 10001
+    CHAR_BOAT       = 10002
+    CHAR_AIRSHIP    = 10004
     CHAR_THIS_EVENT = 10005
 
     # Show Choices holds at most four selectable options; a fifth (index 4) is
@@ -1352,10 +1354,14 @@ module Game
     end
 
     # Operand type 6: a positional value of a character. param5 selects it (10001
-    # the hero / party, "this event" as 0 / 10005, any other positive id a map
-    # event); param6 the value (0 map id, 1 x tile, 2 y tile, 3 facing in
-    # RPG2000's 2/4/6/8 numpad convention, 4 screen x, 5 screen y). Matching a
-    # long-standing RPG_RT quirk, a *map event's* map id reads 0. An unresolvable
+    # the hero / party, 10002-10004 a vehicle (boat/ship/airship), "this event"
+    # as 0 / 10005, any other positive id a map event); param6 the value (0 map
+    # id, 1 x tile, 2 y tile, 3 facing in RPG2000's 2/4/6/8 numpad convention,
+    # 4 screen x, 5 screen y). Matching a long-standing RPG_RT quirk, a *map
+    # event's* map id reads 0 -- a vehicle's does not, since (unlike a map
+    # event) it is a real piece of state that exists independently of whatever
+    # map is currently loaded (yado.tk: a vehicle's position can be read from a
+    # different map than the one it currently occupies). An unresolvable
     # reference (no map_info hook, unknown event, "this event" outside a map
     # event) reads 0.
     def event_operand(cmd)
@@ -1371,6 +1377,8 @@ module Game
         when 3 then @state.direction
         else 0
         end
+      elsif ref >= CHAR_BOAT && ref <= CHAR_AIRSHIP
+        vehicle_operand(ref, attr)
       elsif ref > 0 && ref < 10000 && @map_info.respond_to?(:event_position)
         pos = @map_info.event_position(ref)
         return 0 unless pos
@@ -1382,6 +1390,24 @@ module Game
         end
       else
         0
+      end
+    end
+
+    # A vehicle's own stored position, read straight off `Game::State` rather
+    # than through `@map_info` -- unlike a map event, a vehicle is tracked
+    # independently of any loaded map (`Scene::Map#follow_vehicle` keeps the
+    # ridden one's position live every step, and an unridden one simply sits
+    # wherever it was last placed), so this needs no scene hook and works the
+    # same whether or not the vehicle's own map is the one currently loaded.
+    def vehicle_operand(ref, attr)
+      v = @state.vehicle(Vehicle::TYPES[ref - CHAR_BOAT])
+      return 0 unless v
+      case attr
+      when 0 then v.map_id
+      when 1 then v.x
+      when 2 then v.y
+      when 3 then v.direction
+      else 0
       end
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4269,6 +4269,32 @@ check 'Control Variables reads a map event position (operand type 6)' do
   eq 0, st.variables[5]                                          # unknown event reads 0
 end
 
+check 'Control Variables reads a vehicle position (operand 6, ref 10002-10004)' do
+  st = new_state
+  st.vehicle(:boat).map_id = 3; st.vehicle(:boat).x = 11
+  st.vehicle(:boat).y = 4; st.vehicle(:boat).direction = 8
+  st.vehicle(:airship).map_id = 9; st.vehicle(:airship).x = 20
+  st.vehicle(:airship).y = 15; st.vehicle(:airship).direction = 6
+  it = Game::Interpreter.new(st)
+  # The interpreter's own map (id 1, from new_state) differs from either
+  # vehicle's -- yado.tk: a vehicle's position reads fine from another map.
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 10002, 0]),  # boat map id
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 6, 10002, 1]),  # boat x
+            FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 6, 10002, 2]),  # boat y
+            FakeCmd.new(IC::CONTROL_VARS, [0, 4, 4, 0, 6, 10002, 3]),  # boat facing
+            FakeCmd.new(IC::CONTROL_VARS, [0, 5, 5, 0, 6, 10004, 0]),  # airship map id
+            FakeCmd.new(IC::CONTROL_VARS, [0, 6, 6, 0, 6, 10004, 1]),  # airship x
+            FakeCmd.new(IC::CONTROL_VARS, [0, 7, 7, 0, 6, 10003, 1])]) # ship (unplaced) x -> 0
+  it.update
+  eq 3, st.variables[1]   # unlike a map event, a vehicle's real map id is readable
+  eq 11, st.variables[2]
+  eq 4, st.variables[3]
+  eq 8, st.variables[4]
+  eq 9, st.variables[5]
+  eq 20, st.variables[6]
+  eq 0, st.variables[7]   # an unplaced vehicle sits at its (0,0) default
+end
+
 check 'Control Variables reads "this event" (operand 6, ref 10005 / 0)' do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

- `Game::Interpreter#event_operand` (Control Variables' "character position" operand, type 6) recognised the hero (ref 10001) and map event ids, but a vehicle reference (10002-10004 — boat/ship/airship) fell through to the same "no match" branch a nonexistent map event does, always reading 0.
- This is a documented, currently-unimplemented gap from the viprpg-dev wiki's "Vehicles" findings section of `docs/TODO.md`: *"a vehicle's x/y/screen-x/y can be read via variable ops from a different map than it currently occupies."*
- Added `Game::Interpreter#vehicle_operand`, which reads the target `Game::Vehicle` straight off `Game::State` (map id, x, y, facing) — no scene hook needed, since (unlike a map event) a vehicle's position is tracked independently of whichever map is currently loaded, and `Scene::Map#follow_vehicle` already keeps a ridden vehicle's stored position live every step.
- Unlike a map event's own map-id read (a long-standing RPG_RT quirk that always answers 0), a vehicle's map id operand now returns its real value, the same way the hero's own already does.
- Screen x/y (attr 4/5) are intentionally **not** covered by this fix — they still read 0 for a vehicle, the same degenerate answer an unresolvable map-event screen position already gets, since resolving them would need a scene-side camera hook this fix deliberately avoids depending on.

## Test plan

- Added a new `scripts/rpg2k_logic_check.rb` check: a boat and an airship's map id/x/y/facing read correctly from an interpreter positioned on an unrelated map, and an unplaced vehicle reads its (0,0) default. Confirmed it fails against the pre-fix code (`FAIL ... expected 3, got 0`) before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 688 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 344 checks passed (unaffected by this change, run per the repo's verification gate).
- Updated `docs/TODO.md`'s "Vehicles" bullet under the viprpg-dev wiki backlog to ✅, with the same evidence-citing style as neighboring entries.
- Added `changelog.d/control-variables-vehicle-position.fixed.md`.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015Y1d2mUKp6moLHoJ8FBrkW)_