### PR TITLE
Draw living party members as Idle-pose sprites in RPG2003's alternate battle layout

### DIFF
--- a/changelog.d/rpg2003-actor-battle-sprite-idle.added.md
+++ b/changelog.d/rpg2003-actor-battle-sprite-idle.added.md
@@ -1,0 +1,22 @@
+- **RPG2003's alternative/gauge battle layouts now draw each living party
+  member as an Idle-pose sprite**, alongside the existing status window
+  (which keeps showing HP/SP/party info exactly as before). Sourced from the
+  database's Battler Animation table (`@db.battleranimations`, decoded in a
+  prior change): the actor's resolved pose-set id (`Game::Actor
+  #battler_animation_id`, mirroring EasyRPG's `Game_Actor::
+  GetBattleAnimationId` fallback chain — a runtime override from an actual
+  Change Class event, else the current class's own default, else the
+  actor's own database default) supplies the Idle pose (Pose id 0), whose
+  `battler_name`/`battler_index` frame a `BattleCharSet/<name>` sheet in
+  fixed 48x48 cells. Position is the actor's raw database `battle_x`/
+  `battle_y` (chunk 11 fields 59/60), used literally.
+  Scoped to the plain Idle pose only: no active state, not defending (pose
+  transitions are follow-up work), and only the `animation_type == 0`
+  (character/BattleCharSet) pose format — a pose using `animation_type == 1`
+  (a full battle-animation/CBA sheet) or `battlecommands.placement ==
+  automatic` (a grid-formula position this runtime does not compute) logs a
+  `[RPG2k]` diagnostic and falls back instead of guessing, the same
+  "reported gap, not silently invented" convention this codebase uses
+  throughout. A traditional-layout (RPG2000) database draws no actor
+  sprites, unchanged. Covered by new checks in `mruby-lcf/test/lcf_test.rb`,
+  `scripts/rpg2k_logic_check.rb` and `scripts/rpg2k_scene_check.rb`.

--- a/mruby-lcf/mrblib/schema.rb
+++ b/mruby-lcf/mrblib/schema.rb
@@ -759,6 +759,15 @@ module LCF
           # by the caller instead.
           name: :battlecommands, type: :Array1D,
           elements: {
+            # Where a living party member's battle sprite is positioned in the
+            # alternative/gauge layouts (BattleCommands::Placement in liblcf):
+            # 0 manual (the actor's own database `battle_x`/`battle_y`, see
+            # chunk 11 fields 59/60), 1 automatic (a grid formula keyed by
+            # party size/index and the encounter's terrain -- EasyRPG's
+            # `CalculateBaseGridPosition`, `src/game_battle.cpp` -- not yet
+            # implemented here). Confirmed against liblcf's own
+            # generator/csv/fields.csv (0x02) and enums.csv, not guessed.
+            2 => { name: :placement, type: :int, default: 0 },
             # RPG2003's battle-screen presentation choice (BattleType in
             # liblcf): 0 traditional (RPG2000-style status window only), 1
             # alternative (actor sprites), 2 gauge (actor sprites + HP/SP

--- a/mruby-lcf/test/lcf_test.rb
+++ b/mruby-lcf/test/lcf_test.rb
@@ -164,6 +164,23 @@ assert "LCF::Database battle-commands table decodes battle_type (chunk 29 field 
   assert_equal 0, db2.battlecommands.battle_type
 end
 
+assert "LCF::Database battle-commands table decodes placement (chunk 29 field 2)" do
+  # Where a living party member's battle sprite sits in the alternative/gauge
+  # layouts -- 0 manual (the actor's own database battle_x/battle_y), 1
+  # automatic (a grid formula, not yet implemented in mruby-rpg2k). A
+  # database that never sets field 2 (every RPG2000 file, and most RPG2003
+  # ones too) defaults to 0/manual.
+  automatic = lcf_array1d([lcf_int_field(2, 1)])
+  db = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(29, automatic)])))
+  assert_equal 1, db.battlecommands.placement
+
+  bare = lcf_array1d([lcf_field(10, lcf_array2d([]))])
+  db2 = LCF::Database.new(lcf_file("LcfDataBase",
+    lcf_array1d([lcf_field(29, bare)])))
+  assert_equal 0, db2.battlecommands.placement
+end
+
 assert "LCF::Array1D#key? distinguishes an absent chunk from a present one" do
   row = LCF::Array1D.new(lcf_array1d([lcf_int_field(1, 5), lcf_int_field(3, 0)]),
                          { elements: { 1 => { name: :a, type: :int },

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1329,6 +1329,16 @@ module Game
       @transparent = a.respond_to?(:semi_transparent) ? (a.semi_transparent ? true : false) : false
       @db_row = a
       set_class_id(a.respond_to?(:class_id) ? (a.class_id || 0) : 0)
+      # The runtime battler-animation override and whether a Change Class
+      # event has actually run this session -- see #battler_animation_id.
+      # Both start unset even when the database gives this actor a starting
+      # class (chunk 11 field 57): EasyRPG's own comment on this is explicit
+      # ("The class settings are not applied when the actor has a class on
+      # startup but only when the 'Change Class' event command is used",
+      # `Game_Actor::ChangeClass`, src/game_actor.cpp), and #battler_animation_id
+      # mirrors it by keying on this flag rather than on `@class_id > 0` alone.
+      @battler_animation_override = 0
+      @class_changed = false
       @battle_commands = nil # lazily taken from the database on the first change
       @battle_combo = nil
       @exp = 0
@@ -2324,6 +2334,13 @@ module Game
       old_skills = @skills.dup
 
       set_class_id(class_id)
+      # Mirrors EasyRPG's `data.battler_animation = cls->battler_animation`
+      # (class found) / `= 0` (class removed) inside `ChangeClass` itself --
+      # see #battler_animation_id, and the comment on the ivars in #initialize
+      # for why this is a separate flag from `@class_id`.
+      @class_changed = true
+      @battler_animation_override =
+        @class_row && @class_row.respond_to?(:battler_animation) ? (@class_row.battler_animation || 0) : 0
       # preserve_mod: false -- Change Class always zeroes the Change
       # Parameters mod shadow before applying the new class's own curve
       # (EasyRPG's ChangeClass zeroes attack_mod et al. unconditionally,
@@ -2453,6 +2470,57 @@ module Game
     # #rename_skill? is set.
     def skill_command_name
       @db_row.respond_to?(:custom_battle_command_name) ? (@db_row.custom_battle_command_name || '') : ''
+    end
+
+    # RPG2003's manual battle-sprite position (chunk 11 fields 59/60,
+    # `Game_Actor::GetOriginalPosition` -- `{dbActor->battle_x, dbActor->
+    # battle_y}` directly, no scaling), used as literal screen coordinates by
+    # the alternative/gauge battle layouts. 0 (the database default) for
+    # every RPG2000 row and any RPG2003 one that never set these.
+    def battle_x
+      @db_row.respond_to?(:battle_x) ? (@db_row.battle_x || 0) : 0
+    end
+
+    def battle_y
+      @db_row.respond_to?(:battle_y) ? (@db_row.battle_y || 0) : 0
+    end
+
+    # The `db.battleranimations` (chunk 32) id this actor's battle sprite
+    # draws its poses from -- EasyRPG's `Game_Actor::GetBattleAnimationId`
+    # (`src/game_actor.cpp`; the name is misleading, it resolves a *pose set*
+    # id, not the id of a single animation). Fallback chain, in order:
+    #
+    # 1. `@battler_animation_override` (mirrors `data.battler_animation`) when
+    #    positive -- set only by a Change Class event that actually ran this
+    #    session (see #change_class), never by a database-default starting
+    #    class.
+    # 2. The current class's own `battler_animation` (chunk 30 field 62) when
+    #    Change Class did run and left the actor in a real class.
+    # 3. This actor's own database default (chunk 11 field 62), looked up as
+    #    an id into `db.battleranimations` -- warns and returns 0 (no sprite
+    #    data at all) if that id names no entry, matching EasyRPG's own
+    #    `Output::Warning` + early return there.
+    #
+    # A resolved id of 0 (the chunk was never written) falls back to
+    # battleranimations id 1, matching `GetBattleAnimationId`'s own final
+    # "chunk was missing, set to proper default" step.
+    def battler_animation_id
+      return @battler_animation_override if @battler_animation_override && @battler_animation_override > 0
+
+      anim =
+        if @class_changed && @class_id > 0 && @class_row
+          @class_row.respond_to?(:battler_animation) ? (@class_row.battler_animation || 0) : 0
+        else
+          bid = @db_row.respond_to?(:battler_animation) ? (@db_row.battler_animation || 0) : 0
+          table = @db.respond_to?(:battleranimations) ? @db.battleranimations : nil
+          entry = table ? table[bid] : nil
+          unless entry
+            $stderr.puts "[RPG2k] actor ##{@id}: invalid battle animation id #{bid}, no sprite drawn"
+            return 0
+          end
+          bid
+        end
+      anim == 0 ? 1 : anim
     end
 
     private
@@ -3001,6 +3069,21 @@ module Game
       return false unless @db.respond_to?(:battlecommands)
       table = @db.battlecommands
       table && table.battle_type != 0 ? true : false
+    end
+
+    # RPG2003's battle-sprite placement choice (`battlecommands.placement`,
+    # chunk 29 field 2 -- 0 manual, 1 automatic; see schema.rb). Manual is
+    # `Game::Actor#battle_x`/`#battle_y` read as literal screen coordinates;
+    # automatic computes a grid formula this runtime does not implement yet
+    # (see the alternate-battle-sprite renderer in scene/map.rb), so callers
+    # use this to know when to fall back to the raw coordinates and log a
+    # diagnostic instead of guessing at the formula. A bare test fixture with
+    # no `#battlecommands` table, or an RPG2000 database (which never sets
+    # this field), reads false/manual, same as `#alternate_battle_layout?`.
+    def automatic_battle_placement?
+      return false unless @db.respond_to?(:battlecommands)
+      table = @db.battlecommands
+      table && table.respond_to?(:placement) && table.placement == 1 ? true : false
     end
 
     # Whether item `id` can be used from the field (main-menu) item screen: a

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -98,6 +98,7 @@ class RPG2k
         @backdrop_cache = {}  # Backdrop/<name> (battle background)
         @monster_cache = {}   # Monster/<name> (battler graphics)
         @animation_cache = {} # Battle/<name> (battle animation sheets)
+        @battlecharset_cache = {} # BattleCharSet/<name> (RPG2003 actor battler sprites)
         apply_map_access if apply_access
         # Same Continue-only split as #apply_map_access just above: a fresh
         # map entry (New Game, or any Transfer Player/Teleport, which
@@ -832,7 +833,7 @@ class RPG2k
       # redrawn every frame -- and without this they would hit the decoder
       # again on every request. `cache` is the material's own hash (one of
       # @charset_cache, @picture_cache, @backdrop_cache, @monster_cache,
-      # @animation_cache), so a name is only ever looked up among graphics of
+      # @animation_cache, @battlecharset_cache), so a name is only ever looked up among graphics of
       # its own kind. The block's result is cached as-is, including a
       # nil/fallback for a failed load, so the caller's own rescue logs the
       # error once and every later call reuses that outcome instead of
@@ -4493,6 +4494,7 @@ class RPG2k
         # for a fight it opened itself (see `owner` above).
         @battle_ui[:events].resolver = owner.resolver
         build_battle_sprites
+        build_actor_sprites
         refresh_battle_status
         # RPG_RT's own `Scene_Battle_Rpg2k::ProcessSceneActionStart`
         # (EasyRPG Player's `src/scene_battle_rpg2k.cpp`) narrates the
@@ -4668,6 +4670,132 @@ class RPG2k
         @battle_ui[:sprite_names] = @battle_ui[:foes].map { |f| f.battler_name }
         @battle_ui[:sprite_hues] = @battle_ui[:foes].map { |f| f.battler_hue || 0 }
         refresh_battle_sprites
+      end
+
+      # RPG2003's alternative/gauge battle layouts draw each living party
+      # member as a sprite too (unlike RPG2000's status-window-only layout --
+      # see Game::Party#alternate_battle_layout?), sourced from the
+      # database's Battler Animation table (chunk 32, db.battleranimations --
+      # decoded in a prior change, nothing read it until now). Scoped to the
+      # plain Idle pose only (Pose id 0): no active state, not defending --
+      # EasyRPG's Sprite_Actor::DoIdleAnimation (src/sprite_actor.cpp) swaps
+      # in a Defend or state-mapped pose in those two cases, which is
+      # follow-up work for a later change, not this one. A dead party member
+      # gets no sprite (mirrors a hidden troop member never getting one
+      # either in #build_battle_sprites above); the party status window keeps
+      # showing everyone regardless, so a member left spriteless here (dead,
+      # or any of the gaps #build_actor_sprite itself documents) is never
+      # invisible to the player. A traditional-layout database (or a bare
+      # test fixture whose party doesn't even answer #alternate_battle_layout?)
+      # builds nothing, matching current behaviour exactly.
+      def build_actor_sprites
+        @battle_ui[:actor_sprites] = nil
+        return unless @state.party.respond_to?(:alternate_battle_layout?) &&
+                      @state.party.alternate_battle_layout?
+        @battle_ui[:actor_sprites] = @battle_ui[:allies].each_with_index.map do |ally, i|
+          next nil if ally.dead?
+          build_actor_sprite(ally.actor, i)
+        end
+      end
+
+      # Idle pose id within a `db.battleranimations` entry's `poses` table
+      # (lcf::rpg::BattlerAnimation::Pose_Idle -- schema.rb's own comment on
+      # chunk 32 lists the full 12-pose order).
+      ACTOR_IDLE_POSE = 0
+      # `poses[id].animation_type` values: 0 a BattleCharSet sprite sheet
+      # (implemented below), 1 a full Battle/<name> (CBA) animation sequence
+      # played in place of a static sprite (not implemented here -- see
+      # #build_actor_sprite).
+      ACTOR_POSE_TYPE_BATTLE = 1
+      # A BattleCharSet sheet is framed in fixed 48x48 cells, one row per
+      # `battler_index` (EasyRPG's Sprite_Actor::OnBattlercharsetReady --
+      # `SetSrcRect(Rect(0, battler_index * 48, 48, 48))`).
+      ACTOR_CHARSET_CELL = 48
+      # Clear of both the enemy troop's own z range (#battler_z's 100 +
+      # troop_size-1 span) and the animation overlay's z 150, so an actor
+      # sprite never fights either for draw order; still well below every UI
+      # window (z >= 300).
+      def actor_sprite_z(i)
+        200 + i
+      end
+
+      # A living party member's Idle-pose sprite, or nil when this step
+      # cannot draw one: `actor.battler_animation_id` names no
+      # `db.battleranimations` entry (Game::Actor#battler_animation_id
+      # already logs that diagnostic itself), the resolved entry defines no
+      # Idle pose at all (silent -- an entry legitimately covering only some
+      # of the 12 poses is normal authoring, not a dangling reference), or
+      # the pose uses the `animation_type == 1` battle/CBA format this step
+      # does not implement (logged below, matching this codebase's "reported
+      # gap, not silently invented" convention for unimplemented behaviour).
+      #
+      # Position is the raw database `battle_x`/`battle_y`
+      # (Game_Actor::GetOriginalPosition) -- confirmed against EasyRPG's
+      # actual C++ source this is only what `battlecommands.placement`
+      # manual (0) uses; automatic (1) instead computes a real grid formula
+      # (`CalculateBaseGridPosition`, src/game_battle.cpp) this step does not
+      # implement either, so that case also just logs and falls back to the
+      # same raw coordinates rather than guessing at the formula.
+      def build_actor_sprite(actor, i)
+        anim_id = actor.respond_to?(:battler_animation_id) ? (actor.battler_animation_id || 0) : 0
+        table = db.respond_to?(:battleranimations) ? db.battleranimations : nil
+        entry = (table && anim_id > 0) ? table[anim_id] : nil
+        return nil unless entry
+        pose = entry.respond_to?(:poses) && entry.poses ? entry.poses[ACTOR_IDLE_POSE] : nil
+        return nil unless pose
+
+        if pose.animation_type == ACTOR_POSE_TYPE_BATTLE
+          $stderr.puts "[RPG2k] actor ##{actor.id}: idle pose uses a battle-animation (CBA) " \
+                       "sheet, not a BattleCharSet -- not yet implemented, sprite not drawn"
+          return nil
+        end
+
+        bmp = actor_battlecharset_bitmap(pose.battler_name)
+        return nil unless bmp
+
+        if @state.party.respond_to?(:automatic_battle_placement?) &&
+           @state.party.automatic_battle_placement?
+          $stderr.puts "[RPG2k] actor ##{actor.id}: automatic battler placement not yet " \
+                       "implemented, using the database's manual battle_x/battle_y"
+        end
+
+        spr = Sprite.new
+        spr.bitmap = bmp
+        spr.src_rect = Rect.new(0, (pose.battler_index || 0) * ACTOR_CHARSET_CELL,
+                                ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL)
+        spr.x = actor.respond_to?(:battle_x) ? (actor.battle_x || 0) : 0
+        spr.y = actor.respond_to?(:battle_y) ? (actor.battle_y || 0) : 0
+        spr.z = actor_sprite_z(i)
+        spr
+      end
+
+      # The BattleCharSet bitmap for an actor pose's `battler_name`, cached
+      # like every other named battle graphic (see #cached_bitmap) and
+      # colour-keyed the same way CharSet/Monster are. A missing/empty name
+      # or a failed load draws the same solid placeholder block
+      # #battler_bitmap falls back to for a missing enemy graphic (see
+      # #placeholder_battler), sized to one BattleCharSet cell so the
+      # src_rect crop in #build_actor_sprite still makes sense against it.
+      def actor_battlecharset_bitmap(name)
+        key = (name && !name.empty?) ? name : nil
+        cached_bitmap(@battlecharset_cache, key) do
+          if key
+            begin
+              Bitmap.new("BattleCharSet/#{name}", true)
+            rescue StandardError => e
+              $stderr.puts "[RPG2k] actor battler '#{name}' load failed: #{e.message}"
+              actor_placeholder_battler
+            end
+          else
+            actor_placeholder_battler
+          end
+        end
+      end
+
+      def actor_placeholder_battler
+        bmp = Bitmap.new(ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL)
+        bmp.fill_rect 0, 0, ACTOR_CHARSET_CELL, ACTOR_CHARSET_CELL, Color.new(180, 60, 60, 255)
+        bmp
       end
 
       # Where a battle-event page's message panel sits — above the action banner,
@@ -6900,6 +7028,7 @@ class RPG2k
          @battle_ui[:event_win]].each { |w| w.dispose if w }
         dispose_battle_sprite(@battle_ui[:back_sprite])
         (@battle_ui[:enemy_sprites] || []).each { |s| dispose_battle_sprite(s) }
