### PR TITLE
test: cover Open Main Menu bypassing Change Main Menu Access

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3796,13 +3796,32 @@ Everything below is unverified against the codebase.
   session notes); if a multi-page event's move route is mid-execution when
   its page switches, the route restarts *unless* the two pages' move-route
   settings are byte-identical (**same fact as the "confirmed gap" above**).
-- **Menu screen** — Call Menu Screen bypasses "Prohibit Menu" (only the
-  player's own Cancel-key shortcut respects it); no sub-part of the menu
-  can be called except the dedicated Save-screen command; can't open during
-  battle; opening it pauses *all* event processing including active
-  timers/parallel processes; Erase Screen's black-out is undone if the
-  player opens and closes the menu (✅ implemented — see the "Screen
-  effects" bullet below, same fact from a different site page).
+- **Menu screen** — ✅ **Call Menu Screen bypasses "Prohibit Menu" (only the
+  player's own Cancel-key shortcut respects it) -- confirmed already
+  correct, and now covered by a regression test.** `Scene::Map#
+  perform_event_menu` (Open Main Menu, 11950) never reads `@state.
+  menu_access` at all -- it was already unconditional, the same way
+  `perform_event_save` (Open Save Menu) already ignores `save_access` (see
+  that check's own comment). Nothing exercised this specific claim before,
+  though: `scripts/rpg2k_scene_check.rb` gains "Open Main Menu ignores a
+  Change Main Menu Access lock", setting `menu_access = false` first and
+  asserting the menu still opens, mirroring the existing Open Save Menu
+  check exactly. RPG2003's Open Load Menu (5001) also exists as its own
+  event command (separately tested), so "no sub-part of the menu can be
+  called except the dedicated Save-screen command" describes stock
+  RPG2000's own real limitation accurately rather than something this
+  engine's RPG2003 support contradicts. **Still open, not chased this
+  pass:** whether Call Menu Screen genuinely refuses to open during battle
+  (no battle-context guard exists on `perform_event_menu` today, and there
+  is no battle-time interpreter code path in this codebase that would even
+  reach it to test either way) and the "pauses all event processing
+  including active timers/parallel processes" claim specifically for Open
+  Main Menu (the same *shape* of pausing is already confirmed for the
+  Erase Screen black-out case referenced below, but that is not the same
+  claim as parallel processes/timers themselves halting). Erase Screen's
+  black-out being undone by opening and closing the menu is ✅ implemented
+  — see the "Screen effects" bullet below, same fact from a different site
+  page.
 - **Load** — resuming mid-Autorun/mid-Parallel-Process picks up exactly
   where it left off, *unless* the map was edited/re-saved since, in which
   case that event restarts from the top (edge case, likely not applicable

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8332,6 +8332,28 @@ check 'Open Main Menu pushes the field menu and resumes when it closes' do
   eq 1, st.variables[6], 'the event resumed after the menu closed'
 end
 
+check 'Open Main Menu ignores a Change Main Menu Access lock -- unlike the ' \
+      "player's own Cancel-key shortcut, the event-triggered menu still opens" do
+  # A yado.tk-catalogued quirk (docs/TODO.md's "Menu screen" bullet, Untriaged
+  # backlog): Prohibit Menu (Change Main Menu Access) only blocks the
+  # player's own Cancel-key shortcut for opening the field menu -- it does
+  # not gate this event command at all, the same way Change Save Access does
+  # not gate Open Save Menu (see that check just above). `perform_event_menu`
+  # (mruby-rpg2k/mrblib/scene/map.rb) already never reads `@state.menu_access`
+  # at all, so this was already correct -- this check just closes the gap
+  # where nothing exercised that specific claim.
+  cmds = [ECmd.new(IC2::OPEN_MAIN_MENU, [])]
+  scene = new_scene({}, player: [0, 0])
+  parent = scene.instance_variable_get(:@parent)
+  st = scene.instance_variable_get(:@state)
+  st.menu_access = false
+  scene.instance_variable_get(:@interpreter).start(cmds)
+  2.times { scene.update } # raises the :menu wait, then opens the menu
+  eq 1, parent.pushed.length, 'the menu opens even though menu_access is false'
+  ok parent.pushed.first.is_a?(RPG2k::Scene::Menu),
+     "pushed Scene::Menu, got #{parent.pushed.first.class}"
+end
+
 check 'a BGM position that jumps backwards counts as one play-through' do
   scene = new_scene({}, player: [0, 0])
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s yado.tk-catalogued "Menu screen" quirk claims Call Menu Screen bypasses "Prohibit Menu" — only the player's own Cancel-key shortcut respects it. Checked this engine's own `Scene::Map#perform_event_menu` (the Open Main Menu, 11950, event command): it never reads `@state.menu_access` at all, so this was **already correct** — it just had no regression test exercising that specific claim, unlike the equivalent Open Save Menu / `save_access` case which already has one.
- Added a matching test: sets `menu_access = false`, fires Open Main Menu, and asserts the field menu still opens.
- Also checked the same bullet's "no sub-part of the menu can be called except the dedicated Save-screen command" claim: RPG2003's Open Load Menu (5001) exists as its own, separately-tested event command in this engine, but that's an RPG2003-only command — the claim accurately describes stock RPG2000's own real limitation rather than something this engine's RPG2003 support contradicts, so no fix needed there.
- Updated `docs/TODO.md` to reflect what's confirmed (bypass behavior + regression test) vs. still genuinely open and unchased (whether Call Menu Screen refuses to open during battle — no battle-context guard exists and there's no battle-time interpreter path that would reach it either way to test; and the "pauses all event processing including active timers/parallel processes" claim specifically for Open Main Menu, which is a different claim from the already-confirmed Erase Screen black-out case).

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (1 new check)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_