### PR TITLE
Add the real RPG2k Battle/Auto Battle/Escape options window

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@
   Show Hidden Monster, Change Battle Background, the battle Show Battle
   Animation, the battle Conditional Branch and Terminate Battle. A page whose
   condition box is entirely unticked never fires, which is how RPG_RT reads it
+- The **Battle/Auto Battle/Escape options window** shows automatically once at
+  the start of every fight, and reopens on B/Cancel landing on the first
+  commandable actor's command list. Battle opens the ordinary per-actor
+  command menu; Auto Battle hands every commandable living ally to the same
+  AI pick (`Game::Battle#choose_auto_battle_command`) a 強制AI-flagged actor
+  already used, so the round plays out with no further input; Escape rolls
+  the same agility-based escape chance either way. A party that is entirely
+  asleep/paralysed/forced or already Forced-AI'd skips the window, matching
+  real RPG_RT
 - **Status conditions show on the battle screen**, where until now they were only
   simulated — a poisoned hero and a healthy one looked identical. The status
   panel gained a condition column carrying the *significant* state (death first,

--- a/changelog.d/battle-options-window.added.md
+++ b/changelog.d/battle-options-window.added.md
@@ -1,0 +1,14 @@
+- Real RPG2k's **Battle/Auto Battle/Escape options window** is now modelled:
+  it shows automatically once at the very start of every fight, right after
+  the encounter/turn-0-event messages resolve, and reopens on B/Cancel
+  landing on the first commandable actor's command list -- replacing the
+  engine's old direct-B-press Escape shortcut. Battle falls through to the
+  ordinary per-actor command menu; Auto Battle queues
+  `Game::Battle#choose_auto_battle_command`'s AI pick (already used for
+  Forced-AI actors) for every commandable living ally and starts the round;
+  Escape reuses the existing escape-chance roll unchanged. A party entirely
+  restricted or Forced-AI'd bypasses the window, matching real RPG_RT's
+  `IsAnyControllable()` guard, and the window never reappears automatically
+  at round 2+. Uses the database's `battle_fight`/`battle_auto`/
+  `battle_escape` terms (schema fields 101/102/103), falling back to English.
+  Covered by new checks in `scripts/rpg2k_scene_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3270,7 +3270,7 @@ The work below is roughly ordered by the critical path to a walkable game
   visually sanity-checked with this engine's own build under Xvfb (no
   exception, no crash resuming into the map).
   **The `SelectPreviousActor()` question flagged above is now settled --
-  confirmed, not merely unconfirmed, and it is a real, concretely-shaped
+  confirmed, not merely unconfirmed, and it was a real, concretely-shaped
   gap, not just an SE nuance.** Traced verbatim: `SelectPreviousActor()`
   (`scene_battle_rpg2k.cpp`), when the actor whose command list is open is
   `allies[0]` (the very first commandable member), does not attempt Escape
@@ -3285,21 +3285,51 @@ The work below is roughly ordered by the critical path to a walkable game
   substate calls `battle_message_window->Clear(); SetState(State_Select
   Option);` unconditionally. It does **not** reappear automatically at the
   start of round 2+; only those two triggers (battle start, and B-cancel
-  underflow from the first actor) reach it. Selecting Battle returns to
-  actor command selection; Auto Battle sets the whole party to an AI-driven
-  auto-battle mode for the round; only Escape runs the already-ported
-  `IsEscapeAllowed()` Buzzer-vs-Decision gate. B/Cancel does nothing while
-  this menu itself is open (no cancel handling in that state -- it is the
-  state machine's own root). **Not implemented, on purpose:** this needs an
-  actual Auto Battle AI mode built to have a real third option, which is a
-  meaningfully sized feature of its own (a full party-command-selection AI,
-  not a UI tweak), well beyond the scope of the system-SE pass that
-  surfaced this gap -- attempting a 2-option (Battle/Escape) stand-in
-  without a genuine Auto Battle behind it would either mislead a player
-  familiar with real RPG2k or need its own separate design decision about
-  what "Auto Battle" should even mean here first. Left as a real, sized,
-  and now fully evidenced gap for whoever picks up battle-flow work next,
-  rather than a vague "battle screen might have more gaps" note.
+  underflow from the first actor) reach it.
+- ✅ **The Battle/Auto Battle/Escape options window itself is now
+  implemented**, closing the gap the paragraph above traced but left open
+  "for whoever picks up battle-flow work next." What had blocked it --
+  Auto Battle needing "an actual Auto Battle AI mode built to have a real
+  third option, which is a meaningfully sized feature of its own" -- turned
+  out to already exist for an unrelated use case: `Game::Battle
+  #choose_auto_battle_command` (a faithful port of EasyRPG's default
+  `AutoBattle::RpgRtCompat` algorithm), added earlier to auto-decide a
+  single 強制AI-flagged actor's turn without ever opening its manual command
+  window. "Auto Battle" from the options window just calls that same method
+  for every commandable living ally instead of one, so no new AI engine was
+  actually needed once that port existed -- only the window and its wiring.
+  `Scene::Map` gets a new `:battle_options` sub-state (`#drive_battle_
+  options`/`#draw_battle_options`, reusing the per-actor command window's own
+  rect and drawing convention) wired at both real triggers: automatically
+  once per battle (`#enter_command_phase`, replacing the direct
+  `#open_next_command` call that `#open_battle` and the between-rounds-event
+  return path used, gated by a fresh `options_shown` flag so round 2+ never
+  re-shows it) and on B/Cancel landing on the first commandable actor's
+  command list (`#drive_battle_command`'s `prev_i.nil?` branch, which used
+  to attempt Escape directly -- now calls `#open_battle_options` instead,
+  matching `SelectPreviousActor()`'s own `SetState(State_SelectOption)`
+  exactly, with the same unconditional Cancel SE either branch already
+  played). A party entirely asleep/paralysed/forced or already Forced-AI'd
+  bypasses the window straight to the ordinary command flow the same way
+  real RPG_RT's `IsAnyControllable()` guard does, since neither Battle nor
+  Auto Battle would have anything left to act on. Selecting Battle falls
+  through to the ordinary per-actor command menu (via `#open_next_command`,
+  not a direct draw, so a restricted/Forced-AI leading actor is still
+  skipped the same way the normal flow always skips it); Auto Battle queues
+  every commandable living ally's AI pick and starts the round with no
+  further input, exactly like a lone Forced-AI actor already did; Escape
+  reuses `#try_battle_escape` verbatim, unchanged from the direct-B-press
+  path it replaces. B/Cancel is a no-op while the window itself is open --
+  it is the state machine's own root, matching source exactly. The
+  `battle_fight`/`battle_auto`/`battle_escape` database terms (schema fields
+  101/102/103, decoded but unread before this) supply the row labels, with
+  the same English-fallback convention every other battle-command label in
+  this file already follows. Covered in `scripts/rpg2k_scene_check.rb`: the
+  window's automatic once-per-battle appearance, its absence at round 2+,
+  B-cancel reopening it instead of escaping directly, Battle/Auto
+  Battle/Escape each dispatching correctly (including the Escape-forbidden
+  Buzzer, which now leaves the window open rather than the old command
+  menu), and B/Cancel's no-op while it is open.
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an
   SDL_mixer backend (`src/sdl_audio.cxx`), resolving names under
   `Music/`/`Sound/`/`Audio/*`

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4341,6 +4341,7 @@ class RPG2k
         update_enemy_flashes
         update_enemy_positions
         case @battle_ui[:phase]
