### PR TITLE
Deal SP/MP damage on enemy-scope attack skills

### DIFF
--- a/changelog.d/skill-attack-sp-damage.fixed.md
+++ b/changelog.d/skill-attack-sp-damage.fixed.md
@@ -1,0 +1,8 @@
+- **Enemy-scope attack skills** now deal SP/MP damage when their `affect_sp`
+  flag is set, instead of hardcoding `mp: 0` and silently dropping it (an
+  attack skill's `hp` field is now likewise gated by `affect_hp`, so an
+  SP-only drain no longer also deals HP damage). Both pools draw from the
+  same computed effect value, matching EasyRPG Player's
+  `Game_BattleAlgorithm::Skill::vExecute`, and a killing HP hit now correctly
+  skips the SP damage on that same swing. Covered by new checks in
+  `scripts/rpg2k_logic_check.rb`.

--- a/mruby-rpg2k/mrblib/game.rb
+++ b/mruby-rpg2k/mrblib/game.rb
@@ -4372,7 +4372,17 @@ module Game
         # which broke exactly at this boundary once `dmg` could reach 0 --
         # `attack: true` below now says so explicitly instead.
         dmg = 0 if dmg < 0
-        { cost: cost, hp: -dmg, mp: 0, attack: true,
+        { cost: cost,
+          # `hp`/`mp` each independently gate on their own affect_hp/affect_sp
+          # flag now, mirroring the ally/recovery branch below -- EasyRPG's
+          # `Skill::vExecute` reads the identical one shared `effect` local
+          # into both `SetAffectedHp`/`SetAffectedSp` guards rather than
+          # rolling either separately, so a dual HP+SP attack skill deals the
+          # *same* number to each pool, and an SP-only drain (affect_hp clear,
+          # affect_sp set -- a real, valid Effects-tab combination, per
+          # @2000_battle_bot/デフォ戦bot trivia on the HP-reaches-zero
+          # interaction below) never touches HP at all.
+          hp: sk.affect_hp ? -dmg : 0, mp: sk.affect_sp ? -dmg : 0, attack: true,
           inflict: inflict_ids, chance: skill_hit(sk),
           variance: skill_variance(sk), attributes: skill_attributes(sk),
           # 吸収 — the caster takes what the target loses. RPG_RT reads the flag
@@ -4381,6 +4391,13 @@ module Game
           # that sets it drains nothing.
           absorb: skill_absorbs?(sk), attr_shift: shift, attr_ids: shift_ids,
           stat_mod_keys: stat_keys, cured: cure_ids,
+          # The raw, un-gated effect (see the ally branch's own `stat_effect`
+          # below) -- #apply_skill_hit's ATK/DEF/SPI/AGI modifier and its
+          # damage pipeline (elemental scaling, critical, variance) both need
+          # this even when affect_hp/affect_sp leave `hp`/`mp` at 0, the same
+          # way EasyRPG reads its one `effect` local for every affect_* branch
+          # alike regardless of which ones are actually set.
+          stat_effect: dmg,
           # The skill's own physical_rate (0-10), scaled to a 0..100 percent
           # -- #apply_skill_hit's own #shake_off_states call reads this the
           # same way EasyRPG's `Skill::vExecute` scales `BattlePhysicalStateHeal`'s
@@ -9840,7 +9857,17 @@ module Game
     def apply_skill_hit(b, target, hp, mp, cmd)
       attack = cmd[:attack].nil? ? hp < 0 : cmd[:attack]
       if attack
-        dmg = -hp
+        # The skill's one shared, un-gated effect magnitude: whichever of
+        # hp/mp actually carries it (each already the correct *per-target*
+        # figure -- #command_skill_all's own per-target hp/mp, defence term
+        # included), falling back to `cmd[:stat_effect]` (#battle_skill_command's
+        # enemy branch always sets it now, mirroring the ally branch's own
+        # `stat_effect: base`) only when neither pool is affected at all -- a
+        # stat-mod-only skill (Weaken and friends), which still needs a real
+        # number to scale/roll below even though affect_hp/affect_sp leave
+        # both `hp` and `mp` at 0. Matches EasyRPG's `effect` local, computed
+        # once regardless of which affect_* flags actually read it.
+        dmg = hp != 0 ? -hp : (mp != 0 ? -mp : (cmd[:stat_effect] || 0))
         # An elemental skill scales its damage by the target's resistance first
         # (EasyRPG's ApplyAttributeSkillMultiplier), then a critical hit, then
         # spreads by variance -- EasyRPG's own CalcSkillEffect order exactly
@@ -9883,16 +9910,33 @@ module Game
         # 200-damage drain on a 30 HP foe deals 30 and returns 30 -- the drain is
         # weaker against a nearly-dead target, not merely capped in what it gives.
         absorbed = 0
-        if hits
-          if cmd[:absorb] && dmg > 0
-            dmg = target.hp if dmg > target.hp
-            absorbed = dmg
+        hp_dmg = 0
+        if hits && hp != 0
+          hp_dmg = dmg
+          if cmd[:absorb] && hp_dmg > 0
+            hp_dmg = target.hp if hp_dmg > target.hp
+            absorbed = hp_dmg
           end
-          target.hp -= dmg
-        else
-          dmg = 0
+          target.hp -= hp_dmg
         end
         b.hp = [b.hp + absorbed, b.max_hp].min if absorbed > 0
+        # The same shared, un-gated `dmg` the HP branch above just used, applied
+        # to the target's SP instead -- EasyRPG's `Skill::vExecute` reads its
+        # one `effect` local raw here (no elemental/absorb/defend-adjustment
+        # difference from the HP side), and rolls its own fresh
+        # `Rand::PercentChance(to_hit)` independent of the HP roll above, the
+        # same way the ally/recovery branch's own HP and SP each roll
+        # separately. Skipped entirely once the HP hit above has just killed
+        # the target -- EasyRPG's own `if (!is_dead && GetHp() + AffectedHp <=
+        # 0) return` runs *before* the affect_sp block, so a dual HP+SP attack
+        # skill that lands a killing blow never also drains SP on the same
+        # swing (confirmed against @2000_battle_bot/デフォ戦bot's own trivia on
+        # this exact interaction: "HPがゼロになった場合、MPは減らない").
+        sp_dmg = 0
+        if mp != 0 && !target.dead? && target.mp && target.max_mp && skill_effect_hits?(cmd)
+          sp_dmg = dmg
+          target.mp = [target.mp - sp_dmg, 0].max
+        end
         # An attack skill may inflict its states -- or, under the RPG2003
         # reverse_state_effect flip #battle_skill_command's own `heals_states`
         # already resolved, cure them instead -- and shift attribute defence
@@ -9920,7 +9964,7 @@ module Game
           # block the damage application itself is in, not a separate roll.
           woke = hits ? shake_off_states(target, cmd[:physical_rate] || 0) : []
         end
-        { attacker: b.name, target: target.name, damage: dmg, missed: !hits,
+        { attacker: b.name, target: target.name, damage: hp_dmg, missed: !hits,
           critical: crit,
           target_hp: target.hp < 0 ? 0 : target.hp, defeated: target.dead?,
           inflicted: inflicted, already: already, cured: cured, woke: woke,
@@ -9928,7 +9972,8 @@ module Game
           stat_changed: stat_changed,
           target_ally: ally?(target), skill: cmd[:name],
           skill_id: cmd[:skill_id], target_index: @enemies.index(target),
-          absorbed_hp: absorbed }
+          absorbed_hp: absorbed, sp_damage: sp_dmg,
+          target_mp: target.mp }
       else
         # Spread the recovery by the skill's own variance when the fight rolls
         # it, the same way the attack branch above does: EasyRPG's

--- a/scripts/rpg2k_logic_check.rb
+++ b/scripts/rpg2k_logic_check.rb
@@ -9532,7 +9532,7 @@ end
 
 check 'battle skill damage varies by the skill variance when the fight rolls it' do
   skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 0, power: 20,
-                             mrate: 40, variance: 4) }
+                             mrate: 40, variance: 4, hp: true) }
   st = skill_party(skills)
   mage = Game::Battle.from_actor(st.party.actor_by_id(1))    # spi 12 -> effect 32
   slime = combatant('Slime', 0, 0, 5, 100_000)               # def 0, tanky
