### PR TITLE
rpg2k: equipment no longer treats an item's Seed max HP/SP fields as a live stat bonus

### DIFF
--- a/changelog.d/equip-max-hp-sp-points-not-a-bonus.fixed.md
+++ b/changelog.d/equip-max-hp-sp-points-not-a-bonus.fixed.md
@@ -1,0 +1,17 @@
+- **Equipping an item no longer raises max HP/MP from its `max_hp_points`/
+  `max_sp_points` fields.** `Game::Actor::EQUIP_BONUS_FIELD` summed those two
+  fields live over every equipped slot alongside the four combat stats' own
+  `atk_points1`/`def_points1`/`spi_points1`/`agi_points1` equip bonus, but
+  `max_hp_points`/`max_sp_points` are not part of that "points1" equip-bonus
+  family at all — they are grouped with `atk_points2`/`def_points2`/
+  `spi_points2`/`agi_points2`, the six fields a Seed-type item spends on a
+  one-time, permanent stat-up when *consumed* (`Actor#seed_boosts`), never
+  while merely worn. Verified against EasyRPG Player's actual C++ source:
+  `Game_Actor::GetMaxHp`/`GetMaxSp` resolve to `GetBaseMaxHp`/`GetBaseMaxSp`
+  with no per-equipment summation anywhere, unlike `GetAtk`/`GetDef`/
+  `GetSpi`/`GetAgi`, which each walk every equipped item's own `*_points1`
+  field — RPG2000's editor has no "+Max HP"/"+Max SP" equip-bonus field for
+  weapon/shield/armour/helmet/accessory items at all. Fixed by making
+  `EQUIP_BONUS_FIELD[0]`/`[1]` (max HP/MP) `nil`, so `#equip_bonus` returns 0
+  for them unconditionally instead of reading an item's field; the four
+  combat stats are unchanged.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5380,6 +5380,65 @@ above are repeated here)
   switch is off for the whole run; its content still executes), confirmed to
   fail when `build_resolver` is temporarily made to honour the gate switch,
   restored before finalizing since nothing here needed to change.
