### PR TITLE
Draw RPG2003's gauge card status panel for battle_type 2

### DIFF
--- a/changelog.d/rpg2k-gauge-status-panel.added.md
+++ b/changelog.d/rpg2k-gauge-status-panel.added.md
@@ -1,0 +1,16 @@
+- **RPG2003's gauge battle-screen layout (`battlecommands.battle_type == 2`)
+  now replaces the party status panel with the real "gauge card" layout**
+  instead of the plain text status window: each living party member's face
+  (from the actor's `faceset_name`/`faceset_index`), an HP bar and an SP bar,
+  and their current values as digit-glyph numbers, all drawn from the
+  database's own `System2` graphic. Ported column-for-column from EasyRPG
+  Player's actual `Window_BattleStatus::Refresh`/`RefreshGauge`/
+  `DrawGaugeSystem2`/`DrawNumberSystem2` — including the exactly-full gauge
+  reading a visually distinct "full" fill tile, and `DrawNumberSystem2`'s
+  exact leading-zero-suppression cascade. `battle_type == 1` (alternative) is
+  unchanged and keeps the existing text status window; a database naming no
+  `System2` graphic (or one that fails to load) falls back to the text status
+  window instead of drawing a blank or crashing. The ATB/wait gauge row RPG_RT
+  also draws is out of scope — this runtime has no ATB/wait-timer subsystem.
+  Covered by new checks in `scripts/rpg2k_logic_check.rb` and
+  `scripts/rpg2k_scene_check.rb`.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3092,6 +3092,19 @@ module Game
       table && table.battle_type != 0 ? true : false
     end
 
+    # Whether the database asks specifically for RPG2003's gauge battle-screen
+    # presentation (`battlecommands.battle_type == 2`) -- distinct from
+    # `#alternate_battle_layout?` above, which is also true for the plain
+    # sprite-only layout (1). The party status panel reads this to know when
+    # to replace its text status window with the gauge card layout (see
+    # scene/map.rb's `#refresh_battle_status`); an alternative-layout (1)
+    # database, or one with no `#battlecommands` table at all, reads false.
+    def gauge_battle_layout?
+      return false unless @db.respond_to?(:battlecommands)
+      table = @db.battlecommands
+      table && table.battle_type == 2 ? true : false
+    end
+
     # RPG2003's battle-sprite placement choice (`battlecommands.placement`,
     # chunk 29 field 2 -- 0 manual, 1 automatic; see schema.rb). Manual is
     # `Game::Actor#battle_x`/`#battle_y` read as literal screen coordinates;

--- a/mruby-rpg2k/mrblib/scene/map.rb
+++ b/mruby-rpg2k/mrblib/scene/map.rb
@@ -99,6 +99,7 @@ class RPG2k
         @monster_cache = {}   # Monster/<name> (battler graphics)
         @animation_cache = {} # Battle/<name> (battle animation sheets)
         @battlecharset_cache = {} # BattleCharSet/<name> (RPG2003 actor battler sprites)
+        @system2_cache = {}   # System2/<name> (RPG2003 gauge card sprite sheet)
         apply_map_access if apply_access
         # Same Continue-only split as #apply_map_access just above: a fresh
         # map entry (New Game, or any Transfer Player/Teleport, which
@@ -833,8 +834,9 @@ class RPG2k
       # redrawn every frame -- and without this they would hit the decoder
       # again on every request. `cache` is the material's own hash (one of
       # @charset_cache, @picture_cache, @backdrop_cache, @monster_cache,
-      # @animation_cache, @battlecharset_cache), so a name is only ever looked up among graphics of
-      # its own kind. The block's result is cached as-is, including a
+      # @animation_cache, @battlecharset_cache, @system2_cache), so a name is
+      # only ever looked up among graphics of its own kind. The block's
+      # result is cached as-is, including a
       # nil/fallback for a failed load, so the caller's own rescue logs the
       # error once and every later call reuses that outcome instead of
       # retrying the disk.
@@ -6650,15 +6652,39 @@ class RPG2k
       # sprites and, when targeted, by the target window's name list. The row
       # of whichever actor is currently being commanded gets the cursor,
       # mirroring `status_window->SetIndex` in EasyRPG's `SelectNextActor`.
+      #
+      # `battle_type` 2 (gauge, `#gauge_battle_layout?`) replaces this whole
+      # panel with RPG2003's face/bar "gauge card" layout instead
+      # (`#battle_status_gauge_window`) -- `battle_type` 1 (alternative) is
+      # unchanged, and still builds the same text rows this always has, since
+      # only 2 asks for the card presentation (EasyRPG's own
+      # `Window_BattleStatus::Refresh`/`RefreshGauge` branch the same way, on
+      # `battle_type == BattleType_gauge` specifically, not on "not
+      # traditional"). Falls back to the text rows when the gauge window
+      # cannot be built (no System2 graphic, or a failed load) rather than
+      # leaving the panel blank.
       def refresh_battle_status
         @battle_ui[:status_win].dispose if @battle_ui[:status_win]
-        rows = @battle_ui[:allies].map { |a| battle_status_row(a) }
-        # No row highlighted while the options window is open -- matching
-        # `status_window->SetIndex(-1)` in `ProcessSceneActionFightAutoEscape`'s
-        # own `eMoveWindow` substate; nobody is "the acting actor" until
-        # Battle or Auto Battle is chosen.
-        idx = @battle_ui[:phase] == :battle_options ? nil : @battle_ui[:allies].index(current_actor)
-        @battle_ui[:status_win] = battle_status_window(rows, idx)
+        win = battle_status_gauge_window(@battle_ui[:allies]) if gauge_battle_layout?
+        @battle_ui[:status_win] = win || begin
+          rows = @battle_ui[:allies].map { |a| battle_status_row(a) }
+          # No row highlighted while the options window is open -- matching
+          # `status_window->SetIndex(-1)` in `ProcessSceneActionFightAutoEscape`'s
+          # own `eMoveWindow` substate; nobody is "the acting actor" until
+          # Battle or Auto Battle is chosen.
+          idx = @battle_ui[:phase] == :battle_options ? nil : @battle_ui[:allies].index(current_actor)
+          battle_status_window(rows, idx)
+        end
+      end
+
+      # Whether the database's `battlecommands.battle_type` is specifically 2
+      # (gauge) -- distinct from `Game::Party#alternate_battle_layout?`, which
+      # is also true for the plain sprite-only layout (1) and still uses the
+      # unchanged text status window for that case. A bare test fixture (or
+      # any database `#alternate_battle_layout?` itself already reads false
+      # for) reads false here too.
+      def gauge_battle_layout?
+        @state.party.respond_to?(:gauge_battle_layout?) && @state.party.gauge_battle_layout?
       end
 
       # One party member's row as [text, x, colour index] segments: name,
@@ -6675,6 +6701,158 @@ class RPG2k
       def battle_state_segment(b)
         text, color = state_display(b.states)
         [text, STATUS_STATE_X, color]
+      end
+
+      # `Window_BattleStatus`'s own default `actor_face_height` (24) -- the
+      # small-window variant (14) is `battlecommands.window_size`, which
+      # schema.rb has not decoded yet (see this change's changelog entry), so
+      # every gauge card always uses the large-window offset.
+      ACTOR_FACE_HEIGHT = 24
+
+      # The gauge card layout (`battle_type` 2): one 80px-wide card per party
+      # member -- face, HP/SP bars and digit-glyph numbers, drawn straight
+      # from the database's own System2 graphic -- ported column-for-column
+      # from EasyRPG's real `Window_BattleStatus::Refresh`/`RefreshGauge`
+      # (the `!enemy && battle_type == BattleType_gauge` branch of each).
+      # Borderless like RPG_RT's own gauge window (`Window#transparent=` --
+      # EasyRPG's constructor sets `border_x = border_y = 0` and
+      # `SetOpacity(0)` for this same case, "simulate a borderless window...
+      # makes the implementation on scene-side easier"), and never gets a
+      # cursor rect: `UpdateCursorRect` returns an empty rect unconditionally
+      # for this battle_type, so no row is ever highlighted here, unlike the
+      # text status window's acting-actor cursor. The ATB/wait gauge row
+      # `RefreshGauge` also draws (`DrawGaugeSystem2(..., GetAtbGauge,
+      # GetMaxAtbGauge, 2)`) is skipped -- this runtime has no ATB/wait-timer
+      # subsystem to read a value from. Returns nil (so `#refresh_battle_status`
+      # falls back to the plain text rows) when the database names no System2
+      # graphic, or names one that fails to load -- there is no sensible
+      # placeholder gauge sprite sheet the way there's a placeholder colour
+      # block for a missing battler graphic.
+      def battle_status_gauge_window(allies)
+        system2 = battle_system2_bitmap
+        return nil unless system2
+        inner_w = BATTLE_STATUS_W - Window::BORDER * 2
+        inner_h = BATTLE_PANEL_H - Window::BORDER * 2
+        win = Window.new(0, BATTLE_PANEL_Y, BATTLE_STATUS_W, BATTLE_PANEL_H)
+        win.z = 300
+        win.transparent = true
+        c = Bitmap.new(inner_w, inner_h)
+        allies.each_with_index { |ally, i| draw_battle_gauge_card(c, system2, ally, i) }
+        win.contents = c
+        win
+      end
+
+      # One party member's gauge card at column `i`. `ally` is a
+      # `Game::Battle::Combatant` (`Game::Battle.from_actor`) -- its `.actor`
+      # is the underlying `Game::Actor`, the only place `faceset_name`/
+      # `faceset_index` (chunk 11 fields 15/16, including any Change Actor
+      # Face override) live. Ported from `RefreshGauge`'s own gauge-card
+      # block: the face, then the bar's left cap / stretched centre / right
+      # cap at `System2` (0,32,16,48)/(16,32,16,48)/(32,32,16,48), then the
+      # HP row (`which` 0) and SP row (`which` 1) fills and numbers -- the
+      # exact x/y arithmetic (`32 + 80*i`, `40 + 80*i`, `y + 12 + 4`) is
+      # copied from the real source rather than re-derived.
+      def draw_battle_gauge_card(c, system2, ally, i)
+        draw_battle_gauge_face(c, ally.actor, i)
+        x = 32 + i * 80
+        y = ACTOR_FACE_HEIGHT
+        c.blt x, y, system2, Rect.new(0, 32, 16, 48)
+        x += 16
+        fill_x = x
+        c.stretch_blt Rect.new(x, y, 25, 48), system2, Rect.new(16, 32, 16, 48)
+        x += 25
+        c.blt x, y, system2, Rect.new(32, 32, 16, 48)
+        hp = ally.hp < 0 ? 0 : ally.hp
+        draw_gauge_system2(c, system2, fill_x, y, hp, ally.max_hp, 0)
+        draw_gauge_system2(c, system2, fill_x, y + 16, ally.mp, ally.max_mp, 1)
+        num_x = 40 + 80 * i
+        draw_number_system2(c, system2, num_x, y, hp)
+        draw_number_system2(c, system2, num_x, y + 12 + 4, ally.mp)
+      end
+
+      # The card's face portrait -- the same 48x48 FaceSet crop
+      # `#load_face_bitmap`/`FACE_SIZE` already draw for the name-entry and
+      # message-face screens, just placed at this card's column instead of
+      # its own window. Draws nothing (leaving the card's bars/numbers alone)
+      # for an actor with no faceset set, or a faceset file that fails to
+      # load, the same "a missing portrait shows nothing" rule
+      # `#load_face`/`#draw_kana_face` already use -- and, matching every
+      # other optional actor field this screen reads (`battler_animation_id`,
+      # `battle_x`/`battle_y`), `#respond_to?`-guarded so a bare test fixture
+      # actor with no faceset fields at all still draws the rest of the card.
+      def draw_battle_gauge_face(c, actor, i)
+        return unless actor && actor.respond_to?(:faceset_name)
+        face = load_face_bitmap(actor.faceset_name)
+        return unless face
+        index = actor.respond_to?(:faceset_index) ? (actor.faceset_index || 0) : 0
+        src = Rect.new((index % 4) * FACE_SIZE, (index / 4) * FACE_SIZE, FACE_SIZE, FACE_SIZE)
+        c.blt 80 * i, ACTOR_FACE_HEIGHT, face, src
+      end
+
+      # The HP (`which` 0) or SP (`which` 1) bar fill: a `25 * cur / max`
+      # wide stretch of the fill tile at `System2` `(48, 32 + 16*which, 16,
+      # 16)` -- except an exactly-full gauge (`cur == max`) reads the
+      # visually distinct "full" fill tile 16px over, at `(64, ...)`,
+      # instead of the normal partial-fill one. Ported from
+      # `Window_BattleStatus::DrawGaugeSystem2` exactly, including its
+      # `max == 0` no-draw guard (a stat with no pool at all, e.g. an actor
+      # with 0 max SP, draws no fill for that row).
+      def draw_gauge_system2(c, system2, x, y, cur, max, which)
+        return if max == 0
+        gauge_x = cur == max ? 16 : 0
+        width = 25 * cur / max
+        c.stretch_blt Rect.new(x, y, width, 16), system2,
+                     Rect.new(48 + gauge_x, 32 + 16 * which, 16, 16)
+      end
+
+      # Right-aligned up-to-4-digit number in 8x16 glyph cells (`System2`
+      # `(digit * 8, 80, 8, 16)`), leading zeros suppressed rather than drawn
+      # -- ported from `Window_BattleStatus::DrawNumberSystem2` exactly,
+      # including its exact leading-zero cascade: a thousands (or hundreds)
+      # digit that comes out to 0 still lets the *next* digit down draw via
+      # its own `handle_zero` carry, so 100 draws all three digits ("100")
+      # while 7 draws only the ones cell (three blank cells then "7") and 42
+      # draws the tens+ones cells ("42", blank above).
+      def draw_number_system2(c, system2, x, y, value)
+        handle_zero = false
+        if value >= 1000
+          c.blt x, y, system2, Rect.new((value / 1000) * 8, 80, 8, 16)
+          value %= 1000
+          handle_zero = true if value < 100
+        end
+        if handle_zero || value >= 100
+          handle_zero = false
+          c.blt x + 8, y, system2, Rect.new((value / 100) * 8, 80, 8, 16)
+          value %= 100
+          handle_zero = true if value < 10
+        end
+        if handle_zero || value >= 10
+          c.blt x + 16, y, system2, Rect.new((value / 10) * 8, 80, 8, 16)
+          value %= 10
+        end
+        c.blt x + 24, y, system2, Rect.new(value * 8, 80, 8, 16)
+      end
+
+      # The RPG2003 System2 graphic (gauge fill/caps and the digit glyphs the
+      # gauge card draws numbers with) -- one cache entry, keyed by name like
+      # every other named battle graphic (`#cached_bitmap`), since a project
+      # only ever declares the one in `system.system2_name` (chunk 22 field
+      # 20, schema.rb). A blank name or a failed load returns nil (and logs,
+      # for the latter) so `#battle_status_gauge_window` falls back to the
+      # plain text status row instead of crashing -- unlike
+      # `#battler_bitmap`/`#actor_battlecharset_bitmap`, there is no sensible
+      # placeholder gauge sprite sheet to draw in its place.
+      def battle_system2_bitmap
+        name = db.system.respond_to?(:system2_name) ? db.system.system2_name : nil
+        return nil unless name && !name.empty?
+        cached_bitmap(@system2_cache, name) do
+          begin
+            Bitmap.new("System2/#{name}", true)
+          rescue StandardError => e
+            $stderr.puts "[RPG2k] System2 graphic '#{name}' load failed: #{e.message}"
+            nil
+          end
+        end
       end
 
       # The current actor's command menu — Attack / Skill / Defend / Item, with

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4306,6 +4306,34 @@ check 'Game::Party#alternate_battle_layout? reads chunk 29 field 7 (BattleType)'
      'BattleType_gauge (2) -> alternate layout'
 end
 
+check 'Game::Party#gauge_battle_layout? reads chunk 29 field 7, true for gauge (2) only' do
+  # An RPG2000 database (no chunk 29 at all) reads false, same as
+  # #alternate_battle_layout? does for the same fixture.
+  eq false, party_state.party.gauge_battle_layout?,
+     'no Battle Commands table at all -> not the gauge layout'
+
+  players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30, atk: 10, def: 8) }
+
+  traditional = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                                 battlecommands: FakeBattleCommandsTable.new({}, 0))
+  eq false, Game::Party.new(traditional).gauge_battle_layout?,
+     'BattleType_traditional (0) -> not the gauge layout'
+
+  # Unlike #alternate_battle_layout? (true for both 1 and 2), this reads
+  # false for the plain alternative layout -- only battle_type 2 replaces
+  # the status panel with the gauge card layout (scene/map.rb's
+  # #refresh_battle_status); battle_type 1 keeps the unchanged text rows.
+  alternative = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                                 battlecommands: FakeBattleCommandsTable.new({}, 1))
+  eq false, Game::Party.new(alternative).gauge_battle_layout?,
+     'BattleType_alternative (1) -> not the gauge layout'
+
+  gauge = FakeActorDB.new(players, [1], {}, {}, {}, nil, nil,
+                           battlecommands: FakeBattleCommandsTable.new({}, 2))
+  eq true, Game::Party.new(gauge).gauge_battle_layout?,
+     'BattleType_gauge (2) -> the gauge layout'
+end
+
 check 'Game::Party#automatic_battle_placement? reads chunk 29 field 2 (Placement)' do
   eq false, party_state.party.automatic_battle_placement?,
      'no Battle Commands table at all -> manual (the schema default)'

