### PR TITLE
rpg2k: an enemy's "Appear Transparent" flag now renders at reduced opacity

### DIFF
--- a/changelog.d/enemy-appear-transparent-opacity.fixed.md
+++ b/changelog.d/enemy-appear-transparent-opacity.fixed.md
@@ -1,0 +1,13 @@
+- **An enemy flagged "Appear Transparent" now draws its battle sprite at
+  reduced opacity for the whole fight.** The monster schema's `transparent`
+  field (LCF enemy field 10) was parsed but read nowhere in `mruby-rpg2k`,
+  the same "parsed but unused" gap `levitate` had before its own fix, so
+  every enemy always drew fully opaque regardless of the flag. Confirmed
+  against EasyRPG Player's C++ source (`Game_Enemy::IsTransparent`/
+  `Sprite_Enemy::Draw`): flagged, it draws at 160/255 (~63%) opacity, purely
+  cosmetic with no accuracy/evasion effect. Implemented with a new
+  `Game::Enemy#transparent` reader and `Scene::Map#battler_opacity`, wired
+  into every site that (re)builds an enemy sprite — the initial build, a
+  mid-fight transformation redraw, and Show Hidden Monster. Covered by new
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb` checks,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5793,6 +5793,41 @@ above are repeated here)
   the same fight — confirmed to fail (`expected 70, got 90`) against a
   temporarily-neutered `attack_hit_rate` that always returned 90, then
   restored.
+- ✅ **The "Appear Transparent" enemy flag (field 10) — found while re-checking
+  this same `levitate`/`miss` cluster for anything else parsed-but-unused —
+  is now implemented too, drawing the flagged battler's sprite at reduced
+  opacity for the whole fight.** Same "parsed by the schema, read nowhere in
+  `mruby-rpg2k`" shape as the `levitate` gap directly above: `enemy.transparent`
+  (`mruby-lcf/mrblib/schema.rb` field 10) was already decoded off every
+  database, but `Game::Enemy` (`mruby-rpg2k/mrblib/game.rb`) had no field for
+  it at all, and nothing anywhere set an enemy sprite's opacity — every
+  battler drew fully opaque regardless of the flag. Verified against EasyRPG
+  Player's actual C++ source rather than guessed at: `Game_Enemy::IsTransparent`
+  (`src/game_enemy.h`) is a bare `enemy->transparent` passthrough, and
+  `Sprite_Enemy::Draw` (`src/sprite_enemy.cpp`) computes `alpha = 160 * alpha
+  / 255` whenever it is set — 160/255 (~63%) of whatever opacity the sprite
+  would otherwise have (255 outside of the death-fade/explode timer
+  animations this codebase does not model), purely cosmetic with no
+  accuracy/evasion effect of any kind, exactly like `levitate`. Fixed by
+  adding `Game::Enemy#transparent` (mirroring `#levitate`'s own
+  `row.respond_to?(:transparent) ? ... : false` read) and a new
+  `Scene::Map#battler_opacity(member)` (`TRANSPARENT_ENEMY_OPACITY = 160`,
+  `mruby-rpg2k/mrblib/scene/map.rb`), wired into `spr.opacity =` at the same
+  three sites `#battler_y`/the `levitate` fix already threads through —
+  `#build_battle_sprites`, `#rebuild_battler_sprite` (a mid-fight
+  transformation redraw), `#reveal_battle_monster` (Show Hidden Monster) —
+  so a reveal or transformation lands at the correct opacity too, not just
+  the initial build. Covered by a new `scripts/rpg2k_logic_check.rb` check
+  (the bare `Game::Enemy#transparent` reader: true when flagged, false when
+  explicitly unflagged, false when the row omits the field entirely) and a
+  new `scripts/rpg2k_scene_check.rb` check against a dedicated lone-member
+  troop (`enemy_group` 3, a `transparent`-flagged "Ghost", `enemy` 4) that
+  leaves every existing battler-sprite/flying-offset assertion undisturbed —
+  the sprite draws at 160/255 opacity on the initial build, keeps it through
+  a transformation redraw, and again through a Show Hidden Monster reveal,
+  while a plain (unflagged) enemy is pinned at the ordinary 255 — both
+  confirmed to fail against the pre-fix code (`NoMethodError: undefined
+  method 'transparent'`, and `expected 255, got nil`) before the fix.
 - ✅ **Chipset passability — upper-layer override — confirmed already
   correct, no code change needed.** `Game::ChipSet#passable_tile?`
   (`mruby-rpg2k/mrblib/game.rb`) already mirrors EasyRPG's

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -5890,6 +5890,16 @@ module Game
       # `Scene::Map#flying_offset` the same way. Read here regardless of
       # edition, same as every other schema field this class exposes.
       @levitate = row && row.respond_to?(:levitate) ? (row.levitate ? true : false) : false
