### PR TITLE
Draw the shop status panel for the highlighted item

### DIFF
--- a/changelog.d/rpg2k-shop-status-panel.added.md
+++ b/changelog.d/rpg2k-shop-status-panel.added.md
@@ -1,0 +1,19 @@
+- **The shop screen now draws a status panel for the highlighted item.**
+  `mruby-lcf/mrblib/schema.rb` already decoded the `possessed_items` /
+  `equipped_items` database terms (Term chunk fields 92/93), but nothing in
+  `mruby-rpg2k` ever referenced them. `Scene::Map`'s shop code gains
+  `#draw_shop_status`, a panel beside the buy/sell list — EasyRPG's
+  `Window_ShopStatus` — showing the two terms with right-aligned counts for
+  whichever row the cursor sits on: the bag-only count (`Party#item_count`)
+  and a new `Party#equipped_item_count`, summing how many slots across every
+  party member currently hold the item — matching EasyRPG's
+  `Game_Party::GetEquippedItemCount` / `Game_Actor::GetItemCount` (a plain
+  slot-equality scan; equipping an item removes it from the bag, so the two
+  counts move independently). `Interpreter#item_operand`'s existing
+  equipped-item Control Variables mode now shares the same method instead of
+  duplicating the scan inline. The panel refreshes with the list's own
+  cursor and is torn down for the command menu, the quantity counter and the
+  purchase/sale confirmation, none of which highlight a single item. Covered
+  by a `scripts/rpg2k_logic_check.rb` check on the counting logic in
+  isolation and a `scripts/rpg2k_scene_check.rb` check confirming the panel
+  draws, updates and disappears correctly as the shop cursor moves.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -904,6 +904,17 @@ The work below is roughly ordered by the critical path to a walkable game
   unaffordable, or already capped — does not open the counter, and cancelling it
   returns to the list having traded nothing. Nepheshel opens 10 shops, so this is
   exercised content rather than a hypothetical.
