### PR TITLE
rpg2k: a Change System BGM override for the battle slot now plays

### DIFF
--- a/changelog.d/battle-bgm-system-override.fixed.md
+++ b/changelog.d/battle-bgm-system-override.fixed.md
@@ -1,0 +1,9 @@
+- **Enemy Encounter battles now honour a Change System BGM override for the
+  battle slot.** `Scene::Map#play_battle_bgm` used to always play the
+  database's own System `battle_music`, ignoring a Change System BGM (10660)
+  override the event system already stashed on `Game::State#system_bgm` (slot
+  0 is battle). A new `#battle_bgm` resolves the override first and falls
+  back to the database default, the same override-then-default idiom Change
+  System SFX already gets from `#system_se`. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix
+  code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -612,30 +612,30 @@ The work below is roughly ordered by the critical path to a walkable game
   register a destination for a warp spell to use. **Change Encounter Rate**
   (11740) records its payload too and **is consumed** — see the random-
   encounter entry below (`Scene::Map#current_encounter_steps`) — while
-  **Change System BGM** (10660) still only round-trips its per-slot overrides
-  through the save (`@state.system_bgm[cmd.param(0)]`) with nothing reading
-  them back yet, so they are modelled for save fidelity like the access
-  flags. **Change System
+  **Change System BGM** (10660) round-trips its per-slot overrides through
+  the save (`@state.system_bgm[cmd.param(0)]`); slot 0 (battle) is now read
+  back too (see the battle-BGM paragraph just below), so only the remaining
+  slots (victory / inn / boat / ship / airship / game over) are still
+  save-fidelity-only. **Change System
   SFX** (10670) is now consumed on the map: the choice window plays the cursor
   sound as the selection moves and the decision sound on confirm, resolving a
   Change System SFX override on `Game::State` before the database default
   (`Scene::Map#system_se` / `play_system_se`).
-  ✅ **The battle scene now plays the database's own battle BGM too** —
-  independently of Change System BGM's still-unconsumed override slots.
-  `Scene::Map#open_battle` (both an Enemy Encounter event command and a
-  wandering-monster random encounter route through it) never touched the
-  music at all: a fight started in silence, or just let the field track
-  keep looping, no matter what `db.system.battle_music` named. New
-  `#play_battle_bgm` / `#restore_pre_battle_bgm` mirror the memorize/
+  ✅ **The battle scene now plays the database's own battle BGM too**, and a
+  Change System BGM override for it. `Scene::Map#open_battle` (both an Enemy
+  Encounter event command and a wandering-monster random encounter route
+  through it) never touched the music at all: a fight started in silence, or
+  just let the field track keep looping, no matter what `db.system.battle_music`
+  named. New `#play_battle_bgm` / `#restore_pre_battle_bgm` mirror the memorize/
   restore idiom `#play_vehicle_bgm` / `#restore_pre_vehicle_bgm` already use
   for boarding a boat/ship/airship: `#open_battle` remembers
-  `@state.current_bgm` and plays `battle_music` (via the same
+  `@state.current_bgm` and plays the resolved battle BGM (via the same
   `music_name`/`music_volume`/`music_tempo` helpers vehicle and title BGM
   already use) when one is configured, and `#finish_battle` restores it —
   but only on a victory, an allowed escape, or a defeat with a custom
   `[Defeat]` handler; a game-over defeat skips the restore, since
   `Scene::GameOver` plays its own `gameover_music` and the map is never
-  shown again. A game with no `battle_music` configured leaves whatever was
+  shown again. A game with no battle BGM configured leaves whatever was
   already playing alone, matching RPG_RT's own no-op on a blank Music
   struct. Left unaddressed: the victory jingle (`battle_end_music`) and
   RPG_RT's exact timing for when the field BGM resumes relative to it — that
@@ -646,6 +646,21 @@ The work below is roughly ordered by the critical path to a walkable game
   the configured battle BGM at its own vol/tempo the moment the battle UI
   opens, and the field BGM that was playing before replays once the fight
   is won), confirmed to fail against the pre-fix code before the fix.
+  **A Change System BGM override for the battle slot (slot 0) is now
+  consumed too**: `#play_battle_bgm`'s music source used to be
+  `db.system.battle_music` unconditionally, so an event that ran Change
+  System BGM before a fight silently had no effect on what played — the
+  command stored the override on `@state.system_bgm[0]` and nothing ever
+  read it back, the exact gap this paragraph used to describe. A new
+  `#battle_bgm` resolves the slot-0 override first (name/volume/tempo from
+  the stashed `{name:, volume:, tempo:, ...}` hash) and falls back to the
+  database default otherwise — the identical override-then-default idiom
+  `#system_se` already established for Change System SFX. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a Change System BGM override for
+  slot 0 plays instead of the database `battle_music` the moment the battle
+  UI opens), confirmed to fail against the pre-fix code before the fix. The
+  other System BGM slots (victory / inn / boat / ship / airship / game over)
+  are still save-fidelity-only, per the note above.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2871,9 +2871,11 @@ module Game
     # Change System BGM: override one of the system music slots (battle,
     # victory, inn, ...) selected by param0. The remaining fields carry a Music
     # struct: string = file name, param1 fade-in, param2 volume, param3 tempo,
