### PR TITLE
Implement window open/close animations for RPG2k

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@
 - Message text reveals gradually (a typewriter effect; a button press completes
   it, then dismisses), expands the common control codes (`\v[n]` variable,
   `\n[n]` actor name, `\\`) and draws `\c[n]` colour changes
+- Windows unroll open and shut from their horizontal centre line instead of
+  popping in, matching RPG_RT: the title command window and the message
+  window (with its `\$` gold window) animate; battle messages appear instantly
 - Countdown timers can be set/started/stopped from events — RPG2000's one and
   RPG2003's second, each with its own on-screen window, read back by Control
   Variables and Conditional Branch, and pausing for a battle unless the start

--- a/changelog.d/rpg2k-window-open-animation.added.md
+++ b/changelog.d/rpg2k-window-open-animation.added.md
@@ -1,0 +1,19 @@
+- **rpg2k windows unroll open and shut instead of popping.** Ported from
+  EasyRPG Player's `Window::SetOpenAnimation`/`SetCloseAnimation`
+  (`src/window.cpp`): the window's frame grows from its horizontal centre line
+  over a handful of frames, and contents/cursor/the pause arrow stay hidden
+  until it is fully open — the same behaviour `RGSS::Window`'s native
+  `openness` already draws for XP/VX windows (`mruby-rgss/src/lib.cxx`),
+  reimplemented in pure Ruby for `RPG2k::Window` since it is not a native
+  class. Wired into the two places RPG_RT actually animates: the **title
+  screen's command window** (8 frames, skipped under HideTitle) and the
+  **message window** and its `\$` gold window (7 frames, instant during
+  battle — EasyRPG's `constexpr int message_animation_frames = 7`, gated on
+  `Game_Battle::IsBattleRunning()`). Closing is decoupled from dismissal the
+  way EasyRPG's `Window_Message` decouples it from
+  `FinishMessageProcessing()`: the window is handed off to
+  `Scene::Map#update_closing_windows` and keeps shrinking in the background
+  while the interpreter and the rest of the scene carry on immediately, rather
+  than blocking on the animation. Every other rpg2k window (menu, item, equip,
+  skill, status, shop, inn, ...) is untouched — EasyRPG's own source has no
+  `SetOpenAnimation` call for any of them either.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -63,6 +63,16 @@ class RPG2k
       @visible = true
       @pause = false
       @arrow_anim = 0
+      # Open/close animation: RPG_RT unrolls a window from its horizontal
+      # centre line rather than popping it in, ported from EasyRPG Player's
+      # Window::SetOpenAnimation/SetCloseAnimation (src/window.cpp). @openness
+      # is 0.0 (closed, nothing drawn) .. 1.0 (fully open); everything but the
+      # skin/frame is hidden until it reaches 1.0, matching RGSS::Window's own
+      # openness draw (mruby-rgss/src/lib.cxx) -- see #open_animation below.
+      @openness = 1.0
+      @anim_frames_left = 0
+      @anim_step = 0.0
+      @anim_closing = false
 
       # The viewport groups and clips the four layers to the window rect.
       @viewport = Viewport.new(x, y, [width, 1].max, [height, 1].max)
@@ -133,7 +143,7 @@ class RPG2k
 
     def contents=(bmp)
       @contents = bmp
-      @contents_sprite.visible = !bmp.nil?
+      @contents_sprite.visible = !bmp.nil? && fully_open?
       @contents_sprite.bitmap = bmp if bmp
       bmp
     end
@@ -154,6 +164,58 @@ class RPG2k
       @viewport.visible = v
     end
 
