### PR TITLE
rpg2k: escape chance formula matches EasyRPG exactly (full roster, rounded, fixed at battle start)

### DIFF
--- a/changelog.d/battle-escape-chance-formula.fixed.md
+++ b/changelog.d/battle-escape-chance-formula.fixed.md
@@ -1,0 +1,18 @@
+- **The battle escape-chance roll now matches EasyRPG's
+  `Scene_Battle::InitEscapeChance()` / `TryEscape()` exactly.** Three
+  divergences from the real `150 - 100·enemyAgi/partyAgi` formula are fixed
+  together: a fallen battler is now still counted in its side's average
+  agility (EasyRPG's `Game_Party_Base::GetAverageAgility()` sums over every
+  member, not just the living ones — `Game::Battle#avg_agi` used to `reject`
+  the dead, understating the average the moment anyone went down); the
+  agility ratio is now rounded to the nearest percent rather than truncated
+  (`InitEscapeChance` finishes with `Utils::RoundTo<int>`/`std::lrint`, while
+  this build did a plain integer divide — a 7-agi party against a 10-agi
+  troop should read escape chance 7, not 8); and the chance is now computed
+  once, at battle start (`Game::Battle#initialize`), instead of lazily on
+  the first Flee attempt, matching `Scene_Battle::Start()` calling
+  `InitEscapeChance()` exactly once before any turn runs, so a stat-altering
+  status landing mid-fight no longer skews an escape chance that real
+  RPG_RT fixed before the first round. Covered by three new
+  `scripts/rpg2k_logic_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1014,7 +1014,43 @@ The work below is roughly ordered by the critical path to a walkable game
   **flee**: `Battle#attempt_escape` rolls EasyRPG's agility-ratio chance
   (`150 - 100·enemyAgi/partyAgi`, clamped), a preemptive first strike always
   gets away, and a failed attempt forfeits the party's round (every member
