### PR TITLE
Widen the total-EXP cap to RPG2003's real 9,999,999

### DIFF
--- a/changelog.d/rpg2k-exp-cap-rpg2003.fixed.md
+++ b/changelog.d/rpg2k-exp-cap-rpg2003.fixed.md
@@ -1,0 +1,7 @@
+- **The total-EXP ceiling now widens to RPG2003's real 9,999,999, instead of
+  staying at RPG2000's narrower 999,999 on every database.** Confirmed
+  against EasyRPG Player's source (`Game_Constants::MaxExpValue`): RPG2003
+  widens the ceiling by 10x, mirroring the same edition split this engine
+  already applies to the max HP cap. On an RPG2003 database (whose own
+  default max level is 99, making six-digit-plus EXP totals realistic), an
+  actor's total EXP was silently truncated at a tenth of the real cap.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5662,6 +5662,30 @@ not yet verified:
   "999 damage against a high-max-HP target leaves it alive" was updated to
   an RPG2003 fixture (9999 ceiling, still comfortably above 5000), since a
   genuine RPG2000 actor can no longer reach that total either.
+- ✅ **The total-EXP ceiling now widens to RPG2003's real 9,999,999 too,
+  mirroring the max-HP edition split directly above rather than staying a
+  bare RPG2000-only 999,999.** `Game::Actor::EXP_MAX` (`mruby-rpg2k/mrblib/
+  game.rb`) was a single, edition-blind `999_999`, consulted by `#set_exp`'s
+  clamp, `#change_level_by`'s max-level EXP sentinel, and `#calc_exp`'s own
+  running-total cap — even though `Actor` already had a working `#rpg2003?`
+  helper used for exactly this pattern (`#max_hp_cap`) a few lines away.
+  EasyRPG's `Game_Constants::MaxExpValue` (`src/game_constants.cpp`) widens
+  the real ceiling to `9'999'999` on an RPG2003 database — matching
+  `MaxStatBaseValue`'s own 999/9999 HP split and every other edition-gated
+  constant this file already keys off `Player::IsRPG2k()`. On an RPG2003
+  database (whose own default max level is 99, not RPG2000's 50, making six-
+  digit-plus EXP totals realistic) an actor's total EXP was silently
+  truncated at a tenth of the real cap. Fixed by splitting the constant into
+  `EXP_MAX_2K`/`EXP_MAX_2K3` and a new `#exp_max` method mirroring
+  `#max_hp_cap` exactly, with all three call sites reading it instead of the
+  old bare constant. Covered by a new `scripts/rpg2k_logic_check.rb` check
+  (an RPG2003 database's `#set_exp` clamps at the wider 9,999,999 instead of
+  999,999; a value between the two editions' ceilings survives untouched,
+  confirming the whole range widened rather than just the display; and a
+  database whose own curve alone would exceed the ceiling still stops at the
+  RPG2003 cap via `#calc_exp`'s own clamp, not just `#set_exp`'s), confirmed
+  to fail against the pre-fix code (`expected 9999999, got 999999`) before
+  the fix.
 
 **Variables & Switches**
 - Switches/variables cap at 5000 each (configurable up to that hard max),

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1949,10 +1949,20 @@ module Game
       EQUIP_ORDER.each_index.map { |i| ids[i] || 0 }
     end
 
-    # RPG2000 caps: total EXP maxes at 999_999; the EXP-curve fields default to
-    # 30 when a database row does not carry them (e.g. a test fixture).
-    EXP_MAX = 999_999
+    # Total EXP ceiling: 999_999 on an RPG2000 database, 9_999_999 on RPG2003
+    # (`Game_Constants::MaxExpValue`, `src/game_constants.cpp` -- the same
+    # edition split `#max_hp_cap`/`MAX_EFFECTIVE_HP_2K`/`_2K3` above already
+    # applies to HP). The EXP-curve fields default to 30 when a database row
+    # does not carry them (e.g. a test fixture).
+    EXP_MAX_2K = 999_999
+    EXP_MAX_2K3 = 9_999_999
     EXP_DEFAULT = 30
+
+    # The effective total-EXP ceiling -- `EXP_MAX_2K3` on an RPG2003
+    # database, `EXP_MAX_2K` otherwise. Mirrors `#max_hp_cap` exactly.
+    def exp_max
+      rpg2003? ? EXP_MAX_2K3 : EXP_MAX_2K
+    end
 
     # The actor's maximum level (from the database row; 50 by RPG2000 default).
     def max_level
@@ -1968,13 +1978,13 @@ module Game
       calc_exp(level - 1)
     end
 
-    # Set total EXP (clamped to 0..EXP_MAX) and re-derive the level from the curve
-    # thresholds, recomputing the base stats via #set_level when the level
+    # Set total EXP (clamped to 0..#exp_max) and re-derive the level from the
+    # curve thresholds, recomputing the base stats via #set_level when the level
     # changes. Mirrors EasyRPG's Game_Actor::ChangeExp: raising EXP climbs while
     # the next level's threshold is reached; lowering it drops while below the
     # current level's threshold.
     def set_exp(new_exp)
