### PR TITLE
rpg2k: a wandering map event's position now survives a same-map save/load

### DIFF
--- a/changelog.d/map-event-position-save-load.fixed.md
+++ b/changelog.d/map-event-position-save-load.fixed.md
@@ -1,0 +1,20 @@
+- **A wandered map event's tile position and facing now survive a save/load
+  taken on the same map**, instead of always snapping back to the map's own
+  editor-placed spawn point on Continue. `Scene::Map#build_event` always
+  built a fresh `Game::Character` straight from the map's own `ev.x`/`ev.y`
+  with no override path at all, so even a plain Save-then-Continue on the
+  exact same map reset every NPC that had walked away from its default
+  placement — matching real RPG_RT's own `SaveMapEvent` chunk (x/y/direction,
+  confirmed against EasyRPG Player's `Game_Character::GetX`/`GetY`/
+  `GetDirection`), which this codebase never modelled the save/load half of
+  at all. Fixed with a new `Game::State#map_event_positions`
+  (`event_id => [x, y, direction]`, round-tripped through `to_h`/`.load`
+  following the existing `common_event_progress` idiom), a new
+  `Scene::Map#record_map_event_positions` snapshotting every live event's
+  position once per real frame, and a saved-position override in
+  `#build_event`. Scoped to the currently-loaded map only — `perform_teleport`
+  clears the table before rebuilding the destination's own events, so an
+  ordinary map re-visit (leave and return, no save involved) still resets
+  every event to its own page default, unlike a genuine save/load. The
+  move-route execution index itself (a custom-route event's own in-progress
+  step) is not addressed by this fix and remains a separate, open question.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5108,6 +5108,66 @@ Change, Tile Replacement, a move-route "Change Graphic" on any character,
 Screen Scroll offset (snaps back instantly on return rather than
 animating), a map event's own parallel-process running state.
 
