### PR TITLE
rpg2k: chained Show Battle Animation calls no longer lose an extra frame

### DIFF
--- a/changelog.d/show-battle-animation-back-to-back-stutter.fixed.md
+++ b/changelog.d/show-battle-animation-back-to-back-stutter.fixed.md
@@ -1,0 +1,22 @@
+- **Chaining two Show Battle Animation (11210) calls back-to-back — waiting
+  for the first, then immediately issuing another — no longer loses an extra
+  real frame between them.** EasyRPG Player's own `Game_Interpreter::Update`
+  (`src/game_interpreter.cpp`) is a loop whose only wait-time check is `if
+  (_state.wait_time > 0) { _state.wait_time--; break; }` — it stops
+  processing for the frame *only while* the countdown is still above zero, so
+  the exact real frame a waited-for animation's own duration reaches 0 falls
+  straight through into whatever command follows instead of costing a
+  further frame, the same "spend this frame's own step budget immediately"
+  rule already ported here for Wait 0.0s and the Battle "Lose: Branch" race.
+  `Scene::Map#drive_event`'s `:animation` case used to just call
+  `#drive_map_animation` and stop, unlike the `:wait`/`:battle` cases beside
+  it in the same dispatch — so a command chained right after a finished Show
+  Battle Animation always ran one real frame later than real RPG_RT. Fixed
+  for both the foreground interpreter (`#drive_event`) and a Common Event
+  Parallel Process's own chained calls (`#step_parallel`'s wait-kind
+  dispatch, which previously gave this same-frame treatment only to
+  `:wait`). A separate, structural one-frame startup latency this codebase's
+  request/dispatch split still has for *any* Show Battle Animation (not
+  specific to chaining) remains open. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4738,8 +4738,10 @@ not yet verified:
   the slot is held simply waited its turn — since resolving it needed a real
   RPG_RT comparison this environment could not run; ✅ **now fixed, settled
   against EasyRPG Player's actual C++ source** (see the fuller writeup a few
-  bullets below). "Back-to-back calls stutter" is
-  likewise still open. Covered by two new `scripts/rpg2k_scene_check.rb`
+  bullets below). ✅ **"Back-to-back calls stutter" now loses one fewer
+  frame too** (see the fuller writeup further below — a structural one-frame
+  startup latency remains, not fully closed). Covered by two new
+  `scripts/rpg2k_scene_check.rb`
   checks (a parallel process's Show Battle Animation holds it, then resumes
   once the animation finishes; the animation actually renders — sprite
   shown, screen flash fired — for a parallel-process request, not just a
@@ -4884,7 +4886,7 @@ not yet verified:
   count (still frame 0 after 2 ticks, advances to frame 1 on the 3rd),
   confirmed to fail against the pre-fix code (`expected 2, got 3`) before
   the fix. "Back-to-back calls stutter" (the bullet's third, unrelated
-  claim) remains open, as noted above.
+  claim) is ✅ partly fixed now too, see further below.
 - ✅ **`ANIM_FLASH_FRAMES` — how long a Battle Animation's own fired
   screen/target flash stays visible before the animation forcibly clears it
   again — is now 11, not 8.** The bullet directly above left this constant
@@ -4956,8 +4958,9 @@ not yet verified:
   ticking rather than resuming the instant it loses the slot — matching that
   exactly would need this build to precompute and track each request's own
   duration independently of the shared visual object too, a larger change
