### PR TITLE
Wire RPG2003 Key Input Processing Numbers/Operators to real keys (SDL backend)

### DIFF
--- a/changelog.d/rpg2003-key-input-numbers-operators.added.md
+++ b/changelog.d/rpg2003-key-input-numbers-operators.added.md
@@ -1,0 +1,9 @@
+- **Key Input Processing**'s RPG2003 Numbers/Operators flags now sample real
+  keys instead of being decoded and discarded: `RGSS::Input` gained
+  `N0`-`N9`/`PLUS`/`MINUS`/`MULTIPLY`/`DIVIDE`/`PERIOD` ids, and
+  `Scene::Map`/`Game::Interpreter` resolve a pressed digit or operator to its
+  RPG2000 key code the same way the existing button set does. 🚧 Real key
+  backing exists on the SDL desktop window backend only (digits from the main
+  row or numpad, operators mostly numpad-only) — the PSP, Wio Terminal and
+  terminal/sixel native backends leave the new ids unbound, matching how
+  `F5`-`F12` are already unbound there.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -529,10 +529,22 @@ The work below is roughly ordered by the critical path to a walkable game
   1.50+ parameter layouts, and now also decodes RPG2003's own Numbers /
   Operators layout (`db.rpg2003?`-gated, since it reuses the same param slots
   RPG2000 1.50+ gives Shift and the arrows) into the request's accepted-key
