### PR TITLE
Add Ruby line coverage reporting for engine sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -819,6 +819,31 @@ jobs:
           - name: RPG2k test-bed logic check
             run: ruby scripts/rpg2k_testbed_logic_check.rb
 
+      # How much of the Ruby engine the checks above actually reach. It re-runs
+      # them (concurrently, like the group above) with CRuby's Coverage stdlib
+      # switched on and reports the line coverage of `mruby-*/mrblib` per gem
+      # and per file — see ADR 0049 and docs/coverage.md. Report-only as far as
+      # the *number* goes: it lands in the job summary and in an artifact, and
+      # no floor is enforced (`--min-line-rate` exists for when one is wanted).
+      # The step itself is not `continue-on-error`, so a reporter that breaks —
+      # or a check that fails only on this second, coverage-instrumented run —
+      # is visible rather than a quietly missing report.
+      - name: Ruby coverage report
+        run: ruby scripts/coverage_report.rb
+
+      # `always()`: the reporter writes its files before it exits non-zero on a
+      # failed check, so the report is still worth publishing on a red run.
+      - name: Upload Ruby coverage report
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ruby-coverage
+          path: |
+            coverage/lcov.info
+            coverage/coverage.json
+          if-no-files-found: warn
+
   # `/preview` command gate. Cloudflare previews are opt-in per pull request:
   # they are published when someone with write access comments `/preview` on the
   # PR, not automatically on every push to every PR. This job resolves that

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@
 /assets/voicevox/*
 !/assets/voicevox/README.md
 
+# Line-coverage reports written by scripts/coverage_report.rb (lcov.info,
+# coverage.json, and anything genhtml renders from them). Generated output, and
+# CI publishes its own copy as a build artifact.
+/coverage
+
 # Runtime save artifacts written by the MV/websave (localStorage) shim.
 /save
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,12 @@ only show up in the deployed page. When you touch a codec, reason about the
 ## Testing Standards
 
 - Unit tests are written using Google Test and executed by CTest. Use `cmake --build build -t test` to run it
+- Line coverage of the Ruby engine sources comes from the host-side checks:
+  `ruby scripts/coverage_report.rb` runs the `scripts/*_check.rb` harnesses
+  under CRuby's `Coverage` stdlib and reports `mruby-*/mrblib` per gem and per
+  file (`coverage/lcov.info`, `coverage/coverage.json`). It measures only what
+  those CRuby harnesses reach — `mruby_test` and the native smoke tests run
+  inside mruby, where there is no `Coverage` — so the total is a floor, not a
+  ceiling. When adding a check to the `ruby-checks` CI job, add it to the
+  reporter's `CHECKS` list too, or its coverage goes unmeasured. See
+  `docs/coverage.md` and ADR 0049.

--- a/README.md
+++ b/README.md
@@ -540,6 +540,35 @@
   header notes the two smaller traps as well — a genuine but narrow clang-format
   version difference, and why a line-length grep is not a substitute.
 
+### Code coverage
+
+- Nearly all of the runtime is Ruby (`mruby-*/mrblib`, ~39k lines against ~3k
+  lines of C++ glue), and the `scripts/*_check.rb` harnesses load those exact
+  sources under CRuby. `scripts/coverage_report.rb` runs the harnesses with
+  CRuby's `Coverage` stdlib switched on and reports what they reached:
+
+  ```sh
+  ruby scripts/coverage_report.rb              # -> coverage/lcov.info + .json
+  ruby scripts/coverage_report.rb --per-file   # every file, not just the tail
+  genhtml coverage/lcov.info -o coverage/html  # browsable per-line report
+  ```
+
+  ```
+  mruby-lcf      #################.......   68.8%     271 / 394
+  mruby-rpg2k    ######################..   92.9%   11305 / 12175
+  total          ###################.....   80.5%   12733 / 15810
+  ```
+
+- CI's `ruby-checks` job publishes the same table in its job summary and the
+  files as the `ruby-coverage` artifact. It is report-only; `--min-line-rate`
+  turns it into a gate when a floor is wanted.
+
+- The total is a **floor**: `mruby_test` and the native smoke tests exercise the
+  same sources inside mruby, where no `Coverage` module exists, so what only
+  they reach counts as uncovered here (which is why the RGSS and MV/MZ runtime
+  files read 0%). `docs/coverage.md` and `docs/adr/0049-ruby-line-coverage-from-the-host-side-checks.md`
+  cover the details and the trade-off.
+
 ### Play in the browser (WebAssembly)
 
 - The runtime cross-compiles to WebAssembly with Emscripten and ships a page

--- a/changelog.d/ruby-coverage-report.added.md
+++ b/changelog.d/ruby-coverage-report.added.md
@@ -1,0 +1,7 @@
+- Code coverage reporting for the Ruby engine sources. `ruby
+  scripts/coverage_report.rb` runs the host-side `scripts/*_check.rb` harnesses
+  with CRuby's `Coverage` stdlib enabled and reports line coverage of
+  `mruby-*/mrblib` per gem and per file, writing `coverage/lcov.info` (for
+  `genhtml` or a coverage service) and `coverage/coverage.json`. CI's
+  `ruby-checks` job publishes the table in its job summary and the files as the
+  `ruby-coverage` artifact. See `docs/coverage.md` and ADR 0049.

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,5 +97,7 @@
 
 ## Development flow
 - For basic testing run `clear ; cmake --build build && cmake --build build -t test` to run basic tests
+- `ruby scripts/coverage_report.rb` reports line coverage of the Ruby engine
+  sources (`mruby-*/mrblib`) from the host-side checks — see `docs/coverage.md`
 - Issues and pull requests are labelled by engine, platform, component and type
   — see `docs/labels.md` for the taxonomy and how the labels get applied

--- a/docs/adr/0049-ruby-line-coverage-from-the-host-side-checks.md
+++ b/docs/adr/0049-ruby-line-coverage-from-the-host-side-checks.md
@@ -1,0 +1,85 @@
+# 49. Ruby line coverage measured from the host-side checks
+
+Date: 2026-08-15
+
+## Status
+
+Accepted
+
+## Context
+
+The project has a lot of tests — the mruby gem suites run by `mruby_test`, the
+`scripts/*_check.rb` harnesses in the `ruby-checks` CI job, the native smoke
+tests that boot the binary on real games — and no way to say what they leave
+untouched. "Is this path tested?" has been answered by reading the checks.
+
+The code that matters is Ruby. `mruby-*/mrblib` is ~39 000 lines (the LCF and
+RGSS data layers, the RPG2000 logic and scenes, the MV/MZ core) against ~3 000
+lines of C++ in `src/`, which is SDL/mruby/LVGL glue.
+
+Measuring it has one obstacle: the shipped runtime is **mruby**, which has no
+coverage support at all — no `Coverage` module, no profiler hook to build one
+from. What makes the problem tractable is a property the project already relies
+on: that Ruby is written in the mruby/CRuby common subset, and the check
+harnesses `load` those very files under CRuby (`scripts/rpg2k_logic_check.rb`
+and friends). Under CRuby the stdlib `Coverage` module applies.
+
+Three shapes were considered:
+
+1. **Instrument the harnesses under CRuby** — measures the real sources, needs
+   no new dependency, but only sees what the CRuby-hosted checks reach.
+2. **Add coverage to mruby** — would cover `mruby_test` and the native smokes
+   as well, but means carrying a patched interpreter or writing a bytecode
+   instrumentation gem. Far more machinery than the question deserves.
+3. **gcov/lcov for `src/**.cxx`** — standard, but those files are 8% of the
+   code, are reachable only through the display-bound smoke tests, and the
+   report needs `gcovr`/`lcov`, which the flake does not ship.
+
+## Decision
+
+Take (1). `scripts/coverage_report.rb` runs the host-side checks with CRuby's
+`Coverage` stdlib enabled and reports line coverage of `mruby-*/mrblib` per gem
+and per file, writing `coverage/lcov.info` (standard interchange, feeds
+`genhtml` and the coverage services) and `coverage/coverage.json`.
+
+Coverage must be started before the sources are loaded, so
+`scripts/coverage_hook.rb` is injected into each check process through
+`RUBYOPT=-r<hook>` rather than required by the harnesses. The harnesses are not
+touched, a harness that spawns `ruby` is measured too, and each process writes
+its own result for the reporter to merge — which is also what lets the checks
+keep running concurrently. Files no check loads are added at 0% from
+`Coverage.line_stub`, so an untested file lowers the total instead of being
+absent from it.
+
+CI runs it in `ruby-checks` and publishes the numbers in the job summary and as
+a `ruby-coverage` artifact. It is report-only; `--min-line-rate` exists for
+turning it into a gate later, deliberately unused for now, because the first
+useful thing a coverage number does is show where the tests are thin, not fail
+builds while that is still being learned.
+
+Native C++ coverage is left out (option 3), and `mruby_test`/native-smoke
+coverage is left unmeasured (option 2).
+
+## Consequences
+
+- The gaps become visible and rankable: the report's per-file tail is a list of
+  where the next host-side check pays off the most.
+- The number is a **floor**, not a truth. `mruby_test` and the native smokes
+  exercise the same sources inside mruby, invisibly to this. Files needing a
+  live RGSS window or a JS engine (`mruby-rgss/mrblib/lib.rb`,
+  `mruby-mvjs/mrblib/{mv,mz}.rb`) therefore read 0% while being covered by other
+  suites. `docs/coverage.md` says so up front; a reader who forgets it will
+  draw the wrong conclusion from the total.
+- The measurement rewards exactly the tests this repository already prefers —
+  host-side checks that run in seconds without a display — and says nothing
+  about the ones it cannot count. If that starts distorting where tests get
+  written, the answer is option 2, not a bigger floor.
+- CI re-runs the checks a second time to measure them (concurrently, so it
+  costs the `ruby-checks` job roughly one more check-group's wall clock, no
+  extra runner). The alternative — measuring the existing group in place —
+  would have cost the per-check step granularity that job's log is built
+  around.
+- The check list in `scripts/coverage_report.rb` duplicates the one in
+  `.github/workflows/build.yml`; a check added to CI and not to the reporter is
+  simply unmeasured, which is a silent, low-cost drift. `--list` prints what
+  the reporter believes.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -75,8 +75,17 @@ not in the dev shell. See ADR 0049 for that trade-off.
 ## In CI
 
 The `ruby-checks` job runs the report after its check group and publishes it
-two ways: a per-gem Markdown table in the job summary, and a `ruby-coverage`
-artifact holding `lcov.info` and `coverage.json`. The **number** is report-only
+two ways.
+
+On the run's **summary page** (`$GITHUB_STEP_SUMMARY`): the headline
+percentage and the per-gem table, then two collapsed sections — the least
+covered files, and every check with its result and duration (including the
+ones that skipped, and why). No log-digging to see the number.
+
+As a **`ruby-coverage` artifact**: `lcov.info` and `coverage.json`, the whole
+per-file picture, for `genhtml` or a coverage service.
+
+The **number** is report-only
 — no floor is enforced, so coverage moving does not fail a build. The step
 itself is an ordinary one: a broken reporter, or a check that fails only under
 the coverage re-run, fails the job rather than silently producing no report.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,97 @@
+# Code coverage
+
+Almost all of the runtime is Ruby: the LCF and RGSS data layers, the RPG2000
+game logic and its scenes, the MV/MZ core — about 39 000 lines under
+`mruby-*/mrblib`, against roughly 3 000 lines of C++ glue in `src/`. That Ruby
+is written in the mruby/CRuby common subset and the `scripts/*_check.rb`
+harnesses load it under CRuby (see any harness header), which is what makes it
+measurable: CRuby ships a `Coverage` module, mruby does not.
+
+`scripts/coverage_report.rb` runs those harnesses with coverage switched on and
+reports which lines they reached.
+
+```sh
+ruby scripts/coverage_report.rb            # run every check, write coverage/
+ruby scripts/coverage_report.rb --per-file # ... listing every file
+ruby scripts/coverage_report.rb --only rpg2k   # just the rpg2k-* checks
+ruby scripts/coverage_report.rb --list     # what it would run
+```
+
+Output:
+
+```
+Ruby line coverage
+
+  mruby-lcf      #################.......   68.8%     271 / 394
+  mruby-mvjs     ........................    0.0%       0 / 1064
+  mruby-rgss     ##......................    9.5%      72 / 761
+  mruby-rpg2k    ######################..   92.9%   11305 / 12175
+  mruby-rpgvx    ####################....   85.1%     308 / 362
+  mruby-rpgxp    ##################......   73.7%     777 / 1054
+  total          ###################.....   80.5%   12733 / 15810
+```
+
+plus, in `coverage/`:
+
+- `lcov.info` — the standard interchange format. `genhtml coverage/lcov.info -o
+  coverage/html` renders a browsable per-line report, and coverage services
+  (Codecov, Coveralls) read it directly.
+- `coverage.json` — the same numbers per gem and per file, plus the status of
+  every check that was run, for scripting.
+
+## How it works
+
+`Coverage.start` has to run before the sources are loaded, so
+`scripts/coverage_hook.rb` is injected into each check with
+`RUBYOPT=-r<hook>` instead of being required by the harnesses. The harnesses
+stay untouched, any `ruby` a harness spawns is measured too, and each process
+dumps its own result as JSON into a temporary directory that the reporter then
+merges. Checks run concurrently (`--jobs`, default: processor count).
+
+Files that no check ever loads do not appear in a `Coverage` result at all;
+they are added at 0% from `Coverage.line_stub`, so a whole untested file drags
+the total down instead of silently vanishing from it.
+
+## What the number does and does not mean
+
+It is a **floor**, not a ceiling. Two other test suites exercise the same Ruby
+and cannot be counted:
+
+- `mruby_test` (`cmake --build build -t test`) runs each gem's own tests inside
+  mruby, where there is no `Coverage` module.
+- The native smoke tests (`scripts/*_boot_check.bash`, the MV/MZ runs in CI)
+  drive the built binary, likewise inside mruby.
+
+So a file reported at 0% is not necessarily untested — `mruby-rgss/mrblib/lib.rb`
+and `mruby-mvjs/mrblib/{mv,mz}.rb` read as 0% because they need a live RGSS
+window or a JS engine, which is exactly why no CRuby harness loads them. Read
+the report as "this much of the engine is covered by the host-side checks", and
+use the per-file tail as a list of where the next host-side check would pay off.
+
+C++ coverage (`src/**.cxx`) is not wired up: those files are SDL/mruby/LVGL
+glue reachable only through the display-bound smoke tests, and gcov tooling is
+not in the dev shell. See ADR 0049 for that trade-off.
+
+## In CI
+
+The `ruby-checks` job runs the report after its check group and publishes it
+two ways: a per-gem Markdown table in the job summary, and a `ruby-coverage`
+artifact holding `lcov.info` and `coverage.json`. The **number** is report-only
+— no floor is enforced, so coverage moving does not fail a build. The step
+itself is an ordinary one: a broken reporter, or a check that fails only under
+the coverage re-run, fails the job rather than silently producing no report.
+
+To make it a gate instead, pass a floor:
+
+```sh
+ruby scripts/coverage_report.rb --min-line-rate 75
+```
+
+which exits non-zero when total line coverage falls below it. The reporter also
+exits non-zero when a check it ran fails, so it is honest about a broken check
+rather than reporting a coverage number computed from a half-finished run.
+
+Checks needing data that is not committed (the RPG2000 event-command soak wants
+a downloaded test bed) are reported as skipped rather than failing, so the
+report is runnable in a fresh clone; the coverage they contribute is simply
+missing from it. CI downloads those games, so its numbers are the complete ones.

--- a/scripts/coverage_hook.rb
+++ b/scripts/coverage_hook.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Line-coverage collector, injected into a check process by
+# scripts/coverage_report.rb. Not meant to be run by hand.
+#
+# The engine's game logic is Ruby that runs inside mruby in the shipped binary,
+# but every `scripts/*_check.rb` harness loads those same sources under CRuby
+# (see the header of any of them), so CRuby's own `Coverage` stdlib is what can
+# measure them. Coverage has to be started *before* the sources are loaded,
+# which is why this file is injected with `RUBYOPT=-r...` instead of being
+# required from the harnesses: the harnesses stay untouched, and any `ruby` a
+# harness spawns is measured too.
+#
+# Each process writes its own result as JSON into $RPG_COVERAGE_DIR; the
+# reporter merges them. Nothing else is defined at top level here — the file is
+# loaded into somebody else's process, so it must not add names to it.
+
+require 'coverage'
+
+Coverage.start(lines: true)
+
+at_exit do
+  dir = ENV['RPG_COVERAGE_DIR'].to_s
+  # No directory means nobody asked for coverage (a stray RUBYOPT, say), which
+  # is not an error — just nothing to write.
+  next if dir.empty?
+
+  begin
+    require 'json'
+
+    root = File.expand_path('..', __dir__) + File::SEPARATOR
+    # `stop: false`/`clear: false`: another at_exit handler registered later
+    # still runs after this one and its lines should keep being counted, even
+    # though nothing will read them.
+    result = Coverage.running? ? Coverage.result(stop: false, clear: false) : {}
+
+    lines = result.each_with_object({}) do |(path, cov), acc|
+      # Only the repository's own sources; the stdlib and the gems it pulls in
+      # are not what this measures.
+      next unless path.start_with?(root)
+
+      counts = cov.is_a?(Hash) ? cov[:lines] : cov
+      acc[path[root.length..-1]] = counts if counts
+    end
+
+    tag = ENV['RPG_COVERAGE_TAG'].to_s.gsub(/[^A-Za-z0-9_.-]/, '_')
+    tag = 'check' if tag.empty?
+    # pid alone is not unique across a whole run (they are recycled between
+    # sequential checks) and a harness may spawn nested ruby processes, so add
+    # a random suffix. Drawing from the default RNG here is safe: at_exit runs
+    # after the harness has finished with it.
+    name = format('%s-%d-%08x.json', tag, Process.pid, Random.rand(0xffff_ffff))
+    File.write(File.join(dir, name), JSON.generate(lines))
+  rescue StandardError => e
+    # Losing coverage must not be silent, and must not change the exit status
+    # of the check that was being measured.
+    warn "[coverage] could not record #{$PROGRAM_NAME}: #{e.class}: #{e.message}"
+  end
+end

--- a/scripts/coverage_report.rb
+++ b/scripts/coverage_report.rb
@@ -292,6 +292,11 @@ def bar(percent, width = 24)
   ('#' * filled) + ('.' * (width - filled))
 end
 
+# The tail is where the next test belongs, so it is what both the terminal and
+# the CI summary lead with. Files with nothing to cover are not interesting
+# either way.
+lowest = files.reject { |f| f[:lines].zero? }.sort_by { |f| [f[:rate], -f[:lines]] }.first(10)
+
 puts
 puts 'Ruby line coverage'
 puts
@@ -310,9 +315,6 @@ if options[:per_file]
                 entry[:hit], entry[:lines])
   end
 else
-  # The tail is where the next test belongs, so show it by default. Files with
-  # nothing to cover are not interesting either way.
-  lowest = files.reject { |f| f[:lines].zero? }.sort_by { |f| [f[:rate], -f[:lines]] }.first(10)
   puts '  Least covered files (--per-file for all):'
   lowest.each do |entry|
     puts format('    %-46s %6.1f%%  %6d / %d', entry[:file], entry[:rate],
@@ -326,6 +328,11 @@ puts "  json: #{json_path.sub("#{ROOT}/", '')}"
 skipped = results.select(&:skipped_because)
 failed = results.reject { |r| r.skipped_because || r.status.zero? }
 
+# The CI job summary (the run's front page). The headline number and the
+# per-gem split are laid out flat; the two lists a reader only sometimes wants
+# — where the gaps are, and what was actually run — go in <details> blocks so
+# the summary stays one screen. Appended, never truncated: other steps write
+# their own sections to the same file.
 if (summary_path = ENV['GITHUB_STEP_SUMMARY']) && !summary_path.empty?
   File.open(summary_path, 'a') do |io|
     io.puts '## Ruby line coverage'
@@ -340,15 +347,44 @@ if (summary_path = ENV['GITHUB_STEP_SUMMARY']) && !summary_path.empty?
                      group[:lines])
     end
     io.puts format('| **total** | **%.1f%%** | %d | %d |', total[:rate], total[:hit], total[:lines])
-    unless skipped.empty?
+
+    unless lowest.empty?
       io.puts
-      io.puts "Skipped: #{skipped.map { |r| "`#{r.check[:name]}`" }.join(', ')} " \
-              '(test-bed data not downloaded).'
-    end
-    unless failed.empty?
+      io.puts '<details><summary>Least covered files</summary>'
       io.puts
-      io.puts "Failed: #{failed.map { |r| "`#{r.check[:name]}`" }.join(', ')}."
+      io.puts '| File | Coverage | Covered | Lines |'
+      io.puts '| --- | ---: | ---: | ---: |'
+      lowest.each do |entry|
+        io.puts format('| `%s` | %.1f%% | %d | %d |', entry[:file], entry[:rate], entry[:hit],
+                       entry[:lines])
+      end
+      io.puts
+      io.puts '</details>'
     end
+
+    io.puts
+    io.puts '<details><summary>Checks measured</summary>'
+    io.puts
+    io.puts '| Check | Result | Time |'
+    io.puts '| --- | --- | ---: |'
+    results.sort_by { |r| r.check[:name] }.each do |result|
+      state = if result.skipped_because
+                "skipped — needs #{result.skipped_because}"
+              elsif result.status.zero?
+                'ok'
+              else
+                "**failed** (exit #{result.status})"
+              end
+      io.puts format('| `%s` | %s | %.1fs |', result.check[:name], state, result.seconds)
+    end
+    io.puts
+    io.puts '</details>'
+
+    io.puts
+    io.puts 'Covered by the CRuby harnesses only — `mruby_test` and the native smoke tests ' \
+            'run inside mruby, where there is no `Coverage`, so this is a floor. ' \
+            'Full report in the `ruby-coverage` artifact (`lcov.info`, `coverage.json`); ' \
+            'see `docs/coverage.md`.'
   end
 end
 

--- a/scripts/coverage_report.rb
+++ b/scripts/coverage_report.rb
@@ -1,0 +1,367 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Line-coverage report for the engine's Ruby sources (`mruby-*/mrblib/**.rb`).
+#
+# Almost all of the runtime is Ruby -- the LCF/RGSS data layers, the RPG2000
+# game logic and its scenes, the MV/MZ core -- and it is exercised by the
+# `scripts/*_check.rb` harnesses, which load those sources under CRuby (see
+# ADR 0049). This runs every one of those harnesses with CRuby's `Coverage`
+# stdlib switched on (scripts/coverage_hook.rb, injected through RUBYOPT),
+# merges the per-process results and reports which lines the checks reached:
+#
+#   - a per-gem and per-file summary on stdout,
+#   - `coverage/lcov.info`, the standard interchange format (feed it to
+#     `genhtml` for an HTML report, or to a coverage service),
+#   - `coverage/coverage.json`, the same numbers for scripting,
+#   - a Markdown table in the job summary when $GITHUB_STEP_SUMMARY is set.
+#
+# What it does *not* measure: the mruby-side `rake test` suites and the native
+# smoke tests both run inside the built binary, where the CRuby stdlib does not
+# exist, so the lines only they reach count as uncovered here. The number is a
+# floor on how much of the engine is tested, not a ceiling -- read it as "this
+# much is covered by the host-side checks".
+#
+# Usage: ruby scripts/coverage_report.rb [options]
+#
+#   --jobs N            run N checks concurrently (default: processor count)
+#   --output DIR        write the reports here (default: coverage/)
+#   --only PATTERN      only run checks whose name matches PATTERN (substring)
+#   --min-line-rate PCT exit non-zero when total line coverage is below PCT
+#   --per-file          list every file, not just the least covered ones
+#   --list              list the checks and exit
+#   --help
+
+require 'coverage'
+require 'etc'
+require 'fileutils'
+require 'json'
+require 'set'
+require 'tmpdir'
+
+ROOT = File.expand_path('..', __dir__)
+HOOK = File.join(__dir__, 'coverage_hook.rb')
+
+# The sources the report is about: the pure-Ruby engine libraries. The
+# harnesses under scripts/ are the tests, not the subject, so they are left
+# out; `src/**.cxx` is a different language and a different tool (see the ADR).
+SOURCE_GLOBS = ['mruby-*/mrblib/**/*.rb'].freeze
+
+# The host-side checks, mirroring the `ruby-checks` job in
+# .github/workflows/build.yml plus the one CRuby check CTest owns
+# (error_report_check, which covers mruby-rgss/mrblib/error_report.rb). A check
+# that needs a downloaded test bed says so with `needs:`; without the data it is
+# reported as skipped instead of failing the run, the same way the harnesses
+# themselves skip.
+CHECKS = [
+  { name: 'lcf-testbed',        command: %w[scripts/lcf_testbed_check.rb] },
+  { name: 'rpg2k-command-soak', command: %w[scripts/rpg2k_command_soak.rb],
+    needs: :rpg2k_game },
+  { name: 'rpgxp-testbed',      command: %w[scripts/rpgxp_testbed_check.rb] },
+  { name: 'rpgxp-script-host',  command: %w[scripts/rpgxp_script_host_check.rb] },
+  { name: 'rpgvx-testbed',      command: %w[scripts/rpgvx_testbed_check.rb] },
+  { name: 'mv-testbed',         command: %w[scripts/mv_testbed_check.rb data/mv-sample] },
+  { name: 'mz-testbed',         command: %w[scripts/mz_testbed_check.rb data/mz-sample] },
+  { name: 'rpg2k-logic',        command: %w[scripts/rpg2k_logic_check.rb] },
+  { name: 'rpg2k-scene',        command: %w[scripts/rpg2k_scene_check.rb] },
+  { name: 'rpg2k-render',       command: %w[scripts/rpg2k_render_check.rb] },
+  { name: 'rpg2k-testbed-logic', command: %w[scripts/rpg2k_testbed_logic_check.rb] },
+  { name: 'error-report',       command: %w[scripts/error_report_check.rb] }
+].freeze
+
+# `needs:` predicates. A downloaded RPG2000/2003 game is the only prerequisite
+# any check has that is not committed to the repository.
+REQUIREMENTS = {
+  rpg2k_game: {
+    description: 'a downloaded RPG2000/2003 test bed under data/ ' \
+                 '(scripts/download-nepheshel.bash)',
+    met: -> { !Dir.glob(File.join(ROOT, 'data', '**', 'RPG_RT.ldb')).empty? }
+  }
+}.freeze
+
+options = {
+  jobs: Etc.nprocessors,
+  output: File.join(ROOT, 'coverage'),
+  only: nil,
+  min_line_rate: nil,
+  per_file: false,
+  list: false
+}
+
+args = ARGV.dup
+until args.empty?
+  arg = args.shift
+  case arg
+  when '--jobs' then options[:jobs] = Integer(args.shift)
+  when /\A--jobs=(.+)\z/ then options[:jobs] = Integer(Regexp.last_match(1))
+  when '--output' then options[:output] = File.expand_path(args.shift, Dir.pwd)
+  when /\A--output=(.+)\z/ then options[:output] = File.expand_path(Regexp.last_match(1), Dir.pwd)
+  when '--only' then options[:only] = args.shift
+  when /\A--only=(.+)\z/ then options[:only] = Regexp.last_match(1)
+  when '--min-line-rate' then options[:min_line_rate] = Float(args.shift)
+  when /\A--min-line-rate=(.+)\z/ then options[:min_line_rate] = Float(Regexp.last_match(1))
+  when '--per-file' then options[:per_file] = true
+  when '--list' then options[:list] = true
+  when '-h', '--help'
+    puts File.read(__FILE__)[/^# Usage:.*?(?=\n[^#])/m].gsub(/^# ?/, '')
+    exit 0
+  else
+    warn "coverage report: unknown argument #{arg.inspect} (try --help)"
+    exit 2
+  end
+end
+options[:jobs] = 1 if options[:jobs] < 1
+
+selected = CHECKS.select { |c| options[:only].nil? || c[:name].include?(options[:only]) }
+if selected.empty?
+  warn "coverage report: no check matches #{options[:only].inspect}"
+  exit 2
+end
+
+if options[:list]
+  selected.each do |check|
+    need = check[:needs] ? "  (needs #{REQUIREMENTS.fetch(check[:needs])[:description]})" : ''
+    puts format('%-22s ruby %s%s', check[:name], check[:command].join(' '), need)
+  end
+  exit 0
+end
+
+# --- run the checks, each with the coverage hook injected ------------------
+
+Result = Struct.new(:check, :status, :seconds, :output, :skipped_because)
+
+def run_check(check, coverage_dir)
+  requirement = check[:needs] && REQUIREMENTS.fetch(check[:needs])
+  if requirement && !requirement[:met].call
+    return Result.new(check, nil, 0.0, '', requirement[:description])
+  end
+
+  env = {
+    'RPG_COVERAGE_DIR' => coverage_dir,
+    'RPG_COVERAGE_TAG' => check[:name],
+    # Prepended, so a RUBYOPT the caller set (or the dev shell exports) survives.
+    'RUBYOPT' => ["-r#{HOOK}", ENV['RUBYOPT']].compact.reject(&:empty?).join(' ')
+  }
+  command = ['ruby', *check[:command]]
+
+  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  # The checks run concurrently, so their output is captured and printed in one
+  # piece rather than interleaved on the terminal.
+  output = IO.popen(env, command, chdir: ROOT, err: %i[child out], &:read)
+  status = $?
+  Result.new(check, status.exitstatus, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started,
+             output, nil)
+end
+
+coverage_dir = Dir.mktmpdir('rpg-coverage')
+results = []
+begin
+  queue = Queue.new
+  selected.each { |check| queue << check }
+  mutex = Mutex.new
+
+  workers = Array.new([options[:jobs], selected.size].min) do
+    Thread.new do
+      while (check = begin
+        queue.pop(true)
+      rescue ThreadError
+        nil
+      end)
+        result = run_check(check, coverage_dir)
+        mutex.synchronize do
+          results << result
+          if result.skipped_because
+            puts format('  skip  %-22s %s', result.check[:name], "needs #{result.skipped_because}")
+          else
+            puts format('  %-5s %-22s %5.1fs', result.status.zero? ? 'ok' : 'FAIL',
+                        result.check[:name], result.seconds)
+          end
+        end
+      end
+    end
+  end
+  puts "Running #{selected.size} host-side check(s) with coverage " \
+       "(#{[options[:jobs], selected.size].min} at a time)"
+  workers.each(&:join)
+
+  failed = results.reject { |r| r.skipped_because || r.status.zero? }
+  failed.each do |result|
+    puts
+    puts "--- #{result.check[:name]} failed (exit #{result.status}) ---"
+    puts result.output
+  end
+
+  # --- merge every process's result -----------------------------------------
+
+  merged = {}
+  Dir.glob(File.join(coverage_dir, '*.json')).sort.each do |path|
+    JSON.parse(File.read(path)).each do |file, counts|
+      into = (merged[file] ||= Array.new(counts.size))
+      counts.each_with_index do |count, i|
+        next if count.nil?
+
+        into[i] = (into[i] || 0) + count
+      end
+    end
+  end
+ensure
+  FileUtils.remove_entry(coverage_dir)
+end
+
+# Files no check ever loaded are absent from the merged result, and dropping
+# them would report the covered files' rate as the project's. Ask Coverage for
+# their line layout instead, so they land in the report at 0%.
+SOURCE_GLOBS.each do |glob|
+  Dir.glob(File.join(ROOT, glob)).sort.each do |path|
+    relative = path[(ROOT.length + 1)..-1]
+    next if merged.key?(relative)
+
+    merged[relative] = Coverage.line_stub(path)
+  end
+end
+
+# Anything outside the measured sources (a harness under scripts/, say) rode
+# along in the raw result; the report is about the engine libraries only.
+source_files = SOURCE_GLOBS.flat_map { |g| Dir.glob(File.join(ROOT, g)) }
+                           .map { |p| p[(ROOT.length + 1)..-1] }.to_set
+merged.select! { |file, _| source_files.include?(file) }
+
+if merged.empty?
+  warn 'coverage report: no source file was measured -- nothing to report'
+  exit 1
+end
+
+# --- shape the numbers ----------------------------------------------------
+
+def stats_for(counts)
+  relevant = counts.compact
+  { lines: relevant.size, hit: relevant.count { |c| c > 0 } }
+end
+
+def rate(stat)
+  stat[:lines].zero? ? 100.0 : (stat[:hit] * 100.0 / stat[:lines])
+end
+
+files = merged.keys.sort.map do |file|
+  stat = stats_for(merged[file])
+  { file: file, gem: file[%r{\A[^/]+}], **stat, rate: rate(stat) }
+end
+
+groups = files.group_by { |f| f[:gem] }.map do |gem, gem_files|
+  stat = { lines: gem_files.sum { |f| f[:lines] }, hit: gem_files.sum { |f| f[:hit] } }
+  { gem: gem, **stat, rate: rate(stat) }
+end.sort_by { |g| g[:gem] }
+
+total = { lines: files.sum { |f| f[:lines] }, hit: files.sum { |f| f[:hit] } }
+total[:rate] = rate(total)
+
+# --- write the reports ----------------------------------------------------
+
+FileUtils.mkdir_p(options[:output])
+
+lcov = +''
+files.each do |entry|
+  lcov << "TN:\n" << "SF:#{entry[:file]}\n"
+  merged[entry[:file]].each_with_index do |count, index|
+    lcov << "DA:#{index + 1},#{count}\n" unless count.nil?
+  end
+  lcov << "LF:#{entry[:lines]}\n" << "LH:#{entry[:hit]}\n" << "end_of_record\n"
+end
+lcov_path = File.join(options[:output], 'lcov.info')
+File.write(lcov_path, lcov)
+
+json_path = File.join(options[:output], 'coverage.json')
+File.write(json_path, JSON.pretty_generate(
+                        total: total,
+                        gems: groups,
+                        files: files,
+                        checks: results.sort_by { |r| r.check[:name] }.map do |r|
+                          { name: r.check[:name],
+                            command: r.check[:command].join(' '),
+                            status: r.skipped_because ? 'skipped' : (r.status.zero? ? 'ok' : 'failed'),
+                            exit_status: r.status,
+                            seconds: r.seconds.round(2),
+                            skipped_because: r.skipped_because }
+                        end
+                      ))
+
+# --- report ---------------------------------------------------------------
+
+def bar(percent, width = 24)
+  filled = (percent / 100.0 * width).round
+  ('#' * filled) + ('.' * (width - filled))
+end
+
+puts
+puts 'Ruby line coverage'
+puts
+groups.each do |group|
+  puts format('  %-14s %s %6.1f%%  %6d / %d', group[:gem], bar(group[:rate]),
+              group[:rate], group[:hit], group[:lines])
+end
+puts format('  %-14s %s %6.1f%%  %6d / %d', 'total', bar(total[:rate]),
+            total[:rate], total[:hit], total[:lines])
+puts
+
+if options[:per_file]
+  puts '  Per file:'
+  files.each do |entry|
+    puts format('    %-46s %6.1f%%  %6d / %d', entry[:file], entry[:rate],
+                entry[:hit], entry[:lines])
+  end
+else
+  # The tail is where the next test belongs, so show it by default. Files with
+  # nothing to cover are not interesting either way.
+  lowest = files.reject { |f| f[:lines].zero? }.sort_by { |f| [f[:rate], -f[:lines]] }.first(10)
+  puts '  Least covered files (--per-file for all):'
+  lowest.each do |entry|
+    puts format('    %-46s %6.1f%%  %6d / %d', entry[:file], entry[:rate],
+                entry[:hit], entry[:lines])
+  end
+end
+puts
+puts "  lcov: #{lcov_path.sub("#{ROOT}/", '')}"
+puts "  json: #{json_path.sub("#{ROOT}/", '')}"
+
+skipped = results.select(&:skipped_because)
+failed = results.reject { |r| r.skipped_because || r.status.zero? }
+
+if (summary_path = ENV['GITHUB_STEP_SUMMARY']) && !summary_path.empty?
+  File.open(summary_path, 'a') do |io|
+    io.puts '## Ruby line coverage'
+    io.puts
+    io.puts format('**%.1f%%** of %d lines in `mruby-*/mrblib` (%d covered), from %d host-side check(s).',
+                   total[:rate], total[:lines], total[:hit], results.size - skipped.size)
+    io.puts
+    io.puts '| Gem | Coverage | Covered | Lines |'
+    io.puts '| --- | ---: | ---: | ---: |'
+    groups.each do |group|
+      io.puts format('| `%s` | %.1f%% | %d | %d |', group[:gem], group[:rate], group[:hit],
+                     group[:lines])
+    end
+    io.puts format('| **total** | **%.1f%%** | %d | %d |', total[:rate], total[:hit], total[:lines])
+    unless skipped.empty?
+      io.puts
+      io.puts "Skipped: #{skipped.map { |r| "`#{r.check[:name]}`" }.join(', ')} " \
+              '(test-bed data not downloaded).'
+    end
+    unless failed.empty?
+      io.puts
+      io.puts "Failed: #{failed.map { |r| "`#{r.check[:name]}`" }.join(', ')}."
+    end
+  end
+end
+
+unless failed.empty?
+  warn "coverage report: #{failed.size} check(s) failed: " \
+       "#{failed.map { |r| r.check[:name] }.join(', ')}"
+  exit 1
+end
+
+if options[:min_line_rate] && total[:rate] < options[:min_line_rate]
+  warn format('coverage report: line coverage %.1f%% is below the required %.1f%%',
+              total[:rate], options[:min_line_rate])
+  exit 1
+end
+
+exit 0


### PR DESCRIPTION
## Summary

This PR adds comprehensive line coverage reporting for the Ruby engine sources (`mruby-*/mrblib`). The implementation measures which lines of the ~39k lines of Ruby code are exercised by the host-side check harnesses running under CRuby's `Coverage` stdlib.

## Key Changes

- **`scripts/coverage_report.rb`** — Main reporting tool that:
  - Runs all `scripts/*_check.rb` harnesses with coverage instrumentation enabled
  - Merges per-process coverage results from concurrent check execution
  - Generates `coverage/lcov.info` (standard interchange format for `genhtml` and coverage services)
  - Generates `coverage/coverage.json` for scripting and CI integration
  - Reports per-gem and per-file coverage statistics with visual progress bars
  - Supports filtering checks with `--only`, setting concurrency with `--jobs`, and enforcing minimum coverage with `--min-line-rate`

- **`scripts/coverage_hook.rb`** — Coverage collector injected via `RUBYOPT`:
  - Starts `Coverage` before sources are loaded (critical for accurate measurement)
  - Captures coverage data from each process independently
  - Writes JSON results to a temporary directory for merging
  - Handles edge cases like nested Ruby processes and missing coverage directories

- **CI Integration** (`build.yml`):
  - Added `Ruby coverage report` step in `ruby-checks` job that re-runs checks with coverage
  - Publishes `ruby-coverage` artifact containing `lcov.info` and `coverage.json`
  - Adds per-gem coverage table to job summary via `$GITHUB_STEP_SUMMARY`
  - Report-only by default; `--min-line-rate` available for enforcing floors

- **Documentation**:
  - `docs/coverage.md` — User guide explaining how to run coverage, interpret results, and understand limitations
  - `docs/adr/0049-ruby-line-coverage-from-the-host-side-checks.md` — Architecture decision record explaining why this approach was chosen over alternatives (mruby instrumentation, C++ coverage)
  - Updated `README.md`, `AGENTS.md`, and `docs/README.md` with coverage information

- **Project configuration**:
  - Added `/coverage` to `.gitignore` for generated reports
  - Added changelog entry documenting the new feature

## Notable Implementation Details

- **Measurement scope**: Measures only what CRuby harnesses reach; explicitly documented as a floor, not a ceiling. Other test suites (`mruby_test`, native smoke tests) exercise the same code inside mruby where `Coverage` doesn't exist.

- **Concurrent execution**: Checks run in parallel (default: processor count) with per-process result capture, avoiding the need to serialize coverage data through a single process.

- **Completeness**: Files never loaded by any check are added at 0% coverage via `Coverage.line_stub`, ensuring untested files drag down the total rather than silently vanishing from reports.

- **Flexibility**: Supports filtering checks, adjusting concurrency, and optional per-file listing; designed to work in CI and locally with the same command.

https://claude.ai/code/session_01JLb2Bqn89ZQPzFgETBk3Du