+      # The "Appear Transparent" flag (field 10): the battle screen renders this
+      # enemy's sprite at reduced opacity for the whole fight -- purely cosmetic,
+      # like `levitate`, with no accuracy/evasion effect of any kind. Verified
+      # against EasyRPG Player's actual C++ source: `Game_Enemy::IsTransparent`
+      # (`src/game_enemy.h`) is a bare `enemy->transparent` passthrough, and
+      # `Sprite_Enemy::Draw` (`src/sprite_enemy.cpp`) computes `alpha = 160 *
+      # alpha / 255` whenever it is set -- 160/255 (~63%) of whatever opacity the
+      # sprite would otherwise have (255 outside of the death-fade/explode
+      # animations this codebase does not yet model).
+      @transparent = row && row.respond_to?(:transparent) ? (row.transparent ? true : false) : false
       # The 行動パターン table (field 42), decoded now since `row` isn't kept. An
       # enemy whose row lists none falls back to plain attacking.
       @actions = []
@@ -5905,6 +5915,9 @@ module Game
     # The "airborne" flag (field 28) -- see the comment in #initialize for what
     # it does and does not affect.
     attr_reader :levitate
+
+    # The "Appear Transparent" flag (field 10) -- see the comment in #initialize.
+    attr_reader :transparent
 
     # Base to-hit percentage for this enemy's normal attack (70 when the "miss"
     # flag is set, otherwise 90); fed into the battle's to-hit roll.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3814,6 +3814,20 @@ class RPG2k
         member.y - bmp.height / 2 + flying_offset(member)
       end
 
+      # A troop member's sprite opacity: 160/255 (~63%) for one flagged
+      # "Appear Transparent" (`Game::Enemy#transparent`, database field 10),
+      # 255 (fully opaque) for everyone else -- verified against EasyRPG
+      # Player's actual C++ source, `Sprite_Enemy::Draw`'s `alpha = 160 * alpha
+      # / 255` (`src/sprite_enemy.cpp`), with `alpha` at its 255 baseline since
+      # this codebase has no death-fade/explode sprite animation to scale it
+      # from. Purely cosmetic, no accuracy/evasion effect, same as
+      # #flying_offset -- shared by every site that (re)builds an enemy sprite
+      # so all three agree.
+      TRANSPARENT_ENEMY_OPACITY = 160
+      def battler_opacity(member)
+        member.transparent ? TRANSPARENT_ENEMY_OPACITY : 255
+      end
+
       # RPG2000 is a front-view battle: the enemy troop is drawn as sprites over a
       # battle background, while the party is represented by the status window (not
       # sprites). Build the backdrop and one sprite per visible troop member,
@@ -3829,6 +3843,7 @@ class RPG2k
           spr.x = enemy.x - bmp.width / 2
           spr.y = battler_y(enemy, bmp)
           spr.z = battler_z(i)
+          spr.opacity = battler_opacity(enemy)
           spr
         end
         # The battler each sprite was drawn from, so a transformation mid-fight
@@ -4041,6 +4056,7 @@ class RPG2k
         spr.x = member.x - bmp.width / 2
         spr.y = battler_y(member, bmp)
         spr.z = battler_z(i)
+        spr.opacity = battler_opacity(member)
         spr.visible = !foe.out_of_play?
         sprites[i] = spr
         dispose_battle_sprite(old)
@@ -4807,6 +4823,7 @@ class RPG2k
         spr.x = member.x - bmp.width / 2
         spr.y = battler_y(member, bmp)
         spr.z = battler_z(index)
