### PR TITLE
docs: record wine-verified Skill-screen confirmation and menu-nav reachability wall

### DIFF
--- a/changelog.d/rpg2k-menu-wine-survey-notes.changed.md
+++ b/changelog.d/rpg2k-menu-wine-survey-notes.changed.md
@@ -1,0 +1,9 @@
+- Documentation only: `docs/TODO.md` now records that the Skill screen's
+  empty-list fix (from the previous change) is wine-confirmed against genuine
+  `RPG_RT.exe`, not just inferred from the identical Item-screen code path,
+  and documents a reachability wall hit while extending the same wine
+  comparison to the Equip and Save screens -- confirming the menu cursor
+  moves correctly under Xvfb/wine but the follow-up confirm key reliably
+  fails to register two or more cursor positions in, across every timing,
+  window-targeting and key-choice variant tried. Left as a note for whoever
+  picks up that comparison next, rather than a guessed-at engine fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2098,7 +2098,10 @@ The work below is roughly ordered by the critical path to a walkable game
   but empty cursor, no text -- `Scene::ItemMenu`/`Scene::SkillMenu` instead
   drew a hardcoded English "No items"/"No skills" (the only menu text in
   either scene not sourced through `term(...)`) and collapsed the cursor to
-  zero height. Both fixed to match.
+  zero height. Both fixed to match -- **the Skill side is now wine-confirmed
+  too**, not just inferred from the identical Item-screen code pattern: once
+  reachable at all (see the reachability note below), RPG_RT's empty Skill
+  screen showed the same blank cursor row, no "no skills" text.
   **Left open by the same comparison, not fixed here:**
   - The Item/Skill list windows stay full-`SCREEN_W` wide even with nothing
     in them, where RPG_RT's own list window in that state is narrower (looks
@@ -2122,6 +2125,27 @@ The work below is roughly ordered by the critical path to a walkable game
     obvious dedicated slot for this message to source from, so whether RPG_RT
     shows *any* text here at all is still an open question rather than an
     assumed one.
+  **A harness reachability wall, worth recording for whoever extends this
+  comparison next:** navigating the field menu's command list under wine and
+  then confirming is unreliable past the *second* cursor position. Escape
+  (open the menu) and a bare confirm from the freshly-opened menu (position
+  0, Item) work every time; one Down then a confirm (position 1, Skill)
+  eventually lands if the confirm key is retried several times a second
+  apart; two Downs then a confirm (position 2, Equip, and by extension
+  position 3, Save) never lands, across every combination tried -- longer
+  per-key settle (up to 2.5s), re-resolving and re-activating the window
+  before every single key, an explicit numeric window id (RPG_RT opens
+  *two* `HWND`s both titled "Nepheshel Ver2.04b"; pinning either one made no
+  difference), swapping the confirm key from Return to Z, and retrying the
+  confirm up to 6 times with a pixel-diff check to stop as soon as the frame
+  actually changes. The Down presses themselves are never in doubt -- the
+  menu cursor visibly moves to the right row every time -- only the
+  following confirm is the problem, and only two-or-more-Downs deep. Ruled
+  out as an explanation: `equipment_fixed` on the actor (false), and the
+  equipped items resolving to invalid database ids (all five resolve
+  cleanly). This reads as an Xvfb/wine/xdotool input-queue quirk rather than
+  anything about the engine being compared, but it blocked getting genuine
+  RPG_RT frames for the Equip and Save screens in this pass.
 
 #### Assets & infrastructure
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an


### PR DESCRIPTION
## Summary

Docs-only follow-up to #669, continuing the same wine-based field-menu survey. No code changes.

- The Skill screen's empty-list fix (from #669) is now confirmed directly against genuine `RPG_RT.exe` under wine, not just inferred from the identical Item-screen code path — once reachable, RPG_RT's empty Skill list showed the same blank cursor row with no "no skills" text.
- Documents a reachability wall hit while trying to extend the comparison to the Equip and Save screens: the field menu's Down-navigation always registers correctly under wine (the cursor visibly moves to the right row every time), but the follow-up confirm key reliably fails to register two or more cursor positions deep (Equip, Save) — while it works fine at position 0 (Item, immediately) and position 1 (Skill, with a few retries).
- Ruled out as explanations, for the record: `equipment_fixed` on the actor (false), the equipped items resolving to invalid database ids (all five resolve cleanly), and RPG_RT opening two `HWND`s both titled "Nepheshel Ver2.04b" (pinning either one made no difference). Tried and didn't help: settle times up to 2.5s, re-activating the window before every key, swapping Return for Z, and retrying the confirm up to 6 times with a pixel-diff check to stop as soon as the frame actually changes.
- This reads as an Xvfb/wine/xdotool input-queue quirk specific to this sandboxed environment rather than anything about the engine being compared, but it's left as a documented note (in `docs/TODO.md`) for whoever next extends `scripts/compare-nepheshel-wine.bash`-style harnesses to the Equip/Save screens, rather than guessed around.

## Test plan

N/A — documentation only, no code changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_