### PR TITLE
rpg2k: show the highlighted item's description on the Equip screen

### DIFF
--- a/changelog.d/rpg2k-equip-item-description.added.md
+++ b/changelog.d/rpg2k-equip-item-description.added.md
@@ -1,0 +1,12 @@
+- **The Equip screen now shows the highlighted item's description**, in a
+  one-line banner across the very top of the screen. Found by comparing
+  against a genuine `RPG_RT.exe` under wine: RPG_RT draws the database
+  item's own `description` field there for whichever item is under the
+  cursor (the slot's currently-equipped item, or the highlighted candidate
+  while picking a replacement) -- `Scene::EquipMenu` drew no such banner at
+  all. The fix also closes out a testing-infrastructure bug that had been
+  blocking a clean wine capture of this screen: the retry loop used to
+  detect "has the screen changed yet" by diffing the whole frame, which
+  false-positived on the cursor itself moving between menu rows as often as
+  on a real screen change. Narrowing the diff to just the menu's own region
+  fixed that.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2160,6 +2160,36 @@ The work below is roughly ordered by the critical path to a walkable game
   (e.g. OCR/template-matching the captured frame itself to confirm the
   screen actually changed, rather than trusting either a fixed retry count
   or a naive pixel diff).
+  ✅ **A whole-frame pixel diff was itself the bug in that "smarter
+  automation loop."** Cropping the retry's change-check down to just the
+  menu command-list's own region, rather than diffing the entire frame,
+  fixed it -- a whole-frame diff had been false-positiving on the *cursor
+  itself moving between menu rows* (an expected, harmless difference) as
+  often as on the screen genuinely changing, which is exactly backwards from
+  what a "did Equip open yet" check needs. With that fixed, a clean,
+  freshly-opened Equip frame finally came through, and it found a real gap:
+  **RPG_RT draws the highlighted item's own database `description` in a
+  one-line banner across the very top of the Equip screen**
+  (`[斬光風龍神]イリスの想いを宿す時の剣` for a weapon named
+  エターナルメモリー) -- `Scene::EquipMenu` drew no such banner at all. Fixed
+  (`build_desc_window`/`refresh_desc`, tracking either the slot's equipped
+  item or the highlighted candidate depending on mode), and the fixed
+  screen's banner text now matches RPG_RT's field-for-field.
+  **Left open, found by the same clean capture:** the four combat stats
+  RPG_RT showed on that Equip screen (870/407/868/880 for
+  atk/def/spi/agi) do not match what either engine's own
+  level-curve-plus-equipment-bonus formula computes for this actor (484/531/
+  352/380 -- independently re-derived straight from the database's growth
+  curve and each equipped item's `atk_points1`/`def_points1`/`spi_points1`/
+  `agi_points1` fields, and it lands on exactly what this engine already
+  displays). Not fixed, on purpose: a single ambiguous data point isn't
+  enough to tell "RPG_RT applies some additional modifier this engine
+  doesn't read" apart from "this specific frame was mid-cascade from the
+  same blind-retry input queue that made Equip's reachability flaky in the
+  first place" (the retries that reach Equip cannot be trusted not to have
+  also nudged something else along the way). Needs a second, independently
+  reproduced RPG_RT capture of the same actor's Equip screen before acting
+  on it either way.
 
 #### Assets & infrastructure
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -15,6 +15,11 @@ class RPG2k
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
 
+      # Height of the item-description banner at the very top of the screen
+      # (see #build_desc_window) -- the stats/slot/candidate windows below it
+      # are all offset down by this much.
+      DESC_H = LINE_H + Window::BORDER * 2
+
       def initialize parent, state
         super parent
         @state = state
@@ -27,11 +32,13 @@ class RPG2k
           term(:weapon, "Weapon"), term(:shield, "Shield"), term(:armor, "Armor"),
           term(:helmet, "Helmet"), term(:accessory, "Accessory")
         ]
+        build_desc_window
         build_stats_window
         build_slot_window
       end
 
       def dispose
+        @desc_window.dispose if @desc_window
         @stats_window.dispose if @stats_window
         @slot_window.dispose if @slot_window
         @cand_window.dispose if @cand_window
@@ -129,6 +136,7 @@ class RPG2k
           @cand_window.dispose
           @cand_window = nil
         end
+        refresh_desc
       end
 
       def rebuild_for_actor
@@ -137,11 +145,41 @@ class RPG2k
         build_slot_window
       end
 
