### PR TITLE
rpg2k: announce level-ups/skills on the battle victory result screen

### DIFF
--- a/changelog.d/rpg2k-battle-result-level-up-messages.fixed.md
+++ b/changelog.d/rpg2k-battle-result-level-up-messages.fixed.md
@@ -1,0 +1,5 @@
+- **RPG2000 battle victory result screen** now announces a level-up and any
+  skill it teaches, the same way the Change EXP / Change Level event commands
+  already do, reading the database's own `level`/`level_up`/`skill_learned`
+  terms (falling back to composed English when they're blank). Covered by two
+  new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7768,6 +7768,43 @@ above are repeated here)
   name, including two certain item drops from a two-member troop; a blank
   database falls back to the composed English for all three), both
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **The battle victory result screen now announces a level-up and any
+  skill it teaches, the same way Change EXP/Change Level already do** —
+  `#battle_result_lines`'s own `a.gain_exp(exp)` call (the line right above
+  the EXP/gold/item fix above) granted EXP with zero level-up/skill
+  messaging, unlike `Game::Interpreter#do_change_exp`/`#do_change_level`
+  (`mrblib/interpreter.rb`), which already snapshot each target's
+  level/skills before their own `#gain_exp`/`#change_level_by` and queue one
+  `#level_up_message` per level gained plus one `#skill_learned_message` per
+  growth-table skill it teaches (`#queue_level_up_messages`). EasyRPG's own
+  victory sequence confirms the same shape belongs here too:
+  `Scene_Battle_Rpg2k::ProcessSceneActionVictory` (`src/scene_battle_rpg2k.cpp`)
+  builds the EXP/gold/item summary as one page, then calls
+  `Game_Actor::ChangeExp` once per active ally right after it, and that is
+  exactly where the level-up/skill-learned lines it pushes come from. Fixed
+  by snapshotting each actor's level/skills right before its own
+  `#gain_exp` in `#battle_result_lines`, the same as the interpreter path,
+  appending the resulting lines after the EXP/gold/item lines (this screen
+  has no per-page window like RPG_RT's, only one flat line list for the
+  whole result, so the per-actor page break becomes an in-order append
+  instead). Unlike the interpreter path — still `#level_up_message`/
+  `#skill_learned_message`'s own documented "plain English line for now"
+  simplification, left untouched here — this screen already reads real
+  database terms for every other line, so its `#battle_level_up_message`/
+  `#battle_skill_learned_message` do too now, confirmed against EasyRPG's
+  `ActorMessage::GetLevelUpMessage`/`GetLearningMessage`
+  (`src/game_message_terms.cpp`), stock-RPG2000/CP932 branch: `name << "は"
+  << terms.level << " " << new_level << " " << terms.level_up` and
+  `skill.name << terms.skill_learned` (no actor name — it always trails
+  that actor's own level-up line). Falls back to composed English
+  (matching `#level_up_message`/`#skill_learned_message`'s own wording)
+  when the database leaves `level_up`/`skill_learned` blank, the same rule
+  as every other line here. Covered by two new `scripts/rpg2k_scene_check.rb`
+  checks (a database setting `level`/`level_up`/`skill_learned` shows the
+  composed level-up line and the skill it names, from a stub actor whose one
+  EXP threshold and one learn-table entry line up with the two-Slime troop's
+  10 total EXP; a blank database falls back to the composed English for
+  both), both confirmed to fail against the pre-fix code before the fix.
 - ✅ **Sell price = `floor(list price / 2)`; price 0 = unsellable in a shop
   but free if placed in a shop's own buy list — confirmed already
   correct**, all three facts, no code change needed. `Game::Shop#sell_price`

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5773,12 +5773,34 @@ class RPG2k
       # in `mruby-rpg2k` before now, so a game that customised them (a
       # translation, a non-English original) showed this codebase's
       # hardcoded English regardless.
+      #
+      # A level-up (and any skill the growth table teaches at it) is
+      # announced too now, the missing half of the same gap: EasyRPG's
+      # `Scene_Battle_Rpg2k::ProcessSceneActionVictory`
+      # (`src/scene_battle_rpg2k.cpp`) builds the EXP/gold/item summary as one
+      # page, then calls `Game_Actor::ChangeExp` once per active ally right
+      # after it, which is exactly `Game::Interpreter#do_change_exp`'s own
+      # gain_exp-then-announce shape (`queue_level_up_messages`,
+      # `mrblib/interpreter.rb`) -- so each actor's level/skill snapshot is
+      # taken here the same way, right before its own `#gain_exp`. Unlike
+      # that interpreter path (still the documented "plain English line for
+      # now" simplification), this screen already reads real database terms
+      # for every other line, so `#battle_level_up_message` /
+      # `#battle_skill_learned_message` below do too, built from EasyRPG's
+      # `ActorMessage::GetLevelUpMessage` / `GetLearningMessage`
+      # (`src/game_message_terms.cpp`), stock-RPG2000/CP932 branch: `name <<
+      # "は" << terms.level << " " << new_level << " " << terms.level_up` and
+      # `skill.name << terms.skill_learned` (no actor name -- it always
+      # follows that actor's own level-up line, same as here). RPG_RT shows
+      # these on their own page per actor rather than inline with the EXP
+      # tally; this screen has no per-page window, only one flat line list
+      # for the whole result, so they are appended to that list instead, in
+      # the same after-the-tally order the real sequence uses.
       def battle_result_lines(result, troop)
         return [term(:escape_success, 'Escaped!')] if result == :escape
         return [term(:defeat, 'The party was defeated...')] unless result == :victory
         exp = troop.total_exp
         gold = troop.total_gold
-        @state.party.actors.each { |a| a.gain_exp(exp) }
         @state.party.gain_gold(gold)
         lines = [term(:victory, 'Victory!')]
         lines << "#{exp}#{term(:exp_received, ' EXP gained.')}" if exp > 0
@@ -5794,7 +5816,61 @@ class RPG2k
           name = it ? it.name : "item #{iid}"
           lines << "#{name}#{term(:item_received, ' obtained.')}"
         end
+        @state.party.actors.each do |a|
+          before_level = a.respond_to?(:level) ? a.level : nil
+          before_skills = a.respond_to?(:skills) ? a.skills.dup : []
+          a.gain_exp(exp)
+          lines.concat(battle_level_up_lines(a, before_level, before_skills)) if before_level
+        end
         lines
+      end
+
+      # Level-up (and, for each level, any growth-table skill it teaches)
+      # lines for one actor's post-battle EXP gain, mirroring
+      # `Game::Interpreter#queue_level_up_messages`'s own before/after skill
+      # comparison: `before_skills` is that actor's skill list snapshotted
+      # right before `#gain_exp`, so a skill already known (an earlier
+      # explicit Change Skill teach) is told apart from one this exact gain
+      # just taught. Returns [] when the level did not rise.
+      def battle_level_up_lines(actor, before_level, before_skills)
+        return [] if actor.level <= before_level
+        lines = []
+        ((before_level + 1)..actor.level).each do |lv|
+          lines << battle_level_up_message(actor, lv)
+          next unless actor.respond_to?(:learn_table)
+          actor.learn_table.each do |sid, at|
+            next unless at == lv && !before_skills.include?(sid)
+            sk = @state.party.db_skill(sid)
+            lines << battle_skill_learned_message(actor, sk) if sk
+          end
+        end
+        lines
+      end
+
+      # The one line a level-up announces, built from the database's own
+      # `level`/`level_up` terms the way EasyRPG's stock/CP932
+      # `GetLevelUpMessage` branch does (see `#battle_result_lines`'s own
+      # comment) -- falls back to composed English, matching every other
+      # line on this screen, only when the database leaves `level_up` blank
+      # (a raw `level_up` term with no `level` term set still gets the
+      # 'Lv' stand-in rather than losing the whole line to English).
+      def battle_level_up_message(actor, level)
+        up = term(:level_up, nil)
+        return "#{actor.name} is now level #{level}!" unless up
+        "#{actor.name}は#{term(:level, 'Lv')} #{level} #{up}"
+      end
+
+      # The one line a newly-learned skill announces, immediately following
+      # its level's own line above -- EasyRPG's stock/CP932
+      # `GetLearningMessage` branch names only the skill, never the actor,
+      # since it always trails that actor's own level-up line the way it
+      # does here too. Falls back to composed English (which does name the
+      # actor, since a database leaving `skill_learned` blank gets no
+      # level-up line's context to lean on either) when the term is blank.
+      def battle_skill_learned_message(actor, sk)
+        learned = term(:skill_learned, nil)
+        return "#{actor.name} learned #{sk.name}!" unless learned
+        "#{sk.name}#{learned}"
       end
 
       # RPG_RT's battle windows share one fixed panel: a 320x80 strip along the

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1970,22 +1970,41 @@ end
 # EXP, with the leader Scene::Map reads while rendering.
 class BattleStubActor
   attr_accessor :exp, :hp, :mp
-  attr_reader :id, :name, :atk, :def, :agi, :int, :max_hp, :max_mp, :skills, :states
+  attr_reader :id, :name, :atk, :def, :agi, :int, :max_hp, :max_mp, :skills, :states,
+              :level, :learn_table
   # Defaults are strong enough to beat the two-Slime troop the scene db defines;
   # a defeat test passes weaker stats. `states` seeds the Combatant Game::Battle
   # ::from_actor builds (Game::Battle.actor_states reads it off any source that
   # responds to `:states`), so a battle-command-skip check can start the fight
   # with an ally already afflicted, without reaching into the built battle's
   # own Combatant list after the fact.
+  #
+  # `level_up_at`/`learn_table` are opt-in (default nil/[]): a check that never
+  # sets `level_up_at` gets a stub whose #level never moves, exactly like every
+  # check predating #battle_result_lines's own level-up/skill-learned lines
+  # (mirrors Game::Actor's real growth curve/learn table only as far as a
+  # single EXP-threshold level-up needs, not the full RPG2000 curve).
   def initialize(atk: 40, dfn: 20, agi: 20, hp: 200, mp: 20, int: 20, skills: [], id: 1,
-                 rename_skill: false, skill_name: '', states: [], force_ai: false)
+                 rename_skill: false, skill_name: '', states: [], force_ai: false,
+                 level: 1, level_up_at: nil, learn_table: [])
     @exp = 0; @id = id; @name = 'Hero'
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
     @mp = mp; @max_mp = mp; @int = int; @skills = skills
     @rename_skill = rename_skill; @skill_name = skill_name; @states = states
     @force_ai = force_ai
+    @level = level; @level_up_at = level_up_at; @learn_table = learn_table
   end
-  def gain_exp(n); @exp += n; end
+  # Bumps #level once @exp crosses @level_up_at (nil disables this entirely),
+  # learning whatever @learn_table names for the new level -- the shape
+  # #battle_level_up_lines (Scene::Map) needs to exercise the real Game::Actor
+  # code path it mirrors (Game::Actor#gain_exp -> #set_level -> #learn_level_skills)
+  # without the full RPG2000 EXP curve.
+  def gain_exp(n)
+    @exp += n
+    return unless @level_up_at && @exp >= @level_up_at
+    @level += 1
+    @learn_table.each { |sid, at| @skills.push(sid) if at == @level && !@skills.include?(sid) }
+  end
   # Battle write-back (Game::Battle#apply_to_party) sets the actor's post-battle
   # HP absolutely; the stub has no state model beyond the starting `states`
   # above, so just clamp to [0, max].
@@ -2017,13 +2036,14 @@ class BattleStubParty
   # #flying_offset` reads it off `@state.party`, not the database directly, so
   # a battle scene check needs its stub party to answer it too) -- false by
   # default, matching every other check's plain RPG2000 fixture.
-  def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil)
+  def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil, skill_db: nil)
     @actors = [actor]
     @gold = 0
     @leader = nil
     @rpg2003 = rpg2003
     @items = {}
     @item_db = item_db
