### PR TITLE
rpg2k: a map-triggered Show Battle Animation now flashes its target vehicle too

### DIFF
--- a/changelog.d/battle-animation-vehicle-target-flash.fixed.md
+++ b/changelog.d/battle-animation-vehicle-target-flash.fixed.md
@@ -1,0 +1,22 @@
+- A map-triggered Show Battle Animation's flash_scope-1 ("target") timing
+  aimed at a vehicle (a Move-Event-style target id 10002-10004) now actually
+  pulses that vehicle's own on-screen sprite, instead of being silently
+  dropped as an unsupported target. Verified against EasyRPG Player's actual
+  C++ source: `Game_Character::GetCharacter` (`src/game_character.cpp`)
+  resolves `CharBoat`/`CharShip`/`CharAirship` straight to the live
+  `Game_Vehicle` object — a `Game_Character` subclass, same as the player or
+  a map event — so `BattleAnimationMap::FlashTargets`'s `target->Flash(...)`
+  call (`src/battle_animation.cpp`) reaches a vehicle exactly like it reaches
+  any other character. `Scene::Map#map_animation_flash_target`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) now resolves a vehicle target to its
+  own `Game::Vehicle::TYPES` symbol instead of `nil`, and
+  `#fire_map_target_flash`/`#clear_map_target_flash` pulse
+  `@vehicle_sprites[type]` directly with the native RGSS `Sprite#flash`
+  primitive `#fire_target_flash` already uses for a battle enemy sprite — a
+  vehicle already draws through a real `Sprite`, so it needs no CharSet-tint
+  mechanism the way the player/map-event case does. A new
+  `#update_vehicle_flashes`, called every real frame from `#update`,
+  decays it the same way `#update_enemy_flashes` already does for battle
+  enemy sprites — without it, a vehicle's flash would have stayed at full
+  intensity forever once armed, since nothing ever called `Sprite#update` on
+  a vehicle sprite before this fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5814,7 +5814,59 @@ not yet verified:
   animation arms that event's own flash and never the player's;
   `#map_animation_flash_target`'s own vehicle / unknown-id / "this event"
   decoding), confirmed to fail against the pre-fix code (two `RuntimeError`s
-  and a `NoMethodError`) before the fix.
+  and a `NoMethodError`) before the fix. ✅ **The vehicle exception this same
+  fix carved out is now closed too — it was a real, reachable gap, not a
+  case real RPG_RT exempts.** Verified against EasyRPG Player's actual C++
+  source rather than assumed unsupported: `Game_Character::GetCharacter`
+  (`src/game_character.cpp`) resolves `CharBoat`/`CharShip`/`CharAirship`
+  straight to the live `Game_Vehicle` object — a `Game_Character` subclass,
+  same as the player or a map event — so `BattleAnimationMap::FlashTargets`'s
+  `target->Flash(r, g, b, p, 0)` call (`src/battle_animation.cpp`) reaches a
+  vehicle exactly like it reaches any other character; nothing in the
+  original engine exempts it. This build's own `#map_animation_flash_target`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) returned a bare `nil` for
+  `MOVE_TARGET_BOAT`/`SHIP`/`AIRSHIP`, reasoning that a vehicle has no
+  CharSet-tone flash mechanism to hook the way `@player_flash`/an `@events`
+  entry's `[:flash]` do — true of that *specific* mechanism, but not the
+  same as "cannot flash at all": a vehicle already draws through a real
+  `Sprite` (`@vehicle_sprites[type]`, built and drawn every frame by
+  `#draw_vehicles`), so it can be flashed directly with the native RGSS
+  `Sprite#flash` primitive `#fire_target_flash` already uses for a battle
+  enemy sprite, no CharSet tint needed. Fixed by having
+  `#map_animation_flash_target` return the target's own `Game::Vehicle::TYPES`
+  symbol (`:boat`/`:ship`/`:airship`, via the same
+  `Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT]` idiom
+  `#animation_target_pixel` already uses to place the animation itself)
+  instead of `nil`, and by giving `#fire_map_target_flash`/
+  `#clear_map_target_flash` a vehicle branch that calls
+  `@vehicle_sprites[type].flash(color, ANIM_FLASH_FRAMES)` /
+  `.flash(nil, 0)` directly, mirroring `#fire_target_flash`/
+  `#clear_target_flash`'s own enemy-sprite idiom exactly rather than
+  extending the CharSet-tint mechanism. A second, previously-invisible gap
+  surfaced once a vehicle could be armed this way: the real native
+  `Sprite#flash` primitive only decays (and its rendered intensity only
+  fades) when driven by an explicit `#update` every frame
+  (`mruby-rgss/src/lib.cxx`'s `spr_flash`/`spr_update`) — the exact contract
+  `#update_enemy_flashes` already exists to drive for the battle-only enemy
+  sprites — and nothing anywhere in this codebase ever called `#update` on a
+  vehicle sprite at all, so a vehicle's flash would have stayed at full
+  intensity forever in the real renderer once armed. Fixed with a new
+  `#update_vehicle_flashes`, the map-side counterpart of
+  `#update_enemy_flashes`, called unconditionally every real frame from
+  `#update` (not gated on `@battle_ui`, since a vehicle can be flashed by a
+  map-triggered Show Battle Animation with no fight running at all).
+  Covered by three new `scripts/rpg2k_scene_check.rb` checks (`
+  #map_animation_flash_target` resolving a vehicle target to its own
+  `Game::Vehicle::TYPES` symbol rather than `nil` — updating the pre-existing
+  check that had pinned the old, now-wrong `nil` behaviour;
+  `#fire_map_target_flash`/`#update_vehicle_flashes` arming and then decaying
+  a targeted vehicle sprite's flash directly, leaving a bystander vehicle
+  untouched; the same timing driven through the full event/animation
+  pipeline, confirming the two pieces are actually wired together), all
+  three confirmed to fail against the pre-fix code before the fix (`nil`
+  where `:boat` was expected, a `NoMethodError` from the old
+  Hash-`[]=`-on-a-Symbol dispatch, and the full-pipeline sprite never being
+  flashed at all).
 - ✅ **A Timer with "valid during battle" checked force-ends the battle**
   the instant it reaches 0:00, regardless of encounter source (default or
   scripted) — an easy accidental trap if the same Timer is reused for a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -287,6 +287,7 @@ class RPG2k
         @state.screen.update # screen tint progresses every frame, even in events
         @state.update_pictures # picture moves progress every frame too
         update_sprite_flashes # Flash Sprite decays during events too
+        update_vehicle_flashes # a vehicle's own map-triggered animation flash decays too
         step_ownerless_map_animation # a fire-and-forget Show Battle Animation plays on, unattended
         update_closing_windows # a closed message keeps shrinking in the background
         watch_bgm_loop # so the "BGM played once" branch can be answered
@@ -2737,6 +2738,19 @@ class RPG2k
         return nil if flash.nil?
         flash[:frames] -= 1
         flash[:frames] > 0 ? flash : nil
+      end
+
+      # Decay any in-flight #fire_map_target_flash pulse on a vehicle sprite by
+      # one frame -- the same "native Sprite#flash only decays when driven by an
+      # explicit #update each frame" contract #update_enemy_flashes already
+      # drives for the battle-only enemy sprites (mruby-rgss/src/lib.cxx's
+      # spr_flash/spr_update). Called unconditionally every real frame from
+      # #update, not gated on @battle_ui, since a vehicle can be flashed by a
+      # map-triggered Show Battle Animation with no fight running at all. A
+      # sprite with no flash in flight costs nothing here (native #update
+      # no-ops).
+      def update_vehicle_flashes
+        (@vehicle_sprites || {}).each_value { |s| s.update if s }
       end
 
       # The RGSS tone that paints `flash` over a CharSet frame: the flash colour
@@ -6492,12 +6506,18 @@ class RPG2k
       # The map-triggered half: drop @player_flash / an @events entry's own
       # [:flash] back to nil, the same "no flash in flight" state #tick_flash's
       # own decay already leaves behind, mirroring #fire_map_target_flash's own
-      # arm call. A nil target (a vehicle, or an id no live event matches --
-      # see #map_animation_flash_target) is a no-op, since there is nothing to
+      # arm call. A vehicle target clears the native RGSS flash
+      # #fire_map_target_flash armed on `@vehicle_sprites[type]` directly,
+      # mirroring #clear_target_flash's own `spr.flash(nil, 0)` idiom for an
+      # enemy sprite. A nil target (an id no live event matches -- see
+      # #map_animation_flash_target) is a no-op, since there is nothing to
       # clear.
       def clear_map_target_flash(target)
         return if target.nil?
-        if target == :player
+        if Game::Vehicle::TYPES.include?(target)
+          spr = @vehicle_sprites && @vehicle_sprites[target]
+          spr.flash(nil, 0) if spr
+        elsif target == :player
           @last_frame = nil if @player_flash
           @player_flash = nil
         else
@@ -6559,19 +6579,21 @@ class RPG2k
 
       # The character a map-triggered flash_scope-1 timing (see
       # #fire_map_target_flash) should pulse: `:player`, a specific `@events`
-      # entry (this event / a named map event id), or nil when the target has
-      # no CharSet-tone flash mechanism to hook (a vehicle -- #draw_vehicles
-      # has no counterpart to #flash_tone -- or an id no live event matches).
-      # Mirrors #animation_target_pixel's own target-id decoding exactly,
-      # including its "this event" -> player fallback when there is no active
-      # event (a common event Parallel Process's own Show Battle Animation).
+      # entry (this event / a named map event id), a `Game::Vehicle::TYPES`
+      # symbol (`:boat`/`:ship`/`:airship`) for a vehicle slot, or nil when
+      # the target id names nothing (a stale/invalid event id no live event
+      # matches). Mirrors #animation_target_pixel's own target-id decoding
+      # exactly, including its "this event" -> player fallback when there is
+      # no active event (a common event Parallel Process's own Show Battle
+      # Animation) and its `Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT]`
+      # idiom for a vehicle slot.
       def map_animation_flash_target(target)
         case target
         when MOVE_TARGET_PLAYER then :player
         when 0, MOVE_TARGET_THIS
           @active_event || :player
         when MOVE_TARGET_BOAT, MOVE_TARGET_SHIP, MOVE_TARGET_AIRSHIP
-          nil
+          Game::Vehicle::TYPES[target - MOVE_TARGET_BOAT]
         else
           @events.find { |e| e[:id] == target }
         end
@@ -6707,19 +6729,39 @@ class RPG2k
       # timing on a Show Battle Animation (11210) played over a map character
       # now actually pulses that character, instead of being silently dropped
       # (#fire_animation_flashes only ever reached #fire_target_flash's
-      # battle-only enemy-sprite mechanism before this). There is no separate
-      # "battle animation flash" primitive for a map character -- the Flash
-      # Sprite command (11320) already tones one, via the very same decaying
+      # battle-only enemy-sprite mechanism before this). A player/map-event
+      # target reuses the Flash Sprite command's (11320) own CharSet-tone
+      # mechanism, via the very same decaying
       # {red:, green:, blue:, power:, frames:, total:} hash #apply_sprite_flash
       # builds and #flash_tone/#update_sprite_flashes already drive every frame
-      # (see the "Flash Sprite" section above), so this reuses that mechanism
-      # rather than inventing a second one: `target` (from
+      # (see the "Flash Sprite" section above): `target` (from
       # #map_animation_flash_target) is either `:player` (-> @player_flash) or
-      # an `@events` entry (-> its `[:flash]`), nil when the animated target
-      # has no such sprite (a vehicle, or an unresolved event id) -- a silent
-      # no-op, matching #fire_target_flash's own missing-sprite case.
+      # an `@events` entry (-> its `[:flash]`). A vehicle target (one of
+      # `Game::Vehicle::TYPES`) instead pulses `@vehicle_sprites[type]`
+      # directly with the native RGSS `Sprite#flash` primitive #fire_target_flash
+      # already uses for an enemy sprite -- unlike the player/event case, a
+      # vehicle already draws through a real `Sprite` (#draw_vehicles), so it
+      # needs no CharSet-tint mechanism of its own. Verified against EasyRPG
+      # Player's actual C++ source rather than assumed unsupported:
+      # `Game_Character::GetCharacter` (src/game_character.cpp) resolves
+      # CharBoat/CharShip/CharAirship straight to the live `Game_Vehicle`
+      # object -- a `Game_Character` subclass -- so `BattleAnimationMap::
+      # FlashTargets`'s `target->Flash(...)` call (src/battle_animation.cpp)
+      # reaches a vehicle exactly like it reaches the player or a map event;
+      # nothing in real RPG_RT exempts it. nil (an unresolved event id) is a
+      # silent no-op either way, matching #fire_target_flash's own
+      # missing-sprite case.
       def fire_map_target_flash(target, t)
         return if target.nil?
+        if Game::Vehicle::TYPES.include?(target)
+          spr = @vehicle_sprites && @vehicle_sprites[target]
+          if spr
+            spr.flash(Color.new((t.flash_red || 0) * 8, (t.flash_green || 0) * 8,
+                                 (t.flash_blue || 0) * 8, (t.flash_power || 0) * 8),
+                      ANIM_FLASH_FRAMES)
+          end
+          return
+        end
         flash = { red: (t.flash_red || 0) * 8, green: (t.flash_green || 0) * 8,
                   blue: (t.flash_blue || 0) * 8, power: (t.flash_power || 0) * 8,
                   frames: ANIM_FLASH_FRAMES, total: ANIM_FLASH_FRAMES }

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6136,19 +6136,24 @@ check "a map-triggered Show Battle Animation's target-scope flash pulses the nam
 end
 
 # #map_animation_flash_target's own target-id decoding, isolated from the
-# full event pipeline above: a vehicle has no Flash Sprite-style CharSet tone
-# to hook (unlike a player/event target), an id no live event matches resolves
-# to nothing, and "this event" (0 / MOVE_TARGET_THIS) mirrors
-# #animation_target_pixel's own fallback to the player when there is no active
-# event (a common event Parallel Process's own Show Battle Animation has none).
+# full event pipeline above: a vehicle resolves to its own Game::Vehicle::TYPES
+# symbol (see #fire_map_target_flash / #clear_map_target_flash below -- this
+# used to be a bare nil, "a vehicle has no CharSet-tone flash mechanism to
+# hook," which was true of the player/event mechanism specifically but wrongly
+# treated as "no mechanism at all": a vehicle already draws through a real
+# Sprite, which #fire_map_target_flash now pulses directly instead), an id no
+# live event matches resolves to nothing, and "this event" (0 / MOVE_TARGET_THIS)
+# mirrors #animation_target_pixel's own fallback to the player when there is no
+# active event (a common event Parallel Process's own Show Battle Animation has
+# none).
 check '#map_animation_flash_target resolves vehicle, unknown-id and "this event" targets' do
   scene = new_scene({ 3 => event(1, 1, page) })
   mt = RPG2k::Scene::Map
   eq :player, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_PLAYER)
-  eq nil, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_BOAT),
-     'a vehicle has no CharSet-tone flash mechanism to hook'
-  eq nil, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_SHIP)
-  eq nil, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_AIRSHIP)
+  eq :boat, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_BOAT),
+     "a vehicle target resolves to its own Game::Vehicle::TYPES symbol, not nil"
+  eq :ship, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_SHIP)
+  eq :airship, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_AIRSHIP)
   eq nil, scene.send(:map_animation_flash_target, 999), 'an id no live event matches'
   eq :player, scene.send(:map_animation_flash_target, 0),
      '"this event" with no active event (a common event Parallel Process) falls back to the player'
@@ -6156,6 +6161,78 @@ check '#map_animation_flash_target resolves vehicle, unknown-id and "this event"
   scene.instance_variable_set(:@active_event, ev3)
   eq ev3, scene.send(:map_animation_flash_target, mt::MOVE_TARGET_THIS),
      '"this event" with an active event resolves to it'
+end
+
+# A map-triggered Show Battle Animation's flash_scope-1 timing aimed at a
+# vehicle now actually pulses that vehicle's own on-screen sprite, instead of
+# being silently dropped as an "unsupported target." Verified against EasyRPG
+# Player's actual C++ source rather than assumed unsupported:
+# Game_Character::GetCharacter (src/game_character.cpp) resolves
+# CharBoat/CharShip/CharAirship straight to the live Game_Vehicle object -- a
+# Game_Character subclass -- so BattleAnimationMap::FlashTargets's own
+# target->Flash(...) call (src/battle_animation.cpp) reaches a vehicle exactly
+# like it reaches the player or a map event; nothing in real RPG_RT exempts
+# it. Unlike the player/event case (a CharSet tint mixed into the drawn
+# frame), a vehicle already draws through a real Sprite (#draw_vehicles), so
+# #fire_map_target_flash reaches @vehicle_sprites[:boat] directly with the
+# native RGSS Sprite#flash primitive #fire_target_flash already uses for a
+# battle enemy sprite -- exercised directly here (mirroring the battle-side
+# "a target-scope animation flash pulses the hit enemy" check above), isolated
+# from the full animation/event pipeline the player/event checks above cover.
+check '#fire_map_target_flash/#update_vehicle_flashes pulse a targeted vehicle sprite and decay it' do
+  scene = new_scene({})
+  sprites = scene.instance_variable_get(:@vehicle_sprites)
+  spr = sprites[:boat]
+  bystander = sprites[:ship]
+  timing = OpenStruct.new(flash_red: 31, flash_green: 0, flash_blue: 0, flash_power: 20)
+  scene.send(:fire_map_target_flash, :boat, timing)
+  ok spr.flash_color, 'the targeted vehicle sprite was flashed'
+  eq [248, 0, 0, 160],
+     [spr.flash_color.red, spr.flash_color.green, spr.flash_color.blue, spr.flash_color.alpha],
+     'scaled from the LCF 0..31 fixture fields the same *8 way the player/enemy flash already is'
+  anim_flash_frames = RPG2k::Scene::Map::ANIM_FLASH_FRAMES
+  eq anim_flash_frames, spr.flash_calls.last[1],
+     'held for the same duration a battle-side target flash gets'
+  eq nil, bystander.flash_color, 'a different, untargeted vehicle is untouched'
+  # Before this fix nothing ever called Sprite#update on a vehicle sprite at
+  # all -- the real native Sprite#flash only decays (and its visible
+  # intensity only fades) when driven by an explicit #update each frame
+  # (mruby-rgss/src/lib.cxx's spr_flash/spr_update, the same contract
+  # #update_enemy_flashes already drives for battle-only enemy sprites), so a
+  # vehicle's flash would have stayed at full intensity forever in the real
+  # renderer. #update_vehicle_flashes closes that gap, called unconditionally
+  # every real frame from #update.
+  anim_flash_frames.times { scene.send(:update_vehicle_flashes) }
+  eq nil, spr.flash_color, 'the flash faded out after its duration'
+end
+
+# The same timing, driven through the full event/animation pipeline this time
+# (mirroring "a map-triggered Show Battle Animation's target-scope flash
+# pulses the player" above), confirming #map_animation_flash_target's new
+# vehicle resolution and #fire_map_target_flash's new vehicle dispatch are
+# actually wired together end to end, not just individually correct.
+check "a map-triggered Show Battle Animation's target-scope flash pulses a targeted vehicle" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [9, 10002, 1], indent: 0), # animation, boat, wait
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.vehicle(:boat).map_id = st.map_id
+  st.vehicle(:boat).x = 5
+  st.vehicle(:boat).y = 7
+  spr = scene.instance_variable_get(:@vehicle_sprites)[:boat]
+  seen = false
+  40.times do
+    scene.update
+    seen ||= (spr.flash_color && spr.flash_color.red == 248 && spr.flash_color.green == 0 &&
+              spr.flash_color.blue == 0)
+    break if st.switches[6]
+  end
+  ok seen, "the boat's own sprite was flashed via the full event pipeline"
+  ok st.switches[6], 'the event resumed after the animation'
 end
 
 # yado.tk: only one Battle Animation is ever on screen at once -- true of the


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "map-triggered Show Battle Animation's flash_scope-1 timing now flashes its target too" bullet explicitly left a vehicle target unaddressed, reasoning that "a vehicle has no CharSet-tone flash mechanism to hook... so a vehicle target stays a silent no-op." Verified against EasyRPG Player's actual C++ source and found wrong: `Game_Character::GetCharacter` resolves `CharBoat`/`CharShip`/`CharAirship` straight to the live `Game_Vehicle` object — a `Game_Character` subclass — so `BattleAnimationMap::FlashTargets`'s `target->Flash(...)` reaches a vehicle exactly like it reaches the player or a map event.
- `Scene::Map#map_animation_flash_target` returned `nil` for a vehicle target id (10002-10004), so `#fire_map_target_flash` no-opped. A vehicle already draws through a real RGSS `Sprite` (`@vehicle_sprites[type]`) — the same kind of object battle enemy sprites are — so it needed no CharSet-tint mechanism at all; it just needed to be wired to the native `Sprite#flash` primitive already used for enemy sprites.
- `#map_animation_flash_target` now resolves a vehicle target to its own `Game::Vehicle::TYPES` symbol; `#fire_map_target_flash`/`#clear_map_target_flash` gained a vehicle branch calling `@vehicle_sprites[type].flash`/`.flash(nil, 0)` directly, mirroring the enemy-sprite idiom.
- A second, previously-invisible gap surfaced: the native `Sprite#flash` primitive only decays when driven by an explicit `#update` each frame, and nothing ever called `#update` on a vehicle sprite. Added `#update_vehicle_flashes` (mirroring `#update_enemy_flashes`), called unconditionally every frame — without it a vehicle's flash would stay at full intensity forever once armed.
- `docs/TODO.md` updated ✅ with the citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 764 checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — 480 checks pass (updated a pre-existing check that had pinned the old, now-wrong `nil` result, plus 2 new: a direct unit-style check arming/decaying a targeted vehicle sprite while confirming a bystander vehicle is untouched, and a full event/animation-pipeline check confirming the two pieces are wired together — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_