### PR TITLE
rpg2k: a self-referential batch Control Variables write splits at the source, not one broadcast

### DIFF
--- a/changelog.d/control-variables-range-self-reference.fixed.md
+++ b/changelog.d/control-variables-range-self-reference.fixed.md
@@ -1,0 +1,21 @@
+- **A batch (range) Control Variables write whose own operand reads a
+  variable inside the destination range it writes now splits at the source
+  instead of broadcasting one value to the whole range.** Verified against
+  EasyRPG Player's actual C++ source: `Game_Variables::WriteRangeVariable`
+  (`src/game_variables.cpp`), reached whenever
+  `Game_Interpreter::CommandControlVariables` (`src/game_interpreter.cpp`)
+  sees a direct-variable operand (type 1, "Var A ops B") applied to a genuine
+  multi-id range, writes ids at or before the source from its value *before*
+  the command touched anything, then writes ids after the source from its
+  value *after* that first pass already updated it — so `Var[1..5] += Var[3]`
+  leaves ids 4-5 combining with a different number than ids 1-3 whenever the
+  operation is anything but a plain Set. `Game::Interpreter#do_control_vars`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) always read its operand once up front
+  and broadcast that single value across the whole range, which happened to
+  match RPG_RT except in this one self-referential case. Fixed with a new
+  `#do_control_vars_range_variable`, ported from `WriteRangeVariable`'s
+  two-pass split; a source outside the destination range still degenerates
+  to the original single-read behaviour, and every other operand type
+  (constant, indirect, random, item, actor, ...) is untouched. Covered by a
+  new `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3021,8 +3021,40 @@ following this paragraph as the original record.
   separate dice, not one roll broadcast to all five. The random case is now
   re-evaluated per id inside the loop; every other operand type keeps its
   existing once-up-front evaluation, since nothing establishes RPG_RT
-  re-reads a *non-random* source per id (a self-referential range reading a
-  variable inside its own write range is a different, unverified question).
+  re-reads a *non-random* source per id. ✅ **The self-referential-range
+  question this same bullet left open is now settled and fixed too, verified
+  against EasyRPG Player's actual C++ source rather than left unverified.** A
+  direct-variable operand (type 1, "Var A ops B") applied to a genuine
+  multi-id range whose own source id falls *inside* the destination range is
+  not one value read up front and broadcast to the whole range the way this
+  codebase (and every other operand type, source-outside-range included)
+  already treats it. `Game_Interpreter::CommandControlVariables`
+  (`src/game_interpreter.cpp`) dispatches a direct-variable range write to
+  `Game_Variables::SetRangeVariable`/`AddRangeVariable`/etc.
+  (`src/game_variables.cpp`), all thin wrappers over
+  `Game_Variables::WriteRangeVariable`: when the source id falls in
+  `[first_id, last_id]`, it splits into two passes right at the source —
+  `first_id..src` is written first from `src`'s value *before* this command
+  touched anything, then (only once that first pass has actually run, and
+  therefore already updated `src`'s own stored value for anything but a
+  plain Set) `src+1..last_id` is written from `src`'s value *now*, not its
+  original one. A source outside the range skips the split entirely and
+  degenerates to the single up-front read this codebase already had, so the
+  gap was invisible outside this one specific case. Fixed with a new
+  `Game::Interpreter#do_control_vars_range_variable`, called from
+  `#do_control_vars` only for operand type 1 over a genuine multi-id range
+  (`a < b`), porting `WriteRangeVariable`'s two-pass split exactly (a source
+  outside `a..b` falls back to the same single-read-and-broadcast the
+  generic path already used, so nothing changes there); every other operand
+  type (including random) is untouched. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (a self-referential `+=` range splits
+  at the source exactly as EasyRPG's algorithm predicts — ids after the
+  source combine with its post-first-pass value, not its original one; a
+  source outside the range still broadcasts a single value, unaffected; a
+  self-referential `=` is confirmed unobservably identical either way, since
+  writing the source back onto itself never changes what the second pass
+  re-reads), the first case confirmed to fail against the pre-fix code
+  (`expected [20, 20, 20, 30, 30], got [20, 20, 20, 20, 20]`) before the fix.
   Covered by a new `scripts/rpg2k_logic_check.rb` check (a wide-range batch
   assign must not produce the same value in every variable).
 - ✅ **Indirect ("pointer") target addressing now no-ops on a resolved id

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1350,10 +1350,47 @@ module Game
       # A random operand (type 3) rolls independently for each variable in the
       # range, matching RPG_RT -- a batch "Var[1..5] = random 1~6" is five
       # separate dice, not one roll broadcast to all five. Every other operand
