### PR TITLE
Wire up terrain footstep SE and on_damage_se (RPG2003)

### DIFF
--- a/changelog.d/terrain-footstep-se.added.md
+++ b/changelog.d/terrain-footstep-se.added.md
@@ -1,0 +1,8 @@
+- **Terrain footstep SE**: the database terrain fields `footstep` and
+  `on_damage_se` (parsed since the terrain chunk was first decoded, never
+  read) are wired up, matching EasyRPG's `Game_Player::Move` exactly — the
+  footstep SE is RPG2003-only, and `on_damage_se` turns it from an ordinary
+  per-step sound into one that only plays on a step that actually dealt
+  terrain damage. `Scene::Map#play_terrain_footstep_se`
+  (`mruby-rpg2k/mrblib/scene/map.rb`) plays it from the same `#terrain_row_at`
+  lookup `#note_party_step` already made for the terrain damage tick.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8740,6 +8740,26 @@ the now-dangling tile, and asserts the diagnostic fires exactly once (not
 once per the two call sites that both read the same landed-on tile in a
 single step, and not again on further re-queries of the same tile) while
 terrain damage/bush depth both fall back to their harmless defaults.
+✅ **Terrain's `footstep` and `on_damage_se` fields (chunk 16 elements 15/16)
+are wired up** — parsed by `mruby-lcf/mrblib/schema.rb` since the terrain
+chunk was first decoded (ADR 0034) but never read by the runtime;
+`scripts/rpg2k_field_audit.rb`'s `NOT_OURS` table used to list `footstep` as
+out of scope for exactly that reason. Checked against a real
+`Game_Player::Move` (EasyRPG source, not guessed): the footstep SE is
+**RPG2003-only** — gated on `Player::IsRPG2k3()`, so an RPG2000 database never
+plays one no matter what the field holds — and `on_damage_se` does not gate
+whether the terrain's own damage tick plays a sound; it repurposes `footstep`
+itself, from an ordinary per-step ambient sound into a damage-tick-only one
+(`!terrain->on_damage_se || red_flash`, where `red_flash` is "this step's
+terrain damage actually hit someone"). `Scene::Map#play_terrain_footstep_se`
+(`mruby-rpg2k/mrblib/scene/map.rb`) reproduces both rules, called from
+`#note_party_step` right alongside `#terrain_step_damage` — the same
+`#terrain_row_at` lookup that call site already made for the damage tick is
+now passed to both rather than queried twice. Covered by three new
+`scripts/rpg2k_scene_check.rb` checks: an RPG2003 fixture's footstep SE
+firing once per tile walked; an RPG2000 fixture never playing one even when
+the field is set; and an RPG2003 fixture with `on_damage_se` set staying
+silent on a harmless tile while playing on every tile of a damaging one.
 ✅ **A dangling chipset id no longer renders a map blank and fully passable
 with no trace** — the "chipset" case from the "invalid hero, skill, item,
 enemy, enemy group, battle animation, terrain, chipset, common event" list

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -8555,17 +8555,44 @@ class RPG2k
         # onto belongs to may take HP off everyone not wearing gear that blocks
         # it. Read after the status slip and flashed together, since both are the
         # same "your HP just fell and the map has nowhere to say so" moment.
-        hit = hit + terrain_step_damage
+        row = terrain_row_at(@state.x, @state.y)
+        terrain_hit = terrain_step_damage(row)
+        hit = hit + terrain_hit
+        play_terrain_footstep_se(row, !terrain_hit.empty?)
         return if hit.empty?
         @state.screen.flash(*STEP_DAMAGE_FLASH)
       end
 
       # Apply the damage of the terrain under the party, returning the actors it
       # hit ([] when the tile is harmless or the database has no terrain table).
-      def terrain_step_damage
-        row = terrain_row_at(@state.x, @state.y)
+      # `row` defaults to a fresh #terrain_row_at lookup so existing callers
+      # (and the diagnostic dedup test, which calls this indirectly through a
+      # step) keep working; #note_party_step passes its own already-looked-up
+      # row instead of asking #terrain_row_at a second time for the same tile.
+      def terrain_step_damage(row = terrain_row_at(@state.x, @state.y))
         return [] unless row && row.respond_to?(:damage)
         @state.party.apply_terrain_damage(row.damage)
+      end
+
+      # RPG2003's 歩行音 (footstep SE): EasyRPG's `Game_Player::Move` plays
+      # `terrain->footstep` right after applying that step's terrain damage,
+      # gated on `Player::IsRPG2k3()` -- RPG2000 never plays it at all, which
+      # is why `scripts/rpg2k_field_audit.rb`'s `NOT_OURS` table used to list
+      # `footstep` as out of scope; wiring it here (RPG2003-gated, matching
+      # real behaviour) is what retires that entry. `on_damage_se` repurposes
+      # the same field: when set, `footstep` only plays on a step that actually
+      # damaged someone (EasyRPG's `!terrain->on_damage_se || red_flash`),
+      # turning it from an ambient step sound into the terrain's own damage-tick
+      # SE instead of playing on every ordinary step onto that terrain.
+      def play_terrain_footstep_se(row, damaged)
+        return unless @db.respond_to?(:rpg2003?) && @db.rpg2003?
+        return unless row && row.respond_to?(:footstep) && row.respond_to?(:on_damage_se)
+        return if row.on_damage_se && !damaged
+        name = row.footstep
+        return if name.nil? || name.empty?
+        RGSS::Audio.se_play(name)
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] Terrain: footstep SE playback failed: #{e.message}"
       end
 
       # -- Random ("wandering monster") encounters -----------------------------

