### PR TITLE
Truncate critical-hit chance to a whole percent before rolling

### DIFF
--- a/changelog.d/rpg2k-crit-chance-whole-percent.fixed.md
+++ b/changelog.d/rpg2k-crit-chance-whole-percent.fixed.md
@@ -1,0 +1,9 @@
+- **Critical-hit chance now truncates to a whole percent before rolling**,
+  instead of preserving fractional basis-point precision RPG_RT itself
+  discards. Confirmed against EasyRPG Player's source: RPG_RT sums an actor's
+  base rate and weapon bonus as a float, then truncates the combined result to
+  a whole percent before ever rolling — the fractional remainder is thrown
+  away regardless of which term produced it. A plain 1-in-30 actor with no
+  weapon bonus previously landed a critical hit 3.33% of the time here,
+  against RPG_RT's flat 3% — an eleven percent relative inflation, present for
+  almost every critical rate in both games.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5117,6 +5117,43 @@ not yet verified:
   target hit despite an attacker whose own hit-rate/agility odds would
   otherwise floor at 0, and the 46-vs-59 unequal-agility case above), each
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **Critical-hit chance now truncates to a whole percent before rolling,
+  instead of preserving basis-point precision RPG_RT itself discards** —
+  correcting the "Assets & infrastructure" section's own 会心必殺 bullet
+  above. That bullet's own reasoning was sound on the *shape* of the problem
+  (RPG_RT adds a weapon's percentage to the wielder's 1-in-N rate, and no
+  integer denominator expresses "1/30 and 20% more", so the chance has to be
+  carried as a probability) but wrong about what precision that probability
+  needs: it moved to basis points over `Game::CRIT_SCALE` (10000) on the
+  theory that a 1/30 row "should" read 3.33%, matching the true mathematical
+  fraction. Checked directly against EasyRPG's actual source rather than that
+  assumption: `Game_Actor::GetCriticalHitChance` (`src/game_actor.cpp`) does
+  sum the base rate and weapon bonus as a float (`1.0f/n + bonus/100.0f`) —
+  but its one caller, `Algo::CalcCriticalHitChance` (`src/algo.cpp`),
+  immediately does `static_cast<int>(chance * 100.0)`, and the roll itself
+  goes through `Rand::PercentChance(int rate)` (`GetRandomNumber(0, 99) <
+  rate`, `src/rand.cpp`) — RPG_RT truncates the *combined* rate to a whole
+  percent before it ever rolls, not after; the fractional remainder past the
+  first digit is thrown away regardless of which of the two additive terms
+  produced it. A plain 1-in-30 actor with no weapon crit here landed 3.33% of
+  the time against RPG_RT's flat 3% — an eleven percent relative inflation,
+  present for almost every rate. Fixed by rewriting `Game::Actor#crit_chance`
+  / `Game::Enemy#crit_chance` to return a whole percent
+  (`(100.0 / n).to_i + weapon_crit_bonus`, exactly equal to truncating the
+  float sum the way EasyRPG does, since the weapon bonus is already an
+  integer) and `Game::Battle#critical?` to roll a plain `@rng.random(100) <
+  chance` instead of `@rng.scaled(Game::CRIT_SCALE)` — which also retires the
+  `#scaled`-over-`#random` modulus-bias workaround the old basis-point scale
+  needed (that workaround's own reasoning was correct at scale 10000; a scale
+  of 100 is exactly the "small `n`, `#random` is correct enough" regime every
+  other caller in this file already relies on). `Game::CRIT_SCALE`/
+  `CRIT_PERCENT` are removed as a result — nothing references basis points
+  for this any more. Covered by rewriting the existing crit-chance test suite
+  onto whole percentages (a 1-in-30 actor now asserts 3%, not 333 bp; a
+  50%-rate roll boundary at 49/50/51 instead of a 5000 bp one at 4999/5000/
+  5001) and one real-data test-bed check
+  (`scripts/rpg2k_testbed_logic_check.rb`), each confirmed to fail against
+  the pre-fix code before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6,14 +6,6 @@
 # the not-yet-implemented map renderer, and unit-testable on its own.
 module Game
   TILE = 16 # tile size in pixels
