### PR TITLE
rpg2k: normal attacks and attack skills can now deal zero damage

### DIFF
--- a/changelog.d/attack-and-skill-damage-floor-at-zero.fixed.md
+++ b/changelog.d/attack-and-skill-damage-floor-at-zero.fixed.md
@@ -1,0 +1,13 @@
+- **Normal attacks and attack skills can now genuinely deal zero damage
+  against a heavily-defended target, matching RPG_RT's real floor.**
+  `Game::Battle.attack_damage` and `Game::Party#battle_skill_command` both
+  clamped their damage formula at a minimum of 1 (`d < 1 ? 1 : d` / `dmg = 1
+  if dmg < 1`); EasyRPG's `Algo::CalcNormalAttackEffect` and
+  `Algo::CalcSkillEffect` both floor at 0 (`std::max<int>(0, effect)`), and
+  this codebase's own `#enemy_autodestruct` already floored at 0 correctly,
+  making the other two an internal inconsistency rather than a uniform
+  design choice. Fixed both floors, and gave `Game::Battle#apply_skill_hit`
+  an explicit `attack:` flag (rather than inferring attack-vs-recovery from
+  the sign of `hp`, which is ambiguous exactly at 0) so a 0-damage attack
+  skill still reads as an attack in the battle log instead of being
+  misrouted into the recovery branch.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2234,10 +2234,60 @@ The work below is roughly ordered by the critical path to a walkable game
   see, so a plated knight resisted fire with his plate. `ignore_defense` (防御無視,
   13 and 7 skills) is read at the same time and skips the **whole** subtraction,
   not just the physical half. A missing stat absorbs nothing rather than raising,
