### PR TITLE
Paint Erase/Show Screen's random-blocks transitions (settings 1-3) for real

### DIFF
--- a/changelog.d/rpg2k-transition-random-blocks.added.md
+++ b/changelog.d/rpg2k-transition-random-blocks.added.md
@@ -1,0 +1,25 @@
+- **Erase / Show Screen's random-blocks styles (settings 1–3) now paint real
+  blocks.** They used to run as a plain fade of the right length, the wrong
+  texture, because the style wants RPG_RT's *incremental* per-frame block
+  reveal rather than a full repaint every frame — the last unbuilt style in
+  the transition family (scroll, combine / division, zoom and the mask
+  styles were already done). Confirmed against EasyRPG's real source: `size_
+  random_blocks = 4` in `src/transition.h` (a 4×4-pixel block, so 320×240 is
+  an 80×60 grid, 4800 blocks) and `src/transition.cpp`'s `Draw`
+  (`blocks_to_print = random_blocks.size() * (current_frame + 1) / tf_off`,
+  a linear cumulative-reveal ramp — 120 blocks a frame over the 41-frame
+  default length). `Game::Transition#new_block_rects` returns only the
+  blocks newly revealed each frame, computed from a deterministic
+  permutation of every block index rather than held shuffle/RNG state, so it
+  stays pure logic and replayable like `#capture_ops`/`#visible_rects`.
+  `Scene::Map#draw_random_blocks_transition` paints the overlay solid black
+  once and punches only the new blocks out of it every frame after, instead
+  of the full-cumulative-mask-every-frame shape `#visible_rects`'s other
+  mask styles use — the "incremental paint" this style was left without.
+  The plain style shuffles every block into one random order; **Down**/**Up**
+  bias that order by row (top-to-bottom / bottom-to-top) rather than
+  attempting to replicate EasyRPG's own windowed per-row shuffle, since that
+  depends on matching its RNG stream too. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb` (block-grid geometry, cumulative no-repeat
+  coverage, the Down/Up row bias) and `scripts/rpg2k_scene_check.rb` (the
+  incremental overlay paint).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1946,11 +1946,11 @@ The work below is roughly ordered by the critical path to a walkable game
   back out of it with `fill_rect`, which is exactly how RPG_RT composites the
   screen being left against the screen being arrived at (one of the two is always
   solid black). That draws the blinds, the vertical / horizontal stripes and the
-  border-to-centre / centre-to-border windows for real. Remaining: the styles a
-  black mask cannot express — the scrolls, the combine / division pairs and zoom
-  slide or resample the live scene itself, mosaic / wave resample it too, and
-  random blocks wants thousands of block blits a frame — which run as a fade of
-  the right length and the right end state for now.
+  border-to-centre / centre-to-border windows for real, and — see below —
+  random blocks too. Remaining: the styles a black mask cannot express — the
+  scrolls, the combine / division pairs and zoom slide or resample the live
+  scene itself, and mosaic / wave resample it too — which run as a fade of the
+  right length and the right end state for now.
 
   **That remainder was written up as blocked on a screen capture the renderer
   does not have. It is not: `RGSS::Graphics.snap_to_bitmap` exists, is tested
@@ -1959,8 +1959,8 @@ The work below is roughly ordered by the critical path to a walkable game
   and it answers nil there), and the **RPG Maker XP scene already uses it**
   (`mruby-rpgxp/mrblib/scene.rb`) for exactly this — its own transitions.** The
   same mistake as the fade/flash note below: a capability assumed missing that
-  was already there. What was left per style (scroll, combine / division and
-  zoom are now done — see below):
+  was already there. What was left per style (scroll, combine / division,
+  zoom and random blocks are now done — see below):
 
   - ✅ **Scroll (settings 9–12)** and **combine / division (13–15)**: capture the
     outgoing screen once when the transition starts, then each frame paint the
@@ -1973,12 +1973,14 @@ The work below is roughly ordered by the critical path to a walkable game
     shrinks toward (an Erase) or grows from (a Show) the screen centre, so
     stretching that shrinking/growing crop over the whole screen is what reads
     as zooming in.
+  - ✅ **Random blocks (1–3)**: a mask like the blinds / stripes / window
+    styles above, but painted *incrementally* — only the blocks newly
+    revealed each frame — rather than through `#visible_rects`'s
+    full-cumulative-mask-every-frame shape, which is what made this style
+    expensive enough to be left unbuilt. See the writeup below.
   - **Mosaic (17) / wave (18)**: per-pixel resampling. `get_pixel`/`set_pixel`
     exist but a full-screen loop per frame in Ruby is far too slow, so these are
     the only two that genuinely want a native pass.
-  - **Random blocks (1–3)**: expressible as a mask already; it needs the
-    *incremental* paint RPG_RT uses (only the newly-covered blocks each frame,
-    ~120 of 4800) rather than repainting every block, which is why it was left.
 
   One wrinkle a Show Screen has and an Erase does not: its capture is of the
   screen being arrived at, and `snap_to_bitmap` grabs the rendered screen
@@ -1990,7 +1992,8 @@ The work below is roughly ordered by the critical path to a walkable game
   which is what makes the family worth finishing (`ruby scripts/analyze_game.rb
   --params --code 11010 data/mtf-meido-action/Debug`).
 
-  **Scroll, combine / division and zoom are done.** `Game::Transition#capture_ops`
+  **Scroll, combine / division, zoom and random blocks are done.**
+  `Game::Transition#capture_ops`
   computes, per style, where each piece of a captured screen goes this frame
   (a plain offset for the four scroll directions; two sliding pieces for
   vertical/horizontal combine and division; four for cross; one resampled crop
@@ -2028,8 +2031,44 @@ The work below is roughly ordered by the critical path to a walkable game
   parameters confirm setting 16 (zoom) is real, in-use data, not a corner case:
   `ruby scripts/analyze_game.rb --params --code 11010 data/mtf-meido-action/Debug`
   and `--code 11020` each show one use of param0 `16` among their mode tables.
-  Covered by new checks in `scripts/rpg2k_scene_check.rb`. Mosaic/wave and
-  random blocks are still unbuilt, per the per-style breakdown above.
+  Covered by new checks in `scripts/rpg2k_scene_check.rb`.
+
+  ✅ **Random blocks (1–3) are done too.** Confirmed against EasyRPG's real
+  source rather than guessed: `size_random_blocks = 4` in `src/transition.h`
+  (a 4×4-pixel block, so 320×240 is an 80×60 grid, 4800 blocks total) and
+  `src/transition.cpp`'s `Draw` (`blocks_to_print = random_blocks.size() *
+  (current_frame + 1) / tf_off`, the same linear cumulative-reveal ramp this
+  port uses) — this doc's own earlier "~120 of 4800" estimate holds exactly
+  (4800 blocks / 40 = 120). `Game::Transition#new_block_rects` returns only
+  the blocks newly revealed *this* frame — not the cumulative mask
+  `#visible_rects`'s other shaped styles return — computed from a full
+  permutation of every block index (`#block_order`) sliced by
+  `#block_count_through`: deterministic and RNG-state-free, so replaying the
+  same frame twice returns the same rects, unlike EasyRPG's own
+  `std::shuffle`-plus-running-counter approach.
+  `Scene::Map#draw_random_blocks_transition` paints it the way RPG_RT
+  actually does: the overlay goes solid black once, the first frame a given
+  transition instance is drawn (identity-tracked, the same trick
+  `#draw_captured_transition` uses for its snapshot) — punching every block
+  `#revealed_block_rects` says is due by that frame, cumulative from block 0,
+  since the frame counter can already be past 0 the first time a transition
+  is drawn — and every frame after only punches that frame's `#new_
+  block_rects` delta out of it — never re-filling the whole 4800-block mask
+  from scratch, which is the "incremental paint... rather than repainting
+  every block" this doc used to flag as the reason the style was left. The
+  plain style shuffles every block into one random
+  order; **Down**/**Up** bias that order by row (top-to-bottom for Down,
+  bottom-to-top for Up) rather than EasyRPG's own windowed per-row
+  `std::shuffle` + `std::partial_sort` (same source,
+  `SetAttributesTransitions`) — reproducing that exact wave would mean
+  replaying the same Mersenne Twister stream EasyRPG's RNG produces, which
+  is not meaningful to match without matching its RNG too, so this is a
+  reasoned simplification of the same kind cross combine/division's
+  quadrant motion and zoom's screen-centre anchor already are elsewhere in
+  this class. Covered by new checks in `scripts/rpg2k_logic_check.rb`
+  (block-grid geometry, cumulative no-repeat coverage, the Down/Up row bias)
+  and `scripts/rpg2k_scene_check.rb` (the incremental overlay paint).
+  Mosaic/wave alone is still unbuilt, per the per-style breakdown above.
 
   The fade and flash overlays were listed here as blocked on `RGSS::Viewport`
   tone/alpha support in C++. **They were not**: `RGSS::Sprite#opacity` already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4959,15 +4959,26 @@ module Game
                 HORIZONTAL_COMBINE, HORIZONTAL_DIVISION, CROSS_COMBINE,
                 CROSS_DIVISION, ZOOM_IN, ZOOM_OUT].freeze
 
