### PR TITLE
rpg2k: an uncustomized vehicle draws the database's own graphic cell index

### DIFF
--- a/changelog.d/vehicle-database-graphic-index.fixed.md
+++ b/changelog.d/vehicle-database-graphic-index.fixed.md
@@ -1,0 +1,24 @@
+- **An uncustomized boat, ship or airship now draws the database System
+  boat_index/ship_index/airship_index cell**, instead of always drawing cell 0
+  of its CharSet sheet. The System chunk stores each vehicle's on-map graphic
+  as a filename *and* a cell index within it (`boat_name`/`boat_index`,
+  `ship_name`/`ship_index`, `airship_name`/`airship_index`, System fields
+  11-16), and EasyRPG Player's actual C++ source shows both are read together
+  when a vehicle is built: `Game_Vehicle::Game_Vehicle`
+  (`src/game_vehicle.cpp`) calls `SetSpriteGraphic(ToString(lcf::Data::system.
+  boat_name), lcf::Data::system.boat_index)` (and the ship_/airship_
+  equivalents). `Scene::Map#vehicle_charset` already fell back to the
+  database's `*_name` field when a vehicle's own `charset_name` was never set
+  (by Change Vehicle Graphic), but the sibling `#vehicle_charset_index` had no
+  matching fallback for `*_index` — it read `Game::Vehicle#charset_index`
+  directly, which stays `0` forever unless Change Vehicle Graphic (or a
+  loaded save) writes it. Any game whose vehicle graphic sheet places the
+  vehicle sprite at a cell other than 0 (a common CharSet layout, since a
+  sheet holds several character frames) drew the wrong sprite for every boat,
+  ship and airship that was never given an explicit graphic. Fixed by giving
+  `#vehicle_charset_index` the same empty-`charset_name`-gated fallback to
+  `@db.system.send("#{v.type}_index")` that `#vehicle_charset` already has for
+  the name. Covered by a new `scripts/rpg2k_scene_check.rb` check (all three
+  vehicle types fall back to their database index when uncustomized; an
+  explicit Change Vehicle Graphic still keeps its own index, even index 0),
+  confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8442,6 +8442,35 @@ codebase yet):
   half (a much *faster* target) already floors at the existing `Game.clamp(…,
   0, 100)`, unverified against a specific nonzero floor since neither test
   bed's own accuracy math suggests RPG_RT keeps one there.
+- ✅ **An uncustomized boat, ship or airship now draws the database System
+  `boat_index`/`ship_index`/`airship_index` cell, instead of always drawing
+  cell 0 of its CharSet sheet.** Found via `scripts/rpg2k_field_audit.rb`: the
+  System chunk stores each vehicle's on-map graphic as a filename *and* a
+  cell index within it (`boat_name`/`boat_index`, `ship_name`/`ship_index`,
+  `airship_name`/`airship_index`, System fields 11-16), both parsed by the
+  schema. Verified against EasyRPG Player's actual C++ source:
+  `Game_Vehicle::Game_Vehicle` (`src/game_vehicle.cpp`) builds a fresh
+  vehicle with `SetSpriteGraphic(ToString(lcf::Data::system.boat_name),
+  lcf::Data::system.boat_index)` (and the `ship_`/`airship_` equivalents) —
+  name and index always come from the database together.
+  `Scene::Map#vehicle_charset` (`mruby-rpg2k/mrblib/scene/map.rb`) already
+  fell back to the database's `*_name` field when a vehicle's own
+  `charset_name` was never set (by Change Vehicle Graphic), but the sibling
+  `#vehicle_charset_index` had no matching fallback for `*_index` — it read
+  `Game::Vehicle#charset_index` directly, which stays `0` forever unless
+  Change Vehicle Graphic (or a loaded save) writes it. Any game whose
+  vehicle graphic sheet places the vehicle sprite at a cell other than 0 (a
+  common CharSet layout, since one sheet holds several character frames)
+  drew the wrong sprite for every boat, ship and airship that was never
+  given an explicit graphic. Fixed by giving `#vehicle_charset_index` the
+  same empty-`charset_name`-gated fallback to
+  `@db.system.send("#{v.type}_index")` that `#vehicle_charset` already has
+  for the name. Covered by a new `scripts/rpg2k_scene_check.rb` check ("an
+  uncustomized vehicle draws the database System boat/ship/airship_index,
+  not always cell 0" — all three vehicle types fall back to their database
+  index when uncustomized; an explicit Change Vehicle Graphic still keeps
+  its own index, even index 0), confirmed to fail against the pre-fix code
+  (`expected 4, got 0`) before the fix.
 
 ## RPG Maker with RGSS (XP / VX / VXAce)
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8512,10 +8512,26 @@ class RPG2k
       end
 
       # The CharSet cell index to go with #vehicle_charset, from the same
