### PR TITLE
rpg2k: a reverse-flagged medicine now inflicts its listed states

### DIFF
--- a/changelog.d/reverse-medicine-inflict.fixed.md
+++ b/changelog.d/reverse-medicine-inflict.fixed.md
@@ -1,0 +1,13 @@
+- **RPG2000 medicines with `reverse_state_effect` set now inflict their
+  listed states instead of doing nothing.** `Game::Party#item_cured_states`
+  only ever handled the cure polarity (the flag unset); the inflict polarity
+  was read backwards at first and then left unbuilt when that got fixed,
+  even though the identical mechanism was already built and tested on the
+  field-skill side (`#skill_inflicted_states`/`#cast_skill`, mirroring the
+  same EasyRPG `reverse_state_effect` branch). `#item_inflicted_states` now
+  mirrors `#item_cured_states` the same way, `#use_medicine` applies it
+  (with RPG_RT's state-crowding-out prune on a landed state, matching
+  `#cast_skill`), and `#item_effective?` offers such an item when the target
+  lacks a state it would inflict. Covered by new
+  `scripts/rpg2k_logic_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -504,12 +504,28 @@ The work below is roughly ordered by the critical path to a walkable game
   (アンチドーテ and ユニコーンの角 name all fifteen states; 気付け薬 /
   ドラゴンブラッド / ドラゴンハート name 戦闘不能 alone, so they are revives)
   and mtf-meido-action four. `reverse_state_effect` is what flips a medicine into
-  *inflicting*, exactly as it does for a skill; nothing in either bed sets it, so
-  that half is left unbuilt rather than guessed at. A fixture check cannot catch
+  *inflicting*, exactly as it does for a skill. A fixture check cannot catch
   a polarity error — it is written to match whatever the code does, and four of
   them encoded the wrong reading quite happily — so
   `rpg2k_testbed_logic_check.rb` now asserts against the **real** item table that
   every curative medicine cures exactly the states it names.
+  ✅ **The inflict half (`reverse_state_effect` set) is now built too**, not
+  guessed at: `Game::Party#item_inflicted_states` mirrors `#item_cured_states`
+  the same way `#skill_inflicted_states` already mirrors `#skill_cured_states`
+  for a field skill — both port the identical EasyRPG `reverse_state_effect`
+  branch (`Item::vExecute` for an item, `Game_Battler::UseSkill` for a skill),
+  and the item side's own doc comment already named the skill side as the
+  reference before this landed. `#use_medicine` inflicts a reverse item's
+  listed states on each target not already carrying them (applying RPG_RT's
+  state-crowding-out prune, `Game::States.prune`, exactly as `#cast_skill`
+  does for a landed skill state) and `#item_effective?` offers such an item
+  when the target lacks a state it would inflict, so the menu does not grey
+  out a poison item on an unafflicted target. No item in either test bed sets
+  the flag, so this is unexercised by `rpg2k_testbed_logic_check.rb`'s
+  real-data sweep — covered instead by new `scripts/rpg2k_logic_check.rb`
+  checks built the same way the mirrored skill-side inflict behaviour already
+  was, confirmed to fail against the pre-fix code (a `NoMethodError` for the
+  missing accessor, then a wrong-effective-flag failure) before the fix.
   The **death state (戦闘不能, id 1)** is **coupled to HP** (EasyRPG's
   `kDeathID`): lethal `change_hp` knocks the actor out and inflicts state 1
   (zeroing HP), a downed actor can't be healed by HP changes, and curing the
@@ -535,7 +551,9 @@ The work below is roughly ordered by the critical path to a walkable game
   Simulated Attack damage floor — Nepheshel runs 850 of them — could kill the
   party and leave the player walking the map with it. Enemies inflict states
   too now, by casting the status skills in their action pattern (see the
-  行動パターン entry below). Still remaining here: the non-reverse item case.
+  行動パターン entry below). ✅ The item polarity gap this line used to flag
+  (items only cured, never inflicted) is closed — see the item `state_set`
+  paragraph above.
   ✅ **A wipe an event's Parallel Process itself causes now reaches Game Over
   too**, matching the foreground half above. `check_game_over` raises the same
   `:game_over` wait regardless of which interpreter calls it, but only

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2451,16 +2451,36 @@ module Game
     # "cures nothing" made every antidote and every revive item in both games
     # inert, in the menu and in a fight alike.
     #
