### PR TITLE
rpg2k: a negative elemental attribute rate no longer heals through an attack

### DIFF
--- a/changelog.d/battle-negative-attribute-rate-rpg2k-floor.fixed.md
+++ b/changelog.d/battle-negative-attribute-rate-rpg2k-floor.fixed.md
@@ -1,0 +1,19 @@
+- **A negative elemental attribute rate no longer turns a battle attack into
+  a heal.** A database's `a_rate`..`e_rate` fields are plain signed ints with
+  no validation, so a deliberately-negative rank rate (the old "elemental
+  absorb" editor trick) is real, reachable data — not RPG2003-exclusive
+  content, contrary to this codebase's own prior assumption.
+  `Game::Battle#apply_attr_multiplier` applied a negative rate as a literal
+  percentage multiplier exactly like a positive one, and neither of its two
+  call sites (`#deal_attack`, `#apply_skill_hit`) floor the *result* at zero,
+  so `target.hp -= dmg` applied the negative figure as a genuine heal — on
+  every edition, the opposite of RPG2000's real "just don't scale it"
+  behaviour. Verified against EasyRPG Player's actual
+  `Attribute::ApplyAttributeMultiplier` (`src/attribute.cpp`), which guards
+  both the physical and magical bucket-max rate against `auto limit =
+  Player::IsRPG2k() ? -1 : INT_MIN;`: RPG2000 drops a side whose best rate is
+  negative from consideration entirely, where RPG2003 lets a lone negative
+  side scale damage directly and falls back to the *milder* of the two rates
+  (not a multiply) once either side is negative and both are present. Ported
+  with a new `Game::Battle` `rpg2003:` constructor flag (`Scene::Map
+  #open_battle` passes `db.rpg2003?`) and an `#above_attr_limit?` helper.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5225,7 +5225,48 @@ not yet verified:
   negative" fallback branch (a 2003 `attribute.type` add-on) never applies
   here. Covered by new `scripts/rpg2k_logic_check.rb` checks (both types at
   once multiplying, and two attributes of the *same* type still keeping the
-  strongest rather than multiplying against each other).
+  strongest rather than multiplying against each other). ✅ **The "RPG2000
+  attribute rates never go negative" premise this same bullet opened with was
+  wrong, and the fallback branch it waved off *does* apply — now ported,
+  edition-gated.** A database's own `a_rate`..`e_rate` fields (`#attr_rate`,
+  `mruby-lcf/mrblib/schema.rb`) are plain signed ints with no validation, so a
+  deliberately-negative rank rate (the old "elemental absorb" editor trick) is
+  real, reachable data on an RPG2000 database too, not RPG2003-exclusive
+  content. Fetched EasyRPG Player's actual `Attribute::ApplyAttributeMultiplier`
+  (`src/attribute.cpp`) rather than trust the paraphrase: it guards both the
+  physical and magical bucket-max against `auto limit = Player::IsRPG2k() ?
+  -1 : INT_MIN;` — RPG2000 drops a side whose best rate is negative from
+  consideration *entirely* (the attack passes through unscaled by that side,
+  never healing), where RPG2003 lets a lone negative side scale the damage
+  directly, and falls back to `effect * std::max(physical, magical) / 100`
+  (the milder of the two, not a multiply) once either side is negative and
+  both are present. `Game::Battle#apply_attr_multiplier`
+  (`mruby-rpg2k/mrblib/game.rb`) had no such gate at all — a negative
+  `physical`/`magical` flowed straight into `physical * dmg / 100` (or the
+  ordinary two-percent multiply when both sides were present) exactly like a
+  positive one would, and neither `#deal_attack` nor `#apply_skill_hit` (its
+  two call sites) floor the *result* at zero the way the unrelated base-damage
+  formula does — so a weapon/skill carrying an attribute the target absorbs
+  computed a negative `dmg` that `target.hp -= dmg` then applied as a genuine
+  heal, on every edition, the opposite of RPG2000's real "just don't scale it"
+  behaviour. Fixed by giving `Game::Battle` an `rpg2003:` constructor flag
+  (mirroring `Game::Variables.new(rpg2003)`'s own pattern; `Scene::Map
+  #open_battle` passes `db.respond_to?(:rpg2003?) && db.rpg2003?`) and a new
+  `#above_attr_limit?(v)` helper porting `limit` exactly — `apply_attr_multiplier`
+  now runs each bucket-max through it before deciding which branch applies,
+  reproducing all four of `ApplyAttributeMultiplier`'s outcomes (both above the
+  floor and same-signed: ordinary multiply; both above the floor but either
+  negative: the `max`-based fallback; only one above the floor: that side
+  alone; neither: unchanged). Covered by two new `scripts/rpg2k_logic_check.rb`
+  checks (RPG2000: a lone negative-rate attribute leaves damage unscaled
+  rather than healing, and a positive weapon-type rate alongside a negative
+  magic-type one applies only the weapon side; RPG2003: the same lone
+  negative-rate attribute now does scale directly — a genuine attack-as-heal,
+  matching the edition's own real behaviour — and the same mixed-sign pair
+  takes the milder rate instead of multiplying), both confirmed to fail
+  against the pre-fix code before the fix (a `RuntimeError` on the wrong
+  damage figure for the RPG2000 case, an `ArgumentError` for the RPG2003 one
+  since the `rpg2003:` keyword did not exist yet).
 - Battle Animation: only one on screen at a time (a second forcibly cuts
   off the first); 1 frame = 1/30s, but a "Wait" frame is internally
   **two** consecutive 0.0s-wait frames, not one; chaining two Show Battle

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6656,7 +6656,7 @@ module Game
     # existing fixture keeps its results.
     def initialize(allies, enemies, rng = nil, states = nil, variance = false,
                    criticals = false, accuracy = false, first_strike = false,
-                   attributes = nil, ai = nil)
+                   attributes = nil, ai = nil, rpg2003: false)
       @allies = allies
       @enemies = enemies
       @rng = rng || Rng.new(0x2000)