-      new_exp = Game.clamp(new_exp, 0, EXP_MAX)
+      new_exp = Game.clamp(new_exp, 0, exp_max)
       new_level = @level
       if new_exp > @exp
         while new_level < max_level && exp_for_level(new_level + 1) <= new_exp
@@ -2023,7 +2033,7 @@ module Game
       if new_level > old
         @exp = base if @exp < base
       elsif new_level < old
-        nxt = new_level < max_level ? exp_for_level(new_level + 1) : EXP_MAX + 1
+        nxt = new_level < max_level ? exp_for_level(new_level + 1) : exp_max + 1
         @exp = base if @exp >= nxt
       end
     end
@@ -2342,7 +2352,7 @@ module Game
 
     # EasyRPG's CalculateExp(n): the RPG2000 standard EXP curve summed over n
     # steps. Float arithmetic mirrors RPG_RT; the running total truncates toward
-    # zero each step (C's (int) cast) and the whole result caps at EXP_MAX.
+    # zero each step (C's (int) cast) and the whole result caps at #exp_max.
     def calc_exp(n)
       base = db_exp_param(:exp_basic).to_f
       inflation = 1.5 + db_exp_param(:exp_increase) * 0.01
@@ -2353,7 +2363,8 @@ module Game
         base *= inflation
         inflation = ((n + 1) * 0.002 + 0.8) * (inflation - 1) + 1
       end
-      result > EXP_MAX ? EXP_MAX : result
+      cap = exp_max
+      result > cap ? cap : result
     end
 
     # Read a numeric EXP-curve field from the database row, defaulting when the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -6987,6 +6987,27 @@ check 'set_exp caps EXP at 999999' do
   eq 999_999, a.exp
 end
 
+# Game_Constants::MaxExpValue (src/game_constants.cpp) widens RPG2000's
+# 999_999 EXP ceiling to 9_999_999 on an RPG2003 database -- the same
+# edition split Game::Actor#max_hp_cap already applies to HP.
+check "an RPG2003 database widens the EXP cap to 9999999" do
+  db = FakeActorDB.new({ 1 => ExpRow.new(initial_level: 1, max_level: 99, exp_basic: 100) },
+                       [1], {}, {}, {}, nil, nil, rpg2003: true)
+  a = Game::Party.new(db).actor_by_id(1)
+  a.set_exp(10_000_000)
+  eq 9_999_999, a.exp, 'an RPG2003 over-range set_exp clamps at the wider max'
+  a.set_exp(5_000_000)
+  eq 5_000_000, a.exp, 'a value between the two editions\' ceilings survives untouched'
+  # calc_exp's own running total caps at the same wider ceiling, not just
+  # set_exp's clamp -- a database whose curve alone would exceed it (huge
+  # exp_basic/exp_increase) still stops at 9_999_999, not 999_999.
+  huge = FakeActorDB.new({ 1 => ExpRow.new(initial_level: 1, max_level: 99,
+                                            exp_basic: 500_000, exp_increase: 99) },
+                         [1], {}, {}, {}, nil, nil, rpg2003: true)
+  b = Game::Party.new(huge).actor_by_id(1)
+  eq 9_999_999, b.exp_for_level(50), "calc_exp's own cap is the wider RPG2003 ceiling too"
+end
+
 IC2 = Game::Interpreter::Cmd
 
 check 'Change EXP command levels up a fixed actor' do


### PR DESCRIPTION
## Summary
- `Game::Actor::EXP_MAX` was a single, edition-blind `999_999` constant — consulted by `#set_exp`'s clamp, `#change_level_by`'s max-level EXP sentinel, and `#calc_exp`'s own running-total cap — even though `Actor` already had a working `#rpg2003?` helper used for exactly this pattern (`#max_hp_cap`, a few lines away).
- Confirmed against EasyRPG Player's source: `Game_Constants::MaxExpValue` (`src/game_constants.cpp`) widens the real ceiling to `9'999'999` on an RPG2003 database, matching `MaxStatBaseValue`'s own 999/9999 HP split.
- On an RPG2003 database (whose own default max level is 99, not RPG2000's 50, making six-digit-plus EXP totals realistic), an actor's total EXP was silently truncated at a tenth of the real cap.
- Fixed by splitting the constant into `EXP_MAX_2K`/`EXP_MAX_2K3` and a new `#exp_max` method mirroring `#max_hp_cap` exactly, with all three call sites reading it instead of the old bare constant.

## Testing
- New `scripts/rpg2k_logic_check.rb` check: an RPG2003 database's `#set_exp` clamps at the wider 9,999,999 instead of 999,999; a value between the two editions' ceilings survives untouched (confirming the whole range widened, not just the display); and a database whose own curve alone would exceed the ceiling still stops at the RPG2003 cap via `#calc_exp`'s own clamp, not just `#set_exp`'s — confirmed to fail against the pre-fix code (`expected 9999999, got 999999`) before the fix.
- `ruby -c mruby-rpg2k/mrblib/game.rb` / `ruby -c scripts/rpg2k_logic_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- `ruby scripts/rpg2k_logic_check.rb` — 814 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 550 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_