### PR TITLE
Report a dangling equipped item id on the Equip/Status screens

### DIFF
--- a/changelog.d/equip-status-missing-item-id.fixed.md
+++ b/changelog.d/equip-status-missing-item-id.fixed.md
@@ -1,0 +1,15 @@
+- **The Equip and Status screens no longer show a dangling equipped item id
+  with no trace.** `Scene::EquipMenu#item_name` / `Scene::StatusMenu
+  #item_name` (`mruby-rpg2k/mrblib/scene/equip_menu.rb` /
+  `mruby-rpg2k/mrblib/scene/status_menu.rb`) already degraded a slot whose
+  `db_item(id)` lookup missed to an `"Item #<id>"` placeholder label instead
+  of crashing, but logged nothing, so a database shrink leaving a stale
+  equipped id behind was invisible. Both now log a `[RPG2k] Equip screen:
+  item #<id> not found in the database, showing a placeholder label` /
+  `[RPG2k] Status screen: ...` diagnostic the first time a dangling id is
+  hit, deduped per item id for the scene's lifetime so repeated LEFT/RIGHT
+  actor switches don't spam the console; the placeholder label itself is
+  unchanged. This is the equipped-slot *display* manifestation of the
+  "invalid item" case in docs/TODO.md's runtime error catalog, distinct from
+  the field/battle Item-menu's own inventory-*list*-filtering manifestation.
+  Covered by two new `scripts/rpg2k_scene_check.rb` checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8650,6 +8650,32 @@ behaviour itself is unchanged, this is diagnostics only. Covered by a new
 alongside the unchanged blank name/graphic and default-passable/terrain
 behaviour, plus that an existing id, id `0`, a `nil` id and a chipset-less
 bare fixture all stay silent.
+✅ **The Equip and Status screens no longer show a dangling equipped item id
+with no trace** — the "item" case from the "invalid hero, skill, item,
+enemy, enemy group, battle animation, terrain, chipset, common event" list
+above, on its equipped-slot *display* path specifically (the field/battle
+Item-menu's own *list-filtering* manifestation of the same dangling-item
+case — `Game::Party#field_items`/`#battle_items` — is a separate fix).
+`Scene::EquipMenu#item_name` and `Scene::StatusMenu#item_name`
+(`mruby-rpg2k/mrblib/scene/equip_menu.rb` /
+`mruby-rpg2k/mrblib/scene/status_menu.rb`, near-identical duplicates) already
+degraded a slot whose `db_item(id)` lookup misses to an `"Item #<id>"`
+placeholder label rather than crashing — the graceful part was already
+right — but logged nothing, so a database shrink leaving a stale equipped
+id behind was invisible. Both now log a `[RPG2k] Equip screen: item #<id>
+not found in the database, showing a placeholder label` /
+`[RPG2k] Status screen: ...` diagnostic the first time a dangling id is hit,
+distinguishing it from an existing row that merely has a blank name (still
+silent, since that is not a dangling reference); the placeholder label is
+unchanged, this is diagnostics only. Deduped per item id for the scene's
+lifetime, mirroring the terrain fix's own `@warned_stale_terrain` precedent
+above — `#item_name` reruns every time the slot/status window rebuilds
+(every LEFT/RIGHT actor switch), and logging each of those for an id that
+never resolves would spam the console for as long as the screen stays open.
+Covered by two new `scripts/rpg2k_scene_check.rb` checks (one per screen), each
+equipping a fixture actor with a dangling item id, asserting the diagnostic
+fires exactly once across construction and repeated rebuilds while the
+placeholder label still renders correctly.
 
 **Map/Event ID assignment & tile occupancy**
 - ✅ **Not applicable: Event ID (and, separately, Map ID) assignment by

--- a/mruby-rpg2k/mrblib/scene/equip_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/equip_menu.rb
@@ -36,6 +36,7 @@ class RPG2k
         @slot_index = 0
         @cand_index = 0
         @mode = :slots          # :slots list, or :items candidate pick
