### PR TITLE
Use RPG2003's own EXP curve instead of always running RPG2000's

### DIFF
--- a/changelog.d/rpg2k-exp-curve-rpg2003.fixed.md
+++ b/changelog.d/rpg2k-exp-curve-rpg2003.fixed.md
@@ -1,0 +1,9 @@
+- **An RPG2003 database now uses RPG2003's own EXP curve**, instead of
+  always running RPG2000's regardless of edition. Confirmed against EasyRPG
+  Player's source: the two editions use structurally different
+  formulas — RPG2000's compounds a running base by an inflation factor each
+  level, while RPG2003's is linear in the level index — not a shared curve
+  with an edition-gated constant. Every actor in an RPG2003 database
+  previously levelled up on RPG2000's thresholds throughout the game, off by
+  as much as a third at the very first level and diverging further at every
+  level after.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -561,9 +561,11 @@ The work below is roughly ordered by the critical path to a walkable game
   and **Change Equipment** apply to a fixed actor, a variable-selected actor or
   the whole party, clamped to each actor's maxima (Change HP honours the
   allow-death floor; Change Parameters re-clamps current HP/MP when a maximum is
-  lowered; **Change EXP** re-derives the level from the RPG2000 standard curve
-  (`Game::Actor#exp_for_level`, ported from EasyRPG's `CalculateExp` off the
-  row's exp_basic/increase/correction) and **Change Level** rescales base stats
+  lowered; **Change EXP** re-derives the level from the database edition's own
+  curve (`Game::Actor#exp_for_level`/`#calc_exp`, ported from EasyRPG's
+  `CalculateExp` off the row's exp_basic/increase/correction — RPG2000 and
+  RPG2003 use genuinely different formulas, not a shared one with an
+  edition-gated constant; see the ✅ below) and **Change Level** rescales base stats
   through the per-level growth curve, both keeping EXP and level consistent
   without refilling current HP/MP, matching RPG_RT; Change Equipment folds an
   equipped item's bonuses into the effective stats). **Change Party Member**
@@ -5451,6 +5453,31 @@ not yet verified:
   5, which the old percent model could never produce; and the zero-variance/
   zero-base passthrough cases), confirmed to fail against the pre-fix code
   before the fix.
+- ✅ **An RPG2003 database now uses RPG2003's own EXP curve, instead of
+  always running RPG2000's regardless of edition.** EasyRPG's
+  `Game_Actor::CalculateExp` (`src/game_actor.cpp`) branches entirely on
+  edition (`Player::IsRPG2k() ? 1 : 2`) between two *structurally different*
+  formulas, not a shared curve with an edition-gated constant the way the
+  HP/EXP *ceilings* are: RPG2000's compounds a running base by an inflation
+  factor each step (`base *= inflation`), while RPG2003's is linear in the
+  level index (`result += base + i*inflation + correction` for `i` from 1 to
+  the level). `Game::Actor#calc_exp` had no `#rpg2003?` branch anywhere in
+  it, even though the method already exists and is used elsewhere in this
+  same class — every actor in an RPG2003 database levelled up on RPG2000's
+  thresholds throughout the game. For the shared
+  `exp_basic`/`exp_increase`/`exp_correction` = 30/30/30 default fixture,
+  the level 1→2 threshold computed 60 under the wrongly-applied RPG2000
+  curve where RPG2003's own formula gives 90 — a third off at the very
+  first level, diverging further at every level after since the curves
+  don't just differ by a constant, they have different shapes entirely.
+  Fixed by branching `#calc_exp` on `#rpg2003?` and porting
+  `CalculateExp`'s linear RPG2003 loop verbatim — plain integer arithmetic,
+  since EasyRPG's own `double` locals for this branch never leave integral
+  values, so (unlike the RPG2000 branch) no float compounding is needed to
+  match it exactly. Covered by a new `scripts/rpg2k_logic_check.rb` check
+  pinning the RPG2003 curve's own level 1→2 and 1→3 thresholds against a
+  database flagged `rpg2003: true`, confirmed to fail against the pre-fix
+  code before the fix (`expected 90, got 60`).
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2034,9 +2034,10 @@ module Game
       ml && ml >= 1 ? ml : 50
     end
 
-    # Total EXP required to *be at* `level` (0 at level 1). RPG2000's standard
-    # curve, computed from the row's exp_basic / exp_increase / exp_correction —
-    # a direct port of EasyRPG's CalculateExp(level - 1).
+    # Total EXP required to *be at* `level` (0 at level 1), computed from the
+    # row's exp_basic / exp_increase / exp_correction through the edition's
+    # own curve (#calc_exp) — a direct port of EasyRPG's
+    # CalculateExp(level - 1).
     def exp_for_level(level)
       return 0 if level <= 1
       calc_exp(level - 1)
@@ -2427,10 +2428,38 @@ module Game
       list.is_a?(Array) && !list.empty? ? list.dup : [0]
     end
 
