### PR TITLE
rpg2k: a Parallel Process that wipes the party drops into Game Over

### DIFF
--- a/changelog.d/parallel-process-game-over.fixed.md
+++ b/changelog.d/parallel-process-game-over.fixed.md
@@ -1,0 +1,13 @@
+- **A wipe-triggering command run from a Common Event's Parallel Process now
+  reaches the Game Over screen, instead of the wait being silently discarded.**
+  `Game::Interpreter#check_game_over` raises the same `:game_over` wait
+  whichever interpreter calls it — foreground or a Parallel Process's own —
+  but `Scene::Map#drive_parallel_wait` had no case for it, so the request fell
+  into the generic "background: ignore message/choice/teleport requests"
+  branch and was immediately `#resume`d, leaving a fully-dead party free to
+  keep wandering the map with no Game Over ever shown. Fixed with a
+  `:game_over` branch that calls `#perform_game_over`, now generalized (like
+  the earlier Show Battle Animation fix) to take the requesting interpreter
+  explicitly rather than always stopping the foreground one. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix
+  code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -536,6 +536,30 @@ The work below is roughly ordered by the critical path to a walkable game
   party and leave the player walking the map with it. Enemies inflict states
   too now, by casting the status skills in their action pattern (see the
   行動パターン entry below). Still remaining here: the non-reverse item case.
+  ✅ **A wipe an event's Parallel Process itself causes now reaches Game Over
+  too**, matching the foreground half above. `check_game_over` raises the same
+  `:game_over` wait regardless of which interpreter calls it, but only
+  `Scene::Map#drive_event` (the foreground dispatch) ever answered it —
+  `#drive_parallel_wait`, the equivalent dispatch for a Common Event Parallel
+  Process's own interpreter, had no `:game_over` case at all, so the request
+  fell into the generic "background: ignore message/choice/teleport requests"
+  branch and was immediately `#resume`d: the wait was silently cleared and the
+  process carried on, leaving a fully-dead party free to keep wandering the
+  map with no Game Over screen ever shown — e.g. a Simulated Attack damage
+  floor or a poison Change HP running from a background Parallel Process
+  rather than a foreground event. Fixed with a new `:game_over` branch in
+  `#drive_parallel_wait` that calls `#perform_game_over`, now generalized
+  (`def perform_game_over(interp = @interpreter)`, the same
+  take-the-waiting-interpreter-explicitly pattern the Show Battle Animation
+  fix above already established for `#drive_map_animation`) to stop whichever
+  interpreter actually raised the wait rather than always the foreground one.
+  The still-open `016_ikinari_end` battle-context race (a Parallel Process's
+  own game-over check beating a concurrent Battle "On Lose" recovery branch)
+  is untouched — `check_game_over` already returns early while `@battle` is
+  set, so this fix only reaches the field/non-battle path. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a Parallel Process's own lethal Change
+  HP puts up the Game Over screen and stops the rest of that process from
+  running), confirmed to fail against the pre-fix code before the fix.
   **Show / Move / Erase
   Picture** (11110/11120/11130) are implemented: a `Game::Picture` per shown id
   (centre position, zoom, opacity, tone and the scroll-with-map flag) held on
@@ -3525,7 +3549,19 @@ codebase yet):
   own game-over/party-wipe handling already behaves sanely in this exact
   scenario (HP hits 0 while a message window from the same or a parallel
   event is open) or has some other gap the freeze happened to have masked
