### PR TITLE
rpg2k: a vehicle's Control Variables screen X/Y now resolve, instead of always 0

### DIFF
--- a/changelog.d/vehicle-screen-position-operand.fixed.md
+++ b/changelog.d/vehicle-screen-position-operand.fixed.md
@@ -1,0 +1,15 @@
+- **A vehicle's screen X/Y now resolve through the Control Variables
+  "character position" operand**, instead of always reading 0. A vehicle's
+  map id/x/y/facing (attrs 0-3) were already fixed to read correctly from a
+  different map than the one it currently occupies, but the screen-coordinate
+  selectors (attrs 4/5) fell through `Scene::Map#character_screen_position`'s
+  hero/map-event-only branches to the same degenerate 0 an unresolvable
+  reference gets — the fix that landed the other four attrs explicitly scoped
+  this pair out as needing a scene-side camera hook. `#character_screen_position`
+  now recognises refs 10002-10004 (boat/ship/airship) via a new
+  `#vehicle_pixel`, which reads the ridden vehicle's interpolated pixel
+  position (in lockstep with the hero) or a parked one's tile position — the
+  same rule `#draw_vehicles` renders a vehicle's sprite by — and answers nil
+  (falling back to 0, matching an unresolvable map event) for a vehicle not
+  currently on the loaded map. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check, confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2122,15 +2122,35 @@ Everything below is unverified against the codebase.
   `Scene::Map#follow_vehicle` already keeps a ridden vehicle's stored
   position live every step. A vehicle's map id operand returns its real
   value rather than the map-event quirk's hardcoded 0, the same way the
-  hero's own map id read already does. **Screen x/y (attr 4/5) are not
-  covered by this fix** — those still read 0 for a vehicle, the same
-  degenerate answer an unresolvable map-event screen position already gets,
-  since resolving them would need a scene-side camera hook this fix
-  deliberately avoids depending on. Covered by a new
+  hero's own map id read already does. Covered by a new
   `scripts/rpg2k_logic_check.rb` check (a boat and an airship's map id/x/y/
   facing read correctly from an interpreter positioned on an unrelated map;
   an unplaced vehicle reads its (0,0) default), confirmed to fail against
-  the pre-fix code before the fix.
+  the pre-fix code before the fix. ✅ **Screen x/y (attr 4/5) are now covered
+  too** — the one deliberately-scoped-out half of the fix above, since it
+  needs a live camera that only the currently-loaded map's own scene has.
+  `Scene::Map#character_screen_position` (the method
+  `Interpreter#screen_operand` calls through the `@map_info` hook) only
+  recognised the hero (10001) and map-event ids, so a vehicle ref
+  (10002-10004) fell through to its "nothing to place" branch and read 0
+  the same way an unresolvable map event does — not the vehicle's actual
+  on-screen position. A new `#vehicle_pixel(type)` reads `Game::State`'s
+  `Game::Vehicle` and returns the ridden vehicle's own interpolated pixel
+  position (`#player_pixel`, so it reads in lockstep with the hero mid-step)
+  or a parked one's tile position — the exact same rule `#draw_vehicles`
+  already renders a vehicle's sprite by — and nil when the vehicle isn't
+  placed on the currently loaded map at all (unplaced, or parked on a
+  different one), which `#character_screen_position` treats the same as an
+  unresolvable map event: falls back to 0 one level up in
+  `#screen_operand`. `#character_screen_position` dispatches to it for refs
+  10002-10004 before falling through to the map-event lookup, reusing the
+  same `MOVE_TARGET_BOAT`/`MOVE_TARGET_AIRSHIP` range Set Move Route's own
+  vehicle-target resolution already uses. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (an unplaced boat reads nil; a parked
+  one reads the same tile-centre/tile-bottom position a map event at that
+  tile would; one parked on a different map reads nil again; a boarded one
+  reports the identical screen position the hero riding it does), confirmed
+  to fail against the pre-fix code before the fix.
 - **Battle Event** — separate command set from Map/Common events entirely;
   no Pictures on the battle screen; Parallel Process can't run in battle;
   no further pages run once battle ends.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6183,8 +6183,10 @@ class RPG2k
 
       # Where a character sits on screen, for the Control Variables "character"
       # operand's screen-coordinate selectors. `ref` is the operand's reference:
-      # 10001 the hero, a positive id a map event. nil when it names something
-      # this scene cannot place.
+      # 10001 the hero, 10002-10004 a vehicle (boat/ship/airship), a positive id
+      # a map event. nil when it names something this scene cannot place — a
+      # vehicle not currently on this map included, the same degenerate answer
+      # an unresolvable map event already gets.
       #
       # RPG_RT measures X from the tile's centre and Y from its *bottom* — the
       # asymmetry is real (EasyRPG's GetScreenX subtracts half a tile after
@@ -6192,8 +6194,10 @@ class RPG2k
       # reproduced rather than tidied up.
       def character_screen_position(ref)
         pixel =
-          if ref == 10001
+          if ref == MOVE_TARGET_PLAYER
             player_pixel
+          elsif ref >= MOVE_TARGET_BOAT && ref <= MOVE_TARGET_AIRSHIP
+            vehicle_pixel(Game::Vehicle::TYPES[ref - MOVE_TARGET_BOAT])
           else
             e = @events.find { |ev| ev[:id] == ref }
             e && event_pixel(e)
