### PR TITLE
rpg2k: a Parallel Process's own Battle Processing command now opens a real fight

### DIFF
--- a/changelog.d/parallel-process-battle-processing.fixed.md
+++ b/changelog.d/parallel-process-battle-processing.fixed.md
@@ -1,0 +1,24 @@
+- **A Parallel Process's own Battle Processing (Enemy Encounter) command now
+  actually opens and drives a real fight,** instead of being silently
+  skipped outright. `Scene::Map#drive_parallel_wait` had cases for every
+  other wait kind reachable from a Parallel Process (`:wait`, `:key_input`,
+  `:animation`, `:game_over`, `:movement`, `:teleport`, `:message`,
+  `:choice`, `:number`, `:screen`, `:picture`, `:sprite_flash`) but none for
+  `:battle`, so it fell into the generic "background: ignore ... requests"
+  branch and resumed the interpreter unconditionally the next frame — no
+  battle screen ever opened, and the process fell straight through into its
+  own `[Victory]` handler marker as though the encounter had never run, a
+  real gap for the ordinary "a Common Event's Parallel Process polls a
+  switch/variable and starts a scripted or wandering-style fight" pattern.
+  `#drive_battle`/`#open_battle`/`#finish_battle` now take the raising
+  interpreter explicitly and `@battle_ui` records its own `owner`, so a
+  battle page's Call Common Event resolves against the right interpreter and
+  the outcome resumes it, not always the foreground. A new
+  `#step_battle_owner_parallel` keeps the fight's own owning Parallel
+  Process advancing every frame even though `@battle_ui`'s presence pauses
+  every *other* parallel process for the fight's duration, and
+  `#event_busy?`/`#drive_event` now also freeze ordinary player movement and
+  an unrelated foreground script while a Parallel-Process-opened fight is on
+  screen, matching a foreground-opened one. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3143,7 +3143,72 @@ Everything below is unverified against the codebase.
   `#drive_parallel_wait`'s "background: ignore message/choice requests"
   branch — `:teleport` no longer falls into it, see the "a Transfer Player
   command issued from a Parallel Process..." fix just above), confirmed to
