### PR TITLE
Roll a skill/spell's own critical hit, and fix crit/variance order

### DIFF
--- a/changelog.d/rpg2k-skill-crit-and-crit-variance-order.fixed.md
+++ b/changelog.d/rpg2k-skill-crit-and-crit-variance-order.fixed.md
@@ -1,0 +1,12 @@
+- **A skill/spell attack now rolls its own critical hit**, instead of never
+  critting at all. Confirmed against EasyRPG Player's source: a skill rolls
+  the caster's ordinary weapon-inclusive crit rate, the same rate a basic
+  attack already uses, and triples the damage the same way — every offensive
+  skill's damage was previously capped at its non-critical value on every
+  single cast, in every fight.
+- **A basic attack's critical/charge damage multiplier now applies before
+  variance is rolled, instead of after.** Since variance spreads
+  proportionally to its input, applying it before the multiplier and
+  tripling the *result* afterward could only ever land on a multiple of 3 (or
+  2, for a charged hit) away from the base — a narrower, wrong-shaped spread
+  than rolling variance against the actual landed damage.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5292,6 +5292,52 @@ not yet verified:
   `scripts/rpg2k_logic_check.rb` check (the 50.5-tie case above landing on
   escape chance 100, not 99), confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **A skill/spell attack now rolls its own critical hit, and a critical's
