### PR TITLE
Implement RPG2000 Test Play debug keys (Ctrl, Shift, F9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@
   camera). Nepheshel's town, an interior and an open-water map now render
   **pixel-identical** to RPG_RT — tile layers, autotiles, upper/lower layering
   and event sprites all on its exact pixels
+- RPG_RT's own **Test Play debug keys** work, gated on `--test_play`/`Game.ini`
+  `[Game] Test=1` the same way every other debug tool in this engine is (see
+  "Profiling" below) — a released game never sees any of them do anything:
+  hold **Ctrl** to ignore collision and turn off random encounters; hold
+  **Shift** to fast-forward the current message (same effect a C/B press
+  already has, held down instead of tapped); press **F9** to open a debug
+  menu listing every switch and variable, ten at a time, with a signed number
+  editor for variables
 
 ### Events, menu & saving
 - Map events run through an event-command interpreter: messages and choices,

--- a/README.md
+++ b/README.md
@@ -428,6 +428,13 @@
   `X`/`Esc` to cancel (B), `C` for the A button, `Q` or `Ctrl-C` to quit. The
   same reference is drawn as a one-line legend on the top row above the game
   image
+- The Test Play debug keys (see "Map exploration" above) work here too, held
+  the same hold-to-repeat way the movement keys are: `T` stands in for Ctrl
+  and `F` for Shift, since a raw terminal cannot tell a genuine Ctrl/Shift
+  modifier apart from an ordinary keypress (and Ctrl-C is already bound to
+  quit). `F9` opens the debug menu directly — most terminal emulators forward
+  it as a real function-key escape sequence, the same way `F12`'s
+  return-to-title already works here
 - `--sixel` works in terminals such as `xterm -ti vt340`, mlterm, foot, WezTerm
   and Windows Terminal; `--iterm` works in iTerm2, WezTerm and VS Code
 - Either backend draws its emit rate (frame size, MB/s, fps) on-screen just

--- a/changelog.d/rpg2k-debug-keys.added.md
+++ b/changelog.d/rpg2k-debug-keys.added.md
@@ -1,0 +1,10 @@
+- **RPG2000's Test Play debug keys are implemented.** Holding **Ctrl** ignores
+  collision the same way Through Mode does and suppresses the random-encounter
+  roll; holding **Shift** fast-forwards the current message the same way a
+  C/B press does (complete the reveal, then advance/close once it is fully
+  shown); and **F9** opens a debug menu that lists every switch and variable
+  ten at a time (Left/Right flips between the two, Up/Down moves the cursor,
+  L/R jumps a page, C toggles a switch or opens a signed number editor for a
+  variable). All three are gated on Test Play (`RPG2k#test_play`, see the
+  `--test_play` flag) exactly like the rest of the debug tooling — a released
+  game never sees any of them do anything.

--- a/changelog.d/rpg2k-debug-keys.added.md
+++ b/changelog.d/rpg2k-debug-keys.added.md
@@ -1,10 +1,14 @@
 - **RPG2000's Test Play debug keys are implemented.** Holding **Ctrl** ignores
   collision the same way Through Mode does and suppresses the random-encounter
-  roll; holding **Shift** fast-forwards the current message the same way a
-  C/B press does (complete the reveal, then advance/close once it is fully
-  shown); and **F9** opens a debug menu that lists every switch and variable
+  roll; holding **Shift** fast-forwards the current message's typing the same
+  way a C/B press does, but always waits once the message is fully shown
+  (one paragraph at a time — it never blows through several messages on its
+  own); and **F9** opens a debug menu that lists every switch and variable
   ten at a time (Left/Right flips between the two, Up/Down moves the cursor,
   L/R jumps a page, C toggles a switch or opens a signed number editor for a
   variable). All three are gated on Test Play (`RPG2k#test_play`, see the
   `--test_play` flag) exactly like the rest of the debug tooling — a released
