### PR TITLE
Decode SAVE_INVENTORY's turns field (latest battle round count)

### DIFF
--- a/changelog.d/save-battle-turns-lsd.added.md
+++ b/changelog.d/save-battle-turns-lsd.added.md
@@ -1,0 +1,21 @@
+- **Chunk 109's `turns` field (41, "turns passed in latest battle") now
+  round-trips through the `.lsd` too**, the one save-inventory field left
+  deliberately undecoded by the step-counter/battle-tallies fix for lack of a
+  source value. `Game::Battle` already tracks the fight's own round count
+  live (`@rounds`, incremented once per round up to `MAX_ROUNDS`; `#turn`
+  simply returns it) — it just never survived past the fight, since
+  `Scene::Map#finish_battle` discards the `Battle` object once it hands the
+  outcome back to the event. A new `Game::State#last_battle_turns` (nil
+  until a battle has ever finished) is now set from
+  `@battle_ui[:battle].turn` right there, alongside the existing
+  `apply_to_party` call, and persists in both the Marshal save and the
+  `.lsd`, the same as `#steps`. `LCF::Schema::SAVE_INVENTORY` decodes field
+  41 as a plain undefaulted `:int`, matching its neighbours;
+  `Game::State#to_lsd` writes it only when set (so a save taken before any
+  battle leaves the field genuinely absent, not a spurious 0) and
+  `.from_lsd` restores it. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check (a multi-round battle, capturing the round count the way
+  `#finish_battle` does, then an in-memory `to_lsd`/`from_lsd` round-trip; a
+  legacy save with the field absent keeps the `nil` default) and a new
+  `scripts/rpg2k_scene_check.rb` end-to-end check driving a real battle
+  through `Scene::Map` to confirm `#finish_battle` performs the capture.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1045,8 +1045,11 @@ The work below is roughly ordered by the critical path to a walkable game
   through the `.lsd` too: the inventory chunk (109)'s `steps` field (42) is
   decoded and written by `Game::State#to_lsd` / `.from_lsd`, so a resumed real
   save continues its count instead of starting from 0. The chunk's `turns`
-  field (41, "turns passed in latest battle") stays deliberately undecoded —
-  there is no per-battle turn tracker on the Ruby side to source it from yet.
+  field (41, "turns passed in latest battle") is now decoded too:
+  `Game::Battle#turn` (its live `@rounds` counter) is captured onto
+  `Game::State#last_battle_turns` by `Scene::Map#finish_battle` right before
+  the fought `Battle` object is discarded, and round-trips through the same
+  `to_lsd`/`from_lsd` (and Marshal `to_h`/`.load`) pair as `steps`.
   mtf-meido-action's Poison (1 HP every 4 steps) is the only state in either test
   bed that carries the field, and `rpg2k_testbed_logic_check.rb` walks the real
   party through the real interval against it. **`affect_type` stat
@@ -2695,11 +2698,29 @@ The work below is roughly ordered by the critical path to a walkable game
   `nil`; `Game::State#to_lsd` writes the five live counters into them and
   `.from_lsd` restores them, leaving a legacy save's zeroed `State.new`
   defaults in place when the fields are absent. Chunk 109's `turns` field (41,
-  "turns passed in latest battle") stays deliberately undecoded — there is no
-  per-battle turn tracker on the Ruby side to source it from, and building one
-  is a separate, larger feature. Covered by a new `scripts/
+  "turns passed in latest battle") was left deliberately undecoded at the
+  time — there was no per-battle turn tracker on the Ruby side to source it
+  from — and is now wired up too, see below. Covered by a new `scripts/
   rpg2k_logic_check.rb` check (a non-zero step count and battle tallies both
   round-trip through an in-memory `to_lsd`/`from_lsd`).
+  ✅ **Chunk 109's `turns` field (41, "turns passed in latest battle") now
+  round-trips through the `.lsd` too**, the one field the step/battle-tally
+  entry above deliberately left out for lack of a source value.
+  `Game::Battle` already tracks the fight's own round count live (`@rounds`,
+  incremented once per `#run_round` up to `MAX_ROUNDS`; `#turn` simply
+  returns it) — it just never survived past the fight, since
+  `Scene::Map#finish_battle` discards the `Battle` object once it hands the
+  outcome back to the event. A new `Game::State#last_battle_turns`
+  (Marshal-persisted like `#steps`, nil until a battle has ever finished) is
+  now set from `@battle_ui[:battle].turn` right there, alongside the existing
+  `apply_to_party` call. `LCF::Schema::SAVE_INVENTORY` decodes field 41 as a
+  plain undefaulted `:int`, matching its neighbours; `Game::State#to_lsd`
+  writes it (only when set, so a save taken before any battle leaves the
+  field genuinely absent, not a spurious 0) and `.from_lsd` restores it.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check (a multi-round battle,
+  `finish_battle` capturing the round count, then an in-memory
+  `to_lsd`/`from_lsd` round-trip; a legacy save with the field absent stays at
+  the `nil` default).
 - Battle system — enemy groups, battle scene, actions/damage/states,
   animations (large; Nepheshel uses the default RPG2000 battle). Needs real
   assets + the native build to develop against. The game-over scene is done

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1150,8 +1150,8 @@ module LCF
     # and 導きの書 (item 451) ×1, after the gate crystal had been spent. Item ids
     # are int16; counts and per-item use-counts are one byte each. Field 1 is the
     # party roster (actor ids); the sole entry `[1]` is actor 1, whose database
