### PR TITLE
rpg2k: Screen/Picture/Flash Sprite waits now block a Parallel Process

### DIFF
--- a/changelog.d/parallel-process-screen-picture-flash-wait.fixed.md
+++ b/changelog.d/parallel-process-screen-picture-flash-wait.fixed.md
@@ -1,0 +1,16 @@
+- **A Parallel Process's own screen-effect, Move Picture, or Flash Sprite
+  command now actually blocks that process when its wait flag is set,**
+  instead of reading as a fire-and-forget no-op. `Scene::Map#
+  drive_parallel_wait` had no case for the `:screen` (Erase/Show/Tint/Flash/
+  Pan/Shake Screen), `:picture` (Move Picture), or `:sprite_flash` (Flash
+  Sprite) wait kinds — only the foreground's own `#drive_event` did — so a
+  Common Event or Map Event Parallel Process issuing any of these commands
+  with "wait for completion" set fell into the generic "background: ignore
+  message/choice requests" resume branch and resumed on the very next tick
+  regardless; the effect itself already ran (`#apply_interpreter_requests`
+  applies a parallel process's own requests too), only the wait never held
+  the process up. Fixed by adding the same three predicate checks
+  `#drive_event`'s own dispatch already uses (`@state.screen.busy?`,
+  `@state.pictures_moving?`, `sprite_flashing?`) to `#drive_parallel_wait`.
+  Covered by three new `scripts/rpg2k_scene_check.rb` checks, all three
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3406,6 +3406,49 @@ not yet verified:
   after parking on its own trailing Wait). The rest of this bullet — within
   one group, one command block at a time, round-robin, yielding at a blocking
   command, ascending-id order — was already correct and needed no change.
+- ✅ **A screen-effect or Move Picture/Flash Sprite command's own wait flag,
+  issued from a Parallel Process, now actually blocks that process — same
+  defect class as the already-fixed Proceed With Movement and Transfer
+  Player cases just above, now closed for the remaining wait kinds those two
+  fixes' own comments enumerated as still missing.** `Scene::Map#
+  drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) — the dispatch
+  `#step_parallel` uses for whichever wait kind a parallel-process
+  interpreter is parked on — had cases for `:wait`/`:key_input`/
+  `:animation`/`:game_over`/`:movement`/`:teleport` but none for `:screen`
+  (Erase/Show/Tint/Flash/Pan/Shake Screen, all six of which share this one
+  wait kind — `Game::Interpreter#do_erase_screen`/`#do_show_screen`/
+  `#do_tint_screen`/`#do_flash_screen`/`#do_pan_screen`/`#do_shake_screen`,
+  `interpreter.rb`), `:picture` (Move Picture's own wait flag,
+  `#do_move_picture`) or `:sprite_flash` (Flash Sprite's own wait flag,
+  `#do_flash_sprite`) — each of the three fell into the generic `else`
+  branch (`it.resume # background: ignore message/choice requests`) and
+  resumed unconditionally on the very next tick regardless of the issuing
+  command's own wait flag, exactly the "fire-and-forget no-op" failure mode
+  already documented and fixed for `:movement`/`:teleport` above. The
+  foreground's own `#drive_event` already had the matching cases (`when
+  :screen then @interpreter.resume unless @state.screen.busy?`; `when
+  :picture then @interpreter.resume unless @state.pictures_moving?`; `when
+  :sprite_flash then @interpreter.resume unless sprite_flashing?`), so an
+  Autorun's own screen fade/picture move/sprite flash always blocked
+  correctly; only the identical commands issued from a Parallel Process
+  (a Common Event's or a map event's own) were affected — the effect itself
+  already started regardless, since `#apply_interpreter_requests` (which
+  actually applies a screen/picture/flash write) runs for a parallel
+  process's own requests exactly as it does for the foreground's, only the
+  *wait* never held anything up. Fixed by adding the same three cases to
+  `#drive_parallel_wait`, each the identical pure-predicate check
+  `#drive_event`'s own dispatch already uses — no stepping logic needed,
+  since `Game::Screen`/`Game::State#pictures`/`#update_sprite_flashes` are
+  already advanced once per frame elsewhere in `#update`, the same reasoning
+  the `:movement` fix's own comment gives for calling `#forced_movement_done?`
+  rather than re-stepping anything itself. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (a Parallel Process's Erase Screen
+  holds its own follow-up Control Switches command until the fade settles;
+  its Move Picture holds until the picture reaches its target; its Flash
+  Sprite holds until the flash decays), all three confirmed to fail against
+  the pre-fix code before the fix (each follow-up command ran immediately,
+  one frame after the triggering command, instead of waiting for the effect
+  to finish).
 - A parallel process reaching its own loop end and restarting always costs
   ~1/60s (an implicit one-frame gap), independent of any explicit Wait.
 - "Hero Touch" (trigger 1) does **not** fire in three specific cases

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1394,6 +1394,25 @@ class RPG2k
           # its context is gone post-transfer".
           perform_teleport(it.teleport)
           it.resume
