### PR TITLE
Wire Play BGM's balance/pan parameter to the audio backend

### DIFF
--- a/changelog.d/rpg2k-bgm-pan.added.md
+++ b/changelog.d/rpg2k-bgm-pan.added.md
@@ -1,0 +1,15 @@
+- **Play BGM's balance (pan) parameter is now wired through to playback.**
+  `Game::Interpreter#play_audio`'s `:bgm` branch used to read only
+  `cmd.param(1)`/`cmd.param(2)` (volume/tempo) and leave `cmd.param(3)`
+  (balance) on the floor — pan was never a Play BGM parameter at all before
+  this. SDL_mixer has no per-`Mix_Music` panning API, but
+  `Mix_SetPanning(MIX_CHANNEL_POST, left, right)` registers a postmix effect
+  on the final mixed stream, which is the one documented way to reach a
+  playing music track at all (at the cost of also panning BGS/SE, since they
+  land in the same final mix). Added a `bgm_pan` entry point
+  (`include/rgss_audio.hxx`, `src/sdl_audio.cxx`, `mruby-rgss`'s
+  `_bgm_pan`/`RGSS::Audio.bgm_pan`), mirroring `bgm_volume`'s existing shape,
+  and wired it into `play_audio` on RPG2000's own Play BGM balance scale (0
+  full left, 50 centre, 100 full right), re-applied on every Play BGM
+  regardless of the same-file-no-restart branch since panning has no
+  per-track state to restart.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5594,11 +5594,12 @@ not yet verified:
   #do_play_memorized_bgm` — one shared `same_file_already_playing` idiom,
   three call sites, all now re-applying the command's own volume live
   instead of leaving whatever the interrupted track happened to be at