-  fail against the pre-fix code before the fix.
+  fail against the pre-fix code before the fix. ✅ **A Battle Processing
+  (Enemy Encounter) command issued from a Parallel Process now actually
+  opens and drives a real fight**, instead of being silently skipped
+  outright — the last member of this exact defect-class family left
+  unfixed: `Scene::Map#drive_parallel_wait` had cases for `:wait`/
+  `:key_input`/`:animation`/`:game_over`/`:movement`/`:teleport`/`:message`/
+  `:choice`/`:number`/`:screen`/`:picture`/`:sprite_flash` — every other
+  wait kind reachable from a Parallel Process, each earning its own dispatch
+  over earlier rounds of this same fix — but none for `:battle`, the wait
+  kind `Game::Interpreter#do_enemy_encounter` sets, so it fell into the
+  generic `else` branch (`it.resume`) and cleared the wait unconditionally
+  the very next frame: `@battle_request` sat on the parallel process's own
+  interpreter unread (`#drive_battle` only ever consulted the foreground
+  `@interpreter`'s own copy), no battle screen ever opened, and the process
+  fell straight through into whatever followed the command in its own list
+  (its `[Victory]` handler marker) as though the encounter had been a no-op
+  — a real, reachable gap for the ordinary "a Common Event's Parallel
+  Process polls a variable/switch threshold and starts a scripted or
+  wandering-style fight" pattern real games use. Fixing this needed more
+  than a new dispatch case, since `@battle_ui` is a single shared slot that
+  used to be reachable only from the foreground: `#drive_battle`/
+  `#open_battle`/`#finish_battle` now take the raising interpreter
+  explicitly (`it`, defaulting to `@interpreter`, the same `interp =
+  @interpreter` idiom `#perform_game_over` already used), and the hash
+  itself now records its own `owner`, read by the battle-page Call Common
+  Event resolver (`owner.resolver`, previously hardcoded to the foreground's)
+  and by `#finish_battle` to resume the right interpreter with the outcome
+  (captured before `#close_battle` clears `@battle_ui` out from under it).
+  Two further gaps surfaced once a *parallel* owner became possible: (1)
+  `@battle_ui`'s mere presence already pauses `#step_parallels` for every
+  *other* parallel process for a fight's duration (`#parallels_paused?`,
+  matching "Common events never run during battle" a few lines below), but
+  that pause caught the fight's own owning entry too, freezing it solid one
+  frame after it opened — fixed with a new `#step_battle_owner_parallel`,
+  called from `#update` exactly when `#parallels_paused?` already skipped
+  the ordinary `#step_parallels` pass this frame (so it can never
+  double-step the same entry), which finds and steps only the `@parallels`
+  entry matching `@battle_ui[:owner]`, the same per-frame service
+  `#drive_event`'s own `:battle` case already gives a foreground-opened
+  fight. (2) `#event_busy?` used to read only the foreground `@interpreter`'s
+  own `running?`/`waiting?`, so an otherwise-idle foreground never noticed a
+  Parallel-Process-opened fight at all — the player could freely walk
+  around, open the menu or trigger other events underneath the battle
+  screen; fixed by widening `#event_busy?` with `!@battle_ui.nil?` (a no-op
+  for the pre-existing foreground-owned case, where `@interpreter.waiting?`
+  was already true regardless) and adding a matching early-return to
+  `#drive_event` itself so the foreground's own interpreter does not keep
+  grinding through an unrelated script it was already mid-way through when
+  someone else's fight opened (message/choice/number-input display, a
+  shared resource independent of battle ownership, is deliberately left
+  unblocked by that guard). Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a Common Event Parallel Process's own Battle Processing command
+  opens a real battle screen — owned by the parallel interpreter, not the
+  idle foreground — runs it to a Victory result and reaches its own
+  `[Victory]` handler; ordinary held-direction player movement stays frozen
+  at its starting tile for the fight's whole duration), both confirmed to
+  fail against the pre-fix code before the fix (the first on `@battle_ui`
+  never becoming non-nil at all; the second on the party walking freely
+  since nothing gated it). Two deeper edges are left unaddressed, matching
+  this backlog's own established tolerance for genuinely rare timing
+  questions: two different interpreters each raising their own `:battle`
+  wait on the exact same real frame (whichever opens first wins the slot;
+  the other retries next frame via the same `@battle_ui[:owner].equal?(it)`
+  block-and-retry shape `:message`/`:choice`/`:number` already use) and a
+  shown message window's own display priority interacting with an unrelated
+  parallel process's battle opening concurrently.
 - **Vehicles** — an unset vehicle defaults to map id 0, (0,0); Small/Large
   Ship aren't hardcoded to water, their passability follows the terrain
   table's boat/ship-pass flags like any other vehicle rule; ✅ an airship

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -300,8 +300,15 @@ class RPG2k
         # only a battle or an actively-bursting foreground event is -- see
         # #parallels_paused?). Stepped before the foreground gets a chance to
         # start anything this frame, matching "if both are set to fire the
-        # same frame, parallel process goes first".
-        step_parallels unless parallels_paused?
+        # same frame, parallel process goes first". `paused` is captured once
+        # and reused for both branches below: whichever one runs owns this
+        # frame's only pass over the entry that opened a battle, so the two
+        # can never double-step it (#step_battle_owner_parallel is the only
+        # thing keeping that entry moving once its own fight has paused the
+        # ordinary pass above).
+        paused = parallels_paused?
+        step_parallels unless paused
+        step_battle_owner_parallel if paused
         if event_busy?
           drive_event
           # Message Options' "move other events during message" toggle: other
@@ -1055,7 +1062,17 @@ class RPG2k
       # -- event execution ----------------------------------------------------
 
       def event_busy?
-        @message || @number_input || @interpreter.running? || @interpreter.waiting?
+        @message || @number_input || @interpreter.running? || @interpreter.waiting? ||
+          # A battle a Parallel Process opened (#drive_parallel_wait's :battle
+          # case) is exactly as busy as one the foreground itself opened --
+          # before that fix existed only @interpreter could ever hold
+          # @battle_ui, so @interpreter.waiting? alone already covered this;
+          # now that a Common Event's or a map event's own Parallel Process
+          # can own the single battle slot too, its mere presence has to gate
+          # ordinary player movement/menu/Auto-Start here on its own, the same
+          # way #parallels_paused? already gates every *other* parallel
+          # process on it.
+          !@battle_ui.nil?
       end
 
       # Whether a message window or choice list (Show Message / Show Choices /
@@ -1329,6 +1346,27 @@ class RPG2k
         @parallels.dup.each { |p| step_parallel(p) }
       end
 
