### PR TITLE
psp: start the real RPG2k scene tree

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -9,12 +9,13 @@ This is additive to and independent of the desktop CMake build — building the
 EBOOT does not touch the desktop/wasm builds, and vice versa. The design is in
 [`docs/adr/0010-psp-port.md`](../../docs/adr/0010-psp-port.md).
 
-## Status: HAL bring-up + interpreter boot
+## Status: HAL bring-up + the real RPG2k scene tree
 
-This CMake project builds a **hardware bring-up EBOOT**: it stands up the LVGL
-display over the LCD, reads the pad, and opens an mruby interpreter — without
-starting a game. It exists to prove the HAL and libmruby.a compile, link and
-run on the console (and to get real EBOOT size numbers from CI).
+This CMake project builds an EBOOT that opens an mruby interpreter and, if a
+project is present at its fixed Memory Stick install location, constructs and
+drives the real `RPG2k` scene tree. It exists to prove the HAL, libmruby.a and
+now RGSS itself compile, link and actually run a game on the console (and to
+get real EBOOT size numbers from CI).
 
 What runs today:
 
@@ -25,14 +26,29 @@ What runs today:
   Built as part of `libmruby.a` (the `psp` mruby cross-build compiles the whole
   `mruby-rgss` gem, self-guarded on `PSP_BUILD`), not compiled into the EBOOT
   directly — `app/psp/CMakeLists.txt` links the archive in instead.
+  `mruby-rgss/src/psp_input_bridge.cxx` polls the pad into `RGSS::Input`
+  press/release events (`rgss_psp_poll`) once per frame from
+  `Graphics.update`, so RGSS input needs no help from `main()`.
 - `app/psp/main.cxx` — a pspsdk sketch (module metadata + HOME-exit callback)
-  that draws a status screen, echoes the pressed keys, and opens the
-  interpreter (`mrb_open`, reported via the `RPG2K_PSP_MRUBY_OPEN` marker
-  below). `main()` owns the loop and pumps LVGL once per iteration, mirroring
-  the Emscripten and Wio builds. Its heartbeat also reports free device RAM
-  and LVGL pool usage (see below). No RGSS methods are registered and no game
-  is started yet — the interpreter opens with mruby's own default allocator
-  (plain `malloc`) and then just sits there.
+  that draws a status screen, echoes the pressed keys while idle, and opens
+  the interpreter (`mrb_open`, reported via the `RPG2K_PSP_MRUBY_OPEN`
+  marker). RGSS is already registered the moment `mrb_open()` returns —
+  `libmruby.a`'s gem_init runs every bundled gem's native `Init`, RPG2k
+  included, the same as every other target (see `build_config.rb`'s
+  `rpg_maker_gems`) — so nothing extra wires it in. `main.cxx` sets the
+  `GAME_DIR`/`RTP_DIR` mruby constants mruby-rpg2k/mruby-rgss read directly,
+  and if `RPG_RT.ldb` exists there, constructs `RPG2k.new` and drives its
+  per-frame `#main_loop` once per C++ loop iteration instead of the desktop
+  build's blocking `#start` — the same non-blocking shape the Emscripten
+  build's `rpg_start_game` callback uses, since here too the *host* loop, not
+  mruby, has to stay in charge of the process (heartbeat, HOME-button exit
+  callback). `#main_loop` calls `Graphics.update` itself, which flushes LVGL
+  and polls the pad, so `main()`'s own `lv_timer_handler()`/pad-scanning only
+  run while idle (no project found, or construction failed). Construction and
+  a clean-exit-vs-crash exit are reported via the `RPG2K_PSP_GAME_START` and
+  `RPG2K_PSP_GAME_STOP` markers below. mruby still opens with its own default
+  allocator (plain `malloc`), not routed through `lv_malloc` — ADR 0047's P2
+  remains open (see "Not yet wired").
 - `app/psp/lv_conf.h` — a PSP-tuned LVGL config (RGB565, a few-MB heap, no SIMD
   asm).
 