--- a/scripts/rpg2k_field_audit.rb
+++ b/scripts/rpg2k_field_audit.rb
@@ -65,8 +65,6 @@ NOT_OURS = {
                   'attacker; both test beds fill both fields with the same two ' \
                   'strings, so the data cannot settle it (ADR 0036)',
   enemy_critical: 'see actor_critical',
-  footstep: 'RPG2003 only — EasyRPG plays it from Game_Player::BeginMove ' \
-            'behind an IsRPG2k3() gate',
   hp_change_type: 'RPG2003 only — the schema marks it so, and RPG2000 has one ' \
                   'flat/percentage reading rather than a selector',
   sp_change_type: 'see hp_change_type',

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -298,7 +298,7 @@ end
 
 def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
             airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
-            rpg2003: false, menu_commands: nil)
+            rpg2003: false, menu_commands: nil, footstep: '', on_damage_se: false)
   OpenStruct.new(
     rpg2003?: rpg2003,
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
@@ -493,7 +493,8 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
     # airship checks) whether it may fly over / land on any tile.
     terrain: { 42 => OpenStruct.new(damage: terrain_damage, bush_depth: bush_depth,
                                     airship_land: airship_land, airship_pass: airship_pass,
-                                    boat_pass: boat_pass, ship_pass: ship_pass) },
+                                    boat_pass: boat_pass, ship_pass: ship_pass,
+                                    footstep: footstep, on_damage_se: on_damage_se) },
     common_event: common,
     # Database actor rows carry the *original* names, which a \N[n] must not
     # use once the actor has been renamed in play (see the \N[n] check).
@@ -695,10 +696,12 @@ end
 def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: nil,
               members: [], terrain_damage: 0, bush_depth: 0,
               airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
