### PR TITLE
rpg2k: save/load file-select screen draws its scroll indicator

### DIFF
--- a/changelog.d/rpg2k-save-screen-scroll-arrows.added.md
+++ b/changelog.d/rpg2k-save-screen-scroll-arrows.added.md
@@ -1,0 +1,8 @@
+- **The save/load file-select screen now draws its scroll indicator.**
+  Confirmed against EasyRPG Player's source (`Scene_File`'s own
+  `MakeArrowSprite`/`UpdateArrows`, not the generic list-window scroll
+  mechanism, and not a scrollbar -- RPG_RT has no such thing): two
+  independent blinking arrow sprites pinned at the top and bottom of the
+  3-visible-of-15 slot viewport, shown only while a slot is hidden in that
+  direction, reusing this engine's existing pause-arrow windowskin cells
+  and 20-frame on/off blink timing.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2610,11 +2610,43 @@ The work below is roughly ordered by the critical path to a walkable game
   zero-padding, and sizes each slot's cursor to its own label text via
   `Bitmap#text_size`. Verified against the same reference frame field-for-
   field, on both the header state (File 1 selected, occupied) and after
-  pressing Down onto the empty File 2 slot. **Not chased further:** the
-  16px strip below the third box that a scroll indicator arrow presumably
-  occupies once there is more than one screenful -- the reference capture
-  used here never scrolled, so there is no confirmed glyph/position for it
-  yet.
+  pressing Down onto the empty File 2 slot. **Not chased further, at the
+  time:** the 16px strip below the third box that a scroll indicator arrow
+  presumably occupies once there is more than one screenful -- the
+  reference capture used here never scrolled, so there was no confirmed
+  glyph/position for it yet.
+  ✅ **Now implemented, sourced without needing a wine capture at all.**
+  Confirmed against EasyRPG's own `Scene_File` (`src/scene_file.cpp`,
+  fetched verbatim): it is a pair of independent, blinking arrow sprites --
+  not a scrollbar/track, which does not exist anywhere in RPG_RT/EasyRPG
+  (confirmed by a zero-hit search for any scrollbar-drawing function) --
+  built and driven entirely by `Scene_File` itself (`MakeArrowSprite`/
+  `UpdateArrows`), outside `Window_SaveFile` (which has no scroll logic of
+  its own) and outside the generic `Window_Selectable::UpdateArrows()`
+  every ordinary list window uses instead. It reuses the identical
+  windowskin cells and 20-frame on/off blink this engine's own `Window`
+  class already had for its "waiting for input" pause arrow
+  (`Window::ARROW_SRC_X`/`ARROW_H`/`ARROW_W`/`ARROW_BLINK_FRAMES`, added a
+  session ago porting the same EasyRPG source) -- RPG_RT draws the pause
+  arrow and this screen's own down arrow from the exact same cell, one row
+  up is the (previously unused in this codebase) up-arrow cell.
+  `Scene::SaveLoad` gains two `Sprite`s built in `#build_arrow_sprites`,
+  pinned at the very top (`y = HEADER_H`, right below the header -- this
+  engine's `HEADER_H` (32) already matches EasyRPG's own fixed `y=32` for
+  its up arrow exactly) and very bottom (`y = SCREEN_H - ARROW_H`) of the
+  slot viewport, centred horizontally, each shown only while blinking "on"
+  *and* a slot is hidden in that direction (`@top > 0` for up, `@top <
+  SLOT_COUNT - VISIBLE_SLOTS` for down -- the same shape as EasyRPG's own
+  `top_index < max_index - 2` generalised past its fixed 3-visible layout).
+  A windowskin-less fallback (a solid triangle, mirroring `Window`'s own
+  fallback shape but built in either direction) covers the no-skin case the
+  rest of this engine's UI already degrades to elsewhere. Verified with a
+  deterministic frame-by-frame host-harness test (not a screen capture,
+  which proved too flaky under this sandbox's software-rendered Xvfb to
+  reliably catch a specific blink phase): stepping `Scene::SaveLoad#update`
+  frame by frame confirms the down arrow starts on, flips off at exactly
+  the 20th frame, and swaps places with the up arrow once scrolled to the
+  last slot.
 
 #### Assets & infrastructure
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -46,10 +46,33 @@ class RPG2k
 
       # (SCREEN_H - HEADER_H) / SLOT_BOX_H, i.e. how many slot boxes fit
       # below the header -- 3 on RPG2000's 320x240 screen (32 + 3*64 = 224,
-      # leaving 16px for a scroll indicator this port does not draw yet).
+      # leaving 16px for the scroll indicator #build_arrow_sprites draws).
       # Matches the reference capture exactly: three boxes on screen, the
       # rest reached by scrolling.
       VISIBLE_SLOTS = (SCREEN_H - HEADER_H) / SLOT_BOX_H
