### PR TITLE
rpg2k: same-file BGM re-triggers now re-apply volume live

### DIFF
--- a/changelog.d/bgm-same-file-live-volume.fixed.md
+++ b/changelog.d/bgm-same-file-live-volume.fixed.md
@@ -1,0 +1,15 @@
+- **A same-file Play BGM (or a battle/vehicle/inn/map BGM, or a Play
+  Memorized BGM, matching the already-playing track) now re-applies its own
+  volume live instead of leaving the previous volume in place.** RPG_RT's
+  single native BGM entry point, `Game_System::BgmPlay`, does not restart a
+  track that names the file already playing, but it does "adjust volume and
+  speed" on it — this codebase's existing same-file no-restart logic
+  (`Game::Interpreter#play_audio`, `Scene::Map#play_bgm`,
+  `Game::Interpreter#do_play_memorized_bgm`) previously did neither, since
+  `RGSS::Audio` had no primitive for adjusting a playing track in place.
+  Added a new `bgm_volume` backend entry point (`include/rgss_audio.hxx`,
+  `src/sdl_audio.cxx`'s `Mix_VolumeMusic` call, `mruby-rgss`'s
+  `_bgm_volume`/`bgm_volume`) and wired all three same-file call sites
+  through it. Tempo/pan remain unaddressed: SDL_mixer cannot re-pitch a
+  playing music stream, and pan was never wired as a Play BGM parameter at
+  all.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4000,14 +4000,40 @@ not yet verified:
   each side's own configured values, matching `play_audio`'s existing
   "tracks what should be playing even when the native call is skipped"
   behaviour), confirmed to fail against the pre-fix code (asserting no
-  native replay, getting `[["BattleBGM", 70, 110]]`) before the fix. **The
-  vol/tempo/pan-without-restart half is not addressed**: this build's
-  `RGSS::Audio` exposes no primitive to adjust an already-playing BGM's
-  volume, pitch, or pan in place — `bgm_play` (`mruby-rgss/src/audio.cxx`,
-  backed by `SDL_mixer`) is the only entry point that takes those
-  parameters, and it always starts playback from the top. Implementing
-  this half would need a new native backend primitive (e.g. an
-  `Mix_VolumeMusic`-style setter) that does not exist today. ✅ **"replaying
+  native replay, getting `[["BattleBGM", 70, 110]]`) before the fix. ✅
+  **The volume-without-restart half is now implemented too.** `RGSS::Audio`
+  used to expose no primitive to adjust an already-playing BGM's volume in
+  place — `bgm_play` (`mruby-rgss/src/audio.cxx`, backed by `SDL_mixer`) was
+  the only entry point that took a volume, and it always restarts playback
+  via `Mix_PlayMusic`. Added a new `bgm_volume` slot to `RgssAudioBackend`
+  (`include/rgss_audio.hxx`), implemented in `src/sdl_audio.cxx` as a bare
+  `Mix_VolumeMusic(to_mix_volume(volume))` call — SDL_mixer applies this to
+  the currently-loaded `Mix_Music` stream directly, with no restart, unlike
+  `bgm_play`'s `Mix_PlayMusic` — with a matching `_bgm_volume` forwarder in
+  `mruby-rgss/src/audio.cxx` and a public `RGSS::Audio.bgm_volume(volume)`
+  wrapper in `mruby-rgss/mrblib/lib.rb`, mirroring `bgm_fade`'s existing
+  shape exactly. Every same-file "does not restart" call site now calls it
+  instead of doing nothing: `Game::Interpreter#play_audio`'s `:bgm` branch,
+  `Scene::Map#play_bgm` (the shared helper the battle/vehicle/inn/map-BGM
+  fixes above all route through), and `Game::Interpreter
+  #do_play_memorized_bgm` — one shared `same_file_already_playing` idiom,
+  three call sites, all now re-applying the command's own volume live
+  instead of leaving whatever the interrupted track happened to be at
+  alone. Tempo/pan remain out of reach of this backend: SDL_mixer has no
+  live pitch control for a stream already playing (only a freshly started
+  one, `src/sdl_audio.cxx`'s own header comment), and pan/balance was never
+  wired as a Play BGM parameter at all, a separate, larger gap left
+  unaddressed here. Covered by two new `scripts/rpg2k_logic_check.rb`
+  checks (a same-file Play BGM re-trigger calls `bgm_volume` with the new
+  command's volume instead of `bgm_play`; a Play Memorized BGM replaying a
+  track that never stopped re-applies the memorized volume, distinguishing
+  it from an intervening same-file Play BGM's own live volume change) and a
+  new assertion on the existing `scripts/rpg2k_scene_check.rb` battle-BGM
+  check (entering and leaving a fight whose BGM matches the already-playing
+  field track now calls `bgm_volume` with each side's own volume on top of
+  the existing zero-`bgm_play`-calls assertion), all three confirmed to
+  fail against the pre-fix code (asserting a live `bgm_volume` call,
+  getting none) before the fix. ✅ **"replaying
   always restarts from the top" turns out to be imprecise for Play
   Memorized BGM specifically — it was missing this same same-file skip.**
   Verified against EasyRPG Player's actual C++ source rather than guessed

--- a/include/rgss_audio.hxx
+++ b/include/rgss_audio.hxx
@@ -35,6 +35,13 @@ struct RgssAudioBackend {
   // Background music: a single looping stream. Starting a new one replaces the
   // current music.
   void (*bgm_play)(const char* path, int volume, int pitch);
+  // Re-applies volume to the BGM stream already playing, with no restart --
+  // unlike bgm_play, which always starts its track over. Used when a Play BGM
+  // command re-triggers the file that is already current (RPG_RT re-applies
+  // the command's own volume rather than treating the repeat as a no-op).
+  // There is no live equivalent for pitch: SDL_mixer cannot re-pitch a
+  // playing music stream, only a freshly started one.
+  void (*bgm_volume)(int volume);
   void (*bgm_stop)(void);
   void (*bgm_fade)(int ms);
   // Current playback position of the BGM, in milliseconds (0 if unknown).

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1026,6 +1026,12 @@ module RGSS
         play_packed(:bgm, filename, volume, pitch)
       end
 
+      # Re-applies volume to the already-playing BGM stream in place, with no
+      # restart -- unlike #bgm_play, which always starts its track over.
+      def bgm_volume(volume)
+        _bgm_volume(volume)
+      end
+
       def bgm_stop
         _bgm_stop
       end

--- a/mruby-rgss/src/audio.cxx
+++ b/mruby-rgss/src/audio.cxx
@@ -60,6 +60,14 @@ mrb_value bgm_play(mrb_state* M, mrb_value self) {
   return mrb_nil_value();
 }
 
+mrb_value bgm_volume(mrb_state* M, mrb_value self) {
+  mrb_int volume;
+  mrb_get_args(M, "i", &volume);
+  if (g_backend.bgm_volume)
+    g_backend.bgm_volume((int)volume);
+  return mrb_nil_value();
+}
+
 mrb_value bgm_stop(mrb_state* M, mrb_value self) {
   if (g_backend.bgm_stop)
     g_backend.bgm_stop();
@@ -208,6 +216,8 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
   RClass* audio = mrb_define_module_under(M, rgss, "Audio");
   mrb_define_module_function(M, audio, "_bgm_play", bgm_play,
                              MRB_ARGS_ARG(1, 2));
+  mrb_define_module_function(M, audio, "_bgm_volume", bgm_volume,
+                             MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_bgm_stop", bgm_stop, MRB_ARGS_NONE());
   mrb_define_module_function(M, audio, "_bgm_fade", bgm_fade, MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_bgm_pos", bgm_pos, MRB_ARGS_NONE());

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1097,6 +1097,7 @@ assert "RGSS::Audio primitives are inert without a backend" do
   # The standalone test binary installs no audio backend (that lives in the
   # executable, src/sdl_audio.cxx), so every native primitive is a safe no-op.
   assert_nil RGSS::Audio._bgm_play("nope", 80, 90)
+  assert_nil RGSS::Audio._bgm_volume(50)
   assert_nil RGSS::Audio._bgm_stop
   assert_nil RGSS::Audio._bgm_fade(100)
   assert_equal 0, RGSS::Audio._bgm_pos

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2960,12 +2960,15 @@ module Game
     # `BgmPlay` every other BGM entry point goes through (Play BGM, and the
     # battle/vehicle/inn helpers — see `Scene::Map#play_bgm`), so its "same
     # music: only adjust volume and speed" no-restart rule applies here too,
-    # same idiom as `#play_audio`'s `:bgm` branch just below.
+    # same idiom (volume-in-place included) as `#play_audio`'s `:bgm` branch
+    # just below.
     def do_play_memorized_bgm(_cmd)
       bgm = @state.memorized_bgm
       return if bgm.nil? || bgm[:name].nil? || bgm[:name].empty?
       same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == bgm[:name]
-      unless same_file_already_playing
+      if same_file_already_playing
+        RGSS::Audio.bgm_volume(bgm[:volume] || 100)
+      else
         @state.bgm_looped = false
         RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
       end
@@ -2997,16 +3000,20 @@ module Game
         # BGM has a single channel, and RPG_RT special-cases re-triggering Play
         # BGM with the file that's already current: it does NOT break and
         # restart the track from the top the way any other Play BGM does
-        # (yado.tk). It also re-applies the command's vol/tempo/pan to the
-        # still-playing track, but RGSS::Audio here has no primitive for that
-        # (mruby-rgss/src/audio.cxx's bgm_play is the only vol/pitch entry
-        # point, and it always restarts via SDL_mixer) — that half is
-        # deliberately left unimplemented rather than faked; see docs/TODO.md.
+        # (yado.tk), but it does re-apply the command's own volume to the
+        # still-playing track (`RGSS::Audio.bgm_volume`, backed by
+        # `Mix_VolumeMusic` — see `src/sdl_audio.cxx`, which applies live with
+        # no restart, unlike `bgm_play`'s `Mix_PlayMusic`). Tempo/pan stay
+        # unaddressed: SDL_mixer has no live pitch control for a playing music
+        # stream (only a freshly started one), and pan is not wired as a
+        # Play BGM parameter at all today — see docs/TODO.md.
         same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == name
         # Track what is playing so Memorize BGM can stash it (RPG_RT keeps this
         # as the "current system BGM" regardless of whether playback succeeds).
         @state.current_bgm = { name: name, volume: volume, tempo: pitch }
-        unless same_file_already_playing
+        if same_file_already_playing
+          RGSS::Audio.bgm_volume(volume)
+        else
           @state.bgm_looped = false # a fresh track has not looped yet
           RGSS::Audio.bgm_play(name, volume, pitch)
         end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1512,18 +1512,21 @@ class RPG2k
       # `src/scene_battle.cpp`: `BgmPlay(GetSystemBGM(BGM_Battle))`). This
       # codebase already ported that for the event-command path
       # (`Game::Interpreter#play_audio`'s `:bgm` branch, same
-      # `same_file_already_playing` idiom) but every helper here still called
-      # `RGSS::Audio.bgm_play` unconditionally, so a battle/vehicle/inn BGM
-      # configured to the exact same file as whatever was already playing
-      # broke and restarted it from the top instead of continuing seamlessly
-      # across the transition — including the asymmetric case of restoring a
-      # field track this scene itself never actually stopped. Volume/tempo/
-      # pan are still not adjusted in place on a same-file call: `RGSS::Audio`
-      # has no such primitive (`bgm_play` always restarts via SDL_mixer), the
-      # same already-documented limitation the event-command path carries.
+      # `same_file_already_playing` idiom, volume-in-place included) but every
+      # helper here still called `RGSS::Audio.bgm_play` unconditionally, so a
+      # battle/vehicle/inn BGM configured to the exact same file as whatever
+      # was already playing broke and restarted it from the top instead of
+      # continuing seamlessly across the transition — including the
+      # asymmetric case of restoring a field track this scene itself never
+      # actually stopped. Tempo/pan are still not adjusted in place on a
+      # same-file call: SDL_mixer has no live pitch control for a playing
+      # stream, and pan is not wired as a BGM parameter at all, the same
+      # already-documented limitation the event-command path carries.
       def play_bgm(music)
         same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == music[:name]
-        unless same_file_already_playing
+        if same_file_already_playing
+          RGSS::Audio.bgm_volume(music[:volume] || 100)
+        else
           RGSS::Audio.bgm_play(music[:name], music[:volume] || 100, music[:tempo] || 100)
         end
         @state.current_bgm = music

--- a/scripts/rpg2k_command_soak.rb
+++ b/scripts/rpg2k_command_soak.rb
@@ -38,6 +38,7 @@ module RGSS
   module Audio
     class << self
       def bgm_play(*); end
+      def bgm_volume(*); end
       def bgm_fade(*); end
       def bgm_stop(*); end
       def se_play(*); end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -22,6 +22,7 @@ module RGSS
     class << self
       attr_accessor :log
       def bgm_play(*a); (@log ||= []) << [:bgm, *a]; end
+      def bgm_volume(*a); (@log ||= []) << [:bgm_volume, *a]; end
       def bgm_fade(*a); (@log ||= []) << [:bgm_fade, *a]; end
       def se_play(*a);  (@log ||= []) << [:se, *a];  end
       def se_stop(*a);  (@log ||= []) << [:se_stop, *a]; end
@@ -2326,6 +2327,30 @@ check 'Play Memorized BGM does not restart a track that never stopped playing' d
   eq 80, st.current_bgm[:volume], 'state still tracks the memorized volume'
 end
 
+check 'Play Memorized BGM re-applies its stashed volume to a track that never stopped' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # "town" plays at volume 80, gets memorized, then a plain Play BGM re-ticks
+  # it at volume 30 (still not restarted, per the check above) before Play
+  # Memorized BGM restores the memorized volume (80) -- RPG_RT's single
+  # BgmPlay entry point "only adjusts volume and speed" on a same-file call
+  # rather than doing nothing at all, so the live volume must actually move
+  # back to 80, not stay wherever the intervening Play BGM left it.
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town'),
+    FakeCmd.new(IC::MEMORIZE_BGM, []),
+    FakeCmd.new(IC::PLAY_BGM, [0, 30, 100], string: 'town'),
+    FakeCmd.new(IC::PLAY_MEMORIZED_BGM, []),
+  ])
+  it.update
+  names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
+  eq %w[town], names, 'still only the very first Play BGM reached the restart path'
+  volumes = RGSS::Audio.log.select { |e| e[0] == :bgm_volume }.map { |e| e[1] }
+  eq [30, 80], volumes, 'the same-file Play BGM and then the memorized replay both re-applied volume live'
+  eq 80, st.current_bgm[:volume], 'the memorized volume wins back as the tracked current one'
+end
+
 check 'Play BGM with the file already playing does not restart it' do
   RGSS::Audio.log = []
   st = new_state
@@ -2343,6 +2368,8 @@ check 'Play BGM with the file already playing does not restart it' do
   eq 'town', st.current_bgm[:name]
   eq 50, st.current_bgm[:volume], 'state still tracks the latest requested volume'
   eq 120, st.current_bgm[:tempo], 'state still tracks the latest requested tempo'
+  volumes = RGSS::Audio.log.select { |e| e[0] == :bgm_volume }.map { |e| e[1] }
+  eq [50], volumes, 'the still-playing track had its volume re-applied live instead of doing nothing'
 end
 
 check 'Play BGM with a different file still restarts (or starts) playback' do

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -42,6 +42,7 @@ module RGSS
   module Audio
     class << self
       def bgm_play(*); end
+      def bgm_volume(*); end
       def se_play(*); end
     end
   end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -150,7 +150,12 @@ module RGSS
     # screen) can assert which track started.
     class << self; attr_accessor :bgm_calls; end
     def self.bgm_play(*a); (@bgm_calls ||= []) << a; end
-    def self.reset_bgm; @bgm_calls = []; end
+    def self.reset_bgm; @bgm_calls = []; @bgm_volume_calls = []; end
+    # Recorded separately from bgm_calls: a same-file Play BGM re-trigger
+    # calls this instead of bgm_play (see Game::Interpreter#play_audio /
+    # Scene::Map#play_bgm), so the two checks stay distinguishable.
+    class << self; attr_accessor :bgm_volume_calls; end
+    def self.bgm_volume(v); (@bgm_volume_calls ||= []) << v; end
     def self.bgm_fade(*); end
     def self.bgm_stop(*); end
     # Scriptable playback position, so the "BGM played once" watcher can be
@@ -4218,10 +4223,10 @@ check 'Enemy Encounter scene: a battle BGM matching the already-playing field tr
   eq [], RGSS::Audio.bgm_calls,
      'entering battle does not break and restart a track that is already playing'
   eq 'BattleBGM', st.current_bgm[:name]
-  eq 70, st.current_bgm[:volume], "the battle track's own vol/tempo are still tracked " \
-                                   '(RPG_RT re-applies them in place; this build has no ' \
-                                   'native primitive for that, see docs/TODO.md)'
+  eq 70, st.current_bgm[:volume], "the battle track's own vol/tempo are still tracked"
   eq 110, st.current_bgm[:tempo]
+  eq [70], RGSS::Audio.bgm_volume_calls,
+     'the still-playing track had its volume re-applied live rather than left alone'
   RGSS::Audio.reset_bgm
   battle_attack_to_end(scene) # Attack the Slimes each round until they fall
   RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result
@@ -4233,6 +4238,8 @@ check 'Enemy Encounter scene: a battle BGM matching the already-playing field tr
   eq 'BattleBGM', st.current_bgm[:name]
   eq 50, st.current_bgm[:volume], "the restored pre-battle vol/tempo snapshot wins back"
   eq 90, st.current_bgm[:tempo]
+  eq [50], RGSS::Audio.bgm_volume_calls,
+     'the restore also re-applied its own volume live, not just the tracked state'
 end
 
 check 'Enemy Encounter scene: victory plays the database battle_end_music over the result screen' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -49,6 +49,7 @@ module RGSS
   module Audio
     class << self
       def bgm_play(*); end
+      def bgm_volume(*); end
       def bgm_fade(*); end
       def se_play(*); end
     end

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -349,6 +349,14 @@ void bgm_play(const char* path, int volume, int /*pitch*/) {
   play_music(g_bgm_path, volume, -1);
 }
 
+// Live volume change for whichever BGM is currently playing, with no restart:
+// Mix_VolumeMusic applies to the already-loaded Mix_Music stream directly,
+// unlike bgm_play's Mix_PlayMusic, which always begins the track from the top.
+void bgm_volume(int volume) {
+  g_bgm_volume = volume;
+  Mix_VolumeMusic(to_mix_volume(volume));
+}
+
 void bgm_play_mem(const char* name,
                   const void* data,
                   int size,
@@ -514,10 +522,10 @@ void update(void) {
 }
 
 const RgssAudioBackend kBackend = {
-    bgm_play,     bgm_stop,    bgm_fade,    bgm_pos,        bgs_play,
-    bgs_stop,     bgs_fade,    bgs_pos,     me_play,        me_stop,
-    me_fade,      se_play,     se_stop,     update,         bgm_play_mem,
-    bgs_play_mem, me_play_mem, se_play_mem, midi_available,
+    bgm_play,     bgm_volume,   bgm_stop,    bgm_fade,    bgm_pos,
+    bgs_play,     bgs_stop,     bgs_fade,    bgs_pos,     me_play,
+    me_stop,      me_fade,      se_play,     se_stop,     update,
+    bgm_play_mem, bgs_play_mem, me_play_mem, se_play_mem, midi_available,
 };
 
 }  // namespace


### PR DESCRIPTION
## Summary

- RPG_RT's single native BGM entry point, `Game_System::BgmPlay`, does not restart a track when Play BGM (or a battle/vehicle/inn/map BGM, or Play Memorized BGM) re-triggers the exact file already playing — but it does "adjust volume and speed" on it in place. This codebase's existing same-file no-restart logic (`Game::Interpreter#play_audio`, `Scene::Map#play_bgm`, `Game::Interpreter#do_play_memorized_bgm`) already skipped the restart, but left the previous volume untouched instead, since `RGSS::Audio` had no primitive for a live volume change on an already-playing track.
- Adds a new `bgm_volume` slot to `RgssAudioBackend` (`include/rgss_audio.hxx`), implemented in `src/sdl_audio.cxx` as a bare `Mix_VolumeMusic(to_mix_volume(volume))` call — SDL_mixer applies this directly to the loaded `Mix_Music` stream with no restart, unlike `bgm_play`'s `Mix_PlayMusic` — with a matching `_bgm_volume` forwarder in `mruby-rgss/src/audio.cxx` and a public `RGSS::Audio.bgm_volume(volume)` wrapper in `mruby-rgss/mrblib/lib.rb`, mirroring `bgm_fade`'s existing shape.
- Wires all three same-file call sites through it: `Game::Interpreter#play_audio`'s `:bgm` branch, `Scene::Map#play_bgm` (the shared helper the battle/vehicle/inn/map-BGM fixes route through), and `Game::Interpreter#do_play_memorized_bgm`.
- Tempo/pan remain unaddressed: SDL_mixer has no live pitch control for a stream already playing (only a freshly started one), and pan/balance was never wired as a Play BGM parameter at all — a separate, larger gap left open.
- Updates the existing `docs/TODO.md` "BGM has a single channel" bullet (the "vol/tempo/pan-without-restart half is not addressed" sub-item, which explicitly named the missing native primitive as the blocker) and adds a `changelog.d/` fragment.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 748 checks passed, including 2 new checks: a same-file Play BGM re-trigger calls `bgm_volume` with the new command's volume instead of `bgm_play`; a Play Memorized BGM replaying a track that never stopped re-applies the memorized volume (distinguishing it from an intervening same-file Play BGM's own live volume change).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 453 checks passed, including a new assertion on the existing battle-BGM same-file check: entering and leaving a fight whose BGM matches the already-playing field track now calls `bgm_volume` with each side's own volume.
- [x] Confirmed the new checks fail against the pre-fix code (`git stash` of the two source files only, keeping the test-file changes): 2 logic checks raise `expected [...], got []`, and the scene check reports `expected [70], got []`.
- [x] `clang-format` run on the three touched C++ files.
- [x] The new native backend primitive could not be compile-verified in this sandbox (no SDL2_mixer headers available), so it was written to mirror the existing `bgm_play`/`bgm_fade` pattern exactly rather than guessed at freehand — the mruby-side logic (what actually has regression coverage) is independent of whether the native call ever fires, matching how the rest of this codebase's `RGSS::Audio` calls are tested.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016azbdzokNwDxjiLMgDaQ3F

---
_Generated by [Claude Code](https://claude.ai/code/session_016azbdzokNwDxjiLMgDaQ3F)_