### PR TITLE
Add profiler sections for map renderer and audio subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,8 +488,11 @@
 
 - `frame(work)` is per-frame CPU time (the frame span minus the fps-cap sleep);
   the `sections` list is the bottleneck breakdown — `scene.update`,
-  `input.update` and the `gfx.*` phases of `Graphics.update` — sorted hottest
-  first, each with its average/max time and share of the frame. The memory
+  `input.update`, the `gfx.*` phases of `Graphics.update`, the `map.*` phases
+  of the RPG2000 map scene and the `audio.*` asset-load/poll path — sorted
+  hottest first, each with its average/max time and share of the frame. Only
+  the **top eight** sections fit on the line, so use the Chrome trace below to
+  see the cheap ones. The memory
   fields cover process RSS, the LVGL heap pool and mruby allocation churn (live
   blocks and allocations/sec; the allocation counters need the native build)
 - Game/engine Ruby code can time its own hot spots with
@@ -510,6 +513,11 @@
   `RGSS::Profiler.trace_start("trace.json")` / `RGSS::Profiler.trace_stop`. The
   stream stays loadable even if the process is killed mid-run, so it is safe to
   trace a long session and stop it with `Ctrl-C`
+- [`docs/profiling.md`](docs/profiling.md) records a measured baseline for the
+  RPG2000 map scene — what the sections above currently say, which one is the
+  bottleneck, and why moving audio to another thread does not help the frame
+  rate (SDL_mixer already mixes on its own thread; only asset load blocks the
+  game loop)
 
 ### Build natively without Nix
 

