### PR TITLE
Report a dangling individual enemy id, not silently invented

### DIFF
--- a/changelog.d/enemy-missing-individual-id.fixed.md
+++ b/changelog.d/enemy-missing-individual-id.fixed.md
@@ -1,0 +1,9 @@
+- **A troop member naming a deleted individual enemy id no longer degrades
+  silently** — a database shrink can leave one behind, shown as "?" in the
+  editor, distinct from the enemy-*group*/troop id case fixed separately.
+  `Game::Enemy#initialize` (`mruby-rpg2k/mrblib/game.rb`) already tolerated a
+  missing `enemy` row by degrading to a blank/1-HP model; it now also logs a
+  `[RPG2k] Enemy: enemy id <id> not found in the database, degrading to a
+  blank placeholder` diagnostic instead of doing so with no trace. The
+  degrade behaviour itself is unchanged — this is diagnostics only. Covered
+  by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8487,6 +8487,25 @@ five new `scripts/rpg2k_logic_check.rb` checks (no handlers, an [Escape]
 handler, escape-abort mode, and the random-encounter path both missing and
 present), each asserting on the captured `$stderr` line and that no
 `:battle` wait was ever armed.
+✅ **A troop member naming a deleted *individual* enemy id (chunk 14) no
+longer degrades silently** — the "invalid enemy" case above, distinct from
+the enemy-*group*/troop case fixed just above: there the whole troop id was
+dangling, here the troop itself resolves fine but one of its members points
+at an enemy id the database no longer has. `Game::Enemy#initialize`
+(`mruby-rpg2k/mrblib/game.rb`) already tolerated a missing `enemy` row by
+degrading every field to a safe default (blank name, 1 max HP, 0 stats — see
+the "missing troop / enemy degrades to an empty, harmless model" check), and
+that degrade behaviour is unchanged; it now also logs a `[RPG2k] Enemy:
+enemy id <id> not found in the database, degrading to a blank placeholder`
+diagnostic whenever `id` is truthy/positive but the lookup misses, guarded by
+the same `respond_to?(:enemy)` check `db_item`/`db_enemy_group` use so a bare
+test fixture with no `enemy` table at all stays silent. Placed in the
+constructor itself (rather than `Troop#member`, its one production call
+site) so every construction path is covered, present and future. Covered by
+a new `scripts/rpg2k_logic_check.rb` check asserting the diagnostic fires
+both for a direct `Game::Enemy.new` call and for one reached through a real
+troop member, and that the degrade-to-harmless-model behaviour (1 HP, blank
+name) is unchanged in both cases.
 ✅ **The field skill menu no longer drops a dangling learned-skill id with no
 trace** — one of the "invalid skill" cases above, the "opens a skill-select
 screen" variant. `Game::Party#field_skills` (`mruby-rpg2k/mrblib/game.rb`)

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6436,6 +6436,19 @@ module Game
 
     def initialize(db, id, x = 0, y = 0, hidden = false)
       row = db.enemy[id]
+      # A database shrink can leave a troop member naming a deleted individual
+      # enemy id (chunk 14) -- shown as "?" in the editor, docs/TODO.md's
+      # runtime error catalog, distinct from the enemy-*group* (troop) id case
+      # `Game::Party#db_enemy_group`/Enemy Encounter already reports. Degrading
+      # to a blank/1-HP model below is unchanged (by design, matching real
+      # RPG_RT's own tolerance); only the gap is now visible. `respond_to?`
+      # guarded the same way `db_item`/`db_enemy_group` reach into `@db`, so a
+      # bare test fixture with no `enemy` table at all stays silent -- this is
+      # only for a genuine dangling id in a real database.
+      if row.nil? && id && id > 0 && db.respond_to?(:enemy)
+        $stderr.puts "[RPG2k] Enemy: enemy id #{id} not found in the " \
+                     'database, degrading to a blank placeholder'
+      end
       @id = id
       @name    = row ? row.name.to_s : ''
       # The Monster/<name> battle graphic (blank for a fixture that omits it);

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7754,6 +7754,30 @@ check 'a missing troop / enemy degrades to an empty, harmless model' do
   eq 1, Game::Enemy.new(battle_db, 99).max_hp, 'defaults for a missing enemy'
 end
 
+# A database shrink can leave a troop member naming a deleted *individual*
+# enemy id (chunk 14) -- shown as "?" in the editor, docs/TODO.md's runtime
+# error catalog. This is distinct from the enemy-*group* (troop) id case
+# `Game::Party#db_enemy_group`/Enemy Encounter already reports: here the troop
+# itself resolves fine, but one of its members points at a dangling enemy id.
+# `Game::Enemy.new` already tolerated this by degrading to a blank/1-HP model
+# (see the check above); it now also reports the gap.
+check 'a dangling individual enemy id reports and still degrades to the harmless model' do
+  e = nil
+  out = capture_stderr { e = Game::Enemy.new(battle_db, 99) }
+  ok out.include?('[RPG2k] Enemy: enemy id 99 not found in the database'), out
+  eq 1, e.max_hp, 'degrade behaviour is unchanged -- still a blank 1-HP model'
+  eq '', e.name
+
+  # Reached through a real troop member, not just a direct Game::Enemy.new call.
+  broken_group = { 1 => GroupRow.new('Broken', { 1 => GroupMember.new(99, 5, 5, false) }) }
+  db = BattleDB.new(battle_db.enemy, broken_group)
+  troop = nil
+  out2 = capture_stderr { troop = Game::Troop.new(db, 1) }
+  ok out2.include?('[RPG2k] Enemy: enemy id 99 not found in the database'), out2
+  eq 1, troop.members.size
+  eq 1, troop.members.first.max_hp, 'the dangling member still degrades harmlessly'
+end
+
 check 'Enemy Encounter parses the troop and modes and suspends on :battle' do
   st = party_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary

- Extends the runtime error catalog's "reported gap, not silently invented" diagnostic pattern to `Game::Enemy`. A troop member naming a deleted individual enemy id (database chunk 14) previously degraded silently to a blank 1-HP monster with no trace anywhere — distinct from the enemy-*group*/troop id case already fixed by `Game::Party#db_enemy_group`/Enemy Encounter (#778), which is about the whole troop id, not one member's enemy-type id within it.
- `Game::Enemy#initialize` (`mruby-rpg2k/mrblib/game.rb`) now logs a `[RPG2k] Enemy: enemy id <id> not found in the database, degrading to a blank placeholder` diagnostic whenever the constructor's `id` is truthy/positive but the database lookup misses, guarded by the same `respond_to?(:enemy)` check `db_item`/`db_enemy_group` use so a bare test fixture with no `enemy` table at all stays silent. Placed in the constructor itself (rather than `Troop#member`, its one production call site) so every construction path is covered.
- Degrade behaviour is unchanged — this is diagnostics only.
- Updated `docs/TODO.md`'s runtime error catalog to mark this case ✅, matching the style of the neighboring already-fixed entries.
- Added a `changelog.d/enemy-missing-individual-id.fixed.md` fragment.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` check asserting the diagnostic fires both for a direct `Game::Enemy.new` call and for one reached through a real troop member, and that the degrade-to-harmless-model behaviour (1 HP, blank name) is unchanged in both cases.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 827 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 558 checks passed.
- [x] `pre-commit run` on touched files (trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files; nixfmt skipped, no `.nix` files touched).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UcGhnSw1BVJoAdy1RaHnZY)_