+    # The random-blocks styles: a mask like BLIND_*/*_STRIPES_*/the window
+    # pair above, but painted *incrementally* -- RPG_RT (and this port, see
+    # #new_block_rects) only punches the blocks newly revealed this frame
+    # rather than recomputing and repainting the whole cumulative mask every
+    # frame, which is what the other mask styles' #visible_rects does and
+    # what made this style expensive enough to be left unbuilt (~4800 blocks
+    # by the last frame of a 320x240 screen). Scene::Map paints these via a
+    # separate, identity-tracked path (#draw_random_blocks_transition)
+    # instead of #visible_rects for exactly that reason.
+    RANDOM_BLOCKS_STYLES = [RANDOM_BLOCKS, RANDOM_BLOCKS_DOWN,
+                             RANDOM_BLOCKS_UP].freeze
+
     # Styles this build paints for real. Mosaic / wave still fall through to a
     # plain fade -- they want a native per-pixel resample, which is not built
-    # yet. Random blocks wants RPG_RT's incremental per-frame block paint,
-    # which a mask can express but this does not do yet either.
+    # yet.
     DRAWN = [FADE_IN, FADE_OUT, BLIND_OPEN, BLIND_CLOSE, VERTICAL_STRIPES_IN,
              VERTICAL_STRIPES_OUT, HORIZONTAL_STRIPES_IN,
              HORIZONTAL_STRIPES_OUT, BORDER_TO_CENTER_IN, BORDER_TO_CENTER_OUT,
              CENTER_TO_BORDER_IN, CENTER_TO_BORDER_OUT, CUT_IN, CUT_OUT,
-             NONE, *CAPTURED].freeze
+             NONE, *CAPTURED, *RANDOM_BLOCKS_STYLES].freeze
 
     # The highest setting index the numbering defines (20 = "no transition").
     MAX_SETTING = 20
