### PR TITLE
Preserve a live Change Parameters adjustment across ordinary level changes

### DIFF
--- a/changelog.d/rpg2k-level-up-preserves-change-param.fixed.md
+++ b/changelog.d/rpg2k-level-up-preserves-change-param.fixed.md
@@ -1,0 +1,10 @@
+- **An ordinary level change no longer discards a live Change Parameters
+  adjustment.** Confirmed against EasyRPG Player's source:
+  `Game_Actor::SetLevel` never touches the Change-Parameters mod fields —
+  only `Game_Actor::ChangeClass` zeroes them, and only on an actual class
+  change. An actor with a Change Parameters bonus (or penalty) who leveled
+  up — from battle EXP, the Change EXP command, or the Change Level command
+  — previously had the entire adjustment silently discarded, reverting to
+  the bare level curve with no indication anything had changed. Change
+  Class's own "reset to new level" parameter mode is unaffected and still
+  correctly drops any live adjustment when swapping class.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5635,6 +5635,36 @@ not yet verified:
   purposes. Covered by a new `scripts/rpg2k_logic_check.rb` check pinning the
   concrete debuff-then-equip trace above, confirmed to fail against the
   pre-fix code before the fix (`expected 1, got 31`).
+- ✅ **An ordinary level change (battle EXP, the Change EXP command, or the
+  Change Level command) no longer discards a live Change Parameters
+  adjustment.** Confirmed against EasyRPG's actual C++ source:
+  `Game_Actor::SetLevel` (`src/game_actor.cpp`) only clamps `data.level` and
+  re-clamps current HP/SP — it never touches `data.attack_mod`/
+  `defense_mod`/`spirit_mod`/`agility_mod`/`hp_mod`/`sp_mod`. Those `*_mod`
+  fields are zeroed only inside `Game_Actor::ChangeClass`, never by an
+  ordinary level-up. `#set_level` instead unconditionally rebuilt both
+  `@base` and `@base_raw` from the bare level curve on *every* call,
+  silently discarding any live `#change_param` delta the instant the actor's
+  level changed by any means: an actor with a Change-Parameters Attack bonus
+  who then leveled up in the very next battle saw the entire bonus vanish,
+  replaced by the bare curve value for the new level, with no message or
+  indication anything had reverted. Fixed by giving `#set_level` a
+  `preserve_mod:` keyword (default `true`) that re-derives the mod by
+  diffing `@base_raw` against the curve at the level/class in force before
+  the call, then re-applies that same mod on top of the new level's curve —
+  mirroring how EasyRPG's separate `*_mod` fields ride unchanged through a
+  level change. `#change_class` passes `preserve_mod: false`, matching
+  `ChangeClass`'s own unconditional mod-zeroing before it reapplies the new
+  class's curve; without this, the reset-to-new-level `CLASS_PARAM_RESET_LEVEL`
+  mode (the one mode that never re-derives a mod afterward) would leak the
+  old mod through instead of producing the bare new-class curve it's meant
+  to. Covered by two new `scripts/rpg2k_logic_check.rb` checks — one pinning
+  a level-up carrying a live Attack adjustment forward onto the new level's
+  curve, one pinning Change Class's reset-to-new-level mode dropping that
+  same adjustment instead of inheriting it — both confirmed to fail against
+  the pre-fix code before the fix (`expected 72, got 52`; and, in a manual
+  check with the `change_class` guard alone reverted, `expected 70, got
+  170`, which also broke three pre-existing Change Class checks).
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1349,12 +1349,28 @@ module Game
     # Set the actor's level and recompute the six base stats from the database
     # growth curve at that level (see #base_stats), then the equipment-boosted
     # effective stats. Current HP/MP are re-clamped so lowering the level never