-      # mirror-first source.
+      # mirror-first source. Mirrors #vehicle_charset's own name fallback: an
+      # unset `v.charset_index` (never touched by Change Vehicle Graphic) must
+      # fall back to the database's System boat_index/ship_index/airship_index,
+      # not silently draw cell 0. Verified against EasyRPG Player's actual C++
+      # source: Game_Vehicle::Game_Vehicle (src/game_vehicle.cpp) seeds a fresh
+      # vehicle's sprite with `SetSpriteGraphic(ToString(lcf::Data::system.
+      # boat_name), lcf::Data::system.boat_index)` (and the ship_/airship_
+      # equivalents) -- name and index come from the same database fields
+      # together, never index-0-regardless-of-database. Gated on the same
+      # empty-charset_name test as #vehicle_charset, since RPG_RT ties both to
+      # whether Change Vehicle Graphic / Set Vehicle Location's own graphic
+      # slot has ever been written; a mirror override (Set Move Route's own
+      # "Change Graphic") already returns above and never reaches this.
       def vehicle_charset_index(v)
         mirror = @vehicle_chars[v.type]
         return mirror.graphic_index if mirror && mirror.graphic_name
+        if v.charset_name.nil? || v.charset_name.empty?
+          field = "#{v.type}_index"
+          return @db.system.send(field) if @db.system.respond_to?(field)
+        end
         v.charset_index
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11794,6 +11794,48 @@ check 'a vehicle Change Graphic overrides its sprite without persisting to Game:
      'Transfer Player drops the mirror, reverting the override'
 end
 
+# EasyRPG Player's actual C++ source: Game_Vehicle::Game_Vehicle
+# (src/game_vehicle.cpp) seeds a fresh vehicle with
+# `SetSpriteGraphic(ToString(lcf::Data::system.boat_name), lcf::Data::system.
+# boat_index)` (and the ship_/airship_ equivalents) -- the database's System
+# boat_index/ship_index/airship_index seed the on-map CharSet cell exactly
+# like their _name counterparts seed the graphic file, until Change Vehicle
+# Graphic (or Set Move Route's own override) says otherwise. A vehicle whose
+# graphic was never customized must draw that cell, not always cell 0.
+check 'an uncustomized vehicle draws the database System boat/ship/airship_index, not always cell 0' do
+  scene = new_scene({}, player: [5, 5], boat_pass: true, ship_pass: true)
+  scene.db.system.boat_index = 4
+  scene.db.system.ship_index = 7
+  scene.db.system.airship_index = 2
+  st = scene.instance_variable_get(:@state)
+
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x, boat.y = 0, 1
+  eq 4, scene.send(:vehicle_charset_index, boat),
+     "an unset boat graphic falls back to System's boat_index"
+
+  ship = st.vehicle(:ship)
+  ship.map_id = st.map_id
+  ship.x, ship.y = 0, 2
+  eq 7, scene.send(:vehicle_charset_index, ship),
+     "an unset ship graphic falls back to System's ship_index"
+
+  airship = st.vehicle(:airship)
+  airship.map_id = st.map_id
+  airship.x, airship.y = 0, 3
+  eq 2, scene.send(:vehicle_charset_index, airship),
+     "an unset airship graphic falls back to System's airship_index"
+
+  # Change Vehicle Graphic writes both charset_name and charset_index
+  # together; once the vehicle has its own graphic, the database default no
+  # longer applies -- even when the chosen index is 0.
+  boat.charset_name = 'CustomBoat'
+  boat.charset_index = 0
+  eq 0, scene.send(:vehicle_charset_index, boat),
+     'an explicit Change Vehicle Graphic keeps its own index, even index 0'
+end
+
 check 'a teleport lands the party on its tile, not mid-slide' do
   # A teleport can land while a forced route has a step in flight: the route
   # advances between events, and an auto-start page can fire on the very next


### PR DESCRIPTION
## Summary

- An uncustomized boat/ship/airship always drew CharSet cell 0 of its graphic sheet, ignoring the database's System `boat_index`/`ship_index`/`airship_index` fields.
- Verified against EasyRPG Player's actual C++ source: `Game_Vehicle::Game_Vehicle` (`src/game_vehicle.cpp`) seeds a fresh vehicle with `SetSpriteGraphic(ToString(lcf::Data::system.boat_name), lcf::Data::system.boat_index)` (and the ship_/airship_ equivalents) — name and index always come from the database together.
- This codebase's `Scene::Map#vehicle_charset` already fell back to `db.system.*_name` when a vehicle's `charset_name` was unset, but the sibling `#vehicle_charset_index` had no matching fallback and always read `Game::Vehicle#charset_index`, which defaults to `0` and is only ever written by the Change Vehicle Graphic (10650) command or a loaded save. Any game whose vehicle sprite sheet places the boat/ship/airship at a nonzero cell (a common CharSet layout) drew the wrong sprite for every vehicle never given an explicit graphic.
- `Scene::Map#vehicle_charset_index` now falls back to `@db.system.send("#{v.type}_index")` when `v.charset_name` is empty, mirroring `#vehicle_charset`'s existing name fallback.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 778 passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 512 passed (new check: all three vehicle types fall back to the database's own index; an explicit Change Vehicle Graphic keeps its own index even when that index is 0; confirmed to fail pre-fix)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 passed
- [x] `ruby scripts/rpg2k_command_soak.rb` — 3430 commands, no gaps

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_