@@ -5007,6 +5018,17 @@ module Game
       when NONE              then 0
       else 41
       end
+    end
+
+    # The random-blocks grid for a `width`x`height` screen: `[cols, rows]` of
+    # BLOCK_SIZE-pixel blocks. Confirmed against EasyRPG's src/transition.h
+    # (`size_random_blocks = 4`) -- 320x240 is 80x60, 4800 blocks total, which
+    # is where docs/TODO.md's "~120 of 4800" comes from (4800 blocks over the
+    # 41-frame default length).
+    BLOCK_SIZE = 4
+
+    def self.block_grid(width, height)
+      [width / BLOCK_SIZE, height / BLOCK_SIZE]
     end
 
     attr_reader :style, :frames, :frame
@@ -5104,7 +5126,60 @@ module Game
       end
     end
 
+    # Whether this style is one of the random-blocks family (see
+    # RANDOM_BLOCKS_STYLES) -- Scene::Map paints these through
+    # #new_block_rects instead of #visible_rects.
+    def random_blocks?
+      RANDOM_BLOCKS_STYLES.include?(@style)
+    end
+
+    # The blocks newly revealed *this* frame only -- not the cumulative mask
+    # #visible_rects's callers get from the other shaped styles. Each block is
+    # `[x, y, BLOCK_SIZE, BLOCK_SIZE]`; painting only these over an overlay
+    # that started (and stays) opaque black is RPG_RT's own incremental
+    # paint, confirmed against EasyRPG's src/transition.cpp: `blocks_to_print
+    # = random_blocks.size() * (current_frame + 1) / tf_off` there is
+    # `#block_count_through(@frame)` here, and its `current_blocks_print`
+    # (the count already painted as of the previous frame) is
+    # `#block_count_through(@frame - 1)`.
+    #
+    # #block_order (below) stands in for EasyRPG's own `random_blocks` vector
+    # -- a full permutation of every block index, sliced by count rather than
+    # walked one at a time, so calling this again for a frame already drawn
+    # (replaying, or a test asserting on frame 5 after frame 3) returns the
+    # exact same rects rather than depending on how many times it was called
+    # before. That is a deliberate difference from EasyRPG's own
+    # `std::shuffle` + `current_blocks_print`-tracking approach: this class
+    # holds no Graphics access and no RNG state, only the two ints every
+    # other style already carries (@frame, @frames), per the "pure logic,
+    # unit-testable" precedent #capture_ops and #visible_rects set.
+    def new_block_rects
+      block_rects(block_count_through(@frame - 1), block_count_through(@frame))
+    end
+
+    # Every block revealed by (and including) this frame -- the full
+    # cumulative mask, unlike #new_block_rects's this-frame-only delta.
+    # Scene::Map uses this once, the first frame it paints a given
+    # transition instance, to catch the overlay up in a single pass even
+    # when that first paint lands after frame 0 (the frame counter has
+    # already advanced once before the very first #update/render pass in
+    # some call orders -- see the vertical-division capture test's own "frame
+    # 1 is the first rendered frame" note in scripts/rpg2k_scene_check.rb):
+    # #new_block_rects alone would only punch the delta since frame 0 and
+    # silently leave frame 0's own blocks unrevealed forever in that case.
+    def revealed_block_rects
+      block_rects(0, block_count_through(@frame))
+    end
+
     private
