### PR TITLE
Fix hash literal arguments consumed as kwargs in mruby

### DIFF
--- a/changelog.d/rpg2k-common-event-load-kwarg-hash.fixed.md
+++ b/changelog.d/rpg2k-common-event-load-kwarg-hash.fixed.md
@@ -1,0 +1,22 @@
+- **RPG2000 games granted no starting items/gold and every "Call Event"
+  targeting a common event silently no-op'd**, because
+  `Game::CommonEvent.load` built each entry with a bare `key: value, ...`
+  argument list passed straight to `Array#push`. On this project's mruby
+  build that bare hash literal is consumed as keyword arguments rather than
+  a single positional `Hash`, and since `Array#push` declares no keyword
+  parameters the call silently degenerated to `list.push()` — no exception,
+  but every common event vanished, so any `CALL_EVENT` targeting one
+  resolved to `nil` and did nothing. Confirmed against the freeware game
+  Nepheshel: its opening common event (which grants starting items and gold)
+  never ran, leaving a permanently empty inventory; live tracing showed
+  `CommonEvent.load` iterating 505 entries into a list of size 0 before the
+  fix, and the common event's real commands resolving correctly after it.
+  The same bare-hash-argument pattern also silently dropped every "Change
+  Event Location" and "Trade Event Locations" command
+  (`Game::Interpreter#do_change_event_location` /
+  `#do_trade_event_locations`); both are fixed the same way. All three call
+  sites now wrap the hash literal in explicit braces. A system-Ruby (MRI)
+  unit test of the same loading logic did not reproduce this — MRI accepts
+  the bare hash literal as a single positional argument for a method with no
+  declared keywords — so this was only caught by driving the actual compiled
+  engine.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4159,8 +4159,8 @@ module Game
       ce = db.common_event
       return list unless ce
       ce.each do |id, c|
-        list.push(id: id, trigger: c.start_term, need_flag: c.need_flag,
-                  switch_id: c.switch_id, commands: c.event)
+        list.push({ id: id, trigger: c.start_term, need_flag: c.need_flag,
+                    switch_id: c.switch_id, commands: c.event })
       end
       list
     rescue StandardError => e

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2351,14 +2351,14 @@ module Game
         x = variables[x]
         y = variables[y]
       end
-      @location_requests.push(op: :set, target: cmd.param(0), x: x, y: y)
+      @location_requests.push({ op: :set, target: cmd.param(0), x: x, y: y })
     end
 
     # Trade Event Locations (Swap Event Locations): exchange the tiles of the two
     # characters named by param0 and param1 (same target ids as Change Event
     # Location). Queued as a `:swap` request the scene applies; non-blocking.
     def do_trade_event_locations(cmd)
-      @location_requests.push(op: :swap, a: cmd.param(0), b: cmd.param(1))
+      @location_requests.push({ op: :swap, a: cmd.param(0), b: cmd.param(1) })
     end
 
     # Store Terrain ID: write the terrain id of the tile at (x, y) into the


### PR DESCRIPTION
## Summary

Fixed a critical bug where bare hash literals passed to `Array#push` were being consumed as keyword arguments in mruby, causing silent failures in common event loading and event location commands. The fix wraps hash literals in explicit braces to ensure they're passed as positional Hash arguments.

## Changes

- **CommonEvent.load**: Wrapped hash literal in `Game::CommonEvent.load` with explicit braces when pushing to the list. This fixes the issue where common events were silently dropped, preventing "Call Event" commands from working and blocking initialization events that grant starting items/gold.

- **Interpreter#do_change_event_location**: Wrapped hash literal with explicit braces when pushing location change requests. This ensures "Change Event Location" commands are properly queued.

- **Interpreter#do_trade_event_locations**: Wrapped hash literal with explicit braces when pushing location swap requests. This ensures "Trade Event Locations" commands are properly queued.

## Implementation Details

The root cause was that mruby's `Array#push` method doesn't declare keyword parameters, so bare hash literals (`key: value, ...`) were being interpreted as keyword arguments rather than a single positional Hash argument. This caused the calls to silently degenerate to `push()` with no arguments, resulting in:
- Empty common event lists (505 entries iterated but 0 added)
- Dropped location change/swap commands

By wrapping the hash literals in explicit braces (`{ key: value, ... }`), they're now correctly passed as positional Hash arguments. This issue was only caught when running the compiled mruby engine; system Ruby (MRI) accepts bare hash literals as positional arguments even without explicit braces.

https://claude.ai/code/session_01RVeEb9j6BTJ8FDkYPUbfyu