### PR TITLE
Call Event reports an unresolved target instead of a silent no-op

### DIFF
--- a/changelog.d/call-event-invalid-target-reported.fixed.md
+++ b/changelog.d/call-event-invalid-target-reported.fixed.md
@@ -1,0 +1,8 @@
+- **Call Event now reports an unresolved target** (a stale/missing map event
+  id, a stale page number, "This Event" used inside a Common Event, or an
+  unknown common-event id) as a `[RPG2k] Call Event: ...` diagnostic instead
+  of silently resolving to nothing, matching the reported-not-invented
+  pattern already used elsewhere (Toggle Fullscreen, Call Common Event).
+  `Interpreter#resolve_call`/`#map_event_call`
+  (`mruby-rpg2k/mrblib/interpreter.rb`). Covered by four new
+  `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3794,13 +3794,16 @@ Everything below is unverified against the codebase.
   already independently confirmed elsewhere in this doc. `MAX_CALL_DEPTH =
   1000` matches "nesting caps at 1000" exactly, and "caller resumes right
   after itself" is the natural consequence of the call-stack push/pop.
-  Calling a bad event/page id's specific Windows error dialogs, the heavy-
-  load freeze and its `Wait:0.0s` workaround (a timing/performance edge
-  case), and "Battle Events can't use Call Event through the normal editor"
-  (an editor-authoring limitation with no runtime analog) remain
-  unverifiable in this environment and are not modelled. ("A variable can't
-  pick the called common-event id directly" is confirmed already correct —
-  see below.)
+  Calling a bad event/page id no longer resolves to nothing untraceably —
+  `#resolve_call`/`#map_event_call` now log a `[RPG2k] Call Event: ...`
+  diagnostic for an unresolved target instead (see the "Concrete runtime
+  error catalog" entry below) — but the specific Windows error dialogs
+  themselves, the heavy-load freeze and its `Wait:0.0s` workaround (a
+  timing/performance edge case), and "Battle Events can't use Call Event
+  through the normal editor" (an editor-authoring limitation with no
+  runtime analog) remain unverifiable in this environment and are not
+  modelled. ("A variable can't pick the called common-event id directly" is
+  confirmed already correct — see below.)
 - **Wait** — an inline "(W)" wait option is identical to a separate Wait
   command; Wait 0.0s is one frame, not zero (**confirmed correct**, see
   above).
@@ -7662,6 +7665,29 @@ specific stale tile, invalid battle animation only when it would actually
 display, invalid skill only when a skill-select screen opens (or, if the
 dangling ref is in a hero's learned-skill list, at the moment of
 level-up).
+✅ **Call Event no longer swallows three of the four "invalid event ID"
+causes above, plus the separate "invalid event page" case** — this codebase
+has no error-dialog UI to show real RPG_RT's popup, but the target now
+gets a logged `[RPG2k] Call Event: ...` diagnostic (the same
+reported-not-invented pattern Toggle Fullscreen and Call Common Event
+already use) instead of resolving to nothing with no trace. `Interpreter
+#resolve_call` (`mruby-rpg2k/mrblib/interpreter.rb`) reports an unresolved
+common-event target (mode 0) and any exception raised while resolving a
+target; `#map_event_call` reports "This Event" used with no map-event
+context (mode 1/2 from inside a common event, `#character_ref` returning
+`nil`) and a map-event target whose id or page number doesn't resolve
+(mode 1/2, covering both the "common event referencing a map-event ID
+absent on the current map" cause and "a variable-driven Call Event
+resolving to no match", plus invalid-event-page as a distinct message from
+invalid-event-id). The remaining "invalid event ID" cause — a stale
+Variable-Op/Move-Route target — is a different command family, not part
+of Call Event, and is still open. **Store Event ID has no analogous gap**:
+unlike Call Event it never targets an event *by id*, only by tile position
+(`#do_store_event_id`), and "no event on this tile" (stored as `0`) is a
+genuine, correctly-modelled answer rather than a stale reference — nothing
+there was silently failing. Covered by four new
+`scripts/rpg2k_logic_check.rb` checks (one per new diagnostic path),
+each asserting on the exact captured `$stderr` line.
 
 **Map/Event ID assignment & tile occupancy**
 - Event IDs (and separately, Map IDs) are assigned by **creation order**

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -938,7 +938,9 @@ module Game
     # another page of the event already running — RPG_RT resolves the id through
     # the same `GetCharacter` every other character reference uses, so a game can
     # keep a page of shared subroutine commands on the event itself.
