### PR TITLE
rpg2k: a \. / \| message pause now holds RPG_RT's real 16/61 frames

### DIFF
--- a/changelog.d/message-pause-frames.fixed.md
+++ b/changelog.d/message-pause-frames.fixed.md
@@ -1,0 +1,13 @@
+- **A `\.`/`\|` message pause now holds for RPG_RT's real 16/61 frames, not
+  a naive 15/60.** `\.` is documented as a quarter-second pause and `\|` as a
+  full-second one, and at 60fps a literal reading gives 15 and 60 frames —
+  which is what `Scene::Map::MSG_PAUSE_QUARTER`/`MSG_PAUSE_FULL` held. RPG_RT
+  itself waits one frame longer than its own documentation in both cases
+  (EasyRPG's `Window_Message` ports this exactly, with the comments "Despite
+  documentation saying 1/4 second, RPG_RT waits for 16 frames" and "...saying
+  1 second, RPG_RT waits for 61 frames"), so every timed message pause in
+  this engine was releasing one frame early. Fixed by correcting both
+  constants to 16 and 61. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks that drive a `\.`/`\|` pause end to end and count the exact number
+  of frames it holds the reveal for, both confirmed to fail against the
+  pre-fix code (15/60) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1407,6 +1407,24 @@ The work below is roughly ordered by the critical path to a walkable game
   crops in 48, with the sheet's leftmost/rightmost source columns landing on
   the destination's rightmost/leftmost columns), both confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **`\.` and `\|` now hold for RPG_RT's real 16/61 frames, not the
+  documented (and naturally-implemented) 15/60.** This paragraph's own "¼ /
+  1-second holds" wording is RPG2000's documented duration and, at 60fps,
+  the literal reading — which is exactly what `Scene::Map::MSG_PAUSE_QUARTER`
+  / `MSG_PAUSE_FULL` held (15 and 60), and exactly the "natural implementation
+  and the wrong one" shape this file already flags elsewhere (the drain
+  clamp-order paragraph above, the item-polarity paragraph before it). RPG_RT
+  itself waits one frame past its own documentation for both codes; EasyRPG's
+  `Window_Message` ports the real figures verbatim, with its own comments
+  spelling out the gap ("Despite documentation saying 1/4 second, RPG_RT
+  waits for 16 frames" / "...saying 1 second, RPG_RT waits for 61 frames" —
+  `src/window_message.cpp`, confirmed by fetching the source directly rather
+  than assumed). Fixed by correcting both constants to 16 and 61 — no other
+  code changed, since `drive_message_pause` already counts down whichever
+  constant it is handed one frame at a time. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks that drive a `\.`/`\|` pause end to
+  end and count the exact number of frames the reveal stays held, both
+  confirmed to fail against the pre-fix code (15/60) before the fix.
 - ✅ Common events — auto-start common events run once on the map, and parallel
   common events now run **continuously** in the background alongside the player
   via their own looping interpreter (`Scene::Map#step_parallels`), each gated by

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6236,8 +6236,18 @@ class RPG2k
       # A plain (non-choice) message: type the text out, and let a button press
       # first complete the reveal, then (once fully shown) dismiss and resume.
       # Frames a `\.` (quarter-second) and `\|` (full-second) pause hold.
-      MSG_PAUSE_QUARTER = 15
-      MSG_PAUSE_FULL = 60
+      #
+      # Not 15 / 60 (a literal quarter-/one-second at 60fps), even though
+      # that is what RPG2000's own documentation names and what "quarter"/
+      # "full" naturally suggest: EasyRPG's `Window_Message` ports RPG_RT's
+      # own measured behaviour instead, one frame longer than the documented
+      # duration in both cases ("Despite documentation saying 1/4 second,
+      # RPG_RT waits for 16 frames" / "...saying 1 second, RPG_RT waits for
+      # 61 frames" -- src/window_message.cpp, `case '.'` / `case '|'`), the
+      # same "the natural reading is wrong" shape this codebase already
+      # tracks for other RPG_RT quirks (e.g. the item-drain clamp order).
+      MSG_PAUSE_QUARTER = 16
+      MSG_PAUSE_FULL = 61
 
       def drive_text_message
         reveal = @message[:reveal]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2592,6 +2592,62 @@ check 'a Show Choices that forbids cancelling swallows the cancel key' do
   ok parent.pushed.empty?, 'and the cancel key did not leak to the main menu'
 end
 
+check 'a \\. pause holds the reveal for RPG_RT\'s real 16 frames, not the documented 15' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'a\\.b')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  frames = 0
+  until reveal.pending_pause
+    scene.update
+    frames += 1
+    break if frames > 20
+  end
+  ok reveal.pending_pause, 'the \\. pause is reached'
+  # EasyRPG's own port comment: "Despite documentation saying 1/4 second,
+  # RPG_RT waits for 16 frames" -- one frame past the documented/naive 15
+  # (a quarter of 60fps), the same "natural reading is wrong" shape this
+  # codebase already tracks for other RPG_RT quirks.
+  held = 0
+  until reveal.pending_pause.nil?
+    scene.update
+    held += 1
+    break if held > 30
+  end
+  eq 16, held, 'RPG_RT holds a \\. pause for 16 frames, not the documented 15'
+end
+
+check 'a \\| pause holds the reveal for RPG_RT\'s real 61 frames, not the documented 60' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'a\\|b')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  frames = 0
+  until reveal.pending_pause
+    scene.update
+    frames += 1
+    break if frames > 20
+  end
+  ok reveal.pending_pause, 'the \\| pause is reached'
+  # EasyRPG's own port comment: "Despite documentation saying 1 second,
+  # RPG_RT waits for 61 frames" -- one frame past the documented/naive 60.
+  held = 0
+  until reveal.pending_pause.nil?
+    scene.update
+    held += 1
+    break if held > 70
+  end
+  eq 61, held, 'RPG_RT holds a \\| pause for 61 frames, not the documented 60'
+end
+
 check 'a \\! pause holds the reveal until a button is pressed' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Map::MSG_PAUSE_QUARTER` / `MSG_PAUSE_FULL` held `15` / `60` frames — a literal reading of the `\.` / `\|` control codes' documented "quarter-second" / "one-second" pause at 60fps.
- Real RPG_RT waits one frame past its own documentation for both: EasyRPG's `Window_Message` ports this exactly, with source comments spelling out the gap ("Despite documentation saying 1/4 second, RPG_RT waits for 16 frames" / "...saying 1 second, RPG_RT waits for 61 frames" — confirmed by fetching `src/window_message.cpp` directly, not assumed). Every timed message pause in this engine was therefore releasing one frame early.
- Fixed by correcting the two constants to `16` / `61`. No other code changes — `drive_message_pause` already counts down whichever constant it's handed, one frame at a time.
- Updated `docs/TODO.md`'s Message window entry and added a changelog fragment in the project's established style.

This is the same "the natural/documented reading is wrong" shape the codebase already tracks for other RPG_RT quirks (e.g. the item-drain clamp order, the `reverse_state_effect` polarity).

## Test plan

- Added two new `scripts/rpg2k_scene_check.rb` checks that drive a `\.` and a `\|` pause end to end through the real `Scene::Map`/`Game::TextReveal` path and count the exact number of frames the reveal stays held before releasing.
- Confirmed both new checks fail against the pre-fix code (asserting 16/61, measuring 15/60) before applying the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 713 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 396 checks passed (including the two new ones).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01ErVr57155LHADwGvKKAAuV


---
_Generated by [Claude Code](https://claude.ai/code/session_01ErVr57155LHADwGvKKAAuV)_