### PR TITLE
rpg2k: Item screen now shows the highlighted item's description banner

### DIFF
--- a/changelog.d/rpg2k-item-description-banner.added.md
+++ b/changelog.d/rpg2k-item-description-banner.added.md
@@ -1,0 +1,5 @@
+- **The Item screen now shows the highlighted item's flavour text in a
+  one-line banner across the top**, the same banner `Scene::EquipMenu`
+  already gained. Verified against genuine `RPG_RT.exe` under wine
+  ("HPを80ポイント程度回復する" for a healing item); `Scene::ItemMenu` drew no such
+  banner before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2172,14 +2172,44 @@ The work below is roughly ordered by the critical path to a walkable game
   `@status.visible`. Verified against the same reference frame: our Item
   screen now shows only its own window, and backing out with Escape
   correctly restores the command list and status panel.
-  **Left open by the same comparison, not fixed here:**
-  - The Item/Skill list windows stay full-`SCREEN_W` wide even with nothing
-    in them, where RPG_RT's own list window in that state is narrower (looks
-    roughly menu-command-window width, ~300px) -- seen once the cursor became
-    visible again by the fix above, but not cross-checked against a
-    *populated* list on both engines, so it is recorded rather than guessed
-    at: the window may simply always be full-width once real rows are drawn,
-    which an empty list alone cannot tell apart from a genuine layout bug.
+  **The Item list's full-`SCREEN_W` width question above is now settled --
+  cross-checked with a populated bag** (edit a real save's inventory chunk
+  109's `item_ids`/`item_counts`/`item_count` fields directly, then compare
+  under wine): RPG_RT's own Item window is full-width once it holds real
+  rows too, the same as this engine's always was. The empty-list capture
+  that first raised the question was misleading on its own, not a genuine
+  layout bug -- nothing to fix here.
+  ✅ **That same populated-list capture found a real, still-open gap: the
+  Item screen has an item-description banner too, the same one
+  `Scene::EquipMenu` already gained.** RPG_RT showed "HPを80ポイント程度回復する"
+  across the top of the screen for the highlighted 薬草, sourced from the
+  item's own database `description` field; `Scene::ItemMenu` drew none.
+  Fixed the same way as Equip (`build_desc_window`/`refresh_desc`, tracking
+  the highlighted row in the `:items` list and the pending item while a
+  target/teleport picker is open, since it is still the one thing on screen
+  a description could be about), and confirmed the fixed screen's banner
+  text now matches RPG_RT's field-for-field.
+  **Left open by the same populated-list comparison, not fixed here:**
+  - **RPG_RT lays the item list out in a two-column grid, not a
+    single stacked column.** With 薬草×5 and 傷薬×3 held, RPG_RT drew them
+    side by side on the *same* row (薬草 on the left half, 傷薬 on the right
+    half), where this engine stacks every item on its own row regardless of
+    count. This is a bigger structural change than the banner fix above --
+    it touches cursor navigation (UP/DOWN would need to move by one column
+    instead of unconditionally wrapping the whole list), the row/column
+    math, and needs another populated data point (three or more items) to
+    pin down whether RPG_RT always uses exactly two columns or derives the
+    count from window width/item name length -- recorded rather than
+    guessed at.
+  - The item count's separator glyph differs: RPG_RT draws something
+    resembling a bold "＝" between the name and the count (e.g. "薬草　＝　５"),
+    where this engine draws a plain ASCII ":" (`":#{count}"` in
+    `#build_item_window`). Not chased into a fix -- the exact glyph is small
+    in the captured frame and could be a windowskin-drawn icon rather than a
+    font character at all, which a single wine screenshot cannot
+    distinguish; wants a closer look (a higher-resolution capture, or
+    checking whether EasyRPG's own item-list drawing code names this glyph)
+    before guessing at an implementation.
   - The Save command's "you cannot save right now" message (shown when
     `Change Save Access` has turned saving off) is a hardcoded English
     literal, the same class of bug the two placeholders above turned out to

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -20,6 +20,11 @@ class RPG2k
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
 
+      # Height of the item-description banner at the very top of the screen
+      # (see #build_desc_window) -- mirrors Scene::EquipMenu's own banner,
+      # which the item list is offset down by.
+      DESC_H = LINE_H + Window::BORDER * 2
+
       def initialize parent, state
         super parent
         @state = state
@@ -30,11 +35,13 @@ class RPG2k
         @teleport_index = 0
         @pending_item = nil
         @message = nil
+        build_desc_window
         build_item_window
       end
 
       def dispose
         close_message
+        @desc_window.dispose if @desc_window
         @item_window.dispose if @item_window
         @target_window.dispose if @target_window
         @teleport_window.dispose if @teleport_window
