### PR TITLE
Enemy Encounter: report and skip a battle against a missing troop id

### DIFF
--- a/changelog.d/enemy-encounter-missing-troop.fixed.md
+++ b/changelog.d/enemy-encounter-missing-troop.fixed.md
@@ -1,0 +1,10 @@
+- **Enemy Encounter and random encounters no longer open a battle against a
+  dangling enemy-group (troop) id** — a database shrink can leave one behind,
+  shown as "?" in the editor. `Game::Interpreter#do_enemy_encounter` /
+  `#start_random_battle` (`mruby-rpg2k/mrblib/interpreter.rb`) now check the
+  troop id first and log a `[RPG2k] Enemy Encounter: ...` diagnostic instead
+  of opening a real battle screen (SE, BGM swap, status panel) against zero
+  enemies: a scripted encounter resolves as an immediate Escape would (its
+  [Escape] handler, or ending the event under "abort on escape", or simply
+  continuing), and a random encounter just never arms the wait. Covered by
+  five new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7774,6 +7774,39 @@ genuine, correctly-modelled answer rather than a stale reference — nothing
 there was silently failing. Covered by four new
 `scripts/rpg2k_logic_check.rb` checks (one per new diagnostic path),
 each asserting on the exact captured `$stderr` line.
+✅ **Enemy Encounter no longer opens a battle against a dangling enemy-group
+(troop) id** — one of the "database shrink leaves a dangling id reference"
+cases above. `Game::Troop.new` (`mruby-rpg2k/mrblib/game.rb`) already
+tolerated a missing `enemy_group` row by degrading to an empty member list
+(by design — see the "missing troop / enemy degrades to an empty, harmless
+model" check), but nothing upstream ever noticed the gap, so both a scripted
+Enemy Encounter and a wandering-monster random encounter would open a real
+battle screen (SE, BGM swap, status panel, [Victory]/[Escape]/[Defeat]
+routing) against zero enemies. `Game::Interpreter#do_enemy_encounter` and
+`#start_random_battle` (`mruby-rpg2k/mrblib/interpreter.rb`) now check the
+troop id against the database (`Game::Party#db_enemy_group`, the same
+`respond_to?`-guarded reach into `@db` as `#db_item`/`#db_skill`) *before*
+ever arming the `:battle` wait, and log a `[RPG2k] Enemy Encounter: ...`
+diagnostic instead. Real RPG_RT has no on-screen precedent to match here
+(its own editor forbids saving a dangling reference), so a scripted
+encounter resolves exactly as an immediate Escape would — into the
+[Escape] handler if the command carries one, ending the event outright
+under the "abort on escape" escape mode, or otherwise simply continuing
+past the command — without bumping the win/escape/defeat "Other" battle
+counters, since no battle was ever actually fought; a random encounter has
+no event to resume, so it just never arms the wait and movement continues
+uninterrupted. The validation went in `Game::Interpreter` rather than
+`Scene::Map#open_battle` (the battle screen's own shared entry point for
+both call sites) specifically so it stays covered by the host-side
+`scripts/rpg2k_logic_check.rb` harness, which loads `game.rb`/
+`interpreter.rb` but never `scene/map.rb`; `Game::Party` already held the
+same unified database `Scene::Map` itself reaches through `db` (both trace
+back to the single `Game::Party.new(@db)` / `Scene::Base#db = parent.db` in
+`main.rb`), so no interpreter constructor change was needed. Covered by
+five new `scripts/rpg2k_logic_check.rb` checks (no handlers, an [Escape]
+handler, escape-abort mode, and the random-encounter path both missing and
+present), each asserting on the captured `$stderr` line and that no
+`:battle` wait was ever armed.
 
 **Map/Event ID assignment & tile occupancy**
 - Event IDs (and separately, Map IDs) are assigned by **creation order**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2736,6 +2736,18 @@ module Game
       @db.item[id]
     end
 
+    # The database row for an enemy-group (troop) id, or nil when the database
+    # has no enemy_group table (a bare test fixture) or the id is a dangling
+    # reference -- a database shrink can leave one behind, shown as "?" in the
+    # editor (see docs/TODO.md's runtime error catalog). `Game::Interpreter`
+    # checks this *before* opening a battle for an Enemy Encounter command or a
+    # random encounter, since `Game::Troop.new` itself tolerates a missing row
+    # by degrading to an empty member list rather than raising.
+    def db_enemy_group(id)
+      return nil unless @db.respond_to?(:enemy_group)
+      @db.enemy_group[id]
+    end
+
     # Whether this party's database is an RPG2003 project (see
     # `LCF::Schema::Database#rpg2003?`), exposed here the same way `db_item` /
     # `db_skill` reach into `@db` for other callers -- a bare test fixture with

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1289,22 +1289,51 @@ module Game
     # VICTORY/ESCAPE/DEFEAT_HANDLER, closed by END_BATTLE), like a Show Choices
     # block. The interpreter records the request and suspends on a :battle wait;
     # the scene runs the battle (rewards, game over) and resumes via
-    # resume_battle. The turn-based battle itself is not built yet.
+    # resume_battle. The turn-based battle itself is not built yet. A troop id
+    # the database no longer has never arms the wait at all -- see
+    # #skip_invalid_troop.
     def do_enemy_encounter(cmd)
       escape_mode = cmd.param(3)
+      troop_id = cmd.param(0) == 0 ? cmd.param(1) : variables[cmd.param(1)]
       @battle_indent = cmd.indent
       @battle_escape_aborts = escape_mode == 1
       nxt = @list[@index]
       @battle_has_handlers =
         !nxt.nil? && nxt.code == Cmd::VICTORY_HANDLER && nxt.indent == cmd.indent
+      return skip_invalid_troop(troop_id) unless party.db_enemy_group(troop_id)
       @battle_request = {
-        troop_id: cmd.param(0) == 0 ? cmd.param(1) : variables[cmd.param(1)],
+        troop_id: troop_id,
         allow_escape: escape_mode != 0, first_strike: cmd.param(5) != 0,
         defeat_game_over: cmd.param(4) == 0
       }
       @state.battle_count += 1 # a battle was entered (Control Variables "Other")
       @wait_kind = :battle
       @waiting = true
+    end
+
+    # A database shrink can leave a dangling enemy-group (troop) id reference
+    # (docs/TODO.md's runtime error catalog) -- Game::Troop tolerates the gap
+    # by degrading to an empty member list, which would otherwise open a real
+    # battle screen (SE, BGM swap, status panel) against zero enemies. Real
+    # RPG_RT has no on-screen precedent to match here (its own editor forbids
+    # saving a dangling reference in the first place), so like Call Event's
+    # other reported-but-tolerated gaps this logs instead of crashing or
+    # silently succeeding. Routes exactly where an immediate Escape would --
+    # into the [Escape] handler if the command carries one, ending the event
+    # outright under the "abort on escape" escape mode, or otherwise simply
+    # falling through to the command right after the encounter -- but does not
+    # bump the win/escape/defeat "Other" battle counters (#resume_battle's
+    # job), since no battle was ever actually fought.
+    def skip_invalid_troop(troop_id)
+      $stderr.puts "[RPG2k] Enemy Encounter: enemy group #{troop_id} not " \
+                   'found, skipping battle'
+      if @battle_escape_aborts
+        @index = @list.size
+        @call_stack = []
+        return
+      end
+      target = @battle_has_handlers && find_battle_option(:escape)
+      @index = target if target
     end
 
     # Start a battle that no event triggered — a wandering-monster encounter
@@ -1317,8 +1346,16 @@ module Game
     # (Scene::Map only calls it from ordinary player movement, never while an
     # event is running); escape is always allowed and a wipe is always game
     # over, since a random encounter carries no encounter-specific settings of
-    # its own to say otherwise.
+    # its own to say otherwise. A troop id the database no longer has (the
+    # map's own encounter list can go stale the same way a scripted Enemy
+    # Encounter's can) logs and simply never arms the wait -- there is no
+    # event to resume here, so movement just continues uninterrupted.
     def start_random_battle(troop_id, first_strike: false)
+      unless party.db_enemy_group(troop_id)
+        $stderr.puts "[RPG2k] Enemy Encounter: enemy group #{troop_id} not " \
+                     'found, skipping random encounter'
+        return
+      end
       @battle_has_handlers = false
       @battle_escape_aborts = false
       @battle_request = { troop_id: troop_id, allow_escape: true,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -1125,18 +1125,25 @@ end
 # -- Interpreter (a few existing-behaviour regressions) -----------------------
 
 # Build a minimal State without the LCF database: stub Party just enough for the
-# commands the checks below drive (gold/items).
+# commands the checks below drive (gold/items). `enemy_group` defaults to
+# "every id exists" (Hash.new(true)) since most checks here have nothing to do
+# with troop validity; pass an explicit hash (e.g. {}) to exercise the
+# missing-troop-id diagnostic path (see Game::Interpreter#do_enemy_encounter /
+# #start_random_battle).
 class FakeParty
   attr_reader :gold, :items
-  def initialize(rpg2003: false); @gold = 0; @items = {}; @rpg2003 = rpg2003; end
+  def initialize(rpg2003: false, enemy_group: Hash.new(true))
+    @gold = 0; @items = {}; @rpg2003 = rpg2003; @enemy_group = enemy_group
+  end
   def gain_gold(n); @gold += n; end
   def gain_item(id, n); @items[id] = (@items[id] || 0) + n; end
   def has_item?(id); (@items[id] || 0) > 0; end
   def rpg2003?; @rpg2003; end
+  def db_enemy_group(id); @enemy_group[id]; end
 end
 
-def new_state(rpg2003: false)
-  Game::State.new(FakeParty.new(rpg2003: rpg2003), 1, 0, 0)
+def new_state(rpg2003: false, enemy_group: Hash.new(true))
+  Game::State.new(FakeParty.new(rpg2003: rpg2003, enemy_group: enemy_group), 1, 0, 0)
 end
 
 IC = Game::Interpreter::Cmd
@@ -2994,9 +3001,14 @@ class ClassedRow < SkillRow
 end
 
 class FakeActorDB
-  attr_reader :player, :system, :item, :skill, :job, :situation, :property, :battlecommands
+  attr_reader :player, :system, :item, :skill, :job, :situation, :property, :battlecommands,
+              :enemy_group
+  # `enemy_group` defaults to "every id exists" (Hash.new(true)) since most
+  # checks using this fixture have nothing to do with troop validity; pass an
+  # explicit hash (e.g. {}) to exercise the missing-troop-id diagnostic path.
   def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil,
-                 property = nil, rpg2003: false, battlecommands: nil)
+                 property = nil, rpg2003: false, battlecommands: nil,
+                 enemy_group: Hash.new(true))
     @player = players
     @system = FakeActorSystem.new(party_ids)
     @item = items
