### PR TITLE
docs: confirm step_cost's per-command weighting is intentional, not a bug

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8912,6 +8912,27 @@ codebase yet):
   costs exactly one more step per iteration (3 → 4), landing on a smaller,
   precisely different iteration count (3333 → 2500) for the same 10000-step
   budget.
+- ✅ **`#step_cost`'s 2x weighting for `End Loop`/`Call Event`/`Call Common
+  Event`/an unmatched Conditional Branch is intentional, not a bug —
+  re-investigated this session after a candidate false lead and confirmed
+  correct as-is.** A numeric-constant audit flagged this weighting as
+  diverging from EasyRPG Player's own `Game_Interpreter::Update`
+  (`src/game_interpreter.cpp`), whose `for (; loop_count < loop_limit;
+  ++loop_count)` increments once per `ExecuteCommand()` call with no per-
+  command weighting at all. Checked directly against that source and
+  confirmed genuinely flat there — but that is not evidence this
+  codebase's weighting is wrong: the 2x-cost claim was always sourced from
+  real RPG_RT's own timing measurements (the community "event command
+  spec" this file's own tests already cite), an internal-implementation
+  timing quirk EasyRPG's own from-scratch loop counter never claimed to
+  reproduce. This project's own established stance (`#do_break_loop`'s
+  identical reasoning, "reproducing the bug rather than 'fixing' it into
+  the sane behaviour... modelling RPG_RT's own quirks over a better-
+  behaved reading of the spec") is to prefer a genuine real-RPG_RT source
+  over a cleaner-looking EasyRPG simplification whenever the two disagree.
+  Left unchanged; the code comment now explicitly notes this discrepancy
+  and its resolution so a future pass does not re-flag the same false
+  lead.
 - **Party wipe during "Show Text" freezes or crashes real RPG_RT** (also
   reachable via "Damage Processing," not just "HP change"). Worked repros
   given for both a blocking Autorun HP-drain-to-0-during-a-message and a

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -506,6 +506,20 @@ module Game
     # End Loop marker looping back), a Call Event round trip, and a Conditional
     # Branch evaluation that falls through to its else/end (an unmatched
     # condition, or an End Branch reached after a matched one).
+    #
+    # Deliberately NOT "corrected" to a flat 1-per-command cost to match
+    # EasyRPG Player's own `Game_Interpreter::Update` (`src/game_interpreter.
+    # cpp`), whose `for (; loop_count < loop_limit; ++loop_count)` increments
+    # once per `ExecuteCommand()` call with no per-command weighting at all --
+    # re-checked directly against that source and confirmed genuinely flat
+    # there. That is not evidence this codebase's weighting is wrong: this
+    # specific 2x-cost claim is sourced from real RPG_RT's own timing
+    # measurements (the community "event command spec" reference the tests
+    # below cite), an internal-implementation timing quirk EasyRPG's own
+    # from-scratch loop counter never claimed to reproduce -- this project's
+    # own stance (see `#do_break_loop`'s identical reasoning) is to model
+    # genuine RPG_RT behaviour over a cleaner-looking EasyRPG simplification
+    # whenever the two disagree and a real-RPG_RT source settles it.
     def step_cost(code)
       case code
       when Cmd::END_LOOP, Cmd::CALL_EVENT, Cmd::CALL_COMMON_EVENT, Cmd::END_BRANCH


### PR DESCRIPTION
## Summary
- A numeric-constant audit this session flagged `Interpreter#step_cost`'s 2x weighting for `End Loop`/`Call Event`/`Call Common Event`/an unmatched Conditional Branch as diverging from EasyRPG Player's own `Game_Interpreter::Update` (`src/game_interpreter.cpp`), which increments a flat 1 step per executed command with no per-command weighting at all.
- Checked directly against that source and confirmed genuinely flat there — but this is **not** evidence this codebase's weighting is wrong. The 2x-cost claim was always sourced from real RPG_RT's own timing measurements (the community "event command spec" this file's own tests already cite), an internal-implementation timing quirk EasyRPG's own from-scratch loop counter never claimed to reproduce.
- This project's established stance (`#do_break_loop`'s identical reasoning: "reproducing the bug rather than 'fixing' it into the sane behaviour... modelling RPG_RT's own quirks over a better-behaved reading of the spec") is to prefer a genuine real-RPG_RT source over a cleaner-looking EasyRPG simplification whenever the two disagree.
- **Left unchanged** — this PR only strengthens the code comment and adds a `docs/TODO.md` confirmation explicitly recording the investigation and its conclusion, so a future research pass doesn't re-flag the same false lead as an actionable bug.

## Testing
- `ruby -c mruby-rpg2k/mrblib/interpreter.rb` (comment-only change)
- `ruby scripts/rpg2k_logic_check.rb` — 796 checks passed (sanity, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_