+
+    # Pixel rects for block indices `[from, to)` in reveal order.
+    def block_rects(from, to)
+      cols = block_grid_cols
+      block_order[from...to].map do |i|
+        [(i % cols) * BLOCK_SIZE, (i / cols) * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE]
+      end
+    end
 
     # The frame index the geometry is drawn at, and the span it runs over —
     # EasyRPG's `current_frame` and `total_frames - 1`.
@@ -5341,6 +5416,77 @@ module Game
         out.push [x2, y2, w2, h2] if w2 > 0 && h2 > 0
       end
       out
+    end
+
+    # This instance's block grid, in columns -- see .block_grid.
+    def block_grid_cols
+      @width / BLOCK_SIZE
+    end
+
+    # How many blocks are revealed by (and including) `frame`, clamped to the
+    # block total -- EasyRPG's own `blocks_to_print`. A negative `frame`
+    # (#new_block_rects asking for the count *before* frame 0) is nothing
+    # revealed yet.
+    def block_count_through(frame)
+      return 0 if frame < 0
+      total = block_order.size
+      d = span
+      return total if d <= 0
+      n = total * (frame + 1) / d
+      n > total ? total : n
+    end
+
+    # A deterministic scramble of `index` into `0...total`, standing in for
+    # `std::shuffle`'s randomness (see #new_block_rects) -- a multiplicative
+    # hash mod the block count. BLOCK_SHUFFLE_STRIDE is prime and far smaller
+    # than any screen's block total this build reaches, so the map stays a
+    # bijection (a full reshuffle, not a lossy hash) for every grid actually
+    # in use.
+    BLOCK_SHUFFLE_STRIDE = 2749
+
+    def block_shuffle_rank(index, total)
+      (index * BLOCK_SHUFFLE_STRIDE) % total
+    end
+
+    # The reveal order for this transition's block grid: `order[k]` is the
+    # block index (row-major, matching #new_block_rects's own `i % cols` /
+    # `i / cols`) revealed at cumulative position `k`. Memoized -- @style /
+    # @width / @height never change after #initialize, so this is the same
+    # array on every call, computed once regardless of how many frames are
+    # drawn.
+    #
+    # RANDOM_BLOCKS shuffles every block into one random order, matching
+    # EasyRPG's own `std::shuffle(random_blocks.begin(), random_blocks.end(),
+    # ...)`. RANDOM_BLOCKS_DOWN/UP bias that order by row (top rows first for
+    # Down, bottom rows first for Up) rather than shuffling uniformly --
+    # EasyRPG's own version of that bias is a windowed per-row `std::shuffle`
+    # + `std::partial_sort` (src/transition.cpp's SetAttributesTransitions)
+    # that this class does not attempt to port bit-for-bit: it depends on
+    # replaying the same Mersenne Twister stream EasyRPG's `Rand::GetRNG()`
+    # would produce, which is not meaningful to match without matching its
+    # RNG too, and this class carries no RNG state at all (see
+    # #new_block_rects). Sorting every block by `[row, shuffle rank]` (or
+    # `[-row, shuffle rank]` for Up) keeps the same reasoned-simplification
+    # policy #cross_split_ops's quadrant motion and #zoom_rect's screen-centre
+    # anchor already use elsewhere in this class: reproduce the *behaviour* a
+    # real style reads as (a top-to-bottom or bottom-to-top wave, shuffled
+    # within it) rather than an unmatchable RNG trace.
+    def compute_block_order
+      cols = block_grid_cols
+      total = cols * (@height / BLOCK_SIZE)
+      indices = (0...total).to_a
+      case @style
+      when RANDOM_BLOCKS_DOWN
+        indices.sort_by { |i| [i / cols, block_shuffle_rank(i, total)] }
+      when RANDOM_BLOCKS_UP
+        indices.sort_by { |i| [-(i / cols), block_shuffle_rank(i, total)] }
+      else
+        indices.sort_by { |i| block_shuffle_rank(i, total) }
+      end
+    end
+
+    def block_order
+      @block_order ||= compute_block_order
     end
   end
 

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -500,6 +500,12 @@ class RPG2k
         # transition reuses it instead of re-snapshotting every frame.
         @transition_capture = nil
         @captured_transition = nil
