### PR TITLE
rpg2k: a self/all-ally special item can be used from the item menu

### DIFF
--- a/changelog.d/item-menu-special-item-caster.fixed.md
+++ b/changelog.d/item-menu-special-item-caster.fixed.md
@@ -1,0 +1,15 @@
+- **A self/all-ally scope special item (type 9, 特殊) can be used from the
+  item menu now**, instead of silently reporting "It had no effect." every
+  time. `Scene::ItemMenu#choose_item` routed such an item through the same
+  no-prompt path an all-ally medicine uses, calling `apply_item(id, nil)` —
+  which works for a medicine (`Game::Party#use_medicine`'s all-ally branch
+  never reads that argument, pulling the whole party off `@actors` instead)
+  but not for a special item: `#use_special_item` treats its `actor`
+  argument as the *caster* it casts the invoked skill from, and refuses
+  outright when it is `nil` (`return [] unless actor`) before the skill's
+  own scope is ever consulted. Fixed by passing `@state.party.leader`
+  instead, mirroring `Scene::SkillMenu`, which always has a caster selected
+  before it reaches its own no-prompt scopes. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code (recording the `nil` actor `#use_special_item` was called
+  with) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1448,8 +1448,28 @@ The work below is roughly ordered by the critical path to a walkable game
   switch table). A **special item** (type 9, 特殊) invokes the skill named in its
   `skill_id`, with the item standing in for the SP cost — the user pays nothing
   and need not have learnt it, which is what Nepheshel's whole thrown-bomb line
