### PR TITLE
rpg2k: a fire-and-forget forced route auto-runs before a Wait/Show Text

### DIFF
--- a/changelog.d/move-event-implicit-proceed.fixed.md
+++ b/changelog.d/move-event-implicit-proceed.fixed.md
@@ -1,0 +1,5 @@
+- **A fire-and-forget Move Event's forced route now implicitly auto-runs to
+  completion the instant the same event hits a Show Text or a Wait**, rather
+  than sitting frozen with zero progress until the whole event finishes. No
+  explicit "Proceed With Movement" is needed for this — matching yado.tk's
+  documented rule that only forcing it *mid-list* needs that command.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2402,9 +2402,48 @@ not yet verified:
 - Move-route commands are asynchronous/fire-and-forget by default: the
   interpreter advances immediately while the character keeps sliding in
   the background; only "Proceed With Movement"/"Run All Designated Moves"
-  blocks until every pending route finishes. An implicit auto-run also
-  happens whenever the event's own command list ends or hits a
-  Wait/Show-Text — "Run All" is only needed to force it mid-list.
+  blocks until every pending route finishes. ✅ **An implicit auto-run now
+  also happens whenever the event hits a Wait or a Show Text** — "Run All"
+  is only needed to force it mid-list otherwise. This was a genuine gap:
+  `Game::Interpreter#do_show_message`/`#do_wait` (`mruby-rpg2k/mrblib/
+  interpreter.rb`) set their `:message`/`:wait` wait-kind unconditionally,
+  and `Scene::Map#drive_event`'s dispatch for both
+  (`mruby-rpg2k/mrblib/scene/map.rb`) opened the message window / started
+  the wait countdown immediately, with no awareness of a still-running
+  forced route (set by an earlier fire-and-forget Move Event in the same
+  script) at all — since a forced route only ever advances via
+  `#step_events` (skipped whenever `#event_busy?` is true, which it always
+  is while the triggering event's own interpreter is still running or
+  waiting) or the explicit `:movement` wait's `#step_forced_movement`, a
+  route left pending going into a Wait/Show Text sat completely frozen,
+  with zero progress, until the *whole* event's command list finished —
+  not "auto-running to completion" the way an inserted Proceed With
+  Movement would. Fixed by routing both branches through the same
+  `#step_forced_movement`/`#forced_movement_done?` machinery
+  `:movement` already uses: `:message` now only calls `#open_message` once
+  `#step_forced_movement` reports every forced route (player, every map
+  event, every vehicle — the same map-wide scope Proceed With Movement
+  itself already covers) done, driving it one frame further otherwise; `:wait`
+  gates `#drive_wait` the same way, so the wait timer does not even start
+  counting down until then. The "list ends" half of the original claim
+  needed no change: once the triggering event's own command list is
+  genuinely exhausted, `#event_busy?` already goes false on its own and
+  `#step_events` resumes driving the route at its normal pace — the same
+  outcome Proceed With Movement produces, just via the ordinary per-frame
+  path instead of the `:movement` wait, so nothing was actually broken
+  there. **Still open**: a fire-and-forget route sitting between two
+  *non-blocking* commands (e.g. a Move Event followed by several Control
+  Variables commands with no Wait/Show Text/Proceed before the list ends)
+  genuinely does not animate frame-by-frame while those commands run — it
+  stays frozen until one of the three trigger points above is reached,
+  same as before this fix; true concurrent background sliding while
+  arbitrary non-blocking commands keep executing is a larger,
+  unaddressed change. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a 3-tile forced route on a bystander event, immediately followed
+  by a Show Text with no Proceed With Movement, only opens the window once
+  the route lands; the same setup with a Wait in place of the Show Text
+  only starts that Wait's countdown once the route lands), both confirmed
+  to fail against the pre-fix code before the fix.
 - Moving onto an impassable tile without "Ignore If Can't Move" **hangs**
   at that command until the obstruction clears (not a skip) — a full
   control-lock freeze if the hero is the target. The same freeze class

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2589,7 +2589,13 @@ class RPG2k
 
         if @interpreter.waiting?
           case @interpreter.wait_kind
-          when :message then open_message(@interpreter.message_lines, false)
+          when :message
+            # yado.tk: a still-pending forced move route (Move Event with no
+            # "wait for completion") implicitly auto-runs to completion the
+            # instant the event hits a Show Text, the same way an explicit
+            # Proceed With Movement would -- driven here exactly like the
+            # :movement branch below, before the window is actually opened.
+            open_message(@interpreter.message_lines, false) if step_forced_movement
           when :choice then open_message(@interpreter.choice_labels, true)
           when :number then open_number_input(@interpreter.input_digits)
           when :key_input then drive_key_input
