### PR TITLE
Fix state-infliction default rank to differ by actor vs enemy side

### DIFF
--- a/changelog.d/rpg2k-state-susceptibility-enemy-default.fixed.md
+++ b/changelog.d/rpg2k-state-susceptibility-enemy-default.fixed.md
@@ -1,0 +1,10 @@
+- **A state id past the end of a battler's own susceptibility-rank array now
+  defaults to the correct rank per side — B/80% for an enemy, C/60% for an
+  actor — instead of always C/60%.** Confirmed against EasyRPG Player's
+  source: `Game_Actor::GetStateProbability` and `Game_Enemy::
+  GetStateProbability` are two distinct functions with two distinct
+  defaults, not one shared default. Any enemy whose database row's
+  `state_ranks` array doesn't cover a particular state — a routine
+  situation, since the LCF format truncates trailing default-valued bytes
+  — was landing that state at 60% of a skill's own chance instead of the
+  real 80%.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8026,6 +8026,32 @@ above are repeated here)
   Knockout; the same rank on an ordinary state — the control case — still
   resists it, pinning the exemption to state id 1 specifically), the first
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **A state id past the end of a battler's own `state_ranks` array now
+  defaults to the correct rank per side — B/80% for an enemy, C/60% for an
+  actor — instead of always C/60%.** A routine situation: liblcf/RPG_RT
+  truncate trailing default-valued bytes off a database battler's
+  `state_ranks` array, so any state added to the database after a given
+  actor/enemy row was last saved in the editor, or one whose own trailing
+  ranks are all default, legitimately has a short array — `#state_susceptibility`
+  (`mruby-rpg2k/mrblib/game.rb`) already handled this ("a state id the array
+  doesn't cover") but applied one shared `|| 2` (C) fallback to every
+  target regardless of side. EasyRPG Player's own source models this as two
+  distinct functions with two distinct defaults: `Game_Actor::
+  GetStateProbability` ("rate = 2, C - default") vs. `Game_Enemy::
+  GetStateProbability` ("rate = 1, Enemies have only B as the default state
+  rank") — an explicit, commented asymmetry, not an oversight on EasyRPG's
+  part. Concretely: any enemy whose `state_ranks` doesn't cover a state
+  landed that state at 60% of a skill's own chance instead of the real 80%
+  — a status-inflicting skill read as more resisted than real RPG_RT
+  specifically against monsters with an unpadded `state_ranks` array (a
+  common shape for community test games). Fixed by reusing `#ally?` (the
+  same `Combatant#actor` presence check `Battle` already uses elsewhere) to
+  pick the fallback rank per side. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (an actor and an enemy each missing
+  the same state id from their own `state_ranks` land at 60%/80%
+  respectively; a state id both *do* carry is unaffected either way),
+  confirmed to fail against the pre-fix code (enemy read 60, not 80) before
+  the fix.
 - ✅ A skill flagged "attribute defense up/down" (field 45,
   `affect_attr_defence`) now shifts the target's rank for each attribute in
   its `attribute_effects` list by **exactly one step**, capped at ±1 from the

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9009,9 +9009,17 @@ module Game
     end
 
     # The percentage a target's susceptibility scales an infliction of `sid`: its
-    # rank in the target's `state_ranks` (default C / 60% for a listed-but-absent
-    # state, EasyRPG's GetStateProbability). 100 (unscaled) when the target (a
-    # bare fixture) models no ranks, so a plain sim keeps landing every status.
+    # rank in the target's `state_ranks`, defaulting (for a state id the array
+    # doesn't cover -- routine, since liblcf/RPG_RT truncate trailing default
+    # bytes off it) to C / 60% for an actor or B / 80% for an enemy. EasyRPG
+    # models this as two distinct functions with two distinct defaults --
+    # `Game_Actor::GetStateProbability` ("rate = 2, C - default") and
+    # `Game_Enemy::GetStateProbability` ("rate = 1, Enemies have only B as the
+    # default state rank") -- not one shared default the way this used to read.
+    # `#ally?` is the same actor-vs-enemy tell `Battle` already uses elsewhere
+    # (only an actor-built Combatant, #from_actor, carries a live `actor`).
+    # 100 (unscaled) when the target (a bare fixture) models no ranks at all,
+    # so a plain sim keeps landing every status.
     # The Knockout state (id 1, `Game::Actor::DEATH_STATE`) is exempt from rank
     # scaling entirely -- a skill's "state change" effect list can name it
     # directly (RPG2000 has no separate instant-death mechanic), and yado.tk
@@ -9021,7 +9029,8 @@ module Game
       return 100 if sid == Game::Actor::DEATH_STATE
       ranks = target.state_ranks
       return 100 if ranks.nil? || ranks.empty?
-      rank = ranks[sid] || 2
+      default_rank = ally?(target) ? 2 : 1
+      rank = ranks[sid] || default_rank
       rank = 0 if rank < 0
       rank = 4 if rank > 4
       state_rate(sid, rank)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7483,6 +7483,29 @@ def combatant_mp(name, atk, dfn, agi, hp, mp)
   c
 end
 
+# EasyRPG models an actor's and an enemy's own "state id the target's
+# state_ranks array doesn't cover" case (routine -- liblcf/RPG_RT truncate
+# trailing default bytes off it) as two distinct functions with two distinct
+# defaults: Game_Actor::GetStateProbability defaults to C (rank 2, 60%),
+# Game_Enemy::GetStateProbability to B (rank 1, 80%) -- not one shared
+# default. #ally? (a live Combatant#actor vs nil) is the same tell Battle
+# already uses elsewhere to distinguish the two.
+check "an enemy's own missing state-rank entry defaults to B (80%), an actor's to C (60%)" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.actor = Object.new # a live actor -- #ally? true
+  hero.state_ranks = { 2 => 0 } # only state 2 is explicitly ranked (A)
+  slime = combatant('Slime', 0, 0, 5, 100)
+  slime.state_ranks = { 2 => 0 } # actor is nil (the default) -- #ally? false
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  eq 60, bat.send(:state_susceptibility, hero, 5),
+     "state 5 isn't in the actor's own state_ranks -- defaults to C/60%"
+  eq 80, bat.send(:state_susceptibility, slime, 5),
+     "state 5 isn't in the enemy's own state_ranks -- defaults to B/80%, not the actor's C/60%"
+  # A state that *is* explicitly ranked is unaffected by the default either way.
+  eq 100, bat.send(:state_susceptibility, hero, 2), "state 2 is explicitly rank A (100%) for the actor"
+  eq 100, bat.send(:state_susceptibility, slime, 2), "state 2 is explicitly rank A (100%) for the enemy too"
+end
+
 check 'Battle.attack_damage is half attack less a quarter defence, floored at 0' do
   eq 18, Game::Battle.attack_damage(40, 8),  '20 - 2'
   eq 0,  Game::Battle.attack_damage(2, 40),  'floored at 0, not 1 (a genuine no-damage hit)'


### PR DESCRIPTION
## Summary
- `Game::Battle#state_susceptibility` applied one shared C/60% fallback rank to every battler when a state id fell past the end of its own `state_ranks` array — a routine situation, since liblcf/RPG_RT truncate trailing default-valued bytes off it (any state added to the database after a battler's row was last saved in the editor, or one whose trailing ranks are all default, legitimately has a short array).
- Confirmed against EasyRPG Player's source: `Game_Actor::GetStateProbability` and `Game_Enemy::GetStateProbability` are two distinct functions with two distinct defaults, not one shared default — `rate = 2` (C, 60%) for an actor, `rate = 1` (B, 80%, "Enemies have only B as the default state rank") for an enemy.
- Concretely: any enemy whose `state_ranks` doesn't cover a state landed that state at 60% of a skill's own chance instead of the real 80% — a status-inflicting skill read as more resisted than real RPG_RT specifically against monsters with an unpadded `state_ranks` array.
- Fixed by reusing `#ally?` (the same `Combatant#actor` presence check `Battle` already uses elsewhere) to pick the fallback rank per side, instead of a hardcoded `|| 2`.

## Testing
- New `scripts/rpg2k_logic_check.rb` check: an actor and an enemy each missing the same state id from their own `state_ranks` land at 60%/80% respectively; a state id both *do* carry is unaffected either way — confirmed to fail against the pre-fix code (enemy read 60, not 80) before the fix.
- `ruby -c mruby-rpg2k/mrblib/game.rb` / `ruby -c scripts/rpg2k_logic_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- `ruby scripts/rpg2k_logic_check.rb` — 797 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 536 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_