### PR TITLE
rpg2k: Break Loop reproduces RPG_RT's own indent-blind nesting bug

### DIFF
--- a/changelog.d/break-loop-nesting-bug.fixed.md
+++ b/changelog.d/break-loop-nesting-bug.fixed.md
@@ -1,0 +1,19 @@
+- **Break Loop now reproduces RPG_RT's own indent-blind nesting bug instead
+  of the behaviourally "correct" reading of the command.** viprpg-dev wiki
+  (`200X共通/基本的な仕様`・`バグ`): real RPG_RT's Break Loop does not track
+  nesting depth at all — it searches downward for the very next End Loop
+  command by list position alone and jumps just past whichever one it hits
+  first. When a second, more-deeply-nested Loop/End Loop pair sits between a
+  Break Loop and its own enclosing loop's End Loop, that inner End Loop is
+  what gets hit, not the enclosing one — falling into whatever follows it and
+  looping forever through the *outer* loop's own End Loop, so the code after
+  the outer loop is never reached. `Game::Interpreter#do_break_loop`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) used to scan forward for the first
+  End Loop whose indent was strictly less than the Break Loop's own — a
+  nesting-aware scan that always lands on the true enclosing loop, and so
+  never reproduced this compatibility gap. It now scans for the next End Loop
+  by position alone, indent unconsidered, matching the wiki's worked example.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (the common case
+  with nothing but the enclosing End Loop in between is unaffected; the
+  worked nested-loop example now hangs in the outer loop instead of escaping
+  it), the second confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3515,16 +3515,16 @@ RPGツクール2000 category) and the `200X共通` pages it transcludes
 source from the yado.tk backlog above — corroborates it in places (the
 parallel-process-goes-first-if-both-fire-the-same-frame rule, the 999 damage
 cap) but adds new specifics, especially around per-frame event step
-accounting and a documented RPG_RT loop-exit bug this codebase does not
-reproduce.
+accounting and a documented RPG_RT loop-exit bug (Break Loop's own nesting
+bug — now reproduced, see the "Fixed" bullet below).
 
 **Flagged for priority triage** — checked against the current code this
 session (reading + documenting only, not fixed — see below):
-- **Break Loop does not reproduce RPG_RT's own nesting bug.**
+- ✅ **Break Loop now reproduces RPG_RT's own nesting bug.**
   `Game::Interpreter#do_break_loop` (`mruby-rpg2k/mrblib/interpreter.rb:1008`)
-  scans forward for the first `End Loop` whose `indent < cmd.indent`,
-  i.e. it deliberately skips any `End Loop` at the break command's own
-  nesting depth or deeper and lands exactly on the *enclosing* loop's own
+  used to scan forward for the first `End Loop` whose `indent < cmd.indent`,
+  i.e. it deliberately skipped any `End Loop` at the break command's own
+  nesting depth or deeper and landed exactly on the *enclosing* loop's own
   end — which is the behaviourally "correct" outcome, but not what real
   RPG_RT does. The wiki's worked example: a Loop containing (in order) a
   Break Loop, then a second, empty, more-deeply-nested Loop/End Loop pair,
@@ -3535,10 +3535,22 @@ session (reading + documenting only, not fixed — see below):
   the outer one — control falls into the inner loop's body (the first Show
   Text) and then loops back via the *outer* End Loop forever, so the
   second Show Text after the outer loop is never reached and the first one
-  repeats indefinitely. This codebase's `indent`-aware scan means that
-  exact repro would correctly exit here instead of hanging — a
+  repeats indefinitely. This codebase's old `indent`-aware scan meant that
+  exact repro would have correctly exited here instead of hanging — a
   compatibility gap for any game whose logic (deliberately or not) depends
