### PR TITLE
rpg2k: Show Battle Animation targeting a vehicle reads its live position

### DIFF
--- a/changelog.d/battle-animation-vehicle-target.fixed.md
+++ b/changelog.d/battle-animation-vehicle-target.fixed.md
@@ -1,0 +1,14 @@
+- **Show Battle Animation (11210) targeting a vehicle now plays over that
+  vehicle's own live position**, instead of silently defaulting to the
+  player's. `Scene::Map#animation_target_pixel` (`mruby-rpg2k/mrblib/
+  scene/map.rb`) had no case for a vehicle's Move-Event-style target id
+  (10002-10004, boat/ship/airship), so it fell into the "map event by id"
+  lookup, found nothing (a vehicle slot is never a real map event id), and
+  defaulted to the player's own tile — matching yado.tk's own finding that a
+  vehicle-targeted Battle Animation reads that vehicle's real x/y, off
+  `Game::State` directly, even from a different map than the one on screen,
+  the same blind-read quirk the Control Variables vehicle-position fix
+  already reproduces for the "character position" operand. Fixed with a new
+  `#vehicle_pixel`, reading straight off `Game::Vehicle`'s live `x`/`y`.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check, confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2080,8 +2080,9 @@ Everything below is unverified against the codebase.
   lowest/topmost. Covered by a new `scripts/rpg2k_scene_check.rb` check
   (two events sharing a tile, `Store Event ID` resolves to the higher one).
 - **Battle Animation** — only one can display at once (second supersedes);
-  each frame is exactly 1/30s; targeting a Vehicle position reads that
-  vehicle's live x/y even from a different map than the one shown.
+  each frame is exactly 1/30s; ✅ **targeting a Vehicle position now reads
+  that vehicle's live x/y even from a different map than the one shown** —
+  see the fuller writeup under "Full-site sweep" below.
 - **Material data** — an imported asset takes priority over a same-named RTP
   one; dropping files directly into asset folders bypasses size/transparent-
   colour-index validation.
@@ -3105,6 +3106,26 @@ not yet verified:
   animation actually renders — sprite shown, screen flash fired — for a
   parallel-process request, not just a foreground one), both confirmed to
   fail against the pre-fix code before the fix.
+- ✅ **Show Battle Animation (11210) targeting a vehicle now plays over that
+  vehicle's own live position**, instead of silently defaulting to the
+  player's. `Scene::Map#animation_target_pixel` (`mruby-rpg2k/mrblib/
+  scene/map.rb`) resolved a Move-Event-style target id to the player, "this
+  event," or a map event by id — but had no case at all for a vehicle slot
+  (10002-10004, boat/ship/airship): a vehicle id never matches a real map
+  event id, so it fell straight through to the "map event by id, defaulting
+  to the player" branch and silently drew the animation over the player
+  instead. Fixed with a new `#vehicle_pixel`, reading the target `Game::
+  Vehicle`'s live `x`/`y` straight off `Game::State` — the same source
+  `#event_operand`'s Control Variables "character position" vehicle fix
+  reads (see the "Vehicles" bullet under "Party / Actor / Vehicle" above) —
+  which needs no scene-side camera hook and, matching that fix's own
+  quirk, does not check whether the vehicle is actually on the map this
+  scene has loaded before reading its position: a vehicle target reads its
+  real x/y even when a different map is on screen, exactly as yado.tk
+  describes. Covered by a new `scripts/rpg2k_scene_check.rb` check (a Show
+  Battle Animation targeting the boat lands at the boat's own tile, not the
+  player's or the triggering event's), confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **A Timer with "valid during battle" checked force-ends the battle**
   the instant it reaches 0:00, regardless of encounter source (default or
   scripted) — an easy accidental trap if the same Timer is reused for a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5226,16 +5226,33 @@ class RPG2k
       end
 
       # The target character's map-pixel position: the player, the running event
