### PR TITLE
rpg2k: a map's own configured BGM now auto-plays on entry

### DIFF
--- a/changelog.d/map-tree-default-bgm.fixed.md
+++ b/changelog.d/map-tree-default-bgm.fixed.md
@@ -1,0 +1,14 @@
+- **A map's own configured BGM now auto-plays on entry**, on the initial map
+  load and every Transfer Player alike, instead of requiring an explicit Play
+  BGM event command on every map. The map tree's `bgm_type`/`bgm` fields
+  (RPG_RT.lmt) were already parsed but never read anywhere in `mruby-rpg2k`.
+  A new `Game::MapBgm` module resolves the same parent-inheriting tri-state
+  walk `Game::Backdrop`/`Game::MapAccess` already use for backdrop and
+  Save/Teleport/Escape access, and `Scene::Map#play_map_bgm` (called
+  alongside the existing `#apply_map_access`) routes the result through the
+  already same-file-aware `#play_bgm` helper, so a Transfer Player back onto
+  the same map — or between two maps sharing a track — does not restart it.
+  Skipped while boarded on a vehicle, whose own BGM owns the audio until
+  disembarking. Covered by new `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3985,6 +3985,74 @@ not yet verified:
   Memorized BGM with nothing else played in between reaches the backend
   once, not twice), confirmed to fail against the pre-fix code (`["town",
   "town"]`) before the fix.
+- ✅ **A map's own configured BGM now actually auto-plays, on the initial map
+  load and every Transfer Player alike — a genuine, previously-undocumented
+  gap found while cross-checking this same BGM cluster for anything else the
+  `#play_bgm` same-file-no-restart work above might have missed.** The map
+  tree's `map_properties` table (`RPG_RT.lmt`, LCF fields 11 `bgm_type`, 12
+  `bgm`) was already fully parsed by `mruby-lcf/mrblib/schema.rb`, and this
+  same tree already drives three sibling per-map tri-state walks this
+  codebase gets right — `Game::Backdrop.name_for` (`backdrop_type`, field 21)
+  and `Game::MapAccess`'s Save/Teleport/Escape walk (fields 31-33) — but
+  nothing in `mruby-rpg2k` ever read `bgm_type`/`bgm` at all: a map's own
+  configured music sat parsed and unused, so no field RPG2000 game here ever
+  had its background music start on its own; every track only ever played
+  because some event script issued an explicit Play BGM command. Verified
+  against EasyRPG Player's actual C++ source rather than guessed at:
+  `Game_Map::PlayBgm` (`src/game_map.cpp`) walks `music_type == 0` ("同じ",
+  same as parent) nodes up the tree exactly like `Backdrop`/`MapAccess`
+  already do here, then — once landed on a non-inheriting node — only calls
+  `Game_System::BgmPlay` when that node's own `music.name` is non-empty *and*
+  its type is not 1; type 1 is a no-op that leaves whatever is currently
+  playing alone rather than silencing it, the opposite of what the shared
+  `BGMType` enum's identically-numbered middle value means for `backdrop_type`
+  (there it is "terrain-designated" — liblcf reuses one enum for two fields
+  with different per-value meanings, confirmed by reading both call sites,
+  not assumed from the shared type name). `Game_Player::MoveTo` calls
+  `Game_Map::Setup()` immediately followed by `Game_Map::PlayBgm()`
+  unconditionally, on every map transition — the initial map (via
+  `SetupPlayerSpawn`) and every Transfer Player alike. Implemented with a new
+  `Game::MapBgm` module (`mruby-rpg2k/mrblib/game.rb`), the same
+  walk-with-a-`seen`-guard shape as `Backdrop`/`MapAccess`, returning the
+  resolved node's raw BGM chunk (or nil for an unconfigured/type-1/looping/
+  unknown-map/no-tree resolution) — and a new `Scene::Map#play_map_bgm`
+  (`mruby-rpg2k/mrblib/scene/map.rb`), called right alongside the existing
+  `#apply_map_access` at both of its own call sites (`#initialize`,
+  `#perform_teleport`), routed through the already-same-file-aware `#play_bgm`
+  helper so a Transfer Player back onto the same map (or between two maps
+  sharing a track) does not restart it, matching the fix immediately above.
+  Skipped entirely while boarded on a vehicle (`@state.boarded?`): the
+  vehicle's own BGM (`#play_vehicle_bgm`) owns the audio then, and
+  `#restore_pre_vehicle_bgm` already resumes whatever this would have played
+  once the party disembarks, so nothing here needed to special-case that
+  interaction beyond not firing into it. **Left open**: whether loading a
+  save (Continue) instead resumes the exact previously-playing track from the
+  save's own `current_music` field (which could differ from the destination
+  map's own default if a Play BGM override was mid-flight at save time)
+  rather than recomputing fresh from the map tree — the EasyRPG evidence
+  found this session confirms the recompute-from-tree behaviour for
+  `Game_Player::MoveTo` (new game and every Transfer Player) but not for
+  `Game_Map::SetupFromSave`'s own load path, which was not traced far enough
+  to settle it either way; this fix applies the same recompute-from-tree
+  logic uniformly to `#initialize` (covering both New Game and Continue,
+  since `main.rb` constructs `Scene::Map` identically for both), which is the
+  best-supported reading available but not confirmed for Continue
+  specifically. Covered by nine new `scripts/rpg2k_logic_check.rb` checks
+  pinning `Game::MapBgm.chunk_for`'s walk (type 2 plays the map's own file
+  with its volume/pitch; type 1 leaves the current track alone even with a
+  stray leftover file name; an empty type-2 file name also plays nothing;
+  type 0 inherits one and several levels up; an inherited type-1 resolves to
+  nothing rather than the parent's file; inheriting from the root, an unknown
+  map id and a missing tree all resolve to nothing; a looping or
+  self-parenting tree ends at nothing instead of hanging; a node missing its
+  BGM fields is treated as inheriting) and two new
+  `scripts/rpg2k_scene_check.rb` checks (a three-map fixture tree proving
+  `Scene::Map` actually reaches `Game::MapBgm` — not just that the module
+  answers correctly in isolation — on both `#initialize` and
+  `#perform_teleport`, including the same-file no-restart case and the
+  type-1 leave-alone case; a boarded party gets no map-BGM call at all), the
+  first logic check and the first scene check each confirmed to fail against
+  the pre-fix code before the fix.
 - SE is truly polyphonic (unlike BGM); ✅ **SE "OFF" now stops all playing
   SEs at once**, instead of silently doing nothing. `Game::Interpreter
   #play_audio` (`mruby-rpg2k/mrblib/interpreter.rb`) returned immediately on

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5548,6 +5548,64 @@ module Game
     end
   end
 
