### PR TITLE
Fix self/ally-scoped skills to cure states in battle

### DIFF
--- a/changelog.d/battle-skill-state-cure.fixed.md
+++ b/changelog.d/battle-skill-state-cure.fixed.md
@@ -1,0 +1,18 @@
+- **A self/ally-scoped skill's own `state_effects` list now cures states in
+  battle**, not just HP/SP — a "Cure Poison"/"Full Recovery"-style skill was
+  silently inert on its status half in a fight (only its HP/SP/stat effect
+  landed), while the identical medicine *item* already worked and the same
+  skill cast from the field menu already worked too. EasyRPG's
+  `Game_BattleAlgorithm::Skill::vExecute` settles which polarity applies:
+  `heals_states = IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_
+  effect)`, and under the RPG2000-only reading this runtime models (no
+  `Player::IsRPG2k3()` gate), that collapses to "scope alone decides" — a
+  self/ally-scoped skill's flagged states always cure, `reverse_state_effect`
+  plays no part, mirroring the already-settled `#skill_attr_shift` direction
+  fix off the identical formula. `Game::Party#battle_skill_command`'s
+  self/ally-scope branch now carries `cured: skill_state_ids(sk)`, threaded
+  through `#command_skill`/`#command_skill_all` (the player's battle skill
+  menu) and `Game::Battle#skill_command_hash` (the AI-chosen enemy-cast
+  path) into `Game::Battle#apply_skill_hit`'s existing, already-tested
+  `cmd[:cured]` removal — the same mechanism a battle medicine's own cure
+  already used, unconditionally, with no change needed there.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4453,6 +4453,62 @@ not yet verified:
   error; the identical command from any other trigger type, or from a
   Parallel-Process **common** event, does not crash. (An authentic engine
   crash — flagged for awareness, not necessarily something to reproduce.)