-  alone. Tempo/pan remain out of reach of this backend: SDL_mixer has no
-  live pitch control for a stream already playing (only a freshly started
-  one, `src/sdl_audio.cxx`'s own header comment), and pan/balance was never
-  wired as a Play BGM parameter at all, a separate, larger gap left
-  unaddressed here. Covered by two new `scripts/rpg2k_logic_check.rb`
+  alone. Tempo remains out of reach of this backend: SDL_mixer has no live
+  pitch control for a stream already playing (only a freshly started one,
+  `src/sdl_audio.cxx`'s own header comment); pan/balance was never wired as a
+  Play BGM parameter at all as of this paragraph — see the ✅ addendum at the
+  end of this bullet, where that gap is closed. Covered by two new
+  `scripts/rpg2k_logic_check.rb`
   checks (a same-file Play BGM re-trigger calls `bgm_volume` with the new
   command's volume instead of `bgm_play`; a Play Memorized BGM replaying a
   track that never stopped re-applies the memorized volume, distinguishing
@@ -5635,7 +5636,31 @@ not yet verified:
   `scripts/rpg2k_logic_check.rb` check (Play BGM "town", Memorize BGM, Play
   Memorized BGM with nothing else played in between reaches the backend
   once, not twice), confirmed to fail against the pre-fix code (`["town",
-  "town"]`) before the fix.
+  "town"]`) before the fix. ✅ **Pan/balance is now wired too — the gap
+  flagged above.** `cmd.param(3)` went unread in `#play_audio`'s `:bgm`
+  branch, and `RgssAudioBackend` had no pan slot to read it into at all.
+  SDL_mixer has no per-`Mix_Music` panning API either, but unlike tempo this
+  one has a real documented workaround: `Mix_SetPanning(MIX_CHANNEL_POST,
+  left, right)` registers a postmix effect on the *final* mixed stream, the
+  one place a still-playing music track can be reached at all (at the cost of
+  also panning BGS/SE, since they land in the same final mix — there is no
+  channel-scoped alternative for music). Added a `bgm_pan` slot to
+  `RgssAudioBackend` (`include/rgss_audio.hxx`), implemented in
+  `src/sdl_audio.cxx` on that primitive (RPG2000's own Play BGM balance scale
+  — 0 full left, 50 centre, 100 full right — mapped onto SDL's 0..255 per
+  channel), with a matching `_bgm_pan` forwarder in `mruby-rgss/src/audio.cxx`
+  and a public `RGSS::Audio.bgm_pan(pan)` wrapper in
+  `mruby-rgss/mrblib/lib.rb`, mirroring `bgm_volume`'s shape exactly.
+  `#play_audio`'s `:bgm` branch now reads `cmd.param(3)` (defaulting to 50
+  when the command carries a shorter list) and calls `bgm_pan` on every Play
+  BGM regardless of the same-file-no-restart branch above, since panning has
+  no per-track state to restart in the first place. Covered by a new
+  `mruby-rgss/test/test.rb` check (`_bgm_pan` is a safe no-op with no backend
+  installed, matching every other native Audio primitive) and a new
+  `scripts/rpg2k_logic_check.rb` check (a Play BGM with an explicit balance
+  reaches `bgm_pan` with that value; an omitted balance defaults to 50),
+  confirmed to fail against the pre-fix code (`NoMethodError`/no `bgm_pan`
+  call at all) before the fix.
 - ✅ **A map's own configured BGM now actually auto-plays, on the initial map
   load and every Transfer Player alike — a genuine, previously-undocumented
   gap found while cross-checking this same BGM cluster for anything else the

--- a/include/rgss_audio.hxx
+++ b/include/rgss_audio.hxx
@@ -42,6 +42,15 @@ struct RgssAudioBackend {
   // There is no live equivalent for pitch: SDL_mixer cannot re-pitch a
   // playing music stream, only a freshly started one.
   void (*bgm_volume)(int volume);
+  // Re-applies stereo balance to the BGM stream already playing, with no
+  // restart -- the same live-update shape as bgm_volume. RPG2000's Play BGM
+  // balance parameter is 0 (full left) through 100 (full right), 50 centred;
+  // pan is 0..100 on that same scale. SDL_mixer has no per-Mix_Music panning
+  // API, so the backend implements this via Mix_SetPanning(MIX_CHANNEL_POST,
+  // ...), which pans the whole final mixed output (BGM, BGS and SE alike) --
+  // see src/sdl_audio.cxx for why that is the only technique that reaches a
+  // playing music stream at all.
+  void (*bgm_pan)(int pan);
   void (*bgm_stop)(void);
   void (*bgm_fade)(int ms);
   // Current playback position of the BGM, in milliseconds (0 if unknown).

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1032,6 +1032,14 @@ module RGSS
         _bgm_volume(volume)
       end
 
+      # Re-applies stereo balance to the already-playing BGM stream in place,
+      # with no restart -- the same live-update shape as #bgm_volume. Matches
+      # RPG2000's own Play BGM balance parameter: 0 is full left, 100 is full
+      # right, 50 (the default) is centre.
+      def bgm_pan(pan)
+        _bgm_pan(pan)
+      end
+
       def bgm_stop
         _bgm_stop
       end

--- a/mruby-rgss/src/audio.cxx
+++ b/mruby-rgss/src/audio.cxx
@@ -68,6 +68,14 @@ mrb_value bgm_volume(mrb_state* M, mrb_value self) {
   return mrb_nil_value();
 }
 
+mrb_value bgm_pan(mrb_state* M, mrb_value self) {
+  mrb_int pan;
+  mrb_get_args(M, "i", &pan);
+  if (g_backend.bgm_pan)
+    g_backend.bgm_pan((int)pan);
+  return mrb_nil_value();
+}
+
 mrb_value bgm_stop(mrb_state* M, mrb_value self) {
   if (g_backend.bgm_stop)
     g_backend.bgm_stop();
@@ -218,6 +226,7 @@ void rgss_audio_define(mrb_state* M, RClass* rgss) {
                              MRB_ARGS_ARG(1, 2));
   mrb_define_module_function(M, audio, "_bgm_volume", bgm_volume,
                              MRB_ARGS_REQ(1));
+  mrb_define_module_function(M, audio, "_bgm_pan", bgm_pan, MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_bgm_stop", bgm_stop, MRB_ARGS_NONE());
   mrb_define_module_function(M, audio, "_bgm_fade", bgm_fade, MRB_ARGS_REQ(1));
   mrb_define_module_function(M, audio, "_bgm_pos", bgm_pos, MRB_ARGS_NONE());

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1098,6 +1098,7 @@ assert "RGSS::Audio primitives are inert without a backend" do
   # executable, src/sdl_audio.cxx), so every native primitive is a safe no-op.
   assert_nil RGSS::Audio._bgm_play("nope", 80, 90)
   assert_nil RGSS::Audio._bgm_volume(50)
+  assert_nil RGSS::Audio._bgm_pan(50)
   assert_nil RGSS::Audio._bgm_stop
   assert_nil RGSS::Audio._bgm_fade(100)
   assert_equal 0, RGSS::Audio._bgm_pos

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3083,19 +3083,25 @@ module Game
       end
       if kind == :bgm
         # PlayBGM parameters: [fade_in, volume, tempo, balance]. Volume/tempo
-        # default to 100 when the command carries a shorter list.
+        # default to 100, balance to 50 (centre), when the command carries a
+        # shorter list.
         volume = cmd.parameters.size > 1 ? cmd.param(1) : 100
         pitch = cmd.parameters.size > 2 ? cmd.param(2) : 100
+        balance = cmd.parameters.size > 3 ? cmd.param(3) : 50
         # BGM has a single channel, and RPG_RT special-cases re-triggering Play
         # BGM with the file that's already current: it does NOT break and
         # restart the track from the top the way any other Play BGM does
         # (yado.tk), but it does re-apply the command's own volume to the
         # still-playing track (`RGSS::Audio.bgm_volume`, backed by
         # `Mix_VolumeMusic` — see `src/sdl_audio.cxx`, which applies live with
-        # no restart, unlike `bgm_play`'s `Mix_PlayMusic`). Tempo/pan stay
+        # no restart, unlike `bgm_play`'s `Mix_PlayMusic`). Tempo stays
         # unaddressed: SDL_mixer has no live pitch control for a playing music
-        # stream (only a freshly started one), and pan is not wired as a
-        # Play BGM parameter at all today — see docs/TODO.md.
+        # stream (only a freshly started one). Balance/pan is wired the same
+        # live-update way via `RGSS::Audio.bgm_pan` (backed by
+        # `Mix_SetPanning(MIX_CHANNEL_POST, ...)` — the only technique that
+        # reaches a Mix_Music stream at all, see `src/sdl_audio.cxx`), applied
+        # on every Play BGM regardless of same-file-or-not since it has no
+        # per-track state to restart.
         same_file_already_playing = @state.current_bgm && @state.current_bgm[:name] == name
         # Track what is playing so Memorize BGM can stash it (RPG_RT keeps this
         # as the "current system BGM" regardless of whether playback succeeds).
@@ -3106,6 +3112,7 @@ module Game
           @state.bgm_looped = false # a fresh track has not looped yet
           RGSS::Audio.bgm_play(name, volume, pitch)
         end
+        RGSS::Audio.bgm_pan(balance)
       else
         # PlaySE parameters: [volume, tempo, balance].
         volume = cmd.parameters.size > 0 ? cmd.param(0) : 100

--- a/scripts/rpg2k_command_soak.rb
+++ b/scripts/rpg2k_command_soak.rb
@@ -39,6 +39,7 @@ module RGSS
     class << self
       def bgm_play(*); end
       def bgm_volume(*); end
+      def bgm_pan(*); end
       def bgm_fade(*); end
       def bgm_stop(*); end
       def se_play(*); end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -23,6 +23,7 @@ module RGSS
       attr_accessor :log
       def bgm_play(*a); (@log ||= []) << [:bgm, *a]; end
       def bgm_volume(*a); (@log ||= []) << [:bgm_volume, *a]; end
+      def bgm_pan(*a); (@log ||= []) << [:bgm_pan, *a]; end
       def bgm_fade(*a); (@log ||= []) << [:bgm_fade, *a]; end
       def se_play(*a);  (@log ||= []) << [:se, *a];  end
       def se_stop(*a);  (@log ||= []) << [:se_stop, *a]; end
@@ -2591,6 +2592,48 @@ check 'Play BGM with a different file still restarts (or starts) playback' do
   it.update
   names = RGSS::Audio.log.select { |e| e[0] == :bgm }.map { |e| e[1] }
   eq %w[town field], names, 'a different file always reaches the backend'
+end
+
+check 'Play BGM with an explicit balance parameter forwards it as pan' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # PlayBGM parameters: [fade_in, volume, tempo, balance] -- param(3) is
+  # balance, here full left (0) then full right (100).
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100, 0], string: 'town'),
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100, 100], string: 'field'),
+  ])
+  it.update
+  pans = RGSS::Audio.log.select { |e| e[0] == :bgm_pan }.map { |e| e[1] }
+  eq [0, 100], pans, 'each Play BGM re-applies its own balance parameter'
+end
+
+check 'Play BGM with no balance parameter defaults pan to centre (50)' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # Only [fade_in, volume, tempo] -- no 4th (balance) element at all.
+  it.start([FakeCmd.new(IC::PLAY_BGM, [0, 80, 100], string: 'town')])
+  it.update
+  pans = RGSS::Audio.log.select { |e| e[0] == :bgm_pan }.map { |e| e[1] }
+  eq [50], pans, 'an omitted balance parameter defaults to centre'
+end
+
+check 'Play BGM re-applies pan on a same-file re-trigger, not just a fresh start' do
+  RGSS::Audio.log = []
+  st = new_state
+  it = Game::Interpreter.new(st)
+  # Same file re-triggered with a different balance: unlike bgm_play (skipped
+  # on a same-file match, see above), bgm_pan has no per-track state to
+  # restart, so it must still fire every time.
+  it.start([
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100, 20], string: 'town'),
+    FakeCmd.new(IC::PLAY_BGM, [0, 80, 100, 80], string: 'town'),
+  ])
+  it.update
+  pans = RGSS::Audio.log.select { |e| e[0] == :bgm_pan }.map { |e| e[1] }
+  eq [20, 80], pans, 'pan is re-applied on the same-file branch too'
 end
 
 # -- Play SE "(OFF)" ----------------------------------------------------------

