### PR TITLE
rpg2k: a battle skill's stat/attribute-resistance shift now shows its own message

### DIFF
--- a/changelog.d/battle-stat-attribute-shift-messages.fixed.md
+++ b/changelog.d/battle-stat-attribute-shift-messages.fixed.md
@@ -1,0 +1,26 @@
+- **A skill's ATK/DEF/SPI/AGI stat change and attribute-defence shift now
+  announce themselves in battle**, instead of moving the target's numbers
+  silently. `Game::Battle#apply_stat_mods`/`#apply_attr_shift`
+  (`mruby-rpg2k/mrblib/game.rb`) already computed the effect and threaded it
+  onto every battle log entry as `stat_changed`/`attr_shifted`, but nothing
+  ever read either key back into a message — database `term` chunk fields
+  30/31/34/35 (`parameter_increase`/`parameter_decrease`/
+  `resistance_increase`/`resistance_decrease`) were parsed but named nowhere
+  in `mruby-rpg2k`. EasyRPG Player's actual C++ source confirms this is
+  RPG2000's own battle scene, not an RPG2003-only path:
+  `scene_battle_rpg2k.cpp`'s `ProcessBattleActionStateEffects`/
+  `ProcessBattleActionAttributeEffects` push a message from
+  `BattleMessage::GetAtkChangeMessage`/`GetDefChangeMessage`/
+  `GetSpiChangeMessage`/`GetAgiChangeMessage` and `GetAttributeShiftMessage`
+  (`game_message_terms.cpp`) for every landed action. Ported as
+  `Game::States::BattleText.parameter_change`/`.attribute_shift`, wired into
+  `Scene::Map#battle_state_lines` (`mruby-rpg2k/mrblib/scene/map.rb`)
+  alongside the existing inflicted/cured/defeated sentences — one line per
+  ATK/DEF/SPI/AGI key that actually moved, and one per attribute id whose
+  resistance rank shifted, each falling back to composed English when the
+  database leaves the term blank. `Game::Battle#apply_skill_hit` now also
+  threads `attr_shift_dir` (the shift's own +1/-1) onto the log entry, since
+  `apply_attr_shift` previously reduced it to a bare list of moved attribute
+  ids with no direction to report. Covered by five new
+  `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against the
+  pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8094,6 +8094,60 @@ above are repeated here)
   transformation back to the zero-hue battler redraws with no rotation),
   confirmed to fail against the pre-fix code (`NoMethodError: undefined
   method 'battler_hue'`) before the fix.
+- ✅ **A skill's ATK/DEF/SPI/AGI stat change and attribute-defence shift now
+  announce themselves in battle — the mechanics themselves already landed
+  (see the ability-value and attribute-shift fixes above), but the message
+  RPG_RT prints for either one never did.** `ruby scripts/rpg2k_field_audit.rb`
+  (glob fixed to `mruby-rpg2k/mrblib/**/*.rb` — the shared copy's glob is
+  non-recursive and misses `scene/`, producing false positives for anything
+  read only there) flagged database `term` chunk fields 30/31/34/35
+  (`parameter_increase`/`parameter_decrease`/`resistance_increase`/
+  `resistance_decrease`) as parsed but never named anywhere in
+  `mruby-rpg2k`. `Game::Battle#apply_stat_mods`/`#apply_attr_shift`
+  (`mruby-rpg2k/mrblib/game.rb`) already compute the effect and thread it
+  onto every battle log entry as `stat_changed`/`attr_shifted`, but nothing
+  ever read either key back out — a Weaken landing was numerically correct
+  (confirmed by five existing `rpg2k_logic_check.rb` checks reading
+  `Combatant#atk_mod` directly) but silent on screen, same for an
+  attribute-defence buff/curse. Verified against EasyRPG Player's actual
+  C++ source: `scene_battle_rpg2k.cpp`'s `ProcessBattleActionStateEffects`/
+  `ProcessBattleActionAttributeEffects` push a `pending_message` from
+  `BattleMessage::GetAtkChangeMessage`/`GetDefChangeMessage`/
+  `GetSpiChangeMessage`/`GetAgiChangeMessage` (all four thin wrappers over
+  `GetParameterChangeMessage`, `game_message_terms.cpp`) and
+  `GetAttributeShiftMessage` respectively, for every landed action in
+  RPG2000's own battle scene — not an RPG2003-only path.
+  `GetParameterChangeMessage` reads `terms.parameter_increase`/
+  `_decrease` by the delta's own sign and shows the exact clamped
+  magnitude (`"{name}の{attack/defense/mind/agility}が {n} {term}"`, the
+  same の…が… shape this codebase's own `BattleText.recovered` already
+  used for HP/SP); `GetAttributeShiftMessage` reads
+  `terms.resistance_increase`/`_decrease` by the shift's own direction and
+  names only the attribute, no magnitude
+  (`"{name}は{attribute.name} {term}"`). Ported as
+  `Game::States::BattleText.parameter_change`/`.attribute_shift`
+  (`mruby-rpg2k/mrblib/game.rb`), and `Game::Battle#apply_skill_hit` now
+  also threads `attr_shift_dir` (the shift's own +1/-1, already computed by
+  `Game::Party#skill_attr_shift` but previously dropped once `apply_attr_shift`
+  reduced it to a bare list of moved attribute ids) onto both the attack-
+  and recovery-branch log entries alongside the existing `stat_changed`/
+  `attr_shifted`. `Scene::Map#battle_state_lines`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — the same method that already turns
+  `inflicted`/`already`/`cured`/`defeated` into their own sentences under
+  the action's damage line — now does the same for `stat_changed` (one
+  line per ATK/DEF/SPI/AGI key that actually moved, via a new
+  `STAT_CHANGE_TERM` table naming each stat's own 用語 field) and
+  `attr_shifted` (one line per shifted attribute id, looked up by name in
+  `db.property`), each falling back to composed English exactly like every
+  other sentence in that method when the database leaves the term blank.
+  Covered by five new `scripts/rpg2k_scene_check.rb` checks (a stat rise
+  and a stat drop read in the game's own words, all four ATK/DEF/SPI/AGI
+  keys in `apply_stat_mods`'s own reporting order; a zero-delta entry says
+  nothing; an attribute-shift rise and drop read by the attribute's own
+  name with no magnitude, matching `GetAttributeShiftMessage`; both new
+  line kinds follow the damage line in the same entry, like every other
+  landed condition), all confirmed to fail against the pre-fix code (`got
+  []`/a missing final line) before the fix.
 
 **Asset / graphics format notes** (lower priority — content-authoring
 constraints more than runtime-correctness gaps, but recorded for

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6532,6 +6532,38 @@ module Game
         f = FAILURE_TERMS[i || 0]
         f && action(terms, target_name, f)
       end
+
+      # 「リトの攻撃力が 10 上がった！」 / 「…下がった！」 — what an ATK/DEF/SPI
+      # (mind)/AGI-affecting skill (`skill.affect_attack` and friends, applied
+      # by `Game::Battle#apply_stat_mods`) did to a stat. `value` is the signed
+      # delta actually applied (already clamped against RPG_RT's own -(base/2)
+      # .. +base band); `points` is the 用語 name of the stat itself (`:attack`
+      # / `:defense` / `:mind` / `:agility`) rather than a pool. Same の…が…
+      # shape as #recovered above, but which of the two predicates
+      # (`parameter_increase` / `parameter_decrease`) speaks is `value`'s own
+      # sign rather than fixed -- EasyRPG's `GetParameterChangeMessage`.
+      def self.parameter_change(terms, target_name, value, points)
+        return nil if value.nil? || value == 0
+        t = term(terms, value > 0 ? :parameter_increase : :parameter_decrease)
+        pool = term(terms, points)
+        return nil unless t && pool
+        "#{target_name}の#{pool}が #{value.abs} #{t}"
+      end
+
+      # 「リトは火に対する耐性が 上がった！」 — an attribute-defence-shift skill
+      # (`skill.affect_attr_defence`, applied by `Game::Battle#apply_attr_shift`)
+      # moving a resistance rank. `positive` is the shift's own direction
+      # (`Game::Party#skill_attr_shift`'s `attr_shift`, +1 raises / -1 lowers,
+      # the same for every attribute id one skill cast touches) -- unlike the
+      # parameter version above, EasyRPG's `GetAttributeShiftMessage` never
+      # shows a magnitude here, only which way the rank moved, so there is no
+      # `value` argument to speak of.
+      def self.attribute_shift(terms, target_name, positive, attr_name)
+        return nil if attr_name.nil? || attr_name.to_s.empty?
+        t = term(terms, positive ? :resistance_increase : :resistance_decrease)
+        return nil unless t
+        "#{target_name}は#{attr_name} #{t}"
+      end
     end
 
     # Map-step slip damage: RPG2000's field poison. A state drains HP every
@@ -8752,7 +8784,8 @@ module Game
         { attacker: b.name, target: target.name, damage: dmg,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
           inflicted: inflicted, already: already, cured: cured,
-          attr_shifted: shifted, stat_changed: stat_changed,
+          attr_shifted: shifted, attr_shift_dir: cmd[:attr_shift],
+          stat_changed: stat_changed,
           target_ally: ally?(target), skill: cmd[:name],
           skill_id: cmd[:skill_id], target_index: @enemies.index(target),
           absorbed_hp: absorbed }
@@ -8804,6 +8837,7 @@ module Game
           recover_hp: target.hp - before_hp, recover_mp: (target.mp || 0) - before_mp,
           cured: cured, inflicted: inflicted, already: already,
           target_ally: ally?(target), attr_shifted: shifted,
+          attr_shift_dir: cmd[:attr_shift],
           stat_changed: stat_changed, switch_id: cmd[:switch_id],
           target_hp: target.hp, target_mp: target.mp }
       end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6030,8 +6030,32 @@ class RPG2k
                                                  name, ally) ||
                     "#{name} is defeated!")
         end
