### PR TITLE
rpg2k: a Lose-branch recovery now beats a racing Parallel Process's Game Over check

### DIFF
--- a/changelog.d/battle-lose-branch-recovery-race.fixed.md
+++ b/changelog.d/battle-lose-branch-recovery-race.fixed.md
@@ -1,0 +1,20 @@
+- **A Battle "Lose: Branch" handler's own recovery (a Change HP/Full Recovery
+  right after the encounter) no longer loses a race to a Parallel Process's
+  own Game Over check.** `Scene::Map#finish_battle` clears `@battle_ui`
+  (unpausing every Parallel Process) and calls `Game::Interpreter#resume_battle`
+  before `Scene::Map#update`'s own `#step_parallels` gets another chance to
+  run — but `#resume_battle` only flipped the interpreter off its `:battle`
+  wait; nothing then drove it into the handler's own recovery commands until
+  the *next* frame's ordinary "not waiting" path happened to reach it. That
+  left a full frame — party still at 0 HP, `@battle_ui` already `nil` — for
+  a Parallel Process to notice the wipe (via any command that calls
+  `#check_game_over`: Change HP/MP, Change Condition, Full Recovery, ...) and
+  raise Game Over first, before the Lose branch's own recovery ever ran.
+  Fixed by driving the interpreter one step further immediately once it comes
+  off the `:battle` wait — `Scene::Map#drive_event`'s `when :battle` case now
+  drains its own step budget the same frame, the same "Wait 0.0 sec costs one
+  frame, not two" idiom the `when :wait` case already uses — so a Lose branch
+  with no Wait/Show Text ahead of its own recovery reaches it before this
+  same frame ends, well before the next frame's Parallel Process window ever
+  opens. Covered by a new `scripts/rpg2k_scene_check.rb` check, confirmed to
+  fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2496,10 +2496,14 @@ following this paragraph as the original record.
   Save access resets with Teleport/Escape and Menu access does not.
 
 #### Untriaged backlog, from `2k/09_bug/` (bugs/errors pages read so far)
-- `016_ikinari_end/` — a Parallel Process can observe an all-KO'd party and
-  fire Game Over *before* a concurrent Battle "On Lose" recovery branch gets
-  to run its full-heal, even though the recovery would have prevented it.
-  Ordering/race between the game-over check and parallel-process ticking.
+- ✅ `016_ikinari_end/` — **a Parallel Process could observe an all-KO'd party
+  and fire Game Over *before* a concurrent Battle "Lose: Branch" recovery
+  branch got to run its full-heal, even though the recovery would have
+  prevented it, on a genuinely reachable one-frame window in this codebase's
+  own round-robin scheduler** — not merely a real-RPG_RT-only race. See the
+  fuller writeup under the "Documented race condition" bullet, "Full-site
+  sweep" section below, where this is fixed (`Scene::Map#drive_event`'s
+  `:battle` case, `mruby-rpg2k/mrblib/scene/map.rb`).
 - `017_heiretu_totyu_end/hei_mukou.htm` — (a) a Parallel Process's appearance
   condition going false mid-execution isn't observed until the process
   naturally hits a Wait/yield point, not instantly (may already follow from
@@ -2753,10 +2757,11 @@ Everything below is unverified against the codebase.
   Transfer Player command inside one lets subsequent commands run while the
   new map is still loading (needs a Wait:0.0s after it) — for a **map**
   event specifically, a Wait right there instead ends that event outright
-  since its context is gone post-transfer; "On Loss: Handle Separately" +
-  an immediate recovery branch can still lose to Game Over if *any*
-  Parallel Process is still running (must stop them all first) — same
-  family as the `016_ikinari_end` race above; ✅ **setting a map event's
+  since its context is gone post-transfer; ✅ **"On Loss: Handle Separately" +
+  an immediate recovery branch racing Game Over against a still-running
+  Parallel Process is now fixed** — same family as the `016_ikinari_end`
+  race above, see the fuller writeup under the "Documented race condition"
+  bullet, "Full-site sweep" section below; ✅ **setting a map event's
   trigger to Parallel Process also fires it on hero contact** — instantly
   on overlap for below/above-characters priority, repeatedly while a
   direction key is held against a same-as-characters (blocking) one. This
@@ -4299,14 +4304,61 @@ not yet verified:
   still running, never after it has already settled into `:result`; a second
   reveal of an already-visible member is confirmed to be a sprite-rebuild
   no-op), confirmed to fail if the battler-boundary check is disabled.
