### PR TITLE
rpg2k: timer slides down when a message parks at the top, outside battle

### DIFF
--- a/changelog.d/rpg2k-timer-avoids-top-message.added.md
+++ b/changelog.d/rpg2k-timer-avoids-top-message.added.md
@@ -1,0 +1,10 @@
+- **The on-screen timer now slides down to the bottom edge outside of
+  battle whenever the last message window resolved to the top of the
+  screen, so the two never overlap.** Confirmed against EasyRPG Player's
+  source (`Sprite_Timer::Draw`/`Game_Message::GetRealPosition`/
+  `Window_Message::InsertNewPage`): the check is against the message
+  window's last *resolved* position -- itself downstream of RPG2000's
+  dynamic avoid-the-hero repositioning when the position is not pinned --
+  and it stays sticky even after that message closes, only resetting on a
+  genuine new map visit (Teleport/Transfer Player), not a mere return from
+  a pushed menu/battle scene.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1654,23 +1654,55 @@ The work below is roughly ordered by the critical path to a walkable game
   `screen_height / 3 * 2 - 20` (140 at 320x240) instead of its usual top-edge
   slot; `draw_one_timer` now sets `spr.y` from the same `!@battle_ui.nil?`
   flag `#draw_timer` already threads through for the "pause/hide without the