@@ -3006,6 +3018,7 @@ class FakeActorDB
     @property = property
     @rpg2003 = rpg2003
     @battlecommands = battlecommands
+    @enemy_group = enemy_group
   end
 
   # Mirrors LCF::Schema::Database#rpg2003? (Classes-chunk presence) for tests
@@ -3021,14 +3034,15 @@ end
 FakeBattleCommandsTable = Struct.new(:commands)
 FakeBattleCommand = Struct.new(:name, :type)
 
-def party_state
+def party_state(enemy_group: Hash.new(true))
   players = {
     1 => FakePlayerRow.new('Hero', '', 0, 5,
                            max_hp: 100, max_mp: 30, atk: 10, def: 8),
     2 => FakePlayerRow.new('Ally', '', 0, 3,
                            max_hp: 50, max_mp: 20, atk: 6, def: 5),
   }
-  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2])), 1, 0, 0)
+  Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], enemy_group: enemy_group)),
+                  1, 0, 0)
 end
 
 check 'both timers round-trip through the save; an old save still loads' do
@@ -7467,6 +7481,86 @@ check 'Enemy Encounter escape-abort mode ends the event' do
   it.resume_battle(:escape)
   it.update
   ok !st.switches[5], 'the rest of the event is abandoned on an aborting escape'
