### PR TITLE
rpg2k: all-enemy/all-ally Skill reflect now redirects the whole volley

### DIFF
--- a/changelog.d/reflect-magic-all-target.fixed.md
+++ b/changelog.d/reflect-magic-all-target.fixed.md
@@ -1,0 +1,16 @@
+- **An all-enemies/all-allies-scope Skill now honours "Reflect Magic"
+  (RPG2003) too, redirecting the whole volley onto the caster's entire
+  living party instead of any of its originally-selected targets.**
+  Previously only a single-target Skill's own reflect redirect was
+  implemented; a group-scope Skill's own `#apply_command_all` ignored the
+  state entirely. Ported from EasyRPG Player's
+  `AlgorithmBase::ReflectTargets` (`AddTargets(&source->GetParty(), true)`):
+  the instant any still-pending target in the volley carries Reflect Magic,
+  every originally-targeted battler goes unhit and the caster's own side is
+  hit in their place — replaced outright, not added on top of the original
+  group, as an earlier reading of the same source had guessed. Each
+  redirected hit reuses the reflecting target's own precomputed damage
+  while its elemental multiplier/variance/absorb still resolve fresh
+  against whichever new target it lands on; SP is still spent exactly once.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check, confirmed to fail
+  against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7108,13 +7108,8 @@ above are repeated here)
   itself when it answers true and leaving `#apply_skill_hit` completely
   unmodified otherwise. Not edition-gated, matching `#evades_all_physical?`'s
   own "trust the data" precedent (`HasReflectState` carries no
-  `Player::IsRPG2k3()` check either). **Scoped to a single-target Skill
-  only** (`#apply_command`, not `#apply_command_all`): real RPG_RT's own
-  `ReflectTargets` additionally redirects an all-enemies-scope skill onto
-  the caster's *entire* party the instant any one target in the group
-  reflects (`AddTargets(&source->GetParty(), true)`), on top of — not
-  instead of — the remaining un-reflected targets in that same group, a
-  materially different shape left unaddressed here. Covered by a new
+  `Player::IsRPG2k3()` check either). Scoped to a single-target Skill only
+  at the time (`#apply_command`, not `#apply_command_all`). Covered by a new
   `scripts/rpg2k_logic_check.rb` check (a Skill cast at a reflect-warded foe
   lands on the caster instead, HP/SP-cost accounting unaffected; an
   unafflicted target in the same fight is unaffected; the same redirect
@@ -7160,6 +7155,54 @@ above are repeated here)
   both confirmed to fail against the pre-fix code before the fix (an
   unrelated-state target dodging/reflecting exactly like a genuinely flagged
   one would).
+  ✅ **The all-enemies/all-allies-scope half is now implemented too,
+  verified against EasyRPG Player's actual C++ source rather than the
+  "on top of, not instead of" guess this entry originally carried — which
+  the source shows is backwards.** `AlgorithmBase::ReflectTargets`
+  (`src/game_battlealgorithm.cpp`) is called exactly once per action, before
+  its first target is ever hit (`Scene_Battle_Rpg2k::
+  ProcessBattleActionAnimationImpl`'s dispatch to it happens once per
+  action; `ProcessBattleActionFinished`'s own `TargetNext()` continuation
+  jumps straight to `BattleActionState_Execute` for every later target in
+  the same volley, skipping the Animation state — and thus this check —
+  entirely), and it scans forward from the *current* target
+  (`std::find_if(current_target, targets.end(), ...)`, i.e. every target
+  still to be hit, not merely the first) for the first one flagged Reflect
+  Magic. For a `party_target` action (`AlgorithmBase`'s
+  `Game_Party_Base*`-taking constructor — exactly RPG2000's all-enemies/
+  all-allies skill scope, this codebase's own `#apply_command_all`
+  counterpart) finding one calls `AddTargets(&source->GetParty(), true)`,
+  which both appends every member of the *caster's* own party to `targets`
+  and — the `true`/`set_current` argument — repoints `current_target` at
+  the first newly-appended entry. Since nothing removes the original,
+  not-yet-hit entries from the vector and a forward-only cursor can never
+  reach them again once it has jumped past their position to the new tail,
+  every originally-targeted battler this volley had not already hit goes
+  permanently unvisited — replaced outright by the caster's own side, not
+  layered alongside it. Fixed with a new `#reflecting_target_all(b, live,
+  cmd)` (`mruby-rpg2k/mrblib/game.rb`) — `#apply_command_all`'s own
+  `live`-scanning counterpart to `#reflects_skill?`, gated the identical way
+  (`cmd[:skill_id] && !cmd[:item_id]`, `side_of(target) != side_of(b)`) —
+  called right after the existing `dead?` filter builds `live`; when it
+  finds a reflecting entry, `live` is rebuilt from every *living* member of
+  `side_of(b)`'s own party instead, each one reusing the reflecting entry's
+  own already-computed `hp`/`mp` (the established simplification the
+  single-target fix above already committed to — the skill's raw magnitude
+  does not vary by which battler it was originally queued against), while
+  `#apply_skill_hit` still recomputes each hit's own elemental multiplier,
+  variance and absorb fresh against whichever new target it actually lands
+  on, unmodified. SP is charged exactly once either way, since `cmd[:cost]`
+  is spent (unconditionally, once) after the `live` list is finalized, the
+  same ordering the un-redirected path already had. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check exercising `#apply_command` directly
+  (an all-enemy Meteor with one warded and one unwarded foe redirects onto
+  the caster's whole living party instead of hitting either original foe,
+  each ally taking the reflecting foe's own precomputed damage, SP spent
+  once; a dead ally is excluded from the redirected side; an all-target Item
+  and an all-*ally* Skill — whose targets share the caster's own side to
+  begin with — never redirect even at an identically warded target),
+  confirmed to fail against the pre-fix code (`expected ["Ally", "Mage"],
+  got ["Plain Foe", "Warded Foe"]`) before the fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8237,10 +8237,8 @@ module Game
     # spent or #apply_skill_hit runs, so the skill's own cost/accuracy/damage
     # math is otherwise completely unaffected by which battler it ends up
     # landing on. Scoped to this single-target path only: an all-enemies-scope
