### PR TITLE
Honor per-cell transparency in battle animations

### DIFF
--- a/changelog.d/battle-animation-cell-transparency.fixed.md
+++ b/changelog.d/battle-animation-cell-transparency.fixed.md
@@ -1,0 +1,24 @@
+- **A battle animation cell's own `transparency` is now honoured**, instead of
+  every cell being blitted fully opaque. The LCF `battle_anime` schema
+  (`mruby-lcf/mrblib/schema.rb`, chunk 19's per-cell field 10 — liblcf's
+  `rpg::AnimationCellData::transparency`, an `int32_t` defaulting to 0) has
+  always decoded the field, and `Scene::Map#blit_animation_cell` has always
+  ignored it: an animation whose author faded a cell in or out, or layered a
+  translucent glow over a solid one, played every frame at full strength — a
+  visibly different animation, not a subtler one. A new
+  `Scene::Map#animation_cell_opacity` converts the field's 0-fully-opaque..100-
+  fully-invisible percentage to RGSS's 0..255 opacity exactly the way EasyRPG's
+  own `BattleAnimation::DrawAt` does (`src/battle_animation.cpp`, fetched
+  verbatim): `255 * (100 - cell.transparency) / 100`, integer division and all,
+  and that opacity is passed straight to `Bitmap#blt`, which already blends in
+  straight (non-premultiplied) alpha, so a half-transparent cell lands in the
+  animation bitmap at half coverage with its colour intact rather than dragged
+  toward black. A fully transparent cell is skipped outright rather than run
+  through the blit's own per-pixel loop to draw nothing, and a cell carrying no
+  `transparency` at all (the schema default, a bare test double) reads as 0 and
+  draws exactly as it did before. Out-of-range values are clamped both ways.
+  Per-cell zoom and tone remain approximated as a plain blit, unchanged. Covered
+  by new `scripts/rpg2k_scene_check.rb` checks (the percentage-to-opacity math
+  including the defaulted and out-of-range cases; a drawn cell blitting at its
+  own opacity, in the same place as before, and a 100%-transparent one laying
+  down nothing).

--- a/changelog.d/battle-animation-sheet-colour-key.fixed.md
+++ b/changelog.d/battle-animation-sheet-colour-key.fixed.md
@@ -1,0 +1,19 @@
+- **A battle animation's `Battle/<name>` sheet is now loaded colour-keyed**,
+  instead of opaque. `Bitmap.new`'s second argument maps palette index 0 to
+  transparent (`mruby-rgss/src/lib.cxx`'s `load_xyz_mem` /
+  `load_png_tolerant_mem` `trans` flag), and `Scene::Map#animation_sheet` was
+  the one sheet loader in the RPG2000 runtime that never passed it — CharSet,
+  ChipSet, FaceSet, Monster, System and Picture all did. An animation sheet is
+  a 5-column grid of 96x96 cells whose *entire* background is the transparent
+  colour, so every cell `#blit_animation_cell` laid down painted an opaque
+  96x96 rectangle of that background over its target: a solid block sitting on
+  the enemy for the animation's whole duration rather than a spell. Confirmed
+  against EasyRPG's own material table (`src/cache.cpp`, fetched verbatim),
+  whose `Spec::transparent` column is true for `Battle` — alongside every
+  other directory this runtime already colour-keys — and false only for the
+  four full-screen backdrops (`Backdrop`, `Panorama`, `Title`, `GameOver`),
+  which this runtime already loads opaque and which stay that way. Covered by a
+  new `scripts/rpg2k_scene_check.rb` check (the sheet loads as
+  `Battle/<name>` with the transparency flag set, and `Backdrop/` still loads
+  without it), which required teaching the check suite's stub `Bitmap` to
+  record how a graphic was loaded, not only that it was.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3587,6 +3587,35 @@ The work below is roughly ordered by the critical path to a walkable game
   staying put for center; a map-triggered animation carrying RPG_RT's own
   24px map-target height, not the CharSet frame's 32px), confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **Per-cell transparency is no longer approximated away either.** Each
