### PR TITLE
rpg2k: save/load file-select screen draws party face thumbnails

### DIFF
--- a/changelog.d/save-select-face-thumbnails.fixed.md
+++ b/changelog.d/save-select-face-thumbnails.fixed.md
@@ -1,0 +1,19 @@
+- **The save/load file-select screen now draws each save slot's party face
+  thumbnails**, not just the leader's name/level/HP text. `Game::State#to_lsd`
+  already exported up to four members' `faceset_name`/`faceset_index` into
+  the save's title chunk specifically so a real RPG_RT could show these
+  (LCF save chunk 100, fields 21-28), but `Scene::SaveLoad#draw_slot_box`
+  never read them back. Verified against EasyRPG Player's actual C++ source:
+  `Window_Base::DrawFace` crops a plain 48x48 FaceSet cell with no scaling
+  and never mirrors it for this screen (unlike a message window's Change
+  Face Graphic, which can), and `Window_SaveFile` draws up to four of them
+  in a row at a 56px pitch. Fixed with a new `Scene::SaveLoad#draw_slot_faces`
+  (plus `#load_face_bitmap`/`#build_face_cell`, mirroring `Scene::Map`'s own
+  message-face helpers), drawing each of the slot's party members
+  (`state.party.actors[0..3]`, seat order, the same order `#to_lsd` writes
+  them in) right-anchored in the slot box at the same 56px pitch; a member
+  with no FaceSet set (a blank name) simply leaves its slot empty. Covered
+  by two new `scripts/rpg2k_scene_check.rb` checks (two distinct members'
+  faces crop from their own FaceSet cell at the right position and pitch;
+  a blank-named member and a 5th-and-beyond member both draw nothing),
+  both confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2200,10 +2200,24 @@ The work below is roughly ordered by the critical path to a walkable game
   "an event bypasses the general access flag" precedent Open Main Menu already
   set for Change Main Menu Access. Only the
   `--rpg2k_continue` headless flag still resumes slot 1 directly, since it has
-  no input loop of its own to drive a second screen. See ADR 0045. **Not done
-  yet:** the party face thumbnails a real save-select screen shows
-  (`Game::State#to_lsd`'s title chunk already exports the FaceSets
-  specifically for this).
+  no input loop of its own to drive a second screen. See ADR 0045. ✅ **The
+  party face thumbnails a real save-select screen shows are now drawn too**
+  (`Game::State#to_lsd`'s title chunk already exported the FaceSets
+  specifically for this, unread until now). Verified against EasyRPG
+  Player's actual C++ source rather than guessed at: `Window_Base::DrawFace`
+  crops a plain 48x48 FaceSet cell with no scaling and never mirrors it on
+  this screen specifically, and `Window_SaveFile` lays up to four of them
+  out in a row at a 56px pitch. `Scene::SaveLoad#draw_slot_box` used to draw
+  only the label/leader-name/level+HP text; a new `#draw_slot_faces` (plus
+  `#load_face_bitmap`/`#build_face_cell`, mirroring `Scene::Map`'s own
+  message-face helpers) now draws each of the slot's party members
+  (`state.party.actors[0..3]`, the same seat order `#to_lsd` writes them
+  in) right-anchored in the box at that same 56px pitch, skipping any
+  member with no FaceSet set. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks (two distinct members' faces crop
+  from their own FaceSet cell at the right position/pitch; a blank-named
+  member and a 5th-and-beyond member both draw nothing), both confirmed to
+  fail against the pre-fix code before the fix.
   ✅ **Continue could resume with the wrong actor leading the party.**
   Found by comparing against a genuine `RPG_RT.exe` under wine on a real
   Nepheshel save: chunk 109's party list (field 1) named actor 1 ("リト"),

--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -44,6 +44,20 @@ class RPG2k
       SLOT_LINES = 3
       SLOT_BOX_H = LINE_H * SLOT_LINES + Window::BORDER * 2
 
+      # RPG2000 FaceSet geometry (mirrors Scene::Map's own FACE_SIZE): a
+      # 48x48 cell cropped straight out of a member's FaceSet sheet, never
+      # scaled. `SLOT_BOX_H`'s own content height (LINE_H * SLOT_LINES = 48)
+      # already matches this exactly, which is why a slot box fits one row
+      # of faces with no extra vertical space to spare.
+      FACE_SIZE = 48
+      # EasyRPG's Window_SaveFile lays its four face slots out at
+      # `cx = 92 + i * 56` (Window_Base::DrawFace, 8px of gap past each
+      # 48px cell) -- this screen's own box is a different width, so the
+      # row is anchored to the box's own right edge instead of reusing that
+      # absolute offset, keeping the 56px pitch between slots.
+      FACE_SPACING = 56
+      MAX_SLOT_FACES = 4
+
       # (SCREEN_H - HEADER_H) / SLOT_BOX_H, i.e. how many slot boxes fit
       # below the header -- 3 on RPG2000's 320x240 screen (32 + 3*64 = 224,
       # leaving 16px for a scroll indicator this port does not draw yet).
@@ -159,11 +173,14 @@ class RPG2k
       end
 
       # `slot_index`'s box: the file label always, and -- when the slot holds