+  A **status panel** now sits beside the buy / sell list too — EasyRPG's
+  `Window_ShopStatus` — showing the currently highlighted item's
+  `possessed_items` / `equipped_items` database terms (blank falls back to
+  plain English, matching every other shop term) with right-aligned counts:
+  the bag-only `Party#item_count` and a new `Party#equipped_item_count`
+  (every slot on every party member holding the item, matching EasyRPG's
+  `Game_Party::GetEquippedItemCount` / `Game_Actor::GetItemCount` slot-equality
+  scan — a copy currently equipped no longer counts toward the bag, so the
+  two rows move independently). It refreshes with the list's own cursor and
+  is torn down for the command menu, the quantity counter and the
+  purchase/sale confirmation, none of which highlight a single item.
   **Enemy Encounter** (10710) starts the battle path: `Game::Enemy` / `Game::Troop`
   instantiate a database enemy group into live members and total its EXP / gold
   (and `Troop#drops` rolls each member's treasure item against its `drop_prob`,

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2795,6 +2795,18 @@ module Game
       item_count(id) > 0 || @actors.any? { |a| a.equipment.include?(id) }
     end
 
+    # How many of `id` sit equipped across the whole party right now -- every
+    # slot on every member that holds it, so an id equipped in two slots at
+    # once (nothing stops the same shield id filling both an off-hand and a
+    # main-hand slot) counts twice. Matches EasyRPG's
+    # Game_Party::GetEquippedItemCount / Game_Actor::GetItemCount (a slot
+    # equality scan) and backs both the Control Variables item-operand's
+    # equipped mode (Interpreter#item_operand) and the shop status panel
+    # (Scene::Map#draw_shop_status).
+    def equipped_item_count(id)
+      @actors.reduce(0) { |n, a| n + a.equipment.count(id) }
+    end
+
     def gain_item(id, n = 1)
       c = item_count(id) + n
       c = 0 if c < 0

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1640,11 +1640,7 @@ module Game
     # (each slot equipping it counts). Matches EasyRPG's ControlVariables::Item.
     def item_operand(cmd)
       id = cmd.param(5)
-      if cmd.param(6) == 1
-        party.actors.reduce(0) { |n, a| n + a.equipment.count(id) }
-      else
-        party.item_count(id)
-      end
+      cmd.param(6) == 1 ? party.equipped_item_count(id) : party.item_count(id)
     end
 
     # Operand type 3: a random integer in [param5, param6] inclusive (the bounds

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4026,7 +4026,7 @@ class RPG2k
         has_menu = req[:allow_buy] && req[:allow_sell]
         screen = has_menu ? :command : (req[:allow_buy] ? :buy : :sell)
         @shop = { model: model, has_menu: has_menu, screen: screen, index: 0,
-                  window: nil, gold: build_shop_gold_window,
+                  window: nil, gold: build_shop_gold_window, status: nil,
                   terms: shop_terms(req[:type]), browsed: false }
         draw_shop
       end
@@ -4150,6 +4150,7 @@ class RPG2k
         end
         @shop[:window] = win
         draw_shop_gold
+        draw_shop_status(lines)
       end
 
       def draw_shop_gold
@@ -4159,6 +4160,55 @@ class RPG2k
         c.draw_text 0, 0, c.width, SHOP_LINE_H,
                     "#{@state.party.gold}#{shop_gold_term}"
         @shop[:gold].contents = c
+      end
+
+      # Panel dimensions mirror EasyRPG's Window_ShopStatus (136x48 at
+      # RPG2000's own 320x240 resolution): two rows tall enough for one
+      # SHOP_LINE_H label line each, plus the ordinary window border.
+      SHOP_STATUS_W = 136
+
+      # The item id the status panel should describe: whichever row the
+      # cursor sits on in the buy or sell list. The command menu, the
+      # quantity counter and the purchase/sale confirmation don't highlight
+      # a single item, so there is nothing for the panel to show there.
+      def shop_status_item_id(lines)
+        return nil unless @shop[:screen] == :buy || @shop[:screen] == :sell
+        return nil if lines.nil? || lines.empty?
+        lines[@shop[:index]][1]
+      end
+
+      # The status panel beside the buy/sell list: the `possessed_items` /
+      # `equipped_items` database terms with their counts for the currently
+      # highlighted item right-aligned beside them -- EasyRPG's
+      # Window_ShopStatus, refreshed the same way its own SetItemId call is,
+      # from the list's own cursor. `possessed` is the bag only
+      # (Party#item_count, matching the sell list's own x-count suffix);
+      # `equipped` sums every slot on every party member holding the item
+      # (Party#equipped_item_count) -- a copy currently equipped no longer
+      # counts toward the bag, so the two rows can both be nonzero at once.
+      def draw_shop_status(lines)
+        id = shop_status_item_id(lines)
+        if id.nil?
+          @shop[:status].dispose if @shop[:status]
+          @shop[:status] = nil
+          return
+        end
+        win = @shop[:status]
+        unless win
+          win = Window.new(6, 6, SHOP_STATUS_W, SHOP_LINE_H * 2 + Window::BORDER * 2)
+          win.z = 300
+          win.windowskin = @windowskin
+          @shop[:status] = win
+        end
+        inner_w = SHOP_STATUS_W - Window::BORDER * 2
+        c = Bitmap.new(inner_w, SHOP_LINE_H * 2)
+        c.font.color = Color.new(255, 255, 255, 255)
+        c.draw_text 0, 0, inner_w, SHOP_LINE_H, nonblank(db.term.possessed_items, 'Possessed')
+        c.draw_text 0, SHOP_LINE_H, inner_w, SHOP_LINE_H, nonblank(db.term.equipped_items, 'Equipped')
+        c.draw_text 0, 0, inner_w, SHOP_LINE_H, @state.party.item_count(id).to_s, 2
+        c.draw_text 0, SHOP_LINE_H, inner_w, SHOP_LINE_H,
+                    @state.party.equipped_item_count(id).to_s, 2
+        win.contents = c
       end
 
       def drive_shop_command
@@ -4300,6 +4350,7 @@ class RPG2k
         return unless @shop
         @shop[:window].dispose if @shop[:window]
         @shop[:gold].dispose if @shop[:gold]
+        @shop[:status].dispose if @shop[:status]
         @shop = nil
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5393,6 +5393,31 @@ check 'party#has_item? counts a copy equipped on any member, not just the bag' d
   eq true, st.party.has_item?(7)
 end
 
+# The shop status panel's "equipped" row (Scene::Map#draw_shop_status) sums
+# every slot on every party member holding the item -- EasyRPG's
+# Game_Party::GetEquippedItemCount / Game_Actor::GetItemCount, a plain slot
+# equality scan, so two members (or two slots on one member) each holding a
+# copy count as two, and it moves independently of the bag count.
+check "party#equipped_item_count sums a held item across every member's " \
+      'equipment slots' do
+  items = { 7 => fake_item(atk: 15, type: 1) }   # weapon -> slot 0
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]),
+                        2 => CurveRow.new('Ally', '', 0, 1, [8, 4, 2, 3, 2, 3]) },
+                       [1, 2], items)
+  party = Game::Party.new(db)
+  hero, ally = party.actors
+  eq 0, party.equipped_item_count(7), 'nothing equipped yet'
+  hero.equip([7, 0, 0, 0, 0])
+  eq 1, party.equipped_item_count(7)
+  ally.equip([7, 0, 0, 0, 0])
+  eq 2, party.equipped_item_count(7), 'summed across both party members'
+  party.gain_item(7, 3)
+  eq 3, party.item_count(7), 'the bag count moves independently of what is equipped'
+  eq 2, party.equipped_item_count(7)
+  hero.equip([0, 0, 0, 0, 0])
+  eq 1, party.equipped_item_count(7)
+end
+
 check 'Conditional Branch item test (type 4) sees an equipped copy too' do
   items = { 7 => fake_item(atk: 15, type: 1) }
   st = equip_party(items)

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2222,10 +2222,18 @@ class BattleStubParty
   def db_enemy_group(id); @enemy_group[id]; end
 end
 