--- a/scripts/rpg2k_scene_check.rb
+++ b/scripts/rpg2k_scene_check.rb
@@ -2216,7 +2216,8 @@ class BattleStubActor
                  rename_skill: false, skill_name: '', states: [], force_ai: false,
                  battle_commands: nil, battle_command_table: {},
                  level: 1, level_up_at: nil, learn_table: [],
-                 battler_animation_id: nil, battle_x: 0, battle_y: 0)
+                 battler_animation_id: nil, battle_x: 0, battle_y: 0,
+                 faceset_name: nil, faceset_index: 0)
     @exp = 0; @id = id; @name = 'Hero'
     @atk = atk; @def = dfn; @agi = agi; @hp = hp; @max_hp = hp
     @mp = mp; @max_mp = mp; @int = int; @skills = skills
@@ -2227,8 +2228,13 @@ class BattleStubActor
     @level = level; @level_up_at = level_up_at; @learn_table = learn_table
     @battler_animation_id = battler_animation_id
     @battle_x = battle_x; @battle_y = battle_y
+    @faceset_name = faceset_name; @faceset_index = faceset_index
   end
   attr_reader :battler_animation_id, :battle_x, :battle_y
+  # RPG2003 gauge-card status panel fixture (#draw_battle_gauge_face,
+  # Scene::Map): a nil `faceset_name` (the default) draws no face, the same
+  # answer a real Game::Actor with no faceset row gives.
+  attr_reader :faceset_name, :faceset_index
   # Mirrors Game::Actor's own RPG2003 battle-command-customization interface
   # (`#battle_commands` / `#battle_command_row`), so a stub battle can drive
   # `Scene::Map#custom_battle_commands` the same way a real actor row would.
