### PR TITLE
Round-trip Change System BGM/SFX overrides through .lsd Save/Continue

### DIFF
--- a/changelog.d/system-bgm-sfx-lsd-roundtrip.added.md
+++ b/changelog.d/system-bgm-sfx-lsd-roundtrip.added.md
@@ -1,0 +1,5 @@
+- **Change System BGM** (10660) and **Change System SFX** (10670) overrides
+  now round-trip through a real `.lsd` Save/Continue, not just the portable
+  `Marshal` save — `Game::State#to_lsd` writes every populated slot into its
+  `SAVE_SYSTEM` field (BGM 72-74/79-82, SFX 91-102) and `.from_lsd` reads them
+  back.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2464,6 +2464,25 @@ The work below is roughly ordered by the critical path to a walkable game
   further since it needs another actor's data point to tell the two apart;
   `scripts/rpg2k_save_load_check.rb` skips its hp/mp-within-max assertion for
   this one actor rather than asserting either guess.
+  ✅ **Change System BGM (10660) / Change System SFX (10670) overrides now
+  round-trip through the `.lsd` too**, not just the portable `Marshal` save.
+  `Game::State#system_bgm`/`#system_sfx` (populated by
+  `Interpreter#do_change_system_bgm`/`#do_change_system_sfx`) used to stay
+  Marshal-only even though `LCF::Schema::SAVE_SYSTEM` already decoded every
+  slot's field (BGM: `title_bgm`(71, no Change System BGM slot maps to it —
+  RPG_RT never lets that command override the title screen's own music) /
+  `battle_bgm`(72) / `battle_end_bgm`(73) / `inn_bgm`(74) / `boat_bgm`(79) /
+  `ship_bgm`(80) / `airship_bgm`(81) / `gameover_bgm`(82); SFX: `cursor_se`(91)
+  through `item_se`(102)). `Game::State#to_lsd` now writes every populated
+  slot into its field (a new `SYSTEM_BGM_SAVE_FIELD`/`SYSTEM_SFX_SAVE_FIELD`
+  slot → field map, matching EasyRPG's `Game_System::sys_bgm` enum for BGM
+  and `Scene::Base::DB_SE_FIELD`'s slot order for SFX, reusing `#bgm_chunk`
+  and a new `#se_chunk`), and `.from_lsd` reads them back (`.bgm_from_chunk`
+  and a new `.se_from_chunk`). Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (a battle-slot and a game-over-slot BGM override, plus a cursor-slot
+  and a battle-start-slot SFX override, all round-trip through an in-memory
+  `to_lsd`/`from_lsd`; an untouched slot comes back absent rather than a
+  spurious empty override).
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations (large; Nepheshel uses the default RPG2000 battle). Needs real
   assets + the native build to develop against. The game-over scene is done

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9724,6 +9724,17 @@ module Game
       sys[55] = @player_transparent ? true : false
       sys[75] = bgm_chunk(@current_bgm) if @current_bgm
       sys[78] = bgm_chunk(@memorized_bgm) if @memorized_bgm
+      # Change System BGM (10660) / Change System SFX (10670) overrides, one
+      # save field per populated slot (see SYSTEM_BGM_SAVE_FIELD /
+      # SYSTEM_SFX_SAVE_FIELD above).
+      SYSTEM_BGM_SAVE_FIELD.each do |slot, field|
+        bgm = @system_bgm[slot]
+        sys[field] = bgm_chunk(bgm) if bgm
+      end
+      SYSTEM_SFX_SAVE_FIELD.each do |slot, field|
+        se = @system_sfx[slot]
+        sys[field] = se_chunk(se) if se
+      end
       sys[121] = @teleport_access ? true : false
       sys[122] = @escape_access ? true : false
       sys[123] = @save_access ? true : false
@@ -9790,7 +9801,8 @@ module Game
 
     # Build a BGM chunk (an LCF::Array1D over the BGM schema) from our stored
     # `{ name:, volume:, tempo: }` hash: file (1), volume (3) and pitch (4). Used
-    # for the system chunk's current-BGM (75) and stored-BGM (78) slots.
+    # for the system chunk's current-BGM (75) and stored-BGM (78) slots, and
+    # (below) every Change System BGM override slot.
     def bgm_chunk(bgm)
       b = LCF::Array1D.new('', { elements: LCF::Schema::BGM })
       b[1] = bgm[:name] || ''
@@ -9798,6 +9810,37 @@ module Game
       b[4] = bgm[:tempo] || 100
       b
     end
