### PR TITLE
Report a stale (database-shrunk) terrain id instead of swallowing it

### DIFF
--- a/changelog.d/terrain-missing-id-diagnostic.fixed.md
+++ b/changelog.d/terrain-missing-id-diagnostic.fixed.md
@@ -1,0 +1,15 @@
+- **A stale terrain id (a database shrink leaving a chipset cell pointing at a
+  terrain row that no longer exists) now logs a diagnostic instead of
+  silently falling back to defaults with no trace.** `Scene::Map
+  #terrain_row_at` (`mruby-rpg2k/mrblib/scene/map.rb`) used to swallow the
+  gap with a bare `rescue StandardError; nil`; it now logs a
+  `[RPG2k] Terrain: tile (x, y) references terrain #<id>, which no longer
+  exists in the database` diagnostic the first time the stale id is actually
+  looked up, matching real RPG_RT's own deferred-until-exercised behaviour
+  (it only errors once the player steps onto the specific stale tile, not
+  proactively at load time). Deduped per stale tile for the visit so a party
+  standing on the tile, or its several per-frame callers (encounter rate,
+  terrain damage, bush depth, vehicle passability), don't spam the log.
+  Behaviour is otherwise unchanged: the lookup still returns `nil` and every
+  caller still falls back to its existing default. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8388,15 +8388,15 @@ event-id-existence and page-existence as two distinct checks); invalid
 map (Transfer Player / Teleport-to-Remembered-Location targeting a
 nonexistent map id — error text includes the literal missing filename;
 fixed, see the ✅ below);
