### PR TITLE
docs: mark Screen Flash / Character Flash untriaged claim as confirmed

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3631,10 +3631,14 @@ Everything below is unverified against the codebase.
   during test play disabling encounters (a separate fact from this one) is
   now also implemented — see `Scene::Map#debug_through?`, which the same
   `#check_random_encounter` early-outs on.
-- **Screen Flash / Character Flash** — only one of each can be active at
+- ✅ **Screen Flash / Character Flash** — only one of each can be active at
   once (a second supersedes, doesn't stack); both are capped to 1/30s
   display while a Battle Animation plays concurrently (the animation's own
-  per-frame flash occupies the effect).
+  per-frame flash occupies the effect). **Both halves of this claim are now
+  confirmed correct and fixed** — see the fuller writeup under "Screen
+  effects (Flash / Shake / Tone / Erase Screen / Weather)" above (the
+  `#hold_animation_screen_flash`/`#hold_animation_target_flash` fix), which
+  settles this exact claim against EasyRPG Player's actual C++ source.
 - **Set Move Route / Character movement** — route commands don't apply
   until Move-All/Show-Text/Wait/event-end; only one pending route per
   character (issuing two back-to-back discards the first entirely, not


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Untriaged backlog" section carried a stale, un-checked "Screen Flash / Character Flash" bullet ("only one of each can be active at once... both are capped to 1/30s display while a Battle Animation plays concurrently") that was never marked resolved even though both halves of this exact claim were already fixed and verified against EasyRPG Player's actual C++ source earlier in the same document, under "Screen effects (Flash / Shake / Tone / Erase Screen / Weather)" (`#hold_animation_screen_flash`/`#hold_animation_target_flash`).
- Docs-only change: marks the bullet ✅ and cross-references the existing writeup instead of re-deriving it. No code changes, no changelog fragment (matches the pattern used in PRs #729/#732 for the same kind of stale-note fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_