### PR TITLE
rpg2k: a non-leader actor's Change Actor Name survives a real .lsd save

### DIFF
--- a/changelog.d/save-actor-name-override.fixed.md
+++ b/changelog.d/save-actor-name-override.fixed.md
@@ -1,0 +1,23 @@
+- **A non-leader party member's Change Actor Name override now survives
+  Save/Continue through a real `.lsd`**, not just through the portable
+  Marshal save. `LCF::Schema::SAVE_PARTY_ACTOR` (chunk 108, the whole roster
+  the party has ever held) never modelled field 1 — identified in ADR 0014 as
+  the actor's renamable name (a decoded real save's field 1 matched its own
+  SAVE_TITLE `hero_name` exactly for the leader) but left unmodelled, since
+  `Game::State#to_lsd` only ever wrote a renamed *leader's* name, through the
+  file-screen title chunk (100, which carries only one name). A companion's
+  own Change Actor Name had nowhere to land in the export at all. Field 1 is
+  now decoded (`actor_name`), `#to_lsd` writes every roster actor's current
+  name into it (not just the leader's), and `Game::State.from_lsd` restores
+  it for every actor the chunk covers, leader included — the leader's chunk
+  100 restore stays as a second, redundant source (applied last, so it still
+  wins for a foreign save that only sets one of the two). Fields 2/33/34
+  remain unconfirmed, so a Change Actor *Title* override still does not
+  round-trip. Covered by a new `scripts/rpg2k_logic_check.rb` check (a
+  renamed leader and a renamed non-leader roster member both come back
+  correctly named from an in-memory `to_lsd`/`from_lsd` round-trip, with no
+  bytes serialised in between — the check also newly loads the pure-Ruby
+  `mruby-lcf/mrblib` sources, stubbing `LCF.cp932_to_utf8`/`utf8_to_cp932`
+  the same way `scripts/rpg2k_save_load_check.rb` already does), confirmed to
+  fail against the pre-fix code (the non-leader's name came back as its
+  un-renamed database default) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1720,15 +1720,37 @@ The work below is roughly ordered by the critical path to a walkable game
   `:double` timestamp (via the new `LCF.pack_double`), the leader's
   name/level/HP and the party FaceSets — so a real RPG_RT/EasyRPG file-select
   screen shows the party. Still keeping the Marshal save *primary* (so Continue
-  prefers it) are two fields the `.lsd` cannot yet carry: the **game timer**
-  (liblcf's SaveSystem has no field for it — needs a documented chunk id) and
-  **per-actor name/title overrides for non-leader** members (only the leader's
-  name is in the title chunk). Both save paths carry the **whole actor roster**,
-  not just the current party: chunk 108 holds one entry per actor the party has
-  ever held (which is what a genuine RPG_RT save holds), so a companion who is
-  out of the party when the game is saved is written out and read back rather
-  than being silently dropped — `.from_lsd` used to skip exactly those rows. See
-  ADR 0030
+  prefers it) is one field the `.lsd` cannot yet carry: the **game timer**
+  (liblcf's SaveSystem has no field for it — needs a documented chunk id). Both
+  save paths carry the **whole actor roster**, not just the current party:
+  chunk 108 holds one entry per actor the party has ever held (which is what a
+  genuine RPG_RT save holds), so a companion who is out of the party when the
+  game is saved is written out and read back rather than being silently
+  dropped — `.from_lsd` used to skip exactly those rows. See ADR 0030.
+  ✅ **A non-leader party member's Change Actor Name override now round-trips
+  through the `.lsd` too**, closing the "per-actor name... for non-leader"
+  half of the gap this line used to describe (only the leader's name — via
+  the file-screen title chunk 100, which has room for exactly one — used to
+  survive). Chunk 108 (`SAVE_PARTY_ACTOR`)'s field 1 was already identified
+  in ADR 0014 as the actor's renamable name (a decoded real save's field 1
+  matched its own `SAVE_TITLE` `hero_name` exactly for the leader) but left
+  unmodelled, since nothing needed a *non*-leader's name at the time.
+  `LCF::Schema::SAVE_PARTY_ACTOR` now decodes it (`actor_name`),
+  `Game::State#to_lsd` writes every roster actor's current name into it (not
+  just the leader's), and `.from_lsd` restores it for every actor the chunk
+  covers — the leader's chunk-100 restore stays too, as a redundant
+  belt-and-braces source applied last. **Still not modelled: Change Actor
+  *Title***, since fields 2/33/34 stayed constant in the one sampled save and
+  are not provably the title field. Covered by a new `scripts/
+  rpg2k_logic_check.rb` check (a renamed leader and a renamed non-leader
+  roster member both come back correctly named from an in-memory
+  `to_lsd`/`from_lsd` round-trip — no bytes serialised, since `Array1D#[]=`
+  and `#[]` are already exact inverses on the schema-encoded value; the check
+  loads the pure-Ruby `mruby-lcf/mrblib` sources for the first time in this
+  script, stubbing `LCF.cp932_to_utf8`/`utf8_to_cp932` the same way
+  `scripts/rpg2k_save_load_check.rb` already does), confirmed to fail against
+  the pre-fix code (the non-leader's name came back as its un-renamed
+  database default) before the fix.
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations (large; Nepheshel uses the default RPG2000 battle). Needs real
   assets + the native build to develop against. The game-over scene is done

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1034,12 +1034,17 @@ module LCF
     # armour, helmet, accessory] — every slot's id resolves to an item of the
     # matching type in the database (slot 0 weapons, slot 2 armour, slot 3
     # helmets, slot 4 accessories; a dual-wield hero carries a second weapon in
-    # the shield slot). Field 1 is the (renamable) name — the hero's stored name
-    # matches the SAVE_TITLE hero_name exactly — but it is left unmodelled here
-    # because the runtime resolves names from the database and reserve actors
-    # store only a placeholder. Fields 2/33/34 are single bytes that are constant
-    # in the sampled save, so their meaning is not yet provable.
+    # the shield slot). Field 1 is the (renamable) actor name — the hero's
+    # stored name matches the SAVE_TITLE hero_name exactly, which is what
+    # confirmed it — and is now modelled, so a Change Actor Name override on a
+    # *non*-leader party member round-trips through Save/Continue too (chunk
+    # 100's title only ever carried the leader's). Fields 2/33/34 are single
+    # bytes that are constant in the sampled save, so their meaning is not yet
+    # provable; in particular field 2 is not confirmed to be the actor's title
+    # (Change Actor Title), so that override still does not survive a real
+    # `.lsd` round-trip.
     SAVE_PARTY_ACTOR = {
+      1 => { name: :actor_name, type: :string },            # 名前
       31 => { name: :level, type: :int, default: 1 },      # レベル
       32 => { name: :exp, type: :int, default: 0 },        # 経験値
       51 => { name: :skill_size, type: :int, default: 0 }, # 『特技』情報のデータ数

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8150,6 +8150,11 @@ module Game
       actors = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
       @party.roster.each do |a|
         e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PARTY_ACTOR })