+- ✅ **An equipped item's `max_hp_points`/`max_sp_points` fields never raised
+  max HP/MP — confirmed as a genuine, previously-undocumented gap in the
+  opposite direction from most entries here: this codebase was *wrongly
+  applying* two fields real RPG_RT never treats as an equipment bonus at
+  all.** Found while cross-checking the already-fixed "a seed permanently
+  raises the target's stats (points2 set)" entry above (`Game::Party
+  #use_seed`/`Actor#seed_boosts`) against `Game::Actor::EQUIP_BONUS_FIELD`
+  (`mruby-rpg2k/mrblib/game.rb`), which listed `:max_hp_points`/
+  `:max_sp_points` at indices 0/1 (max HP/MP) alongside the four combat
+  stats' own `atk_points1`/`def_points1`/`spi_points1`/`agi_points1` — summed
+  live over every equipped slot on every `#recompute_stats` call
+  (`@max_hp = @base[0] + equip_bonus(0)`), the identical mechanism the four
+  combat stats correctly use for their own equip bonus. But
+  `max_hp_points`/`max_sp_points` are not part of that "points1" equip-bonus
+  family at all: they are LCF item fields 41/42, numerically and
+  semantically grouped with fields 43-46 (`atk_points2`/`def_points2`/
+  `spi_points2`/`agi_points2`, `mruby-lcf/mrblib/schema.rb`) — the six-field
+  set a Seed-type (database item type 8) item spends on a one-time,
+  permanent stat-up when *consumed*, never while merely worn — exactly the
+  set `Actor#seed_boosts` already reads correctly for that separate,
+  already-working feature. Confirmed against EasyRPG Player's actual C++
+  source rather than guessed at: `Game_Actor::GetMaxHp`/`GetMaxSp`
+  (`src/game_battler.cpp`/`src/game_actor.cpp`) resolve to
+  `GetBaseMaxHp`/`GetBaseMaxSp` with no per-equipment summation anywhere in
+  the call chain, unlike `GetAtk`/`GetDef`/`GetSpi`/`GetAgi`, each of which
+  walks every equipped item via `ForEachEquipment` reading exactly its own
+  `*_points1` field (`src/game_actor.cpp`); `max_hp_points`/`max_sp_points`
+  are read nowhere in that equip-time path, only inside `Game_Actor::UseItem`'s
+  Material (Seed) branch alongside `atk_points2`..`agi_points2` — RPG2000's
+  editor simply has no "+Max HP"/"+Max SP" equip-bonus field for
+  weapon/shield/armour/helmet/accessory items at all, only the four combat
+  stats. (Corroborating evidence already sat in this same codebase:
+  `Scene::EquipMenu`'s comparison-arrow fix above deliberately sums only the
+  four `*_points1` fields, its own comment already calling them "the combat
+  quarter... max HP/SP have no comparison arrow" — a fact recorded once but
+  never propagated back to `#recompute_stats`.) In practice this stayed
+  silent for both test-bed databases — a scripted scan of
+  `data/mtf-meido-action/Debug/RPG_RT.ldb` found zero weapon/shield/armour/
+  helmet/accessory rows with a nonzero `max_hp_points`/`max_sp_points` (the
+  editor never exposes those fields for an equip-type item, so no legitimate
+  authoring path sets them there) — but the LCF schema does not partition
+  fields by item type, so a hand-edited database, or one whose item
+  type was reassigned in the editor without clearing every field the old
+  type used, could carry a stray nonzero value straight into a live,
+  per-frame equip-bonus sum. Fixed by making `EQUIP_BONUS_FIELD[0]`/`[1]`
+  `nil` (max HP/MP have no field at all) and `#equip_bonus` return 0
+  immediately for a `nil` field, before ever touching `@equipment`; indices
+  2-5 (atk/def/spi/agi) are completely unchanged. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a weapon carrying both a combat-stat
+  bonus and a large `max_hp_points`/`max_sp_points` value raises only the
+  combat stat when equipped, leaves max HP/MP untouched both equipped and
+  unequipped), confirmed to fail against the pre-fix code (`[510, 505, 10]`
+  instead of `[10, 5, 10]`); the pre-existing "Actor equipment adds item
+  bonuses to the effective stats" check's own `mhp: 50` equip-bonus
+  assertion — itself asserting the bug — is corrected to a fourth combat
+  stat (`spi:`) instead. `Party#use_seed`/`#seed_boosts`'s own already-passing
+  coverage is unaffected, since a Seed item is never equippable in the first
+  place (`Actor#equip_slot_for`/`#equip_item` gate on item `type` 1-5, Seed
+  is type 8).
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1161,10 +1161,33 @@ module Game
     # The six base stats in database parameter-curve order (chunk 31 stores six
     # shorts -- maxHP, maxSP, atk, def, int, agi -- per level).
     STAT_NAMES = [:max_hp, :max_mp, :atk, :def, :int, :agi].freeze
