### PR TITLE
rpg2k: RPG2003's levitate flag gives an enemy a sine-wave flying bob

### DIFF
--- a/changelog.d/enemy-levitate-flying-offset.fixed.md
+++ b/changelog.d/enemy-levitate-flying-offset.fixed.md
@@ -1,0 +1,14 @@
+- **An RPG2003 enemy flagged "airborne" (`levitate`) now bobs on the battle
+  screen; a genuine RPG2000 database never does, matching real RPG_RT.** The
+  monster schema's `levitate` field (LCF enemy field 28) was parsed but read
+  nowhere in `mruby-rpg2k`, so every enemy always drew at its plain centred
+  position. Confirmed against EasyRPG Player's C++ source
+  (`Game_Enemy::GetFlyingOffset`): the flag is cosmetically inert in RPG2000
+  ("2k does not support flying, albeit mentioned in the help file", their own
+  comment) and only draws a +/-4px, 256-frame-period sine bob under RPG2003.
+  Implemented with a new `Game::Enemy#levitate` reader, `Scene::Map
+  #flying_offset`/`#battler_y` (gated on `@state.party.rpg2003?` and the
+  member's own flag), and a per-fight `@battle_ui[:frame]` counter ticked by
+  a new `#update_enemy_positions` alongside the existing per-frame flash
+  decay. Covered by two new `scripts/rpg2k_scene_check.rb` checks, confirmed
+  to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4479,18 +4479,58 @@ above are repeated here)
   battle-event command naming a member by number gets silently repointed by
   it) is unverified — a separate question about troop-member identity/
   numbering, not the render-order this PR fixes.
-- The "airborne" enemy display flag **only** changes its Y position on
-  screen — it has no accuracy/hit-related effect. **Still open**: the
-  monster schema's `levitate` field (LCF enemy field 28,
-  `mruby-lcf/mrblib/schema.rb`) is parsed but read nowhere in
-  `mruby-rpg2k`, so this codebase draws every enemy at its plain
-  centred position regardless — but yado.tk's own text names no pixel
-  offset or animation shape for the raise, and both the yado.tk and
-  viprpg-dev wiki mirrors were unreachable this session (`yado.tk`
-  itself 503'd; the viprpg-dev wiki 403'd WebFetch), so implementing this
-  would mean guessing a magnitude with no way to check it — left for a
-  session that can compare against real RPG_RT. ✅ **The "frequent miss"
-  enemy option is confirmed already correct: a hardcoded 90%→70% drop to
+- ✅ **The "airborne" enemy display flag only changes Y position on screen, with
+  no accuracy/hit-related effect** — now implemented, with the crucial fact
+  yado.tk's own text never mentions at all: real RPG2000 does not render it,
+  full stop. The monster schema's `levitate` field (LCF enemy field 28,
+  `mruby-lcf/mrblib/schema.rb`) was parsed but read nowhere in `mruby-rpg2k`,
+  so this codebase used to draw every enemy at its plain centred position
+  regardless — matching real RPG2000 *by omission*, but for the wrong
+  reason, and giving RPG2003 no bob at all where the real engine has one.
+  Confirmed against EasyRPG Player's actual C++ source rather than a magnitude
+  guess (yado.tk itself 503'd and the viprpg-dev wiki mirror 403'd again this
+  session): `Game_Enemy::GetFlyingOffset` (`src/game_enemy.cpp`) is `if
+  (!Player::IsRPG2k3() || !IsFlying()) return 0;` — their own comment reads
+  "2k does not support flying, albeit mentioned in the help file" — so a
+  genuine RPG2000 database's `levitate` flag has always been cosmetically
+  inert in the real engine, and this codebase's prior "read nowhere" gap
+  coincidentally already matched that half. The other half — RPG2003 — draws
+  `round(sin(2*PI*frame/256) * 4)`, a per-battler `frame` counter incremented
+  once per battle-screen frame. Implemented by threading `Game::Enemy#levitate`
+  through from the schema (mirroring the existing `@miss`/`attack_hit_rate`
+  pattern right above it) and a new `Scene::Map#flying_offset(member)`
+  (`mruby-rpg2k/mrblib/scene/map.rb`), gated on `@state.party.rpg2003?` (the
+  same accessor the RPG2003 variable-range-widen and Menu-command-list fixes
+  already key off) **and** the member's own flag, reading a new per-fight
+  `@battle_ui[:frame]` counter (reset to 0 in `#open_battle`, incremented once
+  per `#drive_battle` call — this scene's own once-per-screen-frame cadence,
+  the same one `#update_map_tone`'s `@anim_frame` already uses for water/tile
+  animation) rather than EasyRPG's per-battler-randomized start phase, since
+  neither wiki mirror describes members desyncing from one another. A new
+  `#battler_y(member, bmp)` (`member.y - bmp.height / 2 + flying_offset(member)`)
+  replaces the bare centring math at all three sites that place an enemy
+  sprite — `#build_battle_sprites`, `#rebuild_battler_sprite` (a mid-fight
+  transformation redraw), `#reveal_battle_monster` (Show Hidden Monster) — so
+  a reveal or transformation mid-bob lands at the correct phase instead of
+  resetting to the un-offset centre; a new `#update_enemy_positions`, called
+  from `#drive_battle` alongside the existing `#update_enemy_flashes`, ticks
+  the counter and re-seats every levitating member's sprite every frame after
+  that, since none of the three build sites are what keeps a *continuous* bob
+  advancing frame to frame. A non-levitating member or a plain RPG2000 fight
+  costs nothing beyond the frame increment: `#flying_offset` returns 0 before
+  ever reading `@state.party.rpg2003?` (`member.levitate &&` short-circuits
+  first), so no existing battle fixture needed a `rpg2003?` method added
+  to keep working. Covered by two new `scripts/rpg2k_scene_check.rb` checks
+  against a new lone-member fixture troop (`enemy_group` 2, one `levitate`d
+  "Bat", `enemy` 3) that leaves every existing two-Slime battler-sprite
+  assertion undisturbed: `#flying_offset` at the sine curve's four
+  quarter-period landmarks (0, +4, 0, −4 at frames 0/64/128/192); and an
+  end-to-end drive confirming the sprite's own `y` actually moves as
+  `scene.update` ticks the frame counter in an RPG2003 fight, while the
+  identical troop and flag fought with no `rpg2003?` flag never bobs at all
+  after the same number of frames — both confirmed to fail against the
+  pre-fix code (`NoMethodError: undefined method 'levitate'`). ✅ **The
+  "frequent miss" enemy option is confirmed already correct: a hardcoded 90%→70% drop to
   *normal-attack* accuracy only, skills unaffected.** `Game::Enemy#attack_hit_rate`
   (`mruby-rpg2k/mrblib/game.rb`) already reads the schema's `miss` field
   (LCF enemy field 26) exactly this way — `@miss ? 70 : 90` — and

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5617,6 +5617,14 @@ module Game
       # The "miss" flag (field 26): a flagged enemy is clumsier and attacks at a
       # 70% base hit rate rather than the usual 90% (EasyRPG's GetHitChance).
       @miss = row && row.respond_to?(:miss) ? (row.miss ? true : false) : false
