### PR TITLE
rpg2k: message auto-position uses RPG_RT's real thresholds and feet Y

### DIFF
--- a/changelog.d/rpg2k-message-window-auto-position-thresholds.fixed.md
+++ b/changelog.d/rpg2k-message-window-auto-position-thresholds.fixed.md
@@ -1,0 +1,11 @@
+- **The field message window's "avoid hiding the hero" auto-relocation now
+  uses RPG_RT's real thresholds and reference point.** Confirmed against
+  EasyRPG Player's source (`Game_Message::GetRealPosition()`): the real
+  zone boundaries are 112px and 160px (not this engine's earlier
+  `SCREEN_H / 2` = 120px approximation), measured off the hero's *feet*
+  (the tile's bottom edge), not its centre. More significantly, the
+  auto-relocation is not simply "top when low, bottom when high" regardless
+  of the configured Message Options preference the way this engine always
+  treated it -- it is a genuine three-way switch keyed on that preference
+  (Up/Center/Down), each with its own thresholds and behavior, including a
+  Middle outcome the Center preference alone can produce while unpinned.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1564,11 +1564,38 @@ The work below is roughly ordered by the critical path to a walkable game
   RPG2000 draws it (`Game::MessagePalette` locates each swatch — a 10×2 grid of
   16×16 cells from y = 48, per EasyRPG's layout), falling back to a flat colour
   only when no windowskin loaded or for an out-of-range index. When the message
-  is **not pinned** (`position_fixed` off, the RPG2000 default) the window now
-  relocates to keep clear of the hero — top when the hero sits in the lower half
-  of the screen, bottom otherwise — so talking to something at a map's bottom
-  edge shows the text up top; the exact zone boundary is approximate pending a
-  wine diff, but the direction matches RPG_RT. ✅ **The mirrored-face flag is
+  is **not pinned** (`position_fixed` off, the RPG2000 default) the window
+  relocates to keep clear of the hero.
+  ✅ **The exact zone boundary is no longer approximate.** Confirmed against
+  EasyRPG's own `Game_Message::GetRealPosition()`, fetched verbatim: the real
+  thresholds are `16 * 7` = 112px and `16 * 10` = 160px (7 and 10 map tiles
+  at RPG2000's real 16px tile size), not this build's earlier `SCREEN_H / 2`
+  = 120px guess, and they are measured off the hero's **feet** (the tile's
+  bottom edge, `Game_Character::GetScreenY()`), not its centre --
+  `#hero_screen_y` used to compute the latter (`+ TILE / 2`), the same
+  centre-vs-feet distinction this file's "Hero's screen X/Y" Picture-binding
+  bullet already flags for a different command entirely, now also fixed here
+  (`+ TILE`, matching `GetScreenY()`'s own `+ TILE_SIZE` exactly). More
+  significantly, real RPG_RT's auto-relocation is not simply "top when low,
+  bottom when high" regardless of the *configured* Message Options
+  preference the way this build's own `#auto_message_position` always did
+  -- `GetRealPosition()` keys a genuine three-way switch off that
+  preference: configured Down (RPG2000's own default) is `disp >= 160 ?
+  Top : Bottom`; configured Up is the *strict* `disp > 112 ? Top : Bottom`
+  (note the different threshold and the `>` vs `>=`); configured Center is
+  a real three-way split (`<= 112` Bottom, `>= 160` Top, otherwise the one
+  case that can actually land on Middle while unpinned). `#auto_message_
+  position` now takes the configured position and implements all three
+  branches exactly; `#effective_message_position` threads `cfg.position`
+  through instead of ignoring it for the unpinned case. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check exercising all three configured
+  branches at the exact threshold pixels, on a map exactly one screen tall
+  (240px, matching RPG2000's own 15-tile screen height) so the follow
+  camera never scrolls and `#hero_screen_y` tracks `st.y * 16 + 16`
+  directly with nothing else to interfere. Not itself wine-verified (this
+  session's wine harness stayed broken throughout), but the EasyRPG source
+  read leaves little ambiguity.
+  ✅ **The mirrored-face flag is
   now honoured too.** Change Face Graphic's param2 (`cfg.face_flipped`) was
   already read, stored on `Game::MessageConfig` and persisted through the
   save, but `Scene::Map#draw_message_face` never looked at it — the flag was

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7445,17 +7445,13 @@ class RPG2k
       # position, not the raw configured preference.
       def effective_message_position(win_h, cfg)
         return cfg.position if cfg.position_fixed
-        auto_message_position(win_h)
+        auto_message_position(cfg.position)
       end
 
       # Vertical position of a `win_h`-tall message window for the configured
       # display position (top / middle / bottom). When the message is not pinned
       # (`position_fixed` off, RPG2000's default), the window relocates so it does
-      # not cover the hero: if the hero is standing in the lower half of the
-      # screen the window jumps to the top, and vice-versa (so talking to
-      # something at the bottom edge of a map shows the text up top). The exact
-      # zone boundary is approximate pending a wine diff; the direction matches
-      # RPG_RT.
+      # not cover the hero.
       def message_window_y(win_h, cfg)
         case effective_message_position(win_h, cfg)
         when Game::MessageConfig::POS_TOP    then 0
@@ -7464,22 +7460,59 @@ class RPG2k
         end
       end
 
-      # Pick the message position that keeps clear of the hero: top when the hero
-      # is in the lower half of the screen, bottom otherwise.
-      def auto_message_position(_win_h)
-        if hero_screen_y >= SCREEN_H / 2
-          Game::MessageConfig::POS_TOP
+      # RPG2000's own "avoid hiding the hero" auto-relocation, unpinned
+      # (`position_fixed` off, the default) -- confirmed against EasyRPG's
+      # own `Game_Message::GetRealPosition()`, fetched verbatim, which keys
+      # a three-way switch off the *configured* Message Options preference
+      # (`configured`) rather than always choosing top-or-bottom regardless
+      # of it. Zone thresholds are the exact 112px / 160px (7 and 10 map
+      # tiles at RPG2000's real 16px tile size, `16 * 7` / `16 * 10` in
+      # EasyRPG's own source) rather than the earlier `SCREEN_H / 2` (120px)
+      # approximation this build used before a source read pinned the real
+      # figures down:
+      #   configured Up:     hero above 112px -> Top,    else Bottom
+      #   configured Center: hero above 160px -> Top, below 112px -> Bottom,
+      #                      else Middle
+      #   configured Down (RPG2000's own default): hero above 160px -> Top,
+      #                      else Bottom
+      def auto_message_position(configured)
+        disp = hero_screen_y
+        case configured
+        when Game::MessageConfig::POS_TOP
+          disp > 16 * 7 ? Game::MessageConfig::POS_TOP : Game::MessageConfig::POS_BOTTOM
+        when Game::MessageConfig::POS_MIDDLE
+          if disp <= 16 * 7
+            Game::MessageConfig::POS_BOTTOM
+          elsif disp >= 16 * 10
+            Game::MessageConfig::POS_TOP
+          else
+            Game::MessageConfig::POS_MIDDLE
+          end
         else
-          Game::MessageConfig::POS_BOTTOM
+          disp >= 16 * 10 ? Game::MessageConfig::POS_TOP : Game::MessageConfig::POS_BOTTOM
         end
       end
 
-      # The hero tile's centre in screen pixels, from the edge-clamped follow
-      # camera (ignoring transient pan / shake offsets).
+      # The hero's feet in screen pixels (the bottom edge of its tile), from
+      # the edge-clamped follow camera (ignoring transient pan / shake
+      # offsets) -- confirmed against EasyRPG's own `Game_Character::
+      # GetScreenY()` (`Main_Data::game_player->GetScreenY()` is what
+      # `Game_Message::GetRealPosition()` actually compares its thresholds
+      # against): `GetSpriteY() / TILE_SIZE - display_y / TILE_SIZE +
+      # TILE_SIZE` is the tile's own top edge (`GetY() * SCREEN_TILE_SIZE`,
+      # converted to pixels) plus one *full* tile, landing on the tile's
+      # bottom edge -- not a half-tile centre the way `GetScreenX()`
+      # deliberately does for its own, horizontal, centring (`x -=
+      # TILE_SIZE / 2`). The sprite's own draw origin is pinned to the
+      # bottom of its frame (`Sprite_Character`'s `SetOy(chara_height)`)
+      # for the identical reason. Previously computed the tile's centre
+      # (`+ TILE / 2`) instead, which is what the message-position
+      # thresholds above would have been comparing against if left
+      # unfixed alongside them.
       def hero_screen_y
         _px, py = player_pixel
-        cam_y = Game.camera_offset(py + TILE / 2, SCREEN_H, @map.height * TILE)
-        (py + TILE / 2) - cam_y
+        cam_y = Game.camera_offset(py + TILE, SCREEN_H, @map.height * TILE)
+        (py + TILE) - cam_y
       end
 
       # Load the FaceSet graphic named by the message config, or nil when no face

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7107,6 +7107,56 @@ check 'the message window moves away from the hero when not position-fixed' do
   eq (240 - win_h) / 2, mwy.call(cfg), 'position-fixed keeps the configured slot'
 end
 
+check 'auto-relocation uses RPG_RT\'s real 112px/160px zone thresholds and ' \
+      'the feet position, not the earlier SCREEN_H/2 approximation' do
+  # Confirmed against EasyRPG's own Game_Message::GetRealPosition() (fetched
+  # verbatim): the zone boundaries are 16*7=112 and 16*10=160 real pixels --
+  # not this build's old SCREEN_H/2=120 guess -- measured off the hero's
+  # *feet* (Game_Character::GetScreenY(), the tile's bottom edge), not its
+  # centre. A map exactly one screen tall (15 tiles * 16px = 240px) never
+  # scrolls, so #hero_screen_y tracks `st.y * 16 + 16` directly with no
+  # camera-clamp interference, letting these boundaries be hit exactly.
+  scene = new_scene({})
+  st = scene.instance_variable_get(:@state)
+  cfg = st.message_config
+  w = 6; h = 15
+  flat = Game::Map.new(1, OpenStruct.new(
+    width: w, height: h, chipset_id: 1,
+    lower_layer: Array.new(w * h, 0), upper_layer: Array.new(w * h, 0),
+    events: {}))
+  scene.instance_variable_set(:@map, flat)
+  st.map = flat
+  amp = ->(configured) { scene.send(:auto_message_position, configured) }
+
+  # Configured Down (RPG2000's own default): >=160 -> Top, else Bottom.
+  st.y = 9 # feet at 9*16+16 = 160, exactly on the threshold
+  eq Game::MessageConfig::POS_TOP, amp.call(Game::MessageConfig::POS_BOTTOM),
+     'feet exactly at 160 already counts as clearing the hero -- Top'
+  st.y = 8 # feet at 144
+  eq Game::MessageConfig::POS_BOTTOM, amp.call(Game::MessageConfig::POS_BOTTOM),
+     'one tile short of the threshold -- still Bottom'
+
+  # Configured Up: >112 (strictly) -> Top, else Bottom.
+  st.y = 7 # feet at 128
+  eq Game::MessageConfig::POS_TOP, amp.call(Game::MessageConfig::POS_TOP),
+     'feet past 112 -- Top'
+  st.y = 6 # feet at 112, exactly on the threshold -- Up's own check is `>`, not `>=`
+  eq Game::MessageConfig::POS_BOTTOM, amp.call(Game::MessageConfig::POS_TOP),
+     'feet exactly at 112 does not clear Up\'s own strict threshold -- Bottom'
+
+  # Configured Center: a real three-way split, not just top-or-bottom.
+  st.y = 6 # feet at 112
+  eq Game::MessageConfig::POS_BOTTOM, amp.call(Game::MessageConfig::POS_MIDDLE),
+     'at or below 112 -- Bottom'
+  st.y = 9 # feet at 160
+  eq Game::MessageConfig::POS_TOP, amp.call(Game::MessageConfig::POS_MIDDLE),
+     'at or above 160 -- Top'
+  st.y = 7 # feet at 128, strictly between the two thresholds
+  eq Game::MessageConfig::POS_MIDDLE, amp.call(Game::MessageConfig::POS_MIDDLE),
+     'strictly between the two thresholds -- Middle, the one outcome only ' \
+     'the Center-configured case can ever produce'
+end
+
 check 'Weather draws a particle overlay when active and hides it when clear' do
   scene = new_scene({})
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary

- Closes a gap `docs/TODO.md`'s "Message window" bullet had explicitly flagged: "the exact zone boundary is approximate pending a wine diff" for the message window's "avoid hiding the hero" auto-relocation.
- Confirmed against EasyRPG Player's source, fetched verbatim (`Game_Message::GetRealPosition()`, `Game_Character::GetScreenY()`):
  - The real zone boundaries are **112px and 160px** (`16*7`/`16*10`, RPG2000's real 16px tile size) — not this engine's earlier `SCREEN_H / 2` = 120px approximation.
  - They're measured off the hero's **feet** (the tile's bottom edge), not its centre — `#hero_screen_y` used `+ TILE / 2`, now `+ TILE`, matching `GetScreenY()`'s own `+ TILE_SIZE` exactly. (The only caller of `#hero_screen_y` was this auto-relocation logic, so this changes nothing else.)
  - More significantly: the auto-relocation is **not** simply "top when low, bottom when high" regardless of the *configured* Message Options preference, the way this engine always treated it. `GetRealPosition()` is a genuine three-way switch keyed on that preference:
    - Configured **Down** (RPG2000's own default): `disp >= 160 ? Top : Bottom`
    - Configured **Up**: the *strict* `disp > 112 ? Top : Bottom` (different threshold, and `>` not `>=`)
    - Configured **Center**: a real three-way split — `<= 112` Bottom, `>= 160` Top, otherwise the one case that can actually land on **Middle** while unpinned (something this engine's own version could never produce before, always choosing Top or Bottom only).
- `#auto_message_position` now takes the configured position and implements all three branches exactly; `#effective_message_position` threads `cfg.position` through instead of ignoring it for the unpinned case.
- Not itself wine-verified — this session's wine harness stayed broken throughout (a separate, unrelated regression) — but the EasyRPG source read leaves little ambiguity.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (1 new check exercising all three configured branches at the exact threshold pixels, on a map exactly one screen tall so the follow camera never scrolls)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Visually sanity-checked with this engine's own build under Xvfb: boots and resumes into the map cleanly, no exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_