### PR TITLE
Resolve per-swing weapon data for a two-weapon actor's basic Attack

### DIFF
--- a/changelog.d/rpg2k-two-weapon-per-swing-data.fixed.md
+++ b/changelog.d/rpg2k-two-weapon-per-swing-data.fixed.md
@@ -1,0 +1,12 @@
+- **A two-weapon actor's individual swings now each roll their own weapon's
+  hit rate, elemental attributes, weapon states, and crit chance, instead of
+  every swing reusing a value merged across both equipped weapons; and a
+  basic Attack is no longer capped at two swings.** Confirmed against
+  EasyRPG Player's source: each swing resolves to exactly one weapon —
+  never a merge across both — and the swing-count cap doesn't exist in the
+  original engine. A dual-wielding actor with two genuinely different
+  weapons previously had every swing use the higher hit rate, the union of
+  both weapons' elements, and either weapon's status-inflict chance,
+  instead of each swing acting as that specific weapon's own attack; and an
+  actor whose weapon combination totalled three or four swings only ever
+  attacked twice.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5826,6 +5826,48 @@ not yet verified:
   weapon plus one ordinary weapon summing to 3, not 2 — all three
   confirmed to fail against the pre-fix code before the fix (`#strike_count`
   did not exist at all).
+- ✅ **A two-weapon actor's individual swings now each roll their own
+  weapon's hit rate / elemental attributes / weapon states / crit chance,
+  instead of every swing reusing the same value merged (max/union) across
+  both equipped weapons; and `Battle#swing` no longer caps a basic Attack at
+  two swings.** Confirmed against EasyRPG's actual C++ source:
+  `Game_BattleAlgorithm::Normal::GetWeapon` (`src/game_battlealgorithm.cpp`)
+  resolves each swing to exactly *one* weapon — the primary weapon's own hit
+  count worth of swings, then the secondary's — and
+  `Game_Actor::GetHitChance`/`GetCriticalHitChance`'s own `ForEachEquipment`
+  (`src/game_actor.cpp`), `Attribute::ApplyAttributeNormalAttackMultiplier`
+  (`src/attribute.cpp`), and the weapon-state block of `Normal::vExecute`
+  all exclude the *other* weapon's slot outright for that swing — never a
+  merge across both. This engine's `#attack_hit_rate`/`#weapon_attributes`/
+  `#weapon_states`/`#weapon_crit_bonus` are each computed **once** per
+  `Combatant` (at construction time) and reused verbatim for every swing, so
+  a two-weapon actor with two genuinely different weapons (say, 80%-hit fire
+  sword and 60%-hit ice dagger with its own poison chance) had *both*
+  swings read the merged 80%-hit/[fire,ice]/poison-flagged blend, instead of
+  swing one being the sword's own 80%/fire/no-poison and swing two the
+  dagger's own 60%/ice/poison. Separately, `#swing` capped a basic Attack at
+  two `#deal_attack` calls no matter what `#strike_count` reported — a limit
+  that happened to match every value `#strike_count` could ever produce
+  before its own two-weapon fix above (1 or 2), so it went unnoticed until a
+  two-weapon actor with one `dual_attack` weapon could report 3 (or 4);
+  EasyRPG's own `SetRepeat` takes the summed hit count as-is, with no cap.
+  Fixed with `Actor#swing_weapon_data(i)` (backed by a new
+  `#weapon_roll_data`/`#weapon_crit_chance`, the latter shared with
+  `#crit_chance`'s own bonus-plus-base-rate composition), which resolves
+  swing index `i`'s specific weapon and its own roll data; `Battle
+  #deal_attack` now takes a `swing_index`, temporarily substitutes that
+  weapon's data onto the `Combatant` for the call (restored in an `ensure`
+  clause so a later swing, or the enemy/single-weapon/fixture cases with no
+  override to make, see the ordinary merged fields again), and `#swing` now
+  loops `#strike_count` times rather than at most twice. Covered by three
+  new `scripts/rpg2k_logic_check.rb` battle-level checks — per-swing to-hit
+  (a 100%-hit weapon always lands, a low-hit weapon against a much nimbler
+  target clamps to a guaranteed miss, both on the *same* actor), per-swing
+  elemental attribute and weapon state (one swing's element is immune on the
+  target while the other's is unscaled, and each swing inflicts only its
+  own weapon's state, never both), and an actual three-swing basic Attack
+  landing all three hits rather than being capped at two — all three
+  confirmed to fail against the pre-fix code before the fix.
 - ✅ **An item's 使用回数 (`uses`, item field 6) is now honoured: a copy is spent
   only once it has been used that many times, `0` means 無制限 (never
   consumed), and the five equipment types are never consumed by use at all.**

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -1892,11 +1892,63 @@ module Game
     # individual weapon is itself flagged 二刀流, the common case for a
     # dual-wield setup built from two ordinary weapons.
     def strike_count
-      return dual_attack? ? 2 : 1 unless @db.respond_to?(:item)
-      weapons = @equipment.map { |iid| iid && iid != 0 ? @db.item[iid] : nil }
-                          .select { |it| it && it.respond_to?(:type) && it.type == ITEM_WEAPON }
+      weapons = equipped_weapons
       return dual_attack? ? 2 : 1 unless weapons.size >= 2
       weapons[0, 2].reduce(0) { |s, it| s + (it.respond_to?(:dual_attack) && it.dual_attack ? 2 : 1) }
+    end
+
+    # The equipped weapon-type items, in slot order (the weapon slot first,
+    # then the shield slot if it holds a weapon rather than a shield -- only
+    # possible for a `#double_hand?` actor). Shared by `#strike_count` and
+    # `#swing_weapon_data`.
+    def equipped_weapons
+      return [] unless @db.respond_to?(:item)
+      @equipment.map { |iid| iid && iid != 0 ? @db.item[iid] : nil }
+               .select { |it| it && it.respond_to?(:type) && it.type == ITEM_WEAPON }
+    end
+
+    # Which weapon governs swing index `i` (0-based) of a two-weapon actor's
+    # basic Attack -- EasyRPG's `Normal::GetWeapon`/`weapon_style`
+    # (`src/game_battlealgorithm.cpp`): the primary (weapon-slot) weapon's
+    # own hit count worth of swings, then the secondary (shield-slot)
+    # weapon's, each contributing *its own* hit rate / elemental attributes /
+    # weapon states / crit bonus rather than the merged max/union
+    # `#attack_hit_rate`/`#weapon_attributes`/`#weapon_states`/
+    # `#weapon_crit_bonus` compute across every equipped weapon-type item
+    # (correct for the ordinary single-weapon case, wrong once a second,
+    # *different* weapon governs a later swing). `Battle#deal_attack` reads
+    # this per swing; nil when fewer than two weapons are equipped, so it
+    # falls back to the ordinary merged Combatant fields.
+    def swing_weapon_data(i)
+      weapons = equipped_weapons
+      return nil unless weapons.size >= 2
+      w1, w2 = weapons[0, 2]
+      w1_hits = w1.respond_to?(:dual_attack) && w1.dual_attack ? 2 : 1
+      weapon_roll_data(i < w1_hits ? w1 : w2)
+    end
+
+    # The hit rate / elemental attributes / weapon states / crit chance a
+    # single equipped weapon item contributes on its own -- what
+    # `#swing_weapon_data` hands a specific weapon-governed swing, as
+    # opposed to `#attack_hit_rate`/`#weapon_attributes`/`#weapon_states`/
+    # `#crit_chance`'s own merge across every equipped weapon-type item.
+    def weapon_roll_data(it)
+      hit = it.respond_to?(:hit) && it.hit && it.hit > 0 ? it.hit : 90
+      attrs = []
+      set = it.respond_to?(:attribute_set) ? it.attribute_set : nil
+      set.each_with_index { |on, i| attrs << (i + 1) if on } if set
+      inflict = {}
+      heal = {}
+      sset = it.respond_to?(:state_set) ? it.state_set : nil
+      chance = it.respond_to?(:state_chance) ? (it.state_chance || 0) : 0
+      if sset && chance > 0
+        heals = rpg2003? && it.respond_to?(:reverse_state_effect) && it.reverse_state_effect
+        bucket = heals ? heal : inflict
+        sset.each_index { |i| bucket[i + 1] = chance if sset[i] && sset[i] != 0 }
+      end
+      crit = it.respond_to?(:critical_hit) ? (it.critical_hit || 0) : 0
+      { hit_rate: hit, atk_attrs: attrs, atk_states: { inflict: inflict, heal: heal },
+        crit_chance: weapon_crit_chance(crit) }
     end
 
     # 必中 — an equipped weapon whose attack cannot be evaded. RPG_RT's
@@ -2206,7 +2258,15 @@ module Game
     # -- a plain 1-in-30 actor crit 3.33% of the time here against RPG_RT's
     # flat 3%, an eleven percent relative inflation.
     def crit_chance
-      pct = weapon_crit_bonus
+      weapon_crit_chance(weapon_crit_bonus)
+    end
+
+    # `#crit_chance`'s own bonus-plus-base-rate formula, but taking the
+    # weapon bonus as a parameter rather than always `#weapon_crit_bonus`'s
+    # merged max -- shared with `#weapon_roll_data`, which needs the same
+    # composition for one specific weapon's own `critical_hit` bonus.
+    def weapon_crit_chance(bonus)
+      pct = bonus
       if @db_row.respond_to?(:has_critical_rate) && @db_row.has_critical_rate
         n = @db_row.respond_to?(:critical_rate) ? @db_row.critical_rate : 0
         pct += (100.0 / n).to_i if n && n > 0
@@ -9396,18 +9456,54 @@ module Game
     # critical hit, then halved (min 1) if the target defends. A target immune to
     # the weapon's element (0% rate) takes no damage. The crit note rides on the
     # log entry.
-    # One basic attack, which a 二刀流 weapon makes land **twice** (EasyRPG's
-    # `GetNumberOfAttacks`). Returns a single log entry for the ordinary case and
-    # an array when the weapon swings again, so the log reads the same as the
-    # enemy's own dual-attack action — whose "the second swing only lands if the
-    # first did not fell the target" rule this follows too.
+    # One basic attack, which a 二刀流 weapon (or a two-weapon actor -- see
+    # `Actor#strike_count`, which can total more than two swings once one of
+    # the two equipped weapons is itself 二刀流) makes land more than once
+    # (EasyRPG's `GetNumberOfAttacks`/`Normal::Init`'s summed repeat count).
+    # Returns a single log entry for the ordinary one-swing case and an array
+    # for every other count, so the log reads the same as the enemy's own
+    # dual-attack action — whose "a later swing only lands if an earlier one
+    # did not fell the target" rule this follows too. Each swing index is
+    # handed to `#deal_attack`, which resolves a two-weapon actor's specific
+    # governing weapon for that swing (`Actor#swing_weapon_data`) rather than
+    # reusing the same merged hit/attribute/state/crit data for every swing.
     def swing(b, target)
-      first = deal_attack(b, target)
-      return first if b.strike_count < 2 || target.dead?
-      [first, deal_attack(b, target)]
+      entries = []
+      b.strike_count.times do |i|
+        entries << deal_attack(b, target, i)
+        break if target.dead?
+      end
+      entries.size == 1 ? entries.first : entries
     end
 
-    def deal_attack(b, target)
+    # `swing_index` (0-based) is which swing of the current basic Attack this
+    # is. For a two-weapon actor (`Actor#swing_weapon_data`), it resolves
+    # which of the two equipped weapons governs *this* swing and temporarily
+    # substitutes that weapon's own hit rate / elemental attributes / weapon
+    # states / crit chance for `b`'s ordinary merged Combatant fields --
+    # EasyRPG's `Normal::GetWeapon` resolves each swing to exactly one
+    # weapon's own data, never a merge across both (`ForEachEquipment`'s own
+    # `weapon != slot+1` exclusion). Restored before returning either way, so
+    # a later swing (or an unrelated read of `b`) sees the ordinary merged
+    # values again. Every other Combatant (an enemy, or an actor with at
+    # most one equipped weapon) has no override to make, so this is a no-op
+    # for them -- the merged fields already correctly describe their one
+    # weapon.
+    def deal_attack(b, target, swing_index = 0)
+      wdata = b.respond_to?(:actor) && b.actor.respond_to?(:swing_weapon_data) ? b.actor.swing_weapon_data(swing_index) : nil
+      saved = wdata ? [b.hit_rate, b.atk_attrs, b.atk_states, b.crit_chance] : nil
+      if wdata
+        b.hit_rate = wdata[:hit_rate]
+        b.atk_attrs = wdata[:atk_attrs]
+        b.atk_states = wdata[:atk_states]
+        b.crit_chance = wdata[:crit_chance]
+      end
+      deal_attack_with_current_weapon(b, target)
+    ensure
+      b.hit_rate, b.atk_attrs, b.atk_states, b.crit_chance = saved if saved
+    end
+
+    def deal_attack_with_current_weapon(b, target)
       # `attacker_ally` (unlike `target_ally`, which every hit already carries)
       # only appears on a plain Attack's own entry -- it is how
       # Scene::Map#play_battle_action_se tells a normal swing apart from a

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -14531,6 +14531,104 @@ check 'a 二刀流 actor with one dual_attack weapon sums 2 + 1, not just 2' do
   eq 3, hero.strike_count, "the dual_attack sword's 2 swings plus the dagger's 1"
 end
 
+check "battle: a two-weapon actor's swings each roll their own weapon's to-hit, " \
+      'not a merged max' do
+  # Confirmed against EasyRPG's actual C++ source: Game_BattleAlgorithm::
+  # Normal::GetWeapon (src/game_battlealgorithm.cpp) resolves each swing to
+  # exactly one weapon (the primary weapon's own hit count worth of swings,
+  # then the secondary's), and Game_Actor::GetHitChance's own
+  # ForEachEquipment (src/game_actor.cpp) excludes the *other* weapon's slot
+  # entirely -- never a merge/max across both. hit 100 always lands (its own
+  # agi term collapses to zero regardless of either side's Agility); a low
+  # hit rate against a much nimbler target clamps to a guaranteed miss (the
+  # agi term, `100 - (100-base)*(src+tgt)/(2*src)`, goes negative and clamps
+  # to 0). Before this fix, both swings read #attack_hit_rate's merged max
+  # (100, from whichever weapon has it) -- the low-hit weapon's swing would
+  # always land too, identically to the other weapon's.
+  items = { 1 => fake_item(type: 1, atk: 10, hit: 100), # always lands
+            2 => fake_item(type: 1, atk: 10, hit: 10) } # clamps to a guaranteed miss below
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 0, agi: 10 })
+  row.double_hand = true
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  actor = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(actor, 1, Game::Actor::WEAPON_SLOT)
+  ok st.party.equip_from_bag(actor, 2, Game::Actor::SHIELD_SLOT)
+  hero = Game::Battle.from_actor(actor)
+  foe = combatant('Foe', 0, 0, 20, 999) # much nimbler than the hero's agi 10
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), {}, false, false, true)
+  first, second = bat.send(:swing, hero, foe)
+  ok !first[:missed], 'swing 1 (the hit-100 weapon) always lands'
+  eq true, second[:missed], "swing 2 (the hit-10 weapon) always misses -- its own roll, " \
+                            'clamped to 0 against a much nimbler target'
+end
+
+check "battle: a two-weapon actor's swings each carry their own weapon's " \
+      'elemental attribute and state, not a union of both' do
+  # Same GetWeapon/ForEachEquipment exclusion as the to-hit check above, but
+  # for Attribute::ApplyAttributeNormalAttackMultiplier and the weapon-state
+  # block of Normal::vExecute (both also gated on that swing's own resolved
+  # weapon, per EasyRPG's src/attribute.cpp and src/game_battlealgorithm.cpp).
+  # Both weapons hit 100 so accuracy never interferes; element 1 is immune
+  # (rank 4 -> 0%) and element 2 is normal (rank 2 -> 100%) on the target.
+  items = { 1 => fake_item(type: 1, atk: 40, hit: 100, attribute_set: [true, false],
+                           state_set: [1, 0], state_chance: 100),   # element 1, state 1
+            2 => fake_item(type: 1, atk: 40, hit: 100, attribute_set: [false, true],
+                           state_set: [0, 1], state_chance: 100) }  # element 2, state 2
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 0, agi: 10 })
+  row.double_hand = true
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  actor = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(actor, 1, Game::Actor::WEAPON_SLOT)
+  ok st.party.equip_from_bag(actor, 2, Game::Actor::SHIELD_SLOT)
+  hero = Game::Battle.from_actor(actor)
+  foe = combatant('Foe', 0, 0, 10, 999)
+  foe.attr_ranks = { 1 => 4, 2 => 2 } # immune to 1, normal to 2
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), { 1 => fake_state, 2 => fake_state },
+                        false, false, false)
+  first, second = bat.send(:swing, hero, foe)
+  eq 0, first[:damage], "swing 1's own element (1) is immune on the target"
+  ok first[:damage] < second[:damage], "swing 2's own element (2) is unscaled, unlike swing 1's"
+  eq [1], first[:inflicted], "swing 1 only rolls its own weapon's state (1)"
+  eq [2], second[:inflicted], "swing 2 only rolls its own weapon's state (2), not both"
+end
+
+check 'battle: #swing actually lands three attacks when strike_count is three, ' \
+      'not capped at two' do
+  # #swing previously hardcoded "at most two attacks" (`deal_attack` once,
+  # then a second only if strike_count >= 2) -- a limit that happened to
+  # match every *previous* strike_count value (1 or 2, #dual_attack?'s own
+  # binary range), so it went unnoticed until a two-weapon actor with one
+  # dual_attack weapon could report 3 (or 4). EasyRPG's own SetRepeat takes
+  # the summed hit count as-is, with no such cap.
+  items = { 1 => fake_item(type: 1, atk: 5, hit: 100, dual_attack: true), # 2 swings
+            2 => fake_item(type: 1, atk: 5, hit: 100) }                  # 1 swing
+  row = FakePlayerRow.new('Hero', '', 0, 5,
+                          { max_hp: 100, max_mp: 30, atk: 10, def: 0, agi: 10 })
+  row.double_hand = true
+  db = FakeActorDB.new({ 1 => row }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  actor = st.party.actor_by_id(1)
+  st.party.gain_item(1, 1)
+  st.party.gain_item(2, 1)
+  ok st.party.equip_from_bag(actor, 1, Game::Actor::WEAPON_SLOT)
+  ok st.party.equip_from_bag(actor, 2, Game::Actor::SHIELD_SLOT)
+  eq 3, actor.strike_count
+  hero = Game::Battle.from_actor(actor)
+  foe = combatant('Foe', 0, 0, 10, 999)
+  bat = Game::Battle.new([hero], [foe], Game::Rng.new(1), {}, false, false, true)
+  entries = bat.send(:swing, hero, foe)
+  eq 3, entries.size, 'all three swings actually happened, not capped at two'
+  ok entries.none? { |e| e[:missed] }, 'hit 100 on both weapons: every swing lands'
+end
+
 check 'a shield is rejected for a 二刀流 actor\'s shield slot even named directly' do
   st = double_hand_party
   hero = st.party.actor_by_id(1)


### PR DESCRIPTION
## Summary
- A two-weapon actor's individual swings now each roll their own weapon's hit rate / elemental attributes / weapon states / crit chance, instead of every swing reusing the same value merged (max/union) across both equipped weapons; and `Battle#swing` no longer caps a basic Attack at two swings.
- Confirmed against EasyRPG's actual C++ source: `Game_BattleAlgorithm::Normal::GetWeapon` (`src/game_battlealgorithm.cpp`) resolves each swing to exactly *one* weapon — the primary weapon's own hit count worth of swings, then the secondary's — and `Game_Actor::GetHitChance`/`GetCriticalHitChance`'s own `ForEachEquipment` (`src/game_actor.cpp`), `Attribute::ApplyAttributeNormalAttackMultiplier` (`src/attribute.cpp`), and the weapon-state block of `Normal::vExecute` all exclude the *other* weapon's slot outright for that swing — never a merge across both.
- This engine's `#attack_hit_rate`/`#weapon_attributes`/`#weapon_states`/`#weapon_crit_bonus` are each computed **once** per `Combatant` (at construction time) and reused verbatim for every swing, so a two-weapon actor with two genuinely different weapons (say, an 80%-hit fire sword and a 60%-hit ice dagger with its own poison chance) had *both* swings read the merged 80%-hit/[fire,ice]/poison-flagged blend, instead of swing one being the sword's own 80%/fire/no-poison and swing two the dagger's own 60%/ice/poison.
- Separately, `#swing` capped a basic Attack at two `#deal_attack` calls no matter what `#strike_count` reported — a limit that happened to match every value `#strike_count` could ever produce before its own two-weapon fix in #851 (1 or 2), so it went unnoticed until a two-weapon actor with one `dual_attack` weapon could report 3 (or 4); EasyRPG's own `SetRepeat` takes the summed hit count as-is, with no cap.
- Fixed with `Actor#swing_weapon_data(i)` (backed by a new `#weapon_roll_data`/`#weapon_crit_chance`, the latter shared with `#crit_chance`'s own bonus-plus-base-rate composition), which resolves swing index `i`'s specific weapon and its own roll data; `Battle#deal_attack` now takes a `swing_index`, temporarily substitutes that weapon's data onto the `Combatant` for the call (restored in an `ensure` clause so a later swing, or the enemy/single-weapon/fixture cases with no override to make, see the ordinary merged fields again), and `#swing` now loops `#strike_count` times rather than at most twice.

## Test plan
- [x] Three new `scripts/rpg2k_logic_check.rb` battle-level checks — per-swing to-hit (a 100%-hit weapon always lands, a low-hit weapon against a much nimbler target clamps to a guaranteed miss, both on the *same* actor), per-swing elemental attribute and weapon state (one swing's element is immune on the target while the other's is unscaled, and each swing inflicts only its own weapon's state, never both), and an actual three-swing basic Attack landing all three hits rather than being capped at two — all three confirmed to fail against the pre-fix code before the fix
- [x] `ruby scripts/rpg2k_logic_check.rb` — 881 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 594 checks passed
- [x] `ruby scripts/rpg2k_save_load_check.rb` — real save loads cleanly
- [x] `ruby scripts/rpg2k_testbed_logic_check.rb` — 130 checks passed
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v

---
_Generated by [Claude Code](https://claude.ai/code/session_011FBtSd9VnwM7vySVx45g5v)_