### PR TITLE
Fix Simulated Attack's damage variance to match RPG_RT's real formula

### DIFF
--- a/changelog.d/rpg2k-simulated-attack-variance.fixed.md
+++ b/changelog.d/rpg2k-simulated-attack-variance.fixed.md
@@ -1,0 +1,9 @@
+- **The Simulated Attack event command's damage spread now uses RPG_RT's real
+  variance formula**, instead of a coarser stand-in this codebase's own
+  comment had misattributed to EasyRPG's source. Confirmed against EasyRPG
+  Player's actual source: it rolls the same variance formula a normal
+  attack/skill/self-destruct already uses correctly. The two formulas'
+  outer bounds happen to coincide, but the old model's granularity was
+  coarser by a factor that grows with the event's own Attack Power
+  parameter — damage rolls visibly landed only on round multiples instead
+  of the smooth, per-1 spread genuine RPG_RT produces.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5420,6 +5420,37 @@ not yet verified:
   rolling it at all; and a missed attack skill never rolling the shake-off
   either, matching the shared accuracy gate), each confirmed to fail against
   the pre-fix code before the fix.
+- ✅ **Simulated Attack's damage spread now uses RPG_RT's real variance
+  formula, not a coarser stand-in this method's own comment misattributed to
+  EasyRPG's source.** `Interpreter#do_simulated_attack` modelled its damage
+  spread as a flat `+/- (param5 * 5)` *percent* of the base damage. Checked
+  directly against EasyRPG's `CommandSimulatedAttack`
+  (`src/game_interpreter.cpp`) rather than that comment's own claim: it rolls
+  `Algo::VarianceAdjustEffect(result, var)` — the *exact same* function
+  `Game::Battle#varied` already ports correctly for a normal attack/skill/
+  self-destruct's own damage (`adj = max(1, var*base/10)`, `base + rand(0,
+  adj) - adj/2`), not a percent-based model at all. The two formulas'
+  outer bounds happen to coincide algebraically (`base +/- base*var/20`
+  either way), which is presumably how the mistake went undetected, but the
+  percent model's *granularity* is coarser by a factor of `base/100`: at
+  `atk` 500 and variance 5, the percent model can only ever land on one of
+  51 values, all multiples of 5, where the real formula draws uniformly from
+  251 consecutive integers across the identical `[375, 625]` range —
+  visibly "rounder" damage numbers than genuine RPG_RT produces, worsening
+  as the event's own Attack Power parameter grows. Fixed with a new
+  `Interpreter#simulated_attack_variance`, reimplementing
+  `Algo::VarianceAdjustEffect` directly (`#varied` lives on `Battle`, not
+  `Interpreter`) — floored at 0 rather than `#varied`'s own floor of 1,
+  matching `CommandSimulatedAttack`'s own `std::max(0, result)` clamp
+  (applied both before and after the variance call in the real source; a
+  redundant-but-source-faithful floor now sits before the roll too, since
+  `#simulated_attack_variance`'s own `base > 0` guard already passes a
+  non-positive base through unrolled either way). Covered by two
+  new `scripts/rpg2k_logic_check.rb` checks (sampling many draws at `atk`
+  500 / variance 5 and confirming at least one result is not a multiple of
+  5, which the old percent model could never produce; and the zero-variance/
+  zero-base passthrough cases), confirmed to fail against the pre-fix code
+  before the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -1996,11 +1996,13 @@ module Game
     # attacker — the event supplies the attack power itself. param0/param1 pick
     # the targets (the shared scope layout); param2 is the attack strength,
     # param3 how much the target's defence counts and param4 how much its spirit
-    # counts, each as a permille-style divisor, and param5 the damage spread.
-    # When param6 is set the damage dealt is also written into variable param7.
-    # The formula is EasyRPG Player's CommandSimulatedAttack, which mirrors
-    # RPG_RT: `atk - def * p_def / 400 - spi * p_spi / 800`, then spread by
-    # +/- (param5 * 5) percent and floored at 0. The hit can be lethal.
+    # counts, each as a permille-style divisor, and param5 the damage spread (the
+    # database's own 0-10 variance scale, the same one a skill's own `variance`
+    # field uses). When param6 is set the damage dealt is also written into
+    # variable param7. The formula is EasyRPG Player's CommandSimulatedAttack,
+    # which mirrors RPG_RT: `atk - def * p_def / 400 - spi * p_spi / 800`, floored
+    # at 0, then spread by `Algo::VarianceAdjustEffect` and floored at 0 again.
+    # The hit can be lethal.
     #
     # RPG_RT's damage popup is a fixed-width widget (the same reasoning behind
     # `Game::Battle#damage_cap` on the normal-attack/skill/self-destruct/
@@ -2013,7 +2015,8 @@ module Game
       cap = @state.party.rpg2003? ? Battle::DAMAGE_CAP_2K3 : Battle::DAMAGE_CAP_2K
       stat_targets(cmd).each do |a|
         damage = atk - (a.def * cmd.param(3)) / 400 - (a.int * cmd.param(4)) / 800
-        damage += damage * simulated_attack_spread(cmd.param(5)) / 100
+        damage = 0 if damage < 0
+        damage = simulated_attack_variance(damage, cmd.param(5))
         damage = 0 if damage < 0
         damage = cap if damage > cap
         a.change_hp(-damage, true)
@@ -2022,12 +2025,30 @@ module Game
       check_game_over
     end
 
