### PR TITLE
rpg2k: Proceed With Movement now blocks a Parallel Process too

### DIFF
--- a/changelog.d/parallel-process-proceed-with-movement.fixed.md
+++ b/changelog.d/parallel-process-proceed-with-movement.fixed.md
@@ -1,0 +1,12 @@
+- **A Parallel Process's own "Proceed With Movement" (wait for completion on
+  a forced move route) now actually blocks that process.** `Scene::Map#
+  drive_parallel_wait` had no `:movement` case in its wait-kind dispatch —
+  only the foreground's own `#drive_event` did — so a Common Event or Map
+  Event Parallel Process issuing the identical command fell into the generic
+  "background: ignore message/choice/teleport requests" resume branch and
+  read it as a fire-and-forget no-op regardless of "wait for completion",
+  including the documented permanently-impassable/hidden-target freeze. Fixed
+  by adding a `:movement` case that resumes only once `#forced_movement_done?`
+  reports every targeted route finished, the same predicate the foreground
+  path already relies on. Covered by a new `scripts/rpg2k_scene_check.rb`
+  check, confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2503,9 +2503,50 @@ following this paragraph as the original record.
 - `017_heiretu_totyu_end/hei_mukou.htm` — (a) a Parallel Process's appearance
   condition going false mid-execution isn't observed until the process
   naturally hits a Wait/yield point, not instantly (may already follow from
-  how `step_parallel` is structured — unverified); (b) Set Move Route +
-  "wait for completion" targeting a permanently-impassable tile without
-  "Ignore if can't move" stalls a parallel process forever.
+  how `step_parallel` is structured — unverified). ✅ (b) **Set Move Route +
+  "wait for completion" (Proceed With Movement) issued from a Parallel
+  Process now actually blocks that process**, instead of the command reading
+  as a fire-and-forget no-op regardless of "wait for completion" — including
+  the documented permanently-impassable/hidden-event freeze. This was a real,
+  reachable gap broader than the one case this bullet names: `Scene::Map#
+  drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`), the dispatch
+  `#step_parallel` uses for whichever wait kind a parallel-process interpreter
+  is parked on, had cases for `:wait`/`:key_input`/`:animation`/`:game_over`
+  but none for `:movement` — the wait kind `Game::Interpreter#
+  do_proceed_with_movement` (`mruby-rpg2k/mrblib/interpreter.rb`) sets — so it
+  fell into the generic `else` branch (`it.resume # background: ignore
+  message/choice/teleport requests`) and resumed unconditionally on the very
+  next tick, never consulting `#forced_movement_done?` at all. The
+  foreground's own `#drive_event` already had the matching case (`when
+  :movement then @interpreter.resume if step_forced_movement`), so an
+  Autorun's Proceed With Movement always blocked correctly; only a Parallel
+  Process's own use of the identical command was affected. Fixed by adding a
+  `:movement` case to `#drive_parallel_wait` that resumes only once `#
+  forced_movement_done?` answers true — deliberately calling that pure
+  predicate rather than `#step_forced_movement` (which actually advances
+  every pending route): the routes are already stepped exactly once per frame
+  elsewhere, either by the ordinary `#step_events`/`#step_player_route`/`#
+  step_vehicle_routes` pass in `#update`'s not-busy branch (the common case,
+  since a Parallel Process runs independently of the foreground) or by the
+  foreground's own `#step_forced_movement` call when it happens to be parked
+  on `:message`/`:wait`/`:movement` itself — calling it a second time here
+  would double-advance every forced route on any frame both a parallel
+  process and the foreground are waiting on movement at once. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (a Common Event Parallel Process's
+  Move Event + Proceed With Movement holds its own `CONTROL_SWITCHES`
+  follow-up command until the forced 3-tile route actually lands, not on the
+  next tick), confirmed to fail against the pre-fix code before the fix (the
+  unfixed build overshot the route's own endpoint within 10 frames, since the
+  unblocked interpreter kept re-looping the Parallel Process's command list
+  and re-issuing fresh Move Event routes on top of the still-running one —
+  worse than a single early resume). The stuck-forever half of the original
+  claim (a permanently-impassable or hidden target) is exercised by the same
+  fix, since `#forced_movement_done?` is the identical predicate the
+  already-fixed foreground "Set Move Route targeting a currently-hidden map
+  event freezes Proceed With Movement" check (`docs/TODO.md`'s `015_shujinkou_idou_huka`
+  entry above) relies on — no separate `@stuck_move_targets` handling was
+  needed for the parallel-process case. Part (a) of this same bullet remains
+  open.
 - `015_shujinkou_idou_huka/` — catalogue of hero-can't-move causes; most
   already covered by existing passability/move-route logic. ✅ **"Force Move
   All" targeting a currently-hidden (appearance-conditions-unmet) map event

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1230,6 +1230,31 @@ class RPG2k
           # silently cleared the wait and let the process carry on with a
           # fully-dead party never reaching the Game Over screen.
           perform_game_over(it)