+        terms = db.respond_to?(:term) ? db.term : nil
+        (entry[:stat_changed] || {}).each do |key, delta|
+          term_name = STAT_CHANGE_TERM[key]
+          next unless term_name && delta && delta != 0
+          lines << (Game::States::BattleText.parameter_change(terms, name, delta, term_name) ||
+                    "#{name}'s #{term_name} #{delta > 0 ? 'rose' : 'fell'} by #{delta.abs}")
+        end
+        attr_ids = entry[:attr_shifted] || []
+        unless attr_ids.empty?
+          positive = (entry[:attr_shift_dir] || 1) > 0
+          props = db.respond_to?(:property) ? db.property : nil
+          attr_ids.each do |aid|
+            row = props ? props[aid] : nil
+            attr_name = row && row.respond_to?(:name) ? row.name : "attribute #{aid}"
+            lines << (Game::States::BattleText.attribute_shift(terms, name, positive, attr_name) ||
+                      "#{name}'s resistance to #{attr_name} #{positive ? 'rose' : 'fell'}")
+          end
+        end
         lines
       end
+
+      # The 用語 field naming each ATK/DEF/SPI(mind)/AGI stat itself (as
+      # opposed to `Game::Battle::STAT_MOD_FIELD`, which names the Combatant
+      # accessor that holds the modifier) -- what #battle_state_lines passes
+      # `BattleText.parameter_change` as `points`.
+      STAT_CHANGE_TERM = { atk: :attack, def: :defense, spi: :mind, agi: :agility }.freeze
 
       def state_label(id, table)
         Game::States.name(id, table) || "state #{id}"

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -301,7 +301,19 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                          use_item: 'を使った！', hp_recovery: '回復した！',
                          hp: 'ＨＰ', mp: 'ＭＰ',
                          enemy_hp_absorbed: '奪った！',
