### PR TITLE
rpg2k: Change Face Graphic's mirror flag now flips the portrait

### DIFF
--- a/changelog.d/message-face-mirror.fixed.md
+++ b/changelog.d/message-face-mirror.fixed.md
@@ -1,0 +1,16 @@
+- **Change Face Graphic's mirror flag now actually flips the portrait.**
+  `Game::MessageConfig#face_flipped` (param2) was already read, stored and
+  persisted through the save, but `Scene::Map#draw_message_face` never
+  consulted it — every face drew unmirrored regardless. `RGSS::Bitmap#blt`
+  has no flip of its own (`mruby-rgss`'s own `Sprite#mirror=` resorts to the
+  same per-pixel software pass, for the same reason), so a new
+  `#build_face_cell` crops the selected 48x48 cell out of the FaceSet sheet
+  once, at message-open time — a single blit normally, or 48 single-column
+  blits in source-column-reversed order when mirrored — into a small
+  dedicated bitmap `#draw_message_face` then draws unconditionally, instead
+  of re-deriving the crop rect from the raw sheet on every reveal frame.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (an unmirrored
+  face crops in one blit from the right cell; a mirrored one crops in 48,
+  with the sheet's leftmost/rightmost source columns landing on the
+  destination's rightmost/leftmost columns), both confirmed to fail against
+  the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1197,8 +1197,24 @@ The work below is roughly ordered by the critical path to a walkable game
   relocates to keep clear of the hero — top when the hero sits in the lower half
   of the screen, bottom otherwise — so talking to something at a map's bottom
   edge shows the text up top; the exact zone boundary is approximate pending a
-  wine diff, but the direction matches RPG_RT. The mirrored-face flag is a
-  later refinement
+  wine diff, but the direction matches RPG_RT. ✅ **The mirrored-face flag is
+  now honoured too.** Change Face Graphic's param2 (`cfg.face_flipped`) was
+  already read, stored on `Game::MessageConfig` and persisted through the
+  save, but `Scene::Map#draw_message_face` never looked at it — the flag was
+  wired end to end except for the one place that would have made it visible.
+  `RGSS::Bitmap#blt` has no flip primitive of its own (`mruby-rgss`'s own
+  `Sprite#mirror=` resorts to the same per-pixel software pass, for the same
+  reason), so a new `#build_face_cell` crops the selected 48x48 cell out of
+  the FaceSet sheet once, at message-open time, into a small dedicated
+  bitmap: a single blit normally, or 48 single-column blits in
+  source-column-reversed order when mirrored — done once per message rather
+  than re-deriving the crop rect from the raw sheet on every reveal frame,
+  since `#draw_message_face` runs every frame the typewriter is still
+  revealing. Covered by two new `scripts/rpg2k_scene_check.rb` checks (an
+  unmirrored face crops in a single blit from the right cell; a mirrored one
+  crops in 48, with the sheet's leftmost/rightmost source columns landing on
+  the destination's rightmost/leftmost columns), both confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ Common events — auto-start common events run once on the map, and parallel
   common events now run **continuously** in the background alongside the player
   via their own looping interpreter (`Scene::Map#step_parallels`), each gated by

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5593,9 +5593,9 @@ class RPG2k
         # Message Options / Change Face Graphic settings in effect for this
         # window (position, transparency and an optional FaceSet graphic).
         cfg = @state.message_config
-        face = load_face(cfg)
-        face_left = face && !cfg.face_right
-        face_right = face && cfg.face_right
+        face_sheet = load_face(cfg)
+        face_left = face_sheet && !cfg.face_right
+        face_right = face_sheet && cfg.face_right
         text_x = face_left ? FACE_SIZE + FACE_MARGIN : 0
 
         inner_w = MSG_WIN_W - Window::BORDER * 2
@@ -5616,8 +5616,8 @@ class RPG2k
         gold_window = show_gold ? build_inn_gold_window(nonblank(db.term.gold, 'G')) : nil
         @message = { window: win, choice: choice, count: plain.length,
                      choice_start: 0, reveal: reveal, contents: contents,
-                     inner_w: inner_w, seg_lines: seg_lines, face: face,
-                     face_index: cfg.face_index,
+                     inner_w: inner_w, seg_lines: seg_lines,
+                     face: build_face_cell(face_sheet, cfg.face_index, cfg.face_flipped),
                      face_x: face_right ? inner_w - FACE_SIZE : 0,
                      text_x: text_x, text_w: text_w, gold_window: gold_window,
                      # The colour still in effect once this text ends -- a Show
@@ -5722,6 +5722,29 @@ class RPG2k
         nil
       end
 
+      # Crop one 48x48 cell out of a FaceSet sheet into its own bitmap, mirrored
+      # horizontally when Change Face Graphic's own mirror flag (param2,
+      # `cfg.face_flipped`) is set. `RGSS::Bitmap#blt` has no flip of its own
+      # (mruby-rgss's `Sprite#mirror=` resorts to the same per-pixel software
+      # pass for the same reason), so a mirrored face is built one column at a
+      # time -- 48 single-column blits, done once here rather than once per
+      # #draw_message_face call, since that runs every frame the text is still
+      # revealing.
+      def build_face_cell(sheet, index, flipped)
+        return nil unless sheet
+        src_x = (index % 4) * FACE_SIZE
+        src_y = (index / 4) * FACE_SIZE
+        cell = Bitmap.new(FACE_SIZE, FACE_SIZE)
+        unless flipped
+          cell.blt 0, 0, sheet, Rect.new(src_x, src_y, FACE_SIZE, FACE_SIZE)
+          return cell
+        end
+        FACE_SIZE.times do |col|
+          cell.blt FACE_SIZE - 1 - col, 0, sheet, Rect.new(src_x + col, src_y, 1, FACE_SIZE)
+        end
+        cell
+      end
+
       # (Re)draw the message body showing the currently revealed characters,
       # each colour run in its own colour, laid out left to right per line. The
       # face graphic (when present) is drawn first, and text is inset past it.
@@ -5758,15 +5781,13 @@ class RPG2k
         end
       end
 
-      # Blit the selected face cell (a 48x48 tile of the 4x4 FaceSet grid) into
-      # the message contents at its configured side.
+      # Blit the already-cropped (and possibly mirrored, see #build_face_cell)
+      # face cell into the message contents at its configured side.
       def draw_message_face
         face = @message[:face]
         return unless face
-        idx = @message[:face_index]
-        src = Rect.new((idx % 4) * FACE_SIZE, (idx / 4) * FACE_SIZE,
-                       FACE_SIZE, FACE_SIZE)
-        @message[:contents].blt @message[:face_x], 0, face, src
+        @message[:contents].blt @message[:face_x], 0, face,
+                                Rect.new(0, 0, FACE_SIZE, FACE_SIZE)
       end
 
       # RPG2000 message text palette (`\c[n]`). A small built-in approximation

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2615,8 +2615,37 @@ check 'Change Face Graphic opens a message with a face and insets the text' do
   msg = open_msg(scene)
   ok msg, 'message window opened'
   ok msg[:face], 'a face graphic was loaded for the message'
-  eq 2, msg[:face_index]
+  # The face is cropped once out of the FaceSet sheet at message-open time
+  # (see #build_face_cell): a single blit of cell 2 (the third 48x48 tile,
+  # x=96) into the dedicated 48x48 face bitmap, not a per-frame crop.
+  calls = msg[:face].blt_calls
+  eq 1, calls.length, 'an unmirrored face is cropped in one blit'
+  x, y, _src, rect = calls.first
+  eq [0, 0, 96, 0, 48, 48], [x, y, rect.x, rect.y, rect.width, rect.height],
+     'cropped cell 2 straight into the corner of the dedicated face bitmap'
   ok msg[:text_x] > 0, 'text is inset to the right of a left-side face'
+end
+
+check 'Change Face Graphic with the mirror flag draws a horizontally-flipped face' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::CHANGE_FACE, [0, 0, 1], string: 'Faces1'), # cell 0, left side, mirrored
+    ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi'),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = open_msg(scene)
+  ok msg, 'message window opened'
+  calls = msg[:face].blt_calls
+  # RGSS::Bitmap#blt has no flip of its own, so a mirrored face is built one
+  # source column at a time instead of a single crop (see #build_face_cell).
+  eq 48, calls.length, 'a mirrored face is built one column at a time, not one crop'
+  first_x, _y, _src, first_rect = calls.first
+  last_x, _ly, _lsrc, last_rect = calls.last
+  eq 47, first_x, 'the sheet\'s leftmost column lands at the rightmost destination column'
+  eq 0, first_rect.x, 'the sheet\'s leftmost column lands at the rightmost destination column'
+  eq 0, last_x, 'the sheet\'s rightmost column lands at the leftmost destination column'
+  eq 47, last_rect.x, 'the sheet\'s rightmost column lands at the leftmost destination column'
 end
 
 check 'a right-side face draws on the right and does not inset the text' do


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s Message window entry noted "the mirrored-face flag is a later refinement" — `Game::MessageConfig#face_flipped` (Change Face Graphic's param2) was already read, stored, and even round-tripped through the save, but `Scene::Map#draw_message_face` never consulted it, so a mirrored face drew identically to an unmirrored one.

- `RGSS::Bitmap#blt` has no flip primitive of its own (`mruby-rgss`'s own `Sprite#mirror=` resorts to the same per-pixel software pass, for the same reason), so a new `Scene::Map#build_face_cell` crops the selected 48x48 cell out of the FaceSet sheet **once, at message-open time** — a single blit normally, or 48 single-column blits in source-column-reversed order when mirrored — into a small dedicated bitmap that `#draw_message_face` then draws unconditionally every frame, instead of re-deriving the crop rect from the raw sheet on every reveal frame (which is how the code worked before).
- `docs/TODO.md` updated in place (✅) with the mechanism and citations.
- `changelog.d/message-face-mirror.fixed.md` added per house style.

## Why this candidate

Read through the "yado.tk quirks backlog" and "viprpg-dev wiki (2000 category)" sections plus a chunk of the "Full-site sweep" — the overwhelming majority of flagged items there are already fixed or confirmed-already-correct from earlier sessions today (40+ PRs merged). Rather than force a marginal/risky reinterpretation of an already-picked-over quirk (or one needing a real RPG_RT/wine comparison to resolve, which this environment can't do), I found this instead: a concrete, self-contained, engine-behavior gap explicitly flagged as incomplete in the Message window doc itself (not the yado.tk backlog specifically, which the task allows skimming into once that backlog runs thin).

Checked open PRs immediately before committing — #585 ("Fix forced move routes to step while their event is busy") is unrelated, no overlap.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 693 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 356 checks passed (2 new: unmirrored face crops in one blit from the right cell; mirrored face crops in 48, source columns landing reversed)
- [x] Confirmed both new checks fail against the pre-fix code (stashed the `scene/map.rb` change, both `blt_calls` assertions raised `NoMethodError: undefined method 'length' for nil`, since the pre-fix `@message[:face]` was the raw sheet — never a blit destination, so it recorded no calls)
- [x] Rebased onto latest `master` (picked up #584) with a clean auto-merge, re-ran both checks after rebasing

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XHyE1Xq2scsSjybjPV9mDu)_