### PR TITLE
rpg2k: a Face Direction move-route command now turns a fixed-direction event too

### DIFF
--- a/changelog.d/fixed-direction-face-command.fixed.md
+++ b/changelog.d/fixed-direction-face-command.fixed.md
@@ -1,0 +1,27 @@
+- **A move-route Face Direction / Turn sub-command now turns a fixed-direction
+  event's sprite too**, instead of the drawn facing staying pinned to the
+  page's own static direction no matter what a route asked for. Verified
+  against EasyRPG Player's actual C++ source: `Game_Character::SetFacingLocked`
+  folds a page's fixed-direction Animation Type (Fixed / Fixed-Continuous /
+  Fixed-Graphic) into the same lock an explicit Direction Fix ON sets, but its
+  move-route Face-command handling bypasses *any* lock reason unconditionally
+  — only ordinary movement's own facing update respects it. This codebase's
+  `Game::EventGraphic.frame` instead hardcoded the page's `base_dir` for every
+  fixed-direction anim_type outright, discarding the character's live facing
+  regardless of source, so an explicit Face Up/Down/Left/Right/Random/Hero/
+  Away-from-Hero or Turn sub-command had no visible effect on such an event —
+  it kept a Direction-Fix-style lock even after this codebase's earlier "Face
+  Direction overrides Direction Fix ON" fix, since that fix never touched the
+  render layer's separate, unconditional `base_dir` override. Fixed with a new
+  `Character#fixed_facing` flag (set from `Game::EventGraphic.fixed_direction?`
+  by `Scene::Map#build_event`, alongside `#facing_locked` as an independent
+  source of the same lock) that `#face` (movement-driven turning) now also
+  respects, while `#face!` (the Face/Turn sub-commands, already bypassing
+  `#facing_locked`) bypasses it too; `EventGraphic.frame` no longer substitutes
+  `base_dir` for any anim_type, drawing the character's own live facing
+  instead — which stays pinned at the page's own direction through ordinary
+  movement and only turns on an explicit facing command. A Fixed Graphic
+  event's separate "never animates" behaviour (its walk-frame column staying
+  put) is unaffected. Covered by two new `scripts/rpg2k_logic_check.rb` checks
+  and a new `scripts/rpg2k_scene_check.rb` check, all three confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3486,10 +3486,54 @@ not yet verified:
   is no axis to be dominant when nothing moved. Covered by a new
   `scripts/rpg2k_logic_check.rb` check (Direction Fix ON, a locked Move
   Right, an explicit Face Up, then One Step Forward continues east, not
-  north), confirmed to fail against the pre-fix code before the fix. The
-  "Animation Type" half of the original claim (whether an Animation Type
-  setting is also overridden by a Face Direction command) is unverified
-  either way.
+  north), confirmed to fail against the pre-fix code before the fix. ✅ **The
+  "Animation Type" half of the original claim is now fixed too, verified
+  against EasyRPG Player's actual C++ source rather than guessed at.** A
+  page's own fixed-direction Animation Type (Fixed/Fixed-Continuous/Fixed-
+  Graphic, LCF field 36) does suppress facing the same way Direction Fix ON
+  does, but an explicit move-route Face Direction / Turn sub-command still
+  overrides *that* lock too, exactly like it already overrides Direction Fix.
+  `Game_Character::SetFacingLocked` (`src/game_character.h`) folds both
+  sources into one flag (`lock_facing = locked ||
+  IsDirectionFixedAnimationType(anim_type)`, the latter true for all three
+  fixed kinds, `Fixed_graphic` included), which only gates *movement-driven*
+  facing (`UpdateFacing`, called from `Move`/`Jump`) — `ParseMoveRoute`'s own
+  Face-command handling (`src/game_character.cpp`) ends in an unconditional
+  `SetFacing(GetDirection())` with no lock check at all, so it always wins
+  regardless of which of the two reasons set the lock. This codebase had no
+  such fold at all: `Game::EventGraphic.frame` (`mruby-rpg2k/mrblib/game.rb`)
+  hardcoded the page's own `base_dir` for *every* `fixed_direction?` anim_type
+  unconditionally, discarding the character's live `direction` outright — so
+  even though `Character#face!` (the Direction-Fix-bypass fix above) already
+  updated `@direction` correctly, the render layer threw the update away and
+  kept drawing the stale page facing regardless of what the move route asked
+  for. Fixed with a new `Character#fixed_facing` flag, set by `Scene::Map
+  #build_event` from `Game::EventGraphic.fixed_direction?(anim_type)`
+  alongside `#facing_locked` (the two are independent sources of the same
+  lock, matching `SetFacingLocked`'s own OR — an Animation Type lock cannot
+  be turned off by a Direction Fix OFF sub-command, and unlike
+  `#facing_locked` is never itself toggled by a move-route command): `#face`
+  (movement-driven turning) now checks `@facing_locked || @fixed_facing`,
+  while `#face!` (the seven Face Direction sub-commands, already bypassing
+  `#facing_locked`) is untouched, so it bypasses both. `EventGraphic.frame`
+  no longer substitutes `base_dir` for any anim_type — every kind, `FIXED_GRAPHIC`
+  included, now draws `char_dir` — since `char_dir` already stays pinned at
+  the page's own `base_dir` through ordinary movement once `#fixed_facing` is
+  set, and only an explicit Face/Turn command (`#face!`) moves it. `Fixed
+  Graphic`'s own "never animates" behaviour is unaffected: that is purely
+  about its walk-frame *column* never advancing (`EventGraphic.animated?`
+  already stops `#animate_event` from ever ticking `phase` for it), never
+  about its facing, matching `ResetAnimation`'s own scope in the C++ source
+  (only guards `SetAnimFrame`, not `SetFacing`). Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a `fixed_facing` character ignores a
+  Move Right's own facing but still turns on a later Face Up, mirroring the
+  Direction Fix check above; `Game::EventGraphic.frame` across all three fixed
+  kinds draws the live `char_dir`, not `base_dir`, while a `FIXED_GRAPHIC`'s
+  pattern column still stays put) and a new `scripts/rpg2k_scene_check.rb`
+  check (a `FIXED_NON_CONTINUOUS` event on a custom Move Right + Face Up route
+  keeps its drawn facing south through the Move Right step, then turns north
+  once the Face Up step runs), all three confirmed to fail against the
+  pre-fix code before the fix.
 - Jump needs paired Begin/End; movement commands between them sum into a
   net displacement vector (opposite-axis moves cancel); only the *landing*
   tile's passability is tested, tiles crossed are ignored; speed/direction

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -932,8 +932,11 @@ module Game
       LCF_DIR_TO_NUMPAD[lcf_dir] || 2
     end
 