+      # Keep a Parallel Process's own battle advancing once it has opened one
+      # (#drive_parallel_wait's :battle case). @battle_ui's mere presence
+      # pauses #step_parallels for every *other* parallel process for the
+      # fight's duration (#parallels_paused?, "Common events never run during
+      # battle") -- but the one that opened it is not a bystander: it still
+      # needs exactly the same per-frame #drive_battle service #drive_event's
+      # own :battle case already gives a foreground-opened fight, or the
+      # fight it opened would never advance past the single frame it opened
+      # on. Called from #update only when #parallels_paused? already skipped
+      # the ordinary #step_parallels pass this same frame (see there), so
+      # this never double-steps the owner's own entry. A no-op once the
+      # battle belongs to the foreground (nothing here to step) or there is
+      # no battle open at all.
+      def step_battle_owner_parallel
+        return unless @battle_ui
+        owner = @battle_ui[:owner]
+        return if owner.nil? || owner.equal?(@interpreter)
+        p = @parallels.find { |pp| pp[:interp].equal?(owner) }
+        step_parallel(p) if p
+      end
+
       def step_parallel(p)
         return if p[:gate_switch] && !@state.switches[p[:gate_switch]]
         it = p[:interp]
@@ -1416,6 +1454,26 @@ class RPG2k
           # silently cleared the wait and let the process carry on with a
           # fully-dead party never reaching the Game Over screen.
           perform_game_over(it)
+        elsif it.wait_kind == :battle
+          # Battle Processing (Enemy Encounter) issued from a Parallel
+          # Process -- a Common Event's or a map event's own -- opens and
+          # drives the same single global battle screen a foreground-issued
+          # one does, the same shared-slot shape already fixed above for
+          # Show Battle Animation's :animation wait (#drive_map_animation /
+          # @map_animation_interp). Before this branch existed this fell
+          # into the generic "background: ignore message/choice/teleport
+          # requests" #resume below: the request sat on `it.battle_request`
+          # unread (#drive_battle used to only ever consult the foreground
+          # @interpreter's own copy), and `it` was resumed unconditionally
+          # the very next frame as though the command had been a no-op --
+          # no battle screen ever appeared, and any [Victory]/[Escape]/
+          # [Defeat] handler right after the command in `it`'s own list
+          # never ran either. #drive_battle itself now takes the interpreter
+          # to drive explicitly (`it` here), and keeps being called back
+          # into on every later frame by #step_battle_owner_parallel, since
+          # @battle_ui's own presence pauses the ordinary #step_parallels
+          # pass this entry would otherwise need for that (#parallels_paused?).
+          drive_battle(it)
         elsif it.wait_kind == :movement
           # Proceed With Movement / Force Complete Move issued from a
           # Parallel Process: block that process until every targeted
@@ -3305,6 +3363,18 @@ class RPG2k
           return
         end
 
+        # A battle opened by a Parallel Process's own Battle Processing
+        # command (#drive_parallel_wait's :battle case) owns the single
+        # @battle_ui slot exactly the way the foreground does when it opens
+        # one itself. While someone else holds it, the foreground must not
+        # keep grinding through its own unrelated commands underneath the
+        # fight -- the same freeze every *other* parallel process already
+        # gets from #parallels_paused? ("Common events never run during
+        # battle"). The message/choice/number dispatch above is left
+        # unblocked either way, since a shown window is a shared resource
+        # independent of who owns the battle.
+        return if @battle_ui && !@battle_ui[:owner].equal?(@interpreter)
+
         if @interpreter.waiting?
           case @interpreter.wait_kind
           when :message
@@ -3877,13 +3947,25 @@ class RPG2k
       # action landing per BATTLE_ANIM_FRAMES, each bannered with its HP tick)
       # until a side falls. B on the first actor flees when the encounter allows
       # it. Dismissing the result resumes the event with the outcome.
-      def drive_battle
-        req = @interpreter.battle_request
-        return @interpreter.resume_battle(:victory) unless req
+      # `it` is whichever interpreter actually raised the :battle wait -- the
+      # foreground event by default, or a Parallel Process's own interpreter
+      # when #drive_parallel_wait dispatches here (see there and
+      # #step_battle_owner_parallel, which keeps calling back in on every
+      # later frame since a battle a Parallel Process opened stops the
+      # ordinary #step_parallels pass from ever reaching it again). Only one
+      # fight can be open at a time: if @battle_ui already belongs to a
+      # *different* interpreter (two Battle Processing commands landing the
+      # same real frame, one from each of two independent interpreters), this
+      # one simply waits its turn and tries again next frame, the same
+      # block-and-retry shape already used for :message/:choice/:number above.
+      def drive_battle(it = @interpreter)
+        req = it.battle_request
+        return it.resume_battle(:victory) unless req
         if @battle_ui.nil?
