### PR TITLE
Fix jump-arc height to cap at one tile instead of overshooting to 21px

### DIFF
--- a/changelog.d/rpg2k-jump-arc-height-cap.fixed.md
+++ b/changelog.d/rpg2k-jump-arc-height-cap.fixed.md
@@ -1,0 +1,6 @@
+- **A jumping character's hop now peaks at exactly one tile (16px), instead
+  of overshooting to 21px.** Confirmed against EasyRPG Player's source
+  (`Game_Character::GetJumpHeight`): the jump-height formula's own offset/cap
+  shape was previously mis-ported as an uncapped `h + 5`, missing the real
+  formula's `h < 13 ? h + 4 : 16` cap — every full-height jump (hero or
+  event) rose about 31% past the real arc's own ceiling.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -286,10 +286,23 @@ The work below is roughly ordered by the critical path to a walkable game
   step still snaps rather than streaking) and is lifted along the way by
   `Scene::Map#event_jump_offset`, a port of EasyRPG's
   `Game_Character::GetJumpHeight`: the height tracks the remaining step, peaks at
-  the midpoint and is then stretched — doubled while small, offset by 5 past 4 —
-  which is what makes the hop leave the ground sharply and hang near the top. It
-  peaks at 21px on a 16px tile, so a jumping sprite clearly leaves its row. The
-  lift is applied where the sprite is **blitted**, not to its position, so the
+  the midpoint and is then stretched — doubled while small, offset by 4 through
+  h < 13, capped at a flat 16 beyond that — which is what makes the hop leave the
+  ground sharply and hang near the top. ✅ **That cap/offset shape is now the
+  real EasyRPG one — it was previously mis-ported as an uncapped `h + 5`,
+  peaking at 21px (5px, ~31%, past the real arc's own ceiling) instead of the
+  correct, exact 16px (a full tile, never past it).** Fixed by capping
+  `#jump_offset_for` at `h < 13 ? h + 4 : 16`, matching `GetJumpHeight`'s
+  own three-way `jump_height < 5 ? jump_height*2 : jump_height < 13 ?
+  jump_height+4 : 16` exactly; the cap also flattens the true peak into a
+  3-frame plateau (h=14 already caps to 16 one frame either side of the true
+  midpoint's own h=16) rather than a single sharp point, matching "hang near
+  the top" more literally than the old formula did. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check pinning `#jump_offset_for`'s exact
+  value at both branches and the plateau, plus tightened existing checks
+  (an event's own jump and a forced player jump both now assert the correct
+  16px peak instead of 21px), all confirmed to fail against the pre-fix code
+  before the fix. The lift is applied where the sprite is **blitted**, not to its position, so the
   camera and the y-sorted draw order still see the character on the ground, as
   RPG_RT does. `Game::Character#jumped` is what tells the renderer which kind of
   move it is watching, since the distance cannot: a jump can land one tile away

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -2347,10 +2347,14 @@ class RPG2k
       # A port of EasyRPG's `Game_Character::GetJumpHeight`, kept in its own
       # 256-per-tile units so the formula reads as it does there: the height
       # rises and falls linearly with the remaining step, peaking at the
-      # midpoint, and is then stretched -- doubled while small, offset by 5 once
-      # past 4 -- which is what makes the hop leave the ground sharply and hang
-      # near the top. The peak is 21px on a 16px tile, so a jumping sprite
-      # clearly leaves its row.
+      # midpoint, and is then stretched -- doubled while small (h < 5), offset
+      # by 4 through h < 13, and capped at a flat 16 beyond that -- which is
+      # what makes the hop leave the ground sharply, hang near the top, and
+      # never rise past a full tile. The peak is exactly 16px on a 16px tile,
+      # so a jumping sprite clearly leaves its row without overshooting it.
+      # (This offset/cap shape was previously mis-ported as an uncapped `h +
+      # 5`, peaking at 21px -- 5px, ~31%, past the real arc's own ceiling --
+      # now corrected to match EasyRPG's actual source exactly.)
       #
       # The lift is applied where the sprite is blitted, not inside #event_pixel:
       # RPG_RT raises the drawn character without moving it, so its logical
@@ -2369,7 +2373,8 @@ class RPG2k
         remaining = (TILE - move_count) * (JUMP_STEP_UNITS / TILE)
         half = JUMP_STEP_UNITS / 2
         h = (remaining > half ? JUMP_STEP_UNITS - remaining : remaining) / 8
-        h < 5 ? h * 2 : h + 5
+        return h * 2 if h < 5
+        h < 13 ? h + 4 : 16
       end
 
       # Current position of event `e` in map pixels, interpolated from its

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -770,7 +770,7 @@ check 'a jumping sprite is lifted off the ground and comes back down' do
     heights << scene.send(:event_jump_offset, e) if e[:jumping]
   end
   ok heights.max > 0, 'the sprite left the ground'
-  eq 21, heights.max, "RPG_RT's arc peaks at 21px on a 16px tile"
+  eq 16, heights.max, "RPG_RT's arc peaks at exactly 16px on a 16px tile, never past it"
   # It is an arc, not a step up: it rises from nothing and returns.
   peak = heights.index(heights.max)
   ok peak > 0, 'the hop starts on the ground'
@@ -12552,7 +12552,7 @@ check 'a forced player jump arcs the hero the way it arcs an event' do
     heights << h if scene.instance_variable_get(:@player_jumping)
   end
   eq 2, st.x, 'the hop cleared two tiles'
-  eq 21, heights.max, 'and rose to the same peak an event does'
+  eq 16, heights.max, 'and rose to the same peak an event does'
   peak = heights.index(heights.max)
   ok heights[0...peak] == heights[0...peak].sort,
      "rises to the peak: #{heights.inspect}"
@@ -12561,6 +12561,29 @@ check 'a forced player jump arcs the hero the way it arcs an event' do
   eq 0, scene.send(:jump_offset_for, 0), 'the hop begins on the ground'
   eq 0, scene.send(:jump_offset_for, Game::TILE), 'and ends on it'
   eq 0, scene.send(:player_jump_offset), 'and the hero is back on it once landed'
+end
+
+# EasyRPG's own Game_Character::GetJumpHeight (src/game_character.cpp) is
+# `jump_height &lt; 5 ? jump_height * 2 : jump_height &lt; 13 ? jump_height + 4 :
+# 16` -- doubled while small, offset by 4 through h < 13, and capped at a
+# flat 16 beyond that. #jump_offset_for used to mis-port this as an
+# uncapped `h + 5`, peaking at 21px instead of the real arc's own 16px
+# ceiling (a full tile, never past it).
+check "#jump_offset_for's piecewise arc matches EasyRPG's GetJumpHeight exactly" do
+  scene = new_scene({})
+  jh = ->(move_count) { scene.send(:jump_offset_for, move_count) }
+  eq 0, jh.call(0), 'move_count 0: the hop begins on the ground'
+  eq 0, jh.call(Game::TILE), 'move_count 16: and ends on it'
+  eq 4, jh.call(15), 'move_count 15: h=2, the doubled branch (2*2)'
+  eq 4, jh.call(1), 'move_count 1: the symmetric doubled-branch point'
+  eq 12, jh.call(12), 'move_count 12: h=8, the +4 branch (8+4)'
+  eq 12, jh.call(4), 'move_count 4: the symmetric +4-branch point'
+  # The cap flattens the true peak into a 3-frame plateau at exactly 16, not
+  # a single sharp point -- h=14 at move_count 7 and 9 is already >= 13 and
+  # caps the same as h=16's own move_count 8, matching "hang near the top."
+  eq 16, jh.call(9), 'move_count 9: h=14, already capped'
+  eq 16, jh.call(8), 'move_count 8: h=16, the true midpoint'
+  eq 16, jh.call(7), 'move_count 7: h=14, capped again, symmetric'
 end
 
 check 'a forced player walk is never lifted' do


### PR DESCRIPTION
## Summary
- `Scene::Map#jump_offset_for`'s offset/cap shape was mis-ported from EasyRPG's `Game_Character::GetJumpHeight` as an uncapped `h + 5`, peaking at 21px on a 16px tile — self-documented in the code's own comment as an intentional-looking design choice ("The peak is 21px on a 16px tile, so a jumping sprite clearly leaves its row"), but the comment's own framing ("a port of EasyRPG's `Game_Character::GetJumpHeight`") reveals the actual intent was a faithful port that didn't quite match.
- Confirmed against EasyRPG Player's real source: the formula is `jump_height < 5 ? jump_height*2 : jump_height < 13 ? jump_height+4 : 16` — capped at a flat 16 (one full tile) once `h` reaches 13, not an unconditional `+5`. Every full-height jump (hero or event alike, both share this same formula) rose about 31% past the real arc's own ceiling.
- Fixed by adding the missing cap. The cap also flattens the true peak into a 3-frame plateau (h=14 one frame either side of the true midpoint's own h=16, both capping to 16) rather than a single sharp point, matching the code's own "hang near the top" framing more literally than the old formula did.

## Testing
- New `scripts/rpg2k_scene_check.rb` check pinning `#jump_offset_for`'s exact value at both branches and the plateau (doubled branch, +4 branch, and the 3-frame cap plateau at move_count 7/8/9), plus tightened two existing checks (an event's own jump and a forced player jump both now assert the correct 16px peak instead of 21px) — all confirmed to fail against the pre-fix code (`21` instead of `16`, `13` instead of `12`) before the fix.
- `ruby -c mruby-rpg2k/mrblib/scene/map.rb` / `ruby -c scripts/rpg2k_scene_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- `ruby scripts/rpg2k_scene_check.rb` — 540 checks passed
- `ruby scripts/rpg2k_logic_check.rb` — 808 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_