+  # Which BGM (if any) a map auto-plays the instant the party arrives on it --
+  # the initial map and every Transfer Player alike.
+  #
+  # Each map-tree node (RPG_RT.lmt `map_properties` field 11 `bgm_type`, 12
+  # `bgm`) is the same tri-state shape as Backdrop's `backdrop_type` above
+  # (liblcf's `BGMType` enum, shared across both fields), but the middle value
+  # means something different for music than it does for a backdrop -- there
+  # is no "terrain" concept for BGM, so it means "no music" instead:
+  #
+  #   0 親マップと同じ  inherit whatever the parent map resolves to
+  #   1 指定なし        none -- leave whatever is already playing alone
+  #   2 指定する        the map's own `bgm` chunk, every time this map loads
+  #
+  # Verified against EasyRPG Player's actual C++ source: `Game_Map::PlayBgm`
+  # walks `music_type == 0` nodes up to their parent exactly like
+  # `Backdrop.name_for`/`MapAccess` do, then -- once landed on a non-inheriting
+  # node -- only actually plays when that node's own `music.name` is non-empty
+  # *and* its type is not 1 (`if (current_info->music_type == 1) { return; }`,
+  # a no-op that leaves whatever is currently playing alone rather than
+  # silencing it); called unconditionally from `Game_Player::MoveTo` right
+  # after every `Game_Map::Setup`, i.e. the initial map and every Transfer
+  # Player. A walk that runs off the root (or loops) resolves to nothing, the
+  # same "give up and change nothing" outcome as an unset/type-1 node.
+  module MapBgm
+    TYPE_PARENT = 0
+    TYPE_NONE   = 1
+    TYPE_SPECIFIC = 2
+
+    # The BGM chunk (responding to `file`/`volume`/`pitch`) to auto-play on
+    # `map_id`, or nil when the resolved node has no music configured or is
+    # explicitly type 1 (leave the current track alone). `properties` is the
+    # map tree's map_properties table, same shape `Backdrop.name_for` takes.
+    def self.chunk_for(map_id, properties)
+      seen = {}
+      id = map_id.to_i
+      while id > 0 && !seen[id]
+        seen[id] = true
+        row = properties ? properties[id] : nil
+        return nil unless row
+        type = int_field(row, :bgm_type)
+        if type == TYPE_PARENT
+          id = int_field(row, :parent_map_id)
+        else
+          bgm = row.respond_to?(:bgm) ? row.bgm : nil
+          name = bgm && bgm.respond_to?(:file) ? bgm.file.to_s : ''
+          return (type == TYPE_SPECIFIC && !name.empty?) ? bgm : nil
+        end
+      end
+      nil
+    end
+
+    def self.int_field(row, name)
+      return 0 unless row.respond_to?(name)
+      v = row.send(name)
+      v.nil? ? 0 : v.to_i
+    end
+  end
+
   # Whether the menu's Save command, and the Escape / Teleport field skill
   # types, are usable on a given map.
   #

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -84,6 +84,7 @@ class RPG2k
         @monster_cache = {}   # Monster/<name> (battler graphics)
         @animation_cache = {} # Battle/<name> (battle animation sheets)
         apply_map_access
