### PR TITLE
rpg2k: staying at an inn now plays the inn's own BGM

### DIFF
--- a/changelog.d/rpg2k-inn-bgm.fixed.md
+++ b/changelog.d/rpg2k-inn-bgm.fixed.md
@@ -1,0 +1,11 @@
+- **Show Inn** (RPG Maker 2000, command 10730) now plays the inn's own BGM.
+  `Scene::Map#drive_inn` never touched the music at all — staying at an inn
+  played in total silence, or just let the field track keep looping — no
+  matter what the database's System `inn_music` named. New
+  `Scene::Map#play_inn_bgm` / `#restore_pre_inn_bgm` mirror the memorize/
+  restore idiom `#play_battle_bgm` / `#play_vehicle_bgm` already use: the inn
+  BGM (a Change System BGM slot-2 override, else the database default) starts
+  the moment the Show Inn request is seen — prompted or free (price 0) alike
+  — and the prior track resumes once the stay is resolved. Covered by new
+  `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -636,9 +636,10 @@ The work below is roughly ordered by the critical path to a walkable game
   the save (`@state.system_bgm[cmd.param(0)]`); slot 0 (battle, see the
   battle-BGM paragraph below), slots 3-5 (boat / ship / airship, matching
   EasyRPG's `Game_System::sys_bgm` enum, see the vehicle-boarding paragraph
-  below) and slot 6 (game over, see the Game Over paragraph under "Menus,
-  save, battle" below) are now read back too, so only slots 1/2 (victory /
-  inn) are still modelled for save fidelity like the access flags. **Change System
+  below), slot 6 (game over, see the Game Over paragraph under "Menus,
+  save, battle" below) and slot 2 (inn, see the Show Inn paragraph below)
+  are now read back too, so only slot 1 (victory) is still modelled for
+  save fidelity like the access flags. **Change System
   SFX** (10670) is now consumed on the map: the choice window plays the cursor
   sound as the selection moves and the decision sound on confirm, resolving a
   Change System SFX override on `Game::State` before the database default
@@ -681,16 +682,38 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` check (a Change System BGM override for
   slot 0 plays instead of the database `battle_music` the moment the battle
   UI opens), confirmed to fail against the pre-fix code before the fix. The
-  remaining System BGM slots (victory / inn / game over) are still
-  save-fidelity-only, per the note above — boat / ship / airship (slots 3-5)
-  are consumed too, see the vehicle-boarding paragraph below.
+  remaining System BGM slot (victory, slot 1) is still save-fidelity-only,
+  per the note above — inn (slot 2, see the Show Inn paragraph below), boat
+  / ship / airship (slots 3-5, see the vehicle-boarding paragraph below) and
+  game over (slot 6, see the Game Over paragraph under "Menus, save,
+  battle" below) are all consumed too.
   **Show Inn** (10730) is a playable game-mode: a priced inn opens a greeting
   window with Accept / Cancel choices (Accept gated on whether the party can
   afford it) plus a gold window, staying deducts the price and fully heals the
   party, and either outcome routes into the command's optional `[Stay]` /
   `[No Stay]` handler branches (structured and skipped like Show Choices).
   `Game::Interpreter` owns the gameplay and suspends on an `:inn` wait that
-  `Scene::Map` drives; the inn fade and jingle are presentation still to come.
+  `Scene::Map` drives; the inn **fade** is presentation still to come.
+  ✅ **The inn now plays its own BGM.** `Scene::Map#drive_inn` never touched
+  the music at all — staying at an inn played in total silence, or just let
+  the field track keep looping, no matter what `db.system.inn_music` named,
+  the exact gap the "jingle... still to come" wording above used to
+  describe. New `#play_inn_bgm` / `#restore_pre_inn_bgm` mirror the
+  memorize/restore idiom `#play_battle_bgm` / `#play_vehicle_bgm` already
+  use: `#drive_inn` plays the resolved inn BGM (a Change System BGM slot-2
+  override, else the database default, via the same `#inn_bgm` /
+  `music_name`/`music_volume`/`music_tempo` helpers battle and vehicle BGM
+  already use) the first frame it sees a fresh Show Inn request — prompted
+  or free (price 0) alike, since a free stay still resumes through the same
+  `#drive_inn` call rather than a separate branch that could skip the swap —
+  and restores the prior track once the stay is resolved, whether by
+  Accept, Cancel or the free-stay auto-resume. A game with no inn BGM
+  configured leaves whatever was already playing alone, matching
+  `#battle_bgm`'s own no-op. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (the database default plays and the
+  field BGM resumes after a prompted stay; a Change System BGM override for
+  slot 2 beats the database default; a free stay plays and restores the BGM
+  too), confirmed to fail against the pre-fix code before the fix.
   **Open Shop** (10720) is a playable game-mode too: a `Game::Shop` holds the
   goods and buy / sell rules and performs the transactions (buy at the database
   price, sell at half, party 99-item / gold caps enforced), tracking whether

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -118,6 +118,7 @@ class RPG2k
         build_parallels
         @message = nil
         @inn_window = nil
