### PR TITLE
Use ubuntu-slim runner for label management CI jobs

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -18,7 +18,10 @@ concurrency:
 
 jobs:
   label:
-    runs-on: ubuntu-24.04
+    # Just a checkout and a Ruby script driving `gh`, no build tooling -- so
+    # the small `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) covers it
+    # at a lower rate. See `preview-gate` in build.yml for the same reasoning.
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,7 +21,11 @@ concurrency:
 
 jobs:
   label:
-    runs-on: ubuntu-24.04
+    # Nothing here but the labeler action itself -- no checkout, no build
+    # tooling -- so the small `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute
+    # cap) covers it at a lower rate. See `preview-gate` in build.yml for the
+    # same reasoning.
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/labeler@v7
         with:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -31,7 +31,10 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ubuntu-24.04
+    # Just a checkout and a Ruby script driving `gh`, no build tooling -- so
+    # the small `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) covers it
+    # at a lower rate. See `preview-gate` in build.yml for the same reasoning.
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
         with:

--- a/changelog.d/ci-labels-ubuntu-slim.changed.md
+++ b/changelog.d/ci-labels-ubuntu-slim.changed.md
@@ -1,0 +1,6 @@
+- CI's label-management jobs (`labeler.yml`'s `label`, `labels.yml`'s `sync`,
+  and `issue-labels.yml`'s `label`) now run on the `ubuntu-slim` runner
+  instead of `ubuntu-24.04`. None of them need build tooling — just a
+  checkout (or none, for `labeler.yml`) and a script driving `gh` — so the
+  small image (1 CPU, 5 GB RAM, 15-minute cap) covers them at a lower rate,
+  the same reasoning as `preview-gate` in `build.yml`.


### PR DESCRIPTION
## Summary
Optimize CI costs by switching label management jobs from `ubuntu-24.04` to the lighter `ubuntu-slim` runner, which is sufficient for their minimal resource requirements.

## Changes
- **labeler.yml**: Updated `label` job to run on `ubuntu-slim` instead of `ubuntu-24.04`
- **labels.yml**: Updated `sync` job to run on `ubuntu-slim` instead of `ubuntu-24.04`
- **issue-labels.yml**: Updated `label` job to run on `ubuntu-slim` instead of `ubuntu-24.04`
- Added explanatory comments to each job documenting the rationale for using the smaller runner

## Rationale
None of these label management jobs require build tooling or significant resources. They only need:
- A checkout (or none, in the case of `labeler.yml`)
- A script driving the `gh` CLI tool

The `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) is sufficient for these tasks and runs at a lower rate, following the same cost optimization pattern already applied to the `preview-gate` job in `build.yml`.

https://claude.ai/code/session_01TVYgzmWfoRBKT2DEAscZxm