### PR TITLE
Round-trip a map event's custom-route index through .lsd saves

### DIFF
--- a/changelog.d/save-map-event-route-index-lsd.added.md
+++ b/changelog.d/save-map-event-route-index-lsd.added.md
@@ -1,0 +1,22 @@
+- **A map event's mid-route position (chunk 111, `SAVE_MAP_EVENT`/
+  `SAVE_MOVABLE`) now round-trips through a real `.lsd` save, not just the
+  portable Marshal save.** `Game::State#map_event_positions`/
+  `#map_event_route_index` already tracked a wandering event's live tile
+  position and its page's own custom-route cursor, matching real RPG_RT's
+  `SaveMapEvent` chunk — but `#to_lsd` never wrote chunk 111 at all, and
+  `.from_lsd` never read it back, leaving genuine editor saves unable to
+  resume either. `LCF::Schema::SAVE_MOVABLE` gains field 43
+  (`move_route_index`, sourced from EasyRPG's liblcf
+  `generator/csv/fields.csv`, `SaveMapEventBase.move_route_index` == 0x2B)
+  alongside the already-documented position fields (12/13/22); `#to_lsd`
+  writes both for every event the current map has snapshotted a position for
+  (undefaulted, so a save taken before any custom-route cursor was recorded
+  leaves the field genuinely absent), and `.from_lsd` restores them the same
+  way `Scene::Map#build_event` already consults them for a Marshal-save
+  Continue. `SaveMapEvent.original_move_route_index` (liblcf 0x66, the route
+  in force *before* a Set Move Route override) stays unmodelled: this
+  codebase has no separate "original vs current route" concept to source it
+  from. Covered by a new `scripts/rpg2k_logic_check.rb` check: a mid-route
+  event's position and cursor round-trip through `to_lsd`/`from_lsd`, and a
+  legacy save missing field 43 falls back to the existing "no saved index"
+  default (route restarts at 0) rather than erroring.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8189,12 +8189,20 @@ genuine Continue), not this one. Fixed with a new `restore_route_index:`
 keyword threaded through `#build_events`/`#build_event`, `true` by default
 (`Scene::Map#initialize`, `#perform_teleport` — moot there anyway, since
 `#map_event_route_index` is cleared immediately before that call) and passed
-`false` only from `#rebuild_events_preserving_positions`. The
-`original_move_route_index`/`move_route_index` real-RPG_RT fields this
-bullet cites remain unmodelled at the `.lsd` layer (chunk 111's
-`SaveMapEvent`/`SAVE_MOVABLE` schema still has no documented field for
-this), matching `#common_event_progress`'s identical "Marshal save only, not
-yet `.lsd`" scoping. Covered by two new `scripts/rpg2k_scene_check.rb`
+`false` only from `#rebuild_events_preserving_positions`. The `move_route_index`
+real-RPG_RT field this bullet cites is now modelled at the `.lsd` layer too:
+chunk 111's `SAVE_MOVABLE` schema gained field 43 (`move_route_index`,
+sourced from EasyRPG's liblcf `generator/csv/fields.csv`,
+`SaveMapEventBase.move_route_index` == 0x2B), and `Game::State#to_lsd`/
+`.from_lsd` read/write it alongside the position fields (12/13/22) already
+covered — see `mruby-lcf/mrblib/schema.rb` and `#map_event_route_index`'s own
+doc comment in `game.rb`. `original_move_route_index` (liblcf
+`SaveMapEvent.original_move_route_index`, 0x66) — the *pre-override* route a
+Set Move Route command replaced — stays unmodelled: this codebase's
+`#map_event_route_index` has no separate "original vs current route" concept
+of its own to source it from, so decoding that field would mean inventing
+state that does not exist, the same discipline the recent `SaveInventory`
+fields followed. Covered by two new `scripts/rpg2k_scene_check.rb`
 checks: a non-repeating 4-tile custom route snapshotted partway through (via
 `to_h`/`Game::State.load`) resumes a fresh `Scene::Map` at the exact saved
 command index and tile, then finishes only the *remaining* distance rather
