### PR TITLE
rpg2k: Change Parameters now tracks an unclamped total under the display clamp

### DIFF
--- a/changelog.d/change-param-unclamped-total.fixed.md
+++ b/changelog.d/change-param-unclamped-total.fixed.md
@@ -1,0 +1,19 @@
+- **Change Parameters now tracks an unclamped running total underneath its
+  displayed 1..999 (1..9999 for max HP/MP) clamp.** `Game::Actor#change_param`
+  used to clamp and overwrite `@base[type]` on every call, permanently
+  discarding how far past the limit the real total had gone — so lowering
+  Attack by 2000 from a base of 3, then raising it back by 1000, landed at
+  the clamp ceiling (999) instead of staying floored, even though the real
+  total (3 - 2000 + 1000 = -997) is still deep underwater. Per yado.tk's
+  `2000/デフォ戦botまとめ`, real RPG_RT keeps accumulating the true total and
+  only clamps the effective/displayed value, so a partial raise after a big
+  drop stays pinned at the old clamp until the raw total genuinely climbs
+  back past it. Added a parallel `@base_raw` shadow that
+  `#change_param` accumulates the signed delta on before clamping into
+  `@base` (the value `#recompute_stats` and everything else still reads);
+  `@base_raw` is reset alongside every wholesale replacement of `@base`
+  (`#set_level`, and all three branches of `#change_class`'s param-mode
+  handling), so a level-up or class change establishes a fresh baseline
+  rather than carrying stale drift across it. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3722,15 +3722,41 @@ codebase yet):
   the `@2000_battle_bot` Twitter account — worth a dedicated read-through
   once battle-system work resumes rather than transcribing it piecemeal
   now. A few structurally-significant points worth flagging early so
-  they're not missed later: displayed ability-value changes clamp to
+  they're not missed later: ✅ **displayed ability-value changes clamp to
   1–999 but the *underlying* unclamped total is still tracked internally
-  and can un-clamp back into view after a later change (e.g. lower Attack
+  and can un-clamp back into view after a later change** (e.g. lower Attack
   by more than the display can show, then raise it partway back — the
   displayed value stays pinned at its old clamp until the raise actually
-  pushes the real total back above it); a special skill's ability-value
-  *decrease* rounds up on ÷2, a status effect's own halving rounds *down*;
-  dual-wielding's off-hand attack animation is offset by a few frames from
-  the main hand's. ✅ **"Party wipe" for game-over purposes is now "every
+  pushes the real total back above it) — now fixed, see below; a special
+  skill's ability-value *decrease* rounds up on ÷2, a status effect's own
+  halving rounds *down*; dual-wielding's off-hand attack animation is
+  offset by a few frames from the main hand's. **Change Parameters' hidden
+  unclamped total is now tracked.** `Game::Actor#change_param`
+  (`mruby-rpg2k/mrblib/game.rb`) clamped and overwrote `@base[type]` on
+  every call, permanently discarding how far past the 1..999 (1..9999 for
+  max HP/MP) limit the real total had gone — lowering Attack by 2000 off a
+  base of 3, then raising it back by 1000, landed at the clamp ceiling
+  (999) instead of staying floored, even though the real total
+  (3 − 2000 + 1000 = −997) is still deep underwater. Fixed with a parallel
+  `@base_raw` shadow that `#change_param` accumulates the signed delta on
+  before clamping the result into `@base` — the value `#recompute_stats`
+  and every other reader still uses, so nothing outside `#change_param`
+  itself changed. `@base_raw` is reset alongside every wholesale
+  replacement of `@base` (`#set_level`, and all three branches of
+  `#change_class`'s param-mode handling), since a level-up or class change
+  establishes a fresh baseline rather than carrying stale drift across it
+  — the same reasoning `#set_level`'s own existing HP/MP re-clamp already
+  follows for vitals. This build has no existing notion of a "raw" vs.
+  "effective" stat elsewhere, so `@base_raw` is new state, not a rename;
+  save/load persistence of `@base` itself is a separate, pre-existing gap
+  (`Game::Party#load_state` re-derives `@base` purely from saved EXP via
+  `#set_level`, so a live Change Parameters adjustment — clamped or not —
+  does not currently survive a save at all) left untouched here. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check (a large drop floors the
+  stat; a partial raise that doesn't cross back over 1 stays floored; a
+  further raise that does cross back over unclamps to the real total; an
+  ordinary never-clamped sequence is unaffected), confirmed to fail against
+  the pre-fix code before the fix. ✅ **"Party wipe" for game-over purposes is now "every
   member is both unable to act and does not recover naturally," not
   literally "every member's HP is 0"** — why Stone status can wipe a party
   without zeroing anyone's HP. `Game::Battle#alive?` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1180,10 +1180,12 @@ module Game
     # Set the actor's level and recompute the six base stats from the database
     # growth curve at that level (see #base_stats), then the equipment-boosted
     # effective stats. Current HP/MP are re-clamped so lowering the level never
-    # leaves a vital over its cap.
+    # leaves a vital over its cap. A fresh level-derived base is a new baseline
+    # for #change_param's unclamped tracking too -- see @base_raw there.
     def set_level(level)
       @level = level && level >= 1 ? level : 1
       @base = base_stats(@level)
+      @base_raw = @base.dup
       learn_level_skills
       recompute_stats
     end
@@ -1820,10 +1822,20 @@ module Game
     # base stat (the equipment bonus stays on top) and clamps to RPG2000's limits
     # (max HP/MP 1..9999, the four battle stats 1..999); recomputing re-clamps the
     # current HP/MP so a lowered maximum never leaves a vital over its cap.
+    #
+    # yado.tk's `2000/デフォ戦botまとめ`: the displayed/effective stat clamps to
+    # that range, but RPG_RT keeps accumulating the *unclamped* running total
+    # underneath -- lower Attack far past 1 with one call, then raise it back
+    # only part way, and the effective value stays pinned at the old clamp
+    # until the raw total genuinely climbs back past it, rather than reacting
+    # to the partial raise immediately. @base_raw is that shadow total; @base
+    # (read by #recompute_stats and everything else) stays the clamped,
+    # display/effective value throughout.
     def change_param(type, delta)
       return unless type >= 0 && type < STAT_NAMES.size
       limit = (type == PARAM_MAX_HP || type == PARAM_MAX_MP) ? 9999 : 999
-      @base[type] = Game.clamp(@base[type] + delta, 1, limit)
+      @base_raw[type] += delta
+      @base[type] = Game.clamp(@base_raw[type], 1, limit)
       recompute_stats
     end
 
@@ -1875,6 +1887,10 @@ module Game
       when CLASS_PARAM_HALF      then @base = old_base.map { |v| v / 2 }
       when CLASS_PARAM_RESET_LV1 then @base = base_stats(1)
       end
+      # Whichever branch (or none, for CLASS_PARAM_RESET_LEVEL) ran, @base is
+      # a fresh baseline -- reset #change_param's unclamped shadow to match,
+      # the same rule set_level's own reset above already follows.
+      @base_raw = @base.dup
       recompute_stats
 
       @hp = Game.clamp(hp, 0, @max_hp) if hp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2882,6 +2882,27 @@ check 'Actor equipment adds item bonuses to the effective stats' do
   eq [8, 2, 4, 10], [a.atk, a.def, a.agi, a.max_hp]
 end
 
+check 'Change Parameters tracks an unclamped total under the displayed clamp' do
+  # yado.tk `2000/デフォ戦botまとめ`: the displayed/effective stat clamps to
+  # 1..999 (1..9999 for HP/MP), but RPG_RT keeps accumulating the *real*
+  # total underneath -- a big drop below the floor doesn't "spend" any of a
+  # later raise until the raw total genuinely climbs back past the floor.
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1])
+  a = Game::Party.new(db).leader
+  eq 3, a.atk                                     # base atk starts at 3
+  a.change_param(Game::Actor::PARAM_ATK, -2000)    # raw 3 - 2000 = -1997
+  eq 1, a.atk                                      # clamped to the floor
+  a.change_param(Game::Actor::PARAM_ATK, 1000)     # raw -1997 + 1000 = -997
+  eq 1, a.atk                                      # still floored -- raw is still negative
+  a.change_param(Game::Actor::PARAM_ATK, 1000)     # raw -997 + 1000 = 3
+  eq 3, a.atk                                      # raw crossed back above 1: unclamps
+  # An ordinary, never-clamped sequence is untouched by the shadow tracking.
+  a.change_param(Game::Actor::PARAM_DEF, 5)        # base def 2 -> 7
+  eq 7, a.def
+  a.change_param(Game::Actor::PARAM_DEF, -3)       # 7 -> 4
+  eq 4, a.def
+end
+
 check 'Actor without a growth curve falls back to a level-independent status' do
   # party_state uses FakePlayerRow (a status hash, no int16_values): stats stay
   # put regardless of level, and the initial level is honoured.


