### PR TITLE
rpg2k: a state flagged Cursed now locks equipment too

### DIFF
--- a/changelog.d/state-cursed-locks-equipment.fixed.md
+++ b/changelog.d/state-cursed-locks-equipment.fixed.md
@@ -1,0 +1,19 @@
+- **A state flagged "cursed" (RPG2003) now locks equipment changes for as
+  long as it is inflicted, matching real RPG_RT.** The `situation` (state)
+  table's `cursed` field (LCF field 38) was already parsed by
+  `mruby-lcf/mrblib/schema.rb` but read nowhere in `mruby-rpg2k`, so a status
+  built for exactly this purpose left the field equip menu fully usable.
+  Verified against EasyRPG Player's actual C++ source: `Game_Actor::
+  IsEquipmentFixed(check_states)` is `data.lock_equipment || (check_states &&
+  any inflicted state's own cursed flag)`, and its equip-menu caller —
+  refusing to even open a slot's item list, rather than opening it and
+  rejecting a choice — always passes `check_states: true`. `Game::Actor
+  #equipment_fixed?` now also consults a new `#state_cursed?` (scanning the
+  actor's currently-inflicted states for the flag) alongside the actor/class
+  row's own `equipment_fixed` trait it already read. Distinct from the
+  neighbouring `#slot_cursed?` (a property of the *item* worn in a slot): a
+  cursed state locks every slot regardless of what is equipped and unlocks
+  the instant it lifts, while a cursed *item* keeps locking its own slot even
+  after such a state clears. RPG_RT's Change Equipment event command still
+  bypasses this either way, so `Game::Party`'s bag-swapping methods stay
+  unguarded, unchanged.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6977,12 +6977,51 @@ above are repeated here)
   it; a second, unrelated state alongside it changes nothing), confirmed to
   fail against the pre-fix code (`expected 0, got 95`) before the fix.
   **Left open, a separate and more involved feature**: the sibling RPG2003
-  state fields `reflect_magic` (skill/magic attacks bounce back onto their
+  state field `reflect_magic` (skill/magic attacks bounce back onto their
   caster, `Game_Battler::HasReflectState` /
-  `Game_BattleAlgorithm::Skill::IsReflected` in the same C++ source) and
-  `cursed` (`Game_Actor`'s own separate, unrelated usage) — both still
-  parsed but unread here, and both needing real target-redirection/removal
-  logic rather than a single early-return, unlike this narrower fix.
+  `Game_BattleAlgorithm::Skill::IsReflected` in the same C++ source) — still
+  parsed but unread here, and needing real target-redirection logic rather
+  than a single early-return, unlike this narrower fix. ✅ **The sibling
+  `cursed` state field (situation/state field 38) this same bullet flagged
+  as "`Game_Actor`'s own separate, unrelated usage" is now implemented
+  too — the "no test-bed evidence... left unbuilt rather than guessed at"
+  note `Game::Actor#equipment_fixed?` used to carry, now settled straight
+  off EasyRPG Player's actual C++ source instead of left unread.**
+  `Game_Actor::IsEquipmentFixed(check_states)` (`src/game_actor.cpp`) is
+  `data.lock_equipment || (check_states && any inflicted state's own
+  `cursed` flag)`, and its one caller that matters for this codebase's own
+  equip menu, `Scene_Equip::CanRemoveEquipment` (`src/scene_equip.cpp`) —
+  which runs right before opening a slot's item list, refusing to even open
+  it rather than opening it and rejecting a choice, exactly matching
+  `Scene::EquipMenu#update_slots`'s existing `!actor.equipment_fixed? &&
+  !actor.slot_cursed?(@slot_index)` gate (`mruby-rpg2k/mrblib/
+  scene/equip_menu.rb`) — always passes `check_states: true`, so both
+  halves belong in one predicate: `#equipment_fixed?` used to read only the
+  actor/class row's own `equipment_fixed` trait (LCF field 22), leaving a
+  state carrying `cursed` (field 38) cosmetically inert even though the
+  schema already parsed it (`mruby-lcf/mrblib/schema.rb`'s `situation`
+  table). Fixed with a new `Game::Actor#state_cursed?` (`mruby-rpg2k/mrblib/
+  game.rb`) — scanning `@states` for any id whose `@db.situation[sid].cursed`
+  answers true, the same `@db.situation`/`d.respond_to?(name) ? d.send(name)
+  : default` idiom `Game::Party#stat_mode` and `Game::Battle
+  #evades_all_physical?` already use for reading a state row's own flags —
+  consulted by `#equipment_fixed?` alongside the existing row check. Distinct
+  from the neighbouring `#slot_cursed?` (a property of the *item* currently
+  worn, unaffected by this fix): a `cursed` state locks every slot for as
+  long as it is inflicted and unlocks the instant it lifts, regardless of
+  what is equipped, while an equipped cursed *item* keeps locking its own
+  slot even after any such state clears. Matches this codebase's existing
+  "only the equip menu gates on this" split for the row-flag half exactly:
+  RPG_RT's Change Equipment event command still bypasses both halves either
+  way (`Game_Actor::ChangeEquipment` never consults `IsEquipmentFixed` at
+  all), so `Game::Party`'s bag-swapping methods (`#equip_from_bag`/
+  `#unequip_to_bag`) stay unguarded here on purpose, unaffected by the fix.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (a `cursed`-
+  flagged state inflicted and later lifted toggles `#equipment_fixed?`/
+  `#state_cursed?` on and off in step, with an ordinary unrelated state
+  alongside it proven inert; the bag-swap methods stay usable through a
+  cursed state, the same control the row-flag half already has), both
+  confirmed to fail against the pre-fix code before the fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1775,22 +1775,46 @@ module Game
     end
 
     # 装備固定 — an actor (or RPG2003 class) whose equipment cannot be changed
