### PR TITLE
Round the escape-chance formula to even on an exact tie

### DIFF
--- a/changelog.d/rpg2k-escape-chance-round-half-even.fixed.md
+++ b/changelog.d/rpg2k-escape-chance-round-half-even.fixed.md
@@ -1,0 +1,8 @@
+- **The battle escape-chance formula now rounds an exact tie to the nearest
+  even whole percent**, instead of always rounding up — the same
+  rounding-mode gap the `fatigue` condition had. Confirmed against EasyRPG
+  Player's source: its rounding helper uses the default IEEE 754 rounding
+  mode, which rounds an exact `.5` to the nearest even integer, not up. A
+  party at average agility 200 against an enemy average of 101 computes the
+  ratio 50.5 exactly before rounding — EasyRPG lands on 50 (escape chance
+  100), this engine previously landed on 51 (escape chance 99).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5223,6 +5223,32 @@ not yet verified:
   landing on 88 rather than 87, and four direct `Game.round_half_even`
   cases spanning an even tie, an odd tie, and two ordinary non-tie
   fractions), confirmed to fail against the pre-fix code before the fix.
+- ✅ **`Game::Battle#compute_escape_chance` now rounds an exact tie to even
+  too, the same rounding-mode gap `#fatigue` had (immediately above).** This
+  method's own comment already correctly named the mechanism —
+  `Utils::RoundTo<int>` (`std::lrint`), cited as "RPG_RT / Delphi compatible
+  rounding" straight from EasyRPG's own doc comment on `Utils::RoundTo`
+  (`src/utils.h`, linking `delphibasics.co.uk/RTL.asp?Name=Round`) — but the
+  Ruby implementation still used `Float#round`, which rounds half *away from
+  zero*, not to even; Delphi's own `Round()` is documented banker's rounding,
+  the same IEEE 754 `FE_TONEAREST` behaviour `std::lrint` has by default. A
+  party at average agility 200 against an enemy average of 101 computes the
+  ratio `100*101/200 = 50.5` exactly: EasyRPG rounds to 50 (already even,
+  escape chance 100), the prior `.round` landed on 51 (escape chance 99).
+  This exact call was introduced earlier this session (escape chance's own
+  fix, matching EasyRPG's formula and average-agility semantics) before the
+  round-half-to-even insight existed — a real gap in the same bug class, not
+  something the fatigue fix already covered (only `#fatigue` uses it, not
+  `#compute_escape_chance`, until now). Fixed by reusing the same
+  `Game.round_half_even` helper, computed directly in integer arithmetic
+  (`Game.round_half_even(100 * ea, pa)`) rather than through
+  `(100.0 * ea / pa).round`, matching `#fatigue`'s own integer-native style.
+  Every existing `#escape_chance` test computes a ratio that isn't an exact
+  `.5` tie (the existing rounding-vs-truncation check is `100*10/7 =
+  142.857...`, nowhere near a tie), so none of them change. Covered by a new
+  `scripts/rpg2k_logic_check.rb` check (the 50.5-tie case above landing on
+  escape chance 100, not 99), confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -7648,10 +7648,21 @@ module Game
     # agility term, which RPG_RT computes in `float` and truncates on its
     # implicit int conversion -- the two nearby agility-ratio formulas round
     # differently in the reference itself, not just here.
+    #
+    # "Delphi compatible rounding" is banker's rounding -- ties go to the
+    # nearest *even* integer, not always up (`std::lrint` under the default
+    # IEEE 754 `FE_TONEAREST` mode; EasyRPG's own `Utils::RoundTo` doc
+    # comment cites Delphi's own `Round()`, which is documented as exactly
+    # this). A prior version of this method used Ruby's `Float#round`, which
+    # rounds half *away from zero* -- the same rounding-mode gap
+    # `Game::Battle#fatigue` had (see `Game.round_half_even`'s own comment) --
+    # so an exact `.5` ratio (e.g. party average agility 200, enemy average
+    # 101: `100*101/200 = 50.5` precisely) rounded up to 51 here instead of
+    # EasyRPG's 50, landing the escape chance one point off (99 vs 100).
     def compute_escape_chance
       pa = avg_agi(@allies)
       ea = avg_agi(@enemies)
-      base = pa > 0 ? (100.0 * ea / pa).round : 100
+      base = pa > 0 ? Game.round_half_even(100 * ea, pa) : 100
       Game.clamp(150 - base, 0, 100)
     end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8703,6 +8703,19 @@ check 'Battle#escape_chance rounds the agility ratio to the nearest percent' do
   eq 7, b.escape_chance, 'the ratio rounds to 143 before the 150 - x clamp'
 end
 
+check 'Battle#escape_chance rounds an exact tie to even, not always up' do
+  # Same rounding-mode gap Battle#fatigue had (see Game.round_half_even):
+  # Utils::RoundTo<int> is std::lrint under the default IEEE 754 FE_TONEAREST
+  # mode -- round-half-to-*even*, not round-half-up (`Float#round`'s own
+  # half-away-from-zero rule). Party average agility 200, enemy average 101:
+  # 100*101/200 = 50.5 exactly. EasyRPG rounds to 50 (already even) -> escape
+  # 150-50 = 100; round-half-up would land on 51 -> escape 99.
+  hero = combatant('Hero', 0, 0, 200, 10)
+  slime = combatant('Slime', 0, 0, 101, 10)
+  b = Game::Battle.new([hero], [slime], Game::Rng.new(1))
+  eq 100, b.escape_chance, '100 - round(50.5) = 100 - 50 (even), not 100 - 51'
+end
+
 check 'Battle#escape_chance is fixed at battle start, not re-derived per attempt' do
   # EasyRPG calls InitEscapeChance() exactly once, from Scene_Battle::Start;
   # TryEscape only ever adds +10 to that one starting value on a failure, and


### PR DESCRIPTION
## Summary
- `Game::Battle#compute_escape_chance`'s own comment already correctly named the mechanism — `Utils::RoundTo<int>` (`std::lrint`), cited as "RPG_RT / Delphi compatible rounding" straight from EasyRPG's own doc comment on `Utils::RoundTo` (`src/utils.h`, linking Delphi's `Round()`) — but the Ruby implementation still used `Float#round`, which rounds half *away from zero*, not to even. Delphi's `Round()` is documented banker's rounding, the same IEEE 754 `FE_TONEAREST` behaviour `std::lrint` has by default — the same gap `Game::Battle#fatigue` had (previous PR, #819).
- A party at average agility 200 against an enemy average of 101 computes the ratio `100*101/200 = 50.5` exactly: EasyRPG rounds to 50 (already even, escape chance 100), the prior `.round` landed on 51 (escape chance 99).
- Fixed by reusing `Game.round_half_even` (added in #819), computed directly in integer arithmetic (`Game.round_half_even(100 * ea, pa)`) rather than through `(100.0 * ea / pa).round`. Every existing `#escape_chance` test computes a ratio that isn't an exact `.5` tie, so none of them change.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check (the 50.5-tie case landing on escape chance 100, not 99), confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_