### PR TITLE
Decode RPG2003's Battler Animation table (database chunk 0x20)

### DIFF
--- a/changelog.d/rpg2003-battleranimation-decode.added.md
+++ b/changelog.d/rpg2003-battleranimation-decode.added.md
@@ -1,0 +1,12 @@
+- **Decoded RPG2003's Battler Animation table (database chunk 0x20)**, the
+  named set of up to 12 poses (idle, attack, dead, defend, walk, victory, …) an
+  actor's battle sprite can show. `@db.battleranimations` now reads back each
+  entry's `speed` and its `poses` (id-keyed by the fixed Pose enum, one entry
+  per pose) with `name`/`battler_name`/`battler_index`/`animation_type`/
+  `battle_animation_id`; `player.battler_animation` and `job.battler_animation`
+  are ids into this table. This corrects an earlier wiki-derived transcription
+  (`battle_anime2`/`base_data`/`attack_motion`/`extension`) that had several
+  field names and one default wrong, verified against liblcf's own chunk
+  tables instead. This is foundational only — nothing reads the table or
+  renders an actor sprite yet, so no game behavior changes. Covered by new
+  checks in `mruby-lcf/test/lcf_test.rb`.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -110,7 +110,7 @@ module LCF
             57 => { name: :class_id, type: :int, default: 0 },               # 職業ID (2003)
             59 => { name: :battle_x, type: :int, default: 0 },               # 手動配置X (2003)
             60 => { name: :battle_y, type: :int, default: 0 },               # 手動配置Y (2003)
-            62 => { name: :battler_animation, type: :int, default: 0 },      # 戦闘アニメ (2003)
+            62 => { name: :battler_animation, type: :int, default: 0 },      # id into chunk 32's battleranimations (2003)
             63 => { name: :skills, type: :Array2D, elements: LEARNING },     # 習得する特殊技能
             66 => { name: :custom_battle_command, type: :bool, default: false }, # 独自戦闘コマンド有効 (2000)
             67 => { name: :custom_battle_command_name, type: :string },      # 独自戦闘コマンド名称 (2000)
@@ -789,7 +789,7 @@ module LCF
             41 => { name: :exp_basic, type: :int, default: -> { LCF.exp_default } },
             42 => { name: :exp_increase, type: :int, default: -> { LCF.exp_default } },
             43 => { name: :exp_correction, type: :int, default: 0 },
-            62 => { name: :battler_animation, type: :int, default: 1 },
+            62 => { name: :battler_animation, type: :int, default: 1 },      # id into chunk 32's battleranimations
             63 => { name: :skills, type: :Array2D, elements: LEARNING },
             71 => { name: :state_ranks_size, type: :int, default: 0 },
             72 => { name: :state_ranks, type: :int8_array },
