### PR TITLE
mz: real OES_vertex_array_object / ANGLE_instanced_arrays extensions

### DIFF
--- a/changelog.d/mz-webgl-vao-instancing.added.md
+++ b/changelog.d/mz-webgl-vao-instancing.added.md
@@ -1,0 +1,10 @@
+- MZ: PIXI's fast geometry path (`OES_vertex_array_object`,
+  `ANGLE_instanced_arrays`) now works instead of always falling back to
+  PIXI's own no-VAO/no-instancing path — `getExtension` used to return `null`
+  unconditionally. Both are now real extension objects backed by the GLES 3.0
+  core functions the software (llvmpipe) driver actually implements, loaded
+  via `eglGetProcAddress`. The legacy `ANGLE`-suffixed entry points resolve to
+  a non-null pointer too (an implementation may hand back a pointer for a
+  name it does not support) but silently drew nothing, so the loader now
+  tries the core name first and falls back to the OES/ANGLE-suffixed name
+  only for a driver with no core entry points at all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4629,9 +4629,25 @@ Full design and rationale: `docs/adr/0004-javascript-maker-mv-quickjs.md`.
         (Worth noting the engine queues its own ops too — New Game's fade-out
         emits `bgm_fade`/`bgs_fade`/`me_fade` — so the path is exercised even
         without the probe.)
-      - 🚧 Remaining: optional VAO / `vertexAttribDivisor` fast path (PIXI falls
-        back without it, and `getExtension` returns null so the fallback is what
-        runs); and texture Y-flip and uniform-introspection polish as real
+      - ✅ **VAO / `vertexAttribDivisor` fast path.** `getExtension` returned
+        `null` unconditionally, so PIXI's `GeometrySystem.contextChange`
+        always fell back to its own no-VAO/no-instancing path — correct but
+        slower. `OES_vertex_array_object` and `ANGLE_instanced_arrays` (the
+        two PIXI actually asks for) are now real, working extension objects:
+        the GLES 3.0 core functions they wrap (absent from the GLES2 header
+        this builds against) are loaded via `eglGetProcAddress`, core name
+        first — `eglGetProcAddress` resolves the legacy `ANGLE`-suffixed names
+        to a non-null pointer too, but llvmpipe does not actually implement
+        that (non-Khronos) extension namespace and calling it silently drew
+        nothing; the OES-suffixed VAO names happened to work, so this only
+        surfaced once instancing was tested end to end, not just checked for
+        non-null. Covered by `gl_test.rb`: the extension objects are
+        advertised with working methods and cached per call, a VAO round-trips
+        real vertex-attribute state (two VAOs, one with a bound attribute and
+        one without, draw differently through the same program), and
+        `drawArraysInstancedANGLE` paints one primitive per instance at its
+        own per-instance offset.
+      - 🚧 Remaining: texture Y-flip and uniform-introspection polish as real
         content exercises them.
       - ✅ **`.woff` fonts.** The canvas text loader looked only for `.ttf`/`.otf`
         under a game's `fonts/`, but **MZ projects ship `.woff`**

--- a/mruby-mvjs/src/mvwebgl.cxx
+++ b/mruby-mvjs/src/mvwebgl.cxx
@@ -29,6 +29,7 @@
     __has_include(<GLES2/gl2.h>)
 #define MVJS_HAVE_WEBGL 1
 
+#include <EGL/egl.h>
 #include <GLES2/gl2.h>
 
 #include <cstring>
@@ -1286,6 +1287,199 @@ JSValue js_gl_flush(JSContext* ctx,
   return JS_UNDEFINED;
 }
 
