### PR TITLE
rpg2k: save-file-select screen layout matches genuine RPG_RT

### DIFF
--- a/changelog.d/rpg2k-save-file-select-layout.fixed.md
+++ b/changelog.d/rpg2k-save-file-select-layout.fixed.md
@@ -1,0 +1,9 @@
+- **The save-file-select screen's layout now matches genuine RPG_RT.exe.**
+  Verified under wine: RPG_RT shows one bordered box per slot (name and
+  level+HP only, a compact cursor around just the "File N" label, exactly 3
+  slots visible at once, no placeholder text on an empty slot), where this
+  engine packed more into one shared list window (gold, the current map,
+  `/max` on HP, zero-padded labels, "-- No Data --" placeholders, 6 slots
+  without scrolling). `Scene::SaveLoad` now builds one window per visible
+  slot instead of a single list window, matching the reference capture
+  field-for-field.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2216,7 +2216,24 @@ The work below is roughly ordered by the critical path to a walkable game
   almost certainly has the same two-column shape (RPG2000's skill list is
   drawn by the same kind of window as the item list), but that has not
   itself been driven under wine with a populated skill list, so it is left
-  single-column rather than assumed.
+  single-column rather than assumed. **Tried and inconclusive:** getting a
+  populated skill list under wine to check turned out to need more than a
+  save edit -- Nepheshel's own actor 15 (デモ用, the leader on the test save)
+  carries no skills in the save's own chunk 108 at all, so three separate
+  attempts at editing that field in directly (via the same technique that
+  worked for the item bag) each granted a handful of skills this engine's
+  own `Game::Party#field_skill?` heuristic (scope >= 2 plus
+  affect_hp/affect_sp/inflicts a state) predicts should all show up field-
+  side -- and RPG_RT then showed only *one* of them each time (a different
+  one depending which ids were granted, always the first list entry).
+  Genuine RPG_RT's real field-eligibility rule is evidently narrower than
+  that heuristic in some way this comparison did not pin down (the
+  `occasion_field`/`occasion_battle` byte flags this schema does not decode
+  for ordinary, non-switch skills are the likely culprit -- `field_skill?`'s
+  own comment already notes they gate switch skills only *in this engine's
+  own port*, which this result casts some doubt on as the full RPG_RT
+  picture). Left for whoever picks this up next rather than guessed at
+  further.
   - The item count's separator glyph differs: RPG_RT draws something
     resembling a bold "＝" between the name and the count (e.g. "薬草　＝　５"),
     where this engine draws a plain ASCII ":" (`":#{count}"` in
@@ -2322,16 +2339,30 @@ The work below is roughly ordered by the critical path to a walkable game
   `RPG2k#continue_game` passes `apply_access: false`; both the headless
   `--rpg2k_continue` path and the in-game Continue/Load screen
   (`Scene::SaveLoad`, which calls the same `#continue_game`) go through it.
-  **Left open by the same fixed capture:** RPG_RT's save-file-select screen
-  shows one taller box per slot with just the leader's name/level/HP and
-  only 3 of 15 slots visible per screen (presumably scrolling); this
-  engine's own screen packs more per slot (gold and the current map name
-  too, matching the README's own description of what it shows) and fits 6
-  slots without scrolling. A real layout/format difference, not chased into
-  a fix here -- unlike the access-flag bug above it is not a correctness
-  question, and picking which of RPG_RT's specific choices (box height,
-  slots-per-screen, which fields to show) to match wants its own pass
-  rather than folding into this one.
+  ✅ **The save-file-select screen's layout/format difference flagged by the
+  same fixed capture is now fixed too.** RPG_RT shows one taller box *per
+  slot* -- its own bordered window, not a row inside one shared list -- with
+  just the leader's name and level+HP (no gold, no current map, no `/max`
+  on the HP figure), a compact pill-shaped cursor around just the "File N"
+  label rather than a full-row highlight, and exactly 3 of 15 slots visible
+  at once; an empty slot draws only its label line, no "No Data" text at
+  all (the same class of gap the Item/Skill empty-list placeholders turned
+  out to be). This engine's own screen used to pack more into one shared
+  list window (zero-padded "File 01", gold and the current map name,
+  current/max HP, "-- No Data --" on empty slots, 6 slots without
+  scrolling) -- confirmed against a real reference capture
+  (`ファイル　1` / `デモ用` / `LV50    HP600`, with File 2/3 showing only
+  their bare label). `Scene::SaveLoad` now builds `VISIBLE_SLOTS` (3, derived
+  from `(SCREEN_H - HEADER_H) / SLOT_BOX_H`) separate per-slot windows
+  instead of one list window, drops the gold/map/max-HP fields and the
+  zero-padding, and sizes each slot's cursor to its own label text via
+  `Bitmap#text_size`. Verified against the same reference frame field-for-
+  field, on both the header state (File 1 selected, occupied) and after
+  pressing Down onto the empty File 2 slot. **Not chased further:** the
+  16px strip below the third box that a scroll indicator arrow presumably
+  occupies once there is more than one screenful -- the reference capture
+  used here never scrolled, so there is no confirmed glyph/position for it
+  yet.
 
 #### Assets & infrastructure
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -1,9 +1,11 @@
 class RPG2k
   module Scene
     # RPG2000's save-select screen: a scrollable list of the MAX_SAVE_SLOTS
