### PR TITLE
rpg2k: an actor's effective ATK/DEF/SPI/AGI and max HP/MP are now clamped

### DIFF
--- a/changelog.d/actor-stat-effective-clamp.fixed.md
+++ b/changelog.d/actor-stat-effective-clamp.fixed.md
@@ -1,0 +1,19 @@
+- **An actor's effective max HP/MP and four combat stats (ATK/DEF/SPI/AGI)
+  now clamp to RPG_RT's own ceilings, equipment bonus included, instead of
+  growing unbounded.** Verified against EasyRPG Player's actual C++ source:
+  `Game_Actor::GetBaseAtk`/`GetBaseDef`/`GetBaseSpi`/`GetBaseAgi`
+  (`src/game_actor.cpp`) clamp the level curve + Change-Parameters shadow +
+  equipped-item bonus *together* to `Utils::Clamp(n, 1, MaxStatBaseValue())`
+  (999, not edition-gated), and `GetBaseMaxHp`/`GetBaseMaxSp` clamp to
+  `MaxActorHpValue()`/`MaxActorSpValue()` (HP: 999 RPG2000 / 9999 RPG2003;
+  MP: 999 either edition). `Game::Actor#recompute_stats`
+  (`mruby-rpg2k/mrblib/game.rb`) had no ceiling at all on any of the six
+  stats — the existing `#change_param`/`#base_param_limit` clamp only ever
+  applied to a live Change Parameters delta on the unequipped base value,
+  never to the equip-inclusive total, and never to a fresh level-curve
+  assignment either. Fixed with new `MAX_EFFECTIVE_STAT`/`MAX_EFFECTIVE_MP`/
+  `MAX_EFFECTIVE_HP_2K`/`MAX_EFFECTIVE_HP_2K3` constants and a new
+  `Actor#rpg2003?`/`#max_hp_cap` pair (mirroring `Game::Party#rpg2003?`'s
+  detection) applied inside `#recompute_stats`. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3487,11 +3487,63 @@ not yet verified:
 - Running a hero-targeted Parallel-Process Set Move Route while the hero
   is mid-transition onto an event's tile can suppress that event's "Hero
   Touch" trigger for that step.
