### PR TITLE
Fix weather particle counts and airship altitude to match RPG_RT's real constants

### DIFF
--- a/changelog.d/rpg2k-airship-altitude.fixed.md
+++ b/changelog.d/rpg2k-airship-altitude.fixed.md
@@ -1,0 +1,5 @@
+- **The airship now floats a real, full 16px tile above its ground shadow,
+  instead of a wrong half-tile 8px.** Confirmed against EasyRPG Player's
+  source (`Game_Vehicle::GetAltitude()`): the real steady-state (fully
+  airborne) altitude is a full tile, `256 / (256 / 16) = 16` with RPG_RT's
+  own real constants.

--- a/changelog.d/rpg2k-weather-particle-counts.fixed.md
+++ b/changelog.d/rpg2k-weather-particle-counts.fixed.md
@@ -1,0 +1,7 @@
+- **Rain/snow particle counts by strength are now RPG_RT's own real 20/60/100,
+  not an invented, denser progression.** Confirmed against EasyRPG Player's
+  source (`Weather`'s own `num_rain_or_snow_particles` table): the real
+  counts are a literal `{20, 60, 100}` for strength 0/1/2 — not a fixed
+  multiple of the lightest strength's own count. The old formula was
+  roughly 2.4x too dense at the lightest strength and ~44% too dense at the
+  heaviest.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1564,7 +1564,19 @@ The work below is roughly ordered by the critical path to a walkable game
   confirmed to fail against the pre-fix code before the fix.
   Placed vehicles are **drawn on the map** from their CharSet, the
   ridden one following the party under the hero, and the **airship floats above a
-  ground shadow**. Boarding **plays the vehicle's own BGM** (the database System
+  ground shadow**. ✅ **The airship's own float height is now a real, full
+  16px tile, not a wrong half-tile 8px.** `Scene::Map::AIRSHIP_ALTITUDE`
+  was `8`. EasyRPG Player's own `Game_Vehicle::GetAltitude()`
+  (`src/game_vehicle.cpp`) is `SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE /
+  TILE_SIZE)` once fully airborne (this codebase never models the gradual
+  ascend/descend transition itself, only this steady-state value) — `256 /
+  (256 / 16) = 16` with RPG_RT's own real constants, exactly a full tile.
+  Fixed by changing the constant to `16`. Covered by tightening the
+  existing `scripts/rpg2k_scene_check.rb` shadow check from a loose
+  "floats above" ordering assertion to the exact 16px gap (net of the
+  ordinary feet-alignment offset every vehicle sprite already carries),
+  confirmed to fail against the pre-fix code (`8` instead of `16`) before
+  the fix. Boarding **plays the vehicle's own BGM** (the database System
   boat / ship / airship music) and disembarking restores the map BGM.
   ✅ **A Change System BGM override for a vehicle's slot is now honoured
   too**, ahead of the database default. `Scene::Map#vehicle_bgm` used to read
@@ -3964,7 +3976,17 @@ Everything below is unverified against the codebase.
   frames" scheme at the ~3 call sites (`scene/map.rb`'s player slide,
   autonomous/forced event movement, and the vehicle-route equivalent).
   Left open, now with a precise citation trail and fix shape for whoever
-  picks it up next.
+  picks it up next. **A second, independent symptom of this same gap,
+  found separately**: `Scene::Map::ANIM_FRAME_PERIOD = 6` (the fixed real-
+  frame period `#animate_event` holds a moving/continuous-type event's
+  walk/spin cell for) is EasyRPG's own per-speed `GetStationaryAnimFrames`
+  table (`src/game_character.h`, `{12, 10, 8, 6, 5, 4}` indexed by speed
+  1-6) evaluated only at speed 4 — correct for a default-speed *walking*
+  event, but wrong for any other configured speed, and wrong even at the
+  default speed for a *continuous*-type (always-animating) event at rest,
+  whose own table (`GetContinuousAnimFrames`, `{16, 12, 10, 8, 7, 6}`)
+  gives `8` at speed 4, not `6`. Not fixed for the same reason above —
+  it is downstream of the same dead `move_speed` field.
 - ✅ **Repeat/Loop** — loops forever without an explicit Break Loop.
   `Interpreter#do_end_loop` unconditionally scans back to the matching
   `Loop` marker and jumps `@index` there every single time it is reached —
