### PR TITLE
docs: confirm indirect addressing's index&lt;=0 failure modes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5179,16 +5179,24 @@ not yet verified:
   both operand-sign combinations, plus an unaffected same-sign control case;
   divide-by-zero leaves the variable unchanged while modulo-by-zero zeroes
   it), confirmed to fail against the pre-fix code before the fix.
-- **Indirect ("pointer") addressing** — `V[n]`, where the *value* of
+- ✅ **Indirect ("pointer") addressing** — `V[n]`, where the *value* of
   variable n becomes the actual target/operand variable's index — is a
   distinct third addressing mode from a literal variable number or a
   direct-copy-of-another-variable's-value, and it can reach indices well
   past the configured max (used deliberately, though the site warns large
   indices measurably slow opening the Save screen — corroborated by an
   entire `09_bug/` page on the topic). Indirect addressing's failure mode
-  on an index ≤0 differs by role: the **operand** form already resolved to
-  0 (`Variables`/`Switches`' own default for a missing key); the **target**
-  form is fixed now too, see below.
+  on an index ≤0 differs by role, and both halves are now confirmed
+  correct: the **operand** form already resolved to 0
+  (`Game::Interpreter#operand_value`'s indirect case reads
+  `variables[variables[cmd.param(5)]]`, and `Variables#[]`/`Switches#[]`
+  default any missing key — including index ≤0 — to 0/false, matching
+  EasyRPG's own `Game_Variables::Get` returning 0 for `variable_id <= 0`);
+  the **target** form is a genuine no-op rather than a stray write to slot
+  0 (`Game::Interpreter#range`'s mode-2 branch returns an empty range for
+  an index ≤0, so the caller's `(a..b).each` iterates zero times, matching
+  EasyRPG's own `Game_Switches::Set`/`Game_Variables::SetOp`, both of which
+  refuse an id ≤0 outright) — fixed now too, see below.
 - ✅ **Batch (range) operations requiring ascending order or silently no-op is
   confirmed already correct.** `Game::Interpreter#range` returns a batch's
   two ends verbatim with no ordering check, and Ruby's `(a..b).each` on a


### PR DESCRIPTION
## Summary
- `docs/TODO.md`'s "Indirect (\"pointer\") addressing" bullet claimed the operand form of `V[n]` indirect addressing resolves an index ≤0 to 0, and the target form is a no-op, without a leading ✅.
- Both halves confirmed correct against the actual implementation: `Game::Interpreter#operand_value`'s indirect case (`variables[variables[cmd.param(5)]]`) reads through `Variables#[]`/`Switches#[]`, which default any missing key — including index ≤0 — to 0/false; `Game::Interpreter#range`'s mode-2 branch returns an empty range for an index ≤0, so the caller's `(a..b).each` iterates zero times rather than writing to slot 0.
- Cross-referenced against EasyRPG Player's source: `Game_Variables::Get` returns 0 for `variable_id <= 0`, and both `Game_Switches::Set`/`Game_Variables::SetOp` refuse an id ≤0 outright — matching this codebase's read-defaults-to-0/write-no-ops asymmetry exactly.
- Docs-only change: no code changes, no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_