### PR TITLE
rpg2k: a battle switch item now actually flips its switch

### DIFF
--- a/changelog.d/battle-switch-item-effect.fixed.md
+++ b/changelog.d/battle-switch-item-effect.fixed.md
@@ -1,0 +1,9 @@
+- **Battle:** using a switch item (database item type 10) from the battle
+  Item command now actually flips its switch. It was already listed as
+  battle-usable and consumed from the bag when the action landed, but the
+  battle pipeline had nothing to compute for it (no HP/MP/state effect), so
+  it silently did nothing every time — and reported "no effect" in the
+  battle log on top of it. It now skips ally targeting entirely (a switch
+  item has no target, matching the field menu) and flips the switch at the
+  same moment the item is consumed. Covered by a new check in
+  `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2261,6 +2261,28 @@ The work below is roughly ordered by the critical path to a walkable game
   excludes the second actor: the picker offers only the first, and moving
   the cursor has nowhere to go), confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **A battle switch item now actually flips its switch.** A switch item
+  (type 10) was already listed in the battle Item command
+  (`Game::Party#battle_usable?` / `#battle_items` both include `ITEM_SWITCH`,
+  gated by `occasion_battle`) and consumed like any other landed item
+  (`Scene::Map#drive_battle_animate`'s `lose_item`), but the pipeline it went
+  through — `#battle_item_command` computing `item_recovery` / `cured` states,
+  then `Combatant`'s HP/MP change — has nothing for a switch item to compute
+  (its `recover_hp`/`recover_sp` are unset), so it silently consumed a copy
+  and did nothing, every time. `Scene::Map#drive_battle_item` now special-cases
+  a switch item the same way `Scene::ItemMenu#choose_item` already does for
+  the field menu — no ally-target step at all, since a switch item has no
+  target — queuing straight through `#apply_pending_switch_item`.
+  `Game::Battle#command_item` carries a new `switch_id:` alongside `item_id:`,
+  threaded through `#apply_command`'s log entry the same way, so
+  `#drive_battle_animate` can flip `@state.switches[entry[:switch_id]]` at the
+  exact moment it debits the bag — deferred to when the action lands, same as
+  every other battle item. The battle log no longer reports a flipped switch
+  as "no effect" either (`Scene::Map#battle_item_body` / `#battle_action_line`
+  treat a `switch_id` entry as always having done something, the same as
+  `Game::Party#item_effective?` already does for the field menu). Covered by
+  a new `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code (the switch stayed off, the item still vanished) before the fix.
 - ✅ **物理回避率アップ** (the item row's `raise_evasion`, field 26) — unread, so
   a shield/armour/helmet/accessory bought specifically for its evasion bonus
   was purely a stat stick against a normal attack. `ruby

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6795,10 +6795,13 @@ module Game
     # Queue a single-target Item for `ally` on `target`: restore the HP / SP and
     # cure the status conditions from Game::Party#battle_item_command. `item_id`
     # rides along on the log entry so the scene consumes one from the bag when the
-    # action lands.
-    def command_item(ally, target, item_id:, name:, hp: 0, mp: 0, cured: nil)
+    # action lands. `switch_id` is the same ride-along for a switch item (type
+    # 10, no real target -- the scene passes `ally` itself as `target` for one,
+    # see Scene::Map#apply_pending_switch_item): the scene flips it when the
+    # action lands too, the same moment the bag is finally debited.
+    def command_item(ally, target, item_id:, name:, hp: 0, mp: 0, cured: nil, switch_id: nil)
       ally.command = { kind: :item, target: target, item_id: item_id,
-                       name: name, hp: hp, mp: mp, cured: cured || [] }
+                       name: name, hp: hp, mp: mp, cured: cured || [], switch_id: switch_id }
       ally.action = nil; ally.defending = false
     end
 
@@ -7747,7 +7750,7 @@ module Game
           target_index: @enemies.index(target),
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
           cured: cured, target_ally: ally?(target), attr_shifted: shifted,
-          stat_changed: stat_changed,
+          stat_changed: stat_changed, switch_id: cmd[:switch_id],
           target_hp: target.hp, target_mp: target.mp }
       end
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4162,7 +4162,9 @@ class RPG2k
           it = @state.party.db_item(item_id)
           @battle_ui[:pending] = { kind: :item, item_id: item_id, it: it }
           close_battle_item