+    # Start the window unrolling open over `frames` frames (0 opens instantly,
+    # RPG_RT's own battle-message behaviour -- see EasyRPG's
+    # Game_Battle::IsBattleRunning() guard on message_animation_frames). Marks
+    # the window visible, same as EasyRPG's SetOpenAnimation.
+    def open_animation(frames)
+      @visible = true
+      @viewport.visible = true
+      if frames > 0
+        @openness = 0.0
+        @anim_frames_left = frames
+        @anim_step = 1.0 / frames
+        @anim_closing = false
+      else
+        @openness = 1.0
+        @anim_frames_left = 0
+      end
+      redraw_for_animation
+    end
+
+    # Start the window rolling shut over `frames` frames from its current
+    # openness (0 hides it instantly). Unlike #open_animation this does not
+    # dispose the window itself -- the caller drives #update until #closing?
+    # goes false and disposes then, so the rest of the scene keeps running
+    # while the box visibly shrinks (EasyRPG's Window_Message decouples the
+    # close animation from FinishMessageProcessing the same way).
+    def close_animation(frames)
+      if frames > 0 && @openness > 0.0
+        @anim_frames_left = frames
+        @anim_step = -@openness / frames
+        @anim_closing = true
+      else
+        @openness = 0.0
+        @anim_frames_left = 0
+        self.visible = false
+      end
+      redraw_for_animation
+    end
+
+    # Mid-animation: true from #open_animation until the window reaches full
+    # openness. Callers gate input/reveal progress on this the way EasyRPG's
+    # Window::Update() gates on IsOpeningOrClosing().
+    def opening?
+      @anim_frames_left > 0 && !@anim_closing
+    end
+
+    # Mid-animation: true from #close_animation until the window reaches zero
+    # openness. The caller (Scene::Map#update_closing_windows) disposes the
+    # window once this turns false.
+    def closing?
+      @anim_frames_left > 0 && @anim_closing
+    end
+
     # RPG2000's message-window "waiting for input" indicator: a small arrow
     # blinking at the bottom-centre of the window. Turning it on always starts
     # from a visible frame, matching RPG_RT.
@@ -167,11 +229,18 @@ class RPG2k
     end
 
     # Present so the game loop can drive per-frame behaviour: advances the
-    # pause-arrow blink while `pause` is set. The cursor highlight itself is
-    # drawn steadily (RPG_RT alternates two cursor frames, but Nepheshel's own
-    # skin draws both identically -- see Game::WindowCursor), so nothing else
-    # needs a per-frame tick yet.
+    # open/close animation while one is running, and the pause-arrow blink
+    # while `pause` is set. The cursor highlight itself is drawn steadily
+    # (RPG_RT alternates two cursor frames, but Nepheshel's own skin draws
+    # both identically -- see Game::WindowCursor), so nothing else needs a
+    # per-frame tick yet.
     def update
+      if @anim_frames_left > 0
+        @anim_frames_left -= 1
+        @openness = [[@openness + @anim_step, 0.0].max, 1.0].min
+        self.visible = false if @anim_closing && @anim_frames_left <= 0
+        redraw_for_animation
+      end
       return unless @pause
       @arrow_anim = (@arrow_anim + 1) % (ARROW_BLINK_FRAMES * 2)
       draw_arrow_visibility
@@ -233,63 +302,106 @@ class RPG2k
       end
     end
 
-    # Show the arrow sprite only while paused and in the "on" half of the
-    # blink cycle.
+    # Show the arrow sprite only while paused, fully open and in the "on" half
+    # of the blink cycle -- RPG_RT's pause arrow never shows while the window
+    # is still unrolling.
     def draw_arrow_visibility
-      @arrow_sprite.visible = @pause && @arrow_anim < ARROW_BLINK_FRAMES
+      @arrow_sprite.visible = @pause && fully_open? && @arrow_anim < ARROW_BLINK_FRAMES
     end
 
