### PR TITLE
Fix battle freezing forever with an empty or all-KO'd party

### DIFF
--- a/changelog.d/battle-empty-or-koed-party-instant-defeat.fixed.md
+++ b/changelog.d/battle-empty-or-koed-party-instant-defeat.fixed.md
@@ -1,0 +1,18 @@
+- **Entering a battle with no living party member (an emptied party, or one
+  left fully KO'd) now settles as an instant defeat**, instead of freezing
+  the fight open on a blank command menu forever. `Scene::Map
+  #draw_battle_command`'s `current_actor` already resolved to `nil` for
+  either case and quietly declined to draw a command window (`return unless
+  actor`), but nothing then advanced the fight — a round only ever starts
+  once the player picks a command via that window — so `#open_battle` left
+  the encounter stuck in its `:command` phase indefinitely rather than
+  reaching the `Game::Battle#finished?` check every other round already
+  settles through. Fixed with a new `#settle_already_finished_battle`,
+  called from `#open_battle` right after Turn-0 battle-event pages get their
+  chance to run: when `Game::Battle#finished?` already reads true (no living
+  ally), it calls `Game::Battle#end_round` to compute the result and drives
+  the scene straight to the defeat result screen the same way an ordinary
+  round's own wipeout would. `#finish_battle`'s existing `all_dead?` check
+  (which already reads an empty actor list as "all dead") then turns that
+  into a genuine Game Over once the result screen is dismissed, unaffected
+  by this fix — it only needed to be reachable in the first place.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4275,9 +4275,41 @@ not yet verified:
   silent no-op. Removing a member preserves equipment/level/EXP/HP/status;
   re-adding a KO'd member keeps them KO'd. Only the party **leader's**
   sprite is ever drawn on the field, regardless of party size.
-- Empty party doesn't itself Game Over, but battling with one is instant
-  defeat; all-KO'd (or an unrecoverable input-blocking state across the
-  whole party) is instant Game Over the same way.
+- ✅ **Empty party doesn't itself Game Over, but battling with one is instant
+  defeat; an all-KO'd party reads as an instant defeat the same way.** (An
+  unrecoverable input-blocking *state* lock — every member asleep/paralysed
+  at once, rather than HP 0 — is a separate, still-open case; nothing here
+  addresses it.) `Scene::Map#draw_battle_command`'s `current_actor`
+  (`living_allies[@battle_ui[:actor_i]]`) already resolved to `nil` for both
+  an empty party and an all-KO'd one (`living_allies` rejects `dead?`), so it
+  already declined to open a command window rather than crash (`return
+  unless actor`) — but nothing then moved the fight along: a round only ever
+  starts once the player picks a command for *some* actor via the command
+  window, so `#open_battle` left the command phase frozen forever, with no
+  window and no input to act on, instead of ever reaching the
+  `battle.finished?` check `#finish_round_animation`/`#leave_battle_event_phase`
+  already run after every other round. Fixed with a new
+  `#settle_already_finished_battle`, called from `#open_battle` right after
+  the Turn-0 battle-event pages get their chance to run (unchanged) and
+  before the command window would otherwise be drawn: it checks
+  `Game::Battle#finished?` (already true the instant the battle is
+  constructed with no living ally, via the same `alive?(@allies)` empty-`any?`
+  check `#finished?` uses everywhere else) and, if so, calls
+  `Game::Battle#end_round` — the same method that already computes `#result`
+  (`alive?(@allies) ? :victory : :defeat`) at the end of an ordinary round,
+  and is safe to call with nothing queued (`@allies.each` no-ops on an empty
+  or fully-KO'd roster) — then `#enter_battle_result(battle.result)`, the
+  same path a real round's own defeat takes into the result screen.
+  `#finish_battle`'s own existing `@state.party.all_dead?` check (`!any_alive?`,
+  which reads an *empty* actor list as "all dead" too, via `Array#any?`'s
+  empty-is-false rule) already turns that defeat into a genuine Game Over
+  once the result screen is dismissed when the encounter has no custom
+  [Defeat] handler — unaffected by this fix, it only needed to be reachable
+  in the first place. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (an empty-actors party and a single HP-0 actor party both settle a
+  fresh encounter straight to a `:defeat` result instead of stalling in
+  `:command`), both confirmed to fail against the pre-fix code (the battle
+  staying open in `:command` forever) before the fix.
 - "Hero X is in the party" always evaluates in **database ID order**, not
   current seat/slot order — there is no built-in way to read a member's
   current seat position.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3478,7 +3478,34 @@ class RPG2k
         refresh_battle_status
         # Turn-0 pages fire before the party is asked for its first command —
         # this is where a troop's opening dialogue lives.