+        play_map_bgm
         @map = state.map
         @chipset = build_chipset
         @chipset_bmp = load_chipset_graphic
@@ -3776,6 +3777,27 @@ class RPG2k
         @state.escape_access = Game::MapAccess.escape_allowed?(@state.map_id, props)
       end
 
+      # Auto-play the current map's own configured BGM (Game::MapBgm), on the
+      # initial map load and every Transfer Player, same as RPG_RT's
+      # `Game_Player::MoveTo` calling `Game_Map::PlayBgm()` right after every
+      # `Game_Map::Setup` -- a map with nothing configured, or explicitly set
+      # to "none" (type 1), leaves whatever is already playing alone, and
+      # #play_bgm's own same-file check keeps a Transfer Player back onto the
+      # same map (or between maps sharing a track) from restarting it.
+      # Skipped while boarded: the vehicle's own BGM (#play_vehicle_bgm) owns
+      # the audio then, and #restore_pre_vehicle_bgm resumes whatever this
+      # would have played once the party disembarks.
+      def play_map_bgm
+        return if @state.boarded?
+        bgm = Game::MapBgm.chunk_for(@state.map_id, map_properties)
+        return unless bgm
+        name = music_name(bgm)
+        return if name.nil? || name.empty?
+        play_bgm(name: name, volume: music_volume(bgm), tempo: music_tempo(bgm))
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] map BGM failed: #{e.message}"
+      end
+
       # The backdrop named by the terrain of the tile at (x, y) — the database
       # terrain row's `background_name` (field 4). '' when the tile, the terrain
       # table or the field is missing.
@@ -6391,6 +6413,7 @@ class RPG2k
         @state.map = @map
         @state.map_id = map_id
         apply_map_access
+        play_map_bgm
         @state.x = x
         @state.y = y
         @state.direction = dir if dir && dir > 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10894,6 +10894,78 @@ check 'an unknown map, missing field or missing tree defaults teleport/escape to
   eq true, Game::MapAccess.escape_allowed?(1, { 1 => bare })
 end
 