-    # Redraw the windowskin layer (background + frame, or the fallback panel).
+    def fully_open?
+      @openness >= 1.0
+    end
+
+    # How tall the skin/frame band currently is, centred vertically in the
+    # window rect -- the fraction of @height the animation has revealed so
+    # far. Mirrors RGSS::Window's own native openness draw (`full_h *
+    # openness / 255`, mruby-rgss/src/lib.cxx) so a fully-open window (the
+    # default @openness of 1.0) draws exactly as before.
+    def drawn_height
+      return @height if fully_open?
+      h = (@height * @openness).to_i
+      h.negative? ? 0 : h
+    end
+
+    # Redraw the skin at the current animation frame and show/hide the layers
+    # that only appear once fully open (contents, cursor, pause arrow) --
+    # called from #update while an animation runs and from #open_animation /
+    # #close_animation to reflect the frame the animation just jumped to.
+    def redraw_for_animation
+      draw_skin
+      open = fully_open?
+      @contents_sprite.visible = open && !@contents.nil?
+      @cursor_sprite.visible = open
+      draw_arrow_visibility
+    end
+
+    # Redraw the windowskin layer (background + frame, or the fallback panel),
+    # clipped to the currently-animated height and centred in the window rect.
     def draw_skin
       @skin_bmp.clear
       return if @transparent # transparent message window: no frame/background
+      h = drawn_height
+      return if h <= 0
+      y_off = (@height - h) / 2
       if @windowskin
-        draw_background
-        draw_frame
+        draw_background(y_off, h)
+        draw_frame(y_off, h)
       else
-        draw_fallback
+        draw_fallback(y_off, h)
       end
     end
 
-    # Stretch the 32x32 background tile over the whole window; the frame border
-    # is drawn on top of its outer edge afterwards.
-    def draw_background
-      @skin_bmp.stretch_blt Rect.new(0, 0, @width, @height), @windowskin,
+    # Stretch the 32x32 background tile over the [y_off, y_off+h) band; the
+    # frame border is drawn on top of its outer edge afterwards.
+    def draw_background(y_off, h)
+      @skin_bmp.stretch_blt Rect.new(0, y_off, @width, h), @windowskin,
                             Rect.new(0, 0, 32, 32)
     end
 
-    def draw_frame
+    def draw_frame(y_off, h)
       w = @width
-      h = @height
       b = BORDER
       sk = @windowskin
+      # Corner height clamped to half the drawn band so a barely-open window
+      # (mid open/close animation) keeps a frame instead of its top and
+      # bottom corners overlapping -- same clamp RGSS::Window's native draw
+      # uses. Reduces to the plain 8px corner when h >= 2 * BORDER, i.e.
+      # always, for a window that is not mid-animation.
+      ch = [b, h / 2].min
 
-      # Corners (8x8, drawn 1:1).
-      @skin_bmp.blt 0, 0, sk, Rect.new(32, 0, b, b)
-      @skin_bmp.blt w - b, 0, sk, Rect.new(56, 0, b, b)
-      @skin_bmp.blt 0, h - b, sk, Rect.new(32, 24, b, b)
-      @skin_bmp.blt w - b, h - b, sk, Rect.new(56, 24, b, b)
+      # Corners (8x8 source, top/bottom-clipped to `ch` rows when shrunk).
+      @skin_bmp.blt 0, y_off, sk, Rect.new(32, 0, b, ch)
+      @skin_bmp.blt w - b, y_off, sk, Rect.new(56, 0, b, ch)
+      @skin_bmp.blt 0, y_off + h - ch, sk, Rect.new(32, 24 + (b - ch), b, ch)
+      @skin_bmp.blt w - b, y_off + h - ch, sk,
+                    Rect.new(56, 24 + (b - ch), b, ch)
 
-      # Edges (stretched along the free axis).
-      @skin_bmp.stretch_blt Rect.new(b, 0, w - 2 * b, b), sk,
-                            Rect.new(40, 0, 16, b)
-      @skin_bmp.stretch_blt Rect.new(b, h - b, w - 2 * b, b), sk,
-                            Rect.new(40, 24, 16, b)
-      @skin_bmp.stretch_blt Rect.new(0, b, b, h - 2 * b), sk,
+      # Top/bottom edges (stretched horizontally, same `ch` clip as the
+      # corners they sit between).
+      @skin_bmp.stretch_blt Rect.new(b, y_off, w - 2 * b, ch), sk,
+                            Rect.new(40, 0, 16, ch)
+      @skin_bmp.stretch_blt Rect.new(b, y_off + h - ch, w - 2 * b, ch), sk,
+                            Rect.new(40, 24 + (b - ch), 16, ch)
+
+      # Left/right edges fill whatever is left between the corners.
+      mid_h = h - 2 * ch
+      return unless mid_h > 0
+      @skin_bmp.stretch_blt Rect.new(0, y_off + ch, b, mid_h), sk,
                             Rect.new(32, 8, b, 16)