-      # type is evaluated once up front, as before.
+      # type is evaluated once up front, as before -- except a direct-variable
+      # operand (type 1) applied to a genuine multi-id range, which needs its
+      # own split below (a variable-A-ops-B batch reading its own operand out
+      # of the same range it writes).
       random = cmd.param(4) == 3
+      return do_control_vars_range_variable(cmd, a, b, op) if !random && cmd.param(4) == 1 && a < b
       val = operand_value(cmd) unless random
       (a..b).each { |id| variables[id] = apply(op, variables[id], random ? operand_value(cmd) : val) }
+    end
+
+    # A batch (range) Control Variables write whose operand is itself a plain
+    # variable read (type 1, "Var A ops B") and whose source id `src` falls
+    # inside the destination range `a..b` is *not* a single value broadcast to
+    # every id the way an out-of-range source (or any other operand type) is.
+    # EasyRPG's `Game_Variables::WriteRangeVariable`
+    # (`src/game_variables.cpp`) -- the direct-variable-lookup range path
+    # `Game_Interpreter::CommandControlVariables`
+    # (`src/game_interpreter.cpp`) dispatches to whenever the target
+    # evaluation mode is a genuine multi-id range -- splits the write into two
+    # passes right at `src`: ids `a..src` are written first, from `src`'s
+    # value *before* this command touched anything; then, only once that
+    # first pass has run (and, for anything but a plain Set, has therefore
+    # already changed `src`'s own stored value), ids `src+1..b` are written
+    # from `src`'s value *now* -- i.e. the just-updated one, not the original.
+    # For Set this is unobservable (`src` written back to its own unchanged
+    # value), but for Add/Sub/Mult/Div/Mod it means every id *after* `src` in
+    # the range ends up combining the operation with itself twice while every
+    # id at or before `src` only sees it once. A source outside `a..b`
+    # entirely skips this split and degenerates to the ordinary single
+    # up-front read every other operand type already uses.
+    def do_control_vars_range_variable(cmd, a, b, op)
+      src = cmd.param(5)
+      unless src >= a && src <= b
+        val = variables[src]
+        (a..b).each { |id| variables[id] = apply(op, variables[id], val) }
+        return
+      end
+      before = variables[src]
+      (a..src).each { |id| variables[id] = apply(op, variables[id], before) }
+      after = variables[src]
+      ((src + 1)..b).each { |id| variables[id] = apply(op, variables[id], after) }
     end
 
     def operand_value(cmd)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4723,6 +4723,55 @@ check 'Control Variables batch random-assign rolls independently per variable' d
   ok vals.uniq.size > 1, "every variable in the batch got the same roll: #{vals}"
 end
 
