### PR TITLE
rpg2k: an RPG2003 skill's reverse_state_effect now flips its state_effects in battle

### DIFF
--- a/changelog.d/rpg2003-skill-state-reverse.fixed.md
+++ b/changelog.d/rpg2003-skill-state-reverse.fixed.md
@@ -1,0 +1,18 @@
+- **A battle skill's `reverse_state_effect` flag now actually flips its
+  state_effects on an RPG2003 database.** EasyRPG's
+  `Game_BattleAlgorithm::Skill::vExecute` computes `heals_states =
+  IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)` — on
+  RPG2000 the XOR's right-hand term is always false, collapsing to the plain
+  "ally scope cures, enemy scope inflicts" rule this codebase already
+  modelled, but a real RPG2003 database with the flag set can invert either
+  scope: a self/ally skill inflicts its listed states on its own side (a
+  self-scoped Berserk that confuses its own caster) and an enemy skill cures
+  its target's states instead of adding new ones. `Game::Party
+  #battle_skill_command` now computes `heals_states` the same way, gated on
+  the existing `#rpg2003?` accessor, and `Game::Battle#apply_skill_hit`'s
+  attack/recovery branches both honour whichever of `cured:`/`inflict:` it
+  produced rather than assuming one from the branch alone. The field-skill
+  path (`Game_Battler::UseSkill`) was checked too and found already correct —
+  its own cure/inflict polarity carries no RPG2003 gate, matching what this
+  codebase already did there. Covered by new `scripts/rpg2k_logic_check.rb`
+  checks, confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5091,6 +5091,47 @@ above are repeated here)
   enemy-scoped Curse Fire shifting down, an ally-scoped Ward Fire shifting
   back up, both capped at one step from base), both confirmed to fail
   against the pre-fix code before the fix.
