### PR TITLE
Paint Erase/Show Screen's Mosaic and Wave transitions (settings 17-18) for real

### DIFF
--- a/changelog.d/rpg2k-transition-mosaic-wave.added.md
+++ b/changelog.d/rpg2k-transition-mosaic-wave.added.md
@@ -1,0 +1,29 @@
+- **Erase / Show Screen's Mosaic (setting 17) and Wave (setting 18) styles now
+  paint real per-pixel resamples.** They were the last two styles in the
+  transition family and used to run as a plain fade of the right length —
+  scroll, combine / division, zoom and random blocks were already done, but
+  these two genuinely wanted a native pass (a `get_pixel`/`set_pixel` loop
+  over every frame of a 320x240 screen is far too slow in Ruby). Added two
+  `mruby-rgss` `Bitmap` primitives following `#tone_blt`/`#stretch_blt`'s
+  shape: `#mosaic_blt(src, block_size)` resamples each pixel from the pixel
+  nearest the centre of its `block_size`x`block_size` block, and
+  `#wave_blt(src, depth, phase)` displaces each scanline horizontally by a
+  sine wave. Both are ported from EasyRPG Player's real source
+  (`src/transition.cpp`'s `TransitionMosaicIn`/`Out` and
+  `TransitionWaveIn`/`Out` cases, and `Bitmap::WaverBlit` in
+  `src/bitmap.cpp`, fetched verbatim): the mosaic block size ramps
+  `@frames..1` for a Show (sharpening out of a mosaic) and `1..@frames` for
+  an Erase (dissolving into one); the wave depth follows the same ramp with
+  `phase = p * 5 * PI / tf_off + PI`. RPG_RT also nudges the mosaic sampling
+  window by a small per-frame random offset, which this port omits for a
+  deterministic, unit-testable block centre — the same kind of reasoned
+  simplification the random-blocks Down/Up bias already is elsewhere in
+  `Game::Transition`. Both styles ride the same captured-screen snapshot
+  machinery scroll / combine / division / zoom already use
+  (`Game::Transition::CAPTURED`, `Scene::Map#draw_captured_transition`)
+  rather than a black mask, since a mask cannot express a resample. With
+  this, every Erase / Show Screen setting (0–19) paints for real. Covered by
+  new checks in `mruby-rgss/test/test.rb` (the native primitives),
+  `scripts/rpg2k_logic_check.rb` (the block-size/depth/phase ramps) and
+  `scripts/rpg2k_scene_check.rb` (the native calls reached with the right
+  per-frame parameters).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1981,10 +1981,9 @@ The work below is roughly ordered by the critical path to a walkable game
   screen being left against the screen being arrived at (one of the two is always
   solid black). That draws the blinds, the vertical / horizontal stripes and the
   border-to-centre / centre-to-border windows for real, and — see below —
-  random blocks too. Remaining: the styles a black mask cannot express — the
-  scrolls, the combine / division pairs and zoom slide or resample the live
-  scene itself, and mosaic / wave resample it too — which run as a fade of the
-  right length and the right end state for now.
+  random blocks too. The styles a black mask cannot express — the scrolls,
+  the combine / division pairs and zoom slide or resample the live scene
+  itself, and mosaic / wave resample it too — are also done, see below.
 
   **That remainder was written up as blocked on a screen capture the renderer
   does not have. It is not: `RGSS::Graphics.snap_to_bitmap` exists, is tested
@@ -2012,9 +2011,36 @@ The work below is roughly ordered by the critical path to a walkable game
     revealed each frame — rather than through `#visible_rects`'s
     full-cumulative-mask-every-frame shape, which is what made this style
     expensive enough to be left unbuilt. See the writeup below.
-  - **Mosaic (17) / wave (18)**: per-pixel resampling. `get_pixel`/`set_pixel`
-    exist but a full-screen loop per frame in Ruby is far too slow, so these are
-    the only two that genuinely want a native pass.
+  - ✅ **Mosaic (17) / wave (18)**: per-pixel resampling. `get_pixel`/`set_pixel`
+    exist but a full-screen loop per frame in Ruby is far too slow, so these
+    were the only two that genuinely wanted a native pass — now built as
+    `mruby-rgss`'s `Bitmap#mosaic_blt`/`#wave_blt` (`mruby-rgss/src/lib.cxx`),
+    the same shape as the existing `#tone_blt`/`#stretch_blt` primitives.
+    Ported from EasyRPG's real source (`src/transition.cpp`'s
+    `TransitionMosaicIn`/`Out` and `TransitionWaveIn`/`Out` cases, fetched
+    verbatim): **mosaic** resamples each pixel from the nearest-centre pixel
+    of a `block_size`x`block_size` block (`off = block_size / 2`), the block
+    size ramping `@frames..1` for the "in" (Show) style and `1..@frames` the
+    other way for "out" (Erase) — so a show sharpens out of a mosaic and an
+    erase dissolves into one, never through black. RPG_RT also nudges the
+    sampling window by a small per-frame random offset
+    (`mosaic_random_offset`); this port omits that jitter for a
+    deterministic, unit-testable block centre, the same kind of reasoned
+    simplification the random-blocks Down/Up bias and cross combine/
+    division's quadrant motion already are elsewhere in this class. **Wave**
+    displaces each captured scanline horizontally by
+    `trunc(2 * depth * sin(phase + row * 2*pi / 32))` (EasyRPG's
+    `Bitmap::WaverBlit`, `src/bitmap.cpp`, called at 1:1 scale), with
+    `depth`/`phase` driven by the same `@frames..1` / `1..@frames` ramp
+    mosaic's block size uses and `phase = p * 5 * PI / tf_off + PI`. Both
+    ride the CAPTURED snapshot machinery scroll/combine/zoom already use
+    (`Game::Transition#mosaic?`/`#wave?`/`#mosaic_block_size`/`#wave_params`,
+    `Scene::Map#draw_captured_transition`), rather than #capture_ops's
+    blt/stretch_blt geometry list. Covered by new checks in
+    `scripts/rpg2k_logic_check.rb` (the block-size/depth/phase ramps) and
+    `scripts/rpg2k_scene_check.rb` (the native calls reached with the right
+    per-frame parameters), plus `mruby-rgss/test/test.rb` for the native
+    primitives themselves.
 
   One wrinkle a Show Screen has and an Erase does not: its capture is of the
   screen being arrived at, and `snap_to_bitmap` grabs the rendered screen