-- **Documented race condition**: a Battle Processing "Lose: Branch"
-  that revives the party can still lose to an erroneous instant Game Over
-  if a Parallel Process is running concurrently — the parallel process's
-  own game-over check can fire before the Lose-branch's revive commands
-  execute. Corroborated by many independent sources as one of the site's
-  most emphasized gotchas; the documented mitigation is manually stopping
-  all parallel processes immediately before entering such a battle and
-  restarting them from both the Win and Lose branches.
+- ✅ **Documented race condition, now fixed for real (not merely
+  RPG_RT-quirk-modelled): a Battle Processing "Lose: Branch" that revives
+  the party could still lose to an erroneous instant Game Over if a
+  Parallel Process was running concurrently** — the parallel process's own
+  game-over check could fire before the Lose-branch's revive commands ever
+  executed. Corroborated by many independent sources (this bullet,
+  `09_bug/016_ikinari_end`, and `017_heiretu_totyu_end/hei_mukou.htm`'s own
+  part (a)) as one of the site's most emphasized gotchas, with a documented
+  in-editor mitigation (stop every Parallel Process before the fight,
+  restart them from both the Win and Lose branches) — but this codebase's
+  own architecture made the race genuinely reachable on its own terms, not
+  just as an RPG_RT implementation detail to reproduce: `Scene::Map#update`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) calls `#step_parallels` once, at the
+  very top of every frame, strictly *before* `#event_busy?`/`#drive_event`
+  gets a chance to run the foreground interpreter that frame. `#finish_battle`
+  clears `@battle_ui` (so `#parallels_paused?`, gated on `!@battle_ui.nil?`,
+  stops holding Parallel Processes back) and calls
+  `Game::Interpreter#resume_battle` — which only flips the interpreter off
+  its `:battle` wait (`@waiting = false` via `#reset_waits`) and does
+  *nothing* to actually drive it into the Defeat handler's own commands —
+  *before* `drive_event`'s `when :battle` case (the caller of
+  `#finish_battle`, via `#drive_battle`) returned for the frame. So a defeat
+  with a custom `[Defeat]` handler (`defeat_game_over: false`, per
+  `Game::Interpreter#do_enemy_encounter`'s `cmd.param(4) == 0` check) left a
+  full frame — with the party still sitting at 0 HP, `@battle_ui` already
+  `nil` — before anything drove the interpreter into the handler's own
+  recovery commands at all: the very next frame's `#step_parallels` (now
+  unpaused) got first crack, and a Parallel Process reaching any command that
+  calls `Game::Interpreter#check_game_over` (Change HP/MP, Change Condition,
+  Full Recovery, ...) during that window raised `:game_over` on *its own*
+  interpreter and reached `Scene::Map#perform_game_over` via
+  `#drive_parallel_wait`'s `:game_over` case, strictly before the
+  foreground's own Defeat handler ever ran. Fixed by driving the interpreter
+  one step further immediately once `#drive_battle` leaves it off the
+  `:battle` wait — `Scene::Map#drive_event`'s `when :battle` case now calls
+  `@interpreter.update`/`#apply_interpreter_requests` right there when
+  `@interpreter.running? && !@interpreter.waiting?` reads true afterward,
+  the same "spend this frame's own step budget immediately" idiom the
+  `when :wait` case right below it already uses for "Wait 0.0 sec costs one
+  frame, not two" — so a Defeat handler with no Wait/Show Text ahead of its
+  own recovery (a Change HP/Full Recovery command) reaches it before this
+  same frame ends, well before the next frame's `#step_parallels` window
+  ever opens. A defeat resolving into `perform_game_over` directly (no
+  custom handler) is unaffected: `Game::Interpreter#stop` (called by
+  `#perform_game_over`) leaves `@running` false, so the new post-`drive_battle`
+  check's `@interpreter.running?` guard is already false and the extra pump
+  is a no-op. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+  custom-Defeat-handler encounter whose branch heals the party back up races
+  a Common Event Parallel Process armed with nothing but a harmless
+  `Change HP +0` — enough to reach `#check_game_over` on whichever frame it
+  next runs — confirming the branch's own recovery, and the rest of its
+  commands after it, land within the very same frame the result screen is
+  dismissed, and that the racing Parallel Process never wins Game Over
+  afterward), confirmed to fail against the pre-fix code (the recovery not
+  yet applied one frame later) before the fix.
 - A **map event with Parallel Process trigger** executing "Set Vehicle
   Location" **crashes RPG_RT** with a module-address access-violation
   error; the identical command from any other trigger type, or from a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2888,7 +2888,29 @@ class RPG2k
           when :key_input then drive_key_input
           when :inn then drive_inn
           when :shop then drive_shop
