### PR TITLE
rpg2k: a plain attack now plays its weapon's own battle animation

### DIFF
--- a/changelog.d/battle-attack-weapon-animation.fixed.md
+++ b/changelog.d/battle-attack-weapon-animation.fixed.md
@@ -1,0 +1,25 @@
+- **A plain battle Attack now plays its own animation.** RPG2000 keeps the
+  animation for a basic attack on the *equipped weapon* (item field 20,
+  the weapon editor's own "アニメーション" picker) or, unarmed, on the actor
+  row's own `unarmed_animation` (field 56, 素手戦闘アニメID) — both decoded by
+  the schema and read by nothing, so every Skill/Item animation played
+  (see the "Battle animations" entry in `docs/TODO.md`) while a plain sword
+  swing stayed silent. `Game::Actor#attack_animation_id`
+  (`mruby-rpg2k/mrblib/game.rb`) resolves the primary weapon slot's
+  `animation_id` when one is worn and set, falling back to the actor's own
+  unarmed id otherwise; `Game::Battle#deal_attack` attaches it (and the
+  target's `@enemies` index, needed to centre the animation on the right
+  sprite and previously never carried by a plain-attack log entry either)
+  onto every entry it returns, hit or miss alike — a miss still swings, only
+  the damage is zeroed. `Scene::Map#battle_animation_id` now falls back to
+  that field once neither a skill nor an item claims the entry. A monster's
+  own basic attack still plays nothing, matching RPG2000: there is no
+  equivalent per-enemy field to read (Combatant#actor is nil for an enemy
+  snapshot). Covered by new `scripts/rpg2k_logic_check.rb` checks (the
+  weapon/unarmed fallback logic itself; a plain attack's log entry carrying
+  the resolved animation id and target index; both of a 二刀流 weapon's
+  swings carrying the identical id; an enemy attacker carrying none) and new
+  `scripts/rpg2k_scene_check.rb` checks (a plain attack with a resolved id
+  plays over the targeted enemy sprite the same way a skill/item does; one
+  with nothing resolved plays nothing), all confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -966,9 +966,13 @@ The work below is roughly ordered by the critical path to a walkable game
   battler's computed order — this build sorts the flag ahead of agility
   instead of reproducing that literal offset, since the per-round agility
   jitter `CreateExecutionOrder` also rolls is not itself modelled here, and
-  the offset's only observable effect is "always first"). Still unread:
-  **`raise_evasion`**, which has nowhere to land until the to-hit formula
-  grows an evasion term separate from agility. **Elemental attributes**
+  the offset's only observable effect is "always first"). ✅ **`raise_evasion`
+  is read now too** — this line used to end here calling it unread with
+  "nowhere to land until the to-hit formula grows an evasion term separate
+  from agility"; the to-hit formula grew that term (see the "Assets &
+  infrastructure" section's own 物理回避率アップ entry, `Actor#
+  physical_evasion_up?` and `Battle#to_hit`'s flat -25 against a wearer's
+  attacker), just not documented back onto this paragraph. **Elemental attributes**
   scale damage too: a weapon's `attribute_set` / a skill's `attribute_effects`
   are matched against the target's per-attribute defence ranks (A..E, strongest
   element winning) — the rates come from each attribute's own `a_rate` .. `e_rate`
@@ -1912,9 +1916,37 @@ The work below is roughly ordered by the critical path to a walkable game
   by the target's **index** so two monsters sharing a name cannot be confused, or
   over the middle of the screen for an action aimed at a party member, since
   RPG2000's first-person battle draws no ally sprite. Left for their own changes:
