### PR TITLE
Name the window after the running game

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ add_executable(
   src/voicevox_tts.cxx
   src/log_console.cxx
   src/log_bridge.cxx
+  src/window_title.cxx
   src/error_dump.cxx)
 target_link_libraries(
   ${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -420,6 +420,23 @@
   animation's sheet away, which the log reports as `played=true` because the
   cell sprite is there, holding a placeholder bitmap
 
+### Window title
+- The window is named after the game that is running, so the desktop (and the
+  browser tab, in the WebAssembly build) says which project is loaded. Each
+  maker's boot reads it from where that maker keeps it: RPG2000/2003 from
+  `RPG_RT.ini`'s `GameTitle` (decoded from CP932, like the rest of a 2000/2003
+  project), XP from `Game.ini`'s `Title`, VX / VX Ace from the database's
+  `System#game_title`, and MV / MZ from their own `Scene_Boot`, which assigns
+  `$dataSystem.gameTitle` to `document.title`
+- A project with no title of its own is named after the folder it was loaded
+  from; before any game is loaded — and for a boot that never gets far enough to
+  read one — the window says **RPG Maker Clone**
+- A running game can rename the window: `RGSS.window_title = "..."` from Ruby,
+  or (for the JavaScript makers) any `document.title` assignment, the way an MV
+  plugin retitles the page. The terminal backends below have no window to name,
+  so there the title is simply recorded and readable back through
+  `RGSS.window_title`
+
 ### Terminal gaming
 - Render the game to a terminal instead of an SDL window, using either the DEC
   **sixel** protocol or **iTerm2's inline-image** protocol

--- a/changelog.d/window-title-from-game.added.md
+++ b/changelog.d/window-title-from-game.added.md
@@ -1,0 +1,17 @@
+- **The window is named after the game that is running.** It used to open as
+  LVGL's own "LVGL Simulator" and stay that way, so nothing on screen said which
+  project was loaded — and a browser tab said even less. Every maker's boot now
+  sets the title from where that maker keeps it: RPG2000/2003 from `RPG_RT.ini`'s
+  `GameTitle` (decoded from CP932, as the rest of a 2000/2003 project is), XP
+  from `Game.ini`'s `Title`, VX / VX Ace from the database's `System#game_title`,
+  and MV / MZ from their own `Scene_Boot`, whose `document.title` assignment now
+  reaches the window instead of a stub that dropped it. A project with no title
+  of its own falls back to its folder name, and before any game is loaded the
+  window says "RPG Maker Clone". Under Emscripten the same call names the
+  browser tab; the terminal backends (`--sixel` / `--iterm`) have no window to
+  name and are unaffected.
+- `RGSS.window_title` is the runtime's own half of it (`RGSS.window_title = ...`
+  from Ruby, `window_title_set` natively — see `include/terminal.hxx`), so a
+  game can rename the window while it runs, the way an MV plugin retitles the
+  page. Covered by new checks in `mruby-rgss/test/test.rb`,
+  `scripts/rpg2k_scene_check.rb` and `scripts/rpgvx_testbed_check.rb`.

--- a/include/terminal.hxx
+++ b/include/terminal.hxx
@@ -142,3 +142,39 @@ void log_bridge_write(const char* msg, size_t len);
 // forwards it through log_bridge_write.  `msg` must be NUL-terminated and
 // have no trailing newline; one is added to the stderr copy.
 void log_bridge_write_stderr(const char* msg);