+  ×3 multiplier now applies before variance rather than after it — two bugs
+  in the damage-effect formula, both confirmed against EasyRPG's `algo.cpp`.**
+  1. **Skill/spell criticals were entirely unmodelled.** EasyRPG's
+     `Game_BattleAlgorithm::Skill::vExecute` rolls
+     `Algo::CalcCriticalHitChance(source, target, WeaponAll, ...)` — with no
+     `easyrpg_critical_hit_chance` override (an EasyRPG-only extension field
+     no genuine `.ldb` sets), this falls back to the caster's ordinary
+     weapon-inclusive crit rate, the *exact same* rate a basic attack already
+     reads via `#critical?` — and `Algo::CalcSkillEffect` triples the result
+     the same way a basic attack's `CalcNormalAttackEffect` does. Nothing in
+     `Game::Battle#apply_skill_hit` ever rolled this: every offensive skill's
+     damage was silently capped at its non-critical value on every single
+     cast, in every fight. Fixed by rolling `#critical?(b) && side_of(b) !=
+     side_of(target) && !target.prevents_crit` — the identical guard
+     `#deal_attack` already applies — right after the attribute-multiplier
+     step, tripling `dmg` when it lands, and threading a new `critical:` flag
+     onto the returned log entry (`Scene::Map`'s existing "(critical!)"
+     suffix, `#battle_action_line`, already reads this field — it only ever
+     saw it from a basic attack before).
+  2. **A basic attack's own critical/charge multiplier was applying *after*
+     variance instead of before.** EasyRPG's `CalcNormalAttackEffect`:
+     attribute multiplier, then `if (is_critical_hit) dmg *= 3` / `else if
+     (is_charged) dmg *= 2`, then `VarianceAdjustEffect` last.
+     `Game::Battle#deal_attack` had the last two swapped. Since `#varied`'s
+     own spread (`var*base/10`) scales with its input, rolling it on the
+     pre-crit base and tripling the *result* afterward can only ever land a
+     multiple of 3 (or 2, for a charge) away from the tripled/doubled base —
+     each ±1 unit of pre-crit noise becomes ±3 once multiplied — a strictly
+     coarser, differently-shaped spread than rolling variance against the
+     *actual* landed damage, which can land on any integer in its own wider
+     window. Fixed by moving the existing `#varied` call to after the
+     crit/charge multiplier, matching `CalcSkillEffect`'s order (which this
+     codebase's own skill-crit fix above now follows from the start, so the
+     two damage paths stay consistent with each other as well as with
+     EasyRPG). No existing test exercises variance and criticals in the same
+     fight (every one explicitly turns one or the other off, per their own
+     "variance off, criticals on" comments), so none of them change.
+  Covered by three new `scripts/rpg2k_logic_check.rb` checks (a skill/spell
+  attack's damage tripling on a guaranteed crit and reporting `critical:
+  true`, the same target-side gear-guard and criticals-off exclusions a
+  basic attack already has now also blocking a skill's crit, and — for the
+  ordering fix — sampling many seeds of a guaranteed-crit, variance-on basic
+  attack and confirming at least one resulting damage value is *not* a
+  multiple of 3, which the pre-fix order could never produce), each
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9002,7 +9002,6 @@ module Game
       # An elemental weapon scales its damage by the target's resistance before
       # variance / criticals (EasyRPG's ApplyAttributeNormalAttackMultiplier).
       dmg = apply_attr_multiplier(dmg, b.atk_attrs, target)
-      dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
       # No critical on a same-side hit (e.g. a confused ally striking an ally) or
       # against a target whose gear prevents criticals, matching EasyRPG.
       crit = critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit
@@ -9016,6 +9015,17 @@ module Game
       elsif charged
         dmg *= 2
       end
+      # Variance is the *last* term before the popup cap -- EasyRPG's
+      # CalcNormalAttackEffect applies the critical/charge multiplier and only
+      # then spreads by VarianceAdjustEffect, not the other way round. Since
+      # #varied's own spread (`var*base/10`) scales with its input, rolling it
+      # on the pre-crit base and tripling the *result* afterward (a prior
+      # version's order) both narrows the spread relative to the final damage
+      # and collapses it onto only the multiples of 3 (or 2) the pre-crit
+      # value's own noise happened to land on, instead of the wider, finer-
+      # grained spread a variance roll against the *actual* (already tripled/
+      # doubled) damage produces.
+      dmg = varied(dmg, NORMAL_ATTACK_VARIANCE) if @variance && dmg > 0
       # Defending halves the blow, and 強力防御 halves it again — a quarter, not a
       # half (EasyRPG's `AdjustDamageForDefend` applies the second `dmg /= 2`
       # for a battler with strong defence). Seven of Nepheshel's 50 actors have
@@ -9387,8 +9397,21 @@ module Game
       if attack
         dmg = -hp
         # An elemental skill scales its damage by the target's resistance first
-        # (EasyRPG's ApplyAttributeSkillMultiplier), then spreads by variance.
+        # (EasyRPG's ApplyAttributeSkillMultiplier), then a critical hit, then
+        # spreads by variance -- EasyRPG's own CalcSkillEffect order exactly
+        # (algo.cpp: attribute multiplier, `if (is_critical_hit) effect *= 3`,
+        # then VarianceAdjustEffect last).
         dmg = apply_attr_multiplier(dmg, cmd[:attributes], target)
+        # A skill/spell crits at the caster's own basic-attack rate (weapon
+        # bonus included) -- EasyRPG's `Skill::vExecute` rolls
+        # `Algo::CalcCriticalHitChance(source, target, WeaponAll, ...)`, the
+        # exact same rate `#deal_attack` already reads via `#critical?`, not a
+        # separate magic-only chance. Previously nothing here ever rolled a
+        # skill/spell critical at all -- every offensive skill's damage was
+        # capped at its non-critical value on every single cast. Same
+        # same-side / gear exclusions as a basic attack.
+        crit = critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit
+        dmg *= 3 if crit
         # Spread the skill's damage by its own variance when the fight rolls it.
         dmg = varied(dmg, cmd[:variance]) if @variance && dmg > 0 && cmd[:variance] && cmd[:variance] > 0
         # Same hard-cap as a normal attack (#deal_attack), applied before
@@ -9445,6 +9468,7 @@ module Game
           stat_changed = apply_stat_mods(target, stat_keys, stat_amount)
         end
         { attacker: b.name, target: target.name, damage: dmg, missed: !hits,
+          critical: crit,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
           inflicted: inflicted, already: already, cured: cured,
           attr_shifted: shifted, attr_shift_dir: cmd[:attr_shift],

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -8143,6 +8143,32 @@ check 'battle: a critical hit triples the damage when the fight rolls one' do
   eq true, e[:critical]
 end
 
+check "battle: a critical's damage multiplier now applies before variance, not after" do
+  # EasyRPG's CalcNormalAttackEffect applies the critical/charge multiplier
+  # and only then spreads the result by VarianceAdjustEffect -- not the other
+  # way round. #varied's own spread (`var*base/10`) scales with its input, so
+  # rolling variance on the pre-crit base and tripling the *result* afterward
+  # can only ever land on a multiple of 3 away from the tripled base (each
+  # ±1 unit of pre-crit noise becomes ±3 once multiplied) -- a strictly
+  # coarser, wrong-shaped spread than rolling variance against the *actual*
+  # (already-tripled) damage, which lands on any integer in its own wider
+  # window. Sampling many seeds and finding a non-multiple-of-3 damage value
+  # proves the fix is rolling variance second, since the old order could
+  # never produce one.
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_chance = 100 # certainty -> always crits
+  damages = (1..60).map do |seed|
+    slime = combatant('Slime', 0, 0, 5, 100_000)
+    # 6-arg: variance on, criticals on.
+    bat = Game::Battle.new([hero], [slime], Game::Rng.new(seed), nil, true, true)
+    bat.begin_round
+    bat.step_action[:damage]
+  end
+  ok damages.any? { |d| d % 3 != 0 },
+     "variance rolled against the tripled damage should land off a multiple " \
+     "of 3 at least once in 60 seeds (got #{damages.uniq.sort.inspect})"
+end
+
 check 'battle: no critical when the fight has criticals off' do
   hero = combatant('Hero', 40, 0, 20, 100)
   hero.crit_chance = 100                             # would always crit, but...
@@ -9791,6 +9817,49 @@ check "battle: a skill's stat-mod effect rolls independently of its HP effect" d
   eq({ def: -10 }, e[:stat_changed],
      "but the def stat mod still landed on its own, independent roll " \
      '(-20 clamped to the asymmetric -base/2..+base band, base def 20)')
+end
+
+check "battle: a skill/spell attack now rolls its own critical hit too" do
+  # EasyRPG's Game_BattleAlgorithm::Skill::vExecute rolls
+  # Algo::CalcCriticalHitChance(source, target, WeaponAll, ...) -- the exact
+  # same weapon-inclusive rate #deal_attack's own #critical? already reads --
+  # and Algo::CalcSkillEffect triples the result the same way a basic
+  # attack's own CalcNormalAttackEffect does. Previously nothing in
+  # #apply_skill_hit ever rolled a skill/spell critical at all: every
+  # offensive skill's damage was capped at its non-critical value on every
+  # single cast.
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_chance = 100 # certainty -> always crits
+  foe = combatant('Foe', 0, 0, 5, 100)
+  cmd = { attack: true, chance: 100 }
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), nil, false, true) # 6-arg: criticals on
+  e = bat.send(:apply_skill_hit, hero, foe, -20, 0, cmd)
+  eq 60, e[:damage], "base 20 tripled by the crit, matching a basic attack's own crit"
+  eq true, e[:critical]
+  eq 40, foe.hp
+end
+
+check "battle: a target's gear-guard against criticals blocks a skill's crit too" do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_chance = 100
+  guarded = combatant('Foe', 0, 0, 5, 100)
+  guarded.prevents_crit = true
+  cmd = { attack: true, chance: 100 }
+  bat = Game::Battle.new([hero], [guarded], Game::Rng.new(1), nil, false, true)
+  e = bat.send(:apply_skill_hit, hero, guarded, -20, 0, cmd)
+  eq 20, e[:damage], 'gear that prevents criticals blocks a skill crit, same as a basic attack'
+  ok !e[:critical]
+end
+
+check 'battle: no skill/spell critical when the fight has criticals off' do
+  hero = combatant('Hero', 40, 0, 20, 100)
+  hero.crit_chance = 100 # would always crit, but...
+  foe = combatant('Foe', 0, 0, 5, 100)
+  cmd = { attack: true, chance: 100 }
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1)) # 3-arg: criticals off
+  e = bat.send(:apply_skill_hit, hero, foe, -20, 0, cmd)
+  eq 20, e[:damage]
+  ok !e[:critical]
 end
 
 check 'a skill-inflicted "do nothing" state then skips the enemy turn' do


