### PR TITLE
Play a Switch/Escape skill's own sound_effect on a successful cast

### DIFF
--- a/changelog.d/skill-menu-switch-escape-sound-effect.fixed.md
+++ b/changelog.d/skill-menu-switch-escape-sound-effect.fixed.md
@@ -1,0 +1,7 @@
+- A Switch or Escape skill played no sound at all on a successful field
+  cast (only a Buzzer on failure). Real RPG_RT plays the skill's own
+  database `sound_effect` field instead — `Scene::SkillMenu` now does too,
+  reusing the same `Array1D`/`SE` struct read `scene/title.rb#play_cursor_se`
+  already established, and no-oping silently on a blank/absent filename.
+  Teleport is unaffected: it already plays the ordinary decision SE, matching
+  real RPG_RT.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3299,6 +3299,26 @@ The work below is roughly ordered by the critical path to a walkable game
   Option);` unconditionally. It does **not** reappear automatically at the
   start of round 2+; only those two triggers (battle start, and B-cancel
   underflow from the first actor) reach it.
+  ✅ **A Switch or Escape skill played no sound at all on a successful field
+  cast -- only a Buzzer on failure.** Real RPG_RT plays the skill's own
+  database `sound_effect` field (schema.rb field 16, an `SE` struct: file/
+  volume/pitch/balance) instead, confirmed against EasyRPG's
+  `Scene_Skill::Update` (`src/scene_skill.cpp`): Switch and Escape both call
+  `SePlay(skill->sound_effect)` on success. Teleport is the odd one out --
+  it keeps playing the ordinary decision SE instead (already correct here,
+  in `#update_teleport_target`'s confirm step, since that plays before
+  `#apply_teleport_skill` is even reached), so it needed no change.
+  `Scene::SkillMenu#apply_switch_skill`/`#apply_escape_skill` now call a new
+  `#play_skill_sound_effect`, reading the struct the same way
+  `scene/title.rb#play_cursor_se` already reads `cursor_se` (`se.file`/
+  `se.volume`/`se.pitch`, the identical `Array1D`/`SE` schema shape) and
+  no-oping silently on a blank or absent filename. Covered by four new
+  `scripts/rpg2k_scene_check.rb` checks: a configured SE plays (after the
+  ordinary Decision SE that confirming any skill choice already plays) on a
+  successful Switch cast, a blank `sound_effect` plays nothing extra and
+  raises nothing, a failed Switch cast plays only Decision then Buzzer
+  (never the configured SE), and a successful Escape cast plays its SE
+  before the warp closes the menu.
 - ✅ **The Battle/Auto Battle/Escape options window itself is now
   implemented**, closing the gap the paragraph above traced but left open
   "for whoever picks up battle-flow work next." What had blocked it --

--- a/mruby-rpg2k/mrblib/scene/skill_menu.rb
+++ b/mruby-rpg2k/mrblib/scene/skill_menu.rb
@@ -192,11 +192,32 @@ class RPG2k
         switch = @state.party.cast_switch_skill(caster, sid)
         if switch
           @state.switches[switch] = true
+          play_skill_sound_effect(sid)
           show_message("#{caster.name} casts #{skill_name(sid)}!", :cast)
         else
           play_system_se(SFX_BUZZER)
           show_message("It had no effect.")
         end
+      end
+
+      # Switch and Escape skills replace the ordinary decision SE with their
+      # own database `sound_effect` field (schema.rb field 16) on a
+      # successful cast -- confirmed against EasyRPG's `Scene_Skill::Update`,
+      # which calls `SePlay(skill->sound_effect)` for exactly these two
+      # types. Teleport is the odd one out: it keeps playing the ordinary
+      # decision SE instead (see #update_teleport_target), so it does not
+      # call this. Mirrors #play_cursor_se in scene/title.rb (the same
+      # Array1D/SE struct, read the same way) -- a no-op on a blank/absent
+      # filename, or when the field carries no SE at all.
+      def play_skill_sound_effect(sid)
+        sk = @state.party.db_skill(sid)
+        se = sk && sk.sound_effect
+        return unless se
+        name = se.file
+        return if name.nil? || name.empty?
+        Audio.se_play name, se.volume, se.pitch
+      rescue StandardError => e
+        $stderr.puts "[RPG2k] skill SE '#{name}' playback failed: #{e.message}"
       end
 
       def leave_target
@@ -239,6 +260,7 @@ class RPG2k
       def apply_escape_skill(sid)
         target = @state.party.cast_escape_skill(caster, sid, @state)
         if target
