### PR TITLE
Optimize RPG2000 map layer rendering: 20fps to 57fps

### DIFF
--- a/changelog.d/rpg2k-map-layer-cache.changed.md
+++ b/changelog.d/rpg2k-map-layer-cache.changed.md
@@ -1,0 +1,16 @@
+- **The RPG2000 map renderer no longer redraws the tile grid every frame.** It
+  builds the visible grid into a pair of cached buffers and copies those into
+  the frame buffers at the sub-tile scroll offset, rebuilding only when
+  something the grid depends on actually changed — the camera crossing a tile,
+  an animation column the visible tiles actually follow, a Tile Substitution,
+  a tileset swap or a new map. `Game::ChipsetLayout.quads` is memoised on
+  `(id, abf, cf)` as well, which it is a pure function of. Measured on
+  Nepheshel: **20fps to 55fps** — frame work 34.1ms to 8.8ms against a 16.67ms
+  budget, `map.layers` 22.7ms to 2.4ms, and mruby allocation churn ~350k/s to
+  ~30k/s. The map region renders pixel-identically before and after (diffed
+  frame captures; see `docs/profiling.md`).
+- **`RGSS::Bitmap#copy_blt`**, a non-blending counterpart to `#blt` that
+  replaces the destination pixels outright. Onto a cleared destination the two
+  draw the same picture — blending over transparency returns the source
+  unchanged — but `#blt` pays a per-pixel read/blend/write for it, which on the
+  map renderer's two 336x256 layer copies measured ~5ms a frame.

--- a/changelog.d/rpg2k-upper-layer-blank-chip.changed.md
+++ b/changelog.d/rpg2k-upper-layer-blank-chip.changed.md
@@ -1,0 +1,10 @@
+- **The map renderer no longer draws the upper layer's reserved blank chip.**
+  RPG2000's first upper-layer id (`BLOCK_F`) means "nothing on the upper layer
+  here", and real map data is very nearly all of it — 98.45% of the 584,049
+  upper cells across Nepheshel's 543 maps — so the renderer was blitting a
+  fully transparent chipset cell roughly 330 times per grid rebuild for no
+  pixels at all. Skipping it makes a rebuild 28% cheaper (16.5ms to 11.8ms),
+  which is the spike that costs dropped frames, and leaves the rendered frame
+  byte-identical. It is a *drawing* sentinel only: the blank id still indexes
+  entry 0 of the chipset's upper passability table, and that lookup is
+  untouched.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -30,27 +30,27 @@ by wall-clock instead folds in the fps-cap sleep and understates every section.
 
 ## Baseline: RPG2000 / Nepheshel, map scene
 
-1364 frames over 24.8s, `RelWithDebInfo` (the project default), 320x240,
+1405 frames over 24.8s, `RelWithDebInfo` (the project default), 320x240,
 software rendering under Xvfb. Percentages are of **CPU work**, not wall clock.
 
 | section | calls | avg ms | max ms | % work |
 | --- | ---: | ---: | ---: | ---: |
-| `scene.update` | 1365 | 5.00 | 563.35 | 55.3% |
-| `gfx.lvgl` | 1364 | 3.80 | 29.64 | 41.9% |
-| ` map.render` | 1364 | 3.39 | 29.28 | 37.4% |
-| ` map.layers` | 1365 | 2.47 | 28.33 | 27.3% |
-| ` map.pictures` | 1365 | 0.76 | 0.92 | 8.4% |
-| ` map.refresh_pages` | 1364 | 0.10 | 9.50 | 1.1% |
-| `input.update` | 1365 | 0.05 | 0.17 | 0.6% |
-| ` map.overlay` | 1365 | 0.04 | 0.18 | 0.4% |
-| `audio.music_load` | 1 | 34.32 | 34.32 | 0.3% |
-| ` map.chars` | 1365 | 0.02 | 0.19 | 0.2% |
-| `gfx.invalidate` | 1364 | 0.02 | 0.12 | 0.2% |
-| ` map.animate_events` | 1364 | 0.01 | 0.13 | 0.2% |
-| `audio.update` | 1365 | 0.0002 | 0.0004 | 0.0% |
+| `scene.update` | 1406 | 4.69 | 536.65 | 54.0% |
+| `gfx.lvgl` | 1405 | 3.75 | 15.39 | 43.2% |
+| ` map.render` | 1405 | 3.16 | 21.83 | 36.4% |
+| ` map.layers` | 1406 | 2.25 | 20.84 | 26.0% |
+| ` map.pictures` | 1406 | 0.76 | 0.96 | 8.7% |
+| ` map.refresh_pages` | 1405 | 0.09 | 0.34 | 1.0% |
+| `input.update` | 1406 | 0.05 | 0.21 | 0.6% |
+| ` map.overlay` | 1406 | 0.04 | 0.29 | 0.4% |
+| `audio.music_load` | 1 | 32.64 | 32.64 | 0.3% |
+| ` map.chars` | 1406 | 0.02 | 0.12 | 0.2% |
+| `gfx.invalidate` | 1405 | 0.02 | 0.10 | 0.2% |
+| ` map.animate_events` | 1405 | 0.01 | 0.09 | 0.1% |
+| `audio.update` | 1406 | 0.0002 | 0.0004 | 0.0% |
 
-Headline: **9.1ms of work per frame against a 16.67ms budget**, running at
-55fps. Allocation churn is ~30,000 mruby allocations/second.
+Headline: **8.7ms of work per frame against a 16.67ms budget**, running at
+57fps. Allocation churn is ~30,000 mruby allocations/second.
 
 This is the state *after* the map-layer work described below. The same run
 before it sat at **20fps and 34.1ms a frame** — over budget on every single
@@ -112,7 +112,17 @@ two apart.
 alpha-blending onto a surface that had just been cleared. `Bitmap#copy_blt`
 does the same job as a row-wise `memcpy`, taking the copy path to ~1.8ms.
 
-Net: `map.layers` 22.7ms → 2.5ms, frame work 34.1ms → 9.1ms, 20fps → 55fps,
+**(3) The upper layer's blank chip is not drawn.** RPG2000's first upper-layer
+id (`BLOCK_F`) means "nothing here", and real data is very nearly all of it —
+98.45% of the 584,049 upper cells across Nepheshel's 543 maps — so a rebuild
+was blitting a fully transparent chipset cell ~330 times for no pixels. That
+is 28% of a rebuild (16.5ms → 11.8ms), which matters more than its share of
+the average suggests: the rebuild is the spike that drops frames. Note it is a
+*drawing* sentinel only — the blank id still indexes entry 0 of the chipset's
+upper passability table, a real lookup, so `ChipsetLayout.upper_blank?` must
+never be used to skip one.
+
+Net: `map.layers` 22.7ms → 2.3ms, frame work 34.1ms → 8.7ms, 20fps → 57fps,
 and 96% of frames now skip the rebuild entirely.
 
 `gfx.lvgl` (3.8ms, the LVGL render and flush) is now the largest single cost
@@ -142,9 +152,20 @@ driven to the same input-gated point in Nepheshel's opening (`--no_render_wait`
 so the frame-driven waits do not desynchronise two builds running at different
 frame rates). **The map region is pixel-identical — zero differing pixels over
 640x435**, tile layers, autotiles, furniture and character sprites included.
-`scripts/rpg2k_scene_check.rb` covers the invalidation directly: a frame that
-changed nothing must not re-blit a single tile, and a tile crossing, a Tile
-Substitution and an animation step the visible tiles follow each must rebuild.
+Skipping the blank upper chip was diffed the same way and came out identical
+over the *whole* frame, which is the direct evidence that the chip it stopped
+drawing really was fully transparent rather than merely assumed to be.
+
+`scripts/rpg2k_scene_check.rb` covers the behaviour directly: a frame that
+changed nothing must not re-blit a single tile; a tile crossing, a Tile
+Substitution and an animation step the visible tiles follow must each rebuild;
+and a map whose upper layer is entirely the blank id must cost exactly its
+lower layer while still answering passability through that id.
+
+Worth repeating for anyone extending this: the failure mode of a render cache
+is silence. Too eager and it only costs speed, but too lazy and the picture is
+simply wrong, with nothing raising. The invalidation checks are the part of
+this work most worth keeping honest.
 
 ## Audio: what is already off the main thread
 
@@ -170,7 +191,7 @@ the profile prices it at essentially nothing:
 
 So moving "audio processing" to a worker thread would move work that is
 already elsewhere, and would buy ~0.0002ms/frame. It was never where the frame
