### PR TITLE
Confirm a body-less command block still spends its own step

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8215,18 +8215,31 @@ codebase yet):
   cascades into a distinct auto-start *common* event within the same frame),
   the first and third confirmed to fail against the pre-fix code (the second
   event's switch not yet set) before the fix.
-- **A body-less command block still spends a step.** The wiki's own
+- ✅ **A body-less command block still spends a step — already correct, now
+  confirmed against this codebase's own code and its own real-game command-
+  frequency audit rather than left as a wiki restatement.** The wiki's own
   worked example: a `◆繰り返し処理` / (blank inner line) / `：以上繰り返し`
   loop, and the empty branches of a `◆条件分岐`, each spend 1 step per
   visit to their blank line, in addition to whatever `End Loop`/`End
-  Branch` itself costs. Worth confirming the LCF-parsed command list
-  actually carries a real entry for an empty loop/branch body (rather than
-  the parser collapsing/omitting it) and that `Interpreter#step_cost`
-  charges for it — `mruby-rpg2k/mrblib/interpreter.rb:495` already
-  differentiates `END_LOOP`/`CALL_EVENT`/`CALL_COMMON_EVENT`/`END_BRANCH`
-  (cost 2) and a taken/untaken `CONDITIONAL` (1 or 2), which lines up with
-  the wiki's "most commands cost 1, a few vary," but the empty-line case
-  specifically wasn't checked this session.
+  Branch` itself costs. The LCF parser (`mruby-lcf/mrblib/lcf.rb`'s
+  `parse_event_commands`) is a flat, byte-faithful decode with no block-
+  length prefix and no filtering — an editor's blank inner line is a real
+  command-list row (opcode 0 or 10), never collapsed or omitted, and
+  `docs/rpg2000-sample-analysis.md`'s own real-game audit confirms this
+  empirically: one sample's common events (built from switch/variable state
+  machines using exactly `ControlVars`/`ConditionalBranch`/`Loop`/
+  `CallEvent`) carry 168 such blank-line rows out of 1919 total commands.
+  `Interpreter#execute`'s default dispatch arm already no-ops these rows
+  ("blank editor lines (codes 0 / 10) and RPG2003-only commands") and
+  `#step_cost`'s own default arm already charges the ordinary 1-step cost
+  for them, same as any other unweighted command — nothing in the dispatch
+  loop skips a row without also stepping it. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check that isolates the one extra step
+  directly: adding a single blank-line row into an otherwise-identical loop
+  body (next to the existing bare-`CONTROL_VARS` loop check just above)
+  costs exactly one more step per iteration (3 → 4), landing on a smaller,
+  precisely different iteration count (3333 → 2500) for the same 10000-step
+  budget.
 - **Party wipe during "Show Text" freezes or crashes real RPG_RT** (also
   reachable via "Damage Processing," not just "HP change"). Worked repros
   given for both a blocking Autorun HP-drain-to-0-during-a-message and a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1508,6 +1508,33 @@ check 'a single update spends its 10000-step budget at the documented per-comman
   eq 5000, it2.resolver.calls, '10000 steps / 2 per Call Event round trip'
 end
 
+# A "body-less" Repeat/Loop or Conditional Branch, as the editor shows it, is
+# not actually empty in the LCF-parsed command list: the editor's own blank
+# inner line is a real row (opcode 0 or 10) that #execute's default arm
+# ("blank editor lines (codes 0 / 10) and RPG2003-only commands") already
+# no-ops, and #step_cost's own default arm (1, the same as any ordinary
+# command) already charges for it -- confirmed against this codebase's own
+# real-game command-frequency audit (docs/rpg2000-sample-analysis.md), which
+# finds 168 such blank-line rows among a real save's common events. This
+# check isolates that one extra step directly: adding a single blank-line
+# row into an otherwise-identical loop body costs exactly one more step per
+# iteration than the bare-CONTROL_VARS loop above (3 -> 4), landing on a
+# different, smaller iteration count for the same 10000-step budget.
+check 'a body-less command block (a blank editor line) still spends its own step' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.start([
+    FakeCmd.new(IC::LOOP, [], indent: 0),
+    FakeCmd.new(0, [], indent: 0), # a blank editor line -- code 0
+    FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 1, 0, 1], indent: 0), # variable 1 += 1
+    FakeCmd.new(IC::END_LOOP, [], indent: 0),
+  ])
+  it.update
+  eq 2500, st.variables[1],
+     '10000 steps / (1 for the blank line + 1 for the add + 2 for the loop-back) per ' \
+     'iteration -- one more per lap than the otherwise-identical 3333-iteration check above'
+end
+
 check 'a Conditional Branch costs one step when matched, two when not' do
   # Per the event command spec, a Conditional Branch evaluation is one step
   # when it matches (falling through into the true body) and two when it does


### PR DESCRIPTION
## Summary
- `docs/TODO.md` flagged an unverified wiki claim: a body-less Repeat/Loop or Conditional Branch (the editor's own blank inner line) still spends 1 step per visit, in addition to whatever `End Loop`/`End Branch` itself costs.
- Confirmed already correct against this codebase's own implementation: the LCF parser (`mruby-lcf/mrblib/lcf.rb`'s `parse_event_commands`) is a flat, byte-faithful decode — an editor's blank inner line is a real command-list row (opcode 0 or 10), never collapsed or omitted — and `docs/rpg2000-sample-analysis.md`'s own real-game command-frequency audit confirms this empirically (168 such blank-line rows in a real save's common events). `Interpreter#execute`'s default dispatch arm already no-ops these rows and `#step_cost`'s own default arm already charges the ordinary 1-step cost for them.
- Adds a `scripts/rpg2k_logic_check.rb` check that isolates the one extra step directly: adding a single blank-line row into an otherwise-identical loop body (next to the existing bare-`CONTROL_VARS` loop check) costs exactly one more step per iteration, landing on a smaller, precisely different iteration count (3333 → 2500) for the same 10000-step budget.

## Testing
- `ruby -c scripts/rpg2k_logic_check.rb`
- `ruby scripts/rpg2k_logic_check.rb` — 779 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 512 checks passed (sanity, no engine code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_