### PR TITLE
Replace ANIM_FALLBACK_FRAMES with the real, data-driven missing-animation wait

### DIFF
--- a/changelog.d/rpg2k-missing-animation-wait.fixed.md
+++ b/changelog.d/rpg2k-missing-animation-wait.fixed.md
@@ -1,0 +1,12 @@
+- **A Show Battle Animation command naming an animation with nothing
+  drawable now waits the real, data-driven duration RPG_RT actually applies,
+  instead of a fixed guessed-at delay.** Confirmed against EasyRPG Player's
+  source (`Game_Screen::ShowBattleAnimation`, `BattleAnimation`): there is no
+  fixed fallback wait anywhere in the reference implementation. An invalid
+  animation id, or a database row with no frames at all, now waits exactly 0
+  ticks — matching `Game_Interpreter`'s own zero-wait fallthrough, with no
+  one-frame floor. A row with real frame data but an unloadable
+  `Battle/<name>` graphic sheet still waits that row's own real duration
+  (`frames.size * 2` ticks), since EasyRPG computes the frame count from the
+  database row before it ever attempts the graphic load — a missing sheet
+  changes only what (nothing) actually draws, not the timing.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6260,10 +6260,9 @@ not yet verified:
   `3` to `2`; `ANIM_FALLBACK_FRAMES`/`ANIM_FLASH_FRAMES` (10 and 8 frames
   respectively, independent constants) were left untouched by this fix —
   `ANIM_FLASH_FRAMES`'s own 8 turned out to be wrong too, see the ✅ bullet
-  directly below — and the fallback timed
-  wait (`ANIM_FALLBACK_FRAMES * ANIM_CELL_FRAMES`, used when an animation's
-  own sheet/data is missing) shortens to match automatically since it
-  multiplies through the same constant. Covered by a new
+  directly below, and `ANIM_FALLBACK_FRAMES` turned out to be fabricated
+  outright with no real-engine analog at all, see the ✅ bullet further
+  below. Covered by a new
   `scripts/rpg2k_scene_check.rb` check pinning the exact per-frame hold
   count (still frame 0 after 2 ticks, advances to frame 1 on the 3rd),
   confirmed to fail against the pre-fix code (`expected 2, got 3`) before
@@ -6301,6 +6300,31 @@ not yet verified:
   of times to land on `delta_frames` 10 and 11 (11 calls still flashing, the
   12th cleared) independent of the constant's own value, confirmed to fail
   against the pre-fix code (cleared several calls early) before the fix.
+- ✅ **`ANIM_FALLBACK_FRAMES` (the fixed 10-frame/`* ANIM_CELL_FRAMES`-tick
+  wait applied when a Show Battle Animation command names an animation with
+  no drawable frames) is gone — it had no real-engine analog at all.**
+  Checked against EasyRPG Player's actual source rather than left as the
+  guess the two bullets above already flagged it as: neither
+  `Game_Screen::ShowBattleAnimation` (`src/game_screen.cpp`) nor
+  `BattleAnimation`'s own constructor (`src/battle_animation.cpp`) apply any
+  fixed fallback duration for a missing/frameless animation. An invalid
+  animation id, or a database row whose `frames` table is empty, computes a
+  real frame count of 0 and so waits exactly 0 ticks — `Game_Interpreter`'s
+  own `wait_time == 0` case falls straight through to the next command the
+  same tick, with no one-frame floor applied anywhere. A row that does have
+  real frame data but whose `Battle/<name>` graphic sheet fails to load
+  still waits that row's own genuine duration (`frames.size *
+  ANIM_CELL_FRAMES`), since EasyRPG computes the frame count from the
+  database row before it ever attempts the graphic load — a missing sheet
+  changes only what (nothing) actually draws, not the timing. Fixed by
+  removing `ANIM_FALLBACK_FRAMES` and replacing `Scene::Map
+  #begin_map_animation`'s fixed-wait else-branch with
+  `#missing_animation_wait(id)`, which looks the animation row up directly
+  and returns `0` or the row's real `frames.size * ANIM_CELL_FRAMES`.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks: an invalid
+  animation id waits 0 frames, and a valid row with real frame data waits
+  the row's own real duration regardless of whether its graphic sheet
+  exists.
 - ✅ **A second Show Battle Animation (11210) now forcibly cuts the first
   one's sprite off, instead of the second request quietly waiting its turn
   for the shared slot to free up** — the "only one on screen at a time"

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6484,7 +6484,6 @@ class RPG2k
       # 1/30s per frame, matching the "1 frame = 1/30s" fact this codebase already
       # otherwise assumed correctly.
       ANIM_CELL_FRAMES = 2
