### PR TITLE
rpg2k: an in-battle recovery skill's heal now varies too

### DIFF
--- a/changelog.d/battle-heal-skill-variance.fixed.md
+++ b/changelog.d/battle-heal-skill-variance.fixed.md
@@ -1,0 +1,25 @@
+- **A battle Skill's HP/SP recovery now spreads by the skill's own variance
+  too**, matching a damage skill's own spread. RPG2000's
+  `Algo::VarianceAdjustEffect` is one function applied to whichever signed
+  effect `Algo::CalcSkillEffect` produced — a Cure spell's heal wobbles the
+  same way a Fire spell's damage does — but `Game::Party#battle_skill_command`
+  only attached a `variance:` figure to the attack branch (enemy-scope
+  skills), and `Game::Battle#apply_skill_hit`'s recovery branch never read one
+  even when it had it: every ally-scope skill in a fight — self, single-ally
+  and all-ally alike — restored exactly its deterministic base amount, round
+  after round, while the identical field/menu cast was *supposed* to be the
+  only deterministic path (its own doc comment already said so: "battle
+  applies a +/- variance, but field/menu use does not"). Both are fixed:
+  `battle_skill_command`'s heal branch now reports `variance: skill_variance
+  (sk)` alongside its `hp`/`mp`, and `apply_skill_hit` spreads `hp` and `mp`
+  independently through the same `#varied` helper the attack branch already
+  uses, only when the fight has variance enabled. An item's fixed effect is
+  untouched — items carry no `variance` field, so `apply_skill_hit`'s new
+  spread is a no-op there, and an ordinary attack's own variance path is
+  unchanged. Covered by three new `scripts/rpg2k_logic_check.rb` checks (a
+  seeded fight's ally-scope heal lands a spread of values within the same
+  `base`/`variance` range the equivalent attack-scope skill spreads within; a
+  fight with variance off heals for the exact deterministic base amount; and
+  `battle_skill_command`'s heal branch reports the skill's own variance
+  rather than dropping it), confirmed to fail against the pre-fix code (a
+  constant heal, a missing `variance` key) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1671,7 +1671,46 @@ The work below is roughly ordered by the critical path to a walkable game
   with no map or interpreter behind it, so it still cannot tell "this skill is
   legitimately state-gated" from "no menu reaches this skill" on its own, and
   keeps deferring those two types to this note instead of flagging them as
-  unreachable. Left unbuilt still: the battle-time skill variance.
+  unreachable.
+  ✅ **The battle-time skill variance is built now, for a recovery skill too —
+  not just an attack one.** This line used to end "Left unbuilt still: the
+  battle-time skill variance," describing only the missing half:
+  `Game::Party#battle_skill_command`'s attack branch (enemy-scope skills) has
+  carried a `variance:` figure since damage variance first landed (see the
+  Event command interpreter entry above), but its recovery branch (self /
+  single-ally / all-ally skills) never attached one at all, and
+  `Game::Battle#apply_skill_hit`'s recovery half never read `cmd[:variance]`
+  even when a caller supplied it — so every in-battle heal, buff or revive
+  landed exactly its deterministic base amount round after round, the one
+  thing `#skill_effect`'s own doc comment ("battle applies a +/- variance,
+  but field/menu use does not") already said should *not* happen there.
+  RPG2000's `Algo::VarianceAdjustEffect` is one function applied to whichever
+  signed effect `Algo::CalcSkillEffect` produces — a Cure spell's heal
+  wobbles the same way a Fire spell's damage does, there being no
+  damage-only/heal-only split in the reference algorithm — so the fix mirrors
+  the attack branch rather than inventing a new mechanism:
+  `battle_skill_command`'s `else` (heal) branch now reports `variance:
+  skill_variance(sk)` alongside its `hp`/`mp`, and `apply_skill_hit` spreads
+  `hp` and `mp` independently through the same `#varied` helper the attack
+  branch already calls (each rolls its own random offset, since HP and SP are
+  two separate effect values sharing one base rather than one number applied
+  twice), gated on the fight having variance enabled at all. Both the party's
+  own healers and an enemy's ally-scoped heal (行動パターン, see the Event
+  command interpreter entry) go through the identical `battle_skill_command`
+  call, so the fix reaches both sides symmetrically with no separate enemy-AI
+  change needed. An item's fixed recovery is untouched — items carry no
+  `variance` field on their schema, so the new spread is a no-op on that path
+  — and the field/menu Skill scene stays exactly as deterministic as before,
+  since `Game::Party#skill_effect` (the field formula) was never touched.
+  Covered by three new `scripts/rpg2k_logic_check.rb` checks (a seeded
+  in-battle heal spreads across the same base/variance range the equivalent
+  attack skill already spreads within; a variance-off fight heals for the
+  exact deterministic base; `battle_skill_command`'s heal branch reports the
+  skill's own variance rather than dropping it), plus an update to the
+  pre-existing `battle_skill_command yields attack damage, ally heal and self
+  recovery` check's expectations (both now include the `variance` key),
+  confirmed to fail against the pre-fix code (a constant heal across every
+  seeded cast; a missing `variance` key) before the fix.
   ✅ **A special item (type 9) invoking an Escape/Teleport skill is castable
   from the field Item menu now.** `#field_usable?` used to call
   `#field_skill?(db_skill(it.skill_id))` with no `Game::State` at all, so its

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3407,6 +3407,9 @@ module Game
     # to the target — negative HP for an attack skill (base effect less a quarter
     # of the target's defence, min 1), positive HP / SP for a recovery skill. An
     # attack skill also carries the states it may inflict and the roll chance.
+    # Both branches carry the skill's own `variance` now — `Game::Battle#apply_
+    # skill_hit` is what actually spreads either sign of effect by it, this
+    # method just reports the number the skill row names.
     def battle_skill_command(sk, caster, target)
       cost = skill_cost(sk, caster)
       base = skill_effect(sk, caster)
@@ -3429,7 +3432,7 @@ module Game
           absorb: skill_absorbs?(sk), attr_shift: shift, attr_ids: shift_ids }
       else
         { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0,
-          attr_shift: shift, attr_ids: shift_ids }
+          variance: skill_variance(sk), attr_shift: shift, attr_ids: shift_ids }
       end
     end
 
