### PR TITLE
Fix Game::Actor#recompute_stats double-clamping curve+mod before equipment

### DIFF
--- a/changelog.d/rpg2k-recompute-stats-clamp-order.fixed.md
+++ b/changelog.d/rpg2k-recompute-stats-clamp-order.fixed.md
@@ -1,0 +1,11 @@
+- **An actor's effective Attack/Defence/Spirit/Agility/max HP/max SP now
+  clamp curve + Change Parameters mod + equipment together, as one combined
+  total, instead of clamping the curve+mod part alone and then clamping
+  again after adding equipment.** Confirmed against EasyRPG Player's source:
+  `Game_Actor::GetBaseAtk` and its siblings sum all three sources in one
+  expression and clamp exactly once. The old double clamp let equipment
+  bypass an active floor: a stat debuffed low enough to floor its display at
+  1 would let a newly-equipped item's *entire* bonus land back on top of
+  that floor, instead of on top of the real (still deeply negative) total
+  the debuff left behind — silently undoing an active debuff just by
+  re-equipping.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5609,6 +5609,32 @@ not yet verified:
   way either direction, silently passing under both the old buggy code and
   the fix alike). Both confirmed to fail against the pre-fix code before the
   fix.
+- ✅ **`Game::Actor#recompute_stats` now clamps curve + Change-Parameters mod +
+  equipment together as one combined total, instead of clamping the
+  curve+mod part alone and then clamping a second time after adding
+  equipment.** EasyRPG's `Game_Actor::GetBaseAtk`/`GetBaseDef`/`GetBaseSpi`/
+  `GetBaseAgi`/`GetBaseMaxHp`/`GetBaseMaxSp` (`src/game_actor.cpp`) each sum
+  the level curve, the Change Parameters `*_mod` shadow, and every equipped
+  item's own bonus in one expression, then clamp that combined raw total to
+  `Utils::Clamp(n, 1, MaxStatBaseValue())` exactly once. This method instead
+  summed `@base[i]` — the *already-clamped* curve+mod snapshot
+  `#change_param`/`#restore_base` maintain with no equipment involved — with
+  `equip_bonus(i)`, then clamped the sum again: a double clamp that let
+  equipment bypass an active floor/ceiling instead of adding to the real
+  unclamped total underneath it. Concretely, an actor debuffed by Change
+  Parameters far enough to floor a stat's display at 1 (raw deep negative)
+  who then equips a strong item saw the item's *entire* bonus land on top of
+  the floored value (`clamp(1 + 30, 1, 999) = 31`) instead of on top of the
+  real negative total the debuff left behind (`clamp(-50 + 30, 1, 999) = 1`,
+  still fully floored) — silently undoing part or all of an active debuff
+  just by re-equipping. Fixed by switching all six `recompute_stats` lines to
+  read `@base_raw[i]` (the unclamped curve+mod shadow, already tracked and
+  already the read `#change_param`'s own clamp-crossing logic relies on)
+  instead of `@base[i]`; `@base` itself is untouched and still maintained by
+  `#change_param`/`#restore_base`/`#set_level`/`#change_class` for their own
+  purposes. Covered by a new `scripts/rpg2k_logic_check.rb` check pinning the
+  concrete debuff-then-equip trace above, confirmed to fail against the
+  pre-fix code before the fix (`expected 1, got 31`).
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1625,15 +1625,32 @@ module Game
     MAX_EFFECTIVE_HP_2K = 999
     MAX_EFFECTIVE_HP_2K3 = 9999
 
-    # Recompute the six effective stats (base + equipment) into their readers and
-    # re-clamp current HP/MP to the refreshed maxima.
+    # Recompute the six effective stats (curve + Change-Parameters shadow +
+    # equipment, one combined clamp) into their readers, and re-clamp current
+    # HP/MP to the refreshed maxima.
+    #
+    # Reads `@base_raw` (the unclamped curve+mod shadow), not `@base` (the
+    # pre-equipment clamped snapshot #change_param also derives) -- a prior
+    # version summed `@base[i] + equip_bonus(i)`, clamping the curve+mod part
+    # *before* equipment ever entered the formula, where EasyRPG's own
+    # `GetBaseAtk` et al. sum curve + mod + equip and clamp the combined
+    # total exactly once. The two only disagree once `@base_raw` has actually
+    # been pushed outside 1..999/1..9999 (a heavy Change Parameters debuff or
+    # buff) and equipment changes afterward: e.g. Attack debuffed by 100 (base
+    # 50 -> raw -50, clamped display 1), then a +30-Attack weapon equipped --
+    # this method used to compute `clamp(1 + 30, 1, 999) = 31`, letting the
+    # weapon's whole bonus land on top of an already-bottomed-out stat that
+    # real RPG_RT still reads as `clamp(-50 + 30, 1, 999) = 1`, the debuff
+    # still fully in effect. `@base` itself is unaffected by this fix --
+    # #change_param and #restore_base still maintain it as their own clamped
+    # snapshot, just no longer the one #recompute_stats reads.
     def recompute_stats
-      @max_hp = Game.clamp(@base[0] + equip_bonus(0), 1, max_hp_cap)
-      @max_mp = Game.clamp(@base[1] + equip_bonus(1), 0, MAX_EFFECTIVE_MP)
-      @atk = Game.clamp(@base[2] + equip_bonus(2), 1, MAX_EFFECTIVE_STAT)
-      @def = Game.clamp(@base[3] + equip_bonus(3), 1, MAX_EFFECTIVE_STAT)
-      @int = Game.clamp(@base[4] + equip_bonus(4), 1, MAX_EFFECTIVE_STAT)
-      @agi = Game.clamp(@base[5] + equip_bonus(5), 1, MAX_EFFECTIVE_STAT)
+      @max_hp = Game.clamp(@base_raw[0] + equip_bonus(0), 1, max_hp_cap)
+      @max_mp = Game.clamp(@base_raw[1] + equip_bonus(1), 0, MAX_EFFECTIVE_MP)
+      @atk = Game.clamp(@base_raw[2] + equip_bonus(2), 1, MAX_EFFECTIVE_STAT)
+      @def = Game.clamp(@base_raw[3] + equip_bonus(3), 1, MAX_EFFECTIVE_STAT)
+      @int = Game.clamp(@base_raw[4] + equip_bonus(4), 1, MAX_EFFECTIVE_STAT)
+      @agi = Game.clamp(@base_raw[5] + equip_bonus(5), 1, MAX_EFFECTIVE_STAT)
       @hp = @max_hp if @hp && @hp > @max_hp
       @mp = @max_mp if @mp && @mp > @max_mp
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3821,6 +3821,31 @@ check '#recompute_stats clamps the effective max HP/MP and the four combat ' \
   eq 999, a2k3.max_mp                # ... but MP/SP still caps at 999, no RPG2003 widening
 end
 
+check '#recompute_stats clamps curve+mod+equipment together, not the ' \
+      'unequipped total a second time before adding equipment' do
+  # A prior version summed the *already-clamped* @base[i] (curve + Change
+  # Parameters mod, floored/ceilinged with no equipment involved) with
+  # equip_bonus(i), then clamped again -- double-clamping instead of EasyRPG's
+  # real Game_Actor::GetBaseAtk et al., which sum curve + mod + equipment in
+  # one expression and clamp the combined raw total exactly once. The two
+  # only disagree once the raw total has been pushed outside the display
+  # clamp and equipment changes afterward: a heavy debuff floors the display
+  # at 1 while the raw shadow sits deep negative, and equipping a strong item
+  # must add its bonus to that still-deeply-negative raw total, not to the
+  # floored display value.
+  items = { 40 => fake_item(atk: 30) }
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 50, 2, 1, 4]) },
+                       [1], items)
+  a = Game::Party.new(db).leader
+  eq 50, a.atk                                # base atk starts at 50
+  a.change_param(Game::Actor::PARAM_ATK, -100) # raw 50 - 100 = -50
+  eq 1, a.atk                                  # floored -- raw is negative
+  a.equip([40, 0, 0, 0, 0])
+  # raw -50 + equip 30 = -20, still clamps to the floor -- NOT clamp(1, 999) +
+  # 30 = 31, which would let the weapon's whole bonus escape the active debuff.
+  eq 1, a.atk
+end
+
 check 'Change Parameters tracks an unclamped total under the displayed clamp' do
   # yado.tk `2000/デフォ戦botまとめ`: the displayed/effective stat clamps to
   # 1..999 (1..9999 for HP/MP), but RPG_RT keeps accumulating the *real*


