### PR TITLE
rpg2k: enemy AI skills that could never help are excluded from the weighted draw

### DIFF
--- a/changelog.d/enemy-ai-skill-effectiveness-gate.fixed.md
+++ b/changelog.d/enemy-ai-skill-effectiveness-gate.fixed.md
@@ -1,0 +1,21 @@
+- An enemy's own **AI action pattern** no longer offers a self/ally-scope
+  skill that could not possibly help anyone. `Game::Battle#choose_enemy_
+  action`'s weighted draw gated a skill action only on affordability and
+  silence (`#enemy_action_valid?`/`#enemy_skill_ready?`), with nothing
+  checking whether casting it would do anything — so a pure state-cure
+  action ("Cure Poison", say) with no target on the caster's own troop
+  actually carrying that state could still dominate the draw purely off
+  its own rating, casting a visible no-op turn after turn instead of
+  yielding to whatever else the pattern offered. Fixed with a new
+  `Game::Party#skill_helps_troop?`, ported from EasyRPG's
+  `EnemyAi::IsSkillEffectiveOnAnyTarget`/`IsSkillEffectiveOn`
+  (`src/enemyai.cpp`) and reusing the same no-op rule the field menu's own
+  `#skill_effective?` already applies to grey out a wasted cast, consulted
+  in a separate pass mirroring EasyRPG's own two-pass structure: an
+  ineffective skill's raw rating still counts toward the round's
+  `max_prio` (so it still crowds out other, lower-rated candidates exactly
+  as if it were still in the running), only its own draw is zeroed. A
+  party-scope skill (aimed at the player side) is never filtered this way,
+  matching real RPG_RT; nor is an HP/SP/stat-affecting skill, which the
+  real engine always considers worth trying against a live target
+  regardless of its actual HP/SP level.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4691,9 +4691,60 @@ not yet verified:
   Enemy action-pattern selection: candidates are patterns whose condition
   is currently true; the engine looks from the highest priority tier down
   to priority−9, computes a per-pattern weighted "importance" from battle
