### PR TITLE
Gate skill percent-SP-cost to RPG2003 and fix its half-cost rounding

### DIFF
--- a/changelog.d/rpg2k-skill-cost-percent-and-rounding.fixed.md
+++ b/changelog.d/rpg2k-skill-cost-percent-and-rounding.fixed.md
@@ -1,0 +1,9 @@
+- **A skill's percent-based SP cost is now RPG2003-only, and half-SP-cost
+  gear now rounds a percent-based cost down instead of up.** Confirmed
+  against EasyRPG Player's source: RPG2000's editor has no percent-cost UI at
+  all, so a stray `sp_type` byte on an RPG2000 database should read as an
+  ordinary fixed cost instead. Separately, half-cost gear rounds a fixed cost
+  up but a percent cost down — applying the fixed-cost rounding to both
+  previously overcharged a percent-cost skill by up to 1 SP whenever its own
+  intermediate cost came out odd, up to a full 100% overcharge for some
+  gear/skill combinations.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5568,6 +5568,47 @@ not yet verified:
   pinning the RPG2003 curve's own level 1→2 and 1→3 thresholds against a
   database flagged `rpg2003: true`, confirmed to fail against the pre-fix
   code before the fix (`expected 90, got 60`).
+- ✅ **`Game::Party#skill_cost` now edition-gates a percent-based SP cost to
+  RPG2003 and rounds a half-cost percent skill down instead of up, matching
+  two more edition/rounding distinctions EasyRPG's `Algo::CalcSkillCost`
+  (`src/algo.cpp`) makes that this method previously collapsed into one
+  shared rule.** The real function is `(Player::IsRPG2k3() && skill.sp_type
+  == SpType_percent) ? max_sp * sp_percent / 100 / div : (sp_cost +
+  half_sp_cost) / div` — two genuinely different formulas selected by both
+  edition *and* `sp_type`, not a shared cost with a shared halving rule:
+  1. **Percent-cost (`sp_type` 1) is RPG2003-only.** RPG2000's own editor has
+     no percent-cost UI at all, so a stray `sp_type` 1 byte in an RPG2000
+     database should read as the plain fixed-cost branch (`sp_cost`, which a
+     percent-cost row leaves unset — 0) instead of actually computing a
+     percentage. This method had no `rpg2003?` gate at all, unlike sibling
+     methods in this same class (`#calc_exp` immediately above, `#exp_max`)
+     that already use exactly this split.
+  2. **MP消費半分 (half-SP-cost gear) rounds the two branches differently.**
+     A fixed cost gets a `+1` before halving (`(sp_cost + 1) / div`, so a
+     1-SP skill still costs 1, never drops to 0) — this method already had
+     that half right. But a percent cost gets **no** such `+1`, a plain
+     floor by 2 — this method applied the fixed-cost `+1` rounding to
+     *whichever* cost came out, silently overcharging a percent-cost skill
+     by up to 1 SP whenever its own intermediate cost was odd: a 33-max-SP
+     caster wearing half-cost gear casting a 10%-cost RPG2003 skill paid 2 SP
+     (`(3 + 1) / 2`) instead of the correct 1 (`3 / 2`) — a full 100%
+     overcharge for that combination.
+  Fixed by restructuring `#skill_cost` to select the divisor (`half_sp_cost?
+  ? 2 : 1`) once, then apply it *inside* each branch with that branch's own
+  rounding — the percent branch a plain division, the fixed branch its own
+  `+1` first — rather than computing a shared `cost` up front and halving it
+  uniformly afterward, and gating the percent branch on `rpg2003?` the same
+  way `#calc_exp` already does. The existing percent-cost field-skills check
+  (predating this fix, on a database that was never edition-flagged) now
+  explicitly exercises both editions — an RPG2000-flagged party reading a
+  `sp_type` 1 skill as its own unset `sp_cost` (0), and an RPG2003-flagged
+  one reading it as the real percentage — and the existing half-cost check
+  gained a percent-cost skill on an RPG2003-flagged database with an odd
+  intermediate cost to actually distinguish floor from round-up (its old
+  20%-of-40-max-SP case landed on an already-even 8, which rounds the same
+  way either direction, silently passing under both the old buggy code and
+  the fix alike). Both confirmed to fail against the pre-fix code before the
+  fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3440,21 +3440,33 @@ module Game
       @db.respond_to?(:situation) ? @db.situation : nil
     end
 
