### PR TITLE
Fade the screen through an accepted Show Inn stay

### DIFF
--- a/changelog.d/rpg2k-inn-fade.added.md
+++ b/changelog.d/rpg2k-inn-fade.added.md
@@ -1,0 +1,14 @@
+- **Show Inn** (RPG Maker 2000, command 10730) now fades the screen the way
+  real RPG_RT does: accepting a stay — or a free (price 0) stay auto-accepting
+  — fades to black *before* the heal, holds through it, then fades back in,
+  instead of cutting straight from the prompt to the healed party with no
+  transition. `Scene::Map#drive_inn` reuses the same Erase/Show Screen overlay
+  and default 35-frame `FADE_OUT`/`FADE_IN` styles rather than a bespoke fade:
+  new `#start_inn_fade_out` erases the screen the instant Accept is confirmed
+  and parks on a new `@inn_fading_out` sub-state until it settles; `#finish_inn`
+  then charges gold, heals the party and starts the fade back in before
+  resuming the interpreter. Cancel and an ignored (unaffordable) Accept skip
+  the fade entirely, matching real RPG_RT — a declined or unaffordable prompt
+  never fades. Covered by a new `scripts/rpg2k_scene_check.rb` check pinning
+  the exact fade-out/hold/fade-in frame timing, plus fade assertions on the
+  existing cancel and unaffordable-Accept checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -813,7 +813,7 @@ The work below is roughly ordered by the critical path to a walkable game
   party, and either outcome routes into the command's optional `[Stay]` /
   `[No Stay]` handler branches (structured and skipped like Show Choices).
   `Game::Interpreter` owns the gameplay and suspends on an `:inn` wait that
-  `Scene::Map` drives; the inn **fade** is presentation still to come.
+  `Scene::Map` drives.
   ✅ **The inn now plays its own BGM.** `Scene::Map#drive_inn` never touched
   the music at all — staying at an inn played in total silence, or just let
   the field track keep looping, no matter what `db.system.inn_music` named,
@@ -834,6 +834,33 @@ The work below is roughly ordered by the critical path to a walkable game
   field BGM resumes after a prompted stay; a Change System BGM override for
   slot 2 beats the database default; a free stay plays and restores the BGM
   too), confirmed to fail against the pre-fix code before the fix.
+  ✅ **The inn now fades the screen too.** `#drive_inn` never touched
+  `Game::Screen` at all — accepting a stay used to cut straight from the
+  prompt to the healed party with no transition, where real RPG_RT (EasyRPG's
+  `Scene_Map::UpdateInn` / `FinishInn`, reached through the accepted-stay
+  `AsyncOp::eCallInn` continuation `Game_Interpreter_Map::CommandShowInn`
+  returns) fades the screen to black the instant a stay is accepted — before
+  the heal, not after — holds it there while the party is healed, then starts
+  fading back in the same beat, all in the plain FADE_OUT / FADE_IN styles
+  Erase / Show Screen already use at their own default length
+  (`Game::Transition.default_frames`, 35 frames each way), not some
+  inn-specific duration. New `#start_inn_fade_out` erases the screen
+  (`@state.screen.erase(Game::Transition::FADE_OUT)`) the moment Accept is
+  confirmed — or a free (price 0) stay auto-accepts, since it reaches the same
+  `AsyncOp::eCallInn` path in real RPG_RT and fades exactly like a prompted
+  one — and parks `#drive_inn` on a new `@inn_fading_out` sub-state until the
+  erase settles; `#finish_inn` then charges gold, heals the party and starts
+  the fade back in (`@state.screen.show(Game::Transition::FADE_IN)`) before
+  resuming the interpreter, reusing the same overlay sprite Erase/Show Screen
+  already draws through rather than a bespoke fade of its own. Cancel and the
+  insufficient-funds no-op skip `#start_inn_fade_out` entirely and go straight
+  to `#finish_inn(false)`, matching real RPG_RT: a declined or unaffordable
+  prompt never reaches `AsyncOp::eCallInn`, so it never fades. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check pinning the exact 35-frame fade-out /
+  fade-in timing around an accepted stay (fading starts before the gold is
+  charged, holds through the heal, then fades back in), plus fade assertions
+  added to the existing cancel and unaffordable-Accept checks confirming
+  neither ever starts a fade.
   **Open Shop** (10720) is a playable game-mode too: a `Game::Shop` holds the
   goods and buy / sell rules and performs the transactions (buy at the database
   price, sell at half, party 99-item / gold caps enforced), tracking whether

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -159,6 +159,7 @@ class RPG2k
         @message = nil
         @inn_window = nil
         @inn_bgm_started = false
