### PR TITLE
Confirm troop-member numbering stays stable across death/hide mid-fight

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8761,11 +8761,30 @@ above are repeated here)
   that inverts the index (`100 + (members.size - 1 - i)`), so member 0 gets
   the highest z of the group. Covered by a new assertion on the existing
   `scripts/rpg2k_scene_check.rb` two-Slime battler-sprite check, confirmed to
-  fail against the pre-fix code. **Still open**: whether deleting a middle
-  member shifts every later member's number down by one (and whether a
-  battle-event command naming a member by number gets silently repointed by
-  it) is unverified — a separate question about troop-member identity/
-  numbering, not the render-order this PR fixes.
+  fail against the pre-fix code. ✅ **Whether killing or hiding a middle
+  member shifts every later member's number down by one (silently
+  repointing a battle-event command that names a member by number)**: it
+  does not. `Game::Battle`'s `@enemies` (`mruby-rpg2k/mrblib/game.rb`) is
+  built once at battle start and never reassigned or resized afterward —
+  every "living only" use (`.reject(&:out_of_play?)`) builds a throwaway
+  filtered copy rather than mutating the array — so `#enemy(index)`
+  (`@enemies[index]`) always resolves the same troop slot to the same
+  combatant, dead or hidden or not, for the life of the fight. Confirmed
+  against EasyRPG's `Game_EnemyParty` (`src/game_enemyparty.cpp`):
+  `ResetBattle` clears and rebuilds its own `std::vector<Game_Enemy>
+  enemies` only once per fight (`enemies.clear()` then one `emplace_back`
+  per troop member), and `GetEnemy(idx)` is a bare `&enemies[idx]` — no
+  removal function touches the vector mid-battle; death and hide are both
+  in-place flags (`IsDead()`/`IsHidden()`) on the same slot, exactly
+  matching this codebase's `dead?`/`hidden` on `Game::Battle::Combatant`.
+  Locked in by a new `scripts/rpg2k_logic_check.rb` check: a 3-enemy troop
+  has its middle member (index 1) killed via Change Monster HP, then
+  confirms `#enemy(0)`/`#enemy(2)` still resolve to the exact same
+  combatant objects as before (`equal?`), that a Change Monster HP and a
+  battle Conditional Branch enemy-present check naming index 2 still land
+  on the untouched member 2, and that hiding member 0 afterward leaves
+  indices 0 and 2 unmoved too — confirmed to fail against a renumbering
+  (`@enemies.reject(&:dead?)`-style) implementation.
 - ✅ **The "airborne" enemy display flag only changes Y position on screen, with
   no accuracy/hit-related effect** — now implemented, with the crucial fact
   yado.tk's own text never mentions at all: real RPG2000 does not render it,

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11705,6 +11705,63 @@ check 'the battle Conditional Branch tests switches, variables and battlers' do
   eq 2, st.variables[1], 'an actor not in the fight fails'
 end
 
