### PR TITLE
rpg2k: a map-triggered Show Battle Animation now flashes its target on the map

### DIFF
--- a/changelog.d/map-battle-animation-target-flash.fixed.md
+++ b/changelog.d/map-battle-animation-target-flash.fixed.md
@@ -1,0 +1,27 @@
+- A map-triggered **Show Battle Animation** (11210) whose flash_scope-1
+  ("target") timing pulses a map character now actually flashes it, instead
+  of being silently dropped. `Scene::Map#fire_animation_flashes`' flash_scope
+  1 case only ever reached `#fire_target_flash`, the in-battle mechanism that
+  tones an enemy sprite in `@battle_ui[:enemy_sprites]` — a map scene has no
+  battle UI at all, so a map-triggered animation's own target flash simply
+  never fired, a gap the target-scope flash fix (see `changelog.d`'s earlier
+  battle-animation-target-flash entry) explicitly left open pending its own
+  change. `#fire_animation_flashes` now dispatches on the animation's own
+  `battle` flag: the enemy-sprite path for a battle round, and a new
+  `#fire_map_target_flash` for a map-triggered one — which reuses the Flash
+  Sprite command's (11320) own CharSet-tone mechanism (`@player_flash` / an
+  `@events` entry's `[:flash]`, already driven every frame by
+  `#update_sprite_flashes`) rather than inventing a second one. A new
+  `#map_animation_flash_target` resolves the animation's target id the same
+  way `#animation_target_pixel` already does for centring the animation
+  itself — the player, "this event" (falling back to the player when there
+  is none, matching a common event Parallel Process's own animation), or a
+  named map event — except a vehicle, which has no Flash Sprite-style tone
+  mechanism to hook and stays a silent no-op, the one case
+  `#animation_target_pixel` reads a live position for but this cannot flash.
+  Covered by three new `scripts/rpg2k_scene_check.rb` checks (a player-
+  targeted animation arms `@player_flash` with the timing's scaled colour; a
+  named-event-targeted animation arms that event's own flash and never the
+  player's; `#map_animation_flash_target`'s own vehicle / unknown-id /
+  "this event" decoding), confirmed to fail against the pre-fix code (two
+  `RuntimeError`s and a `NoMethodError`) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3792,11 +3792,11 @@ not yet verified:
   silent no-op, since RPG2000's front-view battle draws no sprite for a
   party member to flash (the same fact `#battle_animation_pixel`'s own
   comment already documents) — nothing here invents ally-side behaviour. A
-  map-triggered Show Battle Animation (11210) aimed at a map character is a
+  map-triggered Show Battle Animation (11210) aimed at a map character was a
   different target class entirely (the CharSet-based Flash Sprite mechanism
-  already models flashing one) and is not addressed by this fix;
-  `#build_animation`'s map-triggered call site never sets `target_index`, so
-  a flash_scope-1 timing there stays a no-op too, same as before. The flash
+  already models flashing one) and was left unaddressed by this fix, since
+  `#build_animation`'s map-triggered call site never set `target_index` — see
+  the next bullet, which closes that half. The flash
   itself uses the RGSS `Sprite#flash`/`#update` primitive
   (`mruby-rgss/src/lib.cxx`) — already ported natively but unused anywhere
   else in this codebase — decayed one frame at a time by a new
@@ -3811,6 +3811,37 @@ not yet verified:
   full duration; a target-scope timing with no resolvable target sprite is a
   silent no-op, not a crash), the first confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **A map-triggered Show Battle Animation's flash_scope-1 timing now