+        when :battle_options then drive_battle_options
         when :command     then drive_battle_command
         when :target      then drive_battle_target
         when :skill       then drive_battle_skill
@@ -4381,6 +4382,12 @@ class RPG2k
         situations = db.respond_to?(:situation) ? db.situation : nil
         properties = db.respond_to?(:property) ? db.property : nil
         @battle_ui = { phase: :command, req: req, troop: troop, owner: owner,
+                       # Whether the Battle/Auto Battle/Escape options window
+                       # has already shown its once-per-battle automatic
+                       # appearance (see #enter_command_phase) -- distinct
+                       # from `opt`, the cursor row inside it whenever it is
+                       # open (set fresh by #open_battle_options each time).
+                       options_shown: false, opt: 0,
                        battle: Game::Battle.new(allies, foes, @rng,
                                                 situations, true, true, true,
                                                 req[:first_strike] ? true : false,
@@ -4429,7 +4436,7 @@ class RPG2k
         # Turn-0 pages fire before the party is asked for its first command —
         # this is where a troop's opening dialogue lives.
         return if run_battle_events
-        settle_already_finished_battle || open_next_command
+        settle_already_finished_battle || enter_command_phase
       end
 
       # An encounter can start already decided — an empty party (every member
@@ -4932,31 +4939,154 @@ class RPG2k
         elsif Input.trigger?(Input::C)
           select_battle_command
         elsif Input.trigger?(Input::B)
+          # `ProcessSceneActionCommand`'s own B/Cancel branch plays Cancel
+          # unconditionally, *before* deciding where it lands: `...Cancel...;
+          # --actor_index; SelectPreviousActor();`. `SelectPreviousActor()`
+          # itself is what branches on whether an earlier commandable ally
+          # is left to re-command.
+          play_system_se(SFX_CANCEL)
           prev_i = prev_commandable_actor_index
           if prev_i.nil?
-            # Real RPG2k's B here reopens a Fight/Auto Battle/Escape options
-            # window this engine never modelled (Escape is instead a direct
-            # B-press on the first actor, a deliberate simplification) --
-            # confirmed against EasyRPG's own ProcessSceneActionCommand's
-            # Escape branch, whose disallowed case plays Buzzer rather than
-            # nothing at all: `case Escape: if (!IsEscapeAllowed()) {
-            # ...Buzzer... } else { ...Decision...; SetState(State_Escape) }`.
-            if @battle_ui[:req][:allow_escape]
-              play_system_se(SFX_DECISION)
-              try_battle_escape
-            else
-              play_system_se(SFX_BUZZER)
-            end
+            # `SelectPreviousActor()`'s `allies[0] == active_actor` branch:
+            # the actor whose command list is open is already the first
+            # commandable member, so this reopens the Battle/Auto Battle/
+            # Escape options window (`SetState(State_SelectOption)`) rather
+            # than attempting Escape directly.
+            open_battle_options
           else
-            # Re-commanding the previous actor is a plain Cancel, matching
-            # `ProcessSceneActionCommand`'s own B branch exactly: `...Cancel...;
-            # --actor_index; SelectPreviousActor();`.
-            play_system_se(SFX_CANCEL)
+            # Re-commanding the previous actor is the ordinary case.
             @battle_ui[:actor_i] = prev_i # re-command the previous commandable member
             @battle_ui[:cmd] = 0
             draw_battle_command
           end
         end
+      end
+
+      # The Battle/Auto Battle/Escape options window's own menu rows, in
+      # display order (top to bottom, matching real RPG2k's
+      # `battle_options`/`Window_Command` build). `battle_fight`/
+      # `battle_auto`/`battle_escape` are the database's Term fields
+      # 101/102/103 -- decoded by the schema but never read before this.
+      def battle_option_rows
+        [
+          { label: term(:battle_fight, 'Fight'), action: :battle },
+          { label: term(:battle_auto, 'Auto Battle'), action: :auto_battle },
+          { label: term(:battle_escape, 'Escape'), action: :escape }
+        ]
+      end
+
+      # Whether any living ally could actually be handed a manual command
+      # this round -- EasyRPG's own `IsAnyControllable()` guard inside
+      # `ProcessSceneActionFightAutoEscape`, which skips the options window
+      # entirely (straight to actor selection) when the whole party is
+      # asleep/paralysed/similarly restricted or already flagged for auto
+      # battle, since neither Battle nor Auto Battle would have anything left
+      # to act on. `Game_Actor::IsControllable()` is exactly this pair of
+      # checks: `GetSignificantRestriction() == Restriction_normal &&
+      # !GetAutoBattle()`.
+      def any_commandable_ally?
+        battle = @battle_ui[:battle]
+        living_allies.any? { |a| !battle.command_restricted?(a) && !force_ai_actor?(a) }
+      end
+
+      # The command phase's first entry for this battle only -- opens the
+      # options window once, automatically, the way `ProcessSceneActionStart`'s
+      # final substate does unconditionally after the encounter/turn-0-event
+      # messages resolve (`battle_message_window->Clear();
+      # SetState(State_SelectOption);`). Every later re-entry into the command
+      # phase this battle (round 2+, back from a between-rounds battle event
+      # page) goes straight to the ordinary per-actor command window instead --
+      # the window's *other* trigger, B/Cancel on the first commandable actor,
+      # is wired separately in #drive_battle_command and is not gated by this
+      # flag, matching `SelectPreviousActor()`'s own unconditional re-entry.
+      def enter_command_phase
+        if @battle_ui[:options_shown] || !any_commandable_ally?
+          @battle_ui[:options_shown] = true
+          open_next_command
+        else
+          @battle_ui[:options_shown] = true
+          open_battle_options
+        end
+      end
+
+      def open_battle_options
+        @battle_ui[:phase] = :battle_options
+        @battle_ui[:opt] = 0
+        draw_battle_options
+      end
+
+      # The options window's cursor menu -- Up/Down move the cursor, C
+      # confirms the highlighted row. B/Cancel is a deliberate no-op: this is
+      # the state machine's own root here (matching
+      # `ProcessSceneActionFightAutoEscape`'s `eWaitForInput` substate, which
+      # has no cancel handling at all -- there is no parent state to cancel
+      # back to).
+      def drive_battle_options
+        rows = battle_option_rows
+        if Input.trigger?(Input::DOWN)
+          @battle_ui[:opt] += 1
+          @battle_ui[:opt] %= rows.length
+          draw_battle_options
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::UP)
+          @battle_ui[:opt] -= 1
+          @battle_ui[:opt] %= rows.length
+          draw_battle_options
+          play_system_se(SFX_CURSOR)
+        elsif Input.trigger?(Input::C)
+          select_battle_option
+        end
+      end
+
+      # Act on the highlighted options-window row. Battle dismisses the
+      # window and falls through to the ordinary per-actor command menu,
+      # exactly where the battle already was before the window opened. Auto
+      # Battle hands the whole round to `#queue_auto_battle_round`. Escape
+      # reuses `#try_battle_escape` verbatim -- the same Decision-vs-Buzzer
+      # gate on `allow_escape` this engine's old direct-B-press shortcut
+      # already had, just triggered from the window instead.
+      def select_battle_option
+        case battle_option_rows[@battle_ui[:opt]][:action]
+        when :battle
+          play_system_se(SFX_DECISION)
+          @battle_ui[:phase] = :command
+          # `open_next_command`, not a direct `draw_battle_command` -- the
+          # window opening never advanced `actor_i` past a restricted/
+          # Forced-AI leading actor (matching real RPG_RT's own
+          # `SelectNextActor` doing that skip itself once `State_SelectActor`
+          # is entered from here, not before).
+          open_next_command
+        when :auto_battle
+          play_system_se(SFX_DECISION)
+          queue_auto_battle_round
+        when :escape
+          if @battle_ui[:req][:allow_escape]
+            play_system_se(SFX_DECISION)
+            try_battle_escape
+          else
+            play_system_se(SFX_BUZZER)
+          end
+        end
+      end
+
+      # "Auto Battle": every commandable living ally gets
+      # `Game::Battle#choose_auto_battle_command`'s AI pick queued for the
+      # round instead of the manual per-actor command menu -- the same
+      # engine `#skip_restricted_actors` already calls per-actor for a
+      # 強制AI-flagged ally (see `#force_ai_actor?`), just applied to the
+      # whole party at once rather than one actor. A restricted ally
+      # (asleep/paralysed/forced) is left alone exactly as the ordinary
+      # command phase already leaves it -- its round action is decided
+      # elsewhere, not by a queued command.
+      def queue_auto_battle_round
+        battle = @battle_ui[:battle]
+        living_allies.each do |a|
+          next if battle.command_restricted?(a)
+          battle.choose_auto_battle_command(a)
+        end
+        @battle_ui[:actor_i] = living_allies.length
+        @battle_ui[:phase] = :command
+        open_next_command
       end
 
       # Escape command (cancel on the first actor's menu): roll the party's
@@ -5748,7 +5878,7 @@ class RPG2k
           @battle_ui[:phase] = :animate
         else
           @battle_ui[:phase] = :command
-          open_next_command
+          enter_command_phase
         end
       end
 
@@ -6233,7 +6363,11 @@ class RPG2k
       def refresh_battle_status
         @battle_ui[:status_win].dispose if @battle_ui[:status_win]
         rows = @battle_ui[:allies].map { |a| battle_status_row(a) }
-        idx = @battle_ui[:allies].index(current_actor)
+        # No row highlighted while the options window is open -- matching
+        # `status_window->SetIndex(-1)` in `ProcessSceneActionFightAutoEscape`'s
+        # own `eMoveWindow` substate; nobody is "the acting actor" until
+        # Battle or Auto Battle is chosen.
+        idx = @battle_ui[:phase] == :battle_options ? nil : @battle_ui[:allies].index(current_actor)
         @battle_ui[:status_win] = battle_status_window(rows, idx)
       end
 
@@ -6279,6 +6413,29 @@ class RPG2k
         win.contents = c
         win.cursor_rect =
           Rect.new(0, @battle_ui[:cmd] * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
+        @battle_ui[:cmd_win] = win
+        refresh_battle_status
+      end
+
+      # The Battle/Auto Battle/Escape options window -- the same panel and
+      # rect the per-actor command window uses (only one of the two is ever
+      # on screen at a time), just with `#battle_option_rows`' three entries
+      # instead of the usual four.
+      def draw_battle_options
+        @battle_ui[:cmd_win].dispose if @battle_ui[:cmd_win]
+        labels = battle_option_rows.map { |r| r[:label] }
+        win = Window.new(BATTLE_STATUS_W, BATTLE_PANEL_Y, BATTLE_CMD_W, BATTLE_PANEL_H)
+        win.z = 320
+        win.windowskin = @windowskin
+        inner_w = BATTLE_CMD_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, BATTLE_PANEL_H - Window::BORDER * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        labels.each_with_index do |label, i|
+          c.draw_text 0, i * BATTLE_LINE_H, inner_w, BATTLE_LINE_H, label
+        end
+        win.contents = c
+        win.cursor_rect =
+          Rect.new(0, @battle_ui[:opt] * BATTLE_LINE_H, inner_w, BATTLE_LINE_H)
         @battle_ui[:cmd_win] = win
         refresh_battle_status
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5187,10 +5187,27 @@ def battle_attack_to_end(scene, max = 600)
   max.times do
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :result
-    RGSS::Input.triggered = [RGSS::Input::C] if ui && %i[command target].include?(ui[:phase])
+    # A pressed C on :battle_options picks the cursor's default row 0,
+    # "Battle" -- dismissing the once-per-battle automatic options window
+    # exactly the way a player who ignores Auto Battle/Escape would.
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && %i[command target battle_options].include?(ui[:phase])
     scene.update # a nil ui just means the battle is still opening
     RGSS::Input.triggered = []
   end
+end
+
+# Run `scene` until its battle UI's phase becomes `phase`, budgeted to `max`
+# frames -- used by the options-window checks below, which need to catch the
+# battle right when a phase first appears rather than run it through to a
+# later one the way #battle_attack_to_end does.
+def battle_until_phase(scene, phase, max = 15)
+  ui = nil
+  max.times do
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    break if ui && ui[:phase] == phase
+  end
+  ui
 end
 
 check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Victory' do
@@ -5582,18 +5599,110 @@ check 'Enemy Encounter scene: a game-over defeat returns to the title' do
   ok parent.game_over_shown, 'a game-over defeat puts up the Game Over screen'
 end
 
-check 'Enemy Encounter scene: Flee (B on the first actor) runs Escape' do
+# The real RPG2k Battle/Auto Battle/Escape options window (EasyRPG's
+# `scene_battle_rpg2k.cpp`, `State_SelectOption` /
+# `ProcessSceneActionFightAutoEscape`), traced verbatim in docs/TODO.md's
+# "SelectPreviousActor" writeup: shown automatically once per battle, right
+# after the encounter/turn-0-event messages resolve
+# (`ProcessSceneActionStart`'s final substate: unconditional
+# `SetState(State_SelectOption)`), and reopened whenever B/Cancel lands on
+# the very first commandable actor's command list
+# (`SelectPreviousActor()`'s `allies[0] == active_actor` branch), instead of
+# this engine's old direct-B-press Escape shortcut.
+
+check 'Enemy Encounter scene: the Battle/Auto Battle/Escape options window opens ' \
+      'automatically once at the very start of every fight' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_until_phase(scene, :battle_options)
+  ok ui, 'the battle opened'
+  eq :battle_options, ui[:phase], 'the options window shows before any per-actor command menu'
+  eq 0, ui[:opt], 'the cursor starts on the first row, Battle'
+  eq %w[Fight AutoBattle Escape].map { |s| s == 'AutoBattle' ? 'Auto Battle' : s },
+     scene.send(:battle_option_rows).map { |r| r[:label] },
+     'fake_db leaves the battle_fight/battle_auto/battle_escape terms blank, so these are ' \
+     'the composed English fallbacks'
+end
+
+check 'Enemy Encounter scene: B/Cancel does nothing while the options window is open' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_until_phase(scene, :battle_options)
+  eq :battle_options, ui[:phase]
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::B]
+  scene.update
+  RGSS::Input.triggered = []
+  eq :battle_options, ui[:phase], 'B/Cancel is a no-op here -- there is no parent state to cancel to'
+  eq 0, ui[:opt], 'the cursor did not move either'
+  eq [], RGSS::Audio.se_calls, 'and no SE played, matching a real cancel-into-nothing'
+end
+
+check 'Enemy Encounter scene: selecting Battle from the options window returns to the ' \
+      'ordinary per-actor command menu' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_until_phase(scene, :battle_options)
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # Battle -- the default cursor row 0
+  scene.update
+  RGSS::Input.triggered = []
+  eq :command, ui[:phase], 'Battle dismisses the window and opens the normal command menu'
+  eq 0, ui[:actor_i], 'still commanding the same first actor'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Decision1' }, 'choosing Battle plays Decision'
+end
+
+check "Enemy Encounter scene: B-cancel on the first commandable actor's command list " \
+      'reopens the options window instead of escaping directly' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_until_phase(scene, :battle_options)
+  RGSS::Input.triggered = [RGSS::Input::C] # dismiss via Battle first
+  scene.update
+  RGSS::Input.triggered = []
+  eq :command, ui[:phase]
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::B] # cancel on the very first actor
+  scene.update
+  RGSS::Input.triggered = []
+  eq :battle_options, ui[:phase],
+     'reopens the options window rather than attempting Escape directly, ' \
+     'the deliberate simplification this replaces'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Cancel1' },
+     'B always plays Cancel first, matching a real re-command, before landing on the window'
+end
+
+check 'Enemy Encounter scene: selecting Escape from the options window runs Escape, exactly ' \
+      'as the old direct-B shortcut did' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic, escape_mode: 2) # custom escape handler
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  2.times { scene.update } # the encounter runs, then the command menu opens
-  RGSS::Input.triggered = [RGSS::Input::B] # Flee (cancel on the first actor)
+  ui = battle_until_phase(scene, :battle_options)
+  2.times { RGSS::Input.triggered = [RGSS::Input::DOWN]; scene.update } # Fight -> Auto Battle -> Escape
+  RGSS::Input.triggered = []
+  eq 2, ui[:opt], 'the cursor landed on Escape'
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm Escape
   scene.update
   RGSS::Input.triggered = []
