### PR TITLE
rpg2k: shield/armour raise_evasion now lowers a normal attack's hit chance

### DIFF
--- a/changelog.d/physical-evasion-up-item-field.added.md
+++ b/changelog.d/physical-evasion-up-item-field.added.md
@@ -1,0 +1,11 @@
+- **A shield/armour/helmet/accessory's 物理回避率アップ (`raise_evasion`, item
+  field 26) now lowers a normal attack's chance to land.** 12 of Nepheshel's
+  items carry the flag and nothing read it, so a shield bought specifically
+  for its dodge bonus was purely a stat stick. `Game::Actor#physical_evasion_up?`
+  is true whenever any equipped non-weapon item carries the flag (EasyRPG's
+  `HasPhysicalEvasionUp`), and `Game::Battle#to_hit` subtracts a flat 25 from
+  the attacker's already agility-adjusted hit chance against such a target —
+  the same place and amount as EasyRPG's `CalcNormalAttackToHit`. A 必中
+  weapon's evasion-skip still returns before this term is ever consulted,
+  matching that a wielder's guaranteed hit ignores the target's evasion
+  entirely, gear included.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1721,6 +1721,27 @@ The work below is roughly ordered by the critical path to a walkable game
   excludes the second actor: the picker offers only the first, and moving
   the cursor has nowhere to go), confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **物理回避率アップ** (the item row's `raise_evasion`, field 26) — unread, so
+  a shield/armour/helmet/accessory bought specifically for its evasion bonus
+  was purely a stat stick against a normal attack. `ruby
+  scripts/rpg2k_field_audit.rb` against a freshly re-downloaded Nepheshel
+  flags it with 12 rows once `two_handed`/`actor_set`/the rest above stopped
+  crowding it out. EasyRPG's `Game_Actor::HasPhysicalEvasionUp` scans every
+  equipped **non-weapon** slot for the flag (`ForEachEquipment<false, true>`,
+  weapons excluded by item type, not slot index — the same rule
+  `#equip_bonus` already follows for stat sums, so a 二刀流 actor's second
+  weapon in the shield slot is correctly excluded too), and
+  `Algo::CalcNormalAttackToHit` subtracts a flat 25 from the already
+  agility-adjusted hit chance for such a target, right after the AGI term
+  and never reached at all when the attacker's own weapon is 必中 (that
+  branch already returns before either term). Ported as
+  `Game::Actor#physical_evasion_up?` and a new `Combatant#evasion_up` field
+  (`Battle.from_actor` wires it, an enemy Combatant leaves it nil/false —
+  monsters equip nothing) consulted by `Game::Battle#to_hit` in the same spot.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks (the flat -25, the
+  0..100 floor, 必中 skipping the term entirely, weapon-slot exclusion, and
+  an end-to-end `Battle.from_actor` wiring check), confirmed to fail against
+  the pre-fix code before the fix.
 
 ### yado.tk quirks backlog
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1569,6 +1569,25 @@ module Game
     # mtf-meido-action's is a pair of boots, Nepheshel's four include a swimsuit.
     def prevents_terrain_damage?; equipment_flag?(:no_terrain_damage); end
 
+    # 物理回避率アップ — a shield/armour/helmet/accessory that makes a normal
+    # attack likelier to miss its wearer: RPG_RT subtracts a flat 25 from the
+    # attacker's already agi-adjusted hit chance (EasyRPG's
+    # `HasPhysicalEvasionUp`, consulted by `CalcNormalAttackToHit` right after
+    # its AGI term). The weapon slot never counts — `ForEachEquipment<false,
+    # true>` there excludes weapons by item *type*, not slot index, the same
+    # way #equip_bonus already reads every equipped slot, so a 二刀流 actor's
+    # second weapon (sitting in the shield slot) is correctly excluded too.
+    def physical_evasion_up?
+      return false unless @db.respond_to?(:item)
+      @equipment.any? do |iid|
+        next false if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next false unless it
+        next false if it.respond_to?(:type) && it.type == ITEM_WEAPON
+        it.respond_to?(:raise_evasion) && it.raise_evasion ? true : false
+      end
+    end
+
     # 強力防御 — an actor whose Defend halves damage a *second* time (a quarter
     # rather than a half, per EasyRPG's `AdjustDamageForDefend`). This one is a
     # property of the actor row (field 24), not of gear, and an RPG2003 class can
@@ -5772,6 +5791,12 @@ module Game
                            # whether skills cost half.
                            :strikes, :ignores_evasion, :strong_defence,
                            :half_sp_cost,