-  a **plain attack's** animation (RPG2000 takes it from the equipped weapon,
-  which the entry does not carry), and per-cell tone and scale, which the map
-  path has never had either. See ADR 0037.
+  per-cell tone and scale, which the map path has never had either. See ADR
+  0037.
+  ✅ **A plain Attack now plays its own animation too**, closing the "left for
+  their own changes" gap this line used to name. RPG2000 keeps a basic
+  attack's animation on the *equipped weapon* (item field 20, the weapon
+  editor's own "アニメーション" picker) or, unarmed, on the actor row's own
+  `unarmed_animation` (field 56, 素手戦闘アニメID) — both decoded by the schema
+  and read by nothing, so a Fire spell flashed while the sword swing right
+  before it stayed silent. `Game::Actor#attack_animation_id`
+  (`mruby-rpg2k/mrblib/game.rb`) resolves the primary weapon slot's
+  `animation_id` when one is worn and set, falling back to the unarmed id
+  otherwise (a 二刀流 actor's second weapon, in the shield slot, is not
+  consulted — RPG_RT keeps this as one property per actor rather than one per
+  swing, so both of a dual-wielder's blows play the identical animation), and
+  `Game::Battle#deal_attack` attaches it — plus the target's `@enemies`
+  index, needed to centre on the right sprite and, like the animation id
+  itself, never carried by a plain-attack log entry before this — to every
+  entry it returns, a miss included (the swing still happens; only its
+  damage is what a miss zeroes). `Scene::Map#battle_animation_id` falls back
+  to that field once neither a skill nor an item claims the entry. An
+  enemy's own basic attack still plays nothing, matching RPG2000 (there is
+  no per-monster equivalent field; `Combatant#actor` is nil for an enemy
+  snapshot, which `#attack_animation_id`'s caller reads as "nothing to
+  resolve"). Covered by new `scripts/rpg2k_logic_check.rb` checks (the
+  weapon/unarmed fallback itself; a plain attack's entry carrying the
+  resolved id and target index; a 二刀流 weapon's two swings carrying the
+  identical id; an enemy attacker carrying none) and new
+  `scripts/rpg2k_scene_check.rb` checks (a plain attack with a resolved id
+  plays over the targeted enemy sprite the same way a skill/item does; one
+  with nothing resolved plays nothing), confirmed to fail against the
+  pre-fix code before the fix.
   ✅ **The `position` field (0 head / 1 center / 2 feet, `battle_anime` chunk
   19 field 10) now actually offsets where an animation draws**, instead of
   being decoded (`build_animation`'s own `position:`) and never read again —

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1545,6 +1545,31 @@ module Game
       best && best > 0 ? best : 90
     end
 
+    # The battle animation a basic Attack plays with this actor's current gear:
+    # the primary weapon slot's own `animation_id` (item field 20 -- the
+    # weapon editor's own "アニメーション" picker; the same field
+    # Scene::Map#battle_animation_id already reads off a *used* skill/item,
+    # reused here for a weapon's normal-attack swing) when one is worn and set,
+    # or the actor row's `unarmed_animation` (field 56, 素手戦闘アニメID)
+    # otherwise -- RPG2000 has no equivalent monster-side field (an enemy's
+    # Attack plays no animation at all), so this is Actor-only by design, not
+    # an oversight. Only the primary slot is read: RPG_RT keeps this as one
+    # property per actor rather than one per weapon, and a 二刀流 actor's
+    # second swing (the shield-slot weapon #attack_hit_rate's own scan already
+    # picks up for hit/crit) plays the identical animation as the first, so
+    # there is nothing here for that second weapon to override.
+    def attack_animation_id
+      iid = @equipment[WEAPON_SLOT]
+      if iid && iid != 0 && @db.respond_to?(:item)
+        it = @db.item[iid]
+        if it && it.respond_to?(:type) && it.type == ITEM_WEAPON &&
+           it.respond_to?(:animation_id) && it.animation_id && it.animation_id > 0
+          return it.animation_id
+        end
+      end
+      @db_row.respond_to?(:unarmed_animation) ? @db_row.unarmed_animation : nil
+    end
+
     # Whether any equipped item carries boolean field `name`. The weapon combat
     # flags below all work this way — one piece of gear is enough to grant them.
     # `weapon_only` restricts the search to the weapon slot (item type 1), which
@@ -7117,12 +7142,27 @@ module Game
     end
 
     def deal_attack(b, target)
+      # A plain attack's own battle animation -- the attacking actor's current
+      # gear (Actor#attack_animation_id), or nil for an enemy (b.actor is nil;
+      # see #attack_animation_id's own doc comment for why enemies have none
+      # to read) or a bare fixture Combatant with no #actor field at all. The
+      # animation plays on a miss too -- the swing itself always happens, only
+      # its damage is what a miss zeroes -- so this is computed once and
+      # attached to both branches below.
+      anim = b.respond_to?(:actor) && b.actor.respond_to?(:attack_animation_id) ? b.actor.attack_animation_id : nil
+      # Where it plays: over the targeted enemy's sprite, the same
+      # `@enemies.index(target)` lookup #apply_command already attaches to a
+      # skill/item entry -- nil when the target is a party member (RPG2000
+      # draws no ally sprite; #battle_animation_pixel's screen-centre
+      # fallback covers that case exactly as it does for a skill/item).
+      target_index = @enemies.index(target)
       # When accuracy is on, roll the attacker's to-hit chance: a miss deals no
       # damage and reads as `missed` on the log entry.
       if @accuracy && !hits?(b, target)
         return { attacker: b.name, target: target.name, damage: 0, missed: true,
                  critical: false, target_hp: target.hp < 0 ? 0 : target.hp,
-                 defeated: false, target_ally: ally?(target) }
+                 defeated: false, target_ally: ally?(target), attack_animation_id: anim,
+                 target_index: target_index }
       end
       dmg = Battle.attack_damage(effective_atk(b), effective_def(target))
       # An elemental weapon scales its damage by the target's resistance before