-    # param4 balance. Stashed in a Game::State slot table; the battle / inn / …
-    # scenes that would play these are not built yet, so this only preserves the
-    # configured music across Save / Continue.
+    # param4 balance. Stashed in a Game::State slot table; Scene::Map's
+    # #battle_bgm reads slot 0 (battle) back out ahead of the database
+    # default, the same override-then-default idiom Change System SFX already
+    # gets. The other slots (victory / inn / ...) still only round-trip
+    # through the save, since nothing plays them yet.
     def do_change_system_bgm(cmd)
       @state.system_bgm[cmd.param(0)] = {
         name: cmd.string, fadein: cmd.param(1), volume: cmd.param(2),

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1421,24 +1421,44 @@ class RPG2k
         $stderr.puts "[RPG2k] restoring BGM failed: #{e.message}"
       end
 
-      # Play the database's battle BGM (System battle_music) when a fight opens,
-      # remembering the field/vehicle BGM that was playing so
-      # #restore_pre_battle_bgm can bring it back once the fight ends -- the
-      # same memorize/restore idiom #play_vehicle_bgm already uses for
-      # boarding. A game with no battle_music configured (or an unnamed file)
-      # leaves whatever music was already playing alone, matching RPG_RT's own
-      # no-op on an empty Music struct (Game_System::BgmPlay does nothing for
-      # a blank filename).
+      # System BGM slot indices, as used by Change System BGM (10660) --
+      # matches the slot 0 = battle reading already documented on the
+      # rpg2k_logic_check.rb coverage for that command.
+      SYSTEM_BGM_BATTLE = 0
+
+      # Play the battle BGM when a fight opens, remembering the field/vehicle
+      # BGM that was playing so #restore_pre_battle_bgm can bring it back once
+      # the fight ends -- the same memorize/restore idiom #play_vehicle_bgm
+      # already uses for boarding. A game with no battle BGM configured (or an
+      # unnamed file) leaves whatever music was already playing alone,
+      # matching RPG_RT's own no-op on an empty Music struct
+      # (Game_System::BgmPlay does nothing for a blank filename).
       def play_battle_bgm
-        name = music_name(db.system.battle_music)
-        return if name.nil? || name.empty?
+        music = battle_bgm
+        return unless music
         @pre_battle_bgm = @state.current_bgm
-        vol = music_volume(db.system.battle_music)
-        tempo = music_tempo(db.system.battle_music)
-        RGSS::Audio.bgm_play(name, vol, tempo)
-        @state.current_bgm = { name: name, volume: vol, tempo: tempo }
+        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
+        @state.current_bgm = music
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle BGM failed: #{e.message}"
+      end
+
+      # The battle BGM to play as { name:, volume:, tempo: }, or nil when
+      # neither source names a file. Prefers a Change System BGM override for
+      # the battle slot over the database's own System battle_music -- the
+      # same override-then-default idiom #system_se already uses for Change
+      # System SFX overrides, extended to BGM now that a battle actually
+      # plays music to override.
+      def battle_bgm
+        ov = @state.system_bgm[SYSTEM_BGM_BATTLE]
+        if ov && ov[:name] && !ov[:name].empty?
+          return { name: ov[:name], volume: ov[:volume] || 100,
+                    tempo: ov[:tempo] || 100 }
+        end
+        name = music_name(db.system.battle_music)
+        return nil if name.nil? || name.empty?
+        { name: name, volume: music_volume(db.system.battle_music),
+          tempo: music_tempo(db.system.battle_music) }
       end
 
       # Restore the BGM that was playing before the fight started. A no-op

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3623,6 +3623,23 @@ check 'Enemy Encounter scene: battle BGM plays on entry, field BGM resumes after
   eq 'Field', st.current_bgm[:name]
 end
 
+check 'Enemy Encounter scene: a Change System BGM battle override beats the database default' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  # System BGM slot 0 is battle -- see the matching rpg2k_logic_check.rb note.
+  st.system_bgm[0] = { name: 'CustomBattle', fadein: 0, volume: 85, tempo: 120,
+                       balance: 50 }
+  RGSS::Audio.reset_bgm
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  eq [['CustomBattle', 85, 120]], RGSS::Audio.bgm_calls,
+     'the Change System BGM override played instead of the database BattleBGM'
+  eq 'CustomBattle', st.current_bgm[:name]
+end
+
 check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Map#play_battle_bgm` always read `db.system.battle_music` directly when a fight opened, ignoring a **Change System BGM** (10660) override for slot 0 (battle) — `Game::Interpreter#do_change_system_bgm` already stashed that override on `Game::State#system_bgm[0]`, but nothing ever read it back, so an event that ran Change System BGM ahead of a fight silently had no effect on what played.
- A new `Scene::Map#battle_bgm` resolves the slot-0 override first (name/volume/tempo from the stashed hash) and falls back to the database default otherwise — the identical override-then-default idiom `#system_se` already established for Change System SFX overrides (`Scene::Map#system_se` / `#play_system_se`).
- Updated the stale comment on `do_change_system_bgm` (it used to say "the battle / inn / … scenes that would play these are not built yet" — battle BGM playback has since shipped) and `docs/TODO.md`'s Event system bullet to reflect that slot 0 is now consumed, while the other System BGM slots (victory / inn / boat / ship / airship / game over) remain save-fidelity-only.
- Added a changelog fragment (`changelog.d/battle-bgm-system-override.fixed.md`).

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: `Enemy Encounter scene: a Change System BGM battle override beats the database default` — sets `st.system_bgm[0]` before a battle opens and asserts the override's name/volume/tempo play instead of the database `BattleBGM`/70/110.
- Confirmed the new check **fails against the pre-fix code** (stashed the `scene/map.rb` change and re-ran: `1 of 362 checks FAILED`) and passes with the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 700 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 362 checks passed.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013fhJEKDS5x9pk6k24cgHTA

---
_Generated by [Claude Code](https://claude.ai/code/session_013fhJEKDS5x9pk6k24cgHTA)_