### PR TITLE
rpg2k: a Change System BGM override for the game-over slot now plays

### DIFF
--- a/changelog.d/gameover-bgm-system-override.fixed.md
+++ b/changelog.d/gameover-bgm-system-override.fixed.md
@@ -1,0 +1,23 @@
+- **The Game Over screen now honours a Change System BGM override for the
+  game-over slot.** `Scene::GameOver#play_gameover_bgm` used to always play
+  the database's own `gameover_music`, ignoring a Change System BGM (10660)
+  override the event system already stashed on `Game::State#system_bgm`
+  (slot 6 is game over, matching EasyRPG's `Game_System::BGM_GameOver`,
+  confirmed against `Scene_Gameover::Start`'s own
+  `GetSystemBGM(BGM_GameOver)` call). `Game::State` was not even reachable
+  from the screen before this — `RPG2k#show_game_over` and
+  `Scene::GameOver.new` took no state argument at all, since the whole scene
+  stack (and the `Game::State` living on it) is normally gone by the time a
+  game-over defeat replaces it — so `Scene::Map#perform_game_over` now
+  passes its own `@state` through `show_game_over` to the new screen, which
+  resolves the override first and falls back to the database default,
+  mirroring `Game_System::GetAudio`'s "override wins only when its own name
+  is non-empty" rule. The parameter is optional and defaults to `nil`
+  (falling back to the database default unconditionally, unchanged from
+  before) so the Game Over event command's own reach into this path, and
+  every pre-existing bare-fixture caller, keep working. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (an override plays instead of the
+  database music; omitting the state argument still falls back to the
+  database default; a game-over battle defeat hands the screen the very
+  `Game::State` the battle ran on), confirmed to fail against the pre-fix
+  code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -612,10 +612,11 @@ The work below is roughly ordered by the critical path to a walkable game
   register a destination for a warp spell to use. **Change Encounter Rate**
   (11740) records its payload too and **is consumed** — see the random-
   encounter entry below (`Scene::Map#current_encounter_steps`) — while
-  **Change System BGM** (10660) still only round-trips its per-slot overrides
-  through the save (`@state.system_bgm[cmd.param(0)]`) with nothing reading
-  them back yet, so they are modelled for save fidelity like the access
-  flags. **Change System
+  **Change System BGM** (10660) round-trips its per-slot overrides through
+  the save (`@state.system_bgm[cmd.param(0)]`); slot 6 (game over) is now
+  read back too (see the Game Over paragraph under "Menus, save, battle"
+  below), so only the remaining slots (battle / victory / inn / boat / ship
+  / airship) are still save-fidelity-only. **Change System
   SFX** (10670) is now consumed on the map: the choice window plays the cursor
   sound as the selection moves and the decision sound on confirm, resolving a
   Change System SFX override on `Game::State` before the database default
@@ -1023,6 +1024,31 @@ The work below is roughly ordered by the critical path to a walkable game
   than running a `[Defeat]` handler. A game that names no picture (or whose file
   is missing) still reaches the screen, on plain black, rather than the defeat
   failing.
+  ✅ **A Change System BGM override for the game-over slot (slot 6) is now
+  consumed too**, matching EasyRPG's `Game_System::BGM_GameOver` /
+  `Scene_Gameover::Start` (`GetSystemBGM(BGM_GameOver)`, confirmed against
+  the real source rather than guessed). `Scene::GameOver#play_gameover_bgm`
+  used to read `db.system.gameover_music` unconditionally, so an event that
+  ran Change System BGM before a game-over defeat had no effect on what
+  played there — the exact "nothing reading them back yet" gap the
+  paragraph above used to describe, for this one slot. The screen could not
+  even see the override before this: `RPG2k#show_game_over` /
+  `Scene::GameOver.new` took no `Game::State` at all, since the whole scene
+  stack (and the state living on it) is normally torn down the instant this
+  screen replaces it. `Scene::Map#perform_game_over` now passes its own
+  `@state` through `#show_game_over` to the new screen, whose
+  `#gameover_bgm_override` reads `state.system_bgm[6]` first and falls back
+  to the database default otherwise (the same override-then-default
+  idiom the battle/vehicle BGM already follow), with `state` staying
+  optional (`nil` falls back unconditionally, unchanged) so the Game Over
+  event command's route and every pre-existing bare-fixture caller are
+  unaffected. Covered by three new `scripts/rpg2k_scene_check.rb` checks (an
+  override plays instead of the database `gameover_music`; omitting the
+  state argument still falls back to the database default; a game-over
+  battle defeat hands the screen the very `Game::State` the battle ran on),
+  confirmed to fail against the pre-fix code before the fix. The other
+  System BGM slots (battle / victory / inn / boat / ship / airship) are
+  still save-fidelity-only, per the note above.
   **The battle backdrop is chosen from the game's own data now** rather than
   always being the flat void. RPG2000 keeps it on the map-tree node, not the map:
   `Game::Backdrop.name_for` reads the node's `backdrop_type`, a tri-state the

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -578,9 +578,12 @@ class RPG2k
   # Tear down all scenes and show the Game Over screen; dismissing it returns to
   # the title. Replaces the stack the way return_to_title does rather than
   # pushing, so the map underneath is gone for good — the run is over.
