### PR TITLE
Fix two bugs in the basic-attack to-hit formula

### DIFF
--- a/changelog.d/rpg2k-basic-attack-to-hit-fixes.fixed.md
+++ b/changelog.d/rpg2k-basic-attack-to-hit-fixes.fixed.md
@@ -1,0 +1,10 @@
+- **A basic Attack's to-hit chance is now correct in two ways it wasn't
+  before.** A "do nothing"-restricted target (asleep / paralysed) now always
+  gets hit, instead of still rolling the ordinary hit-rate/agility math — a
+  restricted target was RPG_RT's one guaranteed landing, and this codebase
+  never implemented that rule at all. Separately, a state's `reduce_hit_ratio`
+  (Blind and friends) now scales the attacker's base hit rate *before* the
+  agility adjustment runs, not the finished, agility-adjusted percentage
+  afterward — the two orders disagree whenever attacker and target have
+  unequal agility, since the agility term is not linear in its input. Both
+  confirmed against EasyRPG Player's `Algo::CalcNormalAttackToHit`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5084,6 +5084,39 @@ not yet verified:
   weapon healing one instead, and the same weapon on RPG2000 still
   inflicting since the flag is edition-gated), each confirmed to fail
   against the pre-fix code before the fix.
+- ✅ **A basic Attack's to-hit chance is now correct in two ways it wasn't
+  before, both in `Game::Battle#to_hit`.** Confirmed against EasyRPG's
+  `Algo::CalcNormalAttackToHit` (`src/algo.cpp`) line by line:
+  1. **A "do nothing"-restricted target (asleep / paralysed) now always gets
+     hit**, instead of still rolling the ordinary hit-rate/agility math.
+     `CalcNormalAttackToHit`'s `if (!target.CanAct()) return 100;` sits right
+     below its `EvadesAllPhysicalAttacks` check (already ported) and above
+     every accuracy term — a restricted target was RPG_RT's one guaranteed
+     landing before the "Avoid Attacks" state existed, and this codebase's
+     own comment on the `evades_all_physical?` fix already named this rule
+     in passing without ever implementing it. Ported as a new
+     `Game::Battle#do_nothing_restricted?` (factored out of
+     `#command_restricted?`'s own half of the same check) and a
+     `return 100 if do_nothing_restricted?(target)` right after the
+     avoid-attacks guard.
+  2. **A state's `reduce_hit_ratio` (Blind and friends) now scales the
+     attacker's *base* hit rate before the agility adjustment, not the
+     finished, agility-adjusted percentage afterward.** EasyRPG folds the
+     state modifier in first (`to_hit = to_hit *
+     GetHitChanceModifierFromStates() / 100`) and only then computes
+     `CalcToHitAgiAdjustment` off the already-reduced value; this codebase
+     multiplied by the state modifier last instead. Since the agility term
+     is not linear in its input, the two orders disagree whenever attacker
+     and target have unequal agility — e.g. a Blind (50%) attacker with base
+     hit 90 and agility 20 against a target with agility 10 landed 46% the
+     old way and should land 59% (`90*50/100=45` scaled by the state first,
+     then `100-(100-45)*30/40=59` by agility). Equal-agility fights were
+     unaffected (the agility term is an identity there), which is why the
+     existing Blind coverage never caught it.
+  Covered by two new `scripts/rpg2k_logic_check.rb` checks (a restricted
+  target hit despite an attacker whose own hit-rate/agility odds would
+  otherwise floor at 0, and the 46-vs-59 unequal-agility case above), each
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7595,8 +7595,9 @@ module Game
     end
 
     # `attacker`'s to-hit percentage against `target` for a basic attack: the
-    # attacker's base hit rate (weapon / unarmed 90, a "miss" enemy 70), adjusted
-    # by the agility ratio — EasyRPG's CalcToHitAgiAdjustment, which simplifies to
+    # attacker's base hit rate (weapon / unarmed 90, a "miss" enemy 70), scaled
+    # by the attacker's own state-based accuracy penalty, then adjusted by the
+    # agility ratio — EasyRPG's CalcToHitAgiAdjustment, which simplifies to
     # `100 - (100 - base) * (srcAgi + tgtAgi) / (2 * srcAgi)` — so a nimbler
     # target dodges more. Clamped to 0..100. Only consulted when the fight has
     # accuracy enabled (see #initialize).
@@ -7605,32 +7606,43 @@ module Game
     # attack unconditionally, before any other term -- EasyRPG's
     # `CalcNormalAttackToHit` (algo.cpp) checks `target.EvadesAllPhysicalAttacks()`
     # first and returns 0 immediately, ahead of even the restricted-target
-    # "always hits" rule and a 必中 attacker's own evasion-ignoring branch.
+    # "always hits" rule and a 必中 attacker's own evasion-ignoring branch. A
+    # target with a "do nothing" restriction (asleep / paralysed) is the next
+    # term down and always gets hit -- `CalcNormalAttackToHit`'s `if
+    # (!target.CanAct()) return 100;`, ahead of every accuracy term below it.
     def to_hit(attacker, target)
       return 0 if evades_all_physical?(target)
-      base = attacker.hit_rate || 90
+      return 100 if do_nothing_restricted?(target)
+      # Modify hit chance for each state the *source* has (`#hit_modifier`,
+      # e.g. Blind) before the agility term -- EasyRPG folds this in first
+      # (`to_hit = to_hit * GetHitChanceModifierFromStates() / 100`) and only
+      # then computes `CalcToHitAgiAdjustment` off the already-reduced value,
+      # not the raw weapon hit rate. Applying it last instead (multiplying
+      # the finished, agility-adjusted percentage) skews the result whenever
+      # attacker and target have unequal agility, since the AGI term is not
+      # linear in its input.
+      base = (attacker.hit_rate || 90) * hit_modifier(attacker) / 100
       # 必中: a weapon flagged `ignore_evasion` skips the agility term entirely —
       # RPG_RT's `CalcNormalAttackToHit` returns before it applies evasion for
-      # such a weapon. The attacker's own statuses still spoil its aim, since
-      # what the flag ignores is the *target's* evasion, not the wielder's blind.
-      raw =
-        if attacker.ignores_evasion
-          Game.clamp(base, 0, 100)
-        else
-          src = effective_agi(attacker)
-          src = 1 if src < 1
-          tgt = effective_agi(target)
-          agi_adjusted = 100 - (100 - base) * (src + tgt) / (2 * src)
-          # 物理回避率アップ: a shield/armour/helmet/accessory flagged
-          # `raise_evasion` (Actor#physical_evasion_up?) subtracts a further
-          # flat 25 from the already agi-adjusted chance, right where
-          # EasyRPG's `CalcNormalAttackToHit` applies it -- after the AGI
-          # term, and never reached at all by a 必中 attacker (the branch
-          # above already returned).
-          agi_adjusted -= 25 if target.evasion_up
-          Game.clamp(agi_adjusted, 0, 100)
-        end
-      raw * hit_modifier(attacker) / 100
+      # such a weapon. The attacker's own statuses still spoil its aim (baked
+      # into `base` above), since what the flag ignores is the *target's*
+      # evasion, not the wielder's blind.
+      if attacker.ignores_evasion
+        Game.clamp(base, 0, 100)
+      else
+        src = effective_agi(attacker)
+        src = 1 if src < 1
+        tgt = effective_agi(target)
+        agi_adjusted = 100 - (100 - base) * (src + tgt) / (2 * src)
+        # 物理回避率アップ: a shield/armour/helmet/accessory flagged
+        # `raise_evasion` (Actor#physical_evasion_up?) subtracts a further
+        # flat 25 from the already agi-adjusted chance, right where
+        # EasyRPG's `CalcNormalAttackToHit` applies it -- after the AGI
+        # term, and never reached at all by a 必中 attacker (the branch
+        # above already returned).
+        agi_adjusted -= 25 if target.evasion_up
+        Game.clamp(agi_adjusted, 0, 100)
+      end
     end
 
     # Whether any state currently afflicting `b` is flagged "Avoid Attacks"
@@ -8025,10 +8037,19 @@ module Game
     # back to correctly (a random living foe via #attack_target).
     def command_restricted?(b)
       return true if battler_restriction(b) != 0
-      (b.states || []).any? { |id| state_field(state_def(id), :restriction) == RESTRICTION_DO_NOTHING }
+      do_nothing_restricted?(b)
     end
 
     private
+
+    # Whether `b` currently carries a "do nothing" restriction (asleep /
+    # paralysed) -- EasyRPG's `Game_Battler::CanAct`, which scans exactly this
+    # one restriction value and nothing else (not death, not a forced-target
+    # restriction). Shared by #command_restricted? (half of its own check)
+    # and #to_hit (a restricted target always gets hit).
+    def do_nothing_restricted?(b)
+      (b.states || []).any? { |id| state_field(state_def(id), :restriction) == RESTRICTION_DO_NOTHING }
+    end
 
     # The state definition for `id` from the lookup, or nil (no lookup / unknown).
     def state_def(id); @states ? @states[id] : nil; end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10717,6 +10717,49 @@ check 'battle: an "Avoid Attacks" (RPG2003) state dodges every basic attack unco
   eq 0, bat.send(:to_hit, attacker, dodger), 'still dodges with a second, unrelated state'
 end
 
+check 'battle: a "do nothing"-restricted target always gets hit' do
+  # EasyRPG's CalcNormalAttackToHit: `if (!target.CanAct()) return 100;` --
+  # the next term down from avoid_attacks, ahead of every ordinary accuracy
+  # roll. An asleep/paralysed target (state restriction 1) was previously
+  # rolled through the normal hit-rate/agility math like anyone else.
+  states = { 5 => fake_state(restriction: Game::Battle::RESTRICTION_DO_NOTHING) }
+  # A slow, low-hit-rate attacker against a fast target: agility alone would
+  # push this well under 100 if the restriction were not consulted first.
+  attacker = combatant('Weak', 0, 0, 1, 100)
+  attacker.hit_rate = 10
+  target = combatant('Sleeper', 0, 0, 99, 100)
+  bat = Game::Battle.new([attacker], [target], Game::Rng.new(1), states,
+                         false, false, true)          # accuracy on
+  eq 0, bat.send(:to_hit, attacker, target), "unafflicted: the attacker's own poor odds, floored at 0"
+
+  target.states = [5]
+  eq 100, bat.send(:to_hit, attacker, target), "afflicted: sleep overrides the attacker's own poor odds"
+
+  awake = combatant('Awake', 0, 0, 99, 100)
+  ok bat.send(:to_hit, attacker, awake) < 100,
+     'an unafflicted target of the same agility is not swept up in the same rule'
+end
+
+check "battle: a state's reduce_hit_ratio folds into the base hit rate before " \
+      'the agility term, not after' do
+  # EasyRPG: `to_hit = to_hit * GetHitChanceModifierFromStates() / 100;` runs
+  # *before* `CalcToHitAgiAdjustment`, so the AGI term's own nonlinear
+  # `100 - (100 - to_hit) * (src + tgt) / (2 * src)` shape is applied to the
+  # already-blinded hit rate, not to the unblinded base with the state
+  # discount multiplied on afterward -- the two orders disagree whenever
+  # attacker and target have unequal agility, since the AGI adjustment isn't
+  # linear in its input.
+  states = { 8 => fake_state(reduce_hit_ratio: 50) }
+  blind = combatant('Blind', 0, 0, 20, 100)   # faster than its target
+  blind.hit_rate = 90
+  blind.states = [8]
+  foe = combatant('Foe', 0, 0, 10, 100)
+  bat = Game::Battle.new([blind], [foe], Game::Rng.new(1), states,
+                         false, false, true)          # accuracy on
+  eq 59, bat.send(:to_hit, blind, foe),
+     '90*50/100=45 scaled by the state first, then 100-(100-45)*30/40=59 by agility'
+end
+
 check 'battle: a "Reflect Magic" (RPG2003) state bounces a Skill back onto its own caster' do
   # Parsed (mruby-lcf/mrblib/schema.rb state field 37, reflect_magic) but never
   # read anywhere in Game::Battle before this fix -- EasyRPG's


### PR DESCRIPTION
## Summary
Cross-checked `Game::Battle#to_hit` line by line against EasyRPG's `Algo::CalcNormalAttackToHit` (`src/algo.cpp`) and found two bugs:

1. **A "do nothing"-restricted target (asleep/paralysed) now always gets hit**, instead of still rolling the ordinary hit-rate/agility math. `CalcNormalAttackToHit`'s `if (!target.CanAct()) return 100;` sits right below the already-ported `EvadesAllPhysicalAttacks` check and above every accuracy term. Ported as a new `Game::Battle#do_nothing_restricted?` (factored out of `#command_restricted?`'s own half of the same check).
2. **A state's `reduce_hit_ratio` (Blind and friends) now scales the attacker's base hit rate *before* the agility adjustment**, not the finished, agility-adjusted percentage afterward. EasyRPG folds the state modifier in first and only then computes the agility term off the already-reduced value. Since the agility term is not linear, the two orders disagree whenever attacker and target have unequal agility — equal-agility fights were unaffected, which is why the existing Blind coverage never caught it.

## Test plan
- [x] Two new `scripts/rpg2k_logic_check.rb` checks (a restricted target hit despite an attacker whose own hit-rate/agility odds would otherwise floor at 0, and a 46-vs-59 unequal-agility Blind case), each confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_