+        spr.opacity = battler_opacity(member)
         dispose_battle_sprite(@battle_ui[:enemy_sprites][index])
         @battle_ui[:enemy_sprites][index] = spr
       end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6654,6 +6654,24 @@ check 'Game::Enemy reads its treasure drop id and probability' do
   eq 0, Game::Enemy.new(battle_db, 2).drop_id, 'no drop when the row omits it'
 end
 
+# "Appear Transparent" (database field 10) -- a purely cosmetic reduced-opacity
+# battle-sprite flag, verified against EasyRPG Player's actual C++ source
+# (`Game_Enemy::IsTransparent`/`Sprite_Enemy::Draw`'s `alpha = 160 * alpha /
+# 255`, `src/game_enemy.h`/`src/sprite_enemy.cpp`) -- was parsed by the schema
+# but never read into `Game::Enemy` at all, the same "parsed but unused" shape
+# `levitate` had before its own fix. The scene-level opacity itself is covered
+# by `scripts/rpg2k_scene_check.rb`; this pins the bare reader.
+check 'Game::Enemy reads its "Appear Transparent" flag' do
+  ghost_row = Struct.new(:name, :max_hp, :max_sp, :attack, :defense, :spirit,
+                         :agility, :exp, :gold, :transparent)
+  db = BattleDB.new({ 5 => ghost_row.new('Ghost', 15, 0, 5, 2, 2, 6, 3, 6, true),
+                      6 => ghost_row.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10, false) }, {})
+  eq true, Game::Enemy.new(db, 5).transparent, 'the flagged row reads true'
+  eq false, Game::Enemy.new(db, 6).transparent, 'an explicit false row reads false'
+  eq false, Game::Enemy.new(battle_db, 3).transparent,
+     'a row that omits the field entirely defaults to false, same as `levitate`'
+end
+
 check 'Troop#drops yields certain drops, skipping zero-chance / no-item foes' do
   db = BattleDB.new(
     { 2 => EnemyRow.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10, 7, 100),  # always drops 7

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -334,13 +334,23 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
              3 => OpenStruct.new(name: 'Bat', battler_name: 'Bat',
                                  max_hp: 20, max_sp: 0, attack: 6,
                                  defense: 2, spirit: 2, agility: 8, exp: 4,
-                                 gold: 8, levitate: true) },
+                                 gold: 8, levitate: true),
+             # "Appear Transparent" (field 10) fixture for the enemy-opacity
+             # checks; its own lone-member troop (group 3) keeps it from
+             # disturbing the two-Slime/lone-Bat troops' own assertions.
+             4 => OpenStruct.new(name: 'Ghost', battler_name: 'Ghost',
+                                 max_hp: 15, max_sp: 0, attack: 5,
+                                 defense: 2, spirit: 2, agility: 6, exp: 3,
+                                 gold: 6, transparent: true) },
     enemy_group: { 1 => OpenStruct.new(name: 'Slimes', members: {
       1 => OpenStruct.new(enemy_id: 2, x: 100, y: 80, invisible: false),
       2 => OpenStruct.new(enemy_id: 2, x: 200, y: 80, invisible: false) },
       pages: troop_pages),
       2 => OpenStruct.new(name: 'Bats', members: {
         1 => OpenStruct.new(enemy_id: 3, x: 100, y: 80, invisible: false) },
+        pages: nil),
+      3 => OpenStruct.new(name: 'Ghosts', members: {
+        1 => OpenStruct.new(enemy_id: 4, x: 100, y: 80, invisible: false) },
         pages: nil) },
     # A drawable battle animation (id 8): four frames, with a screen flash timing
     # on frame 1. (Id 7 is intentionally absent so that test exercises the
@@ -6727,6 +6737,7 @@ check 'Enemy Encounter scene: draws a battler sprite per enemy, hidden on death'
   # Centred on the member's troop position (member 1 at x = 100, y = 80).
   eq 100 - sprites[0].bitmap.width / 2, sprites[0].x, 'sprite centred on its x'
   eq 80 - sprites[0].bitmap.height / 2, sprites[0].y, 'sprite centred on its y'
+  eq 255, sprites[0].opacity, 'a plain (non-"Appear Transparent") enemy draws fully opaque'
   ok sprites[0].z < 300, 'battlers sit below the UI windows (z >= 300)'
   ok ui[:back_sprite].z < sprites[0].z, 'the backdrop sits behind the battlers'
   # yado.tk: troop members are numbered by add-order and the *lower*-numbered