+        (@battle_ui[:actor_sprites] || []).each { |s| dispose_battle_sprite(s) }
         @battle_ui = nil
       end
 

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -2893,7 +2893,15 @@ FakePlayerRow = Struct.new(:name, :charset_name, :charset_index,
                            :unarmed_animation,
                            # 強制AI -- Actor#force_ai?. Same reasoning: appended
                            # last, defaults nil (never AI-controlled).
-                           :force_ai)
+                           :force_ai,
+                           # RPG2003's manual battle-sprite position (chunk 11
+                           # fields 59/60, Actor#battle_x/#battle_y) and the
+                           # actor's own database-default battle animation id
+                           # (field 62, into db.battleranimations --
+                           # Actor#battler_animation_id's "else" branch).
+                           # Same reasoning: appended last, nil reads as 0 via
+                           # the reader methods, matching the schema default.
+                           :battle_x, :battle_y, :battler_animation)
 # Like FakePlayerRow but exposing the full growth curve the way a real LCF row
 # does (six shorts per level via #int16_values(31)), so Actor scales its base
 # stats by level instead of using a single level-independent status hash.
@@ -3124,9 +3132,15 @@ end
 # table, EXP curve and battle-command list, exposed the way a real LCF row is.
 class JobRow
   attr_reader :name, :skills, :battle_commands,