-  set. 🚧 Those two flags are decoded but not yet actionable: `RGSS::Input`
-  models a fixed console/keyboard button set with no numeric-keypad or
-  operator keys to sample, so a Numbers/Operators-only request can never
-  resolve — mouse input (Maniac) stays fully out of scope the same way.
+  set. Those two flags now sample real keys: `RGSS::Input` gained
+  `N0`-`N9`/`PLUS`/`MINUS`/`MULTIPLY`/`DIVIDE`/`PERIOD` ids (continuing past
+  `F12`, `mruby-rgss/mrblib/lib.rb`), `Scene::Map`'s
+  `NUMBER_KEY_BUTTONS`/`OPERATOR_KEY_BUTTONS` sample them the same way
+  `KEY_INPUT_BUTTONS` samples the rest, and `Game::Interpreter::KEY_INPUT_CODES`
+  produces the matching RPG2000 codes (digit `d` → `10 + d`, Plus/Minus/
+  Multiply/Divide/Period → 20-24 — matching EasyRPG Player's
+  `Game_Interpreter::KeyInputState::CheckInput`, the documented reference for
+  RPG_RT behaviour this codebase already leans on elsewhere). 🚧 Real key
+  backing exists only on the SDL desktop window backend
+  (`src/sdl_input.cxx`: digits from the main row or numpad, operators mostly
+  numpad-only since a bare `SDL_Keycode` switch can't tell a shifted "+"/"*"
+  chord from the key underneath it) — the PSP, Wio Terminal and
+  terminal/sixel native backends leave these ids unbound (never pressed, no
+  crash), the same way this build already leaves `F5`-`F12` unbound there.
+  Mouse input (Maniac) stays fully out of scope the same way.
   **Change Actor
   Name / Title / Sprite** rename a party actor, set its status-screen title or
   swap its CharSet graphic (the scene reloads the leader's on-screen sprite);

--- a/mruby-rgss/mrbgem.rake
+++ b/mruby-rgss/mrbgem.rake
@@ -16,6 +16,11 @@ MRuby::Gem::Specification.new('mruby-rgss') do |spec|
   # mrbgems" note. wave_blt itself is pure C++ (mruby-rgss/src/lib.cxx), so
   # this is only needed for the test.
   add_test_dependency 'mruby-math'
+  # The RGSS::Input::N0..PERIOD id test uses Array#uniq to prove every new key
+  # id is distinct. Same story as mruby-math above: Array#uniq lives in
+  # mruby-array-ext (build_config.rb's rpg_maker_gems has it for the full
+  # game), so the standalone mrbtest build needs it declared here too.
+  add_test_dependency 'mruby-array-ext'
 
   cxx.include_paths <<
     "#{dir}/../3rd/uni-algo/include" <<

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1358,24 +1358,55 @@ module RGSS
     F9 = 19
     F12 = 20
 
+    # RPG2003's Key Input Processing event command can accept a numeric
+    # keypad (Numbers) or math-operator (Operators) group instead of the
+    # console/keyboard button set above (Game::Interpreter#do_key_input,
+    # Scene::Map::NUMBER_KEY_BUTTONS / OPERATOR_KEY_BUTTONS). Ids continue the
+    # F12 sequence; the digit/operator identity (not the id) is what matters,
+    # since Scene::Map re-maps each hit onto the RPG2000 key-input code
+    # (Game::Interpreter::KEY_INPUT_CODES). Real key backing exists only on
+    # the SDL desktop backend today (src/sdl_input.cxx) — the other native
+    # backends (PSP, Wio Terminal, terminal/sixel) simply never press these
+    # ids, the same way they already leave F5-F12 unbound.
+    N0 = 21
+    N1 = 22
+    N2 = 23
+    N3 = 24
+    N4 = 25
+    N5 = 26
+    N6 = 27
+    N7 = 28
+    N8 = 29
+    N9 = 30
+    PLUS = 31
+    MINUS = 32
+    MULTIPLY = 33
+    DIVIDE = 34
+    PERIOD = 35
+
     # RGSS2 (VX) and RGSS3 (VX Ace) name the keys with **symbols** —
     # `Input.trigger?(:C)` — where RGSS1 (XP) used the integer constants above.
     # The stock VX Ace scripts use symbols exclusively (measured: :C, :UP/:DOWN/
     # :LEFT/:RIGHT, :B, :A, :L, :R, :CTRL, :F9 — see docs/rpgvx-rgss-api-gap.md),
     # so map them onto the same key indices instead of keeping two key tables.
     # An Integer is passed through untouched, so every XP / RPG2000 caller and
-    # the C++ input bridge are unaffected.
+    # the C++ input bridge are unaffected. N0-N9/PLUS-PERIOD have no RGSS
+    # precedent (RPG2003's own Numbers/Operators keys, not an RGSS button) but
+    # are listed the same way for a consistent `Input.trigger?(:N3)` spelling.
     SYMBOL_KEYS = {
       UP: UP, DOWN: DOWN, LEFT: LEFT, RIGHT: RIGHT,
       A: A, B: B, C: C, X: X, Y: Y, Z: Z, L: L, R: R,
       SHIFT: SHIFT, CTRL: CTRL, ALT: ALT,
-      F5: F5, F6: F6, F7: F7, F8: F8, F9: F9, F12: F12
+      F5: F5, F6: F6, F7: F7, F8: F8, F9: F9, F12: F12,
+      N0: N0, N1: N1, N2: N2, N3: N3, N4: N4,
+      N5: N5, N6: N6, N7: N7, N8: N8, N9: N9,
+      PLUS: PLUS, MINUS: MINUS, MULTIPLY: MULTIPLY, DIVIDE: DIVIDE, PERIOD: PERIOD
     }.freeze
 
-    @pressed = Array.new(21, false)
-    @triggered = Array.new(21, false)
-    @repeated = Array.new(21, false)
-    @count = Array.new(21, 0)
+    @pressed = Array.new(36, false)
+    @triggered = Array.new(36, false)
+    @repeated = Array.new(36, false)
+    @count = Array.new(36, 0)
 
     # Key index for either spelling. An unrecognised key reads as unpressed
     # rather than raising (a script may probe a key this build has no name for),

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -1492,7 +1492,7 @@ assert "RGSS::Input accepts RGSS2/RGSS3 symbol keys" do
 
     # Every RGSS3 key name maps, and an unknown one reads as unpressed instead
     # of raising out of the game loop.
-    assert_equal 21, RGSS::Input::SYMBOL_KEYS.size
+    assert_equal 36, RGSS::Input::SYMBOL_KEYS.size
     RGSS::Input::SYMBOL_KEYS.each do |name, index|
       assert_equal index, RGSS::Input.key_index(name), "key #{name} maps wrong"
     end
@@ -1501,6 +1501,34 @@ assert "RGSS::Input accepts RGSS2/RGSS3 symbol keys" do
   ensure
     RGSS::Input.release(:UP)
     RGSS::Input.release(:C)
+  end
+end
+
+assert "RGSS::Input::N0..N9/PLUS..PERIOD are distinct ids continuing past F12" do
+  # RPG2003's Key Input Processing Numbers/Operators groups (see
+  # mruby-rpg2k's Scene::Map::NUMBER_KEY_BUTTONS/OPERATOR_KEY_BUTTONS): every
+  # id must be its own slot so pressing one digit/operator never reads back
+  # as another.
+  digit_keys = [RGSS::Input::N0, RGSS::Input::N1, RGSS::Input::N2, RGSS::Input::N3,
+                RGSS::Input::N4, RGSS::Input::N5, RGSS::Input::N6, RGSS::Input::N7,
+                RGSS::Input::N8, RGSS::Input::N9]
+  operator_keys = [RGSS::Input::PLUS, RGSS::Input::MINUS, RGSS::Input::MULTIPLY,
+                    RGSS::Input::DIVIDE, RGSS::Input::PERIOD]
+  all_keys = digit_keys + operator_keys
+  assert_equal all_keys.uniq.size, all_keys.size, "every id must be distinct"
+  assert_equal RGSS::Input::F12 + 1, RGSS::Input::N0, "ids continue right after F12"
+
+  begin
+    RGSS::Input.press(RGSS::Input::N3)
+    assert_true RGSS::Input.press?(RGSS::Input::N3)
+    assert_false RGSS::Input.press?(RGSS::Input::N4), "a different digit must stay unpressed"
+    assert_false RGSS::Input.press?(RGSS::Input::PLUS), "an operator must stay unpressed"
+
+    RGSS::Input.press(RGSS::Input::PERIOD)
+    assert_true RGSS::Input.press?(:PERIOD), "the symbol spelling must reach the same id"
+  ensure
+    RGSS::Input.release(RGSS::Input::N3)
+    RGSS::Input.release(RGSS::Input::PERIOD)
   end
 end
 

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -766,13 +766,36 @@ module Game
       nil
     end
 
-    # RPG2000 key-input result codes in priority order (highest first). When more
-    # than one accepted button is active RPG_RT returns the largest code:
-    # Shift > Cancel > Decision > Up > Right > Left > Down.
+    # RPG2000/2003 key-input result codes in priority order (highest first).
+    # When more than one accepted button is active RPG_RT returns the largest
+    # code: Period > Divide > Multiply > Minus > Plus > N9..N0 > Shift >
+    # Cancel > Decision > Up > Right > Left > Down. The Numbers/Operators
+    # block (10-24) matches EasyRPG Player's
+    # Game_Interpreter::KeyInputState::CheckInput (src/game_interpreter.cpp),
+    # the documented reference this codebase already leans on for RPG2000/2003
+    # runtime behaviour that RPG_RT itself never published — Numbers is a
+    # digit's own value plus 10 (N0 -> 10 .. N9 -> 19), Operators are
+    # Plus/Minus/Multiply/Divide/Period at 20-24.
     KEY_INPUT_CODES = [
+      [:period, 24], [:divide, 23], [:multiply, 22], [:minus, 21], [:plus, 20],
+      [:n9, 19], [:n8, 18], [:n7, 17], [:n6, 16], [:n5, 15],
+      [:n4, 14], [:n3, 13], [:n2, 12], [:n1, 11], [:n0, 10],
       [:shift, 7], [:cancel, 6], [:decision, 5],
       [:up, 4], [:right, 3], [:left, 2], [:down, 1]
     ].freeze
+
+    # `accepted` (see #do_key_input) only carries whole-group flags for
+    # Numbers/Operators, not one flag per digit/operator — this maps each of
+    # KEY_INPUT_CODES' per-key symbols back onto the group flag that accepts
+    # it, so #key_input_result can look up "was this key's group requested?"
+    # for :n3 the same way it looks up acc[:decision] for :decision. A symbol
+    # absent here (e.g. :decision) is its own group, i.e. `accepted` carries a
+    # flag with that exact name.
+    KEY_INPUT_GROUPS = { n0: :numbers, n1: :numbers, n2: :numbers, n3: :numbers,
+                          n4: :numbers, n5: :numbers, n6: :numbers, n7: :numbers,
+                          n8: :numbers, n9: :numbers,
+                          plus: :operators, minus: :operators, multiply: :operators,
+                          divide: :operators, period: :operators }.freeze
 
     # Given the set of currently-active key symbols (an array like [:decision]),
     # return the RPG2000 code of the highest-priority key the pending request
@@ -782,7 +805,8 @@ module Game
       acc = @key_input_request && @key_input_request[:accepted]
       return 0 unless acc
       KEY_INPUT_CODES.each do |sym, code|
-        return code if acc[sym] && active.include?(sym)
+        group = KEY_INPUT_GROUPS[sym] || sym
+        return code if acc[group] && active.include?(sym)
       end
       0
     end
@@ -1215,11 +1239,14 @@ module Game
     # The interpreter only records the request and suspends on a :key_input
     # wait; the owning scene samples real input (triggered edges when waiting,
     # held state otherwise) and calls resume_key_input with the resulting code.
-    # Numbers/Operators are decoded into `accepted` but not yet actionable: the
-    # input layer (RGSS::Input) models a fixed console/keyboard button set with
-    # no numeric-keypad or operator keys to sample, so a request that accepts
-    # only Numbers/Operators can never resolve — same as the mouse (Maniac),
-    # which stays fully unmodelled.
+    # Numbers/Operators decoded into `accepted` are sampled by
+    # Scene::Map::NUMBER_KEY_BUTTONS/OPERATOR_KEY_BUTTONS (RGSS::Input::N0..N9
+    # / PLUS..PERIOD, see #key_input_result's KEY_INPUT_GROUPS), which today
+    # have real key backing only on the SDL desktop window backend
+    # (src/sdl_input.cxx) — the other native backends (PSP, Wio Terminal,
+    # terminal/sixel) never press those ids, so a Numbers/Operators-only
+    # request there resolves the same as before this: never. 🚧 The mouse
+    # (Maniac) stays fully unmodelled everywhere.
     def do_key_input(cmd)
       var_id = cmd.param(0)
       wait = cmd.param(1) != 0

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -3688,8 +3688,35 @@ class RPG2k
         up: Input::UP, decision: Input::C, cancel: Input::B, shift: Input::SHIFT
       }.freeze
 
