### PR TITLE
rpg2k: a Show Battle Animation caps a concurrent Screen Flash to the current frame

### DIFF
--- a/changelog.d/battle-animation-screen-flash-cap.fixed.md
+++ b/changelog.d/battle-animation-screen-flash-cap.fixed.md
@@ -1,0 +1,10 @@
+- A Screen Flash (11040) concurrent with a Battle Animation is now capped to
+  the current frame instead of running its own full configured duration,
+  matching real RPG_RT: verified against EasyRPG Player's
+  `BattleAnimation::Update` (`src/battle_animation.cpp`), which re-asserts
+  the screen flash from the animation's own (possibly zero) state on every
+  real frame the animation is on screen, silently overwriting anything else.
+  `Scene::Map#step_map_animation` (`mruby-rpg2k/mrblib/scene/map.rb`) now
+  does the same via a new `#hold_animation_screen_flash`, called every real
+  frame the animation drives rather than only on the throttled ticks that
+  carry their own flash_scope-2 timing.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3509,7 +3509,45 @@ not yet verified:
   1/30s display while a Battle Animation is playing, because the
   animation continuously re-asserts its own per-frame flash state for its
   whole duration — corroborated by many independent sources as one of the
-  most commonly-hit surprises on the site.
+  most commonly-hit surprises on the site. ✅ **The Screen Flash half is now
+  fixed, verified against EasyRPG Player's actual C++ source rather than
+  guessed at.** `BattleAnimation::Update` (`src/battle_animation.cpp`) calls
+  `UpdateScreenFlash` on **every real frame** the animation is on screen —
+  not only frames carrying their own flash_scope-2 timing — and
+  `UpdateScreenFlash` always ends in `Game_Screen::FlashOnce(r, g, b, p, 0)`,
+  where r/g/b/p come from the most recently fired timing's own decaying value
+  (`UpdateFlashGeneric`/`CalculateFlashPower`) or are all zero once that decay
+  window has lapsed (or before any timing has fired at all this play) —
+  so an unrelated, independently-ticking Screen Flash gets silently
+  overwritten the very next real frame regardless of its own configured
+  duration, for as long as any Battle Animation is on screen. This
+  codebase's `Scene::Map#fire_animation_flashes` (`mruby-rpg2k/mrblib/
+  scene/map.rb`) already reproduced the timing's own decaying flash
+  correctly on a frame that carries one (`@state.screen.flash(...,
+  ANIM_FLASH_FRAMES)`), but `#step_map_animation` only ever touched the
+  screen flash on those throttled, timing-carrying animation-frame ticks —
+  every other real frame (including an animation's opening frames, before
+  any flash_scope-2 timing has fired at all) left an unrelated flash's own
+  decay running completely untouched, the opposite of "capped to 1/30s".
+  Fixed with a new `#hold_animation_screen_flash`, called from
+  `#step_map_animation` on **every** real frame the animation drives
+  (throttled ticks and the frames in between alike): a new
+  `ma[:screen_flash_hold]` counter (set to `ANIM_FLASH_FRAMES` by
+  `#fire_animation_flashes` whenever a flash_scope-2 timing actually fires,
+  ticking down here) lets the animation's own just-fired flash decay
+  undisturbed for that window, and forcibly zeroes the screen flash
+  (`@state.screen.flash(0, 0, 0, 0, 0)`) every real frame outside it —
+  reproducing `FlashOnce(0,0,0,0,0)`'s own "nothing fired yet/lapsed" case.
+  Scoped to Screen Flash only: **Character Flash is a structurally different
+  mechanism in this codebase** (the decaying `{red:, green:, blue:, power:,
+  frames:, total:}` hash `#apply_sprite_flash`/`#update_sprite_flashes` drive
+  per-target, vs. `Game::Screen`'s own single flash state) and would need its
+  own, separate per-real-frame reassertion — left open. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a Flash Screen command fired with a
+  120-frame duration right before a Show Battle Animation whose own frame 0
+  carries no timing at all gets stomped to not-flashing during those
+  timing-less opening frames, well short of its own configured duration),
+  confirmed to fail against the pre-fix code before the fix.
 - Change Screen Tone affects **only** the map tile+character layer —
   pictures, screen/character flash, battle animations, and message text
   are all completely unaffected even at a maximal dark tone; Erase Screen,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5467,6 +5467,7 @@ class RPG2k
         ma = @map_animation
         if ma[:timer] > 0
           ma[:timer] -= 1
+          hold_animation_screen_flash(ma)
           return
         end
         ma[:frame_i] += 1
@@ -5486,6 +5487,45 @@ class RPG2k
         end
         fire_animation_flashes(ma)
         ma[:timer] = ANIM_CELL_FRAMES