@@ -8206,7 +8214,12 @@ over from page 1's own route — passing unchanged before this fix too (there
 was no saved-index consultation at all yet to leak), added as a standing
 regression guard against the exact mistake described above. The earlier
 `map_event_positions` round-trip and Proceed-With-Movement save/load checks
-this same paragraph already listed are unaffected and still pass.
+this same paragraph already listed are unaffected and still pass. The new
+`.lsd`-layer field 43 is covered separately in
+`scripts/rpg2k_logic_check.rb`: a map event mid-way through a custom route
+round-trips its saved index through `Game::State#to_lsd`/`.from_lsd`, and a
+legacy save missing field 43 falls back to the existing "no saved index"
+default (route restarts at 0) rather than erroring.
 
 State that does **not** survive a save/load specifically (distinct from
 mere map-revisit): screen-shake offset (never saved, always resets);

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -1011,6 +1011,19 @@ module LCF
       22 => { name: :direction, type: :int },
       35 => { name: :animation_type, type: :int },
       37 => { name: :move_speed, type: :int },
+      # SaveMapEventBase's own move-route cursor: how far into a page's
+      # move_type CUSTOM route this event had gotten (Game::MoveRoute#index),
+      # sourced from EasyRPG's liblcf generator/csv/fields.csv (0x2B == 43).
+      # liblcf also has a SaveMapEvent.original_move_route_index (0x66/102),
+      # tracking the route in force *before* a Set Move Route override --
+      # left undecoded, since this codebase's own Game::State
+      # #map_event_route_index has no separate "original vs current route"
+      # concept to source it from, only the single live cursor field 43
+      # already covers. No `default:` (matching e.g. SAVE_INVENTORY's
+      # turns/steps counters), so an absent field reads back as nil rather
+      # than 0 -- Game::State.from_lsd tells "no saved cursor, restart the
+      # route from the top" from "explicitly at command 0" the same way.
+      43 => { name: :move_route_index, type: :int },
       73 => { name: :charset_name, type: :string },
       75 => { name: :charset_index, type: :int },
     }

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9633,31 +9633,33 @@ module Game
     attr_accessor :common_event_progress
     # The current map's own live event positions, event id => [x, y, direction],
     # snapshotted every frame by Scene::Map#record_map_event_positions. Real
-    # RPG_RT's SaveMapEvent chunk carries exactly this (plus a move-route index
-    # this codebase does not attempt to round-trip yet) for whichever map is
-    # loaded at save time -- a wandering NPC's exact spot survives a Save/
-    # Continue on the same map, distinct from an ordinary map re-visit (leave
-    # and return with no save involved), which genuinely does reset every event
-    # to its page's own default placement, matching the "Save / Load
-    # persistence" list in docs/TODO.md. Scoped to the single currently-loaded
-    # map only: event ids are per-map, not global, so this is cleared on every
-    # genuine map change (Scene::Map#perform_teleport) rather than carried
-    # across one, the same "resets on leaving-and-returning" family as
-    # #encounter_rate/#parallax just above.
+    # RPG_RT's SaveMapEvent chunk carries exactly this (plus a move-route index,
+    # see #map_event_route_index just below) for whichever map is loaded at
+    # save time -- a wandering NPC's exact spot survives a Save/Continue on
+    # the same map, distinct from an ordinary map re-visit (leave and return
+    # with no save involved), which genuinely does reset every event to its
+    # page's own default placement, matching the "Save / Load persistence"
+    # list in docs/TODO.md. Scoped to the single currently-loaded map only:
+    # event ids are per-map, not global, so this is cleared on every genuine
+    # map change (Scene::Map#perform_teleport) rather than carried across
+    # one, the same "resets on leaving-and-returning" family as
+    # #encounter_rate/#parallax just above. Round-trips through both the
+    # portable Marshal save (#to_h/.load) and a real `.lsd` (chunk 111,
+    # LCF::Schema::SAVE_MOVABLE fields 12/13/22 -- see Game::State#to_lsd/
+    # .from_lsd).
     attr_accessor :map_event_positions
     # The current map's own live custom-move-route (page move_type CUSTOM)
     # cursor, event id => Game::MoveRoute#index, snapshotted alongside