-  than the observable "does the first get cut off" fact this closes; "Back-
-  to-back calls stutter" remains open as before. Covered by a new
+  than the observable "does the first get cut off" fact this closes; ✅
+  "Back-to-back calls stutter" is partly fixed too now (a chained *non-cut-off*
+  pair, not this cut-off case), see further below. Covered by a new
   `scripts/rpg2k_scene_check.rb` check (two Common Event Parallel Processes,
   the first parked on a long ~20-frame fallback-wait animation and the
   second issuing its own drawable one a few frames later: the shared slot
@@ -5009,6 +5012,60 @@ not yet verified:
   command right away regardless, confirmed to fail against the pre-fix code
   (the slot still showing the first request, the second's own request
   silently and permanently lost) before the fix.
+- ✅ **"Chaining two Show Battle Animation calls back-to-back produces a
+  visible one-frame stutter" — the erroneous extra frame of it is now fixed,
+  verified against EasyRPG Player's actual C++ source rather than guessed
+  at.** `Game_Interpreter::Update` (`src/game_interpreter.cpp`) is a `for`
+  loop whose only wait-time check is `if (_state.wait_time > 0) {
+  _state.wait_time--; break; }` — it only stops processing for the frame
+  *while* `wait_time` is still above zero, so the exact real frame a
+  waited-for Show Battle Animation's own countdown (`_state.wait_time`, set
+  from `Game_Screen::ShowBattleAnimation`'s returned frame count) reaches 0
+  falls straight through into whatever command follows instead of costing a
+  further frame — the identical "spend this frame's own step budget
+  immediately" rule this codebase had already ported for Wait 0.0s and for
+  the Battle "Lose: Branch" race (see those bullets above). `Scene::Map#
+  drive_event`'s `:animation` case (`mruby-rpg2k/mrblib/scene/map.rb`) used
+  to just call `#drive_map_animation` and stop there — unlike the `:wait`/
+  `:battle` cases right above it in the same dispatch, which already re-drive
+  the interpreter the instant they come off their own wait — so `#drive_map_
+  animation` resuming `@interpreter` when its own animation finished
+  naturally (not cut off by a different request, which resumes that *other*
+  interpreter instead) left it merely unparked, with nothing to drive it any
+  further until the *next* real frame's `#drive_event` call: a command
+  chained right after a finished Show Battle Animation, a second one
+  included, always ran one real frame later than real RPG_RT. Fixed by
+  adding the same "spend this frame's own step budget immediately" follow-up
+  used elsewhere: once `#drive_map_animation` returns, `:animation` now also
+  calls `@interpreter.update`/`#apply_interpreter_requests` immediately when
+  `@interpreter.running? && !@interpreter.waiting?` reads true afterward. A
+  **Common Event Parallel Process's own** chained calls had the identical
+  gap in `#step_parallel`'s dispatch: only a `:wait` wait-kind got this
+  same-frame treatment (`unless wait_kind == :wait && !it.waiting?`), so
+  `:animation` kept "old one-frame-per-call pacing" even when *this*
+  process's own animation had just finished naturally — fixed by widening
+  that condition to also cover `:animation`. (A process cut off by a
+  *different* one is unaffected either way: that resume happens on the
+  *other* process's own turn, via `#drive_map_animation`'s existing cut-off
+  branch, a separate code path from this check.) **Not fully closed**: this
+  codebase still has its own extra, structural one-frame startup latency no
+  fix here touches — `Game::Interpreter#do_show_battle_animation` only arms
+  the `:animation` wait (`@wait_kind`/`@waiting`) when the wait flag is set,
+  deferring the actual `#begin_map_animation` call (and the sprite's first
+  visible frame) to the *next* time `#drive_event`/`#step_parallel` reaches
+  the `:animation` dispatch, rather than starting it synchronously the
+  instant the command executes the way EasyRPG's own `Game_Interpreter_Map::
+  CommandShowBattleAnimation` calls `Game_Screen::ShowBattleAnimation`
+  in-line before ever touching `_state.wait_time` — a materially larger,
+  separate architectural change (this build's request/dispatch split, not
+  its wait-resolution timing) left as still open. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (foreground and Common Event
+  Parallel Process alike: two Show Battle Animation calls chained back to
+  back, with a Control Switches marker after each — the marker right after
+  the first now flips the exact same real frame the first animation's
+  sprite goes invisible, not one frame later, and the second animation still
+  plays through to its own trailing marker), both confirmed to fail (`expected
+  N, got N+1`) against the pre-fix code before the fix.
 - ✅ **Show Battle Animation (11210) targeting a vehicle now plays over that
   vehicle's own live position**, instead of silently defaulting to the
   player's. `Scene::Map#animation_target_pixel` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1275,9 +1275,20 @@ class RPG2k
           # A plain Wait resolves the instant its timer elapses; keep spending
           # this same frame's step budget instead of losing a frame to the
           # resume, matching drive_event's foreground handling (see there for
-          # why: Wait 0.0 sec must cost exactly one frame). Other wait kinds
-          # keep their old one-frame-per-call pacing.
-          unless wait_kind == :wait && !it.waiting?
+          # why: Wait 0.0 sec must cost exactly one frame). A Show Battle
+          # Animation's own :animation wait gets the identical same-frame
+          # treatment now too, for the identical reason (see #drive_event's
+          # own :animation case): when *this* process's own animation
+          # finishes naturally inside #drive_map_animation (not cut off by a
+          # different process -- that resumes the *other* interpreter, from
+          # its own step_parallel turn, and is unaffected by this check), it
+          # used to sit merely unparked until the next real frame's
+          # step_parallel call before its own next command ever ran, one
+          # frame later than real RPG_RT -- yado.tk's "chaining two Show
+          # Battle Animation calls back-to-back produces a visible one-frame
+          # stutter", the parallel-process half. Other wait kinds keep their
+          # old one-frame-per-call pacing.
+          unless (wait_kind == :wait || wait_kind == :animation) && !it.waiting?
             apply_interpreter_requests(it, p[:event])
             return record_parallel_progress(p)
           end
@@ -3202,7 +3213,27 @@ class RPG2k
           when :return_title then perform_return_to_title
           when :game_over then perform_game_over
           when :name_input then drive_name_input
-          when :animation then drive_map_animation(@interpreter)
+          when :animation
+            drive_map_animation(@interpreter)
+            # Same "spend this frame's own step budget immediately" idiom as
+            # :wait/:battle above: EasyRPG's own Game_Interpreter::Update loop
+            # only breaks early *while* `_state.wait_time` is still > 0 (`if
+            # (_state.wait_time > 0) { _state.wait_time--; break; }`) -- once a
+            # waited-for Show Battle Animation's own countdown reaches exactly
+            # 0, that same real frame's Update call falls straight through
+            # into whatever command follows instead of costing a further
+            # frame. `#drive_map_animation` resuming `@interpreter` here (its
+            # own animation just finished naturally) used to leave it merely
+            # unparked -- nothing drove it any further until next frame's
+            # `#drive_event` -- so a second Show Battle Animation chained
+            # right after the first always showed its own frame 0 one real
+            # frame later than real RPG_RT: yado.tk's "chaining two Show
+            # Battle Animation calls back-to-back produces a visible
+            # one-frame stutter".
+            if @interpreter.running? && !@interpreter.waiting?
+              @interpreter.update
+              apply_interpreter_requests(@interpreter, @active_event)
+            end
           when :sprite_flash then @interpreter.resume unless sprite_flashing?
           when :save_menu then perform_event_save
           when :menu then perform_event_menu

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5819,6 +5819,87 @@ check 'a fire-and-forget Show Battle Animation also forcibly cuts off a still-pl
   ok st.switches[6], "CE2's own command list reached its trailing Control Switches (it was never blocked by its own no-wait animation)"
 end
 
+# yado.tk: "Battle Animation... chaining two Show Battle Animation calls
+# back-to-back produces a visible one-frame stutter." Settled against
+# EasyRPG's actual C++ source rather than guessed at: `Game_Interpreter::
+# Update`'s own per-frame loop is `if (_state.wait_time > 0) { _state.wait_time
+# --; break; }` -- it only breaks early *while* wait_time is still above zero,
+# so the exact real frame a waited-for Show Battle Animation's own countdown
+# reaches 0 falls straight through into whatever command follows instead of
+# costing a further frame. `#drive_event`'s `:animation` case used to just call
+# `#drive_map_animation` and stop -- unlike the `:wait`/`:battle` cases right
+# above it, which already spend the rest of the frame's own step budget the
+# instant they come off their wait -- so a command chained right after a
+# finished Show Battle Animation (a second one included) always ran one real
+# frame later than real RPG_RT.
+check 'a Show Battle Animation resumes its own event/process and runs the next command the same real ' \
+      'frame it finishes, not one frame later' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # animation 8 then a marker, chained straight into a second Show Battle
+  # Animation (animation 9) then a second marker -- the literal "chaining two
+  # Show Battle Animation calls back-to-back" case.
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0),
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [9, 10001, 1], indent: 0),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  spr = scene.instance_variable_get(:@animation_sprite)
+  finish_frame = nil
+  switch_frame = nil
+  40.times do |i|
+    was_visible = spr.visible
+    scene.update
+    finish_frame ||= i if was_visible && !spr.visible
+    switch_frame ||= i if st.switches[5]
+    break if st.switches[6]
+  end
+  ok finish_frame, 'the first animation actually finished'
+  ok switch_frame, 'the command right after it (marking switch 5) ran'
+  eq finish_frame, switch_frame,
+     "the trailing command runs the exact same real frame the first animation finishes, not one frame " \
+     'later'
+  ok st.switches[6], 'the second (chained) animation played through to its own trailing command too'
+end
+
+# Same fact, for a Common Event Parallel Process's own chained calls -- the
+# `#step_parallel` counterpart to the foreground fix directly above. Before
+# this fix, only a `:wait` wait-kind got the same-frame "spend this frame's
+# own step budget immediately" treatment there; `:animation` kept the old
+# one-frame-per-call pacing even when the process's own animation had just
+# finished naturally (as opposed to being cut off by a *different* process,
+# which resumes that other process from its own turn and is unaffected by
+# this).
+check "a Common Event Parallel Process's own chained Show Battle Animation calls run back-to-back too" do
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),
+                              ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0),
+                              ECmd.new(ic::SHOW_BATTLE_ANIM, [9, 10001, 1], indent: 0),
+                              ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  spr = scene.instance_variable_get(:@animation_sprite)
+  finish_frame = nil
+  switch_frame = nil
+  40.times do |i|
+    was_visible = spr.visible
+    scene.update
+    finish_frame ||= i if was_visible && !spr.visible
+    switch_frame ||= i if st.switches[5]
+    break if st.switches[6]
+  end
+  ok finish_frame, "the parallel process's first animation actually finished"
+  ok switch_frame, 'the command right after it (marking switch 5) ran'
+  eq finish_frame, switch_frame,
+     "a parallel process's own trailing command runs the exact same real frame its animation finishes, " \
+     'not one frame later, matching the foreground fix above'
+  ok st.switches[6], 'the second (chained) animation played through to its own trailing command too'
+end
+
 # yado.tk: RPG_RT drops straight into Game Over the instant a wipe-triggering
 # command finds the whole party dead outside battle, regardless of which
 # event noticed it -- a Simulated Attack floor trap on a background Parallel