-              :exp_basic, :exp_increase, :exp_correction
+              :exp_basic, :exp_increase, :exp_correction,
+              # The class's own default battle animation id (chunk 30 field
+              # 62, into db.battleranimations) -- Actor#battler_animation_id's
+              # "Change Class actually ran" branch. Defaults to 1, the schema
+              # default for this field.
+              :battler_animation
   def initialize(name, curve, learns = [], battle_commands = nil,
-                 exp_basic: 30, exp_increase: 30, exp_correction: 0)
+                 exp_basic: 30, exp_increase: 30, exp_correction: 0,
+                 battler_animation: 1)
     @name = name
     @curve = curve
     @skills = FakeLearnTable.new(learns)
@@ -3134,6 +3148,7 @@ class JobRow
     @exp_basic = exp_basic
     @exp_increase = exp_increase
     @exp_correction = exp_correction
+    @battler_animation = battler_animation
   end
 
   def int16_values(idx); idx == 31 ? @curve : nil; end
@@ -3152,13 +3167,17 @@ end
 
 class FakeActorDB
   attr_reader :player, :system, :item, :skill, :job, :situation, :property, :battlecommands,
-              :enemy_group
+              :enemy_group, :battleranimations
   # `enemy_group` defaults to "every id exists" (Hash.new(true)) since most
   # checks using this fixture have nothing to do with troop validity; pass an
   # explicit hash (e.g. {}) to exercise the missing-troop-id diagnostic path.