@@ -102,6 +109,7 @@ class RPG2k
             @mode = :teleport_target
             @teleport_index = 0
             build_teleport_window
+            refresh_desc
           elsif sk && (sk.scope == 2 || sk.scope == 4)
             # Unlike a medicine (whose all-ally scope needs no actor at all --
             # #use_medicine reads the whole party off `@actors`, ignoring the
@@ -128,6 +136,7 @@ class RPG2k
         @mode = :target
         @target_index = 0
         build_target_window
+        refresh_desc
       end
 
       # A switch item turns on its game switch (the menu owns the switch table)
@@ -207,6 +216,7 @@ class RPG2k
           @teleport_window.dispose
           @teleport_window = nil
         end
+        refresh_desc
       end
 
       # The registered teleport destinations as `[map_id, name]` pairs,
@@ -287,6 +297,7 @@ class RPG2k
           @target_window.dispose
           @target_window = nil
         end
+        refresh_desc
       end
 
       # After a successful use, drop back to the item list and rebuild it (the
@@ -300,12 +311,45 @@ class RPG2k
         build_item_window
       end
 
+      # The highlighted item's flavour text, in a one-line banner across the
+      # very top of the screen -- confirmed against genuine RPG_RT under
+      # wine (e.g. "HPを80ポイント程度回復する" for a healing item), the same
+      # gap Scene::EquipMenu had. Tracks the item under the cursor in :items
+      # mode; the :target/:teleport_target pickers keep showing the pending
+      # item's own description, since it is still the one thing on screen a
+      # description could be about.
+      def build_desc_window
+        @desc_window.dispose if @desc_window
+        inner_w = SCREEN_W - Window::BORDER * 2
+        @desc_window = Window.new(0, 0, SCREEN_W, DESC_H)
+        @desc_window.z = 400
+        @desc_window.windowskin = @skin
+        @desc_contents = Bitmap.new(inner_w, LINE_H)
+        @desc_window.contents = @desc_contents
+        refresh_desc
+      end
+
+      def refresh_desc
+        return unless @desc_contents
+        id = if @mode == :items
+               rows = items
+               rows.empty? ? nil : rows[@item_index].first
+             else
+               @pending_item
+             end
+        it = id && id != 0 ? @state.party.db_item(id) : nil
+        text = it ? it.description.to_s : ''
+        @desc_contents.clear
+        @desc_contents.font.color = Color.new(255, 255, 255, 255)
+        @desc_contents.draw_text 0, 0, @desc_contents.width, LINE_H, text
+      end
+
       def build_item_window
         @item_window.dispose if @item_window
         rows = items
         inner_w = SCREEN_W - Window::BORDER * 2
         h = [rows.size, 1].max * LINE_H
-        @item_window = Window.new(0, 0, SCREEN_W, h + Window::BORDER * 2)
+        @item_window = Window.new(0, DESC_H, SCREEN_W, h + Window::BORDER * 2)
         @item_window.z = 400
         @item_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
@@ -333,6 +377,7 @@ class RPG2k
         h = LINE_H
         @item_window.cursor_rect =
           Rect.new(0, @item_index * LINE_H, @item_window.contents.width, h)
+        refresh_desc
       end
 
       def build_target_window


### PR DESCRIPTION
## Summary

Continuing the wine-based field-menu survey (follows #685).

- The empty-bag comparisons used so far (PR #669) couldn't tell whether the Item list window's full-width layout was correct or just an empty-state artifact. Edited a real save's inventory chunk (109's `item_ids`/`item_counts`/`item_count` fields) directly to give the bag two held items, then compared under wine with a populated list on both engines.
- That settled the width question (RPG_RT's own list window is full-width once it holds real rows too — nothing to fix there) and surfaced a real, previously-invisible gap: **RPG_RT draws a one-line item-description banner across the top of the Item screen**, the same banner `Scene::EquipMenu` already gained in #679 ("HPを80ポイント程度回復する" for a healing item, sourced from the item's own database `description` field). `Scene::ItemMenu` drew no such banner.
- Fixed the same way as Equip: `build_desc_window`/`refresh_desc`, tracking the highlighted row in the `:items` list, or the pending item while a target/teleport picker is open on top of it. Verified the fixed screen's banner text now matches RPG_RT's field-for-field.
- The same comparison surfaced two more gaps, documented in `docs/TODO.md` rather than guessed at (not fixed here): RPG_RT lays the item list out in a **two-column grid** rather than this engine's single stacked column (a bigger structural change touching cursor navigation), and its item-count separator glyph is not this engine's plain `":"`.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 474 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 760 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed
- [x] Rebuilt the native engine and verified under wine against a genuine `RPG_RT.exe` reference capture (populated bag): the Item screen's description banner now matches RPG_RT's text exactly

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_