### PR TITLE
rpg2k: fix ABOVE_BIT to the real passage-byte value (0x10, not 0x20)

### DIFF
--- a/changelog.d/rpg2k-above-bit-value.fixed.md
+++ b/changelog.d/rpg2k-above-bit-value.fixed.md
@@ -1,0 +1,18 @@
+- **A "see-through" upper-layer decoration no longer silently overrides a
+  blocked lower tile.** `ChipSet::ABOVE_BIT`, the passage-byte bit that marks
+  an upper tile as decorative ground deferring to the lower layer instead of
+  standing in for it, was `0x20`. EasyRPG's `Passable` enum (`src/map_data.h`)
+  puts `Above` at `0x10` — `0x20` is a different flag, `Wall`, used only for a
+  narrow autotile-corner carve-out on the lower layer's terrain block.
+  Checking the wrong bit meant every upper tile actually flagged `Above` read
+  as solid ground instead, so `passable_tile?`/`landable_tile?` skipped the
+  lower-layer check they exist to make and answered passable from the upper
+  tile alone. Nepheshel's near-universal blank/filler upper chip (tile id
+  10000, byte `0x1F` — all four direction bits plus the real `Above` bit) hits
+  this on almost every map cell: with the wrong bit, ~1.58M direction-checks
+  across its maps wrongly deferred to the upper tile's own (always-open)
+  passability instead of the lower tile actually painted there; with the fix,
+  those same checks now correctly consult the lower layer, and the tiles that
+  remain "upper overrides lower" are the ~47 real solid-object graphics that
+  are not flagged `Above` at all — matching intended chipset authoring rather
+  than a chip that happens to render blank.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -466,16 +466,17 @@ module Game
   class ChipSet
     # numpad direction -> passability bit.
     DIR_BIT = { 2 => 0x01, 4 => 0x02, 6 => 0x04, 8 => 0x08 }.freeze
-    # The non-directional bits of the same passage byte (EasyRPG's `Passable`).
-    # `ABOVE_BIT` marks an upper tile as *see-through* ground rather than a
-    # solid object in its own right: `IsPassableTile` only falls through to
-    # the lower layer's own passability when this bit is set, so a
-    # painted-on decoration (a rug, a patch of flowers) still collides with
-    # whatever the lower layer says underneath it, while a genuine obstacle
-    # (a boulder, a fence post, a shop counter) is decided by the upper tile
-    # alone. `COUNTER_BIT` marks a tile you may talk *across* — the shop
-    # counter an NPC stands behind.
-    ABOVE_BIT = 0x20
+    # The non-directional bits of the same passage byte (EasyRPG's `Passable`,
+    # src/map_data.h: Down=0x01, Left=0x02, Right=0x04, Up=0x08, Above=0x10,
+    # Wall=0x20, Counter=0x40). `ABOVE_BIT` marks an upper tile as *see-through*
+    # ground rather than a solid object in its own right: `IsPassableTile` only
+    # falls through to the lower layer's own passability when this bit is set,
+    # so a painted-on decoration (a rug, a patch of flowers) still collides
+    # with whatever the lower layer says underneath it, while a genuine
+    # obstacle (a boulder, a fence post, a shop counter) is decided by the
+    # upper tile alone. `COUNTER_BIT` marks a tile you may talk *across* — the
+    # shop counter an NPC stands behind.
+    ABOVE_BIT = 0x10
     COUNTER_BIT = 0x40
     # Every directional bit ORed together, for a jump's any-side landing check.
     ALL_DIRS = (DIR_BIT[2] | DIR_BIT[4] | DIR_BIT[6] | DIR_BIT[8]).freeze


### PR DESCRIPTION
## Summary

- `ChipSet::ABOVE_BIT` (the passage-byte bit deciding whether an upper-layer tile is decorative "see-through" ground that defers to the lower layer, or a solid object whose own passability is final) was `0x20`. EasyRPG's `Passable` enum (`src/map_data.h`) puts `Above` at `0x10` — `0x20` is a distinct flag, `Wall`, used only for a narrow lower-layer autotile-corner carve-out unrelated to this check.
- Checking the wrong bit meant every upper tile actually flagged `Above` read as solid ground instead of decoration, so `passable_tile?`/`landable_tile?` skipped the lower-layer check they exist to make and answered passable from the upper tile alone.
- Confirmed against real game data (Nepheshel): its near-universal blank filler upper chip (tile id 10000, byte `0x1F` — all four direction bits plus the real `Above` bit) hits this on nearly every map cell. With the wrong bit, ~1.58M direction-checks across its maps wrongly deferred to the upper tile's own (always-open) passability instead of the lower tile actually painted there. With the fix, those checks now correctly consult the lower layer, and the tiles that still let the upper layer override are the ~47 real solid-object graphics that are not flagged `Above` at all — matching intended chipset authoring rather than a chip that happens to render blank.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 693 checks pass
- [x] Re-ran an ad-hoc analysis against real Nepheshel map data before/after the fix to confirm the bogus "upper overrides blocked lower" cases collapse from ~1.58M direction-checks down to ~47 distinct legitimate solid-object tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ep97Wn4Nfq2eAiAazKS1qr)_