-      # ("this event" / 0), or a map event by id, defaulting to the player.
+      # ("this event" / 0), a vehicle slot, or a map event by id, defaulting to
+      # the player. yado.tk: a vehicle target reads that vehicle's real,
+      # currently-live x/y off `Game::State` (the same source
+      # `#event_operand`'s Control Variables "character position" vehicle fix
+      # reads) even when the vehicle is not on the map this scene has loaded --
+      # RPG_RT does not check that the two agree before placing the animation,
+      # the same blind-read quirk as the Control Variables fix.
       def animation_target_pixel(target)
         case target
         when MOVE_TARGET_PLAYER then player_pixel
         when 0, MOVE_TARGET_THIS
           @active_event ? event_pixel(@active_event) : player_pixel
+        when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          vehicle_pixel(Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT])
         else
           ev = @events.find { |e| e[:id] == target }
           ev ? event_pixel(ev) : player_pixel
         end
+      end
+
+      # A vehicle's own map-pixel position, read straight off its live
+      # `Game::Vehicle` record -- no interpolation, unlike a walking
+      # player/event, since nothing here animates a standing vehicle's slide.
+      def vehicle_pixel(type)
+        v = @state.vehicle(type)
+        return player_pixel unless v
+        [v.x * TILE, v.y * TILE]
       end
 
       # Fire the screen flashes the current frame's timings request (flash_scope

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4202,6 +4202,40 @@ check 'Show Battle Animation plays: an animation sprite shows and a flash fires'
   ok !spr.visible, 'the animation sprite is hidden once it finishes'
 end
 
+# yado.tk: Show Battle Animation targeting a Vehicle position reads that
+# vehicle's real, currently-live x/y (the same source the Control Variables
+# vehicle-position fix reads), not the player's or the triggering event's own
+# tile. #animation_target_pixel had no branch for a vehicle's Move-Event-style
+# target id (10002-10004) at all, so it fell through to the generic "map event
+# by id" lookup, found none, and silently defaulted to the player's own
+# position.
+check "Show Battle Animation targeting a vehicle uses the vehicle's own live position" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # animation 8 (a drawable one in the fake db) targeting the boat (10002).
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10002, 1], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  # Placed well away from both the player (0,0) and the triggering event
+  # (2,2), so either one substituting for the boat would be caught.
+  st.vehicle(:boat).map_id = st.map_id
+  st.vehicle(:boat).x = 5
+  st.vehicle(:boat).y = 7
+  tile = RPG2k::Scene::Map::TILE
+  anim = nil
+  40.times do
+    scene.update
+    anim = scene.instance_variable_get(:@map_animation)
+    break if anim || st.switches[6]
+  end
+  ok anim, 'the animation actually started'
+  eq [5 * tile, 7 * tile], [anim[:tx], anim[:ty]],
+     "targeted the boat's own live position, not the player's or the event's"
+end
+
 # yado.tk: only one Battle Animation is ever on screen at once -- true of the
 # map-level Show Battle Animation command (11210) same as an in-battle one.
 # That only means anything if a *parallel process* can show one at all: before


### PR DESCRIPTION
## Summary
- yado.tk: Show Battle Animation (11210) targeting a Vehicle position reads
  that vehicle's live x/y even from a different map than the one shown.
- `Scene::Map#animation_target_pixel` had no case for a vehicle's
  Move-Event-style target id (10002-10004, boat/ship/airship) — it fell
  through to the "map event by id" lookup, found nothing, and silently
  defaulted to the player's own position.
- Adds a `MOVE_TARGET_BOAT`/`SHIP`/`AIRSHIP` branch and a new
  `#vehicle_pixel` helper that reads the target `Game::Vehicle`'s live
  `x`/`y` straight off `Game::State` — the same blind-read pattern (no
  check that the vehicle is on the currently-loaded map) as the earlier
  Control Variables vehicle-position fix.
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 690 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 347 checks pass (new check: Show
      Battle Animation targeting a vehicle uses the vehicle's own live
      position — confirmed to fail against the pre-fix code, defaulting to
      the player's position instead)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_