+  flashes its target too**, closing the half the previous bullet's fix
+  explicitly left open. `#fire_animation_flashes`' flash_scope-1 case only
+  ever reached `#fire_target_flash`, the battle-only mechanism that tones an
+  entry in `@battle_ui[:enemy_sprites]` — a map scene run outside a fight has
+  no battle UI at all, so the very common "flash the hero on a damage frame"
+  animation idiom did nothing whenever the animation played over the map
+  rather than in a battle round, the gap the previous bullet named and
+  deferred rather than closed. `#fire_animation_flashes` now dispatches on
+  the animation's own `battle` flag — the enemy-sprite path unchanged for a
+  battle round, and a new `#fire_map_target_flash` for a map-triggered one —
+  which reuses the **Flash Sprite** command's (11320) own CharSet-tone
+  mechanism instead of inventing a second one: the same decaying `{red:,
+  green:, blue:, power:, frames:, total:}` hash `#apply_sprite_flash` already
+  builds, assigned to `@player_flash` or an `@events` entry's `[:flash]` and
+  driven every frame by the pre-existing `#update_sprite_flashes` (see the
+  "Flash Sprite" section above) — no new per-frame driver needed. A new
+  `#map_animation_flash_target` resolves the animation's own target id
+  exactly the way `#animation_target_pixel` already does for centring the
+  animation itself (the player, "this event" — falling back to the player
+  when there is none, matching a common event Parallel Process's own
+  animation — or a named map event), except a vehicle: `#draw_vehicles` has
+  no counterpart to `#flash_tone` at all, so a vehicle target stays a silent
+  no-op, matching `#fire_target_flash`'s own missing-sprite case rather than
+  inventing a third flash mechanism. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (a player-targeted animation arms
+  `@player_flash` with the timing's scaled colour; a named-event-targeted
+  animation arms that event's own flash and never the player's;
+  `#map_animation_flash_target`'s own vehicle / unknown-id / "this event"
+  decoding), confirmed to fail against the pre-fix code (two `RuntimeError`s
+  and a `NoMethodError`) before the fix.
 - ✅ **A Timer with "valid during battle" checked force-ends the battle**
   the instant it reaches 0:00, regardless of encounter source (default or
   scripted) — an easy accidental trap if the same Timer is reused for a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5476,7 +5476,28 @@ class RPG2k
         # sizes a vehicle sprite off the same constant), so the sprite bounding
         # box #animation_position_offset needs is known without asking what
         # kind of character this actually is.
-        build_animation(req[:animation], tx, ty, target_height: Game::CharSet::HEIGHT)
+        build_animation(req[:animation], tx, ty, target_height: Game::CharSet::HEIGHT,
+                         flash_target: map_animation_flash_target(req[:target]))
+      end
+
+      # The character a map-triggered flash_scope-1 timing (see
+      # #fire_map_target_flash) should pulse: `:player`, a specific `@events`
+      # entry (this event / a named map event id), or nil when the target has
+      # no CharSet-tone flash mechanism to hook (a vehicle -- #draw_vehicles
+      # has no counterpart to #flash_tone -- or an id no live event matches).
+      # Mirrors #animation_target_pixel's own target-id decoding exactly,
+      # including its "this event" -> player fallback when there is no active
+      # event (a common event Parallel Process's own Show Battle Animation).
+      def map_animation_flash_target(target)
+        case target
+        when MOVE_TARGET_PLAYER then :player
+        when 0, MOVE_TARGET_THIS
+          @active_event || :player
+        when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
+          nil
+        else
+          @events.find { |e| e[:id] == target }
+        end
       end
 
       # The animation player itself, shared by the map's Show Battle Animation
@@ -5488,7 +5509,8 @@ class RPG2k
       # fallback), which leaves every position setting drawing at the plain
       # centre pixel, same as before this field existed. nil when the animation
       # is unknown or its Battle/<name> sheet is missing.
-      def build_animation(id, tx, ty, battle = false, target_index: nil, target_height: nil)
+      def build_animation(id, tx, ty, battle = false, target_index: nil, target_height: nil,
+                          flash_target: nil)
         anim = animation_row(id)
         return nil unless anim
         frames = table_entries(anim.frames)
@@ -5498,7 +5520,7 @@ class RPG2k
         { frames: frames, timings: table_entries(anim.timings), sheet: sheet,
           position: (anim.position || 1), tx: tx, ty: ty, frame_i: 0,
           timer: ANIM_CELL_FRAMES, battle: battle, target_index: target_index,
-          target_height: target_height }
+          target_height: target_height, flash_target: flash_target }
       end
 
       def animation_row(id)
