### PR TITLE
Report a dangling battle-animation id instead of drawing nothing

### DIFF
--- a/changelog.d/battle-animation-missing-id-diagnostic.fixed.md
+++ b/changelog.d/battle-animation-missing-id-diagnostic.fixed.md
@@ -1,0 +1,10 @@
+- **A dangling battle-animation id now logs a diagnostic instead of silently
+  drawing nothing.** `Scene::Map#animation_row`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) — the single choke point every
+  battle-animation lookup goes through, whether from a Show Battle Animation
+  command or a skill/item's own animation — used to swallow a miss with a
+  bare `rescue StandardError; nil`. It now logs a `[RPG2k] battle animation
+  #<id> not found in database, nothing drawn` message, `respond_to?`-guarded
+  the same way `terrain_row_at`/`db_item` are so a bare test fixture with no
+  `battle_anime` table at all stays quiet. Drawing nothing is unchanged; this
+  is diagnostics only. Covered by new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8453,9 +8453,10 @@ event-id-existence and page-existence as two distinct checks); invalid
 map (Transfer Player / Teleport-to-Remembered-Location targeting a
 nonexistent map id — error text includes the literal missing filename;
 fixed, see the ✅ below);
-invalid hero, skill, item, enemy, enemy group, battle animation, terrain
-(fixed, see the ✅ below), chipset, common event (all: a database shrink
-leaves a dangling id reference somewhere, shown as "?" in the editor);
+invalid hero, skill, item, enemy, enemy group, battle animation, terrain,
+chipset, common event (skill/enemy/enemy-group/battle-animation/terrain/
+chipset fixed, see the ✅ entries below; all: a database shrink leaves a
+dangling id reference somewhere, shown as "?" in the editor);
 event-call recursion past 1000. Several of these errors are **deferred**
 until the stale reference is actually exercised at runtime rather than
 raised at load time — e.g. invalid terrain only errors when the player
@@ -8650,6 +8651,28 @@ behaviour itself is unchanged, this is diagnostics only. Covered by a new
 alongside the unchanged blank name/graphic and default-passable/terrain
 behaviour, plus that an existing id, id `0`, a `nil` id and a chipset-less
 bare fixture all stay silent.
+✅ **A dangling battle-animation id no longer draws nothing with no trace** —
+the "battle animation" case from the "invalid hero, skill, item, enemy,
+enemy group, battle animation, terrain, chipset, common event" list above.
+`Scene::Map#animation_row` (`mruby-rpg2k/mrblib/scene/map.rb`) is the single
+choke point every battle-animation lookup goes through — a Show Battle
+Animation command and a skill/item's own animation (`#start_battle_animation`,
+`#start_map_animation`, `#start_battle_page_animation`, all via
+`#build_animation`) — and used to swallow a miss with a bare
+`rescue StandardError; nil`, so a database shrink leaving a Show Battle
+Animation, or a skill/item's own animation, naming a deleted `battle_anime`
+row simply drew nothing with no trace. It now logs a `[RPG2k] battle
+animation #<id> not found in database, nothing drawn` diagnostic when `id` is
+a positive, resolvable-looking reference that simply misses, `respond_to?`/
+nil-guarded the same way `terrain_row_at`/`db_item` are so a bare test
+fixture with no `battle_anime` table at all stays quiet. This already matches
+the "deferred until exercised" framing above for free: the lookup only ever
+runs when the animation would actually play. Behaviour is otherwise
+unchanged — the lookup still returns `nil` and every caller still draws
+nothing. Covered by new `scripts/rpg2k_scene_check.rb` checks asserting the
+captured `$stderr` line for a dangling id, silence for a valid id/`nil`/`0`/a
+`battle_anime`-less bare fixture, and that a skill naming a since-deleted
+animation still plays nothing through `#start_battle_animation`.
 
 **Map/Event ID assignment & tile occupancy**
 - ✅ **Not applicable: Event ID (and, separately, Map ID) assignment by

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7344,9 +7344,24 @@ class RPG2k
           target_height: target_height, flash_target: flash_target }
       end
 
+      # The single choke point every battle-animation lookup goes through: a
+      # Show Battle Animation command and a skill/item's own animation
+      # (#start_battle_animation, #start_map_animation,
+      # #start_battle_page_animation, all via #build_animation) all land here.
+      # A database shrink can leave one of those naming a deleted battle_anime
+      # id -- the "battle animation" case in docs/TODO.md's runtime error
+      # catalog -- and until now that just drew nothing with no trace.
+      # `respond_to?`/nil-guarded the same way `terrain_row_at`/`db_item` are,
+      # so a bare test fixture with no battle_anime table at all stays silent;
+      # only a genuine dangling id in a real database is reported.
       def animation_row(id)
         return nil if id.nil? || !@db.respond_to?(:battle_anime) || @db.battle_anime.nil?
