### PR TITLE
Implement \s[n] message typing-speed control code

### DIFF
--- a/changelog.d/message-speed-control-code.added.md
+++ b/changelog.d/message-speed-control-code.added.md
@@ -1,0 +1,12 @@
+- **The `\s[n]` message control code (typewriter speed) is implemented**,
+  previously dropped outright. `Game::Message.scan` records each `\s[n]` in
+  revealed-character coordinates (`n` clamped to RPG_RT's real 1..20 range,
+  confirmed against EasyRPG Player's `window_message.cpp` rather than the
+  editor's own documentation), and `Game::TextReveal` picks the speed in
+  effect at the current reveal position, banking its per-frame character
+  budget fractionally so a slower speed still reveals whole characters over
+  several frames instead of stalling. `\s[]` produces no characters and
+  burns no reveal tick, matching `\c[]`. As a consequence, the previously
+  open "`\c[]`/`\s[]` bleed into an attached Show Choices list" finding is
+  now fully resolved: a Show Choices list always reveals instantly, so the
+  new speed state has nothing to bleed into.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1703,6 +1703,37 @@ The work below is roughly ordered by the critical path to a walkable game
   `scripts/rpg2k_scene_check.rb` checks that drive a `\.`/`\|` pause end to
   end and count the exact number of frames the reveal stays held, both
   confirmed to fail against the pre-fix code (15/60) before the fix.
+  ✅ **`\s[n]` (typing speed) is now implemented, no longer dropped.**
+  `Game::Message.scan` (`mruby-rpg2k/mrblib/game.rb`) records each `\s[n]` as
+  a `{ at:, speed: }` entry in a new `:speeds` list (revealed-character
+  coordinates, same as `:pauses`/`:instants`), `n` clamped to RPG_RT's real
+  1..20 range — confirmed against EasyRPG Player's `window_message.cpp`,
+  fetched verbatim (`speed = Utils::Clamp(pres.value, 1, 20)`), not the
+  editor's own documentation, following this file's established
+  check-the-source-not-the-docs methodology (the same one that caught the
+  16/61-not-15/60 `\.`/`\|` gap two paragraphs up). `\s[]` produces no
+  characters and burns no reveal tick, matching `\c[]`. `Game::TextReveal`
+  threads a `speeds` list through and picks the `\s[n]` in effect at the
+  current reveal position (`#speed_at`, 1 = full speed, RPG_RT's own default
+  before the first change); `#advance` banks its per-frame character budget
+  in a fractional `@carry` while a slower speed is active, so e.g. speed 3
+  reveals roughly one character every three frames instead of stalling
+  outright, the same "consume a pacing span, don't just note it" shape
+  `:pauses`/`:instants` already established. This is a simplification of
+  RPG_RT's own pixel-width-scaled per-character wait
+  (`Window_Message::SetWaitForCharacter`: `frames = speed * width / 2 + 1`)
+  down to this codebase's fixed-budget-per-frame typewriter model, not a
+  glyph-width simulation — the duration still scales linearly with `speed`,
+  which is the part that matters for the control code to have an observable
+  effect. `Scene::Map#open_message` collects the per-line `:speeds` the same
+  way it already does `:pauses`/`:instants` and passes them into the
+  `Game::TextReveal` it builds. Covered by new `scripts/rpg2k_logic_check.rb`
+  checks (`Message.scan`'s clamped `:speeds` list; `TextReveal#speed_at`;
+  `TextReveal#advance` revealing at a fraction of its base rate across a
+  `\s[3]` span) and a new `scripts/rpg2k_scene_check.rb` check driving a real
+  `\s[4]` message through `Scene::Map` end to end, all confirmed to fail
+  against the old code, which dropped `\s[]` outright and revealed at a flat
+  rate regardless of it.
 - ✅ Common events — auto-start common events run once on the map, and parallel
   common events now run **continuously** in the background alongside the player
   via their own looping interpreter (`Scene::Map#step_parallels`), each gated by
@@ -5040,9 +5071,10 @@ not yet verified:
   (`\N[5]`, `\V[1]`) resolved exactly as before. `\C[]`/`\S[]` are untouched
   — the site's wording doesn't name them as nesting-capable, only as
   degrading gracefully out of range, which they already do (`\C[]` falls
-  back to a flat colour for an out-of-range index, already implemented;
-  `\S[]` is dropped outright today, a separate open question tracked in the
-  Message window doc above). An out-of-range `\N[]` argument crashing real
+  back to a flat colour for an out-of-range index; `\S[]` clamps to RPG_RT's
+  1..20 range instead, both already implemented — neither reads its bracket
+  argument through `#resolve_arg`, so a nested `\V[]` inside either is not a
+  case this fix covers). An out-of-range `\N[]` argument crashing real
   RPG_RT is a genuine engine crash, not reproduced here. Covered by a new
   `scripts/rpg2k_logic_check.rb` check, confirmed to fail against the
   pre-fix code.