+
+// ---------------------------------------------------------------------------
+// Window title bridge
+// ---------------------------------------------------------------------------
+// Carries the running game's own title -- RPG_RT.ini's GameTitle, Game.ini's
+// Title, VX's System#game_title, MV/MZ's $dataSystem.gameTitle -- from the
+// runtime that loaded it to whatever is showing the game, so the desktop
+// window (and the browser tab, where SDL maps the same call onto
+// document.title) says which game is running rather than the executable's
+// name.
+//
+// Split the same way as the stderr log bridge above and for the same reason:
+// each maker's boot sets it from Ruby through RGSS.window_title=, which reaches
+// window_title_set (mruby-rgss/src/window_title.cxx), and that only calls an
+// optional hook the executable installs at start-up with
+// window_title_set_hook.  The gem therefore needs no SDL -- it is also built
+// for the terminal-only, PSP and Wio Terminal targets, none of which compile
+// LVGL's SDL driver at all.  Where no hook is installed -- the terminal
+// backends, mrbtest, PSP, Wio -- setting a title is a no-op that only records
+// the last value for window_title_get.
+
+using window_title_hook_fn = void (*)(const char* title);
+
+// Install (or clear, with nullptr) the hook every title set reaches.  Called
+// once at start-up, before the mruby interpreter runs any Ruby code; not
+// synchronized against later writers.
+void window_title_set_hook(window_title_hook_fn hook);
+
+// Hand `title` (NUL-terminated, UTF-8) to the installed hook, if any, and
+// remember it.  Safe to call unconditionally.
+void window_title_set(const char* title);
+
+// The last title passed to window_title_set, or an empty string when none was.
+// Exposed to Ruby as RGSS.window_title so a boot can be asserted without a
+// window to read the title back off.
+const std::string& window_title_get();

--- a/include/window_title.hxx
+++ b/include/window_title.hxx
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "terminal.hxx"
+
+// Install the hook (see terminal.hxx's "Window title bridge" section) that
+// puts whatever title the running game sets on the SDL window `display` owns
+// -- under Emscripten SDL maps the same call onto the page's document.title,
+// so the browser tab is named too.  Call this once, right after the display is
+// created and before the mruby interpreter runs any Ruby code.  Only for the
+// SDL window backend: the terminal backends (--sixel / --iterm) drive an LVGL
+// display with no SDL window behind it, so they install nothing and the title a
+// game sets is simply recorded.  Lives in the executable rather than the
+// mruby-rgss gem so the gem keeps no compile-time dependency on SDL, the same
+// way the log bridge keeps it free of ng-log.
+void window_title_install(lv_display_t* display);

--- a/mruby-mvjs/src/mvcanvas.cxx
+++ b/mruby-mvjs/src/mvcanvas.cxx
@@ -1023,6 +1023,26 @@ JSValue js_put_data(JSContext* ctx,
   return JS_UNDEFINED;
 }
 
+// __mv_setWindowTitle(title) -- what `document.title = ...` reaches (see the
+// accessor installed in the preamble below). In a browser that names the tab;
+// here it names the SDL window, through the same bridge every other maker's
+// boot uses (include/terminal.hxx's "Window title bridge"). MV's and MZ's own
+// Scene_Boot assigns $dataSystem.gameTitle to document.title, so a game — and
+// any plugin that retitles the page — names the window itself.
+JSValue js_set_window_title(JSContext* ctx,
+                            JSValueConst,
+                            int argc,
+                            JSValueConst* argv) {
+  if (argc < 1)
+    return JS_UNDEFINED;
+  const char* title = JS_ToCString(ctx, argv[0]);
+  if (!title)
+    return JS_UNDEFINED;
+  window_title_set(title);
+  JS_FreeCString(ctx, title);
+  return JS_UNDEFINED;
+}
+
 // __mv_imageLoad(path) -> a canvas handle holding the decoded image (0 on
 // failure). MV's Bitmap loads PNGs through `new Image()`; we decode them with
 // stb_image (RGBA8) straight into a canvas so the result can be used as a
@@ -1591,6 +1611,19 @@ const char* kCanvasPreamble = R"MVJS(
     fonts: fontFaceSet,
   };
 
+  // document.title: Scene_Boot assigns $dataSystem.gameTitle to it once the
+  // database is loaded, which is how an MV/MZ game names the browser tab. Make
+  // it a real accessor so that assignment reaches the host and names the game
+  // window instead, and so a plugin reading it back gets what it wrote.
+  var docTitle = '';
+  Object.defineProperty(g.document, 'title', {
+    get: function () { return docTitle; },
+    set: function (v) {
+      docTitle = v === undefined || v === null ? '' : '' + v;
+      g.__mv_setWindowTitle(docTitle);
+    },
+  });
+
   // Image: MV's Bitmap loads PNGs with `new Image()` + `.src = url`. We decode
   // synchronously (stb_image, via __mv_imageLoad) into a canvas handle, but fire
   // onload/onerror on the next host frame (via requestAnimationFrame) to match
