### PR TITLE
Fix switch item menu behavior to close menu stack

### DIFF
--- a/changelog.d/item-menu-switch-item-closes-menu.fixed.md
+++ b/changelog.d/item-menu-switch-item-closes-menu.fixed.md
@@ -1,0 +1,6 @@
+- **Field item menu:** using a switch item (database item type 10) now
+  flips its switch, consumes one, and closes the whole menu stack at once —
+  the same as a special item invoking Escape or Teleport — instead of
+  dropping back into the (rebuilt) item list with a "Switch turned on."
+  message. A use that consumed nothing still reports "It had no effect." and
+  leaves the menu open. Covered by new checks in `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1788,7 +1788,10 @@ The work below is roughly ordered by the critical path to a walkable game
   A **switch item** (type **10**, not 9 — see below) is field-usable too:
   `Game::Party#use_switch_item` consumes one and returns the game switch it turns
   on, which the item menu then sets (matching EasyRPG, where the scene owns the
-  switch table). A **special item** (type 9, 特殊) invokes the skill named in its
+  switch table) before closing the whole menu stack at once — the same as a
+  special item invoking Escape or Teleport, with no confirmation message,
+  rather than dropping back to the (rebuilt) item list the way a medicine,
+  skill book or seed does. A **special item** (type 9, 特殊) invokes the skill named in its
   `skill_id`, with the item standing in for the SP cost — the user pays nothing
   and need not have learnt it, which is what Nepheshel's whole thrown-bomb line
   is. ✅ **A self/all-ally scope special item is castable from the item menu

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -5,12 +5,13 @@ class RPG2k
     # whole party (an all-ally item) or asks which ally to use it on (a
     # single-target item). Using an item consumes one and refreshes the list; an
     # item that would have no effect (everyone already full) is reported and not
-    # consumed. A special item invoking an Escape or Teleport skill warps the
+    # consumed. A switch item instead flips its game switch and closes the
+    # whole menu stack outright, with no "Used on ..." message -- the same as
+    # a special item invoking an Escape or Teleport skill, which warps the
     # party instead, the same as Scene::SkillMenu's own Escape/Teleport skills:
     # Escape jumps straight to its one registered target, Teleport opens a
-    # picker of every registered destination, and either closes the whole menu
-    # stack rather than showing a "Used on ..." message. All decision logic
-    # lives in Game::Party (field_items / use_item / item_effective? /
+    # picker of every registered destination. All decision logic lives in
+    # Game::Party (field_items / use_item / use_switch_item / item_effective? /
     # use_special_escape_item / use_special_teleport_item), which the host
     # harnesses test; this class is the RGSS UI over it, mirroring
     # Scene::Menu's window/cursor/message helpers.
@@ -129,12 +130,22 @@ class RPG2k
         build_target_window
       end
 
-      # A switch item turns on its game switch (the party consumes one); the menu
-      # owns the switch table.
+      # A switch item turns on its game switch (the menu owns the switch table)
+      # and consumes one -- then closes the whole menu stack at once, the same
+      # as a special item invoking Escape or Teleport (RPG_RT never leaves a
+      # switch item's user sitting in the item list afterwards, since flipping
+      # a switch is typically what a waiting map event is watching for). No
+      # confirmation message on success, matching that same Escape/Teleport
+      # precedent; a use that consumed nothing (not actually a held switch
+      # item) reports "It had no effect." and stays put instead.
       def apply_switch_item(id)
         sid = @state.party.use_switch_item(id)
-        @state.switches[sid] = true if sid
-        show_message(sid ? "Switch turned on." : "It had no effect.", :used)
+        if sid
+          @state.switches[sid] = true
+          @parent.pop_to_map
+        else
+          show_message("It had no effect.")
+        end
       end
 
       # A special item invoking an Escape-type skill: cast from the party

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8139,6 +8139,61 @@ check 'Scene::ItemMenu: the item list and target cursors wrap around' do
   eq 0, scene.instance_variable_get(:@target_index), 'Down from the last ally wraps to the first'
 end
 
