### PR TITLE
Move canvas scaling from engine to browser page

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,12 @@
 - The page draws an **on-screen keypad** (D-pad plus OK/Cancel/Dash, the L/R
   shoulders and the A/X/Y/Z buttons) beneath the canvas, so the game is playable
   by touch or mouse without a physical keyboard; the keyboard keeps working too.
+- **Scaling is the page's job, not the engine's.** The canvas holds one pixel
+  per game pixel (320x240 for RPG2000/MV, 640x480 for XP) and the page sizes the
+  element in CSS — a whole-number zoom, shrunk to fit when the screen is too
+  narrow for 1:1, with `image-rendering: pixelated` to keep it crisp. The frame
+  is therefore presented 1:1 and the browser does the upscale, instead of the
+  software renderer stretching every frame into a doubled window.
 - CI publishes this page: pushes to `master` deploy it to **GitHub Pages**, and
   commenting `/preview` on a pull request builds that PR and posts a
   **Cloudflare Pages** preview URL back on it. See

--- a/README.md
+++ b/README.md
@@ -593,10 +593,11 @@
   by touch or mouse without a physical keyboard; the keyboard keeps working too.
 - **Scaling is the page's job, not the engine's.** The canvas holds one pixel
   per game pixel (320x240 for RPG2000/MV, 640x480 for XP) and the page sizes the
-  element in CSS — a whole-number zoom, shrunk to fit when the screen is too
-  narrow for 1:1, with `image-rendering: pixelated` to keep it crisp. The frame
-  is therefore presented 1:1 and the browser does the upscale, instead of the
-  software renderer stretching every frame into a doubled window.
+  element in CSS — the whole-number zoom the screen has room for (2x for a
+  320-wide game on a desktop), filling the width on a screen too narrow for it,
+  with `image-rendering: pixelated` to keep it crisp. The frame is therefore
+  presented 1:1 and the browser does the upscale, instead of the software
+  renderer stretching every frame into a doubled window.
 - CI publishes this page: pushes to `master` deploy it to **GitHub Pages**, and
   commenting `/preview` on a pull request builds that PR and posts a
   **Cloudflare Pages** preview URL back on it. See

--- a/changelog.d/wasm-css-canvas-zoom.changed.md
+++ b/changelog.d/wasm-css-canvas-zoom.changed.md
@@ -1,0 +1,10 @@
+- **In the browser** the game screen is now scaled up by the page rather than by
+  the engine. The canvas keeps the game's own resolution (320x240 for
+  RPG2000/MV, 640x480 for XP) and `src/shell.html` gives the element its
+  on-screen size in CSS — a whole-number zoom that shrinks to fit a narrow
+  screen, with `image-rendering: pixelated` for the same nearest-neighbour look.
+  LVGL's window zoom only enlarged the SDL window, so the software renderer
+  stretched every frame on the CPU and handed the canvas four times the pixels
+  at 2x; the browser now does that upscale instead. What the page shows is
+  unchanged, and SDL's pointer coordinates are now game pixels — which is what
+  the MV/MZ `TouchInput` bridge already assumed (`src/sdl_input.cxx`).

--- a/changelog.d/wasm-css-canvas-zoom.changed.md
+++ b/changelog.d/wasm-css-canvas-zoom.changed.md
@@ -1,10 +1,12 @@
 - **In the browser** the game screen is now scaled up by the page rather than by
   the engine. The canvas keeps the game's own resolution (320x240 for
   RPG2000/MV, 640x480 for XP) and `src/shell.html` gives the element its
