### PR TITLE
docs: mark Battle Animation untriaged claim as confirmed

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3721,10 +3721,17 @@ Everything below is unverified against the codebase.
   `event_id_at` reads back; nothing sorts by draw order or picks the
   lowest/topmost. Covered by a new `scripts/rpg2k_scene_check.rb` check
   (two events sharing a tile, `Store Event ID` resolves to the higher one).
-- **Battle Animation** — only one can display at once (second supersedes);
-  each frame is exactly 1/30s; ✅ **targeting a Vehicle position now reads
-  that vehicle's live x/y even from a different map than the one shown** —
-  see the fuller writeup under "Full-site sweep" below.
+- ✅ **Battle Animation** — only one can display at once (second supersedes);
+  each frame is exactly 1/30s. **Both halves of this claim are now confirmed
+  correct and fixed too** — "only one at once, second supersedes" by the
+  "A second Show Battle Animation (11210) now forcibly cuts the first one's
+  sprite off" fix (and its fire-and-forget counterpart) further below, "each
+  frame is exactly 1/30s" by the `ANIM_CELL_FRAMES` fix ("The '1 frame =
+  1/30s' half of the bullet above is now correct...") also further below —
+  both settled against EasyRPG Player's actual C++ source rather than left
+  as this bullet's own unverified restatement. ✅ **targeting a Vehicle
+  position now reads that vehicle's live x/y even from a different map than
+  the one shown** — see the fuller writeup under "Full-site sweep" below.
 - **Material data** — an imported asset takes priority over a same-named RTP
   one; dropping files directly into asset folders bypasses size/transparent-
   colour-index validation.


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Untriaged backlog" section carried a stale, un-checked "Battle Animation" bullet ("only one can display at once (second supersedes); each frame is exactly 1/30s") that was never marked resolved even though both halves of this exact claim were already fixed and verified against EasyRPG Player's actual C++ source elsewhere in the same document:
  - "only one at once, second supersedes" by the "A second Show Battle Animation (11210) now forcibly cuts the first one's sprite off" fix (and its fire-and-forget counterpart).
  - "each frame is exactly 1/30s" by the `ANIM_CELL_FRAMES` fix ("The '1 frame = 1/30s' half of the bullet above is now correct...").
- Docs-only change: marks the bullet ✅ and cross-references the existing writeups instead of re-deriving them. No code changes, no changelog fragment (matches the pattern used in PRs #729/#732/#736 for the same kind of stale-note fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_