### PR TITLE
Evaluate a map event page's Timer condition (flags bit 0x20)

### DIFF
--- a/changelog.d/event-page-timer-condition.fixed.md
+++ b/changelog.d/event-page-timer-condition.fixed.md
@@ -1,0 +1,9 @@
+- **A map event page's Timer condition (flags bit `0x20`, "Timer ≤ N
+  seconds") is now evaluated instead of being ignored.** A page conditioned
+  on the countdown read as always-active regardless of the real Timer1 value.
+  `Game::EventPage::TIMER` and `.active?`/`.select` now compare against
+  Timer1's live seconds-remaining value (active once it counts down to
+  `timer_sec` or below, matching EasyRPG's `Game_Event::AreConditionsMet`),
+  threaded through both `Scene::Map` call sites and folded into
+  `#page_revision` so a Timer-gated page re-selects the instant the
+  displayed second crosses the threshold.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -483,6 +483,29 @@ The work below is roughly ordered by the critical path to a walkable game
   target id fine, but `Scene::Map` silently no-opped it). See the "Vehicle
   move-routes" paragraph in the Movement & collision entry above for the
   implementation
+- ✅ **A page's Timer condition (flags bit `0x20`) is now evaluated, not
+  ignored.** `LCF::Schema::MAP_EVENT_PAGE_CONDITION` already parsed field 8
+  (`timer_sec`), but no flags bit ever gated it, so a page conditioned on
+  "Timer ≤ N seconds" read as always-active regardless of the real countdown.
+  Confirmed against liblcf's generated `EventPageCondition::Flags` declaration
+  order (`switch_a, switch_b, variable, item, actor, timer, timer2`, packed
+  LSB-first — the same convention the existing bits already follow) that
+  `0x20` is `timer`, a genuine RPG2000 condition, and against EasyRPG's
+  `Game_Event::AreConditionsMet` (`src/game_event.cpp`) that the comparison is
+  `if (secs > condition.timer_sec) return false` — active once Timer1 has
+  counted down to `timer_sec` or below, not on an exact match. `timer2` (bit
+  `0x40`) is confirmed RPG2003-only (gated on `Player::IsRPG2k3Commands()` in
+  that same function) and stays out of scope. `Game::EventPage::TIMER` and
+  `.active?`/`.select` now take the live seconds-remaining value, threaded in
+  from `Game::State#timer_seconds` at both call sites in `Scene::Map`
+  (`build_events` and `pages_changed?`); `#page_revision` folds
+  `@state.timer_seconds` into its sum too, so `refresh_event_pages` re-selects
+  a Timer-gated page the instant the displayed second crosses the threshold,
+  the same way it already reacts to a switch/variable/item/party change.
+  Covered by new `Game::EventPage.active?`/`.select` checks in
+  `scripts/rpg2k_logic_check.rb` and a `Scene::Map` check in
+  `scripts/rpg2k_scene_check.rb` driving Timer1 down across a page's
+  threshold mid-map.
 - 🚧 Event command interpreter — `Game::Interpreter` runs a solid subset (Show
   Message + Choices, Control Switches/Variables, Change Gold/Items/Party,
   Change HP/MP, Full Heal, Change Parameters, Change EXP/Level, Change

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -892,8 +892,12 @@ module LCF
       5 => { name: :variable_value, type: :int, default: 0 },
       6 => { name: :item_id, type: :int, default: 1 },
       7 => { name: :actor_id, type: :int, default: 1 },
+      # Genuine RPG2000 condition (flags bit 0x20): the page is active once
+      # Timer1 has counted down to timer_sec seconds or below -- see
+      # Game::EventPage::TIMER.
       8 => { name: :timer_sec, type: :int, default: 0 },
-      # RPG2003-only: a second timer condition and the variable comparison
+      # RPG2003-only: a second timer condition (flags bit 0x40, gated on
+      # Player::IsRPG2k3Commands() in EasyRPG) and the variable comparison
       # operator (0 = >=). The RPG2000 runtime always compares with >=, so these
       # are carried for schema completeness rather than consumed by EventPage.
       9 => { name: :timer2_sec, type: :int, default: 0 },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4824,14 +4824,21 @@ module Game
   # active when every sub-condition enabled in its `flags` bitfield holds; the
   # active page for an event is the highest-numbered active page.
   module EventPage
-    # flags bits (chunk 1 of the page condition).
+    # flags bits (chunk 1 of the page condition). Bit order confirmed against
+    # liblcf's generated EventPageCondition::Flags declaration (switch_a,
+    # switch_b, variable, item, actor, timer, timer2): TIMER is bit 5 (0x20),
+    # a genuine RPG2000 page condition, not an RPG2003 extension. The next bit,
+    # timer2 (0x40), *is* RPG2003-only (EasyRPG's AreConditionsMet gates it on
+    # Player::IsRPG2k3Commands()) and stays out of scope here -- see
+    # schema.rb's MAP_EVENT_PAGE_CONDITION comment.
     SWITCH_A = 0x01
     SWITCH_B = 0x02
     VARIABLE = 0x04
     ITEM     = 0x08
     ACTOR    = 0x10
+    TIMER    = 0x20
 
-    def self.active?(cond, switches, variables, party)
+    def self.active?(cond, switches, variables, party, timer_seconds = 0)
       return true if cond.nil?
       flags = cond.flags || 0
       return false if (flags & SWITCH_A) != 0 && !switches[cond.switch_a_id]
@@ -4845,15 +4852,21 @@ module Game
       if (flags & ACTOR) != 0
         return false unless party && party.include_actor?(cond.actor_id)
       end
+      # RPG_RT's AreConditionsMet: "if (secs > condition.timer_sec) return
+      # false" -- active once Timer1 has counted down to timer_sec or below,
+      # not on an exact match and not while counting up.
+      if (flags & TIMER) != 0
+        return false if timer_seconds > cond.timer_sec
+      end
       true
     end
 
     # Return [id, page] of the active page for an event, or nil when none apply.
-    def self.select(pages, switches, variables, party)
+    def self.select(pages, switches, variables, party, timer_seconds = 0)
       return nil if pages.nil?
       chosen = nil
       pages.each do |id, page|
-        chosen = [id, page] if active?(page.condition, switches, variables, party)
+        chosen = [id, page] if active?(page.condition, switches, variables, party, timer_seconds)
       end
       chosen
     end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -1014,7 +1014,8 @@ class RPG2k
           @event_last_position[id] ||= [ev.x, ev.y, nil]
           next if @erased_events[id] # an Erase Event lasts the whole visit
           selected = Game::EventPage.select(ev.pages, @state.switches,
-                                            @state.variables, @state.party)
+                                            @state.variables, @state.party,
+                                            @state.timer_seconds)
           next unless selected
           page = selected[1]
           @events.push(build_event(id, ev, page, restore_route_index: restore_route_index))