+# A party whose only item is a switch (type 10) one -- Game::Party's own
+# decision logic (#use_switch_item) is covered by scripts/rpg2k_logic_check.rb;
+# this stub only has to hand the scene something that behaves the same way, so
+# the checks below stay about the RGSS wiring (does using it actually flip the
+# switch, consume one, and close the menu stack?).
+class SwitchItemStubParty < MenuStubParty
+  SWITCH_ID = 60
+  ITEM_SWITCH_ID = 77
+
+  attr_reader :use_switch_item_calls
+
+  def initialize
+    super
+    @use_switch_item_calls = []
+  end
+
+  def field_items(_state = nil); [[SWITCH_ID, 1]]; end
+
+  def db_item(id)
+    return nil unless id == SWITCH_ID
+    OpenStruct.new(name: 'Whistle', type: Game::Party::ITEM_SWITCH, switch_id: ITEM_SWITCH_ID)
+  end
+
+  def use_switch_item(id)
+    return nil unless id == SWITCH_ID
+    @use_switch_item_calls << id
+    ITEM_SWITCH_ID
+  end
+end
+
+check 'Scene::ItemMenu: a switch item flips its switch, consumes one, and closes ' \
+      'the whole menu stack, with no confirmation message' do
+  parent = fake_parent(fake_db)
+  state = Game::State.new(SwitchItemStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the only item
+  scene.update
+  RGSS::Input.reset
+  eq [SwitchItemStubParty::SWITCH_ID], state.party.use_switch_item_calls, 'exactly one use, consuming one'
+  ok state.switches[SwitchItemStubParty::ITEM_SWITCH_ID], 'the switch is turned on'
+  ok parent.pop_to_map_called, 'the whole menu stack closes rather than staying open'
+  ok scene.instance_variable_get(:@message).nil?, 'no confirmation message, matching Escape/Teleport'
+end
+
+check 'Scene::ItemMenu: a switch item that consumed nothing reports "no effect" and ' \
+      'leaves the menu open' do
+  parent = fake_parent(fake_db)
+  state = Game::State.new(SwitchItemStubParty.new, 1, 0, 0)
+  scene = RPG2k::Scene::ItemMenu.new(parent, state)
+  scene.send(:apply_switch_item, 999) # not a switch item this stub recognises -- #use_switch_item returns nil
+  ok state.party.use_switch_item_calls.empty?, 'nothing consumed'
+  ok !parent.pop_to_map_called, 'the menu stays open'
+  ok !scene.instance_variable_get(:@message).nil?, 'a message is shown'
+end
+
 # A party whose only item is a special (type 9) one invoking an all-ally scope
 # skill -- Game::Party's own decision logic (#use_special_item /
 # #field_usable?) is covered by scripts/rpg2k_logic_check.rb; this stub only


### PR DESCRIPTION
## Summary
Switch items (database item type 10) now properly close the entire menu stack when used, matching the behavior of special items that invoke Escape or Teleport skills. Previously, using a switch item would show a confirmation message and return to the item list.

## Changes
- **Scene::ItemMenu behavior:** Switch items now flip their associated game switch, consume one item, and immediately close the whole menu stack via `pop_to_map` with no confirmation message
- **Failed switch item use:** If a switch item use consumes nothing (invalid item), the menu shows "It had no effect." and remains open
- **Test coverage:** Added comprehensive checks in `scripts/rpg2k_scene_check.rb`:
  - `SwitchItemStubParty` test fixture for switch item scenarios
  - Verification that successful switch item use closes the menu stack
  - Verification that failed switch item use shows error message and keeps menu open
- **Documentation:** Updated inline comments in `item_menu.rb` to clarify switch item behavior and updated `TODO.md` to reflect the implemented behavior

## Implementation Details
The `apply_switch_item` method now:
1. Calls `@state.party.use_switch_item(id)` to consume the item and get the switch ID
2. On success: sets the switch and calls `@parent.pop_to_map` to close the entire menu stack (no message)
3. On failure: shows "It had no effect." message and leaves the menu open

This aligns switch item behavior with Escape/Teleport special items, which also close the menu stack immediately rather than returning to the item list.

https://claude.ai/code/session_013CdToqKVwSEFMhwcEhZRZv