### PR TITLE
rpg2k: enemy battle-graphic hue shift now recolours the battler sprite

### DIFF
--- a/changelog.d/enemy-battler-hue-shift.fixed.md
+++ b/changelog.d/enemy-battler-hue-shift.fixed.md
@@ -1,0 +1,32 @@
+- An enemy's **battle-graphic hue shift** (database field 3, `battler_hue`)
+  was parsed by the LCF schema but read nowhere in `mruby-rpg2k` — a `ruby
+  scripts/rpg2k_field_audit.rb` run against a freshly re-downloaded
+  Nepheshel and mtf-meido-action flagged it (3 rows, Nepheshel only). A game
+  reusing one `Monster/<name>` bitmap for several palette-swapped monsters
+  (a red slime and a blue slime sharing "Slime.png", a common RPG2000
+  authoring trick that avoids shipping a separate file per colour) always
+  drew every one of them in the file's own unshifted colour. Verified
+  against EasyRPG Player's actual C++ source rather than guessed at:
+  `Game_Enemy::GetHue` (`src/game_enemy.h`) is a bare `enemy->battler_hue`
+  passthrough, and `Sprite_Enemy::OnMonsterSpriteReady`/`Refresh`
+  (`src/sprite_enemy.cpp`) rotate the decoded bitmap through
+  `Bitmap::HueChangeBlit` whenever it is nonzero, rebuilding the sprite
+  whenever either the graphic name or the hue changes. Ported as
+  `Game::Enemy#battler_hue` (read the same way `levitate`/`transparent`
+  already are) and a new `Combatant#battler_hue` field, fed into
+  `Scene::Map#battler_bitmap` (`mruby-rpg2k/mrblib/scene/map.rb`), which now
+  calls the existing `Bitmap#hue_change` (already used elsewhere in this
+  build's RGSS layer) on a freshly decoded battler and keys its
+  `@monster_cache` by name **and** hue rather than name alone — `hue_change`
+  mutates its bitmap in place, so a same-file, zero-hue enemy sharing the
+  cache with a hued one must decode its own copy rather than share the
+  rotated one. `#refresh_battle_sprites`/`#rebuild_battler_sprite` and a
+  monster Transformation (`Game::Battle#enemy_transform_action`) now track
+  and compare hue the same way they already track `battler_name`, matching
+  EasyRPG's own `Sprite_Enemy::Refresh` rebuilding on either changing.
+  Covered by a new `scripts/rpg2k_scene_check.rb` check (a hue-120 fixture
+  enemy's built sprite records exactly one `hue_change(120)` call; a
+  same-file zero-hue enemy sharing the scene's cache decodes unrotated; a
+  mid-fight transformation back to the zero-hue battler redraws with no
+  rotation), confirmed to fail against the pre-fix code (`NoMethodError:
+  undefined method 'battler_hue'`) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7678,6 +7678,36 @@ above are repeated here)
   already queued), all confirmed to fail against the pre-fix code (a bare
   `NoMethodError: undefined method 'force_ai?'`/`'choose_auto_battle_command'`)
   before the fix.
