### PR TITLE
rpg2k: Change Class now announces newly-learned skills

### DIFF
--- a/changelog.d/change-class-skill-learned.fixed.md
+++ b/changelog.d/change-class-skill-learned.fixed.md
@@ -1,0 +1,26 @@
+- **Change Class (1008, RPG2003-only) now announces each skill it newly
+  teaches, not just the level line**, closing the gap the Change Level /
+  Change EXP skill-learned fix (`changelog.d/change-level-skill-learned.fixed.md`)
+  deliberately left open. EasyRPG's `Game_Actor::ChangeClass`
+  (`src/game_actor.cpp`) calls the identical `LearnLevelSkills(1, new_level,
+  pm)` Change Level/Change EXP already use, which pushes
+  `ActorMessage::GetLearningMessage` (`src/game_message_terms.cpp`) for every
+  growth-table skill the class swap teaches, skipping one the actor already
+  knew (`Game_Actor::LearnSkill`'s own `IsSkillLearned` guard). This
+  codebase's `Game::Interpreter#do_change_class` (`mruby-rpg2k/mrblib/
+  interpreter.rb`) already pushed a single level-up line when the class swap
+  raised the level or changed the skill mode, but never named a single skill
+  the change taught. Fixed by snapshotting each target's skill list
+  immediately before `#change_class` runs (`before_skills`, the same idiom
+  `queue_level_up_messages` already uses) and appending one
+  `skill_learned_message` line per post-change skill absent from that
+  snapshot onto the same page as the level-up line. The show-message trigger
+  itself is also more precise now: it fires on an actual skill diff being
+  non-empty rather than guessing from the skill mode alone, so a
+  RESET/ADD class swap that happens to teach nothing the actor didn't
+  already know stays quiet, same as a level that didn't move. Covered by two
+  new `scripts/rpg2k_logic_check.rb` checks (a class swap whose learn table
+  teaches two skills across levels 1 and 3 names both on the level-up page; a
+  skill taught early via an explicit Change Skills stays quiet, naming only
+  the genuinely new one), both confirmed to fail against the pre-fix code
+  before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1582,14 +1582,28 @@ The work below is roughly ordered by the critical path to a walkable game
   already knew (`Game_Actor::LearnSkill`'s own `IsSkillLearned` guard).
   Fixed by snapshotting each target's skill list right before the change and
   appending one line per newly-learned growth-table skill onto its own
-  level's message page. **Change Class (1008, RPG2003-only) has the identical
-  gap** — EasyRPG's `Game_Actor::ChangeClass` calls the same
-  `LearnLevelSkills(1, new_level, pm)` — but is deliberately left unaddressed
-  here, still open. Covered by two new `scripts/rpg2k_logic_check.rb` checks
-  (a two-level Change Level crossing two learn-table thresholds announces
-  each skill on its own level's page; a skill taught early via Change Skills
-  stays quiet once the level that would have taught it is reached), the
-  first confirmed to fail against the pre-fix code before the fix.
+  level's message page. ✅ **Change Class (1008, RPG2003-only) had the
+  identical gap and is now closed too** — EasyRPG's `Game_Actor::ChangeClass`
+  calls the same `LearnLevelSkills(1, new_level, pm)`.
+  `Game::Interpreter#do_change_class` already pushed a single level-up line
+  when the class swap raised the level or changed the skill mode, but never
+  named a single skill the change taught. Fixed the same way as Change
+  Level/Change EXP: snapshot each target's skill list right before
+  `#change_class` runs and append one `skill_learned_message` line per
+  post-change skill absent from that snapshot onto the level-up page. The
+  show-message trigger itself is now more precise too — it fires on an
+  actual skill diff being non-empty rather than guessing from the skill mode
+  alone, so a RESET/ADD class swap that happens to teach nothing new stays
+  quiet, same as a level that didn't move. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (a class swap whose learn table
+  teaches two skills across levels 1 and 3 names both on the level-up page;
+  a skill taught early via an explicit Change Skills stays quiet, naming
+  only the genuinely new one), both confirmed to fail against the pre-fix
+  code before the fix. (The Change Level/Change EXP check list above is
+  unaffected: a two-level Change Level crossing two learn-table thresholds
+  still announces each skill on its own level's page; a skill taught early
+  via Change Skills still stays quiet once the level that would have taught
+  it is reached.)
 - 🚧 Message window — renders text lines and a choice cursor and expands the
   common message control codes (`\v[n]` variable, `\n[n]` actor name, `\\`,
   `\_` space). `\n[n]` names the **live** actor out of the roster rather than the

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1931,14 +1931,27 @@ module Game
       show_msg = cmd.param(6) != 0
       stat_targets(cmd).each do |a|
         before = a.level
+        before_skills = show_msg && a.respond_to?(:skills) ? a.skills.dup : []
         next unless a.change_class(class_id, level_1 ? 1 : a.level,
                                    skill_mode, param_mode)
         # Unlike Change Level (which announces every level crossed) RPG_RT shows
         # a single line here, and shows it whenever the class change taught new