-  # Denominator a critical-hit chance is expressed over -- basis points, so
-  # 10000 is certainty and an actor's 1/30 row rate is 333. RPG_RT adds a
-  # weapon's own percentage to the wielder's rate, which a 1-in-N denominator
-  # cannot express, so the chance is carried as a probability and the whole
-  # damage path stays on integer arithmetic. See Actor#crit_chance.
-  CRIT_SCALE = 10_000
-  # ... and what one percentage point of it is worth.
-  CRIT_PERCENT = CRIT_SCALE / 100
   # The RPG2000 screen, in pixels. `RPG2k::WIDTH`/`HEIGHT` are the same numbers
   # on the scene side; the pure-logic half needs them for the screen-transition
   # geometry, which cannot reach the scene.
@@ -2111,23 +2103,36 @@ module Game
       @hp
     end
 
-    # The actor's critical-hit chance in basis points (0 = never): the row's own
-    # 1-in-`critical_rate` rate, gated by `has_critical_rate`, **plus** the
+    # The actor's critical-hit chance as a whole percent (0 = never): the row's
+    # own 1-in-`critical_rate` rate, gated by `has_critical_rate`, **plus** the
     # equipped weapon's `critical_hit` percentage. RPG_RT adds the two, which is
-    # why this is a probability rather than the 1-in-N denominator it used to
+    # why this is a percentage rather than the 1-in-N denominator it used to
     # be -- there is no denominator that expresses "1/30 and 20% more".
     #
-    # Basis points (1/10000) rather than a float, to stay with the integer
-    # arithmetic the rest of the damage path uses. The base truncates there: a
-    # 1/30 row is 333 bp, i.e. 3.33% against a true 3.333...%, which is one crit
-    # fewer in roughly 300,000 swings.
+    # A whole percent, truncated, not a finer-grained probability: EasyRPG's
+    # `Game_Actor::GetCriticalHitChance` sums the base rate and weapon bonus as
+    # a float (`1.0f/n + bonus/100.0f`), and its one caller,
+    # `Algo::CalcCriticalHitChance`, immediately does
+    # `static_cast<int>(chance * 100.0)` -- RPG_RT itself throws away everything
+    # past the first digit before ever rolling, rather than preserving it. A
+    # previous version of this method kept the fraction (basis points over
+    # 10000, so a 1/30 row read 333 rather than truncating to a flat 3) on the
+    # theory that no integer percent could add a weapon's bonus onto a 1-in-N
+    # rate cleanly -- true, but RPG_RT doesn't attempt that either: it truncates
+    # the *sum*, not the base rate alone, which lands on the same whole percent
+    # this method now computes directly (`(100.0/n).to_i + bonus`, exactly
+    # equal to `((1.0/n + bonus/100.0) * 100).to_i` since the bonus is already
+    # an integer). Keeping the finer-grained probability made every critical
+    # roll land measurably more often than genuine RPG_RT for almost any rate
+    # -- a plain 1-in-30 actor crit 3.33% of the time here against RPG_RT's
+    # flat 3%, an eleven percent relative inflation.
     def crit_chance
-      base = 0
+      pct = weapon_crit_bonus
       if @db_row.respond_to?(:has_critical_rate) && @db_row.has_critical_rate
         n = @db_row.respond_to?(:critical_rate) ? @db_row.critical_rate : 0
-        base = CRIT_SCALE / n if n && n > 0
+        pct += (100.0 / n).to_i if n && n > 0
       end
-      base + weapon_crit_bonus * CRIT_PERCENT
+      pct
     end
 
     # 会心必殺 -- the best `critical_hit` percentage among the equipped weapons
