### PR TITLE
psp: start RPG Maker XP and VX/VX Ace, not just RPG2k

### DIFF
--- a/app/psp/README.md
+++ b/app/psp/README.md
@@ -1,6 +1,7 @@
 # PSP EBOOT
 
-A pspdev/CMake target that runs the RPG2k runtime on the Sony
+A pspdev/CMake target that runs the RPG Maker 2000/2003/XP/VX/VX Ace runtimes
+on the Sony
 [PlayStation Portable](https://en.wikipedia.org/wiki/PlayStation_Portable)
 (Allegrex: MIPS32 R4000 @ 222/333 MHz, ~24 MB usable RAM, 480×272 LCD, D-pad +
 analog stick + ✕○△□/L/R/Start/Select, Memory Stick).
@@ -9,13 +10,14 @@ This is additive to and independent of the desktop CMake build — building the
 EBOOT does not touch the desktop/wasm builds, and vice versa. The design is in
 [`docs/adr/0010-psp-port.md`](../../docs/adr/0010-psp-port.md).
 
-## Status: HAL bring-up + the real RPG2k scene tree
+## Status: HAL bring-up + the real RPG2k/XP/VX/VX Ace scene tree
 
 This CMake project builds an EBOOT that opens an mruby interpreter and, if a
-project is present at its fixed Memory Stick install location, constructs and
-drives the real `RPG2k` scene tree. It exists to prove the HAL, libmruby.a and
-now RGSS itself compile, link and actually run a game on the console (and to
-get real EBOOT size numbers from CI).
+project is present at its fixed Memory Stick install location, detects which
+maker it is for (RPG2k, RPG XP, or RPG VX / VX Ace) and constructs and drives
+the real scene tree. It exists to prove the HAL, libmruby.a and now RGSS
+itself compile, link and actually run a game on the console (and to get real
+EBOOT size numbers from CI).
 
 What runs today:
 
@@ -23,32 +25,45 @@ What runs today:
   mode flushing to the 480×272 framebuffer via `sceDisplay` (accounting for the
   512-pixel line stride); the LVGL tick/delay source from the pspsdk system
   timer; and a scan of the D-pad, analog stick and ✕○△□ buttons into a bitmask.
-  Built as part of `libmruby.a` (the `psp` mruby cross-build compiles the whole
-  `mruby-rgss` gem, self-guarded on `PSP_BUILD`), not compiled into the EBOOT
-  directly — `app/psp/CMakeLists.txt` links the archive in instead.
+  The display is created at whichever maker's project was detected (see
+  below) at *its own* native resolution, not the panel's — the flush callback
+  centers that logical canvas on the panel and clips every row to its actual
+  480×272 bounds, so a canvas smaller than the panel (RPG2k's 320×240) is
+  letterboxed and one larger than the panel in both dimensions (RPG XP's
+  640×480, RPG VX/VX Ace's 544×416 — both designed for a desktop window, not
+  a handheld LCD) shows only a same-scale, centered window onto the game's
+  own screen; content outside that window still runs correctly but is not
+  drawn. Built as part of `libmruby.a` (the `psp` mruby cross-build compiles
+  the whole `mruby-rgss` gem, self-guarded on `PSP_BUILD`), not compiled into
+  the EBOOT directly — `app/psp/CMakeLists.txt` links the archive in instead.
   `mruby-rgss/src/psp_input_bridge.cxx` polls the pad into `RGSS::Input`
   press/release events (`rgss_psp_poll`) once per frame from
   `Graphics.update`, so RGSS input needs no help from `main()`.
 - `app/psp/main.cxx` — a pspsdk sketch (module metadata + HOME-exit callback)
-  that draws a status screen, echoes the pressed keys while idle, and opens
-  the interpreter (`mrb_open`, reported via the `RPG2K_PSP_MRUBY_OPEN`
-  marker). RGSS is already registered the moment `mrb_open()` returns —
-  `libmruby.a`'s gem_init runs every bundled gem's native `Init`, RPG2k
+  that probes `kGameDir` for a project (mirroring `src/main.cxx`'s
+  `is_rpgvx_game`/`is_xp_game` maker-detection predicates and dispatch
+  order), creates the display at that maker's native resolution (or the
+  panel's own 480×272 if none matched, the idle bring-up path), draws a
+  status screen that echoes the pressed keys while idle, and opens the
+  interpreter (`mrb_open`, reported via the `RPG2K_PSP_MRUBY_OPEN` marker).
+  RGSS is already registered the moment `mrb_open()` returns — `libmruby.a`'s
+  gem_init runs every bundled gem's native `Init`, `RPG2k`/`RPGXP`/`RPGVX`
   included, the same as every other target (see `build_config.rb`'s
   `rpg_maker_gems`) — so nothing extra wires it in. `main.cxx` sets the
-  `GAME_DIR`/`RTP_DIR` mruby constants mruby-rpg2k/mruby-rgss read directly,
-  and if `RPG_RT.ldb` exists there, constructs `RPG2k.new` and drives its
-  per-frame `#main_loop` once per C++ loop iteration instead of the desktop
-  build's blocking `#start` — the same non-blocking shape the Emscripten
-  build's `rpg_start_game` callback uses, since here too the *host* loop, not
-  mruby, has to stay in charge of the process (heartbeat, HOME-button exit
-  callback). `#main_loop` calls `Graphics.update` itself, which flushes LVGL
-  and polls the pad, so `main()`'s own `lv_timer_handler()`/pad-scanning only
-  run while idle (no project found, or construction failed). Construction and
-  a clean-exit-vs-crash exit are reported via the `RPG2K_PSP_GAME_START` and
-  `RPG2K_PSP_GAME_STOP` markers below. mruby still opens with its own default
-  allocator (plain `malloc`), not routed through `lv_malloc` — ADR 0047's P2
-  remains open (see "Not yet wired").
+  `GAME_DIR`/`RTP_DIR` mruby constants the game gems' own mrblib read
+  directly, and if a project was detected, constructs the matching class and
+  drives its per-frame `#main_loop` once per C++ loop iteration instead of
+  the desktop build's blocking `#start` — the same non-blocking shape the
+  Emscripten build's `rpg_start_game` callback uses, since here too the
+  *host* loop, not mruby, has to stay in charge of the process (heartbeat,
+  HOME-button exit callback). `#main_loop` calls `Graphics.update` itself,
+  which flushes LVGL and polls the pad, so `main()`'s own
+  `lv_timer_handler()`/pad-scanning only run while idle (no project found, or
+  construction failed). Construction and a clean-exit-vs-crash exit are
+  reported via the `RPG2K_PSP_GAME_START` and `RPG2K_PSP_GAME_STOP` markers
+  below. mruby still opens with its own default allocator (plain `malloc`),
+  not routed through `lv_malloc` — ADR 0047's P2 remains open (see "Not yet
+  wired").
 - `app/psp/lv_conf.h` — a PSP-tuned LVGL config (RGB565, a few-MB heap, no SIMD
   asm).
 
@@ -65,18 +80,18 @@ cmake --build build-psp          # -> build-psp/EBOOT.PBP
 
 Run `EBOOT.PBP` under an emulator such as
 [PPSSPP](https://www.ppsspp.org/), or copy it, together with an RPG Maker
-2000/2003 project's files, to a Memory Stick at
+2000/2003, XP, or VX/VX Ace project's files, to a Memory Stick at
 `ms0:/PSP/GAME/rpg2k/EBOOT.PBP` on a homebrew-enabled console — that fixed
-path is where `app/psp/main.cxx`'s `kGameDir` looks for `RPG_RT.ldb`. There is
-no in-app project picker: one EBOOT install is one game. RPG Maker XP/VX/VX
-Ace projects aren't detected yet (see "Not yet wired").
+path is where `app/psp/main.cxx`'s `kGameDir` looks for a project. There is
+no in-app project picker: one EBOOT install is one game.
 
 The EBOOT writes five markers via `sceIoWrite` — `RPG2K_PSP_BOOT` once at
 startup (a libc-free string literal); `RPG2K_PSP_MRUBY_OPEN ok` (or `FAILED`)
-right after `mrb_open()`; `RPG2K_PSP_GAME_START ok`/`not_found`/`FAILED`
-after attempting to construct `RPG2k` from `kGameDir`; `RPG2K_PSP_GAME_STOP
-exit`/`error` if a running game later raises (a clean `Kernel#exit` vs. an
-actual crash); and `RPG2K_PSP_BRINGUP
+right after `mrb_open()`; `RPG2K_PSP_GAME_START <maker> ok`/`not_found`/
+`FAILED` after attempting to construct the detected maker's class from
+`kGameDir` (`<maker>` is `RPG2k`/`RPGXP`/`RPGVX`, or `none` when nothing
+matched); `RPG2K_PSP_GAME_STOP exit`/`error` if a running game later raises
+(a clean `Kernel#exit` vs. an actual crash); and `RPG2K_PSP_BRINGUP
 frame=N free=N maxfree=N lvgl_used=N lvgl_max=N` once a second, the last four
 fields being `sceKernelTotalFreeMemSize`/`sceKernelMaxFreeMemSize` (the
 device's actual free RAM) and `lv_mem_monitor`'s current/high-water-mark use
@@ -87,7 +102,8 @@ once one is deployed to `kGameDir` instead of just the idle HAL's. CI's
 `psp-smoke` job boots the EBOOT under PPSSPP headless and checks that a
 marker appears, so a regression that links but fails to boot is caught
 automatically; it has no project at `kGameDir`, so it only ever exercises the
-idle path (`RPG2K_PSP_GAME_START not_found`). The job is **non-blocking**:
+idle path (`RPG2K_PSP_GAME_START none not_found`). The job is
+**non-blocking**:
 PPSSPP only partially implements
 pspsdk's libc stdio (plain `printf` is an unimplemented HLE import there), so
 emulator capture can be fragile — the required build gate is the `psp` job. To
@@ -102,13 +118,15 @@ PPSSPPHeadless --log --graphics=software --timeout=15 EBOOT.PBP
 
 The pieces below are scaffolded but **not** part of the EBOOT yet:
 
-- **RPG Maker XP / VX / VX Ace detection.** `kGameDir` in `app/psp/main.cxx`
-  only ever checks for `RPG_RT.ldb` (RPG2k) — ADR 0010 scopes the PSP port to
-  "starting the real RPG2k scene tree". The desktop/Emscripten maker-detection
-  chain (`is_rpgvx_game`/`is_xp_game` in `src/main.cxx`) is the pattern to
-  follow once this path is proven; `RPGXP`/`RPGVX` are already linked into
-  `libmruby.a` the same way `RPG2k` is (`rpg_maker_gems`), just never
-  constructed here.
+- **Full-canvas scaling for RPG XP / VX / VX Ace.** Their native resolutions
+  (640×480, 544×416) are both larger than the 480×272 panel in *both*
+  dimensions — they were designed for a resizable desktop window, not a
+  fixed handheld LCD. `psp.cxx`'s flush callback currently centers a
+  same-scale window onto the game's own canvas rather than resampling it
+  down to fit, so content near an edge of the game's screen is never drawn.
+  Real per-pixel resampling (or GPU-accelerated scaling once `sceGu` lands,
+  see below) would show the whole screen at once, at the cost of real
+  per-frame CPU work this bring-up has not attempted or profiled.
 - **A configurable `GAME_DIR`.** The Memory Stick path is a fixed constant
   (`ms0:/PSP/GAME/rpg2k`), matching one-EBOOT-one-game — there is no
   equivalent of the desktop build's `--game_dir` flag or the browser build's
@@ -121,7 +139,8 @@ The pieces below are scaffolded but **not** part of the EBOOT yet:
   real on-device numbers from an actual game running at `kGameDir` first (see
   "Memory budget" below).
 - **Accelerated rendering.** The bring-up flushes with a CPU `memcpy` into the
-  framebuffer. Moving the blit onto the `sceGu` GPU is a later optimisation.
+  framebuffer. Moving the blit onto the `sceGu` GPU is a later optimisation,
+  and the natural place to also do real scaling (above) instead of clipping.
 
 ## Memory budget
 

--- a/app/psp/main.cxx
+++ b/app/psp/main.cxx
@@ -1,5 +1,5 @@
-// PlayStation Portable EBOOT entry point -- HAL bring-up plus the real RPG2k
-// scene tree.
+// PlayStation Portable EBOOT entry point -- HAL bring-up plus the real
+// RPG2k/XP/VX/VX Ace scene tree.
 //
 // This slice proves the HAL compiles and runs on the PSP and that libmruby.a
 // (built for the psp target by build_config.rb, linked in via
@@ -7,19 +7,36 @@
 // stands up the LVGL display (psp_display_create), scans the pad
 // (psp_input_scan), draws a small status screen that echoes the pressed keys,
 // opens an mruby interpreter (mrb_open), and -- if a project is present at
-// kGameDir -- constructs RPG2k and drives its per-frame #main_loop the same
-// way the Emscripten build drives it from rpg_start_game's callback (mruby's
-// gems are already registered the moment mrb_open() returns; nothing extra
-// wires RGSS in, since libmruby.a's gem_init runs every bundled gem, RPG2k
-// included -- see build_config.rb's rpg_maker_gems). main() owns the loop and
-// pumps LVGL once per iteration when no game is running, and through
-// RPG2k#main_loop's own Graphics.update (which flushes LVGL and polls the pad
-// via rgss_psp_poll, mruby-rgss/src/psp_input_bridge.cxx) once one is -- the
-// same "host owns the loop" shape the Emscripten and Wio builds use. Its
-// per-second heartbeat also reports real free-memory and LVGL-pool numbers
-// (see the RPG2K_PSP_BRINGUP marker below), which is ADR 0047's P1: measuring
-// the HAL's own footprint on real hardware/an emulator, now against a real
+// kGameDir -- constructs the detected maker's game class (RPG2k/RPGXP/RPGVX)
+// and drives its per-frame #main_loop the same way the Emscripten build
+// drives it from rpg_start_game's callback (mruby's gems are already
+// registered the moment mrb_open() returns; nothing extra wires RGSS in,
+// since libmruby.a's gem_init runs every bundled gem -- see
+// build_config.rb's rpg_maker_gems). main() owns the loop and pumps LVGL
+// once per iteration when no game is running, and through the game's own
+// Graphics.update (which flushes LVGL and polls the pad via rgss_psp_poll,
+// mruby-rgss/src/psp_input_bridge.cxx) once one is -- the same "host owns
+// the loop" shape the Emscripten and Wio builds use. Its per-second
+// heartbeat also reports real free-memory and LVGL-pool numbers (see the
+// RPG2K_PSP_BRINGUP marker below), which is ADR 0047's P1: measuring the
+// HAL's own footprint on real hardware/an emulator, now against a real
 // game's usage once one is present at kGameDir instead of just the idle HAL.
+//
+// The display is created at each maker's *native* logical resolution
+// (RPG2k 320x240, RPGXP 640x480, RPGVX/VX Ace 544x416 -- matching
+// RPGXP_WIDTH/RPGVX_WIDTH in src/main.cxx), not the PSP panel's fixed
+// 480x272: RGSS::Graphics.width/height and everything the game draws derive
+// directly from the LVGL display's own resolution
+// (lv_display_get_horizontal_resolution in mruby-rgss/src/lib.cxx), so
+// creating it at the panel's resolution instead would silently distort
+// every game's own coordinate math. mruby-rgss/src/psp.cxx centers that
+// logical canvas on the panel and clips whatever falls outside it -- for
+// RPG2k, comfortably smaller than the panel in both dimensions, that is
+// just letterboxing; for RPGXP/RPGVX, both larger than the panel in both
+// dimensions (they were designed for a desktop window), that means only a
+// same-scale, centered *window* onto the game's own screen is ever visible
+// -- a real, known limitation (not full-canvas scaling, which this bring-up
+// does not attempt), not a correctness or memory-safety one.
 //
 // mrb_open() here uses mruby's own default allocator (plain malloc) rather
 // than routing through lv_malloc the way the desktop build does -- ADR 0047's
@@ -58,11 +75,7 @@ const char* const kKeyNames[PSP_INPUT_KEY_COUNT] = {
 // this same PSP/GAME/rpg2k directory). One EBOOT, one game, no in-app project
 // picker: unlike the desktop build (--game_dir) or the browser build (the
 // page's own loader unzips a project at runtime), there is no way for this
-// build to be told a different location at launch. RPG2k (RPG_RT.ldb) is the
-// only maker checked -- ADR 0010 scopes the PSP port to "starting the real
-// RPG2k scene tree", not XP/VX/VX Ace; those can follow the same pattern
-// (mirroring the desktop/Emscripten maker-detection chain in src/main.cxx)
-// once this path is proven.
+// build to be told a different location at launch.
 const char kGameDir[] = "ms0:/PSP/GAME/rpg2k";
 
 bool file_exists(const char* path) {
@@ -71,6 +84,66 @@ bool file_exists(const char* path) {
     return false;
   std::fclose(f);
   return true;
+}
+
+bool path_exists(const char* dir, const char* rel) {
+  char buf[96];
+  std::snprintf(buf, sizeof(buf), "%s/%s", dir, rel);
+  return file_exists(buf);
+}
+
+// An RPG Maker VX / VX Ace project: mirrors is_rpgvx_game in src/main.cxx.
+// Checked before the XP predicate below, which only looks for Game.ini -- a
+// VX project has one too.
+bool is_rpgvx_game(const char* gd) {
+  return path_exists(gd, "Data/System.rvdata2") ||
+         path_exists(gd, "Data/System.rvdata") ||
+         path_exists(gd, "Game.rgss3a") || path_exists(gd, "Game.rgss2a");
+}
+
+// An RPG Maker XP project: mirrors is_xp_game in src/main.cxx.
+bool is_xp_game(const char* gd) {
+  if (is_rpgvx_game(gd))
+    return false;
+  const bool xp_data =
+      path_exists(gd, "Data/System.rxdata") || path_exists(gd, "Game.rgssad");
+  return path_exists(gd, "Game.ini") && xp_data;
+}
+
+// The mruby class to construct and the LVGL display resolution to create for
+// it -- see the file-level comment on why this has to be each maker's own
+// native resolution, not the panel's.
+struct GameInfo {
+  const char* class_name;
+  int32_t width;
+  int32_t height;
+};
+
+// RPG Maker 2000/2003's native screen size, matching src/main.cxx's --width/
+// --height defaults. RPGXP_WIDTH/HEIGHT and RPGVX_WIDTH/HEIGHT there are the
+// other two.
+constexpr int32_t kRpg2kWidth = 320;
+constexpr int32_t kRpg2kHeight = 240;
+constexpr int32_t kXpWidth = 640;
+constexpr int32_t kXpHeight = 480;
+constexpr int32_t kVxWidth = 544;
+constexpr int32_t kVxHeight = 416;
+
+// Which maker's project (if any) is present at kGameDir, mirroring
+// src/main.cxx's dispatch order: RPG2k (RPG_RT.ldb) first, then VX / VX Ace
+// (whose own archives/data files the XP predicate would otherwise also
+// match), then XP. Returns nullptr if none matched -- the idle HAL bring-up.
+const GameInfo* detect_game(void) {
+  static const GameInfo kRpg2k{"RPG2k", kRpg2kWidth, kRpg2kHeight};
+  static const GameInfo kXp{"RPGXP", kXpWidth, kXpHeight};
+  static const GameInfo kVx{"RPGVX", kVxWidth, kVxHeight};
+  if (path_exists(kGameDir, "RPG_RT.ldb"))
+    return &kRpg2k;
+  if (is_rpgvx_game(kGameDir))
+    return &kVx;
+  if (is_xp_game(kGameDir))
+    return &kXp;
+  return nullptr;
 }
 
 // Write a buffer to the PSP stdout (fd 1) and stderr (fd 2). Under an emulator
@@ -157,8 +230,16 @@ int main(void) {
 
   setup_callbacks();
 
+  // Detected before the display exists: which maker's project (if any) is
+  // present decides the display's own logical resolution (see the
+  // file-level comment), so this has to run first. It is a handful of plain
+  // fopen probes, nothing mruby-related, so it does not need the
+  // interpreter open yet either.
+  const GameInfo* const game_info = detect_game();
+
   lv_init();
-  psp_display_create(PSP_SCR_WIDTH, PSP_SCR_HEIGHT);
+  psp_display_create(game_info ? game_info->width : PSP_SCR_WIDTH,
+                     game_info ? game_info->height : PSP_SCR_HEIGHT);
   psp_input_init();
   build_ui();
 
@@ -174,11 +255,12 @@ int main(void) {
       psp_write(buf, n);
   }
 
-  // GAME_DIR/RTP_DIR are load-bearing mruby constants: mruby-rpg2k/mrblib and
-  // mruby-rgss/mrblib read them directly (RPG_RT.ldb/.lmt paths, asset/audio
-  // search paths, ...), the same as every other target's entry point sets
-  // them (src/main.cxx). RTP_DIR is empty -- this build is a single
-  // self-contained project per EBOOT, no shared RTP install to point at.
+  // GAME_DIR/RTP_DIR are load-bearing mruby constants: mruby-rpg2k/mruby-rpgxp/
+  // mruby-rpgvx/mruby-rgss's own mrblib read them directly (RPG_RT.ldb/.lmt
+  // paths, Game.ini, asset/audio search paths, ...), the same as every other
+  // target's entry point sets them (src/main.cxx). RTP_DIR is empty -- this
+  // build is a single self-contained project per EBOOT, no shared RTP
+  // install to point at.
   mrb_value game_obj = mrb_nil_value();
   bool have_game = false;
   if (M) {
@@ -187,17 +269,20 @@ int main(void) {
     mrb_const_set(M, mrb_obj_value(M->object_class),
                   mrb_intern_lit(M, "RTP_DIR"), mrb_str_new_cstr(M, ""));
 
-    char ldb_path[64];
-    std::snprintf(ldb_path, sizeof(ldb_path), "%s/RPG_RT.ldb", kGameDir);
     const char* game_start_result;
-    if (file_exists(ldb_path)) {
+    if (game_info) {
       // No TestPlay/HideTitle words -- this build has no command line to
       // carry them on.
       const mrb_value args = mrb_ary_new(M);
-      game_obj = mrb_obj_new(M, mrb_class_get(M, "RPG2k"), 1, &args);
+      game_obj =
+          mrb_obj_new(M, mrb_class_get(M, game_info->class_name), 1, &args);
       if (M->exc) {
         // Leaves no game running; falls through to the idle HAL loop below,
-        // same as "not_found".
+        // same as "not_found". The display stays sized for the maker whose
+        // construction failed rather than reverting to the panel's own
+        // resolution -- a rare path (the project's own files exist but its
+        // database failed to parse), not worth the extra bookkeeping to fix
+        // up for what the idle status screen looks like.
         M->exc = nullptr;
         game_start_result = "FAILED";
       } else {
@@ -212,9 +297,10 @@ int main(void) {
     } else {
       game_start_result = "not_found";
     }
-    char buf[48];
-    const int n = std::snprintf(buf, sizeof(buf), "RPG2K_PSP_GAME_START %s\n",
-                                game_start_result);
+    char buf[64];
+    const int n = std::snprintf(
+        buf, sizeof(buf), "RPG2K_PSP_GAME_START %s %s\n",
+        game_info ? game_info->class_name : "none", game_start_result);
     if (n > 0)
       psp_write(buf, n);
   }

--- a/changelog.d/psp-xp-vx-scene-tree.added.md
+++ b/changelog.d/psp-xp-vx-scene-tree.added.md
@@ -1,0 +1,21 @@
+- **The PSP EBOOT now also starts RPG Maker XP and VX/VX Ace games,** not
+  just RPG2k. `app/psp/main.cxx` detects which maker's project (if any) is
+  present at its fixed Memory Stick install location the same way
+  `src/main.cxx` does for desktop (`is_rpgvx_game`/`is_xp_game`), constructs
+  the matching class (`RPG2k`/`RPGXP`/`RPGVX`) and drives its per-frame
+  `#main_loop`. Doing this correctly required creating the LVGL display at
+  each maker's own *native* resolution (RPG2k 320×240, XP 640×480, VX/VX Ace
+  544×416) rather than the panel's fixed 480×272 — `RGSS::Graphics.width`/
+  `height` and everything a game draws derive directly from the display's
+  own resolution, so creating it at the panel's would have silently
+  distorted every game's coordinate math (this was a latent bug even for
+  RPG2k, invisible until now since CI has never had a real project to
+  exercise it against). RPG XP and RPG VX/VX Ace's native resolutions both
+  exceed the panel in *both* dimensions (they were designed for a desktop
+  window), so `mruby-rgss/src/psp.cxx`'s flush callback now centers the
+  logical canvas on the panel and clips every row to its actual bounds
+  instead of writing out of the framebuffer's allocation — for RPG2k that is
+  plain letterboxing, for XP/VX a same-scale, centered window onto the
+  game's own screen (content outside it still runs correctly but is not
+  drawn; real scaling is future work, see `app/psp/README.md`'s "Not yet
+  wired").