+        hold_animation_screen_flash(ma)
+      end
+
+      # yado.tk: Screen Flash / Character Flash are both capped to 1/30s of
+      # display while a Battle Animation is playing, because the animation
+      # continuously re-asserts its own per-frame flash state for its whole
+      # duration -- corroborated independently by EasyRPG's own C++ source:
+      # `BattleAnimation::Update` (src/battle_animation.cpp) calls
+      # `UpdateScreenFlash` on *every* real frame the animation is on screen,
+      # not just frames with their own flash_scope-2 timing, and
+      # `UpdateScreenFlash` always ends in `Game_Screen::FlashOnce(r, g, b, p,
+      # 0)` -- r/g/b/p taken from the most recently fired timing's own
+      # decaying value (`UpdateFlashGeneric`/`CalculateFlashPower`), or all
+      # zero when none has fired yet this play. Either way, any *other*
+      # in-flight screen flash -- one an unrelated Flash Screen command set
+      # ticking before or during this animation -- gets silently overwritten
+      # the very next real frame, regardless of its own configured duration.
+      # `#fire_animation_flashes`'s own `@state.screen.flash` call (fired only
+      # on a frame carrying a flash_scope-2 timing) already reproduces the
+      # timing's own decaying flash correctly; what was missing is this
+      # continuous per-*real*-frame reassertion for every frame in between --
+      # `#step_map_animation` only ever touched the screen flash on the
+      # throttled animation-frame ticks that actually carry a timing, so an
+      # unrelated flash concurrent with an otherwise-silent stretch of the
+      # animation (including its opening frames, before any timing has fired
+      # at all) played out its own full duration untouched. `ma[:screen_flash_hold]`
+      # tracks how many more real frames the *animation's own* most recent
+      # flash_scope-2 fire still owns the screen flash for (set to
+      # ANIM_FLASH_FRAMES by #fire_animation_flashes, ticking down here); once
+      # it reaches zero the animation forcibly zeroes the screen flash again
+      # every real frame, capping any concurrent, unrelated flash to at most
+      # the one frame between two calls here.
+      def hold_animation_screen_flash(ma)
+        hold = ma[:screen_flash_hold]
+        if hold && hold > 0
+          ma[:screen_flash_hold] = hold - 1
+        else
+          @state.screen.flash(0, 0, 0, 0, 0)
+        end
       end
 
       def step_animation_wait
@@ -5623,6 +5663,10 @@ class RPG2k
             @state.screen.flash((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
                                 (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8,
                                 ANIM_FLASH_FRAMES)
+            # #hold_animation_screen_flash keeps re-asserting this fire (and,
+            # once it lapses, zeroing the screen flash outright) every real
+            # frame for as long as the animation itself owns the slot.
+            ma[:screen_flash_hold] = ANIM_FLASH_FRAMES
           when 1
             ma[:battle] ? fire_target_flash(ma[:target_index], t) : fire_map_target_flash(ma[:flash_target], t)
           end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4796,6 +4796,44 @@ check 'Show Battle Animation plays: an animation sprite shows and a flash fires'
   ok !spr.visible, 'the animation sprite is hidden once it finishes'
 end
 
+# yado.tk (corroborated independently against EasyRPG's own C++ source, see
+# #hold_animation_screen_flash's comment): Screen Flash is capped to 1/30s of
+# display while a Battle Animation is playing, since the animation
+# continuously re-asserts its own per-frame flash state -- overwriting an
+# unrelated, still-ticking Screen Flash the very next real frame, regardless
+# of that flash's own configured duration. Fired here with wait off (so the
+# event moves straight on to the animation instead of blocking on the flash's
+# own long duration) and a 20-tenths-of-a-second (120-frame) duration --
+# animation 8's own frame 0 carries no timing at all (its one flash_scope-2
+# timing is on frame 1), so the very first real frames the animation drives
+# have nothing of their own to show and must be stomping the unrelated flash
+# to nothing on their own.
+check 'A Screen Flash concurrent with a Show Battle Animation is capped to the current frame' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::FLASH_SCREEN, [31, 31, 31, 20, 20, 0], indent: 0), # r g b power duration wait=0
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),       # animation, player, wait=1
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  stomped_at_frame_0 = false
+  saw_the_flash_at_all = false
+  40.times do
+    scene.update
+    saw_the_flash_at_all ||= st.screen.flashing?
+    anim = scene.instance_variable_get(:@map_animation)
+    stomped_at_frame_0 ||= (anim && anim[:frame_i] == 0 && !st.screen.flashing?)
+    break if st.switches[6]
+  end
+  ok saw_the_flash_at_all, 'the independently-fired Flash Screen command did take effect at some point'
+  ok stomped_at_frame_0, "the battle animation's own per-frame state stomps the unrelated flash to " \
+                         "nothing during its own timing-less opening frames, capping it well short of " \
+                         'its own configured 120-frame duration'
+  ok st.switches[6], 'the event resumed after the animation'
+end
+
 # yado.tk: Show Battle Animation targeting a Vehicle position reads that
 # vehicle's real, currently-live x/y (the same source the Control Variables
 # vehicle-position fix reads), not the player's or the triggering event's own


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s yado.tk Full-site sweep "Screen effects" bullet flagged: Screen Flash and Character Flash are both capped to 1/30s display while a Battle Animation is playing, because the animation continuously re-asserts its own per-frame flash state for its whole duration. Unverified.
- Verified against EasyRPG Player's actual source: `BattleAnimation::Update` (`src/battle_animation.cpp`) calls `UpdateScreenFlash()` on **every real frame** the animation is on screen, not only frames with their own flash_scope-2 timing — always ending in `Game_Screen::FlashOnce(r,g,b,p,0)`, silently stomping any unrelated Screen Flash the very next frame.
- `Scene::Map#fire_animation_flashes` only touched the screen flash on throttled animation-tick frames that actually carried a flash_scope-2 timing — every other real frame (including an animation's timing-less opening frames) left a concurrent, independent Screen Flash running its own full duration untouched.
- Added `Scene::Map#hold_animation_screen_flash`, called from `#step_map_animation` on every real frame the animation drives. A new `ma[:screen_flash_hold]` counter (set by `#fire_animation_flashes` when a timing fires) lets that flash decay undisturbed during its own window; outside it, the screen flash is forcibly zeroed every frame. Scoped to Screen Flash only — Character Flash uses a structurally different per-target mechanism and is left as a separate, still-open gap (noted in the TODO write-up).
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 407 checks pass (1 new: a Screen Flash concurrent with a Show Battle Animation is capped to the current frame during the animation's timing-less opening frames — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_