### PR TITLE
rpg2k: a state's Avoid Attacks flag now grants immunity to basic attacks

### DIFF
--- a/changelog.d/state-avoid-attacks.fixed.md
+++ b/changelog.d/state-avoid-attacks.fixed.md
@@ -1,0 +1,13 @@
+- **A state flagged "Avoid Attacks" (RPG2003, field 36) now makes its target
+  dodge every basic attack unconditionally**, instead of doing nothing at
+  all. The `situation` (state) schema's `avoid_attacks` field was parsed but
+  read nowhere in `mruby-rpg2k`, so a status built for exactly this purpose —
+  RPG2000's closest thing to a guaranteed-dodge "Blink" — never took effect.
+  Confirmed against EasyRPG Player's C++ source
+  (`Game_Battler::EvadesAllPhysicalAttacks`, `Algo::CalcNormalAttackToHit`):
+  a normal attack against such a target always misses, checked first, ahead
+  of even a `Restriction_do_nothing` target's own "always hits" rule and a
+  必中 (evasion-ignoring) attacker's own bypass. Implemented with a new
+  `Game::Battle#evades_all_physical?` and an early `#to_hit` return. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check, confirmed to fail against
+  the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6699,6 +6699,56 @@ above are repeated here)
   coverage is unaffected, since a Seed item is never equippable in the first
   place (`Actor#equip_slot_for`/`#equip_item` gate on item `type` 1-5, Seed
   is type 8).
+- ✅ **A state's "Avoid Attacks" flag (RPG2003, field 36, `avoid_attacks`)
+  is now implemented — found via the same "parsed by the schema, read
+  nowhere in `mruby-rpg2k`" sweep that already caught `levitate`/
+  `transparent` above.** `LCF::Schema`'s `situation` (state) table
+  (`mruby-lcf/mrblib/schema.rb`) already decoded the field off every
+  database, but `Game::Battle#to_hit` (`mruby-rpg2k/mrblib/game.rb`) never
+  consulted it, so a state built for exactly this purpose — RPG2000's
+  closest thing to a guaranteed-dodge "Blink"/intangibility status — did
+  nothing at all: a target carrying it still resolved a basic attack
+  through the ordinary hit-rate/agility math like any unafflicted target.
+  Verified against EasyRPG Player's actual C++ source rather than guessed
+  at: `Game_Battler::EvadesAllPhysicalAttacks` (`src/game_battler.cpp`) scans
+  the target's own inflicted states for the flag, and `Algo::
+  CalcNormalAttackToHit` (`src/algo.cpp`) checks it **first**, ahead of
+  every other term — including the "a `Restriction_do_nothing` target
+  always gets hit" rule right below it and a 必中 (`ignores_evasion`)
+  attacker's own evasion-skip branch further down — returning a flat `0`
+  the instant it answers true, with nothing able to override it. (The
+  sibling skill-side check, `CalcSkillToHit`'s own
+  `easyrpg_affected_by_evade_all_physical_attacks` gate, is an EasyRPG-only
+  runtime extension with no backing LCF field at all — not something a
+  plain `.ldb` this project reads can ever set — so this fix is correctly
+  scoped to the basic-attack path alone, matching what a real, unmodified
+  RPG2003 database can actually express.) Fixed with a new
+  `Game::Battle#evades_all_physical?(b)` (scanning `b.states` via
+  `state_def`/`state_field`, the identical shape `#hit_modifier` already
+  uses for `reduce_hit_ratio` a few lines below) and a `return 0 if
+  evades_all_physical?(target)` at the very top of `#to_hit`, before the
+  attacker's own base hit rate is even read — mirroring
+  `CalcNormalAttackToHit`'s own ordering exactly, so the state wins over a
+  必中 attacker or a restricted target the same way real RPG_RT's does. Not
+  edition-gated: `EvadesAllPhysicalAttacks` carries no
+  `Player::IsRPG2k3()` check of its own in the C++ source, so — matching
+  this codebase's usual "trust the data" stance for flags real RPG_RT
+  itself never conditions on the running edition — the fix applies
+  unconditionally to whatever state row sets the flag, RPG2000 database
+  included (the RPG2000 editor simply never exposes a way to set it).
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (a slow, low-agility
+  target that would otherwise land a hit-rate roll in its attacker's favour
+  dodges every basic attack unconditionally once flagged; an unafflicted
+  bystander in the same fight is unaffected; a 必中 attacker cannot bypass
+  it; a second, unrelated state alongside it changes nothing), confirmed to
+  fail against the pre-fix code (`expected 0, got 95`) before the fix.
+  **Left open, a separate and more involved feature**: the sibling RPG2003
+  state fields `reflect_magic` (skill/magic attacks bounce back onto their
+  caster, `Game_Battler::HasReflectState` /
+  `Game_BattleAlgorithm::Skill::IsReflected` in the same C++ source) and
+  `cursed` (`Game_Actor`'s own separate, unrelated usage) — both still
+  parsed but unread here, and both needing real target-redirection/removal
+  logic rather than a single early-return, unlike this narrower fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6953,7 +6953,14 @@ module Game
     # `100 - (100 - base) * (srcAgi + tgtAgi) / (2 * srcAgi)` — so a nimbler
     # target dodges more. Clamped to 0..100. Only consulted when the fight has
     # accuracy enabled (see #initialize).
+    #
+    # A target carrying an "Avoid Attacks" (RPG2003) state dodges a basic
+    # attack unconditionally, before any other term -- EasyRPG's
+    # `CalcNormalAttackToHit` (algo.cpp) checks `target.EvadesAllPhysicalAttacks()`
+    # first and returns 0 immediately, ahead of even the restricted-target
+    # "always hits" rule and a 必中 attacker's own evasion-ignoring branch.
     def to_hit(attacker, target)
+      return 0 if evades_all_physical?(target)
       base = attacker.hit_rate || 90
       # 必中: a weapon flagged `ignore_evasion` skips the agility term entirely —
       # RPG_RT's `CalcNormalAttackToHit` returns before it applies evasion for
@@ -6977,6 +6984,17 @@ module Game
           Game.clamp(agi_adjusted, 0, 100)
         end
       raw * hit_modifier(attacker) / 100
+    end
+
+    # Whether any state currently afflicting `b` is flagged "Avoid Attacks"
+    # (RPG2003 state field 36, `avoid_attacks` in `mruby-lcf/mrblib/schema.rb`)
+    # -- EasyRPG's `Game_Battler::EvadesAllPhysicalAttacks` (game_battler.cpp),
+    # scanning every inflicted state the same way `#hit_modifier` does just
+    # below. Parsed but never read anywhere in this file before this fix, so a
+    # state built for this exact purpose (RPG2000's closest thing to a
+    # guaranteed-dodge "Blink"/intangibility status) did nothing at all.
+    def evades_all_physical?(b)
+      (b.states || []).any? { |sid| state_field(state_def(sid), :avoid_attacks) }
     end
 
     # How much the attacker's own statuses cut its accuracy: the **lowest**

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2713,7 +2713,13 @@ FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           # nil (every pre-existing positional FakeStateDef.new
                           # call that stops short of here) reads as 0/LOSE via
                           # #state_field, the schema's own default.
-                          :hp_change_type, :sp_change_type)
+                          :hp_change_type, :sp_change_type,
+                          # ... and the RPG2003 "Avoid Attacks" flag (state field
+                          # 36, `avoid_attacks`): a battler carrying it dodges
+                          # every basic attack unconditionally. Appended last,
+                          # same reason again -- nil reads as falsy via
+                          # #state_field, matching the schema's own false default.
+                          :avoid_attacks)
 # A state row carrying only the fields a check names, with the rest at the
 # database defaults — notably reduce_hit_ratio 100, which is "does not blind".
 def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