@@ -9813,7 +9813,7 @@ end
 
 check 'battle_skill_command yields attack damage, ally heal and self recovery' do
   skills = {
-    7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 20, mrate: 40),
+    7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 20, mrate: 40, hp: true),
     8 => fake_skill(name: 'Heal', scope: 3, sp_cost: 5, power: 20, mrate: 40, hp: true),
     9 => fake_skill(name: 'Cure', scope: 2, sp_cost: 4, power: 10, mrate: 40,
                     hp: true, sp: true)
@@ -9827,7 +9827,8 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
   # all with its armour: 32 - (0*8/40 + 40*16/80) = 32 - 8 = 24.
   eq({ cost: 6, hp: -24, mp: 0, attack: true, inflict: [], chance: 100, variance: 4,
        attributes: [], absorb: false, attr_shift: nil, attr_ids: [],
-       stat_mod_keys: [], cured: [], physical_rate: 0 }, # purely magical -> 0
+       stat_mod_keys: [], cured: [], stat_effect: 24,
+       physical_rate: 0 }, # purely magical -> 0
      st.party.battle_skill_command(st.party.db_skill(7), caster, foe))
   eq({ cost: 5, hp: 32, mp: 0, variance: 4, attr_shift: nil, attr_ids: [],
        stat_mod_keys: [], stat_effect: 32, cured: [], inflict: [], chance: 100 },
@@ -9839,7 +9840,7 @@ check 'battle_skill_command yields attack damage, ally heal and self recovery' d
 end
 
 check 'battle_skill_command respects a stat-halving state on the caster' do
-  skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 0, mrate: 40) }
+  skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 0, mrate: 40, hp: true) }
   states = { 1 => fake_state(affect_type: 0, affect_spirit: true) } # 0 = halve
   players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
                                      atk: 10, def: 8, int: 20, agi: 7) }
