### PR TITLE
Route the Change Equipment event command through the party's bag

### DIFF
--- a/changelog.d/rpg2k-change-equipment-bag.fixed.md
+++ b/changelog.d/rpg2k-change-equipment-bag.fixed.md
@@ -1,0 +1,26 @@
+- **Change Equipment (event command 10450) now swaps through the party's bag,
+  like the equip menu.** `Interpreter#do_change_equipment` called the bare
+  `Actor#equip_item`/`#unequip` directly, so the command conjured its target
+  item out of thin air and discarded whatever it replaced instead — the
+  command's own comment even flagged the gap, and `Game::Party#equip_from_bag`
+  (the menu's own equip path) already carried a note calling out the
+  discrepancy explicitly. Confirmed against real RPG_RT by community
+  デフォ戦bot trivia (independent of this codebase) and EasyRPG Player's actual
+  source: `Game_Interpreter::CommandChangeEquipment` resolves to
+  `Game_Actor::ChangeEquipment`, which always calls `Game_Party::AddItem` for
+  whatever the slot held before (both equipping and unequipping) and
+  `Game_Party::RemoveItem` for the newly-equipped item — a no-op, not a
+  negative count, when the party does not hold it (`RemoveItem`'s underlying
+  `AddItem(-amount)` early-returns once the item's absent and the delta isn't
+  positive). New `Game::Party#equip_item_from_bag` shares its bag-swap
+  mechanics with `#equip_from_bag` (extracted into a private
+  `#swap_equipment_through_bag`) but, unlike the menu, equips even an item the
+  party does not hold — fabricating a new copy per the trivia — rather than
+  refusing; `#unequip_to_bag` now also handles the command's "every slot"
+  operand (5), returning each freed item to the bag in turn, mirroring
+  `Game_Actor::RemoveWholeEquipment`'s own per-slot `ChangeEquipment` loop.
+  Covered by new `scripts/rpg2k_logic_check.rb` checks (equipping consumes a
+  held copy from the bag; equipping without one still succeeds, fabricating
+  rather than pulling from an empty bag; a replaced or removed item returns to
+  the bag, including the "remove every slot" operand), confirmed to fail
+  against the pre-fix code.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -3631,22 +3631,12 @@ module Game
       end
     end
 
-    # Equip bag item `item_id` on `actor` into equipment `slot`, moving it
-    # through the inventory the way the equip menu does: take one from the bag,
-    # equip it into that slot, and return the previously-equipped item (if any)
-    # to the bag. `slot` defaults to the one the item's own type dictates (so
-    # the Item menu's field-usable-item paths that never pass one keep working
-    # unchanged); the equip menu always passes the slot its candidate list
-    # (#equip_candidates) was built for, which is what lets a 二刀流 actor's
-    # second weapon land in the shield slot rather than overwriting the first.
-    # A no-op returning false unless the party holds the item and it is a
-    # genuine candidate for that slot on that actor (#equip_candidate_for?);
-    # true on success. (Unlike the Change Equipment event command, which does
-    # not touch the bag, the menu swaps through it.)
-    def equip_from_bag(actor, item_id, slot = nil)
-      return false unless actor && item_count(item_id) > 0
-      slot ||= equip_slot_for(item_id)
-      return false if slot.nil? || !equip_candidate_for?(actor, item_id, slot)
+    # Equip `item_id` on `actor` into equipment `slot`, moving it through the
+    # inventory: take one from the bag if held, equip it, and return the
+    # previously-equipped item (if any) to the bag. Shared mechanics behind
+    # #equip_from_bag (the equip menu) and #equip_item_from_bag (the Change
+    # Equipment event command) -- see each for the gating layered on top.
+    def swap_equipment_through_bag(actor, item_id, slot)
       previous = actor.equipment[slot]
       # A 両手持ち weapon empties the other hand; whatever it was holding comes
       # back to the bag alongside the item this slot displaced.
@@ -3656,11 +3646,62 @@ module Game
       gain_item(freed, 1) if freed && freed != 0
       true
     end
+    private :swap_equipment_through_bag
 
-    # Unequip `actor`'s `slot`, returning the removed item to the bag. Returns the
-    # removed item id (0 when the slot was already empty or the slot is invalid).
+    # Equip bag item `item_id` on `actor` into equipment `slot`, the way the
+    # equip menu does. `slot` defaults to the one the item's own type dictates
+    # (so the Item menu's field-usable-item paths that never pass one keep
+    # working unchanged); the equip menu always passes the slot its candidate
+    # list (#equip_candidates) was built for, which is what lets a 二刀流
+    # actor's second weapon land in the shield slot rather than overwriting the
+    # first. A no-op returning false unless the party holds the item and it is
+    # a genuine candidate for that slot on that actor (#equip_candidate_for?);
+    # true on success. (Unlike the Change Equipment event command, which also
+    # equips an item the party does not hold -- see #equip_item_from_bag --
+    # the menu only ever offers what #equip_candidates already lists as held.)
+    def equip_from_bag(actor, item_id, slot = nil)
+      return false unless actor && item_count(item_id) > 0
+      slot ||= equip_slot_for(item_id)
+      return false if slot.nil? || !equip_candidate_for?(actor, item_id, slot)
+      swap_equipment_through_bag(actor, item_id, slot)
+    end
+
+    # Equip `item_id` on `actor`, the way the Change Equipment event command
+    # does: a copy already in the bag is consumed exactly as #equip_from_bag
+    # would, but -- unlike the menu -- an item the party does not hold is
+    # still equipped, RPG_RT fabricating a new copy rather than refusing
+    # (community デフォ戦bot trivia: "held in the bag, equip from there; not
+    # held, a new copy is created and equipped"; #lose_item's own floor-at-0
+    # clamp is what makes consuming an unheld item a no-op instead of going
+    # negative). The previously-equipped item, and any item a two-handed swap
+    # frees, still return to the bag exactly as #equip_from_bag does. `slot`
+    # is always the item's own type-based slot (the event command names no
+    # slot, unlike the menu's candidate-list-driven choice); a non-equippable
+    # or unknown item id is a no-op, matching EasyRPG's own type-switch
+    # default. Callers apply any actor_set restriction themselves (per target,
+    # same as #equip_candidate_for? would) before calling this.
+    def equip_item_from_bag(actor, item_id)
+      return false unless actor
+      slot = equip_slot_for(item_id)
+      return false if slot.nil?
+      swap_equipment_through_bag(actor, item_id, slot)
+    end
+
+    # Unequip `actor`'s `slot`, returning the removed item to the bag. 0..4
+    # empties that one slot; EQUIP_ORDER.size (5) empties every slot, each
+    # returning its own item to the bag in turn -- EasyRPG's "remove all" case
+    # is just this same per-slot swap looped over every slot
+    # (Game_Actor::RemoveWholeEquipment calls ChangeEquipment(slot, 0) for
+    # each). Returns the removed item id (0 when the slot was already empty,
+    # the slot is invalid, or "every slot" was requested -- there is no single
+    # id to report there).
     def unequip_to_bag(actor, slot)
-      return 0 unless actor && slot >= 0 && slot < Actor::EQUIP_ORDER.size
+      return 0 unless actor
+      if slot == Actor::EQUIP_ORDER.size
+        Actor::EQUIP_ORDER.size.times { |s| unequip_to_bag(actor, s) }
+        return 0
+      end
+      return 0 unless slot >= 0 && slot < Actor::EQUIP_ORDER.size
       removed = actor.equipment[slot]
       actor.unequip(slot)
       gain_item(removed, 1) if removed && removed != 0

--- a/mruby-rpg2k/mrblib/interpreter.rb
+++ b/mruby-rpg2k/mrblib/interpreter.rb
@@ -2243,18 +2243,24 @@ module Game
     # the slot matching its type; 1 removes equipment, param4 selecting the slot
     # (0..4, or 5 for every slot). Confirmed against real events, e.g.
     # `[1, 3, 0, 0, 127]` equips armour 127 onto actor 3.
+    #
+    # Both operations swap through the party's bag, same as the equip menu
+    # (`Game::Party#equip_item_from_bag` / `#unequip_to_bag`) -- confirmed
+    # against real RPG_RT by community デフォ戦bot trivia: equipping consumes
+    # a held copy from the bag, or fabricates a new one if the party has none,
+    # and whatever was previously equipped comes back to the bag either way.
     def do_change_equipment(cmd)
       targets = stat_targets(cmd)
       if cmd.param(2) == 0
         item = cmd.param(3) == 0 ? cmd.param(4) : variables[cmd.param(4)]
-        it = @state.party.db_item(item)
+        it = party.db_item(item)
         # An actor_set restriction blocks this command the same way it blocks
         # the equip menu (EasyRPG's ChangeEquipment reads Game_Actor::
         # IsItemUsable too) -- per target, since one target of a multi-actor
         # command might be allowed the item and another not.
-        targets.each { |a| a.equip_item(item) if @state.party.item_usable_by?(it, a.id) }
+        targets.each { |a| party.equip_item_from_bag(a, item) if party.item_usable_by?(it, a.id) }
       else
-        targets.each { |a| a.unequip(cmd.param(4)) }
+        targets.each { |a| party.unequip_to_bag(a, cmd.param(4)) }
       end
       check_game_over # losing an item's max-HP bonus can knock the party out
     end

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -4754,17 +4754,33 @@ check 'Change Equipment command equips into the type slot and removes' do
   eq 8, a.equipment[2] # armour still on
 end
 
-check 'Change Equipment command creates/returns items implicitly -- it never ' \
-      "touches the party's bag, unlike the Equip menu screen" do
-  # A yado.tk-catalogued quirk (docs/TODO.md's "Items & equipment" bullet):
-  # the event command conjures the item onto the actor directly and drops it
-  # the same way on removal, with no bag interaction either direction --
-  # unlike Scene::EquipMenu's own #equip_from_bag/#unequip_to_bag, which
-  # explicitly swap through Game::Party's held-item counts. Confirmed by
-  # inspection (Game::Actor#equip_item/#unequip, which this command drives,
-  # call neither #gain_item nor #lose_item anywhere), and now asserted
-  # head-on: the bag's own count for the equipped item stays exactly 0
-  # throughout, whether or not the party ever held one.
+check 'Change Equipment command consumes a held copy from the party bag, ' \
+      'like the equip menu' do
+  # Community デフォ戦bot trivia on real RPG_RT: "イベント命令で「装備の変更」
+  # をさせる場合、該当アイテムが持ち物に一つでもあれば、そこから装備される" --
+  # when the party holds the item, the event command equips *that* copy
+  # rather than conjuring a separate one, so the bag count drops exactly like
+  # Game::Party#equip_from_bag (the equip menu's own path).
+  items = { 7 => fake_item(atk: 15, type: 1) }   # weapon -> slot 0
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  st.party.gain_item(7, 2)
+  eq 2, st.party.item_count(7)
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  eq 7, a.equipment[0], 'equipped from the bag'
+  eq 1, st.party.item_count(7), 'one copy left the bag to be worn'
+end
+
+check 'Change Equipment command still equips an item the party does not ' \
+      'hold, fabricating a copy rather than refusing' do
+  # The other half of the same trivia: "持ち物に無いと新しいアイテムを入手する
+  # 形で装備される" -- absent from the bag, RPG_RT still equips it (a new copy
+  # is created), matching the command's long-observed "always succeeds"
+  # behaviour, but now via the same bag-aware mechanism instead of bypassing
+  # the bag outright: consuming an unheld item is a no-op (#lose_item floors
+  # at 0), so the bag count stays at 0 rather than going negative.
   items = { 7 => fake_item(atk: 15, type: 1) }   # weapon -> slot 0
   db = FakeActorDB.new(
     { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1], items)
@@ -4772,11 +4788,50 @@ check 'Change Equipment command creates/returns items implicitly -- it never ' \
   a = st.party.actor_by_id(1)
   eq 0, st.party.item_count(7), 'the bag starts with none of item 7 at all'
   Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  eq 18, a.atk         # base 3 + 15
   eq 7, a.equipment[0], 'the actor is equipped with an item the party never held'
-  eq 0, st.party.item_count(7), 'equipping created it out of thin air -- the bag is still empty'
+  eq 0, st.party.item_count(7), 'fabricated, not pulled from an empty bag -- still at 0'
+end
+
+check 'Change Equipment command returns the previously-equipped item to ' \
+      'the bag, both replacing it and removing it outright' do
+  items = { 7 => fake_item(atk: 15, type: 1),   # weapon -> slot 0
+            9 => fake_item(atk: 20, type: 1) }  # weapon -> slot 0
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  # Equip weapon 7, held in the bag.
+  st.party.gain_item(7, 1)
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  eq 7, a.equipment[0]
+  eq 0, st.party.item_count(7)
+  # Replace it with weapon 9 (not held -- fabricated): 7 comes back to the bag.
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 9])]); it.update }
+  eq 9, a.equipment[0], 'now wearing the replacement'
+  eq 1, st.party.item_count(7), 'the displaced weapon landed back in the bag'
+  eq 0, st.party.item_count(9), 'the replacement itself is worn, not sitting in the bag too'
+  # Remove it outright (op 1): 9 comes back to the bag too.
   Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, 0])]); it.update }
   eq 0, a.equipment[0], 'unequipped'
