### PR TITLE
rpg2k: a battle/vehicle/inn BGM matching the already-playing track no longer restarts it

### DIFF
--- a/changelog.d/battle-bgm-same-file-no-restart.fixed.md
+++ b/changelog.d/battle-bgm-same-file-no-restart.fixed.md
@@ -1,0 +1,19 @@
+- **A battle/vehicle/inn BGM matching the file already playing no longer
+  breaks and restarts it, and neither does restoring a pre-transition track
+  afterward.** `Game::Interpreter#play_audio` already skips a same-file
+  `RGSS::Audio.bgm_play` for the Play BGM event command, but `Scene::Map`'s
+  own BGM-switching helpers (`#play_battle_bgm`/`#restore_pre_battle_bgm`,
+  `#play_vehicle_bgm`/`#restore_pre_vehicle_bgm`, `#play_victory_bgm`,
+  `#play_inn_bgm`/`#restore_pre_inn_bgm`) each called `RGSS::Audio.bgm_play`
+  unconditionally, independent of that check — so a battle BGM configured to
+  the same file as the field track wrongly restarted it on entry, and
+  restoring the field track after the fight restarted it a second time, even
+  though this scene never actually stopped it. Verified against EasyRPG
+  Player's own `Game_System::BgmPlay` (`src/game_system.cpp`), the single
+  native entry point every one of these transitions funnels through in the
+  real engine, including battle entry (`Scene_Battle::Init`,
+  `src/scene_battle.cpp`). Fixed by extracting a shared
+  `Scene::Map#play_bgm(music)` using the same same-file idiom
+  `Game::Interpreter#play_audio` already has, and routing all seven call
+  sites through it. Covered by a new `scripts/rpg2k_scene_check.rb` check,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3732,7 +3732,45 @@ not yet verified:
   (and the `bgm_looped` reset) when they match, so a same-file re-trigger
   leaves the still-playing track alone. `@state.current_bgm` is still
   updated unconditionally to the command's latest vol/tempo, so Memorize
