### PR TITLE
rpg2k: a battle_anime's position field (head/center/feet) now offsets it

### DIFF
--- a/changelog.d/battle-animation-position-field.fixed.md
+++ b/changelog.d/battle-animation-position-field.fixed.md
@@ -1,0 +1,26 @@
+- **A Battle Animation's `position` field (0 head / 1 center / 2 feet) now
+  actually offsets where it draws**, instead of being decoded and ignored.
+  The LCF `battle_anime` schema (`mruby-lcf/mrblib/schema.rb`, chunk 19 field
+  10) already comments the three values; `Scene::Map#build_animation` already
+  read `anim.position` into the animation's own state, but nothing downstream
+  ever looked at it, so every animation drew centred on its target regardless
+  of what it asked for. A new `Scene::Map#animation_position_offset` splits
+  symmetrically around the existing centre pixel by half the target's own
+  sprite height — `Game::CharSet::HEIGHT` (32px) for a map target (the
+  player, a map event or a vehicle, all drawn from a CharSet frame of that
+  fixed size), the battler bitmap's real height for an in-battle one — so a
+  head-positioned animation now rises and a feet-positioned one sinks,
+  instead of both landing on the same pixel as the schema default. A target
+  with no known height (the ally-side "middle of the screen" fallback
+  `#battle_animation_pixel` returns when RPG2000's front-view battle has no
+  sprite to measure) is never offset, which also means every existing caller
+  that never learned a height keeps its exact old behaviour. The *direction*
+  is confirmed by the schema's own field comment; the exact split RPG_RT
+  itself draws at is still approximate pending a wine diff, the same status
+  the message window's own relocation zone boundary carries elsewhere in
+  this codebase. Covered by new `scripts/rpg2k_scene_check.rb` checks (the
+  pure offset math for head/center/feet and a missing height; a battle
+  animation's draw position shifting by half the enemy sprite's height for
+  head/feet and staying put for center; a map-triggered animation carrying
+  the player's `Game::CharSet::HEIGHT`), confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1733,9 +1733,32 @@ The work below is roughly ordered by the critical path to a walkable game
   over the middle of the screen for an action aimed at a party member, since
   RPG2000's first-person battle draws no ally sprite. Left for their own changes:
   a **plain attack's** animation (RPG2000 takes it from the equipped weapon,
-  which the entry does not carry), the `position` field (whole screen / target /
-  above / below — carried but not acted on, so everything draws centred), and
-  per-cell tone and scale, which the map path has never had either. See ADR 0037.
+  which the entry does not carry), and per-cell tone and scale, which the map
+  path has never had either. See ADR 0037.
+  ✅ **The `position` field (0 head / 1 center / 2 feet, `battle_anime` chunk
+  19 field 10) now actually offsets where an animation draws**, instead of
+  being decoded (`build_animation`'s own `position:`) and never read again —
+  every animation drew centred on its target regardless of what it asked
+  for. A new `Scene::Map#animation_position_offset` splits symmetrically
+  around the existing centre pixel by half the target's own sprite height —
+  `Game::CharSet::HEIGHT` (32px) for a map target (the player, a map event or
+  a vehicle, all drawn from a CharSet frame of that fixed size — see
+  `#draw_vehicles`), the battler bitmap's real height for an in-battle one
+  (`#battle_animation_pixel` now returns it alongside the centre pixel it
+  already computed). A target with no known height — the ally-side "middle
+  of the screen" fallback, which has no sprite to split — is never offset,
+  so every existing caller that never learned a height (and every animation
+  that never sets the field away from its schema default of 1) keeps its
+  exact old behaviour. The *direction* is confirmed by the schema's own
+  field comment; the exact split RPG_RT itself draws at is still
+  approximate pending a wine diff, the same status the Message window's own
+  relocation-zone boundary carries above. Covered by new
+  `scripts/rpg2k_scene_check.rb` checks (the pure offset math for head /
+  center / feet and a missing height; a battle animation's draw position
+  shifting by half the enemy sprite's height for head/feet and staying put
+  for center; a map-triggered animation carrying the player's
+  `Game::CharSet::HEIGHT`), confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **Which fields the games set that the runtime never reads** —
   `ruby scripts/rpg2k_field_audit.rb`. A survey, not a check (it asserts nothing
   and always exits 0): for every scalar database field it counts the rows of the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3980,8 +3980,9 @@ class RPG2k
       def start_battle_animation(entry)
         id = battle_animation_id(entry)
         return false unless id && id > 0
-        tx, ty = battle_animation_pixel(entry)
-        anim = build_animation(id, tx, ty, true, target_index: entry[:target_index])
+        tx, ty, height = battle_animation_pixel(entry)
+        anim = build_animation(id, tx, ty, true, target_index: entry[:target_index],
+                               target_height: height)
         return false unless anim
         @map_animation = anim
         fire_animation_flashes(anim) # frame 0 flashes, as the map path does
@@ -4003,14 +4004,17 @@ class RPG2k
 
       # Where it plays: over the targeted enemy's sprite. RPG2000 draws no sprite
       # for a party member -- its battle is first-person -- so an action aimed at
-      # one plays over the middle of the screen instead of nowhere.
+      # one plays over the middle of the screen instead of nowhere. The third
+      # element is the sprite's own pixel height, for #animation_position_offset
+      # to split into head/feet thirds -- nil for the screen-centre fallback,
+      # which has no sprite to measure and so never moves off it.
       def battle_animation_pixel(entry)
         i = entry[:target_index]
         sprites = @battle_ui[:enemy_sprites]
         spr = i && sprites ? sprites[i] : nil
         bmp = spr && spr.bitmap
-        return [SCREEN_W / 2, SCREEN_H / 2] unless bmp
-        [spr.x + bmp.width / 2, spr.y + bmp.height / 2]
+        return [SCREEN_W / 2, SCREEN_H / 2, nil] unless bmp
+        [spr.x + bmp.width / 2, spr.y + bmp.height / 2, bmp.height]
       end
 
       # Close out an animated round: clear the commands, drop the action banner,
@@ -5350,15 +5354,24 @@ class RPG2k
         req = it.battle_animation
         return nil unless req
         tx, ty = animation_target_pixel(req[:target])
-        build_animation(req[:animation], tx, ty)
+        # Every map target -- the player, a map event, a vehicle -- draws from
+        # a CharSet frame of this one fixed size (see #draw_vehicles, which
+        # sizes a vehicle sprite off the same constant), so the sprite bounding
+        # box #animation_position_offset needs is known without asking what
+        # kind of character this actually is.
+        build_animation(req[:animation], tx, ty, target_height: Game::CharSet::HEIGHT)
       end
 
       # The animation player itself, shared by the map's Show Battle Animation
       # command and by a battle round. `battle` says the pixel is already a
       # screen position rather than a map one, and that nothing is waiting on the
-      # animation to finish. nil when the animation is unknown or its
-      # Battle/<name> sheet is missing.
-      def build_animation(id, tx, ty, battle = false, target_index: nil)
+      # animation to finish. `target_height` is the target sprite's own pixel
+      # height, when known (see #animation_position_offset) -- nil when there is
+      # no real sprite to measure (the ally-side "middle of the screen"
+      # fallback), which leaves every position setting drawing at the plain
+      # centre pixel, same as before this field existed. nil when the animation
+      # is unknown or its Battle/<name> sheet is missing.
+      def build_animation(id, tx, ty, battle = false, target_index: nil, target_height: nil)
         anim = animation_row(id)
         return nil unless anim
         frames = table_entries(anim.frames)
@@ -5367,7 +5380,8 @@ class RPG2k
         return nil unless sheet
         { frames: frames, timings: table_entries(anim.timings), sheet: sheet,
           position: (anim.position || 1), tx: tx, ty: ty, frame_i: 0,
-          timer: ANIM_CELL_FRAMES, battle: battle, target_index: target_index }
+          timer: ANIM_CELL_FRAMES, battle: battle, target_index: target_index,
+          target_height: target_height }
       end
 
       def animation_row(id)