-    # A medicine that really does *inflict* (the flag set) is left unbuilt rather
-    # than guessed at: no item in either bed sets it, so there is nothing to
-    # measure an implementation against.
+    # A medicine that really does *inflict* (the flag set): see
+    # #item_inflicted_states below, which mirrors this the same way
+    # #skill_inflicted_states mirrors #skill_cured_states for a field skill.
     def item_cured_states(it)
       return [] if it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+      item_state_ids(it)
+    end
+
+    # The states item `it` names in its `state_set` (a 0/1 byte per state, index
+    # i -> state id i+1), regardless of polarity. Shared by #item_cured_states
+    # and #item_inflicted_states, mirroring #skill_state_ids.
+    def item_state_ids(it)
       set = it.state_set
       return [] unless set
       out = []
       set.each_index { |i| out.push(i + 1) if set[i] && set[i] != 0 }
       out
+    end
+
+    # The states item `it` inflicts (the reverse case, `reverse_state_effect`
+    # set): the opposite polarity to #item_cured_states, exactly as
+    # #skill_inflicted_states is to #skill_cured_states for a field skill (both
+    # port EasyRPG's identical `reverse_state_effect` branch, `Item::vExecute`
+    # for an item and `Game_Battler::UseSkill` for a skill). No item in either
+    # test bed sets the flag, so this was previously left unbuilt entirely --
+    # unlike the skill side, which already has the mechanism -- even though
+    # using the item this way was reachable and silently did nothing at all.
+    def item_inflicted_states(it)
+      return [] unless it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+      item_state_ids(it)
     end
 
     # 蘇生専用 (`ko_only`): an item that does nothing at all to a target who is
@@ -2512,7 +2532,8 @@ module Game
         return false if ko_only_blocked?(it, actor)
         hp, mp = item_recovery(it, actor)
         (hp > 0 && actor.hp < actor.max_hp) || (mp > 0 && actor.mp < actor.max_mp) ||
-          item_cured_states(it).any? { |s| actor.state?(s) }
+          item_cured_states(it).any? { |s| actor.state?(s) } ||
+          item_inflicted_states(it).any? { |s| !actor.state?(s) }
       when ITEM_SKILL_BOOK
         s = it.skill_id
         !s.nil? && s != 0 && !actor.knows_skill?(s)
@@ -2564,6 +2585,7 @@ module Game
     def use_medicine(it, id, actor)
       targets = it.scope == 1 ? @actors : [actor].compact
       cured = item_cured_states(it)
+      inflicted = item_inflicted_states(it)
       affected = []
       targets.each do |t|
         # A 蘇生専用 item passes over anyone still standing without touching
@@ -2581,6 +2603,20 @@ module Game
             changed = true
           end
         end
+        landed = false
+        inflicted.each do |s|
+          unless t.state?(s)
+            t.add_state(s)
+            changed = true
+            landed = true
+          end
+        end
+        # RPG_RT's crowding-out rule (see Game::States::PRUNE_GAP): a state a
+        # poison item just inflicted may itself immediately push out one
+        # already held, or be pushed out by one already held that outranks it
+        # -- the same prune #cast_skill applies for a skill's own inflicted
+        # states.
+        t.states = Game::States.prune(t.states, state_table) if landed
         hp, mp = item_recovery(it, t)
         before_hp = t.hp
         before_mp = t.mp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3587,16 +3587,35 @@ check 'a heal+cure item counts either the heal or the cure as a use' do
   eq 1, st.party.item_count(5)
 end
 