-    # charset matches the saved hero. The step/turn counters (fields 0x29/0x2A)
-    # are left out until confirmed. Fields 23-30 (0x17-0x1E) are the two Timer
+    # charset matches the saved hero. The turn/step counters (fields 0x29/0x2A)
+    # are now decoded too, below. Fields 23-30 (0x17-0x1E) are the two Timer
     # Operation countdowns -- ids and "value is seconds*60+59" both confirmed
     # against liblcf's own `ChunkSaveInventory` enum, which documents them
     # under this chunk rather than the system chunk (101) `docs/TODO.md` used
@@ -1175,16 +1175,18 @@ module LCF
       28 => { name: :timer2_active, type: :bool },
       29 => { name: :timer2_visible, type: :bool },
       30 => { name: :timer2_battle, type: :bool },
-      # Battle tallies and the field step counter, likewise undefaulted --
-      # confirmed against liblcf's SaveInventory struct (all plain int32_t,
-      # like gold). Field 41 (`turns`, "turns passed in latest battle") is
-      # deliberately left out: there is no Ruby-side per-battle turn tracker
-      # to source it from yet, so decoding it here would have nothing to
-      # round-trip.
+      # Battle tallies, the "turns passed in latest battle" counter and the
+      # field step counter, likewise undefaulted -- confirmed against
+      # liblcf's SaveInventory struct (all plain int32_t, like gold). Field
+      # 41 (`turns`) is sourced from `Game::Battle#turn` (its live `@rounds`
+      # counter), captured onto `Game::State#last_battle_turns` by
+      # `Scene::Map#finish_battle` right before the fought `Battle` object is
+      # discarded.
       32 => { name: :battles, type: :int },
       33 => { name: :defeats, type: :int },
       34 => { name: :escapes, type: :int },
       35 => { name: :victories, type: :int },
+      41 => { name: :turns, type: :int },
       42 => { name: :steps, type: :int },
     }
 

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9501,10 +9501,17 @@ module Game
     # it so far -- the encounter system that would share it is not built. It
     # persists in both the Marshal save and the `.lsd` (inventory chunk 109
     # field 42, see LCF::Schema::SAVE_INVENTORY), so a resumed real save
-    # continues its count rather than restarting from 0. The chunk's `turns`
-    # field (41, "turns passed in latest battle") stays deliberately undecoded
-    # -- there is no per-battle turn tracker on the Ruby side to source it from.
+    # continues its count rather than restarting from 0.
     attr_accessor :steps
+    # How many rounds the most recently finished battle ran for -- RPG2000's
+    # "turns passed in latest battle" (inventory chunk 109 field 41, `turns`).
+    # Nil until a battle has ever finished (matching the chunk's own
+    # undefaulted read); `Scene::Map#finish_battle` sets it from
+    # `Game::Battle#turn` (its live `@rounds` counter) right before the fought
+    # `Battle` object is discarded, since nothing else keeps that count once
+    # the fight ends. Persists in both the Marshal save and the `.lsd`, same
+    # as `#steps`.
+    attr_accessor :last_battle_turns
     # Running tallies RPG2000 keeps and exposes through the Control Variables
     # "Other" operand: how many times the game was saved, and how many battles
     # were fought / won / lost / escaped. All persist in the Marshal save; the
@@ -9608,6 +9615,7 @@ module Game
       @encounter_rate = nil
       @encounter_total = 0
       @steps = 0
+      @last_battle_turns = nil
       @save_count = 0
       @battle_count = 0
       @win_count = 0
@@ -9834,7 +9842,7 @@ module Game
         common_event_progress: @common_event_progress,
         map_event_positions: @map_event_positions,
         map_event_route_index: @map_event_route_index,
-        steps: @steps,
+        steps: @steps, last_battle_turns: @last_battle_turns,
         save_count: @save_count, battle_count: @battle_count,
         win_count: @win_count, defeat_count: @defeat_count,
         escape_count: @escape_count,
@@ -9860,7 +9868,8 @@ module Game
     #     Change Sprite override survives);
     #   * actors (108): the per-actor level/exp/equipment/skills/HP/MP table;
     #   * inventory (109): the party roster / gold / item bag / both timers /
