### PR TITLE
rpg2k: a Skill cast at a Reflect Magic state bounces back onto its caster

### DIFF
--- a/changelog.d/reflect-magic-state.fixed.md
+++ b/changelog.d/reflect-magic-state.fixed.md
@@ -1,0 +1,14 @@
+- **A state flagged "Reflect Magic" (RPG2003) now bounces a single-target
+  Skill back onto its own caster.** `reflect_magic` (state schema field 37)
+  was parsed but never read anywhere in the battle engine. Ported from
+  EasyRPG Player's `Game_Battler::HasReflectState` /
+  `Game_BattleAlgorithm::Skill::IsReflected`: a genuine Skill cast (not an
+  item-cast effect) whose target carries the state and starts on the
+  opposite side from its caster now redirects onto the caster instead,
+  before any hit-chance/elemental/variance math runs — so the skill still
+  rolls its own accuracy and damage normally, just against the new target.
+  Works symmetrically for both player- and enemy-cast skills. Scoped to a
+  single-target Skill only; an all-enemies-scope skill's own group-wide
+  reflect behaviour (redirecting the caster's entire party) is a separate,
+  unaddressed shape. Covered by a new `scripts/rpg2k_logic_check.rb` check,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6992,12 +6992,7 @@ above are repeated here)
   bystander in the same fight is unaffected; a 必中 attacker cannot bypass
   it; a second, unrelated state alongside it changes nothing), confirmed to
   fail against the pre-fix code (`expected 0, got 95`) before the fix.
-  **Left open, a separate and more involved feature**: the sibling RPG2003
-  state field `reflect_magic` (skill/magic attacks bounce back onto their
-  caster, `Game_Battler::HasReflectState` /
-  `Game_BattleAlgorithm::Skill::IsReflected` in the same C++ source) — still
-  parsed but unread here, and needing real target-redirection logic rather
-  than a single early-return, unlike this narrower fix. ✅ **The sibling
+  ✅ **The sibling
   `cursed` state field (situation/state field 38) this same bullet flagged
   as "`Game_Actor`'s own separate, unrelated usage" is now implemented
   too — the "no test-bed evidence... left unbuilt rather than guessed at"
@@ -7038,6 +7033,54 @@ above are repeated here)
   alongside it proven inert; the bag-swap methods stay usable through a
   cursed state, the same control the row-flag half already has), both
   confirmed to fail against the pre-fix code before the fix.
+  ✅ **The sibling `reflect_magic` field (skill/magic attacks bounce back onto
+  their caster) is now implemented too, for the single-target case.**
+  Verified against EasyRPG Player's actual C++ source rather than guessed at:
+  `Game_Battler::HasReflectState` (`src/game_battler.cpp`) scans a battler's
+  inflicted states for the flag, exactly like `#evades_all_physical?` above
+  does for `avoid_attacks`; `Game_BattleAlgorithm::Skill::IsReflected`
+  (`src/game_battlealgorithm.cpp`) gates on three things — `!(item ||
+  skill.easyrpg_ignore_reflect)` (a skill cast from an item never reflects;
+  `easyrpg_ignore_reflect` is an EasyRPG-only extension field no vanilla
+  database can set, so it needs no counterpart here), the target actually
+  carrying the state, and caster/target starting on *opposite* sides
+  (`target.GetType() != GetSource()->GetType()`, which is what keeps an
+  ordinary ally/self-scoped skill from ever reaching this at all, since it
+  never targets the opposing side to begin with) — and
+  `Scene_Battle_Rpg2k::ProcessBattleActionAnimationImpl` calls the engine's
+  own `AlgorithmBase::ReflectTargets` right before the action's `Execute()`
+  step, well before any hit-chance/elemental/variance math runs, so a
+  reflected skill still rolls its own accuracy and damage normally
+  afterward, just against the new target. `reflect_magic` (schema field 37)
+  was parsed but never read anywhere in this file before this fix. Fixed
+  with a new `Game::Battle#reflects_magic?(b)` (the identical
+  `state_def`/`state_field` scan `#evades_all_physical?` uses) and
+  `#reflects_skill?(b, target, cmd)`, which ports the three-part
+  `IsReflected` gate — `cmd[:skill_id] && !cmd[:item_id] && side_of(target)
+  != side_of(b) && reflects_magic?(target)` (this codebase's own item-cast
+  effects carry `cmd[:item_id]` instead of `cmd[:skill_id]`, the same split
+  `#apply_command` already threads apart between a real Skill cast and a
+  medicine/special-item use, which is the `item` half of the EasyRPG check
+  for free) — called from `#apply_command` right after the already-fallen
+  fizzle check and before SP is spent, redirecting `target` to the caster
+  itself when it answers true and leaving `#apply_skill_hit` completely
+  unmodified otherwise. Not edition-gated, matching `#evades_all_physical?`'s
+  own "trust the data" precedent (`HasReflectState` carries no
+  `Player::IsRPG2k3()` check either). **Scoped to a single-target Skill
+  only** (`#apply_command`, not `#apply_command_all`): real RPG_RT's own
+  `ReflectTargets` additionally redirects an all-enemies-scope skill onto
+  the caster's *entire* party the instant any one target in the group
+  reflects (`AddTargets(&source->GetParty(), true)`), on top of — not
+  instead of — the remaining un-reflected targets in that same group, a
+  materially different shape left unaddressed here. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a Skill cast at a reflect-warded foe
+  lands on the caster instead, HP/SP-cost accounting unaffected; an
+  unafflicted target in the same fight is unaffected; the same redirect
+  fires symmetrically for an enemy's own Skill cast at a reflect-warded
+  ally; a raw item-cast command and a same-side ally/self-scoped cast never
+  reflect even against an identically warded target), confirmed to fail
+  against the pre-fix code (`expected "Mage", got "Warded Foe"`) before the
+  fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7057,6 +7057,43 @@ module Game
       (b.states || []).any? { |sid| state_field(state_def(sid), :avoid_attacks) }
     end
 
