### PR TITLE
Widen the battle damage/recovery popup cap to RPG2003's real 9999

### DIFF
--- a/changelog.d/rpg2k-battle-damage-cap-rpg2003.fixed.md
+++ b/changelog.d/rpg2k-battle-damage-cap-rpg2003.fixed.md
@@ -1,0 +1,7 @@
+- **The battle damage/HP-recovery popup cap now widens to RPG2003's real
+  9999, instead of staying a flat 999 on every database.** Confirmed against
+  EasyRPG Player's source (`Game_Constants::MaxDamageValue`): RPG2003 widens
+  the ceiling 10x, mirroring the same edition split this engine already
+  applies to the max HP cap and total-EXP cap. A single hit, heal, self-
+  destruct, or Simulated Attack computing past 999 on an RPG2003 database was
+  silently truncated at a tenth of the real cap.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4991,6 +4991,35 @@ not yet verified:
   indistinguishable from a 999 popup cap by coincidence): a raw 9999 HP heal
   against a 9999-max-HP target sitting at 1 HP lands at the full 9999, not
   1 + 999 = 1000 the way the already-fixed battle-cast equivalent clamps.
+- ✅ **The battle damage/recovery popup cap itself now widens to RPG2003's
+  real 9999 too, instead of staying a flat 999 on every database — the same
+  edition-blind gap the max-HP and total-EXP fixes above already closed for
+  their own constants.** `Game::Battle::DAMAGE_CAP`/`RECOVER_CAP`
+  (`mruby-rpg2k/mrblib/game.rb`) were both a single, uniform `999`, even
+  though `Battle` already carries its own `@rpg2003` flag (set from the
+  constructor's `rpg2003:` keyword, the same one the "Special-skill HP
+  recovery" and "damage cap" fixes above were themselves confirmed against).
+  EasyRPG's `Game_Constants::MaxDamageValue` (`src/game_constants.cpp`)
+  widens the real ceiling to `9'999` on an RPG2003 database, and
+  `game_battlealgorithm.cpp` clamps a Normal Attack/Skill/SelfDestruct
+  effect through this **one** constant symmetrically in both directions
+  (`Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue())` — a healing
+  skill's own effect is just the negative-signed case of the same clamp),
+  confirming `RECOVER_CAP` shares the exact same edition-gated pair rather
+  than being independently 999-only. `Interpreter#do_simulated_attack`
+  (`mruby-rpg2k/mrblib/interpreter.rb`), which cites the same cap for its
+  own damage clamp, had the identical gap. Fixed by splitting both into
+  `_2K`/`_2K3` pairs and new `Game::Battle#damage_cap`/`#recover_cap`
+  methods mirroring `Game::Actor#max_hp_cap` exactly, with every call site
+  (normal attack, skill/item damage and recovery, self-destruct, per-turn
+  state slip damage, and the Simulated Attack command) reading the method
+  instead of the old bare constant. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check pinning the RPG2003 Simulated Attack
+  cap at 9999 (alongside a tightened existing RPG2000 case, now built from
+  an atk large enough to exceed *either* edition's cap distinctly) and a new
+  companion to the existing "recovery skill hard-caps at 999" check for an
+  RPG2003 fight's own wider 9999 ceiling, both confirmed to fail against the
+  pre-fix code before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7165,20 +7165,38 @@ module Game
 
     MAX_ROUNDS = 1000 # safety net against a stalemate (should never be reached)
 
-    # RPG_RT's battle damage popup is a fixed three digits, so every single hit
+    # RPG_RT's battle damage popup is a fixed-width widget, so every single hit
     # -- normal attack, dual-wield swing, attack-skill, self-destruct, and
-    # per-turn state slip damage alike -- is hard-clamped to 999 before it is
+    # per-turn state slip damage alike -- is hard-clamped before it is
     # subtracted from the target's HP, no matter how large the underlying ATK/
     # DEF/attribute math computes. A yado.tk-quirks build with no cap could
     # one-shot a target well past what the original engine could ever display
-    # or apply in a single blow.
-    DAMAGE_CAP = 999
+    # or apply in a single blow. The width itself is edition-gated:
+    # `Game_Constants::MaxDamageValue` (`src/game_constants.cpp`) is `999` on
+    # RPG2000, `9999` on RPG2003 -- the same shape as `MAX_EFFECTIVE_HP_2K`/
+    # `_2K3` and `EXP_MAX_2K`/`_2K3` above. EasyRPG's own
+    # `game_battlealgorithm.cpp` clamps a Normal Attack/Skill/SelfDestruct
+    # effect through this single constant symmetrically in *both* directions
+    # (`Utils::Clamp(effect, -MaxDamageValue(), MaxDamageValue())` -- a
+    # healing skill's own `effect` is just the negative-signed case of the
+    # same clamp), so the same pair covers recovery too.
+    DAMAGE_CAP_2K = 999
+    DAMAGE_CAP_2K3 = 9999
+    RECOVER_CAP_2K = DAMAGE_CAP_2K
+    RECOVER_CAP_2K3 = DAMAGE_CAP_2K3
 
-    # Same fixed-width-popup reasoning as DAMAGE_CAP, for the opposite
-    # direction: RPG_RT's HP-recovery popup is the same fixed 3-digit widget
-    # as the damage one, so a single heal can't display (or apply) more than
-    # 999 either, no matter how large `recover_hp_rate` x max_hp computes it.
-    RECOVER_CAP = 999
+    # The effective damage-popup ceiling for this fight -- `DAMAGE_CAP_2K3` on
+    # an RPG2003 database, `DAMAGE_CAP_2K` otherwise. Mirrors
+    # `Game::Actor#max_hp_cap` exactly.
+    def damage_cap
+      @rpg2003 ? DAMAGE_CAP_2K3 : DAMAGE_CAP_2K
+    end
+
+    # Same as #damage_cap, for HP recovery -- EasyRPG clamps both directions
+    # through the one constant, so the two ceilings are identical per edition.
+    def recover_cap
+      @rpg2003 ? RECOVER_CAP_2K3 : RECOVER_CAP_2K
+    end
 
     attr_reader :allies, :enemies, :rounds, :result, :log, :rng, :escape_chance
 
@@ -7980,7 +7998,8 @@ module Game
           next
         end
         hp = state_field(d, :hp_change_val) + b.max_hp * state_field(d, :hp_change_max) / 100
-        hp = DAMAGE_CAP if hp > DAMAGE_CAP # 999 hard-cap applies to slip damage too
+        cap = damage_cap
+        hp = cap if hp > cap # the popup hard-cap applies to slip damage too
         b.hp = slip_stat(b.hp, b.max_hp, hp, state_field(d, :hp_change_type), 1) if hp > 0
         if b.max_mp && b.mp
           sp = state_field(d, :sp_change_val) + b.max_mp * state_field(d, :sp_change_max) / 100
@@ -8331,7 +8350,8 @@ module Game
         dmg = 0 if dmg < 0
         dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
         dmg = [dmg / 2, 1].max if t.defending && dmg > 0
-        dmg = DAMAGE_CAP if dmg > DAMAGE_CAP
+        cap = damage_cap
+        dmg = cap if dmg > cap
         t.hp -= dmg
         { attacker: b.name, target: t.name, damage: dmg, critical: false,
           autodestruct: true, target_hp: t.hp < 0 ? 0 : t.hp, defeated: t.dead?,
@@ -8800,9 +8820,10 @@ module Game
         dmg = [dmg / 2, 1].max
         dmg = [dmg / 2, 1].max if target.strong_defence
       end
-      # RPG_RT's damage popup tops out at three digits -- a crit/charge blow
-      # that would compute past it still only ever takes 999.
-      dmg = DAMAGE_CAP if dmg > DAMAGE_CAP
+      # RPG_RT's damage popup tops out at a fixed width -- a crit/charge blow
+      # that would compute past it still only ever takes #damage_cap.
+      cap = damage_cap
+      dmg = cap if dmg > cap
       target.hp -= dmg
       woke = target.dead? ? [] : shake_off_states(target)
       entry = { attacker: b.name, target: target.name, damage: dmg, critical: crit,
@@ -9125,9 +9146,10 @@ module Game
         dmg = apply_attr_multiplier(dmg, cmd[:attributes], target)
         # Spread the skill's damage by its own variance when the fight rolls it.
         dmg = varied(dmg, cmd[:variance]) if @variance && dmg > 0 && cmd[:variance] && cmd[:variance] > 0
-        # Same 999 hard-cap as a normal attack (#deal_attack), applied before
+        # Same hard-cap as a normal attack (#deal_attack), applied before
         # absorption so a drain skill can't smuggle a bigger hit past it either.
-        dmg = DAMAGE_CAP if dmg > DAMAGE_CAP
+        cap = damage_cap
+        dmg = cap if dmg > cap
         # The ATK/DEF/SPI/AGI modifier delta (see #apply_stat_mods) shares
         # this same post-attribute-scaling, post-variance, post-cap figure --
         # captured here, before 吸収 trims `dmg` further below, since EasyRPG
@@ -9196,8 +9218,9 @@ module Game
         end
         before_hp = target.hp
         before_mp = target.mp || 0
-        hp = RECOVER_CAP if hp > RECOVER_CAP
-        stat_amount = RECOVER_CAP if stat_amount > RECOVER_CAP
+        rcap = recover_cap
+        hp = rcap if hp > rcap
+        stat_amount = rcap if stat_amount > rcap
         target.hp = [target.hp + hp, target.max_hp].min if hp > 0
         target.mp = [before_mp + mp, target.max_mp].min if mp > 0 && target.max_mp
         # Cure the item's status conditions from the target (an antidote / herb),

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1964,18 +1964,20 @@ module Game
     # RPG_RT: `atk - def * p_def / 400 - spi * p_spi / 800`, then spread by
     # +/- (param5 * 5) percent and floored at 0. The hit can be lethal.
     #
-    # RPG_RT's damage popup is a fixed three digits (the same reasoning behind
-    # `Game::Battle::DAMAGE_CAP` on the normal-attack/skill/self-destruct/
-    # slip-damage paths), so a Simulated Attack's own computed damage is
-    # clamped at 999 too before it reaches HP or the result variable.
+    # RPG_RT's damage popup is a fixed-width widget (the same reasoning behind
+    # `Game::Battle#damage_cap` on the normal-attack/skill/self-destruct/
+    # slip-damage paths -- edition-gated the same way, 999 on RPG2000, 9999
+    # on RPG2003), so a Simulated Attack's own computed damage is clamped
+    # too before it reaches HP or the result variable.
     def do_simulated_attack(cmd)
       atk = cmd.param(2)
       damage = 0
+      cap = @state.party.rpg2003? ? Battle::DAMAGE_CAP_2K3 : Battle::DAMAGE_CAP_2K
       stat_targets(cmd).each do |a|
         damage = atk - (a.def * cmd.param(3)) / 400 - (a.int * cmd.param(4)) / 800
         damage += damage * simulated_attack_spread(cmd.param(5)) / 100
         damage = 0 if damage < 0
-        damage = Battle::DAMAGE_CAP if damage > Battle::DAMAGE_CAP
+        damage = cap if damage > cap
         a.change_hp(-damage, true)
       end
       variables[cmd.param(7)] = damage if cmd.param(6) != 0

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9660,6 +9660,25 @@ check 'Battle command_skill: a recovery skill also hard-caps at 999 (yado.tk)' d
   eq 999, e[:recover_hp], 'capped, not the uncapped 5000'
 end
 
+# Game_Constants::MaxDamageValue widens the same fixed-width-popup cap to
+# 9999 on an RPG2003 database -- Game::Battle#recover_cap follows #damage_cap
+# exactly, so this mirrors the RPG2000 check above with an rpg2003: true
+# battle and a heal large enough to exceed *that* wider ceiling too.
+check 'Battle command_skill: an RPG2003 fight widens the recovery hard-cap to 9999' do
+  mage = combatant_mp('Mage', 0, 0, 20, 100, 10)
+  ally = combatant('Ally', 0, 0, 5, 100_000)
+  ally.hp = 1
+  foe = combatant('Foe', 0, 0, 1, 100)
+  b = Game::Battle.new([mage, ally], [foe], Game::Rng.new(1), nil, false, false, false,
+                       false, nil, nil, rpg2003: true)
+  b.command_skill(mage, ally, name: 'Mega Heal', cost: 10, hp: 50_000)
+  b.command_defend(ally)
+  b.begin_round
+  e = b.step_action # the faster mage heals first
+  eq 10_000, ally.hp, 'capped to +9999 (1 + 9999), not the uncapped 50000'
+  eq 9_999, e[:recover_hp], 'capped at the wider RPG2003 ceiling, not the uncapped 50000'
+end
+
 check 'battle: an all-ally heal skips a downed member but still heals the wounded' do
   # Mirrors Game::Actor#change_hp's `return @hp if dead?` guard on the field: a
   # downed (0 HP) Combatant is filtered out before #apply_skill_hit's HP-raising
@@ -11088,21 +11107,27 @@ end
 # slip-damage cap (Game::Battle::DAMAGE_CAP) applies to this raw event
 # command's own damage too -- it shares no code path with any of those four,
 # so it needed its own clamp.
-check 'Simulated Attack hard-caps damage at 999, matching the battle damage cap' do
-  # max_hp: 5000 needs an RPG2003 fixture database now that #recompute_stats
-  # itself clamps effective max HP to 999/9999 by edition (see "#recompute_
-  # stats clamps the effective max HP..." below) -- an RPG2000 actor could
-  # never actually reach 5000 max HP to survive this hit and show the
-  # leftover HP this check asserts.
-  players = { 1 => FakePlayerRow.new('Tank', '', 0, 5, max_hp: 5000, max_mp: 0, atk: 0, def: 0) }
-  st = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1], {}, {}, {}, nil, nil, rpg2003: true)), 1, 0, 0)
-  it = Game::Interpreter.new(st)
-  # scope 1, actor 1, atk 5000, def-weight 0, spi-weight 0, variance 0,
+check 'Simulated Attack hard-caps damage at the battle damage cap, by edition' do
+  # The damage cap is edition-gated the same way the max-HP cap is
+  # (Game::Battle#damage_cap, Game_Constants::MaxDamageValue: 999 on
+  # RPG2000, 9999 on RPG2003) -- an atk high enough to exceed *either*
+  # edition's own cap is needed to exercise both branches distinctly.
+  players = { 1 => FakePlayerRow.new('Tank', '', 0, 5, max_hp: 999, max_mp: 0, atk: 0, def: 0) }
+  st2k = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1])), 1, 0, 0)
+  it2k = Game::Interpreter.new(st2k)
+  # scope 1, actor 1, atk 15000, def-weight 0, spi-weight 0, variance 0,
   # store-damage flag 1 -> var 1.