-  state, then rolls RNG against those weights. A turn-condition shorthand
-  like "3×?+5" means: first candidate on turn 5, then every 3 turns
-  after.
+  state, then rolls RNG against those weights (**confirmed already
+  correct** — `Game::Battle#choose_enemy_action`'s `pr - max_prio + 10`
+  clamp, `mruby-rpg2k/mrblib/game.rb`, is an exact port of EasyRPG's
+  `SelectEnemyAiActionRpgRtCompat`, src/enemyai.cpp). A turn-condition
+  shorthand like "3×?+5" means: first candidate on turn 5, then every 3
+  turns after. ✅ **A self/ally-scope skill action with no target it could
+  possibly help was still fully eligible for that weighted draw**, cross-
+  checked directly against EasyRPG's actual C++ source rather than the
+  paraphrase above, which says nothing about this: `SelectEnemyAiAction
+  RpgRtCompat` runs a *second*, separate pass after computing every
+  action's weight (`IsSkillEffectiveOnAnyTarget`, `src/enemyai.cpp`) that
+  zeroes a skill action's own draw when it could not possibly do anything
+  — a self/ally/troop-scope skill (2/3/4; a party-scope 0/1 skill is
+  *never* filtered this way, since RPG_RT never checks whether the party
+  side could be affected) whose only content is state-inflict/cure and
+  none of the caster's own troop currently carries a state it would touch.
+  This codebase's `enemy_action_valid?`/`enemy_skill_ready?`
+  (`Game::Battle`) checked only affordability and silence, with no such
+  filter at all, so a "Cure" action with nothing on the caster's side to
+  cure could still dominate the weighted draw purely off its own rating,
+  casting a visible no-op turn after turn instead of yielding to whatever
+  else the pattern offered. Fixed with a new `Game::Party#skill_helps_
+  troop?` (ported from `IsSkillEffectiveOnAnyTarget`/`IsSkillEffectiveOn`,
+  reusing the exact same no-op rule the field menu's own `#skill_effective?`
+  already applies to grey out a wasted cast), reached through a new
+  `Game::EnemyAi#skill_helps_troop?` and consulted in a *separate* pass in
+  `#choose_enemy_action`, mirroring EasyRPG's own two-pass structure
+  exactly rather than folding the check into `#enemy_action_valid?`: an
+  ineffective skill's raw rating still counts toward `max_prio` (and so
+  still crowds out *other*, lower-rated candidates exactly as if it were
+  still in the running) even though its own draw ends up zeroed — folding
+  the check earlier would have silently recomputed `max_prio` without it
+  and let a lower-rated action back into the draw that real RPG_RT would
+  never offer. This port always runs the *actual* RPG_RT behaviour
+  (EasyRPG's `emulate_bugs: true`, matching every other "authentic engine
+  vs. the improved variant" choice made elsewhere in this file), which
+  collapses two of the ported function's branches to a genuine engine bug:
+  a Knockout-flagged (state id 1) skill reads as effective on any hidden/
+  downed troop member purely from the flag being set, and an HP/SP/stat-
+  affecting skill (`affect_hp`/`affect_sp`/`affect_attack`/`affect_
+  defense`/`affect_spirit`/`affect_agility`) is *always* considered
+  effective on a live target regardless of its actual HP/SP level — RPG_RT
+  never computes the effect before choosing, so a self-heal at full HP is
+  not filtered by this mechanism (confirmed directly against the C++
+  source; an earlier draft of this fix wrongly assumed it would be, before
+  checking). Covered by three new `scripts/rpg2k_logic_check.rb` checks (a
+  lone state-cure action with nothing to cure now yields to the plain
+  default attack instead of always firing; the identical action still
+  fires normally once a target actually carries the state; a three-action
+  fixture pins the `max_prio`-crowds-out-a-lower-rated-action nuance
+  specifically, confirming a rating-49 guard stays excluded by an
+  ineffective rating-60 skill's own rating even though the skill itself
+  never fires), all three confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **An HP-increase cannot revive a downed (0 HP) combatant**, checked
   across all three paths that can raise HP. The **field actor** path
   (`Game::Actor#change_hp`, `mruby-rpg2k/mrblib/game.rb`) was already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3422,6 +3422,50 @@ module Game
       end
     end
 
+    # Whether an enemy AI's own self/ally/troop-scope skill action `sk` could
+    # possibly help anyone on `caster`'s side (`troop`, its full battle Combatant
+    # roster including out-of-play members) -- ported from EasyRPG's
+    # EnemyAi::IsSkillEffectiveOnAnyTarget / IsSkillEffectiveOn
+    # (src/enemyai.cpp), which the real engine consults before letting an
+    # AI-selected skill enter its weighted draw at all: an enemy-scope skill
+    # (0 single enemy / 1 all enemies, aimed at the *party*) is always
+    # considered worth trying -- RPG_RT never checks whether the party side
+    # could be affected -- so only scope 2/3/4 (self/single ally/all allies,
+    # always the caster's own troop) is filtered here, against `caster` alone
+    # for scope 2 or every troop member for 3/4 (the real engine does not
+    # distinguish single- from all-ally scope for this purpose, since a single
+    # target is chosen only after an action is already selected). This port
+    # always runs the *actual* RPG_RT behaviour (EasyRPG's `emulate_bugs: true`
+    # -- its alternate bug-fixed "RPG_RT+" algorithm is never selected here,
+    # matching every other "authentic engine vs. EasyRPG's improved variant"
+    # choice elsewhere in this file), which collapses two of the ported
+    # function's branches to their `emulate_bugs` side outright: a
+    # Knockout-flagged (state id 1, a revival) skill reads as effective on any
+    # hidden/downed troop member purely from the flag being set -- an
+    # authentic bug, ignoring `reverse_state_effect` and whether the target is
+    # actually the one that is dead -- and an RPG2003 ally-scope skill with
+    # `reverse_state_effect` set (see `#battle_skill_command`'s `heals_states`)
+    # is checked by whether the target already *has* the state, the same as
+    # an ordinary cure, rather than by whether inflicting it would do
+    # anything.
+    def skill_helps_troop?(sk, caster, troop)
+      return true unless Party.normal_skill?(sk)
+      scope = sk.respond_to?(:scope) ? sk.scope : 0
+      return true if scope == 0 || scope == 1
+      targets = scope == 2 ? [caster] : troop
+      states = skill_state_ids(sk)
+      targets.any? do |t|
+        next false unless t
+        if t.out_of_play?
+          states.include?(1)
+        else
+          sk.affect_hp || sk.affect_sp || !skill_stat_mod_keys(sk).empty? ||
+            states.any? { |sid| t.state?(sid) } ||
+            (sk.respond_to?(:affect_attr_defence) && sk.affect_attr_defence && !skill_attributes(sk).empty?)
+        end
+      end
+    end
+
     # Cast field skill `sid` from `caster` on `target` (scope-dependent). Applies
     # the skill's status changes then restores HP and/or SP by the skill effect to
     # each target (clamped), then spends the caster's SP -- but only when it
@@ -6019,6 +6063,18 @@ module Game
       party.battle_skill_command(sk, caster, target)
     end
 
+    # Whether `sk`, cast by `caster` against its own `troop`, could possibly
+    # help anyone -- reuses Game::Party's own #skill_helps_troop? formula so an
+    # enemy's own AI reads the exact same skill-effectiveness rules a field
+    # cast's greyed-out-if-a-no-op check does. Defaults to "always worth
+    # trying" without a party to ask, matching every other tolerant accessor
+    # here.
+    def skill_helps_troop?(sk, caster, troop)
+      party = @state && @state.respond_to?(:party) ? @state.party : nil
+      return true unless party && party.respond_to?(:skill_helps_troop?)
+      party.skill_helps_troop?(sk, caster, troop)
+    end
+
     def switch?(id)
       sw = @state && @state.respond_to?(:switches) ? @state.switches : nil
       sw ? sw[id] : false
@@ -7419,13 +7475,24 @@ module Game
         max_prio = r if r > max_prio
       end
       return nil if max_prio <= 0
-      total = 0
       prios = prios.map do |pr|
         v = pr > 0 ? pr - max_prio + 10 : 0
         v = 0 if v < 0
-        total += v
         v
       end
+      # A skill action's weight above is computed purely from its rating and
+      # #enemy_action_valid?; a high-rating but currently-ineffective skill
+      # (a self-heal at full HP, a cure with nothing to cure) still crowds out
+      # the *other* candidates via max_prio exactly as if it were still in the
+      # running -- EasyRPG's own two-pass structure (src/enemyai.cpp) does not
+      # recompute the weights above either. Only the ineffective skill's own
+      # draw is zeroed out, in this separate pass, once weights are settled.
+      list.each_with_index do |a, i|
+        next unless prios[i] > 0 && a.skill?
+        sk = @ai && @ai.skill(a.skill_id)
+        prios[i] = 0 if sk && !@ai.skill_helps_troop?(sk, b, @enemies)
+      end
+      total = prios.reduce(0) { |sum, v| sum + v }
       return nil if total <= 0
       which = @rng.random(total)
       chosen = nil

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10785,14 +10785,14 @@ end
 
 # A minimal skill row for the AI env to resolve.
 class FakeAiSkill
-  attr_accessor :name, :scope, :sp_type, :sp_cost, :sp_percent, :power,
+  attr_accessor :name, :type, :scope, :sp_type, :sp_cost, :sp_percent, :power,
                 :physical_rate, :magical_rate, :hit, :variance, :state_effects,
                 :attribute_effects, :affect_hp, :affect_sp
 
   def initialize(h = {})
-    @name = 'Spell'; @scope = 0; @sp_type = 0; @sp_cost = 0; @power = 0
-    @physical_rate = 0; @magical_rate = 0; @hit = 100; @variance = 0
-    @affect_hp = true; @affect_sp = false
+    @name = 'Spell'; @type = 0; @scope = 0; @sp_type = 0; @sp_cost = 0
+    @power = 0; @physical_rate = 0; @magical_rate = 0; @hit = 100
+    @variance = 0; @affect_hp = true; @affect_sp = false
     h.each { |k, v| send("#{k}=", v) }
   end
 end
@@ -10910,6 +10910,90 @@ check 'casting spends the enemy SP' do
   foe = combatant_mp('Slime', 40, 0, 5, 500, 100)
   enemy_entry([enemy_action(kind: 1, skill_id: 1)], ai, foe: foe)
   eq 88, foe.mp, '100 - 12'
+end
+
+# -- skill effectiveness gates the AI's own weighted choice --------------------
+
+check "an enemy's own state-cure skill is excluded from the running when it has nothing to cure" do
+  # EasyRPG's EnemyAi::IsSkillEffectiveOnAnyTarget (src/enemyai.cpp): unlike an
+  # HP/SP/stat-affecting skill (always considered worth trying against a live
+  # target -- the real engine never actually computes the effect before
+  # choosing), a *pure* state-effect skill only counts as effective once some
+  # target already carries a state it would cure -- the same rule
+  # #skill_effective? already applies to the field menu's own no-op
+  # greying-out, now shared with the enemy AI's own action choice. No
+  # competing action here: with only the useless cure valid at all,
+  # #choose_enemy_action must come back with nothing (total weight 0) once
+  # it is correctly excluded, falling through to a plain default attack --
+  # pre-fix, the same lone action was simply always chosen instead.
+  cure = FakeAiSkill.new(name: 'Focus', scope: 2, power: 0, affect_hp: false,
+                         state_effects: [0, 1]) # flags state id 2
+  ai = skill_ai(1 => cure)
+  acts = [enemy_action(kind: 1, skill_id: 1, rating: 60)]
+  hero = combatant('Hero', 40, 0, 5, 500) # slower, so the foe acts first
+  hero.spi ||= 0
+  foe = combatant_mp('Slime', 40, 0, 20, 500, 100) # unafflicted
+  foe.spi ||= 0
+  foe.actions = acts
+  b = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false,
+                       false, false, nil, ai)
+  b.begin_round
+  e = b.step_action
+  ok !e[:recover], 'the useless cure never fires'
+  eq 20, e[:damage], 'the plain default attack fires instead'
+end
+
+check "an enemy's own state-cure skill still fires once a target actually needs it" do
+  # No competing action here (unlike the two checks above/below): with only
+  # the cure valid at all, it must win the draw whenever it is not wrongly
+  # filtered out.
+  cure = FakeAiSkill.new(name: 'Focus', scope: 2, power: 0, affect_hp: false,
+                         state_effects: [0, 1])
+  ai = skill_ai(1 => cure)
+  acts = [enemy_action(kind: 1, skill_id: 1, rating: 60)]
+  hero = combatant('Hero', 40, 0, 5, 500)
+  hero.spi ||= 0
+  foe = combatant_mp('Slime', 40, 0, 20, 500, 100)
+  foe.spi ||= 0
+  foe.states = [2] # actually afflicted this time
+  foe.actions = acts
+  b = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false,
+                       false, false, nil, ai)
+  b.begin_round
+  e = b.step_action
+  eq true, e[:recover], 'the cure fires and cures its own state'
+  eq [2], e[:cured]
+end
+
+check "an ineffective skill's own high rating still crowds out a lower-rated action via max_prio" do
+  # EasyRPG computes max_prio from every action's raw rating first, then
+  # zeroes an ineffective skill's own draw in a *separate* later pass
+  # (src/enemyai.cpp's SelectEnemyAiActionRpgRtCompat) -- it does not drop
+  # the ineffective skill before max_prio is found and recompute the other
+  # actions' weights against a lower max. So a much lower-rated action a
+  # naive "exclude it up front" fix would let back into the draw (49 is
+  # within 10 of a recomputed max of 58, but not of the real max of 60) must
+  # still be excluded here.
+  cure = FakeAiSkill.new(name: 'Focus', scope: 2, power: 0, affect_hp: false,
+                         state_effects: [0, 1])
+  ai = skill_ai(1 => cure)
+  acts = [enemy_action(kind: 1, skill_id: 1, rating: 60), # ineffective, filtered
+          enemy_action(kind: 0, basic: 0, rating: 58),    # attack: weight 8
+          enemy_action(kind: 0, basic: 2, rating: 49)]    # guard: weight -1 -> 0
+  30.times do |i|
+    hero = combatant('Hero', 40, 0, 5, 500)
+    hero.spi ||= 0
+    foe = combatant_mp('Slime', 40, 0, 20, 500, 100)
+    foe.spi ||= 0
+    foe.actions = acts
+    b = Game::Battle.new([hero], [foe], Game::Rng.new(i + 1), nil, false,
+                         false, false, false, nil, ai)
+    b.begin_round
+    e = b.step_action
+    ok !e[:recover], "the cure never fires (seed #{i + 1})"
+    ok e[:defend].nil?, "the rating-49 guard stays excluded by the cure's own rating (seed #{i + 1})"
+    eq 20, e[:damage], 'only the attack ever fires'
+  end
 end
 
 # -- transformation ------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Mines `docs/TODO.md`'s yado.tk "Full-site sweep" backlog's own "Flagged for priority triage" section: the "Enemy action-pattern selection" bullet's weighted-draw description checked out correct (an exact port of EasyRPG's `pr - max_prio + 10` formula), but cross-checking the same real C++ source (`src/enemyai.cpp`) directly — beyond what the paraphrase in `docs/TODO.md` describes — surfaced a genuine, previously undocumented gap.