@@ -2726,7 +2732,8 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                affect_type: 2, affect_attack: false, affect_defense: false,
                affect_spirit: false, affect_agility: false,
                hp_change_type: Game::States::CHANGE_TYPE_LOSE,
-               sp_change_type: Game::States::CHANGE_TYPE_LOSE)
+               sp_change_type: Game::States::CHANGE_TYPE_LOSE,
+               avoid_attacks: false)
   FakeStateDef.new(restriction, hp_val, hp_max, sp_val, sp_max, hold_turn,
                    auto_release, release_by_attack, reduce_hit_ratio,
                    restrict_skill, restrict_skill_level,
@@ -2735,7 +2742,7 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                    hp_map_steps, hp_map_val, sp_map_steps, sp_map_val,
                    affect_type, affect_attack, affect_defense,
                    affect_spirit, affect_agility,
-                   hp_change_type, sp_change_type)
+                   hp_change_type, sp_change_type, avoid_attacks)
 end
 # An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
@@ -9406,6 +9413,33 @@ check 'battle: a blinding state cuts its victim\'s accuracy by reduce_hit_ratio'
   # Several states take the *lowest* ratio, not the product of them.
   blind.states = [8, 9]
   eq 18, bat.send(:to_hit, blind, foe), 'the worst state wins (20%, not 50%*20%)'