-  is. **Switch skills** (type 3) flip their switch: that is how a Nepheshel
-  player summons and dismisses a companion.
+  is. ✅ **A self/all-ally scope special item is castable from the item menu
+  now too**, not just a single-ally one. `Scene::ItemMenu#choose_item` picked
+  its no-prompt path (`sk.scope == 2 || sk.scope == 4`) the same way it does
+  for an all-ally medicine, and called `apply_item(id, nil)` the same way —
+  but a medicine's all-ally branch never reads that argument
+  (`Game::Party#use_medicine` pulls the whole party off `@actors` instead),
+  while `#use_special_item` treats its `actor` argument as the *caster* it
+  casts the invoked skill from and refuses outright when it is nil
+  (`return [] unless actor`, before the skill's own scope is ever
+  consulted) — so a self- or all-ally-scope special item (a thrown bomb's
+  ally-side counterpart, or a self-buff item) silently did nothing whenever
+  chosen, reporting "It had no effect." even though `#field_usable?` /
+  `#item_effective?` (both keyed off the *skill's* scope, not this dispatch)
+  said it should work. Fixed by passing `@state.party.leader` instead of
+  `nil` for that one branch, mirroring `Scene::SkillMenu`, which always has
+  a caster selected before it ever reaches the no-prompt scopes. The
+  single-ally branch (`prompt_item_target`) was never affected — it already
+  passes the chosen target as `actor`. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code (recording the `nil` actor `#use_special_item` was called
+  with) before the fix. **Switch skills** (type 3) flip their switch: that is
+  how a Nepheshel player summons and dismisses a companion.
 
   What decides usability is the **type**, not the occasion flags, and getting
   that wrong used to leave the battle skill menu **empty in both test beds** —

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -76,7 +76,15 @@ class RPG2k
         elsif it && it.type == Game::Party::ITEM_SPECIAL
           sk = @state.party.db_skill(it.skill_id)
           if sk && (sk.scope == 2 || sk.scope == 4)
-            apply_item(id, nil)
+            # Unlike a medicine (whose all-ally scope needs no actor at all --
+            # #use_medicine reads the whole party off `@actors`, ignoring the
+            # argument), a special item's `actor` argument is the *caster*
+            # #use_special_item casts the skill from (mirroring
+            # Scene::SkillMenu, which always has a caster selected). Passing
+            # nil here left every self/all-ally special item uncastable
+            # through this menu -- #use_special_item's own `return [] unless
+            # actor` guard rejected it before the skill's scope ever mattered.
+            apply_item(id, @state.party.leader)
           else
             prompt_item_target(id)
           end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6936,6 +6936,55 @@ check 'Scene::ItemMenu: the item list and target cursors wrap around' do
   eq 0, scene.instance_variable_get(:@target_index), 'Down from the last ally wraps to the first'
 end
 
+# A party whose only item is a special (type 9) one invoking an all-ally scope
+# skill -- Game::Party's own decision logic (#use_special_item /
+# #field_usable?) is covered by scripts/rpg2k_logic_check.rb; this stub only
+# has to hand the scene something that behaves the same way, so the check
+# below stays about the RGSS wiring (does confirming the item actually cast
+# it, and who as?) rather than repeating that coverage under RGSS stubs.
+class SpecialItemStubParty < MenuStubParty
+  SPECIAL_ID = 40
+
+  attr_reader :use_item_calls
+
+  def initialize
+    super
+    @use_item_calls = []
+  end
+
+  def leader; @actors.first; end
+  def field_items; [[SPECIAL_ID, 3]]; end
+
+  def db_item(id)
+    return nil unless id == SPECIAL_ID
+    OpenStruct.new(name: 'Vial', type: Game::Party::ITEM_SPECIAL, skill_id: 90)
+  end
+
+  def db_skill(id)
+    return nil unless id == 90
+    OpenStruct.new(name: 'Heal All', type: 0, scope: 4) # an all-ally skill
+  end
+
+  # `actor` here is the *caster* #use_special_item casts the skill from (see
+  # the class comment above), not a chosen target -- recorded so the check
+  # can tell a real actor from the nil the pre-fix scene passed.
+  def use_item(id, actor = nil)
+    @use_item_calls << [id, actor]
+    actor ? [actor] : []
+  end
+end
+
+check 'Scene::ItemMenu: an all-ally special item is cast by the party leader, ' \
+      'not left uncastable with no actor at all' do
+  st = Game::State.new(SpecialItemStubParty.new, 1, 0, 0)
+  scene = menu_scene(RPG2k::Scene::ItemMenu, st)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item -- no target prompt
+  scene.update
+  RGSS::Input.triggered = []
+  eq [[SpecialItemStubParty::SPECIAL_ID, st.party.leader]], st.party.use_item_calls,
+     'the party leader casts it, rather than a nil actor #use_special_item rejects outright'
+end
+
 check 'Scene::SkillMenu: the skill list, caster and target cursors wrap around' do
   scene = menu_scene(RPG2k::Scene::SkillMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@skill_index), 'starts on the first skill'


### PR DESCRIPTION
## Summary

- `Scene::ItemMenu#choose_item` routed a scope-2 (self) or scope-4 (all-ally)
  special item (database item type 9, 特殊) through the same no-prompt path
  used for an all-ally medicine, calling `apply_item(id, nil)`.
- That works for a medicine — `Game::Party#use_medicine`'s all-ally branch
  reads the whole party off `@actors` and never looks at the `actor`
  argument — but `#use_special_item` treats its `actor` argument as the
  *caster* it casts the invoked skill from, and refuses outright when it is
  `nil` (`return [] unless actor`), before the skill's own scope is ever
  consulted. So a self- or all-ally-scope special item always reported "It
  had no effect.", even though `#field_usable?` / `#item_effective?` (both
  keyed off the skill's scope, not this dispatch) said it should work.
- Fixed by passing `@state.party.leader` instead of `nil` for that one
  branch, mirroring `Scene::SkillMenu`, which always has a caster selected
  before it ever reaches its own no-prompt scopes. The single-ally branch
  (`prompt_item_target`) was never affected — it already passes the chosen
  target as `actor`.
- `docs/TODO.md` updated (✅) in place next to the existing special-item
  paragraph, and a `changelog.d/` fragment added.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check drives `Scene::ItemMenu` with a
  stub party whose only item is a type-9 special item invoking an all-ally
  skill, confirms it, and asserts `Game::Party#use_item` was called with the
  party leader as caster rather than `nil`.
- Confirmed the new check fails against the pre-fix code (`got [[40, nil]]`)
  and passes with the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 699 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 361 checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSwKk9xFJPZmVVKWYaUxua)_