### PR TITLE
Confirm pictures already stay visible under an open message window

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4225,12 +4225,33 @@ Everything below is unverified against the codebase.
   check (a shown picture draws normally before the encounter, is hidden and
   stops compositing the instant the battle screen is up, and reappears the
   instant the fight ends), confirmed to fail against the pre-fix code
-  before the fix. Still open: halted entirely while a text window is up
-  (separate from the battle/menu case — a message window is not a scene
-  push, so a different mechanism would be needed, and this project's own
-  "Picture commands... suppressed while a message window is open" fix above
-  only stops new Show/Move/Erase Picture *commands* from taking effect, not
-  an already-shown picture's own visibility); **changing maps clears all
+  before the fix. ✅ **Checked and already correct: an already-shown
+  picture does *not* need to be hidden while a text window is up.** This
+  bullet used to list that as still open, reasoning by analogy with the
+  Battle case above — but the analogy doesn't hold: unlike Battle (a
+  genuinely separate rendering path whose backdrop sits *below*
+  `@picture_sprite`'s z, hence the explicit `@battle_ui` gate just
+  described) and Menu (an opaque panel painted *above* the picture layer,
+  per `Scene::Base#build_field_background`), a message window is not a
+  scene push and does not blank the screen at all — it is itself a
+  `Window` at z 300, already sitting above the picture layer's z 250 (see
+  `#setup_pictures`). Verified against EasyRPG Player's own C++
+  source rather than left as an assumption: `Sprite_Picture::Draw`
+  (`src/sprite_picture.cpp`) carries no message-window check, and
+  `src/drawable.h`'s z-order enum puts `Priority_PictureOld` (120) below
+  `Priority_Window` (130) — RPG_RT lets an open picture keep compositing
+  and animating under the message window exactly like it does under any
+  other window, relying on ordinary z-order occlusion rather than an
+  explicit hide. This project's own `#render` already reflects that: the
+  picture layer has no `@message` check and never has, so nothing needed
+  fixing. (The "Picture commands... suppressed while a message window is
+  open" fix mentioned above is a separate, correct behaviour — it only
+  stops new Show/Move/Erase Picture *commands* from taking effect while a
+  message is up, which is unrelated to whether an already-shown picture
+  keeps rendering.) Covered by a new `scripts/rpg2k_scene_check.rb` check
+  (a picture shown and mid-move stays visible, keeps compositing every
+  frame, and keeps advancing its move while a message window is open, then
+  is still visible once the window closes). **changing maps clears all
   Pictures — except via Teleport or Escape (skill/item), which don't clear
   them**; semi-transparent (1-99%) opacity costs noticeably more than fully
   opaque/transparent; Erase Picture is instant (no fade) — a gradual fade

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4405,6 +4405,50 @@ check 'a shown picture renders through the scene and its move advances' do
   eq 60, st.pictures[1].y, 'the picture reached its target'
 end
 