@@ -799,26 +799,45 @@ module LCF
           }
         },
         32 => {
+          # RPG2003's database-wide "Battler Animation" table (0x20 on
+          # liblcf's ChunkDatabase, `rpg::BattlerAnimation`) -- a named set of
+          # up to 12 poses an actor's battle sprite can show, one entry per
+          # Pose (lcf::rpg::BattlerAnimation::Pose): 0 idle, 1 attack right, 2
+          # attack left, 3 skill, 4 dead, 5 damage, 6 dazed, 7 defend, 8 walk
+          # left, 9 walk right, 10 victory, 11 item. `player.battler_animation`
+          # (chunk 11 field 62) and `job.battler_animation` (chunk 30 field
+          # 62) hold ids into this table -- 1-based, matching every other
+          # database table id in this format. This entry used to be
+          # transcribed from the VIPRPG wiki's "戦闘アニメ２" page under the
+          # name `battle_anime2` with several field names guessed wrong
+          # (confirmed against liblcf's own generator/csv/fields.csv and
+          # generated/lcf/ldb/chunks.h instead): field 2 is `speed`, not
+          # `attack_motion`, and within each pose entry field 5 is
+          # `battle_animation_id` (an id into chunk 31's `battle_animation`
+          # table), not an unexplained `extension`.
+          #
           # https://wikiwiki.jp/viprpg-dev/200X%E5%85%B1%E9%80%9A/%E8%A7%A3%E6%9E%90%E3%81%BE%E3%81%A8%E3%82%81/%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9/%E6%88%A6%E9%97%98%E3%82%A2%E3%83%8B%E3%83%A1%EF%BC%92
-          name: :battle_anime2, type: :Array2D,
+          name: :battleranimations, type: :Array2D,
           elements: {
             1 => { name: :name, type: :string, default: '' },
-            2 => { name: :attack_motion, type: :int, default: 0 },     # 攻撃モーション (2003)
+            2 => { name: :speed, type: :int, default: 20 },
             10 => {
-              # 基本と拡張 — object list, 33 elements by default (2003).
-              name: :base_data, type: :Array2D,
+              # Id-keyed by Pose (see above), not a densely-packed list -- a
+              # given entry may define anywhere from 0 to 12 of the 12 poses.
+              name: :poses, type: :Array2D,
               elements: {
                 1 => { name: :name, type: :string, default: '' },
                 2 => { name: :battler_name, type: :string, default: '' },   # 戦闘(武器)グラフィック
-                3 => { name: :battler_position, type: :int, default: 0 },   # グラフィック/位置
-                # 戦闘アニメ. The wiki table's type/default cells are garbled
-                # (形式 "0" / 省略時 "空文字列"); it holds the battle-animation id.
-                4 => { name: :animation_id, type: :int, default: 0 },
-                5 => { name: :extension, type: :int, default: 1 },          # 拡張
+                3 => { name: :battler_index, type: :int, default: 0 },      # グラフィック/位置
+                # 0 character (a normal 4-direction charset sheet), 1 battle
+                # (a CBA-style battle sheet).
+                4 => { name: :animation_type, type: :int, default: 0 },
+                5 => { name: :battle_animation_id, type: :int, default: 1 },
               }
             },
             11 => {
-              # 武器 — object list, 33 elements by default (2003).
+              # Per-weapon pose overrides -- out of scope for now, not needed
+              # for base pose rendering; left as originally transcribed.
               name: :weapon_data, type: :Array2D,
               elements: {
                 1 => { name: :name, type: :string, default: '' },

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -245,22 +245,42 @@ assert "LCF::Database skill switch/occasion chunks (13, 16, 18, 19)" do
   assert_false db.skill[1].occasion_battle
 end
 
-assert "LCF::Database battle_anime2 attack motion and pose object lists (chunks 2, 10, 11)" do
-  base = lcf_array1d([lcf_str_field(1, "Swing"), lcf_str_field(2, "Sword"),
-                      lcf_int_field(3, 1), lcf_int_field(4, 6)])
+assert "LCF::Database battleranimations speed and weapon_data pose lists (chunk 32, fields 2, 11)" do
   weapon = lcf_array1d([lcf_str_field(1, "Blade"), lcf_str_field(2, "WpnGfx"),
                         lcf_int_field(3, 2)])
   anim = lcf_array1d([lcf_str_field(1, "Fighter"), lcf_int_field(2, 3),
-                      lcf_field(10, lcf_array2d([[1, base]])),
                       lcf_field(11, lcf_array2d([[1, weapon]]))])
   db = LCF::Database.new(lcf_file("LcfDataBase",
-    lcf_array1d([lcf_field(32, lcf_array2d([[1, anim]]))]))) # battle_anime2 = chunk 32
-  assert_equal "Fighter", db.battle_anime2[1].name
-  assert_equal 3, db.battle_anime2[1].attack_motion
-  b = db.battle_anime2[1].base_data[1]
-  assert_equal "Sword", b.battler_name
-  assert_equal 6, b.animation_id
-  assert_equal "WpnGfx", db.battle_anime2[1].weapon_data[1].battler_name
+    lcf_array1d([lcf_field(32, lcf_array2d([[1, anim]]))]))) # battleranimations = chunk 32
+  assert_equal "Fighter", db.battleranimations[1].name
+  assert_equal 3, db.battleranimations[1].speed
+  assert_equal "WpnGfx", db.battleranimations[1].weapon_data[1].battler_name
+end
+
+assert "LCF::Database battleranimations poses (chunk 32 field 10) round-trip, id-keyed by Pose" do
+  # `poses` is keyed by lcf::rpg::BattlerAnimation::Pose, not densely packed
+  # -- an entry may define anywhere from 0 to 12 of the 12 poses. Build one
+  # with only Idle (0) and Victory (10) present and confirm both resolve at
+  # their own Pose id while the gap (e.g. AttackRight, 1) stays absent.
+  idle = lcf_array1d([lcf_str_field(1, "Idle Pose"), lcf_str_field(2, "Hero"),
+                      lcf_int_field(3, 1), lcf_int_field(4, 1),
+                      lcf_int_field(5, 4)])
+  victory = lcf_array1d([lcf_str_field(2, "HeroWin"), lcf_int_field(4, 0),
+                         lcf_int_field(5, 7)])
+  anim = lcf_array1d([lcf_str_field(1, "Fighter"),
+                      lcf_field(10, lcf_array2d([[0, idle], [10, victory]]))])
+  db = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(32, lcf_array2d([[1, anim]]))])))
+  poses = db.battleranimations[1].poses
+  assert_equal "Idle Pose", poses[0].name
+  assert_equal "Hero", poses[0].battler_name
+  assert_equal 1, poses[0].battler_index
+  assert_equal 1, poses[0].animation_type
+  assert_equal 4, poses[0].battle_animation_id
+  assert_equal "HeroWin", poses[10].battler_name
+  assert_equal 0, poses[10].animation_type
+  assert_equal 7, poses[10].battle_animation_id
+  assert_nil poses[1]
 end
 
 assert "LCF decodes boolean chunks (1 byte 0/1)" do