+    # Whether any state currently afflicting `b` is flagged "Reflect Magic"
+    # (RPG2003 state field 37, `reflect_magic` in `mruby-lcf/mrblib/schema.rb`)
+    # -- EasyRPG's `Game_Battler::HasReflectState` (game_battler.cpp), scanned
+    # the same way #evades_all_physical? scans `avoid_attacks`. Parsed but
+    # never read anywhere in this file before this fix -- see #reflects_skill?,
+    # the one caller that turns this into an actual retarget.
+    def reflects_magic?(b)
+      (b.states || []).any? { |sid| state_field(state_def(sid), :reflect_magic) }
+    end
+
+    # Whether a Skill cast at `target` bounces back onto its own caster `b`
+    # instead, per `cmd` (the command hash #battle_skill_command built).
+    # Ported from EasyRPG's `Game_BattleAlgorithm::Skill::IsReflected`
+    # (game_battlealgorithm.cpp): `if (item || skill.easyrpg_ignore_reflect)
+    # return false; return IsTargetValid(target) && target.HasReflectState() &&
+    # target.GetType() != GetSource()->GetType()`. `item` there is "this skill
+    # effect was cast from a special item, not chosen from the caster's own
+    # skill list" -- this codebase's own item-cast effects carry `cmd[:item_id]`
+    # instead of `cmd[:skill_id]` (#apply_command already threads the two
+    # apart; see #skill_command_hash / #battle_item_command), so checking for a
+    # real `skill_id` is the same gate. `easyrpg_ignore_reflect` is an
+    # EasyRPG-only extension field no vanilla RPG2000/2003 database ever sets,
+    # so it needs no counterpart here. The opposite-side check
+    # (`GetType() != GetSource()->GetType()`) is what keeps an ordinary ally/
+    # self-scoped skill from ever reaching this at all -- it never targets the
+    # opposing side to begin with. `Scene_Battle_Rpg2k::
+    # ProcessBattleActionAnimationImpl` calls the real engine's own
+    # `ReflectTargets` right before the action's `Execute()` step, well before
+    # any hit-chance/elemental/variance math runs -- so a reflected skill still
+    # rolls its own accuracy and damage normally afterward, just against the
+    # new target, which is exactly what redirecting `target` here and letting
+    # #apply_skill_hit run unmodified on the result achieves.
+    def reflects_skill?(b, target, cmd)
+      cmd[:skill_id] && !cmd[:item_id] && side_of(target) != side_of(b) &&
+        reflects_magic?(target)
+    end
+
     # How much the attacker's own statuses cut its accuracy: the **lowest**
     # `reduce_hit_ratio` among the states afflicting it, not the product of them
     # (EasyRPG's `Game_Battler::GetHitChanceModifierFromStates` takes a running
@@ -8178,11 +8215,25 @@ module Game
     # Recovery, a revive item/skill) is the only thing modelled here that can
     # stand a combatant back up, and it does so by writing HP directly rather
     # than through this command path.