@@ -5556,8 +5578,9 @@ class RPG2k
 
       # Fire the current frame's timings request: flash_scope 2 (whole screen,
       # already implemented) or flash_scope 1 (the animation's own target --
-      # see #fire_target_flash). RPG2000 stores the colour / power as 0..31,
-      # scaled up to the 0..255 range both flash paths use.
+      # #fire_target_flash in battle, #fire_map_target_flash on the map).
+      # RPG2000 stores the colour / power as 0..31, scaled up to the 0..255
+      # range every flash path uses.
       def fire_animation_flashes(ma)
         ma[:timings].each do |t|
           next unless (t.frame || 0) == ma[:frame_i]
@@ -5567,7 +5590,7 @@ class RPG2k
                                 (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8,
                                 ANIM_FLASH_FRAMES)
           when 1
-            fire_target_flash(ma[:target_index], t)
+            ma[:battle] ? fire_target_flash(ma[:target_index], t) : fire_map_target_flash(ma[:flash_target], t)
           end
         end
       end
@@ -5579,14 +5602,12 @@ class RPG2k
       # battle-round path (a skill/item's `target_index`, see
       # #battle_animation_pixel): RPG2000's battle is front-view, so an
       # ally-targeted entry has no on-screen sprite to flash (target_index is
-      # nil there, same as it already is for centring the animation itself) and
-      # a map-triggered Show Battle Animation (11210) aimed at a map character
-      # is a different target class entirely, one the Flash Sprite command's own
-      # CharSet tone mechanism already models -- left unaddressed here, since
-      # #build_animation's map path never sets target_index. Uses the RGSS
-      # Sprite#flash/#update primitive (mruby-rgss/src/lib.cxx) already ported
-      # natively but unused elsewhere in this codebase, decayed each frame by
-      # #update_enemy_flashes.
+      # nil there, same as it already is for centring the animation itself).
+      # A map-triggered Show Battle Animation (11210) aimed at a map character
+      # is a different target class entirely, handled by #fire_map_target_flash
+      # below. Uses the RGSS Sprite#flash/#update primitive
+      # (mruby-rgss/src/lib.cxx) already ported natively but unused elsewhere
+      # in this codebase, decayed each frame by #update_enemy_flashes.
       def fire_target_flash(target_index, t)
         sprites = @battle_ui && @battle_ui[:enemy_sprites]
         spr = target_index && sprites ? sprites[target_index] : nil
@@ -5594,6 +5615,34 @@ class RPG2k
         spr.flash(Color.new((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
                             (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8),
                   ANIM_FLASH_FRAMES)
+      end
+
+      # The map-triggered counterpart to #fire_target_flash: a flash_scope-1
+      # timing on a Show Battle Animation (11210) played over a map character
+      # now actually pulses that character, instead of being silently dropped
+      # (#fire_animation_flashes only ever reached #fire_target_flash's
+      # battle-only enemy-sprite mechanism before this). There is no separate
+      # "battle animation flash" primitive for a map character -- the Flash
+      # Sprite command (11320) already tones one, via the very same decaying
+      # {red:, green:, blue:, power:, frames:, total:} hash #apply_sprite_flash
+      # builds and #flash_tone/#update_sprite_flashes already drive every frame
+      # (see the "Flash Sprite" section above), so this reuses that mechanism
+      # rather than inventing a second one: `target` (from
+      # #map_animation_flash_target) is either `:player` (-> @player_flash) or
+      # an `@events` entry (-> its `[:flash]`), nil when the animated target
+      # has no such sprite (a vehicle, or an unresolved event id) -- a silent
+      # no-op, matching #fire_target_flash's own missing-sprite case.
+      def fire_map_target_flash(target, t)
+        return if target.nil?
+        flash = { red: (t.flash_red || 0) * 8, green: (t.flash_green || 0) * 8,
+                  blue: (t.flash_blue || 0) * 8, power: (t.flash_power || 0) * 8,
+                  frames: ANIM_FLASH_FRAMES, total: ANIM_FLASH_FRAMES }
+        if target == :player
+          @player_flash = flash
+          @last_frame = nil # force the hero's cached frame to be re-toned
+        else
+          target[:flash] = flash
+        end
       end
 
       # Collect an Array2D (or a plain Hash test double) into a dense array of its

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -329,6 +329,20 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
       },
       timings: { 1 => OpenStruct.new(frame: 1, flash_scope: 2, flash_red: 31,
                                      flash_green: 31, flash_blue: 31, flash_power: 20) }
+    ),
+    # A second drawable animation (id 9), identical to id 8's frames but with a
+    # flash_scope 1 ("target") timing instead of a screen flash -- for the
+    # map-triggered target-flash checks below.
+    9 => OpenStruct.new(
+      animation_name: 'Anim', position: 1,
+      frames: {
+        1 => OpenStruct.new(cells: { 1 => OpenStruct.new(visible: true, cell_id: 0, x: 0, y: 0) }),
+        2 => OpenStruct.new(cells: { 1 => OpenStruct.new(visible: true, cell_id: 1, x: 0, y: 0) }),
+        3 => OpenStruct.new(cells: {}),
+        4 => OpenStruct.new(cells: {})
+      },
+      timings: { 1 => OpenStruct.new(frame: 1, flash_scope: 1, flash_red: 31,
+                                     flash_green: 0, flash_blue: 0, flash_power: 20) }
     ) },
     # Every tile of the synthetic map is chip 0, which the fake chipset tags as
     # terrain 42 — so this one row decides whether walking hurts, and (for the