-  game never sees any of them do anything.
+  game never sees any of them do anything. Also wired up in the `--sixel`/
+  `--iterm` terminal backend, which has no real Ctrl/Shift modifiers to read:
+  `T` stands in for Ctrl and `F` for Shift, while `F9` is read directly (the
+  same CSI escape sequence `F12`'s return-to-title already relies on there).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2053,9 +2053,10 @@ Everything below is unverified against the codebase.
   the roll (and the encounter_total accumulation for that step) is skipped
   entirely, exactly like flying or a forced-route step. A same-tile *Event
   Touch* (trigger 2) event does **not** suppress it — only Hero Touch does —
-  covered by a new control case in `scripts/rpg2k_scene_check.rb`. Ctrl
-  during test play disabling encounters is a separate, still-open fact, not
-  addressed by this change.
+  covered by a new control case in `scripts/rpg2k_scene_check.rb`. ✅ Ctrl
+  during test play disabling encounters (a separate fact from this one) is
+  now also implemented — see `Scene::Map#debug_through?`, which the same
+  `#check_random_encounter` early-outs on.
 - **Screen Flash / Character Flash** — only one of each can be active at
   once (a second supersedes, doesn't stack); both are capped to 1/30s
   display while a Battle Animation plays concurrently (the animation's own
@@ -2545,8 +2546,8 @@ not yet verified:
   "Untriaged backlog, from `2k/01_shoshin/011_siyou/`" above (the
   `**Encounter**` bullet). Moving via Set Move Route or Jump already
   suppressed encounters before this pass (the `@player_forced_step` /
-  random-encounters fix above); holding Ctrl in test-play doing the same is
-  a separate, still-open fact.
+  random-encounters fix above); ✅ holding Ctrl in test-play doing the same
+  is now also implemented (`Scene::Map#debug_through?`).
 
 **Move Route / Character Movement command**
 - Only **one pending move route per character** — issuing a second while

--- a/mruby-rgss/src/terminal.cxx
+++ b/mruby-rgss/src/terminal.cxx
@@ -37,6 +37,9 @@ enum Key {
   KEY_A = 4,
   KEY_B = 5,
   KEY_C = 6,
+  KEY_SHIFT = 12,
+  KEY_CTRL = 13,
+  KEY_F9 = 19,
   KEY_F12 = 20,
 };
 
@@ -474,7 +477,8 @@ void terminal_append_legend(std::string& s) {
   // legible on any terminal background -- a dim foreground (SGR 2) was too
   // faint to read on light themes.
   s += "\x1b[K\x1b[7m";
-  s += "Move: Arrows/WASD  OK: Z/Enter/Space  Cancel: X/Esc  A: C  Quit: Q";
+  s += "Move: Arrows/WASD  OK: Z/Enter/Space  Cancel: X/Esc  A: C  Quit: Q  "
+       "Debug(testplay): T=Ctrl F=Shift F9";
   s += "\x1b[0m\r\n";
 }
 
@@ -612,11 +616,12 @@ void terminal_poll(mrb_state* M) {
   for (size_t i = 0; i < buf.size();) {
     const unsigned char c = static_cast<unsigned char>(buf[i]);
     if (c == 0x1b && i + 2 < buf.size() && buf[i + 1] == '[') {
-      // F12 -- RPG_RT's return-to-title hotkey (RGSS::Input::F12, read by
-      // mruby-rpg2k's main_loop) -- arrives as a multi-digit CSI sequence
-      // terminated by '~' (`ESC [ 24 ~` in xterm and its descendants: foot,
-      // alacritty, kitty, gnome-terminal, wezterm, tmux, ...), unlike the
-      // single-letter arrow sequences below.
+      // F9 and F12 -- RPG_RT's debug-menu and return-to-title hotkeys
+      // (RGSS::Input::F9/F12, read by mruby-rpg2k's Scene::Map and main_loop)
+      // -- arrive as a multi-digit CSI sequence terminated by '~' (`ESC [ 20
+      // ~` / `ESC [ 24 ~` in xterm and its descendants: foot, alacritty,
+      // kitty, gnome-terminal, wezterm, tmux, ...), unlike the single-letter
+      // arrow sequences below.
       if (buf[i + 2] >= '0' && buf[i + 2] <= '9') {
         size_t j = i + 2;
         int value = 0;
@@ -625,7 +630,9 @@ void terminal_poll(mrb_state* M) {
           ++j;
         }
         if (j < buf.size() && buf[j] == '~') {
-          if (value == 24)
+          if (value == 20)
+            hold_key(M, KEY_F9, now);
+          else if (value == 24)
             hold_key(M, KEY_F12, now);
           i = j + 1;
         } else {
@@ -688,6 +695,25 @@ void terminal_poll(mrb_state* M) {
       case 'c':
       case 'C':
         hold_key(M, KEY_A, now);
+        break;
+      // A raw terminal cannot tell a genuine Ctrl/Shift modifier apart from
+      // an ordinary keypress for most of these bindings (Ctrl-<letter> is
+      // already its own control byte -- Ctrl-C above is bound to quit -- and
+      // Shift-<letter> only changes case, already treated the same as
+      // unshifted throughout this switch), so Ctrl and Shift's *held* debug
+      // behaviour (RGSS::Input::CTRL / SHIFT, see mruby-rpg2k's
+      // Scene::Map#debug_through? and #drive_text_message) gets its own
+      // dedicated key here instead, following the same hold-to-repeat model
+      // as the movement keys above (the terminal's own auto-repeat, plus
+      // hold_key's HOLD_MS grace window, are what make "held" work at all in
+      // a backend with no key-release events).
+      case 't':
+      case 'T':
+        hold_key(M, KEY_CTRL, now);
+        break;
+      case 'f':
+      case 'F':
+        hold_key(M, KEY_SHIFT, now);
         break;
       case 'q':
       case 0x03:  // 'q' or Ctrl-C = quit

--- a/mruby-rpg2k/mrblib/scene/debug_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/debug_menu.rb
@@ -1,0 +1,255 @@
+class RPG2k
+  module Scene
+    # RPG_RT's F9 debug menu (see Scene::Map#try_open_debug_menu -- Test Play
+    # only, opened from the field map). Two flip-able pages, Switch and
+    # Variable, each listing ten ids at a time: Left/Right flips between the
+    # two pages, Up/Down moves the cursor by one row (scrolling into the
+    # neighbouring block of ten at either edge), L/R jumps a full block of ten,
+    # C acts on the selected row (toggle a switch instantly, or open a signed
+    # number editor for a variable) and B closes the menu.
+    #
+    # The id range shown extends to cover every switch/variable the project
+    # actually names (its LDB "switch"/"variable" tables, chunks 23/24 --
+    # `db.switch[id].name` / `db.variable[id].name`) or has already set a
+    # value for this session, with a floor of FLOOR_ID ids so an unauthored
+    # game still has something to browse and toggle. RPG2000 itself has no
+    # fixed switch/variable count for this menu to reproduce -- Control
+    # Switches/Variables accepts any id -- so this is a practical window onto
+    # the ids in play rather than a claim about an engine cap.
+    class DebugMenu < Base
+      SCREEN_W = RPG2k::WIDTH
+      SCREEN_H = RPG2k::HEIGHT
+      PAGE_SIZE = 10
+      LINE_H = 16
+      NAME_COL_W = 208
+      FLOOR_ID = 100
+
+      def initialize(parent, state)
+        super parent
+        @state = state
+        @skin = make_windowskin
+        @background = build_field_background(@skin)
+        @mode = :switch
+        @page = 0
+        @cursor = 0
+        @editor = nil
+        build_window
+      end
+
+      def dispose
+        close_editor
+        @background.dispose if @background
+        @window.dispose if @window
+      end
+
+      def update
+        return update_editor if @editor
+        if Input.trigger?(Input::B)
+          @parent.pop
+        elsif Input.trigger?(Input::LEFT) || Input.trigger?(Input::RIGHT)
+          @mode = @mode == :switch ? :variable : :switch
+          @page = 0
+          @cursor = 0
+          refresh
+        elsif Input.trigger?(Input::DOWN)
+          move_cursor(1)
+        elsif Input.trigger?(Input::UP)
+          move_cursor(-1)
+        elsif Input.trigger?(Input::R)
+          turn_page(1)
+        elsif Input.trigger?(Input::L)
+          turn_page(-1)
+        elsif Input.trigger?(Input::C)
+          activate_row
+        end
+      end
+
+      private
+
+      def max_page
+        (max_id - 1) / PAGE_SIZE
+      end
+
+      def move_cursor(delta)
+        n = @cursor + delta
+        if n.negative?
+          return if @page.zero?
+          @page -= 1
+          n = PAGE_SIZE - 1
+        elsif n >= PAGE_SIZE
+          return if @page >= max_page
+          @page += 1
+          n = 0
+        end
+        @cursor = n
+        refresh
+      end
+
+      def turn_page(delta)
+        p = @page + delta
+        return if p.negative? || p > max_page
+        @page = p
+        @cursor = 0
+        refresh
+      end
+
+      def current_id
+        @page * PAGE_SIZE + @cursor + 1
+      end
+
+      def max_id
+        table = @mode == :switch ? db.switch : db.variable
+        values = @mode == :switch ? @state.switches : @state.variables
+        ids = [FLOOR_ID]
+        # A project that never named a switch/variable in the editor (or, in
+        # RPG2000, one where the switch/variable chunk was simply never
+        # written) has no `db.switch`/`db.variable` table at all -- LCF.to_rb
+        # falls back to the schema default for an absent chunk, and chunks 23
+        # / 24 carry none (see mruby-lcf/mrblib/schema.rb), so it comes back
+        # nil rather than an empty table.
+        table.each { |id, _| ids << id } if table
+        values.to_h.each { |id, _| ids << id }
+        ids.max
+      end
+
+      def activate_row
+        id = current_id
+        if @mode == :switch
+          @state.switches[id] = !@state.switches[id]
+          refresh
+        else
+          open_editor(id)
+        end
+      end
+
+      def row_name(id)
+        table = @mode == :switch ? db.switch : db.variable
+        row = table && table[id]
+        name = row && row.respond_to?(:name) ? row.name : nil
+        name.nil? ? '' : name
+      end
+
+      def row_value_text(id)
+        @mode == :switch ? (@state.switches[id] ? 'ON' : 'OFF') : @state.variables[id].to_s
+      end
+
+      # Zero-padded to (at least) 4 digits, e.g. 7 -> "0007", 12345 -> "12345".
+      # No String#% / Kernel#sprintf here -- mruby-rpg2k does not depend on
+      # mruby-sprintf, and this is the only place that would need it.
+      def id_label(id)
+        s = id.to_s
+        s = '0' + s while s.length < 4
+        s
+      end
+
+      def build_window
+        w = SCREEN_W - 32
+        h = (PAGE_SIZE + 1) * LINE_H + Window::BORDER * 2
+        @window = Window.new(16, 16, w, h)
+        @window.z = 400
+        @window.windowskin = @skin
+        @contents = Bitmap.new(w - Window::BORDER * 2, (PAGE_SIZE + 1) * LINE_H)
+        @window.contents = @contents
+        refresh
+      end
+
+      def refresh
+        return unless @contents
+        @contents.clear
+        @contents.font.color = Color.new(255, 255, 255, 255)
+        title = @mode == :switch ? 'Switch' : 'Variable'
+        first = @page * PAGE_SIZE + 1
+        last = [first + PAGE_SIZE - 1, max_id].min
+        @contents.draw_text 0, 0, @contents.width, LINE_H,
+                            "#{title}  [#{id_label(first)}-#{id_label(last)}]"
+        (0...PAGE_SIZE).each do |i|
+          id = first + i
+          break if id > max_id
+          y = (i + 1) * LINE_H
+          @contents.draw_text 0, y, NAME_COL_W, LINE_H, "#{id_label(id)}:#{row_name(id)}"
+          @contents.draw_text NAME_COL_W, y, @contents.width - NAME_COL_W, LINE_H,
+                              row_value_text(id), 2
+        end
+        @window.cursor_rect = Rect.new(0, (@cursor + 1) * LINE_H, @contents.width, LINE_H)
+      end
+
+      # -- Variable value editor, opened by C on a Variable row ----------------
+
+      EDITOR_DIGITS = 6 # 999,999 -- Game::Variables::MAX/MIN
+
+      def open_editor(id)
+        v = @state.variables[id]
+        @editor = { id: id, negative: v.negative?, digits: digits_of(v.abs), cursor: 0 }
+        build_editor_window
+      end
+
+      # EDITOR_DIGITS-long digit array (most significant first) for a
+      # non-negative value, e.g. digits_of(7) -> [0, 0, 0, 0, 0, 7]. No
+      # String#chars/#rjust here, for the same reason as #id_label above.
+      def digits_of(value)
+        ds = Array.new(EDITOR_DIGITS, 0)
+        (EDITOR_DIGITS - 1).downto(0) do |i|
+          ds[i] = value % 10
+          value /= 10
+        end
+        ds
+      end
+
+      def editor_value
+        v = @editor[:digits].reduce(0) { |a, d| a * 10 + d }
+        @editor[:negative] ? -v : v
+      end
+
+      def build_editor_window
+        w = (EDITOR_DIGITS + 1) * 12 + Window::BORDER * 2
+        h = LINE_H + Window::BORDER * 2
+        @editor_window = Window.new((SCREEN_W - w) / 2, (SCREEN_H - h) / 2, w, h)
+        @editor_window.z = 410
+        @editor_window.windowskin = @skin
+        @editor_contents = Bitmap.new(w - Window::BORDER * 2, LINE_H)
+        @editor_window.contents = @editor_contents
+        refresh_editor
+      end
+
+      def refresh_editor
+        c = @editor_contents
+        c.clear
+        c.font.color = Color.new(255, 255, 255, 255)
+        sign = @editor[:negative] ? '-' : '+'
+        c.draw_text 0, 0, c.width, LINE_H, sign + @editor[:digits].join, 1
+      end
+
+      def update_editor
+        cells = EDITOR_DIGITS + 1 # the sign occupies cell 0, digits follow
+        if Input.trigger?(Input::B)
+          close_editor
+        elsif Input.trigger?(Input::C)
+          @state.variables[@editor[:id]] = editor_value
+          close_editor
+          refresh
+        elsif Input.trigger?(Input::LEFT)
+          @editor[:cursor] -= 1 if @editor[:cursor].positive?
+        elsif Input.trigger?(Input::RIGHT)
+          @editor[:cursor] += 1 if @editor[:cursor] < cells - 1
+        elsif Input.trigger?(Input::UP) || Input.trigger?(Input::DOWN)
+          up = Input.trigger?(Input::UP)
+          if @editor[:cursor].zero?
+            @editor[:negative] = !@editor[:negative]
+          else
+            di = @editor[:cursor] - 1
+            @editor[:digits][di] = (@editor[:digits][di] + (up ? 1 : 9)) % 10
+          end
+        end
+        refresh_editor if @editor
+      end
+
+      def close_editor
+        return unless @editor
+        @editor_window.dispose if @editor_window
+        @editor_window = nil
+        @editor_contents = nil
+        @editor = nil
+      end
+    end
+  end
+end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5964,13 +5964,16 @@ class RPG2k
 
       def drive_text_message
         reveal = @message[:reveal]
-        # Holding Shift during Test Play fast-forwards dialogue: same effect a
-        # C/B tap already has (complete the current reveal, then advance past
-        # a finished message), but held down instead of tapped. Gated on
-        # RPG2k#test_play the same way #debug_through? is, so a released game
-        # never sees it.
-        pressed = Input.trigger?(Input::C) || Input.trigger?(Input::B) ||
-                  (@parent.test_play && Input.press?(Input::SHIFT))
+        confirm = Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        # Holding Shift during Test Play fast-forwards dialogue *while it is
+        # still typing* -- same effect a C/B tap already has there (complete
+        # the current reveal, releasing any inline `\!`/`\.`/`\|` pause along
+        # the way). Once the whole message is shown, though, it always waits
+        # for an actual confirm below, the same as with no Shift held: Shift
+        # speeds up one paragraph's reveal, it does not blow through
+        # paragraph after paragraph on its own. Gated on RPG2k#test_play the
+        # same way #debug_through? is, so a released game never sees it.
+        fast_forward = confirm || (@parent.test_play && Input.press?(Input::SHIFT))
         unless reveal.done?
           pause = reveal.pending_pause
           # The blinking pause arrow only stands for a player-input wait
@@ -5978,8 +5981,8 @@ class RPG2k
           # `\.` / `\|` holds, which clear on their own.
           @message[:window].pause = pause ? pause[:kind] == :key : false
           if pause
-            drive_message_pause(reveal, pause, pressed)
-          elsif pressed
+            drive_message_pause(reveal, pause, fast_forward)
+          elsif fast_forward
             reveal.reveal_all
           else
             reveal.advance(MSG_REVEAL_SPEED)
@@ -5988,7 +5991,7 @@ class RPG2k
           return
         end
         # `\^` closes the finished window on its own; otherwise wait for a button.
-        if reveal.auto_close? || pressed
+        if reveal.auto_close? || confirm
           followup = @interpreter.message_followup
           if followup
             # A Show Choices / Input Number immediately follows this Show Text:

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -296,6 +296,7 @@ class RPG2k
             # otherwise it falls through to the usual event trigger.
             try_action_trigger unless try_board_vehicle
             try_open_menu
+            try_open_debug_menu
           end
         end
         animate_events
@@ -2624,6 +2625,18 @@ class RPG2k
         return unless @state.menu_access
         return unless Input.trigger?(Input::B)
         @parent.push Scene::Menu.new(@parent, @state)
+      end
+
+      # RPG_RT's F9 debug menu: a switch/variable viewer-editor, reachable from
+      # the field map only (not while an event holds the interpreter) and only
+      # during Test Play -- a released game (RPG2k#test_play false) never sees
+      # F9 open anything, same as every other test-play-gated tool (see
+      # changelog.d/test-play-gated-debug-tooling.added.md).
+      def try_open_debug_menu
+        return if event_busy?
+        return unless @parent.test_play
+        return unless Input.trigger?(Input::F9)
+        @parent.push Scene::DebugMenu.new(@parent, @state)
       end
 
       def drive_event
@@ -5951,7 +5964,13 @@ class RPG2k
 
       def drive_text_message
         reveal = @message[:reveal]
-        pressed = Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        # Holding Shift during Test Play fast-forwards dialogue: same effect a
+        # C/B tap already has (complete the current reveal, then advance past
+        # a finished message), but held down instead of tapped. Gated on
+        # RPG2k#test_play the same way #debug_through? is, so a released game
+        # never sees it.
+        pressed = Input.trigger?(Input::C) || Input.trigger?(Input::B) ||
+                  (@parent.test_play && Input.press?(Input::SHIFT))
         unless reveal.done?
           pause = reveal.pending_pause
           # The blinking pause arrow only stands for a player-input wait
@@ -6167,8 +6186,9 @@ class RPG2k
           # Through Mode (see @player_through) bypasses collision the same way
           # it does for an event's own #char_passable? -- touch triggers still
           # fire above regardless, since through-ness is purely a collision
-          # bypass, not a trigger suppression.
-          return unless @player_through || passable?(nx, ny, dir)
+          # bypass, not a trigger suppression. Holding Ctrl during Test Play
+          # (see #debug_through?) does the same.
+          return unless @player_through || debug_through? || passable?(nx, ny, dir)
         end
 
         @dest_x = nx
@@ -6275,6 +6295,17 @@ class RPG2k
         ts.size < tag || (ts[tag - 1] || 0) != 0
       end
 
+      # RPG_RT's own debug walk: holding Ctrl while Test Play is running (see
+      # RPG2k#test_play) ignores collision the same way Through Mode does (see
+      # #step_movement) and, below, suppresses random encounters outright --
+      # released games never run with test_play true, so neither effect can
+      # reach them. Matches EasyRPG's reverse-engineered behaviour
+      # (Game_Player::UpdateNextMovementAction / UpdateEncounterSteps: both
+      # gated on `Player::debug_flag && Input::IsPressed(Input::DEBUG_THROUGH)`).
+      def debug_through?
+        @parent.test_play && Input.press?(Input::CTRL)
+      end
+
       # One ordinary step's roll for a wandering-monster fight. A hit picks a
       # uniform-random troop from #candidate_troops (an empty list -- a map
       # with no encounter entries reaching this tile -- never interrupts the
@@ -6286,6 +6317,7 @@ class RPG2k
       # @player_forced_step), so the interpreter is always idle here -- no
       # event, common event or forced route can be running underneath it.
       def check_random_encounter
+        return if debug_through?
         return if @state.party.flying?(@state)
         # yado.tk quirk, multiply corroborated: a Hero Touch (trigger 1)
         # event's own tile also answers random encounters -- the party can

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7833,7 +7833,8 @@ check 'Ctrl during Test Play suppresses the random-encounter roll' do
   eq 0, st.encounter_total, 'the accumulator never even started'
 end
 
-check 'holding Shift during Test Play fast-forwards a message the same way a button press does' do
+check 'holding Shift during Test Play fast-forwards a message\'s typing, but still waits ' \
+     'once it is fully shown' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hello'),
@@ -7852,8 +7853,16 @@ check 'holding Shift during Test Play fast-forwards a message the same way a but
   ok reveal.done?, 'holding Shift completed the reveal, like a C/B press'
   ok scene.instance_variable_get(:@message), 'message stays open on the completing frame'
 
-  scene.update # Shift still held: the finished message advances on its own
-  ok !scene.instance_variable_get(:@message), 'message dismissed while Shift stayed down'
+  # Unlike a C/B tap, Shift alone never advances past the now-fully-shown
+  # message -- it waits there (one paragraph at a time) no matter how long
+  # Shift stays held, until an actual confirm arrives.
+  10.times { scene.update }
+  ok scene.instance_variable_get(:@message), 'Shift alone never dismisses a finished message'
+  ok !st.switches[1], 'the interpreter has not resumed past the message yet'
+
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  ok !scene.instance_variable_get(:@message), 'an actual confirm dismisses it'
   5.times { RGSS::Input.reset; scene.update }
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -103,6 +103,7 @@ module RGSS
   # `triggered` (buttons pressed this frame). Defaults to no input.
   module Input
     C = 1; B = 2; UP = 3; DOWN = 4; LEFT = 5; RIGHT = 6; SHIFT = 7
+    CTRL = 8; F9 = 9; L = 10; R = 11
     class << self
       attr_accessor :dir_value, :triggered
     end
@@ -387,9 +388,13 @@ class FakeParent
   # every other check wants -- no tree, so save/teleport/escape all default
   # to Allow.
   attr_accessor :map_tree
+  # Test Play, off by default (a released game): see RPG2k#test_play. A check
+  # that wants Ctrl/Shift/F9's debug behaviour sets this true.
+  attr_accessor :test_play
   def initialize(db, &map_maker)
     @db = db
     @map_tree = nil
+    @test_play = false
     @map_maker = map_maker
     @pushed = []
   end
@@ -469,7 +474,7 @@ end
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
               members: [], terrain_damage: 0, bush_depth: 0,
               airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
-              map_tree: nil)
+              map_tree: nil, test_play: false)
   db = fake_db(common, troop_pages, terrain_damage, bush_depth,
                airship_land: airship_land, airship_pass: airship_pass,
                boat_pass: boat_pass, ship_pass: ship_pass)
@@ -477,6 +482,7 @@ def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: n
   state.map = fake_map(1, events, parallax: parallax)
   parent = fake_parent(db)
   parent.map_tree = map_tree if map_tree
+  parent.test_play = test_play
   RPG2k::Scene::Map.new(parent, state)
 end
 
@@ -7792,6 +7798,152 @@ check 'an encounter-steps of 0 disables random encounters and resets the accumul
   scene.send(:check_random_encounter)
   eq 0, st.encounter_total, 'the accumulator resets rather than piling up while encounters are off'
   ok scene.instance_variable_get(:@battle_ui).nil?
+end
+
+# -- Debug keys (RPG2k#test_play only -- see mruby-rpg2k/mrblib/scene/map.rb
+# #debug_through? and #try_open_debug_menu, and scene/debug_menu.rb) ---------
+
+check 'Ctrl during Test Play walks through a wall no ordinary move could cross' do
+  scene = walled_in_scene({}, [2, 2])
+  scene.parent.test_play = true
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.dir_value = 2 # down
+  RGSS::Input.triggered = [RGSS::Input::CTRL]
+  20.times { scene.update }
+  ok st.y > 2, "Ctrl bypassed collision the same way Through Mode does (y=#{st.y})"
+end
+
+check 'Ctrl only bypasses collision during Test Play -- an ordinary run stays walled in' do
+  scene = walled_in_scene({}, [2, 2]) # test_play defaults false
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.dir_value = 2
+  RGSS::Input.triggered = [RGSS::Input::CTRL]
+  20.times { scene.update }
+  eq 2, st.y, 'a released game never sees Ctrl do anything: the wall holds'
+end
+
+check 'Ctrl during Test Play suppresses the random-encounter roll' do
+  tree = fake_map_tree(1 => FakeEncounterNode.new({ 1 => OpenStruct.new(enemy_group_id: 1) }, 1))
+  scene = new_scene({}, map_tree: tree, test_play: true)
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.triggered = [RGSS::Input::CTRL]
+  scene.send(:check_random_encounter)
+  ok scene.instance_variable_get(:@battle_ui).nil?,
+     'Ctrl held: a guaranteed roll (encount_steps 1, default terrain rate) never fires'
+  eq 0, st.encounter_total, 'the accumulator never even started'
+end
+
+check 'holding Shift during Test Play fast-forwards a message the same way a button press does' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hello'),
+                         ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0])]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5], test_play: true)
+  st = scene.instance_variable_get(:@state)
+
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  ok !reveal.done?, 'text is not fully revealed as soon as it opens'
+
+  RGSS::Input.triggered = [RGSS::Input::SHIFT]
+  scene.update
+  ok reveal.done?, 'holding Shift completed the reveal, like a C/B press'
+  ok scene.instance_variable_get(:@message), 'message stays open on the completing frame'
+
+  scene.update # Shift still held: the finished message advances on its own
+  ok !scene.instance_variable_get(:@message), 'message dismissed while Shift stayed down'
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[1], 'the interpreter resumed and ran the next command'
+end
+
+check 'Shift only fast-forwards messages during Test Play' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hello')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5]) # test_play defaults false
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  RGSS::Input.triggered = [RGSS::Input::SHIFT]
+  scene.update
+  ok !reveal.done?, 'a released game never sees Shift fast-forward the reveal'
+end
+
+check 'F9 opens the debug menu during Test Play, and B returns to the map' do
+  scene = new_scene({}, test_play: true)
+  RGSS::Input.triggered = [RGSS::Input::F9]
+  scene.update
+  pushed = scene.parent.pushed
+  eq 1, pushed.size, 'F9 pushed exactly one scene'
+  ok pushed.first.is_a?(RPG2k::Scene::DebugMenu), 'the pushed scene is the debug menu'
+end
+
+check 'F9 does nothing outside Test Play' do
+  scene = new_scene({}) # test_play defaults false
+  RGSS::Input.triggered = [RGSS::Input::F9]
+  scene.update
+  ok scene.parent.pushed.empty?, 'a released game never sees F9 open anything'
+end
+
+check 'the debug menu toggles a switch on C and flips to Variable on Left/Right' do
+  st = menu_state
+  st.switches[1] = false
+  scene = menu_scene(RPG2k::Scene::DebugMenu, st)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  ok st.switches[1], 'C toggled switch 1 (the cursor starts on row 1) on'
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  ok !st.switches[1], 'a second C toggles it back off'
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  eq :variable, scene.instance_variable_get(:@mode), 'Left/Right flips to the Variable page'
+end
+
+check 'the debug menu edits a variable through the signed number editor' do
+  st = menu_state
+  st.variables[1] = 5
+  scene = menu_scene(RPG2k::Scene::DebugMenu, st)
+  scene.instance_variable_set(:@mode, :variable)
+  scene.send(:refresh)
+
+  RGSS::Input.triggered = [RGSS::Input::C] # open the editor on variable 1
+  scene.update
+  ok scene.instance_variable_get(:@editor), 'C on a Variable row opens the editor'
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT] # sign cell -> the leftmost digit
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::UP] # that digit 0 -> 1 (5 -> 100005)
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::LEFT] # back to the sign cell
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::UP] # sign -> negative
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm
+  scene.update
+
+  ok !scene.instance_variable_get(:@editor), 'confirming closes the editor'
+  eq(-100_005, st.variables[1], 'the edited, now-negative value landed in the variable')
+end
+
+check 'B cancels the debug menu variable editor without changing the value' do
+  st = menu_state
+  st.variables[1] = 5
+  scene = menu_scene(RPG2k::Scene::DebugMenu, st)
+  scene.instance_variable_set(:@mode, :variable)
+  scene.send(:refresh)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::UP]
+  scene.update # bump a digit, then cancel instead of confirming
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  ok !scene.instance_variable_get(:@editor), 'B closed the editor'
+  eq 5, st.variables[1], 'cancelling left the variable untouched'
 end
 
 check "a troop's terrain_set excludes it from a tile it does not cover" do


