### PR TITLE
rpg2k: a Change Parameters adjustment survives Save / Continue

### DIFF
--- a/changelog.d/change-parameters-save-persist.fixed.md
+++ b/changelog.d/change-parameters-save-persist.fixed.md
@@ -1,0 +1,28 @@
+- **A Change Parameters event command's stat adjustment now survives Save /
+  Continue**, instead of silently reverting to the level-derived default the
+  moment the game reloads. Continue always rebuilds the actor roster as
+  fresh `Game::Actor` objects seeded from the database's `initial_level`
+  (`Game::State.load` → a new `Game::Party`), and `Party#to_h` never wrote
+  `@base`/`@base_raw` (the stat total `Actor#change_param` maintains, clamped
+  and unclamped) into the save at all — so a live adjustment had nowhere to
+  land on the reloaded actor even before `#load_state` touched it, and was
+  actively overwritten on top of that in the common case: restoring the
+  saved EXP through `#set_exp` calls `#set_level` whenever the computed
+  level differs from the fresh object's own (true of almost any real save,
+  since gameplay has usually raised the level past its starting point), and
+  `#set_level` deliberately re-seeds `@base`/`@base_raw` from the
+  level-derived growth-curve baseline. `Party#to_h` now writes each roster
+  actor's `base_raw` into `actor_meta` alongside the existing name/title/
+  sprite overrides, and `#load_state` calls a new `Actor#restore_base` right
+  after `#set_exp` — deliberately after, since `#set_exp` is what does the
+  re-seeding that needs undoing — which re-applies the saved unclamped total
+  and re-derives the clamped `@base` from it with the identical clamp
+  `#change_param` itself uses (now shared as `#base_param_limit`). A save
+  written before `base_raw` existed simply keeps the level-derived baseline,
+  unchanged from before this fix. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a Change Parameters adjustment —
+  including one still resting on the unclamped floor from a bigger drop —
+  round-trips through `Party#to_h` / `#load_state` into a fresh `Party`
+  unchanged; a save with no `base_raw` field falls back to the level-derived
+  default), the first confirmed to fail against the pre-fix code before the
+  fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4211,7 +4211,44 @@ codebase yet):
   stat; a partial raise that doesn't cross back over 1 stays floored; a
   further raise that does cross back over unclamps to the real total; an
   ordinary never-clamped sequence is unaffected), confirmed to fail against
-  the pre-fix code before the fix. ✅ **"Party wipe" for game-over purposes is now "every
+  the pre-fix code before the fix.
+  ✅ **The save/load gap flagged above is closed too: `@base_raw` now
+  survives Continue.** `Party#to_h` simply never wrote `@base`/`@base_raw`
+  into `actor_meta` at all, and `Continue` always rebuilds the whole roster
+  as fresh `Actor` objects (`Game::State.load` → a new `Game::Party`, whose
+  actors are seeded by `Actor#initialize` from the database's own
+  `initial_level`) — so a Change Parameters edit had nowhere to land on the
+  new objects even before `#load_state` touches them, unconditionally, not
+  just for the out-of-clamp-range case the paragraph above measured. It is
+  also actively overwritten in the common case: `#load_state` restores the
+  level from saved EXP through `#set_exp`, which calls `#set_level`
+  whenever the computed level differs from the fresh object's own — one of
+  the four places (alongside `#change_class`'s three branches) that
+  deliberately re-seeds `@base`/`@base_raw` from the level-derived
+  growth-curve baseline on the reasoning that a level-up establishes a
+  fresh one, correct for a genuine level-up but firing on essentially every
+  real Continue too, since almost any save has gained EXP since the fresh
+  object's own starting level. `Party#to_h` now writes each roster actor's
+  `base_raw` (the same array `#change_param` accumulates onto) into
+  `actor_meta` alongside the existing name/title/sprite overrides, and
+  `load_state` calls a new `Actor#restore_base` right after `#set_exp` —
+  deliberately after, since `#set_exp` is what does the re-seeding that
+  needs undoing — which re-applies the saved unclamped total and re-derives
+  the clamped `@base` from it with the identical clamp `#change_param`
+  itself uses (now shared as `#base_param_limit`), then calls
+  `#recompute_stats` so the restored total's effective stats (and,
+  transitively, the max HP/MP the next line's saved `hp`/`mp` clamp
+  against) are current before they load. A save written before `base_raw`
+  existed simply has no `m[:base_raw]` and the actor keeps the
+  level-derived baseline, unchanged from before this fix. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a Change Parameters adjustment —
+  including one still resting on the unclamped floor from a bigger drop —
+  round-trips through `Party#to_h` / `#load_state` into a fresh `Party`
+  unchanged, both effective stat and the hidden shadow total, while a party
+  with no such adjustment round-trips unaffected), confirmed to fail
+  against the pre-fix code (the restored actor's stats reverted to the
+  level-derived baseline) before the fix.
+  ✅ **"Party wipe" for game-over purposes is now "every
   member is both unable to act and does not recover naturally," not
   literally "every member's HP is 0"** — why Stone status can wipe a party
   without zeroing anyone's HP. `Game::Battle#alive?` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1141,6 +1141,9 @@ module Game
     # sprite (the Change Sprite Association transparency flag).
     attr_accessor :name, :title, :transparent
     attr_reader :max_hp, :max_mp, :atk, :def, :int, :agi
