### PR TITLE
mz: mz_testbed_check.rb no longer requires a non-empty starting party

### DIFF
--- a/changelog.d/mz-testbed-check-empty-party.fixed.md
+++ b/changelog.d/mz-testbed-check-empty-party.fixed.md
@@ -1,0 +1,8 @@
+- `scripts/mz_testbed_check.rb` no longer fails a real MZ project for shipping
+  an empty `System.partyMembers`. `Game_Party.setupStartingMembers` just
+  filters the list through `$gameActors`, which silently skips an id with no
+  matching actor — an empty array is not a boot hazard, and a real
+  freem.ne.jp game that ships one (its first party member arrives via an
+  intro event's Change Party Member command) boots to `Scene_Title`, New
+  Game and a full map walk with no issue. The check now only requires an
+  `Array`, still flagging a listed id that Actors.json doesn't have.

--- a/scripts/mz_testbed_check.rb
+++ b/scripts/mz_testbed_check.rb
@@ -166,14 +166,24 @@ class Checker
     end
 
     party = system["partyMembers"]
-    if party.is_a?(Array) && !party.empty?
+    # Game_Party.setupStartingMembers just filters this through $gameActors,
+    # which returns null (silently skipped) for an id with no Actors.json
+    # entry — so an empty starting party is not a boot hazard the way a bad
+    # startMapId is: Scene_Title, New Game and a full map walk all work fine
+    # with $gameParty holding zero members, verified against a real game that
+    # ships exactly that (its first party member arrives via an intro event's
+    # Change Party Member command instead of System.json). Still expect an
+    # *array* — Game_Party would throw iterating something else — and still
+    # flag a listed id that Actors.json doesn't have, since that is a real
+    # authoring mistake the engine papers over rather than one it condones.
+    if party.is_a?(Array)
       party.each do |aid|
         expect(entry_at(actors, aid),
                "System.partyMembers references actor #{aid.inspect}, " \
                "which is missing from Actors.json")
       end
     else
-      fail("System.partyMembers must be a non-empty Array (got #{party.inspect})")
+      fail("System.partyMembers must be an Array (got #{party.inspect})")
     end
 
     size = system["tileSize"]


### PR DESCRIPTION
## Summary

- Found alongside the `OES_element_index_uint` gap (see the companion PR) while testing a real freem.ne.jp MZ release against this checker: it ships `System.partyMembers = []` and the checker failed it outright with `System.partyMembers must be a non-empty Array`, even though the real engine boots the title screen, New Game, and a full map walk with zero party members and no issue whatsoever.
- `Game_Party.setupStartingMembers` just filters `partyMembers` through `$gameActors`, which silently skips an id with no matching `Actors.json` entry — an empty array is not a boot hazard the way a bad `startMapId` is (that one genuinely throws, per `Scene_Boot.checkPlayerLocation`). This particular game's first party member arrives via an intro event's Change Party Member command instead of a static `System.json` list, which is a legitimate, common authoring pattern the checker shouldn't reject.
- The check now only requires an `Array` (still throwing on `null`/non-array, which `Game_Party` would choke on), and still flags a listed actor id that `Actors.json` doesn't have, since that's a real authoring mistake the engine papers over rather than one it condones.

## Test plan

- [x] `ruby scripts/mz_testbed_check.rb data/mz-sample` still passes (0 errors, unaffected by this change since the sample bed ships a non-empty party)
- [x] Verified against the real MZ game that surfaced this: 1 error → 0 errors after the fix, while the engine itself booted through New Game and a full map walk both before and after (this checker failure was always a false positive, never a real engine gap)

https://claude.ai/code/session_01SUivjkXeYMNK3dwTY2DHcM


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUivjkXeYMNK3dwTY2DHcM)_