### PR TITLE
rpg2k: title screen plays system SE too, disabled Continue no longer silent

### DIFF
--- a/changelog.d/rpg2k-title-screen-system-se.fixed.md
+++ b/changelog.d/rpg2k-title-screen-system-se.fixed.md
@@ -1,0 +1,11 @@
+- **The title screen's New Game / Continue / Shutdown commands now play
+  system SE too, and a grayed-out Continue is no longer silent when
+  confirmed.** Follow-up to the field menu's own system-SE fix, sourced the
+  same way from EasyRPG Player: `Scene_Title::CommandNewGame`/
+  `CommandContinue`/`CommandShutdown` each play Decision right before
+  acting. A Continue with no save to resume was assumed to be a pure no-op
+  (the selection key "ignored"), but real RPG_RT's own `CommandContinue`
+  plays Buzzer there instead -- the enabled check lives inside the command
+  handler, not a guard that skips calling it altogether. `Scene::Title`
+  matches this now: `SFX_BUZZER` on a disabled Continue confirm, `SFX_DECISION`
+  on every successful command.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2383,11 +2383,29 @@ The work below is roughly ordered by the critical path to a walkable game
   all wire cursor moves to Cursor SE, B to Cancel SE, and each confirm to
   Decision or Buzzer per the source above (including a "no effect" item/
   skill use, which the source's own `scene_item.cpp` treats the same as any
-  other refused confirm). **Not modelled:** `Scene::Title`'s own Decision/
-  Buzzer on New Game/Continue/Shutdown (it already had Cursor SE from an
-  earlier pass, `#play_cursor_se`, reading the database directly rather
-  than through a game state that does not exist yet at the title screen);
-  this is a smaller, same-shape gap left for a future pass. Verified this
+  other refused confirm). **Not modelled, at the time:** `Scene::Title`'s own
+  Decision/Buzzer on New Game/Continue/Shutdown (it already had Cursor SE
+  from an earlier pass, `#play_cursor_se`, reading the database directly
+  rather than through a game state that does not exist yet at the title
+  screen). ✅ **Now fixed too**, and it turned up a genuine, not just
+  missing-feature, gap along the way: confirmed against EasyRPG's own
+  `Scene_Title::CommandContinue` (`src/scene_title.cpp`, fetched verbatim),
+  a grayed-out Continue with no save to resume is **not silent** when
+  confirmed -- `if (continue_enabled || Shift) { ...Decision... } else {
+  ...Buzzer...; return; }`, i.e. the enabled check lives *inside* the
+  command handler, not as a guard around calling it at all, so RPG_RT plays
+  Buzzer there rather than doing nothing. This engine's own title screen
+  used to just eat the key silently (a real behavioural gap, not merely an
+  absent SE) -- `Scene::Title#update`'s disabled-Continue branch now plays
+  `SFX_BUZZER`, and the New Game / (enabled) Continue / Shutdown branches
+  each play `SFX_DECISION` right before acting, matching
+  `CommandNewGame`/`CommandContinue`/`CommandShutdown` exactly (Shutdown
+  has no confirmation dialog either way -- EasyRPG's own version fades out
+  and pops immediately, same as this engine's plain `exit`).
+  `scripts/rpg2k_scene_check.rb`'s existing disabled-Continue check
+  (previously titled "...does nothing") is renamed and its comment updated
+  to describe the Buzzer rather than silence, without loosening what it
+  actually asserts (still zero scenes pushed). Verified this
   engine's own build under Xvfb reaches Menu -> actor-selection -> Skill and
   back with no exception and no `[RPG2k] system SE ... playback failed`
   logged (audio itself is silent in this sandboxed container -- no ALSA

--- a/mruby-rpg2k/mrblib/scene/title.rb
+++ b/mruby-rpg2k/mrblib/scene/title.rb
@@ -98,13 +98,18 @@ class RPG2k
 
         confirmed = Input.trigger?(Input::C)
         if confirmed && @selected_index == 1 && !@continue_available
-          # Continue is grayed out with nothing to resume: the selection key
-          # is ignored rather than landing on parent.continue_game's own
-          # "no save data" stub.
+          # Continue is grayed out with nothing to resume, but confirming it
+          # anyway is not silent -- confirmed against EasyRPG's own
+          # `Scene_Title::CommandContinue`, whose disabled branch is
+          # `SePlay(...SFX_Buzzer...); return;`, not a plain no-op (the
+          # enabled check lives inside the handler itself, not a guard in
+          # `vUpdate()` around calling it at all).
+          play_system_se(SFX_BUZZER)
         elsif confirmed || (auto = auto_select?)
           Audio.bgm_stop
           case @selected_index
           when 0  # New Game
+            play_system_se(SFX_DECISION)
             parent.start_new_game
           when 1  # Continue
             # A real player picks the slot themselves on the file-select list
@@ -114,8 +119,15 @@ class RPG2k
             # before this screen existed, which is all
             # scripts/compare-nepheshel-wine.bash (watching stderr for the
             # [RPG2k-MAP] marker only #continue_game emits) needs.
+            play_system_se(SFX_DECISION)
             auto ? parent.continue_game : parent.push(Scene::SaveLoad.new(parent, nil, :load))
           when 2  # Shutdown
+            # No confirmation dialog -- EasyRPG's own `CommandShutdown` plays
+            # Decision then exits immediately (a fade-out transition into
+            # `Scene::Pop`), unlike the field menu's own End Game command,
+            # which pushes a yes/no confirm screen this runtime does not
+            # model either.
+            play_system_se(SFX_DECISION)
             exit
           end
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7735,7 +7735,9 @@ end
 # resume; `any_save_exists?` (main.rb) is the source of truth, routed through
 # Scene::Title's own `continue_available?` (ADR 0012, extended by ADR 0045 to
 # cover every slot rather than just slot 1). The cursor can still reach the
-# grayed-out entry -- only its selection key is ignored.
+# grayed-out entry, and confirming it is not silent -- it plays Buzzer
+# (confirmed against EasyRPG's own Scene_Title::CommandContinue) rather than
+# doing nothing at all, but still never opens the file-select screen.
 
 check 'no save data: Continue is flagged unavailable and reachable by the cursor' do
   parent = TitleParent.new(fake_db, nil, false, false)
@@ -7746,7 +7748,7 @@ check 'no save data: Continue is flagged unavailable and reachable by the cursor
      'moving down from New Game still lands on Continue'
 end
 
-check 'no save data: pressing the selection key on Continue does nothing' do
+check 'no save data: pressing the selection key on Continue plays Buzzer and opens nothing' do
   parent = TitleParent.new(fake_db, nil, false, false)
   scene = RPG2k::Scene::Title.new(parent)
   scene.instance_variable_set(:@selected_index, 1)


### PR DESCRIPTION
## Summary

- Follow-up to #711 (the field menu's own system-SE fix), which explicitly left `Scene::Title`'s Decision/Buzzer playback as a "smaller, same-shape gap" for later.
- Confirmed against EasyRPG Player's source, fetched verbatim: `Scene_Title::CommandNewGame`/`CommandContinue`/`CommandShutdown` (`src/scene_title.cpp`) each play Decision SE right before acting.
- Found a genuine behavioral gap along the way, not just a missing SE: this engine's title screen treated confirming a grayed-out Continue (no save to resume) as a pure no-op. Real RPG_RT's own `CommandContinue` is:
  ```cpp
  if (continue_enabled || Input::IsTriggered(Input::SHIFT)) {
      ...SFX_Decision...
  } else {
      ...SFX_Buzzer...
      return;
  }
  ```
  The enabled check lives *inside* the command handler, not a guard in `vUpdate()` that skips calling it altogether — so a disabled Continue confirm plays Buzzer, not silence.
- `Scene::Title#update` now plays `SFX_BUZZER` on a disabled-Continue confirm and `SFX_DECISION` on each successful command (New Game / Continue / Shutdown). Shutdown still has no confirmation dialog either way — EasyRPG's own version fades out and pops immediately, matching this engine's plain `exit`.
- Updated the existing `rpg2k_scene_check.rb` disabled-Continue check's name/comment (was "...does nothing") to describe the Buzzer rather than silence, without changing what it actually asserts (still zero scenes pushed).

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Verified visually with this engine's own build under Xvfb: title screen → Down (Continue) → confirm correctly opens the file-select screen, no exceptions, no `[RPG2k] system SE ... playback failed` logged (this sandboxed container has no ALSA device, so actual audio output could not be heard — only that the calls run cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_