### PR TITLE
rpg2k: state slip damage is now non-lethal and honors hp/sp_change_type

### DIFF
--- a/changelog.d/state-slip-damage-nonlethal-and-change-type.fixed.md
+++ b/changelog.d/state-slip-damage-nonlethal-and-change-type.fixed.md
@@ -1,0 +1,24 @@
+- **A state's per-turn battle slip damage can no longer knock a battler out
+  by itself, and `hp_change_type`/`sp_change_type` (RPG2003 fields 45/46) are
+  now honoured on both the map and battle slip paths.** Verified against
+  EasyRPG Player's C++ source: `Game_Battler::ApplyConditions`
+  (`src/game_battler.cpp`) calls `ChangeHp(src_hp, /* lethal = */ false)`,
+  flooring at 1 HP regardless of the computed slip — the same non-lethal rule
+  this codebase's map-side field-poison drain already followed, but
+  `Game::Battle#apply_turn_states` never did, so a large enough
+  `hp_change_max` (a boss's own poison-percent-of-max attack, say) could end
+  a battler's turn in death from status alone. Both `ApplyConditions` and its
+  map-step counterpart `Game_Party::ApplyStateDamage` (`src/game_party.cpp`)
+  also branch on `lcf::rpg::State::ChangeType` (`lose`/`gain`/`nothing`),
+  which neither `Game::Battle#apply_turn_states` nor `Game::States.drain`
+  (the map-step helper) read at all — every state was treated as an
+  unconditional loss. Fixed with a new `Game::States::CHANGE_TYPE_LOSE`/
+  `GAIN`/`NOTHING` trio, a shared `Battle#slip_stat` (floor 1 for HP, 0 for
+  SP) that `apply_turn_states` now routes through instead of a bare `-=`, and
+  a signed `Game::States.drain` that `Party#apply_map_step_damage` sums and
+  applies through the existing `change_hp`/`change_mp` calls. Every existing
+  loss-only state (every state in both shipped test beds, since the field is
+  a 2003 addition neither database sets) is unaffected beyond the corrected
+  HP floor. Covered by new `scripts/rpg2k_logic_check.rb` checks, including
+  one confirmed to fail against the pre-fix code (`expected 1, got 0`) before
+  the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -912,6 +912,55 @@ The work below is roughly ordered by the critical path to a walkable game
   blunts a Cure cast on the map afterwards too. Also still unread: the
   RPG2003-only `avoid_attacks` / `reflect_magic`,
   which no state in either test bed sets.
+  ✅ **`hp_change_type`/`sp_change_type` (RPG2003 fields 45/46) are now read
+  too, on both the map and battle slip paths — found while re-checking this
+  same `situation`-table cluster for anything else parsed-but-unused.** Both
+  `Game::States.drain` (the map-step helper just above) and `Game::Battle
+  #apply_turn_states` treated every state's `hp_change_val`/`hp_change_max`/
+  `sp_change_val`/`sp_change_max` as an unconditional **loss**, with no read
+  of the field that actually selects the direction — silently correct for
+  every state either test bed defines (mtf-meido-action's Poison, the one
+  map-slip state either ships, carries no `hp_change_type` value at all,
+  defaulting to 0), but wrong for a state authored as a "regen" (a positive
+  per-turn heal instead of a drain) or explicitly configured to do nothing
+  despite a nonzero amount. Verified against EasyRPG Player's actual C++
+  source rather than guessed at: `lcf::rpg::State::ChangeType` (liblcf's
+  generated `state.h`) is `ChangeType_lose = 0, ChangeType_gain = 1,
+  ChangeType_nothing = 2`, and both `Game_Battler::ApplyConditions`
+  (`src/game_battler.cpp`) and `Game_Party::ApplyStateDamage`
+  (`src/game_party.cpp`, the map-step counterpart) branch on all three
+  explicitly, not a lose/anything-else binary. **A second, more consequential
+  gap surfaced in the same investigation: `apply_turn_states`'s own slip
+  damage could knock a battler out outright**, contradicting
+  `ApplyConditions`'s own `ChangeHp(src_hp, /* lethal = */ false)` call, which
+  floors at 1 HP regardless of the computed magnitude — the exact non-lethal
+  rule the map-side drain already implemented correctly
+  (`Game::Party#apply_map_step_damage`'s own `change_hp(hp, false)`), but the
+  battle-side per-turn tick never did, so a large enough `hp_change_max` (a
+  boss's own poison-percent-of-max attack, say) could end a battler's turn in
+  death from status alone with no attack or skill involved — this codebase's
+  own comment even documented it as intended ("slip damage (which may knock
+  it out)", `Game::Battle#step_action`, now corrected). Fixed with a new
+  `Game::States::CHANGE_TYPE_LOSE`/`GAIN`/`NOTHING` constant trio and a shared
+  `Battle#slip_stat(cur, max, amount, type, floor)` (floor 1 for HP, 0 for SP,
+  matching `ApplyConditions`'s non-lethal-HP/no-floor-SP asymmetry) that both
+  `apply_turn_states`'s HP and SP branches now route through instead of a
+  bare `-=`/`.max`; `Game::States.drain` (map-step) now returns a signed delta
+  (negative lose, positive gain, 0 for nothing or an interval miss) that
+  `Party#apply_map_step_damage` sums and applies through the existing
+  `change_hp`/`change_mp` calls unchanged. Every existing loss-only state —
+  every state in both test beds, since the field is a 2003 addition neither
+  database sets — is unaffected: the schema default (0) is
+  `CHANGE_TYPE_LOSE`, reproducing the prior unconditional-subtraction
+  behaviour exactly, with the one substantive difference being the
+  now-correct HP floor. Covered by new `scripts/rpg2k_logic_check.rb` checks:
+  `States.map_step_drain`/`Party#apply_map_step_damage` with a GAIN-type
+  state heal (clamped to max) and a NOTHING-type state doing neither; a
+  battle GAIN-type state healing per turn the same way, alongside a
+  NOTHING-type control; and — the fail-before proof for the lethality half —
+  a 100%-of-max-HP battle poison tick now floors at 1 HP and leaves the
+  battler alive across two full rounds instead of knocking it out, confirmed
+  to fail against the pre-fix code (`expected 1, got 0`) before the fix.
   **The ground drains it too** — RPG2000's 地形ダメージ, the 地形 row's `damage`
   field (ADR 0034). Stepping onto a tile whose terrain carries one takes that
   much HP off every member who is not already down and is not wearing gear

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2420,21 +2420,26 @@ module Game
 
     # RPG2000 field slip damage: apply every afflicted member's map-step drain
     # for a party that has now walked `steps` tiles. Each state a member carries
-    # is asked for its due HP / SP loss (Game::States.map_step_drain) and the
-    # totals are applied once, so two slipping states stack rather than the
-    # worse one winning -- unlike the battle-side effects, which pick a single
-    # significant state.
+    # is asked for its due signed HP / SP delta (Game::States.map_step_drain --
+    # negative for the ordinary "lose" case, positive for a "gain"-type state,
+    # see Game::States::CHANGE_TYPE_*) and the totals are applied once, so two
+    # slipping states stack rather than the worse one winning -- unlike the
+    # battle-side effects, which pick a single significant state for its
+    # message (though not, per EasyRPG's own ApplyConditions, for the damage
+    # math itself -- see Battle#apply_turn_states).
     #
-    # The HP drain **cannot kill**: it goes through change_hp with death
-    # disallowed, so a poisoned party is worn down to 1 HP and left standing.
-    # That is RPG_RT's rule, and it is why nothing on this path has to re-check
-    # for a game over the way the twelve event commands that *can* wipe the party
-    # do. A member who is already down slips nothing at all.
+    # A **loss cannot kill**: it goes through change_hp with death disallowed,
+    # so a poisoned party is worn down to 1 HP and left standing. That is
+    # RPG_RT's rule, and it is why nothing on this path has to re-check for a
+    # game over the way the twelve event commands that *can* wipe the party
+    # do. A **gain** clamps to max_hp/max_sp the same way change_hp/change_mp
+    # already clamp an ordinary heal. A member who is already down slips
+    # nothing at all.
     #
     # `table` is the database `situation` array; a caller without one (the seeded
-    # harness fixtures) drains nothing. Returns the actors that actually lost
-    # something, so the scene can flash the screen only when there is something
-    # to report.
+    # harness fixtures) drains nothing. Returns the actors actually affected
+    # (lost *or* gained something), so the scene can flash the screen only when
+    # there is something to report.
     def apply_map_step_damage(table, steps)
       hit = []
       @actors.each do |actor|
@@ -2447,8 +2452,8 @@ module Game
           sp += dsp
         end
         next if hp.zero? && sp.zero?
-        actor.change_hp(-hp, false) if hp > 0
-        actor.change_mp(-sp) if sp > 0
+        actor.change_hp(hp, false) unless hp.zero?
+        actor.change_mp(sp) unless sp.zero?
         hit << actor
       end
       hit
@@ -6056,6 +6061,19 @@ module Game
     # The `situation` table's own default colour (schema element 3).
     DEFAULT_COLOR = 6
 
+    # A state's `hp_change_type` / `sp_change_type` (RPG2003 fields 45/46):
+    # which way its slip/regen amount moves the stat once its interval or
+    # threshold lands. 0 (the schema default, and the only meaning a
+    # pre-2003 database's absent field can carry) is **lose** -- every
+    # existing "poison" state in either test bed relies on this default --
+    # 1 is **gain** (a "regen" state that heals instead of drains), 2 is
+    # **nothing** (neither, despite a possibly-nonzero configured amount).
+    # Matches EasyRPG's `lcf::rpg::State::ChangeType` enum exactly (verified
+    # against liblcf's generated `state.h`), not guessed at.
+    CHANGE_TYPE_LOSE    = 0
+    CHANGE_TYPE_GAIN    = 1
+    CHANGE_TYPE_NOTHING = 2
+
     def self.row(id, table)
       return nil if id.nil? || id <= 0 || table.nil?
       table[id]
@@ -6312,15 +6330,23 @@ module Game
     def self.map_step_drain(id, table, steps)
       r = row(id, table)
       return [0, 0] if r.nil? || steps.nil? || steps <= 0
-      [drain(r, steps, :hp_change_map_steps, :hp_change_map_val),
-       drain(r, steps, :sp_change_map_steps, :sp_change_map_val)]
+      [drain(r, steps, :hp_change_map_steps, :hp_change_map_val, :hp_change_type),
+       drain(r, steps, :sp_change_map_steps, :sp_change_map_val, :sp_change_type)]
     end
 
-    def self.drain(row, steps, steps_field, val_field)
+    # The signed HP/SP delta this landing applies -- negative for the default
+    # **lose** type (RPG2000's only meaning for this field), positive for an
+    # explicit **gain**, 0 for **nothing** or for an interval this step does
+    # not land on (see CHANGE_TYPE_LOSE/GAIN/NOTHING above).
+    def self.drain(row, steps, steps_field, val_field, type_field)
       interval = int_field(row, steps_field)
       amount = int_field(row, val_field)
-      return 0 if interval <= 0 || amount <= 0
-      (steps % interval).zero? ? amount : 0
+      return 0 if interval <= 0 || amount <= 0 || !(steps % interval).zero?
+      case int_field(row, type_field)
+      when CHANGE_TYPE_GAIN then amount
+      when CHANGE_TYPE_NOTHING then 0
+      else -amount
+      end
     end
 
     def self.int_field(row, name)
@@ -7135,8 +7161,8 @@ module Game
         b = @queue.shift
         next if b.dead?
         # Afflicted states act at the start of the battler's turn: slip damage
-        # (which may knock it out) and, if it cannot act (asleep / paralysed), its
-        # turn is skipped.
+        # (which cannot itself knock it out -- see apply_turn_states) and, if it
+        # cannot act (asleep / paralysed), its turn is skipped.
         can_act = apply_turn_states(b)
         next if b.dead? || !can_act
         entry = record_action(strike(b))
@@ -7229,6 +7255,18 @@ module Game
     # HP/SP damage (fixed val + a percentage of the max, per EasyRPG's
     # ApplyConditions) and report whether the battler may act (a "do nothing"
     # restriction skips its turn). Returns true if `b` may act.
+    #
+    # The HP half **cannot knock `b` out**: EasyRPG's own `ApplyConditions`
+    # calls `ChangeHp(src_hp, /* lethal = */ false)`, floored at 1 regardless of
+    # how large the computed slip is, the same non-lethal rule the map-side
+    # field-poison drain already follows (Party#apply_map_step_damage) -- only a
+    # direct attack or skill can actually end a battler's turn in death. A state
+    # flagged `hp_change_type`/`sp_change_type` **gain** (Game::States::
+    # CHANGE_TYPE_GAIN, a "regen"-style state) heals instead of draining, and
+    # **nothing** (CHANGE_TYPE_NOTHING) does neither despite a possibly-nonzero
+    # configured amount; the schema default (0, every pre-2003 database's only
+    # meaning for this RPG2003 field) is **lose**, matching this method's prior,
+    # unconditional-loss behaviour exactly.
     def apply_turn_states(b)
       can_act = true
       b.state_turns ||= {}
@@ -7243,14 +7281,28 @@ module Game
         end
         hp = state_field(d, :hp_change_val) + b.max_hp * state_field(d, :hp_change_max) / 100
         hp = DAMAGE_CAP if hp > DAMAGE_CAP # 999 hard-cap applies to slip damage too
-        b.hp -= hp if hp > 0
+        b.hp = slip_stat(b.hp, b.max_hp, hp, state_field(d, :hp_change_type), 1) if hp > 0
         if b.max_mp && b.mp
           sp = state_field(d, :sp_change_val) + b.max_mp * state_field(d, :sp_change_max) / 100
-          b.mp = [b.mp - sp, 0].max if sp > 0
+          b.mp = slip_stat(b.mp, b.max_mp, sp, state_field(d, :sp_change_type), 0) if sp > 0
         end
         can_act = false if state_field(d, :restriction) == RESTRICTION_DO_NOTHING
       end
       can_act
+    end
+
+    # One state's per-turn slip applied to a single stat (`cur` against `max`):
+    # `type` selects direction (see Game::States::CHANGE_TYPE_LOSE/GAIN/NOTHING
+    # above the apply_turn_states doc), `floor` is the lowest the stat may land
+    # at on a loss -- 1 for HP (state slip damage alone can never knock a
+    # battler out) and 0 for SP (running out of SP is never fatal, so it keeps
+    # its prior unfloored clamp).
+    def slip_stat(cur, max, amount, type, floor)
+      case type
+      when States::CHANGE_TYPE_GAIN then [cur + amount, max].min
+      when States::CHANGE_TYPE_NOTHING then cur
+      else [cur - amount, floor].max
+      end
     end
 
     # Whether `b` shakes off state `id` this turn: only once it has held for more

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2705,7 +2705,15 @@ FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           # 1 double / 2 no change, plus which stat(s)).
                           # Appended last for the same reason again.
                           :affect_type, :affect_attack, :affect_defense,
-                          :affect_spirit, :affect_agility)
+                          :affect_spirit, :affect_agility,
+                          # ... and the RPG2003 hp_change_type/sp_change_type
+                          # fields (Game::States::CHANGE_TYPE_LOSE/GAIN/NOTHING):
+                          # which way the *_change_val/*_change_max amount above
+                          # moves the stat. Appended last, same reason again --
+                          # nil (every pre-existing positional FakeStateDef.new
+                          # call that stops short of here) reads as 0/LOSE via
+                          # #state_field, the schema's own default.
+                          :hp_change_type, :sp_change_type)
 # A state row carrying only the fields a check names, with the rest at the
 # database defaults — notably reduce_hit_ratio 100, which is "does not blind".
 def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
@@ -2716,7 +2724,9 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                actor_msg: nil, enemy_msg: nil, recovery_msg: nil,
                hp_map_steps: 0, hp_map_val: 0, sp_map_steps: 0, sp_map_val: 0,
                affect_type: 2, affect_attack: false, affect_defense: false,
-               affect_spirit: false, affect_agility: false)
+               affect_spirit: false, affect_agility: false,
+               hp_change_type: Game::States::CHANGE_TYPE_LOSE,
+               sp_change_type: Game::States::CHANGE_TYPE_LOSE)
   FakeStateDef.new(restriction, hp_val, hp_max, sp_val, sp_max, hold_turn,
                    auto_release, release_by_attack, reduce_hit_ratio,
                    restrict_skill, restrict_skill_level,
@@ -2724,7 +2734,8 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                    name, color, priority, actor_msg, enemy_msg, recovery_msg,
                    hp_map_steps, hp_map_val, sp_map_steps, sp_map_val,
                    affect_type, affect_attack, affect_defense,
-                   affect_spirit, affect_agility)
+                   affect_spirit, affect_agility,
+                   hp_change_type, sp_change_type)
 end
 # An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
