### PR TITLE
docs: flag item/skill grid RIGHT/LEFT row-edge-stop claim for re-verification

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2616,7 +2616,28 @@ The work below is roughly ordered by the critical path to a walkable game
   missing cell (confirmed by pressing DOWN off the grid's last, partial row
   -- the cursor simply stayed, not wrapping to the top as the *old*
   single-column code did), RIGHT/LEFT move by one and do nothing at a row's
-  own edge. `Scene::ItemMenu` gained a `COLUMN_MAX = 2` constant, grid-aware
+  own edge. **This RIGHT/LEFT half needs a real re-check, flagged this
+  session rather than changed outright.** `Window_Selectable` has no method
+  actually named `CursorRight`/`CursorLeft` in EasyRPG Player's current
+  source (checked verbatim against `src/window_selectable.cpp`) — its real
+  `Update()` RIGHT/LEFT branches are a flat `index ± 1`, bounded only by the
+  list's own absolute start/end (`index > 0` / `index < item_max - 1`), with
+  **no row-boundary check at all**, structurally unlike DOWN/UP (genuinely
+  column-locked there, `index < item_max - column_max`) — so on the real
+  grid, RIGHT off a row's last cell should flow into the next row's first
+  cell instead of stopping. Whether the "does nothing at a row's own edge"
+  half of this bullet was itself independently wine-confirmed (as the DOWN
+  case explicitly was, parenthetically) or inferred by analogy from DOWN/UP
+  and attributed to a EasyRPG method that turns out not to exist is not
+  possible to settle from this entry's own wording alone, and wine is
+  unusable this session (see the harness-quirk notes elsewhere) to re-check
+  directly. `#move_item_cursor`/`#move_skill_cursor`
+  (`mruby-rpg2k/mrblib/scene/item_menu.rb`, `skill_menu.rb`) currently gate
+  RIGHT/LEFT on `(@item_index ± 1) % COLUMN_MAX`, matching this bullet's
+  claim as coded — left unchanged pending a real wine re-test (or a fresh
+  EasyRPG source re-read someone is more confident settles it) rather than
+  risk a blind revert of a claimed direct observation. `Scene::ItemMenu`
+  gained a `COLUMN_MAX = 2` constant, grid-aware
   drawing (`#build_item_window`, `#item_col_w`) and cursor math
   (`#move_item_cursor`, replacing the old modulo-wraparound UP/DOWN
   handling and adding RIGHT/LEFT, which the scene never handled before at


### PR DESCRIPTION
## Summary
- A numeric-constant/formula audit flagged a possible bug in `Scene::ItemMenu`/`Scene::SkillMenu`'s grid RIGHT/LEFT cursor movement (`move_item_cursor`/`move_skill_cursor`, gated on `(@item_index ± 1) % COLUMN_MAX`, stopping the cursor at a row's own edge): EasyRPG Player's actual `Window_Selectable::Update()` has no `CursorRight`/`CursorLeft` method (the name the existing `docs/TODO.md` citation uses) and no row-boundary check at all for RIGHT/LEFT — structurally unlike the genuinely column-locked DOWN/UP.
- However, the existing `docs/TODO.md` entry claims this shape was **directly wine-verified against genuine RPG_RT** with a populated 5-item bag ("confirmed against the same five-item reference frames field-for-field, including the exact cell the cursor stops on after each key"). Whether the specific "RIGHT/LEFT do nothing at a row's own edge" half of that claim was itself independently observed (the way the DOWN case explicitly was, parenthetically) or was inferred by analogy from DOWN/UP and mis-attributed to a nonexistent EasyRPG method can't be settled from the doc's own wording alone.
- Wine is unusable this session (documented elsewhere as broken/unreliable) to re-check directly, so rather than risk reverting a claimed direct RPG_RT observation on secondary-source evidence alone, or leaving a real bug silently unflagged, this PR documents the precise contradiction and its evidence for a future pass (with working wine, or higher confidence in the EasyRPG source reading) to resolve.
- **No code change** — deliberately left as-is pending that re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_