### PR TITLE
rpg2k: battle math now draws from the scene's single continuous RNG stream

### DIFF
--- a/changelog.d/battle-rng-reuses-scene-stream.fixed.md
+++ b/changelog.d/battle-rng-reuses-scene-stream.fixed.md
@@ -1,0 +1,14 @@
+- **A battle's own combat math (hit/miss, criticals, damage variance, enemy
+  AI, escape chance, item drops) now draws from the same continuously-
+  advancing RNG stream as the rest of the game session, instead of
+  restarting from the same fixed point every single fight.** Real RPG_RT
+  runs one PRNG stream for the whole session, never reseeded mid-game; this
+  engine's `Scene::Map#open_battle` instead built each fight's `Game::Battle`
+  on a brand-new `Game::Rng.new(0x2000)`, discarding the scene's own
+  already-advancing `@rng` (the same stream random-encounter checks and NPC
+  wandering already draw from). Two battles against the same troop, given
+  the same player inputs, played out byte-identical no matter how far apart
+  in the playthrough they happened. Fixed by threading the scene's own
+  `@rng` into `Game::Battle.new` in place of the disposable one; the
+  scene's own dedicated deterministic RNGs (used for the wine-diff
+  regression methodology) are untouched.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4179,7 +4179,48 @@ not yet verified:
   independently per variable, not once for the whole group, used to be a
   real gap here — now fixed, see below.)
 - The built-in random-number operand is a genuine non-seeded RNG (two New
-  Games produce different sequences) and accepts negative ranges.
+  Games produce different sequences) and accepts negative ranges. **The
+  negative-range half is confirmed already correct**: `Game::Interpreter
+  #random_operand` (`mruby-rpg2k/mrblib/interpreter.rb`) computes
+  `lo + @rng.random(hi - lo + 1)` off the command's two raw operands with no
+  `lo >= 0` assumption anywhere, so a range like -10..10 already resolves
+  correctly. ✅ **A distinct, narrower bug in the same neighbourhood is now
+  fixed: real RPG_RT's own PRNG is a single stream that keeps advancing for
+  the whole game session and is never reseeded mid-game, but this codebase's
+  battle math restarted from the exact same fixed point every single fight.**
+  `Scene::Map#open_battle` (`mruby-rpg2k/mrblib/scene/map.rb`) built every
+  `Game::Battle`'s combat RNG (hit/miss, critical, damage variance, enemy AI
+  weighted-draw, escape chance, item drops — everything `Game::Battle#rng`
+  feeds) from a brand-new `Game::Rng.new(0x2000)`, discarding the scene's own
+  already-advancing `@rng` — the identical stream random-encounter checks and
+  NPC wandering already draw from every step (`#check_random_encounter`,
+  `MapWorld`/`VehicleWorld`) — so a fight's very first roll was always
+  whatever seed 0x2000's first draw is, regardless of how many other rolls
+  the playthrough had already consumed, and two battles against the same
+  troop with the same player inputs played out byte-identical no matter how
+  far apart in the game they happened. This is a different, more concrete
+  claim than "two New Games differ": within a *single* game two separate
+  fights already diverged from real RPG_RT's single-stream behaviour, not
+  just across restarts. `Scene::Map`'s own dedicated, intentionally-seeded
+  RNGs (its own `@rng`, and `Game::Interpreter#@rng` for the Control
+  Variables random operand — see each class's own "seeded like the map
+  scene's own RNG" / "these runs are diffed against the genuine runtime"
+  comments) are deliberately kept deterministic for the wine-diff regression
+  methodology (`scripts/compare-nepheshel-wine.bash`) and are untouched by
+  this fix; only `open_battle`'s own disposable, uncommented `Rng.new(0x2000)`
+  — which had no such rationale attached and matched no reference-diffing
+  need — was the bug. Fixed by threading the scene's own `@rng` straight
+  into `Game::Battle.new` in place of the fresh instance, mirroring how the
+  same object already backs every other per-scene roll; `Game::Battle`'s own
+  `rng = nil` default (`rng || Rng.new(0x2000)`, `mruby-rpg2k/mrblib/game.rb`)
+  is untouched, since every `rpg2k_logic_check.rb` fixture that constructs a
+  `Game::Battle` directly still passes its own explicit controlled seed.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (the `Game::Battle`
+  a scripted Enemy Encounter opens carries the exact same `@rng` object,
+  `equal?`, as the scene's own; a second, otherwise-identical scene with a
+  handful of `@rng` draws already spent before the same fight is triggered
+  plays out a different hit/miss/damage log than one reached with none
+  spent), both confirmed to fail against the pre-fix code before the fix.
 - ✅ **`\N[]`/`\V[]` control codes now accept a nested `\V[n]` as their own
   argument** (`\N[\V[1]]` names the actor whose id is variable 1's *value*;
   `\V[\V[1]]` displays variable 1's value indirectly) — this build has no

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3995,7 +3995,7 @@ class RPG2k
         situations = db.respond_to?(:situation) ? db.situation : nil
         properties = db.respond_to?(:property) ? db.property : nil
         @battle_ui = { phase: :command, req: req, troop: troop, owner: owner,
-                       battle: Game::Battle.new(allies, foes, Game::Rng.new(0x2000),
+                       battle: Game::Battle.new(allies, foes, @rng,
                                                 situations, true, true, true,
                                                 req[:first_strike] ? true : false,
                                                 properties,

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4711,6 +4711,61 @@ check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Vi
   ok !st.switches[2], 'the Escape handler was skipped'
 end
 
+# yado.tk: "the built-in random-number operand is a genuine non-seeded RNG --
+# two New Games produce different sequences," i.e. real RPG_RT's randomness is
+# one continuously-advancing stream for the whole session, never reset mid-game.
+# `Scene::Map#open_battle` (mruby-rpg2k/mrblib/scene/map.rb) used to build each
+# fight's combat math on a brand-new `Game::Rng.new(0x2000)`, discarding
+# whatever the scene's own already-advancing `@rng` (the same stream random
+# encounters and NPC wandering already draw from) had reached -- so every
+# battle's hit/miss/crit/damage rolls started over from the exact same point
+# regardless of how much other randomness the playthrough had already
+# consumed, and two battles against the same troop played out identically
+# given the same player inputs. Fixed by passing the scene's own `@rng`
+# straight through instead of a disposable fresh one.
+check "Enemy Encounter scene: battle math reuses the scene's own advancing " \
+      'RNG stream, not a fresh one reseeded to the same constant every fight' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
+  ui = scene.instance_variable_get(:@battle_ui)
+  rng = scene.instance_variable_get(:@rng)
+  ok ui[:battle].rng.equal?(rng),
+     "the battle's own combat math should draw from the scene's single, " \
+     'already-advancing RNG object, not a freshly constructed one'
+end
+
+check 'Enemy Encounter scene: rolls already spent by earlier map activity change ' \
+      'how the ensuing battle plays out' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+
+  scene_a = new_scene({ 1 => event(2, 2, auto) })
+  scene_a.instance_variable_get(:@state)
+          .instance_variable_set(:@party, BattleStubParty.new)
+  battle_attack_to_end(scene_a)
+  log_a = scene_a.instance_variable_get(:@battle_ui)[:battle].log.dup
+
+  scene_b = new_scene({ 1 => event(2, 2, auto) })
+  scene_b.instance_variable_get(:@state)
+          .instance_variable_set(:@party, BattleStubParty.new)
+  # Stand in for ordinary map play before this same scripted fight is ever
+  # reached -- random-encounter rolls, NPC wandering steps, an earlier fight
+  # entirely -- all of which draw from this same per-scene RNG stream.
+  7.times { scene_b.instance_variable_get(:@rng).next_int }
+  battle_attack_to_end(scene_b)
+  log_b = scene_b.instance_variable_get(:@battle_ui)[:battle].log.dup
+
+  ok log_a != log_b,
+     'a fight reached after other map-side rolls should not replay the exact ' \
+     'same hit/miss/damage sequence as one reached with none spent'
+end
+
 check 'Enemy Encounter scene: battle BGM plays on entry, field BGM resumes after' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "The built-in random-number operand is a genuine non-seeded RNG" bullet's negative-range half was already correct (`Game::Interpreter#random_operand` has no `lo >= 0` assumption). Investigating the RNG angle further surfaced a distinct, concrete bug in the same neighborhood.
- `Scene::Map#open_battle` built every `Game::Battle`'s combat RNG (hit/miss, crit, damage variance, enemy AI weighted draw, escape chance, item drops) from a brand-new `Game::Rng.new(0x2000)`, discarding the scene's own already-advancing `@rng` — the identical stream random-encounter checks and NPC wandering already draw from every step.
- Real RPG_RT runs one PRNG stream for the whole session, never reseeded mid-game. The consequence: two battles against the same troop with identical player inputs played out byte-identical no matter how far apart in the game they happened.
- Threaded the scene's own `@rng` into `Game::Battle.new` in place of the fresh instance. `Game::Battle`'s own `rng = nil` default and every `rpg2k_logic_check.rb` fixture (which pass explicit controlled seeds) are untouched, as is the deliberately-deterministic `Scene::Map#@rng`/`Game::Interpreter#@rng` seeding scheme used for the wine-diff regression methodology.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 760 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 478 checks pass (2 new: the `Game::Battle` a scripted Enemy Encounter opens carries the exact same `@rng` object as the scene's own; a scene with a handful of `@rng` draws spent before the same fight is triggered produces a different hit/miss/damage log than an otherwise-identical scene reached with no prior draws — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_