-    # leaves a vital over its cap. A fresh level-derived base is a new baseline
-    # for #change_param's unclamped tracking too -- see @base_raw there.
-    def set_level(level)
+    # leaves a vital over its cap.
+    #
+    # An ordinary level change (EXP gain/loss, the Change Level command) does
+    # NOT reset a live Change Parameters adjustment -- confirmed against
+    # EasyRPG's actual C++ source: `Game_Actor::SetLevel` (src/game_actor.cpp)
+    # only clamps `data.level` and re-clamps current HP/SP, never touching
+    # `data.attack_mod` et al.; those `*_mod` fields are zeroed only inside
+    # `Game_Actor::ChangeClass`. Since this class tracks the mod as an
+    # unclamped running total (@base_raw = curve + mod) rather than a separate
+    # field, `preserve_mod` re-derives the mod by diffing @base_raw against
+    # the curve at the *old* level/class (whichever was in force when this
+    # actor last had its base set) and re-applies that same mod on top of the
+    # new level's curve, so the delta survives level changes the way EasyRPG's
+    # separate mod field does. #change_class passes `preserve_mod: false`,
+    # matching `ChangeClass`'s own explicit mod-zeroing before it reapplies
+    # the class's own curve.
+    def set_level(level, preserve_mod: true)
+      mod = preserve_mod && @base_raw ? @base_raw.each_index.map { |i| @base_raw[i] - base_stats(@level)[i] } : nil
       @level = level && level >= 1 ? level : 1
-      @base = base_stats(@level)
-      @base_raw = @base.dup
+      curve = base_stats(@level)
+      @base_raw = mod ? curve.each_index.map { |i| curve[i] + mod[i] } : curve.dup
+      @base = @base_raw.each_index.map { |i| Game.clamp(@base_raw[i], 1, base_param_limit(i)) }
       learn_level_skills
       recompute_stats
     end
@@ -2308,7 +2324,12 @@ module Game
       old_skills = @skills.dup
 
       set_class_id(class_id)
-      set_level(Game.clamp(new_level || 1, 1, max_level))
+      # preserve_mod: false -- Change Class always zeroes the Change
+      # Parameters mod shadow before applying the new class's own curve
+      # (EasyRPG's ChangeClass zeroes attack_mod et al. unconditionally,
+      # before the param_mode switch below ever runs), unlike an ordinary
+      # level change, which #set_level's default carries the mod through.
+      set_level(Game.clamp(new_level || 1, 1, max_level), preserve_mod: false)
       @battle_commands = class_battle_commands
       @exp = exp_for_level(@level)
 
@@ -2317,9 +2338,9 @@ module Game
       when CLASS_PARAM_HALF      then @base = old_base.map { |v| v / 2 }
       when CLASS_PARAM_RESET_LV1 then @base = base_stats(1)
       end
-      # Whichever branch (or none, for CLASS_PARAM_RESET_LEVEL) ran, @base is
-      # a fresh baseline -- reset #change_param's unclamped shadow to match,
-      # the same rule set_level's own reset above already follows.
+      # Whichever branch (or none, for CLASS_PARAM_RESET_LEVEL, which keeps
+      # set_level's own zero-mod curve value) ran, @base is a fresh baseline
+      # -- reset #change_param's unclamped shadow to match.
       @base_raw = @base.dup
       recompute_stats
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -3846,6 +3846,31 @@ check '#recompute_stats clamps curve+mod+equipment together, not the ' \
   eq 1, a.atk
 end
 
+check 'An ordinary level change carries a live Change Parameters adjustment ' \
+      'forward instead of discarding it' do
+  # Confirmed against EasyRPG's actual C++ source: Game_Actor::SetLevel
+  # (src/game_actor.cpp) only clamps data.level and re-clamps current HP/SP --
+  # it never touches data.attack_mod/defense_mod/spirit_mod/agility_mod/
+  # hp_mod/sp_mod. Those *_mod fields are zeroed only inside
+  # Game_Actor::ChangeClass, never by an ordinary level-up (battle EXP, the
+  # Change EXP command, or the Change Level command). #set_level previously
+  # unconditionally rebuilt both @base and @base_raw from the bare level
+  # curve on every call, silently discarding any live change_param delta the
+  # moment the actor's level changed by any means.
+  db = FakeActorDB.new({ 1 => CurveRow.new('Hero', '', 0, 1,
+                                            [10, 5, 50, 2, 1, 4,   # level 1
+                                             10, 5, 52, 2, 1, 4]) }, # level 2
+                       [1])
+  a = Game::Party.new(db).leader
+  eq 50, a.atk                                  # level 1 curve atk
+  a.change_param(Game::Actor::PARAM_ATK, 20)    # raw 50 + 20 = 70
+  eq 70, a.atk
+  a.change_level_by(1)                          # level 1 -> 2, curve atk 50 -> 52
+  # The +20 adjustment rides on top of the new level's curve (52 + 20 = 72),
+  # not discarded back down to the bare curve value (52).
+  eq 72, a.atk
+end
+
 check 'Change Parameters tracks an unclamped total under the displayed clamp' do
   # yado.tk `2000/デフォ戦botまとめ`: the displayed/effective stat clamps to
   # 1..999 (1..9999 for HP/MP), but RPG_RT keeps accumulating the *real*
