### PR TITLE
rpg2k: a waited-for Show Battle Animation now shows its sprite the same frame

### DIFF
--- a/changelog.d/show-battle-animation-startup-latency.fixed.md
+++ b/changelog.d/show-battle-animation-startup-latency.fixed.md
@@ -1,0 +1,26 @@
+- **A waited-for Show Battle Animation (11210) now shows its sprite the same
+  real frame the command runs, instead of one frame late.** Verified against
+  EasyRPG Player's actual C++ source: `Game_Interpreter_Map::
+  CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) always calls
+  `Game_Screen::ShowBattleAnimation` in-line — building the animation —
+  *before* it ever touches its own wait_time, so the sprite's frame-0
+  content is visible the instant the command runs. `Game::Interpreter#
+  do_show_battle_animation` only ever armed the `:animation` wait itself;
+  `Scene::Map#drive_map_animation`, the one place anything actually built
+  the animation, used to only ever be reached the *next* time `#drive_event`/
+  `#step_parallel` found the interpreter already parked on that wait, so a
+  waited-for play always missed its own first frame. Fixed by building the
+  animation immediately once the interpreter is freshly parked on the wait
+  (a new `#init_map_animation_this_frame`, factored out of
+  `#drive_map_animation`), for both the foreground interpreter and a Common
+  Event Parallel Process's own play — deliberately only the *build* moves
+  up, not that first frame's own *advance*: `Game_Map::Update` calls
+  `Game_Screen::Update` (the only thing that ever steps a just-built
+  animation, screen/character-flash stomp included) *before*
+  `UpdateForegroundEvents` each real frame but *after*
+  `UpdateCommonEvents`/`UpdateMapEvents`, so a foreground-built animation
+  gets no extra same-frame advance while a Parallel-Process-built one does.
+  Closes the "structural one-frame startup latency" this codebase's own
+  request/dispatch split was previously left with. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks, both confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5988,25 +5988,56 @@ not yet verified:
   that condition to also cover `:animation`. (A process cut off by a
   *different* one is unaffected either way: that resume happens on the
   *other* process's own turn, via `#drive_map_animation`'s existing cut-off
-  branch, a separate code path from this check.) **Not fully closed**: this
-  codebase still has its own extra, structural one-frame startup latency no
-  fix here touches — `Game::Interpreter#do_show_battle_animation` only arms
-  the `:animation` wait (`@wait_kind`/`@waiting`) when the wait flag is set,
-  deferring the actual `#begin_map_animation` call (and the sprite's first
-  visible frame) to the *next* time `#drive_event`/`#step_parallel` reaches
-  the `:animation` dispatch, rather than starting it synchronously the
-  instant the command executes the way EasyRPG's own `Game_Interpreter_Map::
-  CommandShowBattleAnimation` calls `Game_Screen::ShowBattleAnimation`
-  in-line before ever touching `_state.wait_time` — a materially larger,
-  separate architectural change (this build's request/dispatch split, not
-  its wait-resolution timing) left as still open. Covered by two new
-  `scripts/rpg2k_scene_check.rb` checks (foreground and Common Event
-  Parallel Process alike: two Show Battle Animation calls chained back to
-  back, with a Control Switches marker after each — the marker right after
-  the first now flips the exact same real frame the first animation's
-  sprite goes invisible, not one frame later, and the second animation still
-  plays through to its own trailing marker), both confirmed to fail (`expected
-  N, got N+1`) against the pre-fix code before the fix.
+  branch, a separate code path from this check.) ✅ **The "not fully closed"
+  structural one-frame startup latency flagged here is now fixed too.**
+  `Game::Interpreter#do_show_battle_animation` only ever armed the
+  `:animation` wait (`@wait_kind`/`@waiting`) when the wait flag is set;
+  `Scene::Map#drive_map_animation`, the one place anything actually built the
+  animation (and made the sprite's first frame visible), used to only ever be
+  reached the *next* time `#drive_event`/`#step_parallel` found the
+  interpreter already parked on that wait — deferring the sprite's own frame
+  0 by a full real frame, unlike EasyRPG's own `Game_Interpreter_Map::
+  CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`), which calls
+  `Game_Screen::ShowBattleAnimation` in-line — building the animation —
+  *before* it ever touches `_state.wait_time`. Fixed with a new
+  `#init_map_animation_this_frame` (factored out of `#drive_map_animation`'s
+  own slot-claim/cut-off logic), called immediately once the interpreter is
+  freshly parked on a fresh `:animation` wait, from `#drive_event`'s `else`
+  branch and from `#step_parallel`'s own fallthrough after `it.update`.
+  Deliberately builds the animation only, not that first frame's own
+  *advance* (`#step_map_animation`, which also carries the "stomp an
+  unrelated Screen/Character Flash to nothing" side effect): EasyRPG's
+  `Game_Map::Update` calls `Game_Screen::Update` (the only thing that ever
+  advances a just-built animation) *after* `UpdateCommonEvents`/
+  `UpdateMapEvents` but *before* `UpdateForegroundEvents` each real frame, so
+  a Common Event/map event Parallel Process's own freshly-built animation
+  gets an extra same-frame advance that a foreground-built one does not — the
+  existing "A Character Flash concurrent with a Show Battle Animation... is
+  capped to the current frame" check (a foreground scenario) pinned this
+  distinction: it broke when the fix first called the full
+  `#drive_map_animation` (build + advance) synchronously for the foreground
+  case too, and passed again once that path was narrowed to a build-only
+  call. Covered by two new `scripts/rpg2k_scene_check.rb` checks (a
+  foreground event's and a Common Event Parallel Process's own waited-for
+  Show Battle Animation each show their sprite the exact same real frame the
+  command runs), both confirmed to fail against the pre-fix code before the
+  fix. One side effect on existing coverage: the pre-existing parallel-process
+  "chained calls run back-to-back" check below now needs a different
+  finish-detection technique for the same reason the Character Flash check
+  above briefly did — a Parallel Process's own second (chained) animation now
+  starts before that same frame's own render pass, so the sprite's
+  `visible` flag no longer dips false between the two plays for it to detect;
+  updated to detect the handoff by the underlying frame data changing
+  instead, unaffected for the foreground half of that same check, which still
+  gets its one-frame build/advance split and so still shows the dip. The two
+  chained-calls checks themselves — covering the earlier stutter fix, not
+  this one — are otherwise unchanged: `scripts/rpg2k_scene_check.rb` checks
+  (foreground and Common Event Parallel Process alike: two Show Battle
+  Animation calls chained back to back, with a Control Switches marker after
+  each — the marker right after the first now flips the exact same real
+  frame the first animation finishes, not one frame later, and the second
+  animation still plays through to its own trailing marker), both still
+  passing throughout this fix.
 - ✅ **Show Battle Animation (11210) targeting a vehicle now plays over that
   vehicle's own live position**, instead of silently defaulting to the
   player's. `Scene::Map#animation_target_pixel` (`mruby-rpg2k/mrblib/

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1415,6 +1415,12 @@ class RPG2k
           it.event_id = p[:event] && p[:event][:id]
           it.update
         end
+        # Same "starts on the same real frame the command runs" fix as
+        # #drive_event's own mirrored spot above, for a Parallel Process's own
+        # waited-for Show Battle Animation -- #drive_parallel_wait's :animation
+        # case (drive_map_animation) used to only ever be reached the *next*
+        # time this method found `it` already parked on that wait.
+        drive_parallel_wait(p, it) if it.waiting? && it.wait_kind == :animation
         apply_interpreter_requests(it, p[:event])
         record_parallel_progress(p)
       rescue StandardError
@@ -3488,6 +3494,32 @@ class RPG2k
         else
           @interpreter.update
           apply_interpreter_requests(@interpreter, @active_event)
+          # A Show Battle Animation with its wait flag set builds its animation
+          # object synchronously in real RPG_RT -- EasyRPG's own
+          # Game_Interpreter_Map::CommandShowBattleAnimation
+          # (src/game_interpreter_map.cpp) calls Game_Screen::ShowBattleAnimation
+          # in-line *before* it ever touches its own wait_time -- so the sprite's
+          # frame-0 content is visible the very same real frame the command
+          # runs, not one frame later. #do_show_battle_animation only arms the
+          # :animation wait itself (see its own comment); #drive_map_animation,
+          # the one place anything actually builds the animation, used to only
+          # ever be reached the *next* time this method found the interpreter
+          # already parked on that wait -- so a waited-for play always missed
+          # its own frame 0 by a full frame. Fixed by building it immediately
+          # once #interpreter.update leaves the interpreter freshly parked here
+          # (#init_map_animation_this_frame, not the full #drive_map_animation):
+          # only the *build* moves up, not that first frame's own *step* --
+          # EasyRPG's Game_Map::Update calls Game_Screen::Update (the only thing
+          # that ever advances an animation once built, including the "stomp an
+          # unrelated Screen/Character Flash to nothing" side effect riding
+          # along with it) *before* UpdateForegroundEvents each real frame, so a
+          # foreground command building an animation this frame does not also
+          # get an extra, same-frame Update() call on it -- that first advance
+          # still waits for this event's own next real-frame :animation
+          # dispatch, same as before this fix. Scoped to :animation only,
+          # matching this project's own previously "still open" note on this
+          # exact gap.
+          init_map_animation_this_frame(@interpreter) if @interpreter.waiting? && @interpreter.wait_kind == :animation
         end
       end
 
@@ -6380,17 +6412,31 @@ class RPG2k
       # duration independently too, which is a larger change than the
       # observable "does the first get cut off" fact this fixes.
       def drive_map_animation(it)
-        unless @map_animation_interp.equal?(it)
-          if @map_animation || @anim_wait
-            cut_off = @map_animation_interp
-            @map_animation = nil
-            @anim_wait = nil
-            cut_off.resume if cut_off
-          end
-          @map_animation_interp = it
-          init_map_animation(it)
-        end
+        init_map_animation_this_frame(it)
         @map_animation ? step_map_animation : step_animation_wait
+      end
+
+      # Claim the shared animation slot for `it` and build its animation (or
+      # arm the timed fallback) if it does not already hold it -- the "only
+      # one at a time, a second forcibly cuts off the first" precedence rule
+      # (#drive_map_animation's own comment), factored out so a freshly-armed
+      # :animation wait can be built the instant it is armed, before its own
+      # first per-frame #step_map_animation/#step_animation_wait advance is
+      # due (see #drive_event's `else` branch, which calls this directly
+      # rather than the full #drive_map_animation -- see its own comment for
+      # why only the *build* moves up, not that first advance). A no-op when
+      # `it` already owns the slot (mid-play, or already claimed this same
+      # frame).
+      def init_map_animation_this_frame(it)
+        return if @map_animation_interp.equal?(it)
+        if @map_animation || @anim_wait
+          cut_off = @map_animation_interp
+          @map_animation = nil
+          @anim_wait = nil
+          cut_off.resume if cut_off
+        end
+        @map_animation_interp = it
+        init_map_animation(it)
       end
 
       # Advance a fire-and-forget Show Battle Animation (#apply_battle_animation_

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6456,6 +6456,19 @@ end
 # finished naturally (as opposed to being cut off by a *different* process,
 # which resumes that other process from its own turn and is unaffected by
 # this).
+#
+# The "starts the same real frame the command runs" fix below (see
+# `#init_map_animation_this_frame`) tightens this further for a Parallel
+# Process specifically -- unlike the foreground path, EasyRPG's own
+# `Game_Map::Update` calls `Game_Screen::Update` (the only thing that ever
+# advances a just-built animation) *after* `UpdateCommonEvents`/
+# `UpdateMapEvents`, so a Parallel Process's own freshly-armed second
+# animation gets its first advance the very same real frame it is built, not
+# merely built. The animation sprite's own `visible` flag consequently never
+# dips false between the two chained plays any more (the second one replaces
+# the first before this frame's own render pass ever runs), so the "first
+# animation finished" moment is detected here by its underlying frame data
+# actually changing rather than by a visibility dip that no longer happens.
 check "a Common Event Parallel Process's own chained Show Battle Animation calls run back-to-back too" do
   ic = Game::Interpreter::Cmd
   ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
@@ -6465,22 +6478,95 @@ check "a Common Event Parallel Process's own chained Show Battle Animation calls
                               ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)])
   scene = new_scene({}, common: { 1 => ce })
   st = scene.instance_variable_get(:@state)
