### PR TITLE
Play the enemy-attack system SE for an enemy's own Attack

### DIFF
--- a/changelog.d/enemy-attack-system-se.fixed.md
+++ b/changelog.d/enemy-attack-system-se.fixed.md
@@ -1,0 +1,17 @@
+- **An enemy's own Attack now plays the enemy-attack system SE**
+  (`Scene::Base::DB_SE_FIELD` slot 6, `enemy_attack_se`). The slot was
+  already declared for slot-numbering and Change System SFX overrides, but
+  nothing ever called `play_system_se(SFX_ENEMY_ATTACK)`. Confirmed against
+  EasyRPG Player's source (`scene_battle_rpg2k.cpp`):
+  `Game_BattleAlgorithm::Normal::GetStartSe` returns `SFX_EnemyAttacks` only
+  for an enemy-sourced plain Attack, and `ProcessBattleActionUsage` plays it
+  before `ProcessBattleActionAnimation`/`ProcessBattleActionExecute` — once,
+  at the very start of the action, before any hit/miss/damage resolves, and
+  once per action even when a dual-attack enemy swings twice (a repeat
+  re-enters at Execute, not Usage). `Battle#deal_attack` now tags its log
+  entry with `attacker_ally`, and `Scene::Map#play_battle_action_se` plays
+  the SE first when that attacker is an enemy — never for a skill/item hit
+  or an ally's own Attack, and only once even across
+  `EnemyAction::BASIC_DUAL_ATTACK`'s two swings. Covered by a new
+  `scripts/rpg2k_scene_check.rb` check asserting the SE plays for an enemy
+  Attack and not for an ally one.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8518,7 +8518,14 @@ module Game
         first = deal_attack(b, target)
         # The second swing only lands if the first did not fell the target.
         return [first] if target.dead?
-        [first, deal_attack(b, target)]
+        second = deal_attack(b, target)
+        # RPG_RT's enemy-attack SE plays once per action (at its very start),
+        # not once per swing -- EasyRPG's ProcessBattleActionUsage calls
+        # GetStartSe only before the first Execute, a repeat re-enters at
+        # Execute directly. Clearing the second swing's `attacker_ally`
+        # keeps #play_battle_action_se from re-triggering it.
+        second[:attacker_ally] = nil
+        [first, second]
       when EnemyAction::BASIC_DEFEND
         b.defending = true
         { attacker: b.name, defend: true }
@@ -8976,6 +8983,10 @@ module Game
     end
 
     def deal_attack(b, target)
+      # `attacker_ally` (unlike `target_ally`, which every hit already carries)
+      # only appears on a plain Attack's own entry -- it is how
+      # Scene::Map#play_battle_action_se tells a normal swing apart from a
+      # skill/item hit and gates SFX_ENEMY_ATTACK to an enemy's own Attack.
       # A plain attack's own battle animation -- the attacking actor's current
       # gear (Actor#attack_animation_id), or nil for an enemy (b.actor is nil;
       # see #attack_animation_id's own doc comment for why enemies have none
@@ -8995,8 +9006,8 @@ module Game
       if @accuracy && !hits?(b, target)
         return { attacker: b.name, target: target.name, damage: 0, missed: true,
                  critical: false, target_hp: target.hp < 0 ? 0 : target.hp,
-                 defeated: false, target_ally: ally?(target), attack_animation_id: anim,
-                 target_index: target_index }
+                 defeated: false, target_ally: ally?(target), attacker_ally: ally?(b),
+                 attack_animation_id: anim, target_index: target_index }
       end
       dmg = Battle.attack_damage(effective_atk(b), effective_def(target))
       # An elemental weapon scales its damage by the target's resistance before
@@ -9053,7 +9064,8 @@ module Game
       entry = { attacker: b.name, target: target.name, damage: dmg, critical: crit,
                 charged: charged, target_hp: target.hp < 0 ? 0 : target.hp,
                 defeated: target.dead?, target_ally: ally?(target),
-                attack_animation_id: anim, target_index: target_index }
+                attacker_ally: ally?(b), attack_animation_id: anim,
+                target_index: target_index }
       entry[:woke] = woke unless woke.empty?
       entry[:inflicted] = inflicted unless inflicted.empty?
       entry[:cured] = cured unless cured.empty?

--- a/mruby-rpg2k/mrblib/scene/base.rb
+++ b/mruby-rpg2k/mrblib/scene/base.rb
@@ -162,14 +162,29 @@ class RPG2k
                       SFX_ACTOR_DAMAGE => :actor_damaged_se,
                       SFX_DODGE => :dodge_se, SFX_ENEMY_DEATH => :enemy_death_se,
                       SFX_ITEM => :item_se }.freeze
