### PR TITLE
Decode RPG2003's Key Input Processing Numbers/Operators flags

### DIFF
--- a/changelog.d/rpg2k-key-input-numbers-operators.added.md
+++ b/changelog.d/rpg2k-key-input-numbers-operators.added.md
@@ -1,0 +1,10 @@
+- **Key Input Processing** (11610) now decodes RPG2003's own Numbers /
+  Operators parameter layout (`db.rpg2003?`-gated, since it reuses the same
+  param5/param6 slots RPG2000 1.50+ uses for Shift and the arrows) into the
+  request's accepted-key set, instead of silently ignoring those params. The
+  two flags are decoded but not yet actionable — `RGSS::Input` models a fixed
+  console/keyboard button set with no numeric-keypad or operator keys to
+  sample, so a Numbers/Operators-only request can never resolve; other
+  accepted keys in the same request (Decision, Cancel, arrows, Shift) are
+  unaffected. Mouse input (Maniac) remains fully out of scope. Covered by new
+  checks in `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -513,7 +513,14 @@ The work below is roughly ordered by the critical path to a walkable game
   Processing** waits for (or, in no-wait mode, samples) a chosen set of buttons
   and writes the pressed key's RPG2000 code to a variable — the scene drives it
   for foreground and parallel events alike, following RPG_RT's pre-1.50 /
-  1.50+ parameter layouts (number / operator keys and mouse are not modelled). **Change Actor
+  1.50+ parameter layouts, and now also decodes RPG2003's own Numbers /
+  Operators layout (`db.rpg2003?`-gated, since it reuses the same param slots
+  RPG2000 1.50+ gives Shift and the arrows) into the request's accepted-key
+  set. 🚧 Those two flags are decoded but not yet actionable: `RGSS::Input`
+  models a fixed console/keyboard button set with no numeric-keypad or
+  operator keys to sample, so a Numbers/Operators-only request can never
+  resolve — mouse input (Maniac) stays fully out of scope the same way.
+  **Change Actor
   Name / Title / Sprite** rename a party actor, set its status-screen title or
   swap its CharSet graphic (the scene reloads the leader's on-screen sprite);
   these edits survive Save / Continue. **Set Transparent Flag** hides or shows

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1191,29 +1191,59 @@ module Game
 
     # Key Input Processing (11610): wait for — or, in no-wait mode, sample — one
     # of a chosen set of buttons and store its RPG2000 code in a variable. The
-    # parameter layout matches RPG_RT and depends on the command's length:
+    # parameter layout matches RPG_RT and depends on the command's length and,
+    # for the param5/param6 slot, on whether the database is RPG2000 or
+    # RPG2003 (`@state.party.rpg2003?`) — the two editions disagree on what
+    # those two params mean:
     #   param0            target variable id
     #   param1            wait flag (0 = read this frame and continue)
-    #   param2            (pre-1.50 only) accept all four arrows when non-zero
+    #   param2            (pre-1.50, or RPG2003's Numbers/Operators layout)
+    #                     accept all four arrows when non-zero
     #   param3 / param4   accept Decision (OK) / Cancel — always present
-    #   param5..param9    (1.50+) accept Shift / Down / Left / Right / Up
-    # The interpreter only records the request and suspends on a :key_input wait;
-    # the owning scene samples real input (triggered edges when waiting, held
-    # state otherwise) and calls resume_key_input with the resulting code. Number
-    # and operator keys (RPG2003) and the mouse (Maniac) are not modelled.
+    #   param5..param9    (RPG2000 1.50+, or an RPG2000 command carried
+    #                     unchanged into an RPG2003 project — always a
+    #                     10-param command either way) accept Shift / Down /
+    #                     Left / Right / Up
+    #   param5 / param6   (RPG2003's own Numbers/Operators layout — any other
+    #                     length on an RPG2003 database) accept the numeric
+    #                     keypad (0-9) / the five operator keys (+ - * / .) as
+    #                     a whole; RPG_RT does not offer individual per-key
+    #                     flags here, only through the Maniac Patch's own
+    #                     further-extended param list (out of scope, see
+    #                     below). param7/param8 are a separate "timed input"
+    #                     countdown-variable feature, still unmodelled.
+    # The interpreter only records the request and suspends on a :key_input
+    # wait; the owning scene samples real input (triggered edges when waiting,
+    # held state otherwise) and calls resume_key_input with the resulting code.
+    # Numbers/Operators are decoded into `accepted` but not yet actionable: the
+    # input layer (RGSS::Input) models a fixed console/keyboard button set with
+    # no numeric-keypad or operator keys to sample, so a request that accepts
+    # only Numbers/Operators can never resolve — same as the mouse (Maniac),
+    # which stays fully unmodelled.
     def do_key_input(cmd)
       var_id = cmd.param(0)
       wait = cmd.param(1) != 0
+      size = cmd.parameters.size
       accepted = { decision: cmd.param(3) != 0, cancel: cmd.param(4) != 0,
                    shift: false, down: false, left: false, right: false,
-                   up: false }
-      if cmd.parameters.size < 6
+                   up: false, numbers: false, operators: false }
+      if @state.party.rpg2003? && size != 10
+        # RPG2003's Numbers/Operators layout: still a single flag for the
+        # whole D-pad, not the individual Shift/arrows RPG2000 1.50+ offers.
+        if size < 10 && cmd.param(2) != 0
+          accepted[:down] = accepted[:left] = true
+          accepted[:right] = accepted[:up] = true
+        end
+        accepted[:numbers] = cmd.param(5) != 0
+        accepted[:operators] = cmd.param(6) != 0
+      elsif size < 6
         # Pre-1.50: a single flag enables the whole D-pad, no Shift.
         if cmd.param(2) != 0
           accepted[:down] = accepted[:left] = true
           accepted[:right] = accepted[:up] = true
         end
       else
+        # RPG2000 1.50+, or that same layout carried into an RPG2003 project.
         accepted[:shift] = cmd.param(5) != 0
         accepted[:down]  = cmd.param(6) != 0
         accepted[:left]  = cmd.param(7) != 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7095,6 +7095,44 @@ check 'Key Input Proc accepts only the chosen keys' do
   eq 0, it.key_input_result([:cancel, :up, :down]), 'unlisted keys ignored'
 end
 
+check 'Key Input Proc (RPG2003 Numbers/Operators layout) decodes the two flags' do
+  st = new_state(rpg2003: true)
+  it = Game::Interpreter.new(st)
+  # 9 params: var, wait, arrows-all, decision, cancel, numbers, operators,
+  # time-var (unused here), timed (unused here) -- RPG2003's own layout,
+  # distinct from the 10-param RPG2000 1.50+ Shift/arrows layout that reuses
+  # the same param5/param6 slots for something else entirely.
+  it.start([FakeCmd.new(IC::KEY_INPUT_PROC, [1, 1, 1, 1, 0, 1, 1, 0, 0])])
+  it.update
+  acc = it.key_input_request[:accepted]
+  eq true, acc[:numbers], 'Numbers accepted'
+  eq true, acc[:operators], 'Operators accepted'
+  eq true, acc[:decision]
+  eq false, acc[:cancel]
+  [:down, :left, :right, :up].each { |k| eq true, acc[k], "#{k} on (single arrows-all flag)" }
+  eq false, acc[:shift], 'this layout has no individual Shift, unlike RPG2000 1.50+'
+  # Numbers/Operators are accepted but the input layer has no keys mapped to
+  # them (see Scene::Map::KEY_INPUT_BUTTONS), so the scene can never place
+  # them in the active-key list; key_input_result must not resolve them even
+  # if asked to.
+  eq 0, it.key_input_result([:numbers, :operators])
+  eq 5, it.key_input_result([:decision, :numbers]), 'Decision still resolves alongside them'
+end
+
+check 'Key Input Proc (RPG2003, 10 params) is the imported RPG2000 1.50+ layout, not Numbers/Operators' do
+  st = new_state(rpg2003: true)
+  it = Game::Interpreter.new(st)
+  # An RPG2000 project's Key Input command carried unchanged into an RPG2003
+  # database still has exactly 10 params -- RPG_RT keeps reading it as
+  # Shift/Down/Left/Right/Up, never as Numbers/Operators.
+  it.start([FakeCmd.new(IC::KEY_INPUT_PROC, [1, 1, 0, 1, 1, 1, 1, 1, 1, 1])])
+  it.update
+  acc = it.key_input_request[:accepted]
+  eq true, acc[:shift]
+  eq false, acc[:numbers], 'a 10-param command is the RPG2000 layout, not Numbers/Operators'
+  eq false, acc[:operators]
+end
+
 # -- Show Inn (Stay at Inn) ---------------------------------------------------
 
 check 'Show Inn: staying charges the price and full-heals the party' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -657,7 +657,7 @@ class SlipActor
   def change_mp(delta); @mp = [@mp + delta, 0].max; end
 end
 
-def fake_party(members = [])
+def fake_party(members = [], rpg2003: false)
   # A real Game::Party rather than a stand-in: Scene::Map runs the party through
   # Party#apply_map_step_damage on every walked tile, so the fixture has to
   # answer the real interface. It starts empty -- `system.party` is [] and the
@@ -667,9 +667,13 @@ def fake_party(members = [])
   # `enemy_group` defaults to "every id exists" (Hash.new(true)), the same
   # permissive default the other stub parties in this file use, since these
   # movement/event checks are not exercising the missing-troop-id diagnostic
-  # path (covered in scripts/rpg2k_logic_check.rb instead).
+  # path (covered in scripts/rpg2k_logic_check.rb instead). `rpg2003:` mirrors
+  # Game::Party#rpg2003? (`@db.rpg2003?`) for checks that need the RPG2003
+  # branch of a command's parameter decoding (e.g. Key Input Processing's
+  # Numbers/Operators layout).
   party = Game::Party.new(OpenStruct.new(system: OpenStruct.new(party: []),
-                                          enemy_group: Hash.new(true)))
+                                          enemy_group: Hash.new(true),
+                                          rpg2003?: rpg2003))
   members.each { |m| party.actors << m }
   party
 end
@@ -677,11 +681,11 @@ end
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
               members: [], terrain_damage: 0, bush_depth: 0,
               airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
-              map_tree: nil, test_play: false)
+              map_tree: nil, test_play: false, rpg2003: false)
   db = fake_db(common, troop_pages, terrain_damage, bush_depth,
                airship_land: airship_land, airship_pass: airship_pass,
-               boat_pass: boat_pass, ship_pass: ship_pass)
-  state = Game::State.new(fake_party(members), 1, player[0], player[1])
+               boat_pass: boat_pass, ship_pass: ship_pass, rpg2003: rpg2003)
+  state = Game::State.new(fake_party(members, rpg2003: rpg2003), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   parent = fake_parent(db)
   parent.map_tree = map_tree if map_tree
@@ -2279,6 +2283,29 @@ check 'Key Input Proc ignores keys it was not told to accept' do
   scene.update # resumes and stores the code
   eq 5, st.variables[1]
   scene.update # the following command runs
+  ok st.switches[5]
+end
+
+check 'Key Input Proc (RPG2003 Numbers layout) accepts Decision but Numbers has no key to press' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # RPG2003's own 9-param layout: var, wait, arrows off, decision on, cancel
+  # off, numbers on, operators off, time-var/timed unused. Nothing in
+  # Scene::Map::KEY_INPUT_BUTTONS samples Numbers, so only the Decision press
+  # can ever resume this proc even though the request also accepts Numbers.
+  auto.event_commands = [
+    ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 1, 0, 0, 0]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, rpg2003: true)
+  st = scene.instance_variable_get(:@state)
+  5.times { scene.update } # no key this input layer can sample was pressed
+  eq 0, st.variables[1]
+  ok !st.switches[5]
+  RGSS::Input.triggered = [RGSS::Input::C] # Decision (OK)
+  scene.update # this frame resumes the proc and stores the code
+  eq 5, st.variables[1], 'Decision still resolves even with Numbers also accepted'
+  scene.update # the following command runs once the proc has resumed
   ok st.switches[5]
 end
 


### PR DESCRIPTION
## Summary

- `Game::Interpreter#do_key_input` (event command 11610) previously only decoded RPG2000's pre-1.50 and 1.50+ parameter layouts, silently ignoring RPG2003's own Numbers/Operators layout — which reuses the same `param5`/`param6` slots RPG2000 1.50+ uses for Shift and the arrows. It now decodes those two RPG2003 flags into the request's accepted-key set, gated on `db.rpg2003?` and the command's parameter count to correctly disambiguate a genuine RPG2003 Numbers/Operators command from a 10-param RPG2000 command carried unchanged into an RPG2003 project (both real, distinct cases RPG_RT itself distinguishes).
- The exact parameter layout was verified against EasyRPG Player's real source (`Game_Interpreter::CommandKeyInputProc` / `KeyInputState::CheckInput` in `src/game_interpreter.cpp`, and the `Keys` enum in `src/game_interpreter.h`) rather than guessed — RPG2003 models Numbers/Operators as two composite flags (not one flag per digit/operator), and RPG_RT only offers individual per-direction Shift/arrow flags in that layout through the Maniac Patch's own further-extended parameter list.
- **Scope note:** the two flags are decoded correctly but not yet actionable. This codebase's input layer (`RGSS::Input`) models a fixed console/keyboard button set (arrows, A/B/C/X/Y/Z, L/R, Shift/Ctrl/Alt, F5-F9/F12); the native SDL backend (`src/sdl_input.cxx`) has no numeric-keypad or operator-key bindings at all. So a Key Input request that accepts only Numbers/Operators can never resolve — there is genuinely no key to sample yet, this isn't an oversight. Other accepted keys in the same request (Decision, Cancel, arrows, Shift) are unaffected. Mouse input (Maniac Patch) remains fully out of scope, matching this codebase's existing posture elsewhere.
- Updated `docs/TODO.md`'s Key Input Processing paragraph and the `do_key_input` doc comment to describe the new decoding and the still-open 🚧 follow-up (real keyboard support for numbers/operators).
- Added a `changelog.d/rpg2k-key-input-numbers-operators.added.md` fragment.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 807 checks pass, including two new checks for the RPG2003 Numbers/Operators parameter decoding (the 9-param native layout, and the 10-param "RPG2000 layout imported into RPG2003" disambiguation case).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 538 checks pass, including a new end-to-end check driving a Numbers-accepting Key Input Proc through `Scene::Map`, confirming Decision still resolves it while Numbers (correctly) never can.
- [x] `ruby scripts/label_config_check.rb` — label config OK.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KHV5uASaNwXhEd6wjneK3h)_