### PR TITLE
rpg2k: a map event's own Parallel Process survives its own condition going false

### DIFF
--- a/changelog.d/parallel-process-survives-condition-loss.fixed.md
+++ b/changelog.d/parallel-process-survives-condition-loss.fixed.md
@@ -1,0 +1,10 @@
+- An RPG2000 map event's own Parallel Process now keeps running to
+  completion once its owning event's appearance conditions stop being
+  satisfied mid-script, instead of being silently torn down. `#build_events`
+  already drops such an event from `@events`/`@event_tiles` entirely once no
+  page's conditions match, and `#build_parallels`'s bystander-preservation
+  pass only ever looked for a still-running Parallel Process among the
+  events that pass survived into `@events` -- so a process that flipped off
+  its own gating switch, or was otherwise hidden by an unrelated write mid-
+  run, vanished the instant the next page-reselection sweep ran, rather than
+  finishing out its script the way real RPG_RT does.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2350,7 +2350,45 @@ not yet verified:
 - An Autorun/parallel event whose appearance condition goes false
   mid-execution **keeps running to completion** rather than aborting —
   confirmed by many independent sources, including across a map transfer
-  for Autorun specifically.
+  for Autorun specifically. ✅ **The map event Parallel Process half is now
+  fixed too.** A foreground Autorun's own command list already kept
+  running unaffected regardless of `@events` (it steps its own captured
+  `commands` array via `@interpreter`, independent of whether its owning
+  event still has a live `Game::Character`), but a **map event's own
+  Parallel Process** was a real, reachable gap: `#build_events`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) already skips an event outright once
+  no page's conditions are satisfied — dropping it from `@events`/
+  `@event_tiles` entirely, the same "no `Game::Character` built at all"
+  fact already recorded for `event_id_at` above — but
+  `#build_parallels`'s bystander-preservation pass (`preserve_map_events:`,
+  see "A Map Event's own Parallel Process no longer restarts..." just
+  below) only ever looked for a still-running interpreter among the events
+  that survived into the freshly-rebuilt `@events`, so one whose *own*
+  page just stopped matching (e.g. its own script turning off its one
+  gating switch) fell out of `@parallels` on the very next page-reselection
+  sweep and was silently garbage-collected mid-script, instead of finishing
+  out its remaining commands the way this bullet's own claim describes.
+  Fixed by carrying forward any bystander-preserved entry whose event id
+  did *not* end up live this rebuild, under its now-stale event/character
+  reference (unreachable from `@events`/`@event_tiles`, so harmless) — it
+  keeps ticking exactly like an ordinary Parallel Process, indefinitely,
+  until something else stops it (an Erase Event still finds and removes it
+  by object identity) or its conditions later pick the very same page
+  again, in which case the existing same-page reuse check just reattaches
+  this same interpreter rather than starting a fresh one. Whether RPG_RT
+  lets such a hidden process loop forever versus refusing to start a new
+  lap once its script naturally reaches the end is not resolved by this
+  fix — only "does not get torn down mid-script" is confirmed by the
+  source material, so the simpler, more literal reading (treat it exactly
+  like a live one) is what's implemented; only scoped to `preserve_map_events:`
+  rebuilds (an in-place, same-map page reselection), matching every other
+  bystander-preservation rule in `#build_parallels` — a genuine map change
+  still discards it, unaffected. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a single-page event's own Parallel
+  Process runs a marker, waits, turns off its own gating switch — making
+  the event vanish from `@events` — waits again, then runs a second marker,
+  confirmed to still fire once the event is gone), confirmed to fail
+  against the pre-fix code before the fix.
 - A **Common Event's** parallel-process state (its interpreter position)
   **resumes exactly where it left off** when re-enabled, indefinitely,
   persisting in every future save even after the condition goes false — ✅

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1043,8 +1043,10 @@ class RPG2k
           end
         end
         @parallels = []
+        live_map_ids = {}
         @events.each do |e|
           next unless e[:trigger] == TRIGGER_PARALLEL && e[:commands]
+          live_map_ids[e[:id]] = true
           prior = previous_map[e[:id]]
           if prior && prior[:commands].equal?(e[:commands])
             # Same page, same command list -- only the surrounding
@@ -1055,6 +1057,25 @@ class RPG2k
             @parallels.push prior
           else
             @parallels.push new_parallel(e[:commands], nil, e, nil)
