### PR TITLE
rpg2k: a Parallel Process's own Transfer Player now actually warps the party

### DIFF
--- a/changelog.d/parallel-process-transfer-player.fixed.md
+++ b/changelog.d/parallel-process-transfer-player.fixed.md
@@ -1,0 +1,12 @@
+- **Map events:** a Common Event Parallel Process's own Transfer Player
+  command now actually warps the party, instead of silently doing nothing.
+  `Scene::Map#drive_parallel_wait` had no case for the `:teleport` wait kind
+  `Game::Interpreter#do_teleport` raises, so it fell into the generic
+  "background: ignore message/choice/teleport requests" branch and just
+  resumed the interpreter without ever calling `#perform_teleport` — the
+  same command issued from the foreground (an Autorun) already worked. The
+  same Parallel Process interpreter now keeps running on the destination map
+  afterward, matching how it already survives a save/load or an ordinary
+  Transfer Player from elsewhere. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2778,11 +2778,46 @@ Everything below is unverified against the codebase.
   colour-index validation.
 - **Parallel Process** — yields to others during its own Wait/Show-Text
   pause; appearance condition going false mid-run only stops at the next
-  yield point, not instantly (same fact as the `09_bug` item above); a
-  Transfer Player command inside one lets subsequent commands run while the
-  new map is still loading (needs a Wait:0.0s after it) — for a **map**
-  event specifically, a Wait right there instead ends that event outright
-  since its context is gone post-transfer; ✅ **"On Loss: Handle Separately" +
+  yield point, not instantly (same fact as the `09_bug` item above); ✅ **a
+  Transfer Player command issued from a Parallel Process now actually warps
+  the party**, instead of being silently dropped outright — a much larger
+  gap than the bullet's own "needs a Wait:0.0s after it" wording implies.
+  `Scene::Map#drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) had no
+  case for the `:teleport` wait kind `Game::Interpreter#do_teleport` sets —
+  every other wait kind reachable from a Parallel Process (`:wait`,
+  `:key_input`, `:animation`, `:game_over`, `:movement`) had already earned
+  its own dispatch over earlier rounds of this same fix, but `:teleport`
+  fell all the way through to the generic `else` branch (`it.resume #
+  background: ignore message/choice/teleport requests`) and just cleared the
+  wait without ever calling `#perform_teleport` at all — the warp itself
+  never happened, for either a Common Event's or a map event's own Parallel
+  Process, not merely at the wrong time. Fixed by adding a `:teleport` case
+  that calls `#perform_teleport(it.teleport)` and then explicitly resumes
+  `it` — the parallel interpreter, always a distinct object from the
+  foreground `@interpreter` that `#perform_teleport` itself resumes at its
+  own end, mirroring `#drive_event`'s identical `:teleport` dispatch for the
+  foreground. A **Common Event's** own Parallel Process keeps running
+  afterward on the new map with zero extra plumbing: `#build_parallels`
+  (which `#perform_teleport` calls to rebuild `@parallels`) already reuses a
+  Common Event's parallel-process interpreter object unconditionally, keyed
+  by its `common_event_id` — the exact mechanism the "Common Event Parallel
+  Process survives a Transfer Player" fix above relies on — so the very same
+  `it` this branch resumes is still the one `@parallels` loops next frame,
+  letting subsequent commands run on the new map exactly as this bullet's
+  claim describes. A **map** event's own Parallel Process has no such reuse
+  across a genuine map change (`#build_parallels` only carries one forward
+  under `preserve_map_events:`, a keyword `#perform_teleport` never passes),
+  so it drops out of the rebuilt `@parallels` the instant this branch
+  resumes it — happening to match "its context is gone post-transfer" for
+  that half of the claim, though the more specific "a Wait right there
+  instead ends that event outright" wording is not separately modelled.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a Common Event
+  Parallel Process running marker A, a Transfer Player to a second map, then
+  marker B: the map actually changes and the same interpreter reaches
+  marker B on the new map), confirmed to fail against the pre-fix code
+  before the fix (the map id never changed and marker B never ran). The
+  `Wait:0.0s`-after-it timing nuance and the map-event "Wait ends it"
+  wording remain unverified. ✅ **"On Loss: Handle Separately" +
   an immediate recovery branch racing Game Over against a still-running
   Parallel Process is now fixed** — same family as the `016_ikinari_end`
   race above, see the fuller writeup under the "Documented race condition"
@@ -2806,9 +2841,10 @@ Everything below is unverified against the codebase.
   event opens a message window through the foreground touch path the moment
   the party walks into it, distinguishing the two runs by a Show Message a
   background interpreter's own request is silently dropped, per
-  `#drive_parallel_wait`'s "background: ignore message/choice/teleport
-  requests" branch), confirmed to fail against the pre-fix code before the
-  fix.
+  `#drive_parallel_wait`'s "background: ignore message/choice requests"
+  branch — `:teleport` no longer falls into it, see the "a Transfer Player
+  command issued from a Parallel Process..." fix just above), confirmed to
+  fail against the pre-fix code before the fix.
 - **Vehicles** — an unset vehicle defaults to map id 0, (0,0); Small/Large
   Ship aren't hardcoded to water, their passability follows the terrain
   table's boat/ship-pass flags like any other vehicle rule; ✅ an airship

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1256,8 +1256,35 @@ class RPG2k
           # both a parallel process and the foreground happen to be waiting
           # on movement at once.
           it.resume if forced_movement_done?