-    # from the field. Same class-row-then-player-row lookup as #strong_defence?
-    # / #double_hand? (liblcf's `job` table carries the same field id, 22).
-    # EasyRPG's `Game_Actor::IsEquipmentFixed` is `data.lock_equipment ||
-    # (check_states && a currently-inflicted state is 呪い/cursed)` -- the
-    # state-curse half has no test-bed evidence in either game (neither names
-    # a `cursed` state) and is left unbuilt rather than guessed at; this reads
-    # only the row's own flag, which is the half both games actually set.
-    # `Scene::EquipMenu` is what has to act on it (`scene_equip.cpp`'s
-    # `UpdateEquipSelection` refuses to even open the slot's item list, rather
-    # than opening it and rejecting a choice), so nothing in `Game::Party`
-    # reads this -- the bag-swapping methods stay usable for a caller that
-    # already knows better, the same way they do not re-check `menu_access`.
+    # from the field, whether because the actor/class row itself is locked or
+    # because a currently-inflicted state carries RPG2003's own 呪い/cursed flag
+    # (situation/state field 38, `cursed` -- #state_cursed? below) for as long
+    # as it lasts. Same class-row-then-player-row lookup as #strong_defence?
+    # / #double_hand? for the row half (liblcf's `job` table carries the same
+    # field id, 22). Confirmed against EasyRPG Player's actual C++ source
+    # rather than left unbuilt: `Game_Actor::IsEquipmentFixed(check_states)` is
+    # `data.lock_equipment || (check_states && any inflicted state's own
+    # `cursed` flag)` (`src/game_actor.cpp`), and the single caller this class
+    # matters for, `Scene_Equip::CanRemoveEquipment` (`src/scene_equip.cpp`) --
+    # which runs right before opening a slot's item list, refusing to even open
+    # it rather than opening it and rejecting a choice, the exact point
+    # `Scene::EquipMenu#update_slots` gates below -- always passes
+    # `check_states: true`, so both halves belong in this one predicate; the
+    # state-curse half used to have "no test-bed evidence in either game...
+    # left unbuilt rather than guessed at" here, now settled straight off that
+    # source instead of left unread. RPG_RT's Change Equipment event command
+    # still forces past both halves either way (`Game_Actor::ChangeEquipment`
+    # never consults this method at all), so nothing in `Game::Party` reads
+    # this -- the bag-swapping methods stay usable for a caller that already
+    # knows better, the same way they do not re-check `menu_access`.
     def equipment_fixed?
       row = class_row_for(@class_id) if @class_id && @class_id > 0
       row ||= @db_row
