### PR TITLE
rpg2k: confirm \^ inside Show Choices is already inert

### DIFF
--- a/changelog.d/choice-caret-auto-close-inert-confirmed.changed.md
+++ b/changelog.d/choice-caret-auto-close-inert-confirmed.changed.md
@@ -1,0 +1,9 @@
+- **`\^` inside a Show Choices label is confirmed already inert, no code
+  change needed** — a standalone choice window computes `:auto_close` from
+  its labels but `Scene::Map#drive_message` never reads it for a choice
+  window (only ever for a plain text message), and a choice list merged
+  onto a preceding Show Text discards the scanned `:auto_close` outright
+  before a reveal object is even built. Either way a choice list can only
+  ever close on player input, matching real RPG_RT. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against a
+  temporarily-patched build that makes `\^` auto-close a choice window.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3396,7 +3396,28 @@ not yet verified:
   so a pause or more text right after one of these three codes now reveals
   one frame later than it would with the code removed — previously they were
   pure no-ops in the reveal counter.
-- `\^` doesn't work inside Show Choices even though other codes do.
+- ✅ **`\^` inside Show Choices is confirmed already inert, no code change
+  needed** — both the ways a choice list can appear stop it from ever being
+  read. A **standalone** Show Choices (`open_message` in
+  `mruby-rpg2k/mrblib/scene/map.rb`) does compute `:auto_close` off every
+  label's own `Game::Message.scan` and folds it into the `reveal` it builds
+  — but `#drive_message` dispatches a `choice: true` message straight into
+  its Down/Up/C/B navigation branch and never calls `#drive_text_message`,
+  the only place `reveal.auto_close?` is ever consulted; a choice window can
+  only close on an actual player pick or a cancel, exactly matching real
+  RPG_RT (a choice always waits for one). A choice list **merged** onto a
+  preceding Show Text (`#append_choice_lines`, the "text on top, choices
+  below" case one open window shares) does not even reach that far: its own
+  `Game::Message.scan` calls thread `color` through the labels for the
+  \c[]-bleed fix above but discard the returned `:auto_close` outright, so a
+  `\^` there is dropped before a reveal object is even built. Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks (a `\^` in a standalone choice
+  label leaves the window open with no input, closing only once the player
+  actually picks one; the same in a label merged onto a preceding Show
+  Text), both confirmed to fail against a temporarily-patched build that
+  makes `#drive_message` honour `auto_close?` for a choice window (and,
+  for the merged case, makes `#append_choice_lines` thread the scanned
+  `:auto_close` into its own `reveal` too) before being reverted.
 - Message Options (window transparency/position) are **sticky global
   state** — once set, they apply to every subsequent message window for
   the rest of the game (or until reset), not scoped to the current event.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2406,6 +2406,74 @@ check 'an explicit \c[0] in the Show Text stops the colour bleeding into Show Ch
      'the reset before the text ends carries a colour 0 into the choices, not 2'
 end
 
+check 'a \\^ in a standalone Show Choices label is confirmed already inert (yado.tk)' do
+  # yado.tk: "\^ doesn't work inside Show Choices even though other codes
+  # do." A standalone choice window (no preceding Show Text) is what
+  # Game::Message.scan's own :auto_close flag is computed from (open_message
+  # sums it across every label's scan) -- but #drive_message dispatches a
+  # `choice: true` message straight into the Down/Up/C/B navigation branch
+  # and never reaches #drive_text_message, the only place `reveal.auto_close?`
+  # is ever read. A choice list can only ever close on player input, matching
+  # real RPG_RT (choices always wait for a pick), so this stays open here too.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_CHOICES, [0], indent: 0),
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes\\^'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'no'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'the choice window opened'
+  5.times { RGSS::Input.reset; scene.update }
+  ok scene.instance_variable_get(:@message),
+     'the \\^ in the first label did not auto-close the window with no input'
+  eq 2, scene.instance_variable_get(:@message)[:count], 'both options are still listed'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm option 0 ("yes\^")
+  scene.update
+  ok !scene.instance_variable_get(:@message),
+     'the window closes on an actual player pick, same as any other choice'
+end
+
+check 'a \\^ in a choice merged onto a preceding Show Text stays inert there too' do
+  # The merged path (Show Text immediately followed by Show Choices, kept in
+  # one window -- see #append_choice_lines) never even records auto_close
+  # from the choice labels' own scans, so the same yado.tk finding holds
+  # there for a different structural reason than the standalone case above.
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_MESSAGE, [], indent: 0, string: 'hi'),
+    ECmd.new(ic::SHOW_CHOICES, [0], indent: 0),
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes\\^'),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'no'),
+    ECmd.new(ic::CHOICE_END, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  12.times { scene.update; break if scene.instance_variable_get(:@message) }
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # completes the reveal; window stays open
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # a Show Choices follows directly, so it keeps the window open
+  RGSS::Input.reset
+  merged = nil
+  8.times do
+    scene.update
+    merged = scene.instance_variable_get(:@message)
+    break if merged && merged[:choice]
+  end
+  ok merged, 'the choices merged onto the still-open text window'
+  5.times { RGSS::Input.reset; scene.update }
+  ok scene.instance_variable_get(:@message),
+     'the \\^ in the merged choice label did not auto-close the window either'
+end
+
 check 'a Show Text keeps its window open when an Input Number follows directly' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s yado.tk quirks backlog flagged: "`\^` doesn't work inside Show Choices even though other codes do." Traced both ways a choice list can appear on screen and confirmed this is already correct — no code change needed:

- **Standalone Show Choices** (`Scene::Map#open_message`): does compute `:auto_close` off every label's `Game::Message.scan` and folds it into the `reveal` object it builds — but `#drive_message` dispatches a `choice: true` message straight into its Down/Up/C/B navigation branch and never calls `#drive_text_message`, the only place `reveal.auto_close?` is ever read. A choice window can only close on an actual player pick or a cancel.
- **A choice list merged onto a preceding Show Text** (`#append_choice_lines`, the "text on top, choices below" case one shared window handles): doesn't even get that far — its own `Game::Message.scan` calls thread `color` through the labels (for the existing `\c[]`-bleed fix) but discard the returned `:auto_close` outright, so a `\^` there is dropped before a reveal object is even built.

Either way, a choice list can only ever close on player input, which matches real RPG_RT (a choice prompt always waits for a pick).

## Changes

- `docs/TODO.md`: marks the backlog line ✅ "confirmed already correct" with the mechanism above cited.
- `scripts/rpg2k_scene_check.rb`: two new regression checks — one for the standalone case, one for the merged case.
- `changelog.d/choice-caret-auto-close-inert-confirmed.changed.md`: changelog fragment.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 710 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 391 checks passed (388 pre-existing + these 2 new... actually the diff adds 2 new checks to the existing suite).
- Verified both new checks actually catch a regression: temporarily patched `Scene::Map#drive_message` to honor `auto_close?` for a choice window (and, for the merged case, patched `#append_choice_lines` to thread the scanned `:auto_close` into its own `reveal`) — both new checks failed as expected — then reverted the patch before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M2PcLJRYE1poFfcSD7dqb

---
_Generated by [Claude Code](https://claude.ai/code/session_015M2PcLJRYE1poFfcSD7dqb)_