### PR TITLE
rpg2k: a ridden vehicle now walk-cycles with the party

### DIFF
--- a/changelog.d/vehicle-ridden-walk-cycle.fixed.md
+++ b/changelog.d/vehicle-ridden-walk-cycle.fixed.md
@@ -1,0 +1,13 @@
+- **A ridden boat/ship/airship now walk-cycles with the party** instead of
+  always drawing its standing pose. The vehicle sprite already tracked the
+  party's own pixel position frame for frame while boarded, but
+  `Scene::Map#draw_vehicle_frame` hard-coded the CharSet pattern to 1
+  (standing) regardless — so a sailing boat glided across the water with a
+  frozen paddle. It now reuses the hero's own walk-cycle pattern
+  (`#player_walk_pattern`, factored out of `#draw_player_frame`) whenever the
+  vehicle is ridden, since a boarded vehicle slides in lockstep with the
+  party and so animates on the identical schedule the hero's own sprite
+  would have shown were it not hidden underneath the vehicle's. An unridden
+  vehicle still holds its standing pose — it snaps tile to tile rather than
+  sliding (per the Move Event / Set Move Route vehicle work), so there is no
+  in-tile progress to animate against; that remains a follow-up.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -334,6 +334,26 @@ The work below is roughly ordered by the critical path to a walkable game
   Change Event Location repositioning a vehicle; Proceed With Movement
   waiting on a vehicle route; the Change Graphic override reverting on
   Transfer Player), each confirmed to fail against the pre-fix code.
+  ✅ **A ridden vehicle now walk-cycles with the party**, closing half of the
+  walk-cycle gap the paragraph above flagged. `#draw_vehicle_frame` always
+  passed pattern `1` (the standing frame) to `Game::CharSet.frame_rect`, so a
+  sailing boat's paddle never moved even though its sprite already tracked
+  the party's own pixel position frame for frame (`draw_vehicles`' `ridden ?
+  px : v.x * TILE`) — the position was smooth, the pose was frozen. A boarded
+  vehicle rides the party's own in-tile slide exactly, so the pattern it
+  should show is the identical one the hero's own sprite would have, were it
+  not hidden underneath the vehicle's: `#player_walk_pattern` (factored out
+  of `#draw_player_frame`'s own `@moving ? WALK_PATTERNS[...] : 1`
+  expression) is now read by `#draw_vehicle_frame` too, keyed off whether the
+  vehicle being drawn is the ridden one. An unridden vehicle is untouched —
+  it snaps tile to tile with no in-tile progress to animate, and the
+  paragraph above's other follow-ups (its own smooth interpolation, hero/
+  event collision, and the rest) remain open. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (boarding a boat and sailing it walks
+  the vehicle sprite through the same non-standing pattern index the hero
+  would show, while an unridden vehicle placed on the map keeps its standing
+  pose), confirmed to fail against the pre-fix code (a `NoMethodError` for
+  the not-yet-extracted `#player_walk_pattern`) before the fix.
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6715,19 +6715,25 @@ class RPG2k
           spr.x = sx
           spr.y = sy
           spr.visible = true
-          draw_vehicle_frame(type, v, charset, vehicle_charset_index(v))
+          draw_vehicle_frame(type, v, charset, vehicle_charset_index(v), ridden)
         end
       end
 
-      # Blit the vehicle's CharSet cell into its sprite buffer (standing pattern),
-      # skipping the redraw when the graphic/index/direction haven't changed since
-      # the last frame — mirrors draw_player_frame's @last_frame memo.
-      def draw_vehicle_frame(type, v, charset, index)
-        frame = [index, v.direction, charset.object_id]
+      # Blit the vehicle's CharSet cell into its sprite buffer, skipping the
+      # redraw when the graphic/index/direction/pose haven't changed since the
+      # last frame — mirrors draw_player_frame's @last_frame memo. A *ridden*
+      # vehicle walk-cycles through #player_walk_pattern, the same pattern the
+      # hero's own sprite would show (see that method's comment); an unboarded
+      # one always draws its standing pose 1, since it snaps tile to tile
+      # rather than sliding (see the "Vehicle move-routes" note in
+      # docs/TODO.md) and so has no in-tile progress to animate against.
+      def draw_vehicle_frame(type, v, charset, index, ridden)
+        pat = ridden ? player_walk_pattern : 1
+        frame = [index, v.direction, charset.object_id, pat]
         return if frame == @vehicle_last_frame[type]
         @vehicle_last_frame[type] = frame
 
-        rx, ry, rw, rh = Game::CharSet.frame_rect(index, v.direction, 1)
+        rx, ry, rw, rh = Game::CharSet.frame_rect(index, v.direction, pat)
         bmp = @vehicle_bmps[type]
         bmp.clear
         bmp.blt 0, 0, charset, Rect.new(rx, ry, rw, rh)
@@ -7080,10 +7086,21 @@ class RPG2k
         end
       end
 
