### PR TITLE
fix(rpg2k): restore picture zoom/opacity/tone from save chunk 103

### DIFF
--- a/changelog.d/restore-picture-zoom-opacity-tone.fixed.md
+++ b/changelog.d/restore-picture-zoom-opacity-tone.fixed.md
@@ -1,0 +1,7 @@
+- **Resuming a save with a shown picture** now restores its zoom, opacity and
+  tone from chunk 103, not just the file name and centre position — the save's
+  fields use the exact same scale as the live Show Picture command's own
+  zoom/transparency/tone parameters, so `Game::State.restore_pictures` converts
+  transparency through the same `#trans_to_opacity` the command uses and reads
+  zoom/tone straight through, matching `Picture`'s own defaults when a field is
+  absent. Covered by a synthetic-chunk round-trip in `rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -165,9 +165,17 @@ The work below is roughly ordered by the critical path to a walkable game
     slots as doubles of unknown meaning; **31/32 are the centre position**,
     identified by rewriting each candidate pair in a real save and diffing the
     resumed frame against the unedited one (see the ADR 0021 table). The picture
-    region of the resumed frame is now pixel-identical to RPG_RT. Zoom, opacity
-    and tone have save fields but no sample where they are off their defaults,
-    so they are still left at `Picture`'s defaults rather than guessed at.
+    region of the resumed frame is now pixel-identical to RPG_RT. Zoom (33),
+    transparency (34) and tone (41-44) are now restored too — the "no sample
+    off-default" worry was really about validating the field mapping, and that
+    is settled without a sample: the schema's own field names (拡大率/透明度/
+    色調) match Show Picture's param5/param6/param8-11 one for one, and that
+    live path already converts transparency through `#trans_to_opacity` and
+    feeds zoom/tone straight into `Picture#zoom`/red/green/blue/saturation —
+    `Game::State.restore_pictures` now does exactly the same conversion,
+    covered by a synthetic-chunk round-trip in `rpg2k_logic_check.rb` (`to_lsd`
+    does not write chunk 103 itself yet, so there is no live save to round-trip
+    through).
   - ✅ **`Game::State#to_lsd` output is loadable by RPG_RT.** It round-tripped
     through our own parser (`scripts/lcf_save_roundtrip.rb`) but the genuine
     runtime left "Continue" dead, with no error anywhere. The assumed cause —

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -493,6 +493,15 @@ module Game
     v
   end
 
+  # RPG2000 transparency (0 opaque .. 100 fully clear) -> a 0..255 opacity.
+  # Shared by Interpreter#trans_to_opacity (Show/Move Picture's live param) and
+  # Game::State.restore_pictures (the save's chunk 103 field 34), which use the
+  # same 0..100 scale -- see restore_pictures' comment for how that was
+  # confirmed.
+  def self.trans_to_opacity(top_trans)
+    (100 - clamp(top_trans, 0, 100)) * 255 / 100
+  end
+
   # Top-left pixel of the view so the player is centred, clamped so the camera
   # never scrolls past the edges of a map smaller/larger than the screen.
   def self.camera_offset(player_px, screen_px, map_px)
@@ -9968,19 +9977,34 @@ module Game
     # has already run and will not run again: resuming Nepheshel's opening, the
     # genuine RPG_RT drew the backdrop and we drew black. See ADR 0021.
     #
-    # Only the fields the save actually pins down are restored -- the file name
-    # and the centre position. Zoom, opacity and tone have their own save fields,
-    # but this build has never had a sample where they are not at their defaults,
-    # so reading them would be guesswork; they take Picture's defaults instead.
+    # Zoom (field 33), transparency (34) and tone (41-44) are now restored too,
+    # not just the name and centre position. The earlier version left these at
+    # Picture's defaults, reasoning that with no sample save pinning a picture
+    # off its defaults, wiring them would be guesswork -- but the schema's own
+    # field names (rpg2kpsp: 拡大率/透明度/色調, "zoom rate/transparency/tone")
+    # already match Show Picture's own param5/param6/param8-11 one for one (see
+    # #do_show_picture), and that live path is exercised and tested elsewhere in
+    # this codebase: zoom is a raw percentage fed straight into Picture#zoom
+    # (default 100), tone is raw ints fed straight into Picture's red/green/
+    # blue/saturation (default 100, neutral), and transparency is the same
+    # 0 (opaque) .. 100 (clear) scale #trans_to_opacity already converts to a
+    # 0..255 opacity for the live command. There is nothing save-format-specific
+    # left to guess: the save's fields and the command's params are the same
+    # numbers, so they are read the same way here.
     def self.restore_pictures(state, pictures)
       return unless pictures
       pictures.each do |id, pic|
         next unless pic
         name = pic.name
         next if name.nil? || name.empty?
+        transparency = pic.transparency
         state.show_picture(id, name: name,
                                x: (pic.current_x || 0).to_i,
-                               y: (pic.current_y || 0).to_i)
+                               y: (pic.current_y || 0).to_i,
+                               zoom: pic.zoom,
+                               opacity: transparency ? Game.trans_to_opacity(transparency) : nil,
+                               red: pic.tone_red, green: pic.tone_green,
+                               blue: pic.tone_blue, saturation: pic.tone_saturation)
       end
     end
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2896,7 +2896,7 @@ module Game
 
     # RPG2000 transparency (0 opaque .. 100 fully clear) -> a 0..255 opacity.
     def trans_to_opacity(top_trans)
