### PR TITLE
rpg2k: confirm Battle Interrupt's Win/Escape/Defeat exemption; fix a vacuous test

### DIFF
--- a/changelog.d/battle-interrupt-handler-confirmed.changed.md
+++ b/changelog.d/battle-interrupt-handler-confirmed.changed.md
@@ -1,0 +1,16 @@
+- **Battle Interrupt (Terminate Battle, 13410) matching neither the
+  enclosing Enemy Encounter's [Victory] nor [Escape]/[Defeat] handler, and
+  leaving the win/escape/defeat tallies alone, is confirmed rather than an
+  open yado.tk claim.** `Game::Interpreter#resume_battle` and
+  `#find_battle_option`'s `BATTLE_HANDLERS` table already have no `:abort`
+  case, so a Terminate Battle resumes the event right after Branch End with
+  none of the three outcome counters touched. No game-logic change was
+  needed — but the existing `scripts/rpg2k_scene_check.rb` coverage that
+  looked like it proved this turned out to be vacuous: its loop broke the
+  instant `@battle_ui` read `nil`, which is true before the battle opens as
+  well as after it closes, so the check "passed" without the battle event
+  ever running (confirmed by replaying it against an injected counter bug
+  and watching it stay green). Replaced with a new `open_then_close_battle`
+  helper that asserts the battle actually opens before waiting for it to
+  close, plus a new check asserting the counters directly — both confirmed
+  to fail against the bug the old check missed.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3091,10 +3091,39 @@ not yet verified:
   `elsif magical` branch and computes `0 * dmg / 100 = 0`, not a sign flip —
   so a full immunity zeroes the hit rather than healing the target. No code
   change; the claim already held.
-- Battle Interrupt (from inside a battle event) satisfies **neither**
-  the Win nor Lose branch of the enclosing Battle Processing command —
-  it's a third, unlabeled outcome that resumes right after Branch End,
-  and only increments the battle-count stat (not loss/escape counts).
+- ✅ **Battle Interrupt (Terminate Battle, 13410) already satisfies neither
+  the Win nor Lose branch of the enclosing Enemy Encounter command, and
+  already leaves the win/escape/defeat tallies alone — confirmed rather
+  than an open claim, and the regression coverage that looked like it
+  already proved this was actually vacuous.** `Game::Interpreter#resume_battle`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) only bumps `win_count`/`defeat_count`/
+  `escape_count` inside a `case result when :victory/:defeat/:escape` block
+  with no `:abort` arm, and `#find_battle_option`'s `BATTLE_HANDLERS` lookup
+  table has no `:abort` key either, so an unmatched lookup (`want = nil`)
+  never finds a `[Victory]`/`[Escape]`/`[Defeat]` marker and instead lands on
+  the encounter's own `END_BATTLE` — resuming the event right after Branch
+  End, exactly as the site describes. `battle_count` (the "a battle was
+  entered" tally the site's "battle-count stat" bullet half refers to) is
+  bumped once at `do_enemy_encounter`, independent of any outcome, so it is
+  untouched by this path either way. No code change was needed for the game
+  logic — but the existing `scripts/rpg2k_scene_check.rb` check that looked
+  like it already covered this (`'Terminate Battle from a page ends the
+  fight and resumes the event'`) had a loop bug: `12.times { scene.update;
+  break if @battle_ui.nil? }` breaks on the very first frame, before the
+  battle has even opened, since `@battle_ui` reads as `nil` then too —
+  identical to how it reads once the fight has genuinely closed (the
+  Timer-force-end check right after it, which this bullet cites for the
+  "no Win/Escape/Defeat handler matched" half, avoided the trap already, by
+  explicitly waiting for `@battle_ui` to appear before ever expecting it to
+  clear). Confirmed by re-running the *original* (pre-fix) check against an
+  injected `:abort → win_count` bug: all 344 checks still "passed". Fixed by
+  a new `open_then_close_battle` helper that first asserts `@battle_ui`
+  actually appears, then asserts it disappears again, and by a new check
+  built on it (`'Terminate Battle matches neither Win/Escape/Defeat and only
+  bumps the battle-entry count'`) that asserts `battle_count == 1` with
+  `win_count`/`escape_count`/`defeat_count` all `0` and neither handler
+  switch set — confirmed to fail against both an injected win-count bug and
+  an injected `BATTLE_HANDLERS[:abort]` mapping.
 - ✅ **Enemy Appearance (Show Hidden Monster) already gets both halves of this
   right.** Targeting an already-appeared enemy is a silent no-op:
   `Scene::Map#reveal_battle_monster` (`mruby-rpg2k/mrblib/scene/map.rb`)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5647,16 +5647,51 @@ check 'a battle page reveals a reinforcement before the round can end in a prema
      'revealing an already-visible member again is a no-op, not a sprite rebuild'
 end
 
+# Run `scene` until @battle_ui first appears (asserting it does within
+# `open_budget` frames), then continue until it goes away again (asserting
+# that too within `close_budget` more frames). A single "break the instant
+# @battle_ui.nil?" loop is a trap here: @battle_ui reads exactly the same
+# (nil) before the battle has opened as it does after it has cleanly closed,
+# so a naive loop can "pass" by breaking on frame 0, before any battle-event
+# page -- Terminate Battle included -- ever actually ran.
+def open_then_close_battle(scene, open_budget: 10, close_budget: 20)
+  open_budget.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+  end
+  ok scene.instance_variable_get(:@battle_ui), 'the battle opened'
+  close_budget.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui).nil?
+  end
+  eq nil, scene.instance_variable_get(:@battle_ui), 'the battle closed again'
+end
+
 check 'Terminate Battle from a page ends the fight and resumes the event' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }
   scene, _st = battle_scene_with_pages(pages)
