### PR TITLE
rpg2k: the field menu's command list matches RPG2000 vs RPG2003 exactly

### DIFF
--- a/changelog.d/menu-command-list-2003-rpg2k-status.fixed.md
+++ b/changelog.d/menu-command-list-2003-rpg2k-status.fixed.md
@@ -1,0 +1,29 @@
+- **The field menu now shows the right command list for the editor that wrote
+  the game, instead of a fixed six commands.** `Scene::Menu` hardcoded Item,
+  Skill, Equip, Status, Save, End Game for every project, but RPG2000's own
+  menu is only *five* commands — Item, Skill, Equip, Save, End Game, with **no
+  Status entry at all** (EasyRPG's `Scene_Menu::CreateCommandWindow`'s
+  `Player::IsRPG2k()` branch hardcodes exactly that set regardless of database
+  content; RPG2000's party list already shows name/level/HP/MP, and Equip
+  already shows the full stat block, so there is nothing for a separate Status
+  screen to add). RPG2003 replaces the fixed list with the System database's
+  own customizable one (chunk 22 field 27, `menu_commands` — unread until now)
+  matching EasyRPG's `CommandOptionType` enum: Item, Skill, Equipment, Save,
+  Status, Row, Order, Wait, with Quit/End Game appended unconditionally after
+  it. A real RPG2003 game's array both picks *which* commands show (mtf-
+  meido-action's is `[1, 2, 3, 4, 5, 6, 7, 8]`, all eight) and their *order* —
+  our own Status command had no way to appear via the customizable list, and a
+  game that reordered or dropped a command (hiding Save, say) had that ignored
+  entirely. `Scene::Menu#build_commands` now branches on `LCF::Database#rpg2003?`
+  (ADR 0013's edition detector): the RPG2000 fixed five, or the RPG2003
+  database's own list filtered through a small id→command table. Row (battle
+  front/back rank), Order (party reordering) and Wait (the ATB toggle) have no
+  entry in that table and are silently skipped — RPG2003 battle-system
+  features this runtime does not model, the same reported-gap precedent the
+  Toggle ATB Mode (5003) event command already establishes. Covered by new
+  `scripts/rpg2k_scene_check.rb` checks (a non-2003 database never offers
+  Status; a 2003 database's full eight-command array offers Status and drops
+  Row/Order/Wait; a 2003 database that reorders and omits commands is honoured
+  end to end, including actually opening the reordered Status screen),
+  confirmed to fail against the pre-fix code (Status always offered; a 2003
+  reorder/omission ignored) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1609,7 +1609,46 @@ The work below is roughly ordered by the critical path to a walkable game
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a
   command list. Save, End Game, **Item**, **Skill**, **Equip** and **Status** all