+      # The "airborne" flag (field 28, `levitate`): purely a battle-screen
+      # display effect (EasyRPG's Game_Enemy::GetFlyingOffset) with no
+      # accuracy/hit-related effect of any kind -- and, per that same source,
+      # RPG2000 never renders it at all ("2k does not support flying, albeit
+      # mentioned in the help file"), only RPG2003 does, gated by
+      # `Scene::Map#flying_offset` the same way. Read here regardless of
+      # edition, same as every other schema field this class exposes.
+      @levitate = row && row.respond_to?(:levitate) ? (row.levitate ? true : false) : false
       # The 行動パターン table (field 42), decoded now since `row` isn't kept. An
       # enemy whose row lists none falls back to plain attacking.
       @actions = []
@@ -5628,6 +5636,10 @@ module Game
     attr_reader :actions
 
     attr_reader :crit_chance, :attribute_ranks, :state_ranks
+
+    # The "airborne" flag (field 28) -- see the comment in #initialize for what
+    # it does and does not affect.
+    attr_reader :levitate
 
     # Base to-hit percentage for this enemy's normal attack (70 when the "miss"
     # flag is set, otherwise 90); fed into the battle's to-hit roll.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3386,6 +3386,7 @@ class RPG2k
           return
         end
         update_enemy_flashes
+        update_enemy_positions
         case @battle_ui[:phase]
         when :command     then drive_battle_command
         when :target      then drive_battle_target
@@ -3438,7 +3439,12 @@ class RPG2k
                        # its battler's whole action (see #drive_battle_animate),
                        # and which phase a running battle-event page resumes to
                        # once it finishes (see #run_battle_events).