-  battle flag" behaviour. **Still open**: outside of battle, real RPG_RT also
-  slides a timer down to the bottom edge whenever the (sticky,
-  persists-across-messages) message window is currently parked at the top of
-  the screen (`Game_Message::GetWindow()->GetY() < 20`), so the two never
-  overlap — this build has no persistent message-window object to read a
-  sticky position back from (`@message` is a fresh object built per message
-  and torn down when it closes, unlike RPG_RT's one long-lived
-  `Window_Message`), so that half stays unmodelled and a timer sits at the
-  fixed top slot outside of battle regardless of where a message last opened.
-  Covered by six new `scripts/rpg2k_scene_check.rb` checks (the digit cells
+  battle flag" behaviour.
+  ✅ **Now implemented too**: outside of battle, real RPG_RT slides a timer
+  down to the bottom edge whenever the (sticky, persists-across-messages)
+  message window is currently parked at the top of the screen
+  (`Game_Message::GetWindow()->GetY() < 20`), so the two never overlap.
+  Confirmed against EasyRPG's own `Sprite_Timer::Draw`/`Game_Message::
+  GetRealPosition`/`Window_Message::InsertNewPage` (`src/sprite_timer.cpp`,
+  `src/game_message.cpp`, `src/window_message.cpp`, fetched verbatim): the
+  check is against the window's *last resolved* Y, not the raw Message
+  Options preference -- itself downstream of RPG2000's dynamic
+  avoid-the-hero repositioning when the position is not pinned (`Game_
+  Message::GetRealPosition()` calls `game_player->GetScreenY()` exactly the
+  way this build's own `#auto_message_position` already did) -- and that Y
+  is never reset when the message later closes (`Window_Message::
+  FinishMessageProcessing` only starts a close animation, nothing touches
+  `y`), only rebuilt fresh (implicitly starting `>= 20`, i.e. "not top")
+  on a genuine new `Scene_Map::Start` -- a real map entry (Teleport/Transfer
+  Player), not the `Scene_Map::Continue` reuse a mere return from a pushed
+  menu/battle scene gets. This build had no literal persistent
+  `Window_Message` object to read a Y back from (`@message` is a fresh
+  object built per message and torn down when it closes), so `Scene::Map`
+  gains its own sticky `@message_window_top` flag instead, tracking the
+  same "did the last message resolve to the top" outcome directly:
+  `#open_message` sets it the instant a message opens (not when it closes),
+  reading the same `#effective_message_position` helper `#message_window_y`
+  itself now shares (a small extraction with no behaviour change of its
+  own); `#initialize`/`#perform_teleport` reset it to false on every fresh
+  map visit, mirroring EasyRPG's own rebuild. `#draw_one_timer` reads it
+  outside of battle: `SCREEN_H - 20` (220 at 320x240, matching `screen_height
+  - 20 - menu_offset_y` with this build's own zero menu offset) when set,
+  the existing `4` otherwise. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks: the timer drops to the bottom edge
+  the instant a top-resolving message opens (hero positioned low on
+  screen, matching the already-tested `#message_window_y` auto-position
+  logic) and *stays* there once that message closes; and, separately, a
+  bottom-resolving message never sets the flag at all, while a `#perform_
+  teleport` call after manually forcing the flag on confirms a fresh map
+  visit clears it back to the normal top position. Not itself
+  wine-verified (this session's wine harness stayed broken throughout, a
+  separate, unrelated regression), but the EasyRPG source read leaves
+  little ambiguity, unlike some of this file's other open items.
+  The original "six new checks" this bullet already named cover the digit cells
   blitted for a 75s/"1:15" reading, each cell's exact source rect and that
   every one reads from `@windowskin`; the colon cell blinking off exactly on
   a `frames % 60 == 0` boundary and back on at `== 30`; a timer with no
   System graphic loaded never builds a sprite at all even while visible and
   running; the second timer's sprite sitting flush against the right edge;
   the battle-flag pause/hide check extended to also pin the Y drop to the
-  mid-screen battle slot once the fight starts), all six confirmed to fail
+  mid-screen battle slot once the fight starts. All six confirmed to fail
   against the pre-fix code before the fix (either erroring on a `nil`
   `@timer_sprites` array — the old code never built one — or, for the ones
   adapted from pre-existing checks, on the removed `@timer_windows`/

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -116,6 +116,13 @@ class RPG2k
         @charset = load_charset
         @windowskin = load_windowskin
         @interpreter = Game::Interpreter.new(@state)
+        # Whether the last message window shown on this map visit resolved to
+        # the top position -- what #draw_timer's own bottom-edge-avoidance
+        # reads, sticky until #open_message next changes it or this map visit
+        # ends (see #perform_teleport's identical reset). False on a fresh
+        # visit, matching EasyRPG's own Window_Message starting below the
+        # `GetY() < 20` threshold before any message has opened yet.
+        @message_window_top = false
         @started_auto = {}
         @started_common = {}
         @common = Game::CommonEvent.load(@db)
@@ -7133,6 +7140,13 @@ class RPG2k
         old_bmp = @chipset_bmp
         @chipset_bmp = load_chipset_graphic
         old_bmp.dispose if old_bmp && !old_bmp.equal?(@chipset_bmp)
+        # ... nor does the timer's sticky "message was at top" flag: real
+        # RPG_RT rebuilds its own Window_Message fresh on every genuine map
+        # entry (`Scene_Map::Start`, matching a Teleport/Transfer Player, not
+        # `Scene_Map::Continue`'s reuse when merely returning from a pushed
+        # menu/battle scene to the same map) -- see #initialize's identical
+        # reset for the very first visit.
+        @message_window_top = false
         @started_auto = {}
         @started_common = {}
         @active_event = nil
@@ -7318,6 +7332,12 @@ class RPG2k
         text_w = inner_w - text_x - (face_right ? FACE_SIZE + FACE_MARGIN : 0)
         inner_h = MSG_WIN_H - Window::BORDER * 2
         win_h = MSG_WIN_H
+        # The timer's own bottom-edge-avoidance reads this (see #draw_timer's
+        # comment) -- sticky, not reset when this message later closes,
+        # matching EasyRPG's own Window_Message#y, which InsertNewPage sets
+        # afresh every message but FinishMessageProcessing never resets.
+        @message_window_top =
+          effective_message_position(win_h, cfg) == Game::MessageConfig::POS_TOP
         win = Window.new(0, message_window_y(win_h, cfg), MSG_WIN_W, win_h)
         win.z = 300
         win.windowskin = @windowskin
@@ -7412,6 +7432,22 @@ class RPG2k
         set_choice_cursor
       end
 
+      # The display position (top / middle / bottom) a `win_h`-tall message
+      # window actually resolves to right now. When the message is not pinned
+      # (`position_fixed` off, RPG2000's default), this is the position that
+      # keeps clear of the hero (`#auto_message_position`) rather than the
+      # configured one directly -- confirmed against EasyRPG's own
+      # `Game_Message::GetRealPosition()`, which does the identical
+      # pinned-vs-dynamic split. `#open_message` also uses this (not just
+      # `#message_window_y` below) to update the sticky "was the window at
+      # the top" flag the timer's own bottom-edge-avoidance reads, since real
+      # RPG_RT's timer avoidance is downstream of this same per-page resolved
+      # position, not the raw configured preference.
+      def effective_message_position(win_h, cfg)
+        return cfg.position if cfg.position_fixed
+        auto_message_position(win_h)
+      end
+
       # Vertical position of a `win_h`-tall message window for the configured
       # display position (top / middle / bottom). When the message is not pinned
       # (`position_fixed` off, RPG2000's default), the window relocates so it does
@@ -7421,9 +7457,7 @@ class RPG2k
       # zone boundary is approximate pending a wine diff; the direction matches
       # RPG_RT.
       def message_window_y(win_h, cfg)
-        pos = cfg.position
-        pos = auto_message_position(win_h) unless cfg.position_fixed
-        case pos
+        case effective_message_position(win_h, cfg)
         when Game::MessageConfig::POS_TOP    then 0
         when Game::MessageConfig::POS_MIDDLE then (SCREEN_H - win_h) / 2
         else SCREEN_H - win_h
@@ -8246,15 +8280,27 @@ class RPG2k
       # (`Sprite_Timer::Sprite_Timer`'s own `SetX`), and during battle both drop
       # to `screen_height / 3 * 2 - 20` (`Sprite_Timer::Draw`'s
       # `Game_Battle::IsBattleRunning()` branch) rather than sitting at the top
-      # -- both now matched exactly. **Still open**: outside battle, real
-      # RPG_RT also slides a timer to the bottom edge whenever the (sticky,
-      # persists-across-messages) message window is currently parked at the
-      # top of the screen, so the two never overlap
-      # (`Game_Message::GetWindow()->GetY() < 20`); this build has no
-      # persistent message-window object to read a sticky position back from
-      # (`@message` is built fresh per message and torn down when it closes),
-      # so that half stays unmodelled and the timer sits at the fixed top
-      # position outside of battle regardless of where a message last opened.
+      # -- both now matched exactly. **Now also implemented**: outside
+      # battle, real RPG_RT slides a timer to the bottom edge whenever the
+      # (sticky, persists-across-messages) message window is currently
+      # parked at the top of the screen, so the two never overlap
+      # (`Game_Message::GetWindow()->GetY() < 20`) -- confirmed against
+      # EasyRPG's own `Sprite_Timer::Draw`/`Game_Message::GetRealPosition`/
+      # `Window_Message::InsertNewPage` (`src/sprite_timer.cpp`,
+      # `src/game_message.cpp`, `src/window_message.cpp`): the check reads
+      # the message window's own last *resolved* Y (not the raw Message
+      # Options preference), which stays wherever it was last set even after
+      # that message closes, since nothing ever resets it on close, and
+      # which is itself downstream of RPG2000's dynamic avoid-the-hero
+      # repositioning when the position is not pinned. `#open_message`
+      # tracks the same "was it at the top" outcome in `@message_window_top`
+      # (see its own comment) since this build has no long-lived
+      # `Window_Message`-equivalent object to read a literal Y back from;
+      # `#perform_teleport`/`#initialize` reset it on every fresh map visit,
+      # matching a genuine `Scene_Map::Start` rebuilding EasyRPG's own
+      # `Window_Message` from scratch (initial Y below the threshold),
+      # rather than the `Scene_Map::Continue` reuse a mere return from a
+      # pushed menu/battle scene gets.
       def draw_timer
         battle = !@battle_ui.nil?
         @timer_sprites ||= [nil, nil]
@@ -8270,7 +8316,13 @@ class RPG2k
         end
         spr ||= (@timer_sprites[id] = build_timer_sprite)
         spr.x = id == 0 ? 4 : SCREEN_W - TIMER_INNER_W - 4
-        spr.y = battle ? (SCREEN_H * 2 / 3 - 20) : 4
+        spr.y = if battle
+                  SCREEN_H * 2 / 3 - 20
+                elsif @message_window_top
+                  SCREEN_H - 20
+                else
+                  4
+                end
         spr.visible = true
         draw_timer_digits(spr.bitmap, timer)
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7202,6 +7202,60 @@ check "RPG2003's second timer draws in its own sprite, at the screen's right edg
      'sits flush against the right edge, the way RPG_RT parks it'
 end
 
+check 'the timer drops to the bottom edge once a message resolves to the ' \
+      'top, and it stays there after the message closes' do
+  scene = new_scene({})
+  scene.instance_variable_set(:@windowskin, RGSS::Bitmap.new('System/skin'))
+  st = scene.instance_variable_get(:@state)
+  st.timer(0).set(30)
+  st.timer(0).start(true)
+  scene.update
+  spr = scene.instance_variable_get(:@timer_sprites)[0]
+  eq 4, spr.y, 'nothing has opened a message yet -- normal top position'
+  # Hero low on screen -> the (unpinned, RPG2000's default) message resolves
+  # to the top, matching #message_window_y's own already-tested logic.
+  st.y = 28
+  scene.send(:open_message, ['Hi'], false)
+  ok scene.instance_variable_get(:@message_window_top),
+     'the sticky flag is set the instant the message opens, not when it closes'
+  scene.update
+  eq RPG2k::Scene::Map::SCREEN_H - 20, spr.y,
+     'the timer slides down to keep clear of the top-parked message'
+  # Closing the message does not undo it -- EasyRPG's own Window_Message#y
+  # is never reset on FinishMessageProcessing either.
+  scene.send(:close_message, animate: false)
+  scene.update
+  eq RPG2k::Scene::Map::SCREEN_H - 20, spr.y,
+     'still at the bottom edge after the message that caused it has closed'
+end
+
+check 'the timer stays at the top when the last message resolved elsewhere, ' \
+      'and a fresh map visit resets the sticky flag' do
+  scene = new_scene({})
+  scene.instance_variable_set(:@windowskin, RGSS::Bitmap.new('System/skin'))
+  st = scene.instance_variable_get(:@state)
+  st.timer(0).set(30)
+  st.timer(0).start(true)
+  # Hero high on screen -> the message resolves to the bottom, not the top.
+  st.y = 0
+  scene.send(:open_message, ['Hi'], false)
+  ok !scene.instance_variable_get(:@message_window_top),
+     'a bottom-resolved message never sets the sticky flag'
+  scene.update
+  spr = scene.instance_variable_get(:@timer_sprites)[0]
+  eq 4, spr.y, 'the timer stays at its normal top position'
+  scene.send(:close_message, animate: false)
+  # Force the sticky flag on directly (as a top-resolved message would), then
+  # confirm a fresh map visit clears it -- matching a genuine RPG_RT
+  # `Scene_Map::Start` rebuilding `Window_Message` from scratch, unlike
+  # `Scene_Map::Continue`'s reuse when merely returning from a pushed scene.
+  scene.instance_variable_set(:@message_window_top, true)
+  scene.send(:perform_teleport, [1, 0, 0, 0])
+  scene.update
+  eq 4, scene.instance_variable_get(:@timer_sprites)[0].y,
+     'a Teleport to a fresh map resets the sticky flag back to the normal top position'
+end
+
 check 'a timer without the battle flag pauses and hides for the fight, and drops to the mid-screen battle position' do
   scene = new_scene({})
   scene.instance_variable_set(:@windowskin, RGSS::Bitmap.new('System/skin'))


### PR DESCRIPTION
## Summary

- Implements a real gap `docs/TODO.md`'s "Screen effects" bullet had explicitly flagged as open: outside of battle, real RPG_RT slides the on-screen timer sprite down to the bottom edge whenever the message window is currently parked at the top of the screen, so the two never overlap.
- Confirmed against EasyRPG Player's source, fetched verbatim (`Sprite_Timer::Draw`, `Game_Message::GetRealPosition`, `Window_Message::InsertNewPage`): the check is against the message window's **last resolved** Y, not the raw Message Options preference — itself downstream of RPG2000's dynamic avoid-the-hero repositioning when the position isn't pinned (`GetRealPosition()` reads the hero's live screen Y exactly the way this engine's own `#auto_message_position` already did). That Y is **never reset when the message later closes** (`FinishMessageProcessing` only starts a close animation), only rebuilt fresh — implicitly starting "not top" — on a genuine new `Scene_Map::Start` (a real map entry via Teleport/Transfer Player), not the `Scene_Map::Continue` reuse a mere return from a pushed menu/battle scene gets.
- This engine has no literal persistent `Window_Message` object to read a Y back from (`@message` is built fresh per message and torn down when it closes), so `Scene::Map` gains its own sticky `@message_window_top` flag instead, tracking the identical "did the last message resolve to the top" outcome directly:
  - `#open_message` sets it the instant a message opens (not when it closes), reading a small extracted `#effective_message_position` helper `#message_window_y` now shares too (no behavior change to that existing method).
  - `#initialize`/`#perform_teleport` reset it to `false` on every fresh map visit, mirroring EasyRPG's own rebuild-vs-reuse split.
  - `#draw_one_timer` reads it outside of battle: `SCREEN_H - 20` (220 at 320×240, matching `screen_height - 20 - menu_offset_y` with this engine's own zero menu offset) when set, the existing `4` otherwise.
- Not itself wine-verified — this session's wine harness stayed broken throughout (a separate, unrelated regression) — but the EasyRPG source read leaves little ambiguity.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (2 new checks: the timer drops to the bottom edge the instant a top-resolving message opens and stays there once it closes; a bottom-resolving message never sets the flag, and a `Teleport` after manually forcing it on confirms a fresh map visit clears it)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Visually sanity-checked with this engine's own build under Xvfb: boots and resumes into the map cleanly, no exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_