### PR TITLE
rpg2k: a message line beyond its own display width is now truncated, not left to bleed onto a right-side face

### DIFF
--- a/changelog.d/message-text-clip-right-face.fixed.md
+++ b/changelog.d/message-text-clip-right-face.fixed.md
@@ -1,0 +1,16 @@
+- **A message line that overflows its display width is now truncated at the
+  message layout's own boundary instead of bleeding onto a right-side Face
+  Graphic.** `Scene::Map#draw_message_run` handed each colour run straight to
+  `Bitmap#draw_text`/`#blend_text`, neither of which actually clips to the
+  `w`/`h` box they're given (only ever used for centre/right alignment) — this
+  looked correct in the common case purely by coincidence, since the contents
+  bitmap's own right edge happened to sit exactly at the intended text
+  boundary, but a right-side Face Graphic narrows that boundary by
+  `FACE_SIZE + FACE_MARGIN` (52px) while leaving the bitmap itself full width,
+  so an overflowing run kept drawing straight through that gap and over the
+  portrait. Fixed with a new `#clip_text_to_width`, called before either draw
+  path, that measures and slices a run to its own available width using the
+  same `Bitmap#text_size` the layout math already trusts — making the
+  no-face/left-face case correct on purpose too, not just by accident.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks, confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3798,10 +3798,48 @@ not yet verified:
 - Message Options (window transparency/position) are **sticky global
   state** — once set, they apply to every subsequent message window for
   the rest of the game (or until reset), not scoped to the current event.
