### PR TITLE
rpg2k: EXP/gold/drops no longer count a troop member still hidden at victory time

### DIFF
--- a/changelog.d/battle-drops-skip-hidden-troop-members.fixed.md
+++ b/changelog.d/battle-drops-skip-hidden-troop-members.fixed.md
@@ -1,0 +1,16 @@
+- **A troop member still `hidden` at the moment of victory — never revealed
+  by its own Show Hidden Monster page, or sent running by that page's Force
+  Flee — no longer hands over EXP, gold or a treasure drop it never actually
+  fought or fell for.** `Game::Battle#incapacitated?` (`mruby-rpg2k/mrblib/
+  game.rb`) already treats a hidden member the same as a dead one for
+  win/loss purposes, so victory can fire the instant every *visible* member
+  is down, with no requirement that a still-hidden one ever engaged.
+  `Game::Troop#total_exp`/`#total_gold`/`#drops` summed/rolled every member
+  unconditionally, with no such check — verified against EasyRPG Player's
+  actual C++ source: `Game_EnemyParty::GetExp`/`GetMoney`/`GenerateDrops`
+  (`src/game_enemyparty.cpp`) each gate on `enemy.IsDead()`, a bare
+  `GetHp() == 0` check that a hidden or fled member (never damaged, only ever
+  `SetHidden`) always fails. Fixed with a new private `Troop#live_members`
+  (`@members.reject(&:hidden)`) that all three methods now route through.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check, confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5070,6 +5070,44 @@ not yet verified:
   against a defenceless, high-max-HP target clamps at 999, both in the HP
   change and the stored variable), confirmed to fail against the pre-fix
   code.