- `Game::Battle#choose_enemy_action` gated a skill action's own weighted draw only on affordability and silence (`#enemy_action_valid?`/`#enemy_skill_ready?`) — nothing checked whether casting it would actually do anything. A self/ally-scope skill with no valid target (a pure state-cure with nothing on the caster's own troop currently carrying that state) could still dominate the draw purely off its own rating, casting a visible no-op turn after turn instead of yielding to whatever else the pattern offered.
- Fixed with a new `Game::Party#skill_helps_troop?`, ported from EasyRPG's `EnemyAi::IsSkillEffectiveOnAnyTarget`/`IsSkillEffectiveOn` (`src/enemyai.cpp`) and reusing the exact same no-op rule the field menu's own `#skill_effective?` already applies to grey out a wasted cast. Reached through a new `Game::EnemyAi#skill_helps_troop?` and consulted in a **separate pass** in `#choose_enemy_action`, mirroring EasyRPG's own two-pass structure exactly rather than folding the check into `#enemy_action_valid?`: an ineffective skill's raw rating still counts toward `max_prio` (crowding out other, lower-rated candidates exactly as if it were still in the running) even though its own draw ends up zeroed — folding the check earlier would silently recompute `max_prio` without it and let a lower-rated action back into the draw real RPG_RT would never offer.
- A party-scope skill (aimed at the player side) is never filtered this way, matching real RPG_RT — it never checks whether the party side could be affected. Nor is an HP/SP/stat-affecting skill filtered by current HP/SP level: the real engine always considers it worth trying against a live target regardless of magnitude, confirmed directly against the C++ source (an earlier draft of this fix wrongly assumed a full-HP self-heal would be excluded, before checking).
- This port always runs the *actual* RPG_RT behaviour (EasyRPG's `emulate_bugs: true`, matching every other "authentic engine vs. the improved variant" choice made elsewhere in this file), which collapses two of the ported function's branches to a genuine engine bug rather than the fixed behaviour EasyRPG's alternate "RPG_RT+" algorithm offers.
- Updates `docs/TODO.md` with a dense, evidence-citing ✅ entry under the "No built-in hero double-action..." bullet.
- Adds a `changelog.d/enemy-ai-skill-effectiveness-gate.fixed.md` fragment.

## Test plan

- Added three regression checks to `scripts/rpg2k_logic_check.rb`: a lone state-cure action with nothing to cure now yields to the plain default attack instead of always firing; the identical action still fires normally once a target actually carries the state (control case); a three-action fixture pins the `max_prio`-crowds-out-a-lower-rated-action nuance specifically, confirming a rating-49 guard stays excluded by an ineffective rating-60 skill's own rating even though the skill itself never fires.
- Confirmed all three new checks **fail** against the pre-fix `mruby-rpg2k/mrblib/game.rb` (`git stash` of just that file).
- Confirmed all five CI scripts pass on this branch:
  - `ruby scripts/rpg2k_logic_check.rb` — 756 checks passed
  - `ruby scripts/rpg2k_scene_check.rb` — 467 checks passed
  - `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
  - `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped (no local test-bed data; this sandbox's network policy blocks the download proxy)
  - `ruby scripts/rpg2k_command_soak.rb` — skipped (same reason)

---
_Generated by [Claude Code](https://claude.ai/code/session_015VxjbShPXRYEJyjCkKakyX)_