-  ui = scene.instance_variable_get(:@battle_ui)
   eq :result, ui[:phase], 'a successful flee shows the result window too, like a win or a loss'
   ok !st.switches[2], 'the Escape handler has not run yet -- the result is still up'
   RGSS::Input.triggered = [RGSS::Input::C] # dismiss the result
@@ -5603,6 +5712,60 @@ check 'Enemy Encounter scene: Flee (B on the first actor) runs Escape' do
   eq 0, st.party.gold, 'fleeing grants nothing'
   ok !st.switches[1], 'the Victory handler was skipped'
   ok st.switches[2], 'the Escape handler ran'
+end
+
+check 'Enemy Encounter scene: selecting Auto Battle queues the AI pick for every ' \
+      'commandable living ally and starts the round without further input' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, escape_mode: 2)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  st.party.instance_variable_set(:@actors, [BattleStubActor.new(id: 1), BattleStubActor.new(id: 2)])
+  ui = battle_until_phase(scene, :battle_options)
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # Fight -> Auto Battle
+  scene.update
+  RGSS::Input.triggered = []
+  eq 1, ui[:opt], 'the cursor landed on Auto Battle'
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm Auto Battle
+  scene.update
+  RGSS::Input.triggered = []
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Decision1' }, 'choosing Auto Battle plays Decision'
+  ok ui[:allies][0].action || ui[:allies][0].command,
+     "Game::Battle#choose_auto_battle_command queued the first ally's action"
+  ok ui[:allies][1].action || ui[:allies][1].command,
+     "and the second ally's too -- the whole party, not just one"
+  ok ui[:phase] != :command,
+     'the round started on its own -- no per-actor command menu was ever shown'
+end
+
+check 'Enemy Encounter scene: the options window does not reappear automatically at round 2+' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  # A tough hero the two Slimes cannot fell in one round, so the fight is
+  # still going once round 2 opens its own command phase.
+  st.instance_variable_set(:@party,
+                           BattleStubParty.new(BattleStubActor.new(atk: 1, hp: 500)))
+  ui = battle_until_phase(scene, :battle_options)
+  RGSS::Input.triggered = [RGSS::Input::C] # Battle
+  scene.update
+  RGSS::Input.triggered = []
+  eq :command, ui[:phase], 'round 1 command phase, options window already dismissed'
+  saw_options_again = false
+  40.times do
+    RGSS::Input.triggered = [RGSS::Input::C] if %i[command target].include?(ui[:phase])
+    scene.update
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = []
+    saw_options_again ||= ui && ui[:phase] == :battle_options
+    break if ui.nil? || ui[:phase] == :result
+  end
+  ok !saw_options_again, 'round 2 (and beyond) opens the command phase directly, never the options window'
 end
 
 check 'Enemy Encounter scene: a game-over defeat returns to the title' do