@@ -5494,10 +5508,39 @@ class RPG2k
         # A map animation is placed in map pixels and follows the camera; a
         # battle one is already where it belongs on screen.
         cx = ma[:battle] ? ma[:tx] : ma[:tx] - cam_x + TILE / 2
-        cy = ma[:battle] ? ma[:ty] : ma[:ty] - cam_y + TILE / 2
+        cy = (ma[:battle] ? ma[:ty] : ma[:ty] - cam_y + TILE / 2) +
+             animation_position_offset(ma)
         table_entries(frame.cells).each do |cell|
           next if cell.respond_to?(:visible) && cell.visible == false
           blit_animation_cell(ma[:sheet], cell, cx, cy)
+        end
+      end
+
+      # The vertical pixel offset the battle_anime row's own `position` field (0
+      # head / 1 center / 2 feet, LCF `battle_anime` chunk 19 field 10) adds on
+      # top of the target's plain centre pixel -- previously decoded and stored
+      # (`build_animation`'s `position:`) but never read, so every animation
+      # drew centred regardless of what it asked for. Symmetric around the
+      # existing centre pixel so position 1 -- the schema default, and every
+      # animation that never sets the field -- draws exactly where it always
+      # has; a target with no known height (the ally-side "middle of the
+      # screen" fallback battle_animation_pixel returns, or a headless/
+      # fixture animation nothing ever gave a height) is never offset, since
+      # there is no sprite to split. The split point is the target's own real
+      # sprite bounding box -- Game::CharSet's fixed 32px frame for a map
+      # target, the battler bitmap's actual height in a fight -- rather than a
+      # guessed fraction of it: the *direction* is confirmed by the schema's
+      # own field comment (mruby-lcf/mrblib/schema.rb), but the exact split
+      # RPG_RT itself draws at is still approximate pending a wine diff, the
+      # same status the message window's own relocation zone boundary has
+      # above.
+      def animation_position_offset(ma)
+        h = ma[:target_height]
+        return 0 unless h
+        case ma[:position]
+        when 0 then -(h / 2) # head: half the sprite's height above centre
+        when 2 then h / 2    # feet: half the sprite's height below centre
+        else 0
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4571,6 +4571,30 @@ check "Show Battle Animation targeting a vehicle uses the vehicle's own live pos
      "targeted the boat's own live position, not the player's or the event's"
 end
 