+        # Field 1 carries the actor's *current* name (renamed or not, matching
+        # a genuine save), so a Change Actor Name override on any roster
+        # member -- not just the leader, who also gets it via chunk 100's
+        # title -- survives Save/Continue.
+        e[1] = a.name
         e[31] = a.level
         e[32] = a.exp
         e[51] = a.skills.size
@@ -8229,6 +8234,9 @@ module Game
           actor.equip(sa.equipment) if sa.equipment
           actor.skills = sa.skills if sa.skills
           actor.states = sa.states if sa.states
+          # A Change Actor Name override on *any* roster member, not just the
+          # leader (whose name chunk 100's title also carries below).
+          actor.name = sa.actor_name if sa.actor_name && !sa.actor_name.empty?
         end
         hp[aid] = sa.hp if sa.hp
         mp[aid] = sa.mp if sa.mp
@@ -8290,8 +8298,10 @@ module Game
       sg = sys.system_graphic
       state.system_graphic = sg unless sg.nil? || sg.empty?
       state.font_id = sys.font || 0
-      # The leader's display name from the file-screen title chunk (a Change
-      # Actor Name override survives for the leader).
+      # The leader's display name from the file-screen title chunk. Redundant
+      # with chunk 108 field 1 above (both hold the same live name in a
+      # genuine save, and in our own #to_lsd output) but applied last so it
+      # still wins for a foreign save that sets one and not the other.
       title = save[100]
       if title && party.leader
         nm = title.hero_name

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -30,6 +30,29 @@ module RGSS
   def self.warn_stub(*); end
 end
 
