### PR TITLE
Show the shop's purchased/sold confirmation after a transaction

### DIFF
--- a/changelog.d/rpg2k-shop-purchased-sold.added.md
+++ b/changelog.d/rpg2k-shop-purchased-sold.added.md
@@ -1,0 +1,18 @@
+- **The shop screen now shows the database's post-transaction confirmation.**
+  `mruby-lcf/mrblib/schema.rb` already decoded `shop_purchased1/2/3` and
+  `shop_sold1/2/3` (RPG2000's three shopkeeper "voices"), but nothing in
+  `mruby-rpg2k` ever read them: a buy or sell committed silently and dropped
+  the player straight back on the list. `Scene::Map` gains a `:purchased` /
+  `:sold` screen state, entered right after `Game::Shop#buy` / `#sell`
+  commits: `#shop_terms` resolves the right voice (English fallback on a
+  blank field, matching every other shop term), `#shop_header` draws it as
+  the screen's single line, and it is dismissed on a button press — like
+  every other message panel in this scene — back to the buy / sell list it
+  came from. Verified against EasyRPG's `Scene_Shop`/`Window_Shop`
+  (`Bought`/`Sold` modes draw the raw term with no item-name/price
+  interpolation and return to `Buy`/`Sell` respectively); this port swaps
+  their fixed one-second timer for the same button-driven dismissal used
+  everywhere else in the scene, since the transition itself already returns
+  to the same list. Covered by two new `scripts/rpg2k_scene_check.rb` checks
+  (buy and sell) confirming the term text shows and the list reappears after
+  the dismiss.

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3780,8 +3780,10 @@ class RPG2k
       # Drive an Open Shop wait. On the first frame the shop opens (a command
       # menu for a buy+sell shop, or straight to the buy / sell list for a
       # single-mode shop). Buying and selling happen one unit per confirm on
-      # Game::Shop; leaving resumes the interpreter with whether anything was
-      # traded (which picks the [Transaction] / [No Transaction] branch).
+      # Game::Shop, followed by a purchased / sold confirmation line before
+      # control returns to the list; leaving resumes the interpreter with
+      # whether anything was traded (which picks the [Transaction] /
+      # [No Transaction] branch).
       def drive_shop
         req = @interpreter.shop_request
         return @interpreter.resume_shop(false) unless req
@@ -3792,6 +3794,7 @@ class RPG2k
         case @shop[:screen]
         when :command  then drive_shop_command
         when :quantity then drive_shop_quantity
+        when :purchased, :sold then drive_shop_confirm
         else drive_shop_list
         end
       end
@@ -3829,7 +3832,10 @@ class RPG2k
           buy_number: nonblank([t.shop_buy_number1, t.shop_buy_number2, t.shop_buy_number3][i],
                                'How many will you buy?'),
           sell_number: nonblank([t.shop_sell_number1, t.shop_sell_number2, t.shop_sell_number3][i],
-                                'How many will you sell?')
+                                'How many will you sell?'),
+          purchased: nonblank([t.shop_purchased1, t.shop_purchased2, t.shop_purchased3][i],
+                              'Thank you!'),
+          sold: nonblank([t.shop_sold1, t.shop_sold2, t.shop_sold3][i], 'Thank you!')
         }
       end
 
@@ -3838,8 +3844,9 @@ class RPG2k
       # shopkeeper asking "anything else?" on returning to it after browsing
       # (EasyRPG's Window_Shop switches from `shop_greeting` to
       # `shop_regreeting` once the player has entered Buy or Sell mode -- a
-      # per-visit flag, not a persisted "have I shopped here before"), and a
-      # prompt on the buy / sell / quantity screens themselves. nil for any
+      # per-visit flag, not a persisted "have I shopped here before"), a
+      # prompt on the buy / sell / quantity screens themselves, and the
+      # purchased / sold confirmation once a transaction commits. nil for any
       # other screen, which #draw_shop reads as "no header row".
       def shop_header
         t = @shop[:terms]
@@ -3849,6 +3856,8 @@ class RPG2k
         when :sell then t[:sell_select]
         when :quantity
           @shop[:quantity][:mode] == :buy ? t[:buy_number] : t[:sell_number]
