### PR TITLE
Implement RPG2003's Order menu command (party reordering)

### DIFF
--- a/changelog.d/rpg2003-menu-order-command.added.md
+++ b/changelog.d/rpg2003-menu-order-command.added.md
@@ -1,0 +1,8 @@
+- **RPG2003's Order menu command (party reordering)** now works. Unlike Row
+  (battle front/back rank) and Wait (the ATB toggle), which stay blocked on
+  the unmodelled RPG2003 battle system, Order turned out to have no
+  battle-system dependency at all — new `Game::Party#reorder` and
+  `Scene::Order` implement it standalone, following the pick-and-place
+  interaction model (not a swap or drag-drop) confirmed against EasyRPG
+  Player's own `Scene_Order`. `Scene::Menu` dispatches it directly, the same
+  as Item/Save, gated on the party holding more than one member.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2152,8 +2152,8 @@ The work below is roughly ordered by the critical path to a walkable game
 
 #### Menus, save, battle
 - 🚧 Menu scene — opens over the map (cancel button); shows party status and a
-  command list. Save, End Game, **Item**, **Skill**, **Equip** and **Status** all
-  work.
+  command list. Save, End Game, **Item**, **Skill**, **Equip**, **Status** and
+  **Order** all work.
   ✅ **The command list itself now matches the editor that wrote the game**,
   rather than always showing the same fixed six. This line used to claim
   Item/Skill/Equip/Status/Save/End Game was simply "the full main-menu set,"
@@ -2179,10 +2179,10 @@ The work below is roughly ordered by the critical path to a walkable game
   (`mruby-rpg2k/mrblib/scene/menu.rb`) now branches on `db.rpg2003?` (ADR
   0013's edition detector): RPG2000 gets the fixed
   `RPG2K_COMMAND_KEYS` five, RPG2003 filters its own `menu_commands` array
-  through `RPG2K3_COMMAND_IDS` — a small id→command table that has **no**
-  entry for Row (battle front/back rank), Order (party reordering) or Wait
-  (the ATB toggle), so a 2003 game listing them simply does not offer them,
-  the identical reported-gap precedent the Toggle ATB Mode (5003) event
+  through `RPG2K3_COMMAND_IDS` — a small id→command table that (at the time)
+  had **no** entry for Row (battle front/back rank), Order (party reordering)
+  or Wait (the ATB toggle), so a 2003 game listing them simply did not offer
+  them, the identical reported-gap precedent the Toggle ATB Mode (5003) event
   command entry above already establishes for the same unmodelled RPG2003
   battle system — rather than crashing or inventing a screen. Covered by new
   `scripts/rpg2k_scene_check.rb` checks (a non-2003 fixture never offers
@@ -2191,8 +2191,12 @@ The work below is roughly ordered by the critical path to a walkable game
   end to end, including actually opening the reordered Status screen),
   confirmed to fail against the pre-fix code (Status always offered
   regardless of edition; a 2003 reorder/omission silently ignored) before the
-  fix. See `changelog.d/menu-command-list-2003-rpg2k-status.fixed.md`. The
-  **Item** command opens
+  fix. See `changelog.d/menu-command-list-2003-rpg2k-status.fixed.md`.
+  ✅ **Order (id 7) has since gained its own entry too** — unlike Row and
+  Wait it turned out to have no battle-system dependency at all, just party
+  reordering; see the `Order` paragraph further down for the follow-up.
+  Row and Wait remain genuinely blocked on the unmodelled RPG2003 battle
+  system. The **Item** command opens
   `Scene::ItemMenu`: it lists the party's usable **medicines** (database item type
   6), **skill books** (type 7) and **seeds** (type 8) with their held counts. A
   medicine heals its target — a single-target item a chosen ally, an all-ally item