+✅ **Map event positions (and facing) now survive a save/load taken on the
+same map — a gap this consolidated list's own two halves only implicitly
+flagged, rather than named outright.** The "does not survive a map
+re-visit" list just above states every event resets to its page-1 default
+on an ordinary leave-and-return; the "does not survive a save/load
+specifically" list right below never names event positions among what a
+save/load itself resets — meaning this doc's own reading already expected
+them to persist through a save/load, distinct from a plain re-visit.
+Confirmed against EasyRPG Player's actual C++ source rather than taken on
+faith: `Game_Character::GetX`/`GetY`/`GetDirection` (`src/game_character.h`)
+read `data()->position_x`/`position_y`/`direction` straight off the
+per-event `SaveMapEvent` liblcf struct every `Game_Event` is backed by
+(`src/game_event.h`), so a genuine RPG_RT save captures exactly this for
+whichever map is loaded at save time. `Scene::Map#build_event`
+(`mruby-rpg2k/mrblib/scene/map.rb`) always built a fresh `Game::Character`
+straight from the map's own `ev.x`/`ev.y`, with no override path of any
+kind, so even a plain Save-then-Continue on the exact same map snapped
+every wandered NPC back to its editor spawn tile — the save/load half of
+this state was never modelled here at all, not merely broken. Fixed with a
+new `Game::State#map_event_positions` (`event_id => [x, y, direction]`,
+`mruby-rpg2k/mrblib/game.rb`), following the same scoped-override idiom
+`common_event_progress` and `Game::Screen#to_h`/`#load_h` already use —
+round-tripped through `Game::State#to_h`/`.load`, defaulting to `{}` for a
+save written before this field existed; a new
+`Scene::Map#record_map_event_positions` snapshots every live event's tile
+position and facing into it once per real frame, called from `#update`
+alongside the other per-frame bookkeeping (`@state.screen.update` and
+friends); and `#build_event` now takes a saved entry over `ev.x`/`ev.y`
+when one exists for that id, feeding the resolved coordinates into the
+display-origin `disp_x`/`disp_y` too so a restored event does not visibly
+slide in from its old spawn tile on the very first frame. Scoped to the
+currently-loaded map only, since event ids repeat per map and a stale
+entry from a different map would misapply to an unrelated event sharing
+its id: `Scene::Map#perform_teleport` clears the whole hash before
+rebuilding the destination's own events, so an ordinary map re-visit
+(leave and return, no save involved) still resets every event to its own
+page default exactly as the list above already documents — only a genuine
+save/load benefits. `#rebuild_events_preserving_positions`'s own in-place,
+same-map page-reselection copy loop is unaffected by the new override: it
+already overwrites `x`/`y`/`direction` from the live pre-rebuild character
+right after `build_events` runs, so the saved-position lookup is
+functionally a no-op there, just a harmless extra read before being
+immediately superseded by the fresher live value. **Not addressed**: the
+move-route execution *index* itself — the "a map event's move route/
+execution point if paused mid-way" claim in the "persists across both
+map-revisit and save/load" list below — a custom-route event mid-loop
+still restarts its route from the top after this fix exactly as it did
+before; only its raw tile position and facing are restored. Matching real
+RPG_RT's own `original_move_route_index`/`move_route_index` fields
+(`src/game_character.h`, alongside `move_route_finished`) would need those
+threaded through separately, a larger follow-up left open. Covered by a
+new `scripts/rpg2k_logic_check.rb` check (`map_event_positions` round-trips
+through `to_h`/`.load`, with a legacy-save fallback to `{}`) and a new
+`scripts/rpg2k_scene_check.rb` check (a Move Event forces event 2 two
+tiles east and turns it to face down via Proceed With Movement; a
+save/load taken afterward restores exactly that spot on a fresh
+`Scene::Map`, while an ordinary Transfer Player back to the same map id
+instead resets it to its own page default), both confirmed to fail against
+the pre-fix code before the fix.
+
 State that does **not** survive a save/load specifically (distinct from
 mere map-revisit): screen-shake offset (never saved, always resets);
 BGM/SE playback position (always restarts a track from the beginning even

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8283,6 +8283,20 @@ module Game
     # portable Marshal save; not yet in `.lsd` (chunks 113/114 are still
     # opaque, see LCF::Schema::SAVE_FOREGROUND_EVENT / SAVE_COMMON_EVENT).
     attr_accessor :common_event_progress
+    # The current map's own live event positions, event id => [x, y, direction],
+    # snapshotted every frame by Scene::Map#record_map_event_positions. Real
+    # RPG_RT's SaveMapEvent chunk carries exactly this (plus a move-route index
+    # this codebase does not attempt to round-trip yet) for whichever map is
+    # loaded at save time -- a wandering NPC's exact spot survives a Save/
+    # Continue on the same map, distinct from an ordinary map re-visit (leave
+    # and return with no save involved), which genuinely does reset every event
+    # to its page's own default placement, matching the "Save / Load
+    # persistence" list in docs/TODO.md. Scoped to the single currently-loaded
+    # map only: event ids are per-map, not global, so this is cleared on every
+    # genuine map change (Scene::Map#perform_teleport) rather than carried
+    # across one, the same "resets on leaving-and-returning" family as
+    # #encounter_rate/#parallax just above.
+    attr_accessor :map_event_positions
 
     def initialize(party, map_id, x, y)
       @party = party
@@ -8319,6 +8333,7 @@ module Game
       @teleport_targets = {}
       @escape_target = nil
       @common_event_progress = {}
+      @map_event_positions = {}
       @system_bgm = {}
       @system_sfx = {}
       # nil = "not configured yet"; #seed_screen_transitions fills each slot in
@@ -8533,6 +8548,7 @@ module Game
         encounter_rate: @encounter_rate, encounter_total: @encounter_total,
         teleport_targets: @teleport_targets,
         common_event_progress: @common_event_progress,
+        map_event_positions: @map_event_positions,
         steps: @steps,
         save_count: @save_count, battle_count: @battle_count,
         win_count: @win_count, defeat_count: @defeat_count,
@@ -8955,6 +8971,7 @@ module Game
       state.escape_count = h[:escape_count] || 0
       state.teleport_targets = h[:teleport_targets] || {}
       state.common_event_progress = h[:common_event_progress] || {}
+      state.map_event_positions = h[:map_event_positions] || {}
       state.escape_target = h[:escape_target]
       state.system_bgm = h[:system_bgm] || {}
       state.system_sfx = h[:system_sfx] || {}

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -305,6 +305,7 @@ class RPG2k
             try_open_debug_menu
           end
         end
+        record_map_event_positions
         animate_events
         render
       end
@@ -858,7 +859,18 @@ class RPG2k
 
       def build_event(id, ev, page)
         dir = Game::EventGraphic.numpad_direction(page_direction(page))
-        ch = Game::Character.new(ev.x, ev.y, dir)
+        x, y = ev.x, ev.y
+        # A saved wandered position (see #record_map_event_positions) wins over
+        # the map's own default placement -- restoring a Save/Continue taken on
+        # this same map to wherever the NPC actually stood, not back to its
+        # editor spawn tile. Empty for a brand-new visit (perform_teleport
+        # clears it before a genuine map change) and for a fresh game, so those
+        # cases fall through to ev.x/ev.y exactly as before.
+        if (saved = @state.map_event_positions[id])
+          x, y = saved[0], saved[1]
+          dir = saved[2] if saved[2]
+        end
+        ch = Game::Character.new(x, y, dir)
         ch.move_speed = page_move_speed(page)
         ch.move_frequency = page_move_frequency(page)
         ch.set_graphic(page_charset_name(page), page_charset_index(page))
@@ -888,8 +900,24 @@ class RPG2k
           translucent: page_translucent(page),
           anim_type: page_anim_type(page), base_dir: dir,
           base_pattern: page_pattern(page), anim_phase: 0, anim_count: 0,
-          moving: false, disp_x: ev.x, disp_y: ev.y, move_count: TILE,
+          moving: false, disp_x: x, disp_y: y, move_count: TILE,
           jumping: false }