@@ -1748,6 +1781,7 @@ void mv_install_canvas(JSContext* ctx) {
   install(ctx, global, "__mv_canvasFillPattern", js_fill_pattern, 13);
   install(ctx, global, "__mv_canvasFillPolygon", js_fill_polygon, 8);
   install(ctx, global, "__mv_fontMeasure", js_measure_text, 2);
+  install(ctx, global, "__mv_setWindowTitle", js_set_window_title, 1);
   install(ctx, global, "__mv_imageLoad", js_image_load, 1);
   install(ctx, global, "__mv_imageLoadBytes", js_image_load_bytes, 1);
   JS_FreeValue(ctx, global);

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -86,6 +86,14 @@ void log_bridge_write(const char* msg, size_t len);
 // diagnostics below that used to be a bare fprintf(stderr, ...).
 void log_bridge_write_stderr(const char* msg);
 
+// Defined in window_title.cxx (same gem). Hands the running game's own title
+// to the executable's hook -- the SDL window's caption, or the browser tab
+// under Emscripten -- and remembers it. Beyond that record it is a no-op where
+// no hook is installed (the terminal backends, mrbtest, PSP, Wio Terminal);
+// see include/terminal.hxx's "Window title bridge" section.
+void window_title_set(const char* title);
+const std::string& window_title_get();
+
 #if defined(WIO_TERMINAL)
 // Defined in wio_input_bridge.cxx; scans the board's buttons/5-way switch and
 // forwards press/release edges to RGSS::Input.  Guarded so the desktop/wasm
@@ -6030,6 +6038,31 @@ static mrb_value log_bridge_write_m(mrb_state* M, mrb_value) {
   return mrb_nil_value();
 }
 
+// RGSS.window_title = "..." -- the running game's own title, set by each
+// maker's boot once its database says what the game is called (see
+// include/terminal.hxx's "Window title bridge" section). nil clears it back to
+// the empty string rather than raising: a project with no title of its own is
+// a normal state, not an error.
+static mrb_value window_title_set_m(mrb_state* M, mrb_value) {
+  mrb_value title = mrb_nil_value();
+  mrb_get_args(M, "o", &title);
+  if (mrb_nil_p(title)) {
+    window_title_set("");
+    return mrb_nil_value();
+  }
+  const mrb_value str = mrb_obj_as_string(M, title);
+  window_title_set(mrb_str_to_cstr(M, str));
+  return title;
+}
+
+// RGSS.window_title -- the last title set, or nil when none was. Reads the
+// gem's own record rather than the window, so it answers under every backend.
+static mrb_value window_title_get_m(mrb_state* M, mrb_value) {
+  const std::string& title = window_title_get();
+  return title.empty() ? mrb_nil_value()
+                       : mrb_str_new(M, title.data(), title.size());
+}
+
 extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   RClass* m = mrb_define_module(M, "RGSS");
   mrb_define_module_function(M, m, "to_nfd", to_nfd, MRB_ARGS_REQ(1));
@@ -6043,6 +6076,10 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
                              MRB_ARGS_NONE());
   mrb_define_module_function(M, m, "__log_bridge_write", log_bridge_write_m,
                              MRB_ARGS_REQ(1));
+  mrb_define_module_function(M, m, "window_title=", window_title_set_m,
+                             MRB_ARGS_REQ(1));
+  mrb_define_module_function(M, m, "window_title", window_title_get_m,
+                             MRB_ARGS_NONE());
 
   mrb_const_set(M, mrb_obj_value(m), mrb_intern_lit(M, "_game_start"),
                 mrb_fixnum_value(lv_tick_get()));

--- a/mruby-rgss/src/window_title.cxx
+++ b/mruby-rgss/src/window_title.cxx
@@ -1,0 +1,28 @@
+// The gem's half of the window title bridge: a function pointer the executable
+// fills in and the last title set through it. See include/terminal.hxx's
+// "Window title bridge" section for why the two halves are split.
+
+#include "terminal.hxx"
+
+namespace {
+window_title_hook_fn g_hook = nullptr;
+// Kept even when no hook is installed, so RGSS.window_title reads back what the
+// game asked for under every backend (the terminal ones, mrbtest, PSP, Wio).
+std::string g_title;
+}  // namespace
+
+void window_title_set_hook(window_title_hook_fn hook) {
+  g_hook = hook;
+}
+
+void window_title_set(const char* title) {
+  if (title == nullptr)
+    title = "";
+  g_title = title;
+  if (g_hook != nullptr)
+    g_hook(g_title.c_str());
+}
+
+const std::string& window_title_get() {
+  return g_title;
+}

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -10,6 +10,25 @@ assert "RGSS.to_nfd" do
   assert_equal RGSS.to_nfd("Ŵ"), "W\u0302"
 end
 