+        @inn_bgm_started = false
         @shop = nil
         @battle_ui = nil
         @name_ui = nil
@@ -1474,6 +1475,58 @@ class RPG2k
         @state.current_bgm = bgm
       rescue StandardError => e
         $stderr.puts "[RPG2k] restoring BGM after battle failed: #{e.message}"
+      end
+
+      # System BGM slot index for Change System BGM (10660)'s inn override,
+      # matching EasyRPG's Game_System::sys_bgm enum (Battle 0, Victory 1,
+      # Inn 2, ...) -- the same enum VEHICLE_SYSTEM_BGM_SLOT below resolves
+      # its own slots against.
+      SYSTEM_BGM_INN = 2
+
+      # Play the inn's own BGM when a Show Inn command opens its stay -- a
+      # Change System BGM override for the inn slot when one is set, else the
+      # database System inn_music -- remembering the BGM that was playing so
+      # #restore_pre_inn_bgm can bring it back once the stay is resolved. The
+      # same memorize/restore idiom #play_battle_bgm / #play_vehicle_bgm
+      # already use. A game with no inn BGM configured (override or
+      # database) leaves whatever was already playing alone.
+      def play_inn_bgm
+        music = inn_bgm
+        return unless music
+        @pre_inn_bgm = @state.current_bgm
+        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
+        @state.current_bgm = music
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] inn BGM failed: #{e.message}"
+      end
+
+      # The inn BGM to play as { name:, volume:, tempo: }, or nil when
+      # neither source names a file. Prefers a Change System BGM override for
+      # the inn slot over the database's own System inn_music -- the same
+      # override-then-default idiom #battle_bgm / #vehicle_bgm already use.
+      def inn_bgm
+        ov = @state.system_bgm[SYSTEM_BGM_INN]
+        if ov && ov[:name] && !ov[:name].to_s.empty?
+          return { name: ov[:name], volume: ov[:volume] || 100, tempo: ov[:tempo] || 100 }
+        end
+        name = music_name(db.system.inn_music)
+        return nil if name.nil? || name.empty?
+        { name: name, volume: music_volume(db.system.inn_music),
+          tempo: music_tempo(db.system.inn_music) }
+      end
+
+      # Restore the BGM that was playing before the inn stay began. A no-op
+      # when the inn never touched the music (no inn BGM configured), so the
+      # field/vehicle track was never interrupted and there is nothing to
+      # bring back.
+      def restore_pre_inn_bgm
+        bgm = @pre_inn_bgm
+        @pre_inn_bgm = nil
+        return unless bgm && bgm[:name] && !bgm[:name].empty?
+        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
+        @state.current_bgm = bgm
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] restoring BGM after inn failed: #{e.message}"
       end
 
       # System BGM slot indices for Change System BGM (10660), matching
@@ -2841,11 +2894,18 @@ class RPG2k
       # Drive a Show Inn wait: a free stay (price 0) resumes at once; otherwise a
       # greeting window with Accept / Cancel choices and a gold window is shown,
       # Accept selectable only when the party can afford the price. The
-      # interpreter charges gold and heals the party in resume_inn.
+      # interpreter charges gold and heals the party in resume_inn. The inn's
+      # own BGM (#play_inn_bgm) starts the first frame a request is seen and
+      # #restore_pre_inn_bgm brings the prior track back once the stay resolves
+      # -- either path, prompted or free.
       def drive_inn
         req = @interpreter.inn_request
         return @interpreter.resume_inn(false) unless req
-        return @interpreter.resume_inn(true) unless req[:prompt]
+        unless @inn_bgm_started
+          play_inn_bgm
+          @inn_bgm_started = true
+        end
+        return finish_inn(true) unless req[:prompt]
 
         if @inn_window.nil?
           open_inn_window(req) # opened this frame; take input from the next one
@@ -2864,16 +2924,24 @@ class RPG2k
             # Accept: only honoured when the party can pay; otherwise ignored.
             if req[:can_afford]
               close_inn_window
-              @interpreter.resume_inn(true)
+              finish_inn(true)
             end
           else
             close_inn_window
-            @interpreter.resume_inn(false)
+            finish_inn(false)
           end
         elsif Input.trigger?(Input::B)
           close_inn_window
-          @interpreter.resume_inn(false)
+          finish_inn(false)
         end
