### PR TITLE
rpg2k: Continue resumes the save's own BGM instead of the map's default

### DIFF
--- a/changelog.d/continue-resumes-saved-bgm.fixed.md
+++ b/changelog.d/continue-resumes-saved-bgm.fixed.md
@@ -1,0 +1,18 @@
+- **Continue now resumes the save's own remembered BGM track instead of
+  recomputing it fresh from the map tree.** `Scene::Map#initialize` called
+  `#play_map_bgm` unconditionally regardless of `apply_access:` — the same
+  keyword `RPG2k#continue_game` already passes `false` for the analogous
+  Save/Teleport/Escape-access gap — so resuming a save with a Play BGM
+  override mid-flight (a boss theme playing over a field map whose own tree
+  default is an ordinary town track, say) wrongly snapped back to the map's
+  configured default instead of continuing what was actually playing.
+  Verified against EasyRPG Player's actual C++ source: `Scene_Map::Start`
+  only calls `Game_Map::PlayBgm()` (the map-tree walk) for a fresh map entry
+  — resuming a save instead stops whatever's playing and replays the save's
+  own remembered track verbatim, always restarted from the top. A new
+  `Scene::Map#resume_saved_bgm`, called from `#initialize` in place of
+  `#play_map_bgm` on Continue, plays `@state.current_bgm` (already restored
+  from the save) directly, bypassing the same-file skip that would otherwise
+  compare it to itself and never tell the audio backend to play anything.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks, confirmed to
+  fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4867,18 +4867,18 @@ not yet verified:
   vehicle's own BGM (`#play_vehicle_bgm`) owns the audio then, and
   `#restore_pre_vehicle_bgm` already resumes whatever this would have played
   once the party disembarks, so nothing here needed to special-case that
-  interaction beyond not firing into it. **Left open**: whether loading a
-  save (Continue) instead resumes the exact previously-playing track from the
-  save's own `current_music` field (which could differ from the destination
-  map's own default if a Play BGM override was mid-flight at save time)
-  rather than recomputing fresh from the map tree — the EasyRPG evidence
-  found this session confirms the recompute-from-tree behaviour for
-  `Game_Player::MoveTo` (new game and every Transfer Player) but not for
+  interaction beyond not firing into it. **Left open** (at the time): whether
+  loading a save (Continue) instead resumes the exact previously-playing
+  track from the save's own `current_music` field (which could differ from
+  the destination map's own default if a Play BGM override was mid-flight at
+  save time) rather than recomputing fresh from the map tree — the EasyRPG
+  evidence found in that session confirmed the recompute-from-tree behaviour
+  for `Game_Player::MoveTo` (new game and every Transfer Player) but not for
   `Game_Map::SetupFromSave`'s own load path, which was not traced far enough
-  to settle it either way; this fix applies the same recompute-from-tree
+  to settle it either way; that fix applied the same recompute-from-tree
   logic uniformly to `#initialize` (covering both New Game and Continue,
-  since `main.rb` constructs `Scene::Map` identically for both), which is the
-  best-supported reading available but not confirmed for Continue
+  since `main.rb` constructs `Scene::Map` identically for both), which was
+  the best-supported reading available but not confirmed for Continue
   specifically. Covered by nine new `scripts/rpg2k_logic_check.rb` checks
   pinning `Game::MapBgm.chunk_for`'s walk (type 2 plays the map's own file
   with its volume/pitch; type 1 leaves the current track alone even with a
@@ -4894,7 +4894,59 @@ not yet verified:
   `#perform_teleport`, including the same-file no-restart case and the
   type-1 leave-alone case; a boarded party gets no map-BGM call at all), the
   first logic check and the first scene check each confirmed to fail against