+                           # Whether this battler's own gear makes a normal
+                           # attack likelier to miss it (Actor#physical_evasion_up?,
+                           # a flat -25 to the attacker's to_hit -- see
+                           # Battle#to_hit). Enemy Combatants leave it nil/false;
+                           # monsters equip nothing.
+                           :evasion_up,
                            # A basic Attack spread across the target's whole
                            # side (attack_all?) or jumped to the front of the
                            # round's turn order (preemptive?) -- see #turn_order
@@ -5860,6 +5885,7 @@ module Game
       c.preemptive = flag_of(a, :preemptive?)
       c.strong_defence = flag_of(a, :strong_defence?)
       c.half_sp_cost = flag_of(a, :half_sp_cost?)
+      c.evasion_up = flag_of(a, :physical_evasion_up?)
       c.attr_base_ranks = c.attr_ranks.dup
       c
     end
@@ -6221,7 +6247,15 @@ module Game
           src = effective_agi(attacker)
           src = 1 if src < 1
           tgt = effective_agi(target)
-          Game.clamp(100 - (100 - base) * (src + tgt) / (2 * src), 0, 100)
+          agi_adjusted = 100 - (100 - base) * (src + tgt) / (2 * src)
+          # 物理回避率アップ: a shield/armour/helmet/accessory flagged
+          # `raise_evasion` (Actor#physical_evasion_up?) subtracts a further
+          # flat 25 from the already agi-adjusted chance, right where
+          # EasyRPG's `CalcNormalAttackToHit` applies it -- after the AGI
+          # term, and never reached at all by a 必中 attacker (the branch
+          # above already returned).
+          agi_adjusted -= 25 if target.evasion_up
+          Game.clamp(agi_adjusted, 0, 100)
         end
       raw * hit_modifier(attacker) / 100
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2419,7 +2419,10 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :actor_set,
                       # 呪われた装備: once equipped, the equip menu refuses to
                       # remove or replace it (Actor#slot_cursed?).
-                      :cursed)
+                      :cursed,
+                      # 物理回避率アップ: a normal attack against the wearer is
+                      # 25 points likelier to miss (Actor#physical_evasion_up?).
+                      :raise_evasion)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -2428,13 +2431,14 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               field_only: false, dual_attack: false, ignore_evasion: false,
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
-              cursed: false)
+              cursed: false, raise_evasion: false)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
-               ko_only, two_handed, attack_all, preemptive, actor_set, cursed)
+               ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
+               raise_evasion)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -6671,6 +6675,29 @@ check 'Battle#to_hit clamps to 0..100 and a 100% base never misses' do
   eq 100, b.to_hit(atk, b.enemies.first), 'a perfect base stays 100 despite fast target'
 end
 
+check 'Battle#to_hit subtracts 25 for a target with physical-evasion-up gear' do
+  b = Game::Battle.new([combatant('H', 0, 0, 10, 10)],
+                       [combatant('E', 0, 0, 10, 10)], Game::Rng.new(1))
+  atk = b.allies.first
+  tgt = b.enemies.first
+  atk.hit_rate = 90
+  eq 90, b.to_hit(atk, tgt), 'equal agility, no evasion gear -> the base hit rate'
+  tgt.evasion_up = true
+  eq 65, b.to_hit(atk, tgt), '90 - 25, applied after the (zero-effect) agility term'
+end
+
+check 'Battle#to_hit floors the evasion-up penalty at 0, and 必中 skips it entirely' do
+  b = Game::Battle.new([combatant('H', 0, 0, 10, 10)],
+                       [combatant('E', 0, 0, 10, 10)], Game::Rng.new(1))
+  atk = b.allies.first
+  tgt = b.enemies.first
+  atk.hit_rate = 10
+  tgt.evasion_up = true
+  eq 0, b.to_hit(atk, tgt), 'a 10% base minus 25 floors at 0, not negative'
+  atk.ignores_evasion = true
+  eq 10, b.to_hit(atk, tgt), '必中 returns before the evasion-up term is ever consulted'
+end
+
 check 'with accuracy off a basic attack always connects' do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.hit_rate = 1                                  # would nearly always miss...
@@ -8226,6 +8253,33 @@ check 'battle: a 必中 weapon ignores the target\'s evasion' do
                           Game::Rng.new(1), nil, false, false, true)
   eq 90, sure.send(:to_hit, sure.allies[0], swift),
      "必中 drops the evasion term, leaving the weapon's own hit rate"
