### PR TITLE
rpg2k: a map event's custom-route move index now survives a same-map save/load

### DIFF
--- a/changelog.d/map-event-custom-route-index-survives-save.fixed.md
+++ b/changelog.d/map-event-custom-route-index-survives-save.fixed.md
@@ -1,0 +1,24 @@
+- **A map event's own page-authored custom move route now resumes at its
+  exact command when a save is loaded, instead of restarting from the top.**
+  `Scene::Map#build_event` always built a fresh `Game::MoveRoute` at index 0
+  from the page's own `move_route` field, with no override path at all — the
+  already-fixed wandered-position restore only ever carried tile x/y/facing
+  across a save/load, leaving the route's own execution index unmodelled
+  (flagged in `Game::State#map_event_positions`' own comment: "plus a
+  move-route index this codebase does not attempt to round-trip yet"). Fixed
+  with a new `Game::State#map_event_route_index` (event id => `Game::MoveRoute
+  #index`), scoped and round-tripped identically to `#map_event_positions`
+  (Marshal-save-only, per-map, cleared on `#perform_teleport`), and a new
+  `Game::MoveRoute#resume_at(i)` that seeks a freshly-built route to that
+  saved cursor — including reproducing the `@commands.size` sentinel a
+  finished non-repeating route leaves behind, so a route saved right after it
+  naturally finished stays finished on load rather than re-running its last
+  step. Scoped away from `Scene::Map#rebuild_events_preserving_positions` (the
+  live, in-place page-reselection rebuild any unrelated event's switch write
+  can trigger) via a new `restore_route_index:` keyword, so a bystander whose
+  own page just changed to a genuinely different route always starts that
+  route at index 0 rather than seeking into an index that belonged to its old
+  page's route; a bystander whose route did *not* change keeps getting its
+  full-fidelity live object back exactly as before. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks, one confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5840,23 +5840,64 @@ same-map page-reselection copy loop is unaffected by the new override: it
 already overwrites `x`/`y`/`direction` from the live pre-rebuild character
 right after `build_events` runs, so the saved-position lookup is
 functionally a no-op there, just a harmless extra read before being
-immediately superseded by the fresher live value. **Not addressed**: the
-move-route execution *index* itself — the "a map event's move route/
-execution point if paused mid-way" claim in the "persists across both
-map-revisit and save/load" list below — a custom-route event mid-loop
-still restarts its route from the top after this fix exactly as it did
-before; only its raw tile position and facing are restored. Matching real
-RPG_RT's own `original_move_route_index`/`move_route_index` fields
-(`src/game_character.h`, alongside `move_route_finished`) would need those
-threaded through separately, a larger follow-up left open. Covered by a
-new `scripts/rpg2k_logic_check.rb` check (`map_event_positions` round-trips
-through `to_h`/`.load`, with a legacy-save fallback to `{}`) and a new
-`scripts/rpg2k_scene_check.rb` check (a Move Event forces event 2 two
-tiles east and turns it to face down via Proceed With Movement; a
-save/load taken afterward restores exactly that spot on a fresh
-`Scene::Map`, while an ordinary Transfer Player back to the same map id
-instead resets it to its own page default), both confirmed to fail against
-the pre-fix code before the fix.
+immediately superseded by the fresher live value. ✅ **The move-route
+execution *index* itself — the "a map event's move route/execution point
+if paused mid-way" claim in the "persists across both map-revisit and
+save/load" list below, explicitly left as "Not addressed" here and flagged
+again in `Game::State#map_event_positions`' own comment ("plus a move-route
+index this codebase does not attempt to round-trip yet") — is now
+implemented too, for a page's own CUSTOM-move-type route specifically.** A
+custom-route event mid-loop used to restart its route from the top on every
+Save/Continue, since `Scene::Map#build_event` always built a fresh
+`Game::MoveRoute` at index 0 straight from the page's own `move_route`
+field, with no override path of any kind — only the position/facing half
+above was ever threaded through. Fixed with a new `Game::State
+#map_event_route_index` (event id => `Game::MoveRoute#index`), scoped and
+round-tripped identically to `#map_event_positions` right above it (Marshal-
+save-only, per-map, cleared on `#perform_teleport`): `#record_map_event_positions`
+now also snapshots `e[:route].index` every frame for any event whose current
+page has a live custom route, and a new `Game::MoveRoute#resume_at(i)` seeks
+a freshly-built route to that saved cursor in `#build_event` — including
+reproducing `#advance_cursor`'s own `@commands.size` sentinel for a
+non-repeating route that had already finished by save time (marking `#done?`
+true again rather than clamping into a bogus re-run of the last command). A
+genuine map re-visit still restarts every route fresh, matching the position
+half's own scoping and the existing "does not survive a map re-visit"
+list above (`#perform_teleport` clears `#map_event_route_index` alongside
+`#map_event_positions`). One correctness wrinkle the naive version of this
+fix would have introduced, caught and closed before landing: `Scene::Map
+#rebuild_events_preserving_positions` (the *live*, in-place page-reselection
+rebuild any unrelated event's switch/variable write can trigger — see the
+"A Map Event's own... Parallel Process" and "Change Graphic" fixes above)
+also calls `#build_events`/`#build_event`, and unconditionally consulting
+`#map_event_route_index` there would misapply a *stale* index recorded for
+whichever route this event id's *previous* page was running onto a freshly
+selected, unrelated route on its new page — that rebuild's own follow-up
+copy loop already restores a bystander's own *unchanged* route with full
+live fidelity (`e[:route] = old[:route]` when `same_route?`), so the saved-
+index path only needed to fire for the very first build of a scene (a
+genuine Continue), not this one. Fixed with a new `restore_route_index:`
+keyword threaded through `#build_events`/`#build_event`, `true` by default
+(`Scene::Map#initialize`, `#perform_teleport` — moot there anyway, since
+`#map_event_route_index` is cleared immediately before that call) and passed
+`false` only from `#rebuild_events_preserving_positions`. The
+`original_move_route_index`/`move_route_index` real-RPG_RT fields this
+bullet cites remain unmodelled at the `.lsd` layer (chunk 111's
+`SaveMapEvent`/`SAVE_MOVABLE` schema still has no documented field for
+this), matching `#common_event_progress`'s identical "Marshal save only, not
+yet `.lsd`" scoping. Covered by two new `scripts/rpg2k_scene_check.rb`
+checks: a non-repeating 4-tile custom route snapshotted partway through (via
+`to_h`/`Game::State.load`) resumes a fresh `Scene::Map` at the exact saved
+command index and tile, then finishes only the *remaining* distance rather
+than replaying the whole route, confirmed to fail against the pre-fix code
+(`expected 2, got 0`) before the fix; and a two-page event whose page 2 (a
+different, unrelated custom route) is selected mid-visit by an outside
+switch write starts that new route at index 0, not a stale index carried
+over from page 1's own route — passing unchanged before this fix too (there
+was no saved-index consultation at all yet to leak), added as a standing
+regression guard against the exact mistake described above. The earlier
+`map_event_positions` round-trip and Proceed-With-Movement save/load checks
+this same paragraph already listed are unaffected and still pass.
 
 State that does **not** survive a save/load specifically (distinct from
 mere map-revisit): screen-shake offset (never saved, always resets);

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4145,6 +4145,30 @@ module Game
     def repeat?; @repeat; end
     def skippable?; @skippable; end
 