@@ -9858,7 +9859,7 @@ check 'battle_skill_command respects a stat-halving state on the caster' do
 end
 
 check 'battle_skill_command respects a stat-doubling state on the target' do
-  skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 0, mrate: 40) }
+  skills = { 7 => fake_skill(name: 'Fire', scope: 0, sp_cost: 6, power: 0, mrate: 40, hp: true) }
   states = { 2 => fake_state(affect_type: 1, affect_spirit: true) } # 1 = double
   players = { 1 => FakePlayerRow.new('Hero', '', 0, 5, max_hp: 100, max_mp: 30,
                                      atk: 10, def: 8, int: 20, agi: 7) }
@@ -9909,6 +9910,91 @@ check 'an attack skill that computes to 0 damage still reads as an attack, not a
   eq 'Fire', e[:skill], 'still reads as the attack skill that landed, not a recovery'
   ok !e[:recover], 'never mistaken for a heal'
   eq 100, tough_foe.hp, 'the target neither took damage nor was healed'
+end
+
+# Ported from EasyRPG's Game_BattleAlgorithm::Skill::vExecute (algo.cpp's
+# CalcSkillEffect + game_battlealgorithm.cpp): an enemy-scope attack skill's
+# `affect_hp`/`affect_sp` flags each independently gate whether the skill's
+# one shared `effect` value (the same number, not two separately-rolled
+# amounts) lands on the target's HP and/or SP. #battle_skill_command's enemy
+# branch used to hardcode `mp: 0` unconditionally, never reading `affect_sp`
+# at all, and its `hp:` field was never gated by `affect_hp` either -- an
+# SP-only drain (affect_hp clear, affect_sp set: a real, valid Effects-tab
+# combination, per @2000_battle_bot/デフォ戦bot trivia on the very
+# interaction the third check below covers) always dealt HP damage too.
+
+check 'an enemy-scope attack skill with both affect_hp and affect_sp deals ' \
+      'both HP and SP damage to the target, from the same effect value' do
+  skills = { 7 => fake_skill(name: 'Drain Fire', scope: 0, sp_cost: 6, power: 20,
+                             mrate: 40, hp: true, sp: true) }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # spi 12 -> effect 32
+  foe = combatant_mp('Foe', 0, 0, 5, 100, 50)                # def/spi 0 -> no term
+  cmd = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  eq(-32, cmd[:hp], 'hp carries the full effect')
+  eq(-32, cmd[:mp], 'mp carries the identical effect, not a separate roll')
+
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1)) # variance/accuracy off
+  bat.command_skill(caster, foe, name: 'Drain Fire', cost: cmd[:cost], hp: cmd[:hp],
+                    mp: cmd[:mp], attack: cmd[:attack], chance: cmd[:chance],
+                    variance: cmd[:variance])
+  bat.begin_round
+  e = bat.step_action
+  eq 32, e[:damage], 'HP damage applied'
+  eq 32, e[:sp_damage], 'SP damage applied, the same magnitude as the HP hit'
+  eq 68, foe.hp, '100 - 32'
+  eq 18, foe.mp, '50 - 32'
+end
+
+check 'an enemy-scope attack skill with affect_sp but not affect_hp deals ' \
+      'only SP damage' do
+  skills = { 7 => fake_skill(name: 'SP Drain', scope: 0, sp_cost: 6, power: 20,
+                             mrate: 40, sp: true) } # hp: false (default)
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # spi 12 -> effect 32
+  foe = combatant_mp('Foe', 0, 0, 5, 100, 50)
+  cmd = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  eq 0, cmd[:hp], 'affect_hp is not set, so hp stays 0'
+  eq(-32, cmd[:mp], 'affect_sp is set, so mp carries the full effect')
+
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+  bat.command_skill(caster, foe, name: 'SP Drain', cost: cmd[:cost], hp: cmd[:hp],
+                    mp: cmd[:mp], attack: cmd[:attack], chance: cmd[:chance],
+                    variance: cmd[:variance])
+  bat.begin_round
+  e = bat.step_action
+  eq 0, e[:damage], 'no HP damage at all'
+  eq 32, e[:sp_damage], 'the SP damage still lands, off the same effect'
+  eq 100, foe.hp, 'HP genuinely untouched'
+  eq 18, foe.mp, '50 - 32'
+end
+
+check "a dual HP+SP attack skill's killing blow leaves SP untouched -- HP " \
+      'reaching 0 blocks the SP damage on the same swing' do
+  # EasyRPG's own ordering: `if (!is_dead && GetTarget()->GetHp() +
+  # this->GetAffectedHp() <= 0) return IsSuccess();` runs right after the
+  # affect_hp block and *before* affect_sp's -- so a lethal HP hit skips SP
+  # entirely on that swing, matching デフォ戦bot's own trivia: "ＨＰとＭＰに
+  # ダメージを与える技能でＨＰがゼロになった場合、ＭＰは減らない".
+  skills = { 7 => fake_skill(name: 'Drain Fire', scope: 0, sp_cost: 6, power: 20,
+                             mrate: 40, hp: true, sp: true) }
+  st = skill_party(skills)
+  caster = Game::Battle.from_actor(st.party.actor_by_id(1)) # spi 12 -> effect 32
+  foe = combatant_mp('Foe', 0, 0, 5, 10, 50)                 # only 10 HP -- dies
+  cmd = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
+  eq(-32, cmd[:hp])
+  eq(-32, cmd[:mp])
+
+  bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
+  bat.command_skill(caster, foe, name: 'Drain Fire', cost: cmd[:cost], hp: cmd[:hp],
+                    mp: cmd[:mp], attack: cmd[:attack], chance: cmd[:chance],
+                    variance: cmd[:variance])
+  bat.begin_round
+  e = bat.step_action
+  eq 32, e[:damage], 'the killing HP hit still lands in full'
+  ok e[:defeated], 'the target died from the HP hit'
+  eq 0, e[:sp_damage], 'SP damage was skipped -- the target died first'
+  eq 50, foe.mp, 'MP never decreased'
 end
 
 check 'a skill flagged "attribute defence up/down" picks direction from ' \