+        @warned_missing_item_ids = {}
         @slots = [
           term(:weapon, "Weapon"), term(:shield, "Shield"), term(:armor, "Armor"),
           term(:helmet, "Helmet"), term(:accessory, "Accessory")
@@ -65,8 +66,30 @@ class RPG2k
       def item_name(id)
         return "-" if id.nil? || id == 0
         it = @state.party.db_item(id)
-        n = it && it.name.to_s
-        n.nil? || n.empty? ? "Item #{id}" : n
+        if it.nil?
+          warn_missing_item(id)
+          return "Item #{id}"
+        end
+        n = it.name.to_s
+        n.empty? ? "Item #{id}" : n
+      end
+
+      # #item_name's diagnostic for an equipped slot whose item id has no
+      # database row -- the "item" case from docs/TODO.md's runtime error
+      # catalog's dangling-id list (a database shrink leaving a stale
+      # reference behind), on this screen's equipped-slot *display* path
+      # rather than the field/battle Item-menu's inventory-*list*-filtering
+      # one (a separate fix). The placeholder label is unchanged; this is
+      # diagnostics only. Deduped per id for the scene's lifetime --
+      # #item_name reruns every time the slot/candidate windows rebuild
+      # (every LEFT/RIGHT actor switch), and logging each of those for an
+      # id that never resolves would spam the console for as long as the
+      # screen stays open.
+      def warn_missing_item(id)
+        return if @warned_missing_item_ids[id]
+        @warned_missing_item_ids[id] = true
+        $stderr.puts "[RPG2k] Equip screen: item ##{id} not found in the " \
+                     "database, showing a placeholder label"
       end
 
       def update_slots

--- a/mruby-rpg2k/mrblib/scene/status_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/status_menu.rb
@@ -31,6 +31,7 @@ class RPG2k
           term(:weapon, "Weapon"), term(:shield, "Shield"), term(:armor, "Armor"),
           term(:helmet, "Helmet"), term(:accessory, "Accessory")
         ]
+        @warned_missing_item_ids = {}
         build_window
       end
 
@@ -61,8 +62,30 @@ class RPG2k
       def item_name(id)
         return "-" if id.nil? || id == 0
         it = @state.party.db_item(id)
-        n = it && it.name.to_s
-        n.nil? || n.empty? ? "Item #{id}" : n
+        if it.nil?
+          warn_missing_item(id)
+          return "Item #{id}"
+        end
+        n = it.name.to_s
+        n.empty? ? "Item #{id}" : n
+      end
+
+      # #item_name's diagnostic for an equipped slot whose item id has no
+      # database row -- the "item" case from docs/TODO.md's runtime error
+      # catalog's dangling-id list (a database shrink leaving a stale
+      # reference behind), on this screen's equipped-slot *display* path
+      # rather than the field/battle Item-menu's inventory-*list*-filtering
+      # one (a separate fix). The placeholder label is unchanged; this is
+      # diagnostics only. Deduped per id for the scene's lifetime --
+      # #item_name reruns every time the window rebuilds (every LEFT/RIGHT
+      # actor switch), and logging each of those for an id that never
+      # resolves would spam the console for as long as the screen stays
+      # open.
+      def warn_missing_item(id)
+        return if @warned_missing_item_ids[id]
+        @warned_missing_item_ids[id] = true
+        $stderr.puts "[RPG2k] Status screen: item ##{id} not found in the " \
+                     "database, showing a placeholder label"
       end
 
       def build_window

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12648,6 +12648,35 @@ check 'Scene::EquipMenu: the candidate arrow sums all four stat deltas against t
   eq '-', texts[8], 'an exact match draws Same, not counted per-stat'
 end
 
