### PR TITLE
Roll a random Agility jitter into battle turn order each round

### DIFF
--- a/changelog.d/rpg2k-battle-turn-order-agility-jitter.fixed.md
+++ b/changelog.d/rpg2k-battle-turn-order-agility-jitter.fixed.md
@@ -1,0 +1,10 @@
+- **Battle turn order now rolls a random Agility jitter each round, instead
+  of sorting purely by raw Agility.** Confirmed against EasyRPG Player's
+  source: `Scene_Battle_Rpg2k::CreateExecutionOrder` rolls `agi + Rand(0,
+  agi / 4 + 3)` fresh for every battler each round before sorting. This
+  engine sorted by raw Agility alone, with a fixed tie-break rule (ally
+  before enemy, then lower actor id) that doesn't exist in the real game —
+  RPG_RT resolves agility ties via the random roll instead, so two battlers
+  with equal Agility (a common case for a balanced fight) previously acted
+  in the exact same order every single round of every battle, rather than
+  either potentially going first as in the original game.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5761,6 +5761,41 @@ not yet verified:
   buy/sell-a-stack-of-three checks that used to press UP twice and now press
   RIGHT twice), all four confirmed to fail against the pre-fix code before
   the fix.
+- ✅ **Battle turn order now rolls a random Agility jitter each round, instead
+  of sorting purely by raw Agility.** Confirmed against EasyRPG's actual
+  `Scene_Battle_Rpg2k::CreateExecutionOrder` (`src/scene_battle_rpg2k.cpp`):
+  every battler rolls `agi + Rand(0, agi / 4 + 3)` fresh, once per round,
+  before the sort — its own comment notes this must happen *outside* the
+  sort comparator ("because of the strict weak ordering property, so the
+  sort is consistent"), which this port follows too. `Game::Battle#turn_order`
+  instead sorted `(@allies + @enemies)` purely by `-effective_agi`, with an
+  explicit tie-break tuple (ally before enemy, then lower actor id, then
+  troop order) that its own doc comment incorrectly attributed to
+  `CreateExecutionOrder` — real RPG_RT has no such fixed tie-break at all; it
+  resolves agility ties (and near-ties) via the random roll instead. The
+  practical effect: two battlers with equal Agility — a common case for a
+  balanced encounter — acted in the exact same relative order in literally
+  every round of literally every battle (the ally always first), when real
+  RPG_RT lets either go first, independently, each round. Fixed by rolling
+  `agi + rng.random(agi / 4 + 4)` (the `+4` compensating for `#random`'s
+  exclusive upper bound against `Rand::GetRandomNumber`'s inclusive one) for
+  every non-out-of-play battler before sorting, adding the existing 9999
+  preemptive-weapon boost on top same as before, and keeping the old
+  ally/actor-id/troop-order tuple only as a deterministic fallback for the
+  now-rare case where two rolled totals still tie exactly (not because it's
+  RPG_RT's own rule — it isn't — but so the same inputs still reproduce the
+  same output for testing). Built with `[battler, roll]` pairs rather than a
+  `Hash` keyed by battler, since `Combatant` is a `Struct` whose `#hash`/
+  `#eql?` compare field values, not identity — two battlers that happen to
+  share identical stats (same-type enemies) would otherwise collide as one
+  Hash key. Covered by a new `scripts/rpg2k_logic_check.rb` check pinning
+  two battlers tied on raw Agility landing in opposite orders under two
+  different forced rolls, confirmed to fail against the pre-fix code before
+  the fix (it always produced the ally-first order regardless of the RNG
+  sequence supplied); two existing checks that happened to rely on an exact
+  agility tie resolving deterministically were switched from a real (if
+  seeded) RNG to `FixedRng.new(0)`, which zeroes the jitter term and
+  restores the pure-Agility ordering they actually mean to exercise.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -8550,27 +8550,45 @@ module Game
       @queue = @queue.reject { |b| side_of(b) == :enemy } if @first_strike && @rounds == 1
     end
 
-    # Battlers ordered by agility (highest first) -- except a battler whose
-    # round is about to be a basic Attack with a `preemptive` weapon equipped
-    # sorts before everyone else (EasyRPG's `CreateExecutionOrder` adding
-    # 9999 to such a battler's computed order, which in practice always
-    # outruns ordinary agility). Ties between two preemptive battlers still
-    # fall back to agility. On an agility tie, an ally always acts before an
-    # enemy (whether `Combatant#actor` is set ranks 0 below an unset one's 1,
-    # independent of either's magnitude, rather than relying on array
-    # position happening to list every ally before every enemy); among tied
-    # allies specifically, the
-    # **lower actor id** acts first -- not party seat/join order, which can
-    # diverge from id order once a member has left and rejoined in a
-    # different slot (`Game::Party#add_actor` appends to `@actors` in join
-    # order, not id order -- see the "seat order" note on `Party#actors`).
-    # An enemy tie has no documented ordering rule, so it keeps its troop
-    # (definition) order via `i`, same as before.
+    # Battlers ordered by a per-round randomised Agility roll (highest first)
+    # -- except a battler whose round is about to be a basic Attack with a
+    # `preemptive` weapon equipped sorts before everyone else (EasyRPG's
+    # `CreateExecutionOrder`, src/scene_battle_rpg2k.cpp, adding 9999 to such
+    # a battler's computed order, which in practice always outruns ordinary
+    # agility). Confirmed against that same function: real RPG_RT does not
+    # sort by raw Agility at all -- each battler rolls `agi +
+    # Rand(0, agi/4 + 3)` fresh at the start of the round (computed once per
+    # battler *before* sorting, exactly like here, "because of the strict
+    # weak ordering property" its own comment gives, not re-rolled per
+    # comparison), so two battlers with equal Agility do not act in a fixed
+    # order round after round -- either may go first, independently each
+    # round. The previous version sorted purely by `effective_agi` with no
+    # randomisation at all, making an agility tie between an ally and an
+    # enemy resolve the same way in literally every round of literally every
+    # battle, a divergence from real RPG_RT's roll on any encounter with
+    # matched Agility (a common case for a balanced fight).
+    #
+    # EasyRPG's own comparator has no documented rule for what happens when
+    # the *rolled* orders still tie (a `std::sort` over unspecified relative
+    # order); this port keeps its own deterministic fallback for that now-rare
+    # case -- an ally before an enemy, then the lower actor id, then troop
+    # (definition) order -- purely so the same input reproduces the same
+    # output for testing, not because it's meant to mirror any specific
+    # undocumented C++ sort behaviour.
     def turn_order
-      (@allies + @enemies).reject(&:out_of_play?).each_with_index
-                          .sort_by { |b, i| [preemptive_boost?(b) ? 0 : 1, -effective_agi(b),
-                                              b.actor ? 0 : 1, b.actor ? b.actor.id : i] }
-                          .map { |b, _| b }
+      # [battler, rolled_order] pairs, not a Hash keyed by battler --
+      # Combatant is a Struct, whose #hash/#eql? compare field *values*, so
+      # two battlers that happen to share identical stats (a common case for
+      # same-type enemies) would collide as one Hash key instead of two.
+      rolled = (@allies + @enemies).reject(&:out_of_play?).map do |b|
+        agi = effective_agi(b)
+        roll = agi + @rng.random(agi / 4 + 4)
+        roll += 9999 if preemptive_boost?(b)
+        [b, roll]
+      end
+      rolled.each_with_index
+            .sort_by { |(b, roll), i| [-roll, b.actor ? 0 : 1, b.actor ? b.actor.id : i] }
+            .map { |(b, _roll), _i| b }
     end
 
     # Whether `b`'s action this round earns the `preemptive` weapon's

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9587,7 +9587,11 @@ check 'Battle#step_action walks a round one attack at a time for animation' do
   bee = combatant('Bee', 40, 0, 15, 100)
   s1 = combatant('S1', 4, 0, 5, 100)
   s2 = combatant('S2', 4, 0, 5, 100)
-  bat = Game::Battle.new([ace, bee], [s1, s2], Game::Rng.new(1))
+  # A fixed roll of 0 makes #turn_order's new per-round Agility jitter a
+  # no-op (roll == agi exactly), so this test's own point -- #step_action
+  # walking a round one attack at a time -- stays deterministic without
+  # depending on which way a real jitter roll happens to break the S1/S2 tie.
+  bat = Game::Battle.new([ace, bee], [s1, s2], FixedRng.new(0))
   bat.command_attack(ace, s1)
   bat.command_attack(bee, s2)
   bat.begin_round
@@ -10892,16 +10896,41 @@ FakeActorRef = Struct.new(:id)
 check 'battle: an agility tie among allies breaks by actor id, not seat order' do
   # Actor id 2 sits in the party's first seat, actor id 1 in the second --
   # mirrors a party where a lower-id member left and rejoined behind a
-  # higher-id one, so seat order and id order genuinely disagree.
+  # higher-id one, so seat order and id order genuinely disagree. A fixed
+  # roll of 0 makes every battler's rolled order equal its raw Agility (all
+  # three tie at exactly 10), exercising #turn_order's own deterministic
+  # fallback for a tied roll rather than depending on which way a real
+  # jitter roll happens to break it.
   b = combatant('B', 0, 0, 10, 100)
   b.actor = FakeActorRef.new(2)
   a = combatant('A', 0, 0, 10, 100)
   a.actor = FakeActorRef.new(1)
   foe = combatant('Foe', 0, 0, 10, 100) # also agi 10, but has no #actor at all
-  bat = Game::Battle.new([b, a], [foe], Game::Rng.new(1))
+  bat = Game::Battle.new([b, a], [foe], FixedRng.new(0))
   eq [a, b, foe], bat.send(:turn_order),
      "actor id 1 acts before id 2 despite sitting in the later seat; both allies " \
      'still act before the equally-fast foe'
+end
+
+check 'battle: turn order rolls a random Agility jitter each round, instead of ' \
+      'sorting by raw Agility alone' do
+  # Confirmed against EasyRPG's own Scene_Battle_Rpg2k::CreateExecutionOrder
+  # (src/scene_battle_rpg2k.cpp): each battler rolls `agi + Rand(0, agi / 4 +
+  # 3)` fresh, once per round, before the sort ("must be done outside of the
+  # sort function... so the sort is consistent", per that function's own
+  # comment) -- two battlers with identical Agility do not act in a fixed
+  # order round after round the way a plain descending sort by raw Agility
+  # would produce. Agi 20 -> Rand(0, 20/4+3) = Rand(0, 8).
+  ally = combatant('Ally', 0, 0, 20, 100)
+  foe = combatant('Foe', 0, 0, 20, 100)   # same agi -- the old code always put the ally first
+  # SequenceRng hands out rolls in call order: the ally's roll is drawn
+  # first (turn_order walks @allies then @enemies), the foe's second.
+  hi = Game::Battle.new([ally], [foe], SequenceRng.new([8, 0])) # ally 20+8=28, foe 20+0=20
+  eq [ally, foe], hi.send(:turn_order)
+  lo = Game::Battle.new([ally], [foe], SequenceRng.new([0, 8])) # ally 20+0=20, foe 20+8=28
+  eq [foe, ally], lo.send(:turn_order),
+     "the foe's higher roll wins despite tied raw Agility -- a reordering the " \
+     'old, jitter-free sort could never produce'
 end
 
 check 'battle: a self-destruct also reads state-adjusted ATK / DEF' do


### PR DESCRIPTION
## Summary
- Battle turn order now rolls a random Agility jitter each round, instead of sorting purely by raw Agility.
- Confirmed against EasyRPG Player's actual C++ source: `Scene_Battle_Rpg2k::CreateExecutionOrder` (`src/scene_battle_rpg2k.cpp`) rolls `agi + Rand(0, agi / 4 + 3)` fresh for every battler each round, before the sort — its own comment notes this must happen *outside* the sort comparator ("because of the strict weak ordering property, so the sort is consistent").
- `Game::Battle#turn_order` instead sorted `(@allies + @enemies)` purely by `-effective_agi`, with an explicit tie-break tuple (ally before enemy, then lower actor id, then troop order) that its own doc comment incorrectly attributed to `CreateExecutionOrder` — real RPG_RT has no such fixed tie-break; it resolves agility ties (and near-ties) via the random roll instead.
- Practical effect: two battlers with equal Agility — a common case for a balanced encounter — acted in the exact same relative order in literally every round of literally every battle (the ally always first), when real RPG_RT lets either go first, independently, each round.
- Fixed by rolling `agi + rng.random(agi / 4 + 4)` (the `+4` compensating for `#random`'s exclusive upper bound against `Rand::GetRandomNumber`'s inclusive one) for every non-out-of-play battler before sorting, keeping the existing 9999 preemptive-weapon boost on top, and keeping the old ally/actor-id/troop-order tuple only as a deterministic fallback for the now-rare case where two rolled totals still tie exactly.
- Built with `[battler, roll]` pairs rather than a `Hash` keyed by battler, since `Combatant` is a `Struct` whose `#hash`/`#eql?` compare field values, not identity — two battlers that happen to share identical stats (same-type enemies) would otherwise collide as one Hash key.

## Test plan
- [x] New check pinning two battlers tied on raw Agility landing in opposite orders under two different forced rolls, confirmed to fail against the pre-fix code before the fix (it always produced the ally-first order regardless of the RNG sequence supplied)
- [x] Two existing checks that happened to rely on an exact agility tie resolving deterministically were switched from a seeded RNG to `FixedRng.new(0)`, which zeroes the jitter term and restores the pure-Agility ordering they actually mean to exercise
- [x] `ruby scripts/rpg2k_logic_check.rb` — 868 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 590 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_