### PR TITLE
Hide map layers during battle to show backdrop correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@
   invented English string. And a battle page's **Change Monster Condition** now
   redraws the panel: it writes straight to the live combatant, so nothing had
   told the screen it was out of date
+- The **battle background is on screen**, not merely resolved. Which
+  `Backdrop/<name>` a fight uses already came from the game's own data (the map
+  tree's `backdrop_type` walked for inheritance, falling back to the terrain
+  the encounter started on), but the map kept drawing over it: RPG_RT swaps
+  `Scene_Map` out for `Scene_Battle`, while this port runs the fight inline on
+  the map scene, whose tile layers sit above the backdrop and are opaque. The
+  map view is hidden — and stops compositing — for the fight's duration, and is
+  back the frame it ends
 - The **field windows show a condition too** — the menu party list, the item and
   skill target lists, and the status screen, which are the three RPG_RT draws one
   in. The target lists are the point: they are where you pick who to use an

--- a/changelog.d/rpg2k-battle-background-over-map.fixed.md
+++ b/changelog.d/rpg2k-battle-background-over-map.fixed.md
@@ -1,0 +1,22 @@
+- **The battle background is actually visible now.** RPG2000's battle backdrop
+  was resolved from the game's own data correctly (`Game::Backdrop`'s map-tree
+  walk over `backdrop_type`, falling back to the terrain the encounter started
+  on) and then drawn *behind the map*: RPG_RT replaces `Scene_Map` with
+  `Scene_Battle` outright, but this port runs the fight inline on `Scene::Map`,
+  whose `#render` kept compositing the tile layers, the parallax, the hero and
+  the events every frame — and the backdrop sprite's z 5 (EasyRPG Player's own
+  `Priority_Background`, correct there precisely because no map is ever drawn
+  beside it) is outranked by both `@map_viewport` (z 100) and `@upper_viewport`
+  (z 200), whose lower tile layer is opaque. Every fight was therefore fought
+  over whatever chip layer the party happened to be standing on, with the
+  chosen `Backdrop/<name>` image completely hidden. Both viewports are hidden
+  for the fight's whole duration now (`Scene::Map#set_map_layers_visible`) and
+  the tile / parallax / character compositing is skipped outright rather than left
+  running under a hidden layer — the same treatment `#render` already gives the
+  picture layer — then both un-hide and redraw on the first frame after the
+  battle UI clears. The in-battle Show Battle Animation is deliberately not
+  gated: it renders through a top-level sprite (z 150, above the battlers), not
+  through the map viewports. Covered by a new check in
+  `scripts/rpg2k_scene_check.rb` (the map draws normally before the fight, is
+  hidden and stops compositing the instant the battle screen is up, and is back
+  the instant the fight ends), confirmed to fail against the pre-fix code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1497,6 +1497,27 @@ The work below is roughly ordered by the critical path to a walkable game
   Nepheshel never takes since it names no terrain backdrops at all. The walk is
   bounded and cycle-safe, so a tree that loops ends at the terrain instead of
   hanging the battle.
+  **And it is on screen now**, which for a while it was not: the name resolved
+  correctly and the sprite was built, but it drew *behind the map*. RPG_RT
+  replaces `Scene_Map` with `Scene_Battle` outright, so nothing of the map is on
+  screen during a fight and the backdrop is the whole background; this port runs
+  the fight inline on `Scene::Map` instead, and `#render` kept compositing the
+  tile layers, parallax, hero, events and vehicles every frame — over the
+  backdrop, since its z 5 (EasyRPG Player's own `Priority_Background`,
+  `src/drawable.h`, correct there precisely *because* no map is drawn beside it)
+  is outranked by both `@map_viewport` (z 100) and `@upper_viewport` (z 200),
+  and the lower tile layer is opaque. Every fight was fought over whatever chip
+  layer the party stood on. `Scene::Map#set_map_layers_visible` hides both
+  viewports for the fight's duration and `#render` skips the map compositing
+  outright rather than leaving a hidden layer redrawing under the battle — the
+  same treatment the picture layer already gets (see the **Picture** bullet
+  below) — with both back on the first frame after `@battle_ui` clears. The
+  in-battle Show Battle Animation is deliberately *not* gated with them: it
+  renders through `@animation_sprite`, a top-level sprite at z 150 (above the
+  battlers, below the pictures), not through either map viewport. Still open,
+  and a separate question: Change Screen Tone rides on `@map_viewport`'s tone,
+  so it reaches the map and not the backdrop — whether RPG_RT tints the battle
+  background needs a wine diff before anything is changed.
   **Enemies now run their 行動パターン** (action pattern, enemy chunk 42) rather
   than only ever attacking — the single biggest silent gap left in the battle
   system, since **510 of the 959 enemy actions across the two test beds are

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4766,6 +4766,35 @@ class RPG2k
         ''
       end
 