@@ -6484,12 +6489,13 @@ module Game
       @hidden = hidden ? true : false
       @hp = @max_hp
       @sp = @max_sp
-      # Critical-hit chance in basis points (0 = never), from the enemy's
-      # critical_hit flag and its 1-in-`critical_hit_chance` rate. An enemy has
-      # no equipment, so unlike an actor's this is the whole of it.
+      # Critical-hit chance as a whole percent (0 = never), from the enemy's
+      # critical_hit flag and its 1-in-`critical_hit_chance` rate, truncated
+      # the same way -- and for the same reason -- as Actor#crit_chance. An
+      # enemy has no equipment, so unlike an actor's this is the whole of it.
       @crit_chance = if row && row.respond_to?(:critical_hit) && row.critical_hit
                        n = row.respond_to?(:critical_hit_chance) ? row.critical_hit_chance : 0
-                       n && n > 0 ? CRIT_SCALE / n : 0
+                       n && n > 0 ? (100.0 / n).to_i : 0
                      else
                        0
                      end
@@ -8998,16 +9004,22 @@ module Game
     end
 
     # Whether `b`'s attack criticals: enabled for the fight, the attacker has a
-    # non-zero `crit_chance`, and a 0..9999 roll lands under it. A chance at or
-    # above CRIT_SCALE always crits, which is what a weapon carrying 100% means.
+    # non-zero `crit_chance`, and a 0..99 roll lands under it -- EasyRPG's
+    # `Rand::PercentChance(int rate)`, `GetRandomNumber(0, 99) < rate`, the
+    # exact overload `Algo::CalcCriticalHitChance`'s already-truncated whole
+    # percent is rolled through. A chance at or above 100 always crits, which
+    # is what a weapon carrying 100% means.
+    #
+    # Drawn with #random, not #scaled: #scaled exists because a modulus of the
+    # generator's prime period over-represents the low values a *large*-scale
+    # threshold test (thousands/millions) sits in, which a plain 0..99 roll at
+    # `n` = 100 is far too small to suffer from -- the same reasoning
+    # `#random`'s own doc comment already gives for every other small-`n`
+    # caller in this file.
     def critical?(b)
       return false unless @criticals
       chance = b.crit_chance
-      # Drawn with Rng#scaled, not #random: at CRIT_SCALE a modulus of the
-      # generator's prime period over-represents the low values a small
-      # threshold tests against, and pays out every crit chance about 7% more
-      # often than the number says.
-      chance && chance > 0 && @rng.scaled(CRIT_SCALE) < chance
+      chance && chance > 0 && @rng.random(100) < chance
     end
 
     # Whether `attacker`'s basic attack lands on `target`: a 0..99 roll under the

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8073,19 +8073,20 @@ end
 check 'Rng#scaled pays out a small threshold at its stated rate' do
   # The generator's period is prime, so `next_int % scale` leaves the lowest
   # `PERIOD % scale` values over-represented. At the sizes #random is used with
-  # that is invisible; at CRIT_SCALE the surplus is 5537 values sitting exactly
-  # where a roll-under-a-small-threshold test looks, and every such threshold
-  # fires about 7% too often. #scaled spreads it instead.
+  # that is invisible; at a large scale like this one the surplus is a sizeable
+  # block sitting exactly where a roll-under-a-small-threshold test looks, and
+  # every such threshold fires about 7% too often. #scaled spreads it instead.
+  scale = 10_000
   [[333, 30], [500, 20], [3333, 3]].each do |bp, denom|
     trials = 40_000
     modulo = Game::Rng.new(1)
     scaled = Game::Rng.new(1)
     m = s = 0
     trials.times do
-      m += 1 if modulo.random(Game::CRIT_SCALE) < bp
-      s += 1 if scaled.scaled(Game::CRIT_SCALE) < bp
+      m += 1 if modulo.random(scale) < bp
+      s += 1 if scaled.scaled(scale) < bp
     end