-    # Whether the type keeps the sprite's facing pinned to the page direction
-    # (movement does not turn it).
+    # Whether the type keeps the sprite's facing pinned (movement does not
+    # turn it) unless an explicit move-route Face Direction / Turn
+    # sub-command overrides it -- see Character#fixed_facing/#face!, which
+    # is what actually keeps a fixed-direction event's *drawn* facing at
+    # #frame's char_dir equal to its page's base_dir until one runs.
     def self.fixed_direction?(anim_type)
       anim_type == FIXED_NON_CONTINUOUS || anim_type == FIXED_CONTINUOUS ||
         anim_type == FIXED_GRAPHIC
@@ -959,27 +962,41 @@ module Game
     end
 
     # The [direction, column] CharSet frame to draw for an event this render.
-    # `char_dir` is the character's live facing (updated by movement),
-    # `base_dir`/`base_pattern` the page's initial facing/pattern, `phase` the
-    # walk counter and `moving` whether the event is currently stepping. Fixed
-    # graphics stay on their page frame; spinning events derive facing from the
-    # phase but keep the page's own pattern column (a graphic that repurposes
-    # the 3 columns for unrelated frames, like Nepheshel's Crystal Gate save
-    # point -- column 0 lit, column 2 unlit -- would show the wrong one of
-    # those for 3 out of 4 spin frames if the column were forced to a fixed
-    # "standing" index instead); the ordinary types walk (cycling columns)
-    # while moving/continuous and rest on the page pattern when idle.
+    # `char_dir` is the character's live facing (updated by movement, subject
+    # to Character#facing_locked/#fixed_facing -- so it already sits pinned
+    # at the page's own base_dir for a fixed-direction type until an explicit
+    # Face Direction / Turn move-route sub-command, which bypasses both locks
+    # via Character#face!, turns it), `base_pattern` the page's initial
+    # pattern, `phase` the walk counter and `moving` whether the event is
+    # currently stepping.
+    #
+    # `base_dir` is unused here (kept for callers that also need the page's
+    # own starting facing to seed a fresh Character#direction): every
+    # anim_type, fixed-direction ones included, now draws `char_dir`, not a
+    # hardcoded page facing -- real RPG_RT lets an explicit Face command turn
+    # even a "statue" (fixed / never-animating) event's sprite, per EasyRPG's
+    # `Game_Character::ParseMoveRoute`'s Face-command handling, which ends in
+    # an unconditional `SetFacing(GetDirection())` with no `IsFacingLocked()`
+    # check at all -- only ordinary movement's own `UpdateFacing()` respects
+    # the lock. Spinning events derive facing from the phase but keep the
+    # page's own pattern column (a graphic that repurposes the 3 columns for
+    # unrelated frames, like Nepheshel's Crystal Gate save point -- column 0
+    # lit, column 2 unlit -- would show the wrong one of those for 3 out of 4
+    # spin frames if the column were forced to a fixed "standing" index
+    # instead); a fixed graphic never advances its column at all (see
+    # #animated?, which stops #animate_event from ever ticking `phase`, so it
+    # stays base_pattern by construction); the ordinary types walk (cycling
+    # columns) while moving/continuous and rest on the page pattern when idle.
     def self.frame(anim_type, base_dir, base_pattern, char_dir, phase, moving)
       case anim_type
       when SPIN
         [spin_direction(phase), base_pattern]
       when FIXED_GRAPHIC
