### PR TITLE
rpg2k: skills can now raise/lower a target's ATK/DEF/SPI/AGI via a per-battle modifier

### DIFF
--- a/changelog.d/skill-ability-value-modifier.added.md
+++ b/changelog.d/skill-ability-value-modifier.added.md
@@ -1,0 +1,35 @@
+- **A skill flagged to raise or lower ATK/DEF/SPI/AGI (schema fields 33-36,
+  `affect_attack`/`affect_defense`/`affect_spirit`/`affect_agility`) now
+  actually does so**, instead of being parsed and read nowhere. Ported from
+  EasyRPG Player's actual C++ source (`src/game_battlealgorithm.cpp`'s
+  `Game_BattleAlgorithm::Skill::vExecute`, `src/game_battler.cpp`'s
+  `Game_Battler::CanChangeAtkModifier` and its DEF/SPI/AGI siblings): each
+  flag applies the skill's own signed effect — the identical
+  post-attribute-scaling, post-variance, post-cap number `affect_hp`/
+  `affect_sp` already use for the same hit — to a per-battle modifier,
+  clamped to `-(base/2)..+base` (`base` the battler's own raw stat) and reset
+  to 0 every fresh fight for free, since a `Game::Battle::Combatant` (which
+  now carries new `atk_mod`/`def_mod`/`spi_mod`/`agi_mod` fields) is built
+  once per fight and never written back to the actor — the same pattern the
+  attribute-defence-shift feature already established for `attr_ranks`.
+  `Game::Party#skill_stat_mod_keys` reads the four flags; `battle_skill_command`
+  threads them (plus, for a buff-only skill with `affect_hp` clear, the raw
+  effect a `hp: 0` command still needs) through to `Game::Battle#
+  apply_stat_mods`, which clamps and applies the delta from `apply_skill_hit`
+  on both the attack and heal/buff branches. `effective_atk`/`effective_def`/
+  `effective_spi`/`effective_agi` now read the modifier — clamped to a new
+  `MAX_STAT_BATTLE_VALUE = 9999` — *before* a state's own halve/double is
+  applied on top, matching EasyRPG's own `AdjustParam` ordering. The clamp's
+  lower bound is deliberately `-(base / 2)` (dividing the positive `base`
+  first, then negating) rather than the more natural-looking `-base / 2`:
+  EasyRPG's C++ expression truncates toward zero (base 5 → -2), while Ruby's
+  own `/` on a negated numerator floors toward -infinity instead (`-5 / 2`
+  = -3) — reproducing this asymmetry between "a special skill's ability-value
+  decrease rounds up on ÷2" and "a status effect's own halving rounds down"
+  was the whole point of the fix. Wired into the actual battle-menu UI path
+  (`Scene::Map#apply_pending_skill`/`#apply_pending_skill_all`); an enemy AI's
+  own skill cast is left unwired, matching the attribute-defence-shift
+  feature's own scope (`Game::Battle#skill_command_hash` never carried
+  `attr_shift`/`attr_ids` either). Covered by five new
+  `scripts/rpg2k_logic_check.rb` checks, four confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4634,10 +4634,70 @@ codebase yet):
   and can un-clamp back into view after a later change** (e.g. lower Attack
   by more than the display can show, then raise it partway back — the
   displayed value stays pinned at its old clamp until the raise actually
-  pushes the real total back above it) — now fixed, see below; a special
-  skill's ability-value *decrease* rounds up on ÷2, a status effect's own
-  halving rounds *down*; dual-wielding's off-hand attack animation is
-  offset by a few frames from the main hand's. **Change Parameters' hidden
+  pushes the real total back above it) — now fixed, see below; ✅ **a special
+  skill's ability-value change is now modelled at all.** RPG2000's skill
+  `affect_attack`/`affect_defense`/`affect_spirit`/`affect_agility` flags
+  (LCF skill schema fields 33-36, `mruby-lcf/mrblib/schema.rb`) were parsed
+  but read nowhere in `mruby-rpg2k`, so a "raise/lower ATK/DEF/SPI/AGI" skill
+  (a buff like Focus or a debuff like Weaken) silently did nothing beyond
+  whatever incidental `affect_hp`/`affect_sp` damage/heal it also carried —
+  `Game::Battle`'s own `stat_mode`/`adjust_stat` (the state halve/double
+  code, ported from EasyRPG's `Game_Battler::AdjustParam`) even said so in
+  its own comment ("minus its `mod` term: that is a battle-only ATK/DEF/
+  SPI/AGI offset this runtime has no equivalent of"). Confirmed against
+  EasyRPG Player's actual C++ source (`src/game_battlealgorithm.cpp`'s
+  `Game_BattleAlgorithm::Skill::vExecute`, `src/game_battler.cpp`'s
+  `Game_Battler::CanChangeAtkModifier`/`ChangeAtkModifier` and its DEF/SPI/
+  AGI siblings): each flag rolls independently against the skill's own
+  `effect` — the identical signed, post-attribute-scaling, post-variance,
+  post-`MaxDamageValue`-cap number `affect_hp`/`affect_sp` already use for
+  the same hit — and adds it to a per-battle `atk_modifier`/`def_modifier`/
+  `spi_modifier`/`agi_modifier`, clamped to `-(base/2)..+base` (`base` the
+  battler's own raw stat), reset to 0 every fresh fight (`ResetBattle`).
+  `Game::Battle::Combatant` (`mruby-rpg2k/mrblib/game.rb`) now carries
+  `atk_mod`/`def_mod`/`spi_mod`/`agi_mod` fields — needing no explicit
+  reset, since (like the sibling `attr_ranks`/`attr_base_ranks` fields for
+  attribute-defence shifting) a fresh `Combatant` is built once per fight
+  and never written back to the actor. `Game::Party#skill_stat_mod_keys`
+  reads the four skill flags; `battle_skill_command` threads the keys plus
+  — for a buff-only skill with `affect_hp` clear — the raw, un-gated effect
+  through `cmd[:stat_mod_keys]`/`cmd[:stat_effect]`; `Game::Battle#
+  apply_stat_mods` (mirroring `CanChangeAtkModifier`) clamps and applies the
+  delta from `apply_skill_hit`, on both the attack and heal/buff branches,
+  matching how `apply_attr_shift` already rides both; `#command_skill`/
+  `#command_skill_all` and the two `Scene::Map#apply_pending_skill(_all)`
+  call sites (`mruby-rpg2k/mrblib/scene/map.rb`) thread the two new fields
+  through the actual battle-menu UI path the same way `attr_shift`/
+  `attr_ids` already do (enemy AI casts are left unwired, matching that same
+  attribute-shift fix's own scope: `Game::Battle#skill_command_hash` never
+  carried `attr_shift`/`attr_ids` either). `Game::Battle#effective_atk`/
+  `#effective_def`/`#effective_spi`/`#effective_agi` now read `Combatant#
+  atk_mod` and friends, clamped to a new `MAX_STAT_BATTLE_VALUE = 9999`
+  (EasyRPG's `MaxStatBattleValue`) *before* a state's own halve/double is
+  applied on top — matching `AdjustParam`'s own ordering. **The
+  rounding-direction half of this same claim is confirmed correct too, and
+  is the reason the clamp's lower bound is written `-(base / 2)` rather than
+  the more natural-looking `-base / 2`**: EasyRPG's C++ `-base / 2`
+  truncates toward zero (rounds *up*/less-negative for the floor — base 5 →
+  -2, not -3), while Ruby's own `/` on a *negated* numerator floors toward
+  -infinity instead (`-5 / 2` = -3 in Ruby) — dividing the positive `base`
+  first and negating only the quotient reproduces C++'s truncation exactly,
+  contrasted with a status effect's own halving (`adjust_stat`'s
+  `value / 2`, always on a positive stat value, where "toward zero" and
+  "floor" already coincide, so no similar care is needed there). Covered by
+  five new `scripts/rpg2k_logic_check.rb` checks: `skill_stat_mod_keys`
+  reading the four flags; an enemy-scoped Weaken skill lowering a target's
+  ATK modifier across repeat casts, capping at `-(base/2)` and no further; the
+  odd-base rounding case specifically (base 5 clamps at -2, not a floor's
+  -3); a buff-only (`affect_hp` clear) skill still raising a target's DEF
+  modifier, capped at `+base` (a full double); and `effective_atk` clamping
+  base+modifier before a halving state is applied on top — the first four
+  confirmed to fail against the pre-fix code (a `NoMethodError` / a `nil`
+  result, since neither the reader method nor the `Combatant` fields
+  existed), the last a pure ordering pin. Dual-wielding's off-hand attack
+  animation is offset by a few frames from the main hand's remains
+  unverified, a presentation-only question outside this fix's scope.
+  **Change Parameters' hidden
   unclamped total is now tracked.** `Game::Actor#change_param`
   (`mruby-rpg2k/mrblib/game.rb`) clamped and overwrote `@base[type]` on
   every call, permanently discarding how far past the 1..999 (1..9999 for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3464,6 +3464,35 @@ module Game
       sk.scope == 0 || sk.scope == 1 ? -1 : 1
     end
 
+    # The (skill field name -> Combatant ability-value key) pairs
+    # #skill_stat_mod_keys checks; distinct from `affect_attr_defence`
+    # (#skill_attr_shift), which shifts a resistance *rank* rather than a raw
+    # ATK/DEF/SPI/AGI value. EasyRPG's `Game_BattleAlgorithm::Skill::vExecute`
+    # rolls each of `affect_attack`/`affect_defense`/`affect_spirit`/
+    # `affect_agility` independently, alongside `affect_hp`/`affect_sp`, all
+    # against the *same* signed effect value -- this runtime already applies
+    # `affect_hp`/`affect_sp` unconditionally (no roll; see the field-cast
+    # `#skill_state_ids` comment on `hit` being state-infliction-only), so
+    # these four follow suit for consistency, rather than introducing a
+    # per-stat accuracy roll nothing else in this class models.
+    SKILL_STAT_MOD_FLAGS = { atk: :affect_attack, def: :affect_defense,
+                              spi: :affect_spirit, agi: :affect_agility }.freeze
+
+    # Which of `{atk:, def:, spi:, agi:}` skill `sk` touches, per its own
+    # affect_attack/affect_defense/affect_spirit/affect_agility flags (schema
+    # fields 33-36). `[]` when the skill touches none of the four. The actual
+    # signed magnitude is not decided here: `Game::Battle#apply_skill_hit`
+    # feeds whichever of these keys are present the exact same final signed
+    # effect number (post elemental-attribute scaling, variance, and the
+    # damage/recovery cap) it applies to HP/SP for the same hit, matching
+    # EasyRPG reading one shared `effect` local for every one of hp/sp/atk/
+    # def/spi/agi rather than a separately-computed figure per stat. Applied
+    # through `Game::Battle#apply_stat_mods`, which clamps the delta against
+    # the target's own cap before it lands.
+    def skill_stat_mod_keys(sk)
+      SKILL_STAT_MOD_FLAGS.keys.select { |key| sk.respond_to?(SKILL_STAT_MOD_FLAGS[key]) && sk.send(SKILL_STAT_MOD_FLAGS[key]) }
+    end
+
     # The command numbers for casting `sk` from `caster` on `target` (both
     # Combatant snapshots): the caster's SP `cost`, and the signed HP / SP deltas
     # to the target — negative HP for an attack skill (base effect less a quarter
@@ -3481,6 +3510,7 @@ module Game
       # branches below rather than only the attack one.
       shift = skill_attr_shift(sk)
       shift_ids = shift ? skill_attributes(sk) : []
+      stat_keys = skill_stat_mod_keys(sk)
       if sk.scope == 0 || sk.scope == 1 # single or all enemies: an attack skill
         dmg = base - skill_defence_term(sk, target)
         dmg = 1 if dmg < 1
@@ -3491,10 +3521,18 @@ module Game
           # only on an *offensive* skill (EasyRPG's `skill.absorb_damage &&
           # !IsPositive()`), so it rides only on this branch: a healing skill
           # that sets it drains nothing.
-          absorb: skill_absorbs?(sk), attr_shift: shift, attr_ids: shift_ids }
+          absorb: skill_absorbs?(sk), attr_shift: shift, attr_ids: shift_ids,
+          stat_mod_keys: stat_keys }
       else
         { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0,
-          variance: skill_variance(sk), attr_shift: shift, attr_ids: shift_ids }
+          variance: skill_variance(sk), attr_shift: shift, attr_ids: shift_ids,
+          stat_mod_keys: stat_keys,
+          # The raw, un-gated effect a buff-only skill (affect_hp clear,
+          # affect_attack/defense/spirit/agility set) still needs: `hp` above
+          # is 0 for such a skill, but the ATK/DEF/SPI/AGI modifier applies
+          # regardless, off the same `base` EasyRPG's one shared `effect`
+          # local would carry into every affect_* branch alike.
+          stat_effect: base }
       end
     end
 