+      # RPG2003's Numbers/Operators flags (see Game::Interpreter#do_key_input)
+      # each accept a whole group of keys rather than one button, so unlike
+      # KEY_INPUT_BUTTONS these map every digit / operator symbol its own
+      # entry — #resolve_key_input samples each individually and hands the
+      # interpreter whichever specific symbols (:n3, :period, ...) actually
+      # fired; Game::Interpreter::KEY_INPUT_GROUPS maps them back onto the
+      # :numbers/:operators accept flag. Real key backing for
+      # RGSS::Input::N0..PERIOD exists only on the SDL desktop backend today
+      # (src/sdl_input.cxx) — on every other native backend (PSP, Wio
+      # Terminal, terminal/sixel) these ids are simply never pressed, the same
+      # way this build already leaves F5-F12 unbound there.
+      NUMBER_KEY_BUTTONS = {
+        n0: Input::N0, n1: Input::N1, n2: Input::N2, n3: Input::N3, n4: Input::N4,
+        n5: Input::N5, n6: Input::N6, n7: Input::N7, n8: Input::N8, n9: Input::N9
+      }.freeze
+      OPERATOR_KEY_BUTTONS = {
+        plus: Input::PLUS, minus: Input::MINUS, multiply: Input::MULTIPLY,
+        divide: Input::DIVIDE, period: Input::PERIOD
+      }.freeze
+
       def drive_key_input
         resolve_key_input(@interpreter)