@@ -2399,7 +2403,45 @@ The work below is roughly ordered by the critical path to a walkable game
   **Change Main Menu Access** (11960) and **Change Save Access** (11930) gate it:
   the menu will not open while menu access is forbidden, and the Save command
   reports that saving is disallowed while save access is off (both flags default
-  on and persist in the save)
+  on and persist in the save).
+  ✅ **Order (RPG2003 `menu_commands` id 7, party reordering) is implemented.**
+  Of the three ids `RPG2K3_COMMAND_IDS` used to skip wholesale (Row, Order,
+  Wait), Order turned out to have no dependency on the unmodelled battle
+  system at all — it is pure party-array reordering, so it was pulled out and
+  built standalone while Row (battle front/back rank) and Wait (the ATB
+  toggle) stay genuinely blocked on that gap. The interaction model was
+  confirmed against EasyRPG Player's own `Scene_Order` rather than guessed:
+  it is a **pick-and-place build, not a swap or drag-drop** — the player picks
+  party members one at a time from a left column (`UpdateOrder`'s
+  `window_left`), each pick appended to a right column in the order picked
+  (`window_right`), until every member has been placed; a Confirm/Redo prompt
+  then either applies the picked order or clears every pick and starts over
+  (`UpdateConfirm`/`Redo`). Cancel undoes the most recent pick one at a time,
+  or leaves the screen once nothing is picked yet; re-picking an already-
+  picked slot (the row stays selectable even once its name is blanked) is
+  rejected with the Cancel SE, matching `UpdateOrder`'s own duplicate guard.
+  New `Game::Party#reorder(new_order)` takes a permutation of the current
+  member indices and rebuilds `@actors` in that order — the net effect of
+  EasyRPG's `Confirm()` (which removes every member then re-adds them in the
+  picked order) without replaying the remove/re-add dance — and bumps
+  `@revision` the same as the existing `#promote_to_leader`, since
+  reordering can change the party leader outright (`#leader` is simply
+  `@actors.first`). New `Scene::Order` (`mruby-rpg2k/mrblib/scene/order.rb`)
+  is the RGSS UI over it. `Scene::Menu` dispatches Order the same way it
+  already dispatches Item/Save — pushed directly on confirm, no actor-
+  selection step, since Order acts on the whole party at once rather than one
+  member — gated on the party holding more than one member (a buzzer refusal
+  otherwise), matching `Scene_Menu::UpdateCommand`'s own `Order` branch
+  rather than the plain empty-party check every other command here uses.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (`#reorder` applies a
+  picked permutation and changes the leader) and new
+  `scripts/rpg2k_scene_check.rb` checks (Order dispatches directly with no
+  actor-selection focus change; a one-member party is refused with the
+  buzzer; picking moves a member from the left column to the right; a
+  duplicate pick is rejected with the Cancel SE; Cancel undoes one pick at a
+  time or leaves the screen with none picked; Confirm applies the picked
+  order to the party and closes; Redo clears every pick without touching the
+  party)
 - 🚧 Save & Continue — the portable `Marshal` save of the game state
   (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
   menu's Save command; "Continue" reloads it. **Reading** the real

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2562,6 +2562,22 @@ module Game
     def size; @actors.size; end
     def leader; @actors.first; end
 
+    # RPG2003's Order menu command: reassign the party's front-to-back order
+    # to `new_order`, a permutation of the current member indices (new_order[i]
+    # is which existing member becomes the i'th). Confirmed against EasyRPG's
+    # `Scene_Order`: the player picks members one at a time from the original
+    # roster to build exactly this array (`UpdateOrder`'s `actors[actor_counter]
+    # = window_left->GetIndex() + 1`), then `Confirm()` removes every member and
+    # re-adds them in that order -- #reorder applies the net effect directly
+    # rather than replaying the remove/re-add dance. Membership is unchanged,
+    # but the leader can be -- `#leader` is simply `@actors.first` -- which is
+    # why this bumps @revision the same as #promote_to_leader above, the
+    # existing precedent for a leader change with no membership change.
+    def reorder(new_order)
+      @actors = new_order.map { |i| @actors[i] }
+      @revision += 1
+    end
+
     def include_actor?(id); @actors.any? { |a| a.id == id }; end
     def actor_by_id(id); @actors.find { |a| a.id == id }; end
 

--- a/mruby-rpg2k/mrblib/scene/menu.rb
+++ b/mruby-rpg2k/mrblib/scene/menu.rb
@@ -1,19 +1,21 @@
 class RPG2k
   module Scene
     # Main menu, opened over the map with the cancel button. Shows party status
-    # and a command list. Item and Save act immediately; Skill, Equip and
-    # Status instead hand input focus to the party-status panel so the
+    # and a command list. Item, Save and Order act immediately; Skill, Equip
+    # and Status instead hand input focus to the party-status panel so the
     # player picks *which actor* first (UP/DOWN, confirmed with C) before
     # the corresponding scene (Scene::SkillMenu / EquipMenu / StatusMenu)
     # opens for that one -- confirmed against EasyRPG's own
     # `Scene_Menu::UpdateCommand`/`UpdateActorSelection` (`Skill`/
     # `Equipment`/`Status`/`Row` all share this shape; RPG2003's Row, the
-    # battle front/back toggle, is not modelled here). Cancelling back out
-    # of actor selection returns focus to the command list. End Game opens a
-    # Yes/No confirmation (see #open_end_game_confirm); only confirming
-    # "Yes" there returns to the title. Any further command (there are none
-    # left in the built command list today) falls back to a "not implemented
-    # yet" message.
+    # battle front/back toggle, is not modelled here, but Order -- which acts
+    # on the whole party at once, not one actor -- pushes Scene::Order
+    # directly, the same `UpdateCommand` shape Item/Save already use).
+    # Cancelling back out of actor selection returns focus to the command
+    # list. End Game opens a Yes/No confirmation (see #open_end_game_confirm);
+    # only confirming "Yes" there returns to the title. Any further command
+    # (there are none left in the built command list today) falls back to a
+    # "not implemented yet" message.
     class Menu < Base
       SCREEN_W = RPG2k::WIDTH
       SCREEN_H = RPG2k::HEIGHT
@@ -42,22 +44,26 @@ class RPG2k
       # Skill=2, Equipment=3, Save=4, Status=5, Row=6, Order=7, Wait=8; Quit=9
       # is never itself in the list -- `Scene_Menu` appends it unconditionally
       # after the loop, which #build_commands mirrors below). Row (battle
-      # front/back rank), Order (party reordering) and Wait (the ATB toggle)
-      # have no entry here and are silently skipped: they are RPG2003
-      # battle-system features this runtime does not model, the same
-      # reported-gap precedent the Toggle ATB Mode (5003) event command
-      # entry already establishes elsewhere. A real RPG2003 game's array
-      # (mtf-meido-action's is `[1, 2, 3, 4, 5, 6, 7, 8]`, confirmed by
-      # `db.rpg2003?` and reading chunk 22 by id under the CRuby host
-      # harness, where `db.system` itself collides with Kernel#system) can
-      # both omit a command (hiding it, e.g. a game with no Save on principle)
-      # and reorder the survivors, both of which #build_commands honours.
+      # front/back rank) and Wait (the ATB toggle) have no entry here and are
+      # silently skipped: they are RPG2003 battle-system features this runtime
+      # does not model, the same reported-gap precedent the Toggle ATB Mode
+      # (5003) event command entry already establishes elsewhere. Order
+      # (party reordering, id 7) *is* modelled -- unlike Row/Wait it has no
+      # battle-system dependency at all, just Game::Party#reorder and
+      # Scene::Order (see #select_command's :order branch). A real RPG2003
+      # game's array (mtf-meido-action's is `[1, 2, 3, 4, 5, 6, 7, 8]`,
+      # confirmed by `db.rpg2003?` and reading chunk 22 by id under the CRuby
+      # host harness, where `db.system` itself collides with Kernel#system)
+      # can both omit a command (hiding it, e.g. a game with no Save on
+      # principle) and reorder the survivors, both of which #build_commands
+      # honours.
       RPG2K3_COMMAND_IDS = {
         1 => [:item, :battle_item, "Item"],
         2 => [:skill, :battle_skill, "Skill"],
         3 => [:equip, :battle_equipment, "Equip"],
         4 => [:save, :battle_save, "Save"],
-        5 => [:status, :status, "Status"]
+        5 => [:status, :status, "Status"],
+        7 => [:order, :order, "Order"]
       }.freeze
 
       def initialize parent, state
@@ -295,6 +301,17 @@ class RPG2k
           else
             play_system_se(SFX_DECISION)
             enter_actor_selection(key)
+          end
+        when :order
+          # Reordering a single-member (or empty) party is meaningless --
+          # confirmed against EasyRPG's own `Scene_Menu::UpdateCommand`'s
+          # `Order` branch, which gates on `GetActors().size() <= 1` rather
+          # than the plain-empty check every other command here uses.
+          if @state.party.actors.size <= 1
+            play_system_se(SFX_BUZZER)
+          else
+            play_system_se(SFX_DECISION)
+            @parent.push Scene::Order.new(@parent, @state)
           end
         when :save
           # A disabled Save command (Change Save Access off) just refuses the

--- a/mruby-rpg2k/mrblib/scene/order.rb
+++ b/mruby-rpg2k/mrblib/scene/order.rb
@@ -1,0 +1,206 @@
+class RPG2k
+  module Scene
+    # The field Order screen (RPG2003 main menu -> Order, System chunk 22 field
+    # 27's `menu_commands` id 7). Reorders the party front-to-back -- confirmed
+    # against EasyRPG's own `Scene_Order`: it is a *pick-and-place* build, not a
+    # swap or a drag-drop. The left column lists the current party in its
+    # existing order; the player picks members one at a time (DOWN/UP to move,
+    # C to pick), and each pick is appended to the right column in the order
+    # picked -- the eventual front-to-back order. A picked member's name
+    # disappears from the left column (but the row stays selectable and picking
+    # it again is rejected with the Cancel SE, `Scene_Order::UpdateOrder`'s own
+    # `std::find` guard) so the player always sees who is left. Cancel undoes
+    # the most recent pick one at a time, or leaves the screen once nothing is
+    # picked yet. Once every member has been picked, a Confirm/Redo prompt
+    # takes over (`window_confirm`): Confirm applies the new order and closes
+    # the screen, Redo (or Cancel here) clears every pick and starts over.
+    # Reordering can change the party leader outright -- `Game::Party#leader`
+    # is simply `@actors.first` -- exactly like genuine RPG_RT.
+    class Order < Base
+      SCREEN_W = RPG2k::WIDTH
+      SCREEN_H = RPG2k::HEIGHT
+      LINE_H = 16
+      # Width of the left (current order) and right (picked order) columns,
+      # and of the Confirm/Redo prompt below them.
+      COLUMN_W = 96
+
+      def initialize parent, state
+        super parent
+        @state = state
+        @skin = make_windowskin
+        @names = @state.party.actors.map { |a| a.name.to_s }
+        @picked = Array.new(@names.size)   # original index picked into slot i, or nil
+        @counter = 0
+        @cursor_index = 0
+        @confirm_index = 0
+        @focus = :left
+        build_windows
+      end
+
+      def dispose
+        @left_window.dispose if @left_window
+        @right_window.dispose if @right_window
+        @confirm_window.dispose if @confirm_window
+      end
+
+      def update
+        @focus == :confirm ? update_confirm : update_left
+      end
+
+      private
+
+      def update_left
+        if Input.trigger?(Input::B)
+          play_system_se(SFX_CANCEL)
+          @counter == 0 ? @parent.pop : undo_last_pick
+        elsif Input.trigger?(Input::DOWN)
+          move_cursor(1)
+        elsif Input.trigger?(Input::UP)
+          move_cursor(-1)
+        elsif Input.trigger?(Input::C)
+          pick_current
+        end
+      end
+
+      def move_cursor(delta)
+        @cursor_index += delta
+        @cursor_index %= @names.size
+        refresh_left_cursor
+        play_system_se(SFX_CURSOR)
+      end
+
+      # Reject re-picking an already-picked slot (its left-column text is
+      # blank, but the row is still there to land the cursor on) with the
+      # Cancel SE -- `Scene_Order::UpdateOrder`'s own duplicate guard plays
+      # the same SE genuine RPG_RT does for a rejected-but-confirmed choice
+      # elsewhere in this menu (matching #choose_item/#choose_skill's Buzzer
+      # precedent would be a different, unconfirmed SE).
+      def pick_current
+        if @picked.include?(@cursor_index)
+          play_system_se(SFX_CANCEL)
+          return
+        end
+        play_system_se(SFX_DECISION)
+        @picked[@counter] = @cursor_index
+        @counter += 1
+        refresh_left_window
+        refresh_right_window
+        enter_confirm if @counter == @names.size
+      end
+
+      def undo_last_pick
+        @counter -= 1
+        @picked[@counter] = nil
+        refresh_left_window
+        refresh_right_window
+      end
+
+      def enter_confirm
+        @focus = :confirm
+        @confirm_index = 0
+        @left_window.active = false
+        @confirm_window.visible = true
+        @confirm_window.active = true
+        refresh_confirm_cursor
+      end
+
+      # Matches `Scene_Order::UpdateConfirm`: Cancel and choosing "Redo" both
+      # funnel into #redo, whose own Cancel SE plays regardless of which input
+      # triggered it -- Decision on "Confirm" is the only path with its own SE.
+      def update_confirm
+        if Input.trigger?(Input::B)
+          redo_picks
+        elsif Input.trigger?(Input::DOWN) || Input.trigger?(Input::UP)
+          @confirm_index = @confirm_index == 0 ? 1 : 0
+          refresh_confirm_cursor
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C)
+          @confirm_index == 0 ? confirm_order : redo_picks
+        end
+      end
+
+      def confirm_order
+        play_system_se(SFX_DECISION)
+        @state.party.reorder(@picked.compact)
+        @parent.pop
+      end
+
+      def redo_picks
+        play_system_se(SFX_CANCEL)
+        @picked = Array.new(@names.size)
+        @counter = 0
+        @cursor_index = 0
+        refresh_left_window
+        refresh_right_window
+        @left_window.active = true
+        @confirm_window.visible = false
+        @confirm_window.active = false
+        @focus = :left
+        refresh_left_cursor
+      end
+
+      def build_windows
+        h = @names.size * LINE_H + Window::BORDER * 2
+        @left_window = Window.new(20, 20, COLUMN_W, h)
+        @left_window.z = 400
+        @left_window.windowskin = @skin
+        @right_window = Window.new(20 + COLUMN_W, 20, COLUMN_W, h)
+        @right_window.z = 400
+        @right_window.windowskin = @skin
+        refresh_left_window
+        refresh_right_window
+        refresh_left_cursor
+
+        # "Confirm"/"Redo" have no slot of their own in RPG2000/2003's Term
+        # table -- EasyRPG only gained translatable fields for them
+        # (`easyrpg_order_scene_confirm`/`_redo`) as its own extension, which
+        # this schema (modelled on genuine RPG_RT's own chunk layout) does not
+        # carry, so these stay plain English same as genuine RPG_RT itself.
+        labels = ['Confirm', 'Redo']
+        ch = labels.size * LINE_H + Window::BORDER * 2
+        @confirm_window = Window.new((SCREEN_W - COLUMN_W) / 2, SCREEN_H - ch - 20, COLUMN_W, ch)
+        @confirm_window.z = 450
+        @confirm_window.windowskin = @skin
+        cc = Bitmap.new(COLUMN_W - Window::BORDER * 2, labels.size * LINE_H)
+        cc.font.color = Color.new(255, 255, 255, 255)
+        labels.each_with_index { |l, i| cc.draw_text 0, i * LINE_H, cc.width, LINE_H, l }
+        @confirm_window.contents = cc
+        @confirm_window.visible = false
+        @confirm_window.active = false
+      end
+
+      def refresh_left_window
+        inner_w = COLUMN_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, @names.size * LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        @names.each_with_index do |name, i|
+          next if @picked.include?(i)
+          c.draw_text 0, i * LINE_H, inner_w, LINE_H, name
+        end
+        @left_window.contents = c
+      end
+
+      def refresh_right_window
+        inner_w = COLUMN_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, @names.size * LINE_H)
+        c.font.color = Color.new(255, 255, 255, 255)
+        @picked.each_with_index do |orig, i|
+          next unless orig
+          c.draw_text 0, i * LINE_H, inner_w, LINE_H, @names[orig]
+        end
+        @right_window.contents = c
+      end
+
+      def refresh_left_cursor
+        @left_window.cursor_rect =
+          Rect.new(0, @cursor_index * LINE_H, @left_window.contents.width, LINE_H)
+      end
+
+      def refresh_confirm_cursor
+        @confirm_window.cursor_rect =
+          Rect.new(0, @confirm_index * LINE_H, @confirm_window.contents.width, LINE_H)
+      end
+    end
+
+  end
+end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3396,6 +3396,28 @@ check 'add_actor no-ops once the party already holds MAX_SIZE (4) members' do
      'adding is allowed again once a member has left and freed a slot'
 end
 
