### PR TITLE
rpg2k: a fire-and-forget Show Battle Animation also cuts off a still-playing first one

### DIFF
--- a/changelog.d/battle-animation-no-wait-cutoff.fixed.md
+++ b/changelog.d/battle-animation-no-wait-cutoff.fixed.md
@@ -1,0 +1,18 @@
+- **A fire-and-forget (no-wait) Show Battle Animation (11210) now also
+  forcibly cuts off a still-playing first one**, instead of being silently
+  dropped. `Scene::Map#drive_map_animation`'s "a second Show Battle
+  Animation forcibly cuts the first off" fix only ever ran through the
+  `:animation` wait dispatch, which a no-wait request never reaches at all
+  — it is routed instead through `#apply_battle_animation_request`, which
+  still just checked whether the shared `@map_animation`/`@anim_wait` slot
+  was free and returned immediately otherwise, permanently losing the
+  request rather than displacing whatever already held it. Verified against
+  EasyRPG Player's actual C++ source: `Game_Screen::ShowBattleAnimation` is
+  a bare unconditional `animation.reset(...)` with no branch on the *new*
+  request's own wait flag — only the *issuing* interpreter's resulting wait
+  is conditional on that, the cut-off itself is not. Fixed by giving
+  `#apply_battle_animation_request` the same unconditional-claim shape
+  `#drive_map_animation` already uses: whatever currently owns the slot is
+  torn down and immediately resumed before the new fire-and-forget request
+  takes it over. Covered by a new `scripts/rpg2k_scene_check.rb` check,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4483,6 +4483,49 @@ not yet verified:
   resumes rather than hanging forever on a slot it no longer owns),
   confirmed to fail against the pre-fix code (the slot still showing the
   first request 15 frames later) before the fix.
