### PR TITLE
Field/battle Item menus: report and exclude a dangling held-item id

### DIFF
--- a/changelog.d/item-menu-dangling-id.fixed.md
+++ b/changelog.d/item-menu-dangling-id.fixed.md
@@ -1,0 +1,9 @@
+- **The field/battle Item menus no longer drop a dangling held-item id with
+  no trace** — a database shrink can leave a party-held item id pointing at
+  nothing, shown as "?" in the editor. `Game::Party#field_usable?`/
+  `#battle_usable?` (`mruby-rpg2k/mrblib/game.rb`) now each log a `[RPG2k]
+  Item menu: party-held item #<id> has no matching database row, excluding
+  from field menu` (or `..., excluding from battle menu`) diagnostic instead
+  of silently omitting it. The item still doesn't appear in either menu —
+  there's nothing sensible to show for it — this is diagnostics only.
+  Covered by a new `scripts/rpg2k_logic_check.rb` check.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8559,6 +8559,35 @@ time, and this doesn't diverge from that. Covered by a new
 `scripts/rpg2k_logic_check.rb` check asserting the captured `$stderr` line and
 that the dangling id is excluded while a genuine sibling skill still comes
 through.
+✅ **The field/battle Item menus no longer drop a dangling held-item id with
+no trace** — the "item" case from the "invalid hero, skill, item, enemy,
+enemy group, battle animation, terrain, chipset, common event" list above,
+mirroring the field skill menu fix just above it. `Game::Party#field_items`/
+`#battle_items` (`mruby-rpg2k/mrblib/game.rb`) build the bag's usable-item
+lists from `#field_usable?`/`#battle_usable?`, which already tolerated a
+shrunk database by returning `false` for a stale id (`db_item(id)` degrading
+to `nil`, same as `db_skill`), so a dangling item just vanished from both
+menus with no diagnostic anywhere in the chain. `#field_usable?` and
+`#battle_usable?` now each check `db_item(id)` themselves before falling
+through to the type-dispatch `case`, and log a `[RPG2k] Item menu:
+party-held item #<id> has no matching database row, excluding from field
+menu` (or `..., excluding from battle menu`) diagnostic the same
+reported-not-invented way `#field_skills` does, including the item id; the
+item still doesn't appear in either menu — there is nothing sensible to show
+for it — this is diagnostics only. Unlike `#field_skill?` (which the skill
+fix deliberately left untouched, since it also runs for an item's own
+special-skill lookup with no menu behind it), `#field_usable?`/
+`#battle_usable?` have no other caller besides their own list-builder, so the
+check lives directly in them rather than being hoisted into
+`#field_items`/`#battle_items` the way `#field_skills` hoisted its
+`db_skill` check out of `#field_skill?`. Follows the same
+logging-every-occurrence precedent as the skill-menu fix and the three
+fixes it itself follows (Call Event, Enemy Encounter, Teleport): no
+already-logged state, so a menu opened repeatedly logs the same stale id
+each time. Covered by a new `scripts/rpg2k_logic_check.rb` check asserting
+both captured `$stderr` lines and that the dangling id is excluded from both
+`field_items` and `battle_items` while a genuine sibling item still comes
+through.
 ✅ **"invalid map" (Transfer Player / Recall to Location naming a
 nonexistent map id) no longer crashes the interpreter** — `Scene::Map
 #perform_teleport` (`mruby-rpg2k/mrblib/scene/map.rb`) called

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2860,9 +2860,23 @@ module Game
     # available (access flag + a registered target), which a bare item lookup
     # has no way to answer. Omitting it reads such an item as unusable, exactly
     # as the old hard-coded "no state" call always did.
+    #
+    # A database shrink can leave a party-held item id with no matching row
+    # (docs/TODO.md's runtime error catalog) -- `db_item` degrades that to a
+    # silent `nil`, which used to drop the item from the field menu with no
+    # trace anywhere in the call chain. Logged here, the same way
+    # #field_skills reports a dangling learned-skill id: this is the only
+    # caller of #field_usable? with an id from the party's own bag, so it's
+    # the one place that knows the gap came from *that* list rather than some
+    # other `db_item` call with no menu behind it.
     def field_usable?(id, state = nil)
       it = db_item(id)
-      return false unless it && item_count(id) > 0
+      if it.nil?
+        $stderr.puts "[RPG2k] Item menu: party-held item ##{id} has no " \
+                     'matching database row, excluding from field menu'
+        return false
+      end
+      return false unless item_count(id) > 0
       case it.type
       when ITEM_MEDICINE, ITEM_SKILL_BOOK, ITEM_SEED then true
       when ITEM_SWITCH then item_field_occasion?(it)
@@ -4006,9 +4020,17 @@ module Game
     # (the same deferral #field_usable? makes). Nepheshel's whole thrown-bomb line
     # — 火炎玉, 爆裂玉, 氷結玉, 雷撃玉 and the rest — is special items, so this is
     # what puts them in the battle item list at all.
