### PR TITLE
rpg2k: a restricted (asleep/paralysed/confused/berserk) ally no longer gets a battle command prompt

### DIFF
--- a/changelog.d/battle-restricted-actor-command-skip.fixed.md
+++ b/changelog.d/battle-restricted-actor-command-skip.fixed.md
@@ -1,0 +1,18 @@
+- **A living ally under a "do nothing" restriction (asleep/paralysed) or a
+  forced attack-ally/attack-enemy restriction (confused/berserk) no longer
+  gets a manual Attack/Skill/Defend/Item command prompt**, matching real
+  RPG_RT's `Scene_Battle_Rpg2k::SelectNextActor`, which skips straight past
+  such an ally with no prompt at all — auto-assigning "do nothing" or a
+  random forced target instead. `Scene::Map`'s battle command loop only ever
+  filtered `#living_allies` by `dead?`, so an afflicted-but-alive ally still
+  opened the ordinary menu and waited on a choice that
+  `Game::Battle#apply_turn_states`/`#strike` already discard or override
+  regardless of what gets picked — including the degenerate case where every
+  living ally is restricted at once, which previously froze the command
+  phase forever with no player input able to move it along. Fixed with a new
+  `Game::Battle#command_restricted?` predicate and a
+  `Scene::Map#skip_restricted_actors`/`#open_next_command` pair (plus a
+  matching backward skip on Cancel) that advances past every restricted ally
+  automatically, routed through battle open, the per-actor advance, and both
+  battle-event-page resume points that hand control back to the command
+  phase.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4693,8 +4693,11 @@ not yet verified:
 - ✅ **Empty party doesn't itself Game Over, but battling with one is instant
   defeat; an all-KO'd party reads as an instant defeat the same way.** (An
   unrecoverable input-blocking *state* lock — every member asleep/paralysed