-  and a skill costed against no target takes the full effect. Left alone: the
-  `dmg = 1 if dmg < 1` floor, where RPG_RT floors the effect at 0 and lets a 0
-  land as a "no damage" line — a separate divergence, visible in the log rather
-  than the formula, and folding it in would have hidden this change inside it.
+  and a skill costed against no target takes the full effect. ✅ **The
+  `dmg = 1 if dmg < 1` floor left alone by this same entry is now fixed too,
+  and turned out to have a real RPG2000 twin in the normal-attack formula.**
+  Verified against EasyRPG Player's actual C++ source rather than left as a
+  guess: `Algo::CalcSkillEffect` (`src/algo.cpp`) ends in `effect =
+  std::max<int>(0, effect)`, and `Algo::CalcNormalAttackEffect` (the same
+  file) computes its base term as `auto dmg = std::max(0, atk / 2 - def /
+  4)` — both floor at **0**, not 1, letting a heavily-defended target take a
+  genuine zero-damage hit rather than a guaranteed minimum scratch.
+  `Game::Party#battle_skill_command`'s `dmg = 1 if dmg < 1`
+  (`mruby-rpg2k/mrblib/game.rb`) and `Game::Battle.attack_damage`'s
+  identically-shaped `d < 1 ? 1 : d` both had the wrong floor — the latter
+  confirmed as a real, independently-reachable divergence rather than a
+  hypothetical, since this codebase's own `#enemy_autodestruct` (a third,
+  structurally identical `atk − def/2` formula, `CalcSelfDestructEffect`'s
+  own `std::max<int>(0, effect)`) already floored at 0 correctly, making the
+  other two an inconsistency within the same file rather than a uniform
+  design choice. Fixing the floor alone was not enough for the skill path,
+  though: `Game::Battle#apply_skill_hit` used to tell an attack skill apart
+  from a recovery one purely by the **sign** of the `hp` argument (negative
+  = attack) — the one place this "no damage" case was genuinely new,
+  since `-0 == 0` reads exactly like an ordinary non-negative recovery
+  amount, which would have silently misrouted a 0-damage attack into the
+  recovery branch (wrong caster/target field names on the log entry, no
+  `damage:`/`skill:` key). Fixed by giving `#battle_skill_command`'s
+  enemy-scope branch an explicit `attack: true` field, threaded through
+  `#command_skill`/`#command_skill_all` (`attack: nil` by default, so a
+  command built by hand with a negative `hp` and no explicit `attack:` — as
+  several pre-existing checks and the enemy AI's own `#skill_command_hash`
+  effectively do — still falls back to the old sign-of-`hp` rule
+  unaffected) and `Scene::Map#apply_pending_skill`/`#apply_pending_skill_all`
+  (`mruby-rpg2k/mrblib/scene/map.rb`, passing `c[:attack]` through
+  unconverted so a stub `battle_skill_command` in the test suite that omits
+  the key still reaches the fallback), consumed by `#apply_skill_hit` as
+  `attack = cmd[:attack].nil? ? hp < 0 : cmd[:attack]`. The rendering side
+  needed no change at all: `Scene::Map#battle_result_line` already treats
+  `damage: 0` as the "undamaged" term line rather than a number
+  (`return bt.damage(...) if e[:damage] > 0; bt.undamaged(...)`), the same
+  branch an ordinary 0-damage normal attack already took, and
+  `#play_battle_action_se` already gates the hit sound on `damage > 0` —
+  both pre-existing, just previously unreachable for a skill. Regression
+  coverage: `scripts/rpg2k_logic_check.rb` gained a direct
+  `Battle.attack_damage(2, 40)` boundary check (0, not 1), an end-to-end
+  check driving a doubled-spirit target's `battle_skill_command` +
+  `command_skill` + `step_action` through a full round to confirm the
+  resulting log entry still reads `skill: 'Fire'`/`damage: 0` rather than
+  `recover: true`, and several pre-existing fixed-outcome checks (a weak
+  enemy's own attack against an armoured hero, a state that doubles a
+  target's DEF/spirit) were updated from their old "floored to 1" expectation
+  to the correct 0 — all confirmed to fail against the pre-fix code (via a
+  `git stash` of `game.rb`/`scene/map.rb` alone) before the fix, including an
+  `ArgumentError: unknown keyword: :attack` on the new end-to-end check,
+  confirming it genuinely exercises the new code path rather than passing
+  vacuously.
 - ✅ **両手持ち weapons** (the item row's `two_handed`) — unread, so a claymore
   and a shield could be worn together and both bonuses counted. Not a rare flag:
   **35 of Nepheshel's 104 weapons** and **14 of mtf's 26**, more than half that

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3617,8 +3617,15 @@ module Game
       inflict_ids = heals_states ? [] : state_ids
       if enemy_scope # an attack skill
         dmg = base - skill_defence_term(sk, target)
-        dmg = 1 if dmg < 1
-        { cost: cost, hp: -dmg, mp: 0,
+        # Floored at 0, not 1: EasyRPG's `Algo::CalcSkillEffect` clamps with
+        # `effect = std::max<int>(0, effect)`, letting a heavily-defended
+        # target take a genuine zero-damage hit rather than guaranteeing a
+        # minimum scratch. `#apply_skill_hit` used to tell this branch apart
+        # from a recovery skill purely by the sign of `hp` (negative = attack),
+        # which broke exactly at this boundary once `dmg` could reach 0 --
+        # `attack: true` below now says so explicitly instead.
+        dmg = 0 if dmg < 0
+        { cost: cost, hp: -dmg, mp: 0, attack: true,
           inflict: inflict_ids, chance: skill_hit(sk),
           variance: skill_variance(sk), attributes: skill_attributes(sk),
           # 吸収 — the caster takes what the target loses. RPG_RT reads the flag
@@ -6332,10 +6339,17 @@ module Game
     end
 
     # RPG2000-style physical damage: half the attacker's attack less a quarter of
-    # the defender's defence, floored at 1 so a fight always terminates.
+    # the defender's defence, floored at 0 -- not 1 -- matching EasyRPG's
+    # `Algo::CalcNormalAttackEffect` (`auto dmg = std::max(0, atk / 2 - def / 4);`).
+    # A heavily-armoured target can shrug off a weak attacker's blow entirely
+    # (a genuine "no damage" hit, not a guaranteed minimum scratch); `#deal_attack`
+    # already builds an ordinary attack-shaped log entry regardless of the
+    # resulting damage value, and `#battle_result_line` (`scene/map.rb`) already
+    # renders a 0 as the "undamaged" term line rather than a damage number, so
+    # this needed no companion change beyond the floor itself.
     def self.attack_damage(atk, dfn)
       d = atk / 2 - dfn / 4
-      d < 1 ? 1 : d
+      d < 0 ? 0 : d
     end
 
     MAX_ROUNDS = 1000 # safety net against a stalemate (should never be reached)
@@ -6862,13 +6876,19 @@ module Game
     # attack skill, an ally / the caster for a recovery skill), spending `cost`
     # SP and applying the signed HP / SP deltas (negative HP = damage, positive =
     # recovery) computed by Game::Party#battle_skill_command. Resolved in agility
-    # order by #apply_command when the round runs.
+    # order by #apply_command when the round runs. `attack:` is
+    # #battle_skill_command's own explicit attack-vs-recovery flag, carried
+    # through so #apply_skill_hit does not have to re-derive it from the sign
+    # of `hp` alone -- which is ambiguous exactly at a 0-damage hit. Left `nil`
+    # (rather than defaulted `false`) when the caller does not pass it, so
+    # #apply_skill_hit still falls back to the sign of `hp` for a command built
+    # by hand with a negative `hp` and no explicit `attack:`.
     def command_skill(ally, target, name:, cost:, hp: 0, mp: 0, inflict: nil,
                       chance: 100, variance: 0, attributes: nil, skill_id: nil,
                       absorb: false, attr_shift: nil, attr_ids: nil,
-                      stat_mod_keys: nil, stat_effect: 0, cured: nil)
+                      stat_mod_keys: nil, stat_effect: 0, cured: nil, attack: nil)
       ally.command = { kind: :skill, target: target, name: name,
-                       skill_id: skill_id, absorb: absorb,
+                       skill_id: skill_id, absorb: absorb, attack: attack,
                        cost: cost, hp: hp, mp: mp,
                        inflict: inflict || [], chance: chance, variance: variance,
                        attributes: attributes || [],
@@ -6891,9 +6911,10 @@ module Game
     def command_skill_all(ally, targets, name:, cost:, inflict: nil, chance: 100,
                           variance: 0, attributes: nil, skill_id: nil,
                           absorb: false, attr_shift: nil, attr_ids: nil,
-                          stat_mod_keys: nil, stat_effect: 0, cured: nil)
+                          stat_mod_keys: nil, stat_effect: 0, cured: nil, attack: nil)
       ally.command = { kind: :skill, all: true, targets: targets, name: name,
-                       skill_id: skill_id, absorb: absorb, cost: cost, inflict: inflict || [], chance: chance,
+                       skill_id: skill_id, absorb: absorb, attack: attack, cost: cost,
+                       inflict: inflict || [], chance: chance,
                        variance: variance, attributes: attributes || [],
                        attr_shift: attr_shift, attr_ids: attr_ids || [],
                        stat_mod_keys: stat_mod_keys || [], stat_effect: stat_effect,
@@ -7433,7 +7454,7 @@ module Game
     # Wrap the party's cast numbers in the command hash #apply_command consumes.
     def skill_command_hash(sk, cmd, target)
       { kind: :skill, target: target, name: skill_name_of(sk),
-        absorb: cmd[:absorb] ? true : false,
+        absorb: cmd[:absorb] ? true : false, attack: cmd[:attack] ? true : false,
         cost: cmd[:cost] || 0, hp: cmd[:hp] || 0, mp: cmd[:mp] || 0,
         inflict: cmd[:inflict] || [], chance: cmd[:chance] || 100,
         variance: cmd[:variance] || 0, attributes: cmd[:attributes] || [],
@@ -7785,13 +7806,22 @@ module Game
       entries
     end
 
-    # Apply one skill / item effect from `b` to `target`: a negative `hp` is an
-    # attack (elemental scaling, variance, then state infliction, reading as a
-    # `skill:` hit), a non-negative one restores HP / SP and cures states (reading
-    # as a `recover`). Returns the log entry. Shared by single- and all-target
-    # commands.
+    # Apply one skill / item effect from `b` to `target`: an attack (elemental
+    # scaling, variance, then state infliction, reading as a `skill:` hit) or a
+    # restore of HP / SP that also cures states (reading as a `recover`).
+    # Returns the log entry. Shared by single- and all-target commands.
+    #
+    # Which branch runs is `cmd[:attack]` when the caller set it explicitly --
+    # #battle_skill_command always does, so real skill/item play is unambiguous
+    # -- falling back to the sign of `hp` (the old, only rule) when it did not.
+    # The explicit flag matters because the sign alone is ambiguous exactly at
+    # a 0-damage hit: an attack skill's damage can genuinely compute to 0
+    # against a heavily-defended target (see #battle_skill_command's own
+    # floor-at-0 fix), and `-0 == 0` reads the same as an ordinary non-negative
+    # recovery amount.
     def apply_skill_hit(b, target, hp, mp, cmd)
-      if hp < 0
+      attack = cmd[:attack].nil? ? hp < 0 : cmd[:attack]
+      if attack
         dmg = -hp
         # An elemental skill scales its damage by the target's resistance first
         # (EasyRPG's ApplyAttributeSkillMultiplier), then spreads by variance.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4181,6 +4181,14 @@ class RPG2k
         @battle_ui[:battle].command_skill(current_actor, target,
                                           name: sk.name, skill_id: sid,
                                           absorb: c[:absorb] ? true : false,
+                                          # Left as `c[:attack]` verbatim (not coerced to a
+                                          # boolean): a stub `battle_skill_command` in the test
+                                          # suite that omits the key entirely needs `nil` to
+                                          # reach #apply_skill_hit so its own sign-of-hp
+                                          # fallback still applies, matching this build's real
+                                          # Game::Party#battle_skill_command before this key
+                                          # existed at all.
+                                          attack: c[:attack],
                                           cost: c[:cost],
                                           hp: c[:hp], mp: c[:mp],
                                           inflict: c[:inflict], chance: c[:chance],
@@ -4212,6 +4220,7 @@ class RPG2k
         @battle_ui[:battle].command_skill_all(current_actor, effects,
                                               name: sk.name, skill_id: sid,
                                               absorb: meta[:absorb] ? true : false,
+                                              attack: meta[:attack], # see #apply_pending_skill's comment
                                               cost: meta[:cost],
                                               inflict: meta[:inflict], chance: meta[:chance],
                                               variance: meta[:variance] || 0,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6638,10 +6638,10 @@ def combatant_mp(name, atk, dfn, agi, hp, mp)
   c
 end
 
-check 'Battle.attack_damage is half attack less a quarter defence, min 1' do
+check 'Battle.attack_damage is half attack less a quarter defence, floored at 0' do
   eq 18, Game::Battle.attack_damage(40, 8),  '20 - 2'
-  eq 1,  Game::Battle.attack_damage(2, 40),  'floored at 1'
-  eq 1,  Game::Battle.attack_damage(0, 0)
+  eq 0,  Game::Battle.attack_damage(2, 40),  'floored at 0, not 1 (a genuine no-damage hit)'
+  eq 0,  Game::Battle.attack_damage(0, 0)
 end
 
 # base 20 (atk 40 vs def 0); variance 4 -> adj = 8, spread 20-4 .. 20+8-4 = 16..24.
@@ -7533,7 +7533,9 @@ check 'Battle: a stronger party wins, a weaker one is defeated' do
   eq :victory, b.run
   ok slime.dead?, 'the enemy was defeated'
   ok !hero.dead?
-  ok hero.hp < 200, 'the hero took some damage on the way'
+  # Slime's own attack (8/2 - 20/4 = -1) floors at 0, not 1: this armoured a
+  # hero takes no damage at all rather than a guaranteed 1-point scratch.
+  eq 200, hero.hp, 'the slime never landed a scratch (its attack floors at 0 damage against this armour)'
 
   weak = combatant('Weak', 6, 2, 3, 10)
   boss = combatant('Boss', 60, 30, 40, 500)
@@ -7577,7 +7579,9 @@ check 'Battle#run records a combat log of every hit' do
                        [combatant('Slime', 8, 4, 5, 30)], Game::Rng.new(1))
   eq :victory, b.run
   ok b.log.length >= 2, 'the Slime took at least two hits'
-  ok b.log.all? { |e| e[:damage] >= 1 }, 'every hit did at least 1 damage'
+  ok b.log.none? { |e| e[:damage].negative? }, 'no hit ever does negative damage'
+  ok b.log.select { |e| e[:target] == 'Slime' }.all? { |e| e[:damage] >= 1 },
+     "every hit against the Slime did at least 1 damage (the Hero's own attack)"
 end
 
 check 'Battle: a commanded attack hits the chosen enemy; run_round clears it' do
@@ -7739,7 +7743,7 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   # skill_effect = 20 + 40*12/40 = 32. Fire is purely magical (physical_rate 0,
   # magical_rate 40), so RPG_RT blunts it with the target's *spirit* and not at
   # all with its armour: 32 - (0*8/40 + 40*16/80) = 32 - 8 = 24.
-  eq({ cost: 6, hp: -24, mp: 0, inflict: [], chance: 100, variance: 4,
+  eq({ cost: 6, hp: -24, mp: 0, attack: true, inflict: [], chance: 100, variance: 4,
        attributes: [], absorb: false, attr_shift: nil, attr_ids: [],
        stat_mod_keys: [], cured: [] },
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
@@ -7788,8 +7792,41 @@ check 'battle_skill_command respects a stat-doubling state on the target' do
   tough_foe = combatant('Foe', 0, 0, 5, 100)
   tough_foe.spi = 20
   tough_foe.states = [2]
-  eq(-1, st.party.battle_skill_command(st.party.db_skill(7), caster, tough_foe)[:hp],
-     'doubled spirit (40): 20 base - 40*40/80 (20) = 0, floored to 1')
+  eq(0, st.party.battle_skill_command(st.party.db_skill(7), caster, tough_foe)[:hp],
+     'doubled spirit (40): 20 base - 40*40/80 (20) = 0, floored at 0 (a genuine no-damage hit)')
+end
+
+check 'an attack skill that computes to 0 damage still reads as an attack, not a recovery' do
+  # Same fixture as the stat-doubling check above (skill_effect 20, doubled
+  # spirit 40 -> defence term 20 -> dmg = 0), driven all the way through
+  # Battle#command_skill/#step_action/#apply_skill_hit this time -- the actual
+  # bug was not the formula alone: #apply_skill_hit used to tell an attack
+  # apart from a recovery purely by the sign of `hp` (negative = attack), and
+  # `-0 == 0` reads exactly like an ordinary non-negative recovery amount, so
+  # a 0-damage attack skill would have silently taken the recovery branch
+  # (wrong caster/target field names, no `damage:`/`skill:` on the entry, and
+  # -- since `hp` is 0 -- no actual healing either, but the wrong shape of
+  # log entry) without the explicit `attack:` flag this fix threads through.
+  skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 0, mrate: 40) }
+  states = { 2 => fake_state(affect_type: 1, affect_spirit: true) } # 1 = double
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8, int: 20, agi: 7) }
+  db = FakeActorDB.new(players, [1], {}, skills, {}, states)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1))
+  tough_foe = combatant('Foe', 0, 0, 5, 100)
+  tough_foe.spi = 20
+  tough_foe.states = [2] # doubled spirit blunts the spell to exactly 0
+  bat = Game::Battle.new([caster], [tough_foe], Game::Rng.new(1), states)
+  cmd = st.party.battle_skill_command(st.party.db_skill(7), caster, tough_foe)
+  bat.command_skill(caster, tough_foe, name: 'Fire', cost: cmd[:cost], hp: cmd[:hp],
+                     mp: cmd[:mp], attack: cmd[:attack])
+  bat.begin_round
+  e = bat.step_action
+  eq 0, e[:damage], 'the spell genuinely dealt no damage'
+  eq 'Fire', e[:skill], 'still reads as the attack skill that landed, not a recovery'
+  ok !e[:recover], 'never mistaken for a heal'
+  eq 100, tough_foe.hp, 'the target neither took damage nor was healed'
 end
 
 check 'a skill flagged "attribute defence up/down" picks direction from ' \
@@ -8576,7 +8613,7 @@ check 'battle: a confused battler (restriction 3) attacks its own side' do
   bat.command_attack(hero, slime)                         # commanded at the enemy...
   bat.run_round
   eq 100, slime.hp                                        # ...confusion spared the enemy
-  eq 79, hero.hp                                          # slime's 1 + the hero's own 20
+  eq 80, hero.hp                                          # slime's 0 (atk 0 floors at 0, not 1) + the hero's own 20
 end
 
 check 'battle: a berserk battler (restriction 2) attacks despite defending' do
@@ -8678,8 +8715,8 @@ check 'battle: a state that doubles DEF blunts incoming damage' do
   tough_foe = combatant('Foe', 0, 40, 5, 100)
   tough_foe.states = [3]
   bat = Game::Battle.new([hero], [tough_foe], Game::Rng.new(1), states)
-  eq 1, bat.send(:deal_attack, hero, tough_foe)[:damage],
-     'doubled def 80: 40 / 2 - 80 / 4 = 0, floored to 1'
+  eq 0, bat.send(:deal_attack, hero, tough_foe)[:damage],
+     'doubled def 80: 40 / 2 - 80 / 4 = 0, floored at 0 (a genuine no-damage hit)'
 
   plain_foe = combatant('Foe', 0, 40, 5, 100)
   bat2 = Game::Battle.new([hero], [plain_foe], Game::Rng.new(1), states)
@@ -11185,8 +11222,8 @@ check 'a magical skill is blunted by spirit, not by armour' do
      'armour is irrelevant to a spell')
   wise = combatant('Foe', 0, 40, 5, 100)
   wise.spi = 80
-  eq(-1, st.party.battle_skill_command(st.party.db_skill(2), caster, wise)[:hp],
-     'spirit is what resists it (floored at 1)')
+  eq(0, st.party.battle_skill_command(st.party.db_skill(2), caster, wise)[:hp],
+     'spirit resists it hard enough to floor at 0 (32 - 40), not a guaranteed 1')
 end
 
 check 'a skill with both rates takes both halves of the term' do


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "The skill damage defence term" (ADR 0041) entry explicitly left one thing alone: `dmg = 1 if dmg < 1` in `Game::Party#battle_skill_command`, noting "RPG_RT floors the effect at 0 and lets a 0 land as a 'no damage' line".
- Verified against EasyRPG Player's actual C++ source: `Algo::CalcSkillEffect` ends in `effect = std::max<int>(0, effect)`, and `Algo::CalcNormalAttackEffect` computes `auto dmg = std::max(0, atk / 2 - def / 4)` — both floor at **0**, not 1. This codebase's `Game::Battle.attack_damage` (`d < 1 ? 1 : d`) had the identical wrong floor, confirmed as a real, independently-reachable divergence since this codebase's own `#enemy_autodestruct` (a third, structurally identical formula) already floored at 0 correctly — the other two were an internal inconsistency, not a uniform design choice.
- Fixed both floors to 0. Fixing the floor alone wasn't enough for the skill path: `Game::Battle#apply_skill_hit` used to dispatch attack-vs-recovery purely by the **sign** of `hp` (negative = attack), and `-0 == 0` reads exactly like an ordinary non-negative recovery amount — a 0-damage attack skill would have silently taken the recovery branch (wrong field names on the log entry, no `damage:`/`skill:` key).
- Fixed by giving `#battle_skill_command`'s enemy-scope branch an explicit `attack: true` field, threaded through `#command_skill`/`#command_skill_all` (default `attack: nil`, so a command built by hand with a negative `hp` and no explicit `attack:` — as several pre-existing checks and the enemy AI's own `#skill_command_hash` effectively do — still falls back to the old sign-of-`hp` rule) and `Scene::Map#apply_pending_skill`/`#apply_pending_skill_all`, consumed by `#apply_skill_hit` as `attack = cmd[:attack].nil? ? hp < 0 : cmd[:attack]`.
- The rendering side needed no change: `Scene::Map#battle_result_line` already renders `damage: 0` as the "undamaged" term line rather than a number, and `#play_battle_action_se` already gates the hit sound on `damage > 0` — both pre-existing, just previously unreachable for a skill.
- `docs/TODO.md` updated ✅ with the citation; `changelog.d/attack-and-skill-damage-floor-at-zero.fixed.md` added.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 737 checks pass (1 new end-to-end check; several pre-existing "floored to 1" checks updated to the correct 0)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 450 checks pass
- [x] Confirmed the new/updated checks fail against the pre-fix code via `git stash` of `game.rb`/`scene/map.rb` alone (8 checks failed, including an `ArgumentError: unknown keyword: :attack` on the new end-to-end check, confirming it genuinely exercises the new code path)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBHDRnjwm3i6bRqbFrkJjC)_