-      @skin_bmp.stretch_blt Rect.new(w - b, b, b, h - 2 * b), sk,
+      @skin_bmp.stretch_blt Rect.new(w - b, y_off + ch, b, mid_h), sk,
                             Rect.new(56, 8, b, 16)
     end
 
     # Used when no windowskin could be loaded: a plain dark panel with a light
     # border so the window is still visible.
-    def draw_fallback
-      @skin_bmp.fill_rect 0, 0, @width, @height, Color.new(8, 8, 40, 224)
+    def draw_fallback(y_off, h)
+      @skin_bmp.fill_rect 0, y_off, @width, h, Color.new(8, 8, 40, 224)
       edge = Color.new(200, 200, 216, 255)
-      @skin_bmp.fill_rect 0, 0, @width, 1, edge
-      @skin_bmp.fill_rect 0, @height - 1, @width, 1, edge
-      @skin_bmp.fill_rect 0, 0, 1, @height, edge
-      @skin_bmp.fill_rect @width - 1, 0, 1, @height, edge
+      @skin_bmp.fill_rect 0, y_off, @width, 1, edge
+      @skin_bmp.fill_rect 0, y_off + h - 1, @width, 1, edge if h > 1
+      @skin_bmp.fill_rect 0, y_off, 1, h, edge
+      @skin_bmp.fill_rect @width - 1, y_off, 1, h, edge
     end
 
     # Highlight behind the selected item, on its own layer. cursor_rect is

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -237,8 +237,17 @@ class RPG2k
     def update
       if @anim_frames_left > 0
         @anim_frames_left -= 1
-        @openness = [[@openness + @anim_step, 0.0].max, 1.0].min
-        self.visible = false if @anim_closing && @anim_frames_left <= 0
+        if @anim_frames_left <= 0
+          # Snap to the exact boundary on the last frame rather than trusting
+          # the accumulated float sum to land on it: 1.0 / 7 added 7 times
+          # comes out to 0.9999999999999999, one ULP short of 1.0, which would
+          # leave #fully_open? false forever and contents/cursor/the pause
+          # arrow permanently hidden behind an apparently-finished window.
+          @openness = @anim_closing ? 0.0 : 1.0
+          self.visible = false if @anim_closing
+        else
+          @openness = [[@openness + @anim_step, 0.0].max, 1.0].min
+        end
         redraw_for_animation
       end
       return unless @pause

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -194,7 +194,9 @@ class RPG2k
       attr_reader :state
 
       def dispose
-        close_message
+        close_message(animate: false)
+        (@closing_windows || []).each(&:dispose)
+        @closing_windows = nil
         close_inn_window
         close_shop
         close_battle
@@ -257,6 +259,7 @@ class RPG2k
         @state.screen.update # screen tint progresses every frame, even in events
         @state.update_pictures # picture moves progress every frame too
         update_sprite_flashes # Flash Sprite decays during events too
+        update_closing_windows # a closed message keeps shrinking in the background
         watch_bgm_loop # so the "BGM played once" branch can be answered
         @anim_frame += 1 # water / animated tiles cycle even during events
         # An event page's conditions may have just stopped (or started) holding;
@@ -5482,6 +5485,12 @@ class RPG2k
       MSG_LINE_H = 16
       # Characters revealed per frame for the message typewriter effect.
       MSG_REVEAL_SPEED = 2