@@ -4777,6 +4791,87 @@ check "a map-triggered Show Battle Animation carries the target's CharSet height
      "the player's own CharSet sprite height, not the battle-only nil fallback"
 end
 
+# A map-triggered Show Battle Animation's flash_scope-1 timing used to be
+# silently dropped: #fire_animation_flashes only ever reached
+# #fire_target_flash's battle-only enemy-sprite mechanism, which a map scene
+# (no @battle_ui at all) can never populate, so the flash simply never fired.
+# #fire_map_target_flash reuses the Flash Sprite command's own CharSet-tone
+# mechanism (@player_flash / an @events entry's [:flash]) instead of
+# inventing a second one. Animation 9 in the fake db carries a flash_scope 1
+# timing (see the fake-db comment above) rather than id 8's flash_scope 2, so
+# this is isolated from the screen-flash check above.
+check "a map-triggered Show Battle Animation's target-scope flash pulses the player" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [9, 10001, 1], indent: 0), # animation, player, wait
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  seen = false
+  40.times do
+    scene.update
+    pf = scene.instance_variable_get(:@player_flash)
+    seen ||= (pf && pf[:red] == 248 && pf[:green] == 0 && pf[:blue] == 0)
+    break if st.switches[6]
+  end
+  ok seen, "the player's flash was armed, scaled from the LCF 0..31 fixture fields the same *8 way " \
+           'the battle-side enemy flash already is'
+  ok st.switches[6], 'the event resumed after the animation'
+end
+
+# The same timing aimed at a named map event instead pulses *that* event's own
+# flash, not the player's -- #map_animation_flash_target resolves a plain
+# event id the same way #animation_target_pixel already does for centring the
+# animation itself.
+check "a map-triggered Show Battle Animation's target-scope flash pulses the named map event, not the player" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [9, 2, 1], indent: 0), # animation, event 2, wait
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  target_pg = page(trigger: 0) # stationary, never triggers on its own
+  scene = new_scene({ 1 => event(2, 2, auto), 2 => event(4, 4, target_pg) })
+  st = scene.instance_variable_get(:@state)
+  seen_target = false
+  seen_player = false
+  40.times do
+    scene.update
+    ev2 = event_hashes(scene)[2]
+    seen_target ||= (ev2[:flash] && ev2[:flash][:red] == 248)
+    seen_player ||= !scene.instance_variable_get(:@player_flash).nil?
+    break if st.switches[6]
+  end
+  ok seen_target, "the targeted map event's own flash was armed"
+  ok !seen_player, 'the player, who was not the target, was never flashed'
+  ok st.switches[6], 'the event resumed after the animation'
+end
+
+# #map_animation_flash_target's own target-id decoding, isolated from the
+# full event pipeline above: a vehicle has no Flash Sprite-style CharSet tone
+# to hook (unlike a player/event target), an id no live event matches resolves
+# to nothing, and "this event" (0 / MOVE_TARGET_THIS) mirrors
+# #animation_target_pixel's own fallback to the player when there is no active
+# event (a common event Parallel Process's own Show Battle Animation has none).
+check '#map_animation_flash_target resolves vehicle, unknown-id and "this event" targets' do
+  scene = new_scene({ 3 => event(1, 1, page) })
+  mt = RPG2k::Scene::Map
+  eq :player, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_PLAYER)
+  eq nil, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_BOAT),
+     'a vehicle has no CharSet-tone flash mechanism to hook'
+  eq nil, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_SHIP)
+  eq nil, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_AIRSHIP)
+  eq nil, scene.send(:map_animation_flash_target, 999), 'an id no live event matches'
+  eq :player, scene.send(:map_animation_flash_target, 0),
+     '"this event" with no active event (a common event Parallel Process) falls back to the player'
+  ev3 = event_hashes(scene)[3]
+  scene.instance_variable_set(:@active_event, ev3)
+  eq ev3, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_THIS),
+     '"this event" with an active event resolves to it'
+end
+
 # yado.tk: only one Battle Animation is ever on screen at once -- true of the
 # map-level Show Battle Animation command (11210) same as an in-battle one.
 # That only means anything if a *parallel process* can show one at all: before