@@ -6667,6 +6667,7 @@ module Game
       @first_strike = first_strike
       @attributes = attributes
       @ai = ai
+      @rpg2003 = rpg2003 ? true : false
       @rounds = 0
       @result = nil
       @escaped = false # set once the party successfully flees (#attempt_escape)
@@ -7990,9 +7991,18 @@ module Game
     # caller as `dmg * combined / 100`) was tried and dropped in an earlier
     # revision of this method for exactly that reason. Unchanged for an
     # attribute-less attack; a rank the target doesn't list defaults to C
-    # (100%). RPG2000 attribute rates never go negative, so EasyRPG's "one
-    # side is negative" fallback branch (2003's `attribute.type` add-on)
-    # never applies here.
+    # (100%). A database's own `a_rate`..`e_rate` fields are plain signed
+    # ints with no validation (`#attr_rate`), so a negative rank rate is
+    # real, reachable data (a deliberate "elemental absorb" trick), not
+    # exclusive to RPG2003 -- `ApplyAttributeMultiplier`'s own
+    # `limit = Player::IsRPG2k() ? -1 : INT_MIN` gate (verified against
+    # EasyRPG Player's `src/attribute.cpp`) treats the two editions
+    # differently: RPG2000 drops a side whose best rate is negative from
+    # consideration entirely (the attack passes through unscaled by that
+    # side, never healing), while RPG2003 lets a negative side scale the
+    # damage directly when it is the only one present, and falls to
+    # `dmg * [physical, magical].max / 100` (the milder of the two rather
+    # than multiplying) once either side is negative and both are present.
     def apply_attr_multiplier(dmg, attr_ids, target)
       return dmg if attr_ids.nil? || attr_ids.empty?
       ranks = target.attr_ranks || {}
@@ -8009,15 +8019,30 @@ module Game
           magical = pct if magical.nil? || pct > magical
         end
       end
-      if physical && magical
-        magical * (physical * dmg / 100) / 100
-      elsif physical
+      p_ok = above_attr_limit?(physical)
+      m_ok = above_attr_limit?(magical)
+      if p_ok && m_ok
+        if physical >= 0 && magical >= 0
+          magical * (physical * dmg / 100) / 100
+        else
+          dmg * [physical, magical].max / 100
+        end
+      elsif p_ok
         physical * dmg / 100
-      elsif magical
+      elsif m_ok
         magical * dmg / 100
       else
         dmg
       end
