### PR TITLE
rpg2k: a battle victory's EXP/gold/item lines now use the database's own terms

### DIFF
--- a/changelog.d/battle-victory-reward-terms.fixed.md
+++ b/changelog.d/battle-victory-reward-terms.fixed.md
@@ -1,0 +1,18 @@
+- **A battle victory's EXP/gold/item-drop lines now read the database's own
+  `exp_received`/`gold_received_a`/`gold_received_b`/`item_received` terms**,
+  instead of always showing hardcoded English ("Gained 10 EXP.", "Found 20
+  gold.", "Found Potion."). These four `term` chunk fields (LCF fields 7-10)
+  were parsed by the schema and never read anywhere in `mruby-rpg2k`.
+  Confirmed against EasyRPG Player's actual C++ source rather than guessed
+  at: `PartyMessage::GetExperienceGainedMessage`/`GetGoldReceivedMessage`/
+  `GetItemReceivedMessage` (`src/game_message_terms.cpp`) compose, for stock
+  RPG2000 (the non-`Feature::HasPlaceholders`, non-Maniac-Patch branch),
+  `"{exp}{exp_received}"`, `"{gold_received_a} {money}{gold}{gold_received_b}"`
+  and `"{item_name}{item_received}"`. `Scene::Map#battle_result_lines`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) now composes exactly these three
+  shapes, falling back to composed English when the database leaves a term
+  blank, matching the "victory"/"defeat" terms it already read the same way.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks (a database
+  setting all four terms shows the composed sentences around the granted
+  EXP/gold/item name; a blank database falls back to the composed English),
+  both confirmed to fail against the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7406,6 +7406,38 @@ level-up).
 **Database field semantics** (from the `11_db/` sweep, 48 findings — the
 single densest source in this pass; only the ones not already listed
 above are repeated here)
+- ✅ **A battle victory's EXP/gold/item-drop lines now read the database's own
+  `exp_received`/`gold_received_a`/`gold_received_b`/`item_received` terms**,
+  found by a manual sweep of the LCF `term` chunk schema against
+  `mruby-rpg2k` (the same technique `scripts/rpg2k_field_audit.rb` automates,
+  run here against the schema directly rather than a real game's row counts,
+  since no test-bed `.ldb` is available in this environment) — these four
+  fields (LCF `term` chunk fields 7-10) were parsed and never named anywhere
+  in the runtime; `Scene::Map#battle_result_lines`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) always showed hardcoded English
+  ("Gained 10 EXP.", "Found 20 gold.", "Found Potion.") regardless of what a
+  game's own database configured, even though the sibling `victory`/`defeat`
+  terms right next to them in the same method were already read correctly.
+  The method's own prior comment explained why: "nothing here confirms which
+  half is which without a real database to check against — left declared
+  rather than guessed at." Confirmed against EasyRPG Player's actual C++
+  source rather than guessed at: `PartyMessage::GetExperienceGainedMessage`/
+  `GetGoldReceivedMessage`/`GetItemReceivedMessage`
+  (`src/game_message_terms.cpp`), the stock-RPG2000 branch (not
+  `Feature::HasPlaceholders`, which only applies to the RPG2kE Steam release
+  or a 2k3 project opting into RPG2kE-style strings, and not the Maniac
+  Patch's own extra term), compose `"{exp}{exp_received}"` (no separating
+  space outside the RPG2k3-English release), `"{gold_received_a} {money}
+  {gold}{gold_received_b}"` and `"{item_name}{item_received}"` exactly.
+  `#battle_result_lines` now composes these three shapes, falling back to
+  composed English (`"{n} EXP gained."`, `"Found {n}G."`,
+  `"{item} obtained."`) when the database leaves a term blank, the same
+  "falls back to English" rule already covering `victory`/`defeat`. Covered
+  by two new `scripts/rpg2k_scene_check.rb` checks (a database setting all
+  four terms shows the composed sentences around the granted EXP/gold/item
+  name, including two certain item drops from a two-member troop; a blank
+  database falls back to the composed English for all three), both
+  confirmed to fail against the pre-fix code before the fix.
 - **Sell price = `floor(list price / 2)`; price 0 = unsellable in a shop
   but free if placed in a shop's own buy list — confirmed already
   correct**, all three facts, no code change needed. `Game::Shop#sell_price`

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5723,16 +5723,21 @@ class RPG2k
       # map. The headline is the database's own wording -- the 用語 table's
       # `victory` / `defeat` fields, the same table (and the same "falls back to
       # composed English when the database leaves it blank" rule)
