### PR TITLE
Add CI coverage for WOFF font unpacker with hand-authored test font

### DIFF
--- a/changelog.d/mz-woff-unpack-test.added.md
+++ b/changelog.d/mz-woff-unpack-test.added.md
@@ -1,0 +1,12 @@
+- **The WOFF unpacker now has CI coverage.** `woff_to_sfnt` (the MZ `.woff`
+  font unpacker, `mvcanvas.cxx`) previously proved itself only against two real
+  TTFs repacked as WOFF and checked by hand, because it needs a redistributable
+  font and the test beds ship none — and its result sits behind `game_font()`'s
+  process-lifetime cache, so a font dropped into a test's `fonts/` dir is
+  invisible once any earlier test has already drawn text. `MV::Font.unpack_woff`
+  and `MV::Font.smoke_test` (new, test-only bindings) reach the unpacker and a
+  fresh `stb_truetype` rasterisation directly, bypassing that cache.
+  `mruby-mvjs/test/mz_test.rb` hand-authors the smallest font that can prove the
+  pipeline — one glyph mapped from `'A'`, built table-by-table the way the MV
+  image fixtures are — wraps it as WOFF, and checks the unpacked sfnt comes back
+  byte-for-byte identical and rasterises the same real ink as the bare sfnt.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4560,11 +4560,13 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
         `glyf`) and is reported rather than half-parsed into garbage, as are a
         malformed WOFF and a font stb_truetype rejects — silent blank text is
         exactly what let this hide.
