### PR TITLE
rpg2k: Control Variables Divide/Modulo now truncate toward zero like RPG_RT

### DIFF
--- a/changelog.d/control-variables-truncating-divmod.fixed.md
+++ b/changelog.d/control-variables-truncating-divmod.fixed.md
@@ -1,0 +1,16 @@
+- **Control Variables' Divide/Modulo now truncate toward zero like real
+  RPG_RT's C++ math**, instead of mruby's native `/`/`%`, which floor toward
+  negative infinity — the two only ever agreed when both operands shared a
+  sign. `Game::Interpreter#apply` computed Divide/Modulo (op 4/5) as plain
+  `cur / val` / `cur % val`; EasyRPG's `Game_Variables::VarDiv`/`VarMod`
+  (`src/game_variables.cpp`) are bare C++ `n / d` / `n % d`, so e.g. `-7 / 2`
+  is −3 there but mruby's floored `/` gives −4, and `-7 % 2` is −1 there (the
+  remainder takes the dividend's sign) but mruby's `%` gives 1 (the divisor's
+  sign) — a real divergence for any game whose Control Variables math ever
+  goes negative. Fixed with two new helpers, `#trunc_div`/`#trunc_mod`, the
+  same truncating idiom this codebase already uses elsewhere for a different
+  C++-vs-mruby division gap (`Scene::Map.tone_channel`). Divide-by-zero was
+  already correct (`cur` unchanged, matching `VarDiv`'s `d != 0 ? n / d : n`)
+  and is untouched; **modulo by zero now zeroes the variable instead of
+  leaving it unchanged**, matching `VarMod`'s own `d != 0 ? n % d : 0`, which
+  disagrees with `VarDiv`'s behaviour on this exact point.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3307,7 +3307,33 @@ not yet verified:
   division/modulo (no fractional values ever) — the standard workaround
   for `×1.5` etc. is `×15÷10` in that order, since multiplying first can
   silently overflow the ±999999 range with no error (wrong output, not a
-  crash).
+  crash). ✅ **Control Variables' Divide/Modulo now truncate toward zero
+  like real RPG_RT's C++ math, instead of mruby's native `/`/`%`, which
+  floor toward negative infinity** — the two only ever agreed when both
+  operands shared a sign, and variables can hold negatives (`Variables::MIN`
+  is −999999, the "±999999 range" clamp fixed above, and the random operand
+  explicitly "accepts negative ranges," a fact recorded a few lines up).
+  `Game::Interpreter#apply` (`mruby-rpg2k/mrblib/interpreter.rb`) computed
+  Divide/Modulo (op 4/5) as plain `cur / val` / `cur % val`; EasyRPG's
+  `Game_Variables::VarDiv`/`VarMod` (`src/game_variables.cpp`) are bare C++
+  `n / d` / `n % d`, which truncate toward zero, so e.g. `-7 / 2` is −3 there
+  but mruby's floored `/` gives −4, and `-7 % 2` is −1 there (the remainder
+  takes the *dividend's* sign) but mruby's `%` gives 1 (the divisor's sign) —
+  a real divergence for any game whose Control Variables math ever goes
+  negative, not a cosmetic one. Fixed with two new helpers, `#trunc_div`/
+  `#trunc_mod`, computing `n.abs / d.abs` and negating only when the operands'
+  signs differ, the same truncating idiom this codebase already uses
+  elsewhere for a different C++-vs-mruby division gap
+  (`Scene::Map.tone_channel`'s `n < 0 ? -(-n / 100) : n / 100`, `scene/
+  map.rb`). Divide-by-zero was already correct and is untouched (`val == 0 ?
+  cur : …`, matching `VarDiv`'s own `d != 0 ? n / d : n`) — but **modulo by
+  zero now zeroes the variable instead of leaving it unchanged**, matching
+  `VarMod`'s own `d != 0 ? n % d : 0`, which disagrees with `VarDiv`'s
+  behaviour on this exact point rather than mirroring it. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (negative-operand divide/modulo in
+  both operand-sign combinations, plus an unaffected same-sign control case;
+  divide-by-zero leaves the variable unchanged while modulo-by-zero zeroes
+  it), confirmed to fail against the pre-fix code before the fix.
 - **Indirect ("pointer") addressing** — `V[n]`, where the *value* of
   variable n becomes the actual target/operand variable's index — is a
   distinct third addressing mode from a literal variable number or a

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1544,10 +1544,30 @@ module Game
       when 1 then cur + val
       when 2 then cur - val
       when 3 then cur * val
-      when 4 then val == 0 ? cur : cur / val
-      when 5 then val == 0 ? cur : cur % val
+      when 4 then val == 0 ? cur : trunc_div(cur, val)
+      when 5 then val == 0 ? 0 : trunc_mod(cur, val)
       else cur
       end
+    end
+
+    # Control Variables' divide/modulo operands (op 4/5 above) need C++'s
+    # truncate-toward-zero division, not mruby's native `/`/`%`, which floor
+    # toward negative infinity -- the two only agree when both operands share
+    # a sign. EasyRPG's `Game_Variables::VarDiv`/
+    # `VarMod` (`src/game_variables.cpp`) are plain `n / d` / `n % d` in C++,
+    # so e.g. -7 / 2 is -3 there (truncated) but mruby's `-7 / 2` is -4
+    # (floored); -7 % 2 is -1 in C++ (remainder takes the dividend's sign) but
+    # 1 in mruby (remainder takes the divisor's sign). A divide by zero already
+    # left the variable unchanged above, matching `VarDiv`'s own
+    # `d != 0 ? n / d : n`; `VarMod` differs from that -- `d != 0 ? n % d : 0`
+    # -- so a modulo by zero zeroes the variable instead.
+    def trunc_div(n, d)
+      q = n.abs / d.abs
+      (n < 0) == (d < 0) ? q : -q
+    end
+
+    def trunc_mod(n, d)
+      n - d * trunc_div(n, d)
     end
 
     # Timer: op 0 set (seconds), 1 start, 2 stop. Start carries the RPG2000

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4404,6 +4404,58 @@ check 'a variable clamps to +-999999 instead of overflowing' do
   eq 999_999, st.variables[3], 'an add that overflows the range clamps at the max'
 end
 
+check 'Control Variables divide/modulo truncate toward zero like real RPG_RT, not mruby\'s floor' do
+  # EasyRPG's Game_Variables::VarDiv/VarMod (src/game_variables.cpp) are plain
+  # C++ `n / d` / `n % d`, which truncate toward zero -- mruby's native `/`/`%`
+  # floor toward negative infinity instead, and the two only agree when both
+  # operands share a sign. -7 / 2 is -3 in C++ (truncated) but -4 in mruby
+  # (floored); -7 % 2 is -1 in C++ (remainder takes the dividend's sign) but 1
+  # in mruby (remainder takes the divisor's sign).
+  st = new_state
+  st.variables[1] = -7
+  st.variables[2] = -7
+  st.variables[3] = 7
+  st.variables[4] = 7
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 4, 0, 2]),   # var 1 /= 2  (-7 / 2)
+    FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 5, 0, 2]),   # var 2 %= 2  (-7 % 2)
+    FakeCmd.new(IC::CONTROL_VARS, [0, 3, 3, 4, 0, -2]),  # var 3 /= -2 (7 / -2)
+    FakeCmd.new(IC::CONTROL_VARS, [0, 4, 4, 5, 0, -2]),  # var 4 %= -2 (7 % -2)
+  ])
+  it.update
+  eq(-3, st.variables[1], '-7 / 2 truncates to -3, not floors to -4')
+  eq(-1, st.variables[2], '-7 % 2 takes the dividend\'s sign (-1), not the divisor\'s (1)')
+  eq(-3, st.variables[3], '7 / -2 truncates to -3, not floors to -4')
+  eq 1, st.variables[4], '7 % -2 takes the dividend\'s sign (1), not the divisor\'s (-1)'
+
+  # Same-sign operands already agreed with mruby's native math -- confirm the
+  # fix did not disturb the ordinary case.
+  st.variables[5] = 7
+  it2 = Game::Interpreter.new(st)
+  it2.start([FakeCmd.new(IC::CONTROL_VARS, [0, 5, 5, 4, 0, 2])]) # var 5 /= 2
+  it2.update
+  eq 3, st.variables[5], 'an ordinary same-sign divide is unaffected'
+end
+
+check 'Control Variables modulo by zero zeroes the variable, matching EasyRPG; divide by zero leaves it unchanged' do
+  # EasyRPG's VarDiv is `d != 0 ? n / d : n` (unchanged) but VarMod is
+  # `d != 0 ? n % d : 0` (zeroed) -- the two operations disagree with each
+  # other on a zero divisor, not just with mruby's native `/`/`%` (which raise
+  # ZeroDivisionError).
+  st = new_state
+  st.variables[1] = 42
+  st.variables[2] = 42
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 4, 0, 0]), # var 1 /= 0
+    FakeCmd.new(IC::CONTROL_VARS, [0, 2, 2, 5, 0, 0]), # var 2 %= 0
+  ])
+  it.update
+  eq 42, st.variables[1], 'a divide by zero leaves the variable unchanged'
+  eq 0, st.variables[2], 'a modulo by zero zeroes the variable'
+end
+
 check 'a descending batch range silently no-ops for both Switches and Variables' do
   # yado.tk: a batch (range) Control Switches/Variables whose high end is
   # below its low end does nothing at all, no error. range(cmd) returns the


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Variables & Switches" backlog (Full-site sweep) flags Control Variables' Divide/Modulo as "integer-only, truncating" — but `Game::Interpreter#apply` implemented them with mruby's native `/`/`%`, which **floor** toward negative infinity, not truncate toward zero. The two only agree when both operands share a sign.
- Verified against EasyRPG Player's real C++ source (`src/game_variables.cpp`): `Game_Variables::VarDiv`/`VarMod` are bare `n / d` / `n % d`, which truncate in C++ — e.g. `-7 / 2` is `-3` there but mruby's floored `/` gives `-4`; `-7 % 2` is `-1` there (remainder takes the *dividend's* sign) but mruby's `%` gives `1` (divisor's sign).
- Also fixes a second, related divergence: divide-by-zero already correctly left the variable unchanged (matching `VarDiv`'s `d != 0 ? n / d : n`), but modulo-by-zero also left it unchanged — `VarMod` is `d != 0 ? n % d : 0`, so real RPG_RT zeroes the variable on a modulo by zero instead.
- Fixed with two small helpers, `#trunc_div`/`#trunc_mod`, following the same truncating idiom this codebase already uses elsewhere for an analogous C++-vs-mruby division gap (`Scene::Map.tone_channel`).
- Updated `docs/TODO.md`'s "Variables & Switches" bullet to ✅ with the evidence/mechanism, and added a `changelog.d/` fragment.

## Test plan
- Added `scripts/rpg2k_logic_check.rb` checks:
  - Negative-operand divide/modulo in both operand-sign combinations (`-7/2`, `-7%2`, `7/-2`, `7%-2`), plus a same-sign control case confirming the fix doesn't disturb the ordinary path.
  - Divide-by-zero leaves the variable unchanged; modulo-by-zero zeroes it.
- Confirmed both new checks **fail** against the pre-fix `interpreter.rb` (via `git stash` of just that file) before finalizing.
- `ruby scripts/rpg2k_logic_check.rb` — 720 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 406 checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R3YWGdkFMY18brpi5cqCh3)_