@@ -2287,10 +2293,13 @@ class BattleStubParty
   # #automatic_battle_placement?, both keyed off `db.battlecommands` there) --
   # false by default, matching every other check's plain RPG2000 fixture and
   # (for `respond_to?` gating) every check predating the alternate-battle-
-  # sprite renderer, which never set either.
+  # sprite renderer, which never set either. `gauge_layout` mirrors
+  # #gauge_battle_layout? the same way -- distinct from `alternate_layout`,
+  # which is also true for the plain sprite-only layout (battle_type 1); a
+  # check exercising the gauge card status panel sets this one instead/as well.
   def initialize(actor = BattleStubActor.new, rpg2003: false, item_db: nil, skill_db: nil,
                  enemy_group: Hash.new(true), alternate_layout: false,
-                 automatic_placement: false)
+                 automatic_placement: false, gauge_layout: false)
     @actors = [actor]
     @gold = 0
     @leader = nil
@@ -2301,6 +2310,7 @@ class BattleStubParty
     @enemy_group = enemy_group
     @alternate_layout = alternate_layout
     @automatic_placement = automatic_placement
+    @gauge_layout = gauge_layout
   end
   def gain_gold(n); @gold += n; end
   def any_alive?; @actors.any? { |a| !a.dead? }; end
@@ -2308,6 +2318,7 @@ class BattleStubParty
   def rpg2003?; @rpg2003; end
   def alternate_battle_layout?; @alternate_layout; end
   def automatic_battle_placement?; @automatic_placement; end
