### PR TITLE
Wire actor_critical / enemy_critical into the battle log

### DIFF
--- a/changelog.d/battle-log-critical-hit.added.md
+++ b/changelog.d/battle-log-critical-hit.added.md
@@ -1,0 +1,12 @@
+- **The battle log announces a critical hit in the game's own words.**
+  `actor_critical` / `enemy_critical` (「会心の一撃！！」 / 「痛恨の一撃！！」) were
+  held back by ADR 0036 because which side keyed them was unclear from the two
+  test beds' data alone. Reading EasyRPG's actual `GetCriticalHitMessage`
+  settles it: the term is keyed on the **target** taking the crit, the same
+  rule `actor_damaged` / `enemy_damaged` already follow, not the attacker's
+  side the 会心 / 痛恨 wording suggests. `Game::States::BattleText.critical`
+  returns the bare term — no battler name in front of it, unlike every other
+  predicate here — and `battle_action_body` slots it between the start line
+  and the damage line, matching where RPG_RT prints it. A blank term is
+  all-or-nothing with the rest of the entry, falling back to the composed
+  English's existing `' (critical!)'` suffix. See ADR 0036's addendum.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1375,11 +1375,24 @@ The work below is roughly ordered by the critical path to a walkable game
   filling both pools says so once per pool. An item that did nothing keeps the
   composed wording, since unlike a skill it has no `failure_message` to pick a
   sentence with.
-  Still held back on purpose: the **critical** line is left alone
-  because which side keys `actor_critical` / `enemy_critical` is genuinely
-  unclear — EasyRPG picks `actor_critical` when the *target* is an ally, while
-  会心 / 痛恨 read as the *attacker's* side, and both games fill both fields with
-  the same two strings so the data cannot settle it.
+  **The critical-hit line is wired in now too.** ADR 0036 held `actor_critical` /
+  `enemy_critical` (「会心の一撃！！」 / 「痛恨の一撃！！」) back because which side
+  keys them was genuinely unclear from the test-bed data alone — both games fill
+  both fields with the same two strings. Reading EasyRPG's actual source settles
+  it: `GetCriticalHitMessage` (`src/game_message_terms.cpp`) keys on the
+  **target** taking the crit — `target.GetType() == Type_Ally ? actor_critical :
+  enemy_critical` — the same rule `actor_damaged` / `enemy_damaged` already
+  follow, not the attacker's side the words themselves suggest.
+  `Game::States::BattleText.critical` (`game.rb`) returns the bare term with no
+  battler name in front of it, unlike every other predicate here, and
+  `battle_action_body` (`scene/map.rb`) slots it in between the start line and
+  the damage line — matching where RPG_RT's own
+  `Scene_Battle_Rpg2k::ProcessBattleActionCritical` runs, before
+  `ProcessBattleActionApply`: 「スライムの攻撃！」, 「会心の一撃！！」, 「リトは 21
+  のダメージを受けた！」. A blank term is all-or-nothing with the rest of the
+  entry, same as every other field here — the composed English fallback already
+  carried its own `' (critical!)'` suffix (`battle_action_line`), so nothing is
+  lost by falling back whole.
   The **field windows show a condition too** — the menu party list, the item and
   skill target lists and the status screen (a labelled row of its own), which are
   the three RPG_RT draws one in (`Window_MenuStatus`, `Window_ActorTarget`,

--- a/docs/adr/0036-battle-log-in-the-games-own-words.md
+++ b/docs/adr/0036-battle-log-in-the-games-own-words.md
@@ -185,3 +185,53 @@ that filled both, an item that restored HP, one that only cured — where the st
 sentence carries it — and one that did nothing) and by
 `scripts/rpg2k_testbed_logic_check.rb`, which builds both lines out of each real
 term table.