-- Display stat clamping (e.g. displayed max HP capped 1-999) is **cosmetic
-  only** — the underlying stored value is not clamped, so it can go
-  negative or over 999 internally and a later +/- operates on the real
-  (unclamped) value, producing results that look wrong if you assume the
-  displayed number was the true one.
+- ✅ **"Display stat clamping is cosmetic only" turns out to be backwards —
+  verified against EasyRPG Player's actual C++ source rather than taken on
+  faith, the clamp is real and applies to the *effective* stat itself,
+  equipment bonus included, not merely to what gets drawn on screen.**
+  `Game_Actor::GetBaseAtk`/`GetBaseDef`/`GetBaseSpi`/`GetBaseAgi`
+  (`src/game_actor.cpp`) each sum the level curve, the Change-Parameters
+  `*_mod` shadow total, *and* every equipped item's own `*_points1` bonus,
+  then clamp the combined total to `Utils::Clamp(n, 1, MaxStatBaseValue())`
+  — `Game_Constants::MaxStatBaseValue` (`src/game_constants.cpp`) defaults to
+  999 for both RPG2000 and RPG2003, no edition split — so an equip bonus
+  cannot push the effective stat past 999 either, contrary to the claim.
+  `GetBaseMaxHp`/`GetBaseMaxSp` clamp the same way, to `MaxActorHpValue()`/
+  `MaxActorSpValue()`: HP is edition-gated (`Player::IsRPG2k() ? 999 :
+  9999`), SP stays 999 in both editions with no such split.
+  `Game::Actor#recompute_stats` (`mruby-rpg2k/mrblib/game.rb`) computed
+  `@max_hp`/`@max_mp`/`@atk`/`@def`/`@int`/`@agi` as a bare `@base[i] +
+  equip_bonus(i)` with no ceiling at all — the codebase's own existing
+  `#change_param`/`#base_param_limit` clamp (1..999 for the four combat
+  stats, 1..9999 for HP/MP — itself pre-existing, correct for the *base*
+  value alone, and left untouched by this fix) only ever applied to a live
+  Change Parameters delta on `@base`, never to the combined equip-inclusive
+  total `#recompute_stats` derives from it, and never to the *initial*
+  `@base` a level-curve/status-hash assignment (`#set_level`) hands
+  `#recompute_stats` fresh with no clamp of its own either. So a levelling
+  curve or a stray large equip bonus could already carry an actor's
+  effective max HP/MP/ATK/DEF/SPI/AGI arbitrarily far past what real RPG_RT
+  would ever let it reach, silently, before any command even ran. Fixed by
+  clamping each of the six sums in `#recompute_stats` itself: `MAX_EFFECTIVE_
+  STAT = 999` for the four combat stats (uniform, no edition check, matching
+  `MaxStatBaseValue`'s own unconditional default); `MAX_EFFECTIVE_MP = 999`
+  for max MP/SP (also uniform); and a new `#max_hp_cap`/`#rpg2003?` pair —
+  the latter duplicating `Game::Party#rpg2003?`'s own `@db.respond_to?(:rpg2003?)
+  && @db.rpg2003?` test, since an `Actor` only ever holds `@db` directly, not
+  a `Party` back-reference — picking `MAX_EFFECTIVE_HP_2K3 = 9999` on an
+  RPG2003 database and `MAX_EFFECTIVE_HP_2K = 999` otherwise for max HP, the
+  same detection path the RPG2003 variable-range-widen and enemy-levitate
+  fixes already key off. Current HP/MP still reclamp to the freshly-lowered
+  maxima exactly as before (`@hp = @max_hp if @hp && @hp > @max_hp`), now
+  running against the newly-capped ceiling rather than an unbounded one. The
+  codebase's own separate, pre-existing "1..9999 for max HP/MP" reading baked
+  into `#base_param_limit` (the Change Parameters shadow-total clamp) is only
+  correct for HP on an RPG2003 database — real MP/SP was never 9999 in either
+  edition per `MaxActorSpValue`'s own unconditional 999 default — left as-is
+  here since it only ever over-widens a ceiling nothing before this fix
+  re-applied on top of it anyway, a separate, narrower pre-existing mismatch
+  outside this fix's scope. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (an item bonus that would push Attack from 970 to 1020 clamps at
+  999; a level-curve status hash of 5000 max HP/MP with no equipment
+  involved at all clamps to 999/999 on an RPG2000 database — with current HP
+  dragged down to the new max too — and to 5000/999 on an RPG2003 one, since
+  9999 comfortably fits 5000 while MP still caps at 999), confirmed to fail
+  against the pre-fix code (`expected 999, got 1020`) before the fix; a
+  pre-existing Simulated Attack damage-cap check that relied on an
+  RPG2000-fixture actor holding an unclamped 5000 max HP to demonstrate
+  "999 damage against a high-max-HP target leaves it alive" was updated to
+  an RPG2003 fixture (9999 ceiling, still comfortably above 5000), since a
+  genuine RPG2000 actor can no longer reach that total either.
 
 **Variables & Switches**
 - Switches/variables cap at 5000 each (configurable up to that hard max),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1485,17 +1485,59 @@ module Game
       STAT_NAMES.map { |k| st[k] || 0 }
     end
 
+    # Real RPG_RT's "displayed max HP capped 1-999" is not cosmetic -- the
+    # clamp applies to the *effective* stat itself, equipment bonus included,
+    # not just to the level-curve baseline #change_param's own 1..999/1..9999
+    # floor (`#base_param_limit`, just below) already respects. Confirmed
+    # against EasyRPG Player's actual C++ source: `Game_Actor::GetBaseAtk`/
+    # `GetBaseDef`/`GetBaseSpi`/`GetBaseAgi` (`src/game_actor.cpp`) each sum
+    # the level curve, the Change-Parameters `*_mod` shadow, and every
+    # equipped item's own `*_points1` bonus, THEN clamp the total to
+    # `Utils::Clamp(n, 1, MaxStatBaseValue())` -- `Game_Constants::
+    # MaxStatBaseValue` defaults to 999 for both RPG2000 and RPG2003, no
+    # edition split -- so the equip bonus sits *inside* the same ceiling the
+    # base value alone already respects, not stacked unclamped on top of it.
+    # `GetBaseMaxHp`/`GetBaseMaxSp` clamp the same way to `MaxActorHpValue()`/
+    # `MaxActorSpValue()`: HP is edition-gated (`Player::IsRPG2k() ? 999 :
+    # 9999`, matching the existing `#rpg2003?` accessor other RPG2003-widened
+    # limits already key off), SP stays 999 in both editions with no such
+    # split (RPG2000's own "9999 for max HP/MP" reading, baked into
+    # `#base_param_limit` below, is only correct for HP on an RPG2003
+    # database -- MP was never 9999 in either edition, a separate,
+    # pre-existing mismatch left as-is here since it only ever over-widens a
+    # ceiling nothing before this fix re-applied anyway).
+    MAX_EFFECTIVE_STAT = 999
+    MAX_EFFECTIVE_MP = 999
+    MAX_EFFECTIVE_HP_2K = 999
+    MAX_EFFECTIVE_HP_2K3 = 9999
+
     # Recompute the six effective stats (base + equipment) into their readers and
     # re-clamp current HP/MP to the refreshed maxima.
     def recompute_stats