@@ -6030,7 +6068,19 @@ module Game
                            # one) and #apply_to_party never writes it back to
                            # the actor, a shift is battle-scoped for free: it
                            # dies with the Combatant, no separate reset needed.
-                           :attr_base_ranks) do
+                           :attr_base_ranks,
+                           # Per-battle ATK/DEF/SPI/AGI offsets a skill's own
+                           # affect_attack/affect_defense/affect_spirit/
+                           # affect_agility flags accumulate onto (see
+                           # Battle#apply_stat_mods) -- EasyRPG's
+                           # Game_Battler::atk_modifier and friends, reset to 0
+                           # by ResetBattle at battle start there. This class
+                           # needs no equivalent reset: exactly like
+                           # #attr_ranks above, a fresh Combatant is built once
+                           # per fight and never written back to the actor, so
+                           # nil (read as 0 by #effective_atk and friends)
+                           # every construction is the reset for free.
+                           :atk_mod, :def_mod, :spi_mod, :agi_mod) do
       def dead?; hp <= 0; end
 
       # Swings per basic attack: 2 with a 二刀流 weapon, 1 otherwise. Struct
@@ -6540,9 +6590,12 @@ module Game
     # the schema's own default) alongside four independent flags naming which
     # stat(s) it touches (`affect_attack` / `affect_defense` / `affect_spirit`
     # / `affect_agility`). Ported from EasyRPG's `Game_Battler::AdjustParam`,