-          when :battle then drive_battle
+          when :battle
+            drive_battle
+            # yado.tk 09_bug/016_ikinari_end + 017_heiretu_totyu_end/hei_mukou:
+            # a Battle "Lose: Branch" handler's own recovery (a Full Heal right
+            # after the encounter) races a still-running Parallel Process's own
+            # Game Over check -- #finish_battle already clears @battle_ui (so
+            # #parallels_paused? no longer holds parallel processes back) and
+            # calls #resume_battle *before* this frame's own #step_parallels has
+            # any more chances to run this frame, but #resume_battle only flips
+            # the interpreter off its :battle wait; nothing then drives it any
+            # further until #update's *next* frame -- one whole frame during
+            # which the party sits at 0 HP, unrevived, for the very next
+            # #step_parallels (now unpaused) to observe and fire Game Over from,
+            # before the branch's own Full Heal/Change Condition ever runs.
+            # Matches the :wait branch's own "Wait 0.0 sec costs one frame, not
+            # two" reasoning below: once the interpreter is off the :battle wait,
+            # spend the rest of this frame's own step budget on it immediately,
+            # so a Lose branch with no Wait/Show Text before its recovery reaches
+            # it before this frame's #step_parallels window closes, not after.
+            if @interpreter.running? && !@interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
           when :wait
             # Same implicit-Proceed-With-Movement rule as :message above, for a
             # Wait command: the wait timer does not even start counting down

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1649,6 +1649,15 @@ class BattleStubActor
   # HP absolutely; the stub has no state model, so just clamp to [0, max].
   def set_hp(value); @hp = value < 0 ? 0 : (value > @max_hp ? @max_hp : value); end
   def dead?; @hp <= 0; end
+  # Change HP (Game::Interpreter#do_change_hp), so a "Lose: Branch" recovery
+  # command (see the "Battle Lose: Branch" race check below) can revive this
+  # stub the same way it would a real Game::Actor.
+  def change_hp(amount, allow_death = true)
+    @hp += amount
+    floor = allow_death ? 0 : 1
+    @hp = floor if @hp < floor
+    @hp = @max_hp if @hp > @max_hp
+  end
   # Mirrors Game::Actor's own RPG2000 "custom battle command" interface
   # (database fields 66/67), so a stub battle can drive the Skill-label rename
   # the same way a real actor row would.
@@ -4029,6 +4038,64 @@ check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do
   eq 0, st.party.actors.first.exp, 'no EXP on a loss'
   ok !st.switches[1], 'the Victory handler was skipped'
   ok st.switches[3], 'the Defeat handler ran'