+- ✅ **An enemy's battle-graphic hue shift (field 3, `battler_hue`) is now
+  implemented — the same "parsed by the schema but read nowhere in
+  `mruby-rpg2k`" shape as `levitate`/`avoid_attacks`/`reflect_magic`/
+  `force_ai` above.** `ruby scripts/rpg2k_field_audit.rb` against a freshly
+  re-downloaded Nepheshel and mtf-meido-action flagged it (3 rows,
+  Nepheshel only, `enemy.battler_hue`). A game reusing one `Monster/<name>`
+  bitmap for several palette-swapped monsters (a red slime and a blue slime
+  sharing "Slime.png") always drew every one of them in the file's own
+  unshifted colour. Verified against EasyRPG Player's actual C++ source:
+  `Game_Enemy::GetHue` (`src/game_enemy.h`) is a bare `enemy->battler_hue`
+  passthrough, and `Sprite_Enemy::OnMonsterSpriteReady`/`Refresh`
+  (`src/sprite_enemy.cpp`) rotate the decoded bitmap through
+  `Bitmap::HueChangeBlit` whenever it is nonzero, rebuilding the sprite
+  whenever either the graphic name or the hue changes. Ported as
+  `Game::Enemy#battler_hue` and a new `Combatant#battler_hue` field, fed
+  into `Scene::Map#battler_bitmap` (`mruby-rpg2k/mrblib/scene/map.rb`),
+  which now calls the existing `Bitmap#hue_change` on a freshly decoded
+  battler and keys its `@monster_cache` by name **and** hue rather than
+  name alone — `hue_change` mutates its bitmap in place, so a same-file,
+  zero-hue enemy sharing the cache with a hued one must decode its own
+  copy rather than share the rotated one. `#refresh_battle_sprites`/
+  `#rebuild_battler_sprite` and a monster Transformation
+  (`Game::Battle#enemy_transform_action`) now track and compare hue the
+  same way they already track `battler_name`. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a hue-120 fixture enemy's built
+  sprite records exactly one `hue_change(120)` call; a same-file zero-hue
+  enemy sharing the scene's cache decodes unrotated; a mid-fight
+  transformation back to the zero-hue battler redraws with no rotation),
+  confirmed to fail against the pre-fix code (`NoMethodError: undefined
+  method 'battler_hue'`) before the fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6052,6 +6052,17 @@ module Game
       # sprite would otherwise have (255 outside of the death-fade/explode
       # animations this codebase does not yet model).
       @transparent = row && row.respond_to?(:transparent) ? (row.transparent ? true : false) : false
+      # The battle-graphic hue shift (field 3, degrees 0..359): lets a game
+      # reuse one Monster/<name> bitmap for several palette-swapped variants
+      # (a red slime and a blue slime sharing "Slime.png") instead of shipping
+      # a separate file per colour. Verified against EasyRPG Player's actual
+      # C++ source: `Game_Enemy::GetHue` (`src/game_enemy.h`) is a bare
+      # `enemy->battler_hue` passthrough, and `Sprite_Enemy::OnMonsterSpriteReady`
+      # (`src/sprite_enemy.cpp`) rotates the loaded bitmap through
+      # `Bitmap::HueChangeBlit` whenever it is nonzero, before the sprite is
+      # ever shown -- purely a render-time recolour with no stat effect,
+      # unlike every field above it.
+      @battler_hue = row && row.respond_to?(:battler_hue) ? (row.battler_hue || 0) : 0
       # The 行動パターン table (field 42), decoded now since `row` isn't kept. An
       # enemy whose row lists none falls back to plain attacking.
       @actions = []
@@ -6070,6 +6081,9 @@ module Game
 
     # The "Appear Transparent" flag (field 10) -- see the comment in #initialize.
     attr_reader :transparent
+
+    # The battle-graphic hue shift (field 3) -- see the comment in #initialize.
+    attr_reader :battler_hue
 
     # Base to-hit percentage for this enemy's normal attack (70 when the "miss"
     # flag is set, otherwise 90); fed into the battle's to-hit roll.
@@ -6571,6 +6585,7 @@ module Game
                            :prevents_crit, :attr_ranks, :atk_attrs, :skip,
                            :hit_rate, :state_ranks, :hidden, :battle_turn,
                            :actions, :charged, :enemy_id, :battler_name,
+                           :battler_hue,
                            # Equipment-granted combat modifiers (ADR 0033):
                            # how many times a basic attack swings, whether it
                            # can be evaded, whether Defend halves twice, and
@@ -6709,6 +6724,7 @@ module Game
       # The Monster/<name> graphic, carried so the battle screen can redraw a
       # combatant whose transformation swapped it.
       c.battler_name = e.respond_to?(:battler_name) ? e.battler_name : nil
+      c.battler_hue = e.respond_to?(:battler_hue) ? (e.battler_hue || 0) : 0
       c.attr_base_ranks = c.attr_ranks.dup
       c
     end