+end
+
+# A database shrink can leave an Enemy Encounter's troop id (enemy_group)
+# dangling -- shown as "?" in the editor, docs/TODO.md's runtime error
+# catalog. Game::Troop itself tolerates the gap silently (degrades to an
+# empty member list, see "a missing troop / enemy degrades to an empty,
+# harmless model" above), which would otherwise open a real battle screen
+# against zero enemies. The interpreter now checks first and never arms the
+# :battle wait at all -- see #skip_invalid_troop / #start_random_battle.
+
+check 'Enemy Encounter reports a missing troop id and skips the battle, no handlers' do
+  list = [
+    FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 99, 0, 0, 0, 0], indent: 0), # troop 99 missing
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 0)
+  ]
+  st = party_state(enemy_group: {})
+  it = Game::Interpreter.new(st)
+  out = capture_stderr do
+    it.start(list)
+    it.update
+  end
+  ok out.include?('[RPG2k] Enemy Encounter: enemy group 99 not found'), out
+  ok !it.waiting?, 'never suspends on a :battle wait'
+  eq nil, it.battle_request
+  eq 0, st.battle_count, 'no battle was actually entered'
+  eq true, st.switches[1], 'execution falls straight through to the next command'
+end
+
+check 'Enemy Encounter with a missing troop id routes into the [Escape] handler, like a real escape' do
+  list = [
+    FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 99, 0, 2, 1, 0], indent: 0), # troop 99 missing
+    FakeCmd.new(IC::VICTORY_HANDLER, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
+    FakeCmd.new(IC::ESCAPE_HANDLER, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 2, 2, 0], indent: 1),
+    FakeCmd.new(IC::DEFEAT_HANDLER, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 3, 3, 0], indent: 1),
+    FakeCmd.new(IC::END_BATTLE, [], indent: 0),
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 4, 4, 0], indent: 0)
+  ]
+  st = party_state(enemy_group: {})
+  it = Game::Interpreter.new(st)
+  out = capture_stderr do
+    it.start(list)
+    it.update
+  end
+  ok out.include?('[RPG2k] Enemy Encounter: enemy group 99 not found'), out
+  ok !it.waiting?, 'never suspends on a :battle wait'
+  [1, 2, 3].each { |s| eq(s == 2, st.switches[s] || false, "switch #{s}") }
+  eq true, st.switches[4], 'execution continues past the encounter'
+  eq 0, st.escape_count, 'no real escape happened, so the "Other" counter is untouched'
+end
+
+check 'Enemy Encounter escape-abort mode with a missing troop id ends the event, like a real escape' do
+  list = [
+    FakeCmd.new(IC::ENEMY_ENCOUNTER, [0, 99, 0, 1, 0, 0], indent: 0), # escape=abort
+    FakeCmd.new(IC::CONTROL_SWITCHES, [0, 5, 5, 0], indent: 0)
+  ]
+  st = party_state(enemy_group: {})
+  it = Game::Interpreter.new(st)
+  capture_stderr do
+    it.start(list)
+    it.update
+  end
+  ok !it.waiting?
+  ok !st.switches[5], 'the rest of the event is abandoned, same as an aborting escape'
+end
+
+check 'a random encounter reports and skips a missing troop id without arming the :battle wait' do
+  st = party_state(enemy_group: { 1 => true }) # only troop 1 exists
+  it = Game::Interpreter.new(st)
+  out = capture_stderr { it.start_random_battle(99) }
+  ok out.include?('[RPG2k] Enemy Encounter: enemy group 99 not found'), out
+  ok !it.waiting?, 'movement is never interrupted -- there is no event to resume'
+  eq nil, it.battle_request
+  eq 0, st.battle_count
+
+  ok capture_stderr { it.start_random_battle(1) }.empty?, 'an existing troop id logs nothing'
+  ok it.waiting?
+  eq :battle, it.wait_kind
 end
 
 # -- Battle (headless auto-battle) --------------------------------------------

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -650,8 +650,14 @@ def fake_party(members = [])
   # Party#apply_map_step_damage on every walked tile, so the fixture has to
   # answer the real interface. It starts empty -- `system.party` is [] and the
   # movement / event checks have no members to care about -- and takes any it