+# A minimal party member for the shop status panel's equipped-count check --
+# just an equipment slot array, mirroring Game::Actor#equipment.
+class ShopStubActor
+  attr_reader :equipment
+  def initialize(equipment); @equipment = equipment; end
+end
+
 # A party the shop can charge and stock: gold plus an item-count bag, with the
 # leader Scene::Map reads while rendering.
 class ShopStubParty
-  attr_reader :actors, :gold, :items
+  attr_accessor :actors
+  attr_reader :gold, :items
   attr_accessor :leader
   def initialize(gold); @gold = gold; @items = {}; @actors = []; @leader = nil; end
   def gain_gold(n); @gold += n; @gold = 0 if @gold < 0; end
@@ -2235,6 +2243,9 @@ class ShopStubParty
     c = 0 if c < 0
     c = 99 if c > 99
     @items[id] = c
+  end
+  def equipped_item_count(id)
+    @actors.reduce(0) { |n, a| n + a.equipment.count(id) }
   end
 end
 
@@ -10365,6 +10376,61 @@ check 'Open Shop scene: selling shows the shop_sold confirmation, then returns '
   scene.update
   shop = scene.instance_variable_get(:@shop)
   eq :sell, shop[:screen], 'and returns to the sell list, same as EasyRPG\'s Sold -> Sell'
