### PR TITLE
test: cover the two remaining Items & equipment backlog claims

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3415,21 +3415,23 @@ Full page read; ~140 distinct quirks catalogued, grouped by the page's own
 section headers (English). Items already Fixed/Confirmed above are omitted.
 Everything below is unverified against the codebase.
 
-- **Items & equipment** — counts silently cap at 99 (not clamped, just
-  ignored past it); Change Equipment creates/returns inventory copies
-  implicitly; ✅ **item list always sorts by database id, never acquisition
+- **Items & equipment** — ✅ **counts silently cap at 99 (not clamped, just
+  ignored past it) -- already correct, and now asserted head-on rather than
+  only indirectly (the Shop `max_buy` cap checks).** `Game::Party#
+  gain_item`'s own `c = 99 if c > 99` already matched this exactly (a gain
+  past 99 clamps rather than overflowing or erroring); `rpg2k_logic_check.rb`
+  gains "gain_item clamps at 99, silently, past a single gain or several
+  smaller ones" -- a single gain of 150 lands on 99 (not 150 or an error), a
+  further gain once already at the cap is a silent no-op, and losing still
+  works normally once back below it.
+  ✅ **item list always sorts by database id, never acquisition
   order** -- already correct and already tested: `Game::Party#field_items`/
   `#battle_items` (`mruby-rpg2k/mrblib/game.rb`) both build their list off
   `@items.keys.sort`, and `rpg2k_logic_check.rb`'s own "field_items lists
   only held medicines, in id order with counts" check already proves the
   *order*, not just the presence, of the fix: it gains item 9 before item 5
   and still asserts the list comes back `[[5, 1], [9, 2]]`, id-ascending
-  despite the reverse acquisition order. `Game::Party#gain_item`'s own
-  `c = 99 if c > 99` also already matches this same bullet's 99-cap claim
-  functionally (a gain past 99 clamps rather than overflowing or erroring),
-  though that specific claim is so far only indirectly exercised (the Shop
-  `max_buy` cap checks), not asserted head-on the way the sort order now
-  is -- left as-is rather than claiming a rigor it does not have yet.
+  despite the reverse acquisition order.
   ✅ **"Equipped item No." reads 0 when empty, and the 2nd weapon slot reads
   through the *Shield* No. operand for dual-wield -- both already correct
   and already tested too.** `Interpreter#actor_operand`'s equip-slot cases
@@ -3468,11 +3470,20 @@ Everything below is unverified against the codebase.
   mean. ("hero equips X" — the Conditional Branch actor sub-condition —
   already reads `actor.equipped?` directly and was fine; "has item X" was
   the actual gap, now fixed, see above.)
-  **Still genuinely open in this bullet:** "counts silently cap at 99" (see
-  the caveat two paragraphs up -- functionally matched but not yet asserted
-  head-on) and "Change Equipment creates/returns inventory copies
-  implicitly" (not yet checked against this engine's own
-  `equip_from_bag`/`unequip_to_bag`).
+  ✅ **"Change Equipment creates/returns inventory copies implicitly" --
+  also already correct, and it is the well-known real RPG2000 quirk it
+  sounds like: the event command bypasses the party's bag entirely,
+  unlike the Equip menu screen.** `do_change_equipment`
+  (`mruby-rpg2k/mrblib/interpreter.rb`) drives `Game::Actor#equip_item`/
+  `#unequip` (`mruby-rpg2k/mrblib/game.rb`) directly -- neither calls
+  `#gain_item`/`#lose_item` anywhere, unlike `Scene::EquipMenu`'s own
+  `#equip_from_bag`/`#unequip_to_bag`, which explicitly swap through
+  `Game::Party`'s held-item counts. `rpg2k_logic_check.rb` gains "Change
+  Equipment command creates/returns items implicitly", asserting the bag's
+  own count for the equipped item stays exactly 0 throughout: equipping an
+  item the party never held at all still equips it (conjured, not drawn
+  from a bag that had none), and unequipping does not add a copy back
+  either. **Every sub-claim in this bullet is now confirmed correct.**
 - **Call Event** — doesn't move the target event, ignores its appearance
   conditions, can't cross maps, continues the *caller* right after itself
   once the callee finishes/cancels; calling a bad event/page id raises

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3831,6 +3831,31 @@ check 'Change Equipment command equips into the type slot and removes' do
   eq 8, a.equipment[2] # armour still on
 end
 