@@ -7992,9 +8155,15 @@ check 'Enemy Encounter scene: the round animates action by action, not at once' 
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  # Let the encounter open the per-actor command menu (it takes a frame or two).
+  # Let the encounter open the per-actor command menu (it takes a frame or two),
+  # dismissing the once-per-battle automatic options window (C on its default
+  # cursor row 0, "Battle") along the way.
+  ui = nil
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -8068,11 +8237,16 @@ class BattleCustomCommandParty < BattleMagicParty
   end
 end
 
-# Open a battle and step to the per-actor command menu.
+# Open a battle and step to the per-actor command menu, dismissing the
+# once-per-battle automatic Battle/Auto Battle/Escape options window along
+# the way (a C press on its default cursor row 0, "Battle").
 def battle_to_command(scene)
   ui = nil
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -8744,9 +8918,15 @@ check 'Scene::Map#update_enemy_positions: an RPG2003 fight actually bobs the spr
   member = ui[:troop].members[0]
   base_y = member.y - spr.bitmap.height / 2
   frame_before = ui[:frame]
-  # Drive to the next quarter-period boundary (a multiple of 64 frames) so the
-  # expected offset is an exact, easily-asserted +4 rather than a fraction.
-  target = ((frame_before / 64.0).ceil + 1) * 64
+  # Drive to the next frame landing exactly on a sine peak (frame % 256 ==
+  # 64) so the expected offset is an exact, easily-asserted +4 rather than a
+  # fraction -- computed from whatever `frame_before` actually is (the
+  # once-per-battle options window's own dismiss press adds a frame before
+  # reaching :command, so this cannot assume battle_to_command always lands
+  # on frame 0) rather than a fixed multiple-of-64 offset, which only lands
+  # on a peak one time in four.
+  target = (frame_before / 256) * 256 + 64
+  target += 256 while target <= frame_before
   (target - frame_before).times { scene.update }
   eq target, ui[:frame], 'the per-battle frame counter ticks once per scene.update'
   eq base_y + 4, spr.y, "the sprite's own y actually moved with it, not just " \