-    # The SP `caster` pays to cast skill `sk`: a fixed cost (sp_type 0) or a
-    # percentage of the caster's max SP (sp_type 1). Mirrors EasyRPG's
-    # CalculateSkillCost (the half-SP-cost modifier is a later refinement).
+    # The SP `caster` pays to cast skill `sk`: a fixed cost (sp_type 0) or, on
+    # an RPG2003 database only, a percentage of the caster's max SP (sp_type
+    # 1). Ported from EasyRPG's `Algo::CalcSkillCost` (`src/algo.cpp`):
+    # `(Player::IsRPG2k3() && skill.sp_type == SpType_percent) ? max_sp *
+    # sp_percent / 100 / div : (sp_cost + half_sp_cost) / div`. RPG2000's
+    # editor has no percent-cost UI at all, so the `rpg2003?` gate mirrors
+    # `#calc_exp`'s own edition split rather than trusting a stray sp_type
+    # byte a hand-edited RPG2000 database happened to carry.
+    #
+    # MP消費半分 gear halves the bill (`div` 2, else 1) -- but the two branches
+    # round the halving *differently*, and it must stay that way rather than
+    # applying one shared `(cost + 1) / 2` to whichever cost came out: a
+    # fixed cost rounds **up** first (`+1` before the divide, so a 1-SP skill
+    # still costs 1, not 0), while a percent cost has no such `+1` at all and
+    # simply floors. Halving a percent-based cost via the fixed-cost rounding
+    # used to overcharge by up to 1 SP whenever the intermediate percent cost
+    # came out odd -- a 33-max-SP caster with half-cost gear casting a 10%
+    # RPG2003 skill paid 2 SP (`(3 + 1) / 2`) instead of the correct 1
+    # (`3 / 2`), a full 100% overcharge for that combination.
     def skill_cost(sk, caster)
-      cost =
-        if sk.sp_type == 1
-          caster.max_mp * (sk.sp_percent || 0) / 100
-        else
-          sk.sp_cost || 0
-        end
-      # MP消費半分 gear halves the bill, rounding **up** so a 1-SP skill still
-      # costs 1 (EasyRPG's `cost = (cost + 1) / 2`). Asked of whatever the caller
-      # handed over — a Game::Actor in the menus, a battle snapshot in a fight.
-      return cost unless caster.respond_to?(:half_sp_cost?) && caster.half_sp_cost?
-      (cost + 1) / 2
+      half = caster.respond_to?(:half_sp_cost?) && caster.half_sp_cost?
+      div = half ? 2 : 1
+      if rpg2003? && sk.sp_type == 1
+        caster.max_mp * (sk.sp_percent || 0) / 100 / div
+      else
+        ((sk.sp_cost || 0) + (half ? 1 : 0)) / div
+      end
     end
 
     # `caster`'s known skills usable from the field menu, as `[skill_id, cost]`

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -5262,9 +5262,19 @@ check 'an all-ally heal skill heals the whole party (caster included) and spends
   eq 22, hero.mp                               # 30 - 8
 end
 
-check 'skill_cost supports a percentage of max SP (sp_type 1)' do
+check 'skill_cost supports a percentage of max SP (sp_type 1), RPG2003 only' do
+  # EasyRPG's Algo::CalcSkillCost gates the whole percent-cost branch behind
+  # `Player::IsRPG2k3()` -- RPG2000's own editor has no percent-cost UI at
+  # all, so a stray sp_type 1 byte in an RPG2000 database reads as the plain
+  # fixed-cost branch instead (sp_cost, unset here -> 0), not as a percent.
   skills = { 5 => fake_skill(scope: 2, sp_type: 1, sp_percent: 10, power: 5, sp: true) }
-  st = skill_party(skills)
+  st2k = skill_party(skills)
+  hero2k = st2k.party.actor_by_id(1)
+  hero2k.learn_skill(5)
+  eq [[5, 0]], st2k.party.field_skills(hero2k),
+     'RPG2000: sp_type 1 is not a real percent-cost skill, reads as the unset sp_cost'
+
+  st = skill_party(skills, {}, rpg2003: true)
   hero = st.party.actor_by_id(1)               # max SP 30
   hero.learn_skill(5)
   eq [[5, 3]], st.party.field_skills(hero)      # 30 * 10 / 100 = 3
