### PR TITLE
Fix boarded hero's Set Move Route to use the ridden vehicle's passability

### DIFF
--- a/changelog.d/rpg2k-boarded-move-route-vehicle-passability.fixed.md
+++ b/changelog.d/rpg2k-boarded-move-route-vehicle-passability.fixed.md
@@ -1,0 +1,11 @@
+- **A boarded hero's own Set Move Route commands (Dash, Jump, plain
+  movement, all alike) now respect the ridden boat/ship/airship's own
+  passability, instead of on-foot chipset passability.** Confirmed against
+  EasyRPG Player's source (`Game_Player::MakeWay`): real RPG_RT
+  unconditionally delegates to the ridden vehicle's own passability for
+  *all* player movement, input-driven or move-route-driven alike, once
+  boarded. This engine already did that for ordinary input movement, but a
+  move-route-driven hero always checked plain on-foot passability
+  regardless of being boarded — letting a forced route sail/fly through
+  terrain the ridden vehicle itself could never cross, or stall on terrain
+  it could freely cross.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4150,17 +4150,45 @@ Everything below is unverified against the codebase.
   block-and-retry shape `:message`/`:choice`/`:number` already use) and a
   shown message window's own display priority interacting with an unrelated
   parallel process's battle opening concurrently.
-- **Vehicles** — an unset vehicle defaults to map id 0, (0,0); Small/Large
-  Ship aren't hardcoded to water, their passability follows the terrain
-  table's boat/ship-pass flags like any other vehicle rule; ✅ an airship
-  can't land on a tile a map event currently occupies (now fixed — see the
-  "Party / Actor / Vehicle" section under "Full-site sweep" below); airships
-  get no random encounters by default (**confirmed already correct**, same
-  section); hero-targeted Set Move Route commands (Dash,
-  Jump, etc.) still run normally while mounted and must be manually guarded
-  off; **setting a map event's trigger to Parallel Process and running "Set
-  Vehicle Position" from it crashes RPG_RT** (any other trigger type does
-  not) — an authentic engine crash, probably not worth reproducing; ✅ a
+- **Vehicles** — ✅ an unset vehicle defaults to map id 0, (0,0) (already
+  independently confirmed under "Full-site sweep" below — `Game::Vehicle
+  #initialize` defaults `map_id`/`x`/`y` to 0); ✅ Small/Large Ship aren't
+  hardcoded to water, their passability follows the terrain table's
+  boat/ship-pass flags like any other vehicle rule (`Scene::Map
+  #vehicle_passable?` reads `row.boat_pass`/`row.ship_pass`/
+  `row.airship_pass` straight off the per-tile terrain row, matching
+  EasyRPG's `Game_Map::IsPassableTile`); ✅ an airship can't land on a tile a
+  map event currently occupies (now fixed — see the "Party / Actor /
+  Vehicle" section under "Full-site sweep" below); airships get no random
+  encounters by default (**confirmed already correct**, same section). **A
+  real bug, now fixed: "hero-targeted Set Move Route commands (Dash, Jump,
+  etc.) still run normally while mounted" was true, but for the wrong
+  reason.** The commands weren't refused while boarded (`apply_move_request`'s
+  `MOVE_TARGET_PLAYER` case never checked `@state.boarded?`, matching the
+  claim on its face), but `#step_player_route` then always stepped the
+  route against the plain on-foot `@world` regardless of `@state.boarded?`
+  — never the ridden vehicle's own `boat_pass`/`ship_pass`/`airship_pass`
+  clearance the same command already gets under ordinary input movement
+  (`#try_move` already branches to `#vehicle_passable?` once boarded).
+  EasyRPG's `Game_Player::MakeWay` (`src/game_character.cpp`/
+  `game_player.cpp`) unconditionally delegates to the ridden vehicle's own
+  `MakeWay` whenever `IsAboard()`, with no separate branch for move-route-
+  driven movement vs. ordinary input — so a boarded hero's own Set Move
+  Route (Dash, Jump, plain movement, all alike) was checked against on-foot
+  chipset passability instead, letting a route sail/fly through terrain the
+  ridden vehicle itself could never cross, or stall on terrain it could.
+  Fixed by having `#step_player_route` pick `@vehicle_worlds[@state.boarded]`
+  instead of the unconditional `@world` whenever boarded — the existing
+  `VehicleWorld` (already used by `#force_vehicle_route` for a *vehicle*-
+  targeted Set Move Route) needed no changes, since it already accepts an
+  arbitrary `Game::Character` mirror. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check (a boarded boat's own hero-targeted
+  Set Move Route on a `boat_pass: false` map stays put instead of sailing
+  through), confirmed to fail against the pre-fix code (`[1, 1]` instead of
+  the correct `[0, 1]`) before the fix. **Setting a map event's trigger to
+  Parallel Process and running "Set Vehicle Position" from it crashes
+  RPG_RT** (any other trigger type does not) — an authentic engine crash,
+  probably not worth reproducing; ✅ a
   vehicle's x/y/screen-x/y can be read via variable ops from a different map
   than it currently occupies — `Game::Interpreter#event_operand`'s Control
   Variables "character position" operand (type 6) recognised the hero (ref
@@ -4202,10 +4230,21 @@ Everything below is unverified against the codebase.
   tile would; one parked on a different map reads nil again; a boarded one
   reports the identical screen position the hero riding it does), confirmed
   to fail against the pre-fix code before the fix.
