### PR TITLE
rpg2k: a second Auto-Start event now cascades into the same frame as the first

### DIFF
--- a/changelog.d/autostart-cascade-same-frame.fixed.md
+++ b/changelog.d/autostart-cascade-same-frame.fixed.md
@@ -1,0 +1,25 @@
+- **A second, distinct Auto-Start map/common event now starts the same frame
+  the first one finishes with no Wait, instead of waiting for the next real
+  frame.** Verified against EasyRPG Player's actual C++ source rather than
+  guessed at: `Game_Map::UpdateForegroundEvents` (`src/game_map.cpp`) drives
+  the single shared foreground interpreter inside a `while
+  (!interp.IsRunning() && !interp.ReachedLoopLimit())` loop — the instant a
+  pushed event's own command list empties out, that same real-frame call
+  immediately rescans every event's `IsWaitingForegroundExecution()` flag and
+  pushes another eligible one too. `Scene::Map#update`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) used to call `#start_autostart` exactly
+  once per real frame, so a second, not-yet-run Auto-Start event on the same
+  map had to wait for the *next* real frame even when the first one's own
+  script ended with no Wait at all. Fixed with a new
+  `Scene::Map#drive_autostart_cascade`, which keeps calling `#start_autostart`
+  for a fresh candidate every time the interpreter genuinely goes idle again
+  within the same `#update` call, stopping the moment nothing new starts or
+  the interpreter is left busy (mid-script, or parked on a Wait/Show
+  Text/etc.) for a future frame. Each distinct event id can still only ever be
+  picked up once per visit, unchanged — this fix only closes the *cross-event*
+  cascading gap, not whether the very same event's own script restarts from
+  the top on its own natural end (a much larger, deliberately unaddressed
+  question, see `docs/TODO.md`'s "Autorun (auto-start) events run at most
+  once per map visit" bullet). Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks, two confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5995,16 +5995,82 @@ session (reading + documenting only, not fixed — see below):
   rely on `MAX_STEPS`/the existing per-command step cost to bound it the
   way real RPG_RT does, or keep the one-shot behaviour and record the
   divergence as accepted scope — rather than staying marked ✅ as-is.
+  **Re-checked this session against EasyRPG Player's actual C++ source
+  (`src/game_map.cpp`'s `Game_Map::UpdateForegroundEvents`,
+  `src/game_event.cpp`'s `Game_Event::ScheduleForegroundExecution`/
+  `CheckEventAutostart`) rather than the wiki paraphrase alone: the claim
+  holds structurally.** `Game_Event`/`Game_CommonEvent` have no "ran once,
+  ever" flag anywhere — only a transient `waiting_execution` bit
+  (`IsWaitingForegroundExecution`), armed every time `CheckEventAutostart`
+  runs (called from each event's own per-frame `UpdateNextMovementAction`,
+  unconditionally, regardless of whether it has already run before) and
+  cleared the instant `UpdateForegroundEvents` consumes it by pushing the
+  event onto the shared interpreter — so the *only* thing standing between
+  one lap finishing and the very same event's script restarting from the top
+  is whether `UpdateForegroundEvents`'s own `while (!interp.IsRunning() &&
+  !interp.ReachedLoopLimit())` loop happens to still be turning (see the
+  "Autorun cascading" fix just below, which implements exactly this loop's
+  cross-event half). This session deliberately did **not** implement the
+  same-event-restart half: doing so faithfully needs `Game::Interpreter`'s
+  `MAX_STEPS` budget threaded *across* repeated `#start`/`#update` calls
+  within one `Scene::Map#update` (today each call gets a fresh budget), and
+  — far more disruptively — would make *every* existing Auto-Start
+  `scripts/rpg2k_scene_check.rb` fixture that does not itself clear its own
+  eligibility (turn off its gating switch, change page, erase itself) before
+  its script naturally ends start looping every subsequent frame instead of
+  running once, which is not something a single surgical session can safely
+  audit and re-baseline across ~450 existing checks. Left open, now with a
+  precise citation trail for whoever picks it up next.
 
 **Untriaged backlog** (raw reference material, not checked against the
 codebase yet):
