### PR TITLE
rpg2k: a level-up crossing a growth-table threshold now announces the learned skill

### DIFF
--- a/changelog.d/change-level-skill-learned.fixed.md
+++ b/changelog.d/change-level-skill-learned.fixed.md
@@ -1,0 +1,29 @@
+- **Change Level / Change EXP now announce a learned skill alongside the
+  level that teaches it**, matching real RPG_RT. EasyRPG's
+  `Game_Actor::ChangeLevel` (`src/game_actor.cpp`) pushes the level-up line
+  and then calls `LearnLevelSkills(old_level + 1, new_level, pm)`, which
+  pushes `ActorMessage::GetLearningMessage`
+  (`src/game_message_terms.cpp` — the skill's own name glued onto the
+  database's `skill_learned` term) for every growth-table skill the level
+  range teaches, skipping one the actor already knew
+  (`Game_Actor::LearnSkill`'s own `IsSkillLearned` guard). This codebase's
+  `Game::Interpreter#queue_level_up_messages` (`mruby-rpg2k/mrblib/
+  interpreter.rb`) already queued the level-up line itself but never
+  consulted the growth table at all, so a skill a party member gained by
+  levelling up silently joined their skill list with no announcement,
+  regardless of how the level was granted (Change Level, Change EXP, or a
+  battle victory's own EXP award, which reaches the same command path).
+  Fixed by snapshotting each target's skill list immediately before the
+  change (`before_skills`) and, for every level actually gained, appending
+  one line per growth-table skill scheduled at that exact level and absent
+  from the snapshot onto that level's own message page — a skill already
+  known going in (an earlier explicit Change Skill teach) stays silent, the
+  same distinction EasyRPG's `IsSkillLearned` check makes. Change Class
+  (1008, RPG2003-only) shares the same underlying gap — EasyRPG's
+  `Game_Actor::ChangeClass` calls the identical `LearnLevelSkills(1,
+  new_level, pm)` — but is left unaddressed here; see `docs/TODO.md`.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (a two-level
+  Change Level crossing two learn-table thresholds announces each skill on
+  its own level's page; a skill taught early via Change Skills stays quiet
+  when the level that would have taught it is later reached), the first
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1531,7 +1531,27 @@ The work below is roughly ordered by the critical path to a walkable game
   the configured transition" now reads; and **Game
   Over** (12520) returns to the title — all handled. **Vehicle locations** (boat /
   ship / airship) also persist in the save (`Game::Vehicle`, `.lsd` chunks
-  105–107 / the Marshal save).
+  105–107 / the Marshal save). ✅ **Change Level / Change EXP now also announce
+  a skill the level-up itself teaches, not just the level number** — found via
+  a field audit of the database's `skill_learned` `term` chunk field
+  (`scripts/rpg2k_field_audit.rb`), which nothing in the runtime named.
+  `Game::Interpreter#queue_level_up_messages` already queued one message per
+  level gained but never consulted the growth-table learn list at all, unlike
+  EasyRPG's `Game_Actor::ChangeLevel` (`src/game_actor.cpp`), which pushes the
+  level-up line and then `LearnLevelSkills(old_level + 1, new_level, pm)` —
+  each newly-taught skill gets its own `ActorMessage::GetLearningMessage`
+  line (`src/game_message_terms.cpp`), skipped only for a skill the actor
+  already knew (`Game_Actor::LearnSkill`'s own `IsSkillLearned` guard).
+  Fixed by snapshotting each target's skill list right before the change and
+  appending one line per newly-learned growth-table skill onto its own
+  level's message page. **Change Class (1008, RPG2003-only) has the identical
+  gap** — EasyRPG's `Game_Actor::ChangeClass` calls the same
+  `LearnLevelSkills(1, new_level, pm)` — but is deliberately left unaddressed
+  here, still open. Covered by two new `scripts/rpg2k_logic_check.rb` checks
+  (a two-level Change Level crossing two learn-table thresholds announces
+  each skill on its own level's page; a skill taught early via Change Skills
+  stays quiet once the level that would have taught it is reached), the
+  first confirmed to fail against the pre-fix code before the fix.
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`,
   `\_` space). `\n[n]` names the **live** actor out of the roster rather than the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1708,8 +1708,9 @@ module Game
       show_msg = cmd.param(5) != 0
       stat_targets(cmd).each do |a|
         before = a.level
+        before_skills = show_msg && a.respond_to?(:skills) ? a.skills.dup : []
         a.gain_exp(amount)
-        queue_level_up_messages(a, before, a.level) if show_msg
+        queue_level_up_messages(a, before, a.level, before_skills) if show_msg
       end
       # RPG_RT asks about the wipe first: a level change that killed the party
       # goes to Game Over instead of announcing the level-up.
@@ -1728,8 +1729,9 @@ module Game
       show_msg = cmd.param(5) != 0
       stat_targets(cmd).each do |a|
         before = a.level
+        before_skills = show_msg && a.respond_to?(:skills) ? a.skills.dup : []
         a.change_level_by(amount)
-        queue_level_up_messages(a, before, a.level) if show_msg
+        queue_level_up_messages(a, before, a.level, before_skills) if show_msg
       end
       return if check_game_over
       show_next_pending_message
@@ -1738,10 +1740,38 @@ module Game
     # Queue one level-up message per level `actor` gained going from `old_level`
     # to `new_level` (nothing when the level did not rise). RPG_RT phrases these
     # from the database terms; this build uses a plain English line for now.
-    def queue_level_up_messages(actor, old_level, new_level)
+    #
+    # Also queues one line per skill the growth/class table teaches at that
+    # exact level, appended onto the same page as the level's own line -- the
+    # missing half of this feature. EasyRPG's Game_Actor::ChangeLevel
+    # (`src/game_actor.cpp`) calls LearnLevelSkills(old_level+1, new_level, pm)
+    # right after pushing the level-up line and before PushPageEnd, and
+    # LearnSkill only pushes ActorMessage::GetLearningMessage (the
+    # `skill_learned` database term glued onto the skill's own name) for a
+    # skill not already IsSkillLearned -- both are only reachable from
+    # #do_change_exp/#do_change_level, which already call #set_level (and so
+    # Actor#learn_level_skills) before this runs, so `before_skills` -- the
+    # actor's own skill list snapshotted before that happened -- is what tells
+    # a *newly* taught skill apart from one the actor already knew (an earlier
+    # explicit Change Skill teach), matching EasyRPG's own IsSkillLearned guard
+    # without re-deriving it. `before_skills` is an empty array when the
+    # caller's own show-message flag was off (nothing here runs then anyway)
+    # or `actor` is a minimal stub with no #skills of its own (a handful of
+    # scene-level fixtures exercise only the level line, never the skill
+    # table) -- `actor.respond_to?(:learn_table)` guards the same stub case
+    # for the skill lookup below.
+    def queue_level_up_messages(actor, old_level, new_level, before_skills)
       return unless new_level > old_level
       ((old_level + 1)..new_level).each do |lv|
-        @pending_messages.push([level_up_message(actor, lv)])
+        lines = [level_up_message(actor, lv)]
+        if actor.respond_to?(:learn_table)
+          actor.learn_table.each do |sid, at|
+            next unless at == lv && !before_skills.include?(sid)
+            sk = party.db_skill(sid)
+            lines.push(skill_learned_message(actor, sk)) if sk
+          end
+        end
+        @pending_messages.push(lines)
       end
     end
 
@@ -1749,6 +1779,15 @@ module Game
     # terms; this build uses a plain English line for now.
     def level_up_message(actor, level)
       "#{actor.name} is now level #{level}!"
+    end
+
+    # The one line a newly-learned skill announces, immediately following its
+    # level's own level-up line. RPG_RT glues the skill's own name onto the
+    # `skill_learned` database term (EasyRPG's ActorMessage::GetLearningMessage,
+    # `src/game_message_terms.cpp`); this build uses a plain English line for
+    # now, matching #level_up_message's own documented simplification.
+    def skill_learned_message(actor, sk)
+      "#{actor.name} learned #{sk.name}!"
     end
 
     # Enter the next queued level-up message as a :message wait; returns false

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3808,6 +3808,66 @@ check 'Change EXP with the show-message flag announces a level-up' do
   ok !it.waiting?, 'a single level gained -> a single message'
 end
 
+# A three-level growth curve with a learn table, for the skill-learned-message
+# checks: skill 201 at level 2, skill 202 at level 3.
+def skill_level_db(learns = [[201, 2], [202, 3]])
+  FakeActorDB.new(
+    { 1 => SkillRow.new('Hero', '', 0, 1,
+                        [10, 5, 3, 2, 1, 4, 20, 10, 6, 4, 2, 8, 30, 15, 9, 6, 3, 12],
+                        learns) },
+    [1], {},
+    { 201 => fake_skill(name: 'Fireball'), 202 => fake_skill(name: 'Iceball') })
+end
+
+# EasyRPG's Game_Actor::ChangeLevel (src/game_actor.cpp) calls
+# LearnLevelSkills(old_level+1, new_level, pm) right after the level-up line and
+# before PushPageEnd, and LearnSkill only pushes
+# ActorMessage::GetLearningMessage (src/game_message_terms.cpp) for a skill not
+# already IsSkillLearned -- so a level gained across a learn-table threshold
+# announces the new skill alongside the level, and a skill the actor already
+# knew going in stays silent.
+check 'Change Level queues a skill-learned line alongside the level that teaches it' do
+  st = Game::State.new(Game::Party.new(skill_level_db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  it = Game::Interpreter.new(st)
+  # scope 1, actor 1, add, const, amount 2 (1 -> 3), show-message flag on.
+  it.start([FakeCmd.new(IC::CHANGE_LEVEL, [1, 1, 0, 0, 2, 1])])
+  it.update
+  eq 3, a.level, 'gained two levels'
+  eq [201, 202], a.skills.sort, 'both level-gated skills are learnt'
+  eq :message, it.wait_kind
+  eq ['Hero is now level 2!', 'Hero learned Fireball!'], it.message_lines,
+     "the level-2 page carries its own newly-taught skill's line"
+  it.resume
+  eq :message, it.wait_kind, 'the second level queues a second page'
+  eq ['Hero is now level 3!', 'Hero learned Iceball!'], it.message_lines,
+     "the level-3 page carries its own newly-taught skill's line"
+  it.resume
+  it.update
+  ok !it.waiting?
+end
+
+check 'Change EXP stays quiet about a skill the actor already knew going in' do
+  st = Game::State.new(Game::Party.new(skill_level_db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  # Teach skill 201 (the level-2 skill) early, via an explicit Change Skills,
+  # before the actor ever reaches level 2 the normal way.
+  it0 = Game::Interpreter.new(st)
+  it0.start([FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 0, 0, 201])])
+  it0.update
+  eq [201], a.skills
+  need = a.exp_to_next # exactly enough EXP to reach level 2
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_EXP, [1, 1, 0, 0, need, 1])])
+  it.update
+  eq 2, a.level, 'crossed the level-2 threshold'
+  eq :message, it.wait_kind
+  eq ['Hero is now level 2!'], it.message_lines,
+     'skill 201 was already known, so no skill-learned line repeats it'
+  it.resume
+  ok !it.waiting?
+end
+
 check 'Change Equipment command equips into the type slot and removes' do
   items = { 7 => fake_item(atk: 15, type: 1),   # weapon -> slot 0
             8 => fake_item(dfn: 9, type: 3) }    # armour -> slot 2


### PR DESCRIPTION
## Summary

- Change Level (10420) / Change EXP (10410) never announced a newly-learned skill when a level-up crossed a growth-table (or class) learn threshold — only the plain "is now level N!" line was shown, the skill was learned silently.
- Found via a schema-field audit: the database's `term.skill_learned` field is decoded by `mruby-lcf` but was never named anywhere in `mruby-rpg2k`.
- Verified against EasyRPG Player's vendored source: `Game_Actor::ChangeLevel` (`src/game_actor.cpp`) pushes the level-up line, then calls `LearnLevelSkills(old_level + 1, new_level, pm)`. `Game_Actor::LearnSkill` pushes `ActorMessage::GetLearningMessage(*this, *skill)` (`src/game_message_terms.cpp` — the skill's own name glued onto the `skill_learned` database term) for each skill, but only when `!IsSkillLearned(skill_id)`, so a skill already known (e.g. via an earlier explicit Change Skill) stays silent. `Game_Interpreter::CommandChangeExp`/`CommandChangeLevel` (`src/game_interpreter.cpp`) pass a `PendingMessage*` only when the command's own "show message" flag is set, matching this codebase's existing `show_msg` gating.
- `Game_Actor::ChangeClass` has the identical gap (RPG2003-only), left unaddressed and noted as still open in `docs/TODO.md` to keep this fix narrowly scoped.
- `mruby-rpg2k/mrblib/interpreter.rb`: `do_change_exp`/`do_change_level` now snapshot each target's skill list before applying the change; `queue_level_up_messages` appends one line per growth-table skill scheduled at that exact level and not already known, onto that level's own message page.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 776 passed (two new checks: a two-level Change Level crossing two learn-table thresholds announces each skill on its own level's page; a skill taught early via Change Skills stays quiet once the level that would have taught it is reached; confirmed the first fails pre-fix)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 503 passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 passed
- [x] `ruby scripts/rpg2k_command_soak.rb` — 3430 commands, no gaps

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_