### PR TITLE
rpg2k: a Battle Animation's fired flash now lasts the correct 11 real frames

### DIFF
--- a/changelog.d/battle-animation-flash-duration.fixed.md
+++ b/changelog.d/battle-animation-flash-duration.fixed.md
@@ -1,0 +1,10 @@
+- **A Battle Animation's own fired screen/target flash now stays visible for
+  the correct duration.** `Scene::Map::ANIM_FLASH_FRAMES` was an unverified
+  guess of 8 real ticks, force-clearing a fired flash roughly 20% early on
+  every single Battle Animation flash timing. Verified against EasyRPG
+  Player's actual C++ source: `BattleAnimation::UpdateFlashGeneric`
+  (`src/battle_animation.cpp`) keeps a fired timing's colour/power alive for
+  `delta_frames <= 10` — 11 raw ticks (0 through 10 inclusive) from the tick
+  it fires — before falling back to all-zero. Fixed by changing the constant
+  to 11. Covered by a new `scripts/rpg2k_scene_check.rb` check, confirmed to
+  fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4425,7 +4425,9 @@ not yet verified:
   same universal 2-tick hold, just from having only ever isolated it on a
   blank/Wait frame in practice. Fixed by changing `ANIM_CELL_FRAMES` from
   `3` to `2`; `ANIM_FALLBACK_FRAMES`/`ANIM_FLASH_FRAMES` (10 and 8 frames
-  respectively, independent constants) are untouched, and the fallback timed
+  respectively, independent constants) were left untouched by this fix —
+  `ANIM_FLASH_FRAMES`'s own 8 turned out to be wrong too, see the ✅ bullet
+  directly below — and the fallback timed
   wait (`ANIM_FALLBACK_FRAMES * ANIM_CELL_FRAMES`, used when an animation's
   own sheet/data is missing) shortens to match automatically since it
   multiplies through the same constant. Covered by a new
@@ -4434,6 +4436,38 @@ not yet verified:
   confirmed to fail against the pre-fix code (`expected 2, got 3`) before
   the fix. "Back-to-back calls stutter" (the bullet's third, unrelated
   claim) remains open, as noted above.
+- ✅ **`ANIM_FLASH_FRAMES` — how long a Battle Animation's own fired
+  screen/target flash stays visible before the animation forcibly clears it
+  again — is now 11, not 8.** The bullet directly above left this constant
+  "untouched" as one of two "independent constants," alongside
+  `ANIM_FALLBACK_FRAMES`, when `ANIM_CELL_FRAMES` was fixed — an unverified
+  guess that was never itself checked against EasyRPG Player's actual C++
+  source the way `ANIM_CELL_FRAMES` was. `BattleAnimation::UpdateFlashGeneric`
+  (`src/battle_animation.cpp`) computes `delta_frames = GetFrame() -
+  start_frame` (`start_frame = (timing.frame - 1) * 2`, the raw tick a fired
+  timing's own LCF frame begins displaying) and keeps that timing's r/g/b/p
+  alive for `delta_frames <= 10` — 11 raw ticks (0 through 10 inclusive)
+  from the tick it fires — before `UpdateScreenFlash`/`UpdateTargetFlash`
+  fall back to an unconditional all-zero; `GetFrame()` is the same
+  once-per-`Update()`-call raw tick counter (one call per logical 60fps
+  frame) the already-verified `ANIM_CELL_FRAMES` derivation above already
+  relies on, so the two share a tick unit and 11 is directly comparable, not
+  a guess. `Scene::Map#hold_animation_screen_flash`/`#hold_animation_target_flash`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) use `ANIM_FLASH_FRAMES` both as the
+  `frames` duration handed to `Game::Screen#flash`/`Sprite#flash`/the map
+  Character-Flash hash and as the `screen_flash_hold`/`target_flash_hold`
+  per-real-frame countdown that keeps the animation's own just-fired flash
+  from being stomped by its own continuous per-frame reassertion — at 8, a
+  fired flash was force-cleared roughly 3 real ticks (a full 20% of the
+  intended window) early on every single Battle Animation flash timing in
+  either engine's own battle, well short of what `delta_frames <= 10`
+  actually allows. Fixed by changing the constant to `11` and adding a
+  derivation comment mirroring `ANIM_CELL_FRAMES`'s own. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check that hand-drives
+  `#fire_animation_flashes`/`#hold_animation_screen_flash` the exact number
+  of times to land on `delta_frames` 10 and 11 (11 calls still flashing, the
+  12th cleared) independent of the constant's own value, confirmed to fail
+  against the pre-fix code (cleared several calls early) before the fix.
 - ✅ **A second Show Battle Animation (11210) now forcibly cuts the first
   one's sprite off, instead of the second request quietly waiting its turn
   for the shared slot to free up** — the "only one on screen at a time"

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5800,7 +5800,17 @@ class RPG2k
       # otherwise assumed correctly.
       ANIM_CELL_FRAMES = 2
       ANIM_FALLBACK_FRAMES = 10
