### PR TITLE
rpg2k: Message Options' "move other events during message" is honoured

### DIFF
--- a/changelog.d/message-continue-events.fixed.md
+++ b/changelog.d/message-continue-events.fixed.md
@@ -1,0 +1,30 @@
+- **A "Message Options" command's "move other events during message" flag
+  (LCF field 44, `message_continue_events`) now actually does something.**
+  `Game::MessageConfig#continue_events` was already parsed from the database/
+  save and settable via the Message Options event command, but
+  `Scene::Map` never once read it: `#step_events` (autonomous move types and
+  forced/custom routes for every non-parallel map event) was only ever
+  called from the branch of `#update` that runs when nothing is busy, so a
+  bystander event held perfectly still for the whole time any message window
+  or choice list stayed open, whether or not the game had turned this flag
+  on — matching yado.tk's default ("Autorun blocks other events too") but
+  never its documented exception ("unless 'move other events during message
+  wait' is on"). Fixed by calling `#step_events(allow_trigger: false)` a
+  second way, from inside the busy branch, whenever
+  `#events_move_during_message?` (a message window is open **and**
+  `continue_events` is set) — scoped to message windows specifically, not
+  `#event_busy?` in general, so an Autorun grinding through non-blocking
+  commands with no message shown still freezes the map either way.
+  `allow_trigger: false` (threaded through `#step_event`/`#move_autonomous`)
+  still lets a bystander walk, turn and finish its route, but never lets one
+  start a **new** event over the player: there is only one foreground
+  `@interpreter`, already busy with the open message, and RPG2000 never
+  shows two message windows at once — an event-touch (trigger 2) bystander
+  that reaches the player's tile during this window still stops adjacent to
+  it, exactly like the ordinary (nothing-else-running) case, just without
+  starting its own commands. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (a bystander holds still while a
+  message stays open with the flag off, the existing/default case; a
+  bystander keeps walking with the flag on; an approaching trigger-2
+  bystander still never starts its own event while the flag is on), two
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2049,18 +2049,43 @@ Everything below is unverified against the codebase.
 - **Move All / Force Complete Move** — blocks Event Content at that command
   until every targeted character's route finishes; same freeze conditions
   as Set Move Route above.
-- **Autorun** — blocks hero control (unlike Parallel Process) and blocks
-  other events too, unless "move other events during message wait" is on;
-  runs to completion even if its own appearance condition goes false mid-
-  run, *including across a map transfer*; only one Autorun engine-wide at a
-  time, and none can start while any non-parallel event is already running;
-  a self-targeted Set Move Route with a real movement command can let hero
-  control through during an Autorun. **Bug**: an "event touches hero"
-  event approaching via "Approach Hero" that simultaneously triggers a
-  Common Event Autorun can permanently freeze that map event (fixes: touch
-  it again, toggle its appearance switch, or issue any move-route command
-  at it — "Cancel Move Route" alone does not clear it). Related to the
+- **Autorun** — blocks hero control (unlike Parallel Process); runs to
+  completion even if its own appearance condition goes false mid-run,
+  *including across a map transfer*; only one Autorun engine-wide at a time,
+  and none can start while any non-parallel event is already running; a
+  self-targeted Set Move Route with a real movement command can let hero
+  control through during an Autorun. **Bug**: an "event touches hero" event
+  approaching via "Approach Hero" that simultaneously triggers a Common
+  Event Autorun can permanently freeze that map event (fixes: touch it
+  again, toggle its appearance switch, or issue any move-route command at it
+  — "Cancel Move Route" alone does not clear it). Related to the
   already-fixed priority-type/touch-trigger work but distinct and unverified.
+  ✅ **It also blocks other events too, unless "move other events during
+  message wait" is on — now wired up.** `Game::MessageConfig#continue_events`
+  (LCF field 44, `message_continue_events`) was already parsed from the
+  database/save and settable via the Message Options event command, but
+  `Scene::Map` never once read it: `#step_events` (autonomous move types and
+  forced/custom routes for every non-parallel map event) only ever ran from
+  `#update`'s not-busy branch, so a bystander event held still for the whole
+  time any message window stayed open regardless of this flag. Fixed by
+  calling `#step_events(allow_trigger: false)` a second way, from inside the
+  busy branch, whenever a new `#events_move_during_message?` (a message
+  window is open **and** `continue_events` is set) answers true — scoped to
+  an open message window specifically, not `#event_busy?` in general, so an
+  Autorun grinding through non-blocking commands with no message shown still
+  freezes the map either way, unaffected. `allow_trigger: false` (threaded
+  through `#step_event`/`#move_autonomous`) still lets a bystander walk,
+  turn and finish its route, but never lets one start a *new* event over the
+  player's — there is only one foreground `@interpreter`, already busy with
+  the open message, and RPG2000 never shows two message windows at once, so
+  an event-touch (trigger 2) bystander reaching the player's tile during
+  this window still stops adjacent to it without starting its own commands,
+  the same as the ordinary nothing-else-running case. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (a bystander holds still with the
+  flag off, the existing default; a bystander keeps walking with the flag
+  on; an approaching trigger-2 bystander still never starts its own event
+  while the flag is on), two confirmed to fail against the pre-fix code
+  before the fix.
 - **Hero & party** — removing a hero preserves their equipment/level/EXP/HP/
   status; the field sprite is always party member 1's; only the front member
   draws on the field at all; a hero's name can't be copied to another via any

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -272,6 +272,14 @@ class RPG2k
         step_parallels unless parallels_paused?
         if event_busy?
           drive_event
+          # Message Options' "move other events during message" toggle: other
+          # map events keep their own autonomous movement / forced routes
+          # going while this message window sits open (see
+          # #events_move_during_message?). `allow_trigger: false` still lets
+          # them walk, turn and finish routes, but never lets one start a new
+          # event over the player's -- there is only one foreground
+          # interpreter, and it is already busy with this message.
+          step_events(allow_trigger: false) if events_move_during_message?
         else
           start_autostart
           if event_busy?
@@ -938,6 +946,20 @@ class RPG2k
       end
       public :message_window_open?
 
+      # Whether bystander map events should keep stepping their own autonomous
+      # movement / forced routes while a message window sits open -- RPG2000's
+      # Message Options command has a dedicated "move other events during
+      # message" toggle (LCF field 44, `message_continue_events` /
+      # `Game::MessageConfig#continue_events`) for exactly this, defaulting off
+      # (RPG_RT's own default is "other events hold still"). Scoped to a message
+      # window specifically, not #event_busy? in general -- an Autorun grinding
+      # through non-blocking commands with no message up still freezes the rest
+      # of the map either way, matching yado.tk ("Autorun ... blocks other
+      # events too, unless 'move other events during message wait' is on").
+      def events_move_during_message?
+        message_window_open? && @state.message_config.continue_events
+      end
+
       # Whether #step_parallels should sit this frame out. Per yado.tk, real
       # RPG_RT only pauses background parallel processes for the Menu screen
       # (already structural here -- Scene::Map#update simply is not called
@@ -1482,13 +1504,19 @@ class RPG2k
       end
 
       # Advance autonomous / custom-route event movement one frame. Skipped
-      # while an event process is running so the map holds still during messages.
-      def step_events
-        @events.each { |e| step_event(e) }
+      # while an event process is running so the map holds still during messages
+      # -- unless a Message Options command turned `continue_events` on, in which
+      # case #update calls this a second way (allow_trigger: false) while a
+      # message window is open; see #events_move_during_message?.
+      def step_events(allow_trigger: true)
+        @events.each { |e| step_event(e, allow_trigger: allow_trigger) }
       end
 
-      def step_event(e)
-        return if event_busy? # an event fired earlier this frame; hold the rest
+      def step_event(e, allow_trigger: true)
+        # An event fired earlier this frame; hold the rest -- except when this
+        # is the "keep moving during the message" pass, which is *always*
+        # called while busy (that is the point) and must not immediately bail.
+        return if allow_trigger && event_busy?
         ch = e[:char]
         e[:move_timer] -= 1
         return if e[:move_timer] > 0
@@ -1513,7 +1541,7 @@ class RPG2k
           e[:route].step(ch, @world) unless e[:route].done?
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
-          move_autonomous(e, dir) if dir
+          move_autonomous(e, dir, allow_trigger: allow_trigger) if dir
         end
         # A jump that lands where it started still needs the render slide, so
         # the hop is visible; an ordinary step only when the tile changed.
@@ -1560,13 +1588,18 @@ class RPG2k
 
       # Move an autonomous event one step in `dir`. Walking into the player fires
       # an event-touch (trigger 2) event instead of moving; any other obstacle
-      # just turns the event to face it.
-      def move_autonomous(e, dir)
+      # just turns the event to face it. `allow_trigger: false` (the "keep
+      # moving during an open message" pass, see #step_events) still turns the
+      # event to face the player but never starts one -- there is only one
+      # foreground @interpreter, already mid-message, and RPG2000 never shows
+      # two message windows at once, so a second event's commands have nowhere
+      # safe to run until the first message closes.
+      def move_autonomous(e, dir, allow_trigger: true)
         ch = e[:char]
         nx, ny = Game::Character.step_tile(ch.x, ch.y, dir)
         if nx == @state.x && ny == @state.y
           ch.face(dir)
-          start_event(e) if e[:trigger] == TRIGGER_EVENT_TOUCH && e[:commands]
+          start_event(e) if allow_trigger && e[:trigger] == TRIGGER_EVENT_TOUCH && e[:commands]
         elsif @world.passable?(ch, dir)
           ch.move(dir)
         else

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2534,6 +2534,76 @@ check 'Message Options positions the message window at the top' do
   ok msg[:window].y < 60, "top-positioned window should sit near the top, y=#{msg[:window].y}"
 end
 
+check 'a bystander event holds still during an open message by default' do
+  # yado.tk: "Autorun blocks other events too, unless 'move other events
+  # during message wait' is on" -- Message Options' own continue_events flag
+  # (LCF field 44) defaults off, so a bystander's own custom route must not
+  # advance at all while the message stays open (no input pressed).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi')]
+  mover = page(x_move_type: Game::MoveType::CUSTOM,
+              route: move_route([R::MOVE_RIGHT] * 3, repeat: false))
+  scene = new_scene({ 1 => event(2, 2, auto), 2 => event(0, 4, mover) },
+                    player: [5, 5])
+  msg = open_msg(scene)
+  ok msg, 'message window opened'
+  start_x = chars(scene)[2].x
+  20.times { scene.update }
+  eq start_x, chars(scene)[2].x,
+     'a bystander event must hold still while the message is open by default'
+  ok scene.instance_variable_get(:@message), 'the message should still be open (no input pressed)'
+end
+
+check 'Message Options "move other events" lets a bystander event keep walking while the message stays open' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::MESSAGE_OPTIONS, [0, 0, 0, 1]), # continue_events on (param3 = 1)
+    ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi'),
+  ]
+  mover = page(x_move_type: Game::MoveType::CUSTOM,
+              route: move_route([R::MOVE_RIGHT] * 3, repeat: false))
+  scene = new_scene({ 1 => event(2, 2, auto), 2 => event(0, 4, mover) },
+                    player: [5, 5])
+  msg = open_msg(scene)
+  ok msg, 'message window opened'
+  start_x = chars(scene)[2].x
+  20.times { scene.update }
+  ok chars(scene)[2].x > start_x,
+     "the bystander event should have advanced east while the message stayed " \
+     "open, got #{chars(scene)[2].x}"
+  ok scene.instance_variable_get(:@message), 'the message should still be open (no input pressed)'
+end
+
+check '"move other events" during a message never lets a bystander start a second event' do
+  # There is only one foreground @interpreter, already busy with this
+  # message -- an event-touch (trigger 2) bystander approaching the player
+  # while continue_events is on must still stop adjacent without starting its
+  # own commands (see #move_autonomous's allow_trigger), the same way a plain
+  # event-touch approach behaves when nothing else is running (see 'event-
+  # touch (trigger 2): an event walking into the player runs it' above).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::MESSAGE_OPTIONS, [0, 0, 0, 1]), # continue_events on
+    ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi'),
+  ]
+  toucher = page(x_move_type: Game::MoveType::TOWARD, trigger: 2, frequency: 8)
+  toucher.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  scene = new_scene({ 1 => event(5, 4, auto), 2 => event(3, 0, toucher) },
+                    player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  msg = open_msg(scene)
+  ok msg, 'message window opened'
+  20.times { scene.update }
+  ok !st.switches[9],
+     "the toucher's own commands must not run while the message interpreter is still busy"
+  ch = chars(scene)[2]
+  eq [1, 0], [ch.x, ch.y], 'the toucher still approached and stopped adjacent to the player'
+  ok scene.instance_variable_get(:@message), 'the original message must still be the one open'
+end
+
 check 'Change Face Graphic opens a message with a face and insets the text' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- yado.tk: Autorun blocks other events too, unless "move other events
  during message wait" is on — RPG2000's Message Options command has a
  dedicated checkbox for exactly this (LCF field 44,
  `message_continue_events` / `Game::MessageConfig#continue_events`),
  defaulting off.
- `continue_events` was already fully parsed, persisted, and settable via
  the Message Options event command, but `Scene::Map` never read it
  anywhere — other map events always held still while a message window was
  open, matching RPG_RT's default but not the opt-in toggle.
- `Scene::Map#update` now also runs `step_events(allow_trigger: false)`
  while a message window is open and `continue_events` is set. The new
  `allow_trigger:` keyword threads through `step_event`/`move_autonomous`
  so bystanders keep walking, turning and finishing routes without ever
  starting a new event — there is only one foreground interpreter, already
  busy with the open message, and RPG2000 never shows two message windows
  at once.
- Scoped to a message window specifically via a new
  `#events_move_during_message?`, not `#event_busy?` in general — an
  Autorun grinding through non-blocking commands with no message up still
  freezes the rest of the map either way, matching yado.tk's own wording.
- `docs/TODO.md` updated ✅ with the mechanism and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 693 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 355 checks pass (three new
      checks: default-off behavior unchanged; flag-on lets a bystander keep
      walking; an approaching trigger-2 bystander still never starts its
      own event mid-message even with the flag on — two of the three
      confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_