-invalid hero, skill, item, enemy, enemy group, battle animation, terrain,
-chipset, common event (all: a database shrink leaves a dangling id
-reference somewhere, shown as "?" in the editor); event-call recursion
-past 1000. Several of these errors are **deferred** until the stale
-reference is actually exercised at runtime rather than raised at load
-time — e.g. invalid terrain only errors when the player steps onto the
-specific stale tile, invalid battle animation only when it would actually
-display, invalid skill only when a skill-select screen opens (or, if the
-dangling ref is in a hero's learned-skill list, at the moment of
+invalid hero, skill, item, enemy, enemy group, battle animation, terrain
+(fixed, see the ✅ below), chipset, common event (all: a database shrink
+leaves a dangling id reference somewhere, shown as "?" in the editor);
+event-call recursion past 1000. Several of these errors are **deferred**
+until the stale reference is actually exercised at runtime rather than
+raised at load time — e.g. invalid terrain only errors when the player
+steps onto the specific stale tile, invalid battle animation only when it
+would actually display, invalid skill only when a skill-select screen opens
+(or, if the dangling ref is in a hero's learned-skill list, at the moment of
 level-up).
 ✅ **Call Event no longer swallows three of the four "invalid event ID"
 causes above, plus the separate "invalid event page" case** — this codebase
@@ -8480,6 +8480,33 @@ new `scripts/rpg2k_scene_check.rb` checks, each targeting a `FakeParent`
 whose `load_map` raises `Errno::ENOENT` for one specific id and asserting
 the `$stderr` diagnostic fires while `state.map_id`/`state.x`/`state.y`
 stay exactly as they were before the failed command ran.
+✅ **Invalid terrain (a chipset cell whose terrain id a database shrink has
+removed) no longer swallows the gap with a bare `rescue StandardError; nil`**
+— `Scene::Map#terrain_row_at` (`mruby-rpg2k/mrblib/scene/map.rb`), the single
+choke point every terrain lookup goes through (encounter rate, terrain
+damage, bush depth, and boat/ship/airship passability and landing), now
+distinguishes a genuinely terrain-less map/chipset (still silent, exactly as
+before) from a chipset cell whose resolved terrain id has no row in the
+database, and logs a `[RPG2k] Terrain: tile (x, y) references terrain #<id>,
+which no longer exists in the database` diagnostic for the second case. This
+already matches the "deferred until exercised" framing above for free:
+every one of `#terrain_row_at`'s callers only ever asks about a tile
+someone (the party, an event, a vehicle) currently occupies, never
+proactively scanning the whole map, so the diagnostic naturally fires only
+once the player (or a vehicle) actually steps onto the specific stale tile.
+Deduped per stale tile for the visit (a new `@warned_stale_terrain` table,
+reset alongside the other per-visit event tables on a fresh map load or
+teleport) rather than per lookup or per frame — several callers re-ask
+about the tile the party is currently standing on every single frame, and
+logging each of those would spam the console solid for a party that simply
+stands there. Behaviour is otherwise unchanged: the lookup still returns
+`nil` and every caller still falls back to whatever default it already used.
+Covered by a new `scripts/rpg2k_scene_check.rb` check that deletes a
+fixture's only terrain row out from under its chipset, walks the party onto
+the now-dangling tile, and asserts the diagnostic fires exactly once (not
+once per the two call sites that both read the same landed-on tile in a
+single step, and not again on further re-queries of the same tile) while
+terrain damage/bush depth both fall back to their harmless defaults.
 
 **Map/Event ID assignment & tile occupancy**
 - ✅ **Not applicable: Event ID (and, separately, Map ID) assignment by

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -151,6 +151,9 @@ class RPG2k
         # id, so an event whose *very first* selected page fails its
         # conditions still has a position to answer from. See #event_id_at.
         @event_last_position = {}
+        # Tiles #warn_stale_terrain has already reported this visit -- see
+        # #terrain_row_at.
+        @warned_stale_terrain = {}
         @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver
@@ -2205,12 +2208,39 @@ class RPG2k
       public :vehicle_char_can_land?
 
       # The database terrain row under tile (x, y), or nil when the chipset / map
-      # carry no terrain data (e.g. the colour-block fallback or a bare fixture).
+      # carry no terrain data (e.g. the colour-block fallback or a bare fixture)
+      # -- or when the chipset cell at (x, y) points at a terrain id a database
+      # shrink has since removed. Real RPG_RT only surfaces that second case
+      # once the player actually steps onto the specific stale tile rather than
+      # proactively at load time (docs/TODO.md's runtime error catalog), which
+      # this already matches for free: every caller only ever asks about a tile
+      # someone (the party, an event, a vehicle) currently occupies. See
+      # #warn_stale_terrain for the "log once, not once per frame" diagnostic.
       def terrain_row_at(x, y)
         return nil if @chipset.nil? || !@db.respond_to?(:terrain) || @db.terrain.nil?
-        @db.terrain[@chipset.terrain(@map.lower(x, y))]
-      rescue StandardError
+        tid = @chipset.terrain(@map.lower(x, y))
+        row = @db.terrain[tid]
+        warn_stale_terrain(x, y, tid) if row.nil?
+        row
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Terrain: lookup failed at (#{x}, #{y}): #{e.message}"
         nil
+      end
+
+      # #terrain_row_at's diagnostic for a chipset cell whose terrain id has no
+      # database row -- a database shrink leaving a dangling reference behind,
+      # not the ordinary "no terrain table at all" case #terrain_row_at already
+      # returns nil for silently. Deduped per stale tile (`@warned_stale_terrain`,
+      # reset per map visit alongside @erased_event_positions /
+      # @event_last_position above) rather than per lookup: several callers
+      # (encounter rate, bush depth, vehicle passability) ask about the tile the
+      # party is standing on every single frame, and logging each of those would
+      # spam the console solid for a party that simply stands still on it.
+      def warn_stale_terrain(x, y, tid)
+        return if @warned_stale_terrain[[x, y]]
+        @warned_stale_terrain[[x, y]] = true
+        $stderr.puts "[RPG2k] Terrain: tile (#{x}, #{y}) references terrain " \
+                     "##{tid}, which no longer exists in the database"
       end
 
       # Advance autonomous / custom-route event movement one frame. Skipped
@@ -7664,6 +7694,10 @@ class RPG2k
         # left happened to be.
         @state.map_event_positions = {}
         @state.map_event_route_index = {}
+        # Tiles #warn_stale_terrain has already reported are per-visit too, same
+        # reasoning as the tables above -- a stale reference on the map being
+        # left says nothing about the destination.
+        @warned_stale_terrain = {}
         @page_revision = page_revision
         build_events
         @interpreter.resolver = build_resolver

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12777,6 +12777,41 @@ check 'a hero over the tile rather than in it does not sink' do
   eq 0, scene.send(:player_bush_depth), 'mid-jump, over the grass'
 end
 
+# -- stale terrain id (database shrink) ---------------------------------------
+
+check 'stepping onto a chipset cell whose terrain id has no row logs once, ' \
+      'not per frame, and falls back to defaults' do
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero], terrain_damage: 5, bush_depth: 3)
+  # Simulate a database shrink: every tile of the fixture map's chip 0 is
+  # tagged terrain 42 (see fake_chipset), but the row itself is now gone, the
+  # same "chipset cell still points at an id the database no longer has"
+  # dangling reference docs/TODO.md's runtime error catalog describes.
+  scene.db.terrain.delete(42)
+
+  # One step lands on (1, 0). Both #note_party_step (terrain damage) and
+  # #check_random_encounter (encounter rate) look the same tile's terrain row
+  # up in that single landing frame -- two call sites hitting the one stale
+  # tile -- so this alone already exercises the "log once" dedup, not just
+  # the "not every frame while stationary" half of it.
+  out = capture_stderr { walk(scene, 1) }
+  eq 1, out.scan('[RPG2k] Terrain:').size,
+     "expected exactly one diagnostic for the one stale tile, got: #{out.inspect}"
+  ok out.include?('[RPG2k] Terrain: tile (1, 0) references terrain #42, ' \
+                   'which no longer exists in the database'), out
+  eq 100, hero.hp, 'no row resolves -> no terrain damage, the default fallback'
+
+  # Querying the very same tile again (from any of #terrain_row_at's other
+  # callers, and however many more frames pass while the party simply stands
+  # there) must not add a second line.
+  out2 = capture_stderr do
+    3.times { scene.send(:terrain_row_at, 1, 0) }
+    scene.send(:bush_depth_at, 1, 0)
+  end
+  ok out2.empty?, "re-querying the already-warned tile must stay silent, got: #{out2.inspect}"
+  eq 0, scene.send(:bush_depth_at, 1, 0), 'no row resolves -> bush depth falls back to 0'
+end
+
 check 'a boarded party draws its vehicle, so the hero does not sink' do
   scene = new_scene({}, player: [1, 1], bush_depth: 3)
   st = scene.instance_variable_get(:@state)