-  12.times do
-    scene.update
-    break if scene.instance_variable_get(:@battle_ui).nil?
-  end
-  eq nil, scene.instance_variable_get(:@battle_ui),
-     'the battle closed without a result window'
+  open_then_close_battle(scene)
+end
+
+# yado.tk: a Battle Interrupt (Terminate Battle, 13410) satisfies neither the
+# enclosing Enemy Encounter's [Victory] nor [Escape]/[Defeat] handler branch --
+# it resumes right after Branch End, an unlabeled third outcome -- and only
+# the "a battle was entered" tally (Control Variables operand "Other" type 4,
+# battle_count) counts it; win/escape/defeat counts, each scoped to their own
+# matching outcome, do not.
+check 'Terminate Battle matches neither Win/Escape/Defeat and only bumps the battle-entry count' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }
+  scene, st = battle_scene_with_pages(pages)
+  eq 0, st.battle_count, 'not yet entered'
+  open_then_close_battle(scene)
+  ok !st.switches[1], 'the [Victory] handler (switch 1) did not run'
+  ok !st.switches[2], 'the [Escape] handler (switch 2) did not run either'
+  eq 1, st.battle_count, 'the encounter was entered exactly once'
+  eq 0, st.win_count
+  eq 0, st.escape_count
+  eq 0, st.defeat_count
 end
 
 check 'a battle-valid Timer reaching 0:00 force-ends the fight (yado.tk)' do


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s yado.tk backlog had an open claim: **Battle Interrupt** (the
in-battle-event "Terminate Battle" command, LCF id 13410) "satisfies neither
the Win nor Lose branch of the enclosing Battle Processing command... and
only increments the battle-count stat (not loss/escape counts)."

Reading the code, this is **already correct** — no game-logic change was
needed:
- `Game::Interpreter#resume_battle` only bumps `win_count`/`defeat_count`/
  `escape_count` inside `case result when :victory/:defeat/:escape`, with no
  `:abort` arm.
- `#find_battle_option`'s `BATTLE_HANDLERS` lookup table has no `:abort` key
  either, so it never matches a `[Victory]`/`[Escape]`/`[Defeat]` marker and
  instead resolves to the encounter's own `END_BATTLE`, resuming the event
  right after Branch End.
- `battle_count` (the "battle was entered" tally) is bumped once at
  `do_enemy_encounter`, independent of outcome.

While trying to add regression coverage for this, I found the existing
`scripts/rpg2k_scene_check.rb` check that looked like it already proved this
(`'Terminate Battle from a page ends the fight and resumes the event'`) was
**vacuous**: its loop broke the instant `@battle_ui` read `nil`, which is
true before the battle has opened as well as after it has genuinely closed —
so it "passed" on frame 0, before the battle event (and Terminate Battle)
ever actually ran. I confirmed this by replaying the *original* check against
an injected `:abort → win_count` bug: all 344 checks still "passed".

## Changes

- `scripts/rpg2k_scene_check.rb`: added an `open_then_close_battle` helper
  that asserts the battle actually opens before waiting for it to close
  again, fixed the existing Terminate Battle check to use it, and added a
  new check (`'Terminate Battle matches neither Win/Escape/Defeat and only
  bumps the battle-entry count'`) that directly asserts `battle_count == 1`
  with `win_count`/`escape_count`/`defeat_count` all `0` and neither handler
  switch set.
- `docs/TODO.md`: moved the "Battle Interrupt" bullet from the untriaged
  backlog to ✅ Fixed/Confirmed, with the full citation and the test-bug
  writeup.
- `changelog.d/battle-interrupt-handler-confirmed.changed.md`: new fragment.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` → 684 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` → 345 checks passed.
- Confirmed the new check fails against two injected regressions (reverted
  before committing):
  - `resume_battle` treating `:abort` as `:victory` for the counter bump.
  - `BATTLE_HANDLERS` mapping `:abort` to the `[Victory]` handler.
- Confirmed the *original* (pre-fix) check does **not** catch the first
  injected regression — it stays green, demonstrating the vacuous-loop bug
  this PR fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UVq4aMdcuSRZWok4WZbW1i)_