+        # The random-blocks transition (see Game::Transition::RANDOM_BLOCKS_
+        # STYLES) currently painting into the overlay incrementally, or nil --
+        # tracked by identity the same way, so #draw_random_blocks_transition
+        # knows when to (re)paint the overlay solid black versus just punching
+        # this frame's new blocks out of what is already there.
+        @random_blocks_transition = nil
 
         @flash_sprite = Sprite.new
         @flash_sprite.z = 450
@@ -556,11 +562,17 @@ class RPG2k
       # punched back out to fully transparent. `fill_rect` overwrites alpha, so
       # the holes really are holes. A *captured* transition (scroll, combine /
       # division) paints real pixels instead of holes -- see
-      # #draw_captured_transition.
+      # #draw_captured_transition. Random blocks is a shaped mask too, but an
+      # *incremental* one -- see #draw_random_blocks_transition.
       def draw_transition_mask(screen)
         tr = screen.transition
-        return draw_captured_transition(tr) if tr && tr.captured?
+        if tr && tr.captured?
+          release_random_blocks_transition
+          return draw_captured_transition(tr)
+        end
         release_transition_capture
+        return draw_random_blocks_transition(tr) if tr && tr.random_blocks?
+        release_random_blocks_transition
         if tr.nil? || tr.uniform?
           reset_fade_bitmap if @fade_masked
           @fade_sprite.opacity = screen.fade_level
