### PR TITLE
Round the RPG2003 fatigue condition to even on an exact tie

### DIFF
--- a/changelog.d/rpg2k-fatigue-round-half-even.fixed.md
+++ b/changelog.d/rpg2k-fatigue-round-half-even.fixed.md
@@ -1,0 +1,9 @@
+- **The RPG2003 party `fatigue` condition now rounds an exact tie to the
+  nearest even whole percent**, instead of always rounding up. Confirmed
+  against EasyRPG Player's source: its rounding helper uses the default IEEE
+  754 rounding mode, which rounds an exact `.5` to the nearest even integer
+  (banker's rounding), not up. A single ally at max HP 16 / current HP 3 with
+  no SP computes exactly 12.5 before rounding — EasyRPG lands on 12, this
+  engine's round-half-up previously landed on 13, one point apart on the
+  `fatigue` page condition / RPG2003 enemy-AI threshold at that exact
+  boundary.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5199,6 +5199,30 @@ not yet verified:
   independently of each other, and a compound skill's stat-mod effect landing
   on its own roll while its HP effect misses on a different one), each
   confirmed to fail against the pre-fix code before the fix.
+- ✅ **`Game::Battle#fatigue` (the RPG2003 `fatigue` page condition) now
+  rounds an exact tie to the nearest *even* whole percent, not always up.**
+  A prior version of this method's own comment claimed it used "the same
+  round-half-up the C++ does" — checked directly against EasyRPG's actual
+  `Game_Party::GetFatigue` (`src/game_party.cpp`) rather than that assumption:
+  it computes the ratio as a float, then rounds through `Utils::RoundTo<int>`
+  (`src/utils.h`), which calls `std::lrint` — under the default IEEE 754
+  `FE_TONEAREST` rounding mode (nothing in EasyRPG's source changes it),
+  `lrint` rounds an exact `.5` to the nearest *even* integer (banker's
+  rounding), not up. A single ally at max HP 16 / current HP 3 with no SP
+  (the SP term forced to a 1-denominator per the method's own existing
+  divide-by-zero guard) computes exactly 12.5 before rounding: EasyRPG lands
+  on 12 (already even), this method's round-half-up landed on 13 — one point
+  apart on the `fatigue` page condition / RPG2003 enemy-AI `COND_FATIGUE`
+  threshold at that exact boundary. Fixed with a new `Game.round_half_even`
+  (integer `num`/`den` arithmetic: compare `2 * remainder` against the
+  denominator, and break an exact tie toward whichever quotient is even),
+  replacing the method's own hand-rolled round-half-up integer trick.
+  Every existing `#fatigue` test computes a ratio that isn't an exact `.5`
+  tie, so none of them change. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks (the real 12.5-tie `#fatigue` case
+  landing on 88 rather than 87, and four direct `Game.round_half_even`
+  cases spanning an even tie, an odd tie, and two ordinary non-tie
+  fractions), confirmed to fail against the pre-fix code before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -485,6 +485,20 @@ module Game
     v
   end
 
+  # round(num.to_f / den), banker's rounding (ties go to the nearest *even*
+  # integer, not always up) -- integer arithmetic standing in for C's
+  # `std::lrint` under the default IEEE 754 `FE_TONEAREST` rounding mode,
+  # which is round-half-to-even, not round-half-up. `num`/`den` are both
+  # non-negative (every caller's own numerator/denominator are sums/products
+  # of non-negative game values); `den` must be positive.
+  def self.round_half_even(num, den)
+    q, r = num.divmod(den)
+    twice_r = 2 * r
+    return q if twice_r < den
+    return q + 1 if twice_r > den
+    q.even? ? q : q + 1
+  end
+
   # RPG2000 transparency (0 opaque .. 100 fully clear) -> a 0..255 opacity.
   # Shared by Interpreter#trans_to_opacity (Show/Move Picture's live param) and
   # Game::State.restore_pictures (the save's chunk 103 field 34), which use the
@@ -7445,9 +7459,20 @@ module Game
     # The party's exhaustion, 0 (untouched) to 100 (wiped out) — the RPG2003
     # `fatigue` page condition. Ported from EasyRPG's Game_Party::GetFatigue:
     # HP is two thirds of the weight and SP one third, so a party at full HP with
-    # no SP left still only reaches 33. Written in integer arithmetic (mruby has
-    # no rounding helper here) with the same round-half-up the C++ does; an
-    # SP-less party divides by 1 rather than 0, exactly as the original notes.
+    # no SP left still only reaches 33. An SP-less party divides by 1 rather
+    # than 0, exactly as the original notes.
+    #
+    # Written in integer arithmetic (mruby has no rounding helper here) with
+    # round-half-**to-even**, not round-half-up: EasyRPG's own
+    # `Utils::RoundTo<int>` calls `std::lrint`, which under the default IEEE
+    # 754 rounding mode (`FE_TONEAREST`, which nothing in EasyRPG's source
+    # changes) rounds an exact `.5` to the nearest *even* integer, not always
+    # up. A single ally at max_hp 16 / hp 3 with no SP (total_sp forced to 1)
+    # computes exactly 12.5 before rounding -- EasyRPG rounds that to 12
+    # (even), this method used to round it to 13 (a prior version's comment
+    # incorrectly assumed C rounds `.5` up), landing the `fatigue` page
+    # condition/enemy AI threshold one point apart at that exact boundary
+    # (88 vs 87).
     def fatigue
       return 0 if @allies.empty?
       hp = 0; total_hp = 0; sp = 0; total_sp = 0
@@ -7461,7 +7486,7 @@ module Game
       total_sp = 1 if total_sp <= 0
       num = 100 * (2 * hp * total_sp + sp * total_hp)
       den = 3 * total_hp * total_sp
-      100 - (2 * num + den) / (2 * den)
+      100 - Game.round_half_even(num, den)
     end
 
     # The `command_actor` page condition (which battle command an actor just

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11841,6 +11841,24 @@ check 'Battle#fatigue weights HP two thirds and SP one third' do
   eq 100, b2.fatigue
 end
 
+check 'Battle#fatigue rounds an exact tie to even, not always up' do
+  # EasyRPG's Utils::RoundTo<int> is std::lrint under the default IEEE 754
+  # FE_TONEAREST mode -- round-half-to-*even*, not round-half-up. max_hp 16,
+  # hp 3, no SP (total_sp forced to 1) computes exactly 12.5 before rounding:
+  # EasyRPG rounds to 12 (already even), landing fatigue at 88, not 87.
+  tied = combatant('Hero', 10, 0, 10, 16)
+  tied.hp = 3
+  b = Game::Battle.new([tied], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1))
+  eq 88, b.fatigue, '100 - round(12.5) = 100 - 12 (even), not 100 - 13'
+end
+
+check 'Game.round_half_even rounds a tie to the nearest even integer' do
+  eq 12, Game.round_half_even(25, 2), '12.5 -> 12 (already even)'
+  eq 14, Game.round_half_even(27, 2), '13.5 -> 14, not 13 (odd ties round up)'
+  eq 10, Game.round_half_even(31, 3), '10.333... is not a tie -> plain round-down'
+  eq 11, Game.round_half_even(32, 3), '10.666... is not a tie -> plain round-up'
+end
+
 check 'the fatigue page condition tests the window' do
   hero = combatant_mp('Hero', 10, 0, 10, 100, 50)
   b = Game::Battle.new([hero], [combatant('Slime', 5, 0, 5, 10)], Game::Rng.new(1))


