### PR TITLE
Wire up item use_skill/class_set for direct field/battle use

### DIFF
--- a/changelog.d/item-use-skill.added.md
+++ b/changelog.d/item-use-skill.added.md
@@ -1,0 +1,6 @@
+- **A weapon/shield/armour/helmet/accessory item flagged `use_skill`** is now
+  usable directly from the field and battle Item menus, invoking its
+  `skill_id` skill for free without being equipped -- the same "item triggers
+  a skill" path a type-9 special item already gets, restricted to the classes
+  in its `class_set` list when one is set. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2578,6 +2578,41 @@ The work below is roughly ordered by the critical path to a walkable game
   time or leaves the screen with none picked; Confirm applies the picked
   order to the party and closes; Redo clears every pick without touching the
   party)
+  ✅ **A weapon/shield/armour/helmet/accessory item flagged `use_skill`
+  (schema field 71) is now usable directly from the field and battle Item
+  menus too, invoking its `skill_id` skill without being equipped.** The
+  schema has carried `use_skill` and its `class_set` restriction list (field
+  73, RPG2003 classes allowed to trigger it) since the Item struct was
+  written, but nothing in `mruby-rpg2k/mrblib` ever read either field —
+  `#field_usable?`/`#battle_usable?`/`#use_item` only `case`d on
+  `it.type`, and no equipment type (1-5) was ever a reachable branch there,
+  so such an item sat in the bag forever, `use_skill` or not. Confirmed
+  against EasyRPG Player's real source rather than guessed:
+  `Game_Party::UseItem`'s `do_skill` computation is `item->type ==
+  Type_special || (item->use_skill && item->type is one of
+  weapon/shield/armor/helmet/accessory)` — the same "item triggers a skill"
+  shape a type-9 special item already gets here, just gated on a flag
+  instead of a dedicated type. `#field_usable?`/`#battle_usable?` gained a
+  matching `it.type` branch (weapon(1)/shield(2)/armor(3)/helmet(4)/
+  accessory(5)) that defers to `#field_skill?`/`#battle_skill?` on the same
+  `skill_id` exactly like the special-item branch, and a new
+  `Game::Party#use_equip_skill_item` casts it for free through `#cast_skill`
+  the same way `#use_special_item` does, additionally gated on a new
+  `#item_usable_by_class?` — `class_set`'s own restriction check, read the
+  same "empty/short array reads as allowed" way `#item_usable_by?` already
+  reads `actor_set` for every other item kind, indexed by the acting actor's
+  RPG2003 `class_id` rather than actor id. Covered by two new
+  `scripts/rpg2k_logic_check.rb` checks: an unflagged weapon stays ordinary
+  gear (not menu-usable) while the same item flagged `use_skill` behaves
+  exactly like an equivalent type-9 special item across all five equipment
+  types, and a `class_set`-restricted item triggers for an actor in a listed
+  class but not one outside it. `Scene::ItemMenu#choose_item`'s own dispatch
+  is untouched, so a use_skill equipment item always takes the generic
+  "prompt for a target" branch every other single-ally item takes -- correct
+  for the ordinary case, but not yet special-cased the way a type-9 special
+  item is for a self/all-ally-scope or Escape/Teleport-type attached skill
+  (see the special-item field/battle fixes above); left for whenever such an
+  item shows up in a real game.
 - 🚧 Save & Continue — the portable `Marshal` save of the game state
   (`Game::State#to_h` / `State.load`) is the authoritative save, written via the
   menu's Save command; "Continue" reloads it. **Reading** the real

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2845,6 +2845,18 @@ module Game
     ITEM_SPECIAL = 9
     ITEM_SWITCH = 10
 
+    # The five equipment types (see Actor::EQUIP_ORDER for the slot mapping),
+    # named here for #field_usable? / #battle_usable? / #use_item's `use_skill`
+    # branch: an equipment item flagged `use_skill` (field 71) invokes its
+    # `skill_id` skill directly from the Item menu, exactly like a type-9
+    # special item, without being equipped. Confirmed against EasyRPG's
+    # `Game_Party::UseItem`, whose `do_skill` computation ORs `use_skill` with
+    # this exact five-type check.
+    ITEM_SHIELD = 2
+    ITEM_ARMOR = 3
+    ITEM_HELMET = 4
+    ITEM_ACCESSORY = 5
+
     # The database row for a held item id, or nil when the database has no item
     # table (a bare test fixture) or no such row.
     def db_item(id)