@@ -5706,6 +5728,21 @@ not yet verified:
   other lingering state to interrupt — a Change Weather "None" command takes
   effect on the very next frame it runs, the same as any other weather-type
   change.
+- ✅ **Rain/snow particle counts by strength are now RPG_RT's own real
+  20/60/100, not a wrong invented progression.** `Scene::Map
+  ::WEATHER_BASE_PARTICLES` (`mruby-rpg2k/mrblib/scene/map.rb`) was `48`,
+  used as `48 * (strength + 1)` — 48/96/144 for strength 0/1/2. EasyRPG
+  Player's own `num_rain_or_snow_particles` table (`src/weather.cpp`) is
+  the literal `{ 20, 60, 100 }`: a real, non-uniform step (+40, +40), not a
+  multiple of the lightest strength's own count at all. The invented
+  formula was roughly 2.4x too dense at the lightest strength and ~44% too
+  dense at the heaviest, with the wrong progression shape besides. Fixed by
+  replacing the formula with the literal `WEATHER_PARTICLE_COUNTS = [20,
+  60, 100]` table, indexed (and clamped) by strength. Covered by tightening
+  the existing `scripts/rpg2k_scene_check.rb` weather check from a loose
+  "heavier is denser" ordering assertion to the three exact real counts,
+  confirmed to fail against the pre-fix code (`144` instead of `100` at
+  heavy strength) before the fix.
 
 **BGM / SE**
 - 🚧 BGM has a **single channel** — a new Play BGM force-stops whatever's

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -636,8 +636,13 @@ class RPG2k
 
       WEATHER_RAIN = 1
       WEATHER_SNOW = 2
-      # Particles at the lightest strength; each step up adds another band.
-      WEATHER_BASE_PARTICLES = 48
+      # Particle counts by strength (0..2) -- EasyRPG's own
+      # num_rain_or_snow_particles table (src/weather.cpp) is the literal
+      # { 20, 60, 100 }, not a fixed multiple of the lightest strength's own
+      # count: the step from light to medium (+40) and medium to heavy (+40)
+      # is constant, but light itself (20) is under half of what a "* (n+1)"
+      # progression from a single base would give.
+      WEATHER_PARTICLE_COUNTS = [20, 60, 100].freeze
       RAIN_COLOR = Color.new(200, 210, 255, 200)
       SNOW_COLOR = Color.new(255, 255, 255, 220)
 
@@ -659,7 +664,8 @@ class RPG2k
       end
 
       def weather_particle_count(w)
-        WEATHER_BASE_PARTICLES * ((w.strength || 0) + 1)
+        i = Game.clamp(w.strength || 0, 0, WEATHER_PARTICLE_COUNTS.length - 1)
+        WEATHER_PARTICLE_COUNTS[i]
       end
 
       # A single particle's on-screen cell, spread across the screen by a cheap
@@ -8667,8 +8673,13 @@ class RPG2k
       # sits on its own tile; the ridden one follows the party's pixel position
       # (so it slides smoothly), drawn just under the hero. A vehicle on another
       # map, or one with no CharSet graphic, is hidden.
-      # Pixels the airship floats above its shadow on the ground.
-      AIRSHIP_ALTITUDE = 8
+      # Pixels the airship floats above its shadow on the ground -- a full
+      # tile, not half. EasyRPG's own Game_Vehicle::GetAltitude()
+      # (src/game_vehicle.cpp) is `SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE /
+      # TILE_SIZE)` once fully airborne (this codebase never models the
+      # gradual ascend/descend transition itself, only this steady-state
+      # value) -- 256 / (256 / 16) = 16 with RPG_RT's own real constants.
+      AIRSHIP_ALTITUDE = 16
 
       def draw_vehicles(cam_x, cam_y, px, py)
         return unless @vehicle_sprites

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -7042,6 +7042,16 @@ check 'the airship floats above a ground shadow; a boat casts none' do
   shadow = scene.instance_variable_get(:@airship_shadow)
   ok shadow.visible, 'the airship casts a shadow'
   ok sprites[:airship].y < shadow.y, 'the airship floats above its shadow'
