### PR TITLE
Fix shop quantity counter's tens-step axis (vertical, not horizontal)

### DIFF
--- a/changelog.d/rpg2k-shop-quantity-axis.fixed.md
+++ b/changelog.d/rpg2k-shop-quantity-axis.fixed.md
@@ -1,0 +1,7 @@
+- **The shop quantity counter's tens-step now moves on the vertical axis
+  instead of the horizontal one, matching real RPG_RT.** Confirmed against
+  EasyRPG Player's source: `Window_ShopNumber::Update` steps the count by one
+  on RIGHT/LEFT and by ten on UP/DOWN. The two axes were swapped in this
+  engine, so every quantity reachable with a given sequence of key presses —
+  and which key could reach a small stack's maximum in a single press —
+  differed from the real game.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5665,6 +5665,29 @@ not yet verified:
   the pre-fix code before the fix (`expected 72, got 52`; and, in a manual
   check with the `change_class` guard alone reverted, `expected 70, got
   170`, which also broke three pre-existing Change Class checks).
+- ✅ **The shop quantity counter's tens-step is on the vertical axis, not the
+  horizontal one.** Confirmed against EasyRPG's actual C++ source:
+  `Window_ShopNumber::Update` (`src/window_shopnumber.cpp`) moves the count
+  by one on RIGHT/LEFT and by ten on UP/DOWN (`number = min(number + 10,
+  item_max)` / `max(number - 10, 1)`), not the reverse. `Scene::Map`'s
+  `shop_quantity_move` had the two axes swapped — UP/DOWN stepped by one,
+  RIGHT/LEFT by `SHOP_QUANTITY_STEP` (10) — with a doc comment that
+  confidently, incorrectly, attributed the swapped mapping to RPG_RT itself.
+  A concrete divergence: opening the counter for a stack with room for 50
+  and pressing UP once landed on 2 in this engine but 11 in real RPG_RT;
+  pressing RIGHT once did the reverse (11 here, 2 there) — every quantity
+  players could reach with a given number of presses differed between the
+  two engines, and which key could reach a low max (say 5) in a single
+  press was inverted too. Fixed by swapping which axis increments/decrements
+  by one vs by `SHOP_QUANTITY_STEP` in `shop_quantity_move`
+  (`mruby-rpg2k/mrblib/scene/map.rb`), and correcting the two doc comments
+  that described the (wrong) horizontal-tens mapping as RPG_RT's own
+  behavior. Four existing `scripts/rpg2k_scene_check.rb` checks assumed the
+  old axis mapping and were rewritten to the corrected one (stepping by one
+  on RIGHT/LEFT, mirroring EasyRPG's own axis exactly, including the
+  buy/sell-a-stack-of-three checks that used to press UP twice and now press
+  RIGHT twice), all four confirmed to fail against the pre-fix code before
+  the fix.
 - ✅ **A variable's stored value now clamps to RPG_RT's ±999999 range**
   (RPG2000; RPG2003 widens it to ±9999999, per `LCF.var_min`/`var_max`) instead
   of overflowing. `Game::Variables#[]=` had no bound at all, so a Control

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -4259,9 +4259,10 @@ class RPG2k
         draw_shop
       end
 
-      # How far LEFT / RIGHT jump the quantity cursor — RPG_RT's shop counter
-      # moves in tens on the horizontal axis so a stack of 99 is a few presses
-      # away rather than ninety-nine.
+      # How far UP / DOWN jump the quantity cursor — RPG_RT's shop counter
+      # moves in tens on the vertical axis (confirmed against EasyRPG's
+      # Window_ShopNumber::Update, src/window_shopnumber.cpp) so a stack of 99
+      # is a few presses away rather than ninety-nine.
       SHOP_QUANTITY_STEP = 10
 
       # Picking an item opens the quantity counter rather than transacting one
@@ -4277,7 +4278,7 @@ class RPG2k
         draw_shop
       end
 
-      # Drive the quantity counter: UP / DOWN by one, RIGHT / LEFT by ten (both
+      # Drive the quantity counter: RIGHT / LEFT by one, UP / DOWN by ten (both
       # clamped to 1..max), C commits the whole stack in one transaction and B
       # goes back to the list having bought nothing.
       def drive_shop_quantity
@@ -4299,13 +4300,13 @@ class RPG2k
       # Apply one frame of quantity input; returns whether the count changed.
       def shop_quantity_move(q)
         before = q[:count]
-        if Input.trigger?(Input::UP)
+        if Input.trigger?(Input::RIGHT)
           q[:count] += 1
-        elsif Input.trigger?(Input::DOWN)
-          q[:count] -= 1
-        elsif Input.trigger?(Input::RIGHT)
-          q[:count] += SHOP_QUANTITY_STEP
         elsif Input.trigger?(Input::LEFT)
+          q[:count] -= 1
+        elsif Input.trigger?(Input::UP)
+          q[:count] += SHOP_QUANTITY_STEP
+        elsif Input.trigger?(Input::DOWN)
           q[:count] -= SHOP_QUANTITY_STEP
         else
           return false

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -5099,35 +5099,39 @@ check 'Open Shop scene: the quantity counter opens on a chosen good' do
   eq 5, shop[:quantity][:max], '500 gold buys five at 100'
 end
 