-      # `enemy_attack_se` (slot 6) is declared above so the slot numbering and
-      # Change System SFX overrides both land correctly, but nothing calls
-      # `play_system_se(SFX_ENEMY_ATTACK)` yet: RPG_RT plays it at the start of
-      # an enemy's swing, before the hit lands, and this build's round animation
-      # has no separate wind-up moment to hang that on -- a plain attack is one
-      # step (land the hit, then banner and pace by it), not a swing-then-impact
-      # pair. Playing it at the same moment as the impact sound would be a
-      # different, unverified timing rather than a faithful one.
+      # `enemy_attack_se` (slot 6) is played from
+      # Scene::Map#play_battle_action_se, gated on Battle#deal_attack's
+      # `attacker_ally: false` (an enemy's own plain Attack, never a
+      # skill/item hit -- EasyRPG's Game_BattleAlgorithm::Normal::GetStartSe
+      # returns SFX_EnemyAttacks only for an enemy source, and only the
+      # Normal algorithm ever returns it). Confirmed against EasyRPG Player's
+      # source (scene_battle_rpg2k.cpp): ProcessBattleActionUsage plays
+      # GetStartSe() before ProcessBattleActionAnimation and
+      # ProcessBattleActionExecute -- the very start of the action, before
+      # any sprite swing or hit/miss/damage resolution -- and, for a
+      # repeated (dual-attack) action, ProcessBattleActionFinished re-enters
+      # at Execute rather than Usage, so it plays once per action, not once
+      # per swing (mirrored here by nilling `attacker_ally` on the dual
+      # attack's second entry, see #enemy_basic_action).
+      #
+      # This build's round has no separate wind-up beat to hang that lead-in
+      # on -- a plain attack still resolves hit/miss/damage in the one step
+      # that builds the log entry -- so the SE plays at the top of
+      # #play_battle_action_se for that entry, ahead of the dodge/damage/
+      # death cues the same call already fires for it. That collapses
+      # RPG_RT's swing-then-impact gap to nothing, but keeps the one thing
+      # that gap is *for*: the attack cue is heard before, never alongside
+      # or after, the resolution it precedes.
 
       # Play a system sound effect by slot, preferring a Change System SFX
       # override held on the game state and falling back to the database's own

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -6576,6 +6576,12 @@ class RPG2k
       # SFX_EnemyDamage / SFX_AllyDamage and, on top of a kill, SFX_EnemyKill,
       # as separate calls rather than one replacing another).
       def play_battle_action_se(entry)
+        # `attacker_ally` only rides on a plain Attack's own entry (never a
+        # skill/item hit -- see Battle#deal_attack), and is `false` rather
+        # than absent for an enemy's swing, so this fires before the hit's
+        # own resolution SE, matching RPG_RT playing it at the very start of
+        # the action.
+        play_system_se(SFX_ENEMY_ATTACK) if entry[:attacker_ally] == false
         play_system_se(SFX_DODGE) if entry[:missed]
         if entry[:damage] && entry[:damage] > 0
           play_system_se(entry[:target_ally] ? SFX_ACTOR_DAMAGE : SFX_ENEMY_DAMAGE)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -315,6 +315,7 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
                            escape_se: OpenStruct.new(file: 'Escape1', volume: 100, pitch: 100),
                            battle_se: OpenStruct.new(file: 'BattleStart1', volume: 100, pitch: 100),
                            # The battle per-hit sounds (Scene::Base::DB_SE_FIELD).
+                           enemy_attack_se: OpenStruct.new(file: 'EnemyAttack', volume: 100, pitch: 100),
                            enemy_damaged_se: OpenStruct.new(file: 'EnemyHit', volume: 100, pitch: 100),
                            actor_damaged_se: OpenStruct.new(file: 'ActorHit', volume: 100, pitch: 100),
                            dodge_se: OpenStruct.new(file: 'Dodge1', volume: 100, pitch: 100),
@@ -8313,6 +8314,44 @@ check 'Enemy Encounter scene: using an Item heals and consumes one from the bag'
   eq 1, st.party.item_count(5), 'one potion consumed when the item action landed'
   eq 20, ui[:allies].first.hp - hp_before, 'the Hero was healed 20 HP'
   ok RGSS::Audio.se_calls.any? { |c| c[0] == 'ItemUse' }, 'the item SE played too'