### PR DESCRIPTION
## Summary
- `Game::Actor#recompute_stats` now clamps curve + Change Parameters mod + equipment together as one combined total, instead of clamping the curve+mod part alone and then clamping again after adding equipment.
- Confirmed against EasyRPG Player's source: `Game_Actor::GetBaseAtk`/`GetBaseDef`/`GetBaseSpi`/`GetBaseAgi`/`GetBaseMaxHp`/`GetBaseMaxSp` (`src/game_actor.cpp`) each sum the level curve, the Change-Parameters `*_mod` shadow, and equipment bonus in one expression, then clamp exactly once.
- The old double clamp let equipment bypass an active floor/ceiling debuff: a stat debuffed low enough to floor its display at 1 (raw total deep negative) that then had a strong item equipped saw the item's *entire* bonus land on top of the floored display value (`clamp(1 + 30, 1, 999) = 31`) instead of on top of the real negative total underneath (`clamp(-50 + 30, 1, 999) = 1`, still floored) — silently undoing an active debuff just by re-equipping.
- Fixed by switching all six `recompute_stats` lines to read `@base_raw[i]` (the unclamped curve+mod shadow already tracked for `#change_param`'s own clamp-crossing logic) instead of `@base[i]`. `@base` itself is untouched, still maintained by `#change_param`/`#restore_base`/`#set_level`/`#change_class` for their own purposes.

## Test plan
- [x] New `scripts/rpg2k_logic_check.rb` check pinning the debuff-then-equip trace above, confirmed to fail against the pre-fix code (`expected 1, got 31`)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 858 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 585 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 128 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_