-  on-screen size in CSS — a whole-number zoom that shrinks to fit a narrow
-  screen, with `image-rendering: pixelated` for the same nearest-neighbour look.
-  LVGL's window zoom only enlarged the SDL window, so the software renderer
-  stretched every frame on the CPU and handed the canvas four times the pixels
-  at 2x; the browser now does that upscale instead. What the page shows is
-  unchanged, and SDL's pointer coordinates are now game pixels — which is what
-  the MV/MZ `TouchInput` bridge already assumed (`src/sdl_input.cxx`).
+  on-screen size in CSS — the whole-number zoom the screen has room for, filling
+  the width when it is narrower than that, with `image-rendering: pixelated` for
+  the same nearest-neighbour look. LVGL's window zoom only enlarged the SDL
+  window, so the software renderer stretched every frame on the CPU and handed
+  the canvas four times the pixels at 2x; the browser now does that upscale
+  instead. The screen is the same size as before at every width that fits it,
+  and a screen too narrow for 1:1 now fits the viewport instead of overflowing
+  it. SDL's pointer coordinates are game pixels as a result — which is what the
+  MV/MZ `TouchInput` bridge already assumed (`src/sdl_input.cxx`).

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -781,14 +781,16 @@ extern "C" EMSCRIPTEN_KEEPALIVE int rpg_start_game(void) {
     // RPG Maker XP renders at 640x480. Native main() sizes the display from
     // --game_dir before creating it, but in the browser no project exists yet
     // at that point (the page's loader mounts one here, later), so the display
-    // was created at the 320x240 default and doubled. Resize it now, before the
-    // runtime builds any screen-sized object: with a 320x240 canvas the XP
-    // scenes draw off the edge -- the title's command window lands past the
-    // bottom and its centred text past the right (found by the browser check
-    // that ADR 0025 has since dropped; see docs/adr/0025).
+    // was created at the 320x240 default. Resize it now, before the runtime
+    // builds any screen-sized object: with a 320x240 canvas the XP scenes draw
+    // off the edge -- the title's command window lands past the bottom and its
+    // centred text past the right (found by the browser check that ADR 0025 has
+    // since dropped; see docs/adr/0025). The canvas follows the new resolution
+    // (LVGL resizes the SDL window on a resolution change) and the page
+    // rescales it from there; the browser display is never zoomed, see main()
+    // below.
     if (em_display) {
       lv_display_set_resolution(em_display.get(), RPGXP_WIDTH, RPGXP_HEIGHT);
-      lv_sdl_window_set_zoom(em_display.get(), 1.f);
       LOG(INFO) << "RPGXP: display sized to " << RPGXP_WIDTH << "x"
                 << RPGXP_HEIGHT;
     }
@@ -1147,9 +1149,21 @@ int main(int argc, char** argv) {
         [](lv_display_t*) { lv_sdl_quit(); });
     CHECK(display);
     lv_sdl_window_set_resizeable(display.get(), false);
-    // A 640x480 (XP) canvas is already large, so present it 1:1; the smaller
-    // 320x240 (RPG2000/MV) canvas is doubled to a comfortable window size.
+    // A 640x480 (XP) window is already large, so present it 1:1; the smaller
+    // 320x240 (RPG2000/MV) one is doubled to a comfortable size.
+    //
+    // Not in the browser: there the page does the zooming (src/shell.html sizes
+    // the canvas in CSS, with image-rendering: pixelated for the same
+    // nearest-neighbour look), so the display keeps lv_sdl_window's default 1:1
+    // and the canvas keeps the game's own resolution. LVGL's zoom only enlarges
+    // the SDL window, leaving the software renderer to stretch every frame on
+    // the CPU (lv_sdl_sw.c presents with SDL_RenderCopy into the zoom-sized
+    // window) and to hand the canvas four times the pixels at 2x -- work the
+    // browser does for free. It also keeps SDL's window pixels equal to game
+    // pixels, which is what the pointer bridge in src/sdl_input.cxx assumes.
+#ifndef __EMSCRIPTEN__
     lv_sdl_window_set_zoom(display.get(), FLAGS_width >= 640 ? 1.f : 2.f);
+#endif
     // SDL is initialised by lv_sdl_window_create above; install the keyboard
     // watch now so key events reach RGSS::Input.
     rgss_sdl_input_init();

--- a/src/shell.html
+++ b/src/shell.html
@@ -73,9 +73,12 @@
         background: #000;
         border: 1px solid var(--border);
         border-radius: 6px;
-        /* SDL sets the intrinsic pixel size; keep it crisp and never let it
-           overflow a small screen. touch-action:none keeps taps off the canvas
-           from scrolling the page. */
+        /* SDL sets the intrinsic pixel size -- one canvas pixel per game pixel,
+           since the browser display is never zoomed engine-side (src/main.cxx).
+           The zooming happens here: fitCanvas() below sets an explicit CSS size
+           and this keeps the upscale crisp, with max-width as the fallback that
+           already fits the canvas on a small screen before the script runs.
+           touch-action:none keeps taps off the canvas from scrolling the page. */
         image-rendering: pixelated;
         max-width: 100%;
         touch-action: none;
@@ -860,6 +863,56 @@
       });
 
       setStatus('Loading runtime…', 'busy');
+    </script>
+
+    <script type="text/javascript">
+      // The presentation zoom, done by the page instead of by the engine. SDL
+      // keeps the canvas at the game's own resolution (320x240 for RPG2000/MV,
+      // 640x480 for XP -- see src/main.cxx), so the frame is presented 1:1 and
+      // the browser, not the software renderer, does the upscale: the canvas
+      // element is given an explicit CSS size here and `image-rendering:
+      // pixelated` keeps the same nearest-neighbour look SDL_RenderCopy had.
+      (function () {
+        var canvas = document.getElementById('canvas');
+
+        // Until the runtime opens its window the canvas still reports the HTML
+        // default (300x150); that black placeholder is not a game screen, so
+        // leave it to the stylesheet.
+        function sized() {
+          return canvas.width > 0 && canvas.height > 0 &&
+                 !(canvas.width === 300 && canvas.height === 150);
+        }
+
+        // Mirrors the native window zoom in src/main.cxx: a 640-wide game is
+        // already large at 1:1, a 320-wide one is doubled.
+        function preferredZoom(width) { return width >= 640 ? 1 : 2; }
+
+        function fitCanvas() {
+          if (!sized()) return;
+          var w = canvas.width, h = canvas.height;
+          // Body padding is 16px a side (see the stylesheet above).
+          var avail = (document.documentElement.clientWidth || w) - 32;
+          var zoom = Math.min(preferredZoom(w), avail / w);
+          // Whole-number scales keep every game pixel the same size. Only a
+          // screen too narrow for 1:1 gets a fractional one, to fit the width.
+          if (zoom >= 1) zoom = Math.floor(zoom);
+          canvas.style.width = Math.round(w * zoom) + 'px';
+          canvas.style.height = Math.round(h * zoom) + 'px';
+        }
+
+        // The runtime sizes the canvas once the SDL window exists, and again
+        // when a loaded project's resolution differs from the default (an XP
+        // project arrives at 640x480 through the loader). SDL does that by
+        // writing the width/height attributes, which no longer changes the
+        // on-screen size now that the CSS size is set here -- so watch for it.
+        new MutationObserver(fitCanvas).observe(canvas, {
+          attributes: true,
+          attributeFilter: ['width', 'height']
+        });
+        window.addEventListener('resize', fitCanvas);
+        window.addEventListener('orientationchange', fitCanvas);
+        fitCanvas();
+      })();
     </script>
 
     <script type="text/javascript">

