### PR TITLE
docs: confirm shop sell-price / free-good-in-buy-list already correct

### DIFF
--- a/changelog.d/shop-sell-price-free-good-confirmed.changed.md
+++ b/changelog.d/shop-sell-price-free-good-confirmed.changed.md
@@ -1,0 +1,11 @@
+- **Shop sell price (`floor(list price / 2)`), price-0 unsellability, and a
+  price-0 good still being purchasable for free out of a shop's own buy list
+  are confirmed already correct**, all three yado.tk-documented facts at
+  once — no code change needed. `Game::Shop#sell_price` is plain Integer
+  division (`price(id) / 2`, truncating toward zero same as `floor` for a
+  non-negative price); `#sellable?` blocks a sale outright once
+  `price(id) <= 0`, RPG2000's own way of marking a key item unsellable; and
+  `#max_buy` short-circuits to the 99-item stack cap instead of dividing the
+  affordable count by a zero price, so a shop stocking a price-0 good in its
+  own buy list still lets the party take it for free. Already exercised by
+  pre-existing, non-vacuous `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3481,8 +3481,26 @@ level-up).
 **Database field semantics** (from the `11_db/` sweep, 48 findings — the
 single densest source in this pass; only the ones not already listed
 above are repeated here)
-- Sell price = `floor(list price / 2)`; price 0 = unsellable in a shop
-  but free if placed in a shop's own buy list.
+- **Sell price = `floor(list price / 2)`; price 0 = unsellable in a shop
+  but free if placed in a shop's own buy list — confirmed already
+  correct**, all three facts, no code change needed. `Game::Shop#sell_price`
+  (`mruby-rpg2k/mrblib/game.rb`) is `price(id) / 2`, plain Integer division
+  which truncates toward zero the same as `floor` for the non-negative
+  prices a database ever stores. `#sellable?` requires `price(id) > 0`
+  (alongside actually holding the item), so a price-0 item — RPG2000's own
+  way of marking a key item unsellable — can never be sold back regardless
+  of how it entered the party's bag. That price-0 exemption is scoped to
+  *selling*: `#max_buy` short-circuits to the 99-item stack cap alone
+  (`return room if cost <= 0`) rather than dividing the affordable count by
+  a zero price, so a shop that deliberately stocks a price-0 good in its
+  own buy list still lets the party take it for free, matching the second
+  half of the claim exactly. Already covered by existing
+  `scripts/rpg2k_logic_check.rb` checks predating this entry — `'Shop sell
+  refuses unowned, price-0 (key), or in a buy-only shop'`, `'Shop max_buy of
+  a free item is limited only by the cap'` (its own comment: "a price-0
+  good does not divide by zero") and `'Shop sellable_items lists only held,
+  priced goods in id order'` — none of them vacuous; each asserts a concrete
+  gold/item-count/list outcome.
 - State resistance rank A-E only gates **susceptibility** — the actual
   proc chance is entirely the *skill's own* occurrence-rate field (0%
   occurrence never applies regardless of rank) — **confirmed already


### PR DESCRIPTION
## Summary

Triaged a yado.tk "Database field semantics" backlog bullet from
`docs/TODO.md`'s "yado.tk quirks backlog" section:

> Sell price = `floor(list price / 2)`; price 0 = unsellable in a shop but
> free if placed in a shop's own buy list.

All three sub-claims are already implemented correctly in
`Game::Shop` (`mruby-rpg2k/mrblib/game.rb`), so no game-logic change was
needed:

- `#sell_price` is `price(id) / 2`, plain Integer division — truncates
  toward zero the same as `floor` for the non-negative prices a database
  ever stores.
- `#sellable?` requires `price(id) > 0` (on top of actually holding the
  item), so a price-0 item — RPG2000's own way of marking a key item
  unsellable — can never be sold back.
- `#max_buy` short-circuits to the 99-item stack cap instead of dividing
  the affordable count by a zero price (`return room if cost <= 0`), so a
  shop that deliberately stocks a price-0 good in its own buy list still
  lets the party take it for free.

This is a documentation-only change: `docs/TODO.md` records the finding
under "Database field semantics" with citations to the exact methods, and
a `changelog.d/` fragment records the confirmation. No source files were
touched, since the existing behavior was already correct.

Checked the repo's other open PRs and the last ~100 merged commits first
to avoid duplicating in-flight work; this bullet wasn't referenced
anywhere else.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 693 checks passed (unchanged,
      no new checks needed — the existing `'Shop sell refuses unowned,
      price-0 (key), or in a buy-only shop'`, `'Shop max_buy of a free item
      is limited only by the cap'`, and `'Shop sellable_items lists only
      held, priced goods in id order'` checks already pin all three facts
      and are not vacuous).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 350 checks passed.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012xrTjWPcv5Wu1PefpcycBU)_