### PR TITLE
Play the battle victory jingle as a real one-shot ME

### DIFF
--- a/changelog.d/victory-jingle-me.fixed.md
+++ b/changelog.d/victory-jingle-me.fixed.md
@@ -1,0 +1,13 @@
+- **The battle victory jingle now plays as a real one-shot "ME" that the
+  field BGM resumes after**, instead of looping as an ordinary BGM that got
+  cut off the instant the result screen was dismissed. `Scene::Map#play_victory_bgm`
+  now calls `RGSS::Audio.me_play` — the same native music-effect primitive
+  (`src/sdl_audio.cxx`'s `me_play`/`me_stop`, which auto-pauses the BGM
+  channel while the effect plays and auto-resumes it once the effect ends)
+  `mruby-rpgvx`'s `RPG::ME#play` already forwards to — instead of the
+  ordinary looping `#play_bgm`, and `#restore_pre_battle_bgm` calls
+  `RGSS::Audio.me_stop` before restarting the pre-battle field/vehicle
+  track, ending the fanfare through its own stop path rather than a bare
+  BGM play yanking the shared music stream out from under it. Covered by
+  updated `scripts/rpg2k_scene_check.rb` checks, confirmed to fail against
+  the pre-fix code before the fix.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -755,15 +755,25 @@ The work below is roughly ordered by the critical path to a walkable game
   `Scene::GameOver` plays its own `gameover_music` and the map is never
   shown again. A game with no battle BGM configured leaves whatever was
   already playing alone, matching RPG_RT's own no-op on a blank Music
-  struct. Left unaddressed: the victory jingle (`battle_end_music`) and
-  RPG_RT's exact timing for when the field BGM resumes relative to it — that
-  needs a "play a fixed jingle, then resume" sequencing this build's
-  `RGSS::Audio` has no primitive for, so the field track resumes immediately
-  once the result window is dismissed rather than after a fanfare. Covered
-  by a new `scripts/rpg2k_scene_check.rb` check (an Enemy Encounter plays
-  the configured battle BGM at its own vol/tempo the moment the battle UI
-  opens, and the field BGM that was playing before replays once the fight
-  is won), confirmed to fail against the pre-fix code before the fix.
+  struct. ✅ The victory jingle (`battle_end_music`) now plays as a real
+  one-shot "ME" rather than the immediately-cut-off looping BGM this
+  paragraph used to describe: `#play_victory_bgm` calls
+  `RGSS::Audio.me_play`, the same native music-effect primitive
+  `mruby-rpgvx`'s own `RPG::ME#play` already forwards to
+  (`src/sdl_audio.cxx`'s `me_play`/`me_stop`, which auto-pause the BGM
+  channel while the effect plays and auto-resume it once the effect ends),
+  instead of the ordinary looping `#play_bgm`. `#restore_pre_battle_bgm`
+  calls `RGSS::Audio.me_stop` before restarting the pre-battle field/vehicle
+  track, ending the fanfare through the ME's own stop path — a no-op once it
+  has already finished on its own — rather than a bare `RGSS::Audio.bgm_play`
+  yanking the shared music stream out from under it. Covered by
+  `scripts/rpg2k_scene_check.rb` checks (an Enemy Encounter plays the
+  configured battle BGM at its own vol/tempo the moment the battle UI opens,
+  and the field BGM that was playing before replays once the fight is won;
+  the victory fanfare plays through the ME channel rather than an ordinary
+  BGM play, and dismissing the result screen stops it through
+  `RGSS::Audio.me_stop` before the field track restarts), confirmed to fail
+  against the pre-fix code before the fix.
   **A Change System BGM override for the battle slot (slot 0) is now
   consumed too**: `#play_battle_bgm`'s music source used to be
   `db.system.battle_music` unconditionally, so an event that ran Change
@@ -1551,7 +1561,11 @@ The work below is roughly ordered by the critical path to a walkable game
   lookup on slot 1, and `#play_victory_bgm` is called from
   `#enter_battle_result` on `:victory`, leaving `#restore_pre_battle_bgm`
   (called from `#finish_battle` as before) to do the same job it already did