### PR DESCRIPTION
## Summary
Two bugs in the damage-effect formula, both confirmed against EasyRPG's `algo.cpp`:

1. **Skill/spell criticals were entirely unmodelled.** EasyRPG's `Game_BattleAlgorithm::Skill::vExecute` rolls `Algo::CalcCriticalHitChance(source, target, WeaponAll, ...)` — the caster's ordinary weapon-inclusive crit rate, the exact same rate a basic attack already reads via `#critical?` — and `CalcSkillEffect` triples the result the same way `CalcNormalAttackEffect` does. Nothing in `Game::Battle#apply_skill_hit` ever rolled this: every offensive skill's damage was silently capped at its non-critical value on every single cast, in every fight.
   - Fixed by rolling `#critical?(b) && side_of(b) != side_of(target) && !target.prevents_crit` — the identical guard `#deal_attack` already applies — right after the attribute-multiplier step, tripling `dmg` when it lands, and threading a new `critical:` flag onto the returned log entry (`Scene::Map`'s existing "(critical!)" suffix already reads this field).

2. **A basic attack's own critical/charge multiplier was applying *after* variance instead of before.** EasyRPG's `CalcNormalAttackEffect`: attribute multiplier, then critical/charge multiplier, then `VarianceAdjustEffect` last. `Game::Battle#deal_attack` had the last two swapped. Since `#varied`'s own spread (`var*base/10`) scales with its input, rolling it on the pre-crit base and tripling the *result* afterward can only ever land a multiple of 3 (or 2, for a charge) away from the tripled/doubled base — a strictly coarser, differently-shaped spread than rolling variance against the actual landed damage.
   - Fixed by moving the existing `#varied` call to after the crit/charge multiplier, matching `CalcSkillEffect`'s order (which the skill-crit fix above now follows from the start, keeping both damage paths consistent with each other and with EasyRPG). No existing test exercises variance and criticals in the same fight, so none of them change.

## Test plan
- [x] Three new `scripts/rpg2k_logic_check.rb` checks (a skill/spell attack's damage tripling on a guaranteed crit and reporting `critical: true`, the same target-side gear-guard and criticals-off exclusions a basic attack already has now also blocking a skill's crit, and — for the ordering fix — sampling many seeds of a guaranteed-crit, variance-on basic attack and confirming at least one resulting damage value is *not* a multiple of 3, which the pre-fix order could never produce), each confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_