@@ -10140,7 +10226,8 @@ check 'an affect_attack attack skill lowers the target\'s per-battle ATK ' \
   bat = Game::Battle.new([caster], [foe], Game::Rng.new(1)) # variance off
   cast = lambda do
     bat.command_skill(caster, foe, name: 'Weaken', cost: c[:cost], hp: c[:hp],
-                      mp: c[:mp], stat_mod_keys: c[:stat_mod_keys])
+                      mp: c[:mp], attack: c[:attack], stat_mod_keys: c[:stat_mod_keys],
+                      stat_effect: c[:stat_effect])
     bat.run_round
   end
 
@@ -10176,7 +10263,8 @@ check 'ability-value decrease rounds toward zero (up) on an odd base, not ' \
   c = st.party.battle_skill_command(st.party.db_skill(7), caster, foe)
   bat = Game::Battle.new([caster], [foe], Game::Rng.new(1))
   bat.command_skill(caster, foe, name: 'Weaken', cost: c[:cost], hp: c[:hp],
-                    mp: c[:mp], stat_mod_keys: c[:stat_mod_keys])
+                    mp: c[:mp], attack: c[:attack], stat_mod_keys: c[:stat_mod_keys],
+                    stat_effect: c[:stat_effect])
   bat.run_round
   eq(-2, foe.atk_mod, '-(5/2) rounds up (toward zero) to -2, not floor\'s -3')
 end