+    # The unclamped shadow total #change_param accumulates deltas onto (see
+    # #change_param and #restore_base) -- exposed so the save can carry it.
+    attr_reader :base_raw
 
     # The six base stats in database parameter-curve order (chunk 31 stores six
     # shorts -- maxHP, maxSP, atk, def, int, agi -- per level).
@@ -1879,9 +1882,29 @@ module Game
     # display/effective value throughout.
     def change_param(type, delta)
       return unless type >= 0 && type < STAT_NAMES.size
-      limit = (type == PARAM_MAX_HP || type == PARAM_MAX_MP) ? 9999 : 999
       @base_raw[type] += delta
-      @base[type] = Game.clamp(@base_raw[type], 1, limit)
+      @base[type] = Game.clamp(@base_raw[type], 1, base_param_limit(type))
+      recompute_stats
+    end
+
+    # RPG2000's clamp ceiling for a base parameter: HP/MP go to 9999, the four
+    # battle stats to 999. Shared by #change_param and #restore_base, which
+    # both need to re-derive the clamped @base from an unclamped total.
+    def base_param_limit(type)
+      (type == PARAM_MAX_HP || type == PARAM_MAX_MP) ? 9999 : 999
+    end
+
+    # Restore the unclamped shadow total a Change Parameters command left
+    # behind (#change_param's @base_raw) from a save. #set_exp/#set_level
+    # already re-seeded @base/@base_raw from the level-derived baseline by
+    # the time load_state calls this, discarding any live adjustment -- this
+    # re-applies the saved total and re-derives the clamped @base from it the
+    # same way #change_param itself does, rather than leaving a Change
+    # Parameters edit to silently revert on Continue.
+    def restore_base(base_raw)
+      return unless base_raw
+      @base_raw = base_raw.dup
+      @base = @base_raw.each_with_index.map { |v, i| Game.clamp(v, 1, base_param_limit(i)) }
       recompute_stats
     end
 
@@ -2167,6 +2190,11 @@ module Game
                        charset_name: a.charset_name,
                        charset_index: a.charset_index,
                        transparent: a.transparent, states: a.states.dup,
+                       # A Change Parameters command's unclamped shadow total
+                       # (see Actor#change_param / #restore_base) -- without
+                       # it a live adjustment reverts to the level-derived
+                       # baseline the moment #load_state re-seeds it from EXP.
+                       base_raw: a.base_raw.dup,
                        # RPG2003: a Change Class / Change Battle Commands is a
                        # permanent edit, so it has to outlive Save / Continue the
                        # way the name and sprite overrides do.
@@ -2179,8 +2207,10 @@ module Game
 
     # Restore item/gold, per-actor exp/hp/mp and the name/title/sprite overrides
     # from a saved party hash. EXP is restored first (it re-derives the level and
-    # its base stats), then the saved HP/MP are laid over the recomputed maxima.
-    # A save written before actor_meta existed simply keeps the database defaults.
+    # its base stats), then a saved Change Parameters shadow total (base_raw)
+    # is re-applied on top of that fresh baseline, then the saved HP/MP are
+    # laid over the recomputed maxima. A save written before actor_meta (or
+    # before base_raw) existed simply keeps the level-derived defaults.
     #
     # Every id the saved tables mention is restored, not just the current
     # members, so an actor waiting out of the party comes back as they left
@@ -2206,6 +2236,10 @@ module Game
         m = meta[id]
         a.restore_class(m[:class_id]) if m && m[:class_id]
         a.set_exp(exp[id]) if exp[id]
+        # #set_exp re-seeds @base/@base_raw from the level-derived baseline
+        # whenever it changes the level, discarding a live Change Parameters
+        # edit -- restore the saved shadow total after it, not before.
+        a.restore_base(m[:base_raw]) if m && m[:base_raw]
         a.hp = hp[id] if hp[id]
         a.mp = mp[id] if mp[id]
         apply_actor_meta(a, m)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2907,6 +2907,46 @@ check 'Change Parameters tracks an unclamped total under the displayed clamp' do
   eq 4, a.def
 end
 
