### PR TITLE
rpg2k: implement the Zoom (setting 16) screen transition

### DIFF
--- a/changelog.d/rpg2k-transition-zoom.added.md
+++ b/changelog.d/rpg2k-transition-zoom.added.md
@@ -1,0 +1,22 @@
+- **Erase / Show Screen's zoom style now paints real pixels.** It used to run
+  as a plain fade of the right length, the wrong texture, because zoom's own
+  in/out direction had nothing in either test bed to confirm it against (see
+  the prior "scroll and combine / division" note, which finished every other
+  captured style and left zoom, mosaic/wave and random blocks). EasyRPG's
+  `transition.cpp` settles the direction: zoom always draws the *destination*
+  as the full screen and instead shrinks or grows the *source* crop it
+  resamples from, so `ZOOM_IN` shrinks the departing scene down to nothing (an
+  Erase) and `ZOOM_OUT` grows the arriving scene back out from nothing (a
+  Show), both centred on the screen — `Game::Transition` stays pure logic with
+  no scene/player access, so it does not follow EasyRPG's own hero-position
+  centring on the map. `Scene::Map` snapshots the screen the same way it
+  already does for scroll and combine / division, but composites zoom's one
+  piece with `Bitmap#stretch_blt` instead of `blt`, since the destination and
+  source rects now differ in size. The RPG2003 test-bed's real Erase/Show
+  Screen parameters (`scripts/analyze_game.rb --params --code 11010/11020
+  data/mtf-meido-action/Debug`) confirm setting 16 is genuine, in-use data.
+  Mosaic / wave and random blocks still fall through to the plain fade: mosaic
+  and wave want a native per-pixel resample, and random blocks wants RPG_RT's
+  incremental per-frame block paint. Covered by new checks in
+  `scripts/rpg2k_scene_check.rb` (per-style geometry at the start and end of a
+  zoom-in and a zoom-out transition).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1859,10 +1859,10 @@ The work below is roughly ordered by the critical path to a walkable game
   screen being left against the screen being arrived at (one of the two is always
   solid black). That draws the blinds, the vertical / horizontal stripes and the
   border-to-centre / centre-to-border windows for real. Remaining: the styles a
-  black mask cannot express — the scrolls and the combine / division pairs slide
-  the live scene itself, zoom / mosaic / wave resample it, and random blocks wants
-  thousands of block blits a frame — which run as a fade of the right length and
-  the right end state for now.
+  black mask cannot express — the scrolls, the combine / division pairs and zoom
+  slide or resample the live scene itself, mosaic / wave resample it too, and
+  random blocks wants thousands of block blits a frame — which run as a fade of
+  the right length and the right end state for now.
 
   **That remainder was written up as blocked on a screen capture the renderer
   does not have. It is not: `RGSS::Graphics.snap_to_bitmap` exists, is tested
@@ -1871,8 +1871,8 @@ The work below is roughly ordered by the critical path to a walkable game
   and it answers nil there), and the **RPG Maker XP scene already uses it**
   (`mruby-rpgxp/mrblib/scene.rb`) for exactly this — its own transitions.** The
   same mistake as the fade/flash note below: a capability assumed missing that
-  was already there. What was left per style (scroll and combine / division are
-  now done — see below):
+  was already there. What was left per style (scroll, combine / division and
+  zoom are now done — see below):
 
   - ✅ **Scroll (settings 9–12)** and **combine / division (13–15)**: capture the
     outgoing screen once when the transition starts, then each frame paint the
@@ -1880,7 +1880,11 @@ The work below is roughly ordered by the critical path to a walkable game
     sliding offset — rather than as a mask. `Bitmap#blt` is enough; no native
     work. The overlay is opaque and above everything, so painting the whole
     frame into it is what lets the scene appear to move, which a mask cannot do.