-    # #map_event_positions -- the "move-route index this codebase does not
-    # attempt to round-trip yet" gap #map_event_positions' own comment above
-    # used to flag. A map event mid-way through its page's own custom route
-    # when a Save/Continue is taken now resumes at the exact same command
-    # instead of restarting the route from the top, matching real RPG_RT's
-    # SaveMapEvent chunk (still opaque here, see LCF::Schema::SAVE_MOVABLE --
-    # this is Marshal-save-only, same as #common_event_progress). Scoped
-    # identically to #map_event_positions in every other way: per-map, reset
-    # on #perform_teleport, and only ever consulted for a page whose move_type
-    # is CUSTOM (Scene::Map#build_event's `e[:route]`) -- a page with no
-    # custom route of its own leaves a stale entry here unread and harmless.
+    # #map_event_positions. A map event mid-way through its page's own custom
+    # route when a Save/Continue is taken now resumes at the exact same
+    # command instead of restarting the route from the top, matching real
+    # RPG_RT's SaveMapEvent chunk (LCF::Schema::SAVE_MOVABLE field 43,
+    # move_route_index). Scoped identically to #map_event_positions in every
+    # other way: per-map, reset on #perform_teleport, only ever consulted for
+    # a page whose move_type is CUSTOM (Scene::Map#build_event's `e[:route]`)
+    # -- a page with no custom route of its own leaves a stale entry here
+    # unread and harmless -- and round-trips through both the portable
+    # Marshal save and a real `.lsd` the same way #map_event_positions does.
     attr_accessor :map_event_route_index
 
     def initialize(party, map_id, x, y)
@@ -10121,6 +10123,32 @@ module Game
       inv[41] = @last_battle_turns if @last_battle_turns
       save[109] = inv
 
+      # Chunk 111 (SAVE_MAP_EVENT/SAVE_MOVABLE) is the currently-loaded map's
+      # own live event table, mirrored straight from #map_event_positions/
+      # #map_event_route_index -- both already scoped to the current map
+      # only, see their own doc comments above. Camera scroll (SAVE_MAP_EVENT
+      # fields 1/2) is not modelled by this codebase, so it stays absent,
+      # matching the "view derives from the hero" fallback ADR 0021
+      # documents. Omitted entirely on a State that has not recorded any
+      # positions yet (e.g. a fresh, unplayed save), the same "absent means
+      # nothing to restore" rule the unplaced-vehicle chunks above use.
+      unless @map_event_positions.empty?
+        mapev = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MAP_EVENT })
+        events = LCF::Array2D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+        @map_event_positions.each do |id, pos|
+          x, y, direction = pos
+          e = LCF::Array1D.new('', { elements: LCF::Schema::SAVE_MOVABLE })
+          e[12] = x
+          e[13] = y
+          e[22] = direction
+          idx = @map_event_route_index[id]
+          e[43] = idx if idx
+          events[id] = e
+        end
+        mapev[11] = events
+        save[111] = mapev
+      end
+
       save
     end
 
@@ -10350,6 +10378,29 @@ module Game
       # "Turns passed in latest battle" (field 41); absent on a save written
       # before this landed, or one taken before any battle ever finished.
       state.last_battle_turns = inv.turns unless inv.turns.nil?
+      # The currently-loaded map's own live event table (chunk 111,
+      # #to_lsd's write above): position/facing into #map_event_positions and
+      # a page's custom-route cursor (field 43) into #map_event_route_index.
+      # An absent chunk (a save written before this landed, or a state that
+      # never recorded any positions) leaves the constructor's empty {}
+      # defaults in place; an entry with no field 43 restores its position
+      # but nothing for #map_event_route_index, matching build_event's
+      # existing "no saved index means start the custom route from the top"
+      # fallback.
+      map_events = save[111]
+      saved_events = map_events && map_events.events
+      if saved_events
+        positions = {}
+        route_index = {}
+        saved_events.each do |id, mv|
+          next unless mv.x && mv.y
+          positions[id] = [mv.x, mv.y, mv.direction || 2]
+          idx = mv.move_route_index
+          route_index[id] = idx unless idx.nil?
+        end
+        state.map_event_positions = positions
+        state.map_event_route_index = route_index
+      end
       state
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7862,6 +7862,36 @@ check 'to_lsd/from_lsd round-trips the latest battle\'s turn count' do
      'an old save without the field keeps the default (no battle ever captured)'
 end
 