@@ -7983,6 +7999,7 @@ module Game
       b.actions = into.actions
       b.enemy_id = act.enemy_id
       b.battler_name = into.battler_name
+      b.battler_hue = into.battler_hue
       { attacker: b.name, transform: true, target: into.name }
     end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4229,9 +4229,12 @@ class RPG2k
           spr.opacity = battler_opacity(enemy)
           spr
         end
-        # The battler each sprite was drawn from, so a transformation mid-fight
-        # is noticed and redrawn (see #refresh_battle_sprites).
+        # The battler (graphic name + hue) each sprite was drawn from, so a
+        # transformation mid-fight is noticed and redrawn (see
+        # #refresh_battle_sprites) -- matching EasyRPG's own
+        # `Sprite_Enemy::Refresh`, which rebuilds on either changing.
         @battle_ui[:sprite_names] = @battle_ui[:foes].map { |f| f.battler_name }
+        @battle_ui[:sprite_hues] = @battle_ui[:foes].map { |f| f.battler_hue || 0 }
         refresh_battle_sprites
       end
 
@@ -4378,16 +4381,23 @@ class RPG2k
       # The battler graphic for `enemy` (Monster/<battler_name>, colour-keyed), or
       # a solid placeholder block when it has no graphic or the file is missing —
       # the same fallback strategy the map uses for a missing chipset. Cached by
-      # name (see #cached_bitmap) so a monster reused across troop slots, or a
+      # name+hue (see #cached_bitmap) so a monster reused across troop slots, or a
       # transformation that returns to a battler already shown this visit, is
-      # decoded once.
+      # decoded (and hue-rotated) once. The hue rotation (database field 3, see
+      # `Game::Enemy#battler_hue`) is applied to this decode alone, never to a
+      # cached bitmap already shared by a same-named, differently-hued sibling —
+      # `Bitmap#hue_change` (`mruby-rgss/src/lib.cxx`) mutates in place, so the
+      # cache key must fold hue in rather than rotate a shared entry.
       def battler_bitmap(enemy)
         name = enemy.battler_name
-        key = (name && !name.empty?) ? name : nil
+        hue = enemy.respond_to?(:battler_hue) ? (enemy.battler_hue || 0) : 0
+        key = (name && !name.empty?) ? "#{name}\0#{hue}" : nil
         cached_bitmap(@monster_cache, key) do
           if key
             begin
-              Bitmap.new("Monster/#{key}", true)
+              bmp = Bitmap.new("Monster/#{name}", true)
+              bmp.hue_change(hue) if hue != 0
+              bmp
             rescue StandardError => e
               $stderr.puts "[RPG2k] battler load failed for #{enemy.name}: #{e.message}"
               placeholder_battler
@@ -4440,8 +4450,10 @@ class RPG2k
         # combatant no longer wearing the battler its sprite was built from
         # before deciding what is visible.
         names = (@battle_ui[:sprite_names] ||= [])
+        hues = (@battle_ui[:sprite_hues] ||= [])
         @battle_ui[:foes].each_with_index do |foe, i|
-          rebuild_battler_sprite(i, foe) if sprites[i] && names[i] != foe.battler_name
+          changed = names[i] != foe.battler_name || hues[i] != (foe.battler_hue || 0)
+          rebuild_battler_sprite(i, foe) if sprites[i] && changed
         end
         @battle_ui[:foes].each_with_index do |foe, i|
           spr = sprites[i]
@@ -4471,6 +4483,7 @@ class RPG2k
         sprites[i] = spr
         dispose_battle_sprite(old)
         @battle_ui[:sprite_names][i] = foe.battler_name
+        @battle_ui[:sprite_hues][i] = foe.battler_hue || 0
       end
 
       def living_allies; @battle_ui[:allies].reject(&:dead?); end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -69,6 +69,13 @@ module RGSS
     def text_size(_); Rect.new(0, 0, 0, 0); end
     def font; @font ||= OpenStruct.new; end
     def get_pixel(x, y); Color2.new(x % 256, y % 256, 42, 255); end
