### PR TITLE
rpg2k: Set Move Route targeting a hidden map event now freezes, matching RPG_RT

### DIFF
--- a/changelog.d/move-route-hidden-event-target-freeze.fixed.md
+++ b/changelog.d/move-route-hidden-event-target-freeze.fixed.md
@@ -1,0 +1,15 @@
+- **A Set Move Route command targeting a currently-hidden (appearance-
+  conditions-unmet) map event now hard-freezes the interpreter, matching real
+  RPG_RT**, instead of silently completing. A hidden event never gets a
+  `Game::Character` built (`Scene::Map#build_events` skips it outright), and
+  `#apply_move_request`'s target lookup used to just drop the request when it
+  found nothing in `@events` — the same as a genuinely nonexistent event id.
+  The target is now also checked against the map's raw event table
+  (`@map.unit.events`): a real event with no page currently selected is
+  recorded in a new `@stuck_move_targets` list that permanently holds
+  `#forced_movement_done?` false, so Proceed With Movement (and the implicit
+  auto-run a Wait/Show Text triggers) never resumes — the same "hangs until
+  the obstruction clears" family as an impassable-tile target, except there
+  is no obstruction here that can ever clear. A genuinely invalid event id
+  still no-ops as before. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks, one confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2507,10 +2507,42 @@ following this paragraph as the original record.
   "wait for completion" targeting a permanently-impassable tile without
   "Ignore if can't move" stalls a parallel process forever.
 - `015_shujinkou_idou_huka/` — catalogue of hero-can't-move causes; most
-  already covered by existing passability/move-route logic, but **"Force
-  Move All" targeting a currently-hidden (appearance-conditions-unmet) map
-  event causes a hard freeze in real RPG_RT** is a distinct crash-class quirk
-  not cross-checked yet.
+  already covered by existing passability/move-route logic. ✅ **"Force Move
+  All" targeting a currently-hidden (appearance-conditions-unmet) map event
+  now hard-freezes here too, matching real RPG_RT**, instead of silently
+  doing nothing. This was a real, reachable gap: an event whose current page
+  conditions aren't satisfied never gets a `Game::Character` built at all
+  (`Scene::Map#build_events` skips it outright — the same fact already
+  recorded for `event_id_at` and the Parallel Process bullets above), and
+  `#apply_move_request`'s target-resolution fallback
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — the same method a Set Move Route
+  command's queued request goes through — looked the target id up in
+  `@events` and simply dropped the request when nothing was found, the exact
+  same code path a stale/invalid event id takes. So a Move Event + Proceed
+  With Movement (or the implicit auto-run a Wait/Show Text triggers, see the
+  already-fixed "An implicit auto-run now also happens..." entry above)
+  targeting a hidden map event resumed immediately, the opposite of the
+  documented hard freeze. Fixed by distinguishing the two cases: the target
+  id is now also checked against `@map.unit.events` (the map's raw event
+  table, independent of which pages are currently active — the same source
+  `#pages_changed?` already walks) before giving up, and if the id names a
+  real event that just has no page selected right now, it is recorded in a
+  new `@stuck_move_targets` list instead of discarded outright; a genuinely
+  nonexistent id (never a valid event on this map) still no-ops exactly as
+  before, since that is the separate, unmodelled "invalid event ID" error
+  dialog case (see the "Concrete runtime error catalog" entry below). A
+  non-empty `@stuck_move_targets` now holds `#forced_movement_done?` false
+  forever, the same mechanism an ordinary route stuck on an impassable tile
+  already uses to hang — except there is no obstruction here that can ever
+  clear, so once stuck, permanently so (the list is only ever reset by a
+  genuine map change/Transfer Player, alongside every other per-visit forced-
+  route state, never by the target event later becoming visible). Covered by
+  two new `scripts/rpg2k_scene_check.rb` checks (a Move Event + Proceed With
+  Movement targeting a hidden event never resumes, even many frames later,
+  and even after the target's own gating switch turns on and its pages are
+  refreshed; a control case pins that a target id with no matching event *at
+  all* is left as a plain no-op, not this freeze), the first confirmed to
+  fail against the pre-fix code before the fix.
 - `037_zen_tuukou_kanou/` — passability is the AND of lower+upper chip
   passability (probably already correct, unverified); only the chipset's
   literal top-left upper tile is the canonical "no tile" transparent chip,
@@ -2597,9 +2629,10 @@ Everything below is unverified against the codebase.
   between = vertical hop in place), speed/direction fixed for its duration;
   hero-targeted Set Move Route suppresses random encounters during the
   move; running it from a Parallel Process during a hero/event tile overlap
-  can suppress that event's touch trigger; targeting a currently-hidden map
+  can suppress that event's touch trigger; ✅ targeting a currently-hidden map
   event with Move-All freezes (same family as the `015_shujinkou_idou_huka`
-  item above).
+  item above — now fixed there, see the "Untriaged backlog, from
+  `2k/09_bug/`" section above for the full writeup).
 - **Repeat/Loop** — loops forever without an explicit Break Loop.
 - **Common Event** — can't display map graphics or use touch-style
   triggers, can't run during battle or with the menu open; "This Event" as

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -164,6 +164,10 @@ class RPG2k
         @vehicle_chars = {}
         @vehicle_routes = {}
         @vehicle_route_timers = {}
+        # Move Event targets that resolved to a currently-hidden map event
+        # (see #apply_move_request) -- once stuck, permanently so, matching a
+        # freeze that never clears on its own.
+        @stuck_move_targets = []
 
         # Player pixel position and step state. `player_jumping` marks the slide
         # as a hop, which is lifted along an arc (see player_jump_offset).