-  at once, rather than HP 0 — is a separate, still-open case; nothing here
-  addresses it.) `Scene::Map#draw_battle_command`'s `current_actor`
+  at once, rather than HP 0 — was flagged as a separate, still-open case here;
+  ✅ **now fixed too, verified against EasyRPG Player's actual C++ source
+  rather than guessed at** — see the fuller writeup a few bullets below, at
+  "A living ally under a 'do nothing'... restriction now skips the manual
+  command prompt entirely".) `Scene::Map#draw_battle_command`'s `current_actor`
   (`living_allies[@battle_ui[:actor_i]]`) already resolved to `nil` for both
   an empty party and an all-KO'd one (`living_allies` rejects `dead?`), so it
   already declined to open a command window rather than crash (`return
@@ -4725,6 +4728,61 @@ not yet verified:
   fresh encounter straight to a `:defeat` result instead of stalling in
   `:command`), both confirmed to fail against the pre-fix code (the battle
   staying open in `:command` forever) before the fix.
+- ✅ **A living ally under a "do nothing" restriction (asleep/paralysed) or a
+  forced attack-ally/attack-enemy restriction (confused/berserk) now skips the
+  manual command prompt entirely, matching real RPG_RT**, instead of the
+  ordinary Attack/Skill/Defend/Item menu opening and waiting on a choice that
+  can never actually take effect — the "unrecoverable input-blocking state
+  lock" case flagged next to the empty/all-KO'd-party fix just above.
+  `Scene::Map`'s `#living_allies` (`reject(&:dead?)`) was the only filter the
+  battle command loop ever applied: `#draw_battle_command`/`#advance_actor`
+  opened a normal command window for *any* living ally regardless of state,
+  even though the round's own execution already discards or overrides
+  whatever gets queued for one of these two cases either way —
+  `Game::Battle#apply_turn_states` skips a do-nothing-restricted battler's
+  turn outright once the round runs, and `#strike`'s forced-target override
+  replaces a confused/berserk battler's command unconditionally
+  (`mruby-rpg2k/mrblib/game.rb`) — so the prompt was always pointless for
+  them, just never suppressed. Verified against EasyRPG Player's actual C++
+  source rather than guessed at: `Scene_Battle_Rpg2k::SelectNextActor`
+  (`src/scene_battle_rpg2k.cpp`) recurses straight past exactly these two
+  cases — `!active_actor->CanAct()` (a state with `restriction ==
+  Restriction_do_nothing`, `Game_Battler::CanAct`, `src/game_battler.cpp`)
+  auto-assigns a `None` battle algorithm and calls itself again with no
+  `State_SelectCommand` shown at all, and
+  `GetSignificantRestriction() != Restriction_normal` (attack-ally/
+  attack-enemy) auto-picks a random forced target and does the same — only an
+  ally with no active restriction at all ever reaches the Fight/Skill/Defend/
+  Item prompt. Fixed with a new `Game::Battle#command_restricted?(b)`
+  (`mruby-rpg2k/mrblib/game.rb`, public, defined next to `#battler_restriction`)
+  answering true for either case, and a new `Scene::Map#skip_restricted_actors`/
+  `#open_next_command` pair that advances `@battle_ui[:actor_i]` forward past
+  any such ally — writing nothing to its command/action fields, since the
+  no-command default an unrestricted ally with no explicit choice already
+  falls back to (`#attack_target`'s random-living-foe default) is exactly what
+  a do-nothing skip or a forced-restriction override needs anyway — before
+  deciding whether to draw the next ally's menu or, if every remaining living
+  ally is restricted, call `#start_round_animation` immediately the same way
+  running out of allies after the last manual command already does. Routed
+  through every place the command phase can be (re)entered: battle open
+  (`#open_battle`, replacing the bare `draw_battle_command` fallback),
+  `#advance_actor` (after a manual command), and the two battle-event-page
+  resume points that hand control back to `:command`
+  (`#finish_round_animation`, `#leave_battle_event_phase`) — a battle-event
+  page that puts the party to sleep before the first round, or mid-round
+  before the next round's prompt, is caught the same way. The "go back to the
+  previous member" Cancel/B path is symmetric: a new
+  `#prev_commandable_actor_index` walks backward skipping restricted allies
+  the same way, mirroring EasyRPG's `SelectPreviousActor`, so Cancel can never
+  re-open a menu for an ally the forward skip just passed over. Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks (a two-ally party with the first
+  asleep opens the command prompt on the second ally, never the first; a
+  lone asleep ally never shows a command prompt at all — the round starts and
+  animates with zero simulated player input, where the pre-fix build sat
+  frozen in `:command` forever) and a new `scripts/rpg2k_logic_check.rb` check
+  (`command_restricted?` flags a do-nothing, a confused and a berserk ally,
+  and clears an unafflicted one), all three confirmed to fail against the
+  pre-fix code before the fix.
 - "Hero X is in the party" always evaluates in **database ID order**, not
   current seat/slot order — there is no built-in way to read a member's
   current seat position.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6900,6 +6900,26 @@ module Game
       false
     end
 
+    # Whether `b` cannot be handed a manual command this round at all: a
+    # currently-active "do nothing" restriction (asleep/paralysed) discards
+    # whatever gets queued for it regardless, once the round actually runs
+    # (#apply_turn_states skips the whole turn outright), and a forced
+    # attack-ally/attack-enemy restriction (confused/berserk,
+    # #battler_restriction) overrides whatever gets queued with a random
+    # forced target regardless (#strike). Matches EasyRPG's
+    # `Scene_Battle_Rpg2k::SelectNextActor` (`!active_actor->CanAct()` /
+    # `GetSignificantRestriction() != Restriction_normal`), which skips the
+    # Fight/Skill/Defend/Item prompt entirely for exactly these two cases
+    # rather than asking the player to pick a command that can never take
+    # effect. The caller is expected to auto-advance past such an ally with
+    # nothing written to its command/action fields -- the same no-command
+    # default an unrestricted ally with no explicit choice already falls
+    # back to correctly (a random living foe via #attack_target).
+    def command_restricted?(b)
+      return true if battler_restriction(b) != 0
+      (b.states || []).any? { |id| state_field(state_def(id), :restriction) == RESTRICTION_DO_NOTHING }
+    end
+
     private
 
     # The state definition for `id` from the lookup, or nil (no lookup / unknown).

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3557,7 +3557,7 @@ class RPG2k
         # Turn-0 pages fire before the party is asked for its first command —
         # this is where a troop's opening dialogue lives.
         return if run_battle_events
-        settle_already_finished_battle || draw_battle_command
+        settle_already_finished_battle || open_next_command
       end
 
       # An encounter can start already decided — an empty party (every member
@@ -3928,10 +3928,11 @@ class RPG2k
         elsif Input.trigger?(Input::C)
           select_battle_command
         elsif Input.trigger?(Input::B)
-          if @battle_ui[:actor_i].zero?
+          prev_i = prev_commandable_actor_index
+          if prev_i.nil?
             try_battle_escape if @battle_ui[:req][:allow_escape]
           else
-            @battle_ui[:actor_i] -= 1 # re-command the previous member
+            @battle_ui[:actor_i] = prev_i # re-command the previous commandable member
             @battle_ui[:cmd] = 0
             draw_battle_command
           end
@@ -4244,11 +4245,52 @@ class RPG2k
       def advance_actor
         @battle_ui[:actor_i] += 1
         @battle_ui[:cmd] = 0
+        open_next_command
+      end
+
+      # Advance `actor_i` past any living ally the round already decides
+      # for automatically -- a "do nothing" or forced attack-ally/
+      # attack-enemy restriction, see `Game::Battle#command_restricted?` --
+      # then either open the next actually-commandable ally's menu or, if
+      # every remaining living ally is restricted, start the round right
+      # away exactly as running out of allies after the last command
+      # already does. Without this, an asleep/paralysed/confused/berserk
+      # ally still got the ordinary Attack/Skill/Defend/Item prompt, and a
+      # party entirely under such states (e.g. everyone put to sleep by an
+      # enemy's spell) froze the command phase forever waiting on choices
+      # that could never change the outcome -- the "unrecoverable
+      # input-blocking state lock" case flagged as still open next to the
+      # empty/all-KO'd-party fix above.
+      def open_next_command
+        skip_restricted_actors
         if @battle_ui[:actor_i] >= living_allies.length
           start_round_animation
         else
           draw_battle_command
         end
+      end
+
+      def skip_restricted_actors
+        battle = @battle_ui[:battle]
+        allies = living_allies
+        i = @battle_ui[:actor_i]
+        i += 1 while allies[i] && battle.command_restricted?(allies[i])
+        @battle_ui[:actor_i] = i
+      end
+
+      # The index of the previous living ally free to receive a manual
+      # command, walking backward from just before the current one and
+      # skipping any restricted ally the same way `#skip_restricted_actors`
+      # does going forward -- nil once nothing earlier is left to
+      # re-command, matching EasyRPG's `SelectPreviousActor` recursing back
+      # to the Fight/Auto/Escape menu once it would land on the very first
+      # ally.
+      def prev_commandable_actor_index
+        battle = @battle_ui[:battle]
+        allies = living_allies
+        i = @battle_ui[:actor_i] - 1
+        i -= 1 while i >= 0 && battle.command_restricted?(allies[i])
+        i >= 0 ? i : nil
       end
 
       # Frames each attack of the round lingers on screen before the next lands —
@@ -4388,7 +4430,7 @@ class RPG2k
           # A new turn re-arms every page: RPG2000 fires a battle page once per
           # turn in which its condition holds, not once per battle.
           @battle_ui[:pages_run] = {}
-          draw_battle_command unless run_battle_events
+          open_next_command unless run_battle_events
         end
       end
 
@@ -4570,7 +4612,7 @@ class RPG2k
           @battle_ui[:phase] = :animate
         else
           @battle_ui[:phase] = :command
-          draw_battle_command
+          open_next_command
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8389,6 +8389,31 @@ check 'battle: one incapacitated ally among others is not a party wipe' do
   ok !bat.finished?, 'a still-able ally keeps the party in the fight'
 end
 
+# yado.tk's "unrecoverable input-blocking state lock" case, next to the
+# empty/all-KO'd-party fix: EasyRPG's Scene_Battle_Rpg2k::SelectNextActor
+# skips the Fight/Skill/Defend/Item prompt entirely for a "do nothing"
+# restriction (asleep/paralysed, !CanAct()) and a forced attack-ally/
+# attack-enemy restriction (confused/berserk, GetSignificantRestriction() !=
+# Restriction_normal) rather than asking the player to pick a command that
+# can never take effect. Game::Battle#command_restricted? is the predicate
+# Scene::Map's battle command loop now consults to auto-skip such an ally
+# (see the "unrecoverable input-blocking state lock" fix in docs/TODO.md).
+check 'battle: command_restricted? flags do-nothing/confused/berserk allies, not a free one' do
+  states = { 8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0),  # do-nothing (asleep/paralysed)
+             6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0),  # attack-ally (confusion)
+             7 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0) } # attack-enemy (berserk)
+  asleep = combatant('Asleep', 40, 0, 20, 100); asleep.states = [8]
+  confused = combatant('Confused', 40, 0, 20, 100); confused.states = [6]
+  berserk = combatant('Berserk', 40, 0, 20, 100); berserk.states = [7]
+  free = combatant('Free', 40, 0, 20, 100)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([asleep, confused, berserk, free], [slime], Game::Rng.new(1), states)
+  ok bat.command_restricted?(asleep), 'a do-nothing state locks out a manual command'
+  ok bat.command_restricted?(confused), 'a forced attack-ally state locks out a manual command'
+  ok bat.command_restricted?(berserk), 'a forced attack-enemy state locks out a manual command'
+  ok !bat.command_restricted?(free), 'an unafflicted ally is still freely commandable'
+end
+
 check 'battle: a confused battler (restriction 3) attacks its own side' do
   states = { 6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0) } # attack-ally (confusion)
   hero = combatant('Hero', 40, 0, 1, 100)                 # slow: the foe acts first

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -302,7 +302,18 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                                      message_already: ' is already poisoned!',
                                      hp_change_map_steps: 4,
                                      hp_change_map_val: 1),