-  on this specific bug, not yet fixed.
+  on this specific bug. Fixed by dropping the indent comparison entirely:
+  `do_break_loop` now jumps past whichever `End Loop` command it meets first
+  scanning forward by list position alone, matching RPG_RT's own scan and
+  reproducing the bug rather than "fixing" it into the sane behaviour a
+  literal reading of "break the loop" would suggest — consistent with this
+  project's general stance of modelling RPG_RT's own quirks over a
+  better-behaved reading of the spec. The common case (nothing but the
+  enclosing loop's own `End Loop` between the break and it) is unaffected,
+  since an indent-blind scan finds the same command an indent-aware one
+  would. Covered by two new `scripts/rpg2k_logic_check.rb` checks (the
+  common, unaffected case; and the wiki's own worked nested-loop example,
+  asserting the command after the outer loop is never reached), the second
+  confirmed to fail against the pre-fix code before the fix.
 - **Autorun (auto-start) events run at most once per map visit, not once
   per frame.** `Scene::Map#start_autostart` (`mruby-rpg2k/mrblib/scene/
   map.rb:919`) picks the single lowest-id not-yet-started eligible

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1006,12 +1006,23 @@ module Game
       end
     end
 
-    # Break Loop: jump past the enclosing loop's End Loop marker.
-    def do_break_loop(cmd)
+    # Break Loop: real RPG_RT does *not* scan for the enclosing loop's own End
+    # Loop the way a nesting-aware reading of "break" would suggest -- it
+    # searches downward for the very next End Loop command by list position
+    # alone, with no regard for indent/nesting depth at all, and jumps just
+    # past whichever one it hits first (viprpg-dev wiki: 200X共通/基本的な仕様
+    # ・バグ, worked example: a Break Loop followed by a second, more-deeply-
+    # nested, empty Loop/End Loop pair before the enclosing loop's own End
+    # Loop lands on the *inner* End Loop, falls into a Show Text meant to run
+    # only once the outer loop truly exits, and then loops forever through the
+    # outer loop's own End Loop -- the code after the outer loop is never
+    # reached). Reproduced here rather than "fixed" into the sane behavior,
+    # matching this codebase's general stance of modelling RPG_RT's own
+    # quirks rather than a better-behaved reading of the spec.
+    def do_break_loop(_cmd)
       j = @index
       while j < @list.size
-        c = @list[j]
-        if c.code == Cmd::END_LOOP && c.indent < cmd.indent
+        if @list[j].code == Cmd::END_LOOP
           @index = j + 1
           return
         end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1416,6 +1416,46 @@ check 'Jump to Label works from any position in the block, not just the start' d
   eq 1, st.variables[2], 'and landed on the label to run what follows it'
 end
 
+check 'Break Loop jumps to the very next End Loop by list position, not the enclosing one' do
+  # Simple, common case: nothing but the enclosing loop's own End Loop sits
+  # between the Break Loop and it, so an indent-blind forward scan finds the
+  # same command an indent-aware scan would -- this must keep working.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::LOOP, [], indent: 0),                          # 0
+    FakeCmd.new(IC::BREAK_LOOP, [], indent: 1),                    # 1
+    FakeCmd.new(IC::END_LOOP, [], indent: 0),                      # 2
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 0),  # 3: after the loop
+  ])
+  it.update
+  eq 1, st.variables[1], 'landed right after the enclosing End Loop, same as before'
+end
+
+check "Break Loop reproduces RPG_RT's own nesting bug against a closer, unrelated End Loop" do
+  # viprpg-dev wiki (200X共通/基本的な仕様, バグ) worked example: a Break Loop
+  # followed by a second, more-deeply-nested, *empty* Loop/End Loop pair
+  # before the enclosing loop's own End Loop. Real RPG_RT's scan does not
+  # care about nesting depth at all, so it hits the inner Loop's End Loop
+  # first, falls into whatever sits between it and the outer End Loop (here,
+  # `variables[1] = 1`), and then loops forever via the outer End Loop --
+  # the command after the outer loop (`variables[2] = 1`) is never reached.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::LOOP, [], indent: 0),                          # 0: outer loop
+    FakeCmd.new(IC::BREAK_LOOP, [], indent: 1),                    # 1
+    FakeCmd.new(IC::LOOP, [], indent: 1),                          # 2: inner loop (empty body)
+    FakeCmd.new(IC::END_LOOP, [], indent: 1),                      # 3: inner loop's own End Loop
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),  # 4: reached every lap
+    FakeCmd.new(IC::END_LOOP, [], indent: 0),                      # 5: outer loop's own End Loop
+    FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 0, 1], indent: 0),  # 6: after the outer loop -- must never run
+  ])
+  it.update # bounded by MAX_STEPS; the reproduced bug loops forever otherwise
+  eq 1, st.variables[1], 'fell into the inner End Loop and ran what follows it'
+  eq 0, st.variables[2], 'never escaped to the command after the outer loop'
+end
+
 check 'Call Event with no resolver set is a safe no-op' do
   st = new_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary
- viprpg-dev wiki (200X共通/基本的な仕様・バグ): real RPG_RT's Break Loop
  does not scan for the *enclosing* loop's own End Loop the way a
  nesting-aware reading of "break" would suggest — it searches downward for
  the very next End Loop command by list position alone, indent-blind. A
  second, more-deeply-nested Loop/End Loop pair sitting between a Break
  Loop and its own enclosing loop's End Loop makes it land on the *inner*
  End Loop instead, fall into whatever follows it, and then loop forever
  through the outer loop's own End Loop — code after the outer loop is
  never reached.
- `Game::Interpreter#do_break_loop` previously scanned for the first End
  Loop whose `indent < cmd.indent` — behaviourally sane, but not what
  RPG_RT does. Now it scans forward for the very next `Cmd::END_LOOP` by
  list position only, with the indent comparison removed, matching RPG_RT's
  own scan. Reproduced rather than "fixed", matching this codebase's
  general stance of modelling RPG_RT's own quirks over a better-behaved
  reading of the spec.
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 690 checks pass (two new: the
      common case with nothing but the enclosing End Loop in between,
      unaffected by the change; the wiki's worked nested-loop example,
      asserting the command after the outer loop is never reached —
      confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 346 checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_