@@ -2368,7 +2372,24 @@ class RPG2k
           force_vehicle_route(type, route, r[:frequency])
         else
           ev = @events.find { |e| e[:id] == r[:target] }
-          force_event_route(ev, route, r[:frequency]) if ev
+          if ev
+            force_event_route(ev, route, r[:frequency])
+          elsif (@map.unit.events || {})[r[:target]]
+            # A real event on this map, just currently hidden because no page's
+            # conditions are satisfied (#build_events never gave it a
+            # Game::Character) -- yado.tk: targeting one with Set Move Route
+            # hard-freezes real RPG_RT rather than erroring or silently
+            # skipping, the same "control-lock until the obstruction clears"
+            # family as an impassable-tile target, except this one has no
+            # obstruction that can ever clear. Recorded here (rather than just
+            # dropped) so #forced_movement_done? keeps Proceed With Movement
+            # -- and the implicit auto-run a Wait/Show Text triggers, see
+            # #step_forced_movement -- waiting forever, matching the freeze.
+            # A genuinely nonexistent event id is a different, unmodelled
+            # error-dialog case (see the "Concrete runtime error catalog" TODO
+            # entry) and does not land here.
+            @stuck_move_targets << r[:target]
+          end
         end
       end
 
@@ -2667,6 +2688,7 @@ class RPG2k
       def forced_movement_done?
         return false if @player_route
         return false if @events.any? { |e| e[:forced_route] }
+        return false unless @stuck_move_targets.empty?
         !@vehicle_routes.values.any? { |route| route }
       end
 
@@ -5834,6 +5856,7 @@ class RPG2k
         @vehicle_chars = {}
         @vehicle_routes = {}
         @vehicle_route_timers = {}
+        @stuck_move_targets = [] # a stuck target was on the map being left
         # Both are per-visit: an Erase Event does not follow the party to the
         # next map, and the destination's pages are chosen fresh.
         @erased_events = {}

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3129,6 +3129,50 @@ check 'Proceed With Movement holds the interpreter until a forced route finishes
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
+check 'Set Move Route targeting a currently-hidden map event freezes Proceed With Movement (yado.tk)' do
+  ic = Game::Interpreter::Cmd
+  hidden = page(trigger: 0)
+  hidden.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 5)
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::MOVE_EVENT,
+             [2, 4, 0, 0, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT]),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, []),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(0, 1, hidden) },
+                    player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  ok event_hashes(scene)[2].nil?, "event 2's own page never satisfies its condition"
+
+  300.times { scene.update } # far more than the freq-4 route would ever need
+  ok !st.switches[1],
+     'Proceed With Movement never resumes -- the target never existed to move'
+
+  st.switches[5] = true # the event's own condition becomes true too late to help
+  scene.send(:refresh_event_pages)
+  50.times { scene.update }
+  ok !st.switches[1],
+     'the freeze does not clear once the event later appears -- the request was dropped, not queued'
+end
+
+check 'Set Move Route targeting a genuinely nonexistent event id does not freeze' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::MOVE_EVENT,
+             [99, 4, 0, 0, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT]),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, []),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(0, 4, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+
+  20.times { scene.update }
+  ok st.switches[1],
+     'a Move Event with no matching event id at all is a plain no-op, not the hidden-event freeze'
+end
+
 check "Proceed With Movement also waits on a vehicle's forced route" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s `2k/09_bug/015_shujinkou_idou_huka/` untriaged backlog entry flagged that in real RPG_RT, a "Force Move All" (Set Move Route + Proceed With Movement) targeting a currently-hidden (appearance-conditions-unmet) map event causes a hard freeze — a distinct crash-class quirk explicitly called out as not yet cross-checked against the codebase.
- Verified the gap is real: a hidden map event never gets a `Game::Character` built at all (`Scene::Map#build_events` skips it outright once no page's conditions are satisfied), but `#apply_move_request`'s target-resolution fallback just looked the target id up in the live `@events` list and silently dropped the request when nothing was found — the exact same code path a genuinely stale/invalid event id takes. So a Move Event + Proceed With Movement targeting a hidden event resumed immediately instead of freezing, the opposite of the documented behavior.
- Fixed by distinguishing the two cases in `Scene::Map#apply_move_request`: the target id is now also checked against `@map.unit.events` (the map's raw event table, independent of which pages are currently active — the same source `#pages_changed?` already walks) before giving up. A real event with no page currently selected is recorded in a new `@stuck_move_targets` list instead of discarded outright; a genuinely nonexistent id still no-ops as before (the separate, unmodelled "invalid event ID" error-dialog case). A non-empty `@stuck_move_targets` permanently holds `#forced_movement_done?` false — the same mechanism an ordinary route stuck on an impassable tile already uses to hang — except there is no obstruction here that can ever clear, so once stuck, permanently so; it resets only on a genuine map change/Transfer Player, alongside every other per-visit forced-route state.
- `docs/TODO.md` updated ✅ at both the primary entry and its cross-reference under "Full-site sweep"; changelog fragment added.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 722 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 408 checks pass (2 new: a Move Event + Proceed With Movement targeting a hidden event never resumes, even many frames later and even after the target's own gating switch turns on and pages refresh; a control case pins that a target id with no matching event *at all* is left as a plain no-op, not this freeze), the first confirmed to fail against the pre-fix code before the fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaMtmWxVMuipLJrmMco8Sw)_