@@ -7419,6 +7422,22 @@ module Game
           skill_id: cmd[:skill_id], target_index: @enemies.index(target),
           absorbed_hp: absorbed }
       else
+        # Spread the recovery by the skill's own variance when the fight rolls
+        # it, the same way the attack branch above does: EasyRPG's
+        # `Algo::VarianceAdjustEffect` is one function applied to whichever
+        # signed effect `CalcSkillEffect` produced, not a damage-only step, so
+        # a Cure spell's heal wobbles exactly like a Fire spell's damage does.
+        # HP and SP roll independently (`#varied` draws its own random offset
+        # each call) since a skill can restore both from the same base effect
+        # and RPG_RT does not correlate the two rolls. An item's fixed effect
+        # never carries a `variance` (items have no such field), so this is a
+        # no-op there; a 0 (or absent) `hp`/`mp` clears #varied's own `base >
+        # 0` guard, so a skill that only restores one of the two leaves the
+        # other alone.
+        if @variance && cmd[:variance] && cmd[:variance] > 0
+          hp = varied(hp, cmd[:variance])
+          mp = varied(mp, cmd[:variance])
+        end
         before_hp = target.hp
         before_mp = target.mp || 0
         hp = RECOVER_CAP if hp > RECOVER_CAP

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7135,6 +7135,58 @@ check 'battle skill damage varies by the skill variance when the fight rolls it'
   ok dmgs.all? { |d| d >= 26 && d <= 38 }, "within 26..38 (#{dmgs.inspect})"
 end
 
