### PR TITLE
Field skill menu: report and exclude a dangling learned-skill id

### DIFF
--- a/changelog.d/field-skill-menu-dangling-id.fixed.md
+++ b/changelog.d/field-skill-menu-dangling-id.fixed.md
@@ -1,0 +1,8 @@
+- **The field skill menu no longer drops a dangling learned-skill id with no
+  trace** — a database shrink can leave a caster's learned skill id pointing
+  at nothing, shown as "?" in the editor. `Game::Party#field_skills`
+  (`mruby-rpg2k/mrblib/game.rb`) now logs a `[RPG2k] Skill menu: caster's
+  learned skill #<id> has no matching database row, excluding from field
+  menu` diagnostic instead of silently omitting it. The skill still doesn't
+  appear in the menu — there's nothing sensible to show for it — this is
+  diagnostics only. Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8454,6 +8454,26 @@ five new `scripts/rpg2k_logic_check.rb` checks (no handlers, an [Escape]
 handler, escape-abort mode, and the random-encounter path both missing and
 present), each asserting on the captured `$stderr` line and that no
 `:battle` wait was ever armed.
+✅ **The field skill menu no longer drops a dangling learned-skill id with no
+trace** — one of the "invalid skill" cases above, the "opens a skill-select
+screen" variant. `Game::Party#field_skills` (`mruby-rpg2k/mrblib/game.rb`)
+builds a caster's field-usable skill list from `#db_skill(id)`, which already
+tolerated a shrunk database by returning `nil` for a stale id; `#field_skill?`
+just as silently excluded it (`return false unless sk`), so the skill
+vanished from the menu with no diagnostic anywhere in the chain. `#field_skills`
+now checks `db_skill(sid)` itself before delegating to `#field_skill?` and
+logs a `[RPG2k] Skill menu: caster's learned skill #<id> has no matching
+database row, excluding from field menu` diagnostic the same
+reported-not-invented way Call Event/Enemy Encounter/Teleport above do,
+including the skill id; the skill still doesn't appear in the menu — there is
+nothing sensible to show for it — this is diagnostics only. Follows this
+catalog's existing precedent of logging every occurrence rather than deduping
+per id: none of Call Event, Enemy Encounter or Teleport keep any
+already-logged state, so a menu opened repeatedly logs the same stale id each
+time, and this doesn't diverge from that. Covered by a new
+`scripts/rpg2k_logic_check.rb` check asserting the captured `$stderr` line and
+that the dangling id is excluded while a genuine sibling skill still comes
+through.
 ✅ **"invalid map" (Transfer Player / Recall to Location naming a
 nonexistent map id) no longer crashes the interpreter** — `Scene::Map
 #perform_teleport` (`mruby-rpg2k/mrblib/scene/map.rb`) called

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3288,10 +3288,24 @@ module Game
     # `state` is optional and only read for the Escape / Teleport types below —
     # every other caller (the host-side fixture checks included) can omit it and
     # gets the old scope/occasion-only behaviour.
+    #
+    # A database shrink can leave a learned skill id with no matching row
+    # (docs/TODO.md's runtime error catalog) -- `db_skill` degrades that to a
+    # silent `nil`, and `#field_skill?`'s `return false unless sk` would drop
+    # the skill from the menu with no trace. Logged here, at the one place
+    # that knows the gap came from a *caster's own* skill list rather than
+    # from some other `db_skill` call with no menu behind it.
     def field_skills(caster, state = nil)
       return [] unless caster
-      caster.skills.sort.select { |sid| field_skill?(db_skill(sid), state) }
-            .map { |sid| [sid, skill_cost(db_skill(sid), caster)] }
+      caster.skills.sort.select do |sid|
+        sk = db_skill(sid)
+        if sk.nil?
+          $stderr.puts "[RPG2k] Skill menu: caster's learned skill ##{sid} " \
+                       'has no matching database row, excluding from field menu'
+          next false
+        end
+        field_skill?(sk, state)
+      end.map { |sid| [sid, skill_cost(db_skill(sid), caster)] }
     end
 
     # Whether skill row `sk` belongs in the field menu.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5074,6 +5074,22 @@ check 'field_skills lists only known field-usable ally skills; can_cast? checks 
   eq false, st.party.can_cast?(hero, 99)       # unknown skill
 end
 
+# A database shrink can leave a caster's learned skill id dangling -- shown
+# as "?" in the editor, docs/TODO.md's runtime error catalog. #db_skill
+# silently resolves that to nil, and #field_skill? just as silently excludes
+# it (`return false unless sk`); the skill vanished from the field menu with
+# no trace anywhere in the call chain. #field_skills now reports it.
+check 'field_skills reports a dangling learned skill id and excludes it from the menu' do
+  skills = { 7 => fake_skill(scope: 3, sp_cost: 5, power: 10, hp: true) }
+  st = skill_party(skills)
+  hero = st.party.actor_by_id(1)
+  hero.learn_skill(7)
+  hero.learn_skill(99)                          # 99 no longer exists in the database
+  out = capture_stderr { eq [[7, 5]], st.party.field_skills(hero) }
+  ok out.include?("[RPG2k] Skill menu: caster's learned skill #99 has no " \
+                   'matching database row'), out
+end
+
 # A property/attribute row exposing just the weapon (0) / magic (1) `type`
 # flag the equip-gating check reads (field 2 of the real `property` row).
 AttrTypeRow = Struct.new(:type)


### PR DESCRIPTION
## Summary

A database shrink can leave a caster's learned skill id pointing at nothing — one of the still-open cases in `docs/TODO.md`'s "Concrete runtime error catalog" ("invalid skill", the "opens a skill-select screen" variant).

- `Game::Party#db_skill` (`mruby-rpg2k/mrblib/game.rb`) already tolerated this by returning `nil` for a stale id, but `#field_skill?` just as silently excluded the `nil` result (`return false unless sk`), so `#field_skills` dropped the skill from the field menu with no trace anywhere in the call chain.
- `#field_skills` now resolves `db_skill(sid)` itself before delegating to `#field_skill?` and logs a `[RPG2k] Skill menu: caster's learned skill #<id> has no matching database row, excluding from field menu` diagnostic the first time it hits an unresolvable id — the same reported-not-invented pattern the Call Event / Enemy Encounter / Teleport fixes already use. The skill still doesn't appear in the menu (nothing sensible to show for it); this is diagnostics only.
- **Log-every-occurrence, not dedupe-per-id**: checked the existing dangling-reference diagnostics in this catalog (Call Event, Enemy Encounter, Teleport) for precedent — none of them keep any already-logged state, so a repeated trigger (e.g. the menu opened again) logs again each time. This follows that same precedent rather than introducing a new "log once" pattern.

## Test coverage

New check in `scripts/rpg2k_logic_check.rb`: a caster with one genuine skill and one dangling id gets a `field_skills` result containing only the genuine skill, with the `$stderr` diagnostic asserted for the dangling one.

## Docs

- `docs/TODO.md`'s runtime error catalog entry marked ✅, matching the style of the neighboring Call Event / Enemy Encounter / Teleport entries.
- `changelog.d/field-skill-menu-dangling-id.fixed.md` added per the fragment convention.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 819 checks passed (new check added; confirmed it fails against the pre-fix code)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 558 checks passed (unaffected, run as a sanity pass)
- [x] `ruby -c` on both changed Ruby files
- [x] Manually verified no trailing whitespace / missing final newline on changed files (`pre-commit` binary unavailable in this sandbox)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K84T9WmADb4UQZQqpzrf4j)_