### PR TITLE
rpg2k: Continue no longer re-derives Save/Teleport/Escape access from the map

### DIFF
--- a/changelog.d/rpg2k-continue-save-access-not-map-derived.fixed.md
+++ b/changelog.d/rpg2k-continue-save-access-not-map-derived.fixed.md
@@ -1,0 +1,14 @@
+- **Continue could silently lose a save's own Save/Teleport/Escape access,
+  overridden by whatever the current map's tree happens to say instead.**
+  `Scene::Map#initialize` unconditionally re-derived all three access flags
+  from the current map's tree property, which is correct for a fresh map
+  entry (New Game, Transfer Player, Teleport) but wrong for a Continue,
+  which resumes a state that already carries its own values restored from
+  the save (set by a prior Change Save/Teleport/Escape Access event
+  command). Verified under wine: the field-menu Save command on genuine
+  `RPG_RT.exe` opened the real file-select screen on a save whose own
+  `save_allowed` flag was on, on a map the tree itself flags
+  Save-forbidden -- RPG_RT does not re-derive on Continue either.
+  `Scene::Map.new` gained an `apply_access:` keyword (default true) and
+  `RPG2k#continue_game` now passes `apply_access: false`, covering both the
+  headless `--rpg2k_continue` path and the in-game Continue/Load screen.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2239,6 +2239,38 @@ The work below is roughly ordered by the critical path to a walkable game
   also nudged something else along the way). Needs a second, independently
   reproduced RPG_RT capture of the same actor's Equip screen before acting
   on it either way.
+  ✅ **Continue could silently lose a save's own Save/Teleport/Escape access,
+  overridden by whatever the current map's tree happens to say instead.**
+  Chasing the Save screen with the fixed crop-region retry (above) turned up
+  a correctness bug, not just a UI one: `Scene::Map#initialize`
+  unconditionally called `#apply_map_access`, which re-derives all three
+  access flags from the *current map's* tree property -- right for a fresh
+  map entry (a New Game, or any Transfer Player / Teleport, which
+  `#perform_teleport` already calls it for separately), wrong for a
+  Continue, which resumes a state that already carries its own values
+  (restored by `Game::State.load`/`.from_lsd` from whatever a prior Change
+  Save/Teleport/Escape Access command left them as -- exactly the "an event
+  command override persists for the rest of that map's visit" case
+  `#apply_map_access`'s own comment already described, which a Continue is
+  still inside the middle of, not a fresh entry to). Verified under wine:
+  the field-menu Save command on genuine `RPG_RT.exe` opened the real
+  file-select screen on a save whose own `save_allowed` flag was on, on a
+  map the tree itself flags Save-forbidden -- proof RPG_RT does not
+  re-derive on Continue either. `Scene::Map.new` gained an `apply_access:`
+  keyword (default true, so every other caller is unchanged) and
+  `RPG2k#continue_game` passes `apply_access: false`; both the headless
+  `--rpg2k_continue` path and the in-game Continue/Load screen
+  (`Scene::SaveLoad`, which calls the same `#continue_game`) go through it.
+  **Left open by the same fixed capture:** RPG_RT's save-file-select screen
+  shows one taller box per slot with just the leader's name/level/HP and
+  only 3 of 15 slots visible per screen (presumably scrolling); this
+  engine's own screen packs more per slot (gold and the current map name
+  too, matching the README's own description of what it shows) and fits 6
+  slots without scrolling. A real layout/format difference, not chased into
+  a fix here -- unlike the access-flag bug above it is not a correctness
+  question, and picking which of RPG_RT's specific choices (box height,
+  slots-per-screen, which fields to show) to match wants its own pass
+  rather than folding into this one.
 
 #### Assets & infrastructure
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -730,7 +730,12 @@ class RPG2k
       return
     end
     state.map = load_map state.map_id