-  # needs from the caller.
-  party = Game::Party.new(OpenStruct.new(system: OpenStruct.new(party: [])))
+  # needs from the caller. This db is deliberately its own bare OpenStruct, not
+  # the scene's own `fake_db` (built separately by `new_scene`) -- so
+  # `enemy_group` defaults to "every id exists" (Hash.new(true)), the same
+  # permissive default the other stub parties in this file use, since these
+  # movement/event checks are not exercising the missing-troop-id diagnostic
+  # path (covered in scripts/rpg2k_logic_check.rb instead).
+  party = Game::Party.new(OpenStruct.new(system: OpenStruct.new(party: []),
+                                          enemy_group: Hash.new(true)))
   members.each { |m| party.actors << m }
   party
 end
@@ -2051,7 +2057,12 @@ class BattleStubParty
   # #flying_offset` reads it off `@state.party`, not the database directly, so
   # a battle scene check needs its stub party to answer it too) -- false by
   # default, matching every other check's plain RPG2000 fixture.
-  def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil, skill_db: nil)
+  # `enemy_group` defaults to "every id exists" (Hash.new(true)) -- these
+  # checks drive an already-opening or already-open battle, not the
+  # missing-troop-id diagnostic path (covered in scripts/rpg2k_logic_check.rb),
+  # so an Enemy Encounter command's real troop id should never be rejected here.
+  def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil, skill_db: nil,
+                 enemy_group: Hash.new(true))
     @actors = [actor]
     @gold = 0
     @leader = nil
