### PR TITLE
rpg2k: the field Skill screen now shows the highlighted skill's description

### DIFF
--- a/changelog.d/rpg2k-skill-description-banner.fixed.md
+++ b/changelog.d/rpg2k-skill-description-banner.fixed.md
@@ -1,0 +1,11 @@
+- **The field Skill screen now shows the highlighted skill's flavour text in
+  a one-line banner across the top**, the same banner `Scene::ItemMenu` and
+  `Scene::EquipMenu` already have. Verified against EasyRPG Player's actual
+  C++ source: `Window_Skill::UpdateHelp` (`src/window_skill.cpp`) feeds the
+  database skill's own `description` field straight to `Scene_Skill`'s
+  `Window_Help` banner on every selection change. `Scene::SkillMenu` drew no
+  such banner before — `skill.description` was parsed by the LCF schema and
+  never read anywhere in `mruby-rpg2k`, a gap `scripts/rpg2k_field_audit.rb`
+  surfaced against a real game's database (127 skills setting the field).
+  The banner tracks the cursor in the skill list and keeps showing the
+  pending skill's own text while picking a target or a teleport destination.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3046,6 +3046,31 @@ The work below is roughly ordered by the critical path to a walkable game
   0..100 floor, 必中 skipping the term entirely, weapon-slot exclusion, and
   an end-to-end `Battle.from_actor` wiring check), confirmed to fail against
   the pre-fix code before the fix.