@@ -2912,6 +2924,8 @@ module Game
       when ITEM_MEDICINE, ITEM_SKILL_BOOK, ITEM_SEED then true
       when ITEM_SWITCH then item_field_occasion?(it)
       when ITEM_SPECIAL then field_skill?(db_skill(it.skill_id), state)
+      when Actor::ITEM_WEAPON, ITEM_SHIELD, ITEM_ARMOR, ITEM_HELMET, ITEM_ACCESSORY
+        it.use_skill && field_skill?(db_skill(it.skill_id), state)
       else false
       end
     end
@@ -3060,6 +3074,26 @@ module Game
       set[idx] ? true : false
     end
 
+    # `class_set` (item field 73), `use_skill`'s companion restriction list:
+    # whether `actor`'s RPG2003 class (Actor#class_id) is among the classes
+    # allowed to trigger this item's skill, when the item actually restricts by
+    # class (a non-empty `class_set`, i.e. `class_set_size` field 72 > 0).
+    # Mirrors EasyRPG's `Game_Actor::IsItemUsable` class_set arm and follows
+    # #item_usable_by?'s own "empty/short array reads as allowed" convention
+    # for this bit-array field pair (the `_size` field itself is never read --
+    # the array's own length already carries it, as for actor_set/state_set/
+    # attribute_set). An actor with no class (RPG2000 has none) is always
+    # allowed.
+    def item_usable_by_class?(it, actor)
+      return true unless it.respond_to?(:class_set) && it.class_set
+      class_id = actor && actor.respond_to?(:class_id) ? (actor.class_id || 0) : 0
+      return true if class_id <= 0
+      set = it.class_set
+      idx = class_id - 1
+      return true if idx < 0 || set.size <= idx
+      set[idx] ? true : false
+    end
+
     # Whether using item `id` on `actor` would change anything, so the menu can
     # grey out a no-op. A medicine is effective when the target is below full
     # HP/SP and it restores some (RPG_RT forbids using a pure-recovery item on a
@@ -3104,6 +3138,8 @@ module Game
       when ITEM_SKILL_BOOK then use_skill_book(it, id, actor)
       when ITEM_SEED then use_seed(it, id, actor)
       when ITEM_SPECIAL then use_special_item(it, id, actor)
+      when Actor::ITEM_WEAPON, ITEM_SHIELD, ITEM_ARMOR, ITEM_HELMET, ITEM_ACCESSORY
+        it.use_skill ? use_equip_skill_item(it, id, actor) : []
       else []
       end
     end
@@ -3121,6 +3157,18 @@ module Game
     # reason a switch item bypasses #use_item for #use_switch_item.
     def use_special_item(it, id, actor)
       return [] unless actor && item_usable_by?(it, actor.id)
+      affected = cast_skill(actor, it.skill_id, actor, true)
+      lose_item(id, 1) unless affected.empty?
+      affected
+    end
+
+    # A weapon/shield/armour/helmet/accessory item flagged `use_skill` invokes
+    # its `skill_id` skill directly, without being equipped -- the same free
+    # cast #use_special_item gives a type-9 special item, gated additionally by
+    # `class_set` (#item_usable_by_class?), the restriction list a use_skill
+    # equipment item carries that a special item does not.
+    def use_equip_skill_item(it, id, actor)
+      return [] unless actor && item_usable_by?(it, actor.id) && item_usable_by_class?(it, actor)
       affected = cast_skill(actor, it.skill_id, actor, true)
       lose_item(id, 1) unless affected.empty?
       affected
@@ -4072,6 +4120,8 @@ module Game
       when ITEM_MEDICINE then !item_field_only?(it)
       when ITEM_SWITCH then item_battle_occasion?(it)
       when ITEM_SPECIAL then battle_skill?(db_skill(it.skill_id))