--- a/changelog.d/profiler-map-audio-sections.added.md
+++ b/changelog.d/profiler-map-audio-sections.added.md
@@ -1,0 +1,11 @@
+- **Profiler sections for the map renderer and the audio path**, so
+  `--profile` reports where a map frame actually goes instead of showing one
+  opaque `scene.update` bar. `Scene::Map` now times `map.render` and its
+  phases (`map.layers`, `map.parallax`, `map.chars`, `map.pictures`,
+  `map.overlay`, `map.animate_events`, `map.refresh_pages`), and the SDL_mixer
+  backend times `audio.music_load`, `audio.sample_load` and `audio.update`
+  alongside the Ruby-side `audio.resolve` asset search. Measured on Nepheshel,
+  this attributes 67% of frame work to `map.layers` — the per-tile blit loop
+  that redraws both chip layers from scratch every frame — and confirms the
+  steady-state audio cost on the game-loop thread is ~0ms, since SDL_mixer
+  already decodes and mixes on its own thread. See `docs/profiling.md`.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,174 @@
+# Profiling the engine
+
+How to measure where a frame goes, and what the measurement currently says.
+The profiler itself (flags, summary-line format, Chrome trace export) is
+documented in [README.md](../README.md#profiling); this page is the
+*findings* — a recorded baseline to compare against, and the reasoning that
+baseline supports.
+
+## Reproducing the baseline
+
+```sh
+scripts/native-build-without-nix.bash    # or: nix develop, cmake --build build
+
+SDL_AUDIODRIVER=dummy \
+  ./scripts/quiet_alsa.bash xvfb-run -a ./build/rpg_maker_clone \
+  --test_play --profile --profile_interval_ms=1000 \
+  --profile_trace=trace.json --timeout_ms=25000 \
+  --game_dir data/Nepheshel206beta/Nepheshel206Rbeta --rpg2k_new_game
+```
+
+`--rpg2k_new_game` is what pushes the run past the title into the map, which
+is the only scene worth profiling — the title screen draws almost nothing.
+
+Read the summary lines off stderr, or aggregate the whole run from the trace.
+The trace is the better source: the stderr line only prints the **top eight**
+sections, so the cheap ones (the whole audio path, among others) fall off the
+end and look absent when they are merely small. Each `frame` event in the
+trace carries the frame's `work_ms`, which is the right denominator — dividing
+by wall-clock instead folds in the fps-cap sleep and understates every section.
+
+## Baseline: RPG2000 / Nepheshel, map scene
+
+495 frames over 24.8s, `RelWithDebInfo` (the project default), 320x240,
+software rendering under Xvfb. Percentages are of **CPU work**, not wall clock.
+
+| section | calls | avg ms | max ms | % work |
+| --- | ---: | ---: | ---: | ---: |
+| `scene.update` | 496 | 25.46 | 544.25 | 76.2% |
+| ` map.render` | 495 | 23.19 | 49.05 | 69.3% |
+| ` map.layers` | 496 | **22.27** | 45.63 | **66.7%** |
+| `gfx.lvgl` | 495 | 7.73 | 15.04 | 23.1% |
+| ` map.pictures` | 496 | 0.74 | 0.89 | 2.2% |
+| ` map.refresh_pages` | 495 | 0.10 | 0.19 | 0.3% |
+| `audio.music_load` | 1 | 29.40 | 29.40 | 0.2% |
+| `input.update` | 496 | 0.05 | 0.11 | 0.2% |
+| ` map.overlay` | 496 | 0.04 | 0.16 | 0.1% |
+| ` map.chars` | 496 | 0.04 | 5.43 | 0.1% |
+| `gfx.invalidate` | 495 | 0.02 | 0.09 | 0.1% |
+| ` map.animate_events` | 495 | 0.01 | 0.07 | 0.0% |
+| ` map.parallax` | 496 | 0.002 | 0.04 | 0.0% |
+| `audio.sample_load` | 1 | 0.66 | 0.66 | 0.0% |
+| `audio.resolve` | 2 | 0.23 | 0.26 | 0.0% |
+| `audio.update` | 496 | 0.0002 | 0.001 | 0.0% |
+
+Headline: **33.5ms of work per frame against a 16.67ms budget** — 2x over, so
+the run sits at 20fps with every frame counted as a drop. Allocation churn is
+~350,000 mruby allocations/second.
+
+### The bottleneck is `map.layers`
+
+Two thirds of the frame is one loop, `Scene::Map#draw_layers`. Every frame it
+clears both chip-layer bitmaps and re-blits the whole visible grid — 21x16 =
+336 tiles, each up to two layers, each tile going through
+`Game::ChipsetLayout.quads`, which returns a freshly allocated array (four
+8x8 quarters for an autotile) that is then blitted quad by quad.
+
+Nothing about that is conditional. The map is redrawn from scratch whether or
+not the camera moved, whether or not any tile animated, and whether or not
+anything on screen changed at all. That is also where the allocation churn
+comes from: `quads` is a pure function of `(id, abf, cf)` and is called
+~670 times per frame, allocating every time.
+
+Two independent things are therefore being paid for every frame:
+
+1. **Recomputing tile geometry** that depends only on `(id, abf, cf)`.
+2. **Re-blitting static scenery** that did not change since the last frame.
+
+(1) is the cheaper fix and was measured: memoizing `quads` on `(id, abf, cf)`
+took `map.layers` from 22.3ms to 12.9ms, frame work from 33.5ms to 22.8ms
+(20.0 -> 25.4fps), and allocation churn from ~350k to ~225k/s. That is a
+~30% frame-time win from a cache, and it is *not* committed here — this page
+records the measurement, not the change. Note the guard it needs: `quads` is
+called with `nil` ids, so a naive key computation raises.
+
+(1) alone does not reach 60fps — 22.8ms is still over budget, and the residual
+12.9ms is the per-tile blit loop itself. Getting under 16.67ms means attacking
+(2): cache the composed layer and redraw only on camera movement or an actual
+animation step, or move the inner loop out of mruby.
+
+`gfx.lvgl` (7.7ms, the LVGL render and flush) is the second cost and is
+largely a consequence of the first — the full-surface invalidation that a
+from-scratch tile redraw implies.
+
+## Audio: what is already off the main thread
+
+Short version: **the audio *processing* is already on another thread, and it
+was never the bottleneck.** SDL_mixer decodes, synthesises and mixes on the
+audio device thread that `Mix_OpenAudio` starts. Observed directly by counting
+`/proc/self/task` around the call:
+
+| point | threads |
+| --- | --- |
+| before `Mix_OpenAudio` | 1 (`main`) |
+| after `Mix_OpenAudio` | 2 (`+ SDLAudioP2`) |
+| while a `.mid` plays | 5 (`+ 3` TiMidity/decoder workers) |
+
+What genuinely runs on the game-loop thread is only the *control* surface, and
+the profile prices it at essentially nothing:
+
+- `audio.update` — the per-frame backend poll (`Mix_PlayingMusic`, to resume a
+  BGM after an ME): **0.0002ms/frame**, 0.1ms total across a 25s run.
+- `audio.resolve` — the Ruby asset search in `RGSS::Audio.resolve`: 0.23ms,
+  and only on an actual Play command.
+- `Mix_PlayMusic` / `Mix_PlayChannel`: 0.02ms.
+
+So moving "audio processing" to a worker thread would move work that is
+already elsewhere, and would buy ~0.0002ms/frame. It is not where the 33.5ms
+goes.
+
+### The part that *is* worth moving: asset load
+
+One audio call does block the game loop, and it is the load, not the playback.
+Measured against Nepheshel's own files (SDL2\_mixer 2.x, FreePats patch set):
+
+| call | cost on the calling thread |
+| --- | ---: |
+| `Mix_LoadMUS` on a `.mid` | **20–30ms** |
+| `Mix_LoadMUS` on a `.wav` | 0.05ms |
+| `Mix_PlayMusic` | 0.02ms |
+| `Mix_LoadWAV` (SE, first play) | 0.66ms |
+
+A MIDI load is a 1–2 frame hitch, and Nepheshel is 143 `.mid` tracks, so every
+BGM/ME change pays it — including every ME, which reloads the interrupted BGM
+when it finishes (`maybe_resume_bgm`). SE are cached after first decode
+(`g_chunks`), so they cost 0.66ms once per distinct sample and nothing after.
+
+This is a real, if narrow, target: a load/decode worker thread that hands the
+finished `Mix_Music`/`Mix_Chunk` back to the main thread to start. It removes a
+visible stutter on BGM change. It does **not** improve steady-state frame rate,
+because there is no steady-state audio cost to remove.
+
+Note this is the same class of bug already fixed once here: `Mix_GetMusicPosition`
+costs *hundreds* of ms per call on the MIDI decoder, and polling it every frame
+for the "BGM played once" check once dragged this same game to under 2fps. It
+is now answered from the clock instead (see `g_music_start_ms` in
+`src/sdl_audio.cxx`). The lesson generalises — on this backend the expensive
+audio calls are the ones that touch the decoder, not the ones that mix.
+
+### Constraints on any audio threading work
+
+- **The browser build is single-threaded.** The Emscripten link options in
+  `CMakeLists.txt` carry no `-pthread` / `-sUSE_PTHREADS`, and pthreads in wasm
+  additionally need `SharedArrayBuffer`, i.e. COOP/COEP headers on the deployed
+  page. Since GitHub Pages is the primary distribution, a worker thread has to
+  be conditional, with the synchronous path kept for wasm.
+- **PSP and Wio have no usable `std::thread`.** `mruby-rgss/src/terminal.cxx`
+  already documents and handles exactly this: its background writer thread is
+  compiled out with `#if !defined(PSP_BUILD) && !defined(WIO_TERMINAL)`. Any
+  audio worker should follow that same shape.
+- **SDL_mixer's own API is not thread-safe across arbitrary calls.** The load
+  can move; `Mix_PlayMusic`/`Mix_PlayChannel` and the `g_chunks` cache should
+  stay owned by one thread.
+
+## Caveats on these numbers
+
+- Software rendering under Xvfb with `SDL_AUDIODRIVER=dummy`. Absolute
+  milliseconds will differ on real hardware; the *ratios* are what to compare.
+- `--profile` and friends are test-play-only. Without `--test_play` (or
+  `Game.ini` `[Game] Test=1`) the flags are parsed and then ignored, and the
+  run prints no profiler output at all.
+- The stderr summary caps at eight sections. Prefer the trace when you care
+  about anything cheap.
+- One game, one scene. The RPG XP / VX / MV runtimes have their own scene
+  code and are not covered by this baseline.

--- a/mruby-rgss/mrblib/lib.rb
+++ b/mruby-rgss/mrblib/lib.rb
@@ -1176,7 +1176,15 @@ module RGSS
       # or one relative to the current directory), then under GAME_DIR and
       # RTP_DIR crossed with +dirs+; an accented name stored decomposed on disk
       # is retried in NFD form, as Bitmap does.
+      # Timed as `audio.resolve`: every Play SE/BGM/BGS/ME goes through here,
+      # and a miss walks two roots x the kind's directories x EXT_SPELLINGS
+      # (each also in its NFD spelling), so the cost is a burst of File.exist?
+      # syscalls on the game-loop thread rather than anything audio-related.
       def resolve(filename, dirs)
+        RGSS::Profiler.section("audio.resolve") { search_for(filename, dirs) }
+      end
+
+      def search_for(filename, dirs)
         return nil if filename.nil? || filename.empty?
         found = exist_with_ext(filename)
         return found if found

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -318,7 +318,7 @@ class RPG2k
         @anim_frame += 1 # water / animated tiles cycle even during events
         # An event page's conditions may have just stopped (or started) holding;
         # re-select before anything reads a trigger or a graphic this frame.
-        refresh_event_pages
+        RGSS::Profiler.section("map.refresh_pages") { refresh_event_pages }
         # Parallel processes run every frame on their own schedule, independent
         # of whatever the foreground is doing (yado.tk: a message window or a
         # foreground event parked on a blocking wait is not a pause condition,
@@ -369,8 +369,8 @@ class RPG2k
           end
         end
         record_map_event_positions
-        animate_events
-        render
+        RGSS::Profiler.section("map.animate_events") { animate_events }
+        RGSS::Profiler.section("map.render") { render }
       end
 
       private
@@ -9139,8 +9139,8 @@ class RPG2k
         px, py = player_pixel
         cam_x, cam_y = camera_position
 
-        draw_parallax cam_x, cam_y
-        draw_layers cam_x, cam_y
+        RGSS::Profiler.section("map.parallax") { draw_parallax cam_x, cam_y }
+        RGSS::Profiler.section("map.layers") { draw_layers cam_x, cam_y }
 
         @player_sprite.x = px - cam_x - (Game::CharSet::WIDTH - TILE) / 2
         @player_sprite.y = py - cam_y - (Game::CharSet::HEIGHT - TILE) -
@@ -9148,9 +9148,11 @@ class RPG2k
         # Reflect the Set Transparent Flag command (and any leader graphic flag)
         # every frame so the hero hides/shows as events toggle it.
         @player_sprite.visible = !player_hidden?
-        draw_player_frame
-        draw_vehicles cam_x, cam_y, px, py
-        draw_map_animation cam_x, cam_y
+        RGSS::Profiler.section("map.chars") do
+          draw_player_frame
+          draw_vehicles cam_x, cam_y, px, py
+          draw_map_animation cam_x, cam_y
+        end
 
         # Pictures never show on the battle screen (yado.tk / 01_shoshin's
         # 011_siyou: "none show on Menu/Battle screens") -- unlike the Menu
@@ -9167,9 +9169,9 @@ class RPG2k
           @picture_sprite.visible = false
         else
           @picture_sprite.visible = true
-          draw_pictures cam_x, cam_y
+          RGSS::Profiler.section("map.pictures") { draw_pictures cam_x, cam_y }
         end
-        update_screen_overlay
+        RGSS::Profiler.section("map.overlay") { update_screen_overlay }
         draw_timer
       end
 

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -22,6 +22,17 @@ require 'stringio'
 module RGSS
   Rect = Struct.new(:x, :y, :width, :height)
 
+  # The real Profiler is a native mruby module (mruby-rgss/src/profiler.cxx),
+  # so it does not exist under this CRuby host. Scene::Map#render and #update
+  # time their phases through it, and the native implementation is itself a
+  # plain yield when profiling is off -- so stubbing it as exactly that keeps
+  # the measured code path identical here.
+  module Profiler
+    def self.section(_name)
+      yield
+    end
+  end
+
   # Records its components so the screen-overlay checks can assert the colour a
   # layer was filled with, not just that a fill happened.
   class Color

--- a/src/sdl_audio.cxx
+++ b/src/sdl_audio.cxx
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "profiler.hxx"
 #include "rgss_audio.hxx"
 
 namespace {
@@ -195,6 +196,11 @@ Mix_Chunk* load_chunk(const std::string& path) {
   auto it = g_chunks.find(path);
   if (it != g_chunks.end())
     return it->second;
+  // Only the cache *miss* is timed: the hit above is the common per-frame case
+  // and costs a hash lookup, while this decodes the whole sample on the calling
+  // (game-loop) thread. Keeping them apart is what makes the section's `n`
+  // count actual decodes -- see the audio-threading note in docs/profiling.md.
+  ProfilerScope _scope("audio.sample_load");
   Mix_Chunk* chunk = Mix_LoadWAV(path.c_str());
   if (!chunk && has_midi_extension(path)) {
     // SE/BGS play as mixer samples, and SDL_mixer only synthesises MIDI on the
@@ -219,6 +225,7 @@ Mix_Chunk* load_chunk_mem(const std::string& name, const void* data, int size) {
   auto it = g_chunks.find(name);
   if (it != g_chunks.end())
     return it->second;
+  ProfilerScope _scope("audio.sample_load");
   Mix_Chunk* chunk = nullptr;
   SDL_RWops* rw = SDL_RWFromConstMem(data, size);
   if (rw) {
@@ -293,7 +300,13 @@ void log_music_load_failure(const std::string& what, int size = -1) {
 // (loops = -1 loops forever, 1 plays once). Returns false on load failure.
 bool play_music(const std::string& path, int volume, int loops) {
   free_music();
-  g_music = Mix_LoadMUS(path.c_str());
+  {
+    // The music stream is opened on the game-loop thread. For MIDI this is the
+    // TiMidity synth spinning up over the patch set, which is the single most
+    // expensive audio call in the engine -- the reason this section exists.
+    ProfilerScope _scope("audio.music_load");
+    g_music = Mix_LoadMUS(path.c_str());
+  }
   if (!g_music) {
     log_music_load_failure(path);
     return false;
@@ -320,7 +333,10 @@ bool play_music_mem(const std::string& name,
     g_music_bytes.clear();
     return false;
   }
-  g_music = Mix_LoadMUS_RW(rw, 1);  // 1: SDL_mixer closes the RWops
+  {
+    ProfilerScope _scope("audio.music_load");
+    g_music = Mix_LoadMUS_RW(rw, 1);  // 1: SDL_mixer closes the RWops
+  }
   if (!g_music) {
     log_music_load_failure(name, size);
     g_music_bytes.clear();
@@ -535,6 +551,7 @@ void se_stop(void) {
 // -- per-frame --------------------------------------------------------------
 
 void update(void) {
+  ProfilerScope _scope("audio.update");
   // Resume the BGM once a music effect has finished (or faded out).
   if (g_me_active && !Mix_PlayingMusic()) {
     g_me_active = false;


### PR DESCRIPTION
## Summary

This change instruments the RPG2000 map renderer and audio subsystem with profiler sections to provide detailed visibility into where frame time is spent. Previously, the profiler only showed an opaque `scene.update` bar; now it breaks down the map rendering pipeline and audio operations into measurable components.

## Key Changes

- **Map renderer instrumentation** (`mruby-rpg2k/mrblib/scene/map.rb`):
  - Added profiler sections for `map.render`, `map.layers`, `map.parallax`, `map.chars`, `map.pictures`, `map.overlay`, `map.animate_events`, and `map.refresh_pages`
  - Reveals that `map.layers` (the per-tile blit loop) consumes ~67% of frame work

- **Audio subsystem instrumentation** (`src/sdl_audio.cxx`):
  - Added profiler sections for `audio.music_load`, `audio.sample_load`, and `audio.update`
  - Strategically placed to measure only cache misses (actual decodes) rather than cache hits
  - Confirms that steady-state audio cost on the game loop is negligible (~0.0002ms/frame)
  - Documents that SDL_mixer already performs decoding and mixing on its own thread

- **Ruby-side audio asset resolution** (`mruby-rgss/mrblib/lib.rb`):
  - Added `audio.resolve` profiler section to measure the asset search cost
  - Extracted search logic into separate `search_for` method for clarity

- **Documentation and testing**:
  - Added comprehensive `docs/profiling.md` with baseline measurements from Nepheshel (RPG2000 game)
  - Includes reproduction steps, detailed bottleneck analysis, and constraints on future audio threading work
  - Added changelog entry documenting the new profiler sections
  - Added profiler stub to `scripts/rpg2k_scene_check.rb` for CRuby compatibility

## Notable Implementation Details

- The profiler sections use `ProfilerScope` RAII guards in C++ and `RGSS::Profiler.section` blocks in Ruby
- Audio load profiling is carefully scoped to measure only actual decodes (cache misses), not lookups, to accurately reflect the game-loop impact
- The baseline measurement shows the engine is 2x over budget (33.5ms vs 16.67ms target) on the test game, with the bottleneck clearly identified as the tile rendering loop that redraws the entire visible grid every frame regardless of changes
- Documentation notes that moving audio processing to a worker thread would not improve steady-state frame rate, since SDL_mixer already handles that; only asset loading would benefit from threading

https://claude.ai/code/session_01C19A4U3szhL28GHwSVTgEW