-          open_battle(req) # opened this frame; take input from the next one
+          open_battle(req, it) # opened this frame; take input from the next one
           return
         end
+        return unless @battle_ui[:owner].equal?(it)
         update_enemy_flashes
         update_enemy_positions
         case @battle_ui[:phase]
@@ -3898,11 +3980,12 @@ class RPG2k
         end
       rescue StandardError => e
         $stderr.puts "[RPG2k] battle failed: #{e.message}"
+        owner = (@battle_ui && @battle_ui[:owner]) || it
         close_battle
-        @interpreter.resume_battle(:victory)
+        owner.resume_battle(:victory)
       end
 
-      def open_battle(req)
+      def open_battle(req, owner = @interpreter)
         play_battle_bgm
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }
@@ -3911,7 +3994,7 @@ class RPG2k
         # sleep skip) in battle.
         situations = db.respond_to?(:situation) ? db.situation : nil
         properties = db.respond_to?(:property) ? db.property : nil
-        @battle_ui = { phase: :command, req: req, troop: troop,
+        @battle_ui = { phase: :command, req: req, troop: troop, owner: owner,
                        battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
                                                 situations, true, true, true,
                                                 req[:first_strike] ? true : false,
@@ -3946,8 +4029,10 @@ class RPG2k
                        frame: 0 }
         @battle_ui[:events].battle = @battle_ui[:battle]
         # A battle page can Call Common Event (1005), so it needs the same
-        # resolver the map's events run against.
-        @battle_ui[:events].resolver = @interpreter.resolver
+        # resolver the encounter's own owning interpreter runs against --
+        # the foreground by default, or a Parallel Process's own interpreter
+        # for a fight it opened itself (see `owner` above).
+        @battle_ui[:events].resolver = owner.resolver
         build_battle_sprites
         refresh_battle_status
         # Turn-0 pages fire before the party is asked for its first command —
@@ -5105,7 +5190,11 @@ class RPG2k
       # Close the battle and hand the outcome back to the event. A defeat in an
       # encounter whose defeat mode is "game over" (rather than a [Defeat]
       # handler) ends the game instead of resuming the event; every other outcome
-      # — victory, escape, or a defeat with a custom handler — resumes it.
+      # — victory, escape, or a defeat with a custom handler — resumes it. Hands
+      # the outcome to whichever interpreter actually opened this fight
+      # (`@battle_ui[:owner]` -- the foreground by default, or a Parallel
+      # Process's own interpreter, see #drive_battle), captured before
+      # #close_battle clears @battle_ui out from under it.
       def finish_battle(result)
         # Persist the party's post-battle HP (and any knock-outs) before leaving
         # the fight, so damage taken sticks and a downed member stays down.
@@ -5114,12 +5203,13 @@ class RPG2k
         # party knocked out ends the game; every other outcome resumes the event.
         game_over = result == :defeat && @battle_ui[:req][:defeat_game_over] &&
                     @state.party.all_dead?
+        owner = @battle_ui[:owner] || @interpreter
         close_battle
         if game_over
-          perform_game_over
+          perform_game_over(owner)
         else
           restore_pre_battle_bgm
-          @interpreter.resume_battle(result)
+          owner.resume_battle(result)
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5136,6 +5136,71 @@ check 'a game with no game-over picture still reaches the screen' do
   Input.reset
 end
 
+# yado.tk ("Common events... never run during battle") describes what
+# happens to *other* events while a fight is up; the more basic half it
+# implies -- a Parallel Process's own Battle Processing (Enemy Encounter)
+# command, the shape a scripted/threshold-triggered fight actually takes in
+# a real game (a Common Event whose Parallel Process trigger checks a
+# variable, then runs the encounter) -- was never modelled at all.
+# #drive_parallel_wait's wait-kind dispatch had cases for :wait/:key_input/
+# :animation/:game_over/:movement/:teleport/:message/:choice/:number/
+# :screen/:picture/:sprite_flash -- every other wait kind reachable from a
+# Parallel Process, each earning its own case over earlier rounds of this
+# same defect class -- but none for :battle, so it fell into the generic
+# "background: ignore ... requests" #resume and cleared the wait
+# unconditionally the very next frame: @battle_request sat on the parallel
+# process's own interpreter unread (#drive_battle used to only ever consult
+# the foreground @interpreter's copy), no battle screen ever opened, and the
+# process just fell straight through into whatever followed the Enemy
+# Encounter command (its own [Victory] handler marker) as though the fight
+# had been skipped outright.
+check "a Common Event Parallel Process's own Battle Processing now actually opens and drives a real fight" do
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: Game::CommonEvent::PARALLEL, need_flag: false,
+                      switch_id: nil, event: battle_event_commands(ic))
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  eq nil, scene.instance_variable_get(:@battle_ui), 'no battle before the process reaches it'
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui, "the parallel process's own Enemy Encounter actually opened a real battle screen"
+  eq :result, ui[:phase]
+  fg = scene.instance_variable_get(:@interpreter)
+  ok !ui[:owner].equal?(fg),
+     "the parallel process's own interpreter owns this fight, not the (idle) foreground"
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result
+  scene.update
+  RGSS::Input.triggered = []
+  3.times { scene.update }
+  ok st.switches[1], "the Victory handler ran, on the parallel process's own command list"
+  ok !st.switches[2], 'the Escape handler was skipped'
+end
+
+# A battle a Parallel Process opened owns the single @battle_ui slot exactly
+# the way one the foreground opened does -- ordinary player movement/menu
+# access must freeze for its whole duration regardless of which interpreter
+# is driving it, the same freeze every *other* parallel process already gets
+# from #parallels_paused? during any battle. Before this fix, #event_busy?
+# only ever consulted the foreground @interpreter's own running?/waiting?
+# state, so an otherwise-idle foreground (nothing of its own running) never
+# noticed a Parallel-Process-opened fight at all: the player could freely
+# walk around underneath the battle screen.
+check "a battle a Parallel Process opened blocks player movement, just like one the foreground opened" do
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: Game::CommonEvent::PARALLEL, need_flag: false,
+                      switch_id: nil,
+                      event: [ECmd.new(ic::ENEMY_ENCOUNTER, [0, 1, 0, 0, 0, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  RGSS::Input.dir_value = 6 # hold right the whole time
+  12.times { scene.update }
+  RGSS::Input.dir_value = 0
+  ok scene.instance_variable_get(:@battle_ui), 'the fight is open by now'
+  eq 0, st.x, "the party must not walk anywhere while a Parallel Process's own fight is up"
+end
+
 check 'Change System Graphics reloads the windowskin from the override' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Untriaged backlog" Parallel Process bullet — the same defect-class family this session has repeatedly found and fixed (Show Text/Choices, Input Number, Show Battle Animation, ...): `Scene::Map#drive_parallel_wait` had cases for every other wait kind but none for `:battle`, the wait kind `Game::Interpreter#do_enemy_encounter` sets.
- A Common Event's (or map event's) own Parallel Process executing a "Battle Processing" command fell into the generic `else` branch (unconditional `resume`), and `#drive_battle` only ever read the foreground interpreter's own `battle_request` — the encounter never opened a fight at all, silently falling through as if it had been skipped.
- `drive_battle`/`open_battle`/`finish_battle` now take the raising interpreter explicitly (`it`, defaulting to `@interpreter`), and `@battle_ui` records its own `owner`. New `#step_battle_owner_parallel`, called from `#update` whenever `#parallels_paused?` already skipped the ordinary `#step_parallels` pass, keeps the battle's own owning Parallel Process advancing every frame (otherwise it would freeze one frame after opening, since `@battle_ui`'s presence pauses all other parallel processes).
- `#event_busy?` now also checks `!@battle_ui.nil?`, and `#drive_event` gets an early-return guard — so ordinary player movement/menu and an unrelated foreground script correctly freeze while a Parallel-Process-opened battle is on screen (previously only a foreground-opened battle blocked anything).
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 760 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 476 checks pass (2 new: a Common Event Parallel Process's own Battle Processing command opens a real battle, owned by the parallel interpreter, runs to a Victory result, and reaches its own `[Victory]` handler; held-direction player movement stays frozen at its starting tile for the whole fight — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_