### PR TITLE
Fix Berserk/Confusion restriction priority to match real RPG_RT

### DIFF
--- a/changelog.d/battler-restriction-priority.fixed.md
+++ b/changelog.d/battler-restriction-priority.fixed.md
@@ -1,0 +1,16 @@
+- **Berserk (attack-enemy) now correctly beats Confusion (attack-ally) when
+  a battler is afflicted by both at once**, instead of Confusion winning.
+  `Game::Battle#battler_restriction` used to pick whichever restriction had
+  the larger raw database constant (`RESTRICTION_ATTACK_ALLY` = 3 vs
+  `RESTRICTION_ATTACK_ENEMY` = 2), which happens to get real RPG_RT's
+  priority backwards. EasyRPG Player's `State::GetSignificantRestriction`
+  (`src/state.cpp`) instead resolves a fixed hierarchy by restriction type —
+  do_nothing > attack_enemy > attack_ally > normal — while scanning every
+  afflicted state, with asymmetric upgrade rules (attack_enemy overrides
+  attack_ally or normal; attack_ally only overrides normal; a do_nothing
+  state anywhere short-circuits immediately). This matches デフォ戦bot's own
+  trivia: "同時に暴走と混乱の状態になった場合、暴走が優先されて敵を攻撃する"
+  ("Berserk and Confusion together: Berserk takes priority and attacks the
+  enemy"). `battler_restriction` now implements that same hierarchy.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks, confirmed to fail
+  against the pre-fix code before the fix.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -9692,14 +9692,28 @@ module Game
     end
 
     # The most disruptive "forced action" restriction among `b`'s states (0 = act
-    # normally). A "do nothing" state has already skipped the turn upstream, so
-    # only the attack-enemy / attack-ally restrictions matter here; the higher
-    # value (attack-ally) wins when several are present.
+    # normally). This is *not* a numeric max over the restriction constants --
+    # EasyRPG's `State::GetSignificantRestriction` (src/state.cpp) walks every
+    # afflicted state and tracks a fixed priority hierarchy, do_nothing >
+    # attack_enemy (berserk) > attack_ally (confusion) > normal, with
+    # asymmetric upgrade rules: attack_enemy overrides attack_ally or normal,
+    # but attack_ally only ever overrides normal (never attack_enemy), and
+    # do_nothing short-circuits immediately regardless of what else is
+    # present. Matches デフォ戦bot's own trivia: berserk beats confusion when
+    # both are active simultaneously, even though RESTRICTION_ATTACK_ALLY is
+    # numerically the larger constant.
     def battler_restriction(b)
       r = 0
       (b.states || []).each do |id|
         v = state_field(state_def(id), :restriction)
-        r = v if v > r && (v == RESTRICTION_ATTACK_ENEMY || v == RESTRICTION_ATTACK_ALLY)
+        case v
+        when RESTRICTION_DO_NOTHING
+          return RESTRICTION_DO_NOTHING
+        when RESTRICTION_ATTACK_ENEMY
+          r = RESTRICTION_ATTACK_ENEMY if r == 0 || r == RESTRICTION_ATTACK_ALLY
+        when RESTRICTION_ATTACK_ALLY
+          r = RESTRICTION_ATTACK_ALLY if r == 0
+        end
       end
       r
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -10928,6 +10928,40 @@ check 'battle: a berserk battler (restriction 2) attacks despite defending' do
   eq 80, slime.hp                                         # ...but berserk forced a 20 hit
 end
 
+# デフォ戦bot (@2000_battle_bot) trivia, confirmed against EasyRPG's own
+# State::GetSignificantRestriction (src/state.cpp): "同時に暴走と混乱の状態に
+# なった場合、暴走が優先されて敵を攻撃する" -- Berserk (attack-enemy) beats
+# Confusion (attack-ally) when both are inflicted simultaneously. That C++
+# resolves a *fixed priority hierarchy* by restriction type (do_nothing >
+# attack_enemy > attack_ally > normal) while scanning every afflicted state,
+# not a numeric max of the raw restriction constants -- RESTRICTION_ATTACK_ALLY
+# (3) is numerically larger than RESTRICTION_ATTACK_ENEMY (2), so a naive
+# `v > r` comparison gets this backwards and lets Confusion win instead.
+check 'battler_restriction: Berserk (attack_enemy) beats Confusion (attack_ally) together' do
+  states = { 6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0),   # attack-ally (confusion)
+             7 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0) }  # attack-enemy (berserk)
+  both = combatant('Both', 40, 0, 20, 100)
+  both.states = [6, 7]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([both], [slime], Game::Rng.new(1), states)
+  eq Game::Battle::RESTRICTION_ATTACK_ENEMY, bat.send(:battler_restriction, both),
+     'berserk must win over confusion regardless of the states array order'
+  both.states = [7, 6] # order must not matter: berserk still wins reversed
+  eq Game::Battle::RESTRICTION_ATTACK_ENEMY, bat.send(:battler_restriction, both)
+end
+
+check 'battler_restriction: a do_nothing state short-circuits over attack_enemy/attack_ally' do
+  states = { 6 => FakeStateDef.new(3, 0, 0, 0, 0, 0, 0),   # attack-ally (confusion)
+             7 => FakeStateDef.new(2, 0, 0, 0, 0, 0, 0),   # attack-enemy (berserk)
+             8 => FakeStateDef.new(1, 0, 0, 0, 0, 0, 0) }  # do-nothing (asleep/paralysed)
+  all_three = combatant('AllThree', 40, 0, 20, 100)
+  all_three.states = [6, 7, 8]
+  slime = combatant('Slime', 0, 0, 5, 100)
+  bat = Game::Battle.new([all_three], [slime], Game::Rng.new(1), states)
+  eq Game::Battle::RESTRICTION_DO_NOTHING, bat.send(:battler_restriction, all_three),
+     'do_nothing outranks both forced-attack restrictions, wherever it sits in the list'
+end
+
 # デフォ戦botまとめ: "Berserk/Confusion override target selection but still
 # honour 'hits twice'/'ignores evasion,' while Berserk additionally collapses
 # an 'attack all' weapon down to a single target and disables 'always acts