-- Text beyond the display-limit line is silently truncated, not wrapped —
-  and because `\V[]`/`\N[]` substitute a runtime value, a message that
-  fits in the editor can still overflow and truncate at runtime if the
-  substituted value/name is long.
+- ✅ **Text beyond the display-limit line is now genuinely truncated by this
+  codebase's own message layout, not just by an accident of bitmap size.**
+  `Scene::Map#draw_message_run` (`mruby-rpg2k/mrblib/scene/map.rb`) handed
+  each colour run straight to `Bitmap#draw_text`/`#blend_text`
+  (`mruby-rgss/src/lib.cxx`) with a `w`/`h` bounding box — but neither
+  primitive actually clips to it; both only ever use `w`/`h` for
+  centre/right alignment math (`blit_glyph_cov`'s own bounds check is
+  against the *bitmap's own* pixel dimensions, confirmed with no
+  `clip_rect`/scissor concept anywhere in the Bitmap implementation), so an
+  overflowing run kept drawing rightward past the message layout's own
+  intended boundary. This looked correct in the common case (no right-side
+  face) purely by coincidence: `#open_message`'s `text_w` there extends
+  exactly to the contents bitmap's own right edge, so an overflowing glyph
+  simply ran off the bitmap and vanished — the "silently truncated" claim
+  held, but only because the *layout* boundary and the *bitmap* boundary
+  happened to be the same pixel. A **right-side Face Graphic** breaks that
+  coincidence: `text_w` there is narrowed by `FACE_SIZE + FACE_MARGIN`
+  (52px) to leave room for the portrait, but the contents bitmap itself is
+  still the *full* window width, so an overflowing run kept drawing straight
+  through that 52px gap and painted over the face graphic instead of
+  disappearing at the line's own display limit — the opposite of "silently
+  truncated." Fixed with a new `#clip_text_to_width`, called from
+  `#draw_message_run` before either draw path (flat `#draw_text` or
+  windowskin-blended `#draw_system_text` → `#blend_text`) ever sees the run:
+  it walks the text one character (not byte) at a time, measuring with the
+  same `Bitmap#text_size` the layout math already trusts, and stops at the
+  last character that still fits `w` — the message layout's own boundary,
+  not the bitmap's — so the fix also makes the no-face/left-face case
+  correct on purpose rather than by accident. The `\V[]`/`\N[]`
+  runtime-substitution half of the original claim needed no separate code
+  change: `Game::Message.scan` already expands those control codes into
+  plain text before layout ever runs, so a long substituted value now
+  truncates through this exact same per-run clip, no different from a long
+  literal string. Covered by two new `scripts/rpg2k_scene_check.rb` checks
+  (`#clip_text_to_width` sliced against a small fixed-width stand-in canvas,
+  since the scene-check harness's own `Bitmap#text_size` stub is a flat 0px
+  and can't exercise a real clip; a full message-open with a right-side face
+  and a 60-character line, `Bitmap#text_size` patched to a realistic
+  6px/character metric, confirming the drawn run is clipped to exactly the
+  window's own available width rather than the full string), both confirmed
+  to fail against the pre-fix code (a `NoMethodError`, and the full
+  unclipped string) before the fix.
 
 **Battle system (default)**
 - ✅ **Battle pages are checked far more often than once per turn** — the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6320,14 +6320,47 @@ class RPG2k
       # that swatch (`Bitmap#blend_text`), so the text takes the windowskin's own
       # colour and shading the way RPG2000 draws it. Otherwise fall back to a
       # flat font colour (the approximation, or an out-of-range `\c[n]`).
+      #
+      # yado.tk: text beyond a line's own display-limit width is silently
+      # truncated, not wrapped. Neither `Bitmap#draw_text` nor `#blend_text`
+      # (mruby-rgss/src/lib.cxx) clip to the `w`/`h` they are given -- those are
+      # only ever used for centre/right alignment math -- so nothing here
+      # stopped an overflowing run from drawing straight past its own line's
+      # boundary. This happened to look right in the common case (no right-side
+      # face), since the boundary coincides with the contents bitmap's own
+      # right edge and glyphs simply run off the bitmap -- but a right-side Face
+      # Graphic (`#open_message`'s `text_w`) leaves `FACE_SIZE + FACE_MARGIN` of
+      # *bitmap* width beyond the intended text boundary for the portrait,
+      # so an overflowing run kept drawing straight over it instead of
+      # disappearing there. `#clip_text_to_width` measures and slices the run
+      # to `w` itself before either draw path ever sees it, matching the
+      # boundary this codebase's own message layout defines rather than
+      # whatever the contents bitmap happens to be sized to.
       def draw_message_run(c, x, y, w, seg)
         idx = seg[:color]
+        text = clip_text_to_width(c, seg[:text], w)
         if @windowskin && Game::MessagePalette.valid?(idx)
-          draw_system_text c, x, y, w, MSG_LINE_H, seg[:text], @windowskin, idx
+          draw_system_text c, x, y, w, MSG_LINE_H, text, @windowskin, idx
         else
           c.font.color = message_color(idx)
-          c.draw_text x, y, w, MSG_LINE_H, seg[:text]
+          c.draw_text x, y, w, MSG_LINE_H, text
         end
+      end
+
+      # Slice `text` down to however many leading characters fit within `w`
+      # pixels of `c`'s own font metrics, dropping the rest outright -- RPG_RT
+      # truncates an overlong line rather than wrapping it. Walks one character
+      # (not byte) at a time so a multi-byte codepoint is never split mid-way.
+      def clip_text_to_width(c, text, w)
+        return '' if w <= 0
+        return text if c.text_size(text).width <= w
+        out = ''
+        text.each_char do |ch|
+          candidate = out + ch
+          break if c.text_size(candidate).width > w
+          out = candidate
+        end
+        out
       end
 
       # Blit the already-cropped (and possibly mirrored, see #build_face_cell)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2956,6 +2956,55 @@ check 'a right-side face draws on the right and does not inset the text' do
   ok msg[:face_x] > 0, 'the face is drawn on the right side of the contents'
 end
 
+# yado.tk: text beyond a line's own display-limit width is silently truncated,
+# not wrapped. #clip_text_to_width is what now enforces that boundary itself
+# (see its own comment on #draw_message_run) rather than relying on the
+# contents bitmap's own edge, which -- unlike here -- this stub's own
+# #text_size (always a flat 0px) can't exercise directly, so this drives the
+# helper with its own small fixed-width stand-in canvas instead.
+check '#clip_text_to_width slices a run at the exact character its own text_size stops fitting' do
+  scene = new_scene({})
+  canvas = Object.new
+  def canvas.text_size(s); RGSS::Rect.new(0, 0, s.length * 6, 0); end
+  eq 'Hello', scene.send(:clip_text_to_width, canvas, 'Hello, World!', 30),
+     'exactly 5 characters (30px) fit; the 6th would overflow'
+  eq 'Hello, World!', scene.send(:clip_text_to_width, canvas, 'Hello, World!', 999),
+     'a run that already fits is returned unchanged, untouched'
+  eq '', scene.send(:clip_text_to_width, canvas, 'Hello', 0), 'no width at all clips to nothing'
+end
+
+# The end-to-end case #clip_text_to_width exists for: a right-side Face
+# Graphic leaves FACE_SIZE + FACE_MARGIN (52px) of *bitmap* width beyond the
+# message layout's own intended text boundary for the portrait -- before this
+# fix, an overflowing run kept drawing straight through that gap and over the
+# face instead of disappearing at the boundary. Re-renders with a realistic
+# fixed-width #text_size patched onto the message's own contents bitmap (the
+# shared stub's own #text_size is a flat 0px, which would never trigger a
+# clip either way) and a fully-revealed 60-character line, well past the
+# window's own available text width at 6px/character.
+check "a message line beyond its own display width is truncated, not left to bleed onto a right-side face" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  long_line = 'A' * 60
+  auto.event_commands = [
+    ECmd.new(ic::CHANGE_FACE, [0, 1, 0], string: 'Faces1'), # right-side face
+    ECmd.new(ic::SHOW_MESSAGE, [], string: long_line),
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = open_msg(scene)
+  ok msg, 'message window opened'
+  c = msg[:contents]
+  def c.text_size(s); RGSS::Rect.new(0, 0, s.length * 6, 0); end
+  msg[:reveal].reveal_all
+  scene.send(:draw_message_contents)
+  drawn = c.draw_calls.last
+  ok drawn, 'the line was actually drawn'
+  text = drawn[4]
+  eq msg[:text_w] / 6, text.length,
+     "clipped to exactly as many characters as fit #{msg[:text_w]}px, not the full #{long_line.length}"
+  ok text.length < long_line.length, 'the overflowing tail was dropped, not left to draw over the face'
+end
+
 check 'Memorize Location stores the player position into variables' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Text beyond the display-limit line is silently truncated, not wrapped" bullet (yado.tk, `2k/01_shoshin/011_siyou/` sweep) was unverified against the code.
- Verified: `Scene::Map#draw_message_run` (`mruby-rpg2k/mrblib/scene/map.rb`) hands each colour run straight to `Bitmap#draw_text`/`#blend_text` (`mruby-rgss/src/lib.cxx`) — neither actually clips to the `w`/`h` box it's given; both only ever use it for centre/right alignment math (`blit_glyph_cov`'s own bounds check is against the *bitmap's own* pixel dimensions, and there is no `clip_rect`/scissor concept anywhere in the Bitmap implementation).
- This looked correct in the common case purely by coincidence: with no face or a left-side face, `#open_message`'s `text_w` extends exactly to the contents bitmap's own right edge, so an overflowing glyph simply ran off the bitmap and vanished — "silently truncated" held, but only because the layout boundary and the bitmap boundary happened to be the same pixel.
- A **right-side Face Graphic** breaks that coincidence: `text_w` is narrowed by `FACE_SIZE + FACE_MARGIN` (52px) to leave room for the portrait, but the contents bitmap itself is still the full window width — so an overflowing run kept drawing straight through that 52px gap and painted over the face graphic instead of disappearing at the line's own display limit. The opposite of "silently truncated."
- Fixed with a new `#clip_text_to_width`, called from `#draw_message_run` before either draw path (flat `#draw_text` or windowskin-blended `#draw_system_text` → `#blend_text`) ever sees the run: it walks the text one character (not byte) at a time, measuring with the same `Bitmap#text_size` the layout math already trusts, and stops at the last character that still fits `w` — the message layout's own boundary, not the bitmap's. This also makes the no-face/left-face case correct on purpose rather than by accident.
- The `\V[]`/`\N[]` runtime-substitution half of the original claim needed no separate change: `Game::Message.scan` already expands those control codes into plain text before layout runs, so a long substituted value now truncates through this same per-run clip.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 415 checks pass (2 new: `#clip_text_to_width` sliced against a small fixed-width stand-in canvas, since the scene-check harness's own `Bitmap#text_size` stub is a flat 0px and can't exercise a real clip directly; a full message-open with a right-side face and a 60-character line, with `Bitmap#text_size` patched to a realistic 6px/character metric, confirming the drawn run is clipped to exactly the window's own available width rather than the full string) — both confirmed to fail against the pre-fix code (a `NoMethodError`, and the full unclipped string) before the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv7wWJB7fCbDXKPySyx59a)_