+  # `battleranimations` mirrors `db.battleranimations` (chunk 32, id ->
+  # FakeBattlerAnimation) -- nil (the default, same as a genuine RPG2000
+  # database that never carries the chunk) for every check that doesn't need
+  # Actor#battler_animation_id's resolved id to name a real entry.
   def initialize(players, party_ids, items = {}, skills = {}, jobs = {}, situation = nil,
                  property = nil, rpg2003: false, battlecommands: nil,
-                 enemy_group: Hash.new(true))
+                 enemy_group: Hash.new(true), battleranimations: nil)
     @player = players
     @system = FakeActorSystem.new(party_ids)
     @item = items
@@ -3169,6 +3188,7 @@ class FakeActorDB
     @rpg2003 = rpg2003
     @battlecommands = battlecommands
     @enemy_group = enemy_group
+    @battleranimations = battleranimations
   end
 
   # Mirrors LCF::Schema::Database#rpg2003? (Classes-chunk presence) for tests
@@ -3182,8 +3202,25 @@ end
 # `#commands[id]` decode to: an object with `#commands` (id -> entry), a
 # `#battle_type` (chunk 29 field 7, Game::Party#alternate_battle_layout?'s own
 # source), and an entry with `#name` + `#type`.
-FakeBattleCommandsTable = Struct.new(:commands, :battle_type)
+FakeBattleCommandsTable = Struct.new(:commands, :battle_type,
+                                     # RPG2003's battle-sprite placement
+                                     # choice (chunk 29 field 2 -- 0 manual, 1
+                                     # automatic; Game::Party#
+                                     # automatic_battle_placement?'s own
+                                     # source). Appended last, same reasoning
+                                     # as everywhere else in this file: nil
+                                     # reads as manual, matching the schema
+                                     # default.
+                                     :placement)
 FakeBattleCommand = Struct.new(:name, :type)