-    # minus its `mod` term: that is a battle-only ATK/DEF/SPI/AGI offset this
-    # runtime has no equivalent of (the closest thing, an attribute-defence
-    # shift skill, moves #attr_ranks instead of a raw stat).
+    # **now including its `mod` term too** (`Combatant#atk_mod` and friends,
+    # the battle-only ATK/DEF/SPI/AGI offset a *skill's* own same-named
+    # affect_attack/affect_defense/affect_spirit/affect_agility flags
+    # accumulate onto -- see #apply_stat_mods -- distinct from an
+    # attribute-defence shift skill, which moves #attr_ranks instead of a raw
+    # stat).
     #
     # #deal_attack / #enemy_autodestruct (basic-attack and self-destruct
     # damage), #to_hit / #avg_agi (accuracy and escape chance) and #turn_order
@@ -6551,7 +6604,9 @@ module Game
     # through its own copy of this same logic (`Game::Party#stat_mode` and
     # friends) rather than this one, since a skill's caster/target is
     # sometimes a bare `Game::Actor` with no `Battle` -- and no `@states` --
-    # behind it at all (field/menu skill use).
+    # behind it at all (field/menu skill use); that copy has no `mod` term
+    # either, since a bare `Game::Actor` has no `Combatant#atk_mod` to read --
+    # matching #skill_attr_shift's own battle-only scope.
 
     # :half, :double or :normal for `stat_flag` (:affect_attack and friends)
     # on `b` right now. A battler carrying both a halving and a doubling state
