### PR TITLE
Build the battle-command menu from RPG2003's own customization

### DIFF
--- a/changelog.d/rpg2003-battle-command-customization.added.md
+++ b/changelog.d/rpg2003-battle-command-customization.added.md
@@ -1,0 +1,11 @@
+- **RPG2003's per-actor battle-command customization now drives the in-battle
+  menu.** An acting actor whose own `Game::Actor#battle_commands` (edited by
+  Change Battle Commands (1009) or a class change) resolves to at least one
+  usable entry now sees that list — in its own order, reordered or shortened —
+  instead of always the fixed Attack/Skill/Defend/Item four, and
+  `Scene::Map#select_battle_command` dispatches by each row's own action
+  rather than a fixed index, so a customized list still routes to the right
+  handler. Resolving a positive id reads a new LCF chunk 29 (the database-wide
+  Battle Commands table, `mruby-lcf/mrblib/schema.rb`) via a new
+  `Game::Actor#battle_command_row`; a database without it (every RPG2000 file)
+  or a list with nothing usable in it falls back to the fixed four as before.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -889,16 +889,39 @@ The work below is roughly ordered by the critical path to a walkable game
   recomputed per actor rather than cached once for the whole battle, since it
   can differ member to member. RPG2003's own further customization of this
   list (`Game::Actor#battle_commands`, edited by Change Battle Commands (1009)
-  or a class change, both already modelled in `game.rb`) still is not consumed
-  by this menu — a separate, still-open gap, the same "reported, not silently
-  invented" answer Toggle ATB Mode and the field-menu command list above give
-  for the same unmodelled RPG2003 battle-command customization. Covered by new
+  or a class change, both already modelled in `game.rb`) **now drives the menu
+  too**: `Scene::Map#custom_battle_commands` resolves each positive id through
+  a new `Game::Actor#battle_command_row`, itself reading a new LCF chunk 29
+  (`battlecommands`, `mruby-lcf/mrblib/schema.rb`) that decodes the
+  database-wide Battle Commands table (name + type per entry — id/field
+  layout transcribed from liblcf's own `generator/csv/{fields,enums}.csv`,
+  the VIPRPG 200X wiki this schema otherwise cites having no page for it) a
+  positive `battle_commands` id refs into; 0 (Row) and -1 (an empty slot)
+  never do and are skipped, matching EasyRPG's own `Game_Actor
+  ::GetBattleCommands` (its comment marks Row "not impl" and skips it the same
+  way). Only the four types this engine drives — Attack, (sub)Skill, Defense,
+  Item — become a menu row; Escape (already offered as Cancel on the first
+  actor) and Special (no handler modelled anywhere in this engine) are
+  skipped, same as a ref this database's table doesn't define at all (an
+  RPG2000 file, or any database that never decoded/wrote chunk 29). A
+  customized list with nothing usable in it (no data at all, or every entry
+  unsupported) falls back to the fixed four, the same "falls back to
+  defaults" pattern `#skill_command_label` above already follows; a reordered
+  or shortened list still dispatches correctly, since `#select_battle_command`
+  now reads the highlighted row's own `action` off `#battle_command_rows`
+  rather than assuming a fixed Attack/Skill/Defend/Item index. Covered by new
   `scripts/rpg2k_scene_check.rb` checks (the drawn label order; cmd row 2
   committing Defend rather than opening Item; an actor with the rename flag
   showing its custom name; an actor without it keeping the database "Skill"
-  term), plus three existing checks that assumed the old order updated to
-  match, confirmed to fail against the pre-fix code before the fix. See
-  `changelog.d/battle-command-order-and-skill-rename.fixed.md`.
+  term; a skill-only customized list; a shortened, reordered list whose
+  Item/Defense rows draw and dispatch in their own order rather than the
+  fixed four's; Row alone falling back to the fixed four), plus three existing
+  checks that assumed the old order updated to match, confirmed to fail
+  against the pre-fix code before the fix, plus a new
+  `mruby-lcf/test/lcf_test.rb` check and `scripts/rpg2k_logic_check.rb` checks
+  for the new chunk 29 decode and `Game::Actor#battle_command_row`. See
+  `changelog.d/battle-command-order-and-skill-rename.fixed.md` and
+  `changelog.d/rpg2003-battle-command-customization.added.md`.
   The enemy troop is **drawn as
   battler sprites** (`Monster/<battler_name>`, placeholder block fallback, hidden
   on death) over a plain battle field. **Post-battle HP now persists to the