-                       battler_boundary: false, event_return_phase: :command }
+                       battler_boundary: false, event_return_phase: :command,
+                       # Frames elapsed since this battle opened -- cosmetic
+                       # only (drives a levitating enemy's bob, #flying_offset),
+                       # never read for any combat/save-affecting purpose, so
+                       # it needs no seeding beyond starting at 0 every fight.
+                       frame: 0 }
         @battle_ui[:events].battle = @battle_ui[:battle]
         # A battle page can Call Common Event (1005), so it needs the same
         # resolver the map's events run against.
@@ -3460,6 +3466,39 @@ class RPG2k
         100 + (@battle_ui[:troop].members.size - 1 - i)
       end
 
+      # Vertical pixel bob for a levitating (`Game::Enemy#levitate`) troop
+      # member, or 0 for everyone else. yado.tk only ever says the "airborne"
+      # flag "changes its Y position on screen" with no magnitude or edition
+      # given; EasyRPG's own `Game_Enemy::GetFlyingOffset` supplies both
+      # missing facts and, more importantly, the edition gate the yado.tk
+      # source never mentioned at all: `if (!Player::IsRPG2k3() || !IsFlying())
+      # return 0;` -- "2k does not support flying, albeit mentioned in the
+      # help file" (their comment). So a genuine RPG2000 database's own
+      # `levitate` flag has no on-screen effect whatsoever, real RPG_RT bug and
+      # all; only an RPG2003 one draws the +/-4px, 256-frame-period sine bob
+      # (`round(sin(2*PI*frame/256) * 4)`, their `frame` a per-battler counter
+      # incremented once per battle frame) computed here from this scene's own
+      # per-battle `@battle_ui[:frame]` instead -- a single shared phase for
+      # every levitating member rather than EasyRPG's per-battler-randomized
+      # start offset, since nothing in either wiki mirror (both unreachable
+      # this session) describes members desyncing from one another, only that
+      # each one "changes its Y position".
+      FLYING_AMPLITUDE = 4
+      FLYING_PERIOD = 256
+      def flying_offset(member)
+        return 0 unless member.levitate && @state.party.rpg2003?
+        frame = @battle_ui[:frame] || 0
+        (Math.sin(2 * Math::PI * frame / FLYING_PERIOD.to_f) * FLYING_AMPLITUDE).round
+      end
+
+      # A troop member's on-screen y, centred on its database position and
+      # nudged by #flying_offset -- shared by every site that (re)builds an
+      # enemy sprite so the three stay in lockstep with the per-frame update
+      # (#update_enemy_positions) that keeps a levitating one bobbing after.
+      def battler_y(member, bmp)
+        member.y - bmp.height / 2 + flying_offset(member)
+      end
+
       # RPG2000 is a front-view battle: the enemy troop is drawn as sprites over a
       # battle background, while the party is represented by the status window (not
       # sprites). Build the backdrop and one sprite per visible troop member,
@@ -3473,7 +3512,7 @@ class RPG2k
           spr = Sprite.new
           spr.bitmap = bmp
           spr.x = enemy.x - bmp.width / 2
-          spr.y = enemy.y - bmp.height / 2
+          spr.y = battler_y(enemy, bmp)
           spr.z = battler_z(i)
           spr
         end
@@ -3615,6 +3654,22 @@ class RPG2k
         (@battle_ui[:enemy_sprites] || []).each { |s| s.update if s }
       end
 
+      # Advance the per-battle frame counter #flying_offset reads and re-seat
+      # any levitating troop member's sprite at its new bob height. A no-op
+      # (bar the counter tick) for a plain RPG2000 fight or a troop with no
+      # `levitate` member: #flying_offset already reads 0 for both, so the
+      # assignment below is just re-writing the same y already set.
+      def update_enemy_positions
+        @battle_ui[:frame] = (@battle_ui[:frame] || 0) + 1
+        sprites = @battle_ui[:enemy_sprites]
+        return unless sprites
+        @battle_ui[:troop].members.each_with_index do |member, i|
+          spr = sprites[i]
+          next unless spr && member.levitate
+          spr.y = battler_y(member, spr.bitmap)
+        end
+      end
+
       # Show a living enemy's sprite, hide a defeated one — called after each
       # animated action so a downed enemy vanishes from the field.
       def refresh_battle_sprites
@@ -3648,7 +3703,7 @@ class RPG2k
         spr = Sprite.new
         spr.bitmap = bmp
         spr.x = member.x - bmp.width / 2
-        spr.y = member.y - bmp.height / 2
+        spr.y = battler_y(member, bmp)
         spr.z = battler_z(i)
         spr.visible = !foe.out_of_play?
         sprites[i] = spr
@@ -4333,7 +4388,7 @@ class RPG2k
         spr = Sprite.new
         spr.bitmap = bmp
         spr.x = member.x - bmp.width / 2