-    want = trials * bp / Game::CRIT_SCALE.to_f
+    want = trials * bp / scale.to_f
     ok (s - want).abs < want * 0.03,
        "1/#{denom}: scaled gave #{s}, wanted about #{want.round}"
     ok m > want * 1.03,
@@ -8096,10 +8097,10 @@ check 'Rng#scaled pays out a small threshold at its stated rate' do
 end
 
 check 'battle: a crit chance is paid out at the rate it states' do
-  # End to end through the real roll, which is what the bias actually reached.
-  chance = Game::CRIT_SCALE / 20                      # 1/20 -> 500 bp
+  # End to end through the real roll: a 5% (1-in-20) chance should land on
+  # about a twentieth of swings.
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_chance = chance
+  hero.crit_chance = 5
   foe = combatant('Foe', 0, 0, 5, 100)
   bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, true)
   trials = 40_000
@@ -8112,7 +8113,7 @@ end
 
 check 'battle: a critical hit triples the damage when the fight rolls one' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_chance = Game::CRIT_SCALE                # certainty -> always crits
+  hero.crit_chance = 100                             # certainty -> always crits
   slime = combatant('Slime', 0, 0, 5, 100_000)
   # 6-arg: variance off, criticals on.
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
@@ -8124,7 +8125,7 @@ end
 
 check 'battle: no critical when the fight has criticals off' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_chance = Game::CRIT_SCALE                # would always crit, but...
+  hero.crit_chance = 100                             # would always crit, but...
   slime = combatant('Slime', 0, 0, 5, 100_000)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1))  # 3-arg: crit off
   bat.begin_round
@@ -8148,7 +8149,7 @@ end
 # defenceless target (Game::Battle::DAMAGE_CAP).
 check 'battle: a normal-attack critical hard-caps damage at 999' do
   hero = combatant('Hero', 4000, 0, 20, 100)         # base 2000, uncapped x3 crit = 6000
-  hero.crit_chance = Game::CRIT_SCALE                # always crits
+  hero.crit_chance = 100                             # always crits
   slime = combatant('Slime', 0, 0, 5, 100_000)
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)
   bat.begin_round
@@ -8172,23 +8173,26 @@ def crit_party(items)
   Game::State.new(Game::Party.new(FakeActorDB.new(players, [1, 2], items)), 1, 0, 0)
 end
 
-check 'Actor#crit_chance: the row rate alone, in basis points' do
+check 'Actor#crit_chance: the row rate alone, truncated to a whole percent' do
+  # EasyRPG's Algo::CalcCriticalHitChance truncates the actor's own float rate
+  # to a whole int percent before ever rolling (`static_cast<int>(chance *
+  # 100.0)`, fed straight to `Rand::PercentChance(int)`'s plain 0..99 roll) --
+  # a 1-in-30 rate is a flat 3%, not 3.33%.
   st = crit_party({})
-  eq Game::CRIT_SCALE / 30, st.party.actor_by_id(1).crit_chance
-  eq 333, st.party.actor_by_id(1).crit_chance, '1-in-30 is 3.33%'
+  eq 3, st.party.actor_by_id(1).crit_chance, '1-in-30 truncates to 3%'
   eq 0, st.party.actor_by_id(2).crit_chance, 'an actor that never crits'
 end
 
 check 'Actor#crit_chance: an equipped weapon adds its own percentage' do
-  # The whole point of the probability model: RPG_RT adds the weapon's rate to
-  # the wielder's, which no 1-in-N denominator can express.
+  # RPG_RT adds the weapon's rate to the wielder's, which no 1-in-N denominator
+  # can express -- but the *sum*, not the base rate, is what EasyRPG truncates,
+  # so 3% + 20% lands on the same 23% either way the truncation is ordered.
   items = { 7 => fake_item(type: 1, atk: 5, critical_hit: 20) }
   st = crit_party(items)
   a = st.party.actor_by_id(1)
