### PR TITLE
rpg2k: Control Variables' map-event map-id read is an RPG2000-only quirk

### DIFF
--- a/changelog.d/control-variables-event-map-id-rpg2003.fixed.md
+++ b/changelog.d/control-variables-event-map-id-rpg2003.fixed.md
@@ -1,0 +1,14 @@
+- **A map event's Control Variables map id (operand 6, attribute 0) now
+  reads the real map id on an RPG2003 database, instead of RPG_RT's RPG2000
+  bug applying to every game regardless of edition.** EasyRPG's own
+  `ControlVariables::Event` (case 0, `src/game_interpreter_control_variables.cpp`)
+  is explicit that always reading 0 for a map event's map id is "an RPG_RT bug
+  for 2k only" — its guard is `!Player::IsRPG2k() || event_id ==
+  CharPlayer/CharBoat/CharShip/CharAirship`, so a genuine RPG2003 project
+  takes the *true* branch and reads the event's real (current) map id, just
+  like the hero and vehicle branches beside it. `Game::Interpreter#event_operand`
+  zeroed that case unconditionally, with no edition check at all. Fixed with a
+  new `Game::Party#rpg2003?` (mirroring `#db_item`/`#db_skill`'s own `@db`
+  reach-through) consulted by that one branch: RPG2000 still reads 0, RPG2003
+  reads `@state.map_id`. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check, confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -495,8 +495,31 @@ The work below is roughly ordered by the critical path to a walkable game
   **save / battle / win / defeat / escape counts** — running tallies bumped by
   Save and by each Enemy Encounter and its outcome, persisted in the save), a
   **character position** (the hero's or a map event's map id / x / y / facing /
-  **screen x / y** — an event's map id reads 0, matching an RPG_RT 2000 quirk;
-  the screen coordinates are measured against the live camera, which
+  **screen x / y** — an event's map id reads 0, matching an RPG_RT 2000 quirk.
+  ✅ **That quirk is now actually 2000-only, not applied to every database
+  regardless of edition.** This line used to flag a map event's map id as
+  reading 0 unconditionally; EasyRPG's own `ControlVariables::Event` (case 0,
+  `src/game_interpreter_control_variables.cpp`) is explicit that this is "an
+  RPG_RT bug for 2k only" — its guard is `!Player::IsRPG2k() || event_id ==
+  CharPlayer/CharBoat/CharShip/CharAirship`, true (real map id returned) on a
+  genuine RPG2003 project, since `IsRPG2k()` / `IsRPG2k3()` are the mutually
+  exclusive engine flags that `db.rpg2003?` already detects for this build.
+  `Game::Interpreter#event_operand` (`interpreter.rb`) zeroed the map-event
+  branch's `attr == 0` case unconditionally regardless of edition, so a real
+  RPG2003 game reading a map event's own map id (Control Variables operand 6,
+  attribute 0) got the RPG2000 bug it should not have. Fixed by threading a
+  new `Game::Party#rpg2003?` (`game.rb`, mirroring `#db_item`/`#db_skill`'s own
+  `@db` reach-through, so a bare test fixture with no `#rpg2003?` of its own
+  still reads false) into that one case: RPG2000 still reads 0, RPG2003 reads
+  `@state.map_id` — the current map, which is all a `Game_Event`'s own map id
+  can ever be, since (unlike a vehicle) it cannot exist independently of the
+  map it is on (`Game_Event`'s constructor calls `SetMapId(map_id)` with the
+  map it was just built for and nothing ever changes it after). Covered by a
+  new `scripts/rpg2k_logic_check.rb` check (an RPG2003 state reads a map
+  event's real, current map id while its x/y/facing and the hero's own map id
+  stay unaffected), confirmed to fail against the pre-fix code (reading 0
+  instead of the real map id) before the fix.
+  The screen coordinates are measured against the live camera, which
   `Scene::Map#camera_position` now exposes, with RPG_RT's own asymmetric offsets:
   X from the tile's centre, Y from its bottom) and, in a fight, a **monster
   stat** (RPG2003's battle operand — HP / SP / max HP-SP / attack / defence /

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2456,6 +2456,15 @@ module Game
       @db.item[id]
     end
 
+    # Whether this party's database is an RPG2003 project (see
+    # `LCF::Schema::Database#rpg2003?`), exposed here the same way `db_item` /
+    # `db_skill` reach into `@db` for other callers -- a bare test fixture with
+    # no `#rpg2003?` of its own reads false, the same answer a genuine RPG2000
+    # database gives.
+    def rpg2003?
+      @db.respond_to?(:rpg2003?) && @db.rpg2003?
+    end
+
     # Whether item `id` can be used from the field (main-menu) item screen: a
     # medicine or switch item the party holds whose "usable in field" occasion is
     # set (a battle-only medicine is hidden here, mirroring #battle_usable?), or a

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1368,13 +1368,22 @@ module Game
     # the hero / party, 10002-10004 a vehicle (boat/ship/airship), "this event"
     # as 0 / 10005, any other positive id a map event); param6 the value (0 map
     # id, 1 x tile, 2 y tile, 3 facing in RPG2000's 2/4/6/8 numpad convention,
-    # 4 screen x, 5 screen y). Matching a long-standing RPG_RT quirk, a *map
-    # event's* map id reads 0 -- a vehicle's does not, since (unlike a map
-    # event) it is a real piece of state that exists independently of whatever
-    # map is currently loaded (yado.tk: a vehicle's position can be read from a
-    # different map than the one it currently occupies). An unresolvable
-    # reference (no map_info hook, unknown event, "this event" outside a map
-    # event) reads 0.
+    # 4 screen x, 5 screen y). A *map event's* map id reads 0 -- but only on an
+    # RPG2000 database: EasyRPG's `ControlVariables::Event` (case 0) is
+    # explicit that this is "an RPG_RT bug for 2k only" -- its condition is
+    # `!Player::IsRPG2k() || event_id == CharPlayer/CharBoat/CharShip/
+    # CharAirship`, so a genuine RPG2003 project (`IsRPG2k3()`, the mutually
+    # exclusive engine flag `db.rpg2003?` already detects) takes the *true*
+    # branch and reads the event's real map id -- which, for a map event, is
+    # simply whichever map is currently loaded, the same value the hero/party
+    # branch below already returns (`Game_Event`'s own map id is set from the
+    # loaded map at construction and never changes; unlike a vehicle it cannot
+    # exist independently of one). A vehicle's map id reads for real
+    # regardless of edition, since (unlike a map event) it is state that
+    # exists independently of whatever map is currently loaded (yado.tk: a
+    # vehicle's position can be read from a different map than the one it
+    # currently occupies). An unresolvable reference (no map_info hook,
+    # unknown event, "this event" outside a map event) reads 0.
     def event_operand(cmd)
       ref = character_ref(cmd.param(5))
       attr = cmd.param(6)
@@ -1394,10 +1403,11 @@ module Game
         pos = @map_info.event_position(ref)
         return 0 unless pos
         case attr
+        when 0 then @state.party.rpg2003? ? @state.map_id : 0 # the RPG2000-only quirk
         when 1 then pos[:x]
         when 2 then pos[:y]
         when 3 then pos[:direction]
-        else 0 # an event's map id reads 0 (the RPG2000 quirk)
+        else 0
         end
       else
         0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -934,14 +934,15 @@ end
 # commands the checks below drive (gold/items).
 class FakeParty
   attr_reader :gold, :items
-  def initialize; @gold = 0; @items = {}; end
+  def initialize(rpg2003: false); @gold = 0; @items = {}; @rpg2003 = rpg2003; end
   def gain_gold(n); @gold += n; end
   def gain_item(id, n); @items[id] = (@items[id] || 0) + n; end
   def has_item?(id); (@items[id] || 0) > 0; end
+  def rpg2003?; @rpg2003; end
 end
 
-def new_state
-  Game::State.new(FakeParty.new, 1, 0, 0)
+def new_state(rpg2003: false)
+  Game::State.new(FakeParty.new(rpg2003: rpg2003), 1, 0, 0)
 end
 
 IC = Game::Interpreter::Cmd
@@ -4544,6 +4545,21 @@ check 'Control Variables reads a map event position (operand type 6)' do
   eq 6, st.variables[3]
   eq 0, st.variables[4]                                          # a map event's map id reads 0
   eq 0, st.variables[5]                                          # unknown event reads 0
+end
+
+check 'Control Variables: a map event\'s map id is the RPG2000-only quirk -- an ' \
+      'RPG2003 database reads the real (current) map id instead' do
+  st = new_state(rpg2003: true)
+  st.map_id = 12
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new                                  # event 7 at (2,3) dir 6
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 7, 0]),   # event 7 map id
+            FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 0, 6, 7, 1]),   # event 7 x still resolves
+            FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 0, 6, 10001, 0])]) # the hero's own map id
+  it.update
+  eq 12, st.variables[1], 'RPG2003: a map event\'s own map id is the currently loaded one'
+  eq 2, st.variables[2], 'RPG2003 does not disturb the event\'s x/y/facing'
+  eq 12, st.variables[3], 'the hero branch is unaffected by the edition check'
 end
 
 check 'Control Variables reads a vehicle position (operand 6, ref 10002-10004)' do


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s Control Variables "character position" (type 6) paragraph stated flatly that an event's map id operand reads 0, "matching an RPG_RT 2000 quirk" — worded as if this always applies, with no `db.rpg2003?` gate anywhere in the mechanism.
- Verified against EasyRPG Player's actual source (`src/game_interpreter_control_variables.cpp`, `ControlVariables::Event` case 0): the code comment says explicitly *"This is an RPG_RT bug for 2k only"* — the guard is `!Player::IsRPG2k() || event_id == Char{Player,Boat,Ship,Airship}`, so RPG2003 returns the real (current) map id instead. `Game::Interpreter#event_operand` zeroed a map event's map id unconditionally, with no edition check — the same "RPG2000-only vs RPG2003-only conflation" bug class found repeatedly this session (field menu commands, battle command order).
- Added `Game::Party#rpg2003?` (mirroring the existing `@db.respond_to?(...)` reach-through idiom for `#db_item`/`#db_skill`); `event_operand`'s map-event branch now reads `@state.party.rpg2003? ? @state.map_id : 0` for attr 0.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 718 checks pass (1 new: an RPG2003 state reads the event's real map id while x/y/facing and the hero's own map-id branch are unaffected — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 406 checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_