+
+## Addendum: the critical-hit line
+
+Date: 2026-08-15
+
+The base decision held `actor_critical` / `enemy_critical` back because which
+side keys them looked unsettleable from the test-bed data: both games fill both
+fields with the same two strings, so no fixture could distinguish "keyed on the
+target" from "keyed on the attacker."
+
+Reading EasyRPG's actual source resolves it. `BattleMessage::GetCriticalHitMessage`
+(`src/game_message_terms.cpp`, called from
+`Scene_Battle_Rpg2k::ProcessBattleActionCritical`) reads:
+
+```cpp
+std::string_view message = (target.GetType() == Game_Battler::Type_Ally)
+    ? std::string_view(lcf::Data::terms.actor_critical)
+    : std::string_view(lcf::Data::terms.enemy_critical);
+```
+
+Keyed on the **target** taking the crit — `actor_critical` when a party member
+is on the receiving end, `enemy_critical` when an enemy is — the same rule
+`actor_damaged` / `enemy_damaged` already follow in this file. The 会心 / 痛恨
+naming reads backwards from that (会心 as "your" blow, 痛恨 as one landing on
+you), which is exactly the trap the base decision declined to guess through.
+
+The message itself is a bare term: the CP932 (non-placeholder) branch of
+`GetCriticalHitMessage` returns the field with no battler name in front of it,
+the one predicate in this whole table that stands alone rather than following a
+name. `Scene_Battle_Rpg2k::ProcessBattleActionCritical` also runs before
+`ProcessBattleActionApply`, so RPG_RT prints it *between* the start line and the
+damage line: 「スライムの攻撃！」, 「会心の一撃！！」, 「リトは 21 のダメージを受け
+た！」.
+
+`Game::States::BattleText.critical(terms, target_ally)` (`game.rb`) returns that
+bare term or nil, and `battle_action_body` (`scene/map.rb`) folds it into the
+same all-or-nothing shape as `start` / `result`: a blank `actor_critical` /
+`enemy_critical` drops the whole entry back to the composed English, which
+already carries its own `' (critical!)'` suffix (`battle_action_line`), so a
+blank term loses nothing.
+
+`actor_critical` / `enemy_critical` are dropped from `rpg2k_field_audit.rb`'s
+`NOT_OURS` table now that they are read.
+
+Covered by `scripts/rpg2k_logic_check.rb` (`BT.critical` keyed on the target,
+nil on a blank term), by `scripts/rpg2k_scene_check.rb` (a critical from each
+side reading the game's own line between the attack and the damage, and a blank
+critical term falling back to the composed English with its `(critical!)` note)
+and by `scripts/rpg2k_testbed_logic_check.rb`, which reads `actor_critical` /
+`enemy_critical` from each real term table.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -6949,6 +6949,22 @@ module Game
         action(terms, target_name, ally ? :actor_undamaged : :enemy_undamaged)
       end
 
+      # 「会心の一撃！！」 / 「痛恨の一撃！！」 — the extra line RPG_RT inserts
+      # between the start line and the damage line on a critical hit
+      # (`Scene_Battle_Rpg2k::ProcessBattleActionCritical`, which runs before
+      # `ProcessBattleActionApply`). No battler name goes in front of it: the
+      # 2k branch of EasyRPG's own `GetCriticalHitMessage` returns the bare term.
+      #
+      # ADR 0036 left this term unwired because which side keys it was
+      # ambiguous from the test-bed data alone. Reading EasyRPG's actual source
+      # (`GetCriticalHitMessage`, src/game_message_terms.cpp) settles it: `(target.
+      # GetType() == Type_Ally) ? terms.actor_critical : terms.enemy_critical` —
+      # keyed on the **target** taking the crit, the same way `actor_damaged` /
+      # `enemy_damaged` are, not on which side dealt it.
+      def self.critical(terms, target_ally)
+        term(terms, target_ally ? :actor_critical : :enemy_critical)
+      end
+
       # A miss. RPG2000 words it from the target's side ("...は身をかわした！"),
       # which is why one term serves both sides.
       def self.dodge(terms, target_name)

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5851,15 +5851,23 @@ class RPG2k
         t = db.respond_to?(:term) ? db.term : nil
         want_start = battle_start_field(e)
         want_result = battle_result_wanted?(e)