+      end
+
+      # Snapshot every live map event's current tile position and facing onto
+      # Game::State, once per real frame -- so a fresh Scene::Map built later
+      # from this state (a genuine save/load, see #build_event's saved-position
+      # override) restores a wandered NPC to wherever it actually stood rather
+      # than resetting it to the map's own default placement. Scoped to the
+      # current map's own event ids, which #perform_teleport clears before a
+      # genuine map change (see there) -- an ordinary map re-visit (leave and
+      # return, no save involved) still resets every event, matching the
+      # "Save / Load persistence" list in docs/TODO.md.
+      def record_map_event_positions
+        @events.each do |e|
+          ch = e[:char]
+          @state.map_event_positions[e[:id]] = [ch.x, ch.y, ch.direction]
+        end
       end
 
       # Build the Call Event resolver for the current map: common events keyed by
@@ -6447,6 +6475,13 @@ class RPG2k
         # next map, and the destination's pages are chosen fresh.
         @erased_events = {}
         @erased_event_positions = {}
+        # A saved wandered position is scoped to the map it was taken on --
+        # event ids repeat per map, so carrying this forward would misapply a
+        # stale entry to an unrelated event on the destination map. Dropped
+        # here, before the destination's own events are built, so every one of
+        # them falls back to its own page's default placement, matching an
+        # ordinary map re-visit (see #record_map_event_positions).
+        @state.map_event_positions = {}
         @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5417,6 +5417,25 @@ check 'common_event_progress (a Parallel Process interpreter checkpoint) round-t
   eq({}, Game::State.load(db, legacy).common_event_progress)
 end
 