+        when :purchased then t[:purchased]
+        when :sold then t[:sold]
         end
       end
 
@@ -3881,6 +3890,8 @@ class RPG2k
             "#{unit * q[:count]}#{shop_gold_term}", q[:id]]]
         when :buy
           m.goods.map { |id| ["#{m.name(id)}  #{m.price(id)}#{shop_gold_term}", id] }
+        when :purchased, :sold
+          [] # the confirmation line is the whole screen -- no selectable rows
         else # :sell
           m.sellable_items.map do |id|
             ["#{m.name(id)} x#{@state.party.item_count(id)}  " \
@@ -3955,6 +3966,19 @@ class RPG2k
         end
       end
 
+      # The purchased / sold confirmation shown right after a transaction
+      # commits (Game::Shop#buy / #sell): a single line, dismissed on a
+      # button press the same way the battle event message panel is (see
+      # #drive_battle_event_message), then back to the list it came from --
+      # EasyRPG's own Scene_Shop::Bought / Sold modes return to Buy / Sell
+      # respectively (a timed auto-dismiss there; button-driven here to match
+      # every other message screen in this scene).
+      def drive_shop_confirm
+        return unless Input.trigger?(Input::C) || Input.trigger?(Input::B)
+        @shop[:screen] = @shop[:screen] == :purchased ? :buy : :sell
+        draw_shop
+      end
+
       # How far LEFT / RIGHT jump the quantity cursor — RPG_RT's shop counter
       # moves in tens on the horizontal axis so a stack of 99 is a few presses
       # away rather than ninety-nine.
@@ -3982,8 +4006,11 @@ class RPG2k
           draw_shop
         elsif Input.trigger?(Input::C)
           model = @shop[:model]
-          q[:mode] == :buy ? model.buy(q[:id], q[:count]) : model.sell(q[:id], q[:count])
-          close_shop_quantity
+          mode = q[:mode]
+          mode == :buy ? model.buy(q[:id], q[:count]) : model.sell(q[:id], q[:count])
+          @shop[:quantity] = nil
+          @shop[:screen] = mode == :buy ? :purchased : :sold
+          draw_shop
         elsif Input.trigger?(Input::B)
           close_shop_quantity
         end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -4651,6 +4651,10 @@ check 'Open Shop scene: buying then leaving runs the Transaction branch' do
   scene.update
   eq 400, st.party.gold, 'one Potion bought'
   eq 1, st.party.item_count(3)
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the "purchased" confirmation
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
   RGSS::Input.triggered = [RGSS::Input::B] # leave the shop
   scene.update
   scene.update # the Transaction branch runs
@@ -4748,7 +4752,10 @@ check 'Open Shop scene: confirming the counter buys the whole stack at once' do
   eq 200, st.party.gold, '500 - 3*100'
   eq 3, st.party.item_count(3), 'three bought in one confirm'
   shop = scene.instance_variable_get(:@shop)
-  eq :buy, shop[:screen], 'and it returns to the buy list'
+  eq :purchased, shop[:screen], 'the "purchased" confirmation shows first'
+  press(scene, RGSS::Input::C)
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen], 'and dismissing it returns to the buy list'
 end
 
 check 'Open Shop scene: cancelling the counter buys nothing' do
@@ -9475,6 +9482,79 @@ check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each 
   eq :command, shop[:screen]
   ok window_texts(shop[:window]).any? { |t| t.include?('他に何かご入用ですか？') },
      'having browsed once, the shopkeeper asks "anything else?" rather than greeting again'