+check 'Control Variables batch operand reading its own destination range splits at the source, not one broadcast read' do
+  # EasyRPG's Game_Variables::WriteRangeVariable (src/game_variables.cpp),
+  # reached from Game_Interpreter::CommandControlVariables's direct-variable
+  # range dispatch (src/game_interpreter.cpp) whenever the source id falls
+  # inside the destination range: ids at or before the source combine with
+  # its *original* value, then (only once that first pass ran) ids after the
+  # source combine with whatever the first pass just left there -- not one
+  # value read up front and broadcast to the whole range the way every other
+  # operand type (and a source outside the range) already works.
+  st = new_state
+  it = Game::Interpreter.new(st)
+  (1..5).each { |id| st.variables[id] = 10 }
+  # mode 1 (range): ids 1..5, op 1 (+=), operand type 1 (plain variable), src = 3.
+  it.start([FakeCmd.new(IC::CONTROL_VARS, [1, 1, 5, 1, 1, 3])])
+  it.update
+  # var[3]'s own original value (10) is added to ids 1..3 first (-> 20 each,
+  # var[3] included), then var[3]'s *now-updated* value (20) is added to ids
+  # 4..5 (-> 30 each) -- not the original 10 a single up-front read would use.
+  eq [20, 20, 20, 30, 30], (1..5).map { |id| st.variables[id] },
+     'ids after the source should see its post-first-pass value, not its original one'
+
+  # Control: the identical batch with the source *outside* the destination
+  # range degenerates to the ordinary single up-front read, unaffected by
+  # this fix -- every id gets the same, unsplit value.
+  st2 = new_state
+  it2 = Game::Interpreter.new(st2)
+  (1..5).each { |id| st2.variables[id] = 10 }
+  st2.variables[9] = 7
+  it2.start([FakeCmd.new(IC::CONTROL_VARS, [1, 1, 5, 1, 1, 9])])
+  it2.update
+  eq [17, 17, 17, 17, 17], (1..5).map { |id| st2.variables[id] },
+     'a source outside the destination range still broadcasts a single value to the whole batch'
+
+  # Control: a Set (rather than Add) through a self-referential range is
+  # unobservable either way, since writing the source back onto itself never
+  # changes the value the second pass re-reads.
+  st3 = new_state
+  it3 = Game::Interpreter.new(st3)
+  st3.variables[1] = 1
+  st3.variables[2] = 2
+  st3.variables[3] = 99
+  st3.variables[4] = 4
+  st3.variables[5] = 5
+  it3.start([FakeCmd.new(IC::CONTROL_VARS, [1, 1, 5, 0, 1, 3])])
+  it3.update
+  eq [99, 99, 99, 99, 99], (1..5).map { |id| st3.variables[id] },
+     'a self-referential Set still broadcasts the source value to the whole range'
+end
+
 check 'a variable clamps to +-999999 instead of overflowing' do
   # RPG_RT never lets a variable's stored value leave +-999999 in RPG2000
   # (+-9999999 in RPG2003, LCF.var_max/var_min) -- a Control Variables write


### PR DESCRIPTION
## Summary

- `Game::Interpreter#do_control_vars` (`mruby-rpg2k/mrblib/interpreter.rb`) always read a direct-variable operand once, up front, and broadcast that single value to every id in the range — correct only when the source variable sits outside the destination range.
- Verified against EasyRPG Player's actual C++ source: `Game_Variables::WriteRangeVariable` (`src/game_variables.cpp`), reached from `Game_Interpreter::CommandControlVariables`'s direct-variable range dispatch (`src/game_interpreter.cpp`), splits the write into two passes right at the source id — ids at/before the source combine with the source's value *before* the command runs, then ids after the source combine with the source's value *now* (after the first pass has already mutated the array). For anything but a plain Set, this makes ids after the source see a different (already-once-combined) value than ids at/before it, e.g. `Var[1..5] += Var[3]` starting all at 10 yields `[20,20,20,30,30]`, not one broadcast `[20,20,20,20,20]`.
- Added `Game::Interpreter#do_control_vars_range_variable`, called only when the operand is a direct-variable read (type 1) over a genuine multi-id range, porting `WriteRangeVariable`'s two-pass split exactly. A source outside the range still falls back to the original single-read-and-broadcast path; every other operand type (constant, indirect, random, item, actor, ...) is untouched.
- This was an explicitly flagged "unverified question" left next to the already-fixed "batch random-assign rolls independently" bullet in `docs/TODO.md`.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 774 passed (new check: self-referential `+=` splits as predicted, source-outside-range still broadcasts, self-referential `=` unaffected either way; confirmed to fail pre-fix)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 491 passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 passed
- [x] `ruby scripts/rpg2k_command_soak.rb` — 3430 commands, no gaps

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_