+      # RPG_RT unrolls the message window (and its `\$` gold window) open and
+      # shut over 7 frames rather than popping it, except during battle where
+      # it appears/disappears instantly (EasyRPG's window_message.cpp:
+      # `constexpr int message_animation_frames = 7`, gated on
+      # `Game_Battle::IsBattleRunning()`).
+      MSG_ANIM_FRAMES = 7
       # RPG2000 FaceSet geometry: a 4x4 grid of 48x48 face cells, drawn beside
       # the message text with a small gap.
       FACE_SIZE = 48
@@ -5573,6 +5582,10 @@ class RPG2k
         win.z = 300
         win.windowskin = @windowskin
         win.transparent = cfg.transparent
+        # No animation mid-battle: RPG_RT's own message/gold windows pop
+        # straight in there instead of unrolling (see MSG_ANIM_FRAMES above).
+        open_frames = @battle_ui.nil? ? MSG_ANIM_FRAMES : 0
+        win.open_animation(open_frames)
 
         contents = Bitmap.new(inner_w, inner_h)
 
@@ -5580,7 +5593,11 @@ class RPG2k
         reveal = Game::TextReveal.new(plain, 0, pauses, auto_close, instants)
         reveal.reveal_all if choice
         # `\$` shows the party's gold in a small window alongside the message.
