### PR TITLE
rpg2k: a Change System BGM override for boat/ship/airship now plays

### DIFF
--- a/changelog.d/vehicle-bgm-system-override.fixed.md
+++ b/changelog.d/vehicle-bgm-system-override.fixed.md
@@ -1,0 +1,9 @@
+- **Boarding a boat, ship, or airship now honours a Change System BGM
+  override for that vehicle's slot.** `Scene::Map#vehicle_bgm` used to always
+  read the database's own `boat_music`/`ship_music`/`airship_music`, ignoring
+  a Change System BGM (10660) override the event system already stashed on
+  `Game::State#system_bgm` (slots 3/4/5, matching EasyRPG's
+  `Game_System::sys_bgm` enum). It now resolves the override first and falls
+  back to the database default — the same override-then-default idiom Change
+  System SFX already uses. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check, confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -613,10 +613,11 @@ The work below is roughly ordered by the critical path to a walkable game
   (11740) records its payload too and **is consumed** — see the random-
   encounter entry below (`Scene::Map#current_encounter_steps`) — while
   **Change System BGM** (10660) round-trips its per-slot overrides through
-  the save (`@state.system_bgm[cmd.param(0)]`); slot 0 (battle) is now read
-  back too (see the battle-BGM paragraph just below), so only the remaining
-  slots (victory / inn / boat / ship / airship / game over) are still
-  save-fidelity-only. **Change System
+  the save (`@state.system_bgm[cmd.param(0)]`); slot 0 (battle, see the
+  battle-BGM paragraph below) and slots 3-5 (boat / ship / airship, matching
+  EasyRPG's `Game_System::sys_bgm` enum, see the vehicle-boarding paragraph
+  below) are now read back too, so only slots 1/2/6 (victory / inn / game
+  over) are still modelled for save fidelity like the access flags. **Change System
   SFX** (10670) is now consumed on the map: the choice window plays the cursor
   sound as the selection moves and the decision sound on confirm, resolving a
   Change System SFX override on `Game::State` before the database default
@@ -659,8 +660,9 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check (a Change System BGM override for
   slot 0 plays instead of the database `battle_music` the moment the battle
   UI opens), confirmed to fail against the pre-fix code before the fix. The
-  other System BGM slots (victory / inn / boat / ship / airship / game over)
-  are still save-fidelity-only, per the note above.
+  remaining System BGM slots (victory / inn / game over) are still
+  save-fidelity-only, per the note above — boat / ship / airship (slots 3-5)
+  are consumed too, see the vehicle-boarding paragraph below.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the
@@ -1208,7 +1210,23 @@ The work below is roughly ordered by the critical path to a walkable game
   Placed vehicles are **drawn on the map** from their CharSet, the
   ridden one following the party under the hero, and the **airship floats above a
   ground shadow**. Boarding **plays the vehicle's own BGM** (the database System
-  boat / ship / airship music) and disembarking restores the map BGM. **Enter Hero Name**
+  boat / ship / airship music) and disembarking restores the map BGM.
+  ✅ **A Change System BGM override for a vehicle's slot is now honoured
+  too**, ahead of the database default. `Scene::Map#vehicle_bgm` used to read
+  `db.system.send("#{type}_music")` unconditionally, so an event that ran
+  Change System BGM (10660) before boarding had no effect on what played —
+  boat/ship/airship were exactly the "still-unconsumed" slots the paragraph
+  above used to name. `#vehicle_bgm` now resolves `@state.system_bgm[slot]`
+  first (slots 3/4/5 for boat/ship/airship, matching EasyRPG's
+  `Game_System::sys_bgm` enum: Battle 0, Victory 1, Inn 2, Boat 3, Ship 4,
+  Airship 5, GameOver 6) and falls back to the database field otherwise — the
+  same override-then-default idiom Change System SFX already gets from
+  `#system_se`. Covered by a new `scripts/rpg2k_scene_check.rb` check
+  (boarding a boat with a Change System BGM override on slot 3 plays that
+  override instead of the database `boat_music`), confirmed to fail against
+  the pre-fix code before the fix. Battle (slot 0) is consumed too, see the
+  battle-BGM paragraph above; victory / inn / game over (slots 1/2/6) are
+  still save-fidelity-only. **Enter Hero Name**
   (10740) opens a character-entry widget that renames a
   party actor; **Change Level** (10420) / **Change EXP** (10410) honour their
   "show message" flag — a level-up queues one message per level gained, shown

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2868,14 +2868,15 @@ module Game
       @parallax_changed = true
     end
 
