### PR TITLE
fix(rpg2k): Transfer Player / Recall to Location report a missing map instead of crashing

### DIFF
--- a/changelog.d/teleport-missing-map-diagnostic.fixed.md
+++ b/changelog.d/teleport-missing-map-diagnostic.fixed.md
@@ -1,0 +1,9 @@
+- **Transfer Player / Recall to Location naming a deleted map no longer
+  crashes the whole interpreter.** `Scene::Map#perform_teleport`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) now catches a failed map load and
+  reports a `[RPG2k] Teleport: destination map #<id> failed to load: ...`
+  diagnostic (the underlying message carries the literal missing filename,
+  matching real RPG_RT's own error dialog) instead of letting the raw
+  `Errno::ENOENT` from `RPG2k#load_map` propagate out unhandled; the party
+  stays on the map they were already on. Covered by two new
+  `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7740,7 +7740,8 @@ resolving to no match); invalid event *page* (event exists, page number
 doesn't — a **separate** error from invalid event, i.e. RPG_RT validates
 event-id-existence and page-existence as two distinct checks); invalid
 map (Transfer Player / Teleport-to-Remembered-Location targeting a
-nonexistent map id — error text includes the literal missing filename);
+nonexistent map id — error text includes the literal missing filename;
+fixed, see the ✅ below);
 invalid hero, skill, item, enemy, enemy group, battle animation, terrain,
 chipset, common event (all: a database shrink leaves a dangling id
 reference somewhere, shown as "?" in the editor); event-call recursion
@@ -7774,6 +7775,32 @@ genuine, correctly-modelled answer rather than a stale reference — nothing
 there was silently failing. Covered by four new
 `scripts/rpg2k_logic_check.rb` checks (one per new diagnostic path),
 each asserting on the exact captured `$stderr` line.
+✅ **"invalid map" (Transfer Player / Recall to Location naming a
+nonexistent map id) no longer crashes the interpreter** — `Scene::Map
+#perform_teleport` (`mruby-rpg2k/mrblib/scene/map.rb`) called
+`@parent.load_map(map_id)` (`RPG2k#load_map`, `mruby-rpg2k/mrblib/main.rb`,
+a bare `File.open` against `Map####.lmu`) with nothing guarding it
+anywhere in the call chain, so a stale/deleted map id raised
+`Errno::ENOENT` straight out of the running event and killed the whole
+process. The map-load call is now wrapped in its own rescue — narrower
+than catching over the whole method, per this repo's own error-handling
+rule — that logs a `[RPG2k] Teleport: destination map #<id> failed to
+load: <message>` diagnostic (the underlying `e.message` already carries
+the literal missing filename, matching real RPG_RT's own error dialog
+text) and aborts just the teleport: `@interpreter.stop` unwinds the
+requesting event's own command list and the method returns before
+touching `@map`/`@state`, so the party stays exactly where it already
+was. Both routes that can name a bad map id — Transfer Player (the
+`TELEPORT` command) and Recall to Location (`RECALL_LOCATION`, which
+resolves its target from three variables and routes through the very
+same `:teleport` wait/dispatch) — go through this one method, along with
+every other `#perform_teleport` caller (a Teleport/Escape field skill's
+`pending_teleport`, and a Common Event Parallel Process's own teleport
+request), so all of them are covered by the same fix. Verified with two
+new `scripts/rpg2k_scene_check.rb` checks, each targeting a `FakeParent`
+whose `load_map` raises `Errno::ENOENT` for one specific id and asserting
+the `$stderr` diagnostic fires while `state.map_id`/`state.x`/`state.y`
+stay exactly as they were before the failed command ran.
 
 **Map/Event ID assignment & tile occupancy**
 - Event IDs (and separately, Map IDs) are assigned by **creation order**

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7373,7 +7373,21 @@ class RPG2k
       # map change.
       def perform_teleport(t, keep_pictures: false)
         map_id, x, y, dir = t
-        @map = @parent.load_map(map_id)
+        begin
+          @map = @parent.load_map(map_id)
+        rescue StandardError => e
+          # Transfer Player / Recall to Location naming a map id whose .lmu no
+          # longer exists (a deleted map, or a stale id left behind by one) --
+          # docs/TODO.md's runtime error catalog "invalid map": real RPG_RT
+          # shows an error dialog naming the missing file rather than crashing.
+          # This codebase has no error-dialog UI, so it reports the same detail
+          # to $stderr, matching Call Event's own diagnostic-not-crash pattern,
+          # and leaves the party on the map they were already on -- @map/@state
+          # are still untouched at this point, so there is nothing to revert.
+          $stderr.puts "[RPG2k] Teleport: destination map ##{map_id} failed to load: #{e.message}"
+          @interpreter.stop
+          return
+        end
         @state.map = @map
         @state.map_id = map_id
         apply_map_access

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -15,6 +15,7 @@
 # Usage: ruby scripts/rpg2k_scene_check.rb   (exits non-zero on any failure)
 
 require 'ostruct'
+require 'stringio'
 
 # -- RGSS stubs (just enough for Scene::Map to build, render and tick) --------
 
@@ -239,6 +240,17 @@ def ok(cond, msg = 'expected truthy'); raise msg unless cond; end
 def eq(exp, act, msg = nil)
   return if exp == act
   raise "expected #{exp.inspect}, got #{act.inspect}#{msg ? " (#{msg})" : ''}"
+end
+
+# Runs the block with $stderr redirected to a StringIO and returns everything
+# written to it, for checks that assert on a "[RPG2k] ..." diagnostic line.
+def capture_stderr
+  old_stderr = $stderr
+  $stderr = StringIO.new
+  yield
+  $stderr.string
+ensure
+  $stderr = old_stderr
 end
 
 # -- synthetic database / map -------------------------------------------------
@@ -3506,6 +3518,56 @@ check 'a Change Encounter Rate override does not survive a teleport' do
      'Panorama/Tile Replacement -- an override does not survive any map change'
   eq 25, scene.send(:current_encounter_steps),
      "current_encounter_steps falls back to the map tree node's own setting again"
+end
+
+# A parent whose load_map raises for one specific "deleted" map id (mirroring
+# RPG2k#load_map's bare File.open against a stale/removed Map####.lmu) and
+# otherwise behaves like fake_parent's normal empty-map stub.
+def missing_map_parent(db, missing_id)
+  FakeParent.new(db) do |id|
+    if id == missing_id
+      raise Errno::ENOENT, "Map#{format('%04d', missing_id)}.lmu"
+    else
+      fake_map(id, {})
+    end
+  end
+end
+
+check 'a Transfer Player naming a deleted map reports a diagnostic and stays put' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::TELEPORT, [999, 4, 3])]
+  db = fake_db(nil, nil, 0, 0)
+  state = Game::State.new(fake_party([]), 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  parent = missing_map_parent(db, 999)
+  scene = RPG2k::Scene::Map.new(parent, state)
+  out = capture_stderr { 20.times { scene.update } }
+  ok out.include?('[RPG2k] Teleport:') && out.include?('Map0999.lmu'),
+     "expected a [RPG2k] Teleport diagnostic naming the missing file, got: #{out.inspect}"
+  eq 1, state.map_id, 'the party never left the map it was already on'
+  eq [0, 0], [state.x, state.y], 'the player position is untouched by the failed teleport'
+end
+
+check 'Recall to Location naming a deleted map reports a diagnostic and stays put' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = [
+    ECmd.new(ic::CONTROL_VARS, [0, 1, 1, 0, 0, 999]), # var1 = the deleted map id
+    ECmd.new(ic::CONTROL_VARS, [0, 2, 2, 0, 0, 4]),   # var2 = x 4
+    ECmd.new(ic::CONTROL_VARS, [0, 3, 3, 0, 0, 3]),   # var3 = y 3
+    ECmd.new(ic::RECALL_LOCATION, [1, 2, 3]),
+  ]
+  db = fake_db(nil, nil, 0, 0)
+  state = Game::State.new(fake_party([]), 1, 5, 6)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  parent = missing_map_parent(db, 999)
+  scene = RPG2k::Scene::Map.new(parent, state)
+  out = capture_stderr { 20.times { scene.update } }
+  ok out.include?('[RPG2k] Teleport:') && out.include?('Map0999.lmu'),
+     "expected a [RPG2k] Teleport diagnostic naming the missing file, got: #{out.inspect}"
+  eq 1, state.map_id, 'the party never left the map it was already on'
+  eq [5, 6], [state.x, state.y], 'the player position is untouched by the failed recall'
 end
 
 check 'the menu opens on cancel only when menu access is allowed' do


### PR DESCRIPTION
## Summary

- `Scene::Map#perform_teleport` (`mruby-rpg2k/mrblib/scene/map.rb`) called `RPG2k#load_map` (a bare `File.open` against `Map####.lmu`) with nothing guarding it, so a Transfer Player or Recall to Location naming a deleted/stale map id raised `Errno::ENOENT` straight out of the running event and crashed the whole interpreter — an unaddressed case from docs/TODO.md's runtime error catalog ("invalid map").
- The map-load call is now wrapped in its own rescue (narrower than catching over the whole method, per this repo's error-handling rule) that logs a `[RPG2k] Teleport: destination map #<id> failed to load: <message>` diagnostic — the underlying message already carries the literal missing filename, matching real RPG_RT's own error dialog text — and aborts just the teleport: the requesting event's command list is stopped and the method returns before touching `@map`/`@state`, so the party stays exactly on the map they were already on.
- Both routes that can name a bad map id — Transfer Player (`TELEPORT`) and Recall to Location (`RECALL_LOCATION`) — dispatch through this one method, along with every other `#perform_teleport` caller (a Teleport/Escape field skill, a Common Event Parallel Process's own teleport request), so all are covered by the same fix.
- `docs/TODO.md`'s runtime error catalog entry for "invalid map" is marked fixed.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 536 checks pass, including two new checks: a Transfer Player and a Recall to Location each naming a bogus map id against a `FakeParent` whose `load_map` raises `Errno::ENOENT`, asserting the `[RPG2k] Teleport: ...` diagnostic fires (naming the missing file) and that `state.map_id`/`state.x`/`state.y` are untouched.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 796 checks pass (no regressions).
- [x] `changelog.d/teleport-missing-map-diagnostic.fixed.md` added per repo conventions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGq5fPb2mvPYw75baa2c4U)_