-      - 🚧 Remaining for fonts: no CI test covers the unpacker, because it
-        needs a redistributable font and the bed ships none. Verified locally
-        instead, against two real TTFs repacked as WOFF: the unpacked sfnt comes
-        back byte-for-byte the size of the original, stb_truetype accepts it, the
-        vertical metrics and every A-Z advance/lsb match the original exactly,
-        and a glyph rasterises with real ink. Authoring a tiny TTF we own (the
-        way the bed's PNGs are authored) would let the smoke render text and
-        close this.
+      - ✅ CI coverage for the unpacker: it needed a redistributable font and the
+        bed ships none, and its result sits behind `game_font()`'s
+        process-lifetime cache, invisible to a font dropped in after another
+        test has already drawn text. `MV::Font.unpack_woff`/`smoke_test`
+        (test-only mrb bindings) reach `woff_to_sfnt` and a fresh
+        `stb_truetype` rasterisation directly; `mz_test.rb` hand-authors the
+        smallest font that can prove the pipeline (one glyph mapped from
+        `'A'`, the way the MV image fixtures are built) and checks the
+        unpacked sfnt comes back byte-for-byte identical and rasterises the
+        same real ink as the bare original.

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -1671,6 +1671,63 @@ const uint8_t* mv_canvas_pixels(int handle, int* w, int* h) {
   return c->px.data();
 }
 
+// Unpack `in` if it is a WOFF 1.0 font (magic "wOFF"), or pass it through
+// unchanged otherwise (a bare sfnt, or anything else -- the caller finds out
+// via stbtt_InitFont). At file scope so mvjs.cxx can reach the
+// anonymous-namespace woff_to_sfnt for MV::Font.unpack_woff, which exists so
+// the WOFF unpacker itself has CI coverage: it is exercised at load time by
+// game_font() below, but that result is a process-lifetime cache (first text
+// draw wins), so a test-authored font dropped in after another test has
+// already drawn text is invisible to it.
+bool mv_font_unpack(const std::string& in, std::string& out) {
+  const std::vector<uint8_t> bytes(in.begin(), in.end());
+  if (bytes.size() >= 4 && std::memcmp(bytes.data(), "wOFF", 4) == 0) {
+    std::vector<uint8_t> sfnt;
+    if (!woff_to_sfnt(bytes, sfnt))
+      return false;
+    out.assign(sfnt.begin(), sfnt.end());
+    return true;
+  }
+  out = in;
+  return true;
+}
+
+// Rasterise `codepoint` at `pixel` em size from font bytes given directly
+// (WOFF or a bare sfnt), through a *fresh* stbtt_fontinfo -- independent of
+// game_font()'s cached singleton, for the same reason mv_font_unpack exists.
+// Sets *gw/*gh to the glyph bitmap size and *ink to its count of non-zero
+// coverage pixels; false if the bytes do not parse as a font stb_truetype
+// accepts.
+bool mv_font_smoke_test(const std::string& in,
+                        int codepoint,
+                        double pixel,
+                        int* gw,
+                        int* gh,
+                        int* ink) {
+  std::string sfnt;
+  if (!mv_font_unpack(in, sfnt))
+    return false;
+  stbtt_fontinfo info{};
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(sfnt.data());
+  const int off = stbtt_GetFontOffsetForIndex(data, 0);
+  if (off < 0 || !stbtt_InitFont(&info, data, off))
+    return false;
+  const float scale =
+      stbtt_ScaleForMappingEmToPixels(&info, static_cast<float>(pixel));
+  int gxoff = 0, gyoff = 0;
+  uint8_t* bmp = stbtt_GetCodepointBitmap(&info, scale, scale, codepoint, gw,
+                                          gh, &gxoff, &gyoff);
+  *ink = 0;
+  if (bmp) {
+    const size_t n = static_cast<size_t>(*gw) * static_cast<size_t>(*gh);
+    for (size_t i = 0; i < n; ++i)
+      if (bmp[i])
+        ++*ink;
+    stbtt_FreeBitmap(bmp, nullptr);
+  }
+  return true;
+}
+
 void mv_install_canvas(JSContext* ctx) {
   JSValue global = JS_GetGlobalObject(ctx);
   install(ctx, global, "__mv_canvasCreate", js_create, 2);

--- a/mruby-mvjs/src/mvhost.hxx
+++ b/mruby-mvjs/src/mvhost.hxx
@@ -42,3 +42,22 @@ const uint8_t* mv_webgl_pixels(int handle, int* w, int* h);
 // here. Absolute paths and paths already under the base dir are returned
 // unchanged. Defined in mvjs.cxx and shared with the Canvas2D image loader.
 std::string mv_resolve_path(const std::string& p);
+
+// Unpack `in` to the bare sfnt it wraps if it is a WOFF 1.0 font, or pass it
+// through unchanged otherwise. Backs MV::Font.unpack_woff (mvjs.cxx), which
+// gives the WOFF unpacker (mvcanvas.cxx) CI coverage independent of the
+// game_font() cache -- see that function's comment. Returns false only when
+// `in` is a WOFF the unpacker rejects as malformed.
+bool mv_font_unpack(const std::string& in, std::string& out);
+
+// Rasterise `codepoint` at `pixel` em size from font bytes given directly
+// (WOFF or a bare sfnt) through a fresh stb_truetype font, bypassing the
+// game_font() cache. Backs MV::Font.smoke_test (mvjs.cxx). Sets *gw/*gh to
+// the glyph bitmap size and *ink to its count of non-zero coverage pixels;
+// returns false if the bytes do not parse as a font stb_truetype accepts.
+bool mv_font_smoke_test(const std::string& in,
+                        int codepoint,
+                        double pixel,
+                        int* gw,
+                        int* gh,
+                        int* ink);

--- a/mruby-mvjs/src/mvjs.cxx
+++ b/mruby-mvjs/src/mvjs.cxx
@@ -1126,6 +1126,42 @@ mrb_value gl_available(mrb_state* mrb, mrb_value /*self*/) {
   return mrb_bool_value(mvgl::available());
 }
 
+// MV::Font.unpack_woff(bytes) -> the bare sfnt bytes, or nil if `bytes` is a
+// WOFF the unpacker (mvcanvas.cxx) rejects as malformed. A non-WOFF input is
+// returned unchanged. See mv_font_unpack's comment (mvhost.hxx) for why this
+// exists as its own binding rather than relying on the font loader MZ/MV
+// projects boot through.
+mrb_value font_unpack_woff(mrb_state* mrb, mrb_value /*self*/) {
+  const char* p;
+  mrb_int len;
+  mrb_get_args(mrb, "s", &p, &len);
+  std::string out;
+  if (!mv_font_unpack(std::string(p, static_cast<size_t>(len)), out))
+    return mrb_nil_value();
+  return mrb_str_new(mrb, out.data(), out.size());
+}
+
+// MV::Font.smoke_test(bytes, codepoint, pixel) -> [width, height, ink] on
+// success (a real stb_truetype rasterisation of `codepoint`, `ink` its count
+// of non-zero coverage pixels), or nil if `bytes` does not parse as a font.
+// `bytes` may be WOFF or a bare sfnt. See mv_font_smoke_test's comment.
+mrb_value font_smoke_test(mrb_state* mrb, mrb_value /*self*/) {
+  const char* p;
+  mrb_int len;
+  mrb_int codepoint = 'A';
+  mrb_float pixel = 24;
+  mrb_get_args(mrb, "s|if", &p, &len, &codepoint, &pixel);
+  int gw = 0, gh = 0, ink = 0;
+  if (!mv_font_smoke_test(std::string(p, static_cast<size_t>(len)),
+                          static_cast<int>(codepoint), pixel, &gw, &gh, &ink))
+    return mrb_nil_value();
+  mrb_value ary = mrb_ary_new_capa(mrb, 3);
+  mrb_ary_push(mrb, ary, mrb_fixnum_value(gw));
+  mrb_ary_push(mrb, ary, mrb_fixnum_value(gh));
+  mrb_ary_push(mrb, ary, mrb_fixnum_value(ink));
+  return ary;
+}
+
 extern "C" void mrb_mruby_mvjs_gem_init(mrb_state* mrb) {
   RClass* mv = mrb_define_class(mrb, "MV", mrb->object_class);
   RClass* js = mrb_define_class_under(mrb, mv, "JS", mrb->object_class);
@@ -1147,6 +1183,14 @@ extern "C" void mrb_mruby_mvjs_gem_init(mrb_state* mrb) {
   mrb_define_class_method(mrb, gl, "smoke_test", gl_smoke_test,
                           MRB_ARGS_NONE());
   mrb_define_class_method(mrb, gl, "available?", gl_available, MRB_ARGS_NONE());
+
+  // MV::Font — CI coverage for the WOFF unpacker (mvcanvas.cxx) behind the
+  // process-cached GameFont singleton.
+  RClass* font = mrb_define_class_under(mrb, mv, "Font", mrb->object_class);
+  mrb_define_class_method(mrb, font, "unpack_woff", font_unpack_woff,
+                          MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, font, "smoke_test", font_smoke_test,
+                          MRB_ARGS_ARG(1, 2));
 }
 
 extern "C" void mrb_mruby_mvjs_gem_final(mrb_state* mrb) {}

--- a/mruby-mvjs/test/mz_test.rb
+++ b/mruby-mvjs/test/mz_test.rb
@@ -704,3 +704,184 @@ assert 'MZ.host_globals_js provides the FontFace MZ builds when a font is named'
   # document.fonts.add is what the resolved load() calls; it must exist too.
   assert_equal 'function', MV::JS.eval("typeof document.fonts.add")
 end
+
+# The WOFF unpacker (mvcanvas.cxx's woff_to_sfnt, exercised through
+# MV::Font.unpack_woff/smoke_test) is what lets an MZ project's fonts/*.woff
+# draw text at all -- see docs/TODO.md's ".woff fonts" entry. It had no CI
+# coverage because it needs a redistributable font and the test beds ship
+# none; MV::Font.smoke_test bypasses game_font()'s process-lifetime cache
+# (the normal load path, first text draw wins) so a font built fresh in a
+# test is actually exercised rather than shadowed by whatever an earlier test
+# already drew text with. So instead this authors the smallest font that can
+# prove the pipeline: one glyph mapped from 'A', built table-by-table by hand
+# the way the MV image fixtures in canvas_test.rb are (raw bytes, no
+# generator dependency) -- see 3rd/stb/stb_truetype.h's
+# stbtt_InitFont_internal for the required table set.
+module MZFontFixture
+  def self.u8(n)
+    (n & 0xff).chr
+  end
+
+  def self.u16(n)
+    ((n >> 8) & 0xff).chr + (n & 0xff).chr
+  end
+
+  def self.u32(n)
+    ((n >> 24) & 0xff).chr + ((n >> 16) & 0xff).chr + ((n >> 8) & 0xff).chr +
+      (n & 0xff).chr
+  end
+
+  # sfnt/WOFF tables are 4-byte aligned; padding beyond a table's real
+  # (unpadded) length is what its directory entry's length field omits.
+  def self.pad4(s)
+    s + ("\x00" * ((4 - s.bytesize % 4) % 4))
+  end
+
+  # glyph 0 (.notdef) is the empty glyph; glyph 1 is a filled square, wound as
+  # a single closed contour of on-curve points so it rasterises as solid ink
+  # with no quadratic curve handling needed.
+  def self.glyf
+    g = u16(1)                                    # numberOfContours = 1
+    g += u16(100) + u16(100) + u16(700) + u16(700) # xMin,yMin,xMax,yMax
+    g += u16(3)                                    # endPtsOfContours[0]
+    g += u16(0)                                    # instructionLength
+    g += u8(1) * 4                                 # flags: on-curve, full deltas
+    g += u16(100) + u16(600) + u16(0) + u16(-600)  # x deltas (a 600x600 box)
+    g += u16(100) + u16(0) + u16(600) + u16(0)      # y deltas
+    pad4(g)
+  end
+
+  # `glyf_len` is the (4-byte-aligned) total size of the glyf table, i.e. the
+  # offset just past glyph 1 -- glyph 0 (.notdef) is zero-length, so it starts
+  # and ends at 0.
+  def self.loca(glyf_len)
+    u16(0) + u16(0) + u16(glyf_len / 2) # short format: values are offset/2
+  end
+
+  def self.head
+    h = u32(0x00010000) + u32(0x00010000) + u32(0) + u32(0x5F0F3CF5) + u16(0)
+    h += u16(1000)          # unitsPerEm
+    h += "\x00" * 16        # created/modified
+    h += u16(100) + u16(100) + u16(700) + u16(700) # xMin,yMin,xMax,yMax
+    h += u16(0) + u16(8) + u16(2) + u16(0) + u16(0) # ...indexToLocFormat=0 (short)
+    h
+  end
+
+  def self.hhea
+    h = u32(0x00010000)
+    h += u16(800) + u16(-200) + u16(0) # ascent,descent,lineGap
+    h += u16(800)                      # advanceWidthMax
+    h += u16(100) + u16(100) + u16(700) + u16(1) + u16(0) + u16(0)
+    h += "\x00" * 8  # reserved
+    h += u16(0) + u16(2) # metricDataFormat, numberOfHMetrics (both glyphs)
+    h
+  end
+
+  def self.hmtx
+    u16(200) + u16(0) + u16(800) + u16(100) # glyph0(adv,lsb) glyph1(adv,lsb)
+  end
+
+  def self.maxp
+    u32(0x00005000) + u16(2) # version 0.5 (only numGlyphs is read); numGlyphs
+  end
+
+  def self.cmap
+    # Format 6 (trimmed table): codepoint 0x41 ('A') -> glyph 1. Platform 0
+    # (Unicode) is accepted regardless of encodingID by stb_truetype.
+    sub = u16(6) + u16(12) + u16(0) + u16(0x41) + u16(1) + u16(1)
+    c = u16(0) + u16(1)             # version, numTables
+    c += u16(0) + u16(3) + u32(12)  # platformID, encodingID, subtable offset
+    c + sub
+  end
+
+  def self.tables
+    glyf_data = glyf
+    {"cmap" => cmap, "glyf" => glyf_data, "head" => head, "hhea" => hhea,
+     "hmtx" => hmtx, "loca" => loca(glyf_data.bytesize), "maxp" => maxp}
+  end
+
+  # A bare sfnt: header + table directory (checksums left 0 -- stb_truetype
+  # does not verify them, see woff_to_sfnt's comment) + 4-byte-aligned tables,
+  # sorted by tag as woff/sfnt build below both do.
+  def self.build_sfnt(tables)
+    n = tables.size
+    entry_selector = 0
+    entry_selector += 1 while (1 << (entry_selector + 1)) <= n
+    search_range = (1 << entry_selector) * 16
+    range_shift = n * 16 - search_range
+
+    header = u32(0x00010000) + u16(n) + u16(search_range) +
+             u16(entry_selector) + u16(range_shift)
+    dir = String.new
+    data = String.new
+    offset = 12 + n * 16
+    tables.keys.sort.each do |tag|
+      dir += tag + u32(0) + u32(offset) + u32(tables[tag].bytesize)
+      padded = pad4(tables[tag])
+      data += padded
+      offset += padded.bytesize
+    end
+    header + dir + data
+  end
+
+  # The same tables wrapped as WOFF 1.0, every table stored (not deflated) --
+  # the "comp_len == orig_len" branch of woff_to_sfnt -- so this fixture needs
+  # no zlib dependency of its own.
+  def self.build_woff(tables)
+    n = tables.size
+    dir = String.new
+    data = String.new
+    offset = 44 + n * 20
+    tables.keys.sort.each do |tag|
+      bytes = tables[tag]
+      dir += tag + u32(offset) + u32(bytes.bytesize) + u32(bytes.bytesize) +
+             u32(0)
+      padded = pad4(bytes)
+      data += padded
+      offset += padded.bytesize
+    end
+    header = "wOFF" + u32(0x00010000) + u32(44 + dir.bytesize + data.bytesize) +
+             u16(n) + u16(0) + u32(0) + u16(0) + u16(0) + u32(0) + u32(0) +
+             u32(0) + u32(0) + u32(0)
+    header + dir + data
+  end
+end
+
+MZ_TINY_SFNT = MZFontFixture.build_sfnt(MZFontFixture.tables)
+MZ_TINY_WOFF = MZFontFixture.build_woff(MZFontFixture.tables)
+
+assert 'MZ tiny-font fixture: the bare sfnt rasterises real ink' do
+  # Baseline: the hand-authored sfnt itself (no WOFF unpacking involved) is a
+  # font stb_truetype accepts, and 'A' at 24px covers more than a handful of
+  # pixels -- proves the fixture itself is sound before trusting it to
+  # exercise the unpacker below.
+  gw, gh, ink = MV::Font.smoke_test(MZ_TINY_SFNT, 0x41, 24)
+  assert_true gw > 0 && gh > 0
+  assert_true ink > 50
+end
+
+assert 'MZ .woff unpacking: MV::Font.unpack_woff reproduces the sfnt byte-for-byte' do
+  # This is the actual WOFF unpacker (woff_to_sfnt in mvcanvas.cxx) round-
+  # tripping the tables straight back out, checksum field aside (never
+  # verified by stb_truetype either way).
+  unpacked = MV::Font.unpack_woff(MZ_TINY_WOFF)
+  assert_equal MZ_TINY_SFNT.bytesize, unpacked.bytesize
+  assert_equal MZ_TINY_SFNT, unpacked
+end
+
+assert 'MZ .woff unpacking: a real MZ-style .woff renders the same glyph ink' do
+  # End to end: WOFF bytes in, through woff_to_sfnt, through stb_truetype,
+  # to a rasterised glyph -- the path MZ boots through once a font is under
+  # fonts/*.woff (see mv_font_smoke_test's comment for why this needs its own
+  # entry point rather than going through game_font()).
+  sfnt_result = MV::Font.smoke_test(MZ_TINY_SFNT, 0x41, 24)
+  woff_result = MV::Font.smoke_test(MZ_TINY_WOFF, 0x41, 24)
+  assert_equal sfnt_result, woff_result
+  assert_true woff_result[2] > 50
+end
+
+assert 'MZ .woff unpacking: MV::Font.smoke_test/unpack_woff reject non-fonts' do
+  assert_nil MV::Font.smoke_test("wOF2" + ("\x00" * 40), 0x41, 24) # WOFF2, unsupported
+  assert_nil MV::Font.smoke_test("not a font", 0x41, 24)
+  assert_nil MV::Font.unpack_woff("wOFF" + ("\x00" * 4)) # too short to hold a table dir
+end


### PR DESCRIPTION
## Summary
This PR adds comprehensive CI coverage for the WOFF font unpacker (`woff_to_sfnt`) by introducing test-only bindings and a hand-authored minimal font fixture. Previously, the unpacker was only verified manually against real fonts because it needs a redistributable font and sits behind a process-lifetime cache that makes test fonts invisible after the first text draw.

## Key Changes

- **New test bindings in `mvjs.cxx`:**
  - `MV::Font.unpack_woff(bytes)` — unpacks WOFF to bare sfnt bytes or returns nil for malformed input
  - `MV::Font.smoke_test(bytes, codepoint, pixel)` — rasterizes a glyph from font bytes through a fresh stb_truetype instance, returning `[width, height, ink_pixels]` or nil

- **New C++ functions in `mvcanvas.cxx`:**
  - `mv_font_unpack()` — wraps the existing `woff_to_sfnt` logic to handle both WOFF and bare sfnt inputs
  - `mv_font_smoke_test()` — rasterizes a codepoint from font bytes, counting non-zero coverage pixels

- **Hand-authored font fixture in `mz_test.rb`:**
  - `MZFontFixture` module builds the minimal valid font from scratch: one glyph (a filled square) mapped from codepoint 'A', with all required sfnt tables (cmap, glyf, head, hhea, hmtx, loca, maxp)
  - Generates both bare sfnt and WOFF 1.0 formats without external dependencies
  - Follows the same table-by-table hand-authoring pattern as existing MV image fixtures

- **Test coverage in `mz_test.rb`:**
  - Verifies the hand-authored sfnt rasterizes real ink
  - Confirms WOFF unpacking reproduces the sfnt byte-for-byte
  - Validates WOFF and sfnt render identical glyph ink
  - Tests rejection of invalid inputs (WOFF2, truncated headers, non-fonts)

- **Documentation updates:**
  - Updated `docs/TODO.md` to mark WOFF unpacker coverage as complete
  - Added changelog entry describing the new test infrastructure

## Implementation Details

The fixture avoids external font generation dependencies by building tables directly as byte strings. The glyf table uses only on-curve points (no quadratic curves), and the cmap uses Format 6 (trimmed table) for simplicity. Both sfnt and WOFF are built with proper 4-byte alignment and sorted table directories. The smoke test functions bypass `game_font()`'s singleton cache, allowing fresh fonts authored in tests to be exercised independently of earlier test state.

https://claude.ai/code/session_01SUivjkXeYMNK3dwTY2DHcM