-      # a save -- the leader's name and level+HP beneath it. Confirmed
-      # against genuine RPG_RT under wine: an empty slot shows only the
-      # label (no placeholder text at all), and an occupied one shows
-      # neither gold nor the current map, and HP with no `/max`, unlike this
-      # screen's own previous single-list-window layout.
+      # a save -- the leader's name and level+HP beneath it, plus up to four
+      # party face thumbnails along the right edge. Confirmed against
+      # genuine RPG_RT under wine: an empty slot shows only the label (no
+      # placeholder text at all), and an occupied one shows neither gold nor
+      # the current map, and HP with no `/max`, unlike this screen's own
+      # previous single-list-window layout. The faces are data
+      # `Game::State#to_lsd` already exports into the save's title chunk
+      # (see docs/TODO.md) but this screen never read back.
       def draw_slot_box(win, inner_w, slot_index)
         label = slot_label(slot_index)
         c = Bitmap.new(inner_w, LINE_H * SLOT_LINES)
@@ -179,6 +196,7 @@ class RPG2k
           c.draw_text 0, LINE_H * 2, inner_w, LINE_H,
                       "#{term(:level_short, 'Lv')}#{level}    " \
                       "#{term(:hp_short, 'HP')}#{hp}"
+          draw_slot_faces(c, inner_w, state.party.actors)
         end
         win.contents = c
         win.cursor_rect = if slot_index == @index
@@ -186,6 +204,49 @@ class RPG2k
                            else
                              Rect.new(0, 0, 0, 0)
                            end
+      end
+
+      # Up to `MAX_SLOT_FACES` party face thumbnails, right-anchored within
+      # the slot box, one member per slot in seat order (`actors[0..3]`, the
+      # same per-member order `Game::State#to_lsd` already writes them in).
+      # A member with no FaceSet set (a blank name) simply leaves its slot
+      # empty, matching `#draw_message_face`'s own "blank name -> no face"
+      # rule (`Scene::Map#load_face_bitmap`).
+      def draw_slot_faces(c, inner_w, actors)
+        start_x = inner_w - MAX_SLOT_FACES * FACE_SPACING
+        actors.first(MAX_SLOT_FACES).each_with_index do |actor, i|
+          name = actor.respond_to?(:faceset_name) ? actor.faceset_name : nil
+          next if name.nil? || name.empty?
+          sheet = load_face_bitmap(name)
+          next unless sheet
+          index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
+          cell = build_face_cell(sheet, index)
+          c.blt start_x + i * FACE_SPACING, 0, cell, Rect.new(0, 0, FACE_SIZE, FACE_SIZE)
+        end
+      end
+
+      # Load a FaceSet graphic by name, or nil for a missing file (the caller
+      # then draws no thumbnail for that member). Mirrors
+      # `Scene::Map#load_face_bitmap` exactly, including the colour-key
+      # transparency every FaceSet sheet needs.
+      def load_face_bitmap(name)
+        Bitmap.new "FaceSet/#{name}", true
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] face graphic '#{name}' load failed: #{e.message}"
+        nil
+      end
+
+      # Crop one 48x48 cell out of a FaceSet sheet. Unlike
+      # `Scene::Map#build_face_cell`, this screen never mirrors a face --
+      # EasyRPG's own `Window_Base::DrawFace` call for the save-file screen
+      # always passes `flip: false`, unlike a message window's Change Face
+      # Graphic, the only place a mirror flag exists in the data at all.
+      def build_face_cell(sheet, index)
+        src_x = (index % 4) * FACE_SIZE
+        src_y = (index / 4) * FACE_SIZE
+        cell = Bitmap.new(FACE_SIZE, FACE_SIZE)
+        cell.blt 0, 0, sheet, Rect.new(src_x, src_y, FACE_SIZE, FACE_SIZE)
+        cell
       end
 
       # The "Game saved." / "Save failed." feedback banner, mirroring

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9484,12 +9484,14 @@ end
 class MenuStubActor
   attr_reader :name, :title, :level, :hp, :max_hp, :mp, :max_mp,
               :atk, :def, :int, :agi, :exp, :states, :equipment
+  attr_accessor :faceset_name, :faceset_index
   def initialize
     @name = 'Hero'; @title = 'Wanderer'; @level = 5
     @hp = 80; @max_hp = 120; @mp = 10; @max_mp = 30
     @atk = 20; @def = 12; @int = 9; @agi = 14; @exp = 300
     @states = []
     @equipment = [0, 0, 0, 0, 0]
+    @faceset_name = ''; @faceset_index = 0
   end
   def exp_to_next; 120; end
   def add_state(id); @states.push(id) unless @states.include?(id); end
@@ -9802,6 +9804,59 @@ check 'Scene::SaveLoad: an occupied slot shows the leader, level and HP -- no go
      'level and current HP together on the third line'
   ok !texts.any? { |t| t.include?('250G') }, 'no gold shown -- confirmed absent from the ' \
                                               'reference capture, unlike this screen\'s old layout'