-went — not at the 34.1ms this page originally measured, and still not at 9.1ms.
+went — not at the 34.1ms this page originally measured, and still not at 8.7ms.
 
 ### The part that *is* worth moving: asset load
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -30,73 +30,121 @@ by wall-clock instead folds in the fps-cap sleep and understates every section.
 
 ## Baseline: RPG2000 / Nepheshel, map scene
 
-489 frames over 24.8s, `RelWithDebInfo` (the project default), 320x240,
+1364 frames over 24.8s, `RelWithDebInfo` (the project default), 320x240,
 software rendering under Xvfb. Percentages are of **CPU work**, not wall clock.
 
 | section | calls | avg ms | max ms | % work |
 | --- | ---: | ---: | ---: | ---: |
-| `scene.update` | 490 | 25.93 | 537.22 | 76.1% |
-| ` map.render` | 489 | 23.63 | 50.52 | 69.2% |
-| ` map.layers` | 490 | **22.66** | 49.56 | **66.5%** |
-| `gfx.lvgl` | 489 | 7.94 | 34.27 | 23.3% |
-| ` map.pictures` | 490 | 0.78 | 1.13 | 2.3% |
-| ` map.refresh_pages` | 489 | 0.10 | 0.23 | 0.3% |
-| `audio.music_load` | 1 | 29.61 | 29.61 | 0.2% |
-| `input.update` | 490 | 0.05 | 0.12 | 0.2% |
-| ` map.overlay` | 490 | 0.05 | 0.11 | 0.1% |
-| ` map.chars` | 490 | 0.02 | 0.05 | 0.1% |
-| `gfx.invalidate` | 489 | 0.02 | 0.06 | 0.1% |
-| ` map.animate_events` | 489 | 0.01 | 0.08 | 0.0% |
-| ` map.animation` | 490 | 0.004 | 0.03 | 0.0% |
-| ` map.parallax` | 490 | 0.003 | 0.03 | 0.0% |
-| `audio.sample_load` | 1 | 0.60 | 0.60 | 0.0% |
-| `audio.resolve` | 2 | 0.20 | 0.20 | 0.0% |
-| `audio.update` | 490 | 0.0002 | 0.0004 | 0.0% |
+| `scene.update` | 1365 | 5.00 | 563.35 | 55.3% |
+| `gfx.lvgl` | 1364 | 3.80 | 29.64 | 41.9% |
+| ` map.render` | 1364 | 3.39 | 29.28 | 37.4% |
+| ` map.layers` | 1365 | 2.47 | 28.33 | 27.3% |
+| ` map.pictures` | 1365 | 0.76 | 0.92 | 8.4% |
+| ` map.refresh_pages` | 1364 | 0.10 | 9.50 | 1.1% |
+| `input.update` | 1365 | 0.05 | 0.17 | 0.6% |
+| ` map.overlay` | 1365 | 0.04 | 0.18 | 0.4% |
+| `audio.music_load` | 1 | 34.32 | 34.32 | 0.3% |
+| ` map.chars` | 1365 | 0.02 | 0.19 | 0.2% |
+| `gfx.invalidate` | 1364 | 0.02 | 0.12 | 0.2% |
+| ` map.animate_events` | 1364 | 0.01 | 0.13 | 0.2% |
+| `audio.update` | 1365 | 0.0002 | 0.0004 | 0.0% |
 
-Headline: **34.1ms of work per frame against a 16.67ms budget** — 2x over, so
-the run sits at 20fps with every frame counted as a drop. Allocation churn is
-~350,000 mruby allocations/second.
+Headline: **9.1ms of work per frame against a 16.67ms budget**, running at
+55fps. Allocation churn is ~30,000 mruby allocations/second.
+
+This is the state *after* the map-layer work described below. The same run
+before it sat at **20fps and 34.1ms a frame** — over budget on every single
+frame — with `map.layers` alone at 22.7ms (66.5% of work) and ~350,000
+allocations/second. Those are the numbers the rest of this page reasons about,
+and they are what the tile cache and `Bitmap#copy_blt` removed.
 
 Note that `map.layers` and `map.chars` are inside the `if @battle_ui` gate in
 `#render`, so they stop being recorded during a fight — the map is not drawn
 there at all. A profile of a battle-heavy run will show a different shape.
 
-### The bottleneck is `map.layers`
+### What `map.layers` used to cost, and why
 
-Two thirds of the frame is one loop, `Scene::Map#draw_layers`. Every frame it
-clears both chip-layer bitmaps and re-blits the whole visible grid — 21x16 =
+Two thirds of the frame was one loop, `Scene::Map#draw_layers`. Every frame it
+cleared both chip-layer bitmaps and re-blitted the whole visible grid — 21x16 =
 336 tiles, each up to two layers, each tile going through
-`Game::ChipsetLayout.quads`, which returns a freshly allocated array (four
-8x8 quarters for an autotile) that is then blitted quad by quad.
+`Game::ChipsetLayout.quads`, which returned a freshly allocated array (four
+8x8 quarters for an autotile) that was then blitted quad by quad.
 
-Nothing about that is conditional. The map is redrawn from scratch whether or
+Nothing about that was conditional. The map was redrawn from scratch whether or
 not the camera moved, whether or not any tile animated, and whether or not
-anything on screen changed at all. That is also where the allocation churn
-comes from: `quads` is a pure function of `(id, abf, cf)` and is called
-~670 times per frame, allocating every time.
+anything on screen changed at all. That was also where the allocation churn
+came from: `quads` is a pure function of `(id, abf, cf)` and was called ~670
+times per frame, allocating every time.
 
-Two independent things are therefore being paid for every frame:
+So two independent things were being paid for on every frame:
 
 1. **Recomputing tile geometry** that depends only on `(id, abf, cf)`.
 2. **Re-blitting static scenery** that did not change since the last frame.
 
-(1) is the cheaper fix and was measured as a one-off experiment (against a
-baseline reading 22.3ms / 33.5ms, a hair under the table above): memoizing
-`quads` on `(id, abf, cf)` took `map.layers` from 22.3ms to 12.9ms and frame
-work from 33.5ms to 22.8ms (20.0 -> 25.4fps), with allocation churn dropping
-from ~350k to ~225k/s. That is a
-~30% frame-time win from a cache, and it is *not* committed here — this page
-records the measurement, not the change. Note the guard it needs: `quads` is
-called with `nil` ids, so a naive key computation raises.
+Both are now avoided.
 
-(1) alone does not reach 60fps — 22.8ms is still over budget, and the residual
-12.9ms is the per-tile blit loop itself. Getting under 16.67ms means attacking
-(2): cache the composed layer and redraw only on camera movement or an actual
-animation step, or move the inner loop out of mruby.
+**(1) `quads` is memoised** on `(id, abf, cf)`. Alone this took `map.layers`
+from 22.3ms to 12.9ms and frame work from 33.5ms to 22.8ms (20 → 25fps), with
+allocation churn dropping from ~350k to ~225k/s. Two things it needs, both of
+which bit during development: `quads` is called with `nil` ids (the renderer
+draws the map edge every frame), and the key has to stay inside a signed
+32-bit `mrb_int` or it becomes a bignum on the Emscripten / PSP / Wio builds.
+Resolving the tile's block first answers both.
 