@@ -2514,20 +2515,27 @@ class RPG2k
       # -- page refresh -------------------------------------------------------
 
       # An event's active page is chosen by its conditions, and those read the
-      # switches, the variables, the party roster and its items. Change one and
-      # the choice can change with it — the "talk to me once and I turn into my
-      # page 2" idiom every RPG2000 game is built on. The pages were only ever
-      # selected when the map loaded, so an event kept whichever page it started
-      # the visit with until the player left and came back.
+      # switches, the variables, the party roster and its items, and Timer1's
+      # remaining seconds. Change one and the choice can change with it — the
+      # "talk to me once and I turn into my page 2" idiom every RPG2000 game is
+      # built on. The pages were only ever selected when the map loaded, so an
+      # event kept whichever page it started the visit with until the player
+      # left and came back.
       #
-      # RPG_RT re-selects them whenever those four things change (its
-      # `Game_Map::SetNeedRefresh`, set by Control Switches / Variables, Change
-      # Items and Change Party Member). Rather than flagging each command — which
-      # silently misses any path that is not an event command, like using an item
-      # from the menu — this watches the revision counters those four carry, so
-      # every writer is covered by construction.
+      # RPG_RT re-selects them whenever those change (its `Game_Map::
+      # SetNeedRefresh`, set by Control Switches / Variables, Change Items and
+      # Change Party Member -- plus, for a Timer condition, every tick of the
+      # countdown). Rather than flagging each command — which silently misses
+      # any path that is not an event command, like using an item from the menu
+      # — this watches the revision counters those carry, so every writer is
+      # covered by construction. Timer1's seconds figure has no revision
+      # counter of its own, but it only ever changes once a second (it is
+      # already whole seconds -- #timer_seconds), so folding it into the sum
+      # catches exactly the frame a Timer condition's threshold is crossed
+      # without sweeping every frame in between.
       def page_revision
-        rev(@state.switches) + rev(@state.variables) + rev(@state.party)
+        rev(@state.switches) + rev(@state.variables) + rev(@state.party) +
+          @state.timer_seconds
       end
 
       # A collaborator's revision counter, or 0 for one that keeps none (the
@@ -2564,7 +2572,8 @@ class RPG2k
         evs.each do |id, src|
           next if changed || @erased_events[id]
           selected = Game::EventPage.select(src.pages, @state.switches,
-                                            @state.variables, @state.party)
+                                            @state.variables, @state.party,
+                                            @state.timer_seconds)
           page = selected && selected[1]
           e = live[id]
           changed = true unless page.equal?(e && e[:page])

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -11842,12 +11842,107 @@ check 'starting a new BGM clears the "played once" flag' do
   eq false, st.bgm_looped
 end
 