+      # Show or hide the whole map view -- both tile layers, the parallax, the
+      # hero, the events and the vehicles, all of which live inside
+      # @map_viewport (z 100) or @upper_viewport (z 200).
+      #
+      # RPG2000's battle screen is a scene of its own in RPG_RT: `Scene_Battle`
+      # replaces `Scene_Map` outright, so no part of the map is on screen while
+      # a fight runs, and the chosen Backdrop/<name> image is all there is
+      # behind the troop. This port instead runs the fight inline on Scene::Map
+      # (gated on @battle_ui), and #render kept compositing the map every frame
+      # underneath it -- which put the map *over* the battle background, since
+      # the backdrop sprite's z 5 (EasyRPG Player's own `Priority_Background`,
+      # `src/drawable.h`, correct there precisely because no map is ever drawn
+      # beside it) is outranked by both map viewports, and the lower tile layer
+      # is opaque. The backdrop was resolved correctly (`Game::Backdrop`, the
+      # map-tree walk) and then drawn entirely behind the map graphics: every
+      # fight was fought over whatever chip layer the party happened to be
+      # standing on.
+      #
+      # Hidden for the fight's whole duration, and #render skips the tile /
+      # parallax / character compositing outright rather than leaving a stale
+      # frame hidden underneath -- the same treatment the picture layer already
+      # gets there. Both un-hide and redraw on the first frame after @battle_ui
+      # clears; the hero frame's own @last_frame cache is untouched by the
+      # skipped frames, so an unchanged pose is not needlessly rebuilt then.
+      def set_map_layers_visible(visible)
+        @map_viewport.visible = visible if @map_viewport
+        @upper_viewport.visible = visible if @upper_viewport
+      end
+
       def build_battle_back(name = nil)
         bmp = battle_back_bitmap(name)
         spr = Sprite.new
@@ -9139,17 +9168,29 @@ class RPG2k
         px, py = player_pixel
         cam_x, cam_y = camera_position
 
-        draw_parallax cam_x, cam_y
-        draw_layers cam_x, cam_y
+        # The map itself never shows on the battle screen -- see
+        # #set_map_layers_visible, which explains why the backdrop needs it gone
+        # rather than merely sitting above it.
+        if @battle_ui
+          set_map_layers_visible false
+        else
+          set_map_layers_visible true
+          draw_parallax cam_x, cam_y
+          draw_layers cam_x, cam_y
 
-        @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
-        @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE) -
-                           player_jump_offset
-        # Reflect the Set Transparent Flag command (and any leader graphic flag)
-        # every frame so the hero hides/shows as events toggle it.
-        @player_sprite.visible = !player_hidden?
-        draw_player_frame
-        draw_vehicles cam_x, cam_y, px, py
+          @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
+          @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE) -
+                             player_jump_offset
+          # Reflect the Set Transparent Flag command (and any leader graphic flag)
+          # every frame so the hero hides/shows as events toggle it.
+          @player_sprite.visible = !player_hidden?
+          draw_player_frame
+          draw_vehicles cam_x, cam_y, px, py
+        end
+        # Not gated: @animation_sprite is a top-level sprite (z 150, above the
+        # battlers) and #draw_map_animation drives the in-battle Show Battle
+        # Animation through the very same path as the map one -- see its own
+        # `ma[:battle]` branch.
         draw_map_animation cam_x, cam_y
 
         # Pictures never show on the battle screen (yado.tk / 01_shoshin's

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -10170,6 +10170,54 @@ check 'pictures are hidden while the battle screen is up (yado.tk: none show on 
   ok sprite.visible, 'the picture layer reappears the instant the fight ends'
 end
 