@@ -9558,7 +9738,10 @@ check 'an asleep ally is skipped straight to the next commandable one, no comman
                                             BattleStubActor.new(id: 2)])
   ui = nil
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -9620,7 +9803,10 @@ check 'a Forced-AI ally is skipped straight to the next manually-commandable one
                                             BattleStubActor.new(id: 2)])
   ui = nil
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -9644,7 +9830,15 @@ check 'a turn-0 battle-event page runs as the fight opens' do
   scene.update # the exhausted page hands the turn back
   ui = scene.instance_variable_get(:@battle_ui)
   ok ui, 'the battle is still open'
-  eq :command, ui[:phase], 'and control returned to the party'
+  # Control returns to the party through the options window first -- its own
+  # once-per-battle automatic appearance, the same one a bare encounter with
+  # no turn-0 page shows immediately -- not straight to the ordinary
+  # per-actor command menu.
+  eq :battle_options, ui[:phase], 'and control returned to the party via the options window'
+  RGSS::Input.triggered = [RGSS::Input::C] # Battle (default cursor row 0)
+  scene.update
+  RGSS::Input.triggered = []
+  eq :command, ui[:phase], 'dismissing Battle reaches the ordinary per-actor command menu'
 end
 
 check 'a battle page gated on an unmet condition does not fire' do