@@ -6583,10 +6638,76 @@ module Game
       end
     end
 
-    def effective_atk(b); adjust_stat(b.atk, stat_mode(b, :affect_attack)); end
-    def effective_def(b); adjust_stat(b.def, stat_mode(b, :affect_defense)); end
-    def effective_spi(b); adjust_stat(b.spi, stat_mode(b, :affect_spirit)); end
-    def effective_agi(b); adjust_stat(b.agi, stat_mode(b, :affect_agility)); end
+    # RPG_RT's own ceiling on a *modified* ATK/DEF/SPI/AGI (EasyRPG's
+    # `MaxStatBattleValue`, 9999 by default) -- looser than the 1..999 a raw
+    # base stat is clamped to (`Actor#change_param`'s own cap), so a stacked
+    # buff has room to climb well past what the base stat alone could reach.
+    MAX_STAT_BATTLE_VALUE = 9999
+
+    # `b`'s base stat plus its own #atk_mod/#def_mod/#spi_mod/#agi_mod offset
+    # (see #apply_stat_mods), clamped to 1..#MAX_STAT_BATTLE_VALUE the same
+    # way EasyRPG's `AdjustParam(base, mod, ...)` does before states get a say.
+    def modified_stat(base, mod)
+      Game.clamp(base + (mod || 0), 1, MAX_STAT_BATTLE_VALUE)
+    end
+
+    def effective_atk(b)
+      adjust_stat(modified_stat(b.atk, b.atk_mod), stat_mode(b, :affect_attack))
+    end
+
+    def effective_def(b)
+      adjust_stat(modified_stat(b.def, b.def_mod), stat_mode(b, :affect_defense))
+    end
+
+    def effective_spi(b)
+      adjust_stat(modified_stat(b.spi, b.spi_mod), stat_mode(b, :affect_spirit))
+    end
+
+    def effective_agi(b)
+      adjust_stat(modified_stat(b.agi, b.agi_mod), stat_mode(b, :affect_agility))
+    end
+
+    # The Combatant field (Combatant#atk_mod and friends) each ability-value
+    # key names.
+    STAT_MOD_FIELD = { atk: :atk_mod, def: :def_mod, spi: :spi_mod, agi: :agi_mod }.freeze
+
+    # Apply `amount` -- the exact same final signed effect a skill hit just
+    # applied to HP/SP (post elemental-attribute scaling, variance, and the
+    # damage/recovery cap; see the call sites in #apply_skill_hit) -- to
+    # `target`'s per-battle ATK/DEF/SPI/AGI modifier, for each key in `keys`
+    # (`cmd[:stat_mod_keys]`, see Game::Party#skill_stat_mod_keys). Ported
+    # from EasyRPG's `Game_Battler::CanChangeAtkModifier` and its DEF/SPI/AGI
+    # siblings: the *running total* (existing modifier + this delta) is
+    # clamped to -(base/2)..+base, where `base` is the target's own raw,
+    # unmodified stat -- an asymmetric band that lets a buff double a stat but
+    # never lets a debuff zero it out entirely. `-(base / 2)` deliberately
+    # divides the positive `base` *before* negating, matching C++'s own
+    # truncating `-base / 2` (which rounds toward zero, i.e. **up**, for the
+    # negative result) rather than Ruby's `-base / 2`, which would floor
+    # toward -infinity instead and round the floor *down* one further for an
+    # odd base -- the viprpg-dev wiki's "a special skill's ability-value
+    # decrease rounds up on ÷2" (contrasted there with a status effect's own
+    # halving, #adjust_stat's `value / 2`, which rounds down -- both stats
+    # being positive there, "toward zero" and "down" coincide, so no similar
+    # care is needed in that method). Returns the `{atk:, def:, spi:, agi:}`
+    # deltas actually applied -- possibly smaller than `amount` once clamped,
+    # or absent for a stat already pinned at its cap -- for the log entry.
+    def apply_stat_mods(target, keys, amount)
+      return {} unless keys && !keys.empty? && amount != 0
+      applied = {}
+      keys.each do |key|
+        field = STAT_MOD_FIELD[key]
+        next unless field
+        base = target.respond_to?(key) ? (target.send(key) || 0) : 0
+        cur = target.send(field) || 0
+        new_mod = Game.clamp(cur + amount, -(base / 2), base)
+        d = new_mod - cur
+        next if d == 0
+        target.send("#{field}=", new_mod)
+        applied[key] = d
+      end
+      applied
+    end
 
     # Queue a single-target Skill for `ally`: cast on `target` (an enemy for an
     # attack skill, an ally / the caster for a recovery skill), spending `cost`