--- a/docs/adr/0048-rpg2003-battle-command-customization.md
+++ b/docs/adr/0048-rpg2003-battle-command-customization.md
@@ -1,0 +1,91 @@
+# 48. Building the battle-command menu from RPG2003's own customization
+
+Date: 2026-08-15
+
+## Status
+
+Accepted
+
+## Context
+
+`Scene::Map#battle_commands` always drew the fixed Attack/Skill/Defend/Item
+four for every actor's turn. RPG2003 lets a project replace that per actor or
+class (Database > Battle Commands, and the Change Battle Commands (1009)
+event command at runtime) — `Game::Actor#battle_commands` /
+`#change_battle_commands` already modelled the resulting id list (field 80,
+seven slots padded with `-1`, `0` standing for Row), but nothing in the menu
+ever read it.
+
+A positive id in that list is not itself a command type — it is a **1-based
+reference into a separate, database-wide "Battle Commands" table**, one
+`{name, type}` entry per row (`type` one of Attack/Skill/Subskill/
+Defense/Item/Escape/Special). That table is chunk `0x1D` (29) on the LDB
+`Database` struct; nothing in `mruby-lcf/mrblib/schema.rb` decoded it, so
+there was no way to turn a customized id list into real labels or actions at
+all, only the already-established special cases `0` (Row) and `-1` (empty
+slot).
+
+This project's schema is normally sourced from the VIPRPG 200X analysis wiki
+(`schema.rb`'s own header) and, for the LSD save format's undocumented
+chunks, from empirical byte-diffing against real saves (AGENTS.md's "LCF save
+data" section, ADR 0009/0011). Chunk 29 has no page on that wiki and no test
+game close at hand to diff against here. Its field/enum ids are instead
+transcribed from liblcf's own `generator/csv/{fields,enums}.csv` — the
+reference C++ implementation's declared format, not a byte-level guess — and
+checked against a hand-built synthetic blob the same way every other chunk in
+`mruby-lcf/test/lcf_test.rb` is (`db.battlecommands.commands[id].name/.type`).
+It has **not** been validated against a real 2k3 `RPG_RT.ldb` the way
+`lcf_testbed_check.rb` validates the rest of the 2003-specific schema; that
+remains a follow-up once a customized test-bed database is available.
+
+## Decision
+
+- **`mruby-lcf/mrblib/schema.rb`** gains chunk 29 (`battlecommands`): a
+  singleton struct whose field 10 (`commands`) is the `Array2D` of entries,
+  each with `name` (string) and `type` (int — `enums:` is documentation only
+  here, matching every other enum field in this schema; callers compare the
+  raw int).
+- **`Game::Actor#battle_command_row(id)`** (`game.rb`) resolves a positive
+  `battle_commands` id through `@db.battlecommands.commands[id]`, guarded by
+  the same `@db.respond_to?(:x) ? @db.x : nil` idiom the rest of `Game::Actor`
+  already uses for optional database sections — nil for an RPG2000 database,
+  a fixture without chunk 29, or an id the table doesn't define.
+- **`Scene::Map#custom_battle_commands(actor)`** (`scene/map.rb`) walks
+  `actor.battle_commands`, skipping `0`/`-1`/unresolvable refs, and turns
+  each resolved entry into a `{ label:, action: }` row for the four types
+  this engine actually drives (Attack, Skill — Subskill folds into the same
+  Skill submenu, there being no single-skill quick-cast modelled — Defense,
+  Item). Escape (already offered as Cancel on the first actor) and Special
+  (no handler anywhere in this engine) are skipped, the same "reported gap,
+  not silently invented" precedent the rest of this file already follows for
+  unmodelled RPG2003 features. A list with nothing usable in it — no data at
+  all, which reads back as `[0]`, Row alone, same as
+  `Game::Actor#class_battle_commands`'s own default — or every entry
+  unsupported, returns nil so the caller falls back to the fixed four.
+- **`Scene::Map#battle_command_rows`** is the single source both
+  `#battle_commands` (labels) and `#select_battle_command` (dispatch) read,
+  so a reordered or shortened list still routes the highlighted row to the
+  right handler by its own `action` rather than a fixed row index.
+
+## Consequences
+
+An actor with a real RPG2003 customization now sees it in battle instead of
+always the fixed four, and a reordered/shortened list dispatches correctly at
+whatever row it lands on. A database that never decoded/wrote chunk 29 (every
+RPG2000 file, and any fixture built before this change) is unaffected —
+`battle_command_row` returns nil for every id, so `custom_battle_commands`
+always returns nil and the fixed four still draws exactly as before.
+
+Chunk 29's structural correctness rests on liblcf's own declared format plus
+a synthetic round-trip test, not a real save/database byte-diff — the
+weaker of the two forms of evidence this project otherwise insists on for
+LCF chunks. `lcf_testbed_check.rb` should pick up `db.battlecommands` once a
+2003 test-bed project that actually uses this tab is available, closing that
+gap the way the rest of the 2003-specific schema is already closed.
+
+Covered by `mruby-lcf/test/lcf_test.rb` (chunk 29 decode), new
+`scripts/rpg2k_logic_check.rb` checks (`battle_command_row` resolving a real
+entry, an undefined id, and a database with no chunk 29 at all), and new
+`scripts/rpg2k_scene_check.rb` checks (a skill-only customized list; a
+shortened, reordered Item/Defense list drawing and dispatching in its own
+order; Row alone falling back to the fixed four).

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -746,6 +746,30 @@ module LCF
           name: :common_event, type: :Array2D,
           elements: COMMON_EVENT
         },
+        29 => {
+          # RPG2003's database-wide "Battle Commands" list (0x1D on liblcf's
+          # own rpg::Database, not on the VIPRPG 200X wiki this file otherwise
+          # transcribes -- confirmed against liblcf's generator/csv/fields.csv
+          # and enums.csv instead). A single instance, not a table: field 10
+          # (0x0A) is the table itself, one BattleCommand (name + type) per
+          # entry. An actor's or class's own `battle_commands` (field 80 on
+          # 11/30 below) holds ids that index into `commands` here -- 1-based,
+          # matching every other database table id in this format -- except 0
+          # (Row) and -1 (an empty slot), which name no entry and are handled
+          # by the caller instead.
+          name: :battlecommands, type: :Array1D,
+          elements: {
+            10 => {
+              name: :commands, type: :Array2D,
+              elements: {
+                1 => { name: :name, type: :string, default: '' },
+                # 0 attack, 1 skill, 2 subskill (a single named skill used as
+                # its own shortcut), 3 defense, 4 item, 5 escape, 6 special.
+                2 => { name: :type, type: :int, default: 0 },
+              }
+            }
+          }
+        },
         30 => {
           # https://wikiwiki.jp/viprpg-dev/200X%E5%85%B1%E9%80%9A/%E8%A7%A3%E6%9E%90%E3%81%BE%E3%81%A8%E3%82%81/%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9/%E8%81%B7%E6%A5%AD
           name: :job, type: :Array2D,

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -133,6 +133,21 @@ assert "LCF::Database item armour option flags (chunks 25-28) and equip animatio
   assert_equal 4, a.speed
 end
 
+assert "LCF::Database battle-commands table (chunk 29 -- name + type)" do
+  # RPG2003's database-wide Battle Commands list: a singleton struct (not a
+  # table) whose own field 10 holds the actual name+type entries an actor's
+  # or class's `battle_commands` ids (field 80) index into.
+  cmd1 = lcf_array1d([lcf_str_field(1, "Attack"), lcf_int_field(2, 0)])
+  cmd2 = lcf_array1d([lcf_str_field(1, "Cast Fire"), lcf_int_field(2, 2)])
+  battlecommands = lcf_array1d([lcf_field(10, lcf_array2d([[1, cmd1], [2, cmd2]]))])
+  db = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(29, battlecommands)])))
+  assert_equal "Attack", db.battlecommands.commands[1].name
+  assert_equal 0, db.battlecommands.commands[1].type
+  assert_equal "Cast Fire", db.battlecommands.commands[2].name
+  assert_equal 2, db.battlecommands.commands[2].type
+end
+
 assert "LCF::Array1D#key? distinguishes an absent chunk from a present one" do
   row = LCF::Array1D.new(lcf_array1d([lcf_int_field(1, 5), lcf_int_field(3, 0)]),
                          { elements: { 1 => { name: :a, type: :int },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2227,6 +2227,31 @@ module Game
       @battle_commands ||= class_battle_commands
     end
 
+    # `BattleCommand#type` (database chunk 0x1D, field 2) -- the kind of
+    # action a database-wide Battle Command entry performs. A positive id in
+    # `#battle_commands` refers to one of these by index; 0 (Row) and -1
+    # (an empty slot) never do, and are never looked up here.
+    BATTLE_COMMAND_ATTACK   = 0
+    BATTLE_COMMAND_SKILL    = 1
+    BATTLE_COMMAND_SUBSKILL = 2 # a single named skill, used as its own shortcut command
+    BATTLE_COMMAND_DEFENSE  = 3
+    BATTLE_COMMAND_ITEM     = 4
+    BATTLE_COMMAND_ESCAPE   = 5
+    BATTLE_COMMAND_SPECIAL  = 6
+
+    # The database-wide Battle Command entry `cmd_id` (a positive value from
+    # `#battle_commands`) refers to -- an object with `#name` and `#type`, the
+    # RPG2003 database table `#battle_commands`' own ids index into. nil when
+    # this database carries no such table at all (every RPG2000 file, and any
+    # fixture that predates this chunk) or `cmd_id` names no entry in it.
+    def battle_command_row(cmd_id)
+      return nil unless @db.respond_to?(:battlecommands)
+      table = @db.battlecommands
+      return nil unless table
+      cmds = table.commands
+      cmds && cmds[cmd_id]
+    end
+
     # Change Battle Commands (event command 1009). `add` inserts command `id`
     # ahead of the Row entry; otherwise it is removed, and id 0 clears the whole
     # list back to Row alone. Ported from EasyRPG's

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4577,27 +4577,80 @@ class RPG2k
         idx ? @state.party.actors[idx] : nil
       end
 
-      # The four per-actor commands, in menu order (the cursor row is 1 + index,
-      # below the actor-name header): **Attack, Skill, Defend, Item** — EasyRPG's
-      # `Scene_Battle_Rpg2k::CreateBattleCommandWindow` builds that exact array
-      # (`command_attack`, `command_skill`, `command_defend`, `command_item`),
-      # not the Item-before-Defend order this used to assume, read from the
-      # database's battle-command terms with the standard RPG2k labels as
-      # fallback. The Skill slot is not memoized any more: it substitutes the
-      # acting actor's own RPG2000 rename (`#skill_command_label` below) when
-      # the database sets one, so it can change from one actor's turn to the
-      # next. RPG2003's *own* battle-command customization (`Game::Actor
-      # #battle_commands`, edited by Change Battle Commands / a class change) is
-      # a separate list this menu still does not build from — still open, the
-      # same "reported gap, not silently invented" precedent the ATB toggle and
-      # menu-command entries elsewhere in this file already follow.
-      def battle_commands
+      # The per-actor commands, in menu order (the cursor row is 1 + index,
+      # below the actor-name header): each a `{ label:, action: }` pair, drawn
+      # by `#battle_commands` below and dispatched by `#select_battle_command`.
+      #
+      # An acting actor whose own RPG2003 battle-command list
+      # (`Game::Actor#battle_commands`, edited by Change Battle Commands (1009)
+      # or a class change) resolves to at least one usable entry drives the
+      # menu; otherwise this falls back to the fixed **Attack, Skill, Defend,
+      # Item** four — EasyRPG's `Scene_Battle_Rpg2k::CreateBattleCommandWindow`
+      # builds that exact array (`command_attack`, `command_skill`,
+      # `command_defend`, `command_item`), not the Item-before-Defend order
+      # this used to assume, read from the database's battle-command terms with
+      # the standard RPG2k labels as fallback. The Skill slot is not memoized:
+      # it substitutes the acting actor's own RPG2000 rename
+      # (`#skill_command_label` below) when the database sets one, so it can
+      # change from one actor's turn to the next.
+      def battle_command_rows
+        actor = current_actor_row
+        custom = actor && custom_battle_commands(actor)
+        return custom if custom
+
         [
-          term(:battle_attack, 'Attack'),
-          skill_command_label,
-          term(:battle_defend, 'Defend'),
-          term(:battle_item, 'Item')
+          { label: term(:battle_attack, 'Attack'), action: :attack },
+          { label: skill_command_label, action: :skill },
+          { label: term(:battle_defend, 'Defend'), action: :defend },
+          { label: term(:battle_item, 'Item'), action: :item }
         ]
+      end
+
+      # `actor`'s own RPG2003 battle-command list resolved to menu rows, or nil
+      # when there is nothing usable in it (no data at all -- an RPG2000
+      # database, or a class/actor row that never set field 80, both of which
+      # `Game::Actor#battle_commands` itself already reports as `[0]`, Row
+      # alone -- or every entry turned out unsupported), so the caller falls
+      # back to the fixed four.
+      #
+      # Each id is either 0 (Row -- not a menu row here any more than in
+      # EasyRPG's own `Game_Actor::GetBattleCommands`, whose comment marks it
+      # "not impl" and skips it the same way), -1 (an empty padding slot,
+      # likewise skipped), or a positive ref into the database's own
+      # Battle-Commands table (`Game::Actor#battle_command_row`) naming one
+      # entry's `name` + `type`. Only the four types this engine actually
+      # drives -- Attack, (sub)Skill, Defense, Item -- become a row; Escape
+      # (the first actor's own Cancel already offers it) and Special (no
+      # handler modelled anywhere in this engine) are skipped, same as an
+      # unresolvable ref (a project whose database has no Battle-Commands
+      # table decoded, or an id it doesn't define).
+      def custom_battle_commands(actor)
+        return nil unless actor.respond_to?(:battle_commands)
+        cmds = actor.battle_commands
+        return nil unless cmds
+        rows = cmds.each_with_object([]) do |cmd_id, out|
+          next if cmd_id.nil? || cmd_id <= 0 # Row / empty slot
+
+          row = actor.battle_command_row(cmd_id)
+          next unless row
+
+          case row.type
+          when Game::Actor::BATTLE_COMMAND_ATTACK
+            out << { label: nonblank(row.name, term(:battle_attack, 'Attack')), action: :attack }
+          when Game::Actor::BATTLE_COMMAND_SKILL, Game::Actor::BATTLE_COMMAND_SUBSKILL
+            out << { label: nonblank(row.name, skill_command_label), action: :skill }
+          when Game::Actor::BATTLE_COMMAND_DEFENSE
+            out << { label: nonblank(row.name, term(:battle_defend, 'Defend')), action: :defend }
+          when Game::Actor::BATTLE_COMMAND_ITEM
+            out << { label: nonblank(row.name, term(:battle_item, 'Item')), action: :item }
+          end
+          # Escape / Special: no menu row (see the method comment above).
+        end
+        rows.empty? ? nil : rows
+      end
+
+      def battle_commands
+        battle_command_rows.map { |c| c[:label] }
       end
 
       # The Skill command's own label. RPG2000's Actor sheet has a "custom
@@ -4683,7 +4736,11 @@ class RPG2k
       end
 
       # Act on the highlighted command: Attack / Skill open a selection, Defend
-      # is committed at once.
+      # is committed at once. Dispatches by `#battle_command_rows`' own
+      # `action` for the highlighted row rather than a fixed row index, so a
+      # customized, reordered or shortened list (`#custom_battle_commands`)
+      # still routes to the right handler regardless of where each command
+      # landed.
       # Which SE each command plays on confirm -- Decision immediately for
       # Attack/Defend (`Scene_Battle::AttackSelected`/`DefendSelected` both
       # play it as their own first statement, before doing anything else),
@@ -4691,19 +4748,19 @@ class RPG2k
       # RPG_RT's own Decision-on-opening-the-submenu and Buzzer-on-nothing-
       # to-pick are both conditional on that submenu's own state there.
       def select_battle_command
-        case @battle_ui[:cmd]
-        when 0 # Attack
+        case battle_command_rows[@battle_ui[:cmd]][:action]
+        when :attack
           play_system_se(SFX_DECISION)
           @battle_ui[:pending] = { kind: :attack }
           @battle_ui[:target_i] = 0
           @battle_ui[:phase] = :target
           draw_battle_target
-        when 1 then open_battle_skill
-        when 2 # Defend
+        when :skill then open_battle_skill
+        when :defend
           play_system_se(SFX_DECISION)
           @battle_ui[:battle].command_defend(current_actor)
           advance_actor
-        when 3 then open_battle_item
+        when :item then open_battle_item
         end
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2922,9 +2922,9 @@ class ClassedRow < SkillRow
 end
 
 class FakeActorDB
-  attr_reader :player, :system, :item, :skill, :job, :situation, :property
+  attr_reader :player, :system, :item, :skill, :job, :situation, :property, :battlecommands
   def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil,
-                 property = nil, rpg2003: false)
+                 property = nil, rpg2003: false, battlecommands: nil)
     @player = players
     @system = FakeActorSystem.new(party_ids)
     @item = items
@@ -2933,12 +2933,21 @@ class FakeActorDB
     @situation = situation
     @property = property
     @rpg2003 = rpg2003
+    @battlecommands = battlecommands
   end
 
   # Mirrors LCF::Schema::Database#rpg2003? (Classes-chunk presence) for tests
   # that need to distinguish the two editions' own numeric ranges/caps.
   def rpg2003?; @rpg2003; end
 end
+
+# The database-wide RPG2003 Battle Commands table (LCF chunk 29's `commands`
+# field, `Game::Actor#battle_command_row`'s own source) and one of its
+# entries, mirroring the shape `LCF::Array1D#battlecommands` /
+# `#commands[id]` decode to: an object with `#commands` (id -> entry) and an
+# entry with `#name` + `#type`.
+FakeBattleCommandsTable = Struct.new(:commands)
+FakeBattleCommand = Struct.new(:name, :type)
 
 def party_state
   players = {
@@ -3753,6 +3762,26 @@ check 'a class change and its battle commands survive Save / Continue' do
   eq 1, a.class_id
   eq 220, a.max_hp, "the class's curve, not the actor row's"
   eq [3, 7, 0], a.battle_commands
+end
+
+check "Game::Actor#battle_command_row resolves a positive id via the database's Battle Commands table" do
+  actor_curve = []
+  3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
+  players = { 1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, [], 0, [5, 0, -1, -1, -1, -1, -1]) }
+  table = FakeBattleCommandsTable.new({ 5 => FakeBattleCommand.new('Cast Fire', 2) })
+  db = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil, battlecommands: table)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  eq [5, 0, -1, -1, -1, -1, -1], a.battle_commands, 'straight from the database, unedited'
+  row = a.battle_command_row(5)
+  eq 'Cast Fire', row.name
+  eq 2, row.type, 'BATTLE_COMMAND_SUBSKILL'
+  eq nil, a.battle_command_row(99), 'an id the table does not define resolves to nil'
+end
+
+check 'Game::Actor#battle_command_row is nil when the database carries no Battle Commands table at all' do
+  a = party_state.party.actor_by_id(1) # the plain RPG2000 fixture, no chunk 29
+  eq nil, a.battle_command_row(1)
 end
 
 check 'Change HP command damages a fixed actor' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -1968,6 +1968,11 @@ end
 
 # A party the placeholder battle grants rewards to: gold plus actors that bank
 # EXP, with the leader Scene::Map reads while rendering.
