### PR TITLE
rpg2k: a Parallel Process's own Show Text/Show Choices now opens the shared message window

### DIFF
--- a/changelog.d/parallel-process-message-window.fixed.md
+++ b/changelog.d/parallel-process-message-window.fixed.md
@@ -1,0 +1,22 @@
+- **A Parallel Process's own Show Text/Show Choices now actually opens the
+  shared message window, instead of being silently dropped.**
+  `Scene::Map#drive_parallel_wait` had cases for every other wait kind a
+  background process could park on (`:wait`, `:key_input`, `:animation`,
+  `:game_over`, `:movement`, `:teleport`, `:screen`, `:picture`,
+  `:sprite_flash`) but none for `:message`/`:choice`, so a Common Event or
+  map event Parallel Process's own Show Text fell into the generic
+  "background: ignore message/choice requests" branch and the interpreter
+  sailed straight past it — the window never appeared, and the next command
+  ran as if it had been a no-op. Fixed by generalizing `#open_message` to
+  track which interpreter opened the current window (`interp:`, defaulting
+  to the foreground `@interpreter`) and threading that through
+  `#drive_message`/`#drive_text_message` in place of a hardcoded
+  `@interpreter`, then adding `:message`/`:choice` cases to
+  `#drive_parallel_wait` that open the shared window only while it is free
+  and otherwise leave the requesting process parked to retry next frame —
+  matching "two message windows can never be shown simultaneously," which
+  this codebase's single `@message` slot already enforced for the
+  foreground but never extended to a background process. Input Number from
+  a Parallel Process is a separate, narrower gap left open. Covered by three
+  new `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4446,8 +4446,71 @@ not yet verified:
   restriction.
 
 **Message window / Show Choices / control characters**
-- Two message windows can never be shown simultaneously — a hard engine
-  limit.
+- ✅ **A Parallel Process's own Show Text/Show Choices now actually opens the
+  single shared message window, instead of being silently dropped** — closes
+  the missing half of "two message windows can never be shown
+  simultaneously — a hard engine limit," which this codebase's own single
+  `@message` slot already modelled correctly for the foreground but never
+  extended to a background process. `Scene::Map#drive_parallel_wait`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — the dispatch `#step_parallel` uses for
+  whichever wait kind a parallel-process interpreter is parked on — had cases
+  for `:wait`/`:key_input`/`:animation`/`:game_over`/`:movement`/`:teleport`/
+  `:screen`/`:picture`/`:sprite_flash` (each added over earlier rounds of this
+  same fix), but none for `:message` or `:choice`, the wait kinds
+  `Game::Interpreter#do_show_message`/`#do_show_choices` set — so a Common
+  Event or map event Parallel Process's own Show Text fell into the generic
+  `else` branch (`it.resume # background: ignore message/choice requests`)
+  and the interpreter sailed straight past it every frame, the command right
+  after it running as if Show Text had been a no-op; the window itself never
+  appeared. Fixed in two parts. First, `#open_message` gained an `interp:`
+  keyword (default `@interpreter`, so every pre-existing foreground call site
+  needs no change at all) recorded on the new window as `@message[:interp]`;
+  `#drive_message`'s choice-navigation branch and `#drive_text_message`
+  — the two places that already drove *whichever* window is currently open,
+  since `#drive_event`'s own `@message`/`@number_input` checks run ahead of
+  its `@interpreter.waiting?` dispatch and `#event_busy?` already treats a
+  live `@message` as busy regardless of which interpreter opened it — now
+  read `@message[:interp]` instead of hardcoding `@interpreter` for
+  `#choose`/`#cancel_choice`/`#choice_cancellable?`/`#message_followup`/
+  `#resume`, mirroring the same "generalize to a tracked owning interpreter"
+  shape the Show Battle Animation fix already used for a Parallel Process's
+  own animation (`@map_animation_interp`, see the "Full-site sweep" section
+  above). Second, `#drive_parallel_wait` gained `:message`/`:choice` cases
+  that call `open_message(it.message_lines, false, interp: it)` /
+  `open_message(it.choice_labels, true, interp: it)` only when `@message` is
+  `nil` — `#open_message`'s own pre-existing "already open" guard (`return
+  unless choice && @message[:awaiting_followup] == :choice`) is what then
+  enforces the one-window-at-a-time rule for *any* second requester, whether
+  that is the foreground's own next Show Text or a different interpreter's:
+  the request is simply dropped for that frame and the requesting interpreter
+  stays parked on its own wait, unresumed, to retry the next frame once the
+  window frees up — no busy-loop or dropped command either way. The
+  `:message` case additionally gates on `#forced_movement_done?` (not
+  `#step_forced_movement`, which actively steps every pending forced route
+  and would double-advance one on a frame both the foreground and a Parallel
+  Process reach their own Show Text on at once — the same reasoning the
+  `:movement` case above already documents), matching the existing "an
+  implicit auto-run also happens whenever the event hits a Wait or a Show
+  Text" rule; `:choice` has no such gate, matching `#drive_event`'s own
+  ungated `:choice` dispatch, since only Wait/Show Text are documented
+  auto-run trigger points. A Parallel Process's own message correctly blocks
+  bystander input/movement/other-event-starting the map-wide way any open
+  `@message` already does (`#event_busy?`), while other Parallel Processes
+  keep ticking independently of it exactly as an open message never pauses
+  them (`#parallels_paused?` only checks `@battle_ui`/a bursting foreground).
+  **Left open**: Input Number (`:number`) issued from a Parallel Process is
+  still silently dropped — `#open_number_input`'s standalone panel and its
+  merged-into-`@message` follow-up are both foreground-only machinery today,
+  a narrower, separate gap this fix does not close. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks (a Common Event Parallel Process's own
+  Show Text opens the window, blocks the command after it, then resumes once
+  dismissed; a map event Parallel Process's own Show Choices opens, and the
+  picked branch — not the other one — runs once resumed; a Parallel Process's
+  own Show Text blocks for the whole time the foreground's own message stays
+  open, then opens its own and resumes *itself*, not the foreground, proving
+  the tracked `interp:` owner is threaded through correctly rather than
+  hardcoded), all three confirmed to fail against the pre-fix code (the
+  window never opening, or opening on the wrong first attempt).
 - ✅ **A Face Graphic setting persists through the rest of the current event's
   execution content (not just the next message) and is auto-cleared when
   the event ends, but not before** — it must be explicitly "erased" to stop

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1405,6 +1405,47 @@ class RPG2k
           # its context is gone post-transfer".
           perform_teleport(it.teleport)
           it.resume