-  the pre-fix code before the fix.
+  the pre-fix code before the fix. ✅ **The "left open" Continue question
+  above is now settled and fixed, verified against EasyRPG Player's actual
+  C++ source rather than left as the "best-supported reading available" the
+  original fix admitted it was guessing at.** `Scene_Map::Start`
+  (`src/scene_map.cpp`) branches on `from_save_id`: a fresh map entry
+  (`from_save_id == 0`) calls `Game_Map::PlayBgm()` — the map-tree walk
+  `#play_map_bgm` above already ports — but resuming a save (`from_save_id >
+  0`) takes a completely different path instead: `auto current_music =
+  game_system->GetCurrentBGM(); game_system->BgmStop();
+  game_system->BgmPlay(current_music);` — the save's own remembered track
+  verbatim, not whatever the destination map's tree says, and always
+  restarted from the top (an explicit stop precedes the replay) even when it
+  happens to name the same file already "playing" at a fresh process start.
+  `Scene::Map#initialize` called `#play_map_bgm` unconditionally regardless
+  of `apply_access:` (the same keyword `main.rb`'s `RPG2k#continue_game`
+  already passes `false` for the analogous Save/Teleport/Escape-access gap,
+  see the "Continue could silently lose a save's own Save/Teleport/Escape
+  access" fix above), so a Continue whose save had a Play BGM override
+  mid-flight (a boss theme still playing over a field map whose own tree
+  default is an ordinary town track, say) wrongly snapped back to the map's
+  configured default the instant the scene was built, discarding
+  `@state.current_bgm` — already correctly restored from the save by
+  `Game::State.load`/`.from_lsd` — before it was ever heard. Fixed with a new
+  `Scene::Map#resume_saved_bgm`, called from `#initialize` in place of
+  `#play_map_bgm` exactly when `apply_access:` is false: it plays
+  `@state.current_bgm` directly through `RGSS::Audio.bgm_play`, bypassing
+  `#play_bgm`'s own same-file skip on purpose — that check would otherwise
+  compare `@state.current_bgm` to itself (it already *is* the target value,
+  restored before this scene exists) and conclude nothing needs to change,
+  leaving the native audio backend never actually told to play anything after
+  a fresh process start, the opposite of "always restarted from the top."
+  No boarded-vehicle special case is needed here (unlike `#play_map_bgm`,
+  which defers to `#play_vehicle_bgm`): `Scene_Map::Start`'s `from_save_id`
+  branch has no such check either, since `@state.current_bgm` already holds
+  whatever was actually playing at save time — the vehicle's own track
+  included, if that's what was live — so resuming it verbatim is correct
+  regardless of `@state.boarded?`. A save with nothing playing
+  (`current_bgm` nil, or an empty filename) plays nothing, matching the
+  ordinary "ends up not calling the backend" case elsewhere in this file.
+  `#play_map_bgm` itself, and every other caller (New Game, every Transfer
+  Player via `#perform_teleport`), is completely unaffected — the
+  recompute-from-tree behaviour that earlier fix already implemented for
+  those two cases was correct all along, confirmed by the same
+  `Scene_Map::Start` source that settles the Continue half. Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks (a Continue resume replays the
+  save's own tracked BGM instead of the destination map's tree default, with
+  a control case on the same fixture proving an ordinary, non-Continue entry
+  really would have played the map's default instead, pinning the branch as
+  Continue-specific; a Continue resumes correctly even while
+  `@state.boarded?` is true, and a Continue with no BGM playing at save time
+  plays nothing), both confirmed to fail against the pre-fix code (`expected
+  [["Boss Theme", 70, 120]], got [["Town", 90, 105]]`, and no boat BGM call
+  at all) before the fix.
 - SE is truly polyphonic (unlike BGM); ✅ **SE "OFF" now stops all playing
   SEs at once**, instead of silently doing nothing. `Game::Interpreter
   #play_audio` (`mruby-rpg2k/mrblib/interpreter.rb`) returned immediately on

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -99,7 +99,17 @@ class RPG2k
         @monster_cache = {}   # Monster/<name> (battler graphics)
         @animation_cache = {} # Battle/<name> (battle animation sheets)
         apply_map_access if apply_access
-        play_map_bgm
+        # Same Continue-only split as #apply_map_access just above: a fresh
+        # map entry (New Game, or any Transfer Player/Teleport, which
+        # #perform_teleport already calls #play_map_bgm for separately)
+        # recomputes BGM from the map tree, but a Continue resumes a state
+        # that already carries its own #current_bgm (restored by
+        # Game::State.load/.from_lsd from the save) -- see #resume_saved_bgm.
+        if apply_access
+          play_map_bgm
+        else
+          resume_saved_bgm
+        end
         @map = state.map
         @chipset = build_chipset
         @chipset_bmp = load_chipset_graphic
@@ -4220,6 +4230,33 @@ class RPG2k
         play_bgm(name: name, volume: music_volume(bgm), tempo: music_tempo(bgm))
       rescue StandardError => e
         $stderr.puts "[RPG2k] map BGM failed: #{e.message}"
+      end
+
+      # Continue's counterpart to #play_map_bgm, called instead of it when
+      # #initialize's apply_access: is false. Verified against EasyRPG
+      # Player's actual C++ source rather than guessed at: Scene_Map::Start
+      # (src/scene_map.cpp) branches on from_save_id -- a fresh map entry
+      # (from_save_id == 0) calls Game_Map::PlayBgm() (the map-tree walk
+      # #play_map_bgm already ports), but resuming a save
+      # (from_save_id > 0) instead does `auto current_music =
+      # game_system->GetCurrentBGM(); game_system->BgmStop();
+      # game_system->BgmPlay(current_music);` -- the save's own remembered
+      # track, not whatever the destination map's tree says, and always
+      # restarted from the top (an explicit stop before the replay) even if
+      # it happens to name the same file. @state.current_bgm already holds
+      # that exact value here -- Game::State.load/.from_lsd populate it
+      # straight from the save before this scene is ever constructed -- so
+      # this calls the native backend directly instead of going through
+      # #play_bgm, whose same-file check would otherwise compare
+      # @state.current_bgm to itself and skip the call outright, leaving
+      # nothing audible after a fresh process start.
+      def resume_saved_bgm
+        bgm = @state.current_bgm
+        return if bgm.nil? || bgm[:name].nil? || bgm[:name].empty?
+        RGSS::Audio.bgm_play(bgm[:name], bgm[:volume] || 100, bgm[:tempo] || 100)
+        @state.bgm_looped = false
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] saved BGM resume failed: #{e.message}"
       end
 
       # The backdrop named by the terrain of the tile at (x, y) — the database

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10381,6 +10381,59 @@ check 'Scene::Map does not auto-play the map BGM while the party is boarded' do
      "boarded: the ship's own BGM owns the audio, not the map's default"
 end
 