+check 'troop-member numbering stays stable when a middle member dies or is hidden' do
+  # docs/TODO.md's render-order fix left this "still open": does killing or
+  # hiding troop member 1 (the middle of three) shift member 2 down into
+  # slot 1, silently repointing anything that names it by its original
+  # index? Confirmed against EasyRPG's Game_EnemyParty::ResetBattle /
+  # GetEnemy (src/game_enemyparty.cpp) that it does not -- `@enemies` here
+  # mirrors its fixed-size `enemies` vector exactly: built once, never
+  # erased or resized mid-battle, with `dead?`/`hidden` in-place flags on
+  # each entry rather than removal.
+  foe0 = combatant('Foe0', 5, 0, 5, 50)
+  foe1 = combatant('Foe1', 5, 0, 5, 50)
+  foe2 = combatant('Foe2', 5, 0, 5, 50)
+  hero = combatant('Hero', 10, 0, 10, 100)
+  b = Game::Battle.new([hero], [foe0, foe1, foe2], Game::Rng.new(1))
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.battle = b
+
+  # Kill troop member 1 the way a battle event would: Change Monster HP,
+  # lethal damage.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [1, 1, 0, 999, 1])])
+  it.update
+  ok b.enemy(1).dead?, 'member 1 was killed'
+
+  # #enemy(index) must still resolve every index to the exact same
+  # combatant it did before member 1 died -- no shift, no renumbering.
+  ok foe0.equal?(b.enemy(0)), 'member 0 unaffected by member 1 dying'
+  ok foe1.equal?(b.enemy(1)), 'the dead member stays at its own index'
+  ok foe2.equal?(b.enemy(2)), 'member 2 does not shift down into slot 1'
+  eq 'Foe2', b.enemy(2).name
+
+  # A later command naming member 2 by its original index must still land
+  # on Foe2, not on whatever would have shifted into slot 2 under a
+  # renumbering scheme.
+  it.start([FakeCmd.new(IC::CHANGE_MONSTER_HP, [2, 1, 0, 20, 1])])
+  it.update
+  eq 30, foe2.hp, 'Change Monster HP on index 2 still targets Foe2'
+  eq 50, foe0.hp, 'and leaves member 0 untouched'
+
+  # A battle Conditional Branch "troop member present" check (type 3) on
+  # index 2 also keeps addressing Foe2.
+  it.start([FakeCmd.new(IC::CONDITIONAL_B, [3, 2, 0], indent: 0),
+            FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 1], indent: 1),
+            FakeCmd.new(IC::ELSE_BRANCH_B, [], indent: 0),
+            FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 0, 2], indent: 1),
+            FakeCmd.new(IC::END_BRANCH_B, [], indent: 0)])
+  it.update
+  eq 1, st.variables[1], 'member 2 (Foe2) still reads as present at index 2'
+
+  # Hiding is the other way a monster goes "out of play" mid-fight
+  # (Game::Battle::Combatant#out_of_play?): also in-place, never a removal.
+  foe0.hidden = true
+  ok foe0.equal?(b.enemy(0))
+  ok foe2.equal?(b.enemy(2))
+  eq 'Foe2', b.enemy(2).name
+end
+
 check 'battle-only commands are no-ops outside a battle' do
   st = new_state
   it = Game::Interpreter.new(st) # no #battle set: a map/common event


### PR DESCRIPTION
## Summary

The enemy-render-order fix left a "still open" note in `docs/TODO.md`: whether killing or hiding a middle troop member shifts every later member's number down by one, silently repointing a battle-event command (Change Monster HP/MP/Condition, the battle Conditional Branch) that names a member by its 0-based index.

It does not renumber. `Game::Battle`'s `@enemies` (`mruby-rpg2k/mrblib/game.rb`) is built once at battle start and never reassigned or resized — every "living only" use (`.reject(&:out_of_play?)`) builds a throwaway filtered copy rather than mutating the array — so `#enemy(index)` (`@enemies[index]`) always resolves the same troop slot to the same combatant, dead or hidden or not, for the life of the fight.

Confirmed against EasyRPG Player's real source, not just inferred from this codebase's own structure: `Game_EnemyParty` (`src/game_enemyparty.cpp`) clears and rebuilds its own `std::vector<Game_Enemy> enemies` only once per fight, in `ResetBattle`; `GetEnemy(idx)` is a bare `&enemies[idx]`; no removal function touches the vector mid-battle; death and hide are both in-place flags (`IsDead()`/`IsHidden()`) on the same slot — exactly matching this codebase's `dead?`/`hidden` on `Game::Battle::Combatant`.

- Updated the "still open" note in `docs/TODO.md` to ✅, with the EasyRPG citation.
- Added a `scripts/rpg2k_logic_check.rb` regression check: a 3-enemy troop has its middle member (index 1) killed via Change Monster HP, then confirms `#enemy(0)`/`#enemy(2)` still resolve to the exact same combatant objects as before (by identity), that a later Change Monster HP and a battle Conditional Branch enemy-present check naming index 2 still land on the untouched member, and that hiding a member afterward leaves indices unmoved too. Confirmed to fail against a renumbering (`reject(&:dead?)`-style) implementation before landing the check.
- No changelog fragment: this is a confirm-and-test pass with no behavior change, matching this repo's convention for prior "docs: confirm X" PRs (e.g. #758, #494).

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 817 checks passed
- [x] New check confirmed to fail against a renumbering implementation of `#enemy`, confirmed to pass against the real one
- [x] `ruby scripts/rpg2k_scene_check.rb` — 555 checks passed (unaffected, run for safety)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LemNrTt2ZpqRRKnerxqXNd)_