-    # The item field carrying each stat's equipment bonus, in STAT_NAMES order.
-    # RPG2000 keeps every equipped weapon/armour bonus in the "points1" set plus
-    # the max HP/SP points, whatever the slot.
-    EQUIP_BONUS_FIELD = [:max_hp_points, :max_sp_points, :atk_points1,
+    # The item field carrying each stat's equipment bonus, in STAT_NAMES order,
+    # nil for the two stats no equipped item can ever raise. RPG2000's editor
+    # only offers an equip-bonus field for the four combat stats -- Attack,
+    # Defence, Mind (Spirit), Agility -- stored in each item's "points1" set
+    # (`atk_points1`/`def_points1`/`spi_points1`/`agi_points1`) and summed live
+    # over every equipped slot every time gear changes; a weapon/armour/shield/
+    # helmet/accessory has no "+Max HP"/"+Max SP" field to set at all. The
+    # `max_hp_points`/`max_sp_points` fields exist on every item row (the LCF
+    # schema does not split fields by item type), but they are semantically
+    # part of a *different* six-field set together with `atk_points2`/
+    # `def_points2`/`spi_points2`/`agi_points2` -- a Seed-type (材料, database
+    # item type 8) item's own one-time, permanent stat-up amount, applied only
+    # when the item is *consumed* (`Actor#seed_boosts`/`Party#use_seed`, via
+    # `Actor#change_param`), never while merely worn. Confirmed against
+    # EasyRPG's actual C++ source: `Game_Actor::GetMaxHp`/`GetMaxSp` resolve to
+    # `GetBaseMaxHp`/`GetBaseMaxSp` with no per-equipment summation at all
+    # (`src/game_actor.cpp`), unlike `GetAtk`/`GetDef`/`GetSpi`/`GetAgi`, which
+    # each walk every equipped item via `ForEachEquipment` reading exactly the
+    # matching `*_points1` field; `max_hp_points`/`max_sp_points` are read
+    # nowhere in that equip-time path, only inside `UseItem`'s Material branch
+    # alongside `atk_points2`..`agi_points2`, the exact fields
+    # `Game::Actor#seed_boosts` (`use_seed`, `Scene::ItemMenu`'s Seed handling
+    # above) already reads for the one-time consumable boost. So indices 0/1
+    # (max_hp/max_mp) carry no field here at all -- #equip_bonus returns 0 for
+    # them unconditionally, regardless of what an item's own `max_hp_points`/
+    # `max_sp_points` happen to hold.
+    EQUIP_BONUS_FIELD = [nil, nil, :atk_points1,
                          :def_points1, :spi_points1, :agi_points1].freeze
     # Equipment slots, in save/database order: weapon, shield, armour, helmet,
     # accessory.
@@ -1472,11 +1495,15 @@ module Game
     end
 
     # Total equipment bonus for stat index `i` (see EQUIP_BONUS_FIELD): the sum
-    # over equipped items of that item's bonus field. A database that exposes no
-    # item table (the test fixtures) contributes nothing.
+    # over equipped items of that item's bonus field. Always 0 for max HP/MP
+    # (index 0/1, `EQUIP_BONUS_FIELD[i]` nil there -- see its own comment): no
+    # equipped item ever raises those two, only a consumed Seed does. A
+    # database that exposes no item table (the test fixtures) contributes
+    # nothing either.
     def equip_bonus(i)
-      return 0 unless @db.respond_to?(:item)
       field = EQUIP_BONUS_FIELD[i]
+      return 0 unless field
+      return 0 unless @db.respond_to?(:item)
       total = 0
       @equipment.each do |iid|
         next if iid.nil? || iid == 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3000,15 +3000,18 @@ check 'Actor base stats scale with level from the growth curve' do
 end
 
 check 'Actor equipment adds item bonuses to the effective stats' do
+  # id 12's mhp: 50 must NOT reach max_hp while equipped -- see the next check;
+  # kept here at 0 so this check's own +50 arithmetic on the four combat stats
+  # is not shadowed by that separate assertion.
   items = { 10 => fake_item(atk: 20), 11 => fake_item(dfn: 8, agi: -3),
-            12 => fake_item(mhp: 50) }
+            12 => fake_item(spi: 6) }
   # base at L1: maxhp10 maxmp5 atk3 def2 int1 agi4
   db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) },
                        [1], items)
   a = Game::Party.new(db).leader
-  eq [3, 2, 4, 10], [a.atk, a.def, a.agi, a.max_hp]   # nothing equipped
+  eq [3, 2, 4, 1], [a.atk, a.def, a.agi, a.int]       # nothing equipped
   a.equip([10, 11, 12, 0, 0])
-  eq [23, 10, 1, 60], [a.atk, a.def, a.agi, a.max_hp] # +20 atk, +8 def-3 agi, +50 hp
+  eq [23, 10, 1, 7], [a.atk, a.def, a.agi, a.int]     # +20 atk, +8 def-3 agi, +6 int
   eq true, a.equipped?(11)
   eq false, a.equipped?(99)
   # Change Parameters lands on the base stat; the equipment bonus stays on top.
@@ -3016,7 +3019,30 @@ check 'Actor equipment adds item bonuses to the effective stats' do
   eq 28, a.atk                                        # 8 + 20
   # Unequipping removes the bonus.
   a.equip([0, 0, 0, 0, 0])