@@ -6595,13 +6716,15 @@ module Game
     # order by #apply_command when the round runs.
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
                       chance: 100, variance: 0, attributes: nil, skill_id: nil,
-                      absorb: false, attr_shift: nil, attr_ids: nil)
+                      absorb: false, attr_shift: nil, attr_ids: nil,
+                      stat_mod_keys: nil, stat_effect: 0)
       ally.command = { kind: :skill, target: target, name: name,
                        skill_id: skill_id, absorb: absorb,
                        cost: cost, hp: hp, mp: mp,
                        inflict: inflict || [], chance: chance, variance: variance,
                        attributes: attributes || [],
-                       attr_shift: attr_shift, attr_ids: attr_ids || [] }
+                       attr_shift: attr_shift, attr_ids: attr_ids || [],
+                       stat_mod_keys: stat_mod_keys || [], stat_effect: stat_effect }
       ally.action = nil; ally.defending = false
     end
 
@@ -6617,11 +6740,13 @@ module Game
     # #step_action.
     def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
                           variance: 0, attributes: nil, skill_id: nil,
-                          absorb: false, attr_shift: nil, attr_ids: nil)
+                          absorb: false, attr_shift: nil, attr_ids: nil,
+                          stat_mod_keys: nil, stat_effect: 0)
       ally.command = { kind: :skill, all: true, targets: targets, name: name,
                        skill_id: skill_id, absorb: absorb, cost: cost, inflict: inflict || [], chance: chance,
                        variance: variance, attributes: attributes || [],
-                       attr_shift: attr_shift, attr_ids: attr_ids || [] }
+                       attr_shift: attr_shift, attr_ids: attr_ids || [],
+                       stat_mod_keys: stat_mod_keys || [], stat_effect: stat_effect }
       ally.action = nil; ally.defending = false
     end
 
@@ -7501,6 +7626,13 @@ module Game
         # Same 999 hard-cap as a normal attack (#deal_attack), applied before
         # absorption so a drain skill can't smuggle a bigger hit past it either.
         dmg = DAMAGE_CAP if dmg > DAMAGE_CAP
+        # The ATK/DEF/SPI/AGI modifier delta (see #apply_stat_mods) shares
+        # this same post-attribute-scaling, post-variance, post-cap figure --
+        # captured here, before 吸収 trims `dmg` further below, since EasyRPG
+        # reads its one shared `effect` local for every one of hp/atk/def/spi/
+        # agi and has no stat-absorbing counterpart to HP's own (vanilla
+        # RPG2000/2003 never sets `easyrpg_enable_stat_absorbing`).
+        stat_amount = -dmg
         # 吸収: the caster takes what the target loses, and can take no more than
         # the target has. EasyRPG clamps the effect to the target's current HP
         # *before* applying it ("Only absorb the hp that were left"), so a
@@ -7518,13 +7650,16 @@ module Game
         # it lived through the damage.
         if target.dead?
           inflicted = already = shifted = []
+          stat_changed = {}
         else
           inflicted, already = roll_inflict(target, cmd)
           shifted = apply_attr_shift(target, cmd)
+          stat_changed = apply_stat_mods(target, cmd[:stat_mod_keys], stat_amount)
         end
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
           inflicted: inflicted, already: already, attr_shifted: shifted,
+          stat_changed: stat_changed,
           target_ally: ally?(target), skill: cmd[:name],
           skill_id: cmd[:skill_id], target_index: @enemies.index(target),
           absorbed_hp: absorbed }
@@ -7541,13 +7676,21 @@ module Game
         # no-op there; a 0 (or absent) `hp`/`mp` clears #varied's own `base >
         # 0` guard, so a skill that only restores one of the two leaves the
         # other alone.