-        [base_dir, base_pattern]
+        [char_dir, base_pattern]
       else
-        dir = fixed_direction?(anim_type) ? base_dir : char_dir
         col = (moving || continuous?(anim_type)) ? pattern_column(phase)
                                                   : base_pattern
-        [dir, col]
+        [char_dir, col]
       end
     end
   end
@@ -3820,6 +3837,17 @@ module Game
     attr_accessor :direction, :move_speed, :move_frequency
     attr_accessor :through, :facing_locked, :animation_stopped, :transparency
     attr_accessor :layer, :overlap_forbidden
+    # Whether this character's own page Animation Type is one of the three
+    # "fixed direction" kinds (Game::EventGraphic.fixed_direction? -- a plain
+    # or continuous walk with facing pinned, or a single never-animating
+    # graphic). Set by Scene::Map#build_event from the page, alongside
+    # #facing_locked (the move-route Direction Fix ON/OFF toggle): the two
+    # are independent *sources* of the same lock, matching EasyRPG's
+    # `SetFacingLocked` (`lock_facing = locked || IsDirectionFixedAnimationType
+    # (anim_type)`) -- an Animation Type lock cannot be turned off by a
+    # Direction Fix OFF sub-command, and unlike #facing_locked it is never
+    # itself toggled by a move-route command.
+    attr_accessor :fixed_facing
     attr_reader :graphic_name, :graphic_index, :x, :y
 
     # The direction actually walked/jumped by the last successful move,
@@ -3849,6 +3877,7 @@ module Game
       @move_frequency = 3
       @through = false          # ignore collision while moving
       @facing_locked = false    # keep facing fixed while moving
+      @fixed_facing = false     # keep facing fixed per the page's Animation Type
       @animation_stopped = false
       @transparency = 0         # 0 opaque .. 7 fully transparent
       @graphic_name = nil
@@ -3875,20 +3904,27 @@ module Game
       Character.step_tile(@x, @y, dir)
     end
 
-    # Turn to face `dir` without moving (a no-op while facing is locked) --
-    # movement-driven facing only (#move, #jump, #move_diagonal). An explicit
-    # Face Direction / Turn move-route sub-command always wins over a prior
-    # Direction Fix ON in the same route (yado.tk); see #face!.
+    # Turn to face `dir` without moving (a no-op while facing is locked, by
+    # either #facing_locked or #fixed_facing) -- movement-driven facing only
+    # (#move, #jump, #move_diagonal). An explicit Face Direction / Turn
+    # move-route sub-command always wins over a prior Direction Fix ON *or*
+    # a fixed-direction Animation Type in the same route (yado.tk); see
+    # #face!.
     def face(dir)
-      @direction = dir unless @facing_locked || dir.nil?
+      @direction = dir unless @facing_locked || @fixed_facing || dir.nil?
     end
 