+# mruby-lcf/mrblib is the same pure Ruby/mruby-common subset as game.rb -- not
+# the native LCF parser -- and #to_lsd/.from_lsd (Game::State) build/consume its
+# LCF::SaveData / LCF::Array1D straight from Ruby objects, no bytes involved,
+# for the round-trip checks below. LCF.cp932_to_utf8/utf8_to_cp932 are the one
+# native binding those classes call through (a string field's encode/decode);
+# stubbed with Ruby's own Windows-31J transcoder exactly as
+# scripts/rpg2k_save_load_check.rb already does for the same reason.
+require 'stringio'
+module LCF
+  def cp932_to_utf8(s)
+    s.dup.force_encoding('Windows-31J')
+     .encode('UTF-8', invalid: :replace, undef: :replace, replace: "\u{FFFD}")
+  end
+  def utf8_to_cp932(s)
+    s.dup.encode('Windows-31J', invalid: :replace, undef: :replace)
+     .force_encoding('BINARY')
+  end
+  module_function :cp932_to_utf8, :utf8_to_cp932
+end
+lcf_lib = File.expand_path('../mruby-lcf/mrblib', __dir__)
+load File.join(lcf_lib, 'lcf.rb')
+load File.join(lcf_lib, 'schema.rb')
+
 lib = File.expand_path('../mruby-rpg2k/mrblib', __dir__)
 load File.join(lib, 'game.rb')
 load File.join(lib, 'interpreter.rb')
@@ -2583,6 +2606,29 @@ check 'both timers round-trip through the save; an old save still loads' do
   old = Game::State.load(db, legacy)
   eq 30, old.timer(0).seconds, 'the first timer comes back from the old keys'
   eq 0, old.timer(1).seconds, 'and the second starts empty'
+end
+
+check 'to_lsd/from_lsd round-trips a non-leader actor\'s Change Actor Name' do
+  # Chunk 100 (the file-screen title) only ever carries the *leader's* name, so
+  # a Change Actor Name on a companion used to have nowhere to land in the real
+  # .lsd export -- only chunk 108 (SAVE_PARTY_ACTOR)'s per-actor field 1 does,
+  # and #to_lsd never wrote it. Confirmed against a real save in ADR 0014
+  # (field 1's bytes matched the SAVE_TITLE hero_name exactly for the leader).
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
+    2 => FakePlayerRow.new('Ally', '', 0, 3, max_hp: 50, max_mp: 20, atk: 6, def: 5),
+  }
+  db = FakeActorDB.new(players, [1])
+  party = Game::Party.new(db)
+  party.add_actor(2)
+  st = Game::State.new(party, 1, 0, 0)
+  st.party.leader.name = 'Renamed Hero'
+  st.party.actor_by_id(2).name = 'Renamed Ally'
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq 'Renamed Hero', round.party.leader.name, 'the leader (also covered by chunk 100) round-trips'
+  eq 'Renamed Ally', round.party.actor_by_id(2).name,
+     "a non-leader's renamed name now round-trips too, via chunk 108 field 1"
 end
 
 # -- the permanent actor roster (Game::Actors) --------------------------------


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s Save & Continue notes flagged per-actor name overrides for
  non-leader members as a gap the `.lsd` couldn't carry — only the leader's
  name is in the title chunk.
- `SAVE_PARTY_ACTOR` (chunk 108, the whole roster the party has ever held)
  never decoded field 1, even though ADR 0014 already identified it as the
  actor's renamable name (confirmed against a real Nepheshel save: field
  1's bytes matched the leader's own `SAVE_TITLE` `hero_name` exactly).
  `Game::State#to_lsd` only ever wrote a renamed leader's name through the
  file-screen title chunk (100), which has room for exactly one name — a
  Change Actor Name on any other roster member had nowhere to land when
  exporting a genuine `.lsd`, so the rename was silently lost on Continue
  from a real save file (the portable Marshal save, unaffected, already
  preserved it).
- Field 1 is now decoded as `actor_name`; `to_lsd` writes every roster
  actor's name, not just the leader's; `from_lsd` restores it for every
  actor the chunk covers, with the chunk-100 leader restore kept as a
  redundant fallback (applied last) for a foreign save that only sets one
  of the two.
- Left alone: Change Actor **Title** — fields 2/33/34 stayed constant in the
  one sampled real save, so nothing confirms which (if any) is the title
  field; guessing would be an unverifiable claim.
- `docs/TODO.md` updated ✅, narrowing the remaining gap to the game-timer
  chunk and Change Actor Title.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 703 checks pass (new check:
      `to_lsd`/`from_lsd` round-trips a non-leader actor's Change Actor Name
      — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 384 checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — skips gracefully (no
      test-bed `Save*.lsd` in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_