### PR TITLE
rpg2k: attribute defence shift direction is scope-driven, not reverse_state_effect

### DIFF
--- a/changelog.d/skill-attr-defence-shift-direction.fixed.md
+++ b/changelog.d/skill-attr-defence-shift-direction.fixed.md
@@ -1,0 +1,22 @@
+- **A skill's "attribute defence up/down" (field 45, `affect_attr_defence`)
+  shift direction now comes from the skill's own scope, not
+  `reverse_state_effect`.** This was previously an explicitly-unconfirmed
+  guess ("neither Nepheshel nor mtf-meido-action ships a skill with the flag
+  set" to check it against). EasyRPG Player's actual source settles it:
+  `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`)
+  computes `auto shift = IsPositive() ? 1 : -1;` right where it applies
+  `affect_attr_defence`, and `IsPositive()` was set a few lines earlier from
+  `Algo::SkillTargetsAllies(skill)` (`src/algo.h`) — purely the skill's own
+  `scope` field, true for every scope except Scope_enemy(0)/Scope_enemies(1).
+  `reverse_state_effect` plays no part in it at all (that flag's own
+  state-cure/inflict role is separately gated behind an RPG2003-only check in
+  the same function, a wider question left untouched here). Fixed
+  `Game::Party#skill_attr_shift` (`mruby-rpg2k/mrblib/game.rb`) to read the
+  skill's scope (mirroring `#battle_skill_target`'s own enemy-scope test)
+  instead of `reverse_state_effect`: an ally-scoped skill (self/single
+  ally/all allies — the "buff" shape) always raises resistance, an
+  enemy-scoped one (single/all enemies — the "curse" shape) always lowers
+  it. Covered by two new `scripts/rpg2k_logic_check.rb` checks (direction is
+  scope-driven with `reverse_state_effect` proven inert on both sides; the
+  existing shift-and-cap mechanic check reworked around scope-based
+  skills), confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4304,17 +4304,36 @@ above are repeated here)
   on every `Combatant#attr_ranks_of` call (`Game::Actor#attribute_ranks`
   caches nothing), and `Battle#apply_to_party` never writes it back to the
   actor — so a shift dies with the Combatant along with everything else the
-  fight didn't ask to persist. **The direction is this build's own reading,
-  not confirmed against RPG_RT or either test bed**: it reuses
-  `reverse_state_effect` (unset = up/better, set = down/worse), the same
-  polarity flag a skill's state effects already use, on the assumption
-  RPG2000's skill editor drives one shared "raise/lower" toggle for both the
-  state-effect list and the attribute-defence list rather than a separate
-  field of its own — neither Nepheshel nor mtf-meido-action ships a skill
-  with the flag set, so there is nothing to check it against. Attribute
-  ranks must be configured strictly `A>B>C>D>E` for the ±1-step logic to make
-  sense. Covered by a new `scripts/rpg2k_logic_check.rb` check (both
-  directions, and that repeat casts don't stack past the cap).
+  fight didn't ask to persist. ✅ **The direction question this entry left
+  open is now settled against EasyRPG Player's actual C++ source, and the
+  original guess was wrong.** `Game::Party#skill_attr_shift` used to reuse
+  `reverse_state_effect` (unset = up/better, set = down/worse) on the
+  assumption RPG2000's skill editor drives one shared "raise/lower" toggle
+  for both the state-effect list and the attribute-defence list — flagged
+  explicitly as unconfirmed, since neither Nepheshel nor mtf-meido-action
+  ships a skill with the flag set to check it against. EasyRPG's
+  `Game_BattleAlgorithm::Skill::vExecute` (`src/game_battlealgorithm.cpp`)
+  settles it: `auto shift = IsPositive() ? 1 : -1;` right where it applies
+  `affect_attr_defence`, and `IsPositive()` comes from
+  `Algo::SkillTargetsAllies(skill)` (`src/algo.h`) — purely the skill's own
+  `scope` field (true for every scope except Scope_enemy(0)/
+  Scope_enemies(1)). `reverse_state_effect` plays no part in this at all —
+  that flag's own state-cure/inflict role is, per the same function,
+  `IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`, gated
+  behind an RPG2003-only check this runtime does not model either way, a
+  separate, wider question still left untouched. Fixed by reading the
+  skill's scope instead (mirroring `#battle_skill_target`'s own enemy-scope
+  test, `scope == 0 || scope == 1`): an ally-scoped skill (self/single
+  ally/all allies) always raises resistance, an enemy-scoped one
+  (single/all enemies) always lowers it, regardless of
+  `reverse_state_effect`. Attribute ranks must be configured strictly
+  `A>B>C>D>E` for the ±1-step logic to make sense. Covered by two
+  `scripts/rpg2k_logic_check.rb` checks (direction is scope-driven with
+  `reverse_state_effect` proven inert on every combination; the existing
+  shift-and-cap mechanic check reworked around scope-based skills — an
+  enemy-scoped Curse Fire shifting down, an ally-scoped Ward Fire shifting
+  back up, both capped at one step from base), both confirmed to fail
+  against the pre-fix code before the fix.
 - Enemy group members are numbered by add-order. ✅ **The lower-numbered
   member renders in front (closer to camera)**: `Scene::Map#build_battle_sprites`
   / `#rebuild_battler_sprite` / `#reveal_battle_monster`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3436,21 +3436,32 @@ module Game
     end
 
     # Whether skill `sk` is flagged "attribute defence up/down" (`affect_attr_