-  - **Zoom (16)**: the same, with `stretch_blt` instead of `blt`.
+  - ✅ **Zoom (16)**: the same, with `Bitmap#stretch_blt` instead of `blt` — the
+    destination is always the full screen, and it is the *source* rect that
+    shrinks toward (an Erase) or grows from (a Show) the screen centre, so
+    stretching that shrinking/growing crop over the whole screen is what reads
+    as zooming in.
   - **Mosaic (17) / wave (18)**: per-pixel resampling. `get_pixel`/`set_pixel`
     exist but a full-screen loop per frame in Ruby is far too slow, so these are
     the only two that genuinely want a native pass.
@@ -1898,27 +1902,46 @@ The work below is roughly ordered by the critical path to a walkable game
   which is what makes the family worth finishing (`ruby scripts/analyze_game.rb
   --params --code 11010 data/mtf-meido-action/Debug`).
 
-  **Scroll and combine / division are done.** `Game::Transition#capture_ops`
+  **Scroll, combine / division and zoom are done.** `Game::Transition#capture_ops`
   computes, per style, where each piece of a captured screen goes this frame
   (a plain offset for the four scroll directions; two sliding pieces for
-  vertical/horizontal combine and division; four for cross), staying pure
-  logic exactly like `#visible_rects` above — no `Graphics` access, so it is
-  unit-testable without a renderer. `Scene::Map#draw_captured_transition`
-  snapshots the screen once (on the frame a captured `Game::Transition`
-  instance first appears, by object identity, so a same-style transition
-  right after it still re-snapshots) and blits the pieces over a black fill
-  every frame after, disposing the snapshot once the transition ends. The
-  wrinkle above did not end up mattering in practice: a shaped transition still
-  runs a plain fade at the moment a captured one starts (the two families
-  never chain outside a hand-built sequence), so there was no erase overlay
-  hiding the scene to worry about excluding — worth revisiting if that
-  assumption stops holding. Cross combine/division's exact quadrant motion
-  (diagonal from each screen corner) is this build's own reading, not
-  confirmed against RPG_RT — neither test bed exercises that specific style,
-  so the vertical/horizontal pair's confirmed-by-name motion was extended
-  rather than guessed from nothing. Covered by new checks in
-  `scripts/rpg2k_scene_check.rb`. Zoom, mosaic/wave and random blocks are
-  still unbuilt, per the per-style breakdown above.
+  vertical/horizontal combine and division; four for cross; one resampled crop
+  for zoom), staying pure logic exactly like `#visible_rects` above — no
+  `Graphics` access, so it is unit-testable without a renderer.
+  `Scene::Map#draw_captured_transition` snapshots the screen once (on the frame
+  a captured `Game::Transition` instance first appears, by object identity, so
+  a same-style transition right after it still re-snapshots) and composites the
+  pieces over a black fill every frame after — `blt` for every style but zoom,
+  `stretch_blt` for zoom (`Game::Transition#zoom?`) — disposing the snapshot
+  once the transition ends. The wrinkle above did not end up mattering in
+  practice: a shaped transition still runs a plain fade at the moment a
+  captured one starts (the two families never chain outside a hand-built
+  sequence), so there was no erase overlay hiding the scene to worry about
+  excluding — worth revisiting if that assumption stops holding. Cross
+  combine/division's exact quadrant motion (diagonal from each screen corner)
+  is this build's own reading, not confirmed against RPG_RT — neither test bed
+  exercises that specific style, so the vertical/horizontal pair's
+  confirmed-by-name motion was extended rather than guessed from nothing.
+
+  Zoom's own IN/OUT direction — which way the picture scales — used to have
+  nothing in either test bed to confirm it against and was left rather than
+  guessed. It is confirmed now: EasyRPG's `transition.cpp` always draws zoom's
+  destination as the full screen (`dst.StretchBlit(Rect(0, 0, w, h), *screen,
+  Rect(z_pos, z_size), 255)`) and instead shrinks or grows the *source* crop —
+  `z_size` ramps from the full capture down to nothing over the transition for
+  `TransitionZoomIn`, and the same ramp run backwards (from nothing up to the
+  full capture) for `TransitionZoomOut` — so **ZOOM_IN shrinks the departing
+  scene down to nothing (an Erase) and ZOOM_OUT grows the arriving scene back
+  out (a Show)**, both centred on the screen (EasyRPG itself centres on the
+  hero's screen position when the scene is the map; this class stays pure
+  geometry with no scene/player access, so it anchors on the screen centre
+  unconditionally, the same simplification cross combine/division's quadrant
+  motion above already documents). The RPG2003 test-bed's own Erase/Show Screen
+  parameters confirm setting 16 (zoom) is real, in-use data, not a corner case:
+  `ruby scripts/analyze_game.rb --params --code 11010 data/mtf-meido-action/Debug`
+  and `--code 11020` each show one use of param0 `16` among their mode tables.
+  Covered by new checks in `scripts/rpg2k_scene_check.rb`. Mosaic/wave and
+  random blocks are still unbuilt, per the per-style breakdown above.
 
   The fade and flash overlays were listed here as blocked on `RGSS::Viewport`
   tone/alpha support in C++. **They were not**: `RGSS::Sprite#opacity` already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4869,25 +4869,24 @@ module Game
       CROSS_COMBINE, ZOOM_OUT, MOSAIC_IN, WAVE_IN, CUT_IN
     ].freeze
 
