### PR TITLE
rpg2k: opening a battle now plays the database's Battle Start system SE

### DIFF
--- a/changelog.d/battle-start-system-se.fixed.md
+++ b/changelog.d/battle-start-system-se.fixed.md
@@ -1,0 +1,13 @@
+- **Opening a battle now plays the database's Battle Start system SE**,
+  matching real RPG_RT's `Scene_Battle` constructor (`src/scene_battle.cpp`),
+  which plays `SFX_BeginBattle` as its very first act — before even swapping
+  to the battle BGM. `Scene::Map#open_battle` already had every other
+  system-SE slot wired up (cursor/decision/cancel/buzzer, Escape, the
+  per-hit sounds) but never called `#play_system_se(SFX_BATTLE)`, so the
+  database's own Battle Start sound (and any Change System SFX override for
+  that slot) never played on any encounter — a foreground Enemy Encounter
+  command, one issued from a Parallel Process, or a random/wandering-monster
+  encounter alike, since they all share this one entry point. Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks (the database default plays the
+  instant a fight opens; a Change System SFX override for the slot wins over
+  it), both confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5247,6 +5247,34 @@ not yet verified:
   (unverified, separate claim).
 - SE files must be WAVE; BGM accepts MIDI/WAVE/MP3 — an asymmetric format
   restriction.
+- ✅ **Opening a battle now plays the database's Battle Start system SE**,
+  found while auditing the LCF schema for fields parsed but never read
+  anywhere in `mruby-rpg2k` — the same sweep that already caught `levitate`/
+  `transparent`/`avoid_attacks`/`reflect_magic`/`force_ai` above.
+  `mruby-lcf/mrblib/schema.rb`'s database `system` table (fields 41-52)
+  decodes a `battle_se` slot right alongside `cursor_se`/`decision_se`/
+  `escape_se`/the per-hit sounds, and `Scene::Base::DB_SE_FIELD`
+  (`mruby-rpg2k/mrblib/scene/base.rb`) already maps `SFX_BATTLE` to that same
+  field name — but nothing ever called `#play_system_se(SFX_BATTLE)`.
+  Verified against EasyRPG Player's actual C++ source rather than guessed at:
+  `Scene_Battle`'s own constructor (`src/scene_battle.cpp`) plays
+  `GetSystemSE(SFX_BeginBattle)` as its very first act, unconditionally,
+  before even swapping to the battle BGM (`BgmPlay(GetSystemBGM(BGM_Battle))`
+  runs on the very next line) — every real encounter, so a foreground Enemy
+  Encounter command, one issued from a Parallel Process, and a random/
+  wandering-monster encounter all play it. `Scene::Map#open_battle`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — the one entry point all three of
+  those routes already share — called `#play_battle_bgm` but never the
+  matching system SE, so the database's own Battle Start sound (and any
+  Change System SFX override for that slot) never played on any encounter,
+  even though every other system-SE slot (cursor/decision/cancel/buzzer,
+  Escape, the per-hit sounds) was already wired up correctly. Fixed by adding
+  `play_system_se(SFX_BATTLE)` right before `play_battle_bgm`, matching
+  EasyRPG's own ordering. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (the database default plays the instant a fight opens through the
+  Autorun/Enemy-Encounter path; a Change System SFX override for slot 4 wins
+  over the database default, not layered alongside it), both confirmed to
+  fail against the pre-fix code before the fix.
 
 **Message window / Show Choices / control characters**
 - ✅ **A Parallel Process's own Show Text/Show Choices now actually opens the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4068,6 +4068,20 @@ class RPG2k
       end
 
       def open_battle(req, owner = @interpreter)
+        # RPG_RT's own `Scene_Battle` constructor (src/scene_battle.cpp) plays
+        # the database's Battle Start system SE (`SFX_BeginBattle`) as its very
+        # first act, unconditionally and before even the battle BGM swap --
+        # `#play_system_se`/`SFX_BATTLE` already exist (Scene::Base's shared
+        # system-SE table, `DB_SE_FIELD`), but nothing here ever called them for
+        # this slot: Escape/dodge/damage/death/item all already fire at their
+        # own moments (SFX_ESCAPE/SFX_DODGE/SFX_ENEMY_DAMAGE/SFX_ACTOR_DAMAGE/
+        # SFX_ENEMY_DEATH/SFX_ITEM), only the battle-open moment itself was
+        # silent.
+        # Fires for every encounter this scene ever opens through -- a foreground
+        # Enemy Encounter command, one issued from a Parallel Process, and a
+        # random/wandering-monster encounter -- since #open_battle is their one
+        # shared entry point.
+        play_system_se(SFX_BATTLE)
         play_battle_bgm
         troop = Game::Troop.new(db, req[:troop_id])
         allies = @state.party.actors.map { |a| Game::Battle.from_actor(a) }

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -257,6 +257,7 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                            cancel_se: OpenStruct.new(file: 'Cancel1', volume: 100, pitch: 100),
                            buzzer_se: OpenStruct.new(file: 'Buzzer1', volume: 100, pitch: 100),
                            escape_se: OpenStruct.new(file: 'Escape1', volume: 100, pitch: 100),