-      ANIM_FALLBACK_FRAMES = 10
       # ANIM_FLASH_FRAMES is 11, not some other guess: EasyRPG's
       # `BattleAnimation::UpdateFlashGeneric` (src/battle_animation.cpp) keeps a
       # fired timing's own colour/power alive for `delta_frames = GetFrame() -
@@ -6607,8 +6606,30 @@ class RPG2k
         if @map_animation
           fire_animation_flashes(@map_animation) # frame 0 flashes
         else
-          @anim_wait = ANIM_FALLBACK_FRAMES * ANIM_CELL_FRAMES
+          @anim_wait = missing_animation_wait(req[:animation])
         end
+      end
+
+      # The wait a Show Battle Animation command with nothing drawable still
+      # applies -- confirmed against EasyRPG's own `Game_Screen::
+      # ShowBattleAnimation`/`BattleAnimation` (`src/game_screen.cpp`/
+      # `src/battle_animation.cpp`, fetched verbatim): there is no fixed
+      # fallback duration anywhere in the reference implementation (the
+      # `ANIM_FALLBACK_FRAMES` constant this replaced was an unverified
+      # guess, never checked against source the way `ANIM_CELL_FRAMES` and
+      # `ANIM_FLASH_FRAMES` already were). An invalid animation id, or a
+      # database row with no frames at all, waits exactly 0 --
+      # `Game_Interpreter`'s own `wait_time == 0` falls straight through to
+      # the next command the same tick, no one-frame floor. A row with real
+      # frame data but an unloadable `Battle/<name>` sheet still waits the
+      # row's own real duration (`frames.size * ANIM_CELL_FRAMES`) --
+      # EasyRPG computes the frame count from the database row before it
+      # even attempts the graphic load, so a missing file changes nothing
+      # about the timing, only what (nothing) actually draws.
+      def missing_animation_wait(id)
+        anim = animation_row(id)
+        return 0 unless anim
+        table_entries(anim.frames).size * ANIM_CELL_FRAMES
       end
 
       # Advance the drawable animation one frame per ANIM_CELL_FRAMES, firing that

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -370,7 +370,7 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
         pages: nil) },
     # A drawable battle animation (id 8): four frames, with a screen flash timing
     # on frame 1. (Id 7 is intentionally absent so that test exercises the
-    # timed-wait fallback.)
+    # 0-frame invalid-id wait, see #missing_animation_wait.)
     battle_anime: { 8 => OpenStruct.new(
       animation_name: 'Anim', position: 1,
       frames: {
@@ -395,6 +395,17 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
       },
       timings: { 1 => OpenStruct.new(frame: 1, flash_scope: 1, flash_red: 31,
                                      flash_green: 0, flash_blue: 0, flash_power: 20) }
+    ),
+    # A third animation (id 10): real frame data (12 frames, a long real
+    # duration at 2 ticks/frame) under its own animation_name so a test can
+    # poison just its own @animation_cache entry (simulating an unloadable
+    # Battle/<name> sheet) without affecting id 8/9's shared 'Anim' cache
+    # entry. Exercises #missing_animation_wait's "real frame data, sheet
+    # failed to load" branch -- a real duration, not the invalid-id 0-wait.
+    10 => OpenStruct.new(
+      animation_name: 'GhostAnim', position: 1,
+      frames: (1..12).each_with_object({}) { |n, h| h[n] = OpenStruct.new(cells: {}) },
+      timings: {}
     ) },
     # Every tile of the synthetic map is chip 0, which the fake chipset tags as
     # terrain 42 — so this one row decides whether walking hurts, and (for the
@@ -5992,16 +6003,43 @@ end
 check 'Show Battle Animation with the wait flag holds the event then resumes' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