-  for escape and defeat. Only inn (slot 2) is still save-fidelity-only, since
+  for escape and defeat. (`#play_victory_bgm` originally played the fanfare
+  as an ordinary looping BGM, cut off the instant the result screen was
+  dismissed rather than as a real one-shot fanfare; it now plays it through
+  `RGSS::Audio.me_play`/`me_stop` instead — see the battle-BGM paragraph
+  above.) Only inn (slot 2) is still save-fidelity-only, since
   no inn / lodging screen exists in this build. Covered by two new
   `scripts/rpg2k_scene_check.rb` checks (the database `battle_end_music`
   plays over the result screen and the field BGM resumes only once

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1922,16 +1922,19 @@ class RPG2k
       # #play_battle_bgm swaps in the battle track when the fight opens. RPG_RT
       # stops the battle BGM the instant the last enemy falls and plays the
       # System's battle_end_music (Change System BGM slot 1) for the "Victory! /
-      # EXP gained" screen; #restore_pre_battle_bgm already brings the
-      # pre-battle field/vehicle track back once that screen is dismissed
-      # (#finish_battle), so nothing here needs to remember or restore
-      # anything of its own. A game with no victory BGM configured leaves
-      # whatever was playing (the battle track) alone, the same blank-Music
-      # no-op #battle_bgm documents.
+      # EXP gained" screen -- a genuine one-shot "ME" (music effect), not an
+      # ordinary looping track, so RGSS::Audio.me_play is what plays it rather
+      # than #play_bgm: SDL_mixer's ME channel plays it exactly once and, left
+      # alone, auto-resumes whatever BGM it interrupted once it ends.
+      # #restore_pre_battle_bgm already brings the pre-battle field/vehicle
+      # track back once that screen is dismissed (#finish_battle), so nothing
+      # here needs to remember or restore anything of its own. A game with no
+      # victory BGM configured leaves whatever was playing (the battle track)
+      # alone, the same blank-Music no-op #battle_bgm documents.
       def play_victory_bgm
         music = victory_bgm
         return unless music
-        play_bgm(music)
+        RGSS::Audio.me_play(music[:name], music[:volume] || 100, music[:tempo] || 100)
       rescue StandardError => e
         $stderr.puts "[RPG2k] victory BGM failed: #{e.message}"
       end
@@ -1958,10 +1961,21 @@ class RPG2k
       # so the field/vehicle track was never interrupted and there is nothing
       # to bring back -- and when the party is headed to the Game Over screen
       # instead, which plays its own music and never returns to this map.
+      #
+      # A victory's fanfare (#play_victory_bgm's RGSS::Audio.me_play) is still
+      # a one-shot "ME" playing over the (silent, since the battle BGM stopped
+      # when the last enemy fell) music channel at this point if the player
+      # dismissed the result screen before it finished on its own --
+      # RGSS::Audio.me_stop ends it cleanly through the ME's own stop path
+      # (a no-op if it had already finished) rather than leaving #play_bgm's
+      # RGSS::Audio.bgm_play to yank the shared music stream out from under
+      # it. Harmless to call for an escape or a defeat too: there is no ME
+      # active then, so it is a no-op.
       def restore_pre_battle_bgm
         bgm = @pre_battle_bgm
         @pre_battle_bgm = nil
         return unless bgm && bgm[:name] && !bgm[:name].empty?
+        RGSS::Audio.me_stop
         play_bgm(bgm)
       rescue StandardError => e
         $stderr.puts "[RPG2k] restoring BGM after battle failed: #{e.message}"

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -157,7 +157,13 @@ module RGSS
     # screen) can assert which track started.
     class << self; attr_accessor :bgm_calls; end
     def self.bgm_play(*a); (@bgm_calls ||= []) << a; end
-    def self.reset_bgm; @bgm_calls = []; @bgm_volume_calls = []; @bgm_fade_calls = []; end
+    def self.reset_bgm
+      @bgm_calls = []
+      @bgm_volume_calls = []
+      @bgm_fade_calls = []
+      @me_calls = []
+      @me_stop_calls = 0
+    end
     # Recorded separately from bgm_calls: a same-file Play BGM re-trigger
     # calls this instead of bgm_play (see Game::Interpreter#play_audio /
     # Scene::Map#play_bgm), so the two checks stay distinguishable.
@@ -172,6 +178,14 @@ module RGSS
     # driven: a value that jumps backwards is how SDL_mixer reports a loop.
     class << self; attr_accessor :pos; end
     def self.bgm_pos; @pos || 0; end
+    # Record me_play/me_stop calls (the victory fanfare, #play_victory_bgm /
+    # #restore_pre_battle_bgm) separately from bgm_calls -- the whole point of
+    # the fix they cover is that the fanfare goes through the one-shot ME
+    # channel rather than the ordinary looping BGM one, so a check needs to
+    # tell the two apart.
+    class << self; attr_accessor :me_calls, :me_stop_calls; end
+    def self.me_play(*a); (@me_calls ||= []) << a; end
+    def self.me_stop; @me_stop_calls = (@me_stop_calls || 0) + 1; end
     # Record se_play calls so system-SFX checks can assert which sound fired.
     class << self; attr_accessor :se_calls; end
     def self.se_play(*a); (@se_calls ||= []) << a; end
@@ -5003,13 +5017,20 @@ check 'Enemy Encounter scene: victory plays the database battle_end_music over t
   2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
   RGSS::Audio.reset_bgm
   battle_attack_to_end(scene) # Attack the Slimes each round until they fall
-  eq [['VictoryBGM', 90, 105]], RGSS::Audio.bgm_calls,
-     'the victory fanfare played as soon as the result screen appeared'
-  eq 'VictoryBGM', st.current_bgm[:name]
+  eq [], RGSS::Audio.bgm_calls,
+     'the fanfare is a one-shot ME, not an ordinary looping BGM play'
+  eq [['VictoryBGM', 90, 105]], RGSS::Audio.me_calls,
+     'the victory fanfare played over the result screen through the ME channel'
+  eq 'BattleBGM', st.current_bgm[:name],
+     "the ME is not tracked as the ongoing BGM -- #current_bgm still names " \
+     'whatever the last actual BGM play was (the battle track)'
   RGSS::Audio.reset_bgm
   RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result
   scene.update
   RGSS::Input.triggered = []
+  eq 1, RGSS::Audio.me_stop_calls,
+     'the fanfare is ended through its own ME stop path rather than a bare BGM play ' \
+     'yanking the shared music stream out from under it'
   eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
      'the field BGM that was playing before the fight replays once the result is dismissed'
   eq 'Field', st.current_bgm[:name]
@@ -5030,9 +5051,11 @@ check 'Enemy Encounter scene: a Change System BGM victory override beats the dat
   2.times { scene.update } # opens the battle UI (see battle_attack_to_end above)
   RGSS::Audio.reset_bgm
   battle_attack_to_end(scene) # Attack the Slimes each round until they fall
-  eq [['CustomVictory', 60, 130]], RGSS::Audio.bgm_calls,
+  eq [], RGSS::Audio.bgm_calls,
+     'the fanfare is a one-shot ME, not an ordinary looping BGM play'
+  eq [['CustomVictory', 60, 130]], RGSS::Audio.me_calls,
      'the Change System BGM override played instead of the database battle_end_music'
-  eq 'CustomVictory', st.current_bgm[:name]
+  eq 'BattleBGM', st.current_bgm[:name]
 end
 
 check 'Enemy Encounter scene: losing shows the defeat result, no rewards' do


### PR DESCRIPTION
## Summary

- `Scene::Map#play_victory_bgm` called the ordinary looping `#play_bgm` for the victory fanfare (`battle_end_music`), so it was cut off the instant the result screen was dismissed instead of playing once with the field BGM resuming after it — the "play a fixed jingle, then resume" primitive `docs/TODO.md`'s BGM note said this build's `RGSS::Audio` had no equivalent for.
- That primitive already exists: `RGSS::Audio.me_play`/`me_stop` (`mruby-rgss/mrblib/lib.rb`, backed by `src/sdl_audio.cxx`'s `me_play`/`me_stop`), the same one `mruby-rpgvx`'s own `RPG::ME#play` already forwards to — it auto-pauses the BGM channel while the one-shot effect plays and auto-resumes it once the effect ends.
- `#play_victory_bgm` now calls `RGSS::Audio.me_play` instead of `#play_bgm`, and `#restore_pre_battle_bgm` calls `RGSS::Audio.me_stop` before restarting the pre-battle field/vehicle track — ending the fanfare through its own stop path (a no-op once it has already finished on its own) rather than a bare `RGSS::Audio.bgm_play` yanking the shared music stream out from under it.
- Updated the docs/TODO.md BGM bullet (and its later restated paragraph) to reflect this is now addressed.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — updated the two existing victory-BGM checks for the new ME-based sequencing (asserting `RGSS::Audio.me_play`/`me_stop` calls instead of `bgm_play`) and added `me_play`/`me_stop` call tracking to the scene-check test stub. All 524 checks pass.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 785 checks pass (no regressions).
- [x] `pre-commit` hooks applicable to the changed file types (trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01H6V1fFQiLVDPuUAVgvpXVt)_