+        elsif it.wait_kind == :message
+          # Show Text issued from a Parallel Process: real RPG_RT has exactly
+          # one global message window, so this one shares @message with the
+          # foreground rather than getting a background mechanism of its own
+          # (docs/TODO.md "Two message windows can never be shown
+          # simultaneously -- a hard engine limit"). Before this branch
+          # existed this fell into the generic "background: ignore message/
+          # choice requests" #resume below, so a Parallel Process's own Show
+          # Text silently never displayed at all -- the interpreter sailed
+          # straight past it as if the command had not run. #open_message's
+          # own pre-existing "already open" guard (see there) is what
+          # enforces the one-window-at-a-time rule here: this call only opens
+          # a window when @message is nil, and simply leaves `it` parked on
+          # its own :message wait otherwise, to retry next frame once
+          # whichever window is currently up (the foreground's or another
+          # Parallel Process's) closes -- the same block-and-retry shape
+          # already used for :screen/:picture/:sprite_flash just below.
+          # #drive_event's own @message dispatch (unconditional on
+          # #event_busy?, which @message alone already forces true) then
+          # drives it to completion and resumes the tracked `interp:` owner,
+          # not always @interpreter, matching the generalisation that already
+          # threads a Common Event Parallel Process's own Show Battle
+          # Animation through a tracked owner (@map_animation_interp) rather
+          # than hardcoding the foreground.
+          #
+          # Gated on #forced_movement_done? rather than #step_forced_movement
+          # for the same reason the :movement branch above is: the pending
+          # routes are already stepped once a frame elsewhere, and stepping
+          # them again here would double-advance one on any frame both the
+          # foreground and a Parallel Process happen to reach their own
+          # Show Text on at once.
+          if @message.nil? && forced_movement_done?
+            open_message(it.message_lines, false, interp: it)
+          end
+        elsif it.wait_kind == :choice
+          # Show Choices issued from a Parallel Process: the same shared
+          # single window as :message just above, with no implicit-auto-run
+          # gate of its own -- matching #drive_event's own ungated :choice
+          # dispatch, since only Wait/Show Text are documented auto-run
+          # trigger points, not Show Choices.
+          open_message(it.choice_labels, true, interp: it) if @message.nil?
         elsif it.wait_kind == :screen
           # Erase/Show/Tint/Flash/Pan/Shake Screen issued with its own wait
           # flag from a Parallel Process: block that process until the effect