-        spr.y = member.y - bmp.height / 2
+        spr.y = battler_y(member, bmp)
         spr.z = battler_z(index)
         dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
         @battle_ui[:enemy_sprites][index] = spr

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -308,14 +308,24 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
     item: { 3 => OpenStruct.new(name: 'Potion', price: 100),
             5 => OpenStruct.new(name: 'Herb', price: 40) },
     # An enemy and a troop of two, for the placeholder Enemy Encounter victory.
+    # Enemy 3 (Bat) carries the "airborne" flag (field 28, `levitate`) for the
+    # RPG2003 flying-offset checks; its own troop (group 2) is a lone member
+    # so those checks never disturb enemy_group 1's two-Slime assertions.
     enemy: { 2 => OpenStruct.new(name: 'Slime', battler_name: 'Slime',
                                  max_hp: 30, max_sp: 0, attack: 8,
                                  defense: 4, spirit: 3, agility: 5, exp: 5,
-                                 gold: 10) },
+                                 gold: 10),
+             3 => OpenStruct.new(name: 'Bat', battler_name: 'Bat',
+                                 max_hp: 20, max_sp: 0, attack: 6,
+                                 defense: 2, spirit: 2, agility: 8, exp: 4,
+                                 gold: 8, levitate: true) },
     enemy_group: { 1 => OpenStruct.new(name: 'Slimes', members: {
       1 => OpenStruct.new(enemy_id: 2, x: 100, y: 80, invisible: false),
       2 => OpenStruct.new(enemy_id: 2, x: 200, y: 80, invisible: false) },
-      pages: troop_pages) },
+      pages: troop_pages),
+      2 => OpenStruct.new(name: 'Bats', members: {
+        1 => OpenStruct.new(enemy_id: 3, x: 100, y: 80, invisible: false) },
+        pages: nil) },
     # A drawable battle animation (id 8): four frames, with a screen flash timing
     # on frame 1. (Id 7 is intentionally absent so that test exercises the
     # timed-wait fallback.)
@@ -1649,10 +1659,20 @@ end
 class BattleStubParty
   attr_reader :actors, :gold
   attr_accessor :leader
-  def initialize(actor = BattleStubActor.new); @actors = [actor]; @gold = 0; @leader = nil; end
+  # `rpg2003` stands in for the real `Game::Party#rpg2003?` (`Scene::Map
+  # #flying_offset` reads it off `@state.party`, not the database directly, so
+  # a battle scene check needs its stub party to answer it too) -- false by
+  # default, matching every other check's plain RPG2000 fixture.
+  def initialize(actor = BattleStubActor.new, rpg2003: false)
+    @actors = [actor]
+    @gold = 0
+    @leader = nil
+    @rpg2003 = rpg2003
+  end
   def gain_gold(n); @gold += n; end
   def any_alive?; @actors.any? { |a| !a.dead? }; end
   def all_dead?; !any_alive?; end
+  def rpg2003?; @rpg2003; end
 end
 
 # A party the shop can charge and stock: gold plus an item-count bag, with the
@@ -3810,10 +3830,10 @@ check 'Open Shop scene: leaving without buying runs the No Transaction branch' d
 end
 
 # Battle command / result command lists for the encounter tests below.
-def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil)
+def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil, troop_id: 1)
   handler2 = second_switch_code || ic::ESCAPE_HANDLER
   [
-    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, escape_mode, 1, 0], indent: 0),
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, troop_id, 0, escape_mode, 1, 0], indent: 0),
     ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
     ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
     ECmd.new(handler2, [], indent: 0),
@@ -5999,6 +6019,75 @@ check 'Enemy Encounter scene: a monster that leaves the field is not drawn' do
   ok !sprites[0].visible, 'a monster that fled is taken off the field'
   ok !ui[:foes][0].dead?, 'without counting as a kill'
   ok sprites[1].visible, 'its companion is untouched'
