### PR TITLE
Sum both weapons' hit counts for a 二刀流 actor's basic Attack

### DIFF
--- a/changelog.d/rpg2k-two-weapon-strike-count.fixed.md
+++ b/changelog.d/rpg2k-two-weapon-strike-count.fixed.md
@@ -1,0 +1,9 @@
+- **A 二刀流 (dual-wielding) actor with a weapon in both hands now swings at
+  least twice per basic Attack, even when neither individual weapon is
+  itself flagged "attacks twice."** Confirmed against EasyRPG Player's
+  source: `Game_BattleAlgorithm::Normal::Init` sums each weapon's own hit
+  count once both hands hold a real weapon, a different rule from the
+  ordinary single-weapon case. This engine only ever checked whether either
+  equipped weapon carried its own "attacks twice" flag, so a two-weapon
+  actor built from two ordinary weapons — the common case — attacked only
+  once a round, the same as an unarmed actor.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5796,6 +5796,36 @@ not yet verified:
   agility tie resolving deterministically were switched from a real (if
   seeded) RNG to `FixedRng.new(0)`, which zeroes the jitter term and
   restores the pure-Agility ordering they actually mean to exercise.
+- ✅ **A 二刀流 (`double_hand?`) actor with a weapon in both the weapon and
+  shield slots now swings at least twice per basic Attack, even when
+  *neither* individual weapon carries its own 二刀流 "attacks twice"
+  (`dual_attack`) flag.** Confirmed against EasyRPG's actual C++ source:
+  `Game_BattleAlgorithm::Normal::Init` (`src/game_battlealgorithm.cpp`)
+  sums each weapon's own hit count (`GetNumberOfAttacks`) once
+  `GetWeapon() && Get2ndWeapon()` both hold a real weapon — a genuinely
+  different rule from the ordinary single-weapon case
+  (`Game_Actor::GetNumberOfAttacks`'s own max-over-equipment), which the
+  engine already had right via `Actor#dual_attack?`. `Battle::Combatant
+  .from_actor` fed `#dual_attack?`'s plain 2-or-1 straight into
+  `c.strikes` and never consulted `#double_hand?` at all — so a two-weapon
+  actor built from two ordinary weapons (the common case; most 二刀流
+  setups don't additionally flag either weapon `dual_attack`) attacked
+  exactly **once** a round, the same as an unarmed actor, instead of the
+  two independent swings (two independent to-hit/damage/crit rolls, via
+  `Battle#swing`'s existing per-strike loop) real RPG_RT gives them. Fixed
+  by adding `Actor#strike_count`: when both the weapon and shield slots
+  hold a weapon-type item (only possible for a `double_hand?` actor), it
+  sums each one's own `dual_attack`-derived hit count instead of the
+  existing `dual_attack?` scan's implicit max; otherwise it falls back to
+  the already-correct `dual_attack? ? 2 : 1`. `Combatant.from_actor` now
+  reads `#strike_count` (via a new `self.strike_count_of` class helper,
+  matching the file's `self.hit_rate_of`/`self.crit_chance_of` style)
+  instead of `#dual_attack?` directly. Covered by three new
+  `scripts/rpg2k_logic_check.rb` checks — two ordinary weapons summing to
+  2, a single equipped weapon still swinging once, and one `dual_attack`
+  weapon plus one ordinary weapon summing to 3, not 2 — all three
+  confirmed to fail against the pre-fix code before the fix (`#strike_count`
+  did not exist at all).
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1868,6 +1868,27 @@ module Game
     # gives 13 of its weapons this.
     def dual_attack?; equipment_flag?(:dual_attack, true); end
 
+    # A basic Attack's total swing count. Ordinarily this is just
+    # `#dual_attack?`'s 2-or-1 (the higher of whatever weapon-type items are
+    # equipped, which collapses to one item's own flag for a single weapon).
+    # But a `#double_hand?` actor with a weapon in *both* the weapon and
+    # shield slots is a genuinely different case: EasyRPG's
+    # `Game_BattleAlgorithm::Normal::Init` (`src/game_battlealgorithm.cpp`,
+    # the `Style_MultiHit` style RPG2003 uses by default whenever
+    # `GetWeapon() && Get2ndWeapon()` both hold a real weapon) sums each
+    # weapon's own hit count instead of taking the higher of the two the way
+    # `Game_Actor::GetNumberOfAttacks`'s ordinary single-weapon max does --
+    # so a two-weapon actor swings **at least twice** even when *neither*
+    # individual weapon is itself flagged 二刀流, the common case for a
+    # dual-wield setup built from two ordinary weapons.
+    def strike_count
+      return dual_attack? ? 2 : 1 unless @db.respond_to?(:item)
+      weapons = @equipment.map { |iid| iid && iid != 0 ? @db.item[iid] : nil }
+                          .select { |it| it && it.respond_to?(:type) && it.type == ITEM_WEAPON }
+      return dual_attack? ? 2 : 1 unless weapons.size >= 2
+      weapons[0, 2].reduce(0) { |s, it| s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) }
+    end
+
     # 必中 — an equipped weapon whose attack cannot be evaded. RPG_RT's
     # `CalcNormalAttackToHit` returns before it applies the agility / evasion
     # term for such a weapon. 13 of Nepheshel's weapons carry it.
@@ -7548,13 +7569,21 @@ module Game
     # {} when the source (a bare fixture) doesn't model them.
     def self.state_ranks_of(b); b.respond_to?(:state_ranks) ? b.state_ranks : {}; end
 
+    # A battler's basic-attack swing count (`Actor#strike_count`, which
+    # folds in the plain `#dual_attack?` case too); 1 for an enemy or a bare
+    # fixture that models neither.
+    def self.strike_count_of(b)
+      return b.strike_count if b.respond_to?(:strike_count)
+      flag_of(b, :dual_attack?) ? 2 : 1
+    end
+
     def self.from_actor(a)
       c = Combatant.new(a.name, a.atk, a.def, a.agi, a.hp, a.max_hp,
                     nil, false, a.mp, a.max_mp, a.int, nil, a, actor_states(a),
                     nil, crit_chance_of(a), prevents_crit_of(a),
                     attr_ranks_of(a), atk_attrs_of(a), nil, hit_rate_of(a),
                     state_ranks_of(a))
-      c.strikes = flag_of(a, :dual_attack?) ? 2 : 1
+      c.strikes = strike_count_of(a)
       c.ignores_evasion = flag_of(a, :ignores_evasion?)
       c.attack_all = flag_of(a, :attack_all?)
       c.preemptive = flag_of(a, :preemptive?)

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14349,6 +14349,39 @@ check 'equipping a second weapon from the bag lands it in the shield slot' do
   eq 95, hero.attack_hit_rate, 'the better of the two weapons\' hit rates'
   eq 20, hero.weapon_crit_bonus, 'the dagger\'s crit bonus, the sword carrying none'
   eq 10 + 20 + 15, hero.atk, 'both weapons\' attack bonuses are summed in, like any slot'
+  # Confirmed against EasyRPG's actual C++ source: Game_BattleAlgorithm::
+  # Normal::Init (src/game_battlealgorithm.cpp) sums each weapon's own hit
+  # count (GetNumberOfAttacks) once both GetWeapon() and Get2ndWeapon() hold
+  # a real weapon, rather than taking the higher of the two the way the
+  # single-weapon case (Game_Actor::GetNumberOfAttacks's own max-over-
+  # equipment) does -- so a 二刀流 actor swings *twice* even though *neither*
+  # the sword nor the dagger is itself flagged 二刀流 (attacks twice).
+  eq 2, hero.strike_count, 'two ordinary weapons still add up to two swings'
+end
+
+check 'a single weapon (no second hand filled) still swings once unless it is ' \
+      'itself 二刀流' do
+  st = double_hand_party
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  ok st.party.equip_from_bag(hero, 1, Game::Actor::WEAPON_SLOT)
+  eq 1, hero.strike_count, 'only one weapon equipped -- the ordinary single-weapon case'
+end
+
+check 'a 二刀流 actor with one dual_attack weapon sums 2 + 1, not just 2' do
+  items = { 1 => fake_item(type: 1, atk: 20, hit: 95, dual_attack: true), # 二刀流 sword: 2 swings
+            2 => fake_item(type: 1, atk: 15, hit: 85) }                  # ordinary dagger: 1 swing
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 8 })
+  row.double_hand = true
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  hero = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(hero, 1, Game::Actor::WEAPON_SLOT)
+  ok st.party.equip_from_bag(hero, 2, Game::Actor::SHIELD_SLOT)
+  eq 3, hero.strike_count, "the dual_attack sword's 2 swings plus the dagger's 1"
 end
 
 check 'a shield is rejected for a 二刀流 actor\'s shield slot even named directly' do


### PR DESCRIPTION
## Summary
- A 二刀流 (`double_hand?`) actor with a weapon in both the weapon and shield slots now swings at least twice per basic Attack, even when *neither* individual weapon carries its own 二刀流 "attacks twice" (`dual_attack`) flag.
- Confirmed against EasyRPG's actual C++ source: `Game_BattleAlgorithm::Normal::Init` (`src/game_battlealgorithm.cpp`) sums each weapon's own hit count (`GetNumberOfAttacks`) once `GetWeapon() && Get2ndWeapon()` both hold a real weapon — a genuinely different rule from the ordinary single-weapon case (`Game_Actor::GetNumberOfAttacks`'s own max-over-equipment), which the engine already had right via `Actor#dual_attack?`.
- `Battle::Combatant.from_actor` fed `#dual_attack?`'s plain 2-or-1 straight into `c.strikes` and never consulted `#double_hand?` at all — so a two-weapon actor built from two ordinary weapons (the common case; most 二刀流 setups don't additionally flag either weapon `dual_attack`) attacked exactly **once** a round, the same as an unarmed actor, instead of the two independent swings (two independent to-hit/damage/crit rolls, via `Battle#swing`'s existing per-strike loop) real RPG_RT gives them.
- Fixed by adding `Actor#strike_count`: when both the weapon and shield slots hold a weapon-type item (only possible for a `double_hand?` actor), it sums each one's own `dual_attack`-derived hit count instead of the existing `dual_attack?` scan's implicit max; otherwise it falls back to the already-correct `dual_attack? ? 2 : 1`. `Combatant.from_actor` now reads `#strike_count` via a new `self.strike_count_of` class helper, matching the file's `self.hit_rate_of`/`self.crit_chance_of` style.

## Test plan
- [x] Three new `scripts/rpg2k_logic_check.rb` checks — two ordinary weapons summing to 2, a single equipped weapon still swinging once, and one `dual_attack` weapon plus one ordinary weapon summing to 3 — all confirmed to fail against the pre-fix code before the fix (`#strike_count` did not exist)
- [x] `ruby scripts/rpg2k_logic_check.rb` — 870 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 590 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_