-    # The scroll and combine / division styles: a black mask cannot express them
-    # (the true old/new pixels have to move), so Scene::Map instead snapshots the
-    # screen once via RGSS::Graphics.snap_to_bitmap when one of these starts and
-    # blits that capture per #capture_ops every frame -- see docs/TODO.md's
-    # "Screen effects" entry. This class stays pure logic (no Graphics access,
-    # per the SCREEN_W/H comment above): it only computes where each piece of
-    # the capture goes.
+    # The scroll, combine / division and zoom styles: a black mask cannot
+    # express them (the true old/new pixels have to move or resample), so
+    # Scene::Map instead snapshots the screen once via
+    # RGSS::Graphics.snap_to_bitmap when one of these starts and composites
+    # that capture per #capture_ops every frame -- see docs/TODO.md's "Screen
+    # effects" entry. This class stays pure logic (no Graphics access, per the
+    # SCREEN_W/H comment above): it only computes where each piece of the
+    # capture goes.
     CAPTURED = [SCROLL_UP_IN, SCROLL_DOWN_IN, SCROLL_LEFT_IN, SCROLL_RIGHT_IN,
                 SCROLL_UP_OUT, SCROLL_DOWN_OUT, SCROLL_LEFT_OUT,
                 SCROLL_RIGHT_OUT, VERTICAL_COMBINE, VERTICAL_DIVISION,
                 HORIZONTAL_COMBINE, HORIZONTAL_DIVISION, CROSS_COMBINE,
-                CROSS_DIVISION].freeze
+                CROSS_DIVISION, ZOOM_IN, ZOOM_OUT].freeze
 
