### PR TITLE
psp: mrbc debug-info strip + bring-up heartbeat reports real memory

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -25,6 +25,7 @@ What runs today:
 - `app/psp/main.cxx` — a pspsdk sketch (module metadata + HOME-exit callback)
   that draws a status screen and echoes the pressed keys. `main()` owns the loop
   and pumps LVGL once per iteration, mirroring the Emscripten and Wio builds.
+  Its heartbeat also reports free device RAM and LVGL pool usage (see below).
 - `app/psp/lv_conf.h` — a PSP-tuned LVGL config (RGB565, a few-MB heap, no SIMD
   asm).
 
@@ -44,10 +45,16 @@ Run `EBOOT.PBP` under an emulator such as
 `PSP/GAME/rpg2k/EBOOT.PBP` on a Memory Stick (a homebrew-enabled console).
 
 The bring-up writes two markers via `sceIoWrite` — `RPG2K_PSP_BOOT` once at
-startup (a libc-free string literal) and `RPG2K_PSP_BRINGUP frame=N` once a
-second. CI's `psp-smoke` job boots the EBOOT under PPSSPP headless and checks
-that a marker appears, so a regression that links but fails to boot is caught
-automatically. The job is **non-blocking**: PPSSPP only partially implements
+startup (a libc-free string literal) and `RPG2K_PSP_BRINGUP
+frame=N free=N maxfree=N lvgl_used=N lvgl_max=N` once a second, the last four
+fields being `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` (the
+device's actual free RAM) and `lv_mem_monitor`'s current/high-water-mark use
+of LVGL's own pool — real numbers for
+[ADR 0047](../../docs/adr/0047-psp-memory-budget.md)'s P1, captured from the
+`psp-smoke` log rather than estimated. CI's `psp-smoke` job boots the EBOOT
+under PPSSPP headless and checks that a marker appears, so a regression that
+links but fails to boot is caught automatically. The job is **non-blocking**:
+PPSSPP only partially implements
 pspsdk's libc stdio (plain `printf` is an unimplemented HLE import there), so
 emulator capture can be fragile — the required build gate is the `psp` job. To
 reproduce locally, run PPSSPP's headless binary with `--log` (needed to surface

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -4,7 +4,12 @@
 // mruby interpreter: it stands up the LVGL display (psp_display_create), scans
 // the pad (psp_input_scan), and draws a small status screen that echoes the
 // pressed keys. main() owns the loop and pumps LVGL once per iteration -- the
-// same "host owns the loop" shape the Emscripten and Wio builds use.
+// same "host owns the loop" shape the Emscripten and Wio builds use. Its
+// per-second heartbeat also reports real free-memory and LVGL-pool numbers
+// (see the RPG2K_PSP_BRINGUP marker below), which is ADR 0047's P1: this
+// bring-up EBOOT never opens mruby, but it can still measure the device's
+// actual RAM and how much of LVGL's pool the HAL alone uses, ahead of the
+// interpreter-linking slice that will need to size that pool for real.
 //
 // The mruby interpreter, the real RPG2k scene tree and Memory-Stick asset
 // loading are wired in the following slices (see app/psp/README.md and
@@ -16,6 +21,7 @@
 #include <lvgl.h>
 #include <pspiofilemgr.h>
 #include <pspkernel.h>
+#include <pspsysmem.h>
 
 #include "psp.hxx"
 
@@ -124,14 +130,29 @@ int main(void) {
   // The loop runs ~200 iterations/second (5 ms delay); emit a heartbeat line
   // roughly once a second. The CI smoke test asserts this marker appears,
   // proving the EBOOT not only boots but keeps pumping frames (see the
-  // psp-smoke job in .github/workflows/build.yml).
+  // psp-smoke job in .github/workflows/build.yml). It also carries real
+  // memory numbers -- ADR 0047's P1 -- so the memory-budget estimates there
+  // get replaced with device measurements instead of staying host-proxy
+  // guesses: sceKernelTotalFreeMemSize/sceKernelMaxFreeMemSize (pspsysmem.h)
+  // for the PSP's ~24 MB user partition, and lv_mem_monitor for LVGL's own
+  // pool (app/psp/lv_conf.h's 4 MB LV_MEM_SIZE) -- currently used and the
+  // max_used high-water mark, which is the number that actually matters for
+  // sizing that pool once the interpreter is linked.
   for (uint32_t frame = 0;; ++frame) {
     show_keys(psp_input_scan());
     lv_timer_handler();
     if (frame % 200 == 0) {
-      char buf[48];
-      const int n = std::snprintf(buf, sizeof(buf),
-                                  "RPG2K_PSP_BRINGUP frame=%u\n", frame);
+      lv_mem_monitor_t mon;
+      lv_mem_monitor(&mon);
+      char buf[128];
+      const int n = std::snprintf(
+          buf, sizeof(buf),
+          "RPG2K_PSP_BRINGUP frame=%u free=%u maxfree=%u lvgl_used=%u "
+          "lvgl_max=%u\n",
+          frame, static_cast<unsigned>(sceKernelTotalFreeMemSize()),
+          static_cast<unsigned>(sceKernelMaxFreeMemSize()),
+          static_cast<unsigned>(mon.total_size - mon.free_size),
+          static_cast<unsigned>(mon.max_used));
       if (n > 0)
         psp_write(buf, n);
     }

--- a/build_config.rb
+++ b/build_config.rb
@@ -188,6 +188,24 @@ if psp
 
     enable_debug
 
+    # enable_debug also appends ` -g` to mrbc's own compile options (default
+    # "-B%{funcname} -o-", see mruby's Command::Mrbc#initialize), which embeds
+    # line-number/local-variable debug tables in every gem's compiled mrblib
+    # bytecode -- the game's own Ruby (mruby-rpg2k, mruby-rgss, mruby-lcf, ...),
+    # not mruby's C core. Unlike the C-level -g3 kept below (native DWARF, never
+    # mapped into RAM -- ELF debug sections sit outside every PT_LOAD segment),
+    # mrb_load_irep parses these Ruby-level tables into live heap structures the
+    # moment the interpreter boots: measured at roughly 240-350 KB of live RAM
+    # for the rpg2k+lcf+rgss mrblib stack alone (docs/adr/0047-psp-memory-budget.md),
+    # against a 4 MB LVGL pool that may have to cover mruby's whole heap too. It
+    # buys nothing on a device with no interactive Ruby debugger attached to it,
+    # so strip it from mrbc the same way -O0 is stripped from cc/cxx below.
+    # (mruby's own mruby-bin-strip gem -- not part of this project's gem set --
+    # removes the same debug tables after the fact and gives byte-identical
+    # output to this, so this is equivalent to stripping post-compile.)
+    conf.mrbc.compile_options =
+      conf.mrbc.compile_options.split(' ').reject { |o| o == '-g' }.join(' ')
+
     # Allegrex ABI. -G0 disables gp-relative small-data addressing (pspsdk links
     # expect this); PSP_BUILD gates the psp.cxx / psp_input_bridge.cxx HAL in the
     # mruby-rgss gem on. Must be identical on compile and link lines so the mruby

--- a/changelog.d/psp-bringup-memory-heartbeat.added.md
+++ b/changelog.d/psp-bringup-memory-heartbeat.added.md
@@ -1,0 +1,8 @@
+- **PSP bring-up EBOOT reports real memory numbers.** The `RPG2K_PSP_BRINGUP`
+  heartbeat now carries `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize`
+  (the device's actual free RAM) and `lv_mem_monitor`'s current-use and
+  `max_used` high-water mark for LVGL's own pool, once a second, into the same
+  log CI's `psp-smoke` job already captures. This is ADR 0047's P1: real
+  device measurements for the HAL's own footprint, ahead of the
+  interpreter-linking slice that will need to size `LV_MEM_SIZE` for real. See
+  `docs/adr/0047-psp-memory-budget.md`.

--- a/changelog.d/psp-mrbc-debug-strip.added.md
+++ b/changelog.d/psp-mrbc-debug-strip.added.md
@@ -1,0 +1,12 @@
+- **PSP build strips mruby bytecode debug info.** `enable_debug` was adding
+  `-g` to `mrbc`'s compile options for the PSP cross-build, embedding
+  line-number/local-variable debug tables in every gem's compiled mrblib
+  bytecode. Unlike native C debug symbols (file size only, never mapped into
+  RAM), `mrb_load_irep` parses these into live heap structures at boot —
+  measured at roughly 240-350 KB of live RAM for the rpg2k+lcf+rgss mrblib
+  stack, against a 4 MB LVGL pool that may have to cover mruby's whole heap.
+  `build_config.rb`'s `psp` cross-build now strips it back out, the same way
+  it already strips `enable_debug`'s `-O0`. See
+  `docs/adr/0047-psp-memory-budget.md` (Finding 5), which also confirms `-O0`
+  and native `-g3` were never actually live problems for this target — an
+  earlier pass at that research got the `-O0` part wrong.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -46,8 +46,28 @@ own terms: `include/lv_conf.h`'s desktop `LV_MEM_SIZE` is 64 MB today, not
 16 MB — a sign this number was set once, early, and not revisited.) The PSP's
 current pool is 4 MB. If the shared-pool default holds, 4 MB has to cover
 every live LVGL widget *and* the entire mruby object graph for a running game
-— almost certainly too small once a real database and map are loaded, and
-nobody has decided or measured this yet.
+— almost certainly too small once a real database and map are loaded.
+
+**Host-side proxy measurement (not a device number, see the caveat below):**
+built this repo's own `3rd/mruby` submodule into a plain host `mrbc`/`mruby`,
+compiled `mruby-rpg2k` + `mruby-lcf` + `mruby-rgss`'s mrblib the way the gem
+system actually does (concatenated per gem, `mrbc -B` C-array form), and
+loaded the resulting bytecode via `mruby -b` (pre-compiled load, not
+source-compiled — see the correction below) to measure `/proc/self/status`
+RSS before/after. Defining every class and method those three gems' mrblib
+contains costs **~1.2–1.4 MB of live heap**, before any database, map, or
+bitmap is touched. `sizeof(struct RString)` is 40 B and `sizeof(mrb_value)` is
+8 B on this x86-64 host; mruby's own `mrb_static_assert(sizeof(RVALUE) <=
+sizeof(void*)*6)` means these roughly halve on the PSP's 32-bit MIPS, so the
+real device number is plausibly lower, but not by an order of magnitude —
+**this alone is already close to a third of the current 4 MB pool.**
+
+An earlier pass at this number (compiling the mrblib *from source* via
+`mruby script.rb` instead of pre-compiled bytecode) measured ~5.3 MB and is
+wrong for this target: that path pays the parser/AST/codegen compiler's own
+transient memory, which doesn't apply here — the actual PSP build compiles
+mrblib to bytecode ahead of time via `mrbc` and links it in, matching the
+`-b` measurement, not the from-source one.
 
 ### Finding 2 — whole-file asset loads, sharper than ADR 0007's version but not gone
 
@@ -122,18 +142,72 @@ nothing currently caps how many decoded bitmaps can be pinned at once.
 constrained targets; nothing has measured it for the PSP yet because the
 interpreter isn't linked.
 
+### Finding 5 — mrbc's bytecode debug info costs live RAM; native C debug info and `-O0` do not
+
+`enable_debug` (called for every build variant in `build_config.rb` — host,
+wio, psp, emscripten) does three things, and only one of them is a real,
+unaddressed cost:
+
+- **It appends `-O0` to every compiler's flags.** This sounds like exactly
+  the kind of thing that would bloat and slow down the PSP build, but
+  **every one of those four build blocks already strips it back out**
+  immediately afterward (`[conf.cc, conf.cxx].each { |t| t.flags =
+  t.flags.flatten.delete_if { |v| v == '-O0' } }`, present in the host,
+  wio, psp, and emscripten blocks alike), leaving the toolchain's normal
+  `-O3`. Checked directly against `3rd/mruby`'s `tasks/toolchains/gcc.rake`
+  and confirmed by rebuilding this project's own mruby core both ways: with
+  `-O0` surviving, `.text` is 1,612,347 B; with it stripped (this repo's
+  actual, current setting), 1,301,995 B. **The PSP build is not running
+  unoptimized code.** (An earlier pass at this ADR's research got this
+  wrong — flagged `-O0` as a live issue after testing an isolated mruby
+  config that didn't include this project's existing strip. Recorded here so
+  it isn't rediscovered.)
+- **It appends `-g3` to every compiler's flags**, and nothing strips that
+  back out. This is real native (DWARF) debug info, but confirmed via
+  `readelf` on a trivial ELF that every `.debug_*` section has virtual
+  address `0` and sits outside all `PT_LOAD` segments — never mapped into
+  the process. Same ELF format on PSP's MIPS target: **`-g3` costs
+  `EBOOT.PBP`/build-artifact file size only, never runtime RAM.** Confirmed
+  the scale on this project's actual `libmruby.a`: stripping debug symbols
+  takes it from 33.1 MB to 2.97 MB. Not nothing for the build artifact, but
+  out of scope for a *RAM* budget ADR.
+- **It appends `-g` to `mrbc`'s own compile options**
+  (`Command::Mrbc#initialize`'s default is `"-B%{funcname} -o-"`, nothing
+  else) — separately from the two points above, and *this* one is real and
+  unaddressed anywhere in the build. It embeds line-number/local-variable
+  debug tables in the compiled Ruby bytecode for every gem's mrblib (the
+  game's own Ruby, not mruby's C core). Unlike native DWARF, `mrb_load_irep`
+  parses these tables into live heap structures the moment the interpreter
+  boots: measured by loading the same rpg2k+lcf+rgss bytecode from Finding
+  1's benchmark both ways via `mruby -b`, `-g` costs **~240–350 KB of live
+  RAM** on top of a ~15% larger compiled-bytecode file (538,259 B → 621,734
+  B for the combined mrblib). `mruby-strip` (mruby's own `mruby-bin-strip`
+  gem, not currently part of this project's gem set) removes it and gives
+  byte-identical output to compiling without `-g` in the first place —
+  confirmed directly, both in file size and in loaded RSS.
+
 ## Decision
 
 Answer these questions, and capture real numbers, as part of — not after —
 the interpreter-linking slice, in this order:
 
-- **P1 — measure before sizing.** Land the interpreter slice with a
-  lightweight memory-reporting hook alongside it: periodically report
-  `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` and LVGL's own pool
-  stats (`lv_mem_monitor`), mirroring the `psp-smoke` heartbeat pattern
-  (`RPG2K_PSP_BRINGUP`) already used to prove the bring-up EBOOT is alive. Run
-  it against the RPG2k title screen and one real map before picking any pool
-  size, rather than estimating like this ADR does.
+- **P1 — measure before sizing.** Partially done: Finding 1's ~1.2–1.4 MB and
+  Finding 5's ~240–350 KB figures are real measurements, but only a host
+  x86-64 proxy (via this project's own `3rd/mruby` submodule built to a
+  plain host `mrbc`/`mruby`), not device numbers — still worth having, since
+  they replace pure guesswork, but not a substitute for what's below. Land
+  the interpreter slice with a lightweight memory-reporting hook alongside
+  it: periodically report `sceKernelTotalFreeMemSize`/
+  `sceKernelMaxFreeMemSize` and LVGL's own pool stats (`lv_mem_monitor`),
+  mirroring the `psp-smoke` heartbeat pattern (`RPG2K_PSP_BRINGUP`) already
+  used to prove the bring-up EBOOT is alive. Run it against the RPG2k title
+  screen and one real map before picking any pool size, rather than
+  estimating like this ADR does.
+- **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
+  `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
+  gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none
+  either (file size only). This is the one piece of Decision work that
+  shipped as code rather than staying a P-item — see Consequences.
 - **P2 — decide the allocator split explicitly.** Either accept the default
   (mruby shares `LV_MEM_SIZE` with LVGL, matching desktop) and size that one
   pool generously enough for both from the P1 measurements, or add a PSP
@@ -159,8 +233,12 @@ the interpreter-linking slice, in this order:
 
 ## Consequences
 
-- No runtime or build changes ship with this ADR, matching ADR 0007's
-  discipline of agreeing the numbers before the code lands.
+- Unlike ADR 0007's discipline of agreeing every number before any code
+  lands, this revision ships one small build change (P1a: stripping mrbc's
+  `-g` for the `psp` cross-build) alongside the ADR update, because it's a
+  self-contained, already-measured, zero-tradeoff fix — not a pool-sizing or
+  allocator decision that depends on P1's still-outstanding on-device
+  numbers. The rest of the Decision items remain design record only.
 - ADR 0010's "the full gem set should fit" is narrowed: it holds for gem
   *code* size, but says nothing about per-title asset memory, which Finding 2
   shows can exceed the entire 24 MB budget for an RGSSAD-packed game even

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -191,23 +191,23 @@ unaddressed cost:
 Answer these questions, and capture real numbers, as part of — not after —
 the interpreter-linking slice, in this order:
 
-- **P1 — measure before sizing.** Partially done: Finding 1's ~1.2–1.4 MB and
-  Finding 5's ~240–350 KB figures are real measurements, but only a host
-  x86-64 proxy (via this project's own `3rd/mruby` submodule built to a
-  plain host `mrbc`/`mruby`), not device numbers — still worth having, since
-  they replace pure guesswork, but not a substitute for what's below. Land
-  the interpreter slice with a lightweight memory-reporting hook alongside
-  it: periodically report `sceKernelTotalFreeMemSize`/
-  `sceKernelMaxFreeMemSize` and LVGL's own pool stats (`lv_mem_monitor`),
-  mirroring the `psp-smoke` heartbeat pattern (`RPG2K_PSP_BRINGUP`) already
-  used to prove the bring-up EBOOT is alive. Run it against the RPG2k title
-  screen and one real map before picking any pool size, rather than
-  estimating like this ADR does.
+- **P1 — measure before sizing.** Partially done. Finding 1's ~1.2–1.4 MB and
+  Finding 5's ~240–350 KB figures are a host x86-64 proxy, not device
+  numbers — still worth having over pure guesswork, but not a substitute for
+  the device side. That side is now landed too: the bring-up EBOOT's
+  `RPG2K_PSP_BRINGUP` heartbeat (`app/psp/main.cxx`) reports
+  `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` (the device's actual
+  free RAM) and `lv_mem_monitor`'s current-use and `max_used` high-water mark
+  for LVGL's pool, once a second, into the same log CI's `psp-smoke` job
+  already captures — no interpreter needed to start measuring the HAL's own
+  footprint. What's still missing: a real game database and map exercising
+  this (the bring-up never opens mruby), so the *mruby* share of the pool
+  remains unmeasured on-device until the interpreter-linking slice.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none
-  either (file size only). This is the one piece of Decision work that
-  shipped as code rather than staying a P-item — see Consequences.
+  either (file size only). This is Decision work that shipped as code rather
+  than staying a P-item — see Consequences.
 - **P2 — decide the allocator split explicitly.** Either accept the default
   (mruby shares `LV_MEM_SIZE` with LVGL, matching desktop) and size that one
   pool generously enough for both from the P1 measurements, or add a PSP
@@ -234,11 +234,13 @@ the interpreter-linking slice, in this order:
 ## Consequences
 
 - Unlike ADR 0007's discipline of agreeing every number before any code
-  lands, this revision ships one small build change (P1a: stripping mrbc's
-  `-g` for the `psp` cross-build) alongside the ADR update, because it's a
-  self-contained, already-measured, zero-tradeoff fix — not a pool-sizing or
-  allocator decision that depends on P1's still-outstanding on-device
-  numbers. The rest of the Decision items remain design record only.
+  lands, this revision ships two small, self-contained changes alongside the
+  ADR update: P1a (stripping mrbc's `-g` for the `psp` cross-build) and half
+  of P1 (the bring-up EBOOT's heartbeat now reports real device memory
+  numbers). Neither is a pool-sizing or allocator decision — those still
+  depend on numbers only the interpreter-linking slice can produce (a real
+  database and map actually loaded) — so the rest of the Decision items
+  remain design record only.
 - ADR 0010's "the full gem set should fit" is narrowed: it holds for gem
   *code* size, but says nothing about per-title asset memory, which Finding 2
   shows can exceed the entire 24 MB budget for an RGSSAD-packed game even


### PR DESCRIPTION
## Summary

Two small, independent pieces of ADR 0047's P1/P1a work:

**1. `build_config.rb`: strip `mrbc`'s `-g` for the `psp` cross-build (P1a).**
`enable_debug` was adding `-g` to `mrbc`'s compile options, embedding line-number/local-variable debug tables in every gem's compiled mrblib bytecode (the game's own Ruby — `mruby-rpg2k`, `mruby-rgss`, `mruby-lcf`, ...). Unlike native C debug symbols, `mrb_load_irep` parses those tables into live heap structures the moment the interpreter boots — measured at roughly 240–350 KB of live RAM for the rpg2k+lcf+rgss mrblib stack, against a 4 MB LVGL pool that may have to cover mruby's whole heap (ADR 0047, Finding 1). Stripped it the same way `-O0` is already stripped below it.

**2. `app/psp/main.cxx`: the bring-up EBOOT's heartbeat reports real memory numbers (P1).**
`RPG2K_PSP_BRINGUP` now also carries `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` (the device's actual free RAM) and `lv_mem_monitor`'s current-use and `max_used` high-water mark for LVGL's own pool, once a second, into the same log CI's `psp-smoke` job already captures. The bring-up EBOOT never opens mruby, but it can still measure the HAL's own footprint on real hardware/emulator instead of staying a host-proxy estimate.

`docs/adr/0047-psp-memory-budget.md` is updated for both: a new Finding 5 covering `enable_debug`'s three effects, a corrected (lower, measured) live-loading estimate in Finding 1, and P1/P1a marked with what's now actually landed vs. still open.

## Notable details

- **This corrects an earlier finding from the same research, on the record rather than silently.** A prior pass flagged `enable_debug`'s `-O0` as a live problem for the PSP build. That was wrong: every build variant in `build_config.rb` (host, wio, psp, emscripten) already strips `-O0` back out immediately after `enable_debug` adds it, leaving the toolchain's normal `-O3`. Verified by rebuilding this project's own `3rd/mruby` core both ways (`.text`: 1,612,347 B with `-O0` surviving vs 1,301,995 B with it stripped, i.e. this repo's actual current setting). Finding 5 documents this so it isn't rediscovered.
- Native C debug info (`-g3`, also from `enable_debug`, also untouched by this change) was checked too: confirmed via `readelf` on a trivial ELF that `.debug_*` sections have virtual address `0` and sit outside every `PT_LOAD` segment — never mapped into RAM on any ELF target, PSP's MIPS included. Real cost, but file-size-only, out of scope for a RAM budget.
- Finding 1's live-loading estimate corrected from ~5.3 MB to ~1.2–1.4 MB: the earlier number measured compiling mrblib *from source* at runtime, paying the parser/AST/codegen compiler's own transient memory — a cost that doesn't apply to the real PSP build, which compiles mrblib to bytecode ahead of time via `mrbc` and links it in.
- `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` confirmed against the real pspsdk header (`src/user/pspsysmem.h`, both `SceSize (*)(void)`) before writing the include, since this environment has no `psp-gcc` to compile-check against.
- `lv_mem_monitor`/`lv_mem_monitor_t` checked against the vendored `3rd/lvgl` source: unconditionally compiled for `LV_USE_STDLIB_MALLOC == LV_STDLIB_BUILTIN` (already PSP's setting), and `max_used` is a real running high-water mark updated on every alloc/realloc, not a static field.
- Buffer sizing and format-string output verified against the worst case (all-9s 32-bit values, 111 bytes into a 128-byte buffer).
- The `conf.mrbc.compile_options` strip logic was run against a live host mruby build to confirm it produces the expected result before writing it into `build_config.rb`.

## Test plan

- [x] `ruby -c build_config.rb` — syntax check
- [x] Verified `conf.mrbc.compile_options` stripping logic against a live host mruby build
- [x] Rebuilt `3rd/mruby` core with/without `-O0` stripped and compared `.text` sizes to confirm the `-O0` retraction
- [x] Confirmed `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` signatures against the real pspsdk header source
- [x] Confirmed `lv_mem_monitor`/`max_used` semantics against the vendored `3rd/lvgl` source
- [x] `clang-format` (v18 locally; CI pins v21) reports no diff on `app/psp/main.cxx`
- [ ] CI `psp` + `psp-smoke` jobs (cannot cross-compile for PSP or run PPSSPP locally in this environment)