-    # defence`, field 45) and, if so, which direction: -1 (up, a rank toward A
-    # / better resistance) or +1 (down, a rank toward E / worse). yado.tk's
-    # note on the feature ("shifts the target's elemental rank by exactly one
-    # step, capped at +-1 from the character's base rank, resets automatically
-    # at battle end") says what it does but not which flag chooses the
-    # direction; this reuses `reverse_state_effect` (field 20) on the
-    # assumption RPG2000's skill editor drives its one "raise/lower" toggle
-    # for both the state-effect list and the attribute-defence list, the same
-    # way it already does for state infliction vs cure (see
-    # #skill_cured_states) -- not confirmed against real RPG_RT or either test
-    # bed, since neither ships a skill with the flag set. nil when the skill
-    # does not touch attribute defence at all.
+    # defence`, field 45) and, if so, which direction: +1 (the rank index
+    # moves toward E, a *smaller* attr_rate% -- better resistance, less
+    # damage taken from that attribute later) or -1 (toward A, a *larger*
+    # attr_rate% -- worse resistance, more damage taken; see #attr_rate's own
+    # 300/200/100/50/0 table, where a lower-lettered rank means a bigger
+    # multiplier). This used to reuse `reverse_state_effect` (field 20) as an
+    # unconfirmed guess; EasyRPG Player's actual C++ source settles it
+    # instead: `Game_BattleAlgorithm::Skill::vExecute` (src/
+    # game_battlealgorithm.cpp) computes `auto shift = IsPositive() ? 1 : -1;`
+    # right where it applies `affect_attr_defence`, and `IsPositive()` was set
+    # a few lines earlier from `Algo::SkillTargetsAllies(skill)` (src/algo.h),
+    # which is simply `!SkillTargetsEnemies(skill)` -- true for every scope
+    # except Scope_enemy(0)/Scope_enemies(1). `reverse_state_effect` plays no
+    # part in this at all (that flag's own state-cure/inflict role is,
+    # per the same function, `IsPositive() ^ (Player::IsRPG2k3() &&
+    # skill.reverse_state_effect)` -- gated behind an RPG2003 check this
+    # runtime does not model either way, a separate, wider question left
+    # untouched here). So the direction is purely the skill's own target
+    # scope: an ally-scoped skill (self/single ally/all allies, the "buff"
+    # shape) always raises resistance, an enemy-scoped one (single/all
+    # enemies, the "curse" shape) always lowers it -- matching
+    # #battle_skill_target's own enemy-scope test (`scope == 0 || scope ==
+    # 1`). nil when the skill does not touch attribute defence at all.
     def skill_attr_shift(sk)
       return nil unless sk.respond_to?(:affect_attr_defence) && sk.affect_attr_defence
-      sk.respond_to?(:reverse_state_effect) && sk.reverse_state_effect ? 1 : -1
+      sk.scope == 0 || sk.scope == 1 ? -1 : 1
     end
 
     # The command numbers for casting `sk` from `caster` on `target` (both

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2484,7 +2484,9 @@ FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost
                        :ignore_defense,
                        # 属性有効度変化 (attribute defence up/down, field 45):
                        # shifts the target's rank for each attribute_effects id