+assert "RGSS.window_title records what a game names itself" do
+  # No window here (mrbtest installs no hook), so this asserts the record every
+  # backend keeps -- what the SDL window would have been titled with.
+  RGSS.window_title = "ゆめにっき"
+  assert_equal "ゆめにっき", RGSS.window_title
+
+  # Anything else is stringised, the way a title read out of a database or an
+  # ini may not be a String to begin with.
+  RGSS.window_title = 2003
+  assert_equal "2003", RGSS.window_title
+
+  # A project with no title of its own clears it back to "no title" rather than
+  # raising or leaving the previous game's name up.
+  RGSS.window_title = nil
+  assert_nil RGSS.window_title
+  RGSS.window_title = ""
+  assert_nil RGSS.window_title
+end
+
 assert "RGSS::Color basics" do
   c = RGSS::Color.new(10, 20, 30)
   assert_equal 10.0, c.red

--- a/mruby-rpg2k/mrblib/main.rb
+++ b/mruby-rpg2k/mrblib/main.rb
@@ -506,7 +506,7 @@ class RPG2k
   # rather than repeating the literal.
   MAX_SAVE_SLOTS = 15
 
-  attr_reader :db, :map_tree, :test_play
+  attr_reader :db, :map_tree, :test_play, :title
   # Whether the title screen's background picture and command-window position
   # should follow HideTitle (see Scene::Title). Named with a `?` since it
   # answers a question, unlike the plain `test_play` value above.
@@ -542,6 +542,10 @@ class RPG2k
 
     @db = LCF::Database.new File.open "#{GAME_DIR}/RPG_RT.ldb"
     @map_tree = LCF::MapTree.new File.open "#{GAME_DIR}/RPG_RT.lmt"
+    # Put the game's own name on the window (and on the browser tab in the web
+    # build), the way RPG_RT.exe titles its own.
+    @title = read_ini_title
+    RGSS.window_title = @title
     @scenes = []
     push Scene::Title.new self
   end
@@ -553,6 +557,53 @@ class RPG2k
     false
   end
   private :native_test_play?
+
+  # The game's name, from RPG_RT.ini's `[RPG_RT] GameTitle=` -- where RPG_RT.exe
+  # reads the caption of its own window from; the .ldb carries no title of its
+  # own. The value is written in the editor's own encoding (CP932, the same
+  # encoding every string in the database is read back as), so it goes through
+  # the same conversion those do; an ASCII title passes through unchanged.
+  # Parsed with core string operations only -- this mruby build bundles neither
+  # a regexp engine nor String#strip -- and best effort throughout: a missing or
+  # garbled ini falls back to the folder name rather than stopping the boot.
+  INI_TITLE_KEY = 'GameTitle='.freeze
+
+  def read_ini_title
+    path = "#{GAME_DIR}/RPG_RT.ini"
+    return default_title unless File.exist? path
+    File.open(path, 'r') do |f|
+      f.each_line do |line|
+        next unless line.size >= INI_TITLE_KEY.size &&
+                    line[0, INI_TITLE_KEY.size] == INI_TITLE_KEY
+        value = trim_ini_value line[INI_TITLE_KEY.size, line.size]
+        return LCF.cp932_to_utf8(value) unless value.empty?
+      end
+    end
+    default_title
+  rescue StandardError => e
+    $stderr.puts "[RPG2k] RPG_RT.ini read failed: #{e.message}"
+    default_title
+  end
+  private :read_ini_title
+
+  # Strip trailing CR/LF/space/tab from an ini value without String#strip.
+  def trim_ini_value s
+    e = s.size
+    while e > 0
+      c = s[e - 1]
+      break unless c == "\r" || c == "\n" || c == ' ' || c == "\t"
+      e -= 1
+    end
+    s[0, e]
+  end
+  private :trim_ini_value
+
+  def default_title
+    File.basename GAME_DIR
+  rescue StandardError
+    'RPG Maker 2000'
+  end
+  private :default_title
 
   # Push `scene` on top of the stack. The scene it covers gets a #suspend
   # call first (Scene::Menu uses it to hide its own command/status windows --

