### PR TITLE
rpg2k: battle BGM plays on encounter, field BGM resumes after

### DIFF
--- a/changelog.d/battle-bgm-play-restore.fixed.md
+++ b/changelog.d/battle-bgm-play-restore.fixed.md
@@ -1,0 +1,28 @@
+- **Entering a fight now plays the database's battle BGM, and leaving one
+  resumes whatever was playing before.** Both the Enemy Encounter event
+  command and a wandering-monster random encounter route through the same
+  `Scene::Map#open_battle`, which never touched the music at all — a fight
+  was silent (or just kept the field track looping) despite `db.system
+  .battle_music` being configured, and `Change System BGM`'s own note in
+  `docs/TODO.md` had flagged "the battle scene's use of a system BGM slot"
+  as simply not built. New `Scene::Map#play_battle_bgm` / `#restore_pre_
+  battle_bgm` mirror the memorize/restore idiom `#play_vehicle_bgm` /
+  `#restore_pre_vehicle_bgm` already use for boarding a boat/ship/airship:
+  `#open_battle` remembers `@state.current_bgm` and plays `battle_music`
+  (name/volume/pitch via the same `music_name`/`music_volume`/`music_tempo`
+  helpers vehicle and title BGM already use) when one is configured, and
+  `#finish_battle` calls the restore once the fight is over — but only on a
+  victory, an allowed escape, or a defeat with a custom `[Defeat]` handler;
+  a game-over defeat skips it, since `Scene::GameOver` plays its own
+  `gameover_music` and the map is never shown again. A game with no
+  `battle_music` set leaves whatever was already playing alone, matching
+  RPG_RT's own no-op on a blank Music struct. Left unaddressed: the victory
+  jingle (`battle_end_music`) and the exact RPG_RT timing of when the field
+  BGM resumes relative to it — that would need the "play a fixed jingle,
+  then resume" sequencing this build's `RGSS::Audio` has no primitive for,
+  so the field track simply resumes immediately once the result window is
+  dismissed rather than after a fanfare. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (an Enemy Encounter plays the
+  configured battle BGM at its own vol/tempo the moment the battle UI opens,
+  and the field BGM that was playing before replays once the fight is won),
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -592,15 +592,42 @@ The work below is roughly ordered by the critical path to a walkable game
   and round-trip through the save; the field menu's Escape / Teleport skill
   types now consume them (see the field-skill-menu entry below) — an event can
   register a destination for a warp spell to use. **Change Encounter Rate**
-  (11740) and **Change System BGM** (10660) record their payloads too — the
-  encounter step rate and per-slot system music overrides — and round-trip
-  through the save, but nothing consumes them yet (the encounter system and
-  battle scene's use of a system BGM slot are not built), so they are modelled
-  for save fidelity like the access flags. **Change System
+  (11740) records its payload too and **is consumed** — see the random-
+  encounter entry below (`Scene::Map#current_encounter_steps`) — while
+  **Change System BGM** (10660) still only round-trips its per-slot overrides
+  through the save (`@state.system_bgm[cmd.param(0)]`) with nothing reading
+  them back yet, so they are modelled for save fidelity like the access
+  flags. **Change System
   SFX** (10670) is now consumed on the map: the choice window plays the cursor
   sound as the selection moves and the decision sound on confirm, resolving a
   Change System SFX override on `Game::State` before the database default
   (`Scene::Map#system_se` / `play_system_se`).
+  ✅ **The battle scene now plays the database's own battle BGM too** —
+  independently of Change System BGM's still-unconsumed override slots.
+  `Scene::Map#open_battle` (both an Enemy Encounter event command and a
+  wandering-monster random encounter route through it) never touched the
+  music at all: a fight started in silence, or just let the field track
+  keep looping, no matter what `db.system.battle_music` named. New
+  `#play_battle_bgm` / `#restore_pre_battle_bgm` mirror the memorize/
+  restore idiom `#play_vehicle_bgm` / `#restore_pre_vehicle_bgm` already use
+  for boarding a boat/ship/airship: `#open_battle` remembers
+  `@state.current_bgm` and plays `battle_music` (via the same
+  `music_name`/`music_volume`/`music_tempo` helpers vehicle and title BGM
+  already use) when one is configured, and `#finish_battle` restores it —
+  but only on a victory, an allowed escape, or a defeat with a custom
+  `[Defeat]` handler; a game-over defeat skips the restore, since
+  `Scene::GameOver` plays its own `gameover_music` and the map is never
+  shown again. A game with no `battle_music` configured leaves whatever was
+  already playing alone, matching RPG_RT's own no-op on a blank Music
+  struct. Left unaddressed: the victory jingle (`battle_end_music`) and
+  RPG_RT's exact timing for when the field BGM resumes relative to it — that
+  needs a "play a fixed jingle, then resume" sequencing this build's
+  `RGSS::Audio` has no primitive for, so the field track resumes immediately
+  once the result window is dismissed rather than after a fanfare. Covered
+  by a new `scripts/rpg2k_scene_check.rb` check (an Enemy Encounter plays
+  the configured battle BGM at its own vol/tempo the moment the battle UI
+  opens, and the field BGM that was playing before replays once the fight
+  is won), confirmed to fail against the pre-fix code before the fix.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1421,6 +1421,41 @@ class RPG2k
         $stderr.puts "[RPG2k] restoring BGM failed: #{e.message}"
       end
 
+      # Play the database's battle BGM (System battle_music) when a fight opens,
+      # remembering the field/vehicle BGM that was playing so
+      # #restore_pre_battle_bgm can bring it back once the fight ends -- the
+      # same memorize/restore idiom #play_vehicle_bgm already uses for
+      # boarding. A game with no battle_music configured (or an unnamed file)
+      # leaves whatever music was already playing alone, matching RPG_RT's own
+      # no-op on an empty Music struct (Game_System::BgmPlay does nothing for
+      # a blank filename).
+      def play_battle_bgm
+        name = music_name(db.system.battle_music)
+        return if name.nil? || name.empty?
+        @pre_battle_bgm = @state.current_bgm
+        vol = music_volume(db.system.battle_music)
+        tempo = music_tempo(db.system.battle_music)
+        RGSS::Audio.bgm_play(name, vol, tempo)
+        @state.current_bgm = { name: name, volume: vol, tempo: tempo }
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] battle BGM failed: #{e.message}"
+      end
+
+      # Restore the BGM that was playing before the fight started. A no-op
+      # when the fight never touched the music (no battle_music configured),
+      # so the field/vehicle track was never interrupted and there is nothing
+      # to bring back -- and when the party is headed to the Game Over screen
+      # instead, which plays its own music and never returns to this map.
+      def restore_pre_battle_bgm
+        bgm = @pre_battle_bgm
+        @pre_battle_bgm = nil
+        return unless bgm && bgm[:name] && !bgm[:name].empty?
+        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
+        @state.current_bgm = bgm
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] restoring BGM after battle failed: #{e.message}"
+      end
+
       # The database System BGM configured for vehicle `type` (boat / ship /
       # airship), or nil when the database has none.
       def vehicle_bgm(type)