+          play_skill_sound_effect(sid)
           queue_teleport(target)
         else
           play_system_se(SFX_BUZZER)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -12642,6 +12642,123 @@ check 'Scene::SkillMenu: cancelling the destination list returns to the skill li
   ok !parent.pop_to_map_called
 end
 
+# A party whose four field skills exercise #apply_switch_skill /
+# #apply_escape_skill's own `sound_effect` playback (schema.rb field 16) --
+# one Switch skill with a configured SE, one Switch skill with a blank one
+# (no filename set), one Switch skill that always fails (Buzzer only, no
+# skill SE), and an Escape skill with a configured SE. Confirmed against
+# EasyRPG's `Scene_Skill::Update`: Switch/Escape play `skill->sound_effect`
+# on a successful cast; Teleport does not (it keeps the ordinary decision SE
+# played earlier in #update_teleport_target, already covered above), so it
+# is not repeated here.
+class SkillSoundEffectStubParty < MenuStubParty
+  SWITCH_SID = 40
+  SWITCH_SID_BLANK = 41
+  ESCAPE_SID = 42
+  SWITCH_SID_FAIL = 43
+
+  SE = OpenStruct.new(file: 'SwitchOn', volume: 90, pitch: 110, balance: 30)
+  BLANK_SE = OpenStruct.new(file: '', volume: 100, pitch: 100, balance: 50)
+
+  def field_skills(_actor, state = nil)
+    return [] unless state
+    [[SWITCH_SID, 2], [SWITCH_SID_BLANK, 2], [ESCAPE_SID, 5], [SWITCH_SID_FAIL, 2]]
+  end
+
+  def db_skill(id)
+    case id
+    when SWITCH_SID then OpenStruct.new(name: 'Summon', type: Game::Party::SKILL_SWITCH, sound_effect: SE)
+    when SWITCH_SID_BLANK
+      OpenStruct.new(name: 'Silent Switch', type: Game::Party::SKILL_SWITCH, sound_effect: BLANK_SE)
+    when ESCAPE_SID then OpenStruct.new(name: 'Escape', type: Game::Party::SKILL_ESCAPE, sound_effect: SE)
+    when SWITCH_SID_FAIL
+      OpenStruct.new(name: 'Failing Switch', type: Game::Party::SKILL_SWITCH, sound_effect: SE)
+    end
+  end
+
+  def cast_switch_skill(_caster, sid)
+    case sid
+    when SWITCH_SID then 17
+    when SWITCH_SID_BLANK then 18
+    end
+  end
+
+  def cast_escape_skill(_caster, sid, state)
+    return nil unless sid == ESCAPE_SID
+    state.escape_target
+  end
+end
+
+def skill_sound_effect_state
+  st = Game::State.new(SkillSoundEffectStubParty.new, 1, 0, 0)
+  st.escape_target = { map_id: 9, x: 1, y: 2, switch_id: nil }
+  st
+end
+
+check 'Scene::SkillMenu: a Switch skill plays its own sound_effect on a successful cast' do
+  parent = fake_parent(fake_db)
+  state = skill_sound_effect_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Audio.reset_se
+  RGSS::Input.triggered = [RGSS::Input::C]           # confirm the first row, the switch skill with an SE
+  scene.update
+  RGSS::Input.reset
+  eq true, state.switches[17], 'the switch turned on'
+  eq [['Decision1', 100, 100], ['SwitchOn', 90, 110]], RGSS::Audio.se_calls,
+     "the ordinary Decision SE (confirming the choice) then the skill's own sound_effect"
+end
+
+check 'Scene::SkillMenu: a Switch skill with a blank sound_effect plays nothing extra and does not error' do
+  parent = fake_parent(fake_db)
+  state = skill_sound_effect_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]       # move onto the second row, the blank-SE switch skill
+  scene.update
+  RGSS::Input.reset
+  RGSS::Audio.reset_se                               # after the cursor-move SE, before the confirm
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq true, state.switches[18], 'the switch still turned on'
+  eq [['Decision1', 100, 100]], RGSS::Audio.se_calls,
+     'only the ordinary Decision SE -- the blank sound_effect filename makes #play_sound no-op silently'
+end
+
+check 'Scene::SkillMenu: a failed Switch cast plays only Buzzer, not the skill\'s own sound_effect' do
+  parent = fake_parent(fake_db)
+  state = skill_sound_effect_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the fourth skill, row 1 col 1 (always fails)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Input.triggered = [RGSS::Input::RIGHT]
+  scene.update
+  RGSS::Input.reset
+  RGSS::Audio.reset_se                               # after the cursor-move SEs, before the confirm
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  ok !state.switches[17] && !state.switches[18], 'no switch flipped'
+  eq [['Decision1', 100, 100], ['Buzzer1', 100, 100]], RGSS::Audio.se_calls,
+     "Decision then Buzzer -- the configured sound_effect never plays on a failed cast"
+end
+
+check 'Scene::SkillMenu: an Escape skill plays its own sound_effect on a successful cast' do
+  parent = fake_parent(fake_db)
+  state = skill_sound_effect_state
+  scene = RPG2k::Scene::SkillMenu.new(parent, state)
+  RGSS::Input.triggered = [RGSS::Input::DOWN]        # move onto the third skill, row 1 col 0 (Escape)
+  scene.update
+  RGSS::Input.reset
+  RGSS::Audio.reset_se                               # after the cursor-move SE, before the confirm
+  RGSS::Input.triggered = [RGSS::Input::C]
+  scene.update
+  RGSS::Input.reset
+  eq [9, 1, 2, 0], state.pending_teleport, 'queued straight from the one registered escape target'
+  eq [['Decision1', 100, 100], ['SwitchOn', 90, 110]], RGSS::Audio.se_calls,
+     "the ordinary Decision SE then the skill's own sound_effect, before the warp closes the menu"
+end
+
 # EasyRPG's Window_Skill::UpdateHelp (src/window_skill.cpp) feeds the
 # database skill's own `description` straight to Scene_Skill's Window_Help
 # banner every time the selection changes -- the exact mechanism