@@ -2597,6 +2603,10 @@ class RPG2k
           when :shop then drive_shop
           when :battle then drive_battle
           when :wait
+            # Same implicit-Proceed-With-Movement rule as :message above, for a
+            # Wait command: the wait timer does not even start counting down
+            # until any pending forced route has finished.
+            return unless step_forced_movement
             drive_wait
             # RPG_RT resumes a Wait the instant its timer elapses and keeps
             # spending that same frame's step budget -- Wait 0.0 sec is

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2747,6 +2747,61 @@ check "Proceed With Movement also waits on a vehicle's forced route" do
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
+check "a forced route auto-runs to completion before an immediately-following Show Text opens (yado.tk)" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Force event 2 to walk right 3 tiles (freq 4, repeat off), with no Proceed
+  # With Movement -- yado.tk: hitting a Show Text implicitly auto-runs any
+  # still-pending forced route to completion first, the same as an explicit
+  # Proceed With Movement would, before the window actually opens.
+  auto.event_commands = [
+    ECmd.new(ic::MOVE_EVENT,
+             [2, 4, 0, 0, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT]),
+    ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi'),
+  ]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(0, 1, page) },
+                    player: [5, 5])
+  c = chars(scene)[2]
+
+  10.times { scene.update } # mid-route: still moving, message not yet opened
+  ok c.x < 3, "route still in progress, at x=#{c.x}"
+  ok !scene.instance_variable_get(:@message),
+     'Show Text waits for the pending forced route to finish first'
+
+  200.times { scene.update } # enough frames for the freq-4 route to finish
+  eq 3, c.x, 'the forced event reached the end of its route'
+  ok scene.instance_variable_get(:@message),
+     'the message window opens only once the route has completed'
+end
+
+check "a forced route auto-runs to completion before an immediately-following Wait starts counting down (yado.tk)" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::MOVE_EVENT,
+             [2, 4, 0, 0, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT]),
+    ECmd.new(ic::WAIT, [5]), # half a second, once the route lets it start
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(0, 1, page) },
+                    player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  c = chars(scene)[2]
+
+  10.times { scene.update } # mid-route: the Wait must not have started yet
+  ok c.x < 3, "route still in progress, at x=#{c.x}"
+
+  # Stop the instant the route lands, so the half-second Wait has had no
+  # chance yet to also elapse within the same budget.
+  300.times { scene.update; break if c.x == 3 }
+  eq 3, c.x, 'the forced event reached the end of its route'
+  ok !st.switches[1], 'the half-second Wait only starts once the route is done'
+
+  40.times { scene.update } # enough for the half-second Wait itself to elapse
+  ok st.switches[1],
+     'the interpreter resumed once the Wait (started after the route) elapsed'
+end
+
 check 'Tint Screen with a wait holds the interpreter until the tint settles' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- Fixes a yado.tk-documented gap in `docs/TODO.md`'s "Move Route / Character Movement command" section: a Move Event's forced route, issued without "wait for completion," used to sit completely frozen (zero progress) if the same event's script went on to hit a Wait or a Show Text before its command list finished — instead of implicitly auto-running to completion first, the way an explicit "Proceed With Movement" would.
- `Scene::Map#drive_event`'s `:message` and `:wait` branches now gate on the same `#step_forced_movement`/`#forced_movement_done?` machinery the explicit `:movement` wait already uses: the message window doesn't open, and the wait timer doesn't start counting down, until every pending forced route (player, every map event, every vehicle) has finished.
- The "event's command list ends" half of the original claim needed no change — `#event_busy?` already goes false once the list is genuinely exhausted, letting `#step_events` resume driving the route at its normal pace, the same outcome Proceed With Movement produces.
- Still open (documented in `docs/TODO.md`): a route sitting between two *non-blocking* commands (e.g. a Move Event followed by several Control Variables commands, no Wait/Show Text/Proceed before the list ends) still doesn't animate frame-by-frame while those commands run — true concurrent background sliding is a larger, separate change.

## Test plan

- Added two new `scripts/rpg2k_scene_check.rb` checks: a 3-tile forced route on a bystander event immediately followed by a Show Text (no Proceed With Movement) only opens the window once the route lands; the same setup with a Wait in place of the Show Text only starts that Wait's countdown once the route lands.
- Both new checks confirmed to fail against the pre-fix code before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 690 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 348 checks passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKPgTKUguhWHsuL2eYCjiU)_