### PR TITLE
rpg2k: a no-wait Show Battle Animation now actually plays

### DIFF
--- a/changelog.d/show-battle-animation-nowait-plays.fixed.md
+++ b/changelog.d/show-battle-animation-nowait-plays.fixed.md
@@ -1,0 +1,25 @@
+- **A map-triggered Show Battle Animation (11210) with its "wait until it
+  finishes" flag *off* now actually plays**, instead of being recorded and
+  then silently never rendered. EasyRPG Player's own `Game_Interpreter_Map::
+  CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) always starts
+  the animation regardless of the wait flag — the flag only gates whether the
+  interpreter pauses for it — but `Game::Interpreter#do_show_battle_animation`
+  only entered an `:animation` wait when the flag was set, and
+  `Scene::Map#drive_map_animation` (the only place anything ever read
+  `battle_animation` off an interpreter) is reachable exclusively through that
+  wait's own dispatch, so a fire-and-forget request had nothing left to pick
+  it up. Fixed with a new `@battle_animation_pending` flag plus a destructive
+  `#take_battle_animation_request` reader, polled by a new `Scene::
+  Map#apply_battle_animation_request` from `#apply_interpreter_requests` —
+  already run for both the foreground interpreter and every parallel process
+  — which starts the shared animation slot with no owner when it is free (or
+  drops the request when it is already busy, matching this build's existing
+  "waits its turn" precedent for the waited-for collision case). A second new
+  method, `#step_ownerless_map_animation`, is now polled unconditionally every
+  real frame from `#update`, since nothing else was ever advancing an owner-
+  less animation frame-by-frame — it is carefully scoped off an in-progress
+  battle-round animation (`#drive_battle_animate`'s own job) to avoid double-
+  stepping it. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+  no-wait Show Battle Animation both lets the very next command run
+  immediately and still plays the sprite/flash through to completion),
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4139,6 +4139,60 @@ not yet verified:
   shown, screen flash fired — for a parallel-process request, not just a
   foreground one), both confirmed to fail against the pre-fix code before
   the fix.
+- ✅ **A map-triggered Show Battle Animation (11210) with its "wait until it
+  finishes" flag *off* now actually plays too**, instead of being recorded
+  and then silently never rendered. Verified against EasyRPG Player's actual
+  C++ source rather than guessed: `Game_Interpreter_Map::
+  CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) always calls
+  `Game_Screen::ShowBattleAnimation` regardless of the wait flag — the flag
+  only gates whether `_state.wait_time` is then set, pausing the interpreter —
+  so a fire-and-forget play is still expected to render, not merely skip
+  blocking. `Game::Interpreter#do_show_battle_animation`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) recorded `@battle_animation`
+  unconditionally but only entered an `:animation` wait when the flag was
+  set, and `#drive_map_animation` — the *only* place anything ever read
+  `battle_animation` off an interpreter — is reachable exclusively through
+  that wait's own dispatch (`Scene::Map#drive_event`'s and
+  `#drive_parallel_wait`'s `:animation` cases, the fix just above this one
+  included): a fire-and-forget request was recorded and then nothing was
+  ever looking at it. Fixed with a new `@battle_animation_pending` flag (set
+  only on the no-wait branch) and a destructive `#take_battle_animation_
+  request` reader, polled by a new `Scene::Map#apply_battle_animation_request`
+  from `#apply_interpreter_requests` — already called for both the
+  foreground interpreter and every parallel process right after each step,
+  so this covers a Parallel Process's own fire-and-forget play the same way
+  the fix above covers its waited-for one. It starts the shared
+  `@map_animation` slot with no owner when the slot is free (`#start_map_
+  animation`/`#init_map_animation` refactored into `#start_map_animation(req)`/
+  a new shared `#begin_map_animation(req)` so both paths build off the same
+  request hash rather than an interpreter), and drops the request outright
+  when the slot is already busy — matching this build's existing "a second
+  request simply waits its turn" precedent for the waited-for collision case
+  above, not the "cuts off the first" half of this bullet's own opening
+  clause, which is still open either way and has no owner left to keep
+  re-polling for a turn once dropped. A still-open architectural gap this
+  surfaced: nothing was ever advancing `@map_animation` frame-by-frame for a
+  play with no owner — `#drive_map_animation` (the map wait dispatch) and
+  `#drive_battle_animate` (the battle-round phase) are the only two existing
+  callers of `#step_map_animation`, and neither runs for a fire-and-forget
+  play. Fixed with a new `#step_ownerless_map_animation`, called
+  unconditionally every real frame from `#update` alongside `#update_sprite_
+  flashes` and friends, gated on `@map_animation_interp.nil?` (no owner) and
+  `!@map_animation[:battle]` — the latter because `#start_battle_animation`
+  also never sets an owner, so without it a battle-round play would be
+  double-stepped once by this and again by `#drive_battle_animate`'s own
+  explicit call. Covered by a new `scripts/rpg2k_scene_check.rb` check (a
+  no-wait Show Battle Animation both lets the very next command run
+  immediately and still plays the sprite/flash through to completion over
+  the following frames), confirmed to fail against the pre-fix code (the
+  sprite never shown) before the fix. **Still open**: the battle-*page* form
+  of this command (13260) looks structurally different and worse —
+  `Scene::Map#drive_battle_event_wait`'s wait dispatch has no `:animation`
+  case at all, so its generic "a battle page cannot open the map's
+  teleport/shop/menu UI" `else` branch unconditionally `#resume`s it,
+  meaning a battle-page Show Battle Animation may not render even *with*
+  its wait flag set — a separate, not-yet-fixed gap this pass did not
+  touch.
 - ✅ **The "1 frame = 1/30s" half of the bullet above is now correct, and
   the "'Wait' frame is internally two consecutive frames" framing turns out
   to have been a misreading — settled against EasyRPG Player's actual C++

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -421,6 +421,18 @@ module Game
       reqs
     end
 
