### PR TITLE
Roll a weapon's own state-infliction chance on a basic Attack

### DIFF
--- a/changelog.d/rpg2k-weapon-state-infliction.fixed.md
+++ b/changelog.d/rpg2k-weapon-state-infliction.fixed.md
@@ -1,0 +1,12 @@
+- **A basic Attack now rolls its own weapon's state-infliction chance**,
+  instead of doing nothing at all — only Skills and Items ever rolled state
+  infliction before, so a "Poison Dagger"-style weapon (a real mechanic
+  several of Nepheshel's actual weapons use) could never poison anything on
+  a plain swing. Confirmed against EasyRPG Player's source
+  (`Game_BattleAlgorithm::Normal::vExecute`): each state a weapon's
+  `state_set` flags rolls against its own `state_chance`, scaled by the
+  target's susceptibility, the same way a skill's own infliction already
+  works. A dual-wielding actor's second weapon can flag a different state or
+  a different chance for the same one; RPG2003's `reverse_state_effect` flag
+  flips a weapon's own states from inflicting to curing them, but only on
+  RPG2003 — the same flag has no effect here on an RPG2000 database.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3435,9 +3435,13 @@ The work below is roughly ordered by the critical path to a walkable game
   crude in one direction on purpose — a field named only in a comment counts as
   read, so the list under-reports and never over-reports. A row is a question,
   not a defect: the script carries a `NOT_OURS` table of fields checked against
-  EasyRPG and deliberately left alone (`levitate` and `state_chance` are RPG2003
-  only, `message_affected` has no known trigger, and the two critical-hit terms
-  are side-keying-unresolved, ADR 0036), so nobody re-derives them.
+  EasyRPG and deliberately left alone (`levitate` is RPG2003 only,
+  `message_affected` has no known trigger, and the two critical-hit terms are
+  side-keying-unresolved, ADR 0036), so nobody re-derives them. `state_chance`
+  used to sit in this table on the same "RPG2003 only" reasoning, checked only
+  against the item-cure code path; the weapon-attack path reads it on both
+  editions, and a real RPG2000 game (Nepheshel) sets it on several weapons —
+  see the basic-Attack weapon-state-infliction fix below.
 - ✅ **Drain skills** (吸収, the skill row's `absorb_damage`) — 13 of Nepheshel's
   306 skills and 5 of mtf's 134 set it and nothing read it, so every drain spell
   in both games was an ordinary attack spell, and the two 用語 sentences that
@@ -5052,6 +5056,34 @@ not yet verified:
   RPG2003 database, walks the cursor onto the RPG2003-only millions-place
   digit cell, and confirms the value it produces is only reachable with the
   wider editor, confirmed to fail against the pre-fix code before the fix.
+- ✅ **A basic Attack now rolls its own weapon's state-infliction chance**
+  (item fields 63/64 `state_set` and 67 `state_chance`) instead of doing
+  nothing at all — only Skills and Items ever rolled state infliction
+  before, so a "Poison Dagger"-style weapon could never actually poison
+  anything on a plain swing. Confirmed against EasyRPG's
+  `Game_BattleAlgorithm::Normal::vExecute` (`src/game_battlealgorithm.cpp`,
+  the "Conditions caused / healed by weapon" block): each state a weapon's
+  `state_set` flags rolls against `state_chance`, scaled by the target's own
+  susceptibility (`Game::Battle#state_susceptibility`, the same function a
+  skill's infliction already uses) — and, unlike a skill, a state already on
+  the target is silently skipped rather than re-reported. A 二刀流 (dual-
+  wielding) actor's second weapon can flag a different state, or the same
+  state at a different chance, in which case the higher chance wins (ported
+  as a per-state max across both weapons). RPG2003's `reverse_state_effect`
+  flag (field 20) flips a weapon's own states from inflicting to *curing*
+  them — but only on RPG2003 (`is2k3 && w->reverse_state_effect`); the same
+  flag on an RPG2000 database has no effect here, matching how it already
+  behaves for a medicine item / field skill elsewhere in this codebase.
+  Implemented as a new `Game::Actor#weapon_states` reader (mirroring
+  `#weapon_attributes`'s own equipment scan) carried onto the Combatant
+  snapshot as `atk_states`, and a new `Game::Battle#roll_weapon_states`
+  applied from `#deal_attack` once the blow's damage is resolved and the
+  target has survived it — the same guard `#shake_off_states` already uses.
+  Covered by three new `scripts/rpg2k_logic_check.rb` checks (a plain
+  RPG2000 weapon inflicting its state, an RPG2003 `reverse_state_effect`
+  weapon healing one instead, and the same weapon on RPG2000 still
+  inflicting since the flag is edition-gated), each confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1708,6 +1708,51 @@ module Game
       ids.uniq
     end
 
+    # The status conditions the actor's equipped weapon(s) carry into a basic
+    # Attack -- item fields `state_set` (63/64, a flag per state) and
+    # `state_chance` (67, a flat percent applied to every state the weapon
+    # flags) -- split by whether the weapon inflicts or (RPG2003 only)
+    # *heals* them, per `Game::Battle#deal_attack`'s own use.
+    #
+    # EasyRPG's `Game_BattleAlgorithm::Normal::vExecute` (`weapons` block)
+    # is the port target: a weapon with no `state_chance` (or none flagged in
+    # `state_set`) contributes nothing, and a 二刀流 actor's second weapon
+    # (`#weapon_attributes`' own `type == 1` filter already reaches the
+    # shield slot when it holds a weapon, same as here) can name a *different*
+    # state, or the same one at a different chance -- EasyRPG takes the
+    # higher chance when both weapons flag the same state ("we take the max
+    # probability as RPG_RT does"), which is what the `< chance` compare
+    # below does per state id. `reverse_state_effect` (field 20) flips a
+    # weapon's own states from inflicting to curing, but **only on RPG2003**
+    # (`is2k3 && w->reverse_state_effect`) -- on RPG2000 the field has no
+    # effect here, matching the flag's own item-menu/skill-menu handling
+    # elsewhere in this file (`#item_inflicted_states`, `#skill_state_ids`).
+    #
+    # No item table (a fixture) or an unarmed actor carries none of either.
+    def weapon_states
+      inflict = {}
+      heal = {}
+      return { inflict: inflict, heal: heal } unless @db.respond_to?(:item)
+      heals_flip = rpg2003?
+      @equipment.each do |iid|
+        next if iid.nil? || iid == 0
+        it = @db.item[iid]
+        next unless it && it.respond_to?(:type) && it.type == 1 # weapon slot only
+        set = it.respond_to?(:state_set) ? it.state_set : nil
+        next unless set
+        chance = it.respond_to?(:state_chance) ? (it.state_chance || 0) : 0
+        next unless chance > 0
+        heals = heals_flip && it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+        bucket = heals ? heal : inflict
+        set.each_index do |i|
+          next unless set[i] && set[i] != 0
+          sid = i + 1
+          bucket[sid] = chance if (bucket[sid] || 0) < chance
+        end
+      end
+      { inflict: inflict, heal: heal }
+    end
+
     # The actor's basic-attack base hit rate (percent): the highest `hit` among
     # the equipped weapons (item field 17), or the RPG2000 unarmed default of 90
     # when nothing is equipped or the row omits it. Feeds the battle's to-hit
@@ -7046,7 +7091,15 @@ module Game
                            # per fight and never written back to the actor, so
                            # nil (read as 0 by #effective_atk and friends)
                            # every construction is the reset for free.
-                           :atk_mod, :def_mod, :spi_mod, :agi_mod) do
+                           :atk_mod, :def_mod, :spi_mod, :agi_mod,
+                           # The status conditions this battler's equipped
+                           # weapon(s) carry into a basic Attack -- see
+                           # Game::Actor#weapon_states, whose `{ inflict:,
+                           # heal: }` shape this mirrors exactly. An enemy
+                           # Combatant leaves it nil (read as empty by
+                           # #atk_states -- monsters equip nothing in real
+                           # RPG_RT either).
+                           :atk_states) do
       def dead?; hp <= 0; end
 
       # Swings per basic attack: 2 with a 二刀流 weapon, 1 otherwise. Struct
@@ -7055,6 +7108,10 @@ module Game
       # Whether this battler's gear halves what a skill costs (Party#skill_cost
       # asks whatever it is handed, actor or snapshot).
       def half_sp_cost?; half_sp_cost ? true : false; end
+      # The weapon-granted state chances this battler's basic Attack carries,
+      # normalised to `{ inflict: {}, heal: {} }` for a Combatant that never
+      # had any set (an enemy, or an actor built before this field existed).
+      def atk_states; self[:atk_states] || { inflict: {}, heal: {} }; end
 
       # RPG2003 counts turns per battler as well as per battle: this is how many
       # turns *this* battler has taken, which the troop pages' turn_enemy /
@@ -7098,6 +7155,11 @@ module Game
     # weapon's attribute_set); [] for an enemy or an unarmed / fixture attacker.
     def self.atk_attrs_of(b); b.respond_to?(:weapon_attributes) ? b.weapon_attributes : []; end
 
+    # The status conditions a battler's basic attack carries via its equipped
+    # weapon(s) (`Game::Actor#weapon_states`); nil (read as empty by
+    # Combatant#atk_states) for an enemy or an unarmed / fixture attacker.
+    def self.atk_states_of(b); b.respond_to?(:weapon_states) ? b.weapon_states : nil; end
+
     # A battler's basic-attack base hit rate (percent), or 90 (the RPG2000
     # default) when the source (a bare fixture) doesn't model one.
     def self.hit_rate_of(b); b.respond_to?(:attack_hit_rate) ? b.attack_hit_rate : 90; end
@@ -7120,6 +7182,7 @@ module Game
       c.half_sp_cost = flag_of(a, :half_sp_cost?)
       c.evasion_up = flag_of(a, :physical_evasion_up?)
       c.attr_base_ranks = c.attr_ranks.dup
+      c.atk_states = atk_states_of(a)
       c
     end
 
@@ -8825,12 +8888,24 @@ module Game
       cap = damage_cap
       dmg = cap if dmg > cap
       target.hp -= dmg
-      woke = target.dead? ? [] : shake_off_states(target)
+      if target.dead?
+        woke = []
+        inflicted = []
+        cured = []
+      else
+        woke = shake_off_states(target)
+        # A weapon's own state_set/state_chance (二刀流 or otherwise) --
+        # EasyRPG's Normal::vExecute weapon block, skipped like the rest of
+        # this section once the blow already felled the target.
+        inflicted, cured = roll_weapon_states(b, target)
+      end
       entry = { attacker: b.name, target: target.name, damage: dmg, critical: crit,
                 charged: charged, target_hp: target.hp < 0 ? 0 : target.hp,
                 defeated: target.dead?, target_ally: ally?(target),
                 attack_animation_id: anim, target_index: target_index }
       entry[:woke] = woke unless woke.empty?
+      entry[:inflicted] = inflicted unless inflicted.empty?
+      entry[:cured] = cured unless cured.empty?
       entry
     end
 
@@ -9347,6 +9422,41 @@ module Game
         inflicted << sid
       end
       [inflicted, already]
+    end
+
+    # A basic Attack's own weapon-granted states (`b.atk_states`, see
+    # Game::Actor#weapon_states), rolled the same way #roll_inflict rolls a
+    # skill's: each inflict-side state scaled by the target's own
+    # susceptibility, each heal-side state (RPG2003's `reverse_state_effect`
+    # weapons only) an unscaled roll against the weapon's own chance --
+    # EasyRPG's weapon block never calls `GetStateProbability` for the heal
+    # side, only the inflict side.
+    #
+    # Unlike a skill (#roll_inflict's `already`), a weapon that flags a state
+    # the target already carries does **nothing** and reports nothing --
+    # EasyRPG's own comment: "Unlike skills, weapons do not try to reinflict
+    # states already present." No `already` list here for that reason.
+    #
+    # Returns `[inflicted, healed]`.
+    def roll_weapon_states(b, target)
+      states = b.respond_to?(:atk_states) ? b.atk_states : nil
+      return [[], []] unless states
+      inflicted = []
+      (states[:inflict] || {}).each do |sid, chance|
+        next if target.state?(sid)
+        prob = chance * state_susceptibility(target, sid) / 100
+        next unless @rng.random(100) < prob
+        target.states = Game::States.prune((target.states || []) + [sid], @states)
+        inflicted << sid
+      end
+      healed = []
+      (states[:heal] || {}).each do |sid, chance|
+        next unless target.state?(sid)
+        next unless @rng.random(100) < chance
+        target.states = (target.states || []) - [sid]
+        healed << sid
+      end
+      [inflicted, healed]
     end
   end
 

--- a/scripts/rpg2k_field_audit.rb
+++ b/scripts/rpg2k_field_audit.rb
@@ -57,8 +57,6 @@ NOT_OURS = {
   levitate: 'RPG2003 only — EasyRPG\'s Game_Enemy::GetFlyingOffset returns 0 ' \
             'outside 2k3: "2k does not support flying, albeit mentioned in ' \
             'the help file"',
-  state_chance: 'RPG2003 only — an RPG2000 item cures its state_set ' \
-                'unconditionally (see Party#item_cured_states)',
   message_affected: 'no known trigger — EasyRPG defines ' \
                     'GetStateAffectedMessage and never calls it from either ' \
                     'battle scene, so nothing pins when RPG_RT prints it',
@@ -80,10 +78,19 @@ NOT_OURS = {
 # single most common reason a high-ranked row turns out not to be work.
 #
 # It is a filter, not a proof, in either direction. An RPG2000 editor still
-# writes fields RPG_RT ignores — `levitate` and `state_chance` in NOT_OURS above
-# are both set by Nepheshel and both 2k3-only — so an unmarked field can still be
+# writes fields RPG_RT ignores — `levitate` in NOT_OURS above is set by
+# Nepheshel despite being 2k3-only — so an unmarked field can still be
 # 2k3-only, and a marked one can still be a real RPG2000 feature the 2000 test
 # bed simply never used.
+#
+# `state_chance` used to sit in NOT_OURS on the same "2k3-only" reasoning,
+# checked only against Item::vExecute's *medicine* branch (which really does
+# ignore it, unconditionally, on both editions). It was never checked against
+# Normal::vExecute's *weapon* branch, which reads a weapon's own state_chance
+# unconditionally on both editions — and Nepheshel (RPG2000) sets it on
+# several real weapons (e.g. item #30, アサシンダガー). Now that
+# Game::Actor#weapon_states reads it, this substring search finds the field on
+# its own and the entry is gone rather than stale.
 def maker_of(db)
   v = db[22] && db[22].maker_version
   v == 2003 ? :rpg2k3 : :rpg2k
@@ -195,7 +202,7 @@ if mixed
               'RPG2000 one does — check whether RPG_RT reads it on RPG2000 at', n)
   puts '   all before building it. A filter, not a proof, in either direction:'
   puts '   an RPG2000 editor still writes fields RPG_RT ignores, so a field both'
-  puts '   makers set can be 2k3-only too (levitate and state_chance below are).'
+  puts '   makers set can be 2k3-only too (levitate below is).'
 end
 
 unless known.empty?

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2962,9 +2962,13 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :raise_evasion,
                       # アニメーション (weapon field 20): the battle animation a
                       # basic Attack plays with this weapon equipped
-                      # (Actor#attack_animation_id). Appended last, same
+                      # (Actor#attack_animation_id).
+                      :animation_id,
+                      # ステート発生率 (weapon field 67): the flat percent chance
+                      # applied to every state `state_set` flags on a basic
+                      # Attack (Game::Actor#weapon_states). Appended last, same
                       # positional-safety reasoning as every field above.
-                      :animation_id)
+                      :state_chance)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -2973,14 +2977,15 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               field_only: false, dual_attack: false, ignore_evasion: false,
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
-              cursed: false, raise_evasion: false, animation_id: nil)
+              cursed: false, raise_evasion: false, animation_id: nil,
+              state_chance: 0)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
-               raise_evasion, animation_id)
+               raise_evasion, animation_id, state_chance)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -8460,6 +8465,63 @@ check 'Actor weapon/attribute readers feed the combatant snapshot' do
   a.equip([7, 0, 0, 0, 0])
   eq [1, 3], a.weapon_attributes
   eq [1, 3], Game::Battle.from_actor(a).atk_attrs, 'carried onto the combatant'