+# A database-wide Battle Command entry (chunk 29's `commands` table --
+# `Game::Actor#battle_command_row`'s own return shape): just the two fields
+# `#custom_battle_commands` (Scene::Map) reads, `name` and `type`.
+BattleCommandDef = Struct.new(:name, :type)
+
 class BattleStubActor
   attr_accessor :exp, :hp, :mp
   attr_reader :id, :name, :atk, :def, :agi, :int, :max_hp, :max_mp, :skills, :states
@@ -1978,13 +1983,23 @@ class BattleStubActor
   # with an ally already afflicted, without reaching into the built battle's
   # own Combatant list after the fact.
   def initialize(atk: 40, dfn: 20, agi: 20, hp: 200, mp: 20, int: 20, skills: [], id: 1,
-                 rename_skill: false, skill_name: '', states: [], force_ai: false)
+                 rename_skill: false, skill_name: '', states: [], force_ai: false,
+                 battle_commands: nil, battle_command_table: {})
     @exp = 0; @id = id; @name = 'Hero'
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
     @mp = mp; @max_mp = mp; @int = int; @skills = skills
     @rename_skill = rename_skill; @skill_name = skill_name; @states = states
     @force_ai = force_ai
+    @battle_commands = battle_commands
+    @battle_command_table = battle_command_table
   end