+// -- extensions: OES_vertex_array_object, ANGLE_instanced_arrays -------------
+//
+// PIXI's GeometrySystem.contextChange (see libs/pixi.js in a fetched MZ
+// corescript) checks `gl.createVertexArray`/`gl.vertexAttribDivisor` first
+// (the WebGL2 names) and, missing those, falls back to
+// `gl.getExtension('OES_vertex_array_object')` /
+// `gl.getExtension('ANGLE_instanced_arrays')` and calls the *ANGLE/OES-suffixed
+// methods on the returned object. Both extensions were previously unavailable
+// (getExtension always returned null, see its comment below), so every draw
+// went through PIXI's own no-VAO fallback path (`gl.createVertexArray` a
+// no-op, `hasVao`/`hasInstance` false) -- functionally correct but slower.
+//
+// The functions the two extensions need (glGenVertexArrays,
+// glVertexAttribDivisor, ...) are GLES 3.0 core, absent from the GLES2 header
+// this file compiles against, so they are loaded dynamically via
+// eglGetProcAddress -- the same idiom mvgl.cxx uses for its own EGL
+// extensions. mvgl.cxx's context is created ES3-first (falling back to ES2
+// only where ES3 is unavailable, see bind_context), so the bare core name is
+// tried first here too: on the apt/nix llvmpipe driver this is confirmed
+// genuinely functional, while eglGetProcAddress happily hands back a non-null
+// pointer for the legacy ANGLE-suffixed names too (per spec, an
+// implementation may resolve any name) that silently drew nothing when tried
+// first -- ANGLE_instanced_arrays is not a driver extension llvmpipe actually
+// implements, unlike OES_vertex_array_object, whose OES-suffixed entry points
+// did work; non-null is not sufficient evidence of "real", so core-first is
+// the safe default and the suffixed name is only the fallback for a genuine
+// GLES2-only driver with no core entry points at all. A null pointer after
+// both lookups means the driver has neither, and the extension is then not
+// advertised -- PIXI's existing fallback runs exactly as before M6.3c.
+typedef void(GL_APIENTRYP PFNMVGENVERTEXARRAYSPROC)(GLsizei, GLuint*);
+typedef void(GL_APIENTRYP PFNMVBINDVERTEXARRAYPROC)(GLuint);
+typedef void(GL_APIENTRYP PFNMVDELETEVERTEXARRAYSPROC)(GLsizei, const GLuint*);
+typedef GLboolean(GL_APIENTRYP PFNMVISVERTEXARRAYPROC)(GLuint);
+typedef void(GL_APIENTRYP PFNMVVERTEXATTRIBDIVISORPROC)(GLuint, GLuint);
+typedef void(GL_APIENTRYP PFNMVDRAWARRAYSINSTANCEDPROC)(GLenum,
+                                                        GLint,
+                                                        GLsizei,
+                                                        GLsizei);
+typedef void(GL_APIENTRYP PFNMVDRAWELEMENTSINSTANCEDPROC)(GLenum,
+                                                          GLsizei,
+                                                          GLenum,
+                                                          const void*,
+                                                          GLsizei);
+
+// eglGetProcAddress under `core`, falling back to `suffixed` (see the section
+// comment above); nullptr if neither resolves.
+void* load_ext_proc(const char* core, const char* suffixed) {
+  void* p = reinterpret_cast<void*>(eglGetProcAddress(core));
+  return p ? p : reinterpret_cast<void*>(eglGetProcAddress(suffixed));
+}
+
+struct VaoExt {
+  bool tried = false;
+  PFNMVGENVERTEXARRAYSPROC gen = nullptr;
+  PFNMVBINDVERTEXARRAYPROC bind_vao = nullptr;
+  PFNMVDELETEVERTEXARRAYSPROC del = nullptr;
+  PFNMVISVERTEXARRAYPROC is_vao = nullptr;
+  bool ok() const { return gen && bind_vao && del && is_vao; }
+};
+VaoExt& vao_ext() {
+  static VaoExt v;
+  if (v.tried)
+    return v;
+  v.tried = true;
+  v.gen = reinterpret_cast<PFNMVGENVERTEXARRAYSPROC>(
+      load_ext_proc("glGenVertexArrays", "glGenVertexArraysOES"));
+  v.bind_vao = reinterpret_cast<PFNMVBINDVERTEXARRAYPROC>(
+      load_ext_proc("glBindVertexArray", "glBindVertexArrayOES"));
+  v.del = reinterpret_cast<PFNMVDELETEVERTEXARRAYSPROC>(
+      load_ext_proc("glDeleteVertexArrays", "glDeleteVertexArraysOES"));
+  v.is_vao = reinterpret_cast<PFNMVISVERTEXARRAYPROC>(
+      load_ext_proc("glIsVertexArray", "glIsVertexArrayOES"));
+  return v;
+}
+
+struct InstancedExt {
+  bool tried = false;
+  PFNMVVERTEXATTRIBDIVISORPROC divisor = nullptr;
+  PFNMVDRAWARRAYSINSTANCEDPROC draw_arrays = nullptr;
+  PFNMVDRAWELEMENTSINSTANCEDPROC draw_elements = nullptr;
+  bool ok() const { return divisor && draw_arrays && draw_elements; }
+};
+InstancedExt& instanced_ext() {
+  static InstancedExt v;
+  if (v.tried)
+    return v;
+  v.tried = true;
+  v.divisor = reinterpret_cast<PFNMVVERTEXATTRIBDIVISORPROC>(
+      load_ext_proc("glVertexAttribDivisor", "glVertexAttribDivisorANGLE"));
+  v.draw_arrays = reinterpret_cast<PFNMVDRAWARRAYSINSTANCEDPROC>(
+      load_ext_proc("glDrawArraysInstanced", "glDrawArraysInstancedANGLE"));
+  v.draw_elements = reinterpret_cast<PFNMVDRAWELEMENTSINSTANCEDPROC>(
+      load_ext_proc("glDrawElementsInstanced", "glDrawElementsInstancedANGLE"));
+  return v;
+}
+
+JSValue js_gl_ext_vao_available(JSContext* ctx,
+                                JSValueConst,
+                                int argc,
+                                JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)))
+    return JS_NewBool(ctx, 0);
+  return JS_NewBool(ctx, vao_ext().ok());
+}
+
+JSValue js_gl_ext_create_vertex_array(JSContext* ctx,
+                                      JSValueConst,
+                                      int argc,
+                                      JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)) || !vao_ext().ok())
+    return JS_NewInt32(ctx, 0);
+  GLuint v = 0;
+  vao_ext().gen(1, &v);
+  return JS_NewInt32(ctx, static_cast<int32_t>(v));
+}
+
+JSValue js_gl_ext_bind_vertex_array(JSContext* ctx,
+                                    JSValueConst,
+                                    int argc,
+                                    JSValueConst* argv) {
+  if (bind(gi(ctx, argc, argv, 0)) && vao_ext().ok())
+    vao_ext().bind_vao(static_cast<GLuint>(gi(ctx, argc, argv, 1)));
+  return JS_UNDEFINED;
+}
+
+JSValue js_gl_ext_delete_vertex_array(JSContext* ctx,
+                                      JSValueConst,
+                                      int argc,
+                                      JSValueConst* argv) {
+  if (bind(gi(ctx, argc, argv, 0)) && vao_ext().ok()) {
+    GLuint v = static_cast<GLuint>(gi(ctx, argc, argv, 1));
+    vao_ext().del(1, &v);
+  }
+  return JS_UNDEFINED;
+}
+
+JSValue js_gl_ext_is_vertex_array(JSContext* ctx,
+                                  JSValueConst,
+                                  int argc,
+                                  JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)) || !vao_ext().ok())
+    return JS_NewBool(ctx, 0);
+  return JS_NewBool(
+      ctx, vao_ext().is_vao(static_cast<GLuint>(gi(ctx, argc, argv, 1))));
+}
+
+JSValue js_gl_ext_instanced_available(JSContext* ctx,
+                                      JSValueConst,
+                                      int argc,
+                                      JSValueConst* argv) {
+  if (!bind(gi(ctx, argc, argv, 0)))
+    return JS_NewBool(ctx, 0);
+  return JS_NewBool(ctx, instanced_ext().ok());
+}
+
+// vertexAttribDivisorANGLE(index, divisor)
+JSValue js_gl_ext_vertex_attrib_divisor(JSContext* ctx,
+                                        JSValueConst,
+                                        int argc,
+                                        JSValueConst* argv) {
+  if (bind(gi(ctx, argc, argv, 0)) && instanced_ext().ok())
+    instanced_ext().divisor(static_cast<GLuint>(gi(ctx, argc, argv, 1)),
+                            static_cast<GLuint>(gi(ctx, argc, argv, 2)));
+  return JS_UNDEFINED;
+}
+
+// drawArraysInstancedANGLE(mode, first, count, primcount)
+JSValue js_gl_ext_draw_arrays_instanced(JSContext* ctx,
+                                        JSValueConst,
+                                        int argc,
+                                        JSValueConst* argv) {
+  if (bind(gi(ctx, argc, argv, 0)) && instanced_ext().ok())
+    instanced_ext().draw_arrays(static_cast<GLenum>(gi(ctx, argc, argv, 1)),
+                                gi(ctx, argc, argv, 2), gi(ctx, argc, argv, 3),
+                                gi(ctx, argc, argv, 4));
+  return JS_UNDEFINED;
+}
+
+// drawElementsInstancedANGLE(mode, count, type, offset, primcount)
+JSValue js_gl_ext_draw_elements_instanced(JSContext* ctx,
+                                          JSValueConst,
+                                          int argc,
+                                          JSValueConst* argv) {
+  if (bind(gi(ctx, argc, argv, 0)) && instanced_ext().ok())
+    instanced_ext().draw_elements(
+        static_cast<GLenum>(gi(ctx, argc, argv, 1)), gi(ctx, argc, argv, 2),
+        static_cast<GLenum>(gi(ctx, argc, argv, 3)),
+        reinterpret_cast<const void*>(
+            static_cast<uintptr_t>(gi(ctx, argc, argv, 4))),
+        gi(ctx, argc, argv, 5));
+  return JS_UNDEFINED;
+}
+
 void reg(JSContext* ctx,
          JSValue g,
          const char* name,
@@ -1616,11 +1810,43 @@ const char* kWebGLPreamble = R"MVJS(
              premultipliedAlpha: true, preserveDrawingBuffer: false,
              failIfMajorPerformanceCaveat: false };
   };