-`gfx.lvgl` (7.7ms, the LVGL render and flush) is the second cost and is
-largely a consequence of the first — the full-surface invalidation that a
-from-scratch tile redraw implies.
+**(2) The grid is cached.** `#rebuild_tile_cache` builds the visible tiles into
+a pair of buffers on whole-tile boundaries, and each frame `#draw_layers` copies
+those into the frame buffers at the sub-tile scroll offset. The rebuild only
+re-runs when `#tile_cache_valid?` says something it depends on changed: the
+camera crossing a tile, an animation input *the visible tiles actually follow*,
+a Tile Substitution (via `Game::Map#revision`), a tileset swap, or a new map.
+The events cannot be cached — they move every frame and composite into these
+same buffers — which is why the cache is separate from the frame buffers rather
+than being drawn to directly.
+
+That last qualifier matters more than it looks. `Game::ChipsetLayout.anim_c`
+steps every 6 frames but only drives the block C animated chips; keying the
+cache on it unconditionally rebuilt 18% of frames instead of 4%, for an input
+most maps have nothing on screen that reads. `.anim_input` is what tells the
+two apart.
+
+**The per-frame copy then became the cost.** Through `#blt` those two
+336x256 copies measured ~5ms a frame — a third of the whole budget spent
+alpha-blending onto a surface that had just been cleared. `Bitmap#copy_blt`
+does the same job as a row-wise `memcpy`, taking the copy path to ~1.8ms.
+
+Net: `map.layers` 22.7ms → 2.5ms, frame work 34.1ms → 9.1ms, 20fps → 55fps,
+and 96% of frames now skip the rebuild entirely.
+
+`gfx.lvgl` (3.8ms, the LVGL render and flush) is now the largest single cost
+after `map.layers`. It has not changed in absolute terms — the layer surfaces
+are still fully invalidated every frame, because the events drawn over them
+change every frame.
+
+#### Checking it still draws the same thing
+
+This is a renderer with pixel-parity commitments (ADR 0021), so the change was
+diffed rather than argued. Two mechanical facts carry it:
+
+- The coordinate mapping is unchanged. Taking the source from `(ox, oy)` maps
+  cache pixel `rx*TILE + i` to destination `rx*TILE + i - ox`, which is exactly
+  where the old per-tile loop drew it, and both ends clip the same way.
+- `#copy_blt` onto a cleared destination equals `#blt` onto one, because
+  `blend_over` against a fully transparent pixel returns the source unchanged.
+  The mruby-rgss tests assert this over every alpha. The one genuine difference
+  is invisible and worth knowing about: for a *fully transparent* source pixel
+  `#blt` bails out and leaves cleared black where `#copy_blt` copies the colour
+  channels across. Nothing can observe it — a `da == 0` pixel contributes
+  nothing to any later composite and does not render — but a byte-for-byte
+  comparison of the two buffers would show it.
+
+End to end, frames were captured from a build before and after the change,
+driven to the same input-gated point in Nepheshel's opening (`--no_render_wait`
+so the frame-driven waits do not desynchronise two builds running at different
+frame rates). **The map region is pixel-identical — zero differing pixels over
+640x435**, tile layers, autotiles, furniture and character sprites included.
+`scripts/rpg2k_scene_check.rb` covers the invalidation directly: a frame that
+changed nothing must not re-blit a single tile, and a tile crossing, a Tile
+Substitution and an animation step the visible tiles follow each must rebuild.
 
 ## Audio: what is already off the main thread
 
@@ -121,8 +169,8 @@ the profile prices it at essentially nothing:
 - `Mix_PlayMusic` / `Mix_PlayChannel`: 0.02ms.
 
 So moving "audio processing" to a worker thread would move work that is
-already elsewhere, and would buy ~0.0002ms/frame. It is not where the 34.1ms
-goes.
+already elsewhere, and would buy ~0.0002ms/frame. It was never where the frame
+went — not at the 34.1ms this page originally measured, and still not at 9.1ms.
 
 ### The part that *is* worth moving: asset load
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -130,6 +130,44 @@ after `map.layers`. It has not changed in absolute terms — the layer surfaces
 are still fully invalidated every frame, because the events drawn over them
 change every frame.
 