+end
+
+check 'Open Shop scene: buying shows the shop_purchased confirmation, then returns ' \
+      'to the buy list' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.term.shop_purchased1 = '毎度あり！'
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [1, 0, 0, 0, 3], indent: 0)] # buy-only
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  state.instance_variable_set(:@party, ShopStubParty.new(500))
+  3.times { scene.update } # the shop opens straight to the buy list (buy-only)
+
+  RGSS::Input.triggered = [RGSS::Input::C] # select the first good -> the counter
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the default quantity of 1
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+
+  shop = scene.instance_variable_get(:@shop)
+  eq :purchased, shop[:screen], 'the purchase confirms before the list reappears'
+  ok window_texts(shop[:window]).any? { |t| t.include?('毎度あり！') },
+     'the confirmation line uses the database shop_purchased term'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the confirmation
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen], 'a button press returns to the buy list, same as EasyRPG\'s ' \
+                          'Bought -> Buy transition'
+end
+
+check 'Open Shop scene: selling shows the shop_sold confirmation, then returns ' \
+      'to the sell list' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.term.shop_sold1 = '毎度！'
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [2, 0, 0, 0, 3], indent: 0)] # sell-only
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  party = ShopStubParty.new(0)
+  party.gain_item(3, 5)
+  state.instance_variable_set(:@party, party)
+  3.times { scene.update } # the shop opens straight to the sell list (sell-only)
+
+  RGSS::Input.triggered = [RGSS::Input::C] # select the held good -> the counter
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm the default quantity of 1
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+
+  shop = scene.instance_variable_get(:@shop)
+  eq :sold, shop[:screen], 'the sale confirms before the list reappears'
+  ok window_texts(shop[:window]).any? { |t| t.include?('毎度！') },
+     'the confirmation line uses the database shop_sold term'
+
+  RGSS::Input.triggered = [RGSS::Input::B] # dismiss the confirmation (B works too)
+  scene.update
+  RGSS::Input.triggered = []
+  scene.update
+  shop = scene.instance_variable_get(:@shop)
+  eq :sell, shop[:screen], 'and returns to the sell list, same as EasyRPG\'s Sold -> Sell'
 end
 
 check 'Enemy Encounter scene: the result window shows the database Victory term' do


### PR DESCRIPTION
## Summary

- `mruby-lcf/mrblib/schema.rb` already decodes `shop_purchased1/2/3` and
  `shop_sold1/2/3` (one of RPG2000's three shopkeeper "voices", selected the
  same way `#shop_terms` already picks `shop_buy`/`shop_sell`/etc.), but
  nothing in `mruby-rpg2k` ever read or displayed them: a buy or sell
  committed silently and the player was dropped straight back on the list.
- `Scene::Map`'s shop screen gains a `:purchased` / `:sold` state, entered
  right after `Game::Shop#buy` / `#sell` commits in `#drive_shop_quantity`.
  `#shop_terms` resolves the right voice (English fallback on a blank
  field, matching every other shop term), `#shop_header` draws it as the
  screen's single line (`#shop_lines` returns no selectable rows for it),
  and the new `#drive_shop_confirm` dismisses it on a button press — the
  same convention every other message panel in this scene uses (e.g. the
  battle event message window) — back to the buy / sell list it came from.
- **Verified against EasyRPG's `Scene_Shop` / `Window_Shop`** rather than
  guessed: its `Bought`/`Sold` modes draw the raw term with **no**
  item-name/price interpolation, and return to `Buy`/`Sell` respectively
  (not the shop's main command menu). EasyRPG uses a fixed one-second timer
  for that transition; this port swaps it for the same button-driven
  dismissal already used everywhere else in this scene, since a timer would
  be the odd one out here and the destination screen is unchanged either way.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 528/528 checks pass, including
  two new checks (`buying shows the shop_purchased confirmation...` /
  `selling shows the shop_sold confirmation...`) and updates to the two
  existing quantity-confirm checks for the new intermediate state.
- [x] `SKIP=nixfmt pre-commit run --files mruby-rpg2k/mrblib/scene/map.rb scripts/rpg2k_scene_check.rb changelog.d/rpg2k-shop-purchased-sold.added.md`
- [x] Added `changelog.d/rpg2k-shop-purchased-sold.added.md`.
- Not previously flagged in `docs/TODO.md`'s Open Shop section, so the gap
  and fix are documented here and in the changelog fragment instead.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_019VCZf3uaufE58STud4ucyk


---
_Generated by [Claude Code](https://claude.ai/code/session_019VCZf3uaufE58STud4ucyk)_