+      # The highlighted item's flavour text, in a one-line banner across the
+      # very top of the screen -- confirmed against genuine RPG_RT under
+      # wine, which shows the database item's own `description` field there
+      # (e.g. a weapon's "[斬光風龍神]イリスの想いを宿す時の剣"); this scene
+      # drew no such banner at all. Tracks whichever item is currently under
+      # the cursor: the slot's own equipped item in :slots mode, or the
+      # highlighted candidate in :items mode (blank for the leading Remove
+      # entry and for an empty slot, matching there being no item to
+      # describe).
+      def build_desc_window
+        @desc_window.dispose if @desc_window
+        inner_w = SCREEN_W - Window::BORDER * 2
+        @desc_window = Window.new(0, 0, SCREEN_W, DESC_H)
+        @desc_window.z = 400
+        @desc_window.windowskin = @skin
+        @desc_contents = Bitmap.new(inner_w, LINE_H)
+        @desc_window.contents = @desc_contents
+        refresh_desc
+      end
+
+      def refresh_desc
+        return unless @desc_contents
+        id = @mode == :items ? candidates[@cand_index].first : actor.equipment[@slot_index]
+        it = id && id != 0 ? @state.party.db_item(id) : nil
+        text = it ? it.description.to_s : ''
+        @desc_contents.clear
+        @desc_contents.font.color = Color.new(255, 255, 255, 255)
+        @desc_contents.draw_text 0, 0, @desc_contents.width, LINE_H, text
+      end
+
       def build_stats_window
         @stats_window.dispose if @stats_window
         inner_w = SCREEN_W - Window::BORDER * 2
         h = LINE_H * 3
-        @stats_window = Window.new(0, 0, SCREEN_W, h + Window::BORDER * 2)
+        @stats_window = Window.new(0, DESC_H, SCREEN_W, h + Window::BORDER * 2)
         @stats_window.z = 400
         @stats_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
@@ -161,7 +199,7 @@ class RPG2k
         @slot_window.dispose if @slot_window
         inner_w = SCREEN_W - Window::BORDER * 2
         h = @slots.size * LINE_H
-        y = LINE_H * 3 + Window::BORDER * 2
+        y = DESC_H + LINE_H * 3 + Window::BORDER * 2
         @slot_window = Window.new(0, y, SCREEN_W, h + Window::BORDER * 2)
         @slot_window.z = 400
         @slot_window.windowskin = @skin
@@ -180,6 +218,7 @@ class RPG2k
         return unless @slot_window
         @slot_window.cursor_rect =
           Rect.new(0, @slot_index * LINE_H, @slot_window.contents.width, LINE_H)
+        refresh_desc
       end
 
       # yado.tk: the equip-list comparison arrow is the *sum* of all four
@@ -243,6 +282,7 @@ class RPG2k
         return unless @cand_window
         @cand_window.cursor_rect =
           Rect.new(0, @cand_index * LINE_H, @cand_window.contents.width, LINE_H)
+        refresh_desc
       end
     end
 


### PR DESCRIPTION
## Summary

Continuing the wine-based field-menu UI survey. Fixes a real, wine-verified gap and a testing-infrastructure bug that had been blocking a clean capture of the Equip screen.

- **Testing infra fix**: the retry loop used to detect "has the Equip screen changed yet" diffed the *whole frame* against a baseline, which false-positived on the cursor itself moving between menu rows (an expected, harmless difference) as often as on the screen genuinely opening — exactly backwards from what the check needed. Narrowing the diff to just the menu command-list's own region fixed it, finally producing a clean, freshly-opened Equip frame from genuine `RPG_RT.exe`.
- **Real UI gap found and fixed**: that clean frame showed RPG_RT draws the highlighted item's own database `description` field in a one-line banner across the very top of the Equip screen (e.g. a weapon's flavor text, `[斬光風龍神]イリスの想いを宿す時の剣`) — `Scene::EquipMenu` drew no such banner at all. Fixed with a new desc window that tracks either the slot's equipped item or the highlighted candidate depending on mode; verified the fixed screen's banner text matches RPG_RT's exactly.
- `docs/TODO.md` is updated: the earlier "flaky race" note on Equip/Save reachability now records the actual root cause (the whole-frame-diff bug) and the fix, and a genuinely open, *not* acted-on discrepancy the same clean capture surfaced is recorded rather than guessed at — RPG_RT's displayed combat stats (870/407/868/880) don't match either engine's own level-curve-plus-equipment-bonus formula (484/531/352/380, independently re-derived from the database and matching what this engine already computes). A single ambiguous data point from a screen reached via blind retries isn't enough to act on; it needs a second, independently reproduced capture first.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 467 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 753 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] Rebuilt the native engine and verified under wine against genuine `RPG_RT.exe`: the Equip screen's description banner now shows the exact same text as RPG_RT
- [x] Rebased onto latest `master` (this branch's prior commits are already merged) and re-ran the full check suite against the rebased state


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_