### PR TITLE
rpg2k: a boat/ship/airship with a map-tree start position now places there

### DIFF
--- a/changelog.d/vehicle-start-positions.fixed.md
+++ b/changelog.d/vehicle-start-positions.fixed.md
@@ -1,0 +1,21 @@
+- **A boat, ship or airship the map tree gives its own starting position now
+  places there at New Game**, instead of staying unplaced until an event runs
+  Set Vehicle Location. RPG2000's editor has a dedicated "set starting
+  position" tool for each vehicle (the map tree's `initial` chunk, fields
+  11-13 / 21-23 / 31-33: `boat_map_id`/`x`/`y`, `ship_map_id`/`x`/`y`,
+  `airship_map_id`/`x`/`y`), parsed by the schema and never read anywhere in
+  `mruby-rpg2k` — `Game::Vehicle.new` always defaulted to `map_id: 0`
+  ("unplaced"), and the only place any vehicle's location was ever written was
+  the Set Vehicle Location (10850) event command or a save load. A game that
+  relies on the tree's own default position for a vehicle it never explicitly
+  places would show that vehicle nowhere, ever. Fixed with a new
+  `Game::State#seed_vehicle_positions(map_tree)`, mirroring
+  `#seed_screen_transitions`'s shape, called once from `RPG2k#start_new_game`
+  right beside the identical seeding already done for the hero's own
+  `initial_map_id`/`x`/`y` — Continue does not call it, since a vehicle's
+  saved position (from this seeding or a later Set Vehicle Location) already
+  round-trips through `Vehicle#to_h`/`#load_h`/`#load_movable`. A vehicle
+  field the tree leaves unset keeps `Vehicle.new`'s own unplaced default.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (each vehicle
+  places at its own tree-configured position; one the tree never positions
+  stays unplaced), confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1253,6 +1253,30 @@ The work below is roughly ordered by the critical path to a walkable game
   lands only where `airship_land` allows, touching down **in place** rather
   than stepping onto the tile ahead the way a boat / ship disembarks onto the
   shore; boat / ship follow their terrain's `boat_pass` / `ship_pass`).
+  ✅ **A vehicle the map tree gives its own starting position now places there
+  at New Game**, instead of staying unplaced until an event runs Set Vehicle
+  Location. RPG2000's editor has a dedicated "set starting position" tool for
+  each vehicle — the map tree's `initial` chunk carries it (fields 11-13 /
+  21-23 / 31-33: `boat_map_id`/`x`/`y`, `ship_map_id`/`x`/`y`,
+  `airship_map_id`/`x`/`y`, `mruby-lcf/mrblib/schema.rb`), parsed by the
+  schema and never read anywhere in `mruby-rpg2k` — `Game::Vehicle.new`
+  always defaulted to `map_id: 0` ("unplaced"), and the only writer of a
+  vehicle's location was the Set Vehicle Location (10850) event command or a
+  save load. A game relying on the tree's own default for a vehicle it never
+  explicitly places (Nepheshel and mtf-meido-action's own boats/ships/
+  airships are both possible examples, unconfirmed either way) would show
+  that vehicle nowhere, ever. Fixed with a new
+  `Game::State#seed_vehicle_positions(map_tree)`, mirroring
+  `#seed_screen_transitions`'s shape, called once from
+  `RPG2k#start_new_game` right beside the identical seeding already done for
+  the hero's own `initial_map_id`/`x`/`y` — Continue does not call it, since
+  a vehicle's saved position (from this seeding or a later Set Vehicle
+  Location) already round-trips through `Vehicle#to_h`/`#load_h`/
+  `#load_movable`. A vehicle field the tree leaves unset keeps
+  `Vehicle.new`'s own unplaced default. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (each vehicle places at its own
+  tree-configured position; one the tree never positions stays unplaced),
+  confirmed to fail against the pre-fix code before the fix.
   Placed vehicles are **drawn on the map** from their CharSet, the
   ridden one following the party under the hero, and the **airship floats above a
   ground shadow**. Boarding **plays the vehicle's own BGM** (the database System
@@ -1486,17 +1510,21 @@ The work below is roughly ordered by the critical path to a walkable game
   an in-place tone would re-tint an already-tinted layer every frame and walk it
   to black.
 
-  **Nothing calls it yet.** A first attempt at wiring it through `Scene::Map`
-  (tone each scene-owned layer into a shadow bitmap, point the sprite at the
-  shadow) was written and then dropped rather than shipped: instrumentation
-  confirms the code runs and finds its four layers, but the rendered frame is
-  unchanged — a forced full-strength green tint moved the frame's mean green by
-  0.09/255. So the remaining work is not the tone maths but finding why a
-  per-frame `Sprite#bitmap=` swap does not reach the display; suspects are the
-  sprite's cached canvas source and the dirty-flag sweep in
-  `mruby-rgss/src/lib.cxx`. Note the obvious probe is misleading: the Nepheshel
-  opening is nearly black (frame mean ~32/255), where a *subtractive* tint
-  changes almost nothing even when it is working — use an additive one
+  ✅ **This paragraph used to end here on "nothing calls it yet" — a
+  `Sprite#bitmap=` shadow-bitmap approach was tried and dropped when
+  instrumentation showed the rendered frame did not change. A later session
+  found a different, working mechanism instead: `RGSS::Viewport#tone`, not a
+  per-sprite bitmap swap.** Every map sprite now lives in one `Viewport`
+  (`Scene::Map`'s `@map_viewport`/`@upper_viewport`) and
+  `Scene::Map#update_map_tone` sets that viewport's tone from
+  `Game::Screen#tint` every frame, reusing the RPG2000→RGSS channel
+  conversion pictures already use (saturation included, which RPG2000 counts
+  down and RGSS counts up) — see the "Render parity" bullet near the top of
+  this document and `changelog.d/screen-tone-viewport.added.md`. A viewport
+  tints the sprites inside it and nothing else, which is the line the screen
+  tone needs: the map is tinted while pictures, the message window and the
+  weather / flash / fade overlays are not. No longer confirmed only by a
+  0.09/255 probe — this is the fix, not the still-open gap.
 - ✅ Random ("wandering monster") encounters — until now the only way to start
   a fight was a scripted Enemy Encounter event command; the map tree's own
   encounter list (`map_properties` field 41 `enemy_groups`, field 44
@@ -3994,10 +4022,20 @@ above are repeated here)
   `scripts/rpg2k_scene_check.rb` check (a strictly-better, a strictly-worse
   and an exactly-equal candidate against a fixed worn item each draw the
   right glyph), confirmed to fail against the pre-fix code before the fix.
-- Text color slots 1-4 have hardcoded semantic roles (stat label /
-  value-increase / value-decrease / low-HP-MP warning), and a State's own
-  configured display-color field is a pointer into that **same** shared
-  palette.
+- ✅ **A State's own configured display-color field is a pointer into the
+  same shared message-colour palette every `\c[n]` code draws from —
+  confirmed already correct, no code change needed.** There is only one
+  20-slot palette in this runtime (`Game::MessagePalette`, a 10×2 grid of
+  windowskin swatches, `mruby-rpg2k/mrblib/game.rb:235`); nothing here special-cases
+  slots 1-4 for a stat label / increase / decrease / low-HP-MP role the way
+  this bullet's first half wondered about — a project's own database chooses
+  those roles by which index it puts where, same as any other coloured text.
+  `Game::States.color(id, table)` (`game.rb:5683`) reads a state row's own
+  `color` field (falling back to `DEFAULT_COLOR = 6` when unset) and
+  `Scene::Base#state_display`/`#draw_actor_state` (`scene/base.rb:91-105`)
+  feeds that index straight into the same `draw_system_text` /
+  `blend_text` path an ordinary `\c[n]` run uses — one palette, one lookup,
+  for both.
 - **Call Event invoked from an Auto-Start parent runs the called content
   under Auto-Start semantics (blocks input) even if the called common
   event's own configured trigger is Parallel Process; Call Event always

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7981,6 +7981,32 @@ module Game
       $stderr.puts "[RPG2k] screen transition defaults unreadable: #{e.message}"
     end
 
+    # Place each vehicle at the map tree's own boat/ship/airship starting
+    # position — the editor's dedicated "set starting position" tool for each
+    # vehicle (the map tree's `initial` chunk, fields 11-13/21-23/31-33),
+    # RPG_RT's counterpart to the hero's own initial_map_id/x/y a few lines up
+    # in `RPG2k#start_new_game`, which is the only caller: a vehicle's saved
+    # position already carries this (or a later Set Vehicle Location's)
+    # placement through `Vehicle#to_h`/`#load_h`/`#load_movable`, so Continue
+    # does not call this and cannot clobber it. A vehicle the tree never
+    # positions keeps `Vehicle.new`'s own unplaced default (map_id 0).
+    def seed_vehicle_positions(map_tree)
+      init = map_tree && map_tree.respond_to?(:initial) ? map_tree.initial : nil
+      return unless init
+      Vehicle::TYPES.each do |type|
+        next unless init.respond_to?("#{type}_map_id")
+        v = @vehicles[type]
+        v.map_id = init.send("#{type}_map_id") || 0
+        v.x = init.send("#{type}_x") || 0
+        v.y = init.send("#{type}_y") || 0
+      end
+    rescue StandardError => e
+      # A tree without the fields is not fatal — every vehicle then stays
+      # unplaced, same as before this method existed — but it should not pass
+      # unnoticed.
+      $stderr.puts "[RPG2k] vehicle start positions unreadable: #{e.message}"
+    end
+
     # Change System Graphics: override the windowskin graphic (System/<name>) and
     # font id. Scene::Map reloads the windowskin so windows created afterwards use
     # the new skin.

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -605,6 +605,9 @@ class RPG2k
     # The database's System tab configures the six screen transitions a
     # "use the configured transition" (-1) Erase / Show Screen resolves against.
     state.seed_screen_transitions @db
+    # The map tree's own boat/ship/airship starting positions, the editor's
+    # counterpart to the hero's initial_map_id/x/y just above.
+    state.seed_vehicle_positions map_tree
     state.map = load_map state.map_id
     # Build the play scene first; only tear down the title once it succeeds so a
     # data problem leaves the title intact instead of a blank screen.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5130,6 +5130,58 @@ check 'Change Screen Transitions sets the chosen slot; round-trips through save'
   eq [0, 0, 0, 0, 0, 0], Game::State.load(db, legacy).screen_transitions
 end
 
+# -- Vehicle starting positions (map tree's own boat/ship/airship tool) ------
+
+FakeMapTreeInitial = Struct.new(:initial_map_id, :initial_x, :initial_y,
+                                 :boat_map_id, :boat_x, :boat_y,
+                                 :ship_map_id, :ship_x, :ship_y,
+                                 :airship_map_id, :airship_x, :airship_y)
+FakeMapTree = Struct.new(:initial)
+
+check 'seed_vehicle_positions places each vehicle at the map tree\'s own start position' do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5,
+                                     max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  ok !st.vehicle(:boat).placed?, 'a fresh vehicle starts unplaced'
+  ok !st.vehicle(:ship).placed?
+  ok !st.vehicle(:airship).placed?
+
+  # The boat and airship are placed by the tree; the ship's fields are left
+  # nil, matching a project whose designer never used the "set ship start
+  # position" editor tool.
+  init = FakeMapTreeInitial.new(1, 5, 5,
+                                 3, 10, 12,
+                                 nil, nil, nil,
+                                 5, 20, 22)
+  st.seed_vehicle_positions(FakeMapTree.new(init))
+
+  ok st.vehicle(:boat).placed?, 'the boat is placed from the tree'
+  eq 3, st.vehicle(:boat).map_id
+  eq 10, st.vehicle(:boat).x
+  eq 12, st.vehicle(:boat).y
+
+  ok !st.vehicle(:ship).placed?,
+     'a vehicle the tree never positions stays unplaced, like Vehicle.new'
+  eq 0, st.vehicle(:ship).map_id
+
+  ok st.vehicle(:airship).placed?
+  eq 5, st.vehicle(:airship).map_id
+  eq 20, st.vehicle(:airship).x
+  eq 22, st.vehicle(:airship).y
+end
+
+check 'seed_vehicle_positions is a no-op for a tree with no start-position fields' do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5,
+                                     max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.seed_vehicle_positions(nil) # no map tree at all
+  ok !st.vehicle(:boat).placed?
+  ok !st.vehicle(:ship).placed?
+  ok !st.vehicle(:airship).placed?
+end
+
 # -- Change System Graphics ---------------------------------------------------
 
 check 'Change System Graphics overrides the windowskin / font; round-trips' do


### PR DESCRIPTION
## Summary
- RPG2000's editor has a dedicated "set starting position" tool for each
  vehicle (the map tree's `initial` chunk, `mruby-lcf/mrblib/schema.rb`
  fields 11-13/21-23/31-33: `boat_map_id`/`x`/`y`, `ship_map_id`/`x`/`y`,
  `airship_map_id`/`x`/`y`), parsed by the schema and never read anywhere
  in `mruby-rpg2k` — `Game::Vehicle.new` always defaulted to `map_id: 0`
  ("unplaced"), and the only writer of a vehicle's location was the Set
  Vehicle Location (10850) event command or a save load. A game relying
  on the tree's own default for a vehicle it never explicitly places
  would show that vehicle nowhere, ever.
- Fixed with a new `Game::State#seed_vehicle_positions(map_tree)`
  (`mruby-rpg2k/mrblib/game.rb`), mirroring `#seed_screen_transitions`'s
  shape, called once from `RPG2k#start_new_game` (`main.rb`) right
  beside the identical seeding already done for the hero's own
  `initial_map_id`/`x`/`y`. Continue does not call it, since a vehicle's
  saved position (from this seeding or a later Set Vehicle Location)
  already round-trips through `Vehicle#to_h`/`#load_h`/`#load_movable`.
  A vehicle field the tree leaves unset keeps `Vehicle.new`'s own
  unplaced default.
- While auditing this region I also found two `docs/TODO.md` paragraphs
  describing already-fixed behavior as still open (Tint Screen's
  viewport-tone wiring, already landed via `Scene::Map#update_map_tone`;
  and a State's display-color palette pointer, already implemented by
  `Game::States.color`) and corrected them to ✅ with citations, rather
  than leaving future sessions to re-investigate settled ground.
- `docs/TODO.md` updated with a ✅ paragraph for the vehicle fix, and a
  changelog fragment added per `changelog.d/README.md`.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 704 checks pass (two new
      checks: each vehicle places at its own tree-configured position;
      one the tree never positions stays unplaced). Both confirmed to
      fail (`NoMethodError`) against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 384 checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhAfZnycRUq5MukJM3q3Mt)_