-  skips, the enemies still act) while raising the next try by 10 points. Basic
+  skips, the enemies still act) while raising the next try by 10 points.
+  ✅ **That formula summary skipped three details `Scene_Battle::
+  InitEscapeChance()` / `TryEscape()` (`src/scene_battle.cpp`) get right that
+  `Game::Battle#avg_agi` / `#escape_chance` did not.** First, **a fallen
+  battler still counts**: EasyRPG's `Game_Party_Base::GetAverageAgility()`
+  (`src/game_party_base.cpp`) sums over `GetBattlers()` — every member —
+  rather than `GetActiveBattlers()` (the not-dead-or-hidden subset), so a
+  party or troop that has already lost someone still divides by the whole
+  roster and adds the casualty's own agility in; `avg_agi` instead filtered
+  with `side.reject(&:dead?)`, understating the average (or, for a wiped
+  side, reading it as 0 instead of `GetAverageAgility`'s own
+  `battlers.empty() ? 1 : ...`) the moment anyone went down. Second, **the
+  ratio rounds to the nearest percent rather than truncating**:
+  `InitEscapeChance` computes `100.0 * avg_enemy_agi / avg_actor_agi` in
+  `double` and finishes with `Utils::RoundTo<int>` (`std::lrint`, its own
+  comment reading "RPG_RT / Delphi compatible rounding"), while this build
+  did a plain integer divide — a 7-agi party against a 10-agi troop reads
+  escape chance 7 under the real formula (ratio rounds 142.857 → 143) and
+  used to read 8 here (truncated to 142); RPG_RT's own *`to_hit`* agility
+  term truncates instead (`CalcToHitAgiAdjustment`'s `float` return
+  truncates on its implicit int conversion, see the `to_hit` paragraph
+  below), so the two nearby agility-ratio formulas genuinely round
+  differently in the reference itself, not just here. Third, **the chance is
+  fixed once, at battle start, not re-derived on first use**:
+  `Scene_Battle::Start()` calls `InitEscapeChance()` exactly once, before any
+  turn runs, and `TryEscape()` only ever adds +10 to that one starting value
+  on a failure; `escape_chance` was instead a `nil`-until-read memo computed
+  whichever frame the party first chose Flee, which could be turns into the
+  fight — after a stat-halving/doubling state had already changed someone's
+  agility, a change `InitEscapeChance` never sees. `Game::Battle#
+  compute_escape_chance` is now called once from `#initialize` (right beside
+  the Combatant snapshots it reads, matching `Start()`'s own timing), and
+  `#avg_agi` no longer filters by `#dead?`. Covered by three new
+  `scripts/rpg2k_logic_check.rb` checks (a fallen ally still pulling the
+  average down; the 143-vs-142 rounding case; a state applied after
+  construction not moving an already-read `escape_chance`), confirmed to
+  fail against the pre-fix code before the fix. Basic
   attacks can also **miss**: `Battle#to_hit` takes the attacker's base hit rate
   (weapon / unarmed 90, a "miss"-flagged enemy 70) and applies EasyRPG's
   agility-ratio adjustment (`100 - (100 - base)*(srcAgi + tgtAgi)/(2*srcAgi)`),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6136,7 +6136,7 @@ module Game
     # 999 either, no matter how large `recover_hp_rate` x max_hp computes it.
     RECOVER_CAP = 999
 
-    attr_reader :allies, :enemies, :rounds, :result, :log, :rng
+    attr_reader :allies, :enemies, :rounds, :result, :log, :rng, :escape_chance
 
     # `states` is an optional state-definition lookup (`[id]` -> a row exposing
     # `restriction` / `hp_change_val` / `hp_change_max` / `sp_change_val` /
@@ -6176,8 +6176,16 @@ module Game
       @ai = ai
       @rounds = 0
       @result = nil
-      @escaped = false     # set once the party successfully flees (#attempt_escape)
-      @escape_chance = nil # lazily computed from agilities on the first attempt
+      @escaped = false # set once the party successfully flees (#attempt_escape)
+      # Computed once, right here at battle start -- EasyRPG's Scene_Battle::Start
+      # calls InitEscapeChance() exactly once, before any turn runs, and
+      # #attempt_escape only ever adds to that one fixed starting value on a
+      # failure (Scene_Battle::TryEscape's `escape_chance += 10`); nothing
+      # re-derives it from the agilities again later. Computing it lazily on
+      # the first #attempt_escape call instead (as this used to) reads
+      # whatever a state has done to someone's agility by that point in the
+      # fight rather than what the roster carried when the fight began.
+      @escape_chance = compute_escape_chance
       @force_flee = false  # a battle page granted the party a guaranteed escape
       @log = []      # one entry per landed attack, in order (see #strike)
       @queue = []    # battlers still to act this round, in agility order
@@ -6386,25 +6394,46 @@ module Game
       ally.action = nil; ally.defending = false; ally.command = nil; ally.skip = true
     end
 
-    # Average agility of the living battlers on `side` (0 when the side is wiped),
-    # state-adjusted (see #effective_agi).
+    # Average agility of every battler on `side` (EasyRPG's
+    # Game_Party_Base::GetAverageAgility, an int-truncating sum / count), 1 for
+    # an empty side (its own `battlers.empty() ? 1 : ...` fallback, so a
+    # division downstream never sees a zero party). **A fallen battler still
+    # counts**: GetAverageAgility sums over GetBattlers (every member) rather
+    # than GetActiveBattlers (the not-dead-or-hidden subset one might reach for
+    # here) -- there is no live/dead branch in it at all -- so a fight where two
+    # of four party members are already down still divides by four and adds
+    # their agility in, not the two survivors'. Each battler's own #effective_agi
+    # already folds in any agi-affecting state (GetAgi()'s own AdjustParam),
+    # which a death itself does not reset or exclude.
     def avg_agi(side)
-      living = side.reject(&:dead?)
-      return 0 if living.empty?
-      living.reduce(0) { |s, b| s + effective_agi(b) } / living.size
+      return 1 if side.empty?
+      side.reduce(0) { |s, b| s + effective_agi(b) } / side.size
     end
 
-    # The party's current escape chance as a percentage (0..100). On the first
-    # attempt it is EasyRPG's InitEscapeChance -- 150 - 100 * enemyAgi / partyAgi,
-    # clamped -- so a nimbler party flees more often and a slower one struggles;
-    # an agility-less party falls back to a coin toss. Each failed attempt adds
-    # 10 (see #attempt_escape).
-    def escape_chance
-      return @escape_chance unless @escape_chance.nil?
+    # The escape chance this fight started with, as a percentage (0..100)
+    # (see the class's own `attr_reader` above) -- fixed at construction by
+    # #compute_escape_chance and only ever bumped by +10 per failed
+    # #attempt_escape from there, ported from EasyRPG's
+    # Scene_Battle::InitEscapeChance() / TryEscape(), neither of which touches
+    # the agilities again once the fight is under way.
+    #
+    # EasyRPG's InitEscapeChance: 150 - round(100 * enemyAgi / partyAgi),
+    # clamped 0..100, so a nimbler party flees more often and a slower one
+    # struggles; an agility-less party falls back to a coin toss (partyAgi is
+    # never actually 0 here -- #avg_agi floors at 1 -- so this branch is a
+    # defensive guard against a Ruby ZeroDivisionError rather than a case
+    # InitEscapeChance itself has to handle). **The ratio is rounded to the
+    # nearest percent, not truncated**: InitEscapeChance computes it in
+    # `double` and finishes with `Utils::RoundTo<int>` (`std::lrint`, "RPG_RT /
+    # Delphi compatible rounding"), unlike this same battle's own #to_hit
+    # agility term, which RPG_RT computes in `float` and truncates on its
+    # implicit int conversion -- the two nearby agility-ratio formulas round
+    # differently in the reference itself, not just here.
+    def compute_escape_chance
       pa = avg_agi(@allies)
       ea = avg_agi(@enemies)
-      base = pa > 0 ? 100 * ea / pa : 100
-      @escape_chance = Game.clamp(150 - base, 0, 100)
+      base = pa > 0 ? (100.0 * ea / pa).round : 100
+      Game.clamp(150 - base, 0, 100)
     end
 
     # Attempt to flee the fight. A `preemptive` first strike always succeeds, as

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6898,6 +6898,52 @@ check 'Battle#escape_chance scales with the agility ratio, clamped 0..100' do
   eq 0,   escape_battle(5, 20).escape_chance,  'a much slower party clamps at 0'
 end
 
+check 'Battle#escape_chance still counts a fallen battler, per GetAverageAgility' do
+  # EasyRPG's Game_Party_Base::GetAverageAgility sums over GetBattlers (every
+  # member) rather than GetActiveBattlers (the not-dead subset), so a party
+  # that has already lost someone still divides by the whole roster and adds
+  # the fallen member's own agility in.
+  hero = combatant('Hero', 0, 0, 20, 10)      # alive, agi 20
+  squire = combatant('Squire', 0, 0, 0, 0)    # already down, agi 0
+  slime = combatant('Slime', 0, 0, 10, 10)    # agi 10
+  b = Game::Battle.new([hero, squire], [slime], Game::Rng.new(1))
+  # partyAgi = (20 + 0) / 2 = 10, enemyAgi = 10 -> ratio 100 -> 150 - 100 = 50.
+  # Filtering the fallen squire out (the old bug) would read partyAgi as the
+  # survivor's own 20, halving the ratio to 50 and clamping escape to 100.
+  eq 50, b.escape_chance, 'the fallen squire still counts toward partyAgi'
+end
+
+check 'Battle#escape_chance rounds the agility ratio to the nearest percent' do
+  # EasyRPG's InitEscapeChance finishes with Utils::RoundTo<int> (std::lrint),
+  # not a truncating integer divide -- unlike this same class's #to_hit
+  # agility term, which RPG_RT computes in `float` and truncates instead.
+  hero = combatant('Hero', 0, 0, 7, 10)
+  slime = combatant('Slime', 0, 0, 10, 10)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  # 100 * 10 / 7 = 142.857..., which rounds to 143 (-> escape 7), not
+  # truncates to 142 (-> escape 8, what the pre-fix integer divide gave).
+  eq 7, b.escape_chance, 'the ratio rounds to 143 before the 150 - x clamp'
+end
+
+check 'Battle#escape_chance is fixed at battle start, not re-derived per attempt' do
+  # EasyRPG calls InitEscapeChance() exactly once, from Scene_Battle::Start;
+  # TryEscape only ever adds +10 to that one starting value on a failure, and
+  # nothing re-reads the agilities once the fight is under way.
+  states = { 1 => fake_state(affect_type: 0, affect_agility: true) } # 0 = halve
+  hero = combatant('Hero', 0, 0, 20, 10)
+  slime = combatant('Slime', 0, 0, 10, 10)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1), states)
+  # Read escape_chance for the first time only *after* a state lands on the
+  # hero mid-fight -- a lazily-memoized "compute on first read" implementation
+  # would see the halved agility right here and read partyAgi 10 (ratio 100,
+  # escape 50); fixed at construction, before the state existed, it reads
+  # partyAgi 20 (ratio 50, escape 100) regardless of when this is called.
+  hero.states = [1]
+  eq 100, b.escape_chance,
+     'fixed at construction -- a first read after the state lands must not ' \
+     "recompute against the now-halved agility"
+end
+
 check 'Battle#attempt_escape flees the fight when the roll succeeds' do
   b = escape_battle(20, 5)                            # 100% chance
   ok b.attempt_escape, 'a 100% chance always flees'


