### PR TITLE
rpg2k: a Show Battle Animation frame is held for 1/30s (2 ticks), not 1/20s (3)

### DIFF
--- a/changelog.d/battle-animation-frame-duration.fixed.md
+++ b/changelog.d/battle-animation-frame-duration.fixed.md
@@ -1,0 +1,10 @@
+- **A Show Battle Animation frame is now held for 1/30s (2 ticks at 60fps),
+  not 1/20s (3 ticks).** `Scene::Map::ANIM_CELL_FRAMES` was `3`; EasyRPG's
+  `BattleAnimation::Update` (`src/battle_animation.cpp`) ticks its internal
+  `frame` counter once per logical 60fps update and renders `GetFrame() / 2`
+  as the current cell (`num_frames = GetRealFrames() * 2`) — every real (LCF)
+  animation frame is held for exactly 2 ticks, whether or not that frame's
+  own cell list is empty, with no separate doubling rule for "Wait" frames
+  specifically. Fixed by changing the constant to `2`. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the pre-fix
+  code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3967,13 +3967,44 @@ not yet verified:
   rule between two *concurrent* requests (which interpreter, if any, gets
   bumped) is intentionally left unmodelled — a request arriving while the slot
   is held simply waits its turn — since resolving it needs a real RPG_RT
-  comparison this environment cannot run. The "Wait frame is two 0.0s frames"
-  and "back-to-back calls stutter" claims are likewise still open. Covered by
-  two new `scripts/rpg2k_scene_check.rb` checks (a parallel process's Show
-  Battle Animation holds it, then resumes once the animation finishes; the
-  animation actually renders — sprite shown, screen flash fired — for a
-  parallel-process request, not just a foreground one), both confirmed to
-  fail against the pre-fix code before the fix.
+  comparison this environment cannot run. "Back-to-back calls stutter" is
+  likewise still open. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a parallel process's Show Battle Animation holds it, then resumes
+  once the animation finishes; the animation actually renders — sprite
+  shown, screen flash fired — for a parallel-process request, not just a
+  foreground one), both confirmed to fail against the pre-fix code before
+  the fix.
+- ✅ **The "1 frame = 1/30s" half of the bullet above is now correct, and
+  the "'Wait' frame is internally two consecutive frames" framing turns out
+  to have been a misreading — settled against EasyRPG Player's actual C++
+  source rather than left as a guess.** `Scene::Map::ANIM_CELL_FRAMES` (the
+  number of engine ticks each drawable animation cell is held for, driving
+  `#step_map_animation`'s `ma[:timer]` countdown) was `3`, holding every
+  frame — content or blank — for 1/20s at this codebase's 60fps tick rate,
+  not the claimed 1/30s. EasyRPG's `BattleAnimation` (`src/
+  battle_animation.{h,cpp}`) settles both the exact duration and the "Wait
+  frame" question at once: its constructor sets `num_frames =
+  GetRealFrames() * 2`, `Update()` (called once per logical 60fps tick, from
+  `Game_Battle::UpdateAnimation` via `Scene_Battle::UpdateBattlers`)
+  increments a bare `frame` counter by 1 every call with no per-frame-content
+  branching at all, and `GetRealFrame() { return GetFrame() / 2; }` is the
+  index actually drawn — so *every* real (LCF) animation frame, whether its
+  own cell list is populated or empty, is mechanically held for exactly 2
+  ticks (1/30s at 60fps) before the next one shows. There is no separate
+  "Wait frames get doubled" rule in the real engine at all — the yado.tk
+  finding's "internally two consecutive frames" phrasing was describing this
+  same universal 2-tick hold, just from having only ever isolated it on a
+  blank/Wait frame in practice. Fixed by changing `ANIM_CELL_FRAMES` from
+  `3` to `2`; `ANIM_FALLBACK_FRAMES`/`ANIM_FLASH_FRAMES` (10 and 8 frames
+  respectively, independent constants) are untouched, and the fallback timed
+  wait (`ANIM_FALLBACK_FRAMES * ANIM_CELL_FRAMES`, used when an animation's
+  own sheet/data is missing) shortens to match automatically since it
+  multiplies through the same constant. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check pinning the exact per-frame hold
+  count (still frame 0 after 2 ticks, advances to frame 1 on the 3rd),
+  confirmed to fail against the pre-fix code (`expected 2, got 3`) before
+  the fix. "Back-to-back calls stutter" (the bullet's third, unrelated
+  claim) remains open, as noted above.
 - ✅ **Show Battle Animation (11210) targeting a vehicle now plays over that
   vehicle's own live position**, instead of silently defaulting to the
   player's. `Scene::Map#animation_target_pixel` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5444,7 +5444,19 @@ class RPG2k
       # Display frames each animation frame is held; the fallback length (frames)
       # when the database has no data for the requested animation; and the flash
       # duration a timing fires.
-      ANIM_CELL_FRAMES = 3
+      #
+      # ANIM_CELL_FRAMES is 2, not some other guess: EasyRPG's `BattleAnimation`
+      # (src/battle_animation.{h,cpp}) drives an internal `frame` counter that
+      # ticks once per `Update()` call (once per logical 60fps frame, called from
+      # `Game_Battle::UpdateAnimation` every `Scene_Battle::UpdateBattlers`), with
+      # `num_frames = GetRealFrames() * 2` and `GetRealFrame() { return GetFrame()
+      # / 2; }` -- i.e. every real (LCF) animation frame is held for exactly two
+      # ticks before the displayed cell advances, independent of whether that
+      # frame's own cell list is empty (a "Wait" frame) or not; there is no
+      # separate doubling rule for blank frames specifically. 2 ticks at 60fps is
+      # 1/30s per frame, matching the "1 frame = 1/30s" fact this codebase already
+      # otherwise assumed correctly.
+      ANIM_CELL_FRAMES = 2
       ANIM_FALLBACK_FRAMES = 10
       ANIM_FLASH_FRAMES = 8
       # RPG2000 battle-animation cells: a 96x96 grid, 5 cells across the sheet.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7007,6 +7007,28 @@ check 'the round waits for the animation instead of the banner timer' do
   ok !scene.send(:battle_animation_playing?)
 end
 
+# Real RPG_RT (EasyRPG's BattleAnimation::Update, src/battle_animation.cpp)
+# ticks an internal frame counter once per logical 60fps update and shows
+# `GetFrame() / 2` as the current cell -- so every real (LCF) animation frame
+# is held for exactly 2 ticks (1/30s), whether or not that frame's own cell
+# list is empty ("Wait"), before the next one shows. See the ANIM_CELL_FRAMES
+# comment in scene/map.rb for the fuller citation.
+check 'each battle animation frame is held for exactly ANIM_CELL_FRAMES ticks (2, 1/30s)' do
+  scene, = battle_at_command
+  scene.send(:start_battle_animation,
+             { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+               skill_id: 8, target_index: 0, target_ally: false })
+  ma = scene.instance_variable_get(:@map_animation)
+  ok ma, 'the fixture animation (id 8, 4 frames) armed'
+  eq 2, RPG2k::Scene::Map::ANIM_CELL_FRAMES,
+     'matches EasyRPG BattleAnimation::Update -- GetRealFrame() == GetFrame() / 2'
+  eq 0, ma[:frame_i], 'starts on the first frame'
+  2.times { scene.send(:step_map_animation) }
+  eq 0, ma[:frame_i], 'still the first frame after 2 ticks'
+  scene.send(:step_map_animation)
+  eq 1, ma[:frame_i], 'advances to the second frame on tick 3'
+end
+
 check 'an item names its animation the same way a skill does' do
   scene, = battle_at_command
   eq nil, scene.send(:battle_animation_id,


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s yado.tk Full-site sweep "Battle Animation" bullet flagged: "1 frame = 1/30s, but a 'Wait' frame is internally **two** consecutive 0.0s-wait frames, not one" — unverified.
- Verified against EasyRPG Player's actual source: `BattleAnimation` (`src/battle_animation.{h,cpp}`) sets `num_frames = GetRealFrames() * 2` in its constructor, its `Update()` (called once per logical 60fps tick, from `Game_Battle::UpdateAnimation` via `Scene_Battle::UpdateBattlers`) increments a bare `frame` counter by 1 every call with no per-frame-content branching at all, and `GetRealFrame() { return GetFrame() / 2; }` is the index actually drawn. So *every* real (LCF) animation frame — content or blank — is mechanically held for exactly 2 ticks (1/30s at 60fps), with no separate "Wait frames get doubled" rule in the real engine; the yado.tk finding's "internally two consecutive frames" phrasing describes this same universal 2-tick hold, just observed on a blank/Wait frame.
- `Scene::Map::ANIM_CELL_FRAMES` (the number of engine ticks each drawable animation cell is held for, driving `#step_map_animation`'s countdown) was `3`, holding every frame for 1/20s at this codebase's 60fps tick rate instead of the correct 1/30s. Fixed by changing it to `2`. The fallback timed wait (`ANIM_FALLBACK_FRAMES * ANIM_CELL_FRAMES`, used when an animation's own sheet/data is missing) shortens to match automatically since it multiplies through the same constant.
- `docs/TODO.md` updated ✅ with the citation; changelog fragment added. "Back-to-back Show Battle Animation calls stutter" (the bullet's third, unrelated claim) remains open.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 410 checks pass (1 new: each battle animation frame is held for exactly `ANIM_CELL_FRAMES` (2) ticks — still frame 0 after 2 ticks, advances to frame 1 on the 3rd — confirmed to fail against the pre-fix code, `expected 2, got 3`)

---
_Generated by [Claude Code](https://claude.ai/code/session_014dxoTc7VXv9eB884GDkoLK)_