@@ -3993,6 +4018,26 @@ check 'Change Class swaps the growth curve and resets EXP' do
   eq a.exp_for_level(3), a.exp, 'RPG_RT resets EXP to the level threshold'
   ok a.skills.include?(31), "the new class's skill was added"
   ok a.skills.include?(10), 'and the actor kept what it already knew'
+end
+
+check 'Change Class with the reset-to-new-level param mode drops a live ' \
+      'Change Parameters adjustment instead of carrying it across' do
+  # #set_level now preserves a live change_param delta across an *ordinary*
+  # level change (see the dedicated check above), by re-deriving it from
+  # @base_raw against the curve in force before the call. Change Class must
+  # NOT inherit that carry-through for CLASS_PARAM_RESET_LEVEL -- EasyRPG's
+  # ChangeClass (src/game_actor.cpp) unconditionally zeroes attack_mod et al.
+  # before applying the new class's own curve, and the "reset to new level"
+  # mode is the one param_mode that never re-derives a mod afterward
+  # (SetBaseMaxHp/Atk/etc are skipped entirely for eParamReset), so its
+  # result must be the bare new-class curve, mod-free.
+  a = class_state.party.actor_by_id(1)
+  eq 120, a.max_hp                                # actor row, level 3
+  a.change_param(Game::Actor::PARAM_MAX_HP, 50)   # raw 120 + 50 = 170
+  eq 170, a.max_hp
+  a.change_class(2, 3, Game::Actor::CLASS_SKILL_NO_CHANGE,
+                 Game::Actor::CLASS_PARAM_RESET_LEVEL)
+  eq 70, a.max_hp, "class 2's own level-3 max HP, the +50 adjustment gone"
 end
 
 check 'Change Class parameter modes carry, halve or reset the base stats' do


### PR DESCRIPTION
## Summary
- An ordinary level change (battle EXP, the Change EXP command, or the Change Level command) no longer discards a live Change Parameters adjustment.
- Confirmed against EasyRPG Player's source: `Game_Actor::SetLevel` (`src/game_actor.cpp`) only clamps `data.level` and re-clamps current HP/SP — it never touches `data.attack_mod`/`defense_mod`/`spirit_mod`/`agility_mod`/`hp_mod`/`sp_mod`. Those `*_mod` fields are zeroed only inside `Game_Actor::ChangeClass`, never by an ordinary level-up.
- `Game::Actor#set_level` instead unconditionally rebuilt both `@base` and `@base_raw` from the bare level curve on *every* call, silently discarding any live `#change_param` delta the instant the actor's level changed by any means.
- Fixed by giving `#set_level` a `preserve_mod:` keyword (default `true`) that re-derives the mod by diffing `@base_raw` against the curve at the level/class in force before the call, then reapplies that same mod on top of the new level's curve — mirroring how EasyRPG's separate `*_mod` fields ride unchanged through a level change.
- `#change_class` passes `preserve_mod: false`, matching `ChangeClass`'s own unconditional mod-zeroing before it reapplies the new class's curve. Without this, `CLASS_PARAM_RESET_LEVEL` (the one mode that never re-derives a mod afterward) would leak the old mod through instead of producing the bare new-class curve it's meant to.

## Test plan
- [x] New check: a level-up via the Change Level command carries a live Attack adjustment forward onto the new level's curve, confirmed to fail against the pre-fix code (`expected 72, got 52`)
- [x] New check: Change Class's reset-to-new-level mode still correctly drops a live adjustment instead of inheriting it — confirmed this guard is load-bearing by temporarily reverting just the `preserve_mod: false` argument, which broke this check plus 3 pre-existing Change Class checks (`expected 70, got 170`, etc.)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 860 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 585 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 128 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_