### PR TITLE
rpg2k: a second Show Battle Animation now cuts off the first, matching RPG_RT

### DIFF
--- a/changelog.d/battle-animation-second-cuts-off-first.fixed.md
+++ b/changelog.d/battle-animation-second-cuts-off-first.fixed.md
@@ -1,0 +1,31 @@
+- **A second Show Battle Animation (11210) now forcibly cuts the first one's
+  sprite off**, instead of quietly waiting its turn for the shared on-screen
+  slot to free up. Settled against EasyRPG Player's actual C++ source:
+  `Game_Screen::ShowBattleAnimation` (`src/game_screen.cpp`) is a bare
+  `animation.reset(new BattleAnimationMap(...))` — an unconditional
+  `unique_ptr` replace with no check for whether the previous animation had
+  finished. `Scene::Map#drive_map_animation` (`mruby-rpg2k/mrblib/
+  scene/map.rb`) used to only claim the shared `@map_animation`/`@anim_wait`
+  slot when it was free, and otherwise just returned early every frame for
+  any interpreter that was not the current owner — a second request sat
+  completely inert until the first happened to finish naturally, the
+  opposite of "forcibly cuts off." Fixed by claiming the slot unconditionally
+  for whichever interpreter's request is being driven this frame: if a
+  *different* interpreter currently holds it, that request is torn down and
+  immediately resumed (its animation no longer exists, so there is nothing
+  left for it to keep waiting on), before the new request takes the slot
+  over the same frame. `#draw_map_animation` needed no change — it already
+  re-derives the animation sprite's visibility fresh from `@map_animation`
+  every render, so a cut-off animation's last frame does not linger even for
+  one frame. Not reproduced: EasyRPG's own decoupled, precomputed-duration
+  wait (`Game_Interpreter_Map::CommandShowBattleAnimation` arms
+  `_state.wait_time` up front, independent of the shared animation object's
+  own lifecycle), which would let a cut-off interpreter's original countdown
+  keep ticking rather than resuming instantly — a larger change than the
+  observable cut-off behaviour this closes. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (two Common Event Parallel Processes,
+  the first parked on a long fallback-wait animation and the second issuing
+  its own drawable one a few frames later: the shared slot switches over well
+  before the first's own duration could have finished it naturally, and the
+  first interpreter resumes instead of hanging forever on a slot it no
+  longer owns), confirmed to fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4130,9 +4130,11 @@ not yet verified:
   covers making a parallel process's request render and block that process at
   all; the "only one at a time, second forcibly cuts off the first" precedence
   rule between two *concurrent* requests (which interpreter, if any, gets
-  bumped) is intentionally left unmodelled — a request arriving while the slot
-  is held simply waits its turn — since resolving it needs a real RPG_RT
-  comparison this environment cannot run. "Back-to-back calls stutter" is
+  bumped) used to be intentionally left unmodelled — a request arriving while
+  the slot is held simply waited its turn — since resolving it needed a real
+  RPG_RT comparison this environment could not run; ✅ **now fixed, settled
+  against EasyRPG Player's actual C++ source** (see the fuller writeup a few
+  bullets below). "Back-to-back calls stutter" is
   likewise still open. Covered by two new `scripts/rpg2k_scene_check.rb`
   checks (a parallel process's Show Battle Animation holds it, then resumes
   once the animation finishes; the animation actually renders — sprite
@@ -4170,6 +4172,55 @@ not yet verified:
   confirmed to fail against the pre-fix code (`expected 2, got 3`) before
   the fix. "Back-to-back calls stutter" (the bullet's third, unrelated
   claim) remains open, as noted above.
+- ✅ **A second Show Battle Animation (11210) now forcibly cuts the first
+  one's sprite off, instead of the second request quietly waiting its turn
+  for the shared slot to free up** — the "only one on screen at a time"
+  precedence rule the map-triggered concurrency fix above (the "A Common
+  Event Parallel Process's own Show Battle Animation" bullet) deliberately
+  left unmodelled at the time, pending a real RPG_RT comparison. Settled
+  against EasyRPG Player's actual C++ source rather than guessed at:
+  `Game_Screen::ShowBattleAnimation` (`src/game_screen.cpp`) is a bare
+  `animation.reset(new BattleAnimationMap(...))` — an unconditional
+  `unique_ptr` replace with no check for whether the previous animation had
+  finished — and `Game_Interpreter_Map::CommandShowBattleAnimation`
+  (`src/game_interpreter_map.cpp`) arms the issuing interpreter's own "wait
+  until it finishes" as a plain precomputed frame-count (`_state.wait_time =
+  frames`, `frames` being `Game_Screen::ShowBattleAnimation`'s own return
+  value) rather than tying resumption to whether that interpreter's
+  animation is still the one actually on screen. `Scene::Map#drive_map_animation`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) used to only ever claim the shared
+  `@map_animation`/`@anim_wait` slot when it was free (`if @map_animation.nil?
+  && @anim_wait.nil?`) and otherwise just `return`ed early every frame for
+  any interpreter that was not the current owner — a second request sat
+  completely inert, doing nothing, until the first one's animation happened
+  to finish naturally and free the slot, the opposite of "forcibly cuts off."
+  Fixed by claiming the slot unconditionally for whichever interpreter's
+  request is being driven this frame (`unless @map_animation_interp.equal?
+  (it)`): if a *different* interpreter currently holds it, that request is
+  torn down (`@map_animation`/`@anim_wait` reset to `nil`) and immediately
+  resumed — its animation no longer exists, so real RPG_RT's own
+  independent countdown aside, there is nothing left here for it to keep
+  waiting on — before `it`'s own request takes the slot over via the
+  existing `init_map_animation`, same frame. `#draw_map_animation` (the
+  render-pass compositor) needed no change: it already re-derives
+  `@animation_sprite.visible` fresh from `@map_animation` every single
+  frame (`unless ma; @animation_sprite.visible = false; ...`), so a cut-off
+  drawable animation's stale last frame does not linger on screen even for
+  one render. Not reproduced: EasyRPG's own decoupled, precomputed-duration
+  wait, which would let a cut-off interpreter's original countdown keep
+  ticking rather than resuming the instant it loses the slot — matching that
+  exactly would need this build to precompute and track each request's own
+  duration independently of the shared visual object too, a larger change
+  than the observable "does the first get cut off" fact this closes; "Back-
+  to-back calls stutter" remains open as before. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (two Common Event Parallel Processes,
+  the first parked on a long ~20-frame fallback-wait animation and the
+  second issuing its own drawable one a few frames later: the shared slot
+  switches to the second's animation well before the first's own fallback
+  duration could ever have finished it naturally, and the first interpreter
+  resumes rather than hanging forever on a slot it no longer owns),
+  confirmed to fail against the pre-fix code (the slot still showing the
+  first request 15 frames later) before the fix.
 - ✅ **Show Battle Animation (11210) targeting a vehicle now plays over that
   vehicle's own live position**, instead of silently defaulting to the
   player's. `Scene::Map#animation_target_pixel` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5599,16 +5599,39 @@ class RPG2k
       # its target, then resume `it`. When the animation's data / sheet is
       # available it advances frame by frame (composited by #draw_map_animation),
       # firing the screen flashes its timings request; otherwise it degrades to a
-      # plain timed wait, so a cutscene paces the same as RPG_RT either way. If
-      # the slot is currently held by a *different* interpreter's animation, `it`
-      # simply waits its turn -- this build does not model one animation cutting
-      # another short, only that they cannot render concurrently.
+      # plain timed wait, so a cutscene paces the same as RPG_RT either way.
+      #
+      # yado.tk: only one battle animation is ever on screen, and a *second*
+      # one forcibly cuts the first off rather than queueing behind it --
+      # confirmed against EasyRPG Player's actual C++ source rather than left
+      # as a guess: `Game_Screen::ShowBattleAnimation` (src/game_screen.cpp)
+      # is a bare `animation.reset(new BattleAnimationMap(...))`, an
+      # unconditional `unique_ptr` replace with no check for whether the
+      # previous one had finished. If the slot is currently held by a
+      # *different* interpreter's animation, that request is torn down here
+      # (rather than left to finish naturally) and `it`'s own takes over
+      # immediately, same frame. The interpreter that just lost the slot has
+      # nothing left on screen to keep waiting on, so it resumes right away --
+      # EasyRPG's own interpreter actually arms an independent, precomputed
+      # frame-count wait at request time (`Game_Interpreter_Map::
+      # CommandShowBattleAnimation`'s `_state.wait_time = frames`) rather than
+      # tying resumption to the shared animation object's lifecycle at all, so
+      # a cut-off request there keeps counting down its own original duration
+      # instead of resuming the instant it is cut off; reproducing that exact
+      # timing would need this build to precompute and track each request's
+      # duration independently too, which is a larger change than the
+      # observable "does the first get cut off" fact this fixes.
       def drive_map_animation(it)
-        if @map_animation.nil? && @anim_wait.nil?
+        unless @map_animation_interp.equal?(it)
+          if @map_animation || @anim_wait
+            cut_off = @map_animation_interp
+            @map_animation = nil
+            @anim_wait = nil
+            cut_off.resume if cut_off
+          end
           @map_animation_interp = it
           init_map_animation(it)
         end
-        return unless @map_animation_interp.equal?(it)
         @map_animation ? step_map_animation : step_animation_wait
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5280,6 +5280,59 @@ check "a Common Event Parallel Process's Show Battle Animation draws a sprite an
   ok st.switches[6], 'the parallel process resumed after the animation'
 end
 
+# yado.tk: only one Battle Animation is ever on screen, and a *second* one
+# forcibly cuts the first off rather than queueing behind it -- confirmed
+# against EasyRPG Player's actual C++ source (Game_Screen::ShowBattleAnimation,
+# src/game_screen.cpp, a bare unconditional unique_ptr::reset()), see
+# #drive_map_animation's own comment. Before this fix a second request while
+# the shared slot was held simply sat there doing nothing every frame until
+# the first one finished naturally -- never cutting it off, and (worse) had
+# no way to notice being torn down either, since ownership never changed
+# hands mid-flight.
+check 'a second Show Battle Animation forcibly cuts off a still-playing first one' do
+  ic = Game::Interpreter::Cmd
+  # CE1's animation 7 has no drawable data in the fake db (see the fallback-
+  # wait checks above), so it parks on the ~20-frame timed-wait fallback --
+  # long enough that CE2's own animation can cut it off well before it would
+  # ever finish naturally.
+  ce1 = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                       event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [7, 10001, 1], indent: 0),
+                               ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
+  # CE2 waits a moment first (so CE1's animation is already in flight), then
+  # fires its own -- animation 8, the fake db's drawable one.
+  ce2 = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                       event: [ECmd.new(ic::WAIT, [1], indent: 0),
+                               ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),
+                               ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce1, 2 => ce2 })
+  st = scene.instance_variable_get(:@state)
+  3.times { scene.update }
+  ok !st.switches[5], 'CE1 is still parked on its own long fallback wait'
+  ok scene.instance_variable_get(:@anim_wait), "CE1 has claimed the shared slot (fallback path)"
+  # CE2's own Wait[1] (~6 frames) elapses well before CE1's ~20-frame fallback
+  # would ever finish naturally, so bound the search to comfortably less than
+  # that: if the slot is still showing CE1's fallback wait by frame 15, CE2
+  # never cut it off at all -- it is still queued behind CE1, the pre-fix bug.
+  15.times do
+    scene.update
+    break if scene.instance_variable_get(:@map_animation)
+  end
+  ok scene.instance_variable_get(:@map_animation),
+     "the shared slot now shows CE2's own (drawable) animation instead of CE1's fallback wait, " \
+     "well before CE1's own ~20-frame duration could have finished it naturally"
+  ok !st.switches[6], 'CE2 has not resumed yet -- its own animation only just started'
+  # CE1 was resumed the instant it was cut off (this same pass), but its own
+  # trailing Control Switches command only runs on the *next* step_parallel
+  # call for it (only a :wait wait-kind gets the same-frame "spend this
+  # frame's own budget immediately" treatment) -- give it one more frame to
+  # actually reach it, well short of the fallback's own ~20-frame duration.
+  scene.update
+  ok st.switches[5],
+     "CE1 resumed the instant its animation was cut off, well short of the fallback's own ~20-frame duration"
+  60.times { scene.update }
+  ok st.switches[6], 'CE2 resumes once its own animation finishes'
+end
+
 # yado.tk: RPG_RT drops straight into Game Over the instant a wipe-triggering
 # command finds the whole party dead outside battle, regardless of which
 # event noticed it -- a Simulated Attack floor trap on a background Parallel


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s Battle system (default) bullet — "Battle Animation: only one on screen at a time (a second forcibly cuts off the first)" — had a specific clause a prior round explicitly left unresolved, since answering it needed a real RPG_RT comparison this environment previously couldn't run.
- Verified against EasyRPG Player's actual source: `Game_Screen::ShowBattleAnimation` (`src/game_screen.cpp`) is a bare, unconditional `animation.reset(new BattleAnimationMap(...))` — it always replaces whatever animation is currently playing, no completion check.
- `Scene::Map#drive_map_animation` did the opposite: a second Show Battle Animation (11210) request arriving while the shared `@map_animation`/`@anim_wait` slot was held by a different interpreter just returned early every frame until the first happened to finish naturally — the exact reverse of "forcibly cuts off."
- `drive_map_animation` now claims the shared slot unconditionally for whichever interpreter's request is being driven. If a different interpreter currently owns it, that request is torn down and immediately resumed (its animation object no longer exists), and the new request takes over the slot the same frame. One fidelity gap not reproduced (documented in code/TODO.md): EasyRPG's interpreter arms an independent, precomputed frame-count wait at request time rather than tying resumption to the shared object's lifecycle — matching that exactly would need a larger architectural change.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 421 checks pass (1 new: two Parallel Processes, the second's drawable animation takes over the shared slot well within the first's ~20-frame natural duration, and the cut-off interpreter resumes rather than hanging — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_