+#### What it costs in memory
+
+Caching trades memory for time, so the trade was measured rather than assumed.
+Two things are newly allocated:
+
+- **The two cached grids**, `COLS*TILE x ROWS*TILE` at ARGB8888 — 336x256x4 =
+  336 KiB each, **672 KiB** together. Fixed, allocated once with the scene.
+- **The `quads` table.** Bounded, not unbounded: its key space is the game's
+  distinct tile ids x 3 `abf` x 4 `cf`. For Nepheshel that ceiling is 639
+  distinct ids across all 543 maps, so **7,668 entries / ~28,000 small arrays /
+  ~2.7 MiB** (measured under CRuby, whose objects are larger than mruby's) —
+  and only if a session renders every tile in the game in every animation
+  state. It cannot grow with play time past that.
+
+Against that, the change removes ~97% of the engine's allocation churn, which
+is worth more than the caches cost. Two 3-minute runs, same game, both read at
+their RSS plateau:
+
+| | before | after |
+| --- | ---: | ---: |
+| process RSS (plateau) | 70.02 MB | **69.33 MB** |
+| LVGL pool, floor (retained) | 16.60 MB | 16.58 MB |
+| LVGL pool, peak | 26.72 MB | 25.70 MB |
+| mruby live blocks, floor | 21,806 | 21,132 |
+| mruby live blocks, peak | 190,539 | 162,916 |
+| allocations/second | 348,172 | **10,571** |
+
+So there is **no net memory cost** — RSS came out 0.7 MB *lower*, and every
+other figure is flat or down. The 672 KiB of surfaces and whatever the quads
+table has filled are more than paid for by the garbage no longer being
+produced: with 33x fewer allocations the heap holds far less transient rubbish
+between collections (peak live blocks down 27,000).
+
+Read short windows carefully here. A 40-second sample of the same pair showed
+the *optimized* build with a higher heap peak, purely because the two builds
+were caught in different phases of the GC's sawtooth; only at the plateau do
+the numbers mean anything.
+
 #### Checking it still draws the same thing
 
 This is a renderer with pixel-parity commitments (ADR 0021), so the change was

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -241,12 +241,12 @@ mrb_data_type DataType<T>::data_type{
 };
 
 // Generic floating point component getter/setter usable by Color and Tone.
-template <class T, double T::*Field>
+template <class T, double T::* Field>
 mrb_value component_get(mrb_state* M, V self) {
   return mrb_float_value(M, DataType<T>::get(M, self).*Field);
 }
 
-template <class T, double T::*Field, int Lo, int Hi>
+template <class T, double T::* Field, int Lo, int Hi>
 mrb_value component_set(mrb_state* M, V self) {
   mrb_float v;
   mrb_get_args(M, "f", &v);
@@ -4072,7 +4072,7 @@ int vx_tile_quads(int tile_id, int frame, bool table, VXQuad out[8]) {
   const int tx = kind % 8;
   const int ty = kind / 8;
   int sheet = 0, bx = 0, by = 0;
-  const int(*quad_table)[4][2] = VX_FLOOR_QUADS;
+  const int (*quad_table)[4][2] = VX_FLOOR_QUADS;
   int shape_count = 48;
   bool is_table = false;
 

--- a/mruby-rgss/src/lib.cxx
+++ b/mruby-rgss/src/lib.cxx
@@ -241,12 +241,12 @@ mrb_data_type DataType<T>::data_type{
 };
 
 // Generic floating point component getter/setter usable by Color and Tone.
-template <class T, double T::* Field>
+template <class T, double T::*Field>
 mrb_value component_get(mrb_state* M, V self) {
   return mrb_float_value(M, DataType<T>::get(M, self).*Field);
 }
 
-template <class T, double T::* Field, int Lo, int Hi>
+template <class T, double T::*Field, int Lo, int Hi>
 mrb_value component_set(mrb_state* M, V self) {
   mrb_float v;
   mrb_get_args(M, "f", &v);
@@ -1844,6 +1844,97 @@ mrb_value bmp_blt(mrb_state* M, V self) {
       int dr, dg, db, da;
       bmp_read(dst, dx, dy, dr, dg, db, da);
       blend_over(dst, dx, dy, r, g, bl, alpha, dr, dg, db, da);
+    }
+  }
+  dst.dirty = true;
+  return self;
+}
+
+// Bitmap#copy_blt(x, y, src, src_rect) -- put src_rect down at (x, y),
+// *replacing* the destination pixels (alpha included) instead of compositing
+// over them the way #blt does.
+//
+// This is not a new blending rule, it is the one case where blending is
+// provably a no-op: blend_over() against a fully transparent destination
+// returns the source pixel unchanged (dw = 0, out_a = sa), and #blt's own
+// alpha>=255 path is already a plain overwrite. So onto a *cleared*
+// destination the two show the same picture -- identical alpha everywhere and
+// identical colour on every pixel that is visible at all.
+//
+// They part company on exactly one thing, and it is not observable: for a
+// fully transparent source pixel #blt bails out and leaves the cleared black,
+// while this copies the source's colour channels over. Nothing can see the
+// difference -- blend_over weights the destination by its own alpha, so a
+// da == 0 pixel contributes nothing to any later composite, and a fully
+// transparent pixel does not render. The mruby-rgss tests assert both halves
+// of this over every alpha.
+//
+// It exists because that case is the map renderer's hot path. Scene::Map#
+// draw_layers copies its whole cached tile grid into the frame buffer every
+// frame, 336x256 pixels twice, and through #blt's per-pixel read/blend/write
+// that measured ~5ms per frame -- a third of the engine's entire 16.67ms
+// budget spent blending pixels onto transparency. Row-wise, it is a memcpy.
+mrb_value bmp_copy_blt(mrb_state* M, V self) {
+  mrb_int x, y;
+  Bitmap* src;
+  V srect;
+  mrb_get_args(M, "iido", &x, &y, &src, &DataType<Bitmap>::data_type, &srect);
+  Bitmap& dst = bmp_self(M, self);
+  Bitmap& sb = bmp_require(M, src);
+  Rect& rc = DataType<Rect>::get(M, srect);
+
+  mrb_int sx = rc.x, sy = rc.y, w = rc.width, h = rc.height;
+  // Clip against the source's origin, carrying the destination along so the
+  // two stay in step, then against the destination's, then both extents.
+  if (sx < 0) {
+    w += sx;
+    x -= sx;
+    sx = 0;
+  }
+  if (sy < 0) {
+    h += sy;
+    y -= sy;
+    sy = 0;
+  }
+  if (x < 0) {
+    w += x;
+    sx -= x;
+    x = 0;
+  }
+  if (y < 0) {
+    h += y;
+    sy -= y;
+    y = 0;
+  }
+  if (sx + w > sb.width)
+    w = sb.width - sx;
+  if (sy + h > sb.height)
+    h = sb.height - sy;
+  if (x + w > dst.width)
+    w = dst.width - x;
+  if (y + h > dst.height)
+    h = dst.height - y;
+  if (w <= 0 || h <= 0)
+    return self;
+
+  if (dst.format == sb.format) {
+    const unsigned bpp = lv_color_format_get_size(dst.format);
+    for (mrb_int row = 0; row < h; ++row) {
+      const uint8_t* s =
+          sb.buffer.data() + ((size_t)(sy + row) * sb.width + sx) * bpp;
+      uint8_t* d =
+          dst.buffer.data() + ((size_t)(y + row) * dst.width + x) * bpp;
+      std::memcpy(d, s, (size_t)w * bpp);
+    }
+  } else {
+    // Different pixel formats have no shared byte layout to copy, so go
+    // through the accessors -- still a replace, just not a memcpy.
+    for (mrb_int row = 0; row < h; ++row) {
+      for (mrb_int col = 0; col < w; ++col) {
+        int r, g, bl, a;
+        bmp_read(sb, sx + col, sy + row, r, g, bl, a);
+        bmp_put(dst, x + col, y + row, r, g, bl, a);
+      }
     }
   }
   dst.dirty = true;
@@ -3981,7 +4072,7 @@ int vx_tile_quads(int tile_id, int frame, bool table, VXQuad out[8]) {
   const int tx = kind % 8;
   const int ty = kind / 8;
   int sheet = 0, bx = 0, by = 0;
-  const int (*quad_table)[4][2] = VX_FLOOR_QUADS;
+  const int(*quad_table)[4][2] = VX_FLOOR_QUADS;
   int shape_count = 48;
   bool is_table = false;
 
@@ -6253,6 +6344,7 @@ extern "C" void mrb_mruby_rgss_gem_init(mrb_state* M) {
   mrb_define_method(M, bmp, "get_pixel", bmp_get_pixel, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "set_pixel", bmp_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method(M, bmp, "blt", bmp_blt, MRB_ARGS_REQ(4) | MRB_ARGS_OPT(1));
+  mrb_define_method(M, bmp, "copy_blt", bmp_copy_blt, MRB_ARGS_REQ(4));
   mrb_define_method(M, bmp, "tone_blt", bmp_tone_blt, MRB_ARGS_REQ(2));
   mrb_define_method(M, bmp, "stretch_blt", bmp_stretch_blt,
                     MRB_ARGS_REQ(3) | MRB_ARGS_OPT(1));

--- a/mruby-rgss/test/test.rb
+++ b/mruby-rgss/test/test.rb
@@ -412,6 +412,75 @@ assert "RGSS::Bitmap blt" do
   assert_equal 0.0, dst.get_pixel(0, 0).alpha # untouched
 end
 
+assert "RGSS::Bitmap copy_blt matches blt onto a cleared destination" do
+  # The justification for #copy_blt is that onto a *cleared* destination it
+  # shows the same picture as #blt -- that is what lets the map renderer swap
+  # one for the other and stay pixel-identical. Assert it over every alpha,
+  # since a partial alpha is where a blend could diverge from a copy.
+  #
+  # "Same picture" is exact on alpha everywhere, and exact on colour wherever
+  # the pixel is visible at all. The one place the two genuinely differ is the
+  # colour channels of a *fully transparent* pixel: #blt skips it and leaves
+  # the cleared black behind, #copy_blt copies the source's channels across.
+  # Neither is observable -- blend_over weights the destination by its alpha,
+  # so a da == 0 pixel contributes nothing to any later composite, and nothing
+  # renders it either.
+  [0, 1, 64, 128, 254, 255].each do |a|
+    src = RGSS::Bitmap.new(2, 2)
+    src.fill_rect(0, 0, 2, 2, RGSS::Color.new(10, 200, 30, a))
+
+    blted = RGSS::Bitmap.new(4, 4)
+    blted.clear
+    blted.blt(1, 1, src, RGSS::Rect.new(0, 0, 2, 2))
+
+    copied = RGSS::Bitmap.new(4, 4)
+    copied.clear
+    copied.copy_blt(1, 1, src, RGSS::Rect.new(0, 0, 2, 2))
+
+    4.times do |y|
+      4.times do |x|
+        want = blted.get_pixel(x, y)
+        got = copied.get_pixel(x, y)
+        assert_equal want.alpha, got.alpha
+        next if want.alpha == 0.0
+        assert_equal want.red, got.red
+        assert_equal want.green, got.green
+        assert_equal want.blue, got.blue
+      end
+    end
+  end
+end
+
+assert "RGSS::Bitmap copy_blt replaces rather than composites" do
+  # Unlike #blt, it overwrites what is already there -- including replacing an
+  # opaque pixel with a transparent one, which is what makes it a copy.
+  src = RGSS::Bitmap.new(2, 2)
+  src.fill_rect(0, 0, 2, 2, RGSS::Color.new(0, 0, 0, 0))
+  dst = RGSS::Bitmap.new(2, 2)
+  dst.fill_rect(0, 0, 2, 2, RGSS::Color.new(255, 0, 0, 255))
+  dst.copy_blt(0, 0, src, RGSS::Rect.new(0, 0, 2, 2))
+  assert_equal 0.0, dst.get_pixel(0, 0).alpha
+  # ... where #blt would have left the opaque red untouched.
+  other = RGSS::Bitmap.new(2, 2)
+  other.fill_rect(0, 0, 2, 2, RGSS::Color.new(255, 0, 0, 255))
+  other.blt(0, 0, src, RGSS::Rect.new(0, 0, 2, 2))
+  assert_equal 255.0, other.get_pixel(0, 0).alpha
+end
+
+assert "RGSS::Bitmap copy_blt clips out-of-range rects" do
+  src = RGSS::Bitmap.new(4, 4)
+  src.fill_rect(0, 0, 4, 4, RGSS::Color.new(0, 128, 0, 255))
+  dst = RGSS::Bitmap.new(4, 4)
+  # Straddling both origins at once, so the source and destination clips have
+  # to stay in step or the copied region lands at the wrong offset.
+  dst.copy_blt(-2, -2, src, RGSS::Rect.new(-1, -1, 4, 4))
+  assert_equal 128.0, dst.get_pixel(0, 0).green
+  # Entirely off the destination: a no-op, not a crash.
+  dst2 = RGSS::Bitmap.new(4, 4)
+  dst2.copy_blt(99, 99, src, RGSS::Rect.new(0, 0, 4, 4))
+  assert_equal 0.0, dst2.get_pixel(0, 0).alpha
+end
+
 assert "RGSS::Bitmap tone_blt" do
   src = RGSS::Bitmap.new(2, 2)
   src.fill_rect(0, 0, 2, 2, RGSS::Color.new(100, 150, 200, 255))

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -833,14 +833,62 @@ module Game
     # quarters. An absent tile and out-of-range ids return []; id 0 is water, not
     # empty (see .block). `abf` / `cf` are the current animation columns/frames
     # from #anim_ab / #anim_c.
+    # Memoised on (id, abf, cf), which is the whole of the input: the result is
+    # pure geometry, the same six numbers per quad every time. Uncached this was
+    # the single largest source of allocation in the engine -- the map renderer
+    # calls it once per visible tile per layer (~670 times a frame), and an
+    # autotile answers with five fresh arrays -- which measured as ~350k mruby
+    # allocations/second on Nepheshel. The distinct key count is bounded by the
+    # chipset (a few thousand tile ids x 4 animation columns x 3 frames) and
+    # each entry is a handful of small arrays, so the table settles quickly
+    # rather than growing with play time.
+    #
+    # The returned arrays are shared between callers and must not be mutated;
+    # every caller only reads them (see Scene::Map#draw_tile).
     def self.quads(id, abf = 0, cf = 0)
+      # Resolving the block first does double duty. It answers the inputs that
+      # have no quads at all -- `nil` (Game::Map#lower/#upper out of bounds,
+      # which the renderer hits on every map edge), a negative id, and an id
+      # past the last block -- before anything does arithmetic on them. And it
+      # is what bounds the key below: past this guard `id` is under
+      # BLOCK_F + BLOCK_F_TILES, so `id << 16` stays well inside a signed 32-bit
+      # mrb_int and cannot silently become a bignum on the Emscripten / PSP /
+      # Wio builds (see AGENTS.md on 32-bit mrb_int).
+      b = block(id)
+      return [] if b.nil?
+      # abf is 0..2 and cf is 0..3 (see .anim_ab / .anim_c), so eight bits each
+      # is room to spare and the three pack without overlapping.
+      @quads_cache ||= {}
+      key = (id << 16) | (abf << 8) | cf
+      cached = @quads_cache[key]
+      return cached if cached
+      @quads_cache[key] = uncached_quads(b, id, abf, cf)
+    end
+
+    # Which of the two animation inputs a tile id's quads actually move with:
+    # :abf for the block A/B autotiles (every quarter takes its chipset column
+    # from it -- see .water_quads), :cf for the block C animated chips, or nil
+    # for a tile that never changes on its own.
+    #
+    # This is what lets the map renderer tell an animation step that changes
+    # its picture from one that does not. The two inputs run at different
+    # rates and .anim_c is the fast one (every 6 frames, against 12 or 24 for
+    # .anim_ab), so a grid holding no block C tile at all -- which is most
+    # maps -- would otherwise be rebuilt ten times a second for nothing.
+    def self.anim_input(id)
       case block(id)
+      when :water then :abf
+      when :animated then :cf
+      end
+    end
+
+    def self.uncached_quads(b, id, abf, cf)
+      case b
       when :water    then water_quads(id, abf)
       when :animated then [full(3 + (id - BLOCK_C) / 50, 4 + cf)]
       when :terrain  then terrain_quads(id)
       when :lower    then [lower_quad(id - BLOCK_E)]
-      when :upper    then [upper_quad(id - BLOCK_F)]
-      else []
+      else                [upper_quad(id - BLOCK_F)]
       end
     end
 
@@ -4358,7 +4406,16 @@ module Game
   class Map
     attr_reader :id, :unit, :width, :height, :chipset_id
 
+    # Bumped whenever a lookup through #lower / #upper could answer differently
+    # than it did before, which today means only Tile Substitution -- the layer
+    # arrays themselves are set once here and never written again. The map
+    # renderer caches its composed tile layer and watches this to know when that
+    # cache is stale (see Scene::Map#tile_cache_valid?), so anything that starts
+    # rewriting tiles must bump it or the change will not reach the screen.
+    attr_reader :revision
+
     def initialize(id, unit)
+      @revision = 0
       @id = id
       @unit = unit
       @width = unit.width
@@ -4392,6 +4449,7 @@ module Game
       else
         table[old_id] = new_id
       end
+      @revision += 1
     end
 
     # Whether any tile on either layer is currently rewritten.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -865,6 +865,24 @@ module Game
       @quads_cache[key] = uncached_quads(b, id, abf, cf)
     end
 
+    # Whether an upper-layer id draws nothing, so the renderer can skip it.
+    #
+    # Two ids mean "no upper tile here". BLOCK_F -- the *first* upper id -- is
+    # the reserved blank chip, and it is what upper-layer map data is very
+    # nearly all made of: 98.45% of the 584,049 upper cells across Nepheshel's
+    # 543 maps, with the other 1.55% spread over 141 real ids. Drawing it
+    # blitted the chipset's blank cell ~330 times per grid rebuild for no
+    # pixels. A raw 0 is the other sentinel; no real map here uses it (it does
+    # not appear once in those 543 maps), but the lower layer's own ids start
+    # at 0, so a stray one must not be fed to .quads as water set 0.
+    #
+    # Rendering only. The blank id still indexes entry 0 of the chipset's
+    # upper *passability* table, which Game::ChipSet#upper_flags reads for
+    # real -- so this must not be used to skip a passability lookup.
+    def self.upper_blank?(id)
+      id.nil? || id == 0 || id == BLOCK_F
+    end
+
     # Which of the two animation inputs a tile id's quads actually move with:
     # :abf for the block A/B autotiles (every quarter takes its chipset column
     # from it -- see .water_quads), :cf for the block C animated chips, or nil

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -9734,15 +9734,17 @@ class RPG2k
 
             lower = @map.lower(tx, ty)
             upper = @map.upper(tx, ty)
+            upper_drawn = !Game::ChipsetLayout.upper_blank?(upper)
             note_anim_input lower
-            note_anim_input upper if upper && upper != 0
+            note_anim_input upper if upper_drawn
 
             if @chipset_bmp
               draw_tile @lower_tiles, lower, dx, dy, abf, cf
-              # 0 means "no upper tile" (the upper layer's own ids start at
-              # BLOCK_F); on the lower layer the same value is water set 0, so
-              # only this call may skip it. See Game::ChipsetLayout.block.
-              if upper && upper != 0
+              # Nothing to draw for the two "no upper tile here" ids -- the
+              # reserved blank chip the upper layer is almost entirely made of,
+              # and a raw 0. Only this call may skip them: on the lower layer 0
+              # is water set 0, a real tile. See ChipsetLayout.upper_blank?.
+              if upper_drawn
                 # Only a starred ("above hero") upper tile belongs in the
                 # buffer that composites over the player/events -- see
                 # Game::ChipSet#elevated? and its ABOVE_BIT comment. An
@@ -9760,7 +9762,7 @@ class RPG2k
             else
               # Fallback: solid colour blocks keyed by tile id (no chipset image).
               @lower_tiles.fill_rect dx, dy, TILE, TILE, tile_color(lower)
-              @upper_tiles.fill_rect dx, dy, TILE, TILE, tile_color(upper) if upper && upper != 0
+              @upper_tiles.fill_rect dx, dy, TILE, TILE, tile_color(upper) if upper_drawn
             end
           end
         end

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -266,6 +266,9 @@ class RPG2k
         @upper_viewport.dispose if @upper_viewport
         @flash_buffer.dispose if @flash_buffer
         @flash_out_buffer.dispose if @flash_out_buffer
+        # Held by no sprite (see #setup_sprites), so nothing else frees these.
+        @lower_tiles.dispose if @lower_tiles
+        @upper_tiles.dispose if @upper_tiles
         @chipset_bmp.dispose if @chipset_bmp
         @parallax_img.dispose if @parallax_img
       end
@@ -393,6 +396,15 @@ class RPG2k
         @lower_sprite.z = 0
         @lower_bmp = Bitmap.new(COLS * TILE, ROWS * TILE)
         @lower_sprite.bitmap = @lower_bmp
+
+        # The cached tile grids behind @lower_bmp / @upper_bmp: same size, but
+        # holding only the tiles, aligned to whole tiles and with no events on
+        # them, so a frame that changed nothing but the scroll remainder can be
+        # served by copying rather than by re-blitting the grid. Never attached
+        # to a sprite -- #draw_layers copies them into the two buffers above.
+        @lower_tiles = Bitmap.new(COLS * TILE, ROWS * TILE)
+        @upper_tiles = Bitmap.new(COLS * TILE, ROWS * TILE)
+        @tiles_built = false
 
         # The upper (above-character) chip layer lives in its own viewport
         # rather than @map_viewport, purely so a Show Battle Animation sprite
@@ -2792,10 +2804,11 @@ class RPG2k
 
       # A Tile Substitution rewrote a tile id on the current map (11750). The map
       # itself already answers every lookup with the substituted tile
-      # (Game::Map#substitute_tile), and draw_layers rebuilds both tile buffers
-      # from those lookups every frame, so the swap is on screen on the next
-      # render with nothing to invalidate here. Draining the flag is what keeps
-      # the request from being reported again next step.
+      # (Game::Map#substitute_tile), and that same call bumps Game::Map#revision,
+      # which is one of the things #tile_cache_valid? watches -- so the next
+      # render rebuilds the cached tile buffers and the swap is on screen, with
+      # nothing to invalidate by hand here. Draining the flag is what keeps the
+      # request from being reported again next step.
       def apply_tile_substitution(interp)
         interp.take_tiles_changed
         nil
@@ -9610,9 +9623,20 @@ class RPG2k
         out
       end
 
+      # Compose this frame's two tile buffers, then draw the events into them.
+      #
+      # The tiles themselves are not re-blitted every frame. They are built into
+      # a pair of cached buffers (@lower_tiles / @upper_tiles) that hold the grid
+      # on whole-tile boundaries, and each frame those are copied across at the
+      # sub-tile scroll offset. That copy is two full-surface blits instead of
+      # ~670 per-tile ones, and the expensive build behind it only re-runs when
+      # something it depends on actually changed -- see #tile_cache_valid?.
+      #
+      # The events cannot go in the cache: they move every frame and composite
+      # into these same two buffers (see #event_target_buffer), which is exactly
+      # why the buffers stay separate from the cache rather than being drawn to
+      # directly.
       def draw_layers cam_x, cam_y
-        @lower_bmp.clear
-        @upper_bmp.clear
         first_tx = cam_x / TILE
         first_ty = cam_y / TILE
         ox = cam_x % TILE
@@ -9626,18 +9650,95 @@ class RPG2k
           cf = Game::ChipsetLayout.anim_c(@anim_frame)
         end
 
+        unless tile_cache_valid?(first_tx, first_ty, abf, cf)
+          rebuild_tile_cache(first_tx, first_ty, abf, cf)
+        end
+
+        @lower_bmp.clear
+        @upper_bmp.clear
+        # Shifting by taking the source from (ox, oy) rather than blitting to
+        # (-ox, -oy) is the same picture -- the cache is one tile wider and
+        # taller than the screen precisely so the scrolled-in edge is there to
+        # copy -- and keeps every coordinate non-negative. The strip past the
+        # shifted grid is what the clears above leave transparent, exactly as
+        # the old per-tile loop did (it never drew there either).
+        #
+        # #copy_blt, not #blt: the destination was just cleared, and blending
+        # onto transparency returns the source unchanged, so the two draw the
+        # same picture here -- but #blt pays a per-pixel read/blend/write for
+        # it, which on these two 336x256 surfaces measured ~5ms a frame.
+        src = Rect.new(ox, oy, COLS * TILE - ox, ROWS * TILE - oy)
+        @lower_bmp.copy_blt 0, 0, @lower_tiles, src
+        @upper_bmp.copy_blt 0, 0, @upper_tiles, src
+
+        draw_events cam_x, cam_y
+      end
+
+      # Whether the cached tile buffers still show what this frame wants.
+      #
+      # Everything the build reads has to be covered here, or the change never
+      # reaches the screen. In order: the cache has been built at all; the grid
+      # has not scrolled onto a different first tile (the sub-tile remainder is
+      # applied at copy time, so it is deliberately *not* part of this); the
+      # animation has not stepped; the map object is the same one (a teleport
+      # swaps it); its tile lookups still answer the same (Tile Substitution --
+      # see Game::Map#revision); and the tileset has not been swapped under us.
+      # The two animation inputs are only compared when the grid actually holds
+      # a tile that moves with them (see Game::ChipsetLayout.anim_input): an
+      # indoor map with no water and no block C chip is the same picture in
+      # every animation state, and rebuilding it on their schedule would be
+      # pure waste -- .anim_c alone steps ten times a second.
+      def tile_cache_valid?(first_tx, first_ty, abf, cf)
+        @tiles_built &&
+          @tiles_tx == first_tx && @tiles_ty == first_ty &&
+          (!@tiles_uses_abf || @tiles_abf == abf) &&
+          (!@tiles_uses_cf || @tiles_cf == cf) &&
+          @tiles_map.equal?(@map) &&
+          @tiles_revision == @map.revision &&
+          @tiles_chipset.equal?(@chipset) &&
+          @tiles_chipset_bmp.equal?(@chipset_bmp)
+      end
+
+      # Drop the cached tile buffers, forcing the next render to rebuild them.
+      # Only needed for a change #tile_cache_valid? cannot see by itself.
+      def invalidate_tile_cache
+        @tiles_built = false
+      end
+
+      # Record that this tile ties the grid to one of the animation inputs.
+      def note_anim_input(id)
+        case Game::ChipsetLayout.anim_input(id)
+        when :abf then @tiles_uses_abf = true
+        when :cf  then @tiles_uses_cf = true
+        end
+      end
+
+      # Re-blit the whole visible grid into the cached buffers, on whole-tile
+      # boundaries (the scroll remainder is applied when they are copied out).
+      # This is the expensive path the cache exists to avoid running per frame.
+      def rebuild_tile_cache(first_tx, first_ty, abf, cf)
+        @lower_tiles.clear
+        @upper_tiles.clear
+        # Whether anything actually drawn this pass moves with the animation
+        # columns/frames, which is what #tile_cache_valid? consults rather than
+        # assuming every map animates.
+        @tiles_uses_abf = false
+        @tiles_uses_cf = false
+
         (0...ROWS).each do |ry|
           (0...COLS).each do |rx|
             tx = first_tx + rx
             ty = first_ty + ry
-            dx = rx * TILE - ox
-            dy = ry * TILE - oy
+            dx = rx * TILE
+            dy = ry * TILE
 
             lower = @map.lower(tx, ty)
             upper = @map.upper(tx, ty)
+            note_anim_input lower
+            note_anim_input upper if upper && upper != 0
 
             if @chipset_bmp
-              draw_tile @lower_bmp, lower, dx, dy, abf, cf
+              draw_tile @lower_tiles, lower, dx, dy, abf, cf
               # 0 means "no upper tile" (the upper layer's own ids start at
               # BLOCK_F); on the lower layer the same value is water set 0, so
               # only this call may skip it. See Game::ChipsetLayout.block.
@@ -9651,20 +9752,28 @@ class RPG2k
                 # so it draws behind a character standing on or against it
                 # rather than masking them outright.
                 if @chipset.elevated?(upper)
-                  draw_tile @upper_bmp, upper, dx, dy, abf, cf
+                  draw_tile @upper_tiles, upper, dx, dy, abf, cf
                 else
-                  draw_tile @lower_bmp, upper, dx, dy, abf, cf
+                  draw_tile @lower_tiles, upper, dx, dy, abf, cf
                 end
               end
             else
               # Fallback: solid colour blocks keyed by tile id (no chipset image).
-              @lower_bmp.fill_rect dx, dy, TILE, TILE, tile_color(lower)
-              @upper_bmp.fill_rect dx, dy, TILE, TILE, tile_color(upper) if upper && upper != 0
+              @lower_tiles.fill_rect dx, dy, TILE, TILE, tile_color(lower)
+              @upper_tiles.fill_rect dx, dy, TILE, TILE, tile_color(upper) if upper && upper != 0
             end
           end
         end
 
-        draw_events cam_x, cam_y
+        @tiles_built = true
+        @tiles_tx = first_tx
+        @tiles_ty = first_ty
+        @tiles_abf = abf
+        @tiles_cf = cf
+        @tiles_map = @map
+        @tiles_revision = @map.revision
+        @tiles_chipset = @chipset
+        @tiles_chipset_bmp = @chipset_bmp
       end
 
       # Draw every event's graphic into the tile buffers, layered so it composits

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -78,6 +78,13 @@ module RGSS
     def blt(*a); (@blt_calls ||= []) << a; end
     attr_reader :blt_calls
     def clear_blt_calls; @blt_calls = []; end
+    # The non-blending copy the map renderer moves its cached tile grid with
+    # (see Bitmap#copy_blt in mruby-rgss/src/lib.cxx). Recorded apart from
+    # #blt_calls so a check counting *tile* draws is not confused by the one
+    # whole-grid copy per frame.
+    def copy_blt(*a); (@copy_blt_calls ||= []) << a; end
+    attr_reader :copy_blt_calls
+    def clear_copy_blt_calls; @copy_blt_calls = []; end
     # Recorded so the picture layering check can assert *which order* sources
     # were composited in, not only that drawing happened.
     def stretch_blt(*a); (@stretch_calls ||= []) << a; end
@@ -10223,7 +10230,10 @@ check 'the map is hidden while the battle screen is up, so the backdrop actually
     # behaviour. The fight's own hide/show below is checked exactly instead.
     ok vp.visible != false, 'the map view draws normally before any fight opens'
     ok upper.visible != false, 'and so does the above-character layer'
-    ok !(lower_bmp.blt_calls || []).empty?, 'and the tile layers do composite'
+    # The tile layers reach the frame buffer as the cached grid's #copy_blt
+    # (see Scene::Map#draw_layers), so that -- not #blt, which now only carries
+    # the events drawn over it -- is what says compositing happened at all.
+    ok !(lower_bmp.copy_blt_calls || []).empty?, 'and the tile layers do composite'
   end
   ui = scene.instance_variable_get(:@battle_ui)
   ok ui, 'the battle opened'
@@ -10233,9 +10243,12 @@ check 'the map is hidden while the battle screen is up, so the backdrop actually
   eq false, vp.visible, 'so the map view is hidden the instant the battle screen is up'
   eq false, upper.visible, 'and so is the above-character layer'
   lower_bmp.clear_blt_calls
+  lower_bmp.clear_copy_blt_calls
   scene.update
-  eq 0, (lower_bmp.blt_calls || []).size,
+  eq 0, (lower_bmp.copy_blt_calls || []).size,
      'and the tile layers stop compositing entirely while the fight runs'
+  eq 0, (lower_bmp.blt_calls || []).size,
+     'and nothing draws over them either'
 
   20.times do
     scene.update
@@ -10244,7 +10257,7 @@ check 'the map is hidden while the battle screen is up, so the backdrop actually
   eq nil, scene.instance_variable_get(:@battle_ui), 'the battle closed again'
   eq true, vp.visible, 'the map view reappears the instant the fight ends'
   eq true, upper.visible, 'and so does the above-character layer'
-  ok !(lower_bmp.blt_calls || []).empty?, 'and the tile layers composite again'
+  ok !(lower_bmp.copy_blt_calls || []).empty?, 'and the tile layers composite again'
 end
 
 # yado.tk: a Battle Interrupt (Terminate Battle, 13410) satisfies neither the
@@ -13786,22 +13799,95 @@ check 'draw_layers routes an unstarred upper tile behind the player, a starred o
                                               lower_layer: Array.new(w * h, 0),
                                               upper_layer: upper, events: {}))
   scene = RPG2k::Scene::Map.new(fake_parent(db), state)
-  lower = scene.instance_variable_get(:@lower_bmp)
-  upper_bmp = scene.instance_variable_get(:@upper_bmp)
+  # The tiles are blitted into the *cached* grids, which #draw_layers then
+  # copies into @lower_bmp / @upper_bmp at the sub-tile scroll offset. The
+  # routing under test (Game::ChipSet#elevated? picking the grid) happens on
+  # the way into these, so this is where it is observable; @lower_bmp only ever
+  # sees the one whole-grid copy plus whatever events draw over it.
+  lower = scene.instance_variable_get(:@lower_tiles)
+  upper_bmp = scene.instance_variable_get(:@upper_tiles)
   lower.clear_blt_calls
   upper_bmp.clear_blt_calls
+  scene.send(:invalidate_tile_cache)
   scene.send(:draw_layers, 0, 0)
   tile = RPG2k::Scene::Map::TILE
   at = ->(calls, x, y) { calls.count { |c| c[0] == x && c[1] == y } }
   # (0, 0) always gets one blit for its own (plain, id 0) lower tile; the
   # unstarred upper tile at the same spot is a *second* blit into the same
-  # buffer, not one into the upper buffer.
+  # grid, not one into the upper grid.
   eq 2, at.call(lower.blt_calls, 0, 0),
      'the plain floor and the unstarred upper tile both land in the lower buffer'
   eq 0, at.call(upper_bmp.blt_calls, 0, 0), 'the unstarred tile never reaches the upper buffer'
   # (TILE, 0) also gets its own plain lower tile, but the starred upper tile
   # there is the one that must reach the upper (above-player) buffer.
   eq 1, at.call(upper_bmp.blt_calls, tile, 0), 'the starred tile lands in the upper buffer'
+end
+
+# The tile grid is cached across frames (see Scene::Map#tile_cache_valid?), so
+# what needs pinning down is not that a tile is drawn but *when* it is redrawn:
+# too eager and the cache buys nothing, too lazy and a change never reaches the
+# screen. Each case below counts blits into the cached grid across a second
+# #draw_layers, which is zero exactly when the cache was reused.
+def tile_cache_probe(map: nil, &change)
+  w = 8; h = 8
+  db = fake_db
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = map || Game::Map.new(1, OpenStruct.new(
+    width: w, height: h, chipset_id: 1,
+    lower_layer: Array.new(w * h, 0), upper_layer: Array.new(w * h, 0),
+    events: {}))
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  scene.send(:draw_layers, 0, 0) # prime the cache
+  grid = scene.instance_variable_get(:@lower_tiles)
+  grid.clear_blt_calls
+  cam = change ? change.call(scene, state) : [0, 0]
+  scene.send(:draw_layers, cam[0], cam[1])
+  grid.blt_calls.size
+end
+
+check 'a frame that changed nothing reuses the cached tile grid' do
+  eq 0, tile_cache_probe, 'an identical frame must not re-blit a single tile'
+end
+
+check 'scrolling within a tile reuses the cache, crossing a tile rebuilds it' do
+  # A sub-tile scroll is applied when the cached grid is copied out, so the grid
+  # itself is untouched; stepping onto the next tile changes which tiles it holds.
+  eq 0, tile_cache_probe { |_s, _st| [RPG2k::Scene::Map::TILE - 1, 0] }
+  ok tile_cache_probe { |_s, _st| [RPG2k::Scene::Map::TILE, 0] } > 0,
+     'crossing a tile boundary must rebuild the grid'
+end
+
+check 'a Tile Substitution rebuilds the cached tile grid' do
+  # The map answers lookups differently from now on, and Game::Map#revision is
+  # what tells the cache so -- without that bump the swap would never be drawn.
+  ok(tile_cache_probe do |_s, st|
+    st.map.substitute_tile(0, 0, Game::ChipsetLayout::BLOCK_E)
+    [0, 0]
+  end > 0, 'a substituted tile must reach the screen')
+end
+
+check 'stepping the tile animation rebuilds the cached tile grid' do
+  # Water and the block-C animated tiles cycle off @anim_frame, so a frame that
+  # advances the animation column is a different picture even standing still.
+  # The probe map is all tile id 0, a block A/B autotile, so it moves with
+  # .anim_ab -- frame 24 is that input's first step at the default speed. Note
+  # a *cycle* is not a step: .anim_ab(96) is back to 0, so a probe there would
+  # see, correctly, no rebuild at all.
+  ok(tile_cache_probe do |s, _st|
+    s.instance_variable_set(:@anim_frame, 24)
+    [0, 0]
+  end > 0, 'an animation step must reach the screen')
+end
+
+check 'an animation step the visible tiles do not follow leaves the cache alone' do
+  # .anim_c steps every 6 frames but drives only the block C animated chips. A
+  # grid holding none of them -- all id 0 here, which is block A/B -- is the
+  # same picture either way, and rebuilding it ten times a second for an input
+  # nothing on screen reads was most of the cache's remaining cost.
+  eq 0, tile_cache_probe { |s, _st|
+    s.instance_variable_set(:@anim_frame, 6)
+    [0, 0]
+  }, 'a grid with no block C tile must not rebuild for .anim_c'
 end
 
 check 'a clear member walks the same ground untouched' do

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -13782,7 +13782,10 @@ end
 # completely instead of showing him through the bed's own unstarred tiles.
 check 'draw_layers routes an unstarred upper tile behind the player, a starred one in front' do
   up = Array.new(144, 0)
-  up[0] = Game::ChipSet::ALL_DIRS                             # unstarred (e.g. a headboard)
+  # Index 2, not 0: index 0 is the id BLOCK_F itself, the reserved blank chip
+  # the renderer skips outright (ChipsetLayout.upper_blank?), so it cannot
+  # stand in for a real unstarred tile here.
+  up[2] = Game::ChipSet::ALL_DIRS                             # unstarred (e.g. a headboard)
   up[1] = Game::ChipSet::ALL_DIRS | Game::ChipSet::ABOVE_BIT  # starred
   row_class = Struct.new(:name, :chipset_name, :passable_data_lower,
                          :passable_data_upper, :terrain_data,
@@ -13792,7 +13795,7 @@ check 'draw_layers routes an unstarred upper tile behind the player, a starred o
   w = 6; h = 5
   upper = Array.new(w * h, 0)
   bf = Game::ChipsetLayout::BLOCK_F
-  upper[0] = bf       # (0, 0): unstarred
+  upper[0] = bf + 2   # (0, 0): unstarred
   upper[1] = bf + 1   # (1, 0): starred
   state = Game::State.new(fake_party, 1, 0, 0)
   state.map = Game::Map.new(1, OpenStruct.new(width: w, height: h, chipset_id: 1,
@@ -13821,6 +13824,56 @@ check 'draw_layers routes an unstarred upper tile behind the player, a starred o
   # (TILE, 0) also gets its own plain lower tile, but the starred upper tile
   # there is the one that must reach the upper (above-player) buffer.
   eq 1, at.call(upper_bmp.blt_calls, tile, 0), 'the starred tile lands in the upper buffer'
+  # Every other cell of this map is the blank first id, which draws nothing at
+  # all -- so the lower buffer is exactly the map's own tiles plus the one
+  # unstarred upper tile that landed in it. Cells outside the map draw nothing
+  # either (#lower answers nil there), and id 0 is a block A/B autotile, so
+  # each tile is its four quarters rather than one blit -- both taken from the
+  # code rather than written out, so this says "no extra blit" and not "121".
+  per_tile = Game::ChipsetLayout.quads(0, 0, 0).size
+  eq w * h * per_tile + 1, lower.blt_calls.size,
+     'the blank upper id adds no blit anywhere'
+end
+
+# RPG2000's upper layer is overwhelmingly the reserved blank chip -- 98% of the
+# upper cells across Nepheshel's 543 maps -- and drawing it blitted a
+# fully-transparent chipset cell once per tile for nothing. It is a *drawing*
+# sentinel only: it still indexes entry 0 of the chipset's upper passability
+# table, which is a real lookup, so skipping the draw must not leak into
+# passability.
+check 'the reserved blank upper id draws nothing but still answers passability' do
+  up = Array.new(144, 0)
+  up[0] = 0                      # BLOCK_F itself: blocked on every side
+  up[3] = Game::ChipSet::ALL_DIRS
+  row_class = Struct.new(:name, :chipset_name, :passable_data_lower,
+                         :passable_data_upper, :terrain_data,
+                         :animation_type, :animation_speed)
+  db = fake_db
+  db.chipset[1] = row_class.new('cs', 'cs', nil, up, nil, 0, 0)
+  w = 4; h = 4
+  bf = Game::ChipsetLayout::BLOCK_F
+  upper = Array.new(w * h, bf)   # every cell blank, as a real map very nearly is
+  state = Game::State.new(fake_party, 1, 0, 0)
+  state.map = Game::Map.new(1, OpenStruct.new(width: w, height: h, chipset_id: 1,
+                                              lower_layer: Array.new(w * h, 0),
+                                              upper_layer: upper, events: {}))
+  scene = RPG2k::Scene::Map.new(fake_parent(db), state)
+  lower = scene.instance_variable_get(:@lower_tiles)
+  upper_bmp = scene.instance_variable_get(:@upper_tiles)
+  lower.clear_blt_calls
+  upper_bmp.clear_blt_calls
+  scene.send(:invalidate_tile_cache)
+  scene.send(:draw_layers, 0, 0)
+  # The lower layer's own tiles, and nothing more. (Only the map's own cells
+  # draw -- the grid is bigger than this 4x4 map and #lower answers nil past
+  # its edge -- and id 0 is an autotile, so each is its four quarters.)
+  eq w * h * Game::ChipsetLayout.quads(0, 0, 0).size, lower.blt_calls.size,
+     'a blank upper layer costs exactly the lower layer'
+  eq 0, upper_bmp.blt_calls.size, 'and nothing reaches the above-player buffer'
+  # ... while the passability table still reads through it: entry 0 here blocks
+  # every direction, so the blank id is not silently treated as "no tile".
+  cs = scene.instance_variable_get(:@chipset)
+  eq false, cs.passable_tile?(0, bf, 2), 'the blank id still blocks per its passability entry'
 end
 
 # The tile grid is cached across frames (see Scene::Map#tile_cache_valid?), so


### PR DESCRIPTION
Follow-up to #845, which measured the RPG2000 map frame and put two thirds of
it in one loop. This removes that work.

`Scene::Map#draw_layers` re-blitted all 336 visible tiles every frame — whether
or not the camera moved, whether or not anything animated, whether or not a
single pixel of the map had changed — through a `ChipsetLayout.quads` that
allocated a fresh array per tile.

## Result

| | before | after |
| --- | ---: | ---: |
| frame work | 34.1ms | **8.7ms** |
| `map.layers` | 22.7ms | **2.3ms** |
| fps (60 target) | 20 | **57** |
| mruby allocs/sec | ~350k | ~30k |

The frame now fits inside the 16.67ms budget with room to spare; before, every
frame was over it and counted as a drop.

## What changed

1. **`ChipsetLayout.quads` is memoised** on `(id, abf, cf)`, which is the whole
   of its input. Resolving the tile's block first both answers the inputs with
   no quads at all (`nil` ids — the renderer draws the map edge every frame)
   and bounds the cache key, so it cannot become a bignum on the 32-bit
   `mrb_int` builds (Emscripten / PSP / Wio).

2. **The visible grid is cached.** It is built on whole-tile boundaries and
   copied out at the sub-tile scroll offset, rebuilt only when
   `#tile_cache_valid?` sees a real change: a tile crossing, an animation input
   *the visible tiles actually follow*, a Tile Substitution (via the new
   `Game::Map#revision`), a tileset swap, or a new map. Events cannot be cached
   — they move every frame and composite into the same buffers — which is why
   the cache sits behind the frame buffers rather than replacing them.

   Only the animation input something on screen reads counts: `.anim_c` steps
   every 6 frames but drives only the block C chips, and keying on it blindly
   rebuilt 18% of frames rather than 4%.

3. **`Bitmap#copy_blt`** (new). The per-frame copy then dominated: two 336x256
   surfaces through `#blt` cost ~5ms a frame alpha-blending onto a buffer that
   had *just been cleared*. Row-wise `memcpy` instead, ~1.8ms.

4. **The upper layer's reserved blank chip is not drawn.** RPG2000's first
   upper-layer id (`BLOCK_F`) means "nothing here", and real data is very
   nearly all of it — 98.45% of the 584,049 upper cells across Nepheshel's 543
   maps — so a rebuild blitted a fully transparent chipset cell ~330 times for
   no pixels. 28% off a rebuild, which is the spike that drops frames.

   This is a *drawing* sentinel only: the blank id still indexes entry 0 of the
   chipset's upper passability table, and that lookup is untouched.

## Rendering is unchanged, and was diffed rather than argued

This renderer has pixel-parity commitments (ADR 0021), so:

- Frames were captured from builds before and after, driven to the same
  input-gated point in Nepheshel's opening (`--no_render_wait`, so the
  frame-driven waits do not desynchronise two builds running at different frame
  rates). **Zero differing pixels over the whole 640x435 map region** — tile
  layers, autotiles, furniture, character sprites.
- The blank-chip skip was diffed the same way and came out identical over the
  *whole* frame, which is the direct evidence that the chip it stopped drawing
  really was transparent rather than assumed to be.
- The coordinate mapping is unchanged by construction: taking the source from
  `(ox, oy)` maps cache pixel `rx*TILE + i` to `rx*TILE + i - ox`, exactly where
  the old per-tile loop drew it.

One honest caveat, found by a test rather than by reasoning: `#copy_blt` is
**not** byte-identical to `#blt` in one case. For a fully transparent source
pixel `#blt` bails out and leaves cleared black, where `#copy_blt` copies the
unused colour channels across. Nothing can observe it — `blend_over` weights the
destination by its own alpha, so a `da == 0` pixel contributes nothing to any
composite and does not render — but the first version of the test asserted full
equality and correctly failed. The test now pins the precise invariant and the
comments say so rather than overclaiming.

## Tests

A render cache fails silently — too lazy and the picture is simply wrong with
nothing raising — so `rpg2k_scene_check.rb` gains six checks on the behaviour
itself: a frame that changed nothing must not re-blit a single tile; a tile
crossing, a Tile Substitution and a followed animation step must each rebuild;
an animation step the visible tiles do *not* follow must not; and a map whose
upper layer is entirely the blank id must cost exactly its lower layer while
still answering passability through that id.

`mruby-rgss` gains three `copy_blt` tests (equivalence to `#blt` over every
alpha, replace-not-composite, and clipping).

Verified: 8/8 ctest, all 9 Ruby checks, the RPG2000 boot smoke test, and
pre-commit. `docs/profiling.md` is updated — its recorded baseline is what this
change invalidates.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C19A4U3szhL28GHwSVTgEW)_