+  cell of an animation frame carries its own `transparency` (`battle_anime`
+  chunk 19's per-cell field 10 — liblcf's
+  `rpg::AnimationCellData::transparency`, an `int32_t` defaulting to 0),
+  decoded by the schema all along and dropped on the floor by
+  `#blit_animation_cell`, which blitted every cell fully opaque: an animation
+  whose author faded a cell in or out, or layered a translucent glow over a
+  solid one, played every frame at full strength. A new
+  `Scene::Map#animation_cell_opacity` converts the field's percentage (0 fully
+  opaque .. 100 fully invisible) to RGSS's 0..255 opacity exactly the way
+  EasyRPG's own `BattleAnimation::DrawAt` does (`src/battle_animation.cpp`,
+  fetched verbatim): `SetOpacity(255 * (100 - cell.transparency) / 100)`,
+  integer division and all. That opacity goes straight into `Bitmap#blt`'s own
+  optional opacity argument, which blends in *straight* (non-premultiplied)
+  alpha — so a half-transparent cell lands in the screen-sized
+  `@animation_bmp` at half coverage with its colour intact, and
+  `@animation_sprite`'s own composite then attenuates it once, not twice (the
+  exact double-attenuation `blend_over` was written to avoid,
+  `mruby-rgss/src/lib.cxx`). A cell at 100% is skipped rather than run through
+  the blit's 96x96 per-pixel loop to draw nothing, and a cell with no
+  `transparency` at all (the schema default, or a test double that never sets
+  one) reads as 0 and draws exactly as it did before. Out-of-range values clamp
+  both ways. **Still approximated:** per-cell zoom and tone, which need an
+  `RGSS::Viewport` tone and a scaling blit the map rendering path has never had
+  — unchanged by this. Covered by new `scripts/rpg2k_scene_check.rb` checks
+  (the percentage-to-opacity math including the defaulted and out-of-range
+  cases; a drawn cell blitting at its own opacity and in the same place as
+  before; a 100%-transparent cell laying down nothing), confirmed to fail
+  against the pre-fix code before the fix.
 - ✅ **Which fields the games set that the runtime never reads** —
   `ruby scripts/rpg2k_field_audit.rb`. A survey, not a check (it asserts nothing
   and always exits 0): for every scalar database field it counts the rows of the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3616,6 +3616,29 @@ The work below is roughly ordered by the critical path to a walkable game
   cases; a drawn cell blitting at its own opacity and in the same place as
   before; a 100%-transparent cell laying down nothing), confirmed to fail
   against the pre-fix code before the fix.
+  ✅ **The sheet itself is now loaded colour-keyed**, which was the larger
+  half of the same bug. `Bitmap.new`'s second argument maps palette index 0 to
+  transparent (`mruby-rgss/src/lib.cxx`'s `load_xyz_mem` /
+  `load_png_tolerant_mem` `trans` flag), and `#animation_sheet` was the one
+  sheet loader in this runtime that never passed it — `CharSet/`, `ChipSet/`,
+  `FaceSet/`, `Monster/`, `System/` and `Picture/` all did, so `Battle/` alone
+  decoded opaque. An animation sheet is a 5-column grid of 96x96 cells whose
+  *entire* background is the transparent colour, so every cell
+  `#blit_animation_cell` laid down painted an opaque 96x96 rectangle of that
+  background over its target: a solid block parked on the enemy for the
+  animation's whole duration, not a spell. (With the per-cell transparency fix
+  above and without this one, the block would merely have become a translucent
+  block; the two are halves of the same "handle the animation's transparency"
+  gap.) Confirmed against EasyRPG's own material table (`src/cache.cpp`,
+  fetched verbatim), whose `Spec::transparent` column is true for `Battle`
+  alongside every directory this runtime already colour-keys, and false only
+  for the four full-screen backdrops — `Backdrop`, `Panorama`, `Title`,
+  `GameOver` — which this runtime already loads opaque and which stay that
+  way. Covered by a new `scripts/rpg2k_scene_check.rb` check (the sheet loads
+  as `Battle/<name>` with the flag set, `Backdrop/` still loads without it),
+  which needed the check suite's stub `Bitmap` taught to record *how* a
+  graphic was loaded rather than only that it was; confirmed to fail against
+  the pre-fix code before the fix.
 - ✅ **Which fields the games set that the runtime never reads** —
   `ruby scripts/rpg2k_field_audit.rb`. A survey, not a check (it asserts nothing
   and always exits 0): for every scalar database field it counts the rows of the

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7813,8 +7813,9 @@ class RPG2k
       # Composite the animation's current frame over its target. Runs in the
       # render pass (the camera is known here): each visible cell of the frame is
       # blitted from the sheet's 96x96 grid to the target's screen position plus