@@ -1425,7 +1466,13 @@ class RPG2k
           # the :screen/:picture cases just above.
           it.resume unless sprite_flashing?
         else
-          it.resume # background: ignore message/choice requests
+          # :message and :choice are handled above now; an Input Number
+          # request (:number) is the one wait kind still silently dropped
+          # here -- #open_number_input's standalone (no preceding Show Text)
+          # panel and its embedded-in-@message follow-up are both
+          # foreground-only machinery today, a narrower, separate gap left
+          # open by this fix.
+          it.resume
         end
       end
 
@@ -6772,7 +6819,16 @@ class RPG2k
         party.respond_to?(:leader) ? party.leader : nil
       end
 
-      def open_message(lines, choice)
+      # `interp:` is whichever interpreter's Show Text/Show Choices this window
+      # answers to -- the foreground @interpreter by default, or a Parallel
+      # Process's own interpreter when #drive_parallel_wait opens one (see
+      # there). #drive_message/#drive_text_message read @message[:interp]
+      # rather than @interpreter directly, so the window drives and resumes
+      # the interpreter that actually asked for it either way; the "one
+      # message window at a time" rule (yado.tk) that already made a second
+      # same-frame call from @interpreter itself no-op below now equally holds
+      # off a second, different interpreter's request until this one closes.
+      def open_message(lines, choice, interp: @interpreter)
         if @message
           # A Show Choices that directly follows a Show Text keeps the same
           # window: append the choice list below the text already on screen