+  def gauge_battle_layout?; @gauge_layout; end
   # A troop victory drop (Game::Troop#drops -> Scene::Map#battle_result_lines)
   # both grants the item and names it in the result window -- mirrors
   # ShopStubParty's own #gain_item, plus a #db_item lookup against whatever
@@ -9996,14 +10007,17 @@ def troop_page(cmds, flags = Game::BattlePage::TURN, opts = {})
 end
 
 # Open a battle whose troop carries `pages`, running frames until the fight is
-# up. Returns [scene, state].
-def battle_scene_with_pages(pages)
+# up. Returns [scene, state]. `party` defaults to the plain fixture every
+# check predating the gauge-card status panel used; a check exercising a
+# non-default battle-screen presentation (BattleStubParty's `gauge_layout:`)
+# passes its own instead.
+def battle_scene_with_pages(pages, party: BattleStubParty.new)
   ic = Game::Interpreter::Cmd
   auto = page(trigger: 3)
   auto.event_commands = battle_event_commands(ic)
   scene = new_scene({ 1 => event(2, 2, auto) }, troop_pages: pages)
   st = scene.instance_variable_get(:@state)
-  st.instance_variable_set(:@party, BattleStubParty.new)
+  st.instance_variable_set(:@party, party)
   [scene, st]
 end
 
