### PR TITLE
docs: correct a stale "target-only flashes are approximations" note

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1450,8 +1450,14 @@ The work below is roughly ordered by the critical path to a walkable game
   playback for Play Movie (no decoder is linked in; the request is logged). **Show Battle Animation** (11210) now plays on the map — the
   scene composites the animation's cells from its `Battle/<name>` sheet over the
   target frame by frame and fires its screen flashes, holding the event with the
-  wait flag (per-cell zoom / tone and target-only flashes are approximations for
-  now). **Set Vehicle Location** (10850) and **Change Vehicle Graphic** (10650)
+  wait flag. **Target-only flashes are precisely implemented, not an
+  approximation** (this line's own wording used to say otherwise, now stale
+  -- see the fuller, EasyRPG-source-verified writeup a few pages down, "A
+  plain Attack now plays its own animation too"'s neighbouring bullet, which
+  covers the player/map-event/vehicle target-flash mechanism this note used
+  to undersell); **per-cell zoom/tone genuinely still is** an approximation,
+  since it needs an `RGSS::Viewport` tone this codebase's map rendering
+  path has never had either -- see ADR 0037. **Set Vehicle Location** (10850) and **Change Vehicle Graphic** (10650)
   place a boat / ship / airship and set its CharSet (persisted via
   `Game::Vehicle`), and the party can now **board and pilot** a placed vehicle on
   the map (`Game::State#boarded`; the airship flies over any tile whose terrain


### PR DESCRIPTION
## Summary

- Small documentation-accuracy fix, no behavior change. `docs/TODO.md`'s big "Event command interpreter" overview bullet described Show Battle Animation's target-only flashes (flash_scope 1) as "approximations for now" alongside per-cell zoom/tone.
- That was true when written, but this codebase's own `fire_target_flash`/`fire_map_target_flash` (`mruby-rpg2k/mrblib/scene/map.rb`) already precisely implement it for the player/map-event/vehicle cases — verified against EasyRPG's actual C++ source (`Game_Character::GetCharacter`, `BattleAnimationMap::FlashTargets`) per their own doc comments, not an approximation at all.
- Per-cell zoom/tone genuinely still is an approximation — it needs an `RGSS::Viewport` tone this codebase's map rendering path has never had, per ADR 0037 — and stays flagged as such.
- Corrected the note to reflect current reality and point at the fuller, already-existing writeup elsewhere in the file rather than duplicating a now-stale summary.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (docs-only, no behavior change)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_