+end
+
+# viprpg-dev wiki (200X共通/基本的な仕様, 09_bug/016_ikinari_end,
+# 017_heiretu_totyu_end/hei_mukou): a Battle "Lose: Branch" handler's own
+# recovery (a Full Heal / Change HP right after the encounter) races a
+# still-running Parallel Process's own Game Over check. #finish_battle
+# (mruby-rpg2k/mrblib/scene/map.rb) already clears @battle_ui *before*
+# resuming the event into the Defeat handler -- so #parallels_paused? no
+# longer holds a Parallel Process back -- but nothing used to drive the
+# handler's own commands any further this same frame: #drive_event's `:battle`
+# case just called #drive_battle and returned, leaving the interpreter merely
+# off its `:battle` wait until *next* frame's ordinary "not waiting" branch
+# happened to reach it. #step_parallels runs before that at the top of
+# #update, so a Parallel Process gets exactly one whole frame -- with the
+# party still sitting at 0 HP and unrevived -- to notice the wipe and raise
+# Game Over first. Fixed by driving the interpreter one step further
+# immediately once it comes off the `:battle` wait, the same "spend this
+# frame's own step budget immediately" idiom the `:wait` branch already uses
+# right below for "Wait 0.0 sec costs one frame, not two".
+check 'Enemy Encounter scene: a Lose-branch recovery beats a racing ' \
+      "Parallel Process's Game Over check" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 1, 0], indent: 0), # troop 1, custom Defeat handler
+    ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
+    ECmd.new(ic::DEFEAT_HANDLER, [], indent: 0),
+    # The "Lose: Branch" recovery: heal the whole party back up...
+    ECmd.new(ic::CHANGE_HP, [0, 0, 0, 0, 999, 1], indent: 1),
+    # ...then prove the rest of the branch still ran too, not just the heal.
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 3, 3, 0], indent: 1),
+    ECmd.new(ic::END_BATTLE, [], indent: 0)
+  ]
+  # A Common Event Parallel Process that pokes a harmless Change HP +0 every
+  # lap it gets to run -- its only purpose is to reach
+  # Game::Interpreter#check_game_over on whichever frame it is next allowed
+  # to run, exactly the way a real game's own HP-regen/status-tick parallel
+  # process would incidentally do.
+  ce = OpenStruct.new(start_term: 4, need_flag: false,
+                      event: [ECmd.new(ic::CHANGE_HP, [0, 0, 0, 0, 0, 1], indent: 0)])
+  scene = new_scene({ 1 => event(2, 2, auto) }, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  # A frail hero the two Slimes overwhelm.
+  st.instance_variable_set(:@party,
+                           BattleStubParty.new(BattleStubActor.new(atk: 6, dfn: 0, agi: 3, hp: 10)))
+  parent = scene.instance_variable_get(:@parent)
+  scene.update
+  battle_attack_to_end(scene)
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the defeat result -> finish_battle
+  scene.update
+  RGSS::Input.triggered = []
+  ok st.switches[3],
+     "the Defeat handler's recovery must run this same frame, not a frame later"
+  ok !st.party.all_dead?, 'the party was revived by the Defeat handler before anything else ran'
+  ok !parent.game_over_shown, 'no Game Over yet -- the branch already revived the party'
+  2.times { scene.update } # give the racing Parallel Process every chance to run
+  ok !parent.game_over_shown,
+     "the Parallel Process's own Game Over check must never win this race"
 end
 
 check 'Enemy Encounter scene: a game-over defeat returns to the title' do


### PR DESCRIPTION
## Summary
- yado.tk's `09_bug/016_ikinari_end`, `017_heiretu_totyu_end/hei_mukou.htm` part (a), and the `01_shoshin/011_siyou` "Parallel Process" bullet's "On Loss: Handle Separately... must stop them all first" note all describe a real race: a Battle "Lose: Branch" recovery racing a Parallel Process's own Game Over check.
- `Scene::Map#update` calls `#step_parallels` at the very top of every frame, before the foreground interpreter runs. `#finish_battle` clears `@battle_ui` (un-pausing parallels) and calls `Game::Interpreter#resume_battle`, but that only flips the interpreter off its `:battle` wait — it never actually drives it into the encounter's `[Defeat]` handler commands. `Scene::Map#drive_event`'s `when :battle` case previously just called `#drive_battle` and returned, leaving one full frame — party still at 0 HP, `@battle_ui` already `nil` — during which a now-unpaused Parallel Process could reach a command that calls `#check_game_over` (Change HP/MP, Change Condition, Full Recovery) and raise Game Over before the Lose-branch's own recovery ever ran.
- Fixed: `drive_event`'s `when :battle` case now checks `@interpreter.running? && !@interpreter.waiting?` right after `drive_battle` and, if the battle just concluded into a resumed foreground interpreter, immediately spends this frame's step budget on it — the same idiom the neighboring `when :wait` case already uses for "Wait 0.0 sec costs one frame, not two."
- `docs/TODO.md` updated ✅ at three cross-referencing locations.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 416 checks pass (1 new: a Lose-branch recovery beats a racing Parallel Process's Game Over check — the recovery and a marker switch land within the same frame the result is dismissed, and Game Over never triggers over several subsequent frames — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_