-    #     the step counter and battle win/defeat/escape/victory tallies.
+    #     the step counter / battle win/defeat/escape/victory tallies / the
+    #     latest battle's round count.
     #
     # Switch and variable ids are 1-indexed in-game but 0-indexed in the save, so
     # they shift down by one; unset entries default to false / 0. +save_count+
@@ -9875,11 +9884,12 @@ module Game
     # a time until only the title chunk failed, then one field at a time within
     # it. See ADR 0021.
     #
-    # Both Timer Operation countdowns, the step counter, the battle tallies and
-    # every roster member's Change Actor Name and Change Actor Title overrides
-    # round-trip now too (see LCF::Schema::SAVE_INVENTORY's timer1_*/timer2_*,
-    # battles/defeats/escapes/victories/steps fields and SAVE_PARTY_ACTOR's
-    # actor_name/title), so this is a near-parity export.
+    # Both Timer Operation countdowns, the step counter, the battle tallies,
+    # the latest battle's round count and every roster member's Change Actor
+    # Name and Change Actor Title overrides round-trip now too (see
+    # LCF::Schema::SAVE_INVENTORY's timer1_*/timer2_*,
+    # battles/defeats/escapes/victories/steps/turns fields and
+    # SAVE_PARTY_ACTOR's actor_name/title), so this is a near-parity export.
     def to_lsd(save_count = 1, timestamp = nil)
       timestamp = State.ole_now if timestamp.nil?
       save = LCF::SaveData.new
@@ -10034,6 +10044,9 @@ module Game
       inv[34] = @escape_count
       inv[35] = @win_count
       inv[42] = @steps
+      # Undefaulted, like the other counters -- absent until a battle has ever
+      # finished (see #last_battle_turns).
+      inv[41] = @last_battle_turns if @last_battle_turns
       save[109] = inv
 
       save
@@ -10262,6 +10275,9 @@ module Game
       state.escape_count = inv.escapes unless inv.escapes.nil?
       state.win_count = inv.victories unless inv.victories.nil?
       state.steps = inv.steps unless inv.steps.nil?
+      # "Turns passed in latest battle" (field 41); absent on a save written
+      # before this landed, or one taken before any battle ever finished.
+      state.last_battle_turns = inv.turns unless inv.turns.nil?
       state
     end
 
@@ -10381,6 +10397,7 @@ module Game
       state.encounter_rate = h[:encounter_rate]
       state.encounter_total = h[:encounter_total] || 0
       state.steps = h[:steps] || 0
+      state.last_battle_turns = h[:last_battle_turns]
       state.save_count = h[:save_count] || 0
       state.battle_count = h[:battle_count] || 0
       state.win_count = h[:win_count] || 0

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5654,6 +5654,11 @@ class RPG2k
         # Persist the party's post-battle HP (and any knock-outs) before leaving
         # the fight, so damage taken sticks and a downed member stays down.
         @battle_ui[:battle].apply_to_party
+        # Capture the fight's own round count (Game::Battle#turn, its live
+        # @rounds counter) before #close_battle discards the Battle object --
+        # this is RPG2000's "turns passed in latest battle" (Game::State
+        # #last_battle_turns, LCF inventory chunk 109 field 41).
+        @state.last_battle_turns = @battle_ui[:battle].turn
         # A defeat in "game over" mode (no custom [Defeat] handler) with the whole
         # party knocked out ends the game; every other outcome resumes the event.
         game_over = result == :defeat && @battle_ui[:req][:defeat_game_over] &&

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3262,8 +3262,8 @@ check 'to_lsd/from_lsd round-trips the step counter and battle tallies' do
   # only decoded the two timers. Confirmed against liblcf's SaveInventory
   # struct (every field here is a plain int32_t, like gold):
   # battles/defeats/escapes/victories/steps at ids 32/33/34/35/42. Field 41
-  # ("turns passed in latest battle") stays deliberately undecoded -- there
-  # is no per-battle turn tracker on the Ruby side to source it from.
+  # ("turns passed in latest battle") is covered separately below, once
+  # Game::Battle's own round counter is captured onto it.
   db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   st.steps = 1234
@@ -7744,6 +7744,42 @@ def combatant_mp(name, atk, dfn, agi, hp, mp)
   c.mp = mp
   c.max_mp = mp
   c