### PR DESCRIPTION
Adds support for RPG2000's Test Play debug keys, matching RPG_RT's behavior and gated on the `--test_play` flag so released games never see them.

## Summary
This implements three debug features available only during Test Play:
- **Ctrl**: Ignores collision (like Through Mode) and suppresses random encounters
- **Shift**: Fast-forwards message text reveal (same effect as C/B press, but held down)
- **F9**: Opens a debug menu for viewing and editing switches and variables

## Key Changes

- **New `Scene::DebugMenu` class** (`mruby-rpg2k/mrblib/scene/debug_menu.rb`):
  - Two-page menu (Switch/Variable) showing 10 items per page
  - Left/Right flips between pages, Up/Down moves cursor, L/R jumps a page
  - C toggles switches or opens a signed number editor for variables
  - B closes the menu
  - Dynamically determines max ID from named switches/variables and current state values

- **Scene::Map updates** (`mruby-rpg2k/mrblib/scene/map.rb`):
  - `try_open_debug_menu`: Opens debug menu on F9 during Test Play
  - `debug_through?`: Returns true when Ctrl is held during Test Play
  - `step_movement`: Uses `debug_through?` to bypass collision checks
  - `check_random_encounter`: Early-outs if `debug_through?` is true
  - `drive_text_message`: Checks for Shift hold to fast-forward message reveal

- **Input constants** (`scripts/rpg2k_scene_check.rb`):
  - Added `CTRL = 8`, `F9 = 9`, `L = 10`, `R = 11` to Input module
  - Added `test_play` attribute to FakeParent for test harness

- **Test coverage**: Comprehensive checks for all three debug features, including edge cases (e.g., Ctrl only works during Test Play, F9 does nothing in released games)

- **Documentation**: Updated README and TODO with implementation details

## Implementation Details

The debug menu dynamically calculates the range of switches/variables to display by taking the maximum of:
- A floor of 100 IDs (so even an unedited game has something to browse)
- Any switch/variable explicitly named in the LDB
- Any switch/variable that has been set a value during this session

The variable editor uses a 6-digit signed number interface (±999,999) with cursor navigation and digit manipulation via Up/Down arrows.

All three features respect the `RPG2k#test_play` flag—a released game with `test_play = false` never sees any of these debug tools activate, matching RPG_RT's behavior.

https://claude.ai/code/session_013HhUN3aeGsZVGnk2m5YiQ1