### PR TITLE
docs: confirm Call Event bypasses a target common event's own gate switch

### DIFF
--- a/changelog.d/call-event-bypasses-gate-switch-confirmed.changed.md
+++ b/changelog.d/call-event-bypasses-gate-switch-confirmed.changed.md
@@ -1,0 +1,14 @@
+- **Call Event running under Auto-Start semantics and always bypassing the
+  target common event's own condition-switch state are confirmed already
+  correct**, no code change needed. `Game::Interpreter#do_call_event`
+  splices the target's raw command list onto the *calling* interpreter's own
+  call stack rather than dispatching through any trigger-aware path, so an
+  Auto-Start's blocking execution mechanically carries through the whole
+  call regardless of the callee's configured trigger; `Scene::Map
+  #build_resolver` hands the Call Event resolver a plain `id => commands`
+  hash that already discards each common event's trigger/gate-switch fields,
+  so the resolver has nothing to conditionally gate on in the first place.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (an Auto-Start event
+  Call-Events a Parallel-Process common event whose gate switch stays off
+  for the whole run; its content still executes), confirmed to fail when
+  the resolver is temporarily made to honour the gate switch.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3700,10 +3700,33 @@ above are repeated here)
   value-increase / value-decrease / low-HP-MP warning), and a State's own
   configured display-color field is a pointer into that **same** shared
   palette.
-- Call Event invoked from an Auto-Start parent runs the called content
-  under **Auto-Start semantics** (blocks input) even if the called
-  common event's own configured trigger is Parallel Process; Call Event
-  always **bypasses** the target's own condition-switch state entirely.
+- **Call Event invoked from an Auto-Start parent runs the called content
+  under Auto-Start semantics (blocks input) even if the called common
+  event's own configured trigger is Parallel Process; Call Event always
+  bypasses the target's own condition-switch state entirely — confirmed
+  already correct**, both halves, no code change needed.
+  `Game::Interpreter#do_call_event`/`#resolve_call`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) never reads a trigger or a gate
+  switch at all — it just splices the target's raw command list onto the
+  *calling* interpreter's own `@call_stack` and keeps running it inline, so
+  whatever is already true of the caller (an Auto-Start's foreground,
+  input-blocking execution included) mechanically stays true for the whole
+  call, with no separate scheduling path a Parallel Process's trigger could
+  route through instead. The condition-switch bypass is even more
+  structural: `Scene::Map#build_resolver` hands the Call Event resolver a
+  plain `id => commands` hash built from `@common`
+  (`common[c[:id]] = c[:commands]`), discarding each common event's
+  `:trigger`/`:need_flag`/`:switch_id` in that same line — the resolver
+  `do_call_event` reads from has no gate to consult in the first place, so a
+  Call Event cannot observe the callee's switch state even if a future
+  change tried to add such a check without separately plumbing the gate
+  through this hash. `interpreter.rb` has no trigger/switch-related constant
+  or read anywhere, corroborating the same conclusion from the other
+  direction. Covered by a new `scripts/rpg2k_scene_check.rb` check (an
+  Auto-Start event Call-Events a Parallel-Process common event whose gate
+  switch is off for the whole run; its content still executes), confirmed to
+  fail when `build_resolver` is temporarily made to honour the gate switch,
+  restored before finalizing since nothing here needed to change.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1301,6 +1301,34 @@ check 'parallel common event runs only while its switch gate is on' do
   ok st.variables[3] > 0, 'it should run once the gate switch is on'
 end
 
+# yado.tk (01_shoshin/011_siyou, "Call Event"): a Call Event always bypasses
+# the target common event's own condition-switch state entirely, regardless
+# of whether the common event is configured Parallel Process, Auto-Start, or
+# call-only, and regardless of its gate switch's live value. Confirmed
+# already correct: Scene::Map#build_resolver (mruby-rpg2k/mrblib/scene/
+# map.rb) hands the Call Event resolver a plain `id => commands` hash built
+# from `@common`, discarding `:trigger`/`:need_flag`/`:switch_id` in the same
+# line -- the resolver Game::Interpreter#do_call_event reads from structurally
+# has no gate/trigger to consult, so nothing could conditionally block it even
+# if a future change tried to add such a check without also plumbing it
+# through here.
+check "Call Event bypasses a target common event's own gate switch" do
+  ic = Game::Interpreter::Cmd
+  # Common event 1 is a Parallel Process gated on switch 9, which stays off
+  # for this entire check -- Scene::Map#step_parallels would never run it on
+  # its own while that holds.
+  ce = OpenStruct.new(start_term: 4, need_flag: true, switch_id: 9,
+                      event: [add_var_cmd(3)])
+  pg = page(trigger: 3) # auto-start
+  pg.event_commands = [ECmd.new(ic::CALL_EVENT, [0, 1, 0])] # call common event 1
+  scene = new_scene({ 1 => event(2, 2, pg) }, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  10.times { scene.update }
+  ok !st.switches[9], 'the gate switch never turned on during this check'
+  ok st.variables[3] > 0,
+     "Call Event should run the gated common event's content regardless of its own switch"
+end
+
 # A Common Event's own Parallel Process, unlike a Map Event's, is supposed to
 # keep running from wherever it was across a Transfer Player and a save/load
 # (docs/TODO.md's "Common-event Parallel Process state should survive map


### PR DESCRIPTION
## Summary
- yado.tk: Call Event invoked from an Auto-Start parent runs the called
  content under Auto-Start semantics (blocks input) even if the called
  common event's own configured trigger is Parallel Process; Call Event
  always bypasses the target's own condition-switch state entirely.
- Confirmed already correct, no code change: `Game::Interpreter
  #do_call_event`/`#resolve_call` never reads a trigger or gate switch at
  all — it splices the target's raw command list onto the calling
  interpreter's own call stack and keeps running inline, so an Auto-Start
  caller's blocking behavior mechanically carries through.
  `Scene::Map#build_resolver` hands the Call Event resolver a plain
  `id => commands` hash built from `@common`, discarding
  `:trigger`/`:need_flag`/`:switch_id` in the same line it's built — the
  resolver structurally has no gate to consult.
- Verified falsifiable rather than assumed: temporarily made
  `build_resolver` honor the gate switch, confirmed the new regression
  check fails as expected, then reverted (only the test file is touched by
  this PR).
- `docs/TODO.md` updated to the confirmed-already-correct dense citation
  style.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 693 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 356 checks pass (new check: Call
      Event bypasses a target common event's own gate switch)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_