@@ -7157,7 +7197,8 @@ module Game
       woke = target.dead? ? [] : shake_off_states(target)
       entry = { attacker: b.name, target: target.name, damage: dmg, critical: crit,
                 charged: charged, target_hp: target.hp < 0 ? 0 : target.hp,
-                defeated: target.dead?, target_ally: ally?(target) }
+                defeated: target.dead?, target_ally: ally?(target),
+                attack_animation_id: anim, target_index: target_index }
       entry[:woke] = woke unless woke.empty?
       entry
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4079,9 +4079,11 @@ class RPG2k
       # skill rows and 170 item rows across the test beds name one, and none of
       # them played. Returns true when one started.
       #
-      # A plain attack's animation is the equipped weapon's, which the log entry
-      # does not carry, so it is left for a change that plumbs the weapon
-      # through rather than guessed at here.
+      # A plain attack now plays one too: Game::Battle#deal_attack resolves
+      # the attacking actor's own weapon/unarmed animation (Actor#
+      # attack_animation_id) and carries it on the log entry as
+      # `attack_animation_id`, which #battle_animation_id below reads once
+      # neither a skill nor an item claims the entry.
       def start_battle_animation(entry)
         id = battle_animation_id(entry)
         return false unless id && id > 0
@@ -4104,7 +4106,10 @@ class RPG2k
           elsif entry[:item_id] && db.respond_to?(:item) && db.item
             db.item[entry[:item_id]]
           end
-        row && row.respond_to?(:animation_id) ? row.animation_id : nil
+        return row.animation_id if row && row.respond_to?(:animation_id)
+        # Neither a skill nor an item: a plain Attack, whose own animation
+        # Game::Battle#deal_attack already resolved onto the log entry.
+        entry[:attack_animation_id]
       end
 
       # Where it plays: over the targeted enemy's sprite. RPG2000 draws no sprite

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2379,7 +2379,12 @@ FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
                            :equipment_fixed,
                            # The actor's default FaceSet portrait (Enter Hero
                            # Name's face box). Same reasoning: appended last.
-                           :faceset_name, :faceset_index)
+                           :faceset_name, :faceset_index,
+                           # 素手戦闘アニメID -- the battle animation a basic
+                           # Attack plays with no weapon equipped
+                           # (Actor#attack_animation_id). Same reasoning:
+                           # appended last, defaults nil (no animation).
+                           :unarmed_animation)
 # Like FakePlayerRow but exposing the full growth curve the way a real LCF row
 # does (six shorts per level via #int16_values(31)), so Actor scales its base
 # stats by level instead of using a single level-independent status hash.