+        @inn_fading_out = false
         @shop = nil
         @battle_ui = nil
         @name_ui = nil
@@ -3711,15 +3712,26 @@ class RPG2k
       # interpreter charges gold and heals the party in resume_inn. The inn's
       # own BGM (#play_inn_bgm) starts the first frame a request is seen and
       # #restore_pre_inn_bgm brings the prior track back once the stay resolves
-      # -- either path, prompted or free.
+      # -- either path, prompted or free. An accepted stay (prompted or free)
+      # additionally fades the screen to black before the heal and back in
+      # after -- see #start_inn_fade_out; Cancel and the insufficient-funds
+      # no-op leave the screen alone, matching real RPG_RT (its inn fade only
+      # runs down the accepted-stay `AsyncOp::eCallInn` path -- a cancelled
+      # prompt never reaches it).
       def drive_inn
         req = @interpreter.inn_request
         return @interpreter.resume_inn(false) unless req
+        if @inn_fading_out
+          return if @state.screen.fading?
+          @inn_fading_out = false
+          finish_inn(true)
+          return
+        end
         unless @inn_bgm_started
           play_inn_bgm
           @inn_bgm_started = true
         end
-        return finish_inn(true) unless req[:prompt]
+        return start_inn_fade_out unless req[:prompt]
 
         if @inn_window.nil?
           open_inn_window(req) # opened this frame; take input from the next one
@@ -3738,7 +3750,7 @@ class RPG2k
             # Accept: only honoured when the party can pay; otherwise ignored.
             if req[:can_afford]
               close_inn_window
-              finish_inn(true)
+              start_inn_fade_out
             end
           else
             close_inn_window
@@ -3750,11 +3762,33 @@ class RPG2k
         end
       end
 
+      # Begin the accepted-stay fade to black (Erase Screen's own FADE_OUT
+      # style, its default 35-frame length) and park in the :inn wait until it
+      # settles -- #drive_inn's `@inn_fading_out` branch above resumes it and
+      # calls #finish_inn once the screen is fully black. A screen already
+      # erased (e.g. an event faded to black right before the Show Inn command)
+      # is a no-op transition, per #Game::Screen#erase, so it resolves at once
+      # exactly like Erase Screen onto Erase Screen does.
+      def start_inn_fade_out
+        @state.screen.erase(Game::Transition::FADE_OUT)
+        if @state.screen.fading?
+          @inn_fading_out = true
+        else
+          finish_inn(true)
+        end
+      end
+
       # Restore the pre-inn BGM and resume the interpreter with the player's
       # stay/no-stay decision -- the common tail of every #drive_inn exit path.
+      # An accepted stay also starts the fade back in (Show Screen's FADE_IN
+      # style) here, the same frame the heal happens in resume_inn -- like real
+      # RPG_RT's FinishInn, the fade-in only starts, it does not block: the
+      # interpreter resumes immediately below and the screen brightens over the
+      # following frames while the game keeps running.
       def finish_inn(stayed)
         @inn_bgm_started = false
         restore_pre_inn_bgm
+        @state.screen.show(Game::Transition::FADE_IN) if stayed
         @interpreter.resume_inn(stayed)
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2150,19 +2150,57 @@ check 'Show Inn scene: accepting heals the party, spends gold, runs Stay branch'
   5.times { scene.update } # inn command runs; the greeting prompt opens
   ok !st.switches[1] && !st.switches[2], 'still waiting on the prompt'
   RGSS::Input.triggered = [RGSS::Input::C] # cursor starts on Accept (affordable)
