### PR TITLE
rpg2k: a Show Battle Animation caps a concurrent Character Flash to the current frame too

### DIFF
--- a/changelog.d/battle-animation-character-flash-cap.fixed.md
+++ b/changelog.d/battle-animation-character-flash-cap.fixed.md
@@ -1,0 +1,18 @@
+- A Character Flash (Flash Sprite, 11320) concurrent with a Battle Animation
+  targeting the same character/enemy is now capped to the current frame the
+  same way a concurrent Screen Flash already was, matching real RPG_RT:
+  verified against EasyRPG Player's `BattleAnimation::Update`
+  (`src/battle_animation.cpp`), which calls `UpdateTargetFlash()`
+  unconditionally on every real frame right alongside `UpdateScreenFlash()`,
+  and always ends in an unconditional `FlashTargets(r, g, b, p)` —
+  `BattleAnimationMap`/`BattleAnimationBattle`'s own `target->Flash(...)` /
+  `battler->Flash(...)` — silently overwriting any other in-flight flash on
+  that same target every real frame. `Scene::Map#step_map_animation`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) now does the same via a new
+  `#hold_animation_target_flash`, called every real frame the animation
+  drives (mirroring `#hold_animation_screen_flash`) rather than only on the
+  throttled ticks that carry their own flash_scope-1 timing — covering both
+  the battle-round path (an enemy sprite's flash, via a new
+  `#clear_target_flash`) and the map-triggered path (`@player_flash` / an
+  `@events` entry's own `[:flash]`, via a new `#clear_map_target_flash`),
+  scoped to just the animation's own target rather than the whole screen.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3612,16 +3612,59 @@ not yet verified:
   undisturbed for that window, and forcibly zeroes the screen flash
   (`@state.screen.flash(0, 0, 0, 0, 0)`) every real frame outside it —
   reproducing `FlashOnce(0,0,0,0,0)`'s own "nothing fired yet/lapsed" case.
-  Scoped to Screen Flash only: **Character Flash is a structurally different
-  mechanism in this codebase** (the decaying `{red:, green:, blue:, power:,
-  frames:, total:}` hash `#apply_sprite_flash`/`#update_sprite_flashes` drive
-  per-target, vs. `Game::Screen`'s own single flash state) and would need its
-  own, separate per-real-frame reassertion — left open. Covered by a new
-  `scripts/rpg2k_scene_check.rb` check (a Flash Screen command fired with a
-  120-frame duration right before a Show Battle Animation whose own frame 0
-  carries no timing at all gets stomped to not-flashing during those
-  timing-less opening frames, well short of its own configured duration),
-  confirmed to fail against the pre-fix code before the fix.
+  Scoped to Screen Flash only at the time: **Character Flash is a
+  structurally different mechanism in this codebase** (the decaying `{red:,
+  green:, blue:, power:, frames:, total:}` hash `#apply_sprite_flash`/
+  `#update_sprite_flashes` drive per-target, vs. `Game::Screen`'s own single
+  flash state) and needed its own, separate per-real-frame reassertion — left
+  open at the time. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+  Flash Screen command fired with a 120-frame duration right before a Show
+  Battle Animation whose own frame 0 carries no timing at all gets stomped to
+  not-flashing during those timing-less opening frames, well short of its own
+  configured duration), confirmed to fail against the pre-fix code before the
+  fix. ✅ **The Character Flash half is now fixed too, verified against the
+  same EasyRPG C++ source's exact parallel structure.**
+  `BattleAnimation::Update` calls `UpdateTargetFlash()` unconditionally on
+  every real frame right alongside `UpdateScreenFlash()` — not gated on that
+  frame carrying its own flash_scope-1 timing either — and `UpdateTargetFlash`
+  always ends in an unconditional `FlashTargets(r, g, b, p)`:
+  `BattleAnimationMap::FlashTargets` (`target->Flash(r, g, b, p, 0)`, the
+  map-triggered shape) and `BattleAnimationBattle::FlashTargets`
+  (`battler->Flash(r, g, b, p, 0)`, the battle-round shape — the two classes
+  this codebase's own `#fire_map_target_flash`/`#fire_target_flash` already
+  mirror) are both unconditional the exact same way `Game_Screen::FlashOnce`
+  is, with r/g/b/p either the most recently fired flash_scope-1 timing's own
+  decaying value or all zero — so an unrelated Character Flash already
+  running on an animation's own target (a Flash Sprite command mid-decay on
+  the player/a map event, or an enemy's own in-flight flash from an earlier
+  battle-round hit) got silently overwritten the very next real frame too,
+  the same uncapped gap `#hold_animation_screen_flash` closed for the screen.
+  Fixed with a new `#hold_animation_target_flash`, called from
+  `#step_map_animation` alongside `#hold_animation_screen_flash` on every real
+  frame the animation drives: a new `ma[:target_flash_hold]` counter (set to
+  `ANIM_FLASH_FRAMES` by `#fire_animation_flashes` whenever a flash_scope-1
+  timing actually fires, mirroring `ma[:screen_flash_hold]` exactly) lets the
+  animation's own just-fired target flash decay undisturbed for that window,
+  and forcibly clears the target's flash every real frame outside it — a new
+  `#clear_target_flash` (`spr.flash(nil, 0)` on the battle-round path's own
+  `@battle_ui[:enemy_sprites]` entry, the same RGSS `Sprite#flash` primitive
+  `#fire_target_flash` already arms) or `#clear_map_target_flash`
+  (`@player_flash = nil` / an `@events` entry's own `[:flash] = nil`, the same
+  "no flash in flight" state `#tick_flash`'s own decay already leaves behind)
+  depending on `ma[:battle]`. Unlike the screen-flash half, this is scoped to
+  just the animation's own target — a Character Flash on a *different*
+  character is untouched, matching `FlashTargets`' own target-list scope; a
+  nil target (an ally-scoped battle animation with no on-screen sprite, or a
+  map animation aimed at a vehicle/unresolved event id) is a silent no-op on
+  both sides, mirroring `#fire_target_flash`/`#fire_map_target_flash`'s own
+  missing-target guards. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a Flash Sprite fired on the player right before a Show Battle
+  Animation targeting the player, using the same screen-flash-only fixture
+  animation with no flash_scope-1 timing at all, gets stomped to nothing
+  during its own timing-less opening frames; a battle-round check directly
+  arming both a targeted enemy sprite's and a bystander enemy sprite's flash,
+  confirming `#hold_animation_target_flash` clears only the targeted one),
+  both confirmed to fail against the pre-fix code before the fix.
 - Change Screen Tone affects **only** the map tile+character layer —
   pictures, screen/character flash, battle animations, and message text
   are all completely unaffected even at a maximal dark tone; Erase Screen,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5582,6 +5582,7 @@ class RPG2k
         if ma[:timer] > 0
           ma[:timer] -= 1
           hold_animation_screen_flash(ma)
