### PR TITLE
docs: record that swapping the Equip test save's actor hangs RPG_RT

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2317,6 +2317,22 @@ The work below is roughly ordered by the critical path to a walkable game
   also nudged something else along the way). Needs a second, independently
   reproduced RPG_RT capture of the same actor's Equip screen before acting
   on it either way.
+  **Attempted and abandoned:** getting that second data point turned out not
+  to be safe with the one save this whole survey has been driving both
+  engines from. Editing the save's party-roster field (chunk 109 field 1)
+  to swap in a different, better-equipped actor (ディーヴァ, id 4, level 8,
+  real weapon/armour) in place of デモ用 -- the same targeted-edit technique
+  that worked cleanly for the item bag and skill list elsewhere in this
+  survey -- reliably made genuine `RPG_RT.exe` hang on a black screen right
+  after Continue, on more than one fresh wine launch, rather than opening
+  the map. Reverting the roster edit (back to `[15]`, デモ用 alone) restored
+  the save to its known-good state, confirmed both by this engine loading
+  it cleanly and by a subsequent successful Continue under wine -- so the
+  save itself was not left corrupted, but the specific "just try a
+  different actor" approach is off the table: whatever Nepheshel's save
+  logic expects at this exact story point, it is not merely a valid actor
+  id to resolve, and finding out what would take more than this survey's
+  established edit-and-diff technique. Left for whoever picks this up next.
   ✅ **Continue could silently lose a save's own Save/Teleport/Escape access,
   overridden by whatever the current map's tree happens to say instead.**
   Chasing the Save screen with the fixed crop-region retry (above) turned up


### PR DESCRIPTION
## Summary

Docs-only follow-up to the still-open Equip stat-number discrepancy note (from #679).

- Getting a second actor's data point to tell "RPG_RT applies some modifier this engine doesn't" apart from "the capture was mid-cascade from the flaky retry queue" needed a different, better-equipped party member on the one save this survey drives both engines from.
- Editing the save's party-roster field (chunk 109 field 1) to swap in ディーヴァ (id 4, level 8, real weapon/armour) in place of デモ用 — the same targeted-edit technique that worked cleanly for the item bag and skill list elsewhere in this survey — reliably hung genuine `RPG_RT.exe` on a black screen right after Continue, on more than one fresh wine launch.
- Reverting the roster edit back to `[15]` restored the save to its known-good state, confirmed by both this engine loading it cleanly and a subsequent successful wine Continue — no lasting corruption, but "just try a different actor" is off the table for whatever this exact story point expects.
- No code changes; recording the attempt so the next person doesn't repeat it blind. Same shape as #675, which corrected an earlier over-strong claim in these notes.

## Test plan

N/A — documentation only, no code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_