### PR DESCRIPTION
## Summary

- `Game::Battle#battler_restriction` (`mruby-rpg2k/mrblib/game.rb`) picked whichever forced-action restriction had the *larger raw database constant* when a battler carried more than one restriction-causing state — since `RESTRICTION_ATTACK_ALLY` (3) > `RESTRICTION_ATTACK_ENEMY` (2), this made Confusion always beat Berserk when both were active simultaneously.
- Real RPG_RT does the opposite: Berserk beats Confusion. Verified against EasyRPG Player's `State::GetSignificantRestriction` (`src/state.cpp`), which resolves a fixed priority hierarchy by restriction *type* — `do_nothing > attack_enemy > attack_ally > normal` — while scanning every afflicted state, with asymmetric upgrade rules (attack_enemy overrides attack_ally/normal; attack_ally only overrides normal; a `do_nothing` state anywhere short-circuits immediately). This also matches デフォ戦bot's own community trivia: "同時に暴走と混乱の状態になった場合、暴走が優先されて敵を攻撃する" ("Berserk and Confusion together: Berserk takes priority and attacks the enemy").
- `battler_restriction` now implements that same hierarchy instead of a numeric max.

## Test plan

- [x] Added `scripts/rpg2k_logic_check.rb` checks: Berserk beats Confusion regardless of state ordering, and a `do_nothing` state short-circuits over both forced-attack restrictions — both confirmed to fail against the pre-fix code before the fix.
- [x] `ruby scripts/rpg2k_logic_check.rb` passes (880 checks).
- [x] `ruby scripts/rpg2k_scene_check.rb` passes (594 checks).
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds via `scripts/native-build-without-nix.bash`.
- [x] Added a changelog fragment (`changelog.d/battler-restriction-priority.fixed.md`, category `fixed`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRCFVxwfsgVxdTT6Azs6vG)_