+# A map-triggered Show Battle Animation's target is always drawn from a
+# Game::CharSet frame -- the player, a map event or a vehicle, see
+# #draw_vehicles sizing a vehicle sprite off the same constant -- so
+# #start_map_animation can hand #animation_position_offset a real height
+# unconditionally, unlike the battle path's ally-side "no sprite" fallback.
+check "a map-triggered Show Battle Animation carries the target's CharSet height" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0), # animation, player, wait
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  anim = nil
+  40.times do
+    scene.update
+    anim = scene.instance_variable_get(:@map_animation)
+    break if anim
+  end
+  ok anim, 'the animation actually started'
+  eq Game::CharSet::HEIGHT, anim[:target_height],
+     "the player's own CharSet sprite height, not the battle-only nil fallback"
+end
+
 # yado.tk: only one Battle Animation is ever on screen at once -- true of the
 # map-level Show Battle Animation command (11210) same as an in-battle one.
 # That only means anything if a *parallel process* can show one at all: before
@@ -6522,6 +6546,59 @@ check 'the battle animation draws in screen pixels, not map ones' do
   call = bmp.blt_calls.first
   eq [ma[:tx] - 48, ma[:ty] - 48], [call[0], call[1]],
      'placed from the target pixel itself, ignoring the camera'