+end
+
+check 'shield/armour raise_evasion gear grants Actor#physical_evasion_up?, weapon slot excluded' do
+  items = { 7 => fake_item(type: 2, raise_evasion: true),   # a shield
+            8 => fake_item(type: 1, raise_evasion: true) }  # a (miscoded) weapon
+  st = geared_party(items)
+  hero = st.party.leader
+  eq false, hero.physical_evasion_up?
+  hero.equip([0, 7, 0, 0, 0])
+  ok hero.physical_evasion_up?, 'the shield grants it'
+  hero.equip([8, 0, 0, 0, 0])
+  eq false, hero.physical_evasion_up?, 'the weapon slot never counts, even flagged'
+end
+
+check "battle: physical-evasion-up gear drops a normal attack's hit chance by 25" do
+  items = { 7 => fake_item(type: 2, raise_evasion: true) }
+  st = geared_party(items)
+  hero = st.party.leader
+  foe = combatant('Foe', 0, 0, 10, 100)
+  foe.hit_rate = 90
+
+  bare = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  eq 90, bare.send(:to_hit, foe, bare.allies[0]), 'unarmoured, equal agility -> the base rate'
+
+  hero.equip([0, 7, 0, 0, 0])
+  geared = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  eq 65, geared.send(:to_hit, foe, geared.allies[0]), 'the shield drops it to 65'
 end
 
 check 'battle: 必中 still suffers the wielder\'s own blindness' do


### PR DESCRIPTION
## Summary

Found this gap by re-running `scripts/rpg2k_field_audit.rb` against freshly-downloaded real test-bed data (Nepheshel + mtf-meido-action) rather than off the yado.tk/viprpg-dev backlog text — the two prescribed backlog sections turned out to be extremely heavily picked over already (every candidate I sampled there was either already ✅ fixed or already correct by construction). The field audit surfaced a genuinely unread database field instead: an item row's `raise_evasion` (物理回避率アップ, field 26) — 12 rows in Nepheshel — was parsed by the schema but never consulted anywhere in `mruby-rpg2k/mrblib`, so a shield/armour/helmet/accessory bought specifically for its evasion bonus was purely a stat stick against a normal attack.

- **`Game::Actor#physical_evasion_up?`** — true whenever any equipped **non-weapon** item carries the flag, ported from EasyRPG's `Game_Actor::HasPhysicalEvasionUp` (`ForEachEquipment<false, true>`, which excludes weapons by item *type*, not slot index — the same rule `#equip_bonus` already follows for stat sums, so a 二刀流 actor's second weapon sitting in the shield slot is correctly excluded too).
- **`Game::Battle::Combatant#evasion_up`** — a new field, wired from `Battle.from_actor`; an enemy `Combatant` leaves it nil/false since monsters equip nothing.
- **`Game::Battle#to_hit`** — subtracts a flat 25 from the attacker's already agility-adjusted hit chance when the target has the flag, ported from EasyRPG's `Algo::CalcNormalAttackToHit` (`if (target.HasPhysicalEvasionUp()) to_hit -= 25;`), applied right after the AGI term and before the 0..100 clamp. A 必中 (`ignore_evasion`) weapon's existing early-return branch is untouched, so it still skips the AGI term *and* this new term entirely — matching that a guaranteed hit ignores the target's evasion, gear included.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 697 checks pass, including 4 new ones (the flat -25, the 0..100 floor, 必中 skipping the term entirely, weapon-slot exclusion via `Actor#physical_evasion_up?`, and an end-to-end `Battle.from_actor` wiring check). Verified all 4 fail against the pre-fix `game.rb` (`git stash` the source change, re-run — 4 failures, `NoMethodError`/wrong-value as expected).
- `ruby scripts/rpg2k_scene_check.rb` — 352 checks pass, unaffected.
- `ruby scripts/rpg2k_field_audit.rb <Nepheshel> <mtf-meido-action>` (real, freshly-downloaded test-bed data) — `raise_evasion` no longer appears in the unread-fields report.
- `ruby scripts/rpg2k_testbed_logic_check.rb <Nepheshel> <mtf-meido-action>` — 78 checks pass against the real databases.
- `docs/TODO.md` gets a new ✅ bullet in the "which fields the games set that the runtime never reads" family (right before the yado.tk backlog section), and `changelog.d/physical-evasion-up-item-field.added.md` documents it per house style.

Checked open PRs immediately before committing; none touch this field or formula.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hFXMFZyEUwhTZ1uPcAgBT)_