-  it.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 5000, 0, 0, 0, 1, 1])])
-  it.update
-  eq 999, st.variables[1], 'capped, not the uncapped 5000'
-  eq 5000 - 999, st.party.actor_by_id(1).hp
+  it2k.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 15_000, 0, 0, 0, 1, 1])])
+  it2k.update
+  eq 999, st2k.variables[1], 'RPG2000: capped at 999, not the uncapped 15000'
+  eq 0, st2k.party.actor_by_id(1).hp, 'a full-cap hit against the RPG2000 max HP ceiling is exactly lethal'
+
+  st2k3 = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1], {}, {}, {}, nil, nil, rpg2003: true)),
+                          1, 0, 0)
+  it2k3 = Game::Interpreter.new(st2k3)
+  it2k3.start([FakeCmd.new(IC::SIMULATED_ATTACK, [1, 1, 15_000, 0, 0, 0, 1, 1])])
+  it2k3.update
+  eq 9999, st2k3.variables[1], 'RPG2003: capped at 9999, not the uncapped 15000'
 end
 
 check 'Change Actor Face overrides the actor FaceSet' do


### PR DESCRIPTION
## Summary
- `Game::Battle::DAMAGE_CAP`/`RECOVER_CAP` were both a single, uniform `999`, even though `Battle` already carries its own `@rpg2003` flag (set from the constructor's `rpg2003:` keyword).
- Confirmed against EasyRPG Player's source: `Game_Constants::MaxDamageValue` (`src/game_constants.cpp`) widens the real ceiling to `9'999` on an RPG2003 database, and `game_battlealgorithm.cpp` clamps a Normal Attack/Skill/SelfDestruct effect through this **one** constant symmetrically in both directions (a healing skill's own effect is just the negative-signed case of the same clamp) — confirming `RECOVER_CAP` shares the exact same edition-gated pair rather than being independently 999-only.
- `Interpreter#do_simulated_attack`, which cites the same cap for its own damage clamp, had the identical gap.
- Fixed by splitting both into `_2K`/`_2K3` pairs and new `Game::Battle#damage_cap`/`#recover_cap` methods mirroring `Game::Actor#max_hp_cap` exactly, with every call site (normal attack, skill/item damage and recovery, self-destruct, per-turn state slip damage, and Simulated Attack) reading the method instead of the old bare constant.

## Testing
- New `scripts/rpg2k_logic_check.rb` checks: an RPG2003 Simulated Attack caps at 9999 (alongside a tightened existing RPG2000 case, now built from an atk large enough to exceed *either* edition's cap distinctly), and a new companion to the existing "recovery skill hard-caps at 999" check for an RPG2003 fight's own wider 9999 ceiling — both confirmed to fail against the pre-fix code before the fix.
- `ruby -c mruby-rpg2k/mrblib/game.rb` / `ruby -c mruby-rpg2k/mrblib/interpreter.rb` / `ruby -c scripts/rpg2k_logic_check.rb`
- Rebuilt the native engine (`ninja rpg_maker_clone`) cleanly.
- `ruby scripts/rpg2k_logic_check.rb` — 815 checks passed
- `ruby scripts/rpg2k_scene_check.rb` — 551 checks passed
- `ruby scripts/rpg2k_save_load_check.rb` — passed
- `ruby scripts/rpg2k_testbed_logic_check.rb` — 125 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_