@@ -8659,15 +8670,49 @@ check 'battle poison slips HP each turn (fixed val + percent of max)' do
   eq 85, hero.hp                                     # 100 - (5 + 10) poison
 end
 
-check 'battle poison (percent of max) can knock the battler out' do
+check 'battle poison (percent of max) floors at 1 HP -- slip damage alone cannot knock the battler out' do
+  # Verified against EasyRPG's own Game_Battler::ApplyConditions
+  # (src/game_battler.cpp): it calls ChangeHp(src_hp, /* lethal = */ false),
+  # which floors at 1 regardless of how large the computed slip is -- state
+  # slip damage can wear a battler down but never itself end its turn in
+  # death, the same non-lethal rule the map-side field-poison drain already
+  # follows (see "map slip damage cannot kill" above). Only a direct attack or
+  # skill can actually finish a battler off.
   states = { 2 => FakeStateDef.new(0, 0, 100, 0, 0) } # 100% of max HP / turn
   hero = combatant('Hero', 0, 0, 1, 50)               # slow so the slip lands
   hero.states = [2]
-  foe = combatant('Foe', 0, 0, 99, 100)               # fast but nearly harmless
+  foe = combatant('Foe', 0, 0, 99, 100)               # fast but harmless (0 atk)
   bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), states)
