### PR TITLE
rpg2k: empty Item/Skill lists no longer show a hardcoded English placeholder

### DIFF
--- a/changelog.d/rpg2k-empty-item-skill-list-placeholder.fixed.md
+++ b/changelog.d/rpg2k-empty-item-skill-list-placeholder.fixed.md
@@ -1,0 +1,9 @@
+- **The Item and Skill menus no longer show a hardcoded English "No items" /
+  "No skills" message on an empty list.** Found by comparing this engine's
+  field menu against a genuine `RPG_RT.exe` under wine: with an empty bag,
+  RPG_RT draws a blank list row with a visible (but empty) selection cursor
+  and no text at all — the placeholder strings were never localized (every
+  other piece of menu text goes through the `term(...)` database lookup) and
+  don't match what the real runtime shows. `Scene::ItemMenu`/`Scene::SkillMenu`
+  now draw nothing for an empty list, and their selection cursor stays visible
+  on the blank row instead of collapsing to zero height, matching RPG_RT.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2091,7 +2091,37 @@ The work below is roughly ordered by the critical path to a walkable game
 - ✅ Menu screens — the Item, Skill, Equip and Status screens all exist now (see
   Menu scene above). The Skill screen's recovery formula (`power +
   physical_rate*atk/20 + magical_rate*spirit/40`) is the same one the battle
-  system will reuse for skills; battle adds the +/- variance the field path omits
+  system will reuse for skills; battle adds the +/- variance the field path omits.
+  ✅ **The Item/Skill screens' empty-list placeholder didn't match RPG_RT.**
+  Found by driving the field menu under wine against a genuine `RPG_RT.exe`:
+  with an empty bag/skill list, RPG_RT draws a blank list row with a visible
+  but empty cursor, no text -- `Scene::ItemMenu`/`Scene::SkillMenu` instead
+  drew a hardcoded English "No items"/"No skills" (the only menu text in
+  either scene not sourced through `term(...)`) and collapsed the cursor to
+  zero height. Both fixed to match.
+  **Left open by the same comparison, not fixed here:**
+  - The Item/Skill list windows stay full-`SCREEN_W` wide even with nothing
+    in them, where RPG_RT's own list window in that state is narrower (looks
+    roughly menu-command-window width, ~300px) -- seen once the cursor became
+    visible again by the fix above, but not cross-checked against a
+    *populated* list on both engines, so it is recorded rather than guessed
+    at: the window may simply always be full-width once real rows are drawn,
+    which an empty list alone cannot tell apart from a genuine layout bug.
+  - Opening the Item/Skill screen leaves the parent command list and status
+    panel visibly drawn behind/around the new window instead of being fully
+    replaced, where RPG_RT's own screen shows only the one clean window --
+    seen on the Item screen specifically; not chased into a fix, since it
+    touches the scene stack's window-visibility handling and wants more than
+    one data point to scope correctly.
+  - The Save command's "you cannot save right now" message (shown when
+    `Change Save Access` has turned saving off) is a hardcoded English
+    literal, the same class of bug the two placeholders above turned out to
+    be -- but unlike those, this one is *not* wine-verified: the comparison
+    never reached this exact state on the reference side (input lag stacked
+    up over the menu's earlier steps), and RPG2000's Term table has no
+    obvious dedicated slot for this message to source from, so whether RPG_RT
+    shows *any* text here at all is still an open question rather than an
+    assumed one.
 
 #### Assets & infrastructure
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -310,16 +310,16 @@ class RPG2k
         @item_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
-        if rows.empty?
-          c.draw_text 0, 2, inner_w, LINE_H, "No items"
-        else
-          rows.each_with_index do |(id, count), i|
-            it = @state.party.db_item(id)
-            name = (it && it.name.to_s)
-            name = "Item #{id}" if name.nil? || name.empty?
-            c.draw_text 0, i * LINE_H + 2, inner_w - 40, LINE_H, name
-            c.draw_text inner_w - 40, i * LINE_H + 2, 40, LINE_H, ":#{count}"
-          end
+        # An empty bag draws no placeholder text -- confirmed against genuine
+        # RPG_RT under wine, which shows a blank list row (still with a
+        # visible, empty cursor box; see #refresh_item_cursor) rather than
+        # any "no items" message.
+        rows.each_with_index do |(id, count), i|
+          it = @state.party.db_item(id)
+          name = (it && it.name.to_s)
+          name = "Item #{id}" if name.nil? || name.empty?
+          c.draw_text 0, i * LINE_H + 2, inner_w - 40, LINE_H, name
+          c.draw_text inner_w - 40, i * LINE_H + 2, 40, LINE_H, ":#{count}"
         end
         @item_window.contents = c
         refresh_item_cursor
@@ -327,7 +327,10 @@ class RPG2k
 
       def refresh_item_cursor
         return unless @item_window
-        h = items.empty? ? 0 : LINE_H
+        # The cursor box stays visible on the empty row even with no items --
+        # matched against genuine RPG_RT under wine, which highlights the
+        # blank slot rather than hiding the cursor.
+        h = LINE_H
         @item_window.cursor_rect =
           Rect.new(0, @item_index * LINE_H, @item_window.contents.width, h)
       end

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -252,14 +252,14 @@ class RPG2k
         a = caster
         mp_term = term(:mp_short, 'MP')
         c.draw_text 0, 0, inner_w, LINE_H, "#{a.name}   #{mp_term} #{a.mp}/#{a.max_mp}"
-        if rows.empty?
-          c.draw_text 0, head_h, inner_w, LINE_H, "No skills"
-        else
-          rows.each_with_index do |(sid, cost), i|
-            y = head_h + i * LINE_H
-            c.draw_text 0, y, inner_w - 40, LINE_H, skill_name(sid)
-            c.draw_text inner_w - 40, y, 40, LINE_H, "#{cost} #{mp_term}"
-          end
+        # An empty skill list draws no placeholder text -- matching the fix
+        # for the analogous Item screen (see item_menu.rb), confirmed there
+        # against genuine RPG_RT under wine: a blank list row with a visible,
+        # empty cursor box (see #refresh_skill_cursor) rather than a message.
+        rows.each_with_index do |(sid, cost), i|
+          y = head_h + i * LINE_H
+          c.draw_text 0, y, inner_w - 40, LINE_H, skill_name(sid)
+          c.draw_text inner_w - 40, y, 40, LINE_H, "#{cost} #{mp_term}"
         end
         @skill_window.contents = c
         refresh_skill_cursor
@@ -267,7 +267,9 @@ class RPG2k
 
       def refresh_skill_cursor
         return unless @skill_window
-        h = skills.empty? ? 0 : LINE_H
+        # The cursor box stays visible on the empty row even with no skills
+        # -- see item_menu.rb's analogous fix.
+        h = LINE_H
         @skill_window.cursor_rect =
           Rect.new(0, LINE_H + @skill_index * LINE_H, @skill_window.contents.width, h)
       end


### PR DESCRIPTION
## Summary

Follow-up to #667, continuing the same wine-based UI-gap survey (RPG2000 field menu screens, driven against genuine `RPG_RT.exe` under wine).

- With an empty bag or empty skill list, genuine RPG_RT draws a blank list row with a visible-but-empty selection cursor and no text at all. `Scene::ItemMenu` and `Scene::SkillMenu` instead drew a hardcoded `"No items"`/`"No skills"` — the only text in either scene not sourced through the `term(...)` database lookup every other menu string uses — and collapsed the selection cursor to zero height instead of leaving it visible on the blank row.
- Both are fixed to match RPG_RT: no placeholder text is drawn, and the cursor stays visible on the empty row.

Three related findings from the same comparison are recorded in `docs/TODO.md` rather than fixed here, since none of them had enough evidence yet to act on confidently:
- The Item/Skill list windows stay full-`SCREEN_W` wide even when empty, where RPG_RT's own window in that state looks narrower — only ever compared on an *empty* list, so this can't yet be told apart from "the window is always full-width once real rows exist."
- Opening the Item screen leaves the parent menu's command list and status panel visibly drawn behind/around the new window, where RPG_RT shows only the one clean window — seen once, not chased into a scene-stack fix without more data points.
- The Save command's "you cannot save right now" message is a hardcoded English literal (same bug class as the two fixed here), but the wine comparison never actually reached that exact state on the reference side (RPG_RT lagged behind the scripted input by then), so it's flagged rather than assumed.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 458 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 751 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] Rebuilt the native engine and re-ran the field-menu comparison under wine against genuine `RPG_RT.exe`: the Item screen's empty list now shows a blank row with a visible cursor and no "No items" text, matching RPG_RT
- [x] Rebased onto latest `master` (this branch's prior commit, #667, is already merged) and re-ran the full check suite against the rebased state


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_