### PR TITLE
Round-trip Change Actor Title through .lsd Save/Continue

### DIFF
--- a/changelog.d/save-actor-title-override.fixed.md
+++ b/changelog.d/save-actor-title-override.fixed.md
@@ -1,0 +1,24 @@
+- **A Change Actor Title override now survives Save/Continue through a real
+  `.lsd`.** `LCF::Schema::SAVE_PARTY_ACTOR` (chunk 108)'s field 2 was left
+  undecoded because it stayed constant in the one sampled real save, so it
+  was not provably the title field from that sample alone. It is now
+  confirmed against EasyRPG's `liblcf` (`generator/csv/fields.csv`), whose
+  `SaveActor` struct documents field `0x02` as `title` (`String`) right next
+  to `0x01` `name` — and every other already-confirmed field in this table
+  matches liblcf's hex tag decimal-for-decimal (`0x1F`→31 `level`, `0x20`→32
+  `exp`, `0x33`→51 `skill_size`, `0x34`→52 `skills`, `0x3D`→61 `equipped`,
+  `0x47`→71 `current_hp`, `0x48`→72 `current_sp`, `0x51`→81 `status` count,
+  `0x52`→82 `status`), so `0x02`→2 `title` follows the same scheme; liblcf
+  also identifies the other two previously-ambiguous constant bytes as
+  `hp_mod` (`0x21`→33) and `sp_mod` (`0x22`→34) — unconfirmed stat modifiers,
+  not the title. Field 2 (`title`) is now decoded, `Game::State#to_lsd`
+  writes every roster actor's current title into it, and
+  `Game::State.from_lsd` restores it — an empty string is applied as a
+  legitimate cleared title (`do_change_actor_title` explicitly lets an empty
+  command string clear the title, unlike Change Actor Name's blank-is-
+  unchanged rule), skipping only the reserve-actor placeholder byte. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check (a renamed leader and a
+  renamed non-leader roster member both come back with their titles from an
+  in-memory `to_lsd`/`from_lsd` round-trip, plus a cleared title round-trips
+  as an empty string), confirmed to fail against the pre-fix code (the
+  leader's title came back as the database default) before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2294,9 +2294,7 @@ The work below is roughly ordered by the critical path to a walkable game
   `Game::State#to_lsd` writes every roster actor's current name into it (not
   just the leader's), and `.from_lsd` restores it for every actor the chunk
   covers — the leader's chunk-100 restore stays too, as a redundant
-  belt-and-braces source applied last. **Still not modelled: Change Actor
-  *Title***, since fields 2/33/34 stayed constant in the one sampled save and
-  are not provably the title field. Covered by a new `scripts/
+  belt-and-braces source applied last. Covered by a new `scripts/
   rpg2k_logic_check.rb` check (a renamed leader and a renamed non-leader
   roster member both come back correctly named from an in-memory
   `to_lsd`/`from_lsd` round-trip — no bytes serialised, since `Array1D#[]=`
@@ -2306,6 +2304,29 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_save_load_check.rb` already does), confirmed to fail against
   the pre-fix code (the non-leader's name came back as its un-renamed
   database default) before the fix.
+  ✅ **A Change Actor Title override now round-trips through the `.lsd` too.**
+  Chunk 108's field 2 stayed constant in the one sampled real save, so it was
+  not provably the title field from that sample alone; it is now confirmed
+  against EasyRPG's `liblcf` (`generator/csv/fields.csv`), whose `SaveActor`
+  struct documents field `0x02` as `title` (`String`) right next to `0x01`
+  `name` — and every other already-confirmed field in `SAVE_PARTY_ACTOR`
+  matches liblcf's hex tag decimal-for-decimal (`0x1F`→31 `level`, `0x20`→32
+  `exp`, `0x33`→51 `skill_size`, `0x34`→52 `skills`, `0x3D`→61 `equipped`,
+  `0x47`→71 `current_hp`, `0x48`→72 `current_sp`, `0x51`→81 `status` count,
+  `0x52`→82 `status`), so `0x02`→2 `title` follows the same scheme; liblcf also
+  identifies the other two constant bytes as `hp_mod` (`0x21`→33) and `sp_mod`
+  (`0x22`→34), unconfirmed stat modifiers rather than the title, closing the
+  ambiguity. `LCF::Schema::SAVE_PARTY_ACTOR` now decodes it (`title`),
+  `Game::State#to_lsd` writes every roster actor's current title into it, and
+  `.from_lsd` restores it — an empty string is applied as a legitimate
+  cleared title (unlike `actor_name`'s blank-is-unchanged rule, since
+  `do_change_actor_title` explicitly lets an empty command string clear the
+  title), and only the reserve-actor placeholder byte is skipped. Covered by a
+  new `scripts/rpg2k_logic_check.rb` check (a renamed leader and a renamed
+  non-leader roster member both come back with their titles from an in-memory
+  `to_lsd`/`from_lsd` round-trip, plus a cleared title round-trips as an empty
+  string), confirmed to fail against the pre-fix code (the leader's title came
+  back as the database default) before the fix.
   ✅ **A real save/load file-select screen (`Scene::SaveLoad`) now sits between
   the player and every slot.** The main menu's Save command and the title
   screen's Continue entry used to act on a single hardcoded slot; both now

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1038,13 +1038,23 @@ module LCF
     # stored name matches the SAVE_TITLE hero_name exactly, which is what
     # confirmed it — and is now modelled, so a Change Actor Name override on a
     # *non*-leader party member round-trips through Save/Continue too (chunk
-    # 100's title only ever carried the leader's). Fields 2/33/34 are single
-    # bytes that are constant in the sampled save, so their meaning is not yet
-    # provable; in particular field 2 is not confirmed to be the actor's title
-    # (Change Actor Title), so that override still does not survive a real
-    # `.lsd` round-trip.
+    # 100's title only ever carried the leader's). Field 2 (the actor's
+    # renamable title, Change Actor Title) was a single byte constant in the
+    # one sampled save, so it was not provable from that save alone; it is now
+    # confirmed against EasyRPG's `liblcf` (`generator/csv/fields.csv`), whose
+    # `SaveActor` struct documents field `0x02` as `title` (`String`) right
+    # next to `0x01` `name` — and every other already-confirmed field in this
+    # table matches liblcf's hex tag decimal-for-decimal (`0x1F`→31 `level`,
+    # `0x20`→32 `exp`, `0x33`→51 `skill_size`, `0x34`→52 `skills`, `0x3D`→61
+    # `equipped`, `0x47`→71 `current_hp`, `0x48`→72 `current_sp`, `0x51`→81
+    # `status` count, `0x52`→82 `status`), so `0x02`→2 `title` follows the same
+    # scheme. The other two single bytes that were constant in the sampled save
+    # are also identified by liblcf as `hp_mod` (`0x21`→33) and `sp_mod`
+    # (`0x22`→34) — unconfirmed stat modifiers, not the title — which is why
+    # they stay undecoded here.
     SAVE_PARTY_ACTOR = {
       1 => { name: :actor_name, type: :string },            # 名前
+      2 => { name: :title, type: :string },                 # 二つ名 (Change Actor Title)
       31 => { name: :level, type: :int, default: 1 },      # レベル
       32 => { name: :exp, type: :int, default: 0 },        # 経験値
       51 => { name: :skill_size, type: :int, default: 0 }, # 『特技』情報のデータ数

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9554,9 +9554,9 @@ module Game
     # it. See ADR 0021.
     #
     # Both Timer Operation countdowns and every roster member's Change Actor
-    # Name override round-trip now too (see LCF::Schema::SAVE_INVENTORY's
-    # timer1_*/timer2_* fields and SAVE_PARTY_ACTOR's actor_name), so this is
-    # a near-parity export; Change Actor Title still is not (see docs/TODO.md).
+    # Name and Change Actor Title overrides round-trip now too (see
+    # LCF::Schema::SAVE_INVENTORY's timer1_*/timer2_* fields and
+    # SAVE_PARTY_ACTOR's actor_name/title), so this is a near-parity export.
     def to_lsd(save_count = 1, timestamp = nil)
       timestamp = State.ole_now if timestamp.nil?
       save = LCF::SaveData.new
@@ -9660,6 +9660,10 @@ module Game
         # member -- not just the leader, who also gets it via chunk 100's
         # title -- survives Save/Continue.
         e[1] = a.name
+        # Field 2 is the actor's current title (renamed or not by Change
+        # Actor Title), confirmed against liblcf's SaveActor field table --
+        # see SAVE_PARTY_ACTOR's comment in schema.rb.
+        e[2] = a.title
         e[31] = a.level
         e[32] = a.exp
         e[51] = a.skills.size
@@ -9760,6 +9764,12 @@ module Game
           # later lookup by name (see the title-chunk leader fixup below).
           nm = sa.actor_name
           actor.name = nm if nm && !nm.empty? && nm != "\x01"
+          # Field 2 (title) has no equivalent "blank means unchanged" rule --
+          # do_change_actor_title explicitly lets an empty string *clear* the
+          # title -- so an empty string is applied, unlike actor_name above;
+          # only the reserve-actor placeholder byte is skipped.
+          tt = sa.title
+          actor.title = tt if tt && tt != "\x01"
         end
         hp[aid] = sa.hp if sa.hp
         mp[aid] = sa.mp if sa.mp

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2906,6 +2906,36 @@ check 'to_lsd/from_lsd round-trips a non-leader actor\'s Change Actor Name' do
      "a non-leader's renamed name now round-trips too, via chunk 108 field 1"
 end
 
+check 'to_lsd/from_lsd round-trips a Change Actor Title override' do
+  # Chunk 108 (SAVE_PARTY_ACTOR) field 2 was left undecoded because it stayed
+  # constant in the one sampled real save; it is now confirmed as the title
+  # against liblcf's own SaveActor field table (see schema.rb's comment), so a
+  # Change Actor Title override should survive Save/Continue the same way
+  # Change Actor Name already does.
+  players = {
+    1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8),
+    2 => FakePlayerRow.new('Ally', '', 0, 3, max_hp: 50, max_mp: 20, atk: 6, def: 5),
+  }
+  db = FakeActorDB.new(players, [1])
+  party = Game::Party.new(db)
+  party.add_actor(2)
+  st = Game::State.new(party, 1, 0, 0)
+  st.party.leader.title = 'Renamed Title'
+  st.party.actor_by_id(2).title = 'Ally Title'
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq 'Renamed Title', round.party.leader.title, "the leader's Change Actor Title round-trips"
+  eq 'Ally Title', round.party.actor_by_id(2).title,
+     "a non-leader's Change Actor Title round-trips too, via chunk 108 field 2"
+
+  # An empty string is a legitimate Change Actor Title (it explicitly clears
+  # the title), unlike an empty Change Actor Name -- so it must round-trip too,
+  # not be treated as "no override" the way actor_name's blank guard does.
+  st.party.leader.title = ''
+  cleared = Game::State.from_lsd(db, st.to_lsd)
+  eq '', cleared.party.leader.title, 'a cleared title round-trips as an empty string, not the database default'
+end
+
 check 'to_lsd/from_lsd round-trips both Timer Operation countdowns' do
   # docs/TODO.md used to call the game timer the one field the .lsd export
   # "cannot yet carry", guessing it would need "a documented chunk id" of its


### PR DESCRIPTION
## Summary

- `LCF::Schema::SAVE_PARTY_ACTOR` (chunk 108) field 2 stayed constant in the one previously-sampled real save, so it was not provably the *Change Actor Title* field from that sample alone (`docs/TODO.md` and `Game::State#to_lsd`'s own comment both flagged it as the one gap left in the Save/Continue `.lsd` export).
- It is now confirmed against EasyRPG's `liblcf` (`generator/csv/fields.csv`), whose `SaveActor` struct documents field `0x02` as `title` (`String`) right next to `0x01` `name`. Every other already-confirmed field in `SAVE_PARTY_ACTOR` matches liblcf's hex tag decimal-for-decimal (`0x1F`→31 `level`, `0x20`→32 `exp`, `0x33`→51 `skill_size`, `0x34`→52 `skills`, `0x3D`→61 `equipped`, `0x47`→71 `current_hp`, `0x48`→72 `current_sp`, `0x51`→81 `status` count, `0x52`→82 `status`), so `0x02`→2 `title` follows the same scheme. liblcf also identifies the other two previously-ambiguous constant bytes as `hp_mod` (`0x21`→33) and `sp_mod` (`0x22`→34) — unconfirmed stat modifiers, not the title — which resolves the ambiguity `docs/TODO.md` used to call out.
- `SAVE_PARTY_ACTOR` now decodes field 2 (`title`), `Game::State#to_lsd` writes every roster actor's current title into it, and `Game::State.from_lsd` restores it. An empty string is applied as a legitimate cleared title (unlike Change Actor Name's blank-is-unchanged rule), since `do_change_actor_title` explicitly lets an empty command string clear the title; only the reserve-actor placeholder byte (`"\x01"`) is skipped, mirroring `actor_name`'s existing handling.
- Updated `docs/TODO.md`'s "Save & Continue" bullet and `Game::State#to_lsd`'s own comment to reflect that Change Actor Title now round-trips too.

## Investigation

Per the task, I tried to confirm the byte against a real save before touching the schema:
- Downloaded both available test-bed games (`scripts/download-nepheshel.bash`, `scripts/download-mtf-meido-action.bash`) and ran `ruby scripts/analyze_game.rb --params --code 10620 <dir>` against each — neither game uses the Change Actor Title (10620) opcode, so no reachable in-game trigger was available to generate a genuine `.lsd` sample exercising it (and this sandbox has no `wine`, which the existing `gen-lcf-save-wine.bash` pipeline needs to synthesize one via EasyRPG Player's debug menu).
- Instead I found a stronger, independent source: EasyRPG's `liblcf` — the reference C++ implementation of this exact save format, already cited elsewhere in this repo (e.g. ADR 0020, `docs/TODO.md`'s Timer Operation fields) — whose generator CSV explicitly documents field `0x02` of `SaveActor` as `title` (`String`). Cross-checking every other field id in `SAVE_PARTY_ACTOR` against liblcf's table lines up exactly, which gives high confidence this is correct rather than a guess.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 782 checks pass, including a new check that round-trips a leader's and non-leader's Change Actor Title override (and a cleared title) through an in-memory `to_lsd`/`from_lsd`.
- [x] Confirmed the new check fails against the pre-fix code (stashing just the schema/game.rb changes) before the fix.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-added-large-files; `nixfmt` skipped — no `.nix` files touched and `cabal` is unavailable in this sandbox).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F6q84isg9ZQCqLf6p6MNni)_