-    # Turn to face `dir`, ignoring the Direction Fix lock. The move-route
-    # "Face Up/Right/Down/Left/Random/Hero/Away from Hero" sub-commands use
-    # this (Turn Right/Left/180/Random already bypassed the lock by writing
-    # @direction directly) -- Direction Fix only suppresses the facing change
-    # that would otherwise happen from an ordinary move, not an explicit
-    # facing command issued later in the same route.
+    # Turn to face `dir`, ignoring both the Direction Fix lock and a
+    # fixed-direction Animation Type. The move-route "Face Up/Right/Down/
+    # Left/Random/Hero/Away from Hero" sub-commands use this (Turn Right/
+    # Left/180/Random already bypassed both locks by writing @direction
+    # directly) -- neither lock suppresses anything but the facing change
+    # that would otherwise happen from an ordinary move; an explicit facing
+    # command issued later in the same route always wins, and (per EasyRPG's
+    # `Game_Character::UpdateFacing`/its Face-command handler in
+    # `ParseMoveRoute`) so does one on a page whose Animation Type is itself
+    # one of the fixed kinds -- RPG_RT still turns a "statue" NPC's sprite on
+    # an explicit Face command even though it never turns while it walks.
     def face!(dir)
       @direction = dir unless dir.nil?
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -875,6 +875,13 @@ class RPG2k
         ch.move_speed = page_move_speed(page)
         ch.move_frequency = page_move_frequency(page)
         ch.set_graphic(page_charset_name(page), page_charset_index(page))
+        anim_type = page_anim_type(page)
+        # A fixed-direction Animation Type (plain/continuous "fixed", or a
+        # never-animating fixed graphic) pins the *drawn* facing the same way
+        # Direction Fix ON does -- see Character#fixed_facing/#face's doc --
+        # so ordinary movement never turns the sprite, only an explicit move-
+        # route Face Direction / Turn sub-command (#face!) still can.
+        ch.fixed_facing = Game::EventGraphic.fixed_direction?(anim_type)
         layer = page_layer(page)
         ch.layer = layer # collision (see #char_passable?) follows priority type too
         # The page's "doesn't overlap" flag (LCF field 35) is a second,
@@ -899,7 +906,7 @@ class RPG2k
           # and is the one kind that slides across more than a single tile.
           layer: layer, overlap_forbidden: overlap_forbidden,
           translucent: page_translucent(page),
-          anim_type: page_anim_type(page), base_dir: dir,
+          anim_type: anim_type, base_dir: dir,
           base_pattern: page_pattern(page), anim_phase: 0, anim_count: 0,
           moving: false, disp_x: x, disp_y: y, move_count: TILE,
           jumping: false }

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -466,6 +466,56 @@ check 'move forward after a Direction-Fix move continues in the last direction a
   eq 8, c.direction # the lock is still on, so the step itself doesn't re-face south
 end
 
+check 'a fixed-direction Animation Type suppresses movement-driven facing, but ' \
+      'an explicit Face Direction sub-command still turns it' do
+  # yado.tk: "Face Direction always overrides Fixed Direction/Animation Type" --
+  # verified against EasyRPG Player's actual C++ source rather than guessed at.
+  # Game_Character::SetFacingLocked (src/game_character.h) folds a page's own
+  # fixed-direction Animation Type into the exact same `lock_facing` flag an
+  # explicit Direction Fix ON sets (`locked || IsDirectionFixedAnimationType
+  # (anim_type)`), and ParseMoveRoute's Face-command handling
+  # (src/game_character.cpp) ends in an unconditional `SetFacing(GetDirection())`
+  # with no lock check at all -- only ordinary movement's own UpdateFacing()
+  # respects the lock -- so an explicit Face command always wins, the same as
+  # it already does over Direction Fix ON (the check above). Character#fixed_facing
+  # is the new lock source #face now also consults, set by Scene::Map#build_event
+  # from Game::EventGraphic.fixed_direction?; #face! (Turn/Face sub-commands)
+  # bypasses it exactly like it already bypasses #facing_locked.
+  route = R.new([mc(R::MOVE_RIGHT), mc(R::FACE_UP)], repeat: false)
+  c = Game::Character.new(5, 5, 2) # facing south, e.g. this page's base_dir
+  c.fixed_facing = true # this event's page Animation Type is one of the "fixed" kinds
+  w = FakeWorld.new
+  route.step(c, w) # Move Right: steps east, facing stays south -- the fixed-direction lock holds
+  eq [6, 5], [c.x, c.y]
+  eq 2, c.direction
+  route.step(c, w) # Face Up: turns north despite the fixed-direction lock
+  eq 8, c.direction
+end
+
+check "Game::EventGraphic.frame draws a fixed-direction event's live facing, " \
+      'not a hardcoded page facing' do
+  # The display-layer half of the same fix: #frame used to always substitute
+  # the page's own base_dir for every fixed_direction? anim_type, discarding
+  # char_dir outright -- so even once Character#face! correctly updated the
+  # character's own #direction (the check above), the render layer threw it
+  # away and drew the stale page facing regardless. Covers all three
+  # fixed_direction? kinds, FIXED_GRAPHIC ("never animates") included --
+  # EasyRPG only special-cases it for the *walk-frame column* (a fixed
+  # graphic's own pattern column never advances, still true here via
+  # #animated?), never for GetFacing()/its move-route Face handling.
+  eg = Game::EventGraphic
+  dir, col = eg.frame(eg::FIXED_NON_CONTINUOUS, 2, 1, 8, 0, false)
+  eq [8, 1], [dir, col], 'char_dir (an explicit Face Up), not base_dir (2, south)'
+
+  dir, col = eg.frame(eg::FIXED_CONTINUOUS, 2, 1, 8, 3, true)
+  eq 8, dir
+  eq eg.pattern_column(3), col, 'continuous walk-frame cycling is untouched'
+
+  dir, col = eg.frame(eg::FIXED_GRAPHIC, 2, 1, 8, 2, true)
+  eq [8, 1], [dir, col],
+     "a fixed graphic's own facing still turns; its pattern column never does"
+end
+
 check 'switch on/off route commands drive the world switches' do
   route = R.new([mc(R::SWITCH_ON, a: 7), mc(R::SWITCH_OFF, a: 3)], repeat: false)
   c = Game::Character.new(0, 0)