@@ -10963,8 +10977,8 @@ end
 # Open a battle and run it up to the command phase, answering [scene, ui].
 # Dismisses the once-per-battle automatic options window (a C press on its
 # default cursor row 0, "Battle") along the way -- see #battle_to_command.
-def battle_at_command(pages = nil)
-  scene, = battle_scene_with_pages(pages)
+def battle_at_command(pages = nil, party: BattleStubParty.new)
+  scene, = battle_scene_with_pages(pages, party: party)
   ui = nil
   10.times do
     ui = scene.instance_variable_get(:@battle_ui)
@@ -11424,6 +11438,151 @@ check 'Change Monster Condition on a battle page updates the troop, off-panel' d
   # either, only the battle log's own wording when a state lands.
   ok !window_texts(ui[:status_win]).include?('Poison'),
      'the troop never reaches the party-only status window'
+end
+
+# -- the RPG2003 gauge card status panel (battle_type 2) -----------------------
+#
+# `Game::Party#gauge_battle_layout?`/`BattleStubParty#gauge_layout` is true
+# specifically for battle_type 2, distinct from `#alternate_battle_layout?`
+# (true for both 1 and 2) -- see #refresh_battle_status's own comment,
+# scene/map.rb. These checks exercise the dispatch and the card's own
+# drawing, ported from EasyRPG's real `Window_BattleStatus::Refresh`/
+# `RefreshGauge`/`DrawGaugeSystem2`/`DrawNumberSystem2`.
+
+check 'battle_type 0 (no gauge layout) still draws the plain text status row' do
+  scene, ui = battle_at_command
+  ok !scene.send(:gauge_battle_layout?), 'the plain fixture answers false'
+  texts = window_texts(ui[:status_win])
+  ok texts.include?('Hero'), 'the text status row is unchanged'
+  eq [], ui[:status_win].contents.blt_calls || [],
+     'and nothing else touched its contents via #blt (no gauge card drawing)'
+end
+
+check 'battle_type 1 (alternative) keeps the unchanged text status row too, ' \
+      'even when the database also carries a System2 graphic' do
+  actor = BattleStubActor.new
+  party = BattleStubParty.new(actor, alternate_layout: true, gauge_layout: false)
+  scene, ui = battle_at_command(nil, party: party)
+  scene.db.system.system2_name = 'BattleStatus'
+  scene.send(:refresh_battle_status)
+  ok !scene.send(:gauge_battle_layout?),
+     'battle_type 1 answers false to #gauge_battle_layout? -- only 2 does'
+  texts = window_texts(ui[:status_win])
+  ok texts.include?('Hero'), 'the text status row is still what battle_type 1 draws'
+end
+
+check 'battle_type 2 (gauge) with no System2 graphic falls back to the text ' \
+      'status row instead of crashing' do
+  actor = BattleStubActor.new
+  party = BattleStubParty.new(actor, gauge_layout: true)
+  scene, ui = battle_at_command(nil, party: party)
+  ok scene.send(:gauge_battle_layout?), 'the fixture asks for the gauge layout'
+  ok !scene.db.system.respond_to?(:system2_name), 'and the database names no System2 graphic'
+  scene.send(:refresh_battle_status)
+  texts = window_texts(ui[:status_win])
+  ok texts.include?('Hero'), 'falls back to the plain text row rather than an empty/crashed panel'
+end
+
+check 'battle_type 2 (gauge) draws the gauge card: face, HP/SP bars, digit numbers' do
+  actor = BattleStubActor.new(hp: 200, mp: 20, faceset_name: 'HeroFace', faceset_index: 2)
+  party = BattleStubParty.new(actor, gauge_layout: true)
+  scene, ui = battle_at_command(nil, party: party)
+  scene.db.system.system2_name = 'BattleStatus'
+  # A non-full HP (so this same window also exercises the normal, not
+  # "full", fill tile) alongside SP's still-full 20/20.
+  ui[:allies][0].hp = 100
+  scene.send(:refresh_battle_status)
+  win = ui[:status_win]
+
+  ok window_texts(win).empty?,
+     'the gauge card never calls draw_text/blend_text -- it fully replaces the text row'
+  eq 0, win.cursor_rect.width,
+     'never gets a cursor rect, even on the acting actor -- matching UpdateCursorRect' \
+     "'s unconditional empty rect for this battle_type"
+
+  c = win.contents
+  face_call = c.blt_calls[0]
+  eq [0, 24], face_call[0, 2], 'the face lands at column 0, actor_face_height (24)'
+  eq 'FaceSet/HeroFace', face_call[2].load_name, 'loaded from the actor faceset_name'
+  eq [96, 0, 48, 48], [face_call[3].x, face_call[3].y, face_call[3].width, face_call[3].height],
+     'cropped at faceset_index 2 -- (2 % 4) * 48, (2 / 4) * 48'
+
+  left_cap, right_cap = c.blt_calls[1, 2]
+  eq [32, 24], left_cap[0, 2], 'left bar cap at x = 32 + 80*i'
+  eq [0, 32, 16, 48], [left_cap[3].x, left_cap[3].y, left_cap[3].width, left_cap[3].height]
+  eq [73, 24], right_cap[0, 2], 'right bar cap at 32 + 16 (cap) + 25 (centre) = 73'
+  eq [32, 32, 16, 48], [right_cap[3].x, right_cap[3].y, right_cap[3].width, right_cap[3].height]
+
+  eq 3, c.stretch_calls.size, 'one bar-centre stretch, plus one fill each for HP and SP'
+  center, hp_fill, sp_fill = c.stretch_calls
+  eq [48, 24, 25, 48], [center[0].x, center[0].y, center[0].width, center[0].height],
+     'the bar centre stretches to fill the full 25px slot between the caps'
+  eq [48, 24, 12, 16], [hp_fill[0].x, hp_fill[0].y, hp_fill[0].width, hp_fill[0].height],
+     'HP fill: 25 * 100 / 200 = 12px wide -- the normal tile, since 100 != max 200'
+  eq [48, 32, 16, 16], [hp_fill[2].x, hp_fill[2].y, hp_fill[2].width, hp_fill[2].height],
+     'reading the normal (gauge_x 0) HP fill tile'
+  eq [48, 40, 25, 16], [sp_fill[0].x, sp_fill[0].y, sp_fill[0].width, sp_fill[0].height],
+     'SP fill: exactly full (20/20) still stretches to the maximum 25px'
+  eq [64, 48, 16, 16], [sp_fill[2].x, sp_fill[2].y, sp_fill[2].width, sp_fill[2].height],
+     'an exactly-full gauge reads the distinct "full" tile (gauge_x 16), on the SP row (y+16)'
+
+  # Numbers: HP "100" draws all three digit cells (hundreds carries a real,
+  # nonzero digit), SP "20" draws only its own two.
+  hp_digits = c.blt_calls[3, 3].map { |call| [call[0], call[3].x / 8] }
+  eq [[48, 1], [56, 0], [64, 0]], hp_digits, 'HP 100 -> hundreds=1, tens=0, ones=0'
+  sp_digits = c.blt_calls[6, 2].map { |call| [call[0], call[3].x / 8] }
+  eq [[56, 2], [64, 0]], sp_digits, 'SP 20 -> tens=2, ones=0, no hundreds/thousands cell'
+end
+
+check 'DrawGaugeSystem2 stretches the fill by 25 * cur / max, and reads the ' \
+      'distinct "full" tile only when cur == max' do
+  scene = new_scene({})
+  system2 = RGSS::Bitmap.new(80, 96)
+  c = RGSS::Bitmap.new(64, 16)
+  draw = lambda do |cur, max, which|
+    c.clear_stretch_calls
+    scene.send(:draw_gauge_system2, c, system2, 100, 200, cur, max, which)
+    c.stretch_calls.last
+  end
+
+  call = draw.call(100, 200, 0)
+  eq [100, 200, 12, 16], [call[0].x, call[0].y, call[0].width, call[0].height],
+     'width is 25 * cur / max, truncated -- 25 * 100 / 200 = 12.5 -> 12'
+  eq [48, 32, 16, 16], [call[2].x, call[2].y, call[2].width, call[2].height],
+     'the normal (gauge_x 0) fill tile, which=0 -> HP row'
+
+  call = draw.call(200, 200, 0)
+  eq 25, call[0].width, 'an exactly-full gauge still stretches to the maximum 25px width'
+  eq [64, 32], [call[2].x, call[2].y], 'but reads the "full" tile, 16px over (gauge_x 16)'
+
+  call = draw.call(0, 200, 0)
+  eq 0, call[0].width, 'zero current value stretches to 0 width'
+
+  call = draw.call(20, 20, 1)
+  eq [64, 48], [call[2].x, call[2].y],
+     'which=1 (SP) reads its own row, 16px down -- still the "full" tile at cur == max'
+
+  c.clear_stretch_calls
+  scene.send(:draw_gauge_system2, c, system2, 100, 200, 5, 0, 0)
+  eq nil, c.stretch_calls.last, 'max == 0 draws nothing at all, matching the real max_value guard'
+end
+
+check 'DrawNumberSystem2 leading-zero cascade matches EasyRPG exactly (7, 42, 100, 999)' do
+  scene = new_scene({})
+  system2 = RGSS::Bitmap.new(80, 96)
+  c = RGSS::Bitmap.new(64, 16)
+  glyphs = lambda do |value|
+    c.clear_blt_calls
+    scene.send(:draw_number_system2, c, system2, 0, 0, value)
+    c.blt_calls.map { |call| [call[0], call[3].x / 8] }
+  end
+
+  eq [[24, 7]], glyphs.call(7),
+     '7 draws only the ones cell -- the hundreds/tens cells stay blank, never a drawn "0"'
+  eq [[16, 4], [24, 2]], glyphs.call(42), '42 draws tens+ones only, no hundreds/thousands cell'
+  eq [[8, 1], [16, 0], [24, 0]], glyphs.call(100),
+     'a hundreds digit that carries down still draws its own zero tens/ones cells'
+  eq [[8, 9], [16, 9], [24, 9]], glyphs.call(999), 'three 9s, still no (blank) thousands cell'
 end
 
 # -- the battle log in the game's own words ------------------------------------