+        want_crit = e[:critical] ? true : false
         start = want_start && battle_start_line(t, e, want_start)
         result = want_result && battle_result_line(t, e)
+        crit = want_crit &&
+               Game::States::BattleText.critical(t, e[:target_ally] ? true : false)
         # All or nothing per entry: a half-translated line ("スライムの攻撃！"
         # with no damage sentence under it) reads worse than the composed
-        # English, so a blank term drops the whole entry back to the fallback.
+        # English, so a blank term drops the whole entry back to the fallback
+        # — which already carries the crit note itself (`battle_action_line`'s
+        # ' (critical!)' suffix), so a blank `actor_critical` / `enemy_critical`
+        # loses nothing by falling back whole.
         return [battle_action_line(e)] if (want_start && !start) ||
-                                          (want_result && !result)
+                                          (want_result && !result) ||
+                                          (want_crit && !crit)
         lines = []
         lines << start if start
+        lines << crit if crit
         lines << result if result
         lines.empty? ? [battle_action_line(e)] : lines
       end

--- a/scripts/rpg2k_field_audit.rb
+++ b/scripts/rpg2k_field_audit.rb
@@ -60,11 +60,6 @@ NOT_OURS = {
   message_affected: 'no known trigger — EasyRPG defines ' \
                     'GetStateAffectedMessage and never calls it from either ' \
                     'battle scene, so nothing pins when RPG_RT prints it',
-  actor_critical: 'side-keying unresolved — EasyRPG picks it when the ' \
-                  '*target* is an ally, while 会心 / 痛恨 read as keyed on the ' \
-                  'attacker; both test beds fill both fields with the same two ' \
-                  'strings, so the data cannot settle it (ADR 0036)',
-  enemy_critical: 'see actor_critical',
   footstep: 'RPG2003 only — EasyRPG plays it from Game_Player::BeginMove ' \
             'behind an IsRPG2k3() gate',
   hp_change_type: 'RPG2003 only — the schema marks it so, and RPG2000 has one ' \

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -13193,7 +13193,8 @@ BT = Game::States::BattleText
 FakeTerms = Struct.new(:attacking, :defending, :observing, :focus,
                        :autodestruction, :enemy_escape, :enemy_transform,
                        :enemy_damaged, :actor_damaged,
-                       :enemy_undamaged, :actor_undamaged, :dodge)
+                       :enemy_undamaged, :actor_undamaged, :dodge,
+                       :actor_critical, :enemy_critical)
 
 def fake_terms
   FakeTerms.new('の攻撃！', 'は身を守っている', 'は様子を見ている・・・',
@@ -13201,7 +13202,8 @@ def fake_terms
                 'は別のモンスターに変身した！',
                 'のダメージを与えた！', 'のダメージを受けた！',
                 'にダメージを与えられない！', 'はダメージを受けていない！',
-                'は身をかわした！')
+                'は身をかわした！',
+                '会心の一撃！！', '痛恨の一撃！！')
 end
 
 check 'an action line is the battler name and the term, nothing else' do
@@ -13235,14 +13237,28 @@ check 'a miss is worded from the target side, one term for both' do
   eq 'リトは身をかわした！', BT.dodge(t, 'リト')
 end
 