-  bat.run
-  ok hero.dead?, 'the poison finished the hero off'
-  eq :defeat, bat.result
+  bat.run_round
+  eq 1, hero.hp, 'a 100%-of-max poison tick floors at 1, not 0'
+  ok !hero.dead?, "state slip damage alone can't finish the hero off"
+  eq nil, bat.result, 'the battle is not decided by poison alone'
+  bat.run_round                                       # a second round: still floors, no lower
+  eq 1, hero.hp
+  ok !hero.dead?
+end
+
+check 'battle: a GAIN-type state heals per turn instead of draining, clamped to max' do
+  # hp_change_type/sp_change_type == Game::States::CHANGE_TYPE_GAIN (a
+  # "regen"-style state) adds instead of subtracts, clamped to max_hp/max_mp
+  # the same as an ordinary heal; CHANGE_TYPE_NOTHING does neither despite a
+  # nonzero configured amount.
+  states = { 2 => fake_state(hp_max: 100, hp_change_type: Game::States::CHANGE_TYPE_GAIN) }
+  hero = combatant('Hero', 0, 0, 1, 50)               # max HP 50
+  hero.hp = 40                                        # took some damage on the way
+  hero.states = [2]
+  foe = combatant('Foe', 0, 0, 99, 100)               # fast but harmless (0 atk)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), states)
+  bat.run_round
+  eq 50, hero.hp, 'a 100%-of-max regen heals to (and clamps at) max_hp'
+
+  inert = { 3 => fake_state(hp_val: 50, hp_change_type: Game::States::CHANGE_TYPE_NOTHING) }
+  hero2 = combatant('Hero2', 0, 0, 1, 50)
+  hero2.states = [3]
+  bat2 = Game::Battle.new([hero2], [combatant('Foe2', 0, 0, 99, 100)],
+                           Game::Rng.new(1), inert)
+  bat2.run_round
+  eq 50, hero2.hp, 'CHANGE_TYPE_NOTHING neither drains nor heals'
 end
 
 check 'battle: a "do nothing" state (restriction 1) skips the turn' do