-      # Game::States::BattleText already reads every per-action line from, just
-      # two fields that table never touches. The two previously-hardcoded
-      # English sentences are now exactly that fallback rather than the only
-      # wording a game ever showed. The EXP / gold / item lines stay composed:
-      # their own terms (`exp_received`, the `gold_received_a` / `_b` pair,
-      # `item_received`) are two- or three-part sentences with the number or
-      # name sandwiched between literal halves, and nothing here confirms which
-      # half is which without a real database to check against -- left declared
-      # rather than guessed at, the same call this project already makes for a
-      # handful of other under-specified 用語 fields.
+      # Game::States::BattleText already reads every per-action line from.
+      # The EXP / gold / item lines are composed from their own terms too now
+      # (`exp_received`, the `gold_received_a` / `_b` pair, `item_received`),
+      # confirmed against EasyRPG Player's actual C++ source rather than
+      # guessed at: `PartyMessage::GetExperienceGainedMessage` /
+      # `GetGoldReceivedMessage` / `GetItemReceivedMessage`
+      # (`src/game_message_terms.cpp`), stock-RPG2000 (non-`Feature::
+      # HasPlaceholders`, non-Maniac-Patch) branch -- `exp << terms.
+      # exp_received` (no separating space outside the RPG2k3-English
+      # release), `terms.gold_recieved_a << " " << money << terms.gold <<
+      # terms.gold_recieved_b`, `item_name << terms.item_recieved`. These
+      # three term fields were parsed by the schema and never read anywhere
+      # in `mruby-rpg2k` before now, so a game that customised them (a
+      # translation, a non-English original) showed this codebase's
+      # hardcoded English regardless.
       def battle_result_lines(result, troop)
         return [term(:escape_success, 'Escaped!')] if result == :escape
         return [term(:defeat, 'The party was defeated...')] unless result == :victory
@@ -5741,14 +5746,18 @@ class RPG2k
         @state.party.actors.each { |a| a.gain_exp(exp) }
         @state.party.gain_gold(gold)
         lines = [term(:victory, 'Victory!')]
-        lines << "Gained #{exp} EXP." if exp > 0
-        lines << "Found #{gold} gold." if gold > 0
+        lines << "#{exp}#{term(:exp_received, ' EXP gained.')}" if exp > 0
+        if gold > 0
+          lines << "#{term(:gold_received_a, 'Found')} #{gold}#{term(:gold, 'G')}" \
+                   "#{term(:gold_received_b, '.')}"
+        end
         # Each defeated enemy may drop its treasure item (rolled on the battle's
         # own RNG); grant it to the bag and name it in the result window.
         troop.drops(@battle_ui[:battle].rng).each do |iid|
           @state.party.gain_item(iid, 1)
           it = @state.party.db_item(iid)
-          lines << "Found #{it ? it.name : "item #{iid}"}."
+          name = it ? it.name : "item #{iid}"
+          lines << "#{name}#{term(:item_received, ' obtained.')}"
         end
         lines
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1985,16 +1985,25 @@ class BattleStubParty
   # #flying_offset` reads it off `@state.party`, not the database directly, so
   # a battle scene check needs its stub party to answer it too) -- false by
   # default, matching every other check's plain RPG2000 fixture.
-  def initialize(actor = BattleStubActor.new, rpg2003: false)
+  def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil)
     @actors = [actor]
     @gold = 0
     @leader = nil
     @rpg2003 = rpg2003
+    @items = {}
+    @item_db = item_db
   end
   def gain_gold(n); @gold += n; end
   def any_alive?; @actors.any? { |a| !a.dead? }; end
   def all_dead?; !any_alive?; end
   def rpg2003?; @rpg2003; end
+  # A troop victory drop (Game::Troop#drops -> Scene::Map#battle_result_lines)
+  # both grants the item and names it in the result window -- mirrors
+  # ShopStubParty's own #gain_item, plus a #db_item lookup against whatever
+  # item table `item_db` (typically the scene's own fake_db.item) was given.
+  attr_reader :items
+  def gain_item(id, n = 1); @items[id] = (@items[id] || 0) + n; end
+  def db_item(id); @item_db && @item_db[id]; end
 end
 
 # A party the shop can charge and stock: gold plus an item-count bag, with the
@@ -9282,6 +9291,55 @@ check 'Enemy Encounter scene: the result window shows the database Victory term'
   texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
   ok texts.any? { |t| t.include?('戦いに勝利した！') }, 'the database term is shown'
   ok !texts.any? { |t| t.include?('Victory!') }, 'not the composed English fallback'