-                       # by one step, direction shared with reverse_state_effect.
+                       # by one step; direction is the skill's own scope
+                       # (ally-scoped raises resistance, enemy-scoped lowers
+                       # it) -- see Game::Party#skill_attr_shift.
                        :affect_attr_defence)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
@@ -7559,17 +7561,54 @@ check 'battle_skill_command respects a stat-doubling state on the target' do
      'doubled spirit (40): 20 base - 40*40/80 (20) = 0, floored to 1')
 end
 
-check 'a skill flagged "attribute defence up/down" shifts the target rank, ' \
-      'capped at +-1 from base' do
-  # scope 3 (single, non-attack) so this exercises the shift without also
-  # tripping battle_skill_command's separate "scope 0/1 always deals at
-  # least 1 damage" behaviour -- a different, pre-existing question.
-  down = fake_skill(name: 'Weaken Fire', scope: 3, sp_cost: 0, power: 0,
-                    attribute_effects: [1], affect_attr_defence: true,
-                    reverse_state: true) # down: toward a worse (higher) rank
+check 'a skill flagged "attribute defence up/down" picks direction from ' \
+      'the skill\'s own scope, not reverse_state_effect' do
+  # Ported from EasyRPG's Game_BattleAlgorithm::Skill::vExecute: `auto shift
+  # = IsPositive() ? 1 : -1;`, where IsPositive() comes from
+  # Algo::SkillTargetsAllies(skill) -- purely the skill's own `scope` field.
+  # reverse_state_effect never enters into it, unlike this codebase's old,
+  # explicitly-unconfirmed guess that it did. Every scope/reverse_state_effect
+  # combination below targets the same `foe`, proving the flag is inert here:
+  # only scope decides.
+  ally_single = fake_skill(name: 'Ward Fire (ally)', scope: 3, sp_cost: 0, power: 0,
+                            attribute_effects: [1], affect_attr_defence: true,
+                            reverse_state: false)
+  ally_all_reversed = fake_skill(name: 'Ward Fire (all allies, reverse flag set)',
+                                  scope: 4, sp_cost: 0, power: 0,
+                                  attribute_effects: [1], affect_attr_defence: true,
+                                  reverse_state: true) # still ally-scoped -> still up
+  enemy_single = fake_skill(name: 'Curse Fire (enemy)', scope: 0, sp_cost: 0, power: 0,
+                             attribute_effects: [1], affect_attr_defence: true,
+                             reverse_state: false)
+  enemy_all_reversed = fake_skill(name: 'Curse Fire (all enemies, reverse flag set)',
+                                   scope: 1, sp_cost: 0, power: 0,
+                                   attribute_effects: [1], affect_attr_defence: true,
+                                   reverse_state: true) # still enemy-scoped -> still down
+  skills = { 7 => ally_single, 8 => ally_all_reversed,
+             9 => enemy_single, 10 => enemy_all_reversed }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+
+  eq 1, st.party.battle_skill_command(st.party.db_skill(7), caster, foe)[:attr_shift],
+     'ally scope (single ally) -> +1 (up/better) regardless of reverse_state_effect'
+  eq 1, st.party.battle_skill_command(st.party.db_skill(8), caster, foe)[:attr_shift],
+     'ally scope (all allies), reverse_state_effect ON -> still +1, the flag is irrelevant'
+  eq(-1, st.party.battle_skill_command(st.party.db_skill(9), caster, foe)[:attr_shift],
+     'enemy scope (single enemy) -> -1 (down/worse) regardless of reverse_state_effect')
+  eq(-1, st.party.battle_skill_command(st.party.db_skill(10), caster, foe)[:attr_shift],
+     'enemy scope (all enemies), reverse_state_effect ON -> still -1, the flag is irrelevant')
+end
+
+check 'attribute defence shift applies to the target rank, capped at ' \
+      '+-1 from base' do
+  # scope 3/0 (single ally / single enemy) so this also exercises
+  # battle_skill_command's separate "scope 0/1 always deals at least 1
+  # damage" behaviour alongside the shift, unaffected by it.
+  down = fake_skill(name: 'Curse Fire', scope: 0, sp_cost: 0, power: 0,
+                    attribute_effects: [1], affect_attr_defence: true)
   up = fake_skill(name: 'Ward Fire', scope: 3, sp_cost: 0, power: 0,
-                  attribute_effects: [1], affect_attr_defence: true,
-                  reverse_state: false) # up: toward a better (lower) rank
+                  attribute_effects: [1], affect_attr_defence: true)
   skills = { 7 => down, 8 => up }
   st = skill_party(skills)
   caster = Game::Battle.from_actor(st.party.actor_by_id(1))