@@ -625,6 +637,44 @@ class RPG2k
         @transition_capture.dispose
         @transition_capture = nil
         @captured_transition = nil
+      end
+
+      # Paint a random-blocks-style transition incrementally: the overlay is
+      # filled opaque black once, the first frame this particular
+      # Game::Transition instance is drawn (identity, not value, so a
+      # same-style transition right after it still restarts from solid
+      # black) -- and that first paint punches every block #revealed_
+      # block_rects says is due by the current frame, not just this frame's
+      # own #new_block_rects delta, since the frame counter can already be
+      # past 0 by the time a transition is first drawn (see
+      # Game::Transition#revealed_block_rects). Every frame after that only
+      # punches the incremental #new_block_rects delta -- never re-filling
+      # the whole overlay is the point, see
+      # Game::Transition::RANDOM_BLOCKS_STYLES's comment on why the generic
+      # #visible_rects path (a full black fill plus the entire cumulative
+      # mask, every frame) is the wrong shape for ~4800 blocks.
+      def draw_random_blocks_transition(tr)
+        if @random_blocks_transition.equal?(tr)
+          rects = tr.new_block_rects
+        else
+          @fade_bmp.fill_rect 0, 0, SCREEN_W, SCREEN_H, OPAQUE_BLACK
+          @random_blocks_transition = tr
+          rects = tr.revealed_block_rects
+        end
+        rects.each { |x, y, w, h| @fade_bmp.fill_rect x, y, w, h, CLEAR }
+        @fade_masked = true
+        @fade_sprite.opacity = 255
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] screen transition block draw failed: #{e.message}"
+        @fade_sprite.opacity = tr.black_alpha
+      end
+
+      # Drop the identity marker once no random-blocks transition needs it --
+      # otherwise a later same-style transition (a new Game::Transition
+      # object) would look like a continuation of a finished one and never
+      # get the fresh solid-black overlay it needs.
+      def release_random_blocks_transition
+        @random_blocks_transition = nil
       end
 
       # Restore the overlay to solid black after a shaped transition, so the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2102,12 +2102,12 @@ end
 
 check 'Erase Screen records the transition style and ramps the level' do
   st = new_state
-  # Setting 2 is Random Blocks Down, one of the styles a black mask cannot
-  # express, so it runs as a fade of the same length.
+  # Setting 17 is Mosaic, still one of the styles a black mask cannot express
+  # (per-pixel resampling), so it runs as a fade of the same length.
   it = Game::Interpreter.new(st)
-  it.start([FakeCmd.new(IC::ERASE_SCREEN, [2])])
+  it.start([FakeCmd.new(IC::ERASE_SCREEN, [17])])
   it.update
-  eq Game::Transition::RANDOM_BLOCKS_DOWN, st.screen.fade_transition
+  eq Game::Transition::MOSAIC_OUT, st.screen.fade_transition
   ok st.screen.transition.uniform?, 'an unported style falls back to the fade'
   eq 41, st.screen.transition.frames, 'but keeps its own length'
   before = st.screen.fade_level
@@ -2257,6 +2257,61 @@ check 'the window transitions shrink, grow, and invert for the other direction' 
   grow = TR.new(TR::CENTER_TO_BORDER_IN, 41, 320, 240, false)
   20.times { grow.advance }
   eq [[80, 60, 160, 120]], grow.visible_rects