+end
+
+# yado.tk's own text on the "airborne" enemy flag names no pixel offset or
+# animation shape, only that it "changes its Y position on screen" -- but
+# EasyRPG's `Game_Enemy::GetFlyingOffset` supplies both the missing magnitude
+# (+/-4px) and period (256 frames) *and* an edition gate the site never
+# mentions at all: real RPG2000 never renders it ("2k does not support
+# flying, albeit mentioned in the help file" -- their comment), only RPG2003
+# does. Troop 2 (Bats) is the lone-`levitate`-member fixture these exercise;
+# troop 1's two Slimes (neither flagged) are untouched by any of this, which
+# the existing battler-sprite checks above already pin.
+check 'Scene::Map#flying_offset: RPG2003 + levitate is a +/-4px, 256-frame sine bob' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, troop_id: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new(rpg2003: true))
+  ui = battle_to_command(scene)
+  member = ui[:troop].members[0]
+  ok member.levitate, 'the fixture enemy (id 3, Bat) carries the flag'
+
+  ui[:frame] = 0
+  eq 0, scene.send(:flying_offset, member), 'frame 0: sin(0) = 0'
+  ui[:frame] = 64 # a quarter period: sin(pi/2) = 1
+  eq 4, scene.send(:flying_offset, member), 'a quarter period in: the +4px peak'
+  ui[:frame] = 128 # half period: sin(pi) = 0
+  eq 0, scene.send(:flying_offset, member), 'half a period in: back through 0'
+  ui[:frame] = 192 # three-quarter period: sin(3pi/2) = -1
+  eq(-4, scene.send(:flying_offset, member), 'three-quarters in: the -4px trough')
+end
+
+check 'Scene::Map#update_enemy_positions: an RPG2003 fight actually bobs the sprite ' \
+      'as frames pass, an RPG2000 one never does' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, troop_id: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new(rpg2003: true))
+  ui = battle_to_command(scene)
+  spr = ui[:enemy_sprites][0]
+  member = ui[:troop].members[0]
+  base_y = member.y - spr.bitmap.height / 2
+  frame_before = ui[:frame]
+  # Drive to the next quarter-period boundary (a multiple of 64 frames) so the
+  # expected offset is an exact, easily-asserted +4 rather than a fraction.
+  target = ((frame_before / 64.0).ceil + 1) * 64
+  (target - frame_before).times { scene.update }
+  eq target, ui[:frame], 'the per-battle frame counter ticks once per scene.update'
+  eq base_y + 4, spr.y, "the sprite's own y actually moved with it, not just " \
+                        '#flying_offset in isolation'
+
+  # The identical troop and flag, fought with no rpg2003? flag on the party,
+  # never bobs at all -- matching EasyRPG's own edition gate, not merely a
+  # missing test.
+  scene2 = new_scene({ 1 => event(2, 2, auto) })
+  st2 = scene2.instance_variable_get(:@state)
+  st2.instance_variable_set(:@party, BattleStubParty.new(rpg2003: false))
+  ui2 = battle_to_command(scene2)
+  spr2 = ui2[:enemy_sprites][0]
+  member2 = ui2[:troop].members[0]
+  ok member2.levitate, 'still the same flagged enemy row'
+  base_y2 = member2.y - spr2.bitmap.height / 2
+  eq base_y2, spr2.y, 'RPG2000: no bob at battle open'
+  target.times { scene2.update }
+  eq base_y2, spr2.y, 'RPG2000: still no bob after the same number of frames ' \
+                      '-- the database flag is parsed but the engine never ' \
+                      'draws it, a real RPG_RT quirk, not a missing feature'
 end
 
 # -- headless title auto-select (--rpg2k_new_game / --rpg2k_continue) ---------


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "airborne" enemy display flag bullet (`2000/デフォ戦/デフォ戦botまとめ`) was marked "still open" — the monster schema's `levitate` field (LCF enemy field 28) is parsed by `mruby-lcf/mrblib/schema.rb` but was read nowhere in `mruby-rpg2k`. The old prior note said implementing it would mean "guessing a magnitude with no way to check it" since the fan-wiki sources were unreachable.
- Verified against EasyRPG Player's actual C++ source: `Game_Enemy::GetFlyingOffset` (`src/game_enemy.cpp`) is gated `if (!Player::IsRPG2k3() || !IsFlying()) return 0;` — comment: "2k does not support flying, albeit mentioned in the help file." Real RPG2000 never renders the effect at all; RPG2003 draws a `round(sin(2*PI*frame/256) * 4)` sine bob. Neither the edition gate, the ±4px amplitude, nor the 256-frame period was previously known to this codebase.
- Added `Game::Enemy#levitate`; `Scene::Map#flying_offset`/`#battler_y` (gated on `db.rpg2003?` and the enemy's own flag) used at all three enemy-sprite-placement sites; a per-fight frame counter driven by a new `#update_enemy_positions`, called alongside the existing `#update_enemy_flashes`.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 411 checks pass (2 new: `#flying_offset` at the sine curve's four quarter-period landmarks; an end-to-end drive confirming the sprite's actual y moves under RPG2003 but never bobs under plain RPG2000 with the identical flagged troop — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_