### PR TITLE
fix: round-trip step/battle counters through the real .lsd save

### DIFF
--- a/changelog.d/save-step-battle-counters-lsd.fixed.md
+++ b/changelog.d/save-step-battle-counters-lsd.fixed.md
@@ -1,0 +1,21 @@
+- **The step counter and battle win/defeat/escape/victory tallies now
+  round-trip through the real `.lsd` export**, not just the portable Marshal
+  save. `Game::State#steps`/`#battle_count`/`#win_count`/`#defeat_count`/
+  `#escape_count` were already persisted in the Marshal save and already live
+  in-game (bumped by `#walk_step` and by `Interpreter`'s battle-result
+  handling, both readable via Control Variables selectors 4-7), but chunk 109
+  only decoded the two Timer Operation countdowns. Confirmed against
+  liblcf's `SaveInventory` struct (every field here is a plain `int32_t`,
+  like `gold`): `LCF::Schema::SAVE_INVENTORY` now also decodes
+  `battles`(32)/`defeats`(33)/`escapes`(34)/`victories`(35)/`steps`(42),
+  undefaulted like the timer fields so an absent field reads back as `nil`
+  rather than a concrete zero. `Game::State#to_lsd` writes the five live
+  counters into them and `.from_lsd` restores them, leaving a legacy save's
+  zeroed `State.new` defaults in place when the fields are absent. Chunk
+  109's `turns` field (41, "turns passed in latest battle") stays
+  deliberately undecoded — there is no per-battle turn tracker on the Ruby
+  side to source it from, and building one is a separate, larger feature.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (a non-zero step
+  count and battle tallies both round-trip through an in-memory
+  `to_lsd`/`from_lsd`; an old save missing the five fields keeps the default
+  zeroed counters).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -994,9 +994,12 @@ The work below is roughly ordered by the critical path to a walkable game
   but **not** for a teleport — the party arrives without walking, and counting it
   would let an event chain drain the party by shuffling it about. A draining step
   flashes the screen red, because the map has no HP display for the loss to show
-  up on otherwise. The counter persists in the Marshal save; the `.lsd` keeps its
-  own in the inventory chunk (109), whose step / turn fields are still
-  deliberately undecoded, so a resumed real save starts counting from 0.
+  up on otherwise. The counter persists in the Marshal save, and now round-trips
+  through the `.lsd` too: the inventory chunk (109)'s `steps` field (42) is
+  decoded and written by `Game::State#to_lsd` / `.from_lsd`, so a resumed real
+  save continues its count instead of starting from 0. The chunk's `turns`
+  field (41, "turns passed in latest battle") stays deliberately undecoded —
+  there is no per-battle turn tracker on the Ruby side to source it from yet.
   mtf-meido-action's Poison (1 HP every 4 steps) is the only state in either test
   bed that carries the field, and `rpg2k_testbed_logic_check.rb` walks the real
   party through the real interval against it. **`affect_type` stat
@@ -2526,6 +2529,25 @@ The work below is roughly ordered by the critical path to a walkable game
   and a battle-start-slot SFX override, all round-trip through an in-memory
   `to_lsd`/`from_lsd`; an untouched slot comes back absent rather than a
   spurious empty override).
+  ✅ **The step counter and battle win/defeat/escape/victory tallies now
+  round-trip through the `.lsd` too**, closing the gap the map-step-damage
+  entry above used to describe ("a resumed real save starts counting from
+  0"). `Game::State#steps`/`#battle_count`/`#win_count`/`#defeat_count`/
+  `#escape_count` were already Marshal-persisted and already live in-game
+  (bumped by `#walk_step` and by `Interpreter`'s battle-result handling, both
+  readable via Control Variables selectors 4-7), but chunk 109 only decoded
+  the two timers. Confirmed against liblcf's `SaveInventory` struct (every
+  field here is a plain `int32_t`, like `gold`): `LCF::Schema::SAVE_INVENTORY`
+  now also decodes `battles`(32)/`defeats`(33)/`escapes`(34)/`victories`(35)/
+  `steps`(42), undefaulted like the timer fields so an absent field reads back
+  `nil`; `Game::State#to_lsd` writes the five live counters into them and
+  `.from_lsd` restores them, leaving a legacy save's zeroed `State.new`
+  defaults in place when the fields are absent. Chunk 109's `turns` field (41,
+  "turns passed in latest battle") stays deliberately undecoded — there is no
+  per-battle turn tracker on the Ruby side to source it from, and building one
+  is a separate, larger feature. Covered by a new `scripts/
+  rpg2k_logic_check.rb` check (a non-zero step count and battle tallies both
+  round-trip through an in-memory `to_lsd`/`from_lsd`).
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations (large; Nepheshel uses the default RPG2000 battle). Needs real
   assets + the native build to develop against. The game-over scene is done

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1175,6 +1175,17 @@ module LCF
       28 => { name: :timer2_active, type: :bool },
       29 => { name: :timer2_visible, type: :bool },
       30 => { name: :timer2_battle, type: :bool },
