### PR TITLE
rpg2k: map-triggered battle animations split Head/Feet by RPG_RT's real 24px

### DIFF
--- a/changelog.d/rpg2k-battle-animation-map-target-height.fixed.md
+++ b/changelog.d/rpg2k-battle-animation-map-target-height.fixed.md
@@ -1,0 +1,8 @@
+- **A Head/Feet-positioned battle animation triggered on the map (Show
+  Battle Animation over the player, a map event, or a vehicle) now splits
+  by RPG_RT's real 12px offset, not 16px.** Confirmed against EasyRPG
+  Player's source (`BattleAnimationMap::DrawSingle`): the map-side split
+  uses a hardcoded `24`, not the CharSet frame's actual 32px height, despite
+  reading like it should be the same thing. The battle-side split (over an
+  enemy/actor sprite) already used the real battler bitmap height and was
+  unaffected.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2915,16 +2915,37 @@ The work below is roughly ordered by the critical path to a walkable game
   of the screen" fallback, which has no sprite to split — is never offset,
   so every existing caller that never learned a height (and every animation
   that never sets the field away from its schema default of 1) keeps its
-  exact old behaviour. The *direction* is confirmed by the schema's own
-  field comment; the exact split RPG_RT itself draws at is still
-  approximate pending a wine diff, the same status the Message window's own
-  relocation-zone boundary carries above. Covered by new
+  exact old behaviour.
+  ✅ **The exact split is no longer approximate.** Confirmed against
+  EasyRPG's own `CalculateOffset`/`BattleAnimationMap::DrawSingle`/
+  `BattleAnimationBattle::Draw` (`src/battle_animation.cpp`, fetched
+  verbatim): the symmetric half-height split itself was already exactly
+  right (`Position_up` → `-(height / 2)`, `Position_down` → `+(height /
+  2)`, purely vertical, no X component), and the battle-side height (the
+  real battler bitmap's own pixel height, once its graphic has loaded) was
+  already right too. **The map-side height was wrong, though**: EasyRPG
+  does not split by the CharSet frame's actual 32px height there at all --
+  `BattleAnimationMap::DrawSingle` uses a *hardcoded* `const int
+  character_height = 24;`, a magic number local to that one function, with
+  no relationship to `Game::CharSet::HEIGHT` or any other sprite dimension
+  despite reading like it should be the same thing. This engine's own
+  `#start_map_animation` handed `#animation_position_offset` the 32px
+  CharSet frame height directly, splitting Head/Feet by 16px each way
+  instead of RPG_RT's real 12px. Fixed with a new `ANIM_MAP_TARGET_HEIGHT
+  = 24` constant, used only for the map-triggered path (the battle path's
+  own height already matched and is untouched). **Not ported:** EasyRPG's
+  own async-texture-loading fallback (an animation drawn before its
+  battler's own bitmap has finished loading falls back to half the
+  *animation's own* cell size instead, `GetAnimationCellHeight() / 2`) --
+  this codebase's graphic loading is synchronous, so that branch is never
+  reachable here and porting it would be dead code. Covered by
   `scripts/rpg2k_scene_check.rb` checks (the pure offset math for head /
-  center / feet and a missing height; a battle animation's draw position
-  shifting by half the enemy sprite's height for head/feet and staying put
-  for center; a map-triggered animation carrying the player's
-  `Game::CharSet::HEIGHT`), confirmed to fail against the pre-fix code
-  before the fix.
+  center / feet and a missing height, now also asserting the real
+  `ANIM_MAP_TARGET_HEIGHT` value's own halves; a battle animation's draw
+  position shifting by half the enemy sprite's height for head/feet and
+  staying put for center; a map-triggered animation carrying RPG_RT's own
+  24px map-target height, not the CharSet frame's 32px), confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **Which fields the games set that the runtime never reads** —
   `ruby scripts/rpg2k_field_audit.rb`. A survey, not a check (it asserts nothing
   and always exits 0): for every scalar database field it counts the rows of the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6500,6 +6500,17 @@ class RPG2k
       ANIM_CELL = 96
       ANIM_SHEET_COLS = 5
 
+      # The sprite height #animation_position_offset's Head/Feet split uses
+      # for a *map*-drawn target (the player, a map event, a vehicle) --
+      # confirmed against EasyRPG's own `BattleAnimationMap::DrawSingle`
+      # (`src/battle_animation.cpp`, fetched verbatim): `const int
+      # character_height = 24;`, a hardcoded constant local to that one
+      # function, unrelated to `Game::CharSet::HEIGHT` (32, the actual
+      # CharSet frame's pixel height) despite reading like it should be the
+      # same thing. Previously used `Game::CharSet::HEIGHT` directly, which
+      # split Head/Feet by 16px each way instead of RPG_RT's real 12px.
+      ANIM_MAP_TARGET_HEIGHT = 24
+
       # Drive a Show Battle Animation (11210) wait for interpreter `it` -- the
       # foreground event, or a parallel process that issued one of its own (both
       # share this one on-screen animation slot, matching yado.tk: only one
@@ -6775,12 +6786,12 @@ class RPG2k
         return nil unless req
         return start_battle_page_animation(req) if req[:battle]
         tx, ty = animation_target_pixel(req[:target])
-        # Every map target -- the player, a map event, a vehicle -- draws from
-        # a CharSet frame of this one fixed size (see #draw_vehicles, which
-        # sizes a vehicle sprite off the same constant), so the sprite bounding
-        # box #animation_position_offset needs is known without asking what
-        # kind of character this actually is.
-        build_animation(req[:animation], tx, ty, target_height: Game::CharSet::HEIGHT,
+        # Every map target -- the player, a map event, a vehicle -- gets the
+        # same fixed height for #animation_position_offset's Head/Feet split
+        # (see ANIM_MAP_TARGET_HEIGHT's own comment for why this is 24, not
+        # the CharSet frame's actual 32px), so the sprite bounding box is
+        # known without asking what kind of character this actually is.
+        build_animation(req[:animation], tx, ty, target_height: ANIM_MAP_TARGET_HEIGHT,
                          flash_target: map_animation_flash_target(req[:target]))
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -6182,7 +6182,12 @@ end
 # #draw_vehicles sizing a vehicle sprite off the same constant -- so
 # #start_map_animation can hand #animation_position_offset a real height
 # unconditionally, unlike the battle path's ally-side "no sprite" fallback.
-check "a map-triggered Show Battle Animation carries the target's CharSet height" do
+# That height is ANIM_MAP_TARGET_HEIGHT (24), not Game::CharSet::HEIGHT
+# (32) -- confirmed against EasyRPG's own BattleAnimationMap::DrawSingle
+# (`const int character_height = 24;`, src/battle_animation.cpp), a
+# hardcoded constant unrelated to the actual CharSet frame's pixel height
+# despite reading like it should be the same thing.
+check "a map-triggered Show Battle Animation carries RPG_RT's own 24px map-target height" do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = [
@@ -6197,8 +6202,9 @@ check "a map-triggered Show Battle Animation carries the target's CharSet height
     break if anim
   end
   ok anim, 'the animation actually started'
-  eq Game::CharSet::HEIGHT, anim[:target_height],
-     "the player's own CharSet sprite height, not the battle-only nil fallback"
+  eq RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT, anim[:target_height],
+     "RPG_RT's own hardcoded 24px map-target height, not the CharSet frame's 32px " \
+     'or the battle-only nil fallback'
 end
 
 # A map-triggered Show Battle Animation's flash_scope-1 timing used to be
@@ -9481,6 +9487,13 @@ check 'animation_position_offset splits head/center/feet around the target sprit
      'feet sink half the sprite height below centre'
   eq 0, scene.send(:animation_position_offset, { position: 0, target_height: nil }),
      'no known height (the ally-side screen-centre fallback) is never offset'
+  # The real map-target value every #start_map_animation caller actually
+  # hands this (ANIM_MAP_TARGET_HEIGHT, 24 -- RPG_RT's own hardcoded
+  # constant, not the 32px CharSet frame), split at its own halves.
+  eq(-12, scene.send(:animation_position_offset,
+                     { position: 0, target_height: RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT }))
+  eq 12, scene.send(:animation_position_offset,
+                    { position: 2, target_height: RPG2k::Scene::Map::ANIM_MAP_TARGET_HEIGHT })
 end
 
 check 'a head/feet Show Battle Animation position offsets where it draws over the enemy sprite' do


### PR DESCRIPTION
## Summary

- Closes a gap `docs/TODO.md` had explicitly flagged: a Head/Feet-positioned battle animation's exact split was "still approximate pending a wine diff, the same status the Message window's own relocation-zone boundary carries" — the same class of gap PR #731 already closed for message positioning. Confirmed directly against EasyRPG Player's source (`src/battle_animation.cpp`, fetched verbatim), since this session's wine harness stayed broken throughout.
- **Most of the formula already matched exactly:**
  - The symmetric half-height split itself (`Position_up` → `-(height / 2)`, `Position_down` → `+(height / 2)`, purely vertical, no X component).
  - The battle-side height (the real battler bitmap's own pixel height, once its graphic has loaded).
- **The map-side height was wrong, though.** EasyRPG's `BattleAnimationMap::DrawSingle` does not split by the CharSet frame's actual 32px height for a map target (player/event/vehicle) — it uses a hardcoded `const int character_height = 24;`, a magic number local to that one function, with no relationship to the actual CharSet frame dimensions despite reading like it should be the same thing. This engine's own `#start_map_animation` handed `#animation_position_offset` the 32px CharSet frame height directly, splitting Head/Feet by 16px each way instead of RPG_RT's real 12px.
- Fixed with a new `ANIM_MAP_TARGET_HEIGHT = 24` constant, used only for the map-triggered path — the battle path's own height already matched and is untouched.
- **Not ported:** EasyRPG's own async-texture-loading fallback (an animation drawn before its battler's bitmap has finished loading falls back to half the *animation's own* cell size instead). This codebase's graphic loading is synchronous, so that branch is never reachable here and porting it would be dead code.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass (extended the existing pure-offset-math check with the real `ANIM_MAP_TARGET_HEIGHT` value's own halves, and updated the map-triggered-animation check to assert the corrected 24px height instead of the CharSet frame's 32px)
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — OK
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_render_check.rb` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_