-  spr = scene.instance_variable_get(:@animation_sprite)
-  finish_frame = nil
+  first_frames = nil
+  handoff_frame = nil
   switch_frame = nil
   40.times do |i|
-    was_visible = spr.visible
     scene.update
-    finish_frame ||= i if was_visible && !spr.visible
+    ma = scene.instance_variable_get(:@map_animation)
+    first_frames ||= ma && ma[:frames]
+    handoff_frame ||= i if ma && first_frames && !ma[:frames].equal?(first_frames)
     switch_frame ||= i if st.switches[5]
     break if st.switches[6]
   end
-  ok finish_frame, "the parallel process's first animation actually finished"
-  ok switch_frame, 'the command right after it (marking switch 5) ran'
-  eq finish_frame, switch_frame,
-     "a parallel process's own trailing command runs the exact same real frame its animation finishes, " \
-     'not one frame later, matching the foreground fix above'
+  ok handoff_frame, "the parallel process's second animation actually started"
+  ok switch_frame, 'the command right after the first animation (marking switch 5) ran'
+  eq handoff_frame, switch_frame,
+     "a parallel process's own second (chained) animation starts the exact same real frame its trailing " \
+     'command runs, not one frame later, matching the foreground fix above'
   ok st.switches[6], 'the second (chained) animation played through to its own trailing command too'