+    # Resume this route's cursor at a saved index (Scene::Map#build_event
+    # restoring a Save/Continue taken mid-route -- see Game::State
+    # #map_event_route_index / #record_map_event_positions). `i` is whatever
+    # raw #index a still-running route last snapshotted, including the
+    # `@commands.size` sentinel #advance_cursor leaves behind on a *finished*
+    # non-repeating route (@index left one past the last command, @done set
+    # true) -- reproduced here rather than clamped into the last command, or
+    # a save taken the instant such a route naturally finished would silently
+    # re-run its final step on load. A mid-repeat-loop index (always
+    # in-bounds, since #advance_cursor wraps a repeating route back to 0
+    # itself rather than ever leaving it at the sentinel) resumes exactly
+    # where it left off. Out-of-range in the other direction (a negative or
+    # stale index from a shorter/edited route) clamps to the start instead of
+    # raising.
+    def resume_at(i)
+      return if @commands.empty?
+      if i >= @commands.size
+        @index = @commands.size
+        @done = true
+      else
+        @index = [i, 0].max
+      end
+    end
+
     # Build a MoveRoute from an event page's parsed `move_route` field (an
     # LCF::Array1D exposing commands/repeat/skippable), or nil when the page
     # carries no custom route.
@@ -8600,6 +8624,20 @@ module Game
     # across one, the same "resets on leaving-and-returning" family as
     # #encounter_rate/#parallax just above.
     attr_accessor :map_event_positions