+      end
+
+      # True if `btn` is down (no-wait proc) or was just pressed (waiting
+      # proc) this frame, per the sampling rule #resolve_key_input applies to
+      # every accepted button.
+      def key_input_hit?(btn, wait)
+        wait ? Input.trigger?(btn) : Input.press?(btn)
       end
 
       # Drive a Key Input Processing wait for interpreter `it` (the foreground
@@ -3705,8 +3732,17 @@ class RPG2k
         active = []
         KEY_INPUT_BUTTONS.each do |sym, btn|
           next unless accepted[sym]
-          hit = req[:wait] ? Input.trigger?(btn) : Input.press?(btn)
-          active << sym if hit
+          active << sym if key_input_hit?(btn, req[:wait])
+        end
+        if accepted[:numbers]
+          NUMBER_KEY_BUTTONS.each do |sym, btn|
+            active << sym if key_input_hit?(btn, req[:wait])
+          end
+        end
+        if accepted[:operators]
+          OPERATOR_KEY_BUTTONS.each do |sym, btn|
+            active << sym if key_input_hit?(btn, req[:wait])
+          end
         end
         code = it.key_input_result(active)
         if req[:wait]

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7206,12 +7206,32 @@ check 'Key Input Proc (RPG2003 Numbers/Operators layout) decodes the two flags' 
   eq false, acc[:cancel]
   [:down, :left, :right, :up].each { |k| eq true, acc[k], "#{k} on (single arrows-all flag)" }
   eq false, acc[:shift], 'this layout has no individual Shift, unlike RPG2000 1.50+'