-        draw_battle_command unless run_battle_events
+        return if run_battle_events
+        settle_already_finished_battle || draw_battle_command
+      end
+
+      # An encounter can start already decided — an empty party (every member
+      # removed via Change Party Member) or one left all-KO'd from a prior
+      # fight, with no revive in between, both read as no living ally at all.
+      # `#draw_battle_command`'s `current_actor` (`living_allies[actor_i]`) is
+      # nil either way, so it already declines to open a command window
+      # (`return unless actor`) rather than crash — but nothing then moved the
+      # battle on, since a round only ever starts once the player picks a
+      # command for *some* actor. The command phase sat frozen forever, never
+      # reaching the `battle.finished?` check `#finish_round_animation`/
+      # `#leave_battle_event_phase` run after every other round, instead of
+      # yado.tk's documented "battling with an empty party is instant defeat"
+      # (worded the same way for an all-KO'd one). `Game::Battle#end_round`
+      # is what actually computes `#result` (`alive?(@allies) ? :victory :
+      # :defeat`); calling it here settles the same way an ordinary round
+      # ending would, with nothing to clear (`@allies.each` no-ops on an empty
+      # or already-KO'd roster). Returns whether it fired, so `#open_battle`
+      # only falls back to the normal command window when there is actually
+      # someone to command.
+      def settle_already_finished_battle
+        battle = @battle_ui[:battle]
+        return false unless battle.finished?
+        battle.end_round
+        enter_battle_result(battle.result)
+        true
       end
 
       # A troop member's sprite depth for its add-order index `i` (0-based).

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6649,6 +6649,43 @@ def battle_scene_with_pages(pages)
   [scene, st]
 end
 
+# yado.tk / 01_shoshin's 011_siyou: "Empty party doesn't itself Game Over, but
+# battling with one is instant defeat; all-KO'd ... is instant Game Over the
+# same way." #draw_battle_command's current_actor (living_allies[actor_i]) is
+# nil for both an empty party and an all-KO'd one -- it already declines to
+# open a command window rather than crash (`return unless actor`) -- but
+# nothing then advanced the battle: a round only ever starts once the player
+# picks a command for *someone*, so the command phase sat frozen forever
+# (never reaching the `battle.finished?` check every other round settles
+# through) instead of resolving as a defeat.
+check 'entering a battle with an empty party is instant defeat, not a frozen command menu' do
+  scene, st = battle_scene_with_pages({})
+  st.party.instance_variable_set(:@actors, [])
+  12.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :result
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui, 'the battle is open'
+  eq :result, ui[:phase], 'no living ally settles the fight immediately instead of stalling in :command'
+  eq :defeat, ui[:result], 'an empty party reads the same as a wipeout'
+end
+
+check 'entering a battle with an all-KO\'d party is instant defeat too' do
+  scene, st = battle_scene_with_pages({})
+  st.party.instance_variable_set(:@actors, [BattleStubActor.new(hp: 0)])
+  12.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :result
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui, 'the battle is open'
+  eq :result, ui[:phase], 'no living ally settles the fight immediately instead of stalling in :command'
+  eq :defeat, ui[:result]
+end
+
 check 'a turn-0 battle-event page runs as the fight opens' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::CONTROL_SWITCHES, [0, 12, 12, 0])]) }


### PR DESCRIPTION
## Summary
- yado.tk (`01_shoshin/011_siyou`, "Party / Actor / Vehicle") documents: "Empty party doesn't itself Game Over, but battling with one is instant defeat; all-KO'd ... is instant Game Over the same way." This build had a real gap: `Scene::Map#draw_battle_command`'s `current_actor` already resolved to `nil` for an empty or fully-KO'd party and quietly declined to draw a command window (`return unless actor`) — but nothing then advanced the fight, since a round only ever starts once the player picks a command through that window. `#open_battle` left the encounter frozen in its `:command` phase forever instead of ever reaching the `Game::Battle#finished?` check every other round already settles through.
- Fixed with a new `Scene::Map#settle_already_finished_battle`, called from `#open_battle` right after Turn-0 battle-event pages get their chance to run: when `Game::Battle#finished?` is already true (no living ally — `alive?(@allies)`'s empty-`any?` case), it calls `Game::Battle#end_round` (the same method an ordinary round's own wipeout uses to compute `#result`, safe on an empty/all-dead roster since `@allies.each` no-ops) and resolves straight to the defeat result screen via `#enter_battle_result`.
- `#finish_battle`'s existing `@state.party.all_dead?` check (which already reads an empty actor list as "all dead," via `Array#any?`'s empty-is-false rule) already turns that into a genuine Game Over once the result screen is dismissed for an encounter with no custom `[Defeat]` handler — unaffected by this fix, it only needed to be reachable in the first place.
- Updated `docs/TODO.md` to mark the claim ✅ with the fuller writeup, and added a `changelog.d/` fragment.

## Test plan
- Added two `scripts/rpg2k_scene_check.rb` checks: an empty-actors party and a single HP-0 actor party both settle a fresh encounter straight to a `:defeat` result instead of stalling in `:command`. Both confirmed to fail against the pre-fix code (the battle staying open in `:command` forever) via `git stash` of the source file before finalizing.
- `ruby scripts/rpg2k_logic_check.rb` — 727 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 415 checks passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WJJzjqQ7AF7Nibf4wU3pnA)_