@@ -48,20 +64,30 @@ cmake --build build-psp          # -> build-psp/EBOOT.PBP
 ```
 
 Run `EBOOT.PBP` under an emulator such as
-[PPSSPP](https://www.ppsspp.org/), or copy it to
-`PSP/GAME/rpg2k/EBOOT.PBP` on a Memory Stick (a homebrew-enabled console).
+[PPSSPP](https://www.ppsspp.org/), or copy it, together with an RPG Maker
+2000/2003 project's files, to a Memory Stick at
+`ms0:/PSP/GAME/rpg2k/EBOOT.PBP` on a homebrew-enabled console — that fixed
+path is where `app/psp/main.cxx`'s `kGameDir` looks for `RPG_RT.ldb`. There is
+no in-app project picker: one EBOOT install is one game. RPG Maker XP/VX/VX
+Ace projects aren't detected yet (see "Not yet wired").
 
-The bring-up writes three markers via `sceIoWrite` — `RPG2K_PSP_BOOT` once at
-startup (a libc-free string literal), `RPG2K_PSP_MRUBY_OPEN ok` (or `FAILED`)
-right after `mrb_open()`, and `RPG2K_PSP_BRINGUP
+The EBOOT writes five markers via `sceIoWrite` — `RPG2K_PSP_BOOT` once at
+startup (a libc-free string literal); `RPG2K_PSP_MRUBY_OPEN ok` (or `FAILED`)
+right after `mrb_open()`; `RPG2K_PSP_GAME_START ok`/`not_found`/`FAILED`
+after attempting to construct `RPG2k` from `kGameDir`; `RPG2K_PSP_GAME_STOP
+exit`/`error` if a running game later raises (a clean `Kernel#exit` vs. an
+actual crash); and `RPG2K_PSP_BRINGUP
 frame=N free=N maxfree=N lvgl_used=N lvgl_max=N` once a second, the last four
 fields being `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` (the
 device's actual free RAM) and `lv_mem_monitor`'s current/high-water-mark use
 of LVGL's own pool — real numbers for
 [ADR 0047](../../docs/adr/0047-psp-memory-budget.md)'s P1, captured from the
-`psp-smoke` log rather than estimated. CI's `psp-smoke` job boots the EBOOT
-under PPSSPP headless and checks that a marker appears, so a regression that
-links but fails to boot is caught automatically. The job is **non-blocking**:
+`psp-smoke` log rather than estimated, and now against a real game's usage
+once one is deployed to `kGameDir` instead of just the idle HAL's. CI's
+`psp-smoke` job boots the EBOOT under PPSSPP headless and checks that a
+marker appears, so a regression that links but fails to boot is caught
+automatically; it has no project at `kGameDir`, so it only ever exercises the
+idle path (`RPG2K_PSP_GAME_START not_found`). The job is **non-blocking**:
 PPSSPP only partially implements
 pspsdk's libc stdio (plain `printf` is an unimplemented HLE import there), so
 emulator capture can be fragile — the required build gate is the `psp` job. To
@@ -74,43 +100,42 @@ PPSSPPHeadless --log --graphics=software --timeout=15 EBOOT.PBP
 
 ## Not yet wired (later slices)
 
-The pieces below are scaffolded but **not** part of the bring-up EBOOT:
+The pieces below are scaffolded but **not** part of the EBOOT yet:
 
-- **The real `RPG2k` scene tree.** `mruby-rgss/src/psp_input_bridge.cxx`
-  already translates the pad bitmask into `RGSS::Input` press/release events
-  (`rgss_psp_poll`, called from `Graphics.update`), and `libmruby.a` (the
-  `psp` mruby cross-build, `MRUBY_TARGET=psp`) is now linked into the EBOOT
-  and opens successfully (`RPG2K_PSP_MRUBY_OPEN ok`). What's not wired yet:
-  registering the RGSS native methods and actually instantiating `RPG2k.new`
-  against a real game directory — `app/psp/main.cxx` opens the interpreter
-  and stops there.
-- **Memory-Stick assets / `GAME_DIR`.** Game data is opened by path through
-  mruby-io / `std::fopen`; on the PSP these resolve to newlib syscalls backed
-  by the Memory Stick, which pspsdk's `stdio` already routes. What's missing
-  is deciding and setting the `GAME_DIR` Memory-Stick path convention itself
-  (e.g. relative to the EBOOT's own directory) — needed before `RPG2k.new`
-  can find anything.
-- **ADR 0047's P2 (the mruby/LVGL allocator split).** `main.cxx` currently
-  opens mruby with its own default allocator (plain `malloc`), not routed
-  through `lv_malloc` the way the desktop build's `mrb_basic_alloc_func`
-  override does. Proving the interpreter boots didn't require deciding this;
-  starting a real game — where the pool size actually matters — does.
+- **RPG Maker XP / VX / VX Ace detection.** `kGameDir` in `app/psp/main.cxx`
+  only ever checks for `RPG_RT.ldb` (RPG2k) — ADR 0010 scopes the PSP port to
+  "starting the real RPG2k scene tree". The desktop/Emscripten maker-detection
+  chain (`is_rpgvx_game`/`is_xp_game` in `src/main.cxx`) is the pattern to
+  follow once this path is proven; `RPGXP`/`RPGVX` are already linked into
+  `libmruby.a` the same way `RPG2k` is (`rpg_maker_gems`), just never
+  constructed here.
+- **A configurable `GAME_DIR`.** The Memory Stick path is a fixed constant
+  (`ms0:/PSP/GAME/rpg2k`), matching one-EBOOT-one-game — there is no
+  equivalent of the desktop build's `--game_dir` flag or the browser build's
+  runtime project loader, since the PSP EBOOT has no command line and no
+  way to be told a different location after it starts.
+- **ADR 0047's P2 (the mruby/LVGL allocator split).** `main.cxx` still opens
+  mruby with its own default allocator (plain `malloc`), not routed through
+  `lv_malloc` the way the desktop build's `mrb_basic_alloc_func` override
+  does. Starting a real game didn't require deciding this either; it needs
+  real on-device numbers from an actual game running at `kGameDir` first (see
+  "Memory budget" below).
 - **Accelerated rendering.** The bring-up flushes with a CPU `memcpy` into the
   framebuffer. Moving the blit onto the `sceGu` GPU is a later optimisation.
 
 ## Memory budget
 
-The bring-up EBOOT opens mruby but starts no game, so it has not yet had to
-answer how the game's live heap, LVGL's pool and decoded assets fit inside
-the PSP's ~24 MB of RAM.
+CI has no project at `kGameDir`, so it only ever exercises the idle HAL —
+answering how the game's live heap, LVGL's pool and decoded assets actually
+fit inside the PSP's ~24 MB of RAM still needs a real game run on real
+hardware or an emulator with a Memory Stick image, not just CI's `psp-smoke`.
 [`docs/adr/0047-psp-memory-budget.md`](../../docs/adr/0047-psp-memory-budget.md)
-works through that before a real game is started, including a real risk:
-mruby 4.0's global allocator hook defaults to sharing LVGL's pool (as it does
-on desktop) if `main.cxx` ever installs that override the way the desktop
-build's `mrb_basic_alloc_func` does — which it does not yet (see "Not yet
-wired" above) — so `lv_conf.h`'s 4 MB `LV_MEM_SIZE` may need to cover the
-entire mruby object graph, not just LVGL widgets, unless a PSP-specific
-allocator exception is added instead.
+works through that, including a real risk: mruby 4.0's global allocator hook
+defaults to sharing LVGL's pool (as it does on desktop) if `main.cxx` ever
+installs that override the way the desktop build's `mrb_basic_alloc_func`
+does — which it does not yet (see "Not yet wired" above) — so `lv_conf.h`'s
+4 MB `LV_MEM_SIZE` may need to cover the entire mruby object graph, not just
+LVGL widgets, unless a PSP-specific allocator exception is added instead.
 
 For a packed RPG Maker XP/VX/VX Ace title,
 [`scripts/rgssad_unpack.rb`](../../scripts/rgssad_unpack.rb) unpacks

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -1,29 +1,39 @@
-// PlayStation Portable EBOOT entry point -- hardware bring-up.
+// PlayStation Portable EBOOT entry point -- HAL bring-up plus the real RPG2k
+// scene tree.
 //
 // This slice proves the HAL compiles and runs on the PSP and that libmruby.a
 // (built for the psp target by build_config.rb, linked in via
 // app/psp/CMakeLists.txt) actually links and boots on real MIPS/pspdev: it
 // stands up the LVGL display (psp_display_create), scans the pad
 // (psp_input_scan), draws a small status screen that echoes the pressed keys,
-// and opens an mruby interpreter (mrb_open). main() owns the loop and pumps
-// LVGL once per iteration -- the same "host owns the loop" shape the
-// Emscripten and Wio builds use. Its per-second heartbeat also reports real
-// free-memory and LVGL-pool numbers (see the RPG2K_PSP_BRINGUP marker below),
-// which is ADR 0047's P1: measuring the HAL's own footprint on real
-// hardware/an emulator ahead of sizing anything for a real game.
+// opens an mruby interpreter (mrb_open), and -- if a project is present at
+// kGameDir -- constructs RPG2k and drives its per-frame #main_loop the same
+// way the Emscripten build drives it from rpg_start_game's callback (mruby's
+// gems are already registered the moment mrb_open() returns; nothing extra
+// wires RGSS in, since libmruby.a's gem_init runs every bundled gem, RPG2k
+// included -- see build_config.rb's rpg_maker_gems). main() owns the loop and
+// pumps LVGL once per iteration when no game is running, and through
+// RPG2k#main_loop's own Graphics.update (which flushes LVGL and polls the pad
+// via rgss_psp_poll, mruby-rgss/src/psp_input_bridge.cxx) once one is -- the
+// same "host owns the loop" shape the Emscripten and Wio builds use. Its
+// per-second heartbeat also reports real free-memory and LVGL-pool numbers
+// (see the RPG2K_PSP_BRINGUP marker below), which is ADR 0047's P1: measuring
+// the HAL's own footprint on real hardware/an emulator, now against a real
+// game's usage once one is present at kGameDir instead of just the idle HAL.
 //
 // mrb_open() here uses mruby's own default allocator (plain malloc) rather
 // than routing through lv_malloc the way the desktop build does -- ADR 0047's
 // P2 (share LVGL's pool vs. a separate arena) is still an open decision that
-// this slice does not need to make just to prove the interpreter boots. No
-// RGSS methods are registered and no game is started: the real RPG2k scene
-// tree, Memory-Stick asset loading and the GAME_DIR convention are the next
-// slice (see app/psp/README.md and docs/adr/0010-psp-port.md).
+// this slice does not need to make just to prove the interpreter boots and a
+// game can start.
 
 #include <cstdio>
 
 #include <lvgl.h>
 #include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/error.h>
+#include <mruby/variable.h>
 #include <pspiofilemgr.h>
 #include <pspkernel.h>
 #include <pspsysmem.h>
@@ -42,6 +52,26 @@ lv_obj_t* g_status_label = nullptr;
 // Names for the RGSS key ids, indexed by PspKey, for the on-screen echo.
 const char* const kKeyNames[PSP_INPUT_KEY_COUNT] = {
     "Up", "Down", "Left", "Right", "A", "B", "C"};
+
+// The Memory Stick install location this build looks for a project at --
+// matching app/psp/README.md's own install instructions (copy EBOOT.PBP to
+// this same PSP/GAME/rpg2k directory). One EBOOT, one game, no in-app project
+// picker: unlike the desktop build (--game_dir) or the browser build (the
+// page's own loader unzips a project at runtime), there is no way for this
+// build to be told a different location at launch. RPG2k (RPG_RT.ldb) is the
+// only maker checked -- ADR 0010 scopes the PSP port to "starting the real
+// RPG2k scene tree", not XP/VX/VX Ace; those can follow the same pattern
+// (mirroring the desktop/Emscripten maker-detection chain in src/main.cxx)
+// once this path is proven.
+const char kGameDir[] = "ms0:/PSP/GAME/rpg2k";
+
+bool file_exists(const char* path) {
+  FILE* const f = std::fopen(path, "rb");
+  if (!f)
+    return false;
+  std::fclose(f);
+  return true;
+}
 
 // Write a buffer to the PSP stdout (fd 1) and stderr (fd 2). Under an emulator
 // the host captures these; on real hardware they go nowhere. The length is
@@ -134,14 +164,57 @@ int main(void) {
 
   // Open the interpreter and report whether it succeeded. `M` is kept alive
   // (never mrb_close()d) for the rest of the process, the same as every other
-  // target's entry point -- there is nothing to hand it yet, but the next
-  // slice needs it alive for the process's whole lifetime, not just this
-  // function.
+  // target's entry point.
   mrb_state* const M = mrb_open();
   {
     char buf[48];
     const int n = std::snprintf(buf, sizeof(buf), "RPG2K_PSP_MRUBY_OPEN %s\n",
                                 M ? "ok" : "FAILED");
+    if (n > 0)
+      psp_write(buf, n);
+  }
+
+  // GAME_DIR/RTP_DIR are load-bearing mruby constants: mruby-rpg2k/mrblib and
+  // mruby-rgss/mrblib read them directly (RPG_RT.ldb/.lmt paths, asset/audio
+  // search paths, ...), the same as every other target's entry point sets
+  // them (src/main.cxx). RTP_DIR is empty -- this build is a single
+  // self-contained project per EBOOT, no shared RTP install to point at.
+  mrb_value game_obj = mrb_nil_value();
+  bool have_game = false;
+  if (M) {
+    mrb_const_set(M, mrb_obj_value(M->object_class),
+                  mrb_intern_lit(M, "GAME_DIR"), mrb_str_new_cstr(M, kGameDir));
+    mrb_const_set(M, mrb_obj_value(M->object_class),
+                  mrb_intern_lit(M, "RTP_DIR"), mrb_str_new_cstr(M, ""));
+
+    char ldb_path[64];
+    std::snprintf(ldb_path, sizeof(ldb_path), "%s/RPG_RT.ldb", kGameDir);
+    const char* game_start_result;
+    if (file_exists(ldb_path)) {
+      // No TestPlay/HideTitle words -- this build has no command line to
+      // carry them on.
+      const mrb_value args = mrb_ary_new(M);
+      game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &args);
+      if (M->exc) {
+        // Leaves no game running; falls through to the idle HAL loop below,
+        // same as "not_found".
+        M->exc = nullptr;
+        game_start_result = "FAILED";
+      } else {
+        // Keeps `game_obj` reachable from the GC across the frame loop below
+        // -- mruby's GC only sees the VM's own stack/registers and explicit
+        // roots, not arbitrary C++ locals, the same reason src/main.cxx
+        // registers its own game_obj (Emscripten's rpg_start_game).
+        mrb_gc_register(M, game_obj);
+        have_game = true;
+        game_start_result = "ok";
+      }
+    } else {
+      game_start_result = "not_found";
+    }
+    char buf[48];
+    const int n = std::snprintf(buf, sizeof(buf), "RPG2K_PSP_GAME_START %s\n",
+                                game_start_result);
     if (n > 0)
       psp_write(buf, n);
   }
@@ -158,8 +231,35 @@ int main(void) {
   // max_used high-water mark, which is the number that actually matters for
   // sizing that pool once the interpreter is linked.
   for (uint32_t frame = 0;; ++frame) {
-    show_keys(psp_input_scan());
-    lv_timer_handler();
+    if (have_game) {
+      // RPG2k#main_loop (mruby-rpg2k/mrblib/main.rb) is the single-frame step
+      // #start loops forever on desktop; driving it once per C++ frame here
+      // instead keeps this loop, not mruby, in charge of the process, the
+      // same shape src/main.cxx's rpg_start_game gives the browser. It calls
+      // Graphics.update itself, which flushes LVGL (mruby-rgss/src/lib.cxx's
+      // gfx_update) and polls the pad (rgss_psp_poll) -- so neither
+      // lv_timer_handler() nor show_keys()/psp_input_scan() below are needed
+      // while a game is driving its own frame.
+      mrb_funcall(M, game_obj, "main_loop", 0);
+      if (M->exc) {
+        // MRB_EXC_EXIT_P distinguishes a clean Kernel#exit (RPG_RT's own
+        // "Shutdown" title command, via mruby-exit) from an actual crash --
+        // read before clearing, since clearing drops the flag with the
+        // exception object.
+        const bool clean_exit = MRB_EXC_EXIT_P(M->exc);
+        M->exc = nullptr;
+        have_game = false;
+        char buf[48];
+        const int n =
+            std::snprintf(buf, sizeof(buf), "RPG2K_PSP_GAME_STOP %s\n",
+                          clean_exit ? "exit" : "error");
+        if (n > 0)
+          psp_write(buf, n);
+      }
+    } else {
+      show_keys(psp_input_scan());
+      lv_timer_handler();
+    }
     if (frame % 200 == 0) {
       lv_mem_monitor_t mon;
       lv_mem_monitor(&mon);

--- a/changelog.d/psp-rpg2k-scene-tree.added.md
+++ b/changelog.d/psp-rpg2k-scene-tree.added.md
@@ -1,0 +1,16 @@
+- **The PSP EBOOT now starts the real `RPG2k` scene tree.** RGSS was already
+  registered the moment `mrb_open()` returned (`libmruby.a`'s gem_init runs
+  every bundled gem, RPG2k included) — nothing was reading it yet.
+  `app/psp/main.cxx` now sets the `GAME_DIR`/`RTP_DIR` mruby constants
+  mruby-rpg2k/mruby-rgss read directly, checks for a project at a fixed
+  Memory Stick install location (`ms0:/PSP/GAME/rpg2k`, matching the EBOOT's
+  own documented install path), and — if `RPG_RT.ldb` is present — constructs
+  `RPG2k` and drives its per-frame `#main_loop` once per C++ loop iteration,
+  the same non-blocking shape the Emscripten build's `rpg_start_game`
+  callback uses (rather than the desktop build's blocking `#start`, since the
+  PSP's own loop has to stay in charge of the process). Construction and a
+  clean-exit-vs-crash exit are reported via new `RPG2K_PSP_GAME_START`
+  (`ok`/`not_found`/`FAILED`) and `RPG2K_PSP_GAME_STOP` (`exit`/`error`)
+  markers, alongside the existing boot/heartbeat ones. RPG Maker XP/VX/VX Ace
+  detection, a configurable `GAME_DIR`, and ADR 0047's P2 (the mruby/LVGL
+  allocator split) remain open — see `app/psp/README.md`.

--- a/docs/adr/0010-psp-port.md
+++ b/docs/adr/0010-psp-port.md
@@ -99,6 +99,14 @@ and CI-checked before the interpreter and assets are layered on:
   until the next slice wires the interpreter and starts the real `RPG2k` scene
   tree. Memory-Stick asset loading (newlib syscalls, already routed by pspsdk's
   stdio) and moving the framebuffer blit onto `sceGu` follow after that.
+  **Update:** that next slice has landed. `libmruby.a` links into the EBOOT
+  and opens (`RPG2K_PSP_MRUBY_OPEN`), and `app/psp/main.cxx` constructs
+  `RPG2k` against a fixed Memory Stick install location
+  (`ms0:/PSP/GAME/rpg2k`) and drives its per-frame `#main_loop` when a
+  project is present there, reporting the outcome via
+  `RPG2K_PSP_GAME_START`/`RPG2K_PSP_GAME_STOP` — see `app/psp/README.md` for
+  the current status and what's still ahead (XP/VX/VX Ace detection, the
+  allocator split, `sceGu`).
 - Because the PSP has ~24 MB of RAM, the gem-trimming and streaming-asset work
   that ADR 7 needs for the Wio Terminal is not expected to be necessary here; the
   full gem set should fit.

--- a/docs/adr/0047-psp-memory-budget.md
+++ b/docs/adr/0047-psp-memory-budget.md
@@ -235,9 +235,14 @@ the interpreter-linking slice, in this order:
   free RAM) and `lv_mem_monitor`'s current-use and `max_used` high-water mark
   for LVGL's pool, once a second, into the same log CI's `psp-smoke` job
   already captures — no interpreter needed to start measuring the HAL's own
-  footprint. What's still missing: a real game database and map exercising
-  this (the bring-up never opens mruby), so the *mruby* share of the pool
-  remains unmeasured on-device until the interpreter-linking slice.
+  footprint. The interpreter-linking and scene-tree slices have since landed
+  too (`RPG2K_PSP_MRUBY_OPEN`, `RPG2K_PSP_GAME_START`) — `app/psp/main.cxx`
+  constructs `RPG2k` and drives it when a project is present at its fixed
+  `kGameDir` (see `app/psp/README.md`). What's still missing: CI's
+  `psp-smoke` job has no project there, so it only ever exercises the idle
+  path — the *mruby* share of the pool remains unmeasured on-device until a
+  real game database and map actually runs there, on real hardware or an
+  emulator with a Memory Stick image.
 - **P1a — done.** Stripped `-g` from `mrbc`'s compile options in the `psp`
   `MRuby::CrossBuild` block (`build_config.rb`), closing Finding 5's one real
   gap; confirmed `-O0` needed no fix (already stripped) and `-g3` needed none


### PR DESCRIPTION
## Summary

PR #774 linked `libmruby.a` into the PSP EBOOT and opened an mruby interpreter, but registered no RGSS methods and started no game. This slice finishes that: `app/psp/main.cxx` now constructs and drives the real `RPG2k` scene tree.

- RGSS was already registered the moment `mrb_open()` returned — `libmruby.a`'s gem_init runs every bundled gem's native `Init`, RPG2k included (`build_config.rb`'s `rpg_maker_gems`, same as every other target). Nothing extra needed to wire it in.
- `main.cxx` sets `GAME_DIR`/`RTP_DIR` — load-bearing mruby constants `mruby-rpg2k`/`mruby-rgss`'s own mrblib reads directly (`RPG_RT.ldb`/`.lmt` paths, asset/audio search paths, ...) — the same as every other target's entry point.
- Since the PSP EBOOT has no command line and no runtime project loader (unlike desktop's `--game_dir` or the browser build's page loader), `GAME_DIR` is a fixed Memory Stick install location: `ms0:/PSP/GAME/rpg2k`, matching `app/psp/README.md`'s own existing install instructions (one EBOOT, one game, no picker).
- If `RPG_RT.ldb` exists there, constructs `RPG2k.new` and drives its per-frame `#main_loop` once per C++ loop iteration — the same non-blocking shape the Emscripten build's `rpg_start_game` callback uses (not the desktop build's blocking `#start`), since the PSP's own `main()` loop has to stay in charge of the process (heartbeat, HOME-button exit callback). `#main_loop` calls `Graphics.update` itself, which flushes LVGL and polls the pad (`rgss_psp_poll`) — so the idle-loop's `lv_timer_handler()`/pad-scanning only run while no game is active.
- Construction and a clean-exit-vs-crash exit are reported via two new markers: `RPG2K_PSP_GAME_START ok`/`not_found`/`FAILED` and `RPG2K_PSP_GAME_STOP exit`/`error` (the latter distinguishes a clean `Kernel#exit`, e.g. RPG_RT's title "Shutdown" command, from an actual crash via `MRB_EXC_EXIT_P`).
- ADR 0010 and ADR 0047 updated to reflect this landing; `app/psp/README.md` rewritten throughout (status, what runs today, markers, "not yet wired," memory budget).

Out of scope for this slice (see `app/psp/README.md`'s "Not yet wired"): RPG Maker XP/VX/VX Ace detection (only `RPG_RT.ldb` is checked, matching ADR 0010's stated scope), a configurable `GAME_DIR`, and ADR 0047's P2 (the mruby/LVGL allocator split) — that still needs real on-device numbers from an actual game running at `kGameDir`, which CI's `psp-smoke` job doesn't have (no project deployed there, so it only ever exercises the idle path).

## Verification

Still no real `psp-gcc` in this environment, but this sandbox does have `gcc`/`ruby`/`rake`, so more was directly verifiable than in earlier PSP PRs:

- **The new mruby C API calls** (`mrb_const_set`, `mrb_obj_new`, `mrb_class_get`, `mrb_ary_new`, `mrb_gc_register`, `mrb_funcall`, `MRB_EXC_EXIT_P`, ...) were syntax-checked against a *real* generated `mruby/presym/id.h`, produced by actually running `build_config.rb` through `rake` for the host target in this sandbox (downloaded the same CP932/JIS0208 Unicode tables CI needs, initialized the remaining submodules) — not guessed against documentation.
- That same real rake run compiled `mruby-rgss/src/lib.cxx`, `psp.cxx`, `psp_input_bridge.cxx` and all of `mruby-rpg2k`'s sources/mrblib cleanly through the real build pipeline (it only stops short of a full host build at `mruby-mvjs`, which needs the `quickjs` submodule this session didn't need to init).
- `clang-format` reports no diff on `main.cxx`.
- `ruby -c` on the touched Ruby files.

## Test plan

- [x] mruby C API usage syntax-checked against a real generated presym header from an actual host mruby build
- [x] `mruby-rgss`/`mruby-rpg2k` sources confirmed to still compile cleanly through the real rake pipeline
- [x] `clang-format` reports no diff on `main.cxx`
- [ ] CI `psp` job (cannot cross-compile for PSP in this environment) — confirms the actual MIPS/pspdev compile
- [ ] CI `psp-smoke` job — boots the EBOOT under PPSSPP and checks for `RPG2K_PSP_GAME_START not_found` (no project deployed there), proving the new code path doesn't break the idle boot
- [ ] A real on-device/PPSSPP run with an actual RPG2k project at `ms0:/PSP/GAME/rpg2k` — needs real hardware or a Memory Stick image, not available in this environment

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaTSJ4i2Lwxi3VAV2DEr5D)_