-        # skills even if the level itself did not move (EasyRPG's ChangeClass).
-        next unless show_msg && a.level > 1
-        next unless a.level > before || skill_mode != Game::Actor::CLASS_SKILL_NO_CHANGE
-        @pending_messages.push([level_up_message(a, a.level)])
+        # skills even if the level itself did not move (EasyRPG's ChangeClass,
+        # which calls the identical LearnLevelSkills(1, new_level, pm) Change
+        # Level/Change EXP use -- see queue_level_up_messages's own comment).
+        # The actual skill diff (rather than a skill-mode guess) also decides
+        # whether there is anything to announce at all: a RESET/ADD class swap
+        # that happens to teach nothing the actor didn't already know stays
+        # quiet, matching a level that didn't move.
+        next unless show_msg
+        new_skills = a.respond_to?(:skills) ? a.skills - before_skills : []
+        next unless a.level > 1 && (a.level > before || !new_skills.empty?)
+        lines = [level_up_message(a, a.level)]
+        new_skills.each do |sid|
+          sk = party.db_skill(sid)
+          lines.push(skill_learned_message(a, sk)) if sk
+        end
+        @pending_messages.push(lines)
       end
       return if check_game_over
       show_next_pending_message

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3511,6 +3511,65 @@ check 'Change Class stays quiet when the level held and no skills moved' do
   eq true, st.switches[1]
 end
 
+# Same class-1 learn table as class_db (skill 21 at level 1, 22 at level 3),
+# with both skills named in the skill database -- for the Change Class
+# skill-announcement checks below, the "identical gap" to the already-fixed
+# Change Level/Change EXP skill-learned announcement (docs/TODO.md), since
+# EasyRPG's Game_Actor::ChangeClass (src/game_actor.cpp) calls the same
+# LearnLevelSkills(1, new_level, pm) Change Level/Change EXP do.
+def class_db_named_skills(actor_learns = [[10, 1]])
+  actor_curve = []
+  3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
+  job1 = []
+  3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
+  players = {
+    1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, actor_learns, 0,
+                        [1, 2, 0, -1, -1, -1, -1]),
+  }
+  jobs = {
+    1 => JobRow.new('Warrior', job1, [[21, 1], [22, 3]], [3, 0, -1, -1, -1, -1, -1]),
+  }
+  FakeActorDB.new(players, [1], {},
+                  { 21 => fake_skill(name: 'Slash'), 22 => fake_skill(name: 'Cleave') },
+                  jobs)
+end
+
+check 'Change Class announces each newly-learned skill by name, not just the level' do
+  st = Game::State.new(Game::Party.new(class_db_named_skills), 1, 0, 0)
+  it = Game::Interpreter.new(st)
+  # class 1, keep level 3, skills reset, params reset-level, show message on.
+  it.start([FakeCmd.new(IC::CHANGE_CLASS,
+                        [1, 1, 1, 0, Game::Actor::CLASS_SKILL_RESET,
+                         Game::Actor::CLASS_PARAM_RESET_LEVEL, 1])])
+  it.update
+  eq :message, it.wait_kind
+  eq ['Hero is now level 3!', 'Hero learned Slash!', 'Hero learned Cleave!'],
+     it.message_lines,
+     'both class-table skills newly learnt (levels 1 and 3) are named on the same page'
+  it.resume
+  it.update
+  ok !it.waiting?
+end
+
+check 'Change Class stays quiet about a skill the actor already knew going in' do
+  st = Game::State.new(Game::Party.new(class_db_named_skills), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  # Teach skill 21 (the class's level-1 skill) early, before the class change.
+  it0 = Game::Interpreter.new(st)
+  it0.start([FakeCmd.new(IC::CHANGE_SKILLS, [1, 1, 0, 0, 21])])
+  it0.update
+  eq [10, 21], a.skills.sort
+
+  it = Game::Interpreter.new(st)
+  it.start([FakeCmd.new(IC::CHANGE_CLASS,
+                        [1, 1, 1, 0, Game::Actor::CLASS_SKILL_RESET,
+                         Game::Actor::CLASS_PARAM_RESET_LEVEL, 1])])
+  it.update
+  eq :message, it.wait_kind
+  eq ['Hero is now level 3!', 'Hero learned Cleave!'], it.message_lines,
+     'skill 21 was already known, so only the newly-learned skill 22 is named'
+end
+
 check 'Change Battle Commands adds, removes and clears the command list' do
   st = class_state
   a = st.party.actor_by_id(1)


### PR DESCRIPTION
## Summary

- Change Class (1008, RPG2003-only) pushed a single level-up line but never named which skill(s) the class swap actually taught — the "identical gap" `docs/TODO.md` had flagged as still open right next to the already-fixed Change Level/Change EXP skill-learned announcement.
- EasyRPG's `Game_Actor::ChangeClass` (`src/game_actor.cpp`) calls the same `LearnLevelSkills(1, new_level, pm)` that Change Level/Change EXP already use to push `ActorMessage::GetLearningMessage` lines for each newly-taught skill.
- Fixed `Game::Interpreter#do_change_class` (`mruby-rpg2k/mrblib/interpreter.rb`) to snapshot the target's skill list before `#change_class` runs and append one `skill_learned_message` line per post-change skill absent from that snapshot onto the level-up page, mirroring `queue_level_up_messages`'s existing idiom.
- The show-message trigger is now based on the actual skill diff being non-empty rather than guessing from the skill mode alone, so a RESET/ADD class swap that happens to teach nothing new stays quiet, same as a level that didn't move.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 780 checks passed (2 new checks added)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 511 checks passed
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — skipped, no test-bed game dir available in this sandbox (network-restricted)
- [x] `ruby scripts/rpg2k_command_soak.rb` — skipped, no test-bed game dir available in this sandbox (network-restricted)
- [x] Confirmed the two new checks fail against the pre-fix code (temporarily reverted `interpreter.rb`, reran, saw both fail with the old single-line message; reapplied the fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6v9ShvsEaRdd2A3aw3S46)_