### PR TITLE
rpg2k: both Timer Operation countdowns now round-trip through .lsd saves

### DIFF
--- a/changelog.d/save-timer-lsd.fixed.md
+++ b/changelog.d/save-timer-lsd.fixed.md
@@ -1,0 +1,17 @@
+- **Both Timer Operation countdowns now round-trip through the real `.lsd`
+  export**, not just the portable Marshal save. `docs/TODO.md` used to call
+  this the one field the `.lsd` "cannot yet carry", guessing it would need "a
+  documented chunk id" of its own — it already has one: liblcf's own
+  `ChunkSaveInventory` enum documents `timer1_frames`..`timer2_battle` at ids
+  0x17-0x1E (23-30), filed under the inventory chunk (109) next to gold, not
+  the system chunk (101), with a "value is seconds\*60+59" doc comment that
+  matches `Game::Timer#set`'s own encoding exactly. `LCF::Schema::SAVE_INVENTORY`
+  now decodes the eight fields (no `default:`, so an absent field reads back as
+  nil rather than a false zero, distinguishing "not in this save" from
+  "explicitly stopped"), `Game::State#to_lsd` writes both `Game::Timer`s into
+  them and `.from_lsd` restores them, leaving a legacy save's fresh
+  `Timer.new` defaults untouched when the fields are absent. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (both timers round-trip independently
+  through an in-memory `to_lsd`/`from_lsd`; an old save missing the eight
+  fields keeps the default stopped/hidden timers), confirmed to fail against
+  the pre-fix code (the first timer read back at 0 seconds) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1869,9 +1869,27 @@ The work below is roughly ordered by the critical path to a walkable game
   on-map CharSet override (hero chunk 104) and the **title chunk (100)** — the
   `:double` timestamp (via the new `LCF.pack_double`), the leader's
   name/level/HP and the party FaceSets — so a real RPG_RT/EasyRPG file-select