@@ -9154,20 +9199,41 @@ end
 
 check 'States.map_step_drain: a slip lands only on a multiple of its interval' do
   # mtf-meido-action's Poison, the only state in either test bed that slips on
-  # the map: 1 HP every 4 walked tiles.
+  # the map: 1 HP every 4 walked tiles. The default (unset) hp_change_type/
+  # sp_change_type is LOSE, so the returned delta is negative -- see the
+  # "type-aware" check below for GAIN/NOTHING.
   table = { 2 => fake_state(name: 'Poison', hp_map_steps: 4, hp_map_val: 1) }
   eq [0, 0], Game::States.map_step_drain(2, table, 1)
   eq [0, 0], Game::States.map_step_drain(2, table, 3)
-  eq [1, 0], Game::States.map_step_drain(2, table, 4)
+  eq [-1, 0], Game::States.map_step_drain(2, table, 4)
   eq [0, 0], Game::States.map_step_drain(2, table, 5)
-  eq [1, 0], Game::States.map_step_drain(2, table, 8)
+  eq [-1, 0], Game::States.map_step_drain(2, table, 8)
   # Step 0 is a multiple of every interval, so it has to be excluded outright --
   # otherwise standing still on a fresh map would drain on the first frame.
   eq [0, 0], Game::States.map_step_drain(2, table, 0)
   # The SP half is the same field pair; nothing in either test bed uses it.
   sp = { 3 => fake_state(name: 'Drain', sp_map_steps: 2, sp_map_val: 3) }