+- ✅ **The RPG2003-only `reverse_state_effect` gate this same formula's sibling
+  question (attribute-defence direction, just above) explicitly left open is
+  now implemented too.** Verified against EasyRPG Player's actual C++
+  source, fetched twice for this fix: `Game_BattleAlgorithm::Skill::vExecute`
+  (`src/game_battlealgorithm.cpp`) computes `heals_states = IsPositive() ^
+  (Player::IsRPG2k3() && skill.reverse_state_effect)` and then either
+  `State::Remove` (cure) or an accuracy-rolled `State::Add` (inflict) per
+  listed state depending on it — on an RPG2000 database the XOR's right-hand
+  term is always false, so this collapses to the plain "ally scope cures,
+  enemy scope inflicts" rule `Game::Party#battle_skill_command`
+  (`mruby-rpg2k/mrblib/game.rb`) already modeled unconditionally, but a real
+  RPG2003 database with the flag set can flip *either* scope: a self/ally
+  skill inflicts its listed states on its own side instead of curing them (a
+  self-scoped Berserk that confuses its own caster), and an enemy skill cures
+  its target's states instead of adding new ones. `battle_skill_command` now
+  computes `heals_states` the same way, gated on the same `#rpg2003?`
+  accessor the variable-range-widen and enemy-levitate fixes already key
+  off, and routes each scope branch's `cured:`/`inflict:`/`chance:` keys off
+  it rather than off which branch it is. The consumer side needed matching
+  work: `Game::Battle#apply_skill_hit` (`mruby-rpg2k/mrblib/game.rb`) used to
+  only ever roll `cmd[:inflict]` on the attack (negative-HP) branch and only
+  ever apply `cmd[:cured]` on the recovery (non-negative-HP) branch, so
+  neither branch had anywhere to route the flipped case; both branches now
+  handle both keys (each normally empty on the side that doesn't apply, so
+  the ordinary RPG2000/non-reversed path is unaffected), reusing the
+  existing `roll_inflict`/cure-and-prune machinery unchanged. The field-skill
+  path (`#skill_cured_states`/`#skill_inflicted_states`, `Game_Battler::
+  UseSkill` in EasyRPG's `src/game_battler.cpp`) was checked too and found
+  already correct: that function's own `if (skill->reverse_state_effect)`
+  branch carries no `Player::IsRPG2k3()` gate at all, so a field skill's
+  cure-vs-inflict polarity is unconditional on the flag by design, matching
+  what this codebase already did — nothing there needed to change. Covered
+  by three `scripts/rpg2k_logic_check.rb` checks: an RPG2000-database
+  control (`reverse_state_effect` confirmed inert on every scope, matching
+  the prior behavior exactly), a new RPG2003-database check (the flag
+  flipping both an ally/self and an enemy scope, plus a same-database
+  reverse-off control pinning the plain rule still holds there), and an
+  update to the full-hash `battle_skill_command` assertion to expect the new
+  always-present `cured:`/`inflict:`/`chance:` keys — the RPG2003 check
+  confirmed to fail against the pre-fix code (asserting `[]`, getting `[2]`)
+  before the fix.
 - Enemy group members are numbered by add-order. ✅ **The lower-numbered
   member renders in front (closer to camera)**: `Scene::Map#build_battle_sprites`
   / `#rebuild_battler_sprite` / `#reveal_battle_monster`

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3464,10 +3464,10 @@ module Game
     # except Scope_enemy(0)/Scope_enemies(1). `reverse_state_effect` plays no
     # part in this at all (that flag's own state-cure/inflict role is,
     # per the same function, `IsPositive() ^ (Player::IsRPG2k3() &&
-    # skill.reverse_state_effect)` -- gated behind an RPG2003 check this
-    # runtime does not model either way, a separate, wider question left
-    # untouched here). So the direction is purely the skill's own target
-    # scope: an ally-scoped skill (self/single ally/all allies, the "buff"
+    # skill.reverse_state_effect)` -- see #battle_skill_command's own
+    # `heals_states`, which implements exactly that formula, gate and all).
+    # So the direction is purely the skill's own target scope: an ally-scoped
+    # skill (self/single ally/all allies, the "buff"
     # shape) always raises resistance, an enemy-scoped one (single/all
     # enemies, the "curse" shape) always lowers it -- matching
     # #battle_skill_target's own enemy-scope test (`scope == 0 || scope ==
@@ -3524,18 +3524,36 @@ module Game
       shift = skill_attr_shift(sk)
       shift_ids = shift ? skill_attributes(sk) : []
       stat_keys = skill_stat_mod_keys(sk)
-      if sk.scope == 0 || sk.scope == 1 # single or all enemies: an attack skill
+      enemy_scope = sk.scope == 0 || sk.scope == 1 # single or all enemies
+      # A skill's own `state_effects` list normally cures on an ally/self scope
+      # and inflicts on an enemy scope -- EasyRPG's `Game_BattleAlgorithm::
+      # Skill::vExecute` computes `heals_states = IsPositive() ^
+      # (Player::IsRPG2k3() && skill.reverse_state_effect)`, where `IsPositive()`
+      # is simply "this skill targets allies". Under RPG2000 the XOR's
+      # right-hand term is always false, so this collapses to exactly that
+      # plain scope rule (matching #skill_attr_shift's own already-settled
+      # reading of the identical formula) -- but an RPG2003 database with
+      # `reverse_state_effect` set flips it either way: an ally-scoped skill
+      # inflicts its listed states instead of curing them (a self-scoped
+      # Berserk that confuses its own caster, say), and an enemy-scoped one
+      # cures its target's states instead of inflicting new ones.
+      reverse = sk.respond_to?(:reverse_state_effect) && sk.reverse_state_effect
+      heals_states = !enemy_scope ^ (rpg2003? && reverse)
+      state_ids = skill_state_ids(sk)
+      cure_ids = heals_states ? state_ids : []
+      inflict_ids = heals_states ? [] : state_ids
+      if enemy_scope # an attack skill
         dmg = base - skill_defence_term(sk, target)
         dmg = 1 if dmg < 1
         { cost: cost, hp: -dmg, mp: 0,
-          inflict: skill_state_ids(sk), chance: skill_hit(sk),
+          inflict: inflict_ids, chance: skill_hit(sk),
           variance: skill_variance(sk), attributes: skill_attributes(sk),
           # 吸収 — the caster takes what the target loses. RPG_RT reads the flag
           # only on an *offensive* skill (EasyRPG's `skill.absorb_damage &&
           # !IsPositive()`), so it rides only on this branch: a healing skill
           # that sets it drains nothing.
           absorb: skill_absorbs?(sk), attr_shift: shift, attr_ids: shift_ids,
-          stat_mod_keys: stat_keys }
+          stat_mod_keys: stat_keys, cured: cure_ids }
       else
         { cost: cost, hp: sk.affect_hp ? base : 0, mp: sk.affect_sp ? base : 0,
           variance: skill_variance(sk), attr_shift: shift, attr_ids: shift_ids,
@@ -3546,21 +3564,11 @@ module Game
           # regardless, off the same `base` EasyRPG's one shared `effect`
           # local would carry into every affect_* branch alike.
           stat_effect: base,
-          # A self/ally-scoped skill's own `state_effects` list -- EasyRPG's
-          # `Game_BattleAlgorithm::Skill::vExecute` computes `heals_states =
-          # IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`,
-          # and `IsPositive()` is simply "this skill targets allies" (true for
-          # every scope reaching this branch) -- so in battle, unlike on the
-          # field (`#skill_cured_states`), `reverse_state_effect` plays no part
-          # at all under the RPG2000-only rule this runtime models (matching
-          # #skill_attr_shift's own already-settled reading of the identical
-          # formula): an ally/self-scoped skill's flagged states are always
-          # cured here, never inflicted. Reuses `Game::Battle#apply_skill_hit`'s
-          # existing `cmd[:cured]` machinery unconditionally, exactly like a
-          # battle medicine's own state cure -- no separate accuracy roll,
-          # since only the *inflict* direction (the enemy-scope branch above)
-          # is ever gated by `chance`.
-          cured: skill_state_ids(sk) }
+          # Reuses `Game::Battle#apply_skill_hit`'s existing `cmd[:cured]`
+          # machinery when curing (no roll, matching a battle medicine's own
+          # state cure) and its `cmd[:inflict]`/`cmd[:chance]` roll when the
+          # RPG2003 reverse case above turns this into an inflict instead.
+          cured: cure_ids, inflict: inflict_ids, chance: skill_hit(sk) }
       end
     end
 