-      @max_hp = @base[0] + equip_bonus(0)
-      @max_mp = @base[1] + equip_bonus(1)
-      @atk = @base[2] + equip_bonus(2)
-      @def = @base[3] + equip_bonus(3)
-      @int = @base[4] + equip_bonus(4)
-      @agi = @base[5] + equip_bonus(5)
+      @max_hp = Game.clamp(@base[0] + equip_bonus(0), 1, max_hp_cap)
+      @max_mp = Game.clamp(@base[1] + equip_bonus(1), 0, MAX_EFFECTIVE_MP)
+      @atk = Game.clamp(@base[2] + equip_bonus(2), 1, MAX_EFFECTIVE_STAT)
+      @def = Game.clamp(@base[3] + equip_bonus(3), 1, MAX_EFFECTIVE_STAT)
+      @int = Game.clamp(@base[4] + equip_bonus(4), 1, MAX_EFFECTIVE_STAT)
+      @agi = Game.clamp(@base[5] + equip_bonus(5), 1, MAX_EFFECTIVE_STAT)
       @hp = @max_hp if @hp && @hp > @max_hp
       @mp = @max_mp if @mp && @mp > @max_mp
+    end
+
+    # Whether this actor's database is an RPG2003 project -- the same
+    # `@db.respond_to?(:rpg2003?) && @db.rpg2003?` test `Game::Party#rpg2003?`
+    # already exposes, duplicated here since an `Actor` only ever holds `@db`
+    # directly, not a `Party` back-reference; a bare test double with no
+    # `#rpg2003?` of its own reads false, matching a genuine RPG2000 database.
+    def rpg2003?
+      @db.respond_to?(:rpg2003?) && @db.rpg2003?
+    end
+
+    # The effective max HP ceiling #recompute_stats clamps against --
+    # `MAX_EFFECTIVE_HP_2K3` on an RPG2003 database, `MAX_EFFECTIVE_HP_2K`
+    # otherwise.
+    def max_hp_cap
+      rpg2003? ? MAX_EFFECTIVE_HP_2K3 : MAX_EFFECTIVE_HP_2K
     end
 
     # Total equipment bonus for stat index `i` (see EQUIP_BONUS_FIELD): the sum

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3045,6 +3045,48 @@ check 'Actor equipment never adds max_hp_points/max_sp_points to max HP/MP' do
   eq [10, 5, 3], [a.max_hp, a.max_mp, a.atk]          # unequipping is likewise a no-op on HP/MP
 end
 