-    # Change System BGM: override one of the system music slots (battle,
-    # victory, inn, ...) selected by param0. The remaining fields carry a Music
-    # struct: string = file name, param1 fade-in, param2 volume, param3 tempo,
-    # param4 balance. Stashed in a Game::State slot table; Scene::Map's
-    # #battle_bgm reads slot 0 (battle) back out ahead of the database
-    # default, the same override-then-default idiom Change System SFX already
-    # gets. The other slots (victory / inn / ...) still only round-trip
-    # through the save, since nothing plays them yet.
+    # Change System BGM: override one of the system music slots (0 battle,
+    # 1 victory, 2 inn, 3 boat, 4 ship, 5 airship, 6 game over) selected by
+    # param0. The remaining fields carry a Music struct: string = file name,
+    # param1 fade-in, param2 volume, param3 tempo, param4 balance. Stashed in
+    # a Game::State slot table; Scene::Map's #battle_bgm reads slot 0 (battle)
+    # and #vehicle_bgm reads slots 3-5 (boat/ship/airship) back out ahead of
+    # the database default, the same override-then-default idiom Change
+    # System SFX already gets. Victory (1), inn (2) and game over (6) still
+    # only round-trip through the save, since nothing plays them yet.
     def do_change_system_bgm(cmd)
       @state.system_bgm[cmd.param(0)] = {
         name: cmd.string, fadein: cmd.param(1), volume: cmd.param(2),

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1393,19 +1393,18 @@ class RPG2k
         row.airship_land ? true : false
       end
 
-      # Play the vehicle's own BGM (the database System boat / ship / airship
-      # music), remembering the BGM that was playing so #restore_pre_vehicle_bgm
-      # can bring it back on disembark. A vehicle with no configured BGM leaves
-      # the current music playing.
+      # Play the vehicle's own BGM — a Change System BGM (10660) override for
+      # its slot when one is set, else the database System boat / ship /
+      # airship music — remembering the BGM that was playing so
+      # #restore_pre_vehicle_bgm can bring it back on disembark. A vehicle
+      # with no configured BGM (override or database) leaves the current
+      # music playing.
       def play_vehicle_bgm(type)
         music = vehicle_bgm(type)
-        name = music && music_name(music)
-        return if name.nil? || name.empty?
+        return unless music
         @pre_vehicle_bgm = @state.current_bgm
-        vol = music_volume(music)
-        tempo = music_tempo(music)
-        RGSS::Audio.bgm_play(name, vol, tempo)
-        @state.current_bgm = { name: name, volume: vol, tempo: tempo }
+        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
+        @state.current_bgm = music
       rescue StandardError => e
         $stderr.puts "[RPG2k] vehicle BGM failed: #{e.message}"
       end
@@ -1477,12 +1476,29 @@ class RPG2k
         $stderr.puts "[RPG2k] restoring BGM after battle failed: #{e.message}"
       end
 
-      # The database System BGM configured for vehicle `type` (boat / ship /
-      # airship), or nil when the database has none.
+      # System BGM slot indices for Change System BGM (10660), matching
+      # EasyRPG's Game_System::sys_bgm enum (Battle 0, Victory 1, Inn 2,
+      # Boat 3, Ship 4, Airship 5, GameOver 6) — the boat/ship/airship slots
+      # sit between the ones the battle and game-over BGM already resolve.
+      VEHICLE_SYSTEM_BGM_SLOT = { boat: 3, ship: 4, airship: 5 }.freeze
+
+      # The BGM to play for vehicle `type` as { name:, volume:, tempo: }, or
+      # nil when neither source names a file. Prefers a Change System BGM
+      # override for the vehicle's slot over the database's own boat / ship /
+      # airship music — the same override-then-default idiom #system_se
+      # already uses for Change System SFX.
       def vehicle_bgm(type)
+        slot = VEHICLE_SYSTEM_BGM_SLOT[type]
+        ov = slot && @state.system_bgm[slot]
+        if ov && ov[:name] && !ov[:name].to_s.empty?
+          return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100 }
+        end
         field = "#{type}_music"
         return nil unless @db.system.respond_to?(field)
-        @db.system.send(field)
+        bgm = @db.system.send(field)
+        name = music_name(bgm)
+        return nil if name.nil? || name.empty?
+        { name: name, volume: music_volume(bgm), tempo: music_tempo(bgm) }
       end
 
       # A parsed BGM chunk exposes file / volume / pitch; read them defensively so

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5049,6 +5049,27 @@ check 'boarding plays the vehicle BGM; disembarking restores the map BGM' do
   eq 'Field', st.current_bgm[:name], 'the map BGM resumes on disembark'
 end
 
+check 'boarding a vehicle plays a Change System BGM override instead of the database default' do
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  st.direction = 2
+  # System BGM slot 3 is boat -- see the matching interpreter.rb note.
+  st.system_bgm[3] = { name: 'CustomBoat', fadein: 0, volume: 55, tempo: 90, balance: 50 }
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded
+  eq 'CustomBoat', st.current_bgm[:name], 'the override plays instead of the database BoatBGM'
+  eq 55, st.current_bgm[:volume]
+  eq 90, st.current_bgm[:tempo]
+end
+
 check 'Enemy Encounter scene: the round animates action by action, not at once' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Map#vehicle_bgm` used to read `db.system.send("#{type}_music")` unconditionally when boarding a boat/ship/airship, ignoring a Change System BGM (10660) override the interpreter already stashed on `Game::State#system_bgm[cmd.param(0)]`.
- `#vehicle_bgm` now resolves the override for slots 3/4/5 (boat/ship/airship, matching EasyRPG's `Game_System::sys_bgm` enum: Battle 0, Victory 1, Inn 2, Boat 3, Ship 4, Airship 5, GameOver 6) first, falling back to the database default — the same override-then-default idiom Change System SFX (`#system_se`) and, as of PR #600, the battle slot (`#battle_bgm`) already use.
- Slots 1/2/6 (victory/inn/game over) are untouched by this PR — victory needs a "play a fixed jingle, then resume" primitive that doesn't exist yet, inn's BGM/fade/jingle presentation isn't built at all, and game over is covered separately by PR #601.
- Updated `docs/TODO.md`'s Change System BGM paragraph and the vehicle-boarding paragraph to reflect which slots are now consumed vs. still save-fidelity-only, and a changelog fragment per `changelog.d/README.md`.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: boarding a boat with a Change System BGM override on slot 3 plays that override (name/volume/tempo) instead of the database `boat_music`. Confirmed this check fails against the pre-fix code before applying the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 700 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 374 checks passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4Dr9VWzFCUqutA7fTsKtF)_