+        # The ATK/DEF/SPI/AGI modifier delta rides the identical variance roll
+        # as HP/SP (see the comment above), off `cmd[:stat_effect]` rather
+        # than `hp` itself: a buff-only skill (affect_hp clear) leaves `hp` at
+        # 0 throughout, but the modifier still applies off the skill's own
+        # base effect.
+        stat_amount = cmd[:stat_effect] || 0
         if @variance && cmd[:variance] && cmd[:variance] > 0
           hp = varied(hp, cmd[:variance])
           mp = varied(mp, cmd[:variance])
+          stat_amount = varied(stat_amount, cmd[:variance])
         end
         before_hp = target.hp
         before_mp = target.mp || 0
         hp = RECOVER_CAP if hp > RECOVER_CAP
+        stat_amount = RECOVER_CAP if stat_amount > RECOVER_CAP
         target.hp = [target.hp + hp, target.max_hp].min if hp > 0
         target.mp = [before_mp + mp, target.max_mp].min if mp > 0 && target.max_mp
         # Cure the item's status conditions from the target (an antidote / herb),
@@ -7555,11 +7698,13 @@ module Game
         cured = (cmd[:cured] || []).select { |s| target.state?(s) }
         target.states = (target.states || []) - cured unless cured.empty?
         shifted = target.dead? ? [] : apply_attr_shift(target, cmd)
+        stat_changed = target.dead? ? {} : apply_stat_mods(target, cmd[:stat_mod_keys], stat_amount)
         { recover: true, actor: b.name, source: cmd[:name],
           item_id: cmd[:item_id], skill_id: cmd[:skill_id], target: target.name,
           target_index: @enemies.index(target),
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
           cured: cured, target_ally: ally?(target), attr_shifted: shifted,
+          stat_changed: stat_changed,
           target_hp: target.hp, target_mp: target.mp }
       end
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3889,7 +3889,9 @@ class RPG2k
                                           variance: c[:variance] || 0,
                                           attributes: c[:attributes],
                                           attr_shift: c[:attr_shift],
-                                          attr_ids: c[:attr_ids])
+                                          attr_ids: c[:attr_ids],
+                                          stat_mod_keys: c[:stat_mod_keys],
+                                          stat_effect: c[:stat_effect] || 0)
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor
@@ -3916,7 +3918,9 @@ class RPG2k
                                               variance: meta[:variance] || 0,
                                               attributes: meta[:attributes],
                                               attr_shift: meta[:attr_shift],
-                                              attr_ids: meta[:attr_ids])
+                                              attr_ids: meta[:attr_ids],
+                                              stat_mod_keys: meta[:stat_mod_keys],
+                                              stat_effect: meta[:stat_effect] || 0)
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2487,16 +2487,28 @@ FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost
                        # by one step; direction is the skill's own scope
                        # (ally-scoped raises resistance, enemy-scoped lowers
                        # it) -- see Game::Party#skill_attr_shift.
-                       :affect_attr_defence)
+                       :affect_attr_defence,
+                       # Ability-value change (schema fields 33-36): raises or
+                       # lowers the target's per-battle ATK/DEF/SPI/AGI
+                       # modifier by the same signed effect affect_hp/
+                       # affect_sp already carry, direction by scope like
+                       # affect_attr_defence above -- see
+                       # Game::Party#skill_stat_mod_keys / Game::Battle#
+                       # apply_stat_mods. Appended last, for the same reason.
+                       :affect_attack, :affect_defense, :affect_spirit,
+                       :affect_agility)
 def fake_skill(name: '', type: 0, scope: 3, occ: true, sp_type: 0, sp_cost: 0,
                sp_percent: 0, power: 0, prate: 0, mrate: 0, hp: false, sp: false,
                occ_battle: true, state_effects: nil, reverse_state: false, hit: 100,
                variance: 4, attribute_effects: nil, switch_id: 1,
-               ignore_defense: false, affect_attr_defence: false)
+               ignore_defense: false, affect_attr_defence: false,
+               affect_attack: false, affect_defense: false,
+               affect_spirit: false, affect_agility: false)
   FakeSkill.new(name, type, scope, occ, sp_type, sp_cost, sp_percent, power,
                 prate, mrate, hp, sp, occ_battle, state_effects, reverse_state, hit,
                 variance, attribute_effects, switch_id, ignore_defense,
-                affect_attr_defence)
+                affect_attr_defence, affect_attack, affect_defense,
+                affect_spirit, affect_agility)
 end
 # A state-definition lookup for the battle: id -> a row the sim reads for its
 # per-turn slip damage (hp/sp change), action restriction and auto-recovery.