+        elsif it.wait_kind == :screen
+          # Erase/Show/Tint/Flash/Pan/Shake Screen issued with its own wait
+          # flag from a Parallel Process: block that process until the effect
+          # settles, the same as #drive_event's own :screen branch does for
+          # the foreground. Before this branch existed this fell into the
+          # generic #resume below, so a background screen-effect wait was a
+          # fire-and-forget no-op regardless of "wait for completion" set on
+          # the command -- the effect itself already ran (#apply_interpreter_
+          # requests runs for a parallel process's own requests too), only
+          # the wait never actually held anything up.
+          it.resume unless @state.screen.busy?
+        elsif it.wait_kind == :picture
+          # Move Picture's own wait flag, the parallel-process equivalent of
+          # the :screen case just above.
+          it.resume unless @state.pictures_moving?
+        elsif it.wait_kind == :sprite_flash
+          # Flash Sprite's own wait flag, the parallel-process equivalent of
+          # the :screen/:picture cases just above.
+          it.resume unless sprite_flashing?
         else
           it.resume # background: ignore message/choice requests
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3666,6 +3666,90 @@ check "Proceed With Movement blocks a Parallel Process's own interpreter, not ju
   ok st.switches[1], 'the Parallel Process resumed once the route actually finished'
 end
 