--- a/mruby-rpgvx/mrblib/lib.rb
+++ b/mruby-rpgvx/mrblib/lib.rb
@@ -116,6 +116,9 @@ class RPGVX
     # own scripts, so the loaders need it globally (see RGSS.asset_archive).
     RGSS.asset_archive = @db.archive if @db
     @title = read_title
+    # Say which game is running on the window itself (and on the browser tab in
+    # the web build), the way RPG Maker VX's own player does.
+    RGSS.window_title = @title
     # A VX/VX Ace project's engine *is* its script bundle, so the script host is
     # the only path that can run one — and it is on by default, like XP's. The
     # pending-runtime notice below is what a project without scripts (or a boot

--- a/mruby-rpgxp/mrblib/lib.rb
+++ b/mruby-rpgxp/mrblib/lib.rb
@@ -43,6 +43,9 @@ class RPGXP
 
   def initialize(_args)
     @title = read_ini_title
+    # Name the window after the game, as RGSS104E.dll does with the same
+    # Game.ini value (and the browser tab, in the web build).
+    RGSS.window_title = @title
     # XP selects its UI font by family name (Font.default_name, "MS PGothic" on
     # Windows) and expects the file under the project's Fonts/. Projects that
     # ship none would render every window with the 12px shinonome bitmap font

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -16,6 +16,7 @@
 
 require 'ostruct'
 require 'stringio'
+require 'tmpdir'
 
 # -- RGSS stubs (just enough for Scene::Map to build, render and tick) --------
 
@@ -14339,6 +14340,68 @@ check 'Nepheshel-shaped Save choice event: a Show Choices "SAVE" branch reaches 
   scene.update # dispatches the wait and opens the picker
   eq 1, parent.pushed.size, 'the SAVE branch reaches Open Save Menu, which opens the picker'
   ok parent.pushed.first.is_a?(RPG2k::Scene::SaveLoad), 'the pushed scene is the picker'
+end
+
+# -- window title -------------------------------------------------------------
+
+# RPG2k#read_ini_title reads the caption RPG_RT.exe puts on its own window out
+# of RPG_RT.ini, which the boot hands to RGSS.window_title (mruby-rpg2k/mrblib/
+# main.rb; include/terminal.hxx's window title bridge). The rest of the boot
+# needs a real .ldb/.lmt, so the reader is exercised on its own here, against
+# real ini files on disk -- including a CP932 one, since that is what the
+# Japanese editor writes and what every game in the test beds ships.
+check 'the window title comes from RPG_RT.ini, decoded from CP932' do
+  # The engine decodes the ini through LCF.cp932_to_utf8 (native; mruby-lcf/
+  # src/lcf.cxx). Stand in for it with CRuby's own encoding conversion, so this
+  # asserts the reader's parsing and hand-off, not the table.
+  unless Object.const_defined?(:LCF) && LCF.respond_to?(:cp932_to_utf8)
+    mod = Object.const_defined?(:LCF) ? LCF : Object.const_set(:LCF, Module.new)
+    mod.define_singleton_method(:cp932_to_utf8) do |s|
+      s.dup.force_encoding(Encoding::CP932).encode(Encoding::UTF_8)
+    end
+  end
+
+  read_title = lambda do |dir|
+    Object.send(:remove_const, :GAME_DIR) if Object.const_defined?(:GAME_DIR)
+    Object.const_set(:GAME_DIR, dir)
+    RPG2k.allocate.send(:read_ini_title)
+  end
+
+  Dir.mktmpdir('rpg2k-title') do |root|
+    # A Japanese title as the editor writes it: CP932 bytes, CRLF line ends,
+    # and GameTitle sitting among the other [RPG_RT] keys.
+    jp = File.join(root, 'jp')
+    Dir.mkdir jp
+    File.binwrite(File.join(jp, 'RPG_RT.ini'),
+                  "[RPG_RT]\r\nGameTitle=#{'ネフェシエル'.encode(Encoding::CP932)}\r\n" \
+                  "MapEditMode=1\r\nFullPackageFlag=1\r\n")
+    eq 'ネフェシエル', read_title.call(jp), 'the CP932 title, decoded and stripped of its CR'
+
+    # An ASCII title passes through the same conversion unchanged.
+    ascii = File.join(root, 'ascii')
+    Dir.mkdir ascii
+    File.binwrite(File.join(ascii, 'RPG_RT.ini'), "[RPG_RT]\nGameTitle=Meido Action\n")
+    eq 'Meido Action', read_title.call(ascii), 'an ASCII title'
+
+    # A project whose ini has no GameTitle (or no ini at all -- a game unpacked
+    # without it) still names the window something: the folder it was loaded
+    # from, never a blank caption.
+    bare = File.join(root, 'Bare Project')
+    Dir.mkdir bare
+    File.binwrite(File.join(bare, 'RPG_RT.ini'), "[RPG_RT]\nFullPackageFlag=0\n")
+    eq 'Bare Project', read_title.call(bare), 'the folder name when GameTitle is missing'
+
+    none = File.join(root, 'No Ini')
+    Dir.mkdir none
+    eq 'No Ini', read_title.call(none), 'the folder name when there is no ini at all'
+
+    # An empty GameTitle= is the same as none: fall back rather than clearing
+    # the caption to nothing.
+    empty = File.join(root, 'Empty Title')
+    Dir.mkdir empty
+    File.binwrite(File.join(empty, 'RPG_RT.ini'), "[RPG_RT]\nGameTitle=\r\n")
+    eq 'Empty Title', read_title.call(empty), 'the folder name when GameTitle is empty'
+  end
 end
 
 # -- summary ------------------------------------------------------------------