+# -- map auto-BGM resolution (map tree bgm_type/bgm fields 11, 12) -----------
+#
+# The identical tri-state walk as Save/Teleport/Escape above, but the middle
+# value means "none" (leave whatever is playing alone) rather than "allow" --
+# see Game::MapBgm's own comment for the EasyRPG Game_Map::PlayBgm citation.
+
+FakeBgmChunk = Struct.new(:file, :volume, :pitch)
+
+class FakeBgmNode
+  attr_accessor :bgm_type, :bgm, :parent_map_id
+  def initialize(type, file = '', parent = 0)
+    @bgm_type = type
+    @bgm = FakeBgmChunk.new(file, 80, 110)
+    @parent_map_id = parent
+  end
+end
+
+check 'bgm type 2 plays the map own file' do
+  props = { 1 => FakeBgmNode.new(2, 'Town') }
+  chunk = Game::MapBgm.chunk_for(1, props)
+  eq 'Town', chunk.file
+  eq 80, chunk.volume
+  eq 110, chunk.pitch
+end
+
+check 'bgm type 1 (none) leaves the current track alone, even with a stray file name' do
+  props = { 1 => FakeBgmNode.new(1, 'leftover authored data') }
+  eq nil, Game::MapBgm.chunk_for(1, props)
+end
+
+check 'bgm type 2 with an empty file name also plays nothing' do
+  props = { 1 => FakeBgmNode.new(2, '') }
+  eq nil, Game::MapBgm.chunk_for(1, props)
+end
+
+check 'bgm type 0 inherits from the parent map' do
+  props = { 1 => FakeBgmNode.new(2, 'Cave'),
+            2 => FakeBgmNode.new(0, '', 1) }
+  eq 'Cave', Game::MapBgm.chunk_for(2, props).file, 'the parent pins a file'
+end
+
+check 'bgm inheritance walks more than one level' do
+  props = { 1 => FakeBgmNode.new(2, 'Boss'),
+            2 => FakeBgmNode.new(0, '', 1),
+            3 => FakeBgmNode.new(0, '', 2) }
+  eq 'Boss', Game::MapBgm.chunk_for(3, props).file
+end
+
+check 'an inherited none type resolves to nothing, not the parent file' do
+  props = { 1 => FakeBgmNode.new(1, 'unused'),
+            2 => FakeBgmNode.new(0, '', 1) }
+  eq nil, Game::MapBgm.chunk_for(2, props)
+end
+
+check 'a map inheriting from the root, an unknown map id, or a missing tree resolves to nothing' do
+  eq nil, Game::MapBgm.chunk_for(1, { 1 => FakeBgmNode.new(0, '', 0) })   # parent 0 = the tree root
+  eq nil, Game::MapBgm.chunk_for(7, { 1 => FakeBgmNode.new(2, 'x') })
+  eq nil, Game::MapBgm.chunk_for(1, nil), 'and so does having no tree'
+end
+
+check 'a looping or self-parenting map tree ends at nothing instead of hanging' do
+  props = { 1 => FakeBgmNode.new(0, '', 2),
+            2 => FakeBgmNode.new(0, '', 1) }   # 1 -> 2 -> 1 -> ...
+  eq nil, Game::MapBgm.chunk_for(1, props)
+  eq nil, Game::MapBgm.chunk_for(1, { 1 => FakeBgmNode.new(0, '', 1) })
+end
+
+check 'a node missing its bgm fields is treated as inheriting' do
+  bare = Struct.new(:nothing).new(0)
+  eq nil, Game::MapBgm.chunk_for(1, { 1 => bare })
+end
+
 # -- battle log terms (Game::States::BattleText) ------------------------------
 
 BT = Game::States::BattleText

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9304,6 +9304,54 @@ check 'Scene::Map re-derives Save/Teleport/Escape access from the map tree ' \
      'Menu access is not re-derived from the tree; it persists across the transfer'
 end
 
+# One map-tree node's BGM settings (Game::MapBgm, fields 11 bgm_type / 12 bgm).
+FakeBgmChunk = Struct.new(:file, :volume, :pitch)
+FakeBgmTreeNode = Struct.new(:bgm_type, :bgm, :parent_map_id)
+
+check 'Scene::Map auto-plays the map own BGM on load and on Teleport' do
+  parent = fake_parent(fake_db)
+  parent.map_tree = fake_map_tree(
+    1 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Town', 90, 105), 0),
+    2 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Cave', 80, 95), 0),
+    3 => FakeBgmTreeNode.new(1, FakeBgmChunk.new('unused', 0, 0), 0) # none
+  )
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  RGSS::Audio.reset_bgm
+  scene = RPG2k::Scene::Map.new(parent, state)
+  eq [['Town', 90, 105]], RGSS::Audio.bgm_calls, 'map 1 own BGM played on load'
+  eq 'Town', state.current_bgm[:name]
+
+  RGSS::Audio.reset_bgm
+  scene.send(:perform_teleport, [2, 0, 0, 0])
+  eq [['Cave', 80, 95]], RGSS::Audio.bgm_calls, 'map 2 own BGM played on Teleport'
+
+  RGSS::Audio.reset_bgm
+  scene.send(:perform_teleport, [1, 0, 0, 0])
+  eq [['Town', 90, 105]], RGSS::Audio.bgm_calls,
+     'and teleporting back to map 1 plays it again (a fresh Setup, not a same-visit no-op)'
+
+  RGSS::Audio.reset_bgm
+  scene.send(:perform_teleport, [3, 0, 0, 0])
+  eq [], RGSS::Audio.bgm_calls,
+     'map 3 is type 1 (none): the still-playing map-1 track is left alone, nothing restarts'
+  eq 'Town', state.current_bgm[:name], 'so the tracked current BGM is untouched too'
+end
+
+check 'Scene::Map does not auto-play the map BGM while the party is boarded' do
+  parent = fake_parent(fake_db)
+  parent.map_tree = fake_map_tree(
+    1 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Field', 100, 100), 0)
+  )
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  state.boarded = :ship
+  RGSS::Audio.reset_bgm
+  RPG2k::Scene::Map.new(parent, state)
+  eq [], RGSS::Audio.bgm_calls,
+     "boarded: the ship's own BGM owns the audio, not the map's default"
+end
+
 check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around' do
   scene = menu_scene(RPG2k::Scene::EquipMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@slot_index), 'starts on the first slot'