-    # file slots, each showing the party leader, level, HP, gold and current
-    # map when the slot holds a save, or a "no data" placeholder when it does
-    # not. Pushed in two shapes:
+    # file slots, each its own bordered box (not rows in one shared list
+    # window) showing the party leader, level and HP when the slot holds a
+    # save, or just the file label when it does not -- confirmed against
+    # genuine RPG_RT under wine (see VISIBLE_SLOTS/SLOT_BOX_H below for the
+    # specifics this ports). Pushed in two shapes:
     #
     #   * `:save`, from Scene::Menu's Save command, with the running
     #     Game::State to write out. Every slot -- occupied or not -- is
@@ -28,10 +30,26 @@ class RPG2k
       SCREEN_H = RPG2k::HEIGHT
       SLOT_COUNT = RPG2k::MAX_SAVE_SLOTS
       LINE_H = 16
-      # Two text lines per slot: the file label/name/level row, and the
-      # HP/gold/map row beneath it.
-      ROW_H = LINE_H * 2
       HEADER_H = LINE_H + Window::BORDER * 2
+
+      # Each visible slot is its own bordered window, three text lines tall
+      # (file label, leader name, level+HP) -- confirmed against genuine
+      # RPG_RT under wine, which draws File 1/2/3 as three separate boxes
+      # stacked below the header, not rows inside one shared list window
+      # (scripts/rpg2k_scene_check.rb's fixtures aside, a real screenshot
+      # showed each box's own purple border independently). An empty slot's
+      # box shows only the label line, the other two blank -- no "No Data"
+      # placeholder text at all, the same class of gap the Item/Skill empty-
+      # list placeholders turned out to be (see docs/TODO.md).
+      SLOT_LINES = 3
+      SLOT_BOX_H = LINE_H * SLOT_LINES + Window::BORDER * 2
+
+      # (SCREEN_H - HEADER_H) / SLOT_BOX_H, i.e. how many slot boxes fit
+      # below the header -- 3 on RPG2000's 320x240 screen (32 + 3*64 = 224,
+      # leaving 16px for a scroll indicator this port does not draw yet).
+      # Matches the reference capture exactly: three boxes on screen, the
+      # rest reached by scrolling.
+      VISIBLE_SLOTS = (SCREEN_H - HEADER_H) / SLOT_BOX_H
 
       def initialize parent, state, mode
         super parent
@@ -44,14 +62,15 @@ class RPG2k
         @index = 0
         @top = 0
         @message = nil
+        @slot_windows = []
         build_header_window
-        build_list_window
+        build_slot_windows
       end
 
       def dispose
         close_message
         @header_window.dispose if @header_window
-        @list_window.dispose if @list_window
+        @slot_windows.each(&:dispose)
       end
 
       def update
@@ -70,15 +89,11 @@ class RPG2k
 
       private
 
-      def visible_rows
-        [(@list_window.height - Window::BORDER * 2) / ROW_H, 1].max
-      end
-
       def move_selection(delta)
         @index = (@index + delta) % SLOT_COUNT
         @top = @index if @index < @top
-        @top = @index - visible_rows + 1 if @index >= @top + visible_rows
-        draw_list_contents
+        @top = @index - VISIBLE_SLOTS + 1 if @index >= @top + VISIBLE_SLOTS
+        refresh_slot_windows
       end
 
       def confirm_selection
@@ -87,7 +102,7 @@ class RPG2k
         when :save
           ok = @parent.save_game(@state, slot)
           @slots[@index] = @parent.load_save_state(slot) if ok
-          draw_list_contents
+          refresh_slot_windows
           show_message(ok ? "Game saved." : "Save failed.")
         when :load
           # An empty slot has nothing to resume -- ignored, like the
@@ -110,67 +125,59 @@ class RPG2k
         @header_window.contents = c
       end
 
