### PR TITLE
rpg2k: Store Event ID now resolves an event hidden by its own page condition

### DIFF
--- a/changelog.d/store-event-id-hidden-page.fixed.md
+++ b/changelog.d/store-event-id-hidden-page.fixed.md
@@ -1,0 +1,17 @@
+- **Store Event ID (and its "Get Event ID at Location" name on yado.tk) now
+  resolves an event whose current page conditions aren't met**, at wherever it
+  last stood, instead of reading back 0 there for the rest of the visit. Such
+  an event never gets a `Game::Character` built at all (`Scene::Map#build_events`
+  skips it outright whenever no page's conditions are satisfied), but real
+  RPG_RT keeps one `Game_Event` object per map event for the whole visit
+  regardless of page state and answers `Game_Interpreter::CommandStoreEventID`
+  from it with no "is this page active" check at all
+  (`Game_Map::GetEventAt(x, y, /* require_active */ false)`,
+  `src/game_map.cpp`). Fixed with a new per-visit `@event_last_position`
+  table, seeded from an event's raw map placement the first time it is ever
+  seen this visit and kept live for as long as it has an active page, that
+  `#event_id_at` now falls back to for any id that is neither currently live
+  nor erased — with the same highest-id tie-break the already-fixed
+  temporarily-erased-event case uses. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5555,24 +5555,53 @@ level-up).
   a tile" rule (confirmed already correct — see the "Processing order"
   bullet above) now spans live and erased events together: several ids on
   one tile, in any live/erased mix, still resolve to the highest of them.
