### PR TITLE
Widen the F9 debug menu's variable editor to 7 digits on RPG2003

### DIFF
--- a/changelog.d/rpg2k-debug-menu-editor-digits-rpg2003.fixed.md
+++ b/changelog.d/rpg2k-debug-menu-editor-digits-rpg2003.fixed.md
@@ -1,0 +1,7 @@
+- **The F9 debug menu's variable-value editor now widens to 7 digits on an
+  RPG2003 database**, instead of staying a flat 6 digits on every database.
+  Confirmed against EasyRPG Player's source (`Game_Variables::GetMaxDigits`):
+  RPG2003 widens the editable range 10x, mirroring the same edition split
+  this engine already applies to the underlying variable range itself. A
+  flat 6-digit editor could not enter or even display an RPG2003 variable's
+  own top decade.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5032,6 +5032,26 @@ not yet verified:
   companion to the existing "recovery skill hard-caps at 999" check for an
   RPG2003 fight's own wider 9999 ceiling, both confirmed to fail against the
   pre-fix code before the fix.
+- ✅ **The F9 debug menu's variable-value editor now widens to 7 digits on
+  an RPG2003 database, instead of staying a flat 6 digits on every
+  database.** `Scene::DebugMenu` (`mruby-rpg2k/mrblib/scene/debug_menu.rb`)
+  hardcoded `EDITOR_DIGITS = 6`, even though the `Game::Variables` range it
+  edits already splits `MAX`/`RPG2003_MAX` by edition (999,999 vs.
+  9,999,999 — see the variable-clamp fix directly below). EasyRPG's own
+  `Game_Variables::GetMaxDigits` (`src/scene_debug.cpp`) derives its debug
+  menu's `Window_NumberInput` width from this same edition-gated range: 6
+  digits on RPG2000, 7 on RPG2003. A flat 6-digit editor could not enter or
+  even display an RPG2003 variable's own top decade — the cursor had no
+  cell to land on past the sixth digit. Fixed by splitting the constant
+  into `EDITOR_DIGITS_2K`/`EDITOR_DIGITS_2K3` and adding a guarded
+  `#editor_digits` method (mirroring `Game::Actor#rpg2003?`'s own
+  `respond_to?` guard, so a bare test double without `#rpg2003?` still
+  reads as RPG2000), with the digit array, editor window width, and cursor
+  cell count all reading the method instead of the bare constant. Covered
+  by a new `scripts/rpg2k_scene_check.rb` check that opens the editor on an
+  RPG2003 database, walks the cursor onto the RPG2003-only millions-place
+  digit cell, and confirms the value it produces is only reachable with the
+  wider editor, confirmed to fail against the pre-fix code before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/scene/debug_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/debug_menu.rb
@@ -175,7 +175,24 @@ class RPG2k
 
       # -- Variable value editor, opened by C on a Variable row ----------------
 
-      EDITOR_DIGITS = 6 # 999,999 -- Game::Variables::MAX/MIN
+      # 999,999 (RPG2000) / 9,999,999 (RPG2003) -- Game::Variables::MAX/MIN
+      # vs. RPG2003_MAX/MIN (`mruby-rpg2k/mrblib/game.rb`), the same
+      # edition-gated range EasyRPG's own `Game_Variables::GetMaxDigits`
+      # derives its debug-menu editor width from (`src/scene_debug.cpp`
+      # sizes and drives its `Window_NumberInput` straight off it) --
+      # a flat 6-digit editor structurally cannot enter or display an
+      # RPG2003 variable's own top decade.
+      EDITOR_DIGITS_2K = 6
+      EDITOR_DIGITS_2K3 = 7
+
+      # The effective digit width for this state's own database edition. A
+      # bare test double with no #rpg2003? of its own reads false, matching
+      # a genuine RPG2000 database (the same guard Game::Actor#rpg2003?/
+      # Game::Party#rpg2003? already use for their own @db).
+      def editor_digits
+        rpg2003 = @state.party.respond_to?(:rpg2003?) && @state.party.rpg2003?
+        rpg2003 ? EDITOR_DIGITS_2K3 : EDITOR_DIGITS_2K
+      end
 
       def open_editor(id)
         v = @state.variables[id]
@@ -183,12 +200,13 @@ class RPG2k
         build_editor_window
       end
 