-  BGM continues to stash whatever was most recently requested. **The
+  BGM continues to stash whatever was most recently requested. ✅ **The
+  "field and battle BGM sharing the same file continue seamlessly across
+  the transition" half is now implemented too — it turned out to be a
+  distinct, unaddressed gap rather than a restatement of the Play BGM fix
+  above.** Verified against EasyRPG Player's actual C++ source rather than
+  guessed at: real RPG_RT has exactly **one** native BGM entry point,
+  `Game_System::BgmPlay` (`src/game_system.cpp`), and its same-file check
+  ("Same music: Only adjust volume and speed" — `previous_music.name ==
+  bgm.name`) applies to *every* caller, not just the Play BGM event command
+  — `Scene_Battle::Init` (`src/scene_battle.cpp`) opens a fight with a bare
+  `BgmPlay(GetSystemBGM(BGM_Battle))`, the identical function, so a battle
+  track configured to the same file as whatever the field was already
+  playing never breaks and restarts it either. This codebase instead has
+  seven separate BGM-switching helpers on `Scene::Map`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — `#play_battle_bgm`/
+  `#restore_pre_battle_bgm`, `#play_vehicle_bgm`/`#restore_pre_vehicle_bgm`,
+  `#play_victory_bgm`, and `#play_inn_bgm`/`#restore_pre_inn_bgm` — each of
+  which called `RGSS::Audio.bgm_play` unconditionally and independently of
+  the already-fixed `Game::Interpreter#play_audio` same-file check, so a
+  battle/vehicle/inn BGM naming the same file as the current track (or
+  restoring a pre-transition track this scene never actually stopped)
+  wrongly broke and restarted it. Fixed by extracting a shared
+  `Scene::Map#play_bgm(music)` — the same `@state.current_bgm &&
+  @state.current_bgm[:name] == music[:name]` idiom `play_audio`'s `:bgm`
+  branch already uses, skipping `RGSS::Audio.bgm_play` on a match while
+  still updating `@state.current_bgm` to the new call's own vol/tempo — and
+  routing all seven call sites through it, so entering battle no longer
+  restarts a field track that happens to share the battle BGM's filename,
+  and — the asymmetric half a battle-only fix would have missed — restoring
+  that same field track once the fight ends no longer restarts it either,
+  since this scene's own BGM state already agrees it was never stopped.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a battle BGM
+  matching the already-playing field track, at different vol/tempo, opens
+  and closes an encounter with zero `RGSS::Audio.bgm_calls` on either
+  transition, while `@state.current_bgm`'s tracked vol/tempo still follows
+  each side's own configured values, matching `play_audio`'s existing
+  "tracks what should be playing even when the native call is skipped"
+  behaviour), confirmed to fail against the pre-fix code (asserting no
+  native replay, getting `[["BattleBGM", 70, 110]]`) before the fix. **The
   vol/tempo/pan-without-restart half is not addressed**: this build's
   `RGSS::Audio` exposes no primitive to adjust an already-playing BGM's
   volume, pitch, or pan in place — `bgm_play` (`mruby-rgss/src/audio.cxx`,

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1429,6 +1429,35 @@ class RPG2k
         row.airship_land ? true : false
       end
 
+      # Play `music` ({ name:, volume:, tempo: }) as the current BGM, the one
+      # choke point every BGM-switching helper below (vehicle/battle/victory/
+      # inn, play and restore alike) funnels through. RPG_RT's BGM is a
+      # single channel with one real entry point on the native side --
+      # EasyRPG's `Game_System::BgmPlay` (`src/game_system.cpp`) -- and it
+      # special-cases re-selecting the file already playing: "Same music:
+      # Only adjust volume and speed" rather than stopping and restarting it,
+      # for *every* caller, not just the Play BGM event command (battle entry
+      # itself calls the identical `BgmPlay`, per `Scene_Battle::Init` in
+      # `src/scene_battle.cpp`: `BgmPlay(GetSystemBGM(BGM_Battle))`). This
+      # codebase already ported that for the event-command path
+      # (`Game::Interpreter#play_audio`'s `:bgm` branch, same
+      # `same_file_already_playing` idiom) but every helper here still called
+      # `RGSS::Audio.bgm_play` unconditionally, so a battle/vehicle/inn BGM
+      # configured to the exact same file as whatever was already playing
+      # broke and restarted it from the top instead of continuing seamlessly
+      # across the transition — including the asymmetric case of restoring a
+      # field track this scene itself never actually stopped. Volume/tempo/
+      # pan are still not adjusted in place on a same-file call: `RGSS::Audio`
+      # has no such primitive (`bgm_play` always restarts via SDL_mixer), the
+      # same already-documented limitation the event-command path carries.
+      def play_bgm(music)
+        same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == music[:name]
+        unless same_file_already_playing
+          RGSS::Audio.bgm_play(music[:name], music[:volume] || 100, music[:tempo] || 100)
+        end
+        @state.current_bgm = music
+      end
+
       # Play the vehicle's own BGM — a Change System BGM (10660) override for
       # its slot when one is set, else the database System boat / ship /
       # airship music — remembering the BGM that was playing so
@@ -1439,8 +1468,7 @@ class RPG2k
         music = vehicle_bgm(type)
         return unless music
         @pre_vehicle_bgm = @state.current_bgm
-        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
-        @state.current_bgm = music
+        play_bgm(music)
       rescue StandardError => e
         $stderr.puts "[RPG2k] vehicle BGM failed: #{e.message}"
       end
@@ -1451,8 +1479,7 @@ class RPG2k
         bgm = @pre_vehicle_bgm
         @pre_vehicle_bgm = nil
         return unless bgm && bgm[:name] && !bgm[:name].empty?
-        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
-        @state.current_bgm = bgm
+        play_bgm(bgm)
       rescue StandardError => e
         $stderr.puts "[RPG2k] restoring BGM failed: #{e.message}"
       end
@@ -1474,8 +1501,7 @@ class RPG2k
         music = battle_bgm
         return unless music
         @pre_battle_bgm = @state.current_bgm
-        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
-        @state.current_bgm = music
+        play_bgm(music)
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle BGM failed: #{e.message}"
       end
@@ -1511,8 +1537,7 @@ class RPG2k
       def play_victory_bgm
         music = victory_bgm
         return unless music
-        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
-        @state.current_bgm = music
+        play_bgm(music)
       rescue StandardError => e
         $stderr.puts "[RPG2k] victory BGM failed: #{e.message}"
       end
@@ -1543,8 +1568,7 @@ class RPG2k
         bgm = @pre_battle_bgm
         @pre_battle_bgm = nil
         return unless bgm && bgm[:name] && !bgm[:name].empty?
-        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
-        @state.current_bgm = bgm
+        play_bgm(bgm)
       rescue StandardError => e
         $stderr.puts "[RPG2k] restoring BGM after battle failed: #{e.message}"
       end
@@ -1566,8 +1590,7 @@ class RPG2k
         music = inn_bgm
         return unless music
         @pre_inn_bgm = @state.current_bgm
-        RGSS::Audio.bgm_play(music[:name], music[:volume], music[:tempo])
-        @state.current_bgm = music
+        play_bgm(music)
       rescue StandardError => e
         $stderr.puts "[RPG2k] inn BGM failed: #{e.message}"
       end
@@ -1595,8 +1618,7 @@ class RPG2k
         bgm = @pre_inn_bgm
         @pre_inn_bgm = nil
         return unless bgm && bgm[:name] && !bgm[:name].empty?
-        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
-        @state.current_bgm = bgm
+        play_bgm(bgm)
       rescue StandardError => e
         $stderr.puts "[RPG2k] restoring BGM after inn failed: #{e.message}"
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4022,6 +4022,42 @@ check 'Enemy Encounter scene: a Change System BGM battle override beats the data
   eq 'CustomBattle', st.current_bgm[:name]
 end
 
+check 'Enemy Encounter scene: a battle BGM matching the already-playing field track ' \
+      'does not restart it, and neither does restoring it back after the fight' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  # The field track already playing is the exact file the database's own
+  # battle_music names ('BattleBGM', see new_scene's system fixture above),
+  # just at different vol/tempo -- the scenario yado.tk's "field and battle
+  # BGM sharing the same file continue seamlessly across the transition"
+  # describes.
+  st.current_bgm = { name: 'BattleBGM', volume: 50, tempo: 90 }
+  RGSS::Audio.reset_bgm
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  eq [], RGSS::Audio.bgm_calls,
+     'entering battle does not break and restart a track that is already playing'
+  eq 'BattleBGM', st.current_bgm[:name]
+  eq 70, st.current_bgm[:volume], "the battle track's own vol/tempo are still tracked " \
+                                   '(RPG_RT re-applies them in place; this build has no ' \
+                                   'native primitive for that, see docs/TODO.md)'
+  eq 110, st.current_bgm[:tempo]
+  RGSS::Audio.reset_bgm
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result
+  scene.update
+  RGSS::Input.triggered = []
+  eq [], RGSS::Audio.bgm_calls,
+     'restoring the field BGM after the fight does not restart it either -- ' \
+     'this scene never actually stopped it in the first place'
+  eq 'BattleBGM', st.current_bgm[:name]
+  eq 50, st.current_bgm[:volume], "the restored pre-battle vol/tempo snapshot wins back"
+  eq 90, st.current_bgm[:tempo]
+end
+
 check 'Enemy Encounter scene: victory plays the database battle_end_music over the result screen' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s yado.tk "BGM/SE" bullet's sub-claim "field and battle BGM sharing the same file continue seamlessly across the transition" was still open, even though a sibling claim in the same bullet ("re-triggering the exact same file... does not restart it") had already been fixed for the Play BGM event-command path.
- `Game::Interpreter#play_audio`'s `:bgm` branch already suppresses `RGSS::Audio.bgm_play` when the requested filename matches the currently-playing one. But `Scene::Map`'s seven separate BGM-switching helpers (`#play_battle_bgm`/`#restore_pre_battle_bgm`, `#play_vehicle_bgm`/`#restore_pre_vehicle_bgm`, `#play_victory_bgm`, `#play_inn_bgm`/`#restore_pre_inn_bgm`) each called `RGSS::Audio.bgm_play` directly, bypassing that check.
- Verified against EasyRPG Player's actual C++ source: real RPG_RT has exactly one native BGM entry point, `Game_System::BgmPlay` (`src/game_system.cpp`), whose same-file branch ("Same music: Only adjust volume and speed") applies to every caller — including battle entry, since `Scene_Battle::Init` calls the identical `BgmPlay(GetSystemBGM(BGM_Battle))`.
- Extracted a shared `Scene::Map#play_bgm(music)` mirroring `play_audio`'s existing same-file idiom, routed all seven call sites through it. Also fixes the asymmetric half a battle-only patch would have missed: restoring the field BGM after a fight no longer restarts a track this scene never actually stopped.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 422 checks pass (1 new: a battle BGM matching the already-playing field track does not restart it, and neither does restoring it back after the fight — zero `bgm_calls` on either transition while tracked vol/tempo still update — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_