-  # Numbers/Operators are accepted but the input layer has no keys mapped to
-  # them (see Scene::Map::KEY_INPUT_BUTTONS), so the scene can never place
-  # them in the active-key list; key_input_result must not resolve them even
-  # if asked to.
+  # :numbers/:operators are the whole-group accept flags `do_key_input` sets,
+  # not real per-key symbols -- key_input_result only ever receives one of the
+  # concrete keys a group covers (:n0.."n9", :plus.."period", from
+  # Scene::Map::NUMBER_KEY_BUTTONS/OPERATOR_KEY_BUTTONS), so passing the group
+  # symbols themselves as "active" never resolves anything.
   eq 0, it.key_input_result([:numbers, :operators])
   eq 5, it.key_input_result([:decision, :numbers]), 'Decision still resolves alongside them'
+  # The concrete per-key symbols do resolve once Numbers/Operators is
+  # accepted, per KEY_INPUT_GROUPS -- see Scene::Map::NUMBER_KEY_BUTTONS /
+  # OPERATOR_KEY_BUTTONS for where a real key press produces them (SDL
+  # backend only today).
+  eq 10, it.key_input_result([:n0]), 'digit 0 -> code 10'
+  eq 19, it.key_input_result([:n9]), 'digit 9 -> code 19'
+  eq 20, it.key_input_result([:plus]), 'Plus -> code 20 (lowest-priority operator)'
+  eq 24, it.key_input_result([:period]), 'Period -> code 24 (highest-priority operator)'
+  eq 24, it.key_input_result([:period, :n5]), 'Operators outrank Numbers when both fire'
+end
+
+check 'Key Input Proc (RPG2003) key_input_result ignores a digit when Numbers is not accepted' do
+  st = new_state(rpg2003: true)
+  it = Game::Interpreter.new(st)
+  # 9-param layout: Decision only, Numbers/Operators both off.
+  it.start([FakeCmd.new(IC::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 0, 0, 0])])
+  it.update
+  eq 0, it.key_input_result([:n3]), 'Numbers was never accepted, so :n3 must not resolve'
+  eq 5, it.key_input_result([:decision]), 'Decision still resolves on its own'
 end
 
 check 'Key Input Proc (RPG2003, 10 params) is the imported RPG2000 1.50+ layout, not Numbers/Operators' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -139,6 +139,11 @@ module RGSS
   module Input
     C = 1; B = 2; UP = 3; DOWN = 4; LEFT = 5; RIGHT = 6; SHIFT = 7
     CTRL = 8; F9 = 9; L = 10; R = 11