--- a/scripts/rpg2k_render_check.rb
+++ b/scripts/rpg2k_render_check.rb
@@ -257,10 +257,13 @@ check 'pattern_column walks middle,right,middle,left' do
   eq 1, EG.pattern_column(4) # wraps
 end
 
-check 'a fixed-graphic event never animates or turns' do
-  # anim type 4: always the page frame regardless of facing / phase / motion.
-  eq [2, 1], EG.frame(EG::FIXED_GRAPHIC, 2, 1, 8, 3, true)
-  eq [6, 0], EG.frame(EG::FIXED_GRAPHIC, 6, 0, 4, 1, false)
+check 'a fixed-graphic event never animates, but still draws its live facing' do
+  # anim type 4: always the page pattern regardless of phase / motion -- but
+  # the row drawn is char_dir, not base_dir, so an explicit Face Direction
+  # move-route command can still turn the sprite (Character#fixed_facing
+  # gates movement-driven turning only, not #face!'s explicit one).
+  eq [8, 1], EG.frame(EG::FIXED_GRAPHIC, 2, 1, 8, 3, true)
+  eq [4, 0], EG.frame(EG::FIXED_GRAPHIC, 6, 0, 4, 1, false)
 end
 
 check 'a spinning event derives facing from the phase but keeps its own ' \
@@ -280,16 +283,18 @@ check 'ordinary events walk while moving and rest on the page pose when idle' do
   # non-continuous (0): faces its movement, walks only while stepping.
   eq [6, 2], EG.frame(EG::NON_CONTINUOUS, 2, 1, 6, 1, true)  # moving -> walk col
   eq [6, 1], EG.frame(EG::NON_CONTINUOUS, 2, 1, 6, 1, false) # idle -> page pattern
-  # fixed-direction non-continuous (2): keeps the page facing.
-  eq [2, 2], EG.frame(EG::FIXED_NON_CONTINUOUS, 2, 1, 6, 1, true)
-  eq [2, 1], EG.frame(EG::FIXED_NON_CONTINUOUS, 2, 1, 6, 1, false)
+  # fixed-direction non-continuous (2): walk animation still gated on
+  # `moving`, but the row drawn is char_dir (pinned at base_dir by movement,
+  # turned only by an explicit Face Direction command), not base_dir itself.
+  eq [6, 2], EG.frame(EG::FIXED_NON_CONTINUOUS, 2, 1, 6, 1, true)
+  eq [6, 1], EG.frame(EG::FIXED_NON_CONTINUOUS, 2, 1, 6, 1, false)
 end
 
 check 'continuous events animate even while standing still' do
   # continuous (1): faces movement, always cycles regardless of `moving`.
   eq [6, 2], EG.frame(EG::CONTINUOUS, 2, 1, 6, 1, false)