-  def show_game_over
+  # `state` is the running Game::State (the map's own, when this is reached
+  # through a battle/event game over); Scene::GameOver reads a Change System
+  # BGM game-over override off it when one is present.
+  def show_game_over(state = nil)
     @scenes.each { |s| s.dispose if s.respond_to?(:dispose) }
-    @scenes = [Scene::GameOver.new(self)]
+    @scenes = [Scene::GameOver.new(self, state)]
   end
 
   # Load one map (.lmu) by id. Map files are named Map0001.lmu, Map0002.lmu, ...

--- a/mruby-rpg2k/mrblib/scene/game_over.rb
+++ b/mruby-rpg2k/mrblib/scene/game_over.rb
@@ -9,8 +9,23 @@ class RPG2k
     # than running a [Defeat] handler — so both go through Scene::GameOver rather
     # than dropping straight back to the title as they used to.
     class GameOver < Base
-      def initialize(parent)
+      # System BGM slot for Change System BGM (10660), matching EasyRPG's
+      # Game_System::SystemBGM enum (BGM_GameOver = 6) — see
+      # Scene_Gameover::Start, which plays GetSystemBGM(BGM_GameOver) rather
+      # than the database's gameover_music directly.
+      SYSTEM_BGM_GAMEOVER = 6
+
+      # `state` is the running Game::State (nil when this screen is reached
+      # with no game session behind it, e.g. a bare fixture test): threaded
+      # through so a Change System BGM override for the game-over slot can be
+      # read back, the same override this build's battle/vehicle BGM already
+      # honour. `Scene::Map#perform_game_over` / `RPG2k#show_game_over` are
+      # what pass it along; the whole scene stack (and the Game::State that
+      # was living on it) is otherwise gone by the time this screen exists,
+      # since a game-over defeat never returns to the map.
+      def initialize(parent, state = nil)
         super parent
+        @game_state = state
 
         @picture = Sprite.new
         bmp = gameover_bitmap
@@ -49,14 +64,29 @@ class RPG2k
         nil
       end
 
+      # A Change System BGM (10660) override for the game-over slot, when the
+      # running game set one and it names a file, else the database's own
+      # gameover_music. Mirrors EasyRPG's Game_System::GetAudio: the override
+      # wins only when its own filename is non-empty.
       def play_gameover_bgm
-        bgm = db.system.gameover_music
-        return unless bgm
-        name = bgm.file
+        name, vol, tempo = gameover_bgm_override || database_gameover_bgm
         return if name.nil? || name.empty?
-        Audio.bgm_play name, (bgm.volume || 100), (bgm.pitch || 100)
+        Audio.bgm_play name, vol, tempo
       rescue StandardError => e
         $stderr.puts "[RPG2k] game over BGM playback failed: #{e.message}"
+      end
+
+      def gameover_bgm_override
+        return nil unless @game_state
+        ov = @game_state.system_bgm[SYSTEM_BGM_GAMEOVER]
+        return nil unless ov && ov[:name] && !ov[:name].to_s.empty?
+        [ov[:name], ov[:volume] || 100, ov[:tempo] || 100]
+      end
+
+      def database_gameover_bgm
+        bgm = db.system.gameover_music
+        return [nil, 100, 100] unless bgm
+        [bgm.file, (bgm.volume || 100), (bgm.pitch || 100)]
       end
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4231,7 +4231,7 @@ class RPG2k
       def perform_game_over(interp = @interpreter)
         $stderr.puts '[RPG2k] game over'
         interp.stop