@@ -5781,10 +5813,10 @@ not yet verified:
   call — caller and callee — finishes), confirmed to fail against the
   pre-fix code before the fix. It also shrinks the per-line text capacity
   vs. no portrait — unverified, a separate open question.
-- 🚧 \c[]/\s[] (color/speed) control codes set inside Show Text **bleed into
+- ✅ \c[]/\s[] (color/speed) control codes set inside Show Text **bleed into
   an attached Show Choices list** when the two merge into one window
   (≤4 combined lines) — an explicit `\c[0]` reset is needed to stop
-  choices inheriting the preceding text's color. **The colour half is now
+  choices inheriting the preceding text's color. **The colour half is
   implemented**: `Game::Message.scan` takes an optional `start_color` and
   reports the colour still in effect at the end of the line as `:end_color`
   (`mruby-rpg2k/mrblib/game.rb`), and `Scene::Map#open_message` records a
@@ -5792,12 +5824,17 @@ not yet verified:
   now seeds its own scans with instead of always starting at 0 — chained
   across the choice labels themselves too, so the whole merged window (text
   then choices) reads as one continuous colour stream that an explicit
-  `\c[0]` breaks, matching the finding. **The speed half is not addressed**:
-  this codebase drops `\s[]` outright today (see the Message window doc
-  above, "the remaining display code (`\s` speed) is dropped") rather than
-  varying the reveal rate at all, so there is no speed *state* yet for
-  anything to bleed — implementing the bleed would first need `\s[]` itself,
-  a larger, separate feature.
+  `\c[0]` breaks, matching the finding. **The speed half is now moot, not
+  just unaddressed**: `\s[]` is implemented today (see the Message window
+  doc above) and does vary the reveal rate, but a Show Choices list — whether
+  standalone or merged onto a preceding Show Text — always calls
+  `Game::TextReveal#reveal_all` the instant it is built
+  (`Scene::Map#open_message`/`#append_choice_lines`) rather than typing out
+  gradually, the same reason a `\^` inside one is already confirmed inert
+  below. A speed that only throttles a typewriter that never runs for choice
+  labels has nothing to bleed into; `#append_choice_lines` does not even
+  thread a `:speeds` list into the `Game::TextReveal` it builds. No code
+  change needed here beyond `\s[]` itself existing.
 - `\>` (instant display) only affects the current line — must be repeated
   per line for a fully-instant multi-line message.
 - ✅ **`\<`, `\$`, `\^` each cost one character's worth of display time even

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -70,9 +70,11 @@ module Game
 
   # Expansion of RPG2000 message control codes. `\v[n]` inserts variable n,
   # `\n[n]` the name of actor n, `\\` a literal backslash, `\_` a space; `\c[n]`
-  # changes colour. The pacing codes `\.`/`\|`/`\!` (waits), `\^` (auto-close),
-  # `\>`/`\<` (instant span) and `\$` (show the gold window) are surfaced by #scan
-  # for the scene to act on; the remaining display code (`\s` speed) is dropped.
+  # changes colour and `\s[n]` changes the typewriter speed (1..20, RPG_RT's own
+  # clamp -- EasyRPG Player's `window_message.cpp` `Utils::Clamp(pres.value, 1,
+  # 20)`). The pacing codes `\.`/`\|`/`\!` (waits), `\^` (auto-close), `\>`/`\<`
+  # (instant span), `\$` (show the gold window) and `\s[n]` (speed change) are
+  # surfaced by #scan for the scene to act on.
   # `names` may be a Hash or any object responding to `[]`.
   module Message
     # Expand a line to its plain visible text (no colour information): the same
@@ -85,7 +87,7 @@ module Game
     # `{ text:, color: }`, where `color` is the `\c[n]` palette index in effect
     # for that run (0 = the default colour). `\v[n]` (variable) and `\n[n]`
     # (actor name) are expanded into the text and `\\` yields a literal
-    # backslash and `\_` a space; the pacing / display codes (`\s` speed,
+    # backslash and `\_` a space; the pacing / display codes (`\s[n]` speed,
     # `\.`/`\|`/`\!` waits, `\>`/`\<`, `\^`, `\$`) produce no characters here (see
     # #scan for the pacing ones). Runs with no text (e.g. a colour change before
     # any character) are omitted, so a line that renders nothing yields an empty