-    # Styles this build paints for real. Zoom / mosaic / wave still fall through
-    # to a plain fade: mosaic and wave want a native per-pixel resample and zoom's
-    # own IN/OUT direction (which way the picture scales) has nothing in either
-    # test bed to confirm it against, so it is left rather than guessed. Random
-    # blocks wants RPG_RT's incremental per-frame block paint, which a mask can
-    # express but this does not do yet either.
+    # Styles this build paints for real. Mosaic / wave still fall through to a
+    # plain fade -- they want a native per-pixel resample, which is not built
+    # yet. Random blocks wants RPG_RT's incremental per-frame block paint,
+    # which a mask can express but this does not do yet either.
     DRAWN = [FADE_IN, FADE_OUT, BLIND_OPEN, BLIND_CLOSE, VERTICAL_STRIPES_IN,
              VERTICAL_STRIPES_OUT, HORIZONTAL_STRIPES_IN,
              HORIZONTAL_STRIPES_OUT, BORDER_TO_CENTER_IN, BORDER_TO_CENTER_OUT,
@@ -4996,10 +4995,20 @@ module Game
       CAPTURED.include?(@style)
     end
 
-    # The captured screen's pieces for this frame, each `[dx, dy, sx, sy, sw,
-    # sh]` -- paste the capture's `[sx, sy, sw, sh]` region at `(dx, dy)`. Only
-    # called for a captured style; Scene::Map paints these over a black fill, so
-    # a piece that has slid off-screen just leaves black behind it.
+    # Whether this captured style is drawn by resampling (stretch_blt) rather
+    # than pasted 1:1 (blt) -- Scene::Map uses this to pick which Bitmap method
+    # matches #capture_ops's return shape for this style (see #zoom_rect).
+    def zoom?
+      @style == ZOOM_IN || @style == ZOOM_OUT
+    end
+
+    # The captured screen's pieces for this frame. For every style but zoom,
+    # each piece is `[dx, dy, sx, sy, sw, sh]` -- paste the capture's `[sx, sy,
+    # sw, sh]` region at `(dx, dy)` with `Bitmap#blt` (destination size always
+    # matches source size). Zoom instead resamples, so its one piece is `[dx,
+    # dy, dw, dh, sx, sy, sw, sh]` for `Bitmap#stretch_blt` -- see #zoom?. Only
+    # called for a captured style; Scene::Map paints these over a black fill,
+    # so a piece that has slid (or shrunk) off leaves black behind it.
     def capture_ops
       case @style
       when SCROLL_UP_IN, SCROLL_DOWN_IN, SCROLL_LEFT_IN, SCROLL_RIGHT_IN,
@@ -5012,6 +5021,8 @@ module Game
         horizontal_split_ops(@style == HORIZONTAL_COMBINE)
       when CROSS_COMBINE, CROSS_DIVISION
         cross_split_ops(@style == CROSS_COMBINE)
+      when ZOOM_IN, ZOOM_OUT
+        [zoom_rect]
       else
         []
       end
@@ -5112,6 +5123,41 @@ module Game
        [right_dx, top_dy, left_w, 0, right_w, top_h],
        [left_dx, bottom_dy, 0, top_h, left_w, bottom_h],
        [right_dx, bottom_dy, left_w, top_h, right_w, bottom_h]]
+    end
+
+    # Zoom: the capture is drawn full-screen every frame, resampled from a
+    # source region that shrinks toward the screen's centre (ZOOM_IN, an
+    # Erase, shrinking the departing scene down to nothing) or grows back out
+    # from it (ZOOM_OUT, a Show, growing the arriving scene up to full size).
+    #
+    # Confirmed against EasyRPG's `transition.cpp`: the destination rect is
+    # always the full screen (`dst.StretchBlit(Rect(0, 0, w, h), *screen,
+    # Rect(z_pos, z_size), 255)`), and it is the *source* rect that shrinks or
+    # grows -- cropping progressively closer to the zoom point and stretching
+    # that crop to fill the screen is what reads as "zooming in" on it, rather
+    # than the drawn image itself shrinking to a small rect. `z_size` there
+    # ramps `(tf_off - z_cf) / tf_off` with `z_cf = current_frame` for
+    # ZoomIn (so it starts full and ends at zero) and `z_cf = tf_off -
+    # current_frame` for ZoomOut (the same ramp run backwards) -- the same
+    # shrink/grow direction this mirrors with #frame_ratio. That settles the
+    # IN/OUT direction this build's own comment used to say was "left rather
+    # than guessed": ZOOM_IN shrinks, ZOOM_OUT grows.
+    #
+    # EasyRPG's own zoom point is the hero's screen position on the map (the
+    # screen centre otherwise); this class stays pure geometry with no scene
+    # or player access (see the SCREEN_W/H comment above CAPTURED), so it
+    # anchors on the screen centre unconditionally -- the same simplification
+    # #cross_split_ops's own quadrant motion already documents.
+    def zoom_rect
+      p, d = frame_ratio
+      if @style == ZOOM_OUT
+        sw = @width * p / d
+        sh = @height * p / d
+      else
+        sw = @width - @width * p / d
+        sh = @height - @height * p / d
+      end
+      [0, 0, @width, @height, (@width - sw) / 2, (@height - sh) / 2, sw, sh]
     end
 
     # Blinds: 8-pixel bands, each closing (or opening) from its top edge by one

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -583,6 +583,11 @@ class RPG2k
       # leaves the black behind it. The snapshot is taken once, the first frame
       # this particular Game::Transition instance is drawn (identity, not
       # value, so a same-style transition right after it still re-snapshots).