+# The critical-hit line is a bare term with no battler name in front — unlike
+# every predicate above, it stands alone the same way `using_message2` does —
+# and which term speaks is keyed on the *target* taking the crit, matching
+# `actor_damaged` / `enemy_damaged`'s own side rule (EasyRPG's
+# GetCriticalHitMessage: `target.GetType() == Type_Ally ? actor_critical :
+# enemy_critical`), not on which side dealt the blow.
+check 'a critical-hit line is the bare term, keyed on the target taking it' do
+  t = fake_terms
+  eq '会心の一撃！！', BT.critical(t, true), 'a party member took the crit'
+  eq '痛恨の一撃！！', BT.critical(t, false), 'an enemy took the crit'
+end
+
 # A database that leaves a battle term blank (an English release often does)
 # must not produce a half-sentence — the caller keeps its own wording instead.
 check 'a blank or missing term yields nil rather than a bare name' do
-  blank = FakeTerms.new('', '', '', '', '', '', '', '', '', '', '', '')
+  blank = FakeTerms.new('', '', '', '', '', '', '', '', '', '', '', '', '', '')
   eq nil, BT.action(blank, 'リト', :attacking)
   eq nil, BT.damage(blank, 'リト', 42, true)
   eq nil, BT.undamaged(blank, 'リト', true)
   eq nil, BT.dodge(blank, 'リト')
+  eq nil, BT.critical(blank, true)
+  eq nil, BT.critical(blank, false)
   eq nil, BT.action(nil, 'リト', :attacking), 'no term table at all'
   eq nil, BT.action(Struct.new(:nothing).new(0), 'リト', :attacking),
      'a table without the field'

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -341,6 +341,7 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                          enemy_undamaged: 'にダメージを与えられない！',
                          actor_undamaged: 'はダメージを受けていない！',
                          dodge: 'は身をかわした！',
+                         actor_critical: '痛恨の一撃！！', enemy_critical: '会心の一撃！！',
                          skill_failure_a: 'には効かなかった！',
                          skill_failure_b: 'は平気だった！',
                          skill_failure_c: 'は眠らなかった！',
@@ -10753,6 +10754,36 @@ check 'a blow that gets through for nothing says so' do
                      { attacker: 'Hero', target: 'Slime', damage: 0,
                        target_ally: false })
   eq ['Heroの攻撃！', 'Slimeにダメージを与えられない！'], lines
+end
+
+# A critical hit inserts the game's own 会心/痛恨 line between the attack and
+# the damage (Scene_Battle_Rpg2k::ProcessBattleActionCritical runs before
+# ProcessBattleActionApply), keyed on the target taking the crit like the
+# damage predicates themselves, not on which side dealt it.
+check 'a critical hit adds the game\'s own line between the attack and the damage' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Hero', target: 'Slime', damage: 42,
+                       critical: true, target_ally: false })
+  eq ['Heroの攻撃！', '会心の一撃！！', 'Slimeに 42 のダメージを与えた！'], lines
+end
+
+check 'and from the other side, the term keyed on the party member taking it' do
+  scene, = battle_at_command
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Slime', target: 'Hero', damage: 7,
+                       critical: true, target_ally: true })
+  eq ['Slimeの攻撃！', '痛恨の一撃！！', 'Heroは 7 のダメージを受けた！'], lines
+end
+
+check 'a blank critical term drops the whole entry back to the composed ' \
+      'wording, "(critical!)" included' do
+  scene, = battle_at_command
+  scene.db.term.enemy_critical = ''
+  lines = scene.send(:battle_action_lines,
+                     { attacker: 'Hero', target: 'Slime', damage: 42,
+                       critical: true, target_ally: false })
+  eq ['Hero hits Slime for 42 (critical!)'], lines
 end
 
 check 'the basic actions with no target are one line each' do

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -1177,6 +1177,14 @@ def check_terms(dir)
     ok foe.start_with?('スライムに '), 'a foe takes に'
     ok ally.start_with?('リトは '), 'one of yours takes は'
   end
+
+  return unless bt.term(terms, :actor_critical) && bt.term(terms, :enemy_critical)
+  check "#{name}: the critical-hit line is a bare term, keyed on the target" do
+    foe = bt.critical(terms, false)
+    ally = bt.critical(terms, true)
+    eq terms.enemy_critical, foe, 'an enemy taking the crit reads its own term'
+    eq terms.actor_critical, ally, 'a party member taking the crit reads its own term'
+  end
 end
 
 # Every skill and item names a battle animation, and until now none of them