+# A `db.battleranimations[id]` entry (chunk 32): a name plus a poses hash
+# keyed by Pose id (0 idle, matching schema.rb's own comment on the chunk).
+FakeBattlerAnimation = Struct.new(:name, :speed, :poses)
+# A single `poses[id]` row: `animation_type` 0 is a BattleCharSet sheet
+# (`battler_name`/`battler_index` frame it), 1 a Battle/<name> (CBA)
+# animation sequence.
+FakeBattlerAnimationPose = Struct.new(:name, :battler_name, :battler_index,
+                                      :animation_type, :battle_animation_id)
 
 def party_state(enemy_group: Hash.new(true))
   players = {
@@ -4267,6 +4304,116 @@ check 'Game::Party#alternate_battle_layout? reads chunk 29 field 7 (BattleType)'
                            battlecommands: FakeBattleCommandsTable.new({}, 2))
   eq true, Game::Party.new(gauge).alternate_battle_layout?,
      'BattleType_gauge (2) -> alternate layout'
+end
+
+check 'Game::Party#automatic_battle_placement? reads chunk 29 field 2 (Placement)' do
+  eq false, party_state.party.automatic_battle_placement?,
+     'no Battle Commands table at all -> manual (the schema default)'
+
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+
+  manual = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                           battlecommands: FakeBattleCommandsTable.new({}, 1, 0))
+  eq false, Game::Party.new(manual).automatic_battle_placement?, 'Placement_manual (0)'
+
+  automatic = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                              battlecommands: FakeBattleCommandsTable.new({}, 1, 1))
+  eq true, Game::Party.new(automatic).automatic_battle_placement?, 'Placement_automatic (1)'
+end
+
+check "Game::Actor#battle_x/#battle_y read chunk 11 fields 59/60, defaulting to 0" do
+  a = party_state.party.actor_by_id(1) # the plain fixture never sets either
+  eq 0, a.battle_x
+  eq 0, a.battle_y
+
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  players[1].battle_x = 88
+  players[1].battle_y = 132
+  st = Game::State.new(Game::Party.new(FakeActorDB.new(players, [1])), 1, 0, 0)
+  a2 = st.party.actor_by_id(1)
+  eq 88, a2.battle_x
+  eq 132, a2.battle_y
+end
+
+# Game::Actor#battler_animation_id (EasyRPG's misleadingly-named
+# GetBattleAnimationId) -- the db.battleranimations id an actor's alternate-
+# layout battle sprite draws its poses from. Fallback chain verified against
+# EasyRPG's actual C++ source (src/game_actor.cpp): the runtime override
+# (set only by an actual Change Class event) when positive; else the current
+# class's own battler_animation when Change Class actually ran; else the
+# actor's own database default, looked up as an id into db.battleranimations.
+check "Game::Actor#battler_animation_id resolves the actor's own database default" do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  players[1].battler_animation = 3
+  anims = { 3 => FakeBattlerAnimation.new('Fighter', 20, {}) }
+  db = FakeActorDB.new(players, [1], battleranimations: anims)
+  a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
+  eq 3, a.battler_animation_id
+end
+
+check "Game::Actor#battler_animation_id warns and returns 0 for an unset (0) database default, " \
+      'even with a real battleranimations table present' do
+  # battler_animation 0 means "chunk never written"; id 0 names no entry in
+  # any real table (every id here is 1-based, "matching every other database
+  # table id in this format" -- schema.rb's own comment), so this behaves
+  # exactly like any other dangling id: warn and return 0. The "resolved id 0
+  # -> battleranimations id 1" fallback only ever fires from the class-changed
+  # branch (see the two checks below) -- confirmed against EasyRPG's actual
+  # C++ source, whose db-default branch returns 0 immediately on a failed
+  # `ReaderUtil::GetElement` lookup, never reaching its own tail "anim == 0"
+  # check at all.
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  anims = { 1 => FakeBattlerAnimation.new('Default', 20, {}) }
+  db = FakeActorDB.new(players, [1], battleranimations: anims)
+  a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
+  out = capture_stderr { eq 0, a.battler_animation_id }
+  ok out.include?('[RPG2k]'), 'the unset default is reported, not silently invented'
+end
+
+check "Game::Actor#battler_animation_id warns and returns 0 for a dangling database default id" do
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+  players[1].battler_animation = 9 # no such entry below
+  anims = { 3 => FakeBattlerAnimation.new('Fighter', 20, {}) }
+  db = FakeActorDB.new(players, [1], battleranimations: anims)
+  a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
+  out = capture_stderr { eq 0, a.battler_animation_id }
+  ok out.include?('[RPG2k]') && out.include?('9'), 'the dangling id is reported, not silently invented'
+end
+
+check "Game::Actor#battler_animation_id prefers the runtime override a Change Class event set" do
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 0) }
+  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [], nil, battler_animation: 4) }
+  db = FakeActorDB.new(players, [1], {}, {}, jobs)
+  a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
+  a.change_class(1, 1, Game::Actor::CLASS_SKILL_NO_CHANGE, Game::Actor::CLASS_PARAM_NO_CHANGE)
+  eq 4, a.battler_animation_id, "the class's battler_animation, copied into the runtime " \
+                                'override the moment Change Class ran'
+end
+
+check "Game::Actor#battler_animation_id ignores a database-default starting class -- only an " \
+      'actual Change Class event counts' do
+  # RPG2003 lets an actor start in a class (chunk 11 field 57) with no Change
+  # Class event ever firing -- EasyRPG's own comment on this is explicit
+  # ("not applied ... only when the 'Change Class' event command is used").
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 1) }
+  players[1].battler_animation = 3
+  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [], nil, battler_animation: 4) }
+  anims = { 3 => FakeBattlerAnimation.new('Fighter', 20, {}) }
+  db = FakeActorDB.new(players, [1], {}, {}, jobs, nil, nil, battleranimations: anims)
+  a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
+  eq 1, a.class_id, "the starting class is live (Actor#class_id reads it back)"
+  eq 3, a.battler_animation_id, "yet the actor's own database default wins -- the class's " \
+                                '(4) is never consulted without a real Change Class event'
+end
+
+check "Game::Actor#battler_animation_id falls back to 1 when Change Class leaves the actor " \
+      'in a class whose own battler_animation is 0' do
+  players = { 1 => ClassedRow.new('Hero', '', 0, 5, [100, 30, 10, 8, 6, 4] * 20, [], 0) }
+  jobs = { 1 => JobRow.new('Warrior', [120, 40, 12, 10, 8, 6] * 20, [], nil, battler_animation: 0) }
+  db = FakeActorDB.new(players, [1], {}, {}, jobs)
+  a = Game::State.new(Game::Party.new(db), 1, 0, 0).party.actor_by_id(1)
+  a.change_class(1, 1, Game::Actor::CLASS_SKILL_NO_CHANGE, Game::Actor::CLASS_PARAM_NO_CHANGE)
+  eq 1, a.battler_animation_id, 'a resolved id of 0 always falls back to battleranimations id 1'
 end
 
 check 'Change HP command damages a fixed actor' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -122,7 +122,7 @@ module RGSS
   Tone = Struct.new(:red, :green, :blue, :gray)
 
   class Sprite