-      row.respond_to?(:equipment_fixed) ? (row.equipment_fixed ? true : false) : false
+      return true if row.respond_to?(:equipment_fixed) && row.equipment_fixed
+      state_cursed?
+    end
+
+    # Whether any state currently inflicting the actor carries RPG2003's own
+    # `cursed` flag (situation/state field 38) -- see #equipment_fixed?, the
+    # only reader. Unlike #slot_cursed? below (a property of the item worn in
+    # a slot) this is a property of the actor's own affliction list, so it is
+    # read fresh from `@states` every call rather than cached, the same way
+    # #state? is.
+    def state_cursed?
+      return false unless @db.respond_to?(:situation) && @db.situation
+      @states.any? do |sid|
+        d = @db.situation[sid]
+        d && d.respond_to?(:cursed) && d.cursed
+      end
     end
 
     # 呪われた装備 -- an item flagged `cursed` (item field 29, alongside the other

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2738,7 +2738,13 @@ FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           # every basic attack unconditionally. Appended last,
                           # same reason again -- nil reads as falsy via
                           # #state_field, matching the schema's own false default.
-                          :avoid_attacks)
+                          :avoid_attacks,
+                          # ... and the RPG2003 "cursed" flag (state field 38,
+                          # `cursed`): a battler carrying it can't change
+                          # equipment from the field for as long as it lasts
+                          # (Game::Actor#equipment_fixed?/#state_cursed?).
+                          # Appended last, same reason again.
+                          :cursed)
 # A state row carrying only the fields a check names, with the rest at the
 # database defaults — notably reduce_hit_ratio 100, which is "does not blind".
 def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
@@ -2752,7 +2758,7 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                affect_spirit: false, affect_agility: false,
                hp_change_type: Game::States::CHANGE_TYPE_LOSE,
                sp_change_type: Game::States::CHANGE_TYPE_LOSE,
-               avoid_attacks: false)
+               avoid_attacks: false, cursed: false)
   FakeStateDef.new(restriction, hp_val, hp_max, sp_val, sp_max, hold_turn,
                    auto_release, release_by_attack, reduce_hit_ratio,
                    restrict_skill, restrict_skill_level,
@@ -2761,7 +2767,7 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                    hp_map_steps, hp_map_val, sp_map_steps, sp_map_val,
                    affect_type, affect_attack, affect_defense,
                    affect_spirit, affect_agility,
-                   hp_change_type, sp_change_type, avoid_attacks)
+                   hp_change_type, sp_change_type, avoid_attacks, cursed)
 end
 # An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
@@ -12055,6 +12061,51 @@ check 'equipment_fixed? does not itself block Party#equip_from_bag / #unequip_to
   db = FakeActorDB.new({ 1 => row }, [1], items)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  ok st.party.equip_from_bag(hero, 1)