+    @skill_db = skill_db
   end
   def gain_gold(n); @gold += n; end
   def any_alive?; @actors.any? { |a| !a.dead? }; end
@@ -2035,6 +2055,10 @@ class BattleStubParty
   # item table `item_db` (typically the scene's own fake_db.item) was given.
   attr_reader :items
   def gain_item(id, n = 1); @items[id] = (@items[id] || 0) + n; end
+  # A newly-learned skill (#battle_level_up_lines, Scene::Map) is named from
+  # whatever skill table `skill_db` (typically the scene's own fake_db.skill)
+  # was given, mirroring #db_item above.
+  def db_skill(id); @skill_db && @skill_db[id]; end
   def db_item(id); @item_db && @item_db[id]; end
 end
 
@@ -9541,6 +9565,55 @@ check 'Enemy Encounter scene: blank database EXP/gold/item received terms fall b
   ok texts.any? { |t| t.include?('10 EXP gained.') }, 'a blank exp_received term falls back'
   ok texts.any? { |t| t.include?('Found 20G.') }, 'blank gold_received_a/gold/gold_received_b fall back'
   ok texts.count { |t| t.include?('Potion obtained.') } == 2, 'a blank item_received term falls back'
+end
+
+check 'Enemy Encounter scene: the result window announces a level-up and the skill it ' \
+      'teaches, the same way Change EXP/Change Level do' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.term.level = 'レベル'
+  db.term.level_up = 'に上がった！'
+  db.skill[42] = OpenStruct.new(name: 'Meteor')
+  db.term.skill_learned = 'を覚えた！'
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  # Troop 1 (two Slimes, 5 EXP each -- see the EXP/gold/item checks above)
+  # awards exactly 10 EXP; the stub crosses its one level threshold right at
+  # 10 and learns skill 42 at that level, mirroring
+  # Game::Interpreter#queue_level_up_messages's own before/after skill diff.
+  actor = BattleStubActor.new(level_up_at: 10, learn_table: [[42, 2]])
+  state.instance_variable_set(:@party, BattleStubParty.new(actor, skill_db: db.skill))
+  scene.update
+  battle_attack_to_end(scene)
+  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  eq 2, actor.level, 'the EXP gain crossed the one threshold configured'
+  ok texts.any? { |t| t.include?('Heroはレベル 2 に上がった！') },
+     'the level-up line reads name + level term + number + level_up term ' \
+     '(GetLevelUpMessage stock/CP932 branch)'
+  ok texts.any? { |t| t.include?('Meteorを覚えた！') },
+     'the newly-learned skill names itself (GetLearningMessage), right after the level-up line'
+end
+
+check 'Enemy Encounter scene: blank database level_up/skill_learned terms fall back to ' \
+      'composed English' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db # leaves level_up/skill_learned blank
+  db.skill[42] = OpenStruct.new(name: 'Meteor')
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  actor = BattleStubActor.new(level_up_at: 10, learn_table: [[42, 2]])
+  state.instance_variable_set(:@party, BattleStubParty.new(actor, skill_db: db.skill))
+  scene.update
+  battle_attack_to_end(scene)
+  texts = window_texts(scene.instance_variable_get(:@battle_ui)[:result_win])
+  ok texts.any? { |t| t.include?('Hero is now level 2!') }, 'a blank level_up term falls back'
+  ok texts.any? { |t| t.include?('Hero learned Meteor!') }, 'a blank skill_learned term falls back'
 end
 
 check 'Enemy Encounter scene: a blank database Victory/Defeat term falls back to English' do


