### PR TITLE
rpg2k: confirm field-menu item recovery has no 999 HP/SP cap

### DIFF
--- a/changelog.d/field-item-recovery-no-cap-confirmed.changed.md
+++ b/changelog.d/field-item-recovery-no-cap-confirmed.changed.md
@@ -1,0 +1,16 @@
+- **The field-menu medicine path has no 999 HP/SP recovery cap, unlike the
+  battle skill/item path — confirmed rather than an open yado.tk claim.**
+  Verified against EasyRPG Player's actual C++ source: `Scene_ActorTarget`
+  applies a medicine through `Game_Party::UseItem` -> `Game_Actor::UseItem`
+  and ends in a bare status-window refresh, no popup of any kind, unlike a
+  battle round's own floating heal number — and the HP itself is clamped
+  only by `Game_Actor::ClampMaxHpMod`'s `MaxHpValue()`, never a fixed digit
+  constant. `Game::Party#use_item`/`#use_medicine` already matches this: it
+  applies `#item_recovery`'s raw amount straight through `Actor#change_hp`,
+  which clamps to `[floor, max_hp]` and nothing tighter, unlike
+  `Game::Battle#apply_skill_hit`'s battle-cast recovery branch (capped at
+  999 there). Pinned by a new `scripts/rpg2k_logic_check.rb` check on an
+  RPG2003 fixture (needed since an RPG2000 actor's own `max_hp` is itself
+  capped at 999): a raw 9999 HP heal against a 9999-max-HP target sitting at
+  1 HP lands at the full 9999, not 1 + 999 = 1000 the way the battle-cast
+  equivalent clamps.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3303,7 +3303,28 @@ not yet verified:
   is a separate, unconfirmed question left open. Regression coverage added
   to `scripts/rpg2k_logic_check.rb`: a recovery skill computing a raw 5000
   HP heal against a high-max-HP target clamps at 999, confirmed to fail
-  against the pre-fix code.
+  against the pre-fix code. ✅ **The field-menu item-use path is now settled
+  too, confirmed already correct — no code change needed.** Verified against
+  EasyRPG Player's actual C++ source rather than left as a guess:
+  `Scene_ActorTarget` (`src/scene_actortarget.cpp`, the field Item screen's
+  target picker) applies a medicine through `Game_Party::UseItem` ->
+  `Game_Actor::UseItem` and ends in a bare `status_window->Refresh()` — no
+  popup of any kind, unlike a battle round's own floating damage/heal number
+  — and the HP itself is clamped only by `Game_Actor::ClampMaxHpMod`, which
+  reads the actor's own `MaxHpValue()`, never a fixed digit constant; there is
+  no equivalent of `MaxDamageValue`/a 999 popup cap anywhere in this call
+  chain. This codebase's `Game::Party#use_item`/`#use_medicine`
+  (`mruby-rpg2k/mrblib/game.rb`) already matches that exactly: it applies
+  `#item_recovery`'s raw amount straight through `Actor#change_hp`, which
+  clamps to `[floor, max_hp]` and nothing tighter — no `RECOVER_CAP`-style
+  constant is threaded through this path at all, unlike
+  `Game::Battle#apply_skill_hit`'s battle-cast recovery branch just above.
+  Pinned by a new `scripts/rpg2k_logic_check.rb` check on an RPG2003 fixture
+  (needed since an RPG2000 actor's own `max_hp` is itself capped at 999 via
+  `MAX_EFFECTIVE_HP_2K`, which would make "clamped only by max_hp"
+  indistinguishable from a 999 popup cap by coincidence): a raw 9999 HP heal
+  against a 9999-max-HP target sitting at 1 HP lands at the full 9999, not
+  1 + 999 = 1000 the way the already-fixed battle-cast equivalent clamps.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3916,6 +3916,42 @@ check 'use_item on an already-full target has no effect and consumes nothing' do
   eq 2, st.party.item_count(5)                 # not consumed
 end
 
