### PR TITLE
scripts: add rgssad_unpack.rb, closing ADR 0047's P3 tool half

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -90,3 +90,12 @@ real risk: mruby 4.0's global allocator hook defaults to sharing LVGL's pool
 (as it does on desktop), so `lv_conf.h`'s 4 MB `LV_MEM_SIZE` may need to cover
 the entire mruby object graph, not just LVGL widgets, unless a PSP-specific
 allocator exception is added.
+
+For a packed RPG Maker XP/VX/VX Ace title,
+[`scripts/rgssad_unpack.rb`](../../scripts/rgssad_unpack.rb) unpacks
+`Game.rgssad`/`.rgss2a`/`.rgss3a` into a loose file tree in place — the
+loose-file-first loaders already prefer it over the archive, so this avoids
+the whole-archive-resident-in-RAM read the packed form forces (see the ADR's
+Finding 2). Excluding the packed archive from a given PSP deployment, so it
+is never opened at all, is still a manual step the unpacker itself doesn't
+take for you.

--- a/changelog.d/rgssad-unpack-script.added.md
+++ b/changelog.d/rgssad-unpack-script.added.md
@@ -1,0 +1,10 @@
+- **`scripts/rgssad_unpack.rb`.** Unpacks a packed RPG Maker XP/VX/VX Ace
+  archive (`Game.rgssad`/`.rgss2a`/`.rgss3a`) into a loose file tree in
+  place, reusing the existing `RPGXP::RGSSAD` reader rather than
+  reimplementing the format. Closes the tool half of
+  `docs/adr/0047-psp-memory-budget.md`'s P3: the engine's loaders already
+  prefer a loose file over the packed archive, so a PSP deployment that
+  ships a title unpacked (and excludes the packed archive) avoids reading
+  the whole thing into RAM at boot. Verified against real Marshal-encoded
+  `.rxdata` packed as both archive versions, unpacked, and diffed
+  byte-for-byte against the originals.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -215,16 +215,20 @@ the interpreter-linking slice, in this order:
   mruby gets its own bounded arena. Whichever is chosen, fix
   `app/psp/lv_conf.h`'s comment to state it accurately instead of describing
   the un-taken option.