+- ✅ **A fire-and-forget (no-wait) Show Battle Animation now also forcibly
+  cuts off a still-playing first one**, instead of being silently dropped —
+  the missing symmetric half of the "second cuts off the first" fix directly
+  above, which only ever ran for a *waited-for* second request. Re-checking
+  the same EasyRPG C++ source that settled that fix shows the asymmetry was
+  never real in the first place: `Game_Screen::ShowBattleAnimation`
+  (`src/game_screen.cpp`) is a bare unconditional `animation.reset(new
+  BattleAnimationMap(...))` with no branch anywhere on whether the *new*
+  request itself carries a "wait until it finishes" flag — only the
+  *issuing* interpreter's own resulting wait is conditional on that
+  (`Game_Interpreter_Map::CommandShowBattleAnimation`'s `_state.wait_time =
+  frames` runs only when the flag is set), the cut-off of whatever was
+  already playing is not. `Scene::Map#drive_map_animation`'s own
+  `unless @map_animation_interp.equal?(it)` claim only runs through the
+  `:animation` wait dispatch, which a fire-and-forget request never reaches
+  at all (`Game::Interpreter#do_show_battle_animation` only enters that wait
+  when the flag is set); a no-wait play is routed instead through
+  `Scene::Map#apply_battle_animation_request`, called unconditionally after
+  every interpreter step for both the foreground interpreter and every
+  parallel process. That method's own comment even said so explicitly at the
+  time — "this build does not model one animation cutting another off ... a
+  fire-and-forget request has no owner left to keep retrying for a turn" —
+  written before the sibling fix above existed and never revisited once it
+  did: it still just checked whether `@map_animation`/`@anim_wait` was free
+  and returned immediately otherwise, permanently losing the request rather
+  than displacing whichever play (owned by a waiting interpreter, or itself
+  ownerless) already held the slot. Fixed by giving it the identical
+  unconditional-claim shape `#drive_map_animation` already uses: when the
+  slot is busy, whatever currently owns it (`@map_animation_interp`, `nil`
+  for an ownerless holder) is torn down and immediately resumed — its
+  animation no longer exists, so there is nothing left for it to wait on —
+  before the new fire-and-forget request takes the slot over via the
+  existing `#begin_map_animation`. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (mirroring the waited-for check's own
+  two-Common-Event setup, but with the second's Show Battle Animation issued
+  with its wait flag off): the shared slot switches to the second's own
+  drawable animation well before the first's ~20-frame fallback duration
+  could ever have finished it naturally, the first interpreter resumes
+  rather than hanging on a slot it no longer owns, and the second interpreter
+  — never blocked by its own no-wait request — reaches its own trailing
+  command right away regardless, confirmed to fail against the pre-fix code
+  (the slot still showing the first request, the second's own request
+  silently and permanently lost) before the fix.
 - ✅ **Show Battle Animation (11210) targeting a vehicle now plays over that
   vehicle's own live position**, instead of silently defaulting to the
   player's. `Scene::Map#animation_target_pixel` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2296,15 +2296,36 @@ class RPG2k
       # No owner: unlike #init_map_animation's waited-for play, nothing is
       # parked on this one to #resume once it finishes (#step_map_animation
       # already treats a nil #@map_animation_interp as "no one to resume").
-      # When the shared on-screen slot is already busy this play is dropped
-      # rather than queued or cutting the running one short — this build does
-      # not model one animation cutting another off (see #drive_map_animation),
-      # and a fire-and-forget request has no owner left to keep retrying for a
-      # turn the way a waiting interpreter implicitly does by asking again next
-      # frame.
+      #
+      # When the shared on-screen slot is already busy, this play now cuts the
+      # running one off instead of being dropped — the missing half of
+      # #drive_map_animation's own "a second Show Battle Animation forcibly
+      # cuts the first off" fix, settled the same way against EasyRPG's actual
+      # C++ source: `Game_Screen::ShowBattleAnimation` (`src/game_screen.cpp`)
+      # is a bare unconditional `animation.reset(new BattleAnimationMap(...))`
+      # with no check on whether the *new* request itself carries a wait flag —
+      # only the *issuing* interpreter's own resulting wait is conditional on
+      # that (`_state.wait_time = frames` only when the flag is set), the
+      # cut-off of whatever was already playing is not. `#drive_map_animation`
+      # only ever claims the slot this unconditional way for a *waited-for* new
+      # request (reachable only through the `:animation` wait dispatch); a
+      # fire-and-forget one — routed here instead, since it never waits on
+      # anything — used to just check whether the slot was free and silently
+      # drop itself otherwise, leaving whichever request already held it (owned
+      # by a waiting interpreter, or itself ownerless) running untouched. A
+      # cut-off interpreter's animation no longer exists, so — exactly like
+      # #drive_map_animation's own cut-off branch — it has nothing left to wait
+      # on and resumes immediately rather than being left to hang on a slot
+      # that no longer holds its request.
       def apply_battle_animation_request(interp)
         req = interp.take_battle_animation_request
-        return if req.nil? || @map_animation || @anim_wait
+        return if req.nil?
+        if @map_animation || @anim_wait
+          cut_off = @map_animation_interp
+          @map_animation = nil
+          @anim_wait = nil
+          cut_off.resume if cut_off
+        end
         @map_animation_interp = nil
         begin_map_animation(req)
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5473,6 +5473,69 @@ check 'a second Show Battle Animation forcibly cuts off a still-playing first on
   ok st.switches[6], 'CE2 resumes once its own animation finishes'
 end
 
+# The same "second cuts off the first" rule as the check just above, but for
+# the *no-wait* half of Show Battle Animation, verified against EasyRPG's
+# actual C++ source rather than guessed at: `Game_Screen::ShowBattleAnimation`
+# is a bare unconditional `animation.reset(...)` with no branch on the *new*
+# request's own wait flag at all -- only the *issuing* interpreter's resulting
+# wait is conditional on that. `#drive_map_animation`'s own cut-off fix is
+# only ever reachable through the `:animation` wait dispatch, so it only ever
+# ran for a *waited-for* second request; a fire-and-forget one -- routed
+# through `#apply_battle_animation_request` instead, since it never parks on
+# a wait of its own -- used to just check whether the shared slot was free
+# and silently drop itself otherwise, leaving CE1's animation running
+# untouched and CE1 itself stuck waiting out its own fallback naturally
+# instead of being cut off.
+check 'a fire-and-forget Show Battle Animation also forcibly cuts off a still-playing first one' do
+  ic = Game::Interpreter::Cmd
+  # CE1's animation 7 has no drawable data in the fake db, so it parks on the
+  # ~20-frame timed-wait fallback -- long enough that CE2's own fire-and-
+  # forget animation can cut it off well before it would ever finish
+  # naturally.
+  ce1 = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                       event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [7, 10001, 1], indent: 0),
+                               ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
+  # CE2 waits a moment first (so CE1's animation is already in flight), then
+  # fires its own -- animation 8, the fake db's drawable one -- with the
+  # "wait until it finishes" flag *off* (the third SHOW_BATTLE_ANIM parameter
+  # is 0, unlike the waited-for check above).
+  ce2 = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                       event: [ECmd.new(ic::WAIT, [1], indent: 0),
+                               ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 0], indent: 0),
+                               ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce1, 2 => ce2 })
+  st = scene.instance_variable_get(:@state)
+  3.times { scene.update }
+  ok !st.switches[5], 'CE1 is still parked on its own long fallback wait'
+  ok scene.instance_variable_get(:@anim_wait), 'CE1 has claimed the shared slot (fallback path)'
+  # CE2's own Wait[1] (~6 frames) elapses well before CE1's ~20-frame fallback
+  # would ever finish naturally, so bound the search to comfortably less than
+  # that: if the slot never shows CE2's own drawable animation by frame 15,
+  # CE2's fire-and-forget request was dropped instead of cutting CE1 off --
+  # the pre-fix bug (CE2's request is lost forever in that case, not merely
+  # delayed, since nothing keeps retrying it the way a waiting interpreter
+  # implicitly does).
+  15.times do
+    scene.update
+    break if scene.instance_variable_get(:@map_animation)
+  end
+  ok scene.instance_variable_get(:@map_animation),
+     "the shared slot now shows CE2's own (drawable) animation instead of CE1's fallback wait, " \
+     "well before CE1's own ~20-frame duration could have finished it naturally"
+  ok scene.instance_variable_get(:@map_animation_interp).nil?,
+     "CE2's own request is fire-and-forget -- nothing is parked waiting on it"
+  # CE1 was resumed the instant it was cut off (this same pass, during CE2's
+  # own turn later in the same step_parallels sweep), but its own trailing
+  # Control Switches command only runs on the *next* step_parallel call for
+  # it -- give it one more frame to actually reach it, well short of the
+  # fallback's own ~20-frame duration (mirrors the waited-for check above).
+  scene.update
+  ok st.switches[5],
+     "CE1 resumed the instant its animation was cut off, well short of the fallback's own ~20-frame duration"
+  40.times { scene.update }
+  ok st.switches[6], "CE2's own command list reached its trailing Control Switches (it was never blocked by its own no-wait animation)"
+end
+
 # yado.tk: RPG_RT drops straight into Game Over the instant a wipe-triggering
 # command finds the whole party dead outside battle, regardless of which
 # event noticed it -- a Simulated Attack floor trap on a background Parallel


### PR DESCRIPTION
## Summary
- Completes the symmetric half of the "second Show Battle Animation forcibly cuts off the first" fix, which only covered a *waited-for* second request (reachable through the `:animation` wait dispatch).
- A **no-wait / fire-and-forget** Show Battle Animation goes through a different path, `Scene::Map#apply_battle_animation_request`, whose old comment explicitly said "this build does not model one animation cutting another off... a fire-and-forget request has no owner left to keep retrying" — written before the sibling fix landed and never revisited. It still just checked whether the slot was free and returned immediately otherwise, **permanently losing** the request instead of cutting off whatever was already playing — contradicting EasyRPG's actual C++ source, where the cut-off is unconditional regardless of the *new* request's own wait flag (only the *issuing* interpreter's resulting wait is conditional on that).
- `apply_battle_animation_request` now mirrors `drive_map_animation`'s exact idiom: when the slot is busy, whoever owns it is torn down and immediately resumed, then the new fire-and-forget request takes the slot.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 733 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 448 checks pass (1 new: a fire-and-forget Show Battle Animation also forcibly cuts off a still-playing first one — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_