+    # The current map's own live custom-move-route (page move_type CUSTOM)
+    # cursor, event id => Game::MoveRoute#index, snapshotted alongside
+    # #map_event_positions -- the "move-route index this codebase does not
+    # attempt to round-trip yet" gap #map_event_positions' own comment above
+    # used to flag. A map event mid-way through its page's own custom route
+    # when a Save/Continue is taken now resumes at the exact same command
+    # instead of restarting the route from the top, matching real RPG_RT's
+    # SaveMapEvent chunk (still opaque here, see LCF::Schema::SAVE_MOVABLE --
+    # this is Marshal-save-only, same as #common_event_progress). Scoped
+    # identically to #map_event_positions in every other way: per-map, reset
+    # on #perform_teleport, and only ever consulted for a page whose move_type
+    # is CUSTOM (Scene::Map#build_event's `e[:route]`) -- a page with no
+    # custom route of its own leaves a stale entry here unread and harmless.
+    attr_accessor :map_event_route_index
 
     def initialize(party, map_id, x, y)
       @party = party
@@ -8637,6 +8675,7 @@ module Game
       @escape_target = nil
       @common_event_progress = {}
       @map_event_positions = {}
+      @map_event_route_index = {}
       @system_bgm = {}
       @system_sfx = {}
       # nil = "not configured yet"; #seed_screen_transitions fills each slot in
@@ -8852,6 +8891,7 @@ module Game
         teleport_targets: @teleport_targets,
         common_event_progress: @common_event_progress,
         map_event_positions: @map_event_positions,
+        map_event_route_index: @map_event_route_index,
         steps: @steps,
         save_count: @save_count, battle_count: @battle_count,
         win_count: @win_count, defeat_count: @defeat_count,
@@ -9299,6 +9339,7 @@ module Game
       state.teleport_targets = h[:teleport_targets] || {}
       state.common_event_progress = h[:common_event_progress] || {}
       state.map_event_positions = h[:map_event_positions] || {}
+      state.map_event_route_index = h[:map_event_route_index] || {}
       state.escape_target = h[:escape_target]
       state.system_bgm = h[:system_bgm] || {}
       state.system_sfx = h[:system_sfx] || {}

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -845,7 +845,18 @@ class RPG2k
       # Game::Character, tagged with its trigger, command list and how it moves
       # (autonomous move type, or a custom Game::MoveRoute). @event_tiles caches
       # the tiles events occupy, for collision and markers.
-      def build_events
+      # `restore_route_index:` gates whether a fresh page-CUSTOM route's cursor
+      # consults Game::State#map_event_route_index at all (see #build_event) --
+      # true only for the very first build for this scene (a brand new
+      # Scene::Map, i.e. genuinely resuming a save rather than continuing live
+      # play), matching #new_parallel's identical "only the first build" scoping
+      # for a Common Event's own saved progress. #rebuild_events_preserving_positions
+      # passes false: its own follow-up copy loop already restores a bystander's
+      # *unchanged* route with full live fidelity (the actual running object,
+      # not a saved index), and a route that legitimately changed this rebuild
+      # must restart at 0, not seek into an unrelated saved index left over from
+      # whatever this same event id's route was doing before the rebuild.
+      def build_events(restore_route_index: true)
         @events = []
         @event_tiles = {}
         evs = @map.unit.events
@@ -861,7 +872,7 @@ class RPG2k
                                             @state.variables, @state.party)
           next unless selected
           page = selected[1]
-          @events.push(build_event(id, ev, page))
+          @events.push(build_event(id, ev, page, restore_route_index: restore_route_index))
         end
         rebuild_event_tiles
       rescue StandardError => e
@@ -870,7 +881,7 @@ class RPG2k
         @event_tiles = {}
       end
 
-      def build_event(id, ev, page)
+      def build_event(id, ev, page, restore_route_index: true)
         dir = Game::EventGraphic.numpad_direction(page_direction(page))
         x, y = ev.x, ev.y
         # A saved wandered position (see #record_map_event_positions) wins over
@@ -905,6 +916,23 @@ class RPG2k
         move_type = page_move_type(page)
         route = move_type == Game::MoveType::CUSTOM ?
                 Game::MoveRoute.from_page(page_move_route(page)) : nil