+
+    # Build an SE chunk (an LCF::Array1D over the SE schema) from our stored
+    # `{ name:, volume:, tempo: }` hash: file (1), volume (3) and pitch (4).
+    # #bgm_chunk's SE counterpart, used for every Change System SFX override
+    # slot.
+    def se_chunk(se)
+      s = LCF::Array1D.new('', { elements: LCF::Schema::SE })
+      s[1] = se[:name] || ''
+      s[3] = se[:volume] || 100
+      s[4] = se[:tempo] || 100
+      s
+    end
+
+    # Change System BGM (10660) slot -> LCF::Schema::SAVE_SYSTEM field id,
+    # matching EasyRPG's Game_System::sys_bgm enum (Battle 0, Victory/
+    # BattleEnd 1, Inn 2, Boat 3, Ship 4, Airship 5, GameOver 6) against the
+    # save's title_bgm(71)/battle_bgm(72)/battle_end_bgm(73)/inn_bgm(74)/
+    # current_bgm(75)/stored_bgm(78)/boat_bgm(79)/ship_bgm(80)/airship_bgm(81)/
+    # gameover_bgm(82) fields. Field 71 (title_bgm) has no Change System BGM
+    # slot -- RPG_RT never lets that command override the title screen's own
+    # music -- so it is intentionally absent here.
+    SYSTEM_BGM_SAVE_FIELD = {
+      0 => 72, 1 => 73, 2 => 74, 3 => 79, 4 => 80, 5 => 81, 6 => 82
+    }.freeze
+
+    # Change System SFX (10670) slot -> LCF::Schema::SAVE_SYSTEM field id.
+    # Slot N is always field 91+N -- the save's cursor_se(91)..item_se(102)
+    # run keeps the exact same order as Scene::Base::DB_SE_FIELD's slots 0..11
+    # (cursor, decision, cancel, buzzer, battle/escape, the six per-hit
+    # sounds), just renamed and renumbered for the save chunk.
+    SYSTEM_SFX_SAVE_FIELD = (0..11).each_with_object({}) { |slot, h| h[slot] = 91 + slot }.freeze
 
     # Rebuild a State from a parsed LCF::SaveData -- a real Save<N>.lsd written
     # by an actual editor, rather than our own Marshal hash. The modelled fields
@@ -9896,6 +9939,22 @@ module Game
       # Overridden BGM playback state; an empty file name means "none".
       state.current_bgm = bgm_from_chunk(sys.current_bgm)
       state.memorized_bgm = bgm_from_chunk(sys.stored_bgm)
+      # Change System BGM (10660) / Change System SFX (10670) overrides, read
+      # back by the same slot -> field map #to_lsd wrote them with. A slot the
+      # save left un-overridden is simply absent from the hash, matching
+      # do_change_system_bgm/_sfx's own "unset slot" state.
+      system_bgm = {}
+      SYSTEM_BGM_SAVE_FIELD.each do |slot, field|
+        bgm = bgm_from_chunk(sys[field])
+        system_bgm[slot] = bgm if bgm
+      end
+      state.system_bgm = system_bgm
+      system_sfx = {}
+      SYSTEM_SFX_SAVE_FIELD.each do |slot, field|
+        se = se_from_chunk(sys[field])
+        system_sfx[slot] = se if se
+      end
+      state.system_sfx = system_sfx
       # Access flags: only an explicitly-stored value overrides the constructor
       # default (so a foreign save that omits them keeps our defaults).
       state.teleport_access = sys.teleport_allowed unless sys.teleport_allowed.nil?
@@ -10008,6 +10067,15 @@ module Game
     # (an LCF::Array1D over the BGM schema). Returns nil for an absent chunk or an
     # empty file name (the "use the database value" sentinel).
     def self.bgm_from_chunk(chunk)
+      return nil unless chunk
+      name = chunk.file
+      return nil if name.nil? || name.empty?
+      { name: name, volume: chunk.volume || 100, tempo: chunk.pitch || 100 }
+    end
+
+    # #bgm_from_chunk's SE counterpart: rebuild our `{ name:, volume:, tempo: }`
+    # SE hash from a parsed SE chunk (an LCF::Array1D over the SE schema).
+    def self.se_from_chunk(chunk)
       return nil unless chunk
       name = chunk.file
       return nil if name.nil? || name.empty?

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -3015,12 +3015,13 @@ module Game
     # param0. The remaining fields carry a Music struct: string = file name,
     # param1 fade-in, param2 volume, param3 tempo, param4 balance. Stashed in
     # a Game::State slot table; Scene::Map's #battle_bgm reads slot 0 (battle),