-          if @state.party.item_all_allies?(it)
+          if @state.party.switch_item?(item_id)
+            apply_pending_switch_item
+          elsif @state.party.item_all_allies?(it)
             apply_pending_item_all(living_allies)
           else
             @battle_ui[:ally_i] = 0
@@ -4206,6 +4208,27 @@ class RPG2k
             draw_battle_item
           end
         end
+      end
+
+      # Commit a switch item: it has no target at all -- the same as the field
+      # menu's own switch item (Scene::ItemMenu#apply_switch_item) skips
+      # straight past target selection -- so this queues immediately off
+      # #drive_battle_item's Confirm, with `current_actor` standing in for
+      # `command_item`'s `target:` (never read for a switch effect; a switch
+      # item's hp/mp are always 0, so it does not touch its HP/MP either).
+      # `switch_id` rides the log entry the same way `item_id` does, so
+      # #drive_battle_animate can flip it -- and only then, deferred to when
+      # the action actually lands, exactly like the bag deduction it sits
+      # beside there.
+      def apply_pending_switch_item
+        pending = @battle_ui[:pending]
+        @battle_ui[:battle].command_item(current_actor, current_actor,
+                                         item_id: pending[:item_id],
+                                         name: pending[:it].name,
+                                         switch_id: pending[:it].switch_id)
+        @battle_ui[:pending] = nil
+        @battle_ui[:phase] = :command
+        advance_actor
       end
 
       # Commit the pending item on `target` (recovery from the model; the bag is
@@ -4299,8 +4322,12 @@ class RPG2k
         entry = @battle_ui[:battle].step_action
         if entry
           # An Item action consumes one from the real bag when it lands (so
-          # backing out during the command phase never spends it).
+          # backing out during the command phase never spends it). A switch
+          # item flips its switch at the same moment -- the state table is
+          # the scene's, same as the field menu's own Scene::ItemMenu, and
+          # this is the only place a queued switch-item action ever reaches it.
           @state.party.lose_item(entry[:item_id], 1) if entry[:item_id]
+          @state.switches[entry[:switch_id]] = true if entry[:switch_id]
           log_round([entry])
           refresh_battle_status
           refresh_battle_sprites
@@ -4742,7 +4769,13 @@ class RPG2k
         start = bt.item_start(t, e[:actor].to_s, e[:source].to_s)
         return [battle_action_line(e)] unless start
         rest =
-          if skill_achieved_nothing?(e)
+          if e[:switch_id]
+            # A switch item always "does something" (flips its switch), even
+            # though it restores no HP/MP and cures nothing -- unlike a
+            # medicine it never "achieves nothing", so it is just the "used
+            # it!" line alone, the same silent flip the field menu shows.
+            []
+          elsif skill_achieved_nothing?(e)
             # An item that did nothing has no `failure_message` to choose with,
             # so RPG2000 has no sentence for it: the composed line still says
             # more than the bare "used it" would.
@@ -4831,7 +4864,10 @@ class RPG2k
           parts = []
           parts << "#{e[:recover_hp]} HP" if e[:recover_hp] && e[:recover_hp] > 0
           parts << "#{e[:recover_mp]} MP" if e[:recover_mp] && e[:recover_mp] > 0
-          body = parts.empty? ? 'no effect' : "+#{parts.join(' / ')}"
+          body = if !parts.empty? then "+#{parts.join(' / ')}"
+                 elsif e[:switch_id] then 'switch on'
+                 else 'no effect'
+                 end
           "#{e[:actor]}'s #{e[:source]}: #{e[:target]} #{body}"
         elsif e[:missed]
           "#{e[:attacker]} misses #{e[:target]}"

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6009,6 +6009,7 @@ class BattleMagicParty
   def db_item(id); id == 5 ? OpenStruct.new(name: 'Potion') : nil; end
   def battle_item_command(_it, _target); { hp: 20, mp: 0 }; end
   def item_all_allies?(it); it.respond_to?(:scope) && it.scope == 1; end
+  def switch_item?(_id); false; end
 end
 
 # Open a battle and step to the per-actor command menu.