+check 'battle heal skill recovery varies by the skill variance when the fight rolls it' do
+  skills = { 8 => fake_skill(name: 'Heal', scope: 3, sp_cost: 0, power: 20,
+                             mrate: 40, hp: true, variance: 4) }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # spi 12 -> effect 32
+  ally = combatant('Ally', 0, 0, 5, 1000)                   # tall max HP headroom
+  bat = Game::Battle.new([caster, ally], [combatant('Foe', 0, 0, 1, 1)],
+                        Game::Rng.new(1), nil, true)         # variance on
+  c = st.party.battle_skill_command(st.party.db_skill(8), caster, ally) # base 32
+  heals = []
+  20.times do
+    ally.hp = 1 # reset below the cap each cast so the spread is never clipped
+    bat.command_skill(caster, ally, name: 'Heal', cost: c[:cost], hp: c[:hp],
+                      mp: c[:mp], variance: c[:variance])
+    bat.begin_round
+    e = bat.step_action # the faster caster (agi 7) heals before ally/foe act
+    heals << e[:recover_hp] if e && e[:recover]
+  end
+  # base 32, var 4 -> adj = 12, spread 32-6 .. 32+12-6 = 26..38, same range the
+  # attack-side variance check above measures for the identical base/variance --
+  # `#apply_skill_hit`'s heal branch used to skip `#varied` entirely, so every
+  # cast landed exactly 32 (this check would have failed on that count alone).
+  ok heals.uniq.length > 1, "heal recovery varies (#{heals.uniq.sort.inspect})"
+  ok heals.all? { |h| h >= 26 && h <= 38 }, "within 26..38 (#{heals.inspect})"
+end
+
+check 'without variance a seeded fight heals exactly the base amount' do
+  skills = { 8 => fake_skill(name: 'Heal', scope: 3, sp_cost: 0, power: 20,
+                             mrate: 40, hp: true, variance: 4) }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  ally = combatant('Ally', 0, 0, 5, 1000)
+  ally.hp = 1
+  bat = Game::Battle.new([caster, ally], [combatant('Foe', 0, 0, 1, 1)],
+                        Game::Rng.new(1)) # 3-arg: variance off
+  c = st.party.battle_skill_command(st.party.db_skill(8), caster, ally)
+  bat.command_skill(caster, ally, name: 'Heal', cost: c[:cost], hp: c[:hp],
+                    mp: c[:mp], variance: c[:variance])
+  bat.begin_round
+  e = bat.step_action # the faster caster (agi 7) heals before ally/foe act
+  eq 32, e[:recover_hp], 'exact base, unaffected without the fight rolling variance'
+end
+
+check 'battle_skill_command carries the skill variance on its heal branch too' do
+  skills = { 8 => fake_skill(name: 'Heal', scope: 3, sp_cost: 5, power: 20,
+                             mrate: 40, hp: true, variance: 7) }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  c = st.party.battle_skill_command(st.party.db_skill(8), caster, nil)
+  eq 7, c[:variance], 'the heal branch reports the skill row variance, not 0'
+end
+
 check 'Battle: a stronger party wins, a weaker one is defeated' do
   hero = combatant('Hero', 40, 20, 20, 200)
   slime = combatant('Slime', 8, 4, 5, 30)
@@ -7351,10 +7403,10 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   eq({ cost: 6, hp: -24, mp: 0, inflict: [], chance: 100, variance: 4,
        attributes: [], absorb: false, attr_shift: nil, attr_ids: [] },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
-  eq({ cost: 5, hp: 32, mp: 0, attr_shift: nil, attr_ids: [] },
+  eq({ cost: 5, hp: 32, mp: 0, variance: 4, attr_shift: nil, attr_ids: [] },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))
   # Cure affects HP and SP: effect = 10 + 40*12/40 = 22
-  eq({ cost: 4, hp: 22, mp: 22, attr_shift: nil, attr_ids: [] },
+  eq({ cost: 4, hp: 22, mp: 22, variance: 4, attr_shift: nil, attr_ids: [] },
      st.party.battle_skill_command(st.party.db_skill(9), caster, nil))
 end
 


### PR DESCRIPTION
## Summary
- `Game::Party#battle_skill_command`'s attack branch (enemy-scope skills)
  already attached a `variance:` figure and `Game::Battle#apply_skill_hit`'s
  damage branch already spread it via `#varied`, but the recovery branch
  (self/single-ally/all-ally skills — heals, buffs, revives) never got a
  `variance:` key at all, and `apply_skill_hit`'s recovery half never
  called `#varied` even when handed one — every in-battle heal (both the
  party's own healers and an enemy's ally-scoped heal via 行動パターン,
  since both route through the same `battle_skill_command`) landed exactly
  its deterministic base amount round after round, contradicting the
  code's own stated intent that battle applies variance while field/menu
  use does not.
- `battle_skill_command`'s heal branch now reports `variance:
  skill_variance(sk)`; `apply_skill_hit`'s recovery branch spreads `hp` and
  `mp` independently through `#varied` (each its own random roll, since
  RPG_RT doesn't correlate the two) when the fight has variance enabled.
  An item's fixed effect carries no `variance` field, so items are
  unaffected; a skill restoring only one of hp/mp leaves the other alone
  via `#varied`'s own `base > 0` guard.
- `docs/TODO.md` updated ✅, replacing the "Left unbuilt still: the
  battle-time skill variance" note.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 710 checks pass (one updated
      check plus three new: a seeded in-battle heal spreads across the
      expected base/variance range; a variance-off fight heals for the
      exact base; `battle_skill_command`'s heal branch reports the skill's
      own variance — all three confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 384 checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_