--- a/docs/adr/0010-psp-port.md
+++ b/docs/adr/0010-psp-port.md
@@ -99,14 +99,18 @@ and CI-checked before the interpreter and assets are layered on:
   until the next slice wires the interpreter and starts the real `RPG2k` scene
   tree. Memory-Stick asset loading (newlib syscalls, already routed by pspsdk's
   stdio) and moving the framebuffer blit onto `sceGu` follow after that.
-  **Update:** that next slice has landed. `libmruby.a` links into the EBOOT
-  and opens (`RPG2K_PSP_MRUBY_OPEN`), and `app/psp/main.cxx` constructs
-  `RPG2k` against a fixed Memory Stick install location
-  (`ms0:/PSP/GAME/rpg2k`) and drives its per-frame `#main_loop` when a
-  project is present there, reporting the outcome via
-  `RPG2K_PSP_GAME_START`/`RPG2K_PSP_GAME_STOP` — see `app/psp/README.md` for
-  the current status and what's still ahead (XP/VX/VX Ace detection, the
-  allocator split, `sceGu`).
+  **Update:** that next slice has landed, and now covers XP/VX/VX Ace too.
+  `libmruby.a` links into the EBOOT and opens (`RPG2K_PSP_MRUBY_OPEN`), and
+  `app/psp/main.cxx` detects which maker's project (if any) is present at a
+  fixed Memory Stick install location (`ms0:/PSP/GAME/rpg2k`), constructs
+  the matching class (`RPG2k`/`RPGXP`/`RPGVX`) at its own native display
+  resolution, and drives its per-frame `#main_loop`, reporting the outcome
+  via `RPG2K_PSP_GAME_START`/`RPG2K_PSP_GAME_STOP`. RPG XP and RPG VX/VX
+  Ace's native resolutions both exceed the 480×272 panel in both dimensions
+  (they were designed for a desktop window), so `psp.cxx`'s flush callback
+  centers and clips rather than scales — see `app/psp/README.md` for the
+  current status and what's still ahead (full-canvas scaling, the allocator
+  split, `sceGu`).
 - Because the PSP has ~24 MB of RAM, the gem-trimming and streaming-asset work
   that ADR 7 needs for the Wio Terminal is not expected to be necessary here; the
   full gem set should fit.