+check 'Party#reorder applies a picked front-to-back permutation, ' \
+      'and can change the leader' do
+  # RPG2003's Order menu command -- see Scene::Order (mruby-rpg2k/mrblib/
+  # scene/order.rb), which builds exactly this kind of permutation one pick
+  # at a time and hands it to #reorder. Confirmed against EasyRPG's own
+  # `Scene_Order::Confirm`, which has the same net effect (remove every
+  # member, then re-add them in the picked order).
+  players = (1..4).to_h { |i| [i, FakePlayerRow.new("Actor#{i}", '', 0, 1, max_hp: 10)] }
+  db = FakeActorDB.new(players, [1, 2, 3, 4])
+  party = Game::Party.new(db)
+  before_revision = party.revision
+
+  party.reorder([2, 0, 1, 3])
+  eq [3, 1, 2, 4], party.actors.map(&:id),
+     'index 2 (Actor3) leads, then the picked order of the rest'
+  eq 3, party.leader.id, 'the leader changed along with slot 0'
+  ok party.revision > before_revision, 'reordering bumps @revision like #promote_to_leader'
+
+  party.reorder([0, 1, 2, 3])
+  eq [3, 1, 2, 4], party.actors.map(&:id), 'the identity permutation (by current index) is a no-op order'
+end
+
 check 'Actors builds each id once and reports a missing row as nil' do
   roster = Game::Actors.new(roster_db)
   a = roster[1]

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10753,6 +10753,7 @@ class MenuStubParty
   end
   def field_items(_state = nil); []; end
   def field_skills(_actor, _state = nil); []; end