+- ✅ **A self/ally-scoped skill's own `state_effects` now cure in battle too**,
+  not just heal HP/SP — found while cross-checking this codebase's enemy AI
+  (`Game::Battle#choose_enemy_action`/`#enemy_action_valid?`, already a faithful
+  port of EasyRPG's `EnemyAi::AlgorithmRatingBased`) against EasyRPG's
+  `IsSkillEffectiveOnAnyTarget`/`IsSkillEffectiveOn` (`src/enemyai.cpp`), which
+  filter a self/ally-scoped action out of an enemy's choices unless it would
+  actually cure a state some troop-mate currently carries — that filter
+  presupposed a mechanic this codebase never actually had. `Game::Party
+  #battle_skill_command`'s enemy-scope (attack) branch already carried a
+  skill's `state_effects` into `inflict:`/`chance:` (the existing "Attack
+  skills inflict states" note a few paragraphs up), but its self/ally/party-
+  scope (`else`) branch — the "Cure Poison"/"Full Recovery"-style skill shape
+  — carried none of it: no `cured:` key at all, unlike an **item**'s identical
+  cure (`Game::Party#command_item`'s own `cured:`, wired straight through to
+  `Game::Battle#apply_skill_hit`'s existing, already-tested `cmd[:cured]`
+  removal). So an ally-scoped state-cure *skill* was silently inert in battle
+  — only its HP/SP/stat effects landed — while the equivalent medicine item
+  worked, and while the same skill cast from the *field* menu
+  (`Game::Party#cast_skill`, via `#skill_cured_states`) worked too. Which
+  polarity a self/ally-scoped skill's `state_effects` list applies is
+  settled by EasyRPG's `Game_BattleAlgorithm::Skill::vExecute`: `heals_states
+  = IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`, and
+  `IsPositive()` is `Algo::SkillTargetsAllies(skill)` — true for every scope
+  but Scope_enemy(0)/Scope_enemies(1) — so under the RPG2000-only reading
+  this runtime already commits to elsewhere (no `Player::IsRPG2k3()` gate
+  modelled), `reverse_state_effect` plays **no part** in battle cure-vs-inflict
+  either, exactly like the already-settled `#skill_attr_shift` direction fix
+  above reading the identical formula: only scope decides, and a self/ally-
+  scoped skill's flagged states always cure, never inflict. Fixed by adding
+  `cured: skill_state_ids(sk)` to `battle_skill_command`'s `else` branch (the
+  field-only `#skill_cured_states`/`#skill_inflicted_states`, which *do*
+  consult `reverse_state_effect`, are deliberately not reused here — they
+  answer the field's own, different rule) and threading a new `cured:`
+  keyword through both command builders that feed `Game::Battle#apply_skill_hit`:
+  `Game::Party#command_skill`/`#command_skill_all` (the player's own battle
+  skill menu, `Scene::Map#apply_pending_skill`/`#apply_pending_skill_all`) and
+  `Game::Battle#skill_command_hash` (the AI-chosen enemy-cast path,
+  `#enemy_skill_action`) — both previously missing the field entirely, so a
+  monster's own "Cure" action was exactly as inert as the player-menu path.
+  No change was needed to `#apply_skill_hit` itself: its recovery branch's
+  `cured = (cmd[:cured] || []).select { |s| target.state?(s) }` already
+  existed, generic over item- and skill-sourced commands alike, unconditional
+  (no accuracy roll, matching EasyRPG's own unconditional `State::Remove` for
+  the healing direction, versus the probability-gated `State::Add` the
+  inflict direction alone already used). Covered by three new
+  `scripts/rpg2k_logic_check.rb` checks: `battle_skill_command`'s `:cured`
+  across ally-single/ally-all/self scope (with `reverse_state_effect` proven
+  inert on every one, mirroring the `attr_shift` check's own structure) and
+  its absence on the enemy-scope branch; a full `Game::Battle#run_round`
+  confirming a poisoned ally's state is actually removed from a player-cast
+  Antidote skill; and the enemy-cast counterpart, a self-scoped "Focus"
+  monster skill curing its own status through `#enemy_skill_action` — all
+  three confirmed to fail against the pre-fix code (a missing `:cured` key,
+  and the state still present after the round) before the fix, alongside a
+  pre-existing full-hash `battle_skill_command` assertion updated to expect
+  the new key.
 
 **Party / Actor / Vehicle**
 - Party is hard-capped at 4; adding a 5th via Change Party Member is a

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3545,7 +3545,22 @@ module Game
           # is 0 for such a skill, but the ATK/DEF/SPI/AGI modifier applies
           # regardless, off the same `base` EasyRPG's one shared `effect`
           # local would carry into every affect_* branch alike.
-          stat_effect: base }
+          stat_effect: base,
+          # A self/ally-scoped skill's own `state_effects` list -- EasyRPG's
+          # `Game_BattleAlgorithm::Skill::vExecute` computes `heals_states =
+          # IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`,
+          # and `IsPositive()` is simply "this skill targets allies" (true for
+          # every scope reaching this branch) -- so in battle, unlike on the
+          # field (`#skill_cured_states`), `reverse_state_effect` plays no part
+          # at all under the RPG2000-only rule this runtime models (matching
+          # #skill_attr_shift's own already-settled reading of the identical
+          # formula): an ally/self-scoped skill's flagged states are always
+          # cured here, never inflicted. Reuses `Game::Battle#apply_skill_hit`'s
+          # existing `cmd[:cured]` machinery unconditionally, exactly like a
+          # battle medicine's own state cure -- no separate accuracy roll,
+          # since only the *inflict* direction (the enemy-scope branch above)
+          # is ever gated by `chance`.
+          cured: skill_state_ids(sk) }
       end
     end
 
@@ -6742,14 +6757,15 @@ module Game
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
                       chance: 100, variance: 0, attributes: nil, skill_id: nil,
                       absorb: false, attr_shift: nil, attr_ids: nil,
