### PR TITLE
Fix enemy AI "Enemies" condition to check the monster troop, not the party

### DIFF
--- a/changelog.d/rpg2k-enemy-ai-actor-count-condition.fixed.md
+++ b/changelog.d/rpg2k-enemy-ai-actor-count-condition.fixed.md
@@ -1,0 +1,7 @@
+- **An action pattern's "Enemies" condition now ranges over the acting
+  monster's own living troop-mates, instead of the player party's headcount.**
+  Confirmed against EasyRPG Player's source (`EnemyAi::IsActionValid`): the
+  real condition reads the monster troop's own active-battler count, not the
+  player party's. Any action pattern using this condition (a boss escalating
+  once its escorts are down, a minion firing only while several troop-mates
+  remain) evaluated against the wrong side's population entirely.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6917,6 +6917,28 @@ not yet verified:
   ineffective rating-60 skill's own rating even though the skill itself
   never fires), all three confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **An action pattern's "Enemies" condition (`condition_type` 3,
+  `COND_ACTORS`) now ranges over the acting monster's own living
+  troop-mates, not the player party's headcount — a straight side-swap,
+  now fixed.** `Game::Battle#enemy_action_valid?`'s `COND_ACTORS` branch
+  (`mruby-rpg2k/mrblib/game.rb`) counted `@allies.reject(&:out_of_play?)
+  .size` — the number of living *party* members — where EasyRPG Player's
+  own `IsActionValid` (`src/enemyai.cpp`) reads `Main_Data::
+  game_enemyparty`'s own `GetActiveBattlers`, the monster *troop's* own
+  headcount, never `game_party`. Any action pattern using this condition
+  (a boss escalating once its escorts are down, a support minion firing
+  only while several troop-mates remain) evaluated against the wrong
+  side's population entirely — in a typical fixed-size party this made
+  the condition permanently static for the whole fight instead of
+  reacting to the troop actually thinning out. Fixed by reading
+  `@enemies` instead of `@allies`. An existing
+  `scripts/rpg2k_logic_check.rb` check ("an actor-count action ranges
+  over the living party") had itself encoded this same bug rather than
+  independently deriving the real behaviour — replaced with a
+  three-enemy-troop check pinning the condition against the *troop's*
+  own headcount (fires with all three troop-mates alive, stops firing
+  once two are killed off, regardless of the untouched one-hero party),
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An HP-increase cannot revive a downed (0 HP) combatant**, checked
   across all three paths that can raise HP. The **field actor** path
   (`Game::Actor#change_hp`, `mruby-rpg2k/mrblib/game.rb`) was already

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8149,7 +8149,12 @@ module Game
         # BattlePage.check_turns, which documents why it reads backwards).
         BattlePage.check_turns(turn, a.condition_param2, a.condition_param1)
       when EnemyAction::COND_ACTORS
-        n = @allies.reject(&:out_of_play?).size
+        # "Enemies" in the editor's own condition list -- how many of this
+        # monster's own troop-mates are still standing, not the player
+        # party's headcount. EasyRPG's IsActionValid reads
+        # game_enemyparty's own GetActiveBattlers here (src/enemyai.cpp),
+        # never game_party.
+        n = @enemies.reject(&:out_of_play?).size
         n >= a.condition_param1 && n <= a.condition_param2
       when EnemyAction::COND_HP
         within_percent?(b.hp, b.max_hp, a)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11979,10 +11979,26 @@ check 'a switch-gated action is invalid with no AI env to ask' do
   ok enemy_entry([act], nil)[:defend].nil?, 'falls back to attacking'
 end
 
-check 'an actor-count action ranges over the living party' do
+# "Enemies" in the editor's own condition list -- EasyRPG's IsActionValid
+# (src/enemyai.cpp) reads game_enemyparty's own GetActiveBattlers here, never
+# game_party, so this ranges over the acting monster's own living troop-mates,
+# not the player party's headcount.
+check 'an actor-count action ranges over the living enemy troop, not the party' do
   act = enemy_action(kind: 0, basic: 2, condition_type: 3,
                      condition_param1: 2, condition_param2: 4)
-  ok enemy_entry([act], nil)[:defend].nil?, 'a party of one is below the range'
+  hero = combatant('Hero', 40, 0, 20, 500)
+  foe1 = combatant('Slime1', 40, 0, 5, 500)
+  foe1.actions = [act]
+  foe2 = combatant('Slime2', 40, 0, 5, 500)
+  foe3 = combatant('Slime3', 40, 0, 5, 500)
+  b = Game::Battle.new([hero], [foe1, foe2, foe3], Game::Rng.new(1), nil,
+                       false, false, false, false, nil, nil)
+  ok b.send(:enemy_action_valid?, foe1, act),
+     'three troop-mates alive (within 2..4) -- fires regardless of party size'
+  foe2.hp = 0
+  foe3.hp = 0
+  ok !b.send(:enemy_action_valid?, foe1, act),
+     'only foe1 itself left alive now (1, outside 2..4) -- no longer fires'
 end
 
 check 'a turn-gated action uses the battle turn clock' do


### PR DESCRIPTION
## Summary
- `Game::Battle#enemy_action_valid?`'s `COND_ACTORS` branch (the editor's "Enemies" action-pattern condition) counted `@allies.reject(&:out_of_play?).size` — the living **player party's** headcount — instead of the acting monster's own troop.
- Confirmed against EasyRPG Player's source: `EnemyAi::IsActionValid` (`src/enemyai.cpp`) reads `Main_Data::game_enemyparty`'s own `GetActiveBattlers` for this condition, never `game_party`. A straight side-swap.
- Any action pattern using this condition (a boss escalating once its escorts are down, a support minion firing only while several troop-mates remain) evaluated against the wrong side's population entirely — in a typical fixed-size party this made the condition permanently static for the whole fight instead of reacting to the troop actually thinning out.
- Fixed by reading `@enemies` instead of `@allies`.

## Testing
- An existing `scripts/rpg2k_logic_check.rb` check ("an actor-count action ranges over the living party") had itself encoded this same bug rather than independently deriving the real behaviour from source — replaced with a three-enemy-troop check pinning the condition against the *troop's* own headcount (fires with all three troop-mates alive, stops firing once two are killed off, regardless of the untouched one-hero party), confirmed to fail against the pre-fix code before the fix.
- `ruby -c mruby-rpg2k/mrblib/game.rb` / `ruby -c scripts/rpg2k_logic_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- `ruby scripts/rpg2k_logic_check.rb` — 809 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 540 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_