### PR TITLE
rpg2k: Item screen's list is a two-column grid, matching RPG_RT

### DIFF
--- a/changelog.d/rpg2k-item-list-two-column-grid.fixed.md
+++ b/changelog.d/rpg2k-item-list-two-column-grid.fixed.md
@@ -1,0 +1,8 @@
+- **The Item screen's list is now a two-column grid, matching genuine
+  RPG_RT.exe.** Verified under wine with a populated bag: RPG_RT fills the
+  list row-major across two columns rather than stacking every item on its
+  own row, and cursor movement is grid-aware (DOWN/UP move a row, RIGHT/LEFT
+  move a column, all blocked rather than wrapping at a missing cell).
+  `Scene::ItemMenu` now lays out and navigates the same way, replacing its
+  old single-column modulo-wraparound cursor with the confirmed grid
+  behavior and adding RIGHT/LEFT input handling it never had before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2189,18 +2189,34 @@ The work below is roughly ordered by the critical path to a walkable game
   target/teleport picker is open, since it is still the one thing on screen
   a description could be about), and confirmed the fixed screen's banner
   text now matches RPG_RT's field-for-field.
-  **Left open by the same populated-list comparison, not fixed here:**
-  - **RPG_RT lays the item list out in a two-column grid, not a
-    single stacked column.** With 薬草×5 and 傷薬×3 held, RPG_RT drew them
-    side by side on the *same* row (薬草 on the left half, 傷薬 on the right
-    half), where this engine stacks every item on its own row regardless of
-    count. This is a bigger structural change than the banner fix above --
-    it touches cursor navigation (UP/DOWN would need to move by one column
-    instead of unconditionally wrapping the whole list), the row/column
-    math, and needs another populated data point (three or more items) to
-    pin down whether RPG_RT always uses exactly two columns or derives the
-    count from window width/item name length -- recorded rather than
-    guessed at.
+  ✅ **RPG_RT lays the item list out in a two-column grid, not a single
+  stacked column.** With 薬草×5 and 傷薬×3 held, RPG_RT drew them side by
+  side on the *same* row; this engine used to stack every item on its own
+  row regardless of count. A follow-up five-item comparison (薬草/傷薬/癒油/
+  常世の雫/魔法石の欠片, filling two full rows plus one) pinned the shape down
+  precisely: row-major fill (item 0 top-left, item 1 top-right, item 2
+  second row left, ...), an incomplete last row's second cell left blank
+  rather than reflowing, and grid-aware, non-wrapping cursor movement --
+  EasyRPG's own `Window_Selectable::CursorDown/Up/Right/Left` shape with
+  `cycle` off: DOWN/UP move by two (the column count) and do nothing at a
+  missing cell (confirmed by pressing DOWN off the grid's last, partial row
+  -- the cursor simply stayed, not wrapping to the top as the *old*
+  single-column code did), RIGHT/LEFT move by one and do nothing at a row's
+  own edge. `Scene::ItemMenu` gained a `COLUMN_MAX = 2` constant, grid-aware
+  drawing (`#build_item_window`, `#item_col_w`) and cursor math
+  (`#move_item_cursor`, replacing the old modulo-wraparound UP/DOWN
+  handling and adding RIGHT/LEFT, which the scene never handled before at
+  all), confirmed against the same five-item reference frames field-for-
+  field, including the exact cell the cursor stops on after each key.
+  `scripts/rpg2k_scene_check.rb`'s own two-item wraparound test encoded the
+  old (wrong) single-column assumption and is now a grid-boundary test
+  instead -- the actor-target list opened from an item is a separate,
+  genuinely single-column window and keeps its own wraparound coverage
+  unchanged. **Not yet re-verified against RPG_RT:** `Scene::SkillMenu`
+  almost certainly has the same two-column shape (RPG2000's skill list is
+  drawn by the same kind of window as the item list), but that has not
+  itself been driven under wine with a populated skill list, so it is left
+  single-column rather than assumed.
   - The item count's separator glyph differs: RPG_RT draws something
     resembling a bold "＝" between the name and the count (e.g. "薬草　＝　５"),
     where this engine draws a plain ASCII ":" (`":#{count}"` in

--- a/mruby-rpg2k/mrblib/scene/item_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/item_menu.rb
@@ -25,6 +25,18 @@ class RPG2k
       # which the item list is offset down by.
       DESC_H = LINE_H + Window::BORDER * 2
 
+      # The item list is a two-column grid, not a single stacked column --
+      # confirmed against genuine RPG_RT under wine with a five-item bag,
+      # which filled row-major (item 0 top-left, item 1 top-right, item 2
+      # second row left, ...) and left an incomplete last row's second cell
+      # blank rather than reflowing. Cursor movement is grid-aware and does
+      # not wrap at an edge (EasyRPG's own Window_Selectable::CursorDown/Up/
+      # Right/Left shape, `cycle` off): DOWN/UP move by COLUMN_MAX and are a
+      # no-op with no cell below/above (tried pressing DOWN off the last,
+      # partial row -- the cursor simply stayed), RIGHT/LEFT move by one and
+      # are a no-op at the row's own edge.
+      COLUMN_MAX = 2
+
       def initialize parent, state
         super parent
         @state = state
@@ -72,17 +84,29 @@ class RPG2k
       def update_items
         if Input.trigger?(Input::B)
           @parent.pop
-        elsif Input.trigger?(Input::DOWN) && !items.empty?
-          @item_index += 1
-          @item_index %= items.size
-          refresh_item_cursor
-        elsif Input.trigger?(Input::UP) && !items.empty?
-          @item_index -= 1
-          @item_index %= items.size
-          refresh_item_cursor
+        elsif Input.trigger?(Input::DOWN)
+          move_item_cursor(COLUMN_MAX)
+        elsif Input.trigger?(Input::UP)
+          move_item_cursor(-COLUMN_MAX)
+        elsif Input.trigger?(Input::RIGHT)
+          move_item_cursor(1) if (@item_index + 1) % COLUMN_MAX != 0
+        elsif Input.trigger?(Input::LEFT)
+          move_item_cursor(-1) if @item_index % COLUMN_MAX != 0
         elsif Input.trigger?(Input::C)
           choose_item
         end
+      end
+
+      # Move the item cursor by `delta` cells (a row for +-COLUMN_MAX, a
+      # column for +-1), ignored if that cell is off the grid -- confirmed
+      # against genuine RPG_RT under wine, which leaves the cursor put
+      # rather than wrapping (see the COLUMN_MAX comment above).
+      def move_item_cursor(delta)
+        return if items.empty?
+        target = @item_index + delta
+        return if target < 0 || target >= items.size
+        @item_index = target
+        refresh_item_cursor
       end
 
       def choose_item
@@ -344,16 +368,23 @@ class RPG2k
         @desc_contents.draw_text 0, 0, @desc_contents.width, LINE_H, text
       end
 
+      # Column width for the item grid (see the COLUMN_MAX comment above).
+      def item_col_w
+        (SCREEN_W - Window::BORDER * 2) / COLUMN_MAX
+      end
+
       def build_item_window
         @item_window.dispose if @item_window
         rows = items
         inner_w = SCREEN_W - Window::BORDER * 2
-        h = [rows.size, 1].max * LINE_H
+        grid_rows = [(rows.size / COLUMN_MAX.to_f).ceil, 1].max
+        h = grid_rows * LINE_H
         @item_window = Window.new(0, DESC_H, SCREEN_W, h + Window::BORDER * 2)
         @item_window.z = 400
         @item_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
         c.font.color = Color.new(255, 255, 255, 255)
+        col_w = item_col_w
         # An empty bag draws no placeholder text -- confirmed against genuine
         # RPG_RT under wine, which shows a blank list row (still with a
         # visible, empty cursor box; see #refresh_item_cursor) rather than
@@ -362,8 +393,10 @@ class RPG2k
           it = @state.party.db_item(id)
           name = (it && it.name.to_s)
           name = "Item #{id}" if name.nil? || name.empty?
-          c.draw_text 0, i * LINE_H + 2, inner_w - 40, LINE_H, name
-          c.draw_text inner_w - 40, i * LINE_H + 2, 40, LINE_H, ":#{count}"
+          x = (i % COLUMN_MAX) * col_w
+          y = (i / COLUMN_MAX) * LINE_H
+          c.draw_text x, y + 2, col_w - 40, LINE_H, name
+          c.draw_text x + col_w - 40, y + 2, 40, LINE_H, ":#{count}"
         end
         @item_window.contents = c
         refresh_item_cursor
@@ -373,10 +406,12 @@ class RPG2k
         return unless @item_window
         # The cursor box stays visible on the empty row even with no items --
         # matched against genuine RPG_RT under wine, which highlights the
-        # blank slot rather than hiding the cursor.
-        h = LINE_H
-        @item_window.cursor_rect =
-          Rect.new(0, @item_index * LINE_H, @item_window.contents.width, h)
+        # blank slot rather than hiding the cursor. It highlights just the
+        # one grid cell, not the full row -- confirmed by the same captures
+        # that found the grid layout itself (see the COLUMN_MAX comment).
+        x = (@item_index % COLUMN_MAX) * item_col_w
+        y = (@item_index / COLUMN_MAX) * LINE_H
+        @item_window.cursor_rect = Rect.new(x, y, item_col_w, LINE_H)
         refresh_desc
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9653,17 +9653,34 @@ check 'the item / skill target list shows who is afflicted' do
   end
 end
 
-check 'Scene::ItemMenu: the item list and target cursors wrap around' do
+check 'Scene::ItemMenu: the item grid cursor does not wrap, the target cursor does' do
   scene = menu_scene(RPG2k::Scene::ItemMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@item_index), 'starts on the first item'
+  # The item list is a two-column grid (confirmed against genuine RPG_RT
+  # under wine, see Scene::ItemMenu::COLUMN_MAX): with only two items, both
+  # sit in the same row, so UP/DOWN have no cell to move to and RPG_RT
+  # leaves the cursor put rather than wrapping -- unlike the flat
+  # actor-target list below, which does wrap.
   RGSS::Input.triggered = [RGSS::Input::UP]
   scene.update
   RGSS::Input.reset
-  eq 1, scene.instance_variable_get(:@item_index), 'Up from the first item wraps to the last (2 items)'
+  eq 0, scene.instance_variable_get(:@item_index), 'Up from the first item is a no-op (nothing above it)'
   RGSS::Input.triggered = [RGSS::Input::DOWN]
   scene.update
   RGSS::Input.reset
-  eq 0, scene.instance_variable_get(:@item_index), 'Down from the last item wraps to the first'
+  eq 0, scene.instance_variable_get(:@item_index), 'Down from the first item is a no-op (nothing below it)'
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@item_index), 'Right moves onto the second item, same row'
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@item_index), 'Right again is a no-op (row edge)'
+  RGSS::Input.triggered = [RGSS::Input::LEFT]
+  scene.update
+  RGSS::Input.reset
+  eq 0, scene.instance_variable_get(:@item_index), 'Left moves back onto the first item'
 
   # Enter target mode (a two-actor party) and wrap that cursor too.
   scene.send(:prompt_item_target, 1)