-  **The other half of this same claim — an event whose current page
-  conditions simply aren't met — is separate and still open**: such an
-  event never gets a `Game::Character` built at all (`#build_events` skips
-  it outright whenever no page's conditions are satisfied), so there is no
-  position to answer from without first deciding what "its" position even
-  means while hidden, which would need a real RPG_RT comparison to pin
-  down rather than a guess. The "id-lookup position snaps to an event's
+  ✅ **The other half of this same claim — an event whose current page
+  conditions simply aren't met — is now settled and fixed too, verified
+  against EasyRPG Player's actual C++ source rather than left a guess.**
+  Such an event never gets a `Game::Character` built at all (`#build_events`
+  skips it outright whenever no page's conditions are satisfied), so this
+  build genuinely had no position to answer from — but real RPG_RT does:
+  `Game_Event`'s own C++ object (`src/game_event.cpp`) is constructed once
+  per map event for the whole visit regardless of page state, and
+  `RefreshPage()` — called whenever a switch/variable/item/party write might
+  flip the active page, this codebase's own `#pages_changed?` equivalent —
+  only clears the active page and forces Through Mode on when no page
+  matches; it never touches `x`/`y`. `Game_Interpreter::CommandStoreEventID`
+  (`src/game_interpreter.cpp`) looks the target up via
+  `Game_Map::GetEventAt(x, y, /* require_active */ false)`
+  (`src/game_map.cpp`), passing `false` explicitly — so an inactive event is
+  matched by position exactly like a live one, settling the question this
+  bullet left open. Fixed with a new per-visit `@event_last_position` hash
+  (`mruby-rpg2k/mrblib/scene/map.rb`), the same shape as the already-fixed
+  `@erased_event_positions` above: `#build_events` seeds an id's entry from
+  its raw `ev.x`/`ev.y` map placement the first time it ever sees that id
+  this visit (covers an event that starts the visit with no page matching at
+  all, mirroring `Game_Event`'s own constructor-time `SetX`/`SetY` before its
+  first `RefreshPage()`), and `#record_map_event_positions` — already
+  running every frame over every *live* event to drive the pre-existing
+  save/reload wandered-position feature — now also writes the same
+  `[x, y, direction]` into this table, so an event that walked somewhere via
+  its own page before losing it is found at wherever it actually stood, not
+  snapped back to its spawn tile. `#event_id_at` now falls back to
+  `@event_last_position` for any id neither currently live nor erased, with
+  the same last-write-wins/highest-id tie-break the erased-event fallback
+  already uses — live, erased and hidden ids sharing one tile, in any mix,
+  still resolve to the highest of them. Both tables reset on a genuine map
+  change (`#perform_teleport`), matching every other per-visit event-state
+  table in this file. The "id-lookup position snaps to an event's
   destination tile the instant it begins moving" half of the original
   bullet was already confirmed correct earlier, under the `Map Event`
   "hero touches event" bullet above (`#reoccupy` rewrites this same
   `@event_tiles` table the instant a step commits, well before the visual
   slide catches up) — `#event_id_at` reads that same table, so the same
-  fact already covered it. Covered by three new
-  `scripts/rpg2k_scene_check.rb` checks (an erased event alone on a tile
-  still answers with its id; an erased event still outranks a lower-id
-  live event sharing its tile; a live event still outranks a lower-id
-  erased one), two confirmed to fail against the pre-fix code before the
-  fix.
+  fact already covered it. Covered by six `scripts/rpg2k_scene_check.rb`
+  checks in total: the three pre-existing erased-event ones above, plus
+  three new ones for this fix (an event whose page condition has never once
+  held still answers at its raw map placement; an event that walked two
+  tiles via a Custom move route before its gating switch turned off answers
+  at that last-known tile, not its original spawn tile; a hidden event still
+  outranks a lower-id live event sharing its old tile), all three of the new
+  ones confirmed to fail against the pre-fix code before the fix.
 
 **Database field semantics** (from the `11_db/` sweep, 48 findings — the
 single densest source in this pass; only the ones not already listed

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -112,6 +112,13 @@ class RPG2k
         # separately from @erased_events since this needs the position, not
         # just the flag.
         @erased_event_positions = {}
+        # Every event's last-known tile this visit, live or not -- unlike
+        # @erased_event_positions (frozen once, at erasure) this is kept live
+        # for as long as an event has a Game::Character, and seeded from its
+        # raw map-data placement the first time #build_events ever sees its
+        # id, so an event whose *very first* selected page fails its
+        # conditions still has a position to answer from. See #event_id_at.
+        @event_last_position = {}
         @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver
@@ -844,6 +851,11 @@ class RPG2k
         evs = @map.unit.events
         return unless evs
         evs.each do |id, ev|
+          # First sighting of this id this visit: record its raw placement as
+          # the fallback #event_id_at falls back to while it has no active
+          # page (never touched again from here -- only #record_map_event_positions
+          # keeps it current once the event actually goes live).
+          @event_last_position[id] ||= [ev.x, ev.y, nil]
           next if @erased_events[id] # an Erase Event lasts the whole visit
           selected = Game::EventPage.select(ev.pages, @state.switches,
                                             @state.variables, @state.party)
@@ -925,6 +937,9 @@ class RPG2k
         @events.each do |e|
           ch = e[:char]
           @state.map_event_positions[e[:id]] = [ch.x, ch.y, ch.direction]
+          # Also keeps @event_last_position current for #event_id_at's hidden-
+          # event fallback -- see #build_events' seeding comment.
+          @event_last_position[e[:id]] = [ch.x, ch.y, ch.direction]
         end
       end
 
@@ -3048,17 +3063,31 @@ class RPG2k
       # longer blocks or draws (yado.tk: "Get Event ID at Location... still
       # returns an id for a temporarily-erased event") -- #erase_event freezes
       # its tile in @erased_event_positions instead of dropping it outright.
-      # An event whose current page conditions aren't met is a separate,
-      # still-open half of the same claim: it never gets a Game::Character
-      # built at all (see #build_events), so there is no position to answer
-      # from without deciding what "its" position even means while hidden --
-      # unverified, left for a follow-up.
+      # An event whose current page conditions aren't met answers too, from
+      # @event_last_position (its raw placement, or wherever it last stood
+      # while its own page was still active) -- verified against EasyRPG
+      # Player's actual C++ source rather than left a guess: real RPG_RT keeps
+      # one Game_Event object per map event for the whole visit regardless of
+      # page state (Game_Event::RefreshPage, src/game_event.cpp, clears the
+      # active page and sets Through Mode on a no-match but never touches
+      # x/y), and Game_Interpreter::CommandStoreEventID's own lookup,
+      # Game_Map::GetEventAt(x, y, /* require_active */ false)
+      # (src/game_map.cpp), explicitly passes false so an inactive event is
+      # still matched by position. Both fallback tables are checked with the
+      # same last-write-wins tie-break as the live table, so several ids
+      # sharing a tile -- live, erased and hidden in any mix -- still resolve
+      # to the highest of them.
       def event_id_at(x, y)
         best = 0
         ev = @event_tiles[[x, y]]
         best = ev[:id] if ev
         @erased_event_positions.each do |id, tile|
           best = id if tile == [x, y] && id > best
+        end
+        live_ids = @events.each_with_object({}) { |e, h| h[e[:id]] = true }
+        @event_last_position.each do |id, pos|
+          next if live_ids[id] || @erased_events[id]
+          best = id if pos[0] == x && pos[1] == y && id > best
         end
         best
       end
@@ -6573,6 +6602,7 @@ class RPG2k
         # next map, and the destination's pages are chosen fresh.
         @erased_events = {}
         @erased_event_positions = {}
+        @event_last_position = {}
         # A saved wandered position is scoped to the map it was taken on --
         # event ids repeat per map, so carrying this forward would misapply a
         # stale entry to an unrelated event on the destination map. Dropped

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3421,6 +3421,57 @@ check 'a live event still outranks a lower-id temporarily-erased event on the sa
      'the live higher id wins over the erased lower-id event'
 end
 
+check 'Store Event ID resolves an event whose page conditions have never been met' do
+  # yado.tk's "Get Event ID at Location" claim had a second, previously-open
+  # half: an event whose current page conditions simply aren't met never gets
+  # a Game::Character built at all (#build_events skips it outright), so
+  # there was no position to answer from. Verified against EasyRPG Player's
+  # actual C++ source rather than guessed at: real RPG_RT keeps one
+  # Game_Event object per map event for the whole visit regardless of page
+  # state (Game_Event::RefreshPage, src/game_event.cpp, clears the active
+  # page on a no-match but never touches x/y), and
+  # Game_Interpreter::CommandStoreEventID's own lookup,
+  # Game_Map::GetEventAt(x, y, /* require_active */ false) (src/game_map.cpp),
+  # explicitly passes false so an inactive event still matches by position.
+  hidden = page(trigger: 0)
+  hidden.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 5)
+  scene = new_scene({ 2 => event(2, 2, hidden) }, player: [0, 0])
+  5.times { scene.update }
+  ok event_hashes(scene)[2].nil?, 'the condition never held, so nothing is on the map'
+  eq 2, scene.event_id_at(2, 2), 'it still answers at its raw map placement'
+  eq 0, scene.event_id_at(0, 0), 'an ordinary empty tile still answers 0'
+end
+
+check 'Store Event ID resolves a hidden event at wherever it stood before its page stopped matching' do
+  # Distinguishes the fallback from a naive "always answer at the raw spawn
+  # tile": the event walks two tiles east via a Custom move route while its
+  # page is active, then the page's own gating switch turns off -- it should
+  # answer at its last-known (4, 2), not back at its (2, 2) spawn tile.
+  gated = page(trigger: 0, x_move_type: Game::MoveType::CUSTOM,
+               route: move_route([R::MOVE_RIGHT, R::MOVE_RIGHT], repeat: false))
+  gated.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 5)
+  scene = new_scene({ 2 => event(2, 2, gated) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.switches[5] = true
+  40.times { scene.update } # walks right twice and settles at (4, 2)
+  eq [4, 2], [chars(scene)[2].x, chars(scene)[2].y], 'the route finished'
+
+  st.switches[5] = false
+  5.times { scene.update }
+  ok event_hashes(scene)[2].nil?, 'the condition no longer holds, so it drops off the map'
+  eq 2, scene.event_id_at(4, 2), 'it still answers at its last-known tile, not its spawn tile'
+  eq 0, scene.event_id_at(2, 2), 'its old spawn tile does not still answer for it'
+end
+
+check 'a hidden event still outranks a lower-id live event sharing its old tile' do
+  gated = page(trigger: 0)
+  gated.condition = OpenStruct.new(flags: Game::EventPage::SWITCH_A, switch_a_id: 5)
+  scene = new_scene({ 5 => event(3, 1, gated), 2 => event(3, 1, page) }, player: [0, 0])
+  5.times { scene.update }
+  eq 5, scene.event_id_at(3, 1),
+     'the higher-id hidden event still wins over the live lower-id event'
+end
+
 check 'Proceed With Movement holds the interpreter until a forced route finishes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Get Event ID at Location" bullet (under "Map/Event ID assignment & tile occupancy") had a second half explicitly left open: an event whose current page conditions simply aren't met never gets a `Game::Character` built at all (`Scene::Map#build_events` skips it outright), so `#event_id_at` (the Store Event ID command's query) had no position to answer from and silently read back 0 there for the rest of the visit.
- Settled against EasyRPG Player's actual C++ source rather than guessed at: real RPG_RT keeps one `Game_Event` object per map event for the whole visit regardless of page state — `RefreshPage()` (`src/game_event.cpp`) only clears the active page and forces Through Mode on when no page matches, never touching `x`/`y` — and `Game_Interpreter::CommandStoreEventID`'s own lookup, `Game_Map::GetEventAt(x, y, /* require_active */ false)` (`src/game_map.cpp`), explicitly passes `false`, so an inactive event is still matched by position exactly like a live one.
- Fixed with a new per-visit `@event_last_position` hash (`mruby-rpg2k/mrblib/scene/map.rb`), the same shape as the already-fixed `@erased_event_positions`: `#build_events` seeds an id's entry from its raw `ev.x`/`ev.y` map placement the first time it ever sees that id this visit, and `#record_map_event_positions` — already running every frame over every live event to drive the pre-existing save/reload wandered-position feature — now also keeps this table current, so an event that walked somewhere via its own page before losing it is found at wherever it actually stood, not snapped back to its spawn tile. `#event_id_at` falls back to it for any id neither currently live nor erased, with the same highest-id tie-break the erased-event fallback already uses. Both tables reset on a genuine map change (`#perform_teleport`), matching every other per-visit event-state table in this file.
- `docs/TODO.md` updated ✅.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 751 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 461 checks pass (3 new: an event whose page condition has never once held still answers Store Event ID at its raw map placement; an event that walked two tiles via a Custom move route before its gating switch turned off answers at that last-known tile, not its spawn tile; a hidden event still outranks a lower-id live event sharing its old tile), all three confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass (untouched by this change; re-run per the fixture-regression note in this repo's own CI history)
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass (real `mtf-meido-action` test-bed)
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean (real `mtf-meido-action` test-bed, 3430 commands)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWKSqocRt9BHTASijM9Q5g)_