--- a/src/shell.html
+++ b/src/shell.html
@@ -73,6 +73,11 @@
         background: #000;
         border: 1px solid var(--border);
         border-radius: 6px;
+        /* The page-wide border-box rule would take the 1px border out of the
+           size fitCanvas() sets, leaving a fractional scale (638/320 instead of
+           2) that resamples every game pixel. This is the one element whose CSS
+           size has to be the pixel grid itself, so keep the border outside it. */
+        box-sizing: content-box;
         /* SDL sets the intrinsic pixel size -- one canvas pixel per game pixel,
            since the browser display is never zoomed engine-side (src/main.cxx).
            The zooming happens here: fitCanvas() below sets an explicit CSS size
@@ -890,12 +895,17 @@
         function fitCanvas() {
           if (!sized()) return;
           var w = canvas.width, h = canvas.height;
-          // Body padding is 16px a side (see the stylesheet above).
-          var avail = (document.documentElement.clientWidth || w) - 32;
+          // Body padding is 16px a side, and the canvas's own border sits
+          // outside the size set below (see the stylesheet above); both come off
+          // the width the game screen itself may use.
+          var frame = canvas.offsetWidth - canvas.clientWidth;
+          var avail = (document.documentElement.clientWidth || w) - 32 - frame;
+          // A screen with room for the whole-number zoom gets it, so every game
+          // pixel is the same size. A narrower one fills the width it has
+          // instead of dropping to the next whole number, which is what
+          // `max-width: 100%` did before and keeps the screen as large as the
+          // phone allows.
           var zoom = Math.min(preferredZoom(w), avail / w);
-          // Whole-number scales keep every game pixel the same size. Only a
-          // screen too narrow for 1:1 gets a fractional one, to fit the width.
-          if (zoom >= 1) zoom = Math.floor(zoom);
           canvas.style.width = Math.round(w * zoom) + 'px';
           canvas.style.height = Math.round(h * zoom) + 'px';
         }


### PR DESCRIPTION
## Summary
This change moves the responsibility for scaling the game canvas from the LVGL/SDL engine to the browser page. The canvas now maintains the game's native resolution (320x240 for RPG2000/MV, 640x480 for XP) and the HTML page handles all visual scaling via CSS, allowing the browser to perform the upscaling instead of the software renderer.

## Key Changes

- **src/shell.html**: Added a new `fitCanvas()` function that:
  - Sets explicit CSS dimensions on the canvas element based on available screen space
  - Applies whole-number zoom levels (preferring 2x for 320-wide games, 1x for 640-wide)
  - Shrinks to fit when the screen is too narrow for the preferred zoom
  - Watches for canvas dimension changes via MutationObserver and window resize/orientation events
  - Updated comments to explain the new scaling approach

- **src/main.cxx**: 
  - Removed `lv_sdl_window_set_zoom(2.f)` call in `rpg_start_game()` when resizing for XP projects
  - Wrapped the native `lv_sdl_window_set_zoom()` call in `#ifndef __EMSCRIPTEN__` to disable engine-side scaling only in the browser
  - Updated comments to clarify that browser builds use CSS scaling while native builds use LVGL zoom
  - Explained that keeping SDL window pixels equal to game pixels is required for the pointer bridge in `src/sdl_input.cxx`

- **README.md**: Added documentation explaining that scaling is now the page's responsibility, with details on how the CSS-based approach works

- **changelog.d/wasm-css-canvas-zoom.changed.md**: Added changelog entry describing the user-visible change

## Implementation Details

The new approach uses `image-rendering: pixelated` CSS property to maintain the crisp nearest-neighbour appearance that SDL's rendering had. The page calculates zoom based on:
1. Game resolution (320x240 vs 640x480)
2. Available screen width (accounting for 16px padding on each side)
3. Preference for whole-number scales when possible

This eliminates CPU-side frame stretching in the software renderer and reduces pixel data sent to the canvas by 4x at 2x zoom, while keeping the visual result identical.

https://claude.ai/code/session_01VFkJgWmsVU9N4yRBnzEbjH