+      #
+      # Zoom is the one captured style that resamples instead of pasting 1:1
+      # (see Game::Transition#zoom?): its single #capture_ops piece is `[dx,
+      # dy, dw, dh, sx, sy, sw, sh]` for `Bitmap#stretch_blt`, rather than the
+      # `[dx, dy, sx, sy, sw, sh]` every other style hands to `Bitmap#blt`.
       def draw_captured_transition(tr)
         unless @captured_transition.equal?(tr)
           @transition_capture.dispose if @transition_capture
@@ -598,8 +603,13 @@ class RPG2k
           return
         end
         @fade_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, OPAQUE_BLACK
-        tr.capture_ops.each do |dx, dy, sx, sy, sw, sh|
-          @fade_bmp.blt dx, dy, cap, Rect.new(sx, sy, sw, sh)
+        if tr.zoom?
+          dx, dy, dw, dh, sx, sy, sw, sh = tr.capture_ops.first
+          @fade_bmp.stretch_blt Rect.new(dx, dy, dw, dh), cap, Rect.new(sx, sy, sw, sh)
+        else
+          tr.capture_ops.each do |dx, dy, sx, sy, sw, sh|
+            @fade_bmp.blt dx, dy, cap, Rect.new(sx, sy, sw, sh)
+          end
         end
         @fade_masked = true
         @fade_sprite.opacity = 255

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8507,6 +8507,66 @@ check 'a captured transition falls back to a plain fade when the backend cannot 
   ok (fade.bitmap.blt_calls || []).empty?, 'nothing to blit without a snapshot'
 end
 
+check 'zoom in resamples a shrinking crop of the capture, stretched full-screen' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  snap = RGSS::Bitmap.new(320, 240)
+  RGSS::Graphics.snapshot = snap
+
+  st.screen.erase(Game::Transition::ZOOM_IN)
+  fade.bitmap.clear_stretch_calls
+  scene.update
+  eq 255, fade.opacity, 'a captured style paints, so it is fully opaque like a mask'
+  ok (fade.bitmap.blt_calls || []).empty?, 'zoom resamples, it never uses the 1:1 paste path'
+  stretches = fade.bitmap.stretch_calls || []
+  eq 1, stretches.length, 'zoom is a single resampled piece'
+  drect, src, srect = stretches.first
+  eq [0, 0, 320, 240], [drect.x, drect.y, drect.width, drect.height],
+     'the destination always fills the whole screen -- zoom crops the source, not the drawn size'
+  ok src.equal?(snap), 'resampled from the captured snapshot'
+  eq [4, 3, 312, 234], [srect.x, srect.y, srect.width, srect.height],
+     'frame 0 of zoom-in has barely cropped in from the full capture yet'
+
+  mid = Game::Transition.default_frames(Game::Transition::ZOOM_IN) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_stretch_calls
+  scene.update
+  srect = fade.bitmap.stretch_calls.first[2]
+  eq [160, 120, 0, 0], [srect.x, srect.y, srect.width, srect.height],
+     'finished: cropped down to nothing at the screen centre, so nothing paints over the black fill'
+ensure
+  RGSS::Graphics.snapshot = nil
+end
+
+check 'zoom out resamples a growing crop of the capture, stretched full-screen' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  st.screen.erase(Game::Transition::FADE_OUT, 1) # show is a no-op unless erased first
+  2.times { scene.update }
+  RGSS::Graphics.snapshot = RGSS::Bitmap.new(320, 240)
+
+  st.screen.show(Game::Transition::ZOOM_OUT)
+  fade.bitmap.clear_stretch_calls
+  scene.update
+  srect = fade.bitmap.stretch_calls.first[2]
+  eq [156, 117, 8, 6], [srect.x, srect.y, srect.width, srect.height],
+     'frame 0 of zoom-out starts as a sliver at the screen centre'
+
+  mid = Game::Transition.default_frames(Game::Transition::ZOOM_OUT) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_stretch_calls
+  scene.update
+  srect = fade.bitmap.stretch_calls.first[2]
+  eq [0, 0, 320, 240], [srect.x, srect.y, srect.width, srect.height],
+     'finished: the crop has grown back out to the whole capture'
+ensure
+  RGSS::Graphics.snapshot = nil
+end
+
 check 'Flash Screen drives the flash layer, and refills only on a colour change' do
   scene = new_scene({}, player: [5, 5])
   _, flash = overlay(scene)