+end
+
+check 'Enemy Encounter scene: the result window composes the database EXP/gold/item ' \
+      'received terms around the granted numbers/names, not hardcoded English' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.term.exp_received = 'の経験値を得た！'
+  db.term.gold_received_a = '仲間は'
+  db.term.gold = 'ゴールド'
+  db.term.gold_received_b = 'を手に入れた！'
+  db.term.item_received = 'を手に入れた！'
+  # Both Slimes in fake_db's own two-member troop now carry a certain drop.
+  db.enemy[2].drop_id = 3   # Potion, fake_db's own item table
+  db.enemy[2].drop_prob = 100
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, BattleStubParty.new(item_db: db.item))
+  scene.update
+  battle_attack_to_end(scene)
+  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  ok texts.any? { |t| t.include?('10の経験値を得た！') },
+     'the EXP term is composed as amount-then-term (GetExperienceGainedMessage)'
+  ok texts.any? { |t| t.include?('仲間は 20ゴールドを手に入れた！') },
+     'the two-part gold term sandwiches the amount and the gold unit (GetGoldReceivedMessage)'
+  ok texts.count { |t| t.include?('Potionを手に入れた！') } == 2,
+     'both dead Slimes roll their certain drop, each named by the database item term'
+end
+
+check 'Enemy Encounter scene: blank database EXP/gold/item received terms fall back to ' \
+      'composed English' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db # leaves exp_received/gold_received_a/_b/item_received blank
+  db.enemy[2].drop_id = 3
+  db.enemy[2].drop_prob = 100
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, BattleStubParty.new(item_db: db.item))
+  scene.update
+  battle_attack_to_end(scene)
+  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  ok texts.any? { |t| t.include?('10 EXP gained.') }, 'a blank exp_received term falls back'
+  ok texts.any? { |t| t.include?('Found 20G.') }, 'blank gold_received_a/gold/gold_received_b fall back'
+  ok texts.count { |t| t.include?('Potion obtained.') } == 2, 'a blank item_received term falls back'
 end
 
 check 'Enemy Encounter scene: a blank database Victory/Defeat term falls back to English' do


### PR DESCRIPTION
## Summary

- `Scene::Map#battle_result_lines` composed the post-battle EXP/gold/item-drop
  reward lines as hardcoded English ("Gained 10 EXP.", "Found 20 gold.",
  "Found Potion.") regardless of what a game's own database configured. The
  four LCF `term` chunk fields that drive this (`exp_received`,
  `gold_received_a`/`_b`, `item_received` — fields 7-10) were parsed by the
  schema and never read anywhere in `mruby-rpg2k`, even though the sibling
  `victory`/`defeat` terms right next to them in the same method were already
  wired up correctly. The method's own prior comment explained why: "nothing
  here confirms which half is which without a real database to check against
  — left declared rather than guessed at."
- Found by manually sweeping the LCF `term` schema against `mruby-rpg2k`
  (the technique `scripts/rpg2k_field_audit.rb` automates against real game
  row counts — no test-bed `.ldb` is available in this sandbox, so this was
  done by hand against the schema directly).
- Confirmed the exact composition shape against EasyRPG Player's actual C++
  source (`PartyMessage::GetExperienceGainedMessage`/`GetGoldReceivedMessage`/
  `GetItemReceivedMessage` in `src/game_message_terms.cpp`), stock-RPG2000
  branch: `"{exp}{exp_received}"`, `"{gold_received_a} {money}{gold}
  {gold_received_b}"`, `"{item_name}{item_received}"`. Falls back to composed
  English when a term is left blank, matching the existing `victory`/`defeat`
  rule.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 781 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 517 checks passed (2 new checks
      added, both confirmed to fail against the pre-fix code before the fix)
- [x] `ruby scripts/rpg2k_render_check.rb` — 41 checks passed
- [ ] `ruby scripts/rpg2k_testbed_logic_check.rb` — blocked: no RPG2000
      test-bed game data available in this sandbox (network-restricted)
- [ ] `ruby scripts/rpg2k_command_soak.rb` — blocked: same reason

Re-checked open PRs before pushing to avoid duplicating any sibling
session's in-flight work; no overlap found.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0136FZnZdZBCJi6Pg5LfQgNs


---
_Generated by [Claude Code](https://claude.ai/code/session_0136FZnZdZBCJi6Pg5LfQgNs)_