-      def build_list_window
-        y = HEADER_H
-        @list_window = Window.new(0, y, SCREEN_W, SCREEN_H - y)
-        @list_window.z = 400
-        @list_window.windowskin = @skin
-        draw_list_contents
+      def build_slot_windows
+        VISIBLE_SLOTS.times do |i|
+          w = Window.new(0, HEADER_H + i * SLOT_BOX_H, SCREEN_W, SLOT_BOX_H)
+          w.z = 400
+          w.windowskin = @skin
+          @slot_windows << w
+        end
+        refresh_slot_windows
       end
 
-      # Redraw the list window's contents for the current scroll offset
-      # (`@top`) and reposition the cursor onto the selected row -- called
-      # whenever the selection moves or a save just changed a slot's preview.
-      def draw_list_contents
-        inner_w = @list_window.width - Window::BORDER * 2
-        rows = visible_rows
-        c = Bitmap.new(inner_w, rows * ROW_H)
-        c.font.color = Color.new(255, 255, 255, 255)
-        rows.times do |i|
+      # Redraw every visible slot box for the current scroll offset (`@top`)
+      # and put the cursor on the selected one -- called whenever the
+      # selection moves or a save just changed a slot's preview.
+      def refresh_slot_windows
+        inner_w = SCREEN_W - Window::BORDER * 2
+        @slot_windows.each_with_index do |win, i|
           slot_index = @top + i
-          break if slot_index >= SLOT_COUNT
-          draw_slot_row(c, i * ROW_H, inner_w, slot_index)
+          draw_slot_box(win, inner_w, slot_index)
         end
-        @list_window.contents = c
-        @list_window.cursor_rect =
-          Rect.new(0, (@index - @top) * ROW_H, inner_w, ROW_H)
       end
 
       def slot_label(slot_index)
-        slot = slot_index + 1
-        n = slot < 10 ? "0#{slot}" : "#{slot}"
-        "#{term(:file, 'File')} #{n}"
+        "#{term(:file, 'File')} #{slot_index + 1}"
       end
 
-      def draw_slot_row(c, y, w, slot_index)
+      # `slot_index`'s box: the file label always, and -- when the slot holds
+      # a save -- the leader's name and level+HP beneath it. Confirmed
+      # against genuine RPG_RT under wine: an empty slot shows only the
+      # label (no placeholder text at all), and an occupied one shows
+      # neither gold nor the current map, and HP with no `/max`, unlike this
+      # screen's own previous single-list-window layout.
+      def draw_slot_box(win, inner_w, slot_index)
         label = slot_label(slot_index)
+        c = Bitmap.new(inner_w, LINE_H * SLOT_LINES)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, LINE_H, label
         state = @slots[slot_index]
-        unless state
-          c.draw_text 0, y, w, LINE_H, label
-          c.draw_text 0, y + LINE_H, w, LINE_H, "-- No Data --"
-          return
+        if state
+          leader = state.party.leader
+          name = leader ? leader.name.to_s : ''
+          level = leader ? leader.level : 0
+          hp = leader ? leader.hp : 0
+          c.draw_text 0, LINE_H, inner_w, LINE_H, name
+          c.draw_text 0, LINE_H * 2, inner_w, LINE_H,
+                      "#{term(:level_short, 'Lv')}#{level}    " \
+                      "#{term(:hp_short, 'HP')}#{hp}"
         end
-        leader = state.party.leader
-        name = leader ? leader.name.to_s : ''
-        level = leader ? leader.level : 0
-        hp = leader ? leader.hp : 0
-        max_hp = leader ? leader.max_hp : 0
-        c.draw_text 0, y, w, LINE_H,
-                    "#{label}  #{name}  #{term(:level_short, 'Lv')}#{level}"
-        c.draw_text 0, y + LINE_H, w, LINE_H,
-                    "#{term(:hp_short, 'HP')} #{hp}/#{max_hp}  " \
-                    "#{state.party.gold}#{term(:gold, 'G')}  " \
-                    "#{map_display_name(state.map_id)}"
-      end
-
-      # A map's editor name, or its bare id when the tree carries no name for
-      # it -- mirrors Scene::ItemMenu#map_display_name /
-      # Scene::SkillMenu#map_display_name (the teleport destination pickers),
-      # each keeping their own copy rather than sharing one through Base.
-      def map_display_name(map_id)
-        row = map_tree.respond_to?(:map_properties) ? map_tree.map_properties[map_id] : nil
-        name = row && row.respond_to?(:name) ? row.name.to_s : nil
-        name.nil? || name.empty? ? "Map #{map_id}" : name
+        win.contents = c
+        win.cursor_rect = if slot_index == @index
+                             Rect.new(0, 0, c.text_size(label).width, LINE_H)
+                           else
+                             Rect.new(0, 0, 0, 0)
+                           end
       end
 
       # The "Game saved." / "Save failed." feedback banner, mirroring

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9467,24 +9467,30 @@ def save_load_scene(mode, state = nil, db = fake_db, parent: nil)
   [RPG2k::Scene::SaveLoad.new(parent, state, mode), parent]
 end
 
