### PR TITLE
rpg2k: clamp a non-looping parallax's scroll span to the map's own room

### DIFF
--- a/changelog.d/rpg2k-parallax-anchored-scroll-clamp.fixed.md
+++ b/changelog.d/rpg2k-parallax-anchored-scroll-clamp.fixed.md
@@ -1,0 +1,9 @@
+- **A non-looping parallax background wider than the map's own scroll room
+  no longer over-pans past what the map's limited camera range should ever
+  reveal.** Confirmed against EasyRPG Player's source
+  (`Game_Map::Parallax::ResetPositionX`): the image's interpolation span is
+  `min(the map's own scrollable excess, the image's own excess)`, not
+  always the image's full excess. Invisible whenever an image's excess
+  happens to be no larger than the map's own, but a real divergence once a
+  panorama image is wider, relative to its own excess, than the map it
+  sits on has room to scroll.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -189,8 +189,40 @@ The work below is roughly ordered by the critical path to a walkable game
   full-screen backdrop, panned across its excess for a larger image. Grounded
   in the real Nepheshel data (all 45 parallax maps' images resolve and every
   offset stays in range across a camera sweep) and pinned by
-  `scripts/rpg2k_render_check.rb`. The scroll *rate* mirrors EasyRPG's formulae
-  but still wants a native/wine visual diff to confirm. The **Change Parallax
+  `scripts/rpg2k_render_check.rb`.
+  ✅ **The scroll formulae are now confirmed against EasyRPG's actual source
+  directly, not left wanting a wine visual diff** (this session's own wine
+  harness stayed broken throughout, a separate, unrelated regression) --
+  two of the three pieces already matched exactly, and the third turned up
+  a real, narrow bug, now fixed. Fetched verbatim from `src/game_map.cpp`:
+  the looping axis's "half the camera rate" is not an approximation but a
+  provable identity (`Parallax::GetX()`'s `/ (TILE_SIZE * 2)` divisor and
+  `SetPositionX`'s own `% (parallax_width * TILE_SIZE * 2)` wrap share that
+  same `* 2`, which is exactly the half-speed factor once the surrounding
+  1/16-pixel fixed-point units cancel out); the autoscroll speed formula
+  (`Parallax::Update`'s `scroll_amt` closure) matches `#autoscroll_px`'s own
+  bit-shift-and-sign convention and `/32` divisor exactly, including its
+  per-frame accumulation being mathematically equivalent to this codebase's
+  closed-form `(frame * amt) / 32` (`w` in `SetPositionX`'s modulus is
+  always an exact multiple of 32, so incremental wrapping and one-shot
+  division-then-modulo agree for every frame count and sign). **The
+  non-looping (anchored) axis had a real gap**, though: EasyRPG's
+  `ResetPositionX` spans the interpolation across `min(map's own scrollable
+  excess, the image's own excess)`, not always the image's full excess the
+  way `#anchored_offset` did before this fix -- invisible whenever an
+  image's excess happens to be no larger than the map's own (every case
+  this file's existing render checks exercised), but a real divergence
+  once a panorama image is wider, relative to its own excess, than the map
+  it sits on has room to scroll: the image would report an offset past
+  what the map's own limited camera range should ever be able to reveal.
+  Fixed with the missing `[cam_max, img_px - screen_px].min` clamp, and
+  confirmed continuous (re-derived from the live camera every frame, not
+  computed once at map load) matches EasyRPG's own `ResetPositionX`, which
+  `Game_Map::Scroll`'s `ScrollRight`/`ScrollDown` call on every camera move,
+  not just at load. Covered by a new `scripts/rpg2k_render_check.rb` check
+  (a small 800px-wide map against a 2000px-wide panorama: the image pans by
+  the map's own 160px scroll room, not its own 1360px excess, and clamps
+  there rather than continuing to stretch past it). The **Change Parallax
   Background** event command (11720) swaps this panorama at runtime — the
   interpreter records a `Game::State#parallax` override (name + loop / autoscroll
   settings, per EasyRPG's `SetParallax`) and flags a one-shot rebuild the scene

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1046,13 +1046,25 @@ module Game
 
     # A non-looping axis: fixed to the screen while the image is no larger than
     # it, otherwise panned across the image's excess as the camera sweeps the
-    # map (0 at the west/north edge, -excess at the east/south edge).
+    # map (0 at the west/north edge, up to -excess at the east/south edge).
+    #
+    # The excess actually panned across is `[cam_max, img_px - screen_px].min`,
+    # not always the image's own full excess -- confirmed against EasyRPG's
+    # `Game_Map::Parallax::ResetPositionX` (`src/game_map.cpp`, fetched
+    # verbatim): `min(w, parallax_width - pan_screen_width)` where `w` is the
+    # map's own scrollable excess. Without this clamp, a panorama image wider
+    # than the map's own scroll range would report an offset past what
+    # `cam_max` worth of scrolling should ever reveal -- unreachable when the
+    # image's excess happens to be no bigger than the map's own (every case
+    # this codebase's own render checks exercised until now), but a real
+    # divergence once it is: a small map with a wide panorama image.
     def self.anchored_offset(cam_px, screen_px, map_px, img_px)
       return 0 if img_px <= screen_px
       cam_max = map_px - screen_px
       return 0 if cam_max <= 0
       cam = Game.clamp(cam_px, 0, cam_max)
-      -((img_px - screen_px) * cam / cam_max)
+      span = [cam_max, img_px - screen_px].min
+      -(span * cam / cam_max)
     end
   end
 

--- a/scripts/rpg2k_render_check.rb
+++ b/scripts/rpg2k_render_check.rb
@@ -328,6 +328,23 @@ check 'a non-looping panorama wider than the screen pans across its excess' do
   eq(-640, PX.axis_offset(false, false, 0, 0, 9999, 640, 1280, 1280))
 end
 
+check 'a non-looping panorama wider than the map\'s own excess pans by the ' \
+      'map\'s excess, not the image\'s' do
+  # Confirmed against EasyRPG's Game_Map::Parallax::ResetPositionX
+  # (src/game_map.cpp): the span panned across is min(map excess, image
+  # excess), not always the image's own full excess. A small map (800px,
+  # 160px of scroll room) with a much wider panorama (2000px, 1360px of its
+  # own excess) must stop at the map's own 160px scroll limit -- the image
+  # never fully reveals its own far edge, since there is nowhere left on the
+  # map for the camera to go looking for it.
+  eq 0,    PX.axis_offset(false, false, 0, 0, 0,   640, 800, 2000)
+  eq(-80,  PX.axis_offset(false, false, 0, 0, 80,  640, 800, 2000)) # halfway
+  eq(-160, PX.axis_offset(false, false, 0, 0, 160, 640, 800, 2000)) # map's own max
+  # Past the map's own scroll range, the camera itself clamps -- same 160,
+  # not the image's 1360px excess a missing min() would have reported.
+  eq(-160, PX.axis_offset(false, false, 0, 0, 9999, 640, 800, 2000))
+end
+
 check 'a looping panorama scrolls at half the camera rate and wraps' do
   eq 0,   PX.axis_offset(true, false, 0, 0, 0,   640, 4096, 256)
   eq(-50, PX.axis_offset(true, false, 0, 0, 100, 640, 4096, 256)) # half of 100


### PR DESCRIPTION
## Summary

- Closes a gap `docs/TODO.md`'s "Parallax background" bullet had flagged: the scroll formulae were said to "mirror EasyRPG's formulae but still want a native/wine visual diff to confirm." Confirmed directly against EasyRPG Player's source instead (`src/game_map.cpp`, fetched verbatim), since this session's wine harness stayed broken throughout.
- **Two of three pieces already matched exactly** — provable identities, not approximations:
  - The looping axis's "half the camera rate": `Game_Map::Parallax::GetX()`'s `/ (TILE_SIZE * 2)` divisor and `SetPositionX`'s own `% (parallax_width * TILE_SIZE * 2)` wrap share that same `* 2`, which is exactly the half-speed factor once the surrounding 1/16-pixel fixed-point units cancel out.
  - The autoscroll speed formula (`Parallax::Update`'s `scroll_amt` closure): matches `#autoscroll_px`'s own bit-shift-and-sign convention and `/32` divisor exactly, including its per-frame accumulation being mathematically equivalent to this codebase's closed-form `(frame * amt) / 32`.
- **The non-looping (anchored) axis had a real, narrow bug**, though: EasyRPG's `ResetPositionX` spans the interpolation across `min(the map's own scrollable excess, the image's own excess)`, not always the image's full excess the way `#anchored_offset` did before this fix. Invisible whenever an image's excess happens to be no larger than the map's own (every case this codebase's existing render checks exercised), but a real divergence once a panorama image is wider, relative to its own excess, than the map it sits on has room to scroll — the image would report an offset past what the map's own limited camera range should ever be able to reveal.
- Fixed with the missing `[cam_max, img_px - screen_px].min` clamp. Also confirmed the continuous-recompute structure (re-derived from the live camera every frame, not computed once at map load) already matches EasyRPG's own `ResetPositionX`, which `Game_Map::Scroll`'s `ScrollRight`/`ScrollDown` call on every camera move, not just at load.

## Test plan

- [x] `ruby scripts/rpg2k_render_check.rb` — all checks pass (1 new check: a small 800px-wide map against a 2000px-wide panorama pans by the map's own 160px scroll room, not its own 1360px excess, and clamps there rather than continuing to stretch past it)
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_