@@ -2026,7 +2052,8 @@ The work below is roughly ordered by the critical path to a walkable game
   which is what makes the family worth finishing (`ruby scripts/analyze_game.rb
   --params --code 11010 data/mtf-meido-action/Debug`).
 
-  **Scroll, combine / division, zoom and random blocks are done.**
+  **Scroll, combine / division, zoom, mosaic, wave and random blocks are all
+  done.**
   `Game::Transition#capture_ops`
   computes, per style, where each piece of a captured screen goes this frame
   (a plain offset for the four scroll directions; two sliding pieces for
@@ -2102,7 +2129,13 @@ The work below is roughly ordered by the critical path to a walkable game
   this class. Covered by new checks in `scripts/rpg2k_logic_check.rb`
   (block-grid geometry, cumulative no-repeat coverage, the Down/Up row bias)
   and `scripts/rpg2k_scene_check.rb` (the incremental overlay paint).
-  Mosaic/wave alone is still unbuilt, per the per-style breakdown above.
+
+  ✅ **Mosaic (17) / wave (18) are done too**, the native per-pixel resample
+  pass the per-style breakdown above used to flag as the only two styles left
+  — see that bullet for the full writeup (`mruby-rgss`'s
+  `Bitmap#mosaic_blt`/`#wave_blt`, `Game::Transition#mosaic_block_size`/
+  `#wave_params`). With this, every Erase / Show Screen setting (0–19) now
+  paints for real; setting 20 ("no transition") always was a no-op.
 
   The fade and flash overlays were listed here as blocked on `RGSS::Viewport`
   tone/alpha support in C++. **They were not**: `RGSS::Sprite#opacity` already

--- a/mruby-rgss/mrbgem.rake
+++ b/mruby-rgss/mrbgem.rake
@@ -9,6 +9,13 @@ MRuby::Gem::Specification.new('mruby-rgss') do |spec|
   # File, so the standalone mrbtest build needs mruby-io. The loader itself
   # reads files through C stdio, so this is only needed for the tests.
   add_test_dependency 'mruby-io'
+  # The wave_blt test computes its expected phase with Math::PI. Math is part
+  # of the full game's gem set (build_config.rb's rpg_maker_gems), but the
+  # standalone mrbtest build only pulls this gem plus its declared
+  # dependencies -- see AGENTS.md's "mruby stdlib methods live in core *-ext
+  # mrbgems" note. wave_blt itself is pure C++ (mruby-rgss/src/lib.cxx), so
+  # this is only needed for the test.
+  add_test_dependency 'mruby-math'
 
   cxx.include_paths <<
     "#{dir}/../3rd/uni-algo/include" <<

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1925,7 +1925,7 @@ mrb_value bmp_mosaic_blt(mrb_state* M, V self) {
   // The pixel nearest the centre of the block `pos` falls in, clamped onto
   // the bitmap -- see the port note above for the RPG_RT jitter this omits.
   auto block_centre = [&](int32_t pos, int32_t len) {
-    return std::clamp(((pos + off) / blk) * blk - off, 0, len - 1);
+    return std::clamp<int32_t>(((pos + off) / blk) * blk - off, 0, len - 1);
   };
   for (int32_t y = 0; y < src.height; ++y) {
     const int32_t sy = block_centre(y, src.height);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -1882,6 +1882,118 @@ mrb_value bmp_stretch_blt(mrb_state* M, V self) {
   return self;
 }
 
+// RGSS-adjacent Bitmap#mosaic_blt(src, block_size): copy `src` into this
+// bitmap, same size, resampled into `block_size`x`block_size` pixel blocks
+// (nearest-neighbour, one sample per block) -- the Erase/Show Screen Mosaic
+// styles' per-frame resample.
+//
+// This is a native pass, not a Ruby one, because RPG2000's own Mosaic
+// dissolves the *whole* screen every frame: a get_pixel/set_pixel loop over
+// 76800 pixels in Ruby is far too slow to run once per frame, let alone once
+// per block-size step across a 41-frame transition (see docs/TODO.md's
+// "Screen effects" entry).
+//
+// Ported from EasyRPG Player's `Transition::Draw` (`src/transition.cpp`),
+// `TransitionMosaicIn`/`TransitionMosaicOut` case: each output pixel samples
+// the pixel nearest the centre of its `block_size`x`block_size` block --
+// `off = block_size / 2`, `src = clamp(((pos + off) / block_size) *
+// block_size - off, 0, len - 1)` on each axis -- rather than a block average,
+// which is why a 1px block is the identity (`off` is 0, `src == pos`). RPG_RT
+// also nudges the sampling window by a small per-frame random offset (its own
+// `mosaic_random_offset`, resized and filled once per transition from
+// `Rand::GetRandomNumber(0, i)`); this port omits that jitter, sampling the
+// same block centre deterministically every time, which keeps the geometry
+// (`Game::Transition#mosaic_block_size`, mruby-rpg2k/mrblib/game.rb) pure and
+// unit-testable without threading RNG state through it -- the same kind of
+// reasoned simplification the random-blocks Down/Up bias and the cross
+// combine/division quadrant motion already are elsewhere in that class.
+mrb_value bmp_mosaic_blt(mrb_state* M, V self) {
+  Bitmap& dst = bmp_self(M, self);
+  V src_v;
+  mrb_int size;
+  mrb_get_args(M, "oi", &src_v, &size);
+  Bitmap& src = DataType<Bitmap>::get(M, src_v);
+
+  if (src.width != dst.width || src.height != dst.height) {
+    RClass* mod = mrb_module_get(M, "RGSS");
+    RClass* err = mrb_class_get_under(M, mod, "RGSSError");
+    mrb_raisef(M, err, "mosaic_blt: size mismatch (self %dx%d, src %dx%d)",
+               dst.width, dst.height, src.width, src.height);
+  }
+  const int32_t blk = size < 1 ? 1 : static_cast<int32_t>(size);
+  const int32_t off = blk / 2;
+  // The pixel nearest the centre of the block `pos` falls in, clamped onto
+  // the bitmap -- see the port note above for the RPG_RT jitter this omits.
+  auto block_centre = [&](int32_t pos, int32_t len) {
+    return std::clamp(((pos + off) / blk) * blk - off, 0, len - 1);
+  };
+  for (int32_t y = 0; y < src.height; ++y) {
+    const int32_t sy = block_centre(y, src.height);
+    for (int32_t x = 0; x < src.width; ++x) {
+      const int32_t sx = block_centre(x, src.width);
+      int r, g, bl, a;
+      bmp_read(src, sx, sy, r, g, bl, a);
+      bmp_put(dst, x, y, r, g, bl, a);
+    }
+  }
+  dst.dirty = true;
+  return self;
+}
+
+// RGSS-adjacent Bitmap#wave_blt(src, depth, phase): blit `src` into this
+// bitmap, same size, each scanline displaced horizontally by a sine wave --
+// the Erase/Show Screen Wave styles' per-frame resample. Pixels a shifted row
+// no longer covers are left as whatever is already in `self` (the caller
+// fills black first, matching RPG_RT drawing the wave over a cleared frame).
+//
+// Ported from EasyRPG Player's `Bitmap::WaverBlit` (`src/bitmap.cpp`) as
+// called from `Transition::Draw`'s `TransitionWaveIn`/`TransitionWaveOut`
+// case with no scale (`zoom_x = zoom_y = 1`): row `y`'s offset is
+// `trunc(2 * depth * sin(phase + y * 2*pi / 32))`, `depth`/`phase` supplied
+// per frame by `Game::Transition#wave_params` (mruby-rpg2k/mrblib/game.rb),
+// itself the same `p * 5 * pi / tf_off + pi` ramp EasyRPG's own transition
+// code computes.
+mrb_value bmp_wave_blt(mrb_state* M, V self) {
+  Bitmap& dst = bmp_self(M, self);
+  V src_v;
+  mrb_int depth;
+  mrb_float phase;
+  mrb_get_args(M, "oif", &src_v, &depth, &phase);
+  Bitmap& src = DataType<Bitmap>::get(M, src_v);
+
+  if (src.width != dst.width || src.height != dst.height) {
+    RClass* mod = mrb_module_get(M, "RGSS");
+    RClass* err = mrb_class_get_under(M, mod, "RGSSError");
+    mrb_raisef(M, err, "wave_blt: size mismatch (self %dx%d, src %dx%d)",
+               dst.width, dst.height, src.width, src.height);
+  }
+
+  constexpr double two_pi = 2.0 * 3.14159265358979323846;
+  for (int32_t y = 0; y < src.height; ++y) {
+    const double sy = y * two_pi / 32.0;
+    const int32_t offset = static_cast<int32_t>(
+        2.0 * static_cast<double>(depth) * std::sin(phase + sy));
+    for (int32_t x = 0; x < src.width; ++x) {
+      const int32_t dx = x + offset;
+      if (dx < 0 || dx >= dst.width)
+        continue;
+      int r, g, bl, a;
+      bmp_read(src, x, y, r, g, bl, a);
+      if (a <= 0)
+        continue;
+      if (a >= 255) {
+        bmp_put(dst, dx, y, r, g, bl, 255);
+        continue;
+      }
+      int dr, dg, db, da;
+      bmp_read(dst, dx, y, dr, dg, db, da);
+      blend_over(dst, dx, y, r, g, bl, a, dr, dg, db, da);
+    }
+  }
+  dst.dirty = true;
+  return self;
+}
+
 auto find_char = [](char32_t c, const auto* g, unsigned g_len) -> const auto* {
   auto i = std::lower_bound(g, g + g_len, c, [](const auto& e, char32_t v) {
     return e.codepoint < v;
@@ -6082,6 +6194,8 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "tone_blt", bmp_tone_blt, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "stretch_blt", bmp_stretch_blt,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "mosaic_blt", bmp_mosaic_blt, MRB_ARGS_REQ(2));
+  mrb_define_method(M, bmp, "wave_blt", bmp_wave_blt, MRB_ARGS_REQ(3));
   // Both RGSS forms: (x, y, width, height, str[, align]) and (rect, str[,
   // align]).
   mrb_define_method(M, bmp, "draw_text", bmp_draw_text,

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -447,6 +447,60 @@ assert "RGSS::Bitmap stretch_blt" do
   assert_equal 0.0, dst.get_pixel(6, 6).alpha
 end
 
+assert "RGSS::Bitmap mosaic_blt" do
+  # An 8-wide source, one colour per column, so each column's red channel
+  # names the column it came from (col*10) and the resample is checkable
+  # without guessing where a block boundary falls.
+  src = RGSS::Bitmap.new(8, 1)
+  8.times { |c| src.fill_rect(c, 0, 1, 1, RGSS::Color.new(c * 10, 0, 0, 255)) }
+
+  # block_size 1 is the identity -- every pixel samples itself.
+  identity = RGSS::Bitmap.new(8, 1)
+  identity.mosaic_blt(src, 1)
+  8.times { |c| assert_equal(c * 10.0, identity.get_pixel(c, 0).red) }
+
+  # block_size 4 resamples each pixel from the pixel nearest the centre of
+  # its 4px block (EasyRPG's own `off = block_size / 2` centring, ported
+  # verbatim in mruby-rgss/src/lib.cxx's bmp_mosaic_blt) -- columns 2..5 all
+  # land on the same centred block and read column 2's colour, the
+  # pixelation RPG_RT's Mosaic transition applies to the whole screen.
+  dst = RGSS::Bitmap.new(8, 1)
+  dst.mosaic_blt(src, 4)
+  [0, 1].each { |c| assert_equal 0.0, dst.get_pixel(c, 0).red }
+  [2, 3, 4, 5].each { |c| assert_equal 20.0, dst.get_pixel(c, 0).red }
+  [6, 7].each { |c| assert_equal 60.0, dst.get_pixel(c, 0).red }
+
+  # Same size required, matching tone_blt/stretch_blt's own contract.
+  small = RGSS::Bitmap.new(2, 2)
+  assert_raise(RGSS::RGSSError) { dst.mosaic_blt(small, 2) }
+end
+
+assert "RGSS::Bitmap wave_blt" do
+  src = RGSS::Bitmap.new(4, 4)
+  src.fill_rect(0, 0, 4, 4, RGSS::Color.new(0, 128, 0, 255))
+
+  # depth 0 draws every row unshifted -- a no-op wave.
+  flat = RGSS::Bitmap.new(4, 4)
+  flat.wave_blt(src, 0, 0.0)
+  assert_equal 128.0, flat.get_pixel(0, 0).green
+  assert_equal 128.0, flat.get_pixel(3, 3).green
+
+  # A row whose offset pushes it fully off the destination leaves the
+  # destination untouched there -- here still transparent, since it was
+  # never filled first (the caller is expected to fill black beforehand,
+  # matching how RPG_RT clears before drawing the wave -- see the Erase/Show
+  # Screen Wave styles' capture draw in mruby-rpg2k/mrblib/scene/map.rb).
+  # depth 10 at phase PI/2 offsets row 0 by roughly +20px, comfortably past
+  # the 4px-wide destination's right edge regardless of sin's rounding.
+  dst = RGSS::Bitmap.new(4, 4)
+  dst.wave_blt(src, 10, Math::PI / 2)
+  assert_equal 0.0, dst.get_pixel(0, 0).alpha, 'row 0 shifted fully off-screen'
+
+  # Same size required, matching tone_blt/stretch_blt's own contract.
+  small = RGSS::Bitmap.new(2, 2)
+  assert_raise(RGSS::RGSSError) { flat.wave_blt(small, 1, 0.0) }
+end
+
 assert "RGSS::Bitmap gradient_fill_rect" do
   red = RGSS::Color.new(255, 0, 0, 255)
   blue = RGSS::Color.new(0, 0, 255, 255)

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4957,19 +4957,25 @@ module Game
       CROSS_COMBINE, ZOOM_OUT, MOSAIC_IN, WAVE_IN, CUT_IN
     ].freeze
 
-    # The scroll, combine / division and zoom styles: a black mask cannot
-    # express them (the true old/new pixels have to move or resample), so
-    # Scene::Map instead snapshots the screen once via
+    # The scroll, combine / division, zoom, mosaic and wave styles: a black
+    # mask cannot express them (the true old/new pixels have to move or
+    # resample), so Scene::Map instead snapshots the screen once via
     # RGSS::Graphics.snap_to_bitmap when one of these starts and composites
-    # that capture per #capture_ops every frame -- see docs/TODO.md's "Screen
-    # effects" entry. This class stays pure logic (no Graphics access, per the
-    # SCREEN_W/H comment above): it only computes where each piece of the
-    # capture goes.
+    # that capture every frame -- see docs/TODO.md's "Screen effects" entry.
+    # Scroll / combine / division / zoom composite through #capture_ops (a
+    # list of blt/stretch_blt pieces); mosaic and wave instead want a native
+    # per-pixel resample of the *whole* capture (mruby-rgss's
+    # Bitmap#mosaic_blt / #wave_blt), so they go through their own
+    # #mosaic_block_size / #wave_params accessors instead -- see #mosaic? /
+    # #wave?. This class stays pure logic throughout (no Graphics access, per
+    # the SCREEN_W/H comment above): it only computes the geometry or
+    # resample parameters, never touches a Bitmap itself.
     CAPTURED = [SCROLL_UP_IN, SCROLL_DOWN_IN, SCROLL_LEFT_IN, SCROLL_RIGHT_IN,
                 SCROLL_UP_OUT, SCROLL_DOWN_OUT, SCROLL_LEFT_OUT,
                 SCROLL_RIGHT_OUT, VERTICAL_COMBINE, VERTICAL_DIVISION,
                 HORIZONTAL_COMBINE, HORIZONTAL_DIVISION, CROSS_COMBINE,
-                CROSS_DIVISION, ZOOM_IN, ZOOM_OUT].freeze
+                CROSS_DIVISION, ZOOM_IN, ZOOM_OUT, MOSAIC_IN, MOSAIC_OUT,
+                WAVE_IN, WAVE_OUT].freeze
 
     # The random-blocks styles: a mask like BLIND_*/*_STRIPES_*/the window
     # pair above, but painted *incrementally* -- RPG_RT (and this port, see
@@ -4983,9 +4989,7 @@ module Game
     RANDOM_BLOCKS_STYLES = [RANDOM_BLOCKS, RANDOM_BLOCKS_DOWN,
                              RANDOM_BLOCKS_UP].freeze
 
-    # Styles this build paints for real. Mosaic / wave still fall through to a
-    # plain fade -- they want a native per-pixel resample, which is not built
-    # yet.
+    # Styles this build paints for real.
     DRAWN = [FADE_IN, FADE_OUT, BLIND_OPEN, BLIND_CLOSE, VERTICAL_STRIPES_IN,
              VERTICAL_STRIPES_OUT, HORIZONTAL_STRIPES_IN,
              HORIZONTAL_STRIPES_OUT, BORDER_TO_CENTER_IN, BORDER_TO_CENTER_OUT,
@@ -5112,13 +5116,53 @@ module Game
       @style == ZOOM_IN || @style == ZOOM_OUT
     end
 
+    # Whether this captured style is drawn by mosaic/wave resample (native
+    # `Bitmap#mosaic_blt` / `#wave_blt`) rather than #capture_ops's blt /
+    # stretch_blt pieces -- Scene::Map checks these before falling back to
+    # #capture_ops (see #zoom? for the sibling check that picks stretch_blt).
+    def mosaic?
+      @style == MOSAIC_IN || @style == MOSAIC_OUT
+    end
+
+    def wave?
+      @style == WAVE_IN || @style == WAVE_OUT
+    end
+
+    # The pixel block size `Bitmap#mosaic_blt` resamples the captured screen
+    # at this frame (EasyRPG's `m_size`, confirmed against `src/transition.
+    # cpp`'s `TransitionMosaicIn`/`TransitionMosaicOut` case): the "in" (Show)
+    # style starts fully mosaic'd (block size @frames) and sharpens to 1 by
+    # the last frame; the "out" (Erase) style runs the same ramp the other
+    # way, starting sharp and getting chunkier. Only called when #mosaic? is
+    # true.
+    def mosaic_block_size
+      mosaic_wave_progress
+    end
+
+    # `[depth, phase]` for `Bitmap#wave_blt` this frame (EasyRPG's own
+    # `depth`/`phase`, confirmed against `src/transition.cpp`'s
+    # `TransitionWaveIn`/`TransitionWaveOut` case, which itself calls
+    # `Bitmap::WaverBlit` -- ported to `mruby-rgss`'s `bmp_wave_blt`): depth
+    # is the same @frames..1 / 1..@frames progression #mosaic_block_size
+    # uses (the wave settles to flat as a Show finishes, and grows wilder as
+    # an Erase runs out), and phase is EasyRPG's own `p * 5 * PI / tf_off +
+    # PI` ramp (`tf_off` == #span). Only called when #wave? is true.
+    def wave_params
+      p = mosaic_wave_progress
+      d = span
+      phase = (d <= 0 ? 0 : p * 5 * Math::PI / d) + Math::PI
+      [p, phase]
+    end
+
     # The captured screen's pieces for this frame. For every style but zoom,
     # each piece is `[dx, dy, sx, sy, sw, sh]` -- paste the capture's `[sx, sy,
     # sw, sh]` region at `(dx, dy)` with `Bitmap#blt` (destination size always
     # matches source size). Zoom instead resamples, so its one piece is `[dx,
-    # dy, dw, dh, sx, sy, sw, sh]` for `Bitmap#stretch_blt` -- see #zoom?. Only
-    # called for a captured style; Scene::Map paints these over a black fill,
-    # so a piece that has slid (or shrunk) off leaves black behind it.
+    # dy, dw, dh, sx, sy, sw, sh]` for `Bitmap#stretch_blt` -- see #zoom?.
+    # Mosaic and wave are not returned here at all -- see #mosaic_block_size /
+    # #wave_params instead. Only called for a captured, non-mosaic, non-wave
+    # style; Scene::Map paints these over a black fill, so a piece that has
+    # slid (or shrunk) off leaves black behind it.
     def capture_ops
       case @style
       when SCROLL_UP_IN, SCROLL_DOWN_IN, SCROLL_LEFT_IN, SCROLL_RIGHT_IN,
@@ -5202,6 +5246,18 @@ module Game
     def frame_ratio
       d = span
       d <= 0 ? [1, 1] : [@frame, d]
+    end
+
+    # EasyRPG's own `p` for the mosaic/wave pair (`src/transition.cpp`):
+    # `@frames - @frame` for the "in" (Show) styles, `@frame + 1` for "out"
+    # (Erase) -- shared by #mosaic_block_size and #wave_params. Clamped to at
+    # least 1 as a defensive floor for a frame at or past #done? (@frame ==
+    # @frames), which never happens in normal play but would otherwise divide
+    # by zero in #mosaic_blt's block size.
+    def mosaic_wave_progress
+      out = @style == MOSAIC_OUT || @style == WAVE_OUT
+      p = out ? @frame + 1 : @frames - @frame
+      p < 1 ? 1 : p
     end
 
     # Scroll: the whole capture slides in from (or out to) one edge in a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -596,10 +596,14 @@ class RPG2k
       # this particular Game::Transition instance is drawn (identity, not
       # value, so a same-style transition right after it still re-snapshots).
       #
-      # Zoom is the one captured style that resamples instead of pasting 1:1
-      # (see Game::Transition#zoom?): its single #capture_ops piece is `[dx,
-      # dy, dw, dh, sx, sy, sw, sh]` for `Bitmap#stretch_blt`, rather than the
-      # `[dx, dy, sx, sy, sw, sh]` every other style hands to `Bitmap#blt`.
+      # Zoom is the one #capture_ops style that resamples instead of pasting
+      # 1:1 (see Game::Transition#zoom?): its single piece is `[dx, dy, dw,
+      # dh, sx, sy, sw, sh]` for `Bitmap#stretch_blt`, rather than the `[dx,
+      # dy, sx, sy, sw, sh]` every other #capture_ops style hands to
+      # `Bitmap#blt`. Mosaic and wave (Game::Transition#mosaic?/#wave?) are
+      # native per-pixel resamples of the whole capture instead of a geometry
+      # list -- `Bitmap#mosaic_blt`/`#wave_blt`, driven by
+      # `#mosaic_block_size`/`#wave_params` rather than `#capture_ops`.
       def draw_captured_transition(tr)
         unless @captured_transition.equal?(tr)
           @transition_capture.dispose if @transition_capture
@@ -618,6 +622,11 @@ class RPG2k
         if tr.zoom?
           dx, dy, dw, dh, sx, sy, sw, sh = tr.capture_ops.first
           @fade_bmp.stretch_blt Rect.new(dx, dy, dw, dh), cap, Rect.new(sx, sy, sw, sh)
+        elsif tr.mosaic?
+          @fade_bmp.mosaic_blt cap, tr.mosaic_block_size
+        elsif tr.wave?
+          depth, phase = tr.wave_params
+          @fade_bmp.wave_blt cap, depth, phase
         else
           tr.capture_ops.each do |dx, dy, sx, sy, sw, sh|
             @fade_bmp.blt dx, dy, cap, Rect.new(sx, sy, sw, sh)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2123,17 +2123,21 @@ end
 
 check 'Erase Screen records the transition style and ramps the level' do
   st = new_state
-  # Setting 17 is Mosaic, still one of the styles a black mask cannot express
-  # (per-pixel resampling), so it runs as a fade of the same length.
+  # Setting 17 is Mosaic: a black mask cannot express it (per-pixel
+  # resampling), so it composites from a captured screen like scroll /
+  # combine / division / zoom rather than drawing a plain fade -- see
+  # Game::Transition::CAPTURED / #mosaic?.
   it = Game::Interpreter.new(st)
   it.start([FakeCmd.new(IC::ERASE_SCREEN, [17])])
   it.update
   eq Game::Transition::MOSAIC_OUT, st.screen.fade_transition
-  ok st.screen.transition.uniform?, 'an unported style falls back to the fade'
-  eq 41, st.screen.transition.frames, 'but keeps its own length'
+  ok st.screen.transition.captured?, 'mosaic composites from a captured screen'
+  ok st.screen.transition.mosaic?
+  ok !st.screen.transition.uniform?, 'not drawn as a plain fade'
+  eq 41, st.screen.transition.frames, 'and keeps its own length'
   before = st.screen.fade_level
   st.screen.update
-  ok st.screen.fade_level > before, 'the level eases toward black'
+  ok st.screen.fade_level > before, 'the fallback level still eases toward black'
   ok st.screen.fade_level < 255, 'over time, not instantly'
 end
 
@@ -2333,6 +2337,61 @@ check 'random blocks down/up bias the reveal order towards one edge' do
   up = TR.new(TR::RANDOM_BLOCKS_UP, 41, 320, 240, false)
   rows = up.new_block_rects.map { |_x, y, _w, _h| y / 4 }
   ok rows.min >= 60 / 2, 'up reveals rows near the bottom of the screen first'
+end
+
+check 'mosaic/wave are captured styles with their own native-resample params' do
+  # Both ride the CAPTURED snapshot machinery (see Game::Transition::CAPTURED)
+  # but resample through a native Bitmap#mosaic_blt/#wave_blt call instead of
+  # #capture_ops's blt/stretch_blt geometry list.
+  [TR::MOSAIC_IN, TR::MOSAIC_OUT, TR::WAVE_IN, TR::WAVE_OUT].each do |style|
+    tr = TR.new(style, 41, 320, 240, true)
+    ok tr.captured?, "#{style} is captured"
+    eq [], tr.capture_ops, "#{style} has no capture_ops geometry of its own"
+  end
+
+  ok TR.new(TR::MOSAIC_IN, 41, 320, 240, false).mosaic?
+  ok TR.new(TR::MOSAIC_OUT, 41, 320, 240, true).mosaic?
+  ok !TR.new(TR::WAVE_IN, 41, 320, 240, false).mosaic?
+  ok TR.new(TR::WAVE_IN, 41, 320, 240, false).wave?
+  ok TR.new(TR::WAVE_OUT, 41, 320, 240, true).wave?
+  ok !TR.new(TR::MOSAIC_OUT, 41, 320, 240, true).wave?
+end
+
+check 'mosaic block size ramps between sharp and fully chunky, confirmed against EasyRPG' do
+  # src/transition.cpp's TransitionMosaicIn/Out case: `m_size = total_frames -
+  # current_frame` for In, `current_frame + 1` for Out.
+  into = TR.new(TR::MOSAIC_IN, 41, 320, 240, false)
+  eq 41, into.mosaic_block_size, "a show starts fully mosaic'd"
+  40.times { into.advance }
+  eq 1, into.mosaic_block_size, 'and sharpens all the way down by the last frame'
+
+  out = TR.new(TR::MOSAIC_OUT, 41, 320, 240, true)
+  eq 1, out.mosaic_block_size, 'an erase starts sharp'
+  40.times { out.advance }
+  eq 41, out.mosaic_block_size, 'and gets as chunky as it ever gets by the last frame'
+end
+
+check 'wave depth/phase ramp the same way mosaic block size does, confirmed against EasyRPG' do
+  # src/transition.cpp's TransitionWaveIn/Out case: `p` is the same In/Out
+  # ramp mosaic's `m_size` uses, and `phase = p * 5 * PI / tf_off + PI`
+  # (`tf_off` == #span, here 40 for a 41-frame transition).
+  into = TR.new(TR::WAVE_IN, 41, 320, 240, false)
+  depth, phase = into.wave_params
+  eq 41, depth
+  eq 41 * 5 * Math::PI / 40 + Math::PI, phase
+  40.times { into.advance }
+  depth, phase = into.wave_params
+  eq 1, depth
+  eq 1 * 5 * Math::PI / 40 + Math::PI, phase
+
+  out = TR.new(TR::WAVE_OUT, 41, 320, 240, true)
+  depth, phase = out.wave_params
+  eq 1, depth
+  eq 1 * 5 * Math::PI / 40 + Math::PI, phase
+  40.times { out.advance }
+  depth, phase = out.wave_params
+  eq 41, depth
+  eq 41 * 5 * Math::PI / 40 + Math::PI, phase
 end
 
 check 'conditional branch on the timer' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -58,6 +58,15 @@ module RGSS
     def stretch_blt(*a); (@stretch_calls ||= []) << a; end
     attr_reader :stretch_calls
     def clear_stretch_calls; @stretch_calls = []; end
+    # Recorded so the Mosaic/Wave transition checks can assert the native
+    # resample was reached with the right per-frame parameters, mirroring how
+    # #stretch_calls covers zoom.
+    def mosaic_blt(*a); (@mosaic_calls ||= []) << a; end
+    attr_reader :mosaic_calls
+    def clear_mosaic_calls; @mosaic_calls = []; end
+    def wave_blt(*a); (@wave_calls ||= []) << a; end
+    attr_reader :wave_calls
+    def clear_wave_calls; @wave_calls = []; end
     # Record the tone a Flash Sprite pass asks for, so the flash checks can
     # assert the colour actually reached the renderer.
     def tone_blt(src, tone); (@tone_calls ||= []) << [src, tone]; self; end
@@ -8943,6 +8952,110 @@ check 'zoom out resamples a growing crop of the capture, stretched full-screen' 
   srect = fade.bitmap.stretch_calls.first[2]
   eq [0, 0, 320, 240], [srect.x, srect.y, srect.width, srect.height],
      'finished: the crop has grown back out to the whole capture'
+ensure
+  RGSS::Graphics.snapshot = nil
+end
+
+check 'mosaic transitions resample the capture through a shrinking/growing block size' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  snap = RGSS::Bitmap.new(320, 240)
+  RGSS::Graphics.snapshot = snap
+
+  # Erase (MOSAIC_OUT): starts sharp (block size 1) and gets chunkier --
+  # EasyRPG's `m_size = current_frame + 1`, confirmed against
+  # src/transition.cpp's TransitionMosaicOut case.
+  st.screen.erase(Game::Transition::MOSAIC_OUT)
+  fade.bitmap.clear_mosaic_calls
+  scene.update
+  eq 255, fade.opacity, 'a captured style paints, so it is fully opaque like a mask'
+  ok (fade.bitmap.blt_calls || []).empty?, 'mosaic never uses the 1:1 paste path'
+  ok (fade.bitmap.stretch_calls || []).empty?, 'mosaic never uses the resize path either'
+  calls = fade.bitmap.mosaic_calls || []
+  eq 1, calls.length, 'mosaic resamples the whole capture in one native call'
+  cap, size = calls.first
+  ok cap.equal?(snap), 'resampled from the captured snapshot'
+  eq 2, size, 'frame 1 (the first rendered frame) is barely chunkier than sharp'
+
+  mid = Game::Transition.default_frames(Game::Transition::MOSAIC_OUT) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_mosaic_calls
+  scene.update
+  size = fade.bitmap.mosaic_calls.first[1]
+  eq 41, size, 'finished: as chunky as the transition ever gets'
+
+  # Show (MOSAIC_IN): starts fully mosaic'd and sharpens -- `m_size =
+  # total_frames - current_frame`, the same ramp run backwards.
+  st.screen.erase(Game::Transition::FADE_OUT, 1) # show is a no-op unless erased first
+  2.times { scene.update }
+
+  st.screen.show(Game::Transition::MOSAIC_IN)
+  fade.bitmap.clear_mosaic_calls
+  scene.update
+  size = fade.bitmap.mosaic_calls.first[1]
+  eq 40, size, 'frame 1 of a show starts almost as chunky as it gets'
+
+  mid = Game::Transition.default_frames(Game::Transition::MOSAIC_IN) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_mosaic_calls
+  scene.update
+  size = fade.bitmap.mosaic_calls.first[1]
+  eq 1, size, 'finished: sharpened all the way down to 1px blocks'
+ensure
+  RGSS::Graphics.snapshot = nil
+end
+
+check 'wave transitions resample the capture through the depth/phase ramp' do
+  scene = new_scene({}, player: [5, 5])
+  fade, = overlay(scene)
+  scene.update
+  st = scene.instance_variable_get(:@state)
+  snap = RGSS::Bitmap.new(320, 240)
+  RGSS::Graphics.snapshot = snap
+
+  # Erase (WAVE_OUT): depth/phase grow as the screen prepares to vanish --
+  # EasyRPG's `p = current_frame + 1`, confirmed against src/transition.cpp's
+  # TransitionWaveOut case (itself Bitmap::WaverBlit's depth/phase args).
+  st.screen.erase(Game::Transition::WAVE_OUT)
+  fade.bitmap.clear_wave_calls
+  scene.update
+  ok (fade.bitmap.blt_calls || []).empty?, 'wave never uses the 1:1 paste path'
+  ok (fade.bitmap.stretch_calls || []).empty?, 'wave never uses the resize path either'
+  calls = fade.bitmap.wave_calls || []
+  eq 1, calls.length, 'wave resamples the whole capture in one native call'
+  cap, depth, phase = calls.first
+  ok cap.equal?(snap), 'resampled from the captured snapshot'
+  eq 2, depth, 'frame 1 (the first rendered frame) has barely started waving'
+  eq 1.25 * Math::PI, phase
+
+  mid = Game::Transition.default_frames(Game::Transition::WAVE_OUT) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_wave_calls
+  scene.update
+  depth, phase = fade.bitmap.wave_calls.first[1, 2]
+  eq 41, depth, 'finished: the widest the wave ever gets'
+  eq 6.125 * Math::PI, phase
+
+  # Show (WAVE_IN): the same ramp run backwards, settling flat.
+  st.screen.erase(Game::Transition::FADE_OUT, 1) # show is a no-op unless erased first
+  2.times { scene.update }
+
+  st.screen.show(Game::Transition::WAVE_IN)
+  fade.bitmap.clear_wave_calls
+  scene.update
+  depth, phase = fade.bitmap.wave_calls.first[1, 2]
+  eq 40, depth, 'frame 1 of a show starts almost as wide as it gets'
+  eq 6 * Math::PI, phase
+
+  mid = Game::Transition.default_frames(Game::Transition::WAVE_IN) - 3
+  mid.times { scene.update }
+  fade.bitmap.clear_wave_calls
+  scene.update
+  depth, phase = fade.bitmap.wave_calls.first[1, 2]
+  eq 1, depth, 'finished: settled down to a near-flat wave'
+  eq 1.125 * Math::PI, phase
 ensure
   RGSS::Graphics.snapshot = nil
 end


### PR DESCRIPTION
## Summary

- Finishes the last two unbuilt styles in the Erase/Show Screen transition family (docs/TODO.md's "Screen effects" 🚧 item): **Mosaic** (setting 17) and **Wave** (setting 18). Scroll, combine/division, zoom and random blocks were already done — these two wanted a genuine native per-pixel resample per frame (a `get_pixel`/`set_pixel` Ruby loop over a 320x240 screen is far too slow every frame of a 41-frame transition).
- Confirmed the real algorithms against EasyRPG Player's actual source rather than guessing (`src/transition.cpp`'s `TransitionMosaicIn`/`Out` and `TransitionWaveIn`/`Out` cases, and `src/bitmap.cpp`'s `Bitmap::WaverBlit`, all fetched verbatim):
  - **Mosaic** resamples each pixel from the pixel nearest the centre of its `block_size`×`block_size` block (`off = block_size / 2`, `src = clamp(((pos + off) / block_size) * block_size - off, 0, len - 1)`). The block size ramps `@frames..1` for the "in" (Show) style — starting fully mosaic'd and sharpening — and `1..@frames` the other way for "out" (Erase). RPG_RT also nudges the sampling window with a small per-frame random offset; this port omits that jitter for a deterministic, unit-testable block centre — the same kind of reasoned simplification the random-blocks Down/Up bias already is elsewhere in `Game::Transition`.
  - **Wave** displaces each scanline horizontally by `trunc(2 * depth * sin(phase + row * 2*pi / 32))`, with `depth`/`phase` driven by the same `@frames..1`/`1..@frames` ramp mosaic's block size uses and `phase = p * 5 * PI / tf_off + PI`.
- Added two `mruby-rgss` `Bitmap` primitives following `#tone_blt`/`#stretch_blt`'s exact shape (size-mismatch raise, per-pixel loop, `mrb_define_method` registration): `#mosaic_blt(src, block_size)` and `#wave_blt(src, depth, phase)` (`mruby-rgss/src/lib.cxx`).
- `Game::Transition` gains `#mosaic?`/`#wave?`/`#mosaic_block_size`/`#wave_params` — pure logic, no `Graphics` access, unit-testable without a renderer — and both styles now ride the existing `CAPTURED` snapshot machinery scroll/combine/division/zoom already use (`Scene::Map#draw_captured_transition` now branches to the new native calls instead of falling through to a plain fade).
- Fixed an existing logic check that asserted setting 17 (Mosaic) still fell back to a plain fade (it now asserts the real captured/non-uniform behaviour instead).
- Updated `docs/TODO.md`'s "Screen effects" writeup to move Mosaic/Wave from "remaining" to done, alongside Scroll/Combine/Zoom/Random Blocks — every Erase/Show Screen setting (0–19) now paints for real.
- Added a changelog fragment (`changelog.d/rpg2k-transition-mosaic-wave.added.md`).

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — pure-logic coverage: `#mosaic?`/`#wave?`/`captured?` classification, `#capture_ops` returns nothing for either style, and the block-size/depth/phase ramps at both ends of the transition, all confirmed against the EasyRPG formulas above. 811 checks pass.
- [x] `ruby scripts/rpg2k_scene_check.rb` — `Scene::Map` coverage: the native `mosaic_blt`/`wave_blt` calls are reached (never the blt/stretch_blt paths) with the right captured snapshot and per-frame parameters, for both the Erase and Show direction of each style. 540 checks pass.
- [x] Added `mruby-rgss/test/test.rb` coverage for the two new native primitives directly: `mosaic_blt`'s block-centre resample (including the 1px identity case) and `wave_blt`'s per-row sine displacement (including the off-destination and same-size-required cases), mirroring the existing `tone_blt`/`stretch_blt` test shape.
- [ ] **Could not run a full native build/CTest in this sandbox** — `cmake -S . -B build` fails at configure time (`find_package(SDL2)` — no SDL2 dev package or nix available here, matching what other recent native-touching PRs in this repo have hit). Verified instead via `ruby -c` on every touched Ruby file, the two full-coverage Ruby test harnesses above, `clang-format -i` on the touched region of `lib.cxx`, and careful manual review of the C++ diff against the already-proven `bmp_tone_blt`/`bmp_stretch_blt` structure it mirrors.

---
_Generated by [Claude Code](https://claude.ai/code/session_015iWsVbSeHkEgTkMJ9cq9Fi)_