-    attr_accessor :bitmap, :x, :y, :z, :visible, :opacity
+    attr_accessor :bitmap, :x, :y, :z, :visible, :opacity, :src_rect
     # Which viewport the sprite was built in, so the tone checks can assert that
     # the map layers share one and the overlays do not.
     attr_reader :viewport
@@ -323,7 +323,8 @@ end
 
 def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
             airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
-            rpg2003: false, menu_commands: nil, footstep: '', on_damage_se: false)
+            rpg2003: false, menu_commands: nil, footstep: '', on_damage_se: false,
+            battleranimations: nil)
   OpenStruct.new(
     rpg2003?: rpg2003,
     system: OpenStruct.new(system_graphic: '', title: 'TitleGraphic',
@@ -527,8 +528,30 @@ def fake_db(common = nil, troop_pages = nil, terrain_damage = 0, bush_depth = 0,
     # use once the actor has been renamed in play (see the \N[n] check).
     player: { 1 => OpenStruct.new(name: 'DbHero'),
               2 => OpenStruct.new(name: 'DbAlly'),
-              3 => OpenStruct.new(name: 'DbStranger') }
+              3 => OpenStruct.new(name: 'DbStranger') },
+    # RPG2003's Battler Animation table (chunk 32, db.battleranimations) --
+    # nil (the default, an RPG2000 database never carries chunk 32) unless a
+    # check passes its own id => entry hash (#battle_pose, #battle_pose_set
+    # below build the shape #build_actor_sprite reads).
+    battleranimations: battleranimations
   )
+end
+
+# A `db.battleranimations[id]` entry: a name, plus a poses hash keyed by
+# Pose id (0 idle, matching schema.rb's own comment on chunk 32) -- pass
+# `poses: { 0 => battle_pose(...) }` for the common one-pose case.
+def battle_pose_set(name: 'Fighter', poses: {})
+  OpenStruct.new(name: name, speed: 20, poses: poses)
+end
+
+# A single `poses[id]` row: `animation_type` 0 is a BattleCharSet sheet
+# (`battler_name`/`battler_index` frame it), 1 a Battle/<name> (CBA)
+# animation sequence (#build_actor_sprite does not implement this format --
+# see the diagnostic check below).
+def battle_pose(name: 'Idle', battler_name: 'Hero', battler_index: 0,
+                animation_type: 0, battle_animation_id: 1)
+  OpenStruct.new(name: name, battler_name: battler_name, battler_index: battler_index,
+                animation_type: animation_type, battle_animation_id: battle_animation_id)
 end
 
 # An event command (the interpreter reads code/param/string/indent/parameters).
@@ -724,11 +747,12 @@ def new_scene(events, player: [0, 0], common: nil, parallax: nil, troop_pages: n
               members: [], terrain_damage: 0, bush_depth: 0,
               airship_land: true, airship_pass: true, boat_pass: false, ship_pass: false,
               map_tree: nil, test_play: false, rpg2003: false,
-              footstep: '', on_damage_se: false)
+              footstep: '', on_damage_se: false, battleranimations: nil)
   db = fake_db(common, troop_pages, terrain_damage, bush_depth,
                airship_land: airship_land, airship_pass: airship_pass,
                boat_pass: boat_pass, ship_pass: ship_pass, rpg2003: rpg2003,
-               footstep: footstep, on_damage_se: on_damage_se)
+               footstep: footstep, on_damage_se: on_damage_se,
+               battleranimations: battleranimations)
   state = Game::State.new(fake_party(members, rpg2003: rpg2003), 1, player[0], player[1])
   state.map = fake_map(1, events, parallax: parallax)
   parent = fake_parent(db)
@@ -2180,10 +2204,19 @@ class BattleStubActor
   # check predating #battle_result_lines's own level-up/skill-learned lines
   # (mirrors Game::Actor's real growth curve/learn table only as far as a
   # single EXP-threshold level-up needs, not the full RPG2000 curve).
+  # `battler_animation_id`/`battle_x`/`battle_y` mirror Game::Actor's own
+  # RPG2003 alternate-battle-sprite interface (#build_actor_sprite,
+  # Scene::Map): the pre-resolved `db.battleranimations` id to draw from (nil
+  # -- the default -- reads as 0/"no sprite data", the same answer a bare
+  # actor with no battler_animation at all gives) and the raw manual-mode
+  # screen position. The full id-resolution fallback chain itself
+  # (Game::Actor#battler_animation_id) is exercised directly against a real
+  # Game::Actor in scripts/rpg2k_logic_check.rb, not re-derived here.
   def initialize(atk: 40, dfn: 20, agi: 20, hp: 200, mp: 20, int: 20, skills: [], id: 1,
                  rename_skill: false, skill_name: '', states: [], force_ai: false,
                  battle_commands: nil, battle_command_table: {},
-                 level: 1, level_up_at: nil, learn_table: [])
+                 level: 1, level_up_at: nil, learn_table: [],
+                 battler_animation_id: nil, battle_x: 0, battle_y: 0)
     @exp = 0; @id = id; @name = 'Hero'
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
     @mp = mp; @max_mp = mp; @int = int; @skills = skills
