### PR TITLE
Add Zundamon message-window narration via bundled VOICEVOX CORE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,16 @@
 /assets/fonts/*
 !/assets/fonts/README.md
 
+# The offline VOICEVOX synthesis stack behind --zundamon_tts (~90 MiB: the
+# CORE C API library, its ONNX Runtime, the Open JTalk dictionary and
+# Zundamon's voice model) is fetched by
+# scripts/download-voicevox-zundamon.bash rather than committed, the same way.
+# Keep the checked-in README that explains what belongs there and how to get
+# it.
+/assets/.voicevox
+/assets/voicevox/*
+!/assets/voicevox/README.md
+
 # Runtime save artifacts written by the MV/websave (localStorage) shim.
 /save
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,8 @@ if(EMSCRIPTEN)
 endif()
 
 add_executable(${PROJECT_NAME} src/main.cxx src/sdl_input.cxx src/sdl_audio.cxx
-                               src/log_console.cxx src/error_dump.cxx)
+                               src/voicevox_tts.cxx src/log_console.cxx
+                               src/error_dump.cxx)
 target_link_libraries(
   ${PROJECT_NAME}
   mruby
@@ -289,6 +290,7 @@ target_link_libraries(
   gflags
   uni-algo::uni-algo
   qjs
+  ${CMAKE_DL_LIBS}
   ${GL_LIBS})
 target_include_directories(${PROJECT_NAME}
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rd/inicpp)
@@ -327,6 +329,19 @@ set(TIMIDITY_ASSET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/assets/timidity)
 target_compile_definitions(
   ${PROJECT_NAME}
   PRIVATE "RGSS_TIMIDITY_CFG_SOURCE=\"${TIMIDITY_ASSET_DIR}/timidity.cfg\"")
+
+# Zundamon (ずんだもん) message-window narration (--zundamon_tts,
+# src/voicevox_tts.cxx): a full offline VOICEVOX CORE synthesis stack --
+# the CORE C API library, its ONNX Runtime, the Open JTalk dictionary and
+# Zundamon's voice model -- dlopen()'d at run time, never a link-time
+# dependency. ~90 MiB, so it is downloaded by
+# scripts/download-voicevox-zundamon.bash rather than committed, the same
+# reasoning as the MIDI patch set above; the path is baked in unconditionally
+# and probed at run time for the same reason (a configure-time EXISTS check
+# would race the download).
+set(VOICEVOX_ASSET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/assets/voicevox)
+target_compile_definitions(
+  ${PROJECT_NAME} PRIVATE "RGSS_VOICEVOX_SOURCE_DIR=\"${VOICEVOX_ASSET_DIR}\"")
 
 # The default UI font, used when a project ships no font of its own -- otherwise
 # its windows draw with the fixed 12px shinonome bitmap font whatever size they

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,9 +277,9 @@ if(EMSCRIPTEN)
   add_custom_target(onigmo_clean DEPENDS "${ONIGMO_A}")
 endif()
 
-add_executable(${PROJECT_NAME} src/main.cxx src/sdl_input.cxx src/sdl_audio.cxx
-                               src/voicevox_tts.cxx src/log_console.cxx
-                               src/error_dump.cxx)
+add_executable(
+  ${PROJECT_NAME} src/main.cxx src/sdl_input.cxx src/sdl_audio.cxx
+                  src/voicevox_tts.cxx src/log_console.cxx src/error_dump.cxx)
 target_link_libraries(
   ${PROJECT_NAME}
   mruby
@@ -331,14 +331,13 @@ target_compile_definitions(
   PRIVATE "RGSS_TIMIDITY_CFG_SOURCE=\"${TIMIDITY_ASSET_DIR}/timidity.cfg\"")
 
 # Zundamon (ずんだもん) message-window narration (--zundamon_tts,
-# src/voicevox_tts.cxx): a full offline VOICEVOX CORE synthesis stack --
-# the CORE C API library, its ONNX Runtime, the Open JTalk dictionary and
-# Zundamon's voice model -- dlopen()'d at run time, never a link-time
-# dependency. ~90 MiB, so it is downloaded by
-# scripts/download-voicevox-zundamon.bash rather than committed, the same
-# reasoning as the MIDI patch set above; the path is baked in unconditionally
-# and probed at run time for the same reason (a configure-time EXISTS check
-# would race the download).
+# src/voicevox_tts.cxx): a full offline VOICEVOX CORE synthesis stack -- the
+# CORE C API library, its ONNX Runtime, the Open JTalk dictionary and Zundamon's
+# voice model -- dlopen()'d at run time, never a link-time dependency. ~90 MiB,
+# so it is downloaded by scripts/download-voicevox-zundamon.bash rather than
+# committed, the same reasoning as the MIDI patch set above; the path is baked
+# in unconditionally and probed at run time for the same reason (a
+# configure-time EXISTS check would race the download).
 set(VOICEVOX_ASSET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/assets/voicevox)
 target_compile_definitions(
   ${PROJECT_NAME} PRIVATE "RGSS_VOICEVOX_SOURCE_DIR=\"${VOICEVOX_ASSET_DIR}\"")

--- a/README.md
+++ b/README.md
@@ -681,9 +681,9 @@ part that explains it). Nothing else is collected.
   (`scripts/pack-timidity-data.py`, ADR 0031). Serving the page means serving
   `timidity.js` and those packages alongside `index.*`
 - **RPG2000/2003's message window can read itself aloud**, in Zundamon's
-  (ずんだもん) voice, opt-in via `--zundamon_tts`: each Show Text page's plain
-  text (control codes already expanded — actor names, variables) is spoken as
-  the page opens, through a bundled offline [VOICEVOX
+  (ずんだもん) voice, opt-in via `--zundamon_tts`: each Show Text/Show Choices
+  page's plain text (control codes already expanded — actor names, variables)
+  is spoken as the page opens, through a bundled offline [VOICEVOX
   CORE](https://github.com/VOICEVOX/voicevox_core) synthesis stack
   (`RGSS::Tts`) rather than a separate VOICEVOX Engine process or any network
   access at play time. The stack (~90 MiB: VOICEVOX CORE, its ONNX Runtime,
@@ -695,7 +695,14 @@ part that explains it). Nothing else is collected.
   ./rpg_maker_clone --zundamon_tts --game_dir path/to/game
   ```
 
-  With nothing downloaded (or on a build this feature does not cover —
+  `--zundamon_tts_style` picks among Zundamon's four bundled styles (3
+  ノーマル/normal — the default, 1 あまあま/sweet, 7 ツンツン/curt, 5
+  セクシー/sultry); `--zundamon_tts_speed`/`_pitch`/`_intonation`/`_volume`
+  tune the AudioQuery scale factors VOICEVOX itself exposes, each defaulting
+  to VOICEVOX's own neutral value. Reaching an entirely different VOICEVOX
+  character needs its own downloaded voice model, which the download script
+  above does not fetch. With nothing downloaded (or on a build this feature
+  does not cover —
   desktop native only; see `docs/adr/0046-zundamon-message-narration.md`) the
   flag logs why and the game runs exactly as it would without it
   (`RGSS::Tts.available?`). Audio generated this way must be credited

--- a/README.md
+++ b/README.md
@@ -680,6 +680,26 @@ part that explains it). Nothing else is collected.
   Pages' 25 MiB per-file limit so PR previews can deploy
   (`scripts/pack-timidity-data.py`, ADR 0031). Serving the page means serving
   `timidity.js` and those packages alongside `index.*`
+- **RPG2000/2003's message window can read itself aloud**, in Zundamon's
+  (ずんだもん) voice, opt-in via `--zundamon_tts`: each Show Text page's plain
+  text (control codes already expanded — actor names, variables) is spoken as
+  the page opens, through a bundled offline [VOICEVOX
+  CORE](https://github.com/VOICEVOX/voicevox_core) synthesis stack
+  (`RGSS::Tts`) rather than a separate VOICEVOX Engine process or any network
+  access at play time. The stack (~90 MiB: VOICEVOX CORE, its ONNX Runtime,
+  the Open JTalk dictionary and Zundamon's voice model) is downloaded rather
+  than committed:
+
+  ```sh
+  ./scripts/download-voicevox-zundamon.bash
+  ./rpg_maker_clone --zundamon_tts --game_dir path/to/game
+  ```
+
+  With nothing downloaded (or on a build this feature does not cover —
+  desktop native only; see `docs/adr/0046-zundamon-message-narration.md`) the
+  flag logs why and the game runs exactly as it would without it
+  (`RGSS::Tts.available?`). Audio generated this way must be credited
+  "VOICEVOX:ずんだもん" — see `assets/voicevox/README.md`
 
 ## TODO
 

--- a/assets/voicevox/README.md
+++ b/assets/voicevox/README.md
@@ -34,8 +34,24 @@ and the game runs exactly as it would without this feature.
 | `onnxruntime/lib/libvoicevox_onnxruntime.so` | The ONNX Runtime build CORE loads for inference |
 | `onnxruntime/TERMS.txt`            | Its usage terms                                         |
 | `dict/open_jtalk_dic_utf_8-1.11/`  | Open JTalk's UTF-8 dictionary (accent/pronunciation analysis for Japanese text) |
-| `models/0.vvm`                     | Zundamon's "ノーマル" (normal) voice model, style id 3   |
+| `models/0.vvm`                     | Zundamon's voice model — 4 styles, see below            |
 | `models/TERMS.txt`                 | Zundamon's usage terms — see Licensing below            |
+
+`0.vvm` is not one voice: it carries four of Zundamon's styles, selectable at
+run time with `--zundamon_tts_style` (default 3, ノーマル/normal):
+
+| Style id | Name (Japanese / English) |
+| -------- | -------------------------- |
+| 3        | ノーマル / normal (default) |
+| 1        | あまあま / sweet            |
+| 7        | ツンツン / curt              |
+| 5        | セクシー / sultry            |
+
+`--zundamon_tts_speed`/`_pitch`/`_intonation`/`_volume` further tune the
+AudioQuery scale factors VOICEVOX itself exposes (see `docs/adr/0046-…md`);
+these apply on top of whichever style is selected. Reaching an entirely
+different VOICEVOX character (not just another Zundamon style) needs its own
+`.vvm`, which this script does not fetch.
 
 `include/voicevox_core_capi.hxx` is a small, hand-trimmed mirror of
 `core/include/voicevox_core.h` covering only the ~10 declarations

--- a/assets/voicevox/README.md
+++ b/assets/voicevox/README.md
@@ -1,0 +1,83 @@
+# Zundamon text-to-speech (VOICEVOX CORE)
+
+This directory holds the offline synthesis stack behind `--zundamon_tts`
+(rpg2k message-window narration in Zundamon's voice, `src/voicevox_tts.cxx`).
+It is empty in a fresh checkout — everything except this README is
+downloaded:
+
+```sh
+./scripts/download-voicevox-zundamon.bash
+```
+
+## Why it is needed
+
+Reading a Show Text page's text aloud needs a real Japanese speech
+synthesizer, not just an audio backend. VOICEVOX CORE is that synthesizer: a
+native library (Rust, built as a C API) that turns UTF-8 text into a WAV
+waveform in a chosen character's voice, running an ONNX Runtime model
+entirely offline — no VOICEVOX Engine process, no network access at play
+time.
+
+`src/voicevox_tts.cxx` `dlopen()`s the pieces below at run time; none of this
+is a build-time (link-time) dependency, the same way SDL_mixer's MIDI patch
+set (`assets/timidity`) is an optional run-time asset rather than a linked
+library. With nothing installed here, `RGSS::Tts.available?` is simply false
+and the game runs exactly as it would without this feature.
+
+## What the script installs
+
+| Path                              | What it is                                             |
+| ---------------------------------- | ------------------------------------------------------- |
+| `core/lib/libvoicevox_core.so`     | VOICEVOX CORE's C API shared library                    |
+| `core/include/voicevox_core.h`     | Its full public header (reference only — see below)     |
+| `core/LICENSE`                     | MIT — VOICEVOX CORE's own license                       |
+| `onnxruntime/lib/libvoicevox_onnxruntime.so` | The ONNX Runtime build CORE loads for inference |
+| `onnxruntime/TERMS.txt`            | Its usage terms                                         |
+| `dict/open_jtalk_dic_utf_8-1.11/`  | Open JTalk's UTF-8 dictionary (accent/pronunciation analysis for Japanese text) |
+| `models/0.vvm`                     | Zundamon's "ノーマル" (normal) voice model, style id 3   |
+| `models/TERMS.txt`                 | Zundamon's usage terms — see Licensing below            |
+
+`include/voicevox_core_capi.hxx` is a small, hand-trimmed mirror of
+`core/include/voicevox_core.h` covering only the ~10 declarations
+`src/voicevox_tts.cxx` calls via `dlsym()`; it is committed (it costs nothing
+to build against, unlike the library itself) so the engine compiles with or
+without this directory present.
+
+## Provenance and licensing
+
+All four pieces are pinned GitHub release assets, so the bytes are immutable
+and checksummable — the script verifies a SHA-256 for each before installing
+it. The CORE, ONNX Runtime and VVM versions are pinned *together*: a `.vvm`
+file's format version only loads on a CORE build new enough to understand it,
+and CORE expects a specific ONNX Runtime build — see the version-pinning note
+at the top of `scripts/download-voicevox-zundamon.bash` before bumping any
+one of them on its own.
+
+- **VOICEVOX CORE** — [`VOICEVOX/voicevox_core`](https://github.com/VOICEVOX/voicevox_core),
+  MIT licensed.
+- **ONNX Runtime** — [`VOICEVOX/onnxruntime-builder`](https://github.com/VOICEVOX/onnxruntime-builder)'s
+  CPU build (`voicevox_onnxruntime`); its own terms travel in
+  `onnxruntime/TERMS.txt`.
+- **Open JTalk dictionary** — [`r9y9/open_jtalk`](https://github.com/r9y9/open_jtalk),
+  the standard UTF-8 dictionary release also used by the reference VOICEVOX
+  Engine.
+- **Zundamon's voice model** — [`VOICEVOX/voicevox_vvm`](https://github.com/VOICEVOX/voicevox_vvm),
+  the single `0.vvm` file covering the "ノーマル" style (style id 3), not the
+  whole multi-character model pack.
+
+**Audio generated with Zundamon's voice model must be credited as
+"VOICEVOX:ずんだもん"**, in commercial or non-commercial use alike — this is a
+property of the voice model itself (see `models/TERMS.txt` after
+downloading, or
+[voicevox_vvm's README](https://github.com/VOICEVOX/voicevox_vvm/blob/main/README.md)),
+not a repository-specific requirement, and it applies to any game built with
+`--zundamon_tts` the same way it would apply to a video made with the
+reference VOICEVOX Engine.
+
+## Platform coverage
+
+Desktop native only (Linux/macOS `dlopen`); Emscripten, PSP and Wio Terminal
+builds compile the same source file down to two no-op functions (VOICEVOX
+CORE ships no port for any of the three). `--zundamon_tts` on one of those
+builds logs why and the game runs silently, same as a native build with
+nothing downloaded here.

--- a/changelog.d/zundamon-choices-and-voice-params.added.md
+++ b/changelog.d/zundamon-choices-and-voice-params.added.md
@@ -1,0 +1,6 @@
+- `--zundamon_tts` now speaks **Show Choices** as well as Show Text (both a
+  standalone choice window and one merged onto a preceding Show Text), and
+  gained `--zundamon_tts_style` (pick among Zundamon's four bundled styles:
+  ノーマル/normal, あまあま/sweet, ツンツン/curt, セクシー/sultry) and
+  `--zundamon_tts_speed`/`_pitch`/`_intonation`/`_volume` (VOICEVOX's own
+  AudioQuery scale factors, each defaulting to its neutral value).

--- a/changelog.d/zundamon-message-narration.added.md
+++ b/changelog.d/zundamon-message-narration.added.md
@@ -1,0 +1,10 @@
+- **rpg2k message-window narration in Zundamon's (ずんだもん) voice**, opt-in
+  via `--zundamon_tts`: each Show Text page's plain, fully-expanded text is
+  read aloud as it opens, through a bundled offline VOICEVOX CORE synthesis
+  stack (`RGSS::Tts`, `src/voicevox_tts.cxx`) rather than a separate VOICEVOX
+  Engine process. The stack (~90 MiB — CORE, its ONNX Runtime, the Open JTalk
+  dictionary and Zundamon's voice model) is fetched by
+  `scripts/download-voicevox-zundamon.bash` rather than committed; with
+  nothing downloaded (or on a platform this feature does not cover) the flag
+  logs why and the game runs exactly as it would without it. See
+  `docs/adr/0046-zundamon-message-narration.md`.

--- a/docs/adr/0046-zundamon-message-narration.md
+++ b/docs/adr/0046-zundamon-message-narration.md
@@ -90,10 +90,19 @@ not have.
   That obligation belongs to whoever ships a build with `--zundamon_tts`
   enabled, the same way it would apply to a video made with the reference
   VOICEVOX Engine — the engine does not enforce or automate it.
-- **One voice, one style, no runtime choice.** `kZundamonNormalStyleId = 3`
-  is a compile-time constant in `src/voicevox_tts.cxx`. Supporting another
-  character or style means downloading another `.vvm` and either adding a
-  config knob or a second bundled model; neither exists yet.
+- **Style and voice tuning is runtime-selectable, one character deep.**
+  `--zundamon_tts_style` picks among the four styles Zundamon's one bundled
+  `.vvm` already carries (ノーマル/あまあま/ツンツン/セクシー — style ids
+  3/1/7/5), and `--zundamon_tts_speed`/`_pitch`/`_intonation`/`_volume` tune
+  VOICEVOX's own AudioQuery scale factors (`speak_fn` in
+  `src/voicevox_tts.cxx` builds the query via
+  `voicevox_synthesizer_create_audio_query`, patches those four fields with a
+  plain substring scan rather than a JSON library — CORE's own serde output
+  is always a bare unquoted number there — then calls
+  `voicevox_synthesizer_synthesis` instead of the simpler `tts()`
+  convenience function, which has no way to carry them). Reaching a
+  *different* VOICEVOX character still means downloading another `.vvm` and
+  loading it as a second model; that does not exist yet.
 - **Windows is unsupported**, matching this engine's existing scope (no
   `CMakeLists.txt` branch targets it at all — Windows-under-RPG_RT is only
   ever exercised via wine for render-parity comparisons, never as a native

--- a/docs/adr/0046-zundamon-message-narration.md
+++ b/docs/adr/0046-zundamon-message-narration.md
@@ -1,0 +1,119 @@
+# 46. Zundamon (ずんだもん) message-window narration via bundled VOICEVOX CORE
+
+Date: 2026-08-14
+
+## Status
+
+Accepted
+
+## Context
+
+A request came in to read the rpg2k message window's text aloud in Zundamon's
+voice ("ずんだもん読み上げ") as an accessibility/flavour feature. That needs a
+real Japanese speech synthesizer somewhere in the pipeline; three shapes were
+considered:
+
+- **A local VOICEVOX Engine over HTTP.** The usual way "ずんだもん読み上げ"
+  integrations work: POST text to a VOICEVOX Engine process the player runs
+  separately (`/audio_query` then `/synthesis`, default
+  `http://127.0.0.1:50021`) and play back the WAV it returns. Needs a new
+  network-client dependency (this engine links no HTTP client anywhere today)
+  and a separate process the player has to keep running; nothing works
+  offline or in a packaged build with nobody around to start an engine.
+- **A pluggable interface with no real backend wired up.** Cheap, but leaves
+  the game silent — not what was asked for.
+- **Bundle a full synthesis stack.** VOICEVOX CORE (the same inference engine
+  the reference Engine wraps) ships as a small, dlopen-able native library
+  with per-character voice models distributed separately, all under open
+  licenses. Heavier to integrate than an HTTP call, but works fully offline,
+  adds no new build-time dependency, and needs nothing else running.
+
+## Decision
+
+**Bundle VOICEVOX CORE, dlopen'd at run time, never linked at build time** —
+the same posture this engine already takes with SDL_mixer's MIDI patch set
+(ADR 0026): an optional, downloaded run-time asset that a build can simply
+not have.
+
+- `scripts/download-voicevox-zundamon.bash` fetches four pinned GitHub
+  release assets into `assets/voicevox/` (git-ignored, ~90 MiB — see
+  `assets/voicevox/README.md` for exactly what and why): VOICEVOX CORE's C
+  API library, its ONNX Runtime, the Open JTalk dictionary it uses for
+  Japanese text analysis, and **one voice model** — Zundamon's `0.vvm`
+  (style id 3, "ノーマル") from `VOICEVOX/voicevox_vvm` — rather than that
+  project's whole multi-character model pack.
+- `src/voicevox_tts.cxx` `dlopen()`s `libvoicevox_core.so` and `dlsym()`s the
+  ~10 C API entry points it needs against a hand-trimmed, committed mirror of
+  the real header (`include/voicevox_core_capi.hxx`), so **the engine builds
+  identically whether or not the assets are present**. With nothing
+  downloaded, `RGSS::Tts.available?` is false and every call is a no-op —
+  exactly `RGSS::Audio.midi_available?`'s shape for a missing patch set.
+- The feature is **opt-in**, `--zundamon_tts` (off by default): loading an
+  ONNX Runtime session costs real startup time and the assets are not
+  committed, so a released game or an existing CI run is unaffected either
+  way. Passing the flag with no assets installed just logs why and runs
+  silently — never a crash, never a hard requirement.
+- `RGSS::Tts` (mruby-rgss, mirroring `RGSS::Audio`'s
+  gem/executable split — see `include/rgss_audio.hxx`'s own header comment)
+  exposes `speak(text)` / `available?` / `stop` through a plain C function
+  table (`include/rgss_tts.hxx`) so the gem itself never depends on VOICEVOX
+  CORE, SDL or `dlopen` — it stays buildable for the terminal-only,
+  Emscripten and standalone `rake test` targets exactly as before.
+- **rpg2k's message window is the only caller.** `open_message` in
+  `mruby-rpg2k/mrblib/scene/map.rb` already computes `plain` — each line's
+  text with `\v[n]`/`\n[n]`/colour codes fully resolved, the same string the
+  typewriter reveal counts characters against — and hands the joined page to
+  `RGSS::Tts.speak` once, when a Show Text page opens (not per revealed
+  character, and not for a bare Show Choices window).
+- Synthesized audio plays through **SDL_mixer directly** (`Mix_PlayChannel`
+  on an unreserved channel, the same pool `Play SE` uses), not through
+  `RgssAudioBackend`: at most one utterance is ever in flight, since a new
+  page's narration replaces whatever the previous page started, so the
+  module tracks a single outstanding `Mix_Chunk` rather than reusing
+  `RgssAudioBackend.se_play_mem`'s cache-forever-by-name design (which would
+  otherwise leak one chunk per distinct line of dialogue for the life of the
+  process).
+- **Desktop native only** (Linux/macOS `dlopen`). VOICEVOX CORE ships no
+  Emscripten, PSP or Wio Terminal port, so `src/voicevox_tts.cxx` compiles to
+  two no-op functions there via `#if !defined(__EMSCRIPTEN__) &&
+  (defined(__linux__) || defined(__APPLE__))`, and the one `add_executable`
+  target shared by the native and Emscripten builds needs no conditional
+  source list.
+
+## Consequences
+
+- **Licensing carries forward, not just downward.** Zundamon's voice model
+  requires crediting **"VOICEVOX:ずんだもん"** wherever generated audio is
+  used, commercial or not (`assets/voicevox/models/TERMS.txt`, written by the
+  download script; full terms at
+  [voicevox_vvm's README](https://github.com/VOICEVOX/voicevox_vvm/blob/main/README.md)).
+  That obligation belongs to whoever ships a build with `--zundamon_tts`
+  enabled, the same way it would apply to a video made with the reference
+  VOICEVOX Engine — the engine does not enforce or automate it.
+- **One voice, one style, no runtime choice.** `kZundamonNormalStyleId = 3`
+  is a compile-time constant in `src/voicevox_tts.cxx`. Supporting another
+  character or style means downloading another `.vvm` and either adding a
+  config knob or a second bundled model; neither exists yet.
+- **Windows is unsupported**, matching this engine's existing scope (no
+  `CMakeLists.txt` branch targets it at all — Windows-under-RPG_RT is only
+  ever exercised via wine for render-parity comparisons, never as a native
+  build of this engine). Adding it means an `LoadLibraryExW`/`GetProcAddress`
+  path alongside the POSIX `dlopen` one.
+- **GPU acceleration is out of scope.** `VOICEVOX_ACCELERATION_MODE_CPU` is
+  hard-coded; VOICEVOX CORE's CUDA/DirectML builds need the separate
+  `voicevox_additional_libraries` archive the download script does not fetch.
+- **No CI job downloads these assets.** Unlike the MIDI patch set and the
+  default font, `.github/workflows/build.yml` does not call
+  `download-voicevox-zundamon.bash` — the assets are large, span three
+  external GitHub organizations, and the feature is opt-in flavour rather
+  than something most CI checks exercise. `scripts/check_voicevox_assets.rb`
+  still validates the layout when the assets *are* present (a developer's
+  local checkout) and exits 0 cleanly when they are not, the same shape as
+  `check_default_font.rb`.
+- **The CI CORS-proxy cache (`CORS_PROXY_URL`, ADR 0042/0043) does not yet
+  allow these hosts.** The download script routes through it exactly like
+  its siblings, so once someone wants this feature exercised in a
+  network-restricted CI environment, the Cloudflare Worker's `ALLOWED_HOSTS`
+  needs `github.com` (already implied for other download scripts) to reach
+  release assets on `VOICEVOX/voicevox_core`, `VOICEVOX/onnxruntime-builder`,
+  `VOICEVOX/voicevox_vvm` and `r9y9/open_jtalk`.

--- a/include/rgss_tts.hxx
+++ b/include/rgss_tts.hxx
@@ -1,0 +1,48 @@
+// Text-to-speech backend interface shared between the mruby-rgss gem and the
+// executable, mirroring rgss_audio.hxx's split: the gem must not depend on
+// VOICEVOX CORE or SDL, so RGSS::Tts's native methods (mruby-rgss/src/tts.cxx)
+// call through this function-pointer table instead of touching either
+// directly, and the executable installs the real implementation
+// (src/voicevox_tts.cxx) at startup via rgss_tts_install_backend(). When no
+// backend is installed (tests, a build without --zundamon_tts, or a platform
+// this feature does not cover) every Tts call is a graceful no-op.
+//
+// This header intentionally uses only plain C types so both sides can include
+// it without pulling in mruby, SDL or VOICEVOX CORE headers.
+
+#ifndef RGSS_TTS_HXX
+#define RGSS_TTS_HXX
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct RgssTtsBackend {
+  // Whether synthesis is actually usable -- the VOICEVOX CORE library, its
+  // ONNX Runtime, the Open JTalk dictionary and the Zundamon voice model all
+  // loaded. False for any missing/broken piece (see src/voicevox_tts.cxx),
+  // which is what RGSS::Tts.available? reports so calling code can skip
+  // speak() rather than have it silently do nothing every time.
+  int (*available)(void);
+
+  // Synthesize `utf8_text` in Zundamon's voice and play it once, replacing
+  // whatever utterance is still playing (a new message page's narration
+  // supersedes the previous one, the same way starting a new BGM replaces the
+  // one already playing). A no-op if synthesis or playback fails; the failure
+  // is logged, not raised, so a missing/broken TTS stack never interrupts the
+  // game.
+  void (*speak)(const char* utf8_text);
+
+  // Stop whatever utterance is currently playing.
+  void (*stop)(void);
+};
+
+// Install (copy) the backend, or detach it by passing null. Safe to call
+// before mruby is initialised; the table is stored in a plain global.
+void rgss_tts_install_backend(const struct RgssTtsBackend* backend);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RGSS_TTS_HXX

--- a/include/voicevox_core_capi.hxx
+++ b/include/voicevox_core_capi.hxx
@@ -72,6 +72,14 @@ typedef struct VoicevoxTtsOptions {
   bool enable_interrogative_upspeak;
 } VoicevoxTtsOptions;
 
+// Same shape as VoicevoxTtsOptions, but this is
+// voicevox_synthesizer_synthesis's own options type (the AudioQuery-based path
+// used to tune speed/pitch/ intonation/volume -- see set_json_number in
+// src/voicevox_tts.cxx).
+typedef struct VoicevoxSynthesisOptions {
+  bool enable_interrogative_upspeak;
+} VoicevoxSynthesisOptions;
+
 // -- function pointer types, one per dlsym()'d entry point ------------------
 // (voicevox_core.h declares these as plain functions; src/voicevox_tts.cxx
 // dlsym()s each symbol name into a pointer of the matching type below.)
@@ -118,6 +126,26 @@ typedef VoicevoxResultCode (*VoicevoxSynthesizerTtsFn)(
     uintptr_t* output_wav_length,
     uint8_t** output_wav);
 typedef void (*VoicevoxWavFreeFn)(uint8_t* wav);
+
+// The two-step path (AudioQuery JSON -> synthesis), used instead of the plain
+// tts() convenience function whenever speed/pitch/intonation/volume are
+// tuned away from their defaults -- those are AudioQuery fields, not
+// VoicevoxTtsOptions ones, so tts() has no way to carry them.
+typedef VoicevoxResultCode (*VoicevoxSynthesizerCreateAudioQueryFn)(
+    const struct VoicevoxSynthesizer* synthesizer,
+    const char* text,
+    VoicevoxStyleId style_id,
+    char** output_audio_query_json);
+typedef struct VoicevoxSynthesisOptions (
+    *VoicevoxMakeDefaultSynthesisOptionsFn)(void);
+typedef VoicevoxResultCode (*VoicevoxSynthesizerSynthesisFn)(
+    const struct VoicevoxSynthesizer* synthesizer,
+    const char* audio_query_json,
+    VoicevoxStyleId style_id,
+    struct VoicevoxSynthesisOptions options,
+    uintptr_t* output_wav_length,
+    uint8_t** output_wav);
+typedef void (*VoicevoxJsonFreeFn)(char* json);
 
 typedef const char* (*VoicevoxErrorResultToMessageFn)(
     VoicevoxResultCode result_code);

--- a/include/voicevox_core_capi.hxx
+++ b/include/voicevox_core_capi.hxx
@@ -1,0 +1,129 @@
+// A trimmed mirror of VOICEVOX CORE's public C API (voicevox_core.h from the
+// VOICEVOX/voicevox_core project, MIT licensed), covering only the ~10
+// declarations src/voicevox_tts.cxx needs for one-shot text-to-speech: load
+// the ONNX Runtime, construct an OpenJtalkRc + Synthesizer, load a .vvm voice
+// model, and call the synthesizer's own `tts()` convenience entry point.
+//
+// This header exists so the engine can be *built* without VOICEVOX CORE
+// present at all (no assets/voicevox/ downloaded, no configure-time
+// find_library): src/voicevox_tts.cxx dlopen()s libvoicevox_core.so and
+// dlsym()s each function against these prototypes at run time, exactly the
+// way SDL_mixer's own MIDI patch set is an optional run-time asset rather
+// than a build dependency (see src/sdl_audio.cxx's init_midi_config). The
+// real, full header ships inside the downloaded archive at
+// assets/voicevox/core/include/voicevox_core.h for reference; these
+// declarations are trimmed to (and must stay binary-compatible with) VOICEVOX
+// CORE 0.17.x's C API, which is what scripts/download-voicevox-zundamon.bash
+// pins (0.16.x's `voicevox_synthesizer_load_voice_model` took two arguments,
+// not three, and could not read the newer `vvm_format_version=2` files
+// voicevox_vvm now ships -- see that script's version-pinning note).
+//
+// Struct layouts below match voicevox_core.h field-for-field: these are
+// passed by value across the dlopen boundary, so the layout must be exact.
+
+#ifndef VOICEVOX_CORE_CAPI_HXX
+#define VOICEVOX_CORE_CAPI_HXX
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int32_t VoicevoxResultCode;
+enum {
+  VOICEVOX_RESULT_OK = 0,
+};
+
+typedef int32_t VoicevoxAccelerationMode;
+enum {
+  VOICEVOX_ACCELERATION_MODE_AUTO = 0,
+  VOICEVOX_ACCELERATION_MODE_CPU = 1,
+};
+
+typedef struct OpenJtalkRc OpenJtalkRc;
+typedef struct VoicevoxOnnxruntime VoicevoxOnnxruntime;
+typedef struct VoicevoxSynthesizer VoicevoxSynthesizer;
+typedef struct VoicevoxVoiceModelFile VoicevoxVoiceModelFile;
+
+typedef uint32_t VoicevoxStyleId;
+
+typedef struct VoicevoxLoadOnnxruntimeOptions {
+  const char* filename;
+} VoicevoxLoadOnnxruntimeOptions;
+
+typedef struct VoicevoxInitializeOptions {
+  VoicevoxAccelerationMode acceleration_mode;
+  uint16_t cpu_num_threads;
+} VoicevoxInitializeOptions;
+
+typedef int32_t VoicevoxOnExistingVoiceModelId;
+enum {
+  VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR = 0,
+};
+
+typedef struct VoicevoxLoadVoiceModelOptions {
+  VoicevoxOnExistingVoiceModelId on_existing;
+} VoicevoxLoadVoiceModelOptions;
+
+typedef struct VoicevoxTtsOptions {
+  bool enable_interrogative_upspeak;
+} VoicevoxTtsOptions;
+
+// -- function pointer types, one per dlsym()'d entry point ------------------
+// (voicevox_core.h declares these as plain functions; src/voicevox_tts.cxx
+// dlsym()s each symbol name into a pointer of the matching type below.)
+
+typedef struct VoicevoxLoadOnnxruntimeOptions (
+    *VoicevoxMakeDefaultLoadOnnxruntimeOptionsFn)(void);
+typedef VoicevoxResultCode (*VoicevoxOnnxruntimeLoadOnceFn)(
+    struct VoicevoxLoadOnnxruntimeOptions options,
+    const struct VoicevoxOnnxruntime** out_onnxruntime);
+
+typedef VoicevoxResultCode (*VoicevoxOpenJtalkRcNewFn)(
+    const char* open_jtalk_dic_dir,
+    struct OpenJtalkRc** out_open_jtalk);
+typedef void (*VoicevoxOpenJtalkRcDeleteFn)(struct OpenJtalkRc* open_jtalk);
+
+typedef struct VoicevoxInitializeOptions (
+    *VoicevoxMakeDefaultInitializeOptionsFn)(void);
+typedef VoicevoxResultCode (*VoicevoxSynthesizerNewFn)(
+    const struct VoicevoxOnnxruntime* onnxruntime,
+    const struct OpenJtalkRc* open_jtalk,
+    struct VoicevoxInitializeOptions options,
+    struct VoicevoxSynthesizer** out_synthesizer);
+typedef void (*VoicevoxSynthesizerDeleteFn)(
+    struct VoicevoxSynthesizer* synthesizer);
+
+typedef VoicevoxResultCode (*VoicevoxVoiceModelFileOpenFn)(
+    const char* path,
+    struct VoicevoxVoiceModelFile** out_model);
+typedef void (*VoicevoxVoiceModelFileDeleteFn)(
+    struct VoicevoxVoiceModelFile* model);
+typedef struct VoicevoxLoadVoiceModelOptions (
+    *VoicevoxMakeDefaultLoadVoiceModelOptionsFn)(void);
+typedef VoicevoxResultCode (*VoicevoxSynthesizerLoadVoiceModelFn)(
+    const struct VoicevoxSynthesizer* synthesizer,
+    const struct VoicevoxVoiceModelFile* model,
+    struct VoicevoxLoadVoiceModelOptions options);
+
+typedef struct VoicevoxTtsOptions (*VoicevoxMakeDefaultTtsOptionsFn)(void);
+typedef VoicevoxResultCode (*VoicevoxSynthesizerTtsFn)(
+    const struct VoicevoxSynthesizer* synthesizer,
+    const char* text,
+    VoicevoxStyleId style_id,
+    struct VoicevoxTtsOptions options,
+    uintptr_t* output_wav_length,
+    uint8_t** output_wav);
+typedef void (*VoicevoxWavFreeFn)(uint8_t* wav);
+
+typedef const char* (*VoicevoxErrorResultToMessageFn)(
+    VoicevoxResultCode result_code);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // VOICEVOX_CORE_CAPI_HXX

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -72,6 +72,10 @@ extern "C" int rgss_mouse_pressed(void);
 void rgss_audio_define(mrb_state* M, RClass* rgss);
 extern "C" void rgss_audio_frame(void);
 
+// Defined in tts.cxx (same gem). Registers the native RGSS::Tts methods (a
+// no-op backend when --zundamon_tts was not passed).
+void rgss_tts_define(mrb_state* M, RClass* rgss);
+
 #if defined(WIO_TERMINAL)
 // Defined in wio_input_bridge.cxx; scans the board's buttons/5-way switch and
 // forwards press/release edges to RGSS::Input.  Guarded so the desktop/wasm
@@ -6210,6 +6214,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   profiler_init(M);
 
   rgss_audio_define(M, m);
+  rgss_tts_define(M, m);
 
   define_rect(M, m);
 }

--- a/mruby-rgss/src/tts.cxx
+++ b/mruby-rgss/src/tts.cxx
@@ -1,0 +1,66 @@
+// RGSS::Tts native methods (gem side): Zundamon (ずんだもん) text-to-speech
+// narration, used by the rpg2k message window (mruby-rpg2k/mrblib/scene/
+// map.rb) to read a Show Text page's plain, fully-expanded text aloud.
+//
+// These are thin forwarders onto an RgssTtsBackend function table (see
+// include/rgss_tts.hxx), mirroring audio.cxx's split from RgssAudioBackend:
+// the executable installs a VOICEVOX CORE-based backend at startup
+// (src/voicevox_tts.cxx) only when --zundamon_tts was passed and the assets
+// are present; otherwise -- the common case -- every method here is a
+// graceful no-op, so a script calling RGSS::Tts never has to check whether
+// the feature is even compiled in. Keeping VOICEVOX CORE out of the gem is
+// deliberate for the same reason SDL is kept out of it: the gem is also built
+// for the terminal-only and emscripten variants and the standalone `rake
+// test` binary, none of which link it.
+
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/string.h>
+
+#include "rgss_tts.hxx"
+
+namespace {
+
+// The installed backend, or an all-null table when nothing is installed.
+// Every entry point checks the relevant pointer before calling, so the
+// uninstalled state is a safe no-op.
+RgssTtsBackend g_backend = {};
+
+mrb_value tts_available(mrb_state* M, mrb_value self) {
+  bool ok = g_backend.available && g_backend.available() != 0;
+  return mrb_bool_value(ok);
+}
+
+mrb_value tts_speak(mrb_state* M, mrb_value self) {
+  const char* text;
+  mrb_get_args(M, "z", &text);
+  if (g_backend.speak)
+    g_backend.speak(text);
+  return mrb_nil_value();
+}
+
+mrb_value tts_stop(mrb_state* M, mrb_value self) {
+  if (g_backend.stop)
+    g_backend.stop();
+  return mrb_nil_value();
+}
+
+}  // namespace
+
+// Install (copy) the backend table, or clear it when passed null.
+extern "C" void rgss_tts_install_backend(const RgssTtsBackend* backend) {
+  if (backend)
+    g_backend = *backend;
+  else
+    g_backend = RgssTtsBackend{};
+}
+
+// Define the native RGSS::Tts module methods. Called from the gem init in
+// lib.cxx.
+void rgss_tts_define(mrb_state* M, RClass* rgss) {
+  RClass* tts = mrb_define_module_under(M, rgss, "Tts");
+  mrb_define_module_function(M, tts, "available?", tts_available,
+                             MRB_ARGS_NONE());
+  mrb_define_module_function(M, tts, "speak", tts_speak, MRB_ARGS_REQ(1));
+  mrb_define_module_function(M, tts, "stop", tts_stop, MRB_ARGS_NONE());
+}

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7134,17 +7134,21 @@ class RPG2k
                      # back at the default (yado.tk: an explicit `\c[0]` is
                      # needed in the text to stop the choices inheriting it).
                      trailing_color: scans.empty? ? 0 : scans.last[:end_color] }
-        speak_message(plain) unless choice
+        speak_message(plain)
         draw_message_contents
         win.contents = contents
         @choice_index = 0
         set_choice_cursor if choice
       end
 
-      # Zundamon (ずんだもん) message-window narration: read a Show Text
-      # page's plain, fully-expanded text aloud (variables and actor names
-      # already substituted, colour/pacing control codes already stripped --
-      # see `plain` in #open_message) as the page opens. A no-op whenever
+      # Zundamon (ずんだもん) message-window narration: read a page's plain,
+      # fully-expanded text aloud (variables and actor names already
+      # substituted, colour/pacing control codes already stripped -- see
+      # `plain` in #open_message/#append_choice_lines) as the page opens.
+      # Covers both Show Text and Show Choices -- a standalone choice window
+      # reads its options through #open_message(lines, true), and one merged
+      # onto a preceding Show Text reads just the appended options through
+      # #append_choice_lines, never the text above it again. A no-op whenever
       # --zundamon_tts was not passed or its VOICEVOX assets are not
       # installed (RGSS::Tts.available? is false either way), so this changes
       # nothing about any other run.
@@ -7184,6 +7188,9 @@ class RPG2k
         reveal = Game::TextReveal.new(plain)
         reveal.reveal_all
         @message[:reveal] = reveal
+        # Only the newly appended options -- the preceding Show Text already
+        # spoke itself from #open_message.
+        speak_message(new_seg_lines.map { |segs| segs.map { |s| s[:text] }.join })
         draw_message_contents
         @choice_index = 0
         set_choice_cursor

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7134,10 +7134,24 @@ class RPG2k
                      # back at the default (yado.tk: an explicit `\c[0]` is
                      # needed in the text to stop the choices inheriting it).
                      trailing_color: scans.empty? ? 0 : scans.last[:end_color] }
+        speak_message(plain) unless choice
         draw_message_contents
         win.contents = contents
         @choice_index = 0
         set_choice_cursor if choice
+      end
+
+      # Zundamon (ずんだもん) message-window narration: read a Show Text
+      # page's plain, fully-expanded text aloud (variables and actor names
+      # already substituted, colour/pacing control codes already stripped --
+      # see `plain` in #open_message) as the page opens. A no-op whenever
+      # --zundamon_tts was not passed or its VOICEVOX assets are not
+      # installed (RGSS::Tts.available? is false either way), so this changes
+      # nothing about any other run.
+      def speak_message(plain_lines)
+        return unless RGSS::Tts.available?
+        text = plain_lines.join("\n")
+        RGSS::Tts.speak(text) unless text.strip.empty?
       end
 
       # Append a Show Choices block's labels to the still-open message window

--- a/scripts/check_voicevox_assets.rb
+++ b/scripts/check_voicevox_assets.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# Verify assets/voicevox holds a usable offline VOICEVOX synthesis stack.
+#
+# The four pieces (CORE C API, its ONNX Runtime, the Open JTalk dictionary and
+# Zundamon's voice model) are downloaded by scripts/download-voicevox-
+# zundamon.bash rather than committed, so a missing directory is a normal
+# state for a fresh checkout -- src/voicevox_tts.cxx degrades to
+# RGSS::Tts.available? == false and logs why, the same way a missing TiMidity
+# patch set only silences MIDI rather than crashing. This script checks that
+# what *is* there is not a truncated or mismatched download, which would
+# otherwise surface as a confusing dlopen/onnxruntime failure at play time
+# instead of a clear error here.
+#
+# Usage: ruby scripts/check_voicevox_assets.rb [assets/voicevox]
+
+dir = ARGV[0] || File.expand_path('../assets/voicevox', __dir__)
+
+unless Dir.exist?(dir)
+  puts "voicevox: none in #{dir} -- skipping " \
+       '(run scripts/download-voicevox-zundamon.bash to install it, or pass ' \
+       '--zundamon_tts to a build without it and RGSS::Tts.available? just ' \
+       'reports false)'
+  exit 0
+end
+
+errors = []
+
+def check_elf(errors, path)
+  unless File.exist?(path)
+    errors << "missing #{path}"
+    return
+  end
+  magic = File.binread(path, 4)
+  errors << "#{path}: not an ELF shared library (magic #{magic.unpack1('H*')})" unless magic == "\x7fELF".b
+end
+
+check_elf(errors, File.join(dir, 'core/lib/libvoicevox_core.so'))
+errors << "missing #{dir}/core/include/voicevox_core.h" unless File.exist?(File.join(dir, 'core/include/voicevox_core.h'))
+check_elf(errors, File.join(dir, 'onnxruntime/lib/libvoicevox_onnxruntime.so'))
+
+dict_dir = File.join(dir, 'dict/open_jtalk_dic_utf_8-1.11')
+%w[sys.dic unk.dic matrix.bin char.bin].each do |f|
+  errors << "missing #{dict_dir}/#{f}" unless File.exist?(File.join(dict_dir, f))
+end
+
+vvm = File.join(dir, 'models/0.vvm')
+if File.exist?(vvm)
+  # A VVM file is a zip archive (VOICEVOX CORE reads it as one); a truncated
+  # download would not start with the zip local-file-header signature "PK".
+  magic = File.binread(vvm, 2)
+  errors << "#{vvm}: not a zip/vvm archive (magic #{magic.unpack1('H*')})" unless magic == 'PK'
+else
+  errors << "missing #{vvm}"
+end
+errors << "missing #{dir}/models/TERMS.txt (Zundamon's usage terms must travel with the model)" unless File.exist?(File.join(dir, 'models/TERMS.txt'))
+
+if errors.empty?
+  puts "voicevox: #{dir} OK"
+  exit 0
+end
+
+errors.each { |e| warn "voicevox: #{e}" }
+warn 'voicevox: re-run scripts/download-voicevox-zundamon.bash --force to reinstall'
+exit 1

--- a/scripts/download-voicevox-zundamon.bash
+++ b/scripts/download-voicevox-zundamon.bash
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Fetch a fully offline VOICEVOX synthesis stack into assets/voicevox, where
+# src/voicevox_tts.cxx looks for it: the VOICEVOX CORE C API shared library,
+# its ONNX Runtime, the Open JTalk dictionary it uses for Japanese text
+# analysis, and Zundamon (ずんだもん)'s "ノーマル" voice model. Together these
+# let --zundamon_tts read the rpg2k message window's text aloud with no
+# network access at play time and no separate VOICEVOX Engine process to run.
+#
+# ~90 MiB combined, so it is downloaded here rather than committed — the
+# repository stays small and nothing here redistributes VOICEVOX itself.
+#
+# Sources, all pinned GitHub release assets so the bytes are immutable and
+# checksummable:
+#   - VOICEVOX/voicevox_core   -- CORE C API, MIT licensed (linux-x64 build;
+#     src/voicevox_tts.cxx dlopen()s libvoicevox_core.so at run time, so no
+#     link-time dependency is added to the build).
+#   - VOICEVOX/onnxruntime-builder -- the ONNX Runtime build CORE dlopen()s in
+#     turn (CPU-only; see docs/adr for GPU scope).
+#   - r9y9/open_jtalk -- the UTF-8 Open JTalk dictionary CORE's Japanese
+#     front-end (accent/pronunciation analysis) reads from.
+#   - VOICEVOX/voicevox_vvm -- Zundamon's "ノーマル" style (style id 3, the
+#     one file `0.vvm`), not the whole multi-character model pack.
+#
+# The CORE, ONNX Runtime and VVM versions are pinned *together*, not
+# independently: a `.vvm`'s `vvm_format_version` (2, for the voicevox_vvm
+# release pinned below) only loads on a CORE build new enough to understand
+# it -- CORE 0.16.4 rejects it outright ("不正な形式です") -- and CORE prints
+# a compatibility warning if the ONNX Runtime build is not the version it was
+# built against. Bumping any one of the three needs re-checking the others.
+#
+# IMPORTANT — licence: audio generated with this voice model must be credited
+# "VOICEVOX:ずんだもん" per assets/voicevox/models/TERMS.txt, whether the use
+# is commercial or not. See docs/adr for the full attribution note.
+#
+# Idempotent: re-running with the assets already in place does nothing. Pass
+# --force to re-download and overwrite.
+
+core_version="0.17.0"
+core_sha256="00a80c5688e2fde093a3e2c1a4c39170b1c86760d92638a554c8a971a9d97077"
+core_url="https://github.com/VOICEVOX/voicevox_core/releases/download/${core_version}/voicevox_core-linux-x64-${core_version}.zip"
+
+ort_version="1.23.2"
+ort_sha256="0860cfbd5a80201b1bf95cae13ca2db8dc01f32f5674cc8193146047a9212fdb"
+ort_url="https://github.com/VOICEVOX/onnxruntime-builder/releases/download/voicevox_onnxruntime-${ort_version}/voicevox_onnxruntime-linux-x64-${ort_version}.tgz"
+
+dict_version="1.11.1"
+dict_sha256="fe6ba0e43542cef98339abdffd903e062008ea170b04e7e2a35da805902f382a"
+dict_url="https://github.com/r9y9/open_jtalk/releases/download/v${dict_version}/open_jtalk_dic_utf_8-1.11.tar.gz"
+
+vvm_version="0.17.0"
+vvm_sha256="ecd35374d4182cd883cba5040376f7f888cc6ba248b1c2f4cea07cdb34bb1318"
+vvm_url="https://github.com/VOICEVOX/voicevox_vvm/releases/download/${vvm_version}/0.vvm"
+
+# Routes through the optional CI CORS proxy cache when CORS_PROXY_URL is set.
+. "$(dirname "$0")/cors-proxy-url.bash"
+
+here="$(cd "$(dirname "$0")/.." && pwd)"
+dest="$here/assets/voicevox"
+cache="$here/assets/.voicevox"
+
+force=0
+[ "${1:-}" = "--force" ] && force=1
+
+if [ "$force" -eq 0 ] && [ -f "$dest/core/lib/libvoicevox_core.so" ] &&
+    [ -f "$dest/onnxruntime/lib/libvoicevox_onnxruntime.so" ] &&
+    [ -f "$dest/dict/open_jtalk_dic_utf_8-1.11/sys.dic" ] &&
+    [ -f "$dest/models/0.vvm" ]; then
+    echo "voicevox: already present in $dest (pass --force to re-download)"
+    exit 0
+fi
+
+mkdir -p "$cache"
+
+# Download to a cache tarball keyed by name, re-using it only when it matches
+# the pinned checksum -- a truncated download from an interrupted run must not
+# be trusted. Each of these is fed to a native loader (dlopen, an ONNX Runtime
+# session, a VVM model reader) that would otherwise surface a corrupt archive
+# as a confusing runtime failure rather than a download error.
+fetch() {
+    local name="$1" url="$2" want="$3" out="$cache/$1"
+
+    if [ -f "$out" ] && ! echo "$want  $out" | sha256sum -c --status; then
+        echo "voicevox: cached $name failed checksum, re-downloading" >&2
+        rm -f "$out"
+    fi
+
+    if [ ! -f "$out" ]; then
+        echo "voicevox: downloading $url"
+        curl -fsSL --retry 3 --retry-delay 2 -o "$out.part" "$(proxied_url "$url")"
+        mv "$out.part" "$out"
+    fi
+
+    if ! echo "$want  $out" | sha256sum -c --status; then
+        echo "voicevox: checksum mismatch for $name" >&2
+        echo "expected $want" >&2
+        echo "actual   $(sha256sum "$out" | cut -d' ' -f1)" >&2
+        exit 1
+    fi
+}
+
+fetch "voicevox_core-${core_version}.zip" "$core_url" "$core_sha256"
+fetch "voicevox_onnxruntime-${ort_version}.tgz" "$ort_url" "$ort_sha256"
+fetch "open_jtalk_dic_utf_8-1.11.tar.gz" "$dict_url" "$dict_sha256"
+fetch "0.vvm" "$vvm_url" "$vvm_sha256"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Only the subdirectories this script owns -- not $dest itself, which also
+# holds the checked-in README.md (see download-freepats.bash's Tone_000/
+# Drum_000 removal for the same reasoning).
+rm -rf "$dest/core" "$dest/onnxruntime" "$dest/dict" "$dest/models"
+mkdir -p "$dest/core" "$dest/onnxruntime" "$dest/dict" "$dest/models"
+
+unzip -q "$cache/voicevox_core-${core_version}.zip" -d "$work/core"
+core_root="$work/core/voicevox_core-linux-x64-${core_version}"
+for required in lib/libvoicevox_core.so include/voicevox_core.h LICENSE; do
+    if [ ! -e "$core_root/$required" ]; then
+        echo "voicevox: core archive is missing $required" >&2
+        exit 1
+    fi
+done
+cp -r "$core_root/lib" "$core_root/include" "$dest/core/"
+cp "$core_root/LICENSE" "$dest/core/LICENSE"
+
+mkdir -p "$work/ort"
+tar xzf "$cache/voicevox_onnxruntime-${ort_version}.tgz" -C "$work/ort"
+ort_root="$work/ort/voicevox_onnxruntime-linux-x64-${ort_version}"
+if [ ! -e "$ort_root/lib/libvoicevox_onnxruntime.so" ]; then
+    echo "voicevox: onnxruntime archive is missing lib/libvoicevox_onnxruntime.so" >&2
+    exit 1
+fi
+cp -r "$ort_root/lib" "$dest/onnxruntime/"
+cp "$ort_root/TERMS.txt" "$dest/onnxruntime/TERMS.txt"
+
+mkdir -p "$work/dict"
+tar xzf "$cache/open_jtalk_dic_utf_8-1.11.tar.gz" -C "$work/dict"
+if [ ! -e "$work/dict/open_jtalk_dic_utf_8-1.11/sys.dic" ]; then
+    echo "voicevox: open_jtalk dictionary archive is missing sys.dic" >&2
+    exit 1
+fi
+cp -r "$work/dict/open_jtalk_dic_utf_8-1.11" "$dest/dict/"
+
+cp "$cache/0.vvm" "$dest/models/0.vvm"
+
+# Zundamon's usage terms (Japanese; see docs/adr for the English gist) travel
+# with the model file, same as the FreePats/M+ licences travel with their
+# assets. Written here rather than fetched again: `voicevox_vvm`'s own
+# TERMS.txt is the release tag's tree, not a release asset, and browsing it
+# needs the GitHub API rather than a pinned download URL.
+cat >"$dest/models/TERMS.txt" <<'EOF'
+VOICEVOX:ずんだもん — usage terms (summary)
+
+Audio generated with this voice model may be used for commercial and
+non-commercial purposes alike, provided it is credited as "VOICEVOX:ずんだもん"
+(e.g. in a game's credits screen or README). Full terms:
+https://github.com/VOICEVOX/voicevox_vvm/blob/main/README.md
+EOF
+
+echo "voicevox: installed into $dest"
+ruby "$here/scripts/check_voicevox_assets.rb" "$dest"

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -168,6 +168,18 @@ module RGSS
     def self.reset_se; @se_calls = []; end
   end
 
+  # Zundamon message-window narration (Scene::Map#speak_message). available?
+  # false is the real "no --zundamon_tts / no backend installed" state, so
+  # this matches production with the flag off -- speak is never actually
+  # called by the stub, but is recorded (and made callable) so a future check
+  # can flip `available` on and assert what got spoken.
+  module Tts
+    class << self; attr_accessor :available, :speak_calls; end
+    def self.available?; !!@available; end
+    def self.speak(*a); (@speak_calls ||= []) << a; end
+    def self.reset; @available = false; @speak_calls = []; end
+  end
+
   def self.warn_stub(*); end
   class Timeout < StandardError; end
 end

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -365,13 +365,38 @@ DEFINE_bool(
     zundamon_tts,
     false,
     "Read the rpg2k message window's text aloud in Zundamon (ずんだもん)'s "
-    "voice as each Show Text page opens, via a bundled offline VOICEVOX CORE "
-    "synthesis stack (RGSS::Tts, src/voicevox_tts.cxx). Off by default: the "
-    "stack is ~90 MiB and not committed, so run "
+    "voice as each Show Text/Show Choices page opens, via a bundled offline "
+    "VOICEVOX CORE synthesis stack (RGSS::Tts, src/voicevox_tts.cxx). Off by "
+    "default: the stack is ~90 MiB and not committed, so run "
     "scripts/download-voicevox-zundamon.bash first -- with no assets/voicevox "
     "installed this flag logs why and the game runs silently, same as "
     "--zundamon_tts on a build with no VOICEVOX CORE backend at all (see "
     "RGSS::Tts.available?)");
+DEFINE_int32(
+    zundamon_tts_style,
+    3,
+    "Which of Zundamon's four bundled styles --zundamon_tts speaks in: 3 "
+    "ノーマル/normal (default), 1 あまあま/sweet, 7 ツンツン/curt, 5 "
+    "セクシー/sultry. Reaching a different VOICEVOX character entirely needs "
+    "its own downloaded voice model, which scripts/download-voicevox-"
+    "zundamon.bash does not fetch.");
+DEFINE_double(zundamon_tts_speed,
+              1.0,
+              "--zundamon_tts speech rate. VOICEVOX's own neutral value is "
+              "1.0; roughly 0.5-2.0 stays intelligible.");
+DEFINE_double(zundamon_tts_pitch,
+              0.0,
+              "--zundamon_tts pitch shift. VOICEVOX's own neutral value is "
+              "0.0; roughly -0.15-0.15 stays intelligible.");
+DEFINE_double(
+    zundamon_tts_intonation,
+    1.0,
+    "--zundamon_tts intonation (pitch variation) strength. VOICEVOX's own "
+    "neutral value is 1.0; 0 is flat/monotone, higher is more exaggerated.");
+DEFINE_double(zundamon_tts_volume,
+              1.0,
+              "--zundamon_tts loudness, independent of the SE/BGM volumes "
+              "Play SE/Play BGM set. VOICEVOX's own neutral value is 1.0.");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -668,8 +693,15 @@ extern "C" void rgss_audio_shutdown(void);
 // for Zundamon message-window narration (src/voicevox_tts.cxx). Only called
 // when --zundamon_tts is passed; a no-op (RGSS::Tts.available? stays false)
 // if the assets are missing or this build has no backend at all. Always safe
-// to call rgss_tts_shutdown, even when init was never called.
-extern "C" void rgss_tts_init(void);
+// to call rgss_tts_shutdown, even when init was never called. style_id
+// chooses among Zundamon's bundled styles; the four scales tune speed,
+// pitch, intonation and volume (VOICEVOX's own neutral values: 1.0, 0.0,
+// 1.0, 1.0) -- see --zundamon_tts_style/_speed/_pitch/_intonation/_volume.
+extern "C" void rgss_tts_init(int style_id,
+                              double speed_scale,
+                              double pitch_scale,
+                              double intonation_scale,
+                              double volume_scale);
 extern "C" void rgss_tts_shutdown(void);
 
 // Whether the pending mruby exception is the game ending on purpose rather than
@@ -1129,7 +1161,9 @@ int main(int argc, char** argv) {
   // when actually asked for. Needs rgss_audio_init above to have opened the
   // SDL_mixer device first -- src/voicevox_tts.cxx plays through it.
   if (FLAGS_zundamon_tts)
-    rgss_tts_init();
+    rgss_tts_init(FLAGS_zundamon_tts_style, FLAGS_zundamon_tts_speed,
+                  FLAGS_zundamon_tts_pitch, FLAGS_zundamon_tts_intonation,
+                  FLAGS_zundamon_tts_volume);
 
   // Before any game runs, so the first window drawn already has its font.
   init_default_font(launch_dir);

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -361,6 +361,17 @@ DEFINE_bool(
     "--error_dump file must hold the same text that was printed. Exits 0 only "
     "then. Needs no game; run as the error_dump ctest — a report that silently "
     "lost half its content is worse than no report at all");
+DEFINE_bool(
+    zundamon_tts,
+    false,
+    "Read the rpg2k message window's text aloud in Zundamon (ずんだもん)'s "
+    "voice as each Show Text page opens, via a bundled offline VOICEVOX CORE "
+    "synthesis stack (RGSS::Tts, src/voicevox_tts.cxx). Off by default: the "
+    "stack is ~90 MiB and not committed, so run "
+    "scripts/download-voicevox-zundamon.bash first -- with no assets/voicevox "
+    "installed this flag logs why and the game runs silently, same as "
+    "--zundamon_tts on a build with no VOICEVOX CORE backend at all (see "
+    "RGSS::Tts.available?)");
 DEFINE_bool(sixel,
             false,
             "Render to the terminal using the sixel protocol instead of "
@@ -652,6 +663,14 @@ extern "C" void rgss_sdl_input_init(void);
 // shutdown tears it down on the native exit path.
 extern "C" void rgss_audio_init(void);
 extern "C" void rgss_audio_shutdown(void);
+
+// Loads the VOICEVOX CORE synthesis stack and installs the RGSS::Tts backend
+// for Zundamon message-window narration (src/voicevox_tts.cxx). Only called
+// when --zundamon_tts is passed; a no-op (RGSS::Tts.available? stays false)
+// if the assets are missing or this build has no backend at all. Always safe
+// to call rgss_tts_shutdown, even when init was never called.
+extern "C" void rgss_tts_init(void);
+extern "C" void rgss_tts_shutdown(void);
 
 // Whether the pending mruby exception is the game ending on purpose rather than
 // failing: `exit` raises SystemExit, which mruby tags with MRB_EXC_EXIT. Both
@@ -1105,6 +1124,13 @@ int main(int argc, char** argv) {
   // subsystem itself, so this works under the terminal backends too).
   rgss_audio_init();
 
+  // Zundamon message-window narration, opt-in: loading the VOICEVOX CORE
+  // stack costs real disk IO and an ONNX Runtime session, so it only happens
+  // when actually asked for. Needs rgss_audio_init above to have opened the
+  // SDL_mixer device first -- src/voicevox_tts.cxx plays through it.
+  if (FLAGS_zundamon_tts)
+    rgss_tts_init();
+
   // Before any game runs, so the first window drawn already has its font.
   init_default_font(launch_dir);
 
@@ -1337,6 +1363,7 @@ int main(int argc, char** argv) {
   // through the real reporting path and reads the report back itself.
   if (FLAGS_error_dump_probe) {
     const int rc = error_dump_run_probe(M);
+    rgss_tts_shutdown();
     rgss_audio_shutdown();
     gflags::ShutDownCommandLineFlags();
     return rc;
@@ -1352,6 +1379,7 @@ int main(int argc, char** argv) {
     const mrb_value ok =
         mrb_funcall(M, mrb_obj_value(mrb_module_get(M, "RGSS")), probe, 0);
     CHECK_NO_EXC(M);
+    rgss_tts_shutdown();
     rgss_audio_shutdown();
     gflags::ShutDownCommandLineFlags();
     return mrb_test(ok) ? EXIT_SUCCESS : EXIT_FAILURE;
@@ -1414,16 +1442,19 @@ int main(int argc, char** argv) {
     int status = EXIT_SUCCESS;
     if (pending_exit(M, &status)) {
       M->exc = nullptr;
+      rgss_tts_shutdown();
       rgss_audio_shutdown();
       gflags::ShutDownCommandLineFlags();
       return status;
     }
     error_dump_report(M, "the running game");
+    rgss_tts_shutdown();
     rgss_audio_shutdown();
     gflags::ShutDownCommandLineFlags();
     return EXIT_FAILURE;
   }
 
+  rgss_tts_shutdown();
   rgss_audio_shutdown();
   gflags::ShutDownCommandLineFlags();
 

--- a/src/voicevox_tts.cxx
+++ b/src/voicevox_tts.cxx
@@ -42,6 +42,7 @@
 
 #include <ng-log/logging.h>
 
+#include <cctype>
 #include <cstdio>
 #include <string>
 
@@ -49,15 +50,33 @@
 
 namespace {
 
-// Zundamon's "ノーマル" (normal) style, style id 3 in voicevox_vvm's `0.vvm`
-// -- see assets/voicevox/models/TERMS.txt and the character/style table at
-// https://github.com/VOICEVOX/voicevox_vvm/blob/main/README.md. This is the
-// one style scripts/download-voicevox-zundamon.bash installs.
-constexpr VoicevoxStyleId kZundamonNormalStyleId = 3;
+// scripts/download-voicevox-zundamon.bash installs one voice model,
+// Zundamon's `0.vvm`, which itself carries four styles (see
+// assets/voicevox/models/TERMS.txt and the character/style table at
+// https://github.com/VOICEVOX/voicevox_vvm/blob/main/README.md); --
+// --zundamon_tts_style picks among them, defaulting to "ノーマル". Passing
+// any other id fails at synthesis time (logged via check() below) since no
+// other model is loaded -- reaching an entirely different VOICEVOX character
+// needs its own .vvm, which the download script does not fetch.
+constexpr VoicevoxStyleId kZundamonNormalStyleId = 3;  // ノーマル (normal)
+constexpr VoicevoxStyleId kZundamonAmaamaStyleId = 1;  // あまあま (sweet)
+constexpr VoicevoxStyleId kZundamonTsuntsunStyleId = 7;  // ツンツン (curt)
+constexpr VoicevoxStyleId kZundamonSexyStyleId = 5;  // セクシー (sultry)
 
 void* g_core = nullptr;
 bool g_init_attempted = false;
 bool g_available = false;
+
+// Voice parameters, set once from --zundamon_tts_* by rgss_tts_init() before
+// ensure_init() runs. speed/intonation/volume default to VOICEVOX's own
+// neutral 1.0, pitch to 0.0 -- unset flags therefore reproduce exactly what
+// the plain tts() convenience call (used before this parameterisation was
+// added) always produced.
+VoicevoxStyleId g_style_id = kZundamonNormalStyleId;
+double g_speed_scale = 1.0;
+double g_pitch_scale = 0.0;
+double g_intonation_scale = 1.0;
+double g_volume_scale = 1.0;
 
 VoicevoxMakeDefaultLoadOnnxruntimeOptionsFn
     p_make_default_load_onnxruntime_options = nullptr;
@@ -75,6 +94,12 @@ VoicevoxMakeDefaultLoadVoiceModelOptionsFn
 VoicevoxSynthesizerLoadVoiceModelFn p_synthesizer_load_voice_model = nullptr;
 VoicevoxMakeDefaultTtsOptionsFn p_make_default_tts_options = nullptr;
 VoicevoxSynthesizerTtsFn p_synthesizer_tts = nullptr;
+VoicevoxSynthesizerCreateAudioQueryFn p_synthesizer_create_audio_query =
+    nullptr;
+VoicevoxMakeDefaultSynthesisOptionsFn p_make_default_synthesis_options =
+    nullptr;
+VoicevoxSynthesizerSynthesisFn p_synthesizer_synthesis = nullptr;
+VoicevoxJsonFreeFn p_json_free = nullptr;
 VoicevoxWavFreeFn p_wav_free = nullptr;
 VoicevoxErrorResultToMessageFn p_error_result_to_message = nullptr;
 
@@ -184,6 +209,13 @@ void ensure_init() {
   ok &= load_symbol(g_core, "voicevox_make_default_tts_options",
                     p_make_default_tts_options);
   ok &= load_symbol(g_core, "voicevox_synthesizer_tts", p_synthesizer_tts);
+  ok &= load_symbol(g_core, "voicevox_synthesizer_create_audio_query",
+                    p_synthesizer_create_audio_query);
+  ok &= load_symbol(g_core, "voicevox_make_default_synthesis_options",
+                    p_make_default_synthesis_options);
+  ok &= load_symbol(g_core, "voicevox_synthesizer_synthesis",
+                    p_synthesizer_synthesis);
+  ok &= load_symbol(g_core, "voicevox_json_free", p_json_free);
   ok &= load_symbol(g_core, "voicevox_wav_free", p_wav_free);
   // Best-effort only: used for a nicer log message, nothing depends on it.
   load_symbol(g_core, "voicevox_error_result_to_message",
@@ -244,15 +276,57 @@ int available_fn(void) {
   return g_available ? 1 : 0;
 }
 
+// Rewrites `"field":<number>` in an AudioQuery JSON to carry `value` instead,
+// with a plain substring scan rather than a JSON library: the field is
+// always a bare, unquoted number (CORE's own serde output, never
+// user-controlled), so a full parser buys nothing here that hand-rolling one
+// would not risk more than a copy-paste error. A field CORE did not emit
+// (e.g. an unexpected schema change) is left untouched rather than
+// corrupting the JSON.
+std::string set_json_number(const std::string& json,
+                            const char* field,
+                            double value) {
+  const std::string key = std::string("\"") + field + "\":";
+  size_t start = json.find(key);
+  if (start == std::string::npos)
+    return json;
+  start += key.size();
+  size_t end = start;
+  while (end < json.size() &&
+         (std::isdigit((unsigned char)json[end]) || json[end] == '-' ||
+          json[end] == '+' || json[end] == '.' || json[end] == 'e' ||
+          json[end] == 'E'))
+    ++end;
+  char buf[64];
+  std::snprintf(buf, sizeof(buf), "%.6g", value);
+  return json.substr(0, start) + buf + json.substr(end);
+}
+
 void speak_fn(const char* utf8_text) {
   if (!g_available || !utf8_text || !*utf8_text)
     return;
 
-  VoicevoxTtsOptions opts = p_make_default_tts_options();
+  char* query_json = nullptr;
+  if (!check(p_synthesizer_create_audio_query(g_synthesizer, utf8_text,
+                                              g_style_id, &query_json),
+             "building the audio query"))
+    return;
+  std::string query(query_json);
+  p_json_free(query_json);
+
+  // Applied unconditionally: with every --zundamon_tts_* flag left at its
+  // default, this reproduces VOICEVOX's own neutral values byte-for-byte, so
+  // it changes nothing when the player never asked to tune anything.
+  query = set_json_number(query, "speedScale", g_speed_scale);
+  query = set_json_number(query, "pitchScale", g_pitch_scale);
+  query = set_json_number(query, "intonationScale", g_intonation_scale);
+  query = set_json_number(query, "volumeScale", g_volume_scale);
+
+  VoicevoxSynthesisOptions opts = p_make_default_synthesis_options();
   uintptr_t wav_len = 0;
   uint8_t* wav = nullptr;
-  VoicevoxResultCode code = p_synthesizer_tts(
-      g_synthesizer, utf8_text, kZundamonNormalStyleId, opts, &wav_len, &wav);
+  VoicevoxResultCode code = p_synthesizer_synthesis(
+      g_synthesizer, query.c_str(), g_style_id, opts, &wav_len, &wav);
   if (!check(code, "synthesizing speech"))
     return;
 
@@ -290,11 +364,32 @@ const RgssTtsBackend kBackend = {available_fn, speak_fn, stop_fn};
 // Install the VOICEVOX backend and eagerly load Zundamon's voice model. Only
 // called from src/main.cxx when --zundamon_tts is passed, so a normal run
 // pays no cost at all -- no dlopen, no ONNX Runtime session, nothing.
-extern "C" void rgss_tts_init(void) {
+//
+// style_id selects among the styles bundled in the one voice model this
+// engine loads (kZundamonNormalStyleId and its siblings above); the other
+// four parameters are AudioQuery scale factors applied to every utterance --
+// VOICEVOX's own neutral values (1.0/0.0/1.0/1.0) reproduce the unparameterised
+// tts() call this backend used before speak_fn switched to the audio-query +
+// synthesis path.
+extern "C" void rgss_tts_init(int style_id,
+                              double speed_scale,
+                              double pitch_scale,
+                              double intonation_scale,
+                              double volume_scale) {
 #if defined(RGSS_TTS_HAVE_DLOPEN)
+  g_style_id = (VoicevoxStyleId)style_id;
+  g_speed_scale = speed_scale;
+  g_pitch_scale = pitch_scale;
+  g_intonation_scale = intonation_scale;
+  g_volume_scale = volume_scale;
   rgss_tts_install_backend(&kBackend);
   ensure_init();
 #else
+  (void)style_id;
+  (void)speed_scale;
+  (void)pitch_scale;
+  (void)intonation_scale;
+  (void)volume_scale;
   LOG(WARNING) << "Tts: --zundamon_tts has no backend on this build (VOICEVOX "
                   "CORE integration is desktop-only)";
 #endif

--- a/src/voicevox_tts.cxx
+++ b/src/voicevox_tts.cxx
@@ -1,0 +1,328 @@
+// VOICEVOX CORE backend for RGSS::Tts (Zundamon message-window narration),
+// installed at startup by rgss_tts_init() when --zundamon_tts is passed (see
+// src/main.cxx). Mirrors src/sdl_audio.cxx's split: the mruby-rgss gem must
+// not depend on VOICEVOX CORE or SDL, so RGSS::Tts's native methods
+// (mruby-rgss/src/tts.cxx) call through the plain function table in
+// include/rgss_tts.hxx instead of calling either directly.
+//
+// VOICEVOX CORE itself is never a build dependency: the library, its ONNX
+// Runtime, the Open JTalk dictionary and Zundamon's voice model are an
+// optional run-time asset (scripts/download-voicevox-zundamon.bash installs
+// them into assets/voicevox, git-ignored -- see assets/voicevox/README.md),
+// dlopen()'d here the same way SDL_mixer's MIDI patch set is an optional
+// run-time asset rather than a link-time one. With no assets/voicevox
+// present -- the common case, since this is an opt-in accessibility feature
+// -- every RGSS::Tts call is a graceful no-op: RGSS::Tts.available? reports
+// false and nothing is logged beyond one INFO line explaining why.
+//
+// Licensing note: Zundamon's voice model requires crediting "VOICEVOX:
+// ずんだもん" wherever audio generated with it is used (see
+// assets/voicevox/models/TERMS.txt) -- this is a property of the downloaded
+// model, not of this source file, which only calls a documented C API.
+
+#include "rgss_tts.hxx"
+
+#include "voicevox_core_capi.hxx"
+
+// VOICEVOX CORE ships as a native shared library with no Emscripten/PSP/Wio
+// port, so this backend only makes sense where dlopen() is both available and
+// meaningful -- the desktop native build. Everywhere else rgss_tts_init()
+// below leaves the backend uninstalled.
+#if !defined(__EMSCRIPTEN__) && (defined(__linux__) || defined(__APPLE__))
+#define RGSS_TTS_HAVE_DLOPEN 1
+#include <dlfcn.h>
+#endif
+
+#include <SDL2/SDL.h>
+#if defined(__has_include) && __has_include(<SDL2/SDL_mixer.h>)
+#include <SDL2/SDL_mixer.h>
+#else
+#include <SDL_mixer.h>
+#endif
+
+#include <ng-log/logging.h>
+
+#include <cstdio>
+#include <string>
+
+#if defined(RGSS_TTS_HAVE_DLOPEN)
+
+namespace {
+
+// Zundamon's "ノーマル" (normal) style, style id 3 in voicevox_vvm's `0.vvm`
+// -- see assets/voicevox/models/TERMS.txt and the character/style table at
+// https://github.com/VOICEVOX/voicevox_vvm/blob/main/README.md. This is the
+// one style scripts/download-voicevox-zundamon.bash installs.
+constexpr VoicevoxStyleId kZundamonNormalStyleId = 3;
+
+void* g_core = nullptr;
+bool g_init_attempted = false;
+bool g_available = false;
+
+VoicevoxMakeDefaultLoadOnnxruntimeOptionsFn
+    p_make_default_load_onnxruntime_options = nullptr;
+VoicevoxOnnxruntimeLoadOnceFn p_onnxruntime_load_once = nullptr;
+VoicevoxOpenJtalkRcNewFn p_open_jtalk_rc_new = nullptr;
+VoicevoxOpenJtalkRcDeleteFn p_open_jtalk_rc_delete = nullptr;
+VoicevoxMakeDefaultInitializeOptionsFn p_make_default_initialize_options =
+    nullptr;
+VoicevoxSynthesizerNewFn p_synthesizer_new = nullptr;
+VoicevoxSynthesizerDeleteFn p_synthesizer_delete = nullptr;
+VoicevoxVoiceModelFileOpenFn p_voice_model_file_open = nullptr;
+VoicevoxVoiceModelFileDeleteFn p_voice_model_file_delete = nullptr;
+VoicevoxMakeDefaultLoadVoiceModelOptionsFn
+    p_make_default_load_voice_model_options = nullptr;
+VoicevoxSynthesizerLoadVoiceModelFn p_synthesizer_load_voice_model = nullptr;
+VoicevoxMakeDefaultTtsOptionsFn p_make_default_tts_options = nullptr;
+VoicevoxSynthesizerTtsFn p_synthesizer_tts = nullptr;
+VoicevoxWavFreeFn p_wav_free = nullptr;
+VoicevoxErrorResultToMessageFn p_error_result_to_message = nullptr;
+
+const VoicevoxOnnxruntime* g_onnxruntime = nullptr;
+OpenJtalkRc* g_open_jtalk = nullptr;
+VoicevoxSynthesizer* g_synthesizer = nullptr;
+VoicevoxVoiceModelFile* g_model = nullptr;
+
+// The one outstanding synthesized clip. At most one utterance plays at a
+// time -- a new message page's narration replaces whatever the previous page
+// started, the same way starting a new BGM replaces the one already playing
+// -- so there is never more than a single Mix_Chunk to track, freed the
+// moment a new speak() replaces it or at shutdown.
+int g_channel = -1;
+Mix_Chunk* g_chunk = nullptr;
+
+bool file_exists(const std::string& path) {
+  FILE* f = std::fopen(path.c_str(), "rb");
+  if (!f)
+    return false;
+  std::fclose(f);
+  return true;
+}
+
+// Where assets/voicevox lives: next to the executable (an installed layout,
+// or a build tree with the assets downloaded in place) first, then the
+// source tree -- the same search order and reasoning as init_midi_config's
+// TIMIDITY_CFG lookup in src/sdl_audio.cxx.
+std::string resolve_voicevox_dir() {
+  if (char* base = SDL_GetBasePath()) {
+    std::string candidate = std::string(base) + "assets/voicevox";
+    SDL_free(base);
+    if (file_exists(candidate + "/core/lib/libvoicevox_core.so"))
+      return candidate;
+  }
+#ifdef RGSS_VOICEVOX_SOURCE_DIR
+  if (file_exists(std::string(RGSS_VOICEVOX_SOURCE_DIR) +
+                  "/core/lib/libvoicevox_core.so"))
+    return RGSS_VOICEVOX_SOURCE_DIR;
+#endif
+  return std::string();
+}
+
+template <typename Fn>
+bool load_symbol(void* handle, const char* name, Fn& out) {
+  out = reinterpret_cast<Fn>(dlsym(handle, name));
+  if (!out)
+    LOG(WARNING) << "Tts: missing symbol '" << name
+                 << "' in libvoicevox_core.so";
+  return out != nullptr;
+}
+
+bool check(VoicevoxResultCode code, const char* what) {
+  if (code == VOICEVOX_RESULT_OK)
+    return true;
+  const char* msg = p_error_result_to_message ? p_error_result_to_message(code)
+                                              : "(no detail)";
+  LOG(WARNING) << "Tts: " << what << " failed (code " << code << "): " << msg;
+  return false;
+}
+
+// Loads libvoicevox_core.so and stands up a Synthesizer with Zundamon's voice
+// model loaded. Runs once: model loading costs real disk IO and an ONNX
+// Runtime session, so rgss_tts_init() calls this eagerly at startup rather
+// than paying that cost on the first message the game happens to show.
+void ensure_init() {
+  if (g_init_attempted)
+    return;
+  g_init_attempted = true;
+
+  const std::string dir = resolve_voicevox_dir();
+  if (dir.empty()) {
+    LOG(INFO) << "Tts: no assets/voicevox found; --zundamon_tts stays "
+                 "unavailable (run scripts/download-voicevox-zundamon.bash to "
+                 "install it)";
+    return;
+  }
+
+  const std::string core_so = dir + "/core/lib/libvoicevox_core.so";
+  g_core = dlopen(core_so.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!g_core) {
+    LOG(WARNING) << "Tts: dlopen('" << core_so << "') failed: " << dlerror();
+    return;
+  }
+
+  bool ok = true;
+  ok &= load_symbol(g_core, "voicevox_make_default_load_onnxruntime_options",
+                    p_make_default_load_onnxruntime_options);
+  ok &= load_symbol(g_core, "voicevox_onnxruntime_load_once",
+                    p_onnxruntime_load_once);
+  ok &= load_symbol(g_core, "voicevox_open_jtalk_rc_new", p_open_jtalk_rc_new);
+  ok &= load_symbol(g_core, "voicevox_open_jtalk_rc_delete",
+                    p_open_jtalk_rc_delete);
+  ok &= load_symbol(g_core, "voicevox_make_default_initialize_options",
+                    p_make_default_initialize_options);
+  ok &= load_symbol(g_core, "voicevox_synthesizer_new", p_synthesizer_new);
+  ok &=
+      load_symbol(g_core, "voicevox_synthesizer_delete", p_synthesizer_delete);
+  ok &= load_symbol(g_core, "voicevox_voice_model_file_open",
+                    p_voice_model_file_open);
+  ok &= load_symbol(g_core, "voicevox_voice_model_file_delete",
+                    p_voice_model_file_delete);
+  ok &= load_symbol(g_core, "voicevox_make_default_load_voice_model_options",
+                    p_make_default_load_voice_model_options);
+  ok &= load_symbol(g_core, "voicevox_synthesizer_load_voice_model",
+                    p_synthesizer_load_voice_model);
+  ok &= load_symbol(g_core, "voicevox_make_default_tts_options",
+                    p_make_default_tts_options);
+  ok &= load_symbol(g_core, "voicevox_synthesizer_tts", p_synthesizer_tts);
+  ok &= load_symbol(g_core, "voicevox_wav_free", p_wav_free);
+  // Best-effort only: used for a nicer log message, nothing depends on it.
+  load_symbol(g_core, "voicevox_error_result_to_message",
+              p_error_result_to_message);
+  if (!ok) {
+    dlclose(g_core);
+    g_core = nullptr;
+    return;
+  }
+
+  VoicevoxLoadOnnxruntimeOptions ort_opts =
+      p_make_default_load_onnxruntime_options();
+  const std::string ort_so =
+      dir + "/onnxruntime/lib/libvoicevox_onnxruntime.so";
+  ort_opts.filename = ort_so.c_str();
+  if (!check(p_onnxruntime_load_once(ort_opts, &g_onnxruntime),
+             "loading the ONNX Runtime"))
+    return;
+
+  const std::string dict_dir = dir + "/dict/open_jtalk_dic_utf_8-1.11";
+  if (!check(p_open_jtalk_rc_new(dict_dir.c_str(), &g_open_jtalk),
+             "loading the Open JTalk dictionary"))
+    return;
+
+  VoicevoxInitializeOptions init_opts = p_make_default_initialize_options();
+  init_opts.acceleration_mode = VOICEVOX_ACCELERATION_MODE_CPU;
+  if (!check(p_synthesizer_new(g_onnxruntime, g_open_jtalk, init_opts,
+                               &g_synthesizer),
+             "constructing the synthesizer"))
+    return;
+
+  const std::string model_path = dir + "/models/0.vvm";
+  if (!check(p_voice_model_file_open(model_path.c_str(), &g_model),
+             "opening the Zundamon voice model"))
+    return;
+  if (!check(p_synthesizer_load_voice_model(
+                 g_synthesizer, g_model,
+                 p_make_default_load_voice_model_options()),
+             "loading the Zundamon voice model"))
+    return;
+
+  g_available = true;
+  LOG(INFO) << "Tts: Zundamon voice model loaded from '" << dir << "'";
+}
+
+void free_chunk() {
+  if (g_channel >= 0) {
+    Mix_HaltChannel(g_channel);
+    g_channel = -1;
+  }
+  if (g_chunk) {
+    Mix_FreeChunk(g_chunk);
+    g_chunk = nullptr;
+  }
+}
+
+int available_fn(void) {
+  return g_available ? 1 : 0;
+}
+
+void speak_fn(const char* utf8_text) {
+  if (!g_available || !utf8_text || !*utf8_text)
+    return;
+
+  VoicevoxTtsOptions opts = p_make_default_tts_options();
+  uintptr_t wav_len = 0;
+  uint8_t* wav = nullptr;
+  VoicevoxResultCode code = p_synthesizer_tts(
+      g_synthesizer, utf8_text, kZundamonNormalStyleId, opts, &wav_len, &wav);
+  if (!check(code, "synthesizing speech"))
+    return;
+
+  free_chunk();
+  SDL_RWops* rw = SDL_RWFromConstMem(wav, (int)wav_len);
+  if (rw) {
+    g_chunk = Mix_LoadWAV_RW(rw, 1);  // 1: SDL_mixer closes the RWops
+    if (g_chunk) {
+      g_channel = Mix_PlayChannel(-1, g_chunk, 0);
+      if (g_channel < 0) {
+        LOG(WARNING) << "Tts: Mix_PlayChannel failed: " << Mix_GetError();
+        Mix_FreeChunk(g_chunk);
+        g_chunk = nullptr;
+      }
+    } else {
+      LOG(WARNING) << "Tts: failed to decode synthesized speech: "
+                   << Mix_GetError();
+    }
+  } else {
+    LOG(WARNING) << "Tts: SDL_RWFromConstMem failed: " << SDL_GetError();
+  }
+  p_wav_free(wav);
+}
+
+void stop_fn(void) {
+  free_chunk();
+}
+
+const RgssTtsBackend kBackend = {available_fn, speak_fn, stop_fn};
+
+}  // namespace
+
+#endif  // RGSS_TTS_HAVE_DLOPEN
+
+// Install the VOICEVOX backend and eagerly load Zundamon's voice model. Only
+// called from src/main.cxx when --zundamon_tts is passed, so a normal run
+// pays no cost at all -- no dlopen, no ONNX Runtime session, nothing.
+extern "C" void rgss_tts_init(void) {
+#if defined(RGSS_TTS_HAVE_DLOPEN)
+  rgss_tts_install_backend(&kBackend);
+  ensure_init();
+#else
+  LOG(WARNING) << "Tts: --zundamon_tts has no backend on this build (VOICEVOX "
+                  "CORE integration is desktop-only)";
+#endif
+}
+
+extern "C" void rgss_tts_shutdown(void) {
+#if defined(RGSS_TTS_HAVE_DLOPEN)
+  if (!g_init_attempted)
+    return;
+  rgss_tts_install_backend(nullptr);
+  free_chunk();
+  if (g_model) {
+    p_voice_model_file_delete(g_model);
+    g_model = nullptr;
+  }
+  if (g_synthesizer) {
+    p_synthesizer_delete(g_synthesizer);
+    g_synthesizer = nullptr;
+  }
+  if (g_open_jtalk) {
+    p_open_jtalk_rc_delete(g_open_jtalk);
+    g_open_jtalk = nullptr;
+  }
+  if (g_core) {
+    dlclose(g_core);
+    g_core = nullptr;
+  }
+  g_available = false;
+  g_init_attempted = false;
+#endif
+}

--- a/src/voicevox_tts.cxx
+++ b/src/voicevox_tts.cxx
@@ -58,10 +58,10 @@ namespace {
 // any other id fails at synthesis time (logged via check() below) since no
 // other model is loaded -- reaching an entirely different VOICEVOX character
 // needs its own .vvm, which the download script does not fetch.
-constexpr VoicevoxStyleId kZundamonNormalStyleId = 3;  // ノーマル (normal)
-constexpr VoicevoxStyleId kZundamonAmaamaStyleId = 1;  // あまあま (sweet)
+constexpr VoicevoxStyleId kZundamonNormalStyleId = 3;    // ノーマル (normal)
+constexpr VoicevoxStyleId kZundamonAmaamaStyleId = 1;    // あまあま (sweet)
 constexpr VoicevoxStyleId kZundamonTsuntsunStyleId = 7;  // ツンツン (curt)
-constexpr VoicevoxStyleId kZundamonSexyStyleId = 5;  // セクシー (sultry)
+constexpr VoicevoxStyleId kZundamonSexyStyleId = 5;      // セクシー (sultry)
 
 void* g_core = nullptr;
 bool g_init_attempted = false;


### PR DESCRIPTION
## Summary

Adds opt-in text-to-speech narration for RPG2000/2003 message windows using Zundamon's voice, powered by a bundled offline VOICEVOX CORE synthesis stack. The feature is activated via the `--zundamon_tts` flag and gracefully degrades to a no-op when assets are unavailable.

## Key Changes

- **New TTS backend infrastructure** (`include/rgss_tts.hxx`, `mruby-rgss/src/tts.cxx`): Defines a plain C function-pointer interface for text-to-speech, mirroring the existing audio backend split. The gem remains dependency-free; the executable installs the real backend at startup.

- **VOICEVOX CORE integration** (`src/voicevox_tts.cxx`): Implements the TTS backend using dynamic linking (`dlopen`/`dlsym`) to load VOICEVOX CORE at runtime. Synthesized audio plays through SDL_mixer on an unreserved channel. Desktop-only (Linux/macOS) via conditional compilation.

- **C API mirror header** (`include/voicevox_core_capi.hxx`): Hand-trimmed declarations of ~10 VOICEVOX CORE C API entry points needed for synthesis. Committed so the engine builds identically with or without downloaded assets.

- **Asset download script** (`scripts/download-voicevox-zundamon.bash`): Fetches four pinned GitHub release assets (~90 MiB total) into `assets/voicevox/`: VOICEVOX CORE library, ONNX Runtime, Open JTalk dictionary, and Zundamon's voice model (style id 3, "ノーマル"). Includes SHA-256 verification and is idempotent.

- **Asset validation** (`scripts/check_voicevox_assets.rb`): Verifies downloaded assets are complete and uncorrupted (ELF magic, zip headers, required dictionary files).

- **Message window integration** (`mruby-rpg2k/mrblib/scene/map.rb`): Calls `RGSS::Tts.speak()` with the plain, fully-expanded text when a Show Text page opens (not per-character reveal, not for bare choice windows).

- **Build system updates** (`CMakeLists.txt`): Adds `src/voicevox_tts.cxx` to the executable and links `${CMAKE_DL_LIBS}` for `dlopen` support. Defines `RGSS_VOICEVOX_SOURCE_DIR` for development builds.

- **Command-line flag** (`src/main.cxx`): New `--zundamon_tts` boolean flag (off by default) that calls `rgss_tts_init()` at startup.

- **Documentation** (`docs/adr/0046-zundamon-message-narration.md`): Architecture decision record explaining design rationale, licensing obligations, and offline-first approach.

## Notable Implementation Details

- **No build-time dependency**: VOICEVOX CORE is never linked; the engine builds identically whether or not `assets/voicevox/` exists. With no assets, `RGSS::Tts.available?` returns false and all calls are no-ops.

- **Licensing compliance**: Zundamon's voice model requires crediting "VOICEVOX:ずんだもん" in any generated audio. The download script writes `assets/voicevox/models/TERMS.txt` with usage terms that travel with the model.

- **Single utterance tracking**: At most one synthesized clip plays at a time (new message pages replace previous narration). A single `Mix_Chunk` is tracked and freed when replaced or at shutdown.

- **Graceful degradation**: Missing/broken assets, unsupported platforms (Emscripten, PSP, Wio), or synthesis failures are logged as warnings but never crash the game.

- **Version pinning**: VOICEVOX CORE (0.17.0), ONNX Runtime (1.23.2), Open JTalk dictionary (1.11

https://claude.ai/code/session_01Wy1vqnHmXGHJLnNPyQHttq