### PR TITLE
psp: link libmruby.a into the EBOOT, boot the interpreter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1188,22 +1188,27 @@ jobs:
       - name: Build EBOOT (pspdev container)
         # The pspdev image ships psp-gcc, cmake and the psp-cmake wrapper (which
         # points CMake at the pspdev toolchain and provides create_pbp_file), but
-        # not Ruby: the psp mruby cross-build (build_config.rb's `psp`
-        # MRuby::CrossBuild) is driven by `rake`, invoked from a CMake custom
-        # command (app/psp/CMakeLists.txt) exactly the way the desktop/wasm
-        # builds drive it from the root CMakeLists.txt -- but those run inside
-        # the nix devshell, which provides Ruby; this container does not.
-        # Install it before configuring. The image's final stage is Alpine
-        # (github.com/pspdev/pspdev's own Dockerfile, not the archived
-        # pspdev/pspdev-docker repo, which is Ubuntu-based but unrelated to what
-        # actually publishes the pspdev/pspdev:latest tag) -- apk, not apt-get.
+        # not Ruby and not a native (x86_64) compiler: the psp mruby cross-build
+        # (build_config.rb's `psp` MRuby::CrossBuild) is driven by `rake`,
+        # invoked from a CMake custom command (app/psp/CMakeLists.txt) exactly
+        # the way the desktop/wasm builds drive it from the root CMakeLists.txt
+        # -- but those run inside the nix devshell, which provides both; this
+        # container does not. Install them before configuring. The image's
+        # final stage is Alpine (github.com/pspdev/pspdev's own Dockerfile, not
+        # the archived pspdev/pspdev-docker repo, which is Ubuntu-based but
+        # unrelated to what actually publishes the pspdev/pspdev:latest tag) --
+        # apk, not apt-get. build-base is needed alongside psp-gcc: rake's
+        # MRuby::CrossBuild also builds a native "host" mruby (to produce mrbc,
+        # which then compiles the target .rb sources to bytecode), and that
+        # half runs the ambient `gcc`, not psp-gcc -- confirmed missing by a
+        # real CI run ("sh: gcc: not found") once Ruby alone was installed.
         # Pull the image up front with -q: an implicit pull from `docker run`
-        # prints a per-layer download/extract progress block, which `-q` reduces
-        # to the resolved digest.
+        # prints a per-layer download/extract progress block, which `-q`
+        # reduces to the resolved digest.
         run: |
           docker pull -q pspdev/pspdev:latest
           docker run --rm -v "$PWD:/src" -w /src pspdev/pspdev:latest sh -euc '
-            apk add --no-cache ruby ruby-rake
+            apk add --no-cache ruby ruby-rake build-base
             psp-cmake -S app/psp -B build-psp
             cmake --build build-psp -j"$(nproc)"
           '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1187,13 +1187,20 @@ jobs:
 
       - name: Build EBOOT (pspdev container)
         # The pspdev image ships psp-gcc, cmake and the psp-cmake wrapper (which
-        # points CMake at the pspdev toolchain and provides create_pbp_file).
-        # Pull it up front with -q: an implicit pull from `docker run` prints a
-        # per-layer download/extract progress block, which `-q` reduces to the
-        # resolved digest.
+        # points CMake at the pspdev toolchain and provides create_pbp_file), but
+        # not Ruby: the psp mruby cross-build (build_config.rb's `psp`
+        # MRuby::CrossBuild) is driven by `rake`, invoked from a CMake custom
+        # command (app/psp/CMakeLists.txt) exactly the way the desktop/wasm
+        # builds drive it from the root CMakeLists.txt -- but those run inside
+        # the nix devshell, which provides Ruby; this container (Ubuntu-based,
+        # confirmed against github.com/pspdev/pspdev-docker) does not. Install it
+        # before configuring. Pull the image up front with -q: an implicit pull
+        # from `docker run` prints a per-layer download/extract progress block,
+        # which `-q` reduces to the resolved digest.
         run: |
           docker pull -q pspdev/pspdev:latest
           docker run --rm -v "$PWD:/src" -w /src pspdev/pspdev:latest sh -euc '
+            apt-get update -qq && apt-get install -qq -y --no-install-recommends ruby rake
             psp-cmake -S app/psp -B build-psp
             cmake --build build-psp -j"$(nproc)"
           '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1185,6 +1185,38 @@ jobs:
           show-progress: false
           persist-credentials: false
 
+      - name: Download Unicode mapping tables
+        # mruby-lcf/cp932_to_unicode.rb and mruby-rgss/gen_shinonome_data.rb
+        # (both rake-time code generators, run as part of the psp mruby
+        # cross-build below) read $cp932_table / $jis0208_table -- normally
+        # set by the nix devshell's fetchurl derivations (flake.nix), which
+        # this bare-container job does not have. scripts/native-build-without-nix.bash
+        # solves the same gap for a non-nix host build the same way: download
+        # and verify against the flake's own sha256 pins, so the build
+        # consumes the same bytes Nix would hand it, not a lookalike.
+        run: |
+          mkdir -p .native-build-tables
+          fetch_table() {
+            local url="$1" dest="$2" want="$3"
+            curl -fsSL -o "$dest" "$url"
+            local got
+            got="$(python3 -c 'import hashlib,base64,sys; print(base64.b64encode(hashlib.sha256(open(sys.argv[1],"rb").read()).digest()).decode())' "$dest")"
+            if [ "$got" != "$want" ]; then
+              echo "hash mismatch for $dest" >&2
+              echo "  flake.nix pins $want" >&2
+              echo "  downloaded     $got" >&2
+              exit 1
+            fi
+          }
+          fetch_table \
+            'https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WindowsBestFit/bestfit932.txt' \
+            .native-build-tables/bestfit932.txt \
+            'JhTP6jXDyGxB0zGYeTqEykTt7jzw7gATphpD+6Ts4zE='
+          fetch_table \
+            'https://www.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/JIS0208.TXT' \
+            .native-build-tables/JIS0208.TXT \
+            'HFcYcEV/Gcl3IGMfqD7kkVSalroUNtoSlnhqZ9hjLoc='
+
       - name: Build EBOOT (pspdev container)
         # The pspdev image ships psp-gcc, cmake and the psp-cmake wrapper (which
         # points CMake at the pspdev toolchain and provides create_pbp_file), but
@@ -1207,7 +1239,10 @@ jobs:
         # reduces to the resolved digest.
         run: |
           docker pull -q pspdev/pspdev:latest
-          docker run --rm -v "$PWD:/src" -w /src pspdev/pspdev:latest sh -euc '
+          docker run --rm -v "$PWD:/src" -w /src \
+            -e cp932_table=/src/.native-build-tables/bestfit932.txt \
+            -e jis0208_table=/src/.native-build-tables/JIS0208.TXT \
+            pspdev/pspdev:latest sh -euc '
             apk add --no-cache ruby ruby-rake build-base
             psp-cmake -S app/psp -B build-psp
             cmake --build build-psp -j"$(nproc)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1192,15 +1192,18 @@ jobs:
         # MRuby::CrossBuild) is driven by `rake`, invoked from a CMake custom
         # command (app/psp/CMakeLists.txt) exactly the way the desktop/wasm
         # builds drive it from the root CMakeLists.txt -- but those run inside
-        # the nix devshell, which provides Ruby; this container (Ubuntu-based,
-        # confirmed against github.com/pspdev/pspdev-docker) does not. Install it
-        # before configuring. Pull the image up front with -q: an implicit pull
-        # from `docker run` prints a per-layer download/extract progress block,
-        # which `-q` reduces to the resolved digest.
+        # the nix devshell, which provides Ruby; this container does not.
+        # Install it before configuring. The image's final stage is Alpine
+        # (github.com/pspdev/pspdev's own Dockerfile, not the archived
+        # pspdev/pspdev-docker repo, which is Ubuntu-based but unrelated to what
+        # actually publishes the pspdev/pspdev:latest tag) -- apk, not apt-get.
+        # Pull the image up front with -q: an implicit pull from `docker run`
+        # prints a per-layer download/extract progress block, which `-q` reduces
+        # to the resolved digest.
         run: |
           docker pull -q pspdev/pspdev:latest
           docker run --rm -v "$PWD:/src" -w /src pspdev/pspdev:latest sh -euc '
-            apt-get update -qq && apt-get install -qq -y --no-install-recommends ruby rake
+            apk add --no-cache ruby ruby-rake
             psp-cmake -S app/psp -B build-psp
             cmake --build build-psp -j"$(nproc)"
           '

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,6 @@ if(NOT EMSCRIPTEN)
   endif()
 endif()
 