@@ -2192,7 +2225,10 @@ class BattleStubActor
     @battle_commands = battle_commands
     @battle_command_table = battle_command_table
     @level = level; @level_up_at = level_up_at; @learn_table = learn_table
+    @battler_animation_id = battler_animation_id
+    @battle_x = battle_x; @battle_y = battle_y
   end
+  attr_reader :battler_animation_id, :battle_x, :battle_y
   # Mirrors Game::Actor's own RPG2003 battle-command-customization interface
   # (`#battle_commands` / `#battle_command_row`), so a stub battle can drive
   # `Scene::Map#custom_battle_commands` the same way a real actor row would.
@@ -2246,8 +2282,15 @@ class BattleStubParty
   # checks drive an already-opening or already-open battle, not the
   # missing-troop-id diagnostic path (covered in scripts/rpg2k_logic_check.rb),
   # so an Enemy Encounter command's real troop id should never be rejected here.
+  # `alternate_layout`/`automatic_placement` mirror Game::Party's own RPG2003
+  # battle-screen-presentation reads (#alternate_battle_layout?/
+  # #automatic_battle_placement?, both keyed off `db.battlecommands` there) --
+  # false by default, matching every other check's plain RPG2000 fixture and
+  # (for `respond_to?` gating) every check predating the alternate-battle-
+  # sprite renderer, which never set either.
   def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil, skill_db: nil,
-                 enemy_group: Hash.new(true))
+                 enemy_group: Hash.new(true), alternate_layout: false,
+                 automatic_placement: false)
     @actors = [actor]
     @gold = 0
     @leader = nil
@@ -2256,11 +2299,15 @@ class BattleStubParty
     @item_db = item_db
     @skill_db = skill_db
     @enemy_group = enemy_group
+    @alternate_layout = alternate_layout
+    @automatic_placement = automatic_placement
   end
   def gain_gold(n); @gold += n; end
   def any_alive?; @actors.any? { |a| !a.dead? }; end
   def all_dead?; !any_alive?; end
   def rpg2003?; @rpg2003; end
+  def alternate_battle_layout?; @alternate_layout; end
+  def automatic_battle_placement?; @automatic_placement; end
   # A troop victory drop (Game::Troop#drops -> Scene::Map#battle_result_lines)
   # both grants the item and names it in the result window -- mirrors
   # ShopStubParty's own #gain_item, plus a #db_item lookup against whatever
@@ -8947,6 +8994,95 @@ check 'Enemy Encounter scene: draws a battler sprite per enemy, hidden on death'
 
   battle_attack_to_end(scene) # both Slimes fall
   ok sprites.all? { |s| !s.visible }, 'a defeated enemy sprite is hidden'
+end
+
+# RPG2003's alternative/gauge battle layouts (Game::Party#
+# alternate_battle_layout?) draw each living party member as a sprite too,
+# on top of the existing party status window -- unlike RPG2000's
+# status-window-only layout, which draws none. Scoped to the plain Idle pose
+# (character/BattleCharSet format) only; see #build_actor_sprite
+# (mruby-rpg2k/mrblib/scene/map.rb) for the other three checks covering its
+# documented gaps.
+check 'Enemy Encounter scene: the alternative/gauge layout draws a positioned Idle-pose sprite per living party member' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose(battler_name: 'Hero', battler_index: 2) }) }
+  scene = new_scene({ 1 => event(2, 2, auto) }, battleranimations: anims)
+  st = scene.instance_variable_get(:@state)
+  hero = BattleStubActor.new(id: 1, battler_animation_id: 5, battle_x: 40, battle_y: 120)
+  st.instance_variable_set(:@party, BattleStubParty.new(hero, alternate_layout: true))
+  ui = battle_to_command(scene)
+
+  sprites = ui[:actor_sprites]
+  ok sprites, 'built when the layout is alternative/gauge'
+  eq 1, sprites.compact.length, 'one sprite for the sole living party member'
+  spr = sprites[0]
+  eq 40, spr.x, "the actor's raw database battle_x, used literally"
+  eq 120, spr.y, "the actor's raw database battle_y, used literally"
+  eq RGSS::Rect.new(0, 96, 48, 48), spr.src_rect,
+     'cell battler_index 2 of the 48x48-framed BattleCharSet sheet'
+  ok spr.z < 300, 'sits below the UI windows (z >= 300)'
+end
+
+check 'Enemy Encounter scene: the traditional (RPG2000) layout draws no actor sprites' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) })
+  st = scene.instance_variable_get(:@state)
+  st.instance_variable_set(:@party, BattleStubParty.new) # alternate_layout: false, the default
+  ui = battle_to_command(scene)
+  eq nil, ui[:actor_sprites], 'no actor-sprite layer at all, matching current (pre-change) behaviour'
+end
+
+# Out of scope for this step: the pose's `animation_type == 1` (a full
+# Battle/<name> CBA animation sequence in place of a static sprite). Logs a
+# diagnostic and draws nothing rather than guessing at animation playback --
+# this codebase's established "reported gap, not silently invented"
+# convention.
+check 'Enemy Encounter scene: an Idle pose using the battle-animation (CBA) format logs a diagnostic and draws no sprite' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose(animation_type: 1) }) }
+  scene = new_scene({ 1 => event(2, 2, auto) }, battleranimations: anims)
+  st = scene.instance_variable_get(:@state)
+  hero = BattleStubActor.new(id: 1, battler_animation_id: 5)
+  st.instance_variable_set(:@party, BattleStubParty.new(hero, alternate_layout: true))
+  ui = nil
+  out = capture_stderr { ui = battle_to_command(scene) }
+  eq [nil], ui[:actor_sprites], 'no sprite drawn for the unimplemented CBA pose format'
+  ok out.include?('[RPG2k]'), 'the gap is reported, not silently invented'
+end
+
+# A dangling/missing battle-animation reference must never crash or change
+# behaviour, the same convention every other database lookup in this
+# codebase follows (see #battler_bitmap's own missing-graphic handling) --
+# covers both a database with no Battler Animation table at all, and one
+# whose table simply does not define the id the actor names.
+check 'Enemy Encounter scene: an actor with no resolvable battle animation entry draws no sprite and does not crash' do
+  ic = Game::Interpreter::Cmd
+  auto = page(trigger: 3)
+  auto.event_commands = battle_event_commands(ic)
+  scene = new_scene({ 1 => event(2, 2, auto) }) # no battleranimations table at all
+  st = scene.instance_variable_get(:@state)
+  hero = BattleStubActor.new(id: 1) # battler_animation_id left unresolved (nil)
+  st.instance_variable_set(:@party, BattleStubParty.new(hero, alternate_layout: true))
+  ui = battle_to_command(scene)
+  ok ui, 'the battle still reaches the command phase without raising'
+  eq [nil], ui[:actor_sprites], 'no sprite for an actor with no battle animation data at all'
+
+  anims = { 5 => battle_pose_set(poses: { 0 => battle_pose }) }
+  auto2 = page(trigger: 3)
+  auto2.event_commands = battle_event_commands(ic)
+  scene2 = new_scene({ 1 => event(2, 2, auto2) }, battleranimations: anims)
+  st2 = scene2.instance_variable_get(:@state)
+  hero2 = BattleStubActor.new(id: 1, battler_animation_id: 99) # names no entry in `anims`
+  st2.instance_variable_set(:@party, BattleStubParty.new(hero2, alternate_layout: true))
+  ui2 = battle_to_command(scene2)
+  ok ui2, 'a dangling id reaches the command phase without raising too'
+  eq [nil], ui2[:actor_sprites], 'no sprite for a battle animation id the table does not define'
 end
 
 # The "Appear Transparent" flag (field 10, `Game::Enemy#transparent`) was