-        gold_window = show_gold ? build_inn_gold_window(nonblank(db.term.gold, 'G')) : nil
+        gold_window = nil
+        if show_gold
+          gold_window = build_inn_gold_window(nonblank(db.term.gold, 'G'))
+          gold_window.open_animation(open_frames)
+        end
         @message = { window: win, choice: choice, count: plain.length,
                      choice_start: 0, reveal: reveal, contents: contents,
                      inner_w: inner_w, seg_lines: seg_lines, face: face,
@@ -5763,9 +5780,16 @@ class RPG2k
       end
 
       def drive_message
-        # Advances the blink/pause animation each frame so the pause arrow
-        # (set below) actually flashes instead of sitting on one frame.
+        # Advances the open/close and blink/pause animation each frame so the
+        # window unrolls open, and so the pause arrow (set below) actually
+        # flashes instead of sitting on one frame. Text reveal and input are
+        # not held off while it unrolls -- unlike EasyRPG, which pauses
+        # Window_Message::Update() on IsOpeningOrClosing() -- since the window
+        # is a fresh object every message here rather than a persistent one
+        # game scripts can poll, and holding logic off it would only delay
+        # dismissal by MSG_ANIM_FRAMES with nothing else to show for it.
         @message[:window].update
+        @message[:gold_window].update if @message[:gold_window]
         if @message[:choice]
           if Input.trigger?(Input::DOWN)
             @choice_index += 1
@@ -5923,11 +5947,48 @@ class RPG2k
         end
       end
 
-      def close_message
+      # Dismiss the current message. By default this rolls the window (and its
+      # `\$` gold window) shut over MSG_ANIM_FRAMES frames rather than popping
+      # it away, mirroring #open_message; `animate: false` (scene teardown --
+      # see #dispose) skips straight to disposal instead. The closing window
+      # is handed off to #update_closing_windows rather than disposed here:
+      # RPG_RT's own message window keeps shrinking while the game underneath
+      # it already carries on (EasyRPG decouples FinishMessageProcessing's
+      # SetCloseAnimation from the interpreter the same way), so @message is
+      # cleared immediately and the caller (interpreter resume, choice
+      # selection, ...) is never blocked on the animation finishing.
+      def close_message(animate: true)
         return unless @message
-        @message[:window].dispose
-        @message[:gold_window].dispose if @message[:gold_window]
+        win = @message[:window]
+        gold = @message[:gold_window]
+        frames = (animate && @battle_ui.nil?) ? MSG_ANIM_FRAMES : 0
+        if frames > 0
+          win.close_animation(frames)
+          (@closing_windows ||= []) << win
+          if gold
+            gold.close_animation(frames)
+            @closing_windows << gold
+          end
+        else
+          win.dispose
+          gold.dispose if gold
+        end
         @message = nil
+      end
+
+      # Advance every window mid-close-animation (see #close_message) one
+      # frame, disposing each once its animation finishes. Called once a
+      # frame regardless of whether a message is open, since a window can
+      # still be shrinking after @message itself has already moved on.
+      def update_closing_windows
+        return unless @closing_windows
+        @closing_windows.reject! do |w|
+          w.update
+          unless w.closing?
+            w.dispose
+            true
+          end
+        end
       end
 
       # -- number input (Input Number command) --------------------------------

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -13,6 +13,11 @@ class RPG2k
       # three 48px-wide labels the window lands at (128, 148) 64x64.
       BOTTOM_NUM = 53
       BOTTOM_DEN = 60
+      # RPG_RT unrolls the title command window open over 8 frames (EasyRPG's
+      # scene_title.cpp: `command_window->SetOpenAnimation(8)`), skipped under
+      # HideTitle -- the centred window appears with the rest of the screen
+      # rather than flourishing in on its own.
+      OPEN_ANIM_FRAMES = 8
 
       def initialize parent
         super parent
@@ -56,6 +61,7 @@ class RPG2k
         @window = Window.new window_x, window_y, window_width, window_height
         skin = load_windowskin
         @window.windowskin = skin
+        @window.open_animation(hide_title? ? 0 : OPEN_ANIM_FRAMES)
 
         # Render the (unchanging) menu labels once, in the windowskin's own
         # default text colour with RPG_RT's one-pixel shadow. A disabled
@@ -80,6 +86,8 @@ class RPG2k
       end
 
       def update
+        @window.update
+
         if Input.trigger?(Input::DOWN)
           move_selection 1
         elsif Input.trigger?(Input::UP)
@@ -102,8 +110,6 @@ class RPG2k
             exit
           end
         end
-
-        @window.update
       end
 
       def dispose


### PR DESCRIPTION
## Summary
Adds window open and close animations to RPG2k windows, porting the unroll-from-center behavior from EasyRPG Player's `Window::SetOpenAnimation`/`SetCloseAnimation`. Windows now animate open/closed over a configurable number of frames rather than popping in/out instantly, matching RPG_RT's behavior.

## Key Changes

- **Window animation system**: Added `@openness` property (0.0 = closed, 1.0 = open) and animation state tracking (`@anim_frames_left`, `@anim_step`, `@anim_closing`) to `RPG2k::Window`
  - `open_animation(frames)`: Starts window unrolling open over N frames
  - `close_animation(frames)`: Starts window rolling shut over N frames
  - `opening?` / `closing?`: Query animation state
  - `update()`: Advances animation each frame

- **Animation rendering**: 
  - `drawn_height()`: Calculates the currently-visible height based on openness
  - `redraw_for_animation()`: Redraws skin and manages visibility of contents/cursor/pause-arrow during animation
  - Frame drawing now clips to animated height and centers vertically in window rect
  - Contents, cursor, and pause arrow remain hidden until window is fully open

- **Message window integration** (Scene::Map):
  - Message windows animate open/closed over 7 frames (instant during battle)
  - Gold windows (`\$`) animate in sync with message windows
  - Closing windows are decoupled from dismissal: handed off to `update_closing_windows()` which advances them each frame while the interpreter continues
  - `@message` is cleared immediately after close animation starts, unblocking the caller

- **Title screen integration** (Scene::Title):
  - Command window animates open over 8 frames (skipped if HideTitle is set)
  - `update()` now calls `@window.update()` to drive animation

- **Visibility logic**: 
  - `fully_open?()`: Helper to check if window is fully open
  - Contents sprite visibility now gated on both bitmap existence and full openness
  - Pause arrow only shows when window is fully open

## Implementation Details

- Animation uses linear interpolation: `@openness += @anim_step` each frame
- Closing animation preserves current openness as starting point
- Frame corners are clamped to half the drawn height during animation to prevent overlap
- Mirrors RGSS::Window's native openness behavior for consistency
- Thoroughly documented with comments referencing EasyRPG source locations

https://claude.ai/code/session_01F5nPfa7MNeNTPKY5Heuj9n