+check "the field-menu medicine path has no 999 cap, unlike the battle skill/item path (yado.tk, docs/TODO.md's " \
+      "\"Special-skill HP recovery is capped at 999 per use\" bullet)" do
+  # Game::Battle::RECOVER_CAP=999 exists purely because real RPG_RT's in-battle
+  # heal amount pops up in a fixed 3-digit widget over the target's sprite --
+  # confirmed against EasyRPG Player's actual C++ source rather than guessed
+  # at: Scene_ActorTarget (the field Item screen's target picker) applies a
+  # medicine via Game_Party::UseItem -> Game_Actor::UseItem with no popup of
+  # any kind (just a bare status_window->Refresh() of the HP/SP numbers), and
+  # the HP itself is clamped only by Game_Actor::ClampMaxHpMod, which reads the
+  # actor's own MaxHpValue(), never a fixed digit constant. This codebase's
+  # Game::Party#use_item/#use_medicine already matches that: it applies
+  # #item_recovery's raw amount straight through Actor#change_hp, which clamps
+  # to [0, max_hp] and nothing tighter -- no RECOVER_CAP-style constant is
+  # threaded through this path at all, unlike Game::Battle#apply_skill_hit's
+  # battle-cast recovery branch a few sections below.
+  #
+  # An RPG2000-flagged actor's own max_hp is itself capped at
+  # MAX_EFFECTIVE_HP_2K (999, see Game::Actor#max_hp_cap), which would make
+  # "clamped only by max_hp" indistinguishable from a 999 popup cap by
+  # coincidence -- so this needs an RPG2003 fixture (MAX_EFFECTIVE_HP_2K3 =
+  # 9999) to actually separate the two: a raw heal of 9999 (rhp_rate 100% of a
+  # 9999 max_hp actor) against a target sitting at 1 HP lands at the full
+  # 9999, not 1 + 999 = 1000 the way a battle-cast equivalent would clamp.
+  items = { 5 => fake_item(type: 6, rhp_rate: 100) }
+  players = { 1 => FakePlayerRow.new('Titan', '', 0, 5, max_hp: 9_999, max_mp: 30) }
+  db2003 = FakeActorDB.new(players, [1], items, {}, {}, nil, nil, rpg2003: true)
+  st = Game::State.new(Game::Party.new(db2003), 1, 0, 0)
+  st.party.gain_item(5, 1)
+  hero = st.party.leader
+  eq 9_999, hero.max_hp, 'the RPG2003 fixture actually reaches past 999 max HP'
+  hero.change_hp(-9_998)                        # 9999 -> 1
+  affected = st.party.use_item(5, hero)
+  eq [hero], affected
+  eq 9_999, hero.hp, 'the full uncapped heal lands, not clamped to 1 + 999'
+end
+
 check 'an all-ally medicine heals the whole party and consumes one' do
   items = { 8 => fake_item(type: 6, scope: 1, rhp_rate: 100) } # full HP heal
   st = item_party(items)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Special-skill HP recovery is capped at 999 per use" bullet fixed the battle skill/item recovery path (`Game::Battle::RECOVER_CAP`), but explicitly left the field-menu item-use path (`Game::Party#item_recovery`) as "a separate, unconfirmed question left open," reasoning that it "doesn't show the same fixed-width popup."
- Verified against EasyRPG Player's actual C++ source rather than left as a guess: `Scene_ActorTarget` (the field Item screen's target picker) applies a medicine through `Game_Party::UseItem` → `Game_Actor::UseItem`, ending in a bare `status_window->Refresh()` — no popup of any kind, unlike a battle round's own floating heal number. The HP itself is clamped only by `Game_Actor::ClampMaxHpMod`, which reads the actor's own `MaxHpValue()`, never a fixed digit constant — there is no `MaxDamageValue`-style cap anywhere in this call chain.
- This codebase's `Game::Party#use_item`/`#use_medicine` already matches that exactly: it applies `#item_recovery`'s raw amount straight through `Actor#change_hp`, which clamps to `[floor, max_hp]` and nothing tighter. No code change needed — confirmed already correct.
- Added a regression check pinning this fact. It needs an RPG2003 fixture: an RPG2000 actor's own `max_hp` is itself capped at 999 (`MAX_EFFECTIVE_HP_2K`), which would make "clamped only by max_hp" indistinguishable from a 999 popup cap by coincidence, so the check uses a 9999-max-HP RPG2003 actor (`MAX_EFFECTIVE_HP_2K3`) to actually separate the two. Confirmed the check fails (`expected 9999, got 1000`) against a temporarily-injected 999 cap, then reverted.
- `docs/TODO.md` updated ✅ with the citation; changelog fragment added.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 760 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 470 checks pass
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [ ] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped, sandbox has no network access to download the test-bed data (`no RPG2000 game dir found under ./data`)
- [ ] `ruby scripts/rpg2k_command_soak.rb` — skipped, same reason (`no game found under ./data`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BswyxfnsvquMTUJaXSJUSR)_