### PR TITLE
docs: confirm Message Options is already sticky global state

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5506,9 +5506,25 @@ not yet verified:
   makes `#drive_message` honour `auto_close?` for a choice window (and,
   for the merged case, makes `#append_choice_lines` thread the scanned
   `:auto_close` into its own `reveal` too) before being reverted.
-- Message Options (window transparency/position) are **sticky global
-  state** — once set, they apply to every subsequent message window for
-  the rest of the game (or until reset), not scoped to the current event.
+- ✅ **Message Options (window transparency/position) are sticky global
+  state -- once set, they apply to every subsequent message window for the
+  rest of the game (or until reset), not scoped to the current event.**
+  Already correct and, unlike the last few confirmed-already-correct
+  findings, already thoroughly tested too -- no fix or new coverage
+  needed, just the missing ✅. `Interpreter#do_message_options`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) writes straight into
+  `@state.message_config`, the single `Game::State` instance that lives
+  for the whole play session (`Scene::Map#perform_teleport` never
+  constructs a new `Game::State` on a map transfer, only swaps the map
+  data underneath the same one) -- so a change from one event reads back
+  from any later one, on any map, with no scoping mechanism to accidentally
+  reset it. `scripts/rpg2k_logic_check.rb` already exercises this from
+  several angles: multiple checks confirm settings set by one Message
+  Options command are still in effect for later, unrelated message
+  commands, and a dedicated save/load round-trip check (`~line 3074`)
+  confirms `transparent`/`position`/`face_name`/`face_index` all survive a
+  full `to_lsd`/`from_lsd` cycle -- a stronger, already-verified form of
+  "sticky for the rest of the game" than the bare claim asked for.
 - ✅ **Text beyond the display-limit line is now genuinely truncated by this
   codebase's own message layout, not just by an accident of bitmap size.**
   `Scene::Map#draw_message_run` (`mruby-rpg2k/mrblib/scene/map.rb`) handed


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s "Full-site sweep" backlog (yado.tk-catalogued quirks) had an unmarked claim: Message Options (window transparency/position) should be sticky global state — once set, applies to every subsequent message window for the rest of the game, not scoped to the current event.
- Checked this engine's own source: `Interpreter#do_message_options` writes straight into `@state.message_config`, the single `Game::State` instance that lives for the whole play session — `Scene::Map#perform_teleport` never constructs a new `Game::State` on a map transfer, only swaps the map data underneath the same one. So there's no scoping mechanism that could accidentally reset it.
- Already thoroughly tested from several angles in `rpg2k_logic_check.rb`: multiple checks confirm settings set by one Message Options command are still in effect for later, unrelated message commands, and a dedicated save/load round-trip check confirms `transparent`/`position`/`face_name`/`face_index` all survive a full `to_lsd`/`from_lsd` cycle — a stronger, already-verified form of "sticky for the rest of the game" than the bare claim asked for.
- Docs-only: no behavior change or new test needed, just the missing ✅ and the citation trail for whoever reads this next.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (docs-only, no behavior change)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_