@@ -102,6 +104,9 @@ module Game
     #   :auto_close — `\^` (close the window without a keypress once revealed);
     #   :instants — [[start, end)] spans that reveal at once (`\>` … `\<`);
     #   :show_gold — `\$` (show the party's gold in a small window);
+    #   :speeds  — [{ at:, speed: }] for `\s[n]` speed changes, `speed` clamped
+    #              to RPG_RT's 1..20 (1 = full speed, the default before the
+    #              first one) and in effect from `at` until the next entry;
     #   :length  — the visible character count (what the reveal counts);
     #   :end_color — the colour still in effect once the line ends, for a
     #                caller that wants to carry it into the next scan (a Show
@@ -113,6 +118,7 @@ module Game
       segs = []
       pauses = []
       instants = []
+      speeds = []
       instant_start = nil # character index where an open `\>` span began
       auto_close = false
       show_gold = false
@@ -136,6 +142,10 @@ module Game
             segs << { text: cur, color: color } unless cur.empty?
             cur = ''
             color = arg ? arg.to_i : 0
+          when 's', 'S' # speed change: how fast the typewriter reveals from
+            # here on, clamped to RPG_RT's 1..20 (EasyRPG Player's
+            # window_message.cpp: `speed = Utils::Clamp(pres.value, 1, 20)`).
+            speeds << { at: count, speed: Game.clamp(arg ? arg.to_i : 1, 1, 20) }
           when '.'      then pauses << { at: count, kind: :quarter }
           when '|'      then pauses << { at: count, kind: :full }
           when '!'      then pauses << { at: count, kind: :key }
@@ -151,8 +161,6 @@ module Game
               instant_start = nil
               count += 1
             end
-          # the remaining display code (`\s` speed) produces no characters and no
-          # pacing here: dropped.
           end
         else
           cur << ch
@@ -163,7 +171,7 @@ module Game
       segs << { text: cur, color: color } unless cur.empty?
       instants << [instant_start, count] if instant_start # unclosed `\>` runs to EOL
       { segments: segs, pauses: pauses, auto_close: auto_close,
-        instants: instants, show_gold: show_gold, length: count,
+        instants: instants, show_gold: show_gold, speeds: speeds, length: count,
         end_color: color }
     end
 
@@ -297,8 +305,13 @@ module Game
     # unreleased one until the owner calls #release_pause. `auto_close` is the
     # `\^` flag (close the window without a keypress once fully revealed).
     # `instants` are [start, end) spans (`\>` … `\<`) that appear in one frame.
+    # `speeds` are `\s[n]` speed changes ({ at:, speed: }), sorted ascending;
+    # `speed` 1 (full speed, RPG_RT's default before the first one) reveals at
+    # the caller's own per-frame rate unchanged, and each step up slows the
+    # reveal proportionally (RPG_RT's own `Window_Message::SetWaitForCharacter`
+    # scales its per-character wait linearly by `speed`).
     def initialize(lines, revealed = 0, pauses = [], auto_close = false,
-                   instants = [])
+                   instants = [], speeds = [])
       @lines = lines || []
       @total = 0
       @lines.each { |l| @total += l.length }
@@ -308,7 +321,12 @@ module Game
       @pauses = (pauses || []).sort { |a, b| a[:at] <=> b[:at] }
       @auto_close = auto_close ? true : false
       @instants = instants || []
+      @speeds = (speeds || []).sort { |a, b| a[:at] <=> b[:at] }
       @released = 0 # how many leading pauses the owner has let through
+      @carry = 0 # fractional per-frame budget banked while a \s[] slowdown is
+                 # in effect, so a sub-1-character-per-frame rate still lands
+                 # on whole characters over several frames instead of rounding
+                 # every frame down to zero
     end
 
     attr_reader :revealed, :total
@@ -323,17 +341,41 @@ module Game
       @revealed = stop ? stop[:at] : @total
     end
 
-    # Reveal `n` more characters (default 1), never past the total nor past the
-    # next unreleased pause. When the newly revealed position lands inside an
-    # instant (`\>` … `\<`) span, the whole span appears at once (still capped at
-    # the pause limit).
+    # Reveal up to `n` more characters (default 1) at the caller's own base
+    # rate, never past the total nor past the next unreleased pause. The
+    # `\s[n]` speed in effect at the current position throttles that budget:
+    # at speed 1 (the default) the full `n` lands this frame, same as before
+    # `\s[]` existed; a higher speed banks the unused fraction in `@carry`
+    # instead of dropping it, so e.g. speed 3 reveals two characters every
+    # three frames rather than never advancing. When the newly revealed
+    # position lands inside an instant (`\>` … `\<`) span, the whole span
+    # appears at once (still capped at the pause limit).
     def advance(n = 1)
       n = 0 if n < 0
       stop = next_pause
       limit = stop ? stop[:at] : @total