-  scene.update # resumes with a stay
-  scene.update # runs the Stay branch
-  eq 900, st.party.gold, 'the price was deducted'
+  scene.update # accept: fades the screen to black instead of resuming at once
+  ok st.screen.fading?, 'the accepted stay fades out before the heal'
+  eq 1000, st.party.gold, 'not charged yet -- the heal waits for the fade to land'
+  40.times { scene.update } # drain the fade-out (35 frames) and the Stay branch after
+  eq 900, st.party.gold, 'the price was deducted once the screen went black'
   eq st.party.actors.first.max_hp, st.party.actors.first.hp, 'party healed'
   ok st.switches[1], 'the Stay branch ran'
   ok !st.switches[2], 'the No Stay branch was skipped'
 end
 
-check 'Show Inn scene: cancelling with B spends nothing and runs No Stay' do
+check 'Show Inn scene: an accepted stay fades to black, holds through the heal, ' \
+      'then fades back in over the RPG_RT default 35 frames' do
+  # Real RPG_RT (EasyRPG's Scene_Map::UpdateInn / FinishInn, the async
+  # eCallInn path CommandShowInn's accepted-stay continuation triggers) fades
+  # out the instant a stay is accepted -- before the heal, not after -- holds
+  # black while the party is healed, then starts the fade back in the same
+  # beat, all in the plain FADE_OUT / FADE_IN styles Erase/Show Screen use at
+  # their own default length (Game::Transition.default_frames), not some
+  # inn-specific duration.
+  eq 35, Game::Transition.default_frames(Game::Transition::FADE_OUT)
+  eq 35, Game::Transition.default_frames(Game::Transition::FADE_IN)
+
+  scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
+  5.times { scene.update } # inn command runs; the greeting prompt opens
+  RGSS::Input.triggered = [RGSS::Input::C] # cursor starts on Accept (affordable)
+  scene.update # accept: the fade-out starts this same frame, not an immediate resume
+  ok st.screen.fading?, 'fading out the instant the stay is accepted'
+  eq 1000, st.party.gold, 'not charged yet -- the heal waits for the fade to land'
+  34.times { scene.update } # the remaining fade-out frames (35 total)
+  ok st.screen.fading?, 'one frame short of the fade-out landing, still holding'
+  eq 1000, st.party.gold, 'still not charged -- the screen has not gone fully black yet'
+  scene.update # the 35th fade-out frame: lands fully black, heals, starts the fade back in
+  eq 900, st.party.gold, 'charged the moment the screen went fully black'
+  eq st.party.actors.first.max_hp, st.party.actors.first.hp, 'healed the same frame'
+  ok st.screen.fading?, 'the fade back in starts immediately, not a separate wait'
+  34.times { scene.update } # the fade-in's own remaining frames (35 total)
+  ok st.screen.fading?, 'one frame short of the fade-in landing'
+  scene.update # the fade-in's 35th frame lands fully visible again
+  ok !st.screen.fading?, 'the fade-in has landed'
+  eq 0, st.screen.fade_level, 'screen fully visible again'
+end
+
+check 'Show Inn scene: cancelling with B spends nothing, runs No Stay, and never fades' do
   scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 100))
   5.times { scene.update }
+  eq 0, st.screen.fade_level, 'screen fully visible while the prompt is up'
   RGSS::Input.triggered = [RGSS::Input::B]
   scene.update # resumes with no stay
+  ok !st.screen.fading?, 'a cancelled stay never starts a fade -- real RPG_RT never reaches ' \
+                         'its eCallInn path when the prompt is declined'
+  eq 0, st.screen.fade_level, 'still fully visible'
   scene.update # runs the No Stay branch
   eq 1000, st.party.gold, 'no gold spent on cancel'
   eq 1, st.party.actors.first.hp, 'no healing on cancel'
@@ -2180,6 +2218,7 @@ check 'Show Inn scene: an unaffordable Accept is ignored' do
   3.times { scene.update }
   ok !st.switches[1] && !st.switches[2], 'Accept is inert while unaffordable'
   eq 50, st.party.gold, 'no gold spent'
+  ok !st.screen.fading?, 'an ignored Accept never starts a fade either'
   # Cancel still works.
   RGSS::Input.triggered = [RGSS::Input::B]
   scene.update
@@ -2211,9 +2250,10 @@ check 'Show Inn scene: inn BGM plays on entry, field BGM resumes after a stay' d
   eq 'InnBGM', st.current_bgm[:name], 'and is now the tracked current BGM'
   RGSS::Audio.reset_bgm
   RGSS::Input.triggered = [RGSS::Input::C] # cursor starts on Accept (affordable)
