### PR TITLE
Decode RPG2003's Battle Type field, expose Game::Party#alternate_battle_layout?

### DIFF
--- a/changelog.d/rpg2003-battle-type-decode.added.md
+++ b/changelog.d/rpg2003-battle-type-decode.added.md
@@ -1,0 +1,9 @@
+- **Decoded RPG2003's Battle Type field (database chunk 0x1D field 7)**, the
+  editor option that picks between the traditional status-window-only battle
+  screen and the alternate sprite/gauge presentation. `battlecommands.battle_type`
+  now reads back as `0`/`1`/`2` (traditional/alternative/gauge) instead of
+  going unread; `Game::Party#alternate_battle_layout?` exposes whether a
+  database asks for the alternate presentation. This is foundational only —
+  no rendering reads it yet, so every game still draws the existing
+  status-window battle screen regardless of what it asks for. Covered by a
+  new `scripts/rpg2k_logic_check.rb` check.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -759,6 +759,12 @@ module LCF
           # by the caller instead.
           name: :battlecommands, type: :Array1D,
           elements: {
+            # RPG2003's battle-screen presentation choice (BattleType in
+            # liblcf): 0 traditional (RPG2000-style status window only), 1
+            # alternative (actor sprites), 2 gauge (actor sprites + HP/SP
+            # gauges). RPG2000's editor has no such option, so an RPG2000
+            # database never sets this and correctly reads back as 0.
+            7 => { name: :battle_type, type: :int, default: 0 },
             10 => {
               name: :commands, type: :Array2D,
               elements: {

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -148,6 +148,22 @@ assert "LCF::Database battle-commands table (chunk 29 -- name + type)" do
   assert_equal 2, db.battlecommands.commands[2].type
 end
 
+assert "LCF::Database battle-commands table decodes battle_type (chunk 29 field 7)" do
+  # BattleType picks RPG2003's alternate sprite/gauge battle-screen
+  # presentation over RPG2000's status-window-only one -- 0 traditional, 1
+  # alternative, 2 gauge (lcf::rpg::BattleCommands::BattleType). A database
+  # that never sets field 7 at all (every RPG2000 file) defaults to 0.
+  gauge = lcf_array1d([lcf_int_field(7, 2)])
+  db = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(29, gauge)])))
+  assert_equal 2, db.battlecommands.battle_type
+
+  bare = lcf_array1d([lcf_field(10, lcf_array2d([]))])
+  db2 = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(29, bare)])))
+  assert_equal 0, db2.battlecommands.battle_type
+end
+
 assert "LCF::Array1D#key? distinguishes an absent chunk from a present one" do
   row = LCF::Array1D.new(lcf_array1d([lcf_int_field(1, 5), lcf_int_field(3, 0)]),
                          { elements: { 1 => { name: :a, type: :int },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2914,6 +2914,20 @@ module Game
       @db.respond_to?(:rpg2003?) && @db.rpg2003?
     end
 
+    # Whether the database asks for RPG2003's sprite/gauge battle-screen
+    # presentation instead of RPG2000's status-window-only one
+    # (`battlecommands.battle_type`, database chunk 0x1D field 7 -- 0
+    # traditional, 1 alternative, 2 gauge). Nothing in this runtime branches
+    # on it yet -- rendering support lands in a follow-up change -- but it
+    # needs to exist now so that follow-up can be reviewed against real data
+    # instead of guessed. A bare test fixture with no `#battlecommands` table
+    # reads false, the same answer a genuine RPG2000 database gives.
+    def alternate_battle_layout?
+      return false unless @db.respond_to?(:battlecommands)
+      table = @db.battlecommands
+      table && table.battle_type != 0 ? true : false
+    end
+
     # Whether item `id` can be used from the field (main-menu) item screen: a
     # medicine or switch item the party holds whose "usable in field" occasion is
     # set (a battle-only medicine is hidden here, mirroring #battle_usable?), or a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3173,9 +3173,10 @@ end
 # The database-wide RPG2003 Battle Commands table (LCF chunk 29's `commands`
 # field, `Game::Actor#battle_command_row`'s own source) and one of its
 # entries, mirroring the shape `LCF::Array1D#battlecommands` /
-# `#commands[id]` decode to: an object with `#commands` (id -> entry) and an
-# entry with `#name` + `#type`.
-FakeBattleCommandsTable = Struct.new(:commands)
+# `#commands[id]` decode to: an object with `#commands` (id -> entry), a
+# `#battle_type` (chunk 29 field 7, Game::Party#alternate_battle_layout?'s own
+# source), and an entry with `#name` + `#type`.
+FakeBattleCommandsTable = Struct.new(:commands, :battle_type)
 FakeBattleCommand = Struct.new(:name, :type)
 
 def party_state(enemy_group: Hash.new(true))
@@ -4152,7 +4153,7 @@ check "Game::Actor#battle_command_row resolves a positive id via the database's 
   actor_curve = []
   3.times { |i| actor_curve.concat([100 + i * 10, 20, 10 + i, 8, 6, 4]) }
   players = { 1 => ClassedRow.new('Hero', '', 0, 3, actor_curve, [], 0, [5, 0, -1, -1, -1, -1, -1]) }
-  table = FakeBattleCommandsTable.new({ 5 => FakeBattleCommand.new('Cast Fire', 2) })
+  table = FakeBattleCommandsTable.new({ 5 => FakeBattleCommand.new('Cast Fire', 2) }, 0)
   db = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil, battlecommands: table)
   st = Game::State.new(Game::Party.new(db), 1, 0, 0)
   a = st.party.actor_by_id(1)
@@ -4166,6 +4167,30 @@ end
 check 'Game::Actor#battle_command_row is nil when the database carries no Battle Commands table at all' do
   a = party_state.party.actor_by_id(1) # the plain RPG2000 fixture, no chunk 29
   eq nil, a.battle_command_row(1)
+end
+
+check 'Game::Party#alternate_battle_layout? reads chunk 29 field 7 (BattleType)' do
+  # An RPG2000 database (no chunk 29 at all -- RPG2000's editor has no such
+  # option) reads traditional/false, same as party_state's plain fixture.
+  eq false, party_state.party.alternate_battle_layout?,
+     'no Battle Commands table at all -> traditional layout'
+
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+
+  traditional = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                                 battlecommands: FakeBattleCommandsTable.new({}, 0))
+  eq false, Game::Party.new(traditional).alternate_battle_layout?,
+     'BattleType_traditional (0) -> traditional layout'
+
+  alternative = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                                 battlecommands: FakeBattleCommandsTable.new({}, 1))
+  eq true, Game::Party.new(alternative).alternate_battle_layout?,
+     'BattleType_alternative (1) -> alternate layout'
+
+  gauge = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                           battlecommands: FakeBattleCommandsTable.new({}, 2))
+  eq true, Game::Party.new(gauge).alternate_battle_layout?,
+     'BattleType_gauge (2) -> alternate layout'
 end
 
 check 'Change HP command damages a fixed actor' do