### PR DESCRIPTION
## Summary

- `Game::Actor#change_param` (the **Change Parameters** event command) used to clamp and overwrite `@base[type]` on every call, permanently discarding how far past RPG2000's 1..999 (1..9999 for max HP/MP) limit the real total had gone.
- Per yado.tk's `2000/デフォ戦botまとめ` (documented in `docs/TODO.md`'s viprpg-dev wiki backlog), real RPG_RT keeps accumulating the *true*, unclamped total and only clamps the effective/displayed stat — so lowering Attack far below the floor with one call, then raising it back only part way, leaves the effective stat still pinned at the floor rather than reacting to the partial raise, until the raw total genuinely climbs back past it.
- Added a parallel `@base_raw` shadow that `#change_param` accumulates the signed delta on before clamping the result into `@base` — the value `#recompute_stats` and every other reader still uses, so nothing outside `#change_param` itself changed behaviourally. `@base_raw` is reset alongside every wholesale replacement of `@base` (`#set_level`, and all three branches of `#change_class`'s param-mode handling), so a level-up or class change establishes a fresh baseline rather than carrying stale drift across it.
- `docs/TODO.md` updated in place (the `viprpg-dev wiki backlog (2000 category)` → `デフォ戦botまとめ` bullet) with a ✅ citation and full writeup, including a note that `@base`'s own save/load persistence is a separate, pre-existing, untouched gap (`Game::Party#load_state` re-derives `@base` purely from saved EXP).
- Changelog fragment: `changelog.d/change-param-unclamped-total.fixed.md`.

## Test plan

- New `scripts/rpg2k_logic_check.rb` check ("Change Parameters tracks an unclamped total under the displayed clamp"): a −2000 Attack drop floors the stat at 1; a +1000 raise that doesn't cross the raw total back over 1 stays floored; a further +1000 raise that does cross back over unclamps to the real total (3); an ordinary never-clamped Defense sequence is unaffected. Confirmed to fail against the pre-fix code (`got 999` instead of staying floored) before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 691 checks pass, 0 failures.
- `ruby scripts/rpg2k_scene_check.rb` — 350 checks pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vnkn1eRv8EQXC3NjAEfoGT)_