### PR TITLE
docs: confirm enemy "frequent miss" already drops hit rate 90->70

### DIFF
--- a/changelog.d/enemy-frequent-miss-hit-rate-confirmed.changed.md
+++ b/changelog.d/enemy-frequent-miss-hit-rate-confirmed.changed.md
@@ -1,0 +1,9 @@
+- **The "frequent miss" enemy option (a hardcoded 90%→70% drop to a
+  normal attack's hit chance, never a skill's) is confirmed already
+  correct** — no code change needed. `Game::Enemy#attack_hit_rate` already
+  reads the schema's `miss` field this way, and `Game::Battle.hit_rate_of`
+  feeds it into `Battle#to_hit`'s base term at the basic-attack path's one
+  call site; a skill's own hit chance reads the skill row's `hit` field
+  directly, with no code path back to an attacker's `attack_hit_rate` at
+  all. The claim only lacked its own regression coverage, now added to
+  `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3702,9 +3702,37 @@ above are repeated here)
   it) is unverified — a separate question about troop-member identity/
   numbering, not the render-order this PR fixes.
 - The "airborne" enemy display flag **only** changes its Y position on
-  screen — it has no accuracy/hit-related effect. The "frequent miss"
-  enemy option is a hardcoded 90%→70% drop to *normal-attack* accuracy
-  only (skills unaffected).
+  screen — it has no accuracy/hit-related effect. **Still open**: the
+  monster schema's `levitate` field (LCF enemy field 28,
+  `mruby-lcf/mrblib/schema.rb`) is parsed but read nowhere in
+  `mruby-rpg2k`, so this codebase draws every enemy at its plain
+  centred position regardless — but yado.tk's own text names no pixel
+  offset or animation shape for the raise, and both the yado.tk and
+  viprpg-dev wiki mirrors were unreachable this session (`yado.tk`
+  itself 503'd; the viprpg-dev wiki 403'd WebFetch), so implementing this
+  would mean guessing a magnitude with no way to check it — left for a
+  session that can compare against real RPG_RT. ✅ **The "frequent miss"
+  enemy option is confirmed already correct: a hardcoded 90%→70% drop to
+  *normal-attack* accuracy only, skills unaffected.** `Game::Enemy#attack_hit_rate`
+  (`mruby-rpg2k/mrblib/game.rb`) already reads the schema's `miss` field
+  (LCF enemy field 26) exactly this way — `@miss ? 70 : 90` — and
+  `Game::Battle.hit_rate_of` dispatches to it polymorphically the same
+  way it reads an actor's own `attack_hit_rate`, feeding
+  `Game::Battle#to_hit`'s `base` term, the **one and only** call site
+  (`Battle#strike`'s basic-attack path). A skill's own hit chance
+  (`Game::Party#skill_hit`) reads the skill row's `hit` field directly and
+  never touches an attacker's `attack_hit_rate` at all, structurally
+  confirming the "skills unaffected" half — there is no code path between
+  the two. No change was needed; the claim only lacked its own regression
+  coverage, now added: a new `scripts/rpg2k_logic_check.rb` check
+  (`Game::Enemy#attack_hit_rate: the 'miss' flag...`) pins the bare
+  reader (70 flagged / 90 not), the polymorphic `Battle.hit_rate_of`
+  reader agreeing, and an end-to-end `Battle#to_hit` roll against a
+  same-agility target (so the agi-adjustment term drops out and the
+  result is the bare base) for both a flagged and an unflagged enemy in
+  the same fight — confirmed to fail (`expected 70, got 90`) against a
+  temporarily-neutered `attack_hit_rate` that always returned 90, then
+  restored.
 - Chipset passability: an upper-layer "passable" flag **overrides** a
   lower-layer "impassable" one (passable overall); an upper "impassable"
   flag **always** blocks regardless of the lower layer. The simplified

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6597,6 +6597,30 @@ check 'Game::Enemy reads its per-attribute defence ranks' do
   eq({ 1 => 2, 2 => 4, 3 => 0 }, Game::Battle.from_enemy(e).attr_ranks)
 end
 
+check "Game::Enemy#attack_hit_rate: the 'miss' flag (yado.tk's 'frequent miss' " \
+      'enemy option) drops the base rate from 90 to 70' do
+  miss_row = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                        :agility, :exp, :gold, :miss)
+  db = BattleDB.new({ 5 => miss_row.new('Wisp',  20, 0, 8, 4, 3, 10, 5, 5, true),
+                      6 => miss_row.new('Golem', 100, 0, 10, 10, 5, 10, 20, 50, false) }, {})
+  clumsy = Game::Enemy.new(db, 5)
+  steady = Game::Enemy.new(db, 6)
+  eq 70, clumsy.attack_hit_rate, 'the miss flag drops the base rate to 70'
+  eq 90, steady.attack_hit_rate, 'without it, the ordinary RPG2000 default'
+  eq 70, Game::Battle.hit_rate_of(clumsy), 'the polymorphic reader Battle#to_hit uses agrees'
+  eq 90, Game::Battle.hit_rate_of(steady)
+
+  # End to end: the flag actually reaches a live combat roll, not just the
+  # bare reader -- against a same-agility target (no agi-adjustment term to
+  # muddy the number, #to_hit reduces to the bare base rate).
+  target = combatant('Hero', 0, 0, 10, 30)
+  clumsy_atk = Game::Battle.from_enemy(clumsy)
+  steady_atk = Game::Battle.from_enemy(steady)
+  b = Game::Battle.new([target], [clumsy_atk, steady_atk], Game::Rng.new(1))
+  eq 70, b.to_hit(clumsy_atk, target), "the miss enemy's own reduced base reaches the roll"
+  eq 90, b.to_hit(steady_atk, target), 'an ordinary enemy is untouched'
+end
+
 # -- Battle escape ------------------------------------------------------------
 
 def escape_battle(party_agi, enemy_agi, seed = 1)


### PR DESCRIPTION
## Summary
- yado.tk: the "frequent miss" enemy option is a hardcoded 90%→70% drop to
  normal-attack accuracy only (skills unaffected).
- Confirmed already correct, no code change: `Game::Enemy#attack_hit_rate`
  already reads the schema's `miss` field (`@miss ? 70 : 90`),
  `Game::Battle.hit_rate_of`/`#to_hit` feed it in at the one basic-attack
  call site, and a skill's own hit chance reads an entirely separate field
  (`Game::Party#skill_hit`). Nothing in the test suite exercised any of
  this before.
- New coverage verified non-vacuous: temporarily hardcoded
  `attack_hit_rate` to always return 90, confirmed the new check fails
  (`expected 70, got 90`), then reverted.
- Split off from a combined bullet in `docs/TODO.md`'s "Database field
  semantics" section (the sibling "airborne enemy display" half is left
  open — its exact pixel magnitude is undocumented and its two source
  pages were unreachable this session, so it's flagged rather than
  guessed at).

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 698 checks pass (new check:
      `Game::Enemy#attack_hit_rate` bare reader, the polymorphic
      `Battle.hit_rate_of` reader, and an end-to-end `Battle#to_hit` roll
      for both a flagged and unflagged enemy)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 357 checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_