+end
+
+check 'random blocks tile the screen into a 4px grid, confirmed against EasyRPG' do
+  # src/transition.h's `size_random_blocks = 4`: 320x240 / (4x4) is an 80x60
+  # grid, 4800 blocks -- where docs/TODO.md's "~120 of 4800" per frame comes
+  # from.
+  eq [80, 60], TR.block_grid(320, 240)
+end
+
+check 'random blocks reveal cumulatively, never repeat, and cover the grid' do
+  # src/transition.cpp's Draw: `blocks_to_print = random_blocks.size() *
+  # (current_frame + 1) / tf_off` -- frame 0 of a 41-frame transition already
+  # reveals 4800 * 1 / 40 = 120 blocks.
+  tr = TR.new(TR::RANDOM_BLOCKS, 41, 320, 240, true)
+  first = tr.new_block_rects
+  eq 120, first.size, 'frame 0 already reveals its first ~120 blocks'
+  first.each do |x, y, w, h|
+    eq 4, w, 'blocks are 4px square'
+    eq 4, h, 'blocks are 4px square'
+    eq 0, x % 4, 'blocks sit on the 4px grid'
+    eq 0, y % 4, 'blocks sit on the 4px grid'
+  end
+
+  seen = first.map { |x, y, _w, _h| [x, y] }
+  39.times do
+    tr.advance
+    batch = tr.new_block_rects
+    batch.each { |x, y, _w, _h| seen.push [x, y] }
+  end
+  eq seen.uniq.size, seen.size, 'no block is ever revealed twice'
+  eq 4800, seen.size, 'every block is revealed by the time the transition ends'
+
+  # Replaying an already-drawn frame (no #advance in between) returns the
+  # exact same rects -- #new_block_rects holds no shuffle-progress state of
+  # its own, unlike EasyRPG's `current_blocks_print` counter.
+  replay = TR.new(TR::RANDOM_BLOCKS, 41, 320, 240, true)
+  4.times { replay.advance }
+  a = replay.new_block_rects
+  b = replay.new_block_rects
+  eq a, b, 'the same frame replayed twice reveals the same blocks'
+end
+
+check 'random blocks down/up bias the reveal order towards one edge' do
+  # Confirmed against EasyRPG's src/transition.cpp: Down/Up do not shuffle
+  # uniformly like the plain style, they bias the order by row (a per-row
+  # windowed shuffle + partial_sort there; a row-then-shuffle sort here, the
+  # same kind of reasoned simplification #cross_split_ops's quadrant motion
+  # and #zoom_rect's screen-centre anchor already document for other styles).
+  down = TR.new(TR::RANDOM_BLOCKS_DOWN, 41, 320, 240, true)
+  rows = down.new_block_rects.map { |_x, y, _w, _h| y / 4 }
+  ok rows.max < 60 / 2, 'down reveals rows near the top of the screen first'
+
+  up = TR.new(TR::RANDOM_BLOCKS_UP, 41, 320, 240, false)
+  rows = up.new_block_rects.map { |_x, y, _w, _h| y / 4 }
+  ok rows.min >= 60 / 2, 'up reveals rows near the bottom of the screen first'
 end
 
 check 'conditional branch on the timer' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8904,6 +8904,36 @@ ensure
   RGSS::Graphics.snapshot = nil
 end
 
