### PR TITLE
Implement item 使用回数 (use count) consumption mechanics

### DIFF
--- a/changelog.d/rpg2k-item-uses-count.fixed.md
+++ b/changelog.d/rpg2k-item-uses-count.fixed.md
@@ -1,0 +1,15 @@
+- **An item's 使用回数 (use count) is now honoured instead of every item being
+  destroyed by its first use.** A copy is spent only once it has been used as
+  many times as the item's `uses` field (item field 6) says; `0` means 無制限,
+  an item that is never consumed however often it is used; and the five
+  equipment types are never consumed by use at all, so a 特殊効果 weapon that
+  casts its skill from the Item menu is a reusable tool rather than a one-shot.
+  Confirmed against EasyRPG Player's `Game_Party::ConsumeItemUse`, including
+  its companion rule in `AddItem`: a copy *leaving* the bag resets the
+  part-used tally and adding one never does, so selling a half-used item and
+  buying it back refills its uses while topping the stack up does not. The
+  tally survives Save / Continue, both in this runtime's own saves and in a
+  genuine `Save<N>.lsd` (chunk 109's `item_usage`, parsed but until now
+  unused). Every use site goes through one new `Game::Party#consume_item_use`:
+  the field item menu, the battle Item action, medicines, skill books, seeds,
+  special items, switch items and escape/teleport items alike.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5635,6 +5635,43 @@ not yet verified:
   purposes. Covered by a new `scripts/rpg2k_logic_check.rb` check pinning the
   concrete debuff-then-equip trace above, confirmed to fail against the
   pre-fix code before the fix (`expected 1, got 31`).
+- ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
+  only once it has been used that many times, `0` means 無制限 (never
+  consumed), and the five equipment types are never consumed by use at all.**
+  The field has been parsed since the schema was written (`LCF::Schema`'s item
+  chunk 13, field 6, default 1) and no runtime code had ever read it: every one
+  of the eight consumption sites — `#use_medicine`, `#use_skill_book`,
+  `#use_seed`, `#use_special_item`, `#use_equip_skill_item`,
+  `#use_special_escape_item`, `#use_special_teleport_item`, `#use_switch_item`
+  and the battle screen's own Item action (`Scene::Map#drive_battle_animate`) —
+  called a bare `lose_item(id, 1)`, so *every* item vanished on its first use.
+  Three separate behaviours were missing, all from EasyRPG's
+  `Game_Party::ConsumeItemUse` (`src/game_party.cpp`), which
+  `Game_Party::UseItem` calls once an item is known to have done something:
+  a **type gate** (`Type_normal` and the five equipment types return before the
+  use count is ever looked at, so a 特殊効果 `use_skill` weapon casting its
+  skill from the Item menu is a *reusable tool* — this build destroyed the
+  weapon on its first use), **`uses == 0` meaning unlimited**, and the
+  **partial-use tally** itself (`item_usage[idx]++`, and only on reaching
+  `uses` is a copy removed and the tally reset). The tally is per item id, not
+  per copy, matching the save format: chunk 109's `item_usage` (field 14) runs
+  parallel to `item_ids`/`item_counts` and was already decoded but unused.
+  Modelled as `Game::Party#item_usage` (id → uses spent on the copy in hand)
+  behind one new `#consume_item_use` that every site now calls; `#gain_item`
+  carries the other half of the rule — EasyRPG's `AddItem` resets the tally
+  whenever a copy *leaves* the bag and never when one is added, so selling a
+  half-used item and buying it back refills its uses while topping the stack up
+  does not. The tally survives Save/Continue both ways: through
+  `Party#to_h`/`#load_state` for this runtime's own Marshal saves (an older
+  save with no tally simply reads as "nothing spent") and through chunk 109
+  field 14 in `State#to_lsd`/`.from_lsd` for a genuine `Save<N>.lsd`. Covered
+  by six new `scripts/rpg2k_logic_check.rb` checks (the N-uses-per-copy walk,
+  `uses == 0`, the schema default, the gain/lose reset asymmetry, the
+  Save/Continue round-trip and the `.lsd` round-trip) plus a data-driven
+  `scripts/rpg2k_testbed_logic_check.rb` check that walks every real switch
+  item whose 使用回数 is not the default; the two existing `use_skill`
+  equipment checks now assert the weapon is *not* consumed, which is what they
+  had been pinning the old bug as correct.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -2582,6 +2582,11 @@ module Game
 
     attr_reader :actors, :items, :gold
 