+    end
+
+    # Whether a bucket-max rate `v` (nil when that type matched nothing at
+    # all) clears `ApplyAttributeMultiplier`'s own edition-gated floor: any
+    # real value on RPG2003 (mirroring its `INT_MIN` limit), non-negative
+    # only on RPG2000 (its `-1` limit) -- see #apply_attr_multiplier above.
+    def above_attr_limit?(v)
+      return false if v.nil?
+      @rpg2003 || v >= 0
     end
 
     # The most disruptive "forced action" restriction among `b`'s states (0 = act

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4002,7 +4002,12 @@ class RPG2k
                                                 # Lets the troop run its 行動パターン:
                                                 # skills, transformations and the
                                                 # switch / party-level conditions.
-                                                Game::EnemyAi.new(db, @state)),
+                                                Game::EnemyAi.new(db, @state),
+                                                # A negative attribute rank rate
+                                                # (see #apply_attr_multiplier)
+                                                # is handled differently per
+                                                # edition.
+                                                rpg2003: db.respond_to?(:rpg2003?) && db.rpg2003?),
                        allies: allies, foes: foes, actor_i: 0, cmd: 0, target_i: 0,
                        skill_i: 0, item_i: 0, ally_i: 0, pending: nil,
                        skills: [], items: [],

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7292,6 +7292,74 @@ check 'battle: two attributes of the same type keep the strongest rate, not mult
   eq 40, bat.step_action[:damage] # base 20 * 200%, not 200% * 200%
 end
 
+check 'battle: RPG2000 drops a negative-rate attribute instead of healing (yado.tk / ' \
+     'EasyRPG src/attribute.cpp)' do
+  # Rank E (index 4) set to a deliberate -100% -- a plain signed database
+  # field, not something the editor forbids.
+  props = { 1 => RateRow.new(200, 150, 100, 50, -100, 0) } # weapon-type
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1]
+  foe = combatant('Foe', 0, 0, 5, 100_000)
+  foe.attr_ranks = { 1 => 4 } # rank E -> -100%
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false,
+                         false, false, props) # rpg2003 defaults to false
+  bat.command_attack(hero, foe)
+  bat.begin_round
+  # base atk damage = 40/2 - 0/4 = 20; RPG2000 excludes a negative-only match
+  # from the multiplier entirely, so the attack lands unscaled, not doubled
+  # into a -20 heal the way a blind percentage multiply would.
+  eq 20, bat.step_action[:damage]
+
+  # Mixed: a positive weapon-type rate alongside a negative magic-type one --
+  # only the weapon side (still above the RPG2000 floor) applies; the
+  # negative magic side is dropped rather than folded into the multiply.
+  props2 = { 1 => RateRow.new(200, 150, 100, 50, 0, 0),   # weapon-type
+             2 => RateRow.new(200, 150, 100, 50, -100, 1) } # magic-type
+  hero2 = combatant('Hero', 40, 0, 20, 100)
+  hero2.atk_attrs = [1, 2]
+  foe2 = combatant('Foe', 0, 0, 5, 100_000)
+  foe2.attr_ranks = { 1 => 0, 2 => 4 } # weapon rank A (200%), magic rank E (-100%)
+  bat2 = Game::Battle.new([hero2], [foe2], Game::Rng.new(1), nil, false, false,
+                          false, false, props2)
+  bat2.command_attack(hero2, foe2)
+  bat2.begin_round
+  eq 40, bat2.step_action[:damage] # 20 * 200%, the negative magic side excluded
+end
+
+check 'battle: RPG2003 lets a negative attribute rate scale damage directly, and ' \
+     'falls to the milder rate (not a multiply) when only one side is negative' do
+  # Same single-attribute setup as the RPG2000 check above, but with the
+  # `rpg2003:` flag on: unlike RPG2000, RPG2003 keeps EasyRPG's `INT_MIN`
+  # (no) floor, so the lone negative-rate side still applies directly.
+  props = { 1 => RateRow.new(200, 150, 100, 50, -100, 0) }
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.atk_attrs = [1]
+  foe = combatant('Foe', 0, 0, 5, 100_000)
+  foe.attr_ranks = { 1 => 4 }
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, false,
+                         false, false, props, nil, rpg2003: true)
+  bat.command_attack(hero, foe)
+  bat.begin_round
+  eq(-20, bat.step_action[:damage]) # 20 * -100% -- a genuine RPG2003 heal-via-attack
+
+  # Mixed, one side negative: RPG2003's own fallback is `dmg * max(physical,
+  # magical) / 100` (the milder of the two), not the ordinary two-percent
+  # multiply the same-sign case above (and the always-multiply pre-fix code)
+  # would apply.
+  props2 = { 1 => RateRow.new(200, 150, 100, 50, 0, 0),    # weapon-type
+             2 => RateRow.new(200, 150, 100, 50, -100, 1) } # magic-type
+  hero2 = combatant('Hero', 40, 0, 20, 100)
+  hero2.atk_attrs = [1, 2]
+  foe2 = combatant('Foe', 0, 0, 5, 100_000)
+  foe2.attr_ranks = { 1 => 0, 2 => 4 } # weapon rank A (200%), magic rank E (-100%)
+  bat2 = Game::Battle.new([hero2], [foe2], Game::Rng.new(1), nil, false, false,
+                          false, false, props2, nil, rpg2003: true)
+  bat2.command_attack(hero2, foe2)
+  bat2.begin_round
+  # max(200, -100) = 200 -> 20 * 200% = 40, not 20 * (200% * -100%) = -40.
+  eq 40, bat2.step_action[:damage]
+end
+
 check "battle: a database state's own rank rate gates the infliction" do
   # A hardy status: state 3 is 0% at *every* rank, so even a fully-susceptible
   # (rank A) target never catches it — the DB rate overrides the 100% default.