@@ -9861,7 +9878,10 @@ check 'Scene::ItemMenu: a special item invoking Teleport opens a destination ' \
   parent = fake_parent(fake_db)
   state = escape_teleport_item_state
   scene = RPG2k::Scene::ItemMenu.new(parent, state)
-  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the Teleport item (row 2)
+  # The item list is a two-column grid (confirmed against genuine RPG_RT
+  # under wine): with only two items, the second sits beside the first in
+  # the same row, reached by RIGHT rather than DOWN.
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the Teleport item
   scene.update
   RGSS::Input.reset
   RGSS::Input.triggered = [RGSS::Input::C]           # confirm -- opens the destination list
@@ -9886,7 +9906,7 @@ check 'Scene::ItemMenu: cancelling the Teleport destination list returns to the 
   parent = fake_parent(fake_db)
   state = escape_teleport_item_state
   scene = RPG2k::Scene::ItemMenu.new(parent, state)
-  RGSS::Input.triggered = [RGSS::Input::DOWN]
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the Teleport item (see the grid test above)
   scene.update
   RGSS::Input.reset
   RGSS::Input.triggered = [RGSS::Input::C]


### PR DESCRIPTION
## Summary

Continuing the wine-based field-menu survey (follows #686, which flagged this layout question).

- Verified under wine against genuine `RPG_RT.exe` with a five-item bag (filling two full rows plus a partial third): RPG_RT lays the item list out in a **two-column grid**, row-major (item 0 top-left, item 1 top-right, item 2 second row left, ...), leaving an incomplete last row's second cell blank rather than reflowing. `Scene::ItemMenu` used to stack every item on its own row regardless of count.
- Cursor movement is grid-aware and does **not** wrap at an edge — the same `Window_Selectable::CursorDown/Up/Right/Left` shape EasyRPG uses with `cycle` off: DOWN/UP move by the column count and are a no-op with no cell below/above (confirmed by pressing DOWN off the grid's last, partial row — the cursor simply stayed, rather than wrapping as this engine's *old* single-column code did), RIGHT/LEFT move by one and are a no-op at a row's own edge.
- `Scene::ItemMenu` gains a `COLUMN_MAX = 2` constant, grid-aware drawing (`#build_item_window`, `#item_col_w`) and cursor math (`#move_item_cursor`), replacing the old single-column modulo-wraparound UP/DOWN handling and adding RIGHT/LEFT, which the scene never handled before at all. Verified against the same reference frames field-for-field, including the exact cell the cursor stops on after each key.
- `scripts/rpg2k_scene_check.rb`'s two-item wraparound test encoded the old (wrong) single-column assumption for the item grid and is rewritten to assert the confirmed grid-boundary behavior instead; the actor-target list opened from an item is a separate, genuinely single-column window and keeps its own wraparound coverage unchanged.
- Left open in `docs/TODO.md`: `Scene::SkillMenu` almost certainly has the same two-column shape (RPG2000 draws its skill list with the same kind of window), but that has not itself been driven under wine with a populated list, so it's left single-column rather than assumed.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 476 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 760 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed
- [x] Rebuilt the native engine and verified under wine against genuine `RPG_RT.exe` reference frames (five-item bag): grid layout and DOWN/RIGHT cursor navigation now match field-for-field, including the confirmed no-wrap boundary behavior

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_