+    # Per-item 使用回数 progress: item id => uses already spent on the copy
+    # currently being used up (see #consume_item_use). Exposed for the save
+    # layer (#to_h) and for tests; the bag itself stays `items`.
+    attr_reader :item_usage
+
     # The permanent actor roster this party draws from (see Game::Actors). The
     # party owns it, so `State#party.roster` reaches every actor the game has
     # met, including ones who have since left.
@@ -2597,6 +2602,12 @@ module Game
       ids ||= db.system.party || []
       @actors = ids.reject { |i| i.nil? || i <= 0 }.map { |i| @roster[i] }.compact
       @items = {}  # item id => count
+      # 使用回数 bookkeeping: item id => how many uses the *current* copy has
+      # already spent (see #consume_item_use). One tally per id, not per copy,
+      # matching the save format's own `item_usage` array (chunk 109 field 14),
+      # which runs parallel to `item_ids`/`item_counts`. An id absent here has
+      # spent nothing.
+      @item_usage = {}
       @gold = 0
       @revision = 0
     end
@@ -2633,7 +2644,11 @@ module Game
                        class_id: a.class_id,
                        battle_commands: a.battle_commands.dup }
       end
-      { actor_ids: @actors.map { |a| a.id }, items: @items, gold: @gold,
+      { actor_ids: @actors.map { |a| a.id }, items: @items,
+        # Half-spent 使用回数 rides along with the bag, the way the save format
+        # keeps `item_usage` beside `item_counts` -- without it a Save/Continue
+        # silently refills every partly-used item.
+        item_usage: @item_usage, gold: @gold,
         hp: hp, mp: mp, exp: exp, actor_meta: meta }
     end
 
@@ -2651,6 +2666,10 @@ module Game
     def load_state(data)
       @revision += 1
       @items = data[:items] || {}
+      # A save written before 使用回数 was modelled carries no tally at all, so
+      # every held item simply starts its uses over -- the same answer this
+      # runtime gave for the whole of that save's life.
+      @item_usage = data[:item_usage] || {}
       @gold = data[:gold] || 0
       exp = data[:exp] || {}
       hp = data[:hp] || {}
@@ -2857,6 +2876,19 @@ module Game
       c = item_count(id) + n
       c = 0 if c < 0
       c = 99 if c > 99
+      # **Losing** a copy wipes the part-used tally on that id, so the next copy
+      # starts on a full set of uses; gaining one never touches it, even at the
+      # 99 cap (EasyRPG's `Game_Party::AddItem`: "If the item was removed, the
+      # number of uses resets. Adding an item never changes the number of uses,
+      # even when you already have x99 of them."). Selling a half-used potion
+      # and buying it back therefore refills its uses, exactly as RPG_RT does.
+      if n < 0
+        if c == 0
+          @item_usage.delete(id)
+        else
+          @item_usage[id] = 0
+        end
+      end
       return c if @items[id] == c
       @items[id] = c
       @revision += 1
@@ -2890,6 +2922,11 @@ module Game
     ITEM_SEED = 8
     ITEM_SPECIAL = 9
     ITEM_SWITCH = 10
+
+    # 通常物品 (type 0): an item with no effect of its own -- a key item, a quest
+    # token, something an event checks for. It is never *used*, which is why
+    # #consume_item_use names it among the types it passes over untouched.
+    ITEM_NORMAL = 0
 
     # The five equipment types (see Actor::EQUIP_ORDER for the slot mapping),
     # named here for #field_usable? / #battle_usable? / #use_item's `use_skill`
@@ -3011,13 +3048,14 @@ module Game
       !it.nil? && it.type == ITEM_SWITCH
     end
 
-    # Use a switch item from the field menu: consume one and return the id of the
-    # switch to turn on (the caller owns the switch table). nil when `id` is not a
-    # switch item the party holds, so nothing is consumed. Matches EasyRPG, where
-    # UseItem consumes and the scene flips the switch.
+    # Use a switch item from the field menu: spend one use (#consume_item_use, so
+    # a multi-use or 無制限 switch item is not eaten on its first flip) and return
+    # the id of the switch to turn on (the caller owns the switch table). nil when
+    # `id` is not a switch item the party holds, so nothing is consumed. Matches
+    # EasyRPG, where UseItem consumes and the scene flips the switch.
     def use_switch_item(id)
       return nil unless switch_item?(id) && item_count(id) > 0
-      lose_item(id, 1)
+      consume_item_use(id)
       db_item(id).switch_id
     end
 
@@ -3172,6 +3210,69 @@ module Game
       end
     end
 
+    # 使用回数 (`uses`, item field 6): how many times **one copy** of an item may
+    # be used before it is spent. The editor's own wording is 使用回数, with 0
+    # meaning 無制限 -- an item that is never consumed however often it is used
+    # (Nepheshel's reusable tools are exactly this, and until now every one of
+    # them vanished on first use). The default is 1: a plain potion is used up
+    # by a single use, which is why every consumption site could get away with a
+    # bare `lose_item(id, 1)` before this existed.
+    #
+    # A fixture item row with no `uses` field at all reads as 1, the schema's own
+    # default (`LCF::Schema` item field 6), so a hand-built test item keeps the
+    # single-use behaviour it has always had.
+    def item_uses(it)
+      u = it.respond_to?(:uses) ? it.uses : nil
+      u.nil? ? 1 : u
+    end
+
+    # Spend one use of item `id`, consuming a copy only once its 使用回数 runs
+    # out. This is the single consumption point for *using* an item -- the field
+    # menu, the battle item action and every #use_* helper below go through it
+    # instead of calling #lose_item themselves, mirroring EasyRPG's
+    # `Game_Party::ConsumeItemUse`, which `Game_Party::UseItem` calls once the
+    # item is known to have done something.
+    #
+    # Three rules come from RPG_RT and none of them were modelled before:
+    #
+    #   * **Type gate.** A 通常物品 and the five equipment types are never
+    #     consumed by use. The equipment case is the load-bearing one here: an
+    #     item flagged 特殊効果 (`use_skill`) casts its skill straight from the
+    #     Item menu, and RPG_RT does *not* eat the weapon for it -- it is
+    #     `ConsumeItemUse`'s early `return`, not a missing branch. This build
+    #     used to destroy such a weapon on its first use.
+    #   * **`uses == 0` is unlimited.** Nothing is spent, ever.
+    #   * **Partial use.** Otherwise the id's tally rises by one and the copy is
+    #     only removed once the tally reaches `uses`, at which point it resets --
+    #     so an item with 使用回数 3 held ×2 survives five uses and disappears on
+    #     the sixth. #gain_item handles the reset for the other direction (an
+    #     item leaving the bag by any route).
+    #
+    # A dangling id (no database row) is logged and left alone rather than
+    # silently eaten, the same way #field_usable? reports one for the menu.
+    def consume_item_use(id)
+      it = db_item(id)
+      if it.nil?
+        $stderr.puts "[RPG2k] Item use: item ##{id} has no matching database " \
+                     'row, consuming nothing'
+        return
+      end
+      case it.type
+      when ITEM_NORMAL, Actor::ITEM_WEAPON, ITEM_SHIELD, ITEM_ARMOR,
+           ITEM_HELMET, ITEM_ACCESSORY
+        return
+      end
+      uses = item_uses(it)
+      return if uses == 0
+      return unless item_count(id) > 0
+      spent = (@item_usage[id] || 0) + 1
+      if spent >= uses
+        lose_item(id, 1) # clears the tally itself (see #gain_item)
+      else
+        @item_usage[id] = spent
+      end
+    end
+
     # Use item `id` from the field menu, dispatching on its database type, and
     # return the actors it affected (empty when it did nothing -- then nothing is
     # consumed). A medicine heals; a skill book teaches its skill; a seed raises a
@@ -3204,7 +3305,7 @@ module Game
     def use_special_item(it, id, actor)
       return [] unless actor && item_usable_by?(it, actor.id)
       affected = cast_skill(actor, it.skill_id, actor, true)
-      lose_item(id, 1) unless affected.empty?
+      consume_item_use(id) unless affected.empty?
       affected
     end
 
@@ -3213,10 +3314,17 @@ module Game
     # cast #use_special_item gives a type-9 special item, gated additionally by
     # `class_set` (#item_usable_by_class?), the restriction list a use_skill
     # equipment item carries that a special item does not.
+    #
+    # The weapon itself is **not** consumed, however often it is used: RPG_RT
+    # returns from `ConsumeItemUse` on the five equipment types before it ever
+    # looks at 使用回数 (see #consume_item_use), which is what makes a 特殊効果
+    # weapon a reusable tool rather than a one-shot. Routing the consumption
+    # through #consume_item_use is what gets that right -- this used to spend
+    # the weapon on its first use and leave the party without it.
     def use_equip_skill_item(it, id, actor)
       return [] unless actor && item_usable_by?(it, actor.id) && item_usable_by_class?(it, actor)
       affected = cast_skill(actor, it.skill_id, actor, true)
-      lose_item(id, 1) unless affected.empty?
+      consume_item_use(id) unless affected.empty?
       affected
     end
 
@@ -3234,7 +3342,7 @@ module Game
       return nil unless it && it.type == ITEM_SPECIAL && actor && item_usable_by?(it, actor.id)
       target = cast_escape_skill(actor, it.skill_id, state, true)
       return nil unless target
-      lose_item(id, 1)
+      consume_item_use(id)
       target
     end
 
@@ -3246,7 +3354,7 @@ module Game
       return nil unless it && it.type == ITEM_SPECIAL && actor && item_usable_by?(it, actor.id)
       target = cast_teleport_skill(actor, it.skill_id, state, map_id, true)
       return nil unless target
-      lose_item(id, 1)
+      consume_item_use(id)
       target
     end
 
@@ -3298,7 +3406,7 @@ module Game
         changed ||= t.hp != before_hp || t.mp != before_mp
         affected.push(t) if changed
       end
-      lose_item(id, 1) unless affected.empty?
+      consume_item_use(id) unless affected.empty?
       affected
     end
 
@@ -3310,7 +3418,7 @@ module Game
       return [] unless actor && item_usable_by?(it, actor.id) &&
                        skill && skill != 0 && !actor.knows_skill?(skill)
       actor.learn_skill(skill)
-      lose_item(id, 1)
+      consume_item_use(id)
       [actor]
     end
 
@@ -3333,7 +3441,7 @@ module Game
       boosts = seed_boosts(it)
       return [] unless boosts.any? { |b| b != 0 }
       boosts.each_index { |i| actor.change_param(i, boosts[i]) if boosts[i] != 0 }
-      lose_item(id, 1)
+      consume_item_use(id)
       [actor]
     end
 
@@ -10631,6 +10739,11 @@ module Game
       inv[11] = item_ids.size
       inv[12] = item_ids
       inv[13] = item_ids.map { |i| @party.items[i] }
+      # Field 14 runs parallel to 12/13: how many uses the copy in hand has
+      # already spent (Party#consume_item_use). Written for every id, zeros
+      # included, so the three arrays stay the same length the way a genuine
+      # save keeps them -- .from_lsd and RPG_RT alike read them by index.
+      inv[14] = item_ids.map { |i| @party.item_usage[i] || 0 }
       inv[21] = @party.gold
       t1, t2 = @timers[0], @timers[1]
       inv[23] = t1.frames
@@ -10744,7 +10857,16 @@ module Game
       items = {}
       ids = inv.item_ids || []
       counts = inv.item_counts || []
-      ids.each_index { |i| items[ids[i]] = counts[i] || 0 }
+      # `item_usage` (chunk 109 field 14) runs parallel to the id/count arrays:
+      # how many uses the copy currently in hand has already spent, so a potion
+      # with 使用回数 3 that RPG_RT had used twice resumes with one use left
+      # rather than three (see Party#consume_item_use).
+      usage_arr = inv.item_usage || []
+      usage = {}
+      ids.each_index do |i|
+        items[ids[i]] = counts[i] || 0
+        usage[ids[i]] = usage_arr[i] if usage_arr[i] && usage_arr[i] != 0
+      end
       # Per-actor state comes from the SAVE_PARTY_ACTOR table (chunk 108), keyed
       # by actor id. Restore each actor's saved level (which rescales its base
       # stats) and exp first, then its current HP/SP, so Continue resumes a
@@ -10786,7 +10908,8 @@ module Game
         hp[aid] = sa.hp if sa.hp
         mp[aid] = sa.mp if sa.mp
       end
-      party.load_state(items: items, gold: inv.gold, hp: hp, mp: mp)
+      party.load_state(items: items, item_usage: usage, gold: inv.gold,
+                       hp: hp, mp: mp)
       state = new(party, hero.map_id, hero.x, hero.y)
       state.direction = hero.direction || 2
       # Vehicle locations (chunks 105 boat / 106 ship / 107 airship), each a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -5722,12 +5722,15 @@ class RPG2k
         end
         entry = @battle_ui[:battle].step_action
         if entry
-          # An Item action consumes one from the real bag when it lands (so
-          # backing out during the command phase never spends it). A switch
-          # item flips its switch at the same moment -- the state table is
-          # the scene's, same as the field menu's own Scene::ItemMenu, and
+          # An Item action spends one *use* from the real bag when it lands (so
+          # backing out during the command phase never spends it), which only
+          # costs a copy once the item's 使用回数 runs out -- the same
+          # Game::Party#consume_item_use the field menu goes through, so a
+          # multi-use bomb or a 特殊効果 weapon behaves identically in a fight.
+          # A switch item flips its switch at the same moment -- the state table
+          # is the scene's, same as the field menu's own Scene::ItemMenu, and
           # this is the only place a queued switch-item action ever reaches it.
-          @state.party.lose_item(entry[:item_id], 1) if entry[:item_id]
+          @state.party.consume_item_use(entry[:item_id]) if entry[:item_id]
           @state.switches[entry[:switch_id]] = true if entry[:switch_id]
           log_round([entry])
           refresh_battle_status

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2979,7 +2979,12 @@ FakeItem = Struct.new(:atk_points1, :def_points1, :spi_points1, :agi_points1,
                       # allowed to trigger it this way
                       # (Game::Party#item_usable_by_class?). Appended last,
                       # same positional-safety reasoning as every field above.
-                      :class_set)
+                      :class_set,
+                      # 使用回数 (field 6): how many times one copy may be used
+                      # before it is spent, 0 meaning 無制限
+                      # (Game::Party#consume_item_use). The schema's default is
+                      # 1, which is what `fake_item` passes when it is not named.
+                      :uses)
 def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               scope: 0, rhp: 0, rhp_rate: 0, rsp: 0, rsp_rate: 0, price: 0,
               skill_id: 0, atk2: 0, dfn2: 0, spi2: 0, agi2: 0, occ_battle: true,