-    # Skill's own reflect handling (#apply_command_all) is a materially
-    # different shape in real RPG_RT -- one reflecting target there redirects
-    # the *whole* group onto the caster's entire side, not just that one hit
-    # -- and is left unaddressed here.
+    # Skill's own reflect handling is a materially different shape in real
+    # RPG_RT -- see #apply_command_all, where it is now implemented too.
     def apply_command(b)
       cmd = b.command
       return apply_command_all(b, cmd) if cmd[:all]
@@ -8251,6 +8249,22 @@ module Game
       apply_skill_hit(b, target, cmd[:hp] || 0, cmd[:mp] || 0, cmd)
     end
 
+    # The first already-computed `{target:, hp:, mp:}` entry in `live` whose
+    # target carries Reflect Magic, or nil -- #apply_command_all's own
+    # counterpart to #reflects_skill?, scanning the *whole* volley (every
+    # target already selected for this Skill, `live`'s own definition order,
+    # matching EasyRPG's `std::find_if(current_target, targets.end(), ...)`
+    # in `AlgorithmBase::ReflectTargets`) rather than just one. Gated the
+    # same way #reflects_skill? is: only a real Skill reflects (never an
+    # Item), and only a volley aimed at the *opposite* side from `b` can ever
+    # hit a Reflect-Magic-warded battler in the first place -- an all-ally
+    # heal's own targets share `b`'s side, so `side_of` already excludes them
+    # without a separate scope check.
+    def reflecting_target_all(b, live, cmd)
+      return nil unless cmd[:skill_id] && !cmd[:item_id]
+      live.find { |t| side_of(t[:target]) != side_of(b) && reflects_magic?(t[:target]) }
+    end
+
     # An all-target Skill (scope 1 all enemies / 4 all allies): spend the SP once,
     # then apply the per-target effect to every living target, returning one log
     # entry per hit (which #step_action surfaces one at a time). Fizzles — nil, no
@@ -8258,9 +8272,31 @@ module Game
     # per-target `dead?` filter as #apply_command, and for the same reason: a
     # downed member of an all-ally heal is skipped rather than topped up back to
     # life (see #apply_command's comment).