-                         actor_hp_absorbed: '奪われた！'),
+                         actor_hp_absorbed: '奪われた！',
+                         # An affect_attack/defense/spirit/agility skill's stat-mod
+                         # message and an affect_attr_defence skill's resistance-shift
+                         # message (EasyRPG's GetParameterChangeMessage /
+                         # GetAttributeShiftMessage) -- see #battle_state_lines.
+                         parameter_increase: '上がった！', parameter_decrease: '下がった！',
+                         resistance_increase: '耐性が上がった！',
+                         resistance_decrease: '耐性が下がった！',
+                         attack: '攻撃力', defense: '防御力', mind: '精神力',
+                         agility: '敏捷性'),
+    # The Attribute (elemental) table a resistance-shift skill's `attribute_effects`
+    # names, read by #battle_state_lines for the shifted attribute's own name.
+    property: { 1 => OpenStruct.new(name: '火') },
     # Skill rows for the battle log: RPG2000 gives each skill its own two
     # sentences. Skill 8 sets both, 9 only the first, 10 neither (an
     # English-release row), and 11 picks the second failure sentence.
@@ -9769,6 +9781,67 @@ check 'the state sentences still follow the action ones' do
                      { attacker: 'Slime', target: 'Hero', damage: 7,
                        inflicted: [3], target_ally: true })
   eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！', 'Hero is poisoned!'], lines
