### PR TITLE
Report a dangling chipset id instead of silently degrading

### DIFF
--- a/changelog.d/chipset-missing-id-diagnostic.fixed.md
+++ b/changelog.d/chipset-missing-id-diagnostic.fixed.md
@@ -1,0 +1,14 @@
+- **A dangling chipset id now logs a diagnostic instead of silently
+  rendering a map blank and fully passable.** `Game::ChipSet#initialize`
+  (`mruby-rpg2k/mrblib/game.rb`) already degraded every field (name, graphic,
+  passability tables, terrain data, animation params) to a safe blank/nil
+  default when `db.chipset[id]` missed — matching the same graceful-degrade
+  philosophy `Game::Party#db_enemy_group`/`Game::Enemy` use — but nothing
+  ever reported the gap, so a map with a stale `chipset_id` (or a Change Map
+  Tileset override to a bad id) rendered with zero diagnostic trace. It now
+  logs a `[RPG2k] chipset #<id> not found in database, tiles treated as
+  blank/passable` message, `respond_to?`-guarded the same way
+  `db_item`/`db_enemy_group` are so a bare test fixture with no chipset
+  table at all stays quiet. The degrade behaviour itself is unchanged; this
+  is diagnostics only. Covered by a new `scripts/rpg2k_logic_check.rb`
+  check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8549,6 +8549,28 @@ position to report. All four log a `[RPG2k] Control Variables: ...`
 diagnostic and still resolve to `0` — behaviour is unchanged, only the
 gap is now visible. Covered by four new `scripts/rpg2k_logic_check.rb`
 checks, each asserting on the captured `$stderr` line.
+✅ **A dangling chipset id no longer renders a map blank and fully passable
+with no trace** — the "chipset" case from the "invalid hero, skill, item,
+enemy, enemy group, battle animation, terrain, chipset, common event" list
+above. `Game::ChipSet#initialize` (`mruby-rpg2k/mrblib/game.rb`) already
+tolerated a missing `db.chipset[id]` row by degrading every field (name,
+graphic, passability tables, terrain data, animation params) to a safe
+blank/nil default — matching the same graceful-degrade philosophy
+`Game::Party#db_enemy_group`/`Game::Enemy` use — but nothing ever logged the
+gap, so a map with a stale `chipset_id` (or a Change Map Tileset override to
+a bad id; `Scene::Map#build_chipset`, `mruby-rpg2k/mrblib/scene/map.rb`,
+only rescues real exceptions like a missing graphic file) rendered blank
+tiles with every direction passable and no diagnostic anywhere. `ChipSet
+#initialize` now checks the lookup itself, `respond_to?`-guarded the same
+way `db_item`/`db_enemy_group` are so a bare test fixture with no chipset
+table at all stays quiet, and logs a `[RPG2k] chipset #<id> not found in
+database, tiles treated as blank/passable` diagnostic when `id` is a
+positive, resolvable-looking reference that simply misses; the degrade
+behaviour itself is unchanged, this is diagnostics only. Covered by a new
+`scripts/rpg2k_logic_check.rb` check asserting the captured `$stderr` line
+alongside the unchanged blank name/graphic and default-passable/terrain
+behaviour, plus that an existing id, id `0`, a `nil` id and a chipset-less
+bare fixture all stay silent.
 
 **Map/Event ID assignment & tile occupancy**
 - ✅ **Not applicable: Event ID (and, separately, Map ID) assignment by

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -551,8 +551,21 @@ module Game
 
     attr_reader :name, :graphic, :animation_type, :animation_speed
 
+    # `id` a dangling reference (a database shrink, or a bad Change Map
+    # Tileset override, can leave one behind -- see docs/TODO.md's runtime
+    # error catalog) still degrades to a blank name/graphic and nil
+    # passability/terrain tables, same as it always has, but is now reported
+    # rather than silently rendering the map blank and fully passable with no
+    # trace. `has_table` guards the diagnostic the same way `db_item` /
+    # `db_enemy_group` do, so a bare test fixture with no chipset table at all
+    # (rather than a real dangling id) stays quiet.
     def initialize(db, id)