+      end
+
+      # Restore the pre-inn BGM and resume the interpreter with the player's
+      # stay/no-stay decision -- the common tail of every #drive_inn exit path.
+      def finish_inn(stayed)
+        @inn_bgm_started = false
+        restore_pre_inn_bgm
+        @interpreter.resume_inn(stayed)
       end
 
       # RPG2000 inn term set (A or B) selected by the command's type parameter.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -228,6 +228,7 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
   OpenStruct.new(
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
                            battle_music: OpenStruct.new(file: 'BattleBGM', volume: 70, pitch: 110),
+                           inn_music: OpenStruct.new(file: 'InnBGM', volume: 75, pitch: 105),
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
                            ship_music: OpenStruct.new(file: 'ShipBGM', volume: 80, pitch: 100),
                            airship_music: OpenStruct.new(file: 'AirBGM', volume: 80, pitch: 100),
@@ -1700,6 +1701,48 @@ check 'Show Inn scene: the Accept / Cancel cursor wraps around' do
   scene.update
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@inn_choice), 'Down from Cancel wraps back to Accept'
+end
+
+check 'Show Inn scene: inn BGM plays on entry, field BGM resumes after a stay' do
+  scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 } # the map's own BGM
+  RGSS::Audio.reset_bgm
+  5.times { scene.update } # inn command runs; the greeting prompt opens
+  eq [['InnBGM', 75, 105]], RGSS::Audio.bgm_calls,
+     'the database inn BGM played the moment the greeting opened'
+  eq 'InnBGM', st.current_bgm[:name], 'and is now the tracked current BGM'
+  RGSS::Audio.reset_bgm
+  RGSS::Input.triggered = [RGSS::Input::C] # cursor starts on Accept (affordable)
+  scene.update # resumes with a stay
+  eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
+     'the field BGM that was playing before the stay replays once it resolves'
+  eq 'Field', st.current_bgm[:name]
+end
+
+check 'Show Inn scene: a Change System BGM inn override beats the database default' do
+  scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  # System BGM slot 2 is inn -- see the Game::Interpreter::Cmd note near
+  # VEHICLE_SYSTEM_BGM_SLOT / SYSTEM_BGM_INN in scene/map.rb.
+  st.system_bgm[2] = { name: 'CustomInn', fadein: 0, volume: 60, tempo: 130, balance: 50 }
+  RGSS::Audio.reset_bgm
+  5.times { scene.update }
+  eq [['CustomInn', 60, 130]], RGSS::Audio.bgm_calls,
+     'the Change System BGM override played instead of the database inn_music'
+  eq 'CustomInn', st.current_bgm[:name]
+end
+
+check 'Show Inn scene: a free stay (price 0) still plays and restores the inn BGM' do
+  scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 0)) # price 0 skips the prompt
+  st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
+  RGSS::Audio.reset_bgm
+  # No greeting window opens for a free stay, so this reaches both the BGM
+  # swap and the resolved Stay branch in a few frames of ordinary event
+  # processing (unlike the priced-prompt tests, no player input is needed).
+  3.times { scene.update }
+  eq [['InnBGM', 75, 105], ['Field', 100, 100]], RGSS::Audio.bgm_calls,
+     'the inn BGM played, then the field BGM was restored, in the same beat'
+  eq 'Field', st.current_bgm[:name]
+  ok st.switches[1], 'the Stay branch ran (a free stay always stays)'
 end
 
 check 'Key Input Proc waits for a key, stores its code, then continues' do


### PR DESCRIPTION
## Summary
- Show Inn (10730) was already a fully playable game-mode (greeting window, Accept/Cancel, gold charge, party heal, [Stay]/[No Stay] handlers), but `Scene::Map#drive_inn` never touched the music at all — staying at an inn played in total silence, or just let the field track keep looping, no matter what `db.system.inn_music` named. `docs/TODO.md` explicitly flagged this ("the inn fade and jingle are presentation still to come").
- New `Scene::Map#play_inn_bgm` / `#restore_pre_inn_bgm` mirror the memorize/restore idiom `#play_battle_bgm` / `#play_vehicle_bgm` already use: `#drive_inn` plays the resolved inn BGM (a Change System BGM slot-2 override, else the database default, via a new `#inn_bgm` using the same `music_name`/`music_volume`/`music_tempo` helpers) the first frame it sees a fresh Show Inn request — prompted or free (price 0) alike, since a free stay resumes through the same `#drive_inn` call rather than a separate branch — and restores the prior track once the stay resolves, whether by Accept, Cancel, or the free-stay auto-resume.
- `docs/TODO.md` updated ✅ (also fixes an adjacent stale "remaining unconsumed BGM slots" note that still listed game-over as unconsumed, even though `Scene::GameOver` already reads its own slot).
- `changelog.d/rpg2k-inn-bgm.fixed.md` added per the changelog fragment format.

Note: the screen **fade** RPG_RT plays around the inn stay is a separate, still-open presentational gap — left untouched here to keep this change scoped to the audio gap the TODO called out.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 707 checks pass (unchanged; no logic-only surface touched).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 387 checks pass, including three new checks:
  - the database `inn_music` plays the moment the greeting prompt opens, and the field BGM resumes once the stay is accepted
  - a Change System BGM override for slot 2 (inn) beats the database default
  - a free stay (price 0, no prompt) still plays and restores the inn BGM
- [x] All three new checks confirmed to **fail** against the pre-fix code (`got []` — no BGM call at all) before the fix, and pass after.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wurc69Wi2Wb47VULDaWM8t)_