--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -43,6 +43,7 @@ module RGSS
     class << self
       def bgm_play(*); end
       def bgm_volume(*); end
+      def bgm_pan(*); end
       def se_play(*); end
     end
   end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -157,12 +157,17 @@ module RGSS
     # screen) can assert which track started.
     class << self; attr_accessor :bgm_calls; end
     def self.bgm_play(*a); (@bgm_calls ||= []) << a; end
-    def self.reset_bgm; @bgm_calls = []; @bgm_volume_calls = []; @bgm_fade_calls = []; end
+    def self.reset_bgm; @bgm_calls = []; @bgm_volume_calls = []; @bgm_pan_calls = []; @bgm_fade_calls = []; end
     # Recorded separately from bgm_calls: a same-file Play BGM re-trigger
     # calls this instead of bgm_play (see Game::Interpreter#play_audio /
     # Scene::Map#play_bgm), so the two checks stay distinguishable.
     class << self; attr_accessor :bgm_volume_calls; end
     def self.bgm_volume(v); (@bgm_volume_calls ||= []) << v; end
+    # Recorded separately again: the balance/pan re-apply that now
+    # accompanies every Play BGM command (see
+    # Game::Interpreter#play_audio's :bgm branch).
+    class << self; attr_accessor :bgm_pan_calls; end
+    def self.bgm_pan(v); (@bgm_pan_calls ||= []) << v; end
     # Record bgm_fade calls (the fade-length ms) so a check can assert one
     # fired -- e.g. the End Game confirmation's Game_System::BgmFade(400).
     class << self; attr_accessor :bgm_fade_calls; end

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -50,6 +50,7 @@ module RGSS
     class << self
       def bgm_play(*); end
       def bgm_volume(*); end