-                      stat_mod_keys: nil, stat_effect: 0)
+                      stat_mod_keys: nil, stat_effect: 0, cured: nil)
       ally.command = { kind: :skill, target: target, name: name,
                        skill_id: skill_id, absorb: absorb,
                        cost: cost, hp: hp, mp: mp,
                        inflict: inflict || [], chance: chance, variance: variance,
                        attributes: attributes || [],
                        attr_shift: attr_shift, attr_ids: attr_ids || [],
-                       stat_mod_keys: stat_mod_keys || [], stat_effect: stat_effect }
+                       stat_mod_keys: stat_mod_keys || [], stat_effect: stat_effect,
+                       cured: cured || [] }
       ally.action = nil; ally.defending = false
     end
 
@@ -6766,12 +6782,13 @@ module Game
     def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
                           variance: 0, attributes: nil, skill_id: nil,
                           absorb: false, attr_shift: nil, attr_ids: nil,
-                          stat_mod_keys: nil, stat_effect: 0)
+                          stat_mod_keys: nil, stat_effect: 0, cured: nil)
       ally.command = { kind: :skill, all: true, targets: targets, name: name,
                        skill_id: skill_id, absorb: absorb, cost: cost, inflict: inflict || [], chance: chance,
                        variance: variance, attributes: attributes || [],
                        attr_shift: attr_shift, attr_ids: attr_ids || [],
-                       stat_mod_keys: stat_mod_keys || [], stat_effect: stat_effect }
+                       stat_mod_keys: stat_mod_keys || [], stat_effect: stat_effect,
+                       cured: cured || [] }
       ally.action = nil; ally.defending = false
     end
 
@@ -7287,7 +7304,8 @@ module Game
         absorb: cmd[:absorb] ? true : false,
         cost: cmd[:cost] || 0, hp: cmd[:hp] || 0, mp: cmd[:mp] || 0,
         inflict: cmd[:inflict] || [], chance: cmd[:chance] || 100,
-        variance: cmd[:variance] || 0, attributes: cmd[:attributes] || [] }
+        variance: cmd[:variance] || 0, attributes: cmd[:attributes] || [],
+        cured: cmd[:cured] || [] }
     end
 
     def skill_name_of(sk)

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4042,7 +4042,8 @@ class RPG2k
                                           attr_shift: c[:attr_shift],
                                           attr_ids: c[:attr_ids],
                                           stat_mod_keys: c[:stat_mod_keys],
-                                          stat_effect: c[:stat_effect] || 0)
+                                          stat_effect: c[:stat_effect] || 0,
+                                          cured: c[:cured])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor
@@ -4071,7 +4072,8 @@ class RPG2k
                                               attr_shift: meta[:attr_shift],
                                               attr_ids: meta[:attr_ids],
                                               stat_mod_keys: meta[:stat_mod_keys],
-                                              stat_effect: meta[:stat_effect] || 0)
+                                              stat_effect: meta[:stat_effect] || 0,
+                                              cured: meta[:cured])
         @battle_ui[:pending] = nil
         @battle_ui[:phase] = :command
         advance_actor

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7617,11 +7617,11 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
        stat_mod_keys: [] },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
   eq({ cost: 5, hp: 32, mp: 0, variance: 4, attr_shift: nil, attr_ids: [],
-       stat_mod_keys: [], stat_effect: 32 },
+       stat_mod_keys: [], stat_effect: 32, cured: [] },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))
   # Cure affects HP and SP: effect = 10 + 40*12/40 = 22
   eq({ cost: 4, hp: 22, mp: 22, variance: 4, attr_shift: nil, attr_ids: [],
-       stat_mod_keys: [], stat_effect: 22 },
+       stat_mod_keys: [], stat_effect: 22, cured: [] },
      st.party.battle_skill_command(st.party.db_skill(9), caster, nil))
 end
 
@@ -7702,6 +7702,66 @@ check 'a skill flagged "attribute defence up/down" picks direction from ' \
      'enemy scope (single enemy) -> -1 (down/worse) regardless of reverse_state_effect')
   eq(-1, st.party.battle_skill_command(st.party.db_skill(10), caster, foe)[:attr_shift],
      'enemy scope (all enemies), reverse_state_effect ON -> still -1, the flag is irrelevant')
