### PR TITLE
rpg2k: confirm map animation always draws below the picture layer

### DIFF
--- a/changelog.d/map-animation-below-pictures-confirmed.changed.md
+++ b/changelog.d/map-animation-below-pictures-confirmed.changed.md
@@ -1,0 +1,17 @@
+- **A map's Show Battle Animation drawing under the picture layer, and
+  characters always drawing below every picture, are confirmed already
+  correct** — closing two long-standing "still open" z-order questions,
+  verified against EasyRPG Player's actual C++ source rather than guessed
+  at. `Drawable::Priority` (`src/drawable.h`) orders `Priority_PictureOld`
+  (120) above `Priority_BattleAnimation` (110), and `Sprite_Picture`'s
+  constructor (`src/sprite_picture.cpp`) seeds every picture there
+  unconditionally — the lower, animation-above-pictures ordering only
+  applies when `Player::IsMajorUpdatedVersion()` detects the "RPG2000
+  Value!" English re-release or a specifically patched RPG2003 runtime, a
+  file/version signal this project has no way to observe from a plain
+  `.ldb`/`.lmt`/`.lmu` triple and no test-bed game exercises. This runtime's
+  `Scene::Map#setup_sprites` already places `@animation_sprite` (z 150)
+  below `@picture_sprite` (z 250), and `@player_sprite` already sorts
+  beneath the picture layer through the same existing z-order check.
+  Pinned by name, not just transitively, with a new direct assertion added
+  to the existing `scripts/rpg2k_scene_check.rb` map-layer-order check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4033,10 +4033,36 @@ not yet verified:
   (`@picture_sprite.z = 250`, the message window's `z = 300`), already
   covered by an existing check. Covered by a new
   `scripts/rpg2k_scene_check.rb` check (two pictures shown out of id order,
-  asserting the composite draws the lower id first). Still open: Battle
-  Animation drawing above the picture layer specifically, and "map/
-  characters always draw below all pictures" as its own assertion. (Not the
-  same question as "no Pictures on the battle screen" — ✅ fixed, see the
+  asserting the composite draws the lower id first). ✅ **The two "still
+  open" z-order questions this bullet used to leave dangling — a map's Show
+  Battle Animation drawing above the picture layer specifically, and "map/
+  characters always draw below all pictures" as its own assertion — are now
+  both settled, confirmed already correct, verified against EasyRPG Player's
+  actual C++ source rather than guessed at.** `Drawable::Priority`
+  (`src/drawable.h`) orders `Priority_PictureOld = 120 << z_offset` *above*
+  `Priority_BattleAnimation = 110 << z_offset`, and `Sprite_Picture`'s
+  constructor (`src/sprite_picture.cpp`) seeds every picture at
+  `Priority_PictureOld + pic_id` unconditionally — only overridden by the
+  *lower* `Priority_PictureNew` (100, below BattleAnimation) when
+  `feature_priority_layers` (`Player::IsMajorUpdatedVersion()`) detects the
+  "RPG2000 Value!" English re-release or a specifically patched RPG2003
+  English runtime (`ultimate_rt_eb.dll` on disk) — a file/version signal this
+  project's plain `.ldb`/`.lmt`/`.lmu` triple has no way to observe and no
+  test-bed game exercises, so it is out of scope rather than a gap. For every
+  ordinary RPG2000/RPG2003 database this runtime reads, a picture belongs
+  *over* a map animation, and `Scene::Map#setup_sprites`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) already places `@animation_sprite` at
+  z 150, below `@picture_sprite`'s z 250 — confirmed correct, not merely
+  by construction (both already sat on the right sides of the "map layers
+  composite in a fixed order, under the overlays" check's `top` boundary,
+  z 150 < top 200 < z 250) but now pinned by name: a new direct assertion in
+  that same `scripts/rpg2k_scene_check.rb` check compares
+  `@animation_sprite`'s z to `@picture_sprite`'s z rather than relying on the
+  transitive relationship alone. The "characters always draw below all
+  pictures" half needed no separate assertion: `@player_sprite` (z 100) is
+  already one of the `MAP_LAYER_IVARS` the same check sorts beneath `top`,
+  which sits below every `ABOVE_MAP_IVARS` entry including the picture layer.
+  (Not the same question as "no Pictures on the battle screen" — ✅ fixed, see the
   **Picture** bullet under "Untriaged backlog, from `2k/01_shoshin/
   011_siyou/`" above — which is about the picture layer being hidden
   outright while a fight is running, not about its z-order relative to the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -397,6 +397,21 @@ class RPG2k
         # one block against its siblings (gfx_update's per-parent z sort), so
         # pulling this one sprite out changes only whether the map's tone
         # reaches it, not where it draws relative to the layers around it.
+        # z 150 also settles a previously-open question: it sits below
+        # @picture_sprite (z 250), so a Show Battle Animation always draws
+        # *under* the picture layer. EasyRPG Player's own Drawable::Priority
+        # enum (src/drawable.h) orders `Priority_PictureOld = 120 << z_offset`
+        # above `Priority_BattleAnimation = 110 << z_offset` -- the ordering
+        # every standard RPG2000/RPG2003 database uses, since Sprite_Picture's
+        # constructor (src/sprite_picture.cpp) seeds every picture at
+        # `Priority_PictureOld + pic_id` unconditionally, only overridden by
+        # `Priority_PictureNew` (100, *below* BattleAnimation) when
+        # `feature_priority_layers` -- `Player::IsMajorUpdatedVersion()` --
+        # detects the "RPG2000 Value!" English re-release or a specifically
+        # patched RPG2003 English runtime (`ultimate_rt_eb.dll`), neither of
+        # which this project has any file/version signal to detect from a
+        # plain .ldb/.lmt/.lmu triple. So "pictures always draw over a map
+        # animation" is correct for every ordinary database this runtime reads.
         @animation_sprite = Sprite.new
         @animation_sprite.z = 150
         @animation_sprite.visible = false

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -766,6 +766,16 @@ check 'the map layers composite in a fixed order, under the overlays' do
     ok z > top, "#{i} (z=#{z}) must draw over the map (top z=#{top})"
   end
 
+  # A previously "still open" question, now settled directly rather than only
+  # transitively through the two checks above: a map's Show Battle Animation
+  # (@animation_sprite) must draw *under* the picture layer, not over it.
+  # EasyRPG Player's own Priority enum (src/drawable.h) puts
+  # Priority_PictureOld (120) above Priority_BattleAnimation (110) for every
+  # standard RPG2000/RPG2003 database -- see the citation next to
+  # @animation_sprite.z in Scene::Map#setup_sprites.
+  ok sprite_z(scene, :@animation_sprite) < sprite_z(scene, :@picture_sprite),
+     'a map animation draws under the picture layer, not over it'
+
   # The three vehicles sit between the shadow and the hero.
   vs = scene.instance_variable_get(:@vehicle_sprites)
   vs.each_value do |s|


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s **Pictures** bullet (under "Full-site sweep") had left two z-order questions "still open": whether a map's Show Battle Animation draws above or below the picture layer, and whether characters always draw below every picture. Verified both against EasyRPG Player's real C++ source rather than guessing.
- `Drawable::Priority` (`src/drawable.h`) orders `Priority_PictureOld = 120 << z_offset` *above* `Priority_BattleAnimation = 110 << z_offset`, and `Sprite_Picture`'s constructor (`src/sprite_picture.cpp`) seeds every picture at `Priority_PictureOld + pic_id` unconditionally. The lower, animation-above-pictures ordering (`Priority_PictureNew`, 100) only kicks in when `feature_priority_layers` — `Player::IsMajorUpdatedVersion()` — detects the "RPG2000 Value!" English re-release or a specifically patched RPG2003 runtime (`ultimate_rt_eb.dll` on disk), a file/version signal this project has no way to observe from a plain `.ldb`/`.lmt`/`.lmu` triple and no test-bed game exercises.
- For every ordinary RPG2000/RPG2003 database this runtime reads, a picture belongs *over* a map animation — which `Scene::Map#setup_sprites` already implements (`@animation_sprite` at z 150, below `@picture_sprite`'s z 250). Confirmed already correct, no behavior change; only previously covered transitively (both sides of the existing "map layers composite in a fixed order" check's `top` boundary).
- Adds a direct, named regression assertion (`@animation_sprite`'s z below `@picture_sprite`'s z) to `scripts/rpg2k_scene_check.rb`'s existing map-layer-order check, and a citation-backed comment next to the `@animation_sprite.z = 150` assignment in `mruby-rpg2k/mrblib/scene/map.rb`.
- Updates `docs/TODO.md` to mark both "still open" questions ✅ resolved, and adds a `changelog.d` fragment.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 759 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 470 checks passed (includes the new direct z-order assertion)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
- [ ] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped (no test-bed game data available under sandbox network restrictions: "no RPG2000 game dir found under ./data")
- [ ] `ruby scripts/rpg2k_command_soak.rb` — skipped (same reason: "no game found under ./data")

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BSr5tvwxheZ62SZW5btHUn)_