-      pos = Game.clamp(@revealed + n, 0, limit)
+      return if @revealed >= limit # blocked on the pause: no time banked either
+      s = speed_at(@revealed)
+      @carry += n
+      step = @carry / s
+      @carry -= step * s
+      pos = Game.clamp(@revealed + step, 0, limit)
       pos = through_instant(pos) if pos > @revealed
       @revealed = Game.clamp(pos, 0, limit)
+    end
+
+    # The `\s[n]` speed in effect at revealed-character position `pos`: the
+    # most recent `\s[]` entry at or before it, or 1 (full speed) before the
+    # first one -- RPG2000's own default (EasyRPG Player's Window_Message
+    # resets `speed = 1` on every new page, only `\s[]` itself ever changes
+    # it).
+    def speed_at(pos)
+      s = 1
+      @speeds.each do |sp|
+        break if sp[:at] > pos
+        s = sp[:speed]
+      end
+      s
     end
 
     # If the next character to reveal (`pos`) falls inside an instant span, jump

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7387,12 +7387,14 @@ class RPG2k
         # the whole window.
         pauses = []
         instants = []
+        speeds = []
         auto_close = false
         show_gold = false
         offset = 0
         scans.each_with_index do |s, li|
           s[:pauses].each { |p| pauses << { at: offset + p[:at], kind: p[:kind] } }
           (s[:instants] || []).each { |a, b| instants << [offset + a, offset + b] }
+          (s[:speeds] || []).each { |sp| speeds << { at: offset + sp[:at], speed: sp[:speed] } }
           auto_close ||= s[:auto_close]
           show_gold ||= s[:show_gold]
           offset += plain[li].length
@@ -7428,7 +7430,7 @@ class RPG2k
         contents = Bitmap.new(inner_w, inner_h)
 
         # Plain messages type out gradually; choice lists appear at once.
-        reveal = Game::TextReveal.new(plain, 0, pauses, auto_close, instants)
+        reveal = Game::TextReveal.new(plain, 0, pauses, auto_close, instants, speeds)
         reveal.reveal_all if choice
         # `\$` shows the party's gold in a small window alongside the message.
         gold_window = nil

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -772,6 +772,20 @@ check 'Message.scan records \> \< instant spans (and an unclosed one to EOL)' do
   eq [[2, 4]], s2[:instants]
 end
 
+check 'Message.scan records \s[n] speed changes, clamped to RPG_RT\'s 1..20' do
+  vars = Object.new
+  def vars.[](_i); 0; end
+  names = ->(_i) { '' }
+  s = Game::Message.scan('ab\s[3]cd\s[99]ef', vars, names)
+  eq [{ at: 2, speed: 3 }, { at: 4, speed: 20 }], s[:speeds],
+     '\s[99] clamps down to RPG_RT\'s max of 20 (EasyRPG Player\'s ' \
+     'window_message.cpp: Utils::Clamp(pres.value, 1, 20))'
+  eq 6, s[:length], '\s[] produces no characters and burns no tick, like \c[]'
+  # An empty or missing bracket falls back to full speed (1), the same
+  # nil/empty-string handling \c[]'s own default colour uses.
+  eq [{ at: 1, speed: 1 }], Game::Message.scan('a\s[]b', vars, names)[:speeds]
+end
+
 check '\^, \$ and the closing \< each delay what follows by one reveal tick' do
   vars = Object.new
   def vars.[](_i); 0; end
@@ -810,6 +824,35 @@ check 'an instant span still stops at a pause inside it' do
   r.release_pause
   r.advance(1)                          # 3 -> 4, still inside the span -> jump to 5
   eq 5, r.revealed, 'the rest of the span reveals once released'