+check "Erase Screen's own wait flag blocks a Parallel Process's own interpreter, " \
+      'not just the foreground\'s' do
+  # Same defect class as Proceed With Movement/Transfer Player above:
+  # #drive_parallel_wait had no :screen case at all, so Erase/Show/Tint/
+  # Flash/Pan/Shake Screen issued from a Parallel Process fell into the
+  # generic "background: ignore ..." #resume branch and read as fire-and-
+  # forget regardless of the command's own wait flag -- the fade itself
+  # already ran (#apply_interpreter_requests applies a parallel process's
+  # own screen writes too, unaffected by this fix), only the wait never
+  # actually held the process up.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 4)
+  pg.event_commands = [
+    ECmd.new(ic::ERASE_SCREEN, [0]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(2, 2, pg) })
+  st = scene.instance_variable_get(:@state)
+
+  scene.update # runs Erase Screen -> suspends on :screen
+  ok !st.switches[1],
+     'the Parallel Process must wait too, not resume immediately'
+  ok st.screen.fading?, 'the fade is in progress'
+
+  40.times { scene.update } # the scene advances Game::Screen each frame
+  ok st.screen.erased?, 'the screen fully erased'
+  ok st.switches[1], 'the Parallel Process resumed once the fade settled'
+end
+
+check "Move Picture's own wait flag blocks a Parallel Process's own interpreter, " \
+      'not just the foreground\'s' do
+  # Same defect class as the Erase Screen check just above, for the :picture
+  # wait kind #drive_parallel_wait also had no case for.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 4)
+  pg.event_commands = [
+    ECmd.new(ic::MOVE_PICTURE,
+             [1, 0, 200, 200, 0, 100, 0, 0, 100, 100, 100, 100, 0, 0, 10, 1]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(2, 2, pg) })
+  st = scene.instance_variable_get(:@state)
+  st.pictures[1] = Game::Picture.new(1, x: 100, y: 100)
+
+  scene.update # runs Move Picture -> suspends on :picture
+  ok !st.switches[1],
+     'the Parallel Process must wait too, not resume immediately'
+  ok st.pictures[1].moving?, 'the picture is still moving toward its target'
+
+  70.times { scene.update } # 10 tenths (60 frames) is plenty
+  eq [200, 200], [st.pictures[1].x, st.pictures[1].y],
+     'the picture reached its target'
+  ok st.switches[1], 'the Parallel Process resumed once the move settled'
+end
+
+check "Flash Sprite's own wait flag blocks a Parallel Process's own interpreter, " \
+      'not just the foreground\'s' do
+  # Same defect class as the two checks just above, for the :sprite_flash
+  # wait kind #drive_parallel_wait also had no case for.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 4)
+  # 1 tenth (6 frames) with the wait flag set, then a switch flip that only
+  # runs once the flash is over. The page has no gate of its own, so once the
+  # switch flips the loop immediately re-issues the same Flash Sprite for its
+  # next lap -- fine here, since only the *first* lap's timing is asserted,
+  # not that the hero stops flashing for good.
+  pg.event_commands = [
+    ECmd.new(ic::FLASH_SPRITE, [10001, 31, 0, 0, 31, 1, 1]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  scene.update # runs Flash Sprite -> suspends on :sprite_flash
+  ok scene.instance_variable_get(:@player_flash), 'the hero is flashing'
+  ok !st.switches[1], 'the Parallel Process must wait too, not resume immediately'
+
+  4.times { scene.update } # still mid-flash (6-frame duration)
+  ok !st.switches[1], 'still waiting partway through the flash'
+
+  10.times { scene.update } # comfortably past the 6-frame decay
+  ok st.switches[1], 'the Parallel Process resumed once the flash finished'
+end
+
 check "a forced route auto-runs to completion before an immediately-following Show Text opens (yado.tk)" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `Scene::Map#drive_parallel_wait` (`mruby-rpg2k/mrblib/scene/map.rb`) — the dispatch `#step_parallel` uses for whichever wait kind a parallel-process interpreter is parked on — had cases for `:wait`/`:key_input`/`:animation`/`:game_over`/`:movement`/`:teleport` but none for `:screen` (Erase/Show/Tint/Flash/Pan/Shake Screen), `:picture` (Move Picture's own wait flag) or `:sprite_flash` (Flash Sprite's own wait flag). Each of the three fell into the generic `else` branch (`it.resume # background: ignore message/choice requests`) and resumed unconditionally on the very next tick, regardless of the issuing command's own "wait for completion" flag — the same fire-and-forget defect class already fixed in this codebase for `:movement` (Proceed With Movement) and `:teleport` (Transfer Player) issued from a Parallel Process.
- The foreground's own `#drive_event` already had the matching cases (`@state.screen.busy?`, `@state.pictures_moving?`, `sprite_flashing?`), so an Autorun's screen fade/picture move/sprite flash always blocked correctly; only the identical commands issued from a Common Event's or a map event's own Parallel Process were affected. The effect itself already started regardless (`#apply_interpreter_requests` applies a parallel process's own requests too), only the *wait* never held anything up.
- Fixed by adding the same three pure-predicate checks `#drive_event`'s own dispatch already uses to `#drive_parallel_wait`.
- Updated `docs/TODO.md`'s "Multiple simultaneous parallel processes are not concurrent" entry with a dense, evidence-citing paragraph, and added a `changelog.d` fragment.

## Test plan
- Added three new `scripts/rpg2k_scene_check.rb` checks: a Parallel Process's `Erase Screen` holds its own follow-up `Control Switches` command until the fade settles; its `Move Picture` holds until the picture reaches its target; its `Flash Sprite` holds until the flash decays. All three confirmed to fail against the pre-fix code (via `git stash` of just `mruby-rpg2k/mrblib/scene/map.rb`) before the fix.
- Ran all five CI scripts and confirmed they pass: `rpg2k_logic_check.rb` (752 checks), `rpg2k_scene_check.rb` (464 checks), `rpg2k_render_check.rb` (40 checks), `rpg2k_testbed_logic_check.rb` (skips — no local game data, matches baseline), `rpg2k_command_soak.rb` (skips — no local game data, matches baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDJkLQHWkkLsQAZhk9751G

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDJkLQHWkkLsQAZhk9751G)_