### PR TITLE
rpg2k: a null Move Route jump now still forces last_move_direction to Down

### DIFF
--- a/changelog.d/jump-in-place-last-move-direction.fixed.md
+++ b/changelog.d/jump-in-place-last-move-direction.fixed.md
@@ -1,0 +1,14 @@
+- **A Move Route jump landing where it started now still turns the character
+  to face Down internally.** `Character#jump` computes a jump's dominant-axis
+  landing direction and, before this fix, only assigned it to
+  `#last_move_direction` (the direction a later Move Forward continues in)
+  when the jump actually moved somewhere — a net-zero "hop in place" block
+  (e.g. Move Right then Move Left inside one Begin/End Jump, a common idiom)
+  left it at whatever direction was recorded before the jump instead.
+  EasyRPG Player's `Game_Character::Jump` (`src/game_character.cpp`) computes
+  and applies that direction unconditionally, including for a same-tile jump,
+  whose dominant-axis tie always resolves to Down; only the *visible* facing
+  is gated behind the jump having actually moved. A Move Forward issued right
+  after an in-place jump now correctly walks Down, matching real RPG_RT,
+  instead of continuing in whatever direction was last recorded before the
+  jump.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3932,7 +3932,38 @@ not yet verified:
 - Jump needs paired Begin/End; movement commands between them sum into a
   net displacement vector (opposite-axis moves cancel); only the *landing*
   tile's passability is tested, tiles crossed are ignored; speed/direction
-  can't change mid-jump.
+  can't change mid-jump. ✅ **A jump landing where it started (net-zero
+  displacement) now still forces `#last_move_direction` to Down, verified
+  against EasyRPG Player's actual C++ source rather than guessed at.**
+  `Game_Character::Jump` (`src/game_character.cpp`) computes the jump's
+  dominant-axis direction and calls `SetDirection` — this codebase's
+  `Character#last_move_direction`, the field `Move Forward` reads
+  (`Game::MoveRoute#execute`'s `MOVE_FORWARD` case, `mruby-rpg2k/mrblib/
+  game.rb`) — **unconditionally**, before ever checking whether the jump
+  actually moved anywhere; only the *visible* facing (`SetFacing`, this
+  codebase's `Character#face`) is gated behind `dx != 0 || dy != 0` (and,
+  inside that, `IsFacingLocked`). A same-tile jump's own dominant-axis tie
+  (`dy.abs() >= dx.abs()` when both are 0, `dy >= 0` when `dy` is 0) always
+  resolves to Down, so `SetDirection` silently turns the character to face
+  south internally even though nothing is drawn differently.
+  `Character#jump` (`mruby-rpg2k/mrblib/game.rb`) had the opposite bug: it
+  wrapped *both* `@last_move_direction` and the `#face` call in the same
+  `unless dx == 0 && dy == 0` guard, so a null jump (e.g. a Begin Jump /
+  Move Right / Move Left / End Jump "hop in place" block, a common idiom)
+  left `#last_move_direction` at whatever it was before the jump, and a
+  later Move Forward continued in that stale direction instead of Down —
+  contradicting this codebase's own prior comment on the method ("a jump
+  that ends where it started leaves both the facing and
+  `#last_move_direction` alone"), which turned out not to match the real
+  engine. Fixed by always computing and assigning `@last_move_direction`
+  from the dominant-axis formula, and keeping only the `#face` call (the
+  visible sprite turn, which already respects `#facing_locked`/
+  `#fixed_facing` internally) behind the displacement guard. Covered by a
+  new `scripts/rpg2k_logic_check.rb` check (a character facing/last-moved
+  Left jumps in place, ends up with `last_move_direction` forced to Down
+  while its visible `direction` stays Left, and a follow-up Move Forward
+  walks Down rather than the stale pre-jump direction), confirmed to fail
+  against the pre-fix code before the fix.
 - A move-route "Change Graphic" sub-command (hero, event, or vehicle) is
   **not persistent** — it reverts to the base graphic on save-load or map
   transfer, unlike the dedicated Change Graphic event commands. ✅ **All three

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4020,17 +4020,24 @@ module Game
     #
     # RPG_RT faces the jump's **dominant axis**, vertical winning a tie, which is
     # not the direction of the last enclosed move: a jump two right and two down
-    # lands facing down. A jump that ends where it started leaves both the
-    # facing and #last_move_direction alone -- there is no axis to be
-    # dominant when neither one moved.
+    # lands facing down. #last_move_direction always picks up that same
+    # dominant-axis direction, even for a jump that ends where it started --
+    # verified against EasyRPG Player's actual C++ source rather than guessed
+    # at: `Game_Character::Jump` (`src/game_character.cpp`) computes and
+    # applies `SetDirection` (this codebase's #last_move_direction, what Move
+    # Forward reads) unconditionally, before ever checking `dx != 0 || dy !=
+    # 0` -- a null jump's tie (`dy.abs() >= dx.abs()` when both are 0, `dy >=
+    # 0` when dy is 0) always resolves to Down. Only the *visible* facing
+    # (`SetFacing`, this codebase's #face) is gated behind that displacement
+    # check (and, inside it, `IsFacingLocked`, which #face already respects) --
+    # so a jump going nowhere still silently turns a character to face south
+    # internally, it just never shows on screen.
     def jump(x, y)
       dx = x - @x
       dy = y - @y