-    # A Simulated Attack's random damage spread, as a percentage in
-    # -(variance * 5) .. +(variance * 5). A variance of 0 never spreads.
-    def simulated_attack_spread(variance)
-      return 0 if variance.nil? || variance <= 0
-      span = variance * 5
-      @rng.random(span * 2 + 1) - span
+    # A Simulated Attack's random damage spread. Port of EasyRPG's
+    # `Algo::VarianceAdjustEffect` -- the exact same formula
+    # `Game::Battle#varied` already applies to a normal attack/skill/
+    # self-destruct's own damage -- reimplemented here rather than shared
+    # across classes, since `#varied` lives on `Battle`, not `Interpreter`.
+    #
+    # A prior version of this method modelled the spread as a flat +/-
+    # (variance * 5) *percent* of `base` instead, which the doc comment above
+    # incorrectly attributed to EasyRPG's own source. The two formulas'
+    # outer bounds happen to coincide (`base +/- base*var/20` either way),
+    # but the percent model's granularity is coarser by a factor of `100 /
+    # base` -- e.g. at `base` 500, `var` 5, the percent model can only ever
+    # land on one of 51 values, all multiples of 5, where the real formula
+    # (`adj = max(1, var*base/10)`, `base + rand(0, adj) - adj/2`) draws
+    # uniformly from 251 consecutive integers over the identical [375, 625]
+    # range. #varied's own floor of (at least) 1 does not apply here: a
+    # Simulated Attack's own real clamp is `std::max(0, result)`, applied
+    # both before and after the variance call, so this can land on a
+    # genuine 0 the way #varied's callers never do.
+    def simulated_attack_variance(base, var)
+      return base unless var && var > 0 && base > 0
+      adj = var * base / 10
+      adj = 1 if adj < 1
+      base + @rng.random(adj + 1) - adj / 2
     end
 
     # Change Condition: inflict or cure a status condition on the target actors.

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11656,6 +11656,34 @@ check 'Simulated Attack hard-caps damage at the battle damage cap, by edition' d
   eq 9999, st2k3.variables[1], 'RPG2003: capped at 9999, not the uncapped 15000'
 end
 
+check "Simulated Attack's variance uses RPG_RT's real spread, not a coarser percent model" do
+  # EasyRPG's CommandSimulatedAttack rolls Algo::VarianceAdjustEffect(result,
+  # var) -- the exact same formula Game::Battle#varied already applies to a
+  # normal attack/skill/self-destruct's own damage. A prior version of this
+  # method modelled the spread as a flat +/-(var*5) *percent* of the base
+  # instead (its own doc comment incorrectly attributed that to EasyRPG's
+  # source): the two formulas' outer bounds happen to coincide (base +/-
+  # base*var/20 either way), but the percent model's granularity is coarser
+  # by a factor of base/100 -- at base 500, var 5, the percent model can only
+  # ever land on a multiple of 5, where the real formula draws from every
+  # integer across the identical range. Sampling many draws and finding a
+  # non-multiple-of-5 value proves the fix, since the old model could never
+  # produce one.
+  st = party_state
+  it = Game::Interpreter.new(st)
+  results = (1..60).map { it.send(:simulated_attack_variance, 500, 5) }
+  ok results.any? { |d| d % 5 != 0 },
+     "expected a non-multiple-of-5 result at least once in 60 draws " \
+     "(got #{results.uniq.sort.inspect})"
+end
+
+check 'Simulated Attack#simulated_attack_variance skips the roll at zero variance or zero base' do
+  st = party_state
+  it = Game::Interpreter.new(st)
+  eq 500, it.send(:simulated_attack_variance, 500, 0), 'variance 0 never spreads'
+  eq 0, it.send(:simulated_attack_variance, 0, 5), 'a zero base never spreads either'
+end
+
 check 'Change Actor Face overrides the actor FaceSet' do
   st = party_state
   it = Game::Interpreter.new(st)


### PR DESCRIPTION
## Summary
- `Interpreter#do_simulated_attack` modelled its damage spread as a flat `+/- (param5 * 5)` *percent* of the base damage, which its own doc comment misattributed to EasyRPG's source. Checked directly against EasyRPG's `CommandSimulatedAttack` (`src/game_interpreter.cpp`) rather than that claim: it rolls `Algo::VarianceAdjustEffect(result, var)` — the exact same function `Game::Battle#varied` already ports correctly for a normal attack/skill/self-destruct's own damage, not a percent-based model at all.
- The two formulas' outer bounds happen to coincide algebraically (`base +/- base*var/20` either way), which is presumably how the mistake went undetected, but the percent model's granularity is coarser by a factor of `base/100`: at `atk` 500 and variance 5, the percent model can only ever land on one of 51 values, all multiples of 5, where the real formula draws uniformly from 251 consecutive integers across the identical `[375, 625]` range.
- Fixed with a new `Interpreter#simulated_attack_variance`, reimplementing `Algo::VarianceAdjustEffect` directly (`#varied` lives on `Battle`, not `Interpreter`) — floored at 0 rather than `#varied`'s own floor of 1, matching `CommandSimulatedAttack`'s own `std::max(0, result)` clamp.

## Test plan
- [x] Two new `scripts/rpg2k_logic_check.rb` checks (sampling many draws at `atk` 500 / variance 5 and confirming at least one result is not a multiple of 5, which the old percent model could never produce; and the zero-variance/zero-base passthrough cases), confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_