+          hold_animation_target_flash(ma)
           return
         end
         ma[:frame_i] += 1
@@ -5602,6 +5603,7 @@ class RPG2k
         fire_animation_flashes(ma)
         ma[:timer] = ANIM_CELL_FRAMES
         hold_animation_screen_flash(ma)
+        hold_animation_target_flash(ma)
       end
 
       # yado.tk: Screen Flash / Character Flash are both capped to 1/30s of
@@ -5639,6 +5641,73 @@ class RPG2k
           ma[:screen_flash_hold] = hold - 1
         else
           @state.screen.flash(0, 0, 0, 0, 0)
+        end
+      end
+
+      # yado.tk's own "Character Flash" half of the same claim, capped the same
+      # way and for the same reason -- corroborated independently against
+      # EasyRPG's own C++ source right alongside #hold_animation_screen_flash's:
+      # `BattleAnimation::Update` calls `UpdateTargetFlash()` unconditionally on
+      # *every* real frame, right next to its `UpdateScreenFlash()` call
+      # (`src/battle_animation.cpp`), and `UpdateTargetFlash` always ends in
+      # `FlashTargets(r, g, b, p)` -- `BattleAnimationMap::FlashTargets`
+      # (`target->Flash(r, g, b, p, 0)`) and `BattleAnimationBattle::FlashTargets`
+      # (`battler->Flash(r, g, b, p, 0)`, the two map/battle-round shapes this
+      # codebase's own #fire_map_target_flash/#fire_target_flash mirror) are
+      # both unconditional the exact same way `Game_Screen::FlashOnce` is, with
+      # r/g/b/p either the most recently fired flash_scope-1 timing's own
+      # decaying value or all zero. So an unrelated Character Flash already
+      # running on this animation's own target -- a Flash Sprite (11320)
+      # command mid-decay on the player/a map event, or an enemy's own
+      # in-flight flash from an earlier battle-round hit -- gets silently
+      # overwritten the very next real frame too, regardless of its own
+      # configured duration, for as long as the animation is on screen.
+      # `ma[:target_flash_hold]` mirrors `ma[:screen_flash_hold]` exactly (set
+      # to ANIM_FLASH_FRAMES by #fire_animation_flashes whenever a flash_scope-1
+      # timing actually fires, ticking down here); once it lapses, the
+      # animation's own target is forcibly cleared again every real frame,
+      # capping any concurrent, unrelated flash on that same target to at most
+      # the one frame between two calls here. Scoped to just the animation's
+      # own target (#clear_target_flash / #clear_map_target_flash), unlike the
+      # screen-flash half -- a Character Flash on a *different* character is
+      # untouched, matching `FlashTargets`' own target-list scope.
+      def hold_animation_target_flash(ma)
+        hold = ma[:target_flash_hold]
+        if hold && hold > 0
+          ma[:target_flash_hold] = hold - 1
+        else
+          ma[:battle] ? clear_target_flash(ma[:target_index]) : clear_map_target_flash(ma[:flash_target])
+        end
+      end
+
+      # The battle-round half of #hold_animation_target_flash's forced clear:
+      # the same RGSS Sprite#flash primitive #fire_target_flash arms a flash
+      # with, called with a zero duration (flash_count 0 reads as "not
+      # flashing," mruby-rgss/src/lib.cxx's own spr_flash/spr_update) to drop
+      # whatever flash -- this animation's own decayed-away one, or an
+      # unrelated one -- is currently in flight on that enemy sprite. A nil
+      # target_index (an ally-scoped animation, no on-screen sprite) or a
+      # missing @battle_ui (the animation already finished/the fight already
+      # ended) is a silent no-op, matching #fire_target_flash's own guard.
+      def clear_target_flash(target_index)
+        sprites = @battle_ui && @battle_ui[:enemy_sprites]
+        spr = target_index && sprites ? sprites[target_index] : nil
+        spr.flash(nil, 0) if spr
+      end
+
+      # The map-triggered half: drop @player_flash / an @events entry's own
+      # [:flash] back to nil, the same "no flash in flight" state #tick_flash's
+      # own decay already leaves behind, mirroring #fire_map_target_flash's own
+      # arm call. A nil target (a vehicle, or an id no live event matches --
+      # see #map_animation_flash_target) is a no-op, since there is nothing to
+      # clear.
+      def clear_map_target_flash(target)
+        return if target.nil?
+        if target == :player
+          @last_frame = nil if @player_flash
+          @player_flash = nil
+        else
+          target[:flash] = nil
         end
       end
 