--- a/scripts/rpgvx_testbed_check.rb
+++ b/scripts/rpgvx_testbed_check.rb
@@ -125,6 +125,10 @@ module RGSS
   # only has to exist so the boot shell's registration can be asserted.
   class << self
     attr_accessor :asset_archive
+    # The window caption is native too (mruby-rgss/src/window_title.cxx puts it
+    # on the SDL window). Here it only has to be settable and readable back, so
+    # the boot's "name the window after the game" step can be asserted.
+    attr_accessor :window_title
   end
 
   # The default UI font is native too: mruby-rgss/src/default_font.cxx locates
@@ -1172,6 +1176,7 @@ class Checker
     # the shell must load the database, report the pending built-in flow and
     # return — not run anything, and not hang.
     ENV["RGSS_SCRIPT_HOST"] = "0"
+    RGSS.window_title = nil
     with_game_dir(dir) do
       game = RPGVX.new([])
       expect(game.db.is_a?(RPGVX::RGSSData), "boot: no database without the script host")
@@ -1190,6 +1195,11 @@ class Checker
              "boot: shell title #{game.title.inspect}, expected #{title.inspect}")
       game.start
     end
+    # The window is named after the loaded game, not left as the engine's own
+    # caption (mruby-rpgvx/mrblib/lib.rb, include/terminal.hxx's window title
+    # bridge).
+    expect(RGSS.window_title == title,
+           "boot: window title #{RGSS.window_title.inspect}, expected #{title.inspect}")
     expect($rgss_sample_booted == true, "boot: the bundled Main section did not run")
     expect($rgss_sample_title == title,
            "boot: Kernel#load_data returned #{$rgss_sample_title.inspect} " \

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -27,6 +27,7 @@
 #include "profiler.hxx"
 #include "sixel.hxx"
 #include "terminal.hxx"
+#include "window_title.hxx"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -1150,6 +1151,10 @@ int main(int argc, char** argv) {
     // A 640x480 (XP) canvas is already large, so present it 1:1; the smaller
     // 320x240 (RPG2000/MV) canvas is doubled to a comfortable window size.
     lv_sdl_window_set_zoom(display.get(), FLAGS_width >= 640 ? 1.f : 2.f);
+    // Name the window: this one titles it for the run, and every maker's boot
+    // replaces that with the loaded game's own title through
+    // RGSS.window_title= (see include/terminal.hxx's "Window title bridge").
+    window_title_install(display.get());
     // SDL is initialised by lv_sdl_window_create above; install the keyboard
     // watch now so key events reach RGSS::Input.
     rgss_sdl_input_init();

--- a/src/window_title.cxx
+++ b/src/window_title.cxx
@@ -1,0 +1,35 @@
+#include "window_title.hxx"
+
+#include <lvgl.h>
+#include <ng-log/logging.h>
+
+namespace {
+
+// The display the hook below retitles. Captured by window_title_install; the
+// SDL window backend creates exactly one display and it outlives the run, so a
+// file-scope pointer is enough (the hook has no argument to carry it in).
+lv_display_t* g_display = nullptr;
+
+// What the window is called before a game says otherwise, and again if one sets
+// an empty title. LVGL's own default is "LVGL Simulator", which says nothing
+// about what is running.
+constexpr const char* kDefaultTitle = "RPG Maker Clone";
+
+void set_sdl_window_title(const char* title) {
+  if (g_display == nullptr)
+    return;
+  const bool named = title != nullptr && *title != '\0';
+  lv_sdl_window_set_title(g_display, named ? title : kDefaultTitle);
+  if (named)
+    LOG(INFO) << "Window title: " << title;
+}
+
+}  // namespace
+
+void window_title_install(lv_display_t* display) {
+  g_display = display;
+  window_title_set_hook(&set_sdl_window_title);
+  // Name the window before any game is loaded, so a boot that never gets far
+  // enough to read a title (or a project with none) is still identifiable.
+  set_sdl_window_title(nullptr);
+}


### PR DESCRIPTION
The window title now reflects which game is running instead of showing the engine's default caption. Each maker's boot reads the game title from its respective source and sets it via the new `RGSS.window_title` interface.

## Summary
Implements a window title bridge that allows the running game to name the SDL window (and browser tab under Emscripten) after itself. This provides better visibility into which project is loaded, matching the behavior of the original RPG Maker executables.

## Key Changes

- **Window title bridge infrastructure** (`include/terminal.hxx`, `mruby-rgss/src/window_title.cxx`):
  - New `window_title_set_hook()` and `window_title_set()` functions for the executable to install and use a title-setting hook
  - `window_title_get()` exposes the last set title to Ruby via `RGSS.window_title`
  - Gem-side implementation records titles even when no hook is installed (terminal backends)

- **RGSS module interface** (`mruby-rgss/src/lib.cxx`):
  - `RGSS.window_title=` setter to assign a title (stringifies non-string values, treats nil/empty as "no title")
  - `RGSS.window_title` getter to read back the current title

- **RPG2000/2003 boot** (`mruby-rpg2k/mrblib/main.rb`):
  - `read_ini_title()` parses `RPG_RT.ini`'s `GameTitle` key
  - Decodes CP932-encoded titles via `LCF.cp932_to_utf8` (matching database encoding)
  - Falls back to folder name if title is missing, empty, or ini is unreadable

- **RPG Maker XP boot** (`mruby-rpgxp/mrblib/lib.rb`):
  - Sets window title from `Game.ini`'s `Title` value

- **RPG Maker VX/VX Ace boot** (`mruby-rpgvx/mrblib/lib.rb`):
  - Sets window title from database's `System#game_title`

- **MV/MZ JavaScript boot** (`mruby-mvjs/src/mvcanvas.cxx`):
  - Intercepts `document.title` assignments via property accessor
  - Routes them through `window_title_set()` to name the SDL window
  - Allows plugins to retitle the window as they would the browser tab

- **SDL window setup** (`src/main.cxx`, `src/window_title.cxx`):
  - `window_title_install()` hook installed after display creation
  - Sets default title "RPG Maker Clone" before any game loads
  - Logs title changes at INFO level

## Testing
- New comprehensive test in `scripts/rpg2k_scene_check.rb` covering CP932 decoding, ASCII titles, missing/empty titles, and fallback to folder name
- `mruby-rgss/test/test.rb` validates `RGSS.window_title` getter/setter behavior
- `scripts/rpgvx_testbed_check.rb` asserts window title is set during boot
- Terminal backends verified to record titles without a window to display them

https://claude.ai/code/session_01EN2dZxofGt3jVAbWJnjjCS