@@ -2059,6 +2070,7 @@ class BattleStubParty
     @items = {}
     @item_db = item_db
     @skill_db = skill_db
+    @enemy_group = enemy_group
   end
   def gain_gold(n); @gold += n; end
   def any_alive?; @actors.any? { |a| !a.dead? }; end
@@ -2075,6 +2087,7 @@ class BattleStubParty
   # was given, mirroring #db_item above.
   def db_skill(id); @skill_db && @skill_db[id]; end
   def db_item(id); @item_db && @item_db[id]; end
+  def db_enemy_group(id); @enemy_group[id]; end
 end
 
 # A party the shop can charge and stock: gold plus an item-count bag, with the
@@ -7711,6 +7724,9 @@ class BattleMagicParty
   def battle_item_command(_it, _target); { hp: 20, mp: 0 }; end
   def item_all_allies?(it); it.respond_to?(:scope) && it.scope == 1; end
   def switch_item?(_id); false; end
+  # These checks drive an already-opening or already-open battle, not the
+  # missing-troop-id diagnostic path -- every id reads as present.
+  def db_enemy_group(_id); true; end
 end
 
 # BattleMagicParty built around a caller-supplied actor instead of always


### PR DESCRIPTION
## Summary

A database shrink can leave an Enemy Encounter's troop (`enemy_group`) id dangling — shown as "?" in the editor, one of the still-open cases in docs/TODO.md's "Concrete runtime error catalog". `Game::Troop.new` already tolerated a missing row by degrading to an empty member list (by design, existing test coverage), but nothing upstream ever noticed the gap, so both a scripted **Enemy Encounter** command and a wandering-monster **random encounter** would open a real battle screen (SE, BGM swap, status panel, `[Victory]`/`[Escape]`/`[Defeat]` routing) against zero enemies.

