### PR TITLE
rpg2k: fix a truthy-0 bug that made any state dodge attacks / reflect skills

### DIFF
--- a/changelog.d/state-flag-truthy-zero.fixed.md
+++ b/changelog.d/state-flag-truthy-zero.fixed.md
@@ -1,0 +1,9 @@
+- **A battler carrying any state at all — not just one flagged "Avoid
+  Attacks" or "Reflect Magic" (RPG2003) — no longer dodges every basic
+  attack or reflects every Skill.** `Game::Battle#evades_all_physical?` and
+  `#reflects_magic?` scanned a battler's states through `#state_field`, a
+  helper meant for numeric fields whose `|| 0` fallback reads an unset
+  boolean as the integer `0` — which is truthy in Ruby, so `.any? { ... }`
+  answered true for any inflicted state, flagged or not. Both now use
+  `#state_flag`, the helper `#skill_sealed?` already used correctly for the
+  same kind of field.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7103,6 +7103,43 @@ above are repeated here)
   reflect even against an identically warded target), confirmed to fail
   against the pre-fix code (`expected "Mage", got "Warded Foe"`) before the
   fix.
+  ✅ **A latent bug in both `#evades_all_physical?` and `#reflects_magic?`
+  is now fixed: either one answered true for a battler carrying *any* state
+  at all, not only one actually flagged `avoid_attacks`/`reflect_magic`.**
+  Both scanned their target's states via `#state_field`
+  (`d.respond_to?(name) ? (d.send(name) || 0) : 0`), a helper built for a
+  *numeric* field's "unset -> 0" default (`hp_change_val` and friends, a few
+  methods down) — but Ruby's `0` is truthy, so `(b.states || []).any? {
+  |sid| state_field(...) }` returned the integer `0` (truthy) for every
+  state whose `avoid_attacks`/`reflect_magic` value was the ordinary,
+  unflagged `false`, not just the genuinely-flagged one, making `.any?`
+  answer true the instant a battler carried *any* state whatsoever —
+  Poisoned, Blind, Silenced, anything. In practice this meant any afflicted
+  party member or monster dodged every basic attack outright
+  (`#evades_all_physical?`, consumed by `#to_hit`'s very first line) and any
+  Skill cast at an afflicted opposing-side target bounced back onto its own
+  caster (`#reflects_magic?`, via `#reflects_skill?`) — both far more often
+  and far more broadly than either state field was ever meant to trigger.
+  This codebase already has the right helper for a boolean field,
+  `#state_flag` (`d.respond_to?(name) ? (d.send(name) ? true : false) :
+  false`, already used correctly by `#skill_sealed?` for
+  `restrict_skill`/`restrict_magic` a few methods down) — `#evades_all_
+  physical?`/`#reflects_magic?` simply reused the wrong one. Fixed by
+  switching both to `#state_flag`; neither method's own shape changes
+  otherwise. The bug was invisible to both fixes' own original regression
+  coverage above: each one's "an unrelated state changes nothing" case only
+  ever *paired* the flagged state with a second, unflagged one (already
+  true regardless of this bug, since `.any?` only needs one truthy hit) or
+  used a target carrying no states at all (`(b.states || [])` short-circuits
+  to `[]` before the bug's own truthy-`0` block ever runs) — neither
+  isolated a target carrying *only* a genuinely unflagged state, the one
+  case that actually exercises it. Fixed by giving both existing
+  `scripts/rpg2k_logic_check.rb` checks a target/foe carrying exactly that
+  (an ordinary state whose row is otherwise identical to the flagged one's,
+  same table, different id) in place of their old empty-`.states` controls,
+  both confirmed to fail against the pre-fix code before the fix (an
+  unrelated-state target dodging/reflecting exactly like a genuinely flagged
+  one would).
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7053,18 +7053,31 @@ module Game
     # below. Parsed but never read anywhere in this file before this fix, so a
     # state built for this exact purpose (RPG2000's closest thing to a
     # guaranteed-dodge "Blink"/intangibility status) did nothing at all.
+    #
+    # Uses #state_flag, not #state_field: the latter's `d.send(name) || 0`
+    # fallback is built for a *numeric* field's "unset -> 0" default (see
+    # #apply_turn_states' own hp/sp reads further down) and hands back the
+    # integer `0` for an unset/false *boolean* field too -- and `0` is truthy
+    # in Ruby, so `.any? { state_field(...) }` answered true for a battler
+    # carrying *any* state at all, avoid_attacks-flagged or not, until this
+    # fix. #skill_sealed? already has the right idiom for a boolean field
+    # (`state_flag`, scanning `restrict_skill`/`restrict_magic` a few methods
+    # down) -- this one just used the wrong helper.
     def evades_all_physical?(b)
-      (b.states || []).any? { |sid| state_field(state_def(sid), :avoid_attacks) }
+      (b.states || []).any? { |sid| state_flag(state_def(sid), :avoid_attacks) }
     end
 
     # Whether any state currently afflicting `b` is flagged "Reflect Magic"
     # (RPG2003 state field 37, `reflect_magic` in `mruby-lcf/mrblib/schema.rb`)
     # -- EasyRPG's `Game_Battler::HasReflectState` (game_battler.cpp), scanned
-    # the same way #evades_all_physical? scans `avoid_attacks`. Parsed but
-    # never read anywhere in this file before this fix -- see #reflects_skill?,
+    # the same way #evades_all_physical? scans `avoid_attacks` (#state_flag,
+    # not #state_field -- see that method's own comment on why: the same
+    # truthy-`0` bug applied here too, reflecting a Skill off *any* afflicted
+    # target rather than only a Reflect-Magic-flagged one). Parsed but never
+    # read anywhere in this file before this fix -- see #reflects_skill?,
     # the one caller that turns this into an actual retarget.
     def reflects_magic?(b)
-      (b.states || []).any? { |sid| state_field(state_def(sid), :reflect_magic) }
+      (b.states || []).any? { |sid| state_flag(state_def(sid), :reflect_magic) }
     end
 
     # Whether a Skill cast at `target` bounces back onto its own caster `b`

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9555,11 +9555,13 @@ check 'battle: an "Avoid Attacks" (RPG2003) state dodges every basic attack unco
   dodger = combatant('Dodger', 0, 0, 1, 100)        # slow, so agi alone would favour a hit
   dodger.states = [12]
   plain = combatant('Plain', 0, 0, 1, 100)
+  plain.states = [13] # carries an ordinary, unflagged state -- not merely none at all
   bat = Game::Battle.new([attacker], [dodger, plain], Game::Rng.new(1), states,
                          false, false, true)          # accuracy on
   eq 0, bat.send(:to_hit, attacker, dodger),
      'the state forces a flat 0% chance, agility and hit rate notwithstanding'
-  ok bat.send(:to_hit, attacker, plain) > 0, 'an unafflicted target is unaffected'
+  ok bat.send(:to_hit, attacker, plain) > 0,
+     'an unrelated, unflagged state does not itself dodge everything (#state_flag, not #state_field)'
 
   # A 必中 (evasion-ignoring) attacker does not bypass this: real RPG_RT checks
   # avoid_attacks before it ever reaches the ignores_evasion branch.
@@ -9584,6 +9586,7 @@ check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its o
   warded_foe = combatant('Warded Foe', 0, 0, 5, 100)
   warded_foe.states = [20]
   plain_foe = combatant('Plain Foe', 0, 0, 5, 100)
+  plain_foe.states = [21] # carries an ordinary, unflagged state -- not merely none at all
   bat = Game::Battle.new([mage], [warded_foe, plain_foe], Game::Rng.new(1), states)
   bat.command_skill(mage, warded_foe, name: 'Fire', cost: 6, hp: -30, skill_id: 7)
   bat.begin_round
@@ -9599,7 +9602,8 @@ check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its o
   bat.command_skill(mage, plain_foe, name: 'Fire', cost: 0, hp: -30, skill_id: 7)
   bat.begin_round
   e2 = bat.step_action
-  eq 'Plain Foe', e2[:target], 'a foe with no Reflect Magic state takes the hit as normal'
+  eq 'Plain Foe', e2[:target],
+     'an unrelated, unflagged state does not itself reflect (#state_flag, not #state_field)'
   eq 70, plain_foe.hp
 
   # Symmetric across sides: an enemy's own Skill cast at a reflect-warded ally


### PR DESCRIPTION
## Summary

- `Game::Battle#evades_all_physical?` and `#reflects_magic?` (the "Avoid Attacks" / RPG2003 "Reflect Magic" state-flag checks) scanned a battler's states through `#state_field`, a helper built for *numeric* fields whose `d.send(name) || 0` fallback reads an unset value as the integer `0`.
- `0` is truthy in Ruby, so `(b.states || []).any? { |sid| state_field(...) }` answered **true for a battler carrying *any* state at all**, not only one actually flagged `avoid_attacks`/`reflect_magic` — e.g. an ordinary Poisoned or Blinded target dodged every basic attack outright, and a Skill cast at any afflicted opposing-side target bounced back onto its own caster.
- This codebase already has the correct helper for a boolean field, `#state_flag` (`d.send(name) ? true : false`), already used correctly by `#skill_sealed?` for `restrict_skill`/`restrict_magic`. Switched both methods to it; no other logic changes.
- The bug was invisible to the existing regression checks for both features: each one's own "an unrelated state changes nothing" case either paired the flagged state with a *second* one (already true regardless of the bug) or used a target carrying no states at all (short-circuits before the buggy code path runs) — neither isolated a target carrying only a genuinely unflagged state, the one case that exercises it. Fixed both existing checks to use that case instead.
- Recorded in `docs/TODO.md` (the existing `avoid_attacks`/`reflect_magic` write-up) and `changelog.d/`.

## Test plan

- `ruby scripts/rpg2k_logic_check.rb` — 768 checks passed (was 767; two existing checks extended with a negative-control state, both confirmed to fail against the pre-fix code before the fix).
- `ruby scripts/rpg2k_scene_check.rb` — 480 checks passed, unaffected.
- `ruby scripts/rpg2k_render_check.rb` — 40 checks passed, unaffected.
- `ruby scripts/rpg2k_testbed_logic_check.rb` / `ruby scripts/rpg2k_command_soak.rb` — skipped (no test-bed data downloadable in this sandbox), same as prior rounds.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013R49p5sT32NdJ22k5EkgRh


---
_Generated by [Claude Code](https://claude.ai/code/session_013R49p5sT32NdJ22k5EkgRh)_