-  eq 0, st.party.item_count(7), 'and it did not land back in the bag either'
+  eq 1, st.party.item_count(9), 'and it returned to the bag on removal too'
+end
+
+check 'Change Equipment command "remove every slot" (param4 5) returns each ' \
+      'slot to the bag in turn' do
+  items = { 7 => fake_item(atk: 15, type: 1),   # weapon -> slot 0
+            8 => fake_item(dfn: 9, type: 3) }   # armour -> slot 2
+  db = FakeActorDB.new(
+    { 1 => CurveRow.new('Hero', '', 0, 1, [10, 5, 3, 2, 1, 4]) }, [1], items)
+  st = Game::State.new(Game::Party.new(db), 1, 0, 0)
+  a = st.party.actor_by_id(1)
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 7])]); it.update }
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 0, 0, 8])]); it.update }
+  eq [7, 0, 8, 0, 0], a.equipment
+  Game::Interpreter.new(st).tap { |it| it.start([FakeCmd.new(IC::CHANGE_EQUIP, [1, 1, 1, 0, Game::Actor::EQUIP_ORDER.size])]); it.update }
+  eq [0, 0, 0, 0, 0], a.equipment, 'every slot cleared'
+  eq 1, st.party.item_count(7), 'the weapon came back to the bag'
+  eq 1, st.party.item_count(8), 'the armour came back to the bag too'
 end
 
 check 'Change Equipment command respects an actor_set restriction, per actor' do