+          end
+        end
+        # yado.tk, multiply corroborated: a Parallel Process whose own event's
+        # appearance condition goes false *mid-run* keeps executing in the
+        # background rather than being aborted -- it just has nothing left to
+        # draw or collide with. #build_events already drops such an event from
+        # @events/@event_tiles entirely (no page satisfied its conditions), so
+        # without this it would silently vanish from @parallels too, on the
+        # very next in-place page-reselection sweep this same event's own
+        # write triggers. Carried forward under its stale event/character
+        # reference -- unreachable from @events/@event_tiles, so harmless --
+        # for as long as it keeps running; only while `preserve_map_events` is
+        # set (an in-place, same-map reselection), matching every other
+        # bystander-preservation rule in this method. If its conditions later
+        # pick the very same page again, the ordinary reuse above already
+        # reattaches this same interpreter instead of starting a fresh one.
+        if preserve_map_events
+          previous_map.each do |id, prior|
+            @parallels.push(prior) unless live_map_ids[id]
           end
         end
         @common.each do |c|

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1431,6 +1431,41 @@ check "an unrelated event's page change does not restart another event's " \
   eq 1, st.variables[2], 'the wait elapsed after exactly its original countdown'
 end
 
+check "a map event's own Parallel Process keeps running after its own page " \
+      'stops matching mid-run, instead of being torn down' do
+  ic = Game::Interpreter::Cmd
+  # The event has a single page, gated on switch 4; its own Parallel Process
+  # runs marker A, waits 0.3s, turns switch 4 off itself (its own condition,
+  # so the very next page refresh drops it out of @events/@event_tiles
+  # entirely -- #build_events skips an event with no page whose conditions
+  # are satisfied -- with no other page to fall back to), waits another
+  # 0.3s, then runs marker B. yado.tk, multiply corroborated: real RPG_RT
+  # keeps a Parallel Process like this running to completion once started,
+  # rather than aborting it the instant nothing selects its owning event any
+  # more -- marker B must still fire even though the event itself is gone.
+  pg = page(trigger: 4)
+  pg.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 4)
+  pg.event_commands = [add_var_cmd(1), ECmd.new(ic::WAIT, [3]),
+                       ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 1]),
+                       ECmd.new(ic::WAIT, [3]), add_var_cmd(2)]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.switches[4] = true # the page is satisfied from the start
+
+  25.times { scene.update } # runs marker A, clears the first 0.3s wait
+  eq 1, st.variables[1], 'marker A ran once, before the first wait'
+  ok !st.switches[4], 'the process turned its own gating switch off'
+  ok event_hashes(scene)[1].nil?,
+     "the event itself is gone from @events -- no page's condition matches " \
+     'any more'
+  eq 0, st.variables[2], 'marker B has not run yet -- still parked at the second wait'
+
+  25.times { scene.update } # let the second 0.3s wait elapse
+  eq 1, st.variables[2],
+     'the Parallel Process kept running to completion once hidden, instead ' \
+     'of being torn down the moment its own page stopped matching'
+end
+
 check "a common event's Parallel Process resumes where it left off after a " \
       'save/load, not from the top' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s yado.tk backlog (Event triggers & page selection) records, from multiple corroborating sources: "An Autorun/parallel event whose appearance condition goes false mid-execution keeps running to completion rather than aborting." The Autorun (foreground) half already held by construction — a foreground event steps its own captured command list independent of `@events`. The **map event Parallel Process** half was a real gap: `Scene::Map#build_events` already drops an event from `@events`/`@event_tiles` the instant no page's conditions are satisfied, but `#build_parallels`'s bystander-preservation pass (`preserve_map_events:`) only ever looked for a still-running interpreter among events that survived into the freshly-rebuilt `@events` — so a Parallel Process whose *own* page stopped matching mid-script (e.g. turning off its own gating switch) was silently garbage-collected on the very next page-reselection sweep instead of finishing its remaining commands.
- Fixed by carrying forward any bystander-preserved parallel entry whose event id didn't end up live this rebuild, under its now-stale event/character reference (unreachable from `@events`/`@event_tiles`, so harmless to keep around). It then keeps ticking exactly like an ordinary Parallel Process — until an Erase Event removes it by object identity, or its conditions later pick the very same page again, in which case the existing same-page reuse logic reattaches this same interpreter. Only scoped to `preserve_map_events:` rebuilds (in-place, same-map page reselection), matching every other bystander-preservation rule in `#build_parallels`; a genuine map change still discards it, unaffected.
- Whether real RPG_RT lets such a hidden process start a brand new lap once it naturally reaches the end of its script, versus refusing to loop again, isn't resolved by the source material — only "does not get torn down mid-script" is confirmed, so the more literal/conservative reading (treat it exactly like a live process) is what's implemented. Documented as such in `docs/TODO.md`.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: a single-page event gated on a switch runs a marker, waits, turns off its own gating switch (making the event vanish from `@events`), waits again, then runs a second marker — confirmed to still fire once the event is gone. Confirmed to fail against the pre-fix code (`RuntimeError: expected 1, got 0`) before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 693 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 351 checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018vA1YvKFmiFptR24FufmvH)_