### PR TITLE
rpg2k: Play Memorized BGM no longer restarts a still-playing track

### DIFF
--- a/changelog.d/memorized-bgm-same-file-no-restart.fixed.md
+++ b/changelog.d/memorized-bgm-same-file-no-restart.fixed.md
@@ -1,0 +1,13 @@
+- **Play Memorized BGM no longer restarts a track that was never actually
+  stopped.** `Game::Interpreter#do_play_memorized_bgm` called
+  `RGSS::Audio.bgm_play` unconditionally, so restoring a memorized BGM that
+  happened to share its filename with whatever was still currently playing
+  (e.g. Memorize BGM taken with nothing else played afterward, or a
+  duck-and-return to the same track) wrongly broke and restarted it from
+  the top. Verified against EasyRPG Player's own `Game_System::
+  PlayMemorizedBGM` (`src/game_system.h`), a bare call to the same
+  `Game_System::BgmPlay` every other BGM entry point goes through, same-file
+  skip included — not a lower-level call that bypasses it. Fixed with the
+  identical same-file idiom `Game::Interpreter#play_audio`'s `:bgm` branch
+  already uses. Covered by a new `scripts/rpg2k_logic_check.rb` check,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3777,7 +3777,34 @@ not yet verified:
   backed by `SDL_mixer`) is the only entry point that takes those
   parameters, and it always starts playback from the top. Implementing
   this half would need a new native backend primitive (e.g. an
-  `Mix_VolumeMusic`-style setter) that does not exist today.
+  `Mix_VolumeMusic`-style setter) that does not exist today. ✅ **"replaying
+  always restarts from the top" turns out to be imprecise for Play
+  Memorized BGM specifically — it was missing this same same-file skip.**
+  Verified against EasyRPG Player's actual C++ source rather than guessed
+  at: `Game_Interpreter::CommandPlayMemorizedBGM` (`src/game_interpreter.cpp`)
+  is a bare `Main_Data::game_system->PlayMemorizedBGM()`, and
+  `Game_System::PlayMemorizedBGM` (`src/game_system.h`) is itself just
+  `BgmPlay(data.stored_music)` — the identical `Game_System::BgmPlay` every
+  other BGM entry point goes through, same-file check included, not some
+  lower-level call that bypasses it. `Game::Interpreter#do_play_memorized_bgm`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) called `RGSS::Audio.bgm_play`
+  unconditionally, so restoring a memorized track that had, in fact, never
+  stopped playing (e.g. Memorize BGM taken with nothing else played in
+  between, or a duck-and-return where the ducked track happened to share
+  its filename) wrongly broke and restarted it — the same class of bug the
+  battle/vehicle/inn helpers above were fixed for, just missed on this one
+  remaining call site. Fixed with the identical `@state.current_bgm &&
+  @state.current_bgm[:name] == bgm[:name]` idiom `#play_audio`'s `:bgm`
+  branch already uses: the native call (and the `bgm_looped` reset) is
+  skipped on a match, while `@state.current_bgm` still updates to the
+  memorized track's own vol/tempo unconditionally, matching the "uses the
+  vol/tempo/pan settings active at memorize time" half of this bullet
+  exactly. The genuinely-restarts-from-the-top case (a different file, or no
+  BGM currently playing at all) is unaffected. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (Play BGM "town", Memorize BGM, Play
+  Memorized BGM with nothing else played in between reaches the backend
+  once, not twice), confirmed to fail against the pre-fix code (`["town",
+  "town"]`) before the fix.
 - SE is truly polyphonic (unlike BGM); ✅ **SE "OFF" now stops all playing
   SEs at once**, instead of silently doing nothing. `Game::Interpreter
   #play_audio` (`mruby-rpg2k/mrblib/interpreter.rb`) returned immediately on

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2954,13 +2954,22 @@ module Game
 
     # Play Memorized BGM: resume the BGM stashed by Memorize BGM, making it the
     # current BGM again. A no-op when nothing was memorised. Playback resumes
