### PR TITLE
rpg2k: a Parallel Process's own Input Number now opens the shared message window too

### DIFF
--- a/changelog.d/parallel-process-input-number.fixed.md
+++ b/changelog.d/parallel-process-input-number.fixed.md
@@ -1,0 +1,24 @@
+- **A Parallel Process's own Input Number command now actually opens the
+  shared digit-entry widget**, both the standalone panel and the
+  merged-onto-a-preceding-Show-Text shape, instead of being silently
+  dropped. `Scene::Map#drive_parallel_wait` had cases for `:message`/
+  `:choice` (see "A Parallel Process's own Show Text/Show Choices now
+  actually opens the shared message window") but none for `:number`, so a
+  Common Event or map event Parallel Process's own Input Number fell into
+  the generic "background: ignore..." branch and the interpreter sailed
+  straight past it — the widget never appeared, and the next command ran
+  as if it had been a no-op. Fixed by adding an `interp:` keyword to
+  `#open_number_input` (mirroring `#open_message`'s own, defaulting to the
+  foreground `@interpreter`), threading it through `#drive_number_input`'s
+  confirm handler in place of a hardcoded `@interpreter`, and adding a
+  `:number` case to `#drive_parallel_wait` that opens the widget for a
+  fresh request (`@message.nil?`) or the requesting process's own already-
+  open message (`@message[:interp].equal?(it)`, the merged shape) and
+  otherwise leaves it parked to retry next frame — the `:choice` case
+  above gained the identical `@message[:interp].equal?(it)` widening for
+  its own merged shape, which was equally unreachable before this fix.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (a Common
+  Event's standalone Input Number opens its own compact panel and blocks
+  the process until confirmed; a map event's Show Text immediately
+  followed by Input Number merges into the same still-open window),
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4609,19 +4609,53 @@ not yet verified:
   `@message` already does (`#event_busy?`), while other Parallel Processes
   keep ticking independently of it exactly as an open message never pauses
   them (`#parallels_paused?` only checks `@battle_ui`/a bursting foreground).
-  **Left open**: Input Number (`:number`) issued from a Parallel Process is
-  still silently dropped — `#open_number_input`'s standalone panel and its
-  merged-into-`@message` follow-up are both foreground-only machinery today,
-  a narrower, separate gap this fix does not close. Covered by three new
-  `scripts/rpg2k_scene_check.rb` checks (a Common Event Parallel Process's own
-  Show Text opens the window, blocks the command after it, then resumes once
-  dismissed; a map event Parallel Process's own Show Choices opens, and the
-  picked branch — not the other one — runs once resumed; a Parallel Process's
-  own Show Text blocks for the whole time the foreground's own message stays
-  open, then opens its own and resumes *itself*, not the foreground, proving
-  the tracked `interp:` owner is threaded through correctly rather than
-  hardcoded), all three confirmed to fail against the pre-fix code (the
-  window never opening, or opening on the wrong first attempt).
+  Covered by three new `scripts/rpg2k_scene_check.rb` checks (a Common Event
+  Parallel Process's own Show Text opens the window, blocks the command
+  after it, then resumes once dismissed; a map event Parallel Process's own
+  Show Choices opens, and the picked branch — not the other one — runs once
+  resumed; a Parallel Process's own Show Text blocks for the whole time the
+  foreground's own message stays open, then opens its own and resumes
+  *itself*, not the foreground, proving the tracked `interp:` owner is
+  threaded through correctly rather than hardcoded), all three confirmed to
+  fail against the pre-fix code (the window never opening, or opening on
+  the wrong first attempt). ✅ **Input Number (`:number`) issued from a
+  Parallel Process — this same bullet's own "left open" half — is now
+  fixed too, standalone panel and merged-into-`@message` follow-up alike.**
+  `#drive_parallel_wait` had no `:number` case at all (unlike the `:message`/
+  `:choice` cases just fixed above), so it fell into the generic
+  "background: ignore..." `#resume` branch and the request was silently
+  dropped outright — the widget never appeared, and the command right after
+  Input Number ran on the very next tick as if it had been a no-op. Fixed by
+  giving `#open_number_input` (`mruby-rpg2k/mrblib/scene/map.rb`) an
+  `interp:` keyword mirroring `#open_message`'s own (default the foreground
+  `@interpreter`, recorded on the new `@number_input[:interp]`),
+  `#drive_number_input`'s confirm handler reading it back (`ni[:interp] ||
+  @interpreter`) instead of always resuming `@interpreter`, and a new
+  `:number` case in `#drive_parallel_wait` that opens the widget through the
+  existing `#open_number_input`. The merged-follow-up shape needed one more
+  piece beyond a bare `:number` case, though, and it turned out the already-
+  landed `:choice` case above shared the identical gap: both guarded only on
+  `@message.nil?`, which is false for a process's *own* still-open window
+  awaiting its own follow-up (`@message[:awaiting_followup]`, set by
+  `#drive_text_message` once the preceding Show Text finishes typing but
+  before the interpreter has actually reached the Choice/Number command) —
+  so a Show Text immediately followed by Show Choices or Input Number from a
+  Parallel Process left that process parked forever the instant its own
+  window finished typing, never reaching the follow-up at all, worse than
+  the "silently dropped" a standalone request got. Both cases now read
+  `@message.nil? || @message[:interp].equal?(it)`, letting a process
+  recognise its own already-open window's follow-up (which `#open_message`/
+  `#open_number_input` were already able to merge into — see the `awaiting_
+  followup` check inside each — just never reached from this side) while a
+  genuinely different, unrelated request still waits its turn until whichever
+  window is currently up closes. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (a Common Event Parallel Process's
+  standalone Input Number opens its own compact panel, blocks the command
+  after it, and resumes with the entered value once confirmed; a map event
+  Parallel Process's Show Text immediately followed by Input Number merges
+  into the same still-open window, `@number_input[:embedded]` true, and
+  closes both the widget and the message together on confirm), both
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A Face Graphic setting persists through the rest of the current event's
   execution content (not just the next message) and is auto-cleared when
   the event ends, but not before** — it must be explicitly "erased" to stop

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1492,8 +1492,33 @@ class RPG2k
           # single window as :message just above, with no implicit-auto-run
           # gate of its own -- matching #drive_event's own ungated :choice
           # dispatch, since only Wait/Show Text are documented auto-run