@@ -6675,7 +6770,7 @@ check 'a target-scope animation flash pulses the hit enemy, not the screen or a 
   bystander = ui[:enemy_sprites][1]
   timing = OpenStruct.new(frame: 0, flash_scope: 1, flash_red: 31, flash_green: 0,
                           flash_blue: 0, flash_power: 20)
-  ma = { frame_i: 0, target_index: 0, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: 0, timings: [timing] }
   scene.send(:fire_animation_flashes, ma)
   ok spr.flash_color, 'the targeted enemy sprite was flashed'
   eq [248, 0, 0, 160],
@@ -6701,7 +6796,7 @@ check 'a target-scope flash with no resolvable target sprite is a silent no-op' 
   scene, = battle_at_command
   timing = OpenStruct.new(frame: 0, flash_scope: 1, flash_red: 31, flash_green: 0,
                           flash_blue: 0, flash_power: 20)
-  ma = { frame_i: 0, target_index: nil, timings: [timing] }
+  ma = { frame_i: 0, battle: true, target_index: nil, timings: [timing] }
   scene.send(:fire_animation_flashes, ma) # must not raise
   ok true, 'no exception targeting nothing'
 end


### PR DESCRIPTION
## Summary
- The previously-merged Battle Animation target-flash fix left a documented gap: a map-triggered Show Battle Animation (11210) aimed at a map character is a different target class entirely. `fire_animation_flashes`'s `flash_scope == 1` case unconditionally called `fire_target_flash`, which only reads `@battle_ui[:enemy_sprites]` — nonexistent outside a fight — so a map-triggered animation's target-flash timing was a guaranteed silent no-op.
- `fire_animation_flashes` now dispatches on the animation's `battle` flag, routing a map-triggered animation to a new `fire_map_target_flash`, which reuses the existing Flash Sprite (11320) CharSet-tone mechanism (`@player_flash` / an `@events` entry's `[:flash]`, already decayed every frame by `#update_sprite_flashes`) rather than inventing a new one.
- A new `map_animation_flash_target` resolves the animation's target id the same way `animation_target_pixel` already does (player, "this event" with a player fallback, or a named map event id), except a vehicle — which has no CharSet-tone flash mechanism at all and stays a deliberate no-op.
- `docs/TODO.md` updated with a new ✅ bullet, and the prior bullet's stale "not addressed" wording corrected to point at it.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 713 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 400 checks pass (three new checks: a player-targeted map animation arms `@player_flash` with the scaled colour; a named-event-targeted one arms that event's own `[:flash]` and never the player's; and a unit test of `map_animation_flash_target`'s vehicle/unknown-id/"this event" decoding — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_