### PR DESCRIPTION
## Summary

First step of a multi-PR initiative to support RPG2003's alternate battle-screen presentation (actor sprites + gauge status bars) — currently every RPG2003 game renders with our RPG2000-style status-window-only battle screen, regardless of what its database asks for.

This PR is narrow and foundational: **decode one field, expose one predicate, no rendering changes.**

- `mruby-lcf/mrblib/schema.rb`: decode chunk 29 (`battlecommands`)'s field 7 as `:battle_type` (liblcf's `BattleCommands::BattleType` — 0 traditional, 1 alternative, 2 gauge; default 0). Verified against the local liblcf checkout's `chunks.h` and `rpg/battlecommands.h`. RPG2000's editor has no such option, so an RPG2000 database never sets it and correctly reads back as 0 — no edition gating needed.
- `mruby-rpg2k/mrblib/game.rb`: add `Game::Party#alternate_battle_layout?`, placed next to the existing `Game::Party#rpg2003?` (same `@db.respond_to?` pattern used throughout this class, and reachable from `Scene::Map#open_battle` via `@state.party`, which is where a follow-up rendering change would need it). `Game::Battle` doesn't hold a `@db` reference at all, so `Game::Party` is the right home, not `Game::Battle`.

Nothing calls `#alternate_battle_layout?` yet, and `scene/map.rb`'s battle drawing is untouched.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 858 checks passed (857 before, +1 new check)
- [x] `ruby scripts/rpg2k_scene_check.rb` — 585 checks passed, unchanged
- [x] New `mruby-lcf/test/lcf_test.rb` check decoding a real BER-encoded chunk 29 field 7 (byte-level, not a fixture)
- [x] Full mruby gem test suite (`rake test` from `3rd/mruby`, wired the way CTest's `mruby_test` invokes it) — 1789/1789 OK, 0 failures
- [x] Native rebuild (`ninja rpg_maker_clone` via `scripts/native-build-without-nix.bash`) succeeds
- [ ] `scripts/rpg2k_field_audit.rb` against a real RPG2003 game — skipped, no local RPG2003 test data under `data/` in this environment

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NNNXWBbEnt93pxJvMff5SD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNNXWBbEnt93pxJvMff5SD)_