-      # the cell's offset. Zoom / tone / per-cell transparency are approximated as
-      # a plain blit for now.
+      # the cell's offset, at that cell's own transparency
+      # (#animation_cell_opacity). Zoom / tone are still approximated as a plain
+      # blit.
       def draw_map_animation(cam_x, cam_y)
         return unless @animation_sprite
         ma = @map_animation
@@ -7867,13 +7868,47 @@ class RPG2k
         end
       end
 
+      # The blit opacity a cell's own `transparency` field asks for (LCF
+      # `battle_anime` chunk 19's per-cell field 10, decoded in
+      # mruby-lcf/mrblib/schema.rb; liblcf's `rpg::AnimationCellData::
+      # transparency`, an `int32_t` defaulting to 0). It is a *percentage of
+      # transparency*, 0 fully opaque .. 100 fully invisible, and it converts to
+      # RGSS's 0..255 opacity exactly the way EasyRPG's own
+      # `BattleAnimation::DrawAt` does (src/battle_animation.cpp, fetched
+      # verbatim): `SetOpacity(255 * (100 - cell.transparency) / 100)` — integer
+      # division, so 0 -> 255 and 100 -> 0, with the same truncation in between.
+      #
+      # Every drawable cell went down fully opaque before this: an animation
+      # whose author faded a cell in or out (or layered a translucent glow over
+      # a solid one) drew every one of its frames at full strength, which is a
+      # visibly different animation, not a subtler one. The field is decoded off
+      # the real database and was simply never read.
+      #
+      # A cell with no `transparency` at all — a bare test double, or an
+      # Array2D entry the schema left defaulted — reads as 0 (opaque), the same
+      # "absent means the schema default" shape #draw_map_animation's own
+      # `visible` guard uses. Clamped both ways so a database carrying an
+      # out-of-range value cannot ask for a negative or over-255 opacity.
+      def animation_cell_opacity(cell)
+        t = cell.respond_to?(:transparency) ? cell.transparency : nil
+        t = 0 if t.nil?
+        t = 0 if t < 0
+        t = 100 if t > 100
+        255 * (100 - t) / 100
+      end
+
       def blit_animation_cell(sheet, cell, cx, cy)
+        opacity = animation_cell_opacity(cell)
+        # A fully transparent cell contributes nothing; skipping it spares the
+        # blit's own 96x96 per-pixel loop (Bitmap#blt would drop every pixel on
+        # its `alpha <= 0` test anyway, one at a time).
+        return if opacity <= 0
         cid = cell.cell_id || 0
         sx = (cid % ANIM_SHEET_COLS) * ANIM_CELL
         sy = (cid / ANIM_SHEET_COLS) * ANIM_CELL
         dx = cx + (cell.x || 0) - ANIM_CELL / 2
         dy = cy + (cell.y || 0) - ANIM_CELL / 2
-        @animation_bmp.blt dx, dy, sheet, Rect.new(sx, sy, ANIM_CELL, ANIM_CELL)
+        @animation_bmp.blt dx, dy, sheet, Rect.new(sx, sy, ANIM_CELL, ANIM_CELL), opacity
       rescue StandardError
         nil
       end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -7662,11 +7662,28 @@ class RPG2k
       # Animation command can replay the same animation many times over a
       # visit, and previously this reloaded and redecoded the sheet from disk
       # on every single play.
+      #
+      # Loaded **colour-keyed** (`Bitmap.new`'s second argument, which maps
+      # palette index 0 to transparent -- `mruby-rgss/src/lib.cxx`'s
+      # `load_xyz_mem`/`load_png_tolerant_mem` `trans` flag), like every other
+      # RPG2000 sprite sheet this runtime loads. `Battle/` was the one sheet
+      # directory that asked for an opaque decode, and it is the one directory
+      # where that is never right: an animation sheet is a 5-column grid of
+      # 96x96 cells whose *entire* background is the transparent colour, so
+      # every cell #blit_animation_cell laid down painted an opaque 96x96
+      # rectangle of that background over the target -- a solid block sitting
+      # on the enemy for the animation's whole duration, not a spell. Confirmed
+      # against EasyRPG's own material table (`src/cache.cpp`, fetched
+      # verbatim), whose `Spec::transparent` column is true for `Battle` (and
+      # for CharSet / ChipSet / FaceSet / Monster / Picture / System, matching
+      # every other loader here) and false only for the four full-screen
+      # backdrops -- `Backdrop`, `Panorama`, `Title`, `GameOver` -- which this
+      # runtime already loads opaque.
       def animation_sheet(name)
         return nil if name.nil? || name.empty?
         cached_bitmap(@animation_cache, name) do
           begin