@@ -7711,21 +7719,25 @@ module Game
         end
         target.hp -= dmg
         b.hp = [b.hp + absorbed, b.max_hp].min if absorbed > 0
-        # An attack skill may inflict its states -- and shift attribute
-        # defence ranks -- on a surviving target, each rolled/applied only if
-        # it lived through the damage.
+        # An attack skill may inflict its states -- or, under the RPG2003
+        # reverse_state_effect flip #battle_skill_command's own `heals_states`
+        # already resolved, cure them instead -- and shift attribute defence
+        # ranks, each rolled/applied only if the target lived through the
+        # damage.
         if target.dead?
-          inflicted = already = shifted = []
+          inflicted = already = cured = shifted = []
           stat_changed = {}
         else
           inflicted, already = roll_inflict(target, cmd)
+          cured = (cmd[:cured] || []).select { |s| target.state?(s) }
+          target.states = (target.states || []) - cured unless cured.empty?
           shifted = apply_attr_shift(target, cmd)
           stat_changed = apply_stat_mods(target, cmd[:stat_mod_keys], stat_amount)
         end
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
-          inflicted: inflicted, already: already, attr_shifted: shifted,
-          stat_changed: stat_changed,
+          inflicted: inflicted, already: already, cured: cured,
+          attr_shifted: shifted, stat_changed: stat_changed,
           target_ally: ally?(target), skill: cmd[:name],
           skill_id: cmd[:skill_id], target_index: @enemies.index(target),
           absorbed_hp: absorbed }