+  def reorder(new_order); @actors = new_order.map { |i| @actors[i] }; end
 end
 
 def menu_scene(klass, state, db = fake_db)
@@ -10781,6 +10782,27 @@ end
 
 def wrap_menu_state
   Game::State.new(WrapMenuParty.new, 1, 0, 0)
+end
+
+# A two-actor party with distinct names (WrapMenuParty's two MenuStubActors are
+# both unavoidably named "Hero") -- what the Scene::Order checks need in order
+# to tell the left/right columns' rows apart by name rather than only by index.
+class OrderStubActor < MenuStubActor
+  def initialize(name)
+    super()
+    @name = name
+  end
+end
+
+class OrderStubParty < MenuStubParty
+  def initialize
+    super
+    @actors = [OrderStubActor.new('Hero'), OrderStubActor.new('Ally')]
+  end
+end
+
+def order_state
+  Game::State.new(OrderStubParty.new, 1, 0, 0)
 end
 
 check 'the menu party list shows each member condition' do
@@ -11007,18 +11029,19 @@ check 'Scene::Menu: RPG2000 (no rpg2003? flag) never offers Status at all' do
 end
 
 check 'Scene::Menu: an RPG2003 database drives the command list from ' \
-      'System.menu_commands, Status included' do
+      'System.menu_commands, Status and Order included' do
   # mtf-meido-action's own array, id-for-id (confirmed by loading its real
   # RPG_RT.ldb): every one of RPG2003's eight customizable ids, in ascending