+end
+
+# -- ability-value / attribute-resistance messages (term fields 30/31/34/35) --
+#
+# An affect_attack/defense/spirit/agility skill (Game::Battle#apply_stat_mods)
+# and an affect_attr_defence skill (Game::Battle#apply_attr_shift) both already
+# moved the target's numbers with no line ever announcing it -- RPG_RT's own
+# GetParameterChangeMessage / GetAttributeShiftMessage read `term.
+# parameter_increase` / `_decrease` and `term.resistance_increase` / `_decrease`
+# for exactly this, matching every other landed-condition sentence above.
+
+check 'an affect_attack/defense/spirit/agility skill announces the stat rise ' \
+      'or drop, in the game\'s own words' do
+  scene, = battle_at_command
+  up = scene.send(:battle_state_lines, { target: 'Hero', target_ally: true,
+                                         stat_changed: { atk: 10 } })
+  eq ['Heroの攻撃力が 10 上がった！'], up
+
+  down = scene.send(:battle_state_lines, { target: 'Slime', target_ally: false,
+                                           stat_changed: { def: -4 } })
+  eq ['Slimeの防御力が 4 下がった！'], down
+
+  # Every ability-value key the mechanic can touch, and in the order
+  # #apply_stat_mods reports them.
+  all_four = scene.send(:battle_state_lines,
+                        { target: 'Hero', target_ally: true,
+                          stat_changed: { atk: 3, def: -2, spi: 1, agi: -5 } })
+  eq ['Heroの攻撃力が 3 上がった！', 'Heroの防御力が 2 下がった！',
+      'Heroの精神力が 1 上がった！', 'Heroの敏捷性が 5 下がった！'], all_four
+end
+
+check 'a zero-delta stat entry (already pinned at its cap) says nothing' do
+  scene, = battle_at_command
+  eq [], scene.send(:battle_state_lines,
+                    { target: 'Hero', target_ally: true, stat_changed: { atk: 0 } })
+end
+
+check 'an affect_attr_defence skill announces which way the target\'s ' \
+      'resistance moved, by the attribute\'s own name -- no magnitude, ' \
+      'matching EasyRPG\'s GetAttributeShiftMessage' do
+  scene, = battle_at_command
+  raised = scene.send(:battle_state_lines,
+                      { target: 'Hero', target_ally: true,
+                        attr_shifted: [1], attr_shift_dir: 1 })
+  eq ['Heroは火 耐性が上がった！'], raised
+
+  lowered = scene.send(:battle_state_lines,
+                       { target: 'Slime', target_ally: false,
+                         attr_shifted: [1], attr_shift_dir: -1 })
+  eq ['Slimeは火 耐性が下がった！'], lowered
+end
+
+check 'the stat and attribute-shift lines follow the damage line, like every ' \
+      'other landed condition' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Slime', target: 'Hero', damage: 7,
+                       target_ally: true, stat_changed: { def: -5 },
+                       attr_shifted: [1], attr_shift_dir: -1 })
+  eq ['Slimeの攻撃！', 'Heroは 7 のダメージを受けた！',
+      'Heroの防御力が 5 下がった！', 'Heroは火 耐性が下がった！'], lines
 end
 
 check 'a skill announces itself with its own two sentences, then the damage' do


### PR DESCRIPTION
## Summary

- RPG2000 battle skills that raise/lower ATK/DEF/SPI/AGI or shift an attribute's resistance rank already applied the effect numerically (`Game::Battle#apply_stat_mods` / `#apply_attr_shift`, landed in a prior round) but never showed the player any message about it.
- Found via a schema-field audit: LCF database `term` chunk fields 30/31/34/35 (`parameter_increase`/`parameter_decrease`/`resistance_increase`/`resistance_decrease`) were parsed but named nowhere in `mruby-rpg2k`.
- Verified against EasyRPG Player's vendored source: `Scene_Battle_Rpg2k::ProcessBattleActionStateEffects`/`ProcessBattleActionAttributeEffects` (`src/scene_battle_rpg2k.cpp`) push `BattleMessage::GetAtkChangeMessage`/`GetDefChangeMessage`/`GetSpiChangeMessage`/`GetAgiChangeMessage` (`src/game_message_terms.cpp`, all four wrap `GetParameterChangeMessage`, reading `terms.parameter_increase`/`_decrease`) and `GetAttributeShiftMessage` (reading `terms.resistance_increase`/`_decrease`) for every landed action — this is RPG2000's own battle scene, not RPG2003-only.
- Added `Game::States::BattleText.parameter_change`/`.attribute_shift`, ported from the EasyRPG C++ message shapes. `battle_state_lines` now renders one line per stat change and one per attribute shift, alongside the existing inflicted/cured/defeated sentences, with English fallback when the database term is blank.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 780 passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 519 passed (5 new checks; confirmed to fail pre-fix)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 passed
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 31 passed
- [x] `ruby scripts/rpg2k_command_soak.rb` — 3430 commands, no gaps

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvCKjDSmGMH51bFqn3vVhz)_