### PR DESCRIPTION
## Summary

- `Scene::Map#terrain_row_at` (`mruby-rpg2k/mrblib/scene/map.rb`) — the single choke point every terrain lookup goes through (encounter rate, terrain damage, bush depth, boat/ship/airship passability and landing) — used to absorb any lookup failure with a bare `rescue StandardError; nil`. A database shrink that removes the row a chipset cell's terrain id still points at fell back to every caller's default with no trace anything was wrong.
- It now distinguishes that case (a resolved terrain id with no matching database row) from the genuinely terrain-less map/chipset case (still silent, unchanged) and logs `[RPG2k] Terrain: tile (x, y) references terrain #<id>, which no longer exists in the database` the first time the stale id is actually looked up — matching real RPG_RT's own "deferred until exercised" behaviour for free, since every caller only ever asks about a tile someone (party/event/vehicle) currently occupies, never proactively scanning the whole map.
- Deduped per stale tile for the visit via a new `@warned_stale_terrain` table (reset alongside the other per-visit event tables on map load/teleport, same pattern as `@erased_event_positions`/`@event_last_position`) — several callers re-ask about the tile the party is standing on every frame, and logging each of those would spam the console solid for a stationary party. No existing "log once" helper precedent was found elsewhere in the codebase, so this follows the shape of those existing per-visit tables instead.
- Behaviour is otherwise unchanged: the lookup still returns `nil` and every caller still falls back to whatever default it already used.
- `docs/TODO.md`'s runtime error catalog entry for "invalid terrain" is marked ✅ fixed, matching the style of the neighboring Call Event / Enemy Encounter / Transfer Player entries.
- New `changelog.d/terrain-missing-id-diagnostic.fixed.md` fragment.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: deletes a fixture's only terrain row out from under its chipset, walks the party onto the now-dangling tile, and asserts the diagnostic fires exactly once — not once per the two call sites (`terrain_step_damage`/`check_random_encounter`) that both read the same landed-on tile in a single step, and not again on further re-queries of the same tile — while terrain damage and bush depth both fall back to their harmless defaults.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 559 checks passed (558 before this change).
- [x] `ruby scripts/rpg2k_logic_check.rb` — 818 checks passed, unaffected.
- [x] `pre-commit run` (trailing-whitespace / end-of-file-fixer; nixfmt/clang-format/cmake-format have no matching files in this diff) — passed.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017UWBLRYJEi77xfJjcGJ7ih)_