+    #
+    # A dangling item id (see #field_usable?) is reported the same way here,
+    # for the battle menu's own list.
     def battle_usable?(id)
       it = db_item(id)
-      return false unless it && item_count(id) > 0
+      if it.nil?
+        $stderr.puts "[RPG2k] Item menu: party-held item ##{id} has no " \
+                     'matching database row, excluding from battle menu'
+        return false
+      end
+      return false unless item_count(id) > 0
       case it.type
       when ITEM_MEDICINE then !item_field_only?(it)
       when ITEM_SWITCH then item_battle_occasion?(it)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4595,6 +4595,26 @@ check 'a field-only medicine is kept out of battle; every medicine is in the fie
   eq [[5, 1]], st.party.battle_items
 end
 
+# A database shrink can leave a party-held item id dangling -- shown as "?"
+# in the editor, docs/TODO.md's runtime error catalog. #db_item silently
+# resolves that to nil, and #field_usable?/#battle_usable? just as silently
+# excluded it; the item vanished from both menus with no trace anywhere in
+# the call chain. #field_usable?/#battle_usable? now report it.
+check 'field_items/battle_items report a dangling held item id and exclude it from both menus' do
+  items = { 5 => fake_item(type: 6, rhp: 50) }   # medicine, usable everywhere
+  st = item_party(items)
+  st.party.gain_item(5, 1)
+  st.party.gain_item(99, 1)   # 99 no longer exists in the database
+
+  out = capture_stderr { eq [[5, 1]], st.party.field_items }
+  ok out.include?('[RPG2k] Item menu: party-held item #99 has no matching ' \
+                   'database row, excluding from field menu'), out
+
+  out = capture_stderr { eq [[5, 1]], st.party.battle_items }
+  ok out.include?('[RPG2k] Item menu: party-held item #99 has no matching ' \
+                   'database row, excluding from battle menu'), out
+end
+
 check 'a switch item reads its own pair of occasion flags' do
   # A switch item is the one item kind gated on both sides, and by its *own*
   # fields: occasion_field2 (57) and occasion_battle (58).


### PR DESCRIPTION
## Summary

A database shrink can leave a party-held item id pointing at nothing — the "item" case in `docs/TODO.md`'s "Concrete runtime error catalog" ("invalid hero, skill, item, enemy, ..."), the sibling of the field skill menu's already-fixed "invalid skill" case (#807).

- `Game::Party#db_item` (`mruby-rpg2k/mrblib/game.rb`) already tolerated this by returning `nil` for a stale id, but `#field_usable?`/`#battle_usable?` just as silently excluded the `nil` result (`return false unless it && item_count(id) > 0`), so a dangling item vanished from both the field and battle item menus with no trace anywhere in the call chain.
- `#field_usable?` and `#battle_usable?` now each check `db_item(id)` themselves and log a `[RPG2k] Item menu: party-held item #<id> has no matching database row, excluding from field menu` (or `..., excluding from battle menu`) diagnostic — the same reported-not-invented pattern the field skill menu fix (#807) uses. The item still doesn't appear in either menu (nothing sensible to show for it); this is diagnostics only.
- **Placement**: unlike `#field_skill?` (which #807 deliberately left untouched, since it's also called with an item's own special-skill lookup that has no menu behind it), `#field_usable?`/`#battle_usable?` have no other caller besides their own list-builder (`#field_items`/`#battle_items`), so the check lives directly in them rather than being hoisted out into the list-builders the way `#field_skills` hoisted its `db_skill` check out of `#field_skill?`.
- **Log-every-occurrence, not dedupe-per-id**: matches #807's own precedent (itself following Call Event / Enemy Encounter / Teleport) — none of those keep any already-logged state, so a menu opened repeatedly logs the same stale id again each time.

## Test coverage

New check in `scripts/rpg2k_logic_check.rb`: a party holding one genuine medicine and one dangling item id asserts both `field_items`/`battle_items` exclude the dangling id while keeping the genuine one, with the `$stderr` diagnostic asserted for both the field and battle paths.

## Docs

- `docs/TODO.md`'s runtime error catalog entry for the "item" case marked ✅, matching the style of the neighboring field skill menu entry it mirrors.
- `changelog.d/item-menu-dangling-id.fixed.md` added per the fragment convention.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 831 checks passed
- [x] `ruby -c` on both changed Ruby files
- [x] `pre-commit run trailing-whitespace end-of-file-fixer check-yaml check-added-large-files` — all passed (nixfmt/clang-format/cmake-format hooks don't apply; no Nix/C++/CMake files touched)


---
_Generated by [Claude Code](https://claude.ai/code/session_01H3fbf1CV2G9t6QpQdKysQg)_