@@ -6841,7 +6897,7 @@ class RPG2k
         end
         @message = { window: win, choice: choice, count: plain.length,
                      choice_start: 0, reveal: reveal, contents: contents,
-                     inner_w: inner_w, seg_lines: seg_lines,
+                     inner_w: inner_w, seg_lines: seg_lines, interp: interp,
                      face: build_face_cell(face_sheet, cfg.face_index, cfg.face_flipped),
                      face_x: face_right ? inner_w - FACE_SIZE : 0,
                      text_x: text_x, text_w: text_w, gold_window: gold_window,
@@ -7099,15 +7155,17 @@ class RPG2k
           elsif Input.trigger?(Input::C)
             play_system_se(SFX_DECISION)
             index = @choice_index
+            interp = @message[:interp]
             close_message
-            @interpreter.choose(index)
-          elsif Input.trigger?(Input::B) && @interpreter.choice_cancellable?
+            interp.choose(index)
+          elsif Input.trigger?(Input::B) && @message[:interp].choice_cancellable?
             # The Show Choices block says what cancelling means (pick a given
             # choice, or run its [Cancel] branch); a block that forbids it
             # swallows the key, as RPG_RT does.
             play_system_se(SFX_CANCEL)
+            interp = @message[:interp]
             close_message
-            @interpreter.cancel_choice
+            interp.cancel_choice
           end
         else
           drive_text_message
@@ -7201,6 +7259,7 @@ class RPG2k
       MSG_PAUSE_FULL = 61
 
       def drive_text_message
+        interp = @message[:interp]
         reveal = @message[:reveal]
         confirm = Input.trigger?(Input::C) || Input.trigger?(Input::B)
         # Holding Shift during Test Play fast-forwards dialogue *while it is
@@ -7230,7 +7289,7 @@ class RPG2k
         end
         # `\^` closes the finished window on its own; otherwise wait for a button.
         if reveal.auto_close? || confirm
-          followup = @interpreter.message_followup
+          followup = interp.message_followup
           if followup
             # A Show Choices / Input Number immediately follows this Show Text:
             # RPG_RT keeps the same window up, with the choices / digit entry
@@ -7239,7 +7298,7 @@ class RPG2k
           else
             close_message
           end
-          @interpreter.resume
+          interp.resume
         else
           @message[:window].pause = true
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3760,6 +3760,117 @@ check "Flash Sprite's own wait flag blocks a Parallel Process's own interpreter,
   ok st.switches[1], 'the Parallel Process resumed once the flash finished'
 end
 
+check "a Common Event Parallel Process's own Show Text now actually opens the shared message window" do
+  # docs/TODO.md "Two message windows can never be shown simultaneously -- a
+  # hard engine limit": #drive_parallel_wait had no :message case at all, so
+  # a Parallel Process's own Show Text fell into the generic "background:
+  # ignore message/choice requests" #resume branch and the interpreter
+  # sailed straight past it -- no window ever appeared, and the command right
+  # after it ran on the very next tick as if Show Text had been a no-op.
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false,
+                      event: [
+                        ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi'),
+                        ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+                      ])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+
+  msg = open_msg(scene)
+  ok msg, "the Parallel Process's own Show Text opened the shared message window"
+  ok !st.switches[1],
+     'the command after Show Text has not run yet -- the process is blocked on the window'
+
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # complete the (short) reveal
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # dismiss
+  ok !scene.instance_variable_get(:@message), 'message dismissed'
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[1], 'the Parallel Process resumed and ran the command after Show Text'
+end
+
+check "a Map Event Parallel Process's own Show Choices now actually opens the shared message window" do
+  # Same defect class as Show Text just above, for the :choice wait kind.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 4)
+  pg.event_commands = [
+    ECmd.new(ic::SHOW_CHOICES, [0], indent: 0), # cancel forbidden
+    ECmd.new(ic::CHOICE_OPTION, [0], indent: 0, string: 'yes'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    ECmd.new(ic::CHOICE_OPTION, [1], indent: 0, string: 'no'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    ECmd.new(ic::END_BRANCH, [], indent: 0),
+  ]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  msg = open_msg(scene)
+  ok msg, "the Parallel Process's own Show Choices opened the shared message window"
+  ok msg[:choice], 'the window is showing a choice list, not plain text'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # pick "yes" (index 0)
+  scene.update
+  ok !scene.instance_variable_get(:@message), 'the choice window closed on pick'
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[1], "the Parallel Process resumed into the picked choice's own branch"
+  ok !st.switches[2], 'the other branch never ran'
+end
+
+check "a Parallel Process's own Show Text waits for the foreground's already-open " \
+      'message window, then opens its own and resumes the right interpreter' do
+  # The cross-interpreter half of the "two message windows" rule: whichever
+  # interpreter -- foreground or a Parallel Process -- currently owns @message
+  # holds it until dismissed; a second, different interpreter reaching its own
+  # Show Text in the meantime must neither steal the window nor be dropped
+  # (the pre-fix generic #resume branch's bug) but block and retry, then open
+  # its own and resume *itself*, not whichever interpreter the window
+  # happened to belong to first (#open_message's `interp:` -- see there).
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_MESSAGE, [], string: 'first'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  parallel = page(trigger: 4)
+  parallel.event_commands = [
+    ECmd.new(ic::WAIT, [5]), # half a second: comfortably after 'first' opens
+    ECmd.new(ic::SHOW_MESSAGE, [], string: 'second'),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 2, 2, 0]),
+  ]
+  scene = new_scene({ 1 => event(0, 4, auto), 2 => event(0, 1, parallel) },
+                    player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+
+  msg = open_msg(scene)
+  ok msg, "the foreground's own Show Text opened the message window first"
+
+  40.times { scene.update } # the Parallel Process's own Wait elapses meanwhile
+  ok scene.instance_variable_get(:@message),
+     "the foreground's window is still the one open"
+  ok !st.switches[2],
+     "the Parallel Process's own Show Text must wait for the open window, not " \
+     'be silently dropped'
+
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # complete the reveal of 'first'
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # dismiss 'first', resume the foreground
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[1], 'the foreground resumed and ran its own command after Show Text'
+
+  msg2 = open_msg(scene)
+  ok msg2, "the Parallel Process's own Show Text finally opened, now that the window is free"
+
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # complete the reveal of 'second'
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # dismiss 'second'
+  5.times { RGSS::Input.reset; scene.update }
+  ok st.switches[2],
+     'the Parallel Process itself resumed (not the foreground) and ran its own command'
+end
+
 check "a forced route auto-runs to completion before an immediately-following Show Text opens (yado.tk)" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- Found while triaging `docs/TODO.md`'s "Two message windows can never be shown simultaneously — a hard engine limit" claim under the yado.tk "Message window" bullets: `Scene::Map#drive_parallel_wait` (the dispatch `#step_parallel` uses for whichever wait kind a parallel-process interpreter is parked on) had a case for every other wait kind a background process could reach — `:wait`, `:key_input`, `:animation`, `:game_over`, `:movement`, `:teleport`, `:screen`, `:picture`, `:sprite_flash` (each added over earlier rounds of this same recurring fix) — but none for `:message`/`:choice`. A Common Event or map event Parallel Process's own Show Text/Show Choices fell into the generic `else` branch (`it.resume # background: ignore message/choice requests`) and the interpreter sailed straight past it every frame — the window never appeared, and the command right after it ran as if Show Text had been a no-op.
- Fixed in two parts. `Scene::Map#open_message` gained an `interp:` keyword (default `@interpreter`, so every pre-existing foreground call site needs no change) recorded on the window as `@message[:interp]`; `#drive_message`/`#drive_text_message` — the two places that already drive *whichever* window is currently open, since `#drive_event`'s own `@message` check runs ahead of its `@interpreter.waiting?` dispatch and `#event_busy?` already treats a live `@message` as busy regardless of who opened it — now read `@message[:interp]` instead of hardcoding `@interpreter`, mirroring the same "generalize to a tracked owning interpreter" shape the earlier Show Battle Animation fix already used (`@map_animation_interp`). `#drive_parallel_wait` then gained `:message`/`:choice` cases that only open the shared window while `@message` is `nil`, otherwise leaving the requesting process parked to retry next frame — `#open_message`'s own pre-existing "already open" guard is what enforces the one-window-at-a-time rule for any second requester, foreground or a different Parallel Process alike.
- Left open: Input Number (`:number`) issued from a Parallel Process is still silently dropped — `#open_number_input`'s standalone/merged-into-`@message` machinery is foreground-only today, a narrower, separate gap.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 753 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 470 checks pass (3 new: a Common Event Parallel Process's own Show Text opens the window and blocks the following command until dismissed; a map event Parallel Process's own Show Choices opens and the picked branch runs; a Parallel Process's own Show Text blocks while the foreground's message is open, then opens its own and resumes *itself*, not the foreground — all three confirmed to fail against the pre-fix code before the fix)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass (against the real `mtf-meido-action` test bed)
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean (3430 commands, `mtf-meido-action` test bed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKnH1Y78nriiVL91z2eQHi)_