@@ -7564,12 +7576,15 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   # magical_rate 40), so RPG_RT blunts it with the target's *spirit* and not at
   # all with its armour: 32 - (0*8/40 + 40*16/80) = 32 - 8 = 24.
   eq({ cost: 6, hp: -24, mp: 0, inflict: [], chance: 100, variance: 4,
-       attributes: [], absorb: false, attr_shift: nil, attr_ids: [] },
+       attributes: [], absorb: false, attr_shift: nil, attr_ids: [],
+       stat_mod_keys: [] },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
-  eq({ cost: 5, hp: 32, mp: 0, variance: 4, attr_shift: nil, attr_ids: [] },
+  eq({ cost: 5, hp: 32, mp: 0, variance: 4, attr_shift: nil, attr_ids: [],
+       stat_mod_keys: [], stat_effect: 32 },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))
   # Cure affects HP and SP: effect = 10 + 40*12/40 = 22
-  eq({ cost: 4, hp: 22, mp: 22, variance: 4, attr_shift: nil, attr_ids: [] },
+  eq({ cost: 4, hp: 22, mp: 22, variance: 4, attr_shift: nil, attr_ids: [],
+       stat_mod_keys: [], stat_effect: 22 },
      st.party.battle_skill_command(st.party.db_skill(9), caster, nil))
 end
 
@@ -7697,6 +7712,118 @@ check 'attribute defence shift applies to the target rank, capped at ' \
     bat.run_round
   end
   eq 3, foe.attr_ranks[1], 'capped one step better than base (C -> D)'
+end
+
+# -- Ability-value change (schema fields 33-36: affect_attack/defense/spirit/
+# agility) -- a skill's own per-battle ATK/DEF/SPI/AGI modifier, distinct from
+# both attribute-defence rank shifting (above) and a *state*'s halve/double
+# (Game::Battle#stat_mode / #adjust_stat, "stat-halving state" checks nearby).
+# Ported from EasyRPG's Game_Battler::atk_modifier and CanChangeAtkModifier
+# (and its DEF/SPI/AGI siblings) -- this codebase used to parse these four
+# skill flags into FakeSkill/the LCF schema and then read none of them
+# anywhere, so a "raise/lower ATK/DEF/SPI/AGI" skill silently did nothing at
+# all beyond whatever incidental affect_hp/affect_sp damage/heal it also
+# carried.
+
+check 'skill_stat_mod_keys reads a skill\'s own affect_attack/defense/spirit/' \
+      'agility flags' do
+  atk_only = fake_skill(affect_attack: true)
+  all_four = fake_skill(affect_attack: true, affect_defense: true,
+                         affect_spirit: true, affect_agility: true)
+  none = fake_skill
+  st = skill_party({ 7 => atk_only, 8 => all_four, 9 => none })
+  eq [:atk], st.party.skill_stat_mod_keys(st.party.db_skill(7))
+  eq [:atk, :def, :spi, :agi], st.party.skill_stat_mod_keys(st.party.db_skill(8))
+  eq [], st.party.skill_stat_mod_keys(st.party.db_skill(9))
+end
+
+check 'an affect_attack attack skill lowers the target\'s per-battle ATK ' \
+      'modifier, clamped at -(base/2), and Battle#effective_atk reflects it' do
+  weaken = fake_skill(name: 'Weaken', scope: 0, sp_cost: 0, power: 4, prate: 0,
+                      mrate: 0, affect_attack: true)
+  st = skill_party({ 7 => weaken })
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 20, 0, 5, 1000)
+
+  c = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  eq [:atk], c[:stat_mod_keys]
+
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1)) # variance off
+  cast = lambda do
+    bat.command_skill(caster, foe, name: 'Weaken', cost: c[:cost], hp: c[:hp],
+                      mp: c[:mp], stat_mod_keys: c[:stat_mod_keys])
+    bat.run_round
+  end
+
+  cast.call
+  eq(-4, foe.atk_mod, 'first cast: -4 (flat power, no defence term)')
+  eq 16, bat.effective_atk(foe), 'base 20 - 4'
+
+  cast.call
+  eq(-8, foe.atk_mod, 'second cast stacks: -8')
+
+  # A third cast would request a running total of -12, past the -(20/2) = -10
+  # floor -- clamps there instead of overshooting.
+  cast.call
+  eq(-10, foe.atk_mod, 'clamped at -(base/2)')
+  eq 10, bat.effective_atk(foe)
+
+  # A further cast is a pure no-op once already pinned at the cap.
+  cast.call
+  eq(-10, foe.atk_mod, 'still -10, no further movement once capped')
+end
+
+check 'ability-value decrease rounds toward zero (up) on an odd base, not ' \
+      'a Ruby-style floor' do
+  # -(5 / 2) truncates toward zero to -2 in both this Ruby code (dividing the
+  # positive base first, then negating) and EasyRPG's C++ `-base / 2` -- a
+  # floor-toward-negative-infinity reading (Ruby's own `-base / 2`, base
+  # negated first) would instead land one step lower, at -3.
+  weaken = fake_skill(name: 'Weaken', scope: 0, sp_cost: 0, power: 100, prate: 0,
+                      mrate: 0, affect_attack: true)
+  st = skill_party({ 7 => weaken })
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 5, 0, 5, 1000)
+  c = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+  bat.command_skill(caster, foe, name: 'Weaken', cost: c[:cost], hp: c[:hp],
+                    mp: c[:mp], stat_mod_keys: c[:stat_mod_keys])
+  bat.run_round
+  eq(-2, foe.atk_mod, '-(5/2) rounds up (toward zero) to -2, not floor\'s -3')
+end
+
+check 'an affect_defense buff-only skill (affect_hp clear) still raises the ' \
+      'target\'s DEF modifier, capped at +base (a full double)' do
+  ward = fake_skill(name: 'Iron Skin', scope: 3, sp_cost: 0, power: 100, prate: 0,
+                    mrate: 0, affect_defense: true) # hp: false (default) -- buff-only
+  st = skill_party({ 7 => ward })
+  caster = combatant('Buddy', 5, 10, 5, 100)
+  caster.spi = 0 # skill_effect's magical_rate term needs a non-nil spirit even at rate 0
+  foe = combatant('Foe', 0, 0, 5, 1000)
+
+  c = st.party.battle_skill_command(st.party.db_skill(7), caster, caster)
+  eq [:def], c[:stat_mod_keys]
+  eq 0, c[:hp], 'affect_hp is not set, so hp stays 0 even though affect_defense is'
+  eq 100, c[:stat_effect], 'the raw, un-gated effect a buff-only skill still needs'
+
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+  bat.command_skill(caster, caster, name: 'Iron Skin', cost: c[:cost], hp: c[:hp],
+                    mp: c[:mp], stat_mod_keys: c[:stat_mod_keys],
+                    stat_effect: c[:stat_effect])
+  bat.run_round
+  eq 10, caster.def_mod, 'capped at +base (10), even though the requested delta was 100'
+  eq 20, bat.effective_def(caster), 'base 10 doubled'
+end
+
+check 'Battle#effective_atk clamps base+modifier before a stat-halving ' \
+      'state doubles/halves it, not the other way around' do
+  # base 20 + modifier 6 -> 26, *then* halved (floored) by the state -> 13.
+  states = { 1 => fake_state(affect_type: 0, affect_attack: true) } # 0 = halve
+  foe = combatant('Foe', 20, 0, 5, 100)
+  foe.atk_mod = 6
+  foe.states = [1]
+  bat = Game::Battle.new([], [foe], Game::Rng.new(1), states)
+  eq 13, bat.effective_atk(foe)
 end
 
 check 'a battle attack skill inflicts its state_effects on a surviving enemy' do


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s viprpg-dev wiki backlog flagged: "a special skill's ability-value **decrease** rounds up on ÷2, a status effect's own halving rounds **down**." A skill's `affect_attack`/`affect_defense`/`affect_spirit`/`affect_agility` flags (schema fields 33-36) were parsed but read nowhere in `mruby-rpg2k` — distinct from an attribute-defence shift skill (`#skill_attr_shift`), which moves a resistance *rank*, not a raw stat. `Game::Battle`'s own `stat_mode`/`adjust_stat` had a comment admitting the gap ("a battle-only ATK/DEF/SPI/AGI offset this runtime has no equivalent of").
- Verified the real mechanism against EasyRPG Player's source (`game_battlealgorithm.cpp`'s `Skill::vExecute`, `game_battler.cpp`'s `CanChangeAtkModifier` and siblings): a per-battle modifier clamped to `-(base/2)..+base`, where C++'s `-base/2` truncates toward zero (rounds *up*) — exactly the asymmetry the TODO bullet described, versus a state's halve (`value/2`, floors normally).
- Added `atk_mod`/`def_mod`/`spi_mod`/`agi_mod` to `Game::Battle::Combatant`; `Game::Party#skill_stat_mod_keys` reads the four skill flags; `Game::Battle#apply_stat_mods` applies/clamps the delta (the exact same final signed effect number already applied to HP/SP); `effective_atk`/`def`/`spi`/`agi` clamp base+modifier before a state's halve/double applies on top. Threaded through `command_skill`/`command_skill_all` and the real battle-menu UI path in `Scene::Map`. Enemy AI casts deliberately left unwired, matching the existing attribute-defence-shift feature's same scope.
- `docs/TODO.md` updated ✅; also marked three other long-unchecked claims "confirmed already correct" after verification (unrelated small cleanup while reading nearby entries).

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 726 checks pass (5 new: flag reading; an end-to-end debuff test capping at `-(base/2)`; the odd-base rounding case specifically (base 5 → -2, not floor's -3); a buff-only skill still raising a modifier capped at `+base`; an ordering pin — modifier clamped before a halving state applies on top — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 406 checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_