### PR TITLE
rpg2k: a Parallel Process page now also answers hero touch

### DIFF
--- a/changelog.d/parallel-trigger-hero-touch.fixed.md
+++ b/changelog.d/parallel-trigger-hero-touch.fixed.md
@@ -1,0 +1,11 @@
+- **A map event page set to Parallel Process now also answers hero contact**,
+  on top of the background loop it already runs continuously. `touch_trigger?`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) only recognised Player Touch (1) and
+  Event Touch (2), so a Parallel-triggered (4) event never started through the
+  foreground touch path at all — matching yado.tk's documented quirk, it now
+  fires instantly on overlap for a below/above-characters page and repeatedly
+  while a direction key is held into a same-as-characters (blocking) one,
+  through a second, independent run of the shared foreground `@interpreter`
+  that leaves the event's own always-running background process untouched.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check, confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2517,11 +2517,29 @@ Everything below is unverified against the codebase.
   since its context is gone post-transfer; "On Loss: Handle Separately" +
   an immediate recovery branch can still lose to Game Over if *any*
   Parallel Process is still running (must stop them all first) — same
-  family as the `016_ikinari_end` race above; **setting a map event's
+  family as the `016_ikinari_end` race above; ✅ **setting a map event's
   trigger to Parallel Process also fires it on hero contact** — instantly
   on overlap for below/above-characters priority, repeatedly while a
-  direction key is held against a same-as-characters (blocking) one. Worth
-  checking against `step_parallel`/touch-trigger dispatch.
+  direction key is held against a same-as-characters (blocking) one. This
+  was a real, reachable gap: `Scene::Map#touch_trigger?`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — the single check `#step_movement`
+  consults before letting the party step onto a tile — only recognised
+  Player Touch (1) and Event Touch (2), so a Parallel-triggered (4) event
+  never started through the foreground touch path at all; its own
+  always-running background loop (`#step_parallel`) was the only thing that
+  ever ran it. Fixed by adding `TRIGGER_PARALLEL` to `#touch_trigger?`'s
+  check, which inherits the exact dispatch shape the two dedicated touch
+  triggers already have for free — no other code needed to change. The two
+  runs are independent: contact starts a *second* pass through the shared
+  foreground `@interpreter`, alongside (not instead of) the event's own
+  background `@parallels` entry, which keeps looping untouched. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (a below-characters Parallel
+  event opens a message window through the foreground touch path the moment
+  the party walks into it, distinguishing the two runs by a Show Message a
+  background interpreter's own request is silently dropped, per
+  `#drive_parallel_wait`'s "background: ignore message/choice/teleport
+  requests" branch), confirmed to fail against the pre-fix code before the
+  fix.
 - **Vehicles** — an unset vehicle defaults to map id 0, (0,0); Small/Large
   Ship aren't hardcoded to water, their passability follows the terrain
   table's boat/ship-pass flags like any other vehicle rule; ✅ an airship
@@ -2896,10 +2914,11 @@ not yet verified:
   contact); hero and event simultaneously swap tiles. Also newly found
   this pass: touch triggers only fire on **forward** movement onto the
   tile, not on a "move backward" move-route step reaching the same tile.
-- Setting a page's trigger to **Parallel Process** *also* answers hero
+- ✅ Setting a page's trigger to **Parallel Process** *also* answers hero
   contact: fires instantly on overlap for a below/above-characters page,
   or repeatedly while a direction key is held against a same-as-characters