+- ✅ **The field Skill screen now shows the highlighted skill's own flavour
+  text in a one-line banner across the top** — `skill.description`, unread
+  by `mruby-rpg2k` anywhere. `ruby scripts/rpg2k_field_audit.rb` against
+  mtf-meido-action (downloaded fresh via `scripts/download-mtf-meido-action.bash`,
+  the only test bed reachable this session — Nepheshel's host is blocked by
+  this sandbox's network policy) flags it with 127 of 134 skills setting it.
+  `Scene::ItemMenu` and `Scene::EquipMenu` already grew the equivalent
+  description banner for `item.description` (see the two entries above); only
+  `Scene::SkillMenu` never did. Verified against EasyRPG Player's actual C++
+  source: `Window_Skill::UpdateHelp` (`src/window_skill.cpp`) sets
+  `help_window`'s text to `ToString(GetSkill()->description)` on every
+  selection change, and `Scene_Skill::Start` wires that same `Window_Help`
+  in above the skill list — the exact shape `Window_Item`/`Window_Equip`
+  already use for their own description banner. Fixed with a new
+  `Scene::SkillMenu#build_desc_window`/`#refresh_desc` pair, mirroring
+  `Scene::ItemMenu`'s own exactly, and a `DESC_H`-tall offset added to the
+  skill grid window's y position so the banner has room above it. The
+  banner tracks the cursor in the skill list and keeps showing the pending
+  skill's own text while picking a target or a teleport destination (the
+  same "the pending item is still the one thing on screen a description
+  could be about" rule `Scene::ItemMenu#refresh_desc` already follows).
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (the banner shows
+  the first skill's text, follows the cursor onto the second, and keeps
+  showing it once a target is being picked), confirmed to fail against the
+  pre-fix code before the fix.
 
 ### yado.tk quirks backlog
 

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -29,6 +29,12 @@ class RPG2k
       SCREEN_H = RPG2k::HEIGHT
       LINE_H = 16
 
+      # Height of the skill-description banner at the very top of the screen
+      # (see #build_desc_window) -- the same gap Scene::ItemMenu/EquipMenu
+      # both already closed for their own description text; Scene::SkillMenu
+      # never grew the equivalent Window_Help.
+      DESC_H = LINE_H + Window::BORDER * 2
+
       # The skill list is a two-column grid, the same shape and cursor math
       # as Scene::ItemMenu's own (see its COLUMN_MAX comment) -- confirmed
       # via EasyRPG's `Window_Skill` constructor, which sets `column_max =
@@ -47,11 +53,13 @@ class RPG2k
         @pending_skill = nil
         @mode = :skills          # :skills list, :target selection, or :teleport_target
         @message = nil
+        build_desc_window
         build_skill_window
       end
 
       def dispose
         close_message
+        @desc_window.dispose if @desc_window
         @skill_window.dispose if @skill_window
         @target_window.dispose if @target_window
         @teleport_window.dispose if @teleport_window
@@ -132,6 +140,7 @@ class RPG2k
           @mode = :teleport_target
           @teleport_index = 0
           build_teleport_window
+          refresh_desc
         elsif sk && (sk.scope == 2 || sk.scope == 4)
           apply_skill(sid, nil)
         else
@@ -139,6 +148,7 @@ class RPG2k
           @mode = :target
           @target_index = 0
           build_target_window
+          refresh_desc
         end
       end
 
@@ -196,6 +206,7 @@ class RPG2k
           @target_window.dispose
           @target_window = nil
         end
+        refresh_desc
       end
 
       def update_teleport_target
@@ -261,6 +272,7 @@ class RPG2k
           @teleport_window.dispose
           @teleport_window = nil
         end
+        refresh_desc
       end
 
       # After a successful cast, drop back to the skill list and rebuild it (SP
@@ -279,6 +291,39 @@ class RPG2k
         (SCREEN_W - Window::BORDER * 2) / COLUMN_MAX
       end
 
+      # The highlighted skill's flavour text, in a one-line banner across the
+      # very top of the screen -- see Scene::ItemMenu#build_desc_window,
+      # which this mirrors exactly (the same gap, in the Skill screen
+      # instead). Tracks the skill under the cursor in :skills mode; the
+      # :target/:teleport_target pickers keep showing the pending skill's own
+      # description, since it is still the one thing on screen a description
+      # could be about.
+      def build_desc_window
+        @desc_window.dispose if @desc_window
+        inner_w = SCREEN_W - Window::BORDER * 2
+        @desc_window = Window.new(0, 0, SCREEN_W, DESC_H)
+        @desc_window.z = 400
+        @desc_window.windowskin = @skin
+        @desc_contents = Bitmap.new(inner_w, LINE_H)
+        @desc_window.contents = @desc_contents
+        refresh_desc
+      end
+
+      def refresh_desc
+        return unless @desc_contents
+        sid = if @mode == :skills
+                rows = skills
+                rows.empty? ? nil : rows[@skill_index].first
+              else
+                @pending_skill
+              end
+        sk = sid ? @state.party.db_skill(sid) : nil
+        text = sk ? sk.description.to_s : ''
+        @desc_contents.clear
+        @desc_contents.font.color = Color.new(255, 255, 255, 255)
+        @desc_contents.draw_text 0, 0, @desc_contents.width, LINE_H, text
+      end
+
       def build_skill_window
         @skill_window.dispose if @skill_window
         rows = skills
@@ -286,7 +331,7 @@ class RPG2k
         head_h = LINE_H
         grid_rows = [(rows.size / COLUMN_MAX.to_f).ceil, 1].max
         h = head_h + grid_rows * LINE_H
-        @skill_window = Window.new(0, 0, SCREEN_W, h + Window::BORDER * 2)
+        @skill_window = Window.new(0, DESC_H, SCREEN_W, h + Window::BORDER * 2)
         @skill_window.z = 400
         @skill_window.windowskin = @skin
         c = Bitmap.new(inner_w, h)
@@ -321,6 +366,7 @@ class RPG2k
         x = (@skill_index % COLUMN_MAX) * skill_col_w
         y = LINE_H + (@skill_index / COLUMN_MAX) * LINE_H
         @skill_window.cursor_rect = Rect.new(x, y, skill_col_w, LINE_H)
+        refresh_desc
       end
 
       def build_target_window

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -9750,7 +9750,7 @@ class WrapMenuParty < MenuStubParty
   def field_items(_state = nil); [[1, 3], [2, 1]]; end
   def field_skills(_actor, _state = nil); [[10, 2], [11, 4]]; end
   def db_item(id); OpenStruct.new(name: "Item#{id}"); end
-  def db_skill(id); OpenStruct.new(name: "Skill#{id}"); end
+  def db_skill(id); OpenStruct.new(name: "Skill#{id}", description: "Description of skill #{id}."); end
   def equip_candidates(_slot, _actor = nil); [[7, 2], [8, 1]]; end
 end
 
@@ -10755,6 +10755,34 @@ check 'Scene::SkillMenu: cancelling the destination list returns to the skill li
   eq :skills, scene.instance_variable_get(:@mode)
   ok state.pending_teleport.nil?
   ok !parent.pop_to_map_called
+end
+
+# EasyRPG's Window_Skill::UpdateHelp (src/window_skill.cpp) feeds the
+# database skill's own `description` straight to Scene_Skill's Window_Help
+# banner every time the selection changes -- the exact mechanism
+# Scene::ItemMenu/EquipMenu already reproduce for their own item description
+# banner. Scene::SkillMenu never grew the equivalent: the field's own
+# skill.description was parsed by the schema and never read anywhere in
+# mruby-rpg2k (confirmed with scripts/rpg2k_field_audit.rb against a real
+# game's database), so the Skill screen showed no flavour text at all.
+check 'Scene::SkillMenu: the description banner shows the highlighted skill\'s own text, ' \
+      'follows the cursor, and keeps the pending skill\'s text in target mode' do
+  scene = menu_scene(RPG2k::Scene::SkillMenu, wrap_menu_state)
+  ok window_texts(scene.instance_variable_get(:@desc_window)).include?('Description of skill 10.'),
+     'starts on the first skill (id 10)'
+
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second skill (id 11)
+  scene.update
+  RGSS::Input.reset
+  ok window_texts(scene.instance_variable_get(:@desc_window)).include?('Description of skill 11.'),
+     'the banner follows the cursor onto the second skill'
+
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm skill 11 (scope defaults to single-ally)
+  scene.update
+  RGSS::Input.reset
+  eq :target, scene.instance_variable_get(:@mode)
+  ok window_texts(scene.instance_variable_get(:@desc_window)).include?('Description of skill 11.'),
+     'the pending skill\'s own description is still shown while picking a target'
 end
 
 check 'Scene::Map: a pending teleport queued by the field skill menu is applied' do


### PR DESCRIPTION
## Summary

- `skill.description` was parsed by the LCF schema but never read anywhere in `mruby-rpg2k` — found via `scripts/rpg2k_field_audit.rb` run against `mtf-meido-action` (downloaded fresh this session; Nepheshel's host is blocked by this sandbox's network policy), which flagged it with 127 of 134 skills setting the field.
- `Scene::ItemMenu` and `Scene::EquipMenu` already show a one-line description banner across the top of the screen for `item.description`; `Scene::SkillMenu` never grew the equivalent.
- Verified against EasyRPG Player's actual C++ source: `Window_Skill::UpdateHelp` (`src/window_skill.cpp`) sets its `help_window`'s text to the currently-selected skill's own `description` on every selection change, and `Scene_Skill::Start` wires that `Window_Help` in above the skill list — the same shape `Window_Item`/`Window_Equip` already use.
- Fixed with a new `Scene::SkillMenu#build_desc_window`/`#refresh_desc` pair mirroring `Scene::ItemMenu`'s own exactly, and a `DESC_H`-tall offset added to the skill grid window's y position so the banner has room above it. The banner tracks the cursor in the skill list and keeps showing the pending skill's own text while picking a target or a teleport destination.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 774 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 502 checks passed (new check added; confirmed to fail against the pre-fix code first via `git stash`)
- [x] `ruby scripts/rpg2k_render_check.rb` — 40 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 checks passed (against `mtf-meido-action`)
- [x] `ruby scripts/rpg2k_command_soak.rb` — passed (against `mtf-meido-action`)
- [x] `docs/TODO.md` updated with the mechanism and regression-test citation
- [x] `changelog.d/rpg2k-skill-description-banner.fixed.md` added
- [x] Re-checked open PRs before pushing — no collision with this item

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HuHnp8Z4P33VB6PdTxXcte)_