+
+      # The list-scroll indicator: two independent blinking arrow sprites
+      # (not a scrollbar/track -- there is no such thing anywhere in
+      # RPG_RT), pinned at the very top and bottom of the whole slot
+      # viewport and shown only while a slot is hidden in that direction.
+      # Confirmed against EasyRPG's own `Scene_File` (`src/scene_file.cpp`,
+      # `MakeArrowSprite`/`UpdateArrows`): this is entirely `Scene_File`'s
+      # own doing, outside `Window_SaveFile` (which has no scroll logic of
+      # its own -- it just draws one slot's contents) and outside the
+      # generic `Window_Selectable` scroll-arrow mechanism other list
+      # windows use. It reuses the identical windowskin cells and 20-frame
+      # on/off blink this build's own `Window` already tracks for its
+      # "waiting for input" pause arrow (`Window::ARROW_*` -- RPG_RT draws
+      # both from the same System graphic block, the pause arrow and this
+      # screen's down arrow sharing one cell). The up arrow is the same
+      # block one row up (y=8 vs. y=16), which nothing in this codebase
+      # needed a constant for until now.
+      ARROW_W = Window::ARROW_W
+      ARROW_H = Window::ARROW_H
+      ARROW_SRC_X = Window::ARROW_SRC_X
+      UP_ARROW_SRC_Y = 8
+      DOWN_ARROW_SRC_Y = Window::ARROW_SRC_Y
+      ARROW_BLINK_FRAMES = Window::ARROW_BLINK_FRAMES
 
       def initialize parent, state, mode
         super parent
@@ -61,19 +84,24 @@ class RPG2k
         @slots = (1..SLOT_COUNT).map { |slot| parent.load_save_state(slot) }
         @index = 0
         @top = 0
+        @arrow_anim = 0
         @message = nil
         @slot_windows = []
         build_header_window
         build_slot_windows
+        build_arrow_sprites
       end
 
       def dispose
         close_message
         @header_window.dispose if @header_window
         @slot_windows.each(&:dispose)
+        @up_arrow.dispose if @up_arrow
+        @down_arrow.dispose if @down_arrow
       end
 
       def update
+        tick_arrows
         return drive_message if @message
 
         if Input.trigger?(Input::B)
@@ -95,6 +123,7 @@ class RPG2k
         @top = @index if @index < @top
         @top = @index - VISIBLE_SLOTS + 1 if @index >= @top + VISIBLE_SLOTS
         refresh_slot_windows
+        refresh_arrows
         play_system_se(SFX_CURSOR)
       end
 
@@ -117,6 +146,68 @@ class RPG2k
           else
             play_system_se(SFX_BUZZER)
           end
+        end
+      end
+
+      # Tick the blink phase every frame (RPG_RT's own arrows keep animating
+      # even while, say, this screen's save-result message is up -- there is
+      # nothing in EasyRPG's `UpdateArrows` that gates it on anything besides
+      # whether more slots are hidden) and refresh visibility from it.
+      def tick_arrows
+        return unless @up_arrow
+        @arrow_anim = (@arrow_anim + 1) % (ARROW_BLINK_FRAMES * 2)
+        refresh_arrows
+      end
+
+      # An arrow shows only while blinking "on" *and* there is a slot hidden
+      # in that direction -- `@top > 0` for up, and for down: whether the
+      # viewport's last visible row (`@top + VISIBLE_SLOTS - 1`) is still
+      # short of the last real slot (`SLOT_COUNT - 1`), i.e. `@top <
+      # SLOT_COUNT - VISIBLE_SLOTS` -- the same shape as EasyRPG's own
+      # `top_index < max_index - 2` for its fixed 3-visible layout.
+      def refresh_arrows
+        return unless @up_arrow
+        blink_on = @arrow_anim < ARROW_BLINK_FRAMES
+        @up_arrow.visible = blink_on && @top > 0
+        @down_arrow.visible = blink_on && @top < SLOT_COUNT - VISIBLE_SLOTS
+      end
+
+      # Two independent sprites (not part of any one slot's own Window),
+      # pinned to the top and bottom edge of the whole slot viewport and
+      # centred horizontally -- see the class comment above VISIBLE_SLOTS.
+      def build_arrow_sprites
+        @up_arrow = build_arrow_sprite(UP_ARROW_SRC_Y)
+        @up_arrow.y = HEADER_H
+        @down_arrow = build_arrow_sprite(DOWN_ARROW_SRC_Y)
+        @down_arrow.y = SCREEN_H - ARROW_H
+        refresh_arrows
+      end
+
+      def build_arrow_sprite(src_y)
+        sprite = Sprite.new
+        sprite.z = 450
+        sprite.x = (SCREEN_W - ARROW_W) / 2
+        bmp = Bitmap.new(ARROW_W, ARROW_H)
+        if @skin
+          bmp.blt 0, 0, @skin, Rect.new(ARROW_SRC_X, src_y, ARROW_W, ARROW_H)
+        else
+          draw_arrow_fallback(bmp, src_y == UP_ARROW_SRC_Y)
+        end
+        sprite.bitmap = bmp
+        sprite.visible = false
+        sprite
+      end
+
+      # No windowskin to take the arrow art from -- a small solid triangle,
+      # mirroring Window#draw_arrow_fallback's own shape (narrowing toward
+      # the point) but in either direction, since this screen needs both.
+      def draw_arrow_fallback(bmp, pointing_up)
+        color = Color.new(232, 232, 248, 255)
+        ARROW_H.times do |row|
+          r = pointing_up ? ARROW_H - 1 - row : row
+          w = ARROW_W - r * 2
+          next if w <= 0
+          bmp.fill_rect r, row, w, 1, color
         end
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9890,6 +9890,39 @@ check 'Scene::SaveLoad: cancelling (B) pops back without touching the parent app
   eq [], parent.continue_calls, 'or resumes anything'
 end
 
