### PR TITLE
rpg2k: field menu no longer bleeds through behind Item/Skill/Equip/Status

### DIFF
--- a/changelog.d/rpg2k-menu-window-bleed-through.fixed.md
+++ b/changelog.d/rpg2k-menu-window-bleed-through.fixed.md
@@ -1,0 +1,7 @@
+- **Opening Item/Skill/Equip/Status from the field menu no longer leaves the
+  menu's own command list and status panel drawn behind the new screen.**
+  Verified against genuine `RPG_RT.exe` under wine: its Item screen shows
+  only its own item-list window, not the field menu's command/status panels
+  behind it. `RPG2k#push`/`#pop` now call an optional `#suspend`/`#resume` on
+  the scene being covered/uncovered, and `Scene::Menu` uses it to hide its
+  `@command`/`@status` windows while a child screen is on top.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2151,6 +2151,27 @@ The work below is roughly ordered by the critical path to a walkable game
   too**, not just inferred from the identical Item-screen code pattern: once
   reachable at all (see the reachability note below), RPG_RT's empty Skill
   screen showed the same blank cursor row, no "no skills" text.
+  ✅ **Opening Item (or Skill/Equip/Status) used to leave the field menu's own
+  command list and status panel visibly drawn behind/around the new
+  window.** Found the same way as the two placeholder gaps above: genuine
+  `RPG_RT.exe`'s Item screen under wine shows only its own item-list window
+  against the plain field backdrop, nothing else -- none of Item/Skill/
+  Equip/Status build a status/command panel of their own (they rely on
+  `Scene::Menu`'s own `@background` staying up behind them to cover the map,
+  the same full-screen-backdrop idiom `Scene::Base#build_field_background`
+  documents), but `Scene::Menu`'s own two windows (`@command`, the five-entry
+  list; `@status`, the party HP/MP panel) were never hidden while a child
+  screen sat on top of it -- they are ordinary RGSS windows that keep
+  rendering every frame until explicitly hidden or disposed, independent of
+  which scene is receiving input, and `Scene::Menu#dispose` (which does hide
+  them) only runs when Menu itself is popped, not when something is merely
+  pushed above it. `RPG2k#push` now calls an optional `#suspend` on the
+  scene it is about to cover, and `RPG2k#pop` calls an optional `#resume` on
+  the scene that becomes active again once the top is popped off --
+  `Scene::Menu` implements both, toggling `@command.visible`/
+  `@status.visible`. Verified against the same reference frame: our Item
+  screen now shows only its own window, and backing out with Escape
+  correctly restores the command list and status panel.
   **Left open by the same comparison, not fixed here:**
   - The Item/Skill list windows stay full-`SCREEN_W` wide even with nothing
     in them, where RPG_RT's own list window in that state is narrower (looks
@@ -2159,12 +2180,6 @@ The work below is roughly ordered by the critical path to a walkable game
     *populated* list on both engines, so it is recorded rather than guessed
     at: the window may simply always be full-width once real rows are drawn,
     which an empty list alone cannot tell apart from a genuine layout bug.
-  - Opening the Item/Skill screen leaves the parent command list and status
-    panel visibly drawn behind/around the new window instead of being fully
-    replaced, where RPG_RT's own screen shows only the one clean window --
-    seen on the Item screen specifically; not chased into a fix, since it
-    touches the scene stack's window-visibility handling and wants more than
-    one data point to scope correctly.
   - The Save command's "you cannot save right now" message (shown when
     `Change Save Access` has turned saving off) is a hardcoded English
     literal, the same class of bug the two placeholders above turned out to

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -554,16 +554,27 @@ class RPG2k
   end
   private :native_test_play?
 
+  # Push `scene` on top of the stack. The scene it covers gets a #suspend
+  # call first (Scene::Menu uses it to hide its own command/status windows --
+  # see the comment there) -- verified against genuine RPG_RT under wine:
+  # opening Item/Skill/Equip/Status from the field menu shows only that
+  # screen's own window, with none of the menu's own command list or status
+  # panel drawn behind it. Optional (`respond_to?`-gated) since most scenes
+  # have nothing of their own to hide from whatever gets pushed on top.
   def push scene
+    @scenes.last.suspend if @scenes.last && @scenes.last.respond_to?(:suspend)
     @scenes.push scene
   end
 
-  # Pop the top scene (e.g. closing the menu), disposing it. The base scene is
-  # never popped so the loop always has something to update.
+  # Pop the top scene (e.g. closing the menu), disposing it, then #resume the
+  # scene that becomes active again -- the counterpart to #push's #suspend
+  # call. The base scene is never popped so the loop always has something to
+  # update.
   def pop
     return if @scenes.size <= 1
     scene = @scenes.pop
     scene.dispose if scene.respond_to?(:dispose)
+    @scenes.last.resume if @scenes.last.respond_to?(:resume)
   end
 
   # Pop every scene down to (and stopping at) the base `Scene::Map`, disposing

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -76,6 +76,26 @@ class RPG2k
         @status.dispose if @status
       end
 
+      # Hide this menu's own command list and status panel while a child
+      # screen (Item/Skill/Equip/Status) sits on top -- called by
+      # RPG2k#push. None of those screens build a background of their own
+      # (see Scene::Base#build_field_background's comment); they rely on
+      # this menu's `@background` staying up to cover the map, but its two
+      # windows must go, or they show through around/behind whatever the
+      # child draws. Confirmed against genuine RPG_RT under wine: its own
+      # Item screen shows only its own item-list window, nothing else.
+      def suspend
+        @command.visible = false if @command
+        @status.visible = false if @status
+      end
+
+      # Undo #suspend once the child screen above this menu is popped and it
+      # is active again -- called by RPG2k#pop.
+      def resume
+        @command.visible = true if @command
+        @status.visible = true if @status
+      end
+
       def update
         return drive_message if @message
 


### PR DESCRIPTION
## Summary

Continuing the wine-based field-menu survey (this closes one of the open items left by #679/#681).

- Verified under wine against genuine `RPG_RT.exe`: its Item screen shows only its own item-list window over the plain field backdrop. This engine's Item screen instead left `Scene::Menu`'s own command list and status panel visibly drawn behind/around the newly opened window.
- Root cause: an RGSS window, once created, keeps rendering every frame until explicitly hidden or disposed, independent of which scene is currently receiving input. `Scene::Menu#dispose` does hide its own windows, but that only runs when Menu itself is popped — not when Item/Skill/Equip/Status is merely *pushed on top* of it. None of those four screens build a status/command panel of their own; they already rely on Menu's own `@background` staying up behind them to cover the map (the established full-screen-backdrop idiom), so Menu's own two foreground windows were the only leftover.
- Fix: `RPG2k#push` now calls an optional `#suspend` on the scene it's about to cover, and `RPG2k#pop` calls an optional `#resume` on the scene that becomes active again. `Scene::Menu` implements both, toggling `@command.visible`/`@status.visible`. Both hooks are `respond_to?`-gated no-ops for every other scene, so this only changes Menu's own behavior.
- Verified fixed: our engine's Item screen now shows only its own window (matching the reference frame), and backing out with Escape correctly restores the command list and status panel.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 472 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 759 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed
- [x] Rebuilt the native engine and verified under wine against a genuine `RPG_RT.exe` reference capture: Item screen now shows only its own window (no menu bleed-through), and Escape back to Menu correctly restores the command list/status panel

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_