-          # trigger points, not Show Choices.
-          open_message(it.choice_labels, true, interp: it) if @message.nil?
+          # trigger points, not Show Choices. `@message[:interp].equal?(it)`
+          # covers the *merged* shape too -- a Show Choices immediately
+          # following this same process's own Show Text in the same window
+          # (#drive_text_message's `awaiting_followup`, resumed once typing
+          # finishes but not yet reached this command): @message is not nil
+          # there (it is this process's own still-open window), so the plain
+          # `@message.nil?` guard alone would leave it parked forever, never
+          # reaching #open_message's existing "append instead of opening
+          # fresh" branch. A genuinely new, unrelated request still waits its
+          # turn until whichever window is currently up closes.
+          if @message.nil? || @message[:interp].equal?(it)
+            open_message(it.choice_labels, true, interp: it)
+          end
+        elsif it.wait_kind == :number
+          # Input Number issued from a Parallel Process: the same shared
+          # window as :message/:choice above, standalone panel and the
+          # merged-onto-a-preceding-Show-Text shape alike (#open_number_input
+          # already tells the two apart via @message[:awaiting_followup], the
+          # same way #open_message does for :choice, just above). Before this
+          # branch existed this wait kind fell into the generic #resume
+          # below, so an Input Number issued from a Parallel Process was
+          # silently dropped outright -- docs/TODO.md "Left open: Input
+          # Number (:number) issued from a Parallel Process is still
+          # silently dropped."
+          if @message.nil? || @message[:interp].equal?(it)
+            open_number_input(it.input_digits, interp: it)
+          end
         elsif it.wait_kind == :screen
           # Erase/Show/Tint/Flash/Pan/Shake Screen issued with its own wait
           # flag from a Parallel Process: block that process until the effect