+end
+
+check "battle: a basic Attack rolls its weapon's own state-infliction chance" do
+  # A "Poison Dagger" -- state_set flags state 3, state_chance 100 -- ported
+  # from EasyRPG's Game_BattleAlgorithm::Normal::vExecute weapon block, which
+  # this codebase previously left entirely unbuilt: only Skills/Items rolled
+  # state infliction, never a plain Attack.
+  items = { 7 => fake_item(type: 1, atk: 10, state_set: [0, 0, 1], state_chance: 100) }
+  st = skill_party({}, items)
+  a = st.party.actor_by_id(1)
+  a.equip([7, 0, 0, 0, 0])
+  hero = Game::Battle.from_actor(a)
+  eq({ 3 => 100 }, hero.atk_states[:inflict], 'carried onto the combatant')
+  foe = combatant('Foe', 0, 0, 5, 999)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), { 3 => fake_state })
+  entry = bat.send(:deal_attack, hero, foe)
+  eq [3], entry[:inflicted], "the weapon's own state landed alongside the damage"
+  ok foe.state?(3), 'the state is actually on the target, not just reported'
+end
+
+check "battle: an RPG2003 weapon's reverse_state_effect heals instead of inflicts" do
+  # Same weapon, `reverse_state_effect` set: on RPG2003 this flips the weapon
+  # from inflicting its named states to curing them (EasyRPG's
+  # `is2k3 && w->reverse_state_effect` branch) -- the same flip
+  # `#item_inflicted_states`/`#skill_state_ids` already model for items/skills.
+  items = { 7 => fake_item(type: 1, atk: 10, state_set: [0, 0, 1],
+                            state_chance: 100, reverse_state: true) }
+  st = skill_party({}, items, rpg2003: true)
+  a = st.party.actor_by_id(1)
+  a.equip([7, 0, 0, 0, 0])
+  hero = Game::Battle.from_actor(a)
+  eq({ 3 => 100 }, hero.atk_states[:heal], 'carried onto the combatant, on the heal side')
+  foe = combatant('Foe', 0, 0, 5, 999)
+  foe.states = [3] # already afflicted, for the weapon to lift
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), { 3 => fake_state })
+  entry = bat.send(:deal_attack, hero, foe)
+  eq [3], entry[:cured], "the RPG2003 weapon healed its own state instead of inflicting it"
+  ok !foe.state?(3)
+end
+
+check "battle: on RPG2000, a weapon's reverse_state_effect has no effect -- it still inflicts" do
+  # The exact same weapon/scenario as the RPG2003 heal check above, but on an
+  # RPG2000 database: `reverse_state_effect` only flips a weapon's polarity on
+  # RPG2003 (EasyRPG's `is2k3 &&` guard), so the state still inflicts here.
+  items = { 7 => fake_item(type: 1, atk: 10, state_set: [0, 0, 1],
+                            state_chance: 100, reverse_state: true) }
+  st = skill_party({}, items) # rpg2003 defaults to false
+  a = st.party.actor_by_id(1)
+  a.equip([7, 0, 0, 0, 0])
+  hero = Game::Battle.from_actor(a)
+  eq({ 3 => 100 }, hero.atk_states[:inflict],
+     'the flag is ignored on RPG2000 -- the state stays on the inflict side')
+  foe = combatant('Foe', 0, 0, 5, 999)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), { 3 => fake_state })
+  entry = bat.send(:deal_attack, hero, foe)
+  eq [3], entry[:inflicted]
+  ok foe.state?(3)
 end
 
 check 'Game::Enemy reads its per-attribute defence ranks' do