+  # animation 10 has real frame data (a real, non-zero #missing_animation_wait
+  # duration) but its own 'GhostAnim' cache entry is poisoned below to
+  # simulate an unloadable Battle/<name> sheet, so this exercises the
+  # timed-wait fallback path without depending on animation id 7's own
+  # (now instant, 0-frame) invalid-id wait.
   auto.event_commands = [
-    ECmd.new(ic::SHOW_BATTLE_ANIM, [7, 10001, 1], indent: 0), # animation, player, wait
+    ECmd.new(ic::SHOW_BATTLE_ANIM, [10, 10001, 1], indent: 0), # animation, player, wait
     ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
   ]
   scene = new_scene({ 1 => event(2, 2, auto) })
+  scene.instance_variable_get(:@animation_cache)['GhostAnim'] = nil
   st = scene.instance_variable_get(:@state)
   3.times { scene.update }
   ok !st.switches[5], 'the event is held while the animation plays'
   60.times { scene.update } # outlast the fallback animation length
   ok st.switches[5], 'the event resumes once the animation finishes'
+end
+
+# #missing_animation_wait's own two branches, pinned directly (see its own
+# doc comment in mruby-rpg2k/mrblib/scene/map.rb): an invalid/unknown
+# animation id waits 0 real frames -- no one-frame floor, matching
+# EasyRPG's Game_Interpreter wait_time == 0 fallthrough -- while a valid row
+# with real frame data waits that row's own real duration regardless of
+# whether its graphic sheet loads (the sheet is never consulted here at
+# all).
+check "#missing_animation_wait waits 0 for an invalid/unknown animation id" do
+  scene = new_scene({})
+  eq 0, scene.send(:missing_animation_wait, 7), 'animation 7 is absent from the fake db'
+  eq 0, scene.send(:missing_animation_wait, nil), 'a nil animation id is also invalid'
+end
+
+check "#missing_animation_wait waits the row's own real duration for a valid animation, sheet aside" do
+  scene = new_scene({})
+  eq 8, scene.send(:missing_animation_wait, 8),
+     'animation 8 has 4 real frames * ANIM_CELL_FRAMES (2) = 8, whether or not its sheet ever loads'
+  eq 24, scene.send(:missing_animation_wait, 10),
+     'animation 10 has 12 real frames * ANIM_CELL_FRAMES (2) = 24'
 end
 
 check 'Show Battle Animation plays: an animation sprite shows and a flash fires' do
@@ -6374,12 +6412,14 @@ end
 # built or drawn, and the "wait until it finishes" flag did nothing.
 check "a Common Event Parallel Process's Show Battle Animation (wait) actually plays and blocks it" do
   ic = Game::Interpreter::Cmd
-  # animation 7 has no drawable data in the fake db (see the fallback-wait
-  # check above), so this exercises the timed-wait fallback path.
+  # animation 10 has real frame data but its own 'GhostAnim' cache entry is
+  # poisoned below to simulate an unloadable sheet, so this exercises the
+  # timed-wait fallback path (see the fallback-wait check above).
   ce = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
-                      event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [7, 10001, 1], indent: 0),
+                      event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [10, 10001, 1], indent: 0),
                               ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
   scene = new_scene({}, common: { 1 => ce })
+  scene.instance_variable_get(:@animation_cache)['GhostAnim'] = nil
   st = scene.instance_variable_get(:@state)
   3.times { scene.update }
   ok !st.switches[5],
@@ -6423,12 +6463,12 @@ end
 # hands mid-flight.
 check 'a second Show Battle Animation forcibly cuts off a still-playing first one' do
   ic = Game::Interpreter::Cmd
-  # CE1's animation 7 has no drawable data in the fake db (see the fallback-
-  # wait checks above), so it parks on the ~20-frame timed-wait fallback --
-  # long enough that CE2's own animation can cut it off well before it would
-  # ever finish naturally.
+  # CE1's animation 10 has real frame data but its own 'GhostAnim' cache
+  # entry is poisoned below to simulate an unloadable sheet, so it parks on
+  # its own real (24-tick) timed-wait fallback -- long enough that CE2's own
+  # animation can cut it off well before it would ever finish naturally.
   ce1 = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