@@ -1514,12 +1539,7 @@ class RPG2k
           # the :screen/:picture cases just above.
           it.resume unless sprite_flashing?
         else
-          # :message and :choice are handled above now; an Input Number
-          # request (:number) is the one wait kind still silently dropped
-          # here -- #open_number_input's standalone (no preceding Show Text)
-          # panel and its embedded-in-@message follow-up are both
-          # foreground-only machinery today, a narrower, separate gap left
-          # open by this fix.
+          # :message, :choice and :number are all handled above now.
           it.resume
         end
       end
@@ -7430,14 +7450,20 @@ class RPG2k
       # window below the text already shown; otherwise a standalone compact
       # panel opens near the bottom of the screen. Either way the interpreter
       # is resumed with the entered value on confirm.
-      def open_number_input(digits)
+      #
+      # `interp:` is whichever interpreter's Input Number this answers to --
+      # the foreground @interpreter by default, or a Parallel Process's own
+      # interpreter when #drive_parallel_wait opens one (mirrors #open_message's
+      # own `interp:` keyword). #drive_number_input reads it back to resume the
+      # interpreter that actually asked for it rather than always @interpreter.
+      def open_number_input(digits, interp: @interpreter)
         return if @number_input
         model = Game::NumberInput.new(digits || 1)
         if @message && @message[:awaiting_followup] == :number
           @message[:awaiting_followup] = nil
           x = @message[:inner_w] - model.digits * NUM_CELL
           y = @message[:seg_lines].length * MSG_LINE_H
-          @number_input = { model: model, embedded: true, x: x, y: y }
+          @number_input = { model: model, embedded: true, x: x, y: y, interp: interp }
           draw_number_input
           return
         end
@@ -7449,7 +7475,7 @@ class RPG2k
         win.z = 320
         win.windowskin = @windowskin
         contents = Bitmap.new(inner_w, inner_h)
-        @number_input = { window: win, contents: contents, model: model }
+        @number_input = { window: win, contents: contents, model: model, interp: interp }
         draw_number_input
         win.contents = contents
       end
@@ -7497,9 +7523,10 @@ class RPG2k
         elsif Input.trigger?(Input::C)
           value = model.value
           embedded = ni[:embedded]
+          interp = ni[:interp] || @interpreter
           close_number_input
           close_message if embedded
-          @interpreter.resume_number(value)
+          interp.resume_number(value)
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3952,6 +3952,92 @@ check "a Parallel Process's own Show Text waits for the foreground's already-ope
      'the Parallel Process itself resumed (not the foreground) and ran its own command'
 end
 