@@ -6080,6 +6081,57 @@ check 'Enemy Encounter scene: using an Item heals and consumes one from the bag'
   scene.update                          # the Hero uses the Potion first
   eq 1, st.party.item_count(5), 'one potion consumed when the item action landed'
   eq 20, ui[:allies].first.hp - hp_before, 'the Hero was healed 20 HP'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'ItemUse' }, 'the item SE played too'
+end
+
+# A party whose only battle item is a switch (type 10) one -- battle-usability
+# and #use_switch_item's own consumption are Game::Party logic covered by
+# scripts/rpg2k_logic_check.rb; this stub only has to hand the scene something
+# that behaves the same way, so the check below stays about the RGSS wiring
+# (does choosing it skip ally targeting, and does landing actually flip the
+# switch and consume one -- the battle-side gap the field menu never had).
+class BattleSwitchItemParty < BattleMagicParty
+  SWITCH_ITEM_ID = 6
+  ITEM_SWITCH_ID = 42
+
+  def initialize
+    super()
+    @items = { SWITCH_ITEM_ID => 1 }
+  end
+
+  def db_item(id)
+    return OpenStruct.new(name: 'Whistle', switch_id: ITEM_SWITCH_ID) if id == SWITCH_ITEM_ID
+    nil
+  end
+
+  def switch_item?(id); id == SWITCH_ITEM_ID; end
+end
+
+check 'Enemy Encounter scene: using a switch item skips ally targeting, then ' \
+      'flips its switch and consumes one when the action lands' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleSwitchItemParty.new)
+  ui = battle_to_command(scene)
+
+  press_key(scene, RGSS::Input::DOWN)   # Attack -> Skill
+  press_key(scene, RGSS::Input::DOWN)   # Skill -> Defend
+  press_key(scene, RGSS::Input::DOWN)   # Defend -> Item
+  press_key(scene, RGSS::Input::C)      # open the item list
+  eq :item, ui[:phase]
+  press_key(scene, RGSS::Input::C)      # choose the switch item
+  eq :animate, ui[:phase],
+     'a switch item has no target -- it queues straight into the round, unlike the Potion above'
+  eq 1, st.party.item_count(BattleSwitchItemParty::SWITCH_ITEM_ID), 'not spent until the action lands'
+  ok !st.switches[BattleSwitchItemParty::ITEM_SWITCH_ID], 'not flipped yet either'
+
+  RGSS::Audio.reset_se
+  scene.update                          # the Hero's action lands
+  eq 0, st.party.item_count(BattleSwitchItemParty::SWITCH_ITEM_ID), 'one consumed when it landed'
+  ok st.switches[BattleSwitchItemParty::ITEM_SWITCH_ID], 'the switch is flipped'
   ok RGSS::Audio.se_calls.any? { |c| c[0] == 'ItemUse' }, 'the item SE played too'
 end
 


### PR DESCRIPTION
## Summary

- A switch item (database item type 10) was already listed as usable from the battle Item command (`Game::Party#battle_usable?` / `#battle_items`) and consumed from the bag when the queued action landed, but the battle pipeline it went through had nothing to compute for it (no HP/MP/state effect, unlike a medicine) — it silently consumed a copy and did nothing, every time, while the battle log reported it as "no effect" on top of it.
- `Scene::Map#drive_battle_item` now special-cases a switch item the same way the field menu's `Scene::ItemMenu#choose_item` already does: no ally-target step at all, since a switch item has no target.
- `Game::Battle#command_item` carries a new `switch_id:` alongside `item_id:`, threaded through `#apply_command`'s log entry, so `#drive_battle_animate` flips `@state.switches[entry[:switch_id]]` at the exact moment it debits the bag — deferred to when the action lands, the same as every other battle item.
- The battle log no longer reports a flipped switch as "no effect" (`battle_item_body` / `battle_action_line` treat a `switch_id` entry as always having done something).
- Related follow-up to #647, which fixed the equivalent field-menu switch item behavior (the menu now closes on use). This PR addresses the item-usable-count / effect gap on the battle side.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 427 checks passed (new check: choosing a switch item in battle skips ally targeting, then flips the switch and consumes one when the action lands)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 730 checks passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CdToqKVwSEFMhwcEhZRZv


---
_Generated by [Claude Code](https://claude.ai/code/session_013CdToqKVwSEFMhwcEhZRZv)_