@@ -2989,14 +2994,15 @@ def fake_item(atk: 0, dfn: 0, spi: 0, agi: 0, mhp: 0, msp: 0, type: 0, name: '',
               half_sp_cost: false, hit: 0, critical_hit: 0, ko_only: false,
               two_handed: 0, attack_all: false, preemptive: false, actor_set: nil,
               cursed: false, raise_evasion: false, animation_id: nil,
-              state_chance: 0, use_skill: false, class_set: nil)
+              state_chance: 0, use_skill: false, class_set: nil, uses: 1)
   FakeItem.new(atk, dfn, spi, agi, mhp, msp, type, name, scope,
                rhp, rhp_rate, rsp, rsp_rate, price, skill_id,
                atk2, dfn2, spi2, agi2, occ_battle, state_set, reverse_state,
                prevent_crit, attribute_set, switch_id, occ_field, field_only,
                dual_attack, ignore_evasion, half_sp_cost, hit, critical_hit,
                ko_only, two_handed, attack_all, preemptive, actor_set, cursed,
-               raise_evasion, animation_id, state_chance, use_skill, class_set)
+               raise_evasion, animation_id, state_chance, use_skill, class_set,
+               uses)
 end
 # A database skill row exposing the fields Game::Party's field-skill logic reads.
 FakeSkill = Struct.new(:name, :type, :scope, :occasion_field, :sp_type, :sp_cost,
@@ -4600,6 +4606,114 @@ check 'gain_item clamps at 99, silently, past a single gain or several ' \
   eq 49, st.party.item_count(5), 'losing still works normally once below the cap again'
 end
 
+# -- 使用回数 (item uses count, item field 6) ---------------------------------
+
+check 'an item with 使用回数 N is only consumed once a copy has been used N times' do
+  # RPG_RT gives every item a use count and spends a *copy* only when it runs
+  # out (EasyRPG's Game_Party::ConsumeItemUse). The tally is per item id and
+  # resets with each copy spent, so ×2 of a three-use item is worth six uses.
+  # This build used to spend a copy on every single use, whatever the field
+  # said. A switch item is the cleanest probe: it always "does something", so
+  # every call reaches the consumption path.
+  st = item_party({ 4 => fake_item(type: 10, switch_id: 7, uses: 3) })
+  st.party.gain_item(4, 2)
+  2.times do |i|
+    eq 7, st.party.use_switch_item(4), 'it flips its switch every time'
+    eq 2, st.party.item_count(4), "use #{i + 1} of 3 costs no copy"
+    eq i + 1, st.party.item_usage[4], 'it is tallied instead'
+  end
+  eq 7, st.party.use_switch_item(4)
+  eq 1, st.party.item_count(4), 'the third use is what spends the copy'
+  eq 0, st.party.item_usage[4] || 0, 'and the tally starts over for the next one'
+  3.times { st.party.use_switch_item(4) }
+  eq 0, st.party.item_count(4), 'the second copy goes exactly the same way'
+  ok st.party.use_switch_item(4).nil?, 'with nothing left to use afterwards'
+end
+
+check '使用回数 0 means 無制限 -- the item is never consumed, however often it is used' do
+  st = item_party({ 4 => fake_item(type: 10, switch_id: 7, uses: 0) })
+  st.party.gain_item(4, 1)
+  10.times { eq 7, st.party.use_switch_item(4) }
+  eq 1, st.party.item_count(4), 'an unlimited-use item survives every use'
+  eq 0, st.party.item_usage[4] || 0, 'and nothing is tallied against it'
+end
+
+check 'an item row with no 使用回数 field is single-use, the schema default' do
+  # Field 6 defaults to 1 (LCF::Schema item field 6), so an ordinary potion is
+  # spent by one use -- the behaviour every consumption site had hard-coded.
+  st = item_party({ 5 => fake_item(type: 6, rhp: 50) })
+  hero = st.party.actor_by_id(1)
+  hero.change_hp(-60)
+  st.party.gain_item(5, 2)
+  eq [hero], st.party.use_item(5, hero)
+  eq 1, st.party.item_count(5), 'one use, one copy'
+end
+
+check 'losing a copy resets the 使用回数 tally; gaining one never does' do
+  # EasyRPG's Game_Party::AddItem: "If the item was removed, the number of uses
+  # resets. (Adding an item never changes the number of uses, even when you
+  # already have x99 of them.)" So selling a half-used item and buying it back
+  # refills its uses, while topping the stack up leaves the copy in hand alone.
+  st = item_party({ 4 => fake_item(type: 10, switch_id: 7, uses: 3) })
+  st.party.gain_item(4, 2)
+  st.party.use_switch_item(4)
+  eq 1, st.party.item_usage[4], 'one use spent'
+  st.party.gain_item(4, 1)
+  eq 1, st.party.item_usage[4], 'gaining another copy leaves the tally alone'
+  st.party.lose_item(4, 1)
+  eq 0, st.party.item_usage[4], 'losing one resets it'
+  st.party.use_switch_item(4)
+  st.party.lose_item(4, 99)
+  eq 0, st.party.item_count(4)
+  ok st.party.item_usage[4].nil?, 'and an id that leaves the bag drops its tally entirely'
+end
+
+check 'a part-used item keeps its 使用回数 tally across Save / Continue' do
+  items = { 4 => fake_item(type: 10, switch_id: 7, uses: 3) }
+  st = item_party(items)
+  st.party.gain_item(4, 1)
+  st.party.use_switch_item(4)
+  eq 1, st.party.item_usage[4]
+
+  round = item_party(items)
+  round.party.load_state(st.party.to_h)
+  eq 1, round.party.item_usage[4], 'the tally rides along with the bag'
+  2.times { round.party.use_switch_item(4) }
+  eq 0, round.party.item_count(4),
+     'so two more uses finish the copy -- Continue does not refill it'
+
+  # A save written before 使用回数 was modelled has no tally at all; every held
+  # item simply starts its uses over.
+  legacy = st.party.to_h
+  legacy.delete(:item_usage)
+  old = item_party(items)
+  old.party.load_state(legacy)
+  eq 0, old.party.item_usage[4] || 0, 'an older save reads as "nothing spent"'
+end
+
+check 'to_lsd/from_lsd round-trips the 使用回数 tally (chunk 109 field 14)' do
+  # `item_usage` runs parallel to the id/count arrays in a genuine save, so a
+  # potion RPG_RT had already used twice resumes with its remaining uses.
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
+                                     atk: 10, def: 8) }
+  items = { 4 => fake_item(type: 10, switch_id: 7, uses: 3),
+            5 => fake_item(type: 6, rhp: 50) }
+  db = FakeActorDB.new(players, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  st.party.gain_item(4, 1)
+  st.party.gain_item(5, 2)
+  st.party.use_switch_item(4)
+
+  inv = st.to_lsd[109]
+  eq [4, 5], inv.item_ids
+  eq [1, 0], inv.item_usage, 'the array is written for every id, zeros included'
+
+  round = Game::State.from_lsd(db, st.to_lsd)
+  eq 1, round.party.item_usage[4], 'the part-used item comes back part-used'
+  eq 0, round.party.item_usage[5] || 0, 'an untouched one carries no tally'
+  eq 1, round.party.item_count(4)
+end
+
 check 'field_items lists only held medicines, in id order with counts' do
   items = { 5 => fake_item(type: 6, rhp: 50),   # medicine
             7 => fake_item(type: 1, atk: 10),   # weapon -- not field-usable
@@ -5069,7 +5183,14 @@ check 'a use_skill-flagged equipment item invokes its skill directly, free ' \
   eq [hero], affected
   eq 90, hero.hp, 'the skill landed'
   eq 0, hero.mp, 'no SP was spent -- the item is the cost'
-  eq 1, st.party.item_count(4), 'one was consumed'
+  # The weapon survives its own use: RPG_RT's ConsumeItemUse returns on the five
+  # equipment types before it ever reaches 使用回数, so a 特殊効果 weapon is a
+  # reusable tool. This used to eat one copy per use (see
+  # Game::Party#consume_item_use).
+  eq 2, st.party.item_count(4), 'the weapon itself is never consumed by using it'
+  hero.change_hp(-30)
+  eq [hero], st.party.use_item(4, hero), 'so it is still there to be used again'
+  eq 2, st.party.item_count(4), 'and using it again costs nothing either'
 
   # Shield (2), armour (3), helmet (4) and accessory (5) all take the same
   # branch, not just weapons.
@@ -5117,7 +5238,9 @@ check 'a use_skill equipment item restricted by class_set is only usable by ' \
   eq [], st.party.use_item(4, warrior), "class 1 isn't in class_set"
   eq 2, st.party.item_count(4), 'nothing consumed'
   eq [mage], st.party.use_item(4, mage), 'class 2 is listed'
-  eq 1, st.party.item_count(4), 'one was consumed'
+  # Equipment is never consumed by being used this way, whatever its class_set
+  # says -- see the use_skill check above and Game::Party#consume_item_use.
+  eq 2, st.party.item_count(4), 'and the rune itself is not consumed'
 end
 
 check 'a special item invoking an Escape skill is hidden with no runtime ' \

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -8322,6 +8322,10 @@ class BattleMagicParty
   def item_count(id); @items[id] || 0; end
   def gain_item(id, n = 1); @items[id] = item_count(id) + n; end
   def lose_item(id, n = 1); @items[id] = [item_count(id) - n, 0].max; end
+  # The battle scene spends a *use* rather than a copy (Game::Party#
+  # consume_item_use, whose 使用回数 arithmetic rpg2k_logic_check covers); this
+  # stub's potion is an ordinary single-use one, so a use costs a copy.
+  def consume_item_use(id); lose_item(id, 1); end
 
   # Battle sub-menu hooks the scene calls (Game::Party provides these for real):
   def battle_skills(actor, _caster); actor.skills.include?(1) ? [[1, 3]] : []; end

--- a/scripts/rpg2k_testbed_logic_check.rb
+++ b/scripts/rpg2k_testbed_logic_check.rb
@@ -382,6 +382,34 @@ def check_menus(dir)
       ok party.switch_item?(id), "switch item ##{id} is recognised as one"
     end
   end
+
+  # 使用回数 (item field 6) read off real rows: 0 is 無制限 (never consumed) and
+  # anything above 1 makes one copy worth several uses, which this runtime used
+  # to ignore entirely -- every item vanished on its first use. A switch item is
+  # the self-contained probe: using one needs no target and always does
+  # something, so every call reaches Game::Party#consume_item_use. Each gets a
+  # party of its own so the shared one above keeps its full bag.
+  multi = switch.select { |id| (party.db_item(id).uses || 1) != 1 }
+  return if multi.empty?
+  puts "   #{multi.size} switch item(s) with a non-default 使用回数"
+
+  check "#{name}: a switch item's 使用回数 decides when a copy is spent" do
+    multi.each do |id|
+      p2 = Game::Party.new(db, db[DB_SYSTEM] ? db[DB_SYSTEM][SYS_PARTY] : nil)
+      uses = p2.db_item(id).uses
+      p2.gain_item(id, 1)
+      if uses == 0
+        5.times { ok p2.use_switch_item(id), "item ##{id} (無制限) still flips its switch" }
+        eq 1, p2.item_count(id), "item ##{id} (無制限) is never consumed"
+      else
+        (uses - 1).times { p2.use_switch_item(id) }
+        eq 1, p2.item_count(id),
+           "item ##{id} survives its first #{uses - 1} use(s) of #{uses}"
+        p2.use_switch_item(id)
+        eq 0, p2.item_count(id), "and is spent by use #{uses}"
+      end
+    end
+  end
 end
 
 # The status effects a real game's 状態 table asks for, exercised against that


### PR DESCRIPTION
## Summary
Implements proper handling of the item `uses` field (item field 6, 使用回数), which specifies how many times a single copy of an item can be used before it is consumed. Previously, every item was destroyed on its first use regardless of this field.

## Key Changes

- **Added `Party#item_usage` tracking**: A new hash that tracks how many uses have been spent on the current copy of each item (id → uses spent). This is separate from the item count and persists across Save/Continue.

- **Introduced `Party#consume_item_use(id)` method**: A single consumption point that replaces all direct `lose_item(id, 1)` calls. It implements three rules from RPG_RT/EasyRPG:
  - **Type gate**: Normal items (type 0) and all five equipment types are never consumed by use
  - **Unlimited uses**: Items with `uses == 0` are never consumed
  - **Partial consumption**: Other items increment the usage tally and only remove a copy when the tally reaches the `uses` value, then reset the tally

- **Updated all consumption sites** to call `consume_item_use` instead of `lose_item`:
  - Field menu item usage (`use_item`, `use_medicine`, `use_skill_book`, `use_seed`, `use_special_item`, `use_equip_skill_item`, `use_switch_item`)
  - Special items (`use_special_escape_item`, `use_special_teleport_item`)
  - Battle screen Item action (`Scene::Map#drive_battle_animate`)

- **Modified `Party#gain_item`**: Implements the asymmetric reset rule—losing a copy resets the usage tally (so the next copy starts fresh), but gaining one never touches the tally. This means selling a half-used item and buying it back refills its uses.

- **Save/Continue persistence**:
  - `Party#to_h` / `#load_state`: Includes `item_usage` in serialization; older saves without this field default to empty (nothing spent)
  - `State#to_lsd` / `.from_lsd`: Writes/reads chunk 109 field 14 (`item_usage` array) parallel to item ids/counts, matching the genuine save format

- **Added `ITEM_NORMAL` constant** (type 0) for clarity in type-gating logic

- **Comprehensive test coverage**: Six new checks in `rpg2k_logic_check.rb` covering N-uses-per-copy, unlimited uses, schema defaults, gain/lose asymmetry, and Save/Continue round-trips; plus a data-driven check in `rpg2k_testbed_logic_check.rb` for real switch items with non-default use counts.

## Notable Implementation Details

- The usage tally is per item id, not per copy, matching the save format structure
- Equipment items with `use_skill` (special effect weapons) are now properly reusable tools rather than one-shot consumables
- The implementation mirrors EasyRPG's `Game_Party::ConsumeItemUse` and `AddItem` behavior exactly

https://claude.ai/code/session_01Q5F8MaGatimczdGqFJkhLi