### PR TITLE
rpg2k: Battle Animation target-scope flash (flash_scope 1) now flashes its target

### DIFF
--- a/changelog.d/battle-animation-target-flash.fixed.md
+++ b/changelog.d/battle-animation-target-flash.fixed.md
@@ -1,0 +1,19 @@
+- **A Battle Animation's per-frame target-scope flash (flash_scope 1) now
+  actually flashes its target**, instead of being silently dropped.
+  `Scene::Map#fire_animation_flashes` only ever handled flash_scope 2 (the
+  whole screen); the LCF `animation_timing` schema documents flash_scope as a
+  three-way field (0 none / 1 target / 2 screen), and only the screen case
+  was wired up. Scoped to a battle-round Show Battle Animation aimed at an
+  enemy (a skill/item's `target_index`) — RPG2000's battle is front-view, so
+  an ally-targeted entry has no on-screen sprite to flash, and a map-triggered
+  Show Battle Animation (11210) aimed at a map character is a different
+  target class the Flash Sprite command's own CharSet mechanism already
+  models, left unaddressed here. Uses the RGSS `Sprite#flash`/`#update`
+  primitive (already ported natively but unused elsewhere in this codebase),
+  driven once per frame by a new `Scene::Map#update_enemy_flashes` the same
+  way `#update_map_tone` already drives viewport tone. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (the targeted enemy sprite flashes
+  with the LCF colour, decays after its duration, and leaves the screen flash
+  and an untargeted bystander sprite untouched; a target-scope timing with no
+  resolvable target — an ally, whose battle has no sprite — is a silent
+  no-op), the first confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3317,6 +3317,40 @@ not yet verified:
   Battle Animation targeting the boat lands at the boat's own tile, not the
   player's or the triggering event's), confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **A Battle Animation's per-frame target-scope flash (flash_scope 1) now
+  actually flashes its target**, instead of being silently dropped. The LCF
+  `animation_timing` schema (`mruby-lcf/mrblib/schema.rb`) documents
+  flash_scope as a three-way field — 0 none / 1 target / 2 screen — but
+  `Scene::Map#fire_animation_flashes` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  only ever checked for `== 2`, so a very common animation idiom (flash the
+  hit enemy red on a damage frame) silently did nothing. Scoped to the
+  battle-round path: a skill/item log entry already carries a
+  `target_index` (`Game::Battle#apply_skill_hit`, `@enemies.index(target)`)
+  that `#battle_animation_pixel` already uses to centre the animation on the
+  right `@battle_ui[:enemy_sprites]` entry, and the new `#fire_target_flash`
+  reuses the same index to flash that sprite — nil (an ally target) is a
+  silent no-op, since RPG2000's front-view battle draws no sprite for a
+  party member to flash (the same fact `#battle_animation_pixel`'s own
+  comment already documents) — nothing here invents ally-side behaviour. A
+  map-triggered Show Battle Animation (11210) aimed at a map character is a
+  different target class entirely (the CharSet-based Flash Sprite mechanism
+  already models flashing one) and is not addressed by this fix;
+  `#build_animation`'s map-triggered call site never sets `target_index`, so
+  a flash_scope-1 timing there stays a no-op too, same as before. The flash
+  itself uses the RGSS `Sprite#flash`/`#update` primitive
+  (`mruby-rgss/src/lib.cxx`) — already ported natively but unused anywhere
+  else in this codebase — decayed one frame at a time by a new
+  `#update_enemy_flashes`, driven every frame `@battle_ui` is up from
+  `#drive_battle`, the same way `#update_map_tone` already drives
+  `@map_viewport`/`@upper_viewport`'s tone per frame. Colour/strength scale
+  from the LCF's 0..31 fields the identical `*8` way the screen-flash branch
+  already does. Covered by two new `scripts/rpg2k_scene_check.rb` checks (a
+  target-scope timing flashes the targeted enemy sprite with the scaled LCF
+  colour for `ANIM_FLASH_FRAMES`, leaves the screen flash and an untargeted
+  bystander sprite untouched, and fades back to nothing once driven for its
+  full duration; a target-scope timing with no resolvable target sprite is a
+  silent no-op, not a crash), the first confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **A Timer with "valid during battle" checked force-ends the battle**
   the instant it reaches 0:00, regardless of encounter source (default or
   scripted) — an easy accidental trap if the same Timer is reused for a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3165,6 +3165,7 @@ class RPG2k
           open_battle(req) # opened this frame; take input from the next one
           return
         end
