### PR TITLE
Report Control Variables' stale event/character targets, not silent

### DIFF
--- a/changelog.d/control-variables-stale-event-reported.fixed.md
+++ b/changelog.d/control-variables-stale-event-reported.fixed.md
@@ -1,0 +1,7 @@
+- **Control Variables' Character operand now reports a stale event target**
+  ("This Event" used inside a Common Event, or a map event id absent on the
+  current map) as a `[RPG2k] Control Variables: ...` diagnostic instead of
+  silently reading `0`, matching the reported-not-invented pattern already
+  used for Call Event/Enemy Encounter/Transfer Player. `Interpreter
+  #event_operand`/`#screen_operand` (`mruby-rpg2k/mrblib/interpreter.rb`).
+  Covered by four new `scripts/rpg2k_logic_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8414,7 +8414,8 @@ absent on the current map" cause and "a variable-driven Call Event
 resolving to no match", plus invalid-event-page as a distinct message from
 invalid-event-id). The remaining "invalid event ID" cause — a stale
 Variable-Op/Move-Route target — is a different command family, not part
-of Call Event, and is still open. **Store Event ID has no analogous gap**:
+of Call Event; **the Variable-Op half is now fixed too** (see the ✅ entry
+below), leaving only Move-Route open. **Store Event ID has no analogous gap**:
 unlike Call Event it never targets an event *by id*, only by tile position
 (`#do_store_event_id`), and "no event on this tile" (stored as `0`) is a
 genuine, correctly-modelled answer rather than a stale reference — nothing
@@ -8480,6 +8481,22 @@ new `scripts/rpg2k_scene_check.rb` checks, each targeting a `FakeParent`
 whose `load_map` raises `Errno::ENOENT` for one specific id and asserting
 the `$stderr` diagnostic fires while `state.map_id`/`state.x`/`state.y`
 stay exactly as they were before the failed command ran.
+✅ **Control Variables' Character operand no longer swallows a stale
+Variable-Op target** — the last of the four "invalid event ID" causes
+listed above, and a different command family from Call Event. `Interpreter
+#event_operand`/`#screen_operand` (`mruby-rpg2k/mrblib/interpreter.rb`)
+back the Character-attribute selectors (map id/x/y/direction and the
+screen-x/screen-y pair) and previously read `0` at every unresolved-target
+branch with no trace: "This Event" used with no map-event context
+(`#character_ref` returning `nil`, mirroring the Call Event fix's own
+"this event" case) and a map-event id absent on the current map (mirroring
+Call Event's own stale-target case), each now logged for both the
+plain-attribute path (`#event_operand`) and the screen-coordinate path
+(`#screen_operand`), plus a character with a resolvable id but no on-screen
+position to report. All four log a `[RPG2k] Control Variables: ...`
+diagnostic and still resolve to `0` — behaviour is unchanged, only the
+gap is now visible. Covered by four new `scripts/rpg2k_logic_check.rb`
+checks, each asserting on the captured `$stderr` line.
 
 **Map/Event ID assignment & tile occupancy**
 - ✅ **Not applicable: Event ID (and, separately, Map ID) assignment by

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1563,7 +1563,11 @@ module Game
       ref = character_ref(cmd.param(5))
       attr = cmd.param(6)
       return screen_operand(ref, attr) if attr == 4 || attr == 5
-      return 0 if ref.nil?
+      if ref.nil?
+        $stderr.puts '[RPG2k] Control Variables: "this event" has no map ' \
+                     'event to refer to (running inside a common event)'
+        return 0
+      end
       if ref == CHAR_PLAYER # the hero / party leader
         case attr
         when 0 then @state.map_id
@@ -1576,7 +1580,10 @@ module Game
         vehicle_operand(ref, attr)
       elsif ref > 0 && ref < 10000 && @map_info.respond_to?(:event_position)
         pos = @map_info.event_position(ref)
-        return 0 unless pos
+        unless pos
+          $stderr.puts "[RPG2k] Control Variables: map event #{ref} not found"
+          return 0
+        end
         case attr
         when 0 then @state.party.rpg2003? ? @state.map_id : 0 # the RPG2000-only quirk
         when 1 then pos[:x]
@@ -1613,10 +1620,18 @@ module Game
     # battle page) there is no view to measure against, so it reads 0. `ref` has
     # already been through #character_ref, so "this event" arrives as a real id.
     def screen_operand(ref, attr)
-      return 0 if ref.nil?
+      if ref.nil?
+        $stderr.puts '[RPG2k] Control Variables: "this event" has no map ' \
+                     'event to refer to (running inside a common event)'
+        return 0
+      end
       return 0 unless @map_info.respond_to?(:character_screen_position)
       pos = @map_info.character_screen_position(ref)
-      return 0 unless pos
+      unless pos
+        $stderr.puts "[RPG2k] Control Variables: character #{ref} has no " \
+                     'screen position (not on the current map)'
+        return 0
+      end
       attr == 4 ? pos[:x] : pos[:y]
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5721,6 +5721,18 @@ check 'Control Variables reads a map event position (operand type 6)' do
   eq 0, st.variables[5]                                          # unknown event reads 0
 end
 
+check 'Control Variables targeting a stale map event id is reported, not silent' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new # event 7 at (2,3) dir 6; event 9 does not exist
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 9, 1])])
+    it.update
+  end
+  eq 0, st.variables[1]
+  ok out.include?('[RPG2k] Control Variables: map event 9 not found'), out
+end
+
 check 'Control Variables: a map event\'s map id is the RPG2000-only quirk -- an ' \
       'RPG2003 database reads the real (current) map id instead' do
   st = new_state(rpg2003: true)