+        # A saved mid-route cursor (see #record_map_event_positions) resumes a
+        # page's own custom route at the exact command it was on rather than
+        # restarting from the top -- the "move-route index" half of the saved-
+        # position restore just above, previously left unmodelled (see Game::
+        # State#map_event_route_index). Harmless when this page has no custom
+        # route of its own (route is nil) or nothing was ever saved for this
+        # id; `restore_route_index` is false only for
+        # #rebuild_events_preserving_positions' in-place, live rebuild, where
+        # applying a saved index here would be wrong twice over -- a bystander
+        # whose route didn't change gets the actual running object back
+        # wholesale a few lines below in that method (full fidelity, not a
+        # coarser index), and one whose route genuinely did change must
+        # restart at 0, not seek into an index that belonged to a different
+        # route entirely.
+        if restore_route_index && route && (saved_index = @state.map_event_route_index[id])
+          route.resume_at(saved_index)
+        end
         # `page` is kept so a refresh can tell whether the conditions still pick
         # the same one (see #pages_changed?).
         { id: id, char: ch, page: page, trigger: page_trigger(page),
@@ -932,11 +960,16 @@ class RPG2k
       # current map's own event ids, which #perform_teleport clears before a
       # genuine map change (see there) -- an ordinary map re-visit (leave and
       # return, no save involved) still resets every event, matching the
-      # "Save / Load persistence" list in docs/TODO.md.
+      # "Save / Load persistence" list in docs/TODO.md. Also snapshots a
+      # currently-running page-custom move route's own cursor (e[:route], only
+      # ever non-nil for a page whose move_type is CUSTOM -- see #build_event)
+      # into Game::State#map_event_route_index, so the same restore resumes an
+      # in-progress custom route at its exact command rather than the top.
       def record_map_event_positions
         @events.each do |e|
           ch = e[:char]
           @state.map_event_positions[e[:id]] = [ch.x, ch.y, ch.direction]
+          @state.map_event_route_index[e[:id]] = e[:route].index if e[:route]
           # Also keeps @event_last_position current for #event_id_at's hidden-
           # event fallback -- see #build_events' seeding comment.
           @event_last_position[e[:id]] = [ch.x, ch.y, ch.direction]
@@ -2276,7 +2309,9 @@ class RPG2k
       def rebuild_events_preserving_positions
         placed = {}
         @events.each { |e| placed[e[:id]] = e }
-        build_events
+        # false: this is a live, in-place page reselection, not a save/load
+        # restore -- see #build_event's own comment on `restore_route_index`.
+        build_events(restore_route_index: false)
         @events.each do |e|
           old = placed[e[:id]]
           next unless old
@@ -6722,8 +6757,13 @@ class RPG2k
         # stale entry to an unrelated event on the destination map. Dropped
         # here, before the destination's own events are built, so every one of
         # them falls back to its own page's default placement, matching an
-        # ordinary map re-visit (see #record_map_event_positions).
+        # ordinary map re-visit (see #record_map_event_positions). The same
+        # applies to a saved custom-route cursor: dropped alongside so a
+        # destination event beginning its own page's route starts at the top,
+        # not part-way through wherever a same-numbered event on the map being
+        # left happened to be.
         @state.map_event_positions = {}
+        @state.map_event_route_index = {}
         @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3637,6 +3637,87 @@ check "a wandered map event's position and facing survive a save/load, but " \
      'placement, unlike a genuine save/load'
 end
 
+check "a page's own custom move route resumes at its saved cursor across a save/load, not from the top" do
+  # docs/TODO.md's "Save / Load persistence -- consolidated master list": "a
+  # map event's move route/execution point if paused mid-way" is documented
+  # to survive a save/load -- Game::State#map_event_positions' own comment
+  # explicitly flagged the move-route index as "this codebase does not
+  # attempt to round-trip yet" even after the position/facing half was
+  # fixed. Scene::Map#build_event always built a fresh Game::MoveRoute at
+  # index 0 from the page's own move_route field, with no override path at
+  # all, so a save taken mid-way through a non-repeating custom route
+  # restarted it from the very first command on Continue instead of
+  # resuming where it actually left off.
+  ic = Game::Interpreter::Cmd
+  ev = event(0, 1, page(x_move_type: Game::MoveType::CUSTOM,
+                        route: move_route([R::MOVE_RIGHT, R::MOVE_RIGHT,
+                                           R::MOVE_RIGHT, R::MOVE_RIGHT],
+                                          repeat: false)))
+  db = fake_db
+  events = { 1 => ev }
+  state = Game::State.new(fake_party, 1, 5, 5)
+  state.map = fake_map(1, events)
+  parent = FakeParent.new(db) { |id| fake_map(id, events) }
+  scene = RPG2k::Scene::Map.new(parent, state)
+
+  15.times { scene.update } # partway through the 4-tile route
+  e = scene.instance_variable_get(:@events).first
+  c = e[:char]
+  ok c.x > 0 && c.x < 4, "expected partial progress into the route, got x=#{c.x}"
+  ok !e[:route].done?, 'the route has not finished yet'
+  saved_index = e[:route].index
+
+  restored = Game::State.load(db, Marshal.load(Marshal.dump(state.to_h)))
+  restored.map = fake_map(1, events)
+  fresh = RPG2k::Scene::Map.new(FakeParent.new(db) { |id| fake_map(id, events) },
+                                restored)
+  re = fresh.instance_variable_get(:@events).first
+  eq saved_index, re[:route].index,
+     'the restored route resumes at the exact command it was on, not index 0'
+  eq c.x, re[:char].x, 'the character position agrees (the already-fixed position half)'
+
+  # Driving the restored scene onward finishes only the *remaining* distance,
+  # not the full 4-tile route replayed from scratch.
+  40.times { fresh.update }
+  fc = fresh.instance_variable_get(:@events).first[:char]
+  eq 4, fc.x, 'the route completes to its actual endpoint from the resumed cursor'
+end
+
+check "a page's own custom-route index does not leak onto an unrelated page's " \
+      'different route during a live, in-place page reselection' do
+  # The save/load restore above must not also fire during Scene::Map's own
+  # *live* rebuild (#rebuild_events_preserving_positions, triggered whenever
+  # any event's page selection changes mid-visit): that path already
+  # restores a bystander event's own *unchanged* route with full live
+  # fidelity a few lines further down in the very same method (the real
+  # running Game::MoveRoute object, not a coarser saved index), and a route
+  # that genuinely changed this rebuild -- a different page entirely -- must
+  # restart at its own index 0, not seek into Game::State
+  # #map_event_route_index's most recently recorded index for the event id,
+  # which still describes the *old* page's route, not the new one.
+  page1 = page(x_move_type: Game::MoveType::CUSTOM,
+              route: move_route([R::MOVE_RIGHT, R::MOVE_RIGHT,
+                                 R::MOVE_RIGHT, R::MOVE_RIGHT], repeat: false))
+  page2 = page(x_move_type: Game::MoveType::CUSTOM,
+              route: move_route([R::MOVE_LEFT], repeat: true))
+  ev = two_page_event(0, 1, 5, page1, page2)
+  scene = new_scene({ 1 => ev }, player: [5, 4])
+  st = scene.instance_variable_get(:@state)
+
+  20.times { scene.update } # partway through page 1's own route
+  e = scene.instance_variable_get(:@events).first
+  ok e[:route].index > 0, "expected partial progress into page 1's route, got index #{e[:route].index}"
+
+  st.switches[5] = true
+  scene.update # page 2's condition now holds: an in-place page reselection runs
+
+  e2 = scene.instance_variable_get(:@events).first
+  ok !e2[:page].equal?(e[:page]), 'page 2 is now the active page'
+  eq 0, e2[:route].index,
+     "page 2's own different route starts at its own index 0, not a stale " \
+     "index carried over from page 1's unrelated route"
+end
+
 check "Proceed With Movement blocks a Parallel Process's own interpreter, not just the foreground's" do
   # docs/TODO.md, `2k/09_bug/017_heiretu_totyu_end/hei_mukou.htm`: Set Move
   # Route + "wait for completion" is documented to block whichever event's


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Save / Load persistence — consolidated master list" explicitly flagged "a map event's move route/execution point if paused mid-way" as **not addressed**, with a matching flag left in the `Game::State#map_event_positions` code comment: "plus a move-route index this codebase does not attempt to round-trip yet."
- `Scene::Map#build_event` always constructed a fresh `Game::MoveRoute` at index 0 from a page's own `move_route` field on every build. The earlier "wandered position survives save/load" fix only carried tile x/y/facing across a save; a map event mid-way through a non-repeating custom route would silently restart that route from its first command on every Continue.
- Added `Game::MoveRoute#resume_at(i)` (seeks a route's cursor to a saved index, correctly reproducing the `@commands.size` "already finished" sentinel for a non-repeating route); added `Game::State#map_event_route_index` (event id → route index), round-tripped through `to_h`/`.load`, scoped identically to the existing `map_event_positions`.
- `record_map_event_positions` now also snapshots `e[:route].index` each frame; `build_event` applies a saved index via `resume_at` when present. A new `restore_route_index:` keyword (default `true`) is explicitly passed `false` from `rebuild_events_preserving_positions` — the *live*, in-place page-reselection rebuild any unrelated event's switch write can trigger — so a bystander whose page changes to a genuinely different route never gets a stale index misapplied onto it.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 759 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 472 checks pass (2 new: a non-repeating 4-tile custom route snapshotted partway through, restored via `to_h`/`Game::State.load` into a fresh `Scene::Map`, resumes at the exact saved index/position and finishes only the remaining distance — confirmed to fail against the pre-fix code; a two-page event whose page 2 is selected mid-visit by an outside switch write starts at index 0, not a leaked stale index — a standing regression guard)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_