@@ -9679,7 +9873,7 @@ check 'a battle page conditioned on enemy HP fires mid-round, before the round s
   phase_when_fired = nil
   60.times do
     ui = scene.instance_variable_get(:@battle_ui)
-    RGSS::Input.triggered = [RGSS::Input::C] if ui && %i[command target].include?(ui[:phase])
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && %i[command target battle_options].include?(ui[:phase])
     scene.update
     RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
@@ -9713,7 +9907,10 @@ check 'a battle page reveals a reinforcement before the round can end in a prema
                             Game::BattlePage::ENEMY_HP, enemy_id: 0, enemy_hp_max: 0) }
   scene, st = battle_scene_with_pages(pages)
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -9865,7 +10062,10 @@ check 'a page can wound a monster through Change Monster HP' do
   pages = { 1 => troop_page([ECmd.new(ic::CHANGE_MONSTER_HP, [0, 1, 0, 7, 1])]) }
   scene, _st = battle_scene_with_pages(pages)
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -9880,9 +10080,12 @@ check 'Change Battle Background from a page rebuilds the backdrop sprite' do
   scene, _st = battle_scene_with_pages(pages)
   before = nil
   10.times do
-    scene.update
     ui = scene.instance_variable_get(:@battle_ui)
     before ||= ui && ui[:back_sprite]
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
+    scene.update
+    RGSS::Input.triggered = []
+    ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
   ui = scene.instance_variable_get(:@battle_ui)