@@ -7763,13 +7775,20 @@ module Game
         # unconditionally, matching the field item cure.
         cured = (cmd[:cured] || []).select { |s| target.state?(s) }
         target.states = (target.states || []) - cured unless cured.empty?
+        # An RPG2003 reverse_state_effect ally/self-scoped skill flips
+        # #battle_skill_command's own `cmd[:inflict]` on instead of `cmd[:cured]`
+        # (see its comment) -- roll it here the same way an attack skill does,
+        # so e.g. a self-scoped Berserk can confuse its own caster rather than
+        # only ever curing states on this branch.
+        inflicted, already = target.dead? ? [[], []] : roll_inflict(target, cmd)
         shifted = target.dead? ? [] : apply_attr_shift(target, cmd)
         stat_changed = target.dead? ? {} : apply_stat_mods(target, cmd[:stat_mod_keys], stat_amount)
         { recover: true, actor: b.name, source: cmd[:name],
           item_id: cmd[:item_id], skill_id: cmd[:skill_id], target: target.name,
           target_index: @enemies.index(target),
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
-          cured: cured, target_ally: ally?(target), attr_shifted: shifted,
+          cured: cured, inflicted: inflicted, already: already,
+          target_ally: ally?(target), attr_shifted: shifted,
           stat_changed: stat_changed, switch_id: cmd[:switch_id],
           target_hp: target.hp, target_mp: target.mp }
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3849,14 +3849,15 @@ end
 
 # A two-actor party (Hero atk 10 / spirit 12 / max SP 30, Ally max HP 50) plus
 # the given skill table, for the field-skill checks.
-def skill_party(skills, items = {})
+def skill_party(skills, items = {}, rpg2003: false)
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,
                            max_hp: 100, max_mp: 30, atk: 10, def: 8, int: 12, agi: 7),
     2 => FakePlayerRow.new('Ally', '', 0, 3,
                            max_hp: 50, max_mp: 20, atk: 6, def: 5, int: 4, agi: 6),
   }
-  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items, skills)), 1, 0, 0)
+  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items, skills,
+                                                   rpg2003: rpg2003)), 1, 0, 0)
 end
 
 check 'an RPG2003 subskill category behaves as an ordinary skill' do
@@ -7634,14 +7635,14 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   # all with its armour: 32 - (0*8/40 + 40*16/80) = 32 - 8 = 24.
   eq({ cost: 6, hp: -24, mp: 0, inflict: [], chance: 100, variance: 4,
        attributes: [], absorb: false, attr_shift: nil, attr_ids: [],
-       stat_mod_keys: [] },
+       stat_mod_keys: [], cured: [] },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
   eq({ cost: 5, hp: 32, mp: 0, variance: 4, attr_shift: nil, attr_ids: [],
-       stat_mod_keys: [], stat_effect: 32, cured: [] },
+       stat_mod_keys: [], stat_effect: 32, cured: [], inflict: [], chance: 100 },
      st.party.battle_skill_command(st.party.db_skill(8), caster, nil))
   # Cure affects HP and SP: effect = 10 + 40*12/40 = 22
   eq({ cost: 4, hp: 22, mp: 22, variance: 4, attr_shift: nil, attr_ids: [],
-       stat_mod_keys: [], stat_effect: 22, cured: [] },
+       stat_mod_keys: [], stat_effect: 22, cured: [], inflict: [], chance: 100 },
      st.party.battle_skill_command(st.party.db_skill(9), caster, nil))
 end
 
@@ -7724,16 +7725,18 @@ check 'a skill flagged "attribute defence up/down" picks direction from ' \
      'enemy scope (all enemies), reverse_state_effect ON -> still -1, the flag is irrelevant')
 end
 
-check 'a self/ally-scoped skill\'s own state_effects cure in battle, ' \
-      'ignoring reverse_state_effect (an enemy-scoped one still inflicts)' do
+check 'on an RPG2000 database, a self/ally-scoped skill\'s own state_effects ' \
+      'cure in battle, ignoring reverse_state_effect (an enemy-scoped one ' \
+      'still inflicts)' do
   # EasyRPG's Game_BattleAlgorithm::Skill::vExecute: `heals_states =
   # IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`, and
   # `IsPositive()` is `Algo::SkillTargetsAllies(skill)` -- true for every scope