+- ✅ **A troop member still `hidden` at the moment of victory — never
+  revealed by its own Show Hidden Monster page, or sent running by that
+  page's Force Flee — used to still hand over its EXP, gold and treasure
+  drop, even though it never actually fought or fell.** Not a claim from the
+  site's own text; found by comparing `Game::Troop` against EasyRPG Player's
+  actual C++ source while triaging the drop-related bullets nearby.
+  `Game::Battle#incapacitated?` (`mruby-rpg2k/mrblib/game.rb`) already treats
+  `out_of_play?` (dead **or** hidden) as "out of the fight" for win/loss
+  purposes, so `alive?(@enemies)` — and with it victory — can go true the
+  instant every *visible* member is down, with no requirement that a
+  still-hidden one (never revealed, or fled) ever took a hit at all. `Game::
+  Troop#total_exp`/`#total_gold`/`#drops` summed/rolled every member
+  unconditionally, with no such check. Verified against real RPG_RT's own
+  logic rather than guessed at: EasyRPG's `Game_EnemyParty::GetExp`/
+  `GetMoney`/`GenerateDrops` (`src/game_enemyparty.cpp`) each loop `if
+  (enemy.IsDead())` before counting a member at all, and `Game_Battler::
+  IsDead` (`src/game_battler.h`) is a bare `GetHp() == 0` — a hidden
+  member's HP is never touched by sitting out the fight, and Force Flee only
+  ever calls `SetHidden`, never `Kill`, so both cases read `IsDead() ==
+  false` there too, matching this codebase's own "hidden" signal exactly.
+  `Troop`'s own `Enemy` members never take damage in the first place — the
+  actual fight plays out on separate `Combatant` structs in `Game::Battle` —
+  so `hidden` (kept live by `Scene::Map#reveal_battle_monster`/
+  `#remove_fled_monster`, the same flag the already-fixed "reinforcement
+  revealed before a premature victory" and "hidden troop member not
+  targetable" checks rely on) is both the only signal available here and,
+  given the `incapacitated?` equivalence above, the *correct* one: any
+  non-hidden member reaching this call is guaranteed to be the dead case.
+  Fixed by adding a private `Troop#live_members` (`@members.reject(&:hidden)`)
+  and routing all three methods through it instead of the raw `@members`
+  list. Covered by a new `scripts/rpg2k_logic_check.rb` check (a troop with
+  one ordinary member and one starting/ending hidden grants only the visible
+  member's EXP/gold and never rolls the hidden one's 100%-certain drop, both
+  for a never-revealed member and one flagged hidden mid-fight to simulate a
+  Force Flee), confirmed to fail against the pre-fix code before the fix; the
+  pre-existing `Game::Troop instantiates its members and totals EXP / gold`
+  check's own totals (which had baked in the old, buggy inclusion of its
+  fixture's invisible-from-the-start Bat) were corrected to match.
 - ✅ **Turn-order tie-break on equal Agility: an ally acts before an
   equal-agility enemy; among tied allies, the lower actor id acts first.**
   The ally-before-enemy half was already correct by construction —

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6027,21 +6027,49 @@ module Game
       @pages = row && row.respond_to?(:pages) ? row.pages : nil
     end
 
-    def total_exp;  @members.reduce(0) { |s, e| s + e.exp } end
-    def total_gold; @members.reduce(0) { |s, e| s + e.gold } end
+    # EXP / gold / drops are only earned from members that actually fell in
+    # this fight -- a member still flagged `hidden` at victory time (either
+    # never revealed by a Show Hidden Monster page, or sent running by a
+    # page's own Force Flee) contributes none of the three, even though a
+    # fight can end in victory while such a member is technically still at
+    # full HP: `Game::Battle#incapacitated?` (`mruby-rpg2k/mrblib/game.rb`)
+    # already treats hidden the same as dead for win/loss purposes
+    # (`out_of_play?`), so `alive?(@enemies)` goes false -- and victory fires
+    # -- the instant every *visible* member is down, with no requirement that
+    # a still-hidden one ever engaged at all. Matches EasyRPG's actual C++
+    # source: `Game_EnemyParty::GetExp`/`GetMoney`/`GenerateDrops`
+    # (`src/game_enemyparty.cpp`) each loop `if (enemy.IsDead())` before
+    # summing/rolling that member at all, and `Game_Battler::IsDead` (`src/
+    # game_battler.h`) is a bare `GetHp() == 0` check -- a hidden member's own
+    # HP is never touched by never fighting, and a Force-Fled member's isn't
+    # either (`SetHidden` alone, no `Kill`), so both read `IsDead() == false`
+    # and are skipped by all three real methods. This class never lets a
+    # member's HP move at all -- the actual combat plays out on parallel
+    # `Combatant` structs in `Game::Battle`, not on `Troop`'s own `Enemy`
+    # objects -- so `hidden` (kept live by `Scene::Map#reveal_battle_monster`/
+    # `#remove_fled_monster`) is the one signal available here, and by the
+    # "hidden ~ not dead" equivalence above it is also the *correct* one: a
+    # non-hidden member reaching this call is always the dead case.
+    def total_exp;  live_members.reduce(0) { |s, e| s + e.exp } end
+    def total_gold; live_members.reduce(0) { |s, e| s + e.gold } end
 
     # The item ids the troop yields on victory: each member carrying a drop item
     # rolls its `drop_prob` percentage against `rng` (0..99 < prob, EasyRPG's
     # Rand::PercentChance), so a 100% drop is certain, a 0% never lands, and the
     # same item can drop from several members. Returns the ids in member order.
     def drops(rng)
-      @members.each_with_object([]) do |e, out|
+      live_members.each_with_object([]) do |e, out|
         next unless e.drop_id && e.drop_id > 0
         out << e.drop_id if rng.random(100) < e.drop_prob
       end
     end
 
     private
+
+    # Members that actually took part and fell -- see the comment on
+    # #total_exp/#total_gold/#drops above for why `hidden` is the right (and
+    # only available) proxy for "dead" at this call site.
+    def live_members; @members.reject(&:hidden) end
 
     def member(db, m)
       Enemy.new(db, m.enemy_id, m.x, m.y, m.invisible)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6710,8 +6710,13 @@ check 'Game::Troop instantiates its members and totals EXP / gold' do
   troop = Game::Troop.new(battle_db, 1)
   eq 'Slimes', troop.name
   eq [2, 2, 3], troop.members.map(&:id)
-  eq 13, troop.total_exp, '5 + 5 + 3'
-  eq 24, troop.total_gold, '10 + 10 + 4'
+  # The third member (a Bat) starts invisible; totals only ever count members
+  # a fight actually finished off, so the still-hidden Bat's own 3 EXP / 4
+  # gold are excluded here even though it's a live member of this troop --
+  # see the "Troop EXP/gold/drops exclude a member still hidden..." check
+  # below for the dedicated regression coverage.
+  eq 10, troop.total_exp, '5 + 5, excluding the still-hidden Bat'
+  eq 20, troop.total_gold, '10 + 10, excluding the still-hidden Bat'
   first = troop.members.first
   eq 30, first.max_hp
   eq 30, first.hp, 'starts at full HP'
@@ -6778,6 +6783,31 @@ check 'Troop#drops rolls the drop probability on the given RNG' do
   results = Array.new(40) { troop.drops(rng) }
   ok results.any? { |r| r == [7] }, 'the 50% drop sometimes lands'
   ok results.any?(&:empty?), 'and sometimes misses'
+end
+
+check 'Troop EXP/gold/drops exclude a member still hidden at victory time (yado.tk, EasyRPG game_enemyparty.cpp)' do
+  # A never-revealed Show-Hidden-Monster member: victory can fire while it's
+  # still flagged invisible (Game::Battle#incapacitated? treats hidden the
+  # same as dead for win/loss purposes), yet it never actually fell.
+  db = BattleDB.new(
+    { 2 => EnemyRow.new('Slime', 30, 0, 8, 4, 3, 5, 5, 10, 7, 100),  # visible, always drops 7
+      3 => EnemyRow.new('Bat',   12, 0, 6, 2, 2, 9, 3,  4, 9, 100) },# hidden, would always drop 9
+    { 1 => GroupRow.new('Mob', { 1 => GroupMember.new(2, 0, 0, false),
+                                 2 => GroupMember.new(3, 0, 0, true) }) })
+  troop = Game::Troop.new(db, 1)
+  eq 5, troop.total_exp, 'only the visible Slime\'s 5 EXP counts, not the hidden Bat\'s 3'
+  eq 10, troop.total_gold, 'same for gold: 10, not 10 + 4'
+  eq [7], troop.drops(Game::Rng.new(1)), 'the hidden Bat\'s 100% drop never rolls'
+
+  # A Force-Fled member: starts visible, but a battle-event page's Force Flee
+  # (Scene::Map#remove_fled_monster) sets `hidden` mid-fight the same way an
+  # unrevealed one starts -- it ran off, so it drops nothing either, exactly
+  # like the never-shown case above.
+  fled_troop = Game::Troop.new(db, 1)
+  fled_troop.members[1].hidden = true # simulates a mid-battle Force Flee
+  eq 5, fled_troop.total_exp, 'a fled member grants no EXP even though it started visible'
+  eq 10, fled_troop.total_gold
+  eq [7], fled_troop.drops(Game::Rng.new(1)), 'and no drop either'
 end
 
 check 'a missing troop / enemy degrades to an empty, harmless model' do


### PR DESCRIPTION
## Summary
- `Game::Battle#incapacitated?` already treats a hidden troop member (never revealed by Show Hidden Monster, or fled mid-battle via `Scene::Map#remove_fled_monster`) the same as dead for win/loss purposes, so `alive?(@enemies)` — and victory — can go true while a still-hidden member sits at full HP, having never engaged.
- `Game::Troop#total_exp`, `#total_gold`, and `#drops` summed/rolled every troop member unconditionally, with no such exclusion — a never-revealed or fled monster still contributed its EXP, gold, and had its treasure-drop chance rolled.
- Verified against EasyRPG's real logic: `Game_EnemyParty::GetExp`/`GetMoney`/`GenerateDrops` each gate on `enemy.IsDead()` (`GetHp() == 0`), which a hidden/fled member always fails since only `SetHidden` is ever called on it, never `Kill`.
- Added a private `Troop#live_members` (`@members.reject(&:hidden)`); `#total_exp`, `#total_gold`, and `#drops` now route through it instead of the raw `@members` list.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 761 checks pass (1 new: a never-revealed hidden member and a member flagged hidden mid-fight (simulating Force Flee) are both excluded from EXP, gold, and a would-be-certain 100% drop roll — confirmed to fail against the pre-fix code; also corrected a pre-existing check whose totals had baked in the old buggy inclusion of its fixture's invisible-from-the-start Bat)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 478 checks pass
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_