### PR TITLE
Remove unused cmdline submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,6 @@
 [submodule "third_party/mruby"]
 	path = 3rd/mruby
 	url = https://github.com/mruby/mruby.git
-[submodule "third_party/cmdline"]
-	path = 3rd/cmdline
-	url = https://github.com/tanakh/cmdline.git
 [submodule "third_party/lvgl"]
 	path = 3rd/lvgl
 	url = https://github.com/lvgl/lvgl.git

--- a/changelog.d/remove-cmdline-submodule.removed.md
+++ b/changelog.d/remove-cmdline-submodule.removed.md
@@ -1,0 +1,3 @@
+- Dropped the unused `3rd/cmdline` submodule (tanakh/cmdline). Nothing in the
+  source tree or build files ever included it — `src/main.cxx`'s command-line
+  parsing has always gone through `gflags` (`3rd/gflags`) instead.


### PR DESCRIPTION
## Summary
Removed the unused `3rd/cmdline` submodule that was never integrated into the codebase. Command-line argument parsing has always been handled by `gflags` instead.

## Changes
- Removed `third_party/cmdline` submodule entry from `.gitmodules`
- Deleted the `3rd/cmdline` submodule directory
- Added changelog entry documenting the removal

## Details
The `cmdline` submodule (tanakh/cmdline) was present in the repository but never actually used. The codebase's command-line parsing in `src/main.cxx` has always relied on `gflags` (`3rd/gflags`), making this submodule redundant. This cleanup removes the unused dependency to reduce repository clutter and maintenance overhead.

https://claude.ai/code/session_01BasrmJ9EGL4B6bLcnwxdYc