-  screen shows the party. Still keeping the Marshal save *primary* (so Continue
-  prefers it) is one field the `.lsd` cannot yet carry: the **game timer**
-  (liblcf's SaveSystem has no field for it — needs a documented chunk id). Both
+  screen shows the party. ✅ **Both Timer Operation countdowns now round-trip
+  through the `.lsd` too.** This line used to call the game timer the one
+  field the export "cannot yet carry", guessing it would "need a documented
+  chunk id" of its own in liblcf's SaveSystem (chunk 101) — it already had
+  one, just filed elsewhere: liblcf's own `ChunkSaveInventory` enum documents
+  `timer1_frames`..`timer2_battle` at ids 0x17-0x1E (23-30), under the
+  inventory chunk (109) next to gold, not the system chunk, and its
+  "value is seconds\*60+59" doc comment for the frame fields matches
+  `Game::Timer#set`'s own encoding exactly — no guessing needed for the
+  layout either. `LCF::Schema::SAVE_INVENTORY` now decodes the eight fields
+  (frames/active/visible/battle per timer, deliberately with no `default:`,
+  matching SaveSystem's own access-flag fields, so an absent field reads back
+  nil rather than a false zero — the way `.from_lsd` tells "not in this save"
+  from "explicitly stopped" everywhere else); `Game::State#to_lsd` writes
+  both `Game::Timer`s into them and `.from_lsd` restores them, leaving a
+  legacy save's fresh `Timer.new` defaults (stopped, hidden, zero) untouched
+  when the fields are absent. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (both timers round-trip independently through an in-memory
+  `to_lsd`/`from_lsd`; an old save missing all eight fields keeps the default
+  timers), confirmed to fail against the pre-fix code (the first timer
+  reading back at 0 seconds) before the fix. Both
   save paths carry the **whole actor roster**, not just the current party:
   chunk 108 holds one entry per actor the party has ever held (which is what a
   genuine RPG_RT save holds), so a companion who is out of the party when the

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1116,8 +1116,12 @@ module LCF
     # and 導きの書 (item 451) ×1, after the gate crystal had been spent. Item ids
     # are int16; counts and per-item use-counts are one byte each. Field 1 is the
     # party roster (actor ids); the sole entry `[1]` is actor 1, whose database
-    # charset matches the saved hero. The step/turn counters are left out until
-    # confirmed.
+    # charset matches the saved hero. The step/turn counters (fields 0x29/0x2A)
+    # are left out until confirmed. Fields 23-30 (0x17-0x1E) are the two Timer
+    # Operation countdowns -- ids and "value is seconds*60+59" both confirmed
+    # against liblcf's own `ChunkSaveInventory` enum, which documents them
+    # under this chunk rather than the system chunk (101) `docs/TODO.md` used
+    # to guess they would need a new id in.
     SAVE_INVENTORY = {
       1 => { name: :party, type: :int8_array },
       11 => { name: :item_count, type: :int, default: 0 },
@@ -1125,6 +1129,18 @@ module LCF
       13 => { name: :item_counts, type: :int8_array },
       14 => { name: :item_usage, type: :int8_array },
       21 => { name: :gold, type: :int, default: 0 },
+      # No `default:` on these eight (matching e.g. SAVE_SYSTEM's
+      # teleport_allowed) so an absent field reads back as nil rather than a
+      # concrete value -- #from_lsd tells "not in this save" from "explicitly
+      # false/zero" the same way it already does for the access flags.
+      23 => { name: :timer1_frames, type: :int },
+      24 => { name: :timer1_active, type: :bool },
+      25 => { name: :timer1_visible, type: :bool },
+      26 => { name: :timer1_battle, type: :bool },
+      27 => { name: :timer2_frames, type: :int },
+      28 => { name: :timer2_active, type: :bool },
+      29 => { name: :timer2_visible, type: :bool },
+      30 => { name: :timer2_battle, type: :bool },
     }
 
     # Saved common-event execution state (chunk 114): an Array2D indexed by

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8169,9 +8169,10 @@ module Game
     # a time until only the title chunk failed, then one field at a time within
     # it. See ADR 0021.
     #
-    # The only live-state fields still dropped versus #to_h are the game timer
-    # (which liblcf's SaveSystem has no field for) and per-actor name/title
-    # overrides for non-leader members, so this is now a near-parity export.
+    # Both Timer Operation countdowns and every roster member's Change Actor
+    # Name override round-trip now too (see LCF::Schema::SAVE_INVENTORY's
+    # timer1_*/timer2_* fields and SAVE_PARTY_ACTOR's actor_name), so this is
+    # a near-parity export; Change Actor Title still is not (see docs/TODO.md).
     def to_lsd(save_count = 1, timestamp = nil)
       timestamp = State.ole_now if timestamp.nil?
       save = LCF::SaveData.new
@@ -8297,6 +8298,15 @@ module Game
       inv[12] = item_ids
       inv[13] = item_ids.map { |i| @party.items[i] }
       inv[21] = @party.gold
+      t1, t2 = @timers[0], @timers[1]
+      inv[23] = t1.frames
+      inv[24] = t1.running
+      inv[25] = t1.visible
+      inv[26] = t1.in_battle
+      inv[27] = t2.frames
+      inv[28] = t2.running
+      inv[29] = t2.visible
+      inv[30] = t2.in_battle
       save[109] = inv
 
       save
@@ -8428,6 +8438,17 @@ module Game
         party.leader.name = nm if nm && !nm.empty?
       end
       restore_pictures(state, save[103])
+      # Both Timer Operation countdowns (inventory chunk 109 fields 23-30); a
+      # save written before this landed simply omits them, leaving the fresh
+      # `Timer.new` defaults #initialize already seeded in place.
+      state.timer(0).frames = inv.timer1_frames unless inv.timer1_frames.nil?
+      state.timer(0).running = inv.timer1_active unless inv.timer1_active.nil?
+      state.timer(0).visible = inv.timer1_visible unless inv.timer1_visible.nil?
+      state.timer(0).in_battle = inv.timer1_battle unless inv.timer1_battle.nil?
+      state.timer(1).frames = inv.timer2_frames unless inv.timer2_frames.nil?
+      state.timer(1).running = inv.timer2_active unless inv.timer2_active.nil?
+      state.timer(1).visible = inv.timer2_visible unless inv.timer2_visible.nil?
+      state.timer(1).in_battle = inv.timer2_battle unless inv.timer2_battle.nil?
       state
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2641,6 +2641,43 @@ check 'to_lsd/from_lsd round-trips a non-leader actor\'s Change Actor Name' do
      "a non-leader's renamed name now round-trips too, via chunk 108 field 1"
 end
 
+check 'to_lsd/from_lsd round-trips both Timer Operation countdowns' do
+  # docs/TODO.md used to call the game timer the one field the .lsd export
+  # "cannot yet carry", guessing it would need "a documented chunk id" of its
+  # own in liblcf's SaveSystem (chunk 101). It already has one: liblcf's own
+  # `ChunkSaveInventory` enum documents timer1_frames..timer2_battle at ids
+  # 0x17..0x1E (23..30), filed under the inventory chunk (109) next to gold,
+  # not the system chunk -- and the "value is seconds*60+59" semantics its own
+  # doc comment gives for timer1_frames/timer2_frames match Game::Timer#set
+  # exactly, so no guessing was needed for the encoding either.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.timer(0).set(30); st.timer(0).start(true, true)
+  st.timer(1).set(90); st.timer(1).start(false, false)
+
+  saved = st.to_lsd
+  round = Game::State.from_lsd(db, saved)
+  eq 30, round.timer(0).seconds, 'the first timer\'s remaining time round-trips'
+  eq true, round.timer(0).running, 'and whether it is running'
+  eq true, round.timer(0).visible, 'and whether it is drawn'
+  eq true, round.timer(0).in_battle, 'and whether it keeps running in battle'
+  eq 90, round.timer(1).seconds, 'the second timer round-trips independently of the first'
+  eq false, round.timer(1).visible, 'started without the visible flag'
+  eq false, round.timer(1).in_battle
+
+  # A save written before this landed simply omits all eight fields; from_lsd
+  # must leave the freshly-constructed State's Timer.new defaults (stopped,
+  # hidden, zero) alone rather than crash reading an absent field.
+  legacy = st.to_lsd
+  inv = legacy[109]
+  [23, 24, 25, 26, 27, 28, 29, 30].each { |idx| inv.delete(idx) }
+  old = Game::State.from_lsd(db, legacy)
+  eq 0, old.timer(0).seconds, 'an old save without the timer fields keeps the default first timer'
+  eq false, old.timer(0).running
+  eq 0, old.timer(1).seconds, 'and the default second timer'
+  eq false, old.timer(1).running
+end
+
 # -- the permanent actor roster (Game::Actors) --------------------------------
 #
 # Nepheshel drives its whole party mechanic through Change Party Member: it adds


### PR DESCRIPTION
## Summary

`docs/TODO.md`'s Save & Continue entry claimed the game timer was "one field the `.lsd` cannot yet carry", guessing it would need "a documented chunk id" of its own in liblcf's `SaveSystem` (chunk 101). That guess was wrong on both counts: liblcf's own `ChunkSaveInventory` enum (confirmed against the public `EasyRPG/liblcf` source) already documents `timer1_frames`..`timer2_battle` at ids `0x17`-`0x1E` (23-30), filed under the *inventory* chunk (109) next to gold — and its "value is `seconds*60+59`" doc comment for the frame fields matches this build's own `Game::Timer#set` encoding exactly, so no guessing was needed for the layout either.

- `LCF::Schema::SAVE_INVENTORY` now decodes the eight fields (frames/active/visible/battle for each of the two RPG2003 timers), deliberately with no `default:` — matching `SaveSystem`'s own access-flag fields — so an absent field reads back `nil` rather than a false zero, letting `.from_lsd` tell "not in this save" from "explicitly stopped" the same way it already does elsewhere.
- `Game::State#to_lsd` writes both `Game::Timer`s into the new fields.
- `Game::State.from_lsd` restores them, leaving a legacy save's fresh `Timer.new` defaults (stopped, hidden, zero) untouched when the fields are absent.
- Updated the stale `to_lsd` doc comment and the `docs/TODO.md` Save & Continue entry (✅ paragraph) to record the fix.

## Test plan

- Added `to_lsd/from_lsd round-trips both Timer Operation countdowns` to `scripts/rpg2k_logic_check.rb`: both timers round-trip independently through an in-memory `to_lsd`/`from_lsd` call, and an old save missing all eight fields keeps the default stopped/hidden timers.
- Confirmed the new check fails against the pre-fix code (stashed the `schema.rb`/`game.rb` changes, ran the script — the first timer read back at 0 seconds instead of 30) before restoring the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 714 checks passed, zero failures.
- `ruby scripts/rpg2k_scene_check.rb` — 400 checks passed, zero failures.
- Changelog fragment added at `changelog.d/save-timer-lsd.fixed.md` per `changelog.d/README.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CXQ77fp59av6ygdSU2EA92)_