### PR DESCRIPTION
## Summary
- `Game::Battle#apply_attr_multiplier` applied a negative elemental attribute rank rate (`a_rate`..`e_rate`, a plain unvalidated signed-int database field — the old "elemental absorb" editor trick) as a literal percentage multiplier on every edition, and neither call site (`#deal_attack`, `#apply_skill_hit`) floors the *result* at zero, so `target.hp -= dmg` applied the negative figure as a genuine heal — the opposite of RPG2000's real "just don't scale it" behaviour.
- Verified against EasyRPG Player's actual `Attribute::ApplyAttributeMultiplier` (`src/attribute.cpp`) rather than trust `docs/TODO.md`'s own prior paraphrase ("RPG2000 attribute rates never go negative"), which was wrong: the function guards both the physical and magical bucket-max rate against `auto limit = Player::IsRPG2k() ? -1 : INT_MIN;` — RPG2000 drops a side whose best rate is negative from consideration entirely, where RPG2003 lets a lone negative side scale damage directly and falls back to the *milder* of the two rates (not a multiply) once either side is negative and both are present.
- Ported both edition behaviours with a new `Game::Battle` `rpg2003:` constructor flag (mirroring `Game::Variables.new(rpg2003)`'s existing pattern; `Scene::Map#open_battle` passes `db.rpg2003?`) and an `#above_attr_limit?` helper that reproduces the C++ `limit` gate.
- Updated `docs/TODO.md`'s existing attribute-stacking entry (which had originally waved off this exact fallback branch) with the corrected, evidence-cited writeup, and added a changelog fragment.

## Test plan
- Added two `scripts/rpg2k_logic_check.rb` checks: RPG2000 — a lone negative-rate attribute leaves damage unscaled rather than healing, and a positive weapon-type rate alongside a negative magic-type one applies only the weapon side; RPG2003 — the same lone negative-rate attribute now does scale directly (a genuine attack-as-heal, matching the edition's own real behaviour), and the same mixed-sign pair takes the milder rate instead of multiplying. Both confirmed to fail against the pre-fix code (`git stash` of the two source files) before the fix — a `RuntimeError` on the wrong damage figure for the RPG2000 case, an `ArgumentError` for the RPG2003 one since the `rpg2003:` keyword did not exist yet.
- `ruby scripts/rpg2k_logic_check.rb` — 762 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 476 checks passed.
- `ruby scripts/rpg2k_render_check.rb` — 40 checks passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` / `ruby scripts/rpg2k_command_soak.rb` — skipped (no test-bed game data available; this sandbox has no network access to download one).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015uZ6FAAU1qJUcY1HZqmY96)_