### PR TITLE
rpg2k: an unridden boat/ship/airship blocks movement again

### DIFF
--- a/changelog.d/unridden-vehicle-collision.fixed.md
+++ b/changelog.d/unridden-vehicle-collision.fixed.md
@@ -1,0 +1,17 @@
+- **A parked boat, ship or airship now blocks the hero and map events again**,
+  instead of being fully walk-through. `#char_passable?`/`#char_can_land?`
+  (a map event's own autonomous/custom-route movement, and the player's own
+  forced Set Move Route mirror) and the hero's own manual-input `#passable?`
+  only ever consulted `@event_tiles`, built solely from map events — an
+  unridden vehicle was never in it, so the party and every map event could
+  walk straight onto or through its tile. Verified against EasyRPG Player's
+  actual C++ source: `Game_Map::CheckOrMakeWayEx` blocks every mover, the
+  player included, on a parked Boat/Ship's own tile, but only checks the
+  Airship for a non-player mover — a walking hero passes clean over one,
+  while a map event's own movement (and the player's forced-route mirror)
+  is stopped by all three vehicle types alike. A new
+  `Scene::Map#vehicle_blocks?(x, y, block_airship:)` closes the gap in all
+  three functions, gated on that same player-vs-everyone-else split. A
+  ridden vehicle's own movement (`#vehicle_passable?`/`VehicleWorld`) is
+  untouched. Covered by two new `scripts/rpg2k_scene_check.rb` checks,
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -354,6 +354,46 @@ The work below is roughly ordered by the critical path to a walkable game
   would show, while an unridden vehicle placed on the map keeps its standing
   pose), confirmed to fail against the pre-fix code (a `NoMethodError` for
   the not-yet-extracted `#player_walk_pattern`) before the fix.