+  eq 1, hero.equipment[0]
+  ok st.party.unequip_to_bag(hero, 0) != 0
+  eq 0, hero.equipment[0]
+end
+
+# -- 呪い states lock equipment too (Actor#equipment_fixed?/#state_cursed?) ---
+# The RPG2003 state field EasyRPG's own `IsEquipmentFixed(true)` folds into the
+# same predicate as the row's `equipment_fixed` trait -- see the fuller
+# writeup at #equipment_fixed? above. Distinct from #slot_cursed? (a property
+# of the *item*, checked further below): this one is a property of whatever
+# states the actor currently carries, so it comes and goes with the state
+# itself rather than staying put once removed.
+
+check 'Actor#equipment_fixed? is also true while a `cursed`-flagged state is inflicted' do
+  situation = { 9 => fake_state(cursed: true), 10 => fake_state }
+  row = FakePlayerRow.new('Hero', '', 0, 5, { max_hp: 10 })
+  db = FakeActorDB.new({ 1 => row }, [1], {}, {}, {}, situation)
+  hero = Game::Party.new(db).leader
+  ok !hero.equipment_fixed?, 'no state inflicted yet'
+
+  hero.add_state(10)
+  ok !hero.equipment_fixed?, 'an ordinary (non-cursed) state does not lock equipment'
+
+  hero.add_state(9)
+  ok hero.equipment_fixed?, 'the cursed state locks equipment on top of the ordinary one'
+
+  hero.remove_state(9)
+  ok !hero.equipment_fixed?, 'lifting the cursed state unlocks equipment again'
+  ok !hero.state_cursed?, 'and #state_cursed? itself agrees'
+end
+
+check 'state_cursed? does not itself block Party#equip_from_bag / #unequip_to_bag' do
+  # Same split as the row-flag half above: the gate belongs to the equip menu,
+  # not the bag-swap logic, so a caller that already knows better (an event
+  # command, this test) can still equip/unequip through a cursed state.
+  situation = { 9 => fake_state(cursed: true) }
+  items = { 1 => fake_item(type: 1, atk: 20) }
+  row = FakePlayerRow.new('Hero', '', 0, 5, { max_hp: 10 })
+  db = FakeActorDB.new({ 1 => row }, [1], items, {}, {}, situation)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  hero.add_state(9)
+  ok hero.equipment_fixed?
   st.party.gain_item(1, 1)
   ok st.party.equip_from_bag(hero, 1)
   eq 1, hero.equipment[0]


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s state-flags bullet explicitly flagged the RPG2003 `cursed` state field (situation/state field 38) as "left open, a separate and more involved feature." A standing comment in the code itself (`Game::Actor#equipment_fixed?`) already admitted the state-curse half was "left unbuilt rather than guessed at."
- `mruby-lcf/mrblib/schema.rb` already parses the `situation` table's `cursed` field, but `mruby-rpg2k` read it nowhere.
- Verified against EasyRPG Player's actual C++ source: `Game_Actor::IsEquipmentFixed(check_states)` is `data.lock_equipment || (check_states && any inflicted state's own cursed flag)`, and its equip-menu caller `Scene_Equip::CanRemoveEquipment` — which runs right before opening a slot's item list, exactly matching this codebase's `Scene::EquipMenu#update_slots` gate — always passes `check_states: true`.
- Added `Game::Actor#state_cursed?`, scanning `@states` against `@db.situation[sid].cursed`, using the same `@db.situation`/`respond_to?`-guarded read idiom `Game::Party#stat_mode` and `Game::Battle#evades_all_physical?` already use. `#equipment_fixed?` now returns true if either the row's own `equipment_fixed` trait or `#state_cursed?` is true — matching `IsEquipmentFixed(true)` exactly. `Game::Party`'s bag-swapping methods remain unguarded on purpose, matching `Game_Actor::ChangeEquipment` never consulting this predicate either.
- `docs/TODO.md` updated ✅ with the citation; the sibling RPG2003 `reflect_magic` field is explicitly left open (target-redirection is a materially larger feature).

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 767 checks pass (2 new: inflicting a cursed state locks equipment on top of an ordinary state not doing so, and lifting it unlocks equipment again; `state_cursed?` does not itself block `Party#equip_from_bag`/`#unequip_to_bag` — confirmed to fail against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 480 checks pass
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks pass
- [x] `ruby scripts/rpg2k_command_soak.rb` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_