### PR DESCRIPTION
## Summary
- `docs/TODO.md` described `Battle#attempt_escape`'s agility-ratio formula only in shape, not exact semantics. Cross-checked against EasyRPG Player's real source (`game_party_base.cpp`'s `GetAverageAgility`, `scene_battle.cpp`'s `InitEscapeChance`/`TryEscape`) and found three genuine divergences:
  1. `avg_agi` excluded dead battlers from the average, but EasyRPG's `GetAverageAgility()` sums the full roster (`GetBattlers()`), not just active ones.
  2. The ratio was truncated via integer division; EasyRPG computes it in `double` and rounds with `std::lrint` — e.g. 7 agi vs 10 agi troop should give chance 7 (143 rounded), not 8 (142 truncated). Notably RPG_RT's own `to_hit` agility term *does* truncate, so the reference itself rounds these two formulas differently.
  3. The chance was lazily memoized on first read/attempt rather than fixed once at battle start (`Scene_Battle::Start()` calls `InitEscapeChance()` exactly once) — a mid-fight agility-halving state shouldn't move an already-open Flee chance.
- `Game::Battle#avg_agi` no longer filters dead battlers; a new `#compute_escape_chance` uses rounding instead of truncation and is called once from `#initialize`; `escape_chance` is now a plain `attr_reader`.
- `docs/TODO.md` updated ✅ with the citations.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 717 checks pass (3 new: a fallen ally still pulling down the party average; the 143-vs-142 rounding boundary; escape chance staying fixed after a mid-fight agility-halving state lands — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 406 checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_