+end
+
+# SFX_ENEMY_ATTACK (Scene::Base::DB_SE_FIELD slot 6): confirmed against
+# EasyRPG Player's source (scene_battle_rpg2k.cpp's ProcessBattleActionUsage)
+# to fire once, at the very start of an *enemy's* plain Attack action, never
+# for a skill/item hit or for an ally's own Attack -- see the doc comment on
+# `SFX_ENEMY_ATTACK` in mruby-rpg2k/mrblib/scene/base.rb.
+check 'Enemy Encounter scene: the enemy-attack SE plays for an enemy Attack, ' \
+      'not an ally one' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_to_command(scene)
+
+  2.times { press_key(scene, RGSS::Input::C) } # Attack -> the first Slime -> animate
+  eq :animate, ui[:phase]
+
+  RGSS::Audio.reset_se
+  scene.update # the (faster) Hero's own attack lands first
+  eq 1, ui[:battle].log.length
+  ok !RGSS::Audio.se_calls.any? { |c| c[0] == 'EnemyAttack' },
+     "an ally's own Attack does not play the enemy-attack SE"
+
+  # The Slime survives the Hero's hit (19 damage against 30 HP), so it is
+  # still alive to take its own turn next and swing back.
+  RGSS::Audio.reset_se
+  40.times do
+    scene.update
+    break if ui[:battle].log.length >= 2
+  end
+  eq 2, ui[:battle].log.length, "the Slime's counter-attack landed"
+  entry = ui[:battle].log.last
+  eq false, entry[:attacker_ally], 'the attacker is the enemy, not an ally'
+  ok RGSS::Audio.se_calls.any? { |c| c[0] == 'EnemyAttack' },
+     "and the enemy's own Attack plays the enemy-attack SE"
 end
 
 # The battle command/target/skill/item flow's own system SE -- confirmed


### PR DESCRIPTION
## Summary

- `SFX_ENEMY_ATTACK` (`Scene::Base::DB_SE_FIELD` slot 6, `enemy_attack_se`) was declared for slot-numbering and Change System SFX overrides, but nothing ever called `play_system_se(SFX_ENEMY_ATTACK)`.
- Confirmed the real timing against EasyRPG Player's source (`scene_battle_rpg2k.cpp`): `Game_BattleAlgorithm::Normal::GetStartSe` returns `SFX_EnemyAttacks` only for an enemy-sourced plain Attack, and `ProcessBattleActionUsage` plays it once, before `ProcessBattleActionAnimation`/`ProcessBattleActionExecute` — i.e. at the very start of the action, before any sprite swing or hit/miss/damage resolution. For a dual-attack enemy's second swing, `ProcessBattleActionFinished` re-enters at `Execute`, not `Usage`, so the SE plays once per action, not once per swing.
- `Battle#deal_attack` (`mruby-rpg2k/mrblib/game.rb`) now tags its log entry with `attacker_ally`, and `Scene::Map#play_battle_action_se` (`mruby-rpg2k/mrblib/scene/map.rb`) plays `SFX_ENEMY_ATTACK` first when the attacker is an enemy — never for a skill/item hit (only a plain Attack ever carries `attacker_ally`) or an ally's own Attack, and only once across `EnemyAction::BASIC_DUAL_ATTACK`'s two entries (the second swing's `attacker_ally` is nilled to match RPG_RT's once-per-action timing).
- Updated the doc comment on `SFX_ENEMY_ATTACK` in `mruby-rpg2k/mrblib/scene/base.rb` to describe the actual wiring and the reasoned simplification: this build's round resolves hit/miss/damage in one step (no separate wind-up beat), so the SE plays at the top of `#play_battle_action_se` for that entry rather than at a genuinely separate pre-swing moment — collapsing RPG_RT's swing-then-impact gap to nothing while still guaranteeing the attack cue is heard *before*, never alongside or after, the resolution it precedes.
- `docs/TODO.md` had no open (🚧) mention of `enemy_attack_se`/`SFX_ENEMY_ATTACK` to update, so no changes there.

## Test plan

- [x] New `scripts/rpg2k_scene_check.rb` check: an enemy's own Attack plays the enemy-attack SE, an ally's own Attack does not. Confirmed it fails against the pre-fix code and passes with the fix.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 576 checks passed.
- [x] `ruby scripts/rpg2k_logic_check.rb` — 843 checks passed (battle logic untouched otherwise).
- [x] `changelog.d/enemy-attack-system-se.fixed.md` added per `AGENTS.md`.
- [x] No trailing-whitespace / EOF-newline issues in touched files (pre-commit itself unavailable in this environment).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_015P6wFh4qQ8ojGnawc8mUP5

---
_Generated by [Claude Code](https://claude.ai/code/session_015P6wFh4qQ8ojGnawc8mUP5)_