+check 'Scene::Map resumes the saved BGM on Continue (apply_access: false) ' \
+     'instead of recomputing it from the map tree' do
+  parent = fake_parent(fake_db)
+  parent.map_tree = fake_map_tree(
+    1 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Town', 90, 105), 0)
+  )
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  # A save resumed mid-visit with a Play BGM override still in effect --
+  # different from the destination map's own tree default ('Town' above).
+  state.current_bgm = { name: 'Boss Theme', volume: 70, tempo: 120 }
+  RGSS::Audio.reset_bgm
+  scene = RPG2k::Scene::Map.new(parent, state, apply_access: false)
+  eq [['Boss Theme', 70, 120]], RGSS::Audio.bgm_calls,
+     "Continue replays the save's own current_bgm, not the map's default"
+  eq 'Boss Theme', state.current_bgm[:name], 'and the tracked current BGM is unchanged'
+
+  # Confirms the map-tree default really would have played instead, if this
+  # were an ordinary (non-Continue) map entry -- pinning that the branch
+  # above is Continue-specific, not a change to #play_map_bgm itself.
+  state2 = Game::State.new(fake_party, 1, 0, 0)
+  state2.map = fake_map(1, {})
+  state2.current_bgm = { name: 'Boss Theme', volume: 70, tempo: 120 }
+  RGSS::Audio.reset_bgm
+  RPG2k::Scene::Map.new(parent, state2)
+  eq [['Town', 90, 105]], RGSS::Audio.bgm_calls,
+     'an ordinary (apply_access: true) entry recomputes from the tree instead'
+end
+
+check 'Scene::Map resumes the saved BGM on Continue even while boarded, ' \
+     'and plays nothing when no BGM was playing at save time' do
+  parent = fake_parent(fake_db)
+  parent.map_tree = fake_map_tree(
+    1 => FakeBgmTreeNode.new(2, FakeBgmChunk.new('Field', 100, 100), 0)
+  )
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, {})
+  state.boarded = :ship
+  state.current_bgm = { name: 'Sea Voyage', volume: 60, tempo: 100 }
+  RGSS::Audio.reset_bgm
+  RPG2k::Scene::Map.new(parent, state, apply_access: false)
+  eq [['Sea Voyage', 60, 100]], RGSS::Audio.bgm_calls,
+     "the save's own boat BGM resumes verbatim -- #play_map_bgm's boarded " \
+     'skip does not apply to this, separate, resume path'
+
+  state2 = Game::State.new(fake_party, 1, 0, 0)
+  state2.map = fake_map(1, {})
+  state2.current_bgm = nil
+  RGSS::Audio.reset_bgm
+  RPG2k::Scene::Map.new(parent, state2, apply_access: false)
+  eq [], RGSS::Audio.bgm_calls, 'nothing was playing at save time, so nothing plays now'
+end
+
 check 'Scene::EquipMenu: the slot list, actor and candidate cursors wrap around' do
   scene = menu_scene(RPG2k::Scene::EquipMenu, wrap_menu_state)
   eq 0, scene.instance_variable_get(:@slot_index), 'starts on the first slot'