@@ -10007,7 +10210,10 @@ end
 check 'a hidden troop member is not targetable until it is revealed' do
   scene, _st = battle_scene_with_pages(nil)
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -10298,50 +10504,57 @@ check 'Enemy Encounter scene: a successful Flee shows the database escape_succes
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  2.times { scene.update }
+  ui = battle_until_phase(scene, :battle_options)
+  2.times { RGSS::Input.triggered = [RGSS::Input::DOWN]; scene.update } # Fight -> Auto Battle -> Escape
+  RGSS::Input.triggered = []
   RGSS::Audio.reset_se
-  RGSS::Input.triggered = [RGSS::Input::B] # Flee
+  RGSS::Input.triggered = [RGSS::Input::C] # confirm Escape
   scene.update
   RGSS::Input.triggered = []
-  ui = scene.instance_variable_get(:@battle_ui)
   eq :result, ui[:phase]
   texts = window_texts(ui[:result_win])
   ok texts.any? { |t| t.include?('Escaped!') },
      'fake_db leaves escape_success blank, so this is the composed English fallback'
-  # Decision plays first (attempting Escape at all is a confirm action), then
-  # the dedicated Escape SE right before the battle actually ends -- see
-  # #try_battle_escape's comment.
-  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Decision1' }, 'attempting escape plays Decision'
+  # Decision plays first (choosing Escape from the options window is a
+  # confirm action), then the dedicated Escape SE right before the battle
+  # actually ends -- see #try_battle_escape's comment.
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Decision1' }, 'choosing Escape plays Decision'
   ok RGSS::Audio.se_calls.any? { |c| c[0] == 'Escape1' },
      'a successful escape also plays the dedicated Escape SE'
 end
 
 check 'Enemy Encounter scene: Escape forbidden (the default escape_mode 0) plays ' \