-    # #victory_bgm reads slot 1 (the "Victory!" result screen) and #vehicle_bgm
-    # reads slots 3-5 (boat/ship/airship) back out ahead of the database
-    # default, the same override-then-default idiom Change System SFX already
-    # gets; Scene::GameOver#gameover_bgm_override does the same for slot 6.
-    # Inn (2) still only round-trips through the save, since nothing plays it
-    # yet (no inn / lodging screen exists in this build).
+    # #victory_bgm reads slot 1 (the "Victory!" result screen), #inn_bgm reads
+    # slot 2 and #vehicle_bgm reads slots 3-5 (boat/ship/airship) back out
+    # ahead of the database default, the same override-then-default idiom
+    # Change System SFX already gets; Scene::GameOver#gameover_bgm_override
+    # does the same for slot 6. All seven slots round-trip through a real
+    # .lsd Save/Continue now too (Game::State#to_lsd/.from_lsd, SAVE_SYSTEM
+    # fields 72-74/79-82), not just the portable Marshal save.
     def do_change_system_bgm(cmd)
       @state.system_bgm[cmd.param(0)] = {
         name: cmd.string, fadein: cmd.param(1), volume: cmd.param(2),
@@ -3033,7 +3034,9 @@ module Game
     # string = file name, param1 volume, param2 tempo, param3 balance. The map
     # scene (Scene::Map::DB_SE_FIELD) already plays most of these slots at the
     # moments they name; a slot beyond the ones it plays is still stored for
-    # save fidelity, matching the system BGM.
+    # save fidelity, matching the system BGM -- all twelve slots round-trip
+    # through a real .lsd Save/Continue now too (SAVE_SYSTEM fields 91-102),
+    # not just the portable Marshal save.
     def do_change_system_sfx(cmd)
       @state.system_sfx[cmd.param(0)] = {
         name: cmd.string, volume: cmd.param(1),

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3022,6 +3022,37 @@ check 'to_lsd/from_lsd round-trips a Change Actor Title override' do
   eq '', cleared.party.leader.title, 'a cleared title round-trips as an empty string, not the database default'
 end
 
+check 'to_lsd/from_lsd round-trips Change System BGM / Change System SFX overrides' do
+  # do_change_system_bgm/_sfx (interpreter.rb) stash overrides in
+  # @state.system_bgm/@state.system_sfx, keyed by slot -- the same slots
+  # Scene::Map's #battle_bgm/#victory_bgm/#vehicle_bgm and
+  # Scene::GameOver#gameover_bgm_override, plus Scene::Base#system_se, read
+  # back out. These used to round-trip only through the portable Marshal
+  # save (Game::State#to_h/.load); #to_lsd/.from_lsd now write/read every
+  # slot too, via SAVE_SYSTEM's BGM fields 72-74/79-82 and SE fields 91-102.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.system_bgm[0] = { name: 'Battle1', fadein: 500, volume: 90, tempo: 110, balance: 50 }
+  st.system_bgm[6] = { name: 'GameOver1', fadein: 0, volume: 80, tempo: 100, balance: 50 }
+  st.system_sfx[0] = { name: 'Cursor1', volume: 95, tempo: 105, balance: 50 }
+  st.system_sfx[4] = { name: 'BattleStart1', volume: 85, tempo: 95, balance: 50 }
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq 'Battle1', round.system_bgm[0][:name], 'Change System BGM slot 0 (battle) round-trips'
+  eq 90, round.system_bgm[0][:volume]
+  eq 110, round.system_bgm[0][:tempo]
+  eq 'GameOver1', round.system_bgm[6][:name], 'Change System BGM slot 6 (game over) round-trips'
+  eq 'Cursor1', round.system_sfx[0][:name], 'Change System SFX slot 0 (cursor) round-trips'
+  eq 95, round.system_sfx[0][:volume]
+  eq 105, round.system_sfx[0][:tempo]
+  eq 'BattleStart1', round.system_sfx[4][:name], 'Change System SFX slot 4 (battle start) round-trips'
+
+  # A slot never touched by Change System BGM/SFX stays absent, not a
+  # spurious empty-string override.
+  eq nil, round.system_bgm[1], 'an untouched BGM slot round-trips as absent, not an empty override'
+  eq nil, round.system_sfx[1], 'an untouched SFX slot round-trips as absent, not an empty override'
+end
+
 check 'to_lsd/from_lsd round-trips both Timer Operation countdowns' do
   # docs/TODO.md used to call the game timer the one field the .lsd export
   # "cannot yet carry", guessing it would need "a documented chunk id" of its


### PR DESCRIPTION
## Summary

- `Game::State#system_bgm`/`#system_sfx` (populated by `Interpreter#do_change_system_bgm`/`#do_change_system_sfx`, Change System BGM 10660 / Change System SFX 10670) used to survive only the portable `Marshal` save — `LCF::Schema::SAVE_SYSTEM` already decoded every relevant field (BGM: `battle_bgm`(72), `battle_end_bgm`(73), `inn_bgm`(74), `boat_bgm`(79), `ship_bgm`(80), `airship_bgm`(81), `gameover_bgm`(82); SFX: `cursor_se`(91) through `item_se`(102)) but `#to_lsd`/`.from_lsd` never wrote/read them.
- `Game::State#to_lsd` now writes every populated slot into its field via new `SYSTEM_BGM_SAVE_FIELD`/`SYSTEM_SFX_SAVE_FIELD` slot → field maps (matching EasyRPG's `Game_System::sys_bgm` enum for BGM and `Scene::Base::DB_SE_FIELD`'s slot order for SFX), reusing the existing `#bgm_chunk` helper and a new `#se_chunk` counterpart.
- `.from_lsd` reads them back via the existing `.bgm_from_chunk` and a new `.se_from_chunk`.
- Updated the stale interpreter.rb comments and `docs/TODO.md`'s Save & Continue bullet to reflect that these overrides now round-trip through a real `.lsd` file, not just the Marshal save.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 789 checks passed, including a new round-trip check for a BGM slot (battle, game-over) and an SFX slot (cursor, battle-start), plus verifying an untouched slot round-trips as absent rather than a spurious empty override.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 526 checks passed (unaffected scene-level `system_bgm`/`system_sfx` coverage still green).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DC4MRq6FjxKdMDpi5k5BGr)_