+# -- map-event pages ----------------------------------------------------------
+
+# A page: a condition plus the command list it runs. Shared by the map-event
+# and battle-event page checks below.
+FakePage = Struct.new(:condition, :event)
+
+# A map event page condition (LMU chunk 1 of MAP_EVENT_PAGE_CONDITION). Only
+# the fields a given check enables in `flags` are read, so the rest can stay
+# at their editor defaults.
+FakeEventCond = Struct.new(:flags, :switch_a_id, :switch_b_id, :variable_id,
+                            :variable_value, :item_id, :actor_id, :timer_sec)
+def event_cond(flags, opts = {})
+  c = FakeEventCond.new(flags)
+  c.variable_value = 0
+  c.timer_sec = 0
+  opts.each { |k, v| c.send("#{k}=", v) }
+  c
+end
+
+# A minimal party stand-in for EventPage::ITEM / ::ACTOR: just enough to
+# answer has_item?/include_actor? from plain arrays.
+FakeEventPageParty = Struct.new(:items, :actor_ids) do
+  def has_item?(id); items.include?(id); end
+  def include_actor?(id); actor_ids.include?(id); end
+end
+
+check 'Game::EventPage.active? tests switch, variable, item and actor conditions' do
+  st = new_state
+  sw = st.switches
+  vars = st.variables
+  party = FakeEventPageParty.new([], [])
+
+  # RPG_RT reads an entirely unticked condition box as "always", unlike a
+  # battle-event page's box (BattlePage.active? above reads that as "never").
+  eq true, Game::EventPage.active?(nil, sw, vars, party), 'a page with no condition always fires'
+  eq true, Game::EventPage.active?(event_cond(0), sw, vars, party), 'nor does one with no flags set'
+
+  cond = event_cond(Game::EventPage::SWITCH_A, switch_a_id: 3)
+  eq false, Game::EventPage.active?(cond, sw, vars, party)
+  sw[3] = true
+  eq true, Game::EventPage.active?(cond, sw, vars, party)
+
+  vcond = event_cond(Game::EventPage::VARIABLE, variable_id: 2, variable_value: 5)
+  eq false, Game::EventPage.active?(vcond, sw, vars, party)
+  vars[2] = 5
+  eq true, Game::EventPage.active?(vcond, sw, vars, party), 'the test is >=, not =='
+
+  icond = event_cond(Game::EventPage::ITEM, item_id: 7)
+  eq false, Game::EventPage.active?(icond, sw, vars, party)
+  party.items << 7
+  eq true, Game::EventPage.active?(icond, sw, vars, party)
+
+  acond = event_cond(Game::EventPage::ACTOR, actor_id: 1)
+  eq false, Game::EventPage.active?(acond, sw, vars, party)
+  party.actor_ids << 1
+  eq true, Game::EventPage.active?(acond, sw, vars, party)
+end
+
+check 'Game::EventPage.active? tests the Timer (0x20) condition against Timer1 seconds' do
+  st = new_state
+  sw = st.switches
+  vars = st.variables
+  party = FakeEventPageParty.new([], [])
+
+  # RPG_RT's AreConditionsMet: "if (secs > condition.timer_sec) return false"
+  # -- active once Timer1 has counted down to timer_sec seconds or below.
+  cond = event_cond(Game::EventPage::TIMER, timer_sec: 30)
+  eq false, Game::EventPage.active?(cond, sw, vars, party, 60), 'well above the threshold'
+  eq false, Game::EventPage.active?(cond, sw, vars, party, 31), 'one second above the threshold'
+  eq true, Game::EventPage.active?(cond, sw, vars, party, 30), 'exactly at the threshold: <=, not <'
+  eq true, Game::EventPage.active?(cond, sw, vars, party, 10), 'counted down past the threshold'
+  eq true, Game::EventPage.active?(cond, sw, vars, party, 0), 'timer fully elapsed'
+
+  # A page can gate on more than one thing at once -- both must hold.
+  combo = event_cond(Game::EventPage::SWITCH_A | Game::EventPage::TIMER,
+                      switch_a_id: 4, timer_sec: 30)
+  eq false, Game::EventPage.active?(combo, sw, vars, party, 10), 'timer alone is not enough'
+  sw[4] = true
+  eq true, Game::EventPage.active?(combo, sw, vars, party, 10)
+  eq false, Game::EventPage.active?(combo, sw, vars, party, 60), 'switch alone is not enough'
+end
+
+check 'Game::EventPage.select picks the last page whose conditions (including Timer) hold' do
+  st = new_state
+  sw = st.switches
+  vars = st.variables
+  party = FakeEventPageParty.new([], [])
+
+  always = FakePage.new(nil, [])
+  timer_gated = FakePage.new(event_cond(Game::EventPage::TIMER, timer_sec: 10), [])
+  pages = { 1 => always, 2 => timer_gated }
+
+  eq [1, always], Game::EventPage.select(pages, sw, vars, party, 60),
+     'above the threshold: only the unconditional page qualifies'
+  eq [2, timer_gated], Game::EventPage.select(pages, sw, vars, party, 5),
+     'once the timer counts down past the threshold, the later page wins'
+end
+
 # -- battle-event pages and their commands ------------------------------------
 
 BP = Game::BattlePage