### PR DESCRIPTION
## Summary

- Switch (type 3) and Escape (type 1) field skills played **no sound at all** on a successful cast — only a Buzzer on failure. Real RPG_RT plays the skill's own database `sound_effect` field (`mruby-lcf/mrblib/schema.rb` field 16, an `SE` struct: file/volume/pitch/balance) instead, confirmed against EasyRPG Player's `Scene_Skill::Update` (`src/scene_skill.cpp`): both types call `SePlay(skill->sound_effect)` on success.
- Teleport (type 2) is the odd one out and needed **no change** — it calls `SePlay(GetSystemSE(SFX_Decision))` instead of its own `sound_effect` field, which this engine already does correctly in `#update_teleport_target`'s confirm step (before `#apply_teleport_skill` is even reached).
- `Scene::SkillMenu#apply_switch_skill` / `#apply_escape_skill` now call a new `#play_skill_sound_effect`, reading the `SE` struct the same way `scene/title.rb#play_cursor_se` already reads `cursor_se` (`se.file` / `se.volume` / `se.pitch`, the identical `Array1D`/`SE` schema shape), and no-oping silently on a blank or absent filename — no console error.

### A note on the task brief's suggested reuse target

The task description pointed at `Scene::Base#play_sound` (~`scene/base.rb:235-240`) as an existing general-purpose SE-struct playback helper to reuse. That method turned out not to exist on `Scene::Base` — `#play_sound` is defined on the `MapWorld`/`VehicleWorld` move-route adapters instead (a different mechanism, for the Move Event "Play SE" command), so `SkillMenu` (which subclasses `Base`) can't call it. Went with the `title.rb#play_cursor_se` pattern instead, which is the actual established way this codebase reads an arbitrary `Array1D`/`SE` struct outside that adapter.

## Test plan

- [x] Added 4 new checks to `scripts/rpg2k_scene_check.rb`: a configured `sound_effect` plays on a successful Switch cast (after the ordinary Decision SE that confirming any skill choice already plays), a blank `sound_effect` plays nothing extra and raises nothing, a failed Switch cast plays only Decision then Buzzer (never the configured SE), and a successful Escape cast plays its SE before the warp closes the menu.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 579 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 843 checks passed (unaffected, included for completeness since it shares fixtures)
- [x] `docs/TODO.md` updated (Menu screens section) and `changelog.d/skill-menu-switch-escape-sound-effect.fixed.md` added per `AGENTS.md`
- [ ] `pre-commit` was not runnable in this sandbox (no `pre-commit`/`nix` binary available); manually verified no trailing whitespace and every touched file ends with a newline — the only two hooks that apply to the touched file types


---
_Generated by [Claude Code](https://claude.ai/code/session_01FwXN1W2Q3QHnPwm9SVe2Ps)_