+end
+
+check 'a self/ally-scoped skill\'s own state_effects cure in battle, ' \
+      'ignoring reverse_state_effect (an enemy-scoped one still inflicts)' do
+  # EasyRPG's Game_BattleAlgorithm::Skill::vExecute: `heals_states =
+  # IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`, and
+  # `IsPositive()` is `Algo::SkillTargetsAllies(skill)` -- true for every scope
+  # but Scope_enemy(0)/Scope_enemies(1). Under the RPG2000-only reading this
+  # runtime models (no RPG2003 gate), reverse_state_effect therefore never
+  # enters into it here either, matching #skill_attr_shift's own already-
+  # settled reading of the identical formula: only scope decides cure vs.
+  # inflict. state_effects index i -> state id i+1.
+  cure_single = fake_skill(name: 'Antidote (ally)', scope: 3, sp_cost: 0, power: 0,
+                            state_effects: [0, 1], reverse_state: false)
+  cure_all_reversed = fake_skill(name: 'Antidote (all allies, reverse flag set)',
+                                  scope: 4, sp_cost: 0, power: 0,
+                                  state_effects: [0, 1], reverse_state: true)
+  cure_self = fake_skill(name: 'Focus (self)', scope: 2, sp_cost: 0, power: 0,
+                          state_effects: [0, 1], reverse_state: false)
+  attack = fake_skill(name: 'Poison Sting (enemy)', scope: 0, sp_cost: 0, power: 0,
+                       state_effects: [0, 1])
+  skills = { 7 => cure_single, 8 => cure_all_reversed, 9 => cure_self, 10 => attack }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+
+  eq [2], st.party.battle_skill_command(st.party.db_skill(7), caster, foe)[:cured],
+     'ally scope (single ally) -> cures state 2, reverse_state_effect off'
+  eq [2], st.party.battle_skill_command(st.party.db_skill(8), caster, foe)[:cured],
+     'ally scope (all allies), reverse_state_effect ON -> still cures, the flag is irrelevant'
+  eq [2], st.party.battle_skill_command(st.party.db_skill(9), caster, foe)[:cured],
+     'self scope -> cures too'
+  c = st.party.battle_skill_command(st.party.db_skill(10), caster, foe)
+  ok !c.key?(:cured), 'enemy scope carries no :cured key at all -- it inflicts instead'
+  eq [2], c[:inflict], 'the same flagged state, on the attack branch, is an inflict roll'
+end
+
+check 'a self/ally-scoped skill cures its own state_effects states in battle' do
+  # The gap this closes: Game::Party#battle_skill_command's self/ally-scope
+  # branch never carried a skill's own state_effects into the command at all,
+  # so a "Cure Poison"-style *skill* (as opposed to an item, which already had
+  # its own `cured:` wired via Game::Party#command_item) silently did nothing
+  # about a target's status in battle -- Game::Battle#apply_skill_hit's
+  # recovery branch already had the machinery (`cmd[:cured]`, shared with
+  # items), the skill side just never fed it.
+  cure = fake_skill(name: 'Antidote', scope: 3, sp_cost: 0, power: 0,
+                    state_effects: [0, 1]) # index 1 -> state id 2
+  st = skill_party(7 => cure)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  ally = combatant('Ally', 0, 0, 5, 100)
+  ally.states = [2]
+  foe = combatant('Foe', 0, 0, 1, 10)
+  bat = Game::Battle.new([caster, ally], [foe], Game::Rng.new(1))
+
+  c = st.party.battle_skill_command(st.party.db_skill(7), caster, ally)
+  eq [2], c[:cured]
+  bat.command_skill(caster, ally, name: 'Antidote', cost: c[:cost],
+                    hp: c[:hp], mp: c[:mp], cured: c[:cured])
+  bat.run_round
+  eq [], ally.states, 'the poisoned ally is cured'
 end
 
 check 'attribute defence shift applies to the target rank, capped at ' \