+  # Mirrors Game::Actor's own RPG2003 battle-command-customization interface
+  # (`#battle_commands` / `#battle_command_row`), so a stub battle can drive
+  # `Scene::Map#custom_battle_commands` the same way a real actor row would.
+  # nil (the default) means "no customization", same as an actor whose class
+  # sets no such list.
+  attr_reader :battle_commands
+  def battle_command_row(id); @battle_command_table[id]; end
   def gain_exp(n); @exp += n; end
   # Battle write-back (Game::Battle#apply_to_party) sets the actor's post-battle
   # HP absolutely; the stub has no state model beyond the starting `states`
@@ -7667,6 +7682,18 @@ class BattleMagicParty
   def switch_item?(_id); false; end
 end
 
+# BattleMagicParty built around a caller-supplied actor instead of always
+# constructing its own -- lets a check outfit the lone actor with a
+# customized RPG2003 battle-command list while keeping the Skill/Item
+# sub-menu backing (`battle_skills` / `db_skill` / `battle_items` / `db_item`)
+# those commands need to actually open.
+class BattleCustomCommandParty < BattleMagicParty
+  def initialize(actor)
+    super()
+    @actors = [actor]
+  end
+end
+
 # Open a battle and step to the per-actor command menu.
 def battle_to_command(scene)
   ui = nil