+end
+
+# docs/TODO.md's own "still open" note on the chained-animation fixes above:
+# this codebase's own extra, structural one-frame startup latency was not
+# touched by either one. Settled against EasyRPG's actual C++ source rather
+# than left a guess: `Game_Interpreter_Map::CommandShowBattleAnimation`
+# (src/game_interpreter_map.cpp) always calls `Game_Screen::ShowBattleAnimation`
+# in-line -- building the animation -- *before* it ever touches its own
+# wait_time, so a waited-for play's sprite is visible the exact same real
+# frame the command runs. `Game::Interpreter#do_show_battle_animation` only
+# ever arms the `:animation` wait itself; `#drive_map_animation` (the one
+# place anything actually builds/steps the animation) used to only ever be
+# reached the *next* time `#drive_event` found the interpreter already parked
+# on that wait, so a waited-for play always missed its own frame 0 by a full
+# frame -- a foreground event just reaching the command for the first time
+# stayed invisible for one extra real frame before ever showing anything.
+check 'a Show Battle Animation with the wait flag set shows its sprite the same real frame the command ' \
+      'runs, not one frame later' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # A marker right before the command pins the exact real frame the
+  # interpreter reaches it (both run in the same #update burst, since Control
+  # Switches is non-blocking and only Show Battle Animation itself arms a
+  # wait) -- animation 8 is the same drawable fixture the tests above use.
+  auto.event_commands = [
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0], indent: 0),
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0), # animation, player, wait
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  spr = scene.instance_variable_get(:@animation_sprite)
+  reached_frame = nil
+  visible_frame = nil
+  10.times do |i|
+    scene.update
+    reached_frame ||= i if st.switches[4]
+    visible_frame ||= i if spr.visible
+    break if visible_frame
+  end
+  ok reached_frame, 'the event actually reached the Show Battle Animation command'
+  ok visible_frame, 'the animation sprite eventually shows'
+  eq reached_frame, visible_frame,
+     'the animation sprite is visible the exact same real frame the command runs, not one frame later'
+  ok !st.switches[5], 'the event is still held on its own wait that same frame, not resumed already'
+end
+
+# Same fact, for a Common Event Parallel Process's own waited-for play --
+# #step_parallel's counterpart to the foreground fix directly above.
+check "a Common Event Parallel Process's own waited-for Show Battle Animation shows its sprite the same " \
+      'real frame the command runs, not one frame later' do
+  ic = Game::Interpreter::Cmd
+  ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
+                      event: [ECmd.new(ic::CONTROL_SWITCHES, [0, 4, 4, 0], indent: 0),
+                              ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),
+                              ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
+  scene = new_scene({}, common: { 1 => ce })
+  st = scene.instance_variable_get(:@state)
+  spr = scene.instance_variable_get(:@animation_sprite)
+  reached_frame = nil
+  visible_frame = nil
+  10.times do |i|
+    scene.update
+    reached_frame ||= i if st.switches[4]
+    visible_frame ||= i if spr.visible
+    break if visible_frame
+  end
+  ok reached_frame, "the process actually reached the Show Battle Animation command"
+  ok visible_frame, 'the animation sprite eventually shows'
+  eq reached_frame, visible_frame,
+     'the animation sprite is visible the exact same real frame the command runs, not one frame later'
+  ok !st.switches[5], "the process is still held on its own wait that same frame, not resumed already"
 end
 
 # yado.tk: RPG_RT drops straight into Game Over the instant a wipe-triggering