+        update_enemy_flashes
         case @battle_ui[:phase]
         when :command     then drive_battle_command
         when :target      then drive_battle_target
@@ -3380,6 +3381,17 @@ class RPG2k
         bmp = Bitmap.new(32, 32)
         bmp.fill_rect 0, 0, 32, 32, Color.new(180, 60, 60, 255)
         bmp
+      end
+
+      # Decay any in-flight target-scope Battle Animation flash (#fire_target_flash)
+      # by one frame. RGSS's native Sprite#flash bakes its colour into the
+      # composite and fades it linearly, but only when driven by an explicit
+      # Sprite#update each frame (mruby-rgss/src/lib.cxx) -- the same contract
+      # #update_map_tone already drives on @map_viewport/@upper_viewport, just
+      # for the per-enemy sprites instead of a viewport tone. A sprite with no
+      # flash in flight costs nothing here (native #update no-ops).
+      def update_enemy_flashes
+        (@battle_ui[:enemy_sprites] || []).each { |s| s.update if s }
       end
 
       # Show a living enemy's sprite, hide a defeated one — called after each
@@ -3881,7 +3893,7 @@ class RPG2k
         id = battle_animation_id(entry)
         return false unless id && id > 0
         tx, ty = battle_animation_pixel(entry)
-        anim = build_animation(id, tx, ty, true)
+        anim = build_animation(id, tx, ty, true, target_index: entry[:target_index])
         return false unless anim
         @map_animation = anim
         fire_animation_flashes(anim) # frame 0 flashes, as the map path does
@@ -5257,7 +5269,7 @@ class RPG2k
       # screen position rather than a map one, and that nothing is waiting on the
       # animation to finish. nil when the animation is unknown or its
       # Battle/<name> sheet is missing.
-      def build_animation(id, tx, ty, battle = false)
+      def build_animation(id, tx, ty, battle = false, target_index: nil)
         anim = animation_row(id)
         return nil unless anim
         frames = table_entries(anim.frames)
@@ -5266,7 +5278,7 @@ class RPG2k
         return nil unless sheet
         { frames: frames, timings: table_entries(anim.timings), sheet: sheet,
           position: (anim.position || 1), tx: tx, ty: ty, frame_i: 0,
-          timer: ANIM_CELL_FRAMES, battle: battle }
+          timer: ANIM_CELL_FRAMES, battle: battle, target_index: target_index }
       end
 
       def animation_row(id)
@@ -5322,17 +5334,46 @@ class RPG2k
         [v.x * TILE, v.y * TILE]
       end
 
-      # Fire the screen flashes the current frame's timings request (flash_scope
-      # 2 = whole screen); RPG2000 stores the colour / power as 0..31 (scaled up
-      # to the 0..255 the shared Game::Screen flash uses).
+      # Fire the current frame's timings request: flash_scope 2 (whole screen,
+      # already implemented) or flash_scope 1 (the animation's own target --
+      # see #fire_target_flash). RPG2000 stores the colour / power as 0..31,
+      # scaled up to the 0..255 range both flash paths use.
       def fire_animation_flashes(ma)
         ma[:timings].each do |t|
           next unless (t.frame || 0) == ma[:frame_i]