+        elsif it.wait_kind == :movement
+          # Proceed With Movement / Force Complete Move issued from a
+          # Parallel Process: block that process until every targeted
+          # character's forced route has actually finished, the same as
+          # #drive_event's own :movement branch does for the foreground --
+          # docs/TODO.md ("Move All / Force Complete Move ... blocks Event
+          # Content at that command until every targeted character's route
+          # finishes"), which used to apply to a foreground Autorun only.
+          # Before this branch existed this fell into the generic #resume
+          # below too, so the command never actually blocked anything issued
+          # from a parallel process -- it read as a fire-and-forget request
+          # regardless of "wait for completion", and a target stuck forever
+          # (e.g. hidden map event, see the sibling foreground check) never
+          # froze the process the way real RPG_RT does.
+          #
+          # Deliberately calls #forced_movement_done? rather than
+          # #step_forced_movement: the routes themselves are already stepped
+          # exactly once this frame elsewhere -- by the ordinary #step_events
+          # pass in #update's not-busy branch when the foreground is idle, or
+          # by the foreground's own #step_forced_movement call when it is
+          # itself parked on :message/:wait/:movement -- so stepping them
+          # again here would double-advance every forced route on any frame
+          # both a parallel process and the foreground happen to be waiting
+          # on movement at once.
+          it.resume if forced_movement_done?
         else
           it.resume # background: ignore message/choice/teleport requests
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3199,6 +3199,45 @@ check "Proceed With Movement also waits on a vehicle's forced route" do
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
+check "Proceed With Movement blocks a Parallel Process's own interpreter, not just the foreground's" do
+  # docs/TODO.md, `2k/09_bug/017_heiretu_totyu_end/hei_mukou.htm`: Set Move
+  # Route + "wait for completion" is documented to block whichever event's
+  # own Event Content issued it until every targeted character's route
+  # finishes -- the same rule already covered above for a foreground
+  # Autorun's own Proceed With Movement, but #drive_parallel_wait had no
+  # :movement case at all, so a Common Event Parallel Process issuing the
+  # identical command fell into the generic "background: ignore message/
+  # choice/teleport requests" #resume branch instead and read it as a plain
+  # fire-and-forget no-op regardless of "wait for completion".
+  ic = Game::Interpreter::Cmd
+  # Gated on switch 2, which the process itself turns off right after Proceed
+  # With Movement resumes -- otherwise a Parallel Process loops its command
+  # list forever by design, and a second lap's own Move Event would replace
+  # the still-settling forced route with a fresh one before the 200-frame
+  # budget below could tell "resumed on time" apart from "resumed early".
+  ce = OpenStruct.new(start_term: 4, need_flag: true, switch_id: 2,
+                      event: [
+                        ECmd.new(ic::MOVE_EVENT,
+                                 [2, 4, 0, 0, R::MOVE_RIGHT, R::MOVE_RIGHT, R::MOVE_RIGHT]),
+                        ECmd.new(ic::PROCEED_WITH_MOVEMENT, []),
+                        ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 1]), # gate off: one lap only
+                        ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+                      ])
+  scene = new_scene({ 2 => event(0, 1, page) }, common: { 1 => ce }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  st.switches[2] = true
+  c = chars(scene)[2]
+
+  10.times { scene.update } # mid-route: still moving, switch not yet flipped
+  ok c.x < 3, "route still in progress, at x=#{c.x}"
+  ok !st.switches[1],
+     'Proceed With Movement issued by a Parallel Process must wait too, not resume immediately'
+
+  200.times { scene.update } # enough frames for the freq-4 route to finish
+  eq 3, c.x, 'the forced event reached the end of its route'
+  ok st.switches[1], 'the Parallel Process resumed once the route actually finished'
+end
+
 check "a forced route auto-runs to completion before an immediately-following Show Text opens (yado.tk)" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s `2k/09_bug/017_heiretu_totyu_end/hei_mukou.htm` bullet flagged: Set Move Route + "wait for completion" (Proceed With Movement) targeting a permanently-impassable tile without "Ignore if can't move" stalls a Parallel Process forever. Unverified.
- Verified against the code: `Scene::Map#drive_parallel_wait` (the wait-kind dispatch `#step_parallel` uses for a parallel-process interpreter) had cases for `:wait`/`:key_input`/`:animation`/`:game_over` but none for `:movement` — the wait kind `Game::Interpreter#do_proceed_with_movement` sets — so it fell into the generic `else` branch (`it.resume # background: ignore message/choice/teleport requests`) and resumed unconditionally on the very next tick. The foreground's own `#drive_event` already had the matching case (`when :movement then @interpreter.resume if step_forced_movement`), so only a Parallel Process's own use of the identical command was affected.
- The actual gap is broader than the doc's own framing: it's not just the stuck-forever edge case, it's that Proceed With Movement issued from a Parallel Process never blocked *at all* — it read as a fire-and-forget no-op regardless of "wait for completion", every time.
- Fixed by adding a `:movement` case to `#drive_parallel_wait` that resumes only once `#forced_movement_done?` reports every targeted route finished. Deliberately calls that pure predicate rather than `#step_forced_movement` (which actually advances routes): the routes are already stepped exactly once per frame elsewhere (the ordinary `#step_events`/`#step_player_route`/`#step_vehicle_routes` pass when the foreground is idle, or the foreground's own `#step_forced_movement` call when it's parked on a matching wait itself) — stepping them again here would double-advance every forced route on any frame both a parallel process and the foreground happen to be waiting on movement at once.
- `docs/TODO.md` updated ✅ with the citation; part (a) of the same bullet (appearance-condition timing) remains open.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 410 checks pass (1 new: a Common Event Parallel Process's Move Event + Proceed With Movement holds its own follow-up command until the forced 3-tile route actually lands, not on the next tick — confirmed to fail against the pre-fix code, which overshot the route's own endpoint within 10 frames since the unblocked interpreter kept re-looping the process and re-issuing fresh routes on top of the still-running one)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ny6386exXf1xKLWMsyDyh)_