-            Bitmap.new "Battle/#{name}"
+            Bitmap.new "Battle/#{name}", true
           rescue StandardError => e
             $stderr.puts "[RPG2k] battle animation '#{name}' load failed: #{e.message}"
             nil

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -11089,6 +11089,58 @@ check 'a head/feet Show Battle Animation position offsets where it draws over th
      'position 1 (center), the schema default, is unchanged from the plain centre pixel'
 end
 
+# Each animation cell carries its own `transparency` (LCF battle_anime chunk
+# 19's per-cell field 10 -- mruby-lcf/mrblib/schema.rb), decoded all along and
+# never read, so every cell drew fully opaque no matter what its author asked
+# for. #animation_cell_opacity is the pure-logic half, mirroring EasyRPG's own
+# `BattleAnimation::DrawAt`: `SetOpacity(255 * (100 - cell.transparency) / 100)`.
+check 'animation_cell_opacity converts a cell transparency percentage to a blit opacity' do
+  scene, = battle_at_command
+  op = ->(t) { scene.send(:animation_cell_opacity, OpenStruct.new(cell_id: 0, transparency: t)) }
+  eq 255, op.call(0), '0% transparent is fully opaque, the schema default'
+  eq 0, op.call(100), '100% transparent is fully invisible'
+  eq 127, op.call(50), 'half transparent is half opacity (255 * 50 / 100, truncated)'
+  eq 191, op.call(25)
+  eq 63, op.call(75)
+  eq 255, scene.send(:animation_cell_opacity, OpenStruct.new(cell_id: 0)),
+     'a cell carrying no transparency field at all reads as the 0 default, not as nil'
+  # A real Array1D only ever decodes an unsigned BER here, but a hand-authored
+  # or corrupt row must not be able to ask for an out-of-range opacity.
+  eq 255, op.call(-10), 'a negative transparency clamps to fully opaque'
+  eq 0, op.call(150), 'a transparency past 100 clamps to fully invisible'
+end
+
+check 'a battle animation cell blits at its own transparency' do
+  scene, = battle_at_command
+  scene.send(:start_battle_animation,
+             { attacker: 'Hero', target: 'Slime', damage: 7, skill: 'Fire',
+               skill_id: 8, target_index: 0, target_ally: false })
+  ma = scene.instance_variable_get(:@map_animation)
+  bmp = scene.instance_variable_get(:@animation_bmp)
+  cell = ma[:frames][0].cells[1]
+
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  eq 255, bmp.blt_calls.first[4],
+     'a cell with no transparency set goes down fully opaque, exactly as before this fix'
+
+  cell.transparency = 60
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  eq 1, bmp.blt_calls.size, 'still one cell'
+  eq 102, bmp.blt_calls.first[4], '60% transparent blits at 255 * 40 / 100'
+  eq [ma[:tx] - 48, ma[:ty] - 48], bmp.blt_calls.first[0, 2],
+     'and lands in exactly the same place -- opacity is the only thing that changed'
+
+  cell.transparency = 100
+  bmp.clear_blt_calls
+  scene.send(:draw_map_animation, 500, 400)
+  ok bmp.blt_calls.empty?,
+     'a fully transparent cell is skipped outright rather than blitted at opacity 0'
+  # The fixture database is rebuilt per scene (#new_scene -> #fake_db), so the
+  # mutated cell does not leak into the next check.
+end
+
 check 'the battle status window shows each ally condition, or the normal term' do
   scene, ui = battle_at_command
   texts = window_texts(ui[:status_win])

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -37,8 +37,21 @@ module RGSS
   # ChipsetLayout blit path instead of the colour-block fallback.
   class Bitmap
     attr_reader :width, :height