-  # order. Row (6) / Order (7) / Wait (8) are RPG2003 battle-system features
-  # this runtime does not model (the same reported-gap precedent as Toggle ATB
-  # Mode, 5003) and are silently skipped; End Game is appended unconditionally,
-  # matching EasyRPG's own unconditional Quit push outside the customized loop.
+  # order. Row (6) and Wait (8) are RPG2003 battle-system features this
+  # runtime does not model (the same reported-gap precedent as Toggle ATB
+  # Mode, 5003) and are silently skipped; Order (7) has no such dependency and
+  # is offered, same as Status; End Game is appended unconditionally, matching
+  # EasyRPG's own unconditional Quit push outside the customized loop.
   db = fake_db(rpg2003: true, menu_commands: [1, 2, 3, 4, 5, 6, 7, 8])
   scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)
   keys = scene.instance_variable_get(:@commands).map(&:first)
-  eq [:item, :skill, :equip, :save, :status, :end_game], keys,
-     'Status (id 5) is offered, and Row/Order/Wait are dropped rather than crashing'
+  eq [:item, :skill, :equip, :save, :status, :order, :end_game], keys,
+     'Status (id 5) and Order (id 7) are offered, Row/Wait (6/8) are dropped rather than crashing'
 end
 
 check 'Scene::Menu: RPG2003 System.menu_commands can reorder and omit commands' do
