### PR TITLE
docs: mark the last two viprpg-dev backlog items

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9129,7 +9129,7 @@ codebase yet):
   running straight off read-only media. Not applicable to this project's
   own portable `Marshal` save format today; relevant only if/when `.lsd`
   save compatibility is targeted.
-- RTP graphic asset mistakes (`FaceSet/モンスター.png` has the Dark Elf's
+- ✅ **Not applicable: RTP graphic asset mistakes** (`FaceSet/モンスター.png` has the Dark Elf's
   face bleeding into the Grim Reaper's portrait next to it; `CharSet/
   主人公3.png`'s female ninja sideways sprite has a transparency mistake in
   her hair; two `ChipSet` off-by-one-pixel errors in `基本.png`'s castle
@@ -9137,11 +9137,13 @@ codebase yet):
   official RTP art assets, fixable by an official patch — not applicable
   unless this project ever ships or tests against the stock RTP bitmaps
   directly.
-- `2000/デフォ戦/デフォ戦botまとめ` is a large (~140-item), fine-grained
+- 🚧 `2000/デフォ戦/デフォ戦botまとめ` is a large (~140-item), fine-grained
   community trivia dump for default-battle-system fidelity, sourced from
   the `@2000_battle_bot` Twitter account — worth a dedicated read-through
   once battle-system work resumes rather than transcribing it piecemeal
-  now. A few structurally-significant points worth flagging early so
+  now; deliberately left as raw, untriaged reference material for that
+  future pass rather than attempted item-by-item here. A few
+  structurally-significant points worth flagging early so
   they're not missed later: ✅ **displayed ability-value changes clamp to
   1–999 but the *underlying* unclamped total is still tracked internally
   and can un-clamp back into view after a later change** (e.g. lower Attack


### PR DESCRIPTION
## Summary
Small follow-up to the yado.tk/viprpg-dev backlog triage. The "### viprpg-dev wiki backlog (2000 category)" section turned out to already be almost entirely triaged by earlier sessions — only two items still lacked a disposition marker despite already carrying full reasoning:

- **RTP graphic asset mistakes**: not applicable unless this project ships or tests against the stock RTP bitmaps directly (it doesn't today).
- **The large (~140-item) `デフォ戦botまとめ` trivia dump**: marked as the properly-scoped, deliberately-deferred reference material it already was ("worth a dedicated read-through once battle-system work resumes rather than transcribing it piecemeal now").

The one remaining unmarked bullet in this section ("Autorun events run at most once per map visit, not once per frame") is left untouched — it's Autorun-topic territory that may overlap in-flight work on the concurrent `claude/rpg2k-ui-gaps-9dua4i` branch.

No engine code changes — docs-only triage.

## Test plan
- N/A — documentation-only change, no code paths touched.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TX4f85BUosNgH43zw5hpvU)_