+  ✅ **The "hero/event collision with a moving unboarded vehicle" follow-up
+  the first-cut paragraph flagged is now closed too, verified against
+  EasyRPG Player's actual C++ source rather than left a guess.**
+  `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) — the collision test
+  every `MakeWay` call routes through — loops every Boat/Ship on the current
+  map and refuses the step for **any** mover, the player included, when one
+  sits on the target tile; it then separately checks the Airship, but only
+  when `self.GetType() != Game_Character::Player` — an unridden airship is a
+  walkable, non-blocking tile for the party on foot, yet still a solid
+  obstacle for every other mover (a map event's own autonomous/custom-route
+  movement, or the player's own forced Set Move Route mirror, `@player_char`).
+  This codebase's `#char_passable?`/`#char_can_land?` (map events and the
+  player's own forced-route mirror alike, via `MapWorld`) and the hero's own
+  manual-input `#passable?` (`mruby-rpg2k/mrblib/scene/map.rb`) only ever
+  consulted `@event_tiles` — built solely from map events
+  (`#rebuild_event_tiles`) — so a parked boat, ship or airship was fully
+  transparent to every other character: the party and every map event could
+  freely walk onto or through its tile. (`#board_vehicle`'s own asymmetric
+  boarding rule — a boat/ship only boards by facing it from an adjacent
+  tile, an airship only by already standing on it — only makes sense under
+  exactly this real rule, corroborating it from a second angle.) Fixed with
+  a new `#vehicle_blocks?(x, y, block_airship:)`, scanning `Game::Vehicle::
+  TYPES` (boat/ship always, airship only when `block_airship` is true) for
+  a placed vehicle occupying the tile on the currently loaded map, called
+  from all three of the functions above — `block_airship: !character.equal?
+  (@player_char)` in the two `char_*` methods (true for a map event, false
+  for the player's own forced-route mirror), and `block_airship: false`
+  unconditionally in the hero's own `#passable?`. A vehicle currently being
+  ridden is unaffected in practice: it tracks the party's own tile every
+  frame (`#follow_vehicle`), so this only ever blocks a *different*
+  character stepping onto the party's own tile, never the ridden vehicle's
+  own movement (driven entirely separately, through `#vehicle_passable?`/
+  `VehicleWorld`, which this fix leaves untouched — a moving vehicle's own
+  collision against a *different* parked vehicle remains unmodelled, a
+  narrower, rarer edge case than hero/event collision with a parked one).
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (a hero on foot
+  is blocked by a parked boat but walks straight over a parked airship; a
+  map event's own custom-route movement is blocked by both a parked boat
+  and a parked airship, unlike the hero's own airship exemption), both
+  confirmed to fail against the pre-fix code before the fix.
 
 #### Event system
 - ✅ Event pages — page conditions (switch/variable/item/actor) are implemented

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3222,6 +3222,30 @@ class RPG2k
         (f && f >= 1 && f <= 8) ? f : nil
       end
 
+      # Whether an unridden boat/ship (always) or airship (only when
+      # `block_airship` is true) is parked on the current map's (x, y) --
+      # verified against EasyRPG Player's actual C++ source rather than
+      # guessed at: `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) blocks
+      # every character type, the player included, on a Boat/Ship's own tile,
+      # but only checks the Airship when `self.GetType() != Game_Character::
+      # Player` -- an unridden airship is a walkable, non-blocking tile for
+      # the party on foot, but still a solid obstacle for every other
+      # character (a map event's autonomous/custom-route movement, or the
+      # player's own forced Set Move Route mirror, `@player_char`). A vehicle
+      # currently being ridden still counts here: it tracks the party's own
+      # tile every frame (`#follow_vehicle`), so this only ever blocks a
+      # *different* character trying to step onto the party's own tile, never
+      # the ridden vehicle's own movement (driven through the entirely
+      # separate `#vehicle_passable?`/`VehicleWorld`, never through this
+      # method or `#char_passable?`/`#passable?`).
+      def vehicle_blocks?(x, y, block_airship:)
+        types = block_airship ? Game::Vehicle::TYPES : %i[boat ship]
+        types.any? do |type|
+          v = @state.vehicle(type)
+          v && v.placed? && v.map_id == @state.map_id && v.x == x && v.y == y
+        end
+      end
+
       # Collision test for an event stepping one tile in `dir`: in bounds,
       # passable per the chipset, and not onto the hero or another event that
       # shares its collision layer. A "through" character ignores all of this.
@@ -3252,6 +3276,7 @@ class RPG2k
         end
         blocker = @event_tiles[[nx, ny]]
         return false if blocker && (blocker[:layer] == character.layer || blocker[:overlap_forbidden])
+        return false if vehicle_blocks?(nx, ny, block_airship: !character.equal?(@player_char))
         return true if @chipset.nil?
         @chipset.passable_tile?(@map.lower(character.x, character.y),
                                  @map.upper(character.x, character.y), dir) &&
@@ -3285,6 +3310,7 @@ class RPG2k
         end
         blocker = @event_tiles[[x, y]]
         return false if blocker && (blocker[:layer] == character.layer || blocker[:overlap_forbidden])
+        return false if vehicle_blocks?(x, y, block_airship: !character.equal?(@player_char))
         return true if @chipset.nil?
         @chipset.landable_tile?(@map.lower(x, y), @map.upper(x, y))
       end
@@ -7982,6 +8008,11 @@ class RPG2k
         # unless that event's own "doesn't overlap" flag forces the block
         # regardless of layer (LCF page field 35, #overlap_forbidden).
         return false if blocker && (blocker[:layer] == LAYER_SAME || blocker[:overlap_forbidden])
+        # An unridden boat/ship blocks the hero on foot exactly like a
+        # same-layer event would (see #vehicle_blocks?); an unridden airship
+        # never does, on foot or otherwise (block_airship: false — the hero
+        # is always "the player" for this rule).
+        return false if vehicle_blocks?(x, y, block_airship: false)
         return true if @chipset.nil?
         @chipset.passable_tile?(@map.lower(@state.x, @state.y),
                                  @map.upper(@state.x, @state.y), dir) &&

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5869,6 +5869,62 @@ check 'the airship cannot land on a tile a map event occupies unless it has Thro
   eq [0, 0], [st.x, st.y], 'the party stands where the airship touched down'
 end
 
+check 'an unridden boat/ship blocks the hero on foot, but an unridden airship does not' do
+  # Verified against EasyRPG Player's actual C++ source: Game_Map::
+  # CheckOrMakeWayEx blocks every character type (the player included) on a
+  # parked Boat/Ship's own tile, but only checks the Airship when
+  # self.GetType() != Player -- a walking hero passes clean over one.
+  scene = new_scene({}, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 1
+  boat.y = 0
+  RGSS::Input.dir_value = 6 # hold right, straight into the parked boat
+  10.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [0, 0], [st.x, st.y], 'an unridden boat blocks the hero on foot, same as a same-layer event'
+
+  air = st.vehicle(:airship)
+  air.map_id = st.map_id
+  air.x = 0
+  air.y = 1
+  RGSS::Input.dir_value = 2 # hold down, straight into the parked airship
+  10.times { scene.update }
+  RGSS::Input.dir_value = 0
+  eq [0, 1], [st.x, st.y], 'an unridden airship never blocks the hero on foot'
+end
+
+check 'an unridden boat/ship/airship all block a map event\'s own custom-route movement' do
+  # Unlike the hero (checked above), an event's own movement has no Player
+  # exemption for the Airship: EasyRPG's CheckOrMakeWayEx only skips the
+  # Airship check when self.GetType() == Player, so every other mover -- a
+  # map event's autonomous/custom route, and the player's own forced Set
+  # Move Route mirror -- is blocked by all three vehicle types alike.
+  east = event(0, 1, page(x_move_type: Game::MoveType::CUSTOM,
+                          route: move_route([R::MOVE_RIGHT])))
+  scene = new_scene({ 1 => east }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 1
+  boat.y = 1
+  200.times { scene.update }
+  eq 0, chars(scene)[1].x, 'an unridden boat stops the event dead before its first step'
+
+  south = event(2, 0, page(x_move_type: Game::MoveType::CUSTOM,
+                           route: move_route([R::MOVE_DOWN])))
+  scene2 = new_scene({ 1 => south }, player: [5, 5])
+  st2 = scene2.instance_variable_get(:@state)
+  air = st2.vehicle(:airship)
+  air.map_id = st2.map_id
+  air.x = 2
+  air.y = 1
+  200.times { scene2.update }
+  eq 0, chars(scene2)[1].y,
+     'an unridden airship stops the event too, unlike its hero-on-foot exemption above'
+end
+
 check 'Show Battle Animation with the wait flag holds the event then resumes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)


### PR DESCRIPTION
## Summary

- `Scene::Map#char_passable?`/`#char_can_land?` (a map event's own autonomous/custom-route movement, and the player's own forced Set Move Route mirror) and the hero's own manual-input `#passable?` only ever consulted `@event_tiles`, built solely from map events — a parked, unridden boat, ship or airship was fully transparent to every other character: the party and every map event could walk freely onto or through its tile.
- This was an explicit, deliberate follow-up flagged when vehicle move-routes first landed (`docs/TODO.md`'s "Vehicle move-routes" paragraph: "**Out of scope for this first cut, flagged as follow-ups**: ... hero/event collision with a moving unboarded vehicle (vehicles are not in the `@event_tiles` occupancy table)").
- Verified against EasyRPG Player's actual C++ source: `Game_Map::CheckOrMakeWayEx` (`src/game_map.cpp`) blocks **every** mover — the player included — on a parked Boat/Ship's own tile, but only checks the Airship when `self.GetType() != Game_Character::Player`. A walking hero passes clean over a parked airship; a map event's own movement (and the player's own forced-route mirror) is blocked by all three vehicle types alike. This asymmetry is corroborated by this codebase's own `#board_vehicle`: a boat/ship only boards by facing it from an adjacent tile, while an airship only boards by already standing on it — which only makes sense if the airship is meant to be walkable and the boat/ship is meant to be a solid obstacle.
- Fixed with a new `Scene::Map#vehicle_blocks?(x, y, block_airship:)`, scanning `Game::Vehicle::TYPES` (boat/ship always, airship only when `block_airship` is true) for a placed vehicle occupying the target tile on the currently loaded map. Wired into `#char_passable?`/`#char_can_land?` with `block_airship: !character.equal?(@player_char)` (true for a map event, false for the player's own forced-route mirror), and into the hero's own `#passable?` with `block_airship: false` unconditionally.
- A vehicle currently being ridden is unaffected in practice — it tracks the party's own tile every frame (`#follow_vehicle`) — and its own movement (`#vehicle_passable?`/`VehicleWorld`) is untouched by this fix; a moving vehicle's own collision against a *different* parked vehicle remains unmodelled, a narrower edge case than hero/event collision with a parked one.

## Test plan

- [x] Added two new `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against the pre-fix code (`git stash` of just `mruby-rpg2k/mrblib/scene/map.rb`) before the fix landed.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 773 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 491 checks passed.
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed.
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped (no test-bed data available in this sandbox; network-restricted).
- [x] `ruby scripts/rpg2k_command_soak.rb` — skipped (same reason).
- [x] Updated `docs/TODO.md` with a dense, evidence-citing writeup and a changelog fragment (`changelog.d/unridden-vehicle-collision.fixed.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoF8LNKFZ9NeuYEctKiK8B

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoF8LNKFZ9NeuYEctKiK8B)_