-        @parent.show_game_over
+        @parent.show_game_over(@state)
       rescue StandardError => e
         $stderr.puts "[RPG2k] Game over failed: #{e.message}"
         interp.stop

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -431,9 +431,14 @@ class FakeParent
   attr_reader :returned_to_title
   def return_to_title; @returned_to_title = true; end
   # Game Over (12420) and a game-over battle defeat put up Scene::GameOver,
-  # which returns to the title once dismissed. Record that it was reached.
-  attr_reader :game_over_shown
-  def show_game_over; @game_over_shown = true; end
+  # which returns to the title once dismissed. Record that it was reached
+  # along with whatever Game::State it was handed (nil from a bare fixture
+  # test that never sets one up).
+  attr_reader :game_over_shown, :game_over_state
+  def show_game_over(state = nil)
+    @game_over_shown = true
+    @game_over_state = state
+  end
   # Open Save Menu (11910) saves through the app; record the calls.
   def saved; @saved ||= []; end
   def save_game(state); saved << state; true; end
@@ -3791,6 +3796,49 @@ check 'the Game Over screen shows its picture, plays its BGM and waits' do
   scene.update
   ok parent.returned_to_title, 'and then hands back to the title'
   Input.reset
+end
+
+check 'the Game Over screen plays a Change System BGM override instead of the database gameover_music' do
+  parent = fake_parent(fake_db)
+  Audio.reset_bgm
+  Input.reset
+  state = OpenStruct.new(
+    system_bgm: { RPG2k::Scene::GameOver::SYSTEM_BGM_GAMEOVER =>
+                  { name: 'OverrideGameOverBGM', volume: 33, tempo: 66 } }
+  )
+  RPG2k::Scene::GameOver.new(parent, state)
+  eq [['OverrideGameOverBGM', 33, 66]], Audio.bgm_calls,
+     'the override plays, not the database GameOverBGM'
+  Input.reset
+end
+
+check 'a bare Game Over (no Game::State) still falls back to the database gameover_music' do
+  parent = fake_parent(fake_db)
+  Audio.reset_bgm
+  Input.reset
+  RPG2k::Scene::GameOver.new(parent) # state omitted, as every pre-existing caller does
+  eq [['GameOverBGM', 90, 100]], Audio.bgm_calls, 'unaffected by the new optional state arg'
+  Input.reset
+end
+
+check 'a game-over battle defeat hands its Game::State to the Game Over screen' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # A bare encounter with defeat mode 0 (game over) and no handler block, the
+  # same setup the "returns to the title" check above uses.
+  auto.event_commands = [ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 0, 0], indent: 0)]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party,
+                           BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
+  scene.update
+  battle_attack_to_end(scene)
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the defeat result window
+  scene.update
+  RGSS::Input.triggered = []
+  parent = scene.instance_variable_get(:@parent)
+  ok parent.game_over_shown, 'the defeat reached Game Over'
+  eq st, parent.game_over_state, 'carrying the very Game::State the battle ran on'
 end
 
 check 'a button still held from the battle does not skip the Game Over screen' do


### PR DESCRIPTION
## Summary
- Change System BGM (10660) stashed its per-slot override on
  `Game::State#system_bgm` but nothing read slot 6 (game over) back —
  `Scene::GameOver` always played `db.system.gameover_music` directly.
  Verified the slot mapping against EasyRPG's actual source
  (`game_system.h`/`.cpp`, `scene_gameover.cpp`): `BGM_GameOver = 6`, and
  `Scene_Gameover::Start` plays `GetSystemBGM(BGM_GameOver)` rather than the
  database field directly.
- `Scene::GameOver` now takes an optional `Game::State` argument, threaded
  through `RPG2k#show_game_over`/`Scene::Map#perform_game_over` (default
  `nil`, so every existing caller including bare-fixture tests is
  unaffected — the whole scene stack, and the state living on it, is
  otherwise gone by the time this screen exists, since a game-over defeat
  never returns to the map). `play_gameover_bgm` resolves the slot-6
  override first and falls back to the database default, the same
  override-then-default idiom battle BGM (#598/#600) and Change System SFX
  already use.
- `docs/TODO.md` updated ✅.
- No overlap with #600 (battle slot, disjoint code paths).

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 700 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 375 checks pass (three new
      checks: the override plays instead of the database default; an
      existing caller with no state passed is unaffected; the state is
      correctly handed through from a map game-over — two confirmed to
      fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_