+    # RPG2003 Key Input Processing's Numbers/Operators groups (see
+    # Scene::Map::NUMBER_KEY_BUTTONS / OPERATOR_KEY_BUTTONS).
+    N0 = 20; N1 = 21; N2 = 22; N3 = 23; N4 = 24
+    N5 = 25; N6 = 26; N7 = 27; N8 = 28; N9 = 29
+    PLUS = 30; MINUS = 31; MULTIPLY = 32; DIVIDE = 33; PERIOD = 34
     class << self
       attr_accessor :dir_value, :triggered
     end
@@ -2340,26 +2345,65 @@ check 'Key Input Proc ignores keys it was not told to accept' do
   ok st.switches[5]
 end
 
-check 'Key Input Proc (RPG2003 Numbers layout) accepts Decision but Numbers has no key to press' do
+check 'Key Input Proc (RPG2003 Numbers layout) resolves a digit key press' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   # RPG2003's own 9-param layout: var, wait, arrows off, decision on, cancel
-  # off, numbers on, operators off, time-var/timed unused. Nothing in
-  # Scene::Map::KEY_INPUT_BUTTONS samples Numbers, so only the Decision press
-  # can ever resume this proc even though the request also accepts Numbers.
+  # off, numbers on, operators off, time-var/timed unused.
   auto.event_commands = [
     ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 1, 0, 0, 0]),
     ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
   ]
   scene = new_scene({ 1 => event(2, 2, auto) }, rpg2003: true)
   st = scene.instance_variable_get(:@state)
-  5.times { scene.update } # no key this input layer can sample was pressed
+  5.times { scene.update } # no key pressed yet: the proc keeps waiting
   eq 0, st.variables[1]
   ok !st.switches[5]
-  RGSS::Input.triggered = [RGSS::Input::C] # Decision (OK)
+  RGSS::Input.triggered = [RGSS::Input::N3] # digit 3
   scene.update # this frame resumes the proc and stores the code
-  eq 5, st.variables[1], 'Decision still resolves even with Numbers also accepted'
+  eq 13, st.variables[1], 'digit 3 -> RPG2000 code 13 (10 + the digit)'
   scene.update # the following command runs once the proc has resumed
+  ok st.switches[5]
+end
+
+check 'Key Input Proc (RPG2003 Operators layout) resolves an operator key press' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Same 9-param layout, but with operators (not numbers) accepted.
+  auto.event_commands = [
+    ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 1, 0, 0]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, rpg2003: true)
+  st = scene.instance_variable_get(:@state)
+  5.times { scene.update } # no key pressed yet: the proc keeps waiting
+  eq 0, st.variables[1]
+  ok !st.switches[5]
+  RGSS::Input.triggered = [RGSS::Input::PERIOD] # decimal point
+  scene.update
+  eq 24, st.variables[1], 'Period is the highest-priority operator code'
+  scene.update
+  ok st.switches[5]
+end
+
+check 'Key Input Proc (RPG2003 Numbers layout) ignores a digit key when Numbers is not accepted' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  # Decision only; Numbers off.
+  auto.event_commands = [
+    ECmd.new(ic::KEY_INPUT_PROC, [1, 1, 0, 1, 0, 0, 0, 0, 0]),
+    ECmd.new(ic::CONTROL_SWITCHES, [0, 5, 5, 0])
+  ]
+  scene = new_scene({ 1 => event(2, 2, auto) }, rpg2003: true)
+  st = scene.instance_variable_get(:@state)
+  RGSS::Input.triggered = [RGSS::Input::N3] # not accepted: Numbers is off
+  3.times { scene.update }
+  ok !st.switches[5], 'an unaccepted digit must not resume the proc'
+  eq 0, st.variables[1]
+  RGSS::Input.triggered = [RGSS::Input::C] # Decision: accepted
+  scene.update
+  eq 5, st.variables[1]
+  scene.update
   ok st.switches[5]
 end
 