@@ -7579,32 +7618,33 @@ check 'a skill flagged "attribute defence up/down" shifts the target rank, ' \
   bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
 
   c = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
-  eq 1, c[:attr_shift], 'reverse_state_effect set -> down (worse)'
+  eq(-1, c[:attr_shift], 'enemy-scoped Curse Fire -> down (worse)')
   eq [1], c[:attr_ids]
-  bat.command_skill(caster, foe, name: 'Weaken Fire', cost: c[:cost],
+  bat.command_skill(caster, foe, name: 'Curse Fire', cost: c[:cost],
                     hp: c[:hp], mp: c[:mp], attr_shift: c[:attr_shift],
                     attr_ids: c[:attr_ids])
   bat.run_round
-  eq 3, foe.attr_ranks[1], 'shifted one step down (C -> D)'
+  eq 1, foe.attr_ranks[1], 'shifted one step down (C -> B)'
 
   # A second cast does not stack past the +-1 cap from the base rank (2).
-  bat.command_skill(caster, foe, name: 'Weaken Fire', cost: c[:cost],
+  bat.command_skill(caster, foe, name: 'Curse Fire', cost: c[:cost],
                     hp: c[:hp], mp: c[:mp], attr_shift: c[:attr_shift],
                     attr_ids: c[:attr_ids])
   bat.run_round
-  eq 3, foe.attr_ranks[1], 'capped at one step from base, does not keep sliding'
+  eq 1, foe.attr_ranks[1], 'capped at one step from base, does not keep sliding'
 
-  # The opposite skill shifts it back the other way, past base and up to its
-  # own +-1 (better) cap -- three casts, still capped at one step from base.
+  # The opposite (ally-scoped) skill shifts it back the other way, past base
+  # and up to its own +-1 (better) cap -- three casts, still capped at one
+  # step from base.
   c2 = st.party.battle_skill_command(st.party.db_skill(8), caster, foe)
-  eq(-1, c2[:attr_shift], 'reverse_state_effect unset -> up (better)')
+  eq 1, c2[:attr_shift], 'ally-scoped Ward Fire -> up (better)'
   3.times do
     bat.command_skill(caster, foe, name: 'Ward Fire', cost: c2[:cost],
                       hp: c2[:hp], mp: c2[:mp], attr_shift: c2[:attr_shift],
                       attr_ids: c2[:attr_ids])
     bat.run_round
   end
-  eq 1, foe.attr_ranks[1], 'capped one step better than base (C -> B)'
+  eq 3, foe.attr_ranks[1], 'capped one step better than base (C -> D)'
 end
 
 check 'a battle attack skill inflicts its state_effects on a surviving enemy' do


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "attribute defence up/down" flag (`affect_attr_defence`, field 45) entry flagged its direction logic as an unconfirmed guess — no test game ships a skill with the flag set. `Game::Party#skill_attr_shift` derived the raise/lower direction from `reverse_state_effect`, assuming RPG2000's editor shares one "raise/lower" toggle between state effects and attribute-defence shifting.
- Verified against EasyRPG Player's actual source (`src/game_battlealgorithm.cpp`, `src/algo.h`): `Game_BattleAlgorithm::Skill::vExecute` computes `auto shift = IsPositive() ? 1 : -1;` where `IsPositive()` is `Algo::SkillTargetsAllies(skill)` — purely the skill's own `scope` field (ally-scoped = true, enemy-scoped = false). `reverse_state_effect` is never consulted for this; it's a separate RPG2003-only mechanism (state cure/inflict) in the same function.
- `Game::Party#skill_attr_shift` now returns `sk.scope == 0 || sk.scope == 1 ? -1 : 1` (mirroring `#battle_skill_target`'s own enemy-scope test) instead of reading `reverse_state_effect`.
- `docs/TODO.md` updated ✅ with the citation and corrected polarity explanation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 719 checks pass (new checks prove direction is scope-driven and `reverse_state_effect` is inert on both ally- and enemy-scoped skills, plus a reworked shift-and-cap mechanic check around scope-based skills — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 406 checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_