-set(MRUBY_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/3rd/mruby")
-add_library(mruby STATIC IMPORTED)
 set(MRUBY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/mruby")
 if(EMSCRIPTEN)
   # The native "host" build only produces mrbc; the app links the cross build.
@@ -172,94 +170,32 @@ if(EMSCRIPTEN)
   set(ONIGMO_DIR
       "${MRUBY_BUILD_DIR}/emscripten/mrbgems/mruby-onig-regexp/onigmo-6.2.0")
   set(ONIGMO_A "${CMAKE_CURRENT_BINARY_DIR}/libonigmo_clean.a")
+  # Tell build_config.rb to emit the emscripten cross build, and give it
+  # native compilers to build mrbc with (CXX=/CC= below point at em++/emcc).
+  set(MRUBY_EXTRA_OPTS MRUBY_TARGET=emscripten "HOST_CC=cc" "HOST_CXX=c++")
 else()
   set(MRUBY_TARGET_NAME "host")
+  set(MRUBY_EXTRA_OPTS "")
 endif()
-set(LIBMRUBY_A "${MRUBY_BUILD_DIR}/${MRUBY_TARGET_NAME}/lib/libmruby.a")
-set_target_properties(mruby PROPERTIES IMPORTED_LOCATION "${LIBMRUBY_A}")
-list(APPEND ADDITIONAL_CLEAN_FILES "${MRUBY_BUILD_DIR}")
-# mruby 4.0 always enables presym, so <mruby.h> unconditionally pulls in
-# <mruby/presym.h> and its generated mruby/presym/id.h. That header lives in the
-# build tree (produced by the mruby build below), not in the source include dir,
-# so expose it too. Create it now so CMake's imported-target check — which
-# requires INTERFACE include dirs to exist at configure time — passes before the
-# build populates it.
-set(MRUBY_GEN_INCLUDE "${MRUBY_BUILD_DIR}/${MRUBY_TARGET_NAME}/include")
-file(MAKE_DIRECTORY "${MRUBY_GEN_INCLUDE}")
-target_include_directories(mruby INTERFACE "${MRUBY_PREFIX}/include"
-                                           "${MRUBY_GEN_INCLUDE}")
-# Collect the source of each local mrbgem so libmruby.a rebuilds when any of it
-# changes. GLOB_RECURSE also picks up files in nested subdirectories, and
-# CONFIGURE_DEPENDS makes CMake re-run the glob at build time: adding or
-# removing a source file triggers a reconfigure (and thus a libmruby rebuild) on
-# the next `make`, with no manual `cmake` re-run. Header changes under src/ are
-# caught too so an edit to a private header still forces the archive to be
-# rebuilt.
-foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx mruby-mvjs)
-  file(
-    GLOB_RECURSE
-    src
-    CONFIGURE_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.cxx
-    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/${g}/src/*.hxx)
-  file(GLOB_RECURSE rb CONFIGURE_DEPENDS
-       ${CMAKE_CURRENT_SOURCE_DIR}/${g}/mrblib/*.rb)
-  list(APPEND MRB_FILES ${src} ${rb}
-       ${CMAKE_CURRENT_SOURCE_DIR}/${g}/mrbgem.rake)
-endforeach()
 
-# Also rebuild libmruby.a when mruby's own core changes. These sources live in
-# the 3rd/mruby submodule; CONFIGURE_DEPENDS keeps the list current as the
-# submodule is checked out or updated to a new revision.
-file(
-  GLOB_RECURSE
-  mruby_core
-  CONFIGURE_DEPENDS
-  ${MRUBY_PREFIX}/src/*.c
-  ${MRUBY_PREFIX}/src/*.h
-  ${MRUBY_PREFIX}/mrblib/*.rb
-  ${MRUBY_PREFIX}/include/*.h)
-list(APPEND MRB_FILES ${mruby_core})
-set(MRB_OPTS
-    MRUBY_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/build_config.rb
-    MRUBY_BUILD_DIR=${MRUBY_BUILD_DIR}
+# Build libmruby.a via mruby's own rake-based build system (build_config.rb),
+# factored into cmake/build-mruby.cmake since the PSP EBOOT build
+# (app/psp/CMakeLists.txt) drives the exact same rake invocation with only the
+# target name, gem list and a few extra rake options differing.
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build-mruby.cmake)
+rpg2k_add_mruby(
+  TARGET_NAME ${MRUBY_TARGET_NAME}
+  REPO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}
+  PROJECT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}
+  GEMS mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx mruby-mvjs
+  MRB_OPTS
     BUILD_DIR=${MRUBY_BUILD_DIR}
-    PROJECT_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
     "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
     "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
     "CXXFLAGS=${CMAKE_CXX_FLAGS}"
     "CFLAGS=${CMAKE_C_FLAGS}"
-    "LDFLAGS=${CMAKE_CXX_FLAGS}")
-if(EMSCRIPTEN)
-  # Tell build_config.rb to emit the emscripten cross build, and give it native
-  # compilers to build mrbc with (CC/CXX above point at emcc/em++).
-  list(APPEND MRB_OPTS MRUBY_TARGET=emscripten "HOST_CC=cc" "HOST_CXX=c++")
-endif()
-# Point mruby's rake at the vendored mgem-list (the mgem index) via symlinks in
-# its repos/ dir so it resolves gems locally instead of cloning from GitHub. Use
-# `ln -sfn`, not `ln -sf`: once these links exist, a plain `ln -sf` would
-# dereference the existing symlink-to-directory and drop a new link *inside*
-# 3rd/mgem-list (a self-referential 3rd/mgem-list/mgem-list), dirtying the
-# submodule. `-n` (no-dereference; portable across GNU and BSD/macOS) replaces
-# the symlink in place instead.
-add_custom_command(
-  OUTPUT "${LIBMRUBY_A}"
-  COMMAND
-    mkdir -p ${MRUBY_BUILD_DIR}/repos/host
-    ${MRUBY_BUILD_DIR}/repos/${MRUBY_TARGET_NAME} && ln -sfn
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rd/mgem-list
-    ${MRUBY_BUILD_DIR}/repos/host/mgem-list && ln -sfn
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rd/mgem-list
-    ${MRUBY_BUILD_DIR}/repos/${MRUBY_TARGET_NAME}/mgem-list && ${MRB_OPTS} rake
-    -v
-  WORKING_DIRECTORY "${MRUBY_PREFIX}"
-  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/build_config.rb" ${MRB_FILES})
-add_custom_target(mruby_build DEPENDS "${LIBMRUBY_A}")
-add_dependencies(mruby mruby_build)
+    "LDFLAGS=${CMAKE_CXX_FLAGS}" ${MRUBY_EXTRA_OPTS})
+list(APPEND ADDITIONAL_CLEAN_FILES "${MRUBY_BUILD_DIR}")
 
 if(EMSCRIPTEN)
   # Re-archive onigmo's pristine per-file wasm objects (see ONIGMO_A above).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,8 +170,8 @@ if(EMSCRIPTEN)
   set(ONIGMO_DIR
       "${MRUBY_BUILD_DIR}/emscripten/mrbgems/mruby-onig-regexp/onigmo-6.2.0")
   set(ONIGMO_A "${CMAKE_CURRENT_BINARY_DIR}/libonigmo_clean.a")
-  # Tell build_config.rb to emit the emscripten cross build, and give it
-  # native compilers to build mrbc with (CXX=/CC= below point at em++/emcc).
+  # Tell build_config.rb to emit the emscripten cross build, and give it native
+  # compilers to build mrbc with (CXX=/CC= below point at em++/emcc).
   set(MRUBY_EXTRA_OPTS MRUBY_TARGET=emscripten "HOST_CC=cc" "HOST_CXX=c++")
 else()
   set(MRUBY_TARGET_NAME "host")
@@ -184,17 +184,27 @@ endif()
 # target name, gem list and a few extra rake options differing.
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build-mruby.cmake)
 rpg2k_add_mruby(
-  TARGET_NAME ${MRUBY_TARGET_NAME}
-  REPO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}
-  PROJECT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}
-  GEMS mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx mruby-mvjs
+  TARGET_NAME
+  ${MRUBY_TARGET_NAME}
+  REPO_ROOT
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  PROJECT_BUILD_DIR
+  ${CMAKE_CURRENT_BINARY_DIR}
+  GEMS
+  mruby-rgss
+  mruby-lcf
+  mruby-rpg2k
+  mruby-rpgxp
+  mruby-rpgvx
+  mruby-mvjs
   MRB_OPTS
-    BUILD_DIR=${MRUBY_BUILD_DIR}
-    "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
-    "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
-    "CXXFLAGS=${CMAKE_CXX_FLAGS}"
-    "CFLAGS=${CMAKE_C_FLAGS}"
-    "LDFLAGS=${CMAKE_CXX_FLAGS}" ${MRUBY_EXTRA_OPTS})
+  BUILD_DIR=${MRUBY_BUILD_DIR}
+  "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
+  "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
+  "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+  "CFLAGS=${CMAKE_C_FLAGS}"
+  "LDFLAGS=${CMAKE_CXX_FLAGS}"
+  ${MRUBY_EXTRA_OPTS})
 list(APPEND ADDITIONAL_CLEAN_FILES "${MRUBY_BUILD_DIR}")
 
 if(EMSCRIPTEN)

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -103,6 +103,16 @@ target_compile_definitions(rpg2k_psp PRIVATE PSP_BUILD LV_CONF_INCLUDE_SIMPLE)
 target_include_directories(rpg2k_psp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                              ${REPO_ROOT}/include)
 
+# libpspkernel.a bundles its own "ForKernel" NID-stub implementations of a
+# handful of libc functions (seen so far: strtol, strtoul) alongside the real
+# ones this user-mode (THREAD_ATTR_USER) EBOOT actually wants from newlib's
+# libc.a -- both get pulled into the link (each also resolves other symbols
+# genuinely needed from the same object) and collide as a hard "multiple
+# definition" error. --allow-multiple-definition keeps the first definition ld
+# encounters and discards the rest; libc.a is linked implicitly ahead of the
+# explicit libraries below, so that first definition is newlib's real one.
+target_link_options(rpg2k_psp PRIVATE -Wl,--allow-multiple-definition)
+
 target_link_libraries(
   rpg2k_psp
   mruby

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -61,10 +61,9 @@ add_subdirectory(${REPO_ROOT}/3rd/uni-algo 3rd/uni-algo EXCLUDE_FROM_ALL)
 
 # Build libmruby.a for the psp target via mruby's own rake-based build system
 # (build_config.rb's `psp` MRuby::CrossBuild), the same way the root
-# CMakeLists.txt does for the desktop/wasm builds -- a separate build system
-# or invoked as a custom command, not a native CMake target, because mruby's
-# gem system (which C sources, generated headers, gembox membership) is all
-# decided by that Rakefile, not by anything CMake can glob on its own.
+# CMakeLists.txt does for the desktop/wasm builds -- factored into
+# cmake/build-mruby.cmake since both drive the same rake invocation with only
+# the target name, gem list and a few extra rake options differing.
 #
 # Unlike the root build, no native `mrbc`-producing host build needs its own
 # CC/CXX override here: build_config.rb's psp block hardcodes psp-gcc/psp-g++
@@ -72,67 +71,16 @@ add_subdirectory(${REPO_ROOT}/3rd/uni-algo 3rd/uni-algo EXCLUDE_FROM_ALL)
 # (which still produces mrbc) uses the ambient CC/CXX -- ordinary host
 # compilers, since this CMake project's own C/CXX compiler *is* the psp
 # cross-compiler (set via the pspdev toolchain file), not a host one.
-set(MRUBY_PREFIX ${REPO_ROOT}/3rd/mruby)
-set(MRUBY_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/mruby)
-set(LIBMRUBY_A ${MRUBY_BUILD_DIR}/psp/lib/libmruby.a)
-set(MRUBY_GEN_INCLUDE ${MRUBY_BUILD_DIR}/psp/include)
-file(MAKE_DIRECTORY ${MRUBY_GEN_INCLUDE})
-
-# Rebuild whenever any local mrbgem this target actually uses changes --
-# mirrors the root CMakeLists.txt's MRB_FILES collection, trimmed to the gems
-# build_config.rb's psp cross-build actually pulls in (rpg_maker_gems with
-# include_mvjs: false -- no mruby-mvjs/quickjs on this target).
-foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx)
-  file(
-    GLOB_RECURSE
-    src
-    CONFIGURE_DEPENDS
-    ${REPO_ROOT}/${g}/src/*.c
-    ${REPO_ROOT}/${g}/src/*.cxx
-    ${REPO_ROOT}/${g}/src/*.cpp
-    ${REPO_ROOT}/${g}/src/*.h
-    ${REPO_ROOT}/${g}/src/*.hpp
-    ${REPO_ROOT}/${g}/src/*.hxx)
-  file(GLOB_RECURSE rb CONFIGURE_DEPENDS ${REPO_ROOT}/${g}/mrblib/*.rb)
-  list(APPEND MRB_FILES ${src} ${rb} ${REPO_ROOT}/${g}/mrbgem.rake)
-endforeach()
-file(
-  GLOB_RECURSE
-  mruby_core
-  CONFIGURE_DEPENDS
-  ${MRUBY_PREFIX}/src/*.c
-  ${MRUBY_PREFIX}/src/*.h
-  ${MRUBY_PREFIX}/mrblib/*.rb
-  ${MRUBY_PREFIX}/include/*.h)
-list(APPEND MRB_FILES ${mruby_core})
-
-set(MRB_OPTS
-    MRUBY_CONFIG=${REPO_ROOT}/build_config.rb
-    MRUBY_TARGET=psp
-    MRUBY_BUILD_DIR=${MRUBY_BUILD_DIR}
-    PROJECT_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR})
-
-# Same mgem-list symlink dance as the root CMakeLists.txt: points mruby's rake
-# at the vendored mgem index so it resolves gems locally instead of trying to
-# clone from GitHub. `ln -sfn` (not `-sf`) so re-running this doesn't
-# dereference the existing symlink-to-directory and nest one inside the other.
-add_custom_command(
-  OUTPUT "${LIBMRUBY_A}"
-  COMMAND
-    mkdir -p ${MRUBY_BUILD_DIR}/repos/host ${MRUBY_BUILD_DIR}/repos/psp &&
-    ln -sfn ${REPO_ROOT}/3rd/mgem-list
-    ${MRUBY_BUILD_DIR}/repos/host/mgem-list && ln -sfn
-    ${REPO_ROOT}/3rd/mgem-list ${MRUBY_BUILD_DIR}/repos/psp/mgem-list &&
-    ${MRB_OPTS} rake -v
-  WORKING_DIRECTORY "${MRUBY_PREFIX}"
-  DEPENDS "${REPO_ROOT}/build_config.rb" ${MRB_FILES})
-add_custom_target(mruby_build DEPENDS "${LIBMRUBY_A}")
-
-add_library(mruby STATIC IMPORTED)
-set_target_properties(mruby PROPERTIES IMPORTED_LOCATION "${LIBMRUBY_A}")
-target_include_directories(mruby INTERFACE "${MRUBY_PREFIX}/include"
-                                           "${MRUBY_GEN_INCLUDE}")
-add_dependencies(mruby mruby_build)
+include(${REPO_ROOT}/cmake/build-mruby.cmake)
+rpg2k_add_mruby(
+  TARGET_NAME psp
+  REPO_ROOT ${REPO_ROOT}
+  PROJECT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}
+  # Mirrors the root CMakeLists.txt's gem list, trimmed to what
+  # build_config.rb's psp cross-build actually pulls in (rpg_maker_gems with
+  # include_mvjs: false -- no mruby-mvjs/quickjs on this target).
+  GEMS mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx
+  MRB_OPTS MRUBY_TARGET=psp)
 
 # The bring-up HAL (mruby-rgss/src/psp.cxx) now comes from libmruby.a -- the
 # psp cross-build compiles it as part of the mruby-rgss gem, self-guarded on

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -73,17 +73,26 @@ add_subdirectory(${REPO_ROOT}/3rd/uni-algo 3rd/uni-algo EXCLUDE_FROM_ALL)
 # cross-compiler (set via the pspdev toolchain file), not a host one.
 include(${REPO_ROOT}/cmake/build-mruby.cmake)
 rpg2k_add_mruby(
-  TARGET_NAME psp
-  REPO_ROOT ${REPO_ROOT}
-  PROJECT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}
+  TARGET_NAME
+  psp
+  REPO_ROOT
+  ${REPO_ROOT}
+  PROJECT_BUILD_DIR
+  ${CMAKE_CURRENT_BINARY_DIR}
   # Mirrors the root CMakeLists.txt's gem list, trimmed to what
   # build_config.rb's psp cross-build actually pulls in (rpg_maker_gems with
   # include_mvjs: false -- no mruby-mvjs/quickjs on this target).
-  GEMS mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx
-  MRB_OPTS MRUBY_TARGET=psp)
+  GEMS
+  mruby-rgss
+  mruby-lcf
+  mruby-rpg2k
+  mruby-rpgxp
+  mruby-rpgvx
+  MRB_OPTS
+  MRUBY_TARGET=psp)
 
-# The bring-up HAL (mruby-rgss/src/psp.cxx) now comes from libmruby.a -- the
-# psp cross-build compiles it as part of the mruby-rgss gem, self-guarded on
+# The bring-up HAL (mruby-rgss/src/psp.cxx) now comes from libmruby.a -- the psp
+# cross-build compiles it as part of the mruby-rgss gem, self-guarded on
 # PSP_BUILD the same way it always was. Compiling it here directly too, as the
 # earlier HAL-only bring-up did, would double-define every symbol in it
 # (psp_display_create, psp_input_scan, ...) once both this executable and

--- a/app/psp/CMakeLists.txt
+++ b/app/psp/CMakeLists.txt
@@ -18,8 +18,8 @@ project(rpg2k_psp C CXX ASM)
 set(REPO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
 # pspsdk static libraries are built without gp-relative small-data addressing;
-# every object linked with them (LVGL and our own) must match, so force -G0 at
-# directory scope before LVGL is added.
+# every object linked with them (LVGL, uni-algo, mruby and our own) must match,
+# so force -G0 at directory scope before any of them are added.
 add_compile_options(-G0)
 
 # LVGL ships ARM Helium/NEON SIMD blend kernels as hand-written .S assembly and
@@ -39,15 +39,108 @@ endif()
 # Build the vendored LVGL with the PSP-tuned lv_conf.h in this directory (same
 # submodule the desktop and Wio builds use). LV_BUILD_CONF_DIR points LVGL's
 # build at our config.
+#
+# Binary dir is "3rd/lvgl", not "lvgl": the psp mruby cross-build below (via
+# rake, a separate build system from this CMake project) links against
+# mruby-rgss's own linker.library_paths, which -- matching the root
+# CMakeLists.txt's layout, where "3rd/lvgl" is genuinely the path from the repo
+# root -- expects to find liblvgl.a at "${PROJECT_BUILD_DIR}/3rd/lvgl/lib".
+# Verified against a real (host-compiler) build of the vendored LVGL/uni-algo
+# CMakeLists.txt: LVGL places its archive at "<binary_dir>/lib/liblvgl.a";
+# uni-algo places its directly at "<binary_dir>/libuni-algo.a" (its own
+# CMakeLists.txt sets no output subdirectory) -- both reflected below.
 set(LV_BUILD_CONF_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}
     CACHE PATH "lv_conf.h location" FORCE)
-add_subdirectory(${REPO_ROOT}/3rd/lvgl lvgl EXCLUDE_FROM_ALL)
+add_subdirectory(${REPO_ROOT}/3rd/lvgl 3rd/lvgl EXCLUDE_FROM_ALL)
 
-# The bring-up EBOOT: the platform HAL (compiled straight from the mruby-rgss
-# gem, self-guarded on PSP_BUILD) plus the entry-point sketch. libmruby and the
-# input bridge are layered on in a later slice.
-add_executable(rpg2k_psp main.cxx ${REPO_ROOT}/mruby-rgss/src/psp.cxx)
+# mruby-rgss and mruby-lcf both link uni-algo (Unicode normalisation / CP932
+# conversion). See the LVGL comment above for why the binary dir must be
+# "3rd/uni-algo".
+add_subdirectory(${REPO_ROOT}/3rd/uni-algo 3rd/uni-algo EXCLUDE_FROM_ALL)
+
+# Build libmruby.a for the psp target via mruby's own rake-based build system
+# (build_config.rb's `psp` MRuby::CrossBuild), the same way the root
+# CMakeLists.txt does for the desktop/wasm builds -- a separate build system
+# or invoked as a custom command, not a native CMake target, because mruby's
+# gem system (which C sources, generated headers, gembox membership) is all
+# decided by that Rakefile, not by anything CMake can glob on its own.
+#
+# Unlike the root build, no native `mrbc`-producing host build needs its own
+# CC/CXX override here: build_config.rb's psp block hardcodes psp-gcc/psp-g++
+# directly (conf.cc.command = 'psp-gcc', ...), and the host build alongside it
+# (which still produces mrbc) uses the ambient CC/CXX -- ordinary host
+# compilers, since this CMake project's own C/CXX compiler *is* the psp
+# cross-compiler (set via the pspdev toolchain file), not a host one.
+set(MRUBY_PREFIX ${REPO_ROOT}/3rd/mruby)
+set(MRUBY_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/mruby)
+set(LIBMRUBY_A ${MRUBY_BUILD_DIR}/psp/lib/libmruby.a)
+set(MRUBY_GEN_INCLUDE ${MRUBY_BUILD_DIR}/psp/include)
+file(MAKE_DIRECTORY ${MRUBY_GEN_INCLUDE})
+
+# Rebuild whenever any local mrbgem this target actually uses changes --
+# mirrors the root CMakeLists.txt's MRB_FILES collection, trimmed to the gems
+# build_config.rb's psp cross-build actually pulls in (rpg_maker_gems with
+# include_mvjs: false -- no mruby-mvjs/quickjs on this target).
+foreach(g mruby-rgss mruby-lcf mruby-rpg2k mruby-rpgxp mruby-rpgvx)
+  file(
+    GLOB_RECURSE
+    src
+    CONFIGURE_DEPENDS
+    ${REPO_ROOT}/${g}/src/*.c
+    ${REPO_ROOT}/${g}/src/*.cxx
+    ${REPO_ROOT}/${g}/src/*.cpp
+    ${REPO_ROOT}/${g}/src/*.h
+    ${REPO_ROOT}/${g}/src/*.hpp
+    ${REPO_ROOT}/${g}/src/*.hxx)
+  file(GLOB_RECURSE rb CONFIGURE_DEPENDS ${REPO_ROOT}/${g}/mrblib/*.rb)
+  list(APPEND MRB_FILES ${src} ${rb} ${REPO_ROOT}/${g}/mrbgem.rake)
+endforeach()
+file(
+  GLOB_RECURSE
+  mruby_core
+  CONFIGURE_DEPENDS
+  ${MRUBY_PREFIX}/src/*.c
+  ${MRUBY_PREFIX}/src/*.h
+  ${MRUBY_PREFIX}/mrblib/*.rb
+  ${MRUBY_PREFIX}/include/*.h)
+list(APPEND MRB_FILES ${mruby_core})
+
+set(MRB_OPTS
+    MRUBY_CONFIG=${REPO_ROOT}/build_config.rb
+    MRUBY_TARGET=psp
+    MRUBY_BUILD_DIR=${MRUBY_BUILD_DIR}
+    PROJECT_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR})
+
+# Same mgem-list symlink dance as the root CMakeLists.txt: points mruby's rake
+# at the vendored mgem index so it resolves gems locally instead of trying to
+# clone from GitHub. `ln -sfn` (not `-sf`) so re-running this doesn't
+# dereference the existing symlink-to-directory and nest one inside the other.
+add_custom_command(
+  OUTPUT "${LIBMRUBY_A}"
+  COMMAND
+    mkdir -p ${MRUBY_BUILD_DIR}/repos/host ${MRUBY_BUILD_DIR}/repos/psp &&
+    ln -sfn ${REPO_ROOT}/3rd/mgem-list
+    ${MRUBY_BUILD_DIR}/repos/host/mgem-list && ln -sfn
+    ${REPO_ROOT}/3rd/mgem-list ${MRUBY_BUILD_DIR}/repos/psp/mgem-list &&
+    ${MRB_OPTS} rake -v
+  WORKING_DIRECTORY "${MRUBY_PREFIX}"
+  DEPENDS "${REPO_ROOT}/build_config.rb" ${MRB_FILES})
+add_custom_target(mruby_build DEPENDS "${LIBMRUBY_A}")
+
+add_library(mruby STATIC IMPORTED)
+set_target_properties(mruby PROPERTIES IMPORTED_LOCATION "${LIBMRUBY_A}")
+target_include_directories(mruby INTERFACE "${MRUBY_PREFIX}/include"
+                                           "${MRUBY_GEN_INCLUDE}")
+add_dependencies(mruby mruby_build)
+
+# The bring-up HAL (mruby-rgss/src/psp.cxx) now comes from libmruby.a -- the
+# psp cross-build compiles it as part of the mruby-rgss gem, self-guarded on
+# PSP_BUILD the same way it always was. Compiling it here directly too, as the
+# earlier HAL-only bring-up did, would double-define every symbol in it
+# (psp_display_create, psp_input_scan, ...) once both this executable and
+# libmruby.a define them.
+add_executable(rpg2k_psp main.cxx)
 
 target_compile_definitions(rpg2k_psp PRIVATE PSP_BUILD LV_CONF_INCLUDE_SIMPLE)
 target_include_directories(rpg2k_psp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
@@ -55,7 +148,9 @@ target_include_directories(rpg2k_psp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 
 target_link_libraries(
   rpg2k_psp
+  mruby
   lvgl
+  uni-algo::uni-algo
   pspdisplay
   pspge
   pspctrl

--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -9,12 +9,12 @@ This is additive to and independent of the desktop CMake build — building the
 EBOOT does not touch the desktop/wasm builds, and vice versa. The design is in
 [`docs/adr/0010-psp-port.md`](../../docs/adr/0010-psp-port.md).
 
-## Status: HAL bring-up
+## Status: HAL bring-up + interpreter boot
 
 This CMake project builds a **hardware bring-up EBOOT**: it stands up the LVGL
-display over the LCD and reads the pad, without the mruby interpreter. It is the
-first slice of the roadmap in the ADR and exists to prove the HAL compiles and
-runs on the console (and to get real EBOOT size numbers from CI).
+display over the LCD, reads the pad, and opens an mruby interpreter — without
+starting a game. It exists to prove the HAL and libmruby.a compile, link and
+run on the console (and to get real EBOOT size numbers from CI).
 
 What runs today:
 
@@ -22,10 +22,17 @@ What runs today:
   mode flushing to the 480×272 framebuffer via `sceDisplay` (accounting for the
   512-pixel line stride); the LVGL tick/delay source from the pspsdk system
   timer; and a scan of the D-pad, analog stick and ✕○△□ buttons into a bitmask.
+  Built as part of `libmruby.a` (the `psp` mruby cross-build compiles the whole
+  `mruby-rgss` gem, self-guarded on `PSP_BUILD`), not compiled into the EBOOT
+  directly — `app/psp/CMakeLists.txt` links the archive in instead.
 - `app/psp/main.cxx` — a pspsdk sketch (module metadata + HOME-exit callback)
-  that draws a status screen and echoes the pressed keys. `main()` owns the loop
-  and pumps LVGL once per iteration, mirroring the Emscripten and Wio builds.
-  Its heartbeat also reports free device RAM and LVGL pool usage (see below).
+  that draws a status screen, echoes the pressed keys, and opens the
+  interpreter (`mrb_open`, reported via the `RPG2K_PSP_MRUBY_OPEN` marker
+  below). `main()` owns the loop and pumps LVGL once per iteration, mirroring
+  the Emscripten and Wio builds. Its heartbeat also reports free device RAM
+  and LVGL pool usage (see below). No RGSS methods are registered and no game
+  is started yet — the interpreter opens with mruby's own default allocator
+  (plain `malloc`) and then just sits there.
 - `app/psp/lv_conf.h` — a PSP-tuned LVGL config (RGB565, a few-MB heap, no SIMD
   asm).
 
@@ -44,8 +51,9 @@ Run `EBOOT.PBP` under an emulator such as
 [PPSSPP](https://www.ppsspp.org/), or copy it to
 `PSP/GAME/rpg2k/EBOOT.PBP` on a Memory Stick (a homebrew-enabled console).
 
-The bring-up writes two markers via `sceIoWrite` — `RPG2K_PSP_BOOT` once at
-startup (a libc-free string literal) and `RPG2K_PSP_BRINGUP
+The bring-up writes three markers via `sceIoWrite` — `RPG2K_PSP_BOOT` once at
+startup (a libc-free string literal), `RPG2K_PSP_MRUBY_OPEN ok` (or `FAILED`)
+right after `mrb_open()`, and `RPG2K_PSP_BRINGUP
 frame=N free=N maxfree=N lvgl_used=N lvgl_max=N` once a second, the last four
 fields being `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` (the
 device's actual free RAM) and `lv_mem_monitor`'s current/high-water-mark use
@@ -68,59 +76,41 @@ PPSSPPHeadless --log --graphics=software --timeout=15 EBOOT.PBP
 
 The pieces below are scaffolded but **not** part of the bring-up EBOOT:
 
-- **mruby interpreter + game.** `mruby-rgss/src/psp_input_bridge.cxx` already
-  translates the pad bitmask into `RGSS::Input` press/release events
-  (`rgss_psp_poll`, called from `Graphics.update`), and `build_config.rb` has a
-  `psp` mruby MIPS cross-build (`MRUBY_TARGET=psp`). Wiring `libmruby.a` into the
-  EBOOT link and starting the real `RPG2k` scene tree is the next slice.
-
-  Three prerequisite blockers the `psp` cross-build hit the moment it was
-  actually exercised (found while scoping this slice, before any of it
-  compiled against real pspdev headers — none of this was caught by CI, since
-  the `psp` cross-build had never pulled `mruby-rgss` in before):
-  - `mruby-rgss/src/terminal.cxx` (the sixel/iTerm2 backends) used POSIX
-    `termios.h`/`sys/ioctl.h` and a `std::thread` writer unconditionally at
-    file scope — unlike `psp.cxx`/`wio.cxx`, it was never self-guarded to be
-    a no-op off its own target, so it would not have compiled against
-    pspdev's newlib. Now guarded the same way (`#if !defined(PSP_BUILD) &&
-    !defined(WIO_TERMINAL)`), with a stub for the one symbol
-    (`rgss_terminal_poll`) called unconditionally elsewhere in the gem.
-  - `mrbgem.rake` unconditionally linked `pthread`, needed only by that same
-    `std::thread` writer. Now conditional on the *build's own* name (`psp`/
-    `wio`), not on `MRUBY_TARGET` — that env var is also set while the
-    native host build (which still needs pthread, to produce `mrbc`) runs
-    in the same cross-compile session.
-  - `mruby-mvjs` (RPG Maker MV/MZ via embedded QuickJS) links against `qjs`
-    and optionally EGL/GLESv2, neither of which exists for MIPS/pspdev or is
-    built by `app/psp`'s CMake project. MV/MZ was never in scope for this
-    port, so `rpg_maker_gems(conf, include_mvjs: false)` drops it for `psp`
-    specifically rather than porting QuickJS and a software GL stack as a
-    side effect.
-
-  Still ahead: building `uni-algo` for the `app/psp` CMake project (currently
-  only LVGL is added as a subdirectory there; `mruby-rgss`/`mruby-lcf` both
-  link it), actually invoking the `psp` mruby cross-build from
-  `app/psp/CMakeLists.txt` and linking `libmruby.a` in (dropping the
-  now-redundant direct `psp.cxx` compilation once the gem supplies it),
-  deciding the `GAME_DIR` Memory-Stick path convention, and — per ADR
-  0047's P2 — the mruby/LVGL allocator split.
-- **Memory-Stick assets.** Game data is opened by path through mruby-io /
-  `std::fopen`; on the PSP these resolve to newlib syscalls backed by the
-  Memory Stick, which pspsdk's `stdio` already routes. Pointing `GAME_DIR` at a
-  project on the stick follows once mruby is linked.
+- **The real `RPG2k` scene tree.** `mruby-rgss/src/psp_input_bridge.cxx`
+  already translates the pad bitmask into `RGSS::Input` press/release events
+  (`rgss_psp_poll`, called from `Graphics.update`), and `libmruby.a` (the
+  `psp` mruby cross-build, `MRUBY_TARGET=psp`) is now linked into the EBOOT
+  and opens successfully (`RPG2K_PSP_MRUBY_OPEN ok`). What's not wired yet:
+  registering the RGSS native methods and actually instantiating `RPG2k.new`
+  against a real game directory — `app/psp/main.cxx` opens the interpreter
+  and stops there.
+- **Memory-Stick assets / `GAME_DIR`.** Game data is opened by path through
+  mruby-io / `std::fopen`; on the PSP these resolve to newlib syscalls backed
+  by the Memory Stick, which pspsdk's `stdio` already routes. What's missing
+  is deciding and setting the `GAME_DIR` Memory-Stick path convention itself
+  (e.g. relative to the EBOOT's own directory) — needed before `RPG2k.new`
+  can find anything.
+- **ADR 0047's P2 (the mruby/LVGL allocator split).** `main.cxx` currently
+  opens mruby with its own default allocator (plain `malloc`), not routed
+  through `lv_malloc` the way the desktop build's `mrb_basic_alloc_func`
+  override does. Proving the interpreter boots didn't require deciding this;
+  starting a real game — where the pool size actually matters — does.
 - **Accelerated rendering.** The bring-up flushes with a CPU `memcpy` into the
   framebuffer. Moving the blit onto the `sceGu` GPU is a later optimisation.
 
 ## Memory budget
 
-The bring-up EBOOT never opens mruby, so it has never had to answer how the
-game's live heap, LVGL's pool and decoded assets fit inside the PSP's ~24 MB
-of RAM. [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)
-works through that before the interpreter-linking slice lands, including a
-real risk: mruby 4.0's global allocator hook defaults to sharing LVGL's pool
-(as it does on desktop), so `lv_conf.h`'s 4 MB `LV_MEM_SIZE` may need to cover
-the entire mruby object graph, not just LVGL widgets, unless a PSP-specific
-allocator exception is added.
+The bring-up EBOOT opens mruby but starts no game, so it has not yet had to
+answer how the game's live heap, LVGL's pool and decoded assets fit inside
+the PSP's ~24 MB of RAM.
+[`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)
+works through that before a real game is started, including a real risk:
+mruby 4.0's global allocator hook defaults to sharing LVGL's pool (as it does
+on desktop) if `main.cxx` ever installs that override the way the desktop
+build's `mrb_basic_alloc_func` does — which it does not yet (see "Not yet
+wired" above) — so `lv_conf.h`'s 4 MB `LV_MEM_SIZE` may need to cover the
+entire mruby object graph, not just LVGL widgets, unless a PSP-specific
+allocator exception is added instead.
 
 For a packed RPG Maker XP/VX/VX Ace title,
 [`scripts/rgssad_unpack.rb`](../../scripts/rgssad_unpack.rb) unpacks

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -1,24 +1,29 @@
 // PlayStation Portable EBOOT entry point -- hardware bring-up.
 //
-// This first slice proves the HAL compiles and runs on the PSP without the
-// mruby interpreter: it stands up the LVGL display (psp_display_create), scans
-// the pad (psp_input_scan), and draws a small status screen that echoes the
-// pressed keys. main() owns the loop and pumps LVGL once per iteration -- the
-// same "host owns the loop" shape the Emscripten and Wio builds use. Its
-// per-second heartbeat also reports real free-memory and LVGL-pool numbers
-// (see the RPG2K_PSP_BRINGUP marker below), which is ADR 0047's P1: this
-// bring-up EBOOT never opens mruby, but it can still measure the device's
-// actual RAM and how much of LVGL's pool the HAL alone uses, ahead of the
-// interpreter-linking slice that will need to size that pool for real.
+// This slice proves the HAL compiles and runs on the PSP and that libmruby.a
+// (built for the psp target by build_config.rb, linked in via
+// app/psp/CMakeLists.txt) actually links and boots on real MIPS/pspdev: it
+// stands up the LVGL display (psp_display_create), scans the pad
+// (psp_input_scan), draws a small status screen that echoes the pressed keys,
+// and opens an mruby interpreter (mrb_open). main() owns the loop and pumps
+// LVGL once per iteration -- the same "host owns the loop" shape the
+// Emscripten and Wio builds use. Its per-second heartbeat also reports real
+// free-memory and LVGL-pool numbers (see the RPG2K_PSP_BRINGUP marker below),
+// which is ADR 0047's P1: measuring the HAL's own footprint on real
+// hardware/an emulator ahead of sizing anything for a real game.
 //
-// The mruby interpreter, the real RPG2k scene tree and Memory-Stick asset
-// loading are wired in the following slices (see app/psp/README.md and
-// docs/adr/0010-psp-port.md); this build intentionally links neither libmruby
-// nor the mruby input bridge.
+// mrb_open() here uses mruby's own default allocator (plain malloc) rather
+// than routing through lv_malloc the way the desktop build does -- ADR 0047's
+// P2 (share LVGL's pool vs. a separate arena) is still an open decision that
+// this slice does not need to make just to prove the interpreter boots. No
+// RGSS methods are registered and no game is started: the real RPG2k scene
+// tree, Memory-Stick asset loading and the GAME_DIR convention are the next
+// slice (see app/psp/README.md and docs/adr/0010-psp-port.md).
 
 #include <cstdio>
 
 #include <lvgl.h>
+#include <mruby.h>
 #include <pspiofilemgr.h>
 #include <pspkernel.h>
 #include <pspsysmem.h>
@@ -126,6 +131,20 @@ int main(void) {
   psp_display_create(PSP_SCR_WIDTH, PSP_SCR_HEIGHT);
   psp_input_init();
   build_ui();
+
+  // Open the interpreter and report whether it succeeded. `M` is kept alive
+  // (never mrb_close()d) for the rest of the process, the same as every other
+  // target's entry point -- there is nothing to hand it yet, but the next
+  // slice needs it alive for the process's whole lifetime, not just this
+  // function.
+  mrb_state* const M = mrb_open();
+  {
+    char buf[48];
+    const int n = std::snprintf(buf, sizeof(buf), "RPG2K_PSP_MRUBY_OPEN %s\n",
+                                M ? "ok" : "FAILED");
+    if (n > 0)
+      psp_write(buf, n);
+  }
 
   // The loop runs ~200 iterations/second (5 ms delay); emit a heartbeat line
   // roughly once a second. The CI smoke test asserts this marker appears,

--- a/build_config.rb
+++ b/build_config.rb
@@ -223,9 +223,19 @@ if psp
     # objects match the EBOOT's ABI.
     cpu_flags = %w[-G0]
 
+    # pspsdk's own headers (pspctrl.h, pspdisplay.h, pspkernel.h, ... --
+    # needed once PSP_BUILD turns on the real psp.cxx / psp_input_bridge.cxx
+    # HAL below) live outside psp-gcc's baked-in sysroot; psp-cmake's
+    # toolchain file adds this automatically for CMake's own compiles (main.cxx,
+    # LVGL, uni-algo), but this Rakefile drives psp-gcc/psp-g++ directly and
+    # gets none of that, so ask pspsdk's own discovery tool for the path
+    # instead of hardcoding one.
+    pspsdk_include = "#{`psp-config --pspsdk-path`.strip}/include"
+
     [conf.cc, conf.cxx].each do |t|
       t.flags = t.flags.flatten.delete_if { |v| v == '-O0' }
       t.flags += cpu_flags
+      t.include_paths << pspsdk_include
       t.defines << 'PSP_BUILD'
       # newlib on the PSP defines none of __linux__/__APPLE__/__*BSD__, so
       # mruby's string.c falls through to the 1 MiB MRB_STR_LENGTH_MAX cap and

--- a/changelog.d/cmake-shared-mruby-build.changed.md
+++ b/changelog.d/cmake-shared-mruby-build.changed.md
@@ -1,0 +1,12 @@
+- **The mruby build's CMake glue is no longer duplicated.** Root
+  `CMakeLists.txt` (desktop/wasm) and `app/psp/CMakeLists.txt` (the PSP EBOOT)
+  each drove `libmruby.a`'s rake-based build (`build_config.rb`) with their
+  own near-identical copy of the same custom command, gem-source glob and
+  mgem-list symlink dance. Factored the shared parts into
+  `cmake/build-mruby.cmake`'s `rpg2k_add_mruby()`, parameterized by the mruby
+  build's target name, its local gem list (root includes `mruby-mvjs`, PSP
+  does not) and any extra rake options (`MRUBY_TARGET=`, host `CC=`/`CXX=`
+  overrides, ...). Both call sites now differ only in those arguments. No
+  behavior change: verified with a scratch CMake project reproducing each
+  call site that the generated `mruby_build` custom command and rake
+  invocation are unchanged.

--- a/changelog.d/psp-eboot-links.fixed.md
+++ b/changelog.d/psp-eboot-links.fixed.md
@@ -1,0 +1,21 @@
+- **The PSP EBOOT now links end to end.** Once `libmruby.a` reached the final
+  link step for the first time, three more platform gaps surfaced:
+  - `umask` (backing `File.umask`) is an eighth POSIX symbol pspdev's newlib
+    declares but does not implement -- added to `mruby-rgss/src/psp_io_stubs.c`
+    alongside the six from the previous fix. Unlike those, `umask` cannot
+    fail per POSIX, so it reports success (an always-0 mask) rather than
+    `ENOSYS`.
+  - `mruby-rgss`'s rake-driven compile (`mrbgem.rake`) never saw
+    `app/psp/lv_conf.h` -- it always resolved LVGL's config through the
+    shared `include/lv_conf.h` (`LV_USE_LOG 1`, `LV_USE_SNAPSHOT 1`) instead,
+    while `app/psp/CMakeLists.txt`'s own LVGL build genuinely used
+    `app/psp/lv_conf.h` (`LV_USE_LOG 0`). The two disagreeing about what
+    `liblvgl.a` actually compiled in left `lib.cxx`'s calls to `lv_log_add`
+    and `lv_snapshot_take` unresolved at link time. `mrbgem.rake` now puts
+    `app/psp/`'s include directory ahead of the shared one for the `psp`
+    build specifically, so both compiles see the same config.
+  - `libpspkernel.a` bundles its own NID-stub implementations of a couple of
+    libc functions (`strtol`, `strtoul`) alongside newlib's real ones, which
+    collided as a hard "multiple definition" link error. Added
+    `-Wl,--allow-multiple-definition` to the EBOOT's link options, which
+    keeps the first (real, newlib) definition linked ahead of `libpspkernel.a`.

--- a/changelog.d/psp-libmruby-linked.added.md
+++ b/changelog.d/psp-libmruby-linked.added.md
@@ -1,0 +1,13 @@
+- **PSP EBOOT links `libmruby.a` and boots the interpreter.**
+  `app/psp/CMakeLists.txt` now builds `uni-algo` (mruby-rgss/mruby-lcf's
+  Unicode dependency) and invokes the `psp` mruby cross-build via the same
+  rake-based process the root CMakeLists.txt uses for desktop/wasm, then
+  links the resulting `libmruby.a` into the EBOOT — dropping the now-redundant
+  direct compile of `mruby-rgss/src/psp.cxx`, which the gem now supplies.
+  `app/psp/main.cxx` calls `mrb_open()` right after the display/input HAL
+  comes up and reports success via a new `RPG2K_PSP_MRUBY_OPEN` marker. No
+  RGSS methods are registered and no game starts yet — mruby opens with its
+  own default allocator (not yet routed through `lv_malloc`; see ADR 0047's
+  P2) and the interpreter just sits there. See `app/psp/README.md`'s "Not yet
+  wired" section for what's left before a real game can boot (the `GAME_DIR`
+  convention, the RGSS scene tree, and the allocator decision).

--- a/changelog.d/psp-mruby-io-posix-stubs.fixed.md
+++ b/changelog.d/psp-mruby-io-posix-stubs.fixed.md
@@ -1,0 +1,10 @@
+- **The PSP EBOOT now links libmruby.a.** mruby-io's default I/O HAL
+  (hal-posix-io, auto-selected since nothing in `build_config.rb` picks one
+  explicitly) calls six POSIX functions pspdev's newlib declares but does
+  not implement -- `dup`/`dup2`/`sysconf` back its subprocess-spawn support,
+  `ftruncate`/`flock`/`dup` back `IO#dup`/`File#flock`/`File#truncate` --
+  which failed the final link with six "undefined reference" errors. None of
+  that is reachable from this bring-up (no process model on the PSP, no game
+  code yet), so `mruby-rgss/src/psp_io_stubs.c` (`PSP_BUILD`-gated, like the
+  rest of the PSP HAL) now supplies minimal set-errno-and-fail definitions
+  instead.

--- a/changelog.d/psp-mruby-pspsdk-include-path.fixed.md
+++ b/changelog.d/psp-mruby-pspsdk-include-path.fixed.md
@@ -1,0 +1,10 @@
+- **The `psp` mruby cross-build now finds pspsdk's own headers.** Now that
+  `mruby-rgss/src/psp.cxx` (the real LVGL/pad HAL, `PSP_BUILD`-gated) compiles
+  as part of `libmruby.a` instead of being compiled directly by CMake,
+  `#include <pspctrl.h>` and friends failed with "No such file or directory":
+  `psp-cmake`'s toolchain file adds pspsdk's include path to CMake's own
+  compiles automatically, but `build_config.rb`'s `psp` `MRuby::CrossBuild`
+  drives `psp-gcc`/`psp-g++` directly through mruby's own rake-based build
+  and got none of that. `psp-config --pspsdk-path` (pspsdk's own discovery
+  tool, the same one Makefile-based pspsdk projects use) now supplies the
+  path instead.

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -1,0 +1,123 @@
+# Shared logic for building libmruby.a via mruby's own rake-based build
+# system (build_config.rb), used by both the desktop/wasm build (root
+# CMakeLists.txt) and the PSP EBOOT build (app/psp/CMakeLists.txt). mruby's
+# gem system -- which C sources, generated headers, gembox membership -- is
+# entirely decided by that Rakefile, not by anything CMake can glob on its
+# own, so this drives rake as an external build system via a custom command
+# rather than declaring a native CMake target.
+#
+# rpg2k_add_mruby(
+#   TARGET_NAME <name>              # the mruby build's own name (build.name in
+#                                    # build_config.rb -- "host", "emscripten",
+#                                    # "psp", ...)
+#   REPO_ROOT <path>                # repo root: build_config.rb, 3rd/mruby and
+#                                    # 3rd/mgem-list all hang off this
+#   PROJECT_BUILD_DIR <path>        # the calling project's CMAKE_CURRENT_BINARY_DIR
+#   GEMS <gem> [<gem> ...]          # local mrbgem dirs to watch for rebuild
+#                                    # triggers (e.g. mruby-rgss)
+#   [MRB_OPTS <opt> ...]            # extra rake VAR=value args beyond the
+#                                    # MRUBY_CONFIG/MRUBY_BUILD_DIR/PROJECT_BUILD_DIR
+#                                    # this function always sets itself
+# )
+#
+# Defines an IMPORTED STATIC `mruby` target (INTERFACE-including its generated
+# presym header dir) and a `mruby_build` custom target that `mruby` depends on.
+function(rpg2k_add_mruby)
+  set(one_value_args TARGET_NAME REPO_ROOT PROJECT_BUILD_DIR)
+  set(multi_value_args GEMS MRB_OPTS)
+  cmake_parse_arguments(ARG "" "${one_value_args}" "${multi_value_args}"
+                        ${ARGN})
+
+  set(mruby_prefix "${ARG_REPO_ROOT}/3rd/mruby")
+  set(mruby_build_dir "${ARG_PROJECT_BUILD_DIR}/mruby")
+  set(libmruby_a
+      "${mruby_build_dir}/${ARG_TARGET_NAME}/lib/libmruby.a")
+  # mruby 4.0 always enables presym, so <mruby.h> unconditionally pulls in
+  # <mruby/presym.h> and its generated mruby/presym/id.h. That header lives in
+  # the build tree (produced by the rake build below), not in the source
+  # include dir, so expose it too. Create it now so CMake's imported-target
+  # check -- which requires INTERFACE include dirs to exist at configure time
+  # -- passes before the build populates it.
+  set(mruby_gen_include "${mruby_build_dir}/${ARG_TARGET_NAME}/include")
+  file(MAKE_DIRECTORY "${mruby_gen_include}")
+
+  add_library(mruby STATIC IMPORTED)
+  set_target_properties(mruby PROPERTIES IMPORTED_LOCATION "${libmruby_a}")
+  target_include_directories(mruby INTERFACE "${mruby_prefix}/include"
+                                             "${mruby_gen_include}")
+
+  # Collect the source of each local mrbgem so libmruby.a rebuilds when any of
+  # it changes. GLOB_RECURSE also picks up files in nested subdirectories, and
+  # CONFIGURE_DEPENDS makes CMake re-run the glob at build time: adding or
+  # removing a source file triggers a reconfigure (and thus a libmruby
+  # rebuild) on the next build, with no manual `cmake` re-run. Header changes
+  # under src/ are caught too so an edit to a private header still forces the
+  # archive to be rebuilt.
+  foreach(g ${ARG_GEMS})
+    file(
+      GLOB_RECURSE
+      src
+      CONFIGURE_DEPENDS
+      ${ARG_REPO_ROOT}/${g}/src/*.c
+      ${ARG_REPO_ROOT}/${g}/src/*.cxx
+      ${ARG_REPO_ROOT}/${g}/src/*.cpp
+      ${ARG_REPO_ROOT}/${g}/src/*.h
+      ${ARG_REPO_ROOT}/${g}/src/*.hpp
+      ${ARG_REPO_ROOT}/${g}/src/*.hxx)
+    file(GLOB_RECURSE rb CONFIGURE_DEPENDS
+         ${ARG_REPO_ROOT}/${g}/mrblib/*.rb)
+    list(APPEND mrb_files ${src} ${rb} ${ARG_REPO_ROOT}/${g}/mrbgem.rake)
+  endforeach()
+
+  # Also rebuild libmruby.a when mruby's own core changes. These sources live
+  # in the 3rd/mruby submodule; CONFIGURE_DEPENDS keeps the list current as
+  # the submodule is checked out or updated to a new revision.
+  file(
+    GLOB_RECURSE
+    mruby_core
+    CONFIGURE_DEPENDS
+    ${mruby_prefix}/src/*.c
+    ${mruby_prefix}/src/*.h
+    ${mruby_prefix}/mrblib/*.rb
+    ${mruby_prefix}/include/*.h)
+  list(APPEND mrb_files ${mruby_core})
+
+  set(mrb_opts
+      MRUBY_CONFIG=${ARG_REPO_ROOT}/build_config.rb
+      MRUBY_BUILD_DIR=${mruby_build_dir}
+      PROJECT_BUILD_DIR=${ARG_PROJECT_BUILD_DIR} ${ARG_MRB_OPTS})
+
+  # Point mruby's rake at the vendored mgem-list (the mgem index) via symlinks
+  # in its repos/ dir so it resolves gems locally instead of cloning from
+  # GitHub. Both repos/host and repos/<TARGET_NAME> are linked: a cross build
+  # (emscripten, psp, ...) also runs a native "host" build alongside the cross
+  # target to produce mrbc, and that half looks for the index under its own
+  # repos/host too. Use `ln -sfn`, not `ln -sf`: once these links exist, a
+  # plain `ln -sf` would dereference the existing symlink-to-directory and
+  # drop a new link *inside* 3rd/mgem-list (a self-referential
+  # 3rd/mgem-list/mgem-list), dirtying the submodule. `-n` (no-dereference;
+  # portable across GNU and BSD/macOS) replaces the symlink in place instead.
+  add_custom_command(
+    OUTPUT "${libmruby_a}"
+    COMMAND
+      mkdir -p ${mruby_build_dir}/repos/host
+      ${mruby_build_dir}/repos/${ARG_TARGET_NAME} && ln -sfn
+      ${ARG_REPO_ROOT}/3rd/mgem-list ${mruby_build_dir}/repos/host/mgem-list
+      && ln -sfn ${ARG_REPO_ROOT}/3rd/mgem-list
+      ${mruby_build_dir}/repos/${ARG_TARGET_NAME}/mgem-list && ${mrb_opts}
+      rake -v
+    WORKING_DIRECTORY "${mruby_prefix}"
+    DEPENDS "${ARG_REPO_ROOT}/build_config.rb" ${mrb_files})
+  add_custom_target(mruby_build DEPENDS "${libmruby_a}")
+  add_dependencies(mruby mruby_build)
+
+  # Expose the computed paths and final rake options to the caller for
+  # anything downstream that needs them: root CMakeLists.txt's emscripten-only
+  # onigmo re-archiving step and ADDITIONAL_CLEAN_FILES key off
+  # MRUBY_BUILD_DIR, and its `rake test` CTest target re-runs rake with the
+  # same MRUBY_PREFIX/MRB_OPTS this function just used to build.
+  set(MRUBY_BUILD_DIR "${mruby_build_dir}" PARENT_SCOPE)
+  set(LIBMRUBY_A "${libmruby_a}" PARENT_SCOPE)
+  set(MRUBY_PREFIX "${mruby_prefix}" PARENT_SCOPE)
+  set(MRB_OPTS "${mrb_opts}" PARENT_SCOPE)
+endfunction()

--- a/cmake/build-mruby.cmake
+++ b/cmake/build-mruby.cmake
@@ -1,24 +1,19 @@
-# Shared logic for building libmruby.a via mruby's own rake-based build
-# system (build_config.rb), used by both the desktop/wasm build (root
-# CMakeLists.txt) and the PSP EBOOT build (app/psp/CMakeLists.txt). mruby's
-# gem system -- which C sources, generated headers, gembox membership -- is
-# entirely decided by that Rakefile, not by anything CMake can glob on its
-# own, so this drives rake as an external build system via a custom command
-# rather than declaring a native CMake target.
+# Shared logic for building libmruby.a via mruby's own rake-based build system
+# (build_config.rb), used by both the desktop/wasm build (root CMakeLists.txt)
+# and the PSP EBOOT build (app/psp/CMakeLists.txt). mruby's gem system -- which
+# C sources, generated headers, gembox membership -- is entirely decided by that
+# Rakefile, not by anything CMake can glob on its own, so this drives rake as an
+# external build system via a custom command rather than declaring a native
+# CMake target.
 #
-# rpg2k_add_mruby(
-#   TARGET_NAME <name>              # the mruby build's own name (build.name in
-#                                    # build_config.rb -- "host", "emscripten",
-#                                    # "psp", ...)
-#   REPO_ROOT <path>                # repo root: build_config.rb, 3rd/mruby and
-#                                    # 3rd/mgem-list all hang off this
-#   PROJECT_BUILD_DIR <path>        # the calling project's CMAKE_CURRENT_BINARY_DIR
-#   GEMS <gem> [<gem> ...]          # local mrbgem dirs to watch for rebuild
-#                                    # triggers (e.g. mruby-rgss)
-#   [MRB_OPTS <opt> ...]            # extra rake VAR=value args beyond the
-#                                    # MRUBY_CONFIG/MRUBY_BUILD_DIR/PROJECT_BUILD_DIR
-#                                    # this function always sets itself
-# )
+# rpg2k_add_mruby() takes TARGET_NAME (the mruby build's own name -- build.name
+# in build_config.rb, e.g. "host", "emscripten", "psp"), REPO_ROOT (repo root:
+# build_config.rb, 3rd/mruby and 3rd/mgem-list all hang off this),
+# PROJECT_BUILD_DIR (the calling project's CMAKE_CURRENT_BINARY_DIR), GEMS
+# (local mrbgem dirs to watch for rebuild triggers, e.g. mruby-rgss) and an
+# optional MRB_OPTS (extra rake VAR=value args beyond the
+# MRUBY_CONFIG/MRUBY_BUILD_DIR/PROJECT_BUILD_DIR this function always sets
+# itself).
 #
 # Defines an IMPORTED STATIC `mruby` target (INTERFACE-including its generated
 # presym header dir) and a `mruby_build` custom target that `mruby` depends on.
@@ -30,14 +25,13 @@ function(rpg2k_add_mruby)
 
   set(mruby_prefix "${ARG_REPO_ROOT}/3rd/mruby")
   set(mruby_build_dir "${ARG_PROJECT_BUILD_DIR}/mruby")
-  set(libmruby_a
-      "${mruby_build_dir}/${ARG_TARGET_NAME}/lib/libmruby.a")
+  set(libmruby_a "${mruby_build_dir}/${ARG_TARGET_NAME}/lib/libmruby.a")
   # mruby 4.0 always enables presym, so <mruby.h> unconditionally pulls in
   # <mruby/presym.h> and its generated mruby/presym/id.h. That header lives in
-  # the build tree (produced by the rake build below), not in the source
-  # include dir, so expose it too. Create it now so CMake's imported-target
-  # check -- which requires INTERFACE include dirs to exist at configure time
-  # -- passes before the build populates it.
+  # the build tree (produced by the rake build below), not in the source include
+  # dir, so expose it too. Create it now so CMake's imported-target check --
+  # which requires INTERFACE include dirs to exist at configure time -- passes
+  # before the build populates it.
   set(mruby_gen_include "${mruby_build_dir}/${ARG_TARGET_NAME}/include")
   file(MAKE_DIRECTORY "${mruby_gen_include}")
 
@@ -49,10 +43,10 @@ function(rpg2k_add_mruby)
   # Collect the source of each local mrbgem so libmruby.a rebuilds when any of
   # it changes. GLOB_RECURSE also picks up files in nested subdirectories, and
   # CONFIGURE_DEPENDS makes CMake re-run the glob at build time: adding or
-  # removing a source file triggers a reconfigure (and thus a libmruby
-  # rebuild) on the next build, with no manual `cmake` re-run. Header changes
-  # under src/ are caught too so an edit to a private header still forces the
-  # archive to be rebuilt.
+  # removing a source file triggers a reconfigure (and thus a libmruby rebuild)
+  # on the next build, with no manual `cmake` re-run. Header changes under src/
+  # are caught too so an edit to a private header still forces the archive to be
+  # rebuilt.
   foreach(g ${ARG_GEMS})
     file(
       GLOB_RECURSE
@@ -64,14 +58,13 @@ function(rpg2k_add_mruby)
       ${ARG_REPO_ROOT}/${g}/src/*.h
       ${ARG_REPO_ROOT}/${g}/src/*.hpp
       ${ARG_REPO_ROOT}/${g}/src/*.hxx)
-    file(GLOB_RECURSE rb CONFIGURE_DEPENDS
-         ${ARG_REPO_ROOT}/${g}/mrblib/*.rb)
+    file(GLOB_RECURSE rb CONFIGURE_DEPENDS ${ARG_REPO_ROOT}/${g}/mrblib/*.rb)
     list(APPEND mrb_files ${src} ${rb} ${ARG_REPO_ROOT}/${g}/mrbgem.rake)
   endforeach()
 
-  # Also rebuild libmruby.a when mruby's own core changes. These sources live
-  # in the 3rd/mruby submodule; CONFIGURE_DEPENDS keeps the list current as
-  # the submodule is checked out or updated to a new revision.
+  # Also rebuild libmruby.a when mruby's own core changes. These sources live in
+  # the 3rd/mruby submodule; CONFIGURE_DEPENDS keeps the list current as the
+  # submodule is checked out or updated to a new revision.
   file(
     GLOB_RECURSE
     mruby_core
@@ -92,32 +85,40 @@ function(rpg2k_add_mruby)
   # GitHub. Both repos/host and repos/<TARGET_NAME> are linked: a cross build
   # (emscripten, psp, ...) also runs a native "host" build alongside the cross
   # target to produce mrbc, and that half looks for the index under its own
-  # repos/host too. Use `ln -sfn`, not `ln -sf`: once these links exist, a
-  # plain `ln -sf` would dereference the existing symlink-to-directory and
-  # drop a new link *inside* 3rd/mgem-list (a self-referential
-  # 3rd/mgem-list/mgem-list), dirtying the submodule. `-n` (no-dereference;
-  # portable across GNU and BSD/macOS) replaces the symlink in place instead.
+  # repos/host too. Use `ln -sfn`, not `ln -sf`: once these links exist, a plain
+  # `ln -sf` would dereference the existing symlink-to-directory and drop a new
+  # link *inside* 3rd/mgem-list (a self-referential 3rd/mgem-list/mgem-list),
+  # dirtying the submodule. `-n` (no-dereference; portable across GNU and
+  # BSD/macOS) replaces the symlink in place instead.
   add_custom_command(
     OUTPUT "${libmruby_a}"
     COMMAND
       mkdir -p ${mruby_build_dir}/repos/host
       ${mruby_build_dir}/repos/${ARG_TARGET_NAME} && ln -sfn
-      ${ARG_REPO_ROOT}/3rd/mgem-list ${mruby_build_dir}/repos/host/mgem-list
-      && ln -sfn ${ARG_REPO_ROOT}/3rd/mgem-list
-      ${mruby_build_dir}/repos/${ARG_TARGET_NAME}/mgem-list && ${mrb_opts}
-      rake -v
+      ${ARG_REPO_ROOT}/3rd/mgem-list ${mruby_build_dir}/repos/host/mgem-list &&
+      ln -sfn ${ARG_REPO_ROOT}/3rd/mgem-list
+      ${mruby_build_dir}/repos/${ARG_TARGET_NAME}/mgem-list && ${mrb_opts} rake
+      -v
     WORKING_DIRECTORY "${mruby_prefix}"
     DEPENDS "${ARG_REPO_ROOT}/build_config.rb" ${mrb_files})
   add_custom_target(mruby_build DEPENDS "${libmruby_a}")
   add_dependencies(mruby mruby_build)
 
-  # Expose the computed paths and final rake options to the caller for
-  # anything downstream that needs them: root CMakeLists.txt's emscripten-only
-  # onigmo re-archiving step and ADDITIONAL_CLEAN_FILES key off
-  # MRUBY_BUILD_DIR, and its `rake test` CTest target re-runs rake with the
-  # same MRUBY_PREFIX/MRB_OPTS this function just used to build.
-  set(MRUBY_BUILD_DIR "${mruby_build_dir}" PARENT_SCOPE)
-  set(LIBMRUBY_A "${libmruby_a}" PARENT_SCOPE)
-  set(MRUBY_PREFIX "${mruby_prefix}" PARENT_SCOPE)
-  set(MRB_OPTS "${mrb_opts}" PARENT_SCOPE)
+  # Expose the computed paths and final rake options to the caller for anything
+  # downstream that needs them: root CMakeLists.txt's emscripten-only onigmo
+  # re-archiving step and ADDITIONAL_CLEAN_FILES key off MRUBY_BUILD_DIR, and
+  # its `rake test` CTest target re-runs rake with the same
+  # MRUBY_PREFIX/MRB_OPTS this function just used to build.
+  set(MRUBY_BUILD_DIR
+      "${mruby_build_dir}"
+      PARENT_SCOPE)
+  set(LIBMRUBY_A
+      "${libmruby_a}"
+      PARENT_SCOPE)
+  set(MRUBY_PREFIX
+      "${mruby_prefix}"
+      PARENT_SCOPE)
+  set(MRB_OPTS
+      "${mrb_opts}"
+      PARENT_SCOPE)
 endfunction()

--- a/mruby-rgss/mrbgem.rake
+++ b/mruby-rgss/mrbgem.rake
@@ -12,7 +12,19 @@ MRuby::Gem::Specification.new('mruby-rgss') do |spec|
 
   cxx.include_paths <<
     "#{dir}/../3rd/uni-algo/include" <<
-    "#{dir}/../3rd/lvgl" <<
+    "#{dir}/../3rd/lvgl"
+  # PSP wants its own lv_conf.h (LV_USE_LOG 0, LVGL's pool sized for the
+  # PSP's ~24 MB) ahead of the shared repo-root one below: LVGL's
+  # lv_conf_internal.h auto-includes whichever lv_conf.h __has_include finds
+  # first on the search path, and this rake-driven compile of mruby-rgss
+  # (which calls into LVGL -- lib.cxx's vp_refresh_overlay/gfx_snap_to_bitmap)
+  # needs to see the same config app/psp/CMakeLists.txt's own LVGL build
+  # used, or the two disagree on what LVGL actually compiled in
+  # (LV_USE_LOG/LV_USE_SNAPSHOT) and the final EBOOT link fails with
+  # undefined references (lv_log_add, lv_snapshot_take) that only the
+  # *other* config's LVGL build would have provided.
+  cxx.include_paths << "#{dir}/../app/psp" if build.name == 'psp'
+  cxx.include_paths <<
     "#{dir}/../include" <<
     "#{dir}/../3rd/stb" <<
     build_dir

--- a/mruby-rgss/src/psp_io_stubs.c
+++ b/mruby-rgss/src/psp_io_stubs.c
@@ -1,0 +1,61 @@
+// mruby-io's default I/O HAL (hal-posix-io, auto-selected by
+// 3rd/mruby/mrbgems/mruby-io/mrbgem.rake since nothing in build_config.rb
+// picks one explicitly) calls six POSIX functions pspdev's newlib declares
+// in its headers (so hal-posix-io compiles) but does not implement (so
+// linking the EBOOT fails with "undefined reference"): dup/dup2/sysconf
+// back mrb_hal_io_spawn_process's fork-and-exec dance, and
+// ftruncate/flock/dup are also reachable from IO#dup, File#flock and
+// File#truncate. None of that is reachable from this bring-up -- there is
+// no process model on the PSP to spawn into, and no game code yet -- so
+// minimal set-errno-and-fail definitions are enough to satisfy the linker
+// without claiming functionality the platform does not have. Only built for
+// PSP_BUILD; every other target already has a real implementation of these.
+#if defined(PSP_BUILD)
+
+#include <errno.h>
+#include <sys/file.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int ftruncate(int fd, off_t length) {
+  (void)fd;
+  (void)length;
+  errno = ENOSYS;
+  return -1;
+}
+
+int flock(int fd, int operation) {
+  (void)fd;
+  (void)operation;
+  errno = ENOSYS;
+  return -1;
+}
+
+int dup(int fd) {
+  (void)fd;
+  errno = ENOSYS;
+  return -1;
+}
+
+int dup2(int fd, int fd2) {
+  (void)fd;
+  (void)fd2;
+  errno = ENOSYS;
+  return -1;
+}
+
+long sysconf(int name) {
+  (void)name;
+  errno = ENOSYS;
+  return -1;
+}
+
+pid_t waitpid(pid_t pid, int* status, int options) {
+  (void)pid;
+  (void)status;
+  (void)options;
+  errno = ENOSYS;
+  return -1;
+}
+
+#endif  // PSP_BUILD

--- a/mruby-rgss/src/psp_io_stubs.c
+++ b/mruby-rgss/src/psp_io_stubs.c
@@ -1,19 +1,20 @@
 // mruby-io's default I/O HAL (hal-posix-io, auto-selected by
 // 3rd/mruby/mrbgems/mruby-io/mrbgem.rake since nothing in build_config.rb
-// picks one explicitly) calls six POSIX functions pspdev's newlib declares
+// picks one explicitly) calls seven POSIX functions pspdev's newlib declares
 // in its headers (so hal-posix-io compiles) but does not implement (so
 // linking the EBOOT fails with "undefined reference"): dup/dup2/sysconf
-// back mrb_hal_io_spawn_process's fork-and-exec dance, and
-// ftruncate/flock/dup are also reachable from IO#dup, File#flock and
-// File#truncate. None of that is reachable from this bring-up -- there is
-// no process model on the PSP to spawn into, and no game code yet -- so
-// minimal set-errno-and-fail definitions are enough to satisfy the linker
+// back mrb_hal_io_spawn_process's fork-and-exec dance, umask backs
+// File.umask, and ftruncate/flock/dup are also reachable from IO#dup,
+// File#flock and File#truncate. None of that is reachable from this
+// bring-up -- there is no process model on the PSP to spawn into, and no
+// game code yet -- so minimal stand-ins are enough to satisfy the linker
 // without claiming functionality the platform does not have. Only built for
 // PSP_BUILD; every other target already has a real implementation of these.
 #if defined(PSP_BUILD)
 
 #include <errno.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -56,6 +57,14 @@ pid_t waitpid(pid_t pid, int* status, int options) {
   (void)options;
   errno = ENOSYS;
   return -1;
+}
+
+// umask has no error return in POSIX -- it always succeeds -- so unlike the
+// stubs above this reports success: no permission bits are ever cleared (an
+// always-0 mask), and the previous mask it reports back is always 0 too.
+mode_t umask(mode_t mask) {
+  (void)mask;
+  return 0;
 }
 
 #endif  // PSP_BUILD


### PR DESCRIPTION
## Summary

`app/psp/CMakeLists.txt` now actually builds and links `libmruby.a` into the PSP EBOOT — the "wiring `libmruby.a` into the EBOOT link" half of ADR 0010's next slice (the other half, starting the real `RPG2k` scene tree, is still ahead — see below).

- Builds `uni-algo` (`mruby-rgss`/`mruby-lcf`'s Unicode dependency) as a CMake subdirectory, matching the existing LVGL pattern.
- Invokes the `psp` mruby cross-build via the same rake-based custom-command process the root `CMakeLists.txt` already uses for the desktop/wasm builds — same mgem-list symlink dance, same dependency-file collection, adapted to `app/psp`'s standalone build tree.
- Links the resulting `libmruby.a` into `rpg2k_psp`, and drops the now-redundant direct compilation of `mruby-rgss/src/psp.cxx` — the gem now supplies it as part of the archive (built on `PR #766`'s work making `mruby-rgss` actually compile for pspdev), and compiling it twice would double-define every symbol in it.
- `app/psp/main.cxx` calls `mrb_open()` right after the display/input HAL comes up and reports success via a new `RPG2K_PSP_MRUBY_OPEN` marker.

No RGSS methods are registered and no game starts yet — mruby opens with its own default allocator, not yet routed through `lv_malloc` (ADR 0047's P2 remains open; proving the interpreter boots didn't require deciding it). `app/psp/README.md` is updated throughout — status, what runs today, the marker list, "not yet wired," and the memory-budget section — to reflect that mruby now opens rather than never running at all.

## Verification

Still no real `psp-gcc` in this environment, so this can't be compiled for the actual target here. What I could and did verify:

- **LVGL's and uni-algo's actual CMake output paths.** `mrbgem.rake` expects `liblvgl.a` at `.../3rd/lvgl/lib/` and `libuni-algo.a` at `.../3rd/uni-algo/` directly — rather than assume, I configured and built the real vendored submodules with the host compiler in an isolated scratch project and confirmed exactly where each lands (`<binary_dir>/lib/liblvgl.a` vs. `<binary_dir>/libuni-algo.a`, reflecting each library's own CMakeLists.txt, not a shared convention). That's what drove renaming the existing `add_subdirectory(... lvgl ...)` binary dir to `3rd/lvgl` and adding uni-algo the same way.
- **The CMake-to-rake handoff.** Reproduced the exact custom command (env vars, mgem-list symlinks, working directory) standalone and ran it for real. It correctly resolved the host build (producing `mrbc`) and then reached genuine cross-compilation — onigmo's `./configure --host mipsel-unknown-linux` correctly detecting and invoking `psp-gcc` — failing only because `psp-gcc` doesn't exist in this environment. That's the real toolchain boundary, not a bug in the wiring.
- **`main.cxx`'s `mrb_open()`/`mrb_state*` usage** checked against the real `mruby.h` signature (`MRB_API mrb_state* mrb_open(void);`). `clang-format` reports no diff.

## Notable details

- Builds on `PR #766` (making `mruby-rgss` actually buildable for pspdev — the `terminal.cxx` guard, conditional `pthread`, `mruby-mvjs` exclusion), which already merged and passed CI's `psp` job.
- This PR is a much bigger bet than #766: it's the first time the *entire* link step (mruby core + every gem + LVGL + uni-algo + pspsdk libraries) has to resolve together for PSP. CI's `psp` job is the real test.

## Test plan

- [x] LVGL/uni-algo CMake output paths confirmed via a real host-compiler build of the vendored submodules
- [x] CMake→rake custom command handoff verified end to end in an isolated reproduction, reaching real cross-compilation before hitting the missing-`psp-gcc` boundary
- [x] `mrb_open()`/`mrb_state*` signature checked against real `mruby.h`
- [x] `clang-format` reports no diff on `main.cxx`
- [ ] CI `psp` job (cannot cross-compile for PSP in this environment) — the real test of whether the full link resolves


---
_Generated by [Claude Code](https://claude.ai/code/session_01CaTSJ4i2Lwxi3VAV2DEr5D)_