-  eq 333, a.crit_chance, 'unarmed: the row rate'
+  eq 3, a.crit_chance, 'unarmed: the row rate'
   a.equip([7, 0, 0, 0, 0])
-  eq 333 + 20 * Game::CRIT_PERCENT, a.crit_chance
-  eq 2333, a.crit_chance, '3.33% + 20% = 23.33%'
+  eq 23, a.crit_chance, '3% + 20% = 23%'
 end
 
 check 'Actor#crit_chance: the best weapon wins, and only a weapon counts' do
@@ -8203,10 +8207,9 @@ check 'Actor#crit_chance: the best weapon wins, and only a weapon counts' do
   st = crit_party(items)
   a = st.party.actor_by_id(1)
   a.equip([8, 7, 0, 0, 0])
-  eq 333 + 20 * Game::CRIT_PERCENT, a.crit_chance,
-     'the better of two wielded weapons, not their sum'
+  eq 23, a.crit_chance, 'the better of two wielded weapons, not their sum'
   a.equip([0, 0, 9, 0, 0])
-  eq 333, a.crit_chance, 'the armour contributes nothing'
+  eq 3, a.crit_chance, 'the armour contributes nothing'
 end
 
 check 'Actor#crit_chance: a weapon arms an actor whose own rate is off' do
@@ -8219,7 +8222,7 @@ check 'Actor#crit_chance: a weapon arms an actor whose own rate is off' do
   ally = st.party.actor_by_id(2)
   eq 0, ally.crit_chance
   ally.equip([7, 0, 0, 0, 0])
-  eq 20 * Game::CRIT_PERCENT, ally.crit_chance
+  eq 20, ally.crit_chance
 end
 
 check 'battle: a 100% weapon crits every swing, and still triples' do
@@ -8227,8 +8230,8 @@ check 'battle: a 100% weapon crits every swing, and still triples' do
   hero = st.party.actor_by_id(1)
   hero.equip([7, 0, 0, 0, 0])
   c = Game::Battle.from_actor(hero)