-              map_tree: nil, test_play: false, rpg2003: false)
+              map_tree: nil, test_play: false, rpg2003: false,
+              footstep: '', on_damage_se: false)
   db = fake_db(common, troop_pages, terrain_damage, bush_depth,
                airship_land: airship_land, airship_pass: airship_pass,
-               boat_pass: boat_pass, ship_pass: ship_pass, rpg2003: rpg2003)
+               boat_pass: boat_pass, ship_pass: ship_pass, rpg2003: rpg2003,
+               footstep: footstep, on_damage_se: on_damage_se)
   state = Game::State.new(fake_party(members, rpg2003: rpg2003), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   parent = fake_parent(db)
@@ -12850,6 +12853,48 @@ check 'harmless ground takes nothing' do
   scene = new_scene({}, player: [0, 0], members: [hero])   # damage 0
   walk(scene, 4)
   eq 100, hero.hp
+end
+
+# -- footstep SE (RPG2003 歩行音, ADR 0034 follow-up) --------------------------
+#
+# EasyRPG's Game_Player::Move plays terrain->footstep behind a
+# Player::IsRPG2k3() gate -- RPG2000 never plays it -- and on_damage_se
+# repurposes the same field into a damage-tick-only SE instead of an
+# ordinary per-step one: `!terrain->on_damage_se || red_flash`. See
+# #play_terrain_footstep_se's comment (mruby-rpg2k/mrblib/scene/map.rb).
+
+check 'RPG2003 terrain footstep plays every ordinary step onto that tile' do
+  RGSS::Audio.reset_se
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero], rpg2003: true, footstep: 'Step1')
+  walk(scene, 3)
+  eq 3, RGSS::Audio.se_calls.count { |c| c[0] == 'Step1' }, 'one footstep per tile walked'
+end
+
+check 'RPG2000 never plays a terrain footstep, even when one is set' do
+  RGSS::Audio.reset_se
+  hero = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [hero], rpg2003: false, footstep: 'Step1')
+  walk(scene, 3)
+  ok RGSS::Audio.se_calls.none? { |c| c[0] == 'Step1' },
+     'footstep is an RPG2003-only feature (EasyRPG gates it on Player::IsRPG2k3())'
+end
+
+check 'on_damage_se withholds the footstep on a harmless step, and plays it on a damaging one' do
+  RGSS::Audio.reset_se
+  harmless = SlipActor.new([])
+  scene = new_scene({}, player: [0, 0], members: [harmless], rpg2003: true,
+                     footstep: 'Hurt1', on_damage_se: true)   # terrain_damage 0 -> harmless
+  walk(scene, 2)
+  ok RGSS::Audio.se_calls.none? { |c| c[0] == 'Hurt1' },
+     'on_damage_se suppresses the footstep on a step that dealt no damage'
+
+  RGSS::Audio.reset_se
+  hurt = SlipActor.new([])
+  scene2 = new_scene({}, player: [0, 0], members: [hurt], rpg2003: true, terrain_damage: 3,
+                      footstep: 'Hurt1', on_damage_se: true)
+  walk(scene2, 2)
+  eq 2, RGSS::Audio.se_calls.count { |c| c[0] == 'Hurt1' }, 'and plays it on every step that does'
 end
 
 # -- bush depth (下半身消去) ---------------------------------------------------


### PR DESCRIPTION
## Summary

- The database terrain fields `footstep` (chunk 16 field 15) and
  `on_damage_se` (field 16) have been parsed by `mruby-lcf/mrblib/schema.rb`
  since the terrain chunk was first decoded (ADR 0034), but the runtime never
  read either one — `scripts/rpg2k_field_audit.rb`'s `NOT_OURS` table used to
  list `footstep` as out of scope for exactly that reason.
- Checked against EasyRPG's real `Game_Player::Move` rather than guessing:
  the footstep SE is **RPG2003-only** (gated on `Player::IsRPG2k3()` — an
  RPG2000 database never plays one, no matter what the field holds), and
  `on_damage_se` does **not** gate whether the terrain damage tick's own
  sound plays. Instead it repurposes `footstep` itself: from an ordinary
  per-step ambient sound into a damage-tick-only one
  (`!terrain->on_damage_se || red_flash`, where `red_flash` means "this
  step's terrain damage actually hit someone").
- `Scene::Map#play_terrain_footstep_se`
  (`mruby-rpg2k/mrblib/scene/map.rb`) reproduces both rules and is called
  from `#note_party_step` right alongside `#terrain_step_damage` — reusing
  the same `#terrain_row_at` lookup that call site already made for the
  damage tick, rather than querying it a second time.
- Dropped the now-stale `footstep` entry from `rpg2k_field_audit.rb`'s
  `NOT_OURS` table, since the field is genuinely read now.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 566 checks pass, including three
  new checks: an RPG2003 fixture's footstep SE firing once per tile walked;
  an RPG2000 fixture never playing one even when the field is set; and an
  RPG2003 fixture with `on_damage_se` set staying silent on a harmless tile
  while playing on every tile of a damaging one.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 835 checks pass (unaffected,
  run as a touched-adjacent sanity check).
- [x] `ruby scripts/rpg2k_field_audit.rb` — runs cleanly (no local game data
  to scan in this environment).
- [x] `docs/TODO.md` updated with a `✅` writeup next to the existing terrain
  diagnostic entry.
- [x] `changelog.d/terrain-footstep-se.added.md` fragment added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D6SEq22V1SBcBCzPsTAvot)_