-  work — the full main-menu set. The **Item** command opens
+  work.
+  ✅ **The command list itself now matches the editor that wrote the game**,
+  rather than always showing the same fixed six. This line used to claim
+  Item/Skill/Equip/Status/Save/End Game was simply "the full main-menu set,"
+  which is EasyRPG's RPG**2003** menu, not RPG2000's: `Scene_Menu::
+  CreateCommandWindow`'s `Player::IsRPG2k()` branch hardcodes exactly **five**
+  commands — Item, Skill, Equip, Save, End Game, **no Status entry at all** —
+  regardless of database content, since RPG2000's party list already shows
+  name/level/HP/MP and Equip already shows the full stat block, leaving
+  nothing for a separate Status screen to add. RPG2003 instead builds the list
+  from the System database's own customizable field (chunk 22 field 27,
+  `menu_commands`, `mruby-lcf/mrblib/schema.rb` — parsed by the schema and
+  never read anywhere in `mruby-rpg2k` before this), matching EasyRPG's
+  `CommandOptionType` enum (Item=1, Skill=2, Equipment=3, Save=4, Status=5,
+  Row=6, Order=7, Wait=8), with Quit/End Game appended unconditionally outside
+  that list rather than being one of its ids. A real 2003 game's array both
+  picks *which* commands show and their *order* — mtf-meido-action's own
+  database (loaded directly, not guessed: `LCF::Database#rpg2003?` reads true
+  and chunk 22 field 27 decodes to `[1, 2, 3, 4, 5, 6, 7, 8]`, confirmed by
+  reading the System chunk by numeric id under the CRuby host harness, where
+  `db.system` itself resolves to `Kernel#system` — see
+  `scripts/rpg2k_testbed_logic_check.rb`'s own `DB_SYSTEM` comment) uses all
+  eight, Status included. `Scene::Menu#build_commands`
+  (`mruby-rpg2k/mrblib/scene/menu.rb`) now branches on `db.rpg2003?` (ADR
+  0013's edition detector): RPG2000 gets the fixed
+  `RPG2K_COMMAND_KEYS` five, RPG2003 filters its own `menu_commands` array
+  through `RPG2K3_COMMAND_IDS` — a small id→command table that has **no**
+  entry for Row (battle front/back rank), Order (party reordering) or Wait
+  (the ATB toggle), so a 2003 game listing them simply does not offer them,
+  the identical reported-gap precedent the Toggle ATB Mode (5003) event
+  command entry above already establishes for the same unmodelled RPG2003
+  battle system — rather than crashing or inventing a screen. Covered by new
+  `scripts/rpg2k_scene_check.rb` checks (a non-2003 fixture never offers
+  Status at all; a 2003 fixture's full eight-id array offers Status and drops
+  Row/Order/Wait; a 2003 fixture that reorders and omits commands is honoured
+  end to end, including actually opening the reordered Status screen),
+  confirmed to fail against the pre-fix code (Status always offered
+  regardless of edition; a 2003 reorder/omission silently ignored) before the
+  fix. See `changelog.d/menu-command-list-2003-rpg2k-status.fixed.md`. The
+  **Item** command opens
   `Scene::ItemMenu`: it lists the party's usable **medicines** (database item type
   6), **skill books** (type 7) and **seeds** (type 8) with their held counts. A
   medicine heals its target — a single-target item a chosen ally, an all-ally item

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -4,22 +4,53 @@ class RPG2k
     # and a command list. Item, Skill, Equip and Status each push their own
     # scene (Scene::ItemMenu / SkillMenu / EquipMenu / StatusMenu); Save writes
     # through the app and End Game returns to the title. Any further command
-    # (there are none left in COMMAND_KEYS today) falls back to a "not
-    # implemented yet" message.
+    # (there are none left in the built command list today) falls back to a
+    # "not implemented yet" message.
     class Menu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
-      # Command keys in menu order, paired with the database term (and its
-      # RPG_RT-standard English fallback) that names each on screen.
-      COMMAND_KEYS = [
+
+      # RPG2000's field menu is a *fixed* five commands with no separate Status
+      # entry -- EasyRPG's `Scene_Menu::CreateCommandWindow`'s `Player::IsRPG2k()`
+      # branch hardcodes exactly Item / Skill / Equipment / Save / Quit
+      # regardless of database content (a per-actor status readout has no
+      # screen of its own in RPG2000; the party list already shown here is
+      # what stands in for it, and Equip already shows the full stat block).
+      # RPG2003 replaces this fixed list with the System database's own
+      # customizable one -- see RPG2K3_COMMAND_IDS below -- so this constant
+      # is the RPG2000 (and RPG2003-without-a-menu_commands-chunk) default.
+      RPG2K_COMMAND_KEYS = [
         [:item, :battle_item, "Item"],
         [:skill, :battle_skill, "Skill"],
         [:equip, :battle_equipment, "Equip"],
-        [:status, :status, "Status"],
         [:save, :battle_save, "Save"],
         [:end_game, :battle_end_game, "End Game"]
       ].freeze
+
+      # RPG2003's System chunk 22 field 27 (`menu_commands`, schema.rb) lists
+      # the game's own command ids in the order the editor's "menu order" tab
+      # arranges them -- matching EasyRPG's `CommandOptionType` enum (Item=1,
+      # Skill=2, Equipment=3, Save=4, Status=5, Row=6, Order=7, Wait=8; Quit=9
+      # is never itself in the list -- `Scene_Menu` appends it unconditionally
+      # after the loop, which #build_commands mirrors below). Row (battle
+      # front/back rank), Order (party reordering) and Wait (the ATB toggle)
+      # have no entry here and are silently skipped: they are RPG2003
+      # battle-system features this runtime does not model, the same
+      # reported-gap precedent the Toggle ATB Mode (5003) event command
+      # entry already establishes elsewhere. A real RPG2003 game's array
+      # (mtf-meido-action's is `[1, 2, 3, 4, 5, 6, 7, 8]`, confirmed by
+      # `db.rpg2003?` and reading chunk 22 by id under the CRuby host
+      # harness, where `db.system` itself collides with Kernel#system) can
+      # both omit a command (hiding it, e.g. a game with no Save on principle)
+      # and reorder the survivors, both of which #build_commands honours.
+      RPG2K3_COMMAND_IDS = {
+        1 => [:item, :battle_item, "Item"],
+        2 => [:skill, :battle_skill, "Skill"],
+        3 => [:equip, :battle_equipment, "Equip"],
+        4 => [:save, :battle_save, "Save"],
+        5 => [:status, :status, "Status"]
+      }.freeze
 
       def initialize parent, state
         super parent
@@ -28,9 +59,7 @@ class RPG2k
         @message = nil
         @skin = make_windowskin
         @background = build_field_background(@skin)
-        @commands = COMMAND_KEYS.map { |key, term_name, fallback|
-          [key, term(term_name, fallback)]
-        }
+        @commands = build_commands
         # yado.tk: opening the Menu (Save included — it has no scene of its own,
         # see the :save command below) auto-cancels an Erase Screen black-out
         # with no "Show Screen" involved, and RPG_RT never restores it when the
@@ -66,6 +95,23 @@ class RPG2k
       end
 
       private
+
+      # The command list this menu shows, in order: RPG2000's fixed five, or
+      # RPG2003's customizable subset (plus an unconditional End Game at the
+      # tail, matching EasyRPG's own unconditional `Quit` push) -- see the two
+      # constants above for the reference this ports. `db.rpg2003?` is nil
+      # (falsy) on the RPG2000-shaped fixtures the scene-check harness builds,
+      # which is the correct reading for them too: they carry no `menu_commands`
+      # chunk any more than a genuine RPG2000 database does.
+      def build_commands
+        keys = if db.rpg2003?
+                 ids = db.system.menu_commands || []
+                 ids.filter_map { |id| RPG2K3_COMMAND_IDS[id] } << RPG2K_COMMAND_KEYS.last
+               else
+                 RPG2K_COMMAND_KEYS
+               end
+        keys.map { |key, term_name, fallback| [key, term(term_name, fallback)] }
+      end
 
       def build_windows
         cw = 108

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -224,9 +224,12 @@ def fake_map_with_counters(id, events, counters)
 end
 
 def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
-            airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false)
+            airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
+            rpg2003: false, menu_commands: nil)
   OpenStruct.new(
+    rpg2003?: rpg2003,
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
+                           menu_commands: menu_commands,
                            battle_music: OpenStruct.new(file: 'BattleBGM', volume: 70, pitch: 110),
                            inn_music: OpenStruct.new(file: 'InnBGM', volume: 75, pitch: 105),
                            boat_music: OpenStruct.new(file: 'BoatBGM', volume: 80, pitch: 100),
@@ -7141,8 +7144,8 @@ class MenuStubParty
   def field_skills(_actor, _state = nil); []; end
 end
 
-def menu_scene(klass, state)
-  klass.new(fake_parent(fake_db), state)
+def menu_scene(klass, state, db = fake_db)
+  klass.new(fake_parent(db), state)
 end
 
 def menu_state
@@ -7206,7 +7209,9 @@ check 'Scene::Menu: the main command cursor wraps around' do
   RGSS::Input.triggered = [RGSS::Input::UP]
   scene.update
   RGSS::Input.reset
-  eq 5, scene.instance_variable_get(:@index), 'Up from the first command wraps to the last (6 commands)'
+  eq 4, scene.instance_variable_get(:@index),
+     'Up from the first command wraps to the last (RPG2000\'s fixed 5 commands: ' \
+     'Item/Skill/Equip/Save/End Game -- no Status, see RPG2K_COMMAND_KEYS)'
   RGSS::Input.triggered = [RGSS::Input::DOWN]
   scene.update
   RGSS::Input.reset
@@ -7214,15 +7219,16 @@ check 'Scene::Menu: the main command cursor wraps around' do
 end
 
 check 'Scene::Menu: choosing Item pushes Scene::ItemMenu (and the rest their own scenes)' do
-  # COMMAND_KEYS order is Item, Skill, Equip, Status, Save, End Game; the first
-  # four each push their own scene onto the parent stack rather than falling
-  # into the generic "not implemented yet" message -- confirm the field Item
-  # command actually reaches Scene::ItemMenu, and its neighbours are not stubs.
+  # RPG2K_COMMAND_KEYS order is Item, Skill, Equip, Save, End Game -- RPG2000
+  # has no Status entry at all (see Scene::Menu's own doc comment, ported from
+  # EasyRPG's Scene_Menu::CreateCommandWindow); the first three each push their
+  # own scene onto the parent stack rather than falling into the generic "not
+  # implemented yet" message -- confirm the field Item command actually reaches
+  # Scene::ItemMenu, and its neighbours are not stubs.
   {
     0 => RPG2k::Scene::ItemMenu,
     1 => RPG2k::Scene::SkillMenu,
     2 => RPG2k::Scene::EquipMenu,
-    3 => RPG2k::Scene::StatusMenu,
   }.each do |index, klass|
     scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
     scene.instance_variable_set(:@index, index)
@@ -7237,13 +7243,53 @@ end
 check 'Scene::Menu: End Game returns to the title on the first press, like F12 and ' \
       'the Return to Title Screen event command' do
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
-  scene.instance_variable_set(:@index, 5)  # End Game, last of COMMAND_KEYS
+  scene.instance_variable_set(:@index, 4)  # End Game, last of RPG2K_COMMAND_KEYS
   RGSS::Input.triggered = [RGSS::Input::C]
   scene.update
   RGSS::Input.reset
   ok scene.parent.returned_to_title,
      'End Game hands control back to the app immediately, with no confirmation ' \
      'message to dismiss first'
+end
+
+check 'Scene::Menu: RPG2000 (no rpg2003? flag) never offers Status at all' do
+  scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state)
+  keys = scene.instance_variable_get(:@commands).map(&:first)
+  eq [:item, :skill, :equip, :save, :end_game], keys,
+     'the fixed RPG2000 five, matching EasyRPG\'s Player::IsRPG2k() branch -- ' \
+     'no Status, since a real RPG2000 database never customizes the menu'
+end
+
+check 'Scene::Menu: an RPG2003 database drives the command list from ' \
+      'System.menu_commands, Status included' do
+  # mtf-meido-action's own array, id-for-id (confirmed by loading its real
+  # RPG_RT.ldb): every one of RPG2003's eight customizable ids, in ascending
+  # order. Row (6) / Order (7) / Wait (8) are RPG2003 battle-system features
+  # this runtime does not model (the same reported-gap precedent as Toggle ATB
+  # Mode, 5003) and are silently skipped; End Game is appended unconditionally,
+  # matching EasyRPG's own unconditional Quit push outside the customized loop.
+  db = fake_db(rpg2003: true, menu_commands: [1, 2, 3, 4, 5, 6, 7, 8])
+  scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)
+  keys = scene.instance_variable_get(:@commands).map(&:first)
+  eq [:item, :skill, :equip, :save, :status, :end_game], keys,
+     'Status (id 5) is offered, and Row/Order/Wait are dropped rather than crashing'
+end
+
+check 'Scene::Menu: RPG2003 System.menu_commands can reorder and omit commands' do
+  # An arbitrary game that put Status first, dropped Item and Skill entirely,
+  # and never touched Save: #build_commands must reproduce the game's own
+  # order and omissions, not fall back to the RPG2000 default shape.
+  db = fake_db(rpg2003: true, menu_commands: [5, 3])
+  scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)
+  keys = scene.instance_variable_get(:@commands).map(&:first)
+  eq [:status, :equip, :end_game], keys,
+     'Status then Equip, in the game\'s own order, End Game still appended last'
+  scene.instance_variable_set(:@index, 0)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  ok scene.parent.pushed.last.is_a?(RPG2k::Scene::StatusMenu),
+     'selecting the reordered Status command actually opens Scene::StatusMenu'
 end
 
 check 'the item / skill target list shows who is afflicted' do


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s Menu scene bullet asserted "Save, End Game, Item, Skill,
  Equip and Status all work — the full main-menu set." That six-command
  list is actually EasyRPG's **RPG2003** menu, not RPG2000's — verified
  directly against EasyRPG Player's source (`scene_menu.cpp`/`.h`):
  `Player::IsRPG2k()` hardcodes exactly five commands (Item, Skill, Equip,
  Save, End Game — **no Status**), while RPG2003 instead builds the list
  from the System database's own customizable `menu_commands` field (LCF
  chunk 22 field 27, decoded by the schema but never read anywhere in the
  runtime).
- Confirmed against real data: mtf-meido-action's actual `RPG_RT.ldb`
  (downloaded via `scripts/download-mtf-meido-action.bash`) reads
  `rpg2003? == true` and `menu_commands == [1,2,3,4,5,6,7,8]` — every
  customizable id, Status included.
- `RPG2K_COMMAND_KEYS` is RPG2000's fixed five; `RPG2K3_COMMAND_IDS` maps
  the customizable command ids (matching EasyRPG's `CommandOptionType`
  enum) to the same key/term/fallback shape, deliberately skipping
  Row/Order/Wait (RPG2003 battle-system features this runtime doesn't
  model — the same precedent the Toggle ATB Mode event command already
  establishes). New `#build_commands` branches on `db.rpg2003?`, honouring
  both omission and reordering in a real game's array, and always appends
  End Game last, matching EasyRPG's own unconditional Quit push.
- `docs/TODO.md` updated ✅ with the citations.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 713 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 394 checks pass (three new
      checks: an RPG2000 fixture never offers Status; a full 2003 array
      offers Status and drops Row/Order/Wait; a reordered/pruned 2003 array
      is honoured end-to-end including actually opening
      `Scene::StatusMenu` — confirmed to fail against the pre-fix code, 5
      failures)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_