@@ -5783,6 +5852,11 @@ class RPG2k
             ma[:screen_flash_hold] = ANIM_FLASH_FRAMES
           when 1
             ma[:battle] ? fire_target_flash(ma[:target_index], t) : fire_map_target_flash(ma[:flash_target], t)
+            # #hold_animation_target_flash keeps re-asserting this fire (and,
+            # once it lapses, forcibly clearing the target's flash outright)
+            # every real frame, the exact same shape as #ma[:screen_flash_hold]
+            # just above.
+            ma[:target_flash_hold] = ANIM_FLASH_FRAMES
           end
         end
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4937,6 +4937,47 @@ check 'A Screen Flash concurrent with a Show Battle Animation is capped to the c
   ok st.switches[6], 'the event resumed after the animation'
 end
 
+# yado.tk's own "Character Flash" half of the same claim, capped the same way
+# and for the same reason (corroborated independently against EasyRPG's own
+# C++ source, see #hold_animation_target_flash's comment):
+# `BattleAnimation::Update` calls `UpdateTargetFlash()` unconditionally right
+# alongside `UpdateScreenFlash()` on every real frame, and it always ends in
+# an unconditional `FlashTargets(r, g, b, p)` the same way `FlashOnce` is for
+# the screen. Fired here with a Flash Sprite (11320) on the player (wait off,
+# so the event moves straight on to the animation instead of blocking on the
+# flash's own long duration), then animation 8 -- the screen-flash-only
+# fixture, no flash_scope-1 timing at all -- targeting the player: its own
+# timing-less opening frames must stomp the unrelated Character Flash to
+# nothing the same way they already do the unrelated Screen Flash above.
+check 'A Character Flash concurrent with a Show Battle Animation targeting the same character is capped ' \
+      'to the current frame' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::FLASH_SPRITE, [10001, 31, 0, 0, 31, 20, 0], indent: 0), # player, r g b power, 2s, wait=0
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),            # animation 8, player, wait=1
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  stomped_at_frame_0 = false
+  saw_the_flash_at_all = false
+  40.times do
+    scene.update
+    pf = scene.instance_variable_get(:@player_flash)
+    saw_the_flash_at_all ||= !pf.nil?
+    anim = scene.instance_variable_get(:@map_animation)
+    stomped_at_frame_0 ||= (anim && anim[:frame_i] == 0 &&
+                            scene.instance_variable_get(:@player_flash).nil?)
+    break if st.switches[6]
+  end
+  ok saw_the_flash_at_all, 'the independently-fired Flash Sprite command did take effect at some point'
+  ok stomped_at_frame_0, "the battle animation's own per-frame state stomps the unrelated Character Flash " \
+                         "to nothing during its own timing-less opening frames, capping it well short of " \
+                         'its own configured 120-frame duration'
+  ok st.switches[6], 'the event resumed after the animation'
+end
+
 # yado.tk: Show Battle Animation targeting a Vehicle position reads that
 # vehicle's real, currently-live x/y (the same source the Control Variables
 # vehicle-position fix reads), not the player's or the triggering event's own