@@ -5791,6 +5803,30 @@ check 'Control Variables "this event" reads 0 without a running map event' do
   eq 0, st.variables[2]
 end
 
+check '"this event" with no running map event is reported (event_operand: x/y/direction)' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 10005, 1])]) # this event's x
+    it.update
+  end
+  eq 0, st.variables[1]
+  ok out.include?('[RPG2k] Control Variables: "this event" has no map event to refer to'), out
+end
+
+check '"this event" with no running map event is reported (screen_operand: screen x/y)' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 10005, 4])]) # this event's screen x
+    it.update
+  end
+  eq 0, st.variables[1]
+  ok out.include?('[RPG2k] Control Variables: "this event" has no map event to refer to'), out
+end
+
 check 'Control Variables reads an actor stat (operand type 5)' do
   st = party_state
   a = st.party.actor_by_id(1) # atk 10, max_hp 100
@@ -5820,6 +5856,18 @@ check 'Control Variables reads a character screen position (operand 6, attr 4/5)
   eq 120, st.variables[2]
   eq 40, st.variables[3]
   eq 0, st.variables[4]
+end
+
+check 'a character with no screen position (not on this map) is reported, not silent' do
+  st = new_state
+  it = Game::Interpreter.new(st)
+  it.map_info = FakeMapInfo.new # event 9 has no screen position
+  out = capture_stderr do
+    it.start([FakeCmd.new(IC::CONTROL_VARS, [0, 1, 1, 0, 6, 9, 4])])
+    it.update
+  end
+  eq 0, st.variables[1]
+  ok out.include?('[RPG2k] Control Variables: character 9 has no screen position'), out
 end
 
 check 'a screen position with no camera to measure against reads 0' do


### PR DESCRIPTION
## Summary

- `Interpreter#event_operand`/`#screen_operand` (`mruby-rpg2k/mrblib/interpreter.rb`), which back Control Variables' Character-attribute selectors (map id/x/y/direction and screen-x/screen-y), silently read `0` at every unresolved-target branch: "This Event" used with no map-event context, and a map event id absent on the current map — with no diagnostic anywhere.
- This extends the "reported gap, not silently invented" pattern already applied to Call Event, Enemy Encounter and Transfer Player. Each unresolved branch now logs a `[RPG2k] Control Variables: ...` diagnostic and still returns `0` — behavior is unchanged, the gap is now visible.
- This closes the last of the four "invalid event ID" causes in `docs/TODO.md`'s runtime error catalog (the "stale Variable-Op ... target" case), leaving only the Move-Route target open (out of scope here, being worked on separately).

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 822 checks pass (4 new checks, one per new diagnostic path), each asserting on the captured `$stderr` line.
- [x] Verified no trailing whitespace / missing EOF newline in touched files (pre-commit's `trailing-whitespace`/`end-of-file-fixer` hooks were unavailable in this sandbox).
- [x] `docs/TODO.md` runtime error catalog entry updated to ✅.
- [x] `changelog.d/control-variables-stale-event-reported.fixed.md` fragment added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VXXXKXhATAXQarRwU398XQ)_