### PR TITLE
rpg2k: Pan Screen offset and Lock now survive a save/load

### DIFF
--- a/changelog.d/screen-pan-lock-save-load.fixed.md
+++ b/changelog.d/screen-pan-lock-save-load.fixed.md
@@ -1,0 +1,22 @@
+- **Pan Screen's offset and Lock now survive a save/load** through this
+  codebase's own authoritative Marshal save (`Game::State#to_h`/`.load`),
+  instead of silently snapping the camera back to hero-centred and unlocked
+  on every Continue. `@screen` was the one nested `Game::State` object with
+  no serialisation at all — `@weather`, every vehicle, the message config
+  and everything else already round-trip through a `to_h`/`load_h` pair. A
+  cutscene that pans the camera and locks it (so the hero stops re-centring
+  the view) can leave that mode active indefinitely, and a Save event or the
+  menu's own Save command taken while it holds used to lose the state
+  entirely, with no way for a script to detect it. Fixed with a new
+  `Game::Screen#to_h`/`#load_h` pair scoped to `pan_x`/`pan_y`/`pan_tx`/
+  `pan_ty`/`pan_step`/`pan_locked` — a pan mid-scroll when the game is saved
+  now resumes the rest of that scroll on load rather than jumping straight to
+  (or stopping short of) its destination. Every other screen effect (tint
+  transition, shake, flash, fade) stays deliberately transient, reset on
+  every load exactly as before. The `.lsd` export (`State#to_lsd`/
+  `.from_lsd`) is untouched — real RPG_RT's own save chunk stores an
+  absolute camera pixel position rather than a hero-relative pan offset,
+  which needs a live camera reading from the open `Scene::Map` at save time,
+  a separate, bigger question left open. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4989,7 +4989,49 @@ mere map-revisit): screen-shake offset (never saved, always resets);
 BGM/SE playback position (always restarts a track from the beginning even
 though the *filename* is remembered); Screen Scroll offset (saved but
 documented as broken/buggy after resuming — the site explicitly
-recommends never saving mid-scroll). A **Common Event's** parallel-process
+recommends never saving mid-scroll). ✅ **This codebase's own authoritative
+save (the portable Marshal `to_h`/`State.load` pair `save_game`/
+`load_save_state` actually use, `mruby-rpg2k/mrblib/main.rb`) now carries
+the Pan Screen offset and Lock across a save/load, closing the clear-cut
+half of this gap** — whatever real RPG_RT's own "broken/buggy after
+resuming" quirk turns out to mean exactly (unconfirmed here, no wine rig
+in this environment to reproduce it against), dropping the state entirely
+was strictly worse: every other per-frame effect `Game::Screen` owns
+(tint transition, shake, flash, fade) is a genuinely transient animation
+with no standing "mode" a script leaves active, but Pan Screen's Lock
+operation is different in kind — a cutscene that pans the camera and
+locks it (so the hero no longer re-centres the view) can leave that mode
+active indefinitely, and a Save event or the player opening the menu to
+save while it holds used to silently snap the camera back to hero-centred
+*and* unlocked on load, with no way for a script to tell. `Game::State#
+to_h`/`.load` (`mruby-rpg2k/mrblib/game.rb`) already round-trips every
+other nested object this way (`@weather.to_h`/`#load_h`, the same idiom
+this fix copies); `@screen` was the one exception, built fresh every load
+with no serialisation at all. Fixed with a new `Game::Screen#to_h`/
+`#load_h` pair scoped to exactly `pan_x`/`pan_y`/`pan_tx`/`pan_ty`/
+`pan_step`/`pan_locked` — the pan offset, its still-in-flight scroll
+target/step, and the lock flag — deliberately excluding tint/shake/flash/
+fade, which stay reset-on-load exactly as before (shake in particular
+stays matched to the "never saved, always resets" fact this same bullet
+already records). A pan mid-scroll when the game is saved now resumes the
+rest of that scroll on load rather than jumping straight to (or stopping
+short of) its destination, since `pan_tx`/`pan_ty`/`pan_step` — not just
+the current `pan_x`/`pan_y` — are carried too. Out of scope: the `.lsd`
+export (`State#to_lsd`/`.from_lsd`) is untouched — real RPG_RT's own
+chunk-111 fields 1/2 store the *absolute* camera pixel position rather
+than a hero-relative pan offset (see `LCF::Schema::SAVE_MAP_EVENT` in
+`mruby-lcf/mrblib/schema.rb`, ADR 0021), which needs a live camera reading
+from whichever `Scene::Map` is open at save time — a bigger, separate
+plumbing question left for later, alongside chunks 113/114's still-opaque
+event-interpreter state the paragraph below already flags as `.lsd`-only
+gaps. Covered by a new `scripts/rpg2k_logic_check.rb` check (a locked,
+mid-scroll pan survives a `to_h`/`.load` round trip — the lock flag, the
+offset at whatever point it had reached, and the still-open scroll target,
+which then finishes advancing correctly afterward — while tint/shake/
+flash armed on the same `Game::Screen` are confirmed to *not* survive it;
+a legacy save missing the new `:screen` key loads a neutral, unlocked,
+zero-offset camera), confirmed to fail against the pre-fix code (the Lock
+lost on load) before the fix. A **Common Event's** parallel-process
 position **does** survive save/load (✅ fixed for the portable Marshal save,
 see "A Common Event's Parallel Process now survives a Transfer Player and a
 save/load" above; the `.lsd` export still does not, chunks 113/114 remain

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5018,6 +5018,34 @@ module Game
     # True while a pan/reset scroll has not yet reached its target.
     def panning?; @pan_x != @pan_tx || @pan_y != @pan_ty; end
 
+    # Persisted pan/lock state only, mirroring Weather's own `to_h`/`load_h`
+    # idiom. Every *other* field this class holds (tint transition, shake,
+    # flash, fade) stays deliberately transient -- see the class-level
+    # "Transient screen-effect state" comment on `Game::State#initialize` --
+    # but Pan Screen's Lock is not a per-frame effect the same way: it is a
+    # standing camera mode a script can leave active indefinitely (e.g. a
+    # cutscene that pans and locks the view before a Save event or the
+    # player opening the menu to save), and dropping it silently snapped the
+    # camera back to hero-centred *and* unlocked on every load -- the pan
+    # offset and its still-in-flight target/step are carried too so a pan
+    # that had not finished scrolling when the game was saved resumes the
+    # rest of that scroll instead of jumping straight to (or short of) its
+    # destination.
+    def to_h
+      { pan_x: @pan_x, pan_y: @pan_y, pan_tx: @pan_tx, pan_ty: @pan_ty,
+        pan_step: @pan_step, pan_locked: @pan_locked }
+    end
+
+    def load_h(h)
+      return unless h
+      @pan_x = h[:pan_x] || 0
+      @pan_y = h[:pan_y] || 0
+      @pan_tx = h[:pan_tx] || 0
+      @pan_ty = h[:pan_ty] || 0
+      @pan_step = h[:pan_step] || 1
+      @pan_locked = h[:pan_locked] ? true : false
+    end
+
     # Screen erasure level (0 fully visible .. 255 fully black). The scene draws
     # a black overlay at this opacity. While a shaped transition is running the
     # overlay is a mask instead (see #transition), and this holds the level the
@@ -8262,8 +8290,10 @@ module Game
       @vehicles = { boat: Vehicle.new(:boat), ship: Vehicle.new(:ship),
                     airship: Vehicle.new(:airship) }
       @boarded = nil
-      # Transient screen-effect state (tint transition); not serialised, so a
-      # reloaded game starts with a neutral screen.
+      # Screen effects: tint transition/shake/flash/fade stay transient (not
+      # serialised, so a reloaded game starts with them neutral) -- but the
+      # Pan Screen offset/lock *does* now survive a save/load, see
+      # Game::Screen#to_h/#load_h.
       @screen = Screen.new
       # Shown pictures, id => Game::Picture. Transient like @screen (RPG2000's
       # HUD pictures are re-shown by parallel events on load), so not serialised.
@@ -8456,6 +8486,7 @@ module Game
         menu_access: @menu_access, save_access: @save_access,
         current_bgm: @current_bgm, memorized_bgm: @memorized_bgm,
         player_transparent: @player_transparent, weather: @weather.to_h,
+        screen: @screen.to_h,
         teleport_access: @teleport_access, escape_access: @escape_access,
         encounter_rate: @encounter_rate, encounter_total: @encounter_total,
         teleport_targets: @teleport_targets,
@@ -8867,6 +8898,7 @@ module Game
       state.memorized_bgm = h[:memorized_bgm]
       state.player_transparent = h[:player_transparent] ? true : false
       state.weather.load_h(h[:weather])
+      state.screen.load_h(h[:screen])
       state.teleport_access = h[:teleport_access] ? true : false
       state.escape_access = h[:escape_access] ? true : false
       # Registries default empty / unset; a save written before these existed

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5759,6 +5759,44 @@ check 'Weather round-trips through the save' do
   ok Game::State.load(db, legacy).weather.none?
 end
 
+check 'Screen pan/lock round-trips through the save; other effects stay transient' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.screen.pan(1, 2, 3) # pan right 2 tiles (32px) at speed 3 -> 4px/frame
+  2.times { st.screen.update } # in-flight (8px), short of the 32px target
+  st.screen.pan_lock
+  # Deliberately-transient effects, armed too, to prove they do NOT survive.
+  st.screen.tint_to(200, 100, 100, 100, 10)
+  st.screen.shake(5, 5, 10)
+  st.screen.flash(255, 0, 0, 20, 10)
+  ok st.screen.pan_locked?
+  ok st.screen.panning?
+  before_offset = st.screen.pan_offset
+
+  loaded = Game::State.load(db, st.to_h)
+  eq true, loaded.screen.pan_locked?, 'the Lock survives the save'
+  eq before_offset, loaded.screen.pan_offset,
+     'the in-progress pan offset survives at whatever point it had scrolled to'
+  ok loaded.screen.panning?, 'the still-unfinished scroll toward its target survives too'
+  6.times { loaded.screen.update } # remaining 24px at 4px/frame lands on the 32px target
+  eq [32, 0], loaded.screen.pan_offset, 'the scroll resumes toward its original target'
+  ok !loaded.screen.tinting?, 'tint transitions stay transient, unlike pan'
+  ok !loaded.screen.shaking?, 'shake stays transient, unlike pan'
+  ok !loaded.screen.flashing?, 'flash stays transient, unlike pan'
+
+  # A save written before Screen pan state was persisted defaults to a
+  # neutral, hero-following camera -- not locked, no offset.
+  legacy = st.to_h
+  legacy.delete(:screen)
+  legacy_loaded = Game::State.load(db, legacy)
+  ok !legacy_loaded.screen.pan_locked?
+  eq [0, 0], legacy_loaded.screen.pan_offset
+end
+
 # -- Change Teleport / Escape Access ------------------------------------------
 
 check 'Change Teleport / Escape Access toggle their flags, non-blocking' do


### PR DESCRIPTION
## Summary

- `Game::State#to_h`/`.load` (the portable Marshal save this codebase's own Continue/Save actually use) never serialised `Game::Screen` at all, so a cutscene that pans the camera and locks it (so the hero stops re-centring the view) silently lost that state on load — the camera snapped back to hero-centred and unlocked, with no way for a script to detect it.
- Adds a `Game::Screen#to_h`/`#load_h` pair (mirroring `Weather`'s existing `to_h`/`load_h` idiom) scoped to `pan_x`/`pan_y`/`pan_tx`/`pan_ty`/`pan_step`/`pan_locked` — the pan offset, its still-in-flight scroll target/step, and the lock flag — and wires it into `Game::State#to_h`/`.load`.
- Every other screen effect (tint transition, shake, flash, fade) stays deliberately transient, reset on every load exactly as before — matching the already-documented "screen-shake offset never saved" fact in `docs/TODO.md`.
- The `.lsd` export (`State#to_lsd`/`.from_lsd`) is deliberately untouched: real RPG_RT's own save chunk stores an *absolute* camera pixel position rather than a hero-relative pan offset, which would need a live camera reading from whichever `Scene::Map` is open at save time — a separate, bigger plumbing question left open (noted in `docs/TODO.md`).
- Updates `docs/TODO.md`'s "Save / Load persistence — consolidated master list" entry and adds a changelog fragment.

## Test plan

- Added `scripts/rpg2k_logic_check.rb` check: a locked, mid-scroll Pan Screen state survives a `to_h`/`.load` round trip (the lock flag, the offset at whatever point it had reached, and the still-open scroll target, which then finishes advancing correctly afterward), while tint/shake/flash armed on the same `Game::Screen` are confirmed to *not* survive it; a legacy save missing the new `:screen` key loads a neutral, unlocked, zero-offset camera.
- Confirmed the new check fails against the pre-fix code (`git stash` of `mruby-rpg2k/mrblib/game.rb` only) before finalizing.
- `ruby scripts/rpg2k_logic_check.rb` — 735 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 448 checks passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEG9oPi9gFhXy8vAUcRGUy)_