-    scene = Scene::Map.new(self, state)
+    # apply_access: false -- a resumed save already carries its own
+    # save/teleport/escape access (restored by Game::State.load / .from_lsd
+    # from whatever a prior Change Save/Teleport/Escape Access command left
+    # it as), which re-deriving from the current map's tree here would
+    # silently discard. See Scene::Map#initialize's own comment.
+    scene = Scene::Map.new(self, state, apply_access: false)
     @scenes.last.dispose
     @scenes = [scene]
     # Same marker start_new_game emits, so a headless run resuming a save (see

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -68,7 +68,22 @@ class RPG2k
       MOVE_TARGET_AIRSHIP = 10004
       MOVE_TARGET_THIS    = 10005
 
-      def initialize parent, state
+      # `apply_access:` is false only for a Continue resume (see main.rb's
+      # continue_game) -- every other caller (a fresh New Game, and every
+      # ordinary map load besides) wants the default true. Re-deriving
+      # save/teleport/escape access from the map tree here unconditionally
+      # was wrong for Continue specifically: verified under wine against a
+      # genuine RPG_RT.exe, whose Save command opened the real file-select
+      # screen on a map the tree itself flags Save-forbidden, because the
+      # save being resumed had that access explicitly granted (chunk 101's
+      # save_allowed) by a prior Change Save Access command -- exactly the
+      # "an event command override persists for the rest of that map's
+      # visit" case #apply_map_access's own comment already describes, which
+      # a Continue is still inside the middle of, not a fresh entry to. Every
+      # other call site *is* a fresh entry (New Game's first map, and every
+      # Transfer Player / Teleport via #perform_teleport's own separate call)
+      # and keeps re-deriving as before.
+      def initialize parent, state, apply_access: true
         super parent
         @state = state
         # Named graphics loaded and memoized on demand -- see #cached_bitmap.
@@ -83,7 +98,7 @@ class RPG2k
         @backdrop_cache = {}  # Backdrop/<name> (battle background)
         @monster_cache = {}   # Monster/<name> (battler graphics)
         @animation_cache = {} # Battle/<name> (battle animation sheets)
-        apply_map_access
+        apply_map_access if apply_access
         play_map_bgm
         @map = state.map
         @chipset = build_chipset


### PR DESCRIPTION
## Summary

Continuing the wine-based field-menu survey, extended to the Save screen. Found a real correctness bug, not just a cosmetic one.

- `Scene::Map#initialize` unconditionally called `#apply_map_access`, which re-derives `save_access`/`teleport_access`/`escape_access` from the *current map's own tree property*. That's correct for a fresh map entry (New Game, Transfer Player, Teleport — `#perform_teleport` already calls it separately for those) but wrong for a Continue, which resumes a state that already carries its own values restored from the save (set by a prior Change Save/Teleport/Escape Access event command) — exactly the "an event command override persists for the rest of that map's visit" case `#apply_map_access`'s own comment already described, which a Continue is still inside the middle of, not a fresh entry to.
- Verified under wine: with a save's own `save_allowed` flag flipped on, genuine `RPG_RT.exe`'s field-menu Save command opened the real file-select screen even though the current map's tree flags Save-forbidden — proof RPG_RT does not re-derive access on Continue either. This engine's own Continue, by contrast, silently discarded the save's `save_allowed` and kept showing "you cannot save right now."
- `Scene::Map.new` gained an `apply_access:` keyword (default `true`, so `start_new_game` and `perform_teleport` are unchanged), and `RPG2k#continue_game` now passes `apply_access: false`. Both the headless `--rpg2k_continue` path and the in-game Continue/Load screen (`Scene::SaveLoad`, which calls the same `#continue_game`) go through the fix.
- A separate, non-correctness difference the same fixed capture surfaced — RPG_RT's save-file-select screen uses a taller per-slot box showing fewer fields and 3 slots per screen, where this engine's shows 6 slots with more fields (gold, current map) — is recorded as an open item in `docs/TODO.md` rather than folded into this fix.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 470 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 759 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed
- [x] Rebuilt the native engine and verified under wine against genuine `RPG_RT.exe`: on a save whose `save_allowed` was on but whose current map forbids saving, this engine's Save command now opens the real file-select screen instead of "you cannot save right now", matching RPG_RT
- [x] Rebased onto latest `master` (this branch's prior commits are already merged) and re-ran the full check suite against the rebased state


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_