### PR TITLE
rpg2k: pictures are hidden while the battle screen is up

### DIFF
--- a/changelog.d/battle-screen-hides-pictures.fixed.md
+++ b/changelog.d/battle-screen-hides-pictures.fixed.md
@@ -1,0 +1,16 @@
+- **Pictures no longer show through the battle screen.** yado.tk / the
+  viprpg-dev wiki's `01_shoshin`/`011_siyou` sweep: "Picture -- none show on
+  Menu/Battle screens." The Menu half was already correct --
+  `Scene::Base#build_field_background` paints an opaque panel above the
+  picture layer (`@picture_sprite`, z 250) specifically so nothing behind the
+  menu shows through, and `Scene::Map#update` (and with it `#render`) simply
+  is not called while `Scene::Menu` sits on top. The battle screen has no
+  equivalent scene push -- it runs inline on the same `Scene::Map`, gated only
+  by `@battle_ui` -- and nothing painted over the picture layer for it: the
+  battle backdrop (`@battle_ui[:back_sprite]`) sits at a much lower z, so a
+  picture shown before the encounter, or by a Parallel Process still running
+  during it, drew straight over the battle UI. `#render` now hides
+  `@picture_sprite` and skips compositing entirely for as long as `@battle_ui`
+  is set, and un-hides and resumes drawing the instant it clears. Covered by
+  a new `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2153,16 +2153,47 @@ Everything below is unverified against the codebase.
   reports the identical screen position the hero riding it does), confirmed
   to fail against the pre-fix code before the fix.
 - **Battle Event** — separate command set from Map/Common events entirely;
-  no Pictures on the battle screen; Parallel Process can't run in battle;
-  no further pages run once battle ends.
-- **Picture** — none show on Menu/Battle screens; halted entirely while a text
-  window is up; **changing maps clears all Pictures — except via Teleport
-  or Escape (skill/item), which don't clear them**; semi-transparent
-  (1-99%) opacity costs noticeably more than fully opaque/transparent;
-  Erase Picture is instant (no fade) — a gradual fade needs Move Picture to
-  the same spot at 0% opacity instead. (50 slots with the higher id always
-  drawing on top, independent of show order, is confirmed already correct —
-  see below.)
+  ✅ no Pictures on the battle screen (see the fuller writeup under the
+  **Picture** bullet directly below — the same fix); Parallel Process can't
+  run in battle; no further pages run once battle ends.
+- **Picture** — ✅ **none show on Menu/Battle screens — the Menu half was
+  already correct, the Battle half was a real gap, now fixed.**
+  `Scene::Base#build_field_background` already paints an opaque panel above
+  the picture layer (`@picture_sprite`, z 250) the instant `Scene::Menu`
+  opens, and `Scene::Map#update` — and with it `#render`, the one place
+  `@picture_sprite` is drawn — simply is not called while a menu scene sits
+  on top of it, so the picture layer never gets a chance to draw over the
+  menu in the first place. The battle screen has no equivalent scene push:
+  RPG2000's front-view battle runs inline on the very same `Scene::Map`,
+  gated only by `@battle_ui`, so `#render` kept calling `#draw_pictures`
+  every frame regardless — and the battle backdrop
+  (`@battle_ui[:back_sprite]`) sits at a much lower z than the picture
+  layer, so nothing painted over it. A picture shown before the encounter
+  (a field HUD element, say) or by a Parallel Process still running during
+  the fight (per the "parallel processes were paused too broadly" fix
+  above, one keeps ticking through a battle-adjacent message window, though
+  not through the battle itself — `#parallels_paused?` does gate on
+  `@battle_ui`) drew straight over the battle UI. Fixed by gating
+  `#render`'s picture step on `@battle_ui`: `@picture_sprite.visible = false`
+  and `#draw_pictures` is skipped entirely for as long as a fight is running
+  (not merely hidden with a stale composited frame underneath), and the
+  sprite un-hides and resumes drawing on the very first frame after
+  `@battle_ui` clears. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check (a shown picture draws normally before the encounter, is hidden and
+  stops compositing the instant the battle screen is up, and reappears the
+  instant the fight ends), confirmed to fail against the pre-fix code
+  before the fix. Still open: halted entirely while a text window is up
+  (separate from the battle/menu case — a message window is not a scene
+  push, so a different mechanism would be needed, and this project's own
+  "Picture commands... suppressed while a message window is open" fix above
+  only stops new Show/Move/Erase Picture *commands* from taking effect, not
+  an already-shown picture's own visibility); **changing maps clears all
+  Pictures — except via Teleport or Escape (skill/item), which don't clear
+  them**; semi-transparent (1-99%) opacity costs noticeably more than fully
+  opaque/transparent; Erase Picture is instant (no fade) — a gradual fade
+  needs Move Picture to the same spot at 0% opacity instead. (50 slots with
+  the higher id always drawing on top, independent of show order, is
+  confirmed already correct — see below.)
 - **Map Event** — "hero touches event" does *not* fire in three specific
   cases: (a) ✅ the event has already logically started moving into its next
   tile (hit-test uses the target tile, even if the sprite still visually
@@ -2688,7 +2719,12 @@ not yet verified:
   `scripts/rpg2k_scene_check.rb` check (two pictures shown out of id order,
   asserting the composite draws the lower id first). Still open: Battle
   Animation drawing above the picture layer specifically, and "map/
-  characters always draw below all pictures" as its own assertion.
+  characters always draw below all pictures" as its own assertion. (Not the
+  same question as "no Pictures on the battle screen" — ✅ fixed, see the
+  **Picture** bullet under "Untriaged backlog, from `2k/01_shoshin/
+  011_siyou/`" above — which is about the picture layer being hidden
+  outright while a fight is running, not about its z-order relative to the
+  battle animation sprite while both are visible on the map.)
 - ✅ **Show Picture now no-ops on a picture id outside 1..50** — the "Still
   open: picture id range 1-50" gap left by the numeric-constants bullet
   above. RPG2000's editor caps the Show Picture id field at 50 (a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6320,7 +6320,23 @@ class RPG2k
         draw_vehicles cam_x, cam_y, px, py
         draw_map_animation cam_x, cam_y
 
-        draw_pictures cam_x, cam_y
+        # Pictures never show on the battle screen (yado.tk / 01_shoshin's
+        # 011_siyou: "none show on Menu/Battle screens") -- unlike the Menu
+        # screen, which is already covered by its own opaque field background
+        # sitting above the picture layer (see Scene::Base#build_field_background),
+        # nothing else painted over @picture_sprite (z 250) while a fight is
+        # running: the battle backdrop (@battle_ui[:back_sprite]) sits well below
+        # it, so a picture shown before the encounter (or by a Parallel Process
+        # still running during it) would otherwise draw straight over the battle
+        # UI. Hidden for the fight's whole duration and stops compositing
+        # entirely (not just hidden with a stale frame underneath), then resumes
+        # -- and immediately redraws -- the instant the battle UI is gone.
+        if @battle_ui
+          @picture_sprite.visible = false
+        else
+          @picture_sprite.visible = true
+          draw_pictures cam_x, cam_y
+        end
         update_screen_overlay
         draw_timer
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5827,6 +5827,40 @@ check 'Terminate Battle from a page ends the fight and resumes the event' do
   open_then_close_battle(scene)
 end
 
+# yado.tk / 01_shoshin's 011_siyou: "Picture -- none show on Menu/Battle
+# screens." The Menu half was already correct (Scene::Base#build_field_background
+# paints an opaque panel above the picture layer); the battle screen had no
+# equivalent -- the battle backdrop sits well below @picture_sprite's z, so a
+# picture shown before the encounter (or by a still-running Parallel Process)
+# used to draw straight over the battle UI.
+check 'pictures are hidden while the battle screen is up (yado.tk: none show on Menu/Battle screens)' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }
+  scene, _st = battle_scene_with_pages(pages)
+  st = scene.instance_variable_get(:@state)
+  st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
+  sprite = scene.instance_variable_get(:@picture_sprite)
+  bmp = scene.instance_variable_get(:@picture_bmp)
+
+  10.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+    ok sprite.visible, 'the picture layer draws normally before any fight opens'
+  end
+  ok scene.instance_variable_get(:@battle_ui), 'the battle opened'
+  ok !sprite.visible, 'the picture layer is hidden the instant the battle screen is up'
+  bmp.clear_stretch_calls
+  scene.update
+  eq 0, bmp.stretch_calls.size, 'and stops compositing pictures entirely while the fight runs'
+
+  20.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui).nil?
+  end
+  eq nil, scene.instance_variable_get(:@battle_ui), 'the battle closed again'
+  ok sprite.visible, 'the picture layer reappears the instant the fight ends'
+end
+
 # yado.tk: a Battle Interrupt (Terminate Battle, 13410) satisfies neither the
 # enclosing Enemy Encounter's [Victory] nor [Escape]/[Defeat] handler branch --
 # it resumes right after Branch End, an unlabeled third outcome -- and only


### PR DESCRIPTION
## Summary
- yado.tk (`01_shoshin`/`011_siyou`): pictures never show on the Menu or
  Battle screens.
- The Menu half was already correct — `Scene::Base#build_field_background`
  paints an opaque panel above the picture layer (`@picture_sprite`, z 250)
  whenever `Scene::Menu` opens, and `Scene::Map#update`/`#render` simply
  doesn't run while a menu scene sits on top.
- The Battle half was a genuine gap: RPG2000's battle is drawn inline on
  the same `Scene::Map` (gated only by `@battle_ui`, no scene push), and
  `#render` unconditionally called `#draw_pictures` every frame regardless
  of battle state. The battle backdrop sits at a much lower z (5) than the
  picture layer, and nothing else covered it, so a picture shown before an
  encounter (or by a Parallel Process still running during the fight) drew
  straight over the battle UI.
- `#render` now hides `@picture_sprite` and skips `#draw_pictures` entirely
  while `@battle_ui` is set, un-hiding and resuming the instant the battle
  screen closes.
- `docs/TODO.md` updated ✅, distinguishing this from the separate,
  still-open "Battle Animation vs. picture-layer z-order" question.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 693 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 351 checks pass (new check:
      pictures are hidden while the battle screen is up — confirmed to
      fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_