--- a/src/sdl_input.cxx
+++ b/src/sdl_input.cxx
@@ -42,6 +42,25 @@ enum RgssKey {
   KEY_F8 = 18,
   KEY_F9 = 19,
   KEY_F12 = 20,
+  // RPG2003 Key Input Processing's Numbers/Operators groups (mruby-rgss's
+  // RGSS::Input::N0..PERIOD). Real key backing for these lives only in this
+  // SDL backend today -- see the comment on those constants in
+  // mruby-rgss/mrblib/lib.rb.
+  KEY_N0 = 21,
+  KEY_N1 = 22,
+  KEY_N2 = 23,
+  KEY_N3 = 24,
+  KEY_N4 = 25,
+  KEY_N5 = 26,
+  KEY_N6 = 27,
+  KEY_N7 = 28,
+  KEY_N8 = 29,
+  KEY_N9 = 30,
+  KEY_PLUS = 31,
+  KEY_MINUS = 32,
+  KEY_MULTIPLY = 33,
+  KEY_DIVIDE = 34,
+  KEY_PERIOD = 35,
 };
 
 // Map an SDL keysym to an RGSS::Input key id, or -1 when the key is unbound.
@@ -103,6 +122,56 @@ int map_key(SDL_Keycode k) {
       return KEY_F9;
     case SDLK_F12:
       return KEY_F12;
+    // Numbers: both the main-row digit keys and the numeric keypad produce
+    // the same digit (real RPG_RT/EasyRPG accept either), so both feed the
+    // same RGSS::Input id.
+    case SDLK_0:
+    case SDLK_KP_0:
+      return KEY_N0;
+    case SDLK_1:
+    case SDLK_KP_1:
+      return KEY_N1;
+    case SDLK_2:
+    case SDLK_KP_2:
+      return KEY_N2;
+    case SDLK_3:
+    case SDLK_KP_3:
+      return KEY_N3;
+    case SDLK_4:
+    case SDLK_KP_4:
+      return KEY_N4;
+    case SDLK_5:
+    case SDLK_KP_5:
+      return KEY_N5;
+    case SDLK_6:
+    case SDLK_KP_6:
+      return KEY_N6;
+    case SDLK_7:
+    case SDLK_KP_7:
+      return KEY_N7;
+    case SDLK_8:
+    case SDLK_KP_8:
+      return KEY_N8;
+    case SDLK_9:
+    case SDLK_KP_9:
+      return KEY_N9;
+    // Operators: the numpad has a dedicated key for all five; the main
+    // keyboard row only has unshifted "-", "/" and "." (a bare SDL keycode
+    // switch can't tell a shifted "+"/"*" chord from the unshifted digit
+    // underneath it, so PLUS/MULTIPLY are numpad-only here).
+    case SDLK_KP_PLUS:
+      return KEY_PLUS;
+    case SDLK_MINUS:
+    case SDLK_KP_MINUS:
+      return KEY_MINUS;
+    case SDLK_KP_MULTIPLY:
+      return KEY_MULTIPLY;
+    case SDLK_SLASH:
+    case SDLK_KP_DIVIDE:
+      return KEY_DIVIDE;
+    case SDLK_PERIOD:
+    case SDLK_KP_PERIOD:
+      return KEY_PERIOD;
     default:
       return -1;
   }


### PR DESCRIPTION
## Summary