-  eq [0, 3], Game::States.map_step_drain(3, sp, 2)
+  eq [0, -3], Game::States.map_step_drain(3, sp, 2)
   eq [0, 0], Game::States.map_step_drain(3, sp, 3)
+end
+
+check 'States.map_step_drain is type-aware: GAIN heals, NOTHING does nothing' do
+  # RPG2003's hp_change_type/sp_change_type (Game::States::CHANGE_TYPE_*):
+  # a "regen"-style field state (GAIN) returns a positive delta instead of a
+  # negative one, and NOTHING returns 0 despite a nonzero configured amount --
+  # verified against EasyRPG's own lcf::rpg::State::ChangeType enum and
+  # Game_Party::ApplyStateDamage (src/game_party.cpp).
+  regen = { 4 => fake_state(name: 'Regen', hp_map_steps: 2, hp_map_val: 5,
+                             hp_change_type: Game::States::CHANGE_TYPE_GAIN,
+                             sp_map_steps: 2, sp_map_val: 3,
+                             sp_change_type: Game::States::CHANGE_TYPE_GAIN) }
+  eq [5, 3], Game::States.map_step_drain(4, regen, 2)
+  eq [0, 0], Game::States.map_step_drain(4, regen, 3), 'not a multiple: no delta either way'
+
+  inert = { 5 => fake_state(name: 'Inert', hp_map_steps: 2, hp_map_val: 5,
+                             hp_change_type: Game::States::CHANGE_TYPE_NOTHING) }
+  eq [0, 0], Game::States.map_step_drain(5, inert, 2),
+     'NOTHING drains and heals neither, despite a configured amount'
 end
 
 check 'States.map_step_drain: a half-configured row drains nothing' do