+    #
+    # If any originally-selected target carries Reflect Magic
+    # (#reflecting_target_all), the whole volley redirects onto `b`'s own
+    # entire living side instead -- EasyRPG's `AlgorithmBase::ReflectTargets`
+    # calls `AddTargets(&source->GetParty(), true)` for exactly this
+    # `party_target` (all-enemies/all-allies scope) shape, which both adds
+    # the caster's whole party *and* repoints the still-to-execute cursor at
+    # it, so none of the originally-targeted battlers this bullet's own
+    # `live` list built end up hit at all -- replaced outright, not layered
+    # alongside them, the same way a reflected single-target Skill lands
+    # only on `b`, never on both `b` and the original target. Every
+    # redirected hit reuses the reflecting entry's own precomputed `hp`/`mp`
+    # (the #apply_command single-target fix's identical simplification --
+    # the skill's raw magnitude does not vary by which battler it was
+    # queued against), while #apply_skill_hit still recomputes each hit's
+    # own elemental multiplier/variance/absorb fresh against whichever new
+    # target it actually lands on.
     def apply_command_all(b, cmd)
       live = (cmd[:targets] || []).select { |t| t[:target] && !t[:target].dead? }
       return nil if live.empty?
+      reflected = reflecting_target_all(b, live, cmd)
+      if reflected
+        own_side = (side_of(b) == :ally ? @allies : @enemies).reject(&:dead?)
+        live = own_side.map { |t| { target: t, hp: reflected[:hp], mp: reflected[:mp] } }
+      end
       b.mp = [b.mp - cmd[:cost], 0].max if cmd[:cost] && cmd[:cost] > 0
       entries = live.map { |t| apply_skill_hit(b, t[:target], t[:hp] || 0, t[:mp] || 0, cmd) }
       # An all-ally item is consumed once for the whole volley: keep item_id on

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9636,6 +9636,73 @@ check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its o
      'a same-side (ally/self-scoped) skill never reflects, warded target or not'
 end
 
+check "battle: an all-enemy Skill's own reflect redirects the whole volley onto the caster's entire party" do
+  # EasyRPG's AlgorithmBase::ReflectTargets (game_battlealgorithm.cpp), for the
+  # `party_target` (all-enemies/all-allies scope) shape the single-target
+  # reflect fix's own comment names as a "materially different shape" left
+  # unaddressed: `AddTargets(&source->GetParty(), true)` both adds every
+  # member of the caster's own party as new targets *and* repoints the
+  # still-to-execute cursor there, so none of the volley's originally-selected
+  # enemies (this build's own cmd[:targets]) end up hit at all once any one of
+  # them carries Reflect Magic -- the caster's whole living side does, in
+  # their place, not merely the one foe that reflected.
+  # #apply_command is exercised directly (as #reflects_skill?'s own checks
+  # above do), sidestepping #step_action's round machinery entirely -- an
+  # enemy combatant with no 行動パターン and no queued command would
+  # otherwise take its own default swing at a random ally on its turn,
+  # noise this check has no interest in filtering back out.
+  states = { 20 => fake_state(reflect_magic: true) }
+  mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  ally = combatant('Ally', 0, 0, 5, 100)
+  warded_foe = combatant('Warded Foe', 0, 0, 5, 100)
+  warded_foe.states = [20]
+  plain_foe = combatant('Plain Foe', 0, 0, 5, 100)
+  bat = Game::Battle.new([mage, ally], [warded_foe, plain_foe], Game::Rng.new(1), states)
+  bat.command_skill_all(mage, [{ target: warded_foe, hp: -30 }, { target: plain_foe, hp: -30 }],
+                        name: 'Meteor', cost: 6, skill_id: 7)
+  entries = bat.send(:apply_command, mage)
+  eq ['Ally', 'Mage'], entries.map { |e| e[:target] }.sort,
+     "the whole volley lands on the caster's own party, not the two original foes"
+  eq [70, 70], [mage.hp, ally.hp], 'each ally eats the same -30 the reflecting foe would have taken'
+  eq 100, warded_foe.hp, 'the warded foe itself takes nothing'
+  eq 100, plain_foe.hp, 'the unwarded foe is untouched too -- the whole group redirects, not just the warded one'
+  eq 4, mage.mp, 'SP is still spent exactly once for the whole volley, reflected or not'
+
+  # A dead ally is skipped from the redirected side too, the same #dead?
+  # filter the un-reflected path already applies to its own targets.
+  dead_ally = combatant('Dead Ally', 0, 0, 5, 0)
+  mage2 = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  warded_foe2 = combatant('Warded Foe', 0, 0, 5, 100)
+  warded_foe2.states = [20]
+  plain_foe2 = combatant('Plain Foe', 0, 0, 5, 100)
+  bat2 = Game::Battle.new([mage2, dead_ally], [warded_foe2, plain_foe2], Game::Rng.new(1), states)
+  bat2.command_skill_all(mage2, [{ target: warded_foe2, hp: -30 }, { target: plain_foe2, hp: -30 }],
+                         name: 'Meteor', cost: 6, skill_id: 7)
+  entries2 = bat2.send(:apply_command, mage2)
+  eq ['Mage'], entries2.map { |e| e[:target] },
+     'only the one living party member -- the caster itself -- is hit, the dead ally never joins'
+
+  # Neither an all-target Item nor an all-*ally* Skill (never reaching the
+  # opposing side to begin with) ever redirects, even at an identically
+  # warded target.
+  mage3 = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  warded_foe3 = combatant('Warded Foe', 0, 0, 5, 100)
+  warded_foe3.states = [20]
+  bat3 = Game::Battle.new([mage3], [warded_foe3], Game::Rng.new(1), states)
+  bat3.command_item_all(mage3, [{ target: warded_foe3, hp: -30 }], item_id: 5, name: 'Bomb')
+  entries3 = bat3.send(:apply_command, mage3)
+  eq 'Warded Foe', entries3.first[:target], 'an all-target item never reflects, even at a warded foe'
+
+  healer = combatant_mp('Healer', 0, 0, 20, 100, 10)
+  mate = combatant('Mate', 0, 0, 5, 100); mate.hp = 60
+  mate.states = [20] # hypothetically warded -- irrelevant, same side as the caster
+  bat4 = Game::Battle.new([healer, mate], [combatant('Foe', 0, 0, 1, 1)], Game::Rng.new(1), states)
+  bat4.command_skill_all(healer, [{ target: mate, hp: 20 }], name: 'Heal', cost: 4, skill_id: 8)
+  entries4 = bat4.send(:apply_command, healer)
+  eq 'Mate', entries4.first[:target], "an all-ally heal never redirects -- its target shares the caster's own side"
+  eq 80, mate.hp
+end
+
 check 'battle: a normal attack can shake a state off its target' do
   states = { 10 => fake_state(release_by_attack: 100),  # always
              11 => fake_state(release_by_attack: 0) }   # never