+      # The hero's own walk-cycle pattern (RPG2000's 3-frame charset animation,
+      # `Game::CharSet::WALK_PATTERNS` stepping with the in-tile slide) or the
+      # standing pose 1 when not sliding. Shared with #draw_vehicle_frame for a
+      # *ridden* vehicle: a boarded vehicle's sprite tracks the party's own
+      # pixel position frame for frame (#draw_vehicles' `ridden ? px : ...`),
+      # so it walks the identical cycle the hero's own sprite would have shown
+      # were it not hidden underneath the vehicle's.
+      def player_walk_pattern
+        @moving ? Game::CharSet::WALK_PATTERNS[(@move_count / 4) % 4] : 1
+      end
+
       def draw_player_frame
         charset, charset_index = player_draw_charset
         return unless charset
-        pat = @moving ? Game::CharSet::WALK_PATTERNS[(@move_count / 4) % 4] : 1
+        pat = player_walk_pattern
         bush = player_bush_depth
         # The sunken depth is part of the frame key, so walking into and out of
         # tall grass redraws the sprite even though the pose has not changed.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4667,6 +4667,46 @@ check 'the airship floats above a ground shadow; a boat casts none' do
   ok !shadow.visible, 'a boat casts no airship shadow'
 end
 
+check 'a ridden vehicle walk-cycles with the party; an unridden one holds its standing pose' do
+  scene = new_scene({}, player: [0, 0], boat_pass: true)
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  boat.charset_name = 'Boat'
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat ahead (facing down by default)
+  scene.update
+  RGSS::Input.reset
+  eq :boat, st.boarded
+
+  RGSS::Input.dir_value = 2 # hold down -- sail further south
+  scene.update
+  pat = scene.send(:player_walk_pattern)
+  5.times do
+    break if pat != 1
+    scene.update
+    pat = scene.send(:player_walk_pattern)
+  end
+  RGSS::Input.dir_value = 0
+  ok scene.instance_variable_get(:@moving), 'the party (and the boat under it) is mid-slide'
+  ok pat != 1, 'a walk-cycle frame, not the standing pose'
+  frame = scene.instance_variable_get(:@vehicle_last_frame)[:boat]
+  eq [st.direction, pat], [frame[1], frame[3]],
+     'the ridden boat draws the same direction/walk-cycle frame the hero would have shown'
+
+  # An unridden vehicle always holds the standing pose 1, even while placed on
+  # the map: it snaps tile to tile rather than sliding, so it has no in-tile
+  # progress to walk-cycle against (see #draw_vehicle_frame's comment).
+  ship = st.vehicle(:ship)
+  ship.map_id = st.map_id
+  ship.x = 5
+  ship.y = 4
+  ship.charset_name = 'Ship'
+  scene.update
+  eq 1, scene.instance_variable_get(:@vehicle_last_frame)[:ship][3]
+end
+
 def tint_scene(*params)
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s "Vehicle move-routes" paragraph flagged this as an explicit follow-up left out of the original vehicle-driving work: "vehicles already only ever draw one standing pattern regardless, even ridden."

Root cause: `Scene::Map#draw_vehicle_frame` always passed CharSet pattern `1` (the standing pose) to `Game::CharSet.frame_rect`, regardless of motion. A *ridden* vehicle's sprite already tracks the party's own pixel position frame for frame (`draw_vehicles`' `ridden ? px : v.x * TILE`), so a boat sailing across the water moved smoothly but its paddle sprite never animated — the position was right, the pose was frozen.

## Changes

- Factored the hero's own walk-cycle pattern computation out of `#draw_player_frame` into a new `#player_walk_pattern` (`@moving ? WALK_PATTERNS[(@move_count / 4) % 4] : 1`), with no behavior change to the hero's own drawing.
- `#draw_vehicle_frame` now takes a `ridden` flag and uses `#player_walk_pattern` for a ridden vehicle's frame — the identical pattern the hero's own sprite would show, since a boarded vehicle slides in exact lockstep with the party. An unridden vehicle still always draws its standing pose 1: it snaps tile to tile per the existing Move Event / Set Move Route vehicle work, so there's no in-tile progress to animate against.
- `docs/TODO.md`'s "Vehicle move-routes" paragraph and a new changelog fragment document the fix; the other flagged follow-ups (smooth interpolation for an unridden vehicle, hero/event collision with a moving one, etc.) remain open and are called out as such.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 700 checks pass (unaffected; this is a pure rendering change).
- `ruby scripts/rpg2k_scene_check.rb` — 375 checks pass, including a new check: boarding a boat and sailing it walks the vehicle sprite through the same non-standing walk-cycle pattern index the hero would show, while an unridden vehicle placed on the map keeps its standing pose.
- Confirmed the new check fails against the pre-fix code (`git stash` the `map.rb` change, rerun) — a `NoMethodError` for the not-yet-extracted `#player_walk_pattern`, since the whole mechanism didn't exist before this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RjvyFEQeAQCUyXfYUGBTu)_