+check 'to_lsd/from_lsd round-trips a map event\'s custom-route index' do
+  # Chunk 111 (SAVE_MAP_EVENT/SAVE_MOVABLE) used to never be written or read
+  # at all -- #map_event_positions/#map_event_route_index already tracked a
+  # map event's live position and its page's custom-route cursor, round-
+  # tripping through the portable Marshal save, but docs/TODO.md flagged
+  # both as "remain unmodelled at the `.lsd` layer". Field 43
+  # (move_route_index) now carries the route cursor alongside the position
+  # fields (12/13/22) chunk 111 already covers.
+  db = FakeActorDB.new({ 1 => FakePlayerRow.new('Hero', '', 0, 1, max_hp: 10) }, [1])
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.map_event_positions = { 3 => [5, 7, 1] }
+  st.map_event_route_index = { 3 => 4 }
+
+  saved = st.to_lsd
+  round = Game::State.from_lsd(db, saved)
+  eq [5, 7, 1], round.map_event_positions[3], 'the event\'s position round-trips'
+  eq 4, round.map_event_route_index[3], 'the mid-route cursor round-trips'
+
+  # A save written before this field existed (or one taken before this event
+  # ever recorded a custom-route index) simply omits field 43; from_lsd must
+  # leave #map_event_route_index without an entry for that id rather than
+  # invent one, matching Scene::Map#build_event's existing "no saved index
+  # means start the custom route from the top" fallback.
+  legacy = st.to_lsd
+  legacy[111].events[3].delete(43)
+  old = Game::State.from_lsd(db, legacy)
+  eq [5, 7, 1], old.map_event_positions[3], 'position still round-trips without a route index'
+  eq nil, old.map_event_route_index[3], 'no saved cursor means the route restarts at 0'
+end
+
 # EasyRPG models an actor's and an enemy's own "state id the target's
 # state_ranks array doesn't cover" case (routine -- liblcf/RPG_RT truncate
 # trailing default bytes off it) as two distinct functions with two distinct


### PR DESCRIPTION
## Summary

- `Game::State#map_event_positions`/`#map_event_route_index` already tracked a wandering map event's live tile position and its page's own custom-move-route cursor, round-tripping through the portable Marshal save — but `#to_lsd` never wrote chunk 111 (`SAVE_MAP_EVENT`) at all, and `.from_lsd` never read it back, so a genuine `.lsd` save/Continue could not resume either. `docs/TODO.md` flagged this as "remain unmodelled at the `.lsd` layer".
- Add `LCF::Schema::SAVE_MOVABLE` field 43 (`move_route_index`), sourced from EasyRPG's liblcf `generator/csv/fields.csv` (`SaveMapEventBase.move_route_index` == 0x2B), alongside the already-documented position fields (12/13/22).
- Wire `Game::State#to_lsd` to write chunk 111 for the current map's snapshotted events (position + route cursor, undefaulted so a save before any custom route ran leaves field 43 genuinely absent), and `.from_lsd` to read it back into the same accessors.
- `liblcf`'s `SaveMapEvent.original_move_route_index` (0x66 — the route in force *before* a Set Move Route override) stays unmodelled: this codebase has no separate "original vs current route" concept to source it from, so decoding it would mean inventing state that doesn't exist.
- Update `docs/TODO.md`'s "remain unmodelled at the `.lsd` layer" note and `#map_event_route_index`'s own doc comment in `game.rb`.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 815 checks pass, including a new one: a mid-route event's position and cursor round-trip through `to_lsd`/`from_lsd`, and a legacy save missing field 43 falls back to the existing "no saved index" default (route restarts at 0) rather than erroring.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 551 checks pass (unaffected Marshal-save-path coverage for the same accessors).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LC4quhb17NYu8GKREYxnCk)_