@@ -2445,7 +2450,12 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :cursed,
                       # 物理回避率アップ: a normal attack against the wearer is
                       # 25 points likelier to miss (Actor#physical_evasion_up?).
-                      :raise_evasion)
+                      :raise_evasion,
+                      # アニメーション (weapon field 20): the battle animation a
+                      # basic Attack plays with this weapon equipped
+                      # (Actor#attack_animation_id). Appended last, same
+                      # positional-safety reasoning as every field above.
+                      :animation_id)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -2454,14 +2464,14 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               field_only: false, dual_attack: false, ignore_evasion: false,
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
-              cursed: false, raise_evasion: false)
+              cursed: false, raise_evasion: false, animation_id: nil)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
-               raise_evasion)
+               raise_evasion, animation_id)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -8573,6 +8583,66 @@ check "battle: physical-evasion-up gear drops a normal attack's hit chance by 25
   hero.equip([0, 7, 0, 0, 0])
   geared = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
   eq 65, geared.send(:to_hit, foe, geared.allies[0]), 'the shield drops it to 65'
+end
+
+# アニメーション (weapon field 20): a basic Attack now plays the equipped
+# weapon's own battle animation, or the actor row's own 素手戦闘アニメID when
+# unarmed -- previously decoded and read by neither, so a plain attack was
+# always silent regardless of what the weapon editor named
+# (docs/TODO.md's "Battle animations" entry used to end "Left for their own
+# changes: a plain attack's animation... left for a change that plumbs the
+# weapon through rather than guessed at here").
+check "Actor#attack_animation_id reads the primary weapon slot, falling back to unarmed" do
+  items = { 7 => fake_item(type: 1, animation_id: 12),   # a sword, animation 12
+            8 => fake_item(type: 1) }                    # a sword naming none
+  row = CurveRow.new('Hero', '', 0, 1, [200, 50, 20, 10, 10, 10])
+  row.unarmed_animation = 4
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.leader
+
+  eq 4, hero.attack_animation_id, 'unarmed falls back to the actor row\'s own id'
+  hero.equip([7, 0, 0, 0, 0])
+  eq 12, hero.attack_animation_id, 'the equipped weapon\'s own animation wins'
+  hero.equip([8, 0, 0, 0, 0])
+  eq 4, hero.attack_animation_id,
+     'a weapon naming no animation (0, the "none" choice) falls back to unarmed too'
+end
+
+check 'battle: a plain attack carries its attacker\'s weapon animation and target index on the log entry' do
+  items = { 7 => fake_item(type: 1, atk: 5, animation_id: 9) }
+  st = geared_party(items)
+  hero = st.party.leader
+  hero.equip([7, 0, 0, 0, 0])
+  foe = combatant('Foe', 0, 0, 5, 100)
+
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  entry = bat.send(:deal_attack, bat.allies[0], foe)
+  eq 9, entry[:attack_animation_id], 'the hero\'s equipped weapon animation rides along'
+  eq 0, entry[:target_index], 'and so does the target\'s index into @enemies'
+
+  # An enemy attacking the party has no weapon to read: `combatant` builds a
+  # bare Combatant with #actor nil, exactly what Battle.from_enemy itself
+  # leaves nil (enemies keep no source actor) -- matching the "no such field
+  # for a monster" note on Actor#attack_animation_id's own doc comment.
+  attacker = combatant('Foe', 20, 0, 5, 100)
+  rev = Game::Battle.new([bat.allies[0]], [attacker], Game::Rng.new(1))
+  back = rev.send(:deal_attack, attacker, rev.allies[0])
+  eq nil, back[:attack_animation_id], 'an enemy\'s own basic attack plays no animation'
+  eq nil, back[:target_index], 'the target is a party member -- no enemy-side sprite to index'
+end
+
+check 'battle: 二刀流\'s second swing plays the same weapon animation as the first' do
+  items = { 7 => fake_item(type: 1, atk: 5, dual_attack: true, animation_id: 3) }
+  st = geared_party(items)
+  hero = st.party.leader
+  hero.equip([7, 0, 0, 0, 0])
+  foe = combatant('Foe', 0, 0, 5, 10_000) # never dies, so both swings land
+
+  bat = Game::Battle.new([Game::Battle.from_actor(hero)], [foe], Game::Rng.new(1))
+  first, second = bat.send(:swing, bat.allies[0], foe)
+  eq 3, first[:attack_animation_id]
+  eq 3, second[:attack_animation_id], 'both of a 二刀流 weapon\'s blows carry the identical id'
 end
 
 check 'battle: 必中 still suffers the wielder\'s own blindness' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6657,7 +6657,33 @@ check 'an item names its animation the same way a skill does' do
      'the fixture Potion names none'
   eq 8, scene.send(:battle_animation_id, { skill_id: 8 })
   eq nil, scene.send(:battle_animation_id, { attacker: 'Hero' }),