-  scene.update # resumes with a stay
+  scene.update # accept: starts the fade-out, the BGM swap waits for it to land
+  35.times { scene.update } # drain the 35-frame fade-out
   eq [['Field', 100, 100]], RGSS::Audio.bgm_calls,
-     'the field BGM that was playing before the stay replays once it resolves'
+     'the field BGM that was playing before the stay replays once the fade lands'
   eq 'Field', st.current_bgm[:name]
 end
 
@@ -2233,12 +2273,17 @@ check 'Show Inn scene: a free stay (price 0) still plays and restores the inn BG
   scene, st = inn_scene(1000, inn_commands(Game::Interpreter::Cmd, 0)) # price 0 skips the prompt
   st.current_bgm = { name: 'Field', volume: 100, tempo: 100 }
   RGSS::Audio.reset_bgm
-  # No greeting window opens for a free stay, so this reaches both the BGM
-  # swap and the resolved Stay branch in a few frames of ordinary event
-  # processing (unlike the priced-prompt tests, no player input is needed).
+  # No greeting window opens for a free stay, so this reaches the inn BGM in a
+  # couple of frames of ordinary event processing (unlike the priced-prompt
+  # tests, no player input is needed) -- but a free stay still auto-accepts,
+  # so it still fades to black (35 frames) before the field BGM restores and
+  # the resolved Stay branch runs, same as a prompted Accept.
   3.times { scene.update }
+  eq [['InnBGM', 75, 105]], RGSS::Audio.bgm_calls, 'the inn BGM played'
+  ok st.screen.fading?, 'a free stay auto-accepts, so it fades out too'
+  40.times { scene.update } # drain the fade-out (35 frames) and the Stay branch after
   eq [['InnBGM', 75, 105], ['Field', 100, 100]], RGSS::Audio.bgm_calls,
-     'the inn BGM played, then the field BGM was restored, in the same beat'
+     'the field BGM was restored once the fade landed'
   eq 'Field', st.current_bgm[:name]
   ok st.switches[1], 'the Stay branch ran (a free stay always stays)'
 end


### PR DESCRIPTION
## Summary

- `docs/TODO.md`'s Show Inn writeup called out "the inn **fade** is presentation still to come" — this fills that gap.
- Real RPG_RT (EasyRPG's `Scene_Map::UpdateInn` / `FinishInn`, reached through the accepted-stay `AsyncOp::eCallInn` path `Game_Interpreter_Map::CommandShowInn`'s continuation returns) fades the screen to black the instant a stay is accepted — before the heal, not after — holds while the party is healed, then starts fading back in, all in the plain FADE_OUT / FADE_IN styles Erase/Show Screen already use at their own default length (35 frames each way), not some inn-specific duration. A free (price 0, no-prompt) stay auto-accepts and fades the same way; Cancel and an ignored (unaffordable) Accept never reach `AsyncOp::eCallInn`, so they never fade.
- New `Scene::Map#start_inn_fade_out` erases the screen (`@state.screen.erase(Game::Transition::FADE_OUT)`) the moment Accept is confirmed (or a free stay auto-accepts) and parks `#drive_inn` on a new `@inn_fading_out` sub-state until it settles. `#finish_inn` then charges gold, heals the party and starts the fade back in (`@state.screen.show(Game::Transition::FADE_IN)`) before resuming the interpreter — reusing the exact same Erase/Show Screen overlay sprite rather than a bespoke fade mechanism.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 539 checks passed, including a new check pinning the exact fade-out/hold/fade-in frame timing around an accepted stay, plus fade assertions added to the existing cancel and unaffordable-Accept checks.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 805 checks passed (unaffected; interpreter-level inn logic untouched).
- [ ] `cmake --build build -t test` — not run in this sandbox: the native build requires SDL2 and the nix-managed toolchain (`nix` is unavailable here, and `cmake` configure fails on the missing `SDL2Config.cmake`).
- [x] `pre-commit` (`trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`) run against the touched files — all pass. (`clang-format`/`cmake-format`/`nixfmt` don't apply to any file in this diff; `nixfmt`'s own hook environment couldn't install in this sandbox — no `cabal` — but it never matches here.)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0152A6JAiiMKCbFurouxzWVz)_