+      # Battle tallies and the field step counter, likewise undefaulted --
+      # confirmed against liblcf's SaveInventory struct (all plain int32_t,
+      # like gold). Field 41 (`turns`, "turns passed in latest battle") is
+      # deliberately left out: there is no Ruby-side per-battle turn tracker
+      # to source it from yet, so decoding it here would have nothing to
+      # round-trip.
+      32 => { name: :battles, type: :int },
+      33 => { name: :defeats, type: :int },
+      34 => { name: :escapes, type: :int },
+      35 => { name: :victories, type: :int },
+      42 => { name: :steps, type: :int },
     }
 
     # Saved common-event execution state (chunk 114): an Array2D indexed by

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9303,14 +9303,17 @@ module Game
     # status condition's own step interval to decide when a field ailment slips
     # HP / SP (see Party#apply_map_step_damage), which is the only thing reading
     # it so far -- the encounter system that would share it is not built. It
-    # persists in the Marshal save; the `.lsd` keeps its step counter in the
-    # inventory chunk (109), whose step / turn fields are deliberately still
-    # undecoded (see LCF::Schema::SAVE_INVENTORY), so a resumed real save starts
-    # its count from 0.
+    # persists in both the Marshal save and the `.lsd` (inventory chunk 109
+    # field 42, see LCF::Schema::SAVE_INVENTORY), so a resumed real save
+    # continues its count rather than restarting from 0. The chunk's `turns`
+    # field (41, "turns passed in latest battle") stays deliberately undecoded
+    # -- there is no per-battle turn tracker on the Ruby side to source it from.
     attr_accessor :steps
     # Running tallies RPG2000 keeps and exposes through the Control Variables
     # "Other" operand: how many times the game was saved, and how many battles
-    # were fought / won / lost / escaped. All persist in the save.
+    # were fought / won / lost / escaped. All persist in the Marshal save; the
+    # battle tallies (not `save_count`) also round-trip through the `.lsd`
+    # inventory chunk (109 fields 32-35).
     attr_accessor :save_count, :battle_count, :win_count, :defeat_count,
                   :escape_count
     # Teleport / Escape skill destinations registered by Set Teleport Target
@@ -9660,7 +9663,8 @@ module Game
     #   * hero (104): map position, facing and the leader's on-map CharSet (so a
     #     Change Sprite override survives);
     #   * actors (108): the per-actor level/exp/equipment/skills/HP/MP table;
-    #   * inventory (109): the party roster / gold / item bag.
+    #   * inventory (109): the party roster / gold / item bag / both timers /
+    #     the step counter and battle win/defeat/escape/victory tallies.
     #
     # Switch and variable ids are 1-indexed in-game but 0-indexed in the save, so
     # they shift down by one; unset entries default to false / 0. +save_count+
@@ -9675,10 +9679,11 @@ module Game
     # a time until only the title chunk failed, then one field at a time within
     # it. See ADR 0021.
     #
-    # Both Timer Operation countdowns and every roster member's Change Actor
-    # Name and Change Actor Title overrides round-trip now too (see
-    # LCF::Schema::SAVE_INVENTORY's timer1_*/timer2_* fields and
-    # SAVE_PARTY_ACTOR's actor_name/title), so this is a near-parity export.
+    # Both Timer Operation countdowns, the step counter, the battle tallies and
+    # every roster member's Change Actor Name and Change Actor Title overrides
+    # round-trip now too (see LCF::Schema::SAVE_INVENTORY's timer1_*/timer2_*,
+    # battles/defeats/escapes/victories/steps fields and SAVE_PARTY_ACTOR's
+    # actor_name/title), so this is a near-parity export.
     def to_lsd(save_count = 1, timestamp = nil)
       timestamp = State.ole_now if timestamp.nil?
       save = LCF::SaveData.new
@@ -9828,6 +9833,11 @@ module Game
       inv[28] = t2.running
       inv[29] = t2.visible
       inv[30] = t2.in_battle
+      inv[32] = @battle_count
+      inv[33] = @defeat_count
+      inv[34] = @escape_count
+      inv[35] = @win_count
+      inv[42] = @steps
       save[109] = inv
 
       save
@@ -10048,6 +10058,14 @@ module Game
       state.timer(1).running = inv.timer2_active unless inv.timer2_active.nil?
       state.timer(1).visible = inv.timer2_visible unless inv.timer2_visible.nil?
       state.timer(1).in_battle = inv.timer2_battle unless inv.timer2_battle.nil?