-  // Extensions: none advertised yet. PIXI degrades gracefully (no-VAO geometry
-  // path, no float textures) when getExtension returns null. The specific set
-  // PIXI wants (VAO, anisotropy, ...) is filled in M6.3c.
-  P.getExtension = function () { return null; };
-  P.getSupportedExtensions = function () { return []; };
+  // Extensions: only the two PIXI's GeometrySystem checks for a fast path
+  // (OES_vertex_array_object, ANGLE_instanced_arrays -- see the native-side
+  // comment above js_gl_ext_vao_available). Everything else PIXI probes
+  // (anisotropy, float textures, ...) still degrades gracefully to null; PIXI
+  // handles a missing extension for those the same way it always has. Cached
+  // per context in `this._ext` so repeat calls return the same object, as the
+  // WebGL spec requires and PIXI's own caching (`context.extensions.*`)
+  // expects.
+  P.getExtension = function (name) {
+    if (Object.prototype.hasOwnProperty.call(this._ext, name)) {
+      return this._ext[name];
+    }
+    var gl = this.__gl;
+    var ext = null;
+    if (name === 'OES_vertex_array_object' && g.__mv_glExtVaoAvailable(gl)) {
+      ext = {
+        createVertexArrayOES: function () { return g.__mv_glExtCreateVertexArray(gl); },
+        bindVertexArrayOES: function (a) { g.__mv_glExtBindVertexArray(gl, a || 0); },
+        deleteVertexArrayOES: function (a) { g.__mv_glExtDeleteVertexArray(gl, a || 0); },
+        isVertexArrayOES: function (a) { return g.__mv_glExtIsVertexArray(gl, a || 0); },
+      };
+    } else if (name === 'ANGLE_instanced_arrays' && g.__mv_glExtInstancedAvailable(gl)) {
+      ext = {
+        vertexAttribDivisorANGLE: function (i, d) { g.__mv_glExtVertexAttribDivisor(gl, i, d); },
+        drawArraysInstancedANGLE: function (m, f, c, p) { g.__mv_glExtDrawArraysInstanced(gl, m, f, c, p); },
+        drawElementsInstancedANGLE: function (m, c, t, o, p) { g.__mv_glExtDrawElementsInstanced(gl, m, c, t, o, p); },
+      };
+    }
+    this._ext[name] = ext;
+    return ext;
+  };
+  P.getSupportedExtensions = function () {
+    var out = [];
+    if (g.__mv_glExtVaoAvailable(this.__gl)) out.push('OES_vertex_array_object');
+    if (g.__mv_glExtInstancedAvailable(this.__gl)) out.push('ANGLE_instanced_arrays');
+    return out;
+  };
 
   g.WebGLRenderingContext = WebGLRenderingContext;
 })(typeof globalThis !== 'undefined' ? globalThis : this);