-      ANIM_FLASH_FRAMES = 8
+      # ANIM_FLASH_FRAMES is 11, not some other guess: EasyRPG's
+      # `BattleAnimation::UpdateFlashGeneric` (src/battle_animation.cpp) keeps a
+      # fired timing's own colour/power alive for `delta_frames = GetFrame() -
+      # start_frame` from 0 up to and including 10 (`if (delta_frames <= 10)`)
+      # before `UpdateScreenFlash`/`UpdateTargetFlash` fall back to all-zero --
+      # `GetFrame()` is the same raw once-per-`Update()`-call tick counter
+      # `ANIM_CELL_FRAMES`'s own derivation above already relies on, so this is
+      # 11 raw ticks (0..10 inclusive), not 8. Previously an unverified guess,
+      # left untouched by the `ANIM_CELL_FRAMES` fix's own comment ("independent
+      # constants").
+      ANIM_FLASH_FRAMES = 11
       # RPG2000 battle-animation cells: a 96x96 grid, 5 cells across the sheet.
       ANIM_CELL = 96
       ANIM_SHEET_COLS = 5

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7756,6 +7756,36 @@ check 'a target-scope animation flash pulses the hit enemy, not the screen or a 
   eq nil, spr.flash_color, 'the flash faded out after its duration'
 end
 
+# ANIM_FLASH_FRAMES itself, pinned against EasyRPG's actual C++ source rather
+# than against its own value (the checks above derive their expectations from
+# the constant, so a wrong constant would still "pass" them). EasyRPG's
+# `BattleAnimation::UpdateFlashGeneric` (src/battle_animation.cpp) computes
+# `delta_frames = GetFrame() - start_frame` and keeps a fired timing's own
+# colour/power alive for `delta_frames <= 10` -- 11 raw ticks (0 through 10
+# inclusive) from the tick it fires, not some other guess -- before
+# `UpdateScreenFlash` falls back to an unconditional all-zero. Hand-drives
+# #hold_animation_screen_flash (the per-real-frame reassertion loop
+# `#step_map_animation` calls, once per real tick, right alongside
+# #fire_animation_flashes on the very same tick the timing fires and every
+# tick after) to land on delta_frames 10 and 11 without needing a full fixture
+# animation or 60 real `scene.update` calls.
+check 'a fired animation screen flash stays alive for exactly 11 real frames, matching ' \
+      "EasyRPG's UpdateFlashGeneric delta_frames <= 10" do
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  timing = OpenStruct.new(frame: 0, flash_scope: 2, flash_red: 31, flash_green: 0,
+                          flash_blue: 0, flash_power: 20)
+  ma = { frame_i: 0, timings: [timing] }
+  scene.send(:fire_animation_flashes, ma) # delta_frames 0: fires, sets the hold counter
+  # #step_map_animation calls #hold_animation_screen_flash on this exact same
+  # tick too (right after #fire_animation_flashes), so 11 calls here cover
+  # delta_frames 0 through 10 -- the tick that fired plus 10 more.
+  11.times { scene.send(:hold_animation_screen_flash, ma) }
+  ok st.screen.flashing?, 'still alive through delta_frames 10 (still <= 10)'
+  scene.send(:hold_animation_screen_flash, ma) # delta_frames 11
+  ok !st.screen.flashing?, 'cleared at delta_frames 11, matching the C++ falling back to all-zero'
+end
+
 # An ally-targeted entry (RPG2000's battle is front-view: no sprite for a
 # party member, so target_index is nil there -- see #battle_animation_pixel)
 # has nothing to flash; #fire_target_flash must not raise reaching for a


### PR DESCRIPTION
## Summary
- `Scene::Map::ANIM_FLASH_FRAMES` — how long a Battle Animation's own fired screen/target flash stays visible before the animation forcibly clears it again — was an unverified guess of 8 real ticks. It was explicitly flagged as one of two "independent constants" left untouched by the earlier `ANIM_CELL_FRAMES` fix (docs/TODO.md), meaning it was never itself checked against EasyRPG Player's real source the way `ANIM_CELL_FRAMES` was.
- Verified against EasyRPG Player's actual C++ source: `BattleAnimation::UpdateFlashGeneric` (`src/battle_animation.cpp`) computes `delta_frames = GetFrame() - start_frame` and keeps a fired timing's own colour/power alive for `delta_frames <= 10` — 11 raw ticks (0 through 10 inclusive) from the tick it fires — before `UpdateScreenFlash`/`UpdateTargetFlash` fall back to an unconditional all-zero. `GetFrame()` is the same once-per-`Update()`-call raw tick counter (one call per logical 60fps frame) the already-verified `ANIM_CELL_FRAMES` derivation relies on, so the two constants share a tick unit and are directly comparable.
- At 8, a fired flash was force-cleared roughly 3 real ticks (20% of the correct window) early on every single Battle Animation flash timing, in either the screen-flash or the character-flash path (`#hold_animation_screen_flash`/`#hold_animation_target_flash`, `mruby-rpg2k/mrblib/scene/map.rb`).
- Fixed by changing `ANIM_FLASH_FRAMES` from 8 to 11 and adding a derivation comment mirroring `ANIM_CELL_FRAMES`'s own. Also corrected the earlier `ANIM_CELL_FRAMES` bullet's stale "8 frames... untouched" claim in `docs/TODO.md` to point at this fix.
- `docs/TODO.md` updated ✅ with the citation; `changelog.d/battle-animation-flash-duration.fixed.md` added.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 734 checks pass (unaffected)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 449 checks pass (1 new: hand-drives `#fire_animation_flashes`/`#hold_animation_screen_flash` to land on `delta_frames` 10 and 11 independent of the constant's own value — confirmed to fail against the pre-fix code, clearing several calls early)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWiV6AvVhQpj2yhBVSkHbS)_