### PR DESCRIPTION
## Summary

- Wires the database's `actor_critical` / `enemy_critical` 用語 terms into the battle log, replacing the hardcoded English `' (critical!)'` suffix in the *database-term* path (`battle_action_body`), which previously had no critical-hit handling at all.
- Resolves the side-keying ambiguity ADR 0036 explicitly left open: reading EasyRPG's actual `GetCriticalHitMessage` (`src/game_message_terms.cpp`) shows the term is keyed on the **target** taking the crit (`target.GetType() == Type_Ally ? actor_critical : enemy_critical`) — the same rule `actor_damaged` / `enemy_damaged` already follow in this codebase — not the attacker's side the 会心 / 痛恨 wording suggests. See the new addendum in `docs/adr/0036-battle-log-in-the-games-own-words.md`.
- `Game::States::BattleText.critical(terms, target_ally)` (`mruby-rpg2k/mrblib/game.rb`) returns the bare term (no battler name in front of it, unlike every other predicate in this table — matching EasyRPG's own 2k-branch composition).
- `battle_action_body` (`mruby-rpg2k/mrblib/scene/map.rb`) slots the critical line in **between** the start line and the damage line, matching where RPG_RT's `Scene_Battle_Rpg2k::ProcessBattleActionCritical` runs (before `ProcessBattleActionApply`): 「スライムの攻撃！」, 「会心の一撃！！」, 「リトは 21 のダメージを受けた！」.
- A blank `actor_critical` / `enemy_critical` term is all-or-nothing with the rest of the entry, same as every other field here — falling back to the composed-English path, which already carries its own `' (critical!)'` suffix (`battle_action_line`), so a blank-term database loses nothing.
- Drops `actor_critical` / `enemy_critical` from `scripts/rpg2k_field_audit.rb`'s `NOT_OURS` table now that they're read.

## Note on the task's suggested side-keying

The task that prompted this branch suggested keying the term on the *attacker's* side. I found ADR 0036 (and the matching entry in `rpg2k_field_audit.rb`'s `NOT_OURS`), which explicitly left this term unwired because a prior session found the side-keying "genuinely unclear" and could not settle it from the two test beds' data alone (both fill both fields with the same two strings). I fetched EasyRPG's actual source (`raw.githubusercontent.com/EasyRPG/Player/master/src/game_message_terms.cpp`) to settle it directly rather than guess, and it keys on the **target**, not the attacker — consistent with how `actor_damaged`/`enemy_damaged`/`actor_undamaged`/`enemy_undamaged` already work in this codebase. I implemented the target-keyed version rather than the attacker-keyed one the task suggested, since it matches the real engine.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 836 checks passed (new `BT.critical` coverage: keyed on the target, nil on a blank term).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 566 checks passed (new coverage: a critical from each side reading the game's own line between the attack and the damage; a blank critical term falling back to the composed English with its `(critical!)` note).
- [x] Added `actor_critical`/`enemy_critical` reads in `scripts/rpg2k_testbed_logic_check.rb` (runs against real `RPG_RT.ldb` test beds; no test-bed data available in this sandbox, so it reports "skipped" here — will run in CI).
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files) on all changed files — the `nixfmt` hook couldn't initialize offline in this sandbox (missing `cabal`), but no `.nix` files are touched by this change.

## Docs

- `docs/adr/0036-battle-log-in-the-games-own-words.md` — new addendum resolving the critical-hit line.
- `docs/TODO.md` — updated the "held back on purpose" note for the critical line to describe what's now wired.
- `changelog.d/battle-log-critical-hit.added.md` — new fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdU5j7cCH25tXh1RvfLMZ4)_