@@ -6201,6 +6205,18 @@ class RPG2k
         return nil unless pixel
         cam_x, cam_y = camera_position
         { x: pixel[0] - cam_x + TILE / 2, y: pixel[1] - cam_y + TILE }
+      end
+
+      # Current position of vehicle `type` in map pixels: the party's own
+      # interpolated pixel position while it's the one being ridden
+      # (#player_pixel, so it reads in lockstep with the hero mid-step),
+      # otherwise wherever it sits parked — the same rule #draw_vehicles
+      # renders a vehicle's sprite by. nil when the vehicle isn't placed on the
+      # currently loaded map at all (unplaced, or sitting on a different one).
+      def vehicle_pixel(type)
+        v = @state.vehicle(type)
+        return nil unless v.placed? && v.map_id == @state.map_id
+        @state.boarded == type ? player_pixel : [v.x * TILE, v.y * TILE]
       end
       public :camera_position, :character_screen_position
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4546,6 +4546,42 @@ check 'character_screen_position measures against the live camera' do
   eq nil, scene.character_screen_position(99), 'no such event on this map'
 end
 
+check "a vehicle's screen position now reads through the same operand a map event's does" do
+  # yado.tk: a vehicle's x/y/map id/facing can already be read via Control
+  # Variables from a different map than the one it currently occupies (see the
+  # vehicle_operand fix), but its *screen* x/y (attr 4/5) needs a live camera,
+  # which only the currently-loaded map's own scene has -- that half was left
+  # reading the same degenerate 0 an unresolvable map event gets. Ref 10002 is
+  # the boat, matching Scene::Map::MOVE_TARGET_BOAT.
+  scene = new_scene({}, player: [1, 2])
+  st = scene.instance_variable_get(:@state)
+  tile = RPG2k::Scene::Map::TILE
+  eq [0, 0], scene.camera_position, 'a map smaller than the view cannot scroll'
+
+  boat = st.vehicle(:boat)
+  eq nil, scene.character_screen_position(10002), 'an unplaced vehicle has nowhere on screen to report'
+
+  # Parked on this map, off to the side: reads exactly like a map event would
+  # at that same tile (the shared tile-centre/tile-bottom asymmetry included).
+  boat.map_id = st.map_id
+  boat.x = 3
+  boat.y = 4
+  parked = scene.character_screen_position(10002)
+  eq 3 * tile + tile / 2, parked[:x]
+  eq 4 * tile + tile, parked[:y]
+
+  boat.map_id = st.map_id + 1
+  eq nil, scene.character_screen_position(10002), "a vehicle parked on a different map isn't on this camera"
+  boat.map_id = st.map_id
+
+  # Boarded: it rides along with the hero's own interpolated pixel position,
+  # not wherever it was left parked.
+  st.boarded = :boat
+  ridden = scene.character_screen_position(10002)
+  hero = scene.character_screen_position(10001)
+  eq hero, ridden, 'a boarded vehicle reports the same screen position as the hero riding it'
+end
+
 check 'a scrolled camera shifts the screen position it reports' do
   # A tall map so the follow camera actually scrolls, and the hero's screen
   # position stops tracking its map position.


### PR DESCRIPTION
## Summary

Closes the one deliberately-scoped-out half of an earlier fix (`docs/TODO.md`'s "Vehicles" bullet under the yado.tk backlog): a boat/ship/airship's map id/x/y/facing already read correctly via the Control Variables "character position" operand from a different map than the vehicle currently occupies, but the screen-coordinate selectors (attrs 4/5) still read the same degenerate `0` an unresolvable reference gets, since resolving them needs a live camera that only the currently-loaded map's own scene has.

- `Scene::Map#character_screen_position` (reached through `Interpreter#screen_operand`'s `@map_info` hook) only recognised the hero (`10001`) and map-event ids; a vehicle ref (`10002`-`10004`) fell through to the map-event lookup and found nothing.
- A new `#vehicle_pixel(type)` reads the target `Game::Vehicle` off `Game::State` and returns:
  - the ridden vehicle's own interpolated pixel position (`#player_pixel`, so it reads in lockstep with the hero mid-step) while boarded,
  - a parked vehicle's tile position otherwise — the exact same rule `#draw_vehicles` already renders its sprite by,
  - `nil` when the vehicle isn't placed on the currently loaded map at all (unplaced, or parked on a different one) — treated the same as an unresolvable map event, which falls back to `0` one level up.
- `#character_screen_position` dispatches to it for the `MOVE_TARGET_BOAT..MOVE_TARGET_AIRSHIP` range, the same constants Set Move Route's own vehicle-target resolution already uses.

Documented in `docs/TODO.md` (extending the existing "Vehicles" bullet with a ✅ follow-up) and `changelog.d/vehicle-screen-position-operand.fixed.md`.

## Test plan

- Added a new `scripts/rpg2k_scene_check.rb` check: an unplaced boat reads `nil`; a parked one reads the same tile-centre/tile-bottom position a map event at that tile would; one parked on a different map reads `nil` again; a boarded one reports the identical screen position the hero riding it does.
- Confirmed the new check fails (1 of 347) against the pre-fix code via `git stash` on just the `map.rb` change, and passes clean with the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 688 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 347 checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZMmMb2Fz8dazyVJM4rCXZ


---
_Generated by [Claude Code](https://claude.ai/code/session_011ZMmMb2Fz8dazyVJM4rCXZ)_