-- **P3 — ship PSP XP/VX titles unpacked, not as `Game.rgssad`.** Pre-unpack
-  the archive offline (desktop-side, using the existing `RGSSAD` reader) into
-  a loose `Data`/`Graphics`/`Audio` tree, and exclude the packed
-  `Game.rgssad`/`.rgss2a`/`.rgss3a` from the PSP deployment so
-  `open_archive` never reads it. This needs no interpreter/gem changes — only
-  a packaging step and a place to hang it (e.g. a `scripts/` unpack tool). A
-  streaming `RGSSAD` reader is the fallback if Memory Stick space, not RAM,
-  turns out to be the constraint. Deferred relative to P1/P2 since RPG2k
-  bring-up never calls this path, but tracked now so it isn't rediscovered as
-  an on-device crash.
+- **P3 — done (the tool; the deployment step itself is still per-release).**
+  `scripts/rgssad_unpack.rb` unpacks a `Game.rgssad`/`.rgss2a`/`.rgss3a`
+  (desktop-side, reusing the existing `RPGXP::RGSSAD` reader rather than
+  reimplementing the format) into a loose file tree in place beside it,
+  exactly where the loose-file-first loaders already look. Verified against
+  real Marshal-encoded `.rxdata` (the `OpenGame.exe` XP test-bed
+  `scripts/download-opengame-xp.bash` already fetches for CI): packed both as
+  v1 and v3 archives, unpacked, diffed byte-for-byte against the originals —
+  exact match both ways. What's still a per-release step, not something this
+  tool can do for you: excluding the packed archive from a given PSP
+  deployment so `open_archive` never reads it (see Finding 2's catch) — the
+  unpacker never touches or deletes the archive itself. A streaming `RGSSAD`
+  reader remains the fallback if Memory Stick space, not RAM, turns out to be
+  the constraint for a release that can't afford the doubled storage.
 - **P4 — bound the LVGL image cache** and confirm decoded-bitmap sizes for
   the target games' resolutions fit inside whatever pool P2 settles on.
 - **P5 — size and verify the main-thread stack** against measured mruby
@@ -234,13 +238,13 @@ the interpreter-linking slice, in this order:
 ## Consequences
 
 - Unlike ADR 0007's discipline of agreeing every number before any code
-  lands, this revision ships two small, self-contained changes alongside the
-  ADR update: P1a (stripping mrbc's `-g` for the `psp` cross-build) and half
-  of P1 (the bring-up EBOOT's heartbeat now reports real device memory
-  numbers). Neither is a pool-sizing or allocator decision — those still
-  depend on numbers only the interpreter-linking slice can produce (a real
-  database and map actually loaded) — so the rest of the Decision items
-  remain design record only.
+  lands, this revision ships small, self-contained changes alongside the ADR
+  update: P1a (stripping mrbc's `-g` for the `psp` cross-build), half of P1
+  (the bring-up EBOOT's heartbeat now reports real device memory numbers),
+  and the tool half of P3 (`scripts/rgssad_unpack.rb`). None of these is a
+  pool-sizing or allocator decision — those still depend on numbers only the
+  interpreter-linking slice can produce (a real database and map actually
+  loaded) — so the rest of the Decision items remain design record only.
 - ADR 0010's "the full gem set should fit" is narrowed: it holds for gem
   *code* size, but says nothing about per-title asset memory, which Finding 2
   shows can exceed the entire 24 MB budget for an RGSSAD-packed game even
@@ -249,11 +253,11 @@ the interpreter-linking slice, in this order:
 - **Risk register:** P2 (allocator split / pool sizing) is soft-blocking the
   interpreter-linking slice — the slice can land without it decided, but
   `LV_MEM_SIZE` will be guessed rather than sized until it is. P3 (RGSSAD
-  whole-archive loads) is hard-blocking for any future XP/VX PSP target, but
-  cheap to close (a packaging step, not new runtime code) precisely because the
-  loose-file-first loaders already exist — the risk is forgetting to strip the
-  packed archive from the deployment, not the fix itself. P4/P5 are lower-risk
-  follow-ups once a title actually renders.
+  whole-archive loads) is hard-blocking for any future XP/VX PSP target; the
+  tool to close it is done, but running it and excluding the packed archive
+  is still a manual step per release, not something CI or the build enforces
+  — that's the remaining risk, not the unpack logic itself. P4/P5 are
+  lower-risk follow-ups once a title actually renders.
 - Follow-up: once P1's real numbers exist, replace this ADR's estimates with
   measured figures (a memory budget table, as ADR 0007 has for the Wio
   Terminal) — either as an amendment here or a superseding ADR.

--- a/scripts/rgssad_unpack.rb
+++ b/scripts/rgssad_unpack.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Unpack an RPG Maker XP/VX/VX Ace packed archive (Game.rgssad / .rgss2a /
+# .rgss3a) into a loose file tree.
+#
+# Why this exists: RGSSData#read_object and Bitmap#init_from_archive already
+# prefer a loose file over the packed archive ("loose shadows packed, as in
+# RGSS" -- mruby-rgss/mrblib/lib.rb) -- but RGSSData#open_archive still
+# unconditionally reads the *whole* packed archive into memory the moment it
+# finds one on disk, whether or not anything inside it ends up used. On a
+# RAM-constrained target like the PSP (~24 MB usable, see
+# docs/adr/0047-psp-memory-budget.md) that whole-archive read can exceed the
+# entire budget by itself for a real released game. Unpacking once, offline,
+# and excluding the packed archive from that deployment avoids the read
+# entirely -- no interpreter or gem changes needed, since the loose-file path
+# already exists and is already preferred.
+#
+# The reader (mruby-rpgxp/mrblib/rgssad.rb) is written in the mruby/CRuby
+# common subset specifically so it runs under plain CRuby too (see its own
+# comment, and scripts/rpgxp_testbed_check.rb, which loads it the same way);
+# this script does the same rather than reimplementing the format.
+#
+# Usage:
+#   ruby scripts/rgssad_unpack.rb GAME_DIR [DEST_DIR]
+# DEST_DIR defaults to GAME_DIR itself (unpack in place, beside the archive,
+# which is what a PSP deployment wants: the loose tree lands exactly where
+# the loose-file-first loaders already look). Never touches the packed
+# archive itself -- removing it from a given deployment (so it is never
+# eagerly opened) is a separate, deliberate step; see the ADR.
+
+require "fileutils"
+
+mrblib = File.expand_path("../mruby-rpgxp/mrblib", __dir__)
+class RPGXP; end
+load File.join(mrblib, "rgssad.rb")
+
+# Unpack every entry of the archive found under +game_dir+ into +dest_dir+,
+# preserving the archive's relative paths ('\' separators normalised to '/').
+# Returns [archive_path, unpacked entry count]. Raises if no archive is found.
+def rgssad_unpack(game_dir, dest_dir)
+  path = RPGXP::RGSSAD.find(game_dir)
+  raise "no Game.rgssad/.rgss2a/.rgss3a found under #{game_dir}" unless path
+
+  archive = RPGXP::RGSSAD.open(path)
+  archive.names.each do |name|
+    out_path = File.join(dest_dir, name.tr("\\", "/"))
+    FileUtils.mkdir_p(File.dirname(out_path))
+    File.binwrite(out_path, archive.read(name))
+  end
+  [path, archive.names.size]
+end
+
+if $PROGRAM_NAME == __FILE__
+  game_dir = ARGV[0] or abort "usage: ruby scripts/rgssad_unpack.rb GAME_DIR [DEST_DIR]"
+  dest_dir = ARGV[1] || game_dir
+
+  begin
+    archive_path, count = rgssad_unpack(game_dir, dest_dir)
+  rescue => e
+    abort e.message
+  end
+  puts "unpacked #{count} files from #{archive_path} into #{dest_dir}"
+end


### PR DESCRIPTION
## Summary

- New `scripts/rgssad_unpack.rb`: unpacks a packed RPG Maker XP/VX/VX Ace archive (`Game.rgssad`/`.rgss2a`/`.rgss3a`) into a loose file tree in place, reusing the existing `RPGXP::RGSSAD` reader (`mruby-rpgxp/mrblib/rgssad.rb`) rather than reimplementing the format — the same load pattern `scripts/rpgxp_testbed_check.rb` already uses to run that reader under CRuby.
- `docs/adr/0047-psp-memory-budget.md`: marks the tool half of P3 done, with the remaining manual step (excluding the packed archive from a given deployment) called out explicitly as the risk that's left, not the unpack logic.
- `app/psp/README.md`: points the Memory budget section at the new script.
- Changelog fragment.

## Why

`RGSSData#read_object` and `Bitmap#init_from_archive` already prefer a loose file over the packed archive ("loose shadows packed, as in RGSS"), but `RGSSData#open_archive` still unconditionally reads the *whole* packed archive into memory whenever one is merely present on disk — regardless of whether anything in it ends up used. On the PSP's ~24 MB budget (ADR 0047, Finding 2), that whole-archive read can exceed the entire budget by itself for a real released game. Shipping a title unpacked (and excluding the packed archive) avoids the read entirely — no interpreter or gem changes needed, since the loose-file path already exists and is already preferred.

## Verification

No PSP toolchain needed for this one — it's plain Ruby, tested directly against real game data:

- Downloaded the real `OpenGame.exe` RPG Maker XP test-bed (`scripts/download-opengame-xp.bash`, already used elsewhere in CI) — 16 real Marshal-encoded `.rxdata` files.
- Packed them into a synthetic archive both ways (`RPGXP::RGSSAD.pack_v1` and `.pack_v3`), ran the new script against each, and diffed every unpacked file byte-for-byte against the original — exact match for both archive versions.
- Exercised the CLI entry point directly (`ruby scripts/rgssad_unpack.rb DIR`), both the success path and the "no archive found" error path (clean message, exit 1, no stack trace).
- `ruby -c` syntax check.

## Test plan

- [x] `ruby -c scripts/rgssad_unpack.rb`
- [x] Round-trip against real `.rxdata`, both RGSSAD v1 and v3, byte-for-byte diff
- [x] CLI success and error paths exercised directly


---
_Generated by [Claude Code](https://claude.ai/code/session_01CaTSJ4i2Lwxi3VAV2DEr5D)_