-- **Battle Event** — separate command set from Map/Common events entirely;
+- ✅ **Battle Event** — separate command set from Map/Common events
+  entirely (`Game::Interpreter`'s battle-only opcodes — `CHANGE_MONSTER_HP`/
+  `MP`/`CONDITION`, `SHOW_HIDDEN_MONSTER`, `FORCE_FLEE`, `TERMINATE_BATTLE`,
+  etc. — are no-ops outside battle, and condition evaluation is its own
+  `Game::BattlePage` module, structurally distinct from `Game::EventPage`);
   ✅ no Pictures on the battle screen (see the fuller writeup under the
-  **Picture** bullet directly below — the same fix); Parallel Process can't
-  run in battle; no further pages run once battle ends.
+  **Picture** bullet directly below — the same fix); ✅ Parallel Process
+  can't run in battle (`@battle_ui`'s mere presence pauses `#step_parallels`
+  for every process except the one that itself opened the fight, kept alive
+  only so it can observe the result — deliberate, extensively commented);
+  ✅ no further pages run once battle ends (`#leave_battle_event_phase`
+  deliberately chains one more matching page *before* checking
+  `battle.finished?`, per its own comment about handing the turn to the
+  result window when the page itself decided the fight — no page runs after
+  the result screen opens).
 - **Picture** — ✅ **none show on Menu/Battle screens — the Menu half was
   already correct, the Battle half was a real gap, now fixed.**
   `Scene::Base#build_field_background` already paints an opaque panel above

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3134,7 +3134,18 @@ class RPG2k
         @player_route_timer = EVENT_MOVE_DELAY[@player_char.move_frequency] || 40
         ox = @player_char.x
         oy = @player_char.y
-        @player_route.step(@player_char, @world) unless @player_route.done?
+        # A boarded party's own Set Move Route commands (Dash, Jump, plain
+        # movement, all alike) must clear the *ridden vehicle's* passability,
+        # not on-foot chipset passability -- EasyRPG's own Game_Player::
+        # MakeWay (src/game_player.cpp) unconditionally delegates to
+        # GetVehicle()->MakeWay whenever IsAboard(), with no separate branch
+        # for move-route-driven movement vs. ordinary input movement, so a
+        # boat/ship/airship's own boat_pass/ship_pass/airship_pass clearance
+        # (or an airship's own event-blind rule) applies here exactly as it
+        # already does for #try_move (the input-driven path, see
+        # @state.boarded? above).
+        world = @state.boarded? ? @vehicle_worlds[@state.boarded] : @world
+        @player_route.step(@player_char, world) unless @player_route.done?
         # Mirror Through Mode out to the standing flag every step (not just when
         # the route ends), so a Halt All Movement mid-route sees whatever the
         # route had set so far rather than the mirror's now-discarded state.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5906,6 +5906,42 @@ check "a boat's move route is blocked by terrain the same way ordinary sailing i
   eq 0, boat.x, 'terrain blocked it before it ever moved'
 end
 