-check 'Scene::SaveLoad: an empty slot shows the "No Data" placeholder' do
+check 'Scene::SaveLoad: an empty slot shows only the file label, no placeholder text' do
+  # Confirmed against genuine RPG_RT under wine: each slot is its own box
+  # (file label / leader name / level+HP), and an empty one draws only the
+  # label line -- no "No Data" text at all, unlike this screen's old
+  # single-list-window layout.
   scene, = save_load_scene(:load)
-  texts = window_texts(scene.instance_variable_get(:@list_window))
-  ok texts.include?('File 01'), 'slot 1 is labelled, zero-padded'
-  ok texts.include?('-- No Data --'), 'and shown as empty'
+  texts = window_texts(scene.instance_variable_get(:@slot_windows)[0])
+  ok texts.include?('File 1'), 'slot 1 is labelled with a plain, non-zero-padded number'
+  ok !texts.any? { |t| t.include?('No Data') }, 'no placeholder text for an empty slot'
 end
 
-check 'Scene::SaveLoad: an occupied slot shows the leader, level, HP and gold' do
+check 'Scene::SaveLoad: an occupied slot shows the leader, level and HP -- no gold or map' do
   st = menu_state
   st.party.leader = st.party.actors.first # Hero, Lv5, 80/120 HP (MenuStubActor)
   st.party.instance_variable_set(:@gold, 250)
   parent = fake_parent(fake_db)
   parent.save_states[1] = st
   scene, = save_load_scene(:load, nil, fake_db, parent: parent)
-  texts = window_texts(scene.instance_variable_get(:@list_window))
-  ok texts.any? { |t| t.include?('Hero') && t.include?('Lv5') }, 'name and level on the first line'
-  ok texts.any? { |t| t.include?('HP 80/120') && t.include?('250G') },
-     'current/max HP and gold on the second line'
+  texts = window_texts(scene.instance_variable_get(:@slot_windows)[0])
+  ok texts.include?('Hero'), 'the leader name gets its own line'
+  ok texts.any? { |t| t.include?('Lv5') && t.include?('HP80') },
+     'level and current HP together on the third line'
+  ok !texts.any? { |t| t.include?('250G') }, 'no gold shown -- confirmed absent from the ' \
+                                              'reference capture, unlike this screen\'s old layout'
 end
 
 check 'Scene::SaveLoad :save mode: confirming a slot saves through the parent, shows a ' \


### PR DESCRIPTION
## Summary

Continuing the wine-based field-menu survey (closes a layout question left open by #681).

- Verified under wine against genuine `RPG_RT.exe`: its save-file-select screen draws **one bordered box per slot** (file label, leader name, level+HP) — no gold, no current map, no `/max` on the HP figure, a compact pill-shaped cursor around just the "File N" label rather than a full-row highlight, and exactly 3 of 15 slots visible on screen at once. An empty slot draws only its label line, no "No Data" text at all.
- `Scene::SaveLoad` used to pack more into one shared list window: zero-padded "File 01", gold and the current map name, current/max HP, "-- No Data --" placeholders, and 6 slots without scrolling.
- `Scene::SaveLoad` now builds `VISIBLE_SLOTS` (3, derived from `(SCREEN_H - HEADER_H) / SLOT_BOX_H`) separate per-slot windows instead of one list window, drops the gold/map/max-HP fields and the zero-padding, and sizes each slot's cursor to its own label text via `Bitmap#text_size`. Verified against the same reference frame field-for-field: the header state (File 1 selected, occupied) and after pressing Down onto the empty File 2 slot both match.
- `scripts/rpg2k_scene_check.rb`'s two affected checks (the "No Data" placeholder and the occupied-slot fields) are rewritten against the new per-slot `@slot_windows` array and the confirmed fields.
- Left open in `docs/TODO.md`: the scroll indicator for more than one screenful of slots (the reference capture never scrolled, so there's no confirmed glyph/position for it yet), and a separate, unrelated finding from this iteration's Skill-screen grid investigation — three attempts to get a populated skill list under wine each showed only one qualifying skill, suggesting genuine RPG_RT's field-skill eligibility is narrower than this engine's own heuristic in some way not yet pinned down.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 478 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 763 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed
- [x] Rebuilt the native engine and verified under wine against genuine `RPG_RT.exe` reference frames: the save screen's layout, cursor style, and empty-slot rendering now match field-for-field

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_