@@ -6735,6 +6746,46 @@ check 'Enemy Encounter scene: draws a battler sprite per enemy, hidden on death'
 
   battle_attack_to_end(scene) # both Slimes fall
   ok sprites.all? { |s| !s.visible }, 'a defeated enemy sprite is hidden'
+end
+
+# The "Appear Transparent" flag (field 10, `Game::Enemy#transparent`) was
+# parsed by the schema but read nowhere in mruby-rpg2k -- the same
+# "parsed but unused" shape as the `levitate` flag above, and every enemy
+# battler sprite drew fully opaque regardless. Verified against EasyRPG
+# Player's actual C++ source: `Sprite_Enemy::Draw` (`src/sprite_enemy.cpp`)
+# computes `alpha = 160 * alpha / 255` whenever `Game_Enemy::IsTransparent`
+# is set, with no accuracy/evasion effect of any kind -- purely cosmetic,
+# like `levitate`. Troop 3's lone Ghost (enemy id 4) is the dedicated
+# fixture, kept off the two-Slime/lone-Bat troops so this never disturbs
+# their own opacity-agnostic assertions (now pinned at a plain 255 above).
+check 'Enemy Encounter scene: an "Appear Transparent" enemy draws at reduced ' \
+      'opacity everywhere its sprite is (re)built' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, troop_id: 3)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_to_command(scene)
+  member = ui[:troop].members[0]
+  ok member.transparent, 'the fixture enemy (id 4, Ghost) carries the flag'
+  eq 160, ui[:enemy_sprites][0].opacity,
+     'build_battle_sprites draws it at 160/255 opacity, matching EasyRPG exactly'
+
+  # A mid-fight transformation redraw (#rebuild_battler_sprite) keeps the
+  # reduced opacity, not just the initial build.
+  ui[:foes][0].battler_name = 'Wraith'
+  ui[:foes][0].name = 'Wraith'
+  scene.send(:refresh_battle_sprites)
+  eq 160, ui[:enemy_sprites][0].opacity,
+     'a transformation redraw keeps the reduced opacity'
+
+  # Show Hidden Monster (#reveal_battle_monster) builds a fresh sprite too.
+  ui[:foes][0].hidden = true
+  ui[:troop].members[0].hidden = true
+  scene.send(:reveal_battle_monster, 0)
+  eq 160, ui[:enemy_sprites][0].opacity,
+     'Show Hidden Monster also draws it at the reduced opacity'
 end
 
 check 'Enemy Encounter scene: a monster that leaves the field is not drawn' do


### PR DESCRIPTION
## Summary
- Found by cross-checking the "Database field semantics" bullets for other parsed-but-unused schema fields — the same pattern that produced the earlier `levitate`/flying-offset fix. The enemy database's "Appear Transparent" flag (LCF `enemy` chunk field 10) is already parsed by `mruby-lcf/mrblib/schema.rb`, but `Game::Enemy` had no field for it at all, and no rendering code in `mruby-rpg2k` ever applied any opacity reduction — every enemy always drew fully opaque.
- Verified against EasyRPG Player's actual C++ source: `Game_Enemy::IsTransparent` is a bare `enemy->transparent` passthrough, and `Sprite_Enemy::Draw` applies `alpha = 160 * alpha / 255` when transparent — cosmetic only, no accuracy/evasion effect.
- Added `Game::Enemy#transparent`, read the same way `#levitate` already is. Added `Scene::Map#battler_opacity(member)` (`TRANSPARENT_ENEMY_OPACITY = 160`), wired into `spr.opacity =` at the three sites that (re)build an enemy sprite — `#build_battle_sprites`, `#rebuild_battler_sprite` (mid-fight transformation), `#reveal_battle_monster` (Show Hidden Monster) — the same three sites the `levitate` fix already threads through.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 752 checks pass (1 new: `Game::Enemy` reads its "Appear Transparent" flag — explicit true/false and default-when-omitted false)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 459 checks pass (1 new: the sprite draws at 160/255 opacity on initial build, through a transformation redraw, and through a Show Hidden Monster reveal; existing baseline check pinned to 255 for an unflagged enemy — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_