### PR TITLE
rpg2k: a battle victory now plays the fanfare over the result screen

### DIFF
--- a/changelog.d/battle-victory-bgm.fixed.md
+++ b/changelog.d/battle-victory-bgm.fixed.md
@@ -1,0 +1,17 @@
+- **Enemy Encounter** battles now play the victory fanfare. Winning a fight
+  used to jump straight to the "Victory! / EXP gained" result window with
+  whatever track the battle itself had playing still running; RPG_RT instead
+  swaps in the System's `battle_end_music` (Change System BGM slot 1) the
+  moment the result screen opens, and only brings the pre-battle field /
+  vehicle track back once the player dismisses it. `Scene::Map#victory_bgm`
+  mirrors the existing `#battle_bgm` override-then-default lookup (a Change
+  System BGM slot-1 override wins over the database default), and
+  `#play_victory_bgm` is called from `#enter_battle_result` on a win, right
+  alongside the two slot-0/3-5 lookups `#battle_bgm`/`#vehicle_bgm` already
+  had and the slot-6 one `Scene::GameOver` already had — victory (slot 1) was
+  the one remaining `Game_System::sys_bgm` slot Change System BGM could set
+  but nothing ever played. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (the database `battle_end_music` plays over the result screen and
+  the field BGM resumes only once it is dismissed; a Change System BGM
+  override on slot 1 beats the database default), both confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1295,8 +1295,25 @@ The work below is roughly ordered by the critical path to a walkable game
   (boarding a boat with a Change System BGM override on slot 3 plays that
   override instead of the database `boat_music`), confirmed to fail against
   the pre-fix code before the fix. Battle (slot 0) is consumed too, see the
-  battle-BGM paragraph above; victory / inn / game over (slots 1/2/6) are
-  still save-fidelity-only. **Enter Hero Name**
+  battle-BGM paragraph above; game over (slot 6) too, by
+  `Scene::GameOver#gameover_bgm_override`. ✅ **Victory (slot 1) is now
+  consumed as well: a battle win plays the fanfare over the result screen.**
+  Winning an Enemy Encounter used to cut straight to the "Victory! / EXP
+  gained" window with the battle track still running (or silence, if the
+  encounter had none) — RPG_RT instead swaps in the System's
+  `battle_end_music` the instant the result screen opens, restoring the
+  pre-battle field/vehicle track only once the player dismisses it. A new
+  `Scene::Map#victory_bgm` mirrors `#battle_bgm`'s override-then-default
+  lookup on slot 1, and `#play_victory_bgm` is called from
+  `#enter_battle_result` on `:victory`, leaving `#restore_pre_battle_bgm`
+  (called from `#finish_battle` as before) to do the same job it already did
+  for escape and defeat. Only inn (slot 2) is still save-fidelity-only, since
+  no inn / lodging screen exists in this build. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (the database `battle_end_music`
+  plays over the result screen and the field BGM resumes only once
+  dismissed; a Change System BGM override on slot 1 beats the database
+  default), both confirmed to fail against the pre-fix code before the fix.
+  **Enter Hero Name**
   (10740) opens a character-entry widget that renames a
   party actor; **Change Level** (10420) / **Change EXP** (10410) honour their
   "show message" flag — a level-up queues one message per level gained, shown

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2872,11 +2872,13 @@ module Game
     # 1 victory, 2 inn, 3 boat, 4 ship, 5 airship, 6 game over) selected by
     # param0. The remaining fields carry a Music struct: string = file name,
     # param1 fade-in, param2 volume, param3 tempo, param4 balance. Stashed in
-    # a Game::State slot table; Scene::Map's #battle_bgm reads slot 0 (battle)
-    # and #vehicle_bgm reads slots 3-5 (boat/ship/airship) back out ahead of
-    # the database default, the same override-then-default idiom Change
-    # System SFX already gets. Victory (1), inn (2) and game over (6) still
-    # only round-trip through the save, since nothing plays them yet.
+    # a Game::State slot table; Scene::Map's #battle_bgm reads slot 0 (battle),
+    # #victory_bgm reads slot 1 (the "Victory!" result screen) and #vehicle_bgm
+    # reads slots 3-5 (boat/ship/airship) back out ahead of the database
+    # default, the same override-then-default idiom Change System SFX already
+    # gets; Scene::GameOver#gameover_bgm_override does the same for slot 6.
+    # Inn (2) still only round-trips through the save, since nothing plays it
+    # yet (no inn / lodging screen exists in this build).
     def do_change_system_bgm(cmd)
       @state.system_bgm[cmd.param(0)] = {
         name: cmd.string, fadein: cmd.param(1), volume: cmd.param(2),

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1422,9 +1422,10 @@ class RPG2k
       end
 
       # System BGM slot indices, as used by Change System BGM (10660) --
-      # matches the slot 0 = battle reading already documented on the
-      # rpg2k_logic_check.rb coverage for that command.
+      # matches the slot 0 = battle / 1 = victory reading already documented
+      # on the rpg2k_logic_check.rb coverage for that command.
       SYSTEM_BGM_BATTLE = 0
+      SYSTEM_BGM_VICTORY = 1
 
       # Play the battle BGM when a fight opens, remembering the field/vehicle
       # BGM that was playing so #restore_pre_battle_bgm can bring it back once
@@ -1459,6 +1460,42 @@ class RPG2k
         return nil if name.nil? || name.empty?
         { name: name, volume: music_volume(db.system.battle_music),
           tempo: music_tempo(db.system.battle_music) }
+      end
+
+      # Play the victory fanfare over the result window on a win, the same way
+      # #play_battle_bgm swaps in the battle track when the fight opens. RPG_RT
+      # stops the battle BGM the instant the last enemy falls and plays the
+      # System's battle_end_music (Change System BGM slot 1) for the "Victory! /
+      # EXP gained" screen; #restore_pre_battle_bgm already brings the
+      # pre-battle field/vehicle track back once that screen is dismissed
+      # (#finish_battle), so nothing here needs to remember or restore
+      # anything of its own. A game with no victory BGM configured leaves
+      # whatever was playing (the battle track) alone, the same blank-Music
+      # no-op #battle_bgm documents.
+      def play_victory_bgm
+        music = victory_bgm
+        return unless music
+        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
+        @state.current_bgm = music
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] victory BGM failed: #{e.message}"
+      end
+
+      # The victory BGM to play as { name:, volume:, tempo: }, or nil when
+      # neither source names a file. Prefers a Change System BGM override for
+      # the victory slot over the database's own System battle_end_music --
+      # the same override-then-default idiom #battle_bgm uses for the battle
+      # slot.
+      def victory_bgm
+        ov = @state.system_bgm[SYSTEM_BGM_VICTORY]
+        if ov && ov[:name] && !ov[:name].to_s.empty?
+          return { name: ov[:name], volume: ov[:volume] || 100,
+                    tempo: ov[:tempo] || 100 }
+        end
+        name = music_name(db.system.battle_end_music)
+        return nil if name.nil? || name.empty?
+        { name: name, volume: music_volume(db.system.battle_end_music),
+          tempo: music_tempo(db.system.battle_end_music) }
       end
 
       # Restore the BGM that was playing before the fight started. A no-op