+      when Actor::ITEM_WEAPON, ITEM_SHIELD, ITEM_ARMOR, ITEM_HELMET, ITEM_ACCESSORY
+        it.use_skill && battle_skill?(db_skill(it.skill_id))
       else false
       end
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2966,9 +2966,20 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       :animation_id,
                       # ステート発生率 (weapon field 67): the flat percent chance
                       # applied to every state `state_set` flags on a basic
-                      # Attack (Game::Actor#weapon_states). Appended last, same
-                      # positional-safety reasoning as every field above.
-                      :state_chance)
+                      # Attack (Game::Actor#weapon_states).
+                      :state_chance,
+                      # 特殊効果 (field 71): a weapon/shield/armour/helmet/
+                      # accessory item flagged this way invokes `skill_id`
+                      # directly from the Item menu, the same as a type-9
+                      # special item, without being equipped
+                      # (Game::Party#use_equip_skill_item).
+                      :use_skill,
+                      # 使用可能職業 (field 73): `use_skill`'s companion --
+                      # the RPG2003 class ids (0-based index, bool per class)
+                      # allowed to trigger it this way
+                      # (Game::Party#item_usable_by_class?). Appended last,
+                      # same positional-safety reasoning as every field above.
+                      :class_set)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -2978,14 +2989,14 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
               cursed: false, raise_evasion: false, animation_id: nil,
-              state_chance: 0)
+              state_chance: 0, use_skill: false, class_set: nil)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
-               raise_evasion, animation_id, state_chance)
+               raise_evasion, animation_id, state_chance, use_skill, class_set)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -5000,6 +5011,88 @@ check 'a special item invokes its skill, free of SP and without knowing it' do
   eq 90, hero.hp, 'the skill landed'
   eq 0, hero.mp, 'no SP was spent'
   eq 1, st.party.item_count(3), 'one was consumed'
+end
+
+check 'a use_skill-flagged equipment item invokes its skill directly, free ' \
+      'and unequipped, the same as a type-9 special item' do
+  # Type 1 is 武器 (weapon): with no use_skill flag it is ordinary gear, never
+  # offered by the Item menu. Flip use_skill on and it behaves exactly like a
+  # type-9 special item -- confirmed against EasyRPG's Game_Party::UseItem,
+  # whose `do_skill` ORs `use_skill` with a Weapon/Shield/Armor/Helmet/
+  # Accessory type check.
+  skills = { 8 => fake_skill(name: 'Elixir', scope: 3, sp_cost: 99,
+                             power: 40, hp: true) }
+  plain = { 3 => fake_item(type: 1, skill_id: 8, name: 'Plain Sword') }
+  st = skill_party(skills, plain)
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(3, 2)
+  ok !st.party.field_usable?(3), 'no use_skill flag -- ordinary equipment, not menu-usable'
+  ok !st.party.battle_usable?(3)
+  eq [], st.party.use_item(3, hero)
+  eq 2, st.party.item_count(3), 'nothing consumed'
+
+  rune = { 4 => fake_item(type: 1, skill_id: 8, use_skill: true, name: 'Rune Sword') }
+  st = skill_party(skills, rune)
+  hero = st.party.actor_by_id(1)
+  hero.change_hp(-50)
+  hero.mp = 0                                   # cannot afford the skill itself
+  ok !hero.knows_skill?(8), 'and has never learnt it'
+  st.party.gain_item(4, 2)
+  ok st.party.field_usable?(4), 'use_skill plus an ally-scope skill offers it'
+  ok st.party.battle_usable?(4)
+  affected = st.party.use_item(4, hero)
+  eq [hero], affected
+  eq 90, hero.hp, 'the skill landed'
+  eq 0, hero.mp, 'no SP was spent -- the item is the cost'
+  eq 1, st.party.item_count(4), 'one was consumed'
+
+  # Shield (2), armour (3), helmet (4) and accessory (5) all take the same
+  # branch, not just weapons.
+  [2, 3, 4, 5].each do |t|
+    gear = { 5 => fake_item(type: t, skill_id: 8, use_skill: true, name: "Gear #{t}") }
+    gst = skill_party(skills, gear)
+    ghero = gst.party.actor_by_id(1)
+    ghero.change_hp(-50)
+    gst.party.gain_item(5, 1)
+    ok gst.party.field_usable?(5), "type #{t} with use_skill is field-usable"
+    eq [ghero], gst.party.use_item(5, ghero)
+  end
+end
+
+check 'a use_skill equipment item restricted by class_set is only usable by ' \
+      'an actor in one of its listed classes' do
+  actor_curve = []
+  3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
+  job1 = []
+  3.times { |i| job1.concat([200 + i * 10, 40, 20 + i, 16, 12, 8]) }
+  job2 = []
+  3.times { |i| job2.concat([50 + i * 10, 10, 5 + i, 4, 3, 2]) }
+  skills = { 8 => fake_skill(name: 'Elixir', scope: 3, sp_cost: 99, power: 40, hp: true) }
+  # class_set index 0 (class 1) false, index 1 (class 2) true: only class 2 may
+  # trigger it.
+  items = { 4 => fake_item(type: 1, skill_id: 8, use_skill: true,
+                           class_set: [false, true], name: 'Class Rune') }
+  players = {
+    1 => ClassedRow.new('Warrior', '', 0, 3, actor_curve, [], 1, nil),
+    2 => ClassedRow.new('Mage', '', 0, 3, actor_curve, [], 2, nil),
+  }
+  jobs = {
+    1 => JobRow.new('Fighter', job1),
+    2 => JobRow.new('Mage', job2),
+  }
+  db = FakeActorDB.new(players, [1, 2], items, skills, jobs)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  warrior = st.party.actor_by_id(1)
+  mage = st.party.actor_by_id(2)
+  eq 1, warrior.class_id
+  eq 2, mage.class_id
+  st.party.gain_item(4, 2)
+  warrior.change_hp(-50)
+  mage.change_hp(-50)
+  eq [], st.party.use_item(4, warrior), "class 1 isn't in class_set"
+  eq 2, st.party.item_count(4), 'nothing consumed'
+  eq [mage], st.party.use_item(4, mage), 'class 2 is listed'
+  eq 1, st.party.item_count(4), 'one was consumed'
 end
 
 check 'a special item invoking an Escape skill is hidden with no runtime ' \