@@ -7133,6 +7174,28 @@ check 'a target-scope flash with no resolvable target sprite is a silent no-op' 
   ma = { frame_i: 0, battle: true, target_index: nil, timings: [timing] }
   scene.send(:fire_animation_flashes, ma) # must not raise
   ok true, 'no exception targeting nothing'
+end
+
+# The battle-round half of the Character Flash cap (see the map-triggered
+# check above and #hold_animation_target_flash's own comment): an unrelated
+# flash already in flight on an animation's own target enemy -- simulating an
+# earlier hit's own target-scope timing still decaying when a second, later
+# animation with no flash_scope-1 timing of its own starts playing over the
+# same enemy -- gets forcibly cleared the moment #hold_animation_target_flash
+# runs with nothing of its own to hold, mirroring #hold_animation_screen_flash
+# exactly but scoped to just this one sprite: the untargeted bystander is left
+# alone.
+check 'a Character Flash concurrent with a battle-round animation on the same enemy is capped, a bystander is not' do
+  scene, ui = battle_at_command
+  spr = ui[:enemy_sprites][0]
+  bystander = ui[:enemy_sprites][1]
+  spr.flash(Color.new(200, 0, 0, 200), 60)
+  bystander.flash(Color.new(0, 200, 0, 200), 60)
+  ok spr.flash_color && bystander.flash_color, 'both unrelated flashes are in flight to start with'
+  ma = { frame_i: 0, battle: true, target_index: 0, timings: [] } # no target_flash_hold armed
+  scene.send(:hold_animation_target_flash, ma)
+  eq nil, spr.flash_color, "the animation's own target sprite had its unrelated flash stomped to nothing"
+  ok bystander.flash_color, 'the untargeted bystander sprite is untouched'
 end
 
 check 'a skill that names none plays nothing' do


### PR DESCRIPTION
## Summary
- Completes the Character Flash half of `docs/TODO.md`'s "Screen effects" bullet — the Screen Flash half was already fixed in #633, which left Character Flash open ("a structurally different mechanism... would need its own, separate per-real-frame reassertion").
- Verified against EasyRPG Player's actual source (`src/battle_animation.cpp`): `BattleAnimation::Update` calls `UpdateTargetFlash()` unconditionally every real frame, right next to `UpdateScreenFlash()` — always ending in an unconditional `FlashTargets(r, g, b, p)` on the animation's own target, just as unconditional as `Game_Screen::FlashOnce` was for the already-fixed screen half.
- `Scene::Map#step_map_animation` only touched a target's Character Flash on throttled ticks carrying their own flash_scope-1 timing — an unrelated, independently-decaying Character Flash on that same target (a Flash Sprite command mid-decay, or an enemy's flash from an earlier hit) played out its full duration untouched instead of being capped.
- Added `#hold_animation_target_flash`, called from `#step_map_animation` on every real frame alongside the existing `#hold_animation_screen_flash`, plus `#clear_target_flash` (battle-round path) / `#clear_map_target_flash` (map path), scoped to just the animation's own target rather than the whole screen.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 415 checks pass (2 new: a Character Flash concurrent with a Show Battle Animation targeting the same character is capped to the current frame (map path); a Character Flash concurrent with a battle-round animation on the same enemy is capped, a bystander is not (battle path) — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_