### PR TITLE
rpg2k: a map event's forced/custom move route now fires Event Touch on hero contact

### DIFF
--- a/changelog.d/event-touch-custom-route.fixed.md
+++ b/changelog.d/event-touch-custom-route.fixed.md
@@ -1,0 +1,21 @@
+- **A map event's own Set Move Route / page-authored custom route now fires
+  its Event Touch (trigger 2) page when it steps onto the party, instead of
+  silently blocking with no trigger at all.** `Scene::Map#move_autonomous`
+  already had a dedicated check for an *autonomous* (Random/Approach/Away)
+  move stepping onto the player, but `Game::MoveRoute#do_move` — the engine
+  both a Set Move Route and a page's own Custom move-type route share —
+  just called `world.passable?` and turned to face any obstacle, with no
+  distinction between a wall and the party. Verified against EasyRPG
+  Player's actual C++ source: `Game_Event`'s own move-failure handling
+  starts a Trigger_collision page whenever the blocked tile is the
+  player's, with no guard gating it off while a move route is active
+  (unlike `Game_Player`, whose own touch check *is* gated on exactly that —
+  confirmed already correct here too, and now documented in `docs/TODO.md`
+  with the citation). Fixed by having `do_move` report a new
+  `:touched_hero` status — purely a re-classification of an already-refused
+  move, so it changes nothing about whether the move itself succeeds, and
+  never affects a vehicle's own route since vehicles don't collide with the
+  party at all — which `Scene::Map#step_event` turns into the same trigger
+  `#move_autonomous` already fires. Covered by new
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb` checks,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3574,7 +3574,61 @@ not yet verified:
   priority-type/collision work.
 - Running a hero-targeted Parallel-Process Set Move Route while the hero
   is mid-transition onto an event's tile can suppress that event's "Hero
-  Touch" trigger for that step.
+  Touch" trigger for that step — **confirmed already correct**, verified
+  against EasyRPG Player's actual C++ source rather than guessed at.
+  `Game_Player::UpdateMovement` (`src/game_player.cpp`) only calls
+  `CheckEventTriggerHere({Trigger_touched, Trigger_collision}, false)` when
+  `!IsMoveRouteOverwritten() && IsStopping()` — a forced move route grabbing
+  the player mid-step sets exactly that flag, so the touch check for
+  whichever tile the player was walking onto never runs for that step, real
+  RPG_RT included. `Scene::Map#step_movement` (`mruby-rpg2k/mrblib/
+  scene/map.rb`) already mirrors this precisely: its own touch-trigger check
+  (`event_at`/`touch_trigger?`) bails out immediately via `return if
+  @player_route` before ever reaching it, and `#step_player_route`/
+  `#start_player_slide` (which actually drive a forced route once one is
+  set) never consult it either — so a hero-targeted Set Move Route
+  categorically never fires a touch trigger for its own steps, matching
+  `IsMoveRouteOverwritten()`'s effect exactly, no code change needed. ✅
+  **A closely related, genuinely broken case this same investigation
+  surfaced — not itself a named backlog bullet — is now fixed: a *map
+  event's* own Set Move Route / page-authored custom route stepping onto
+  the party's tile never fired that event's own Event Touch (trigger 2)
+  page**, the opposite asymmetry from the player's own case above. Also
+  verified against EasyRPG Player's actual C++ source: unlike
+  `Game_Player`, `Game_Event`'s own move failure handling
+  (`Game_Character::Move` → `CheckCollisonOnMoveFailure`,
+  `src/game_event.cpp`/`src/game_character.cpp`) starts a `Trigger_collision`
+  page whenever the blocked tile is the player's, with **no**
+  `IsMoveRouteOverwritten`-style guard at all — a forced/custom route fires
+  it exactly like an ordinary autonomous move does. This codebase already
+  modelled the autonomous half correctly (`Scene::Map#move_autonomous`'s own
+  dedicated `nx == @state.x && ny == @state.y` check, starting the event
+  when its trigger is `TRIGGER_EVENT_TOUCH`), but `Game::MoveRoute#do_move`
+  (`mruby-rpg2k/mrblib/game.rb`) — the move-command engine both a Set Move
+  Route (`e[:forced_route]`) and a page's own Custom move-type route
+  (`e[:route]`) share, per `Scene::Map#step_event` — just called
+  `world.passable?`/turned to face the obstacle on any block, with nothing
+  distinguishing "blocked by the party" from "blocked by a wall." Fixed by
+  reclassifying an already-refused move as a new `:touched_hero` status
+  exactly when the blocked tile is `world.hero_position` — a pure
+  re-classification of an outcome `world.passable?` had already decided (a
+  map event's own layer/overlap-forbidden collision with the party, per the
+  pre-existing `Scene::Map#char_passable?`), so it changes nothing about
+  *whether* a move succeeds, and, since a vehicle's own `vehicle_passable?`
+  never blocks on the party's tile at all, this never reclassifies (or
+  otherwise touches) a vehicle route's own step either. `Scene::Map
+  #step_event` now starts the event when its own step reports
+  `:touched_hero` and its current page's trigger is `TRIGGER_EVENT_TOUCH`,
+  the identical gate `#move_autonomous` already uses. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (`Game::MoveRoute#do_move` reports
+  `:touched_hero`, not plain `:blocked`, for a move refused specifically by
+  the hero's tile, with the same skippable/non-skippable retry rule either
+  way; an ordinary wall the hero does not stand on still reports plain
+  `:blocked`) and a new `scripts/rpg2k_scene_check.rb` check (a same-layer,
+  Event-Touch-triggered map event on a one-tile Custom move-type route
+  toward the party fires its own page instead of silently walking onto the
+  party's tile), both confirmed to fail against the pre-fix code before the
+  fix.
 - ✅ **"Display stat clamping is cosmetic only" turns out to be backwards —
   verified against EasyRPG Player's actual C++ source rather than taken on
   faith, the clamp is real and applies to the *effective* stat itself,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4167,6 +4167,25 @@ module Game
 
     # Attempt a one-tile move in `dir`. Returns [status, advance?]: a blocked
     # move on a non-skippable route returns advance == false so it is retried.
+    #
+    # A block caused specifically by the hero's own tile is reported as
+    # `:touched_hero` rather than plain `:blocked` (same skippable/non-
+    # skippable retry rule either way) -- purely a re-classification of an
+    # outcome `world.passable?` already refused (a map event's own layer/
+    # overlap-forbidden collision with the hero, `Scene::Map#char_passable?`;
+    # a vehicle's own `vehicle_passable?` never blocks on the hero at all, so
+    # this never reclassifies a vehicle route's own step), not a new
+    # obstruction -- so it changes nothing about *whether* a move succeeds,
+    # only what the caller does with a failure that was already going to
+    # happen. `Scene::Map#step_event` turns it into this map event's own
+    # Event Touch (2) trigger, mirroring `#move_autonomous`'s identical
+    # dedicated hero check for a Random/Approach/Away-type move: EasyRPG's
+    # `Game_Character::Move` calls `CheckCollisonOnMoveFailure`, which starts
+    # an Event Touch (`Trigger_collision`) page right here with no
+    # `IsMoveRouteOverwritten` guard (unlike the player's own touch check,
+    # gated on exactly that flag in `Game_Player::UpdateMovement`) -- so a Set
+    # Move Route/page-authored custom route walking a map event onto the
+    # party fires it exactly like an autonomous move already does.
     def do_move(character, world, dir)
       return [:turned, true] if dir.nil?
       if character.through || world.passable?(character, dir)
@@ -4174,7 +4193,9 @@ module Game
         [:moved, true]
       else
         character.face(dir) # an obstructed move still turns to face it
-        @skippable ? [:blocked, true] : [:blocked, false]
+        nx, ny = Character.step_tile(character.x, character.y, dir)
+        status = world.hero_position == [nx, ny] ? :touched_hero : :blocked
+        @skippable ? [status, true] : [status, false]
       end
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1822,8 +1822,9 @@ class RPG2k
         e[:move_timer] = EVENT_MOVE_DELAY[freq] || 40
         ox = ch.x
         oy = ch.y
+        status = nil
         if forced
-          forced.step(ch, @world) unless forced.done?
+          status = forced.step(ch, @world) unless forced.done?
           if forced.done? # revert to page movement
             e[:forced_route] = nil
             # The page's own Move Frequency reasserts itself once the forced
@@ -1833,10 +1834,19 @@ class RPG2k
             ch.move_frequency = page_move_frequency(e[:page])
           end
         elsif e[:route]
-          e[:route].step(ch, @world) unless e[:route].done?
+          status = e[:route].step(ch, @world) unless e[:route].done?
         else
           dir = Game::MoveType.next_direction(e[:move_type], ch, @world)
           move_autonomous(e, dir, allow_trigger: allow_trigger) if dir
+        end
+        # A Set Move Route (forced) or page-authored custom route stepping
+        # into the hero's own tile fires this event's own Event Touch (2)
+        # trigger too, the same as #move_autonomous's dedicated hero check
+        # already does for a Random/Approach/Away-type move -- see
+        # Game::MoveRoute#do_move's `:touched_hero` status.
+        if allow_trigger && status == :touched_hero &&
+           e[:trigger] == TRIGGER_EVENT_TOUCH && e[:commands]
+          start_event(e)
         end
         # A jump that lands where it started still needs the render slide, so
         # the hop is visible; an ordinary step only when the tile changed.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -222,6 +222,37 @@ check 'a blocked skippable move advances past the obstruction' do
   eq [0, 1], [c.x, c.y]
 end
 
+check 'a move blocked specifically by the hero reports :touched_hero, not ' \
+      'plain :blocked, with the same retry rule' do
+  # yado.tk (docs/TODO.md "Running a hero-targeted Parallel-Process Set Move
+  # Route..."): a Set Move Route / page-authored custom route stepping a map
+  # event onto the party's own tile is a move failure like any other
+  # obstacle -- Scene::Map#step_event fires this event's own Event Touch (2)
+  # trigger off exactly this status, mirroring #move_autonomous's identical
+  # check for a Random/Approach/Away-type move. FakeWorld's `blocked:` list
+  # models scenery; `hero:` is a *separate* tile it also refuses, letting a
+  # test tell the two outcomes apart the way #char_passable? actually does
+  # (map-event/hero collision vs. an ordinary obstacle).
+  non_skip = R.new([mc(R::MOVE_RIGHT)], repeat: false, skippable: false)
+  c = Game::Character.new(0, 0)
+  w = FakeWorld.new(blocked: [[1, 0]], hero: [1, 0])
+  eq :touched_hero, non_skip.step(c, w)
+  eq [0, 0], [c.x, c.y] # did not step onto the hero
+  eq 6, c.direction     # but still turned to face it
+  ok !non_skip.done?, 'non-skippable retries a hero collision just like a wall'
+
+  skip = R.new([mc(R::MOVE_RIGHT), mc(R::MOVE_DOWN)],
+              repeat: false, skippable: true)
+  c2 = Game::Character.new(0, 0)
+  eq :touched_hero, skip.step(c2, w)
+  eq :moved, skip.step(c2, w) # skippable advances past it, same as :blocked
+
+  # An ordinary wall the hero does not stand on is still plain :blocked.
+  c3 = Game::Character.new(0, 0)
+  wall_only = FakeWorld.new(blocked: [[1, 0]], hero: [5, 5])
+  eq :blocked, R.new([mc(R::MOVE_RIGHT)], repeat: false).step(c3, wall_only)
+end
+
 # -- Begin Jump / End Jump ----------------------------------------------------
 
 check 'a jump block hops to its accumulated destination in one step' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1199,6 +1199,35 @@ check 'event-touch (trigger 2): an event walking into the player runs it' do
   eq [1, 0], [ch.x, ch.y], 'event stopped adjacent, did not enter the player'
 end
 
+check 'event-touch (trigger 2): a custom-route event stepping into the ' \
+      'player runs it too, not just an autonomous Approach move' do
+  # docs/TODO.md, "Running a hero-targeted Parallel-Process Set Move Route...
+  # can suppress that event's touch trigger" -- the real, broader gap this
+  # surfaced: a Set Move Route / page-authored custom route (Game::MoveRoute,
+  # driven through Game::MoveRoute#do_move) never fired Event Touch at all
+  # when it stepped a map event onto the party's tile, unlike an autonomous
+  # Random/Approach/Away-type move (#move_autonomous's own dedicated check,
+  # already covered by the check just above). Verified against EasyRPG
+  # Player's actual C++ source: `Game_Character::Move`'s
+  # `CheckCollisonOnMoveFailure` starts a Trigger_collision page the same way
+  # regardless of whether a move route is driving the character, with no
+  # `IsMoveRouteOverwritten`-style guard the way the *player's* own touch
+  # check has.
+  ic = Game::Interpreter::Cmd
+  # layer 1 (LAYER_SAME): a below-characters event walks straight through the
+  # party (a separate, already-correct rule -- see #char_passable?), so this
+  # needs the ordinary same-layer NPC priority to actually collide at all.
+  pg = page(x_move_type: Game::MoveType::CUSTOM, trigger: 2, layer: 1,
+           route: move_route([R::MOVE_RIGHT], repeat: false))
+  pg.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])]
+  scene = new_scene({ 1 => event(0, 0, pg) }, player: [1, 0])
+  ch = chars(scene)[1]
+  20.times { scene.update }
+  st = scene.instance_variable_get(:@state)
+  ok st.switches[5], "a custom-route event's own Event Touch trigger ran"
+  eq [0, 0], [ch.x, ch.y], 'the event stayed put, it did not step onto the player'
+end
+
 check 'action (trigger 0) does not fire on mere contact' do
   ic = Game::Interpreter::Cmd
   pg = page(trigger: 0) # needs the action button


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s "Running a hero-targeted Parallel-Process Set Move Route while the hero is mid-transition onto an event's tile can suppress that event's 'Hero Touch' trigger" bullet was unverified. Checked against EasyRPG Player's actual C++ source: `Game_Player::UpdateMovement` only checks touch triggers when `!IsMoveRouteOverwritten() && IsStopping()`, so a forced route really does suppress the *player's* own touch check — this codebase's `Scene::Map#step_movement` already matches that exactly (`return if @player_route` before ever reaching the touch check), so this half is **confirmed already correct**, no code change.
- The same investigation surfaced a different, genuinely broken case in the opposite direction: a **map event's** own Set Move Route / page-authored custom route stepping onto the party never fired that event's own Event Touch (trigger 2) page, unlike an autonomous Random/Approach/Away move (`Scene::Map#move_autonomous`'s own dedicated check). Verified against EasyRPG's source: unlike `Game_Player`, `Game_Event`'s own move-failure handling starts a `Trigger_collision` page with **no** move-route guard at all.
- `Game::MoveRoute#do_move` (the move engine both a Set Move Route and a page's own Custom route share) just treated the party's tile as an ordinary obstacle. Fixed by reporting a new `:touched_hero` status — a pure re-classification of a move `world.passable?` had already refused, so it changes nothing about whether a step succeeds, and never touches a vehicle's own route since vehicles don't collide with the party at all. `Scene::Map#step_event` turns that status into the same trigger `#move_autonomous` already fires.
- Updates `docs/TODO.md` with both the confirmed-correct citation and a new ✅ entry for the fix, plus a `changelog.d/` fragment.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 739 checks passed, including a new check: `Game::MoveRoute#do_move` reports `:touched_hero` (not plain `:blocked`) for a move refused specifically by the hero's tile, with the same skippable/non-skippable retry rule either way; an ordinary wall the hero doesn't stand on still reports plain `:blocked`.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 452 checks passed, including a new check: a same-layer, Event-Touch-triggered map event on a one-tile Custom move-type route toward the party fires its own page instead of silently walking onto the party's tile.
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed (untouched by this change, run to confirm no incidental breakage).
- [x] Confirmed the two new checks fail against the pre-fix code (`git stash` of the two source files only, keeping the test-file changes): the logic check reports `expected :touched_hero, got :blocked`, and the scene check reports the switch never got set.

---
_Generated by [Claude Code](https://claude.ai/code/session_016q7kUay7UxPqjCWUscENeF)_