+end
+
+check 'battle: an "Avoid Attacks" (RPG2003) state dodges every basic attack unconditionally' do
+  # Parsed (mruby-lcf/mrblib/schema.rb state field 36, avoid_attacks) but never
+  # read anywhere in Game::Battle before this fix -- EasyRPG's
+  # Game_Battler::EvadesAllPhysicalAttacks (game_battler.cpp) forces
+  # CalcNormalAttackToHit to 0 the instant the target carries one, ahead of
+  # every other term, so the state did nothing at all here.
+  states = { 12 => fake_state(avoid_attacks: true), 13 => fake_state }
+  attacker = combatant('Attacker', 20, 0, 10, 100) # a fast, hard-hitting attacker
+  dodger = combatant('Dodger', 0, 0, 1, 100)        # slow, so agi alone would favour a hit
+  dodger.states = [12]
+  plain = combatant('Plain', 0, 0, 1, 100)
+  bat = Game::Battle.new([attacker], [dodger, plain], Game::Rng.new(1), states,
+                         false, false, true)          # accuracy on
+  eq 0, bat.send(:to_hit, attacker, dodger),
+     'the state forces a flat 0% chance, agility and hit rate notwithstanding'
+  ok bat.send(:to_hit, attacker, plain) > 0, 'an unafflicted target is unaffected'
+
+  # A 必中 (evasion-ignoring) attacker does not bypass this: real RPG_RT checks
+  # avoid_attacks before it ever reaches the ignores_evasion branch.
+  attacker.ignores_evasion = true
+  eq 0, bat.send(:to_hit, attacker, dodger), 'even a 必中 attacker cannot bypass it'
+
+  # Carrying an unrelated, unflagged state alongside it changes nothing.
+  dodger.states = [12, 13]
+  eq 0, bat.send(:to_hit, attacker, dodger), 'still dodges with a second, unrelated state'
 end
 
 check 'battle: a normal attack can shake a state off its target' do


### PR DESCRIPTION
## Summary

- RPG2003's state (`situation`) database field 36, `avoid_attacks` ("Avoid Attacks"), was decoded by `mruby-lcf/mrblib/schema.rb` but never consulted anywhere in `mruby-rpg2k` — a status built for exactly this purpose (RPG2000's closest thing to a guaranteed-dodge "Blink"/intangibility status) did nothing at all: an afflicted target's basic-attack accuracy still resolved through the ordinary hit-rate/agility math as if unafflicted.
- Verified against EasyRPG Player's actual C++ source rather than guessed at: `Game_Battler::EvadesAllPhysicalAttacks` (`src/game_battler.cpp`) scans a target's inflicted states for the flag, and `Algo::CalcNormalAttackToHit` (`src/algo.cpp`) checks it **first** — ahead of the `Restriction_do_nothing` "always hits" rule and a 必中 (evasion-ignoring) attacker's own bypass — returning a flat `0%` hit chance the instant it's set, with nothing able to override it.
- Fixed with a new `Game::Battle#evades_all_physical?(b)` (scans `b.states` via the existing `state_def`/`state_field` helpers, the same shape `#hit_modifier` already uses for `reduce_hit_ratio`) and a `return 0 if evades_all_physical?(target)` at the very top of `#to_hit`, mirroring `CalcNormalAttackToHit`'s own ordering exactly.
- Not edition-gated: `EvadesAllPhysicalAttacks` carries no `Player::IsRPG2k3()` check of its own in the C++ source, so the fix applies to whatever state row sets the flag, unconditionally (the RPG2000 editor simply never exposes a way to set it in practice).
- Left open as a separate, more involved feature: the sibling RPG2003 state fields `reflect_magic` (skill/magic attacks bounce back onto their caster) and `cursed` — both still parsed but unread, and both needing real target-redirection/removal logic rather than a single early-return.

## Test plan

- Added a new `scripts/rpg2k_logic_check.rb` check: a slow, low-agility target that would otherwise land a hit-rate roll in its attacker's favour dodges every basic attack unconditionally once flagged; an unafflicted bystander in the same fight is unaffected; a 必中 attacker cannot bypass it; a second, unrelated state alongside it changes nothing. Confirmed to fail against the pre-fix code (`expected 0, got 95`) before the fix.
- `ruby scripts/rpg2k_logic_check.rb` — 761 checks passed.
- `ruby scripts/rpg2k_scene_check.rb` — 476 checks passed.
- `ruby scripts/rpg2k_render_check.rb` — 40 checks passed.
- `ruby scripts/rpg2k_testbed_logic_check.rb` / `ruby scripts/rpg2k_command_soak.rb` — could not run (no test-bed game data available; this sandbox has no network access to download it). Both skip cleanly with their standard "no game found under ./data" message.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X2U6PLJ2DK6PHEzRvGAxuL)_