+# Unlike the battle screen (a genuinely separate scene whose own backdrop
+# sits *below* @picture_sprite's z, needing an explicit hide -- see "pictures
+# are hidden while the battle screen is up" above) and the Menu screen (an
+# opaque panel painted *above* the picture layer, per Scene::Base
+# #build_field_background), a message window is not a scene push and does not
+# blank the screen -- it is itself a z=300 Window sitting above the z=250
+# picture layer (see the "below the message window" assertion just above).
+# RPG_RT's own Draw() carries no message-window check for pictures either
+# (verified against EasyRPG Player's Sprite_Picture::Draw and Scene_Map --
+# `Priority_PictureOld` sits below `Priority_Window` in src/drawable.h, and
+# neither file gates picture visibility on message state), so an already-shown
+# picture keeps compositing and animating under an open message window exactly
+# like it does under any other window; the window's own z-order is what covers
+# it, the same way it covers the map tiles beneath it.
+check 'a shown picture keeps rendering and moving while a message window is open' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3) # autostart
+  auto.event_commands = [ECmd.new(ic::SHOW_MESSAGE, [], string: 'hi')]
+  scene = new_scene({ 1 => event(2, 2, auto) }, player: [5, 5])
+  st = scene.instance_variable_get(:@state)
+  st.show_picture(1, name: 'pic', x: 160, y: 120, zoom: 100, opacity: 255)
+  st.move_picture(1, 160, 60, 200, 128, 100, 100, 100, 100, 6)
+  sprite = scene.instance_variable_get(:@picture_sprite)
+
+  msg = nil
+  12.times { scene.update; msg = scene.instance_variable_get(:@message); break if msg }
+  ok msg, 'the message window opened'
+  ok sprite.visible, 'the picture layer is not hidden while the message window is up'
+  bmp = scene.instance_variable_get(:@picture_bmp)
+  bmp.clear_stretch_calls
+  scene.update
+  eq 1, bmp.stretch_calls.size, 'the picture still composites every frame under the message window'
+  ok st.pictures_moving?, 'the picture keeps advancing its move while the message window is up'
+
+  # Complete the reveal, then dismiss, the same two-press sequence the
+  # "types out gradually" check above uses.
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  ok !scene.instance_variable_get(:@message), 'the message window closed'
+  ok sprite.visible, 'the picture layer is still visible once the message window closes'
+end
+
 check 'pictures composite in ascending id order, independent of show order' do
   # yado.tk: 50 concurrent picture slots, higher id always draws on top,
   # independent of show order. Shown here in the opposite order (2 then 1) so


### PR DESCRIPTION
## Summary

`docs/TODO.md` (~line 4079) listed "pictures halted entirely while a text window is up" as a still-open gap in `Scene::Map#render` (`mruby-rpg2k/mrblib/scene/map.rb`), reasoning by analogy with the already-fixed battle-screen case (`@battle_ui` gate hiding `@picture_sprite`).

Investigating before implementing turned up that the analogy doesn't hold, and current behavior is already correct — **no code change was needed**:

- The battle screen needs an explicit hide because it's a genuinely separate rendering path whose own backdrop (`@battle_ui[:back_sprite]`) sits at a *lower* z than the picture layer, so nothing else painted over a shown picture.
- The Menu screen is covered by `Scene::Base#build_field_background`'s opaque panel, painted *above* the picture layer.
- A message window is neither of those — it's just another `Window` at z 300, already sitting above the picture layer's z 250 (see `#setup_pictures`'s own comment). Ordinary z-order occlusion already does the job; a message window is not a scene push and doesn't blank the screen.

Verified against EasyRPG Player's real C++ source rather than left as an assumption: `Sprite_Picture::Draw` (`src/sprite_picture.cpp`) carries no message-window check, and `src/drawable.h`'s z-order enum puts `Priority_PictureOld` (120) below `Priority_Window` (130). RPG_RT itself lets an open picture keep compositing and animating under the message window rather than hiding it — this is also why RPG2000 games can layer pictures as a "message backdrop" technique (higher picture id drawn on top, still below the window's own z).

## Changes

- **`docs/TODO.md`**: rewrote the "still open" bullet to record the investigation and its conclusion (checked, already correct), with the EasyRPG evidence.
- **`scripts/rpg2k_scene_check.rb`**: added a check — a picture shown and mid-move stays visible, keeps compositing every frame, and keeps advancing its move while an autostart Show Message window is open, then is still visible once the window closes and dismisses. Passes against the unmodified code, since there was nothing to fix.
- No `mruby-rpg2k/mrblib/scene/map.rb` change, since `#render`'s picture step already behaves correctly.
- No changelog fragment, per this repo's convention of skipping one when a TODO investigation concludes no code change was needed.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 525 checks passed (new check included)
- [x] `pre-commit run --files scripts/rpg2k_scene_check.rb docs/TODO.md` (nixfmt skipped — no nix files touched, and `cabal` isn't available in this sandbox)


---
_Generated by [Claude Code](https://claude.ai/code/session_012pC6hFqDMGpnhQuAcuegoA)_