+    # Drain the fire-and-forget Show Battle Animation (11210) request queued
+    # since the last call — `battle_animation` itself, only once, the one call
+    # this made with its wait flag off (a waited-for one is driven straight off
+    # the :animation wait instead and never touches this flag; see
+    # #do_show_battle_animation). Returns nil when nothing new fired, so the
+    # owning scene does not replay the same play every frame.
+    def take_battle_animation_request
+      return nil unless @battle_animation_pending
+      @battle_animation_pending = false
+      @battle_animation
+    end
+
     # Drain the Show Hidden Monster (13150) troop-member indices queued since the
     # last call. The scene polls this and builds the sprites for the revealed
     # members. Non-blocking.
@@ -780,6 +792,7 @@ module Game
       @battle_request = nil
       @name_input_request = nil
       @battle_animation = nil
+      @battle_animation_pending = false
     end
 
     def switches;  @state.switches;  end
@@ -2764,16 +2777,26 @@ module Game
     # Show Battle Animation (11210): play battle animation param0 over a target
     # character on the map. param1 is the target id (the player, an event, or
     # this event — the Move Event target scheme) and param2 the "wait until it
-    # finishes" flag. Records the request (which a future map-animation renderer
-    # will draw) and, when the wait flag is set, suspends on an :animation wait so
-    # the owning scene can hold the event for the animation's duration. Drawing
-    # the animation itself is native renderer work still to come.
+    # finishes" flag. EasyRPG's own `Game_Interpreter_Map::
+    # CommandShowBattleAnimation` (src/game_interpreter_map.cpp) always starts the
+    # animation through `Game_Screen::ShowBattleAnimation` regardless of the wait
+    # flag — only whether `_state.wait_time` is then set (pausing the interpreter)
+    # depends on it — so a fire-and-forget play is not merely non-blocking, it is
+    # still expected to render. With the wait flag set, this suspends on an
+    # :animation wait so the owning scene can hold the event for the animation's
+    # duration (#drive_map_animation reads `battle_animation` directly off that
+    # wait); with it unset, `@battle_animation_pending` flags this request for
+    # #take_battle_animation_request instead, since nothing will ever visit an
+    # :animation wait for it otherwise.
     def do_show_battle_animation(cmd)
       @battle_animation = { animation: cmd.param(0), target: cmd.param(1),
                             wait: cmd.param(2) != 0 }
-      return unless cmd.param(2) != 0
-      @wait_kind = :animation
-      @waiting = true
+      if cmd.param(2) != 0
+        @wait_kind = :animation
+        @waiting = true
+      else
+        @battle_animation_pending = true
+      end
     end
 
     # A picture coordinate: the literal param at `idx`, or the value of the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -264,6 +264,7 @@ class RPG2k
         @state.screen.update # screen tint progresses every frame, even in events
         @state.update_pictures # picture moves progress every frame too
         update_sprite_flashes # Flash Sprite decays during events too
+        step_ownerless_map_animation # a fire-and-forget Show Battle Animation plays on, unattended
         update_closing_windows # a closed message keeps shrinking in the background
         watch_bgm_loop # so the "BGM played once" branch can be answered
         @anim_frame += 1 # water / animated tiles cycle even during events
@@ -2227,6 +2228,38 @@ class RPG2k
                      "#{req[:width]}x#{req[:height]}: video playback is not supported"
       end
 
