### PR TITLE
Add auto-merge label workflow and configuration

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -144,6 +144,12 @@
   color: "fbca04"
   description: "Needs a repro, a game, or a log before it can be worked on"
 
+# --- automation --------------------------------------------------------------
+# Applied by a workflow rather than by hand or by changed paths.
+- name: "auto-merge"
+  color: "2ea44f"
+  description: "Auto-merge is enabled; treat as already review-approved (see AGENTS.md)"
+
 # --- GitHub defaults worth keeping ------------------------------------------
 # Listed so `--prune` does not sweep them away.
 - name: "good first issue"

--- a/.github/workflows/auto-merge-label.yml
+++ b/.github/workflows/auto-merge-label.yml
@@ -1,0 +1,40 @@
+# Label pull requests that have auto-merge enabled, so the `auto-merge` review
+# state (see AGENTS.md's "auto-merge counts as approval" rule) is visible
+# without opening the PR.
+#
+# `pull_request_target` so the label lands even when the toggle happens on a
+# fork's PR. Nothing from the pull request is checked out or run here -- gh
+# only reads/writes the PR's labels -- so the write-scoped token never meets
+# the branch's code.
+name: Auto-merge label
+
+on:
+  pull_request_target:
+    types: [ auto_merge_enabled, auto_merge_disabled ]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    # Just a `gh pr edit` call -- no checkout, no build tooling -- so the small
+    # `ubuntu-slim` image (1 CPU, 5 GB RAM, 15-minute cap) covers it at a lower
+    # rate. See `preview-gate` in build.yml for the same reasoning.
+    runs-on: ubuntu-slim
+    steps:
+      - name: Sync the auto-merge label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          if [ "$ACTION" = "auto_merge_enabled" ]; then
+            gh pr edit "$NUMBER" --add-label auto-merge
+          else
+            gh pr edit "$NUMBER" --remove-label auto-merge
+          fi

--- a/changelog.d/auto-merge-pr-label.added.md
+++ b/changelog.d/auto-merge-pr-label.added.md
@@ -1,0 +1,3 @@
+- Pull requests with auto-merge enabled now get an **auto-merge** label,
+  applied and removed automatically by `.github/workflows/auto-merge-label.yml`
+  on the `auto_merge_enabled` / `auto_merge_disabled` webhook events.


### PR DESCRIPTION
## Summary
This change adds automation to visually indicate when a pull request has auto-merge enabled by applying an `auto-merge` label. This makes the auto-merge status visible at a glance without opening the PR details.

## Key Changes
- **New workflow** (`.github/workflows/auto-merge-label.yml`): Automatically adds/removes the `auto-merge` label when auto-merge is enabled/disabled on a PR
  - Uses `pull_request_target` trigger to work safely with fork PRs
  - Runs on `ubuntu-slim` for efficiency (no checkout or build needed)
  - Uses GitHub CLI to manage labels via the `GITHUB_TOKEN`
  
- **Label configuration** (`.github/labels.yml`): Added the new `auto-merge` label definition
  - Green color (`2ea44f`) to indicate approval status
  - Description references AGENTS.md's auto-merge approval rule
  
- **Changelog entry**: Documents the new feature for release notes

## Implementation Details
- The workflow is triggered by GitHub's native `auto_merge_enabled` and `auto_merge_disabled` webhook events
- Concurrency control prevents race conditions when toggling auto-merge multiple times
- No code checkout occurs, so the write-scoped token never interacts with branch code, maintaining security

https://claude.ai/code/session_01RS31ZfdzAE1pvhPXS5wgjL