-
-# A troop battle-event page: a condition plus the command list it runs.
-FakePage = Struct.new(:condition, :event)
 
 # A troop battle-event page condition. Only the fields a given check enables in
 # `flags` are read, so the rest can stay at their editor defaults.

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -939,6 +939,33 @@ check 'flipping a switch re-selects an event page mid-map' do
   ok st.switches[5], 'and its parallel process now runs'
 end
 
+# An event whose page 2 is gated on Timer1 having counted down to
+# `timer_sec` seconds or below (flags bit 0x20 -- see Game::EventPage::TIMER).
+def timer_gated_event(x, y, timer_sec, page1, page2)
+  page2.condition = OpenStruct.new(flags: Game::EventPage::TIMER, timer_sec: timer_sec)
+  OpenStruct.new(x: x, y: y, pages: { 1 => page1, 2 => page2 })
+end
+
+check "Timer1 counting down past a page's threshold re-selects it mid-map" do
+  # Page 1 (trigger 0) is active above 5 s left; page 2 (trigger 4) takes over
+  # once Timer1 reads 5 s or below.
+  p1 = page(trigger: 0, charset_name: 'Villager')
+  p2 = page(trigger: 4, charset_name: 'Ghost')
+  scene = new_scene({ 1 => timer_gated_event(2, 2, 5, p1, p2) }, player: [0, 0])
+  st = scene.instance_variable_get(:@state)
+  st.timer(0).set(7) # 7 s left -- above the 5 s threshold
+  st.timer(0).start(false)
+
+  scene.update
+  ev = event_hashes(scene)[1]
+  eq 0, ev[:trigger], 'still above the threshold: page 1 stays active'
+
+  130.times { scene.update } # ticks Timer1 down from 7 s to 5 s (< 60*2 frames)
+  ev = event_hashes(scene)[1]
+  eq 4, ev[:trigger], 'Timer1 counted down to the threshold: page 2 takes over'
+  eq 5, st.timer_seconds
+end
+
 check "an unrelated event's page change does not reset another event's " \
       'Through Mode / Direction Fix / Stop Animation / Transparency' do
   # Event 1 (the bystander) never changes page; event 2 is the one gated on


### PR DESCRIPTION
## Summary

- A map event page conditioned on "Timer ≤ N seconds" (flags bit `0x20`) read as always-active regardless of Timer1's actual countdown. `LCF::Schema::MAP_EVENT_PAGE_CONDITION` already parsed field 8 (`timer_sec`), but no flags bit ever gated it in `Game::EventPage.active?`.
- Confirmed against liblcf's generated `EventPageCondition::Flags` declaration order (`switch_a, switch_b, variable, item, actor, timer, timer2`, packed LSB-first) that `0x20` is `timer`, a genuine RPG2000 condition — `timer2` (`0x40`) is confirmed RPG2003-only (gated on `Player::IsRPG2k3Commands()` in EasyRPG's `Game_Event::AreConditionsMet`) and stays out of scope for this PR.
- Confirmed against that same `AreConditionsMet` (`src/game_event.cpp`) that the comparison is `if (secs > condition.timer_sec) return false` — the page is active once Timer1 has counted down to `timer_sec` seconds or below, not on an exact match.
- Added `Game::EventPage::TIMER = 0x20` and extended `.active?`/`.select` to take the live seconds-remaining value, following the exact structural pattern of the existing `SWITCH_A`/`VARIABLE`/`ITEM`/`ACTOR` checks.
- Threaded `Game::State#timer_seconds` through both `Scene::Map` call sites (`build_events`, `pages_changed?`), and folded it into `#page_revision`'s sum so a Timer-gated page re-selects the instant the displayed second crosses the threshold — the same way the sweep already reacts to a switch/variable/item/party change.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 854 checks pass, including new `Game::EventPage.active?`/`.select` unit checks (switch/variable/item/actor plus the new Timer condition, individually and combined).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 582 checks pass, including a new `Scene::Map` check driving Timer1 down across a page's threshold mid-map.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files) on the touched files.
- [x] `docs/TODO.md` and a `changelog.d/` fragment updated per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01AWgqJHRDn3PVuy3A96Nh5y


---
_Generated by [Claude Code](https://claude.ai/code/session_01AWgqJHRDn3PVuy3A96Nh5y)_