-          next unless (t.flash_scope || 0) == 2
-          @state.screen.flash((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
-                              (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8,
-                              ANIM_FLASH_FRAMES)
+          case (t.flash_scope || 0)
+          when 2
+            @state.screen.flash((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
+                                (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8,
+                                ANIM_FLASH_FRAMES)
+          when 1
+            fire_target_flash(ma[:target_index], t)
+          end
         end
+      end
+
+      # yado.tk / the LCF schema itself (`animation_timing`'s flash_scope field,
+      # 0 none / 1 target / 2 screen): a Battle Animation frame's flash can pulse
+      # its *target* instead of the whole screen -- previously dropped outright,
+      # since only flash_scope 2 was ever handled here. Scoped to the
+      # battle-round path (a skill/item's `target_index`, see
+      # #battle_animation_pixel): RPG2000's battle is front-view, so an
+      # ally-targeted entry has no on-screen sprite to flash (target_index is
+      # nil there, same as it already is for centring the animation itself) and
+      # a map-triggered Show Battle Animation (11210) aimed at a map character
+      # is a different target class entirely, one the Flash Sprite command's own
+      # CharSet tone mechanism already models -- left unaddressed here, since
+      # #build_animation's map path never sets target_index. Uses the RGSS
+      # Sprite#flash/#update primitive (mruby-rgss/src/lib.cxx) already ported
+      # natively but unused elsewhere in this codebase, decayed each frame by
+      # #update_enemy_flashes.
+      def fire_target_flash(target_index, t)
+        sprites = @battle_ui && @battle_ui[:enemy_sprites]
+        spr = target_index && sprites ? sprites[target_index] : nil
+        return unless spr
+        spr.flash(Color.new((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
+                            (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8),
+                  ANIM_FLASH_FRAMES)
       end
 
       # Collect an Array2D (or a plain Hash test double) into a dense array of its

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -86,6 +86,24 @@ module RGSS
     attr_reader :viewport
     def initialize(viewport = nil, *); @viewport = viewport; end
     def dispose; end
+    # #flash/#update, as the target-scope Battle Animation flash
+    # (Scene::Map#fire_target_flash/#update_enemy_flashes) uses them: mirrors
+    # the real native contract (mruby-rgss/src/lib.cxx's spr_flash/spr_update)
+    # closely enough for the wiring checks -- #flash records the colour/duration
+    # requested, #update decays it by one frame and clears it once the
+    # duration runs out, the same "fades over the duration, then gone" shape
+    # the real Sprite gives a caller who drives it every frame.
+    attr_reader :flash_color, :flash_calls
+    def flash(color, duration)
+      (@flash_calls ||= []) << [color, duration]
+      @flash_color = color
+      @flash_count = duration
+    end
+    def update
+      return unless @flash_count && @flash_count > 0
+      @flash_count -= 1
+      @flash_color = nil if @flash_count == 0
+    end
   end
 
   class Viewport
@@ -6275,6 +6293,50 @@ check 'a skill that names an animation plays it over the targeted enemy' do
   spr = ui[:enemy_sprites][0]
   eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
      [ma[:tx], ma[:ty]], 'centred on the enemy sprite'
+end
+
+# flash_scope 1 ("target") -- previously dropped outright, since
+# #fire_animation_flashes only ever handled flash_scope 2 (the whole screen).
+# yado.tk / the LCF schema's own flash_scope enum (0 none / 1 target / 2
+# screen) both name this as a distinct case from the screen flash already
+# covered by the check above; a hand-built timing entry (rather than a
+# fixture animation) isolates it from the screen-flash timing that check
+# already exercises on the shared fixture animation.
+check 'a target-scope animation flash pulses the hit enemy, not the screen or a bystander' do
+  scene, ui = battle_at_command
+  spr = ui[:enemy_sprites][0]
+  bystander = ui[:enemy_sprites][1]
+  timing = OpenStruct.new(frame: 0, flash_scope: 1, flash_red: 31, flash_green: 0,
+                          flash_blue: 0, flash_power: 20)
+  ma = { frame_i: 0, target_index: 0, timings: [timing] }
+  scene.send(:fire_animation_flashes, ma)
+  ok spr.flash_color, 'the targeted enemy sprite was flashed'
+  eq [248, 0, 0, 160],
+     [spr.flash_color.red, spr.flash_color.green, spr.flash_color.blue, spr.flash_color.alpha],
+     'scaled from the LCF 0..31 fixture fields the same *8 way the screen flash already is'
+  anim_flash_frames = RPG2k::Scene::Map::ANIM_FLASH_FRAMES
+  eq anim_flash_frames, spr.flash_calls.last[1],
+     'held for the same duration a screen flash from an animation gets'
+  st = scene.instance_variable_get(:@state)
+  ok !st.screen.flashing?, 'flash_scope 1 never touches the screen flash, unlike flash_scope 2'
+  eq nil, bystander.flash_color, 'the other, untargeted enemy sprite is untouched'
+  # Driven every frame the way #drive_battle already does (#update_enemy_flashes),
+  # the flash fades out and clears after its own duration -- not left stuck on.
+  anim_flash_frames.times { scene.send(:update_enemy_flashes) }
+  eq nil, spr.flash_color, 'the flash faded out after its duration'
+end
+
+# An ally-targeted entry (RPG2000's battle is front-view: no sprite for a
+# party member, so target_index is nil there -- see #battle_animation_pixel)
+# has nothing to flash; #fire_target_flash must not raise reaching for a
+# nonexistent sprite.
+check 'a target-scope flash with no resolvable target sprite is a silent no-op' do
+  scene, = battle_at_command
+  timing = OpenStruct.new(frame: 0, flash_scope: 1, flash_red: 31, flash_green: 0,
+                          flash_blue: 0, flash_power: 20)
+  ma = { frame_i: 0, target_index: nil, timings: [timing] }
+  scene.send(:fire_animation_flashes, ma) # must not raise
+  ok true, 'no exception targeting nothing'
 end
 
 check 'a skill that names none plays nothing' do


### PR DESCRIPTION
## Summary

- The LCF `animation_timing` schema documents `flash_scope` as a three-way field (0 none / 1 target / 2 screen), but `Scene::Map#fire_animation_flashes` only ever handled `== 2` (the whole screen). A Battle Animation's per-frame *target*-scope flash — the common "flash the hit enemy red on the damage frame" idiom — was silently dropped.
- Wires `flash_scope == 1` up for the battle-round path: a skill/item log entry already carries a `target_index` (`Game::Battle#apply_skill_hit`) that `#battle_animation_pixel` already uses to centre the animation on the right `@battle_ui[:enemy_sprites]` entry; a new `#fire_target_flash` reuses that same index to flash that sprite via the RGSS `Sprite#flash`/`#update` primitive (already ported natively in `mruby-rgss/src/lib.cxx`, unused anywhere in this codebase until now), decayed once per frame by a new `#update_enemy_flashes` driven from `#drive_battle` — the same pattern `#update_map_tone` already uses to drive viewport tone every frame.
- Deliberately scoped: an ally-targeted entry (`target_index` nil) is a silent no-op, since RPG2000's front-view battle draws no sprite for a party member to flash (already documented by `#battle_animation_pixel`'s own comment) — nothing here invents ally-side behavior. A map-triggered Show Battle Animation (11210) aimed at a map character is a different target class entirely (the CharSet-based Flash Sprite mechanism already models that) and is intentionally left unaddressed; `#build_animation`'s map-triggered call site never sets `target_index`, so that path stays a no-op exactly as before.
- `docs/TODO.md` updated in place (new ✅ bullet next to the existing vehicle-target Battle Animation fix), and a `changelog.d` fragment added.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 693 checks passed (unchanged; this fix touches only `mruby-rpg2k/mrblib/scene/map.rb`, not `game.rb`/`interpreter.rb`)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 359 checks passed, including two new checks:
  - a target-scope timing flashes the targeted enemy sprite with the LCF colour scaled the same `*8` way the screen flash already is, holds for `ANIM_FLASH_FRAMES`, leaves the screen flash and an untargeted bystander sprite untouched, and fades back to nothing once driven for its full duration
  - a target-scope timing with no resolvable target sprite (an ally target) is a silent no-op, not a crash
- [x] Confirmed the first new check fails against the pre-fix code (reverted `mruby-rpg2k/mrblib/scene/map.rb` only, re-ran `rpg2k_scene_check.rb`): `RuntimeError: the targeted enemy sprite was flashed`

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CWAKTasA5iASWWzBxbieyo)_