-                       event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [7, 10001, 1], indent: 0),
+                       event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [10, 10001, 1], indent: 0),
                                ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
   # CE2 waits a moment first (so CE1's animation is already in flight), then
   # fires its own -- animation 8, the fake db's drawable one.
@@ -6437,11 +6477,12 @@ check 'a second Show Battle Animation forcibly cuts off a still-playing first on
                                ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 1], indent: 0),
                                ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)])
   scene = new_scene({}, common: { 1 => ce1, 2 => ce2 })
+  scene.instance_variable_get(:@animation_cache)['GhostAnim'] = nil
   st = scene.instance_variable_get(:@state)
   3.times { scene.update }
   ok !st.switches[5], 'CE1 is still parked on its own long fallback wait'
   ok scene.instance_variable_get(:@anim_wait), "CE1 has claimed the shared slot (fallback path)"
-  # CE2's own Wait[1] (~6 frames) elapses well before CE1's ~20-frame fallback
+  # CE2's own Wait[1] (~6 frames) elapses well before CE1's ~24-frame fallback
   # would ever finish naturally, so bound the search to comfortably less than
   # that: if the slot is still showing CE1's fallback wait by frame 15, CE2
   # never cut it off at all -- it is still queued behind CE1, the pre-fix bug.
@@ -6451,16 +6492,16 @@ check 'a second Show Battle Animation forcibly cuts off a still-playing first on
   end
   ok scene.instance_variable_get(:@map_animation),
      "the shared slot now shows CE2's own (drawable) animation instead of CE1's fallback wait, " \
-     "well before CE1's own ~20-frame duration could have finished it naturally"
+     "well before CE1's own ~24-frame duration could have finished it naturally"
   ok !st.switches[6], 'CE2 has not resumed yet -- its own animation only just started'
   # CE1 was resumed the instant it was cut off (this same pass), but its own
   # trailing Control Switches command only runs on the *next* step_parallel
   # call for it (only a :wait wait-kind gets the same-frame "spend this
   # frame's own budget immediately" treatment) -- give it one more frame to
-  # actually reach it, well short of the fallback's own ~20-frame duration.
+  # actually reach it, well short of the fallback's own ~24-frame duration.
   scene.update
   ok st.switches[5],
-     "CE1 resumed the instant its animation was cut off, well short of the fallback's own ~20-frame duration"
+     "CE1 resumed the instant its animation was cut off, well short of the fallback's own ~24-frame duration"
   60.times { scene.update }
   ok st.switches[6], 'CE2 resumes once its own animation finishes'
 end
@@ -6480,12 +6521,13 @@ end
 # instead of being cut off.
 check 'a fire-and-forget Show Battle Animation also forcibly cuts off a still-playing first one' do
   ic = Game::Interpreter::Cmd
-  # CE1's animation 7 has no drawable data in the fake db, so it parks on the
-  # ~20-frame timed-wait fallback -- long enough that CE2's own fire-and-
-  # forget animation can cut it off well before it would ever finish
-  # naturally.
+  # CE1's animation 10 has real frame data but its own 'GhostAnim' cache
+  # entry is poisoned below to simulate an unloadable sheet, so it parks on
+  # its own real (24-tick) timed-wait fallback -- long enough that CE2's own
+  # fire-and-forget animation can cut it off well before it would ever
+  # finish naturally.
   ce1 = OpenStruct.new(start_term: 4, need_flag: false, switch_id: nil,
-                       event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [7, 10001, 1], indent: 0),
+                       event: [ECmd.new(ic::SHOW_BATTLE_ANIM, [10, 10001, 1], indent: 0),
                                ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)])
   # CE2 waits a moment first (so CE1's animation is already in flight), then
   # fires its own -- animation 8, the fake db's drawable one -- with the
@@ -6496,11 +6538,12 @@ check 'a fire-and-forget Show Battle Animation also forcibly cuts off a still-pl
                                ECmd.new(ic::SHOW_BATTLE_ANIM, [8, 10001, 0], indent: 0),
                                ECmd.new(ic::CONTROL_SWITCHES, [0, 6, 6, 0], indent: 0)])
   scene = new_scene({}, common: { 1 => ce1, 2 => ce2 })