-                 4 => OpenStruct.new(name: 'Sleep', color: 4, priority: 80),
+                 # `restriction: 1` (do-nothing) + a nonzero auto_release_prob mirrors
+                 # RPG2000's own Sleep row -- a state that skips the afflicted
+                 # battler's turn entirely but can still wear off on its own, unlike
+                 # the always-comatose Stone row the battle-command-skip checks use.
+                 4 => OpenStruct.new(name: 'Sleep', color: 4, priority: 80,
+                                     restriction: 1, auto_release_prob: 50),
+                 # Do-nothing with 0% auto-release: never wears off on its own -- the
+                 # "everyone permanently incapacitated" battle-command-skip check
+                 # uses this one instead of Sleep so the round has no chance of
+                 # waking anyone back up mid-test.
+                 6 => OpenStruct.new(name: 'Stone', color: 8, priority: 90,
+                                     restriction: 1, auto_release_prob: 0),
                  5 => OpenStruct.new(name: 'Silence', color: 5, priority: 10) },
     # A tiny item table the Open Shop window prices its goods from.
     item: { 3 => OpenStruct.new(name: 'Potion', price: 100),
@@ -1634,19 +1645,24 @@ end
 # EXP, with the leader Scene::Map reads while rendering.
 class BattleStubActor
   attr_accessor :exp, :hp, :mp
-  attr_reader :id, :name, :atk, :def, :agi, :int, :max_hp, :max_mp, :skills
+  attr_reader :id, :name, :atk, :def, :agi, :int, :max_hp, :max_mp, :skills, :states
   # Defaults are strong enough to beat the two-Slime troop the scene db defines;
-  # a defeat test passes weaker stats.
+  # a defeat test passes weaker stats. `states` seeds the Combatant Game::Battle
+  # ::from_actor builds (Game::Battle.actor_states reads it off any source that
+  # responds to `:states`), so a battle-command-skip check can start the fight
+  # with an ally already afflicted, without reaching into the built battle's
+  # own Combatant list after the fact.
   def initialize(atk: 40, dfn: 20, agi: 20, hp: 200, mp: 20, int: 20, skills: [], id: 1,
-                 rename_skill: false, skill_name: '')
+                 rename_skill: false, skill_name: '', states: [])
     @exp = 0; @id = id; @name = 'Hero'
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
     @mp = mp; @max_mp = mp; @int = int; @skills = skills
