### PR TITLE
rpg2k: a special item invoking Escape/Teleport is castable from the item menu

### DIFF
--- a/changelog.d/special-item-escape-teleport.fixed.md
+++ b/changelog.d/special-item-escape-teleport.fixed.md
@@ -1,0 +1,14 @@
+- **A special item invoking an Escape or Teleport skill is castable from the
+  field Item menu now**, not silently unusable. `Game::Party#field_usable?`
+  called `#field_skill?` with no `Game::State`, so the Escape/Teleport arm
+  always read "unsupported" and such an item never appeared in the list, even
+  with access on and a destination registered. `#field_usable?` / `#field_items`
+  now take an optional `state`, threaded through from `Scene::ItemMenu` exactly
+  as `Scene::SkillMenu` already threads it into `#field_skills`. Casting is
+  free (the item is the cost, mirroring every other special item): new
+  `Game::Party#use_special_escape_item` / `#use_special_teleport_item` reuse
+  `#cast_escape_skill` / `#cast_teleport_skill` via a new `free` flag on each
+  (mirroring `#cast_skill`'s own), and `Scene::ItemMenu` gained a Teleport
+  destination picker mirroring `Scene::SkillMenu`'s. Covered by new
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb` checks,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1597,11 +1597,42 @@ The work below is roughly ordered by the critical path to a walkable game
   with no map or interpreter behind it, so it still cannot tell "this skill is
   legitimately state-gated" from "no menu reaches this skill" on its own, and
   keeps deferring those two types to this note instead of flagging them as
-  unreachable. Left unbuilt still: the battle-time skill variance, and a
-  **special item** (type 9) invoking an Escape/Teleport skill —
-  `#field_usable?` does not thread `Game::State` through to `#field_skill?`
-  the way the field menu does, so such an item (neither test bed has one)
-  would still read as unusable rather than warping.
+  unreachable. Left unbuilt still: the battle-time skill variance.
+  ✅ **A special item (type 9) invoking an Escape/Teleport skill is castable
+  from the field Item menu now.** `#field_usable?` used to call
+  `#field_skill?(db_skill(it.skill_id))` with no `Game::State` at all, so its
+  Escape/Teleport arm (`#escape_skill_available?` / `#teleport_skill_available?`,
+  both `return false unless state`) always read "unsupported" — the exact gap
+  `#field_skills` used to have before it started taking `state`, just never
+  closed on the item side, and Nepheshel and mtf-meido-action both happen to
+  have no such item to have caught it. `#field_usable?` / `#field_items` now
+  take an optional `state`, threaded through the identical way
+  `Scene::SkillMenu` already threads it into `#field_skills`
+  (`Scene::ItemMenu#items` now calls `@state.party.field_items(@state)`).
+  Casting is a new problem `#use_special_item` doesn't solve, though: it
+  invokes `#cast_skill`, which has no notion of a warp destination, and even
+  if it read as usable an Escape/Teleport special item would still do
+  nothing on use. New `Game::Party#use_special_escape_item` /
+  `#use_special_teleport_item` cast through `#cast_escape_skill` /
+  `#cast_teleport_skill` instead — each gained a `free` flag (mirroring
+  `#cast_skill`'s own) so the item pays instead of the caster's SP, and the
+  caster need not know the skill, exactly like every other special item.
+  `Scene::ItemMenu` routes a special item by the *skill's* type the same way
+  `Scene::SkillMenu` already does for an ordinary cast: Escape warps straight
+  to its one registered target with no prompt, Teleport opens a destination
+  picker (a new `:teleport_target` mode, `build_teleport_window` and
+  friends — copied from `Scene::SkillMenu`'s own, since a menu-owned item and
+  a menu-owned skill land in the identical place), and either closes the
+  whole menu stack via `@parent.pop_to_map` rather than showing a "Used on
+  ..." message, matching `Scene::SkillMenu#queue_teleport`. Covered by two
+  new `scripts/rpg2k_logic_check.rb` checks (an Escape/Teleport special item
+  is hidden with no state, gated on access/target exactly like the skill
+  path, and warps for free without spending SP) and three new
+  `scripts/rpg2k_scene_check.rb` checks (the item queues the escape target
+  and closes the menu with no message; the item opens the destination list
+  and queues the chosen one; cancelling the list returns to the item list),
+  all confirmed to fail against the pre-fix code before the fix. Still
+  untested by the real data, since neither test bed has such an item.
   **Dual-wield equipping is done too, the opposite rule to two-handed.** A
   weapon's own *combat* effect (a 二刀流 weapon swinging twice) was read
   already (ADR 0033); what remained was the *actor*-row 二刀流 (`double_hand`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2391,13 +2391,20 @@ module Game
     # thrown bomb. That is what keeps Nepheshel's 火炎玉 out of the field menu —
     # its skill targets an enemy — while 天使の翼, whose skill targets an ally,
     # stays in.
-    def field_usable?(id)
+    #
+    # `state` is optional and threaded straight through to #field_skill? for the
+    # same reason #field_skills takes it: a special item invoking an Escape or
+    # Teleport skill needs `Game::State` to know whether one is actually
+    # available (access flag + a registered target), which a bare item lookup
+    # has no way to answer. Omitting it reads such an item as unusable, exactly
+    # as the old hard-coded "no state" call always did.
+    def field_usable?(id, state = nil)
       it = db_item(id)
       return false unless it && item_count(id) > 0
       case it.type
       when ITEM_MEDICINE, ITEM_SKILL_BOOK, ITEM_SEED then true
       when ITEM_SWITCH then item_field_occasion?(it)
-      when ITEM_SPECIAL then field_skill?(db_skill(it.skill_id))
+      when ITEM_SPECIAL then field_skill?(db_skill(it.skill_id), state)
       else false
       end
     end
@@ -2448,9 +2455,11 @@ module Game
     end
 
     # The bag's field-usable items as `[id, count]` pairs in ascending id order,
-    # for the item menu's list.
-    def field_items
-      @items.keys.sort.select { |id| field_usable?(id) }
+    # for the item menu's list. `state` is optional, passed straight through to
+    # #field_usable? (see there) for a special item invoking an Escape/Teleport
+    # skill.
+    def field_items(state = nil)
+      @items.keys.sort.select { |id| field_usable?(id, state) }
             .map { |id| [id, item_count(id)] }
     end
 
@@ -2596,11 +2605,48 @@ module Game
     # the item taking the place of the SP cost: the user pays nothing and need not
     # have learnt the skill. One is consumed only when the cast actually did
     # something, matching how the other item kinds here refuse to be wasted.
+    #
+    # Only for a skill #cast_skill can express -- one that changes HP/SP or a
+    # status condition. An Escape or Teleport skill returns a warp destination
+    # instead of a set of affected actors, which does not fit this method's
+    # return shape (and needs `Game::State` besides), so those go through
+    # #use_special_escape_item / #use_special_teleport_item instead -- the same
+    # reason a switch item bypasses #use_item for #use_switch_item.
     def use_special_item(it, id, actor)
       return [] unless actor && item_usable_by?(it, actor.id)
       affected = cast_skill(actor, it.skill_id, actor, true)
       lose_item(id, 1) unless affected.empty?
       affected
+    end
+
+    # A special item (特殊) invoking an **Escape**-type skill: consumes the item
+    # and returns the registered escape destination for the caller to warp to
+    # (the same `{map_id:, x:, y:}` shape #cast_escape_skill returns), free —
+    # mirroring #use_special_item's own "the item is the cost" rule via
+    # #cast_escape_skill's `free` flag, so the user need not know the skill and
+    # spends no SP for it. nil when `id` does not name a special item invoking
+    # an Escape skill, `actor` may not use it (#item_usable_by?), or Escape is
+    # not currently available (#escape_skill_available?) — and then nothing is
+    # consumed, mirroring `Scene::SkillMenu#apply_escape_skill`'s own gate.
+    def use_special_escape_item(id, actor, state)
+      it = db_item(id)
+      return nil unless it && it.type == ITEM_SPECIAL && actor && item_usable_by?(it, actor.id)
+      target = cast_escape_skill(actor, it.skill_id, state, true)
+      return nil unless target
+      lose_item(id, 1)
+      target
+    end
+
+    # The same for a special item invoking a **Teleport**-type skill, to the
+    # registered destination named by `map_id` (the caller's own picker chooses
+    # which — see `Scene::SkillMenu`'s teleport list, which this mirrors).
+    def use_special_teleport_item(id, actor, state, map_id)
+      it = db_item(id)
+      return nil unless it && it.type == ITEM_SPECIAL && actor && item_usable_by?(it, actor.id)
+      target = cast_teleport_skill(actor, it.skill_id, state, map_id, true)
+      return nil unless target
+      lose_item(id, 1)
+      target
     end
 
     # A single-target medicine (scope 0) heals `actor`; an all-ally medicine
@@ -2917,13 +2963,19 @@ module Game
     # to, or nil when `sid` is not a castable, available Escape skill. Matches
     # EasyRPG's Scene_Skill, which jumps straight to `Game_Targets`' single
     # escape target with no picker.
-    def cast_escape_skill(caster, sid, state)
+    #
+    # `free`, like #cast_skill's own flag, casts without the knows-it /
+    # can-afford-it gate and without spending SP — used by
+    # #use_special_escape_item for a special item invoking this type, where the
+    # item is the cost.
+    def cast_escape_skill(caster, sid, state, free = false)
       sk = db_skill(sid)
       return nil unless sk && sk.type == SKILL_ESCAPE
-      return nil unless can_cast?(caster, sid) && escape_skill_available?(state)
+      return nil unless (free ? !caster.nil? : can_cast?(caster, sid)) &&
+                         escape_skill_available?(state)
       target = state.escape_target
       return nil unless target
-      caster.change_mp(-skill_cost(sk, caster))
+      caster.change_mp(-skill_cost(sk, caster)) unless free
       { map_id: target[:map_id], x: target[:x], y: target[:y] }
     end
 
@@ -2932,13 +2984,17 @@ module Game
     # `sid` is not a castable, available Teleport skill or `map_id` names no
     # registered target (the picker only offers ids that do, so this is a
     # defensive check rather than one real play can trigger).
-    def cast_teleport_skill(caster, sid, state, map_id)
+    #
+    # `free` mirrors #cast_escape_skill's own flag, for
+    # #use_special_teleport_item.
+    def cast_teleport_skill(caster, sid, state, map_id, free = false)
       sk = db_skill(sid)
       return nil unless sk && sk.type == SKILL_TELEPORT
-      return nil unless can_cast?(caster, sid) && teleport_skill_available?(state)
+      return nil unless (free ? !caster.nil? : can_cast?(caster, sid)) &&
+                         teleport_skill_available?(state)
       target = state.teleport_targets[map_id]
       return nil unless target
-      caster.change_mp(-skill_cost(sk, caster))
+      caster.change_mp(-skill_cost(sk, caster)) unless free
       { map_id: map_id, x: target[:x], y: target[:y] }
     end
 

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -5,9 +5,15 @@ class RPG2k
     # whole party (an all-ally item) or asks which ally to use it on (a
     # single-target item). Using an item consumes one and refreshes the list; an
     # item that would have no effect (everyone already full) is reported and not
-    # consumed. All decision logic lives in Game::Party (field_items / use_item /
-    # item_effective?), which the host harnesses test; this class is the RGSS UI
-    # over it, mirroring Scene::Menu's window/cursor/message helpers.
+    # consumed. A special item invoking an Escape or Teleport skill warps the
+    # party instead, the same as Scene::SkillMenu's own Escape/Teleport skills:
+    # Escape jumps straight to its one registered target, Teleport opens a
+    # picker of every registered destination, and either closes the whole menu
+    # stack rather than showing a "Used on ..." message. All decision logic
+    # lives in Game::Party (field_items / use_item / item_effective? /
+    # use_special_escape_item / use_special_teleport_item), which the host
+    # harnesses test; this class is the RGSS UI over it, mirroring
+    # Scene::Menu's window/cursor/message helpers.
     class ItemMenu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
@@ -17,9 +23,10 @@ class RPG2k
         super parent
         @state = state
         @skin = make_windowskin
-        @mode = :items          # :items list, or :target selection
+        @mode = :items          # :items list, :target selection, or :teleport_target
         @item_index = 0
         @target_index = 0
+        @teleport_index = 0
         @pending_item = nil
         @message = nil
         build_item_window
@@ -29,18 +36,25 @@ class RPG2k
         close_message
         @item_window.dispose if @item_window
         @target_window.dispose if @target_window
+        @teleport_window.dispose if @teleport_window
       end
 
       def update
         return drive_message if @message
-        @mode == :target ? update_target : update_items
+        case @mode
+        when :target then update_target
+        when :teleport_target then update_teleport_target
+        else update_items
+        end
       end
 
       private
 
       # Cached list of [id, count] pairs; invalidated after a use changes counts.
+      # `@state` decides whether a special item invoking an Escape/Teleport
+      # skill belongs in it (see Game::Party#field_items).
       def items
-        @items ||= @state.party.field_items
+        @items ||= @state.party.field_items(@state)
       end
 
       def invalidate_items
@@ -75,7 +89,19 @@ class RPG2k
           apply_switch_item(id)
         elsif it && it.type == Game::Party::ITEM_SPECIAL
           sk = @state.party.db_skill(it.skill_id)
-          if sk && (sk.scope == 2 || sk.scope == 4)
+          if sk && sk.type == Game::Party::SKILL_ESCAPE
+            # Escape has one registered target and no picker -- mirroring
+            # Scene::SkillMenu#apply_escape_skill, a successful cast warps
+            # straight there with no confirmation message.
+            apply_escape_item(id)
+          elsif sk && sk.type == Game::Party::SKILL_TELEPORT
+            # Teleport opens a third list of every registered destination, the
+            # same as Scene::SkillMenu's own teleport picker.
+            @pending_item = id
+            @mode = :teleport_target
+            @teleport_index = 0
+            build_teleport_window
+          elsif sk && (sk.scope == 2 || sk.scope == 4)
             # Unlike a medicine (whose all-ally scope needs no actor at all --
             # #use_medicine reads the whole party off `@actors`, ignoring the
             # argument), a special item's `actor` argument is the *caster*
@@ -109,6 +135,111 @@ class RPG2k
         sid = @state.party.use_switch_item(id)
         @state.switches[sid] = true if sid
         show_message(sid ? "Switch turned on." : "It had no effect.", :used)
+      end
+
+      # A special item invoking an Escape-type skill: cast from the party
+      # leader (mirroring the self/all-ally special-item branch above), free.
+      # A successful cast closes the whole menu stack at once, matching
+      # Scene::SkillMenu#apply_escape_skill -- there is no field-menu message
+      # shown afterwards, since the map that would show it is gone before the
+      # next frame draws.
+      def apply_escape_item(id)
+        target = @state.party.use_special_escape_item(id, @state.party.leader, @state)
+        if target
+          queue_teleport(target)
+        else
+          show_message("It had no effect.")
+        end
+      end
+
+      # The same for a Teleport-type skill, once a destination is chosen from
+      # the list built by #build_teleport_window.
+      def apply_teleport_item(id, map_id)
+        target = @state.party.use_special_teleport_item(id, @state.party.leader, @state, map_id)
+        if target
+          queue_teleport(target)
+        else
+          show_message("It had no effect.")
+        end
+      end
+
+      # Queue the warp for Scene::Map (see Game::State#pending_teleport) and pop
+      # every menu on top of it in one step -- the same shape
+      # Scene::SkillMenu#queue_teleport uses.
+      def queue_teleport(target)
+        @state.pending_teleport = [target[:map_id], target[:x], target[:y], 0]
+        @parent.pop_to_map
+      end
+
+      def update_teleport_target
+        targets = teleport_targets
+        if Input.trigger?(Input::B)
+          leave_teleport_target
+        elsif Input.trigger?(Input::DOWN) && !targets.empty?
+          @teleport_index += 1
+          @teleport_index %= targets.size
+          refresh_teleport_cursor
+        elsif Input.trigger?(Input::UP) && !targets.empty?
+          @teleport_index -= 1
+          @teleport_index %= targets.size
+          refresh_teleport_cursor
+        elsif Input.trigger?(Input::C) && !targets.empty?
+          map_id, = targets[@teleport_index]
+          apply_teleport_item(@pending_item, map_id)
+        end
+      end
+
+      def leave_teleport_target
+        @pending_item = nil
+        @mode = :items
+        if @teleport_window
+          @teleport_window.dispose
+          @teleport_window = nil
+        end
+      end
+
+      # The registered teleport destinations as `[map_id, name]` pairs,
+      # ascending by map id -- see Scene::SkillMenu#teleport_targets, which
+      # this mirrors exactly.
+      def teleport_targets
+        @state.teleport_targets.keys.sort.map { |id| [id, map_display_name(id)] }
+      end
+
+      # A map's editor name for the teleport picker, or its bare id when the
+      # tree carries no name for it -- see Scene::SkillMenu#map_display_name.
+      def map_display_name(map_id)
+        row = map_tree.respond_to?(:map_properties) ? map_tree.map_properties[map_id] : nil
+        name = row && row.respond_to?(:name) ? row.name.to_s : nil
+        name.nil? || name.empty? ? "Map #{map_id}" : name
+      end
+
+      def build_teleport_window
+        @teleport_window.dispose if @teleport_window
+        rows = teleport_targets
+        inner_w = SCREEN_W - Window::BORDER * 2
+        h = [rows.size, 1].max * LINE_H
+        @teleport_window = Window.new(0, SCREEN_H - h - Window::BORDER * 2,
+                                      SCREEN_W, h + Window::BORDER * 2)
+        @teleport_window.z = 450
+        @teleport_window.windowskin = @skin
+        c = Bitmap.new(inner_w, h)
+        c.font.color = Color.new(255, 255, 255, 255)
+        if rows.empty?
+          c.draw_text 0, 0, inner_w, LINE_H, "No destinations"
+        else
+          rows.each_with_index do |(_id, name), i|
+            c.draw_text 0, i * LINE_H, inner_w, LINE_H, name
+          end
+        end
+        @teleport_window.contents = c
+        refresh_teleport_cursor
+      end
+
+      def refresh_teleport_cursor
+        return unless @teleport_window
+        h = teleport_targets.empty? ? 0 : LINE_H
+        @teleport_window.cursor_rect =
+          Rect.new(0, @teleport_index * LINE_H, @teleport_window.contents.width, h)
       end
 
       def update_target

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3802,6 +3802,66 @@ check 'a special item invokes its skill, free of SP and without knowing it' do
   eq 1, st.party.item_count(3), 'one was consumed'
 end
 
+check 'a special item invoking an Escape skill is hidden with no runtime ' \
+      'state, then gated on access/target like the skill itself, and warps ' \
+      'for free without spending an SP the item never had' do
+  # #field_usable? used to call #field_skill? with no `state` at all, so an
+  # item wrapping an Escape/Teleport skill always read unusable -- the same
+  # gap #field_skills used to have before it started threading `state`
+  # through, just never closed on the item side. See docs/TODO.md's "Menu
+  # scene" entry.
+  skills = { 6 => fake_skill(name: 'Scroll of Escape',
+                             type: Game::Party::SKILL_ESCAPE, sp_cost: 4) }
+  items = { 3 => fake_item(type: 9, skill_id: 6, name: 'Scroll') }
+  st = skill_party(skills, items)
+  hero = st.party.actor_by_id(1)
+  ok !hero.knows_skill?(6), 'the item is the cost -- the caster need not know it'
+  st.party.gain_item(3, 2)
+  ok !st.party.field_usable?(3), 'unsupported with no state to gate on'
+  ok st.party.use_special_escape_item(3, hero, nil).nil?, 'and casts nothing'
+  eq 2, st.party.item_count(3), 'nothing consumed'
+  # State present, but access off (the RPG2000 default) and no target set.
+  ok !st.party.field_usable?(3, st)
+  st.escape_access = true
+  ok !st.party.field_usable?(3, st), 'access alone is not enough -- no target yet'
+  st.escape_target = { map_id: 3, x: 4, y: 5, switch_id: nil }
+  ok st.party.field_usable?(3, st)
+  eq [[3, 2]], st.party.field_items(st)
+  before = hero.mp
+  eq({ map_id: 3, x: 4, y: 5 }, st.party.use_special_escape_item(3, hero, st))
+  eq before, hero.mp, 'free -- the item pays, not the caster'
+  eq 1, st.party.item_count(3), 'one was consumed'
+  # Flying bars it even with access and a target set, same as the skill path.
+  st.boarded = :airship
+  ok !st.party.field_usable?(3, st), 'the airship blocks it'
+  ok st.party.use_special_escape_item(3, hero, st).nil?
+  eq 1, st.party.item_count(3), 'and nothing more is consumed by a failed cast'
+end
+
+check 'a special item invoking a Teleport skill offers every registered ' \
+      'destination and warps to the one chosen, for free' do
+  skills = { 7 => fake_skill(name: 'Scroll of Teleport',
+                             type: Game::Party::SKILL_TELEPORT, sp_cost: 3) }
+  items = { 4 => fake_item(type: 9, skill_id: 7, name: 'Scroll') }
+  st = skill_party(skills, items)
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(4, 1)
+  ok !st.party.field_usable?(4, st), 'no destinations registered yet'
+  st.teleport_access = true
+  st.teleport_targets[10] = { x: 1, y: 2, switch_id: nil }
+  st.teleport_targets[5]  = { x: 8, y: 9, switch_id: nil }
+  ok st.party.field_usable?(4, st), 'access plus any target offers it'
+  before = hero.mp
+  eq({ map_id: 5, x: 8, y: 9 }, st.party.use_special_teleport_item(4, hero, st, 5))
+  eq before, hero.mp, 'free -- no SP spent for an item cast'
+  eq 0, st.party.item_count(4), 'consumed'
+  # An id that was never registered casts nothing and consumes nothing --
+  # there is no second one left to consume anyway, so gain one more first.
+  st.party.gain_item(4, 1)
+  ok st.party.use_special_teleport_item(4, hero, st, 999).nil?
+  eq 1, st.party.item_count(4), 'an unregistered destination consumes nothing'
+end
+
 check 'a field heal skill restores HP by the RPG2000 formula and spends SP' do
   # effect = power 20 + physical_rate 0 * atk/20 + magical_rate 40 * spirit 12 /40
   #        = 20 + 0 + 12 = 32

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6858,7 +6858,7 @@ class MenuStubParty
   def initialize
     @actors = [MenuStubActor.new]; @gold = 0; @leader = nil; @revision = 0
   end
-  def field_items; []; end
+  def field_items(_state = nil); []; end
   def field_skills(_actor, _state = nil); []; end
 end
 
@@ -6879,7 +6879,7 @@ class WrapMenuParty < MenuStubParty
     super
     @actors = [MenuStubActor.new, MenuStubActor.new]
   end
-  def field_items; [[1, 3], [2, 1]]; end
+  def field_items(_state = nil); [[1, 3], [2, 1]]; end
   def field_skills(_actor, _state = nil); [[10, 2], [11, 4]]; end
   def db_item(id); OpenStruct.new(name: "Item#{id}"); end
   def db_skill(id); OpenStruct.new(name: "Skill#{id}"); end
@@ -7020,7 +7020,7 @@ class SpecialItemStubParty < MenuStubParty
   end
 
   def leader; @actors.first; end
-  def field_items; [[SPECIAL_ID, 3]]; end
+  def field_items(_state = nil); [[SPECIAL_ID, 3]]; end
 
   def db_item(id)
     return nil unless id == SPECIAL_ID
@@ -7050,6 +7050,125 @@ check 'Scene::ItemMenu: an all-ally special item is cast by the party leader, ' 
   RGSS::Input.triggered = []
   eq [[SpecialItemStubParty::SPECIAL_ID, st.party.leader]], st.party.use_item_calls,
      'the party leader casts it, rather than a nil actor #use_special_item rejects outright'
+end
+
+# A party whose only item is a special (type 9) one invoking either an Escape
+# or a Teleport skill -- Game::Party's own decision logic
+# (#field_usable? / #use_special_escape_item / #use_special_teleport_item) is
+# covered by scripts/rpg2k_logic_check.rb; this stub only has to hand the
+# scene something that behaves the same way, mirroring
+# EscapeTeleportStubParty below for Scene::SkillMenu, so these checks stay
+# about the RGSS wiring (does confirming the item actually warp the party and
+# close the menu stack?) rather than repeating that coverage under RGSS stubs.
+class EscapeTeleportItemStubParty < MenuStubParty
+  ESCAPE_ID = 50
+  TELEPORT_ID = 51
+
+  def field_items(state = nil)
+    return [] unless state
+    rows = []
+    rows << [ESCAPE_ID, 1] if state.escape_access && state.escape_target
+    rows << [TELEPORT_ID, 1] if state.teleport_access && !state.teleport_targets.empty?
+    rows
+  end
+
+  def db_item(id)
+    case id
+    when ESCAPE_ID
+      OpenStruct.new(name: 'Escape Scroll', type: Game::Party::ITEM_SPECIAL, skill_id: 30)
+    when TELEPORT_ID
+      OpenStruct.new(name: 'Warp Scroll', type: Game::Party::ITEM_SPECIAL, skill_id: 31)
+    end
+  end
+
+  def db_skill(id)
+    case id
+    when 30 then OpenStruct.new(name: 'Escape', type: Game::Party::SKILL_ESCAPE)
+    when 31 then OpenStruct.new(name: 'Warp', type: Game::Party::SKILL_TELEPORT)
+    end
+  end
+
+  def use_special_escape_item(id, _actor, state)
+    return nil unless id == ESCAPE_ID && state.escape_target
+    state.escape_target
+  end
+
+  def use_special_teleport_item(id, _actor, state, map_id)
+    return nil unless id == TELEPORT_ID
+    target = state.teleport_targets[map_id]
+    return nil unless target
+    { map_id: map_id, x: target[:x], y: target[:y] }
+  end
+end
+
+def escape_teleport_item_state
+  st = Game::State.new(EscapeTeleportItemStubParty.new, 1, 0, 0)
+  st.escape_access = true
+  st.escape_target = { map_id: 9, x: 1, y: 2, switch_id: nil }
+  st.teleport_access = true
+  st.teleport_targets[10] = { x: 11, y: 12, switch_id: nil }
+  st.teleport_targets[20] = { x: 21, y: 22, switch_id: nil }
+  st
+end
+
+check 'Scene::ItemMenu: a special item invoking Escape queues its target and ' \
+      'closes the menu, with no confirmation message' do
+  parent = fake_parent(fake_db)
+  state = escape_teleport_item_state
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  eq [[EscapeTeleportItemStubParty::ESCAPE_ID, 1],
+      [EscapeTeleportItemStubParty::TELEPORT_ID, 1]], scene.send(:items)
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm the first row, Escape
+  scene.update
+  RGSS::Input.reset
+  eq [9, 1, 2, 0], state.pending_teleport, 'queued straight from the one registered escape target'
+  ok parent.pop_to_map_called, 'the whole menu stack closes rather than staying open'
+  ok scene.instance_variable_get(:@message).nil?, 'no "Used on ..." message, matching Scene::SkillMenu'
+end
+
+check 'Scene::ItemMenu: a special item invoking Teleport opens a destination ' \
+      'list and queues the chosen one' do
+  parent = fake_parent(fake_db)
+  state = escape_teleport_item_state
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the Teleport item (row 2)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
+  scene.update
+  RGSS::Input.reset
+  eq :teleport_target, scene.instance_variable_get(:@mode)
+  eq [[10, 'Map 10'], [20, 'Map 20']], scene.send(:teleport_targets),
+     'both registered destinations, ascending by map id (this fixture parent carries no map tree)'
+  ok state.pending_teleport.nil?, 'opening the list does not warp yet'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the second destination (map 20)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm it
+  scene.update
+  RGSS::Input.reset
+  eq [20, 21, 22, 0], state.pending_teleport
+  ok parent.pop_to_map_called
+end
+
+check 'Scene::ItemMenu: cancelling the Teleport destination list returns to the item list' do
+  parent = fake_parent(fake_db)
+  state = escape_teleport_item_state
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq :teleport_target, scene.instance_variable_get(:@mode)
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  eq :items, scene.instance_variable_get(:@mode)
+  ok state.pending_teleport.nil?
+  ok !parent.pop_to_map_called
 end
 
 check 'Scene::SkillMenu: the skill list, caster and target cursors wrap around' do


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s "Menu scene" entry documented this as a known, unbuilt gap: a special item (type 9, 特殊) invoking an Escape- or Teleport-type skill would always read as unusable in the field Item menu and, even if it somehow got there, would do nothing on use.

Root cause: `Game::Party#field_usable?` called `#field_skill?(db_skill(it.skill_id))` with **no `Game::State`**, so its Escape/Teleport arm (`#escape_skill_available?` / `#teleport_skill_available?`, both `return false unless state`) always read "unsupported" — the same gap `#field_skills` used to have before it started threading `state` through for `Scene::SkillMenu`, just never closed on the item side. Neither Nepheshel nor mtf-meido-action happens to carry such an item, which is why this stayed unnoticed.

## Changes

- `Game::Party#field_usable?` / `#field_items` now take an optional `state`, threaded through to `#field_skill?` exactly as `Scene::SkillMenu` already threads it into `#field_skills`. `Scene::ItemMenu#items` now calls `@state.party.field_items(@state)`.
- `#cast_escape_skill` / `#cast_teleport_skill` gained a `free` flag (mirroring `#cast_skill`'s own), so a special item can invoke them without spending the caster's SP and without the caster knowing the skill — the item is the cost, like every other special item.
- New `Game::Party#use_special_escape_item` / `#use_special_teleport_item`: the generic `#use_item` → `#use_special_item` path invokes `#cast_skill`, which has no notion of a warp destination, so Escape/Teleport special items need their own entry points (the same reason a switch item already bypasses `#use_item` for `#use_switch_item`).
- `Scene::ItemMenu#choose_item` now routes a special item by the *skill's* type: Escape warps straight to its one registered target (no prompt), Teleport opens a new destination picker (`:teleport_target` mode + `build_teleport_window` and friends, copied from `Scene::SkillMenu`'s own picker). Either closes the whole menu stack via `@parent.pop_to_map` rather than showing a "Used on ..." message, matching `Scene::SkillMenu#queue_teleport`.
- `docs/TODO.md`'s "Menu scene" entry and a new changelog fragment document the fix.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 702 checks pass, including two new checks (an Escape/Teleport special item is hidden with no state, gated on access/target exactly like the skill path, and warps for free without spending SP).
- `ruby scripts/rpg2k_scene_check.rb` — 377 checks pass, including three new checks (the item queues the escape target and closes the menu with no message; the item opens the destination list and queues the chosen one; cancelling the list returns to the item list).
- Confirmed all five new checks fail against the pre-fix code (`git stash` the source changes, rerun) before the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCsBkq9xeH9VafgUJzVgQC)_