-      (100 - Game.clamp(top_trans, 0, 100)) * 255 / 100
+      Game.trans_to_opacity(top_trans)
     end
 
     # The picture's file name (the command's string parameter), or ''.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3059,6 +3059,67 @@ check 'to_lsd/from_lsd round-trips both Timer Operation countdowns' do
   eq false, old.timer(1).running
 end
 
+check 'restore_pictures restores zoom, opacity and tone, not just name/position' do
+  # These used to stay at Picture's defaults: no sample save had them off-
+  # default, so reading save fields 33/34/41-44 would have been guesswork. That
+  # is resolved by cross-checking against the *live* Show Picture command
+  # (#do_show_picture, interpreter.rb), which is already exercised elsewhere in
+  # this codebase and uses the exact same field semantics the rpg2kpsp save
+  # schema names: zoom (33, "拡大率") is a raw percentage fed straight into
+  # Picture#zoom, tone (41-44, "色調") are raw ints fed straight into Picture's
+  # red/green/blue/saturation, and transparency (34, "透明度") is the same
+  # 0 (opaque) .. 100 (clear) scale #trans_to_opacity already converts for the
+  # live command. `to_lsd` does not write chunk 103 yet (see ADR 0021's
+  # addendum), so this builds a synthetic chunk 103 entry directly rather than
+  # round-tripping through our own writer.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+
+  pic = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+  pic[1] = 'backdrop'
+  pic[31] = 200.0
+  pic[32] = 150.0
+  pic[33] = 150 # zoom: 150%
+  pic[34] = 25  # transparency: 25 (out of 100, clear side)
+  pic[41] = 50  # tone red
+  pic[42] = 60  # tone green
+  pic[43] = 70  # tone blue
+  pic[44] = 80  # tone saturation
+  pictures = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+  pictures[3] = pic
+
+  Game::State.restore_pictures(st, pictures)
+  restored = st.pictures[3]
+  ok !restored.nil?, 'the picture is shown'
+  eq 'backdrop', restored.name
+  eq 200, restored.x
+  eq 150, restored.y
+  eq 150, restored.zoom, 'zoom is the save\'s raw percentage, matching Show Picture\'s own param5'
+  eq Game.trans_to_opacity(25), restored.opacity,
+     'transparency converts through the same 0..100 -> 0..255 scale Show Picture uses'
+  eq 191, restored.opacity, 'trans_to_opacity(25) == (100-25)*255/100 == 191'
+  eq 50, restored.red
+  eq 60, restored.green
+  eq 70, restored.blue
+  eq 80, restored.saturation
+
+  # A picture entry with none of these fields present (an older-style save, or
+  # a still-empty slot) must keep Picture's own defaults rather than crash on a
+  # nil transparency reaching #trans_to_opacity.
+  bare = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+  bare[1] = 'plain'
+  bare_pictures = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })
+  bare_pictures[4] = bare
+  Game::State.restore_pictures(st, bare_pictures)
+  plain = st.pictures[4]
+  eq 100, plain.zoom, 'no saved zoom keeps Picture\'s default'
+  eq 255, plain.opacity, 'no saved transparency keeps Picture\'s default opacity'
+  eq 100, plain.red
+  eq 100, plain.green
+  eq 100, plain.blue
+  eq 100, plain.saturation
+end
+
 # -- the permanent actor roster (Game::Actors) --------------------------------
 #
 # Nepheshel drives its whole party mechanic through Change Party Member: it adds


### PR DESCRIPTION
## Summary

- `Game::State.restore_pictures` used to restore only a shown picture's name
  and centre position from save chunk 103, leaving zoom/opacity/tone at
  `Picture`'s defaults. The comment justified this as "guesswork" since no
  sample save pinned these fields off their defaults.
- That worry is really about validating the field mapping, not about the
  fields being unused: the save schema's own field names (rpg2kpsp: 拡大率/
  透明度/色調 — "zoom rate/transparency/tone") match Show Picture's own
  `param5`/`param6`/`param8-11` one for one (`Interpreter#do_show_picture`),
  and that live path is already exercised elsewhere in this codebase. Zoom
  and tone are raw values fed straight into `Picture#zoom`/red/green/blue/
  saturation; transparency is the same 0 (opaque)..100 (clear) scale
  `#trans_to_opacity` already converts to a 0..255 opacity for the live
  command.
- Factored `trans_to_opacity` out to `Game.trans_to_opacity` so
  `Interpreter#trans_to_opacity` and `Game::State.restore_pictures` share the
  exact same conversion rather than duplicating it.
- `to_lsd` does not write chunk 103 yet (still true as of this change — see
  ADR 0021's addendum), so there is no live save to round-trip through;
  instead the new test builds a synthetic chunk 103 entry directly and
  asserts the restored `Game::Picture` reflects non-default zoom/opacity/
  tone, plus that an entry with none of these fields still falls back to
  `Picture`'s own defaults (no crash on a nil transparency reaching
  `#trans_to_opacity`).
- Updated `docs/TODO.md`'s `restore_pictures` bullet to drop the "guesswork"
  framing and describe what was actually confirmed.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 789 checks passed, including the
      new `restore_pictures restores zoom, opacity and tone, not just
      name/position` check.


---
_Generated by [Claude Code](https://claude.ai/code/session_012mW1XbHEJSByzn7VW65KXo)_