@@ -9226,6 +9292,26 @@ check 'map slip damage cannot kill: it floors at 1 HP' do
   ally.add_state(2)
   ally.set_hp(0)
   eq [hero], st.party.apply_map_step_damage(table, 3)
+end
+
+check 'map slip damage: a GAIN-type state heals instead of draining, clamped to max_hp/max_sp' do
+  # A field "regen" state (hp_change_type/sp_change_type == CHANGE_TYPE_GAIN)
+  # is the opposite of Poison: it adds, not subtracts, and -- unlike the LOSE
+  # floor-at-1 rule -- simply clamps at the actor's own max, the same as any
+  # other heal (change_hp/change_mp's own existing clamp).
+  table = { 2 => fake_state(name: 'Regen', hp_map_steps: 1, hp_map_val: 30,
+                             hp_change_type: Game::States::CHANGE_TYPE_GAIN,
+                             sp_map_steps: 1, sp_map_val: 30,
+                             sp_change_type: Game::States::CHANGE_TYPE_GAIN) }
+  st = party_state
+  hero = st.party.actor_by_id(1)
+  hero.add_state(2)
+  hero.set_hp(hero.max_hp - 5)
+  before_mp = hero.mp
+  hit = st.party.apply_map_step_damage(table, 1)
+  eq [hero], hit
+  eq hero.max_hp, hero.hp, 'a 30 HP regen against a 5-HP deficit clamps to max, not overshoots'
+  eq [hero.max_mp, before_mp + 30].min, hero.mp
 end
 
 check 'two slipping states stack rather than the worse one winning' do