+        elsif it.wait_kind == :teleport
+          # Transfer Player / Recall to Location issued from a Parallel
+          # Process (yado.tk: "a Transfer Player command inside one [a
+          # Parallel Process] lets subsequent commands run while the new map
+          # is still loading"). Before this branch existed this fell into the
+          # generic "background: ignore ... teleport requests" #resume below,
+          # so a Parallel Process's own warp silently never happened at all --
+          # not merely mistimed. #perform_teleport itself resumes the
+          # *foreground* @interpreter at its end (mirroring #drive_event's own
+          # :teleport dispatch above), so `it` -- this parallel interpreter,
+          # always a distinct object from @interpreter -- still needs its own
+          # explicit #resume once the map has actually changed.
+          # #build_parallels (run inside #perform_teleport) already keys a
+          # Common Event's own parallel process off its common_event_id and
+          # reuses the very same interpreter object across the rebuild
+          # (`previous_common`, unconditionally -- unlike a map event's own
+          # parallel process, which is only carried over under
+          # `preserve_map_events:`, a keyword #perform_teleport never passes),
+          # so `p`/`it` themselves are unaffected by the rebuild here and can
+          # simply resume afterward, continuing the rest of the process's own
+          # command list on the new map. A *map* event's own Parallel Process
+          # has no such reuse for a genuine map change, so it naturally drops
+          # out of the rebuilt @parallels and this #resume call is its last --
+          # matching the separately-documented "for a map event specifically,
+          # its context is gone post-transfer".
+          perform_teleport(it.teleport)
+          it.resume
         else
-          it.resume # background: ignore message/choice/teleport requests
+          it.resume # background: ignore message/choice requests
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1494,6 +1494,36 @@ check "Transfer Player reuses a common event's Parallel Process interpreter " \
      "the rebuilt map event's parallel process starts over at the top"
 end
 
+check "a common event's Parallel Process's own Transfer Player command " \
+      'actually warps the party, then keeps running on the new map' do
+  ic = Game::Interpreter::Cmd
+  # Marker A, a Transfer Player to map 2, marker B: before this fix,
+  # #drive_parallel_wait had no :teleport case, so a Parallel Process's own
+  # Transfer Player fell into the generic "background: ignore ... teleport
+  # requests" #resume branch -- the warp itself never happened at all (not
+  # merely mistimed), and the process looped straight back to marker A
+  # instead of ever reaching marker B. yado.tk (01_shoshin/011_siyou,
+  # "Parallel Process"): "a Transfer Player command inside one lets
+  # subsequent commands run while the new map is still loading." A Parallel
+  # Process's own command list loops forever once it reaches the end (by
+  # design, unrelated to this fix), so this only checks the first pass --
+  # three frames is exactly enough for marker A, the teleport landing, and
+  # marker B to each take effect one frame apart.
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [add_var_cmd(3), ECmd.new(ic::TELEPORT, [2, 0, 0, 0]),
+                              add_var_cmd(4)])
+  scene = new_scene({}, common: { 7 => ce })
+  st = scene.instance_variable_get(:@state)
+  eq 1, st.map_id, 'starts on map 1'
+
+  3.times { scene.update }
+  eq 1, st.variables[3], "marker A ran once, on the process's first pass"
+  eq 2, st.map_id, "the process's own Transfer Player actually warped the party"
+  eq 1, st.variables[4],
+     "the SAME Parallel Process interpreter kept running past the teleport " \
+     'and reached marker B on the new map'
+end
+
 check "an unrelated event's page change does not restart another event's " \
       'own Parallel Process' do
   ic = Game::Interpreter::Cmd


### PR DESCRIPTION
## Summary

- `Scene::Map#drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) had no case for the `:teleport` wait kind `Game::Interpreter#do_teleport` sets, so a Transfer Player command issued from a Parallel Process (a map event's or a Common Event's) fell into the generic `else` branch (`it.resume # background: ignore message/choice/teleport requests`) and just cleared the wait without ever calling `#perform_teleport` — the warp itself silently never happened at all, not merely at the wrong time. The identical command already worked fine from the foreground (an Autorun), via `#drive_event`'s own `:teleport` dispatch.
- Fixed by adding a `:teleport` case that calls `#perform_teleport(it.teleport)` and then explicitly resumes `it` — the parallel interpreter, always a distinct object from the foreground `@interpreter` that `#perform_teleport` itself resumes at its own end.
- A Common Event's own Parallel Process keeps running afterward on the new map with zero extra plumbing: `#build_parallels` (called by `#perform_teleport` to rebuild `@parallels`) already reuses a Common Event's parallel-process interpreter object unconditionally, keyed by its `common_event_id` — the same mechanism an earlier round's "Common Event Parallel Process survives a Transfer Player" fix relies on — so the very same interpreter this branch resumes is still the one `@parallels` loops next frame. A map event's own Parallel Process has no such reuse across a genuine map change and drops out of the rebuilt `@parallels`, matching the yado.tk claim's "its context is gone post-transfer" (`docs/TODO.md`, "Untriaged backlog, from `2k/01_shoshin/011_siyou/`" → **Parallel Process**).
- Updated `docs/TODO.md` to mark the claim ✅ with the full writeup and cited code paths, plus fixed a stale citation elsewhere in the same bullet that referenced the old (now-changed) "ignore message/choice/teleport requests" comment text.
- Added `changelog.d/parallel-process-transfer-player.fixed.md`.

## Test plan

- New `scripts/rpg2k_scene_check.rb` check: a Common Event Parallel Process runs a marker, a Transfer Player to a second map, then a second marker; asserts the map id actually changes and the same interpreter reaches the second marker on the new map. Confirmed to fail against the pre-fix code (`git stash` of just `mruby-rpg2k/mrblib/scene/map.rb`) — the map id never changed and the second marker never ran.
- `ruby scripts/rpg2k_logic_check.rb` — 731 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 430 checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011uYaWSzBCEZohLLPKZSihH)_