-  (blocking) one.
+  (blocking) one — now fixed, see the fuller writeup under the
+  "Full-site sweep" **Parallel Process** bullet above.
 - ✅ **Standing on a "Hero Touch" trigger's tile suppresses random
   encounters there** (multiply corroborated) — see the fuller writeup under
   "Untriaged backlog, from `2k/01_shoshin/011_siyou/`" above (the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1295,10 +1295,16 @@ class RPG2k
         ev && ev[:trigger] == TRIGGER_ACTION && ev[:commands] ? true : false
       end
 
-      # Whether a trigger is one of the two the party can set off by walking into
-      # the event (see the note in #try_move).
+      # Whether a trigger is one the party can set off by walking into the event
+      # (see the note in #step_movement). yado.tk: a Parallel Process page
+      # answers hero contact too, on top of the background loop #step_parallel
+      # already drives it through -- the two are independent, so a below/above-
+      # characters Parallel event fires the instant the party overlaps its
+      # tile and a same-as-characters one fires again on every repeat into it,
+      # exactly like the two dedicated touch triggers already do.
       def touch_trigger?(trigger)
-        trigger == TRIGGER_PLAYER_TOUCH || trigger == TRIGGER_EVENT_TOUCH
+        trigger == TRIGGER_PLAYER_TOUCH || trigger == TRIGGER_EVENT_TOUCH ||
+          trigger == TRIGGER_PARALLEL
       end
 
       # Whether (x, y) carries an upper-layer counter tile.
@@ -6451,7 +6457,10 @@ class RPG2k
           # the one the trigger names suggest — an "event touch" (2) event fires
           # whether it walked into the party or the party walked into it, while
           # a "player touch" (1) fires only on the party's own move (the event
-          # side checks trigger 2 alone, see #move_autonomous).
+          # side checks trigger 2 alone, see #move_autonomous). A **Parallel
+          # Process** (4) page answers here too (see #touch_trigger?) — its own
+          # background loop (#step_parallel) is untouched, so contact starts a
+          # second, independent run through the shared foreground @interpreter.
           touched = event_at(nx, ny)
           if touched && touch_trigger?(touched[:trigger]) && touched[:commands]
             start_event(touched)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1264,6 +1264,29 @@ check 'parallel (trigger 4): a background event runs every frame' do
   ok v >= 8, "parallel event should have looped ~10 times, got #{v}"
 end
 
+check 'parallel (trigger 4) also answers hero touch, independent of its own ' \
+      'background loop (yado.tk)' do
+  # yado.tk: setting a page's trigger to Parallel Process also answers hero
+  # contact -- instantly on overlap for a below/above-characters page (the
+  # default layer here), same as the two dedicated touch triggers. Distinguish
+  # the foreground touch-triggered run from the event's own always-running
+  # background loop with a Show Message: a background interpreter's message
+  # request is silently ignored (#drive_parallel_wait's "background: ignore
+  # message/choice/teleport requests" branch), so @message only ever opens
+  # through the foreground #start_event/#drive_event path this fix adds.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 4) # parallel process
+  pg.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi')]
+  scene = new_scene({ 1 => event(1, 0, pg) }, player: [0, 0])
+  RGSS::Input.dir_value = 6 # hold right, into the parallel event at (1,0)
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'walking into a Parallel Process event opened a message window ' \
+          'through the foreground touch path'
+  st = scene.instance_variable_get(:@state)
+  eq [0, 0], [st.x, st.y], 'the party did not step onto the event'
+end
+
 check 'Wait 0.0 sec pauses a foreground event for exactly one frame' do
   # RPG_RT pauses a Wait 0.0 command and resumes it on the very next frame,
   # since 0 seconds have already elapsed by then -- so it costs exactly one


### PR DESCRIPTION
## Summary

- yado.tk documents a real RPG_RT quirk (corroborated twice in `docs/TODO.md`'s backlog): a map event page whose trigger is set to **Parallel Process** still answers hero contact on top of its own always-running background loop — instantly on overlap for a below/above-characters page, repeatedly while a direction key is held into a same-as-characters (blocking) one, exactly like the two dedicated touch triggers (Player Touch / Event Touch) already do.
- `Scene::Map#touch_trigger?` (`mruby-rpg2k/mrblib/scene/map.rb`), the single check `#step_movement` consults before letting the party step onto a tile, only recognised `TRIGGER_PLAYER_TOUCH`/`TRIGGER_EVENT_TOUCH`. A Parallel-triggered event's own `#step_parallel` background loop was the only thing that ever ran it — walking into one did nothing extra.
- Fixed by adding `TRIGGER_PARALLEL` to `#touch_trigger?`, which inherits the existing dispatch shape for free (no other logic needed to change). The two runs are independent: contact starts a *second*, foreground pass through the shared `@interpreter`, alongside — not instead of — the event's own background `@parallels` entry, which keeps looping untouched.
- Updated the two corresponding `docs/TODO.md` backlog citations to ✅ and added a changelog fragment (`changelog.d/parallel-trigger-hero-touch.fixed.md`).

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: a below-characters Parallel Process event opens a message window through the foreground touch path the instant the party walks into it. Distinguishes the foreground run from the event's own background loop via Show Message — a background interpreter's own message request is silently dropped (`#drive_parallel_wait`'s "background: ignore message/choice/teleport requests" branch), so `@message` only ever opens through the foreground `#start_event`/`#drive_event` path this fix adds.
- Confirmed the new check fails against the pre-fix code (stashed the `map.rb` change and re-ran) before the fix, and passes after.
- `ruby scripts/rpg2k_logic_check.rb` — 713 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 392 checks passed (including the new check).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Up8VY3A72Xg8giko2GT12q)_