### PR TITLE
Fix stale save/load test for Game::State.restore_pictures' zoom/tone fields

### DIFF
--- a/scripts/rpg2k_save_load_check.rb
+++ b/scripts/rpg2k_save_load_check.rb
@@ -173,13 +173,24 @@ def check_game(dir)
   entry[1] = 'island'
   entry[31] = 80.0
   entry[32] = 60.0
+  # Zoom (33), transparency (34) and tone (41-44) round-trip too -- see
+  # #restore_pictures' own comment for why these fields read the same way
+  # Show Picture's own live params do. transparency 25 -> opacity
+  # (100-25)*255/100 = 191 via the same #trans_to_opacity the live command uses.
+  entry[33] = 150
+  entry[34] = 25
+  entry[41] = 90
+  entry[42] = 110
+  entry[43] = 95
+  entry[44] = 80
   pics[3] = entry
   restored = {}
   Game::State.restore_pictures(Struct.new(:pictures) do
     def show_picture(id, opts); pictures[id] = opts; end
   end.new(restored), pics)
-  eq({ 3 => { name: 'island', x: 80, y: 60 } }, restored,
-     'a saved picture is re-shown at its saved centre')
+  eq({ 3 => { name: 'island', x: 80, y: 60, zoom: 150, opacity: 191,
+              red: 90, green: 110, blue: 95, saturation: 80 } }, restored,
+     'a saved picture is re-shown at its saved centre, zoom, opacity and tone')
 
   # An entry with no file name is one of the empty slots RPG2000 always writes.
   blank = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_PICTURE })


### PR DESCRIPTION
## Summary
- `ruby scripts/rpg2k_save_load_check.rb` was failing on master: `Game::State.restore_pictures` was already correctly extended by a concurrent session's own already-merged change to pass `zoom`/`opacity`/`red`/`green`/`blue`/`saturation` to `show_picture` (previously left at Picture's defaults), but this pre-existing test's exact-hash assertion was never updated to match, so it started failing.
- No engine behavior change — `#restore_pictures` itself is already correct (well-reasoned, cites the exact field/param correspondence with the live Show Picture command). Fixed the test instead of the code.
- Rather than just widening the expected hash to include the new fields as `nil`, the test now sets real zoom/transparency/tone values on the synthetic save entry and asserts their real converted output (`transparency 25 -> opacity 191` via the same `#trans_to_opacity` the live command uses), so this also exercises the new restoration logic itself instead of merely tolerating it.

## Testing
- `ruby -c scripts/rpg2k_save_load_check.rb`
- `ruby scripts/rpg2k_save_load_check.rb` — passed (no more failure)
- `ruby scripts/rpg2k_scene_check.rb` — 534 checks passed (sanity, unrelated file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_