+# The scroll indicator: two independent blinking arrow sprites, not a
+# scrollbar -- see the class comment above Scene::SaveLoad::VISIBLE_SLOTS.
+# Confirmed against EasyRPG's own Scene_File (MakeArrowSprite/UpdateArrows).
+check 'Scene::SaveLoad: at the top of the list, only the down arrow can show, ' \
+      'blinking on a 20-frame cycle' do
+  scene, = save_load_scene(:load)
+  up = scene.instance_variable_get(:@up_arrow)
+  down = scene.instance_variable_get(:@down_arrow)
+  ok !up.visible, 'no slot is hidden above the first, so the up arrow starts hidden'
+  ok down.visible, 'more slots are hidden below, so the down arrow starts on'
+  19.times { RGSS::Input.triggered = []; scene.update }
+  ok down.visible, 'still on 19 frames into the 20-frame "on" half'
+  RGSS::Input.triggered = []
+  scene.update
+  ok !down.visible, 'the 20th frame flips it to the "off" half of the blink'
+  ok !up.visible, 'the up arrow never turns on while still at the top'
+end
+
+check 'Scene::SaveLoad: scrolled to the bottom, only the up arrow can show' do
+  scene, = save_load_scene(:load)
+  (RPG2k::MAX_SAVE_SLOTS - 1).times do
+    RGSS::Input.triggered = [RGSS::Input::DOWN]
+    scene.update
+    RGSS::Input.reset
+  end
+  up = scene.instance_variable_get(:@up_arrow)
+  down = scene.instance_variable_get(:@down_arrow)
+  eq RPG2k::MAX_SAVE_SLOTS - 1, scene.instance_variable_get(:@index),
+     'moved all the way down to the last slot'
+  ok up.visible, 'slots are hidden above the now-scrolled viewport'
+  ok !down.visible, 'the last slot is on screen, nothing hidden below'
+end
+
 # -- Open Save Menu / Open Load Menu (event commands) driving the same picker --
 #
 # RPG2003's Open Save Menu (11910) and Open Load Menu (5001) event commands


### PR DESCRIPTION
## Summary

- The save/load file-select screen (`Scene::SaveLoad`, 3-of-15 slots visible at once) now draws the scroll indicator that a previous PR (the per-slot-box layout rewrite) left as an explicitly unconfirmed gap — there was no wine reference capture that ever scrolled the list.
- Resolved this time without needing a wine capture at all: confirmed against EasyRPG Player's own `Scene_File` source (`MakeArrowSprite`/`UpdateArrows`, fetched verbatim), which shows it's **two independent blinking arrow sprites, not a scrollbar** — RPG_RT has no scrollbar-drawing code anywhere (confirmed by a zero-hit search across the whole repo). This is `Scene_File`'s own doing, entirely outside `Window_SaveFile` (which has no scroll logic of its own — it only draws one slot's contents) and outside the generic `Window_Selectable::UpdateArrows()` mechanism every ordinary list window uses instead.
- `Scene::SaveLoad` gains two sprites (`#build_arrow_sprites`) pinned at the very top (`y = HEADER_H`) and bottom (`y = SCREEN_H - ARROW_H`) of the slot viewport, centered horizontally, each shown only while blinking "on" *and* a slot is hidden in that direction. They reuse this engine's existing `Window::ARROW_*` constants — the same windowskin cells and 20-frame on/off blink already established for the message "waiting for input" pause arrow (RPG_RT draws both from the same System graphic block; the up-arrow cell one row above the down/pause cell had no constant yet).
- A windowskin-less fallback (a solid triangle, mirroring `Window`'s own fallback shape but built pointing either direction) covers the no-skin case the rest of this engine's UI already degrades to elsewhere.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (2 new checks added)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Verified with a **deterministic frame-by-frame host-harness test** rather than a screen capture — stepping `Scene::SaveLoad#update` frame by frame confirms the down arrow starts visible, flips off at exactly the 20th frame (matching `ARROW_BLINK_FRAMES`), and swaps places with the up arrow once scrolled to the last slot. A live screen capture under this sandbox's software-rendered Xvfb proved too flaky to reliably catch a specific ~0.33s blink phase, but the underlying game logic itself is proven correct this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_