-    # from the start — the SDL_mixer backend cannot seek to the stored position.
+    # from the start — the SDL_mixer backend cannot seek to the stored position
+    # — *unless* the memorized file is the one still playing right now: real
+    # RPG_RT's `Game_System::PlayMemorizedBGM` is a bare call to the same
+    # `BgmPlay` every other BGM entry point goes through (Play BGM, and the
+    # battle/vehicle/inn helpers — see `Scene::Map#play_bgm`), so its "same
+    # music: only adjust volume and speed" no-restart rule applies here too,
+    # same idiom as `#play_audio`'s `:bgm` branch just below.
     def do_play_memorized_bgm(_cmd)
       bgm = @state.memorized_bgm
       return if bgm.nil? || bgm[:name].nil? || bgm[:name].empty?
-      RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
+      same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == bgm[:name]
+      unless same_file_already_playing
+        @state.bgm_looped = false
+        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
+      end
       @state.current_bgm = bgm.dup
-      @state.bgm_looped = false
     rescue StandardError => e
       $stderr.puts "[RPG2k] memorized BGM playback failed: #{e.message}"
       nil

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2306,6 +2306,26 @@ check 'Play Memorized BGM with nothing memorized does nothing' do
   eq nil, st.memorized_bgm
 end
 
+check 'Play Memorized BGM does not restart a track that never stopped playing' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # "town" is still the current track (nothing else played in between), so
+  # replaying the memorized BGM must not break and restart it, matching real
+  # RPG_RT's PlayMemorizedBGM -> BgmPlay same-file rule (see Play BGM's own
+  # "does not restart it" check just below).
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::MEMORIZE_BGM, []),
+    FakeCmd.new(IC::PLAY_MEMORIZED_BGM, []),
+  ])
+  it.update
+  names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
+  eq %w[town], names, 'the still-playing town track was not broken and restarted'
+  eq 'town', st.current_bgm[:name]
+  eq 80, st.current_bgm[:volume], 'state still tracks the memorized volume'
+end
+
 check 'Play BGM with the file already playing does not restart it' do
   RGSS::Audio.log = []
   st = new_state


### PR DESCRIPTION
## Summary

- `Game::Interpreter#do_play_memorized_bgm` (Play Memorized BGM, 11540) called `RGSS::Audio.bgm_play` unconditionally, so restoring a memorized BGM that happened to share its filename with whatever was still currently playing (e.g. Memorize BGM taken with nothing else played afterward, or a duck-and-return to the same track) wrongly broke and restarted it from the top.
- Verified against EasyRPG Player's actual C++ source rather than guessed at: `Game_Interpreter::CommandPlayMemorizedBGM` is a bare `Main_Data::game_system->PlayMemorizedBGM()`, and `Game_System::PlayMemorizedBGM` (`src/game_system.h`) is itself just `BgmPlay(data.stored_music)` — the identical `Game_System::BgmPlay` every other BGM entry point goes through, same-file skip included, not a lower-level call that bypasses it.
- Fixed with the identical `@state.current_bgm && @state.current_bgm[:name] == bgm[:name]` idiom `Game::Interpreter#play_audio`'s `:bgm` branch already uses (the same fix already applied to the battle/vehicle/inn BGM helpers in earlier PRs) — the native call and the `bgm_looped` reset are skipped on a match, while `@state.current_bgm` still updates to the memorized track's own vol/tempo unconditionally.
- Updated `docs/TODO.md`'s BGM/SE entry to reflect that "replaying always restarts from the top" was imprecise for this one command, and added a changelog fragment.

## Test plan

- [x] Added a regression check to `scripts/rpg2k_logic_check.rb` ("Play Memorized BGM does not restart a track that never stopped playing") — confirmed to fail against the pre-fix code (`["town", "town"]` instead of `["town"]`) via `git stash` of just `mruby-rpg2k/mrblib/interpreter.rb`.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 731 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 423 checks passed (unaffected, included for completeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAUyXdENUvoz33D8VzeH5F

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAUyXdENUvoz33D8VzeH5F)_