- `Game::Interpreter#do_enemy_encounter` / `#start_random_battle` (`mruby-rpg2k/mrblib/interpreter.rb`) now check the troop id against the database *before* ever arming the `:battle` wait, and log a `[RPG2k] Enemy Encounter: ...` diagnostic instead — the same reported-not-invented pattern the recent Call Event fix uses.
- A scripted encounter with a missing troop resolves exactly as an immediate Escape would: into the `[Escape]` handler if the command carries one, ending the event outright under the "abort on escape" escape mode, or otherwise simply falling through to the next command — but it does **not** bump the win/escape/defeat "Other" battle counters, since no battle was ever actually fought.
- A random encounter has no event to resume, so it just never arms the wait and movement continues uninterrupted.
- Added `Game::Party#db_enemy_group` (`mruby-rpg2k/mrblib/game.rb`), mirroring the existing `#db_item`/`#db_skill` "reach into `@db`, respond_to?-guarded" pattern.

### Where the check lives, and why

The task description offered two candidate locations: `Game::Interpreter` (before arming the wait) or `Scene::Map#open_battle` (the shared entry point right before `Game::Troop.new` is constructed). I chose the interpreter, for two reasons:

1. **Testability.** `scripts/rpg2k_logic_check.rb` loads `game.rb`/`interpreter.rb` directly under host Ruby but never `scene/map.rb` (that's `rpg2k_scene_check.rb`'s job, an RGSS-stubbed integration harness). Validating in the interpreter keeps this regression covered by the cheap, fast logic-check harness the task asked for.
2. **No new plumbing needed.** `Game::Interpreter` has no direct database reference, but `@state.party` (a real `Game::Party`) already holds the same unified database object `Scene::Map` itself reaches through `db` — both trace back to the single `Game::Party.new(@db)` / `Scene::Base#db = parent.db` wiring in `main.rb`. So `party.db_enemy_group` reads the identical database `open_battle`'s `Game::Troop.new(db, ...)` would have used, with no interpreter constructor change required.

### Test coverage

Five new checks in `scripts/rpg2k_logic_check.rb`:
- Enemy Encounter with a missing troop id and no handlers: diagnostic logged, no `:battle` wait armed, event falls through to the next command.
- Enemy Encounter with a missing troop id and an `[Escape]` handler: routes there, `[Victory]`/`[Defeat]` skipped, "Other" escape counter untouched.
- Enemy Encounter escape-abort mode with a missing troop id: ends the event, same as a real aborting escape.
- Random encounter with a missing troop id: diagnostic logged, wait never armed.
- Random encounter with an existing troop id: unaffected, still opens normally.

Also updated the various fixture "party" doubles in `rpg2k_logic_check.rb` and `rpg2k_scene_check.rb` (`FakeParty`, `FakeActorDB`, `BattleStubParty`, `BattleMagicParty`, `fake_party`) to answer `db_enemy_group` — defaulting to "every id exists" (`Hash.new(true)`) so none of the ~1300 pre-existing checks change behavior, with the new checks passing an explicit restricted hash to exercise the missing-id path.

Updated `docs/TODO.md`'s runtime error catalog entry to mark this case handled, and added a `changelog.d/enemy-encounter-missing-troop.fixed.md` fragment.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 800 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 534 checks passed
- [x] `pre-commit run` (trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files) — passed on all changed files

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Sw7rDUFeaJkQARziJA5THM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw7rDUFeaJkQARziJA5THM)_