### PR TITLE
Show real RPG_RT battle-start encounter messages before the command phase

### DIFF
--- a/changelog.d/battle-encounter-message.added.md
+++ b/changelog.d/battle-encounter-message.added.md
@@ -1,0 +1,12 @@
+- The RPG2000 runtime now narrates a battle's opening the way real RPG_RT
+  does: one database `encounter` line per visible troop member (name +
+  term, matching how `victory`/`level_up`/`item_received` already
+  substitute), plus a fixed `special_combat` line appended after them on a
+  first-strike ambush — confirmed against EasyRPG Player's
+  `Scene_Battle_Rpg2k::ProcessSceneActionStart` that `special_combat` trails
+  the per-enemy lines rather than replacing them. A troop member flagged
+  invisible is skipped, matching Show Hidden Monster's own `hidden`
+  modelling. Shown via the existing action-banner window (the same one a
+  landed hit banners) right after the Battle Start SE/BGM and before the
+  command phase opens. Covered by three new `scripts/rpg2k_scene_check.rb`
+  checks.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3374,6 +3374,38 @@ The work below is roughly ordered by the critical path to a walkable game
   Battle/Escape each dispatching correctly (including the Escape-forbidden
   Buzzer, which now leaves the window open rather than the old command
   menu), and B/Cancel's no-op while it is open.
