### PR TITLE
Make rpg2k_field_audit.rb's mrblib glob recursive

### DIFF
--- a/changelog.d/rpg2k-field-audit-scene-glob.fixed.md
+++ b/changelog.d/rpg2k-field-audit-scene-glob.fixed.md
@@ -1,0 +1,7 @@
+- **`scripts/rpg2k_field_audit.rb`** — the "does the runtime name this field"
+  glob only scanned `mruby-rpg2k/mrblib/*.rb`, missing the entire `scene/`
+  subdirectory where most gameplay logic actually lives (12 of the runtime's
+  15 `.rb` files). That made the survey's "never named by the runtime" list
+  full of false positives — fields read from a `scene/` file the glob never
+  scanned. Made the glob recursive (`**/*.rb`) so it scans the whole tree; no
+  runtime or gameplay behaviour changed, only the survey script's accuracy.

--- a/scripts/rpg2k_field_audit.rb
+++ b/scripts/rpg2k_field_audit.rb
@@ -126,7 +126,7 @@ if dirs.empty?
   exit 0
 end
 
-runtime = Dir[File.join(ROOT, 'mruby-rpg2k/mrblib/*.rb')]
+runtime = Dir[File.join(ROOT, 'mruby-rpg2k/mrblib/**/*.rb')]
           .map { |f| File.read(f, encoding: 'UTF-8') }.join("\n")
 
 dbs = dirs.map do |d|


### PR DESCRIPTION
## Summary

- `scripts/rpg2k_field_audit.rb`'s "does the runtime name this field" check
  globbed `mruby-rpg2k/mrblib/*.rb`, which is non-recursive. Almost all
  gameplay logic actually lives under `mruby-rpg2k/mrblib/scene/*.rb`
  (12 files) — only 3 files sit directly under `mrblib/`. Missing `scene/`
  entirely made the survey's "never named by the runtime" output full of
  false positives: fields that *are* read, just from a file the glob never
  scanned.
- Fixed the glob to `mruby-rpg2k/mrblib/**/*.rb` so it recurses into `scene/`
  (and any future subdirectory).
- Survey-script accuracy fix only — no runtime or gameplay behavior changed.
  Not acting on the (now smaller and more accurate) "unread field" list;
  that's separate follow-up work.

## Test plan

- [x] Verified the glob mechanics directly: old glob picks up 3 files under
      `mruby-rpg2k/mrblib/`, new glob picks up all 15 (3 top-level + all 12
      under `scene/`).
- [x] `ruby scripts/rpg2k_logic_check.rb` — 857 checks passed, unaffected.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 585 checks passed, unaffected.
- [ ] Could not re-run `ruby scripts/rpg2k_field_audit.rb data/mtf-meido-action/Debug`
      in this sandbox — that proprietary game data isn't present here. This was
      already confirmed against real data before filing this task: the
      false-positive count dropped from ~19 fields to a handful of genuine ones
      (things needing whole unbuilt subsystems, e.g. RPG2003 battler-animation
      sprites and enemy-formation grid positioning).

Added a `changelog.d/rpg2k-field-audit-scene-glob.fixed.md` fragment per
`AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5oXuzADzwqdLkyzEBWvRQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01W5oXuzADzwqdLkyzEBWvRQ)_