@@ -10365,6 +10425,29 @@ check 'an enemy heals a fellow monster with an ally-scoped skill' do
   e = b.step_action                            # the medic casts
   eq true, e[:recover], 'a recovery, not an attack'
   ok e[:recover_hp] > 0, 'HP restored to a monster'
+end
+
+check "an enemy's self-scoped skill cures its own status — enemy-cast cure" do
+  # The enemy-cast counterpart of "a self/ally-scoped skill cures its own
+  # state_effects states in battle" above: Game::Battle#skill_command_hash
+  # (the command shape #enemy_skill_action builds for an AI-chosen skill)
+  # never carried :cured either, so a monster's own "Cure" action was just as
+  # silently inert as the player-menu path was before that fix.
+  ai = skill_ai(1 => FakeAiSkill.new(name: 'Focus', scope: 2, power: 0,
+                                     affect_hp: false, state_effects: [0, 1]))
+  hero = combatant('Hero', 40, 0, 30, 500)
+  medic = combatant_mp('Medic', 10, 0, 5, 500, 100)
+  medic.states = [2]
+  medic.actions = [enemy_action(kind: 1, skill_id: 1)]
+  [hero, medic].each { |c| c.spi ||= 0 }
+  b = Game::Battle.new([hero], [medic], Game::Rng.new(1), nil, false,
+                       false, false, false, nil, ai)
+  b.begin_round
+  b.step_action                                # the hero swings
+  e = b.step_action                            # the monster casts on itself
+  eq true, e[:recover], 'a recovery, not an attack'
+  eq [2], e[:cured], 'the afflicted monster cures its own status'
+  ok !medic.state?(2), 'and no longer carries the state'
 end
 
 check 'an all-enemies skill hits every party member at once' do


### PR DESCRIPTION
## Summary

Self/ally-scoped skills with `state_effects` now properly cure states during battle, matching the behavior of battle medicine items and field-cast skills. Previously, these skills would only apply their HP/SP/stat effects while silently ignoring their status cure properties.

## Changes

- **Game::Party#battle_skill_command**: Added `cured: skill_state_ids(sk)` to the self/ally-scope branch, enabling state cures for these skill types in battle. The `reverse_state_effect` flag is ignored in battle (only scope determines cure vs. inflict), matching EasyRPG's formula and the already-settled `#skill_attr_shift` behavior.

- **Game::Party#command_skill** and **#command_skill_all**: Added `cured:` parameter to thread the state cure information from `battle_skill_command` through to `Game::Battle#apply_skill_hit`, which already had the machinery to process `cmd[:cured]`.

- **Game::Battle#skill_command_hash**: Added `cured: cmd[:cured] || []` to support state cures for enemy AI-chosen skills, fixing the parallel issue where a monster's self-scoped "Cure" action was also silently inert.

- **Scene::Map#apply_pending_skill** and **#apply_pending_skill_all**: Updated to pass the `cured:` parameter through to the command builders.

## Implementation Details

- The fix reuses `Game::Battle#apply_skill_hit`'s existing `cmd[:cured]` machinery (already tested with items), applying state removal unconditionally with no accuracy roll — matching how the inflict direction works but without the probability gate.

- Under RPG2000-only semantics (no `Player::IsRPG2k3()` gate), `reverse_state_effect` plays no role in determining cure vs. inflict for self/ally-scoped skills in battle; only the skill's scope matters.

- Three new test cases verify: (1) ally-single/ally-all/self scope skills cure states with `reverse_state_effect` proven inert; (2) a full battle round confirms a poisoned ally is actually cured by a player-cast Antidote skill; (3) an enemy's self-scoped skill cures its own status through the AI path.

- One pre-existing test assertion updated to expect the new `:cured` key in `battle_skill_command` output.

https://claude.ai/code/session_01RYwDmKbncnVCrvytDYAn34