+# A party whose weapon slot equips a dangling item id (a database shrink
+# removed row 99) -- db_item(99) misses while db_item(1) resolves normally,
+# so a check can tell "reported gap" apart from an ordinary equipped item.
+class DanglingItemParty < MenuStubParty
+  ITEMS = { 1 => OpenStruct.new(name: 'Bronze Sword') }.freeze
+  def db_item(id); ITEMS[id]; end
+end
+
+check 'Scene::EquipMenu: a dangling equipped item id logs once, not per rebuild, ' \
+      'while the slot still shows the "Item #<id>" placeholder' do
+  state = Game::State.new(DanglingItemParty.new, 1, 0, 0)
+  state.party.actors.first.equipment[0] = 99 # weapon slot: dangling id, no database row
+  scene = nil
+  out = capture_stderr { scene = menu_scene(RPG2k::Scene::EquipMenu, state) }
+  eq 1, out.scan('[RPG2k] Equip screen:').size,
+     "expected exactly one diagnostic for the one dangling id, got: #{out.inspect}"
+  ok out.include?('[RPG2k] Equip screen: item #99 not found in the database, ' \
+                   'showing a placeholder label'), out
+
+  texts = window_texts(scene.instance_variable_get(:@slot_window))
+  ok texts.include?('Item 99'), "the placeholder label still shows, got: #{texts.inspect}"
+
+  # Switching actors and back rebuilds the slot window (#rebuild_for_actor)
+  # without a fresh database shrink -- the same dangling id re-renders every
+  # time, and must not add a second line to the console.
+  out2 = capture_stderr { 3.times { scene.send(:build_slot_window) } }
+  ok out2.empty?, "re-rendering the already-warned id must stay silent, got: #{out2.inspect}"
+end
+
 check 'the status screen gives the condition a labelled row' do
   st = menu_state
   texts = window_texts(menu_scene(RPG2k::Scene::StatusMenu, st)
@@ -12672,6 +12701,27 @@ check 'Scene::StatusMenu: the actor cursor wraps around' do
   scene.update
   RGSS::Input.reset
   eq 0, scene.instance_variable_get(:@actor_index), 'Right from the last actor wraps to the first'
+end
+
+check 'Scene::StatusMenu: a dangling equipped item id logs once, not per rebuild, ' \
+      'while the slot still shows the "Item #<id>" placeholder' do
+  state = Game::State.new(DanglingItemParty.new, 1, 0, 0)
+  state.party.actors.first.equipment[0] = 99 # weapon slot: dangling id, no database row
+  scene = nil
+  out = capture_stderr { scene = menu_scene(RPG2k::Scene::StatusMenu, state) }
+  eq 1, out.scan('[RPG2k] Status screen:').size,
+     "expected exactly one diagnostic for the one dangling id, got: #{out.inspect}"
+  ok out.include?('[RPG2k] Status screen: item #99 not found in the database, ' \
+                   'showing a placeholder label'), out
+
+  texts = window_texts(scene.instance_variable_get(:@window))
+  ok texts.any? { |t| t.include?('Item 99') }, "the placeholder label still shows, got: #{texts.inspect}"
+
+  # Switching actors and back rebuilds the whole window (#build_window)
+  # without a fresh database shrink -- the same dangling id re-renders every
+  # time, and must not add a second line to the console.
+  out2 = capture_stderr { 3.times { scene.send(:build_window) } }
+  ok out2.empty?, "re-rendering the already-warned id must stay silent, got: #{out2.inspect}"
 end
 
 check 'the field windows resolve the same condition the battle panel does' do


### PR DESCRIPTION
## Summary

- Extends the "reported gap, not silently invented" diagnostic pattern (already applied to Call Event, Enemy Encounter, the field Skill menu, Terrain and Chipset) to the Equip and Status screens' equipped-item display.
- `Scene::EquipMenu#item_name` and `Scene::StatusMenu#item_name` (`mruby-rpg2k/mrblib/scene/equip_menu.rb` / `mruby-rpg2k/mrblib/scene/status_menu.rb`, near-identical duplicates) already degraded a slot whose `db_item(id)` lookup misses to an `"Item #<id>"` placeholder label instead of crashing — the graceful-degrade part was already right — but logged nothing anywhere, so a database shrink leaving a stale equipped id behind was invisible.
- Both now log a `[RPG2k] Equip screen: item #<id> not found in the database, showing a placeholder label` / `[RPG2k] Status screen: ...` diagnostic the first time a dangling id is actually hit. A row that exists but merely has a blank name stays silent — that's not a dangling reference.
- Deduped per item id for the scene's lifetime, mirroring the Terrain fix's own `@warned_stale_terrain` precedent — `#item_name` reruns every time the slot/status window rebuilds (every LEFT/RIGHT actor switch), so logging every rebuild would spam the console for as long as the screen stays open.
- Placeholder-label behavior is unchanged; this is diagnostics only.
- This covers the **equipped-slot display** manifestation of the "invalid item" case in `docs/TODO.md`'s runtime error catalog — a separate, sibling PR in this same batch covers the field/battle Item-menu's own **inventory-list-filtering** manifestation (`Game::Party#field_items`/`#battle_items`).

## Test plan

- [x] Added two new `scripts/rpg2k_scene_check.rb` checks (one per screen): a fixture actor equips a dangling item id, and each check asserts the `[RPG2k]` diagnostic fires exactly once — across construction and several window rebuilds — while the `"Item #<id>"` placeholder still renders.
- [x] `ruby scripts/rpg2k_scene_check.rb` — all 561 checks pass.
- [x] Updated `docs/TODO.md`'s runtime error catalog with a new ✅ entry for this manifestation.
- [x] Added a `changelog.d/equip-status-missing-item-id.fixed.md` fragment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPNoHfsNTHu6moU1gALbG)_