-    # A missing/empty target is a no-op; recursion is bounded by MAX_CALL_DEPTH.
+    # A missing target is a logged no-op (see #resolve_call/#map_event_call); an
+    # empty (but resolved) target is a silent no-op, since that page/event
+    # genuinely has nothing to run. Recursion is bounded by MAX_CALL_DEPTH.
     def do_call_event(cmd)
       return unless @resolver
       cmds = resolve_call(cmd)
@@ -951,22 +953,37 @@ module Game
 
     def resolve_call(cmd)
       case cmd.param(0)
-      when 0 then @resolver.common_event_commands(cmd.param(1))
+      when 0
+        id = cmd.param(1)
+        cmds = @resolver.common_event_commands(id)
+        $stderr.puts "[RPG2k] Call Event: common event #{id} not found" if cmds.nil?
+        cmds
       when 1 then map_event_call(cmd.param(1), cmd.param(2))
       when 2 then map_event_call(variables[cmd.param(1)],
                                  variables[cmd.param(2)])
       end
-    rescue StandardError
+    rescue StandardError => e
+      $stderr.puts "[RPG2k] Call Event: failed to resolve target: #{e.message}"
       nil
     end
 
     # The command list of a map event's page, with the event id resolved through
     # #character_ref so "this event" reaches the running event. An unresolvable
-    # reference (a common event calling "this event") has no page to run.
+    # reference (a common event calling "this event") has no page to run, and a
+    # stale event id or page number resolves to no commands either -- both are
+    # reported here rather than left a silent no-op, matching real RPG_RT's
+    # error dialog for the same targets (see docs/TODO.md's runtime error
+    # catalog).
     def map_event_call(event_ref, page)
       id = character_ref(event_ref)
-      return nil if id.nil?
-      @resolver.map_event_commands(id, page)
+      if id.nil?
+        $stderr.puts '[RPG2k] Call Event: "this event" has no map event to ' \
+                     'refer to (running inside a common event)'
+        return nil
+      end
+      cmds = @resolver.map_event_commands(id, page)
+      $stderr.puts "[RPG2k] Call Event: map event #{id} page #{page} not found" if cmds.nil?
+      cmds
     end
 
     # Translate a command's character reference into the map event id the scene

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -82,6 +82,17 @@ def ok(cond, msg = 'expected truthy')
   raise msg unless cond
 end
 
+# Runs the block with $stderr redirected to a StringIO and returns everything
+# written to it, for checks that assert on a "[RPG2k] ..." diagnostic line.
+def capture_stderr
+  old_stderr = $stderr
+  $stderr = StringIO.new
+  yield
+  $stderr.string
+ensure
+  $stderr = old_stderr
+end
+
 # -- fakes --------------------------------------------------------------------
 
 # A grid world implementing the MoveRoute/MoveType `world` protocol. Passability
@@ -1419,6 +1430,17 @@ check 'a missing Call Event target is a no-op and the caller continues' do
   ok !it.running?
 end
 
+check 'a missing Call Event common-event target is reported, not silent' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(common: {}) # id 5 not defined
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0])])
+    it.update
+  end
+  ok out.include?('[RPG2k] Call Event: common event 5 not found'), out
+end
+
 check 'a face set inside a Call Event survives back into the caller and clears only once the caller finishes too' do
   st = new_state
   cfg = st.message_config