-  # but Scope_enemy(0)/Scope_enemies(1). Under the RPG2000-only reading this
-  # runtime models (no RPG2003 gate), reverse_state_effect therefore never
-  # enters into it here either, matching #skill_attr_shift's own already-
-  # settled reading of the identical formula: only scope decides cure vs.
-  # inflict. state_effects index i -> state id i+1.
+  # but Scope_enemy(0)/Scope_enemies(1). On an RPG2000 database the XOR's
+  # right-hand term is always false (`Player::IsRPG2k3()` false), so
+  # reverse_state_effect never enters into it here, matching #skill_attr_shift's
+  # own already-settled reading of the identical formula: only scope decides
+  # cure vs. inflict. See the RPG2003 check just below for the flag actually
+  # mattering. state_effects index i -> state id i+1.
   cure_single = fake_skill(name: 'Antidote (ally)', scope: 3, sp_cost: 0, power: 0,
                             state_effects: [0, 1], reverse_state: false)
   cure_all_reversed = fake_skill(name: 'Antidote (all allies, reverse flag set)',
@@ -7755,8 +7758,52 @@ check 'a self/ally-scoped skill\'s own state_effects cure in battle, ' \
   eq [2], st.party.battle_skill_command(st.party.db_skill(9), caster, foe)[:cured],
      'self scope -> cures too'
   c = st.party.battle_skill_command(st.party.db_skill(10), caster, foe)
-  ok !c.key?(:cured), 'enemy scope carries no :cured key at all -- it inflicts instead'
+  eq [], c[:cured], 'enemy scope cures nothing -- it inflicts instead'
   eq [2], c[:inflict], 'the same flagged state, on the attack branch, is an inflict roll'
+end
+
+check 'on an RPG2003 database, reverse_state_effect flips a skill\'s own ' \
+      'state_effects between curing and inflicting' do
+  # The gap this closes: #battle_skill_command used to apply the plain
+  # scope-only rule (ally cures / enemy inflicts) unconditionally, the same
+  # simplification #skill_attr_shift's own sibling formula settled for good
+  # reason -- but unlike attribute-defence direction, EasyRPG's `heals_states`
+  # line does gate on `Player::IsRPG2k3()`, so a real RPG2003 database with
+  # `reverse_state_effect` set can invert either scope: an ally/self skill
+  # inflicts its listed states on its own side (a self-scoped Berserk that
+  # confuses its own caster), and an enemy skill cures its target's states
+  # instead of adding new ones.
+  ally_reversed = fake_skill(name: 'Berserk (self, reverse flag set)', scope: 2,
+                              sp_cost: 0, power: 0, state_effects: [0, 1],
+                              reverse_state: true)
+  enemy_reversed = fake_skill(name: 'Cleanse Curse (enemy, reverse flag set)',
+                               scope: 0, sp_cost: 0, power: 0,
+                               state_effects: [0, 1], reverse_state: true)
+  # A control pair on the same RPG2003 database with the flag off, proving
+  # the plain scope rule still holds when reverse_state_effect isn't set.
+  ally_plain = fake_skill(name: 'Focus (self)', scope: 2, sp_cost: 0, power: 0,
+                           state_effects: [0, 1], reverse_state: false)
+  enemy_plain = fake_skill(name: 'Poison Sting (enemy)', scope: 0, sp_cost: 0,
+                            power: 0, state_effects: [0, 1], reverse_state: false)
+  skills = { 7 => ally_reversed, 8 => enemy_reversed,
+             9 => ally_plain, 10 => enemy_plain }
+  st = skill_party(skills, rpg2003: true)
+  ok st.party.rpg2003?, 'the fixture database is flagged RPG2003'
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  foe = combatant('Foe', 0, 0, 5, 100)
+
+  c = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  eq [], c[:cured], 'self scope, reverse ON, RPG2003 -> no longer cures...'
+  eq [2], c[:inflict], '...inflicts the flagged state on the caster\'s own side instead'
+
+  c = st.party.battle_skill_command(st.party.db_skill(8), caster, foe)
+  eq [2], c[:cured], 'enemy scope, reverse ON, RPG2003 -> cures the target instead...'
+  eq [], c[:inflict], '...of inflicting a new state on it'
+
+  eq [2], st.party.battle_skill_command(st.party.db_skill(9), caster, foe)[:cured],
+     'control: self scope, reverse OFF, RPG2003 -> still cures, matching RPG2000'
+  eq [2], st.party.battle_skill_command(st.party.db_skill(10), caster, foe)[:inflict],
+     'control: enemy scope, reverse OFF, RPG2003 -> still inflicts, matching RPG2000'
 end
 
 check 'a self/ally-scoped skill cures its own state_effects states in battle' do
@@ -7769,7 +7816,7 @@ check 'a self/ally-scoped skill cures its own state_effects states in battle' do
   # items), the skill side just never fed it.
   cure = fake_skill(name: 'Antidote', scope: 3, sp_cost: 0, power: 0,
                     state_effects: [0, 1]) # index 1 -> state id 2
-  st = skill_party(7 => cure)
+  st = skill_party({ 7 => cure })
   caster = Game::Battle.from_actor(st.party.actor_by_id(1))
   ally = combatant('Ally', 0, 0, 5, 100)
   ally.states = [2]


### PR DESCRIPTION
## Summary

- `Game::Party#battle_skill_command` used to apply the plain "ally scope cures its listed `state_effects`, enemy scope inflicts them" rule unconditionally, regardless of `reverse_state_effect` or the database edition. That was a real, previously-flagged gap (see `docs/TODO.md`'s "attribute defence up/down" entry, which explicitly left this "a separate, wider question left untouched").
- Verified against EasyRPG Player's actual C++ source (fetched twice, `game_battlealgorithm.cpp` and `game_battler.cpp`): `Game_BattleAlgorithm::Skill::vExecute` computes `heals_states = IsPositive() ^ (Player::IsRPG2k3() && skill.reverse_state_effect)`. On an RPG2000 database the XOR's right-hand term is always false, so this collapses to exactly the rule already modelled — but a real RPG2003 database with the flag set can invert *either* scope: a self/ally skill inflicts its listed states on its own side instead of curing them (a self-scoped Berserk that confuses its own caster), and an enemy skill cures its target's states instead of inflicting new ones.
- `battle_skill_command` now computes `heals_states` the same way, gated on the existing `#rpg2003?` accessor, and routes each scope branch's `cured:`/`inflict:`/`chance:` keys off it. `Game::Battle#apply_skill_hit`'s attack and recovery branches both now honour whichever key applies, reusing the existing `roll_inflict`/cure-and-prune machinery — the ordinary RPG2000/non-reversed path is unaffected (the "other" key is simply empty).
- The field-skill path (`#skill_cured_states`/`#skill_inflicted_states`, matching EasyRPG's `Game_Battler::UseSkill`) was checked too and found already correct: that function's own `reverse_state_effect` branch carries no RPG2003 gate, matching what this codebase already did there — no change needed.
- Updated `docs/TODO.md` (✅ new entry after the sibling "attribute defence up/down" bullet) and added a changelog fragment.

## Test plan

- [x] Added `scripts/rpg2k_logic_check.rb` checks: an RPG2000-database control (the flag confirmed inert on every scope, matching prior behavior), a new RPG2003-database check (the flag flipping both an ally/self and an enemy scope, plus a same-database reverse-off control), and updated a full-hash `battle_skill_command` assertion for the new always-present `cured:`/`inflict:`/`chance:` keys.
- [x] Confirmed the new RPG2003 check fails against the pre-fix `mruby-rpg2k/mrblib/game.rb` (via `git stash` of just that file) before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 731 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 428 checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WstMeMTirgsZ2DA6c3XMLv)_