### PR DESCRIPTION
## Summary

- The map tree's `bgm_type`/`bgm` fields (`RPG_RT.lmt`, LCF fields 11/12) were already fully parsed by `mruby-lcf/mrblib/schema.rb`, but nothing in `mruby-rpg2k` ever read them — a field map's own configured background music never auto-played; every track only played because some event script issued an explicit Play BGM command.
- Verified against EasyRPG Player's actual C++ source: `Game_Map::PlayBgm` (`src/game_map.cpp`) walks `music_type == 0` ("same as parent") nodes up the tree, then plays the resolved node's own `music` chunk unless that node's type is 1 (a no-op that leaves whatever is currently playing alone). `Game_Player::MoveTo` calls this unconditionally right after every `Game_Map::Setup` — the initial map and every Transfer Player alike.
- Adds `Game::MapBgm` (`mruby-rpg2k/mrblib/game.rb`), the identical parent-inheriting tri-state walk `Game::Backdrop`/`Game::MapAccess` already use for backdrop and Save/Teleport/Escape access.
- Wires `Scene::Map#play_map_bgm` (`mruby-rpg2k/mrblib/scene/map.rb`) in alongside the existing `#apply_map_access`, at both of its call sites (`#initialize`, `#perform_teleport`), routed through the already same-file-aware `#play_bgm` helper so a Transfer Player back onto the same map (or between two maps sharing a track) does not restart it.
- Skipped entirely while boarded on a vehicle — the vehicle's own BGM owns the audio then, and `#restore_pre_vehicle_bgm` already resumes whatever this would have played once the party disembarks.
- Left open (documented in `docs/TODO.md`): whether loading a save (Continue) resumes the exact previously-playing track from the save's own `current_music` field, rather than recomputing fresh from the map tree the way this fix does — the EasyRPG evidence found this session confirms the recompute-from-tree behavior for `Game_Player::MoveTo` but wasn't traced far enough to settle the save-load path specifically.
- Updates `docs/TODO.md` with a new ✅ entry (found while cross-checking the BGM cluster, not from an existing backlog bullet) and adds a `changelog.d/` fragment.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 745 checks passed, including 9 new `Game::MapBgm.chunk_for` checks (type 2 plays own file; type 1 leaves the current track alone even with a stray leftover file name; empty type-2 file name plays nothing; type 0 inherits, including multi-level; an inherited type-1 resolves to nothing; unknown map id / no tree / root inheritance resolve to nothing; a looping or self-parenting tree ends at nothing instead of hanging; a node missing its BGM fields is treated as inheriting).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 452 checks passed, including 2 new checks: a three-map fixture tree proving `Scene::Map` actually reaches `Game::MapBgm` on both `#initialize` and `#perform_teleport` (including the same-file no-restart case and the type-1 leave-alone case), and a boarded-party check confirming no map-BGM call fires while riding a vehicle.
- [x] Confirmed the new checks fail against the pre-fix code (`git stash` of the two source files only): 9 logic checks raise `NameError: uninitialized constant Game::MapBgm`, and the new scene check reports `expected [["Town", 90, 105]], got []`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VT1dAcWwzn1GeunmHPT17j

---
_Generated by [Claude Code](https://claude.ai/code/session_01VT1dAcWwzn1GeunmHPT17j)_