-  # fixed continuous (3): page facing, always cycles.
-  eq [2, 2], EG.frame(EG::FIXED_CONTINUOUS, 2, 1, 6, 1, false)
+  # fixed continuous (3): always cycles, drawn at char_dir (see above).
+  eq [6, 2], EG.frame(EG::FIXED_CONTINUOUS, 2, 1, 6, 1, false)
 end
 
 check 'animation-type predicates classify the six types' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -924,6 +924,39 @@ check 'a different custom move route restarts from the top on a page switch' do
   eq 0, event_hashes(scene)[1][:route].index, 'a changed route restarts from the top'
 end
 
+check "a fixed-direction event's own explicit Face Direction sub-command still " \
+      'turns its drawn sprite, even though ordinary movement never does' do
+  # yado.tk: "Face Direction always overrides Fixed Direction/Animation Type" --
+  # verified against EasyRPG Player's actual C++ source (see the pure-logic
+  # checks in scripts/rpg2k_logic_check.rb for the exact citations). This is the
+  # full-stack version: Scene::Map#build_event now wires a page's own
+  # Game::EventGraphic.fixed_direction? into Character#fixed_facing, and
+  # Game::EventGraphic.frame reads the character's own live facing instead of
+  # hardcoding the page's base_dir for every fixed-direction anim_type.
+  pg = page(x_move_type: Game::MoveType::CUSTOM, direction: 2, # south
+            animation_type: Game::EventGraphic::FIXED_NON_CONTINUOUS,
+            route: move_route([R::MOVE_RIGHT, R::FACE_UP], repeat: false))
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [5, 4])
+  frame_of = lambda do
+    e = event_hashes(scene)[1]
+    Game::EventGraphic.frame(e[:anim_type], e[:base_dir], e[:base_pattern],
+                              e[:char].direction, e[:anim_phase], e[:moving])
+  end
+
+  # Move Right fires once move_timer (EVENT_MOVE_DELAY[frequency 6] == 6)
+  # elapses; Face Up fires 6 frames after that.
+  8.times { scene.update }
+  ok event_hashes(scene)[1][:char].x > 2, 'the Move Right step landed first'
+  ok !event_hashes(scene)[1][:route].done?, "Face Up hasn't run yet"
+  dir, = frame_of.call
+  eq 2, dir, "ordinary movement never turns a fixed-direction event's sprite"
+
+  10.times { scene.update }
+  ok event_hashes(scene)[1][:route].done?, 'the Face Up step ran too'
+  dir, = frame_of.call
+  eq 8, dir, 'an explicit Face Direction sub-command still turns it, though'
+end
+
 check 'a refresh does not resurrect an erased event' do
   ic = Game::Interpreter::Cmd
   p1 = page(trigger: 3) # auto-start: erase myself


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "A move-route 'Face Direction' sub-command always overrides an earlier 'Direction Fix ON'" bullet left one half explicitly "unverified either way": whether a Face Direction command also overrides a page's own fixed-direction Animation Type (Fixed / Fixed-Continuous / Fixed-Graphic).
- Verified against EasyRPG Player's actual C++ source: `Game_Character::SetFacingLocked` folds a fixed-direction Animation Type into the *same* `lock_facing` flag an explicit Direction Fix ON sets, but that flag only gates *movement-driven* facing (`UpdateFacing`); the move-route Face-command handler in `ParseMoveRoute` ends in an unconditional `SetFacing(GetDirection())` with no lock check — so an explicit Face/Turn command always turns the sprite, even on a "fixed"/statue-type event.
- `Game::EventGraphic.frame` instead hardcoded the page's own `base_dir` for *every* `fixed_direction?` anim_type unconditionally, discarding the character's live `direction` — so even though the earlier "Face Direction overrides Direction Fix" fix correctly updated `@direction` via `#face!`, the render layer threw it away.
- Added `Character#fixed_facing` (set from `Game::EventGraphic.fixed_direction?(anim_type)`), consulted by `#face` (movement-driven turning) alongside `#facing_locked`, while `#face!` (the Face/Turn sub-commands) bypasses both. `EventGraphic.frame` no longer substitutes `base_dir`; every anim_type now draws the character's live `char_dir`, which stays pinned at `base_dir` through ordinary movement and only turns via an explicit command.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 749 checks pass (2 new: `Character#fixed_facing` suppresses movement-driven turning but not `#face!`; `Game::EventGraphic.frame` across all three fixed kinds draws live `char_dir`, with `FIXED_GRAPHIC`'s pattern column confirmed still frozen)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 454 checks pass (1 new: a fixed-direction event on a Move Right + Face Up custom route keeps facing south through the move, then turns north on the Face Up — confirmed to fail against the pre-fix code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_