+check 'random blocks paint incrementally: solid black once, then only new blocks' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+
+  st.screen.erase(Game::Transition::RANDOM_BLOCKS)
+  fade.bitmap.fill_calls.clear if fade.bitmap.fill_calls
+  scene.update
+  eq 255, fade.opacity, 'the mask itself carries the shape, not the opacity'
+  # #update already advanced once before this first draw (same "frame 1 is
+  # the first rendered frame" quirk the capture tests above rely on), so the
+  # very first paint has to catch up on everything due by frame 1, not just
+  # frame 1's own delta -- Game::Transition#revealed_block_rects, not
+  # #new_block_rects. 4800 * 2 / 40 = 240 blocks due by frame 1.
+  fills = fade.bitmap.fill_calls || []
+  eq 241, fills.length, 'one full-screen black fill, then every block due by frame 1'
+  eq [0, 0, 320, 240], fills.first[0, 4], 'blacked out first'
+  fills.drop(1).each { |f| eq [4, 4], f[2, 2], 'every punched block is 4x4' }
+
+  # The next frame only punches its own newly revealed blocks -- no repeat
+  # full-screen fill, and nothing already punched is painted again.
+  fade.bitmap.fill_calls.clear
+  scene.update
+  fills = fade.bitmap.fill_calls || []
+  ok fills.none? { |f| f[0, 4] == [0, 0, 320, 240] },
+     'no repeat full-screen fill once the overlay has already started black'
+  eq 120, fills.length, "one frame's worth of newly revealed blocks"
+end
+
 check 'Flash Screen drives the flash layer, and refills only on a colour change' do
   scene = new_scene({}, player: [5, 5])
   _, flash = overlay(scene)


### PR DESCRIPTION
## Summary

- Finishes the last unbuilt style in the Erase/Show Screen transition family (docs/TODO.md's "Screen effects" 🚧 item): Random Blocks / Random Blocks Down / Random Blocks Up (settings 1–3), which used to fall through to a plain fade of the right length but the wrong texture.
- Confirmed the real grid size and reveal ramp against EasyRPG's actual source rather than guessing: `size_random_blocks = 4` in `src/transition.h` (a 4×4-pixel block, so 320×240 is an 80×60 grid, 4800 blocks total) and `src/transition.cpp`'s `Draw` (`blocks_to_print = random_blocks.size() * (current_frame + 1) / tf_off`, a linear cumulative-reveal ramp — 120 blocks/frame over the 41-frame default length, matching the doc's existing "~120 of 4800" note exactly).
- `Game::Transition` gains `#new_block_rects` (this frame's newly revealed blocks only) and `#revealed_block_rects` (the full cumulative catch-up, used for a transition's very first paint), both pure logic and RNG-state-free — a deterministic permutation of block indices stands in for EasyRPG's `std::shuffle`, so replaying an already-drawn frame is idempotent and unit-testable without a renderer.
- `Scene::Map#draw_random_blocks_transition` paints the overlay solid black once (identity-tracked, same trick `#draw_captured_transition` uses for its snapshot) and punches only the new blocks each frame after — the "incremental paint... rather than repainting every block" the doc flagged as the reason this style was left, instead of the generic `#visible_rects` full-cumulative-mask-every-frame shape the other mask styles use.
- **Down**/**Up** bias the reveal order by row (top-to-bottom / bottom-to-top) rather than EasyRPG's own windowed per-row `std::shuffle` + `std::partial_sort`, which depends on replaying its exact RNG stream to match bit-for-bit — a reasoned simplification of the same kind this class's cross-combine quadrant motion and zoom's screen-centre anchor already document.
- Updates `docs/TODO.md`'s "Screen effects" writeup to move Random Blocks from "remaining" to done, alongside Scroll/Combine/Zoom.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — pure-logic coverage: block-grid geometry confirmed against EasyRPG, cumulative no-repeat coverage of all 4800 blocks, replay idempotency, and the Down/Up row bias.
- [x] `ruby scripts/rpg2k_scene_check.rb` — `Scene::Map` coverage: the overlay goes solid black once then only punches new blocks each frame, with no repeated full-screen fill.
- [x] Fixed an existing logic check that assumed setting 2 (Random Blocks Down) still fell back to a plain fade — swapped it to setting 17 (Mosaic), which is still genuinely unported.
- [x] Added a changelog fragment (`changelog.d/rpg2k-transition-random-blocks.added.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSNmjuE5xsPy4JFQeoHePn)_