-check 'a reverse medicine cures nothing: inflicting is deliberately unbuilt' do
-  # The flag flips a medicine from curing to inflicting, the same way it does for
-  # a skill. No item in either test bed sets it, so there is nothing to measure
-  # an implementation of the inflict half against and it is left unbuilt -- but
-  # such an item must not be treated as a cure either.
+check 'a reverse medicine inflicts its listed states instead of curing them' do
+  # The flag flips a medicine from curing to inflicting, the same way it already
+  # does for a field skill (#skill_inflicted_states / #cast_skill) -- the same
+  # EasyRPG reverse_state_effect branch, just on the item side. No item in
+  # either test bed sets it, but the mechanism is the identical, already-tested
+  # one the skill side runs.
   st = item_party({})
   it = fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true)
   eq [], st.party.item_cured_states(it)
+  eq [3], st.party.item_inflicted_states(it)
   eq [3], st.party.item_cured_states(fake_item(type: 6, state_set: [0, 0, 1])),
      'the same row without the flag does cure'
+  eq [], st.party.item_inflicted_states(fake_item(type: 6, state_set: [0, 0, 1])),
+     'and does not also inflict'
+end
+
+check 'a reverse medicine actually inflicts on use, and is greyed out once landed' do
+  items = { 5 => fake_item(type: 6, state_set: [0, 0, 1], reverse_state: true) }
+  st = item_party(items)
+  st.party.gain_item(5, 2)
+  hero = st.party.leader
+  eq false, hero.state?(3)
+  eq true, st.party.item_effective?(5, hero)
+  eq [hero], st.party.use_item(5, hero)
+  eq true, hero.state?(3)                       # inflicted
+  eq 1, st.party.item_count(5)                  # consumed
+  eq false, st.party.item_effective?(5, hero), 'already afflicted -> no longer effective'
+  eq [], st.party.use_item(5, hero)
+  eq 1, st.party.item_count(5), 'a no-op use does not consume another'
 end
 
 check 'field_items includes skill books alongside medicines' do


### PR DESCRIPTION
## Summary

- RPG2000 medicines with `reverse_state_effect` set were doing nothing at all: `Game::Party#item_cured_states` only handled the cure polarity (the flag unset). The inflict polarity was correctly flagged in `docs/TODO.md` as "left unbuilt rather than guessed at" — but the exact mechanism it needed already exists and is tested on the field-skill side (`#skill_inflicted_states`/`#cast_skill`, both porting the same EasyRPG `reverse_state_effect` branch: `Item::vExecute` for an item, `Game_Battler::UseSkill` for a skill).
- Added `Game::Party#item_inflicted_states`, mirroring `#item_cured_states` the same way the skill side already mirrors itself.
- `#use_medicine` now inflicts a reverse item's listed states on each target lacking them, applying RPG_RT's state-crowding-out prune (`Game::States.prune`) on a landed state — the identical step `#cast_skill` already performs for a skill.
- `#item_effective?` now offers such an item when the target lacks a state it would inflict, so the field menu doesn't grey out a poison item on an unafflicted target.
- No item in either test bed (`rpg2k_testbed_logic_check.rb`'s real-data sweep) sets the flag, so this is unexercised there — covered instead by new synthetic `scripts/rpg2k_logic_check.rb` checks, built the same way the mirrored skill-side behaviour already was.
- Updated `docs/TODO.md`'s "Event system" entry to mark the gap ✅, and added a `changelog.d` fragment.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 699 checks passed (0 failures), including the two new checks.
- Confirmed the two new checks fail against the pre-fix code (`git stash` the `game.rb` change): one `NoMethodError` for the missing `item_inflicted_states` accessor, one wrong-effective-flag failure.
- `ruby scripts/rpg2k_scene_check.rb` — 359 checks passed (0 failures), unaffected (no scene-level coverage needed; this is pure `Game::Party` logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VPyuryL5DeTzyQsbZZ62n

---
_Generated by [Claude Code](https://claude.ai/code/session_018VPyuryL5DeTzyQsbZZ62n)_