### PR DESCRIPTION
## Summary

- An all-enemies/all-allies-scope Skill's own Reflect Magic (RPG2003) handling was never implemented — only the single-target reflect path (`#apply_command`) redirected onto the caster; `#apply_command_all` ignored the state entirely.
- Ported EasyRPG Player's `AlgorithmBase::ReflectTargets` (`src/game_battlealgorithm.cpp`, verified against a fresh clone of `EasyRPG/player`): the instant any still-pending target in the volley carries Reflect Magic, `AddTargets(&source->GetParty(), true)` both adds the caster's own party as new targets *and* repoints the still-to-execute cursor there — so every originally-targeted battler goes permanently unhit, **replaced outright by the caster's own side, not layered on top of it**. This corrects a "on top of, not instead of" guess the relevant `docs/TODO.md` entry had previously carried before this session traced the actual C++ control flow.
- New `Game::Battle#reflecting_target_all(b, live, cmd)` scans the volley's `live` list the same way `#reflects_skill?` gates a single target (`cmd[:skill_id] && !cmd[:item_id]`, `side_of(target) != side_of(b)`); `#apply_command_all` rebuilds `live` from every living member of the caster's own side when it fires, each reusing the reflecting entry's own precomputed `hp`/`mp` (matching the single-target fix's existing simplification), while `#apply_skill_hit` still recomputes elemental multiplier/variance/absorb fresh per new target.
- Rebased onto master to pick up PR #701's `state_field`→`state_flag` fix for `#evades_all_physical?`/`#reflects_magic?`, which this change builds on.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check exercising `Game::Battle#apply_command` directly: an all-enemy Meteor with one warded and one unwarded foe redirects onto the caster's whole living party (not either original foe), each ally taking the reflecting foe's own precomputed damage, SP spent once; a dead ally is excluded from the redirected side; an all-target Item and an all-*ally* Skill (whose targets already share the caster's own side) never redirect even against an identically warded target. Confirmed to fail against the pre-fix code (`git stash` of `game.rb` only) before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 769 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 480 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped (no test-bed game data available in this sandbox: network-restricted, no `./data` dir)
- [x] `ruby scripts/rpg2k_command_soak.rb` — skipped (same reason)
- [x] `docs/TODO.md` updated with a ✅ writeup citing the exact EasyRPG source mechanism
- [x] `changelog.d/reflect-magic-all-target.fixed.md` added


---
_Generated by [Claude Code](https://claude.ai/code/session_01XNSk3hpxXpcURFJANGgR3o)_