+- ✅ **The encounter/monster-appear messages flagged above are now shown
+  too** — the other half of `ProcessSceneActionStart()` the options-window
+  writeup traced but left open: `Scene::Map#open_battle` used to jump
+  straight from the Battle Start SE/BGM into the options window (or the
+  ordinary command menu) with no message at all. It now narrates the
+  encounter first, exactly as EasyRPG's source builds it:
+  `GetActiveBattlers` (not dead or hidden — the same subset `Game::Enemy
+  #hidden`/Show Hidden Monster already models) feeds one `terms.encounter`
+  line per visible troop member, each built by concatenating the enemy's own
+  name in front of the term (`PushWithSubject`'s stock, non-Maniac-Patch
+  branch: `subject + message`, no placeholder — the same convention this
+  screen's `victory`/`level_up`/`item_received` lines already follow), and
+  then, only for a first-strike ambush (`req[:first_strike]`, already
+  threaded through for the actual mechanic), a final fixed `terms.
+  special_combat` line with no name substitution. **Confirmed against the
+  real source rather than assumed:** `special_combat` is pushed *in addition
+  to*, not instead of, the per-enemy lines — `ProcessSceneActionStart`'s
+  `eFirstStrike` substate runs strictly after `eDisplayMonsters` clears.
+  Nothing shows when every troop member is hidden and the fight is not a
+  first strike, matching `if (!visible_enemies.empty()) SetWait(...)`
+  gating the whole substate there. This screen has no per-page message
+  window (see `#battle_result_lines`'s own comment on the same
+  simplification), so the whole narration — every line at once — reuses the
+  existing action-banner mechanism (`#show_battle_banner`/
+  `#battle_panel_window`, the same one a landed hit banners) rather than a
+  new window, held for a new `:encounter_message` sub-state's own short
+  fixed beat (`BATTLE_ENCOUNTER_MSG_FRAMES`) instead of RPG_RT's per-line
+  wordwrap/wait-timer pacing. Covered by three new
+  `scripts/rpg2k_scene_check.rb` checks: a normal encounter narrates every
+  visible troop member by name, a first-strike encounter appends
+  `special_combat` after those same per-enemy lines rather than replacing
+  them, and a troop member flagged invisible gets no arrival line at all.
 - ✅ Audio playback — `RGSS::Audio` now plays real BGM/BGS/ME/SE through an
   SDL_mixer backend (`src/sdl_audio.cxx`), resolving names under
   `Music/`/`Sound/`/`Audio/*`

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4392,6 +4392,7 @@ class RPG2k
         update_enemy_flashes
         update_enemy_positions
         case @battle_ui[:phase]
+        when :encounter_message then drive_battle_encounter_message
         when :battle_options then drive_battle_options
         when :command     then drive_battle_command
         when :target      then drive_battle_target
@@ -4484,8 +4485,68 @@ class RPG2k
         @battle_ui[:events].resolver = owner.resolver
         build_battle_sprites
         refresh_battle_status
-        # Turn-0 pages fire before the party is asked for its first command —
-        # this is where a troop's opening dialogue lives.
+        # RPG_RT's own `Scene_Battle_Rpg2k::ProcessSceneActionStart`
+        # (EasyRPG Player's `src/scene_battle_rpg2k.cpp`) narrates the
+        # encounter before the party is ever asked for a command: one
+        # `terms.encounter` line per visible (non-`hidden`) troop member
+        # -- `Game_EnemyParty::GetActiveBattlers`, "not dead or hidden" --
+        # each built by concatenating the enemy's own name in front of the
+        # term (`Window_BattleMessage::PushWithSubject`'s stock, non-
+        # Maniac-Patch branch: `subject + message`, no placeholder), then,
+        # if this encounter is a first-strike ambush
+        # (`req[:first_strike]`, already threaded through to `Game::Battle`
+        # above for the actual mechanic), a final fixed `terms.
+        # special_combat` line with no name substitution -- pushed
+        # *in addition to*, not instead of, the per-enemy lines, exactly as
+        # real RPG_RT orders them. Nothing shows when the troop is entirely
+        # hidden and the fight is not a first strike, matching
+        # `if (!visible_enemies.empty()) SetWait(...)` gating the whole
+        # substate there.
+        lines = battle_encounter_lines(troop, req)
+        if lines.empty?
+          return if run_battle_events
+          settle_already_finished_battle || enter_command_phase
+        else
+          show_battle_banner(lines)
+          @battle_ui[:phase] = :encounter_message
+          @battle_ui[:anim_timer] = BATTLE_ENCOUNTER_MSG_FRAMES
+        end
+      end
+
+      # The encounter narration lines built above -- see #open_battle's own
+      # comment for the real-RPG_RT sourcing. Returns [] when there is
+      # nothing to say (every troop member hidden, no first strike).
+      def battle_encounter_lines(troop, req)
+        lines = troop.members.reject(&:hidden).map do |enemy|
+          "#{enemy.name}#{term(:encounter, ' appeared!')}"
+        end
+        lines << term(:special_combat, 'You get the first strike!') if req[:first_strike]
+        lines
+      end
+
+      # How long the encounter banner lingers before the command phase opens.
+      # Real RPG_RT paces this per-line with wordwrap and per-page wait
+      # timers (`SetWait(4, 4)` / `SetWait(8, 8)` / `SetWait(30, 70)`); this
+      # screen has no per-page message window (see #battle_result_lines'
+      # own comment on the same simplification), so the whole banner -- every
+      # line at once -- holds for one flat beat instead, matching only
+      # RPG_RT's own minimum `SetWait(4, 4)` gate rather than the full
+      # per-line reading pause -- long enough to register as its own frame
+      # of input-free banner before the command menu takes over the same
+      # screen rect.
+      BATTLE_ENCOUNTER_MSG_FRAMES = 4
+
+      # Drive the encounter-message phase: hold the banner for
+      # `BATTLE_ENCOUNTER_MSG_FRAMES`, then drop it and fall into the same
+      # turn-0-battle-event / command-phase flow #open_battle used to reach
+      # directly.
+      def drive_battle_encounter_message
+        if @battle_ui[:anim_timer] > 0
+          @battle_ui[:anim_timer] -= 1
+          return
+        end
+        close_battle_action
+        @battle_ui[:phase] = :command
         return if run_battle_events
         settle_already_finished_battle || enter_command_phase
       end

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5178,10 +5178,12 @@ check 'Open Shop scene: leaving without buying runs the No Transaction branch' d
 end
 
 # Battle command / result command lists for the encounter tests below.
-def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil, troop_id: 1)
+def battle_event_commands(ic, escape_mode: 0, second_switch_code: nil, troop_id: 1,
+                          first_strike: false)
   handler2 = second_switch_code || ic::ESCAPE_HANDLER
   [
-    ECmd.new(ic::ENEMY_ENCOUNTER, [0, troop_id, 0, escape_mode, 1, 0], indent: 0),
+    ECmd.new(ic::ENEMY_ENCOUNTER,
+             [0, troop_id, 0, escape_mode, 1, first_strike ? 1 : 0], indent: 0),
     ECmd.new(ic::VICTORY_HANDLER, [], indent: 0),
     ECmd.new(ic::CONTROL_SWITCHES, [0, 1, 1, 0], indent: 1),
     ECmd.new(handler2, [], indent: 0),
@@ -5221,6 +5223,15 @@ def battle_until_phase(scene, phase, max = 15)
     break if ui && ui[:phase] == phase
   end
   ui
+end
+
+# Every string a window's contents had drawn into it, whichever path drew it:
+# `draw_text(x, y, w, h, text, align)` and `blend_text(x, y, w, h, text, skin,
+# ...)` both carry the text at index 4.
+def window_texts(win)
+  c = win && win.contents
+  return [] unless c
+  ((c.draw_calls || []) + (c.blend_calls || [])).map { |a| a[4] }
 end
 
 check 'Enemy Encounter scene: winning (per-actor Attack) grants rewards, runs Victory' do
@@ -5319,6 +5330,70 @@ check 'Enemy Encounter scene: a Change System SFX battle-start override wins ove
      'the override plays instead of the database BattleStart1'
   ok !RGSS::Audio.se_calls.any? { |c| c[0] == 'BattleStart1' },
      'the database default is fully superseded, not layered alongside it'
+end
+
+# EasyRPG Player's `Scene_Battle_Rpg2k::ProcessSceneActionStart`
+# (`src/scene_battle_rpg2k.cpp`) narrates the encounter before the party is
+# ever asked for a command: `GetActiveBattlers` (not dead or hidden) feeds one
+# `PushWithSubject(terms.encounter, enemy->GetName())` per visible member --
+# stock RPG2000's `PushWithSubject` concatenates `subject + message`, no
+# placeholder -- and `Scene::Map#open_battle` used to skip straight past this
+# into `phase: :command` with no message at all.
+check 'Enemy Encounter scene: opening a battle narrates each visible enemy with ' \
+      'the database encounter term before any command menu shows' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  scene.db.term.encounter = 'があらわれた！'
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_until_phase(scene, :encounter_message)
+  ok ui, 'the encounter-message phase was reached'
+  eq ['Slimeがあらわれた！', 'Slimeがあらわれた！'], window_texts(ui[:action_win]),
+     'both troop members are named, once each, using the database term'
+end
+
+# `ProcessSceneActionStart`'s `eFirstStrike` substate pushes `terms.
+# special_combat` (no subject, a fixed line) *after* every per-enemy
+# `encounter` line, only when the encounter is a first-strike ambush -- it is
+# appended to the same narration, not a replacement for it.
+check 'Enemy Encounter scene: a first-strike encounter appends the special_combat ' \
+      'line after the per-enemy encounter lines' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic, first_strike: true)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  scene.db.term.encounter = 'があらわれた！'
+  scene.db.term.special_combat = '先制攻撃！'
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_until_phase(scene, :encounter_message)
+  ok ui, 'the encounter-message phase was reached'
+  eq ['Slimeがあらわれた！', 'Slimeがあらわれた！', '先制攻撃！'],
+     window_texts(ui[:action_win]),
+     'special_combat trails the per-enemy lines rather than replacing them, ' \
+     "matching EasyRPG Player's own ordering"
+end
+
+# `GetActiveBattlers` is the "not dead or hidden" subset (`Game_Battler::
+# Exists`) -- a troop member the editor placed but flagged invisible
+# (`Game::Enemy#hidden`, the same flag Show Hidden Monster clears) never gets
+# an arrival line, matching the sprite-build skip in #build_battle_sprites.
+check 'Enemy Encounter scene: a hidden troop member gets no encounter line' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  scene.db.term.encounter = 'があらわれた！'
+  scene.db.enemy_group[1].members[2].invisible = true # the second Slime starts hidden
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new)
+  ui = battle_until_phase(scene, :encounter_message)
+  ok ui, 'the encounter-message phase was reached'
+  eq ['Slimeがあらわれた！'], window_texts(ui[:action_win]),
+     'only the still-visible Slime is narrated'
+  ok ui[:troop].members[1].hidden, 'and the troop model agrees the second member is hidden'
 end
 
 # yado.tk: "the built-in random-number operand is a genuine non-seeded RNG --