+check 'Party save round-trips a Change Parameters adjustment across Continue' do
+  # Continue always rebuilds the roster as fresh Actor objects (a new
+  # Game::Party seeded from the database's initial_level), so a live Change
+  # Parameters edit has nowhere to land on the reload unless the save itself
+  # carries it -- see the "save/load gap ... closed" paragraph in
+  # docs/TODO.md's Change Parameters section.
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  hero.gain_exp(500) # level up, so Continue's #set_exp also re-derives @base via
+                      # #set_level -- the common case, not just the fresh-object one
+  hero.change_param(Game::Actor::PARAM_DEF, 5)      # ordinary, never-clamped: 2 -> 7
+  hero.change_param(Game::Actor::PARAM_ATK, -2000)  # floors atk at 1, raw deep negative
+  hero.change_param(Game::Actor::PARAM_ATK, 1000)   # raw still negative -- stays floored
+  eq 7, hero.def
+  eq 1, hero.atk
+  loaded = Game::State.load(db, st.to_h).party.actor_by_id(1)
+  eq hero.level, loaded.level      # the level-up itself round-tripped too
+  eq 7, loaded.def                 # ordinary adjustment survives Continue
+  eq 1, loaded.atk                 # still floored, not reverted to the level-derived base
+  # The floor is still the hidden shadow total (raw -997), not a fresh clamp:
+  # one more +1000 crosses it back above 1 on the reloaded actor exactly as it
+  # does on the live one, rather than needing a second raise the way a
+  # freshly-floored (raw -1997) actor would.
+  loaded.change_param(Game::Actor::PARAM_ATK, 1000)
+  hero.change_param(Game::Actor::PARAM_ATK, 1000)
+  eq 3, loaded.atk
+  eq hero.atk, loaded.atk
+end
+
+check 'A save written before base_raw existed keeps the level-derived baseline' do
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.actor_by_id(1).change_param(Game::Actor::PARAM_ATK, 5)
+  legacy = st.to_h
+  legacy[:party][:actor_meta].each_value { |m| m.delete(:base_raw) }
+  loaded = Game::State.load(db, legacy).party.actor_by_id(1)
+  eq 3, loaded.atk # base_raw missing (a pre-fix save) -> the level-derived default
+end
+
 check 'Actor without a growth curve falls back to a level-independent status' do
   # party_state uses FakePlayerRow (a status hash, no int16_values): stats stay
   # put regardless of level, and the initial level is honoured.


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s Change Parameters entry already flagged this precisely:
  "save/load persistence of `@base` itself is a separate, pre-existing gap
  (`Game::Party#load_state` re-derives `@base` purely from saved EXP via
  `#set_level`, so a live Change Parameters adjustment — clamped or not —
  does not currently survive a save at all)".
- Confirmed by reading the code: `Party#to_h` never wrote
  `Actor#base_raw`/`@base` into `actor_meta` at all, and Continue always
  rebuilds the whole roster as fresh `Actor` objects (`Game::State.load` →
  a new `Game::Party`, seeded from the database's `initial_level`) — so a
  live Change Parameters edit had nowhere to land on the reloaded actor
  even before `#load_state` ran. It's also actively overwritten in the
  common case: restoring the saved EXP through `#set_exp` calls
  `#set_level` whenever the computed level differs from the fresh object's
  own (true of almost any real save, since gameplay has usually leveled up
  since the character's starting point), and `#set_level` deliberately
  re-seeds `@base`/`@base_raw` from the level-derived growth-curve
  baseline.
- `Party#to_h` now writes each roster actor's `base_raw` (the unclamped
  shadow total `#change_param` accumulates onto, per ADR-adjacent work
  already in the codebase) into `actor_meta` alongside the existing
  name/title/sprite overrides.
- `load_state` calls a new `Actor#restore_base` right after `#set_exp` —
  deliberately after, since `#set_exp` is what does the re-seeding that
  needs undoing — which re-applies the saved unclamped total and
  re-derives the clamped `@base` from it with the identical clamp
  `#change_param` itself uses (now shared as `#base_param_limit`).
- A save written before `base_raw` existed simply has no such field and
  the actor keeps the level-derived baseline, unchanged from before this
  fix.
- `docs/TODO.md` updated with a ✅ paragraph documenting the fix, and a
  changelog fragment added per `changelog.d/README.md`.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 704 checks pass (two new
      checks: a Change Parameters adjustment — including one still resting
      on the unclamped floor from a bigger drop — round-trips through
      `Party#to_h`/`#load_state` into a fresh `Party` unchanged; a save
      with no `base_raw` field falls back to the level-derived default).
      The first check was confirmed to fail against the pre-fix code
      (`expected 7, got 2`) before the fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 384 checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSNmPifCv9rwm5HxsoD258)_