-      unless dx == 0 && dy == 0
-        dir = dy.abs >= dx.abs ? (dy >= 0 ? 2 : 8) : (dx >= 0 ? 6 : 4)
-        face(dir)
-        @last_move_direction = dir
-      end
+      dir = dy.abs >= dx.abs ? (dy >= 0 ? 2 : 8) : (dx >= 0 ? 6 : 4)
+      @last_move_direction = dir
+      face(dir) unless dx == 0 && dy == 0
       @x = x
       @y = y
       @jumped = true

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -299,7 +299,26 @@ check 'a jump that lands where it started still counts as a jump' do
         repeat: false).step(c, FakeWorld.new)
   eq [3, 3], [c.x, c.y], 'back where it started'
   eq true, c.jumped
-  eq 8, c.direction, 'and a jump going nowhere leaves the facing alone'
+  eq 8, c.direction, 'and a jump going nowhere leaves the visible facing alone'
+end
+
+check 'a jump that lands where it started still updates last_move_direction to Down' do
+  # Verified against EasyRPG Player's actual C++ source: Game_Character::Jump
+  # (src/game_character.cpp) calls SetDirection unconditionally -- even for a
+  # net-zero (dx == 0 && dy == 0) jump, whose dominant-axis tie-break always
+  # resolves to Down -- and only gates the *visible* facing (SetFacing) behind
+  # `dx != 0 || dy != 0`. A later Move Forward continues Down, regardless of
+  # the direction last recorded before the null jump and regardless of the
+  # (unaffected) displayed facing.
+  c = Game::Character.new(3, 3, 4) # facing/last-moved left
+  route = R.new([mc(R::BEGIN_JUMP), mc(R::MOVE_RIGHT), mc(R::MOVE_LEFT), mc(R::END_JUMP),
+                 mc(R::MOVE_FORWARD)], repeat: false)
+  route.step(c, FakeWorld.new)
+  eq [3, 3], [c.x, c.y], 'back where it started'
+  eq 2, c.last_move_direction, 'a null jump still forces last_move_direction to Down'
+  eq 4, c.direction, 'the visible facing is untouched by the null jump itself'
+  eq :moved, route.step(c, FakeWorld.new)
+  eq [3, 4], [c.x, c.y], 'Move Forward continues Down, not the stale pre-jump direction'
 end
 
 check 'placing a character outright is not a jump' do


### PR DESCRIPTION
## Summary

- Fixes `Character#jump` (`mruby-rpg2k/mrblib/game.rb`) so a Move Route jump that lands where it started (a net-zero "hop in place" Begin Jump / Move Right / Move Left / End Jump block, a common idiom) still forces `#last_move_direction` — the field a later `Move Forward` sub-command reads — to Down, instead of leaving it at whatever direction was recorded before the jump.
- Verified against EasyRPG Player's actual C++ source: `Game_Character::Jump` (`src/game_character.cpp`) computes the jump's dominant-axis direction and calls `SetDirection` (this codebase's `#last_move_direction`) **unconditionally**, before ever checking whether the jump actually moved anywhere — a same-tile jump's dominant-axis tie (`dy.abs() >= dx.abs()` when both are 0, `dy >= 0` when `dy` is 0) always resolves to Down. Only the *visible* facing (`SetFacing`, this codebase's `#face`) is gated behind `dx != 0 || dy != 0`.
- This codebase's own prior code comment on `#jump` claimed the opposite ("a jump that ends where it started leaves both the facing and `#last_move_direction` alone"), which didn't hold up against the real engine's source — corrected.
- Updates `docs/TODO.md`'s existing "Jump needs paired Begin/End..." bullet under the yado.tk "Full-site sweep" backlog with a ✅ entry citing the exact mechanism, and adds a changelog fragment.

## Test plan

- Added a new `scripts/rpg2k_logic_check.rb` check: a character facing/last-moved Left jumps in place, ends up with `last_move_direction` forced to Down while its visible `direction` stays Left, and a follow-up Move Forward walks Down rather than the stale pre-jump direction. Confirmed to **fail** against the pre-fix code (`RuntimeError: expected 2, got 4`) via `git stash` of just `mruby-rpg2k/mrblib/game.rb`, and to **pass** with the fix.
- Ran all five CI scripts:
  - `ruby scripts/rpg2k_logic_check.rb` — 763 checks passed
  - `ruby scripts/rpg2k_scene_check.rb` — 478 checks passed
  - `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
  - `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped (sandbox network restrictions block test-bed download; confirmed via a manual `download-nepheshel.bash` attempt, which hit `Proxy tunneling failed: Forbidden`)
  - `ruby scripts/rpg2k_command_soak.rb` — skipped (same reason, no test-bed data under `./data`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7iLH31db2SPgE2QbJ3Pn9)_