@@ -11039,6 +11062,165 @@ check 'Scene::Menu: RPG2003 System.menu_commands can reorder and omit commands' 
   RGSS::Input.reset
   ok scene.parent.pushed.last.is_a?(RPG2k::Scene::StatusMenu),
      'selecting the reordered Status command actually opens Scene::StatusMenu'
+end
+
+check 'Scene::Menu: choosing Order pushes Scene::Order directly, no actor-' \
+      'selection step' do
+  # Unlike Skill/Equip/Status, Order acts on the whole party at once --
+  # confirmed against EasyRPG's own Scene_Menu::UpdateCommand, whose `case
+  # Order:` pushes Scene_Order straight away, the same shape as Item/Save,
+  # not the Skill/Equipment/Status/Row actor-selection branch.
+  db = fake_db(rpg2003: true, menu_commands: [1, 7])
+  scene = menu_scene(RPG2k::Scene::Menu, wrap_menu_state, db)
+  eq [:item, :order, :end_game], scene.instance_variable_get(:@commands).map(&:first)
+  scene.instance_variable_set(:@index, 1)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  pushed = scene.parent.pushed.last
+  ok pushed.is_a?(RPG2k::Scene::Order), "Order pushes a live Scene::Order, got #{pushed.class}"
+  eq :command, scene.instance_variable_get(:@focus),
+     'no actor-selection focus change, unlike Skill/Equip/Status'
+end
+
+check 'Scene::Menu: Order refuses a single-member party with the buzzer, ' \
+      'no scene pushed' do
+  # Confirmed against EasyRPG's own Scene_Menu::UpdateCommand's `Order`
+  # branch, which gates on `GetActors().size() <= 1` rather than the plain
+  # empty-party check every other command here uses -- reordering a single
+  # member is meaningless.
+  db = fake_db(rpg2003: true, menu_commands: [7])
+  scene = menu_scene(RPG2k::Scene::Menu, menu_state, db) # menu_state: one actor
+  scene.instance_variable_set(:@index, 0)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  ok scene.parent.pushed.empty?, 'nothing pushed for a one-member party'
+end
+
+# -- Scene::Order: RPG2003's party-reordering screen --------------------------
+#
+# Confirmed against EasyRPG Player's own `Scene_Order::UpdateOrder`/
+# `UpdateConfirm`/`Redo`/`Confirm`: the player picks party members one at a
+# time from a left column (building a right column in the picked order), then
+# confirms or redoes the whole pick from a two-option prompt. This is *not* a
+# swap or drag-drop -- see mruby-rpg2k/mrblib/scene/order.rb's own class
+# comment.
+
+def order_scene(state = order_state, db = fake_db)
+  [RPG2k::Scene::Order.new(fake_parent(db), state), state]
+end
+
+check 'Scene::Order: picking a member moves them from the left column to ' \
+      'the next right-column slot' do
+  scene, = order_scene
+  eq [nil, nil], scene.instance_variable_get(:@picked), 'nobody picked yet'
+  RGSS::Input.triggered = [RGSS::Input::C] # pick cursor row 0 (Hero)
+  scene.update
+  RGSS::Input.reset
+  eq [0, nil], scene.instance_variable_get(:@picked), 'index 0 picked into the first slot'
+  eq 1, scene.instance_variable_get(:@counter)
+  left_texts = window_texts(scene.instance_variable_get(:@left_window))
+  ok !left_texts.include?('Hero'), 'the picked member\'s name disappears from the left column'
+  ok left_texts.include?('Ally'), 'an unpicked member is still listed there'
+  ok window_texts(scene.instance_variable_get(:@right_window)).include?('Hero'),
+     'and appears in the right column'
+end
+
+check 'Scene::Order: re-picking an already-picked slot is rejected with ' \
+      'the Cancel SE, not Decision' do
+  scene, = order_scene
+  RGSS::Input.triggered = [RGSS::Input::C] # pick row 0
+  scene.update
+  RGSS::Input.reset
+  scene.instance_variable_set(:@cursor_index, 0) # land back on the now-picked row
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@counter), 'the duplicate pick did not register'
+  eq 'Cancel1', RGSS::Audio.se_calls.last[0],
+     'Scene_Order::UpdateOrder\'s own duplicate guard plays the Cancel SE'
+end
+
+check 'Scene::Order: Cancel undoes the most recent pick, one at a time' do
+  scene, = order_scene
+  RGSS::Input.triggered = [RGSS::Input::C] # pick row 0
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  eq [nil, nil], scene.instance_variable_get(:@picked), 'the pick was undone'
+  eq 0, scene.instance_variable_get(:@counter)
+  ok window_texts(scene.instance_variable_get(:@left_window)).include?('Hero'),
+     'the undone member\'s name is back in the left column'
+  ok scene.parent.pushed.empty? && !scene.parent.pop_called, 'still on this screen'
+end
+
+check 'Scene::Order: Cancel with nothing picked leaves the screen' do
+  scene, = order_scene
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.reset
+  ok scene.parent.pop_called, 'popped with no picks made yet'
+end
+
+check 'Scene::Order: picking every member opens the Confirm/Redo prompt, ' \
+      'Confirm applies the new order to Game::Party#reorder and closes' do
+  scene, state = order_scene
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move onto the second (last) actor
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # pick index 1 first
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::UP] # back onto index 0
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # pick index 0 second
+  scene.update
+  RGSS::Input.reset
+  eq :confirm, scene.instance_variable_get(:@focus), 'both picked -- prompt opens'
+  eq 0, scene.instance_variable_get(:@confirm_index), 'defaults to Confirm'
+
+  before = state.party.actors.map(&:object_id)
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm
+  scene.update
+  RGSS::Input.reset
+  eq before.reverse, state.party.actors.map(&:object_id),
+     'the party was reordered to the picked order (second actor first)'
+  ok scene.parent.pop_called, 'the screen closes on Confirm'
+end
+
+check 'Scene::Order: Redo clears every pick and returns to the left column, ' \
+      'without touching the party' do
+  scene, state = order_scene
+  original_order = state.party.actors.map(&:object_id)
+  RGSS::Input.triggered = [RGSS::Input::C] # pick index 0
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move onto the only unpicked row
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::C] # pick index 1 -- both picked, prompt opens
+  scene.update
+  RGSS::Input.reset
+  eq :confirm, scene.instance_variable_get(:@focus)
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move onto "Redo"
+  scene.update
+  RGSS::Input.reset
+  eq 1, scene.instance_variable_get(:@confirm_index)
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+
+  eq :left, scene.instance_variable_get(:@focus), 'back to picking'
+  eq [nil, nil], scene.instance_variable_get(:@picked), 'every pick cleared'
+  eq 0, scene.instance_variable_get(:@counter)
+  ok scene.parent.pushed.empty? && !scene.parent.pop_called, 'still on this screen'
+  eq original_order, state.party.actors.map(&:object_id), 'the party is untouched'
 end
 
 # -- Scene::SaveLoad: the save/load file-select screen -------------------------


