### PR TITLE
rpg2k: fix a stale save-screen comment about face thumbnails

### DIFF
--- a/mruby-rpg2k/mrblib/scene/save_load.rb
+++ b/mruby-rpg2k/mrblib/scene/save_load.rb
@@ -265,13 +265,13 @@ class RPG2k
 
       # `slot_index`'s box: the file label always, and -- when the slot holds
       # a save -- the leader's name and level+HP beneath it, plus up to four
-      # party face thumbnails along the right edge. Confirmed against
-      # genuine RPG_RT under wine: an empty slot shows only the label (no
+      # party face thumbnails along the right edge (`#draw_slot_faces`,
+      # reading the same title-chunk FaceSet data `Game::State#to_lsd`
+      # already exports -- see docs/TODO.md). Confirmed against genuine
+      # RPG_RT under wine: an empty slot shows only the label (no
       # placeholder text at all), and an occupied one shows neither gold nor
       # the current map, and HP with no `/max`, unlike this screen's own
-      # previous single-list-window layout. The faces are data
-      # `Game::State#to_lsd` already exports into the save's title chunk
-      # (see docs/TODO.md) but this screen never read back.
+      # previous single-list-window layout.
       def draw_slot_box(win, inner_w, slot_index)
         label = slot_label(slot_index)
         c = Bitmap.new(inner_w, LINE_H * SLOT_LINES)


### PR DESCRIPTION
## Summary

- Small housekeeping fix, no behavior change. `Scene::SaveLoad#draw_slot_box`'s doc comment said the save-select screen's face thumbnail data (already exported by `Game::State#to_lsd`'s title chunk) was "never read back" by this screen.
- That was true when the comment was written, but a concurrent session's own change since then added `#draw_slot_faces`, which does read it back and draw up to four party face thumbnails per slot — `docs/TODO.md` was already updated to mark this ✅ at the time, but this one inline source comment was left describing the pre-fix state.
- Corrected the comment to reference `#draw_slot_faces` directly instead.

Found while sweeping `docs/TODO.md`'s untriaged backlog sections for more real-fix candidates this iteration (following #721/#725/#726/#727/#728) — most of the "Call Event", "Map & characters", and "Event system" claims checked out as already correct with existing coverage, so rather than another docs-confirmation PR, this fixes the one genuine (if small) staleness this pass turned up. Also identified a more substantial, well-scoped real gap for a follow-up: the timer-slides-to-avoid-a-top-parked-message-window behavior `docs/TODO.md`'s "Screen effects" bullet already flags as open — worth its own iteration with proper EasyRPG source verification rather than a rushed implementation here.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (comment-only change)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_