-      c = db.chipset[id]
+      has_table = db.respond_to?(:chipset)
+      c = has_table ? db.chipset[id] : nil
+      if c.nil? && has_table && id && id > 0
+        $stderr.puts "[RPG2k] chipset ##{id} not found in database, " \
+                     'tiles treated as blank/passable'
+      end
       @name = c ? c.name : ''
       @graphic = c ? c.chipset_name : ''
       @passable_lower = c ? c.passable_data_lower : nil

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13804,6 +13804,30 @@ check 'elevated? reads ABOVE_BIT off the upper passability table' do
      'a chipset with no upper table at all is never starred'
 end
 
+# A dangling chipset id (a database shrink, or a bad Change Map Tileset
+# override) reports and degrades to the same blank/passable model as before,
+# rather than rendering the map blank and fully passable with no trace.
+check 'a dangling chipset id reports and degrades to a blank/passable chipset' do
+  db = Struct.new(:chipset).new({ 1 => FakeChipsetRow.new('cs', 'cs.png', [1], [2], [3], 1, 1) })
+  out = capture_stderr { @cs = Game::ChipSet.new(db, 99) }
+  ok out.include?('[RPG2k] chipset #99 not found in database'), out
+
+  eq '', @cs.name
+  eq '', @cs.graphic
+  ok !@cs.elevated?(BLOCK_F), 'no upper passability table -- never starred'
+  ok @cs.passable?(0, 2), 'no passability table -- everything degrades to passable'
+  ok @cs.landable?(0), 'no passability table -- everything degrades to landable'
+  eq 1, @cs.terrain(0), 'no terrain table -- reads the default terrain 1'
+
+  ok capture_stderr { Game::ChipSet.new(db, 1) }.empty?, 'an existing chipset id logs nothing'
+  ok capture_stderr { Game::ChipSet.new(db, 0) }.empty?, 'id 0 (no chipset) is not a dangling reference'
+  ok capture_stderr { Game::ChipSet.new(db, nil) }.empty?, 'a nil id is not a dangling reference'
+
+  bare_db = Struct.new(:name).new('bare fixture, no chipset table at all')
+  ok capture_stderr { Game::ChipSet.new(bare_db, 99) }.empty?,
+     'a bare fixture with no chipset table at all is not a dangling reference'
+end
+
 # -- summary ------------------------------------------------------------------
 
 if $failures.zero?


### PR DESCRIPTION
## Summary
- `Game::ChipSet#initialize` (`mruby-rpg2k/mrblib/game.rb`) already tolerated a dangling `chipset_id` by degrading name/graphic/passability/terrain to a blank/nil default, but nothing ever logged the gap — a map with a stale chipset id (or a bad Change Map Tileset override) rendered blank and fully passable with zero diagnostic trace.
- Add a `[RPG2k] chipset #<id> not found in database, tiles treated as blank/passable` diagnostic, `respond_to?`-guarded the same way `db_item`/`db_enemy_group` are so a bare test fixture with no chipset table at all stays quiet. Degrade behavior is unchanged — diagnostics only.
- Marks the "chipset" case in docs/TODO.md's runtime error catalog as ✅, matching the neighboring Call Event / Enemy Encounter / Transfer Player / Control Variables / Field Skill menu entries.

## Test plan
- [x] `ruby scripts/rpg2k_logic_check.rb` — 827 checks passed (new check: "a dangling chipset id reports and degrades to a blank/passable chipset")
- [x] `ruby scripts/rpg2k_scene_check.rb` — 558 checks passed
- [x] `ruby -c` syntax check on touched Ruby files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D1WYRWhVeWQoc7uFj9PfS3)_