### PR DESCRIPTION
## Summary

Step 4 of the RPG2003 alternate-battle-screen initiative (step 1: #838, step 2: #847, step 3: #850). Step 3's own scoping note flagged this as open follow-up: when `battlecommands.battle_type` is specifically 2 (gauge — not 1, alternative), the party status panel is a real UI replacement, not an addition, so it now draws RPG2003's own face/HP-SP-bar/digit-glyph "gauge card" layout instead of the existing text status window. `battle_type` 1 keeps that text window exactly as before.

Verified directly against EasyRPG Player's real source (`src/window_battlestatus.cpp`, `src/window_base.cpp`) rather than guessed:

- **`Game::Party#gauge_battle_layout?`** reads `battlecommands.battle_type == 2` specifically — distinct from the existing `#alternate_battle_layout?` (true for both 1 and 2).
- **`Scene::Map#battle_status_gauge_window`** ports `Window_BattleStatus::Refresh`/`RefreshGauge`'s own gauge-card block column-for-column: the actor's face (`faceset_name`/`faceset_index`, reusing the same `#load_face_bitmap`/`FACE_SIZE` crop the name-entry/message-face screens already use), the bar's left cap / stretched centre / right cap, then an HP row and an SP row.
- **`#draw_gauge_system2`** ports `DrawGaugeSystem2` exactly, including the real, deliberate distinction that an exactly-full gauge (`cur == max`) reads a visually distinct "full" fill tile 16px over from the normal partial-fill one.
- **`#draw_number_system2`** ports `DrawNumberSystem2`'s exact leading-zero-suppression cascade for the up-to-4-digit HP/SP numbers (a hundreds/thousands digit that carries down to zero still lets the next digit draw; a value under 100 draws no thousands/hundreds cell at all).
- **System2 graphic loading** mirrors the existing named-graphic-with-cache pattern (`battler_bitmap`/`actor_battlecharset_bitmap`, step 3) — cache key is `system.system2_name` (schema.rb, chunk 22 field 20) since a project only ever has one. A blank/missing name or a failed load falls back to the plain text status row instead of crashing or drawing a blank panel, since there's no sensible placeholder gauge sprite sheet the way there's a placeholder colour block for a missing battler graphic.

**Explicitly out of scope, same "reported gap, not silently invented" convention as prior steps**:
- The ATB/wait gauge row `RefreshGauge` also draws (`DrawGaugeSystem2(..., GetAtbGauge, GetMaxAtbGauge, 2)`) — this runtime has no Active Time Battle/wait-timer subsystem at all, a separate, large feature. Only the HP and SP rows draw.
- `battlecommands.window_size`/`transparency` (large/small, opaque/transparent) — not yet decoded in `mruby-lcf/mrblib/schema.rb`'s `battlecommands` chunk (only fields 2/7 exist there so far). The gauge card always uses the large-window `actor_face_height` (24), matching `Window_BattleStatus`'s own default; the *behaviour* those fields would drive is itself out of scope, this step just doesn't let a missing decode crash anything.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 879 checks pass (new: `Game::Party#gauge_battle_layout?`'s full battle_type 0/1/2 matrix).
- [x] `ruby scripts/rpg2k_scene_check.rb` — 600 checks pass (new: battle_type 0/1 unchanged text-row regression checks, battle_type 2 with no System2 graphic falls back without crashing, battle_type 2 draws the full gauge card — face crop, bar caps, centre stretch, HP/SP fill widths including the exact-full "full" tile, digit blits — and the `DrawGaugeSystem2`/`DrawNumberSystem2` formulas verified directly against a few concrete fractions/values, not guessed).
- [x] Native build (`ninja rpg_maker_clone`, configured via `scripts/native-build-without-nix.bash`) succeeds.
- [x] `pre-commit` (trailing-whitespace, end-of-file-fixer, check-added-large-files) passes on the changed files.

---

_Generated with [Claude Code](https://claude.ai/code)_
Co-Authored-By: Claude Sonnet 5
https://claude.ai/code/session_01Fxy28MRBEAsVJt7RSUV8RQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fxy28MRBEAsVJt7RSUV8RQ)_