### PR DESCRIPTION
## Summary
- Found while cross-checking the `situation` (state) database table's `hp_change_type`/`sp_change_type` fields (RPG2003 fields 45/46) for anything parsed-but-unused — the same pattern that produced the `levitate` and `Appear Transparent` fixes.
- `Game::Battle#apply_turn_states` (per-turn battle slip damage) always treated a state's HP/SP change as an unconditional loss with no floor, so it could reduce a battler straight to 0/dead. Real EasyRPG's `Game_Battler::ApplyConditions` calls `ChangeHp(src_hp, /* lethal = */ false)`, which floors at 1 HP — state slip damage alone can never end a battler's turn in death. The codebase's own comment even documented the wrong behavior as intentional ("slip damage (which may knock it out)").
- Neither the battle path nor the map-step path (`Game::States.drain`/`Party#apply_map_step_damage`) read `hp_change_type`/`sp_change_type` at all — every state was assumed to be a "lose" type, when `lcf::rpg::State::ChangeType` is a three-way enum (lose/gain/nothing) and both `Game_Battler::ApplyConditions` and `Game_Party::ApplyStateDamage` branch on it explicitly. A "regen"-type custom state would have been drained instead of healed.
- Added `Game::States::CHANGE_TYPE_LOSE/GAIN/NOTHING`; `.drain`/`.map_step_drain` now return a signed delta; `Party#apply_map_step_damage` applies it directly (gain clamps to max instead of always subtracting). `Battle#apply_turn_states` now routes through a new `Battle#slip_stat(cur, max, amount, type, floor)` helper — floor 1 for HP (non-lethal), floor 0 for SP.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 756 checks pass (rewrote the pre-existing incorrect "battle poison can knock the battler out" test into "...floors at 1 HP"; added GAIN/NOTHING-type battle slip and map drain checks — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 467 checks pass
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_