@@ -3186,6 +3221,7 @@ class RPG2k
       end
 
       def open_battle(req)
+        play_battle_bgm
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
         foes = troop.members.map { |e| Game::Battle.from_enemy(e) }
@@ -4159,6 +4195,7 @@ class RPG2k
         if game_over
           perform_game_over
         else
+          restore_pre_battle_bgm
           @interpreter.resume_battle(result)
         end
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -226,6 +226,7 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
             airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false)
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
+                           battle_music: OpenStruct.new(file: 'BattleBGM', volume: 70, pitch: 110),
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
                            ship_music: OpenStruct.new(file: 'ShipBGM', volume: 80, pitch: 100),
                            airship_music: OpenStruct.new(file: 'AirBGM', volume: 80, pitch: 100),
@@ -3594,6 +3595,32 @@ check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Vi
   3.times { scene.update }
   ok st.switches[1], 'the Victory handler ran'
   ok !st.switches[2], 'the Escape handler was skipped'
+end
+
+check 'Enemy Encounter scene: battle BGM plays on entry, field BGM resumes after' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 } # the map's own BGM
+  RGSS::Audio.reset_bgm
+  # One update steps the Autorun's interpreter onto the :battle wait; a
+  # second is what actually opens the battle UI (like battle_attack_to_end's
+  # own "a nil ui just means the battle is still opening" allowance above).
+  2.times { scene.update }
+  eq [['BattleBGM', 70, 110]], RGSS::Audio.bgm_calls,
+     'the database battle BGM played, at its configured vol/tempo'
+  eq 'BattleBGM', st.current_bgm[:name], 'and is now the tracked current BGM'
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result
+  scene.update
+  RGSS::Input.triggered = []
+  eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
+     'the field BGM that was playing before the fight replays once it ends'
+  eq 'Field', st.current_bgm[:name]
 end
 
 check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do


### PR DESCRIPTION
## Summary
- The database's System `battle_music` was already parsed (`Game::Interpreter`'s
  "Change Encounter Rate and Change System BGM record their payloads too...
  but nothing consumes them yet" note was stale — Change Encounter Rate is
  in fact consumed elsewhere; battle BGM genuinely wasn't), but
  `Scene::Map#open_battle`/`#finish_battle` never touched it — every fight
  (Enemy Encounter command or a wandering-monster random encounter) started
  and ended in silence relative to the configured battle track.
- New `#play_battle_bgm`/`#restore_pre_battle_bgm` mirror the existing
  `#play_vehicle_bgm`/`#restore_pre_vehicle_bgm` memorize/restore idiom
  (same `music_name`/`music_volume`/`music_tempo` helpers): entering a
  fight remembers whatever field/vehicle track was playing and plays
  `battle_music` (a no-op if unset, matching RPG_RT's no-op on a blank
  Music struct); leaving via victory, an allowed escape, or a defeat with
  a custom `[Defeat]` handler resumes the remembered track.
- A game-over defeat skips the restore, since `Scene::GameOver` plays its
  own configured music instead and the map is never shown again.
- `docs/TODO.md` updated ✅, also correcting the stale "nothing consumes
  them yet" claim with a cross-reference to where Change Encounter Rate is
  actually consumed.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 698 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 360 checks pass (new check:
      battle BGM plays on entry, field BGM resumes after — confirmed to
      fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_