### PR TITLE
rpg2k: disabled Save command shows no message, matching RPG_RT

### DIFF
--- a/changelog.d/rpg2k-save-disabled-no-message.fixed.md
+++ b/changelog.d/rpg2k-save-disabled-no-message.fixed.md
@@ -1,0 +1,7 @@
+- **The field menu's Save command no longer shows a hardcoded English "You
+  cannot save right now." message when Change Save Access has turned saving
+  off.** Confirmed against EasyRPG Player's own `Scene_Menu::UpdateCommand`
+  source: a disabled Save command plays the buzzer SE and shows no message
+  at all -- the menu simply stays put. `Scene::Menu`'s Save branch now
+  matches: it pushes the save picker only when access is on, with no
+  message otherwise.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2243,15 +2243,22 @@ The work below is roughly ordered by the critical path to a walkable game
     distinguish; wants a closer look (a higher-resolution capture, or
     checking whether EasyRPG's own item-list drawing code names this glyph)
     before guessing at an implementation.
-  - The Save command's "you cannot save right now" message (shown when
-    `Change Save Access` has turned saving off) is a hardcoded English
-    literal, the same class of bug the two placeholders above turned out to
-    be -- but unlike those, this one is *not* wine-verified: the comparison
-    never reached this exact state on the reference side (input lag stacked
-    up over the menu's earlier steps), and RPG2000's Term table has no
-    obvious dedicated slot for this message to source from, so whether RPG_RT
-    shows *any* text here at all is still an open question rather than an
-    assumed one.
+  ✅ **The Save command's "you cannot save right now" message is gone --
+  RPG_RT shows no text at all.** This one was never wine-verified (the
+  comparison never reached this exact state on the reference side, and
+  RPG2000's Term table has no obvious slot for such a message), so rather
+  than keep guessing, this got checked against EasyRPG Player's own
+  `Scene_Menu::UpdateCommand` source directly: its disabled-Save branch
+  plays the buzzer SE (`SFX_Buzzer`) and does nothing else -- no message,
+  no scene push, the menu simply stays where it is. `Scene::Menu`'s Save
+  branch now does the same: `@parent.push Scene::SaveLoad.new(...) if
+  @state.save_access`, no `else`. **Not modelled:** the buzzer SE itself --
+  none of the field-menu scenes (`Scene::Menu`, `Scene::ItemMenu`,
+  `Scene::SkillMenu`, `Scene::EquipMenu`) play *any* system SE yet
+  (cursor-move, decision, cancel, buzzer), unlike `Scene::Title`, which
+  already has its own `#play_cursor_se`. Adding menu-wide SE playback is a
+  bigger, separate piece of work than this one hardcoded-message fix, left
+  for its own pass.
   **A harness reachability quirk, worth recording for whoever extends this
   comparison next:** navigating the field menu's command list under wine and
   then confirming gets unreliable past the *second* cursor position, but it
@@ -2307,8 +2314,21 @@ The work below is roughly ordered by the critical path to a walkable game
   about a display-mode negotiation specific to entering the map scene --
   but this was not chased to a root cause or a workaround; recorded so
   whoever hits it next does not re-derive the same ruled-out list from
-  scratch. Swapping to a fresh `WINEPREFIX` (untried, since it would lose
-  this session's whole configured setup) is the next thing to try.
+  scratch. **A fresh `WINEPREFIX` (`wineboot --init` into a brand new
+  directory) does not fix it either** -- the same fresh-title,
+  fresh-file-select, black-after-Continue pattern reproduced there too,
+  ruling out prefix-local corruption entirely. Whatever this is lives
+  either in the `Nepheshel206beta` game directory itself (unlikely --
+  only `Save01.lsd` has been touched this whole survey, and its own
+  `.ldb`/`.lmt`/`.lmu` files are read-only inputs no script here writes),
+  in some shared, non-prefix wine/X state this session has not identified,
+  or is a genuine RPG_RT behaviour under this specific
+  wine+Xvfb+llvmpipe stack that the many *earlier*, successful Continue
+  captures in this same session (menu/item/equip/save-screen comparisons)
+  happened not to trigger. Left for whoever picks this up next with a
+  clean slate -- re-downloading a pristine `Nepheshel206beta` copy and
+  diffing it against the one in `data/` would be the next thing to rule
+  out.
   ✅ **A whole-frame pixel diff was itself the bug in that "smarter
   automation loop."** Cropping the retry's change-check down to just the
   menu command-list's own region, rather than diffing the entire frame,

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -183,11 +183,16 @@ class RPG2k
         when :status
           @parent.push Scene::StatusMenu.new(@parent, @state)
         when :save
-          if @state.save_access
-            @parent.push Scene::SaveLoad.new(@parent, @state, :save)
-          else
-            show_message("You cannot save right now.")
-          end
+          # A disabled Save command (Change Save Access off) just refuses the
+          # selection outright -- confirmed against EasyRPG's own
+          # Scene_Menu::UpdateCommand, whose disabled-Save branch plays the
+          # buzzer SE and does nothing else, no message of any kind. This
+          # engine drew a hardcoded English "You cannot save right now.",
+          # the same class of gap the Item/Skill empty-list placeholders and
+          # this screen's own bleed-through fix turned out to be, but this
+          # one only needed removing -- there was nothing to source instead,
+          # matching RPG2000's own Term table, which has no slot for it.
+          @parent.push Scene::SaveLoad.new(@parent, @state, :save) if @state.save_access
         when :end_game
           @parent.return_to_title
         else

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9525,7 +9525,11 @@ check 'Scene::Menu: choosing Save opens Scene::SaveLoad in :save mode' do
   eq st, pushed.instance_variable_get(:@state), 'carrying the running game state to write out'
 end
 
-check 'Scene::Menu: Save access forbidden still shows the inline message, not the picker' do
+check 'Scene::Menu: Save access forbidden refuses the selection silently, no message' do
+  # Confirmed against EasyRPG's own Scene_Menu::UpdateCommand: a disabled
+  # Save command just refuses the selection (plays a buzzer SE this engine
+  # does not yet model any menu SE for), no message of any kind -- unlike
+  # this screen's old hardcoded English "You cannot save right now.".
   st = wrap_menu_state
   st.save_access = false
   scene = menu_scene(RPG2k::Scene::Menu, st)
@@ -9534,9 +9538,7 @@ check 'Scene::Menu: Save access forbidden still shows the inline message, not th
   scene.update
   RGSS::Input.reset
   ok scene.parent.pushed.empty?, 'no picker opens while save access is off'
-  ok window_texts(scene.instance_variable_get(:@message)[:window])
-       .include?('You cannot save right now.'),
-     'the existing inline "cannot save" message still shows'
+  ok scene.instance_variable_get(:@message).nil?, 'no message shown at all'
 end
 
 def save_load_scene(mode, state = nil, db = fake_db, parent: nil)


### PR DESCRIPTION
## Summary

This session's wine reference runtime developed a Continue-specific rendering regression (documented separately in `docs/TODO.md`, and reconfirmed this iteration with a fresh `WINEPREFIX` — no change), so this fix is verified against EasyRPG Player's own source instead of a live capture.

- `EasyRPG/Player`'s `Scene_Menu::UpdateCommand` disabled-Save branch plays the buzzer SE and does nothing else — no message, no scene push, the menu simply stays put.
- `Scene::Menu`'s own Save branch drew a hardcoded English "You cannot save right now." instead — the same class of gap the Item/Skill empty-list placeholders and this screen's own bleed-through fix (#685) turned out to be, but this one only needed *removing*: there was nothing to source instead, matching RPG2000's own Term table, which has no slot for such a message.
- `Scene::Menu`'s `:save` branch is now a one-liner: push the save picker only when access is on, no `else`.
- **Not modelled, left for its own pass:** the buzzer SE itself. None of the field-menu scenes (`Scene::Menu`, `Scene::ItemMenu`, `Scene::SkillMenu`, `Scene::EquipMenu`) play any system SE yet (cursor-move, decision, cancel, buzzer) — `Scene::Title` already has its own `#play_cursor_se`, but menu-wide SE playback is a bigger, separate piece of work than this one hardcoded-message fix.
- `scripts/rpg2k_scene_check.rb`'s affected check is rewritten to assert no message shows at all, rather than checking for specific text.
- Also folds in a `docs/TODO.md` addendum from this iteration's own troubleshooting: a fresh `WINEPREFIX` does not fix the Continue-rendering regression either, ruling out prefix-local corruption as the cause.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 480 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 768 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real Nepheshel save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed
- [x] Rebuilt the native engine and verified with `save_access` toggled off: pressing Confirm on Save now does nothing (no message, menu stays open), matching the sourced RPG_RT behavior

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_