### PR TITLE
rpg2k: Show Picture now no-ops past RPG2000's 1..50 picture id range

### DIFF
--- a/changelog.d/picture-id-range-cap.fixed.md
+++ b/changelog.d/picture-id-range-cap.fixed.md
@@ -1,0 +1,13 @@
+- **Show Picture now no-ops on a picture id outside RPG2000's 1..50 range**,
+  instead of tracking the picture anyway. `Game::State#show_picture`
+  (`mruby-rpg2k/mrblib/game.rb`) only rejected `id <= 0`; RPG2000's editor
+  caps the Show Picture id field at 50 (a fixed-size internal slot array —
+  the same fact the already-implemented "50 concurrent picture slots, higher
+  id always draws on top" behaviour is built on), so an id above that is not
+  a real picture and RPG_RT does nothing with it. Fixed with a new
+  `Game::State::MAX_PICTURE_ID = 50` and an upper bound alongside the
+  existing `id > 0` check; `#move_picture`/`#erase_picture` need no matching
+  guard, since neither can ever find such an id shown in the first place.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (id 51 is silently
+  dropped; the boundary id 50 still works), confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2301,7 +2301,8 @@ not yet verified:
   switches/variables capping at 5000 (configurable in the editor, so this may
   be a non-issue rather than a gap — nothing here enforces a count ceiling on
   how many distinct ids get used, which is a different question from a single
-  variable's *value* range, now fixed); picture id range 1-50.
+  variable's *value* range, now fixed). Picture id range 1-50 is now fixed
+  too, see the "Pictures" bullet under "Full-site sweep" below.
 - **Runtime per-map overrides that reset on leaving-and-returning to the
   map**, not just on Transfer Player/save-load: Chipset Change, Panorama/
   parallax Change, Encounter Steps Change, Tile Replacement, and — per one
@@ -2688,6 +2689,22 @@ not yet verified:
   asserting the composite draws the lower id first). Still open: Battle
   Animation drawing above the picture layer specifically, and "map/
   characters always draw below all pictures" as its own assertion.
+- ✅ **Show Picture now no-ops on a picture id outside 1..50** — the "Still
+  open: picture id range 1-50" gap left by the numeric-constants bullet
+  above. RPG2000's editor caps the Show Picture id field at 50 (a
+  fixed-size internal slot array, the same fact the "50 concurrent picture
+  slots" confirmation just above already relies on), so an id past it is
+  not a real picture and RPG_RT does nothing with it.
+  `Game::State#show_picture` (`mruby-rpg2k/mrblib/game.rb`) only ever
+  rejected `id <= 0`, so an out-of-range high id was tracked, drawn and
+  addressable by Move/Erase Picture like any other. Fixed with a new
+  `Game::State::MAX_PICTURE_ID = 50` and an upper bound alongside the
+  existing `id > 0` check on `#show_picture`; `#move_picture`/
+  `#erase_picture` need no matching guard of their own, since neither can
+  ever find such an id shown in the first place once `#show_picture`
+  refuses to create one. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (id 51 is silently dropped; the boundary id 50 still works),
+  confirmed to fail against the pre-fix code before the fix.
 - Changing maps **auto-clears every picture** — except when the transfer
   was via Teleport or Escape, which is an explicit, deliberate exception
   (multiply corroborated). ✅ **The Teleport/Escape skill/item half of this

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7516,6 +7516,11 @@ module Game
   end
 
   class State
+    # RPG2000's Show Picture editor field only offers picture numbers 1-50 (a
+    # fixed-size internal slot array); an id outside that range is not a real
+    # picture and Show Picture on one is a no-op (yado.tk).
+    MAX_PICTURE_ID = 50
+
     attr_reader :party, :switches, :variables, :message_config, :screen, :weather
     attr_accessor :map, :map_id, :x, :y, :direction
     # Whether the player may open the main menu / save, toggled by the Change
@@ -7709,9 +7714,12 @@ module Game
     # neither does this.
     def walk_step; @steps += 1; end
 
-    # Show (or replace) picture `id` with the given Picture options hash.
+    # Show (or replace) picture `id` with the given Picture options hash. An id
+    # outside 1..MAX_PICTURE_ID does nothing -- #move_picture/#erase_picture
+    # need no matching guard of their own, since neither can ever find such an
+    # id shown in the first place.
     def show_picture(id, opts)
-      @pictures[id] = Picture.new(id, opts) if id && id > 0
+      @pictures[id] = Picture.new(id, opts) if id && id > 0 && id <= MAX_PICTURE_ID
     end
 
     # Start a move on picture `id` (a no-op if it is not shown). `args` are the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4903,6 +4903,24 @@ check 'Erase Picture removes the picture' do
   ok st.pictures[5].nil?, 'erased'
 end
 
+check 'Show Picture on an id past the 50-slot range is a no-op' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::SHOW_PICTURE,
+                        [51, 0, 0, 0, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0],
+                        string: 'p')])
+  it.update
+  ok st.pictures[51].nil?, 'id 51 is past RPG2000\'s 1..50 picture range'
+  eq 0, st.pictures.size, 'nothing was shown at all'
+  # The boundary id itself still works.
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::SHOW_PICTURE,
+                         [50, 0, 0, 0, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0],
+                         string: 'p')])
+  it2.update
+  ok st.pictures[50], 'id 50 is the last valid slot'
+end
+
 # -- Player Visibility / Return to Title --------------------------------------
 
 check 'Set Transparent Flag toggles the player-transparent state, non-blocking' do


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s yado.tk backlog ("Numeric constants worth asserting directly") flagged the Show Picture id's 1-50 range as still open — RPG2000's editor caps the Show Picture id field at 50 (a fixed-size internal slot array, the same fact the already-implemented "50 concurrent picture slots, higher id always draws on top" behaviour is built on), so an id above 50 is not a real picture and RPG_RT does nothing with it.

`Game::State#show_picture` (`mruby-rpg2k/mrblib/game.rb`) only ever rejected `id <= 0`, so an out-of-range high id was tracked, drawn, and addressable by Move/Erase Picture like any other slot.

## Changes

- Added `Game::State::MAX_PICTURE_ID = 50` and an upper bound alongside the existing `id > 0` check in `#show_picture`. `#move_picture`/`#erase_picture` need no matching guard of their own, since neither can ever find such an id shown in the first place once `#show_picture` refuses to create one.
- `docs/TODO.md`: moved the "picture id range 1-50" item from "Still open" to ✅ Fixed, with the citation.
- `changelog.d/picture-id-range-cap.fixed.md` per house style.

## Test plan

- New `scripts/rpg2k_logic_check.rb` check: Show Picture with id 51 is silently dropped (`st.pictures` stays empty), while the boundary id 50 still works.
- Confirmed the new check fails against the pre-fix code (temporarily reverted just the `game.rb` change and re-ran).
- `ruby scripts/rpg2k_logic_check.rb` — 691 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 350 checks passed.

https://claude.ai/code/session_01A88H6JER5yVt5wDfyLSApR


---
_Generated by [Claude Code](https://claude.ai/code/session_01A88H6JER5yVt5wDfyLSApR)_