+      # Step counter and battle win/defeat/escape/victory tallies (inventory
+      # chunk 109 fields 32-35/42); a save written before this landed simply
+      # omits them, leaving the fresh State's zeroed defaults in place.
+      state.battle_count = inv.battles unless inv.battles.nil?
+      state.defeat_count = inv.defeats unless inv.defeats.nil?
+      state.escape_count = inv.escapes unless inv.escapes.nil?
+      state.win_count = inv.victories unless inv.victories.nil?
+      state.steps = inv.steps unless inv.steps.nil?
       state
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3171,6 +3171,46 @@ check 'to_lsd/from_lsd round-trips both Timer Operation countdowns' do
   eq false, old.timer(1).running
 end
 
+check 'to_lsd/from_lsd round-trips the step counter and battle tallies' do
+  # docs/TODO.md used to say a resumed real save "starts counting from 0" for
+  # both the step counter and the battle win/defeat/escape/victory tallies --
+  # they were already Marshal-persisted and already live in-game (bumped by
+  # #walk_step and by Interpreter's battle-result handling), but chunk 109
+  # only decoded the two timers. Confirmed against liblcf's SaveInventory
+  # struct (every field here is a plain int32_t, like gold):
+  # battles/defeats/escapes/victories/steps at ids 32/33/34/35/42. Field 41
+  # ("turns passed in latest battle") stays deliberately undecoded -- there
+  # is no per-battle turn tracker on the Ruby side to source it from.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.steps = 1234
+  st.battle_count = 7
+  st.win_count = 4
+  st.defeat_count = 2
+  st.escape_count = 1
+
+  saved = st.to_lsd
+  round = Game::State.from_lsd(db, saved)
+  eq 1234, round.steps, 'the step counter round-trips'
+  eq 7, round.battle_count, 'battles entered round-trips'
+  eq 4, round.win_count, 'victories round-trips'
+  eq 2, round.defeat_count, 'defeats round-trips'
+  eq 1, round.escape_count, 'escapes round-trips'
+
+  # A save written before this landed simply omits all five fields; from_lsd
+  # must leave the freshly-constructed State's zeroed defaults alone rather
+  # than crash reading an absent field.
+  legacy = st.to_lsd
+  inv = legacy[109]
+  [32, 33, 34, 35, 42].each { |idx| inv.delete(idx) }
+  old = Game::State.from_lsd(db, legacy)
+  eq 0, old.steps, 'an old save without the counter fields keeps the default step count'
+  eq 0, old.battle_count
+  eq 0, old.win_count
+  eq 0, old.defeat_count
+  eq 0, old.escape_count
+end
+
 check 'restore_pictures restores zoom, opacity and tone, not just name/position' do
   # These used to stay at Picture's defaults: no sample save had them off-
   # default, so reading save fields 33/34/41-44 would have been guesswork. That


### PR DESCRIPTION
## Summary

- `Game::State#steps`/`#battle_count`/`#win_count`/`#defeat_count`/`#escape_count` were already persisted in the portable Marshal save and already live in-game (bumped by `#walk_step` and by `Interpreter`'s battle-result handling, both readable via Control Variables selectors 4-7), but chunk 109 (`SAVE_INVENTORY`) only decoded the two Timer Operation countdowns — so resuming from a real `.lsd` save restarted the step count and battle tallies from 0.
- Confirmed the field ids/types against liblcf's `SaveInventory` struct (`src/generated/lcf/rpg/saveinventory.h`): `battles`/`defeats`/`escapes`/`victories`/`turns`/`steps` are all plain `int32_t`, same as `gold`. `LCF::Schema::SAVE_INVENTORY` now decodes `battles`(32)/`defeats`(33)/`escapes`(34)/`victories`(35)/`steps`(42) — undefaulted like the existing timer fields, so an absent field reads back `nil` rather than a concrete zero.
- `Game::State#to_lsd` writes the five live counters into those fields and `.from_lsd` restores them, mirroring the existing timer round-trip structure exactly.
- **Deliberately deferred:** chunk 109's `turns` field (41, "turns passed in latest battle") is left undecoded — there is no per-battle turn tracker on the Ruby side to source it from, and building one is a separate, larger feature.
- Updated `docs/TODO.md`'s "starts counting from 0" note (map-step-damage entry) and added a new ✅ bullet to the "Save & Continue" section describing the fix and the deferred `turns` field.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 797 checks pass, including a new check that round-trips a non-zero step count and battle tallies through an in-memory `to_lsd`/`from_lsd`, plus a legacy-save case confirming absent fields keep the zeroed defaults.
- [x] `ruby scripts/rpg2k_save_load_check.rb` — runs clean (no local `Save*.lsd` fixture available in this environment to exercise against a real save).
- [x] `pre-commit run` (nixfmt hook skipped — no `cabal` toolchain available in this environment, and no `.nix` files were touched) on all changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ToSn1MCmQwx1r1MBcbhMV6)_