+                           battle_se: OpenStruct.new(file: 'BattleStart1', volume: 100, pitch: 100),
                            # The battle per-hit sounds (Scene::Base::DB_SE_FIELD).
                            enemy_damaged_se: OpenStruct.new(file: 'EnemyHit', volume: 100, pitch: 100),
                            actor_damaged_se: OpenStruct.new(file: 'ActorHit', volume: 100, pitch: 100),
@@ -4728,6 +4729,54 @@ check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Vi
   3.times { scene.update }
   ok st.switches[1], 'the Victory handler ran'
   ok !st.switches[2], 'the Escape handler was skipped'
+end
+
+# RPG_RT's own `Scene_Battle` constructor (src/scene_battle.cpp) plays the
+# database's Battle Start system SE (`SFX_BeginBattle`) as its very first act,
+# unconditionally, before even swapping to the battle BGM -- `Scene::Map
+# #open_battle` (mruby-rpg2k/mrblib/scene/map.rb) already had every other
+# system-SE slot wired up (cursor/decision/cancel/buzzer, escape, the per-hit
+# sounds) but never called `#play_system_se(SFX_BATTLE)` at all, so the
+# database's own Battle Start sound never played on any encounter -- a
+# foreground Enemy Encounter command, one issued from a Parallel Process, or a
+# random/wandering-monster encounter alike, since they all share this one
+# entry point.
+check 'Enemy Encounter scene: opening a battle plays the database Battle Start SE' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  RGSS::Audio.reset_se
+  10.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+  end
+  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'BattleStart1' },
+     'the database Battle Start SE played the instant the fight opened'
+end
+
+check 'Enemy Encounter scene: a Change System SFX battle-start override wins over the database default' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  # System SFX slot 4 is Battle Start (Scene::Base::SFX_BATTLE).
+  st.system_sfx[4] = { name: 'CustomBattleStart', volume: 60, tempo: 120 }
+  RGSS::Audio.reset_se
+  10.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+  end
+  ok scene.instance_variable_get(:@battle_ui), 'the battle actually opened'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'CustomBattleStart' },
+     'the override plays instead of the database BattleStart1'
+  ok !RGSS::Audio.se_calls.any? { |c| c[0] == 'BattleStart1' },
+     'the database default is fully superseded, not layered alongside it'
 end
 
 # yado.tk: "the built-in random-number operand is a genuine non-seeded RNG --


### PR DESCRIPTION
## Summary

- Found by auditing the LCF schema for fields decoded but never read anywhere in `mruby-rpg2k` (the same technique that previously caught `levitate`/`transparent`/`avoid_attacks`/`reflect_magic`/`force_ai`): the database's Battle Start system SE (LCF System field 45, `battle_se`) was never played when a battle opened.
- `Scene::Base::DB_SE_FIELD` already mapped `SFX_BATTLE` to `:battle_se` and `#play_system_se`/`#db_system_se` already worked correctly for every other slot (cursor/decision/cancel/buzzer, Escape, the four per-hit sounds) — nothing ever called `play_system_se(SFX_BATTLE)`.
- Verified against EasyRPG Player's vendored source: `Scene_Battle`'s constructor (`src/scene_battle.cpp`) plays `SePlay(GetSystemSE(SFX_BeginBattle))` as its very first act, unconditionally, immediately before swapping to the battle BGM. This fires for every real encounter — foreground Enemy Encounter command, one issued from a Parallel Process, or a random encounter — since `Scene_Battle` construction is the single choke point in real RPG_RT, matching this codebase's own single `Scene::Map#open_battle` entry point.
- Added `play_system_se(SFX_BATTLE)` right before `play_battle_bgm` in `Scene::Map#open_battle`, matching EasyRPG's ordering. This automatically also honors a Change System SFX override for slot 4, since `play_system_se` already checks the state override before the database default.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 774 passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 495 passed (two new checks: database `battle_se` plays the instant a fight opens via Autorun's Enemy Encounter, and a Change System SFX override for slot 4 supersedes the database default; confirmed both fail pre-fix)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 passed
- [x] `ruby scripts/rpg2k_command_soak.rb` — 3430 commands, no gaps

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_