### PR TITLE
rpg2k: a battle-page Show Battle Animation (13260) now actually plays too

### DIFF
--- a/changelog.d/battle-page-show-battle-animation.fixed.md
+++ b/changelog.d/battle-page-show-battle-animation.fixed.md
@@ -1,0 +1,25 @@
+- **A Battle Event page's own Show Battle Animation (13260) now actually
+  plays**, instead of the "wait until it finishes" flag being silently
+  ignored — the same shape as the Parallel Process gap for the map command
+  (11210), for the battle-page form. `Scene::Map#drive_battle_event_wait`'s
+  dispatch had no `:animation` case, so a page blocked on one fell into the
+  generic "release the request, resume unconditionally" `else` branch and
+  was `#resume`d the very next frame — never built or drawn, regardless of
+  the wait flag. Fixed by adding `when :animation then drive_map_animation(it)`,
+  reusing the same shared renderer. That renderer needed generalizing
+  further: the command's own `target` param is a **troop member index**, not
+  a map target id, so a new `#start_battle_page_animation` (dispatched by
+  `#start_map_animation` off the request's `battle:` flag) positions it via
+  `#battle_animation_pixel` — the same enemy-sprite lookup a battle round's
+  own animation already uses — instead of misreading it the map way. This
+  also surfaced a latent bug in `#step_map_animation`'s finish branch: it
+  used to read the `battle:` flag itself as a proxy for "no interpreter is
+  waiting" (true only by coincidence for every prior caller), which would
+  have silently swallowed the resume a battle-page's own waiting interpreter
+  needs; now reads the real owner instead (`owner.resume if owner`).
+  Covered by three new `scripts/rpg2k_scene_check.rb` checks (the page's
+  interpreter actually parks on the `:animation` wait and stays held well
+  past the pre-fix bug's next-frame resume; the sprite draws centred on the
+  named troop member, not the ally screen-centre fallback; a flash_scope-1
+  timing pulses only that member, not a bystander or the screen), confirmed
+  to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4231,8 +4231,61 @@ not yet verified:
   case at all, so its generic "a battle page cannot open the map's
   teleport/shop/menu UI" `else` branch unconditionally `#resume`s it,
   meaning a battle-page Show Battle Animation may not render even *with*
-  its wait flag set — a separate, not-yet-fixed gap this pass did not
-  touch.
+  its wait flag set — fixed separately below.
+- ✅ **The battle-*page*'s own Show Battle Animation (13260,
+  `Game::Interpreter#do_show_battle_animation_b`) now actually plays too —
+  the same silently-ignored shape as the Parallel Process gap above, closed
+  the same way.** `Scene::Map#drive_battle_event_wait`'s dispatch (the wait
+  driver `#drive_battle_event` calls whenever a running battle-event page's
+  interpreter is parked) had no `:animation` case at all, so a page's Show
+  Battle Animation with the wait flag **on** fell into the generic "a battle
+  page cannot open the map's teleport/shop/menu UI" `else` branch and was
+  `#resume`d unconditionally the very next frame — never built, never drawn,
+  never actually waited on, regardless of the wait flag the command itself
+  set. Fixed by adding `when :animation then drive_map_animation(it)`,
+  reusing the exact same shared renderer the map command and the Parallel
+  Process fix above already drive. That renderer needed generalizing further
+  still: `#start_map_animation` always read a request's `target` the *map*
+  way (`#animation_target_pixel` — the player, "this event," a map event id,
+  a vehicle), but `do_show_battle_animation_b`'s own `target` is a **troop
+  member index** (param1, "the target troop member," not a map target id at
+  all) — reusing the map decoding for it would misplace the animation and
+  arm the wrong flash mechanism outright. Fixed with a new
+  `#start_battle_page_animation`, dispatched by `#start_map_animation`
+  whenever the request carries the `battle: true` flag
+  `do_show_battle_animation_b` already sets: it reads the target's live
+  screen position through `#battle_animation_pixel` (the same enemy-sprite
+  lookup `#start_battle_animation`'s own battle-round path already uses) and
+  builds through `#build_animation`'s `battle`/`target_index` args, so the
+  animation lands on the named troop member's actual sprite and its own
+  flash_scope-1 timing pulses that same sprite via the existing
+  `#fire_target_flash` battle-round mechanism, not a map character's
+  CharSet-tone one. This surfaced one more latent bug in code the Parallel
+  Process fix above had left untested on this exact combination:
+  `#step_map_animation`'s finish branch used to read `ma[:battle]` itself as
+  a proxy for "no interpreter is waiting on this" (`owner.resume unless
+  ma[:battle] || owner.nil?`), true only by coincidence for every *existing*
+  caller of `ma[:battle] = true` — `#start_battle_animation`'s own
+  battle-round animations, which never set `@map_animation_interp` at all,
+  so `owner` was always already `nil` there regardless of the flag. A
+  battle-page's own animation breaks that coincidence on purpose: it needs
+  `ma[:battle]` true for its screen-space pixel and enemy-sprite flash
+  target, *and* a real owning interpreter (the battle-event interpreter
+  parked on the wait) that must actually resume once the animation finishes.
+  Fixed by reading the real owner instead of the flag: `owner.resume if
+  owner` — unaffected for the battle-round path, where `owner` is `nil` by
+  construction either way. Covered by three new `scripts/rpg2k_scene_check.rb`
+  checks (the page's interpreter is confirmed to actually reach and hold on
+  the `:animation` wait, and its trailing Control Switches command is still
+  unrun two frames past that point — short of animation 8's own ~8-frame
+  play, unlike the pre-fix unconditional next-frame resume — before finally
+  landing once the animation genuinely finishes; the animation sprite draws
+  centred on the named troop member's own sprite position, not the
+  screen-centre ally fallback or a map character; a flash_scope-1 timing
+  pulses only the named troop member's sprite, leaving a bystander member
+  and the screen flash untouched), the first and third confirmed to fail
+  against the pre-fix code before the fix (the second failing on the sprite
+  never having drawn at all).
 - ✅ **The "1 frame = 1/30s" half of the bullet above is now correct, and
   the "'Wait' frame is internally two consecutive frames" framing turns out
   to have been a misreading — settled against EasyRPG Player's actual C++

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4444,6 +4444,7 @@ class RPG2k
       def drive_battle_event_wait(it)
         case it.wait_kind
         when :message, :choice then drive_battle_event_message(it)
+        when :animation then drive_map_animation(it)
         when :wait
           @battle_ui[:event_timer] ||= frames_from_tenths(it.wait_frames)
           if @battle_ui[:event_timer] <= 0
@@ -5754,9 +5755,15 @@ class RPG2k
           owner = @map_animation_interp
           @map_animation_interp = nil
           # A battle-round animation (#start_battle_animation) is driven by the
-          # round rather than by an event command, so it never set an owner --
-          # there is no paused interpreter waiting on it.
-          owner.resume unless ma[:battle] || owner.nil?
+          # round rather than by an event command, so it never sets
+          # @map_animation_interp in the first place -- owner is nil there by
+          # construction, not because ma[:battle] itself means "no owner": a
+          # battle-*page*'s own Show Battle Animation (13260,
+          # #start_battle_page_animation) also carries ma[:battle] true, for
+          # its screen-space pixel and enemy-sprite flash target, but very
+          # much does have one (the battle-event interpreter waiting on it),
+          # so this reads the actual owner rather than special-casing the flag.
+          owner.resume if owner
           return
         end
         fire_animation_flashes(ma)
@@ -5885,8 +5892,17 @@ class RPG2k
       # (`{ animation:, target:, ... }`), or nil when there is no request, the
       # animation is unknown, or its Battle/<name> sheet is missing (then the
       # timed-wait fallback runs).
+      #
+      # A request's own `battle` flag (set only by #do_show_battle_animation_b,
+      # the battle-*page* form of this command, 13260) picks which target
+      # scheme `req[:target]` names: a map target id (the player/"this
+      # event"/a map event/a vehicle) for the ordinary map-triggered form
+      # (11210), or a troop *member index* for the battle-page one -- the two
+      # are not interchangeable, so this dispatches to the matching builder
+      # rather than always reading `req[:target]` the map way.
       def start_map_animation(req)
         return nil unless req
+        return start_battle_page_animation(req) if req[:battle]
         tx, ty = animation_target_pixel(req[:target])
         # Every map target -- the player, a map event, a vehicle -- draws from
         # a CharSet frame of this one fixed size (see #draw_vehicles, which
@@ -5895,6 +5911,22 @@ class RPG2k
         # kind of character this actually is.
         build_animation(req[:animation], tx, ty, target_height: Game::CharSet::HEIGHT,
                          flash_target: map_animation_flash_target(req[:target]))
+      end
+
+      # Show Battle Animation (13260), the battle-page form of 11210: it needs
+      # the battle-*round*'s own positioning (#battle_animation_pixel, the
+      # targeted enemy's live sprite -- or the ally-side screen-centre
+      # fallback) and its Character Flash mechanism (#fire_target_flash, an
+      # `@battle_ui[:enemy_sprites]` entry), the same two `battle_animation_id`/
+      # `entry`-shaped inputs #start_battle_animation already builds from a
+      # round's own log entry -- just keyed off `req[:target]` (the command's
+      # own troop-member param) directly instead of an entry's
+      # `target_index`, since a battle page names its target explicitly
+      # rather than inheriting it from whichever action just landed.
+      def start_battle_page_animation(req)
+        tx, ty, height = battle_animation_pixel(target_index: req[:target])
+        build_animation(req[:animation], tx, ty, true, target_index: req[:target],
+                         target_height: height)
       end
 
       # The character a map-triggered flash_scope-1 timing (see

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7225,6 +7225,98 @@ check 'Change Battle Background from a page rebuilds the backdrop sprite' do
   ok !ui[:back_sprite].equal?(before), 'and it was rebuilt for the new name'
 end
 
+# Show Battle Animation (13260), the battle-page form of 11210 (see
+# do_show_battle_animation_b in interpreter.rb): drive_battle_event_wait's
+# dispatch used to have no :animation case at all, so a battle page's own
+# Show Battle Animation -- wait flag on or off -- fell into the generic
+# "release the request, resume unconditionally" else branch on the very
+# next frame: never built, never drawn, never actually waited on, the exact
+# same silently-ignored shape the already-fixed Common Event Parallel
+# Process gap had for the map-level command (11210). Fixed by adding an
+# :animation case that reuses #drive_map_animation, generalized (see
+# #start_battle_page_animation and #step_map_animation's finish check) to
+# also build a battle-round-styled animation -- keyed by troop *member
+# index*, per this command's own param1, not a map target id -- for a
+# request carrying the `battle:` flag do_show_battle_animation_b sets.
+check "a battle page's Show Battle Animation actually holds the page, not resuming immediately" do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [8, 0, 1], indent: 0), # anim 8, member 0, wait
+                             ECmd.new(ic::CONTROL_SWITCHES, [0, 21, 21, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages)
+  # Drive until the page's interpreter is actually parked on the :animation
+  # wait the command sets (rather than counting frames blindly, since the
+  # battle itself takes a few frames to open first).
+  it = nil
+  60.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    it = ui && ui[:events]
+    break if it && it.waiting? && it.wait_kind == :animation
+  end
+  ok it && it.wait_kind == :animation, 'the page reached the :animation wait'
+  ok !st.switches[21], 'the trailing Control Switches has not run yet'
+  # The pre-fix bug resumed unconditionally the very next frame regardless of
+  # the wait it just set (drive_battle_event_wait's missing :animation case
+  # fell into the generic else branch), landing the trailing Control
+  # Switches within two frames of this point -- well short of animation 8's
+  # own ~8-frame play (4 frames * ANIM_CELL_FRAMES 2).
+  2.times { scene.update }
+  ok !st.switches[21], 'still held two frames later: not resumed unconditionally on the next tick'
+  40.times { scene.update }
+  ok st.switches[21], 'the page ran on once the animation actually finished'
+end
+
+check "a battle page's Show Battle Animation draws over the targeted troop member's own sprite position" do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [8, 1, 1], indent: 0), # anim 8, member 1, wait
+                             ECmd.new(ic::CONTROL_SWITCHES, [0, 22, 22, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages)
+  spr_shown = false
+  ma_seen = nil
+  40.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    anim_spr = scene.instance_variable_get(:@animation_sprite)
+    spr_shown ||= anim_spr && anim_spr.visible
+    ma = scene.instance_variable_get(:@map_animation)
+    ma_seen ||= ma
+    break if st.switches[22]
+  end
+  ok spr_shown, 'the animation sprite actually drew'
+  ok ma_seen, 'the request was recorded as a live animation, not silently dropped'
+  ok ma_seen[:battle], 'positioned in screen space, like a battle-round animation'
+  ui = scene.instance_variable_get(:@battle_ui)
+  spr = ui[:enemy_sprites][1]
+  eq [spr.x + spr.bitmap.width / 2, spr.y + spr.bitmap.height / 2],
+     [ma_seen[:tx], ma_seen[:ty]], "centred on troop member 1's sprite, the command's own target param"
+  ok st.switches[22], 'and the page still ran on once it finished'
+end
+
+check "a battle page's Show Battle Animation target-scope flash pulses the named troop member, not a bystander" do
+  ic = Game::Interpreter::Cmd
+  # Animation 9 carries a flash_scope-1 ("target") timing on frame 0 -- see
+  # fake_db -- rather than 8's flash_scope-2 (screen) one. Targets troop
+  # member 0; member 1 is the untargeted bystander.
+  pages = { 1 => troop_page([ECmd.new(ic::SHOW_BATTLE_ANIM_B, [9, 0, 1], indent: 0),
+                             ECmd.new(ic::CONTROL_SWITCHES, [0, 23, 23, 0], indent: 0)]) }
+  scene, st = battle_scene_with_pages(pages)
+  ui = nil
+  target_flashed = false
+  bystander_flashed = false
+  40.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    next unless ui && ui[:enemy_sprites]
+    target_flashed ||= !!ui[:enemy_sprites][0].flash_color
+    bystander_flashed ||= !!ui[:enemy_sprites][1].flash_color
+    break if st.switches[23]
+  end
+  ok target_flashed, 'the targeted troop member (index 0) was flashed at some point during the play'
+  ok !bystander_flashed, 'the untargeted troop member (index 1) was never flashed'
+  ok !st.screen.flashing?, 'a flash_scope-1 timing never touches the screen flash'
+  ok st.switches[23], 'and the page still ran on once the animation finished'
+end
+
 check 'a battle page shows its message in a battle panel and waits for a key' do
   ic = Game::Interpreter::Cmd
   pages = { 1 => troop_page([ECmd.new(ic::SHOW_MESSAGE, [], string: 'It appears!'),


### PR DESCRIPTION
## Summary
- Closes a gap PR #642 explicitly left open: "the battle-page form of this command (13260) looks structurally worse — `drive_battle_event_wait`'s dispatch has no `:animation` case at all, so it may not render even with its wait flag set."
- `Game::Interpreter#do_show_battle_animation_b` (battle page's Show Battle Animation, 13260) correctly sets `@wait_kind = :animation` when its wait flag is on, but `Scene::Map#drive_battle_event_wait` had no `:animation` case in its dispatch — it fell into the generic `else` branch (`it.resume`), resuming the page unconditionally the very next frame without ever building or drawing the animation, regardless of the wait flag.
- Routing it through the existing `#drive_map_animation`/`#start_map_animation` renderer wasn't sufficient on its own: that renderer assumed a request's `target` was always a *map* target id, but a battle page's target is a **troop member index** — reusing the map decoding would misplace the animation and arm the wrong flash mechanism.
- Added `when :animation then drive_map_animation(it)` to `drive_battle_event_wait`; added `#start_battle_page_animation(req)`, dispatched by `#start_map_animation` when `req[:battle]` is set, using `#battle_animation_pixel` (the same enemy-sprite positioning a battle round's own animation uses).
- Fixed a latent bug this exposed in `#step_map_animation`'s finish branch: `owner.resume unless ma[:battle] || owner.nil?` treated `ma[:battle]` itself as a proxy for "no interpreter is waiting" — true only by coincidence for the pre-existing battle-round caller. A battle-page's own animation also sets `ma[:battle] = true` but *does* have a real waiting owner, so changed to `owner.resume if owner` (behavior-preserving for the round path, correct for the new page path).
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 727 checks pass (unaffected)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 426 checks pass (3 new: the page's interpreter actually reaches and holds on the `:animation` wait before finally resuming once the animation genuinely finishes; the animation sprite draws centred on the named troop member's own sprite position; a flash_scope-1 timing pulses only the named troop member's sprite — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_