-    # EasyRPG's CalculateExp(n): the RPG2000 standard EXP curve summed over n
-    # steps. Float arithmetic mirrors RPG_RT; the running total truncates toward
-    # zero each step (C's (int) cast) and the whole result caps at #exp_max.
+    # EasyRPG's CalculateExp(n): two genuinely different curves picked by
+    # edition (`Player::IsRPG2k() ? 1 : 2`), not a shared formula with an
+    # edition-gated constant the way the HP/EXP *caps* are -- RPG2003's own
+    # curve is linear in the level index, not the RPG2000 curve's compounding
+    # multiply-by-inflation-each-step shape. A prior version of this method
+    # ran the RPG2000 branch unconditionally regardless of database edition
+    # (no `rpg2003?` check anywhere in it), even though `#rpg2003?` already
+    # exists and is used elsewhere in this class. For the shared
+    # `exp_basic`/`exp_increase`/`exp_correction` = 30/30/30 default fixture,
+    # `calc_exp(1)` (the level 1->2 threshold) computed 60 under the RPG2000
+    # curve but should be 90 under RPG2003's -- a full third off at the very
+    # first level, diverging further at every level after since the two
+    # curves have different shapes, not just different constants. Every actor
+    # in an RPG2003 database levelled up on the wrong EXP thresholds
+    # throughout the game.
+    #
+    # RPG2000: float arithmetic mirrors RPG_RT; the running total truncates
+    # toward zero each step (C's (int) cast) and the whole result caps at
+    # #exp_max. RPG2003: the three fields are summed as plain integers, `i`
+    # times the increase field accumulating each step -- EasyRPG's own
+    # `double` locals for this branch never leave integral values, so no
+    # float arithmetic is needed to match it exactly.
     def calc_exp(n)
+      if rpg2003?
+        base = db_exp_param(:exp_basic)
+        inflation = db_exp_param(:exp_increase)
+        correction = db_exp_param(:exp_correction)
+        result = 0
+        (1..n).each { |i| result += base + i * inflation + correction }
+        cap = exp_max
+        return result > cap ? cap : result
+      end
       base = db_exp_param(:exp_basic).to_f
       inflation = 1.5 + db_exp_param(:exp_increase) * 0.01
       correction = db_exp_param(:exp_correction).to_f

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -7122,6 +7122,20 @@ check "an RPG2003 database widens the EXP cap to 9999999" do
   eq 9_999_999, b.exp_for_level(50), "calc_exp's own cap is the wider RPG2003 ceiling too"
 end
 
+check "an RPG2003 database's EXP curve is RPG2003's own linear formula, not RPG2000's" do
+  # EasyRPG's CalculateExp branches entirely on edition
+  # (`Player::IsRPG2k() ? 1 : 2`) -- RPG2003's own curve sums
+  # `base + i*inflation + correction` linearly over the level index, a
+  # structurally different formula from RPG2000's compounding
+  # multiply-by-inflation-each-step one, not just a different constant.
+  db = FakeActorDB.new({ 1 => ExpRow.new(exp_basic: 30, exp_increase: 30, exp_correction: 30) },
+                       [1], {}, {}, {}, nil, nil, rpg2003: true)
+  a = Game::Party.new(db).actor_by_id(1)
+  eq 0, a.exp_for_level(1)
+  eq 90, a.exp_for_level(2), 'level index 1 alone: 30 + 1*30 + 30 = 90'
+  eq 210, a.exp_for_level(3), 'level indices 1 and 2: 90 + (30 + 2*30 + 30 = 120) = 210'
+end
+
 IC2 = Game::Interpreter::Cmd
 
 check 'Change EXP command levels up a fixed actor' do


### PR DESCRIPTION
## Summary
- EasyRPG's `Game_Actor::CalculateExp` (`src/game_actor.cpp`) branches entirely on edition (`Player::IsRPG2k() ? 1 : 2`) between two structurally different formulas, not a shared curve with an edition-gated constant the way the HP/EXP ceilings are: RPG2000's compounds a running base by an inflation factor each step, while RPG2003's is linear in the level index (`result += base + i*inflation + correction` for `i` from 1 to the level).
- `Game::Actor#calc_exp` had no `#rpg2003?` branch anywhere in it, even though the method already exists and is used elsewhere in this same class — every actor in an RPG2003 database levelled up on RPG2000's thresholds throughout the game. For the shared `exp_basic`/`exp_increase`/`exp_correction` = 30/30/30 default fixture, the level 1→2 threshold computed 60 under the wrongly-applied RPG2000 curve where RPG2003's own formula gives 90 — a third off at the very first level, diverging further at every level after since the curves don't just differ by a constant, they have different shapes entirely.
- Fixed by branching `#calc_exp` on `#rpg2003?` and porting `CalculateExp`'s linear RPG2003 loop verbatim — plain integer arithmetic, since EasyRPG's own `double` locals for this branch never leave integral values, so no float compounding is needed to match it exactly.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check pinning the RPG2003 curve's own level 1→2 and 1→3 thresholds against a database flagged `rpg2003: true`, confirmed to fail against the pre-fix code before the fix (`expected 90, got 60`).
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_