### PR TITLE
Move light label-management CI jobs to ubuntu-slim

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -18,16 +18,23 @@ concurrency:
 
 jobs:
   label:
-    # NOT ubuntu-slim: this needs Ruby (`ruby scripts/issue_form_labels.rb`
-    # below), and that small image doesn't ship an interpreter -- only `gh`
-    # and `jq` are preinstalled there. See labels.yml's `sync` job, which hit
-    # this same gap ("ruby: command not found", exit 127) for real.
-    runs-on: ubuntu-24.04
+    # Just a checkout and a Ruby script driving `gh`, no build tooling -- so
+    # the small `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) covers it
+    # at a lower rate. See `preview-gate` in build.yml for the same reasoning.
+    # The image itself only preinstalls `gh` and `jq` -- no Ruby interpreter
+    # (see labels.yml's `sync` job, which hit that gap for real: "ruby:
+    # command not found", exit 127) -- so `ruby/setup-ruby` below installs one
+    # first.
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
         with:
           show-progress: false
           persist-credentials: false
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
 
       # The body is untrusted input, so it reaches ruby through the
       # environment, never through the shell command line. The script maps it

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -18,10 +18,11 @@ concurrency:
 
 jobs:
   label:
-    # Just a checkout and a Ruby script driving `gh`, no build tooling -- so
-    # the small `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) covers it
-    # at a lower rate. See `preview-gate` in build.yml for the same reasoning.
-    runs-on: ubuntu-slim
+    # NOT ubuntu-slim: this needs Ruby (`ruby scripts/issue_form_labels.rb`
+    # below), and that small image doesn't ship an interpreter -- only `gh`
+    # and `jq` are preinstalled there. See labels.yml's `sync` job, which hit
+    # this same gap ("ruby: command not found", exit 127) for real.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -31,16 +31,22 @@ concurrency:
 
 jobs:
   sync:
-    # NOT ubuntu-slim: this needs Ruby (`ruby scripts/sync_github_labels.rb`
-    # below), and that small image doesn't ship an interpreter -- only `gh`
-    # and `jq` are preinstalled there. Confirmed by a real run failing with
-    # "ruby: command not found" (exit 127) the first time this was tried.
-    runs-on: ubuntu-24.04
+    # Just a checkout and a Ruby script driving `gh`, no build tooling -- so
+    # the small `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) covers it
+    # at a lower rate. See `preview-gate` in build.yml for the same reasoning.
+    # The image itself only preinstalls `gh` and `jq` -- no Ruby interpreter
+    # (confirmed by a real run failing with "ruby: command not found", exit
+    # 127) -- so `ruby/setup-ruby` below installs one first.
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
         with:
           show-progress: false
           persist-credentials: false
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
 
       # `inputs.prune` is a typed boolean, and empty on a push, so the
       # expression can only ever expand to `--prune` or nothing.

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -31,10 +31,11 @@ concurrency:
 
 jobs:
   sync:
-    # Just a checkout and a Ruby script driving `gh`, no build tooling -- so
-    # the small `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) covers it
-    # at a lower rate. See `preview-gate` in build.yml for the same reasoning.
-    runs-on: ubuntu-slim
+    # NOT ubuntu-slim: this needs Ruby (`ruby scripts/sync_github_labels.rb`
+    # below), and that small image doesn't ship an interpreter -- only `gh`
+    # and `jq` are preinstalled there. Confirmed by a real run failing with
+    # "ruby: command not found" (exit 127) the first time this was tried.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/changelog.d/ci-labels-ubuntu-slim.changed.md
+++ b/changelog.d/ci-labels-ubuntu-slim.changed.md
@@ -1,9 +1,9 @@
-- CI's `labeler.yml` `label` job now runs on the `ubuntu-slim` runner instead
-  of `ubuntu-24.04`. It only runs the `actions/labeler` action — no checkout,
-  no build tooling — so the small image (1 CPU, 5 GB RAM, 15-minute cap)
-  covers it at a lower rate, the same reasoning as `preview-gate` in
-  `build.yml`. `labels.yml`'s `sync` job and `issue-labels.yml`'s `label` job
-  were tried on `ubuntu-slim` too but reverted to `ubuntu-24.04`: both run a
-  Ruby script, and the slim image doesn't ship a Ruby interpreter (only `gh`
-  and `jq` are preinstalled there), which failed a real run with "ruby:
-  command not found".
+- CI's label-management jobs (`labeler.yml`'s `label`, `labels.yml`'s `sync`,
+  and `issue-labels.yml`'s `label`) now run on the `ubuntu-slim` runner
+  instead of `ubuntu-24.04`. None of them need build tooling, so the small
+  image (1 CPU, 5 GB RAM, 15-minute cap) covers them at a lower rate, the
+  same reasoning as `preview-gate` in `build.yml`. The image only preinstalls
+  `gh` and `jq`, not a Ruby interpreter (confirmed by a real run of `sync`
+  failing with "ruby: command not found"), so the two jobs that run a Ruby
+  script (`labels.yml`'s `sync`, `issue-labels.yml`'s `label`) install one
+  with `ruby/setup-ruby` before their script step.

--- a/changelog.d/ci-labels-ubuntu-slim.changed.md
+++ b/changelog.d/ci-labels-ubuntu-slim.changed.md
@@ -1,6 +1,9 @@
-- CI's label-management jobs (`labeler.yml`'s `label`, `labels.yml`'s `sync`,
-  and `issue-labels.yml`'s `label`) now run on the `ubuntu-slim` runner
-  instead of `ubuntu-24.04`. None of them need build tooling — just a
-  checkout (or none, for `labeler.yml`) and a script driving `gh` — so the
-  small image (1 CPU, 5 GB RAM, 15-minute cap) covers them at a lower rate,
-  the same reasoning as `preview-gate` in `build.yml`.
+- CI's `labeler.yml` `label` job now runs on the `ubuntu-slim` runner instead
+  of `ubuntu-24.04`. It only runs the `actions/labeler` action — no checkout,
+  no build tooling — so the small image (1 CPU, 5 GB RAM, 15-minute cap)
+  covers it at a lower rate, the same reasoning as `preview-gate` in
+  `build.yml`. `labels.yml`'s `sync` job and `issue-labels.yml`'s `label` job
+  were tried on `ubuntu-slim` too but reverted to `ubuntu-24.04`: both run a
+  Ruby script, and the slim image doesn't ship a Ruby interpreter (only `gh`
+  and `jq` are preinstalled there), which failed a real run with "ruby:
+  command not found".


### PR DESCRIPTION
## Summary
- Move `labeler.yml`'s `label` job, `labels.yml`'s `sync` job, and `issue-labels.yml`'s `label` job to the `ubuntu-slim` runner, matching `preview-gate` in `build.yml` (none of these jobs need build tooling, so the small 1 CPU / 5 GB / 15-minute-cap image covers them at a lower rate).
- `labels.yml`'s `sync` and `issue-labels.yml`'s `label` also run a Ruby script, and `ubuntu-slim` only preinstalls `gh` and `jq` — confirmed by a real run of `sync` failing with `ruby: command not found` (exit 127) after the first version of this change merged as #624. Both jobs now install Ruby with `ruby/setup-ruby` before their script step.

## Test plan
- [x] `labeler.yml`'s `label` job ran successfully on `ubuntu-slim` in #624 (no Ruby dependency, unaffected by this follow-up).
- [ ] Confirm `labels.yml`'s `sync` job succeeds on `ubuntu-slim` with `ruby/setup-ruby` (triggers on push to master touching label config, or manual dispatch — not exercised by this PR's own CI).
- [ ] Confirm `issue-labels.yml`'s `label` job succeeds on `ubuntu-slim` with `ruby/setup-ruby` (triggers on issue open/edit — not exercised by this PR's own CI either).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TVYgzmWfoRBKT2DEAscZxm)_