+check 'Change Equipment command creates/returns items implicitly -- it never ' \
+      "touches the party's bag, unlike the Equip menu screen" do
+  # A yado.tk-catalogued quirk (docs/TODO.md's "Items & equipment" bullet):
+  # the event command conjures the item onto the actor directly and drops it
+  # the same way on removal, with no bag interaction either direction --
+  # unlike Scene::EquipMenu's own #equip_from_bag/#unequip_to_bag, which
+  # explicitly swap through Game::Party's held-item counts. Confirmed by
+  # inspection (Game::Actor#equip_item/#unequip, which this command drives,
+  # call neither #gain_item nor #lose_item anywhere), and now asserted
+  # head-on: the bag's own count for the equipped item stays exactly 0
+  # throughout, whether or not the party ever held one.
+  items = { 7 => fake_item(atk: 15, type: 1) }   # weapon -> slot 0
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  eq 0, st.party.item_count(7), 'the bag starts with none of item 7 at all'
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  eq 7, a.equipment[0], 'the actor is equipped with an item the party never held'
+  eq 0, st.party.item_count(7), 'equipping created it out of thin air -- the bag is still empty'
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, 0])]); it.update }
+  eq 0, a.equipment[0], 'unequipped'
+  eq 0, st.party.item_count(7), 'and it did not land back in the bag either'
+end
+
 check 'Change Equipment command respects an actor_set restriction, per actor' do
   items = { 7 => fake_item(atk: 15, type: 1, actor_set: [true, false]) } # actor 1 only
   db = FakeActorDB.new(
@@ -3858,6 +3883,21 @@ def item_party(items)
     2 => FakePlayerRow.new('Ally', '', 0, 3, max_hp: 50, max_mp: 20, atk: 6, def: 5),
   }
   Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items)), 1, 0, 0)
+end
+
+check 'gain_item clamps at 99, silently, past a single gain or several ' \
+      'smaller ones' do
+  # A yado.tk-catalogued quirk (docs/TODO.md's "Items & equipment" bullet):
+  # counts silently cap at 99, not clamped-with-a-message, just ignored past
+  # it. Previously only exercised indirectly (through the Shop max_buy cap
+  # checks) -- asserted head-on here.
+  st = item_party({ 5 => fake_item(type: 6, rhp: 50) })
+  st.party.gain_item(5, 150)
+  eq 99, st.party.item_count(5), 'a single gain past 99 clamps, not overflows'
+  st.party.gain_item(5, 5) # already at the cap
+  eq 99, st.party.item_count(5), 'gaining more once already at the cap is a silent no-op'
+  st.party.lose_item(5, 50)
+  eq 49, st.party.item_count(5), 'losing still works normally once below the cap again'
 end
 
 check 'field_items lists only held medicines, in id order with counts' do


### PR DESCRIPTION
## Summary

Fully closes out the "Items & equipment" bullet in `docs/TODO.md`'s untriaged backlog (following #726/#727), by covering the two remaining sub-claims. Both already correct — no behavior fix needed.

- **Change Equipment (the event command) creates/returns inventory copies implicitly, bypassing the party's bag entirely** — the well-known real RPG2000 quirk it sounds like, unlike the Equip menu screen's own `equip_from_bag`/`unequip_to_bag`. `do_change_equipment` drives `Game::Actor#equip_item`/`#unequip` directly, and neither calls `gain_item`/`lose_item` anywhere. New test asserts the bag's own count for the equipped item stays exactly 0 throughout: equipping an item the party never held still equips it (conjured, not drawn from an empty bag), and unequipping doesn't add a copy back either.
- **Item counts silently cap at 99.** `Game::Party#gain_item`'s `c = 99 if c > 99` already matched this; previously only exercised indirectly through the Shop `max_buy` cap checks. New test asserts it head-on: a single gain of 150 clamps to 99 (not 150 or an error), a further gain once already at the cap is a silent no-op, and losing still works normally once back below it.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass (2 new checks)
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_