+      def bgm_pan(*); end
       def bgm_fade(*); end
       def se_play(*); end
     end

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -357,6 +357,28 @@ void bgm_volume(int volume) {
   Mix_VolumeMusic(to_mix_volume(volume));
 }
 
+// Live stereo-balance change for the BGM, with no restart -- the same shape
+// as bgm_volume. SDL_mixer's Mix_SetPanning only works on Mix_Chunk mixer
+// channels (0..N), never on the Mix_Music stream BGM/ME actually play
+// through; the one documented way to reach the music at all is to register it
+// as a postmix effect on MIX_CHANNEL_POST, which pans the *final* mixed
+// output -- so this also pans BGS and SE, since there is no channel-scoped
+// alternative for music (see the doc comment on Mix_SetPanning in
+// SDL_mixer.h: "the panning will be done to the final mixed stream"). pan is
+// RPG2000's own Play BGM balance scale: 0 full left, 50 centre, 100 full
+// right. "True panning" per that same doc comment is Mix_SetPanning(chan,
+// left, 255 - left), so right alone (0..255) is derived from pan and left is
+// its complement.
+void bgm_pan(int pan) {
+  if (pan < 0)
+    pan = 0;
+  if (pan > 100)
+    pan = 100;
+  Uint8 right = (Uint8)(pan * 255 / 100);
+  Uint8 left = (Uint8)(255 - right);
+  Mix_SetPanning(MIX_CHANNEL_POST, left, right);
+}
+
 void bgm_play_mem(const char* name,
                   const void* data,
                   int size,
@@ -522,10 +544,11 @@ void update(void) {
 }
 
 const RgssAudioBackend kBackend = {
-    bgm_play,     bgm_volume,   bgm_stop,    bgm_fade,    bgm_pos,
-    bgs_play,     bgs_stop,     bgs_fade,    bgs_pos,     me_play,
-    me_stop,      me_fade,      se_play,     se_stop,     update,
-    bgm_play_mem, bgs_play_mem, me_play_mem, se_play_mem, midi_available,
+    bgm_play,       bgm_volume,   bgm_pan,      bgm_stop,    bgm_fade,
+    bgm_pos,        bgs_play,     bgs_stop,     bgs_fade,    bgs_pos,
+    me_play,        me_stop,      me_fade,      se_play,     se_stop,
+    update,         bgm_play_mem, bgs_play_mem, me_play_mem, se_play_mem,
+    midi_available,
 };
 
 }  // namespace