-      # EDITOR_DIGITS-long digit array (most significant first) for a
+      # #editor_digits-long digit array (most significant first) for a
       # non-negative value, e.g. digits_of(7) -> [0, 0, 0, 0, 0, 7]. No
       # String#chars/#rjust here, for the same reason as #id_label above.
       def digits_of(value)
-        ds = Array.new(EDITOR_DIGITS, 0)
-        (EDITOR_DIGITS - 1).downto(0) do |i|
+        n = editor_digits
+        ds = Array.new(n, 0)
+        (n - 1).downto(0) do |i|
           ds[i] = value % 10
           value /= 10
         end
@@ -201,7 +219,7 @@ class RPG2k
       end
 
       def build_editor_window
-        w = (EDITOR_DIGITS + 1) * 12 + Window::BORDER * 2
+        w = (editor_digits + 1) * 12 + Window::BORDER * 2
         h = LINE_H + Window::BORDER * 2
         @editor_window = Window.new((SCREEN_W - w) / 2, (SCREEN_H - h) / 2, w, h)
         @editor_window.z = 410
@@ -220,7 +238,7 @@ class RPG2k
       end
 
       def update_editor
-        cells = EDITOR_DIGITS + 1 # the sign occupies cell 0, digits follow
+        cells = editor_digits + 1 # the sign occupies cell 0, digits follow
         if Input.trigger?(Input::B)
           close_editor
         elsif Input.trigger?(Input::C)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13524,6 +13524,37 @@ check 'B cancels the debug menu variable editor without changing the value' do
   eq 5, st.variables[1], 'cancelling left the variable untouched'
 end
 
+# EasyRPG's own Game_Variables::GetMaxDigits (src/game_variables.cpp) derives
+# the debug menu's own Window_NumberInput width from the same edition-gated
+# range Game::Variables::MAX/RPG2003_MAX already carries -- 6 digits on
+# RPG2000, 7 on RPG2003, not a flat 6 regardless of database.
+class Rpg2003MenuStubParty < MenuStubParty
+  def rpg2003?; true; end
+end
+
+check "the debug menu variable editor widens to 7 digits on an RPG2003 database" do
+  st = Game::State.new(Rpg2003MenuStubParty.new, 1, 0, 0)
+  st.variables[1] = 5
+  scene = menu_scene(RPG2k::Scene::DebugMenu, st)
+  scene.instance_variable_set(:@mode, :variable)
+  scene.send(:refresh)
+  eq 7, scene.send(:editor_digits), 'RPG2003 widens the editor to 7 digits'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # open the editor on variable 1
+  scene.update
+  eq 7, scene.instance_variable_get(:@editor)[:digits].size,
+     'the digit array itself is 7 cells wide, not 6'
+  # Digits are most-significant-first, so the new, RPG2003-only millions
+  # place is digit index 0 -- cursor cell 1, right after the sign cell (0).
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]; scene.update
+  RGSS::Input.triggered = [RGSS::Input::UP] # the millions digit 0 -> 1
+  scene.update
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm
+  scene.update
+  eq 1_000_005, st.variables[1],
+     'the millions digit only the RPG2003-widened editor exposes landed in the variable'
+end
+
 check "a troop's terrain_set excludes it from a tile it does not cover" do
   scene = new_scene({})
   scene.db.enemy_group[9] = OpenStruct.new(name: 'Wolves', members: {}, terrain_set: [0])


### PR DESCRIPTION
## Summary
- `Scene::DebugMenu`'s F9 variable-value editor hardcoded `EDITOR_DIGITS = 6` regardless of database edition, even though the underlying `Game::Variables` range it edits already splits `MAX`/`RPG2003_MAX` by edition (999,999 vs. 9,999,999).
- EasyRPG Player's own `Game_Variables::GetMaxDigits` (`src/scene_debug.cpp`) derives its debug menu editor width from this same edition-gated range, widening to 7 digits on RPG2003 — a flat 6-digit editor could not enter or even display an RPG2003 variable's own top decade.
- Splits `EDITOR_DIGITS` into `EDITOR_DIGITS_2K`/`EDITOR_DIGITS_2K3` and adds a guarded `#editor_digits` method (mirroring `Game::Actor#rpg2003?`'s own `respond_to?` guard, so a bare test double without `#rpg2003?` still reads as RPG2000), updating all three call sites (digit array size, editor window width, cursor cell count) to read the method instead of the bare constant.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` check opens the editor on an RPG2003 database, walks the cursor onto the RPG2003-only millions-place digit cell, and confirms the resulting value is only reachable with the wider editor — confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_