+check 'map_event_positions (a wandered NPC\'s live tile + facing) round-trips through the save' do
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5,
+                           max_hp: 100, max_mp: 30, atk: 10, def: 8),
+  }
+  db = FakeActorDB.new(players, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.map_event_positions[3] = [5, 9, 8] # event 3, tile (5, 9), facing up
+  st.map_event_positions[7] = [0, 0, 2]
+  loaded = Game::State.load(db, st.to_h)
+  eq({ 3 => [5, 9, 8], 7 => [0, 0, 2] }, loaded.map_event_positions)
+  # A save written before this field existed restores an empty table, so every
+  # event falls back to its page's own default placement -- the same
+  # behaviour as before this change existed at all.
+  legacy = st.to_h
+  legacy.delete(:map_event_positions)
+  eq({}, Game::State.load(db, legacy).map_event_positions)
+end
+
 check 'Return to Title Screen raises a :return_title request' do
   st = party_state
   it = Game::Interpreter.new(st)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3394,6 +3394,66 @@ check "Proceed With Movement also waits on a vehicle's forced route" do
   ok st.switches[1], 'the interpreter resumed and ran the next command'
 end
 
+check "a wandered map event's position and facing survive a save/load, but " \
+      'reset to their own page default on an ordinary map re-visit' do
+  # docs/TODO.md's "Save / Load persistence -- consolidated master list":
+  # runtime state that does *not* survive a plain map re-visit (leave and
+  # return, no save involved) explicitly includes "map event positions
+  # (reset to their default page-1 placement)" -- but the same list's "does
+  # not survive a save/load specifically" half never names event positions,
+  # meaning they are expected to survive one, matching real RPG_RT's own
+  # SaveMapEvent chunk (x/y/direction, confirmed against EasyRPG's
+  # Game_Event -- see Game::State#map_event_positions). This codebase had no
+  # mechanism at all for the save/load half: Scene::Map#build_event always
+  # built a fresh Game::Character from the map's own ev.x/ev.y, so even a
+  # same-map Save-then-Continue snapped every wandered NPC back to its
+  # editor spawn tile.
+  ic = Game::Interpreter::Cmd
+  # Auto-start event 1 forces event 2 to walk two tiles east and turn to
+  # face down, blocking on Proceed With Movement so the route has actually
+  # landed by the time #update returns control.
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::MOVE_EVENT,
+             [2, 8, 0, 0, R::MOVE_RIGHT, R::MOVE_RIGHT, R::FACE_DOWN]),
+    ECmd.new(ic::PROCEED_WITH_MOVEMENT, []),
+  ]
+  events = { 1 => event(0, 4, auto), 2 => event(1, 1, page) }
+  db = fake_db
+  state = Game::State.new(fake_party, 1, 5, 5)
+  state.map = fake_map(1, events)
+  # A map_maker that hands back the same event table on every load (rather
+  # than the default fake_parent's empty map), so event 2 still exists post-
+  # teleport for part two's reset assertion to mean anything.
+  parent = FakeParent.new(db) { |id| fake_map(id, events) }
+  scene = RPG2k::Scene::Map.new(parent, state)
+  40.times { scene.update }
+  c = chars(scene)[2]
+  eq 3, c.x, 'the forced route walked event 2 two tiles east'
+  eq 1, c.y, 'staying on its row'
+  eq 2, c.direction, 'and turned to face down at the end of the route'
+
+  # Part one: a save/load restores exactly that wandered spot.
+  restored = Game::State.load(db, Marshal.load(Marshal.dump(state.to_h)))
+  restored.map = fake_map(1, events)
+  fresh = RPG2k::Scene::Map.new(FakeParent.new(db) { |id| fake_map(id, events) },
+                                restored)
+  rc = chars(fresh)[2]
+  eq [3, 1, 2], [rc.x, rc.y, rc.direction],
+     'a fresh Scene::Map built from the saved state keeps the wandered spot, ' \
+     'not the map default'
+
+  # Part two: an ordinary re-visit (leave and return, no save involved) is
+  # documented to reset every event to its own page default instead -- a
+  # Transfer Player to this same map id must not carry the wandered position
+  # over the way a save/load does.
+  scene.send(:perform_teleport, [1, 5, 5, 0]) # leave and return to the same map
+  tc = chars(scene)[2]
+  eq [1, 1], [tc.x, tc.y],
+     'an ordinary map re-visit resets the event to its own default ' \
+     'placement, unlike a genuine save/load'
+end
+
 check "Proceed With Movement blocks a Parallel Process's own interpreter, not just the foreground's" do
   # docs/TODO.md, `2k/09_bug/017_heiretu_totyu_end/hei_mukou.htm`: Set Move
   # Route + "wait for completion" is documented to block whichever event's


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Save / Load persistence — consolidated master list" implies a gap it never named outright: the "does not survive a map re-visit" list states map event positions reset to their page-1 default on an ordinary leave-and-return, while the separate "does not survive a save/load specifically" list never lists event positions among what a save/load itself resets — implying they should persist through a save/load, distinct from a plain revisit.
- `Scene::Map#build_event` always constructed each event's `Game::Character` straight from the map's own `ev.x`/`ev.y`, with zero override mechanism. `Game::State` had no field to carry a wandered NPC's position through a save.
- Verified against EasyRPG Player's actual C++ source: real RPG_RT's `SaveMapEvent` chunk genuinely stores each event's live x/y/direction, so a same-map Save-then-Continue restores exactly where an NPC stood — this codebase instead silently snapped every wandered NPC back to its editor spawn tile on load.
- New `Game::State#map_event_positions` (event id => [x, y, direction]), snapshotted every frame by a new `#record_map_event_positions`, round-tripped through `#to_h`/`.load` following the existing `common_event_progress` idiom. `#build_event` takes a saved entry over `ev.x`/`ev.y` when present. `#perform_teleport` clears the table before rebuilding a destination map's events, so an ordinary map re-visit still resets positions — only a genuine save/load benefits.
- Left open (documented in TODO.md/changelog): the move-route execution *index* of a custom-route event mid-loop is not restored, only raw position/facing.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 737 checks pass (1 new: `map_event_positions` round-trips through `to_h`/`.load`, with legacy-save fallback to `{}` — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 451 checks pass (1 new: a Move Event forces an event two tiles east and turns it to face down; a save/load taken afterward restores that exact spot on a fresh `Scene::Map`, while an ordinary Transfer Player back to the same map id resets it to its page default — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_