-        @db.battle_anime[id]
+        row = @db.battle_anime[id]
+        if row.nil? && id.is_a?(Integer) && id > 0
+          $stderr.puts "[RPG2k] battle animation ##{id} not found in " \
+                       'database, nothing drawn'
+        end
+        row
       rescue StandardError
         nil
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10466,6 +10466,50 @@ check 'a skill that names none plays nothing' do
   eq nil, scene.instance_variable_get(:@map_animation)
 end
 
+# -- dangling battle-animation id (database shrink) ---------------------------
+# The "battle animation" case from docs/TODO.md's runtime error catalog:
+# #animation_row is the single choke point every battle-animation lookup goes
+# through (Show Battle Animation, and a skill/item's own animation via
+# #build_animation), so this is exercised once at that choke point rather than
+# once per caller.
+
+check '#animation_row reports a dangling animation id, stays silent for a ' \
+      'valid id, a nil id, id 0 or a db with no battle_anime table at all' do
+  scene = new_scene({})
+  # Id 7 is intentionally absent from the fake db (see its own fixture
+  # comment) -- a stand-in for a database shrink leaving a Show Battle
+  # Animation / skill / item naming a deleted battle_anime row.
+  out = capture_stderr { eq nil, scene.send(:animation_row, 7) }
+  ok out.include?('[RPG2k] battle animation #7 not found in database, ' \
+                  'nothing drawn'), out
+
+  out2 = capture_stderr do
+    ok scene.send(:animation_row, 8), 'a real id still resolves its row'
+    eq nil, scene.send(:animation_row, nil), 'a nil id is the ordinary no-animation case'
+    eq nil, scene.send(:animation_row, 0), 'id 0 is the ordinary no-animation case'
+  end
+  ok out2.empty?, "a valid id, nil or 0 must stay silent, got: #{out2.inspect}"
+
+  # A bare fixture with no battle_anime table at all (respond_to? false) must
+  # not be mistaken for a dangling reference either.
+  bare_db = OpenStruct.new
+  scene.instance_variable_set(:@db, bare_db)
+  out3 = capture_stderr { eq nil, scene.send(:animation_row, 7) }
+  ok out3.empty?, "a db with no battle_anime table at all must stay silent, got: #{out3.inspect}"
+end
+
+check 'a skill naming a since-deleted battle animation plays nothing, but reports the gap' do
+  scene, = battle_at_command
+  scene.db.battle_anime.delete(8) # simulate the database shrink Fire's animation_id (8) now dangles from
+  entry = { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+            skill_id: 8, target_index: 0, target_ally: false }
+  out = capture_stderr do
+    ok !scene.send(:start_battle_animation, entry), 'nothing plays -- unchanged from before this diagnostic'
+  end
+  eq nil, scene.instance_variable_get(:@map_animation), 'draws nothing, same as always'
+  ok out.include?('[RPG2k] battle animation #8 not found in database, nothing drawn'), out
+end
+
 # RPG2000's battle is first-person: no sprite is drawn for a party member, so an
 # action aimed at one has nowhere to centre on.
 check 'an action on a party member plays over the middle of the screen' do


### PR DESCRIPTION
## Summary
- Extend the "reported gap, not silently invented" diagnostic pattern (already applied to hero enemy/enemy-group, terrain, chipset, field-skill-menu lookups) to battle-animation lookup.
- `Scene::Map#animation_row` (`mruby-rpg2k/mrblib/scene/map.rb`) is the single choke point every battle-animation lookup goes through — a Show Battle Animation command and a skill/item's own animation (`#start_battle_animation`, `#start_map_animation`, `#start_battle_page_animation`, all via `#build_animation`) — and previously swallowed a miss with a bare `rescue StandardError; nil`, so a database shrink leaving one of those naming a deleted `battle_anime` id just drew nothing with no trace.
- It now logs a `[RPG2k] battle animation #<id> not found in database, nothing drawn` diagnostic when `id` is a positive, resolvable-looking reference that simply misses, `respond_to?`/nil-guarded the same way `terrain_row_at`/`db_item` are so a bare test fixture with no `battle_anime` table at all stays quiet. Behaviour is otherwise unchanged: the lookup still returns `nil` and every caller still draws nothing — this is diagnostics only.
- Updated `docs/TODO.md`'s runtime error catalog to mark the "battle animation" case ✅.
- Added a `changelog.d/battle-animation-missing-id-diagnostic.fixed.md` fragment.

## Test plan
- [x] New `scripts/rpg2k_scene_check.rb` checks: the diagnostic fires for a dangling animation id, stays silent for a valid id/`nil`/`0`/a `battle_anime`-less bare fixture, and a skill naming a since-deleted animation still plays nothing through `#start_battle_animation` while reporting the gap.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 561 checks passed.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 830 checks passed.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0199KfsqyF9m4Ve1DMDqomTu)_