RPG2003's Key Input Processing event command has always decoded its Numbers /
Operators flags (`Game::Interpreter#do_key_input`, since #791), but `RGSS::Input`
had no numeric-keypad or operator keys to sample, so a Numbers/Operators-only
request could never resolve. This wires real key support:

- `RGSS::Input` (`mruby-rgss/mrblib/lib.rb`) gains `N0`-`N9` / `PLUS` / `MINUS` /
  `MULTIPLY` / `DIVIDE` / `PERIOD` ids, continuing the sequence right after
  `F12` (21-35). Symbol spellings (`:N3`, `:PERIOD`, ...) are added to
  `SYMBOL_KEYS` for consistency with the existing RGSS2/3 button symbols.
- **SDL desktop backend only** (`src/sdl_input.cxx`'s `map_key`): digits bind
  both the main keyboard row and the numpad; operators bind the numpad for
  all five, plus the main-row unshifted `-`, `/` and `.` (a bare
  `SDL_Keycode` switch can't distinguish a shifted `+`/`*` chord from the key
  underneath it, so `+`/`*` are numpad-only).
- `Game::Interpreter::KEY_INPUT_CODES` produces the real RPG2000 key-input
  result codes for these keys — digit `d` → `10 + d`, operators
  Plus/Minus/Multiply/Divide/Period → 20-24 — matching EasyRPG Player's
  `Game_Interpreter::KeyInputState::CheckInput` (`src/game_interpreter.cpp`),
  the documented reference this codebase already leans on for RPG_RT behaviour
  that was never officially published. A new `KEY_INPUT_GROUPS` table maps
  each per-key symbol back onto the `:numbers`/`:operators` accept flag
  `do_key_input` actually decodes.
- `Scene::Map` gains `NUMBER_KEY_BUTTONS` / `OPERATOR_KEY_BUTTONS` and
  `#resolve_key_input` now samples them whenever the pending request accepts
  Numbers/Operators, exactly like the existing button set.

### Scope: SDL backend only, honestly

This repo has separate native input backends for PSP
(`mruby-rgss/src/psp_input_bridge.cxx`), Wio Terminal
(`mruby-rgss/src/wio_input_bridge.cxx`) and the terminal/sixel backend
(`mruby-rgss/src/terminal.cxx`). None of those are touched — they only ever
scan a small, fixed key-id range (7 buttons for PSP/Wio, a `KEY_F12 + 1`
array for the terminal), so the new ids are simply never pressed there, the
same way this build already leaves `F5`-`F12` unbound on those targets. I
can't test PSP/Wio hardware or a real terminal session for a new keyboard
binding in this sandbox, so I scoped this down to the one backend
(SDL desktop) that already has real, testable precedent and left the rest
honestly deferred — `docs/TODO.md` and the `interpreter.rb`/`scene/map.rb`
comments say so explicitly. Mouse input (Maniac) remains fully out of scope,
unchanged.

### Key set confirmed against EasyRPG Player's source

I verified the real RPG2000/2003 key set and code table against EasyRPG
Player (`src/input_buttons.h`, `src/game_interpreter.cpp`'s
`KeyInputState::CheckInput`), rather than guessing: Numbers is `N0`-`N9`
(codes 10-19), Operators is `Plus`/`Minus`/`Multiply`/`Divide`/`Period`
(codes 20-24, no separate equals key). EasyRPG's own SDL2 backend binds both
the main-row digits and the numpad digits to the same logical key, which is
what this PR follows for Numbers.

## Test plan

- [x] `ruby -c` on every changed Ruby file
- [x] `ruby scripts/rpg2k_logic_check.rb` — interpreter-level `key_input_result`
  checks for the new per-key symbols and priority ordering (815 checks pass)
- [x] `ruby scripts/rpg2k_scene_check.rb` — scene-level checks driving a real
  Key Input Processing wait through `Scene::Map#resolve_key_input` with
  simulated Numbers/Operators key presses (557 checks pass)
- [x] `mruby-rgss/test/test.rb` — added assertions for the new
  `RGSS::Input` ids (distinct, continue past `F12`, symbol spelling); **not
  run against the real mruby test binary** — this sandbox has no `rake`/mruby
  toolchain, same native-build caveat as other recent native PRs here. I
  syntax-checked it with `ruby -c` and reviewed it by hand instead.
- [x] `clang-format -i src/sdl_input.cxx` (no changes — already formatted)
- [x] `g++ -fsyntax-only` on `src/sdl_input.cxx` against a hand-written SDL2
  header stub (no real SDL2 dev packages in this sandbox) to catch typos and
  duplicate `case` labels in `map_key`'s new branches — clean, no warnings.
  **Not compiled against real SDL2 or linked**, so please give the switch
  statement a careful look.
- [x] Manual review of the C++ changes (no automated native build available
  here)

## Docs

- `docs/TODO.md`'s Key Input Processing note now describes what's wired
  (SDL backend, with the code table) and what's honestly deferred (the other
  native backends).
- `changelog.d/rpg2003-key-input-numbers-operators.added.md` added per the
  fragment convention.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GF5X4dmB8JwHPeXL1CcUY7)_