@@ -11622,12 +11632,19 @@ check 'battle: 強力防御 halves damage a second time' do
      'strong defence takes half of what an ordinary guard leaves'
 end
 
-check 'MP消費半分 gear halves a skill cost, rounding up' do
+check 'MP消費半分 gear halves a fixed cost rounding up, a percent cost rounding down' do
+  # EasyRPG's Algo::CalcSkillCost rounds the two sp_type branches differently
+  # when half-cost gear is worn: a fixed cost gets a `+1` before halving (so
+  # a 1-SP skill still costs 1), a percent cost gets no such `+1` and simply
+  # floors. Applying one shared `(cost + 1) / 2` to whichever cost came out
+  # (a prior version of this method) silently overcharged the percent branch
+  # by up to 1 SP whenever its own intermediate cost was odd -- 10% of a 33
+  # max-SP caster is 3, which should halve to 1 (3 / 2), not 2 ((3 + 1) / 2).
   skills = { 1 => fake_skill(sp_cost: 7), 2 => fake_skill(sp_cost: 1),
-             3 => fake_skill(sp_type: 1, sp_percent: 20) }
+             3 => fake_skill(sp_type: 1, sp_percent: 10) }
   items = { 9 => fake_item(type: 5, half_sp_cost: true) }  # an accessory
-  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [100, 40, 10, 5, 5, 5]) },
-                       [1], items, skills)
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [100, 33, 10, 5, 5, 5]) },
+                       [1], items, skills, {}, nil, nil, rpg2003: true)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   hero = st.party.leader
   eq false, hero.half_sp_cost?
@@ -11636,8 +11653,7 @@ check 'MP消費半分 gear halves a skill cost, rounding up' do
   ok hero.half_sp_cost?, 'the accessory grants it'
   eq 4, st.party.skill_cost(db.skill[1], hero), '7 -> 4, rounded up'
   eq 1, st.party.skill_cost(db.skill[2], hero), 'a 1-SP skill still costs 1'
-  # A percentage cost is halved the same way (20% of 40 max SP = 8 -> 4).
-  eq 4, st.party.skill_cost(db.skill[3], hero)
+  eq 1, st.party.skill_cost(db.skill[3], hero), '10% of 33 = 3, halved down to 1, not up to 2'
 end
 
 check 'Battle end_round clears a queued Skill / Item command' do


### PR DESCRIPTION
## Summary
`Game::Party#skill_cost` previously computed a shared `cost` (fixed or percent) and applied one uniform `(cost + 1) / 2` for half-SP-cost gear. EasyRPG's `Algo::CalcSkillCost` (`src/algo.cpp`) is actually two genuinely different formulas selected by both edition and `sp_type`:

```cpp
(Player::IsRPG2k3() && skill.sp_type == SpType_percent)
    ? max_sp * sp_percent / 100 / div
    : (sp_cost + half_sp_cost) / div
```

1. **Percent-cost (`sp_type` 1) is RPG2003-only.** RPG2000's own editor has no percent-cost UI at all, so a stray `sp_type` 1 byte in an RPG2000 database should read as the plain fixed-cost branch (`sp_cost`, unset → 0), not compute a percentage. This method had no `rpg2003?` gate at all, unlike sibling methods in this same class (`#calc_exp`, `#exp_max`) that already use exactly this split.
2. **MP消費半分 rounds the two branches differently**: a fixed cost gets a `+1` before halving (so a 1-SP skill still costs 1), a percent cost gets no such `+1`, a plain floor by 2. Applying the fixed-cost rounding to whichever cost came out silently overcharged a percent-cost skill by up to 1 SP whenever its own intermediate cost was odd — a 33-max-SP caster with half-cost gear casting a 10%-cost RPG2003 skill paid 2 SP instead of the correct 1, a full 100% overcharge.

Fixed by selecting the divisor once, then applying it inside each branch with that branch's own rounding, and gating the percent branch on `rpg2003?`.

## Test plan
- [x] The existing percent-cost field-skills check (on a database that was never edition-flagged) now exercises both editions explicitly, and the existing half-cost check gained a percent-cost skill on an RPG2003-flagged database with an odd intermediate cost — its old 20%-of-40 case landed on an already-even 8, which rounds the same way either direction and silently passed under both the buggy code and the fix alike. Both confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_scene_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_save_load_check.rb` — all checks pass
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — all checks pass
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v


---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_