### PR DESCRIPTION
## Summary

Step 3 of the RPG2003 alternate-battle-screen initiative (step 1: #838, step 2: #847) — the first *visual* change. When `battlecommands.battle_type` selects the alternative/gauge battle layout (`Game::Party#alternate_battle_layout?`), each living party member now draws as a positioned Idle-pose sprite, alongside the existing party status window (unchanged).

- **`Game::Actor#battler_animation_id`** resolves which `db.battleranimations` entry an actor's pose set comes from, mirroring EasyRPG's `Game_Actor::GetBattleAnimationId` (`src/game_actor.cpp`) fallback chain exactly:
  1. a runtime override set only by an actual Change Class event this session (never by a database-default starting class — verified against EasyRPG's own comment: *"The class settings are not applied when the actor has a class on startup but only when the 'Change Class' event command is used"*),
  2. else the current class's own `battler_animation` when Change Class did run,
  3. else the actor's own database default, looked up in `db.battleranimations` (warns and returns 0 for a dangling id, matching `Output::Warning` there).
- **`Game::Actor#battle_x`/`#battle_y`** expose the raw manual-mode position (chunk 11 fields 59/60), used literally as screen coordinates (`Game_Actor::GetOriginalPosition`).
- **`Scene::Map#build_actor_sprite`** (mirroring the existing `#build_battle_sprites` enemy path) resolves the Idle pose (Pose id 0) from that entry, and for the `animation_type == 0` (character/BattleCharSet) format loads `BattleCharSet/<name>` framed in 48x48 cells by `battler_index`.
- **Decoded `battlecommands.placement`** (chunk 29 field 2 — confirmed against liblcf's `fields.csv`/`enums.csv`, not guessed) so the renderer can tell manual from automatic placement.

**Explicitly out of scope, logged with a `[RPG2k]` diagnostic and a graceful fallback instead of guessing** (this codebase's "reported gap, not silently invented" convention):
- Defending/state-driven pose swaps (`Sprite_Actor::DoIdleAnimation`'s two non-idle branches) — scoped to the plain Idle pose only, follow-up work for a later step.
- `animation_type == 1` (a full Battle/CBA animation sequence in place of a static sprite) — draws nothing rather than guessing at animation playback.
- `battlecommands.placement == automatic` — EasyRPG computes a real grid formula here (`CalculateBaseGridPosition`, `src/game_battle.cpp`); this step falls back to the raw `battle_x`/`battle_y` instead of inventing one.

A dangling/missing battle-animation reference (no override, no matching table entry, no Idle pose defined) never crashes and simply draws no sprite — the party status window still shows that member's HP/name regardless.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 875 checks pass (new: `battler_animation_id`'s full fallback chain including the class-changed/database-default/dangling-id/anim-0-fallback branches, `battle_x`/`battle_y`, `automatic_battle_placement?`).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 594 checks pass (new: alternate layout draws a positioned sprite; traditional layout draws none; `animation_type == 1` logs and draws nothing; a dangling/missing battle-animation reference draws nothing without crashing).
- [x] `mruby-lcf/test/lcf_test.rb` (via `ctest -R mruby_test`) — passes, including the new `battlecommands.placement` decode check.
- [x] Native build (`cmake --build build -t rpg_maker_clone`) succeeds.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-added-large-files) passes on the changed files.

## Scoping note for a later step

While verifying EasyRPG's manual-placement source, its own comment notes the RPG2003 gauge layout can visually replace the status window with HP/SP gauges rather than just adding sprites on top of it. This PR deliberately keeps the existing status window untouched per the assigned scope; whether/how to add gauge-mode's own presentation is left as an open question for a future step.

---

_Generated with [Claude Code](https://claude.ai/code)_
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_011jT9A7D5d5tmnNTegtuKb9

---
_Generated by [Claude Code](https://claude.ai/code/session_011jT9A7D5d5tmnNTegtuKb9)_