### PR TITLE
Make hero debug marker test-play-only

### DIFF
--- a/changelog.d/rpg2k-hero-debug-marker-test-play-only.fixed.md
+++ b/changelog.d/rpg2k-hero-debug-marker-test-play-only.fixed.md
@@ -1,0 +1,8 @@
+- **The hero's missing-graphic debug marker is now Test-Play-only.** When the
+  party leader's CharSet graphic fails to load, `Scene::Map` used to paint a
+  solid yellow block over the hero as a fallback marker regardless of how the
+  game was launched — visible in a released game exactly like it was during
+  development. The marker's alpha now follows `Game#test_play`: full opacity
+  under Test Play (TestPlay/Game.ini `Test=1`/`--test_play`), fully
+  transparent otherwise, so a released game with a missing hero graphic
+  renders nothing there, matching RPG_RT.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -386,10 +386,13 @@ class RPG2k
         @animation_sprite.visible = false
         @animation_bmp = Bitmap.new(SCREEN_W, SCREEN_H)
         @animation_sprite.bitmap = @animation_bmp
-        # Fallback marker when the CharSet graphic is unavailable.
+        # Fallback marker when the CharSet graphic is unavailable -- a debug
+        # aid, so it only shows during Test Play; a released game with a
+        # missing hero graphic draws nothing, same as RPG_RT.
         unless @charset
+          alpha = parent.test_play ? 255 : 0
           @player_bmp.fill_rect 4, 0, TILE, Game::CharSet::HEIGHT,
-                                Color.new(240, 240, 80, 255)
+                                Color.new(240, 240, 80, alpha)
         end
         setup_parallax
         setup_pictures

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -387,9 +387,15 @@ class FakeParent
   # every other check wants -- no tree, so save/teleport/escape all default
   # to Allow.
   attr_accessor :map_tree
+  # Mirrors RPG2k::Game#test_play (see mruby-rpg2k/mrblib/main.rb). Writable
+  # so a check can exercise the Test-Play-only behaviour it gates (the hero's
+  # missing-graphic debug marker); every other check wants the same default
+  # (false) a plainly-launched game gets.
+  attr_accessor :test_play
   def initialize(db, &map_maker)
     @db = db
     @map_tree = nil
+    @test_play = false
     @map_maker = map_maker
     @pushed = []
   end


### PR DESCRIPTION
## Summary
The hero's missing-graphic debug marker is now only visible during Test Play, matching RPG_RT behavior. Previously, the yellow fallback block would appear in released games when a CharSet graphic failed to load.

## Changes
- Modified the debug marker rendering in `Scene::Map#setup_sprites` to conditionally set the marker's alpha based on `Game#test_play`
- When `test_play` is true, the marker displays with full opacity (255) for visibility during development
- When `test_play` is false, the marker is fully transparent (0), rendering nothing in released games
- Updated comments to clarify that the marker is a debug aid intended only for Test Play

## Implementation Details
The fix uses the existing `parent.test_play` flag to determine marker visibility, ensuring the behavior aligns with how RPG_RT handles missing hero graphics in released games versus the development environment.

https://claude.ai/code/session_01DnsCvpf1LaGiiswdc1dJ92