+  scene.instance_variable_get(:@animation_cache)['GhostAnim'] = nil
   st = scene.instance_variable_get(:@state)
   3.times { scene.update }
   ok !st.switches[5], 'CE1 is still parked on its own long fallback wait'
   ok scene.instance_variable_get(:@anim_wait), 'CE1 has claimed the shared slot (fallback path)'
-  # CE2's own Wait[1] (~6 frames) elapses well before CE1's ~20-frame fallback
+  # CE2's own Wait[1] (~6 frames) elapses well before CE1's ~24-frame fallback
   # would ever finish naturally, so bound the search to comfortably less than
   # that: if the slot never shows CE2's own drawable animation by frame 15,
   # CE2's fire-and-forget request was dropped instead of cutting CE1 off --
@@ -6513,17 +6556,17 @@ check 'a fire-and-forget Show Battle Animation also forcibly cuts off a still-pl
   end
   ok scene.instance_variable_get(:@map_animation),
      "the shared slot now shows CE2's own (drawable) animation instead of CE1's fallback wait, " \
-     "well before CE1's own ~20-frame duration could have finished it naturally"
+     "well before CE1's own ~24-frame duration could have finished it naturally"
   ok scene.instance_variable_get(:@map_animation_interp).nil?,
      "CE2's own request is fire-and-forget -- nothing is parked waiting on it"
   # CE1 was resumed the instant it was cut off (this same pass, during CE2's
   # own turn later in the same step_parallels sweep), but its own trailing
   # Control Switches command only runs on the *next* step_parallel call for
   # it -- give it one more frame to actually reach it, well short of the
-  # fallback's own ~20-frame duration (mirrors the waited-for check above).
+  # fallback's own ~24-frame duration (mirrors the waited-for check above).
   scene.update
   ok st.switches[5],
-     "CE1 resumed the instant its animation was cut off, well short of the fallback's own ~20-frame duration"
+     "CE1 resumed the instant its animation was cut off, well short of the fallback's own ~24-frame duration"
   40.times { scene.update }
   ok st.switches[6], "CE2's own command list reached its trailing Control Switches (it was never blocked by its own no-wait animation)"
 end


### PR DESCRIPTION
## Summary
- `Scene::Map`'s `ANIM_FALLBACK_FRAMES` constant (10 frames, `* ANIM_CELL_FRAMES` = a fixed 20-tick wait) applied whenever a Show Battle Animation command names an animation with nothing drawable turns out to have no real-RPG_RT analog at all — it was an unverified guess flagged by two neighboring `docs/TODO.md` bullets but never itself checked against source.
- Confirmed against EasyRPG Player's actual C++ source (`Game_Screen::ShowBattleAnimation`, `BattleAnimation`, `src/game_screen.cpp`/`src/battle_animation.cpp`): there is no fixed fallback duration anywhere in the reference implementation.
  - An invalid animation id, or a database row with an empty `frames` table, waits exactly **0** ticks — `Game_Interpreter`'s own `wait_time == 0` falls straight through to the next command the same tick, with no one-frame floor.
  - A row with real frame data but an unloadable `Battle/<name>` graphic sheet still waits that row's own real duration (`frames.size * ANIM_CELL_FRAMES`), since EasyRPG computes the frame count from the database row *before* it ever attempts the graphic load — a missing sheet changes only what (nothing) actually draws, not the timing.
- Replaced the fixed constant with `Scene::Map#missing_animation_wait(id)`, which looks the animation row up directly and returns `0` or the row's own real `frames.size * ANIM_CELL_FRAMES`.

## Testing
- `ruby -c mruby-rpg2k/mrblib/scene/map.rb` / `ruby -c scripts/rpg2k_scene_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- Added a new `battle_anime` fixture (id 10, real 12-frame data under its own cache-poisonable name) plus two direct `#missing_animation_wait` unit checks (invalid id → 0, valid row → `frames.size * 2`), and updated the existing fallback/cut-off integration checks that used to lean on animation id 7's now-changed (0-tick) wait to use the new fixture instead so they still exercise a real, controllable fallback duration.
- `ruby scripts/rpg2k_scene_check.rb` — 509 checks passed
- `ruby scripts/rpg2k_logic_check.rb` — 776 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_