### PR TITLE
rpg2k: common-event Parallel Processes now advance before map-event ones each frame

### DIFF
--- a/changelog.d/parallel-process-common-before-map-order.fixed.md
+++ b/changelog.d/parallel-process-common-before-map-order.fixed.md
@@ -1,0 +1,13 @@
+- **A common event's own Parallel Process now advances before any map
+  event's Parallel Process on the same frame, matching real RPG_RT's fixed
+  update order.** `Scene::Map#build_parallels` used to push every map event's
+  parallel process into `@parallels` before any common event's, so a common
+  event's write this frame (a gate switch, a shared variable) was not
+  visible to a map event's own parallel process reading it until the
+  *following* frame. Verified against EasyRPG Player's actual C++ source:
+  `Game_Map::Update` always calls `UpdateCommonEvents()` before
+  `UpdateMapEvents()`, with no interleaving by id across the two groups.
+  Fixed by swapping the two loops' order in `#build_parallels`; each loop's
+  own internal (ascending id) ordering is unchanged. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3261,7 +3261,45 @@ not yet verified:
 - Multiple simultaneous parallel processes are **not concurrent** — the
   engine advances one command block at a time, round-robin, yielding at a
   blocking command (Wait/Show Text/Show Picture), in definition/event-ID
-  order.
+  order. ✅ **The precise cross-group ordering half of this claim — where a
+  parallel *common* event's own advance falls relative to a parallel *map*
+  event's — is now settled and fixed, verified against EasyRPG Player's
+  actual C++ source rather than guessed at.** `Game_Map::Update`
+  (`src/game_map.cpp`) always calls `UpdateCommonEvents()` before
+  `UpdateMapEvents()`, every real frame, with no interleaving by id across the
+  two groups; `Game_CommonEvent`'s constructor (`src/game_commonevent.cpp`)
+  only ever builds an interpreter when the common event's own trigger is
+  Parallel, so `UpdateCommonEvents` is this engine's exact counterpart to
+  `Scene::Map#step_parallels`' common-event half, and `UpdateMapEvents` (which
+  iterates every `Game_Event`, not filtered by trigger the same way) the
+  counterpart to its map-event half. `Scene::Map#build_parallels`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — which decides what order
+  `#step_parallels`/`#step_parallel` walk `@parallels` in, since they simply
+  iterate it start to end with no per-entry ordering key of their own — used
+  to push every live map event's own parallel process first (looping
+  `@events`), *then* every parallel common event after (looping `@common`),
+  the opposite of real RPG_RT's fixed frame order. In practice this meant a
+  common event's write this frame (a gate switch another process's page
+  condition depends on, a shared variable, anything) was not visible to a map
+  event's own parallel process reading it until the *next* frame, one tick
+  later than the real engine, whenever both processes' scripts happened to
+  reach that read/write on the same real frame. Fixed by swapping the two
+  loops' order in `#build_parallels`: the common-event loop (unchanged
+  internally — still `@common`'s own definition order, i.e. ascending id) now
+  runs first and is pushed into `@parallels` first, followed by the map-event
+  loop (also internally unchanged, `@events`' own ascending-id order, itself
+  already confirmed correct — see the "Processing order" bullet above) and
+  its bystander-preservation pass; neither loop's own internal ordering rule
+  changed, only which group goes first. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a common event's Parallel Process
+  turns a switch on with no intervening Wait, and a map event's own Parallel
+  Process — checking that same switch — observes it already on within the
+  very same first `#step_parallels` sweep, not merely by the following
+  frame), confirmed to fail against the pre-fix code before the fix (the map
+  event's own check ran first, saw the switch still off, and never re-checked
+  after parking on its own trailing Wait). The rest of this bullet — within
+  one group, one command block at a time, round-robin, yielding at a blocking
+  command, ascending-id order — was already correct and needed no change.
 - A parallel process reaching its own loop end and restarting always costs
   ~1/60s (an implicit one-frame gap), independent of any explicit Wait.
 - "Hero Touch" (trigger 1) does **not** fire in three specific cases

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1023,10 +1023,11 @@ class RPG2k
         @state.switches[c[:switch_id]]
       end
 
-      # Build the background (parallel-process) interpreters: map events with a
-      # parallel trigger plus parallel common events. Each gets its own
-      # Game::Interpreter, looped by #step_parallels; a common event that needs a
-      # flag carries its gate switch so it only runs while that switch is on.
+      # Build the background (parallel-process) interpreters: parallel common
+      # events plus map events with a parallel trigger, in that order (see the
+      # order comment inside, below). Each gets its own Game::Interpreter,
+      # looped by #step_parallels; a common event that needs a flag carries
+      # its gate switch so it only runs while that switch is on.
       #
       # A Common Event's own parallel process, unlike a Map Event's, keeps its
       # interpreter position across a Transfer Player: called again by
@@ -1078,6 +1079,25 @@ class RPG2k
           end
         end
         @parallels = []
+        # Common events are pushed before map events, matching real RPG_RT's
+        # own fixed frame order: `Game_Map::Update` (src/game_map.cpp) always
+        # calls `UpdateCommonEvents()` before `UpdateMapEvents()`, with no
+        # interleaving by id across the two groups -- `Game_CommonEvent`
+        # (src/game_commonevent.cpp) only ever builds an interpreter for a
+        # Parallel-trigger common event, so that call is this engine's exact
+        # counterpart to #step_parallels' common-event half. A common event's
+        # write this same real frame (e.g. a gate switch, or a value another
+        # process reads) is therefore visible to a map event's own parallel
+        # process reading it later in the same #step_parallels sweep, never
+        # the other way around -- #step_parallels/#step_parallel walk
+        # @parallels in array order, so the order they are pushed in here is
+        # the order they run in.
+        @common.each do |c|
+          next unless c[:trigger] == Game::CommonEvent::PARALLEL && c[:commands]
+          gate = c[:need_flag] ? c[:switch_id] : nil
+          @parallels.push(previous_common[c[:id]] ||
+                           new_parallel(c[:commands], gate, nil, c[:id]))
+        end
         live_map_ids = {}
         @events.each do |e|
           next unless e[:trigger] == TRIGGER_PARALLEL && e[:commands]