+# RPG_RT's Scene_Battle replaces Scene_Map outright, so the map is not on
+# screen during a fight at all -- the Backdrop/<name> image is the whole
+# background. This port runs the fight inline on Scene::Map, and #render used
+# to keep compositing the map every frame underneath it: the backdrop sprite's
+# z 5 (EasyRPG's Priority_Background) is outranked by @map_viewport (z 100) and
+# @upper_viewport (z 200), and the lower tile layer is opaque, so the correctly
+# resolved backdrop was drawn entirely behind the map graphics.
+check 'the map is hidden while the battle screen is up, so the backdrop actually shows' do
+  ic = Game::Interpreter::Cmd
+  pages = { 1 => troop_page([ECmd.new(ic::TERMINATE_BATTLE, [])]) }
+  scene, _st = battle_scene_with_pages(pages)
+  vp = scene.instance_variable_get(:@map_viewport)
+  upper = scene.instance_variable_get(:@upper_viewport)
+  lower_bmp = scene.instance_variable_get(:@lower_bmp)
+
+  10.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui)
+    # `!= false` rather than a plain truth test: RGSS::Viewport#visible
+    # defaults to true on the real backend but nil on this stub, so a bare
+    # `ok vp.visible` here would be asserting the stub's default, not the
+    # behaviour. The fight's own hide/show below is checked exactly instead.
+    ok vp.visible != false, 'the map view draws normally before any fight opens'
+    ok upper.visible != false, 'and so does the above-character layer'
+    ok !(lower_bmp.blt_calls || []).empty?, 'and the tile layers do composite'
+  end
+  ui = scene.instance_variable_get(:@battle_ui)
+  ok ui, 'the battle opened'
+  ok ui[:back_sprite], 'the fight has a battle background sprite'
+  ok ui[:back_sprite].z < vp.z, 'whose z sits below the map viewport ...'
+  ok ui[:back_sprite].z < upper.z, '... and below the upper-layer viewport'
+  eq false, vp.visible, 'so the map view is hidden the instant the battle screen is up'
+  eq false, upper.visible, 'and so is the above-character layer'
+  lower_bmp.clear_blt_calls
+  scene.update
+  eq 0, (lower_bmp.blt_calls || []).size,
+     'and the tile layers stop compositing entirely while the fight runs'
+
+  20.times do
+    scene.update
+    break if scene.instance_variable_get(:@battle_ui).nil?
+  end
+  eq nil, scene.instance_variable_get(:@battle_ui), 'the battle closed again'
+  eq true, vp.visible, 'the map view reappears the instant the fight ends'
+  eq true, upper.visible, 'and so does the above-character layer'
+  ok !(lower_bmp.blt_calls || []).empty?, 'and the tile layers composite again'
+end
+
 # yado.tk: a Battle Interrupt (Terminate Battle, 13410) satisfies neither the
 # enclosing Enemy Encounter's [Victory] nor [Escape]/[Defeat] handler branch --
 # it resumes right after Branch End, an unlabeled third outcome -- and only


### PR DESCRIPTION
## Summary
The battle background (backdrop) was being drawn behind the map graphics instead of being visible as the battle screen background. This fix hides the map viewport layers during battle so the backdrop is properly displayed.

## Problem
RPG2000's `Scene_Battle` replaces `Scene_Map` entirely, so the map is never visible during a fight. This port runs battles inline on `Scene::Map`, which kept compositing the tile layers, parallax, hero, and events every frame during battle. Since the backdrop sprite has z-order 5 and the map viewports have z-orders 100 and 200, the map graphics rendered on top of the backdrop, making it invisible.

## Solution
- Added `Scene::Map#set_map_layers_visible(visible)` method to control visibility of `@map_viewport` and `@upper_viewport`
- Modified `Scene::Map#render` to hide both viewports when `@battle_ui` is active and skip all map compositing (parallax, tile layers, player sprite, vehicles)
- The in-battle Show Battle Animation is deliberately not gated since it uses a separate top-level sprite at z 150
- Both viewports are shown again and map compositing resumes on the first frame after battle ends

## Changes
- **mruby-rpg2k/mrblib/scene/map.rb**: Added `set_map_layers_visible` method and conditional rendering logic in `render` method
- **scripts/rpg2k_scene_check.rb**: Added comprehensive test verifying map visibility before/during/after battle and that tile compositing is skipped during battle
- **changelog.d/rpg2k-battle-background-over-map.fixed.md**: New changelog entry documenting the fix
- **docs/TODO.md** and **README.md**: Updated documentation reflecting the fix

## Implementation Details
- The fix uses the existing `@battle_ui` flag to determine when to hide the map layers
- Skips compositing entirely rather than rendering hidden, matching the existing treatment of the picture layer
- The hero frame's `@last_frame` cache is untouched by skipped frames, so unchanged poses aren't needlessly rebuilt when rendering resumes

https://claude.ai/code/session_01SCHeCUqzH5R7XUG2ocwuxF