### PR DESCRIPTION
## Summary

- The Item database's `use_skill` flag (Item schema field 71) and its `class_set` companion (field 73) were completely unread in `mruby-rpg2k/mrblib`, so a weapon/shield/armour/helmet/accessory item flagged this way never appeared as usable in either the field or battle Item menu, and never actually triggered its `skill_id` skill.
- Confirmed the real rule against EasyRPG Player's source directly: `Game_Party::UseItem`'s `do_skill` computation is `item->type == Type_special || (item->use_skill && item->type is one of weapon/shield/armor/helmet/accessory)` — the same "item triggers a skill" shape a type-9 special item already gets here, just gated on a flag instead of a dedicated type. `Game_Actor::IsItemUsable` restricts by `class_set` (indexed by the actor's class id) the same "empty/short array reads as allowed" way it restricts by `actor_set` for every item kind.
- `#field_usable?`/`#battle_usable?` gained a matching equipment-type branch that defers to `#field_skill?`/`#battle_skill?` on the item's `skill_id`, exactly like the existing type-9 special-item branch.
- New `Game::Party#use_equip_skill_item` casts the skill for free through `#cast_skill`, the same way `#use_special_item` does, additionally gated by a new `#item_usable_by_class?` reading `class_set`.
- Added `docs/TODO.md` and `changelog.d/item-use-skill.added.md` entries, including an honest caveat that `Scene::ItemMenu#choose_item`'s dispatch is untouched (a use_skill equipment item always takes the generic "prompt for a target" branch, not yet special-cased for a self/all-ally-scope or Escape/Teleport-type attached skill the way a type-9 special item is).

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 853 checks pass, including two new checks: a use_skill-flagged weapon/shield/armour/helmet/accessory item behaves like an equivalent type-9 special item (field/battle usability + actual skill trigger), and a `class_set`-restricted item is usable only by an actor in one of its listed classes.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer) on all changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn7B4RLfTLSnHbMoerZh3v)_