+    #
+    # A single-target Skill whose target carries Reflect Magic bounces back
+    # onto `b` itself (#reflects_skill?) -- checked against the originally
+    # queued target, after the already-fallen fizzle check above (a fizzled
+    # action never reflects either, matching real RPG_RT never reaching
+    # `ReflectTargets` for an action that never starts) and before SP is
+    # spent or #apply_skill_hit runs, so the skill's own cost/accuracy/damage
+    # math is otherwise completely unaffected by which battler it ends up
+    # landing on. Scoped to this single-target path only: an all-enemies-scope
+    # Skill's own reflect handling (#apply_command_all) is a materially
+    # different shape in real RPG_RT -- one reflecting target there redirects
+    # the *whole* group onto the caster's entire side, not just that one hit
+    # -- and is left unaddressed here.
     def apply_command(b)
       cmd = b.command
       return apply_command_all(b, cmd) if cmd[:all]
       target = cmd[:target]
       return nil if target.nil? || target.dead?
+      target = b if reflects_skill?(b, target, cmd)
       b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
       apply_skill_hit(b, target, cmd[:hp] || 0, cmd[:mp] || 0, cmd)
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2739,6 +2739,11 @@ FakeStateDef = Struct.new(:restriction, :hp_change_val, :hp_change_max,
                           # same reason again -- nil reads as falsy via
                           # #state_field, matching the schema's own false default.
                           :avoid_attacks,
+                          # ... and the RPG2003 "Reflect Magic" flag (state
+                          # field 37, `reflect_magic`): a Skill cast at a
+                          # battler carrying it bounces back onto its own
+                          # caster. Appended last, same reason again.
+                          :reflect_magic,
                           # ... and the RPG2003 "cursed" flag (state field 38,
                           # `cursed`): a battler carrying it can't change
                           # equipment from the field for as long as it lasts
@@ -2758,7 +2763,7 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                affect_spirit: false, affect_agility: false,
                hp_change_type: Game::States::CHANGE_TYPE_LOSE,
                sp_change_type: Game::States::CHANGE_TYPE_LOSE,
-               avoid_attacks: false, cursed: false)
+               avoid_attacks: false, reflect_magic: false, cursed: false)
   FakeStateDef.new(restriction, hp_val, hp_max, sp_val, sp_max, hold_turn,
                    auto_release, release_by_attack, reduce_hit_ratio,
                    restrict_skill, restrict_skill_level,
@@ -2767,7 +2772,8 @@ def fake_state(restriction: 0, hp_val: 0, hp_max: 0, sp_val: 0, sp_max: 0,
                    hp_map_steps, hp_map_val, sp_map_steps, sp_map_val,
                    affect_type, affect_attack, affect_defense,
                    affect_spirit, affect_agility,
-                   hp_change_type, sp_change_type, avoid_attacks, cursed)
+                   hp_change_type, sp_change_type, avoid_attacks, reflect_magic,
+                   cursed)
 end
 # An RPG2003 class row (職業, database chunk 30): its own growth curve, learn
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
@@ -9563,6 +9569,67 @@ check 'battle: an "Avoid Attacks" (RPG2003) state dodges every basic attack unco
   # Carrying an unrelated, unflagged state alongside it changes nothing.
   dodger.states = [12, 13]
   eq 0, bat.send(:to_hit, attacker, dodger), 'still dodges with a second, unrelated state'