-  ok c.crit_chance >= Game::CRIT_SCALE, 'certainty or better'
-  # A chance at or over the scale must land on every roll, whatever the seed.
+  ok c.crit_chance >= 100, 'certainty or better'
+  # A chance at or over 100 must land on every roll, whatever the seed.
   5.times do |i|
     slime = combatant('Slime', 0, 0, 5, 100_000)
     bat = Game::Battle.new([Game::Battle.from_actor(hero)], [slime],
@@ -8243,34 +8246,28 @@ end
 class FixedRng
   def initialize(value); @value = value; end
   def random(n); n <= 0 ? 0 : @value % n; end
-  # The crit roll draws through #scaled; a fixture pinning an exact roll wants
-  # that value handed back untouched rather than rescaled.
-  def scaled(scale); scale <= 0 ? 0 : @value % scale; end
 end
 
-check 'battle: the crit roll is read against the basis-point scale' do
-  # A rate of N must crit on a roll of N-1 and not on N. This is what says the
-  # chance is a probability over CRIT_SCALE rather than a denominator: 5000 bp
-  # and "1 in 2" sample the same, but only one of them answers this.
-  [[4999, true], [5000, false], [5001, false]].each do |roll, want|
+check 'battle: the crit roll is read against a whole-percent scale' do
+  # A rate of N must crit on a roll of N-1 and not on N -- EasyRPG's
+  # Rand::PercentChance(int rate), `GetRandomNumber(0, 99) < rate`.
+  [[49, true], [50, false], [51, false]].each do |roll, want|
     hero = combatant('Hero', 40, 0, 20, 100)
-    hero.crit_chance = 5000
+    hero.crit_chance = 50
     slime = combatant('Slime', 0, 0, 5, 100_000)
     bat = Game::Battle.new([hero], [slime], FixedRng.new(roll), nil, false, true)
     bat.begin_round
-    eq want, bat.step_action[:critical], "a 5000 bp rate on a roll of #{roll}"
+    eq want, bat.step_action[:critical], "a 50% rate on a roll of #{roll}"
   end
 end
 
 check 'battle: the crit rate is the chance, not a 1-in-N denominator' do
-  # A 2500 bp battler crits about a quarter of the time; the old model could
-  # only have said "1 in 4" and had no way to add a weapon's 20% to it.
-  hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_chance = 2500
+  # A 25% battler crits about a quarter of the time; the old model could only
+  # have said "1 in 4" and had no way to add a weapon's 20% to it.
   crits = 0
   400.times do |i|
     h = combatant('Hero', 40, 0, 20, 100)
-    h.crit_chance = 2500
+    h.crit_chance = 25
     slime = combatant('Slime', 0, 0, 5, 100_000)
     bat = Game::Battle.new([h], [slime], Game::Rng.new(i + 1), nil, false, true)
     bat.begin_round
@@ -8282,7 +8279,7 @@ end
 
 check 'battle: gear that prevents criticals blocks the 3x hit' do
   hero = combatant('Hero', 40, 0, 20, 100)
-  hero.crit_chance = Game::CRIT_SCALE                # would always crit...
+  hero.crit_chance = 100                             # would always crit...
   slime = combatant('Slime', 0, 0, 5, 100_000)
   slime.prevents_crit = true                         # ...but the target is guarded
   bat = Game::Battle.new([hero], [slime], Game::Rng.new(1), nil, false, true)

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -807,7 +807,7 @@ def check_equipment(dir)
       crit_weapons.each do |iid|
         a = Game::Actor.new(db, aid)
         a.equip([iid, 0, 0, 0, 0])
-        eq base + items[iid].critical_hit * Game::CRIT_PERCENT, a.crit_chance,
+        eq base + items[iid].critical_hit, a.crit_chance,
            "item ##{iid} (#{items[iid].name}) adds #{items[iid].critical_hit}%"
         ok a.crit_chance > base, 'and the weapon really moves the rate'
       end


### PR DESCRIPTION
## Summary
- Checked critical-hit chance against EasyRPG's actual source rather than an earlier assumption in this codebase: `Game_Actor::GetCriticalHitChance` sums the base 1-in-N rate and weapon bonus as a float, but its one caller, `Algo::CalcCriticalHitChance`, immediately truncates the combined result to a whole int percent (`static_cast<int>(chance * 100.0)`), and the roll itself goes through `Rand::PercentChance(int rate)` — `GetRandomNumber(0, 99) < rate`. RPG_RT truncates the *combined* rate before it ever rolls, not after.
- The previous basis-point model (`Game::CRIT_SCALE = 10000`) preserved the fractional remainder past the first digit instead of discarding it, so a plain 1-in-30 actor crit 3.33% of the time here against RPG_RT's flat 3% — an eleven percent relative inflation, present for almost every critical rate in both test-bed games.
- Rewrites `Game::Actor#crit_chance` / `Game::Enemy#crit_chance` to return a whole percent (`(100.0/n).to_i + weapon_crit_bonus`, exactly equal to truncating the float sum EasyRPG computes, since the weapon bonus is already an integer) and `Game::Battle#critical?` to roll a plain `@rng.random(100)` instead of `@rng.scaled(CRIT_SCALE)` — which also retires the `#scaled`-over-`#random` modulus-bias workaround the old basis-point scale needed; a scale of 100 is exactly the "small `n`, `#random` is correct enough" regime every other caller already relies on. `CRIT_SCALE`/`CRIT_PERCENT` are removed as a result.

## Test plan
- [x] Rewrote the existing crit-chance test suite onto whole percentages (a 1-in-30 actor now asserts 3%, not 333 bp; a 50%-rate roll boundary at 49/50/51 instead of a 5000 bp one) and added a real-data test-bed assertion — each confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_