+    # Records the hue(s) applied, mirroring the real RGSS::Bitmap#hue_change
+    # (mruby-rgss/src/lib.cxx) contract: mutates this bitmap in place, no
+    # return value asserted on. #battler_bitmap (mruby-rpg2k/mrblib/scene/
+    # map.rb) calls this on a freshly decoded, not-yet-cached bitmap only, so
+    # a nonempty log here is only ever this decode's own hue.
+    def hue_change(h); (@hue_calls ||= []) << h; end
+    attr_reader :hue_calls
     def dispose; end
   end
 
@@ -356,7 +363,17 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
              4 => OpenStruct.new(name: 'Ghost', battler_name: 'Ghost',
                                  max_hp: 15, max_sp: 0, attack: 5,
                                  defense: 2, spirit: 2, agility: 6, exp: 3,
-                                 gold: 6, transparent: true) },
+                                 gold: 6, transparent: true),
+             # Battle-graphic hue shift (field 3, `Game::Enemy#battler_hue`)
+             # fixture: reuses Slime's own "Slime" battler file with a
+             # nonzero hue, the way a real game palette-swaps one monster
+             # bitmap into several -- its own lone-member troop (group 4)
+             # keeps it from disturbing the two-Slime troop's own
+             # (un-hue-shifted) battler-cache assertions.
+             5 => OpenStruct.new(name: 'Red Slime', battler_name: 'Slime',
+                                 max_hp: 30, max_sp: 0, attack: 8,
+                                 defense: 4, spirit: 3, agility: 5, exp: 5,
+                                 gold: 10, battler_hue: 120) },
     enemy_group: { 1 => OpenStruct.new(name: 'Slimes', members: {
       1 => OpenStruct.new(enemy_id: 2, x: 100, y: 80, invisible: false),
       2 => OpenStruct.new(enemy_id: 2, x: 200, y: 80, invisible: false) },
@@ -366,6 +383,9 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
         pages: nil),
       3 => OpenStruct.new(name: 'Ghosts', members: {
         1 => OpenStruct.new(enemy_id: 4, x: 100, y: 80, invisible: false) },
+        pages: nil),
+      4 => OpenStruct.new(name: 'Red Slimes', members: {
+        1 => OpenStruct.new(enemy_id: 5, x: 100, y: 80, invisible: false) },
         pages: nil) },
     # A drawable battle animation (id 8): four frames, with a screen flash timing
     # on frame 1. (Id 7 is intentionally absent so that test exercises the
@@ -7780,6 +7800,54 @@ check 'Enemy Encounter scene: an "Appear Transparent" enemy draws at reduced ' \
   scene.send(:reveal_battle_monster, 0)
   eq 160, ui[:enemy_sprites][0].opacity,
      'Show Hidden Monster also draws it at the reduced opacity'