### PR DESCRIPTION
## Summary
- `Game::Battle#fatigue`'s own comment claimed it used "the same round-half-up the C++ does" — checked directly against EasyRPG's actual `Game_Party::GetFatigue` (`src/game_party.cpp`) rather than that assumption: it rounds through `Utils::RoundTo<int>`, which calls `std::lrint`. Under the default IEEE 754 `FE_TONEAREST` rounding mode (nothing in EasyRPG's source changes it), `lrint` rounds an exact `.5` to the nearest even integer (banker's rounding), not up.
- A single ally at max HP 16 / current HP 3 with no SP computes exactly 12.5 before rounding: EasyRPG lands on 12 (already even), this method's round-half-up landed on 13 — one point apart on the `fatigue` page condition / RPG2003 enemy-AI `COND_FATIGUE` threshold at that exact boundary.
- Fixed with a new `Game.round_half_even` (integer `num`/`den` arithmetic: compare `2*remainder` against the denominator, breaking an exact tie toward whichever quotient is even), replacing the method's own hand-rolled round-half-up integer trick. Every existing `#fatigue` test computes a ratio that isn't an exact `.5` tie, so none of them change.

## Test plan
- [x] Two new `scripts/rpg2k_logic_check.rb` checks (the real 12.5-tie `#fatigue` case landing on 88 rather than 87, and four direct `Game.round_half_even` cases spanning an even tie, an odd tie, and two ordinary non-tie fractions), confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_