### PR TITLE
Fix block D and E tile terrain index calculation

### DIFF
--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -513,8 +513,8 @@ module Game
     # Chip index into the lower passability table for a lower-layer tile id.
     def self.lower_index(tile_id)
       return nil if tile_id.nil?
-      if tile_id >= 10000 then 18 + (tile_id - 10000)
-      elsif tile_id >= 5000 then 6 + (tile_id - 5000) / 50
+      if tile_id >= 5000 then 18 + (tile_id - 5000)
+      elsif tile_id >= 4000 then 6 + (tile_id - 4000) / 50
       elsif tile_id >= 3000 then 3 + (tile_id - 3000) / 50
       else tile_id / 1000
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10339,7 +10339,7 @@ end
 check 'a chipset that stores no terrain table reads terrain 1' do
   cs = chipset_with(nil)
   eq 1, cs.terrain(0), 'the first lower tile'
-  eq 1, cs.terrain(4000), 'a block-E tile'
+  eq 1, cs.terrain(4000), 'a block-D tile'
   cs = chipset_with([])
   eq 1, cs.terrain(0), 'an empty table is the same absence'
 end
@@ -10350,6 +10350,19 @@ check 'a chipset that stores one reads it' do
   cs = chipset_with(td)
   eq 7, cs.terrain(0)
   eq 3, cs.terrain(4000)
+end
+
+# Block D (terrain autotiles, ids 4000-4599, index base 6) and block E (144
+# plain lower tiles, ids 5000-5143, index base 18, 1:1 stride) must land on
+# distinct, correctly-spaced indices — a uniform table can't tell a wrong
+# index from a right one, so this uses a distinct value per index.
+check 'block D and block E tiles resolve to their own distinct indices' do
+  td = Array.new(30) { |i| i }
+  cs = chipset_with(td)
+  eq 6, cs.terrain(4000), 'first block-D autotile -> index 6'
+  eq 17, cs.terrain(4599), 'last block-D autotile -> index 17 (11 groups of 50 from 6)'
+  eq 18, cs.terrain(5000), 'first block-E tile -> index 18'
+  eq 20, cs.terrain(5002), 'block-E tile 5002 -> index 20 (1:1 stride)'
 end
 
 # RPG_RT reads the first lower tile's terrain for anything it cannot index,


### PR DESCRIPTION
## Summary
Corrects the terrain index calculation for RPG2k block D (terrain autotiles) and block E (plain lower tiles) to properly distinguish between them and ensure correct index spacing.

## Key Changes
- **Fixed terrain index ranges**: Swapped the condition order in `lower_index()` to check for block E tiles (5000+) before block D tiles (4000+), since block E has a higher base ID
- **Corrected block D calculation**: Changed from `(tile_id - 5000) / 50` to `(tile_id - 4000) / 50` to properly map block D tile IDs starting at 4000
- **Corrected block E calculation**: Changed from `18 + (tile_id - 10000)` to `18 + (tile_id - 5000)` to properly map block E tile IDs starting at 5000
- **Added comprehensive test**: New test case validates that block D and E tiles resolve to distinct, correctly-spaced indices with a non-uniform terrain table
- **Updated test comment**: Fixed misleading comment from "block-E tile" to "block-D tile" in existing test

## Implementation Details
The terrain index calculation now correctly handles:
- Block D (IDs 4000-4599): Maps to indices 6-17 with stride of 50 (11 groups)
- Block E (IDs 5000-5143): Maps to indices 18+ with 1:1 stride
- The new test uses a distinct value per index to catch any off-by-one errors that a uniform table would miss

https://claude.ai/code/session_01Ep97Wn4Nfq2eAiAazKS1qr