### PR DESCRIPTION
## Summary

- `Game::Interpreter#play_audio`'s `:bgm` branch reads `fade_in`/`volume`/`tempo` from a Play BGM command but never `cmd.param(3)` (balance) — pan was never wired as a Play BGM parameter at all, per `docs/TODO.md` and the branch's own comment.
- SDL_mixer has no per-`Mix_Music` panning API, but `Mix_SetPanning(MIX_CHANNEL_POST, left, right)` (confirmed against the real SDL_mixer header doc comment) registers a postmix effect on the *final* mixed stream — the one documented technique that reaches a playing music track at all, at the cost of also panning BGS/SE since they land in the same final mix.
- Added a `bgm_pan` entry point through the exact same layers as the existing `bgm_volume` live-update primitive: `RgssAudioBackend` (`include/rgss_audio.hxx`), the SDL_mixer implementation (`src/sdl_audio.cxx`), the `mruby-rgss` native forwarder (`_bgm_pan`) and the `RGSS::Audio.bgm_pan` wrapper (`mruby-rgss/mrblib/lib.rb`).
- `play_audio` now reads `cmd.param(3)` (defaulting to 50/centre when the command carries a shorter list) and re-applies it via `bgm_pan` on every Play BGM, regardless of the same-file-no-restart branch, since panning has no per-track state to restart. Value range mirrors RPG2000's own Play BGM balance scale: 0 full left, 50 centre, 100 full right (confirmed via RPG Maker 2003 utility docs and the task's own citation, since `easyrpg.org`/`wiki.libsdl.org` were unreachable from this sandbox's egress proxy — the SDL_mixer header itself was fetched directly from `raw.githubusercontent.com` to confirm the `MIX_CHANNEL_POST` postmix technique).
- Updated `docs/TODO.md`'s BGM bullet and the `interpreter.rb` comment to record pan as wired, leaving the (unrelated, still-real) tempo/SDL_mixer live-pitch limitation as-is.

## Test coverage

- `mruby-rgss/test/test.rb`: `_bgm_pan` is a safe no-op with no backend installed, matching every other native Audio primitive.
- `scripts/rpg2k_logic_check.rb`: three new checks — an explicit balance parameter forwards as pan, an omitted balance defaults to 50 (centre), and pan is re-applied on a same-file Play BGM re-trigger (unlike `bgm_play`, which is skipped there).
- Updated the `RGSS::Audio` stub modules in `scripts/rpg2k_scene_check.rb`, `scripts/rpg2k_testbed_logic_check.rb`, `scripts/rpg2k_save_load_check.rb` and `scripts/rpg2k_command_soak.rb` with a `bgm_pan` no-op/recorder so they keep loading `play_audio` cleanly now that it calls it unconditionally.
- Ran `ruby scripts/rpg2k_logic_check.rb` (788 checks passed) and `ruby scripts/rpg2k_scene_check.rb` (524 checks passed) locally. `rpg2k_command_soak.rb` / `rpg2k_save_load_check.rb` / `rpg2k_testbed_logic_check.rb` need a downloaded test-bed game this sandbox doesn't have, so they weren't exercised here, but their stub changes mirror the already-passing pattern in the other scripts.

## Native build

This sandbox has no `SDL2`/`SDL2_mixer` dev packages and no `nix` (the repo's usual dependency source), so `cmake -S . -B build` fails at `find_package(SDL2)` before anything native can be built or the Google Test suite run — verified by actually attempting the configure step, not assumed. Verification here is limited to `clang-format -i` on the touched C++ files (`include/rgss_audio.hxx`, `src/sdl_audio.cxx`, `mruby-rgss/src/audio.cxx` — clean, no additional diff) plus `ruby -c` / the mruby-side logic-check harnesses above.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb`
- [x] `ruby scripts/rpg2k_scene_check.rb`
- [x] `ruby -c` on every touched Ruby file
- [x] `clang-format -i` on every touched C++ file
- [ ] `cmake --build build -t test` — not feasible in this sandbox (no SDL2/SDL2_mixer, no nix); noted above rather than skipped silently

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012onQP6NsXQ4a6cxR7AQXeS)_