+      # -- Show Battle Animation (fire-and-forget) ------------------------------
+
+      # Start a Show Battle Animation (11210) that was issued with its "wait
+      # until it finishes" flag off. EasyRPG's own `Game_Interpreter_Map::
+      # CommandShowBattleAnimation` always calls `Game_Screen::
+      # ShowBattleAnimation` regardless of that flag — it only gates whether the
+      # interpreter's own wait_time is then set — so a fire-and-forget play is
+      # still expected to render, not merely skip blocking. This codebase used to
+      # only ever start one from the :animation wait dispatch
+      # (#drive_map_animation), which a non-waiting call never reaches at all —
+      # #do_show_battle_animation records the request either way but nothing
+      # then picked it up, so it silently never played. Polled here instead,
+      # right alongside every other request this interpreter queued this step
+      # (Move Event, Flash Sprite, ...), for both the foreground interpreter and
+      # every parallel process (#apply_interpreter_requests runs for both).
+      #
+      # No owner: unlike #init_map_animation's waited-for play, nothing is
+      # parked on this one to #resume once it finishes (#step_map_animation
+      # already treats a nil #@map_animation_interp as "no one to resume").
+      # When the shared on-screen slot is already busy this play is dropped
+      # rather than queued or cutting the running one short — this build does
+      # not model one animation cutting another off (see #drive_map_animation),
+      # and a fire-and-forget request has no owner left to keep retrying for a
+      # turn the way a waiting interpreter implicitly does by asking again next
+      # frame.
+      def apply_battle_animation_request(interp)
+        req = interp.take_battle_animation_request
+        return if req.nil? || @map_animation || @anim_wait
+        @map_animation_interp = nil
+        begin_map_animation(req)
+      end
+
       # -- Flash Sprite --------------------------------------------------------
 
       # Start the character flashes an interpreter queued this step (11320). The
@@ -2961,6 +2994,7 @@ class RPG2k
         apply_sprite_flash_requests(interp, this_event)
         apply_vehicle_toggle(interp)
         apply_movie_request(interp)
+        apply_battle_animation_request(interp)
       end
 
       # Maps the interpreter's accepted-key symbols onto RGSS input buttons.
@@ -5612,11 +5646,42 @@ class RPG2k
         @map_animation ? step_map_animation : step_animation_wait
       end
 
+      # Advance a fire-and-forget Show Battle Animation (#apply_battle_animation_
+      # request) once per real frame. A waited-for play (map or battle-round
+      # alike) always has *something* re-visiting it every frame on its own --
+      # #drive_map_animation for the map :animation wait, #drive_battle_animate's
+      # own explicit #step_map_animation call for a battle round -- but a
+      # fire-and-forget one has no interpreter parked on it at all, so without
+      # this it would show its first frame once and then freeze there forever
+      # instead of playing through. Gated on @map_animation_interp being nil (no
+      # owner) so an owned map play is left to #drive_map_animation untouched,
+      # and on `!@map_animation[:battle]` so a battle-round play -- which also
+      # leaves @map_animation_interp nil, since #start_battle_animation never
+      # sets an owner either -- is left entirely to #drive_battle_animate's own
+      # call instead of being stepped twice a frame.
+      def step_ownerless_map_animation
+        return unless @map_animation_interp.nil?
+        if @map_animation
+          step_map_animation unless @map_animation[:battle]
+        elsif @anim_wait
+          step_animation_wait
+        end
+      end
+
       # Begin the animation: build the frame-by-frame player from `it`'s
       # request, or arm the timed-wait fallback when there is no drawable
       # animation.
       def init_map_animation(it)
-        @map_animation = start_map_animation(it)
+        begin_map_animation(it.battle_animation)
+      end
+
+      # Shared by #init_map_animation (a waited-for play, owned by `it`) and
+      # #apply_battle_animation_request (a fire-and-forget one, no owner):
+      # build the frame-by-frame player from a raw `battle_animation` request
+      # hash, or arm the timed-wait fallback when there is no drawable
+      # animation.
+      def begin_map_animation(req)
+        @map_animation = start_map_animation(req)
         if @map_animation
           fire_animation_flashes(@map_animation) # frame 0 flashes
         else
@@ -5771,10 +5836,11 @@ class RPG2k
         end
       end
 
-      # Build the animation player, or nil when the animation is unknown or its
-      # Battle/<name> sheet is missing (then the timed-wait fallback runs).
-      def start_map_animation(it)
-        req = it.battle_animation
+      # Build the animation player from a raw `battle_animation` request hash
+      # (`{ animation:, target:, ... }`), or nil when there is no request, the
+      # animation is unknown, or its Battle/<name> sheet is missing (then the
+      # timed-wait fallback runs).
+      def start_map_animation(req)
         return nil unless req
         tx, ty = animation_target_pixel(req[:target])
         # Every map target -- the player, a map event, a vehicle -- draws from

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5015,6 +5015,41 @@ check 'Show Battle Animation plays: an animation sprite shows and a flash fires'
   ok !spr.visible, 'the animation sprite is hidden once it finishes'
 end
 