+# EasyRPG's own Game_Player::MakeWay (src/game_player.cpp) unconditionally
+# delegates to the ridden vehicle's own MakeWay whenever IsAboard(), with no
+# separate branch for move-route-driven movement vs. ordinary input
+# movement -- #try_move (the input path) already reads #vehicle_passable?
+# once boarded (see the boat/below-characters-event checks above), but
+# #step_player_route used to always step the player's route mirror against
+# the plain on-foot @world regardless of @state.boarded?, so a boarded
+# hero's own Set Move Route (Dash, Jump, plain movement, all alike) checked
+# on-foot chipset passability instead of the ridden vehicle's own
+# boat_pass/ship_pass/airship_pass clearance.
+check "a boarded hero's own Set Move Route respects the ridden vehicle's " \
+      'passability, not on-foot' do
+  # boat_pass left false (the default): the whole map is unsailable for the
+  # boat, exactly like "a boat's move route is blocked by terrain the same
+  # way ordinary sailing is" above -- but every tile is still ordinarily
+  # walkable on foot, so the pre-fix bug (checking on-foot passability while
+  # boarded) would have let this route sail through anyway.
+  scene = new_scene({}, player: [0, 1])
+  st = scene.instance_variable_get(:@state)
+  boat = st.vehicle(:boat)
+  boat.map_id = st.map_id
+  boat.x = 0
+  boat.y = 1
+  RGSS::Input.triggered = [RGSS::Input::C] # board the boat in place (same tile)
+  scene.update
+  RGSS::Input.triggered = []
+  eq :boat, st.boarded, 'boarded the boat'
+  route = Game::MoveRoute.new([Game::MoveCommand.new(R::MOVE_RIGHT)],
+                              repeat: false, skippable: true)
+  scene.send(:start_player_route, route, 8)
+  20.times { scene.update }
+  eq [0, 1], [st.x, st.y],
+     "the boarded hero's own Set Move Route must not sail where the boat itself " \
+     "can't -- ended at (#{st.x}, #{st.y})"
+end
+
 check 'a Move Route request targeting a currently-ridden vehicle is ignored' do
   scene = new_scene({}, player: [0, 0], boat_pass: true)
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary
- `Scene::Map#step_player_route` always stepped a hero-targeted move route against the plain on-foot `@world`, regardless of `@state.boarded?`. Ordinary input movement already branches to `#vehicle_passable?` once boarded (`#try_move`), but a Set Move Route command on the hero (Dash, Jump, plain movement, all alike) checked on-foot chipset passability instead of the ridden boat/ship/airship's own `boat_pass`/`ship_pass`/`airship_pass` clearance.
- Confirmed against EasyRPG Player's source: `Game_Player::MakeWay` unconditionally delegates to the ridden vehicle's own `MakeWay` whenever `IsAboard()`, with no separate branch for move-route-driven movement vs. ordinary input movement — RPG_RT uniformly uses the ridden vehicle's own passability for all player movement once boarded.
- Fixed by picking `@vehicle_worlds[@state.boarded]` instead of the unconditional `@world` in `#step_player_route` — the existing `VehicleWorld` (already used by `#force_vehicle_route` for a *vehicle*-targeted Set Move Route) needed no changes, since it already accepts an arbitrary `Game::Character` mirror.
- Also confirms several adjacent "Vehicles" and "Battle Event" `docs/TODO.md` claims that were already correct in the implementation.

## Testing
- New `scripts/rpg2k_scene_check.rb` check: a boarded boat's own hero-targeted Set Move Route on a `boat_pass: false` map stays put instead of sailing through — confirmed to fail against the pre-fix code (`[1, 1]` instead of the correct `[0, 1]`) before the fix.
- `ruby -c mruby-rpg2k/mrblib/scene/map.rb` / `ruby -c scripts/rpg2k_scene_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- `ruby scripts/rpg2k_scene_check.rb` — 526 checks passed
- `ruby scripts/rpg2k_logic_check.rb` — 785 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_