@@ -7956,6 +7983,81 @@ check 'Enemy Encounter scene: an actor without the custom name keeps the Skill t
   ui = battle_to_command(scene)
   labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
   eq 'Skill', labels[1], 'no rename set (the default) falls back to the database term'
+end
+
+check "Enemy Encounter scene: an actor's RPG2003 skill-only battle-command list drives the menu" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  actor = BattleStubActor.new(atk: 40, agi: 20, mp: 10, skills: [1],
+    battle_commands: [10, 0, -1, -1, -1, -1, -1],
+    battle_command_table: { 10 => BattleCommandDef.new('Cast Magic', Game::Actor::BATTLE_COMMAND_SUBSKILL) })
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(actor))
+  ui = battle_to_command(scene)
+  labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
+  eq ['Cast Magic'], labels,
+     "a customized list of just one Subskill entry (plus Row, still unimplemented) " \
+     'shows that one row alone, not the fixed four'
+  press_key(scene, RGSS::Input::C) # the only row, cmd 0, is a Skill-type command
+  eq :skill, ui[:phase], 'a Subskill entry opens the Skill list the same as the generic Skill command'
+end
+
+check "Enemy Encounter scene: an actor's shortened, reordered battle-command list draws in its own order" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  actor = BattleStubActor.new(
+    battle_commands: [4, 3, 0, -1, -1, -1, -1],
+    battle_command_table: {
+      4 => BattleCommandDef.new('Bag', Game::Actor::BATTLE_COMMAND_ITEM),
+      3 => BattleCommandDef.new('Guard', Game::Actor::BATTLE_COMMAND_DEFENSE)
+    })
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(actor))
+  ui = battle_to_command(scene)
+  labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
+  eq %w[Bag Guard], labels, 'Item first then Defense, the database order, not Attack/Skill/Defend/Item'
+  press_key(scene, RGSS::Input::C) # cmd 0 here is the Item-type command
+  eq :item, ui[:phase], 'the reordered list still opens the Item sub-menu, not Attack'
+end
+
+check "Enemy Encounter scene: a reordered Defense command still commits at once, not just at cmd 2" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  actor = BattleStubActor.new(
+    battle_commands: [4, 3, 0, -1, -1, -1, -1],
+    battle_command_table: {
+      4 => BattleCommandDef.new('Bag', Game::Actor::BATTLE_COMMAND_ITEM),
+      3 => BattleCommandDef.new('Guard', Game::Actor::BATTLE_COMMAND_DEFENSE)
+    })
+  st.instance_variable_set(:@party, BattleCustomCommandParty.new(actor))
+  ui = battle_to_command(scene)
+  press_key(scene, RGSS::Input::DOWN) # Bag (cmd 0) -> Guard (cmd 1)
+  eq 1, ui[:cmd]
+  press_key(scene, RGSS::Input::C)    # Defense commits at once, no sub-menu, despite sitting at cmd 1
+  eq :animate, ui[:phase],
+     "cmd 1's own action (:defend) drove this, not the fixed four's cmd-2-is-Defend rule"
+end
+
+check "Enemy Encounter scene: a battle-command list of Row alone falls back to the fixed four" do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party,
+    BattleStubParty.new(BattleStubActor.new(battle_commands: [0, -1, -1, -1, -1, -1, -1])))
+  ui = battle_to_command(scene)
+  labels = ui[:cmd_win].contents.draw_calls.map { |c| c[4] }
+  eq %w[Attack Skill Defend Item], labels,
+     'Row alone (the same shape an actor with no customization at all reads from the database) ' \
+     'is not a usable list on its own, so this falls back to the fixed four'
 end
 
 # A hero with two battle skills, so the skill-list cursor has more than one row