+# EasyRPG's own Game_Interpreter_Map::CommandShowBattleAnimation
+# (src/game_interpreter_map.cpp) always starts the animation through
+# Game_Screen::ShowBattleAnimation regardless of the wait flag -- the flag only
+# gates whether the interpreter's own wait_time is set afterwards. This
+# codebase used to only ever start an animation from the :animation wait
+# dispatch (#drive_map_animation), which a non-waiting command never reaches
+# at all, so a "wait until it finishes" flag left unchecked silently dropped
+# the play instead of firing it in the background.
+check 'Show Battle Animation with the wait flag off still plays, without blocking the event' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # animation 8 (the same drawable one the wait=1 check above uses) on the
+  # player, wait flag OFF this time.
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 0], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  spr = scene.instance_variable_get(:@animation_sprite)
+  shown = false
+  flashed = false
+  not_blocked = nil
+  40.times do |i|
+    scene.update
+    shown ||= spr.visible
+    flashed ||= st.screen.flashing?
+    not_blocked = st.switches[6] if i == 2
+  end
+  ok not_blocked, 'the event is not held by a fire-and-forget Show Battle Animation'
+  ok shown, 'the animation sprite was shown even though the wait flag was off'
+  ok flashed, 'a screen-flash timing fired during the fire-and-forget animation'
+  ok !spr.visible, 'the animation sprite is hidden once it finishes'
+end
+
 # yado.tk (corroborated independently against EasyRPG's own C++ source, see
 # #hold_animation_screen_flash's comment): Screen Flash is capped to 1/30s of
 # display while a Battle Animation is playing, since the animation


### PR DESCRIPTION
## Summary
- A map-triggered Show Battle Animation (11210) with its "wait until it finishes" flag **off** recorded `@battle_animation` and then silently never rendered it. `Scene::Map#drive_map_animation` — the only place anything ever read `battle_animation` off an interpreter — is reachable *exclusively* through the `:animation` wait dispatch (`drive_event`'s and `drive_parallel_wait`'s `:animation` cases), and a fire-and-forget call never enters that wait at all.
- Verified against EasyRPG Player's actual C++ source rather than guessed: `Game_Interpreter_Map::CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) always calls `Game_Screen::ShowBattleAnimation` regardless of the wait flag — the flag only gates whether the interpreter's own `wait_time` is set afterwards, pausing it. A fire-and-forget play is still expected to render, not merely skip blocking.
- Fixed with a new `@battle_animation_pending` flag (set only on the no-wait branch) and a destructive `Game::Interpreter#take_battle_animation_request` reader, polled by a new `Scene::Map#apply_battle_animation_request` from `#apply_interpreter_requests` — already called for both the foreground interpreter and every parallel process after each step, so this covers a Parallel Process's own fire-and-forget play too.
- `#start_map_animation`/`#init_map_animation` were refactored into `#start_map_animation(req)` / a new shared `#begin_map_animation(req)` so both the waited-for and fire-and-forget paths build off the same request hash rather than an interpreter.
- A second, related gap this surfaced: nothing was ever advancing `@map_animation` frame-by-frame for a play with no owner (`#drive_map_animation` and `#drive_battle_animate` are the only two existing callers of `#step_map_animation`, and neither runs for a fire-and-forget play — it would show its first frame once and then freeze). Fixed with a new `#step_ownerless_map_animation`, polled unconditionally every real frame from `#update`, carefully scoped off an in-progress battle-round animation (`!@map_animation[:battle]`) to avoid double-stepping it.
- `docs/TODO.md` updated ✅ under the "Battle Animation" bullet (Full-site sweep, Battle system section), including a note on a related still-open gap this surfaced: the battle-*page* form of this command (13260) looks structurally worse — `drive_battle_event_wait`'s dispatch has no `:animation` case at all, so it may not render even *with* its wait flag set. Left untouched, out of scope for this PR.
- Checked open PRs before starting and again before pushing: #641 ("a second Show Battle Animation now cuts off the first") is a different, complementary fix to the animation-collision precedence rule — no overlap with this PR's wait-flag-off gap.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 421 checks pass (1 new: a no-wait Show Battle Animation both lets the very next command run immediately and still plays the sprite/flash through to completion — confirmed to fail against the pre-fix code via `git stash` of just the source files)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHteF7a6idxJMV7SHZNS7L)_