+check '#recompute_stats clamps the effective max HP/MP and the four combat ' \
+      'stats to RPG_RT\'s own ceilings, equipment bonus included' do
+  # "Display stat clamping is cosmetic only, the underlying stored value is
+  # not clamped" turns out to be wrong once checked against EasyRPG Player's
+  # actual C++ source: Game_Actor::GetBaseAtk/GetBaseDef/GetBaseSpi/GetBaseAgi
+  # (src/game_actor.cpp) sum the level curve, the Change-Parameters *_mod
+  # shadow, AND every equipped item's own *_points1 bonus, THEN clamp the
+  # total to Utils::Clamp(n, 1, MaxStatBaseValue()) -- 999 by default, not
+  # edition-gated -- so an equip bonus can't push the effective stat past 999
+  # either, only the unequipped base value was ever floored/ceilinged before
+  # this fix (#change_param's own 1..999 clamp on @base, still correct and
+  # untouched). GetBaseMaxHp/GetBaseMaxSp clamp the same way, to
+  # MaxActorHpValue() (999 RPG2000 / 9999 RPG2003) / MaxActorSpValue() (999
+  # either edition) -- and neither one needs an equip bonus to demonstrate
+  # the gap, since the level curve alone already reached #recompute_stats
+  # with no clamp of its own before this fix (#change_param's floor only ever
+  # applied to a live Change Parameters delta, never to the initial
+  # #set_level assignment).
+  items = { 30 => fake_item(atk: 50) }
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 970, 2, 1, 4]) },
+                       [1], items)
+  a = Game::Party.new(db).leader
+  eq 970, a.atk                      # unequipped base sits under the ceiling
+  a.equip([30, 0, 0, 0, 0])
+  eq 999, a.atk                      # +50 would be 1020; clamps to 999, not 1020
+
+  # A level curve alone (no equipment involved) that already exceeds the
+  # ceiling clamps too, and the reclamp drags current HP/MP down with it.
+  hp_db_2k = FakeActorDB.new({ 1 => CurveRow.new('Tank', '', 0, 1, [5000, 5000, 3, 2, 1, 4]) }, [1])
+  a2k = Game::Party.new(hp_db_2k).leader
+  eq 999, a2k.max_hp                 # RPG2000: capped at 999, not the raw 5000
+  eq 999, a2k.max_mp                 # MP/SP caps at 999 in both editions
+  eq 999, a2k.hp                     # current HP reclamps to the new max, not left at 5000
+  eq 999, a2k.mp
+
+  hp_db_2k3 = FakeActorDB.new({ 1 => CurveRow.new('Tank', '', 0, 1, [5000, 5000, 3, 2, 1, 4]) },
+                              [1], {}, {}, {}, nil, nil, rpg2003: true)
+  a2k3 = Game::Party.new(hp_db_2k3).leader
+  eq 5000, a2k3.max_hp               # RPG2003 widens the HP ceiling to 9999; 5000 fits
+  eq 999, a2k3.max_mp                # ... but MP/SP still caps at 999, no RPG2003 widening
+end
+
 check 'Change Parameters tracks an unclamped total under the displayed clamp' do
   # yado.tk `2000/デフォ戦botまとめ`: the displayed/effective stat clamps to
   # 1..999 (1..9999 for HP/MP), but RPG_RT keeps accumulating the *real*
@@ -9423,8 +9465,13 @@ end
 # command's own damage too -- it shares no code path with any of those four,
 # so it needed its own clamp.
 check 'Simulated Attack hard-caps damage at 999, matching the battle damage cap' do
+  # max_hp: 5000 needs an RPG2003 fixture database now that #recompute_stats
+  # itself clamps effective max HP to 999/9999 by edition (see "#recompute_
+  # stats clamps the effective max HP..." below) -- an RPG2000 actor could
+  # never actually reach 5000 max HP to survive this hit and show the
+  # leftover HP this check asserts.
   players = { 1 => FakePlayerRow.new('Tank', '', 0, 5, max_hp: 5000, max_mp: 0, atk: 0, def: 0) }
-  st = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1])), 1, 0, 0)
+  st = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1], {}, {}, {}, nil, nil, rpg2003: true)), 1, 0, 0)
   it = Game::Interpreter.new(st)
   # scope 1, actor 1, atk 5000, def-weight 0, spi-weight 0, variance 0,
   # store-damage flag 1 -> var 1.


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Display stat clamping ... is cosmetic only" bullet had the claim backwards — the underlying stored value actually should be clamped too.
- Verified against EasyRPG Player's actual C++ source: `Game_Actor::GetBaseAtk/GetBaseDef/GetBaseSpi/GetBaseAgi` sum level curve + Change-Parameters mod + equipped-item bonus and clamp the *combined* total to `MaxStatBaseValue()` (999, not edition-gated), and `GetBaseMaxHp/GetBaseMaxSp` clamp to `MaxActorHpValue()`/`MaxActorSpValue()` (HP: 999 RPG2000 / 9999 RPG2003; MP: always 999).
- `Game::Actor#recompute_stats` had no ceiling at all — the pre-existing `#change_param`/`#base_param_limit` clamp only ever bounded the unequipped base value's live Change-Parameters delta, never the equip-inclusive total `#recompute_stats` derives, and never a fresh level-curve assignment from `#set_level` either.
- `#recompute_stats` now clamps all six computed stats; new constants `MAX_EFFECTIVE_STAT`/`MAX_EFFECTIVE_MP`/`MAX_EFFECTIVE_HP_2K`/`MAX_EFFECTIVE_HP_2K3`, plus a new `Actor#rpg2003?` (mirroring `Party#rpg2003?`) and `#max_hp_cap` helper.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 735 checks pass (1 new: an equip-bonus overflow case (ATK 970+50 → clamps to 999) and a bare level-curve overflow case (5000 max HP/MP on RPG2000 → clamps to 999/999 with current HP/MP dragged down; on RPG2003 → HP stays 5000, MP still clamps to 999) — confirmed to fail against the pre-fix code; also updated a pre-existing fixture that relied on an unclamped RPG2000 actor holding 5000 max HP)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 448 checks pass (unaffected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_