### PR DESCRIPTION
## Summary

- RPG2003's Order menu command (`menu_commands` id 7) turns out to have no dependency on the unmodelled battle system, unlike Row and Wait — it's pure party-array reordering. `RPG2K3_COMMAND_IDS` (`mruby-rpg2k/mrblib/scene/menu.rb`) now maps id 7 to `:order`, and `Scene::Menu#select_command` pushes a new `Scene::Order` directly (same shape as Item/Save — Order acts on the whole party at once, not one actor), gated on the party holding more than one member (matching EasyRPG's own `Scene_Menu::UpdateCommand`'s `Order` branch).
- New `Game::Party#reorder(new_order)` (`mruby-rpg2k/mrblib/game.rb`) rebuilds `@actors` from a permutation of the current indices, bumping `@revision` the same as the existing `#promote_to_leader` since reordering can change the party leader outright (`#leader` is `@actors.first`).
- New `Scene::Order` (`mruby-rpg2k/mrblib/scene/order.rb`) is the RGSS UI. The interaction model was confirmed against EasyRPG Player's own `Scene_Order` source rather than guessed: it's a **pick-and-place build, not a swap or drag-drop** — the player picks party members one at a time into a right-hand column in the order picked, then confirms or redoes from a two-option prompt. Cancel undoes the most recent pick, or leaves the screen with nothing picked; re-picking an already-picked (blanked) row is rejected with the Cancel SE, matching `UpdateOrder`'s own duplicate guard; Redo clears every pick.
- `docs/TODO.md` and the `scene/menu.rb` doc comment are updated to split Order out from Row/Wait, which remain correctly described as blocked on the unmodelled RPG2003 battle system.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 809 checks passed (new `Party#reorder` unit check)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 547 checks passed (new `Scene::Menu`/`Scene::Order` dispatch, pick/undo/duplicate/confirm/redo checks; updated the pre-existing RPG2003 command-list check now that Order is offered)
- [x] Added `changelog.d/rpg2003-menu-order-command.added.md`
- No C++ changed, so the native CTest/Google Test suite is unaffected.

https://claude.ai/code/session_01RzGRJeAKcZ5LRQMUf5Y6z4


---
_Generated by [Claude Code](https://claude.ai/code/session_01RzGRJeAKcZ5LRQMUf5Y6z4)_