+end
+
+# The battle_anime row's own `position` field (0 head / 1 center / 2 feet,
+# LCF chunk 19 field 10 -- mruby-lcf/mrblib/schema.rb) was decoded into
+# build_animation's `position:` and then never read anywhere, so an animation
+# authored to play at a target's head or feet drew centred exactly like one
+# left at the default. #animation_position_offset is the pure-logic half:
+# symmetric around the plain centre pixel, split at the target's own known
+# sprite height (nil, as every caller passed before this fix, always reads as
+# "no offset", so an old caller/fixture that never learned a height keeps the
+# exact old behaviour).
+check 'animation_position_offset splits head/center/feet around the target sprite' do
+  scene, = battle_at_command
+  eq 0, scene.send(:animation_position_offset, { position: 1, target_height: 32 }),
+     'center is the plain centre pixel, unmoved'
+  eq(-16, scene.send(:animation_position_offset, { position: 0, target_height: 32 }),
+     'head rises half the sprite height above centre')
+  eq 16, scene.send(:animation_position_offset, { position: 2, target_height: 32 }),
+     'feet sink half the sprite height below centre'
+  eq 0, scene.send(:animation_position_offset, { position: 0, target_height: nil }),
+     'no known height (the ally-side screen-centre fallback) is never offset'
+end
+
+check 'a head/feet Show Battle Animation position offsets where it draws over the enemy sprite' do
+  scene, = battle_at_command
+  scene.send(:start_battle_animation,
+             { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+               skill_id: 8, target_index: 0, target_ally: false })
+  ma = scene.instance_variable_get(:@map_animation)
+  bmp = scene.instance_variable_get(:@animation_bmp)
+  ok ma[:target_height], 'start_battle_animation carried the enemy sprite\'s real height through'
+  half_height = ma[:target_height] / 2
+
+  ma[:position] = 0
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  call = bmp.blt_calls.first
+  eq [ma[:tx] - 48, ma[:ty] - 48 - half_height], [call[0], call[1]],
+     'position 0 (head) draws half the sprite height above the plain centre'
+
+  ma[:position] = 2
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  call = bmp.blt_calls.first
+  eq [ma[:tx] - 48, ma[:ty] - 48 + half_height], [call[0], call[1]],
+     'position 2 (feet) draws half the sprite height below the plain centre'
+
+  ma[:position] = 1
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  call = bmp.blt_calls.first
+  eq [ma[:tx] - 48, ma[:ty] - 48], [call[0], call[1]],
+     'position 1 (center), the schema default, is unchanged from the plain centre pixel'
 end
 
 check 'the battle status window shows each ally condition, or the normal term' do


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Battle animations" bullet listed the `battle_anime` row's
  `position` field (0 head / 1 center / 2 feet) as "carried but not acted
  on, so everything draws centred." Verified real: `build_animation`/
  `draw_map_animation` decoded and stored the position on every animation
  but never read it anywhere downstream.
- New `#animation_position_offset` splits ±half the target's own sprite
  height (`Game::CharSet::HEIGHT` for a map target — the player, an event,
  or a vehicle all draw from the same fixed 32px CharSet frame; the
  battler bitmap's real height in a fight) around the existing centre
  pixel, symmetric so position 1 (the schema default, and every animation
  that never sets the field) draws exactly where it always has. A target
  with no known height (the ally-side "middle of the screen" fallback,
  since RPG2000 draws no sprite for a party member) is never offset.
- The *direction* is confirmed by the schema's own field comment; the
  exact pixel split RPG_RT itself draws at is still approximate pending a
  wine diff — flagged as such in `docs/TODO.md`, matching the precedent
  set by the message window's own relocation-zone note.
- `docs/TODO.md` updated ✅, removing the now-stale "not acted on" line.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 700 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 380 checks pass (three new
      checks: pure offset math for head/center/feet/no-height; a battle
      animation's draw position actually shifts for head/feet and stays
      put for center; a map-triggered animation carries the player's
      `Game::CharSet::HEIGHT` — confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_