-      'Buzzer on B, not Escape, and the battle continues' do
+      'Buzzer on Escape, and the options window stays open' do
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic) # default escape_mode: 0 -> allow_escape false
   scene = new_scene({ 1 => event(2, 2, auto) })
   st = scene.instance_variable_get(:@state)
   st.instance_variable_set(:@party, BattleStubParty.new)
-  2.times { scene.update }
-  ui = scene.instance_variable_get(:@battle_ui)
-  eq :command, ui[:phase]
+  ui = battle_until_phase(scene, :battle_options)
+  2.times { RGSS::Input.triggered = [RGSS::Input::DOWN]; scene.update } # Fight -> Auto Battle -> Escape
+  RGSS::Input.triggered = []
+  eq 2, ui[:opt], 'the cursor landed on Escape'
   RGSS::Audio.reset_se
-  RGSS::Input.triggered = [RGSS::Input::B]
+  RGSS::Input.triggered = [RGSS::Input::C] # attempt Escape
   scene.update
   RGSS::Input.triggered = []
-  eq :command, ui[:phase], 'the battle is not left -- escape stays refused'
+  eq :battle_options, ui[:phase], 'the battle is not left -- escape stays refused, the window stays open'
   eq 'Buzzer1', RGSS::Audio.se_calls.last[0],
      'a disallowed escape attempt plays Buzzer, matching a disallowed Save/Continue elsewhere'
 end
 
 # Open a battle and run it up to the command phase, answering [scene, ui].
+# Dismisses the once-per-battle automatic options window (a C press on its
+# default cursor row 0, "Battle") along the way -- see #battle_to_command.
 def battle_at_command(pages = nil)
   scene, = battle_scene_with_pages(pages)
   ui = nil
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end
@@ -13399,7 +13612,10 @@ end
 check 'a transformed monster is redrawn with its new battler graphic' do
   scene, _st = battle_scene_with_pages(nil)
   10.times do
+    ui = scene.instance_variable_get(:@battle_ui)
+    RGSS::Input.triggered = [RGSS::Input::C] if ui && ui[:phase] == :battle_options
     scene.update
+    RGSS::Input.triggered = []
     ui = scene.instance_variable_get(:@battle_ui)
     break if ui && ui[:phase] == :command
   end


### PR DESCRIPTION
## Summary

- Implements real RPG2k's `SelectPreviousActor()` / `State_SelectOption` battle sub-state (`ProcessSceneActionFightAutoEscape()` in EasyRPG's `scene_battle_rpg2k.cpp`): a navigable **Battle / Auto Battle / Escape** options window, shown automatically once at the very start of every fight (right after the encounter/turn-0-event messages resolve) and reopened whenever B/Cancel lands on the first commandable actor's command list — replacing this engine's old "B on the first actor directly attempts Escape" simplification.
- **Battle** falls through to the ordinary per-actor command menu. **Auto Battle** queues `Game::Battle#choose_auto_battle_command`'s AI pick (a pre-existing port of EasyRPG's default auto-battle algorithm, already used for 強制AI-flagged actors) for every commandable living ally and starts the round with no further input — this is what unblocked the feature; docs/TODO.md previously left it unimplemented on the grounds that Auto Battle needed its own AI engine, which turned out to already exist for a different use case. **Escape** reuses the existing `#try_battle_escape` roll verbatim.
- A party that is entirely asleep/paralysed/forced or already Forced-AI'd bypasses the window straight to the ordinary flow, matching real RPG_RT's `IsAnyControllable()` guard. The window never reappears automatically at round 2+. B/Cancel is a no-op while it is open (it is the state machine's own root, matching source).
- Uses the database's `battle_fight`/`battle_auto`/`battle_escape` terms (schema fields 101/102/103, decoded but unread before this), falling back to English.
- Updates `docs/TODO.md`'s "SelectPreviousActor" writeup to ✅, `README.md`'s battle bullets, and adds a changelog fragment.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 572 checks pass, including new coverage for: the window's automatic once-per-battle appearance; B-cancel on the first actor's command list reopening it instead of escaping directly; selecting Battle/Auto Battle/Escape each dispatching correctly (including the Escape-forbidden Buzzer, which now leaves the window open); the window not reappearing at round 2+; and B/Cancel being a no-op while it is open.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 837 checks pass (unaffected `Game::` logic layer, sanity-checked since `choose_auto_battle_command` is reused).
- [x] Manually traced the exact trigger conditions and window contents against EasyRPG's real `scene_battle_rpg2k.cpp`/`scene_battle.cpp`/`game_party.cpp`/`game_actor.cpp` source (fetched directly) rather than relying solely on the docs/TODO.md writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQcXLau6x1NzWCvWZEKJwG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQcXLau6x1NzWCvWZEKJwG)_