+end
+
+check 'Open Shop scene: the status panel shows the highlighted item\'s possessed ' \
+      'and equipped counts, and disappears off the buy/sell list' do
+  ic = Game::Interpreter::Cmd
+  db = fake_db
+  db.term.possessed_items = '所持数'
+  db.term.equipped_items = '装備数'
+  auto = page(trigger: 3)
+  auto.event_commands = [ECmd.new(ic::OPEN_SHOP, [0, 0, 0, 0, 3, 5], indent: 0)] # buy+sell
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = fake_map(1, { 1 => event(2, 2, auto) })
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  party = ShopStubParty.new(500)
+  party.gain_item(3, 2)                                # two Potions already in the bag
+  party.actors = [ShopStubActor.new([3, 0, 0, 0, 0])]  # one of them equipped
+  state.instance_variable_set(:@party, party)
+  3.times { scene.update } # the command menu opens (mode 0: buy+sell)
+
+  shop = scene.instance_variable_get(:@shop)
+  eq :command, shop[:screen]
+  ok shop[:status].nil?, 'the command menu highlights no single item -- no panel'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # choose Buy
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen]
+  texts = window_texts(shop[:status])
+  ok texts.include?('所持数'), 'the possessed_items term labels the first row'
+  ok texts.include?('装備数'), 'the equipped_items term labels the second row'
+  ok texts.include?('2'), 'two Potions already held'
+  ok texts.include?('1'), 'one Potion equipped across the party'
+
+  RGSS::Input.triggered = [RGSS::Input::DOWN] # move to the second good (Herb, id 5)
+  scene.update
+  RGSS::Input.triggered = []
+  texts = window_texts(scene.instance_variable_get(:@shop)[:status])
+  ok texts.include?('0'), 'no Herbs held or equipped'
+  ok !texts.include?('2') && !texts.include?('1'),
+     'the stale Potion counts are gone once the cursor moves to a different good'
+
+  RGSS::Input.triggered = [RGSS::Input::C] # open the quantity counter for the Herb
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :quantity, shop[:screen]
+  ok shop[:status].nil?, 'the quantity counter highlights no single list row -- no panel'
+
+  RGSS::Input.triggered = [RGSS::Input::B] # back to the buy list
+  scene.update
+  RGSS::Input.triggered = []
+  shop = scene.instance_variable_get(:@shop)
+  eq :buy, shop[:screen]
+  ok !shop[:status].nil?, 'the panel returns once a good is highlighted again'
 end
 
 check 'Enemy Encounter scene: the result window shows the database Victory term' do


### PR DESCRIPTION
## Summary

- `mruby-lcf/mrblib/schema.rb` already decoded the `possessed_items` / `equipped_items` database terms (Term chunk fields 92/93), but nothing in `mruby-rpg2k` ever referenced them: the shop screen's buy/sell list had no side panel showing what the party already holds or wears.
- `Scene::Map`'s shop code gains `#draw_shop_status`, a panel beside the list — EasyRPG's `Window_ShopStatus` — showing the two terms with right-aligned counts for whichever row the cursor sits on: the bag-only count (`Party#item_count`) and a new `Party#equipped_item_count`, summing how many equipment slots across the whole party hold the item (matching EasyRPG's `Game_Party::GetEquippedItemCount` / `Game_Actor::GetItemCount` slot-equality scan, verified against the real source). `Interpreter#item_operand`'s existing equipped-item Control Variables mode now shares that same method instead of duplicating the scan inline.
- The panel refreshes with the list's own cursor and is torn down for the command menu, the quantity counter and the purchase/sale confirmation, none of which highlight a single item.
- `docs/TODO.md` and a `changelog.d/` fragment document the addition.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 844 checks pass (new: `Party#equipped_item_count` sums across every member's equipment slots)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 576 checks pass (new: the status panel shows the highlighted item's possessed/equipped counts, term-driven, and disappears off the buy/sell list)
- [x] `pre-commit` (trailing-whitespace / end-of-file-fixer / check-added-large-files) on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAbmus49TKzABKATGjLFeX


---
_Generated by [Claude Code](https://claude.ai/code/session_01DAbmus49TKzABKATGjLFeX)_