@@ -1724,6 +1746,56 @@ check 'Call Event on "this event" from a common event is a no-op' do
   it.update
   eq false, st.switches[9], 'there is no "this event" to call'
   eq true, st.switches[1], 'and the caller carries on'
+end
+
+check 'Call Event on "this event" from a common event reports the unresolved target' do
+  st = new_state
+  page2 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(maps: { 7 => { 2 => page2 } })
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CALL_EVENT, [1, 10005, 2])]) # no event is running it
+    it.update
+  end
+  ok out.include?('[RPG2k] Call Event: "this event" has no map event to refer to'), out
+end
+
+check 'Call Event targeting a stale map event id or page is reported, not silent' do
+  st = new_state
+  page2 = [FakeCmd.new(IC::CONTROL_SWITCHES, [0, 9, 9, 0])]
+  it = Game::Interpreter.new(st)
+  it.resolver = FakeResolver.new(maps: { 7 => { 2 => page2 } })
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CALL_EVENT, [1, 8, 2])]) # event 8 does not exist
+    it.update
+  end
+  ok out.include?('[RPG2k] Call Event: map event 8 page 2 not found'), out
+
+  st2 = new_state
+  it2 = Game::Interpreter.new(st2)
+  it2.resolver = FakeResolver.new(maps: { 7 => { 2 => page2 } })
+  out2 = capture_stderr do
+    it2.start([FakeCmd.new(IC::CALL_EVENT, [1, 7, 3])]) # event 7 has no page 3
+    it2.update
+  end
+  ok out2.include?('[RPG2k] Call Event: map event 7 page 3 not found'), out2
+end
+
+check 'a Call Event resolver failure is reported instead of swallowed' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  failing_resolver = Object.new
+  def failing_resolver.common_event_commands(_id)
+    raise 'resolver exploded'
+  end
+  it.resolver = failing_resolver
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CALL_EVENT, [0, 5, 0]),
+              FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0])])
+    it.update
+  end
+  ok out.include?('[RPG2k] Call Event: failed to resolve target: resolver exploded'), out
+  eq true, st.switches[1], 'the caller still continues after the failed call'
 end
 
 check 'Call Event has no indirect mode for a common event id (target 0 stays literal)' do


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s runtime error catalog documents that real RPG_RT shows an error dialog when Call Event targets a stale event id/page, or when "This Event" is used inside a Common Event (no map event to refer to). This codebase's `Interpreter#do_call_event`/`#resolve_call`/`#map_event_call`/`#character_ref` (`mruby-rpg2k/mrblib/interpreter.rb`) previously resolved these cases to `nil` untraceably.
- `#resolve_call`/`#map_event_call` now emit a `[RPG2k] Call Event: ...` diagnostic for each unresolved-target case, following the exact `$stderr.puts` convention already used by Toggle Fullscreen and Call Common Event:
  - an unknown common-event id (mode 0)
  - "This Event" used with no map-event context (mode 1/2 from inside a Common Event)
  - a map-event target whose id or page number doesn't resolve (mode 1/2 — covers a stale id, a stale page, and a variable-driven Call Event resolving to no match)
  - any exception raised while resolving a target
- Gameplay behavior is unchanged — still a no-op, diagnostics only, matching how Toggle Fullscreen works.
- `Store Event ID` (`#do_store_event_id`) has no analogous gap: unlike Call Event it resolves by tile position, not by id, so "no event here" (`0`) is already a genuine, correctly-modelled answer rather than a stale reference.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 792 checks passed (4 new checks added, one per new diagnostic path, each asserting on the captured `$stderr` output)
- [x] Manually verified no trailing whitespace / missing EOF newline on touched files (`pre-commit` binary unavailable in this environment; the only applicable hooks for `.rb`/`.md` files are `trailing-whitespace`/`end-of-file-fixer`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbU9M6LdJ3ywRnmTiHuHWN)_