### PR DESCRIPTION
## Summary

- `Scene::Map`'s per-actor battle command menu always drew the fixed Attack/Skill/Defend/Item four. An acting actor's own RPG2003 battle-command customization (`Game::Actor#battle_commands`, edited by Change Battle Commands (1009) or a class change — both already modelled in `game.rb`) now drives it instead, when the actor has one: `Scene::Map#custom_battle_commands` resolves each positive id and `#select_battle_command` dispatches by each row's own action, so a reordered or shortened list still routes to the right handler regardless of where a command landed.
- Resolving a positive id needed a new LCF chunk 29 (the database-wide "Battle Commands" table, `name` + `type` per entry) that nothing in `mruby-lcf/mrblib/schema.rb` decoded before — an actor's own list only holds refs into it, not command types directly. Field/enum ids are transcribed from liblcf's own `generator/csv/{fields,enums}.csv` (there's no page for this chunk on the VIPRPG 200X wiki `schema.rb` otherwise cites) and checked with a synthetic round-trip test in `mruby-lcf/test/lcf_test.rb`, the same way every other chunk in that file is. See `docs/adr/0048-rpg2003-battle-command-customization.md` for the full writeup, including the one caveat: this hasn't been validated against a real 2k3 database yet (no such test-bed project close at hand), unlike the rest of this project's 2003-specific schema.
- A database with nothing usable (an RPG2000 file, a fixture without chunk 29, or a customized list that resolves to nothing) falls back to the fixed four exactly as before — `#skill_command_label`'s own existing "falls back to defaults" pattern.

## Testing

- `ruby scripts/rpg2k_logic_check.rb` — 790 checks passed (new: `Game::Actor#battle_command_row` resolving a real entry / an undefined id / no chunk 29 at all).
- `ruby scripts/rpg2k_scene_check.rb` — 530 checks passed (new: a skill-only customized list; a shortened, reordered Item/Defense list drawing and dispatching in its own order; Row alone falling back to the fixed four).
- `mruby-lcf/test/lcf_test.rb` gets a new chunk-29 decode check; not run through a full native `mrbgem` build in this environment (no toolchain available here), but the identical decode logic was independently verified via a CRuby harness loading the same `lcf.rb`/`schema.rb` sources (the same trick `scripts/lcf_testbed_check.rb` uses).
- `pre-commit` isn't installed in this environment; ran the applicable hooks directly (`trailing-whitespace`, `end-of-file-fixer`, `check-added-large-files`) against every changed file — all passed. No `.cxx`/`.nix`/`.cmake` files were touched, so `clang-format`/`nixfmt`/`cmake-format` don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LeqBxLcjuDqZkyscG1A3oT)_