### PR DESCRIPTION
## Summary

- Mines `docs/TODO.md`'s yado.tk "Full-site sweep" backlog: "chaining two Show Battle Animation calls back-to-back produces a visible one-frame stutter."
- Verified against EasyRPG Player's actual C++ source (`src/game_interpreter.cpp`'s `Game_Interpreter::Update`): its only wait-time check is `if (_state.wait_time > 0) { _state.wait_time--; break; }` — it only breaks early *while* the countdown is still above zero, so the exact real frame a waited-for Show Battle Animation's own duration reaches 0 falls straight through into whatever command follows instead of costing a further frame. This is the same "spend this frame's own step budget immediately" rule this codebase already ports for Wait 0.0s and the Battle "Lose: Branch" race.
- `Scene::Map#drive_event`'s `:animation` case used to just call `#drive_map_animation` and stop there — unlike the `:wait`/`:battle` cases right beside it in the same dispatch, which already re-drive the interpreter the instant they come off their own wait — so a command chained right after a finished Show Battle Animation (a second one included) always ran one real frame later than real RPG_RT.
- Fixed for both the foreground interpreter (`#drive_event`) and a Common Event Parallel Process's own chained calls (`#step_parallel`'s wait-kind dispatch, which previously only gave this same-frame treatment to `:wait`, not `:animation`).
- **Not fully closed**: this codebase has a separate, structural one-frame startup latency for *any* Show Battle Animation (not specific to chaining), since `#do_show_battle_animation` only arms the `:animation` wait and defers the actual animation build to the next `:animation` dispatch, rather than starting it synchronously the way EasyRPG's `Game_Interpreter_Map::CommandShowBattleAnimation` does. Left open as a materially larger architectural change, documented in `docs/TODO.md`.
- Updates `docs/TODO.md` with a dense, evidence-citing ✅ entry, and updates the three prior "still open"/"remains open" cross-references to this claim elsewhere in the same file.
- Adds a `changelog.d/show-battle-animation-back-to-back-stutter.fixed.md` fragment.

## Test plan

- Added two regression checks to `scripts/rpg2k_scene_check.rb`: a foreground event and a Common Event Parallel Process each chain two waited-for Show Battle Animation calls with a Control Switches marker between them, asserting the marker flips the exact same real frame the first animation's sprite goes invisible, not one frame later.
- Confirmed both new checks **fail** against the pre-fix `mruby-rpg2k/mrblib/scene/map.rb` (`git stash` of just that file): `expected 12, got 13` for both.
- Confirmed all five CI scripts pass on this branch:
  - `ruby scripts/rpg2k_logic_check.rb` — 752 checks passed
  - `ruby scripts/rpg2k_scene_check.rb` — 463 checks passed
  - `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
  - `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks passed (against a freshly downloaded `mtf-meido-action` test bed)
  - `ruby scripts/rpg2k_command_soak.rb` — 3430 commands, no raises/gaps


---
_Generated by [Claude Code](https://claude.ai/code/session_01HavkbeRHXExi6WCHVQ8Pyq)_