@@ -4219,6 +4256,7 @@ class RPG2k
 
       def enter_battle_result(result)
         @battle_ui[:result] = result
+        play_victory_bgm if result == :victory
         lines = battle_result_lines(result, @battle_ui[:troop])
         [@battle_ui[:status_win], @battle_ui[:cmd_win]].each { |w| w.dispose if w }
         @battle_ui[:status_win] = nil

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3647,6 +3647,51 @@ check 'Enemy Encounter scene: a Change System BGM battle override beats the data
   eq 'CustomBattle', st.current_bgm[:name]
 end
 
+check 'Enemy Encounter scene: victory plays the database battle_end_music over the result screen' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.db.system.battle_end_music =
+    OpenStruct.new(file: 'VictoryBGM', volume: 90, pitch: 105)
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 } # the map's own BGM
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  eq [['VictoryBGM', 90, 105]], RGSS::Audio.bgm_calls,
+     'the victory fanfare played as soon as the result screen appeared'
+  eq 'VictoryBGM', st.current_bgm[:name]
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result
+  scene.update
+  RGSS::Input.triggered = []
+  eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
+     'the field BGM that was playing before the fight replays once the result is dismissed'
+  eq 'Field', st.current_bgm[:name]
+end
+
+check 'Enemy Encounter scene: a Change System BGM victory override beats the database battle_end_music' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  scene.db.system.battle_end_music =
+    OpenStruct.new(file: 'VictoryBGM', volume: 90, pitch: 105)
+  # System BGM slot 1 is victory -- see the matching rpg2k_logic_check.rb note.
+  st.system_bgm[1] = { name: 'CustomVictory', fadein: 0, volume: 60, tempo: 130,
+                       balance: 50 }
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  eq [['CustomVictory', 60, 130]], RGSS::Audio.bgm_calls,
+     'the Change System BGM override played instead of the database battle_end_music'
+  eq 'CustomVictory', st.current_bgm[:name]
+end
+
 check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- Winning an Enemy Encounter used to jump straight to the "Victory! / EXP gained" result window with whatever track the battle itself had playing still running (or silence, if the encounter named no battle music). RPG_RT instead stops the battle track and plays the System's `battle_end_music` (Change System BGM slot 1) the instant the result screen opens, restoring the pre-battle field/vehicle track only once the player dismisses it.
- `Scene::Map#victory_bgm` mirrors the existing `#battle_bgm` override-then-default lookup, now on slot 1 (a Change System BGM override on slot 1 wins over the database default). `#play_victory_bgm` is called from `#enter_battle_result` on a `:victory` outcome, alongside the slot-0 battle lookup and the slot-3/4/5 vehicle lookups that already existed; `#restore_pre_battle_bgm` (already called from `#finish_battle`) does the rest, unchanged.
- Also fixes a stale comment on `do_change_system_bgm` that still listed game over (slot 6) as unplayed, even though `Scene::GameOver#gameover_bgm_override` already consumes it — only inn (slot 2) remains save-fidelity-only now, since there's no inn/lodging screen in this build yet.
- Updates `docs/TODO.md`'s Event system section with the ✅ writeup, and adds `changelog.d/battle-victory-bgm.fixed.md`.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 707 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 386 checks passed, including two new checks:
  - "victory plays the database battle_end_music over the result screen" (and that the field BGM resumes only once the result is dismissed)
  - "a Change System BGM victory override beats the database battle_end_music"
- Both new checks confirmed to **fail** against the pre-fix code (`got []` — no BGM call at all) before the fix, and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fgb89Jfzha1LFhkviKPAgo)_