-    def initialize(w = 1, h = 1)
+    # The `"Dir/name"` a file-loading construction asked for, and whether it
+    # asked for the colour-keyed (palette index 0 transparent) decode -- the
+    # real Bitmap's own second argument. Recorded so a check can assert *how* a
+    # graphic was loaded, not only that something was: an RPG2000 sprite sheet
+    # loaded opaque draws its whole transparent background as solid pixels.
+    # The real Bitmap overloads its second argument the same way: it is the
+    # height for `Bitmap.new(w, h)` and the transparency flag for
+    # `Bitmap.new("Dir/name", trans)` (mruby-rgss/src/lib.cxx, `bmp_init`'s
+    # `"z|b"` vs the two-integer form), so it is read here as whichever the
+    # first argument makes it.
+    attr_reader :load_name, :load_transparent
+    def initialize(w = 1, h = nil)
       if w.is_a?(String)
+        @load_name = w
+        @load_transparent = h ? true : false
         @width = 480; @height = 256
       else
         @width = w.to_i; @height = h.to_i
@@ -11087,6 +11100,27 @@ check 'a head/feet Show Battle Animation position offsets where it draws over th
   call = bmp.blt_calls.first
   eq [ma[:tx] - 48, ma[:ty] - 48], [call[0], call[1]],
      'position 1 (center), the schema default, is unchanged from the plain centre pixel'
+end
+
+# An RPG2000 animation sheet is a grid of 96x96 cells whose whole background is
+# the palette's transparent colour, so it has to be decoded colour-keyed
+# (`Bitmap.new`'s second argument) the same way every other sprite sheet this
+# runtime loads is. `Battle/` was the one sheet directory asking for an opaque
+# decode, which made every cell blit a solid 96x96 rectangle of background over
+# its target. EasyRPG's own material table (`src/cache.cpp`) sets
+# `Spec::transparent` true for Battle, and false only for the four full-screen
+# backdrops this runtime already loads opaque.
+check 'the Battle/ animation sheet is loaded colour-keyed, like every other sprite sheet' do
+  scene, = battle_at_command
+  sheet = scene.send(:animation_sheet, 'Anim')
+  ok sheet, 'the sheet loaded'
+  eq 'Battle/Anim', sheet.load_name
+  eq true, sheet.load_transparent,
+     'palette index 0 must decode transparent, or every cell paints an opaque 96x96 block'
+  # The four full-screen backdrops are the deliberate exceptions, and stay
+  # opaque -- they have no transparent colour to key out.
+  eq false, scene.send(:battle_back_bitmap, 'Back').load_transparent,
+     'Backdrop/ is a full-screen image and stays opaque'
 end
 
 # Each animation cell carries its own `transparency` (LCF battle_anime chunk


### PR DESCRIPTION
## Summary

Battle animation cells now respect their individual `transparency` field instead of always being blitted fully opaque. This fixes animations where authors intended to fade cells in/out or layer translucent effects.

## Changes

- **Added `animation_cell_opacity` method** in `Scene::Map` that converts the LCF `battle_anime` cell transparency percentage (0=opaque, 100=invisible) to RGSS opacity (0-255) using the formula `255 * (100 - transparency) / 100`, matching EasyRPG's implementation exactly.

- **Updated `blit_animation_cell`** to:
  - Retrieve the opacity from the new `animation_cell_opacity` method
  - Skip fully transparent cells (opacity ≤ 0) to avoid unnecessary per-pixel blitting
  - Pass the calculated opacity to `Bitmap#blt`'s optional opacity parameter

- **Handles edge cases**:
  - Cells with no `transparency` field default to 0 (fully opaque), preserving existing behavior
  - Out-of-range values clamp to valid bounds (negative → 0, >100 → 100)
  - Uses straight (non-premultiplied) alpha blending via `Bitmap#blt`

## Testing

Added comprehensive checks in `scripts/rpg2k_scene_check.rb`:
- Opacity calculation for various transparency percentages (0%, 25%, 50%, 75%, 100%)
- Default behavior when transparency field is absent
- Clamping of out-of-range values
- Integration test verifying cells blit at correct opacity in the same position
- Verification that fully transparent cells produce no blit calls

Updated `docs/TODO.md` and added changelog entry documenting the fix.

https://claude.ai/code/session_01Qg8nuPUzVwFsJLVTZiKyNB