### PR DESCRIPTION
## Summary

- Closes the `docs/TODO.md` "still open" note on Show Battle Animation's own structural one-frame startup latency: a waited-for Show Battle Animation (11210) now shows its sprite the same real frame the command runs, instead of one frame late.
- `Game::Interpreter#do_show_battle_animation` only ever armed the interpreter's `:animation` wait; `Scene::Map#drive_map_animation` — the one place anything actually built the animation, making its sprite visible — was only ever reached the *next* real frame `#drive_event`/`#step_parallel` found the interpreter already parked on that wait. EasyRPG Player's own `Game_Interpreter_Map::CommandShowBattleAnimation` (`src/game_interpreter_map.cpp`) builds the animation in-line, before it ever touches its own `wait_time`.
- Fixed with a new `#init_map_animation_this_frame` (factored out of `#drive_map_animation`'s own slot-claim/cut-off logic), called immediately once the interpreter freshly parks on an `:animation` wait, from both `#drive_event`'s `else` branch and `#step_parallel`'s own fallthrough after `it.update`.
- Deliberately builds the animation only, not that first frame's own *advance* (frame-timer countdown, and the "stomp an unrelated Screen/Character Flash to nothing" side effect that rides along with it): EasyRPG's `Game_Map::Update` calls `Game_Screen::Update` (the only thing that ever advances a just-built animation) *after* `UpdateCommonEvents`/`UpdateMapEvents` but *before* `UpdateForegroundEvents` each real frame — so a Common Event/map event Parallel Process's own freshly-built animation gets an extra same-frame advance that a foreground-built one does not. The existing "A Character Flash concurrent with a Show Battle Animation... is capped to the current frame" check (a foreground scenario) pinned this distinction during development.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 773 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 491 checks passed (2 new checks added; confirmed to fail against the pre-fix code, then pass after the fix — see below)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
- [ ] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped: no RPG2000 test-bed game data present in this sandbox (network-restricted; would need `scripts/download-nepheshel.bash`/`scripts/download-mtf-meido-action.bash`)
- [ ] `ruby scripts/rpg2k_command_soak.rb` — skipped for the same reason

New/updated regression coverage in `scripts/rpg2k_scene_check.rb`:
- Two new checks (foreground event, Common Event Parallel Process) confirming the animation sprite becomes visible the exact same real frame the `Show Battle Animation` command runs — both confirmed to fail against the pre-fix code (`expected 0, got 1`) before the fix.
- The pre-existing "a Common Event Parallel Process's own chained Show Battle Animation calls run back-to-back too" check's finish-detection technique is updated: a Parallel Process's own second (chained) animation now starts before that same frame's render pass, so the sprite's `visible` flag no longer dips false between the two plays — the check now detects the handoff via the underlying frame data changing instead, and still fails against the pre-fix code (`expected 13, got 12`) before the fix.

Also updates `docs/TODO.md` to mark the item ✅ with a mechanism note and citation, and adds `changelog.d/show-battle-animation-startup-latency.fixed.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019qprDV95BnhZXVonMkjo9H)_