-  eq [8, 2, 4, 10], [a.atk, a.def, a.agi, a.max_hp]
+  eq [8, 2, 4, 1], [a.atk, a.def, a.agi, a.int]
+end
+
+check 'Actor equipment never adds max_hp_points/max_sp_points to max HP/MP' do
+  # Verified against EasyRPG's actual C++ source: Game_Actor::GetMaxHp/GetMaxSp
+  # resolve to GetBaseMaxHp/GetBaseMaxSp with no per-equipment summation at all
+  # (src/game_actor.cpp), unlike GetAtk/GetDef/GetSpi/GetAgi, which each walk
+  # every equipped item's own *_points1 field via ForEachEquipment. An item's
+  # max_hp_points/max_sp_points fields are read only from UseItem's Material
+  # (Seed) branch -- a one-time, on-consumption stat-up (Actor#seed_boosts) --
+  # never from equipping. A weapon/armour/shield/helmet/accessory row can
+  # still carry a nonzero max_hp_points/max_sp_points value (the LCF schema
+  # does not split fields by item type, and a hand-edited or type-reassigned
+  # database row could leave one behind), but it must have zero effect while
+  # merely worn.
+  items = { 20 => fake_item(mhp: 500, msp: 500, atk: 7, type: 1) } # a "cursed" weapon row
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) },
+                       [1], items)
+  a = Game::Party.new(db).leader
+  eq [10, 5, 3], [a.max_hp, a.max_mp, a.atk]          # nothing equipped
+  a.equip([20, 0, 0, 0, 0])
+  eq [10, 5, 10], [a.max_hp, a.max_mp, a.atk]         # max HP/MP untouched; +7 atk still lands
+  a.equip([0, 0, 0, 0, 0])
+  eq [10, 5, 3], [a.max_hp, a.max_mp, a.atk]          # unequipping is likewise a no-op on HP/MP
 end
 
 check 'Change Parameters tracks an unclamped total under the displayed clamp' do


### PR DESCRIPTION
## Summary
- Found while auditing `Game::Actor::EQUIP_BONUS_FIELD` against the already-fixed "a seed permanently raises the target's stats" entry: `Scene::EquipMenu`'s comparison-arrow fix already comments "max HP/SP have no comparison arrow, only the four battle stats do," but `#recompute_stats` was still summing an item's `max_hp_points`/`max_sp_points` fields (LCF item fields 41/42) as if they were a live equipment bonus, alongside the four real combat-stat equip bonuses.
- Fields 41/42 are semantically grouped with 43-46 (`atk_points2`..`agi_points2`) — the six-field set a Seed-type item spends as a **one-time, permanent** stat-up when *consumed* (already correctly implemented in `Actor#seed_boosts`/`Party#use_seed`), never while merely worn.
- Verified against EasyRPG's real source: `Game_Actor::GetMaxHp`/`GetMaxSp` resolve to `GetBaseMaxHp`/`GetBaseMaxSp` with no per-equipment summation at all, unlike `GetAtk`/`GetDef`/`GetSpi`/`GetAgi`, which walk equipped items reading only their own `*_points1` field. RPG2000's editor has no "+Max HP"/"+Max SP" equip-bonus field for weapon/shield/armour/helmet/accessory items — only the four combat stats. A live scan of real test-bed data confirmed no legitimately-authored item exercises this, but a hand-edited/type-reassigned database row could carry a stray value straight into the per-frame stat computation, and the code was objectively wrong either way.
- `EQUIP_BONUS_FIELD[0]`/`[1]` (max HP/MP) set to `nil`; `#equip_bonus` returns `0` immediately when the field is `nil`. Indices 2-5 (atk/def/spi/agi) unchanged.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 734 checks pass (1 new: a weapon carrying both a combat-stat bonus and a large max_hp/sp value raises only the combat stat when equipped, leaves max HP/MP untouched both equipped and unequipped — confirmed to fail against the pre-fix code; also corrected a pre-existing check that had been asserting the buggy behavior as correct)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 448 checks pass (unaffected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_