@@ -14297,11 +14385,11 @@ end
 
 def defence_party
   skills = {
-    1 => fake_skill(name: 'Slash', scope: 0, power: 20, prate: 10, mrate: 0),
-    2 => fake_skill(name: 'Bolt',  scope: 0, power: 20, prate: 0,  mrate: 40),
+    1 => fake_skill(name: 'Slash', scope: 0, power: 20, prate: 10, mrate: 0, hp: true),
+    2 => fake_skill(name: 'Bolt',  scope: 0, power: 20, prate: 0,  mrate: 40, hp: true),
     3 => fake_skill(name: 'Pierce', scope: 0, power: 20, prate: 10, mrate: 0,
-                    ignore_defense: true),
-    4 => fake_skill(name: 'Mixed', scope: 0, power: 20, prate: 10, mrate: 40),
+                    ignore_defense: true, hp: true),
+    4 => fake_skill(name: 'Mixed', scope: 0, power: 20, prate: 10, mrate: 40, hp: true),
   }
   skill_party(skills)
 end


### PR DESCRIPTION
## Summary

- `Game::Party#battle_skill_command`'s enemy-scope branch hardcoded `mp: 0`
  unconditionally, never reading a skill's own `affect_sp` flag, and never
  gated `hp` by `affect_hp` either — so an SP-only drain skill always dealt
  HP damage too. `hp`/`mp` now each independently gate on
  `affect_hp`/`affect_sp` off the same computed effect value, matching
  EasyRPG Player's `Game_BattleAlgorithm::Skill::vExecute` (fetched and
  read directly from `src/game_battlealgorithm.cpp`/`src/algo.cpp` to
  confirm).
- `Game::Battle#apply_skill_hit`'s attack branch previously ignored the `mp`
  parameter entirely; it now applies SP damage from that same shared effect
  value, with its own independent to-hit roll (mirroring the existing
  ally/recovery branch's independent HP/SP rolls), and skips it altogether
  when the HP hit on the same swing kills the target — matching EasyRPG's
  own ordering and the community-documented デフォ戦bot trivia that HP
  reaching 0 blocks the SP damage.
- Added a `stat_effect` field to the enemy branch, mirroring the ally
  branch's existing one, so ATK/DEF/SPI/AGI-modifier skills (e.g. Weaken)
  keep working now that `hp` is gated by `affect_hp`.
- Updated pre-existing fixtures in `scripts/rpg2k_logic_check.rb` that
  relied on the enemy branch's old unconditional `hp` field.

## New checks

Added to `scripts/rpg2k_logic_check.rb`:
- An enemy-scope attack skill with both `affect_hp` and `affect_sp` set
  deals both HP and SP damage to the target, from the same effect value.
- A skill with `affect_sp` but not `affect_hp` deals only SP damage.
- A dual HP+SP attack skill's killing blow leaves SP untouched (HP
  reaching 0 blocks the SP damage on the same swing).

All three fail against the pre-fix code and pass after the fix.

## Test plan

- [x] `ruby scripts/rpg2k_logic_check.rb` — 881 checks passed
- [x] `ruby scripts/rpg2k_scene_check.rb` — 594 checks passed
- [x] `cmake -S . -B build -GNinja && cmake --build build` — `rpg_maker_clone`
      builds successfully


---
_Generated by [Claude Code](https://claude.ai/code/session_01RxriEhSHShhYwx9A284K7n)_