+end
+
+check 'to_lsd/from_lsd round-trips the latest battle\'s turn count' do
+  # Field 41 ("turns passed in latest battle") used to stay deliberately
+  # undecoded: there was no per-battle turn tracker on the Ruby side to
+  # source it from (see the step-counter-and-battle-tallies check above).
+  # There is now -- Game::Battle already counts its own rounds live
+  # (@rounds, exposed by #turn); Scene::Map#finish_battle (scene/map.rb)
+  # captures it onto Game::State#last_battle_turns right before the fought
+  # Battle object is discarded. This exercises that capture + round-trip
+  # without going through the scene layer: run a fight for a fixed number of
+  # rounds, read #turn the way #finish_battle does, then round-trip it
+  # through to_lsd/from_lsd like the sibling counters do.
+  hero = combatant('Hero', 40, 0, 20, 10_000)
+  slime = combatant('Slime', 0, 0, 5, 10_000) # tanky on both sides: nobody dies mid-loop
+  bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  5.times { bat.run_round }
+  eq 5, bat.turn, 'the battle itself ran exactly 5 rounds'
+
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  eq nil, st.last_battle_turns, 'no battle has ever finished yet'
+  st.last_battle_turns = bat.turn # what #finish_battle does with @battle_ui[:battle].turn
+
+  saved = st.to_lsd
+  round = Game::State.from_lsd(db, saved)
+  eq 5, round.last_battle_turns, 'the latest battle\'s round count round-trips'
+
+  # A save written before this landed simply omits the field; from_lsd must
+  # leave a freshly-constructed State's nil default alone rather than crash
+  # reading an absent field.
+  legacy = st.to_lsd
+  legacy[109].delete(41)
+  old = Game::State.from_lsd(db, legacy)
+  eq nil, old.last_battle_turns,
+     'an old save without the field keeps the default (no battle ever captured)'
 end
 
 # EasyRPG models an actor's and an enemy's own "state id the target's

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5063,6 +5063,32 @@ check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Vi
   ok !st.switches[2], 'the Escape handler was skipped'
 end
 
+# `Game::Battle` already tracks the fight's own round count live (`@rounds`,
+# `#turn`), but nothing captured it before `#close_battle` discarded the
+# `Battle` object once the fight ended -- see docs/TODO.md's "turns passed in
+# latest battle" entry. `#finish_battle` (mruby-rpg2k/mrblib/scene/map.rb) now
+# reads `@battle_ui[:battle].turn` onto `Game::State#last_battle_turns` right
+# alongside the existing `apply_to_party` call, so it survives past
+# `close_battle` for the `.lsd`'s inventory chunk 109 `turns` field (41) to
+# round-trip (see the `to_lsd`/`from_lsd` check in rpg2k_logic_check.rb).
+check 'Enemy Encounter scene: finish_battle captures the round count as last_battle_turns' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  eq nil, st.last_battle_turns, 'no battle has ever finished yet'
+  scene.update # opens the per-actor command menu (Attack / Defend)
+  battle_attack_to_end(scene) # Attack the Slimes each round until they fall
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss the Victory result -> finish_battle
+  scene.update
+  RGSS::Input.triggered = []
+  ok st.last_battle_turns && st.last_battle_turns > 0,
+     "finish_battle captured the fought battle's own round count " \
+     "(got #{st.last_battle_turns.inspect})"
+end
+
 # RPG_RT's own `Scene_Battle` constructor (src/scene_battle.cpp) plays the
 # database's Battle Start system SE (`SFX_BeginBattle`) as its very first act,
 # unconditionally, before even swapping to the battle BGM -- `Scene::Map


### PR DESCRIPTION
## Summary

- Chunk 109's `turns` field (41, "turns passed in latest battle") was left deliberately undecoded by the recent SaveInventory counters fix (#785) — "there is no per-battle turn tracker on the Ruby side to source it from." There is one now: `Game::Battle` already counts its own rounds live (`@rounds`, incremented once per round up to `MAX_ROUNDS`; `#turn` simply returns it) — it just never survived past the fight.
- Added `Game::State#last_battle_turns` (nil until a battle has ever finished), set from `@battle_ui[:battle].turn` in `Scene::Map#finish_battle` right alongside the existing `apply_to_party` call, before `close_battle` discards the `Battle` object.
- Decoded field 41 (`turns`) in `LCF::Schema::SAVE_INVENTORY` as a plain undefaulted `:int`, matching its neighbours (`steps`/`battles`/etc.).
- Wired it into `Game::State#to_lsd` (written only when set, so a save taken before any battle leaves the field genuinely absent) / `.from_lsd`, and into the Marshal `to_h`/`.load` path for consistency with the portable save.
- Updated `docs/TODO.md` and the `schema.rb` comment to reflect this is now wired.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — new round-trip check (multi-round battle → `to_lsd`/`from_lsd`; legacy save with the field absent stays at the `nil` default) — 810 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — new end-to-end check driving a real battle through `Scene::Map` and confirming `#finish_battle` performs the capture — 549 checks passed
- [x] `ruby -c` on every touched `.rb` file


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQSeTzKs9j2Cxe89yKq9Fe)_