+end
+
+# The battle-graphic hue shift (field 3, `Game::Enemy#battler_hue`) was parsed
+# by the schema but read nowhere in mruby-rpg2k -- the same "parsed but
+# unused" shape as `levitate`/`transparent` above, so a game reusing one
+# Monster/<name> bitmap for several palette-swapped monsters (a common
+# RPG2000 authoring trick) always drew every one of them in the file's own
+# unshifted colour. Verified against EasyRPG Player's actual C++ source:
+# `Game_Enemy::GetHue` (`src/game_enemy.h`) is a bare `enemy->battler_hue`
+# passthrough, and `Sprite_Enemy::OnMonsterSpriteReady`/`Refresh`
+# (`src/sprite_enemy.cpp`) rotate the decoded bitmap through
+# `Bitmap::HueChangeBlit` whenever it is nonzero and rebuild whenever either
+# the sprite name or the hue changes. Troop 4's lone Red Slime (enemy id 5,
+# reusing Slime's own "Slime" battler file at hue 120) is the dedicated
+# fixture, kept off the two-Slime troop so this never disturbs its own
+# zero-hue battler-cache assertions.
+check 'Enemy Encounter scene: a battle-graphic hue shift rotates the battler ' \
+      'bitmap, keyed separately from a same-named zero-hue battler' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, troop_id: 4)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_to_command(scene)
+  member = ui[:troop].members[0]
+  eq 120, member.battler_hue, 'the fixture enemy (id 5, Red Slime) carries the hue'
+  eq [120], ui[:enemy_sprites][0].bitmap.hue_calls,
+     'build_battle_sprites rotates the decoded battler bitmap by the database hue'
+
+  # The plain (hue 0) Slime shares this same scene's @monster_cache and the
+  # very same "Slime" battler file -- its own decode must stay unrotated
+  # rather than being mutated by the Red Slime's #hue_change call above,
+  # since #battler_bitmap keys the cache by name+hue rather than name alone.
+  plain = scene.send(:battler_bitmap, Game::Enemy.new(scene.db, 2))
+  ok plain.hue_calls.nil? || plain.hue_calls.empty?,
+     'a same-file, zero-hue enemy decodes its own unrotated bitmap'
+
+  # A mid-fight transformation redraw (#rebuild_battler_sprite) picks up the
+  # new hue too, matching EasyRPG's `Sprite_Enemy::Refresh` rebuilding on
+  # either the sprite name or the hue changing -- not just the initial build.
+  ui[:foes][0].battler_name = 'Slime'
+  ui[:foes][0].battler_hue = 0
+  ui[:foes][0].name = 'Slime'
+  scene.send(:refresh_battle_sprites)
+  ok ui[:enemy_sprites][0].bitmap.hue_calls.nil? ||
+     ui[:enemy_sprites][0].bitmap.hue_calls.empty?,
+     'transforming into the zero-hue battler redraws with no hue rotation'
 end
 
 check 'Enemy Encounter scene: a monster that leaves the field is not drawn' do


### PR DESCRIPTION
## Summary
- Database field 3 (`battler_hue`) was parsed by the LCF schema but read nowhere in `mruby-rpg2k` — found via `ruby scripts/rpg2k_field_audit.rb` against a freshly re-downloaded Nepheshel and mtf-meido-action. A game reusing one `Monster/<name>` bitmap for several palette-swapped monsters (a common RPG2000 authoring trick) always drew every one of them in the file's own unshifted colour.
- Verified against EasyRPG Player's actual C++ source: `Game_Enemy::GetHue` (`src/game_enemy.h`) is a bare `enemy->battler_hue` passthrough, and `Sprite_Enemy::OnMonsterSpriteReady`/`Refresh` (`src/sprite_enemy.cpp`) rotate the decoded bitmap through `Bitmap::HueChangeBlit` whenever it is nonzero, rebuilding whenever either the graphic name or the hue changes.
- Ported as `Game::Enemy#battler_hue` and a new `Combatant#battler_hue` field, fed into `Scene::Map#battler_bitmap`, which now calls the existing `Bitmap#hue_change` on a freshly decoded battler and keys its `@monster_cache` by name **and** hue — `hue_change` mutates its bitmap in place, so a same-file, zero-hue enemy sharing the cache with a hued one must decode its own copy. `#refresh_battle_sprites`/`#rebuild_battler_sprite` and a monster Transformation now track and compare hue the same way they already track `battler_name`.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb`
- [x] `ruby scripts/rpg2k_scene_check.rb` (new check added, confirmed to fail against the pre-fix code with `NoMethodError: undefined method 'battler_hue'` before the fix, passes after)
- [x] `ruby scripts/rpg2k_render_check.rb`
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb`
- [x] `ruby scripts/rpg2k_command_soak.rb`
- [x] `docs/TODO.md` updated with a ✅ entry and regression-test citation
- [x] `changelog.d/enemy-battler-hue-shift.fixed.md` added


---
_Generated by [Claude Code](https://claude.ai/code/session_012RTwebCWsQkqNzKAGqNDD2)_