@@ -10281,15 +10356,6 @@ check 'a hidden troop member is not targetable until it is revealed' do
   ok !ui[:foes][1].hidden, 'revealing clears the combatant flag, not just the sprite'
   eq 2, scene.send(:living_foes).length, 'and it becomes targetable'
   ok ui[:enemy_sprites][1], 'with a sprite built for it'
-end
-
-# Every string a window's contents had drawn into it, whichever path drew it:
-# `draw_text(x, y, w, h, text, align)` and `blend_text(x, y, w, h, text, skin,
-# ...)` both carry the text at index 4.
-def window_texts(win)
-  c = win && win.contents
-  return [] unless c
-  ((c.draw_calls || []) + (c.blend_calls || [])).map { |a| a[4] }
 end
 
 check 'Open Shop scene: the shopkeeper terms show greeting, regreeting and each screen prompt' do


### PR DESCRIPTION
## Summary

- `Scene::Map#open_battle` used to jump straight from the Battle Start SE/BGM into actor command selection with no message at all, even though real RPG_RT always narrates the encounter first.
- It now shows the database's own encounter narration before the command phase opens, confirmed against EasyRPG Player's `Scene_Battle_Rpg2k::ProcessSceneActionStart` (`src/scene_battle_rpg2k.cpp`) rather than guessed at:
  - One `terms.encounter` line per **visible** (non-`hidden`) troop member — `GetActiveBattlers`'s "not dead or hidden" subset, the same modelling `Game::Enemy#hidden`/Show Hidden Monster already use — each built by concatenating the enemy's own name in front of the term (stock `PushWithSubject`: `subject + message`, no placeholder), matching how this screen's `victory`/`level_up`/`item_received` lines already substitute.
  - On a first-strike ambush (`req[:first_strike]`, already threaded through for the actual mechanic), a fixed `terms.special_combat` line **appended after** the per-enemy lines — not instead of them. This corrected an initial assumption: EasyRPG's source shows both are always independent pushes, `special_combat` never replaces the per-enemy narration.
  - Nothing shows when the whole troop is hidden and the fight is not a first strike, matching the real `if (!visible_enemies.empty())` gate.
- Reuses the existing action-banner mechanism (`#show_battle_banner`/`#battle_panel_window`, the same one that banners a landed hit) instead of building a new message window, on a new `:encounter_message` battle sub-state that holds for a short fixed beat (`BATTLE_ENCOUNTER_MSG_FRAMES = 4`) rather than RPG_RT's own per-line wordwrap/wait-timer pacing — this screen already takes that "flat line list, no per-page window" simplification for the victory/level-up result screen.

## Test plan

- [x] `ruby scripts/rpg2k_scene_check.rb` — 584 checks passed (581 pre-existing + 3 new: per-enemy narration, first-strike appends `special_combat` after the per-enemy lines, a hidden troop member gets no line).
- [x] `pre-commit run` (trailing-whitespace / end-of-file-fixer / check-added-large-files) on the changed files.
- [ ] `cmake --build build -t test` — not run; this change touches only `mrblib`/Ruby-level code, already covered by the `rpg2k_scene_check.rb` harness above (no native build needed, per that script's own header), and no CMake build was available in this session's environment.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Ss5igBtEt8mUaGzCvkxxPM


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss5igBtEt8mUaGzCvkxxPM)_