@@ -1733,6 +1959,18 @@ void mv_install_webgl(JSContext* ctx) {
   reg(ctx, g, "__mv_glGetError", js_gl_get_error, 1);
   reg(ctx, g, "__mv_glFinish", js_gl_finish, 1);
   reg(ctx, g, "__mv_glFlush", js_gl_flush, 1);
+  reg(ctx, g, "__mv_glExtVaoAvailable", js_gl_ext_vao_available, 1);
+  reg(ctx, g, "__mv_glExtCreateVertexArray", js_gl_ext_create_vertex_array, 1);
+  reg(ctx, g, "__mv_glExtBindVertexArray", js_gl_ext_bind_vertex_array, 2);
+  reg(ctx, g, "__mv_glExtDeleteVertexArray", js_gl_ext_delete_vertex_array, 2);
+  reg(ctx, g, "__mv_glExtIsVertexArray", js_gl_ext_is_vertex_array, 2);
+  reg(ctx, g, "__mv_glExtInstancedAvailable", js_gl_ext_instanced_available, 1);
+  reg(ctx, g, "__mv_glExtVertexAttribDivisor", js_gl_ext_vertex_attrib_divisor,
+      3);
+  reg(ctx, g, "__mv_glExtDrawArraysInstanced", js_gl_ext_draw_arrays_instanced,
+      5);
+  reg(ctx, g, "__mv_glExtDrawElementsInstanced",
+      js_gl_ext_draw_elements_instanced, 6);
   JS_FreeValue(ctx, g);
 
   JSValue r = JS_Eval(ctx, kWebGLPreamble, std::strlen(kWebGLPreamble),

--- a/mruby-mvjs/test/gl_test.rb
+++ b/mruby-mvjs/test/gl_test.rb
@@ -544,3 +544,193 @@ assert 'the stencil test masks inside a render texture, where MZ actually draws'
   assert_true parts[2].to_i > 200 # right: drawn
   assert_true parts[1].to_i < 60  # left: masked out
 end
+
+# --- M6.3c fast path: OES_vertex_array_object / ANGLE_instanced_arrays ------
+#
+# PIXI's GeometrySystem.contextChange (libs/pixi.js in a fetched MZ
+# corescript) checks `gl.createVertexArray`/`gl.vertexAttribDivisor` (WebGL2)
+# first and, missing those, asks `getExtension` for these two by name and
+# calls their ANGLE/OES-suffixed methods. `getExtension` used to always
+# return null, so every draw went through PIXI's no-VAO/no-instancing
+# fallback -- correct but slower. These prove the extension objects are real
+# and functionally correct, not just present.
+
+assert 'getExtension advertises OES_vertex_array_object / ANGLE_instanced_arrays with working methods, cached per call' do
+  skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
+
+  out = MV::JS.eval(<<~'JS')
+    (function () {
+      var cv = document.createElement('canvas'); cv.width = 4; cv.height = 4;
+      var gl = cv.getContext('webgl');
+      var supported = gl.getSupportedExtensions();
+      var vao1 = gl.getExtension('OES_vertex_array_object');
+      var vao2 = gl.getExtension('OES_vertex_array_object');
+      var inst1 = gl.getExtension('ANGLE_instanced_arrays');
+      var inst2 = gl.getExtension('ANGLE_instanced_arrays');
+      var bogus = gl.getExtension('NOT_A_REAL_EXTENSION');
+      var flags = [
+        supported.indexOf('OES_vertex_array_object') >= 0,
+        supported.indexOf('ANGLE_instanced_arrays') >= 0,
+        !!vao1,
+        vao1 === vao2,
+        typeof vao1.createVertexArrayOES === 'function',
+        typeof vao1.bindVertexArrayOES === 'function',
+        typeof vao1.deleteVertexArrayOES === 'function',
+        typeof vao1.isVertexArrayOES === 'function',
+        !!inst1,
+        inst1 === inst2,
+        typeof inst1.vertexAttribDivisorANGLE === 'function',
+        typeof inst1.drawArraysInstancedANGLE === 'function',
+        typeof inst1.drawElementsInstancedANGLE === 'function',
+        bogus === null,
+      ];
+      return flags.map(function (f) { return f ? 1 : 0; }).join(',');
+    })()
+  JS
+  flags = out.split(",").map(&:to_i)
+  assert_equal 14, flags.size
+  flags.each_with_index { |f, i| assert_equal 1, f, "flag #{i}" }
+end
+
+assert 'a VAO round-trips vertex attribute state (OES_vertex_array_object)' do
+  skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
+
+  # VAO A binds a full-screen (overflowing) triangle to attribute 0; VAO B
+  # never sets up attribute 0 at all. Drawing through each with the *same*
+  # program/draw call must produce different pixels only if the buffer
+  # binding, enable state and vertexAttribPointer really are captured and
+  # restored per-VAO rather than living in shared context state.
+  out = MV::JS.eval(<<~'JS')
+    (function () {
+      var W = 64, H = 64;
+      var cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+      var gl = cv.getContext('webgl');
+      if (!gl) return 'no-context';
+      var vaoExt = gl.getExtension('OES_vertex_array_object');
+      if (!vaoExt) return 'no-vao-ext';
+
+      var vs = gl.createShader(gl.VERTEX_SHADER);
+      gl.shaderSource(vs, '#version 100\nattribute vec2 aPos;\nvoid main(){ gl_Position = vec4(aPos,0.0,1.0); }\n');
+      gl.compileShader(vs);
+      var fs = gl.createShader(gl.FRAGMENT_SHADER);
+      gl.shaderSource(fs, '#version 100\nprecision mediump float;\nvoid main(){ gl_FragColor = vec4(0.0,1.0,0.0,1.0); }\n');
+      gl.compileShader(fs);
+      var p = gl.createProgram();
+      gl.attachShader(p, vs); gl.attachShader(p, fs);
+      gl.bindAttribLocation(p, 0, 'aPos');
+      gl.linkProgram(p);
+      if (!gl.getProgramParameter(p, gl.LINK_STATUS)) return 'link-failed';
+      gl.useProgram(p);
+      gl.viewport(0, 0, W, H);
+
+      var vaoA = vaoExt.createVertexArrayOES();
+      vaoExt.bindVertexArrayOES(vaoA);
+      var bufA = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, bufA);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 3,-1, -1,3]), gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+      // VAO B: created and bound, but attribute 0 is left disabled -- its
+      // "current value" defaults to (0,0,0,1) for every vertex, collapsing
+      // the triangle to a single point (nothing rasterises).
+      var vaoB = vaoExt.createVertexArrayOES();
+      vaoExt.bindVertexArrayOES(vaoB);
+      vaoExt.bindVertexArrayOES(null);
+
+      function draw(vao) {
+        gl.clearColor(0.6, 0.0, 0.0, 1.0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        vaoExt.bindVertexArrayOES(vao);
+        gl.drawArrays(gl.TRIANGLES, 0, 3);
+        gl.finish();
+        var px = new Uint8Array(4);
+        gl.readPixels(W / 2, H / 2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px);
+        return px[1];
+      }
+
+      var greenA = draw(vaoA);
+      var greenB = draw(vaoB);
+      var wasVaoA = vaoExt.isVertexArrayOES(vaoA);
+      vaoExt.deleteVertexArrayOES(vaoA);
+      vaoExt.deleteVertexArrayOES(vaoB);
+      var isVaoAAfterDelete = vaoExt.isVertexArrayOES(vaoA);
+      return [greenA, greenB, wasVaoA ? 1 : 0, isVaoAAfterDelete ? 1 : 0].join(',');
+    })()
+  JS
+  parts = out.split(",")
+  assert_equal 4, parts.size
+  assert_true parts[0].to_i > 200 # VAO A: its own attribute state draws green
+  assert_true parts[1].to_i < 60  # VAO B: no attribute 0 set up, nothing drawn
+  assert_equal "1", parts[2]      # isVertexArrayOES true for a live VAO
+  assert_equal "0", parts[3]      # ...and false once deleted
+end
+
+assert 'drawArraysInstancedANGLE draws one primitive per instance at its own offset (ANGLE_instanced_arrays)' do
+  skip 'EGL/GLES2 backend not compiled into this build' unless MV::GL.available?
+
+  # A per-vertex triangle big enough to fully cover a small square around the
+  # origin (the same "overflowing triangle" trick as the plain smoke test,
+  # scaled down), offset per-instance by a divisor-1 attribute. Two instances,
+  # at -0.5 and +0.5 on the x axis, must each paint their own small square and
+  # leave the gap between them (and everywhere else) untouched -- proof this
+  # is really two separate instanced draws and not one shape spanning both.
+  out = MV::JS.eval(<<~'JS')
+    (function () {
+      var W = 64, H = 64;
+      var cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+      var gl = cv.getContext('webgl');
+      if (!gl) return 'no-context';
+      var instExt = gl.getExtension('ANGLE_instanced_arrays');
+      if (!instExt) return 'no-instance-ext';
+
+      var vs = gl.createShader(gl.VERTEX_SHADER);
+      gl.shaderSource(vs,
+        '#version 100\nattribute vec2 aPos;\nattribute vec2 aOffset;\n' +
+        'void main(){ gl_Position = vec4(aPos * 0.15 + aOffset,0.0,1.0); }\n');
+      gl.compileShader(vs);
+      if (!gl.getShaderParameter(vs, gl.COMPILE_STATUS)) return 'vs-failed';
+      var fs = gl.createShader(gl.FRAGMENT_SHADER);
+      gl.shaderSource(fs, '#version 100\nprecision mediump float;\nvoid main(){ gl_FragColor = vec4(0.0,1.0,0.0,1.0); }\n');
+      gl.compileShader(fs);
+      var p = gl.createProgram();
+      gl.attachShader(p, vs); gl.attachShader(p, fs);
+      gl.bindAttribLocation(p, 0, 'aPos');
+      gl.bindAttribLocation(p, 1, 'aOffset');
+      gl.linkProgram(p);
+      if (!gl.getProgramParameter(p, gl.LINK_STATUS)) return 'link-failed';
+      gl.useProgram(p);
+      gl.viewport(0, 0, W, H);
+      gl.clearColor(0.6, 0.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+
+      var posBuf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, posBuf);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 3,-1, -1,3]), gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+      var offBuf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, offBuf);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-0.5,0, 0.5,0]), gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(1);
+      gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
+      instExt.vertexAttribDivisorANGLE(1, 1);
+
+      instExt.drawArraysInstancedANGLE(gl.TRIANGLES, 0, 3, 2);
+      gl.finish();
+
+      function px(x, y) {
+        var out = new Uint8Array(4);
+        gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, out);
+        return out[1];
+      }
+      return [px(16, 32), px(32, 32), px(48, 32)].join(',');
+    })()
+  JS
+  parts = out.split(",")
+  assert_equal 3, parts.size
+  assert_true parts[0].to_i > 200 # left instance (offset -0.5): drawn
+  assert_true parts[1].to_i < 60  # midpoint between them: untouched
+  assert_true parts[2].to_i > 200 # right instance (offset +0.5): drawn
+end