### PR DESCRIPTION
## Summary

- Erase / Show Screen's **Zoom (setting 16)** transition now paints real pixels instead of falling through to a plain fade. This is the next item in docs/TODO.md's "Screen effects" bullet, right after Scroll (9-12) and combine/division (13-15), which serve as the template.
- Confirmed Zoom's real IN/OUT scaling direction from EasyRPG's `transition.cpp` rather than guessing (the code previously had a comment saying this direction was "left rather than guessed"): zoom always draws the destination as the full screen and shrinks/grows the *source* crop it resamples from — `ZOOM_IN` shrinks the departing scene down to nothing (an Erase), `ZOOM_OUT` grows the arriving scene back out from nothing (a Show). Both are centred on the screen, since `Game::Transition` stays pure geometry with no scene/player access (unlike EasyRPG, which centres on the hero's screen position on the map).
- `Game::Transition::CAPTURED` now includes `ZOOM_IN`/`ZOOM_OUT`, and `#capture_ops` computes zoom's single resampled piece the same pure-logic, unit-testable way it already does for scroll and combine/division.
- `Scene::Map#draw_captured_transition` composites zoom's piece with `Bitmap#stretch_blt` instead of `blt`, since destination and source rects now differ in size (`Game::Transition#zoom?` picks the path).
- The RPG2003 test-bed (`data/mtf-meido-action`) confirms setting 16 is real, in-use data: `ruby scripts/analyze_game.rb --params --code 11010/11020 data/mtf-meido-action/Debug` each show one real use of param0 `16`.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 523 checks passed, including two new checks covering zoom-in and zoom-out geometry at the start and end of the transition (stretch_blt destination always full-screen, source crop shrinking/growing correctly, falling back to blt never happening for zoom).
- [x] `ruby scripts/rpg2k_logic_check.rb` — 781 checks passed (unaffected, but touches `Game::Transition`).
- [x] `ruby -c` syntax check on all touched Ruby files.
- [x] `pre-commit run trailing-whitespace end-of-file-fixer check-yaml check-added-large-files` on touched files (nixfmt/clang-format hooks are not applicable — no `.nix`/C++ files touched, and the sandboxed `cabal`-based nixfmt hook can't install here).
- [x] `docs/TODO.md`'s "Screen effects" bullet updated to move Zoom from the remaining list to done, matching the Scroll/Combine writeup.
- [x] Changelog fragment added: `changelog.d/rpg2k-transition-zoom.added.md`.

Scope note: this stays within `Game::Transition` (mruby-rpg2k/mrblib/game.rb) and the transition-drawing code in `mruby-rpg2k/mrblib/scene/map.rb`, per the parallel-session split; it does not touch `Game::Message`/`TextReveal` or the save schema.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NBP8CZw5tNeSracHbkHHW9)_