+end
+
+check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its own caster' do
+  # Parsed (mruby-lcf/mrblib/schema.rb state field 37, reflect_magic) but never
+  # read anywhere in Game::Battle before this fix -- EasyRPG's
+  # Game_BattleAlgorithm::Skill::IsReflected (game_battlealgorithm.cpp) redirects
+  # a Skill's target onto its own caster the instant the intended target carries
+  # one, checked by Scene_Battle_Rpg2k::ProcessBattleActionAnimationImpl right
+  # before the action's own Execute() step -- so the skill still rolls its own
+  # damage/accuracy/variance normally afterward, just against the new target.
+  states = { 20 => fake_state(reflect_magic: true), 21 => fake_state }
+  mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  warded_foe = combatant('Warded Foe', 0, 0, 5, 100)
+  warded_foe.states = [20]
+  plain_foe = combatant('Plain Foe', 0, 0, 5, 100)
+  bat = Game::Battle.new([mage], [warded_foe, plain_foe], Game::Rng.new(1), states)
+  bat.command_skill(mage, warded_foe, name: 'Fire', cost: 6, hp: -30, skill_id: 7)
+  bat.begin_round
+  e = bat.step_action
+  eq 'Mage', e[:target], 'the hit lands on the caster, not the warded foe'
+  eq 100, warded_foe.hp, 'the warded foe itself takes nothing'
+  eq 70, mage.hp, 'the caster eats its own 30-damage Fire instead'
+  eq 4, mage.mp, 'SP is still spent exactly once, same as an unreflected cast'
+
+  # An unafflicted target is unaffected -- the reflected case above is not a
+  # blanket redirect of every Skill this caster ever casts.
+  mage.hp = 100
+  bat.command_skill(mage, plain_foe, name: 'Fire', cost: 0, hp: -30, skill_id: 7)
+  bat.begin_round
+  e2 = bat.step_action
+  eq 'Plain Foe', e2[:target], 'a foe with no Reflect Magic state takes the hit as normal'
+  eq 70, plain_foe.hp
+
+  # Symmetric across sides: an enemy's own Skill cast at a reflect-warded ally
+  # bounces back onto that enemy itself, not just the player's own casts.
+  warded_ally = combatant('Warded Ally', 0, 0, 1, 100) # slow: acts after the caster below
+  warded_ally.states = [20]
+  caster_foe = combatant_mp('Caster Foe', 0, 0, 20, 100, 10)
+  bat2 = Game::Battle.new([warded_ally], [caster_foe], Game::Rng.new(1), states)
+  bat2.command_skill(caster_foe, warded_ally, name: 'Dark', cost: 6, hp: -25, skill_id: 9)
+  bat2.begin_round
+  e3 = bat2.step_action
+  eq 'Caster Foe', e3[:target], 'the enemy caster eats its own reflected Skill'
+  eq 100, warded_ally.hp
+  eq 75, caster_foe.hp
+
+  # A skill's own reflect check requires a genuine skill cast (cmd[:skill_id]) --
+  # an item-cast effect (EasyRPG's own "item" guard in Skill::IsReflected) never
+  # reflects even against the identical warded target, and neither does a skill
+  # whose target starts on the *same* side as its caster (an ally/self-scoped
+  # skill never legitimately reaches the opposing side to begin with).
+  bare = Game::Battle.new([mage], [warded_foe], Game::Rng.new(1), states)
+  ok !bare.send(:reflects_skill?, mage, warded_foe,
+                 { skill_id: 7, item_id: 3 }), 'an item-cast effect never reflects'
+  ok !bare.send(:reflects_skill?, mage, warded_foe, { item_id: 3 }),
+     'no skill_id at all (a bare item command) never reflects either'
+  ok bare.send(:reflects_skill?, mage, warded_foe, { skill_id: 7 }),
+     'a genuine skill cast at the warded foe does reflect'
+  mage.states = [20] # hypothetically warded itself, for the same-side check below
+  ok !bare.send(:reflects_skill?, mage, mage, { skill_id: 7 }),
+     'a same-side (ally/self-scoped) skill never reflects, warded target or not'
 end
 
 check 'battle: a normal attack can shake a state off its target' do


### PR DESCRIPTION
## Summary
- `reflect_magic` (RPG2003 state schema field 37) was parsed (`mruby-lcf/mrblib/schema.rb`) but never read anywhere in the battle engine, so a state built to bounce magic back at its caster did nothing.
- Ported from EasyRPG Player's actual C++ source (`Game_Battler::HasReflectState`, `Game_BattleAlgorithm::Skill::IsReflected`, `Scene_Battle_Rpg2k::ProcessBattleActionAnimationImpl`): a genuine single-target Skill cast (not an item-cast effect) whose target carries the state, and whose target starts on the opposite side from its caster, now redirects onto the caster before any hit-chance/elemental/variance math runs — so the skill still rolls its own accuracy and damage normally, just against the new target.
- Works symmetrically for both player-cast and enemy-cast skills, since both route through the same `Game::Battle#apply_command` choke point.
- Deliberately scoped to a single-target Skill only (`#apply_command`, not `#apply_command_all`): real RPG_RT's own `ReflectTargets` additionally redirects an all-enemies-scope skill onto the caster's *entire* party once any one target in the group reflects — a materially different, larger shape left unaddressed here and called out explicitly in `docs/TODO.md`.
- Updates `docs/TODO.md`'s "Database field semantics" entry with a dense, evidence-citing writeup (merged alongside the sibling `cursed`/equipment-lock fix that landed in #698 while this was in progress).
- Adds a `changelog.d/reflect-magic-state.fixed.md` fragment.

## Test plan
- New `scripts/rpg2k_logic_check.rb` check: a Skill cast at a reflect-warded foe lands on the caster instead (HP/SP-cost accounting unaffected); an unafflicted target in the same fight is unaffected; the same redirect fires symmetrically for an enemy's own Skill cast at a reflect-warded ally; a raw item-cast command and a same-side ally/self-scoped cast never reflect even against an identically warded target. Confirmed to fail against the pre-fix code (`expected "Mage", got "Warded Foe"`) via `git stash` of just `mruby-rpg2k/mrblib/game.rb`.
- `ruby scripts/rpg2k_logic_check.rb` — 768 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 480 checks passed
- `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` / `ruby scripts/rpg2k_command_soak.rb` — skipped (no test-bed game data available in this sandbox; both correctly report "no game dir found" and exit cleanly rather than erroring)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WgXYnt3tiHrsvYNkb86eEn)_