-     'a plain attack carries no animation yet'
+     'a plain attack with no attack_animation_id resolved (a bare fixture Combatant, or an enemy) carries none'
+  eq 5, scene.send(:battle_animation_id, { attacker: 'Hero', attack_animation_id: 5 }),
+     'a plain attack falls back to the id Game::Battle#deal_attack already resolved onto the entry'
+end
+
+# A plain Attack now plays its attacker's own weapon/unarmed animation too,
+# not just a Skill/Item -- Game::Battle#deal_attack resolves
+# Actor#attack_animation_id onto the log entry, and #battle_animation_id reads
+# it once neither skill_id nor item_id claims the entry (see the check above).
+check 'a plain attack with a resolved weapon animation plays it over the targeted enemy' do
+  scene, ui = battle_at_command
+  entry = { attacker: 'Hero', target: 'Slime', damage: 7,
+            attack_animation_id: 8, target_index: 0, target_ally: false }
+  ok scene.send(:start_battle_animation, entry), 'an animation started, same as a skill would'
+  ma = scene.instance_variable_get(:@map_animation)
+  ok ma, 'the player was armed'
+  spr = ui[:enemy_sprites][0]
+  eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
+     [ma[:tx], ma[:ty]], 'centred on the targeted enemy sprite, same as a skill/item animation'
+end
+
+check 'a plain attack with nothing resolved plays no animation' do
+  scene, = battle_at_command
+  ok !scene.send(:start_battle_animation,
+                 { attacker: 'Hero', target: 'Slime', damage: 7, target_index: 0 }),
+     'an unarmed attacker with no unarmed_animation configured, or an enemy, carries no id'
+  eq nil, scene.instance_variable_get(:@map_animation)
 end
 
 check 'the battle animation draws in screen pixels, not map ones' do


### PR DESCRIPTION
## Summary
- RPG2000 keeps a basic attack's battle animation on the equipped weapon
  (item field 20, `animation_id`) or, unarmed, on the actor's own
  `unarmed_animation` field (56) — both parsed by the schema but never read
  by the runtime, so every Skill/Item animation played in battle while a
  plain sword swing stayed silent.
- New `Game::Actor#attack_animation_id` resolves the primary weapon slot's
  `animation_id`, falling back to `unarmed_animation`.
  `Game::Battle#deal_attack` resolves it once per swing and attaches it plus
  the target's `@enemies` index to every log entry, hit and miss alike (the
  swing itself always happens; only its damage is what a miss zeroes),
  including both blows of a dual-wield attack.
  `Scene::Map#battle_animation_id` falls back to
  `entry[:attack_animation_id]` when neither a skill nor an item claims the
  entry — no new native work, reusing the existing skill/item animation
  pipeline. Enemies correctly still play nothing: RPG_RT has no equivalent
  monster-side field.
- Also corrected a stale `docs/TODO.md` note: `raise_evasion` was flagged as
  unread, but it was already implemented in an earlier session
  (`Actor#physical_evasion_up?` / `Battle#to_hit`'s flat -25).
- `docs/TODO.md` updated ✅.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 713 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 391 checks pass (new checks
      confirmed to fail against the pre-fix code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_