### PR DESCRIPTION
## Summary

- `Scene::Map#initialize` called `#play_map_bgm` unconditionally, even for a Continue resume (`apply_access: false`), silently discarding a save's own `current_bgm` (e.g. a Play BGM override still in flight at save time) in favor of the destination map's tree default the instant the scene was built.
- This was an explicitly "left open" question from an earlier fix (see `docs/TODO.md`'s "A map's own configured BGM now actually auto-plays" entry), which admitted it applied the recompute-from-tree behavior to Continue as only a guess, not confirmed against real RPG_RT.
- Verified against EasyRPG Player's actual C++ source this round: `Scene_Map::Start` (`src/scene_map.cpp`) only calls `Game_Map::PlayBgm()` (the map-tree recompute) for a fresh map entry (`from_save_id == 0`). Resuming a save (`from_save_id > 0`) instead does `BgmStop(); BgmPlay(current_music)` — the save's own remembered track verbatim, always restarted from the top.
- Fixed with a new `Scene::Map#resume_saved_bgm`, called from `#initialize` in place of `#play_map_bgm` exactly when `apply_access:` is false (the same keyword `RPG2k#continue_game` already uses for the analogous Save/Teleport/Escape-access gap). It plays `@state.current_bgm` (already restored from the save by `Game::State.load`/`.from_lsd`) directly through the native backend, bypassing `#play_bgm`'s own same-file skip — which would otherwise compare `@state.current_bgm` to itself and never actually call the backend.
- `#play_map_bgm` itself (New Game, every Transfer Player) is unaffected — its recompute-from-tree behavior was already correct, just not for Continue.

## Test plan

- [x] Added two new `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against the pre-fix code (`git stash` of just `mruby-rpg2k/mrblib/scene/map.rb`) before the fix landed.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 773 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 484 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed.
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped (no test-bed data available in this sandbox; network-restricted).
- [x] `ruby scripts/rpg2k_command_soak.rb` — skipped (same reason).
- [x] Updated `docs/TODO.md` with a dense, evidence-citing writeup and a changelog fragment (`changelog.d/continue-resumes-saved-bgm.fixed.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao549N3q6zRWvYx9knx7be

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao549N3q6zRWvYx9knx7be)_