### PR DESCRIPTION
## Summary

- Step 2 of the RPG2003 alternate-battle-screen initiative (step 1, #838, decoded `battlecommands.battle_type` + `Game::Party#alternate_battle_layout?`).
- Decodes liblcf's `ChunkDatabase::battleranimations` (0x20 / chunk 32) — a top-level table of named pose sets an actor's battle sprite can show, one entry per fixed `Pose` id (Idle, AttackRight, AttackLeft, Skill, Dead, Damage, Dazed, Defend, WalkLeft, WalkRight, Victory, Item). `player.battler_animation` (chunk 11 field 62) and `job.battler_animation` (chunk 30 field 62) already held ids into this table; nothing they pointed at existed in the schema before this change.
- Chunk 32 turned out not to be undecoded: it already existed in `schema.rb` as `battle_anime2`, transcribed from the VIPRPG wiki with a few field names (and one default) guessed wrong. This PR corrects and **renames it in place** rather than adding a second, colliding `32 =>` entry to the same schema hash — confirmed against liblcf's own `chunks.h`/`battleranimation.h` instead of the wiki page:
  - field 2 is `speed` (default `20`), not `attack_motion` (default `0`)
  - each pose's field 5 is `battle_animation_id` (an id into chunk 31's `battle_animation` table), not an unexplained `extension`
  - field 10 (`base_data` → `poses`) is `Array2D` keyed by the fixed `Pose` enum, not a densely-packed list — an entry may define anywhere from 0 to 12 of the 12 poses
  - `weapon_data` (field 11, a per-weapon pose override table) is left as originally transcribed — out of scope for base pose rendering
- **Schema-only**, like step 1: nothing reads `@db.battleranimations` yet and no actor sprite is rendered. This only makes it a working accessor for a follow-up PR.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 867 checks passed, unchanged
- [x] `ruby scripts/rpg2k_scene_check.rb` — 589 checks passed, unchanged
- [x] New checks in `mruby-lcf/test/lcf_test.rb` covering `battleranimations.speed`/`weapon_data` and a byte-level round-trip of `poses`, id-keyed by `Pose` (only Idle=0 and Victory=10 present, confirming the sparse-id shape and that a gap like AttackRight=1 stays absent)
- [x] `ctest -R mruby_test` (native build) — passed, exercising the new test through the real mruby VM
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds; `--rgss_effect_probe` under Xvfb still OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa3BRZcaMxhNCpDtg3pNqw


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa3BRZcaMxhNCpDtg3pNqw)_