+  # shadow.y carries no feet-alignment offset (it sits flat on the tile), but
+  # the airship sprite's own y is drawn CharSet::HEIGHT - TILE pixels above
+  # that already (every vehicle/character sprite's own feet-alignment,
+  # unrelated to floating), plus AIRSHIP_ALTITUDE on top of that -- a full
+  # tile (16px), not half. EasyRPG's own Game_Vehicle::GetAltitude() is
+  # SCREEN_TILE_SIZE / (SCREEN_TILE_SIZE / TILE_SIZE) once fully airborne,
+  # 256 / (256 / 16) = 16 with RPG_RT's own real constants.
+  base_offset = Game::CharSet::HEIGHT - Game::TILE
+  eq 16, shadow.y - sprites[:airship].y - base_offset,
+     "the airship floats a full 16px tile above its shadow, not half"
   ok shadow.z < sprites[:airship].z, 'the shadow sits under the airship'
   # A boat (no airship placed) casts no shadow.
   air.map_id = 0 # unplace the airship
@@ -7434,11 +7444,14 @@ check 'Weather draws a particle overlay when active and hides it when clear' do
   st.weather.set(1, 2) # heavy rain
   scene.update
   ok wsp.visible, 'rain draws an overlay'
-  # A stronger downpour draws more particles than a light one.
-  heavy = scene.send(:weather_particle_count, st.weather)
+  # EasyRPG's own num_rain_or_snow_particles table (src/weather.cpp) is the
+  # literal { 20, 60, 100 } for strength 0/1/2 -- a real, non-uniform step
+  # (+40, +40), not a fixed multiple of the lightest strength's own count.
+  eq 100, scene.send(:weather_particle_count, st.weather), 'strength 2 (heavy)'
+  st.weather.set(1, 1) # medium rain
+  eq 60, scene.send(:weather_particle_count, st.weather), 'strength 1 (medium)'
   st.weather.set(1, 0) # light rain
-  light = scene.send(:weather_particle_count, st.weather)
-  ok heavy > light, 'strength scales the particle count'
+  eq 20, scene.send(:weather_particle_count, st.weather), 'strength 0 (light)'
   st.weather.set(2, 1) # snow
   scene.update
   ok wsp.visible, 'snow draws an overlay too'


### PR DESCRIPTION
## Summary
Both found via an audit of uncited numeric constants in `mruby-rpg2k/mrblib/scene/map.rb` against EasyRPG Player's actual C++ source:

- **`Scene::Map::WEATHER_BASE_PARTICLES`** (`48`, used as `48 * (strength + 1)` → 48/96/144 particles for strength 0/1/2) is replaced by the literal `WEATHER_PARTICLE_COUNTS = [20, 60, 100]` table, matching EasyRPG's own `num_rain_or_snow_particles` (`src/weather.cpp`). The real per-strength counts are a non-uniform `{20, 60, 100}`, not a multiple of the lightest strength's own count — the old formula was ~2.4x too dense at the lightest strength and ~44% too dense at the heaviest.
- **`Scene::Map::AIRSHIP_ALTITUDE`** (`8` px) is changed to `16` px, matching EasyRPG's `Game_Vehicle::GetAltitude()` (`src/game_vehicle.cpp`) steady-state value — a full tile (`256 / (256 / 16) = 16` with RPG_RT's own real constants), not half a tile.

Also documents (but deliberately does not fix, same reasoning already applied to the open Move Speed dead-code bug) a related divergence surfaced by the same audit: `ANIM_FRAME_PERIOD`'s fixed 6-frame animation cadence for moving/continuous-type events is EasyRPG's own per-speed table evaluated only at the default speed — a second, independent symptom of the same dead `move_speed` field.

## Testing
- New/tightened `scripts/rpg2k_scene_check.rb` checks: the weather check now asserts the exact real particle counts (was a loose "heavier is denser" ordering check), and the airship shadow check now asserts the exact 16px gap net of the ordinary feet-alignment offset (was a loose "floats above" ordering check). Both confirmed to fail against the pre-fix code (`144` instead of `100`; `8` instead of `16`) before the fix.
- `ruby -c mruby-rpg2k/mrblib/scene/map.rb` / `ruby -c scripts/rpg2k_scene_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- `ruby scripts/rpg2k_scene_check.rb` — 534 checks passed
- `ruby scripts/rpg2k_logic_check.rb` — 794 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed (one unrelated pre-existing failure on master, "a saved picture is re-shown at its saved centre", predates this branch and is out of scope for this PR)
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_