-- **Autorun cascading within one frame.** If the lowest-id eligible Autorun
-  map event's content contains no wait-including command, real RPG_RT lets
-  the next-lowest-id eligible Autorun event start immediately in the same
-  frame (potentially chaining through several before one of them blocks on
-  a wait). `#start_autostart` only ever starts one event per frame
-  regardless — entangled with the run-once-per-visit item above, since
-  fixing that one changes how this needs to be tested too.
+- ✅ **Autorun cascading within one frame — the narrower, cross-event half of
+  this claim is now fixed, verified against EasyRPG Player's actual C++
+  source rather than guessed at.** If the lowest-id eligible Autorun map
+  event's content contains no wait-including command, real RPG_RT lets the
+  next-lowest-id eligible Autorun event start immediately in the same frame
+  (potentially chaining through several before one of them blocks on a
+  wait). `Game_Map::UpdateForegroundEvents` (`src/game_map.cpp`) drives the
+  single shared foreground interpreter inside a `while (!interp.IsRunning()
+  && !interp.ReachedLoopLimit())` loop: the instant a pushed event's own
+  command list empties out (`IsRunning()` false), that same real-frame call
+  immediately rescans every `Game_Event`/`Game_CommonEvent`'s
+  `IsWaitingForegroundExecution()` flag and pushes another eligible one too
+  — a *different* event's own Auto-Start page is not, and never was, gated
+  on the first one having already finished a whole frame ago, only on the
+  shared interpreter (`Game_Map::GetInterpreter()`, `main_flag=true`) being
+  idle right now. `Scene::Map#update` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  used to call `#start_autostart` exactly once per real frame — a second,
+  distinct not-yet-run Auto-Start map/common event on the same map had to
+  wait for the *next* real frame even when the first one's own script ended
+  with no Wait at all, one tick later than real RPG_RT whenever both
+  happened to be eligible on the same frame. Fixed with a new
+  `Scene::Map#drive_autostart_cascade`, called instead of a bare
+  `#drive_event` once `#start_autostart` finds something: it loops
+  `#drive_event` then, once the interpreter genuinely goes idle again (not
+  merely parked on a Wait/Show Text/etc.), calls `#start_autostart` again for
+  a fresh candidate, stopping the moment nothing new starts or the
+  interpreter is left busy for a future frame to continue. Each distinct id
+  can still only ever be picked up once per visit (`@started_auto`/
+  `@started_common` are completely untouched by this), so the loop is
+  naturally bounded by the finite number of map/common Auto-Start events on
+  the map — no `MAX_STEPS`-style guard was needed. **The other, much larger
+  half of this same finding — whether the very *same* event, once its own
+  script hits its natural end with no Wait, immediately restarts from the
+  top and keeps consuming that frame's own step budget — remains open**, see
+  the "Autorun (auto-start) events run at most once per map visit" bullet
+  directly above, now itself re-verified against this same EasyRPG source and
+  confirmed accurate rather than a wiki misreading; deliberately left
+  unaddressed here since it would also require every existing Auto-Start
+  test in this suite to arrange for its own event to fall out of eligibility
+  once done, unlike this narrower, cross-event-only fix. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (two distinct no-Wait auto-start map
+  events both fire within a single `scene.update`; a still-Waiting first
+  event correctly blocks a second one from cascading in early, which then
+  fires normally once the Wait clears; a no-Wait auto-start map event
+  cascades into a distinct auto-start *common* event within the same frame),
+  the first and third confirmed to fail against the pre-fix code (the second
+  event's switch not yet set) before the fix.
 - **A body-less command block still spends a step.** The wiki's own
   worked example: a `◆繰り返し処理` / (blank inner line) / `：以上繰り返し`
   loop, and the empty branches of a `◆条件分岐`, each spend 1 step per

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -293,7 +293,7 @@ class RPG2k
         else
           start_autostart
           if event_busy?
-            drive_event
+            drive_autostart_cascade
           else
             step_player_route
             step_events
@@ -1024,6 +1024,52 @@ class RPG2k
       # past a single frame's MAX_STEPS budget without hitting a wait).
       def parallels_paused?
         !@battle_ui.nil? || (@interpreter.running? && !@interpreter.waiting?)
+      end
+
+      # Drive the just-started foreground Auto-Start process, then -- yado.tk
+      # "Autorun cascading within one frame" -- keep looking for a *different*,
+      # not-yet-run Auto-Start map/common event to start the instant this one's
+      # own command list fully drains with no Wait/Show Text left pending, all
+      # within this same real frame, rather than waiting for the next one.
+      # Verified against EasyRPG Player's actual C++ source rather than
+      # guessed at: `Game_Map::UpdateForegroundEvents` (src/game_map.cpp)
+      # drives the single shared foreground interpreter inside a `while
+      # (!interp.IsRunning() && !interp.ReachedLoopLimit())` loop -- the
+      # instant a pushed event's own command list empties out
+      # (`IsRunning()` false), that same call immediately rescans every
+      # `IsWaitingForegroundExecution()` map/common event and pushes another
+      # one too, all sharing one `Game_Interpreter::loop_count`/`loop_limit`
+      # (10000) budget rather than ending the frame the first time the
+      # interpreter goes idle. `Scene::Map#update`'s own foreground dispatch
+      # used to call `#start_autostart` exactly once per real frame, so a
+      # second, distinct not-yet-run Auto-Start event on the same map had to
+      # wait for the *next* real frame even when the first one's own script
+      # ended with no Wait at all. Each distinct id can still only ever be
+      # picked up once per visit (`@started_auto`/`@started_common` are
+      # untouched by this), so the loop is naturally bounded by the finite
+      # number of map/common Auto-Start events on the map and stops the
+      # instant nothing new starts, or the interpreter is left running/
+      # waiting (mid-script, or genuinely parked on a Wait/Show Text/etc.) for
+      # a future frame to continue.
+      #
+      # The other half of this same finding -- whether the very *same* event,
+      # once its own script hits its natural end with no Wait, immediately
+      # restarts from the top and keeps consuming this frame's budget (a
+      # documented worked example: a one-line Auto-Start common event
+      # advancing a variable 5000 times within a single frame, 10000 steps / 2
+      # per lap) -- is a separate, much larger question left open, see the
+      # "Autorun (auto-start) events run at most once per map visit, not once
+      # per frame" bullet in docs/TODO.md: changing that would also require
+      # every existing Auto-Start test in this suite to arrange for its own
+      # event to fall out of eligibility once done, which this narrower,
+      # cascade-only fix does not.
+      def drive_autostart_cascade
+        loop do
+          drive_event
+          break if event_busy?
+          start_autostart
+          break unless event_busy?
+        end
       end
 
       # Start the first not-yet-run auto-start process in the foreground: map

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1433,6 +1433,61 @@ check 'Wait 0.0 sec pauses a foreground event for exactly one frame' do
   ok st.switches[2], 'Wait 0.0 sec costs exactly one frame, not two'
 end
 
+# yado.tk "Untriaged backlog": "Autorun cascading within one frame" -- if the
+# lowest-id eligible Autorun map event's content contains no wait-including
+# command, real RPG_RT lets the next-lowest-id eligible Autorun event start
+# immediately in the same frame. Verified against EasyRPG Player's actual C++
+# source: `Game_Map::UpdateForegroundEvents` drives the shared foreground
+# interpreter inside a `while (!interp.IsRunning() && ...)` loop that rescans
+# for another eligible event the instant one's own command list drains, all
+# within the same real-frame call -- see `Scene::Map#drive_autostart_cascade`.
+check 'a second, distinct auto-start map event starts the same frame the ' \
+      'first one finishes with no Wait (Autorun cascading)' do
+  ic = Game::Interpreter::Cmd
+  p1 = page(trigger: 3) # auto-start, no Wait: just flips switch 1
+  p1.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0])]
+  p2 = page(trigger: 3) # auto-start: flips switch 2
+  p2.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0])]
+  scene = new_scene({ 1 => event(1, 1, p1), 2 => event(2, 2, p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  ok st.switches[1], 'the first auto-start event ran'
+  ok st.switches[2], 'a second, distinct auto-start event cascaded into the ' \
+                      'very same frame instead of waiting for the next one'
+end
+
+check 'a second auto-start map event does NOT cascade in while the first ' \
+      'one is still parked on its own Wait' do
+  ic = Game::Interpreter::Cmd
+  p1 = page(trigger: 3) # auto-start: flips switch 1, then waits
+  p1.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+                       ECmd.new(ic::WAIT, [2])] # 0.2s = 12 frames
+  p2 = page(trigger: 3) # auto-start: flips switch 2
+  p2.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0])]
+  scene = new_scene({ 1 => event(1, 1, p1), 2 => event(2, 2, p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  ok st.switches[1], 'the first event\'s pre-wait command ran'
+  ok !st.switches[2], 'a still-running (waiting) first event must not let a ' \
+                       'second one cascade in on top of it'
+  20.times { scene.update }
+  ok st.switches[2], 'the second event eventually runs once the first one\'s Wait clears'
+end
+
+check 'a distinct auto-start common event cascades in behind a finishing ' \
+      'auto-start map event within the same frame' do
+  ic = Game::Interpreter::Cmd
+  p1 = page(trigger: 3) # auto-start, no Wait
+  p1.event_commands = [ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0])]
+  ce = OpenStruct.new(start_term: 3, need_flag: false,
+                      event: [ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0])])
+  scene = new_scene({ 1 => event(1, 1, p1) }, player: [0, 0], common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  scene.update
+  ok st.switches[1], 'the auto-start map event ran'
+  ok st.switches[2], 'the auto-start common event cascaded in the same frame'
+end
+
 check 'Wait 0.0 sec doubles a parallel process lap gap to two frames' do
   # A parallel process already gets a free one-frame gap between laps with no
   # explicit wait at all (the check above). Adding a Wait 0.0 stacks one more


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Autorun cascading within one frame" bullet, entangled with the neighboring "Autorun events run at most once per map visit, not once per frame" flagged-priority bullet.
- `Scene::Map#update` called `#start_autostart` exactly once per real frame. If that event's own script had no Wait and finished within the same `drive_event` call, a second, distinct, not-yet-run Auto-Start map or common event on the same map had to wait for the *next* real frame before it could even begin.
- Verified against EasyRPG Player's actual C++ source: `Game_Map::UpdateForegroundEvents` drives the single shared foreground interpreter inside a `while (!interp.IsRunning() && !interp.ReachedLoopLimit())` loop that immediately rescans every event's `IsWaitingForegroundExecution()` flag the instant the current one's command list empties, chaining another eligible event into the very same frame.
- New `Scene::Map#drive_autostart_cascade`, called instead of a bare `drive_event` once `start_autostart` finds something. It loops `drive_event` → `start_autostart` until either nothing new starts or the interpreter is left busy for a future frame — naturally bounded since each event id can still only ever be picked up once per visit.
- Left open (documented in `docs/TODO.md` with full citations): the harder same-event-restart half (an Auto-Start event re-triggering itself thousands of times in one frame), traced through EasyRPG's `OnFinishStackFrame`/`ScheduleForegroundExecution`/`CheckEventAutostart` and confirmed structurally accurate against real source — but implementing it would need a `MAX_STEPS` budget threaded across repeated interpreter starts and would likely break most existing Auto-Start scene checks.
- `docs/TODO.md` updated ✅.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 751 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 458 checks pass (3 new: two distinct no-Wait auto-start map events both fire within a single `scene.update`; a still-Waiting first event correctly blocks a second from cascading in early; a no-Wait auto-start map event cascades into a distinct auto-start common event within the same frame — two confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_