### PR DESCRIPTION
## Summary

- `Scene::Map#battle_result_lines` granted post-victory EXP via
  `Actor#gain_exp` with zero level-up or skill-learned messaging — just the
  plain EXP/gold/item lines — unlike the Change EXP / Change Level event
  commands, which already queue these via
  `Game::Interpreter#queue_level_up_messages`.
- Each actor's level/skills are now snapshotted right before its own
  `#gain_exp` (mirroring the interpreter's own before/after mechanism), and
  the resulting level-up / skill-learned lines are appended to the result
  screen's flat line list, after the EXP/gold/item lines — the closest match
  to EasyRPG's real victory sequence (`Scene_Battle_Rpg2k::
  ProcessSceneActionVictory` builds the EXP/gold/item summary as one page,
  then calls `Game_Actor::ChangeExp` once per active ally right after it;
  this screen has no per-page window, so the per-actor page break becomes an
  in-order append instead).
- Since this screen already reads real database terms for every other line
  (`victory`, `exp_received`, `gold_received_a/b`, `item_received`), the new
  `#battle_level_up_message`/`#battle_skill_learned_message` do too, built
  from EasyRPG's `ActorMessage::GetLevelUpMessage`/`GetLearningMessage`
  (`src/game_message_terms.cpp`), stock-RPG2000/CP932 branch — falling back
  to composed English when the database leaves `level_up`/`skill_learned`
  blank, matching every other line here.
- `Game::Interpreter#level_up_message`/`#skill_learned_message` (used by
  Change EXP/Change Level) are intentionally left untouched — they're a
  separately documented "plain English line for now" simplification, out of
  scope for this battle-result-screen fix.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 528 checks pass, including two
  new ones: a database `level`/`level_up`/`skill_learned` term setup shows
  the composed level-up line and the skill it names (a stub actor whose one
  EXP threshold and one learn-table entry line up with the two-Slime troop's
  10 total EXP), and a blank database falls back to composed English for
  both.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VPfL6hDLFV9feqczhcshzs)_