-  in the original.
+  in the original. ✅ **Part of that question is answered now**: a Parallel
+  Process's own wipe reaching Game Over at all was a real, separate gap
+  (`Scene::Map#drive_parallel_wait` had no `:game_over` case — see the "Event
+  system" entry near the top of this file for the full writeup), now fixed
+  and regression-covered. **Still open**: this fix says nothing about the
+  specific "while a message window is open" timing the repro asks about — a
+  Parallel Process keeps advancing non-blocking commands during a message
+  window per the "parallel processes were paused too broadly" fix above, so a
+  lethal Change HP there would reach `check_game_over` and now correctly
+  raises Game Over, but whether the message window itself is torn down
+  cleanly (rather than leaking a disposed sprite reference, say) is
+  unverified — no test bed or session note here exercises that exact
+  interleaving yet.
 - **Save data location fallback.** If `RPG_RT.exe` itself is read-only,
   real RPG_RT reads/writes save files from `My Documents\<GameName>\`
   instead of the game folder, and stops listing game-folder saves (even

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1165,6 +1165,16 @@ class RPG2k
           # same single on-screen animation slot #drive_map_animation already
           # drives for the foreground, see there.
           drive_map_animation(it)
+        elsif it.wait_kind == :game_over
+          # A wipe-triggering command (Change HP, Change Condition, ...) run
+          # from a Parallel Process's own interpreter raises the same
+          # :game_over wait #check_game_over uses for the foreground -- ending
+          # the game does not depend on which interpreter noticed the wipe.
+          # Before this branch existed this fell into the generic "background:
+          # ignore message/choice/teleport requests" #resume below, which
+          # silently cleared the wait and let the process carry on with a
+          # fully-dead party never reaching the Game Over screen.
+          perform_game_over(it)
         else
           it.resume # background: ignore message/choice/teleport requests
         end
@@ -4078,13 +4088,21 @@ class RPG2k
       # Game Over (12420), and a battle defeat the encounter marked "game over":
       # show the Game Over screen, which returns to the title once dismissed.
       # Nothing resumes, so the event is stopped rather than released.
-      def perform_game_over
+      #
+      # `interp` is whichever interpreter actually raised the :game_over wait --
+      # the foreground event by default, or a Parallel Process's own interpreter
+      # when #drive_parallel_wait dispatches here (see there). Stopping the
+      # right one matters less than it looks: replacing the whole scene stack
+      # below orphans every interpreter in this scene regardless, but stopping
+      # it too keeps its own state consistent for the rest of this frame, the
+      # same as the foreground's already did.
+      def perform_game_over(interp = @interpreter)
         $stderr.puts '[RPG2k] game over'
-        @interpreter.stop
+        interp.stop
         @parent.show_game_over
       rescue StandardError => e
         $stderr.puts "[RPG2k] Game over failed: #{e.message}"
-        @interpreter.stop
+        interp.stop
       end
 
       def log_round(entries)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4249,6 +4249,34 @@ check "a Common Event Parallel Process's Show Battle Animation draws a sprite an
   ok st.switches[6], 'the parallel process resumed after the animation'
 end
 
+# yado.tk: RPG_RT drops straight into Game Over the instant a wipe-triggering
+# command finds the whole party dead outside battle, regardless of which
+# event noticed it -- a Simulated Attack floor trap on a background Parallel
+# Process is exactly as fatal as an identical trap on a foreground event (see
+# the "an event that wipes the party drops into Game Over" check above for the
+# foreground half of the same fact). Before this fix #drive_parallel_wait's
+# wait-kind dispatch had no :game_over branch, so a Parallel Process's own
+# Game::Interpreter#check_game_over call fell into the generic "background:
+# ignore message/choice/teleport requests" #resume case -- the wait was
+# silently cleared and the process carried on, leaving a fully-dead party
+# free to keep wandering the map with no Game Over screen ever shown.
+check 'a Parallel Process that wipes the party drops into Game Over too' do
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::CHANGE_HP, [0, 0, 1, 0, 9999, 1], indent: 0), # party, lethal
+                              ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, WipeStubParty.new)
+  parent = scene.instance_variable_get(:@parent)
+  5.times do
+    scene.update
+    break if parent.game_over_shown
+  end
+  ok parent.game_over_shown, 'a Parallel Process wiping the party put up the Game Over screen'
+  ok !st.switches[5], 'and the rest of the parallel process never ran'
+end
+
 check 'a vehicle placed on the current map is drawn; one off-map or absent is not' do
   scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary
- `Game::Interpreter#check_game_over` raises the same `:game_over` wait
  regardless of which interpreter (the foreground event, or a Common
  Event's own Parallel Process) calls it, but only the foreground dispatch
  (`Scene::Map#drive_event`) ever answered that wait. `#drive_parallel_wait`
  had no `:game_over` case and fell into the generic "background: ignore
  message/choice/teleport requests" branch, silently `#resume`-ing and
  clearing the wait — so a Parallel Process wiping the whole party (a
  poison tick, a Simulated Attack floor trap, etc.) never reached the Game
  Over screen; the party just kept walking around fully dead.
- `perform_game_over` now takes the interpreter that actually raised the
  wait (`interp = @interpreter` default, so the existing foreground/battle
  call sites are unaffected), and `drive_parallel_wait` routes `:game_over`
  to it the same way it already routes `:animation` to
  `drive_map_animation`.
- Scoped to the field path only — `check_game_over` already returns early
  while `@battle` is set, so the separate, still-open battle-context race
  (a Parallel Process game-over check racing a Battle "On Lose" recovery
  branch, `016_ikinari_end`) is untouched.
- `docs/TODO.md` updated with a ✅ addendum in the Event-system party-wipe
  paragraph, plus a note on the viprpg-dev wiki backlog bullet this
  partially answers.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 687 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 345 checks pass (new check: a
      Parallel Process that wipes the party drops into Game Over too —
      confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_