### PR DESCRIPTION
## Summary

- `getExtension` on the MZ WebGL shim (`mvwebgl.cxx`) returned `null` unconditionally, so PIXI's `GeometrySystem.contextChange` always fell back to its own no-VAO/no-instancing draw path instead of the fast one. `OES_vertex_array_object` and `ANGLE_instanced_arrays` — the two extensions PIXI actually asks for — are now real, working extension objects, backed by the GLES 3.0 core functions the software (llvmpipe) driver implements, loaded dynamically via `eglGetProcAddress`.
- The loader tries the **core** (unsuffixed) function name first, not the legacy `OES`/`ANGLE`-suffixed one: `eglGetProcAddress` resolves the `ANGLE`-suffixed instancing names to a non-null pointer too (an implementation may resolve any name per spec), but llvmpipe does not actually implement that non-Khronos extension namespace, so calling through it silently drew nothing. The `OES`-suffixed VAO names happened to work — this asymmetry only surfaced once instancing was verified end to end (real pixels painted), not just checked for a non-null pointer.
- `gl_test.rb` covers all three: the extension objects are advertised with real working methods and cached per call (`getExtension`/`getSupportedExtensions`), a VAO genuinely round-trips vertex-attribute state (two VAOs — one with a bound attribute, one without — draw differently through the same program/draw call), and `drawArraysInstancedANGLE` paints one primitive per instance at its own per-instance offset.
- Closes the last remaining item filed under docs/TODO.md's MZ WebGL rendering section for this fast path (texture Y-flip / uniform-introspection polish stays open, pending real content to exercise it).

## Test plan

- [x] Native build (`scripts/native-build-without-nix.bash`) succeeds
- [x] `rake test` (mrbtest): 1786 tests, 0 failures
- [x] `ctest`: all green except the pre-existing, unrelated `exe_open` failure (missing proprietary game fixture not present in this sandbox)
- [x] `clang-format --dry-run --Werror` clean on touched files

https://claude.ai/code/session_01SUivjkXeYMNK3dwTY2DHcM


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUivjkXeYMNK3dwTY2DHcM)_