+end
+
+check 'TextReveal.speed_at reports the \s[n] in effect at a position, defaulting to 1' do
+  r = Game::TextReveal.new(['abcdef'], 0, [], false, [],
+                            [{ at: 2, speed: 5 }, { at: 4, speed: 1 }])
+  eq 1, r.speed_at(0), 'full speed before the first \s[] change'
+  eq 1, r.speed_at(1)
+  eq 5, r.speed_at(2), 'the change applies from its own position onward'
+  eq 5, r.speed_at(3)
+  eq 1, r.speed_at(4), 'a later \s[1] resets back to full speed'
+end
+
+check 'TextReveal varies its reveal rate across a \s[n] speed span' do
+  # "ab" at full speed (1), then a \s[3] change at position 2 slows the rest
+  # ("cdef") to a third of the per-frame budget.
+  speeds = [{ at: 2, speed: 3 }]
+  r = Game::TextReveal.new(['abcdef'], 0, [], false, [], speeds)
+  r.advance(2)
+  eq 2, r.revealed, 'full speed reveals the whole first budget in one frame'
+  # From here, a budget of 2/frame banked at speed 3 lands one whole
+  # character roughly every 1.5 frames instead of every frame: frame 1 banks
+  # 2/3 of a character (0 revealed), frame 2 banks 4/3 (1 revealed, 1/3
+  # left over), frame 3 banks 3/3 (1 more revealed).
+  r.advance(2)
+  eq 2, r.revealed, 'a slow \s[3] span does not reveal a character every frame'
+  r.advance(2)
+  eq 3, r.revealed
+  r.advance(2)
+  eq 4, r.revealed
 end
 
 # -- Screen (tint state machine) ---------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -3060,6 +3060,26 @@ check 'a \\! pause holds the reveal until a button is pressed' do
   ok reveal.done?
 end
 
+check '\\s[n] slows the message typewriter; a higher n takes longer to fully reveal' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # "ab" reveals at the default speed, then \s[4] slows the rest ("cdefgh").
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'ab\\s[4]cdefgh')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'message window opened'
+  reveal = msg[:reveal]
+  # At the plain 2 chars/frame rate all 8 characters would be fully revealed
+  # within 4 frames; a message that drops \s[] outright (the pre-fix
+  # behaviour) reveals at that same flat rate regardless of the code, so it
+  # would already be done here too.
+  6.times { RGSS::Input.reset; scene.update }
+  ok !reveal.done?, '\\s[4] slows the reveal well past where the plain rate would finish'
+  30.times { RGSS::Input.reset; scene.update }
+  ok reveal.done?, 'the slowed reveal still finishes given enough frames'
+end
+
 # A party whose actors have been renamed in play, backed by a roster, for the
 # \N[n] message-code check.
 class RosterStubActor


### PR DESCRIPTION
## Summary

- `Game::Message.scan` no longer drops the RPG2000 `\s[n]` (typing speed) control code: it now records each speed change as a `{ at:, speed: }` entry in a new `:speeds` list, in the same revealed-character coordinates as `:pauses`/`:instants`. `n` is clamped to RPG_RT's real 1..20 range, confirmed against EasyRPG Player's `window_message.cpp` (`speed = Utils::Clamp(pres.value, 1, 20)`) rather than the editor's own documentation — following this file's established check-the-source methodology.
- `Game::TextReveal` threads a `speeds` list through and picks the `\s[n]` in effect at the current reveal position (`#speed_at`, defaulting to 1 = full speed, RPG_RT's own default before the first change). `#advance` banks its per-frame character budget in a fractional `@carry` while a slower speed is active, so e.g. speed 3 reveals roughly one character every three frames instead of stalling outright — the duration scales linearly with `speed`, matching RPG_RT's own `Window_Message::SetWaitForCharacter`, simplified from its pixel-width scaling down to this codebase's fixed-budget-per-frame typewriter model. `\s[]` produces no characters and burns no reveal tick, matching `\c[]`.
- `Scene::Map#open_message` collects each line's `:speeds` the same way it already does `:pauses`/`:instants` and passes them into the `Game::TextReveal` it builds.
- As a consequence, the previously-open **"`\c[]`/`\s[]` bleed into an attached Show Choices list"** finding (`docs/TODO.md`) is now fully resolved, not just partially: a Show Choices list — standalone or merged onto a preceding Show Text — always calls `Game::TextReveal#reveal_all` instantly rather than typing out gradually, so the new speed state has nothing to bleed into.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 784 checks pass, including new `Message.scan` `:speeds` coverage and `TextReveal#speed_at`/`#advance` speed-driven reveal checks.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 522 checks pass, including a new end-to-end `Scene::Map` check driving a real `\s[4]` message.
- [x] All three new checks confirmed to **fail** against the pre-fix code (temporarily reverted `game.rb`/`map.rb` while keeping the new tests) before the fix.
- [x] `pre-commit run` on the changed files (trailing-whitespace, end-of-file-fixer, check-added-large-files; clang-format/cmake-format/label-config/nixfmt had no matching files).

Docs (`docs/TODO.md`) and a changelog fragment (`changelog.d/message-speed-control-code.added.md`) are updated accordingly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxkDcCCebWrAQ6vcuzQejt)_