### PR DESCRIPTION
## Summary

- `Interpreter#do_change_equipment` called the bare `Actor#equip_item`/`#unequip` directly, so the Change Equipment event command (10450) conjured its target item out of thin air and discarded whatever it replaced — the command's own comment already flagged this, and `Game::Party#equip_from_bag` (the equip menu's path) carried a comment explicitly calling out the discrepancy.
- Confirmed against real RPG_RT behavior two ways: EasyRPG Player's actual source (`Game_Interpreter::CommandChangeEquipment` → `Game_Actor::ChangeEquipment`, which always `AddItem`s the displaced item back and `RemoveItem`s the newly-equipped one — a no-op rather than a negative count when the party doesn't hold it) and independent community デフォ戦bot trivia describing the same bag-swap-or-fabricate behavior.
- New `Game::Party#equip_item_from_bag` shares its bag-swap mechanics with `#equip_from_bag` (extracted into a private `#swap_equipment_through_bag`), but — unlike the menu — still equips an item the party doesn't hold by fabricating a copy rather than refusing. `#unequip_to_bag` now also handles the command's "every slot" operand (5), returning each freed item to the bag in turn, mirroring `Game_Actor::RemoveWholeEquipment`'s own per-slot loop.

## Test plan

- [x] New `scripts/rpg2k_logic_check.rb` checks: equipping consumes a held copy from the bag; equipping without one still succeeds (fabricated, not pulled from an empty bag); a replaced or removed item returns to the bag, including the "remove every slot" (param4 5) operand.
- [x] Confirmed the new checks fail against the pre-fix code (verified by reverting the source changes locally and re-running).
- [x] `ruby scripts/rpg2k_logic_check.rb` — 881 checks passed.
- [x] `ruby scripts/rpg2k_scene_check.rb` — 594 checks passed.
- [x] Native rebuild (`ninja rpg_maker_clone`) succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL58KvGGDcgQAzo8pkEF3E)_