+check "a Common Event Parallel Process's own standalone Input Number now actually opens the widget" do
+  # docs/TODO.md "Left open: Input Number (:number) issued from a Parallel
+  # Process is still silently dropped" -- #drive_parallel_wait had no :number
+  # case at all (unlike the already-fixed :message/:choice above), so the
+  # request fell into the generic "background: ignore..." #resume branch and
+  # the interpreter sailed straight past it, the command right after it
+  # running on the very next tick as if Input Number had been a no-op.
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false,
+                      event: [
+                        ECmd.new(ic::INPUT_NUMBER, [2, 5]),
+                        ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+                      ])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+
+  ni = nil
+  12.times do
+    scene.update
+    ni = scene.instance_variable_get(:@number_input)
+    break if ni
+  end
+  ok ni, "the Parallel Process's own Input Number opened the shared widget"
+  ok !ni[:embedded], 'a standalone Input Number opens its own compact panel'
+  ok !st.switches[1],
+     'the command after Input Number has not run yet -- the process is blocked on the widget'
+
+  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm
+  scene.update
+  ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
+  5.times { RGSS::Input.reset; scene.update }
+  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  ok st.switches[1], 'the Parallel Process resumed and ran the command after Input Number'
+end
+
+check "a Map Event Parallel Process's own Show Text + Input Number merges into the same window" do
+  # The merged shape docs/TODO.md's same "Left open" note names explicitly:
+  # "#open_number_input's standalone ... panel and its embedded-in-@message
+  # follow-up are both foreground-only machinery." @message is not nil once
+  # the process's own Show Text is still open awaiting this follow-up, so the
+  # plain "block until @message is nil" guard the standalone case alone would
+  # need is not enough here -- #open_message's own `@message[:interp].equal?
+  # (it)` check (mirrored for Input Number) is what lets it recognise this as
+  # its *own* window's follow-up rather than someone else's still-open one.
+  ic = Game::Interpreter::Cmd
+  pg = page(trigger: 4)
+  pg.event_commands = [
+    ECmd.new(ic::SHOW_MESSAGE, [], string: 'enter a value'),
+    ECmd.new(ic::INPUT_NUMBER, [2, 5]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0]),
+  ]
+  scene = new_scene({ 1 => event(2, 2, pg) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+
+  msg = open_msg(scene)
+  ok msg, "the Parallel Process's own Show Text opened the shared message window"
+
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # complete the (short) reveal
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update # advance past the finished text into the Input Number follow-up
+  RGSS::Input.reset # the still-held C from the dismiss above must not confirm the widget too
+
+  ni = nil
+  6.times do
+    scene.update
+    ni = scene.instance_variable_get(:@number_input)
+    break if ni
+  end
+  ok ni, "the Input Number follow-up opened, merged into the process's own still-open window"
+  ok ni[:embedded], 'merged onto the preceding Show Text, not a fresh standalone panel'
+  ok scene.instance_variable_get(:@message), 'the message window is still the one carrying it'
+
+  RGSS::Input.triggered = [RGSS::Input::UP] # tens digit 0 -> 1 (value 10)
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm
+  scene.update
+  ok !scene.instance_variable_get(:@number_input), 'the widget closed on confirm'
+  ok !scene.instance_variable_get(:@message), 'the merged message window closed with it'
+  5.times { RGSS::Input.reset; scene.update }
+  eq 10, st.variables[5], 'the entered value landed in variable 5'
+  ok st.switches[1], 'the Parallel Process resumed and ran the command after Input Number'
+end
+
 check "a forced route auto-runs to completion before an immediately-following Show Text opens (yado.tk)" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- Completes the message-window fix's explicitly left-open half: "Input Number (`:number`) issued from a Parallel Process is still silently dropped — `#open_number_input`'s standalone panel and its merged-into-`@message` follow-up are both foreground-only machinery today."
- `Scene::Map#drive_parallel_wait` had cases for `:message`/`:choice` and every other wait kind but none for `:number` — a Parallel Process's own Input Number command fell into the generic `else` branch and was silently dropped.
- While implementing, also found the *merged* follow-up shape (Show Text immediately followed by Show Choices/Input Number in the same window) was independently broken for a Parallel Process, including for the already-"fixed" `:choice` case: both guarded on `@message.nil?`, false while a process's own still-open window awaits its own follow-up (`@message[:awaiting_followup]`), so the process was left permanently parked rather than merely dropped.
- `#open_number_input` gained an `interp:` keyword (default `@interpreter`), recorded on `@number_input[:interp]`; `#drive_number_input`'s confirm handler resumes `ni[:interp] || @interpreter`. `#drive_parallel_wait`'s `:choice` case widened and a new `:number` case added, both guarded on `@message.nil? || @message[:interp].equal?(it)`.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 759 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 474 checks pass (2 new: a Common Event Parallel Process's standalone Input Number opens its own panel and resumes with the entered value; a map event Parallel Process's Show Text immediately followed by Input Number merges into the same still-open window, closing both together on confirm — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_