+end
+
+check 'Scene::SaveLoad: an occupied slot draws each party member\'s own face thumbnail, ' \
+      'right-anchored in seat order' do
+  # Game::State#to_lsd already exports up to four faceset_name/faceset_index
+  # pairs into the save's title chunk for a real RPG_RT to show (see
+  # docs/TODO.md); this screen used to read none of it back.
+  st = wrap_menu_state # WrapMenuParty: two MenuStubActor members
+  st.party.actors[0].faceset_name = 'Faces1'
+  st.party.actors[0].faceset_index = 2 # third cell: x=96, y=0
+  st.party.actors[1].faceset_name = 'Faces2'
+  st.party.actors[1].faceset_index = 5 # sixth cell: x=48, y=48
+  st.party.leader = st.party.actors.first
+  parent = fake_parent(fake_db)
+  parent.save_states[1] = st
+  scene, = save_load_scene(:load, nil, fake_db, parent: parent)
+  contents = scene.instance_variable_get(:@slot_windows)[0].contents
+  calls = contents.blt_calls
+  eq 2, calls.length, 'one face thumbnail blitted per party member'
+
+  x0, y0, cell0, rect0 = calls[0]
+  eq [80, 0, 0, 0, 48, 48], [x0, y0, rect0.x, rect0.y, rect0.width, rect0.height],
+     'first member lands at the box\'s own right-anchored start (304 - 4*56)'
+  eq [[0, 0, 96, 0, 48, 48]],
+     cell0.blt_calls.map { |cx, cy, _s, r| [cx, cy, r.x, r.y, r.width, r.height] },
+     'cropped straight from Faces1 cell 2 (x=96,y=0), no scaling'
+
+  x1, y1, cell1, rect1 = calls[1]
+  eq [136, 0, 0, 0, 48, 48], [x1, y1, rect1.x, rect1.y, rect1.width, rect1.height],
+     'second member sits one 56px pitch to the right of the first'
+  eq [[0, 0, 48, 48, 48, 48]],
+     cell1.blt_calls.map { |cx, cy, _s, r| [cx, cy, r.x, r.y, r.width, r.height] },
+     'cropped from Faces2 cell 5 (x=48,y=48), the sheet\'s second row'
+end
+
+check 'Scene::SaveLoad: a member with no FaceSet draws no thumbnail; only the first four ' \
+      'members ever draw one' do
+  st = wrap_menu_state
+  st.party.actors[0].faceset_name = '' # blank name -- no face set for this member
+  st.party.actors[1].faceset_name = 'Faces2'
+  st.party.actors[1].faceset_index = 0
+  3.times { st.party.actors << MenuStubActor.new } # 5 members total
+  st.party.actors[2].faceset_name = 'Faces3'
+  st.party.actors[3].faceset_name = 'Faces4'
+  st.party.actors[4].faceset_name = 'Faces5' # a 5th member, never drawn
+  st.party.leader = st.party.actors.first
+  parent = fake_parent(fake_db)
+  parent.save_states[1] = st
+  scene, = save_load_scene(:load, nil, fake_db, parent: parent)
+  contents = scene.instance_variable_get(:@slot_windows)[0].contents
+  eq 3, contents.blt_calls.length,
+     'the blank-named first member is skipped, and a 5th member never gets a slot -- ' \
+     'only members 2/3/4 (of 5) draw a face'
 end
 
 check 'Scene::SaveLoad :save mode: confirming a slot saves through the parent, shows a ' \


### PR DESCRIPTION
## Summary
- `Game::State#to_lsd` already exports up to four party members' `faceset_name`/`faceset_index` into the save's title chunk (LCF save chunk 100, fields 21-28), specifically so a real RPG_RT can show them on the save-select screen — but `Scene::SaveLoad#draw_slot_box` never read them back, so occupied slots showed only the leader's name/level/HP text and no face art at all.
- Verified against EasyRPG Player's actual C++ source (`Window_Base::DrawFace`, `Window_SaveFile`): each face is a plain 48x48 crop out of the member's FaceSet with no scaling and never mirrored on this screen (unlike a message window's Change Face Graphic, which can be), and up to four are laid out in a row at a 56px pitch.
- Added `Scene::SaveLoad#draw_slot_faces` (plus `#load_face_bitmap`/`#build_face_cell`, mirroring `Scene::Map`'s own message-face helpers) — draws each of the slot's party members (`state.party.actors[0..3]`, the same seat order `#to_lsd` writes them in) right-anchored in the slot box; a member with no FaceSet set (blank name) simply leaves its slot empty.
- Marked the corresponding `docs/TODO.md` bullet ✅ with the mechanism note and citation.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 773 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 493 checks passed (includes 2 new checks for this fix)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped (no downloaded test-bed game data in this sandbox; network-restricted)
- [x] `ruby scripts/rpg2k_command_soak.rb` — skipped (same reason)
- [x] Confirmed both new `scripts/rpg2k_scene_check.rb` checks fail against the pre-fix code (temporarily reverted `save_load.rb` only, reran, saw `NoMethodError: undefined method 'length' for nil` on `blt_calls`, then restored the fix)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0191578kKe1QECY22u8YNgh9)_