-    @rename_skill = rename_skill; @skill_name = skill_name
+    @rename_skill = rename_skill; @skill_name = skill_name; @states = states
   end
   def gain_exp(n); @exp += n; end
   # Battle write-back (Game::Battle#apply_to_party) sets the actor's post-battle
-  # HP absolutely; the stub has no state model, so just clamp to [0, max].
+  # HP absolutely; the stub has no state model beyond the starting `states`
+  # above, so just clamp to [0, max].
   def set_hp(value); @hp = value < 0 ? 0 : (value > @max_hp ? @max_hp : value); end
   def dead?; @hp <= 0; end
   # Change HP (Game::Interpreter#do_change_hp), so a "Lose: Branch" recovery
@@ -6965,6 +6981,49 @@ check 'entering a battle with an all-KO\'d party is instant defeat too' do
   ok ui, 'the battle is open'
   eq :result, ui[:phase], 'no living ally settles the fight immediately instead of stalling in :command'
   eq :defeat, ui[:result]
+end
+
+# The "unrecoverable input-blocking state lock" case flagged as still open next
+# to the two fixes above: a living ally under a "do nothing" restriction
+# (asleep/paralysed) or a forced attack-ally/attack-enemy restriction
+# (confused/berserk) is not merely dead-or-alive -- #living_allies (rejects
+# only #dead?) used to still open the ordinary Attack/Skill/Defend/Item prompt
+# for one, waiting on a choice that #apply_turn_states/#strike (see
+# Game::Battle#command_restricted?) discard or override regardless of what
+# gets picked. EasyRPG's Scene_Battle_Rpg2k::SelectNextActor recurses straight
+# past exactly these two cases (`!CanAct()` / `GetSignificantRestriction() !=
+# Restriction_normal`) with no manual prompt shown at all.
+check 'an asleep ally is skipped straight to the next commandable one, no command prompt for it' do
+  scene, st = battle_scene_with_pages({})
+  st.party.instance_variable_set(:@actors, [BattleStubActor.new(id: 1, states: [4]),
+                                            BattleStubActor.new(id: 2)])
+  ui = nil
+  10.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == :command
+  end
+  ok ui, 'the battle opened'
+  eq :command, ui[:phase], 'a still-commandable ally is left to open the prompt'
+  eq ui[:allies][1], scene.send(:current_actor),
+     'the asleep ally at index 0 was skipped straight to the awake one at index 1'
+end
+
+check 'a lone ally under a do-nothing state (asleep) never gets a command prompt -- the round starts on its own' do
+  scene, st = battle_scene_with_pages({})
+  st.party.instance_variable_set(:@actors, [BattleStubActor.new(id: 1, states: [4])])
+  saw_animate = false
+  ui = nil
+  30.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    saw_animate ||= ui && ui[:phase] == :animate
+    break if ui && ui[:phase] == :result
+  end
+  ok ui, 'the battle opened'
+  ok saw_animate || ui[:phase] == :result,
+     'the round left :command and started animating on its own -- no player input was ever supplied'
+  ok ui[:phase] != :command, 'the sole ally being asleep does not freeze the command phase forever'
 end
 
 check 'a turn-0 battle-event page runs as the fight opens' do


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s empty/all-KO'd-party bullet had an open parenthetical: "An unrecoverable input-blocking state lock — every member asleep/paralysed at once, rather than HP 0 — is a separate, still-open case; nothing here addresses it."
- `Scene::Map`'s battle command loop filtered `#living_allies` by `dead?` only, so a living ally under a "do nothing" restriction (asleep/paralysed) or a forced-target restriction (confused/berserk) still got the ordinary Attack/Skill/Defend/Item prompt — a choice `Game::Battle#apply_turn_states`/`#strike` already discard or override at execution time regardless of what's picked.
- Verified against EasyRPG Player's actual C++ source (`scene_battle_rpg2k.cpp`'s `SelectNextActor`, `game_battler.cpp`'s `CanAct`/`GetSignificantRestriction`): real RPG_RT recurses straight past both restriction classes with no manual prompt shown at all, auto-assigning "do nothing" or a random forced target instead.
- Added `Game::Battle#command_restricted?(b)` (do-nothing state, or `battler_restriction != 0`); new `Scene::Map#skip_restricted_actors`/`#open_next_command` pair advances past every restricted living ally before deciding whether to draw the next commandable ally's menu or start the round immediately if none remain — routed through battle open, actor advance, and both battle-event-page resume points. A symmetric `#prev_commandable_actor_index` covers the Cancel/B "go back" path.
- `docs/TODO.md` updated ✅.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 732 checks pass (1 new: `command_restricted?` flags a do-nothing/confused/berserk ally and clears an unafflicted one)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 430 checks pass (2 new: a two-ally party with the first asleep opens the command prompt on the second ally only; a lone asleep ally never shows a prompt at all — the round starts and animates with zero simulated input — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_