### PR DESCRIPTION
## Summary
- Only Skills and Items ever rolled state infliction; a weapon's own `state_set`/`state_chance` fields (item fields 63/64/67) were never read at all, so a "Poison Dagger"-style weapon could never actually poison anything on a plain swing.
- Several of Nepheshel's real weapons (confirmed RPG2000 data — no `maker_version` chunk) set these fields, e.g. item #30, an "Assassin Dagger" with `state_chance` 75.
- Ports EasyRPG's `Game_BattleAlgorithm::Normal::vExecute` weapon block: each state a weapon's `state_set` flags rolls against its own `state_chance`, scaled by the target's susceptibility (`Game::Battle#state_susceptibility`, already shared with skill infliction). A dual-wielding actor's second weapon can flag a different state, or the same state at a different chance — the higher chance wins. RPG2003's `reverse_state_effect` flips a weapon's own states from inflicting to curing, but only on RPG2003 — the flag has no effect here on RPG2000.
- Adds `Game::Actor#weapon_states` (mirrors `#weapon_attributes`), carried onto the Combatant snapshot as `atk_states`, and `Game::Battle#roll_weapon_states`, applied from `#deal_attack` once the target has survived the hit.
- `docs/TODO.md`'s own field-audit note previously claimed `state_chance` was RPG2003-only, checked only against the item-cure code path (which really does ignore it unconditionally, both editions) and never against the weapon-attack path. Corrected `scripts/rpg2k_field_audit.rb`'s `NOT_OURS` table and its `docs/TODO.md` reference accordingly.

## Test plan
- [x] Three new `scripts/rpg2k_logic_check.rb` checks: a plain RPG2000 weapon inflicting its state, an RPG2003 `reverse_state_effect` weapon healing one instead, and the same weapon on RPG2000 still inflicting since the flag is edition-gated — each confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_field_audit.rb` — output confirmed clean after the `NOT_OURS` correction
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_