--- a/mruby-rgss/src/psp.cxx
+++ b/mruby-rgss/src/psp.cxx
@@ -21,6 +21,25 @@ namespace {
 // cache writeback.
 uint16_t* g_fb = nullptr;
 
+// Physical-pixel offset of the logical canvas's (0, 0) origin, set once by
+// psp_display_create() from the requested hor_res/ver_res. RPG2k's native
+// 320x240 is smaller than the 480x272 panel in both dimensions, so it is
+// centered with a positive offset (black bars, no scaling). RPG XP's 640x480
+// and RPG VX/VX Ace's 544x416 are each larger than the panel in *both*
+// dimensions (they were designed for a desktop window, not a handheld LCD) --
+// there is no offset that fits them, so they get a negative offset instead,
+// centering a same-scale *window* onto the middle of the game's own canvas:
+// content runs at its correct native resolution and everything RGSS-side
+// (Graphics.width/height, mouse-free coordinate math) is unaffected, but
+// anything drawn near an edge of a XP/VX screen -- a window docked in a
+// corner, say -- falls outside the visible 480x272 and is simply never
+// flushed. flush_cb clips every row to the panel's bounds either way, so
+// this is a real, known limitation (not full-canvas scaling, which would
+// need per-pixel resampling this bring-up doesn't attempt) but not a
+// correctness or memory-safety one.
+int32_t g_offset_x = 0;
+int32_t g_offset_y = 0;
+
 // LVGL partial-render draw buffers, in main RAM. Quarter-screen each
 // (480 * 68 * 2 = ~64 KB); two buffers let LVGL render one while the other is
 // being copied out. The PSP has ~24 MB of user RAM, so unlike the Wio backend
@@ -41,8 +60,14 @@ void delay_cb(uint32_t ms) {
 }
 
 // Copy one rendered rectangle into the VRAM framebuffer. LVGL hands RGB565
-// pixels packed at the rectangle's own width; the framebuffer has a fixed
-// 512-pixel line stride, so each row is copied to its (x, y) offset there.
+// pixels packed at the rectangle's own width, in the *logical* canvas's
+// coordinate space; g_offset_x/g_offset_y translate that into panel-relative
+// coordinates (see the comment above them), and every row is clipped to the
+// panel's actual 480x272 bounds before it is copied -- required whenever the
+// logical canvas is larger than the panel (RPG XP/VX/VX Ace), since an
+// unclipped row or column would land outside g_fb's PSP_BUF_WIDTH * 272
+// allocation. The framebuffer's fixed 512-pixel line stride is accounted for
+// in the destination row stride either way.
 //
 // NOTE: the PSP's 565 display format is BGR-ordered (red in the low 5 bits)
 // while LVGL's RGB565 puts red high, so the red/blue channels are swapped on
@@ -55,9 +80,27 @@ void flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
   const uint16_t* src = reinterpret_cast<const uint16_t*>(px_map);
 
   for (int32_t row = 0; row < h; ++row) {
-    uint16_t* dst = g_fb + (area->y1 + row) * PSP_BUF_WIDTH + area->x1;
-    std::memcpy(dst, src, static_cast<size_t>(w) * 2);
+    const int32_t dst_y = area->y1 + row + g_offset_y;
+    const uint16_t* row_src = src;
     src += w;
+    if (dst_y < 0 || dst_y >= PSP_SCR_HEIGHT)
+      continue;
+
+    int32_t dst_x = area->x1 + g_offset_x;
+    int32_t copy_w = w;
+    if (dst_x < 0) {
+      // The row's first -dst_x source pixels land left of the panel.
+      row_src -= dst_x;
+      copy_w += dst_x;
+      dst_x = 0;
+    }
+    if (dst_x + copy_w > PSP_SCR_WIDTH)
+      copy_w = PSP_SCR_WIDTH - dst_x;
+    if (copy_w <= 0)
+      continue;
+
+    uint16_t* dst = g_fb + dst_y * PSP_BUF_WIDTH + dst_x;
+    std::memcpy(dst, row_src, static_cast<size_t>(copy_w) * 2);
   }
 
   lv_display_flush_ready(disp);
@@ -78,6 +121,13 @@ lv_display_t* psp_display_create(int32_t hor_res, int32_t ver_res) {
 
   lv_tick_set_cb(tick_cb);
   lv_delay_set_cb(delay_cb);
+
+  // Center the logical canvas on the panel (see the g_offset_x/y comment
+  // above): positive when it is smaller than the panel (RPG2k's 320x240),
+  // negative when larger (RPG XP/VX/VX Ace), either way computed once here
+  // rather than per flush.
+  g_offset_x = (PSP_SCR_WIDTH - hor_res) / 2;
+  g_offset_y = (PSP_SCR_HEIGHT - ver_res) / 2;
 
   lv_display_t* disp = lv_display_create(hor_res, ver_res);
   if (!disp)


### PR DESCRIPTION
## Summary

PR #790 started the real `RPG2k` scene tree on PSP. This extends the same pattern to RPG Maker XP and VX/VX Ace.

- `app/psp/main.cxx` now detects which maker's project (if any) is present at `kGameDir`, mirroring `src/main.cxx`'s `is_rpgvx_game`/`is_xp_game` predicates and dispatch order, and constructs the matching class (`RPG2k`/`RPGXP`/`RPGVX`).
- **Found and fixed a latent bug along the way**, not just an omission: `RGSS::Graphics.width`/`height` (and everything a game draws) derive directly from the LVGL display's own resolution (`lv_display_get_horizontal_resolution`, `mruby-rgss/src/lib.cxx`), but `main.cxx` always created the display at the panel's fixed 480×272 rather than each maker's *native* resolution — silently distorting every game's coordinate math, including RPG2k's (should be 320×240). This was invisible until now because CI has never had a real project to exercise it against. The display is now created at the detected maker's own resolution (RPG2k 320×240, XP 640×480, VX/VX Ace 544×416) before `mrb_open()`.
- RPG XP and VX/VX Ace's native resolutions both exceed the 480×272 panel in **both** dimensions (they were designed for a resizable desktop window, not a fixed handheld LCD) — writing an unclipped row/column there would land outside the framebuffer's allocation. `mruby-rgss/src/psp.cxx`'s flush callback now centers the logical canvas on the panel and clips every row to its actual bounds. For RPG2k (smaller than the panel) that's plain letterboxing; for XP/VX it means only a same-scale, centered *window* onto the game's own screen is shown — content near an edge is never drawn. Real per-pixel scaling is future work (see `app/psp/README.md`'s "Not yet wired"), deliberately not attempted here given the per-frame CPU cost and no way to profile it in this environment.
- ADR 0010 and `app/psp/README.md` updated throughout.

## Verification

Still no real `psp-gcc` in this environment, but this sandbox has `gcc`/`ruby`/`rake`, which let me verify more directly than usual:

- **Both `psp.cxx` and `main.cxx` compile cleanly** against the real vendored LVGL headers and mruby headers (with a real generated presym header from an actual host mruby build), plus faithful pspsdk API stubs (`SceCtrlData`, `sceDisplaySetMode`, `sceGeEdramGetAddr`, etc., matching the real pspsdk API surface) for the handful of PSP-only functions this environment can't provide real headers for.
- **The flush callback's clipping/offset arithmetic** was worked through by hand for all three cases (canvas smaller than panel, larger in both dimensions, and the boundary rows/columns) before implementation, then confirmed via the syntax-checked compile above.
- **Confirmed no effect on desktop/wasm**: re-ran the real host mruby build after the `psp.cxx` change and verified it still compiles the file down to an empty translation unit (all new code sits inside the existing `#ifdef PSP_BUILD` guard).
- `clang-format` reports no diff on both files.

## Test plan

- [x] `psp.cxx`/`main.cxx` compile cleanly against real LVGL/mruby headers + pspsdk stubs
- [x] Confirmed the host mruby build still compiles `psp.cxx` to nothing (no desktop/wasm effect)
- [x] `clang-format` reports no diff
- [ ] CI `psp` job (cannot cross-compile for PSP in this environment) — confirms the actual MIPS/pspdev compile
- [ ] CI `psp-smoke` job — boots under PPSSPP, still exercises only the idle path (`RPG2K_PSP_GAME_START none not_found`, no project deployed there)
- [ ] A real XP or VX/VX Ace project run on real hardware or an emulator with a Memory Stick image — needed to confirm the clipping/centering actually looks right, not available in this environment

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaTSJ4i2Lwxi3VAV2DEr5D)_