@@ -1112,12 +1132,6 @@ class RPG2k
           previous_map.each do |id, prior|
             @parallels.push(prior) unless live_map_ids[id]
           end
-        end
-        @common.each do |c|
-          next unless c[:trigger] == Game::CommonEvent::PARALLEL && c[:commands]
-          gate = c[:need_flag] ? c[:switch_id] : nil
-          @parallels.push(previous_common[c[:id]] ||
-                           new_parallel(c[:commands], gate, nil, c[:id]))
         end
       rescue StandardError
         @parallels = []

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1418,6 +1418,54 @@ check 'parallel common event runs only while its switch gate is on' do
   ok st.variables[3] > 0, 'it should run once the gate switch is on'
 end
 
+# yado.tk "Full-site sweep": "Multiple simultaneous parallel processes are not
+# concurrent -- the engine advances one command block at a time, round-robin,
+# ... in definition/event-ID order." Settled precisely against EasyRPG
+# Player's actual C++ source rather than guessed at: `Game_Map::Update`
+# (src/game_map.cpp) always calls `UpdateCommonEvents()` before
+# `UpdateMapEvents()`, every real frame, with no interleaving by id across the
+# two groups -- `Game_CommonEvent` (src/game_commonevent.cpp) only ever builds
+# an interpreter for a Parallel-trigger common event, so `UpdateCommonEvents`
+# is this engine's exact counterpart to `#step_parallels`' common-event half.
+# `Scene::Map#build_parallels` (mruby-rpg2k/mrblib/scene/map.rb) used to push
+# every *map* event's own parallel process into `@parallels` before any
+# *common* event's, the opposite order -- `#step_parallels`/`#step_parallel`
+# simply walk `@parallels` in array order, so a common event's write this
+# frame (a gate switch, a shared variable) was not visible to a map event's
+# own parallel process reading it until the *next* frame, one tick later than
+# real RPG_RT. Fixed by pushing the common-event loop first in
+# `#build_parallels`, ahead of the map-event loop, with no other change to
+# either loop's own internal (ascending id) ordering.
+check "a common event's Parallel Process write is visible to a map event's " \
+      'own Parallel Process the very same frame it happens (yado.tk)' do
+  ic = Game::Interpreter::Cmd
+  # Common event 1: turns switch 10 on, then parks on a long Wait -- one
+  # non-blocking command, so it fully executes (switch write included) the
+  # instant #step_parallel first drives it, well before parking.
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::CONTROL_SWITCHES, [0, 10, 10, 0], indent: 0),
+                              ECmd.new(ic::WAIT, [60], indent: 0)])
+  # Map event 2 (Parallel Process): checks switch 10 exactly once, sets switch
+  # 20 on if it is already on, then also parks on a long Wait -- it never
+  # loops back to re-check, so this only ever catches a same-frame write, not
+  # one that merely lands a frame or two later.
+  pg = page(trigger: 4)
+  pg.event_commands = [
+    ECmd.new(ic::CONDITIONAL, [0, 10, 0], indent: 0), # switch 10 == on ?
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 20, 20, 0], indent: 1),
+    ECmd.new(ic::END_BRANCH, [], indent: 0),
+    ECmd.new(ic::WAIT, [60], indent: 0),
+  ]
+  scene = new_scene({ 2 => event(3, 3, pg) }, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  ok st.switches[10], "the common event's own switch write must land this same frame"
+  ok st.switches[20],
+     "the map event's Parallel Process must observe switch 10 already on within " \
+     'this same #step_parallels sweep -- common events run first, matching ' \
+     "Game_Map::Update's UpdateCommonEvents-before-UpdateMapEvents order"
+end
+
 # yado.tk (01_shoshin/011_siyou, "Call Event"): a Call Event always bypasses
 # the target common event's own condition-switch state entirely, regardless
 # of whether the common event is configured Parallel Process, Auto-Start, or


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Multiple simultaneous parallel processes are not concurrent... in definition/event-ID order" bullet had an unaddressed part: the relative order in which a *common* event's Parallel Process advances versus a *map* event's Parallel Process on the same real frame.
- `Scene::Map#build_parallels` pushed every live map event's own parallel-process interpreter first, then every parallel common event afterward — `#step_parallels` simply walks the resulting array in order.
- Verified against EasyRPG Player's actual C++ source: `Game_Map::Update` (`src/game_map.cpp`) always calls `UpdateCommonEvents()` before `UpdateMapEvents()` every frame with no interleaving by id. So a common event's same-frame write (a gate switch, a shared variable) was invisible to a map event's own parallel process until the *following* frame — one tick later than the real engine — whenever both scripts reached that read/write in the same real frame.
- Swapped the two loops' order inside `#build_parallels` — common-event loop now runs and is pushed first, map-event loop second. Neither loop's own internal ascending-id ordering changed.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 736 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 450 checks pass (1 new: a common event's Parallel Process write is visible to a map event's own Parallel Process the very same frame it happens — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_