-check 'Open Shop scene: the counter steps by one and clamps to its bounds' do
+check 'Open Shop scene: the counter steps by one on the horizontal axis and ' \
+      'clamps to its bounds' do
   scene, _st = shop_quantity_scene(500)
   shop = scene.instance_variable_get(:@shop)
-  press(scene, RGSS::Input::UP)
+  press(scene, RGSS::Input::RIGHT)
   eq 2, shop[:quantity][:count]
-  press(scene, RGSS::Input::DOWN)
+  press(scene, RGSS::Input::LEFT)
   eq 1, shop[:quantity][:count]
-  press(scene, RGSS::Input::DOWN)
+  press(scene, RGSS::Input::LEFT)
   eq 1, shop[:quantity][:count], 'never below one'
-  5.times { press(scene, RGSS::Input::UP) }
+  5.times { press(scene, RGSS::Input::RIGHT) }
   eq 5, shop[:quantity][:count], 'never past what the party can afford'
 end
 
-check 'Open Shop scene: the counter steps by ten on the horizontal axis' do
+check 'Open Shop scene: the counter steps by ten on the vertical axis' do
+  # Confirmed against EasyRPG's Window_ShopNumber::Update
+  # (src/window_shopnumber.cpp): RIGHT/LEFT step by one, UP/DOWN by ten -- the
+  # tens step is vertical, not horizontal.
   scene, _st = shop_quantity_scene(999_999)
   shop = scene.instance_variable_get(:@shop)
   eq 99, shop[:quantity][:max], 'rich enough to hit the item cap'
-  press(scene, RGSS::Input::RIGHT)
+  press(scene, RGSS::Input::UP)
   eq 11, shop[:quantity][:count], '1 + 10'
-  press(scene, RGSS::Input::LEFT)
+  press(scene, RGSS::Input::DOWN)
   eq 1, shop[:quantity][:count]
-  20.times { press(scene, RGSS::Input::RIGHT) }
+  20.times { press(scene, RGSS::Input::UP) }
   eq 99, shop[:quantity][:count], 'clamped at the cap'
 end
 
 check 'Open Shop scene: confirming the counter buys the whole stack at once' do
   scene, st = shop_quantity_scene(500)
-  press(scene, RGSS::Input::UP)
-  press(scene, RGSS::Input::UP)   # three
+  press(scene, RGSS::Input::RIGHT)
+  press(scene, RGSS::Input::RIGHT)   # three
   press(scene, RGSS::Input::C)
   eq 200, st.party.gold, '500 - 3*100'
   eq 3, st.party.item_count(3), 'three bought in one confirm'
@@ -5140,7 +5144,7 @@ end
 
 check 'Open Shop scene: cancelling the counter buys nothing' do
   scene, st = shop_quantity_scene(500)
-  press(scene, RGSS::Input::UP)
+  press(scene, RGSS::Input::RIGHT)
   press(scene, RGSS::Input::B)
   eq 500, st.party.gold, 'no gold spent'
   eq 0, st.party.item_count(3)
@@ -5166,8 +5170,8 @@ check 'Open Shop scene: the counter sells a whole stack too' do
   eq :quantity, shop[:screen]
   eq :sell, shop[:quantity][:mode], 'selling, not buying'
   eq 5, shop[:quantity][:max], 'bounded by what is held'
-  press(scene, RGSS::Input::UP)
-  press(scene, RGSS::Input::UP)         # three
+  press(scene, RGSS::Input::RIGHT)
+  press(scene, RGSS::Input::RIGHT)      # three
   press(scene, RGSS::Input::C)
   eq 150, st.party.gold, '3 * half of 100'
   eq 2, st.party.item_count(3)


### PR DESCRIPTION
## Summary
- The shop quantity counter's tens-step is now on the vertical axis, not the horizontal one, matching real RPG_RT.
- Confirmed against EasyRPG Player's source: `Window_ShopNumber::Update` (`src/window_shopnumber.cpp`) moves the count by one on RIGHT/LEFT and by ten on UP/DOWN (`number = min(number + 10, item_max)` / `max(number - 10, 1)`), not the reverse.
- `Scene::Map#shop_quantity_move` (`mruby-rpg2k/mrblib/scene/map.rb`) had the two axes swapped — UP/DOWN stepped by one, RIGHT/LEFT by `SHOP_QUANTITY_STEP` (10) — with a doc comment that confidently, incorrectly, attributed the swapped mapping to RPG_RT itself.
- Concrete divergence: opening the counter for a stack with room for 50 and pressing UP once landed on 2 in this engine but 11 in real RPG_RT; pressing RIGHT once did the reverse. Every quantity reachable with a given sequence of key presses differed between the two engines, and which key could reach a small stack's maximum in a single press was inverted too.
- Fixed by swapping which axis increments/decrements by one vs by `SHOP_QUANTITY_STEP`, and correcting the two doc comments that described the wrong horizontal-tens mapping as RPG_RT's own behavior.

## Test plan
- [x] Four existing `scripts/rpg2k_scene_check.rb` checks assumed the old (swapped) axis mapping and were rewritten to the corrected one, all four confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_scene_check.rb` — 585 checks passed
- [x] `ruby scripts/rpg2k_logic_check.rb` — 861 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 128 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_